### PR TITLE
Add Hubble CLI integration tests and skip running e2e/conformance on Hubble CLI only changes

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -93,40 +93,40 @@ triggers:
 
 workflows:
   conformance-aks.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-aws-cni.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-clustermesh.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-e2e.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-ipsec-e2e.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-eks.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-externalworkloads.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-gateway-api.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-ginkgo.yaml:
     paths-ignore-regex: Documentation/
   conformance-gke.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-ingress.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-multi-pool.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   conformance-runtime.yaml:
     paths-ignore-regex: Documentation/
   integration-test.yaml:
     paths-ignore-regex: Documentation/
   tests-clustermesh-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   tests-datapath-verifier.yaml:
     paths-regex: (bpf|test/verifier|vendor|images)/
   tests-l4lb.yaml:
     paths-regex: (bpf|daemon|images|pkg|test/l4lb|test/nat46x64|vendor)/
   tests-e2e-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/
   tests-ipsec-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation)/
+    paths-ignore-regex: (test|Documentation|hubble)/

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -23,6 +23,7 @@ triggers:
     - tests-l4lb.yaml
     - tests-e2e-upgrade.yaml
     - tests-ipsec-upgrade.yaml
+    - hubble-cli-integration-test.yaml
   /ci-aks:
     workflows:
     - conformance-aks.yaml
@@ -90,6 +91,9 @@ triggers:
   /net-perf-gke:
     workflows:
     - net-perf-gke.yaml
+  /ci-hubble-cli:
+    workflows:
+    - hubble-cli-integration-test.yaml
 
 workflows:
   conformance-aks.yaml:
@@ -130,3 +134,5 @@ workflows:
     paths-ignore-regex: (test|Documentation|hubble)/
   tests-ipsec-upgrade.yaml:
     paths-ignore-regex: (test|Documentation|hubble)/
+  hubble-cli-integration-test.yaml:
+    paths-ignore-regex: (test|Documentation)/

