### PR TITLE
Fix two bugs in dnsproxy tcp conn reuse

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -1322,14 +1322,14 @@ func (w *wrappedTCPConn) Read(b []byte) (int, error) {
 	n, err := w.TCPConn.Read(b)
 	if err != nil {
 		// Any error is reason enough to close the upstream conn.
-		w.sc.ShutdownClient(w.key())
+		w.sc.ShutdownTCPClient(w.key())
 	}
 	return n, err
 }
 func (w *wrappedTCPConn) Write(b []byte) (int, error) {
 	n, err := w.TCPConn.Write(b)
 	if err != nil {
-		w.sc.ShutdownClient(w.key())
+		w.sc.ShutdownTCPClient(w.key())
 	}
 	return n, err
 }
@@ -1340,7 +1340,7 @@ func (w *wrappedTCPConn) Close() error {
 	// It's possible that there is no shared client behind this key, as we don't
 	// always use the original source address. That's okay, since ShutdownClient
 	// does nothing for keys it doesn't know.
-	w.sc.ShutdownClient(w.key())
+	w.sc.ShutdownTCPClient(w.key())
 	return w.TCPConn.Close()
 }
 

--- a/pkg/fqdn/dnsproxy/shared_client.go
+++ b/pkg/fqdn/dnsproxy/shared_client.go
@@ -50,9 +50,9 @@ func (s *SharedClients) ExchangeContext(ctx context.Context, key string, conf *d
 func (s *SharedClients) ShutdownClient(key string) {
 	// lock for s.clients access
 	s.lock.Lock()
-	// locate client to re-use if possible.
 	client := s.clients[key]
 	if client == nil {
+		s.lock.Unlock()
 		return
 	}
 	s.lock.Unlock()


### PR DESCRIPTION
In #33989 I managed to introduce two bugs in short succession:

1. a self-deadlock by forgetting to unlock in the early return
2. a slightly more involved reference counting bug for TCP

(release-note/misc as the bugs have not been released yet)


