### PR TITLE
datapath: Add configuration cell for XDP

### DIFF
--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/datapath/xdp"
 	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
 	"github.com/cilium/cilium/pkg/maps"
 	"github.com/cilium/cilium/pkg/maps/eventsmap"
@@ -140,6 +141,9 @@ var Cell = cell.Module(
 
 	// Provides prefilter, a means of configuring XDP pre-filters for DDoS-mitigation.
 	prefilter.Cell,
+
+	// XDP cell provides modularized XDP enablement.
+	xdp.Cell,
 
 	// Provides node handler, which handles node events.
 	cell.Provide(linuxdatapath.NewNodeHandler),

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/datapath/xdp"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node"
@@ -40,6 +41,7 @@ func newLocalNodeConfig(
 	directRoutingDevTbl tables.DirectRoutingDevice,
 	devices statedb.Table[*tables.Device],
 	nodeAddresses statedb.Table[tables.NodeAddress],
+	xdpConfig xdp.Config,
 ) (datapath.LocalNodeConfiguration, <-chan struct{}, <-chan struct{}, <-chan struct{}, error) {
 	auxPrefixes := []*cidr.CIDR{}
 
@@ -92,5 +94,6 @@ func newLocalNodeConfig(
 		EncryptNode:                  config.EncryptNode,
 		IPv4PodSubnets:               cidr.NewCIDRSlice(config.IPv4PodSubnets),
 		IPv6PodSubnets:               cidr.NewCIDRSlice(config.IPv6PodSubnets),
+		XDPConfig:                    xdpConfig,
 	}, devsWatch, addrsWatch, directRoutingDevWatch, nil
 }

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/datapath/xdp"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/inctimer"
@@ -77,6 +78,7 @@ type orchestratorParams struct {
 	Lifecycle           cell.Lifecycle
 	EndpointManager     endpointmanager.EndpointManager
 	ConfigPromise       promise.Promise[*option.DaemonConfig]
+	XDPConfig           xdp.Config
 }
 
 func newOrchestrator(params orchestratorParams) *orchestrator {
@@ -160,6 +162,7 @@ func (o *orchestrator) reconciler(ctx context.Context, health cell.Health) error
 			o.params.DirectRoutingDevice,
 			o.params.Devices,
 			o.params.NodeAddresses,
+			o.params.XDPConfig,
 		)
 		if err != nil {
 			health.Degraded("failed to get local node configuration", err)

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/datapath/xdp"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
 
@@ -165,6 +166,10 @@ type LocalNodeConfiguration struct {
 	// these are then used when encryption is enabled to configure the node
 	// for encryption over these subnets at node initialization.
 	IPv6PodSubnets []*cidr.CIDR
+
+	// XDPConfig holds configuration options to determine how the node should
+	// handle XDP programs.
+	XDPConfig xdp.Config
 }
 
 func (cfg *LocalNodeConfiguration) DeviceNames() []string {

--- a/pkg/datapath/types/zz_generated.deepequal.go
+++ b/pkg/datapath/types/zz_generated.deepequal.go
@@ -248,5 +248,9 @@ func (in *LocalNodeConfiguration) DeepEqual(other *LocalNodeConfiguration) bool 
 		}
 	}
 
+	if in.XDPConfig != other.XDPConfig {
+		return false
+	}
+
 	return true
 }

--- a/pkg/datapath/xdp/cell.go
+++ b/pkg/datapath/xdp/cell.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xdp
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// Cell is a cell that provides the configuration parameters
+// for XDP based on requests from external modules.
+var Cell = cell.Module(
+	"datapath-xdp-config",
+	"XDP configuration",
+
+	cell.Provide(
+		newConfig,
+
+		// Determine the XDP mode requested by XDP LoadBalancer acceleration
+		// settings. This is done here since the relevant LoadBalancer configuration
+		// has not been modularized yet.
+		//
+		// Users configure the `loadbalancer.acceleration` helm value, which is
+		// passed to cilium through --bpf-lb-acceleration. This flag's value is
+		// stored in `option.LoadBalancerAcceleration`, which is then used during
+		// DaemonConfig's population to set `DaemonConfig.NodePortAcceleration`.
+		//
+		// Eventually, a cell will be created to handle load balancer settings,
+		// which should import this module's EnablerOut function to request an
+		// XDP Mode based on the user provided settings.
+		func(dcfg *option.DaemonConfig) (EnablerOut, error) {
+			xdpMode, ok := map[string]AccelerationMode{
+				"":                                    AccelerationModeDisabled,
+				option.NodePortAccelerationDisabled:   AccelerationModeDisabled,
+				option.NodePortAccelerationGeneric:    AccelerationModeGeneric,
+				option.NodePortAccelerationBestEffort: AccelerationModeBestEffort,
+				option.NodePortAccelerationNative:     AccelerationModeNative,
+			}[dcfg.NodePortAcceleration]
+
+			if !ok {
+				return NewEnabler(AccelerationModeDisabled), fmt.Errorf("Invalid value for --%s: %s", option.NodePortAcceleration, dcfg.NodePortAcceleration)
+			}
+
+			return NewEnabler(xdpMode), nil
+		},
+	),
+
+	cell.Invoke(func(c Config, l *slog.Logger) {
+		l.Info("Determined final XDP mode", "acceleration-mode", c.AccelerationMode(), "mode", c.Mode())
+	}),
+)

