### PR TITLE
l4lb: fix inability to properly update service

### DIFF
--- a/pkg/service/cell.go
+++ b/pkg/service/cell.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/pkg/datapath/types"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 )
 
@@ -30,6 +31,7 @@ type serviceManagerParams struct {
 	MonitorAgent monitorAgent.Agent
 
 	HealthCheckers []HealthChecker `group:"healthCheckers"`
+	Clientset      k8sClient.Clientset
 }
 
 func newServiceInternal(params serviceManagerParams) *Service {
@@ -40,5 +42,5 @@ func newServiceInternal(params serviceManagerParams) *Service {
 		}
 	}
 
-	return newService(params.MonitorAgent, params.Datapath.LBMap(), params.Datapath.NodeNeighbors(), enabledHealthCheckers)
+	return newService(params.MonitorAgent, params.Datapath.LBMap(), params.Datapath.NodeNeighbors(), enabledHealthCheckers, params.Clientset.IsEnabled())
 }

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -220,7 +220,7 @@ func setupManagerTestSuite(tb testing.TB) *ManagerTestSuite {
 }
 
 func (m *ManagerTestSuite) newServiceMock(lbmap datapathTypes.LBMap) {
-	m.svc = newService(&FakeMonitorAgent{}, lbmap, nil, nil)
+	m.svc = newService(&FakeMonitorAgent{}, lbmap, nil, nil, true)
 	m.svc.backendConnectionHandler = testsockets.NewMockSockets(make([]*testsockets.MockSocket, 0))
 }
 
@@ -730,7 +730,7 @@ func TestRestoreServiceWithStaleBackends(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lbmap := mockmaps.NewLBMockMap()
-			svc := newService(&FakeMonitorAgent{}, lbmap, nil, nil)
+			svc := newService(&FakeMonitorAgent{}, lbmap, nil, nil, true)
 
 			_, id1, err := svc.upsertService(service("foo", "bar", "172.16.0.1", backendAddrs...))
 			require.NoError(t, err, "Failed to upsert service")
@@ -740,7 +740,7 @@ func TestRestoreServiceWithStaleBackends(t *testing.T) {
 			require.ElementsMatch(t, backendAddrs, toBackendAddrs(maps.Values(lbmap.BackendByID)), "lbmap not populated correctly")
 
 			// Recreate the Service structure, but keep the lbmap to restore services from
-			svc = newService(&FakeMonitorAgent{}, lbmap, nil, nil)
+			svc = newService(&FakeMonitorAgent{}, lbmap, nil, nil, true)
 			require.NoError(t, svc.RestoreServices(), "Failed to restore services")
 
 			// Simulate a set of service updates. Until synchronization completes, a given service
@@ -2261,7 +2261,7 @@ func TestRestoreServicesWithLeakedBackends(t *testing.T) {
 	m.svc.lbmap.AddBackend(backend5, backend5.L3n4Addr.IsIPv6())
 	require.Equal(t, len(backends)+4, len(m.lbmap.BackendByID))
 	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
-	m.svc = newService(&FakeMonitorAgent{}, lbmap, nil, nil)
+	m.svc = newService(&FakeMonitorAgent{}, lbmap, nil, nil, true)
 
 	// Restore services from lbmap
 	err := m.svc.RestoreServices()


### PR DESCRIPTION
When cilium-agent is restarted the restored backends are put into `restoredBackendHashes` set so that obsolete ones can be properly deleted only when k8s sync is done.

This is valid in k8s case, but when cilium-agent is running in standalone L4LB mode there is no way to do sync. There are only the ServiceAPI calls.
Therefore with the current code it is not possible to restart l4lb and remove specific backend from a service without previous service update call (to let l4lb know all the backends - simulate the sync). This should not be needed.

This commit fixes it in l4lb case.

```release-note
l4lb: fix inability to properly update service after agent restart 
```
related slack thread: https://cilium.slack.com/archives/C07BRCWT7GC/p1721913208811839
