### PR TITLE
v1.15 Backports 2024-07-15

### DIFF
--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -190,7 +190,7 @@ jobs:
           # Please refer to https://github.com/kubernetes-sigs/ingress-controller-conformance/pull/101 for more details.
           repository: cilium/ingress-controller-conformance
           path: ingress-controller-conformance
-          ref: 010bbae21b71d9785660b87908dfe2ba8cd2f25d
+          ref: 6a193b3f73d8b1201a818bb7c8f204059b064857
           persist-credentials: false
 
       - name: Install Ingress conformance test tool
@@ -301,7 +301,7 @@ jobs:
         timeout-minutes: 30
         run: |
           cd ingress-controller-conformance
-          ./ingress-controller-conformance -ingress-class cilium -wait-time-for-ingress-status 60s -wait-time-for-ready 60s
+          ./ingress-controller-conformance -ingress-class cilium -wait-time-for-ingress-status 60s -wait-time-for-ready 60s -http-client-timeout 60s
 
       - name: Post-test information gathering
         if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -334,7 +334,7 @@ jobs:
         run: |
           kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
           kubectl create -n kube-system secret generic cilium-ipsec-keys \
-              --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
+              --from-literal=keys="3+ rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 
           mkdir -p cilium-junits
 

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -88,6 +88,7 @@ cilium-agent [flags]
       --dnsproxy-concurrency-limit int                            Limit concurrency of DNS message processing
       --dnsproxy-concurrency-processing-grace-period duration     Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing
       --dnsproxy-enable-transparent-mode                          Enable DNS proxy transparent mode
+      --dnsproxy-socket-linger-timeout int                        Timeout (in seconds) when closing the connection between the DNS proxy and the upstream server. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background (default 10)
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
       --egress-masquerade-interfaces strings                      Limit iptables-based egress masquerading to interface selector

--- a/Documentation/community/roadmap.rst
+++ b/Documentation/community/roadmap.rst
@@ -32,6 +32,8 @@ Major Feature Status
 ++-------------------------------------------------+----------------------------------------------------------+
 || :ref:`bandwidth-manager`                        | Stable                                                   |
 ++-------------------------------------------------+----------------------------------------------------------+
+|| :ref:`local-redirect-policy`                    | Stable                                                   |
+++-------------------------------------------------+----------------------------------------------------------+
 | Cilium Mesh                                      | Stable (:ref:`Roadmap Details<rm-clustermesh>`)          |
 ++-------------------------------------------------+----------------------------------------------------------+
 || :ref:`Multi-Cluster (ClusterMesh)<clustermesh>` | Stable                                                   |
@@ -126,7 +128,6 @@ these are already in production use with a set of adopters. We expect the
 following features to graduate to stable:
 
 * :ref:`BGP<bgp>`
-* :ref:`Local Redirect Policy<local-redirect-policy>`
 * :ref:`CiliumEndpointSlice<gsg_ces>`
 * :ref:`Multi-Pool IPAM<ipam_crd_multi_pool>`
 * :ref:`Node-to-node WireGuard encryption<node-node-wg>`

--- a/Documentation/community/roadmap.rst
+++ b/Documentation/community/roadmap.rst
@@ -87,11 +87,6 @@ courses, testing and more. Check the :ref:`dev_guide` documentation to understan
 involved with code contributions, and the `Get Involved`_ guide for guidance on
 contributing blog posts, training and other resources. 
 
-CNCF Graduation
-~~~~~~~~~~~~~~~
-
-Cilium has applied for `CNCF Graduation`_, please add your support on the PR!
-
 .. _rm-cilium-service-mesh:
 
 Cilium Service Mesh 

--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -118,20 +118,7 @@ Second, fetch a VM image:
 
 .. code-block:: shell-session
 
