### PR TITLE
Fix workflow telemetry in ci-ipsec-upgrade

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -231,7 +231,7 @@ jobs:
           echo downgrade_version=${CILIUM_DOWNGRADE_VERSION} >> $GITHUB_OUTPUT
           echo image_tag=${IMAGE_TAG} >> $GITHUB_OUTPUT
 
-      - name: Call actions/checkout again to remove credentials
+      - name: Checkout pull request branch (NOT TRUSTED)
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ inputs.context-ref || github.sha }}


### PR DESCRIPTION
Basically, workflow telemetry uses step names for gantt charts which uses Github's native support for mermaidjs for rendering the charts in issues and PRs. However mermaidjs has an issue
(https://github.com/mermaid-js/mermaid/issues/2495) when you use mermaid reserved keywords in node names/text.

To fix rendering of the ipsec upgrade workflow's telemetry, avoid the use of the "call" keyword.

This is a work around for https://github.com/catchpoint/workflow-telemetry-action/issues/76. If an when https://github.com/catchpoint/workflow-telemetry-action/pull/77 is merged, we do not need to be concerned with workflow step names.

Fixes #32241