### PR TITLE
Remove extraneous call to cidr.Addr()

### DIFF
--- a/pkg/maps/ipmasq/ipmasq.go
+++ b/pkg/maps/ipmasq/ipmasq.go
@@ -83,8 +83,6 @@ func IPMasq6Map() *bpf.Map {
 type IPMasqBPFMap struct{}
 
 func (*IPMasqBPFMap) Update(cidr netip.Prefix) error {
-	cidr.Addr()
-
 	if cidr.Addr().Is4() {
 		if option.Config.EnableIPv4Masquerade {
 			return IPMasq4Map().Update(keyIPv4(cidr), &Value{})


### PR DESCRIPTION
This is a small typo fix.

Follow up to https://github.com/cilium/cilium/pull/33925