### PR TITLE
[v1.16] docs: Add note for CNP empty slices semantic under v1.16 section

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -391,6 +391,14 @@ communicating via the proxy must reconnect to re-establish connections.
 * For IPsec, the use of per-tunnel keys is mandatory, via the use of the ``+``
   sign in the secret. See the :ref:`encryption_ipsec` guide for more
   information.
+* ``CiliumNetworkPolicy`` changed the semantics of the empty non-nil slice.
+  For an Ingress CNP, an empty slice in one of the fields ``fromEndpoints``, ``fromCIDR``,
+  ``fromCIDRSet`` and ``fromEntities`` will not select any identity, thus falling back to
+  default deny for an allow policy. Similarly, for an Egress CNP, an empty slice in one of
+  the fields ``toEndpoints``, ``toCIDR``, ``toCIDRSet`` and ``toEntities`` will not select
+  any identity either. Additionally, the behaviour of a CNP with ``toCIDRSet`` or
+  ``fromCIDRSet`` selectors using ``cidrGroupRef`` targeting only non-existent CIDR groups
+  was changed from allow-all to deny-all to align with the new semantics.
 
 Removed Options
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
The semantic change for empty non-nil slice in CNPs targeted v1.16, but the related release note was inadvertently appended under the "v1.15 Upgrade Notes" section (see PR https://github.com/cilium/cilium/pull/29608). Therefore, that note was deleted when preparing the documentation for v1.16 in https://github.com/cilium/cilium/pull/33703

The PR adds back the upgrade note in the v1.16 section where it belongs.

Related: e47e295a04 ("docs: cleanup upgrade docs on 1.16")
Related: 966757d822 ("docs: add upgrade note for dangling cidrGroupRefs")
Fixes: 5f77d50ee3 ("docs: Add upgrade note for CNP empty slices new semantic")
