### PR TITLE
ipsec: consolidate DeleteXFRM related functions

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -30,7 +30,7 @@ func setupIPSecSuitePrivileged(tb testing.TB) *slog.Logger {
 	tb.Cleanup(func() {
 		ipSecKeysGlobal = make(map[string]*ipSecKey)
 		node.UnsetTestLocalNodeStore()
-		err := DeleteXFRM(log)
+		err := DeleteXFRM(log, AllReqID)
 		if err != nil {
 			tb.Errorf("Failed cleaning XFRM state: %v", err)
 		}
@@ -147,7 +147,7 @@ func TestUpsertIPSecEquals(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, len(result))
 
-	err = DeleteXFRM(log)
+	err = DeleteXFRM(log, AllReqID)
 	require.NoError(t, err)
 
 	_, aeadKey, err := decodeIPSecKey("44434241343332312423222114131211f4f3f2f1")
@@ -222,7 +222,7 @@ func TestUpsertIPSecEndpoint(t *testing.T) {
 	// ESN bit is not set, so ReplayWindow should be 0
 	require.Equal(t, 0, state.ReplayWindow)
 
-	err = DeleteXFRM(log)
+	err = DeleteXFRM(log, AllReqID)
 	require.NoError(t, err)
 
 	_, aeadKey, err := decodeIPSecKey("44434241343332312423222114131211f4f3f2f1")

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1289,13 +1289,13 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 		if err := n.removeEncryptRules(); err != nil {
 			n.log.Warn("Cannot cleanup previous encryption rule state.", logfields.Error, err)
 		}
-		if err := ipsec.DeleteXFRM(n.log); err != nil {
+		if err := ipsec.DeleteXFRM(n.log, ipsec.AllReqID); err != nil {
 			return fmt.Errorf("failed to delete xfrm policies on node configuration changed: %w", err)
 		}
 	}
 
 	if !newConfig.EnableIPSecEncryptedOverlay {
-		if err := ipsec.DeleteXFRMWithReqID(n.log, ipsec.EncryptedOverlayReqID); err != nil {
+		if err := ipsec.DeleteXFRM(n.log, ipsec.EncryptedOverlayReqID); err != nil {
 			return fmt.Errorf("failed to delete encrypt overlay xfrm policies on node configuration change: %w", err)
 		}
 	}

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -196,7 +196,7 @@ func setupLinuxPrivilegedIPv4AndIPv6TestSuite(tb testing.TB) *linuxPrivilegedIPv
 }
 
 func tearDownTest(tb testing.TB) {
-	ipsec.DeleteXFRM(hivetest.Logger(tb))
+	ipsec.DeleteXFRM(hivetest.Logger(tb), ipsec.AllReqID)
 	node.UnsetTestLocalNodeStore()
 	removeDevice(dummyHostDeviceName)
 	removeDevice(dummyExternalDeviceName)


### PR DESCRIPTION
In 68f5f4140530ecd7af0768d459debef8ebd6fdc3 we introduced EncryptedOverlay related XFRM policies which use a separate request ID when created.

To remove these policies a new function was created, DeleteXFRMWithReqID, which removes XFRM policies based on the request IDs.

The original `DeleteXFRM` function becomes a bit useless as it simply calls into the more specific `DeleteXFRMWithReqID`.

Therefore, consolidate the function signatures and expand the API to delete policies by ReqID.

```release-note
Consolidate DeleteXFRM function signatures. 
```
