### PR TITLE
[v1.16] policy/k8s: Fix deadlock in ToServices implementation

### DIFF
--- a/pkg/policy/k8s/cell.go
+++ b/pkg/policy/k8s/cell.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/cilium/hive/cell"
-	"github.com/cilium/stream"
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/k8s"
@@ -83,8 +82,7 @@ func startK8sPolicyWatcher(params PolicyWatcherParams) {
 	// We want to subscribe before the start hook is invoked in order to not miss
 	// any events
 	ctx, cancel := context.WithCancel(context.Background())
-	svcCacheNotifications := stream.ToChannel(ctx, params.ServiceCache.Notifications(),
-		stream.WithBufferSize(int(params.Config.K8sServiceCacheSize)))
+	svcCacheNotifications := serviceNotificationsQueue(ctx, params.ServiceCache.Notifications())
 
 	p := &policyWatcher{
 		log:                              params.Logger,

--- a/pkg/policy/k8s/service.go
+++ b/pkg/policy/k8s/service.go
@@ -4,14 +4,18 @@
 package k8s
 
 import (
+	"context"
 	"errors"
+	"sync"
 
+	"github.com/cilium/stream"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/time"
@@ -319,4 +323,98 @@ func (s *serviceEndpoints) processRule(rule *api.Rule) (numMatches int) {
 		}
 	}
 	return numMatches
+}
+
+type serviceQueue struct {
+	mu    *lock.Mutex
+	cond  *sync.Cond
+	queue []k8s.ServiceNotification
+}
+
+func newServiceQueue() *serviceQueue {
+	mu := new(lock.Mutex)
+	return &serviceQueue{
+		mu:    mu,
+		cond:  sync.NewCond(mu),
+		queue: []k8s.ServiceNotification{},
+	}
+}
+
+func (q *serviceQueue) enqueue(item k8s.ServiceNotification) {
+	q.mu.Lock()
+	q.queue = append(q.queue, item)
+	q.cond.Signal()
+	q.mu.Unlock()
+}
+
+func (q *serviceQueue) signal() {
+	q.mu.Lock()
+	q.cond.Signal()
+	q.mu.Unlock()
+}
+
+func (q *serviceQueue) dequeue(ctx context.Context) (item k8s.ServiceNotification, ok bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	for len(q.queue) == 0 {
+		q.cond.Wait()
+
+		// If ctx is cancelled, we return immediately
+		if ctx.Err() != nil {
+			return item, false
+		}
+	}
+
+	item = q.queue[0]
+	q.queue = q.queue[1:]
+
+	return item, true
+}
+
+// serviceNotificationsQueue converts the observable src into a channel.
+// When the provided context is cancelled the underlying subscription is
+// cancelled and the channel is closed.
+// In contrast to stream.ToChannel, this function has an unbounded buffer,
+// meaning the consumer must always consume the channel (or cancel ctx)
+func serviceNotificationsQueue(ctx context.Context, src stream.Observable[k8s.ServiceNotification]) <-chan k8s.ServiceNotification {
+	ctx, cancel := context.WithCancel(ctx)
+	ch := make(chan k8s.ServiceNotification)
+	q := newServiceQueue()
+
+	// This go routine is woken up whenever there a new item has been added to
+	// queue and forwards it to ch. It exits when context ctx is cancelled.
+	go func() {
+		// Close downstream channel on exit
+		defer close(ch)
+
+		// Exit the for-loop below if the context is cancelled.
+		// See https://pkg.go.dev/context#AfterFunc for a more detailed
+		// explanation of this pattern
+		cleanupCancellation := context.AfterFunc(ctx, q.signal)
+		defer cleanupCancellation()
+
+		for {
+			item, ok := q.dequeue(ctx)
+			if !ok {
+				return
+			}
+
+			select {
+			case ch <- item:
+				continue
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	src.Observe(ctx,
+		q.enqueue,
+		func(err error) {
+			cancel() // stops above go routine
+		},
+	)
+
+	return ch
 }


### PR DESCRIPTION
v1.16 backports 2024-07-15

 - [ ] #33739 -- policy/k8s: Fix deadlock in ToServices implementation (@gandro)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
33739
```
