### PR TITLE
pkg/ciliumidentity: Add CID OP metrics

### DIFF
--- a/operator/pkg/ciliumidentity/cell.go
+++ b/operator/pkg/ciliumidentity/cell.go
@@ -5,6 +5,8 @@ package ciliumidentity
 
 import (
 	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/metrics"
 )
 
 // Cell implements the CID Controller. It subscribes to CID, CES, Pods
@@ -13,6 +15,7 @@ var Cell = cell.Module(
 	"k8s-cid-controller",
 	"Cilium Identity Controller Operator",
 	cell.Invoke(registerController),
+	metrics.Metric(NewMetrics),
 )
 
 // SharedConfig contains the configuration that is shared between

--- a/operator/pkg/ciliumidentity/identity.go
+++ b/operator/pkg/ciliumidentity/identity.go
@@ -25,6 +25,10 @@ func (c CIDItem) Key() resource.Key {
 func (c CIDItem) Reconcile(reconciler *reconciler) error {
 	return reconciler.reconcileCID(c.key)
 }
+func (c CIDItem) Meter(enqueuedLatency float64, processingLatency float64, isErr bool, metrics *Metrics) {
+	metrics.meterLatency(LabelValueCID, enqueuedLatency, processingLatency)
+	metrics.markEvent(LabelValueCID, isErr)
+}
 
 func (c *Controller) processCiliumIdentityEvents(ctx context.Context) error {
 	for event := range c.ciliumIdentity.Events(ctx) {

--- a/operator/pkg/ciliumidentity/metrics.go
+++ b/operator/pkg/ciliumidentity/metrics.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/utils/clock"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+const (
+	// LabelResource indicates resources that the metrics are attributed to.
+	LabelResource = "resource"
+	// LabelPhase indicates the phases the metrics are attributed to.
+	LabelPhase = "phase"
+
+	LabelValueCID               = "cid"
+	LabelValuePod               = "pod"
+	LabelValueEnqueuedLatency   = "enqueued"
+	LabelValueProcessingLatency = "processing"
+)
+
+func NewMetrics() *Metrics {
+	return &Metrics{
+		EventCount: metric.NewCounterVec(metric.CounterOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "cid_controller_work_queue_event_count",
+			Help:      "Counts processed events by CID controller work queues labeled by outcome",
+		}, []string{LabelResource, metrics.LabelOutcome}),
+
+		QueueLatency: metric.NewHistogramVec(metric.HistogramOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "cid_controller_work_queue_latency",
+			Help:      "Duration of CID controller work queues enqueuing and processing latencies in seconds",
+			Buckets:   append(prometheus.DefBuckets, 60, 300, 900, 1800, 3600),
+		}, []string{LabelResource, LabelPhase}),
+	}
+}
+
+type Metrics struct {
+	EventCount   metric.Vec[metric.Counter]
+	QueueLatency metric.Vec[metric.Observer]
+}
+
+func (m Metrics) meterLatency(label string, enqueuedLatency float64, processingLatency float64) {
+	m.QueueLatency.WithLabelValues(label, LabelValueEnqueuedLatency).Observe(enqueuedLatency)
+	m.QueueLatency.WithLabelValues(label, LabelValueProcessingLatency).Observe(processingLatency)
+}
+
+func (m Metrics) markEvent(label string, isErr bool) {
+	var labelValue string
+	if isErr {
+		labelValue = metrics.LabelValueOutcomeFail
+	} else {
+		labelValue = metrics.LabelValueOutcomeSuccess
+	}
+
+	m.EventCount.WithLabelValues(label, labelValue).Inc()
+
+}
+
+// EnqueueTimeTracker provides a thread safe mechanism to record
+// and manage the time when items are enqueued.
+type EnqueueTimeTracker struct {
+	enqueuedAt map[string]time.Time
+	mu         lock.Mutex
+	clock      clock.Clock
+}
+
+func (e *EnqueueTimeTracker) Track(item string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.enqueuedAt[item].IsZero() {
+		e.enqueuedAt[item] = e.clock.Now()
+	}
+}
+
+func (e *EnqueueTimeTracker) GetAndReset(item string) (time.Time, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	enqueuedTime, exists := e.enqueuedAt[item]
+	if !exists {
+		return time.Time{}, false
+	}
+
+	delete(e.enqueuedAt, item)
+	return enqueuedTime, true
+}

