### PR TITLE
v1.14 Backports 2024-07-15

### DIFF
--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -178,7 +178,7 @@ jobs:
           # Please refer to https://github.com/kubernetes-sigs/ingress-controller-conformance/pull/101 for more details.
           repository: cilium/ingress-controller-conformance
           path: ingress-controller-conformance
-          ref: 010bbae21b71d9785660b87908dfe2ba8cd2f25d
+          ref: 6a193b3f73d8b1201a818bb7c8f204059b064857
           persist-credentials: false
 
       - name: Install Ingress conformance test tool
@@ -275,7 +275,7 @@ jobs:
         timeout-minutes: 30
         run: |
           cd ingress-controller-conformance
-          ./ingress-controller-conformance -ingress-class cilium -wait-time-for-ingress-status 60s -wait-time-for-ready 60s
+          ./ingress-controller-conformance -ingress-class cilium -wait-time-for-ingress-status 60s -wait-time-for-ready 60s -http-client-timeout 60s
 
       - name: Post-test information gathering
         if: ${{ !success() }}

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -87,6 +87,7 @@ cilium-agent [flags]
       --dnsproxy-concurrency-limit int                            Limit concurrency of DNS message processing
       --dnsproxy-concurrency-processing-grace-period duration     Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing
       --dnsproxy-enable-transparent-mode                          Enable DNS proxy transparent mode
+      --dnsproxy-socket-linger-timeout int                        Timeout (in seconds) when closing the connection between the DNS proxy and the upstream server. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background (default 10)
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
       --egress-masquerade-interfaces string                       Limit iptables-based egress masquerading to interface selector

--- a/Documentation/community/roadmap.rst
+++ b/Documentation/community/roadmap.rst
@@ -32,6 +32,8 @@ Major Feature Status
 ++-------------------------------------------------+----------------------------------------------------------+
 || :ref:`bandwidth-manager`                        | Stable                                                   |
 ++-------------------------------------------------+----------------------------------------------------------+
+|| :ref:`local-redirect-policy`                    | Stable                                                   |
+++-------------------------------------------------+----------------------------------------------------------+
 | Cilium Mesh                                      | Stable (:ref:`Roadmap Details<rm-clustermesh>`)          |
 ++-------------------------------------------------+----------------------------------------------------------+
 || :ref:`Multi-Cluster (ClusterMesh)<clustermesh>` | Stable                                                   |
@@ -131,7 +133,6 @@ these are already in production use with a set of adopters. We expect the
 following features to graduate to stable:
 
 * :ref:`BGP<bgp>`
-* :ref:`Local Redirect Policy<local-redirect-policy>`
 * :ref:`CiliumEndpointSlice<gsg_ces>`
 * :ref:`Multi-Pool IPAM<ipam_crd_multi_pool>`
 * :ref:`Node-to-node WireGuard encryption<node-node-wg>`

--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -117,20 +117,7 @@ Second, fetch a VM image:
 
 .. code-block:: shell-session
 
-    $ mkdir images/
-    $ docker run -v $(pwd)/images:/mnt/images \
-        quay.io/lvh-images/kind:6.0-main \
-        cp /data/images/kind_6.0.qcow2.zst /mnt/images
-    $ cd images/
-    $ zstd -d kind_6.0.qcow2.zst
-
-Alternatively, you can use the ``scripts/pull_image.sh``:
-
-.. code-block:: shell-session
-
-    $ mkdir images/
-    $ git clone https://github.com/cilium/little-vm-helper
-    $ IMAGE_DIR=./images ./little-vm-helper/scripts/pull_image.sh quay.io/lvh-images/kind:6.0-main
+    $ lvh images pull quay.io/lvh-images/kind:6.1-main --dir .
 
 See `<https://quay.io/organization/lvh-images/kind?tab=tags>`_ for all available
 images. To build a new VM image (or to update any existing) please refer to
@@ -140,7 +127,7 @@ Next, start a VM:
 
 .. code-block:: shell-session
 
-    $ lvh run --image ./images/kind_6.0.qcow2 --host-mount $GOPATH/src/github.com/cilium/ --daemonize -p 2222:22 --cpu=3 --mem=6G
+    $ lvh run --image ./images/kind_6.1.qcow2 --host-mount $GOPATH/src/github.com/cilium/ --daemonize -p 2222:22 --cpu=3 --mem=6G
 
 .. _test_cilium_on_lvh:
 

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -828,6 +828,10 @@
      - The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.
      - string
      - ``"100ms"``
+   * - :spelling:ignore:`dnsProxy.socketLingerTimeout`
+     - Timeout (in seconds) when closing the connection between the DNS proxy and the upstream server. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background.
+     - int
+     - ``10``
    * - :spelling:ignore:`egressGateway`
      - Enables egress gateway to redirect and SNAT the traffic that leaves the cluster.
      - object