--- a/pkg/datapath/xdp/xdp.go
+++ b/pkg/datapath/xdp/xdp.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xdp
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/hive/cell"
+)
+
+// AccelerationMode represents the mode to use when loading XDP programs.
+// They are wrappers around the underlying mode names passed to
+// the traffic control (tc) system in the kernel.
+type AccelerationMode string
+
+const (
+	// AccelerationModeNative for loading progs with TCModeLinkDriver
+	AccelerationModeNative AccelerationMode = "native"
+
+	// AccelerationModeBestEffort for loading progs with TCModeLinkDriver,
+	// falling back to TCModeLinkGeneric if unsupported by the
+	// underlying device.
+	AccelerationModeBestEffort AccelerationMode = "best-effort"
+
+	// AccelerationModeGeneric for loading progs with TCModeLinkGeneric
+	AccelerationModeGeneric AccelerationMode = "testing-only"
+
+	// AccelerationModeDisabled for not having XDP enabled
+	AccelerationModeDisabled AccelerationMode = "disabled"
+)
+
+// Mode represents the name of an XDP mode from the perspective
+// of the kernel.
+type Mode string
+
+const (
+
+	// ModeLinkDriver is the tc selector for native XDP
+	ModeLinkDriver Mode = "xdpdrv"
+
+	// ModeLinkGeneric is the tc selector for generic XDP
+	ModeLinkGeneric Mode = "xdpgeneric"
+
+	// XDPModeLinkNone for not having XDP enabled
+	ModeLinkNone Mode = Mode(AccelerationModeDisabled)
+)
+
+// Config represents the materialized XDP configuration to be used,
+// depending on its required use by other features.
+type Config struct {
+	mode AccelerationMode
+}
+
+type newConfigIn struct {
+	cell.In
+
+	Enablers []enabler `group:"request-xdp-mode"`
+}
+
+func newConfig(in newConfigIn) (Config, error) {
+	cfg := Config{
+		mode: AccelerationModeDisabled,
+	}
+
+	allValidators := []Validator{}
+
+	for _, e := range in.Enablers {
+		// Ensure the mode given in the enabler is valid.
+		switch e.mode {
+		case AccelerationModeBestEffort, AccelerationModeNative, AccelerationModeGeneric, AccelerationModeDisabled:
+			break
+		default:
+			return cfg, fmt.Errorf("unknown xdp mode: %s", e.mode)
+		}
+
+		if e.mode != cfg.mode {
+			allValidators = append(allValidators, e.validators...)
+
+			// If an enabler requests a mode that we've already set,
+			// then there's nothing to do.
+			if cfg.mode == e.mode {
+				continue
+			}
+
+			// If an enabler passes ModeDisabled, it becomes a no-op since
+			// that's the default. If an enabler wishes to enforce that
+			// XDP is disabled, it should use a verifier.
+			if e.mode == AccelerationModeDisabled {
+				continue
+			}
+
+			// Ensure ModeNative takes precedence over ModeBestEffort.
+			// It doesn't make sense the other way around.
+			if e.mode == AccelerationModeBestEffort && cfg.mode == AccelerationModeNative {
+				continue
+			} else if cfg.mode == AccelerationModeBestEffort && e.mode == AccelerationModeNative {
+				cfg.mode = e.mode
+				continue
+			}
+
+			// If a mode has been set and the enabler requests a conflicting
+			// mode, then raise an error.
+			if cfg.mode != AccelerationModeDisabled {
+				return cfg, fmt.Errorf("XDP mode conflict: trying to set conflicting modes %s and %s",
+					cfg.mode, e.mode)
+			}
+
+			cfg.mode = e.mode
+		}
+	}
+
+	// Perform validation at the end, when the config is fully determined,
+	// to ensure that processing order does not play a role in the validation.
+	for _, v := range allValidators {
+		if err := v(cfg.AccelerationMode(), cfg.Mode()); err != nil {
+			return cfg, err
+		}
+	}
+
+	return cfg, nil
+}
+
+// AccelerationMode is the high-level XDP operating mode for Cilium.
+func (cfg Config) AccelerationMode() AccelerationMode { return cfg.mode }
+
+// Mode, is the underlying mode name that is used for loading the XDP
+// program into the kernel.
+func (cfg Config) Mode() Mode {
+	switch cfg.mode {
+	case AccelerationModeNative, AccelerationModeBestEffort:
+		return ModeLinkDriver
+	case AccelerationModeGeneric:
+		return ModeLinkGeneric
+	}
+
+	return ModeLinkNone
+}
+
+// Disabled returns true if XDP is disabled based on the configuration.
+func (cfg Config) Disabled() bool { return cfg.mode == AccelerationModeDisabled }
+
+// GetAttachFlags returns the XDP attach flags for the configured TCMode.
+func (cfg Config) GetAttachFlags() link.XDPAttachFlags {
+	switch cfg.mode {
+	case AccelerationModeNative, AccelerationModeBestEffort:
+		return link.XDPDriverMode
+	case AccelerationModeGeneric:
+		return link.XDPGenericMode
+	}
+
+	return 0
+}
+
+// EnablerOut allows requesting to enable a certain XDP operating mode.
+type EnablerOut struct {
+	cell.Out
+	Enabler enabler `group:"request-xdp-mode"`
+}
+
+// NewEnabler returns an object to be injected through hive to request to
+// enable a specific operating mode for XDP. Extra options are meaningful only
+// when enable is set to true, and are ignored otherwise.
+func NewEnabler(mode AccelerationMode, opts ...enablerOpt) EnablerOut {
+	enabler := enabler{mode: mode}
+
+	for _, opt := range opts {
+		opt(&enabler)
+	}
+
+	return EnablerOut{Enabler: enabler}
+}
+
+type Validator func(AccelerationMode, Mode) error
+
+// WithValidator allows to register extra validation functions
+// to assert that the configured XDP mode the one expected by
+// the given feature.
+func WithValidator(validator Validator) enablerOpt {
+	return func(te *enabler) {
+		te.validators = append(te.validators, validator)
+	}
+}
+
+// WithEnforceXDPDisabled registers a validation function that
+// returns an error if XDP is enabled.
+func WithEnforceXDPDisabled(reason string) enablerOpt {
+	return func(te *enabler) {
+		te.validators = append(
+			te.validators,
+			func(m AccelerationMode, _ Mode) error {
+				if m != AccelerationModeDisabled {
+					return fmt.Errorf("XDP config failed validation: XDP must be disabled because %s", reason)
+				}
+
+				return nil
+			},
+		)
+	}
+}
+
+type enabler struct {
+	mode       AccelerationMode
+	validators []Validator
+}
+
+type enablerOpt func(*enabler)

