### PR TITLE
contrib/scripts/kind.sh: fix DNS resolution on nodes

### DIFF
--- a/contrib/scripts/kind-kubelet.conf
+++ b/contrib/scripts/kind-kubelet.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/bin/bash /home/vagrant/go/src/github.com/cilium/cilium/contrib/scripts/kind-setup-dns.sh

--- a/contrib/scripts/kind-setup-dns.sh
+++ b/contrib/scripts/kind-setup-dns.sh
@@ -1,0 +1,35 @@
+# no shebang, this script is never run directly
+# This script is set up to run before kubelet startup in order to install
+# and deploy dnsmasq at first run of a new cluster node without having to
+# modify the Kind image. dnsmasq is set up to forward cluster-local DNS
+# requests (without suffix) to dockerd, and all other requests to external
+# DNS bypassing dockerd. This is required for two reasons:
+# (a) in case of BPF Host Routing we bypass iptables thus breaking DNS.
+#     See https://github.com/cilium/cilium/issues/23330
+# (b) In case host has L7 DNS policy dockerd's iptables rule acts before
+#     we redirect the DNS request to proxy port, breaking DNS proxy.
+
+set -euo pipefail
+
+external_dns="1.1.1.1"
+for i in /etc/kind-external-dns-*.conf; do
+  external_dns="${i#*kind-external-dns-}"
+  external_dns="${external_dns%.conf}"
+done
+
+if ! dnsmasq -v 2>/dev/null
+then
+  apt-get update
+  apt install -y dnsmasq
+  read _ ddns < <(grep nameserver /etc/resolv.conf)
+  <<EOF cat >/etc/dnsmasq.conf
+no-poll
+no-resolv
+listen-address=127.0.0.1
+server=//$ddns
+server=$external_dns
+EOF
+  conf=$(sed "s/nameserver.*/nameserver 127.0.0.1/" /etc/resolv.conf)
+  echo "$conf" > /etc/resolv.conf
+  systemctl restart dnsmasq
+fi


### PR DESCRIPTION
This PR fixes contrib/scripts/kind.sh so that connectivity test for #34024 (Enable L7 DNS proxy for nodes) works.

The test fails in the default cluster created by `contrib/scripts/kind.sh` because, as has been described in #23330, #32489 and many other issues in between, dockerd is routing packets to its internal DNS server with a netfilter rule. This rule snatches packets off the datapath before they arrive at DNS proxy. #24713 worked around this for pods in clusters created by `contrib/scripts/kind.sh` by replacing the nameserver in coredns pods' /etc/resolv.conf. Unfortunately this approach cannot be made to work reliably in the host: kubelets need to be able to resolve node hostnames to find their k8s cluster peers, and so they need to either somehow refer to dockerd's internal DNS server for node hostnames, or to have all node hostnames mapped to addresses in /etc/hosts. (It is possible to overwrite host /etc/resolv.conf to replace dockerd's DNS with 8.8.8.8 several seconds after kubelet has started - after it has resolved node hostnames - but this is not reliable.) 

This PR adds a kubelet drop-in that replaces the nameserver configured by docker with dnsmasq defaulting to 8.8.8.8, but deferring local lookups to docker DNS so that kubelets can resolve nodes by name.