### PR TITLE
v1.16 backports 2024-07-23

### DIFF
--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -56,8 +56,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-vm
-  vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-vm
+  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
+  vmName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   vmStartupScript: .github/gcp-vm-startup.sh
   cilium_cli_ci_version:
   USE_GKE_GCLOUD_AUTH_PLUGIN: True

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -27,7 +27,7 @@ env:
 jobs:
   kubernetes-e2e:
     name: Installation and Conformance Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER }}
     timeout-minutes: 45
     strategy:
       fail-fast: false

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -27,7 +27,7 @@ env:
 jobs:
   kubernetes-e2e:
     name: Installation and Conformance Test
-    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER }}
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER || 'ubuntu-latest' }}
     timeout-minutes: 45
     strategy:
       fail-fast: false

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -153,22 +153,20 @@ jobs:
             # ingress-controller: 'true'
             bgp-control-plane: 'true'
 
-#          Disable until https://github.com/cilium/cilium/issues/32689
-#          is resolved.
-#          - name: '7'
-#            # renovate: datasource=docker depName=quay.io/lvh-images/kind
-#            kernel: '6.6-20240710.064909'
-#            kube-proxy: 'none'
-#            kpr: 'true'
-#            devices: '{eth0,eth1}'
-#            secondary-network: 'true'
-#            tunnel: 'disabled'
-#            lb-mode: 'snat'
-#            egress-gateway: 'true'
-#            lb-acceleration: 'testing-only'
-#            # Disable until https://github.com/cilium/cilium/issues/30717
-#            # has been resolved.
-#            # ingress-controller: 'true'
+          - name: '7'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: '6.6-20240710.064909'
+            kube-proxy: 'none'
+            kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
+            tunnel: 'disabled'
+            lb-mode: 'snat'
+            egress-gateway: 'true'
+            lb-acceleration: 'testing-only'
+            # Disable until https://github.com/cilium/cilium/issues/30717
+            # has been resolved.
+            # ingress-controller: 'true'
 
           - name: '8'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -109,6 +109,9 @@ issues:
     - path: "pkg/ipam/(cidrset|service)/.+\\.go"
       linters:
         - goheader
+    - path: "pkg/hubble/dropeventemitter/fake_recorder.go"
+      linters:
+        - goheader
 
 linters:
   disable-all: true

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -200,7 +200,7 @@ cilium-agent [flags]
       --http-retry-count uint                                     Number of retries performed after a forwarded request attempt fails (default 3)
       --http-retry-timeout uint                                   Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --hubble-disable-tls                                        Allow Hubble server to run on the given listen address without TLS.
-      --hubble-drop-events                                        Emit packet drop Events related to pods
+      --hubble-drop-events                                        Emit packet drop Events related to pods (alpha)
       --hubble-drop-events-interval duration                      Minimum time between emitting same events (default 2m0s)
       --hubble-drop-events-reasons string                         Drop reasons to emit events for (default "auth_required,policy_denied")
       --hubble-event-buffer-capacity int                          Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1529,7 +1529,7 @@
      - object
      - ``{}``
    * - :spelling:ignore:`hubble.dropEventEmitter`
