### PR TITLE
gha: Add extended features in gateway profile run

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -128,6 +128,10 @@ jobs:
             EXEMPT_FEATURES+=",HTTPRouteDestinationPortMatching,HTTPRouteRequestTimeout,HTTPRouteBackendTimeout"
           fi
 
+          if [ ${{ matrix.conformance-profile }} == "true" ]; then
+            SKIPPED_TESTS+="GatewayStaticAddresses,MeshConsumerRoute,HTTPRouteListenerPortMatching"
+          fi
+
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=kubeProxyReplacement=true \
             --helm-set=extraArgs={--envoy-config-retry-interval=5s} \
@@ -262,7 +266,7 @@ jobs:
               -v ./operator/pkg/gateway-api \
               --gateway-class cilium \
               --all-features \
-              --exempt-features "${{ steps.vars.outputs.exempt-features }}" \
+              --skip-tests "${{ steps.vars.outputs.skipped_tests }}" \
               --allow-crds-mismatch \
               --conformance-profiles GATEWAY-HTTP,GATEWAY-TLS,GATEWAY-GRPC,MESH-HTTP,MESH-GRPC \
               --organization cilium \
@@ -272,7 +276,6 @@ jobs:
               --contact https://github.com/cilium/community/blob/main/roles/Maintainers.md \
               --report-output report.yaml \
               -test.run "TestConformance" \
-              -test.skip "${{ steps.vars.outputs.skipped_tests }}" \
               -json \
             | tparse -progress
           else


### PR DESCRIPTION
### Description 
    
Unlike normal run, Gateway API conformance profile didn't work well with
exempt features flag, which causes issues of missing extended features
in the report. This commit is to use --skip-tests instead.

Old report (without extended features) https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.1.0/cilium-cilium/experimental-1.16-default-report.yaml

New report (with extended features)

```yaml
apiVersion: gateway.networking.k8s.io/v1
date: "2024-08-02T12:50:00Z"
gatewayAPIChannel: experimental
gatewayAPIVersion: v1.1.0
implementation:
  contact:
  - https://github.com/cilium/community/blob/main/roles/Maintainers.md
  organization: cilium
  project: cilium
  url: github.com/cilium/cilium
  version: main
kind: ConformanceReport
mode: default
profiles:
- core:
    result: success
    statistics:
      Failed: 0
      Passed: 3
      Skipped: 0
  extended:
    result: partial
    skippedTests:
    - MeshConsumerRoute
    statistics:
      Failed: 0
      Passed: 3
      Skipped: 1
    supportedFeatures:
    - HTTPRouteBackendProtocolH2C
    - HTTPRouteBackendProtocolWebSocket
    - HTTPRouteBackendRequestHeaderModification
    - HTTPRouteBackendTimeout
    - HTTPRouteHostRewrite
    - HTTPRouteMethodMatching
    - HTTPRouteParentRefPort
    - HTTPRoutePathRedirect
    - HTTPRoutePathRewrite
    - HTTPRoutePortRedirect
    - HTTPRouteQueryParamMatching
    - HTTPRouteRequestMirror
    - HTTPRouteRequestMultipleMirrors
    - HTTPRouteRequestTimeout
    - HTTPRouteResponseHeaderModification
    - HTTPRouteSchemeRedirect
    - MeshClusterIPMatching
    - MeshConsumerRoute
  name: MESH-HTTP
  summary: Core tests succeeded. Extended tests partially succeeded with 1 test skips.
- core:
    result: success
    statistics:
      Failed: 0
      Passed: 12
      Skipped: 0
  extended:
    result: partial
    skippedTests:
    - GatewayStaticAddresses
    statistics:
      Failed: 0
      Passed: 0
      Skipped: 1
    supportedFeatures:
    - GatewayHTTPListenerIsolation
    - GatewayPort8080
    - GatewayStaticAddresses
  name: GATEWAY-GRPC
  summary: Core tests succeeded. Extended tests partially succeeded with 1 test skips.
- core:
    result: success
    statistics:
      Failed: 0
      Passed: 33
      Skipped: 0
  extended:
    result: partial
    skippedTests:
    - GatewayStaticAddresses
    - HTTPRouteListenerPortMatching
    statistics:
      Failed: 0
      Passed: 19
      Skipped: 2
    supportedFeatures:
    - GatewayHTTPListenerIsolation
    - GatewayPort8080
    - GatewayStaticAddresses
    - HTTPRouteBackendProtocolH2C
    - HTTPRouteBackendProtocolWebSocket
    - HTTPRouteBackendRequestHeaderModification
    - HTTPRouteBackendTimeout
    - HTTPRouteHostRewrite
    - HTTPRouteMethodMatching
    - HTTPRouteParentRefPort
    - HTTPRoutePathRedirect
    - HTTPRoutePathRewrite
    - HTTPRoutePortRedirect
    - HTTPRouteQueryParamMatching
    - HTTPRouteRequestMirror
    - HTTPRouteRequestMultipleMirrors
    - HTTPRouteRequestTimeout
    - HTTPRouteResponseHeaderModification
    - HTTPRouteSchemeRedirect
  name: GATEWAY-HTTP
  summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
- core:
    result: success
    statistics:
      Failed: 0
      Passed: 11
      Skipped: 0
  extended:
    result: partial
    skippedTests:
    - GatewayStaticAddresses
    statistics:
      Failed: 0
      Passed: 0
      Skipped: 1
    supportedFeatures:
    - GatewayHTTPListenerIsolation
    - GatewayPort8080
    - GatewayStaticAddresses
  name: GATEWAY-TLS
  summary: Core tests succeeded. Extended tests partially succeeded with 1 test skips.
```