### PR TITLE
operator/ciliumidentity: Update CID allocation logs

### DIFF
--- a/operator/pkg/ciliumidentity/cache.go
+++ b/operator/pkg/ciliumidentity/cache.go
@@ -52,7 +52,7 @@ func (c *CIDState) Upsert(id string, k *key.GlobalIdentity) {
 		return
 	}
 
-	c.logger.Debug("Upsert internal mapping between", logfields.CIDName, id, "labels", k.Labels().String())
+	c.logger.Debug("Upsert internal mapping", logfields.CIDName, id)
 	c.idToLabels[id] = k
 
 	keyStr := k.GetKey()
@@ -81,7 +81,7 @@ func (c *CIDState) Remove(id string) {
 		return
 	}
 
-	c.logger.Debug("Remove internal mapping between", logfields.CIDName, id, "labels", k.Labels().String())
+	c.logger.Debug("Remove internal mapping", logfields.CIDName, id)
 
 	delete(c.idToLabels, id)
 

--- a/operator/pkg/ciliumidentity/reconciler.go
+++ b/operator/pkg/ciliumidentity/reconciler.go
@@ -319,11 +319,13 @@ func (r *reconciler) allocateCIDForPod(pod *slim_corev1.Pod) error {
 	podName := podResourceKey(pod.Name, pod.Namespace).String()
 	prevCIDName, _ := r.cidUsageInPods.AssignCIDToPod(podName, cidName)
 
-	r.logger.Info("CID allocated for pod",
-		logfields.K8sPodName, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
-		logfields.CIDName, cidName,
-		logfields.OldIdentity, prevCIDName,
-		logfields.Labels, k8sLabels)
+	if cidName != prevCIDName {
+		r.logger.Info("CID allocated for pod",
+			logfields.K8sPodName, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
+			logfields.CIDName, cidName,
+			logfields.OldIdentity, prevCIDName,
+			logfields.Labels, k8sLabels)
+	}
 
 	if isNewCID {
 		r.queueOps.enqueueCIDReconciliation(cidResourceKey(cidName), 0)


### PR DESCRIPTION
1. Remove labels from the CIDState upsert and remove log lines because they are included in the following log "CID allocated for pod" in reconciler. https://github.com/cilium/cilium/blob/main/operator/pkg/ciliumidentity/reconciler.go#L326

2. Log "CID allocated for pod" only when the pod to CID mapping is updated.

Nothing will be logged if nothing changed -- pod has the same CID assigned and no CID mappings
changed.

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>
