### PR TITLE
policy: Minor Ownership Equality Update

### DIFF
--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -687,15 +687,17 @@ func (e *MapStateEntry) HasDependent(key Key) bool {
 	return ok
 }
 
-// HasSameOwners returns true if both MapStateEntries
-// have the same owners as one another (which means that
-// one of the entries is redundant).
-func (e *MapStateEntry) HasSameOwners(bEntry *MapStateEntry) bool {
-	if len(e.owners) != len(bEntry.owners) {
+// CoversOwners returns true if the receiver MapStateEntry
+// has all the owners that the argument MapStateEntry has.
+func (e *MapStateEntry) CoversOwners(bEntry *MapStateEntry) bool {
+	if bEntry == nil || len(bEntry.owners) == 0 {
+		return true
+	}
+	if len(e.owners) < len(bEntry.owners) {
 		return false
 	}
-	for owner := range e.owners {
-		if _, ok := bEntry.owners[owner]; !ok {
+	for owner := range bEntry.owners {
+		if _, ok := e.owners[owner]; !ok {
 			return false
 		}
 	}
@@ -1214,7 +1216,7 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 				ms.validator.isAnyOrSame(k, newKey, identities)
 			}
 			// Identical key needs to be added if owners are different (to merge them).
-			if !(k == newKey && !v.HasSameOwners(&newEntry)) {
+			if k == newKey && v.CoversOwners(&newEntry) {
 				// If the ID of this iterated-deny-entry is ANY or equal of
 				// the new-entry and the iterated-deny-entry has a broader (or
 				// equal) port-protocol then we need not insert the new entry.
@@ -1307,7 +1309,7 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 				ms.validator.isAnyOrSame(newKey, k, identities)
 			}
 			// Identical key needs to remain if owners are different to merge them
-			if !(k == newKey && !v.HasSameOwners(&newEntry)) {
+			if newKey == k && (&newEntry).CoversOwners(&v) {
 				// If this iterated-deny-entry is a subset (or equal) of the
 				// new-entry and the new-entry has a broader (or equal)
 				// port-protocol the newKey will match all the packets the iterated

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1507,42 +1507,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			}),
-			wantAdds: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
-			},
-			wantDeletes: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
-				Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
-			},
-			wantOld: map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
-				},
 				{
 					Identity:         1,
 					DestPort:         80,
@@ -1553,7 +1517,18 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         0,
+					InvertedPortMask: 0xffff,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
 			},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
 			name: "test-10b - L3 ingress deny KV should overwrite a L3-L4-L7 port-range ingress allow and a L3-L4 port-range deny",
@@ -1608,45 +1583,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			}),
-			wantAdds: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
-			},
-			wantDeletes: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
-				Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
-			},
-			wantOld: map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
-				},
 				{
 					Identity:         1,
 					DestPort:         64,
@@ -1658,7 +1594,18 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
+			}),
+			wantAdds: Keys{
+				Key{
+					Identity:         1,
+					DestPort:         0,
+					InvertedPortMask: 0xffff,
+					Nexthdr:          0,
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}: struct{}{},
 			},
+			wantDeletes: Keys{},
+			wantOld:     map[Key]MapStateEntry{},
 		},
 		{
 			name: "test-11a - L3 ingress allow should not be allowed if there is a L3 'all' deny",


### PR DESCRIPTION
The preferred insert methods that keep track
of MapState based on precedence determine
the redundancy of MapState entries via
ownership. The previous method, HasSameOwners
used too strict a comparison, wherein the
MapStateEntries were only redundant if their
ownership groups were exactly equal. This is
not correct. The method should instead check
that the receiver MapStateEntry "covers" all
of the owners belonging to the argument
MapStateEntry.
