### PR TITLE
pkg/metrics: fix data race warning on metrics init hook.

### DIFF
--- a/pkg/metrics/logging_hook.go
+++ b/pkg/metrics/logging_hook.go
@@ -26,7 +26,6 @@ func FlushLoggingMetrics() {
 	flushMetrics.Do(func() {
 		if metricsInitialized != nil {
 			close(metricsInitialized)
-			metricsInitialized = nil
 		}
 	})
 }
@@ -50,6 +49,7 @@ func NewLoggingHook() *LoggingHook {
 		// accurate, however init errors can only happen during initialization so it probably doesn't make
 		// a big difference in practice.
 		<-metricsInitialized
+		metricsInitialized = nil
 		ErrorsWarnings.WithLabelValues(logrus.ErrorLevel.String(), "init").Add(float64(lh.errs.Load()))
 		ErrorsWarnings.WithLabelValues(logrus.WarnLevel.String(), "init").Add(float64(lh.warn.Load()))
 	}()


### PR DESCRIPTION
This was added to allow for flushing logging metrics that may
have been accumulated at init time (i.e. prior to hive) before
the metrics infra being set up in Hive.

However, it may be possible for the channel being set to nil (to allow for GC)
while the setup logging hooks is reading the channel in order to wait
for init.
This was leading to a concurrent read/write of the channel.

To fix this, we no longer set the channel to nil in the finish init function
but instead serialize it by doing it after the wait on channel unblocks.

Fixes: https://github.com/cilium/cilium/issues/33812