### PR TITLE
Metrics: add ipsec_spi_changes

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -160,6 +160,9 @@ var (
 	// It provides XfrmStateAdd/Update/Del wrappers that ensure cache
 	// is correctly invalidate.
 	xfrmStateCache = NewXfrmStateListCache(time.Minute)
+
+	// tracks changes in SPI to identify when a key got rotated
+	changeCountSpi int
 )
 
 func getGlobalIPsecKey(ip net.IP) *ipSecKey {
@@ -1164,6 +1167,10 @@ func LoadIPSecKeys(log *slog.Logger, r io.Reader) (int, uint8, error) {
 
 		ipSecKeysRemovalTime[oldSpi] = time.Now()
 		ipSecCurrentKeySPI = spi
+
+		if ipSecCurrentKeySPI != oldSpi && oldSpi != 0 {
+			changeCountSpi++
+		}
 	}
 	return keyLen, spi, nil
 }

--- a/pkg/datapath/linux/ipsec/xfrm_collector.go
+++ b/pkg/datapath/linux/ipsec/xfrm_collector.go
@@ -53,6 +53,7 @@ type xfrmCollector struct {
 	nbKeysDesc       *prometheus.Desc
 	nbXFRMStatesDesc *prometheus.Desc
 	nbXFRMPolsDesc   *prometheus.Desc
+	nbSPIChangesDesc *prometheus.Desc
 }
 
 func NewXFRMCollector() prometheus.Collector {
@@ -77,6 +78,11 @@ func NewXFRMCollector() prometheus.Collector {
 			"Number of XFRM policies",
 			[]string{labelDir}, nil,
 		),
+		nbSPIChangesDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(metrics.Namespace, subsystem, "spi_changes"),
+			"Number of SPI changes",
+			[]string{}, nil,
+		),
 	}
 }
 
@@ -85,6 +91,7 @@ func (x *xfrmCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- x.nbKeysDesc
 	ch <- x.nbXFRMStatesDesc
 	ch <- x.nbXFRMPolsDesc
+	ch <- x.nbSPIChangesDesc
 }
 
 func (x *xfrmCollector) collectErrors(ch chan<- prometheus.Metric) {
@@ -150,6 +157,8 @@ func (x *xfrmCollector) collectConfigStats(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(x.nbXFRMPolsDesc, prometheus.GaugeValue, float64(nbPolIn), labelDirIn)
 	ch <- prometheus.MustNewConstMetric(x.nbXFRMPolsDesc, prometheus.GaugeValue, float64(nbPolOut), labelDirOut)
 	ch <- prometheus.MustNewConstMetric(x.nbXFRMPolsDesc, prometheus.GaugeValue, float64(nbPolFwd), labelDirFwd)
+
+	ch <- prometheus.MustNewConstMetric(x.nbSPIChangesDesc, prometheus.CounterValue, float64(changeCountSpi))
 }
 
 func (x *xfrmCollector) Collect(ch chan<- prometheus.Metric) {


### PR DESCRIPTION
This commit introduces a new Prometheus metric
to observe changes in IPSec SPI.
