### PR TITLE
Lint for default flag configurations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,6 +50,19 @@ linters-settings:
         deny:
           - pkg: "math/rand$"
             desc: "Use math/rand/v2 instead"
+  exhaustruct:
+    # Ensure that command-line flags are explicitly default-initialized.
+    include:
+      - '.+\.[Cc]onfig'
+      - '.+[Cc]fg'
+    exclude:
+      - '.+cache\.Config' # k8s
+      - '.+fqdn\.Config' # internal API
+      - '.+tls\.Config' # Go TLS
+      - '.+v3\.Config' # etcd
+    # Uninitialized config as input to tests is not as big of an issue as the
+    # scope is limited to the usage of the related structures in the test.
+    test: false
   govet:
     enable:
       - nilness
@@ -119,6 +132,7 @@ linters:
     - depguard
     - errorlint
     - err113
+    - exhaustruct
     - gofmt
     - goimports
     - govet

--- a/Documentation/contributing/development/hive.rst
+++ b/Documentation/contributing/development/hive.rst
@@ -439,6 +439,13 @@ returns a cell that "provides" the parsed configuration to the application:
         cell.Provide(New),
     )
 
+Every field in the default configuration structure must be explicitly populated.
+When selecting defaults for the option, consider which option will introduce
+the minimal disruption to existing users during upgrade. For instance, if the
+flag retains existing behavior from a previous release, then the default flag
+value should retain that behavior. If you are introducing a new optional
+feature, consider disabling the option by default.
+
 In tests the configuration can be populated in various ways:
 
 .. code-block:: go

--- a/pkg/ciliumenvoyconfig/cec_reconciler.go
+++ b/pkg/ciliumenvoyconfig/cec_reconciler.go
@@ -83,6 +83,7 @@ func (r *ciliumEnvoyConfigReconciler) handleCECEvent(ctx context.Context, event 
 		r.cecSynced.Store(true)
 	case resource.Upsert:
 		scopedLogger.Debug("Received CiliumEnvoyConfig upsert event")
+		//exhaustruct:ignore // CEC config does not need to be fully specified
 		err = r.configUpserted(ctx, event.Key, &config{meta: event.Object.ObjectMeta, spec: &event.Object.Spec})
 		if err != nil {
 			scopedLogger.WithError(err).Info("Failed to handle CEC upsert, Hive will retry")
@@ -115,6 +116,7 @@ func (r *ciliumEnvoyConfigReconciler) handleCCECEvent(ctx context.Context, event
 		r.ccecSynced.Store(true)
 	case resource.Upsert:
 		scopedLogger.Debug("Received CiliumClusterwideEnvoyConfig upsert event")
+		//exhaustruct:ignore // CEC config does not need to be fully specified
 		err = r.configUpserted(ctx, event.Key, &config{meta: event.Object.ObjectMeta, spec: &event.Object.Spec})
 		if err != nil {
 			scopedLogger.WithError(err).Info("Failed to handle CCEC upsert, Hive will retry")

--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -344,6 +344,7 @@ func createConfig(apiServerURL, kubeCfgPath string, qps float32, burst int, user
 		}
 		config.Host = apiServerURL
 	default:
+		//exhaustruct:ignore
 		config = &rest.Config{Host: apiServerURL, UserAgent: userAgent}
 	}
 
@@ -498,10 +499,12 @@ func (c *FakeClientset) Disable() {
 }
 
 func (c *FakeClientset) Config() Config {
+	//exhaustruct:ignore
 	return Config{}
 }
 
 func (c *FakeClientset) RestConfig() *rest.Config {
+	//exhaustruct:ignore
 	return &rest.Config{}
 }
 

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -48,6 +48,7 @@ type Config struct {
 // DefaultConfig represents the default k8s resources config values.
 var DefaultConfig = Config{
 	EnableK8sEndpointSlice: true,
+	K8sServiceProxyName:    "",
 }
 
 const (

--- a/pkg/kvstore/consul_test.go
+++ b/pkg/kvstore/consul_test.go
@@ -59,6 +59,7 @@ func TestConsulClientOk(t *testing.T) {
 		close(doneC)
 	}
 
+	//exhaustruct:ignore // Consul API configuration does not need to be fully specified.
 	_, err := newConsulClient(context.TODO(), &consulAPI.Config{
 		Address: ":8000",
 	}, nil)

--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -128,6 +128,7 @@ func ParseLabelPrefixCfg(prefixes, nodePrefixes []string, file string) error {
 		fromCustomFile = true
 	}
 
+	//exhaustruct:ignore // Reading clean configuration, no need to initialize
 	nodeCfg = &labelPrefixCfg{}
 	log.Infof("Parsing node label prefixes from user inputs: %v", nodePrefixes)
 	for _, label := range nodePrefixes {
@@ -202,7 +203,7 @@ type labelPrefixCfg struct {
 	LabelPrefixes []*LabelPrefix `json:"valid-prefixes"`
 	// whitelist if true, indicates that an inclusive rule has to match
 	// in order for the label to be considered
-	whitelist bool
+	whitelist bool `exhaustruct:"optional"`
 }
 
 // defaultLabelPrefixCfg returns a default LabelPrefixCfg using the latest
@@ -259,6 +260,7 @@ func readLabelPrefixCfgFrom(fileName string) (*labelPrefixCfg, error) {
 		return nil, err
 	}
 	defer f.Close()
+	//exhaustruct:ignore // Reading clean configuration, no need to initialize
 	lpc := labelPrefixCfg{}
 	err = json.NewDecoder(f).Decode(&lpc)
 	if err != nil {


### PR DESCRIPTION
Depends on: https://github.com/cilium/cilium/pull/34254, https://github.com/cilium/cilium/pull/34255, https://github.com/cilium/cilium/pull/34256

Introduce `exhaustruct` into the tree specifically to lint that all configuration flags provided between the user and Cilium, or between modules within Cilium, are explicitly populated.

The intent here is twofold:

- Encourage developers and reviewers to consider what sane defaults should look like by forcing commits with new flags to explicitly initialize the default configuration

- Make it easier to grep for default configurations within the codebase, even when those configurations are defined for a specific Cell.

Historically this was always the case because the flags library expects a default setting to be provided. However, with the move towards defining configuration in the Hive/Cell framework, those references often directly pointed to the Configuration object inside the Cell module, which may or may not be explicitly initialized. This PR extends this property to Cell-provided configuration.