--- a/pkg/datapath/xdp/xdp_test.go
+++ b/pkg/datapath/xdp/xdp_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xdp
+
+import (
+	"testing"
+
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+
+	"github.com/cilium/cilium/pkg/hive"
+)
+
+func TestConf(t *testing.T) {
+	enabler := func(mode AccelerationMode, opts ...enablerOpt) any {
+		return func() EnablerOut { return NewEnabler(mode, opts...) }
+	}
+
+	tests := []struct {
+		name             string
+		enablers         []any
+		givesError       bool
+		accelerationMode AccelerationMode
+		mode             Mode
+	}{
+		{
+			name:             "enable generic",
+			enablers:         []any{enabler(AccelerationModeGeneric)},
+			givesError:       false,
+			accelerationMode: AccelerationModeGeneric,
+			mode:             ModeLinkGeneric,
+		},
+		{
+			name:             "enable native",
+			enablers:         []any{enabler(AccelerationModeNative)},
+			givesError:       false,
+			accelerationMode: AccelerationModeNative,
+			mode:             ModeLinkDriver,
+		},
+		{
+			name:             "enable best effort",
+			enablers:         []any{enabler(AccelerationModeBestEffort)},
+			givesError:       false,
+			accelerationMode: AccelerationModeBestEffort,
+			mode:             ModeLinkDriver,
+		},
+		{
+			name:             "disable, single",
+			enablers:         []any{enabler(AccelerationModeDisabled)},
+			givesError:       false,
+			accelerationMode: AccelerationModeDisabled,
+			mode:             ModeLinkNone,
+		},
+		{
+			name:             "disable, no enablers",
+			enablers:         []any{},
+			givesError:       false,
+			accelerationMode: AccelerationModeDisabled,
+			mode:             ModeLinkNone,
+		},
+		{
+			name:       "conflicting enablers, native and generic",
+			enablers:   []any{enabler(AccelerationModeNative), enabler(AccelerationModeGeneric)},
+			givesError: true,
+		},
+		{
+			name:       "conflicting enablers, best effort and generic",
+			enablers:   []any{enabler(AccelerationModeBestEffort), enabler(AccelerationModeGeneric)},
+			givesError: true,
+		},
+		{
+			name:             "native and best effort results in native",
+			enablers:         []any{enabler(AccelerationModeNative), enabler(AccelerationModeBestEffort)},
+			accelerationMode: AccelerationModeNative,
+			mode:             ModeLinkDriver,
+		},
+		{
+			name:       "conflicting enablers, native and disabled validator",
+			enablers:   []any{enabler(AccelerationModeNative, WithEnforceXDPDisabled("test native"))},
+			givesError: true,
+		},
+		{
+			name:       "conflicting enablers, best effort and disabled validator",
+			enablers:   []any{enabler(AccelerationModeBestEffort, WithEnforceXDPDisabled("test best effort"))},
+			givesError: true,
+		},
+		{
+			name:       "conflicting enablers, generic and disabled validator",
+			enablers:   []any{enabler(AccelerationModeGeneric, WithEnforceXDPDisabled("test generic"))},
+			givesError: true,
+		},
+		{
+			name:             "disabled validator passes when disabled",
+			enablers:         []any{enabler(AccelerationModeDisabled, WithEnforceXDPDisabled("test generic"))},
+			accelerationMode: AccelerationModeDisabled,
+			mode:             ModeLinkNone,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var result Config
+
+			err := hive.New(
+				cell.Provide(newConfig),
+				cell.Provide(test.enablers...),
+				cell.Invoke(func(cfg Config) { result = cfg }),
+			).Populate(hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)))
+
+			if test.givesError {
+				if err == nil {
+					t.Error("expected error from hive but got nil")
+					t.FailNow()
+				}
+
+				return
+			}
+
+			if result.AccelerationMode() != test.accelerationMode {
+				t.Errorf("expected acceleration mode %s but instead got %s", test.accelerationMode, result.AccelerationMode())
+			}
+
+			if result.Mode() != test.mode {
+				t.Errorf("expected mode %s but instead got %s", test.mode, result.Mode())
+			}
+		})
+	}
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3319,8 +3319,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	}
 	c.IPv6PodSubnets = subnets
 
-	c.XDPMode = XDPModeLinkNone
-
 	err = c.populateNodePortRange(vp)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to populate NodePortRange")


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

This commit introduces a new datapath cell for managing XDP-related configuration options. The cell allows for other cells to request a specific XDP mode to be enabled and provides a struct other cells can use to consume the XDP configuration.

Currently, XDP configuration is monopolized by the bpf LB acceleration feature as part of the KPR suite. When KPR configuration settings are initialized as part of the `DaemonConfig.Populate` method, the mode for XDP is determined based on the bpf LB acceleration mode passed via helm or on the command line. The mode is stored in a global variable inside of the `option` module, named `NodePortAcceleration` and is read throughout other areas of the datapath that handle compiling and loading the XDP program.

In the future, new features can utilize the `Enabler` function provided in this commit to request XDP enablement outside of the bpf LB acceleration configuration. Additionally, when the KPR and bpf LB settings are modularized, they can use the `Enabler` function to request XDP enablement.

The design of the XDP configuration cell was based off of @giorio94's work for creating a cell that centralizes Cilium's tunneling configuration. Thanks @giorio94!

```release-node
Modularize XDP configuration
```
