### PR TITLE
Enable L7 DNS proxy for nodes

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -964,8 +964,9 @@ latter rule will have no effect.
           endpoint. This might change in the future when support for ranges is
           added.
 
-.. note:: Layer 7 rules are not currently supported in `HostPolicies`, i.e.,
-          policies that use :ref:`NodeSelector`.
+.. note:: In `HostPolicies`, i.e. policies that use :ref:`NodeSelector`,
+          only DNS layer 7 rules are currently supported.
+          Other types of layer 7 rules are not supported in `HostPolicies`.
 
 .. note:: Layer 7 policies will proxy traffic through a node-local :ref:`envoy`
           instance, which will either be deployed as a DaemonSet or embedded in the agent pod.

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -285,7 +285,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 			ret = __ipv6_host_policy_ingress(ctx, ip6, ct_buffer, &remote_id, &trace,
 							 ext_err);
 		}
-		if (IS_ERR(ret))
+		if (IS_ERR(ret) || ret == CTX_ACT_REDIRECT)
 			return ret;
 	}
 #endif /* ENABLE_HOST_FIREWALL */
@@ -716,7 +716,7 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 			ret = __ipv4_host_policy_ingress(ctx, ip4, ct_buffer, &remote_id, &trace,
 							 ext_err);
 		}
-		if (IS_ERR(ret))
+		if (IS_ERR(ret) || ret == CTX_ACT_REDIRECT)
 			return ret;
 	}
 #endif /* ENABLE_HOST_FIREWALL */
@@ -1425,6 +1425,9 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 		ret = DROP_UNKNOWN_L3;
 		break;
 	}
+
+	if (ret == CTX_ACT_REDIRECT)
+		return ret;
 
 	if (IS_ERR(ret))
 		goto drop_err;

--- a/bpf/lib/source_info.h
+++ b/bpf/lib/source_info.h
@@ -55,6 +55,7 @@ __id_for_file(const char *const header_name)
 	_strcase_(111, "trace.h");
 	_strcase_(112, "encap.h");
 	_strcase_(113, "encrypt.h");
