### PR TITLE
chore: Avoid using deprecated grpc.Dial

### DIFF
--- a/operator/auth/spire/client.go
+++ b/operator/auth/spire/client.go
@@ -179,7 +179,7 @@ func (c *Client) connect(ctx context.Context) (*grpc.ClientConn, error) {
 		logfields.Address: c.cfg.SpireServerAddress,
 		logfields.IPAddr:  resolvedTarget,
 	}).Info("Trying to connect to SPIRE server")
-	conn, err := grpc.Dial(*resolvedTarget, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	conn, err := grpc.NewClient(*resolvedTarget, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create connection to SPIRE server: %w", err)
 	}

--- a/pkg/auth/spire/delegate.go
+++ b/pkg/auth/spire/delegate.go
@@ -338,7 +338,7 @@ func (s *SpireDelegateClient) initWatcher(ctx context.Context) (delegatedidentit
 
 	unixPath := fmt.Sprintf("unix://%s", s.cfg.SpireAdminSocketPath)
 
-	conn, err := grpc.Dial(unixPath, grpc.WithTransportCredentials(insecure.NewCredentials()),
+	conn, err := grpc.NewClient(unixPath, grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(20*1024*1024),
 			grpc.MaxCallSendMsgSize(20*1024*1024))) // setting this to 20MB to handle large bundles TODO: improve this once fixed upstream (https://github.com/cilium/cilium/issues/24297)


### PR DESCRIPTION
This is to ease the work for below issue.

Relates: #32274 
