### PR TITLE
Do not exclude dummy devices during local addr detection

### DIFF
--- a/pkg/node/ip_linux.go
+++ b/pkg/node/ip_linux.go
@@ -23,6 +23,13 @@ func initExcludedIPs() {
 		return
 	}
 	for _, l := range links {
+		// Don't exclude dummy devices, since they may be setup by
+		// processes like nodelocaldns and they aren't always brought up. See
+		// https://github.com/kubernetes/dns/blob/fa0192f004c9571cf24d8e9868be07f57380fccb/pkg/netif/netif.go#L24-L36
+		// Such devices in down state may still be relevant.
+		if l.Type() == "dummy" {
+			continue
+		}
 		// ... also all down devices since they won't be reachable.
 		//
 		// We need to check for both "up" and "unknown" state, as some


### PR DESCRIPTION
Processes like `nodelocaldns (NLD)` might setup a dummy device and attach a custom IP to them. But these devices aren't always brought up. See [kubernetes/dns](https://github.com/kubernetes/dns/blob/fa0192f004c9571cf24d8e9868be07f57380fccb/pkg/netif/netif.go#L24-L36). Currently devices that are in down state are excluded. If NLD IP isn't recognized as a local address, when bpf host routing is used, traffic to NLD IP would go through fib_lookup. This lookup will fail because fib_lookup doesn't work for local routes.

This is currently a blocker for enabling bpf host routing while using NLD in host network.

<img width="670" alt="Screenshot 2024-08-07 at 12 32 28 PM" src="https://github.com/user-attachments/assets/24a779a5-e975-4df9-9dad-22fbee276626">

```
root@i<>:/home/cilium# ip a
....
3: nodelocaldns: <BROADCAST,NOARP> mtu 9001 qdisc noop state DOWN group default qlen 1000
    link/ether 7a:2e:4c:35:90:7b brd ff:ff:ff:ff:ff:ff
    inet 169.254.20.10/32 scope global nodelocaldns
       valid_lft forever preferred_lft forever
...
```
_Side Note : LRP isn't stable until 1.16 as an alternative for running NLD in pod network_

```release-note
Addresses attached to dummy devices aren't ignored from node addresses even if the device is down, unblocking usage of host network nodelocaldns with eBPF host routing.
```
