### PR TITLE
Clean up documentation make targets for cases of nesting make builds inside container invocations

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -62,7 +62,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build HTML
-        uses: docker://quay.io/cilium/docs-builder:9ccbdd04a50d599e9e699face6231e59c0036a51@sha256:6d1a0eaeb32ba98b60df52c69e7c8031a38e8aa6a0d4738bef35bd48a3bfbc0e
+        uses: docker://quay.io/cilium/docs-builder:ea8511e4d2b39d2ef7a4c71edbe6eddb19e8bb5c@sha256:3a04bb23e017dfb229c0139a3ff7208a6d4ec3944bc24b8441c73ed7d70d781f
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -25,6 +25,7 @@ ADD ./requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt
 
 ENV HOME=/tmp
+ARG READTHEDOCS_VERSION
 ENV READTHEDOCS_VERSION=$READTHEDOCS_VERSION
 ENV MAKE_GIT_REPO_SAFE=1
 

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -44,6 +44,7 @@ endif
 # documentation to be generated correctly.
 cilium-build:
 ifndef SKIP_BUILD
+	$(MAKE) builder-image
 	../contrib/scripts/builder.sh env MAKEFLAGS="$(MAKEFLAGS)" make build
 else
 	echo "SKIP_BUILD set, assuming all build artifacts are already present."
@@ -71,7 +72,7 @@ api-flaggen: ## Update the table of API flags restrictions.
 		> configuration/api-restrictions-table.rst
 
 .PHONY: update-cmdref
-update-cmdref: builder-image cilium-build ## Update the command reference documents (agent, bugtool, operators, etc.).
+update-cmdref: cilium-build ## Update the command reference documents (agent, bugtool, operators, etc.).
 	@$(ECHO_GEN)cmdref
 	-$(QUIET)rm -rf cmdref/cilium*.md
 	$(QUIET)$(DOCKER_RUN) ./update-cmdref.sh

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -20,7 +20,9 @@ define build_image
   # Pre-pull FROM docker image due to Buildkit sometimes failing to pull them.
   grep -m 1 "^FROM " $(1) | tr -d '\r' | cut -d ' ' -f2 | xargs -n1 $(CONTAINER_ENGINE) pull
   $(QUIET)tar c $(REQUIREMENTS) Dockerfile \
-    | $(CONTAINER_ENGINE) build $(DOCKER_BUILD_FLAGS) --target $(2) --tag $(3) -
+    | $(CONTAINER_ENGINE) build $(DOCKER_BUILD_FLAGS) \
+                          --build-arg READTHEDOCS_VERSION \
+                          --target $(2) --tag $(3) -
 endef
 
 ##@ Development Images
@@ -47,7 +49,7 @@ else
 	echo "SKIP_BUILD set, assuming all build artifacts are already present."
 endif
 
-READTHEDOCS_VERSION:=$(READTHEDOCS_VERSION)
+READTHEDOCS_VERSION ?= latest
 DOCKER_CTR_ROOT_DIR := /src
 DOCKER_CTR_BASE := $(CONTAINER_ENGINE) container run --rm \
 		--workdir $(DOCKER_CTR_ROOT_DIR)/Documentation \

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -110,10 +110,10 @@ GOLANGCILINT_VERSION = $(shell golangci-lint version --format short 2>/dev/null)
 VERSION = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION)
 VERSION_MAJOR = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION | cut -d. -f1)
 # Use git only if in a Git repo
-ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/.git),)
+ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/.git/HEAD),)
     GIT_VERSION = $(shell git show -s --format='format:%h %aI')
 else
-    GIT_VERSION = $(shell cat $(ROOT_DIR)/GIT_VERSION)
+    GIT_VERSION = $(shell cat 2>/dev/null $(ROOT_DIR)/GIT_VERSION)
 endif
 FULL_BUILD_VERSION = $(VERSION) $(GIT_VERSION)
 GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/version.ciliumVersion=$(FULL_BUILD_VERSION)"
@@ -135,7 +135,7 @@ endif
 
 # Use git only if in a Git repo, otherwise find the files from the file system
 BPF_SRCFILES_IGNORE = bpf/.gitignore
-ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/.git),)
+ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/.git/HEAD),)
     BPF_SRCFILES := $(shell git ls-files $(ROOT_DIR)/bpf/ | LC_ALL=C sort | tr "\n" ' ')
 else
     # this line has to be in-sync with bpf/.gitignore, please note usage of make patterns like `%.i`

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -34,7 +34,10 @@ else
     endif
   endif
 endif
+DOCKER_EXISTS := $(shell command -v docker 2>/dev/null)
+ifdef DOCKER_EXISTS
 DOCKER_BUILDER := $(shell docker buildx ls | grep -E -e "[a-zA-Z0-9-]+ \*" | cut -d ' ' -f1)
+endif
 
 ##@ Docker Images
 .PHONY: builder-info


### PR DESCRIPTION
There's a few warnings and errors that come up occasionally when running builds
using the Documentation/ make targets. For the most part these appear to be
cosmetic, not having an impact on the success or failure of the builds, but
they can be confusing for developers when reading through the make output.

There is one functional fix here, where the git detection would previously fail
in a fatal way when using git worktrees. Rather than failing fatally, it's
better to just fall back to pretending that there is no git tree and run the
rest of the build that way if worktrees are involved. Perhaps a better solution
in future would be to ensure that worktrees are properly mapped into docker
containers when running builds in there, but that seems more complicated than
necessary for now.

See individual commits for more details.

Fixes: #33976
Supersedes: #34135 (Need to post this on cilium/cilium to pass docs-builder CI)
