### PR TITLE
helm: be able to run only Kvstoremesh container in clustermesh-apiserver

### DIFF
--- a/examples/kvstoremesh/kvstoremesh.yaml
+++ b/examples/kvstoremesh/kvstoremesh.yaml
@@ -1,0 +1,42 @@
+cluster:
+  id: 1
+  name: cluster1
+clustermesh:
+  apiserver:
+    enabled: false
+    etcd:
+      enabled: false
+    extraVolumes:
+      - configMap:
+          defaultMode: 256
+          items:
+          - key: etcd-config
+            path: etcd.config
+          name: cilium-config
+        name: etcd-config-path
+    kvstoremesh:
+      enabled: true
+      extraArgs:
+        - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
+      extraVolumeMounts:
+        - mountPath: /var/lib/etcd-config
+          name: etcd-config-path
+          readOnly: true
+  config:
+    clusters:
+      - name: cluster2
+        address: 172.20.0.1
+        port: 2579
+    enabled: true
+  useAPIServer: true
+etcd:
+  enabled: true
+  endpoints:
+    - http://172.20.0.1:2479
+identityAllocationMode: kvstore
+image:
+  pullPolicy: IfNotPresent
+ipam:
+  mode: kubernetes
+nodePort:
+  enabled: true

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -46,6 +46,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.clustermesh.apiserver.etcd.enabled }}
       initContainers:
       - name: etcd-init
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
@@ -98,7 +99,9 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- end }}
       containers:
+      {{- if .Values.clustermesh.apiserver.etcd.enabled }}
       - name: etcd
         # The clustermesh-apiserver container image includes an etcd binary.
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
@@ -164,6 +167,8 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- end }}
+      {{- if .Values.clustermesh.apiserver.enabled }}
       - name: apiserver
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
@@ -260,6 +265,7 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- end }}
       {{- if .Values.clustermesh.apiserver.kvstoremesh.enabled }}
       - name: kvstoremesh
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -109,8 +109,10 @@
 
 {{/* validate clustermesh-apiserver */}}
 {{- if .Values.clustermesh.useAPIServer }}
-  {{- if ne .Values.identityAllocationMode "crd" }}
-    {{ fail (printf "The clustermesh-apiserver cannot be enabled in combination with .Values.identityAllocationMode=%s. To establish a Cluster Mesh, directly configure the parameters to access the remote kvstore through .Values.clustermesh.config" .Values.identityAllocationMode ) }}
+  {{- if or .Values.clustermesh.apiserver.etcd.enabled .Values.clustermesh.apiserver.enabled }}
+    {{- if ne .Values.identityAllocationMode "crd" }}
+      {{ fail (printf "The clustermesh-apiserver cannot be enabled in combination with .Values.identityAllocationMode=%s. To establish a Cluster Mesh, directly configure the parameters to access the remote kvstore through .Values.clustermesh.config" .Values.identityAllocationMode ) }}
+    {{- end }}
   {{- end }}
   {{- if .Values.disableEndpointCRD }}
     {{ fail "The clustermesh-apiserver cannot be enabled in combination with .Values.disableEndpointCRD=true" }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2932,6 +2932,8 @@ clustermesh:
     #     key: ""
     #     caCert: ""
   apiserver:
+    # -- Enable/disable apiserver container
+    enabled: true
     # -- Clustermesh API server image.
     image:
       # @schema
@@ -2953,6 +2955,9 @@ clustermesh:
       # Independent override isn't supported, because clustermesh-apiserver is tested against the etcd version it is
       # built with.
 
+      # -- Enable/disable etcd container
+      enabled: true
+      
       # -- Specifies the resources for etcd container in the apiserver
       resources: {}
       #   requests:


### PR DESCRIPTION
When running clustermesh-apiserver, there should be an option to enable and disable containers that are not needed.
For example the etcd container is not necessary when running kvstoremesh with an external kvstore.

This commit adds the options to disable these containers.
