### PR TITLE
gha: use GH_RUNNER_EXTRA_POWER for conformance-k8s-kind workflow

### DIFF
--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -27,7 +27,7 @@ env:
 jobs:
   kubernetes-e2e:
     name: Installation and Conformance Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER }}
     timeout-minutes: 45
     strategy:
       fail-fast: false


### PR DESCRIPTION
Similarly to [1,2], use GH_RUNNER_EXTRA_POWER for the Conformance K8s Kind workflow.

\[1]: 4bc5c06cf9d5 ("Use GH_RUNNER_EXTRA_POWER for CI image workflow")
\[2]: bd675975d656 ("gha: make runner type for clustermesh workflows configurable")