### PR TITLE
Enable L7 DNS proxy for nodes (take 2)

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -285,7 +285,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 			ret = __ipv6_host_policy_ingress(ctx, ip6, ct_buffer, &remote_id, &trace,
 							 ext_err);
 		}
-		if (IS_ERR(ret))
+		if (IS_ERR(ret) || ret == CTX_ACT_REDIRECT)
 			return ret;
 	}
 #endif /* ENABLE_HOST_FIREWALL */
@@ -714,7 +714,7 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 			ret = __ipv4_host_policy_ingress(ctx, ip4, ct_buffer, &remote_id, &trace,
 							 ext_err);
 		}
-		if (IS_ERR(ret))
+		if (IS_ERR(ret) || ret == CTX_ACT_REDIRECT)
 			return ret;
 	}
 #endif /* ENABLE_HOST_FIREWALL */
@@ -1423,6 +1423,12 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 
 	if (IS_ERR(ret))
 		goto drop_err;
+
+	if (ret == CTX_ACT_REDIRECT)
+	{
+		/* perhaps it's better to move part of the redirectio code here? */	
+		return ret;
+	}
 
 skip_host_firewall:
 #endif /* ENABLE_HOST_FIREWALL */

--- a/bpf/lib/source_info.h
+++ b/bpf/lib/source_info.h
@@ -55,6 +55,7 @@ __id_for_file(const char *const header_name)
 	_strcase_(111, "trace.h");
 	_strcase_(112, "encap.h");
 	_strcase_(113, "encrypt.h");
