### PR TITLE
Transactional selector cache

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -1161,7 +1161,12 @@ func (d *Daemon) GetDNSRules(epID uint16) restore.DNSRules {
 		return nil
 	}
 
-	rules, err := proxy.DefaultDNSProxy.GetRules(epID)
+	// We get the latest consistent view on the DNS rules by getting handle to the latest
+	// coherent state of the selector cache
+	version := d.policy.GetSelectorCache().GetVersionHandle()
+	rules, err := proxy.DefaultDNSProxy.GetRules(version, epID)
+	version.Close()
+
 	if err != nil {
 		log.WithField(logfields.EndpointID, epID).WithError(err).Error("Could not get DNS rules")
 		return nil

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -15,6 +15,7 @@ import (
 	ciliumdns "github.com/cilium/dns"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -91,6 +92,9 @@ func (*dummyInfoRegistry) FillEndpointInfo(ctx context.Context, info *accesslog.
 type dummySelectorCacheUser struct{}
 
 func (d *dummySelectorCacheUser) IdentitySelectionUpdated(selector policy.CachedSelector, added, deleted []identity.NumericIdentity) {
+}
+
+func (d *dummySelectorCacheUser) IdentitySelectionCommit(*versioned.Tx) {
 }
 
 // BenchmarkNotifyOnDNSMsg stresses the main callback function for the DNS

--- a/pkg/container/versioned/value.go
+++ b/pkg/container/versioned/value.go
@@ -1,0 +1,514 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package versioned
+
+import (
+	"errors"
+	"fmt"
+	"iter"
+	"math"
+	"runtime"
+	"slices"
+	"strconv"
+	"sync/atomic"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+type version uint64
+
+const (
+	// invalidVersion is never found from the value range.
+	// Also used as the upper bound for new values, so that the value is
+	// found when looking with 'maxVersion'
+	invalidVersion = version(math.MaxUint64)
+
+	// maxVersion in a VersionHandle finds the latest version of all non-removed values
+	maxVersion = version(math.MaxUint64 - 1)
+)
+
+// KeepVersion is an exported version type used when releasing memory held for old versions.
+type KeepVersion version
+
+var (
+	ErrInvalidVersion   = errors.New("invalid version")
+	ErrStaleTransaction = errors.New("stale transaction")
+	ErrStaleVersion     = errors.New("stale version")
+	ErrVersionNotFound  = errors.New("version not found")
+)
+
+// VersionHandle is used to keep values valid for a specific version from being released, so that
+// they are available for use for as long as the VersionHandle is not closed.
+//
+// A special form with a nil coordinator, which is returned by Latest(), always finds the latest
+// versions and does not keep any versions from being released.
+type VersionHandle struct {
+	// 'version' is the version this versionHandle keeps from being released
+	version version
+	// Coordinator of this versionHandle, if any. Used for closing if non-nil.
+	// Atomic due to nilling and for copy prevention.
+	coordinator atomic.Pointer[Coordinator]
+}
+
+func (h *VersionHandle) IsValid() bool {
+	return h != nil && (h.version == maxVersion || h.coordinator.Load() != nil)
+}
+
+func (h *VersionHandle) Version() KeepVersion {
+	return KeepVersion(h.version)
+}
+
+func (h *VersionHandle) String() string {
+	if h == nil {
+		return "version: <nil>"
+	}
+	validity := "invalid"
+	if h.IsValid() {
+		validity = "valid"
+	}
+	return fmt.Sprintf("%d (%s)", h.version, validity)
+}
+
+// Close releases the held version for removal once no handle for it are no longer held.
+// This may not be called while holding any locks that the 'closer' function passed to the
+// coordinator may take!
+func (h *VersionHandle) Close() error {
+	if h == nil || h.version == invalidVersion {
+		return ErrInvalidVersion
+	}
+	// handle with 'maxVersion' is never closed
+	if h.version != maxVersion {
+		// Using CompareAndSwap makes sure each handle is closed at most once
+		coordinator := h.coordinator.Load()
+		if coordinator != nil && h.coordinator.CompareAndSwap(coordinator, nil) {
+			runtime.SetFinalizer(h, nil)
+			return coordinator.releaseVersion(h.version)
+		}
+		return ErrStaleVersion
+	}
+	return nil
+}
+
+// versionHandleFinalizer is used to warn about missing Close() calls.
+func versionHandleFinalizer(h *VersionHandle) {
+	coordinator := h.coordinator.Load()
+	if coordinator != nil && coordinator.Logger != nil {
+		coordinator.Logger.WithField(logfields.Version, h.version).Error("Handle for version not closed.")
+	}
+	h.Close()
+}
+
+func newVersionHandle(version version, coordinator *Coordinator) *VersionHandle {
+	// handle on maxVersion never expires
+	if version == maxVersion {
+		coordinator = nil
+	}
+	h := &VersionHandle{version: version}
+	h.coordinator.Store(coordinator)
+	if coordinator != nil {
+		// Set a finalizer to catch unclosed handles. The finalizer function complains
+		// loudly, so that we do not rely the finalizer for closing.
+		runtime.SetFinalizer(h, versionHandleFinalizer)
+	}
+	return h
+}
+
+// Latest returns a VersionHandle for the latest version of current/non-removed values
+// Only to be used in cases where the latest values are needed and no transactionality is required.
+func Latest() *VersionHandle {
+	return newVersionHandle(maxVersion, nil)
+}
+
+type atomicVersion struct {
+	version atomic.Uint64
+}
+
+func (a *atomicVersion) load() version {
+	return version(a.version.Load())
+}
+
+func (a *atomicVersion) store(version version) {
+	a.version.Store(uint64(version))
+}
+
+type versionCount struct {
+	version version
+	count   int
+}
+
+// Coordinator defines a common version number space for multiple versioned.Values,
+// and provides facilities for cleaning out stale versions.
+// The Value's are not directly managed by the Coordinator, but all the values under coordination
+// should be cleaned by the 'cleaner' function given to the Coordinator.
+type Coordinator struct {
+	// Logger supplied to NewCoordinator. Should be set if logging is desired.
+	Logger *logrus.Entry
+
+	// Cleaner is called with the earliest version that must be kept.
+	// Must be set to clean up resources held for old versions.
+	// Cleaner function may be called concurrently, the function must synchronize
+	// use of any shared resources.
+	Cleaner func(KeepVersion)
+
+	// mutex protects the rest of the fields
+	mutex lock.RWMutex
+
+	// version is the version number of the last applied change
+	version version
+
+	// oldest version not cleaned off
+	oldestVersion version
+
+	// versions is an ordered list of outstanding VersionHandles with a reference count.
+	// Outdated values can be cleaned when there are no outstanding VersionHandles for them.
+	versions []versionCount
+}
+
+// PrepareNextVersion returns a transaction to be used when adding or removing values.
+//
+// Callers need to coordinate so that a single goroutine is performing modifications at any one
+// time, consisting of the following operations:
+//
+// - tx := coordinator.PrepareNextVersion()
+//   - value.SetAt(... , tx)
+//   - value.RemoveAt(..., tx)
+//   - ...
+//
+// - tx.Commit()
+func (v *Coordinator) PrepareNextVersion() *Tx {
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
+	return &Tx{
+		nextVersion: v.version + 1,
+		coordinator: v,
+	}
+}
+
+// All values in Tx are constants
+type Tx struct {
+	nextVersion version
+	coordinator *Coordinator
+}
+
+// LatestTx refers to maxVersion without having a coordinator, should only be used for testing.
+var LatestTx = &Tx{nextVersion: maxVersion}
+
+func (tx *Tx) String() string {
+	return strconv.FormatUint(uint64(tx.nextVersion), 10)
+}
+
+func (tx *Tx) After(v KeepVersion) bool {
+	return tx.nextVersion > version(v)
+}
+
+// Commit makes a new version of values available to readers
+// Commit call may be omitted if no changes were actually made.
+func (tx *Tx) Commit() error {
+	return tx.coordinator.commit(tx.nextVersion)
+}
+
+// GetVersionHandle returns a VersionHandle for the given transaction.
+func (tx *Tx) GetVersionHandle() *VersionHandle {
+	// This is only needed to support LatestTx to make some testing easier
+	if tx.coordinator == nil && tx.nextVersion == maxVersion {
+		return Latest()
+	}
+	return tx.coordinator.getVersionHandle(tx.nextVersion)
+}
+
+func versionHandleCmp(a versionCount, b version) int {
+	if a.version < b {
+		return -1
+	}
+	if a.version == b {
+		return 0
+	}
+	return 1
+}
+
+// commit makes a new version of values available to readers
+// and cleans up any possible stale versions
+func (v *Coordinator) commit(version version) error {
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
+
+	if v.version != version-1 {
+		return ErrStaleVersion
+	}
+	v.version = version
+
+	// clean up stale versions if any
+	v.clean()
+	return nil
+}
+
+func (v *Coordinator) releaseVersion(version version) error {
+	if version == invalidVersion {
+		return ErrInvalidVersion
+	}
+
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
+
+	n, found := slices.BinarySearchFunc(v.versions, version, versionHandleCmp)
+	if !found {
+		if v.Logger != nil {
+			v.Logger.WithFields(logrus.Fields{
+				logfields.Version:    version,
+				logfields.Stacktrace: hclog.Stacktrace(),
+			}).Error("Version not found.")
+		}
+		return ErrVersionNotFound
+	}
+	v.versions[n].count--
+	if v.versions[n].count <= 0 {
+		v.versions = slices.Delete(v.versions, n, n+1)
+	}
+
+	// clean if needed
+	v.clean()
+	return nil
+}
+
+// clean must be called with lock held
+func (v *Coordinator) clean() {
+	// 'keepVersion' is the current version if there are no outstanding VersionHandles
+	keepVersion := v.version
+	if len(v.versions) > 0 {
+		keepVersion = v.versions[0].version
+	}
+
+	// Call the cleaner for 'keepVersion' only if not already called for this 'keepVersion'.
+	if keepVersion > v.oldestVersion {
+		// The cleaner is called from a goroutine without holding any locks
+		if v.Cleaner != nil {
+			if v.Logger != nil {
+				v.Logger.WithFields(logrus.Fields{
+					logfields.OldVersion: v.oldestVersion,
+					logfields.NewVersion: keepVersion,
+				}).Debug("releaseVersion: calling cleaner")
+			}
+			go v.Cleaner(KeepVersion(keepVersion))
+			v.oldestVersion = keepVersion
+		} else if v.Logger != nil {
+			v.Logger.Warnf("VersionHandle.Close: Cleaner function not set")
+		}
+	}
+}
+
+// getVersionHandle returns a VersionHandle for the given version.
+func (v *Coordinator) getVersionHandle(version version) *VersionHandle {
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
+	return v.getVersionHandleLocked(version)
+}
+
+func (v *Coordinator) getVersionHandleLocked(version version) *VersionHandle {
+	// never get a handle for the invalid version
+	if version == invalidVersion {
+		version = maxVersion
+	}
+
+	if version < v.oldestVersion {
+		oldVersion := version
+		version = v.oldestVersion
+		if v.Logger != nil {
+			v.Logger.WithFields(logrus.Fields{
+				logfields.Stacktrace: hclog.Stacktrace(),
+				logfields.Version:    version,
+				logfields.OldVersion: oldVersion,
+			}).Warn("GetVersionHandle: Handle to a stale version requested, returning oldest valid version instead")
+		}
+	}
+	n, found := slices.BinarySearchFunc(v.versions, version, versionHandleCmp)
+	if !found {
+		v.versions = slices.Insert(v.versions, n, versionCount{version, 1})
+	} else {
+		v.versions[n].count++
+	}
+
+	return newVersionHandle(version, v)
+}
+
+// GetVersionHandle returns a VersionHandle for the current version, so that it can not be
+// cleaned off before the returned VersionHandle is closed.
+func (v *Coordinator) GetVersionHandle() *VersionHandle {
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
+	return v.getVersionHandleLocked(v.version)
+}
+
+// versionRange is a range from the first to one-past-the-last version, "[first, past)".
+// 'past' is atomically modified to a smaller value when removing or a new version is added.
+type versionRange struct {
+	first version       // first version this value is valid for
+	past  atomicVersion // first version this value is invalid for
+}
+
+func (r *versionRange) contains(version version) bool {
+	return r.first <= version && version < r.past.load()
+}
+
+// valueNode is the node used in the linked list rooted at Value[T]
+type valueNode[T any] struct {
+	versions versionRange
+	next     atomic.Pointer[valueNode[T]]
+	value    T
+}
+
+// Value is a container for versioned values, implemented as a lock-free linked list.
+type Value[T any] struct {
+	// valueNodes are non-overlapping and in sorted by version in ascending order.
+	head atomic.Pointer[valueNode[T]]
+}
+
+// SetAt adds the value with validity starting from 'version'.  All values are added with "infinite"
+// validity, which is then truncated when an overlapping entry is added, or the value is removed.
+// 'next' version must be later than any the current version visible to the readers.
+// Returns an error if this is not the case.
+// Callers must coordinate for mutual exclusion.
+func (v *Value[T]) SetAt(value T, tx *Tx) error {
+	version := tx.nextVersion
+	if version == invalidVersion {
+		return ErrInvalidVersion
+	}
+
+	newNode := &valueNode[T]{
+		versions: versionRange{
+			first: version,
+		},
+		value: value,
+	}
+	// All new values are initially set to never expire
+	// ('invalidVersion' is one past 'maxVersion')
+	newNode.versions.past.store(invalidVersion)
+
+	// find if there is a current value that is valid for this new version
+	node := v.head.Load()
+	prev := &v.head
+	for node != nil {
+		if version < node.versions.first {
+			return fmt.Errorf("SetAt may not add values at versions lower than those already added (%d<%d): %w", version, node.versions.first, ErrStaleVersion)
+		}
+
+		if node.versions.contains(version) {
+			// link the new node after the current one
+			newNode.next.Store(node.next.Load())
+			node.next.Store(newNode)
+
+			// truncate the validity of this node to end at 'version' *after* the new
+			// node with validity starting from 'version' has been linked after it
+			// (above), so that either this or the new value is reachable at all times
+			// for readers with 'version'
+			node.versions.past.store(version)
+			break
+		}
+
+		node = node.next.Load()
+		if node != nil {
+			prev = &node.next
+		}
+	}
+	if node == nil {
+		// Add the new value at the end
+		prev.Store(newNode)
+	}
+
+	return nil
+}
+
+// RemoveAt changes the validity of the stored value previously valid at version 'next' to have
+// ended at version 'next'.
+// 'next' must be later than any the current version visible to the readers.
+// Returns an error if this is not the case.
+// Callers must coordinate for mutual exclusion.
+func (v *Value[T]) RemoveAt(tx *Tx) error {
+	version := tx.nextVersion
+	if version == invalidVersion {
+		return ErrInvalidVersion
+	}
+
+	for node := v.head.Load(); node != nil; node = node.next.Load() {
+		if version < node.versions.first {
+			return fmt.Errorf("RemoveAt may not be called with version lower than existing already (%d<%d): %w", version, node.versions.first, ErrStaleVersion)
+		}
+
+		if node.versions.contains(version) {
+			// Truncate the validity of this node to end at 'version'.
+			// After this readers with 'version' and above no longer see this value,
+			// while readers with versions before 'version' still see this.
+			node.versions.past.store(version)
+			break
+		}
+	}
+	return nil
+}
+
+// RemoveBefore removes all values whose validity ends before 'keepVersion'.
+// Caller must coordinate for mutual exclusion.
+func (v *Value[T]) RemoveBefore(keepVersion KeepVersion) {
+	version := version(keepVersion)
+	// find all values that are no longer valid at 'version'
+	node := v.head.Load()
+	for node != nil && node.versions.past.load() <= version {
+		// This node is no longer visible for readers with 'version' and above,
+		// so this can be safely removed.
+		node = node.next.Load()
+	}
+	v.head.Store(node)
+}
+
+// At returns value of type 'T' valid for the given version, or an empty value if none is found.
+func (v *Value[T]) At(handle *VersionHandle) T {
+	if handle != nil {
+		version := handle.version
+		for node := v.head.Load(); node != nil; node = node.next.Load() {
+			if node.versions.contains(version) {
+				return node.value
+			}
+		}
+	}
+	var empty T
+	return empty
+}
+
+// Versioned is a pair of a version and any type T
+type Versioned[T any] struct {
+	version version
+	value   T
+}
+
+type VersionedSlice[T any] []Versioned[T]
+
+// Append appends a pair of 'nextVersion' and 'value' to VersionedSlice 's', returning updated
+// 's'. Needed to keep members private.
+// Should only be called with monotonically increasing 'nextVersion's, so that the slice remains
+// sorted by version in ascending order.
+func (s VersionedSlice[T]) Append(value T, tx *Tx) VersionedSlice[T] {
+	return append(s, Versioned[T]{
+		version: tx.nextVersion,
+		value:   value,
+	})
+}
+
+// Before returns an iterator over the elements in VersionedSlice 's' having a version earlier than
+// 'keepVersion'.
+// The slice is assumed to be sorted by version in ascending order.
+func (s VersionedSlice[T]) Before(keepVersion KeepVersion) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		version := version(keepVersion)
+		for n := 0; n < len(s); n++ {
+			if s[n].version >= version {
+				break
+			}
+			if !yield(s[n].value) {
+				return
+			}
+		}
+	}
+}

--- a/pkg/container/versioned/value_test.go
+++ b/pkg/container/versioned/value_test.go
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package versioned
+
+import (
+	"math/rand/v2"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+type testCleaner struct {
+	oldestVersion atomicVersion
+	cleanerMutex  lock.Mutex
+	cleanerCond   *sync.Cond
+}
+
+func newTestCleaner() *testCleaner {
+	c := &testCleaner{}
+	c.cleanerCond = sync.NewCond(&c.cleanerMutex)
+	return c
+}
+
+func (c *testCleaner) waitUntilOldest(t *testing.T, version version) {
+	c.cleanerMutex.Lock()
+	for oldest := c.oldestVersion.load(); oldest < version; oldest = c.oldestVersion.load() {
+		t.Logf("Waiting due to oldest %d < %d version\n", oldest, version)
+		c.cleanerCond.Wait()
+	}
+	c.cleanerMutex.Unlock()
+}
+
+func (c *testCleaner) cleanValue(keepVersion KeepVersion, value *Value[[]uint32]) {
+	c.cleanerMutex.Lock()
+	defer c.cleanerMutex.Unlock()
+
+	// 'keepVersion' may be older than 'oldestVersion', keep oldestVersion monotonically
+	// increasing
+	oldest := c.oldestVersion.load()
+	if oldest < version(keepVersion) {
+		value.RemoveBefore(keepVersion)
+		c.oldestVersion.store(version(keepVersion))
+		c.cleanerCond.Signal()
+	}
+}
+
+func (c *testCleaner) cleanValues(keepVersion KeepVersion, values []Value[[]uint32]) {
+	c.cleanerMutex.Lock()
+	defer c.cleanerMutex.Unlock()
+
+	// 'keepVersion' may be older than 'oldestVersion', keep oldestVersion monotonically
+	// increasing
+	oldest := c.oldestVersion.load()
+	if oldest < version(keepVersion) {
+		// remove old versions for all values before bumping 'oldestVersion'
+		for i := 0; i < len(values); i++ {
+			values[i].RemoveBefore(keepVersion)
+		}
+		c.oldestVersion.store(version(keepVersion))
+		c.cleanerCond.Signal()
+	}
+}
+
+func TestVersionedValue(t *testing.T) {
+	var value1 Value[[]uint32]
+
+	cleaner := newTestCleaner()
+
+	cv := Coordinator{
+		Cleaner: func(keepVersion KeepVersion) {
+			cleaner.cleanValue(keepVersion, &value1)
+		},
+	}
+
+	// Initially empty
+	handle := cv.GetVersionHandle()
+	assert.Empty(t, value1.At(handle))
+	assert.Nil(t, handle.Close())
+	// 2nd call does nothing
+	assert.NotNil(t, handle.Close())
+
+	// Add first value
+	handle1 := cv.GetVersionHandle()
+	assert.Empty(t, value1.At(handle1))
+	version1 := handle1.Version()
+
+	tx := cv.PrepareNextVersion()
+	assert.False(t, tx.After(KeepVersion(tx.nextVersion)))
+	assert.True(t, tx.After(version1))
+
+	assert.Nil(t, value1.SetAt([]uint32{100, 200}, tx))
+	assert.Nil(t, tx.Commit())
+
+	oldTx := tx
+	tx = cv.PrepareNextVersion()
+	assert.Equal(t, tx.nextVersion, oldTx.nextVersion+1)
+
+	// New value is invisible for the old handle
+	assert.Empty(t, value1.At(handle))
+
+	// But is visible for any new handles
+	handle2 := cv.GetVersionHandle()
+
+	v := value1.At(handle2)
+	assert.Equal(t, []uint32{100, 200}, v)
+
+	// Set a new value
+	tx = cv.PrepareNextVersion()
+	assert.Nil(t, value1.SetAt([]uint32{100, 150, 200}, tx))
+	assert.Nil(t, tx.Commit())
+
+	// new handle sees the new value
+	handle3 := cv.GetVersionHandle()
+	v = value1.At(handle3)
+	assert.Equal(t, []uint32{100, 150, 200}, v)
+
+	// Old handle sees the previous value
+	v = value1.At(handle2)
+	assert.Equal(t, []uint32{100, 200}, v)
+
+	// first handle still sees no value
+	assert.Empty(t, value1.At(handle))
+
+	// delete the value at next version
+	tx = cv.PrepareNextVersion()
+	assert.Nil(t, value1.RemoveAt(tx))
+	assert.Nil(t, tx.Commit())
+
+	// new handle sees an empty value
+	handle4 := cv.GetVersionHandle()
+	assert.Empty(t, value1.At(handle4))
+	assert.Empty(t, value1.At(handle))
+	v = value1.At(handle3)
+	assert.Equal(t, []uint32{100, 150, 200}, v)
+	v = value1.At(handle2)
+	assert.Equal(t, []uint32{100, 200}, v)
+
+	// closers can be called in any order
+	assert.Nil(t, handle2.Close())
+	assert.Nil(t, handle1.Close())
+
+	// stale handle should now get an empty value after it's closer has been called and a new
+	// value has been inserted
+	cleaner.waitUntilOldest(t, handle3.version)
+	assert.Empty(t, value1.At(handle2))
+
+	v = value1.At(handle3)
+	assert.Equal(t, []uint32{100, 150, 200}, v)
+
+	assert.Nil(t, handle3.Close())
+
+	cleaner.waitUntilOldest(t, handle4.version)
+	assert.Empty(t, value1.At(handle3))
+
+	assert.Nil(t, handle4.Close())
+
+	// old values have been cleaned off
+	assert.Nil(t, value1.head.Load())
+}
+
+func TestVersionedValueMultiple(t *testing.T) {
+	var value1 Value[[]uint32]
+	var value2 Value[[]uint32]
+
+	cleaner := newTestCleaner()
+
+	cv := Coordinator{
+		Cleaner: func(keepVersion KeepVersion) {
+			cleaner.cleanValue(keepVersion, &value1)
+			cleaner.cleanValue(keepVersion, &value2)
+		},
+	}
+
+	// Initially empty
+	handle := cv.GetVersionHandle()
+	assert.Empty(t, value1.At(handle))
+	assert.Empty(t, value2.At(handle))
+	assert.Nil(t, handle.Close())
+	assert.NotNil(t, handle.Close())
+
+	// Add first values
+	handle1 := cv.GetVersionHandle()
+	assert.Empty(t, value1.At(handle1))
+	assert.Empty(t, value2.At(handle1))
+
+	tx := cv.PrepareNextVersion()
+
+	assert.Nil(t, value1.SetAt([]uint32{100, 200}, tx))
+	assert.Nil(t, value2.SetAt([]uint32{110, 190}, tx))
+	assert.Nil(t, tx.Commit())
+
+	oldTx := tx
+	tx = cv.PrepareNextVersion()
+	assert.Equal(t, tx.nextVersion, oldTx.nextVersion+1)
+
+	// New value is invisible for the old handle
+	assert.Empty(t, value1.At(handle1))
+	assert.Empty(t, value2.At(handle1))
+
+	// But is visible for any new handles
+	handle2 := cv.GetVersionHandle()
+
+	v := value1.At(handle2)
+	assert.Equal(t, []uint32{100, 200}, v)
+
+	v = value2.At(handle2)
+	assert.Equal(t, []uint32{110, 190}, v)
+
+	// New value appears at both values at the same version
+	tx = cv.PrepareNextVersion()
+	assert.Nil(t, value1.SetAt([]uint32{100, 150, 200}, tx))
+	assert.Nil(t, value2.SetAt([]uint32{110, 150, 190}, tx))
+	assert.Nil(t, tx.Commit())
+
+	// new handle sees the new value
+	handle3 := cv.GetVersionHandle()
+	v = value1.At(handle3)
+	assert.Equal(t, []uint32{100, 150, 200}, v)
+
+	v = value2.At(handle3)
+	assert.Equal(t, []uint32{110, 150, 190}, v)
+
+	// Old handle sees the previous values
+	v = value1.At(handle2)
+	assert.Equal(t, []uint32{100, 200}, v)
+
+	v = value2.At(handle2)
+	assert.Equal(t, []uint32{110, 190}, v)
+
+	// first handle still sees no value
+	assert.Empty(t, value1.At(handle))
+
+	// delete the value1 at next version
+	tx = cv.PrepareNextVersion()
+	assert.Nil(t, value1.RemoveAt(tx))
+	assert.Nil(t, tx.Commit())
+
+	// new handle sees an empty value1, but value2 remains
+	handle4 := cv.GetVersionHandle()
+	assert.Empty(t, value1.At(handle4))
+
+	v = value2.At(handle4)
+	assert.Equal(t, []uint32{110, 150, 190}, v)
+
+	assert.Empty(t, value1.At(handle))
+	assert.Empty(t, value2.At(handle))
+
+	v = value1.At(handle3)
+	assert.Equal(t, []uint32{100, 150, 200}, v)
+
+	v = value2.At(handle3)
+	assert.Equal(t, []uint32{110, 150, 190}, v)
+
+	v = value1.At(handle2)
+	assert.Equal(t, []uint32{100, 200}, v)
+
+	v = value2.At(handle2)
+	assert.Equal(t, []uint32{110, 190}, v)
+
+	// handle closers can be called in any order
+	assert.Nil(t, handle2.Close())
+	assert.Nil(t, handle3.Close())
+	assert.Nil(t, handle1.Close())
+	assert.Nil(t, handle4.Close())
+
+	// old value1 have been cleaned off
+	cleaner.waitUntilOldest(t, tx.nextVersion)
+	assert.Nil(t, value1.head.Load())
+
+	// but value2 remains, as it was not removed
+	assert.NotNil(t, value2.head.Load())
+}
+
+func TestPairSlice(t *testing.T) {
+	cv := Coordinator{}
+	s := make(VersionedSlice[int], 0, 10)
+
+	// 1st value '2000' at version 1
+	tx := cv.PrepareNextVersion()
+	s = s.Append(2000, tx)
+	assert.Len(t, s, 1)
+	assert.Equal(t, version(1), s[0].version)
+	assert.Equal(t, 2000, s[0].value)
+
+	tx.Commit()
+	tx = cv.PrepareNextVersion()
+
+	// 2nd value '1000' at version 2
+	s = s.Append(1000, tx)
+	assert.Len(t, s, 2)
+	assert.Equal(t, version(1), s[0].version)
+	assert.Equal(t, 2000, s[0].value)
+	assert.Equal(t, version(2), s[1].version)
+	assert.Equal(t, 1000, s[1].value)
+
+	tx.Commit()
+	tx = cv.PrepareNextVersion()
+
+	// 3rd value '3000' at version 3
+	s = s.Append(3000, tx)
+	assert.Len(t, s, 3)
+	assert.Equal(t, version(1), s[0].version)
+	assert.Equal(t, 2000, s[0].value)
+	assert.Equal(t, version(2), s[1].version)
+	assert.Equal(t, 1000, s[1].value)
+	assert.Equal(t, version(3), s[2].version)
+	assert.Equal(t, 3000, s[2].value)
+
+	// get all values before version 3; excluding the last value
+	var values []int
+	n := 0
+	for i := range s.Before(KeepVersion(3)) {
+		values = append(values, i)
+		n++
+	}
+	assert.Equal(t, []int{2000, 1000}, values)
+	s = s[n:]
+
+	// get all values upto and including maxVersion; get the lone value
+	values = nil
+	n = 0
+	for i := range s.Before(KeepVersion(invalidVersion)) {
+		values = append(values, i)
+		n++
+	}
+	assert.Equal(t, []int{3000}, values)
+	s = s[n:]
+	assert.Len(t, s, 0)
+}
+
+func TestVersionedChaos(t *testing.T) {
+	const nValues = 10
+	values := make([]Value[[]uint32], nValues)
+
+	cleaner := newTestCleaner()
+
+	cv := Coordinator{
+		Cleaner: func(keepVersion KeepVersion) {
+			for i := 0; i < nValues; i++ {
+				cleaner.cleanValues(keepVersion, values)
+			}
+		},
+	}
+
+	// Initially empty
+	handle := cv.GetVersionHandle()
+	for i := 0; i < nValues; i++ {
+		assert.Empty(t, values[i].At(handle))
+	}
+	assert.Nil(t, handle.Close())
+	assert.NotNil(t, handle.Close())
+
+	var mutex lock.Mutex
+	var writerWg, readerWg sync.WaitGroup
+	for j := 0; j < 1000; j++ {
+		for k := 0; k < 100; k++ {
+			readerWg.Add(1)
+			go func() {
+				time.Sleep(time.Duration(rand.IntN(100)) * time.Millisecond)
+				version := cv.GetVersionHandle()
+				time.Sleep(time.Duration(rand.IntN(100)) * time.Millisecond)
+				version.Close()
+				readerWg.Done()
+			}()
+		}
+		writerWg.Add(1)
+		go func() {
+			time.Sleep(time.Duration(rand.IntN(100)) * time.Millisecond)
+			mutex.Lock()
+			defer mutex.Unlock()
+			// Add some values
+			tx := cv.PrepareNextVersion()
+			idx := rand.IntN(nValues)
+			var value []uint32
+			switch rand.IntN(5) {
+			case 0:
+				value = []uint32{}
+			case 1:
+				value = []uint32{1}
+			case 2:
+				value = []uint32{1, 2}
+			case 3:
+				value = []uint32{1, 2, 3}
+			case 4:
+				value = []uint32{1, 2, 3, 4}
+			case 5:
+				value = []uint32{1, 2, 3, 4, 5}
+			}
+			assert.Nil(t, values[idx].SetAt(value, tx))
+			tx.Commit()
+			writerWg.Done()
+		}()
+	}
+
+	t.Logf("Waiting until all writers are done\n")
+	writerWg.Wait()
+
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	tx := cv.PrepareNextVersion()
+	for i := 0; i < nValues; i++ {
+		assert.Nil(t, values[i].RemoveAt(tx))
+	}
+	tx.Commit()
+
+	t.Logf("Waiting until oldest version is %d\n", tx.nextVersion)
+	cleaner.waitUntilOldest(t, tx.nextVersion)
+
+	// Check that all values were removed
+	for i := 0; i < nValues; i++ {
+		assert.Nil(t, values[i].head.Load())
+	}
+
+	t.Logf("Waiting until all readers are done\n")
+	readerWg.Wait()
+}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -763,6 +763,13 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 	// Mark the desired policy as ready when done before the lock is released
 	defer e.desiredPolicy.Ready()
 
+	// Apply pending policy map changes so that desired map is up-to-date before
+	// we update network policies and sync the maps below.
+	err = e.applyPolicyMapChanges()
+	if err != nil {
+		return err
+	}
+
 	// We cannot obtain the rules while e.mutex is held, because obtaining
 	// fresh DNSRules requires the IPCache lock (which must not be taken while
 	// holding e.mutex to avoid deadlocks). Therefore, rules are obtained
@@ -1249,7 +1256,13 @@ func (e *Endpoint) applyPolicyMapChanges() error {
 	//  ConsumeMapChanges() applies the incremental updates to the
 	//  desired policy and only returns changes that need to be
 	//  applied to the Endpoint's bpf policy map.
-	changes := e.desiredPolicy.ConsumeMapChanges()
+	closer, changes := e.desiredPolicy.ConsumeMapChanges()
+	defer closer()
+
+	if changes.Empty() {
+		// no changes, nothing to do
+		return nil
+	}
 
 	// Add possible visibility redirects due to incrementally added keys
 	if e.visibilityPolicy != nil {
@@ -1267,6 +1280,12 @@ func (e *Endpoint) applyPolicyMapChanges() error {
 				e.desiredPolicy.AddVisibilityKeys(e, redirectPort, visMeta, changes)
 			}
 		}
+	}
+
+	// Ingress endpoint does not need to wait.
+	// This also lets daemon/cmd integration tests to proceed
+	if e.isProperty(PropertySkipBPFPolicy) {
+		return nil
 	}
 
 	// Add policy map entries before deleting to avoid transient drops
@@ -1301,7 +1320,7 @@ func (e *Endpoint) applyPolicyMapChanges() error {
 		e.getLogger().WithFields(logrus.Fields{
 			logfields.AddedPolicyID:   changes.Adds,
 			logfields.DeletedPolicyID: changes.Deletes,
-		}).Debug("Applied policy map updates due identity changes")
+		}).Debug("Applied policy map updates due to identity changes")
 	}
 
 	return nil
@@ -1311,13 +1330,6 @@ func (e *Endpoint) applyPolicyMapChanges() error {
 // difference between the realized and desired policy state without
 // dumping the bpf policy map.
 func (e *Endpoint) syncPolicyMap() error {
-	// Apply pending policy map changes first so that desired map is up-to-date before
-	// we diff the maps below.
-	err := e.applyPolicyMapChanges()
-	if err != nil {
-		return err
-	}
-
 	// Nothing to do if the desired policy is already fully realized.
 	if e.realizedPolicy == e.desiredPolicy {
 		e.PolicyDebug(nil, "syncPolicyMap(): not syncing as desired == realized")
@@ -1325,7 +1337,7 @@ func (e *Endpoint) syncPolicyMap() error {
 	}
 
 	// Diffs between the maps are expected here, so do not bother collecting them
-	_, _, err = e.syncPolicyMapsWith(e.realizedPolicy.GetPolicyMap(), false)
+	_, _, err := e.syncPolicyMapsWith(e.realizedPolicy.GetPolicyMap(), false)
 	return err
 }
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -760,6 +760,8 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 	if err := e.setDesiredPolicy(policyResult); err != nil {
 		return err
 	}
+	// Mark the desired policy as ready when done before the lock is released
+	defer e.desiredPolicy.Ready()
 
 	// We cannot obtain the rules while e.mutex is held, because obtaining
 	// fresh DNSRules requires the IPCache lock (which must not be taken while

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/datapath/linux/bandwidth"
@@ -1591,6 +1592,13 @@ func (e *Endpoint) OnDNSPolicyUpdateLocked(rules restore.DNSRules) {
 			e.DNSRules[pp.ToV1()] = rules
 		}
 	}
+}
+
+func (e *Endpoint) GetPolicyVersionHandle() *versioned.VersionHandle {
+	if e.desiredPolicy != nil {
+		return e.desiredPolicy.VersionHandle
+	}
+	return nil
 }
 
 // getProxyStatistics gets the ProxyStatistics for the flows with the

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -53,7 +53,6 @@ func (e *Endpoint) HasBPFPolicyMap() bool {
 }
 
 // GetNamedPort returns the port for the given name.
-// Must be called with e.mutex NOT held
 func (e *Endpoint) GetNamedPort(ingress bool, name string, proto u8proto.U8proto) uint16 {
 	if ingress {
 		// Ingress only needs the ports of the POD itself

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -141,6 +141,12 @@ func (e *Endpoint) updateNetworkPolicy(proxyWaitGroup *completion.WaitGroup) (re
 		return nil, nil
 	}
 
+	// Need a valid handle to be able to update the network policy, get one if needed
+	if !e.desiredPolicy.VersionHandle.IsValid() {
+		e.desiredPolicy.VersionHandle = e.desiredPolicy.SelectorCache.GetVersionHandle()
+		defer e.desiredPolicy.Ready()
+	}
+
 	if e.IsProxyDisabled() {
 		return nil, nil
 	}

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -184,7 +184,9 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 		// Apply any pending incremental changes
 		// This mirrors the existing code, where we consume map changes
 		// while holding the endpoint lock
-		res.endpointPolicy.ConsumeMapChanges()
+		closer, _ := res.endpointPolicy.ConsumeMapChanges()
+		closer()
+
 		haveIDs := make(sets.Set[identity.NumericIdentity], testfactor)
 		res.endpointPolicy.GetPolicyMap().ForEach(func(k policy.Key, _ policy.MapStateEntry) bool {
 			haveIDs.Insert(k.Identity)

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -387,7 +387,7 @@ func combineL4L7(l4 []api.PortRule, l7 *api.L7Rules) []api.PortRule {
 }
 
 func (s *RedirectSuite) testMapState(initMap policy.MapStateMap) policy.MapState {
-	return policy.NewMapState().WithState(initMap, s.do.repo.GetSelectorCache())
+	return policy.NewMapState().WithState(initMap)
 }
 
 func TestRedirectWithDeny(t *testing.T) {

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/endpointstate"
 	_ "github.com/cilium/cilium/pkg/envoy/resource"
@@ -1413,13 +1414,13 @@ func GetEnvoyHTTPRules(secretManager certificatemanager.SecretManager, l7Rules *
 	return nil, true
 }
 
-func getPortNetworkPolicyRule(sel policy.CachedSelector, wildcard bool, l7Parser policy.L7ParserType, l7Rules *policy.PerSelectorPolicy, useFullTLSContext bool) (*cilium.PortNetworkPolicyRule, bool) {
+func getPortNetworkPolicyRule(version *versioned.VersionHandle, sel policy.CachedSelector, wildcard bool, l7Parser policy.L7ParserType, l7Rules *policy.PerSelectorPolicy, useFullTLSContext bool) (*cilium.PortNetworkPolicyRule, bool) {
 	r := &cilium.PortNetworkPolicyRule{}
 
 	// Optimize the policy if the endpoint selector is a wildcard by
 	// keeping remote policies list empty to match all remote policies.
 	if !wildcard {
-		selections := sel.GetSelections()
+		selections := sel.GetSelections(version)
 
 		// No remote policies would match this rule. Discard it.
 		if len(selections) == 0 {
@@ -1518,14 +1519,14 @@ func getPortNetworkPolicyRule(sel policy.CachedSelector, wildcard bool, l7Parser
 
 // getWildcardNetworkPolicyRule returns the rule for port 0, which
 // will be considered after port-specific rules.
-func getWildcardNetworkPolicyRule(selectors policy.L7DataMap) *cilium.PortNetworkPolicyRule {
+func getWildcardNetworkPolicyRule(version *versioned.VersionHandle, selectors policy.L7DataMap) *cilium.PortNetworkPolicyRule {
 	// selections are pre-sorted, so sorting is only needed if merging selections from multiple selectors
 	if len(selectors) == 1 {
 		for sel := range selectors {
 			if sel.IsWildcard() {
 				return &cilium.PortNetworkPolicyRule{}
 			}
-			selections := sel.GetSelections()
+			selections := sel.GetSelections(version)
 			if len(selections) == 0 {
 				// No remote policies would match this rule. Discard it.
 				return nil
@@ -1553,7 +1554,7 @@ func getWildcardNetworkPolicyRule(selectors policy.L7DataMap) *cilium.PortNetwor
 			log.Warningf("L3-only rule for selector %v surprisingly requires proxy redirection (%v)!", sel, *l7)
 		}
 
-		selections := sel.GetSelections()
+		selections := sel.GetSelections(version)
 		if len(selections) == 0 {
 			continue
 		}
@@ -1584,6 +1585,8 @@ func getWildcardNetworkPolicyRule(selectors policy.L7DataMap) *cilium.PortNetwor
 }
 
 func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4PolicyMap, policyEnforced bool, useFullTLSContext bool, vis policy.DirectionalVisibilityPolicy, dir string) []*cilium.PortNetworkPolicy {
+	version := ep.GetPolicyVersionHandle()
+
 	// TODO: integrate visibility with enforced policy
 	if !policyEnforced {
 		PerPortPolicies := make([]*cilium.PortNetworkPolicy, 0, len(vis)+1)
@@ -1641,10 +1644,11 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 		if port == 0 {
 			// L3-only rule, must generate L7 allow-all in case there are other
 			// port-specific rules. Otherwise traffic from allowed remotes could be dropped.
-			rule := getWildcardNetworkPolicyRule(l4.PerSelectorPolicies)
+			rule := getWildcardNetworkPolicyRule(version, l4.PerSelectorPolicies)
 			if rule != nil {
 				log.WithFields(logrus.Fields{
 					logfields.EndpointID:       ep.GetID(),
+					logfields.Version:          version,
 					logfields.TrafficDirection: dir,
 					logfields.Port:             port,
 					logfields.PolicyID:         rule.RemotePolicies,
@@ -1665,7 +1669,7 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 				// then the proxy may need to drop some allowed l3 due to l7 rules potentially
 				// being different between the selectors.
 				wildcard := nSelectors == 1 || sel.IsWildcard()
-				rule, cs := getPortNetworkPolicyRule(sel, wildcard, l4.L7Parser, l7, useFullTLSContext)
+				rule, cs := getPortNetworkPolicyRule(version, sel, wildcard, l4.L7Parser, l7, useFullTLSContext)
 				if rule != nil {
 					if !cs {
 						canShortCircuit = false
@@ -1673,6 +1677,7 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 
 					log.WithFields(logrus.Fields{
 						logfields.EndpointID:       ep.GetID(),
+						logfields.Version:          version,
 						logfields.TrafficDirection: dir,
 						logfields.Port:             port,
 						logfields.PolicyID:         rule.RemotePolicies,

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1695,7 +1695,11 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 		}
 		// Short-circuit rules if a rule allows all and all other rules can be short-circuited
 		if allowAll && canShortCircuit {
-			log.Debug("Short circuiting HTTP rules due to rule allowing all and no other rules needing attention")
+			log.WithFields(logrus.Fields{
+				logfields.EndpointID:       ep.GetID(),
+				logfields.TrafficDirection: dir,
+				logfields.Port:             port,
+			}).Debug("Short circuiting HTTP rules due to rule allowing all and no other rules needing attention")
 			rules = nil
 		}
 
@@ -1704,6 +1708,11 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 		// In this case, just don't generate any PortNetworkPolicy for this
 		// port.
 		if !allowAll && len(rules) == 0 {
+			log.WithFields(logrus.Fields{
+				logfields.EndpointID:       ep.GetID(),
+				logfields.TrafficDirection: dir,
+				logfields.Port:             port,
+			}).Debug("Skipping PortNetworkPolicy due to no matching remote identities")
 			return true
 		}
 

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -30,6 +30,9 @@ type DummySelectorCacheUser struct{}
 func (d *DummySelectorCacheUser) IdentitySelectionUpdated(selector policy.CachedSelector, added, deleted []identity.NumericIdentity) {
 }
 
+func (d *DummySelectorCacheUser) IdentitySelectionCommit(*versioned.Tx) {
+}
+
 var (
 	IPv4Addr = "10.1.1.1"
 

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/re"
@@ -208,7 +209,7 @@ type MockCachedSelector struct {
 	key string
 }
 
-func (m MockCachedSelector) GetSelections() identity.NumericIdentitySlice {
+func (m MockCachedSelector) GetSelections(*versioned.VersionHandle) identity.NumericIdentitySlice {
 	return nil
 }
 
@@ -216,7 +217,7 @@ func (m MockCachedSelector) GetMetadataLabels() labels.LabelArray {
 	panic("implement me")
 }
 
-func (m MockCachedSelector) Selects(_ identity.NumericIdentity) bool {
+func (m MockCachedSelector) Selects(*versioned.VersionHandle, identity.NumericIdentity) bool {
 	return false
 }
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -246,6 +246,9 @@ type DummySelectorCacheUser struct{}
 func (d *DummySelectorCacheUser) IdentitySelectionUpdated(selector policy.CachedSelector, added, deleted []identity.NumericIdentity) {
 }
 
+func (d *DummySelectorCacheUser) IdentitySelectionCommit(*versioned.Tx) {
+}
+
 // Setup identities, ports and endpoint IDs we will need
 var (
 	cacheAllocator          = cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
+	"github.com/cilium/cilium/pkg/container/versioned"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
@@ -783,12 +784,12 @@ func TestFullPathDependence(t *testing.T) {
 			asIPRule(s.proxy.allowed[epID1][tcpProtoPort53][cachedDstID1Selector], makeMapOfRuleIPOrCIDR("::")),
 		},
 	}
-	restored1, _ := s.proxy.GetRules(uint16(epID1))
+	restored1, _ := s.proxy.GetRules(versioned.Latest(), uint16(epID1))
 	restored1.Sort(nil)
 	require.EqualValues(t, expected1, restored1)
 
 	expected2 := restore.DNSRules{}
-	restored2, _ := s.proxy.GetRules(uint16(epID2))
+	restored2, _ := s.proxy.GetRules(versioned.Latest(), uint16(epID2))
 	restored2.Sort(nil)
 	require.EqualValues(t, expected2, restored2)
 
@@ -802,7 +803,7 @@ func TestFullPathDependence(t *testing.T) {
 			asIPRule(s.proxy.allowed[epID3][tcpProtoPort53][cachedDstID3Selector], makeMapOfRuleIPOrCIDR()),
 		},
 	}
-	restored3, _ := s.proxy.GetRules(uint16(epID3))
+	restored3, _ := s.proxy.GetRules(versioned.Latest(), uint16(epID3))
 	restored3.Sort(nil)
 	require.EqualValues(t, expected3, restored3)
 
@@ -822,7 +823,7 @@ func TestFullPathDependence(t *testing.T) {
 			asIPRule(s.proxy.allowed[epID1][tcpProtoPort53][cachedDstID1Selector], makeMapOfRuleIPOrCIDR()),
 		},
 	}
-	restored1b, _ := s.proxy.GetRules(uint16(epID1))
+	restored1b, _ := s.proxy.GetRules(versioned.Latest(), uint16(epID1))
 	restored1b.Sort(nil)
 	require.EqualValues(t, expected1b, restored1b)
 
@@ -1108,7 +1109,7 @@ func TestRestoredEndpoint(t *testing.T) {
 	}
 
 	// Get restored rules
-	restored, _ := s.proxy.GetRules(uint16(epID1))
+	restored, _ := s.proxy.GetRules(versioned.Latest(), uint16(epID1))
 	restored.Sort(nil)
 
 	// remove rules
@@ -1209,7 +1210,7 @@ type selectorMock struct {
 	key string
 }
 
-func (t selectorMock) GetSelections() identity.NumericIdentitySlice {
+func (t selectorMock) GetSelections(*versioned.VersionHandle) identity.NumericIdentitySlice {
 	panic("implement me")
 }
 
@@ -1217,7 +1218,7 @@ func (t selectorMock) GetMetadataLabels() labels.LabelArray {
 	panic("implement me")
 }
 
-func (t selectorMock) Selects(nid identity.NumericIdentity) bool {
+func (t selectorMock) Selects(*versioned.VersionHandle, identity.NumericIdentity) bool {
 	panic("implement me")
 }
 

--- a/pkg/fqdn/proxy/proxy.go
+++ b/pkg/fqdn/proxy/proxy.go
@@ -4,13 +4,14 @@
 package proxy
 
 import (
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/policy"
 )
 
 type DNSProxier interface {
-	GetRules(uint16) (restore.DNSRules, error)
+	GetRules(*versioned.VersionHandle, uint16) (restore.DNSRules, error)
 	RemoveRestoredRules(uint16)
 	UpdateAllowed(endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) error
 	GetBindPort() uint16
@@ -21,7 +22,7 @@ type DNSProxier interface {
 
 type MockFQDNProxy struct{}
 
-func (m MockFQDNProxy) GetRules(u uint16) (restore.DNSRules, error) {
+func (m MockFQDNProxy) GetRules(*versioned.VersionHandle, uint16) (restore.DNSRules, error) {
 	return nil, nil
 }
 

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/identity"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -94,6 +95,9 @@ func testNewPolicyRepository() *policy.Repository {
 }
 
 func (d *DummySelectorCacheUser) IdentitySelectionUpdated(selector policy.CachedSelector, added, deleted []identity.NumericIdentity) {
+}
+
+func (d *DummySelectorCacheUser) IdentitySelectionCommit(*versioned.Tx) {
 }
 
 func TestParseNetworkPolicyIngress(t *testing.T) {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -23,6 +23,9 @@ const (
 	// Stacktrace is a field for a stacktrace
 	Stacktrace = "stacktrace"
 
+	// Changes is a generic field for any relevant changes
+	Changes = "changes"
+
 	// Signal is the field to print os signals on exit etc.
 	Signal = "signal"
 
@@ -434,6 +437,9 @@ const (
 
 	// Selector is a selector of any sort: endpoint, CIDR, toFQDNs
 	Selector = "Selector"
+
+	// SelectorCacgeVersion is the version of the SelectorCache.
+	SelectorCacheVersion = "selectorCacheVersion"
 
 	// EndpointLabelSelector is a selector for Endpoints by label
 	EndpointLabelSelector = "EndpointLabelSelector"

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -11,6 +11,15 @@ const (
 	// LogSubsys is the field denoting the subsystem when logging
 	LogSubsys = "subsys"
 
+	// Version is a field for a generic version number
+	Version = "version"
+
+	// NewVersion is a field for a new version number
+	NewVersion = "newVersion"
+
+	// OldVersion is a field for a old version number
+	OldVersion = "oldVersion"
+
 	// Stacktrace is a field for a stacktrace
 	Stacktrace = "stacktrace"
 

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync/atomic"
 
+	"github.com/cilium/cilium/pkg/container/versioned"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/lock"
@@ -176,7 +177,7 @@ func (cache *PolicyCache) GetAuthTypes(localID, remoteID identityPkg.NumericIden
 		}
 		// Only check if 'cs' selects 'remoteID' if one of the authTypes is still missing
 		// from the result
-		if missing && cs.Selects(remoteID) {
+		if missing && cs.Selects(versioned.Latest(), remoteID) {
 			if resTypes == nil {
 				resTypes = make(AuthTypes, 1)
 			}

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -1570,37 +1570,9 @@ var (
 			ToCIDR: api.CIDRSlice{worldIPCIDR},
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
-	mapKeyAnyIngress                        = IngressKey()
-	mapKeyL4AnyPortProtoWorldIPIngress      = IngressKey().WithIdentity(worldIPIdentity)
-	mapKeyL4AnyPortProtoWorldIPEgress       = EgressKey().WithIdentity(worldIPIdentity)
-	mapKeyL4Port8080ProtoTCPWorldIPIngress  = IngressKey().WithIdentity(worldIPIdentity).WithTCPPort(8080)
-	mapKeyL4Port8080ProtoTCPWorldIPEgress   = EgressKey().WithIdentity(worldIPIdentity).WithTCPPort(8080)
-	mapKeyL4Port8080ProtoUDPWorldIPIngress  = IngressKey().WithIdentity(worldIPIdentity).WithUDPPort(8080)
-	mapKeyL4Port8080ProtoUDPWorldIPEgress   = EgressKey().WithIdentity(worldIPIdentity).WithUDPPort(8080)
-	mapKeyL4Port8080ProtoSCTPWorldIPIngress = IngressKey().WithIdentity(worldIPIdentity).WithSCTPPort(8080)
-	mapKeyL4Port8080ProtoSCTPWorldIPEgress  = EgressKey().WithIdentity(worldIPIdentity).WithSCTPPort(8080)
-	mapEntryL4WorldIPDependentsIngressDeny  = MapStateEntry{
-		ProxyPort:        0,
-		IsDeny:           true,
-		DerivedFromRules: labels.LabelArrayList{nil},
-		owners:           map[MapStateOwner]struct{}{},
-		dependents: Keys{
-			mapKeyL4Port8080ProtoTCPWorldIPIngress:  struct{}{},
-			mapKeyL4Port8080ProtoUDPWorldIPIngress:  struct{}{},
-			mapKeyL4Port8080ProtoSCTPWorldIPIngress: struct{}{},
-		},
-	}
-	mapEntryL4WorldIPDependentsEgressDeny = MapStateEntry{
-		ProxyPort:        0,
-		IsDeny:           true,
-		DerivedFromRules: labels.LabelArrayList{nil},
-		owners:           map[MapStateOwner]struct{}{},
-		dependents: Keys{
-			mapKeyL4Port8080ProtoTCPWorldIPEgress:  struct{}{},
-			mapKeyL4Port8080ProtoUDPWorldIPEgress:  struct{}{},
-			mapKeyL4Port8080ProtoSCTPWorldIPEgress: struct{}{},
-		},
-	}
+	mapKeyAnyIngress                   = IngressKey()
+	mapKeyL4AnyPortProtoWorldIPIngress = IngressKey().WithIdentity(worldIPIdentity)
+	mapKeyL4AnyPortProtoWorldIPEgress  = EgressKey().WithIdentity(worldIPIdentity)
 
 	ruleL3AllowWorldSubnetNamedPort = api.NewRule().WithIngressRules([]api.IngressRule{{
 		ToPorts: api.PortRules{
@@ -1737,14 +1709,8 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 			mapKeyL3L4Port8080ProtoUDPWorldSNEgress:   mapEntryAllow,
 			mapKeyL3L4Port8080ProtoSCTPWorldSNIngress: mapEntryAllow,
 			mapKeyL3L4Port8080ProtoSCTPWorldSNEgress:  mapEntryAllow,
-			mapKeyL4AnyPortProtoWorldIPIngress:        mapEntryL4WorldIPDependentsIngressDeny,
-			mapKeyL4AnyPortProtoWorldIPEgress:         mapEntryL4WorldIPDependentsEgressDeny,
-			mapKeyL4Port8080ProtoTCPWorldIPIngress:    mapEntryDeny,
-			mapKeyL4Port8080ProtoTCPWorldIPEgress:     mapEntryDeny,
-			mapKeyL4Port8080ProtoUDPWorldIPIngress:    mapEntryDeny,
-			mapKeyL4Port8080ProtoUDPWorldIPEgress:     mapEntryDeny,
-			mapKeyL4Port8080ProtoSCTPWorldIPIngress:   mapEntryDeny,
-			mapKeyL4Port8080ProtoSCTPWorldIPEgress:    mapEntryDeny,
+			mapKeyL4AnyPortProtoWorldIPIngress:        mapEntryDeny,
+			mapKeyL4AnyPortProtoWorldIPEgress:         mapEntryDeny,
 		})}, {"named_port_world_subnet", api.Rules{ruleAllowAllIngress, ruleL3AllowWorldSubnetNamedPort}, testMapState(MapStateMap{
 			mapKeyAnyIngress: mapEntryAllow,
 			mapKeyL3L4NamedPortHTTPProtoTCPWorldSubNetIngress: mapEntryAllow,

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -417,6 +417,8 @@ func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.Labe
 	// the extra egress allow-all is technically correct, but omitted from the
 	// expected output that's asserted against for the sake of brevity.
 	epp.policyMapState.delete(mapKeyAllowAllE_, nil)
+	epp.Ready()
+	epp.Detach()
 
 	return epp.policyMapState, nil
 }

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -8,6 +8,7 @@ import (
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -87,5 +88,6 @@ func FuzzAccumulateMapChange(f *testing.F) {
 		value := NewMapStateEntry(csFoo, nil, proxyPort, "", 0, deny, DefaultAuthType, AuthTypeDisabled)
 		policyMaps := MapChanges{}
 		policyMaps.AccumulateMapChanges(csFoo, adds, deletes, []Key{key}, value)
+		policyMaps.SyncMapChanges(versioned.LatestTx)
 	})
 }

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -50,7 +50,7 @@ func FuzzDenyPreferredInsert(f *testing.F) {
 		ff.GenerateStruct(keys)
 		ff.GenerateStruct(&key)
 		ff.GenerateStruct(&entry)
-		keys.denyPreferredInsert(key, entry, nil, allFeatures)
+		keys.denyPreferredInsert(key, entry, allFeatures)
 	})
 }
 

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -628,7 +628,7 @@ func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redir
 		if cs.IsWildcard() {
 			for _, keyToAdd := range keysToAdd {
 				keyToAdd.Identity = 0
-				p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
+				p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, features, changes)
 
 				if port == 0 {
 					// Allow-all
@@ -660,15 +660,15 @@ func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redir
 		for _, id := range idents {
 			for _, keyToAdd := range keysToAdd {
 				keyToAdd.Identity = id
-				p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
+				p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, features, changes)
 				// If Cilium is in dual-stack mode then the "World" identity
 				// needs to be split into two identities to represent World
 				// IPv6 and IPv4 traffic distinctly from one another.
 				if id == identity.ReservedIdentityWorld && option.Config.IsDualStack() {
 					keyToAdd.Identity = identity.ReservedIdentityWorldIPv4
-					p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
+					p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, features, changes)
 					keyToAdd.Identity = identity.ReservedIdentityWorldIPv6
-					p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
+					p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, features, changes)
 				}
 			}
 		}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -2015,11 +2015,12 @@ func (mc *MapChanges) AccumulateMapChanges(cs CachedSelector, adds, deletes []id
 
 // consumeMapChanges transfers the incremental changes from MapChanges to the caller,
 // while applying the changes to PolicyMapState.
-func (mc *MapChanges) consumeMapChanges(policyOwner PolicyOwner, policyMapState MapState, identities Identities, features policyFeatures) (adds, deletes Keys) {
+func (mc *MapChanges) consumeMapChanges(policyOwner PolicyOwner, policyMapState MapState, identities Identities, features policyFeatures) ChangeState {
 	mc.mutex.Lock()
 	changes := ChangeState{
 		Adds:    make(Keys, len(mc.changes)),
 		Deletes: make(Keys, len(mc.changes)),
+		Old:     make(map[Key]MapStateEntry),
 	}
 	var redirects map[string]uint16
 	if policyOwner != nil {
@@ -2058,5 +2059,5 @@ func (mc *MapChanges) consumeMapChanges(policyOwner PolicyOwner, policyMapState 
 	}
 	mc.changes = nil
 	mc.mutex.Unlock()
-	return changes.Adds, changes.Deletes
+	return changes
 }

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -3238,8 +3238,10 @@ func TestDenyPreferredInsertLogic(t *testing.T) {
 	mapState.validator = &validator{} // insert validator
 
 	// This is DistillPolicy, but with MapState validator injected
+	version := p.SelectorCache.GetVersionHandle()
 	epPolicy := &EndpointPolicy{
 		selectorPolicy: p,
+		VersionHandle:  version,
 		policyMapState: mapState,
 		PolicyOwner:    DummyOwner{},
 	}
@@ -3250,10 +3252,9 @@ func TestDenyPreferredInsertLogic(t *testing.T) {
 	}
 	p.insertUser(epPolicy)
 
-	p.SelectorCache.mutex.RLock()
 	epPolicy.toMapState()
 	epPolicy.policyMapState.determineAllowLocalhostIngress()
-	p.SelectorCache.mutex.RUnlock()
+	epPolicy.Ready()
 
 	n := epPolicy.policyMapState.Len()
 	p.Detach()

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1796,11 +1796,11 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 			value := NewMapStateEntry(cs, nil, proxyPort, "", 0, x.deny, DefaultAuthType, AuthTypeDisabled)
 			policyMaps.AccumulateMapChanges(cs, adds, deletes, []Key{key}, value)
 		}
-		adds, deletes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, selectorCache, denyRules)
+		changes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, selectorCache, denyRules)
 		policyMapState.validatePortProto(t)
 		require.True(t, policyMapState.Equals(tt.state), "%s (MapState):\n%s", tt.name, policyMapState.Diff(tt.state))
-		require.EqualValues(t, tt.adds, adds, tt.name+" (adds)")
-		require.EqualValues(t, tt.deletes, deletes, tt.name+" (deletes)")
+		require.EqualValues(t, tt.adds, changes.Adds, tt.name+" (adds)")
+		require.EqualValues(t, tt.deletes, changes.Deletes, tt.name+" (deletes)")
 	}
 }
 
@@ -2136,11 +2136,11 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			value := NewMapStateEntry(cs, nil, proxyPort, "", 0, x.deny, x.hasAuth, x.authType)
 			policyMaps.AccumulateMapChanges(cs, adds, deletes, []Key{key}, value)
 		}
-		adds, deletes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, nil, authRules|denyRules)
+		changes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, nil, authRules|denyRules)
 		policyMapState.validatePortProto(t)
 		require.True(t, policyMapState.Equals(tt.state), "%s (MapState):\n%s", tt.name, policyMapState.Diff(tt.state))
-		require.EqualValues(t, tt.adds, adds, tt.name+" (adds)")
-		require.EqualValues(t, tt.deletes, deletes, tt.name+" (deletes)")
+		require.EqualValues(t, tt.adds, changes.Adds, tt.name+" (adds)")
+		require.EqualValues(t, tt.deletes, changes.Deletes, tt.name+" (deletes)")
 	}
 }
 
@@ -2719,12 +2719,8 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			value := NewMapStateEntry(cs, nil, proxyPort, "", 0, x.deny, DefaultAuthType, AuthTypeDisabled)
 			policyMaps.AccumulateMapChanges(cs, adds, deletes, []Key{key}, value)
 		}
-		adds, deletes := policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, selectorCache, denyRules)
-		changes = ChangeState{
-			Adds:    adds,
-			Deletes: deletes,
-			Old:     make(MapStateMap),
-		}
+		changes = policyMaps.consumeMapChanges(DummyOwner{}, policyMapState, selectorCache, denyRules)
+		changes.Old = make(MapStateMap)
 
 		// Visibilty redirects need to be re-applied after consumeMapChanges()
 		for _, arg := range tt.visArgs {

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -2792,9 +2792,9 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		worldSubnetIdentity:            lblWorldSubnet.LabelArray(), // "192.0.2.0/24"
 	}
 
-	reservedWorldID := identity.ReservedIdentityWorld
-	worldIPID := worldIPIdentity
-	worldSubnetID := worldSubnetIdentity
+	reservedWorldSelections := identity.ReservedIdentityWorld
+	worldIPSelections := worldIPIdentity
+	worldSubnetSelections := worldSubnetIdentity
 	selectorCache := testNewSelectorCache(identityCache)
 	type action uint16
 	const (
@@ -2830,118 +2830,118 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		outcome              action
 	}{
 		// deny-allow insertions
-		{"deny-allow: a superset a|b L3-only; subset allow inserted as deny", WithAllowAll, reservedWorldID, worldSubnetID, true, false, 0, 0, 0, 0, insertAllowAll | insertA | insertBasDeny},
-		{"deny-allow: a superset a|b L3-only; without allow-all", WithoutAllowAll, reservedWorldID, worldSubnetID, true, false, 0, 0, 0, 0, insertA | insertBasDeny},
+		{"deny-allow: a superset a|b L3-only; subset allow inserted as deny", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 0, 0, 0, insertAllowAll | insertA | insertBasDeny},
+		{"deny-allow: a superset a|b L3-only; without allow-all", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 0, 0, 0, insertA | insertBasDeny},
 
-		{"deny-allow: b superset a|b L3-only", WithAllowAll, worldIPID, worldSubnetID, true, false, 0, 0, 0, 0, insertAllowAll | insertBoth},
-		{"deny-allow: b superset a|b L3-only; without allow-all", WithoutAllowAll, worldIPID, worldSubnetID, true, false, 0, 0, 0, 0, insertBoth},
+		{"deny-allow: b superset a|b L3-only", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 0, 0, 0, insertAllowAll | insertBoth},
+		{"deny-allow: b superset a|b L3-only; without allow-all", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 0, 0, 0, insertBoth},
 
-		{"deny-allow: a superset a L3-only, b L4; subset allow inserted as deny", WithAllowAll, reservedWorldID, worldSubnetID, true, false, 0, 0, 0, 6, insertAllowAll | insertA | insertBasDeny},
-		{"deny-allow: a superset a L3-only, b L4; without allow-all, subset allow inserted as deny", WithoutAllowAll, reservedWorldID, worldSubnetID, true, false, 0, 0, 0, 6, insertA | insertBasDeny},
+		{"deny-allow: a superset a L3-only, b L4; subset allow inserted as deny", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 0, 0, 6, insertAllowAll | insertA | insertBasDeny},
+		{"deny-allow: a superset a L3-only, b L4; without allow-all, subset allow inserted as deny", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 0, 0, 6, insertA | insertBasDeny},
 
-		{"deny-allow: b superset a L3-only, b L4", WithAllowAll, worldIPID, worldSubnetID, true, false, 0, 0, 0, 6, insertAllowAll | insertBoth | insertAWithBProto},
-		{"deny-allow: b superset a L3-only, b L4; without allow-all, added deny TCP due to intersecting deny", WithoutAllowAll, worldIPID, worldSubnetID, true, false, 0, 0, 0, 6, insertBoth | insertAWithBProto},
+		{"deny-allow: b superset a L3-only, b L4", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 0, 0, 6, insertAllowAll | insertBoth | insertAWithBProto},
+		{"deny-allow: b superset a L3-only, b L4; without allow-all, added deny TCP due to intersecting deny", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 0, 0, 6, insertBoth | insertAWithBProto},
 
-		{"deny-allow: a superset a L3-only, b L3L4; subset allow inserted as deny", WithAllowAll, reservedWorldID, worldSubnetID, true, false, 0, 0, 80, 6, insertAllowAll | insertA | insertBasDeny},
-		{"deny-allow: a superset a L3-only, b L3L4; without allow-all, subset allow inserted as deny", WithoutAllowAll, reservedWorldID, worldSubnetID, true, false, 0, 0, 80, 6, insertA | insertBasDeny},
+		{"deny-allow: a superset a L3-only, b L3L4; subset allow inserted as deny", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 0, 80, 6, insertAllowAll | insertA | insertBasDeny},
+		{"deny-allow: a superset a L3-only, b L3L4; without allow-all, subset allow inserted as deny", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 0, 80, 6, insertA | insertBasDeny},
 
-		{"deny-allow: b superset a L3-only, b L3L4; added deny TCP/80 due to intersecting deny", WithAllowAll, worldIPID, worldSubnetID, true, false, 0, 0, 80, 6, insertAllowAll | insertBoth | insertAWithBProto},
-		{"deny-allow: b superset a L3-only, b L3L4; without allow-all, added deny TCP/80 due to intersecting deny", WithoutAllowAll, worldIPID, worldSubnetID, true, false, 0, 0, 80, 6, insertBoth | insertAWithBProto},
+		{"deny-allow: b superset a L3-only, b L3L4; added deny TCP/80 due to intersecting deny", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 0, 80, 6, insertAllowAll | insertBoth | insertAWithBProto},
+		{"deny-allow: b superset a L3-only, b L3L4; without allow-all, added deny TCP/80 due to intersecting deny", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 0, 80, 6, insertBoth | insertAWithBProto},
 
-		{"deny-allow: a superset a L4, b L3-only", WithAllowAll, reservedWorldID, worldSubnetID, true, false, 0, 6, 0, 0, insertAllowAll | insertBoth | insertBWithAProtoAsDeny},
-		{"deny-allow: a superset a L4, b L3-only; without allow-all", WithoutAllowAll, reservedWorldID, worldSubnetID, true, false, 0, 6, 0, 0, insertBoth | insertBWithAProtoAsDeny},
+		{"deny-allow: a superset a L4, b L3-only", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 6, 0, 0, insertAllowAll | insertBoth | insertBWithAProtoAsDeny},
+		{"deny-allow: a superset a L4, b L3-only; without allow-all", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 6, 0, 0, insertBoth | insertBWithAProtoAsDeny},
 
-		{"deny-allow: b superset a L4, b L3-only", WithAllowAll, worldIPID, worldSubnetID, true, false, 0, 6, 0, 0, insertAllowAll | insertBoth},
-		{"deny-allow: b superset a L4, b L3-only; without allow-all", WithoutAllowAll, worldIPID, worldSubnetID, true, false, 0, 6, 0, 0, insertBoth},
+		{"deny-allow: b superset a L4, b L3-only", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 6, 0, 0, insertAllowAll | insertBoth},
+		{"deny-allow: b superset a L4, b L3-only; without allow-all", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 6, 0, 0, insertBoth},
 
-		{"deny-allow: a superset a L4, b L4; subset allow inserted as deny", WithAllowAll, reservedWorldID, worldSubnetID, true, false, 0, 6, 0, 6, insertAllowAll | insertA | insertBasDeny},
-		{"deny-allow: a superset a L4, b L4; without allow-all, subset allow inserted as deny", WithoutAllowAll, reservedWorldID, worldSubnetID, true, false, 0, 6, 0, 6, insertA | insertBasDeny},
+		{"deny-allow: a superset a L4, b L4; subset allow inserted as deny", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 6, 0, 6, insertAllowAll | insertA | insertBasDeny},
+		{"deny-allow: a superset a L4, b L4; without allow-all, subset allow inserted as deny", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 6, 0, 6, insertA | insertBasDeny},
 
-		{"deny-allow: b superset a L4, b L4", WithAllowAll, worldIPID, worldSubnetID, true, false, 0, 6, 0, 6, insertAllowAll | insertBoth},
-		{"deny-allow: b superset a L4, b L4; without allow-all", WithoutAllowAll, worldIPID, worldSubnetID, true, false, 0, 6, 0, 6, insertBoth},
+		{"deny-allow: b superset a L4, b L4", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 6, 0, 6, insertAllowAll | insertBoth},
+		{"deny-allow: b superset a L4, b L4; without allow-all", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 6, 0, 6, insertBoth},
 
-		{"deny-allow: a superset a L4, b L3L4; subset allow inserted as deny", WithAllowAll, reservedWorldID, worldSubnetID, true, false, 0, 6, 80, 6, insertAllowAll | insertA | insertBasDeny},
-		{"deny-allow: a superset a L4, b L3L4; without allow-all, subset allow inserted as deny", WithoutAllowAll, reservedWorldID, worldSubnetID, true, false, 0, 6, 80, 6, insertA | insertBasDeny},
+		{"deny-allow: a superset a L4, b L3L4; subset allow inserted as deny", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 6, 80, 6, insertAllowAll | insertA | insertBasDeny},
+		{"deny-allow: a superset a L4, b L3L4; without allow-all, subset allow inserted as deny", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 6, 80, 6, insertA | insertBasDeny},
 
-		{"deny-allow: b superset a L4, b L3L4", WithAllowAll, worldIPID, worldSubnetID, true, false, 0, 6, 80, 6, insertAllowAll | insertBoth | insertAWithBProto},
-		{"deny-allow: b superset a L4, b L3L4; without allow-all", WithoutAllowAll, worldIPID, worldSubnetID, true, false, 0, 6, 80, 6, insertBoth | insertAWithBProto},
+		{"deny-allow: b superset a L4, b L3L4", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 6, 80, 6, insertAllowAll | insertBoth | insertAWithBProto},
+		{"deny-allow: b superset a L4, b L3L4; without allow-all", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 6, 80, 6, insertBoth | insertAWithBProto},
 
-		{"deny-allow: a superset a L3L4, b L3-only", WithAllowAll, reservedWorldID, worldSubnetID, true, false, 80, 6, 0, 0, insertAllowAll | insertBoth | insertBWithAProtoAsDeny},
-		{"deny-allow: a superset a L3L4, b L3-only; without allow-all", WithoutAllowAll, reservedWorldID, worldSubnetID, true, false, 80, 6, 0, 0, insertBoth | insertBWithAProtoAsDeny},
+		{"deny-allow: a superset a L3L4, b L3-only", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 80, 6, 0, 0, insertAllowAll | insertBoth | insertBWithAProtoAsDeny},
+		{"deny-allow: a superset a L3L4, b L3-only; without allow-all", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 80, 6, 0, 0, insertBoth | insertBWithAProtoAsDeny},
 
-		{"deny-allow: b superset a L3L4, b L3-only", WithAllowAll, worldIPID, worldSubnetID, true, false, 80, 6, 0, 0, insertAllowAll | insertBoth},
-		{"deny-allow: b superset a L3L4, b L3-only; without allow-all", WithoutAllowAll, worldIPID, worldSubnetID, true, false, 80, 6, 0, 0, insertBoth},
+		{"deny-allow: b superset a L3L4, b L3-only", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 80, 6, 0, 0, insertAllowAll | insertBoth},
+		{"deny-allow: b superset a L3L4, b L3-only; without allow-all", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 80, 6, 0, 0, insertBoth},
 
-		{"deny-allow: a superset a L3L4, b L4", WithAllowAll, reservedWorldID, worldSubnetID, true, false, 80, 6, 0, 6, insertAllowAll | insertBoth | insertBWithAProtoAsDeny},
-		{"deny-allow: a superset a L3L4, b L4; without allow-all", WithoutAllowAll, reservedWorldID, worldSubnetID, true, false, 80, 6, 0, 6, insertBoth | insertBWithAProtoAsDeny},
+		{"deny-allow: a superset a L3L4, b L4", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 80, 6, 0, 6, insertAllowAll | insertBoth | insertBWithAProtoAsDeny},
+		{"deny-allow: a superset a L3L4, b L4; without allow-all", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 80, 6, 0, 6, insertBoth | insertBWithAProtoAsDeny},
 
-		{"deny-allow: b superset a L3L4, b L4", WithAllowAll, worldIPID, worldSubnetID, true, false, 80, 6, 0, 6, insertAllowAll | insertBoth},
-		{"deny-allow: b superset a L3L4, b L4 without allow-all", WithoutAllowAll, worldIPID, worldSubnetID, true, false, 80, 6, 0, 6, insertBoth},
+		{"deny-allow: b superset a L3L4, b L4", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 80, 6, 0, 6, insertAllowAll | insertBoth},
+		{"deny-allow: b superset a L3L4, b L4 without allow-all", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 80, 6, 0, 6, insertBoth},
 
-		{"deny-allow: a superset a L3L4, b L3L4", WithAllowAll, reservedWorldID, worldSubnetID, true, false, 80, 6, 80, 6, insertAllowAll | insertA | insertBasDeny},
-		{"deny-allow: a superset a L3L4, b L3L4 without allow-all", WithoutAllowAll, reservedWorldID, worldSubnetID, true, false, 80, 6, 80, 6, insertA | insertBasDeny},
+		{"deny-allow: a superset a L3L4, b L3L4", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 80, 6, 80, 6, insertAllowAll | insertA | insertBasDeny},
+		{"deny-allow: a superset a L3L4, b L3L4 without allow-all", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 80, 6, 80, 6, insertA | insertBasDeny},
 
-		{"deny-allow: b superset a L3L4, b L3L4", WithAllowAll, worldIPID, worldSubnetID, true, false, 80, 6, 80, 6, insertAllowAll | insertBoth},
-		{"deny-allow: b superset a L3L4, b L3L4; without allow-all", WithoutAllowAll, worldIPID, worldSubnetID, true, false, 80, 6, 80, 6, insertBoth},
+		{"deny-allow: b superset a L3L4, b L3L4", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 80, 6, 80, 6, insertAllowAll | insertBoth},
+		{"deny-allow: b superset a L3L4, b L3L4; without allow-all", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 80, 6, 80, 6, insertBoth},
 
 		// deny-deny insertions: Note: There is no dedundancy between different non-zero security IDs on the
 		// datapath, even if one would be a CIDR subset of another. Situation would be different if we could
 		// completely remove (or not add in the first place) the redundant ID from the ipcache so that
 		// datapath could never assign that ID to a packet for policy enforcement.
 		// These test case are left here for such future improvement.
-		{"deny-deny: a superset a|b L3-only", WithAllowAll, worldSubnetID, worldIPID, true, true, 0, 0, 0, 0, insertAllowAll | insertBoth},
-		{"deny-deny: a superset a|b L3-only; without allow-all", WithoutAllowAll, worldSubnetID, worldIPID, true, true, 0, 0, 0, 0, insertBoth},
+		{"deny-deny: a superset a|b L3-only", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 0, 0, 0, insertAllowAll | insertBoth},
+		{"deny-deny: a superset a|b L3-only; without allow-all", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 0, 0, 0, insertBoth},
 
-		{"deny-deny: b superset a|b L3-only", WithAllowAll, worldSubnetID, reservedWorldID, true, true, 0, 0, 0, 0, insertAllowAll | insertBoth},
-		{"deny-deny: b superset a|b L3-only; without allow-all", WithoutAllowAll, worldSubnetID, reservedWorldID, true, true, 0, 0, 0, 0, insertBoth},
+		{"deny-deny: b superset a|b L3-only", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 0, 0, 0, insertAllowAll | insertBoth},
+		{"deny-deny: b superset a|b L3-only; without allow-all", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 0, 0, 0, insertBoth},
 
-		{"deny-deny: a superset a L3-only, b L4", WithAllowAll, worldSubnetID, worldIPID, true, true, 0, 0, 0, 6, insertAllowAll | insertBoth},
-		{"deny-deny: a superset a L3-only, b L4", WithoutAllowAll, worldSubnetID, worldIPID, true, true, 0, 0, 0, 6, insertBoth},
+		{"deny-deny: a superset a L3-only, b L4", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 0, 0, 6, insertAllowAll | insertBoth},
+		{"deny-deny: a superset a L3-only, b L4", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 0, 0, 6, insertBoth},
 
-		{"deny-deny: b superset a L3-only, b L4", WithAllowAll, worldSubnetID, reservedWorldID, true, true, 0, 0, 0, 6, insertAllowAll | insertBoth},
-		{"deny-deny: b superset a L3-only, b L4", WithoutAllowAll, worldSubnetID, reservedWorldID, true, true, 0, 0, 0, 6, insertBoth},
+		{"deny-deny: b superset a L3-only, b L4", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 0, 0, 6, insertAllowAll | insertBoth},
+		{"deny-deny: b superset a L3-only, b L4", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 0, 0, 6, insertBoth},
 
-		{"deny-deny: a superset a L3-only, b L3L4", WithAllowAll, worldSubnetID, worldIPID, true, true, 0, 0, 80, 6, insertAllowAll | insertBoth},
-		{"deny-deny: a superset a L3-only, b L3L4", WithoutAllowAll, worldSubnetID, worldIPID, true, true, 0, 0, 80, 6, insertBoth},
+		{"deny-deny: a superset a L3-only, b L3L4", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 0, 80, 6, insertAllowAll | insertBoth},
+		{"deny-deny: a superset a L3-only, b L3L4", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 0, 80, 6, insertBoth},
 
-		{"deny-deny: b superset a L3-only, b L3L4", WithAllowAll, worldSubnetID, reservedWorldID, true, true, 0, 0, 80, 6, insertAllowAll | insertBoth},
-		{"deny-deny: b superset a L3-only, b L3L4", WithoutAllowAll, worldSubnetID, reservedWorldID, true, true, 0, 0, 80, 6, insertBoth},
+		{"deny-deny: b superset a L3-only, b L3L4", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 0, 80, 6, insertAllowAll | insertBoth},
+		{"deny-deny: b superset a L3-only, b L3L4", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 0, 80, 6, insertBoth},
 
-		{"deny-deny: a superset a L4, b L3-only", WithAllowAll, worldSubnetID, worldIPID, true, true, 0, 6, 0, 0, insertAllowAll | insertBoth},
-		{"deny-deny: a superset a L4, b L3-only", WithoutAllowAll, worldSubnetID, worldIPID, true, true, 0, 6, 0, 0, insertBoth},
+		{"deny-deny: a superset a L4, b L3-only", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 6, 0, 0, insertAllowAll | insertBoth},
+		{"deny-deny: a superset a L4, b L3-only", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 6, 0, 0, insertBoth},
 
-		{"deny-deny: b superset a L4, b L3-only", WithAllowAll, worldSubnetID, reservedWorldID, true, true, 0, 6, 0, 0, insertAllowAll | insertBoth},
-		{"deny-deny: b superset a L4, b L3-only", WithoutAllowAll, worldSubnetID, reservedWorldID, true, true, 0, 6, 0, 0, insertBoth},
+		{"deny-deny: b superset a L4, b L3-only", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 6, 0, 0, insertAllowAll | insertBoth},
+		{"deny-deny: b superset a L4, b L3-only", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 6, 0, 0, insertBoth},
 
-		{"deny-deny: a superset a L4, b L4", WithAllowAll, worldSubnetID, worldIPID, true, true, 0, 6, 0, 6, insertAllowAll | insertBoth},
-		{"deny-deny: a superset a L4, b L4", WithoutAllowAll, worldSubnetID, worldIPID, true, true, 0, 6, 0, 6, insertBoth},
+		{"deny-deny: a superset a L4, b L4", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 6, 0, 6, insertAllowAll | insertBoth},
+		{"deny-deny: a superset a L4, b L4", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 6, 0, 6, insertBoth},
 
-		{"deny-deny: b superset a L4, b L4", WithAllowAll, worldSubnetID, reservedWorldID, true, true, 0, 6, 0, 6, insertAllowAll | insertBoth},
-		{"deny-deny: b superset a L4, b L4", WithoutAllowAll, worldSubnetID, reservedWorldID, true, true, 0, 6, 0, 6, insertBoth},
+		{"deny-deny: b superset a L4, b L4", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 6, 0, 6, insertAllowAll | insertBoth},
+		{"deny-deny: b superset a L4, b L4", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 6, 0, 6, insertBoth},
 
-		{"deny-deny: a superset a L4, b L3L4", WithAllowAll, worldSubnetID, worldIPID, true, true, 0, 6, 80, 6, insertAllowAll | insertBoth},
-		{"deny-deny: a superset a L4, b L3L4", WithoutAllowAll, worldSubnetID, worldIPID, true, true, 0, 6, 80, 6, insertBoth},
+		{"deny-deny: a superset a L4, b L3L4", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 6, 80, 6, insertAllowAll | insertBoth},
+		{"deny-deny: a superset a L4, b L3L4", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 6, 80, 6, insertBoth},
 
-		{"deny-deny: b superset a L4, b L3L4", WithAllowAll, worldSubnetID, reservedWorldID, true, true, 0, 6, 80, 6, insertAllowAll | insertBoth},
-		{"deny-deny: b superset a L4, b L3L4", WithoutAllowAll, worldSubnetID, reservedWorldID, true, true, 0, 6, 80, 6, insertBoth},
+		{"deny-deny: b superset a L4, b L3L4", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 6, 80, 6, insertAllowAll | insertBoth},
+		{"deny-deny: b superset a L4, b L3L4", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 6, 80, 6, insertBoth},
 
-		{"deny-deny: a superset a L3L4, b L3-only", WithAllowAll, worldSubnetID, worldIPID, true, true, 80, 6, 0, 0, insertAllowAll | insertBoth},
-		{"deny-deny: a superset a L3L4, b L3-only", WithoutAllowAll, worldSubnetID, worldIPID, true, true, 80, 6, 0, 0, insertBoth},
+		{"deny-deny: a superset a L3L4, b L3-only", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 80, 6, 0, 0, insertAllowAll | insertBoth},
+		{"deny-deny: a superset a L3L4, b L3-only", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 80, 6, 0, 0, insertBoth},
 
-		{"deny-deny: b superset a L3L4, b L3-only", WithAllowAll, worldSubnetID, reservedWorldID, true, true, 80, 6, 0, 0, insertAllowAll | insertBoth},
-		{"deny-deny: b superset a L3L4, b L3-only", WithoutAllowAll, worldSubnetID, reservedWorldID, true, true, 80, 6, 0, 0, insertBoth},
+		{"deny-deny: b superset a L3L4, b L3-only", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 80, 6, 0, 0, insertAllowAll | insertBoth},
+		{"deny-deny: b superset a L3L4, b L3-only", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 80, 6, 0, 0, insertBoth},
 
-		{"deny-deny: a superset a L3L4, b L4", WithAllowAll, worldSubnetID, worldIPID, true, true, 80, 6, 0, 6, insertAllowAll | insertBoth},
-		{"deny-deny: a superset a L3L4, b L4", WithoutAllowAll, worldSubnetID, worldIPID, true, true, 80, 6, 0, 6, insertBoth},
+		{"deny-deny: a superset a L3L4, b L4", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 80, 6, 0, 6, insertAllowAll | insertBoth},
+		{"deny-deny: a superset a L3L4, b L4", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 80, 6, 0, 6, insertBoth},
 
-		{"deny-deny: b superset a L3L4, b L4", WithAllowAll, worldSubnetID, reservedWorldID, true, true, 80, 6, 0, 6, insertAllowAll | insertBoth},
-		{"deny-deny: b superset a L3L4, b L4", WithoutAllowAll, worldSubnetID, reservedWorldID, true, true, 80, 6, 0, 6, insertBoth},
+		{"deny-deny: b superset a L3L4, b L4", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 80, 6, 0, 6, insertAllowAll | insertBoth},
+		{"deny-deny: b superset a L3L4, b L4", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 80, 6, 0, 6, insertBoth},
 
-		{"deny-deny: a superset a L3L4, b L3L4", WithAllowAll, worldSubnetID, worldIPID, true, true, 80, 6, 80, 6, insertAllowAll | insertBoth},
-		{"deny-deny: a superset a L3L4, b L3L4", WithoutAllowAll, worldSubnetID, worldIPID, true, true, 80, 6, 80, 6, insertBoth},
+		{"deny-deny: a superset a L3L4, b L3L4", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 80, 6, 80, 6, insertAllowAll | insertBoth},
+		{"deny-deny: a superset a L3L4, b L3L4", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 80, 6, 80, 6, insertBoth},
 
-		{"deny-deny: b superset a L3L4, b L3L4", WithAllowAll, worldSubnetID, reservedWorldID, true, true, 80, 6, 80, 6, insertAllowAll | insertBoth},
-		{"deny-deny: b superset a L3L4, b L3L4", WithoutAllowAll, worldSubnetID, reservedWorldID, true, true, 80, 6, 80, 6, insertBoth},
+		{"deny-deny: b superset a L3L4, b L3L4", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 80, 6, 80, 6, insertAllowAll | insertBoth},
+		{"deny-deny: b superset a L3L4, b L3L4", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 80, 6, 80, 6, insertBoth},
 
 		// allow-allow insertions do not need tests as their affect on one another does not matter.
 	}

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -2792,11 +2792,19 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		worldSubnetIdentity:            lblWorldSubnet.LabelArray(), // "192.0.2.0/24"
 	}
 
-	reservedWorldSelections := identity.ReservedIdentityWorld
-	worldIPSelections := worldIPIdentity
-	worldSubnetSelections := worldSubnetIdentity
+	// Mock the identities what would be selected by the world, IP, and subnet selectors
+
+	// Selections for the label selector 'reserved:world'
+	reservedWorldSelections := identity.NumericIdentitySlice{identity.ReservedIdentityWorld, worldIPIdentity, worldSubnetIdentity}
+
+	// Selections for the CIDR selector 'cidr:192.0.2.3/32'
+	worldIPSelections := identity.NumericIdentitySlice{worldIPIdentity}
+
+	// Selections for the CIDR selector 'cidr:192.0.2.0/24'
+	worldSubnetSelections := identity.NumericIdentitySlice{worldSubnetIdentity, worldIPIdentity}
+
 	selectorCache := testNewSelectorCache(identityCache)
-	type action uint16
+	type action uint32
 	const (
 		noAction       = action(iota)
 		insertAllowAll = action(1 << iota)
@@ -2808,6 +2816,13 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		insertBWithAProtoAsDeny
 		insertAasDeny
 		insertBasDeny
+		worldIPl3only        // Do not expect L4 keys for IP covered by a subnet
+		worldIPProtoOnly     // Do not expect port keys for IP covered by a subnet
+		worldSubnetl3only    // Do not expect L4 keys for IP subnet
+		worldSubnetProtoOnly // Do not expect port keys for IP subnet
+		insertDenyWorld
+		insertDenyWorldTCP
+		insertDenyWorldHTTP
 		insertBoth = insertA | insertB
 	)
 
@@ -2819,15 +2834,16 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 
 	// these tests are based on the sheet https://docs.google.com/spreadsheets/d/1WANIoZGB48nryylQjjOw6lKjI80eVgPShrdMTMalLEw#gid=2109052536
 	tests := []struct {
-		name                 string
-		withAllowAll         withAllowAll
-		aIdentity, bIdentity identity.NumericIdentity
-		aIsDeny, bIsDeny     bool
-		aPort                uint16
-		aProto               u8proto.U8proto
-		bPort                uint16
-		bProto               u8proto.U8proto
-		outcome              action
+		name             string
+		withAllowAll     withAllowAll
+		aIdentities      identity.NumericIdentitySlice
+		bIdentities      identity.NumericIdentitySlice
+		aIsDeny, bIsDeny bool
+		aPort            uint16
+		aProto           u8proto.U8proto
+		bPort            uint16
+		bProto           u8proto.U8proto
+		outcome          action
 	}{
 		// deny-allow insertions
 		{"deny-allow: a superset a|b L3-only; subset allow inserted as deny", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 0, 0, 0, insertAllowAll | insertA | insertBasDeny},
@@ -2836,14 +2852,14 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		{"deny-allow: b superset a|b L3-only", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 0, 0, 0, insertAllowAll | insertBoth},
 		{"deny-allow: b superset a|b L3-only; without allow-all", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 0, 0, 0, insertBoth},
 
-		{"deny-allow: a superset a L3-only, b L4; subset allow inserted as deny", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 0, 0, 6, insertAllowAll | insertA | insertBasDeny},
-		{"deny-allow: a superset a L3-only, b L4; without allow-all, subset allow inserted as deny", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 0, 0, 6, insertA | insertBasDeny},
+		{"deny-allow: a superset a L3-only, b L4; subset allow inserted as deny", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 0, 0, 6, insertAllowAll | insertA},
+		{"deny-allow: a superset a L3-only, b L4; without allow-all, subset allow inserted as deny", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 0, 0, 6, insertA},
 
 		{"deny-allow: b superset a L3-only, b L4", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 0, 0, 6, insertAllowAll | insertBoth | insertAWithBProto},
 		{"deny-allow: b superset a L3-only, b L4; without allow-all, added deny TCP due to intersecting deny", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 0, 0, 6, insertBoth | insertAWithBProto},
 
-		{"deny-allow: a superset a L3-only, b L3L4; subset allow inserted as deny", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 0, 80, 6, insertAllowAll | insertA | insertBasDeny},
-		{"deny-allow: a superset a L3-only, b L3L4; without allow-all, subset allow inserted as deny", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 0, 80, 6, insertA | insertBasDeny},
+		{"deny-allow: a superset a L3-only, b L3L4; subset allow not inserted", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 0, 80, 6, insertAllowAll | insertA},
+		{"deny-allow: a superset a L3-only, b L3L4; without allow-all, subset allow not inserted", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 0, 80, 6, insertA},
 
 		{"deny-allow: b superset a L3-only, b L3L4; added deny TCP/80 due to intersecting deny", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 0, 80, 6, insertAllowAll | insertBoth | insertAWithBProto},
 		{"deny-allow: b superset a L3-only, b L3L4; without allow-all, added deny TCP/80 due to intersecting deny", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 0, 80, 6, insertBoth | insertAWithBProto},
@@ -2860,8 +2876,8 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		{"deny-allow: b superset a L4, b L4", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 6, 0, 6, insertAllowAll | insertBoth},
 		{"deny-allow: b superset a L4, b L4; without allow-all", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 6, 0, 6, insertBoth},
 
-		{"deny-allow: a superset a L4, b L3L4; subset allow inserted as deny", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 6, 80, 6, insertAllowAll | insertA | insertBasDeny},
-		{"deny-allow: a superset a L4, b L3L4; without allow-all, subset allow inserted as deny", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 6, 80, 6, insertA | insertBasDeny},
+		{"deny-allow: a superset a L4, b L3L4; subset allow not inserted", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 6, 80, 6, insertAllowAll | insertA},
+		{"deny-allow: a superset a L4, b L3L4; without allow-all, subset allow not inserted", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 6, 80, 6, insertA},
 
 		{"deny-allow: b superset a L4, b L3L4", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 6, 80, 6, insertAllowAll | insertBoth | insertAWithBProto},
 		{"deny-allow: b superset a L4, b L3L4; without allow-all", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 6, 80, 6, insertBoth | insertAWithBProto},
@@ -2895,23 +2911,23 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		{"deny-deny: b superset a|b L3-only", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 0, 0, 0, insertAllowAll | insertBoth},
 		{"deny-deny: b superset a|b L3-only; without allow-all", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 0, 0, 0, insertBoth},
 
-		{"deny-deny: a superset a L3-only, b L4", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 0, 0, 6, insertAllowAll | insertBoth},
-		{"deny-deny: a superset a L3-only, b L4", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 0, 0, 6, insertBoth},
+		{"deny-deny: a superset a L3-only, b L4", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 0, 0, 6, insertAllowAll | insertA},
+		{"deny-deny: a superset a L3-only, b L4; without allow-all", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 0, 0, 6, insertA},
 
-		{"deny-deny: b superset a L3-only, b L4", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 0, 0, 6, insertAllowAll | insertBoth},
-		{"deny-deny: b superset a L3-only, b L4", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 0, 0, 6, insertBoth},
+		{"deny-deny: b superset a L3-only, b L4", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 0, 0, 6, insertAllowAll | insertBoth | worldIPl3only | worldSubnetl3only},
+		{"deny-deny: b superset a L3-only, b L4; without allow-all", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 0, 0, 6, insertBoth | worldIPl3only | worldSubnetl3only},
 
-		{"deny-deny: a superset a L3-only, b L3L4", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 0, 80, 6, insertAllowAll | insertBoth},
-		{"deny-deny: a superset a L3-only, b L3L4", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 0, 80, 6, insertBoth},
+		{"deny-deny: a superset a L3-only, b L3L4", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 0, 80, 6, insertAllowAll | insertA},
+		{"deny-deny: a superset a L3-only, b L3L4; without allow-all", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 0, 80, 6, insertA},
 
-		{"deny-deny: b superset a L3-only, b L3L4", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 0, 80, 6, insertAllowAll | insertBoth},
-		{"deny-deny: b superset a L3-only, b L3L4", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 0, 80, 6, insertBoth},
+		{"deny-deny: b superset a L3-only, b L3L4", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 0, 80, 6, insertAllowAll | insertBoth | worldIPl3only | worldSubnetl3only},
+		{"deny-deny: b superset a L3-only, b L3L4; without allow-all", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 0, 80, 6, insertBoth | worldIPl3only | worldSubnetl3only},
 
-		{"deny-deny: a superset a L4, b L3-only", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 6, 0, 0, insertAllowAll | insertBoth},
-		{"deny-deny: a superset a L4, b L3-only", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 6, 0, 0, insertBoth},
+		{"deny-deny: a superset a L4, b L3-only", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 6, 0, 0, insertAllowAll | insertBoth | worldIPl3only},
+		{"deny-deny: a superset a L4, b L3-only; without allow-all", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 6, 0, 0, insertBoth | worldIPl3only},
 
-		{"deny-deny: b superset a L4, b L3-only", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 6, 0, 0, insertAllowAll | insertBoth},
-		{"deny-deny: b superset a L4, b L3-only", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 6, 0, 0, insertBoth},
+		{"deny-deny: b superset a L4, b L3-only", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 6, 0, 0, insertAllowAll | insertBoth | worldIPl3only | worldSubnetl3only},
+		{"deny-deny: b superset a L4, b L3-only; without allow-all", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 6, 0, 0, insertBoth | worldIPl3only | worldSubnetl3only},
 
 		{"deny-deny: a superset a L4, b L4", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 6, 0, 6, insertAllowAll | insertBoth},
 		{"deny-deny: a superset a L4, b L4", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 6, 0, 6, insertBoth},
@@ -2919,23 +2935,23 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		{"deny-deny: b superset a L4, b L4", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 6, 0, 6, insertAllowAll | insertBoth},
 		{"deny-deny: b superset a L4, b L4", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 6, 0, 6, insertBoth},
 
-		{"deny-deny: a superset a L4, b L3L4", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 6, 80, 6, insertAllowAll | insertBoth},
-		{"deny-deny: a superset a L4, b L3L4", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 6, 80, 6, insertBoth},
+		{"deny-deny: a superset a L4, b L3L4", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 6, 80, 6, insertAllowAll | insertBoth | worldIPProtoOnly},
+		{"deny-deny: a superset a L4, b L3L4; without allow-all", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 0, 6, 80, 6, insertBoth | worldIPProtoOnly},
 
-		{"deny-deny: b superset a L4, b L3L4", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 6, 80, 6, insertAllowAll | insertBoth},
-		{"deny-deny: b superset a L4, b L3L4", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 6, 80, 6, insertBoth},
+		{"deny-deny: b superset a L4, b L3L4", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 6, 80, 6, insertAllowAll | insertBoth | worldIPProtoOnly | worldSubnetProtoOnly},
+		{"deny-deny: b superset a L4, b L3L4; without allow-all", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 0, 6, 80, 6, insertBoth | worldIPProtoOnly | worldSubnetProtoOnly},
 
-		{"deny-deny: a superset a L3L4, b L3-only", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 80, 6, 0, 0, insertAllowAll | insertBoth},
-		{"deny-deny: a superset a L3L4, b L3-only", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 80, 6, 0, 0, insertBoth},
+		{"deny-deny: a superset a L3L4, b L3-only", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 80, 6, 0, 0, insertAllowAll | insertBoth | worldIPl3only},
+		{"deny-deny: a superset a L3L4, b L3-only; without allow-all", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 80, 6, 0, 0, insertBoth | worldIPl3only},
 
-		{"deny-deny: b superset a L3L4, b L3-only", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 80, 6, 0, 0, insertAllowAll | insertBoth},
-		{"deny-deny: b superset a L3L4, b L3-only", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 80, 6, 0, 0, insertBoth},
+		{"deny-deny: b superset a L3L4, b L3-only", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 80, 6, 0, 0, insertAllowAll | insertBoth | worldIPl3only | worldSubnetl3only},
+		{"deny-deny: b superset a L3L4, b L3-only; without allow-all", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 80, 6, 0, 0, insertBoth | worldIPl3only | worldSubnetl3only},
 
-		{"deny-deny: a superset a L3L4, b L4", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 80, 6, 0, 6, insertAllowAll | insertBoth},
-		{"deny-deny: a superset a L3L4, b L4", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 80, 6, 0, 6, insertBoth},
+		{"deny-deny: a superset a L3L4, b L4", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 80, 6, 0, 6, insertAllowAll | insertBoth | worldIPProtoOnly},
+		{"deny-deny: a superset a L3L4, b L4; without allow-all", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 80, 6, 0, 6, insertBoth | worldIPProtoOnly},
 
-		{"deny-deny: b superset a L3L4, b L4", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 80, 6, 0, 6, insertAllowAll | insertBoth},
-		{"deny-deny: b superset a L3L4, b L4", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 80, 6, 0, 6, insertBoth},
+		{"deny-deny: b superset a L3L4, b L4", WithAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 80, 6, 0, 6, insertAllowAll | insertBoth | worldIPProtoOnly | worldSubnetProtoOnly},
+		{"deny-deny: b superset a L3L4, b L4; without allow-all", WithoutAllowAll, worldSubnetSelections, reservedWorldSelections, true, true, 80, 6, 0, 6, insertBoth | worldIPProtoOnly | worldSubnetProtoOnly},
 
 		{"deny-deny: a superset a L3L4, b L3L4", WithAllowAll, worldSubnetSelections, worldIPSelections, true, true, 80, 6, 80, 6, insertAllowAll | insertBoth},
 		{"deny-deny: a superset a L3L4, b L3L4", WithoutAllowAll, worldSubnetSelections, worldIPSelections, true, true, 80, 6, 80, 6, insertBoth},
@@ -2948,78 +2964,199 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 	for _, tt := range tests {
 		anyIngressKey := IngressKey()
 		allowEntry := MapStateEntry{}
-		aKey := IngressKey().WithIdentity(tt.aIdentity).WithPortProto(tt.aProto, tt.aPort)
+		var aKeys []Key
+		for _, idA := range tt.aIdentities {
+			if tt.outcome&worldIPl3only > 0 && idA == worldIPIdentity &&
+				(tt.aProto != 0 || tt.aPort != 0) {
+				continue
+			}
+			if tt.outcome&worldIPProtoOnly > 0 && idA == worldIPIdentity &&
+				tt.aPort != 0 {
+				continue
+			}
+			if tt.outcome&worldSubnetl3only > 0 && idA == worldSubnetIdentity &&
+				(tt.aProto != 0 || tt.aPort != 0) {
+				continue
+			}
+			if tt.outcome&worldSubnetProtoOnly > 0 && idA == worldSubnetIdentity &&
+				tt.aPort != 0 {
+				continue
+			}
+			aKeys = append(aKeys, IngressKey().WithIdentity(idA).WithPortProto(tt.aProto, tt.aPort))
+		}
 		aEntry := MapStateEntry{IsDeny: tt.aIsDeny}
-		bKey := IngressKey().WithIdentity(tt.bIdentity).WithPortProto(tt.bProto, tt.bPort)
+		var bKeys []Key
+		for _, idB := range tt.bIdentities {
+			if tt.outcome&worldIPl3only > 0 && idB == worldIPIdentity &&
+				(tt.bProto != 0 || tt.bPort != 0) {
+				continue
+			}
+			if tt.outcome&worldIPProtoOnly > 0 && idB == worldIPIdentity &&
+				tt.bPort != 0 {
+				continue
+			}
+			if tt.outcome&worldSubnetl3only > 0 && idB == worldSubnetIdentity &&
+				(tt.bProto != 0 || tt.bPort != 0) {
+				continue
+			}
+			if tt.outcome&worldSubnetProtoOnly > 0 && idB == worldSubnetIdentity &&
+				tt.bPort != 0 {
+				continue
+			}
+			bKeys = append(bKeys, IngressKey().WithIdentity(idB).WithPortProto(tt.bProto, tt.bPort))
+		}
 		bEntry := MapStateEntry{IsDeny: tt.bIsDeny}
 		expectedKeys := newMapState()
 		if tt.outcome&insertAllowAll > 0 {
-			expectedKeys.allows.upsert(anyIngressKey, allowEntry, selectorCache)
+			expectedKeys.insert(anyIngressKey, allowEntry, selectorCache)
 		}
-		if tt.outcome&insertA > 0 {
-			if tt.aIsDeny {
-				expectedKeys.denies.upsert(aKey, aEntry, selectorCache)
-			} else {
-				expectedKeys.allows.upsert(aKey, aEntry, selectorCache)
-			}
-		}
-		if tt.outcome&insertAasDeny > 0 {
-			expectedKeys.denies.upsert(aKey, aEntry.asDeny(), selectorCache)
-		}
+		// insert allow expectations before deny expectations to manage overlap
 		if tt.outcome&insertB > 0 {
-			if tt.bIsDeny {
-				expectedKeys.denies.upsert(bKey, bEntry, selectorCache)
-			} else {
-				expectedKeys.allows.upsert(bKey, bEntry, selectorCache)
-			}
-		}
-		if tt.outcome&insertBasDeny > 0 {
-			expectedKeys.denies.upsert(bKey, bEntry.asDeny(), selectorCache)
-		}
-		if tt.outcome&insertAWithBProto > 0 {
-			aKeyWithBProto := IngressKey().WithIdentity(tt.aIdentity).WithPortProto(tt.bProto, tt.bPort)
-			aEntryCpy := MapStateEntry{IsDeny: tt.aIsDeny}
-			aEntryCpy.owners = map[MapStateOwner]struct{}{aKey: {}}
-			aEntryWithDep := aEntry.WithDependents(aKeyWithBProto)
-			if tt.aIsDeny {
-				expectedKeys.denies.upsert(aKey, aEntryWithDep, selectorCache)
-				expectedKeys.denies.upsert(aKeyWithBProto, aEntryCpy, selectorCache)
-			} else {
-				expectedKeys.allows.upsert(aKey, aEntryWithDep, selectorCache)
-				expectedKeys.allows.upsert(aKeyWithBProto, aEntryCpy, selectorCache)
+			for _, bKey := range bKeys {
+				expectedKeys.insert(bKey, bEntry, selectorCache)
 			}
 		}
 		if tt.outcome&insertAasB > 0 {
-			aKeyWithBProto := IngressKey().WithIdentity(tt.aIdentity).WithPortProto(tt.bProto, tt.bPort)
-			bEntryWithOwner := bEntry.WithOwners(bKey)
-			bEntryWithDep := bEntry.WithDependents(aKeyWithBProto)
-			if tt.bIsDeny {
-				expectedKeys.denies.upsert(bKey, bEntryWithDep, selectorCache)
-				expectedKeys.denies.upsert(aKeyWithBProto, bEntryWithOwner, selectorCache)
-			} else {
-				expectedKeys.allows.upsert(bKey, bEntryWithDep, selectorCache)
-				expectedKeys.allows.upsert(aKeyWithBProto, bEntryWithOwner, selectorCache)
+			for _, bKey := range bKeys {
+				for _, idA := range tt.aIdentities {
+					if tt.outcome&worldIPl3only > 0 && idA == worldIPIdentity &&
+						(tt.bProto != 0 || tt.bPort != 0) {
+						continue
+					}
+					if tt.outcome&worldIPProtoOnly > 0 && idA == worldIPIdentity &&
+						(tt.bPort != 0) {
+						continue
+					}
+					if tt.outcome&worldSubnetl3only > 0 && idA == worldSubnetIdentity &&
+						(tt.bProto != 0 || tt.bPort != 0) {
+						continue
+					}
+					if tt.outcome&worldSubnetProtoOnly > 0 && idA == worldSubnetIdentity &&
+						(tt.bPort != 0) {
+						continue
+					}
+					aKeyWithBProto := IngressKey().WithIdentity(idA).WithPortProto(tt.bProto, tt.bPort)
+					bEntryWithOwner := bEntry.WithOwners(bKey)
+					bEntryWithDep := bEntry.WithDependents(aKeyWithBProto)
+
+					expectedKeys.insert(bKey, bEntryWithDep, selectorCache)
+					expectedKeys.insert(aKeyWithBProto, bEntryWithOwner, selectorCache)
+				}
 			}
 		}
 		if tt.outcome&insertBWithAProto > 0 {
-			bKeyWithBProto := IngressKey().WithIdentity(tt.bIdentity).WithPortProto(tt.aProto, tt.aPort)
-			bEntryCpy := MapStateEntry{IsDeny: tt.bIsDeny}
-			bEntryCpy.owners = map[MapStateOwner]struct{}{bKey: {}}
-			bEntryWithDep := bEntry.WithDependents(bKeyWithBProto)
-			if tt.bIsDeny {
-				expectedKeys.denies.upsert(bKey, bEntryWithDep, selectorCache)
-				expectedKeys.denies.upsert(bKeyWithBProto, bEntryCpy, selectorCache)
-			} else {
-				expectedKeys.allows.upsert(bKey, bEntryWithDep, selectorCache)
-				expectedKeys.allows.upsert(bKeyWithBProto, bEntryCpy, selectorCache)
+			for _, idB := range tt.bIdentities {
+				if tt.outcome&worldIPl3only > 0 && idB == worldIPIdentity &&
+					(tt.aProto != 0 || tt.aPort != 0) {
+					continue
+				}
+				if tt.outcome&worldIPProtoOnly > 0 && idB == worldIPIdentity &&
+					(tt.aPort != 0) {
+					continue
+				}
+				if tt.outcome&worldSubnetl3only > 0 && idB == worldSubnetIdentity &&
+					(tt.aProto != 0 || tt.aPort != 0) {
+					continue
+				}
+				if tt.outcome&worldSubnetProtoOnly > 0 && idB == worldSubnetIdentity &&
+					(tt.aPort != 0) {
+					continue
+				}
+				bKey := IngressKey().WithIdentity(idB).WithPortProto(tt.bProto, tt.bPort)
+				bKeyWithAProto := bKey.WithPortProto(tt.aProto, tt.aPort)
+				bEntryWithProto := bEntry.WithOwners(bKey)
+				bEntryWithDep := bEntry.WithDependents(bKeyWithAProto)
+
+				expectedKeys.insert(bKey, bEntryWithDep, selectorCache)
+				expectedKeys.insert(bKeyWithAProto, bEntryWithProto, selectorCache)
+			}
+		}
+		if tt.outcome&insertA > 0 {
+			for _, aKey := range aKeys {
+				expectedKeys.insert(aKey, aEntry, selectorCache)
+			}
+		}
+		if tt.outcome&insertAasDeny > 0 {
+			for _, aKey := range aKeys {
+				expectedKeys.insert(aKey, aEntry.asDeny(), selectorCache)
+			}
+		}
+		if tt.outcome&insertBasDeny > 0 {
+			for _, bKey := range bKeys {
+				expectedKeys.insert(bKey, bEntry.asDeny(), selectorCache)
+			}
+		}
+		if tt.outcome&insertAWithBProto > 0 {
+			for _, idA := range tt.aIdentities {
+				if tt.outcome&worldIPl3only > 0 && idA == worldIPIdentity &&
+					(tt.bProto != 0 || tt.bPort != 0) {
+					continue
+				}
+				if tt.outcome&worldIPProtoOnly > 0 && idA == worldIPIdentity &&
+					(tt.bPort != 0) {
+					continue
+				}
+				if tt.outcome&worldSubnetl3only > 0 && idA == worldSubnetIdentity &&
+					(tt.bProto != 0 || tt.bPort != 0) {
+					continue
+				}
+				if tt.outcome&worldSubnetProtoOnly > 0 && idA == worldSubnetIdentity &&
+					(tt.bPort != 0) {
+					continue
+				}
+				aKey := IngressKey().WithIdentity(idA).WithPortProto(tt.aProto, tt.aPort)
+				aKeyWithBProto := aKey.WithPortProto(tt.bProto, tt.bPort)
+				aEntryWithProto := aEntry.WithOwners(aKey)
+				aEntryWithDep := aEntry.WithDependents(aKeyWithBProto)
+
+				expectedKeys.insert(aKey, aEntryWithDep, selectorCache)
+				expectedKeys.insert(aKeyWithBProto, aEntryWithProto, selectorCache)
 			}
 		}
 		if tt.outcome&insertBWithAProtoAsDeny > 0 {
-			bKeyWithAProto := IngressKey().WithIdentity(tt.bIdentity).WithPortProto(tt.aProto, tt.aPort)
-			bEntryAsDeny := bEntry.WithOwners(aKey).asDeny()
-			aEntryWithDep := aEntry.WithDependents(bKeyWithAProto)
-			expectedKeys.denies.upsert(aKey, aEntryWithDep, selectorCache)
-			expectedKeys.denies.upsert(bKeyWithAProto, bEntryAsDeny, selectorCache)
+			for _, aKey := range aKeys {
+				for _, idB := range tt.bIdentities {
+					if tt.outcome&worldIPl3only > 0 && idB == worldIPIdentity &&
+						(tt.aProto != 0 || tt.aPort != 0) {
+						continue
+					}
+					if tt.outcome&worldIPProtoOnly > 0 && idB == worldIPIdentity &&
+						(tt.aPort != 0) {
+						continue
+					}
+					if tt.outcome&worldSubnetl3only > 0 && idB == worldSubnetIdentity &&
+						(tt.aProto != 0 || tt.aPort != 0) {
+						continue
+					}
+					if tt.outcome&worldSubnetProtoOnly > 0 && idB == worldSubnetIdentity &&
+						(tt.aPort != 0) {
+						continue
+					}
+					bKey := IngressKey().WithIdentity(idB).WithPortProto(tt.bProto, tt.bPort)
+					bKeyWithAProto := bKey.WithPortProto(tt.aProto, tt.aPort)
+					bEntryAsDeny := bEntry.WithOwners(aKey).asDeny()
+					aEntryWithDep := aEntry
+
+					aEntryWithDep.AddDependent(bKeyWithAProto)
+					expectedKeys.insert(aKey, aEntryWithDep, selectorCache)
+					expectedKeys.insert(bKeyWithAProto, bEntryAsDeny, selectorCache)
+				}
+			}
+		}
+		if tt.outcome&insertDenyWorld > 0 {
+			worldIngressKey := IngressKey().WithIdentity(2)
+			denyEntry := MapStateEntry{IsDeny: true}
+			expectedKeys.insert(worldIngressKey, denyEntry, selectorCache)
+		}
+		if tt.outcome&insertDenyWorldTCP > 0 {
+			worldIngressKey := IngressKey().WithIdentity(2).WithTCPPort(0)
+			denyEntry := MapStateEntry{IsDeny: true}
+			expectedKeys.insert(worldIngressKey, denyEntry, selectorCache)
+		}
+		if tt.outcome&insertDenyWorldHTTP > 0 {
+			worldIngressKey := IngressKey().WithIdentity(2).WithTCPPort(80)
+			denyEntry := MapStateEntry{IsDeny: true}
+			expectedKeys.insert(worldIngressKey, denyEntry, selectorCache)
 		}
 		outcomeKeys := newMapState()
 		outcomeKeys.validator = &validator{} // insert validator
@@ -3027,17 +3164,41 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		if tt.withAllowAll {
 			outcomeKeys.denyPreferredInsert(anyIngressKey, allowEntry, selectorCache, allFeatures)
 		}
-		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
-		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
+		for _, idA := range tt.aIdentities {
+			aKey := IngressKey().WithIdentity(idA).WithPortProto(tt.aProto, tt.aPort)
+			outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
+		}
+		for _, idB := range tt.bIdentities {
+			bKey := IngressKey().WithIdentity(idB).WithPortProto(tt.bProto, tt.bPort)
+			outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
+		}
 		outcomeKeys.validatePortProto(t)
+		if !expectedKeys.Equals(outcomeKeys) {
+			fmt.Println("OUTCOME KEYS:")
+			fmt.Println("DENIES:")
+			for k, v := range outcomeKeys.denies.entries {
+				fmt.Printf("%v: %v\n", k, v)
+			}
+			fmt.Println("ALLOWS:")
+			for k, v := range outcomeKeys.allows.entries {
+				fmt.Printf("%v: %v\n", k, v)
+			}
+		}
+
 		require.True(t, expectedKeys.Equals(outcomeKeys), "%s (MapState):\n%s", tt.name, outcomeKeys.Diff(expectedKeys))
 
 		// Test also with reverse insertion order
 		outcomeKeys = newMapState()
 		outcomeKeys.validator = &validator{} // insert validator
 
-		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
-		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
+		for _, idB := range tt.bIdentities {
+			bKey := IngressKey().WithIdentity(idB).WithPortProto(tt.bProto, tt.bPort)
+			outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
+		}
+		for _, idA := range tt.aIdentities {
+			aKey := IngressKey().WithIdentity(idA).WithPortProto(tt.aProto, tt.aPort)
+			outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
+		}
 		if tt.withAllowAll {
 			outcomeKeys.denyPreferredInsert(anyIngressKey, allowEntry, selectorCache, allFeatures)
 		}
@@ -3051,25 +3212,28 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		anyIngressKey := IngressKey()
 		anyEgressKey := EgressKey()
 		allowEntry := MapStateEntry{}
-		aKey := IngressKey().WithIdentity(tt.aIdentity).WithPortProto(tt.aProto, tt.aPort)
+		var aKeys []Key
+		for _, idA := range tt.aIdentities {
+			aKeys = append(aKeys, IngressKey().WithIdentity(idA).WithPortProto(tt.aProto, tt.aPort))
+		}
 		aEntry := MapStateEntry{IsDeny: tt.aIsDeny}
-		bKey := EgressKey().WithIdentity(tt.bIdentity).WithPortProto(tt.bProto, tt.bPort)
+		var bKeys []Key
+		for _, idB := range tt.bIdentities {
+			bKeys = append(bKeys, EgressKey().WithIdentity(idB).WithPortProto(tt.bProto, tt.bPort))
+		}
 		bEntry := MapStateEntry{IsDeny: tt.bIsDeny}
 		expectedKeys := newMapState()
 		if tt.outcome&insertAllowAll > 0 {
-			expectedKeys.allows.upsert(anyIngressKey, allowEntry, selectorCache)
-			expectedKeys.allows.upsert(anyEgressKey, allowEntry, selectorCache)
+			expectedKeys.insert(anyIngressKey, allowEntry, selectorCache)
+			expectedKeys.insert(anyEgressKey, allowEntry, selectorCache)
 		}
-		if tt.aIsDeny {
-			expectedKeys.denies.upsert(aKey, aEntry, selectorCache)
-		} else {
-			expectedKeys.allows.upsert(aKey, aEntry, selectorCache)
+		for _, aKey := range aKeys {
+			expectedKeys.insert(aKey, aEntry, selectorCache)
 		}
-		if tt.bIsDeny {
-			expectedKeys.denies.upsert(bKey, bEntry, selectorCache)
-		} else {
-			expectedKeys.allows.upsert(bKey, bEntry, selectorCache)
+		for _, bKey := range bKeys {
+			expectedKeys.insert(bKey, bEntry, selectorCache)
 		}
+
 		outcomeKeys := newMapState()
 		outcomeKeys.validator = &validator{} // insert validator
 
@@ -3077,8 +3241,12 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 			outcomeKeys.denyPreferredInsert(anyIngressKey, allowEntry, selectorCache, allFeatures)
 			outcomeKeys.denyPreferredInsert(anyEgressKey, allowEntry, selectorCache, allFeatures)
 		}
-		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
-		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
+		for _, aKey := range aKeys {
+			outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
+		}
+		for _, bKey := range bKeys {
+			outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
+		}
 		outcomeKeys.validatePortProto(t)
 		require.True(t, expectedKeys.Equals(outcomeKeys), "%s different traffic directions (MapState):\n%s", tt.name, outcomeKeys.Diff(expectedKeys))
 
@@ -3086,8 +3254,12 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		outcomeKeys = newMapState()
 		outcomeKeys.validator = &validator{} // insert validator
 
-		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
-		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
+		for _, bKey := range bKeys {
+			outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
+		}
+		for _, aKey := range aKeys {
+			outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
+		}
 		if tt.withAllowAll {
 			outcomeKeys.denyPreferredInsert(anyEgressKey, allowEntry, selectorCache, allFeatures)
 			outcomeKeys.denyPreferredInsert(anyIngressKey, allowEntry, selectorCache, allFeatures)

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/container/versioned"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -113,30 +114,39 @@ func (p *selectorPolicy) Detach() {
 // PolicyOwner (aka Endpoint) is also unlocked during this call,
 // but the Endpoint's build mutex is held.
 func (p *selectorPolicy) DistillPolicy(policyOwner PolicyOwner, isHost bool) *EndpointPolicy {
-	version := p.SelectorCache.GetVersionHandle()
-	calculatedPolicy := &EndpointPolicy{
-		selectorPolicy: p,
-		VersionHandle:  version,
-		policyMapState: NewMapState(),
-		PolicyOwner:    policyOwner,
-	}
+	var calculatedPolicy *EndpointPolicy
+
+	// EndpointPolicy is initialized while 'GetCurrentVersionHandleFunc' keeps the selector
+	// cache write locked. This syncronizes the SelectorCache handle creation and the insertion
+	// of the new policy to the selectorPolicy before any new incremental updated can be
+	// generated.
+	//
+	// With this we have to following guarantees:
+	// - Selections seen with the 'version' are the ones available at the time of the 'version'
+	//   creation, and the IDs therein have been applied to all Selectors cached at the time.
+	// - All further incremental updates are delivered to 'policyMapChanges' as whole
+	//   transactions, i.e, changes to all selectors due to addition or deletion of new/old
+	//   identities are visible in the set of changes processed and returned by
+	//   ConsumeMapChanges().
+	p.SelectorCache.GetVersionHandleFunc(func(version *versioned.VersionHandle) {
+		calculatedPolicy = &EndpointPolicy{
+			selectorPolicy: p,
+			VersionHandle:  version,
+			policyMapState: NewMapState(),
+			policyMapChanges: MapChanges{
+				firstVersion: version.Version(),
+			},
+			PolicyOwner: policyOwner,
+		}
+		// Register the new EndpointPolicy as a receiver of incremental
+		// updates before selector cache lock is released by 'GetHandle'.
+		p.insertUser(calculatedPolicy)
+	})
 
 	if !p.IngressPolicyEnabled || !p.EgressPolicyEnabled {
 		calculatedPolicy.policyMapState.allowAllIdentities(
 			!p.IngressPolicyEnabled, !p.EgressPolicyEnabled)
 	}
-
-	// Register the new EndpointPolicy as a receiver of delta
-	// updates.  Any updates happening after this, but before
-	// computeDesiredL4PolicyMapEntries() call finishes may
-	// already be applied to the PolicyMapState, specifically:
-	//
-	// - policyMapChanges may contain an addition of an entry that
-	//   is already added to the PolicyMapState
-	//
-	// - policyMapChanges may contain a deletion of an entry that
-	//   has already been deleted from PolicyMapState
-	p.insertUser(calculatedPolicy)
 
 	// Must come after the 'insertUser()' above to guarantee
 	// PolicyMapChanges will contain all changes that are applied
@@ -149,7 +159,7 @@ func (p *selectorPolicy) DistillPolicy(policyOwner PolicyOwner, isHost bool) *En
 	return calculatedPolicy
 }
 
-// Ready releases the hold on a selector cache version so that stale state can be released.
+// Ready releases the handle on a selector cache version so that stale state can be released.
 // This should be called when the policy has been realized.
 func (p *EndpointPolicy) Ready() (err error) {
 	// release resources held for this version
@@ -179,12 +189,16 @@ func (p *EndpointPolicy) SetPolicyMap(ms MapState) {
 // to allow the EndpointPolicy to be GC'd.
 // PolicyOwner (aka Endpoint) is also locked during this call.
 func (p *EndpointPolicy) Detach() {
+	p.selectorPolicy.removeUser(p)
 	// in case the call was missed previouly
 	if p.Ready() == nil {
 		// succeeded, so it was missed previously
 		log.Warningf("Detach: EndpointPolicy was not marked as Ready")
 	}
-	p.selectorPolicy.removeUser(p)
+	// Also release the version handle held for incremental updates, if any.
+	// This must be done after the removeUser() call above, so that we do not get a new version
+	// handles any more!
+	p.policyMapChanges.detach()
 }
 
 // NewMapStateWithInsert returns a new MapState and an insert function that can be used to populate
@@ -282,9 +296,36 @@ func (l4policy L4DirectionPolicy) updateRedirects(p *EndpointPolicy, createRedir
 // calls before calling ConsumeMapChanges so that if we see any partial changes here, there will be
 // another call after to cover for the rest.
 // PolicyOwner (aka Endpoint) is locked during this call.
-func (p *EndpointPolicy) ConsumeMapChanges() ChangeState {
+// Caller is responsible for calling the returned 'closer' to release resources held for the new version!
+// 'closer' may not be called while selector cache is locked!
+func (p *EndpointPolicy) ConsumeMapChanges() (closer func(), changes ChangeState) {
 	features := p.selectorPolicy.L4Policy.Ingress.features | p.selectorPolicy.L4Policy.Egress.features
-	return p.policyMapChanges.consumeMapChanges(p.PolicyOwner, p.policyMapState, p.SelectorCache, features)
+	version, changes := p.policyMapChanges.consumeMapChanges(p, features)
+
+	closer = func() {}
+	if version.IsValid() {
+		var msg string
+		// update the version handle in p.VersionHandle so that any follow-on processing acts on the
+		// basis of the new version
+		if p.VersionHandle.IsValid() {
+			p.VersionHandle.Close()
+			msg = "ConsumeMapChanges: updated valid version"
+		} else {
+			closer = func() {
+				// p.VersionHandle was not valid, close it
+				p.Ready()
+			}
+			msg = "ConsumeMapChanges: new incremental version"
+		}
+		p.VersionHandle = version
+
+		p.PolicyOwner.PolicyDebug(logrus.Fields{
+			logfields.Version: version,
+			logfields.Changes: changes,
+		}, msg)
+	}
+
+	return closer, changes
 }
 
 // NewEndpointPolicy returns an empty EndpointPolicy stub.

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -282,7 +282,7 @@ func (l4policy L4DirectionPolicy) updateRedirects(p *EndpointPolicy, createRedir
 // calls before calling ConsumeMapChanges so that if we see any partial changes here, there will be
 // another call after to cover for the rest.
 // PolicyOwner (aka Endpoint) is locked during this call.
-func (p *EndpointPolicy) ConsumeMapChanges() (adds, deletes Keys) {
+func (p *EndpointPolicy) ConsumeMapChanges() ChangeState {
 	features := p.selectorPolicy.L4Policy.Ingress.features | p.selectorPolicy.L4Policy.Egress.features
 	return p.policyMapChanges.consumeMapChanges(p.PolicyOwner, p.policyMapState, p.SelectorCache, features)
 }

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -208,28 +208,28 @@ func NewMapStateWithInsert() (MapState, func(k Key, e MapStateEntry)) {
 	currentMap := NewMapState()
 
 	return currentMap, func(k Key, e MapStateEntry) {
-		currentMap.insert(k, e, nil)
+		currentMap.insert(k, e)
 	}
 }
 
 func (p *EndpointPolicy) InsertMapState(key Key, entry MapStateEntry) {
 	// SelectorCache used as Identities interface which only has GetPrefix() that needs no lock
-	p.policyMapState.insert(key, entry, p.SelectorCache)
+	p.policyMapState.insert(key, entry)
 }
 
 func (p *EndpointPolicy) DeleteMapState(key Key) {
 	// SelectorCache used as Identities interface which only has GetPrefix() that needs no lock
-	p.policyMapState.delete(key, p.SelectorCache)
+	p.policyMapState.delete(key)
 }
 
 func (p *EndpointPolicy) RevertChanges(changes ChangeState) {
 	// SelectorCache used as Identities interface which only has GetPrefix() that needs no lock
-	p.policyMapState.revertChanges(p.SelectorCache, changes)
+	p.policyMapState.revertChanges(changes)
 }
 
 func (p *EndpointPolicy) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMeta *VisibilityMetadata, changes ChangeState) {
 	// SelectorCache used as Identities interface which only has GetPrefix() that needs no lock
-	p.policyMapState.addVisibilityKeys(e, redirectPort, visMeta, p.SelectorCache, changes)
+	p.policyMapState.addVisibilityKeys(e, redirectPort, visMeta, changes)
 }
 
 // toMapState transforms the EndpointPolicy.L4Policy into

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -634,16 +634,16 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 		}, td.sc),
 	}
 
-	adds, deletes := policy.ConsumeMapChanges()
+	changes := policy.ConsumeMapChanges()
 	// maps on the policy got cleared
 
 	require.Equal(t, Keys{
 		ingressKey(192, 6, 80, 0): {},
 		ingressKey(194, 6, 80, 0): {},
-	}, adds)
+	}, changes.Adds)
 	require.Equal(t, Keys{
 		ingressKey(193, 6, 80, 0): {},
-	}, deletes)
+	}, changes.Deletes)
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop
 	policy.selectorPolicy.Detach()

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -283,6 +283,8 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
+	policy.policyMapChanges.mutex = lock.Mutex{}
+	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
 		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
@@ -376,6 +378,8 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
+	policy.policyMapChanges.mutex = lock.Mutex{}
+	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
 		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
@@ -476,7 +480,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	// Cleanup the identities from the testSelectorCache
 	defer td.sc.UpdateIdentities(nil, added1, wg)
 	wg.Wait()
-	require.Equal(t, 0, len(policy.policyMapChanges.changes))
+	require.Equal(t, 0, len(policy.policyMapChanges.synced))
 
 	// Have to remove circular reference before testing to avoid an infinite loop
 	policy.selectorPolicy.Detach()
@@ -484,6 +488,8 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
+	policy.policyMapChanges.mutex = lock.Mutex{}
+	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
 		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
@@ -563,7 +569,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	td.sc.UpdateIdentities(added1, nil, wg)
 	wg.Wait()
-	require.Len(t, policy.policyMapChanges.changes, 3)
+	require.Len(t, policy.policyMapChanges.synced, 3)
 
 	deleted1 := identity.IdentityMap{
 		identity.NumericIdentity(193): labels.ParseSelectLabelArray("id=resolve_test_1", "num=2"),
@@ -571,7 +577,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	wg = &sync.WaitGroup{}
 	td.sc.UpdateIdentities(nil, deleted1, wg)
 	wg.Wait()
-	require.Len(t, policy.policyMapChanges.changes, 4)
+	require.Len(t, policy.policyMapChanges.synced, 4)
 
 	cachedSelectorWorld := td.sc.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorld])
 	require.NotNil(t, cachedSelectorWorld)
@@ -634,7 +640,8 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 		}, td.sc),
 	}
 
-	changes := policy.ConsumeMapChanges()
+	closer, changes := policy.ConsumeMapChanges()
+	closer()
 	// maps on the policy got cleared
 
 	require.Equal(t, Keys{
@@ -656,6 +663,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	// difference of the internal time.Time from the lock_debug.go.
 	policy.selectorPolicy.L4Policy.mutex = lock.RWMutex{}
 	policy.policyMapChanges.mutex = lock.Mutex{}
+	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
 		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -190,6 +190,7 @@ func BenchmarkRegenerateCIDRDenyPolicyRules(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		epPolicy := ip.DistillPolicy(DummyOwner{}, false)
 		n += epPolicy.policyMapState.Len()
+		epPolicy.Ready()
 	}
 	ip.Detach()
 	fmt.Printf("Number of MapState entries: %d\n", n/b.N)
@@ -201,6 +202,7 @@ func TestRegenerateCIDRDenyPolicyRules(t *testing.T) {
 	ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
 	epPolicy := ip.DistillPolicy(DummyOwner{}, false)
 	n := epPolicy.policyMapState.Len()
+	epPolicy.Ready()
 	ip.Detach()
 	assert.True(t, n > 0)
 }
@@ -241,6 +243,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
+	policy.Ready()
 
 	expectedEndpointPolicy := EndpointPolicy{
 		selectorPolicy: &selectorPolicy{
@@ -327,10 +330,10 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 
 	repo.Mutex.RLock()
 	defer repo.Mutex.RUnlock()
-
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
+	policy.Ready()
 
 	cachedSelectorHost := td.sc.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameHost])
 	require.NotNil(t, cachedSelectorHost)
@@ -422,7 +425,9 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	defer repo.Mutex.RUnlock()
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
+
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
+	policy.Ready()
 
 	rule1MapStateEntry := NewMapStateEntry(td.wildcardCachedSelector, labels.LabelArrayList{ruleLabel}, 0, "", 0, true, DefaultAuthType, AuthTypeDisabled)
 	allowEgressMapStateEntry := NewMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, "", 0, false, ExplicitAuthType, AuthTypeDisabled)
@@ -545,7 +550,9 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	defer repo.Mutex.RUnlock()
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
+
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
+	policy.Ready()
 
 	// Add new identity to test accumulation of MapChanges
 	added1 := identity.IdentityMap{

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -468,7 +468,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 			// will still allow egress to world.
 			EgressKey():                  allowEgressMapStateEntry,
 			IngressKey().WithTCPPort(80): rule1MapStateEntry,
-		}, td.sc),
+		}),
 	}
 
 	// Add new identity to test accumulation of MapChanges
@@ -637,7 +637,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 			IngressKey().WithIdentity(identity.ReservedIdentityWorldIPv6).WithTCPPort(80): rule1MapStateEntry.WithOwners(cachedSelectorWorldV6, cachedSelectorWorld),
 			IngressKey().WithIdentity(192).WithTCPPort(80):                                rule1MapStateEntry,
 			IngressKey().WithIdentity(194).WithTCPPort(80):                                rule1MapStateEntry,
-		}, td.sc),
+		}),
 	}
 
 	closer, changes := policy.ConsumeMapChanges()

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -727,17 +727,17 @@ func TestMapStateWithIngress(t *testing.T) {
 	cachedSelectorTest = td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
 	require.Nil(t, cachedSelectorTest)
 
-	adds, deletes := policy.ConsumeMapChanges()
+	changes := policy.ConsumeMapChanges()
 	// maps on the policy got cleared
 	require.Nil(t, policy.policyMapChanges.changes)
 
 	require.Equal(t, Keys{
 		ingressKey(192, 6, 80, 0): {},
 		ingressKey(194, 6, 80, 0): {},
-	}, adds)
+	}, changes.Adds)
 	require.Equal(t, Keys{
 		ingressKey(193, 6, 80, 0): {},
-	}, deletes)
+	}, changes.Deletes)
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -225,6 +225,7 @@ func BenchmarkRegenerateCIDRPolicyRules(b *testing.B) {
 	n := 0
 	for i := 0; i < b.N; i++ {
 		epPolicy := ip.DistillPolicy(DummyOwner{}, false)
+		epPolicy.Ready()
 		n += epPolicy.policyMapState.Len()
 	}
 	ip.Detach()
@@ -237,7 +238,8 @@ func BenchmarkRegenerateL3IngressPolicyRules(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
-		_ = ip.DistillPolicy(DummyOwner{}, false)
+		policy := ip.DistillPolicy(DummyOwner{}, false)
+		policy.Ready()
 		ip.Detach()
 	}
 }
@@ -248,7 +250,8 @@ func BenchmarkRegenerateL3EgressPolicyRules(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
-		_ = ip.DistillPolicy(DummyOwner{}, false)
+		policy := ip.DistillPolicy(DummyOwner{}, false)
+		policy.Ready()
 		ip.Detach()
 	}
 }
@@ -298,6 +301,7 @@ func TestL7WithIngressWildcard(t *testing.T) {
 	require.Equal(t, redirectTypeEnvoy, selPolicy.L4Policy.redirectTypes)
 
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
+	policy.Ready()
 
 	expectedEndpointPolicy := EndpointPolicy{
 		selectorPolicy: &selectorPolicy{
@@ -397,10 +401,11 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 
 	repo.Mutex.RLock()
 	defer repo.Mutex.RUnlock()
-
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
+
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
+	policy.Ready()
 
 	cachedSelectorHost := td.sc.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameHost])
 	require.NotNil(t, cachedSelectorHost)
@@ -501,7 +506,9 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 	defer repo.Mutex.RUnlock()
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
+
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
+	policy.Ready()
 
 	rule1MapStateEntry := NewMapStateEntry(td.wildcardCachedSelector, labels.LabelArrayList{ruleLabel}, 0, "", 0, false, DefaultAuthType, AuthTypeDisabled)
 	allowEgressMapStateEntry := NewMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, "", 0, false, ExplicitAuthType, AuthTypeDisabled)
@@ -625,7 +632,9 @@ func TestMapStateWithIngress(t *testing.T) {
 	defer repo.Mutex.RUnlock()
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
+
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
+	policy.Ready()
 
 	// Add new identity to test accumulation of MapChanges
 	added1 := identity.IdentityMap{

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -546,7 +546,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 		policyMapState: newMapState().withState(MapStateMap{
 			EgressKey():                  allowEgressMapStateEntry,
 			IngressKey().WithTCPPort(80): rule1MapStateEntry,
-		}, td.sc),
+		}),
 	}
 
 	// Add new identity to test accumulation of MapChanges
@@ -723,7 +723,7 @@ func TestMapStateWithIngress(t *testing.T) {
 			IngressKey().WithIdentity(identity.ReservedIdentityWorldIPv6).WithTCPPort(80): rule1MapStateEntry.WithOwners(cachedSelectorWorld, cachedSelectorWorldV6),
 			IngressKey().WithIdentity(192).WithTCPPort(80):                                rule1MapStateEntry.WithAuthType(AuthTypeDisabled),
 			IngressKey().WithIdentity(194).WithTCPPort(80):                                rule1MapStateEntry.WithAuthType(AuthTypeDisabled),
-		}, td.sc),
+		}),
 	}
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop
@@ -788,8 +788,6 @@ func (p *EndpointPolicy) allowsIdentity(identity identity.NumericIdentity) (ingr
 }
 
 func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
-	td := newTestData()
-
 	type fields struct {
 		selectorPolicy *selectorPolicy
 		PolicyMapState *mapState
@@ -843,7 +841,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 				},
 				PolicyMapState: newMapState().withState(MapStateMap{
 					IngressKey(): {},
-				}, td.sc),
+				}),
 			},
 			args: args{
 				identity: 0,
@@ -860,7 +858,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 				},
 				PolicyMapState: newMapState().withState(MapStateMap{
 					EgressKey(): {},
-				}, td.sc),
+				}),
 			},
 			args: args{
 				identity: 0,
@@ -877,7 +875,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 				},
 				PolicyMapState: newMapState().withState(MapStateMap{
 					IngressKey(): {IsDeny: true},
-				}, td.sc),
+				}),
 			},
 			args: args{
 				identity: 0,
@@ -894,7 +892,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 				},
 				PolicyMapState: newMapState().withState(MapStateMap{
 					IngressKey(): {IsDeny: true},
-				}, td.sc),
+				}),
 			},
 			args: args{
 				identity: 0,
@@ -911,7 +909,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 				},
 				PolicyMapState: newMapState().withState(MapStateMap{
 					EgressKey(): {IsDeny: true},
-				}, td.sc),
+				}),
 			},
 			args: args{
 				identity: 0,
@@ -928,7 +926,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 				},
 				PolicyMapState: newMapState().withState(MapStateMap{
 					EgressKey(): {IsDeny: true},
-				}, td.sc),
+				}),
 			},
 			args: args{
 				identity: 0,

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/proxy/pkg/policy/api/kafka"
 
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/identity"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -621,7 +622,7 @@ func (r *rule) matchesSubject(securityIdentity *identity.Identity) bool {
 		return r.getSelector().Matches(securityIdentity.LabelArray)
 	}
 
