### PR TITLE
Make initial nat gc async during Daemon initialization.

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1056,7 +1056,7 @@ func (e *Endpoint) deleteMaps() []error {
 // local conntrack table or the global conntrack table.
 //
 // The endpoint lock must be held
-func (e *Endpoint) garbageCollectConntrack(filter *ctmap.GCFilter) {
+func (e *Endpoint) garbageCollectConntrack(filter ctmap.GCFilter) {
 	var maps []*ctmap.Map
 
 	if e.ConntrackLocalLocked() {
@@ -1082,7 +1082,7 @@ func (e *Endpoint) garbageCollectConntrack(filter *ctmap.GCFilter) {
 }
 
 func (e *Endpoint) scrubIPsInConntrackTableLocked() {
-	e.garbageCollectConntrack(&ctmap.GCFilter{
+	e.garbageCollectConntrack(ctmap.GCFilter{
 		MatchIPs: map[netip.Addr]struct{}{
 			e.IPv4: {},
 			e.IPv6: {},

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -171,10 +171,6 @@ type GCFilter struct {
 	// removed
 	Time uint32
 
-	// ValidIPs is the list of valid IPs to scrub all entries for which the
-	// source or destination IP is *not* matching one of the valid IPs.
-	ValidIPs map[netip.Addr]struct{}
-
 	// MatchIPs is the list of IPs to remove from the conntrack table
 	MatchIPs map[netip.Addr]struct{}
 
@@ -586,13 +582,6 @@ func doGC4(m *Map, filter *GCFilter) gcStats {
 func (f *GCFilter) doFiltering(srcIP, dstIP netip.Addr, srcPort, dstPort uint16, nextHdr, flags uint8, entry *CtEntry) action {
 	if f.RemoveExpired && entry.Lifetime < f.Time {
 		return deleteEntry
-	}
-	if f.ValidIPs != nil {
-		_, srcIPExists := f.ValidIPs[srcIP]
-		_, dstIPExists := f.ValidIPs[dstIP]
-		if !srcIPExists && !dstIPExists {
-			return deleteEntry
-		}
 	}
 
 	if f.MatchIPs != nil {

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -369,7 +369,7 @@ func purgeCtEntry6(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map) error {
 
 // doGC6 iterates through a CTv6 map and drops entries based on the given
 // filter.
-func doGC6(m *Map, filter *GCFilter) gcStats {
+func doGC6(m *Map, filter GCFilter) gcStats {
 	var natMap *nat.Map
 
 	if m.clusterID == 0 {
@@ -490,7 +490,7 @@ func purgeCtEntry4(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map) error {
 
 // doGC4 iterates through a CTv4 map and drops entries based on the given
 // filter.
-func doGC4(m *Map, filter *GCFilter) gcStats {
+func doGC4(m *Map, filter GCFilter) gcStats {
 	var natMap *nat.Map
 
 	if m.clusterID == 0 {
@@ -579,7 +579,7 @@ func doGC4(m *Map, filter *GCFilter) gcStats {
 	return stats
 }
 
-func (f *GCFilter) doFiltering(srcIP, dstIP netip.Addr, srcPort, dstPort uint16, nextHdr, flags uint8, entry *CtEntry) action {
+func (f GCFilter) doFiltering(srcIP, dstIP netip.Addr, srcPort, dstPort uint16, nextHdr, flags uint8, entry *CtEntry) action {
 	if f.RemoveExpired && entry.Lifetime < f.Time {
 		return deleteEntry
 	}
@@ -599,7 +599,7 @@ func (f *GCFilter) doFiltering(srcIP, dstIP netip.Addr, srcPort, dstPort uint16,
 	return noAction
 }
 
-func doGC(m *Map, filter *GCFilter) (int, error) {
+func doGC(m *Map, filter GCFilter) (int, error) {
 	if m.mapType.isIPv6() {
 		stats := doGC6(m, filter)
 		return int(stats.deleted), stats.dumpError
@@ -613,7 +613,7 @@ func doGC(m *Map, filter *GCFilter) (int, error) {
 
 // GC runs garbage collection for map m with name mapType with the given filter.
 // It returns how many items were deleted from m.
-func GC(m *Map, filter *GCFilter) (int, error) {
+func GC(m *Map, filter GCFilter) (int, error) {
 	if filter.RemoveExpired {
 		t, _ := timestamp.GetCTCurTime(timestamp.GetClockSourceFromOptions())
 		filter.Time = uint32(t)
@@ -719,7 +719,7 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 // Flush runs garbage collection for map m with the name mapType, deleting all
 // entries. The specified map must be already opened using bpf.OpenMap().
 func (m *Map) Flush() int {
-	d, _ := doGC(m, &GCFilter{
+	d, _ := doGC(m, GCFilter{
 		RemoveExpired: true,
 		Time:          MaxTime,
 	})

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -206,7 +206,7 @@ func TestCtGcIcmp(t *testing.T) {
 	require.Equal(t, 2, len(buf))
 
 	// GC and check whether NAT entries have been collected
-	filter := &GCFilter{
+	filter := GCFilter{
 		RemoveExpired: true,
 		Time:          39000,
 	}
@@ -317,7 +317,7 @@ func TestCtGcTcp(t *testing.T) {
 	require.Equal(t, 2, len(buf))
 
 	// GC and check whether NAT entries have been collected
-	filter := &GCFilter{
+	filter := GCFilter{
 		RemoveExpired: true,
 		Time:          39000,
 	}
@@ -408,7 +408,7 @@ func TestCtGcDsr(t *testing.T) {
 	require.Equal(t, 1, len(buf))
 
 	// GC and check whether NAT entry has been collected
-	filter := &GCFilter{
+	filter := GCFilter{
 		RemoveExpired: true,
 		Time:          39000,
 	}

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -65,7 +65,6 @@ type GC struct {
 	nodeAddrs statedb.Table[tables.NodeAddress]
 
 	endpointsManager EndpointManager
-	nodeAddressing   types.NodeAddressing
 	signalHandler    SignalHandler
 
 	perClusterCTMapsRetriever PerClusterCTMapsRetriever
@@ -83,7 +82,6 @@ func New(params parameters) *GC {
 		nodeAddrs: params.NodeAddrs,
 
 		endpointsManager: params.EndpointManager,
-		nodeAddressing:   params.NodeAddressing,
 		signalHandler:    params.SignalManager,
 
 		controllerManager: controller.NewManager(),


### PR DESCRIPTION
## Background

The initial CTMap GC has a hard coded timeout of 30 seconds: https://github.com/cilium/cilium/blob/4d016cc0c42de76f993877ea4dc3c618166ea62b/pkg/maps/ctmap/gc/gc.go#L227

This was designed to give more than sufficient time for this to complete. However, I would argue that such a timeout is not good practice as it's impossible to know all the possible environments this may be running on.  Specifically, a CPU constrained environment, such as a new Node starting possibly running other workloads, may experience unecessary crashes due to this if the ctmap + NAT map sweeps can't complete in time.  As well, this GC is also linked with the restored endpoint list - so a high number of restored endpoints also presents a factor in this timeout as well.

This PR seeks to make the initial CT GC async, such that newDaemon initialization continues without waiting for the first sweep to complete.  See [discussion](https://github.com/cilium/cilium/pull/34070#discussion_r1701046071) below for context regarding any possible issues resulting from implicit ordering in the newDaemon initialization.

Fixes: https://github.com/cilium/cilium/issues/32680