### PR TITLE
pkg/ciliumidentity: Use cell flag for EnableOperatorManageCIDs

### DIFF
--- a/operator/pkg/ciliumidentity/cell.go
+++ b/operator/pkg/ciliumidentity/cell.go
@@ -5,6 +5,7 @@ package ciliumidentity
 
 import (
 	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/metrics"
 )
@@ -18,15 +19,19 @@ var Cell = cell.Module(
 	metrics.Metric(NewMetrics),
 )
 
+type config struct {
+	EnableOperatorManageCIDs bool
+}
+
+func (c config) Flags(flags *pflag.FlagSet) {
+	flags.Bool("operator-manages-identities", c.EnableOperatorManageCIDs, "Enables operator to manage Cilium Identities by running a Cilium Identity controller")
+}
+
 // SharedConfig contains the configuration that is shared between
 // this module and others.
 // It is a temporary solution meant to avoid polluting this module with a direct
 // dependency on global operator and daemon configurations.
 type SharedConfig struct {
-	// EnableOperatorManageCIDs enables operator to manage Cilium Identities by
-	// running a Cilium Identity controller.
-	EnableOperatorManageCIDs bool
-
 	// EnableCiliumEndpointSlice indicates if the Cilium Endpoint Slice feature is
 	// enabled.
 	EnableCiliumEndpointSlice bool

--- a/operator/pkg/ciliumidentity/controller.go
+++ b/operator/pkg/ciliumidentity/controller.go
@@ -47,6 +47,7 @@ type params struct {
 	cell.In
 
 	Logger              *slog.Logger
+	Config              config
 	Lifecycle           cell.Lifecycle
 	Clientset           k8sClient.Clientset
 	SharedCfg           SharedConfig
@@ -89,7 +90,7 @@ type Controller struct {
 }
 
 func registerController(p params) {
-	if !p.Clientset.IsEnabled() || !p.SharedCfg.EnableOperatorManageCIDs {
+	if !p.Clientset.IsEnabled() || !p.Config.EnableOperatorManageCIDs {
 		return
 	}
 

--- a/operator/pkg/ciliumidentity/controller_test.go
+++ b/operator/pkg/ciliumidentity/controller_test.go
@@ -109,9 +109,13 @@ func initHiveTest(operatorManagingCID bool) (*resource.Resource[*capi_v2.CiliumI
 		k8sClient.FakeClientCell,
 		k8s.ResourcesCell,
 		metrics.Metric(NewMetrics),
+		cell.Provide(func() config {
+			return config{
+				EnableOperatorManageCIDs: operatorManagingCID,
+			}
+		}),
 		cell.Provide(func() SharedConfig {
 			return SharedConfig{
-				EnableOperatorManageCIDs:  operatorManagingCID,
 				EnableCiliumEndpointSlice: true,
 			}
 		}),


### PR DESCRIPTION
The EnableOperatorManageCIDs flag no longer needs to be shared. Its only consumer, identitygc, was reworked as part of cilium#34058.

Related CFP https://github.com/cilium/cilium/issues/27752
