### PR TITLE
helm: kvstoremesh with external etcd 

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -588,10 +588,10 @@
      - KVStoreMesh Security context
      - object
      - ``{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}``
-   * - :spelling:ignore:`clustermesh.apiserver.kvstoremesh.useExternalKVStore`
-     - Use external KVStore for KVStoreMesh. The KVStore address is set through `etcd.endpoints`.
-     - bool
-     - ``false``
+   * - :spelling:ignore:`clustermesh.apiserver.kvstoremesh.kvstoreMode`
+     - Specify the KVStore mode when running KVStoreMesh     Supported values:- "":         ``clustermesh-apiserver`` will use the containers ``apiserver``, ``etcd`` and ``kvstoremesh``            - "external": ``clustermesh-apiserver`` will only use the container ``kvstoremesh`` and the user has to configure the etcd outside of the cluster, the KVStore address is set through `etcd.endpoints`.            - "sidecar": ``clustermesh-apiserver`` will use the containers ``etcd`` and ``kvstoremesh``
+     - string
+     - ``""``
    * - :spelling:ignore:`clustermesh.apiserver.lifecycle`
      - lifecycle setting for the apiserver container
      - object

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -840,6 +840,10 @@
      - Enable Multi-Cluster Services API support
      - bool
      - ``false``
+   * - :spelling:ignore:`clustermesh.kvstoremeshExternalKVStore`
+     - Use external KVStore for kvstoremesh.
+     - bool
+     - ``false``
    * - :spelling:ignore:`clustermesh.maxConnectedClusters`
      - The maximum number of clusters to support in a ClusterMesh. This value cannot be changed on running clusters, and all clusters in a ClusterMesh must be configured with the same value. Values > 255 will decrease the maximum allocatable cluster-local identities. Supported values are 255 and 511.
      - int

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -588,6 +588,10 @@
      - KVStoreMesh Security context
      - object
      - ``{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}``
+   * - :spelling:ignore:`clustermesh.apiserver.kvstoremesh.useExternalKVStore`
+     - Use external KVStore for KVStoreMesh. The KVStore address is set through `etcd.endpoints`.
+     - bool
+     - ``false``
    * - :spelling:ignore:`clustermesh.apiserver.lifecycle`
      - lifecycle setting for the apiserver container
      - object
@@ -838,10 +842,6 @@
      - ``false``
    * - :spelling:ignore:`clustermesh.enableMCSAPISupport`
      - Enable Multi-Cluster Services API support
-     - bool
-     - ``false``
-   * - :spelling:ignore:`clustermesh.kvstoremeshExternalKVStore`
-     - Use external KVStore for kvstoremesh.
      - bool
      - ``false``
    * - :spelling:ignore:`clustermesh.maxConnectedClusters`

--- a/Documentation/network/clustermesh/clustermesh.rst
+++ b/Documentation/network/clustermesh/clustermesh.rst
@@ -147,11 +147,6 @@ Example install using the Cilium CLI:
   cilium install --set cluster.name=$CLUSTER1 --set cluster.id=1 --context $CLUSTER1
   cilium install --set cluster.name=$CLUSTER2 --set cluster.id=2 --context $CLUSTER2
 
-.. note::
-
-  If you are planning on using external etcd with your cluster, you have to set the value of the Helm option ``clustermesh.kvstoremeshExternalKVStore`` 
-  to ``true`` for the KVStoreMesh to run with the external etcd instead of creating a new etcd instance upon creation.
-
 .. important::
 
    If you change the cluster ID and/or cluster name in a cluster with running
@@ -200,6 +195,9 @@ clusters.
 
      cilium clustermesh enable --context $CLUSTER1 --enable-kvstoremesh=false
      cilium clustermesh enable --context $CLUSTER2 --enable-kvstoremesh=false
+
+   If you are planning on using KVStoreMesh with external etcd in your cluster, you have to set the value of the Helm option ``clustermesh.apiserver.kvstoremesh.useExternalKVStore`` 
+   to ``true`` so that a new etcd instance is not created upon creation.
 
 .. important::
 

--- a/Documentation/network/clustermesh/clustermesh.rst
+++ b/Documentation/network/clustermesh/clustermesh.rst
@@ -196,8 +196,8 @@ clusters.
      cilium clustermesh enable --context $CLUSTER1 --enable-kvstoremesh=false
      cilium clustermesh enable --context $CLUSTER2 --enable-kvstoremesh=false
 
