### PR TITLE
Deprecate providing Hubble TLS secrets in helm values

### DIFF
--- a/Documentation/gettingstarted/hubble-configuration.rst
+++ b/Documentation/gettingstarted/hubble-configuration.rst
@@ -31,40 +31,6 @@ provided) or generate automatically via either:
 * cilium's `certgen <https://github.com/cilium/certgen>`__ (using a Kubernetes ``CronJob``)
 * `cert-manager <https://cert-manager.io/>`__
 
-User provided certificates
---------------------------
-
-In order to use custom TLS certificates, ``hubble.tls.auto.enabled`` must be set
-to ``false`` and TLS certificates manually provided.  This can be done by
-specifying the options below to Helm at install or upgrade time.
-
-::
-
-    --set hubble.tls.auto.enabled=false                          # disable automatic TLS certificate generation
-    --set-file tls.ca.cert=ca.crt.b64                            # certificate of the CA that signs all certificates
-    --set-file hubble.tls.server.cert=server.crt.b64             # certificate for Hubble server
-    --set-file hubble.tls.server.key=server.key.b64              # private key for the Hubble server certificate
-    --set-file hubble.relay.tls.client.cert=relay-client.crt.b64 # client certificate for Hubble Relay to connect to Hubble instances
-    --set-file hubble.relay.tls.client.key=relay-client.key.b64  # private key for Hubble Relay client certificate
-    --set-file hubble.relay.tls.server.cert=relay-server.crt.b64 # server certificate for Hubble Relay
-    --set-file hubble.relay.tls.server.key=relay-server.key.b64  # private key for Hubble Relay server certificate
-    --set-file hubble.ui.tls.client.cert=ui-client.crt.b64       # client certificate for Hubble UI
-    --set-file hubble.ui.tls.client.key=ui-client.key.b64        # private key for Hubble UI client certificate
-
-Options ``hubble.relay.tls.server.cert``, ``hubble.relay.tls.server.key``
-``hubble.ui.tls.client.cert`` and ``hubble.ui.tls.client.key``
-only need to be provided when ``hubble.relay.tls.server.enabled=true`` (default ``false``)
-which enable TLS for the Hubble Relay server.
-
-.. note::
-
-   Provided files must be **base64 encoded** PEM certificates.
-
-   In addition, the **Common Name (CN)** and **Subject Alternative Name (SAN)**
-   of the certificate for Hubble server MUST be set to
-   ``*.{cluster-name}.hubble-grpc.cilium.io`` where ``{cluster-name}`` is the
-   cluster name defined by ``cluster.name`` (defaults to ``default``).
-
 Auto generated certificates via Helm
 ------------------------------------
 
@@ -196,6 +162,40 @@ resolve this issue. Pick one of the options below:
                     --set webhook.tolerations='["operator": "Exists"]'
 
         Then configure an issuer and install Cilium.
+
+User provided certificates
+--------------------------
+
+In order to use custom TLS certificates, ``hubble.tls.auto.enabled`` must be set
+to ``false`` and TLS certificates manually provided.  This can be done by
+specifying the options below to Helm at install or upgrade time.
+
+::
+
+    --set hubble.tls.auto.enabled=false                          # disable automatic TLS certificate generation
+    --set-file tls.ca.cert=ca.crt.b64                            # certificate of the CA that signs all certificates
+    --set-file hubble.tls.server.cert=server.crt.b64             # certificate for Hubble server
+    --set-file hubble.tls.server.key=server.key.b64              # private key for the Hubble server certificate
+    --set-file hubble.relay.tls.client.cert=relay-client.crt.b64 # client certificate for Hubble Relay to connect to Hubble instances
+    --set-file hubble.relay.tls.client.key=relay-client.key.b64  # private key for Hubble Relay client certificate
+    --set-file hubble.relay.tls.server.cert=relay-server.crt.b64 # server certificate for Hubble Relay
+    --set-file hubble.relay.tls.server.key=relay-server.key.b64  # private key for Hubble Relay server certificate
+    --set-file hubble.ui.tls.client.cert=ui-client.crt.b64       # client certificate for Hubble UI
+    --set-file hubble.ui.tls.client.key=ui-client.key.b64        # private key for Hubble UI client certificate
+
+Options ``hubble.relay.tls.server.cert``, ``hubble.relay.tls.server.key``
+``hubble.ui.tls.client.cert`` and ``hubble.ui.tls.client.key``
+only need to be provided when ``hubble.relay.tls.server.enabled=true`` (default ``false``)
+which enable TLS for the Hubble Relay server.
+
+.. note::
+
+   Provided files must be **base64 encoded** PEM certificates.
+
+   In addition, the **Common Name (CN)** and **Subject Alternative Name (SAN)**
+   of the certificate for Hubble server MUST be set to
+   ``*.{cluster-name}.hubble-grpc.cilium.io`` where ``{cluster-name}`` is the
+   cluster name defined by ``cluster.name`` (defaults to ``default``).
 
 .. _hubble_configure_metrics_tls:
 

--- a/Documentation/gettingstarted/hubble-configuration.rst
+++ b/Documentation/gettingstarted/hubble-configuration.rst
@@ -166,36 +166,70 @@ resolve this issue. Pick one of the options below:
 User provided certificates
 --------------------------
 
