### PR TITLE
Remove deprecated call to DialContext in Hubble

### DIFF
--- a/hubble/cmd/common/conn/tls.go
+++ b/hubble/cmd/common/conn/tls.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/cilium/cilium/hubble/cmd/common/config"
 	"github.com/cilium/cilium/hubble/pkg/defaults"
@@ -22,7 +23,7 @@ import (
 func grpcOptionTLS(vp *viper.Viper) (grpc.DialOption, error) {
 	target := vp.GetString(config.KeyServer)
 	if !(vp.GetBool(config.KeyTLS) || strings.HasPrefix(target, defaults.TargetTLSPrefix)) {
-		return grpc.WithInsecure(), nil
+		return grpc.WithTransportCredentials(insecure.NewCredentials()), nil
 	}
 
 	tlsConfig := tls.Config{

--- a/hubble/cmd/list/namespaces.go
+++ b/hubble/cmd/list/namespaces.go
@@ -26,7 +26,7 @@ func newNamespacesCommand(vp *viper.Viper) *cobra.Command {
 		Short: "List namespaces with recent flows",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
-			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
 			if err != nil {
 				return err
 			}

--- a/hubble/cmd/list/node.go
+++ b/hubble/cmd/list/node.go
@@ -33,7 +33,7 @@ func newNodeCommand(vp *viper.Viper) *cobra.Command {
 		Short:   "List Hubble nodes",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
-			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
 			if err != nil {
 				return err
 			}

--- a/hubble/cmd/observe/agent_events.go
+++ b/hubble/cmd/observe/agent_events.go
@@ -45,7 +45,7 @@ func newAgentEventsCommand(vp *viper.Viper) *cobra.Command {
 			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
 			defer cancel()
 
-			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
 			if err != nil {
 				return err
 			}

--- a/hubble/cmd/observe/debug_events.go
+++ b/hubble/cmd/observe/debug_events.go
@@ -44,7 +44,7 @@ func newDebugEventsCommand(vp *viper.Viper) *cobra.Command {
 			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
 			defer cancel()
 
-			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
 			if err != nil {
 				return err
 			}

--- a/hubble/cmd/observe/flows.go
+++ b/hubble/cmd/observe/flows.go
@@ -159,7 +159,7 @@ var GetHubbleClientFunc = func(ctx context.Context, vp *viper.Viper) (client obs
 		return client, cleanup, nil
 	}
 	// read flows from a hubble server
-	hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+	hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/hubble/cmd/record/record.go
+++ b/hubble/cmd/record/record.go
@@ -62,7 +62,7 @@ protocols are TCP, UDP, SCTP, and ANY.`,
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
 			if err != nil {
 				return err
 			}

--- a/hubble/cmd/reflect/reflect.go
+++ b/hubble/cmd/reflect/reflect.go
@@ -28,7 +28,7 @@ func New(vp *viper.Viper) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
 			if err != nil {
 				return err
 			}

--- a/hubble/cmd/status/status.go
+++ b/hubble/cmd/status/status.go
@@ -36,7 +36,7 @@ func New(vp *viper.Viper) *cobra.Command {
 connectivity health check.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
 			if err != nil {
 				return err
 			}

--- a/hubble/cmd/watch/peer.go
+++ b/hubble/cmd/watch/peer.go
@@ -29,7 +29,7 @@ func newPeerCommand(vp *viper.Viper) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Remove deprecated call to DialContext in Hubble

Related:#32274, #33065

Signed-off-by: David Chosrova <dchosrova@gmail.com>