### PR TITLE
Revert "operator/identitygc: Disable identitygc when Operator manages CID"

### DIFF
--- a/operator/identitygc/cell.go
+++ b/operator/identitygc/cell.go
@@ -81,8 +81,4 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 type SharedConfig struct {
 	// IdentityAllocationMode specifies what mode to use for identity allocation
 	IdentityAllocationMode string
-	// EnableOperatorManageCIDs enables operator to manage CID by
-	// running a CID controller. If enabled, Identity GC cell is
-	// then disabled because CID controller takes care of garbage collection.
-	EnableOperatorManageCIDs bool
 }

--- a/operator/identitygc/gc.go
+++ b/operator/identitygc/gc.go
@@ -88,7 +88,7 @@ type GC struct {
 }
 
 func registerGC(p params) {
-	if !p.Clientset.IsEnabled() || p.SharedCfg.EnableOperatorManageCIDs {
+	if !p.Clientset.IsEnabled() {
 		return
 	}
 


### PR DESCRIPTION
Reverts cilium/cilium#33381

Follow-up on https://github.com/cilium/cilium/pull/33380#discussion_r1669494701.

The current implementation of Operator Managing CIDs will still use the existing identitygc. 