-   If you are planning on using KVStoreMesh with external etcd in your cluster, you have to set the value of the Helm option ``clustermesh.apiserver.kvstoremesh.useExternalKVStore`` 
-   to ``true`` so that a new etcd instance is not created upon creation.
+   If you are planning on using KVStoreMesh with external or sidecar etcd in your cluster, you have to specify the value of the Helm option ``clustermesh.apiserver.kvstoremesh.kvstoreMode`` 
+   to either ``external`` or ``sidecar``.
 
 .. important::
 

--- a/Documentation/network/clustermesh/clustermesh.rst
+++ b/Documentation/network/clustermesh/clustermesh.rst
@@ -147,6 +147,11 @@ Example install using the Cilium CLI:
   cilium install --set cluster.name=$CLUSTER1 --set cluster.id=1 --context $CLUSTER1
   cilium install --set cluster.name=$CLUSTER2 --set cluster.id=2 --context $CLUSTER2
 
+.. note::
+
+  If you are planning on using external etcd with your cluster, you have to set the value of the Helm option ``clustermesh.kvstoremeshExternalKVStore`` 
+  to ``true`` for the KVStoreMesh to run with the external etcd instead of creating a new etcd instance upon creation.
+
 .. important::
 
    If you change the cluster ID and/or cluster name in a cluster with running

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -197,6 +197,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.kvstoremesh.readinessProbe | object | `{}` | Configuration for the KVStoreMesh readiness probe. |
 | clustermesh.apiserver.kvstoremesh.resources | object | `{}` | Resource requests and limits for the KVStoreMesh container |
 | clustermesh.apiserver.kvstoremesh.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | KVStoreMesh Security context |
+| clustermesh.apiserver.kvstoremesh.useExternalKVStore | bool | `false` | Use external KVStore for KVStoreMesh. The KVStore address is set through `etcd.endpoints`. |
 | clustermesh.apiserver.lifecycle | object | `{}` | lifecycle setting for the apiserver container |
 | clustermesh.apiserver.metrics.enabled | bool | `true` | Enables exporting apiserver metrics in OpenMetrics format. |
 | clustermesh.apiserver.metrics.etcd.enabled | bool | `true` | Enables exporting etcd metrics in OpenMetrics format. |
@@ -260,7 +261,6 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.config.enabled | bool | `false` | Enable the Clustermesh explicit configuration. |
 | clustermesh.enableEndpointSliceSynchronization | bool | `false` | Enable the synchronization of Kubernetes EndpointSlices corresponding to the remote endpoints of appropriately-annotated global services through ClusterMesh |
 | clustermesh.enableMCSAPISupport | bool | `false` | Enable Multi-Cluster Services API support |
-| clustermesh.kvstoremeshExternalKVStore | bool | `false` | Use external KVStore for KVStoreMesh. |
 | clustermesh.maxConnectedClusters | int | `255` | The maximum number of clusters to support in a ClusterMesh. This value cannot be changed on running clusters, and all clusters in a ClusterMesh must be configured with the same value. Values > 255 will decrease the maximum allocatable cluster-local identities. Supported values are 255 and 511. |
 | clustermesh.useAPIServer | bool | `false` | Deploy clustermesh-apiserver for clustermesh |
 | cni.binPath | string | `"/opt/cni/bin"` | Configure the path to the CNI binary directory on the host. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -260,6 +260,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.config.enabled | bool | `false` | Enable the Clustermesh explicit configuration. |
 | clustermesh.enableEndpointSliceSynchronization | bool | `false` | Enable the synchronization of Kubernetes EndpointSlices corresponding to the remote endpoints of appropriately-annotated global services through ClusterMesh |
 | clustermesh.enableMCSAPISupport | bool | `false` | Enable Multi-Cluster Services API support |
