### PR TITLE
bpf: proxy: only change packet type when needed

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1654,6 +1654,9 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 			  &ext_err, &proxy_port, from_tunnel);
 	switch (ret) {
 	case POLICY_ACT_PROXY_REDIRECT:
+		if (from_tunnel)
+			ctx_change_type(ctx, PACKET_HOST);
+
 		ret = ctx_redirect_to_proxy6(ctx, &tuple, proxy_port, from_host);
 		proxy_redirect = true;
 		break;
@@ -1999,6 +2002,9 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 			  &ext_err, &proxy_port, from_tunnel);
 	switch (ret) {
 	case POLICY_ACT_PROXY_REDIRECT:
+		if (from_tunnel)
+			ctx_change_type(ctx, PACKET_HOST);
+
 		ret = ctx_redirect_to_proxy4(ctx, &tuple, proxy_port, from_host);
 		proxy_redirect = true;
 		break;

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -232,7 +232,6 @@ __ctx_redirect_to_proxy(struct __ctx_buff *ctx, void *tuple __maybe_unused,
 #endif /* ENABLE_IPV6 */
 	}
 #endif /* ENABLE_TPROXY */
-	ctx_change_type(ctx, PACKET_HOST); /* Required for ingress packets from overlay */
 	return result;
 }
 


### PR DESCRIPTION
Pull the ctx_change_type() call into the code path that's described by the code comment. Thus limiting the cases where we touch the packet type.