### PR TITLE
ipsec: define marks consistently

### DIFF
--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -33,7 +33,7 @@ const (
 
 	// RouteMarkDecrypt is the default route mark to use to indicate datapath
 	// needs to decrypt a packet.
-	RouteMarkDecrypt = 0x0D00
+	RouteMarkDecrypt = MagicMarkDecrypt
 
 	// RouteMarkDecryptedOverlay is the output mark used for EncryptedOverlay
 	// XFRM policies.
@@ -41,11 +41,11 @@ const (
 	// When this mark is present on a packet it indicates that overlay traffic
 	// was decrypted by XFRM and should be forwarded to a tunnel device for
 	// decapsulation.
-	RouteMarkDecryptedOverlay = 0x1D00
+	RouteMarkDecryptedOverlay = MagicMarkDecryptedOverlay
 
 	// RouteMarkEncrypt is the default route mark to use to indicate datapath
 	// needs to encrypt a packet.
-	RouteMarkEncrypt = 0x0E00
+	RouteMarkEncrypt = MagicMarkEncrypt
 
 	// RouteMarkMask is the mask required for the route mark value
 	RouteMarkMask = 0xF00

--- a/pkg/datapath/linux/linux_defaults/mark.go
+++ b/pkg/datapath/linux/linux_defaults/mark.go
@@ -102,6 +102,22 @@ const (
 	// 0x1000, and the K8s marks are 0x4000 and 0x8000. So both are not
 	// interfering with that bit.
 	MagicMarkWireGuardEncrypted int = 0x1E00
+
+	// MagicMarkDecrypt is the packet mark used to indicate the datapath needs
+	// to decrypt a packet.
+	MagicMarkDecrypt = 0x0D00
+
+	// MagicMarkDecryptedOverlay indicates to the datapath that the packet
+	// was IPsec decrypted and now contains a vxlan header.
+	//
+	// When this mark is present on a packet it indicates that overlay traffic
+	// was decrypted by XFRM and should be forwarded to a tunnel device for
+	// decapsulation.
+	MagicMarkDecryptedOverlay = 0x1D00
+
+	// MagicMarkEncrypt is the packet mark to use to indicate datapath
+	// needs to encrypt a packet.
+	MagicMarkEncrypt = 0x0E00
 )
 
 // getMagicMark returns the magic marker with which each packet must be marked.


### PR DESCRIPTION
Most skb marks are defined in pkg/datapath/linux/linux_defaults/mark.go where accompanying comments are found.

Due to IPSec marks being used in userspace as well (ip rules, xfrm, etc...) these marks were defined in pkg/datapath/linux/linux_defaults/linux_defaults.go with a 'RouteMark' prefix.

For consistency, this PR defines MagicMark* constants for IPsec related skb marks and links these to their RouteMark* constants used in userspace.

```release-note
Defines IPsec related marks consistently. 
```