-     - Emit v1.Events related to pods on detection of packet drops.
+     - Emit v1.Events related to pods on detection of packet drops.    This feature is alpha, please provide feedback at https://github.com/cilium/cilium/issues/33975.
      - object
      - ``{"enabled":false,"interval":"2m","reasons":["auth_required","policy_denied"]}``
    * - :spelling:ignore:`hubble.dropEventEmitter.interval`

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1594,10 +1594,10 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, int ifindex, __u32 src_
 
 skip_policy_enforcement:
 	if (ret == CT_NEW) {
-#ifdef ENABLE_NODEPORT
+#if defined(ENABLE_NODEPORT) && defined(ENABLE_IPSEC)
 		ct_state_new.node_port = ct_has_nodeport_egress_entry6(get_ct_map6(tuple),
 								       tuple, NULL, false);
-#endif /* ENABLE_NODEPORT */
+#endif /* ENABLE_NODEPORT && ENABLE_IPSEC */
 		ct_state_new.src_sec_id = src_label;
 		ct_state_new.from_tunnel = from_tunnel;
 		ct_state_new.proxy_redirect = *proxy_port > 0;
@@ -1941,10 +1941,13 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, int ifindex, __u32 src_la
 
 skip_policy_enforcement:
 	if (ret == CT_NEW) {
-#ifdef ENABLE_NODEPORT
+#if defined(ENABLE_NODEPORT) && defined(ENABLE_IPSEC)
+		/* Needed for hostport support, until
+		 * https://github.com/cilium/cilium/issues/32897 is fixed.
+		 */
 		ct_state_new.node_port = ct_has_nodeport_egress_entry4(get_ct_map4(tuple),
 								       tuple, NULL, false);
-#endif /* ENABLE_NODEPORT */
+#endif /* ENABLE_NODEPORT && ENABLE_IPSEC */
 		ct_state_new.src_sec_id = src_label;
 		ct_state_new.from_tunnel = from_tunnel;
 		ct_state_new.proxy_redirect = *proxy_port > 0;

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -983,7 +983,7 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.StringSlice(option.HubbleRedactHttpHeadersDeny, []string{}, "HTTP headers to redact from flows")
 	option.BindEnv(vp, option.HubbleRedactHttpHeadersDeny)
 
-	flags.Bool(option.HubbleDropEvents, defaults.HubbleDropEventsEnabled, "Emit packet drop Events related to pods")
+	flags.Bool(option.HubbleDropEvents, defaults.HubbleDropEventsEnabled, "Emit packet drop Events related to pods (alpha)")
 	option.BindEnv(vp, option.HubbleDropEvents)
 
 	flags.Duration(option.HubbleDropEventsInterval, defaults.HubbleDropEventsInterval, "Minimum time between emitting same events")

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -147,6 +147,10 @@ func (d *Daemon) cleanupHealthEndpoint() {
 		d.deleteEndpointRelease(ep, true)
 	}
 
+	// The CNI plugin is not invoked for the health endpoint since it was
+	// spawned by the agent itself. The endpoint manager will only down the
+	// device, but not remove it. Hence we need to trigger final removal.
+
 	// Delete the process
 	health.KillEndpoint()
 

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -121,6 +121,8 @@ func (d *Daemon) initHealth(spec *healthApi.Spec, cleaner *daemonCleanup, sysctl
 }
 
 func (d *Daemon) cleanupHealthEndpoint() {
+	log.Info("Cleaning up Cilium health endpoint")
+
 	// Delete the process
 	health.KillEndpoint()
 
@@ -145,5 +147,7 @@ func (d *Daemon) cleanupHealthEndpoint() {
 			log.WithError(err).Debug("Error occurred while deleting cilium-health endpoint")
 		}
 	}
+
+	// Remove health endpoint devices
 	health.CleanupEndpoint()
 }

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -101,6 +101,12 @@ func (d *Daemon) initHealth(spec *healthApi.Spec, cleaner *daemonCleanup, sysctl
 							return fmt.Errorf("failed to restart endpoint (check failed: %w): %w", err, launchErr)
 						}
 						return launchErr
+					} else {
+						// Now that we relaunched, retry so that the cleanup and time
+						// to bring up the health endpoint does not skew the probing
+						if pingErr := client.PingEndpoint(); pingErr == nil {
+							lastSuccessfulPing = time.Now()
+						}
 					}
 				}
 				return err

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -117,8 +117,7 @@ func (d *Daemon) initHealth(spec *healthApi.Spec, cleaner *daemonCleanup, sysctl
 	)
 
 	// Make sure to clean up the endpoint namespace when cilium-agent terminates
