### PR TITLE
Ginkgo: test runner: add flag to allow helm overrides

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -411,7 +411,7 @@ jobs:
              -cilium.hubble-relay-tag=${{ needs.setup-vars.outputs.SHA }} \
              -cilium.kubeconfig=/root/.kube/config \
              -cilium.provision-k8s=false \
-             -cilium.operator-suffix=-ci"
+             -cilium.operator-suffix=-ci ${{ env.CILIUM_GINKGO_EXTRA_ARGS }}"
 
               ./test.test \
                --ginkgo.focus="${{ matrix.cliFocus }}" \
@@ -427,7 +427,7 @@ jobs:
                -cilium.hubble-relay-tag=${{ needs.setup-vars.outputs.SHA }} \
                -cilium.kubeconfig=/root/.kube/config \
                -cilium.provision-k8s=false \
-               -cilium.operator-suffix=-ci
+               -cilium.operator-suffix=-ci ${{ env.CILIUM_GINKGO_EXTRA_ARGS }}
 
       - name: Fetch artifacts
         if: ${{ !success() && steps.provision-vh-vms.outcome == 'success' }}

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -40,6 +40,8 @@ type CiliumTestConfigType struct {
 	Kubeconfig           string
 	KubectlPath          string
 	RegistryCredentials  string
+	InstallHelmOverrides string
+
 	// Multinode enables the running of tests that involve more than one
 	// node. If false, some tests will silently skip multinode checks.
 	Multinode      bool
@@ -97,6 +99,9 @@ func (c *CiliumTestConfigType) ParseFlags() {
 	flagset.BoolVar(&c.RunQuarantined, "cilium.runQuarantined", false,
 		"Run tests that are under quarantine.")
 	flagset.BoolVar(&c.Help, "cilium.help", false, "Display this help message.")
+	flagset.StringVar(&c.InstallHelmOverrides, "cilium.install-helm-overrides", "",
+		"Comma separated list of cilium install helm --set overrides. "+
+			"*note*: This will take precedence over any other value set by the tests")
 
 	args := make([]string, 0, len(os.Args))
 	for index, flag := range os.Args {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2616,7 +2616,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		if err != nil {
 			return err
 		}
-		devices := fmt.Sprintf(`'{%s,%s,%s}'`, privateIface, defaultIfaceIPv4, defaultIfaceIPv6)
+		devices := fmt.Sprintf(`{%s,%s,%s}`, privateIface, defaultIfaceIPv4, defaultIfaceIPv6)
 		addIfNotOverwritten(options, "devices", devices)
 	}
 
@@ -2787,7 +2787,11 @@ func (kub *Kubectl) RunHelm(action, repo, helmName, version, namespace string, o
 	optionsString := ""
 
 	for k, v := range options {
-		optionsString += fmt.Sprintf(" --set %s=%s ", k, v)
+		if v == "true" || v == "false" {
+			optionsString += fmt.Sprintf(" --set %s=%s ", k, v)
+		} else {
+			optionsString += fmt.Sprintf(" --set '%s=%s' ", k, v)
+		}
 	}
 
 	return kub.ExecMiddle(fmt.Sprintf("helm %s %s %s "+
@@ -4333,7 +4337,11 @@ func (kub *Kubectl) HelmTemplate(chartDir, namespace, filename string, options m
 	optionsString := ""
 
 	for k, v := range options {
-		optionsString += fmt.Sprintf(" --set %s=%s ", k, v)
+		if v == "true" || v == "false" {
+			optionsString += fmt.Sprintf(" --set %s=%s ", k, v)
+		} else {
+			optionsString += fmt.Sprintf(" --set '%s=%s' ", k, v)
+		}
 	}
 
 	return kub.ExecMiddle("helm template --validate " +

--- a/test/helpers/kubectl_test.go
+++ b/test/helpers/kubectl_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_parseHelmOverrides(t *testing.T) {
+	// This should be able to parse key value pairs, including those
+	// where the value has commas but is delimited by quotes.
+	overridesStr := "key1=value1,\"key2={a,b,c}\",\"key3={}\""
+	expected := map[string]string{
+		"key1": "value1",
+		"key2": "{a,b,c}",
+		"key3": "{}",
+	}
+	overrides := map[string]string{}
+	parseHelmOverrides(overridesStr, overrides)
+	assert.Equal(t, expected, overrides)
+}

--- a/test/k8s/hubble.go
+++ b/test/k8s/hubble.go
@@ -126,7 +126,7 @@ var _ = Describe("K8sAgentHubbleTest", func() {
 
 			ciliumFilename = helpers.TimestampFilename("cilium.yaml")
 			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-				"hubble.metrics.enabled": `"{dns:query;ignoreAAAA,drop,tcp,flow,port-distribution,icmp,http}"`,
+				"hubble.metrics.enabled": `{dns:query;ignoreAAAA,drop,tcp,flow,port-distribution,icmp,http}`,
 				"hubble.relay.enabled":   "true",
 				"bpf.monitorAggregation": "none",
 			})

--- a/test/k8s/updates.go
+++ b/test/k8s/updates.go
@@ -186,7 +186,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 			"cleanState":         "true",
 			"image.tag":          imageTag,
 			"sleepAfterInit":     "true",
-			"operator.enabled":   "false ",
+			"operator.enabled":   "false",
 			"hubble.tls.enabled": "false",
 			"cluster.name":       clusterName,
 			"cluster.id":         clusterID,
@@ -268,9 +268,9 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 
 		hasNewHelmValues := versioncheck.MustCompile(">=1.12.90")
 		if hasNewHelmValues(versioncheck.MustVersion(newHelmChartVersion)) {
-			opts["bandwidthManager.enabled"] = "false "
+			opts["bandwidthManager.enabled"] = "false"
 		} else {
-			opts["bandwidthManager"] = "false "
+			opts["bandwidthManager"] = "false"
 		}
 
 		// Eventually allows multiple return values, and performs the assertion
@@ -421,12 +421,12 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		By("Install Cilium pre-flight check DaemonSet")
 
 		opts = map[string]string{
-			"preflight.enabled":   "true ",
-			"config.enabled":      "false ",
-			"operator.enabled":    "false ",
+			"preflight.enabled":   "true",
+			"config.enabled":      "false",
+			"operator.enabled":    "false",
 			"preflight.image.tag": newImageVersion,
 			"nodeinit.enabled":    "false",
-			"agent":               "false ",
+			"agent":               "false",
 		}
 
 		EventuallyWithOffset(1, func() (*helpers.CmdRes, error) {


### PR DESCRIPTION
test: add ability to override/add extra helm flags for ginkgo tests.

This adds `-cilium.install-helm-overrides` flag which provides a way to
add or override test flags without modifying the test code.

This is useful for forked projects to extend testing by providing their
own custom flags to the test program.

For example, you could extend the tests by doing:

`-cilium.install-helm-overrides="foo=bar,\"zap={a,b,c}\""` which would
    add: `--set foo=bar and --set zap={a,b,c}` to the cilium install params.
