### PR TITLE
cilium-dbg: Add output format option to statedb

### DIFF
--- a/Documentation/cmdref/cilium-dbg_statedb_bandwidth-edts.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_bandwidth-edts.md
@@ -12,6 +12,7 @@ cilium-dbg statedb bandwidth-edts [flags]
 
 ```
   -h, --help             help for bandwidth-edts
+  -o, --output string    Output format, one of: table, json or yaml (default "table")
   -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
 ```
 

--- a/Documentation/cmdref/cilium-dbg_statedb_bandwidth-qdiscs.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_bandwidth-qdiscs.md
@@ -12,6 +12,7 @@ cilium-dbg statedb bandwidth-qdiscs [flags]
 
 ```
   -h, --help             help for bandwidth-qdiscs
+  -o, --output string    Output format, one of: table, json or yaml (default "table")
   -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
 ```
 

--- a/Documentation/cmdref/cilium-dbg_statedb_devices.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_devices.md
@@ -12,6 +12,7 @@ cilium-dbg statedb devices [flags]
 
 ```
   -h, --help             help for devices
+  -o, --output string    Output format, one of: table, json or yaml (default "table")
   -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
 ```
 

--- a/Documentation/cmdref/cilium-dbg_statedb_experimental_backends.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_experimental_backends.md
@@ -12,6 +12,7 @@ cilium-dbg statedb experimental backends [flags]
 
 ```
   -h, --help             help for backends
+  -o, --output string    Output format, one of: table, json or yaml (default "table")
   -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
 ```
 

--- a/Documentation/cmdref/cilium-dbg_statedb_experimental_frontends.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_experimental_frontends.md
@@ -12,6 +12,7 @@ cilium-dbg statedb experimental frontends [flags]
 
 ```
   -h, --help             help for frontends
+  -o, --output string    Output format, one of: table, json or yaml (default "table")
   -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
 ```
 

--- a/Documentation/cmdref/cilium-dbg_statedb_experimental_services.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_experimental_services.md
@@ -12,6 +12,7 @@ cilium-dbg statedb experimental services [flags]
 
 ```
   -h, --help             help for services
+  -o, --output string    Output format, one of: table, json or yaml (default "table")
   -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
 ```
 

--- a/Documentation/cmdref/cilium-dbg_statedb_health.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_health.md
@@ -12,6 +12,7 @@ cilium-dbg statedb health [flags]
 
 ```
   -h, --help             help for health
+  -o, --output string    Output format, one of: table, json or yaml (default "table")
   -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
 ```
 

--- a/Documentation/cmdref/cilium-dbg_statedb_ipsets.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_ipsets.md
@@ -12,6 +12,7 @@ cilium-dbg statedb ipsets [flags]
 
 ```
   -h, --help             help for ipsets
+  -o, --output string    Output format, one of: table, json or yaml (default "table")
   -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
 ```
 

--- a/Documentation/cmdref/cilium-dbg_statedb_l2-announce.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_l2-announce.md
@@ -12,6 +12,7 @@ cilium-dbg statedb l2-announce [flags]
 
 ```
   -h, --help             help for l2-announce
+  -o, --output string    Output format, one of: table, json or yaml (default "table")
   -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
 ```
 

--- a/Documentation/cmdref/cilium-dbg_statedb_nat-stats.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_nat-stats.md
@@ -12,6 +12,7 @@ cilium-dbg statedb nat-stats [flags]
 
 ```
   -h, --help             help for nat-stats
+  -o, --output string    Output format, one of: table, json or yaml (default "table")
   -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
 ```
 

--- a/Documentation/cmdref/cilium-dbg_statedb_node-addresses.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_node-addresses.md
@@ -12,6 +12,7 @@ cilium-dbg statedb node-addresses [flags]
 
 ```
   -h, --help             help for node-addresses
+  -o, --output string    Output format, one of: table, json or yaml (default "table")
   -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
 ```
 

--- a/Documentation/cmdref/cilium-dbg_statedb_routes.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_routes.md
@@ -12,6 +12,7 @@ cilium-dbg statedb routes [flags]
 
 ```
   -h, --help             help for routes
+  -o, --output string    Output format, one of: table, json or yaml (default "table")
   -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
 ```
 

--- a/Documentation/cmdref/cilium-dbg_statedb_sysctl.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_sysctl.md
@@ -12,6 +12,7 @@ cilium-dbg statedb sysctl [flags]
 
 ```
   -h, --help             help for sysctl
+  -o, --output string    Output format, one of: table, json or yaml (default "table")
   -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
 ```
 


### PR DESCRIPTION
Add support for json and yaml output to the
"cilium-dbg statedb table" commands to allow parsing out relevant data from the output.

While this is similar to "cilium-dbg statedb dump" the key difference here is that it allows dumping specific table and allows streaming further changes to that table as json or yaml.

Example:
```
  $ kubectl exec  -c cilium-agent -n kube-system ds/cilium -- \
      cilium-dbg statedb devices -o json|jq -r '[.Name, .Addrs[0].Addr] | @tsv' |column -t
  lxc19a8fbb1f0cd  fe80::4c07:3ff:fe69:adfb
  lxc0041e7923b2d  fe80::90fe:9eff:fe0b:39cd
  lxcee9984efe8f1  fe80::4c25:72ff:fe04:f1fc
  eth0             172.19.0.3
  lo               127.0.0.1
  cilium_net       fe80::c4ab:bfff:fed2:abda
  cilium_vxlan     fe80::b450:30ff:fe28:f479
  lxc_health       fe80::c8a6:44ff:fe06:a3be
  cilium_host      10.244.0.81
```
