### PR TITLE
gha: update unsupported ci-gke k8s version from 1.26 to 1.27

### DIFF
--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,7 +1,7 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.26"
+  - version: "1.27"
     zone: us-west2-c
     vmIndex: 1
     default: true


### PR DESCRIPTION
The GKE and external workloads workflows started failing because the only configured k8s version 1.26 is no longer available on GKE [1]. Hence, let's bump the tested k8s version to 1.27.

\[1]: https://cloud.google.com/kubernetes-engine/docs/release-notes-stable#July_10_2024