### PR TITLE
contrib/containerlab/bgpv2: Bump Cilium to v1.16.0, minor fixes for servcie lab

### DIFF
--- a/contrib/containerlab/bgpv2/README.md
+++ b/contrib/containerlab/bgpv2/README.md
@@ -19,6 +19,4 @@ Each lab contains a 'Makefile' which can be used to deploy, destroy or reload la
 - make destroy
 - make reload
 
-Version of Cilium in these labs is pinned to commit 8c97a2119d, since BGPv2 feature is not yet available in official release.
-It can be overridden by VERSION environment variable. 
-
+Version of Cilium in these labs is pinned to v1.16.0. It can be overridden by VERSION environment variable.

--- a/contrib/containerlab/bgpv2/multi-homing/Makefile
+++ b/contrib/containerlab/bgpv2/multi-homing/Makefile
@@ -1,5 +1,5 @@
 # version of cilium to deploy
-VERSION ?= v1.16.0-rc.0
+VERSION ?= v1.16.0
 
 deploy:
 	kind create cluster --config cluster.yaml

--- a/contrib/containerlab/bgpv2/pod-ip-pool/Makefile
+++ b/contrib/containerlab/bgpv2/pod-ip-pool/Makefile
@@ -1,5 +1,5 @@
 # version of cilium to deploy
-VERSION ?= v1.16.0-rc.0
+VERSION ?= v1.16.0
 
 deploy:
 	kind create cluster --config cluster.yaml

--- a/contrib/containerlab/bgpv2/service/Makefile
+++ b/contrib/containerlab/bgpv2/service/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= v1.16.0-rc.0
+VERSION ?= v1.16.0
 
 deploy:
 	kind create cluster --config cluster.yaml

--- a/contrib/containerlab/bgpv2/service/lb-ip.yaml
+++ b/contrib/containerlab/bgpv2/service/lb-ip.yaml
@@ -38,6 +38,9 @@ metadata:
     bgp: blue
 spec:
   type: LoadBalancer
+  ipFamilyPolicy: PreferDualStack
+  selector:
+    app: curl-blue
   ports:
     - port: 1234
   externalTrafficPolicy: Local
@@ -52,5 +55,8 @@ metadata:
     bgp: red
 spec:
   type: LoadBalancer
+  ipFamilyPolicy: PreferDualStack
+  selector:
+    app: curl-red
   ports:
     - port: 1236

--- a/contrib/containerlab/bgpv2/service/service.yaml
+++ b/contrib/containerlab/bgpv2/service/service.yaml
@@ -8,6 +8,7 @@ metadata:
     bgp: blue
 spec:
   type: NodePort
+  ipFamilyPolicy: PreferDualStack
   ports:
     - port: 1234
   selector:
@@ -27,6 +28,7 @@ metadata:
     bgp: red
 spec:
   type: NodePort
+  ipFamilyPolicy: PreferDualStack
   ports:
     - port: 1236
   selector:


### PR DESCRIPTION
Bumps Cilium to v1.16.0 and fixes the following in the service lab:
- enables dual-stack for services
- adds missing selector in LB services