### PR TITLE
pkg/endpointmanager: don't hold lock while iterating over subscribers

### DIFF
--- a/pkg/auth/authmap_gc.go
+++ b/pkg/auth/authmap_gc.go
@@ -401,9 +401,11 @@ func (r *authMapGarbageCollector) cleanupExpiredEntries(_ context.Context) error
 // Endpoints
 
 func (r *authMapGarbageCollector) subscribeToEndpointEvents(endpointManager endpointmanager.EndpointManager) {
+	localEPs := endpointManager.GetEndpoints()
+
 	r.endpointsCacheMutex.Lock()
 	r.endpointsCache = map[uint16]*endpoint.Endpoint{}
-	for _, ep := range endpointManager.GetEndpoints() {
+	for _, ep := range localEPs {
 		r.endpointsCache[ep.GetID16()] = ep
 	}
 	r.endpointsCacheSynced = true


### PR DESCRIPTION
Holding the lock while iterating over the subscribers is causing a potential deadlock with pkg/auth. Since pkg/auth is a subscriber of the endpoint manager, it will lock an internal mutex and then perform a GetEndpoints which will also perform a RLock to the endpointsmanager's Mutex. This itself is not an issue. However, on a separate go routine the pkg/auth will perform a lock on its internal mutex and then will do a GetEndpoints, causing inconsistent locking between these two cases which can cause a deadlock in the agent.