### PR TITLE
fix: Assign PodStore from Pod resource until cell migration is completed

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -652,6 +652,15 @@ func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 	ciliumNodeSynchronizer := newCiliumNodeSynchronizer(legacy.clientset, nodeManager, withKVStore)
 
 	if legacy.clientset.IsEnabled() {
+		// ciliumNodeSynchronizer uses operatorWatchers.PodStore for IPAM surge
+		// allocation. Initializing PodStore from Pod resource is temporary until
+		// ciliumNodeSynchronizer is migrated to a cell.
+		podStore, err := legacy.resources.Pods.Store(legacy.ctx)
+		if err != nil {
+			log.WithError(err).Fatal("Unable to retrieve Pod store from Pod resource watcher")
+		}
+		operatorWatchers.PodStore = podStore.CacheStore()
+
 		if err := ciliumNodeSynchronizer.Start(legacy.ctx, &legacy.wg); err != nil {
 			log.WithError(err).Fatal("Unable to setup cilium node synchronizer")
 		}

--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -105,9 +105,11 @@ func PodResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.Li
 		opts...,
 	)
 
-	// The index will be used only by Operator Managing CIDs to reconcile NS labels changes
 	indexers := cache.Indexers{
+		// The index will be used only by Operator Managing CIDs to reconcile NS labels changes.
 		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		// Thix index is used for IPAM by the ciliumNodeSynchronizer.
+		PodNodeNameIndex: PodNodeNameIndexFunc,
 	}
 
 	return resource.New[*slim_corev1.Pod](lc, lw,

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	CiliumEndpointIndexIdentity = "identity"
+	PodNodeNameIndex            = "pod-node"
 )
 
 var (
@@ -80,4 +81,13 @@ func HasCEWithIdentity(cepStore resource.Store[*cilium_api_v2.CiliumEndpoint], i
 	ces, _ := cepStore.IndexKeys(CiliumEndpointIndexIdentity, identity)
 
 	return len(ces) != 0
+}
+
+// podNodeNameIndexFunc indexes pods by node name.
+func PodNodeNameIndexFunc(obj interface{}) ([]string, error) {
+	pod := obj.(*slim_corev1.Pod)
+	if pod.Spec.NodeName != "" {
+		return []string{pod.Spec.NodeName}, nil
+	}
+	return []string{}, nil
 }

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/cache"
 
+	operatorK8s "github.com/cilium/cilium/operator/k8s"
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/operator/watchers"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -310,7 +311,7 @@ func getPendingPodCount(nodeName string) (int, error) {
 	if watchers.PodStore == nil {
 		return pendingPods, fmt.Errorf("pod store uninitialized")
 	}
-	values, err := watchers.PodStore.(cache.Indexer).ByIndex(watchers.PodNodeNameIndex, nodeName)
+	values, err := watchers.PodStore.(cache.Indexer).ByIndex(operatorK8s.PodNodeNameIndex, nodeName)
 	if err != nil {
 		return pendingPods, fmt.Errorf("unable to access pod to node name index: %w", err)
 	}


### PR DESCRIPTION
Fixes: https://github.com/cilium/cilium/issues/32713

Changes:
1. PodStore from Pod resource is assigned to PodStore of cilium-operator on startup.
2. `PodNodeNameIndex` is added to the Pod watcher in `operatorK8s.PodResource`.

This will be refactored once `ciliumNodeSynchronizer` is migrated to a cell.

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>
```release-note
Fixed bug which prevented IP surge allocation from working
```