### PR TITLE
helm: prevent failure on 1.17 upgrade from 1.16 due to nil values in templates

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -351,10 +351,10 @@ data:
 
 
 
-{{- if .Values.bpf.events.default.rateLimit }}
-  bpf-events-default-rate-limit: {{ .Values.bpf.events.default.rateLimit | quote }}
+{{- if (((.Values.bpf).events).default).rateLimit }}
+  bpf-events-default-rate-limit: {{ (((.Values.bpf).events).default).rateLimit | quote }}
 {{- end }}
-{{- if .Values.bpf.events.default.burstLimit }}
+{{- if (((.Values.bpf).events).default).burstLimit }}
   bpf-events-default-burst-limit: {{ .Values.bpf.events.default.burstLimit | quote }}
 {{- end}}
 
@@ -1053,7 +1053,7 @@ data:
   enable-node-ipam: "true"
 {{- end }}
 
-{{- if .Values.LBIPAM.requireLBClass }}
+{{- if (.Values.LBIPAM).requireLBClass }}
   lbipam-require-lb-class: "true"
 {{- end }}
 
@@ -1193,17 +1193,17 @@ data:
   annotate-k8s-node: "true"
 {{- end }}
 
-{{- with .Values.k8sClientRateLimit.qps }}
+{{- with (.Values.k8sClientRateLimit).qps }}
   k8s-client-qps: {{ . | quote }}
 {{- end }}
-{{- with .Values.k8sClientRateLimit.burst }}
+{{- with (.Values.k8sClientRateLimit).burst }}
   k8s-client-burst: {{ . | quote }}
 {{- end }}
 
-{{- with .Values.k8sClientRateLimit.operator.qps }}
+{{- with ((.Values.k8sClientRateLimit).operator).qps }}
   operator-k8s-client-qps: {{ .| quote }}
 {{- end }}
-{{- with .Values.k8sClientRateLimit.operator.burst }}
+{{- with ((.Values.k8sClientRateLimit).operator).burst }}
   operator-k8s-client-burst: {{ .| quote }}
 {{- end }}
 
@@ -1315,8 +1315,8 @@ data:
   clustermesh-enable-endpoint-sync: {{ .Values.clustermesh.enableEndpointSliceSynchronization | quote }}
   clustermesh-enable-mcs-api: {{ .Values.clustermesh.enableMCSAPISupport | quote }}
 
-  nat-map-stats-entries: {{ .Values.nat.mapStatsEntries | quote }}
-  nat-map-stats-interval: {{ .Values.nat.mapStatsInterval | quote }}
+  nat-map-stats-entries: {{ (.Values.nat).mapStatsEntries | quote }}
+  nat-map-stats-interval: {{ (.Values.nat).mapStatsInterval | quote }}
 
 # Extra config allows adding arbitrary properties to the cilium config.
 # By putting it at the end of the ConfigMap, it's also possible to override existing properties.


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

---

<!-- Description of change -->

Previously, upgrading from helm chart `1.16` to `1.17-dev` would fail because some values would evaluate to nil due to changes in the default values, printing errors like:

```error
Error: UPGRADE FAILED: template: cilium/templates/cilium-configmap.yaml:354:14: executing "cilium/templates/cilium-configmap.yaml" at <.Values.bpf.events.default.rateLimit>: nil pointer evaluating interface {}.rateLimit
```

This change adds `()` to such values to prevent nil pointer errors.