### PR TITLE
test: explicitly configure kubeadm image repository

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -171,6 +171,7 @@ controllerManager:
 apiServer:
   extraArgs:
     "feature-gates": "{{ .API_SERVER_FEATURE_GATES }}"
+imageRepository: "registry.k8s.io"
 EOF
 )
 
@@ -210,6 +211,10 @@ controllerManager:
 apiServer:
   extraArgs:
     "feature-gates": "{{ .API_SERVER_FEATURE_GATES }},IPv6DualStack={{ .IPV6_DUAL_STACK_FEATURE_GATE }}"
+imageRepository: "registry.k8s.io"
+dns:
+  imageRepository: "registry.k8s.io/coredns"
+  imageTag: "v1.8.0"
 EOF
 )
 
@@ -251,6 +256,9 @@ controllerManager:
 apiServer:
   extraArgs:
     "feature-gates": "{{ .API_SERVER_FEATURE_GATES }},IPv6DualStack={{ .IPV6_DUAL_STACK_FEATURE_GATE }}"
+imageRepository: "registry.k8s.io"
+dns:
+  imageRepository: "registry.k8s.io/coredns"
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
@@ -310,6 +318,9 @@ controllerManager:
 apiServer:
   extraArgs:
     "feature-gates": "{{ .API_SERVER_FEATURE_GATES }},IPv6DualStack={{ .IPV6_DUAL_STACK_FEATURE_GATE }}"
+imageRepository: "registry.k8s.io"
+dns:
+  imageRepository: "registry.k8s.io/coredns"
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
@@ -370,6 +381,9 @@ networking:
   dnsDomain: cluster.local
   podSubnet: "{{ .KUBEADM_V1BETA2_POD_CIDR }}"
   serviceSubnet: "{{ .KUBEADM_V1BETA2_SVC_CIDR }}"
+imageRepository: "registry.k8s.io"
+dns:
+  imageRepository: "registry.k8s.io/coredns"
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1


### PR DESCRIPTION
The old k8s.gcr.io Kubernetes image registry has been frozen in Apr, 2023, in favor of registry.k8s.io.

Although old images are still present in the old registry, we have recently started witnessing failures (e.g., [1]) in the  k8s-1.16-kernel-4.19 Jenkins test during the provisioning phase, with errors along the lines of:

```
  [ERROR ImagePull]: failed to pull image k8s.gcr.io/etcd:3.3.15-0: output:
        Error response from daemon: Head "https://k8s.gcr.io/v2/etcd/manifests/3.3.15-0":
        unable to decode token response: invalid character '<' looking for beginning of value
```

Let's attempt to address this error by explicitly configuring the usage of the newer registry, until v1.13 goes EOL and we can finally get rid of these tests.

Additionally, we explicitly specify the coredns image repository, as it seems that in certain versions (v1.21 in particular) it otherwise defaults to using an incorrect path (i.e., without the coredns subpath) if a custom registry is specified [2]:

```
  ERROR ImagePull]: failed to pull image registry.k8s.io/coredns:v1.8.0: output:
      Error response from daemon: manifest for registry.k8s.io/coredns:v1.8.0 not found:
      manifest unknown: Failed to fetch "v1.8.0"
```

 Finally, let's hard-code the coredns version for older k8s versions, as coredns older than v1.8.0 seems to follow yet another versioning scheme in the registry.

\[1]: https://jenkins.cilium.io/job/Cilium-PR-K8s-1.16-kernel-4.19/1323/console
\[2]: https://github.com/kubernetes/kubeadm/issues/2714
