### PR TITLE
svc: Use in-memory l7 service map to check L7 service

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -851,7 +851,7 @@ func (s *Service) upsertService(params *lb.SVC) (bool, lb.ID, error) {
 			// There is one special case is L7 proxy service, which never have any
 			// backends because the traffic will be redirected.
 			activeBackends := 0
-			if params.L7LBProxyPort != 0 {
+			if l7lbInfo != nil {
 				// Set this to 1 because Envoy will be running in this case.
 				getScopedLog().WithField(logfields.ServiceHealthCheckNodePort, svc.svcHealthCheckNodePort).
 					Debug("L7 service with HealthcheckNodePort enabled")


### PR DESCRIPTION
The params.L7LBProxyPort could be populated only when ownerRef is not
empty from CiliumEnvoyConfig controller, hence leads to potential race
condition. This commit is to use l7lb in service map instead.

https://github.com/cilium/cilium/blob/19c74877ffc0d35daf81f4e0cde81623d4246c5c/pkg/service/service.go#L697-L702

Relates: https://github.com/cilium/cilium/commit/1cd50e63d0ffc31fb58f5630f090fb41fc495c7d
Fixes: #33039