### PR TITLE
bgpv2: Avoid duplicate route policy naming

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
@@ -206,7 +206,7 @@ func (r *PodCIDRReconciler) getDesiredRoutePolicies(p ReconcileParams, desiredPe
 				}
 
 				if len(v6Prefixes) > 0 || len(v4Prefixes) > 0 {
-					name := PolicyName(peer, fam.Afi.String(), string(advert.AdvertisementType))
+					name := PolicyName(peer, fam.Afi.String(), advert.AdvertisementType, "")
 					policy, err := CreatePolicy(name, peerAddr, v4Prefixes, v6Prefixes, advert)
 					if err != nil {
 						return nil, err

--- a/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool.go
@@ -399,7 +399,7 @@ func (r *PodIPPoolReconciler) getPodIPPoolPolicy(p ReconcileParams, peer string,
 		return nil, nil
 	}
 
-	policyName := PolicyName(peer, family.Afi.String(), fmt.Sprintf("%s-%s", pool.Name, pool.Namespace))
+	policyName := PolicyName(peer, family.Afi.String(), advert.AdvertisementType, pool.Name)
 	return CreatePolicy(policyName, peerAddr, v4Prefixes, v6Prefixes, advert)
 }
 

--- a/pkg/bgpv1/manager/reconcilerv2/policies.go
+++ b/pkg/bgpv1/manager/reconcilerv2/policies.go
@@ -154,8 +154,13 @@ func ReconcileRoutePolicies(rp *ReconcileRoutePoliciesParams) (RoutePolicyMap, e
 	return runningPolicies, nil
 }
 
-func PolicyName(peer, family, advertType string) string {
-	return fmt.Sprintf("%s-%s-%s", peer, family, advertType)
+// PolicyName returns a unique route policy name for the provided peer, family and advertisement type.
+// If there a is a need for multiple route policies per advertisement type, unique resourceID can be provided.
+func PolicyName(peer, family string, advertType v2alpha1.BGPAdvertisementType, resourceID string) string {
+	if resourceID == "" {
+		return fmt.Sprintf("%s-%s-%s", peer, family, advertType)
+	}
+	return fmt.Sprintf("%s-%s-%s-%s", peer, family, advertType, resourceID)
 }
 
 func CreatePolicy(name string, peerAddr netip.Addr, v4Prefixes, v6Prefixes types.PolicyPrefixMatchList, advert v2alpha1.BGPAdvertisement) (*types.RoutePolicy, error) {

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -822,7 +822,7 @@ func (r *ServiceReconciler) getLBRoutePolicy(p ReconcileParams, peer string, fam
 		return nil, nil
 	}
 
-	policyName := PolicyName(peer, family.Afi.String(), fmt.Sprintf("%s-%s", lbPool.Name, lbPool.Namespace))
+	policyName := PolicyName(peer, family.Afi.String(), advert.AdvertisementType, lbPool.Name)
 	policy, err := CreatePolicy(policyName, peerAddr, v4Prefixes, v6Prefixes, advert)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create lb pool route policy: %w", err)
@@ -907,7 +907,7 @@ func (r *ServiceReconciler) getExternalIPRoutePolicy(p ReconcileParams, peer str
 		return nil, nil
 	}
 
-	policyName := PolicyName(peer, family.Afi.String(), fmt.Sprintf("%s-%s-%s", svc.Name, svc.Namespace, v2alpha1.BGPExternalIPAddr))
+	policyName := PolicyName(peer, family.Afi.String(), advert.AdvertisementType, fmt.Sprintf("%s-%s-%s", svc.Name, svc.Namespace, v2alpha1.BGPExternalIPAddr))
 	policy, err := CreatePolicy(policyName, peerAddr, v4Prefixes, v6Prefixes, advert)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create external IP route policy: %w", err)
@@ -1000,7 +1000,7 @@ func (r *ServiceReconciler) getClusterIPRoutePolicy(p ReconcileParams, peer stri
 		return nil, nil
 	}
 
-	policyName := PolicyName(peer, family.Afi.String(), fmt.Sprintf("%s-%s-%s", svc.Name, svc.Namespace, v2alpha1.BGPClusterIPAddr))
+	policyName := PolicyName(peer, family.Afi.String(), advert.AdvertisementType, fmt.Sprintf("%s-%s-%s", svc.Name, svc.Namespace, v2alpha1.BGPClusterIPAddr))
 	policy, err := CreatePolicy(policyName, peerAddr, v4Prefixes, v6Prefixes, advert)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cluster IP route policy: %w", err)

--- a/pkg/bgpv1/manager/reconcilerv2/service_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service_test.go
@@ -32,7 +32,7 @@ var (
 
 var (
 	redSvcKey           = resource.Key{Name: "red-svc", Namespace: "non-default"}
-	redLBPoolKey        = resource.Key{Name: "red-lb-pool", Namespace: "non-default"}
+	redLBPoolKey        = resource.Key{Name: "red-lb-pool"}
 	redSvcSelector      = &slim_metav1.LabelSelector{MatchLabels: map[string]string{"color": "red"}}
 	mismatchSvcSelector = &slim_metav1.LabelSelector{MatchLabels: map[string]string{"color": "blue"}}
 	ingressV4           = "192.168.0.1"
@@ -52,9 +52,8 @@ var (
 
 	redLBPool = &v2alpha1.CiliumLoadBalancerIPPool{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "red-lb-pool",
-			Namespace: "non-default",
-			Labels:    redSvcSelector.MatchLabels,
+			Name:   "red-lb-pool",
+			Labels: redSvcSelector.MatchLabels,
 		},
 		Spec: v2alpha1.CiliumLoadBalancerIPPoolSpec{
 			Blocks: []v2alpha1.CiliumLoadBalancerIPPoolIPBlock{
@@ -96,7 +95,7 @@ var (
 		return cp
 	}
 
-	redPeer65001v4LBRPName = PolicyName("red-peer-65001", "ipv4", "red-lb-pool-non-default")
+	redPeer65001v4LBRPName = PolicyName("red-peer-65001", "ipv4", v2alpha1.BGPServiceAdvert, "red-lb-pool")
 	redPeer65001v4LBRP     = &types.RoutePolicy{
 		Name: redPeer65001v4LBRPName,
 		Type: types.RoutePolicyTypeExport,
@@ -120,7 +119,7 @@ var (
 		},
 	}
 
-	redPeer65001v6LBRPName = PolicyName("red-peer-65001", "ipv6", "red-lb-pool-non-default")
+	redPeer65001v6LBRPName = PolicyName("red-peer-65001", "ipv6", v2alpha1.BGPServiceAdvert, "red-lb-pool")
 	redPeer65001v6LBRP     = &types.RoutePolicy{
 		Name: redPeer65001v6LBRPName,
 		Type: types.RoutePolicyTypeExport,
@@ -165,7 +164,7 @@ var (
 		return cp
 	}
 
-	redPeer65001v4ExtRPName = PolicyName("red-peer-65001", "ipv4", "red-svc-non-default-ExternalIP")
+	redPeer65001v4ExtRPName = PolicyName("red-peer-65001", "ipv4", v2alpha1.BGPServiceAdvert, "red-svc-non-default-ExternalIP")
 	redPeer65001v4ExtRP     = &types.RoutePolicy{
 		Name: redPeer65001v4ExtRPName,
 		Type: types.RoutePolicyTypeExport,
@@ -189,7 +188,7 @@ var (
 		},
 	}
 
-	redPeer65001v6ExtRPName = PolicyName("red-peer-65001", "ipv6", "red-svc-non-default-ExternalIP")
+	redPeer65001v6ExtRPName = PolicyName("red-peer-65001", "ipv6", v2alpha1.BGPServiceAdvert, "red-svc-non-default-ExternalIP")
 	redPeer65001v6ExtRP     = &types.RoutePolicy{
 		Name: redPeer65001v6ExtRPName,
 		Type: types.RoutePolicyTypeExport,
@@ -235,7 +234,7 @@ var (
 		return cp
 	}
 
-	redPeer65001v4ClusterRPName = PolicyName("red-peer-65001", "ipv4", "red-svc-non-default-ClusterIP")
+	redPeer65001v4ClusterRPName = PolicyName("red-peer-65001", "ipv4", v2alpha1.BGPServiceAdvert, "red-svc-non-default-ClusterIP")
 	redPeer65001v4ClusterRP     = &types.RoutePolicy{
 		Name: redPeer65001v4ClusterRPName,
 		Type: types.RoutePolicyTypeExport,
@@ -259,7 +258,7 @@ var (
 		},
 	}
 
-	redPeer65001v6ClusterRPName = PolicyName("red-peer-65001", "ipv6", "red-svc-non-default-ClusterIP")
+	redPeer65001v6ClusterRPName = PolicyName("red-peer-65001", "ipv6", v2alpha1.BGPServiceAdvert, "red-svc-non-default-ClusterIP")
 	redPeer65001v6ClusterRP     = &types.RoutePolicy{
 		Name: redPeer65001v6ClusterRPName,
 		Type: types.RoutePolicyTypeExport,


### PR DESCRIPTION
Consolidates route policy naming to always contain advertisement type, to avoid duplicate route policy names (and thus missing route policy) if the same name is used for two different resource types (e.g. `CiliumPodIPPool` & `CiliumLoadBalancerIPPool`). 

Also removes namespace from the policy name of non-namespaced resources (`CiliumPodIPPool` & `CiliumLoadBalancerIPPool`).