### PR TITLE
bpf: egressgw: don't install allow-all policy in to-netdev tests

### DIFF
--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -55,9 +55,6 @@ int egressgw_redirect_setup(struct __ctx_buff *ctx)
 	create_ct_entry(ctx, client_port(TEST_REDIRECT));
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP, 0);
 
-	/* Avoid policy drop */
-	policy_add_egress_allow_all_entry();
-
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, TO_NETDEV);
 	/* Fail if we didn't jump */
@@ -71,7 +68,6 @@ int egressgw_redirect_check(const struct __ctx_buff *ctx)
 			.status_code = TC_ACT_REDIRECT,
 	});
 
-	policy_delete_egress_entry();
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24);
 
 	return ret;
@@ -96,9 +92,6 @@ int egressgw_skip_excluded_cidr_redirect_setup(struct __ctx_buff *ctx)
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP, 0);
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_EXCLUDED_CIDR, 0);
 
-	/* Avoid policy drop */
-	policy_add_egress_allow_all_entry();
-
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, TO_NETDEV);
 	/* Fail if we didn't jump */
@@ -112,7 +105,6 @@ int egressgw_skip_excluded_cidr_redirect_check(const struct __ctx_buff *ctx)
 			.status_code = TC_ACT_OK,
 	});
 
-	policy_delete_egress_entry();
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24);
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
 
@@ -136,9 +128,6 @@ int egressgw_skip_no_gateway_redirect_setup(struct __ctx_buff *ctx)
 	ipcache_v4_add_entry_with_mask_size(v4_all, 0, WORLD_IPV4_ID, 0, 0, 0);
 	create_ct_entry(ctx, client_port(TEST_REDIRECT_SKIP_NO_GATEWAY));
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_NO_GATEWAY, 0);
-
-	/* Avoid policy drop */
-	policy_add_egress_allow_all_entry();
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, TO_NETDEV);
@@ -167,7 +156,6 @@ int egressgw_skip_no_gateway_redirect_check(const struct __ctx_buff *ctx)
 		test_fatal("metrics entry not found");
 	assert(entry->count == 1);
 
-	policy_delete_egress_entry();
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
 
 	test_finish();


### PR DESCRIPTION
This was probably copy&pasted from the bpf_lxc tests. But to-netdev doesn't have any egress-policy hook, so we don't need to explicitly allow the test traffic.