### PR TITLE
fix(helm-chart): cilium-configmap extraConfig

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1300,8 +1300,8 @@ data:
   clustermesh-enable-endpoint-sync: {{ .Values.clustermesh.enableEndpointSliceSynchronization | quote }}
   clustermesh-enable-mcs-api: {{ .Values.clustermesh.enableMCSAPISupport | quote }}
 
-# Extra config allows adding arbitrary properties to the cilium config.
-# By putting it at the end of the ConfigMap, it's also possible to override existing properties.
+  # Extra config allows adding arbitrary properties to the cilium config.
+  # By putting it at the end of the ConfigMap, it's also possible to override existing properties.
 {{- if .Values.extraConfig }}
   {{ toYaml .Values.extraConfig | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
The `extraConfig` field description comments were incorrectly indented. When the option was used the generated ConfigMap was invalid, causing the installation to fail.

Fixes #33829 

```release-note
Fix wrong indentation in Helm Chart's extraConfig option
```

