### PR TITLE
ci: clustermesh run tests concurrently

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -318,6 +318,7 @@ jobs:
 
           CONNECTIVITY_TEST_DEFAULTS="--hubble=false \
             --flow-validation=disabled \
+            --test-concurrency=5 \
             --multi-cluster=${{ env.contextName2 }} \
             --external-target=google.com. \
             --include-unsafe-tests \


### PR DESCRIPTION
Conformance clustermesh workflow improved with connectivity test concurrent run to make it faster.

Average workflow runtime:
- without concurrent run: [~14m ... ~24m](https://github.com/cilium/cilium/actions/runs/10039409850)
- with `--test-concurrency=5`: [~9m ... ~13m](https://github.com/cilium/cilium/actions/runs/10041731384)

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