-In order to use custom TLS certificates, ``hubble.tls.auto.enabled`` must be set
-to ``false`` and TLS certificates manually provided.  This can be done by
-specifying the options below to Helm at install or upgrade time.
+In order to use custom TLS certificates, ``hubble.tls.auto.enabled`` must be
+set to ``false``, secrets containing the certificates must be created in the
+``kube-system`` namespace, and the secret names must be provided to Helm.
+
+Provided files must be **base64 encoded** PEM certificates.
+
+In addition, the **Common Name (CN)** and **Subject Alternative Name (SAN)**
+of the certificate for Hubble server MUST be set to
+``*.{cluster-name}.hubble-grpc.cilium.io`` where ``{cluster-name}`` is the
+cluster name defined by ``cluster.name`` (defaults to ``default``).
+
+Once the certificates have been issued, the secrets must be created in the ``kube-system`` namespace.
+
+Each secret must contain the following keys:
+
+- ``tls.crt``: The certificate file.
+- ``tls.key``: The private key file.
+- ``ca.crt``: The CA certificate file.
+
+The following examples demonstrates how to create the secrets.
+
+Create the hubble server certificate secret:
+
+.. code-block:: shell-session
+
+  $ kubectl -n kube-system create secret generic hubble-server-certs --from-file=hubble-server.crt --from-file=hubble-server.key --from-file=ca.crt
+
+If hubble-relay is enabled, the following secrets must be created:
+
+.. code-block:: shell-session
+
+  $ kubectl -n kube-system create secret generic hubble-relay-server-certs --from-file=hubble-relay-server.crt --from-file=hubble-relay-server.key --from-file=ca.crt
+  $ kubectl -n kube-system create secret generic hubble-relay-client-certs --from-file=hubble-relay-client.crt --from-file=hubble-relay-client.key --from-file=ca.crt
+
+If hubble-ui is enabled, the following secret must be created:
+
+.. code-block:: shell-session
+
+  $ kubectl -n kube-system create secret generic hubble-ui-client-certs --from-file=hubble-ui-client.crt --from-file=hubble-ui-client.key --from-file=ca.crt
+
+Lastly, if the Hubble metrics API is enabled, the following secret must be created:
+
+.. code-block:: shell-session
+
+  $ kubectl -n kube-system create secret generic hubble-metrics-certs --from-file=hubble-metrics.crt --from-file=hubble-metrics.key --from-file=ca.crt
+
+After the secrets have been created, the secret names must be provided to Helm and automatic certificate generation must be disabled:
 
 ::
 
-    --set hubble.tls.auto.enabled=false                          # disable automatic TLS certificate generation
-    --set-file tls.ca.cert=ca.crt.b64                            # certificate of the CA that signs all certificates
-    --set-file hubble.tls.server.cert=server.crt.b64             # certificate for Hubble server
-    --set-file hubble.tls.server.key=server.key.b64              # private key for the Hubble server certificate
-    --set-file hubble.relay.tls.client.cert=relay-client.crt.b64 # client certificate for Hubble Relay to connect to Hubble instances
-    --set-file hubble.relay.tls.client.key=relay-client.key.b64  # private key for Hubble Relay client certificate
-    --set-file hubble.relay.tls.server.cert=relay-server.crt.b64 # server certificate for Hubble Relay
-    --set-file hubble.relay.tls.server.key=relay-server.key.b64  # private key for Hubble Relay server certificate
-    --set-file hubble.ui.tls.client.cert=ui-client.crt.b64       # client certificate for Hubble UI
-    --set-file hubble.ui.tls.client.key=ui-client.key.b64        # private key for Hubble UI client certificate
+    --set hubble.tls.auto.enabled=false                                       # Disable automatic TLS certificate generation
+    --set hubble.tls.server.existingSecret="hubble-server-certs"
+    --set hubble.relay.tls.server.enabled=true                                # Enable TLS on Hubble Relay (optional)
+    --set hubble.relay.tls.server.existingSecret="hubble-relay-server-certs"
+    --set hubble.relay.tls.client.existingSecret="hubble-relay-client-certs"
+    --set hubble.ui.tls.client.existingSecret="hubble-ui-client-certs"
+    --set hubble.metrics.tls.enabled=true                                     # Enable TLS on the Hubble metrics API (optional)
+    --set hubble.metrics.tls.server.existingSecret="hubble-metrics-certs"
 
-Options ``hubble.relay.tls.server.cert``, ``hubble.relay.tls.server.key``
-``hubble.ui.tls.client.cert`` and ``hubble.ui.tls.client.key``
-only need to be provided when ``hubble.relay.tls.server.enabled=true`` (default ``false``)
-which enable TLS for the Hubble Relay server.
-
-.. note::
-
-   Provided files must be **base64 encoded** PEM certificates.
-
-   In addition, the **Common Name (CN)** and **Subject Alternative Name (SAN)**
-   of the certificate for Hubble server MUST be set to
-   ``*.{cluster-name}.hubble-grpc.cilium.io`` where ``{cluster-name}`` is the
-   cluster name defined by ``cluster.name`` (defaults to ``default``).
+- ``hubble.relay.tls.server.existingSecret`` and ``hubble.ui.tls.client.existingSecret``
+  only need to be provided when ``hubble.relay.tls.server.enabled=true`` (default ``false``).
+- ``hubble.ui.tls.client.existingSecret`` only needs to be provided when ``hubble.ui.enabled`` (default ``false``).
+- ``hubble.metrics.tls.server.existingSecret`` only needs to be provided when ``hubble.metrics.tls.enabled`` (default ``false``).
+  For more details on configuring the Hubble metrics API with TLS, see :ref:`hubble_configure_metrics_tls`.
 
 .. _hubble_configure_metrics_tls:
 

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1607,7 +1607,7 @@
    * - :spelling:ignore:`hubble.metrics`
      - Hubble metrics configuration. See https://docs.cilium.io/en/stable/observability/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics.
      - object
