### PR TITLE
[v1.15] helm: Add validation to prevent users from using deprecated values that have been removed

### DIFF
--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -1,3 +1,17 @@
+{{/* validate deprecated options are not being used */}}
+{{- if .Values.tunnel }}
+  {{ fail "tunnel was deprecated in v1.14 and has been removed in v1.15. For details please refer to https://docs.cilium.io/en/v1.15/operations/upgrade/#helm-options" }}
+{{- end }}
+{{- if or (dig "clustermesh" "apiserver" "tls" "ca" "cert" "" .Values.AsMap) (dig "clustermesh" "apiserver" "tls" "ca" "key" "" .Values.AsMap) }}
+  {{ fail "clustermesh.apiserver.tls.ca.cert and clustermesh.apiserver.tls.ca.key were deprecated in v1.14 and has been removed in v1.15. For details please refer to https://docs.cilium.io/en/v1.15/operations/upgrade/#helm-options" }}
+{{- end }}
+{{- if .Values.enableK8sEventHandover }}
+  {{ fail "enableK8sEventHandover was deprecated in v1.14 and has been removed in v1.15. For details please refer to https://docs.cilium.io/en/v1.15/operations/upgrade/#helm-options" }}
+{{- end }}
+{{- if .Values.enableCnpStatusUpdates }}
+  {{ fail "enableCnpStatusUpdates was deprecated in v1.14 and has been removed in v1.15. For details please refer to https://docs.cilium.io/en/v1.15/operations/upgrade/#helm-options" }}
+{{- end }}
+
 {{/* validate hubble config */}}
 {{- if and .Values.hubble.ui.enabled (not .Values.hubble.ui.standalone.enabled) }}
   {{- if not .Values.hubble.relay.enabled }}


### PR DESCRIPTION
I've seen a few users who upgraded from v1.14 to v1.15 and encountered issues because they were still using the `tunnel: disabled`, and upon upgrading to v1.15, they suddenly found themselves using vxlan. In many cases, the upgrade proceeded but cilium failed in unexpected ways due to other configuration options being used that are incompatible with vxlan, such as the hybrid loadbalancer mode. An example of such an issue came up in this slack thread: https://cilium.slack.com/archives/C1MATJ5U5/p1722983084876839

To prevent these sorts of issues when upgrading, let's add some validation that fails the helm install/upgrade entirely if the user is specifying an option that was once previously valid, but has since been removed.

```release-note
helm: Add validation to prevent users from using deprecated values that have been removed
```