+| clustermesh.kvstoremeshExternalKVStore | bool | `false` | Use external KVStore for KVStoreMesh. |
 | clustermesh.maxConnectedClusters | int | `255` | The maximum number of clusters to support in a ClusterMesh. This value cannot be changed on running clusters, and all clusters in a ClusterMesh must be configured with the same value. Values > 255 will decrease the maximum allocatable cluster-local identities. Supported values are 255 and 511. |
 | clustermesh.useAPIServer | bool | `false` | Deploy clustermesh-apiserver for clustermesh |
 | cni.binPath | string | `"/opt/cni/bin"` | Configure the path to the CNI binary directory on the host. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -197,7 +197,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.kvstoremesh.readinessProbe | object | `{}` | Configuration for the KVStoreMesh readiness probe. |
 | clustermesh.apiserver.kvstoremesh.resources | object | `{}` | Resource requests and limits for the KVStoreMesh container |
 | clustermesh.apiserver.kvstoremesh.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | KVStoreMesh Security context |
-| clustermesh.apiserver.kvstoremesh.useExternalKVStore | bool | `false` | Use external KVStore for KVStoreMesh. The KVStore address is set through `etcd.endpoints`. |
+| clustermesh.apiserver.kvstoremesh.kvstoreMode | string | `""` | Specify the KVStore mode when running KVStoreMesh     Supported values:- "":         ``clustermesh-apiserver`` will use the containers ``apiserver``, ``etcd`` and ``kvstoremesh``            - "external": ``clustermesh-apiserver`` will only use the container ``kvstoremesh`` and the user has to configure the etcd outside of the cluster, the KVStore address is set through `etcd.endpoints`.            - "sidecar": ``clustermesh-apiserver`` will use the containers ``etcd`` and ``kvstoremesh`` |
 | clustermesh.apiserver.lifecycle | object | `{}` | lifecycle setting for the apiserver container |
 | clustermesh.apiserver.metrics.enabled | bool | `true` | Enables exporting apiserver metrics in OpenMetrics format. |
 | clustermesh.apiserver.metrics.etcd.enabled | bool | `true` | Enables exporting etcd metrics in OpenMetrics format. |

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore) }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore) }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -46,7 +46,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if not .Values.clustermesh.kvstoremeshExternalKVStore}}
+      {{- if not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore}}
       initContainers:
       - name: etcd-init
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
@@ -101,7 +101,7 @@ spec:
         {{- end }}
       {{- end }}
       containers:
-      {{- if not .Values.clustermesh.kvstoremeshExternalKVStore}}
+      {{- if not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore}}
       - name: etcd
         # The clustermesh-apiserver container image includes an etcd binary.
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
@@ -328,9 +328,11 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
+        {{- if (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore) }}
         - name: etcd-admin-client
           mountPath: /var/lib/cilium/etcd-secrets
           readOnly: true
+        {{- end }}
         - name: kvstoremesh-secrets
           mountPath: /var/lib/cilium/clustermesh
           readOnly: true
@@ -348,6 +350,7 @@ spec:
         {{- end }}
       {{- end }}
       volumes:
+      {{- if (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore) }}
       - name: etcd-server-secrets
         projected:
           # note: the leading zero means this number is in octal representation: do not remove it
@@ -402,6 +405,7 @@ spec:
       - name: etcd-data-dir
         emptyDir:
           medium: {{ ternary "Memory" "" (eq .Values.clustermesh.apiserver.etcd.storageMedium "Memory") | quote }}
+      {{- end }}
       {{- if .Values.clustermesh.apiserver.kvstoremesh.enabled }}
       - name: kvstoremesh-secrets
         projected:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -46,6 +46,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if not .Values.clustermesh.kvstoremeshExternalKVStore}}
       initContainers:
       - name: etcd-init
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
@@ -98,7 +99,9 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- end }}
       containers:
+      {{- if not .Values.clustermesh.kvstoremeshExternalKVStore}}
       - name: etcd
         # The clustermesh-apiserver container image includes an etcd binary.
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
@@ -260,6 +263,7 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- end }}
       {{- if .Values.clustermesh.apiserver.kvstoremesh.enabled }}
       - name: kvstoremesh
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -2,6 +2,9 @@
 {{- if not (list "legacy" "migration" "cluster" | has .Values.clustermesh.apiserver.tls.authMode) -}}
 {{- fail ".Values.clustermesh.apiserver.tls.authMode must be one of legacy, migration, cluster" -}}
 {{- end -}}
