### PR TITLE
ClusterMesh: improve validation of IPs to identities mappings

### DIFF
--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -209,6 +209,7 @@ func (rc *remoteCluster) ipCacheWatcherOpts(config *cmtypes.CiliumClusterConfig)
 
 	if config != nil {
 		opts = append(opts, ipcache.WithCachedPrefix(config.Capabilities.Cached))
+		opts = append(opts, ipcache.WithIdentityValidator(config.ID))
 	}
 
 	if rc.ipCacheWatcherExtraOpts != nil {

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -6,6 +6,7 @@ package ipcache
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/netip"
 	"path"
@@ -165,6 +166,7 @@ type IPIdentityWatcher struct {
 	clusterID                  uint32
 	source                     source.Source
 	withSelfDeletionProtection bool
+	validators                 []ipIdentityValidator
 
 	started bool
 	synced  chan struct{}
@@ -198,12 +200,14 @@ func NewIPIdentityWatcher(
 	return &watcher
 }
 
+type ipIdentityValidator func(*identity.IPIdentityPair) error
 type IWOpt func(*iwOpts)
 
 type iwOpts struct {
 	clusterID              uint32
 	selfDeletionProtection bool
 	cachedPrefix           bool
+	validators             []ipIdentityValidator
 }
 
 // WithClusterID configures the ClusterID associated with the given watcher.
@@ -231,6 +235,33 @@ func WithCachedPrefix(cached bool) IWOpt {
 	}
 }
 
+// WithIdentityValidator registers a validation function to ensure that the
+// observed IPs are associated with an identity belonging to the expected range.
+func WithIdentityValidator(clusterID uint32) IWOpt {
+	return func(opts *iwOpts) {
+		min := identity.GetMinimalAllocationIdentity(clusterID)
+		max := identity.GetMaximumAllocationIdentity(clusterID)
+
+		validator := func(pair *identity.IPIdentityPair) error {
+			switch {
+			// The identity belongs to the expected range based on the Cluster ID.
+			case pair.ID >= min && pair.ID <= max:
+				return nil
+
+			// Allow all reserved IDs as well, including well-known and
+			// user-reserved identities, as they are not scoped by Cluster ID.
+			case pair.ID < identity.MinimalNumericIdentity:
+				return nil
+
+			default:
+				return fmt.Errorf("ID %d does not belong to the allocation range of cluster ID %d", pair.ID, clusterID)
+			}
+		}
+
+		opts.validators = append(opts.validators, validator)
+	}
+}
+
 // Watch starts the watcher and blocks waiting for events, until the context is
 // closed. When events are received from the kvstore, all IPIdentityMappingListener
 // are notified. It automatically emits deletion events for stale keys when appropriate
@@ -255,6 +286,7 @@ func (iw *IPIdentityWatcher) Watch(ctx context.Context, backend storepkg.WatchSt
 	iw.started = true
 	iw.clusterID = iwo.clusterID
 	iw.withSelfDeletionProtection = iwo.selfDeletionProtection
+	iw.validators = iwo.validators
 	iw.store.Watch(ctx, backend, prefix)
 }
 
@@ -298,6 +330,14 @@ func (iw *IPIdentityWatcher) OnUpdate(k storepkg.Key) {
 	}
 
 	iw.log.WithField(logfields.IPAddr, ip).Debug("Observed upsertion event")
+
+	for _, validator := range iw.validators {
+		if err := validator(ipIDPair); err != nil {
+			log.WithError(err).WithField(logfields.IPAddr, ip).
+				Warning("Skipping invalid upsertion event")
+			return
+		}
+	}
 
 	var k8sMeta *K8sMetadata
 	if ipIDPair.K8sNamespace != "" || ipIDPair.K8sPodName != "" || len(ipIDPair.NamedPorts) > 0 {


### PR DESCRIPTION
Explicitly validate that the endpoints retrieved from a remote cluster are associated with identities that match the expected range based on the corresponding clusterID, to ensure improved consistency and prevent the propagation of corrupted data. Please refer to the individual commit messages for additional details.

Related: https://github.com/cilium/cilium/pull/32785

<!-- Description of change -->

```release-note
ClusterMesh: improve validation of IPs to identities mappings
```