-    $ mkdir images/
-    $ docker run -v $(pwd)/images:/mnt/images \
-        quay.io/lvh-images/kind:6.0-main \
-        cp /data/images/kind_6.0.qcow2.zst /mnt/images
-    $ cd images/
-    $ zstd -d kind_6.0.qcow2.zst
-
-Alternatively, you can use the ``scripts/pull_image.sh``:
-
-.. code-block:: shell-session
-
-    $ mkdir images/
-    $ git clone https://github.com/cilium/little-vm-helper
-    $ IMAGE_DIR=./images ./little-vm-helper/scripts/pull_image.sh quay.io/lvh-images/kind:6.0-main
+    $ lvh images pull quay.io/lvh-images/kind:6.1-main --dir .
 
 See `<https://quay.io/repository/lvh-images/kind?tab=tags>`_ for all available
 images. To build a new VM image (or to update any existing) please refer to
@@ -141,7 +128,7 @@ Next, start a VM:
 
 .. code-block:: shell-session
 
-    $ lvh run --image ./images/kind_6.0.qcow2 --host-mount $GOPATH/src/github.com/cilium/ --daemonize -p 2222:22 --cpu=3 --mem=6G
+    $ lvh run --image ./images/kind_6.1.qcow2 --host-mount $GOPATH/src/github.com/cilium/ --daemonize -p 2222:22 --cpu=3 --mem=6G
 
 .. _test_cilium_on_lvh:
 

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -904,6 +904,10 @@
      - The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.
      - string
      - ``"100ms"``
+   * - :spelling:ignore:`dnsProxy.socketLingerTimeout`
+     - Timeout (in seconds) when closing the connection between the DNS proxy and the upstream server. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background.
+     - int
+     - ``10``
    * - :spelling:ignore:`egressGateway.enabled`
      - Enables egress gateway to redirect and SNAT the traffic that leaves the cluster.
      - bool

--- a/Documentation/installation/cni-chaining-azure-cni.rst
+++ b/Documentation/installation/cni-chaining-azure-cni.rst
@@ -88,6 +88,7 @@ Deploy Cilium release via Helm:
      --namespace kube-system \\
      --set cni.chainingMode=generic-veth \\
      --set cni.customConf=true \\
+     --set cni.exclusive=false \\
      --set nodeinit.enabled=true \\
      --set cni.configMap=cni-configuration \\
      --set routingMode=native \\

--- a/Documentation/network/clustermesh/policy.rst
+++ b/Documentation/network/clustermesh/policy.rst
@@ -45,12 +45,3 @@ between two clusters. The cluster name refers to the name given via the
         - matchLabels:
             name: rebel-base
             io.cilium.k8s.policy.cluster: cluster2
-
-Limitations
-###########
-
- * L7 security policies currently only work across multiple clusters if worker
-   nodes have routes installed allowing to route pod IPs of all clusters. This
-   is obtained when running in direct routing mode by running a routing daemon or
-   ``--auto-direct-node-routes`` but won't work automatically when using
-   tunnel/encapsulation mode.

--- a/Documentation/network/kubernetes/kata.rst
+++ b/Documentation/network/kubernetes/kata.rst
@@ -77,15 +77,10 @@ Deploy Cilium release via Helm:
 
 .. warning::
 
-   Kata containers do not work with the socket-level loadbalancer, or with
-   :ref:`kube-proxy replacement <kubeproxy-free>` enabled. These
-   features should be disabled with ``--set socketLB.enabled=false``
-   (default) and ``--set kubeProxyReplacement=false``.
-
-   Both features rely on socket-based load-balancing, which is not possible
-   given that Kata containers are virtual machines running with their own
-   kernel. For kube-proxy replacement, this limitation is tracked with
-   :gh-issue:`15437`.
+   When using :ref:`kube-proxy-replacement <kubeproxy-free>` or its socket-level
+   loadbalancer with Kata containers, the socket-level loadbalancer should be
+   disabled for pods by setting ``socketLB.hostNamespaceOnly=true``. See
+   :ref:`socketlb-host-netns-only` for more details.
 
 .. include:: ../../installation/k8s-install-validate.rst
 

