### PR TITLE
Add hubble metrics for Node-local DNS addon

### DIFF
--- a/pkg/hubble/metrics/metrics.go
+++ b/pkg/hubble/metrics/metrics.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/http"              // invoke init
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/icmp"              // invoke init
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/kafka"             // invoke init
+	_ "github.com/cilium/cilium/pkg/hubble/metrics/nld"               // invoke init
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/policy"            // invoke init
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/port-distribution" // invoke init
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/tcp"               // invoke init

--- a/pkg/hubble/metrics/nld/handler.go
+++ b/pkg/hubble/metrics/nld/handler.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package nld
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/metrics/api"
+	"github.com/cilium/cilium/pkg/identity"
+)
+
+const (
+	nldLabel        = "k8s:k8s-app=node-local-dns"
+	systemNamespace = "kube-system"
+	queryLabel      = "dnsQuery"
+	responseLabel   = "dnsReponse"
+	dnsPort         = 53
+)
+
+type nldHandler struct {
+	includeDirection bool
+	ignoreHost       bool
+
+	context *api.ContextOptions
+
+	upstream   *prometheus.CounterVec
+	downstream *prometheus.CounterVec
+	bypass     *prometheus.CounterVec
+}
+
+func (d *nldHandler) Init(registry *prometheus.Registry, options api.Options) error {
+	c, err := api.ParseContextOptions(options)
+	if err != nil {
+		return err
+	}
+	d.context = c
+
+	for key := range options {
+		switch strings.ToLower(key) {
+		case "direction":
+			d.includeDirection = true
+		case "ignoreHost":
+			d.ignoreHost = true
+		}
+	}
+
+	contextLabels := d.context.GetLabelNames()
+	var directionLabel []string
+	if d.includeDirection {
+		directionLabel = []string{"direction"}
+	}
+
+	finalLabels := append(contextLabels, directionLabel...)
+
+	d.downstream = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: api.DefaultPrometheusNamespace,
+		Name:      "nld_downstream_total",
+		Help:      "Number of observed DNS queries from workloads to the Node Local DNS Cache",
+	}, finalLabels)
+	registry.MustRegister(d.downstream)
+
+	d.upstream = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: api.DefaultPrometheusNamespace,
+		Name:      "nld_upstream_total",
+		Help:      "Number of observed DNS queries from the Node Local DNS Cache to the upstream",
+	}, finalLabels)
+	registry.MustRegister(d.upstream)
+
+	d.bypass = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: api.DefaultPrometheusNamespace,
+		Name:      "nld_bypass_total",
+		Help:      "Number of observed DNS queries not going through the Node Local DNS Cache",
+	}, finalLabels)
+	registry.MustRegister(d.bypass)
+
+	return nil
+}
+
+func (d *nldHandler) Status() string {
+	var status []string
+	if d.includeDirection {
+		status = append(status, "includeDirection")
+	}
+	if d.ignoreHost {
+		status = append(status, "ignoreHost")
+	}
+
+	return strings.Join(append(status, d.context.Status()), ",")
+}
+
+func (d *nldHandler) Context() *api.ContextOptions {
+	return d.context
+}
+
+func (d *nldHandler) ListMetricVec() []*prometheus.MetricVec {
+	return []*prometheus.MetricVec{d.upstream.MetricVec, d.downstream.MetricVec, d.bypass.MetricVec}
+}
+
+func (d *nldHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
+	if flow.GetVerdict() != flowpb.Verdict_FORWARDED || flow.GetL4() == nil {
+		return nil
+	}
+
+	if d.ignoreHost && isHostTraffic(flow) {
+		return nil
+	}
+
+	isDNSQuery := checkDestinationPort(flow.GetL4())
+	isDNSResponse := checkSourcePort(flow.GetL4())
+	if !(isDNSQuery || isDNSResponse) {
+		return nil
+	}
+
+	contextLabels, err := d.context.GetLabelValues(flow)
+	if err != nil {
+		return err
+	}
+
+	var directionLabel []string
+	if d.includeDirection && isDNSQuery {
+		directionLabel = []string{queryLabel}
+	}
+	if d.includeDirection && isDNSResponse {
+		directionLabel = []string{responseLabel}
+	}
+
+	finalLabels := append(contextLabels, directionLabel...)
+
+	srcnld := isNodeLocalDNSPod(flow.Source)
+	dstnld := isNodeLocalDNSPod(flow.Destination)
+
+	switch {
+	case !srcnld && !dstnld:
+		d.bypass.WithLabelValues(finalLabels...).Inc()
+	case !srcnld && dstnld && isDNSQuery:
+		d.downstream.WithLabelValues(finalLabels...).Inc()
+	case srcnld && !dstnld && isDNSResponse:
+		d.downstream.WithLabelValues(finalLabels...).Inc()
+	case !srcnld && dstnld && isDNSResponse:
+		d.upstream.WithLabelValues(finalLabels...).Inc()
+	case srcnld && !dstnld && isDNSQuery:
+		d.upstream.WithLabelValues(finalLabels...).Inc()
+	}
+
+	return nil
+}
+
+func checkDestinationPort(l4 *flowpb.Layer4) bool {
+	if l4.GetUDP().GetDestinationPort() == dnsPort {
+		return true
+	}
+	if l4.GetTCP().GetDestinationPort() == dnsPort {
+		return true
+	}
+	return false
+}
+
+func checkSourcePort(l4 *flowpb.Layer4) bool {
+	if l4.GetUDP().GetSourcePort() == dnsPort {
+		return true
+	}
+	if l4.GetTCP().GetSourcePort() == dnsPort {
+		return true
+	}
+	return false
+}
+
+func isNodeLocalDNSPod(endpoint *flowpb.Endpoint) bool {
+	return endpoint.GetNamespace() == systemNamespace && slices.Contains(endpoint.Labels, nldLabel)
+}
+
+func isHostTraffic(flow *flowpb.Flow) bool {
+	return flow.GetSource().GetIdentity() == uint32(identity.ReservedIdentityHost) ||
+		flow.GetDestination().GetIdentity() == uint32(identity.ReservedIdentityHost)
+}

