### PR TITLE
bpf: csum size_to type changed

### DIFF
--- a/bpf/include/bpf/csum.h
+++ b/bpf/include/bpf/csum.h
@@ -29,8 +29,8 @@ static __always_inline __wsum csum_sub(__wsum csum, __wsum addend)
 	return csum_add(csum, ~addend);
 }
 
-static __always_inline __wsum csum_diff(const void *from, __u32 size_from,
-					const void *to,   __u32 size_to,
+static __always_inline __wsum csum_diff(const void *from, __u64 size_from,
+					const void *to,   __u64 size_to,
 					__u32 seed)
 {
 	if (__builtin_constant_p(size_from) &&

--- a/bpf/include/bpf/helpers.h
+++ b/bpf/include/bpf/helpers.h
@@ -59,9 +59,12 @@ BPF_FUNC(trace_printk, const char *fmt, int fmt_size, ...);
 /* Random numbers */
 static __u32 BPF_FUNC(get_prandom_u32);
 
-/* Checksumming */
-static int BPF_FUNC_REMAP(csum_diff_external, const void *from, __u32 size_from,
-			  const void *to, __u32 size_to, __u32 seed) =
+/* Checksumming size_from and size_to parameters have __u64 type
+ * intentional which corresponds to ARG_CONST_SIZE_OR_ZERO type
+ * used in the eBPF verifier.
+ */
+static int BPF_FUNC_REMAP(csum_diff_external, const void *from, __u64 size_from,
+			  const void *to, __u64 size_to, __u32 seed) =
 	(void *)BPF_FUNC_csum_diff;
 
 /* Tail calls */


### PR DESCRIPTION
The function bpf_csum_diff arguments `from_size` and `to_size` have type ARG_CONST_SIZE_OR_ZERO which is `__u64`.
The commit changes the corresponding arguments type to `__u64` which allows to overcome some eBPF verifier related issues.
Suggested-by: @gentoo-root <Maxim Mikityanskiy>.

Related issue: https://github.com/cilium/cilium/issues/29504

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