-	return r.subjectSelector.Selects(securityIdentity.ID)
+	return r.subjectSelector.Selects(versioned.Latest(), securityIdentity.ID)
 }
 
 // ****************** EGRESS POLICY ******************

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -42,6 +42,9 @@ type rule struct {
 func (r *rule) IdentitySelectionUpdated(_ CachedSelector, _, _ []identity.NumericIdentity) {
 }
 
+func (d *rule) IdentitySelectionCommit(*versioned.Tx) {
+}
+
 func (r *rule) String() string {
 	return r.EndpointSelector.String()
 }

--- a/pkg/policy/selectorcache_selector.go
+++ b/pkg/policy/selectorcache_selector.go
@@ -91,13 +91,17 @@ func (s CachedSelectorSlice) SelectsAllEndpoints() bool {
 // CachedSelectionUser inserts selectors into the cache and gets update
 // callbacks whenever the set of selected numeric identities change for
 // the CachedSelectors pushed by it.
+// Callbacks are executed from a separate goroutine that does not take the
+// selector cache lock, so the implemenations generally may call back to
+// the selector cache.
 type CachedSelectionUser interface {
-	// IdentitySelectionUpdated implementations MUST NOT call back
-	// to the name manager or the selector cache while executing this function!
-	//
 	// The caller is responsible for making sure the same identity is not
 	// present in both 'added' and 'deleted'.
 	IdentitySelectionUpdated(selector CachedSelector, added, deleted []identity.NumericIdentity)
+
+	// IdentitySelectionCommit tells the user that all IdentitySelectionUpdated calls relating
+	// to a specific added or removed identity have been made.
+	IdentitySelectionCommit(*versioned.Tx)
 }
 
 // identitySelector is the internal type for all selectors in the

--- a/pkg/policy/selectorcache_selector.go
+++ b/pkg/policy/selectorcache_selector.go
@@ -9,10 +9,14 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"sync/atomic"
 
+	"github.com/hashicorp/go-hclog"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
 
@@ -21,7 +25,7 @@ type CachedSelector interface {
 	// GetSelections returns the cached set of numeric identities
 	// selected by the CachedSelector.  The retuned slice must NOT
 	// be modified, as it is shared among multiple users.
-	GetSelections() identity.NumericIdentitySlice
+	GetSelections(*versioned.VersionHandle) identity.NumericIdentitySlice
 
 	// GetMetadataLabels returns metadata labels for additional context
 	// surrounding the selector. These are typically the labels associated with
@@ -30,7 +34,7 @@ type CachedSelector interface {
 
 	// Selects return 'true' if the CachedSelector selects the given
 	// numeric identity.
-	Selects(nid identity.NumericIdentity) bool
+	Selects(*versioned.VersionHandle, identity.NumericIdentity) bool
 
 	// IsWildcard returns true if the endpoint selector selects
 	// all endpoints.
@@ -134,7 +138,7 @@ type CachedSelectionUser interface {
 type identitySelector struct {
 	source           selectorSource
 	key              string
-	selections       atomic.Pointer[identity.NumericIdentitySlice]
+	selections       versioned.Value[identity.NumericIdentitySlice]
 	users            map[CachedSelectionUser]struct{}
 	cachedSelections map[identity.NumericIdentity]struct{}
 	metadataLbls     labels.LabelArray
@@ -231,12 +235,15 @@ func (i *identitySelector) Equal(b *identitySelector) bool {
 // that case GetSelections() will return either the old or new version
 // of the selections. If the old version is returned, the user is
 // guaranteed to receive a notification including the update.
-func (i *identitySelector) GetSelections() identity.NumericIdentitySlice {
-	selections := i.selections.Load()
-	if selections == nil {
-		return emptySelection
+func (i *identitySelector) GetSelections(version *versioned.VersionHandle) identity.NumericIdentitySlice {
+	if !version.IsValid() {
+		log.WithFields(logrus.Fields{
+			logfields.Version:    version,
+			logfields.Stacktrace: hclog.Stacktrace(),
+		}).Error("GetSelections: Invalid VersionHandle finds nothing")
+		return identity.NumericIdentitySlice{}
 	}
-	return *selections
+	return i.selections.At(version)
 }
 
 func (i *identitySelector) GetMetadataLabels() labels.LabelArray {
@@ -245,11 +252,11 @@ func (i *identitySelector) GetMetadataLabels() labels.LabelArray {
 
 // Selects return 'true' if the CachedSelector selects the given
 // numeric identity.
-func (i *identitySelector) Selects(nid identity.NumericIdentity) bool {
+func (i *identitySelector) Selects(version *versioned.VersionHandle, nid identity.NumericIdentity) bool {
 	if i.IsWildcard() {
 		return true
 	}
-	nids := i.GetSelections()
+	nids := i.GetSelections(version)
 	idx := sort.Search(len(nids), func(i int) bool { return nids[i] >= nid })
 	return idx < len(nids) && nids[idx] == nid
 }
@@ -298,7 +305,7 @@ func (i *identitySelector) numUsers() int {
 // cached selections after the cached selections have been changed.
 //
 // lock must be held
-func (i *identitySelector) updateSelections() {
+func (i *identitySelector) updateSelections(nextVersion *versioned.Tx) {
 	selections := make(identity.NumericIdentitySlice, len(i.cachedSelections))
 	idx := 0
 	for nid := range i.cachedSelections {
@@ -311,13 +318,18 @@ func (i *identitySelector) updateSelections() {
 	sort.Slice(selections, func(i, j int) bool {
 		return selections[i] < selections[j]
 	})
-	i.setSelections(&selections)
+	i.setSelections(selections, nextVersion)
 }
 
-func (i *identitySelector) setSelections(selections *identity.NumericIdentitySlice) {
-	if len(*selections) > 0 {
-		i.selections.Store(selections)
+func (i *identitySelector) setSelections(selections identity.NumericIdentitySlice, nextVersion *versioned.Tx) {
+	var err error
+	if len(selections) > 0 {
+		err = i.selections.SetAt(selections, nextVersion)
 	} else {
-		i.selections.Store(&emptySelection)
+		err = i.selections.RemoveAt(nextVersion)
+	}
+	if err != nil {
+		stacktrace := hclog.Stacktrace()
+		log.WithError(err).WithField(logfields.Stacktrace, stacktrace).Error("setSelections failed")
 	}
 }

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -24,6 +24,9 @@ type DummySelectorCacheUser struct{}
 func (d *DummySelectorCacheUser) IdentitySelectionUpdated(selector CachedSelector, added, deleted []identity.NumericIdentity) {
 }
 
+func (d *DummySelectorCacheUser) IdentitySelectionCommit(*versioned.Tx) {
+}
+
 type cachedSelectionUser struct {
 	t    *testing.T
 	sc   *SelectorCache
@@ -145,7 +148,9 @@ func (csu *cachedSelectionUser) IdentitySelectionUpdated(selector CachedSelector
 
 	// update selections
 	csu.selections[selector] = selections
+}
 
+func (csu *cachedSelectionUser) IdentitySelectionCommit(*versioned.Tx) {
 	csu.updateCond.Signal()
 }
 
@@ -540,7 +545,7 @@ func TestTransactionalUpdate(t *testing.T) {
 	}, nil, wg)
 	wg.Wait()
 
-	// Old version hold still gets the same selections as before
+	// Old version handle still gets the same selections as before
 	require.Equal(t, identity.NumericIdentitySlice{li1}, cs32.GetSelections(version))
 	require.Equal(t, identity.NumericIdentitySlice{li1}, cs24.GetSelections(version))
 	require.Equal(t, identity.NumericIdentitySlice{li1, li2}, cs8.GetSelections(version))
@@ -562,7 +567,7 @@ func TestTransactionalUpdate(t *testing.T) {
 	}, wg)
 	wg.Wait()
 
-	// Oldest version hold still gets the same selections as before
+	// Oldest version handle still gets the same selections as before
 	require.Equal(t, identity.NumericIdentitySlice{li1}, cs32.GetSelections(version))
 	require.Equal(t, identity.NumericIdentitySlice{li1}, cs24.GetSelections(version))
 	require.Equal(t, identity.NumericIdentitySlice{li1, li2}, cs8.GetSelections(version))

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -616,31 +616,3 @@ func testNewSelectorCache(ids identity.IdentityMap) *SelectorCache {
 	sc.SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 	return sc
 }
-
-func Test_getLocalScopePrefix(t *testing.T) {
-	prefix := getLocalScopePrefix(identity.ReservedIdentityWorld, nil)
-	require.False(t, prefix.IsValid())
-
-	prefix = getLocalScopePrefix(identity.ReservedIdentityWorld, labels.LabelArray{labels.Label{Source: labels.LabelSourceCIDR, Key: "0.0.0.0/0"}})
-	require.False(t, prefix.IsValid())
-
-	prefix = getLocalScopePrefix(identity.IdentityScopeLocal, labels.LabelArray{labels.Label{Source: labels.LabelSourceCIDR, Key: "0.0.0.0/0"}})
-	require.True(t, prefix.IsValid())
-	require.Equal(t, "0.0.0.0/0", prefix.String())
-
-	prefix = getLocalScopePrefix(identity.IdentityScopeLocal, labels.LabelArray{labels.Label{Source: labels.LabelSourceCIDR, Key: "::/0"}})
-	require.True(t, prefix.IsValid())
-	require.Equal(t, "::/0", prefix.String())
-
-	prefix = getLocalScopePrefix(identity.IdentityScopeLocal, labels.LabelArray{labels.Label{Source: labels.LabelSourceCIDR, Key: "--/0"}})
-	require.True(t, prefix.IsValid())
-	require.Equal(t, "::/0", prefix.String())
-
-	prefix = getLocalScopePrefix(identity.IdentityScopeLocal, labels.LabelArray{
-		labels.Label{Source: labels.LabelSourceCIDR, Key: "ff--/8"},
-		labels.Label{Source: labels.LabelSourceCIDR, Key: "--/0"},
-		labels.Label{Source: labels.LabelSourceCIDR, Key: "--1/128"},
-	})
-	require.True(t, prefix.IsValid())
-	require.Equal(t, "::1/128", prefix.String())
-}

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/identity"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
@@ -72,7 +73,7 @@ func (csu *cachedSelectionUser) AddIdentitySelector(sel api.EndpointSelector) Ca
 	_, exists := csu.selections[cached]
 	// Not added if already exists for this user
 	require.Equal(csu.t, !exists, added)
-	csu.selections[cached] = cached.GetSelections()
+	csu.selections[cached] = cached.GetSelections(versioned.Latest())
 
 	// Pre-existing selections are not notified as updates
 	require.False(csu.t, csu.sc.haveUserNotifications())
@@ -90,7 +91,7 @@ func (csu *cachedSelectionUser) AddFQDNSelector(sel api.FQDNSelector) CachedSele
 	_, exists := csu.selections[cached]
 	// Not added if already exists for this user
 	require.Equal(csu.t, !exists, added)
-	csu.selections[cached] = cached.GetSelections()
+	csu.selections[cached] = cached.GetSelections(versioned.Latest())
 
 	// Pre-existing selections are not notified as updates
 	require.False(csu.t, csu.sc.haveUserNotifications())
@@ -132,7 +133,7 @@ func (csu *cachedSelectionUser) IdentitySelectionUpdated(selector CachedSelector
 	csu.adds += len(added)
 	csu.deletes += len(deleted)
 
-	selections := selector.GetSelections()
+	selections := selector.GetSelections(versioned.Latest())
 
 	// Validate added & deleted against the selections
 	for _, add := range added {
@@ -149,7 +150,8 @@ func (csu *cachedSelectionUser) IdentitySelectionUpdated(selector CachedSelector
 }
 
 // Mock CachedSelector for unit testing.
-
+//
+// testCachedSelector is used in isolation so there is no point to implement versioning for it.
 type testCachedSelector struct {
 	name       string
 	wildcard   bool
@@ -174,7 +176,7 @@ func (cs *testCachedSelector) addSelections(selections ...int) (adds []identity.
 		if cs == nil {
 			continue
 		}
-		if !cs.Selects(nid) {
+		if !cs.Selects(versioned.Latest(), nid) {
 			cs.selections = append(cs.selections, nid)
 		}
 	}
@@ -201,13 +203,14 @@ func (cs *testCachedSelector) deleteSelections(selections ...int) (deletes []ide
 
 // CachedSelector interface
 
-func (cs *testCachedSelector) GetSelections() identity.NumericIdentitySlice {
+func (cs *testCachedSelector) GetSelections(*versioned.VersionHandle) identity.NumericIdentitySlice {
 	return cs.selections
 }
+
 func (cs *testCachedSelector) GetMetadataLabels() labels.LabelArray {
 	return nil
 }
-func (cs *testCachedSelector) Selects(nid identity.NumericIdentity) bool {
+func (cs *testCachedSelector) Selects(_ *versioned.VersionHandle, nid identity.NumericIdentity) bool {
 	for _, id := range cs.selections {
 		if id == nid {
 			return true
@@ -247,7 +250,7 @@ func TestAddRemoveSelector(t *testing.T) {
 	cached := user1.AddIdentitySelector(testSelector)
 
 	// Current selections contain the numeric identities of existing identities that match
-	selections := cached.GetSelections()
+	selections := cached.GetSelections(versioned.Latest())
 	require.Equal(t, 1, len(selections))
 	require.Equal(t, identity.NumericIdentity(1234), selections[0])
 
@@ -309,7 +312,7 @@ func TestMultipleIdentitySelectors(t *testing.T) {
 	cached := user1.AddIdentitySelector(testSelector)
 
 	// Current selections contain the numeric identities of existing identities that match
-	selections := cached.GetSelections()
+	selections := cached.GetSelections(versioned.Latest())
 	require.Equal(t, 1, len(selections))
 	require.Equal(t, identity.NumericIdentity(1234), selections[0])
 
@@ -318,13 +321,13 @@ func TestMultipleIdentitySelectors(t *testing.T) {
 	require.NotEqual(t, cached, cached2)
 
 	// Current selections contain the numeric identities of existing identities that match
-	selections2 := cached2.GetSelections()
+	selections2 := cached2.GetSelections(versioned.Latest())
 	require.Equal(t, 1, len(selections2))
 	require.Equal(t, identity.NumericIdentity(2345), selections2[0])
 
 	shouldSelect := func(sel api.EndpointSelector, wantIDs ...identity.NumericIdentity) {
 		csel := user1.AddIdentitySelector(sel)
-		selections := csel.GetSelections()
+		selections := csel.GetSelections(versioned.Latest())
 		require.EqualValues(t, identity.NumericIdentitySlice(wantIDs), selections)
 		user1.RemoveSelector(csel)
 	}
@@ -359,7 +362,7 @@ func TestIdentityUpdates(t *testing.T) {
 	cached := user1.AddIdentitySelector(testSelector)
 
 	// Current selections contain the numeric identities of existing identities that match
-	selections := cached.GetSelections()
+	selections := cached.GetSelections(versioned.Latest())
 	require.Equal(t, 1, len(selections))
 	require.Equal(t, identity.NumericIdentity(1234), selections[0])
 
@@ -368,7 +371,7 @@ func TestIdentityUpdates(t *testing.T) {
 	require.NotEqual(t, cached, cached2)
 
 	// Current selections contain the numeric identities of existing identities that match
-	selections2 := cached2.GetSelections()
+	selections2 := cached2.GetSelections(versioned.Latest())
 	require.Equal(t, 1, len(selections2))
 	require.Equal(t, identity.NumericIdentity(2345), selections2[0])
 
@@ -385,7 +388,7 @@ func TestIdentityUpdates(t *testing.T) {
 	require.Equal(t, 0, deletes)
 
 	// Current selections contain the numeric identities of existing identities that match
-	selections = cached.GetSelections()
+	selections = cached.GetSelections(versioned.Latest())
 	require.Equal(t, 2, len(selections))
 	require.Equal(t, identity.NumericIdentity(1234), selections[0])
 	require.Equal(t, identity.NumericIdentity(12345), selections[1])
@@ -403,7 +406,7 @@ func TestIdentityUpdates(t *testing.T) {
 	require.Equal(t, 1, deletes)
 
 	// Current selections contain the numeric identities of existing identities that match
-	selections = cached.GetSelections()
+	selections = cached.GetSelections(versioned.Latest())
 	require.Equal(t, 1, len(selections))
 	require.Equal(t, identity.NumericIdentity(1234), selections[0])
 
@@ -454,13 +457,13 @@ func TestIdentityUpdatesMultipleUsers(t *testing.T) {
 	require.Equal(t, 0, deletes)
 
 	// Current selections contain the numeric identities of existing identities that match
-	selections := cached.GetSelections()
+	selections := cached.GetSelections(versioned.Latest())
 	require.Equal(t, 3, len(selections))
 	require.Equal(t, identity.NumericIdentity(123), selections[0])
 	require.Equal(t, identity.NumericIdentity(345), selections[1])
 	require.Equal(t, identity.NumericIdentity(1234), selections[2])
 
-	require.EqualValues(t, cached2.GetSelections(), cached.GetSelections())
+	require.EqualValues(t, cached2.GetSelections(versioned.Latest()), cached.GetSelections(versioned.Latest()))
 
 	user1.Reset()
 	user2.Reset()
@@ -480,15 +483,109 @@ func TestIdentityUpdatesMultipleUsers(t *testing.T) {
 	require.Equal(t, 1, deletes)
 
 	// Current selections contain the numeric identities of existing identities that match
-	selections = cached.GetSelections()
+	selections = cached.GetSelections(versioned.Latest())
 	require.Equal(t, 2, len(selections))
 	require.Equal(t, identity.NumericIdentity(345), selections[0])
 	require.Equal(t, identity.NumericIdentity(1234), selections[1])
 
-	require.EqualValues(t, cached2.GetSelections(), cached.GetSelections())
+	require.EqualValues(t, cached2.GetSelections(versioned.Latest()), cached.GetSelections(versioned.Latest()))
 
 	user1.RemoveSelector(cached)
 	user2.RemoveSelector(cached2)
+
+	// All identities removed
+	require.Equal(t, 0, len(sc.selectors))
+}
+
+func TestTransactionalUpdate(t *testing.T) {
+	sc := testNewSelectorCache(identity.IdentityMap{})
+
+	// Add some identities to the identity cache
+	wg := &sync.WaitGroup{}
+	li1 := identity.IdentityScopeLocal
+	li2 := li1 + 1
+	sc.UpdateIdentities(identity.IdentityMap{
+		li1: labels.GetCIDRLabels(netip.MustParsePrefix("10.0.0.1/32")).LabelArray(),
+		li2: labels.GetCIDRLabels(netip.MustParsePrefix("10.0.0.0/8")).LabelArray(),
+	}, nil, wg)
+	wg.Wait()
+
+	// Test both exact and broader CIDR selectors
+	cidr32Selector := api.NewESFromLabels(labels.NewLabel("cidr:10.0.0.1/32", "", labels.LabelSourceCIDR))
+	cidr24Selector := api.NewESFromLabels(labels.NewLabel("cidr:10.0.0.0/24", "", labels.LabelSourceCIDR))
+	cidr8Selector := api.NewESFromLabels(labels.NewLabel("cidr:10.0.0.0/8", "", labels.LabelSourceCIDR))
+	cidr7Selector := api.NewESFromLabels(labels.NewLabel("cidr:10.0.0.0/7", "", labels.LabelSourceCIDR))
+
+	user1 := newUser(t, "user1", sc)
+
+	cs32 := user1.AddIdentitySelector(cidr32Selector)
+	cs24 := user1.AddIdentitySelector(cidr24Selector)
+	cs8 := user1.AddIdentitySelector(cidr8Selector)
+	cs7 := user1.AddIdentitySelector(cidr7Selector)
+
+	version := sc.versioned.GetVersionHandle()
+	defer version.Close()
+	require.Equal(t, identity.NumericIdentitySlice{li1}, cs32.GetSelections(version))
+	require.Equal(t, identity.NumericIdentitySlice{li1}, cs24.GetSelections(version))
+	require.Equal(t, identity.NumericIdentitySlice{li1, li2}, cs8.GetSelections(version))
+	require.Equal(t, identity.NumericIdentitySlice{li1, li2}, cs7.GetSelections(version))
+
+	// Add some identities to the identity cache
+	li3 := li2 + 1
+	li4 := li3 + 1
+	wg = &sync.WaitGroup{}
+	sc.UpdateIdentities(identity.IdentityMap{
+		li3: labels.GetCIDRLabels(netip.MustParsePrefix("10.0.0.0/31")).LabelArray(),
+		li4: labels.GetCIDRLabels(netip.MustParsePrefix("10.0.0.0/7")).LabelArray(),
+	}, nil, wg)
+	wg.Wait()
+
+	// Old version hold still gets the same selections as before
+	require.Equal(t, identity.NumericIdentitySlice{li1}, cs32.GetSelections(version))
+	require.Equal(t, identity.NumericIdentitySlice{li1}, cs24.GetSelections(version))
+	require.Equal(t, identity.NumericIdentitySlice{li1, li2}, cs8.GetSelections(version))
+	require.Equal(t, identity.NumericIdentitySlice{li1, li2}, cs7.GetSelections(version))
+
+	// New version handle sees the new updates on all selectors
+	version2 := sc.versioned.GetVersionHandle()
+	defer version2.Close()
+
+	require.Equal(t, identity.NumericIdentitySlice{li1}, cs32.GetSelections(version2))
+	require.Equal(t, identity.NumericIdentitySlice{li1, li3}, cs24.GetSelections(version2))
+	require.Equal(t, identity.NumericIdentitySlice{li1, li2, li3}, cs8.GetSelections(version2))
+	require.Equal(t, identity.NumericIdentitySlice{li1, li2, li3, li4}, cs7.GetSelections(version2))
+
+	// Remove some identities from the identity cache
+	wg = &sync.WaitGroup{}
+	sc.UpdateIdentities(nil, identity.IdentityMap{
+		li1: labels.GetCIDRLabels(netip.MustParsePrefix("10.0.0.1/32")).LabelArray(),
+	}, wg)
+	wg.Wait()
+
+	// Oldest version hold still gets the same selections as before
+	require.Equal(t, identity.NumericIdentitySlice{li1}, cs32.GetSelections(version))
+	require.Equal(t, identity.NumericIdentitySlice{li1}, cs24.GetSelections(version))
+	require.Equal(t, identity.NumericIdentitySlice{li1, li2}, cs8.GetSelections(version))
+	require.Equal(t, identity.NumericIdentitySlice{li1, li2}, cs7.GetSelections(version))
+
+	require.Equal(t, identity.NumericIdentitySlice{li1}, cs32.GetSelections(version2))
+	require.Equal(t, identity.NumericIdentitySlice{li1, li3}, cs24.GetSelections(version2))
+	require.Equal(t, identity.NumericIdentitySlice{li1, li2, li3}, cs8.GetSelections(version2))
+	require.Equal(t, identity.NumericIdentitySlice{li1, li2, li3, li4}, cs7.GetSelections(version2))
+
+	// New version handle sees the removal
+	version3 := sc.versioned.GetVersionHandle()
+	defer version3.Close()
+
+	require.Equal(t, identity.NumericIdentitySlice(nil), cs32.GetSelections(version3))
+	require.Equal(t, identity.NumericIdentitySlice{li3}, cs24.GetSelections(version3))
+	require.Equal(t, identity.NumericIdentitySlice{li2, li3}, cs8.GetSelections(version3))
+	require.Equal(t, identity.NumericIdentitySlice{li2, li3, li4}, cs7.GetSelections(version3))
+
+	user1.RemoveSelector(cs32)
+	user1.RemoveSelector(cs24)
+	user1.RemoveSelector(cs8)
+	user1.RemoveSelector(cs7)
 
 	// All identities removed
 	require.Equal(t, 0, len(sc.selectors))
@@ -504,7 +601,7 @@ func TestSelectorManagerCanGetBeforeSet(t *testing.T) {
 		key:   "test",
 		users: make(map[CachedSelectionUser]struct{}),
 	}
-	selections := idSel.GetSelections()
+	selections := idSel.GetSelections(versioned.Latest())
 	require.NotEqual(t, nil, selections)
 	require.Equal(t, 0, len(selections))
 }

--- a/pkg/proxy/endpoint/endpoint.go
+++ b/pkg/proxy/endpoint/endpoint.go
@@ -4,6 +4,7 @@
 package endpoint
 
 import (
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -36,4 +37,6 @@ type EndpointUpdater interface {
 	// OnDNSPolicyUpdateLocked is called when the Endpoint's DNS policy has been updated.
 	// 'rules' is a fresh copy of the DNS rules passed to the callee.
 	OnDNSPolicyUpdateLocked(rules restore.DNSRules)
+
+	GetPolicyVersionHandle() *versioned.VersionHandle
 }

--- a/pkg/proxy/endpoint/test/updater_mock.go
+++ b/pkg/proxy/endpoint/test/updater_mock.go
@@ -4,15 +4,17 @@
 package test
 
 import (
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 type ProxyUpdaterMock struct {
-	Id   uint64
-	Ipv4 string
-	Ipv6 string
+	Id            uint64
+	Ipv4          string
+	Ipv6          string
+	VersionHandle *versioned.VersionHandle
 }
 
 func (m *ProxyUpdaterMock) GetID() uint64 { return m.Id }
@@ -32,3 +34,7 @@ func (m *ProxyUpdaterMock) UpdateProxyStatistics(proxyTypet, l4Protocol string, 
 }
 
 func (m *ProxyUpdaterMock) OnDNSPolicyUpdateLocked(rules restore.DNSRules) {}
+
+func (m *ProxyUpdaterMock) GetPolicyVersionHandle() *versioned.VersionHandle {
+	return m.VersionHandle
+}


### PR DESCRIPTION
Make SelectorCache identity updates transactional. This allows changes to selections of different selectors to appear at once on a new version published by the selector cache after all the changes have been completed, which allows removal of the CIDR index within MapState, making computation of CIDR heavy policies ~45% faster, mainly due to reduction of allocations by ~37%.

This change allows SelectorCache users to rely on all the selectors to be in sync with each other, so that if a given identity is selected by multiple selectors, that identity appears in the result of the `GetSelections()` call for all of them. Previously it was possible that at the time of the respective GetSelections() calls, some of them would have failed to include the new identity, due to the update of that selector still being in progress.

With this change the visibility of new identities in the selections of any cached selector is delayed until all affected selectors have been updated.

Incremental updates are synchronized after each round of identity modifications in the selector cache so that the updates on all affected MapState entries appear during the same round of updates, essentially making incremental updates transactional as well. The consumer of incremental updates gets the version of the selector cache as of after the changes, so that a consistent NetworkPolicy can be computed for Envoy as well.

Now that SelectorCache GetSelections() and incremental updates are both transactional, we can rely on a covering CIDR selector to also select any covered new identities. For example, given a L3-only WORLD deny rule and an toFQDNs allow rule, and newly allocated FQDN identities are also selected by the deny WORLD selector, and we can rely on these new
identities appearing on those selectors "at the same time", so that on any given round of DistillPolicy or ConsumeMapChanges, any new identities appear on all affected selectors, and conversely, and removed identities are likewise removed from all affected selectors.

Given the above, we do not need to go look for non-wildcard superset/subset identities, as keys with them will be added (or have already been added) or removed on the same round and the effect of them will be present in the computed MapState. In the above example, even if on a given round we first add an allow rules the new FQDN-derived identity, we will later replace it with a deny entry based on the same ID being selected by the (deny) WORLD selector. Conversely, if on a given round we add the deny entry first, the allow entry will be naturally bailed due to the existing deny entry.

Following PR(s) have been carved out to merge separately:
- #34343
- #34346
- #34347
- #34349
- #34562
- #34679