### PR TITLE
helm: Allow socket linger timeout to be set to zero

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1226,7 +1226,7 @@ data:
   # default DNS proxy to transparent mode in non-chaining modes
   dnsproxy-enable-transparent-mode: {{ $defaultDNSProxyEnableTransparentMode | quote }}
   {{- end }}
-  {{- if .Values.dnsProxy.socketLingerTimeout }}
+  {{- if (not (kindIs "invalid" .Values.dnsProxy.socketLingerTimeout)) }}
   dnsproxy-socket-linger-timeout: {{ .Values.dnsProxy.socketLingerTimeout | quote }}
   {{- end }}
   {{- if .Values.dnsProxy.dnsRejectResponseCode }}


### PR DESCRIPTION
Before this commit, if one explicitly wanted to set the linger timeout to 0 (which is a valid value), our Helm chart skipped the ConfigMap entry, thereby ignoring the user-specified value of 0 and falling back on the default value in the agent (which is 10).

This commit fixes that by using checking if the Helm value is `nil` or unset. I have manually tested this.

Fixes: f534200249da ("helm: expose socket linger timeout helm option")