### PR TITLE
policy/k8s: Fix race in service notification shutdown

### DIFF
--- a/pkg/policy/k8s/service.go
+++ b/pkg/policy/k8s/service.go
@@ -357,13 +357,13 @@ func (q *serviceQueue) dequeue(ctx context.Context) (item k8s.ServiceNotificatio
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	for len(q.queue) == 0 {
+	for len(q.queue) == 0 && ctx.Err() == nil {
 		q.cond.Wait()
+	}
 
-		// If ctx is cancelled, we return immediately
-		if ctx.Err() != nil {
-			return item, false
-		}
+	// If ctx is cancelled, we return immediately
+	if ctx.Err() != nil {
+		return item, false
 	}
 
 	item = q.queue[0]


### PR DESCRIPTION
This fixes a race caught [by CI](https://github.com/cilium/cilium/actions/runs/9936297823/job/27444237699) and reported by @joamaki  on `main` where `serviceQueue.dequeue` was not woken up when `ctx` was cancelled. The error was that `dequeue` would enter `cond.Wait()` without checking if the context was cancelled before it was called.

I have reproduced the race via the following command and verified that this patch fixes it:

```
cd pkg/policy/k8s
go test -run '^\QTest_serviceNotificationsQueue\E$' -v . -count 1000 -timeout 1s
```

Fixes: e0fc5e6a0ca3 ("policy/k8s: Fix deadlock in ToServices implementation")
