### PR TITLE
pkg/ciliumidentity: Operator Managing CID Controller 

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
+	"github.com/cilium/cilium/pkg/labelsfilter"
+
 	operatorApi "github.com/cilium/cilium/api/v1/operator/server"
 	ciliumdbg "github.com/cilium/cilium/cilium-dbg/cmd"
 	"github.com/cilium/cilium/operator/api"
@@ -696,6 +698,12 @@ func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 		if err != nil {
 			log.WithError(err).WithField(logfields.LogSubsys, "CCNPWatcher").Fatal(
 				"Cannot connect to Kubernetes apiserver ")
+		}
+	}
+
+	if legacy.clientset.IsEnabled() {
+		if err := labelsfilter.ParseLabelPrefixCfg(option.Config.Labels, option.Config.NodeLabels, option.Config.LabelPrefixFile); err != nil {
+			log.WithError(err).Fatal("Unable to parse Label prefix configuration")
 		}
 	}
 

--- a/operator/pkg/ciliumidentity/ciliumendpointslice.go
+++ b/operator/pkg/ciliumidentity/ciliumendpointslice.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// CID controller also watches for CESs. The only reason is to keep a cache of
+// what CIDs are used in CESs. This is required only when CESs are enabled.
+// CID controller won't delete a CID until it is no longer present in any CESs.
+func (c *Controller) processCiliumEndpointSliceEvents(ctx context.Context) error {
+	if !c.cesEnabled {
+		return nil
+	}
+
+	for event := range c.ciliumEndpointSlice.Events(ctx) {
+		var idsWithNoCESUsage []int64
+
+		switch event.Kind {
+		case resource.Upsert:
+			c.logger.Debug("Got Upsert CES event", logfields.CESName, event.Key.String())
+			idsWithNoCESUsage = c.reconciler.cidUsageInCES.ProcessCESUpsert(event.Object.Name, event.Object.Endpoints)
+		case resource.Delete:
+			c.logger.Debug("Got Delete CES event", logfields.CESName, event.Key.String())
+			idsWithNoCESUsage = c.reconciler.cidUsageInCES.ProcessCESDelete(event.Object.Name, event.Object.Endpoints)
+		}
+
+		for _, cid := range idsWithNoCESUsage {
+			cidName := strconv.Itoa(int(cid))
+			c.logger.Info("Reconciling CID as it is no longer used in CESs", logfields.CIDName, cidName)
+			c.enqueueReconciliation(CIDItem{cidResourceKey(cidName)}, 0)
+		}
+
+		event.Done(nil)
+	}
+	return nil
+}

--- a/operator/pkg/ciliumidentity/controller.go
+++ b/operator/pkg/ciliumidentity/controller.go
@@ -20,9 +20,11 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 )
 
