### PR TITLE
clustermesh: add service export read path in clustermesh/operator

### DIFF
--- a/pkg/clustermesh/operator/metrics.go
+++ b/pkg/clustermesh/operator/metrics.go
@@ -11,6 +11,8 @@ import (
 type Metrics struct {
 	// TotalGlobalServices tracks the total number of global services.
 	TotalGlobalServices metric.Vec[metric.Gauge]
+	// TotalGlobalServiceExports tracks the total number of global service exports.
+	TotalGlobalServiceExports metric.Vec[metric.Gauge]
 }
 
 func NewMetrics() Metrics {
@@ -20,6 +22,12 @@ func NewMetrics() Metrics {
 			Subsystem: subsystem,
 			Name:      "global_services",
 			Help:      "The total number of global services in the cluster mesh",
+		}, []string{metrics.LabelSourceCluster}),
+		TotalGlobalServiceExports: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Subsystem: subsystem,
+			Name:      "global_service_exports",
+			Help:      "The total number of MCS-API global service exports in the cluster mesh",
 		}, []string{metrics.LabelSourceCluster}),
 	}
 }

--- a/pkg/clustermesh/operator/remote_cluster.go
+++ b/pkg/clustermesh/operator/remote_cluster.go
@@ -7,8 +7,11 @@ import (
 	"context"
 	"path"
 
+	"k8s.io/utils/ptr"
+
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
+	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/clustermesh/wait"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -26,10 +29,10 @@ type remoteCluster struct {
 	clusterMeshEnableEndpointSync bool
 	clusterMeshEnableMCSAPI       bool
 
-	globalServices *common.GlobalServiceCache
-
 	// remoteServices is the shared store representing services in remote clusters
 	remoteServices store.WatchStore
+	// remoteServiceExports is the shared store representing service exports in remote clusters
+	remoteServiceExports store.WatchStore
 
 	storeFactory store.Factory
 
@@ -62,6 +65,17 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 		})
 	}
 
