### PR TITLE
[v1.14] Revert "docs: Update LRP feature status"

### DIFF
--- a/Documentation/community/roadmap.rst
+++ b/Documentation/community/roadmap.rst
@@ -32,8 +32,6 @@ Major Feature Status
 ++-------------------------------------------------+----------------------------------------------------------+
 || :ref:`bandwidth-manager`                        | Stable                                                   |
 ++-------------------------------------------------+----------------------------------------------------------+
-|| :ref:`local-redirect-policy`                    | Stable                                                   |
-++-------------------------------------------------+----------------------------------------------------------+
 | Cilium Mesh                                      | Stable (:ref:`Roadmap Details<rm-clustermesh>`)          |
 ++-------------------------------------------------+----------------------------------------------------------+
 || :ref:`Multi-Cluster (ClusterMesh)<clustermesh>` | Stable                                                   |
@@ -133,6 +131,7 @@ these are already in production use with a set of adopters. We expect the
 following features to graduate to stable:
 
 * :ref:`BGP<bgp>`
+* :ref:`Local Redirect Policy<local-redirect-policy>`
 * :ref:`CiliumEndpointSlice<gsg_ces>`
 * :ref:`Multi-Pool IPAM<ipam_crd_multi_pool>`
 * :ref:`Node-to-node WireGuard encryption<node-node-wg>`


### PR DESCRIPTION
This reverts commit 95c15bf5de17ab8bb12c4d7d922b9171fe1825c7.

The commit to promote the LRP feature status to stable was incorrectly backported to v1.14. (LRP is beta in v1.14.)
