### PR TITLE
bpf: lxc: limit nodeport RevDNAT support to IPsec configurations

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1591,10 +1591,10 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, int ifindex, __u32 src_
 
 skip_policy_enforcement:
 	if (ret == CT_NEW) {
-#ifdef ENABLE_NODEPORT
+#if defined(ENABLE_NODEPORT) && defined(ENABLE_IPSEC)
 		ct_state_new.node_port = ct_has_nodeport_egress_entry6(get_ct_map6(tuple),
 								       tuple, NULL, false);
-#endif /* ENABLE_NODEPORT */
+#endif /* ENABLE_NODEPORT && ENABLE_IPSEC */
 		ct_state_new.src_sec_id = src_label;
 		ct_state_new.from_tunnel = from_tunnel;
 		ct_state_new.proxy_redirect = *proxy_port > 0;
@@ -1937,10 +1937,13 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, int ifindex, __u32 src_la
 
 skip_policy_enforcement:
 	if (ret == CT_NEW) {
-#ifdef ENABLE_NODEPORT
+#if defined(ENABLE_NODEPORT) && defined(ENABLE_IPSEC)
+		/* Needed for hostport support, until
+		 * https://github.com/cilium/cilium/issues/32897 is fixed.
+		 */
 		ct_state_new.node_port = ct_has_nodeport_egress_entry4(get_ct_map4(tuple),
 								       tuple, NULL, false);
-#endif /* ENABLE_NODEPORT */
+#endif /* ENABLE_NODEPORT && ENABLE_IPSEC */
 		ct_state_new.src_sec_id = src_label;
 		ct_state_new.from_tunnel = from_tunnel;
 		ct_state_new.proxy_redirect = *proxy_port > 0;


### PR DESCRIPTION
bpf_lxc currently marks all nodeport-ish connections in the CT entry, and
performs RevDNAT for their replies in from-container.

But we typically want to perform RevDNAT for nodeport-ish connections at
the node's egress interface, after the traffic has passed through eg. the
L7 proxy. This requires a RevDNAT hook in the relevant code path - in
either to-overlay, to-netdev or more recently also to-wireguard.

IPsec is the exception here, as there is currently no RevDNAT hook in the
IPsec path when forwarding traffic to the XFRM layer
(see https://github.com/cilium/cilium/issues/32897). Hence we continue
to apply RevDNAT in from-container whenever IPsec is enabled, until
#32897 has been addressed. But for all other configurations we can disable
the RevDNAT support in bpf_lxc, so that new connections use the "native"
RevDNAT path. This allows us to eventually phase out the RevDNAT path in
bpf_lxc, similar as has been done for DSR in
https://github.com/cilium/cilium/pull/32642.