### PR TITLE
k8s: Reflector for reflecting ListerWatcher into StateDB table

### DIFF
--- a/pkg/k8s/statedb.go
+++ b/pkg/k8s/statedb.go
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	"github.com/cilium/stream"
+
+	"github.com/cilium/cilium/pkg/time"
+)
+
+var errListerWatcherNil = errors.New("ReflectorConfig.ListerWatcher must be defined (was nil)")
+
+// RegisterReflector registers a Kubernetes to StateDB table reflector.
+//
+// Intended to be used with [cell.Invoke] and the module's job group.
+// See [ExampleRegisterReflector] for example usage.
+func RegisterReflector[Obj any](jobGroup job.Group, db *statedb.DB, targetTable statedb.RWTable[Obj], cfg ReflectorConfig[Obj]) error {
+	if cfg.ListerWatcher == nil {
+		return errListerWatcherNil
+	}
+
+	// Register initializer that marks when the table has been initially populated,
+	// e.g. the initial "List" has concluded.
+	r := &k8sReflector[Obj]{
+		ReflectorConfig: cfg.withDefaults(),
+		db:              db,
+		table:           targetTable,
+	}
+	wtxn := db.WriteTxn(targetTable)
+	r.initDone = targetTable.RegisterInitializer(wtxn, "k8s-reflector")
+	wtxn.Commit()
+
+	jobGroup.Add(job.OneShot(
+		fmt.Sprintf("k8s-reflector-[%T]", *new(Obj)),
+		r.run))
+
+	return nil
+}
+
+type ReflectorConfig[Obj any] struct {
+	// Maximum number of objects to commit in one transaction. Uses default if left zero.
+	// This does not apply to the initial listing which is committed in one go.
+	BufferSize int
+
+	// The amount of time to wait for the buffer to fill. Uses default if left zero.
+	BufferWaitTime time.Duration
+
+	// The ListerWatcher to use to retrieve the objects.
+	//
+	// Use [utils.ListerWatcherFromTyped] to create one from the Clientset, e.g.
+	//
+	//   var cs client.Clientset
+	//   utils.ListerWatcherFromTyped(cs.CoreV1().Nodes())
+	//
+	ListerWatcher cache.ListerWatcher
+
+	// Optional function to transform the objects given by the ListerWatcher. This can
+	// be used to convert into an internal model on the fly to save space and add additional
+	// fields or to for example implement TableRow/TableHeader for a cilium-dbg statedb command.
+	Transform TransformFunc[Obj]
+
+	// Optional function to query all objects. Used when replacing the objects on resync.
+	// This can be used to "namespace" the objects managed by this reflector, e.g. on
+	// source.Source etc.
+	QueryAll QueryAllFunc[Obj]
+}
+
+// TransformFunc is an optional function to give to the Kubernetes reflector
+// to transform the object returned by the ListerWatcher to the desired
+// target object. If the function returns false the object is silently
+// skipped.
+type TransformFunc[Obj any] func(any) (obj Obj, ok bool)
+
+// QueryAllFunc is an optional function to give to the Kubernetes reflector
+// to query all objects in the table that are managed by the reflector.
+// It is used to delete all objects when the underlying cache.Reflector needs
+// to Replace() all items for a resync.
+type QueryAllFunc[Obj any] func(statedb.ReadTxn, statedb.Table[Obj]) statedb.Iterator[Obj]
+
+const (
+	// DefaultBufferSize is the maximum number of objects to commit to the table in one write transaction.
+	DefaultBufferSize = 10000
+
+	// DefaultBufferWaitTime is the amount of time to wait to fill the buffer before committing objects.
+	// 10000 * 50ms => 200k objects per second throughput limit.
+	DefaultBufferWaitTime = 50 * time.Millisecond
+)
+
+// withDefaults fills in unset fields with default values.
+func (cfg ReflectorConfig[Obj]) withDefaults() ReflectorConfig[Obj] {
+	if cfg.BufferSize == 0 {
+		cfg.BufferSize = DefaultBufferSize
+	}
+	if cfg.BufferWaitTime == 0 {
+		cfg.BufferWaitTime = DefaultBufferWaitTime
+	}
+	return cfg
+}
+
+type k8sReflector[Obj any] struct {
+	ReflectorConfig[Obj]
+
+	initDone func(statedb.WriteTxn)
+	db       *statedb.DB
+	table    statedb.RWTable[Obj]
+}
+
+func (r *k8sReflector[Obj]) run(ctx context.Context, health cell.Health) error {
+	type entry struct {
+		deleted   bool
+		name      string
+		namespace string
+		obj       Obj
+	}
+	type buffer struct {
+		replaceItems []any
+		entries      map[string]entry
+	}
+	bufferSize := r.BufferSize
+	waitTime := r.BufferWaitTime
+	table := r.table
+
+	transform := r.Transform
+	if transform == nil {
+		// No provided transform function, use the identity function instead.
+		transform = TransformFunc[Obj](func(obj any) (Obj, bool) { return obj.(Obj), true })
+	}
+
+	queryAll := r.QueryAll
+	if queryAll == nil {
+		// No query function provided, use All()
+		queryAll = QueryAllFunc[Obj](func(txn statedb.ReadTxn, tbl statedb.Table[Obj]) statedb.Iterator[Obj] {
+			return tbl.All(txn)
+		})
+	}
+
+	// Construct a stream of K8s objects, buffered into chunks every [waitTime] period
+	// and then committed.
+	// This reduces the number of write transactions required and thus the number of times
+	// readers get woken up, which results in much better overall throughput.
+	src := stream.Buffer(
+		ListerWatcherToObservable(r.ListerWatcher),
+		bufferSize,
+		waitTime,
+
+		// Buffer the events into a map, coalescing them by key.
+		func(buf *buffer, ev CacheStoreEvent) *buffer {
+			switch {
+			case ev.Kind == CacheStoreEventReplace:
+				return &buffer{
+					replaceItems: ev.Obj.([]any),
+					entries:      make(map[string]entry, bufferSize), // Forget prior entries
+				}
+			case buf == nil:
+				buf = &buffer{
+					replaceItems: nil,
+					entries:      make(map[string]entry, bufferSize),
+				}
+			}
+
+			var entry entry
+			var ok bool
+			entry.obj, ok = transform(ev.Obj)
+			if !ok {
+				return buf
+			}
+			entry.deleted = ev.Kind == CacheStoreEventDelete
+
+			meta, err := meta.Accessor(ev.Obj)
+			if err != nil {
+				panic(fmt.Sprintf("%T internal error: meta.Accessor failed: %s", r, err))
+			}
+			entry.name = meta.GetName()
+			entry.namespace = meta.GetNamespace()
+			var key string
+			if entry.namespace != "" {
+				key = entry.namespace + "/" + entry.name
+			} else {
+				key = entry.name
+			}
+			buf.entries[key] = entry
+			return buf
+		},
+	)
+
+	commitBuffer := func(buf *buffer) {
+		numUpserted, numDeleted := 0, 0
+
+		txn := r.db.WriteTxn(table)
+		if buf.replaceItems != nil {
+			iter := queryAll(txn, table)
+			for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+				numDeleted++
+				table.Delete(txn, obj)
+			}
+			for _, item := range buf.replaceItems {
+				if obj, ok := transform(item); ok {
+					table.Insert(txn, obj)
+					numUpserted++
+				}
+			}
+			// Mark the table as initialized. Internally this has a sync.Once
+			// so safe to call multiple times.
+			r.initDone(txn)
+		}
+
+		for _, entry := range buf.entries {
+			if !entry.deleted {
+				numUpserted++
+				table.Insert(txn, entry.obj)
+			} else {
+				numDeleted++
+				table.Delete(txn, entry.obj)
+			}
+		}
+
+		numTotal := table.NumObjects(txn)
+		txn.Commit()
+
+		health.OK(fmt.Sprintf("%d inserted, %d deleted, %d total", numUpserted, numDeleted, numTotal))
+	}
+
+	errs := make(chan error)
+	src.Observe(
+		ctx,
+		commitBuffer,
+		func(err error) {
+			errs <- err
+			close(errs)
+		},
+	)
+	return <-errs
+}
+
+// ListerWatcherToObservable turns a ListerWatcher into an observable using the
+// client-go's Reflector.
+func ListerWatcherToObservable(lw cache.ListerWatcher) stream.Observable[CacheStoreEvent] {
+	return stream.FuncObservable[CacheStoreEvent](
+		func(ctx context.Context, next func(CacheStoreEvent), complete func(err error)) {
+			store := &cacheStoreListener{
+				onAdd: func(obj any) {
+					next(CacheStoreEvent{CacheStoreEventAdd, obj})
+				},
+				onUpdate:  func(obj any) { next(CacheStoreEvent{CacheStoreEventUpdate, obj}) },
+				onDelete:  func(obj any) { next(CacheStoreEvent{CacheStoreEventDelete, obj}) },
+				onReplace: func(objs []any) { next(CacheStoreEvent{CacheStoreEventReplace, objs}) },
+			}
+			reflector := cache.NewReflector(lw, nil, store, 0)
+			go func() {
+				reflector.Run(ctx.Done())
+				complete(nil)
+			}()
+		})
+}
+
+type CacheStoreEventKind int
+
+const (
+	CacheStoreEventAdd = CacheStoreEventKind(iota)
+	CacheStoreEventUpdate
+	CacheStoreEventDelete
+	CacheStoreEventReplace
+)
+
+type CacheStoreEvent struct {
+	Kind CacheStoreEventKind
+	Obj  any
+}
+
+// cacheStoreListener implements the methods used by the cache reflector and
+// calls the given handlers for added, updated and deleted objects.
+type cacheStoreListener struct {
+	onAdd, onUpdate, onDelete func(any)
+	onReplace                 func([]any)
+}
+
+func (s *cacheStoreListener) Add(obj interface{}) error {
+	s.onAdd(obj)
+	return nil
+}
+
+func (s *cacheStoreListener) Update(obj interface{}) error {
+	s.onUpdate(obj)
+	return nil
+}
+
+func (s *cacheStoreListener) Delete(obj interface{}) error {
+	s.onDelete(obj)
+	return nil
+}
+
+func (s *cacheStoreListener) Replace(items []interface{}, resourceVersion string) error {
+	if items == nil {
+		// Always emit a non-nil slice for replace.
+		items = []interface{}{}
+	}
+	s.onReplace(items)
+	return nil
+}
+
+// These methods are never called by cache.Reflector:
+
+func (*cacheStoreListener) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	panic("unimplemented")
+}
+func (*cacheStoreListener) GetByKey(key string) (item interface{}, exists bool, err error) {
+	panic("unimplemented")
+}
+func (*cacheStoreListener) List() []interface{} { panic("unimplemented") }
+func (*cacheStoreListener) ListKeys() []string  { panic("unimplemented") }
+func (*cacheStoreListener) Resync() error       { panic("unimplemented") }
+
+var _ cache.Store = &cacheStoreListener{}

