### PR TITLE
gha: Free up Github runner disk space

### DIFF
--- a/.github/actions/disk-cleanup/action.yaml
+++ b/.github/actions/disk-cleanup/action.yaml
@@ -1,0 +1,28 @@
+name: Disk cleanup
+description: "Cleanup disk space"
+runs:
+  using: composite
+  steps:
+    - name: Free up disk space
+      shell: bash
+      run: |
+        echo "Disk space before cleanup..."
+        df -h /
+        echo "Removing unnecessary files to free up disk space..."
+        # https://github.com/actions/runner-images/issues/2840#issuecomment-2272410832
+        sudo rm -rf \
+          /opt/hostedtoolcache \
+          /opt/google/chrome \
+          /opt/microsoft/msedge \
+          /opt/microsoft/powershell \
+          /opt/pipx \
+          /usr/lib/mono \
+          /usr/local/julia* \
+          /usr/local/lib/android \
+          /usr/local/lib/node_modules \
+          /usr/local/share/chromium \
+          /usr/local/share/powershell \
+          /usr/share/dotnet \
+          /usr/share/swift
+        echo "Disk space after cleanup..."
+        df -h /

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -122,6 +122,9 @@ jobs:
           ref: ${{ inputs.context-ref || github.sha }}
           persist-credentials: false
 
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
+
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 


### PR DESCRIPTION
### Description

We are having the below failure due to no disk space, it seems like we can remove pre-installed software and language runtimes, which are not use in Cilium, to reclaim more disk space.

Alternative option is to bump the runner, but it might not be the best resource and cost utilization.

Relates: https://github.com/cilium/cilium/actions/runs/10300396788
Relates: https://github.com/actions/runner-images/issues/2840#issuecomment-2272410832

_Note_: only integration test workflow is updated with disk cleanup step right now

### Testing

With this cleanup step, we are easily re-claiming a huge amount of ~28+ GB (i.e. 19 -> 47GB).

```
Disk space before cleanup...
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   55G   19G  75% /
Removing unnecessary files to free up disk space...
Agent tool dir: /opt/hostedtoolcache
Disk space after cleanup...
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   27G   47G  36% /
```