### PR TITLE
Ignore the link-local IPv6 addresses in generic veth chain

### DIFF
--- a/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
+++ b/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
@@ -96,7 +96,16 @@ func (f *GenericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.Plug
 
 			addrsv6, err := netlink.AddrList(link, netlink.FAMILY_V6)
 			if err == nil && len(addrsv6) > 0 {
-				vethIPv6 = addrsv6[0].IPNet.IP.String()
+				if len(addrsv6) == 1 {
+					vethIPv6 = addrsv6[0].IPNet.IP.String()
+				} else {
+					for _, addrv6 := range addrsv6 {
+						if addrv6.IP.IsGlobalUnicast() {
+							vethIPv6 = addrv6.IPNet.IP.String()
+							break
+						}
+					}
+				}
 			} else if err != nil {
 				pluginCtx.Logger.WithError(err).WithField(logfields.Interface, link.Attrs().Name).Warn("No valid IPv6 address found")
 			}


### PR DESCRIPTION
Ignore the link-local IPv6 addresses as it is generated based on the MAC address and is not actually reachable within the network. 
Additionally, in some network plugins, the MAC addresses in pods may be the same, leading to conflicts in the generated IPv6 addresses and preventing the creation of Cilium endpoints.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
generic-veth will ignore the automatically generated link-local IPv6 addresses on the link.
```
