### PR TITLE
bpf: Fix missing revDNAT when IPsec is used with L7 ingress policy and KPR

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1589,7 +1589,7 @@ skip_egress_gateway:
 		 * handle_nat_fwd tail calls in the majority of cases,
 		 * so control might never return to this program.
 		 */
-		ret = handle_nat_fwd(ctx, 0, proto, &trace, &ext_err);
+		ret = handle_nat_fwd(ctx, 0, proto, false, &trace, &ext_err);
 		if (ret == CTX_ACT_REDIRECT)
 			return ret;
 	}

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1654,7 +1654,26 @@ int cil_to_host(struct __ctx_buff *ctx)
 	 * to mark as PACKET_OTHERHOST and drop.
 	 */
 	ctx_change_type(ctx, PACKET_HOST);
-#endif
+
+# ifdef ENABLE_NODEPORT
+	if ((ctx->mark & MARK_MAGIC_HOST_MASK) != MARK_MAGIC_ENCRYPT)
+		goto skip_ipsec_nodeport_revdnat;
+
+	if (!validate_ethertype(ctx, &proto))
+		goto skip_ipsec_nodeport_revdnat;
+
+	/* handle_nat_fwd() tail calls in the majority of cases, so control
+	 * might never return to this program. Since IPsec is not compatible
+	 * iwth Host Firewall, this won't be an issue.
+	 */
+	ret = handle_nat_fwd(ctx, 0, proto, true, &trace, &ext_err);
+	if (IS_ERR(ret))
+		goto out;
+
+skip_ipsec_nodeport_revdnat:
+# endif /* ENABLE_NODEPORT */
+
+#endif /* ENABLE_IPSEC */
 #ifdef ENABLE_HOST_FIREWALL
 	if (!validate_ethertype(ctx, &proto)) {
 		ret = DROP_UNSUPPORTED_L2;

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -795,7 +795,7 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 		goto out;
 	}
 
-	ret = handle_nat_fwd(ctx, cluster_id, proto, &trace, &ext_err);
+	ret = handle_nat_fwd(ctx, cluster_id, proto, false, &trace, &ext_err);
 out:
 #endif
 	if (IS_ERR(ret))

--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -39,7 +39,7 @@ int cil_to_wireguard(struct __ctx_buff *ctx)
 	if (magic == MARK_MAGIC_OVERLAY)
 		goto out;
 
-	ret = handle_nat_fwd(ctx, 0, proto, &trace, &ext_err);
+	ret = handle_nat_fwd(ctx, 0, proto, true, &trace, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
 						  CTX_ACT_DROP, METRIC_EGRESS);

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -801,6 +801,8 @@ static __always_inline __u32 or_encrypt_key(__u8 key)
 #define TC_INDEX_F_UNUSED		8
 #define TC_INDEX_F_SKIP_HOST_FIREWALL	16
 
+#define CB_NAT_FLAGS_REVDNAT_ONLY	(1 << 0)
+
 /*
  * For use in ctx_{load,store}_meta(), which operates on sk_buff->cb or
  * the cilium_xdp_scratch pad.
@@ -834,6 +836,7 @@ enum {
 #define	CB_CLUSTER_ID_INGRESS	CB_POLICY	/* Alias, non-overlapping */
 #define CB_HSIPC_PORT		CB_POLICY	/* Alias, non-overlapping */
 #define CB_DSR_SRC_LABEL	CB_POLICY	/* Alias, non-overlapping */
+#define CB_NAT_FLAGS		CB_POLICY	/* Alias, non-overlapping */
 	CB_3,
 #define	CB_ADDR_V6_3		CB_3		/* Alias, non-overlapping */
 #define	CB_FROM_HOST		CB_3		/* Alias, non-overlapping */

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1471,6 +1471,7 @@ skip_service_lookup:
 
 static __always_inline int
 nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, bool *snat_done,
