### PR TITLE
Fix for small typos on documentation 

### DIFF
--- a/Documentation/gettingstarted/hubble-configuration.rst
+++ b/Documentation/gettingstarted/hubble-configuration.rst
@@ -122,7 +122,7 @@ documented methods:
 
 #. First, install `cert-manager <https://cert-manager.io/docs/installation/>`__
    and setup an `issuer <https://cert-manager.io/docs/configuration/>`_.
-   Please make sure that your issuer is be able to create certificates under the
+   Please make sure that your issuer is able to create certificates under the
    ``cilium.io`` domain name.
 #. Install/upgrade Cilium including the following Helm flags:
 

--- a/Documentation/gettingstarted/hubble.rst
+++ b/Documentation/gettingstarted/hubble.rst
@@ -40,7 +40,7 @@ Enable the Hubble UI by running the following command:
             cilium hubble enable --ui
             🔑 Found existing CA in secret cilium-ca
             ✨ Patching ConfigMap cilium-config to enable Hubble...
-            ♻️  Restarted Cilium pods
+            ♻️ Restarted Cilium pods
             ✅ Relay is already deployed
             ✅ Hubble UI is already deployed
 

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -157,7 +157,7 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
        Install Rancher Desktop >= v1.1.0 as per Rancher Desktop documentation:
        `Install Rancher Desktop <https://docs.rancherdesktop.io/getting-started/installation>`_.
 
-       Next you need to configure Rancher Desktop so to disable the builtin CNI so you can install Cilium.
+       Next you need to configure Rancher Desktop to disable the built-in CNI so you can install Cilium.
 
        .. include:: ../installation/rancher-desktop-configure.rst
 

--- a/Documentation/installation/alibabacloud-eni.rst
+++ b/Documentation/installation/alibabacloud-eni.rst
@@ -21,8 +21,8 @@ the list below has to be deleted to prevent conflicts.
 .. note::
 
     If you are using ACK with Flannel (DaemonSet ``kube-flannel-ds``),
-    the Cloud Controller Manager (CCM) will create route (Pod CIDR) in VPC.
-    If your cluster is an Managed Kubernetes you cannot disable this behavior.
+    the Cloud Controller Manager (CCM) will create a route (Pod CIDR) in VPC.
+    If your cluster is a Managed Kubernetes you cannot disable this behavior.
     Please consider creating a new cluster.
 
 .. code-block:: shell-session

--- a/Documentation/installation/cni-chaining-aws-cni.rst
+++ b/Documentation/installation/cni-chaining-aws-cni.rst
@@ -132,7 +132,7 @@ to the IAM role associated with the EKS cluster:
         --policy-arn arn:aws:iam::aws:policy/AmazonEKSVPCResourceController \
         --role-name "${EKS_CLUSTER_ROLE_NAME}"
 
-Then, and as mentioned above, make sure that the version of the AWS VPC CNI
+Then, as mentioned above, make sure that the version of the AWS VPC CNI
 plugin running in the cluster is up-to-date:
 
 .. code-block:: shell-session

--- a/contrib/vagrant/scripts/04-install-kubectl.sh
+++ b/contrib/vagrant/scripts/04-install-kubectl.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Installs and configures kubernetes kubect, it will use default values from
+# Installs and configures kubernetes kubectl, it will use default values from
 # ./helpers.bash
 # Globals:
 #   INSTALL, if set installs k8s binaries, otherwise it will only configure k8s


### PR DESCRIPTION
I have fixed some typos in the gettingstarted, vagrant, and installation sections of the documentation.

If there are any mistakes with the PR(commits, description, etc.) please let me know.