### PR TITLE
cert-manager's Gateway API support is no longer experimental in cert-manager 1.15

### DIFF
--- a/Documentation/network/servicemesh/tls-cert.rst
+++ b/Documentation/network/servicemesh/tls-cert.rst
@@ -32,11 +32,11 @@ Create TLS Certificate and Private Key
         .. code-block:: shell-session
 
             $ helm repo add jetstack https://charts.jetstack.io
-            $ helm install cert-manager jetstack/cert-manager --version v1.10.0 \
+            $ helm install cert-manager jetstack/cert-manager --version v1.15.1 \
                 --namespace cert-manager \
-                --set installCRDs=true \
                 --create-namespace \
-                --set "extraArgs={--enable-gateway-api}"
+                --set crds.enabled=true \
+                --set config.enableGatewayAPI=true  
 
         Now, create a CA Issuer:
 

--- a/Documentation/network/servicemesh/tls-cert.rst
+++ b/Documentation/network/servicemesh/tls-cert.rst
@@ -36,7 +36,7 @@ Create TLS Certificate and Private Key
                 --namespace cert-manager \
                 --set installCRDs=true \
                 --create-namespace \
-                --set "extraArgs={--feature-gates=ExperimentalGatewayAPISupport=true}"
+                --set "extraArgs={--enable-gateway-api}"
 
         Now, create a CA Issuer:
 


### PR DESCRIPTION
Hey,

I'm happy to report that cert-manager has graduated the Gateway API support to beta! You no longer have to pass the feature flag `ExperimentalGatewayAPISupport` anymore. Most importantly, the feature flag `ExperimentalGatewayAPISupport` was removed, so folks who used it in cert-manager 1.14 and below will need to remove it and add the new flag `--enable-gateway-api`.

Source: https://cert-manager.io/docs/releases/upgrading/upgrading-1.14-1.15#gatewayapi-promotion-to-beta

Ref: https://github.com/cert-manager/website/issues/851#issuecomment-2230387300

```release-note
NONE
```
