### PR TITLE
Make hubble-relay more resilient to transient errors

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -78,14 +78,33 @@ spec:
             grpc:
               port: 4222
             timeoutSeconds: 3
+          # livenessProbe will kill the pod, we should be very conservative
+          # here on failures since killing the pod should be a last resort, and
+          # we should provide enough time for relay to retry before killing it.
           livenessProbe:
             grpc:
               port: 4222
-            timeoutSeconds: 3
+            timeoutSeconds: 10
+            # Give relay time to establish connections and make a few retries
+            # before starting livenessProbes.
+            initialDelaySeconds: 10
+            # 10 second * 12 failures = 2 minutes of failure.
+            # If relay cannot become healthy after 2 minutes, then killing it
+            # might resolve whatever issue is occurring.
+            #
+            # 10 seconds is a reasonable retry period so we can see if it's
+            # failing regularly or only sporadically.
+            periodSeconds: 10
+            failureThreshold: 12
           startupProbe:
             grpc:
               port: 4222
+            # Give relay time to get it's certs and establish connections and
+            # make a few retries before starting startupProbes.
+            initialDelaySeconds: 10
+            # 20 * 3 seconds = 1 minute of failure before we consider startup as failed.
             failureThreshold: 20
+            # Retry more frequently at startup so that it can be considered started more quickly.
             periodSeconds: 3
           {{- with .Values.hubble.relay.extraEnv }}
           env:

--- a/pkg/hubble/relay/defaults/defaults.go
+++ b/pkg/hubble/relay/defaults/defaults.go
@@ -16,7 +16,7 @@ const (
 	ClusterName = ciliumDefaults.ClusterName
 	// DialTimeout is the timeout that is used when establishing a new
 	// connection.
-	DialTimeout = 5 * time.Second
+	DialTimeout = 30 * time.Second
 	// HealthCheckInterval is the time interval between health checks.
 	HealthCheckInterval = 5 * time.Second
 	// GopsPort is the default port for gops to listen on.

--- a/pkg/hubble/relay/pool/manager_test.go
+++ b/pkg/hubble/relay/pool/manager_test.go
@@ -613,7 +613,7 @@ func TestPeerManager(t *testing.T) {
 					},
 				},
 				log: []string{
-					`level=warning msg="Failed to create gRPC client" address="192.0.1.1:4244" error="Don't feel like workin' today" hubble-tls=false next-try-in=10s peer=unreachable`,
+					`level=warning msg="Failed to create gRPC client" address="192.0.1.1:4244" error="Don't feel like workin' today" hubble-tls=false next-try-in=1s peer=unreachable`,
 				},
 			},
 		}, {

--- a/pkg/hubble/relay/pool/option.go
+++ b/pkg/hubble/relay/pool/option.go
@@ -33,8 +33,8 @@ var defaultOptions = options{
 		},
 	},
 	backoff: &backoff.Exponential{
-		Min:    10 * time.Second,
-		Max:    90 * time.Minute,
+		Min:    time.Second,
+		Max:    time.Minute,
 		Factor: 2.0,
 	},
 	connCheckInterval:  2 * time.Minute,


### PR DESCRIPTION
Fixes: #33891 

See the commit messages for a concise description of what each change aims to do. Overall, in some cases, hubble-relay isn't very robust to transient errors, typically caused by individual agents restarting or the Hubble API being briefly unavailable. As a result, hubble-relay often gets restarted when downstream dependencies like Cilium are down for a only a moderate amount of time. In general, it's probably not wise for us to use the peer manager to define Hubble-relay's health, however changing that requires a more substantial change and rethink of how we do health for API services.

As an intermediate solution, we should give hubble-relay more time to do the actions it needs to become healthy (ie: connect to the peer service). This means giving it more time to do various actions such as connecting to the peer service, and retrying.

To start, and address the issue reported in #33891, we can increase the default dial timeout for the peer service, which should improve Hubble-relay in constrained environments like small dev clusters or KIND clusters, where it may take longer than 5 seconds to connect to cilium's Hubble API. 

Additionally, in the event that hubble-relay cannot connect to the peer service, such as when cilium is being updated, reconfigured or otherwise restarted, we should retry more aggressively to improve how quickly it responds to failures and reduce the amount of exponential backoff accrued. During rollouts, especially in smaller clusters, it's fairly likely Hubble-relay will end up being disconnected from the cilium pod it's currently using as its peer service. It will then try to connect to the same pod, or another one which might get restarted while it's retrying; quickly causing the exponential backoff timer to grow, resulting in relay only attempting to reconnect a small number times before failing it's livenessProbe and being killed, negating many of the benefits of having support for retrying at all. Retrying more quickly should improve this, and shouldn't adversely impact Cilium or Hubble with the new default backoff values.

As mentioned, with the current livenessProbe settings, since it relies on relay being connected to the peer service, its health is tied to downstream dependencies, which is out of its control. To reduce the impact of downstream agents being restarted on Hubble-relay, we should give it enough time to retry and reconnect before it's livenessProbe results in the pod being restarted, so let's increase the number of failures in the livenessProbe to give hubble-relay ample time to reconnect and become healthy. 