### PR TITLE
gha: add spot input to setup-eks-cluster action

### DIFF
--- a/.github/actions/setup-eks-cluster/action.yml
+++ b/.github/actions/setup-eks-cluster/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: ''
     required: false
     default: ''
+  spot:
+    description: ''
+    required: false
+    default: 'true'
 runs:
   using: composite
   steps:
@@ -37,7 +41,7 @@ runs:
           instanceTypes:
            - t3.medium
           desiredCapacity: 1
-          spot: true
+          spot: ${{ inputs.spot }}
           privateNetworking: true
           volumeType: "gp3"
           volumeSize: 10
@@ -49,7 +53,7 @@ runs:
           instanceTypes:
            - t4g.medium
           desiredCapacity: 1
-          spot: true
+          spot: ${{ inputs.spot }}
           privateNetworking: true
           volumeType: "gp3"
           volumeSize: 10


### PR DESCRIPTION
The blamed commit was supposed to disable the usage of spot instances, as causing unnecessary flakes. However, it didn't work as intended, because the setup-eks-cluster action did hard-code the usage of spot instances. This is a stripped down backport of 83cbb19f8617, as the rest is now obsolete, so that the spot input takes actually effect.

Fixes: c8084210d89a ("eks: Don't use spot instances")