### PR TITLE
[v1.15] datapath: Fix update to NodeAddress table and prioritize Node IP

### DIFF
--- a/pkg/datapath/tables/node_address_test.go
+++ b/pkg/datapath/tables/node_address_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/statedb"
 )
@@ -57,8 +58,12 @@ func TestNodeAddressConfig(t *testing.T) {
 	}
 }
 
-var ciliumHostIP = net.ParseIP("9.9.9.9")
-var ciliumHostIPLinkScoped = net.ParseIP("9.9.9.8")
+var (
+	testNodeIPv4           = netip.MustParseAddr("172.16.0.1")
+	testNodeIPv6           = netip.MustParseAddr("2222::1")
+	ciliumHostIP           = net.ParseIP("9.9.9.9")
+	ciliumHostIPLinkScoped = net.ParseIP("9.9.9.8")
+)
 
 var nodeAddressTests = []struct {
 	name         string
@@ -245,6 +250,53 @@ var nodeAddressTests = []struct {
 			net.ParseIP("2001:db8::1"),
 		},
 	},
+
+	{
+		name: "node IP preferred",
+		addrs: []tables.DeviceAddress{
+			{
+				Addr:  netip.MustParseAddr("10.0.0.1"),
+				Scope: unix.RT_SCOPE_UNIVERSE,
+			},
+			{
+				Addr:  netip.MustParseAddr("1.1.1.1"),
+				Scope: unix.RT_SCOPE_UNIVERSE,
+			},
+			{
+				Addr:  testNodeIPv4,
+				Scope: unix.RT_SCOPE_UNIVERSE,
+			},
+			{
+				Addr:  netip.MustParseAddr("2001:db8::1"),
+				Scope: unix.RT_SCOPE_UNIVERSE,
+			},
+			{
+				Addr:  testNodeIPv6,
+				Scope: unix.RT_SCOPE_UNIVERSE,
+			},
+		},
+
+		wantAddrs: []net.IP{
+			ciliumHostIP,
+			ciliumHostIPLinkScoped,
+			net.ParseIP("10.0.0.1"),
+			net.ParseIP("1.1.1.1"),
+			net.ParseIP("2001:db8::1"),
+			testNodeIPv4.AsSlice(),
+			testNodeIPv6.AsSlice(),
+		},
+
+		wantPrimary: []net.IP{
+			ciliumHostIP,
+			testNodeIPv4.AsSlice(),
+			testNodeIPv6.AsSlice(),
+		},
+
+		wantNodePort: []net.IP{
+			testNodeIPv4.AsSlice(),
+			testNodeIPv6.AsSlice(),
+		},
+	},
 }
 
 func TestNodeAddress(t *testing.T) {
@@ -252,7 +304,7 @@ func TestNodeAddress(t *testing.T) {
 
 	for _, tt := range nodeAddressTests {
 		t.Run(tt.name, func(t *testing.T) {
-			db, devices, nodeAddrs := fixture(t, defaults.AddressScopeMax, nil)
+			db, devices, nodeAddrs, _ := fixture(t, defaults.AddressScopeMax, nil)
 
 			txn := db.WriteTxn(devices)
 			_, watch := nodeAddrs.All(txn)
@@ -301,7 +353,6 @@ func TestNodeAddress(t *testing.T) {
 			assertOnePrimaryPerDevice(t, addrs)
 		})
 	}
-
 }
 
 // TestNodeAddressHostDevice checks that the for cilium_host the link scope'd
@@ -310,7 +361,7 @@ func TestNodeAddress(t *testing.T) {
 func TestNodeAddressHostDevice(t *testing.T) {
 	t.Parallel()
 
-	db, devices, nodeAddrs := fixture(t, unix.RT_SCOPE_SITE, nil)
+	db, devices, nodeAddrs, _ := fixture(t, unix.RT_SCOPE_SITE, nil)
 
 	txn := db.WriteTxn(devices)
 	_, watch := nodeAddrs.All(txn)
@@ -441,7 +492,7 @@ func TestNodeAddressWhitelist(t *testing.T) {
 
 	for _, tt := range nodeAddressWhitelistTests {
 		t.Run(tt.name, func(t *testing.T) {
-			db, devices, nodeAddrs := fixture(t, defaults.AddressScopeMax,
+			db, devices, nodeAddrs, _ := fixture(t, defaults.AddressScopeMax,
 				func(h *hive.Hive) {
 					h.Viper().Set("nodeport-addresses", tt.cidrs)
 				})
@@ -490,7 +541,7 @@ func TestNodeAddressWhitelist(t *testing.T) {
 
 // TestNodeAddressUpdate tests incremental updates to the node addresses.
 func TestNodeAddressUpdate(t *testing.T) {
-	db, devices, nodeAddrs := fixture(t, defaults.AddressScopeMax, func(*hive.Hive) {})
+	db, devices, nodeAddrs, _ := fixture(t, defaults.AddressScopeMax, func(*hive.Hive) {})
 
 	// Insert 10.0.0.1
 	txn := db.WriteTxn(devices)
@@ -588,24 +639,77 @@ func TestNodeAddressUpdate(t *testing.T) {
 	assert.False(t, ok, "expected no addresses")
 }
 
-func fixture(t *testing.T, addressScopeMax int, beforeStart func(*hive.Hive)) (*statedb.DB, statedb.RWTable[*tables.Device], statedb.Table[tables.NodeAddress]) {
+func TestNodeAddressNodeIPChange(t *testing.T) {
+	db, devices, nodeAddrs, localNodeStore := fixture(t, defaults.AddressScopeMax, func(*hive.Hive) {})
+
+	// Insert 10.0.0.1 and the current node IP
+	txn := db.WriteTxn(devices)
+	_, watch := nodeAddrs.All(txn)
+	devices.Insert(txn, &tables.Device{
+		Index: 1,
+		Name:  "test",
+		Flags: net.FlagUp,
+		Addrs: []tables.DeviceAddress{
+			{Addr: netip.MustParseAddr("10.0.0.1"), Scope: unix.RT_SCOPE_UNIVERSE},
+			{Addr: testNodeIPv4, Scope: unix.RT_SCOPE_UNIVERSE},
+		},
+		Selected: true,
+	})
+	txn.Commit()
+	<-watch // wait for propagation
+
+	nodePortAddrs := func() (addrs []tables.NodeAddress, watch <-chan struct{}) {
+		iter, watch := nodeAddrs.All(db.ReadTxn())
+		for addr, _, ok := iter.Next(); ok; addr, _, ok = iter.Next() {
+			if addr.NodePort {
+				addrs = append(addrs, addr)
+			}
+		}
+		return addrs, watch
+	}
+
+	addrs, watch := nodePortAddrs()
+	if assert.Len(t, addrs, 1) {
+		assert.Equal(t, testNodeIPv4, addrs[0].Addr)
+		assert.Equal(t, "test", addrs[0].DeviceName)
+	}
+
+	// Make the 10.0.0.1 the new NodeIP.
+	localNodeStore.Update(func(n *node.LocalNode) {
+		n.SetNodeExternalIP(net.ParseIP("10.0.0.1"))
+	})
+	<-watch
+
+	// The new node IP should now be preferred for NodePort.
+	addrs, _ = nodePortAddrs()
+	if assert.Len(t, addrs, 1) {
+		assert.Equal(t, "10.0.0.1", addrs[0].Addr.String())
+		assert.Equal(t, "test", addrs[0].DeviceName)
+	}
+}
+
+func fixture(t *testing.T, addressScopeMax int, beforeStart func(*hive.Hive)) (*statedb.DB, statedb.RWTable[*tables.Device], statedb.Table[tables.NodeAddress], *node.LocalNodeStore) {
 	var (
-		db        *statedb.DB
-		devices   statedb.RWTable[*tables.Device]
-		nodeAddrs statedb.Table[tables.NodeAddress]
+		db             *statedb.DB
+		devices        statedb.RWTable[*tables.Device]
+		nodeAddrs      statedb.Table[tables.NodeAddress]
+		localNodeStore *node.LocalNodeStore
 	)
 	h := hive.New(
 		job.Cell,
 		statedb.Cell,
 		tables.NodeAddressCell,
+		node.LocalNodeStoreCell,
 		cell.Provide(
 			tables.NewDeviceTable,
 			statedb.RWTable[*tables.Device].ToTable,
 		),
-		cell.Invoke(func(db_ *statedb.DB, d statedb.RWTable[*tables.Device], na statedb.Table[tables.NodeAddress]) {
+		cell.Provide(func() node.LocalNodeSynchronizer { return testLocalNodeSync{} }),
+		cell.Invoke(func(db_ *statedb.DB, d statedb.RWTable[*tables.Device], na statedb.Table[tables.NodeAddress], lns *node.LocalNodeStore) {
 			db = db_
 			devices = d
 			nodeAddrs = na
+			localNodeStore = lns
 			db.RegisterTable(d)
 		}),
 
@@ -621,11 +725,28 @@ func fixture(t *testing.T, addressScopeMax int, beforeStart func(*hive.Hive)) (*
 		beforeStart(h)
 	}
 	require.NoError(t, h.Start(context.TODO()), "Start")
+
 	t.Cleanup(func() {
 		assert.NoError(t, h.Stop(context.TODO()), "Stop")
 	})
-	return db, devices, nodeAddrs
+	return db, devices, nodeAddrs, localNodeStore
 }
+
+type testLocalNodeSync struct {
+}
+
+// InitLocalNode implements node.LocalNodeSynchronizer.
+func (t testLocalNodeSync) InitLocalNode(_ context.Context, n *node.LocalNode) error {
+	n.SetNodeExternalIP(testNodeIPv4.AsSlice())
+	n.SetNodeExternalIP(testNodeIPv6.AsSlice())
+	return nil
+}
+
+// SyncLocalNode implements node.LocalNodeSynchronizer.
+func (t testLocalNodeSync) SyncLocalNode(context.Context, *node.LocalNodeStore) {
+}
+
+var _ node.LocalNodeSynchronizer = testLocalNodeSync{}
 
 // ipStrings converts net.IP to a string. Used to assert equalence without having to deal
 // with e.g. IPv4-mapped IPv6 presentation etc.

--- a/pkg/datapath/tables/node_addressing_test.go
+++ b/pkg/datapath/tables/node_addressing_test.go
@@ -66,6 +66,7 @@ func setupNodeAddressing(t *testing.T, addrs []tables.DeviceAddress) (nodeAddres
 
 		// LocalNodeStore as required by Router(), PrimaryExternal(), etc.
 		node.LocalNodeStoreCell,
+		cell.Provide(func() node.LocalNodeSynchronizer { return testLocalNodeSync{} }),
 
 		// option.DaemonConfig needed for AddressMaxScope. This flag will move into NodeAddressConfig
 		// in a follow-up PR.


### PR DESCRIPTION
This is backport of https://github.com/cilium/cilium/pull/33629 to v1.15.

The commit about fallback addresses is not relevant as the functionality is not present in v1.15.


```upstream-prs
33629
```