### PR TITLE
gha: ensure that helm values.schema.json is not accidentally backported

### DIFF
--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -75,6 +75,9 @@ jobs:
           make -C install/kubernetes
           test -z "$(git status --porcelain)" || (echo "please run 'make -C install/kubernetes' and submit your changes"; exit 1)
 
+          git rm --ignore-unmatch install/kubernetes/cilium/values.schema.json
+          test -z "$(git status --porcelain)" || (echo "please delete 'install/kubernetes/cilium/values.schema.json' and submit your changes"; exit 1)
+
   conformance-test:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.tested == 'true' && github.event_name != 'merge_group' }}


### PR DESCRIPTION
79733d2dafe6 ("helm: Introduce values.schema.json and tooling") introduced the helm schema file for Cilium v1.16 and later. Let's add a CI check to prevent accidentally backporting it to v1.15 and earlier, as we always hit a conflict if the upstream commit modifies it, due to this file not being present in the target branch.