--- a/.github/workflows/hubble-cli-integration-test.yaml
+++ b/.github/workflows/hubble-cli-integration-test.yaml
@@ -1,0 +1,222 @@
+name: Hubble CLI integration tests
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  workflow_dispatch:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: true
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: true
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: true
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        default: '{}'
+  push:
+    branches:
+    - main
+    - ft/main/**
+    - 'renovate/main-**'
+    paths-ignore:
+    - 'Documentation/**'
+
+concurrency:
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - workflow_dispatch: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing, such that re-runs will cancel the previous run.
+  group: |
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'push' && github.sha) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+    }}
+  cancel-in-progress: true
+
+env:
+  kind_config: .github/kind-config.yaml
+
+jobs:
+  echo-inputs:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    name: Echo Workflow Dispatch Inputs
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Echo Workflow Dispatch Inputs
+        run: |
+          echo '${{ tojson(inputs) }}'
+
+  commit-status-start:
+    name: Commit Status Start
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set initial commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+
+  integration-test:
+    runs-on: ubuntu-latest
+    name: Hubble CLI Integration Test
+    timeout-minutes: 20
+    steps:
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
+        with:
+          comment_on_pr: false
+
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Get Cilium's default values
+        id: default_vars
+        uses: ./.github/actions/helm-default
+        with:
+          image-tag: ${{ inputs.SHA }}
+          chart-dir: ./untrusted/install/kubernetes/cilium
+
+      - name: Set image tag
+        id: vars
+        run: |
+          echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
+
+          CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
+            --helm-set=hubble.relay.enabled=true"
+
+          echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ steps.vars.outputs.sha }}
+          persist-credentials: false
+          path: untrusted
+          sparse-checkout: |
+            install/kubernetes/cilium
+            examples
+
+      # Build hubble CLI before setting up the cluster and waiting on images to
+      # save time on failures.
+      - name: Setup go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Build hubble CLI
+        run: make
+
+      # Setup the cluster
+      - name: Create kind cluster
+        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        with:
+          version: ${{ env.KIND_VERSION }}
+          node_image: ${{ env.KIND_K8S_IMAGE }}
+          kubectl_version: ${{ env.KIND_K8S_VERSION }}
+          config: ${{ env.KIND_CONFIG }}
+          wait: 0 # The control-plane never becomes ready, since no CNI is present
+
+      - name: Wait for images to be available
+        timeout-minutes: 30
+        shell: bash
+        run: |
+          for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.sha.outputs.sha }} &> /dev/null; do sleep 45s; done
+          done
+
+      - name: Install Cilium CLI
+        uses: cilium/cilium-cli@1afb3ff7eb6ace8ab5f8d4d844afe02e2018bb4e # v0.16.13
+        with:
+          skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
+          image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
+          image-tag: ${{ env.CILIUM_CLI_VERSION }}
+
+      - name: Install Cilium
+        id: install-cilium
+        run: |
+          cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
+
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
+          kubectl -n kube-system get pods
+
+      - name: Wait for hubble-relay to be running
+        run: |
+          kubectl -n kube-system rollout status deployment/hubble-relay
+
+      - name: Run Hubble CLI integration test
+        timeout-minutes: 5
+        run: |
+          set -ex
+          ./hubble --version
+
+          kubectl -n kube-system port-forward service/hubble-relay 4245:80 &
+          # wait until the port-forward is running
+          until [ $(pgrep --count --full "kubectl.*port-forward.*service\/hubble-relay.*4245:80") -eq 1 ]; do
+            sleep 1
+          done
+
+          # give relay a little bit more time to actually connect to agent before running commands.
+          sleep 5
+
+          ./hubble status
+
+          # query hubble until we receive flows, or timeout
+          flowCount=0
+          until [ $flowCount -gt 0 ]; do
+            ./hubble observe -n kube-system -o jsonpb  | tee flows.json
+            flowCount=$(jq -r --slurp 'length' flows.json)
+            sleep 5
+          done
+
+          # verify we got some flows
+          test $(jq -r --slurp 'length' flows.json) -gt 0
+          # test piping flows into the CLI
+          test $(./hubble observe < flows.json -o json | jq -r --slurp 'length') -eq $(jq -r --slurp 'length' flows.json)
+
+      - name: Post-test information gathering
+        if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
+        run: |
+          kubectl get pods --all-namespaces -o wide
+          cilium status
+          cilium sysdump --output-filename cilium-sysdump-out-${{ join(matrix.*, '-') }}
+        shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
+
+      - name: Upload artifacts
+        if: ${{ !success() }}
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        with:
+          name: cilium-sysdump-out-${{ matrix.conformance-profile }}-${{ matrix.crd-channel }}
+          path: cilium-sysdump-out-*.zip
+          retention-days: 5
+
+  commit-status-final:
+    if: ${{ always() }}
+    name: Commit Status Final
+    needs: integration-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set final commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+          status: ${{ needs.integration-test.result }}

--- a/.github/workflows/hubble-cli.yaml
+++ b/.github/workflows/hubble-cli.yaml
@@ -8,24 +8,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check_changes:
-    name: Deduce required tests from code changes
-    runs-on: ubuntu-22.04
-    outputs:
-      tested: ${{ steps.tested-tree.outputs.src }}
-    steps:
-      - name: Check code changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: tested-tree
-        with:
-          filters: |
-            src:
-              - '!(test|Documentation)/**'
-
   build-hubble-cli-release-binaries:
     name: Build Hubble CLI release binaries
-    needs: check_changes
-    if: ${{ needs.check_changes.outputs.tested == 'true' }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout the repository


### PR DESCRIPTION
Since moving Hubble CLI into the Cilium repository I noticed 2 things:

- We're running all the regular e2e/conformance tests for Hubble CLI changes. Since we're not building Hubble CLI from source in any of those tests, it doesn't make sense to run them for CLI only changes.
- We didn't copy the [existing Hubble CLI integration tests](https://github.com/cilium/hubble/blob/main/.github/workflows/integration-tests.yaml). 

In this PR I address both of these issues. This is my first time introducing a new Github workflow, so I mostly copied the existing Hubble CLI integration tests and adapted it based on existing conformance test workflows to follow existing conventions 🤞 .