+{{- if not (list "" "external" "sidecar" | has .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode) -}}
+{{- fail ".Values.clustermesh.apiserver.kvstoremesh.kvstoreMode must either be empty or have the value of external or sidecar" -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,7 +49,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore}}
+      {{- if ne .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external"}}
       initContainers:
       - name: etcd-init
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
@@ -101,7 +104,7 @@ spec:
         {{- end }}
       {{- end }}
       containers:
-      {{- if not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore}}
+      {{- if ne .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external"}}
       - name: etcd
         # The clustermesh-apiserver container image includes an etcd binary.
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
@@ -167,6 +170,8 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- end }}
+      {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "" }}
       - name: apiserver
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
@@ -328,7 +333,7 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
-        {{- if (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore) }}
+        {{- if (ne .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external") }}
         - name: etcd-admin-client
           mountPath: /var/lib/cilium/etcd-secrets
           readOnly: true
@@ -350,7 +355,7 @@ spec:
         {{- end }}
       {{- end }}
       volumes:
-      {{- if (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore) }}
+      {{- if (ne .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external") }}
       - name: etcd-server-secrets
         projected:
           # note: the leading zero means this number is in octal representation: do not remove it

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
@@ -1,4 +1,4 @@
-{{- if (or .Values.externalWorkloads.enabled  .Values.clustermesh.useAPIServer) }}
+{{- if and (or .Values.externalWorkloads.enabled  .Values.clustermesh.useAPIServer) (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled  .Values.clustermesh.useAPIServer) (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore) }}
+{{- if and (or .Values.externalWorkloads.enabled  .Values.clustermesh.useAPIServer) (ne .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external") }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
@@ -32,7 +32,7 @@ spec:
     matchNames:
     - {{ .Release.Namespace }}
   endpoints:
-  {{- if .Values.clustermesh.apiserver.metrics.enabled }}
+  {{- if and .Values.clustermesh.apiserver.metrics.enabled (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore) }}
   - port: apiserv-metrics
     interval: {{ .Values.clustermesh.apiserver.metrics.serviceMonitor.interval | quote }}
     honorLabels: true
@@ -60,7 +60,7 @@ spec:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
-  {{- if .Values.clustermesh.apiserver.metrics.etcd.enabled }}
+  {{- if and .Values.clustermesh.apiserver.metrics.etcd.enabled (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore) }}
   - port: etcd-metrics
     interval: {{ .Values.clustermesh.apiserver.metrics.serviceMonitor.etcd.interval | quote }}
     honorLabels: true

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
@@ -32,7 +32,7 @@ spec:
     matchNames:
     - {{ .Release.Namespace }}
   endpoints:
-  {{- if and .Values.clustermesh.apiserver.metrics.enabled (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore) }}
+  {{- if and .Values.clustermesh.apiserver.metrics.enabled (ne .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external") }}
   - port: apiserv-metrics
     interval: {{ .Values.clustermesh.apiserver.metrics.serviceMonitor.interval | quote }}
     honorLabels: true
@@ -60,7 +60,7 @@ spec:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
-  {{- if and .Values.clustermesh.apiserver.metrics.etcd.enabled (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore) }}
+  {{- if and .Values.clustermesh.apiserver.metrics.etcd.enabled (ne .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external") }}
   - port: etcd-metrics
     interval: {{ .Values.clustermesh.apiserver.metrics.serviceMonitor.etcd.interval | quote }}
     honorLabels: true

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
@@ -1,6 +1,7 @@
 {{- if and
   (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer)
   (ne .Values.clustermesh.apiserver.tls.authMode "legacy")
+  (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore)
 }}
 ---
 apiVersion: v1

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
@@ -1,7 +1,7 @@
 {{- if and
   (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer)
   (ne .Values.clustermesh.apiserver.tls.authMode "legacy")
-  (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore)
+  (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "")
 }}
 ---
 apiVersion: v1

--- a/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 data:
   {{- $kvstoremesh := and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled }}
-  {{- $override := ternary (printf "https://clustermesh-apiserver.%s.svc:2379" .Release.Namespace) "" $kvstoremesh }}
+  {{- $override := ternary (join "\n- " $.Values.etcd.endpoints) (ternary (printf "https://clustermesh-apiserver.%s.svc:2379" .Release.Namespace) "" $kvstoremesh) .Values.clustermesh.kvstoremeshExternalKVStore }}
   {{- range .Values.clustermesh.config.clusters }}
   {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain $override) | b64enc }}
   {{- /* The parenthesis around .tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}

--- a/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 data:
   {{- $kvstoremesh := and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled }}
-  {{- $override := ternary (join "\n- " $.Values.etcd.endpoints) (ternary (printf "https://clustermesh-apiserver.%s.svc:2379" .Release.Namespace) "" $kvstoremesh) .Values.clustermesh.kvstoremeshExternalKVStore }}
+  {{- $override := ternary (join "\n- " $.Values.etcd.endpoints) (ternary (printf "https://clustermesh-apiserver.%s.svc:2379" .Release.Namespace) "" $kvstoremesh) .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore }}
   {{- range .Values.clustermesh.config.clusters }}
   {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain $override) | b64enc }}
   {{- /* The parenthesis around .tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}

--- a/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 data:
   {{- $kvstoremesh := and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled }}
-  {{- $override := ternary (join "\n- " $.Values.etcd.endpoints) (ternary (printf "https://clustermesh-apiserver.%s.svc:2379" .Release.Namespace) "" $kvstoremesh) .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore }}
+  {{- $override := ternary (join "\n- " $.Values.etcd.endpoints) (ternary (printf "https://clustermesh-apiserver.%s.svc:2379" .Release.Namespace) "" $kvstoremesh) (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external") }}
   {{- range .Values.clustermesh.config.clusters }}
   {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain $override) | b64enc }}
   {{- /* The parenthesis around .tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -152,8 +152,8 @@
 {{- end }}
 
 {{/* validate clustermesh-apiserver */}}
-{{- if .Values.clustermesh.useAPIServer }}
-  {{- if and (ne .Values.identityAllocationMode "crd") (ne .Values.identityAllocationMode "doublewrite-readkvstore") (ne .Values.identityAllocationMode "doublewrite-readcrd") (not .Values.clustermesh.kvstoremeshExternalKVStore) }}
+{{- if and .Values.clustermesh.useAPIServer (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore) }}
+  {{- if and (ne .Values.identityAllocationMode "crd") (ne .Values.identityAllocationMode "doublewrite-readkvstore") (ne .Values.identityAllocationMode "doublewrite-readcrd") }}
     {{ fail (printf "The clustermesh-apiserver cannot be enabled in combination with .Values.identityAllocationMode=%s. To establish a Cluster Mesh, directly configure the parameters to access the remote kvstore through .Values.clustermesh.config" .Values.identityAllocationMode ) }}
   {{- end }}
   {{- if .Values.disableEndpointCRD }}
@@ -166,6 +166,20 @@
   {{- end }}
   {{- if .Values.disableEndpointCRD }}
     {{ fail "External workloads support cannot be enabled in combination with .Values.disableEndpointCRD=true" }}
+  {{- end }}
+{{- end }}
+{{- if .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore }}
+  {{- if or (not .Values.etcd.enabled) (has "https://CHANGE-ME:2379" .Values.etcd.endpoints) }}
+    {{- fail "etcd is not configured correctly"}}
+  {{- end }}
+  {{- if not .Values.clustermesh.apiserver.kvstoremesh.enabled }}
+    {{- fail "KVStoreMesh with an external KVStore cannot be enabled in combination with .Values.clustermesh.apiserver.kvstoremesh.enabled=false" }}
+  {{- end }}
+  {{- if not .Values.clustermesh.useAPIServer }}
+    {{- fail "KVStoreMesh with an external KVStore cannot be enabled in combination with .Values.clustermesh.useAPIServer=false" }}
+  {{- end }}
+  {{- if .Values.externalWorkloads.enabled }}
+    {{- fail "KVStoreMesh with an external KVStore cannot be enabled in combination with .Values.externalWorkloads.enabled=true" }}
   {{- end }}
 {{- end }}
 

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -153,7 +153,7 @@
 
 {{/* validate clustermesh-apiserver */}}
 {{- if .Values.clustermesh.useAPIServer }}
-  {{- if and (ne .Values.identityAllocationMode "crd") (ne .Values.identityAllocationMode "doublewrite-readkvstore") (ne .Values.identityAllocationMode "doublewrite-readcrd") }}
+  {{- if and (ne .Values.identityAllocationMode "crd") (ne .Values.identityAllocationMode "doublewrite-readkvstore") (ne .Values.identityAllocationMode "doublewrite-readcrd") (not .Values.clustermesh.kvstoremeshExternalKVStore) }}
     {{ fail (printf "The clustermesh-apiserver cannot be enabled in combination with .Values.identityAllocationMode=%s. To establish a Cluster Mesh, directly configure the parameters to access the remote kvstore through .Values.clustermesh.config" .Values.identityAllocationMode ) }}
   {{- end }}
   {{- if .Values.disableEndpointCRD }}

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -152,7 +152,7 @@
 {{- end }}
 
 {{/* validate clustermesh-apiserver */}}
-{{- if and .Values.clustermesh.useAPIServer (not .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore) }}
+{{- if and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "") }}
   {{- if and (ne .Values.identityAllocationMode "crd") (ne .Values.identityAllocationMode "doublewrite-readkvstore") (ne .Values.identityAllocationMode "doublewrite-readcrd") }}
     {{ fail (printf "The clustermesh-apiserver cannot be enabled in combination with .Values.identityAllocationMode=%s. To establish a Cluster Mesh, directly configure the parameters to access the remote kvstore through .Values.clustermesh.config" .Values.identityAllocationMode ) }}
   {{- end }}
@@ -168,18 +168,17 @@
     {{ fail "External workloads support cannot be enabled in combination with .Values.disableEndpointCRD=true" }}
   {{- end }}
 {{- end }}
-{{- if .Values.clustermesh.apiserver.kvstoremesh.useExternalKVStore }}
-  {{- if or (not .Values.etcd.enabled) (has "https://CHANGE-ME:2379" .Values.etcd.endpoints) }}
-    {{- fail "etcd is not configured correctly"}}
-  {{- end }}
-  {{- if not .Values.clustermesh.apiserver.kvstoremesh.enabled }}
-    {{- fail "KVStoreMesh with an external KVStore cannot be enabled in combination with .Values.clustermesh.apiserver.kvstoremesh.enabled=false" }}
-  {{- end }}
-  {{- if not .Values.clustermesh.useAPIServer }}
-    {{- fail "KVStoreMesh with an external KVStore cannot be enabled in combination with .Values.clustermesh.useAPIServer=false" }}
-  {{- end }}
+{{- if ne .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode ""}}
   {{- if .Values.externalWorkloads.enabled }}
-    {{- fail "KVStoreMesh with an external KVStore cannot be enabled in combination with .Values.externalWorkloads.enabled=true" }}
+    {{- fail (printf "KVStoreMesh with %s etcd cannot be enabled in combination with .Values.externalWorkloads.enabled=true" .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode) }}
+  {{- end }}
+  {{- if ne .Values.identityAllocationMode "kvstore" }}
+    {{- fail (printf "KVStoreMesh with %s etcd cannot be enabled in combination with .Values.identityAllocationMode=%s" .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode .Values.identityAllocationMode)}}
+  {{- end }}
+  {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external" }}
+    {{- if or (not .Values.etcd.enabled) (has "https://CHANGE-ME:2379" .Values.etcd.endpoints) }}
+      {{- fail "etcd is not configured correctly"}}
+    {{- end }}
   {{- end }}
 {{- end }}
 

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1389,6 +1389,9 @@
         "enableMCSAPISupport": {
           "type": "boolean"
         },
+        "kvstoremeshExternalKVStore": {
+          "type": "boolean"
+        },
         "maxConnectedClusters": {
           "type": "integer"
         },

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1001,8 +1001,8 @@
                   },
                   "type": "object"
                 },
-                "useExternalKVStore": {
-                  "type": "boolean"
+                "kvstoreMode": {
+                  "type": "string"
                 }
               },
               "type": "object"

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1000,6 +1000,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "useExternalKVStore": {
+                  "type": "boolean"
                 }
               },
               "type": "object"
@@ -1387,9 +1390,6 @@
           "type": "boolean"
         },
         "enableMCSAPISupport": {
-          "type": "boolean"
-        },
-        "kvstoremeshExternalKVStore": {
           "type": "boolean"
         },
         "maxConnectedClusters": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3052,8 +3052,12 @@ clustermesh:
             - ALL
       # -- lifecycle setting for the KVStoreMesh container
       lifecycle: {}
-      # -- Use external KVStore for KVStoreMesh. The KVStore address is set through `etcd.endpoints`.
-      useExternalKVStore: false
+      # -- Specify the KVStore mode when running KVStoreMesh
+      # Supported values:
+      # - "":         ``clustermesh-apiserver`` will use the containers ``apiserver``, ``etcd`` and ``kvstoremesh``
+      # - "external": ``clustermesh-apiserver`` will only use the container ``kvstoremesh`` and the user has to configure the etcd outside of the cluster, the KVStore address is set through `etcd.endpoints`.
+      # - "sidecar":  ``clustermesh-apiserver`` will use the containers ``etcd`` and ``kvstoremesh``
+      kvstoreMode: ""
     service:
       # -- The type of service used for apiserver access.
       type: NodePort

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2923,6 +2923,8 @@ clustermesh:
   # maximum allocatable cluster-local identities.
   # Supported values are 255 and 511.
   maxConnectedClusters: 255
+  # -- Use external KVStore for KVStoreMesh.
+  kvstoremeshExternalKVStore: false
   # -- Enable the synchronization of Kubernetes EndpointSlices corresponding to
   # the remote endpoints of appropriately-annotated global services through ClusterMesh
   enableEndpointSliceSynchronization: false

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2923,8 +2923,6 @@ clustermesh:
   # maximum allocatable cluster-local identities.
   # Supported values are 255 and 511.
   maxConnectedClusters: 255
-  # -- Use external KVStore for KVStoreMesh.
-  kvstoremeshExternalKVStore: false
   # -- Enable the synchronization of Kubernetes EndpointSlices corresponding to
   # the remote endpoints of appropriately-annotated global services through ClusterMesh
   enableEndpointSliceSynchronization: false
@@ -3054,6 +3052,8 @@ clustermesh:
             - ALL
       # -- lifecycle setting for the KVStoreMesh container
       lifecycle: {}
+      # -- Use external KVStore for KVStoreMesh. The KVStore address is set through `etcd.endpoints`.
+      useExternalKVStore: false
     service:
       # -- The type of service used for apiserver access.
       type: NodePort

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3074,8 +3074,12 @@ clustermesh:
             - ALL
       # -- lifecycle setting for the KVStoreMesh container
       lifecycle: {}
-      # -- Use external KVStore for KVStoreMesh. The KVStore address is set through `etcd.endpoints`.
-      useExternalKVStore: false
+      # -- Specify the KVStore mode when running KVStoreMesh
+      # Supported values:
+      # - "":         ``clustermesh-apiserver`` will use the containers ``apiserver``, ``etcd`` and ``kvstoremesh``
+      # - "external": ``clustermesh-apiserver`` will only use the container ``kvstoremesh`` and the user has to configure the etcd outside of the cluster, the KVStore address is set through `etcd.endpoints`.
+      # - "sidecar":  ``clustermesh-apiserver`` will use the containers ``etcd`` and ``kvstoremesh``
+      kvstoreMode: ""
     service:
       # -- The type of service used for apiserver access.
       type: NodePort

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2938,6 +2938,8 @@ clustermesh:
   # maximum allocatable cluster-local identities.
   # Supported values are 255 and 511.
   maxConnectedClusters: 255
+  # -- Use external KVStore for KVStoreMesh.
+  kvstoremeshExternalKVStore: false
   # -- Enable the synchronization of Kubernetes EndpointSlices corresponding to
   # the remote endpoints of appropriately-annotated global services through ClusterMesh
   enableEndpointSliceSynchronization: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2938,8 +2938,6 @@ clustermesh:
   # maximum allocatable cluster-local identities.
   # Supported values are 255 and 511.
   maxConnectedClusters: 255
-  # -- Use external KVStore for KVStoreMesh.
-  kvstoremeshExternalKVStore: false
   # -- Enable the synchronization of Kubernetes EndpointSlices corresponding to
   # the remote endpoints of appropriately-annotated global services through ClusterMesh
   enableEndpointSliceSynchronization: false
@@ -3076,6 +3074,8 @@ clustermesh:
             - ALL
       # -- lifecycle setting for the KVStoreMesh container
       lifecycle: {}
+      # -- Use external KVStore for KVStoreMesh. The KVStore address is set through `etcd.endpoints`.
+      useExternalKVStore: false
     service:
       # -- The type of service used for apiserver access.
       type: NodePort


### PR DESCRIPTION
When running clustermesh-apiserver, there should be an option to enable and disable containers that are not needed.
For example the etcd and apiserver containers are not necessary when running kvstoremesh with an external kvstore.

This commit adds the options to disable these containers.
