### PR TITLE
[v1.15] Revert "docs: Update LRP feature status"

### DIFF
--- a/Documentation/community/roadmap.rst
+++ b/Documentation/community/roadmap.rst
@@ -32,8 +32,6 @@ Major Feature Status
 ++-------------------------------------------------+----------------------------------------------------------+
 || :ref:`bandwidth-manager`                        | Stable                                                   |
 ++-------------------------------------------------+----------------------------------------------------------+
-|| :ref:`local-redirect-policy`                    | Stable                                                   |
-++-------------------------------------------------+----------------------------------------------------------+
 | Cilium Mesh                                      | Stable (:ref:`Roadmap Details<rm-clustermesh>`)          |
 ++-------------------------------------------------+----------------------------------------------------------+
 || :ref:`Multi-Cluster (ClusterMesh)<clustermesh>` | Stable                                                   |
@@ -128,6 +126,7 @@ these are already in production use with a set of adopters. We expect the
 following features to graduate to stable:
 
 * :ref:`BGP<bgp>`
+* :ref:`Local Redirect Policy<local-redirect-policy>`
 * :ref:`CiliumEndpointSlice<gsg_ces>`
 * :ref:`Multi-Pool IPAM<ipam_crd_multi_pool>`
 * :ref:`Node-to-node WireGuard encryption<node-node-wg>`


### PR DESCRIPTION
This reverts commit 75d68317089d14ea3c9433367d3e67389e2f6dab.

The commit to promote the LRP feature status to stable was incorrectly backported to v1.15. (LRP is beta in v1.15.)