--- a/pkg/k8s/statedb_test.go
+++ b/pkg/k8s/statedb_test.go
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/k8s"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func ExampleRegisterReflector() {
+	var module = cell.Module(
+		"example-reflector",
+		"Reflector example",
+
+		cell.ProvidePrivate(
+			// The table the reflector writes to (RWTable[*Node]).
+			newTestNodeTable,
+
+			// ReflectorConfig defines the ListerWatcher to use the fetch the objects
+			// and how to write them to the table.
+			func(client k8sClient.Clientset) k8s.ReflectorConfig[*corev1.Node] {
+				return k8s.ReflectorConfig[*corev1.Node]{
+					ListerWatcher: utils.ListerWatcherFromTyped(client.CoreV1().Nodes()),
+				}
+			},
+		),
+
+		// Provide Table[*Node] for read-access to all modules in the application.
+		cell.Provide(statedb.RWTable[*corev1.Node].ToTable),
+
+		// Register the reflector to this module's job group.
+		cell.Invoke(k8s.RegisterReflector[*corev1.Node]),
+	)
+
+	hive.New(module)
+}
+
+var (
+	testNodeNameIndex = statedb.Index[*corev1.Node, string]{
+		Name: "name",
+		FromObject: func(obj *corev1.Node) index.KeySet {
+			return index.NewKeySet(index.String(obj.Name))
+		},
+		FromKey: index.String,
+		Unique:  true,
+	}
+)
+
+func newTestNodeTable(db *statedb.DB) (statedb.RWTable[*corev1.Node], error) {
+	tbl, err := statedb.NewTable(
+		"test-nodes",
+		testNodeNameIndex,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return tbl, db.RegisterTable(tbl)
+}
+
+func TestStateDBReflector(t *testing.T) {
+	testStateDBReflector(t, false, false)
+}
+
+func TestStateDBReflector_Transform(t *testing.T) {
+	testStateDBReflector(t, true, false)
+}
+
+func TestStateDBReflector_QueryAll(t *testing.T) {
+	testStateDBReflector(t, false, true)
+}
+
+func TestStateDBReflector_TransformQueryAll(t *testing.T) {
+	testStateDBReflector(t, true, true)
+}
+
+func testStateDBReflector(t *testing.T, doTransform, doQueryAll bool) {
+	var (
+		node1Name = "node1"
+		node2Name = "node2"
+		node      = &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            node1Name,
+				ResourceVersion: "0",
+			},
+			Status: corev1.NodeStatus{
+				Phase: "init",
+			},
+		}
+		fakeClient, cs = k8sClient.NewFakeClientset()
+
+		db                              *statedb.DB
+		nodeTable                       statedb.Table[*corev1.Node]
+		transformCalled, queryAllCalled atomic.Bool
+	)
+
+	// Create the initial version of the node. Do this before anything
+	// starts watching the resources to avoid a race.
+	fakeClient.KubernetesFakeClientset.Tracker().Create(
+		corev1.SchemeGroupVersion.WithResource("nodes"),
+		node.DeepCopy(), "")
+
+	var testTimeout = 10 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	var transformFunc k8s.TransformFunc[*corev1.Node]
+	if doTransform {
+		transformFunc = func(a any) (obj *corev1.Node, ok bool) {
+			transformCalled.Store(true)
+			obj = a.(*corev1.Node).DeepCopy()
+			obj.ObjectMeta.GenerateName = "transformed"
+			return obj, true
+		}
+	}
+
+	var queryAllFunc k8s.QueryAllFunc[*corev1.Node]
+	if doQueryAll {
+		queryAllFunc = func(txn statedb.ReadTxn, tbl statedb.Table[*corev1.Node]) statedb.Iterator[*corev1.Node] {
+			// This method is called on the initial synchronization (e.g. Replace()) and whenever
+			// connection is lost to api-server and resynchronization is needed.
+			queryAllCalled.Store(true)
+			return tbl.All(txn)
+		}
+	}
+
+	hive := hive.New(
+		cell.Provide(func() k8sClient.Clientset { return cs }),
+		cell.Module("test", "test",
+			cell.ProvidePrivate(
+				func(client k8sClient.Clientset) k8s.ReflectorConfig[*corev1.Node] {
+					return k8s.ReflectorConfig[*corev1.Node]{
+						BufferSize:     10,
+						BufferWaitTime: time.Millisecond,
+						ListerWatcher:  utils.ListerWatcherFromTyped(client.CoreV1().Nodes()),
+						Transform:      transformFunc,
+						QueryAll:       queryAllFunc,
+					}
+				},
+				newTestNodeTable,
+			),
+			cell.Invoke(
+				k8s.RegisterReflector[*corev1.Node],
+				func(db_ *statedb.DB, tbl statedb.RWTable[*corev1.Node]) {
+					// Insert a dummy node into the table to verify that the initial synchronization
+					// cleans things up.
+					// BTW, if you don't want everything cleaned up you can specify the QueryAll
+					// function to "namespace" what the reflector is managing.
+					wtxn := db_.WriteTxn(tbl)
+					var garbageNode corev1.Node
+					garbageNode.Name = "garbage"
+					tbl.Insert(wtxn, &garbageNode)
+					wtxn.Commit()
+
+					db = db_
+					nodeTable = tbl
+				}),
+		),
+	)
+
+	tlog := hivetest.Logger(t)
+	if err := hive.Start(tlog, ctx); err != nil {
+		t.Fatalf("hive.Start failed: %s", err)
+	}
+
+	// Wait until the table has been initialized.
+	require.Eventually(
+		t,
+		func() bool { return nodeTable.Initialized(db.ReadTxn()) },
+		time.Second,
+		5*time.Millisecond)
+
+	// After initialization we should see the node that was created
+	// before starting.
+	iter, watch := nodeTable.AllWatch(db.ReadTxn())
+	nodes := statedb.Collect(iter)
+	require.Len(t, nodes, 1)
+	require.Equal(t, node1Name, nodes[0].Name)
+
+	if doTransform {
+		// Transform func set, check that it was used.
+		require.Equal(t, "transformed", nodes[0].GenerateName)
+	}
+
+	// Update the node and check that it updated.
+	node.Status.Phase = "update1"
+	node.ObjectMeta.ResourceVersion = "1"
+	fakeClient.KubernetesFakeClientset.Tracker().Update(
+		corev1.SchemeGroupVersion.WithResource("nodes"),
+		node.DeepCopy(), "")
+
+	<-watch
+	iter, watch = nodeTable.AllWatch(db.ReadTxn())
+	nodes = statedb.Collect(iter)
+	require.Len(t, nodes, 1)
+	require.EqualValues(t, "update1", nodes[0].Status.Phase)
+
+	// Create another node after initialization.
+	node2 := node.DeepCopy()
+	node2.ObjectMeta.Name = node2Name
+	fakeClient.KubernetesFakeClientset.Tracker().Create(
+		corev1.SchemeGroupVersion.WithResource("nodes"),
+		node2.DeepCopy(), "")
+
+	// Wait until updated.
+	<-watch
+	iter, watch = nodeTable.AllWatch(db.ReadTxn())
+	nodes = statedb.Collect(iter)
+	require.Len(t, nodes, 2)
+	require.Equal(t, node1Name, nodes[0].Name)
+	require.Equal(t, node2Name, nodes[1].Name)
+
+	// Finally delete the nodes
+	fakeClient.KubernetesFakeClientset.Tracker().Delete(
+		corev1.SchemeGroupVersion.WithResource("nodes"),
+		"", node1Name)
+
+	<-watch
+	iter, watch = nodeTable.AllWatch(db.ReadTxn())
+	nodes = statedb.Collect(iter)
+	require.Len(t, nodes, 1)
+	require.EqualValues(t, node2Name, nodes[0].Name)
+
+	fakeClient.KubernetesFakeClientset.Tracker().Delete(
+		corev1.SchemeGroupVersion.WithResource("nodes"),
+		"", node2Name)
+
+	<-watch
+	iter, _ = nodeTable.AllWatch(db.ReadTxn())
+	nodes = statedb.Collect(iter)
+	require.Len(t, nodes, 0)
+
+	// Finally check that the hive stops correctly. Note that we're not doing this in a
+	// defer to avoid potentially deadlocking on the Fatal calls.
+	if err := hive.Stop(tlog, context.TODO()); err != nil {
+		t.Fatalf("hive.Stop failed: %s", err)
+	}
+
+	if doTransform {
+		assert.True(t, transformCalled.Load(), "provided transform func not used")
+	}
+	if doQueryAll {
+		assert.True(t, queryAllCalled.Load(), "provided query all func not used")
+	}
+
+}


