### PR TITLE
Fixes to Active Connection Tracking

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -970,8 +970,12 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 		 */
 		backend = lb6_lookup_backend(ctx, backend_id);
 #ifdef ENABLE_ACTIVE_CONNECTION_TRACKING
-		if (state->closing && backend)
-			_lb_act_conn_closed(svc->rev_nat_index, backend->zone);
+		if (backend) {
+			if (state->syn) /* Reopened connections */
+				_lb_act_conn_open(svc->rev_nat_index, backend->zone);
+			else if (state->closing)
+				_lb_act_conn_closed(svc->rev_nat_index, backend->zone);
+		}
 #endif
 		if (unlikely(!backend || backend->flags != BE_STATE_ACTIVE)) {
 			/* Drain existing connections, but redirect new ones to only
@@ -1670,8 +1674,12 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 		 */
 		backend = lb4_lookup_backend(ctx, backend_id);
 #ifdef ENABLE_ACTIVE_CONNECTION_TRACKING
-		if (state->closing && backend)
-			_lb_act_conn_closed(svc->rev_nat_index, backend->zone);
+		if (backend) {
+			if (state->syn) /* Reopened connections */
+				_lb_act_conn_open(svc->rev_nat_index, backend->zone);
+			else if (state->closing)
+				_lb_act_conn_closed(svc->rev_nat_index, backend->zone);
+		}
 #endif
 		if (unlikely(!backend || backend->flags != BE_STATE_ACTIVE)) {
 			/* Drain existing connections, but redirect new ones to only

--- a/pkg/act/act.go
+++ b/pkg/act/act.go
@@ -507,7 +507,7 @@ func (a *ACT) reconcileServices(ctx context.Context) error {
 	svcs := a.svcIDs()
 	tracked := make(map[uint16]bool, len(svcs))
 	for _, svc := range svcs {
-		tracked[uint16(svc)] = true
+		tracked[byteorder.HostToNetwork16(uint16(svc))] = true
 	}
 	select {
 	case <-ctx.Done():

--- a/pkg/act/act_test.go
+++ b/pkg/act/act_test.go
@@ -306,7 +306,8 @@ func TestReconcileServices(t *testing.T) {
 		123: {24: nl, 26: nl, 27: nl, 29: nl},
 		124: {25: nl, 26: nl, 27: nl, 28: nl},
 	}
-	activeServices := []loadbalancer.ServiceID{24, 26, 27}
+	// {24, 26, 27} but in host byte order
+	activeServices := []loadbalancer.ServiceID{24 * 256, 26 * 256, 27 * 256}
 	a.svcIDs = func() []loadbalancer.ServiceID {
 		return activeServices
 	}


### PR DESCRIPTION
Fixes https://github.com/cilium/cilium/pull/32584
1. Uses the correct byte order when translating ServiceID to `svc_id` used in BPF map
2. Counts connections that have the same source port as a previous one (either reopened or the old entry hasn't expired yet)

Part of https://github.com/cilium/cilium/issues/31752

```release-note
Reopened connections are now correctly counted towards opened in Active Connection Tracking
```
