### PR TITLE
bgpv1 + bgpv2: Fix DiffStore to work with multiple server instances

### DIFF
--- a/pkg/bgpv1/manager/instance/instance.go
+++ b/pkg/bgpv1/manager/instance/instance.go
@@ -22,6 +22,9 @@ import (
 //
 // This is used in BGPv1 implementation.
 type ServerWithConfig struct {
+	// ASN is the local ASN number of the virtual router instance.
+	ASN uint32
+
 	// backed BgpServer configured in accordance to the accompanying
 	// CiliumBGPVirtualRouter configuration.
 	Server types.Router
@@ -52,6 +55,7 @@ func NewServerWithConfig(ctx context.Context, log *logrus.Entry, params types.Se
 		return nil, err
 	}
 	return &ServerWithConfig{
+		ASN:                params.Global.ASN,
 		Server:             s,
 		Config:             nil,
 		ReconcilerMetadata: make(map[string]any),
@@ -62,6 +66,7 @@ func NewServerWithConfig(ctx context.Context, log *logrus.Entry, params types.Se
 //
 // This is used in BGPv2 implementation.
 type BGPInstance struct {
+	ASN       uint32
 	CancelCtx context.CancelFunc
 	Config    *v2alpha1api.CiliumBGPNodeInstance
 	Router    types.Router
@@ -85,6 +90,7 @@ func NewBGPInstance(ctx context.Context, log *logrus.Entry, params types.ServerP
 	}
 
 	return &BGPInstance{
+		ASN:       params.Global.ASN,
 		CancelCtx: cancel,
 		Config:    nil,
 		Router:    s,

--- a/pkg/bgpv1/manager/reconciler/neighbor.go
+++ b/pkg/bgpv1/manager/reconciler/neighbor.go
@@ -53,6 +53,12 @@ func (r *NeighborReconciler) Priority() int {
 	return 60
 }
 
+func (r *NeighborReconciler) Init(_ *instance.ServerWithConfig) error {
+	return nil
+}
+
+func (r *NeighborReconciler) Cleanup(_ *instance.ServerWithConfig) {}
+
 func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
 	if p.DesiredConfig == nil {
 		return fmt.Errorf("attempted neighbor reconciliation with nil CiliumBGPPeeringPolicy")

--- a/pkg/bgpv1/manager/reconciler/pod_cidr.go
+++ b/pkg/bgpv1/manager/reconciler/pod_cidr.go
@@ -48,6 +48,12 @@ func (r *ExportPodCIDRReconciler) Priority() int {
 	return 30
 }
 
+func (r *ExportPodCIDRReconciler) Init(_ *instance.ServerWithConfig) error {
+	return nil
+}
+
+func (r *ExportPodCIDRReconciler) Cleanup(_ *instance.ServerWithConfig) {}
+
 func (r *ExportPodCIDRReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
 	if p.DesiredConfig == nil {
 		return fmt.Errorf("attempted pod CIDR advertisements reconciliation with nil CiliumBGPPeeringPolicy")

--- a/pkg/bgpv1/manager/reconciler/pod_ip_pool.go
+++ b/pkg/bgpv1/manager/reconciler/pod_ip_pool.go
@@ -61,6 +61,12 @@ func (r *PodIPPoolReconciler) Priority() int {
 	return 50
 }
 
+func (r *PodIPPoolReconciler) Init(_ *instance.ServerWithConfig) error {
+	return nil
+}
+
+func (r *PodIPPoolReconciler) Cleanup(_ *instance.ServerWithConfig) {}
+
 func (r *PodIPPoolReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
 	lp := r.populateLocalPools(p.CiliumNode)
 

--- a/pkg/bgpv1/manager/reconciler/preflight.go
+++ b/pkg/bgpv1/manager/reconciler/preflight.go
@@ -48,6 +48,12 @@ func (r *PreflightReconciler) Priority() int {
 	return 10
 }
 
+func (r *PreflightReconciler) Init(_ *instance.ServerWithConfig) error {
+	return nil
+}
+
+func (r *PreflightReconciler) Cleanup(_ *instance.ServerWithConfig) {}
+
 func (r *PreflightReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
 	var (
 		l = log.WithFields(

--- a/pkg/bgpv1/manager/reconciler/reconciler.go
+++ b/pkg/bgpv1/manager/reconciler/reconciler.go
@@ -30,6 +30,12 @@ type ConfigReconciler interface {
 	// Priority is used to determine the order in which reconcilers are called. Reconcilers are called from lowest to
 	// highest.
 	Priority() int
+	// Init is called upon virtual router instance creation. Reconcilers can initialize any instance-specific
+	// resources here, and clean them up upon Cleanup call.
+	Init(sc *instance.ServerWithConfig) error
+	// Cleanup is called upon virtual router instance deletion. When called, reconcilers are supposed
+	// to clean up all instance-specific resources saved outside the ReconcilerMetadata.
+	Cleanup(sc *instance.ServerWithConfig)
 	// Reconcile If the `Config` field in `params.sc` is nil the reconciler should unconditionally
 	// perform the reconciliation actions, as no previous configuration is present.
 	Reconcile(ctx context.Context, params ReconcileParams) error

--- a/pkg/bgpv1/manager/reconciler/route_policy.go
+++ b/pkg/bgpv1/manager/reconciler/route_policy.go
@@ -68,6 +68,12 @@ func (r *RoutePolicyReconciler) Priority() int {
 	return 70
 }
 
+func (r *RoutePolicyReconciler) Init(_ *instance.ServerWithConfig) error {
+	return nil
+}
+
+func (r *RoutePolicyReconciler) Cleanup(_ *instance.ServerWithConfig) {}
+
 func (r *RoutePolicyReconciler) Reconcile(ctx context.Context, params ReconcileParams) error {
 	l := log.WithFields(logrus.Fields{"component": "RoutePolicyReconciler"})
 

--- a/pkg/bgpv1/manager/reconciler/service_test.go
+++ b/pkg/bgpv1/manager/reconciler/service_test.go
@@ -629,19 +629,22 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 			testSC.Config = oldc
 
 			diffstore := store.NewFakeDiffStore[*slim_corev1.Service]()
+			epDiffStore := store.NewFakeDiffStore[*k8s.Endpoints]()
+
+			reconciler := NewServiceReconciler(diffstore, epDiffStore).Reconciler.(*ServiceReconciler)
+			reconciler.Init(testSC)
+			defer reconciler.Cleanup(testSC)
+
 			for _, obj := range tt.upsertedServices {
 				diffstore.Upsert(obj)
 			}
 			for _, key := range tt.deletedServices {
 				diffstore.Delete(key)
 			}
-
-			epDiffStore := store.NewFakeDiffStore[*k8s.Endpoints]()
 			for _, obj := range tt.upsertedEndpoints {
 				epDiffStore.Upsert(obj)
 			}
 
-			reconciler := NewServiceReconciler(diffstore, epDiffStore).Reconciler.(*ServiceReconciler)
 			serviceAnnouncements := reconciler.getMetadata(testSC)
 
 			for svcKey, cidrs := range tt.advertised {
@@ -1285,19 +1288,22 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 			testSC.Config = oldc
 
 			diffstore := store.NewFakeDiffStore[*slim_corev1.Service]()
+			epDiffStore := store.NewFakeDiffStore[*k8s.Endpoints]()
+
+			reconciler := NewServiceReconciler(diffstore, epDiffStore).Reconciler.(*ServiceReconciler)
+			reconciler.Init(testSC)
+			defer reconciler.Cleanup(testSC)
+
 			for _, obj := range tt.upsertedServices {
 				diffstore.Upsert(obj)
 			}
 			for _, key := range tt.deletedServices {
 				diffstore.Delete(key)
 			}
-
-			epDiffStore := store.NewFakeDiffStore[*k8s.Endpoints]()
 			for _, obj := range tt.upsertedEndpoints {
 				epDiffStore.Upsert(obj)
 			}
 
-			reconciler := NewServiceReconciler(diffstore, epDiffStore).Reconciler.(*ServiceReconciler)
 			serviceAnnouncements := reconciler.getMetadata(testSC)
 
 			for svcKey, cidrs := range tt.advertised {
@@ -1939,19 +1945,22 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 			testSC.Config = oldc
 
 			diffstore := store.NewFakeDiffStore[*slim_corev1.Service]()
+			epDiffStore := store.NewFakeDiffStore[*k8s.Endpoints]()
+
+			reconciler := NewServiceReconciler(diffstore, epDiffStore).Reconciler.(*ServiceReconciler)
+			reconciler.Init(testSC)
+			defer reconciler.Cleanup(testSC)
+
 			for _, obj := range tt.upsertedServices {
 				diffstore.Upsert(obj)
 			}
 			for _, key := range tt.deletedServices {
 				diffstore.Delete(key)
 			}
-
-			epDiffStore := store.NewFakeDiffStore[*k8s.Endpoints]()
 			for _, obj := range tt.upsertedEndpoints {
 				epDiffStore.Upsert(obj)
 			}
 
-			reconciler := NewServiceReconciler(diffstore, epDiffStore).Reconciler.(*ServiceReconciler)
 			serviceAnnouncements := reconciler.getMetadata(testSC)
 
 			for svcKey, cidrs := range tt.advertised {
@@ -2151,6 +2160,8 @@ func TestEPUpdateOnly(t *testing.T) {
 	diffstore := store.NewFakeDiffStore[*slim_corev1.Service]()
 	epDiffStore := store.NewFakeDiffStore[*k8s.Endpoints]()
 	reconciler := NewServiceReconciler(diffstore, epDiffStore).Reconciler.(*ServiceReconciler)
+	reconciler.Init(testSC)
+	defer reconciler.Cleanup(testSC)
 
 	for _, step := range steps {
 		t.Logf("running step: %s", step.name)
@@ -2282,19 +2293,22 @@ func TestServiceReconcilerWithExternalIPAndClusterIP(t *testing.T) {
 			testSC.Config = oldc
 
 			diffstore := store.NewFakeDiffStore[*slim_corev1.Service]()
+			epDiffStore := store.NewFakeDiffStore[*k8s.Endpoints]()
+
+			reconciler := NewServiceReconciler(diffstore, epDiffStore).Reconciler.(*ServiceReconciler)
+			reconciler.Init(testSC)
+			defer reconciler.Cleanup(testSC)
+
 			for _, obj := range tt.upsertedServices {
 				diffstore.Upsert(obj)
 			}
 			for _, key := range tt.deletedServices {
 				diffstore.Delete(key)
 			}
-
-			epDiffStore := store.NewFakeDiffStore[*k8s.Endpoints]()
 			for _, obj := range tt.upsertedEndpoints {
 				epDiffStore.Upsert(obj)
 			}
 
-			reconciler := NewServiceReconciler(diffstore, epDiffStore).Reconciler.(*ServiceReconciler)
 			serviceAnnouncements := reconciler.getMetadata(testSC)
 
 			for svcKey, cidrs := range tt.advertised {

--- a/pkg/bgpv1/manager/reconcilerv2/neighbor.go
+++ b/pkg/bgpv1/manager/reconcilerv2/neighbor.go
@@ -139,6 +139,12 @@ func (r *NeighborReconciler) Priority() int {
 	return 60
 }
 
+func (r *NeighborReconciler) Init(_ *instance.BGPInstance) error {
+	return nil
+}
+
+func (r *NeighborReconciler) Cleanup(_ *instance.BGPInstance) {}
+
 func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
 	if p.DesiredConfig == nil {
 		return fmt.Errorf("attempted neighbor reconciliation with nil CiliumBGPNodeInstance")

--- a/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
@@ -64,6 +64,12 @@ func (r *PodCIDRReconciler) Priority() int {
 	return 30
 }
 
+func (r *PodCIDRReconciler) Init(_ *instance.BGPInstance) error {
+	return nil
+}
+
+func (r *PodCIDRReconciler) Cleanup(_ *instance.BGPInstance) {}
+
 func (r *PodCIDRReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
 	if p.DesiredConfig == nil {
 		return fmt.Errorf("BUG: PodCIDR reconciler called with nil CiliumBGPNodeConfig")

--- a/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool.go
@@ -76,6 +76,12 @@ func (r *PodIPPoolReconciler) Priority() int {
 	return 50
 }
 
+func (r *PodIPPoolReconciler) Init(_ *instance.BGPInstance) error {
+	return nil
+}
+
+func (r *PodIPPoolReconciler) Cleanup(_ *instance.BGPInstance) {}
+
 func (r *PodIPPoolReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
 	if p.DesiredConfig == nil {
 		return fmt.Errorf("BUG: PodIPPoolReconciler reconciler called with nil CiliumBGPNodeConfig")

--- a/pkg/bgpv1/manager/reconcilerv2/preflight.go
+++ b/pkg/bgpv1/manager/reconcilerv2/preflight.go
@@ -50,6 +50,12 @@ func (r *PreflightReconciler) Priority() int {
 	return 10
 }
 
+func (r *PreflightReconciler) Init(_ *instance.BGPInstance) error {
+	return nil
+}
+
+func (r *PreflightReconciler) Cleanup(_ *instance.BGPInstance) {}
+
 func (r *PreflightReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
 	l := r.Logger.WithFields(logrus.Fields{
 		types.InstanceLogField: p.DesiredConfig.Name,

--- a/pkg/bgpv1/manager/reconcilerv2/reconcilers.go
+++ b/pkg/bgpv1/manager/reconcilerv2/reconcilers.go
@@ -27,6 +27,12 @@ type ConfigReconciler interface {
 	// Priority is used to determine the order in which reconcilers are called. Reconcilers are called from lowest to
 	// highest.
 	Priority() int
+	// Init is called upon virtual router instance creation. Reconcilers can initialize any instance-specific
+	// resources here, and clean them up upon Cleanup call.
+	Init(i *instance.BGPInstance) error
+	// Cleanup is called upon virtual router instance deletion. When called, reconcilers are supposed
+	// to clean up all instance-specific resources saved outside the instance Metadata.
+	Cleanup(i *instance.BGPInstance)
 	// Reconcile performs the reconciliation actions for given BGPInstance.
 	Reconcile(ctx context.Context, params ReconcileParams) error
 }

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -99,6 +99,22 @@ func (r *ServiceReconciler) Priority() int {
 	return 40
 }
 
+func (r *ServiceReconciler) Init(i *instance.BGPInstance) error {
+	if i == nil {
+		return fmt.Errorf("BUG: service reconciler initialization with nil BGPInstance")
+	}
+	r.svcDiffStore.CleanupDiff(r.diffID(i.ASN))
+	r.epDiffStore.CleanupDiff(r.diffID(i.ASN))
+	return nil
+}
+
+func (r *ServiceReconciler) Cleanup(i *instance.BGPInstance) {
+	if i != nil {
+		r.svcDiffStore.CleanupDiff(r.diffID(i.ASN))
+		r.epDiffStore.CleanupDiff(r.diffID(i.ASN))
+	}
+}
+
 func (r *ServiceReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
 	if p.DesiredConfig == nil {
 		return fmt.Errorf("BUG: attempted service reconciliation with nil CiliumBGPNodeConfig")
@@ -132,6 +148,12 @@ func (r *ServiceReconciler) reconcileServices(ctx context.Context, p ReconcilePa
 	if fullReconcile {
 		r.logger.Debug("performing all services reconciliation")
 
+		// Init diff in diffstores, so that it contains only changes since the last full reconciliation.
+		// Despite doing it in Init(), we still need this InitDiff to clean up the old diff when the instance is re-created
+		// by the preflight reconciler. Once Init() is called upon re-create by preflight, we can remove this.
+		r.svcDiffStore.InitDiff(r.diffID(p.BGPInstance.ASN))
+		r.epDiffStore.InitDiff(r.diffID(p.BGPInstance.ASN))
+
 		desiredSvcRoutePolicies, err = r.getAllRoutePolicies(p, ls)
 		if err != nil {
 			return err
@@ -147,7 +169,7 @@ func (r *ServiceReconciler) reconcileServices(ctx context.Context, p ReconcilePa
 
 		// get services to reconcile and to withdraw.
 		// Note : we should only call svc diff only once in a reconcile loop.
-		toReconcile, toWithdraw, err := r.diffReconciliationServiceList()
+		toReconcile, toWithdraw, err := r.diffReconciliationServiceList(p)
 		if err != nil {
 			return err
 		}
@@ -552,8 +574,8 @@ func (r *ServiceReconciler) getDiffPaths(p ReconcileParams, toReconcile []*slim_
 
 // diffReconciliationServiceList returns a list of services to reconcile and to withdraw when
 // performing partial (diff) service reconciliation.
-func (r *ServiceReconciler) diffReconciliationServiceList() (toReconcile []*slim_corev1.Service, toWithdraw []resource.Key, err error) {
-	upserted, deleted, err := r.svcDiffStore.Diff()
+func (r *ServiceReconciler) diffReconciliationServiceList(p ReconcileParams) (toReconcile []*slim_corev1.Service, toWithdraw []resource.Key, err error) {
+	upserted, deleted, err := r.svcDiffStore.Diff(r.diffID(p.BGPInstance.ASN))
 	if err != nil {
 		return nil, nil, fmt.Errorf("svc store diff: %w", err)
 	}
@@ -564,7 +586,7 @@ func (r *ServiceReconciler) diffReconciliationServiceList() (toReconcile []*slim
 	// We don't handle service deletion here since we only see
 	// the key, we cannot resolve associated service, so we have
 	// nothing to do.
-	epsUpserted, _, err := r.epDiffStore.Diff()
+	epsUpserted, _, err := r.epDiffStore.Diff(r.diffID(p.BGPInstance.ASN))
 	if err != nil {
 		return nil, nil, fmt.Errorf("EPs store diff: %w", err)
 	}
@@ -1007,6 +1029,10 @@ func (r *ServiceReconciler) getClusterIPRoutePolicy(p ReconcileParams, peer stri
 	}
 
 	return policy, nil
+}
+
+func (r *ServiceReconciler) diffID(asn uint32) string {
+	return fmt.Sprintf("%s-%d", r.Name(), asn)
 }
 
 // checkServiceAdvertisement checks if the service advertisement is enabled in the advertisement.

--- a/pkg/bgpv1/manager/reconcilerv2/service_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service_test.go
@@ -756,6 +756,8 @@ func Test_ServiceLBReconciler(t *testing.T) {
 
 			svcReconciler := NewServiceReconciler(params).Reconciler.(*ServiceReconciler)
 			testBGPInstance := instance.NewFakeBGPInstance()
+			svcReconciler.Init(testBGPInstance)
+			defer svcReconciler.Cleanup(testBGPInstance)
 
 			// reconcile twice to validate idempotency
 			for i := 0; i < 2; i++ {
@@ -984,6 +986,8 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 
 			svcReconciler := NewServiceReconciler(params).Reconciler.(*ServiceReconciler)
 			testBGPInstance := instance.NewFakeBGPInstance()
+			svcReconciler.Init(testBGPInstance)
+			defer svcReconciler.Cleanup(testBGPInstance)
 
 			// reconcile twice to validate idempotency
 			for i := 0; i < 2; i++ {
@@ -1212,6 +1216,8 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 
 			svcReconciler := NewServiceReconciler(params).Reconciler.(*ServiceReconciler)
 			testBGPInstance := instance.NewFakeBGPInstance()
+			svcReconciler.Init(testBGPInstance)
+			defer svcReconciler.Cleanup(testBGPInstance)
 
 			// reconcile twice to validate idempotency
 			for i := 0; i < 2; i++ {
@@ -1562,6 +1568,8 @@ func Test_ServiceAndAdvertisementModifications(t *testing.T) {
 
 	svcReconciler := NewServiceReconciler(params).Reconciler.(*ServiceReconciler)
 	testBGPInstance := instance.NewFakeBGPInstance()
+	svcReconciler.Init(testBGPInstance)
+	defer svcReconciler.Cleanup(testBGPInstance)
 
 	for _, tt := range steps {
 		t.Logf("Running step - %s", tt.name)

--- a/pkg/bgpv1/manager/store/diffstore.go
+++ b/pkg/bgpv1/manager/store/diffstore.go
@@ -18,14 +18,25 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-var ErrStoreUninitialized = errors.New("the store has not initialized yet")
+var (
+	ErrStoreUninitialized = errors.New("the store has not initialized yet")
+	ErrDiffUninitialized  = errors.New("diff not initialized for caller")
+)
 
 // DiffStore is a wrapper around the resource.Store. The diffStore tracks all changes made to it since the
 // last time the user synced up. This allows a user to get a list of just the changed objects while still being able
 // to query the full store for a full sync.
 type DiffStore[T k8sRuntime.Object] interface {
-	// Diff returns a list of items that have been upserted(updated or inserted) and deleted since the last call to Diff.
-	Diff() (upserted []T, deleted []resource.Key, err error)
+	// InitDiff initializes tracking io items to Diff for the given callerID.
+	InitDiff(callerID string)
+
+	// Diff returns a list of items that have been upserted (updated or inserted) and deleted
+	// since InitDiff or the last call to Diff with the same callerID.
+	// Init(callerID) has to be called before Diff(callerID).
+	Diff(callerID string) (upserted []T, deleted []resource.Key, err error)
+
+	// CleanupDiff cleans up all caller-specific diff state.
+	CleanupDiff(callerID string)
 
 	// GetByKey returns the latest version of the object with given key.
 	GetByKey(key resource.Key) (item T, exists bool, err error)
@@ -46,6 +57,9 @@ type diffStoreParams[T k8sRuntime.Object] struct {
 	Signaler  *signaler.BGPCPSignaler
 }
 
+// updatedKeysMap is a map of updated resource keys since the last diff against the map.
+type updatedKeysMap map[resource.Key]bool
+
 // diffStore takes a resource.Resource[T] and watches for events, it stores all of the keys that have been changed.
 // diffStore can still be used as a normal store, but adds the Diff function to get a Diff of all changes.
 // The diffStore also takes in Signaler which it will signal after the initial sync and every update thereafter.
@@ -57,8 +71,8 @@ type diffStore[T k8sRuntime.Object] struct {
 
 	initialSync bool
 
-	mu          lock.Mutex
-	updatedKeys map[resource.Key]bool
+	mu                lock.Mutex
+	callerUpdatedKeys map[string]updatedKeysMap // updated keys per caller ID
 }
 
 func NewDiffStore[T k8sRuntime.Object](params diffStoreParams[T]) DiffStore[T] {
@@ -70,7 +84,7 @@ func NewDiffStore[T k8sRuntime.Object](params diffStoreParams[T]) DiffStore[T] {
 		resource: params.Resource,
 		signaler: params.Signaler,
 
-		updatedKeys: make(map[resource.Key]bool),
+		callerUpdatedKeys: make(map[string]updatedKeysMap),
 	}
 
 	params.JobGroup.Add(
@@ -95,7 +109,9 @@ func NewDiffStore[T k8sRuntime.Object](params diffStoreParams[T]) DiffStore[T] {
 func (ds *diffStore[T]) handleEvent(event resource.Event[T]) {
 	update := func(k resource.Key) {
 		ds.mu.Lock()
-		ds.updatedKeys[k] = true
+		for _, updatedKeys := range ds.callerUpdatedKeys {
+			updatedKeys[k] = true
+		}
 		ds.mu.Unlock()
 
 		// Start triggering the signaler after initialization to reduce reconciliation load.
@@ -115,8 +131,18 @@ func (ds *diffStore[T]) handleEvent(event resource.Event[T]) {
 	event.Done(nil)
 }
 
-// Diff returns a list of items that have been upserted(updated or inserted) and deleted since the last call to Diff.
-func (ds *diffStore[T]) Diff() (upserted []T, deleted []resource.Key, err error) {
+// InitDiff initializes tracking io items to Diff for the given callerID.
+func (ds *diffStore[T]) InitDiff(callerID string) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	ds.callerUpdatedKeys[callerID] = make(updatedKeysMap)
+}
+
+// Diff returns a list of items that have been upserted (updated or inserted) and deleted
+// since InitDiff or the last call to Diff with the same callerID.
+// Init(callerID) has to be called before Diff(callerID).
+func (ds *diffStore[T]) Diff(callerID string) (upserted []T, deleted []resource.Key, err error) {
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
 
@@ -124,13 +150,18 @@ func (ds *diffStore[T]) Diff() (upserted []T, deleted []resource.Key, err error)
 		return nil, nil, ErrStoreUninitialized
 	}
 
+	updatedKeys, ok := ds.callerUpdatedKeys[callerID]
+	if !ok {
+		return nil, nil, ErrDiffUninitialized
+	}
+
 	// Deleting keys doesn't shrink the memory size. So if the size of updateKeys ever reaches above this threshold
 	// we should re-create it to reduce memory usage. Below the threshold, don't bother to avoid unnecessary allocation.
 	// Note: this value is arbitrary, can be changed to tune CPU/Memory tradeoff
 	const shrinkThreshold = 64
-	shrink := len(ds.updatedKeys) > shrinkThreshold
+	shrink := len(updatedKeys) > shrinkThreshold
 
-	for k := range ds.updatedKeys {
+	for k := range updatedKeys {
 		item, found, err := ds.store.GetByKey(k)
 		if err != nil {
 			return nil, nil, err
@@ -143,15 +174,23 @@ func (ds *diffStore[T]) Diff() (upserted []T, deleted []resource.Key, err error)
 		}
 
 		if !shrink {
-			delete(ds.updatedKeys, k)
+			delete(updatedKeys, k)
 		}
 	}
 
 	if shrink {
-		ds.updatedKeys = make(map[resource.Key]bool, shrinkThreshold)
+		ds.callerUpdatedKeys[callerID] = make(updatedKeysMap, shrinkThreshold)
 	}
 
 	return upserted, deleted, err
+}
+
+// CleanupDiff cleans up all caller-specific diff state.
+func (ds *diffStore[T]) CleanupDiff(callerID string) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	delete(ds.callerUpdatedKeys, callerID)
 }
 
 // GetByKey returns the latest version of the object with given key.

--- a/pkg/bgpv1/manager/store/diffstore_fake.go
+++ b/pkg/bgpv1/manager/store/diffstore_fake.go
@@ -18,13 +18,13 @@ type fakeDiffStore[T runtime.Object] struct {
 	objects map[resource.Key]T
 
 	changedMu lock.Mutex
-	changed   map[resource.Key]bool
+	changed   map[string]updatedKeysMap // updated keys per caller ID
 }
 
 func NewFakeDiffStore[T runtime.Object]() *fakeDiffStore[T] {
 	return &fakeDiffStore[T]{
 		objects: make(map[resource.Key]T),
-		changed: make(map[resource.Key]bool),
+		changed: make(map[string]updatedKeysMap),
 	}
 }
 
@@ -35,12 +35,23 @@ func InitFakeDiffStore[T runtime.Object](objs []T) *fakeDiffStore[T] {
 	}
 	return mds
 }
-
-func (mds *fakeDiffStore[T]) Diff() (upserted []T, deleted []resource.Key, err error) {
+func (mds *fakeDiffStore[T]) InitDiff(callerID string) {
 	mds.changedMu.Lock()
 	defer mds.changedMu.Unlock()
 
-	for key := range mds.changed {
+	mds.changed[callerID] = make(map[resource.Key]bool)
+}
+
+func (mds *fakeDiffStore[T]) Diff(callerID string) (upserted []T, deleted []resource.Key, err error) {
+	mds.changedMu.Lock()
+	defer mds.changedMu.Unlock()
+
+	changed, ok := mds.changed[callerID]
+	if !ok {
+		return nil, nil, ErrDiffUninitialized
+	}
+
+	for key := range changed {
 		obj, exists, err := mds.GetByKey(key)
 		if err != nil {
 			return nil, nil, err
@@ -53,9 +64,16 @@ func (mds *fakeDiffStore[T]) Diff() (upserted []T, deleted []resource.Key, err e
 	}
 
 	// Reset the changed map
-	mds.changed = make(map[resource.Key]bool)
+	mds.changed[callerID] = make(map[resource.Key]bool)
 
 	return upserted, deleted, nil
+}
+
+func (mds *fakeDiffStore[T]) CleanupDiff(callerID string) {
+	mds.changedMu.Lock()
+	defer mds.changedMu.Unlock()
+
+	delete(mds.changed, callerID)
 }
 
 // List returns all items currently in the store.
@@ -83,7 +101,9 @@ func (mds *fakeDiffStore[T]) Upsert(obj T) {
 
 	key := resource.NewKey(obj)
 	mds.objects[key] = obj
-	mds.changed[key] = true
+	for _, changed := range mds.changed {
+		changed[key] = true
+	}
 }
 
 func (mds *fakeDiffStore[T]) Delete(key resource.Key) {
@@ -93,5 +113,7 @@ func (mds *fakeDiffStore[T]) Delete(key resource.Key) {
 	defer mds.changedMu.Unlock()
 
 	delete(mds.objects, key)
-	mds.changed[key] = true
+	for _, changed := range mds.changed {
+		changed[key] = true
+	}
 }


### PR DESCRIPTION
As the same DiffStore instance is used to diff services when reconciling for multiple server instances (virtual routers), we need to differentiate the diff per instance (and to be future-proof per reconciler as well) for diff to work properly.

Fixes: #33076

```release-note
BGPv1 + BGPv2: Fix incorrect service reconciliation in setups with multiple BGP instances (virtual routers)
```