--- a/operator/pkg/ciliumidentity/metrics_test.go
+++ b/operator/pkg/ciliumidentity/metrics_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumidentity
+
+import (
+	"testing"
+	"time"
+
+	clocktesting "k8s.io/utils/clock/testing"
+)
+
+func TestEnqueueTimeTracker(t *testing.T) {
+	const item = "item"
+	startTime := time.Now()
+
+	testCases := []struct {
+		name             string
+		actions          []func(tracker *EnqueueTimeTracker)
+		expectedTime     time.Time
+		expectedExists   bool
+		advanceClockBy   time.Duration
+		initialClockTime time.Time
+	}{
+		{
+			name: "track_new_item",
+			actions: []func(tracker *EnqueueTimeTracker){
+				func(tracker *EnqueueTimeTracker) { tracker.Track(item) },
+			},
+			expectedTime:     startTime,
+			expectedExists:   true,
+			advanceClockBy:   0,
+			initialClockTime: startTime,
+		},
+		{
+			name: "track_existing_item",
+			actions: []func(tracker *EnqueueTimeTracker){
+				func(tracker *EnqueueTimeTracker) { tracker.Track(item) },
+				func(tracker *EnqueueTimeTracker) { tracker.Track(item) },
+			},
+			expectedTime:     startTime,
+			expectedExists:   true,
+			advanceClockBy:   time.Second * 5,
+			initialClockTime: startTime,
+		},
+		{
+			name: "get_and_reset",
+			actions: []func(tracker *EnqueueTimeTracker){
+				func(tracker *EnqueueTimeTracker) { tracker.Track(item) },
+			},
+			expectedTime:     startTime,
+			expectedExists:   true,
+			advanceClockBy:   0,
+			initialClockTime: startTime,
+		},
+		{
+			name: "non_existent_item",
+			actions: []func(tracker *EnqueueTimeTracker){
+				func(tracker *EnqueueTimeTracker) { tracker.Track("random_item") },
+			},
+			expectedTime:     time.Time{},
+			expectedExists:   false,
+			advanceClockBy:   0,
+			initialClockTime: startTime,
+		},
+		{
+			name: "already_reset",
+			actions: []func(tracker *EnqueueTimeTracker){
+				func(tracker *EnqueueTimeTracker) { tracker.Track(item) },
+				func(tracker *EnqueueTimeTracker) { tracker.GetAndReset(item) },
+			},
+			expectedTime:     time.Time{},
+			expectedExists:   false,
+			advanceClockBy:   0,
+			initialClockTime: startTime,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClock := clocktesting.NewFakeClock(tc.initialClockTime)
+
+			tracker := &EnqueueTimeTracker{
+				enqueuedAt: make(map[string]time.Time),
+				clock:      fakeClock,
+			}
+
+			for _, action := range tc.actions {
+				action(tracker)
+				fakeClock.Step(tc.advanceClockBy)
+			}
+
+			actualTime, actualExists := tracker.GetAndReset(item)
+			if !actualTime.Equal(tc.expectedTime) {
+				t.Errorf("Expected time %v, but got %v", tc.expectedTime, actualTime)
+			}
+			if actualExists != tc.expectedExists {
+				t.Errorf("Expected exists %v, but got %v", tc.expectedExists, actualExists)
+			}
+		})
+	}
+}

--- a/operator/pkg/ciliumidentity/pod.go
+++ b/operator/pkg/ciliumidentity/pod.go
@@ -26,6 +26,10 @@ func (p PodItem) Reconcile(reconciler *reconciler) error {
 	return reconciler.reconcilePod(p.key)
 }
 
+func (p PodItem) Meter(enqueuedLatency float64, processingLatency float64, isErr bool, metrics *Metrics) {
+	metrics.meterLatency(LabelValuePod, enqueuedLatency, processingLatency)
+	metrics.markEvent(LabelValuePod, isErr)
+}
 func (c *Controller) processPodEvents(ctx context.Context) error {
 	for event := range c.pod.Events(ctx) {
 		if event.Kind == resource.Upsert || event.Kind == resource.Delete {


### PR DESCRIPTION
Add metrics for the Operator managing CIDs.

- Add `cid_controller_work_queue_event_count` which counts processed events by CID controller work queues labeled by outcome 
- Add `cid_controller_work_queue_latency` which meters the duration of CID controller work queues enqueuing and processing latencies in seconds

Related CFP https://github.com/cilium/cilium/issues/27752

```release-note
operator: Add metrics for processing CiliumIdentity objects
```