### PR TITLE
daemon: Fix parsing of complex api-rate-limit arguments

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -19,7 +19,7 @@ cilium-agent [flags]
       --allow-icmp-frag-needed                                    Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
       --allow-localhost string                                    Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
       --annotate-k8s-node                                         Annotate Kubernetes node
-      --api-rate-limit stringToString                             API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default [])
+      --api-rate-limit string                                     API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
       --arping-refresh-period duration                            Period for remote node ARP entry refresh (set 0 to disable) (default 30s)
       --auto-create-cilium-node-resource                          Automatically create CiliumNode resource for own node on startup (default true)
       --auto-direct-node-routes                                   Enable automatic L2 routing between nodes

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -12,7 +12,7 @@ cilium-agent hive [flags]
 
 ```
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
-      --api-rate-limit stringToString                             API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default [])
+      --api-rate-limit string                                     API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --cluster-id uint32                                         Unique identifier of the cluster

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -18,7 +18,7 @@ cilium-agent hive dot-graph [flags]
 
 ```
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
-      --api-rate-limit stringToString                             API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default [])
+      --api-rate-limit string                                     API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --cluster-id uint32                                         Unique identifier of the cluster

--- a/daemon/restapi/api_limits_test.go
+++ b/daemon/restapi/api_limits_test.go
@@ -6,7 +6,9 @@ package restapi
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/cilium/hive/cell"
@@ -19,15 +21,36 @@ import (
 	"github.com/cilium/cilium/pkg/rate"
 )
 
+var testLimits = map[string]string{
+	APIRequestEndpointCreate: "rate-limit:42/m,rate-burst:1",
+	APIRequestEndpointDelete: "rate-limit:72/s,rate-burst:2",
+}
+
+func testLimitsKVString() string {
+	var limits []string
+	for k, v := range testLimits {
+		limits = append(limits, k+"="+v)
+	}
+	return strings.Join(limits, ",")
+}
+
+func testLimitsJSONString() string {
+	bs, err := json.Marshal(testLimits)
+	if err != nil {
+		panic(err)
+	}
+	return string(bs)
+}
+
 // TestRateLimiterConfigFlag checks that rateLimiterConfig is properly parsed from
 // command-line flag.
-func testRateLimiterConfig(t *testing.T, burst int, setConfig func(h *hive.Hive, limiter string, limits string)) {
+func testRateLimiterConfig(t *testing.T, setConfig func(h *hive.Hive)) {
 	var limiterSet *rate.APILimiterSet
 	take := cell.Invoke(func(l *rate.APILimiterSet) { limiterSet = l })
 
 	h := hive.New(rateLimiterCell, take)
 
-	setConfig(h, APIRequestEndpointCreate, fmt.Sprintf("rate-limit:42/m,rate-burst:%d", burst))
+	setConfig(h)
 	tlog := hivetest.Logger(t)
 	assert.Nil(t, h.Start(tlog, context.TODO()))
 
@@ -36,18 +59,26 @@ func testRateLimiterConfig(t *testing.T, burst int, setConfig func(h *hive.Hive,
 
 	p := l.Parameters()
 	assert.Equal(t, timeRate.Limit(42.0/60.0), p.RateLimit)
-	assert.Equal(t, burst, p.RateBurst)
+	assert.Equal(t, 1, p.RateBurst)
+
+	l = limiterSet.Limiter(APIRequestEndpointDelete)
+	assert.NotNil(t, l)
+
+	p = l.Parameters()
+	assert.Equal(t, timeRate.Limit(72.0), p.RateLimit)
+	assert.Equal(t, 2, p.RateBurst)
+
 	assert.Nil(t, h.Stop(tlog, context.TODO()))
 }
 
 // TestRateLimiterConfigFlag checks that rateLimiterConfig is properly parsed from
 // command-line flag.
 func TestRateLimiterConfigFlag(t *testing.T) {
-	testRateLimiterConfig(t, 1234,
-		func(h *hive.Hive, limiter string, limits string) {
+	testRateLimiterConfig(t,
+		func(h *hive.Hive) {
 			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 			h.RegisterFlags(flags)
-			err := flags.Parse([]string{"--api-rate-limit", limiter + "=" + limits})
+			err := flags.Parse([]string{"--api-rate-limit", testLimitsKVString()})
 			assert.Nil(t, err, "failed to parse flags")
 		})
 }
@@ -55,13 +86,42 @@ func TestRateLimiterConfigFlag(t *testing.T) {
 // TestRateLimiterConfigFile checks that rateLimiterConfig is properly parsed from
 // a config file.
 func TestRateLimiterConfigFile(t *testing.T) {
-	testRateLimiterConfig(t, 1235,
-		func(h *hive.Hive, limiter string, limits string) {
-			cfg := fmt.Sprintf("api-rate-limit:\n  %s: %s\n", limiter, limits)
+	testRateLimiterConfig(t,
+		func(h *hive.Hive) {
+			cfg := fmt.Sprintf("api-rate-limit: %s\n", testLimitsKVString())
 			buf := bytes.NewReader([]byte(cfg))
 			v := h.Viper()
 			v.SetConfigType("yaml")
 			err := v.ReadConfig(buf)
 			assert.Nil(t, err, "failed to ReadConfig with Viper")
+		})
+}
+
+// TestRateLimiterConfigDir checks that rateLimiterConfig is properly parsed from
+// a config directory.
+func TestRateLimiterConfigDir(t *testing.T) {
+	// Test with k=v string
+	testRateLimiterConfig(t,
+		func(h *hive.Hive) {
+			// option.InitConfig reads the files into a map[string]any which
+			// is then merged into viper with MergeConfig. We're simulating that
+			// here.
+			configMap := map[string]any{
+				"api-rate-limit": testLimitsKVString(),
+			}
+			v := h.Viper()
+			err := v.MergeConfigMap(configMap)
+			assert.Nil(t, err, "failed to MergeConfigMap with Viper")
+		})
+
+	// Test with JSON string
+	testRateLimiterConfig(t,
+		func(h *hive.Hive) {
+			configMap := map[string]any{
+				"api-rate-limit": testLimitsJSONString(),
+			}
+			v := h.Viper()
+			err := v.MergeConfigMap(configMap)
+			assert.Nil(t, err, "failed to MergeConfigMap with Viper")
 		})
 }


### PR DESCRIPTION
In d7ac88839768 the API rate limit parsing was redone to use StringToString. This broke parsing of api-rate-limits of form:

```
  "foo=rate-limit:1/s,rate-burst:1,bar=rate-limit:2/s"
```

The pflag StringToString failed to split this correctly leading to it trying to parse "rate-burst:1" as a "key=value". Additionally the change broke the support for specifying the rate limits in JSON format.

Expand the test-cases to cover this usage and fix the issue by switching back to parsing with the command.ToStringMapStringE method.

Fixes: #31894
Fixes: d7ac88839768 ("daemon: Move rate limiter to daemon/restapi")

```release-note
Fix parsing of complex api-rate-limit options. The parsing failed when rate limits were configured for multiple API endpoints with multiple options, for example: "endpoint-create=rate-limit:1/s,rate-burst=1,endpoint-delete=rate-limit:2/s,rate-burst=2". The ability to also specify the rate limits as JSON strings was also returned.
```