-     - ``{"dashboards":{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null},"enableOpenMetrics":false,"enabled":null,"port":9965,"serviceAnnotations":{},"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","jobLabel":"","labels":{},"metricRelabelings":null,"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}],"tlsConfig":{}},"tls":{"enabled":false,"server":{"cert":"","extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":{"enabled":false,"key":"ca.crt","name":null,"useSecret":false}}}}``
+     - ``{"dashboards":{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null},"enableOpenMetrics":false,"enabled":null,"port":9965,"serviceAnnotations":{},"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","jobLabel":"","labels":{},"metricRelabelings":null,"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}],"tlsConfig":{}},"tls":{"enabled":false,"server":{"cert":"","existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":{"enabled":false,"key":"ca.crt","name":null,"useSecret":false}}}}``
    * - :spelling:ignore:`hubble.metrics.dashboards`
      - Grafana dashboards for hubble grafana can import dashboards based on the label and value ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards
      - object
@@ -1657,7 +1657,11 @@
      - list
      - ``[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]``
    * - :spelling:ignore:`hubble.metrics.tls.server.cert`
-     - base64 encoded PEM values for the Hubble metrics server certificate.
+     - base64 encoded PEM values for the Hubble metrics server certificate (deprecated). Use existingSecret instead.
+     - string
+     - ``""``
+   * - :spelling:ignore:`hubble.metrics.tls.server.existingSecret`
+     - Name of the Secret containing the certificate and key for the Hubble metrics server. If specified, cert and key are ignored.
      - string
      - ``""``
    * - :spelling:ignore:`hubble.metrics.tls.server.extraDnsNames`
@@ -1669,7 +1673,7 @@
      - list
      - ``[]``
    * - :spelling:ignore:`hubble.metrics.tls.server.key`
-     - base64 encoded PEM values for the Hubble metrics server key.
+     - base64 encoded PEM values for the Hubble metrics server key (deprecated). Use existingSecret instead.
      - string
      - ``""``
    * - :spelling:ignore:`hubble.metrics.tls.server.mtls`
@@ -1887,15 +1891,35 @@
    * - :spelling:ignore:`hubble.relay.tls`
      - TLS configuration for Hubble Relay
      - object
-     - ``{"client":{"cert":"","key":""},"server":{"cert":"","enabled":false,"extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":false,"relayName":"ui.hubble-relay.cilium.io"}}``
+     - ``{"client":{"cert":"","existingSecret":"","key":""},"server":{"cert":"","enabled":false,"existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":false,"relayName":"ui.hubble-relay.cilium.io"}}``
    * - :spelling:ignore:`hubble.relay.tls.client`
-     - base64 encoded PEM values for the hubble-relay client certificate and private key This keypair is presented to Hubble server instances for mTLS authentication and is required when hubble.tls.enabled is true. These values need to be set manually if hubble.tls.auto.enabled is false.
+     - The hubble-relay client certificate and private key. This keypair is presented to Hubble server instances for mTLS authentication and is required when hubble.tls.enabled is true. These values need to be set manually if hubble.tls.auto.enabled is false.
      - object
-     - ``{"cert":"","key":""}``
+     - ``{"cert":"","existingSecret":"","key":""}``
+   * - :spelling:ignore:`hubble.relay.tls.client.cert`
+     - base64 encoded PEM values for the Hubble relay client certificate (deprecated). Use existingSecret instead.
+     - string
+     - ``""``
+   * - :spelling:ignore:`hubble.relay.tls.client.existingSecret`
+     - Name of the Secret containing the certificate and key for the Hubble metrics server. If specified, cert and key are ignored.
+     - string
+     - ``""``
+   * - :spelling:ignore:`hubble.relay.tls.client.key`
+     - base64 encoded PEM values for the Hubble relay client key (deprecated). Use existingSecret instead.
+     - string
+     - ``""``
    * - :spelling:ignore:`hubble.relay.tls.server`
-     - base64 encoded PEM values for the hubble-relay server certificate and private key
+     - The hubble-relay server certificate and private key
      - object
-     - ``{"cert":"","enabled":false,"extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":false,"relayName":"ui.hubble-relay.cilium.io"}``
+     - ``{"cert":"","enabled":false,"existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":false,"relayName":"ui.hubble-relay.cilium.io"}``
+   * - :spelling:ignore:`hubble.relay.tls.server.cert`
+     - base64 encoded PEM values for the Hubble relay server certificate (deprecated). Use existingSecret instead.
+     - string
+     - ``""``
+   * - :spelling:ignore:`hubble.relay.tls.server.existingSecret`
+     - Name of the Secret containing the certificate and key for the Hubble relay server. If specified, cert and key are ignored.
+     - string
+     - ``""``
    * - :spelling:ignore:`hubble.relay.tls.server.extraDnsNames`
      - extra DNS names added to certificate when its auto gen
      - list
@@ -1904,6 +1928,10 @@
      - extra IP addresses added to certificate when its auto gen
      - list
      - ``[]``
+   * - :spelling:ignore:`hubble.relay.tls.server.key`
+     - base64 encoded PEM values for the Hubble relay server key (deprecated). Use existingSecret instead.
+     - string
+     - ``""``
    * - :spelling:ignore:`hubble.relay.tolerations`
      - Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      - list
@@ -1927,7 +1955,7 @@
    * - :spelling:ignore:`hubble.tls`
      - TLS configuration for Hubble
      - object
-     - ``{"auto":{"certManagerIssuerRef":{},"certValidityDuration":1095,"enabled":true,"method":"helm","schedule":"0 0 1 */4 *"},"enabled":true,"server":{"cert":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}}``
+     - ``{"auto":{"certManagerIssuerRef":{},"certValidityDuration":1095,"enabled":true,"method":"helm","schedule":"0 0 1 */4 *"},"enabled":true,"server":{"cert":"","existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}}``
    * - :spelling:ignore:`hubble.tls.auto`
      - Configure automatic TLS certificates generation.
      - object
@@ -1957,9 +1985,17 @@
      - bool
      - ``true``
    * - :spelling:ignore:`hubble.tls.server`
-     - base64 encoded PEM values for the Hubble server certificate and private key
+     - The Hubble server certificate and private key
      - object
-     - ``{"cert":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}``
+     - ``{"cert":"","existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}``
+   * - :spelling:ignore:`hubble.tls.server.cert`
+     - base64 encoded PEM values for the Hubble server certificate (deprecated). Use existingSecret instead.
+     - string
+     - ``""``
+   * - :spelling:ignore:`hubble.tls.server.existingSecret`
+     - Name of the Secret containing the certificate and key for the Hubble server. If specified, cert and key are ignored.
+     - string
+     - ``""``
    * - :spelling:ignore:`hubble.tls.server.extraDnsNames`
      - Extra DNS names added to certificate when it's auto generated
      - list
@@ -1968,6 +2004,10 @@
      - Extra IP addresses added to certificate when it's auto generated
      - list
      - ``[]``
+   * - :spelling:ignore:`hubble.tls.server.key`
+     - base64 encoded PEM values for the Hubble server key (deprecated). Use existingSecret instead.
+     - string
+     - ``""``
    * - :spelling:ignore:`hubble.ui.affinity`
      - Affinity for hubble-ui
      - object
@@ -2116,10 +2156,18 @@
      - When deploying Hubble UI in standalone, with tls enabled for Hubble relay, it is required to provide a volume for mounting the client certificates.
      - object
      - ``{}``
-   * - :spelling:ignore:`hubble.ui.tls.client`
-     - base64 encoded PEM values used to connect to hubble-relay This keypair is presented to Hubble Relay instances for mTLS authentication and is required when hubble.relay.tls.server.enabled is true. These values need to be set manually if hubble.tls.auto.enabled is false.
-     - object
-     - ``{"cert":"","key":""}``
+   * - :spelling:ignore:`hubble.ui.tls.client.cert`
+     - base64 encoded PEM values for the Hubble UI client certificate (deprecated). Use existingSecret instead.
+     - string
+     - ``""``
+   * - :spelling:ignore:`hubble.ui.tls.client.existingSecret`
+     - Name of the Secret containing the client certificate and key for Hubble UI If specified, cert and key are ignored.
+     - string
+     - ``""``
+   * - :spelling:ignore:`hubble.ui.tls.client.key`
+     - base64 encoded PEM values for the Hubble UI client key (deprecated). Use existingSecret instead.
+     - string
+     - ``""``
    * - :spelling:ignore:`hubble.ui.tolerations`
      - Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      - list

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -314,6 +314,13 @@ Deprecated Options
 Helm Options
 ~~~~~~~~~~~~
 
+* The Helm options ``hubble.tls.server.cert``, ``hubble.tls.server.key``,
+  ``hubble.relay.tls.client.cert``, ``hubble.relay.tls.client.key``,
+  ``hubble.relay.tls.server.cert``, ``hubble.relay.tls.server.key``,
+  ``hubble.ui.tls.client.cert``, and ``hubble.ui.tls.client.key`` have been
+  deprecated in favor of the associated ``existingSecret`` options and will be
+  removed in a future release.
+
 Added Metrics
 ~~~~~~~~~~~~~
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -315,6 +315,7 @@ etcd
 eth
 ethernet
 ethtool
+existingSecret
 extTrafficPolicy
 extern
 externalIPs
@@ -433,6 +434,9 @@ jsgt
 jsle
 jslt
 json
+k8sServiceHost
+k8sServiceLookupConfigMapName
+k8sServiceLookupNamespace
 kTLS
 kafka
 kallsyms
@@ -457,9 +461,6 @@ kubespray
 kvstore
 kvstoremesh
 kvstores
-k8sServiceHost
-k8sServiceLookupConfigMapName
-k8sServiceLookupNamespace
 lan
 latencies
 leia

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -451,7 +451,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.export.fileMaxSizeMb | int | `10` | - Defines max file size of output file before it gets rotated. |
 | hubble.export.static | object | `{"allowList":[],"denyList":[],"enabled":false,"fieldMask":[],"filePath":"/var/run/cilium/hubble/events.log"}` | - Static exporter configuration. Static exporter is bound to agent lifecycle. |
 | hubble.listenAddress | string | `":4244"` | An additional address for Hubble to listen to. Set this field ":4244" if you are enabling Hubble Relay, as it assumes that Hubble is listening on port 4244. |
-| hubble.metrics | object | `{"dashboards":{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null},"enableOpenMetrics":false,"enabled":null,"port":9965,"serviceAnnotations":{},"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","jobLabel":"","labels":{},"metricRelabelings":null,"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}],"tlsConfig":{}},"tls":{"enabled":false,"server":{"cert":"","extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":{"enabled":false,"key":"ca.crt","name":null,"useSecret":false}}}}` | Hubble metrics configuration. See https://docs.cilium.io/en/stable/observability/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics. |
+| hubble.metrics | object | `{"dashboards":{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null},"enableOpenMetrics":false,"enabled":null,"port":9965,"serviceAnnotations":{},"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","jobLabel":"","labels":{},"metricRelabelings":null,"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}],"tlsConfig":{}},"tls":{"enabled":false,"server":{"cert":"","existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":{"enabled":false,"key":"ca.crt","name":null,"useSecret":false}}}}` | Hubble metrics configuration. See https://docs.cilium.io/en/stable/observability/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics. |
 | hubble.metrics.dashboards | object | `{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null}` | Grafana dashboards for hubble grafana can import dashboards based on the label and value ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards |
 | hubble.metrics.enableOpenMetrics | bool | `false` | Enables exporting hubble metrics in OpenMetrics format. |
 | hubble.metrics.enabled | string | `nil` | Configures the list of metrics to collect. If empty or null, metrics are disabled. Example:    enabled:   - dns:query;ignoreAAAA   - drop   - tcp   - flow   - icmp   - http  You can specify the list of metrics from the helm CLI:    --set hubble.metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"  |
@@ -464,10 +464,11 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.metrics.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor hubble |
 | hubble.metrics.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor hubble |
 | hubble.metrics.serviceMonitor.relabelings | list | `[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]` | Relabeling configs for the ServiceMonitor hubble |
-| hubble.metrics.tls.server.cert | string | `""` | base64 encoded PEM values for the Hubble metrics server certificate. |
+| hubble.metrics.tls.server.cert | string | `""` | base64 encoded PEM values for the Hubble metrics server certificate (deprecated). Use existingSecret instead. |
+| hubble.metrics.tls.server.existingSecret | string | `""` | Name of the Secret containing the certificate and key for the Hubble metrics server. If specified, cert and key are ignored. |
 | hubble.metrics.tls.server.extraDnsNames | list | `[]` | Extra DNS names added to certificate when it's auto generated |
 | hubble.metrics.tls.server.extraIpAddresses | list | `[]` | Extra IP addresses added to certificate when it's auto generated |
-| hubble.metrics.tls.server.key | string | `""` | base64 encoded PEM values for the Hubble metrics server key. |
+| hubble.metrics.tls.server.key | string | `""` | base64 encoded PEM values for the Hubble metrics server key (deprecated). Use existingSecret instead. |
 | hubble.metrics.tls.server.mtls | object | `{"enabled":false,"key":"ca.crt","name":null,"useSecret":false}` | Configure mTLS for the Hubble metrics server. |
 | hubble.metrics.tls.server.mtls.key | string | `"ca.crt"` | Entry of the ConfigMap containing the CA. |
 | hubble.metrics.tls.server.mtls.name | string | `nil` | Name of the ConfigMap containing the CA to validate client certificates against. If mTLS is enabled and this is unspecified, it will default to the same CA used for Hubble metrics server certificates. |
@@ -521,17 +522,23 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.sortBufferDrainTimeout | string | `nil` | When the per-request flows sort buffer is not full, a flow is drained every time this timeout is reached (only affects requests in follow-mode) (e.g. "1s"). |
 | hubble.relay.sortBufferLenMax | int | `nil` | Max number of flows that can be buffered for sorting before being sent to the client (per request) (e.g. 100). |
 | hubble.relay.terminationGracePeriodSeconds | int | `1` | Configure termination grace period for hubble relay Deployment. |
-| hubble.relay.tls | object | `{"client":{"cert":"","key":""},"server":{"cert":"","enabled":false,"extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":false,"relayName":"ui.hubble-relay.cilium.io"}}` | TLS configuration for Hubble Relay |
-| hubble.relay.tls.client | object | `{"cert":"","key":""}` | base64 encoded PEM values for the hubble-relay client certificate and private key This keypair is presented to Hubble server instances for mTLS authentication and is required when hubble.tls.enabled is true. These values need to be set manually if hubble.tls.auto.enabled is false. |
-| hubble.relay.tls.server | object | `{"cert":"","enabled":false,"extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":false,"relayName":"ui.hubble-relay.cilium.io"}` | base64 encoded PEM values for the hubble-relay server certificate and private key |
+| hubble.relay.tls | object | `{"client":{"cert":"","existingSecret":"","key":""},"server":{"cert":"","enabled":false,"existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":false,"relayName":"ui.hubble-relay.cilium.io"}}` | TLS configuration for Hubble Relay |
+| hubble.relay.tls.client | object | `{"cert":"","existingSecret":"","key":""}` | The hubble-relay client certificate and private key. This keypair is presented to Hubble server instances for mTLS authentication and is required when hubble.tls.enabled is true. These values need to be set manually if hubble.tls.auto.enabled is false. |
+| hubble.relay.tls.client.cert | string | `""` | base64 encoded PEM values for the Hubble relay client certificate (deprecated). Use existingSecret instead. |
+| hubble.relay.tls.client.existingSecret | string | `""` | Name of the Secret containing the certificate and key for the Hubble metrics server. If specified, cert and key are ignored. |
+| hubble.relay.tls.client.key | string | `""` | base64 encoded PEM values for the Hubble relay client key (deprecated). Use existingSecret instead. |
+| hubble.relay.tls.server | object | `{"cert":"","enabled":false,"existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":false,"relayName":"ui.hubble-relay.cilium.io"}` | The hubble-relay server certificate and private key |
+| hubble.relay.tls.server.cert | string | `""` | base64 encoded PEM values for the Hubble relay server certificate (deprecated). Use existingSecret instead. |
+| hubble.relay.tls.server.existingSecret | string | `""` | Name of the Secret containing the certificate and key for the Hubble relay server. If specified, cert and key are ignored. |
 | hubble.relay.tls.server.extraDnsNames | list | `[]` | extra DNS names added to certificate when its auto gen |
 | hubble.relay.tls.server.extraIpAddresses | list | `[]` | extra IP addresses added to certificate when its auto gen |
+| hubble.relay.tls.server.key | string | `""` | base64 encoded PEM values for the Hubble relay server key (deprecated). Use existingSecret instead. |
 | hubble.relay.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | hubble.relay.topologySpreadConstraints | list | `[]` | Pod topology spread constraints for hubble-relay |
 | hubble.relay.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | hubble-relay update strategy |
 | hubble.skipUnknownCGroupIDs | bool | `true` | Skip Hubble events with unknown cgroup ids |
 | hubble.socketPath | string | `"/var/run/cilium/hubble.sock"` | Unix domain socket path to listen to when Hubble is enabled. |
-| hubble.tls | object | `{"auto":{"certManagerIssuerRef":{},"certValidityDuration":1095,"enabled":true,"method":"helm","schedule":"0 0 1 */4 *"},"enabled":true,"server":{"cert":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}}` | TLS configuration for Hubble |
+| hubble.tls | object | `{"auto":{"certManagerIssuerRef":{},"certValidityDuration":1095,"enabled":true,"method":"helm","schedule":"0 0 1 */4 *"},"enabled":true,"server":{"cert":"","existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}}` | TLS configuration for Hubble |
 | hubble.tls.auto | object | `{"certManagerIssuerRef":{},"certValidityDuration":1095,"enabled":true,"method":"helm","schedule":"0 0 1 */4 *"}` | Configure automatic TLS certificates generation. |
 | hubble.tls.auto.certManagerIssuerRef | object | `{}` | certmanager issuer used when hubble.tls.auto.method=certmanager. |
 | hubble.tls.auto.certValidityDuration | int | `1095` | Generated certificates validity duration in days. |
@@ -539,9 +546,12 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.tls.auto.method | string | `"helm"` | Set the method to auto-generate certificates. Supported values: - helm:         This method uses Helm to generate all certificates. - cronJob:      This method uses a Kubernetes CronJob the generate any                 certificates not provided by the user at installation                 time. - certmanager:  This method use cert-manager to generate & rotate certificates. |
 | hubble.tls.auto.schedule | string | `"0 0 1 */4 *"` | Schedule for certificates regeneration (regardless of their expiration date). Only used if method is "cronJob". If nil, then no recurring job will be created. Instead, only the one-shot job is deployed to generate the certificates at installation time.  Defaults to midnight of the first day of every fourth month. For syntax, see https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax |
 | hubble.tls.enabled | bool | `true` | Enable mutual TLS for listenAddress. Setting this value to false is highly discouraged as the Hubble API provides access to potentially sensitive network flow metadata and is exposed on the host network. |
-| hubble.tls.server | object | `{"cert":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}` | base64 encoded PEM values for the Hubble server certificate and private key |
+| hubble.tls.server | object | `{"cert":"","existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}` | The Hubble server certificate and private key |
+| hubble.tls.server.cert | string | `""` | base64 encoded PEM values for the Hubble server certificate (deprecated). Use existingSecret instead. |
+| hubble.tls.server.existingSecret | string | `""` | Name of the Secret containing the certificate and key for the Hubble server. If specified, cert and key are ignored. |
 | hubble.tls.server.extraDnsNames | list | `[]` | Extra DNS names added to certificate when it's auto generated |
 | hubble.tls.server.extraIpAddresses | list | `[]` | Extra IP addresses added to certificate when it's auto generated |
+| hubble.tls.server.key | string | `""` | base64 encoded PEM values for the Hubble server key (deprecated). Use existingSecret instead. |
 | hubble.ui.affinity | object | `{}` | Affinity for hubble-ui |
 | hubble.ui.annotations | object | `{}` | Annotations to be added to all top-level hubble-ui objects (resources under templates/hubble-ui) |
 | hubble.ui.backend.extraEnv | list | `[]` | Additional hubble-ui backend environment variables. |
@@ -579,7 +589,9 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.service.type | string | `"ClusterIP"` | - The type of service used for Hubble UI access, either ClusterIP or NodePort. |
 | hubble.ui.standalone.enabled | bool | `false` | When true, it will allow installing the Hubble UI only, without checking dependencies. It is useful if a cluster already has cilium and Hubble relay installed and you just want Hubble UI to be deployed. When installed via helm, installing UI should be done via `helm upgrade` and when installed via the cilium cli, then `cilium hubble enable --ui` |
 | hubble.ui.standalone.tls.certsVolume | object | `{}` | When deploying Hubble UI in standalone, with tls enabled for Hubble relay, it is required to provide a volume for mounting the client certificates. |
-| hubble.ui.tls.client | object | `{"cert":"","key":""}` | base64 encoded PEM values used to connect to hubble-relay This keypair is presented to Hubble Relay instances for mTLS authentication and is required when hubble.relay.tls.server.enabled is true. These values need to be set manually if hubble.tls.auto.enabled is false. |
+| hubble.ui.tls.client.cert | string | `""` | base64 encoded PEM values for the Hubble UI client certificate (deprecated). Use existingSecret instead. |
+| hubble.ui.tls.client.existingSecret | string | `""` | Name of the Secret containing the client certificate and key for Hubble UI If specified, cert and key are ignored. |
+| hubble.ui.tls.client.key | string | `""` | base64 encoded PEM values for the Hubble UI client key (deprecated). Use existingSecret instead. |
 | hubble.ui.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | hubble.ui.topologySpreadConstraints | list | `[]` | Pod topology spread constraints for hubble-ui |
 | hubble.ui.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | hubble-ui update strategy. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -984,7 +984,7 @@ spec:
           defaultMode: 0400
           sources:
           - secret:
-              name: hubble-server-certs
+              name: {{ .Values.hubble.tls.server.existingSecret | default "hubble-server-certs" }}
               optional: true
               items:
               - key: tls.crt
@@ -1010,7 +1010,7 @@ spec:
           defaultMode: 0400
           sources:
           - secret:
-              name: hubble-metrics-server-certs
+              name: {{ .Values.hubble.tls.server.existingSecret | default "hubble-metrics-server-certs" }}
               optional: true
               items:
               - key: tls.crt

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -170,7 +170,7 @@ spec:
           defaultMode: 0400
           sources:
           - secret:
-              name: hubble-relay-client-certs
+              name: {{ .Values.hubble.relay.tls.client.existingSecret | default "hubble-relay-client-certs" }}
               items:
                 - key: tls.crt
                   path: client.crt
@@ -188,7 +188,7 @@ spec:
           {{- end }}
           {{- if .Values.hubble.relay.tls.server.enabled }}
           - secret:
-              name: hubble-relay-server-certs
+              name: {{ .Values.hubble.relay.tls.server.existingSecret | default "hubble-relay-server-certs" }}
               items:
                 - key: tls.crt
                   path: server.crt

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -189,7 +189,7 @@ spec:
           defaultMode: 0400
           sources:
           - secret:
-              name: hubble-ui-client-certs
+              name: {{ .Values.hubble.ui.tls.client.existingSecret | default "hubble-ui-client-certs" }}
               items:
                 - key: tls.crt
                   path: client.crt

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/metrics-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/metrics-server-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agent .Values.hubble.enabled .Values.hubble.metrics.tls.enabled (not .Values.hubble.tls.auto.enabled) }}
+{{- if and .Values.agent .Values.hubble.enabled .Values.hubble.metrics.tls.enabled (not .Values.hubble.tls.auto.enabled) (not .Values.hubble.metrics.tls.server.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/relay-client-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) .Values.hubble.relay.enabled }}
+{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) .Values.hubble.relay.enabled (not .Values.hubble.relay.tls.client.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/relay-server-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) .Values.hubble.relay.enabled .Values.hubble.relay.tls.server.enabled }}
+{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) .Values.hubble.relay.enabled .Values.hubble.relay.tls.server.enabled (not .Values.hubble.relay.tls.server.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/server-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agent .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) }}
+{{- if and .Values.agent .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) (not .Values.hubble.tls.server.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/ui-client-certs.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) .Values.hubble.ui.enabled .Values.hubble.relay.enabled .Values.hubble.relay.tls.server.enabled }}
+{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) .Values.hubble.ui.enabled .Values.hubble.relay.enabled .Values.hubble.relay.tls.server.enabled (not .Values.hubble.ui.tls.client.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2635,6 +2635,9 @@
                     "cert": {
                       "type": "string"
                     },
+                    "existingSecret": {
+                      "type": "string"
+                    },
                     "extraDnsNames": {
                       "items": {},
                       "type": "array"
@@ -3010,6 +3013,9 @@
                     "cert": {
                       "type": "string"
                     },
+                    "existingSecret": {
+                      "type": "string"
+                    },
                     "key": {
                       "type": "string"
                     }
@@ -3023,6 +3029,9 @@
                     },
                     "enabled": {
                       "type": "boolean"
+                    },
+                    "existingSecret": {
+                      "type": "string"
                     },
                     "extraDnsNames": {
                       "items": {},
@@ -3114,6 +3123,9 @@
             "server": {
               "properties": {
                 "cert": {
+                  "type": "string"
+                },
+                "existingSecret": {
                   "type": "string"
                 },
                 "extraDnsNames": {
@@ -3402,6 +3414,9 @@
                 "client": {
                   "properties": {
                     "cert": {
+                      "type": "string"
+                    },
+                    "existingSecret": {
                       "type": "string"
                     },
                     "key": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1131,9 +1131,14 @@ hubble:
       enabled: false
       # Configure hubble metrics server TLS.
       server:
-        # -- base64 encoded PEM values for the Hubble metrics server certificate.
+        # -- Name of the Secret containing the certificate and key for the Hubble metrics server.
+        # If specified, cert and key are ignored.
+        existingSecret: ""
+        # -- base64 encoded PEM values for the Hubble metrics server certificate (deprecated).
+        # Use existingSecret instead.
         cert: ""
-        # -- base64 encoded PEM values for the Hubble metrics server key.
+        # -- base64 encoded PEM values for the Hubble metrics server key (deprecated).
+        # Use existingSecret instead.
         key: ""
         # -- Extra DNS names added to certificate when it's auto generated
         extraDnsNames: []
@@ -1331,9 +1336,16 @@ hubble:
       #   name: ca-issuer
       # -- certmanager issuer used when hubble.tls.auto.method=certmanager.
       certManagerIssuerRef: {}
-    # -- base64 encoded PEM values for the Hubble server certificate and private key
+    # -- The Hubble server certificate and private key
     server:
+      # -- Name of the Secret containing the certificate and key for the Hubble server.
+      # If specified, cert and key are ignored.
+      existingSecret: ""
+      # -- base64 encoded PEM values for the Hubble server certificate (deprecated).
+      # Use existingSecret instead.
       cert: ""
+      # -- base64 encoded PEM values for the Hubble server key (deprecated).
+      # Use existingSecret instead.
       key: ""
       # -- Extra DNS names added to certificate when it's auto generated
       extraDnsNames: []
@@ -1445,14 +1457,21 @@ hubble:
     listenPort: "4245"
     # -- TLS configuration for Hubble Relay
     tls:
-      # -- base64 encoded PEM values for the hubble-relay client certificate and private key
+      # -- The hubble-relay client certificate and private key.
       # This keypair is presented to Hubble server instances for mTLS
       # authentication and is required when hubble.tls.enabled is true.
       # These values need to be set manually if hubble.tls.auto.enabled is false.
       client:
+        # -- Name of the Secret containing the certificate and key for the Hubble metrics server.
+        # If specified, cert and key are ignored.
+        existingSecret: ""
+        # -- base64 encoded PEM values for the Hubble relay client certificate (deprecated).
+        # Use existingSecret instead.
         cert: ""
+        # -- base64 encoded PEM values for the Hubble relay client key (deprecated).
+        # Use existingSecret instead.
         key: ""
-      # -- base64 encoded PEM values for the hubble-relay server certificate and private key
+      # -- The hubble-relay server certificate and private key
       server:
         # When set to true, enable TLS on for Hubble Relay server
         # (ie: for clients connecting to the Hubble Relay API).
@@ -1461,8 +1480,14 @@ hubble:
         # False allow non-mutual TLS connections.
         # This option has no effect when TLS is disabled.
         mtls: false
-        # These values need to be set manually if hubble.tls.auto.enabled is false.
+        # -- Name of the Secret containing the certificate and key for the Hubble relay server.
+        # If specified, cert and key are ignored.
+        existingSecret: ""
+        # -- base64 encoded PEM values for the Hubble relay server certificate (deprecated).
+        # Use existingSecret instead.
         cert: ""
+        # -- base64 encoded PEM values for the Hubble relay server key (deprecated).
+        # Use existingSecret instead.
         key: ""
         # -- extra DNS names added to certificate when its auto gen
         extraDnsNames: []
@@ -1569,12 +1594,15 @@ hubble:
     # -- Roll out Hubble-ui pods automatically when configmap is updated.
     rollOutPods: false
     tls:
-      # -- base64 encoded PEM values used to connect to hubble-relay
-      # This keypair is presented to Hubble Relay instances for mTLS
-      # authentication and is required when hubble.relay.tls.server.enabled is true.
-      # These values need to be set manually if hubble.tls.auto.enabled is false.
       client:
+        # -- Name of the Secret containing the client certificate and key for Hubble UI
+        # If specified, cert and key are ignored.
+        existingSecret: ""
+        # -- base64 encoded PEM values for the Hubble UI client certificate (deprecated).
+        # Use existingSecret instead.
         cert: ""
+        # -- base64 encoded PEM values for the Hubble UI client key (deprecated).
+        # Use existingSecret instead.
         key: ""
     backend:
       # -- Hubble-ui backend image.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1138,9 +1138,14 @@ hubble:
       enabled: false
       # Configure hubble metrics server TLS.
       server:
-        # -- base64 encoded PEM values for the Hubble metrics server certificate.
+        # -- Name of the Secret containing the certificate and key for the Hubble metrics server.
+        # If specified, cert and key are ignored.
+        existingSecret: ""
+        # -- base64 encoded PEM values for the Hubble metrics server certificate (deprecated).
+        # Use existingSecret instead.
         cert: ""
-        # -- base64 encoded PEM values for the Hubble metrics server key.
+        # -- base64 encoded PEM values for the Hubble metrics server key (deprecated).
+        # Use existingSecret instead.
         key: ""
         # -- Extra DNS names added to certificate when it's auto generated
         extraDnsNames: []
@@ -1338,9 +1343,16 @@ hubble:
       #   name: ca-issuer
       # -- certmanager issuer used when hubble.tls.auto.method=certmanager.
       certManagerIssuerRef: {}
-    # -- base64 encoded PEM values for the Hubble server certificate and private key
+    # -- The Hubble server certificate and private key
     server:
+      # -- Name of the Secret containing the certificate and key for the Hubble server.
+      # If specified, cert and key are ignored.
+      existingSecret: ""
+      # -- base64 encoded PEM values for the Hubble server certificate (deprecated).
+      # Use existingSecret instead.
       cert: ""
+      # -- base64 encoded PEM values for the Hubble server key (deprecated).
+      # Use existingSecret instead.
       key: ""
       # -- Extra DNS names added to certificate when it's auto generated
       extraDnsNames: []
@@ -1452,14 +1464,21 @@ hubble:
     listenPort: "4245"
     # -- TLS configuration for Hubble Relay
     tls:
-      # -- base64 encoded PEM values for the hubble-relay client certificate and private key
+      # -- The hubble-relay client certificate and private key.
       # This keypair is presented to Hubble server instances for mTLS
       # authentication and is required when hubble.tls.enabled is true.
       # These values need to be set manually if hubble.tls.auto.enabled is false.
       client:
+        # -- Name of the Secret containing the certificate and key for the Hubble metrics server.
+        # If specified, cert and key are ignored.
+        existingSecret: ""
+        # -- base64 encoded PEM values for the Hubble relay client certificate (deprecated).
+        # Use existingSecret instead.
         cert: ""
+        # -- base64 encoded PEM values for the Hubble relay client key (deprecated).
+        # Use existingSecret instead.
         key: ""
-      # -- base64 encoded PEM values for the hubble-relay server certificate and private key
+      # -- The hubble-relay server certificate and private key
       server:
         # When set to true, enable TLS on for Hubble Relay server
         # (ie: for clients connecting to the Hubble Relay API).
@@ -1468,8 +1487,14 @@ hubble:
         # False allow non-mutual TLS connections.
         # This option has no effect when TLS is disabled.
         mtls: false
-        # These values need to be set manually if hubble.tls.auto.enabled is false.
+        # -- Name of the Secret containing the certificate and key for the Hubble relay server.
+        # If specified, cert and key are ignored.
+        existingSecret: ""
+        # -- base64 encoded PEM values for the Hubble relay server certificate (deprecated).
+        # Use existingSecret instead.
         cert: ""
+        # -- base64 encoded PEM values for the Hubble relay server key (deprecated).
+        # Use existingSecret instead.
         key: ""
         # -- extra DNS names added to certificate when its auto gen
         extraDnsNames: []
@@ -1576,12 +1601,15 @@ hubble:
     # -- Roll out Hubble-ui pods automatically when configmap is updated.
     rollOutPods: false
     tls:
-      # -- base64 encoded PEM values used to connect to hubble-relay
-      # This keypair is presented to Hubble Relay instances for mTLS
-      # authentication and is required when hubble.relay.tls.server.enabled is true.
-      # These values need to be set manually if hubble.tls.auto.enabled is false.
       client:
+        # -- Name of the Secret containing the client certificate and key for Hubble UI
+        # If specified, cert and key are ignored.
+        existingSecret: ""
+        # -- base64 encoded PEM values for the Hubble UI client certificate (deprecated).
+        # Use existingSecret instead.
         cert: ""
+        # -- base64 encoded PEM values for the Hubble UI client key (deprecated).
+        # Use existingSecret instead.
         key: ""
     backend:
       # -- Hubble-ui backend image.


### PR DESCRIPTION
This is the first step in a few changes to improve our documentation around configuring and using Hubble with TLS. The next PR https://github.com/cilium/cilium/pull/34115 will build upon this to make some improvements on the Hubble TLS documentation.

The primary goal with this PR is to add support for using existing secrets for Hubble TLS certificates and private keys to discourage storing private keys in helm values, and to better support users who wish to manage TLS certificates using other methods. While introducing support for using existing secrets, we should deprecate the previous method of directly providing certificates via helm values.

In the same vein, we want to encourage users to use one of the automated TLS methods rather than provide their own certificates in most cases, so let's move the documentation for user provided certificates to the end of the section. 

I've got a number of other TLS related improvements coming, mostly in the form of documentation updates, and would like to get all of those improvements in to the stable/v1.16 documentation, so I'm setting the `needs-backport/1.16` label on this PR. If the deprecation, and/or helm changes are an issue to backport, then we could skip the backport on this PR, and I'll just have to deal with conflicts when back porting the rest of my upcoming PRs to v1.16. Let me know what you think.