### PR TITLE
Documentation: Update readthedocs configuration

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -190,6 +190,13 @@ html_context = {
     'release': release
 }
 
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
+
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.


### PR DESCRIPTION
Readthedocs used to inject configuration into conf.py at build time, but
they're deprecating this functionality in the coming months. In
preparation, we need to make a couple of tweaks to ensure that RTD can
inject configuration options. The following link contains more details:

https://about.readthedocs.com/blog/2024/07/addons-by-default/
