### PR TITLE
gha(update-label-backport): ignore leading 'v' in branch parameter

### DIFF
--- a/.github/workflows/update-label-backport-pr.yaml
+++ b/.github/workflows/update-label-backport-pr.yaml
@@ -40,10 +40,12 @@
           - name: Update labels
             env:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              BRANCH: ${{ inputs.branch }}
             run: |
+              VERSION=${BRANCH#v}
               echo "${{steps.pre-process.outputs.result}}" | sed -En "/upstream-prs/ { n; p }" | cut -d ';' -f 1 | grep -Eo '[0-9]+' | while read -r pr; do
-                echo "Removing label backport-pending/${{ inputs.branch }} from pr #${pr}."
-                gh pr edit ${pr} --repo "${GITHUB_REPOSITORY}" --remove-label backport-pending/${{ inputs.branch }}
-                echo "Adding label backport-done/${{ inputs.branch }} to pr #${pr}."
-                gh pr edit ${pr} --repo "${GITHUB_REPOSITORY}" --add-label backport-done/${{ inputs.branch }}
+                echo "Removing label backport-pending/${VERSION} from pr #${pr}."
+                gh pr edit ${pr} --repo "${GITHUB_REPOSITORY}" --remove-label backport-pending/${VERSION}
+                echo "Adding label backport-done/${VERSION} to pr #${pr}."
+                gh pr edit ${pr} --repo "${GITHUB_REPOSITORY}" --add-label backport-done/${VERSION}
               done


### PR DESCRIPTION
The blamed commit modified the call-backport-label-updater workflow to directly call the update-label-backport-pr reusable workflow passing github.base_ref as branch name, rather than manually computing it. However, the branch name includes a leading 'v' (e.g., v1.15), while the backport labels don't (e.g., backport-done/1.15), causing the update to fail. Let's fix this by removing the leading 'v' from the branch name, if present.

Successfully tested in my personal fork (last time I had incorrectly used backport labels with the leading v).

Fixes: e91378b34f94 ("gha: simplify the call-backport-label-updater workflow")