### PR TITLE
ci: show logs for integration-test etc containers.

### DIFF
--- a/.github/actions/unit-tests/build.sh
+++ b/.github/actions/unit-tests/build.sh
@@ -12,9 +12,16 @@ V=0 make precheck build -j 2 --quiet
 # as not used by the subsequent steps.
 make clean
 
+# Start kvstores seperately so we can do some pre-run checks.
+make start-kvstores
+
+# Check status of kvstores.
+docker logs kvstore1
+docker logs kvstore2
+
 # Run with default verbosity here since this builds all Go code by running
 # 'go vet' and all integration tests. At least one line of output is generated
 # after each Go package is built and tested.
-make integration-tests
+SKIP_KVSTORES=true make integration-tests
 
 exit 0

--- a/.github/actions/unit-tests/build.sh
+++ b/.github/actions/unit-tests/build.sh
@@ -15,9 +15,10 @@ make clean
 # Start kvstores seperately so we can do some pre-run checks.
 make start-kvstores
 
-# Check status of kvstores.
-docker logs kvstore1
-docker logs kvstore2
+
+# Check status of kvstore.
+sleep 15
+docker logs cilium-etcd-test-container 
 
 # Run with default verbosity here since this builds all Go code by running
 # 'go vet' and all integration tests. At least one line of output is generated

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -174,8 +174,7 @@ jobs:
       - name: On failure collect logs
         if: ${{ failure() }}
         run: |
-          docker logs kvstore1
-          docker logs kvstore2
+          docker logs cilium-etcd-test-container 
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -171,6 +171,12 @@ jobs:
           export DOCKER_BUILD_FLAGS=--quiet
           ./.github/actions/unit-tests/build.sh
 
+      - name: On failure collect logs
+        if: ${{ failure() }}
+        run: |
+          docker logs kvstore1
+          docker logs kvstore2
+
   commit-status-final:
     if: ${{ always() }}
     name: Commit Status Final


### PR DESCRIPTION
There's been some occasional failures with connections to the test etcd cluster. To help debug this, and other issues in the future, lets dump out some logs from etcd before the tests and after if the tests fail.

Addresses: #33915

