### PR TITLE
.github: Update tests-ipsec-upgrade to use fork of workflow-telemetry-action

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -180,7 +180,7 @@ jobs:
     timeout-minutes: 70
     steps:
       - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
+        uses: chancez/workflow-telemetry-action@pr/chancez/quote_step_names
         with:
           comment_on_pr: false
 


### PR DESCRIPTION
Running on my branch of the workflow-telemetry-action with https://github.com/catchpoint/workflow-telemetry-action/pull/77 to see if it can help the rendering problem in https://github.com/cilium/cilium/issues/32241.

If this works I'll report back in https://github.com/catchpoint/workflow-telemetry-action/pull/77. However there's not been many recent releases so we'll have to see how they respond if we want this fix.