### PR TITLE
test: use cgr.dev/chainguard/busybox:latest instead of docker.io image.

### DIFF
--- a/test/k8s/manifests/frr.yaml.tmpl
+++ b/test/k8s/manifests/frr.yaml.tmpl
@@ -10,7 +10,7 @@ spec:
   hostNetwork: true
   initContainers:
   - name: init
-    image: busybox:1.28
+    image: cgr.dev/chainguard/busybox:latest
     securityContext:
       privileged: true
     command:

--- a/test/k8s/manifests/pod_mac_address.yaml
+++ b/test/k8s/manifests/pod_mac_address.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: specific-mac-address
-      image: busybox:1.36
+      image: cgr.dev/chainguard/busybox:latest
       command:
         - sleep
         - "3600"

--- a/test/vtep/busybox-master.yaml
+++ b/test/vtep/busybox-master.yaml
@@ -11,6 +11,6 @@ spec:
     dedicated: master
   containers:
   - name: busybox
-    image: busybox
+    image: cgr.dev/chainguard/busybox:latest
     imagePullPolicy: IfNotPresent
     command: ['sh', '-c', 'echo Container 1 is Running ; sleep 3600']


### PR DESCRIPTION
Right now, we're seeing regular ImagePullBackoffs on test images being pulled from docker.io.  Switching busybox off of the docker.io image should reduce pressure on the ratelimit and reduce flakes.

As a follow up, I'll track failures in ci-ginkgo and begin to move other images to quay.io as needed.

Running this through CI a couple times, I didn't see any pull issues (but that could just be the time of day) so the plan is to merge this and see if it makes any difference in CI failures.

**note:** the chainguard repo only allows unauthenticated access to "latest" versions, but this should be fine for test containers just using busybox.