--- a/pkg/hubble/metrics/nld/handler.go
+++ b/pkg/hubble/metrics/nld/handler.go
@@ -5,7 +5,6 @@ package nld
 
 import (
 	"context"
-	"slices"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -16,11 +15,9 @@ import (
 )
 
 const (
-	nldLabel        = "k8s:k8s-app=node-local-dns"
-	systemNamespace = "kube-system"
-	queryLabel      = "dnsQuery"
-	responseLabel   = "dnsReponse"
-	dnsPort         = 53
+	queryLabel    = "dnsQuery"
+	responseLabel = "dnsReponse"
+	dnsPort       = 53
 )
 
 type nldHandler struct {
@@ -172,7 +169,9 @@ func checkSourcePort(l4 *flowpb.Layer4) bool {
 }
 
 func isNodeLocalDNSPod(endpoint *flowpb.Endpoint) bool {
-	return endpoint.GetNamespace() == systemNamespace && slices.Contains(endpoint.Labels, nldLabel)
+	id := endpoint.GetIdentity()
+	return id == uint32(identity.ReservedNodeLocalDNS) ||
+		id == uint32(identity.ReservedNodeLocalDNS2)
 }
 
 func isHostTraffic(flow *flowpb.Flow) bool {

--- a/pkg/hubble/metrics/nld/handler.go
+++ b/pkg/hubble/metrics/nld/handler.go
@@ -5,6 +5,7 @@ package nld
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -15,9 +16,11 @@ import (
 )
 
 const (
-	queryLabel    = "dnsQuery"
-	responseLabel = "dnsReponse"
-	dnsPort       = 53
+	nldLabel        = "k8s:k8s-app=node-local-dns"
+	systemNamespace = "kube-system"
+	queryLabel      = "dnsQuery"
+	responseLabel   = "dnsReponse"
+	dnsPort         = 53
 )
 
 type nldHandler struct {
@@ -169,9 +172,7 @@ func checkSourcePort(l4 *flowpb.Layer4) bool {
 }
 
 func isNodeLocalDNSPod(endpoint *flowpb.Endpoint) bool {
-	id := endpoint.GetIdentity()
-	return id == uint32(identity.ReservedNodeLocalDNS) ||
-		id == uint32(identity.ReservedNodeLocalDNS2)
+	return endpoint.GetNamespace() == systemNamespace && slices.Contains(endpoint.Labels, nldLabel)
 }
 
 func isHostTraffic(flow *flowpb.Flow) bool {

--- a/pkg/hubble/metrics/nld/plugin.go
+++ b/pkg/hubble/metrics/nld/plugin.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package nld
+
+import (
+	"github.com/cilium/cilium/pkg/hubble/metrics/api"
+)
+
+type nldPlugin struct{}
+
+func (p *nldPlugin) NewHandler() api.Handler {
+	return &nldHandler{}
+}
+
+func (p *nldPlugin) HelpText() string {
+	return `nodelocaldns related metrics
+Reports metrics related to DNS queries and responses focusing on NodeLocalDNS,
+the caching layer.
+
+Metrics:
+  hubble_nld_downstream_total   Number of observed DNS queries to NLD
+  hubble_nld_upstream_total     Number of observed DNS queries from NLD
+  hubble_nld_bypass_total       Number of observed DNS queries bypassing NLD
+
+Options:
+ direction              - Include direction as label
+ ignoreHost             - Exclude DNS traffic from the node/host` +
+		api.ContextOptionsHelp
+}
+
+func init() {
+	api.DefaultRegistry().Register("nld", &nldPlugin{})
+}

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -170,9 +170,6 @@ const (
 	// ReservedCiliumEtcdOperator is the reserved identity used for the Cilium etcd operator
 	ReservedCiliumEtcdOperator
 
-	// ReservedNodeLocalDNS is the reserved identity used for nodelocaldns addon
-	ReservedNodeLocalDNS
-
 	// Second identities for all above components
 	ReservedETCDOperator2
 	ReservedCiliumKVStore2
@@ -182,7 +179,6 @@ const (
 	ReservedCiliumOperator2
 	ReservedEKSCoreDNS2
 	ReservedCiliumEtcdOperator2
-	ReservedNodeLocalDNS2
 )
 
 // localNodeIdentity is the endpoint identity allocated for the local node
@@ -393,17 +389,6 @@ func InitWellKnownIdentities(c Configuration, cinfo cmtypes.ClusterInfo) int {
 	WellKnown.add(ReservedCiliumEtcdOperator, ciliumEtcdOperatorLabels)
 	WellKnown.add(ReservedCiliumEtcdOperator2, append(ciliumEtcdOperatorLabels,
 		k8sLabel(api.PodNamespaceMetaNameLabel, c.CiliumNamespaceName())))
-
-	// NodeLocalDNS labels
-	//   k8s:io.kubernetes.pod.namespace=kube-system
-	//   k8s:k8s-app=node-local-dns
-	nodelocaldnsDNSLabels := []string{
-		"k8s:k8s-app=node-local-dns",
-		k8sLabel(api.PodNamespaceLabel, "kube-system"),
-	}
-	WellKnown.add(ReservedNodeLocalDNS, nodelocaldnsDNSLabels)
-	WellKnown.add(ReservedNodeLocalDNS2, append(nodelocaldnsDNSLabels,
-		k8sLabel(api.PodNamespaceMetaNameLabel, "kube-system")))
 
 	return len(WellKnown)
 }

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -170,6 +170,9 @@ const (
 	// ReservedCiliumEtcdOperator is the reserved identity used for the Cilium etcd operator
 	ReservedCiliumEtcdOperator
 
+	// ReservedNodeLocalDNS is the reserved identity used for nodelocaldns addon
+	ReservedNodeLocalDNS
+
 	// Second identities for all above components
 	ReservedETCDOperator2
 	ReservedCiliumKVStore2
@@ -179,6 +182,7 @@ const (
 	ReservedCiliumOperator2
 	ReservedEKSCoreDNS2
 	ReservedCiliumEtcdOperator2
+	ReservedNodeLocalDNS2
 )
 
 // localNodeIdentity is the endpoint identity allocated for the local node
@@ -389,6 +393,17 @@ func InitWellKnownIdentities(c Configuration, cinfo cmtypes.ClusterInfo) int {
 	WellKnown.add(ReservedCiliumEtcdOperator, ciliumEtcdOperatorLabels)
 	WellKnown.add(ReservedCiliumEtcdOperator2, append(ciliumEtcdOperatorLabels,
 		k8sLabel(api.PodNamespaceMetaNameLabel, c.CiliumNamespaceName())))
+
+	// NodeLocalDNS labels
+	//   k8s:io.kubernetes.pod.namespace=kube-system
+	//   k8s:k8s-app=node-local-dns
+	nodelocaldnsDNSLabels := []string{
+		"k8s:k8s-app=node-local-dns",
+		k8sLabel(api.PodNamespaceLabel, "kube-system"),
+	}
+	WellKnown.add(ReservedNodeLocalDNS, nodelocaldnsDNSLabels)
+	WellKnown.add(ReservedNodeLocalDNS2, append(nodelocaldnsDNSLabels,
+		k8sLabel(api.PodNamespaceMetaNameLabel, "kube-system")))
 
 	return len(WellKnown)
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

Introduce hubble metrics for monitoring DNS traffic for Node-local DNS.


The metrics gives an insight if workload’s DNS requests are passing through Node-local DNS cache and not bypassing it. It is useful for monitoring if the cache is performing it’s job.

Fixes: #34142

```release-note
Add hubble metrics for monitoring DNS traffic for Node-local DNS addon
```