+	if rc.clusterMeshEnableMCSAPI && config.Capabilities.ServiceExportsEnabled != nil {
+		mgr.Register(adapter(mcsapitypes.ServiceExportStorePrefix), func(ctx context.Context) {
+			rc.remoteServiceExports.Watch(ctx, backend, path.Join(adapter(mcsapitypes.ServiceExportStorePrefix), rc.name))
+		})
+	} else {
+		// Drain the remote service exports in case the remote cluster no longer supports them
+		rc.remoteServiceExports.Drain()
+		// Mimic that service exports are synced if not enabled
+		rc.synced.serviceExports.Stop()
+	}
+
 	close(ready)
 	for _, clusterAddHook := range rc.clusterAddHooks {
 		clusterAddHook(rc.name)
@@ -81,17 +95,20 @@ func (rc *remoteCluster) Remove(context.Context) {
 	// is removed, and not in case the operator is shutting down, otherwise we
 	// would break existing connections on restart.
 	rc.remoteServices.Drain()
+	rc.remoteServiceExports.Drain()
 }
 
 type synced struct {
 	wait.SyncedCommon
-	services *lock.StoppableWaitGroup
+	services       *lock.StoppableWaitGroup
+	serviceExports *lock.StoppableWaitGroup
 }
 
 func newSynced() synced {
 	return synced{
-		SyncedCommon: wait.NewSyncedCommon(),
-		services:     lock.NewStoppableWaitGroup(),
+		SyncedCommon:   wait.NewSyncedCommon(),
+		services:       lock.NewStoppableWaitGroup(),
+		serviceExports: lock.NewStoppableWaitGroup(),
 	}
 }
 
@@ -102,10 +119,18 @@ func (s *synced) Services(ctx context.Context) error {
 	return s.Wait(ctx, s.services.WaitChannel())
 }
 
+// ServiceExports returns after that the initial list of service exports has been
+// received from the remote cluster, the remote cluster is disconnected,
+// or the given context is canceled.
+func (s *synced) ServiceExports(ctx context.Context) error {
+	return s.Wait(ctx, s.serviceExports.WaitChannel())
+}
+
 func (rc *remoteCluster) Status() *models.RemoteCluster {
 	status := rc.status()
 
 	status.NumSharedServices = int64(rc.remoteServices.NumEntries())
+	status.NumServiceExports = int64(rc.remoteServiceExports.NumEntries())
 
 	status.Synced = &models.RemoteClusterSynced{
 		Services: !rc.clusterMeshEnableEndpointSync || rc.remoteServices.Synced(),
@@ -115,9 +140,14 @@ func (rc *remoteCluster) Status() *models.RemoteCluster {
 		Endpoints:  true,
 		Identities: true,
 	}
+	if status.Config != nil && status.Config.ServiceExportsEnabled != nil &&
+		rc.clusterMeshEnableMCSAPI {
+		status.Synced.ServiceExports = ptr.To(rc.remoteServiceExports.Synced())
+	}
 
 	status.Ready = status.Ready &&
 		status.Synced.Nodes && status.Synced.Services &&
+		(status.Synced.ServiceExports == nil || *status.Synced.ServiceExports) &&
 		status.Synced.Identities && status.Synced.Endpoints
 
 	return status

--- a/pkg/clustermesh/operator/remote_cluster_test.go
+++ b/pkg/clustermesh/operator/remote_cluster_test.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package operator
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/clustermesh/common"
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+// Configure a generous timeout to prevent flakes when running in a noisy CI environment.
+var (
+	tick    = 10 * time.Millisecond
+	timeout = 5 * time.Second
+)
+
+func TestRemoteClusterStatus(t *testing.T) {
+	testutils.IntegrationTest(t)
+
+	kvstore.SetupDummy(t, "etcd")
+	kvsService := map[string]string{
+		"cilium/state/services/v1/foo/baz/bar": `{"name": "bar", "namespace": "baz", "cluster": "foo", "clusterID": 1}`,
+	}
+	kvsServiceExport := map[string]string{
+		"cilium/state/serviceexports/v1/foo/baz/bar": `{"name": "bar", "namespace": "baz", "cluster": "foo", "exportCreationTimestamp": "2024-07-07T15:55:07.627472784+02:00", "type": "ClusterSetIP", "sessionAffinity": "None"}`,
+	}
+
+	tests := []struct {
+		name                            string
+		clusterMeshEnableEndpointSync   bool
+		clusterMeshEnableMCSAPI         bool
+		capabilityServiceExportsEnabled *bool
+		expectedServiceSync             bool
+		expectedMCSAPISync              bool
+	}{
+		{
+			name:                            "Everything disabled",
+			clusterMeshEnableEndpointSync:   false,
+			clusterMeshEnableMCSAPI:         false,
+			capabilityServiceExportsEnabled: nil,
+			expectedServiceSync:             false,
+			expectedMCSAPISync:              false,
+		},
+		{
+			name:                            "Both config enabled but remote doesn't support service exports",
+			clusterMeshEnableEndpointSync:   true,
+			clusterMeshEnableMCSAPI:         true,
+			capabilityServiceExportsEnabled: nil,
+			expectedServiceSync:             true,
+			expectedMCSAPISync:              false,
+		},
+		{
+			name:                            "Both config enabled and remote supports service exports",
+			clusterMeshEnableEndpointSync:   true,
+			clusterMeshEnableMCSAPI:         true,
+			capabilityServiceExportsEnabled: ptr.To(false),
+			expectedServiceSync:             true,
+			expectedMCSAPISync:              true,
+		},
+	}
+
+	st := store.NewFactory(store.MetricsProvider())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var wg sync.WaitGroup
+			ctx, cancel := context.WithCancel(context.Background())
+
+			t.Cleanup(func() {
+				cancel()
+				wg.Wait()
+
+				require.NoError(t, kvstore.Client().DeletePrefix(context.Background(), kvstore.BaseKeyPrefix))
+			})
+
+			metrics := NewMetrics()
+			logger := logrus.New()
+			cm := clusterMesh{
+				logger:       logger,
+				storeFactory: st,
+				globalServices: common.NewGlobalServiceCache(
+					metrics.TotalGlobalServices.WithLabelValues("foo"),
+				),
+				globalServiceExports: NewGlobalServiceExportCache(
+					metrics.TotalGlobalServiceExports.WithLabelValues("foo"),
+				),
+				cfg:       ClusterMeshConfig{ClusterMeshEnableEndpointSync: tt.clusterMeshEnableEndpointSync},
+				cfgMCSAPI: MCSAPIConfig{ClusterMeshEnableMCSAPI: tt.clusterMeshEnableMCSAPI},
+			}
+
+			// Populate the kvstore with the appropriate KV pairs
+			for key, value := range kvsService {
+				require.NoErrorf(t, kvstore.Client().Update(ctx, key, []byte(value), false), "Failed to set %s=%s", key, value)
+			}
+			if tt.capabilityServiceExportsEnabled != nil {
+				for key, value := range kvsServiceExport {
+					require.NoErrorf(t, kvstore.Client().Update(ctx, key, []byte(value), false), "Failed to set %s=%s", key, value)
+				}
+			}
+
+			rc := cm.newRemoteCluster("foo", func() *models.RemoteCluster {
+				return &models.RemoteCluster{Ready: true, Config: &models.RemoteClusterConfig{
+					ServiceExportsEnabled: tt.capabilityServiceExportsEnabled,
+				}}
+			})
+
+			// Validate the status before watching the remote cluster.
+			status := rc.(*remoteCluster).Status()
+			if tt.expectedServiceSync || tt.expectedMCSAPISync {
+				require.False(t, status.Ready, "Status should not be ready")
+			}
+
+			if tt.expectedServiceSync {
+				require.False(t, status.Synced.Services, "Services should not be synced")
+			}
+			if tt.expectedMCSAPISync {
+				require.False(t, status.Synced.ServiceExports != nil && *status.Synced.ServiceExports, "Service Exports should not be synced")
+			} else {
+				require.Nil(t, status.Synced.ServiceExports, "Service Exports should not be considered for syncing")
+			}
+
+			require.EqualValues(t, 0, status.NumSharedServices, "Incorrect number of services")
+			require.EqualValues(t, 0, status.NumServiceExports, "Incorrect number of service exports")
+
+			cfg := types.CiliumClusterConfig{
+				ID: 10, Capabilities: types.CiliumClusterConfigCapabilities{
+					ServiceExportsEnabled: tt.capabilityServiceExportsEnabled,
+				},
+			}
+			ready := make(chan error)
+			wg.Add(1)
+			go func() {
+				rc.Run(ctx, kvstore.Client(), cfg, ready)
+				wg.Done()
+			}()
+
+			require.NoError(t, <-ready, "rc.Run() failed")
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				status := rc.(*remoteCluster).Status()
+				assert.True(c, status.Ready, "Status should be ready")
+
+				assert.True(c, status.Synced.Services, "Services should be synced")
+				if tt.expectedMCSAPISync {
+					require.True(t, status.Synced.ServiceExports != nil && *status.Synced.ServiceExports, "Service Exports should be synced")
+				} else {
+					require.Nil(t, status.Synced.ServiceExports, "Service Exports should not be considered for syncing")
+				}
+
+				if tt.expectedServiceSync {
+					assert.EqualValues(c, 1, status.NumSharedServices, "Incorrect number of services")
+				} else {
+					assert.EqualValues(c, 0, status.NumSharedServices, "Incorrect number of services")
+				}
+				if tt.expectedMCSAPISync {
+					assert.EqualValues(c, 1, status.NumServiceExports, "Incorrect number of service exports")
+				} else {
+					assert.EqualValues(c, 0, status.NumServiceExports, "Incorrect number of service exports")
+				}
+			}, timeout, tick, "Reported status is not correct")
+		})
+	}
+}
+
+func TestRemoteClusterHooks(t *testing.T) {
+	testutils.IntegrationTest(t)
+
+	kvstore.SetupDummy(t, "etcd")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+
+		require.NoError(t, kvstore.Client().DeletePrefix(context.Background(), kvstore.BaseKeyPrefix))
+	})
+	st := store.NewFactory(store.MetricsProvider())
+	metrics := NewMetrics()
+	logger := logrus.New()
+	cm := clusterMesh{
+		logger:       logger,
+		storeFactory: st,
+		globalServices: common.NewGlobalServiceCache(
+			metrics.TotalGlobalServices.WithLabelValues("foo"),
+		),
+		globalServiceExports: NewGlobalServiceExportCache(
+			metrics.TotalGlobalServiceExports.WithLabelValues("foo"),
+		),
+	}
+
+	clusterAddCalledCount := atomic.Uint32{}
+	clusterRemoveCalledCount := atomic.Uint32{}
+
+	cm.RegisterClusterAddHook(func(s string) {
+		clusterAddCalledCount.Add(1)
+	})
+	cm.RegisterClusterDeleteHook(func(s string) {
+		clusterRemoveCalledCount.Add(1)
+	})
+
+	cfg := types.CiliumClusterConfig{
+		ID: 10, Capabilities: types.CiliumClusterConfigCapabilities{},
+	}
+	ready := make(chan error)
+	rc := cm.newRemoteCluster("foo", func() *models.RemoteCluster {
+		return &models.RemoteCluster{Ready: true, Config: &models.RemoteClusterConfig{}}
+	})
+
+	wg.Add(1)
+	go func() {
+		rc.Run(ctx, kvstore.Client(), cfg, ready)
+		wg.Done()
+	}()
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.EqualValues(c, 1, clusterAddCalledCount.Load(), "cluster add called once")
+	}, timeout, tick, "Reported status is not correct")
+
+	rc.Remove(ctx)
+	require.EqualValues(t, 1, clusterRemoveCalledCount.Load(), "cluster remove called once")
+}

