### PR TITLE
gha: configure fallback runner type for conformance-k8s-kind workflow

### DIFF
--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -27,7 +27,7 @@ env:
 jobs:
   kubernetes-e2e:
     name: Installation and Conformance Test
-    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER }}
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER || 'ubuntu-latest' }}
     timeout-minutes: 45
     strategy:
       fail-fast: false


### PR DESCRIPTION
The blamed commit configured the usage of GH_RUNNER_EXTRA_POWER for the Conformance K8s Kind workflow. However, this turned out not working correctly in case of PRs from forks, as the variable is not available in that case. Let's fix this by adding 'ubuntu-latest' as fallback value.

Fixes: 91b7c88cfeb0 ("gha: use GH_RUNNER_EXTRA_POWER for conformance-k8s-kind workflow")