### PR TITLE
kvstoremesh: add configuration options for logging

### DIFF
--- a/clustermesh-apiserver/kvstoremesh/root.go
+++ b/clustermesh-apiserver/kvstoremesh/root.go
@@ -36,8 +36,8 @@ func NewCmd(h *hive.Hive) *cobra.Command {
 			// Overwrite the metrics namespace with the one specific for KVStoreMesh
 			metrics.Namespace = metrics.CiliumKVStoreMeshNamespace
 			option.Config.Populate(h.Viper())
-			if option.Config.Debug {
-				log.Logger.SetLevel(logrus.DebugLevel)
+			if err := logging.SetupLogging(option.Config.LogDriver, option.Config.LogOpt, "kvstoremesh", option.Config.Debug); err != nil {
+				log.Fatal(err)
 			}
 			option.LogRegisteredOptions(h.Viper(), log)
 			log.Infof("Cilium KVStoreMesh %s", version.Version)

--- a/clustermesh-apiserver/option/config.go
+++ b/clustermesh-apiserver/option/config.go
@@ -42,7 +42,9 @@ func (def LegacyClusterMeshConfig) Flags(flags *pflag.FlagSet) {
 // LegacyKVStoreMeshConfig is used to register the flags for the options which
 // are still accessed through the global DaemonConfig variable.
 type LegacyKVStoreMeshConfig struct {
-	Debug bool
+	Debug     bool
+	LogDriver []string
+	LogOpt    map[string]string
 }
 
 var DefaultLegacyKVStoreMeshConfig = LegacyKVStoreMeshConfig{
@@ -51,4 +53,6 @@ var DefaultLegacyKVStoreMeshConfig = LegacyKVStoreMeshConfig{
 
 func (def LegacyKVStoreMeshConfig) Flags(flags *pflag.FlagSet) {
 	flags.BoolP(option.DebugArg, "D", def.Debug, "Enable debugging mode")
+	flags.StringSlice(option.LogDriver, def.LogDriver, "Logging endpoints to use (example: syslog)")
+	flags.Var(option.NewNamedMapOptions(option.LogOpt, &option.Config.LogOpt, nil), option.LogOpt, "Log driver options (example: format=json)")
 }


### PR DESCRIPTION
# Description
This allows users to customize logging configuration options of the KVStoreMesh.

# Testing
The new parameters are properly shown in `--help`:
```
$ ./clustermesh-apiserver kvstoremesh --help
Run KVStoreMesh

Usage:
  clustermesh-apiserver kvstoremesh [flags]
  clustermesh-apiserver kvstoremesh [command]

Available Commands:
  hive        Inspect the hive

Flags:
     [...]
      --log-driver strings                           Logging endpoints to use (example: syslog)
      --log-opt map                                  Log driver options (example: format=json)
     [...]
``` 

When no parameters are specified, logs are still emitted to stdout as k/v values (default formatting):
```
$ ./clustermesh-apiserver kvstoremesh
time="2024-07-31T12:22:25Z" level=info msg="  --api-serve-addr='localhost:9889'" subsys=kvstoremesh
[...]
time="2024-07-31T12:22:25Z" level=info msg="  --prometheus-serve-addr=''" subsys=kvstoremesh
time="2024-07-31T12:22:25Z" level=info msg="Cilium KVStoreMesh 1.17.0-dev 9592c69c27 2024-07-30T11:40:18-07:00 go version go1.22.0 linux/amd64" subsys=kvstoremesh
time="2024-07-31T12:22:25Z" level=info msg="Prometheus metrics are disabled" subsys=metrics
[...]
```

The log option overrides are properly working, for example we can now log in JSON:
```
$ ./clustermesh-apiserver kvstoremesh --log-opt=format=json-ts
{"level":"info","msg":"  --api-serve-addr='localhost:9889'","subsys":"kvstoremesh","time":"2024-07-31T12:22:48.805577561Z"}
[...]
{"level":"info","msg":"  --prometheus-serve-addr=''","subsys":"kvstoremesh","time":"2024-07-31T12:22:48.80590825Z"}
{"level":"info","msg":"Cilium KVStoreMesh 1.17.0-dev 9592c69c27 2024-07-30T11:40:18-07:00 go version go1.22.0 linux/amd64","subsys":"kvstoremesh","time":"2024-07-31T12:22:48.805916308Z"}
{"level":"info","msg":"Prometheus metrics are disabled","subsys":"metrics","time":"2024-07-31T12:22:48.808057402Z"}
[...]
```

```release-note
kvstoremesh: add configuration options for logging
```
