### PR TITLE
bugtool: dumping more Envoy information

### DIFF
--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -257,6 +257,17 @@ func runTool() {
 			if err := dumpEnvoy(cmdDir, "http://admin/config_dump?include_eds", "envoy-config.json", envoySecretMask); err != nil {
 				fmt.Fprintf(os.Stderr, "Unable to dump envoy config: %s\n", err)
 			}
+			if err := dumpEnvoy(cmdDir, "http://admin/listeners", "envoy-listeners.txt", nil); err != nil {
+				fmt.Fprintf(os.Stderr, "Unable to dump envoy listeners: %s\n", err)
+			}
+
+			if err := dumpEnvoy(cmdDir, "http://admin/clusters", "envoy-clusters.txt", nil); err != nil {
+				fmt.Fprintf(os.Stderr, "Unable to dump envoy clusters: %s\n", err)
+			}
+
+			if err := dumpEnvoy(cmdDir, "http://admin/server_info", "envoy-server-info.json", nil); err != nil {
+				fmt.Fprintf(os.Stderr, "Unable to dump envoy server info: %s\n", err)
+			}
 		}
 
 		if envoyMetrics {


### PR DESCRIPTION
Currently, during a Cilium sysdump the bugtool dumps the full Envoy config and prometheus metrics.

In some cases it would be nice to have some information about listeners and clusters easier at hand.

Therefore this commit extends the bugtool to dump the listeners, clusters and server_info that are available though the [Envoy admin interface](https://www.envoyproxy.io/docs/envoy/latest/operations/admin#get--listeners) during a sysdump.