### PR TITLE
etcd: fix paginated list missing events with parallel operations

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -981,7 +981,14 @@ func (e *etcdClient) paginatedList(ctx context.Context, log *logrus.Entry, prefi
 
 		kvs = append(kvs, res.Kvs...)
 
-		revision = res.Header.Revision
+		// Do not modify the revision once set, as subsequent Get queries may
+		// return higher revisions in case other operations are performed in
+		// parallel (regardless of whether we specify WithRev), leading to
+		// possibly missing the events happened in the meantime.
+		if revision == 0 {
+			revision = res.Header.Revision
+		}
+
 		if !res.More || len(res.Kvs) == 0 {
 			return kvs, revision, nil
 		}


### PR DESCRIPTION
Currently, the etcd paginatedList implementation is affected by a bug that can lead to missing events of both upsertions and deletions that are performed between the end of the first Get call and the last Get call. Indeed, the tracked revision is incorrectly updated after every Get call, and etcd always returns the current revision, regardless of whether WithRev is actually requesting a specific revision. In turn, this leads to subsequent Get calls targeting different revisions, hence missing all the events happened in between for the already processed chunks of the prefix, as the watch operation is eventually started from the latest retrieved revision.

Let's address this by consistently using the same revision during the entire paginatedList execution, to ensure that we correctly list all entries at that revision, and subsequently start watching events from the next one. Additionally, let's update the associated unit test to additionally cover the parallel operations case and prevent future regressions in this respect.

This bug affected both Cilium running in KVStore mode and clustermesh, although the race condition window is sufficiently short to trigger its occurrence only rarely and in high scale environments.

Marked for backport to all affected versions, as IMO it fits into the

> Major bugfixes relevant to the correct operation of Cilium

category, considering the Cilium then only recovers after a restart of the agent (although that may again trigger the same problem).

<!-- Description of change -->

```release-note
Fix bug causing etcd upsertion/deletion events to be potentially missed during the initial synchronization, when Cilium operates in KVStore mode, or Cluster Mesh is enabled. 
```