--- a/pkg/clustermesh/operator/service_exports.go
+++ b/pkg/clustermesh/operator/service_exports.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package operator
+
+import (
+	"golang.org/x/exp/maps"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+type (
+	ServiceExportsByNamespace map[string]ServiceExportsByName
+	ServiceExportsByName      map[string]ServiceExportsByCluster
+	ServiceExportsByCluster   map[string]*mcsapitypes.MCSAPIServiceSpec
+)
+
+type GlobalServiceExportCache struct {
+	mutex lock.RWMutex
+	cache ServiceExportsByNamespace
+
+	// size is used to manage a counter of globalServiceExport
+	// as uint instead of the float of metric.Gauge as float are not reliable to count
+	size uint64
+	// metricTotalGlobalServiceExports is the gauge metric for total of global service exports
+	metricTotalGlobalServiceExports metric.Gauge
+}
+
+func NewGlobalServiceExportCache(metricTotalGlobalServiceExports metric.Gauge) *GlobalServiceExportCache {
+	return &GlobalServiceExportCache{
+		cache:                           ServiceExportsByNamespace{},
+		metricTotalGlobalServiceExports: metricTotalGlobalServiceExports,
+	}
+}
+
+// GetServiceExports returns all the service exports for a specific namespace
+// that have at least one service export in one of the remote cluster in the mesh.
+func (c *GlobalServiceExportCache) GetServiceExportsName(namespace string) []string {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	return maps.Keys(c.cache[namespace])
+}
+
+// GetServiceExportByCluster returns a shallow copy of the GlobalServiceExport
+// object, thus the MCSAPIServiceSpec objects should not be mutated.
+func (c *GlobalServiceExportCache) GetServiceExportByCluster(serviceExportNN types.NamespacedName) ServiceExportsByCluster {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	svcExportsByName, ok := c.cache[serviceExportNN.Namespace]
+	if !ok {
+		return nil
+	}
+	svcExportsByCluster, ok := svcExportsByName[serviceExportNN.Name]
+	if !ok {
+		return nil
+	}
+	return maps.Clone(svcExportsByCluster)
+}
+
+func (c *GlobalServiceExportCache) OnUpdate(svcExport *mcsapitypes.MCSAPIServiceSpec) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	svcExportsByName, ok := c.cache[svcExport.Namespace]
+	if !ok {
+		svcExportsByName = ServiceExportsByName{}
+		c.cache[svcExport.Namespace] = svcExportsByName
+	}
+	svcExportsByCluster, ok := svcExportsByName[svcExport.Name]
+	if !ok {
+		svcExportsByCluster = ServiceExportsByCluster{}
+		svcExportsByName[svcExport.Name] = svcExportsByCluster
+		c.size += 1
+		c.metricTotalGlobalServiceExports.Set(float64(c.size))
+	}
+
+	svcExportsByCluster[svcExport.Cluster] = svcExport
+}
+
+func (c *GlobalServiceExportCache) OnDelete(svcExport *mcsapitypes.MCSAPIServiceSpec) bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	svcExportsByName, ok := c.cache[svcExport.Namespace]
+	if !ok {
+		return false
+	}
+	svcExportsByCluster, ok := svcExportsByName[svcExport.Name]
+	if !ok {
+		return false
+	}
+
+	_, ok = svcExportsByCluster[svcExport.Cluster]
+	if !ok {
+		return false
+	}
+	delete(svcExportsByCluster, svcExport.Cluster)
+
+	// cleanup the maps and update the size
+	if len(svcExportsByName[svcExport.Name]) != 0 {
+		return true
+	}
+	c.size -= 1
+	c.metricTotalGlobalServiceExports.Set(float64(c.size))
+	delete(svcExportsByName, svcExport.Name)
+
+	if len(c.cache[svcExport.Namespace]) != 0 {
+		return true
+	}
+	delete(c.cache, svcExport.Namespace)
+
+	return true
+}
+
+func (c *GlobalServiceExportCache) Size() uint64 {
+	return c.size
+}
+
+type remoteServiceExportObserver struct {
+	cache *GlobalServiceExportCache
+
+	onUpdate func(*mcsapitypes.MCSAPIServiceSpec)
+	onDelete func(*mcsapitypes.MCSAPIServiceSpec)
+}
+
+// NewServiceExportsObserver returns an observer implementing the logic to convert
+// and filter export notifications, update the global service export cache and
+// call the upstream handlers when appropriate.
+func NewServiceExportsObserver(
+	cache *GlobalServiceExportCache, onUpdate, onDelete func(*mcsapitypes.MCSAPIServiceSpec),
+) store.Observer {
+	return &remoteServiceExportObserver{
+		cache: cache,
+
+		onUpdate: onUpdate,
+		onDelete: onDelete,
+	}
+}
+
+// OnUpdate is called when a service export in a remote cluster is updated
+func (r *remoteServiceExportObserver) OnUpdate(key store.Key) {
+	svcExport := &(key.(*mcsapitypes.ValidatingMCSAPIServiceSpec).MCSAPIServiceSpec)
+	r.cache.OnUpdate(svcExport)
+	r.onUpdate(svcExport)
+}
+
+// OnDelete is called when a service export in a remote cluster is deleted
+func (r *remoteServiceExportObserver) OnDelete(key store.NamedKey) {
+	svcExport := &(key.(*mcsapitypes.ValidatingMCSAPIServiceSpec).MCSAPIServiceSpec)
+	r.onDelete(svcExport)
+}

