### PR TITLE
chore: changing default values for policy-cidr-match-mode

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2879,7 +2879,7 @@
    * - :spelling:ignore:`policyCIDRMatchMode`
      - policyCIDRMatchMode is a list of entities that may be selected by CIDR selector. The possible value is "nodes".
      - string
-     - ``nil``
+     - ``nodes``
    * - :spelling:ignore:`policyEnforcementMode`
      - The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/security/policy/intro/#policy-enforcement-modes
      - string

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -763,10 +763,10 @@ Handling policy-cidr-match-mode during upgrades
 ===============================================
 
 
-From version 1.17 onwards, the default value of `policy-cidr-match-mode` is set to `nodes`. 
-Previously, this was set to `nil`. This change allows `ToCIDR` and `IPBlock` selectors to 
+From version 1.17 onwards, the default value of ``policy-cidr-match-mode`` is set to ``nodes``. 
+Previously, this was not set to ``""``. This change allows ``ToCIDR`` and ``IPBlock`` selectors to 
 include nodes by default, a feature that was previously only available by explicitly 
-setting `policy-cidr-match-mode=nodes`. It is important to review this change during 
+setting ``policy-cidr-match-mode=nodes``. It is important to review this change during 
 an upgrade of Cilium, as it may lead to unexpected behavior in existing installations.
 
 Impacted versions / configurations
@@ -774,21 +774,21 @@ Impacted versions / configurations
 
 This change impacts versions 1.17 and onwards, as it modifies the default value of this configuration.
 
