### PR TITLE
[1.16 - manual backport] bgpv2: deprecate local port setting

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeerconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeerconfigs.yaml
@@ -221,9 +221,11 @@ spec:
                   used."
                 properties:
                   localPort:
-                    default: 179
-                    description: "LocalPort is the local port to be used for the BGP
-                      session. \n If not specified, defaults to TCP port 179."
+                    description: "Deprecated LocalPort is the local port to be used
+                      for the BGP session. \n If not specified, ephemeral port will
+                      be picked to initiate a connection. \n This field is deprecated
+                      and will be removed in a future release. Local port configuration
+                      is unnecessary and is not recommended."
                     format: int32
                     maximum: 65535
                     minimum: 1

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_peer_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_peer_types.go
@@ -124,14 +124,17 @@ type CiliumBGPFamilyWithAdverts struct {
 
 // CiliumBGPTransport defines the BGP transport parameters for the peer.
 type CiliumBGPTransport struct {
+	// Deprecated
 	// LocalPort is the local port to be used for the BGP session.
 	//
-	// If not specified, defaults to TCP port 179.
+	// If not specified, ephemeral port will be picked to initiate a connection.
+	//
+	// This field is deprecated and will be removed in a future release.
+	// Local port configuration is unnecessary and is not recommended.
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
-	// +kubebuilder:default=179
 	LocalPort *int32 `json:"localPort,omitempty"`
 
 	// PeerPort is the peer port to be used for the BGP session.


### PR DESCRIPTION
Deprecate setting local port for BGP peer transport configuration. Setting local port from user prospective is unnecessary, it should be ephemeral port picked by the kernel when establishing TCP connection.

There are various issues with setting local port manually
- Multiple peers using same peer config will conflict on usage of local port.
- `+kubebuilder:default=179` on local port is problematic, because even if users do not specify local port, it will be configured as 179.

Upstream commit :  https://github.com/cilium/cilium/commit/2193ab83dfe235861347c0ac47ee6f0c6f594329 
Fixes: #34016

```release-note
bgpv2: deprecate the usage of local port in peer transport.
```
