### PR TITLE
feat:use latest directory commit timestamp + short commit as tag

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -50,7 +50,7 @@ binaries or libraries are included.
 ## `runtime` & `builder`
 
 These images are wholly defined by the contents of the image directory, and are
-tagged with git tree hash  for the image directory (see
+tagged with the timestamp of the last commit of the image directory + its short commit sha1 (see
 [`cilium/image-tools` documentation](https://github.com/cilium/image-tools#usage)
 for details).
 

--- a/images/scripts/make-image-tag.sh
+++ b/images/scripts/make-image-tag.sh
@@ -38,12 +38,9 @@ if [ "$#" -eq 1 ] ; then
     echo "${image_dir} is not a directory (path is relative to git root)"
     exit 1
   fi
-  git_ls_tree="$(git ls-tree --full-tree HEAD -- "${image_dir}")"
-  if [ -z "${git_ls_tree}" ] ; then
-    echo "${image_dir} exists, but it is not checked in git (path is relative to git root)"
-    exit 1
-  fi
-  image_tag="$(printf "%s" "${git_ls_tree}" | sed 's/^[0-7]\{6\} tree \([0-9a-f]\{40\}\).*/\1/')"
+  timestamp="$(git log -1 --pretty=format:"%ct" "${image_dir}")"
+  short_commit="$(git log -1 --pretty=format:"%h" "${image_dir}")"
+  image_tag="${timestamp}-${short_commit}"
 else
   # if no arguments are given, attempt detecting if version tag is present,
   # otherwise use the a short commit hash


### PR DESCRIPTION
This commit change the way of tagging images, from using git-lfs-tree sha256 to using a combination of the directory's last commit timestamp and its sha1 shortened.
It will permit renovate to sort versions and update properly new images, where renovate wasn't able to do so before due to its inability to sort SHAs.

Fixes: [#285](https://github.com/cilium/image-tools/issues/285)