### PR TITLE
gha: lint absence of trailing spaces in workflow files

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -7,7 +7,7 @@ assignees: ''
 ---
 
 ## Cilium Feature Proposal
-        
+
 Thanks for taking time to make a feature proposal for Cilium! If you have usage questions, please try the [slack channel](http://slack.cilium.io/) and see the [FAQ](https://github.com/cilium/cilium/issues?utf8=%E2%9C%93&q=is:issue+label:kind/question+) first.
 
 **Is your proposed feature related to a problem?**
@@ -20,7 +20,7 @@ Include any specific requirements you need
 
 **(Optional) Describe your proposed solution**
 
-Please complete this section if you have ideas / suggestions on how to implement the feature. We strongly recommend discussing your approach with Cilium committers before spending lots of time implementing a change. 
+Please complete this section if you have ideas / suggestions on how to implement the feature. We strongly recommend discussing your approach with Cilium committers before spending lots of time implementing a change.
 
 For longer proposals, you are welcome to link to an external doc (e.g. a Google doc). We have a [Cilium Feature Proposal template](https://docs.google.com/document/d/1vtE82JExQHw8_-pX2Uhq5acN1BMPxNlS6cMQUezRTWg/edit) to help you structure your proposal - if you would like to use it, please make a copy and ensure it's publicly visible, and then add the link here.
 

--- a/.github/ISSUE_TEMPLATE/prerelease-testing.yaml
+++ b/.github/ISSUE_TEMPLATE/prerelease-testing.yaml
@@ -19,7 +19,7 @@ body:
         - Regression Testing
         - Feature Interaction
         - Performance Testing
-        - Other  
+        - Other
       default: 0
     validations:
       required: true
@@ -34,7 +34,7 @@ body:
         3. Tested this feature...
         4. Resulting in error...
         5. Run '...'
-        6. See error... 
+        6. See error...
       value: "I tested a Cilium feature"
     validations:
       required: true
@@ -42,7 +42,7 @@ body:
     id: how-long
     attributes:
       label: Time
-      description: How long did it take you to test? 
+      description: How long did it take you to test?
       placeholder: |
         The test took 1 hour
       value: "It took 1 hour to attempt this test"
@@ -50,12 +50,12 @@ body:
       required: true
   - type: dropdown
     attributes:
-      label: Test Status 
+      label: Test Status
       description: Were you able to complete the test successfully?
       multiple: false
       options:
         - "Success: Test completed without issue"
-        - "Incomplete: Ran out of time" 
+        - "Incomplete: Ran out of time"
         - "Failure: Reproducible bug encountered/filed"
         - "Unknown: Something went wrong, but not sure what"
       default: 0

--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -167,7 +167,7 @@ runs:
           if [ "${{ inputs.ciliumendpointslice }}" == "true" ]; then
             CILIUMENDPOINTSLICE="--helm-set=ciliumEndpointSlice.enabled=true"
           fi
-        
+
           LOCAL_REDIRECT_POLICY=""
           if [ "${{ inputs.local-redirect-policy }}" == "true" ]; then
             LOCAL_REDIRECT_POLICY="--helm-set=localRedirectPolicy=true"

--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -188,7 +188,7 @@ include:
     cliFocus: 'K8sDatapathServicesTest Checks E/W loadbalancing \\(ClusterIP, NodePort from inside cluster, etc\\) TFTP|K8sDatapathServicesTest Checks E/W loadbalancing \\(ClusterIP, NodePort from inside cluster, etc\\) with'
 
   ###
-  # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Tests NodePort inside cluster (kube-proxy) 
+  # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Tests NodePort inside cluster (kube-proxy) vanilla
   # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Tests NodePort inside cluster (kube-proxy) with externalTrafficPolicy=Local
   # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Tests NodePort inside cluster (kube-proxy) with IPSec and externalTrafficPolicy=Local
   # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Tests NodePort inside cluster (kube-proxy) with the host firewall and externalTrafficPolicy=Local

--- a/.github/workflows/ci-images-garbage-collect.yaml
+++ b/.github/workflows/ci-images-garbage-collect.yaml
@@ -13,7 +13,7 @@ jobs:
     name: scruffy
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout 
+      - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0

--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -1,5 +1,5 @@
 name: Close stale issues
-  
+
 on:
   schedule:
   - cron: "30 1 * * *"

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set initial commit status
-        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1  
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
         with:
           sha: ${{ inputs.SHA || github.sha }}
 

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set initial commit status
-        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1  
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
         with:
           sha: ${{ inputs.SHA || github.sha }}
 

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -122,7 +122,7 @@ jobs:
         id: vars
         run: |
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
-          
+
           EXEMPT_FEATURES="GatewayStaticAddresses,HTTPRouteParentRefPort,MeshConsumerRoute"
           if [ ${{ matrix.crd-channel }} == "standard" ]; then
             EXEMPT_FEATURES+=",HTTPRouteDestinationPortMatching,HTTPRouteRequestTimeout,HTTPRouteBackendTimeout"
@@ -234,7 +234,7 @@ jobs:
           EOF
           cat pool.yaml
           kubectl apply -f pool.yaml
-          
+
           echo "Deploying L2-Announcement Policy..."
           cat << 'EOF' > l2policy.yaml
           apiVersion: "cilium.io/v2alpha1"
@@ -320,7 +320,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1  
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
         with:
           sha: ${{ inputs.SHA || github.sha }}
           status: ${{ needs.gateway-api-conformance-test.result }}

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set initial commit status
-        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1  
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
         with:
           sha: ${{ inputs.SHA || github.sha }}
 

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -238,7 +238,7 @@ jobs:
           EOF
           cat pool.yaml
           kubectl apply -f pool.yaml
-          
+
           echo "Deploying L2-Announcement Policy..."
           cat << 'EOF' > l2policy.yaml
           apiVersion: "cilium.io/v2alpha1"
@@ -274,7 +274,7 @@ jobs:
       - name: Run Sanity check (external)
         timeout-minutes: 5
         run: |
-          lb=$(kubectl get ingress basic-ingress -o jsonpath='{.status.loadBalancer.ingress[0].ip}')     
+          lb=$(kubectl get ingress basic-ingress -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
           curl -s -v --connect-timeout 5 --max-time 20 --retry 3 --retry-all-errors --retry-delay 5 --fail -- http://"$lb"
 
           # By now the service should be up, no need to do the manual retries for the second request
@@ -289,7 +289,7 @@ jobs:
           else
             node_port=$(kubectl get -n kube-system svc cilium-ingress -o jsonpath='{.spec.ports[?(@.port==80)].nodePort}')
           fi
-          docker exec -i chart-testing-control-plane curl -s -v --connect-timeout 5 --max-time 20 --retry 3 --fail http://localhost:$node_port/details/1 
+          docker exec -i chart-testing-control-plane curl -s -v --connect-timeout 5 --max-time 20 --retry 3 --fail http://localhost:$node_port/details/1
 
       - name: Run Sanity check (headless service)
         timeout-minutes: 5
@@ -382,7 +382,7 @@ jobs:
             sleep 3
           done
           lb=$(kubectl get ingress basic-ingress-headless -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-          curl -s -v --connect-timeout 2 --max-time 20 --retry 3 --retry-all-errors --retry-delay 3 --fail -- http://"$lb"/details/1      
+          curl -s -v --connect-timeout 2 --max-time 20 --retry 3 --retry-all-errors --retry-delay 3 --fail -- http://"$lb"/details/1
           curl -s -v --connect-timeout 2 --max-time 20 --retry 3 --retry-all-errors --retry-delay 3 --fail -- http://"$lb"/details/2
 
       - name: Cleanup Sanity check
@@ -430,7 +430,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1  
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
         with:
           sha: ${{ inputs.SHA || github.sha }}
           status: ${{ needs.ingress-conformance-test.result }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1  
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
         with:
           sha: ${{ inputs.SHA || github.sha }}
           status: ${{ needs.integration-test.result }}

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -1,7 +1,7 @@
 name: Build Commits
 
 # Any change in triggers needs to be reflected in the concurrency group.
-on: 
+on:
   pull_request: {}
 
 permissions: read-all

--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -249,3 +249,17 @@ jobs:
             fi
           done
           exit ${EXIT}
+
+      - name: Validate Absence of Trailing Spaces
+        shell: bash
+        working-directory: src/github.com/cilium/cilium/
+        run: |
+          if grep --quiet --recursive '[[:blank:]]$' .github; then
+            echo "Found trailing spaces in the following workflow files"
+            grep --files-with-matches --recursive '[[:blank:]]$' .github
+            echo
+            echo "Please run:"
+            echo "  find .github -type f -exec sed -ri 's/[[:blank:]]+$//' {} \;"
+            echo "and submit your changes"
+            exit 1
+          fi

--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
-      
+
       - name: Get Cilium's default values
         id: default_vars
         uses: ./.github/actions/helm-default
@@ -113,7 +113,7 @@ jobs:
         with:
           project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
           version: ${{ env.gcloud_version }}
-      
+
       - name: Clone ClusterLoader2
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -178,7 +178,7 @@ jobs:
       - name: Wait for Cilium status to be ready
         run: |
           cilium status --wait
-      
+
       - name: Run CL2
         id: run-cl2
         working-directory: ./perf-tests/clusterloader2

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set initial commit status
-        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1  
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
         with:
           sha: ${{ inputs.SHA || github.sha }}
 
@@ -146,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1  
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
         with:
           sha: ${{ inputs.SHA || github.sha }}
           status: ${{ needs.setup-and-test.result }}

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -181,7 +181,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 				testExternalTrafficPolicyLocal(kubectl, ni)
 			})
 
-			It("", func() {
+			It("vanilla", func() {
 				testNodePort(kubectl, ni, false, false, 0)
 			})
 		})


### PR DESCRIPTION
Trailing spaces in workflow files tend to be a pain during backports, as they cause conflicts due to slight divergences across branches, and require manual intervention. Additionally, depending on the editor settings of each developer, they either lead to unnecessary churn in the code-base, or require extra effort to explicitly ignore them.

To prevent these issues, let's introduce a linter that verifies the absence of trailing spaces in all files under `.github`, and prompts a command to remove them if found.

Example run with failures: https://github.com/cilium/cilium/actions/runs/10005692170/job/27656895161?pr=33908