### PR TITLE
option: Add --bpf-ipcache-map-max (default 512000)

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -41,6 +41,7 @@ cilium-agent [flags]
       --bpf-events-policy-verdict-enabled                         Expose 'policy verdict' events for Cilium monitor and/or Hubble (default true)
       --bpf-events-trace-enabled                                  Expose 'trace' events for Cilium monitor and/or Hubble (default true)
       --bpf-fragments-map-max int                                 Maximum number of entries in fragments tracking map (default 8192)
+      --bpf-ipcache-map-max int                                   Maximum number of entries for the ipcache BPF map (default 512000)
       --bpf-lb-acceleration string                                BPF load balancing acceleration via XDP ("native", "disabled") (default "disabled")
       --bpf-lb-algorithm string                                   BPF load balancing algorithm ("random", "maglev") (default "random")
       --bpf-lb-dsr-dispatch string                                BPF load balancing DSR dispatch method ("opt", "ipip", "geneve") (default "opt")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -805,6 +805,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Int(option.SockRevNatEntriesName, option.SockRevNATMapEntriesDefault, "Maximum number of entries for the SockRevNAT BPF map")
 	option.BindEnv(vp, option.SockRevNatEntriesName)
 
+	flags.Int(option.IPCacheMapEntriesName, option.IPCacheMapEntriesDefault, "Maximum number of entries for the ipcache BPF map")
+	option.BindEnv(vp, option.IPCacheMapEntriesName)
+
 	flags.Float64(option.MapEntriesGlobalDynamicSizeRatioName, 0.0025, "Ratio (0.0-1.0] of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps")
 	option.BindEnv(vp, option.MapEntriesGlobalDynamicSizeRatioName)
 

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
 	ipmasqmap "github.com/cilium/cilium/pkg/maps/ipmasq"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