--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -599,6 +599,7 @@ mode would look as follows:
         --set k8sServiceHost=${API_SERVER_IP} \\
         --set k8sServicePort=${API_SERVER_PORT}
 
+.. _socketlb-host-netns-only:
 
 Socket LoadBalancer Bypass in Pod Namespace
 *******************************************

--- a/Documentation/network/kubernetes/local-redirect-policy.rst
+++ b/Documentation/network/kubernetes/local-redirect-policy.rst
@@ -53,10 +53,21 @@ Enable the feature by setting the ``localRedirectPolicy`` value to ``true``.
 
 .. parsed-literal::
 
-   helm install cilium |CHART_RELEASE| \\
+   helm upgrade cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --reuse-values \\
      --set localRedirectPolicy=true
 
-Verify that Cilium agent pod is running.
+
+Rollout the operator and agent pods to make the changes effective:
+
+.. code-block:: shell-session
+
+    $ kubectl rollout restart deploy cilium-operator -n kube-system
+    $ kubectl rollout restart ds cilium -n kube-system
+
+
+Verify that Cilium agent and operator pods are running.
 
 .. code-block:: shell-session
 
@@ -64,6 +75,9 @@ Verify that Cilium agent pod is running.
     NAME           READY   STATUS    RESTARTS   AGE
     cilium-5ngzd   1/1     Running   0          3m19s
 
+    $ kubectl -n kube-system get pods -l name=cilium-operator
+    NAME                               READY   STATUS    RESTARTS   AGE
+    cilium-operator-544b4d5cdd-qxvpv   1/1     Running   0          3m19s
 
 Validate that the Cilium Local Redirect Policy CRD has been registered.
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -57,11 +57,10 @@ ifeq ($(DOCKER_IMAGE_TAG),)
     DOCKER_IMAGE_TAG=latest
 endif
 
-ifeq ($(shell uname -m),aarch64)
-    ETCD_IMAGE=quay.io/coreos/etcd:v3.3.20-arm64
-else
-    ETCD_IMAGE=quay.io/coreos/etcd:v3.3.20
-endif
+# renovate: datasource=docker depName=gcr.io/etcd-development/etcd
+ETCD_IMAGE_VERSION = v3.5.11
+ETCD_IMAGE_SHA = sha256:8eff25cf636711fb48426005b55fc9f4d6ffa4f38f483fa87c8cc82976347bbb
+ETCD_IMAGE=gcr.io/etcd-development/etcd:$(ETCD_IMAGE_VERSION)@$(ETCD_IMAGE_SHA)
 
 CONSUL_IMAGE=consul:1.7.2
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -885,6 +885,10 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.DNSProxyLockTimeout)
 	option.BindEnv(vp, option.DNSProxyLockTimeout)
 
+	flags.Int(option.DNSProxySocketLingerTimeout, defaults.DNSProxySocketLingerTimeout, "Timeout (in seconds) when closing the connection between the DNS proxy and the upstream server. "+
+		"If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background")
+	option.BindEnv(vp, option.DNSProxySocketLingerTimeout)
+
 	flags.Bool(option.DNSProxyEnableTransparentMode, defaults.DNSProxyEnableTransparentMode, "Enable DNS proxy transparent mode")
 	option.BindEnv(vp, option.DNSProxyEnableTransparentMode)
 

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -182,10 +182,13 @@ func (d *Daemon) allocateRouterIPv6(family types.NodeAddressingFamily, fromK8s, 
 }
 
 // Coalesce CIDRS when allocating the DatapathIPs and healthIPs. GH #18868