-	cleaner.cleanupFuncs.Add(health.KillEndpoint)
-	cleaner.cleanupFuncs.Add(health.CleanupEndpoint)
+	cleaner.cleanupFuncs.Add(d.cleanupHealthEndpoint)
 }
 
 func (d *Daemon) cleanupHealthEndpoint() {

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -133,6 +133,7 @@ func (d *Daemon) launchHubble() {
 			option.Config.HubbleDropEventsInterval,
 			option.Config.HubbleDropEventsReasons,
 			d.clientset,
+			d.k8sWatcher,
 		)
 
 		observerOpts = append(observerOpts,

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -432,7 +432,7 @@ contributors across the globe, there is almost always someone available to help.
 | hostFirewall.enabled | bool | `false` | Enables the enforcement of host policies in the eBPF datapath. |
 | hostPort.enabled | bool | `false` | Enable hostPort service support. |
 | hubble.annotations | object | `{}` | Annotations to be added to all top-level hubble objects (resources under templates/hubble) |
-| hubble.dropEventEmitter | object | `{"enabled":false,"interval":"2m","reasons":["auth_required","policy_denied"]}` | Emit v1.Events related to pods on detection of packet drops. |
+| hubble.dropEventEmitter | object | `{"enabled":false,"interval":"2m","reasons":["auth_required","policy_denied"]}` | Emit v1.Events related to pods on detection of packet drops.    This feature is alpha, please provide feedback at https://github.com/cilium/cilium/issues/33975. |
 | hubble.dropEventEmitter.interval | string | `"2m"` | - Minimum time between emitting same events. |
 | hubble.dropEventEmitter.reasons | list | `["auth_required","policy_denied"]` | - Drop reasons to emit events for. ref: https://docs.cilium.io/en/stable/_api/v1/flow/README/#dropreason |
 | hubble.enabled | bool | `true` | Enable Hubble (true by default). |

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -78,14 +78,33 @@ spec:
             grpc:
               port: 4222
             timeoutSeconds: 3
+          # livenessProbe will kill the pod, we should be very conservative
+          # here on failures since killing the pod should be a last resort, and
+          # we should provide enough time for relay to retry before killing it.
           livenessProbe:
             grpc:
               port: 4222
-            timeoutSeconds: 3
+            timeoutSeconds: 10
+            # Give relay time to establish connections and make a few retries
+            # before starting livenessProbes.
+            initialDelaySeconds: 10
+            # 10 second * 12 failures = 2 minutes of failure.
+            # If relay cannot become healthy after 2 minutes, then killing it
+            # might resolve whatever issue is occurring.
+            #
+            # 10 seconds is a reasonable retry period so we can see if it's
+            # failing regularly or only sporadically.
+            periodSeconds: 10
+            failureThreshold: 12
           startupProbe:
             grpc:
               port: 4222
+            # Give relay time to get it's certs and establish connections and
+            # make a few retries before starting startupProbes.
+            initialDelaySeconds: 10
+            # 20 * 3 seconds = 1 minute of failure before we consider startup as failed.
             failureThreshold: 20
+            # Retry more frequently at startup so that it can be considered started more quickly.
             periodSeconds: 3
           {{- with .Values.hubble.relay.extraEnv }}
           env:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1721,6 +1721,7 @@ hubble:
             #     excludeFilters: []
             #     end: "2023-10-09T23:59:59-07:00"
   # -- Emit v1.Events related to pods on detection of packet drops.
+  #    This feature is alpha, please provide feedback at https://github.com/cilium/cilium/issues/33975.
   dropEventEmitter:
     enabled: false
     # --- Minimum time between emitting same events.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1727,6 +1727,7 @@ hubble:
             #     end: "2023-10-09T23:59:59-07:00"
 
   # -- Emit v1.Events related to pods on detection of packet drops.
+  #    This feature is alpha, please provide feedback at https://github.com/cilium/cilium/issues/33975.
   dropEventEmitter:
     enabled: false
     # --- Minimum time between emitting same events.

--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -106,10 +106,21 @@ func (n *linuxNodeHandler) allocateIDForNode(oldNode *nodeTypes.Node, node *node
 
 	for _, addr := range node.IPAddresses {
 		ip := addr.IP.String()
-		if _, exists := n.nodeIDsByIPs[ip]; exists {
+		if id, exists := n.nodeIDsByIPs[ip]; exists && id == nodeID {
 			if !SPIChanged {
 				continue
 			}
+		} else if exists && id != nodeID {
+			// The map is in an inconsistent state. This can occur when a node
+			// is deleted while the agent is down and its IPs are reused. To
+			// allocate a fresh ID, unmap the IPs of this node, and try again.
+			for _, addr := range node.IPAddresses {
+				if err := n.unmapNodeID(addr.IP.String()); err != nil {
+					n.log.Error("Failed to unmap stale nodeID mapping", logfields.IPAddr, ip, logfields.Error, err)
+				}
+			}
+
+			return n.allocateIDForNode(oldNode, node)
 		}
 		if err := n.mapNodeID(ip, nodeID, node.EncryptionKey); err != nil {
 			n.log.Error("Failed to map node IP address to allocated ID",

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -532,6 +532,10 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 	stats.waitingForLock.End(true)
 	defer e.owner.GetCompilationLock().RUnlock()
 
+	if err := e.aliveCtx.Err(); err != nil {
+		return 0, fmt.Errorf("endpoint was closed while waiting for datapath lock: %w", err)
+	}
+
 	datapathRegenCtxt.prepareForProxyUpdates(regenContext.parentContext)
 	defer datapathRegenCtxt.completionCancel()
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2474,6 +2474,12 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 
 	e.Stop()
 
+	// Wait for any pending endpoint regenerate() calls to finish. The
+	// latter bails out after taking the lock when it detects that the
+	// endpoint state is disconnecting.
+	e.buildMutex.Lock()
+	defer e.buildMutex.Unlock()
+
 	// Lock out any other writers to the endpoint.  In case multiple delete
 	// requests have been enqueued, have all of them except the first
 	// return here. Ignore the request if the endpoint is already

--- a/pkg/hubble/dropeventemitter/fake_recorder.go
+++ b/pkg/hubble/dropeventemitter/fake_recorder.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2015 The Kubernetes Authors.
+
+package dropeventemitter
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+)
+
+// FakeRecorder is used as a fake during tests. It is thread safe. It is usable
+// when created manually and not by NewFakeRecorder, however all events may be
+// thrown away in this case.
+type FakeRecorder struct {
+	Events chan string
+
+	IncludeObject bool
+}
+
+func objectString(object runtime.Object, includeObject bool) string {
+	if !includeObject {
+		return ""
+	}
+	return fmt.Sprintf(" involvedObject{kind=%s,apiVersion=%s}",
+		object.GetObjectKind().GroupVersionKind().Kind,
+		object.GetObjectKind().GroupVersionKind().GroupVersion(),
+	)
+}
+
+func annotationsString(annotations map[string]string) string {
+	if len(annotations) == 0 {
+		return ""
+	} else {
+		return " " + fmt.Sprint(annotations)
+	}
+}
+
+func (f *FakeRecorder) writeEvent(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	if f.Events != nil {
+		f.Events <- fmt.Sprintf(eventtype+" "+reason+" "+messageFmt, args...) +
+			objectString(object, f.IncludeObject) + annotationsString(annotations)
+	}
+}
+
+func (f *FakeRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	f.writeEvent(object, nil, eventtype, reason, "%s", message)
+}
+
+func (f *FakeRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	f.writeEvent(object, nil, eventtype, reason, messageFmt, args...)
+}
+
+func (f *FakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	f.writeEvent(object, annotations, eventtype, reason, messageFmt, args...)
+}
+
+func (f *FakeRecorder) WithLogger(logger klog.Logger) record.EventRecorderLogger {
+	return f
+}
+
+// NewFakeRecorder creates new fake event recorder with event channel with
+// buffer of given size.
+func NewFakeRecorder(bufferSize int) *FakeRecorder {
+	return &FakeRecorder{
+		Events: make(chan string, bufferSize),
+	}
+}

--- a/pkg/hubble/dropeventemitter/fake_recorder.go
+++ b/pkg/hubble/dropeventemitter/fake_recorder.go
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2015 The Kubernetes Authors.
 
+// Copy of client-go/tools/record/fake.go
+// Duplicated this since there's no easy way to access UID from client-go's fake recorder
+
 package dropeventemitter
 
 import (
@@ -21,12 +24,18 @@ type FakeRecorder struct {
 }
 
 func objectString(object runtime.Object, includeObject bool) string {
+	var uid string
+	uo, err := runtime.DefaultUnstructuredConverter.ToUnstructured(object)
+	if err != nil && uo["metadata"] != nil && uo["metadata"].(map[string]interface{})["uid"] != nil {
+		uid = uo["metadata"].(map[string]interface{})["uid"].(string)
+	}
 	if !includeObject {
 		return ""
 	}
-	return fmt.Sprintf(" involvedObject{kind=%s,apiVersion=%s}",
+	return fmt.Sprintf(" involvedObject{kind=%s,apiVersion=%s,uid=%s}",
 		object.GetObjectKind().GroupVersionKind().Kind,
 		object.GetObjectKind().GroupVersionKind().GroupVersion(),
+		uid,
 	)
 }
 

--- a/pkg/hubble/relay/defaults/defaults.go
+++ b/pkg/hubble/relay/defaults/defaults.go
@@ -16,7 +16,7 @@ const (
 	ClusterName = ciliumDefaults.ClusterName
 	// DialTimeout is the timeout that is used when establishing a new
 	// connection.
-	DialTimeout = 5 * time.Second
+	DialTimeout = 30 * time.Second
 	// HealthCheckInterval is the time interval between health checks.
 	HealthCheckInterval = 5 * time.Second
 	// GopsPort is the default port for gops to listen on.

--- a/pkg/hubble/relay/pool/manager_test.go
+++ b/pkg/hubble/relay/pool/manager_test.go
@@ -613,7 +613,7 @@ func TestPeerManager(t *testing.T) {
 					},
 				},
 				log: []string{
-					`level=warning msg="Failed to create gRPC client" address="192.0.1.1:4244" error="Don't feel like workin' today" hubble-tls=false next-try-in=10s peer=unreachable`,
+					`level=warning msg="Failed to create gRPC client" address="192.0.1.1:4244" error="Don't feel like workin' today" hubble-tls=false next-try-in=1s peer=unreachable`,
 				},
 			},
 		}, {

--- a/pkg/hubble/relay/pool/option.go
+++ b/pkg/hubble/relay/pool/option.go
@@ -33,8 +33,8 @@ var defaultOptions = options{
 		},
 	},
 	backoff: &backoff.Exponential{
-		Min:    10 * time.Second,
-		Max:    90 * time.Minute,
+		Min:    time.Second,
+		Max:    time.Minute,
 		Factor: 2.0,
 	},
 	connCheckInterval:  2 * time.Minute,

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -107,6 +107,11 @@ type cgroupManager interface {
 	OnDeletePod(pod *slim_corev1.Pod)
 }
 
+type CacheAccessK8SWatcher interface {
+	GetCachedNamespace(namespace string) (*slim_corev1.Namespace, error)
+	GetCachedPod(namespace, name string) (*slim_corev1.Pod, error)
+}
+
 type ipcacheManager interface {
 	// GH-21142: Re-evaluate the need for these APIs
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (namedPortsChanged bool, err error)


### PR DESCRIPTION
v1.16 backports 2024-07-23

 - [x] #33865 -- gha: use GH_RUNNER_EXTRA_POWER for conformance-k8s-kind workflow (@giorio94)
 - [x] #33882 -- loader: work around race in ebpf.MapSpec.createMap (@lmb)
 - [ ] #33296 -- Attach hubble packet drop events on egress to source pod (@hemanthmalla)
 - [x] #33940 -- gha: configure fallback runner type for conformance-k8s-kind workflow (@giorio94)
 - [x] #33939 -- gha: shorten conformance-externalworkloads cluster name (@giorio94)
 - [x] #33960 -- bpf: lxc: limit nodeport RevDNAT support to IPsec configurations (@julianwiedmann)
 - [x] #33666 -- linux/node: reallocate nodeID upon conflict (@bimmlerd)
 - [x] #33700 -- cilium: Small health cleanup improvements (@borkmann)
   - ⚠️ Minor conflict where v1.16 uses Linux 6.6 instead of bpf-next in the github workflow.
 - [ ] #33894 -- Make hubble-relay more resilient to transient errors (@chancez)
 - [x] #33977 -- daemon: Mark --hubble-drop-events as alpha (@joestringer)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
33865 33882 33296 33940 33939 33960 33666 33700 33894 33977
```
