### PR TITLE
time: Add UTC

### DIFF
--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -51,6 +51,7 @@ var (
 	Now                    = time.Now
 	Parse                  = time.Parse
 	ParseInLocation        = time.ParseInLocation
+	UTC                    = time.UTC
 	Unix                   = time.Unix
 	UnixMicro              = time.UnixMicro
 	UnixMilli              = time.UnixMilli


### PR DESCRIPTION
cilium-cli uses time.UTC variable [^1], so we'll need it when cilium-cli repo gets merged to cilium repo [^2].

[^1]: https://github.com/cilium/cilium-cli/blob/9ffcbb478ceb038b8b643dccd4f693efd47475e5/sysdump/writers.go#L74-L75
[^2]: https://github.com/cilium/design-cfps/pull/9