-func coalesceCIDRs(rCIDRs []string) (result []string) {
+func coalesceCIDRs(rCIDRs []string) (result []string, err error) {
 	cidrs := make([]*net.IPNet, 0, len(rCIDRs))
 	for _, k := range rCIDRs {
-		ip, mask, _ := net.ParseCIDR(k)
+		ip, mask, err := net.ParseCIDR(k)
+		if err != nil {
+			return nil, err
+		}
 		cidrs = append(cidrs, &net.IPNet{IP: ip, Mask: mask.Mask})
 	}
 	ipv4cidr, ipv6cidr := iputil.CoalesceCIDRs(cidrs)
@@ -278,7 +281,10 @@ func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily, fromK8s,
 		option.Config.IPAM == ipamOption.IPAMENI &&
 		result != nil &&
 		len(result.CIDRs) > 0 {
-		result.CIDRs = coalesceCIDRs(result.CIDRs)
+		result.CIDRs, err = coalesceCIDRs(result.CIDRs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to coalesce CIDRs: %w", err)
+		}
 	}
 
 	if (option.Config.IPAM == ipamOption.IPAMENI ||
@@ -320,7 +326,10 @@ func (d *Daemon) allocateHealthIPs() error {
 				option.Config.IPAM == ipamOption.IPAMENI &&
 				result != nil &&
 				len(result.CIDRs) > 0 {
-				result.CIDRs = coalesceCIDRs(result.CIDRs)
+				result.CIDRs, err = coalesceCIDRs(result.CIDRs)
+				if err != nil {
+					return fmt.Errorf("failed to coalesce CIDRs: %w", err)
+				}
 			}
 
 			log.Debugf("IPv4 health endpoint address: %s", result.IP)
@@ -352,7 +361,10 @@ func (d *Daemon) allocateHealthIPs() error {
 				option.Config.IPAM == ipamOption.IPAMENI &&
 				result != nil &&
 				len(result.CIDRs) > 0 {
-				result.CIDRs = coalesceCIDRs(result.CIDRs)
+				result.CIDRs, err = coalesceCIDRs(result.CIDRs)
+				if err != nil {
+					return fmt.Errorf("failed to coalesce CIDRs: %w", err)
+				}
 			}
 
 			node.SetEndpointHealthIPv6(result.IP)
@@ -394,7 +406,10 @@ func (d *Daemon) allocateIngressIPs() error {
 				option.Config.IPAM == ipamOption.IPAMENI &&
 				result != nil &&
 				len(result.CIDRs) > 0 {
-				result.CIDRs = coalesceCIDRs(result.CIDRs)
+				result.CIDRs, err = coalesceCIDRs(result.CIDRs)
+				if err != nil {
+					return fmt.Errorf("failed to coalesce CIDRs: %w", err)
+				}
 			}
 
 			node.SetIngressIPv4(result.IP)
@@ -452,7 +467,10 @@ func (d *Daemon) allocateIngressIPs() error {
 				option.Config.IPAM == ipamOption.IPAMENI &&
 				result != nil &&
 				len(result.CIDRs) > 0 {
-				result.CIDRs = coalesceCIDRs(result.CIDRs)
+				result.CIDRs, err = coalesceCIDRs(result.CIDRs)
+				if err != nil {
+					return fmt.Errorf("failed to coalesce CIDRs: %w", err)
+				}
 			}
 
 			node.SetIngressIPv6(result.IP)

--- a/daemon/cmd/ipam_test.go
+++ b/daemon/cmd/ipam_test.go
@@ -19,58 +19,58 @@ import (
 func TestCoalesceCIDRs(t *testing.T) {
 	CIDR := []string{"10.0.0.0/8"}
 	expectedCIDR := []string{"10.0.0.0/8"}
-	newCIDR := coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err := coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"10.105.0.0/16", "10.0.0.0/8"}
 	expectedCIDR = []string{"10.0.0.0/8"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"10.105.0.0/16", "10.104.0.0/19", "10.0.0.0/8"}
 	expectedCIDR = []string{"10.0.0.0/8"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24"}
 	expectedCIDR = []string{"10.105.0.0/16", "192.168.1.0/24"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8"}
 	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8", "f00d::a0f:0:0:0/96"}
 	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24", "f00d::a0f:0:0:0/96"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"f00d::a0f:0:0:0/96", "10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8"}
 	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24", "f00d::a0f:0:0:0/96"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"f00d::a0f:0:0:0/96"}
 	expectedCIDR = []string{"f00d::a0f:0:0:0/96"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 }
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -276,6 +276,7 @@ contributors across the globe, there is almost always someone available to help.
 | dnsProxy.preCache | string | `""` | DNS cache data at this path is preloaded on agent startup. |
 | dnsProxy.proxyPort | int | `0` | Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port. |
 | dnsProxy.proxyResponseMaxDelay | string | `"100ms"` | The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. |
+| dnsProxy.socketLingerTimeout | int | `10` | Timeout (in seconds) when closing the connection between the DNS proxy and the upstream server. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background. |
 | egressGateway.enabled | bool | `false` | Enables egress gateway to redirect and SNAT the traffic that leaves the cluster. |
 | egressGateway.installRoutes | bool | `false` | Deprecated without a replacement necessary. |
 | egressGateway.reconciliationTriggerInterval | string | `"1s"` | Time between triggers of egress gateway state reconciliations |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1171,6 +1171,9 @@ data:
   # default DNS proxy to transparent mode in non-chaining modes
   dnsproxy-enable-transparent-mode: {{ $defaultDNSProxyEnableTransparentMode | quote }}
   {{- end }}
+  {{- if .Values.dnsProxy.socketLingerTimeout }}
+  dnsproxy-socket-linger-timeout: {{ .Values.dnsProxy.socketLingerTimeout | quote }}
+  {{- end }}
   {{- if .Values.dnsProxy.dnsRejectResponseCode }}
   tofqdns-dns-reject-response-code: {{ .Values.dnsProxy.dnsRejectResponseCode | quote }}
   {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3353,6 +3353,8 @@ enableK8sTerminatingEndpoint: true
 agentNotReadyTaintKey: "node.cilium.io/agent-not-ready"
 
 dnsProxy:
+  # -- Timeout (in seconds) when closing the connection between the DNS proxy and the upstream server. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background.
+  socketLingerTimeout: 10
   # -- DNS response code for rejecting DNS requests, available options are '[nameError refused]'.
   dnsRejectResponseCode: refused
   # -- Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3350,6 +3350,8 @@ enableK8sTerminatingEndpoint: true
 agentNotReadyTaintKey: "node.cilium.io/agent-not-ready"
 
 dnsProxy:
+  # -- Timeout (in seconds) when closing the connection between the DNS proxy and the upstream server. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background.
+  socketLingerTimeout: 10
   # -- DNS response code for rejecting DNS requests, available options are '[nameError refused]'.
   dnsRejectResponseCode: refused
   # -- Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present.

--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -272,7 +272,7 @@ func (rc *remoteCluster) getClusterConfig(ctx context.Context, backend kvstore.B
 	rc.config = &models.RemoteClusterConfig{Required: requireConfig}
 	rc.mutex.Unlock()
 
-	cfgch := make(chan *types.CiliumClusterConfig)
+	cfgch := make(chan *types.CiliumClusterConfig, 1)
 	defer close(cfgch)
 
 	// We retry here rather than simply returning an error and relying on the external

--- a/pkg/crypto/certloader/server_test.go
+++ b/pkg/crypto/certloader/server_test.go
@@ -126,6 +126,8 @@ func TestNewWatchedServerConfig(t *testing.T) {
 	assert.Equal(t, tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
 	// Check that our base option is honored.
 	assert.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MinVersion)
+	// check that the ALPN protocol is set.
+	assert.Contains(t, tlsConfig.NextProtos, alpnProtocolH2)
 }
 
 func TestWatchedServerConfigRotation(t *testing.T) {
@@ -175,4 +177,6 @@ func TestWatchedServerConfigRotation(t *testing.T) {
 	assert.Equal(t, tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth)
 	// Check that our base option is honored.
 	assert.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MinVersion)
+	// check that the ALPN protocol is set.
+	assert.Contains(t, tlsConfig.NextProtos, alpnProtocolH2)
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -173,6 +173,10 @@ const (
 	// DNSProxyEnableTransparentMode enables transparent mode for the DNS proxy.
 	DNSProxyEnableTransparentMode = false
 
+	// DNSProxySocketLingerTimeout defines how many seconds we wait for the connection
+	// between the DNS proxy and the upstream server to be closed.
+	DNSProxySocketLingerTimeout = 10
+
 	// IdentityChangeGracePeriod is the default value for
 	// option.IdentityChangeGracePeriod
 	IdentityChangeGracePeriod = 5 * time.Second

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -422,7 +422,7 @@ func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
 	})
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
 		c.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(c.T, expected))
+			ep.desiredPolicy.GetPolicyMap().Diff(expected))
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -462,7 +462,7 @@ func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
 	// that port, as it is shadowed by the deny rule
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected2) {
 		c.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(c.T, expected2))
+			ep.desiredPolicy.GetPolicyMap().Diff(expected2))
 	}
 
 	// Keep only desired redirects
@@ -478,7 +478,7 @@ func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
 	// Check that the state before addRedirects is restored
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
 		c.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(c.T, expected))
+			ep.desiredPolicy.GetPolicyMap().Diff(expected))
 	}
 	c.Assert(len(ep.realizedRedirects), check.Equals, 0)
 	c.Assert(ep.desiredPolicy.GetPolicyMap().Len(), check.Equals, 2)

--- a/pkg/endpointmanager/host.go
+++ b/pkg/endpointmanager/host.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/node"
 )
 
@@ -31,7 +32,10 @@ func (mgr *endpointManager) HostEndpointExists() bool {
 
 func (mgr *endpointManager) startNodeLabelsObserver(old map[string]string) {
 	mgr.localNodeStore.Observe(context.Background(), func(ln node.LocalNode) {
-		if maps.Equal(old, ln.Labels) {
+		oldIdtyLabels, _ := labelsfilter.Filter(labels.Map2Labels(old, labels.LabelSourceK8s))
+		newIdtyLabels, _ := labelsfilter.Filter(labels.Map2Labels(ln.Labels, labels.LabelSourceK8s))
+		if maps.Equal(oldIdtyLabels.K8sStringMap(), newIdtyLabels.K8sStringMap()) {
+			log.Debug("Host endpoint identity labels unchanged, skipping labels update")
 			return
 		}
 

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	apiv1 "github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/checker"
@@ -21,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -998,4 +1001,127 @@ func (s *EndpointManagerSuite) TestMissingNodeLabelsUpdate(c *C) {
 	c.Assert(ok, checker.Equals, true)
 	got := hostEP.OpLabels.IdentityLabels().K8sStringMap()
 	c.Assert(map[string]string{"k2": "v2"}, checker.DeepEquals, got)
+}
+
+func TestUpdateHostEndpointLabels(t *testing.T) {
+	// Initialize label filter config.
+	labelsfilter.ParseLabelPrefixCfg([]string{"k8s:!ignore1", "k8s:!ignore2"}, "")
+
+	idAllocator := testidentity.NewMockIdentityAllocator(nil)
+	s := &EndpointManagerSuite{
+		repo: policy.NewPolicyRepository(idAllocator, nil, nil, nil),
+	}
+
+	mgr := New(&dummyEpSyncher{}, nil, nil)
+	hostEPID := uint16(17)
+	type args struct {
+		oldLabels, newLabels map[string]string
+	}
+	type want struct {
+		labels      map[string]string
+		labelsCheck assert.ComparisonAssertionFunc
+	}
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWant   func() want
+		preTestRun  func()
+		postTestRun func()
+	}{
+		{
+			name: "Add labels",
+			preTestRun: func() {
+				ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep.SetIsHost(true)
+				ep.ID = hostEPID
+				require.Nil(t, mgr.expose(ep))
+			},
+			setupArgs: func() args {
+				return args{
+					newLabels: map[string]string{"k1": "v1"},
+				}
+			},
+			setupWant: func() want {
+				return want{
+					labels:      map[string]string{"k1": "v1"},
+					labelsCheck: assert.EqualValues,
+				}
+			},
+			postTestRun: func() {
+				if hostEP, ok := mgr.endpoints[hostEPID]; ok {
+					mgr.WaitEndpointRemoved(hostEP)
+				}
+			},
+		},
+		{
+			name: "Update labels",
+			preTestRun: func() {
+				ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep.SetIsHost(true)
+				ep.ID = hostEPID
+				ep.OpLabels.Custom = labels.Labels{"k1": labels.NewLabel("k1", "v1", labels.LabelSourceK8s)}
+				require.Nil(t, mgr.expose(ep))
+			},
+			setupArgs: func() args {
+				return args{
+					oldLabels: map[string]string{"k1": "v1"},
+					newLabels: map[string]string{"k2": "v2"},
+				}
+			},
+			setupWant: func() want {
+				return want{
+					labels:      map[string]string{"k2": "v2"},
+					labelsCheck: assert.EqualValues,
+				}
+			},
+			postTestRun: func() {
+				if hostEP, ok := mgr.endpoints[hostEPID]; ok {
+					mgr.WaitEndpointRemoved(hostEP)
+				}
+			},
+		},
+		{
+			name: "Ignore labels",
+			preTestRun: func() {
+				ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep.SetIsHost(true)
+				ep.ID = hostEPID
+				ep.OpLabels.Custom = labels.Labels{"k1": labels.NewLabel("k1", "v1", labels.LabelSourceK8s)}
+				require.Nil(t, mgr.expose(ep))
+			},
+			setupArgs: func() args {
+				return args{
+					oldLabels: map[string]string{"k1": "v1"},
+					newLabels: map[string]string{"k1": "v1", "ignore1": "v2", "ignore2": "v2"},
+				}
+			},
+			setupWant: func() want {
+				return want{
+					labels:      map[string]string{"k1": "v1"},
+					labelsCheck: assert.EqualValues,
+				}
+			},
+			postTestRun: func() {
+				if hostEP, ok := mgr.endpoints[hostEPID]; ok {
+					mgr.WaitEndpointRemoved(hostEP)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt.preTestRun()
+		args := tt.setupArgs()
+		want := tt.setupWant()
+		mgr.localNodeStore = node.NewTestLocalNodeStore(node.LocalNode{Node: types.Node{
+			Labels: args.oldLabels,
+		}})
+		mgr.startNodeLabelsObserver(args.oldLabels)
+		mgr.localNodeStore.Update(func(ln *node.LocalNode) { ln.Labels = args.newLabels })
+
+		hostEP, ok := mgr.endpoints[hostEPID]
+		require.EqualValues(t, ok, true)
+		got := hostEP.OpLabels.IdentityLabels().K8sStringMap()
+		want.labelsCheck(t, want.labels, got, "Test Name: %s", tt.name)
+		tt.postTestRun()
+	}
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -482,6 +482,10 @@ const (
 	// DNSProxyLockCount.
 	DNSProxyLockTimeout = "dnsproxy-lock-timeout"
 
+	// DNSProxySocketLingerTimeout defines how many seconds we wait for the connection
+	// between the DNS proxy and the upstream server to be closed.
+	DNSProxySocketLingerTimeout = "dnsproxy-socket-linger-timeout"
+
 	// DNSProxyEnableTransparentMode enables transparent mode for the DNS proxy.
 	DNSProxyEnableTransparentMode = "dnsproxy-enable-transparent-mode"
 
@@ -1894,6 +1898,10 @@ type DaemonConfig struct {
 	// DNSProxyLockTimeout is timeout when acquiring the locks controlled by
 	// DNSProxyLockCount.
 	DNSProxyLockTimeout time.Duration
+
+	// DNSProxySocketLingerTimeout defines how many seconds we wait for the connection
+	// between the DNS proxy and the upstream server to be closed.
+	DNSProxySocketLingerTimeout int
 
 	// EnableXTSocketFallback allows disabling of kernel's ip_early_demux
 	// sysctl option if `xt_socket` kernel module is not available.
@@ -3365,6 +3373,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.DNSProxyInsecureSkipTransparentModeCheck = vp.GetBool(DNSProxyInsecureSkipTransparentModeCheck)
 	c.DNSProxyLockCount = vp.GetInt(DNSProxyLockCount)
 	c.DNSProxyLockTimeout = vp.GetDuration(DNSProxyLockTimeout)
+	c.DNSProxySocketLingerTimeout = vp.GetInt(DNSProxySocketLingerTimeout)
 	c.FQDNRejectResponse = vp.GetString(FQDNRejectResponseCode)
 
 	// Convert IP strings into net.IPNet types


### PR DESCRIPTION
 * [x] #33283 (@bimmlerd) :warning: resolved conflicts
    * :warning: Fixed minor conflicts in `allocateHealthIPs`, due to different indentation, and extended the same changes to the IPv6 branch (`coalescenceCIDR` got removed there by https://github.com/cilium/cilium/commit/023818c9dade7a1e99852b617efc3faee0f7e159 as IPv6 is not supported in ENI mode).
 * [x] #33373 (@aditighag) :warning: resolved conflicts
    * :information_source: Skipped 69e5edee4aa8, as codeowners changes are not propagated to stable branches.
 * [ ] #33449 (@jrajahalme) :warning: resolved conflicts
    * :warning: Hit minor conflict in `pkg/policy/mapstate.go` due to different surrounding context, resolved accepting combination. Additionally hit multiple conflicts concerning the removal of the `testing.T` parameter from the Diff method in test files. Resolved accepting the current changes, and manually removing the parameter.
 * [x] #33621 (@brb)
 * [x] #33626 (@giorio94)
 * [x] #33680 (@joestringer)
 * [ ] #33655 (@aditighag) :warning: resolved conflicts
    * :information_source: Hit minor conflict due to different surrounding context; resolved accepting combination.
 * [ ] #33634 (@chaunceyjiang)
 * [x] #33683 (@sayboras) :warning: resolved conflicts
    * :information_source: Hit minor conflicts, resolved adapting the upstream changes to the local structure.
 * [x] #33592 (@gandro) :warning: resolved conflicts
    * :information_source: Hit minor conflict in `pkg/defaults/defaults.go` due to different surrounding context; resolved accepting combination. Additionally dropped the values.schema.json hunk, as not applicable in v1.15.
 * [x] #33708 (@Mais316)
 * [x] #33679 (@giorio94) :warning: resolved conflicts
    * :information_source: Hit conflict as v1.15 still used an old etcd image for integration tests; accepted the incoming changes, as we want to keep the etcd version up-to-date.
 * [x] #33725 (@brb)
 * [ ] #33616 (@mrproliu)
 * [x] #33769 (@pchaigno)
 * [x] #33735 (@giorio94) :warning: resolved conflicts
    * :information_source: Hit minor conflict due to different surrounding context; resolved accepting combination.
 * [x] #33306 (@skmatti) :warning: resolved conflicts
    * :warning: Adapted the `TestUpdateHostEndpointLabels` test due to the different structure in v1.15.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 33283 33373 33449 33621 33626 33680 33655 33634 33683 33592 33708 33679 33725 33616 33769 33735 33306
```
