### PR TITLE
contrib: Add helper DaemonSet for clearing kube-proxy iptables rules

### DIFF
--- a/contrib/k8s/clear-kubeproxy-iptables.yaml
+++ b/contrib/k8s/clear-kubeproxy-iptables.yaml
@@ -1,0 +1,46 @@
+# clear-kubeproxy-iptables.yaml: Remove iptables rules installed
+# by kube-proxy from all nodes in a cluster. Removing iptables rules
+# installed by kube-proxy may be required as part of installing Cilium
+# with KubeProxyReplacement enabled. This DaemonSet deploys a Pod on
+# each node which runs within the Node's namespace and removes iptables rules
+# installed by kube-proxy. The Pod will enter into a Ready state and go
+# idle after the rules have been removed. To use:
+# 1. Deploy to a cluster:
+#    kubectl apply -f ./clear-kubeproxy-iptables.yaml
+# 2. Wait for all Pods in the DaemonSet to be ready:
+#    kubectl rollout status --watch -n kube-system ds/clear-kubeproxy-iptables
+# 3. Delete the DaemonSet:
+#    kubectl delete -n kube-system ds/clear-kubeproxy-iptables
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: clear-kubeproxy-iptables
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: clear-kubeproxy-iptables
+  template:
+    metadata:
+      labels:
+        name: clear-kubeproxy-iptables
+    spec:
+      hostNetwork: true
+      containers:
+      - name: script-runner
+        image: nicolaka/netshoot:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        command:
+        - /bin/bash
+        - -c
+        - "iptables save | grep -V KUBE | iptables-restore && touch /readyz && sleep infinity"
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /readyz
+          initialDelaySeconds: 1
+          periodSeconds: 5
+


### PR DESCRIPTION
This commit adds a helper DaemonSet which can be used to clear kube-proxy iptables rules from all nodes in a cluster, to help facilitate the installation of Cilium with KPR enabled. This DaemonSet may be helpful for users trying to install KPR in a dev environment, as it is quick and cloud-agnostic.

I'm not sure if this is appropriate for `contrib` or worth committing to the tree, but I figured I'd share just in case.