### PR TITLE
Documentation: Introduce support for redirects

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -64,7 +64,7 @@ jobs:
           # Needed to detect missing redirects
           fetch-depth: 0
       - name: Build HTML
-        uses: docker://quay.io/cilium/docs-builder:ea8511e4d2b39d2ef7a4c71edbe6eddb19e8bb5c@sha256:3a04bb23e017dfb229c0139a3ff7208a6d4ec3944bc24b8441c73ed7d70d781f
+        uses: docker://quay.io/cilium/docs-builder:7ca68722994a8fb0bf5778d3d13b2f29cd8472c8@sha256:94947b159622d7bcd280ce72a9df79575b09b3930b14051c6af948b0ffc5bab6
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -61,6 +61,8 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           persist-credentials: false
+          # Needed to detect missing redirects
+          fetch-depth: 0
       - name: Build HTML
         uses: docker://quay.io/cilium/docs-builder:ea8511e4d2b39d2ef7a4c71edbe6eddb19e8bb5c@sha256:3a04bb23e017dfb229c0139a3ff7208a6d4ec3944bc24b8441c73ed7d70d781f
         with:
@@ -76,6 +78,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           persist-credentials: false
+          # Needed to detect missing redirects
       - name: Install Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -54,6 +54,9 @@ READTHEDOCS_VERSION ?= latest
 DOCKER_CTR_ROOT_DIR := /src
 DOCKER_CTR_BASE := $(CONTAINER_ENGINE) container run --rm \
 		--workdir $(DOCKER_CTR_ROOT_DIR)/Documentation \
+		--env GIT_CONFIG_COUNT=1 \
+		--env GIT_CONFIG_KEY_0=safe.directory \
+		--env GIT_CONFIG_VALUE_0=$(DOCKER_CTR_ROOT_DIR) \
 		--volume $(CURDIR)/..:$(DOCKER_CTR_ROOT_DIR) \
 		--user "$(shell id -u):$(shell id -g)"
 DOCKER_CTR := $(DOCKER_CTR_BASE) \
@@ -147,6 +150,12 @@ live-preview: builder-image ## Build and serve the documentation locally.
 		--publish $(DOCS_PORT):$(DOCS_PORT) \
 			$(DOCS_BUILDER_IMG) \
 		sphinx-autobuild --open-browser --host 0.0.0.0 --port $(DOCS_PORT) $(SPHINX_OPTS) --ignore *.swp -Q . _preview
+
+update-redirects: builder-image ## Build and serve the documentation locally.
+	@echo "$$(tput setaf 2)Writing redirects$$(tput sgr0)"
+	$(QUIET)$(DOCKER_CTR) \
+		$(DOCS_BUILDER_IMG) \
+		sphinx-build -M rediraffewritediff . _preview
 
 ##@ Development
 

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -153,7 +153,7 @@ live-preview: builder-image ## Build and serve the documentation locally.
 update-requirements: base-image $(REQUIREMENTS_NODEP) ## Regenerate the requirements.txt file from requirements-min/requirements.txt.
 	@echo '## Auto-generated from $(REQUIREMENTS_NODEP) with "make update-requirements"' > $(REQUIREMENTS)
 	$(QUIET)$(DOCKER_CTR_BASE) $(DOCS_BASE_IMG) \
-		bash -c "pip install -r $(REQUIREMENTS_NODEP) && pip freeze -r $(REQUIREMENTS_NODEP) >> $(REQUIREMENTS)"
+		bash -c "export HOME=/tmp && pip install --no-warn-script-location -r $(REQUIREMENTS_NODEP) && pip freeze -r $(REQUIREMENTS_NODEP) >> $(REQUIREMENTS)"
 
 clean: ## Clean up all artefacts from documentation.
 	-$(QUIET)rm -rf _build _exts/__pycache__ _preview Pipfile Pipfile.lock

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -44,7 +44,18 @@ extensions = ['myst_parser',
               'sphinx_tabs.tabs',
               'sphinxcontrib.googleanalytics',
               'sphinxcontrib.spelling',
-              'versionwarning.extension']
+              'versionwarning.extension',
+              "sphinxext.rediraffe",
+]
+
+rediraffe_redirects = 'redirects.txt'
+# rediraffe_branch is the base for which rediraffe compares the current HEAD to
+# to detect which Documentation pages have moved or been deleted so it can
+# check for missing redirects and automatically generate new redirect files.
+# The value specified is the commit before we branched v1.16 found using:
+# `git merge-base v1.16 main`
+rediraffe_branch = '5614531067a83e20d24bccc7b12b314330d043c3'
+rediraffe_auto_redirect_perc = 90
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/Documentation/redirects.txt
+++ b/Documentation/redirects.txt
@@ -1,0 +1,1 @@
+"network/egress-gateway.rst" "network/egress-gateway/egress-gateway.rst"

--- a/Documentation/requirements-min/requirements.txt
+++ b/Documentation/requirements-min/requirements.txt
@@ -15,6 +15,7 @@ sphinxcontrib-googleanalytics==0.4
 sphinxcontrib-openapi==0.8.1
 sphinxcontrib-spelling==8.0.0
 sphinxcontrib-websupport==1.2.4