+			   bool revdnat_only __maybe_unused,
 			   struct trace_ctx *trace, __s8 *ext_err __maybe_unused)
 {
 	struct bpf_fib_lookup_padded fib_params __maybe_unused = {};
@@ -1495,6 +1496,9 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, bool *snat_done,
 		return CTX_ACT_OK;
 
 #if defined(IS_BPF_HOST) && !defined(ENABLE_SKIP_FIB)
+	if (revdnat_only)
+		goto skip_fib;
+
 	fib_params.l.family = AF_INET6;
 	fib_params.l.ifindex = ctx_get_ifindex(ctx);
 	ipv6_addr_copy((union v6addr *)fib_params.l.ipv6_src,
@@ -1505,6 +1509,8 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, bool *snat_done,
 	ret = nodeport_fib_lookup_and_redirect(ctx, &fib_params, ext_err);
 	if (ret != CTX_ACT_OK)
 		return ret;
+
+skip_fib:
 #endif
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS,
@@ -1562,16 +1568,14 @@ int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 }
 
 static __always_inline int
-__handle_nat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
+__handle_nat_fwd_ipv6(struct __ctx_buff *ctx, bool revdnat_only, struct trace_ctx *trace,
 		      __s8 *ext_err)
 {
 	bool snat_done = false;
 	int ret;
 
-	ret = nodeport_rev_dnat_fwd_ipv6(ctx, &snat_done, trace, ext_err);
-#if !defined(IS_BPF_WIREGUARD)
-	if (ret != CTX_ACT_OK)
-#endif /* !IS_BPF_WIREGUARD */
+	ret = nodeport_rev_dnat_fwd_ipv6(ctx, &snat_done, revdnat_only, trace, ext_err);
+	if (ret != CTX_ACT_OK || revdnat_only)
 		return ret;
 
 #if !defined(ENABLE_DSR) ||						\
@@ -1592,7 +1596,10 @@ static __always_inline int
 handle_nat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 		    __s8 *ext_err)
 {
-	return __handle_nat_fwd_ipv6(ctx, trace, ext_err);
+	__u32 cb_nat_flags = ctx_load_and_clear_meta(ctx, CB_NAT_FLAGS);
+	bool revdnat_only = cb_nat_flags & CB_NAT_FLAGS_REVDNAT_ONLY;
+
+	return __handle_nat_fwd_ipv6(ctx, revdnat_only, trace, ext_err);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_NAT_FWD)
@@ -3057,6 +3064,7 @@ skip_service_lookup:
 
 static __always_inline int
 nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, bool *snat_done,
+			   bool revdnat_only __maybe_unused,
 			   struct trace_ctx *trace, __s8 *ext_err __maybe_unused)
 {
 	struct bpf_fib_lookup_padded fib_params __maybe_unused = {};
@@ -3087,6 +3095,9 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, bool *snat_done,
 		return CTX_ACT_OK;
 
 #if defined(IS_BPF_HOST) && !defined(ENABLE_SKIP_FIB)
+	if (revdnat_only)
+		goto skip_fib;
+
 	/* Perform FIB lookup with post-RevDNAT src IP, and redirect
 	 * packet to the correct egress interface:
 	 */
@@ -3098,6 +3109,8 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, bool *snat_done,
 	ret = nodeport_fib_lookup_and_redirect(ctx, &fib_params, ext_err);
 	if (ret != CTX_ACT_OK)
 		return ret;
+
+skip_fib:
 #endif
 
 	/* Cache is_fragment in advance, nodeport_fib_lookup_and_redirect may invalidate ip4. */
@@ -3184,15 +3197,13 @@ int tail_handle_snat_fwd_ipv4(struct __ctx_buff *ctx)
 
 static __always_inline int
 __handle_nat_fwd_ipv4(struct __ctx_buff *ctx, __u32 cluster_id __maybe_unused,
-		      struct trace_ctx *trace, __s8 *ext_err)
+		      bool revdnat_only, struct trace_ctx *trace, __s8 *ext_err)
 {
 	bool snat_done = false;
 	int ret;
 
-	ret = nodeport_rev_dnat_fwd_ipv4(ctx, &snat_done, trace, ext_err);
-#if !defined(IS_BPF_WIREGUARD)
-	if (ret != CTX_ACT_OK)
-#endif /* !IS_BPF_WIREGUARD */
+	ret = nodeport_rev_dnat_fwd_ipv4(ctx, &snat_done, revdnat_only, trace, ext_err);
+	if (ret != CTX_ACT_OK || revdnat_only)
 		return ret;
 
 #if !defined(ENABLE_DSR) ||						\
@@ -3216,9 +3227,11 @@ static __always_inline int
 handle_nat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 		    __s8 *ext_err)
 {
+	__u32 cb_nat_flags = ctx_load_and_clear_meta(ctx, CB_NAT_FLAGS);
+	bool revdnat_only = cb_nat_flags & CB_NAT_FLAGS_REVDNAT_ONLY;
 	__u32 cluster_id = ctx_load_and_clear_meta(ctx, CB_CLUSTER_ID_EGRESS);
 
-	return __handle_nat_fwd_ipv4(ctx, cluster_id, trace, ext_err);
+	return __handle_nat_fwd_ipv4(ctx, cluster_id, revdnat_only, trace, ext_err);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_NAT_FWD)
@@ -3347,13 +3360,24 @@ lb_handle_health(struct __ctx_buff *ctx __maybe_unused, __be16 proto)
 }
 #endif /* ENABLE_HEALTH_CHECK */
 
+/* handle_nat_fwd() handles revDNAT, fib_lookup_redirect, and bpf_snat for
+ * nodeport. If revdnat_only is set to true, fib_lookup and bpf_snat are
+ * skipped. The typical use case of handle_nat_fwd(revdnat_only=true) is for
+ * handling reply traffic that requires revDNAT prior to wireguard/IPsec
+ * encryption.
+ */
 static __always_inline int
 handle_nat_fwd(struct __ctx_buff *ctx, __u32 cluster_id, __be16 proto,
-	       struct trace_ctx *trace __maybe_unused,
+	       bool revdnat_only, struct trace_ctx *trace __maybe_unused,
 	       __s8 *ext_err __maybe_unused)
 {
 	int ret = CTX_ACT_OK;
+	__u32 cb_nat_flags = 0;
 
+	if (revdnat_only)
+		cb_nat_flags |= CB_NAT_FLAGS_REVDNAT_ONLY;
+
+	ctx_store_meta(ctx, CB_NAT_FLAGS, cb_nat_flags);
 	ctx_store_meta(ctx, CB_CLUSTER_ID_EGRESS, cluster_id);
 
 	switch (proto) {


### PR DESCRIPTION
This PR adds a new revDNAT hook at to-host@cilium_net to fix a connectivity issue.

Fixes: #32897 

```release-note
Fixes broken pod-to-remote-hostport connectivity when IPsec is used with L7 ingress policy and KPR.
```
