### PR TITLE
policy: Fixed  CIDRGroupRef breaking the sanitization

### DIFF
--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -528,6 +528,10 @@ func (c CIDR) sanitize() error {
 // valid, and ensuring that all of the exception CIDR prefixes are contained
 // within the allowed CIDR prefix.
 func (c *CIDRRule) sanitize() error {
+	if c.CIDRGroupRef != "" {
+		// When a CIDRGroupRef is set, we don't need to validate the CIDR
+		return nil
+	}
 	// Only allow notation <IP address>/<prefix>. Note that this differs from
 	// the logic in api.CIDR.Sanitize().
 	prefix, err := netip.ParsePrefix(string(c.Cidr))

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -590,6 +590,10 @@ func TestCIDRsanitize(t *testing.T) {
 	err = cidr.sanitize()
 	require.Nil(t, err)
 
+	cidr = CIDRRule{Cidr: "", CIDRGroupRef: "cidrgroup"}
+	err = cidr.sanitize()
+	require.Nil(t, err)
+
 	cidr = CIDRRule{Cidr: "2001:0db8:85a3:0000:0000:8a2e:0370:7334/128"}
 	err = cidr.sanitize()
 	require.Nil(t, err)


### PR DESCRIPTION
Fixes: #34066

```release-note
policy:  Fixed  CIDRGroupRef breaking the sanitization
```
