### PR TITLE
Add Prometheus counters for successful nat.DeleteMapping invocations

### DIFF
--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/timestamp"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/tuple"
 )
@@ -307,6 +308,7 @@ func DeleteMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
 
 		m.SilentDelete(&key)
 		m.SilentDelete(&rkey)
+		metrics.NatDeleteMappingv4Events.Inc()
 	}
 	return nil
 }
@@ -331,6 +333,7 @@ func DeleteMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
 
 		m.SilentDelete(&key)
 		m.SilentDelete(&rkey)
+		metrics.NatDeleteMappingv6Events.Inc()
 	}
 	return nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1409,7 +1409,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Namespace:  Namespace,
 			Subsystem:  SubsystemDatapath,
 			Name:       "nat_delete_mapping_ipv6_events_total",
-			Help:       "Number of NAT delete mapping for ipv6 events received",
+			Help:       "Number of garbage collected IPv6 NAT mappings",
 		}),
 	}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -660,6 +660,12 @@ var (
 		Name:       "retries_total",
 		Help:       "Total number of retries handled by workqueue.",
 	}, []string{"name"})
+
+	// NatDeleteMappingv4Events is the number of NAT delete mappings received for ipv4
+	NatDeleteMappingv4Events = NoOpCounter
+
+	// NatDeleteMappingv6Events is the number of NAT delete mappings received for ipv6
+	NatDeleteMappingv6Events = NoOpCounter
 )
 
 type LegacyMetrics struct {
@@ -745,6 +751,8 @@ type LegacyMetrics struct {
 	WorkQueueUnfinishedWork          metric.Vec[metric.Gauge]
 	WorkQueueLongestRunningProcessor metric.Vec[metric.Gauge]
 	WorkQueueRetries                 metric.Vec[metric.Counter]
+	NatDeleteMappingv4Events         metric.Counter
+	NatDeleteMappingv6Events         metric.Counter
 }
 
 func NewLegacyMetrics() *LegacyMetrics {
@@ -1387,6 +1395,22 @@ func NewLegacyMetrics() *LegacyMetrics {
 		WorkQueueUnfinishedWork:          WorkQueueUnfinishedWork,
 		WorkQueueLongestRunningProcessor: WorkQueueLongestRunningProcessor,
 		WorkQueueRetries:                 WorkQueueRetries,
+
+		NatDeleteMappingv4Events: metric.NewCounter(metric.CounterOpts{
+			ConfigName: Namespace + "_" + SubsystemDatapath + "_nat_delete_mapping_ipv4_events_total",
+			Namespace:  Namespace,
+			Subsystem:  SubsystemDatapath,
+			Name:       "nat_delete_mapping_ipv4_events_total",
+			Help:       "Number of NAT delete mapping for ipv4 events received",
+		}),
+
+		NatDeleteMappingv6Events: metric.NewCounter(metric.CounterOpts{
+			ConfigName: Namespace + "_" + SubsystemDatapath + "_nat_delete_mapping_ipv6_events_total",
+			Namespace:  Namespace,
+			Subsystem:  SubsystemDatapath,
+			Name:       "nat_delete_mapping_ipv6_events_total",
+			Help:       "Number of NAT delete mapping for ipv6 events received",
+		}),
 	}
 
 	ifindexOpts := metric.GaugeOpts{
@@ -1477,6 +1501,8 @@ func NewLegacyMetrics() *LegacyMetrics {
 	APILimiterRateLimit = lm.APILimiterRateLimit
 	APILimiterAdjustmentFactor = lm.APILimiterAdjustmentFactor
 	APILimiterProcessedRequests = lm.APILimiterProcessedRequests
+	NatDeleteMappingv4Events = lm.NatDeleteMappingv4Events
+	NatDeleteMappingv6Events = lm.NatDeleteMappingv6Events
 
 	return lm
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1401,7 +1401,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Namespace:  Namespace,
 			Subsystem:  SubsystemDatapath,
 			Name:       "nat_delete_mapping_ipv4_events_total",
-			Help:       "Number of NAT delete mapping for ipv4 events received",
+			Help:       "Number of garbage collected IPv4 NAT mappings",
 		}),
 
 		NatDeleteMappingv6Events: metric.NewCounter(metric.CounterOpts{


### PR DESCRIPTION
Add Prometheus counters for successful nat.DeleteMapping invocations
To better understand how many SNAT entries are GC-ed

Fixes: #17239

Signed-off-by: Umesh Keerthy <umesh.freelance@gmail.com>
