### PR TITLE
docs: clarified IPSEC packet monitoring

### DIFF
--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -207,6 +207,34 @@ to all clusters in the mesh. You might need to increase the transition time to
 allow for the new keys to be deployed and applied across all clusters,
 which you can do with the agent flag ``ipsec-key-rotation-duration``.
 
+Monitoring
+==========
+
+When monitoring network traffic on a node with IPSec enabled, it is normal to observe
+in the same interface both the outer packet (node-to-node) carrying the ESP-encrypted
+payload and then the decrypted inner packet (pod-to-pod). This occurs as, once a packet
+is decrypted, it is recirculated back to the same interface for further processing.
+Therefore, depending on the ``tcpdump`` filter applied, the capture might differ, but this
+**does not** indicate that encryption is not functioning correctly. In particular, to observe:
+    
+1. Only the encrypted packet: use the filter ``esp``.
+2. Only the decrypted packet: use a specific filter for the protocol used by the pods (such as ``icmp`` for ping).
+3. Both encrypted and decrypted packets: use no filter or combine the filters for both (such as ``esp or icmp``).
+
+The following capture was taken on a Kind cluster with no filter applied (replace ``eth0``
+with ``cilium_vxlan`` if tunneling is enabled). The nodes have IP addresses ``10.244.2.92``
+and ``10.244.1.148``, while the pods have IP addresses ``10.244.2.189`` and ``10.244.1.7``,
+using ping (ICMP) for communication.
+
+.. code-block:: shell-session
+
+  tcpdump -l -n -i eth0
+  tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
+  listening on cilium_vxlan, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+  09:22:16.379908 IP 10.244.2.92 > 10.244.1.148: ESP(spi=0x00000003,seq=0x8), length 120
+  09:22:16.379908 IP 10.244.2.189 > 10.244.1.7: ICMP echo request, id 33, seq 1, length 64
+
+
 Troubleshooting
 ===============
 


### PR DESCRIPTION
According to the related issue, this part of the doc should better explain the different types of packets observable on a cluster with IPSEC enabled depending on the filter provided to `tcpdump`.

Fixes: #19274