+type QueuedItem interface {
+	Key() resource.Key
+}
 type queueOperations interface {
-	enqueueCIDReconciliation(cidKey resource.Key, delay time.Duration)
-	enqueuePodReconciliation(podKey resource.Key, delay time.Duration)
+	enqueueReconciliation(item QueuedItem, delay time.Duration)
 }
 
 type params struct {
@@ -111,10 +113,7 @@ func (c *Controller) Start(_ cell.HookContext) error {
 	return nil
 }
 
-func (c *Controller) enqueueCIDReconciliation(cidKey resource.Key, delay time.Duration) {
-}
-
-func (c *Controller) enqueuePodReconciliation(podKey resource.Key, delay time.Duration) {
+func (c *Controller) enqueueReconciliation(item QueuedItem, delay time.Duration) {
 }
 
 func (c *Controller) Stop(hookContext cell.HookContext) error {

--- a/operator/pkg/ciliumidentity/controller.go
+++ b/operator/pkg/ciliumidentity/controller.go
@@ -10,7 +10,9 @@ import (
 	"time"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/util/workqueue"
 
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -18,12 +20,24 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+const (
+	// defaultSyncBackOff is the default backoff period for resource workqueue errors.
+	defaultSyncBackOff = 1 * time.Second
+	// maxSyncBackOff is the max backoff period for resource workqueue errors.
+	maxSyncBackOff = 100 * time.Second
+	// maxRetries is the number of times a work queue will be retried before
+	// it is dropped out of the queue.
+	maxProcessRetries = 15
 )
 
 type QueuedItem interface {
 	Key() resource.Key
+	Reconcile(reconciler *reconciler) error
 }
-type queueOperations interface {
+type queueOperation interface {
 	enqueueReconciliation(item QueuedItem, delay time.Duration)
 }
 
@@ -34,6 +48,7 @@ type params struct {
 	Lifecycle           cell.Lifecycle
 	Clientset           k8sClient.Clientset
 	SharedCfg           SharedConfig
+	JobGroup            job.Group
 	Namespace           resource.Resource[*slim_corev1.Namespace]
 	Pod                 resource.Resource[*slim_corev1.Pod]
 	CiliumIdentity      resource.Resource[*cilium_api_v2.CiliumIdentity]
@@ -47,11 +62,18 @@ type Controller struct {
 	contextCancel       context.CancelFunc
 	clientset           k8sClient.Clientset
 	reconciler          *reconciler
+	jobGroup            job.Group
 	namespace           resource.Resource[*slim_corev1.Namespace]
 	pod                 resource.Resource[*slim_corev1.Pod]
 	ciliumIdentity      resource.Resource[*cilium_api_v2.CiliumIdentity]
 	ciliumEndpoint      resource.Resource[*cilium_api_v2.CiliumEndpoint]
 	ciliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice]
+
+	// Work queue is used to sync resources with the api-server. It will rate-limit
+	// requests going to api-server. Ensures a single resource key will not be
+	// processed multiple times concurrently, and if a resource key is added
+	// multiple times before it can be processed, this will only be processed once.
+	resourceQueue workqueue.RateLimitingInterface
 
 	cesEnabled bool
 
@@ -70,12 +92,15 @@ func registerController(p params) {
 		clientset:           p.Clientset,
 		namespace:           p.Namespace,
 		pod:                 p.Pod,
+		jobGroup:            p.JobGroup,
 		ciliumIdentity:      p.CiliumIdentity,
 		ciliumEndpoint:      p.CiliumEndpoint,
 		ciliumEndpointSlice: p.CiliumEndpointSlice,
 		oldNSSecurityLabels: make(map[string]labels.Labels),
 		cesEnabled:          p.SharedCfg.EnableCiliumEndpointSlice,
 	}
+
+	cidController.initializeQueues()
 
 	p.Lifecycle.Append(cidController)
 }
@@ -110,12 +135,116 @@ func (c *Controller) Start(_ cell.HookContext) error {
 		return fmt.Errorf("cid controller failed to calculate the desired state: %w", err)
 	}
 
+	// The Cilium Identity (CID) controller running in cilium-operator is
+	// responsible only for managing CID API objects.
+	//
+	// Pod events are added to Pod work queue.
+	// Namespace events are processed immediately and added to Pod work queue.
+	// CID events are added to CID work queue.
+	// Processing Pod work queue items are adding items to CID work queue.
+	// Processed CID work queue items result in mutations to CID API objects.
+	//
+	// Diagram:
+	//-------------------------Pod,CID event
+	//---------------------------||
+	//----------------------------V
+	// Namespace event -> Resource work queue -> Mutate CID API objects
+	c.startEventProcessing()
+	c.startWorkQueues()
+
+	return nil
+}
+
+func (c *Controller) Stop(_ cell.HookContext) error {
+	c.resourceQueue.ShutDown()
+	c.contextCancel()
+
+	return nil
+}
+
+func (c *Controller) initializeQueues() {
+
+	c.logger.Info("CID controller resource work queue configuration",
+		logfields.WorkQueueSyncBackOff, defaultSyncBackOff,
+		logfields.WorkQueueMaxSyncBackOff, maxSyncBackOff)
+
+	c.resourceQueue = workqueue.NewRateLimitingQueueWithConfig(
+		workqueue.NewItemExponentialFailureRateLimiter(defaultSyncBackOff, maxSyncBackOff),
+		workqueue.RateLimitingQueueConfig{Name: "ciliumidentity_resource"})
+}
+
+func (c *Controller) startEventProcessing() {
+
+	c.jobGroup.Add(
+		job.OneShot("proc-cid-events", func(ctx context.Context, health cell.Health) error {
+			return c.processCiliumIdentityEvents(ctx)
+		}),
+
+		job.OneShot("proc-pod-events", func(ctx context.Context, health cell.Health) error {
+			return c.processPodEvents(ctx)
+		}),
+
+		job.OneShot("proc-ces-events", func(ctx context.Context, health cell.Health) error {
+			return c.processCiliumEndpointSliceEvents(ctx)
+		}),
+
+		job.OneShot("proc-ns-events", func(ctx context.Context, health cell.Health) error {
+			return c.processNamespaceEvents(ctx)
+		}),
+	)
+}
+
+func (c *Controller) startWorkQueues() {
+
+	c.jobGroup.Add(
+		job.OneShot("op-managing-resource-wq", func(ctx context.Context, health cell.Health) error {
+			return c.runResourceWorker(ctx)
+		}),
+	)
+}
+
+func (c *Controller) runResourceWorker(context context.Context) error {
+	c.logger.Info("Starting resource worker")
+	defer c.logger.Info("Stopping resource worker")
+
+	for c.processNextItem() {
+		select {
+		case <-context.Done():
+			return nil
+		case <-c.context.Done():
+			return nil
+		default:
+		}
+	}
+
 	return nil
 }
 
 func (c *Controller) enqueueReconciliation(item QueuedItem, delay time.Duration) {
+	c.resourceQueue.AddAfter(item, delay)
 }
 
-func (c *Controller) Stop(hookContext cell.HookContext) error {
-	return nil
+func (c *Controller) processNextItem() bool {
+	item, quit := c.resourceQueue.Get()
+	if quit {
+		return false
+	}
+	defer c.resourceQueue.Done(item)
+
+	qItem := item.(QueuedItem)
+	if err := qItem.Reconcile(c.reconciler); err != nil {
+		retries := c.resourceQueue.NumRequeues(item)
+		c.logger.Warn("Failed to process resource item", logfields.Key, qItem.Key().String(), "retries", retries, "maxRetries", maxProcessRetries, logfields.Error, err)
+
+		if retries < maxProcessRetries {
+			c.resourceQueue.AddRateLimited(item)
+			return true
+		}
+
+		// Drop the pod from queue, exceeded max retries
+		c.logger.Error("Dropping item from resource queue, exceeded maxRetries", logfields.Key, qItem.Key().String(), "maxRetries", maxProcessRetries, logfields.Error, err)
+	}
+
+	c.resourceQueue.Forget(item)
+	return true
 }

--- a/operator/pkg/ciliumidentity/controller_test.go
+++ b/operator/pkg/ciliumidentity/controller_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/job"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/operator/k8s"
+	cestest "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/health/types"
+	capi_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+const (
+	WaitUntilTimeout = 5 * time.Second
+)
+
+func TestRegisterControllerWithOperatorManagingCIDs(t *testing.T) {
+	cidResource, cesResource, fakeClient, h := initHiveTest(true)
+
+	ctx := context.Background()
+	tlog := hivetest.Logger(t)
+	if err := h.Start(tlog, ctx); err != nil {
+		t.Fatalf("starting hive encountered an error: %s", err)
+	}
+
+	if err := createNsAndPod(ctx, fakeClient); err != nil {
+		t.Errorf("Failed to create namespace or pod: %v", err)
+	}
+
+	cidStore, _ := (*cidResource).Store(ctx)
+	err := testutils.WaitUntil(func() bool { return len(cidStore.List()) > 0 }, WaitUntilTimeout)
+	if err != nil {
+		t.Errorf("Expected CID to be created, got %v", err)
+	}
+
+	if err := verifyCIDUsageInCES(ctx, fakeClient, *cidResource, *cesResource); err != nil {
+		t.Errorf("Failed to verify CID usage in CES, got %v", err)
+	}
+
+	if err := h.Stop(tlog, ctx); err != nil {
+		t.Fatalf("stopping hive encountered an error: %v", err)
+	}
+}
+
+func TestRegisterController(t *testing.T) {
+	cidResource, _, fakeClient, h := initHiveTest(false)
+
+	ctx := context.Background()
+	tlog := hivetest.Logger(t)
+	if err := h.Start(tlog, ctx); err != nil {
+		t.Fatalf("starting hive encountered an error: %s", err)
+	}
+
+	if err := createNsAndPod(ctx, fakeClient); err != nil {
+		t.Errorf("Failed to create namespace or pod: %v", err)
+	}
+
+	cidStore, _ := (*cidResource).Store(ctx)
+	if len(cidStore.List()) != 0 {
+		t.Errorf("Expected no CIDs to be present in the store, but found %d", len(cidStore.List()))
+	}
+
+	if err := h.Stop(tlog, ctx); err != nil {
+		t.Fatalf("stopping hive encountered an error: %v", err)
+	}
+}
+
+func initHiveTest(operatorManagingCID bool) (*resource.Resource[*capi_v2.CiliumIdentity], *resource.Resource[*capi_v2a1.CiliumEndpointSlice], *k8sClient.FakeClientset, *hive.Hive) {
+	var cidResource resource.Resource[*capi_v2.CiliumIdentity]
+	var cesResource resource.Resource[*capi_v2a1.CiliumEndpointSlice]
+	var fakeClient k8sClient.FakeClientset
+	h := hive.New(
+		k8sClient.FakeClientCell,
+		k8s.ResourcesCell,
+		cell.Provide(func() SharedConfig {
+			return SharedConfig{
+				EnableOperatorManageCIDs:  operatorManagingCID,
+				EnableCiliumEndpointSlice: true,
+			}
+		}),
+		cell.Provide(func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
+			h := p.ForModule(cell.FullModuleID{"test"})
+			jg := jr.NewGroup(h)
+			lc.Append(jg)
+			return jg
+		}),
+		cell.Invoke(func(p params) error {
+			registerController(p)
+			return nil
+		}),
+		cell.Invoke(func(
+			c *k8sClient.FakeClientset,
+			cid resource.Resource[*capi_v2.CiliumIdentity],
+			ces resource.Resource[*capi_v2a1.CiliumEndpointSlice],
+		) error {
+			fakeClient = *c
+			cidResource = cid
+			cesResource = ces
+			return nil
+		}),
+	)
+	return &cidResource, &cesResource, &fakeClient, h
+}
+
+func createNsAndPod(ctx context.Context, fakeClient *k8sClient.FakeClientset) error {
+	ns := testCreateNSObj("ns1", nil)
+	if _, err := fakeClient.Slim().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+	pod := testCreatePodObj("pod1", "ns1", testLbsA, nil)
+	if _, err := fakeClient.Slim().CoreV1().Pods("ns1").Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func verifyCIDUsageInCES(ctx context.Context, fakeClient *k8sClient.FakeClientset, cidResource resource.Resource[*capi_v2.CiliumIdentity], cesResource resource.Resource[*capi_v2a1.CiliumEndpointSlice]) error {
+	cidStore, _ := cidResource.Store(ctx)
+	cids := cidStore.List()
+	if len(cids) == 0 {
+		return fmt.Errorf("no CIDs found in the store")
+	}
+
+	cidNum, err := strconv.Atoi(cids[0].Name)
+	if err != nil {
+		return err
+	}
+
+	cep1 := cestest.CreateManagerEndpoint("cep1", int64(cidNum))
+	ces1 := cestest.CreateStoreEndpointSlice("ces1", "ns", []capi_v2a1.CoreCiliumEndpoint{cep1})
+	if _, err := fakeClient.CiliumV2alpha1().CiliumEndpointSlices().Create(ctx, ces1, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+
+	cesStore, _ := cesResource.Store(context.Background())
+	if err := testutils.WaitUntil(func() bool {
+		return len(cesStore.List()) > 0
+	}, WaitUntilTimeout); err != nil {
+		return fmt.Errorf("failed to get CES: %w", err)
+	}
+
+	// CID is not deleted even when Pod is, because the CID is still used in CES.
+	if err := fakeClient.Slim().CoreV1().Pods("ns1").Delete(ctx, "pod1", metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+
+	if len(cidStore.List()) == 0 {
+		return fmt.Errorf("expected for CID to not be deleted")
+	}
+
+	if err := fakeClient.CiliumV2alpha1().CiliumEndpointSlices().Delete(ctx, ces1.Name, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/operator/pkg/ciliumidentity/identity.go
+++ b/operator/pkg/ciliumidentity/identity.go
@@ -22,6 +22,10 @@ func (c CIDItem) Key() resource.Key {
 	return c.key
 }
 
+func (c CIDItem) Reconcile(reconciler *reconciler) error {
+	return reconciler.reconcileCID(c.key)
+}
+
 func (c *Controller) processCiliumIdentityEvents(ctx context.Context) error {
 	for event := range c.ciliumIdentity.Events(ctx) {
 		if event.Kind == resource.Upsert || event.Kind == resource.Delete {

--- a/operator/pkg/ciliumidentity/identity.go
+++ b/operator/pkg/ciliumidentity/identity.go
@@ -8,3 +8,11 @@ import "github.com/cilium/cilium/pkg/k8s/resource"
 func cidResourceKey(cidName string) resource.Key {
 	return resource.Key{Name: cidName}
 }
+
+type CIDItem struct {
+	key resource.Key
+}
+
+func (c CIDItem) Key() resource.Key {
+	return c.key
+}

--- a/operator/pkg/ciliumidentity/namespace.go
+++ b/operator/pkg/ciliumidentity/namespace.go
@@ -3,8 +3,60 @@
 
 package ciliumidentity
 
-import "github.com/cilium/cilium/pkg/k8s/resource"
+import (
+	"context"
+
+	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/labelsfilter"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/policy"
+)
 
 func nsResourceKey(namespace string) resource.Key {
 	return resource.Key{Name: namespace}
+}
+
+func (c *Controller) processNamespaceEvents(ctx context.Context) error {
+	for event := range c.namespace.Events(ctx) {
+		switch event.Kind {
+		case resource.Upsert:
+			c.logger.Debug("Got Upsert Namespace event", logfields.K8sNamespace, event.Key.String())
+
+			c.onNamespaceEvent(event.Object)
+		}
+		event.Done(nil)
+	}
+	return nil
+}
+
+// onNamespaceEvent sends namespace to Cilium Identity for reconciliation if
+// the namespace labels are changed.
+func (c *Controller) onNamespaceEvent(ns *slimcorev1.Namespace) {
+	newLabels := getNamespaceLabels(ns)
+
+	oldIdLabels := c.oldNSSecurityLabels[ns.Name]
+	newIdLabels, _ := labelsfilter.Filter(newLabels)
+
+	// Do not perform any other operations if labels did not change.
+	if oldIdLabels.DeepEqual(&newIdLabels) {
+		return
+	}
+
+	c.oldNSSecurityLabels[ns.Name] = newIdLabels
+
+	if err := c.reconciler.reconcileNamespace(nsResourceKey(ns.Name)); err != nil {
+		c.logger.Error("Failed to process namespaces changes", logfields.K8sNamespace, ns.Name, logfields.Error, err)
+	}
+}
+
+func getNamespaceLabels(ns *slimcorev1.Namespace) labels.Labels {
+	lbs := ns.GetLabels()
+	labelMap := make(map[string]string, len(lbs))
+	for k, v := range lbs {
+		labelMap[policy.JoinPath(ciliumio.PodNamespaceMetaLabels, k)] = v
+	}
+	return labels.Map2Labels(labelMap, labels.LabelSourceK8s)
 }

--- a/operator/pkg/ciliumidentity/namespace_test.go
+++ b/operator/pkg/ciliumidentity/namespace_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import (
+	"reflect"
+	"testing"
+
+	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+func TestGetNamespaceLabels(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		namespace     *slimcorev1.Namespace
+		expected      labels.Labels
+		expectedError error
+	}{
+		{
+			desc: "empty_labels",
+			namespace: &slimcorev1.Namespace{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+			},
+			expected: labels.Map2Labels(map[string]string{}, labels.LabelSourceK8s),
+		},
+		{
+			desc: "single_label",
+			namespace: &slimcorev1.Namespace{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "my-app",
+					},
+				},
+			},
+			expected: labels.Map2Labels(map[string]string{
+				policy.JoinPath(ciliumio.PodNamespaceMetaLabels, "app"): "my-app",
+			}, labels.LabelSourceK8s),
+		},
+		{
+			desc: "multiple_labels",
+			namespace: &slimcorev1.Namespace{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app":     "my-app",
+						"version": "1.0",
+					},
+				},
+			},
+			expected: labels.Map2Labels(map[string]string{
+				policy.JoinPath(ciliumio.PodNamespaceMetaLabels, "app"):     "my-app",
+				policy.JoinPath(ciliumio.PodNamespaceMetaLabels, "version"): "1.0",
+			}, labels.LabelSourceK8s),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := getNamespaceLabels(tc.namespace)
+
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Expected %v, but got %v", tc.expected, result)
+			}
+		})
+	}
+}

--- a/operator/pkg/ciliumidentity/pod.go
+++ b/operator/pkg/ciliumidentity/pod.go
@@ -22,6 +22,10 @@ func (p PodItem) Key() resource.Key {
 	return p.key
 }
 
+func (p PodItem) Reconcile(reconciler *reconciler) error {
+	return reconciler.reconcilePod(p.key)
+}
+
 func (c *Controller) processPodEvents(ctx context.Context) error {
 	for event := range c.pod.Events(ctx) {
 		if event.Kind == resource.Upsert || event.Kind == resource.Delete {

--- a/operator/pkg/ciliumidentity/pod.go
+++ b/operator/pkg/ciliumidentity/pod.go
@@ -3,7 +3,12 @@
 
 package ciliumidentity
 
-import "github.com/cilium/cilium/pkg/k8s/resource"
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
 
 func podResourceKey(podName, podNamespace string) resource.Key {
 	return resource.Key{Name: podName, Namespace: podNamespace}
@@ -15,4 +20,15 @@ type PodItem struct {
 
 func (p PodItem) Key() resource.Key {
 	return p.key
+}
+
+func (c *Controller) processPodEvents(ctx context.Context) error {
+	for event := range c.pod.Events(ctx) {
+		if event.Kind == resource.Upsert || event.Kind == resource.Delete {
+			c.logger.Debug("Got Pod event", logfields.Type, event.Kind, logfields.K8sPodName, event.Key.String())
+			c.enqueueReconciliation(PodItem{podResourceKey(event.Object.Name, event.Object.Namespace)}, 0)
+		}
+		event.Done(nil)
+	}
+	return nil
 }

--- a/operator/pkg/ciliumidentity/pod.go
+++ b/operator/pkg/ciliumidentity/pod.go
@@ -8,3 +8,11 @@ import "github.com/cilium/cilium/pkg/k8s/resource"
 func podResourceKey(podName, podNamespace string) resource.Key {
 	return resource.Key{Name: podName, Namespace: podNamespace}
 }
+
+type PodItem struct {
+	key resource.Key
+}
+
+func (p PodItem) Key() resource.Key {
+	return p.key
+}

--- a/operator/pkg/ciliumidentity/reconciler.go
+++ b/operator/pkg/ciliumidentity/reconciler.go
@@ -328,7 +328,7 @@ func (r *reconciler) allocateCIDForPod(pod *slim_corev1.Pod) error {
 	}
 
 	if isNewCID {
-		r.queueOps.enqueueCIDReconciliation(cidResourceKey(cidName), 0)
+		r.queueOps.enqueueReconciliation(CIDItem{cidResourceKey(cidName)}, 0)
 	}
 
 	return nil
@@ -430,7 +430,7 @@ func (r *reconciler) updateAllPodsInNamespace(namespace string) error {
 	var lastErr error
 
 	for _, pod := range podList {
-		r.queueOps.enqueuePodReconciliation(podResourceKey(pod.Name, pod.Namespace), 0)
+		r.queueOps.enqueueReconciliation(PodItem{podResourceKey(pod.Name, pod.Namespace)}, 0)
 	}
 
 	return lastErr

--- a/operator/pkg/ciliumidentity/reconciler.go
+++ b/operator/pkg/ciliumidentity/reconciler.go
@@ -43,7 +43,7 @@ type reconciler struct {
 	// (that is, when processing a pod event and a CID event concurrently).
 	cidCreateLock lock.RWMutex
 	cesEnabled    bool
-	queueOps      queueOperations
+	queueOps      queueOperation
 
 	nsStore  resource.Store[*slim_corev1.Namespace]
 	podStore resource.Store[*slim_corev1.Pod]
@@ -62,7 +62,7 @@ func newReconciler(
 	ciliumEndpoint resource.Resource[*cilium_api_v2.CiliumEndpoint],
 	ciliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice],
 	cesEnabled bool,
-	queueOps queueOperations,
+	queueOps queueOperation,
 ) (*reconciler, error) {
 	logger.Info("Creating CID controller Operator reconciler")
 

--- a/operator/pkg/ciliumidentity/reconciler_test.go
+++ b/operator/pkg/ciliumidentity/reconciler_test.go
@@ -42,12 +42,8 @@ type testQueueOps struct {
 	fakeWorkQueue map[string]bool
 }
 
-func (t testQueueOps) enqueueCIDReconciliation(cidKey resource.Key, _ time.Duration) {
-	t.fakeWorkQueue[cidKey.String()] = true
-}
-
-func (t testQueueOps) enqueuePodReconciliation(cidKey resource.Key, _ time.Duration) {
-	t.fakeWorkQueue[cidKey.String()] = true
+func (t testQueueOps) enqueueReconciliation(item QueuedItem, delay time.Duration) {
+	t.fakeWorkQueue[item.Key().String()] = true
 }
 
 func testNewReconciler(t *testing.T, ctx context.Context, enableCES bool) (*reconciler, *testQueueOps, k8sClient.FakeClientset, func()) {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -690,7 +690,8 @@ const (
 	WorkQueueBurstLimit = "workQueueBurstLimit"
 
 	// WorkQueueSyncBackoff is the backoff time used by workqueues before an attempt to retry sync with k8s-apiserver.
-	WorkQueueSyncBackOff = "workQueueSyncBackOff"
+	WorkQueueSyncBackOff    = "workQueueSyncBackOff"
+	WorkQueueMaxSyncBackOff = "workQueueMaxSyncBackOff"
 
 	// SourceIP is a source IP
 	SourceIP = "sourceIP"


### PR DESCRIPTION
Add the controller for handling the Operator managing CIDs. The Cilium Identity (CID) controller running in cilium-operator and is responsible only for managing CID API objects.
* Pod events are added to Pod work queue
* Namespace events are processed immediately and added to Pod work queue
* CID events are added to CID work queue
* Processing Pod work queue items are adding items to CID work queue
* Processed CID work queue items result in mutations to CID API objects

Related CFP #27752
Reconciler PR: #33383

```release-note
Adds the operator logic for managing CIDs.
```