@@ -379,7 +378,7 @@ func (d *Daemon) getBPFMapStatus() *models.BPFMapStatus {
 			},
 			{
 				Name: "IP cache",
-				Size: int64(ipcachemap.MaxEntries),
+				Size: int64(option.Config.IPCacheMapEntries),
 			},
 			{
 				Name: "IPv4 masquerading agent",

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -205,7 +205,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	cDefinesMap["CONFIG_MAP"] = configmap.MapName
 	cDefinesMap["CONFIG_MAP_SIZE"] = fmt.Sprintf("%d", configmap.MaxEntries)
 	cDefinesMap["IPCACHE_MAP"] = ipcachemap.Name
-	cDefinesMap["IPCACHE_MAP_SIZE"] = fmt.Sprintf("%d", ipcachemap.MaxEntries)
+	cDefinesMap["IPCACHE_MAP_SIZE"] = fmt.Sprintf("%d", option.Config.IPCacheMapEntries)
 	cDefinesMap["NODE_MAP"] = nodemap.MapName
 	cDefinesMap["NODE_MAP_V2"] = nodemap.MapNameV2
 	cDefinesMap["NODE_MAP_SIZE"] = fmt.Sprintf("%d", h.nodeMap.Size())

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -18,10 +18,6 @@ import (
 )
 
 const (
-	// MaxEntries is the maximum number of keys that can be present in the
-	// RemoteEndpointMap.
-	MaxEntries = 512000
-
 	// Name is the canonical name for the IPCache map on the filesystem.
 	Name = "cilium_ipcache"
 )
@@ -172,7 +168,7 @@ func newIPCacheMap(name string) *bpf.Map {
 		ebpf.LPMTrie,
 		&Key{},
 		&RemoteEndpointInfo{},
-		MaxEntries,
+		option.Config.IPCacheMapEntries,
 		bpf.BPF_F_NO_PREALLOC)
 }
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -589,6 +589,9 @@ const (
 	// that sock rev NAT is mostly used for UDP and getpeername only.
 	SockRevNATMapEntriesDefault = CTMapEntriesGlobalAnyDefault
 
+	// IPCacheMapEntriesDefault defines the default ipcache map limit.
+	IPCacheMapEntriesDefault = 512000
+
 	// MapEntriesGlobalDynamicSizeRatioName is the name of the option to
 	// set the ratio of total system memory to use for dynamic sizing of the
 	// CT, NAT, Neighbor and SockRevNAT BPF maps.
@@ -648,6 +651,9 @@ const (
 	// EgressGatewayPolicyMapEntriesName configures max entries for egress gateway's policy
 	// map.
 	EgressGatewayPolicyMapEntriesName = "egress-gateway-policy-map-max"
+
+	// IPCacheMapEntriesName configures max entries for BPF ipcache map.
+	IPCacheMapEntriesName = "bpf-ipcache-map-max"
 
 	// LogSystemLoadConfigName is the name of the option to enable system
 	// load loggging
@@ -1601,6 +1607,9 @@ type DaemonConfig struct {
 	// PolicyMapEntries is the maximum number of peer identities that an
 	// endpoint may allow traffic to exchange traffic with.
 	PolicyMapEntries int
+
+	// IPCacheMapEntries is the maximum number of entries in the ipcache map.
+	IPCacheMapEntries int
 
 	// PolicyMapFullReconciliationInterval is the interval at which to perform
 	// the full reconciliation of the endpoint policy map.
@@ -3716,6 +3725,15 @@ func (c *DaemonConfig) checkMapSizeLimits() error {
 			c.SockRevNatEntries, LimitTableMax)
 	}
 
+	if c.IPCacheMapEntries < LimitTableMin {
+		return fmt.Errorf("specified IPCacheMap max entries %d must exceed minimum %d",
+			c.IPCacheMapEntries, LimitTableMin)
+	}
+	if c.IPCacheMapEntries > LimitTableMax {
+		return fmt.Errorf("specified IPCacheMap max entries %d must not exceed maximum %d",
+			c.IPCacheMapEntries, LimitTableMax)
+	}
+
 	if c.PolicyMapEntries < PolicyMapMin {
 		return fmt.Errorf("specified PolicyMap max entries %d must exceed minimum %d",
 			c.PolicyMapEntries, PolicyMapMin)
@@ -3849,6 +3867,7 @@ func (c *DaemonConfig) calculateBPFMapSizes(vp *viper.Viper) error {
 	c.LBAffinityMapEntries = vp.GetInt(LBAffinityMapMaxEntries)
 	c.LBSourceRangeMapEntries = vp.GetInt(LBSourceRangeMapMaxEntries)
 	c.LBMaglevMapEntries = vp.GetInt(LBMaglevMapMaxEntries)
+	c.IPCacheMapEntries = vp.GetInt(IPCacheMapEntriesName)
 
 	// Don't attempt dynamic sizing if any of the sizeof members was not
 	// populated by the daemon (or any other caller).

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -265,6 +265,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		CTMapEntriesGlobalAny int
 		NATMapEntriesGlobal   int
 		PolicyMapEntries      int
+		IPCacheMapEntries     int
 		LBMapEntries          int
 		FragmentsMapEntries   int
 		NeighMapEntriesGlobal int
@@ -284,6 +285,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalAny: CTMapEntriesGlobalAnyDefault,
 				NATMapEntriesGlobal:   NATMapEntriesGlobalDefault,
 				PolicyMapEntries:      16384,
+				IPCacheMapEntries:     512000,
 				LBMapEntries:          65536,
 				FragmentsMapEntries:   defaults.FragmentsMapEntries,
 				NeighMapEntriesGlobal: NATMapEntriesGlobalDefault,
@@ -295,6 +297,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalAny: CTMapEntriesGlobalAnyDefault,
 				NATMapEntriesGlobal:   NATMapEntriesGlobalDefault,
 				PolicyMapEntries:      16384,
+				IPCacheMapEntries:     512000,
 				LBMapEntries:          65536,
 				FragmentsMapEntries:   defaults.FragmentsMapEntries,
 				NeighMapEntriesGlobal: NATMapEntriesGlobalDefault,
@@ -310,6 +313,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalAny: 18000,
 				NATMapEntriesGlobal:   2048,
 				PolicyMapEntries:      512,
+				IPCacheMapEntries:     1024000,
 				LBMapEntries:          1 << 14,
 				SockRevNatEntries:     18000,
 				FragmentsMapEntries:   2 << 14,
@@ -320,6 +324,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalAny: 18000,
 				NATMapEntriesGlobal:   2048,
 				PolicyMapEntries:      512,
+				IPCacheMapEntries:     1024000,
 				LBMapEntries:          1 << 14,
 				SockRevNatEntries:     18000,
 				FragmentsMapEntries:   2 << 14,
@@ -415,6 +420,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				NATMapEntriesGlobal:   NATMapEntriesGlobalDefault,
 				SockRevNatEntries:     4096,
 				PolicyMapEntries:      16384,
+				IPCacheMapEntries:     512000,
 				LBMapEntries:          65536,
 				FragmentsMapEntries:   defaults.FragmentsMapEntries,
 			},
@@ -425,6 +431,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				NATMapEntriesGlobal:   (2048 + 4096) * 2 / 3,
 				SockRevNatEntries:     4096,
 				PolicyMapEntries:      16384,
+				IPCacheMapEntries:     512000,
 				LBMapEntries:          65536,
 				FragmentsMapEntries:   defaults.FragmentsMapEntries,
 				WantErr:               false,
@@ -465,6 +472,26 @@ func TestCheckMapSizeLimits(t *testing.T) {
 			},
 		},
 		{
+			name: "IPCache map size below range",
+			d: &DaemonConfig{
+				IPCacheMapEntries: LimitTableMin - 1,
+			},
+			want: sizes{
+				IPCacheMapEntries: LimitTableMin - 1,
+				WantErr:           true,
+			},
+		},
+		{
+			name: "IPCache map size above range",
+			d: &DaemonConfig{
+				IPCacheMapEntries: LimitTableMax + 1,
+			},
+			want: sizes{
+				IPCacheMapEntries: LimitTableMax + 1,
+				WantErr:           true,
+			},
+		},
+		{
 			name: "Fragments map size below range",
 			d: &DaemonConfig{
 				FragmentsMapEntries: FragmentsMapMin - 1,
@@ -495,6 +522,7 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalAny: tt.d.CTMapEntriesGlobalAny,
 				NATMapEntriesGlobal:   tt.d.NATMapEntriesGlobal,
 				PolicyMapEntries:      tt.d.PolicyMapEntries,
+				IPCacheMapEntries:     tt.d.IPCacheMapEntries,
 				LBMapEntries:          tt.d.LBMapEntries,
 				FragmentsMapEntries:   tt.d.FragmentsMapEntries,
 				NeighMapEntriesGlobal: tt.d.NeighMapEntriesGlobal,


### PR DESCRIPTION
Add flag `--bpf-ipcache-map-max` to allow configuring the ipcache map size, bounded by LimitTableMin(1024) and LimitTableMax(16777216).

```release-note
Add a new flag `--bpf-ipcache-map-max` to allow configuring the ipcache map size.
```
