### PR TITLE
pkg/option: add ctmap-initial-gc-timeout option.

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -383,6 +383,11 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.BPFEventsTraceEnabled, defaults.BPFEventsTraceEnabled, "Expose 'trace' events for Cilium monitor and/or Hubble")
 	option.BindEnv(vp, option.BPFEventsTraceEnabled)
 
+	flags.Duration(option.CTMapInitialGCTimeout, 30*time.Second, "Initial timeout for garbage collection of connection tracking maps. "+
+		"If the initial gc fails to complete in this time then cilium will terminate. "+
+		"This may need to be increased in environments with large ctmap sizes or high CPU contention to avoid startup failures")
+	flags.MarkHidden(option.CTMapInitialGCTimeout)
+
 	flags.Bool(option.EnableTracing, false, "Enable tracing while determining policy (debugging)")
 	option.BindEnv(vp, option.EnableTracing)
 

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -223,7 +223,7 @@ func (gc *GC) Enable() {
 	select {
 	case <-initialScanComplete:
 		gc.logger.Info("Initial scan of connection tracking completed")
-	case <-time.After(30 * time.Second):
+	case <-time.After(option.Config.CTMapInitialGCTimeout):
 		gc.logger.Fatal("Timeout while waiting for initial conntrack scan")
 	}
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1245,6 +1245,11 @@ const (
 
 	// BPFEventsTraceEnabled defines the TraceNotification setting for any endpoint
 	BPFEventsTraceEnabled = "bpf-events-trace-enabled"
+
+	// CTMapInitialGCTimeout defines the timeout for how long to wait for first ctmap gc pass
+	// can take before terminating the agent.
+	// TODO: We should refactor the ctmap code so it doesn't need this timeout and remove this option.
+	CTMapInitialGCTimeout = "ctmap-initial-gc-timeout"
 )
 
 // Default string arguments
@@ -2461,6 +2466,10 @@ type DaemonConfig struct {
 	// EnableSocketLBPodConnectionTermination enables the termination of connections from pods
 	// to deleted service backends when socket-LB is enabled
 	EnableSocketLBPodConnectionTermination bool
+
+	// CTMapInitialGCTimeout is the initial timeout for the garbage collection of the connection tracking map
+	// prior to terminating the agent.
+	CTMapInitialGCTimeout time.Duration
 }
 
 var (
@@ -3144,6 +3153,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.BPFEventsPolicyVerdictEnabled = vp.GetBool(BPFEventsPolicyVerdictEnabled)
 	c.BPFEventsTraceEnabled = vp.GetBool(BPFEventsTraceEnabled)
 	c.EnableIPSecEncryptedOverlay = vp.GetBool(EnableIPSecEncryptedOverlay)
+	c.CTMapInitialGCTimeout = vp.GetDuration(CTMapInitialGCTimeout)
 
 	c.ServiceNoBackendResponse = vp.GetString(ServiceNoBackendResponse)
 	switch c.ServiceNoBackendResponse {


### PR DESCRIPTION
`ctmap-initial-gc-timeout` will be used set the ctmap initial gc pass timeout, at which point cilium agent will terminate.

This is needed because under some circumstances the previously hard coded 30 second timeout could be insufficient in resources constrained environments.
