### PR TITLE
service: Relax protocol matching for L7 Service

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -220,7 +220,10 @@ type L7LBInfo struct {
 // 'ports' is typically short for no point optimizing the search.
 func (i *L7LBInfo) isProtoAndPortMatch(fe *lb.L4Addr) bool {
 	// L7 LB redirect is only supported for TCP frontends
-	if fe.Protocol != lb.TCP {
+	// The below is to make sure that UDP and SCTP are not allowed instead of comparing with lb.TCP
+	// The reason is to avoid extra dependencies with ongoing work to differentiate protocols in datapath,
+	// which might add more values such as lb.Any, lb.None, etc.
+	if fe.Protocol == lb.UDP || fe.Protocol == lb.SCTP {
 		return false
 	}
 


### PR DESCRIPTION
### Description 

Currently, the service datapath maps for both ipv4 and ipv6 didn't
use protoc field, hence despite the protocol value is passed from k8s
Service spec, the same information is not stored in datapath maps. Upon
agent restart, service restoration will just perform no-op for such
field (i.e. NONE will be used), this will cause severe failure for L7
service due to the protocol mismatch [^1].

This commit is to make sure that UDP and SCTP are not allowed instead,
the reason is to avoid extra dependencies with ongoing work [^2], which
will treat values of lb.NONE, (newly added) lb.ANY and lb.TCP in the same
way.

Fixes: https://github.com/cilium/cilium/issues/34075

[^1]: https://github.com/cilium/cilium/blob/19c74877ffc0d35daf81f4e0cde81623d4246c5c/pkg/service/service.go#L697-L702
[^2]: https://github.com/cilium/cilium/pull/33434

Reported-by: Michael Kashin <mmkashin@gmail.com>
Signed-off-by: Tam Mach <tam.mach@cilium.io>

---
### Testing

Testing was done by just restart cilium agent and verify lb map

Before the fix, there is no L7 service and proxy details.

```shell
$ ksysex ds/cilium -- cilium bpf lb list | grep 10.103.194.131
Defaulted container "cilium-agent" out of: cilium-agent, config (init), mount-cgroup (init), apply-sysctl-overwrites (init), mount-bpf-fs (init), wait-for-node-init (init), clean-cilium-state (init), install-cni-binaries (init)
10.103.194.131:443 (0)    0.0.0.0:0 (5) (0) [LoadBalancer]                               
10.103.194.131:80 (0)     0.0.0.0:0 (4) (0) [LoadBalancer]   
```

After the fix

```shell
$ ksysex ds/cilium -- cilium bpf lb list | grep 10.103.194.131                
Defaulted container "cilium-agent" out of: cilium-agent, config (init), mount-cgroup (init), apply-sysctl-overwrites (init), mount-bpf-fs (init), wait-for-node-init (init), clean-cilium-state (init), install-cni-binaries (init)
10.103.194.131:443 (0)    0.0.0.0:0 (5) (0) [LoadBalancer]                                                        
10.103.194.131:80 (0)     0.0.0.0:0 (4) (0) [LoadBalancer, l7-load-balancer] (L7LB Proxy Port: 14408)   

$ ksysex ds/cilium -- cilium bpf lb list | grep l7-load-balancer
Defaulted container "cilium-agent" out of: cilium-agent, config (init), mount-cgroup (init), apply-sysctl-overwrites (init), mount-bpf-fs (init), wait-for-node-init (init), clean-cilium-state (init), install-cni-binaries (init)
10.103.194.131:80 (0)     0.0.0.0:0 (4) (0) [LoadBalancer, l7-load-balancer] (L7LB Proxy Port: 14408)             
192.168.49.2:30191 (0)    0.0.0.0:0 (6) (0) [NodePort, l7-load-balancer] (L7LB Proxy Port: 14408)                 
10.98.62.74:80 (0)        0.0.0.0:0 (1) (0) [LoadBalancer, l7-load-balancer] (L7LB Proxy Port: 17837)             
0.0.0.0:30469 (0)         0.0.0.0:0 (3) (0) [NodePort, non-routable, l7-load-balancer] (L7LB Proxy Port: 17837)   
192.168.49.2:30469 (0)    0.0.0.0:0 (2) (0) [NodePort, l7-load-balancer] (L7LB Proxy Port: 17837)                 
0.0.0.0:30191 (0)         0.0.0.0:0 (7) (0) [NodePort, non-routable, l7-load-balancer] (L7LB Proxy Port: 14408)   
```