### PR TITLE
ci: multi pool run tests concurrently

### DIFF
--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -154,7 +154,8 @@ jobs:
             --helm-set=ipam.operator.autoCreateCiliumPodIPPools.echo-other-node-pool.ipv4.cidrs='{192.168.16.0/20}' \
             --helm-set=ipam.operator.autoCreateCiliumPodIPPools.echo-other-node-pool.ipv4.maskSize=27"
 
-          CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --collect-sysdump-on-failure \
+          CONNECTIVITY_TEST_DEFAULTS="--test-concurrency=5 \
+            --flow-validation=disabled --hubble=false --collect-sysdump-on-failure \
             --external-target bing.com. --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8 \
             --namespace-annotations='{\"ipam.cilium.io/ip-pool\":\"cilium-test-pool\"}' \
             --deployment-pod-annotations='{ \
@@ -223,7 +224,7 @@ jobs:
         id: ips
         run: |
           for pod in client client2 echo-same-node echo-other-node; do
-            kubectl get pod -n cilium-test -l "name=${pod}" -o jsonpath="${pod}={.items[*].status.podIP}{'\n'}" >> "$GITHUB_OUTPUT"
+            kubectl get pod -A -l "name=${pod}" -o jsonpath="${pod}={.items[*].status.podIP}{'\n'}" >> "$GITHUB_OUTPUT"
           done
 
           for pool in cilium-test-pool client-pool echo-other-node-pool; do
@@ -235,10 +236,17 @@ jobs:
         run: |
           from ipaddress import ip_address, ip_network
 
-          assert ip_address("${{ steps.ips.outputs.client }}") in ip_network("${{ steps.ips.outputs.client-pool }}"), "client pool mismatch"
-          assert ip_address("${{ steps.ips.outputs.client2 }}") in ip_network("${{ steps.ips.outputs.cilium-test-pool }}"), "client2 pool mismatch"
-          assert ip_address("${{ steps.ips.outputs.echo-same-node }}") in ip_network("${{ steps.ips.outputs.cilium-test-pool }}"), "echo-same-node pool mismatch"
-          assert ip_address("${{ steps.ips.outputs.echo-other-node }}") in ip_network("${{ steps.ips.outputs.echo-other-node-pool }}"), "echo-other-node pool mismatch"
+          for ip in "${{ steps.ips.outputs.client }}".split():
+            assert ip_address(ip) in ip_network("${{ steps.ips.outputs.client-pool }}"), "client pool mismatch"
+
+          for ip in "${{ steps.ips.outputs.client2 }}".split():
+            assert ip_address(ip) in ip_network("${{ steps.ips.outputs.cilium-test-pool }}"), "client2 pool mismatch"
+
+          for ip in "${{ steps.ips.outputs.echo-same-node }}".split():
+            assert ip_address(ip) in ip_network("${{ steps.ips.outputs.cilium-test-pool }}"), "echo-same-node pool mismatch"
+
+          for ip in "${{ steps.ips.outputs.echo-other-node }}".split():
+            assert ip_address(ip) in ip_network("${{ steps.ips.outputs.echo-other-node-pool }}"), "echo-other-node pool mismatch"
 
       - name: Post-test information gathering
         if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}


### PR DESCRIPTION
Conformance multi pool IPAM workflow improved with connectivity test concurrent run to make it faster.

Connectivity tests runtime:
- without concurrent run: ~11m
- with `--test-concurrency=5`: ~4m

Workflow [run example](https://github.com/cilium/cilium/actions/runs/10046592874/job/27766376162).

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
