### PR TITLE
Allow Renovate to bump to golang v1.22

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -334,26 +334,8 @@
       ],
       "allowedVersions": "<1.23",
       "matchBaseBranches": [
-        "v1.16"
-      ]
-    },
-    {
-      "matchPackageNames": [
-        "docker.io/library/golang",
-        "go"
-      ],
-      "allowedVersions": "<1.22",
-      "matchBaseBranches": [
-        "v1.15"
-      ]
-    },
-    {
-      "matchPackageNames": [
-        "docker.io/library/golang",
-        "go"
-      ],
-      "allowedVersions": "<1.22",
-      "matchBaseBranches": [
+        "v1.16",
+        "v1.15",
         "v1.14",
         "v1.13"
       ]


### PR DESCRIPTION
Golang v1.21 will be EOL soon – this change will allow us to keep on top of security updates to the standard library.