+sphinxext-rediraffe==0.2.7
 
 # Linters
 rstcheck==6.2.0

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -14,6 +14,7 @@ sphinxcontrib-googleanalytics==0.4
 sphinxcontrib-openapi==0.8.1
 sphinxcontrib-spelling==8.0.0
 sphinxcontrib-websupport==1.2.4
+sphinxext-rediraffe==0.2.7
 # Linters
 rstcheck==6.2.0
 yamllint==1.32.0


### PR DESCRIPTION
Introduce support for redirects in the documentation using [sphinxext-rediraffe](https://github.com/wpilibsuite/sphinxext-rediraffe).

## Motivation

Ensuring previously working URLs do not 404, but rather send users to the new location will improve user experience and improve SEO. Additionally, by supporting redirects, it reduces the likelihood that someone might be hesitant to do larger refactors of the documentation in fear of breaking existing links. In general, preserving links using redirects is "the right thing to do". 

## Details

sphinxext-rediraffe uses the git history to determine what has changed to determine if there are missing redirects, enabling us to validate that redirects are created whenever someone moves docs, ensuring that refactoring documentation by moving pages never produces broken links, which has been a long standing issue for the Cilium documentation.

I had a few issues updating dependencies, which you will see some fixes for this in the first 2 commits. In the remaining changes I incrementally added basic support for using rediraffe, then improved upon those changes, introducing better validation messages in `check-build.sh` and adding a Makefile target to automatically generate `redirects.txt`. While adding the new Makefile target I hit the git safe directory issue and found a "better" alternative using `GIT_CONFIG_` env variables, which avoids needing to mess with the git configuration entirely.


## Backport

I propose we backport this to v1.16 since I'm planning to re-organize some of the Hubble documentation in v1.16 and would like to ensure existing links to the docs being moved continue to work. We will likely hit a few conflicts with the docs image used, but I can manually backport this change since it's likely we'll see conflicts.

## Examples

An example of the validation in action:


Let's say we moved a documentation file somewhere else as part of a docs reorganization project:
```
$ git mv Documentation/further_reading.rst Documentation/further_reading_new.rst                   
```

Then we update the relevant TOC and we build the docs:
```
$ make -C Documentation clean html
...

Please fix the following missing redirects:
ERROR: (broken) /src/Documentation/further_reading.rst was deleted but is not redirected! Hint: This file was renamed to /src/Documentation/further_reading_new.rst with a similarity of 100%.

Tip, try running:
make -C Documentation update-redirects
```

Let's see our current git repo status:
```
$ git diff
diff --git a/Documentation/further_reading.rst b/Documentation/further_reading_new.rst
similarity index 100%
rename from Documentation/further_reading.rst
rename to Documentation/further_reading_new.rst
diff --git a/Documentation/index.rst b/Documentation/index.rst
index f260a4b0e1..d421e5f4b7 100644
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -147,7 +147,7 @@ get started and experiment with Cilium.
    cmdref/index
    helm-reference
    kvstore
-   further_reading
+   further_reading_new
    glossary
 
 .. toctree::
```

And let's run `make -C Documentation update-redirects` as suggested:
```
$ make -C Documentation update-redirects
...
building [rediraffewritediff]: targets for 0 source files that are out of date
looking for now-outdated files... none found
no targets are out of date.
rediraffe: Redirect generation skipped for unsupported builders. Supported builders: html, dirhtml, readthedocs, readthedocsdirhtml.
build succeeded.
```

Now let's check what it did:
```
$ git diff
diff --git a/Documentation/redirects.txt b/Documentation/redirects.txt
index e69de29bb2..db958c5a9f 100644
--- a/Documentation/redirects.txt
+++ b/Documentation/redirects.txt
@@ -0,0 +1 @@
+"further_reading.rst" "further_reading_new.rst"
```

Great it detected the file moved and generated a redirect.

What does the `redirects.txt` do? It's quite simple. If we build the `html` target we can look at the file generated in the previous page location at `Documentation/_build/html/further_reading.html`:

```
$ cat Documentation/_build/html/further_reading.html
<html>
    <head>
        <noscript>
            <meta http-equiv="refresh" content="0; url=further_reading_new.html"/>
        </noscript>
    </head>
    <body>
        <script>
            window.location.href = 'further_reading_new.html' + (window.location.search || '') + (window.location.hash || '');
        </script>
        <p>You should have been redirected.</p>
        <a href="further_reading_new.html">If not, click here to continue.</a>
    </body>
</html>
```

As you can see, sphinxext-rediraffe generates a new page which does two important things:
- It sets a `<meta>` tag with the `http-equiv="refresh"` attribute and the url set to the new page, which user-agents can use to do a client side redirect. This is put into a `<noscript>` tag so this is only applied when the user-agent isn't running Javascript. 
- It creates a `<script>` tag with some Javascript to redirect the user to the new page. This is used for when a user-agent does have Javascript enabled.

As you can see it the generated page does a redirect. The approach taken is very common with static website generators since we don't have much control over the web-server for the site (eg: readthedocs) and this allows us to do client side redirects without having to manage redirects outside of the project. This means we can do larger refactors of the documentation while still preserving links, without the difficulty of asking an admin to add redirects into readthedocs, which in bigger refactors can be untenable. Additionally, many web hosts will limit the number of redirects they support, meaning we could run into issues once we hit their configurable redirect's limit. This approach avoids most of those issues, with the trade-off of the redirects being client side. However client side redirects are well supported by web crawlers and browser based user-agents so this should be acceptable.