### PR TITLE
dnsproxy: fix error when sessionUDPFactory fails

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -1283,8 +1283,8 @@ func bindToAddr(address string, port uint16, handler dns.Handler, ipv4, ipv6 boo
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to listen on %s: %w", ipFamily.UDPAddress, err)
 		}
-		sessionUDPFactory, ferr := NewSessionUDPFactory(ipFamily)
-		if ferr != nil {
+		sessionUDPFactory, err := NewSessionUDPFactory(ipFamily)
+		if err != nil {
 			return nil, 0, fmt.Errorf("failed to create UDP session factory for %s: %w", ipFamily.UDPAddress, err)
 		}
 		dnsServers = append(dnsServers, &dns.Server{


### PR DESCRIPTION
Fixes: #28163

Before, we were always printing nil from previous err rather than current ferr.

I've asked you @mhofstetter for review  just to double check as I wasn't sure if you wanted to have separate error for some side-effect with `ferr` / `err`:thinking:? I couldn't find anything though. 