### PR TITLE
helm: Add validation to prevent users from using deprecated values that have been removed in v1.15 and v1.16

### DIFF
--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -1,3 +1,17 @@
+{{/* validate deprecated options are not being used */}}
+{{- if .Values.tunnel }}
+  {{ fail "tunnel was deprecated in v1.14 and has been removed in v1.15. For details please refer to https://docs.cilium.io/en/v1.15/operations/upgrade/#helm-options" }}
+{{- end }}
+{{- if or (dig "clustermesh" "apiserver" "tls" "ca" "cert" "" .Values.AsMap) (dig "clustermesh" "apiserver" "tls" "ca" "key" "" .Values.AsMap) }}
+  {{ fail "clustermesh.apiserver.tls.ca.cert and clustermesh.apiserver.tls.ca.key were deprecated in v1.14 and has been removed in v1.15. For details please refer to https://docs.cilium.io/en/v1.15/operations/upgrade/#helm-options" }}
+{{- end }}
+{{- if .Values.enableK8sEventHandover }}
+  {{ fail "enableK8sEventHandover was deprecated in v1.14 and has been removed in v1.15. For details please refer to https://docs.cilium.io/en/v1.15/operations/upgrade/#helm-options" }}
+{{- end }}
+{{- if .Values.enableCnpStatusUpdates }}
+  {{ fail "enableCnpStatusUpdates was deprecated in v1.14 and has been removed in v1.15. For details please refer to https://docs.cilium.io/en/v1.15/operations/upgrade/#helm-options" }}
+{{- end }}
+
 {{/* validate hubble config */}}
 {{- if and .Values.hubble.ui.enabled (not .Values.hubble.ui.standalone.enabled) }}
   {{- if not .Values.hubble.relay.enabled }}

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -1,4 +1,34 @@
 {{/* validate deprecated options are not being used */}}
+
+{{/* Options deprecated in v1.15 and removed in v1.16 */}}
+{{- if or
+  (dig "encryption" "keyFile" "" .Values.AsMap)
+  (dig "encryption" "mountPath" "" .Values.AsMap)
+  (dig "encryption" "secretName" "" .Values.AsMap)
+  (dig "encryption" "interface" "" .Values.AsMap)
+}}
+  {{ fail "encryption.{keyFile,mountPath,secretName,interface} were deprecated in v1.14 and has been removed in v1.16. For details please refer to https://docs.cilium.io/en/v1.16/operations/upgrade/#helm-options" }}
+{{- end }}
+{{- if or
+  ((dig "proxy" "prometheus" "enabled" "" .Values.AsMap) | toString)
+  (dig "proxy" "prometheus" "port" "" .Values.AsMap)
+}}
+  {{ fail "proxy.prometheus.enabled and proxy.prometheus.port were deprecated in v1.14 and has been removed in v1.16. For details please refer to https://docs.cilium.io/en/v1.16/operations/upgrade/#helm-options" }}
+{{- end }}
+{{- if (dig "endpointStatus" "" .Values.AsMap) }}
+  {{ fail "endpointStatus has been removed in v1.16. For details please refer to https://docs.cilium.io/en/v1.16/operations/upgrade/#helm-options" }}
+{{- end }}
+{{- if (dig "remoteNodeIdentity" "" .Values.AsMap) }}
+  {{ fail "remoteNodeIdentity was deprecated in v1.15 and has been removed in v1.16. For details please refer to https://docs.cilium.io/en/v1.16/operations/upgrade/#helm-options" }}
+{{- end }}
+{{- if (dig "containerRuntime" "integration" "" .Values.AsMap) }}
+  {{ fail "containerRuntime.integration was deprecated in v1.14 and has been removed in v1.16. For details please refer to https://docs.cilium.io/en/v1.16/operations/upgrade/#helm-options" }}
+{{- end }}
+{{- if (dig "etcd" "managed" "" .Values.AsMap) }}
+  {{ fail "etcd.managed was deprecated in v1.10 has been removed in v1.16. For details please refer to https://docs.cilium.io/en/v1.16/operations/upgrade/#helm-options" }}
+{{- end }}
+
+{{/* Options deprecated in v1.14 and removed in v1.15 */}}
 {{- if .Values.tunnel }}
   {{ fail "tunnel was deprecated in v1.14 and has been removed in v1.15. For details please refer to https://docs.cilium.io/en/v1.15/operations/upgrade/#helm-options" }}
 {{- end }}


### PR DESCRIPTION
This is a follow up to the PR I did for v1.15: https://github.com/cilium/cilium/pull/34213

I cherry-picked and amended the first commit taken from the PR for v1.15 and added additional validations for v1.16. I believe the validations for the options removed in v1.15 are still useful even if users are upgrading between minor versions because it's possible they're copying values from a blog or an outdated guide that's using the removed options.

Motivation:

I've seen a few users who upgraded from v1.14 to v1.15 and encountered issues because they were still using the `tunnel: disabled`, and upon upgrading to v1.15, they suddenly found themselves using vxlan. In many cases, the upgrade proceeded but cilium failed in unexpected ways due to other configuration options being used that are incompatible with vxlan, such as the hybrid loadbalancer mode. An example of such an issue came up in this slack thread: https://cilium.slack.com/archives/C1MATJ5U5/p1722983084876839

To prevent these sorts of issues when upgrading, let's add some validation that fails the helm install/upgrade entirely if the user is specifying an option that was once previously valid, but has since been removed.

In the future, perhaps the helm schema validation will catch some of these, but based on my testing thus far, it does not catch these issues because we currently allow unspecified additional fields via the `additionalProperties` option. This is due to the fact that our schema is generated from the `values.yaml` and we do not actually include all possible values in the values.yaml, and leave some option specified in the values.yaml. If we were to ensure values.yaml included all possible values, then we could generate our helm schema from the values.yaml and disable the options to allow unknown fields, obviating the need for this additional validation. 

Since this would help users upgrading from v1.15 to v1.16, I'mm nominating it for backport. 

Ideally we would ensure this gets updated whenever someone deprecates a new field, but we do not seem to have an official or standard process for deprecation, other than having maintainers ensure it's documented. I'll try to inform the Cilium maintainers so that we can ensure this is updated for v1.17 as well.

```release-note
Add validation to prevent users from using deprecated values that have been removed in v1.15 and v1.16
```