--- a/Documentation/installation/cni-chaining-azure-cni.rst
+++ b/Documentation/installation/cni-chaining-azure-cni.rst
@@ -88,6 +88,7 @@ Deploy Cilium release via Helm:
      --namespace kube-system \\
      --set cni.chainingMode=generic-veth \\
      --set cni.customConf=true \\
+     --set cni.exclusive=false \\
      --set nodeinit.enabled=true \\
      --set cni.configMap=cni-configuration \\
      --set routingMode=native \\

--- a/Documentation/network/clustermesh/policy.rst
+++ b/Documentation/network/clustermesh/policy.rst
@@ -45,12 +45,3 @@ between two clusters. The cluster name refers to the name given via the
         - matchLabels:
             name: rebel-base
             io.cilium.k8s.policy.cluster: cluster2
-
-Limitations
-###########
-
- * L7 security policies currently only work across multiple clusters if worker
-   nodes have routes installed allowing to route pod IPs of all clusters. This
-   is obtained when running in direct routing mode by running a routing daemon or
-   ``--auto-direct-node-routes`` but won't work automatically when using
-   tunnel/encapsulation mode.

--- a/Documentation/network/kubernetes/local-redirect-policy.rst
+++ b/Documentation/network/kubernetes/local-redirect-policy.rst
@@ -53,10 +53,21 @@ Enable the feature by setting the ``localRedirectPolicy`` value to ``true``.
 
 .. parsed-literal::
 
-   helm install cilium |CHART_RELEASE| \\
+   helm upgrade cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --reuse-values \\
      --set localRedirectPolicy=true
 
-Verify that Cilium agent pod is running.
+
+Rollout the operator and agent pods to make the changes effective:
+
+.. code-block:: shell-session
+
+    $ kubectl rollout restart deploy cilium-operator -n kube-system
+    $ kubectl rollout restart ds cilium -n kube-system
+
+
+Verify that Cilium agent and operator pods are running.
 
 .. code-block:: shell-session
 
@@ -64,6 +75,9 @@ Verify that Cilium agent pod is running.
     NAME           READY   STATUS    RESTARTS   AGE
     cilium-5ngzd   1/1     Running   0          3m19s
 
+    $ kubectl -n kube-system get pods -l name=cilium-operator
+    NAME                               READY   STATUS    RESTARTS   AGE
+    cilium-operator-544b4d5cdd-qxvpv   1/1     Running   0          3m19s
 
 Validate that the Cilium Local Redirect Policy CRD has been registered.
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -56,11 +56,10 @@ ifeq ($(DOCKER_IMAGE_TAG),)
     DOCKER_IMAGE_TAG=latest
 endif
 
