### PR TITLE
policy: Sanitize DNS Rules to Disallow Port Ranges

### DIFF
--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -420,7 +420,7 @@ func (pr *PortRule) sanitize(ingress bool) error {
 	for i := range pr.Ports {
 		var isZero bool
 		var err error
-		if isZero, err = pr.Ports[i].sanitize(); err != nil {
+		if isZero, err = pr.Ports[i].sanitize(hasDNSRules); err != nil {
 			return err
 		}
 		if isZero {
@@ -465,7 +465,7 @@ func (pr *PortRule) sanitize(ingress bool) error {
 	return nil
 }
 
-func (pp *PortProtocol) sanitize() (isZero bool, err error) {
+func (pp *PortProtocol) sanitize(hasDNSRules bool) (isZero bool, err error) {
 	if pp.Port == "" {
 		return isZero, fmt.Errorf("Port must be specified")
 	}
@@ -481,6 +481,9 @@ func (pp *PortProtocol) sanitize() (isZero bool, err error) {
 			return isZero, fmt.Errorf("Unable to parse port: %w", err)
 		}
 		isZero = p == 0
+		if hasDNSRules && pp.EndPort > int32(p) {
+			return isZero, errors.New("DNS rules do not support port ranges")
+		}
 	}
 
 	pp.Protocol, err = ParseL4Proto(string(pp.Protocol))

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -719,6 +719,34 @@ func TestL7Rules(t *testing.T) {
 	require.NotNil(t, err)
 }
 
+// This test ensures that DNS rules do not accept port ranges
+func TestPortRangesNotAllowedWithDNSRules(t *testing.T) {
+	// Rule is invalid because DNS rules do not support port ranges.
+	invalidPortRule := Rule{
+		EndpointSelector: WildcardEndpointSelector,
+		Egress: []EgressRule{
+			{
+				EgressCommonRule: EgressCommonRule{
+					ToEndpoints: []EndpointSelector{WildcardEndpointSelector},
+				},
+				ToPorts: []PortRule{{
+					Ports: []PortProtocol{
+						{Port: "443", EndPort: 445, Protocol: ProtoTCP},
+					},
+					Rules: &L7Rules{
+						DNS: []PortRuleDNS{
+							{MatchName: "www.google.com"},
+						},
+					},
+				}},
+			},
+		},
+	}
+	err := invalidPortRule.Sanitize()
+	require.NotNil(t, err)
+	require.Equal(t, "DNS rules do not support port ranges", err.Error())
+}
+
 // This test ensures that host policies with L7 rules are rejected.
 func TestL7RulesWithNodeSelector(t *testing.T) {
 	setUpSuite(t)


### PR DESCRIPTION
DNS rules do not (yet) support port ranges.


