### PR TITLE
pkg/ciliumidentity: Add ciliumidentity to ControlPlane module

### DIFF
--- a/operator/pkg/ciliumidentity/cell.go
+++ b/operator/pkg/ciliumidentity/cell.go
@@ -26,6 +26,7 @@ type config struct {
 
 func (c config) Flags(flags *pflag.FlagSet) {
 	flags.Bool("operator-manages-identities", c.EnableOperatorManageCIDs, "Enables operator to manage Cilium Identities by running a Cilium Identity controller")
+	flags.MarkHidden("operator-manages-identities") // See https://github.com/cilium/cilium/issues/34675
 }
 
 var defaultConfig = config{


### PR DESCRIPTION
This allows enabling the Cilium Identity Cell to manage CIDs. CiliumIdentity controller manages Cilium Identity API objects. It creates and updates Cilium Identities (CIDs) based on CID, Pod, Namespace and CES events.

The cell should be disabled by default, see https://github.com/cilium/cilium/pull/34193.
This one can be merged after the agent implementation is merged though.


Related CFP https://github.com/cilium/cilium/issues/27752

```release-note
CiliumIdentity controller manages Cilium Identity API objects. It creates and updates Cilium Identities (CIDs) based on CID, Pod, Namespace and CES events.
```
