### PR TITLE
Preserve Count of Failed Connections across agent restarts

### DIFF
--- a/pkg/maps/act/act.go
+++ b/pkg/maps/act/act.go
@@ -151,7 +151,7 @@ func (m actMap) SaveFailed(key *ActiveConnectionTrackerKey, count uint64) error 
 
 func (m actMap) RestoreFailed(key *ActiveConnectionTrackerKey) (uint64, error) {
 	val, err := m.f.Lookup(key)
-	if err != nil && errors.Is(err, ebpf.ErrKeyNotExist) {
+	if errors.Is(err, ebpf.ErrKeyNotExist) {
 		// Ignore not found.
 		return 0, nil
 	}

--- a/pkg/maps/act/act.go
+++ b/pkg/maps/act/act.go
@@ -151,6 +151,10 @@ func (m actMap) SaveFailed(key *ActiveConnectionTrackerKey, count uint64) error 
 
 func (m actMap) RestoreFailed(key *ActiveConnectionTrackerKey) (uint64, error) {
 	val, err := m.f.Lookup(key)
+	if err != nil && errors.Is(err, ebpf.ErrKeyNotExist) {
+		// Ignore not found.
+		return 0, nil
+	}
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1189,6 +1189,19 @@ func (s *Service) GetDeepCopyServices() []*lb.SVC {
 	return svcs
 }
 
+// GetServiceIDs returns a list of IDs of all installed services.
+func (s *Service) GetServiceIDs() []lb.ServiceID {
+	s.RLock()
+	defer s.RUnlock()
+
+	svcs := make([]lb.ServiceID, 0, len(s.svcByID))
+	for _, svc := range s.svcByID {
+		svcs = append(svcs, lb.ServiceID(svc.frontend.ID))
+	}
+
+	return svcs
+}
+
 // GetDeepCopyServiceByFrontend returns a deep-copy of the service that matches the Frontend address.
 func (s *Service) GetDeepCopyServiceByFrontend(frontend lb.L3n4Addr) (*lb.SVC, bool) {
 	s.RLock()

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -31,6 +31,9 @@ type ServiceManager interface {
 	// GetDeepCopyServices returns a deep-copy of all installed services.
 	GetDeepCopyServices() []*lb.SVC
 
+	// GetServiceIDs returns a list of IDs of all installed services.
+	GetServiceIDs() []lb.ServiceID
+
 	// GetDeepCopyServiceByFrontend returns a deep-copy of the service that matches the Frontend address.
 	GetDeepCopyServiceByFrontend(frontend lb.L3n4Addr) (*lb.SVC, bool)
 


### PR DESCRIPTION
As described in https://github.com/cilium/design-cfps/pull/31, this is part of https://github.com/cilium/cilium/issues/31752

When `cilium-agent` restarts we lose information on the number of failed connections (purged from CT map) meaning that when we read the counts of open/closed connections from ACT map, the difference won't reflect the actual number of active connections.

In this PR I synchronize it into a new BPF map on agent shutdown and then read it again when recreating the metrics. I also periodically reconcile services tracked by agent with metrics/map entries.

I expect this to be the last PR in the series.

Example configuration (in `cilium-config`) for KIND cluster:
```
  fixed-zone-mapping: zone-a=123,zone-b=129
  enable-active-connection-tracking: "true"
```
where topology labels were set on the nodes:
```
kubectl label node kind-control-plane topology.kubernetes.io/zone=zone-a
kubectl label node kind-worker topology.kubernetes.io/zone=zone-b
```

Zone mapping can be verified with `cilium map get cilium_lb4_backends_v3`:
```
Key   Value                        State   Error
16    ANY://10.244.1.74[zone-b]    sync
17    ANY://10.244.1.74[zone-b]    sync
18    ANY://10.244.1.202[zone-b]   sync
19    ANY://10.244.1.202[zone-b]   sync
13    ANY://192.168.11.2[zone-b]   sync
14    ANY://10.244.0.178[zone-a]   sync
15    ANY://10.244.0.178[zone-a]   sync
```

LRS accounting can be verified with `cilium map get cilium_lb_act`:
```
Key                       Value     State   Error
10.96.138.80:80[zone-b]   +72 -72
10.96.138.80:80[zone-a]   +28 -28
```

Or by querying prometheus endpoint:
```
# HELP cilium_act_active_connections_total
# TYPE cilium_act_active_connections_total gauge
cilium_act_active_connections_total{service="10.96.43.108:443",zone="zone-a"} 0
cilium_act_active_connections_total{service="10.96.43.108:443",zone="zone-b"} 0
cilium_act_active_connections_total{service="10.96.43.108:80",zone="zone-a"} 12
cilium_act_active_connections_total{service="10.96.43.108:80",zone="zone-b"} 38
# HELP cilium_act_failed_connections_total
# TYPE cilium_act_failed_connections_total gauge
cilium_act_failed_connections_total{service="10.96.43.108:443",zone="zone-a"} 32
cilium_act_failed_connections_total{service="10.96.43.108:443",zone="zone-b"} 68
# HELP cilium_act_new_connections_total
# TYPE cilium_act_new_connections_total gauge
cilium_act_new_connections_total{service="10.96.43.108:443",zone="zone-a"} 0
cilium_act_new_connections_total{service="10.96.43.108:443",zone="zone-b"} 0
cilium_act_new_connections_total{service="10.96.43.108:80",zone="zone-a"} 24
cilium_act_new_connections_total{service="10.96.43.108:80",zone="zone-b"} 76
```

```release-note
Preserve failed connection counts to restore the correct cilium_act_{new,active,failed}_connections_total values after agent restart
```
