### PR TITLE
helm: Support configuring imagePullSecrets for spire agent/server pods

### DIFF
--- a/install/kubernetes/cilium/templates/spire/agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/daemonset.yaml
@@ -39,6 +39,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init
           image: {{ include "cilium.image" .Values.authentication.mutual.spire.install.initImage | quote }}

--- a/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
@@ -38,6 +38,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if gt (len .Values.authentication.mutual.spire.install.server.initContainers) 0 }}
       initContainers:
         {{- toYaml .Values.authentication.mutual.spire.install.server.initContainers | nindent 8 }}


### PR DESCRIPTION
I've been noticing spire failing to pull images in conformance tests a few times recently, and noticed we don't have anyway to configure image pull secrets for these pods, so let's start there.

Note: the spire images come from a different registry than the rest of our images, however, the image pull secret format supports configuring multiple credentials based on the registry URI in the same file. Additionally, it's possible to configure multiple image pull secrets on a pod. So there shouldn't be any major issues with this using the same `.Values.imagePullSecrets` as the rest of the components, since you can configure it by registry (either in a single secret, or via multiple secrets).
 
 Since this might be helpful for CI, I'm nominating it for backport to v1.16.

```release-note
 Support configuring imagePullSecrets for spire agent/server pods
```