--- a/pkg/clustermesh/operator/service_exports_test.go
+++ b/pkg/clustermesh/operator/service_exports_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package operator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
+)
+
+func TestGlobalServiceExportCache(t *testing.T) {
+	metrics := NewMetrics()
+	globalServiceExports := NewGlobalServiceExportCache(
+		metrics.TotalGlobalServiceExports.WithLabelValues("foo"),
+	)
+
+	globalServiceExports.OnUpdate(&mcsapitypes.MCSAPIServiceSpec{
+		Cluster:   "cluster1",
+		Name:      "reset",
+		Namespace: "default",
+	})
+	// Call OnUpdate twice to check if we don't duplicate this service somehow
+	globalServiceExports.OnUpdate(&mcsapitypes.MCSAPIServiceSpec{
+		Cluster:   "cluster1",
+		Name:      "reset",
+		Namespace: "default",
+	})
+	require.EqualValues(t, 1, globalServiceExports.Size())
+	require.EqualValues(t, []string{"reset"}, globalServiceExports.GetServiceExportsName("default"))
+	require.Len(t, globalServiceExports.GetServiceExportByCluster(types.NamespacedName{
+		Namespace: "default",
+		Name:      "reset",
+	}), 1)
+	require.Nil(t, globalServiceExports.GetServiceExportByCluster(types.NamespacedName{
+		Namespace: "default",
+		Name:      "unknown",
+	}), 1)
+
+	require.True(t, globalServiceExports.OnDelete(&mcsapitypes.MCSAPIServiceSpec{
+		Cluster:   "cluster1",
+		Name:      "reset",
+		Namespace: "default",
+	}))
+	// Check that calling OnDelete twice doesn't do anything
+	require.False(t, globalServiceExports.OnDelete(&mcsapitypes.MCSAPIServiceSpec{
+		Cluster:   "cluster1",
+		Name:      "reset",
+		Namespace: "default",
+	}))
+	require.EqualValues(t, 0, globalServiceExports.Size(), "should have no global service exports")
+	require.Len(t, globalServiceExports.cache, 0, "Cache should be fully reset")
+
+	// Initial state
+	globalServiceExports.OnUpdate(&mcsapitypes.MCSAPIServiceSpec{
+		Cluster:   "cluster1",
+		Name:      "service-1",
+		Namespace: "default",
+	})
+	globalServiceExports.OnUpdate(&mcsapitypes.MCSAPIServiceSpec{
+		Cluster:   "cluster1",
+		Name:      "service-2",
+		Namespace: "default",
+	})
+	globalServiceExports.OnUpdate(&mcsapitypes.MCSAPIServiceSpec{
+		Cluster:   "cluster2",
+		Name:      "service-2",
+		Namespace: "default",
+	})
+	require.EqualValues(t, 2, globalServiceExports.Size())
+	require.Len(t, globalServiceExports.GetServiceExportByCluster(types.NamespacedName{
+		Namespace: "default",
+		Name:      "service-2",
+	}), 2)
+
+	// Delete the service-2 from one cluster
+	globalServiceExports.OnDelete(&mcsapitypes.MCSAPIServiceSpec{
+		Cluster:   "cluster2",
+		Name:      "service-2",
+		Namespace: "default",
+	})
+	require.EqualValues(t, 2, globalServiceExports.Size())
+	require.Len(t, globalServiceExports.GetServiceExportByCluster(types.NamespacedName{
+		Namespace: "default",
+		Name:      "service-2",
+	}), 1)
+
+	// Completely delete service-2
+	globalServiceExports.OnDelete(&mcsapitypes.MCSAPIServiceSpec{
+		Cluster:   "cluster1",
+		Name:      "service-2",
+		Namespace: "default",
+	})
+	require.EqualValues(t, 1, globalServiceExports.Size())
+	require.Nil(t, globalServiceExports.GetServiceExportByCluster(types.NamespacedName{
+		Namespace: "default",
+		Name:      "service-2",
+	}))
+	require.Nil(t, globalServiceExports.cache["default"]["service-2"])
+
+	// Check that the other service is intact
+	require.Len(t, globalServiceExports.GetServiceExportByCluster(types.NamespacedName{
+		Namespace: "default",
+		Name:      "service-1",
+	}), 1)
+}


### PR DESCRIPTION
This commit adds the read path support for service exports inside the clustermesh/operator package like there is currently for regular services. We also copy a strip down/adapted version of GlobalServiceCache for service exports called GlobalServiceExportCache.

These new interfaces will be used for the MCS-API service import sync feature.

Related to #32712 #27902
Follow up to #32972 