### PR TITLE
lbipam: improve status message for incompatible services

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -453,8 +453,8 @@ func (ipam *LBIPAM) serviceViewFromService(key resource.Key, svc *slim_core_v1.S
 	sv.Labels = svcLabels(svc)
 	sv.RequestedFamilies.IPv4, sv.RequestedFamilies.IPv6 = ipam.serviceIPFamilyRequest(svc)
 	sv.RequestedIPs = getSVCRequestedIPs(ipam.logger, svc)
-	sv.SharingKey = getSVCSharingKey(ipam.logger, svc)
-	sv.SharingCrossNamespace = getSVCSharingCrossNamespace(ipam.logger, svc)
+	sv.SharingKey = getSVCSharingKey(svc)
+	sv.SharingCrossNamespace = getSVCSharingCrossNamespace(svc)
 	sv.ExternalTrafficPolicy = svc.Spec.ExternalTrafficPolicy
 	sv.Ports = make([]slim_core_v1.ServicePort, len(svc.Spec.Ports))
 	copy(sv.Ports, svc.Spec.Ports)
@@ -699,14 +699,14 @@ func getSVCRequestedIPs(log logrus.FieldLogger, svc *slim_core_v1.Service) []net
 	})
 }
 
-func getSVCSharingKey(log logrus.FieldLogger, svc *slim_core_v1.Service) string {
+func getSVCSharingKey(svc *slim_core_v1.Service) string {
 	if val, _ := annotation.Get(svc, annotation.LBIPAMSharingKey, annotation.LBIPAMSharingKeyAlias); val != "" {
 		return val
 	}
 	return ""
 }
 
-func getSVCSharingCrossNamespace(log logrus.FieldLogger, svc *slim_core_v1.Service) []string {
+func getSVCSharingCrossNamespace(svc *slim_core_v1.Service) []string {
 	if val, _ := annotation.Get(svc, annotation.LBIPAMSharingAcrossNamespace, annotation.LBIPAMSharingAcrossNamespaceAlias); val != "" {
 		return strings.Split(val, ",")
 	}

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -507,7 +507,7 @@ func (ipam *LBIPAM) stripInvalidAllocations(sv *ServiceView) error {
 		if pool.Spec.ServiceSelector != nil {
 			selector, err := slim_meta_v1.LabelSelectorAsSelector(pool.Spec.ServiceSelector)
 			if err != nil {
-				errs = errors.Join(errs, fmt.Errorf("Making selector from pool '%s' label selector", pool.Name))
+				errs = errors.Join(errs, fmt.Errorf("making selector from pool '%s' label selector", pool.Name))
 				continue
 			}
 
@@ -645,7 +645,7 @@ func (ipam *LBIPAM) stripOrImportIngresses(sv *ServiceView) (statusModified bool
 					continue
 				}
 
-				return statusModified, fmt.Errorf("Error while attempting to allocate IP '%s'", ingress.IP)
+				return statusModified, fmt.Errorf("error while attempting to allocate IP '%s'", ingress.IP)
 			}
 
 			sv.AllocatedIPs = append(sv.AllocatedIPs, ServiceViewIP{
@@ -1119,7 +1119,7 @@ func (ipam *LBIPAM) findRangeOfIP(sv *ServiceView, ip netip.Addr) (lbRange *LBRa
 		if pool.Spec.ServiceSelector != nil {
 			selector, err := slim_meta_v1.LabelSelectorAsSelector(pool.Spec.ServiceSelector)
 			if err != nil {
-				return nil, false, fmt.Errorf("Making selector from pool '%s' label selector: %w", pool.Name, err)
+				return nil, false, fmt.Errorf("making selector from pool '%s' label selector: %w", pool.Name, err)
 			}
 
 			if !selector.Matches(sv.Labels) {
@@ -1197,7 +1197,7 @@ func (ipam *LBIPAM) allocateIPAddress(
 		if pool.Spec.ServiceSelector != nil {
 			selector, err := slim_meta_v1.LabelSelectorAsSelector(pool.Spec.ServiceSelector)
 			if err != nil {
-				return netip.Addr{}, nil, fmt.Errorf("Making selector from pool '%s' label selector: %w", pool.Name, err)
+				return netip.Addr{}, nil, fmt.Errorf("making selector from pool '%s' label selector: %w", pool.Name, err)
 			}
 
 			if !selector.Matches(sv.Labels) {
@@ -1300,12 +1300,12 @@ func (ipam *LBIPAM) handleNewPool(ctx context.Context, pool *cilium_api_v2alpha1
 	for _, ipBlock := range pool.Spec.Blocks {
 		from, to, fromCidr, err := ipRangeFromBlock(ipBlock)
 		if err != nil {
-			return fmt.Errorf("Error parsing ip block: %w", err)
+			return fmt.Errorf("error parsing ip block: %w", err)
 		}
 
 		lbRange, err := NewLBRange(from, to, pool)
 		if err != nil {
-			return fmt.Errorf("Error making LB Range for '%s': %w", ipBlock.Cidr, err)
+			return fmt.Errorf("error making LB Range for '%s': %w", ipBlock.Cidr, err)
 		}
 
 		// If AllowFirstLastIPs is no, mark the first and last IP as allocated upon range creation.
@@ -1333,7 +1333,7 @@ func ipRangeFromBlock(block cilium_api_v2alpha1.CiliumLoadBalancerIPPoolIPBlock)
 	if string(block.Cidr) != "" {
 		prefix, err := netip.ParsePrefix(string(block.Cidr))
 		if err != nil {
-			return netip.Addr{}, netip.Addr{}, false, fmt.Errorf("Error parsing cidr '%s': %w", block.Cidr, err)
+			return netip.Addr{}, netip.Addr{}, false, fmt.Errorf("error parsing cidr '%s': %w", block.Cidr, err)
 		}
 
 		to, from = rangeFromPrefix(prefix)
@@ -1373,7 +1373,7 @@ func (ipam *LBIPAM) handlePoolModified(ctx context.Context, pool *cilium_api_v2a
 	for _, newBlock := range pool.Spec.Blocks {
 		from, to, fromCidr, err := ipRangeFromBlock(newBlock)
 		if err != nil {
-			return fmt.Errorf("Error parsing ip block: %w", err)
+			return fmt.Errorf("error parsing ip block: %w", err)
 		}
 
 		newRanges = append(newRanges, rng{
@@ -1450,7 +1450,7 @@ func (ipam *LBIPAM) handlePoolModified(ctx context.Context, pool *cilium_api_v2a
 
 		newLBRange, err := NewLBRange(newRange.from, newRange.to, pool)
 		if err != nil {
-			return fmt.Errorf("Error while making new LB range for range '%s - %s': %w", newRange.from, newRange.to, err)
+			return fmt.Errorf("error while making new LB range for range '%s - %s': %w", newRange.from, newRange.to, err)
 		}
 
 		// If AllowFirstLastIPs is no, mark the first and last IP as allocated upon range creation.

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -415,7 +415,7 @@ func (ipam *LBIPAM) handleUpsertService(ctx context.Context, svc *slim_core_v1.S
 		return fmt.Errorf("stripOrImportIngresses: %w", err)
 	}
 
-	// Attempt to satisfy this service in particular now. We do this now instread of relying on
+	// Attempt to satisfy this service in particular now. We do this now instead of relying on
 	// ipam.satisfyServices to avoid updating the service twice in quick succession.
 	if !sv.isSatisfied() {
 		modified, err := ipam.satisfyService(sv)
@@ -1496,7 +1496,7 @@ func (ipam *LBIPAM) revalidateAllServices(ctx context.Context) error {
 			return fmt.Errorf("stripOrImportIngresses: %w", err)
 		}
 
-		// Attempt to satisfy this service in particular now. We do this now instread of relying on
+		// Attempt to satisfy this service in particular now. We do this now instead of relying on
 		// ipam.satisfyServices to avoid updating the service twice in quick succession.
 		if !sv.isSatisfied() {
 			modified, err := ipam.satisfyService(sv)
@@ -1653,7 +1653,7 @@ func (ipam *LBIPAM) deleteRangeAllocations(ctx context.Context, delRange *LBRang
 			return fmt.Errorf("stripOrImportIngresses: %w", err)
 		}
 
-		// Attempt to satisfy this service in particular now. We do this now instread of relying on
+		// Attempt to satisfy this service in particular now. We do this now instead of relying on
 		// ipam.satisfyServices to avoid updating the service twice in quick succession.
 		if !sv.isSatisfied() {
 			statusModified, err := ipam.satisfyService(sv)

--- a/operator/pkg/lbipam/service_store.go
+++ b/operator/pkg/lbipam/service_store.go
@@ -86,18 +86,18 @@ type ServiceView struct {
 }
 
 // isCompatible checks if two services are compatible for sharing an IP.
-func (sv *ServiceView) isCompatible(osv *ServiceView) bool {
+func (sv *ServiceView) isCompatible(osv *ServiceView) (bool, string) {
 	// They have the same sharing key.
 	if sv.SharingKey != osv.SharingKey {
-		return false
+		return false, "different sharing key"
 	}
 
 	// Services are namespaced, so services are only compatible if they are in the same namespace.
-	// This is for security reasons, otherwise a bad tennant could use a service in another namespace.
+	// This is for security reasons, otherwise a bad tenant could use a service in another namespace.
 	// We still allow cross-namespace sharing if specifically allowed on both services.
 	if sv.Namespace != osv.Namespace {
 		if !slices.Contains(sv.SharingCrossNamespace, osv.Namespace) && !slices.Contains(sv.SharingCrossNamespace, ciliumSvcLBISKCNWildward) || !slices.Contains(osv.SharingCrossNamespace, sv.Namespace) && !slices.Contains(osv.SharingCrossNamespace, ciliumSvcLBISKCNWildward) {
-			return false
+			return false, "different and not permitted namespace"
 		}
 	}
 
@@ -107,7 +107,7 @@ func (sv *ServiceView) isCompatible(osv *ServiceView) bool {
 	for _, port1 := range sv.Ports {
 		for _, port2 := range osv.Ports {
 			if port1.Port == port2.Port {
-				return false
+				return false, "same port"
 			}
 		}
 	}
@@ -116,7 +116,7 @@ func (sv *ServiceView) isCompatible(osv *ServiceView) bool {
 	// If this were not the case, then we could end up in a situation directing traffic to a node which doesn't
 	// have the pod running on it for one of the services with an `local` external traffic policy.
 	if sv.ExternalTrafficPolicy != osv.ExternalTrafficPolicy {
-		return false
+		return false, "different ExternalTrafficPolicy"
 	}
 
 	// If both services have a 'local' external traffic policy, then they must select the same set of pods.
@@ -126,17 +126,17 @@ func (sv *ServiceView) isCompatible(osv *ServiceView) bool {
 		// If any of the two service doesn't select any pods with the selector, it likely uses an endpoints object to
 		// link the service to pods. LB-IPAM isn't smart enough to handle this case (yet), so we don't allow it.
 		if len(sv.Selector) == 0 || len(osv.Selector) == 0 {
-			return false
+			return false, "compatible ExternalTrafficPolicy local but selecting different set of pods"
 		}
 
 		// If both use selectors, and they are not the same, then the services are not compatible.
 		if !maps.Equal(sv.Selector, osv.Selector) {
-			return false
+			return false, "compatible ExternalTrafficPolicy local but selecting different set of pods"
 		}
 	}
 
 	// If we can't find any reason to disqualify the services, then they are compatible.
-	return true
+	return true, ""
 }
 
 func (sv *ServiceView) isSatisfied() bool {


### PR DESCRIPTION
Currently, when requesting a specific IP from LB IPAM, the logic validates whether
all the services requesting the same IP are compatible with each other.

If they are incompatible, it always results in the following status message.

```
message: The IP '100.64.0.102' is already allocated to another service with a different sharing key
reason: already_allocated_different_sharing_key
```

It's the same reason (different sharing key), even though the underlying reason might be a different one.

- Different sharing key
- Different and not permitted namespace
- Same port
- Different ExternalTrafficPolicy
- Same ExternalTrafficPolicy Local but selecting different set of pods

Therefore, this commit improves the message by adding the actual reason to the message.

In addition, the reason changed from `already_allocated_different_sharing_key` to `already_allocated_incompatible_service`.

Note: fixed some diagnostics on the changed files too.