-ifeq ($(shell uname -m),aarch64)
-    ETCD_IMAGE=quay.io/coreos/etcd:v3.3.20-arm64
-else
-    ETCD_IMAGE=quay.io/coreos/etcd:v3.3.20
-endif
+# renovate: datasource=docker depName=gcr.io/etcd-development/etcd
+ETCD_IMAGE_VERSION = v3.5.11
+ETCD_IMAGE_SHA = sha256:8eff25cf636711fb48426005b55fc9f4d6ffa4f38f483fa87c8cc82976347bbb
+ETCD_IMAGE=gcr.io/etcd-development/etcd:$(ETCD_IMAGE_VERSION)@$(ETCD_IMAGE_SHA)
 
 CONSUL_IMAGE=consul:1.7.2
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -906,6 +906,10 @@ func initializeFlags() {
 	flags.MarkHidden(option.DNSProxyLockTimeout)
 	option.BindEnv(Vp, option.DNSProxyLockTimeout)
 
+	flags.Int(option.DNSProxySocketLingerTimeout, defaults.DNSProxySocketLingerTimeout, "Timeout (in seconds) when closing the connection between the DNS proxy and the upstream server. "+
+		"If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background")
+	option.BindEnv(Vp, option.DNSProxySocketLingerTimeout)
+
 	flags.Bool(option.DNSProxyEnableTransparentMode, defaults.DNSProxyEnableTransparentMode, "Enable DNS proxy transparent mode")
 	option.BindEnv(Vp, option.DNSProxyEnableTransparentMode)
 

--- a/daemon/cmd/ipam_test.go
+++ b/daemon/cmd/ipam_test.go
@@ -10,57 +10,57 @@ import (
 func TestCoalesceCIDRs(t *testing.T) {
 	CIDR := []string{"10.0.0.0/8"}
 	expectedCIDR := []string{"10.0.0.0/8"}
-	newCIDR := coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err := coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"10.105.0.0/16", "10.0.0.0/8"}
 	expectedCIDR = []string{"10.0.0.0/8"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"10.105.0.0/16", "10.104.0.0/19", "10.0.0.0/8"}
 	expectedCIDR = []string{"10.0.0.0/8"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24"}
 	expectedCIDR = []string{"10.105.0.0/16", "192.168.1.0/24"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8"}
 	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8", "f00d::a0f:0:0:0/96"}
 	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24", "f00d::a0f:0:0:0/96"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"f00d::a0f:0:0:0/96", "10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8"}
 	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24", "f00d::a0f:0:0:0/96"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 
 	CIDR = []string{"f00d::a0f:0:0:0/96"}
 	expectedCIDR = []string{"f00d::a0f:0:0:0/96"}
-	newCIDR = coalesceCIDRs(CIDR)
-	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
-		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
+	newCIDR, err = coalesceCIDRs(CIDR)
+	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
+		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
 	}
 }

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -257,6 +257,7 @@ contributors across the globe, there is almost always someone available to help.
 | dnsProxy.preCache | string | `""` | DNS cache data at this path is preloaded on agent startup. |
 | dnsProxy.proxyPort | int | `0` | Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port. |
 | dnsProxy.proxyResponseMaxDelay | string | `"100ms"` | The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. |
+| dnsProxy.socketLingerTimeout | int | `10` | Timeout (in seconds) when closing the connection between the DNS proxy and the upstream server. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background. |
 | egressGateway | object | `{"enabled":false,"installRoutes":false,"reconciliationTriggerInterval":"1s"}` | Enables egress gateway to redirect and SNAT the traffic that leaves the cluster. |
 | egressGateway.installRoutes | bool | `false` | Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface |
 | egressGateway.reconciliationTriggerInterval | string | `"1s"` | Time between triggers of egress gateway state reconciliations |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1107,6 +1107,9 @@ data:
   # default DNS proxy to transparent mode in non-chaining modes
   dnsproxy-enable-transparent-mode: {{ $defaultDNSProxyEnableTransparentMode | quote }}
   {{- end }}
+  {{- if .Values.dnsProxy.socketLingerTimeout }}
+  dnsproxy-socket-linger-timeout: {{ .Values.dnsProxy.socketLingerTimeout | quote }}
+  {{- end }}
   {{- if .Values.dnsProxy.dnsRejectResponseCode }}
   tofqdns-dns-reject-response-code: {{ .Values.dnsProxy.dnsRejectResponseCode | quote }}
   {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3099,6 +3099,8 @@ enableK8sTerminatingEndpoint: true
 agentNotReadyTaintKey: "node.cilium.io/agent-not-ready"
 
 dnsProxy:
+  # -- Timeout (in seconds) when closing the connection between the DNS proxy and the upstream server. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background.
+  socketLingerTimeout: 10
   # -- DNS response code for rejecting DNS requests, available options are '[nameError refused]'.
   dnsRejectResponseCode: refused
   # -- Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3096,6 +3096,8 @@ enableK8sTerminatingEndpoint: true
 agentNotReadyTaintKey: "node.cilium.io/agent-not-ready"
 
 dnsProxy:
+  # -- Timeout (in seconds) when closing the connection between the DNS proxy and the upstream server. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background.
+  socketLingerTimeout: 10
   # -- DNS response code for rejecting DNS requests, available options are '[nameError refused]'.
   dnsRejectResponseCode: refused
   # -- Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present.

--- a/pkg/clustermesh/internal/remote_cluster.go
+++ b/pkg/clustermesh/internal/remote_cluster.go
@@ -259,7 +259,7 @@ func (rc *remoteCluster) getClusterConfig(ctx context.Context, backend kvstore.B
 	rc.config = &models.RemoteClusterConfig{Required: requireConfig}
 	rc.mutex.Unlock()
 
-	cfgch := make(chan *types.CiliumClusterConfig)
+	cfgch := make(chan *types.CiliumClusterConfig, 1)
 	defer close(cfgch)
 
 	// We retry here rather than simply returning an error and relying on the external

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -161,6 +161,10 @@ const (
 	// DNSProxyEnableTransparentMode enables transparent mode for the DNS proxy.
 	DNSProxyEnableTransparentMode = false
 
+	// DNSProxySocketLingerTimeout defines how many seconds we wait for the connection
+	// between the DNS proxy and the upstream server to be closed.
+	DNSProxySocketLingerTimeout = 10
+
 	// IdentityChangeGracePeriod is the default value for
 	// option.IdentityChangeGracePeriod
 	IdentityChangeGracePeriod = 5 * time.Second

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -870,6 +870,23 @@ func setSoMarks(fd int, ipFamily ipfamily.IPFamily, secId identity.NumericIdenti
 		}
 	}
 
+	// Set SO_LINGER to ensure the TCP socket is closed and ready to be re-used in case
+	// the client reuses the same source port in short succession (this is e.g. the case
+	// with glibc). If SO_LINGER is not used, the old socket might have not yet reached
+	// the TIME_WAIT state by the time we are trying to reuse the port on a new socket.
+	// If that happens, the connect() call will fail with EADDRNOTAVAIL.
+	// Note that the linger timeout can also be set to 0, in which case the socket is
+	// terminated forcefully with a TCP RST and thus can also be reused immediately.
+	if linger := option.Config.DNSProxySocketLingerTimeout; linger >= 0 {
+		err = unix.SetsockoptLinger(fd, unix.SOL_SOCKET, unix.SO_LINGER, &unix.Linger{
+			Onoff:  1,
+			Linger: int32(linger),
+		})
+		if err != nil {
+			return fmt.Errorf("setsockopt(SO_LINGER) failed: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -502,6 +502,10 @@ const (
 	// DNSProxyLockCount.
 	DNSProxyLockTimeout = "dnsproxy-lock-timeout"
 
+	// DNSProxySocketLingerTimeout defines how many seconds we wait for the connection
+	// between the DNS proxy and the upstream server to be closed.
+	DNSProxySocketLingerTimeout = "dnsproxy-socket-linger-timeout"
+
 	// DNSProxyEnableTransparentMode enables transparent mode for the DNS proxy.
 	DNSProxyEnableTransparentMode = "dnsproxy-enable-transparent-mode"
 
@@ -1903,6 +1907,10 @@ type DaemonConfig struct {
 	// DNSProxyLockTimeout is timeout when acquiring the locks controlled by
 	// DNSProxyLockCount.
 	DNSProxyLockTimeout time.Duration
+
+	// DNSProxySocketLingerTimeout defines how many seconds we wait for the connection
+	// between the DNS proxy and the upstream server to be closed.
+	DNSProxySocketLingerTimeout int
 
 	// EnableXTSocketFallback allows disabling of kernel's ip_early_demux
 	// sysctl option if `xt_socket` kernel module is not available.
@@ -3369,6 +3377,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.DNSProxyInsecureSkipTransparentModeCheck = vp.GetBool(DNSProxyInsecureSkipTransparentModeCheck)
 	c.DNSProxyLockCount = vp.GetInt(DNSProxyLockCount)
 	c.DNSProxyLockTimeout = vp.GetDuration(DNSProxyLockTimeout)
+	c.DNSProxySocketLingerTimeout = vp.GetInt(DNSProxySocketLingerTimeout)
 	c.FQDNRejectResponse = vp.GetString(FQDNRejectResponseCode)
 
 	// Convert IP strings into net.IPNet types


### PR DESCRIPTION
 * [x] #33283 (@bimmlerd) :warning: resolved conflicts
    * ⚠️ Fixed minor conflicts in allocateHealthIPs, due to different indentation, and extended the same changes to the IPv6 branch (coalescenceCIDR got removed there by https://github.com/cilium/cilium/commit/023818c9dade7a1e99852b617efc3faee0f7e159 as IPv6 is not supported in ENI mode).
 * [x] #33373 (@aditighag) :warning: resolved conflicts
    * ℹ️ Skipped https://github.com/cilium/cilium/commit/69e5edee4aa8cce140ece1838b6ee06b603ebd35, as codeowners changes are not propagated to stable branches.
 * [x] #33621 (@brb)
 * [x] #33626 (@giorio94)
 * [x] #33655 (@aditighag) :warning: resolved conflicts
    * ℹ️ Hit minor conflict due to different surrounding context; resolved accepting combination.
 * [x] #33683 (@sayboras) :warning: resolved conflicts
    * ℹ️ Hit minor conflicts, resolved adapting the upstream changes to the local structure.
 * [x] #33592 (@gandro) :warning: resolved conflicts
    * ℹ️ Hit minor conflict in pkg/defaults/defaults.go due to different surrounding context; resolved accepting combination. Adapted flag registration, changing `vp` to `Vp`. Additionally dropped the `values.schema.json` hunk, as not applicable in v1.14, and regenerated helm values documentation.
 * [ ] #33708 (@Mais316)
 * [x] #33679 (@giorio94) :warning: resolved conflicts
    * ℹ️ Hit conflict as v1.15 still used an old etcd image for integration tests; accepted the incoming changes, as we want to keep the etcd version up-to-date.
 * [ ] ~~#33769 (@pchaigno)~~
    * :x: Skipped, as causes the Cilium IPsec upgrade workflow to fail, and needs further investigation.
 * [x] #33735 (@giorio94) :warning: resolved conflicts
    * ℹ️ Hit minor conflict due to different surrounding context; resolved accepting combination.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 33283 33373 33621 33626 33655 33683 33592 33708 33679 33735
```
