### PR TITLE
policy: Avoid crashing due to index out of range

### DIFF
--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -1097,6 +1097,13 @@ func (ms *mapState) revertChanges(identities Identities, changes ChangeState) {
 // Incremental changes performed are recorded in 'adds' and 'deletes', if not nil.
 // See https://docs.google.com/spreadsheets/d/1WANIoZGB48nryylQjjOw6lKjI80eVgPShrdMTMalLEw#gid=2109052536 for details
 func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStateEntry, identities Identities, features policyFeatures, changes ChangeState) {
+	// Sanity check on the newKey
+	if newKey.TrafficDirection >= trafficdirection.Invalid.Uint8() {
+		stacktrace := hclog.Stacktrace()
+		log.Errorf("mapState.denyPreferredInsertWithChanges: invalid traffic direction in key: %d. Stacktrace: %s",
+			newKey.TrafficDirection, stacktrace)
+		return
+	}
 	// Skip deny rules processing if the policy in this direction has no deny rules
 	if !features.contains(denyRules) {
 		ms.authPreferredInsert(newKey, newEntry, identities, features, changes)


### PR DESCRIPTION
Check Key.TrafficDirection for invalid values before using it to index an array. Return from denyPreferredInsertWithChanges() without doing anything if the given key has an invalid traffic direction. Dump a stack trace into logs if this happens so that we can trace where the invalid key originates from.

Fixes: #33313
