### PR TITLE
mtu: Add dynamic MTU mismatch detection logging

### DIFF
--- a/pkg/mtu/detect_other.go
+++ b/pkg/mtu/detect_other.go
@@ -5,7 +5,12 @@
 
 package mtu
 
-import "net"
+import (
+	"context"
+	"net"
+
+	"github.com/cilium/hive/cell"
+)
 
 func autoDetect() (int, error) {
 	return EthernetMTU, nil
@@ -13,4 +18,8 @@ func autoDetect() (int, error) {
 
 func getMTUFromIf(net.IP) (int, error) {
 	return EthernetMTU, nil
+}
+
+func detectRuntimeMTUChange(ctx context.Context, p mtuParams, health cell.Health, runningMTU int) error {
+	return nil
 }


### PR DESCRIPTION
This commit adds logic to log a warning when we detect when the MTU of a device doesn't match the device MTU that Cilium is using. Every time a change in the selected devices is detected, we run this logic.

This warning log is hopefully a useful indicator of MTU issues for anyone inspecting the agent logs.