### PR DESCRIPTION
This implements a reflector from a client-go ListerWatcher into StateDB table. It is implemented on top of the client-go Reflector that the Informer uses. This is aiming to eventually replace `Resource[T]`.

Benefits over `Resource[T]`:
- Flexible indexing, querying and watching capabilities. With a statedb.Index on the objects we can have complex querying capabilities. Easy to also watch a subset of objects for changes (e.g. ListWatch/PrefixWatch etc.).
- The objects can be inspected easily from outside (e.g. "cilium-dbg statedb dump", or custom "cilium-dbg statedb table-name" command).
- Consistent way of combining event-based processing with queries against the table. The read transaction used with the Changes() iteration can be used to do consistent queries against the state without worrying about the event saying one thing and the store another. This enables controller-runtime style reconciliation patterns.
- No workqueue. The Resource[T] workqueue was useful only in certain specific cases. Here there is no "per-subscriber" state that uses up memory. If needed, one can use the StateDB reconciler to reconcile the changes with retrying etc. (a custom model and "transform func" needed for the status field).
- Batch processing. The readers of the table can process new changes in batches which reduces context switching and allows for more efficient operations down the line (BPF batch ops etc.).

Example usage:
```
  var (
    db *statedb.DB
    myTable statedb.RWTable[*someObject]
	lw cache.ListerWatcher // Same as with Resource[T]
	jobGroup job.Group
  )
  cfg := k8s.ReflectorConfig[*someObject]{
	Table: myTable,
	ListerWatcher: lw,
  }

  // Register a background job to the 'jobGroup' to start reflecting
  // to [myTable] with the [lw].
  k8s.RegisterReflector[*someObject](
	jobGroup,
	db,
	cfg
  )

  // Initialized() returns true when initial listing is done.
  // E.g. this is replacement for the Resource[T] "Sync" event or
  // "CachesSynced"
  for !myTable.Initialized(db.ReadTxn()) { ... }

  // The objects can be queried:
  myTable.Get(db.ReadTxn(), myIndex.Query("foo"))

  // Resource[T]-style event stream is possible with Changes():
  wtxn := db.WriteTxn(myTable)
  changes := myTable.Changes(wtxn, "foo")
  wtxn.Commit()

  for {
      for obj, rev, deleted, ok := changes.Next(); ok; obj, rev, deleted, ok = changes.Next() {
        // process change
      }
      // Wait for new changes to refresh the iterator.
      <-changes.Wait(db.ReadTxn())
  }

  // The above iteration API can also be turned into an event stream for an almost
  // drop-in replacement for Resource[T] (there's no retrying though):
  var src stream.Observable[statedb.Change[*someObject]] =
    statedb.Observable(db, myTable)
```
