### PR TITLE
detecting IPSEC SPI unchanged

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -1146,6 +1146,9 @@ func LoadIPSecKeys(log *slog.Logger, r io.Reader) (int, uint8, error) {
 		ipSecKey.ESN = esn
 
 		if oldKey, ok := ipSecKeysGlobal[""]; ok {
+			if oldKey.Spi == spi {
+				return 0, 0, fmt.Errorf("invalid SPI: changing IPSec keys requires incrementing the key id")
+			}
 			ipSecKeysRemovalTime[oldKey.Spi] = time.Now()
 		}
 		ipSecKeysGlobal[""] = ipSecKey

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -1416,3 +1416,11 @@ func (skr staleKeyReclaimer) onTimer(ctx context.Context) error {
 
 	return nil
 }
+
+// UnsetTestIPSecKey reinitialize the IPSec key-related variables.
+// This function is for testing purpose only and **must not** be used elsewhere.
+func UnsetTestIPSecKey() {
+	ipSecCurrentKeySPI = 0
+	ipSecKeysGlobal = make(map[string]*ipSecKey)
+	ipSecKeysRemovalTime = make(map[uint8]time.Time)
+}

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -28,7 +28,7 @@ func setupIPSecSuitePrivileged(tb testing.TB) *slog.Logger {
 	log := hivetest.Logger(tb)
 
 	tb.Cleanup(func() {
-		ipSecKeysGlobal = make(map[string]*ipSecKey)
+		UnsetTestIPSecKey()
 		node.UnsetTestLocalNodeStore()
 		err := DeleteXFRM(log, AllReqID)
 		if err != nil {

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -40,10 +40,11 @@ func setupIPSecSuitePrivileged(tb testing.TB) *slog.Logger {
 
 var (
 	path           = "ipsec_keys_test"
-	keysDat        = []byte("1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n1 digest_null \"\" cipher_null \"\"\n")
-	keysAeadDat    = []byte("6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
-	keysAeadDat256 = []byte("6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f144434241343332312423222114131211 128\n")
-	invalidKeysDat = []byte("1 test abcdefghijklmnopqrstuvwzyzABCDEF test abcdefghijklmnopqrstuvwzyzABCDEF\n")
+	keysDat        = []byte("1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n2 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n3 digest_null \"\" cipher_null \"\"\n")
+	keysAeadDat    = []byte("4 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
+	keysAeadDat256 = []byte("5 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f144434241343332312423222114131211 128\n")
+	invalidKeysDat = []byte("6 test abcdefghijklmnopqrstuvwzyzABCDEF test abcdefghijklmnopqrstuvwzyzABCDEF\n")
+	keysSameSpiDat = []byte("7 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n7 digest_null \"\" cipher_null \"\"\n")
 )
 
 func TestLoadKeysNoFile(t *testing.T) {
@@ -80,6 +81,14 @@ func TestLoadKeys(t *testing.T) {
 		err = SetIPSecSPI(log, spi)
 		require.NoError(t, err)
 	}
+}
+
+func TestLoadKeysSameSPI(t *testing.T) {
+	log := setupIPSecSuitePrivileged(t)
+
+	keys := bytes.NewReader(keysSameSpiDat)
+	_, _, err := LoadIPSecKeys(log, keys)
+	require.ErrorContains(t, err, "invalid SPI: changing IPSec keys requires incrementing the key id")
 }
 
 func TestParseSPI(t *testing.T) {

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -200,6 +200,7 @@ func setupLinuxPrivilegedIPv4AndIPv6TestSuite(tb testing.TB) *linuxPrivilegedIPv
 }
 
 func tearDownTest(tb testing.TB) {
+	ipsec.UnsetTestIPSecKey()
 	ipsec.DeleteXFRM(hivetest.Logger(tb), ipsec.AllReqID)
 	node.UnsetTestLocalNodeStore()
 	removeDevice(dummyHostDeviceName)
@@ -826,6 +827,9 @@ func TestNodeChurnXFRMLeaks(t *testing.T) {
 	defer removeDevice(externalNodeDevice)
 	option.Config.EncryptInterface = []string{externalNodeDevice}
 	option.Config.RoutingMode = option.RoutingModeNative
+
+	// Same test suite, remove previous IPSec key.
+	ipsec.UnsetTestIPSecKey()
 
 	// Cover the XFRM configuration for subnet encryption: IPAM modes AKS and EKS.
 	ipv4PodSubnets, err := cidr.ParseCIDR("4.4.0.0/16")


### PR DESCRIPTION
Adding logic (and unit test) to detect unchanged SPI while creating a new IPSEC key.

Fixes: #14873

@pchaigno @julianwiedmann :smiley: 

```release-note
In case of an IPsec key rotation, error if the user forgot to increment the SPI per the documentation.
```