-It also affects versions prior to 1.17 because, during an upgrade, the `policy-cidr-match-mode` is set to `nodes`. 
+It also affects versions prior to 1.17 because, during an upgrade, the ``policy-cidr-match-mode`` is set to ``nodes``. 
 This could potentially alter the traffic patterns, either allowing or denying traffic that was not previously allowed or denied. 
 For more details about this configuration, see the [Cilium documentation](https://docs.cilium.io/en/latest/security/policy/language/#selecting-nodes-with-cidr-ipblock).
 
 Mitigation
 ----------
 
-In order to ensure this change does not affect existing installations, pass `--set upgradeCompatibility=1.X` 
+In order to ensure this change does not affect existing installations, pass ``--set upgradeCompatibility=1.X`` 
 (where X is the version prior to 1.17) while generating the Helm template. 
-This will keep the `policy-cidr-match-mode` value unchanged from the existing installation.
+This will keep the ``policy-cidr-match-mode`` value unchanged from the existing installation.
 
 Migration
 ---------
 
-If you are already using the `--policy-cidr-match-mode=nodes` configuration in your existing cluster, this change will not affect you, and no migration is needed.
+If you are already using the ``--policy-cidr-match-mode=nodes`` configuration in your existing cluster, this change will not affect you, and no migration is needed.
 
-If you do not use `--policy-cidr-match-mode=nodes`, explicitly pass `--set policy-cidr-match-mode=""` during the upgrade. 
-If you use a `values.yaml` file local to your deployment, you can also set it there.
+If you do not use ``--policy-cidr-match-mode=nodes``, explicitly pass ``--set policy-cidr-match-mode=""`` during the upgrade. 
+If you use a ``values.yaml`` file local to your deployment, you can also set it there.

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -776,7 +776,7 @@ This change impacts versions 1.17 and onwards, as it modifies the default value 
 
 It also affects versions prior to 1.17 because, during an upgrade, the ``policy-cidr-match-mode`` is set to ``nodes``. 
 This could potentially alter the traffic patterns, either allowing or denying traffic that was not previously allowed or denied. 
-For more details about this configuration, see the [Cilium documentation](https://docs.cilium.io/en/latest/security/policy/language/#selecting-nodes-with-cidr-ipblock).
+For more details about this configuration, see the `Cilium documentation <https://docs.cilium.io/en/latest/security/policy/language/#selecting-nodes-with-cidr-ipblock>`_.
 
 Mitigation
 ----------

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -758,3 +758,37 @@ policies are now valid.
       level=info msg="All CCNPs and CNPs valid!"
 
 Once they are valid you can continue with the upgrade process. :ref:`cleanup_preflight_check`
+
+Handling policy-cidr-match-mode during upgrades
+===============================================
+
+
+From version 1.17 onwards, the default value of `policy-cidr-match-mode` is set to `nodes`. 
+Previously, this was set to `nil`. This change allows `ToCIDR` and `IPBlock` selectors to 
+include nodes by default, a feature that was previously only available by explicitly 
+setting `policy-cidr-match-mode=nodes`. It is important to review this change during 
+an upgrade of Cilium, as it may lead to unexpected behavior in existing installations.
+
+Impacted versions / configurations
+----------------------------------
+
+This change impacts versions 1.17 and onwards, as it modifies the default value of this configuration.
+
+It also affects versions prior to 1.17 because, during an upgrade, the `policy-cidr-match-mode` is set to `nodes`. 
+This could potentially alter the traffic patterns, either allowing or denying traffic that was not previously allowed or denied. 
+For more details about this configuration, see the [Cilium documentation](https://docs.cilium.io/en/latest/security/policy/language/#selecting-nodes-with-cidr-ipblock).
+
+Mitigation
+----------
+
+In order to ensure this change does not affect existing installations, pass `--set upgradeCompatibility=1.X` 
+(where X is the version prior to 1.17) while generating the Helm template. 
+This will keep the `policy-cidr-match-mode` value unchanged from the existing installation.
+
+Migration
+---------
+
+If you are already using the `--policy-cidr-match-mode=nodes` configuration in your existing cluster, this change will not affect you, and no migration is needed.
+
+If you do not use `--policy-cidr-match-mode=nodes`, explicitly pass `--set policy-cidr-match-mode=""` during the upgrade. 
+If you use a `values.yaml` file local to your deployment, you can also set it there.

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -769,7 +769,7 @@ contributors across the globe, there is almost always someone available to help.
 | podLabels | object | `{}` | Labels to be added to agent pods |
 | podSecurityContext | object | `{"appArmorProfile":{"type":"Unconfined"}}` | Security Context for cilium-agent pods. |
 | podSecurityContext.appArmorProfile | object | `{"type":"Unconfined"}` | AppArmorProfile options for the `cilium-agent` and init containers |
-| policyCIDRMatchMode | string | `nil` | policyCIDRMatchMode is a list of entities that may be selected by CIDR selector. The possible value is "nodes". |
+| policyCIDRMatchMode | string | `nodes` | policyCIDRMatchMode is a list of entities that may be selected by CIDR selector. The possible value is "nodes". |
 | policyEnforcementMode | string | `"default"` | The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/security/policy/intro/#policy-enforcement-modes |
 | pprof.address | string | `"localhost"` | Configure pprof listen address for cilium-agent |
 | pprof.enabled | bool | `false` | Enable pprof for cilium-agent |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -189,8 +189,13 @@ data:
   enable-policy: "{{ lower .Values.policyEnforcementMode }}"
 {{- end }}
 
-{{- if hasKey .Values "policyCIDRMatchMode" }}
-  policy-cidr-match-mode: {{ join " " .Values.policyCIDRMatchMode | quote }}
+{{- /* from 1.17 and onwards default value of policy-cidr-match-mode is 'nodes' */ -}}
+# if no upgradeCompatibility is supplied or if a value >= 1.17 is supllied, value 
+# of policy-cidr-match-mode is changed to the one defined in values.yaml
+{{- if semverCompare ">=1.17" (default "1.17" .Values.upgradeCompatibility) -}}
+  {{- if hasKey .Values "policyCIDRMatchMode" }}
+    policy-cidr-match-mode: {{ join " " .Values.policyCIDRMatchMode | quote }}
+  {{- end}}
 {{- end}}
 
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -53,6 +53,14 @@
   {{- $defaultDNSProxyEnableTransparentMode = "true" -}}
 {{- end -}}
 
+{{- $policyCIDRMatchMode := ""}}
+{{- /* Default values when 1.6 was initially deployed */ -}}
+{{- if semverCompare ">=1.17" (default "1.17" .Values.upgradeCompatibility) -}}
+  {{- if hasKey .Values "policyCIDRMatchMode"}}
+    {{- $policyCIDRMatchMode =  (join " " .Values.policyCIDRMatchMode | quote ) -}}
+  {{- end}}
+{{- end}}
+
 {{- /* Default values when 1.14 was initially deployed */ -}}
 {{- if semverCompare ">=1.14" (default "1.14" .Values.upgradeCompatibility) -}}
   {{- /* KPR default for 1.14 needed to override earlier version defaults set above when upgradeCompatibility is not specified */ -}}
@@ -189,14 +197,13 @@ data:
   enable-policy: "{{ lower .Values.policyEnforcementMode }}"
 {{- end }}
 
-{{- /* from 1.17 and onwards default value of policy-cidr-match-mode is 'nodes' */ -}}
+
 # if no upgradeCompatibility is supplied or if a value >= 1.17 is supllied, value 
 # of policy-cidr-match-mode is changed to the one defined in values.yaml
-{{- if semverCompare ">=1.17" (default "1.17" .Values.upgradeCompatibility) -}}
-  {{- if hasKey .Values "policyCIDRMatchMode" }}
-    policy-cidr-match-mode: {{ join " " .Values.policyCIDRMatchMode | quote }}
-  {{- end}}
+{{- if not (eq $policyCIDRMatchMode "") }}
+  policy-cidr-match-mode: {{ $policyCIDRMatchMode}}
 {{- end}}
+
 
 
 {{- if .Values.prometheus.enabled }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -54,7 +54,7 @@
 {{- end -}}
 
 {{- $policyCIDRMatchMode := ""}}
-{{- /* Default values when 1.6 was initially deployed */ -}}
+{{- /* Default values when 1.17 was initially deployed */ -}}
 {{- if semverCompare ">=1.17" (default "1.17" .Values.upgradeCompatibility) -}}
   {{- if hasKey .Values "policyCIDRMatchMode"}}
     {{- $policyCIDRMatchMode =  (join " " .Values.policyCIDRMatchMode | quote ) -}}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2112,7 +2112,7 @@ policyEnforcementMode: "default"
 # @schema
 # -- policyCIDRMatchMode is a list of entities that may be selected by CIDR selector.
 # The possible value is "nodes".
-policyCIDRMatchMode: ["nodes"]
+policyCIDRMatchMode:
 pprof:
   # -- Enable pprof for cilium-agent
   enabled: false

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2112,7 +2112,7 @@ policyEnforcementMode: "default"
 # @schema
 # -- policyCIDRMatchMode is a list of entities that may be selected by CIDR selector.
 # The possible value is "nodes".
-policyCIDRMatchMode:
+policyCIDRMatchMode: "nodes"
 pprof:
   # -- Enable pprof for cilium-agent
   enabled: false

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2112,7 +2112,7 @@ policyEnforcementMode: "default"
 # @schema
 # -- policyCIDRMatchMode is a list of entities that may be selected by CIDR selector.
 # The possible value is "nodes".
-policyCIDRMatchMode:
+policyCIDRMatchMode: ["nodes"]
 pprof:
   # -- Enable pprof for cilium-agent
   enabled: false

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2112,7 +2112,7 @@ policyEnforcementMode: "default"
 # @schema
 # -- policyCIDRMatchMode is a list of entities that may be selected by CIDR selector.
 # The possible value is "nodes".
-policyCIDRMatchMode: "nodes"
+policyCIDRMatchMode: ["nodes"]
 pprof:
   # -- Enable pprof for cilium-agent
   enabled: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2125,7 +2125,7 @@ policyEnforcementMode: "default"
 # @schema
 # -- policyCIDRMatchMode is a list of entities that may be selected by CIDR selector.
 # The possible value is "nodes".
-policyCIDRMatchMode:
+policyCIDRMatchMode: ["nodes"]
 pprof:
   # -- Enable pprof for cilium-agent
   enabled: false

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -628,5 +628,5 @@ var (
 		"cilium_lb6_affinity_match": "enabled,128,0",
 	}
 
-	PolicyCIDRMatchMode = []string{}
+	PolicyCIDRMatchMode = []string{"nodes"}
 )


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

This PR changes the default value of `policy-cidr-match-mode` to `nodes` while installation.
Since this has unwanted consequences on existing installations, the changed is being supported by `upgradeCompatibility` flag.

The intended behaviour of this change is 
- for all new installations `policy-cidr-match-mode` is set to `nodes` by default
- for upgrades if no upgradeCompatibility is set or if upgradeCompatibility >= 1.17 then `policy-cidr-match-mode` is set to `nodes`.
- for upgrades if upgradeCompatibility < 1.17 then the `policy-cidr-match-mode` remains unchanged. 
- docs can be found [here](https://deploy-preview-34080--docs-cilium-io.netlify.app/operations/upgrade#handling-policy-cidr-match-mode-during-upgrades)


Fixes: #31961

```release-note
Changed default values for policy-cidr-match-mode to nodes
```
### Local tests 
- When `upgradeCompatibility`  is _not_ provided then `policy-cidr-match-mode` is set to `nodes` as defined in values.yaml. 
```
helm template test-release --debug  ./install/kubernetes/cilium \              
  --namespace kube-system | grep 'policy-cidr-match-mode'
install.go:222: [debug] Original chart version: ""
install.go:239: [debug] CHART PATH: /Users/anuragdubey/Documents/GitHub/cilium/install/kubernetes/cilium

# of policy-cidr-match-mode is changed to the one defined in values.yaml
  policy-cidr-match-mode: "nodes"
```
- When `upgradeCompatibility`  is provided as _1.17_ then `policy-cidr-match-mode` is set to `nodes` as defined in values.yaml. 
```
helm template test-release --debug  ./install/kubernetes/cilium \
  --set upgradeCompatibility=1.17 \
  --namespace kube-system | grep 'policy-cidr-match-mode'
install.go:222: [debug] Original chart version: ""
install.go:239: [debug] CHART PATH: /Users/anuragdubey/Documents/GitHub/cilium/install/kubernetes/cilium

# of policy-cidr-match-mode is changed to the one defined in values.yaml
  policy-cidr-match-mode: "nodes"
```

-  When `upgradeCompatibility`  is provided as _1.18_ then `policy-cidr-match-mode` is set to `nodes` as defined in values.yaml. 
```
helm template test-release --debug  ./install/kubernetes/cilium \
  --set upgradeCompatibility=1.18 \
  --namespace kube-system | grep 'policy-cidr-match-mode'
install.go:222: [debug] Original chart version: ""
install.go:239: [debug] CHART PATH: /Users/anuragdubey/Documents/GitHub/cilium/install/kubernetes/cilium

# of policy-cidr-match-mode is changed to the one defined in values.yaml
  policy-cidr-match-mode: "nodes"
  ```
  - When `upgradeCompatibility`  is provided as _1.16_ then `policy-cidr-match-mode` is not set and hence remains unchanged.
  ```
  helm template test-release --debug  ./install/kubernetes/cilium \
  --set upgradeCompatibility=1.16 \
  --namespace kube-system | grep 'policy-cidr-match-mode'
install.go:222: [debug] Original chart version: ""
install.go:239: [debug] CHART PATH: /Users/anuragdubey/Documents/GitHub/cilium/install/kubernetes/cilium

# of policy-cidr-match-mode is changed to the one defined in values.yaml
```