### PR TITLE
bugtool: dump cilium_skip_lb{4,6}

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -187,6 +187,8 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"tc/globals/cilium_l2_responder_v4",
 		"tc/globals/cilium_ratelimit",
 		"tc/globals/cilium_ratelimit_metrics",
+		"tc/globals/cilium_skip_lb4",
+		"tc/globals/cilium_skip_lb6",
 	}
 	commands = append(commands, bpfMapDumpCommands(bpfMapsPath)...)
 


### PR DESCRIPTION
Collect cilium_skip_lb{4,6} maps added by https://github.com/cilium/cilium/pull/26144 in sysdump

fixes: #33901