### PR TITLE
gha: shorten conformance-externalworkloads cluster name

### DIFF
--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -59,8 +59,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-vm
-  vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-vm
+  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
+  vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   vmStartupScript: .github/gcp-vm-startup.sh
   cilium_cli_ci_version:
   USE_GKE_GCLOUD_AUTH_PLUGIN: True


### PR DESCRIPTION
The cluster name is used both for the GKE cluster and in the Cilium's context. However, since [1] Cilium imposes a maximum cluster name length of 32 characters. Given the recent increase in the length of the run_id, the generated cluster name is dangerously close to the limit, and can easily exceed it in case of forks if the repository owner name is slightly longer. Hence, let's trim the final suffix to get back a few more characters.

\[1]: 3ba429d0f2f6 ("options: formalize and validate cluster name format")