+	_strcase_(114, "host_firewall.h");
 
 	/* @@ source files list end */
 

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -191,7 +191,7 @@ type restoredIPRule struct {
 type restoredEPs map[netip.Addr]*endpoint.Endpoint
 
 // asIPRule returns a new restore.IPRule representing the rules, including the provided IP map.
-func asIPRule(r *regexp.Regexp, IPs map[string]struct{}) restore.IPRule {
+func asIPRule(r *regexp.Regexp, IPs map[restore.RuleIPOrCIDR]struct{}) restore.IPRule {
 	pattern := "^-$"
 	if r != nil {
 		pattern = r.String()
@@ -216,12 +216,32 @@ func (p *DNSProxy) checkRestored(endpointID uint64, destPortProto restore.PortPr
 		}
 	}
 
+	dest, err := restore.ParseRuleIPOrCIDR(destIP)
+	if err != nil || !dest.IsAddr() {
+		return false
+	}
+
 	for i := range ipRules {
 		ipRule := ipRules[i]
-		if _, exists := ipRule.IPs[destIP]; exists || len(ipRule.IPs) == 0 {
-			if ipRule.regex != nil && ipRule.regex.MatchString(name) {
-				return true
+		if IPs := ipRule.IPs; len(IPs) == 0 {
+			// ok
+		} else if _, exists := IPs[dest]; exists {
+			// ok
+		} else if _, exists := IPs[dest.ToSingleCIDR()]; exists {
+			// ok
+		} else {
+			for ip := range IPs {
+				if ip.ContainsAddr(dest) {
+					exists = true
+					break
+				}
 			}
+			if !exists {
+				continue
+			}
+		}
+		if ipRule.regex != nil && ipRule.regex.MatchString(name) {
+			return true
 		}
 	}
 	return false
@@ -276,7 +296,7 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 				ipRules = append(ipRules, asIPRule(selRegex.re, nil))
 				continue
 			}
-			ips := make(map[string]struct{})
+			ips := make(map[restore.RuleIPOrCIDR]struct{})
 			count := 0
 			nids := selRegex.cs.GetSelections()
 		Loop:
@@ -285,10 +305,21 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 				nidIPs := p.LookupIPsBySecID(nid)
 				p.RLock()
 				for _, ip := range nidIPs {
-					if p.skipIPInRestorationRLocked(ip) {
+					rip, err := restore.ParseRuleIPOrCIDR(ip)
+					if err != nil {
+						log.WithFields(logrus.Fields{
+							logfields.EndpointID:            endpointID,
+							logfields.Port:                  pp.Port(),
+							logfields.Protocol:              pp.Protocol(),
+							logfields.EndpointLabelSelector: selRegex.cs,
+							logfields.IPAddr:                ip,
+						}).Warning("Could not parse IP for a DNS rule (?!), skipping")
 						continue
 					}
-					ips[ip] = struct{}{}
+					if rip.IsAddr() && p.skipIPInRestorationRLocked(ip) {
+						continue
+					}
+					ips[rip] = struct{}{}
 					count++
 					if count > p.maxIPsPerRestoredDNSRule {
 						log.WithFields(logrus.Fields{

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -147,6 +147,9 @@ type DNSProxy struct {
 	// mapping restored endpoint IP (both IPv4 and IPv6) to *Endpoint
 	restoredEPs restoredEPs
 
+	// FIXME: host endpoint does not have an IP address yet
+	restoredHost *endpoint.Endpoint
+
 	// rejectReply is the OPCode send from the DNS-proxy to the endpoint if the
 	// DNS request is invalid
 	rejectReply atomic.Int32
@@ -357,6 +360,9 @@ func (p *DNSProxy) RestoreRules(ep *endpoint.Endpoint) {
 	if ep.IPv6.IsValid() {
 		p.restoredEPs[ep.IPv6] = ep
 	}
+	if ep.IsHost() {
+		p.restoredHost = ep
+	}
 	// Use V2 if it is populated, otherwise
 	// use V1.
 	dnsRules := ep.DNSRulesV2
@@ -404,6 +410,9 @@ func (p *DNSProxy) removeRestoredRulesLocked(endpointID uint64) {
 			for _, r := range rule {
 				p.cache.releaseRegex(r.regex)
 			}
+		}
+		if p.restoredHost != nil && p.restoredHost.ID == uint16(endpointID) {
+			p.restoredHost = nil
 		}
 		delete(p.restored, endpointID)
 	}
@@ -564,7 +573,7 @@ func (allow perEPAllow) getPortRulesForID(endpointID uint64, destPortProto resto
 
 // LookupEndpointIDByIPFunc wraps logic to lookup an endpoint with any backend.
 // See DNSProxy.LookupRegisteredEndpoint for usage.
-type LookupEndpointIDByIPFunc func(ip netip.Addr) (endpoint *endpoint.Endpoint, err error)
+type LookupEndpointIDByIPFunc func(ip netip.Addr) (endpoint *endpoint.Endpoint, isHost bool, err error)
 
 // LookupSecIDByIPFunc Func wraps logic to lookup an IP's security ID from the
 // ipcache.
@@ -769,16 +778,18 @@ func shutdownServers(dnsServers []*dns.Server) {
 }
 
 // LookupEndpointByIP wraps LookupRegisteredEndpoint by falling back to an restored EP, if available
-func (p *DNSProxy) LookupEndpointByIP(ip netip.Addr) (endpoint *endpoint.Endpoint, err error) {
-	endpoint, err = p.LookupRegisteredEndpoint(ip)
-	if err != nil {
+func (p *DNSProxy) LookupEndpointByIP(ip netip.Addr) (endpoint *endpoint.Endpoint, isHost bool, err error) {
+	if endpoint, isHost, err = p.LookupRegisteredEndpoint(ip); err != nil {
 		// Check restored endpoints
-		endpoint, found := p.restoredEPs[ip]
-		if found {
-			return endpoint, nil
+		var found bool
+		if endpoint, found = p.restoredEPs[ip]; found {
+			return endpoint, endpoint.IsHost(), nil
+		}
+		if isHost && p.restoredHost != nil {
+			return p.restoredHost, true, nil
 		}
 	}
-	return endpoint, err
+	return
 }
 
 // UpdateAllowed sets newRules for endpointID and destPort. It compiles the DNS
@@ -992,7 +1003,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		return
 	}
 	epAddr := addrPort.Addr()
-	ep, err := p.LookupEndpointByIP(epAddr)
+	ep, _, err := p.LookupEndpointByIP(epAddr)
 	if err != nil {
 		scopedLog.WithError(err).Error("cannot extract endpoint ID from DNS request")
 		stat.Err = fmt.Errorf("Cannot extract endpoint ID from DNS request: %w", err)

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -81,11 +81,11 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 	}
 	proxy, err := StartDNSProxy(dnsProxyConfig, // any address, any port, enable ipv4, enable ipv6, enable compression, max 1000 restore IPs
 		// LookupEPByIP
-		func(ip netip.Addr) (*endpoint.Endpoint, error) {
+		func(ip netip.Addr) (*endpoint.Endpoint, bool, error) {
 			if s.restoring {
-				return nil, fmt.Errorf("No EPs available when restoring")
+				return nil, false, fmt.Errorf("No EPs available when restoring")
 			}
-			return endpoint.NewTestEndpointWithState(tb, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady), nil
+			return endpoint.NewTestEndpointWithState(tb, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady), false, nil
 		},
 		// LookupSecIDByIP
 		func(ip netip.Addr) (ipcache.Identity, bool) {

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -532,6 +532,16 @@ func TestCheckAllowedTwiceRemovedOnce(t *testing.T) {
 	require.Equal(t, false, allowed, "request was allowed when it should be rejected")
 }
 
+func makeMapOfRuleIPOrCIDR(addrs ...string) map[restore.RuleIPOrCIDR]struct{} {
+	m := make(map[restore.RuleIPOrCIDR]struct{}, len(addrs))
+	for _, addr := range addrs {
+		if ripc, err := restore.ParseRuleIPOrCIDR(addr); err == nil {
+			m[ripc] = struct{}{}
+		}
+	}
+	return m
+}
+
 func TestFullPathDependence(t *testing.T) {
 	s := setupDNSProxyTestSuite(t)
 
@@ -752,14 +762,14 @@ func TestFullPathDependence(t *testing.T) {
 	// Get rules for restoration
 	expected1 := restore.DNSRules{
 		udpProtoPort53: restore.IPRules{
-			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID1Selector], map[string]struct{}{"::": {}}),
-			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID2Selector], map[string]struct{}{"127.0.0.1": {}, "127.0.0.2": {}}),
+			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID1Selector], makeMapOfRuleIPOrCIDR("::")),
+			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID2Selector], makeMapOfRuleIPOrCIDR("127.0.0.1", "127.0.0.2")),
 		}.Sort(nil),
 		udpProtoPort54: restore.IPRules{
 			asIPRule(s.proxy.allowed[epID1][udpProtoPort54][cachedWildcardSelector], nil),
 		},
 		tcpProtoPort53: restore.IPRules{
-			asIPRule(s.proxy.allowed[epID1][tcpProtoPort53][cachedDstID1Selector], map[string]struct{}{"::": {}}),
+			asIPRule(s.proxy.allowed[epID1][tcpProtoPort53][cachedDstID1Selector], makeMapOfRuleIPOrCIDR("::")),
 		},
 	}
 	restored1, _ := s.proxy.GetRules(uint16(epID1))
@@ -773,12 +783,12 @@ func TestFullPathDependence(t *testing.T) {
 
 	expected3 := restore.DNSRules{
 		udpProtoPort53: restore.IPRules{
-			asIPRule(s.proxy.allowed[epID3][udpProtoPort53][cachedDstID1Selector], map[string]struct{}{"::": {}}),
-			asIPRule(s.proxy.allowed[epID3][udpProtoPort53][cachedDstID3Selector], map[string]struct{}{}),
-			asIPRule(s.proxy.allowed[epID3][udpProtoPort53][cachedDstID4Selector], map[string]struct{}{}),
+			asIPRule(s.proxy.allowed[epID3][udpProtoPort53][cachedDstID1Selector], makeMapOfRuleIPOrCIDR("::")),
+			asIPRule(s.proxy.allowed[epID3][udpProtoPort53][cachedDstID3Selector], makeMapOfRuleIPOrCIDR()),
+			asIPRule(s.proxy.allowed[epID3][udpProtoPort53][cachedDstID4Selector], makeMapOfRuleIPOrCIDR()),
 		}.Sort(nil),
 		tcpProtoPort53: restore.IPRules{
-			asIPRule(s.proxy.allowed[epID3][tcpProtoPort53][cachedDstID3Selector], map[string]struct{}{}),
+			asIPRule(s.proxy.allowed[epID3][tcpProtoPort53][cachedDstID3Selector], makeMapOfRuleIPOrCIDR()),
 		},
 	}
 	restored3, _ := s.proxy.GetRules(uint16(epID3))
@@ -791,14 +801,14 @@ func TestFullPathDependence(t *testing.T) {
 
 	expected1b := restore.DNSRules{
 		udpProtoPort53: restore.IPRules{
-			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID1Selector], map[string]struct{}{}),
-			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID2Selector], map[string]struct{}{"127.0.0.2": {}}),
+			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID1Selector], makeMapOfRuleIPOrCIDR()),
+			asIPRule(s.proxy.allowed[epID1][udpProtoPort53][cachedDstID2Selector], makeMapOfRuleIPOrCIDR("127.0.0.2")),
 		}.Sort(nil),
 		udpProtoPort54: restore.IPRules{
 			asIPRule(s.proxy.allowed[epID1][udpProtoPort54][cachedWildcardSelector], nil),
 		},
 		tcpProtoPort53: restore.IPRules{
-			asIPRule(s.proxy.allowed[epID1][tcpProtoPort53][cachedDstID1Selector], map[string]struct{}{}),
+			asIPRule(s.proxy.allowed[epID1][tcpProtoPort53][cachedDstID1Selector], makeMapOfRuleIPOrCIDR()),
 		},
 	}
 	restored1b, _ := s.proxy.GetRules(uint16(epID1))

--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -9,7 +9,9 @@
 package restore
 
 import (
+	"bytes"
 	"fmt"
+	"net/netip"
 	"sort"
 	"testing"
 )
@@ -75,7 +77,63 @@ type IPRules []IPRule
 // IPRule stores the allowed destination IPs for a DNS names matching a regex
 type IPRule struct {
 	Re  RuleRegex
-	IPs map[string]struct{} // IPs, nil set is wildcard and allows all IPs!
+	IPs map[RuleIPOrCIDR]struct{} // IPs, nil set is wildcard and allows all IPs!
+}
+
+// RuleIPOrCIDR is one allowed destination IP or CIDR
+// It marshals to/from text in a way that is compatible with net.IP and CIDRs
+type RuleIPOrCIDR netip.Prefix
+
+func ParseRuleIPOrCIDR(s string) (ip RuleIPOrCIDR, err error) {
+	err = ip.UnmarshalText([]byte(s))
+	return
+}
+
+func (ip RuleIPOrCIDR) ContainsAddr(addr RuleIPOrCIDR) bool {
+	return addr.IsAddr() && netip.Prefix(ip).Contains(netip.Prefix(addr).Addr())
+}
+
+func (ip RuleIPOrCIDR) IsAddr() bool {
+	return netip.Prefix(ip).Bits() == -1
+}
+
+func (ip RuleIPOrCIDR) String() string {
+	if ip.IsAddr() {
+		return netip.Prefix(ip).Addr().String()
+	} else {
+		return netip.Prefix(ip).String()
+	}
+}
+
+func (ip RuleIPOrCIDR) ToSingleCIDR() RuleIPOrCIDR {
+	addr := netip.Prefix(ip).Addr()
+	return RuleIPOrCIDR(netip.PrefixFrom(addr, addr.BitLen()))
+}
+
+func (ip RuleIPOrCIDR) MarshalText() ([]byte, error) {
+	if ip.IsAddr() {
+		return netip.Prefix(ip).Addr().MarshalText()
+	} else {
+		return netip.Prefix(ip).MarshalText()
+	}
+}
+
+func (ip *RuleIPOrCIDR) UnmarshalText(b []byte) (err error) {
+	if b == nil {
+		return fmt.Errorf("cannot unmarshal nil into RuleIPOrCIDR")
+	}
+	if i := bytes.IndexByte(b, byte('/')); i < 0 {
+		var addr netip.Addr
+		if err = addr.UnmarshalText(b); err == nil {
+			*ip = RuleIPOrCIDR(netip.PrefixFrom(addr, 0xff))
+		}
+	} else {
+		var prefix netip.Prefix
+		if err = prefix.UnmarshalText(b); err == nil {
+			*ip = RuleIPOrCIDR(prefix)
+		}
+	}
+	return
 }
 
 // RuleRegex is a wrapper for a pointer to a string so that we can define marshalers for it.

--- a/pkg/monitor/api/files.go
+++ b/pkg/monitor/api/files.go
@@ -32,6 +32,7 @@ var files = map[uint8]string{
 	111: "trace.h",
 	112: "encap.h",
 	113: "encrypt.h",
+	114: "host_firewall.h",
 
 	// @@ source files list end
 }

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"strconv"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node/addressing"
 	"github.com/cilium/cilium/pkg/option"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
@@ -179,6 +181,14 @@ func GetIPv4AllocRange() *cidr.CIDR {
 // GetIPv6AllocRange returns the IPv6 allocation prefix of this node
 func GetIPv6AllocRange() *cidr.CIDR {
 	return getLocalNode().IPv6AllocCIDR.DeepCopy()
+}
+
+// IsNodeIP determines if addr is one of the node's IP addresses,
+// and returns which type of address it is. "" is returned if addr
+// is not one of the node's IP addresses.
+func IsNodeIP(addr netip.Addr) addressing.AddressType {
+	n := getLocalNode()
+	return n.IsNodeIP(addr)
 }
 
 // GetIPv4 returns one of the IPv4 node address available with the following

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"path"
 	"slices"
 
@@ -298,6 +299,25 @@ func (a Address) ToString() string {
 
 func (a Address) AddrType() addressing.AddressType {
 	return a.Type
+}
+
+// IsNodeIP determines if addr is one of the node's IP addresses,
+// and returns which type of address it is. "" is returned if addr
+// is not one of the node's IP addresses.
+func (n *Node) IsNodeIP(addr netip.Addr) addressing.AddressType {
+	for _, a := range n.IPAddresses {
+		// for IPv4 this should not allocate memory
+		// this conversion will go away once net.IP is replaced with netip.Addr
+		ip := a.IP.To4()
+		if ip == nil {
+			ip = a.IP
+		}
+		if na, ok := netip.AddrFromSlice(ip); ok && na == addr {
+			return a.Type
+		}
+	}
+
+	return ""
 }
 
 // GetNodeIP returns one of the node's IP addresses available with the

--- a/pkg/policy/api/egress_test.go
+++ b/pkg/policy/api/egress_test.go
@@ -352,7 +352,7 @@ func TestIsLabelBasedEgress(t *testing.T) {
 	for _, tt := range tests {
 		args := tt.setupArgs()
 		want := tt.setupWanted()
-		require.Equal(t, nil, args.eg.sanitize(), fmt.Sprintf("Test name: %q", tt.name))
+		require.Equal(t, nil, args.eg.sanitize(false), fmt.Sprintf("Test name: %q", tt.name))
 		isLabelBased := args.eg.AllowsWildcarding()
 		require.EqualValues(t, want.isLabelBased, isLabelBased, fmt.Sprintf("Test name: %q", tt.name))
 	}

--- a/pkg/policy/api/ingress_test.go
+++ b/pkg/policy/api/ingress_test.go
@@ -289,7 +289,7 @@ func TestIsLabelBasedIngress(t *testing.T) {
 	for _, tt := range tests {
 		args := tt.setupArgs()
 		want := tt.setupWanted()
-		require.Equal(t, nil, args.eg.sanitize(), fmt.Sprintf("Test name: %q", tt.name))
+		require.Equal(t, nil, args.eg.sanitize(false), fmt.Sprintf("Test name: %q", tt.name))
 		isLabelBased := args.eg.AllowsWildcarding()
 		require.EqualValues(t, want.isLabelBased, isLabelBased, fmt.Sprintf("Test name: %q", tt.name))
 	}


### PR DESCRIPTION
FQDN-based network policy is extremely useful for egress filtering, but is currently only supported in pods. This means that nodes must either rely on some other filtering mechanism, or resort to periodically updating L3/L4 CIDR policies. However, the code which collects DNS requests and combines them with policy to automatically produce L3/L4 filters is at endpoint level and is almost agnostic with respect to kind of endpoint (pod or node). This PR enables FQDN-based network policy for nodes by adding a bit of BPF code which, when instructed by network policy, redirects node's DNS requests to the same transparent proxy that is used for pods. No changes in iptables rules or routing are required.

FQDN-based network policy for nodes is likely to be a good addition to Cilium, as it would enable egress filtering by FQDNs for the whole cluster without relying on third-party solutions. Also, the same approach may possibly work for other L7 rules.

A sample policy I used for testing is
```yaml
apiVersion: cilium.io/v2
kind: CiliumClusterwideNetworkPolicy
metadata:
  name: hostdns
specs:
- egress:
  - toCIDR:
    - 168.63.129.16/32 # example DNS server IP (whatever is in cilium agent's /etc/resolv.conf)
    toPorts:
    - ports:
      - port: "53"
        protocol: ANY
      rules:
        dns:
        - matchPattern: '*'
  - toFQDNs: # works when host has L7 DNS policy
    - matchName: api.ipify.org
  nodeSelector: {}
```