+	_strcase_(114, "host_firewall.h");
 
 	/* @@ source files list end */
 

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -146,6 +146,9 @@ type DNSProxy struct {
 	// mapping restored endpoint IP (both IPv4 and IPv6) to *Endpoint
 	restoredEPs restoredEPs
 
+	// FIXME: host endpoint does not have an IP address yet
+	restoredHost *endpoint.Endpoint
+
 	// rejectReply is the OPCode send from the DNS-proxy to the endpoint if the
 	// DNS request is invalid
 	rejectReply atomic.Int32
@@ -346,6 +349,9 @@ func (p *DNSProxy) RestoreRules(ep *endpoint.Endpoint) {
 	if ep.IPv6.IsValid() {
 		p.restoredEPs[ep.IPv6] = ep
 	}
+	if ep.IsHost() {
+		p.restoredHost = ep
+	}
 	// Use V2 if it is populated, otherwise
 	// use V1.
 	dnsRules := ep.DNSRulesV2
@@ -393,6 +399,9 @@ func (p *DNSProxy) removeRestoredRulesLocked(endpointID uint64) {
 			for _, r := range rule {
 				p.cache.releaseRegex(r.regex)
 			}
+		}
+		if p.restoredHost != nil && p.restoredHost.ID == uint16(endpointID) {
+			p.restoredHost = nil
 		}
 		delete(p.restored, endpointID)
 	}
@@ -553,7 +562,7 @@ func (allow perEPAllow) getPortRulesForID(endpointID uint64, destPortProto resto
 
 // LookupEndpointIDByIPFunc wraps logic to lookup an endpoint with any backend.
 // See DNSProxy.LookupRegisteredEndpoint for usage.
-type LookupEndpointIDByIPFunc func(ip netip.Addr) (endpoint *endpoint.Endpoint, err error)
+type LookupEndpointIDByIPFunc func(ip netip.Addr) (endpoint *endpoint.Endpoint, isHost bool, err error)
 
 // LookupSecIDByIPFunc Func wraps logic to lookup an IP's security ID from the
 // ipcache.
@@ -758,16 +767,18 @@ func shutdownServers(dnsServers []*dns.Server) {
 }
 
 // LookupEndpointByIP wraps LookupRegisteredEndpoint by falling back to an restored EP, if available
-func (p *DNSProxy) LookupEndpointByIP(ip netip.Addr) (endpoint *endpoint.Endpoint, err error) {
-	endpoint, err = p.LookupRegisteredEndpoint(ip)
-	if err != nil {
+func (p *DNSProxy) LookupEndpointByIP(ip netip.Addr) (endpoint *endpoint.Endpoint, isHost bool, err error) {
+	if endpoint, isHost, err = p.LookupRegisteredEndpoint(ip); err != nil {
 		// Check restored endpoints
-		endpoint, found := p.restoredEPs[ip]
-		if found {
-			return endpoint, nil
+		var found bool
+		if endpoint, found = p.restoredEPs[ip]; found {
+			return endpoint, endpoint.IsHost(), nil
+		}
+		if isHost && p.restoredHost != nil {
+			return p.restoredHost, true, nil
 		}
 	}
-	return endpoint, err
+	return
 }
 
 // UpdateAllowed sets newRules for endpointID and destPort. It compiles the DNS
@@ -981,7 +992,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		return
 	}
 	epAddr := addrPort.Addr()
-	ep, err := p.LookupEndpointByIP(epAddr)
+	ep, _, err := p.LookupEndpointByIP(epAddr)
 	if err != nil {
 		scopedLog.WithError(err).Error("cannot extract endpoint ID from DNS request")
 		stat.Err = fmt.Errorf("Cannot extract endpoint ID from DNS request: %w", err)

--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -9,7 +9,9 @@
 package restore
 
 import (
+	"bytes"
 	"fmt"
+	"net/netip"
 	"sort"
 	"testing"
 )
@@ -75,7 +77,70 @@ type IPRules []IPRule
 // IPRule stores the allowed destination IPs for a DNS names matching a regex
 type IPRule struct {
 	Re  RuleRegex
-	IPs map[string]struct{} // IPs, nil set is wildcard and allows all IPs!
+	IPs map[RuleIPOrCIDR]struct{} // IPs, nil set is wildcard and allows all IPs!
+}
+
+// RuleIPOrCIDR is one allowed destination IP or CIDR
+// It marshals to/from text in a way that is compatible with net.IP and CIDRs
+type RuleIPOrCIDR netip.Prefix
+
+func ParseRuleIPOrCIDR(s string) (ip RuleIPOrCIDR, err error) {
+	err = ip.UnmarshalText([]byte(s))
+	return
+}
+
+func MustParseRuleIPOrCIDR(s string) (ip RuleIPOrCIDR) {
+	if err := ip.UnmarshalText([]byte(s)); err != nil {
+		panic(fmt.Errorf("bad input '%s': %s", s, err))
+	}
+	return
+}
+
+func (ip RuleIPOrCIDR) ContainsAddr(addr RuleIPOrCIDR) bool {
+	return addr.IsAddr() && netip.Prefix(ip).Contains(netip.Prefix(addr).Addr())
+}
+
+func (ip RuleIPOrCIDR) IsAddr() bool {
+	return netip.Prefix(ip).Bits() == -1
+}
+
+func (ip RuleIPOrCIDR) String() string {
+	if ip.IsAddr() {
+		return netip.Prefix(ip).Addr().String()
+	} else {
+		return netip.Prefix(ip).String()
+	}
+}
+
+func (ip RuleIPOrCIDR) ToSingleCIDR() RuleIPOrCIDR {
+	addr := netip.Prefix(ip).Addr()
+	return RuleIPOrCIDR(netip.PrefixFrom(addr, addr.BitLen()))
+}
+
+func (ip RuleIPOrCIDR) MarshalText() ([]byte, error) {
+	if ip.IsAddr() {
+		return netip.Prefix(ip).Addr().MarshalText()
+	} else {
+		return netip.Prefix(ip).MarshalText()
+	}
+}
+
+func (ip *RuleIPOrCIDR) UnmarshalText(b []byte) (err error) {
+	if b == nil {
+		return fmt.Errorf("cannot unmarshal nil into RuleIPOrCIDR")
+	}
+	if i := bytes.IndexByte(b, byte('/')); i < 0 {
+		var addr netip.Addr
+		if err = addr.UnmarshalText(b); err == nil {
+			*ip = RuleIPOrCIDR(netip.PrefixFrom(addr, 0xff))
+		}
+	} else {
+		var prefix netip.Prefix
+		if err = prefix.UnmarshalText(b); err == nil {
+			*ip = RuleIPOrCIDR(prefix)
+		}
+	}
+	return
 }
 
 // RuleRegex is a wrapper for a pointer to a string so that we can define marshalers for it.

--- a/pkg/monitor/api/files.go
+++ b/pkg/monitor/api/files.go
@@ -32,6 +32,7 @@ var files = map[uint8]string{
 	111: "trace.h",
 	112: "encap.h",
 	113: "encrypt.h",
+	114: "host_firewall.h",
 
 	// @@ source files list end
 }

--- a/pkg/policy/api/egress_test.go
+++ b/pkg/policy/api/egress_test.go
@@ -352,7 +352,7 @@ func TestIsLabelBasedEgress(t *testing.T) {
 	for _, tt := range tests {
 		args := tt.setupArgs()
 		want := tt.setupWanted()
-		require.Equal(t, nil, args.eg.sanitize(), fmt.Sprintf("Test name: %q", tt.name))
+		require.Equal(t, nil, args.eg.sanitize(false), fmt.Sprintf("Test name: %q", tt.name))
 		isLabelBased := args.eg.AllowsWildcarding()
 		require.EqualValues(t, want.isLabelBased, isLabelBased, fmt.Sprintf("Test name: %q", tt.name))
 	}

--- a/pkg/policy/api/ingress_test.go
+++ b/pkg/policy/api/ingress_test.go
@@ -289,7 +289,7 @@ func TestIsLabelBasedIngress(t *testing.T) {
 	for _, tt := range tests {
 		args := tt.setupArgs()
 		want := tt.setupWanted()
-		require.Equal(t, nil, args.eg.sanitize(), fmt.Sprintf("Test name: %q", tt.name))
+		require.Equal(t, nil, args.eg.sanitize(false), fmt.Sprintf("Test name: %q", tt.name))
 		isLabelBased := args.eg.AllowsWildcarding()
 		require.EqualValues(t, want.isLabelBased, isLabelBased, fmt.Sprintf("Test name: %q", tt.name))
 	}


### PR DESCRIPTION
@aanm @jrajahalme So I merged my changes from #19892 into the current branch (two of them turned out to be no longer needed) and tried to make the BPF datapath shunt DNS packets with redirect policy egressing from the host into the proxy socket. The output of `cilium monitor` indicates that the added code is running, but packets don't go to the proxy socket:

```
CPU 02: MARK 0x2013f5c8 FROM 3372 DEBUG: Successfully mapped addr=172.19.0.2 to identity=1
CPU 02: MARK 0x2013f5c8 FROM 3372 DEBUG: Conntrack lookup 1/2: src=172.19.0.2:40573 dst=168.63.129.16:53
CPU 02: MARK 0x2013f5c8 FROM 3372 DEBUG: Conntrack lookup 2/2: nexthdr=17 flags=1 dir=0 scope=2
CPU 02: MARK 0x2013f5c8 FROM 3372 DEBUG: CT verdict: New, revnat=0
CPU 02: MARK 0x2013f5c8 FROM 3372 DEBUG: Successfully mapped addr=168.63.129.16 to identity=16777217
CPU 02: MARK 0x2013f5c8 FROM 3372 DEBUG: Matched L4 policy; creating conntrack src=16777217 dst=1 dport=53 proto=17
CPU 02: MARK 0x2013f5c8 FROM 3372 DEBUG: Conntrack create: proxy-port=0 revnat=0 src-identity=1 lb=0.0.0.0
Policy verdict log: flow 0x2013f5c8 local EP ID 3372, remote ID 16777217, proto 17, egress, action redirect, auth: disabled, match L3-L4, 172.19.0.2:40573 -> 168.63.129.16:53 udp
-> proxy port 38101 flow 0x2013f5c8 , identity host->unknown state new ifindex 0 orig-ip 0.0.0.0: 172.19.0.2:40573 -> 168.63.129.16:53 udp
-> network flow 0x2013f5c8 , identity host->unknown state new ifindex eth0 orig-ip 0.0.0.0: 172.19.0.2:40573 -> 168.63.129.16:53 udp
CPU 02: MARK 0x2013f5c8 FROM 3372 DEBUG: Successfully mapped addr=172.19.0.2 to identity=1
CPU 02: MARK 0x2013f5c8 FROM 3372 DEBUG: Conntrack lookup 1/2: src=172.19.0.2:40573 dst=168.63.129.16:53
CPU 02: MARK 0x2013f5c8 FROM 3372 DEBUG: Conntrack lookup 2/2: nexthdr=17 flags=1 dir=0 scope=2
CPU 02: MARK 0x2013f5c8 FROM 3372 DEBUG: CT entry found lifetime=184799, revnat=0
CPU 02: MARK 0x2013f5c8 FROM 3372 DEBUG: CT verdict: Established, revnat=0
CPU 02: MARK 0x2013f5c8 FROM 3372 DEBUG: Successfully mapped addr=168.63.129.16 to identity=16777217
CPU 02: MARK 0x2013f5c8 FROM 3372 DEBUG: Matched L4 policy; creating conntrack src=16777217 dst=1 dport=53 proto=17
-> proxy port 38101 flow 0x2013f5c8 , identity host->unknown state established ifindex 0 orig-ip 0.0.0.0: 172.19.0.2:40573 -> 168.63.129.16:53 udp
-> network flow 0x2013f5c8 , identity host->unknown state established ifindex eth0 orig-ip 0.0.0.0: 172.19.0.2:40573 -> 168.63.129.16:53 udp
```

This is with CiliumClusterwideNetworkPolicy fragment

```yaml
- egress:
    - toCIDR:
      - 168.63.129.16/32
      toPorts:
      - ports:
        - port: "53"
          protocol: ANY
        rules:
          dns:
          - matchPattern: '*'
    - toFQDNs:
      - matchName: api.ipify.org # for testing
    nodeSelector: {}
```

and enforcement set to audit. What am I doing wrong? Also, if it is possible to reopen the old PR, I will move these commits and this conversation there, as seems more appropriate.