### PR TITLE
Initialize default flag configurations (deployments)

### DIFF
--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -50,7 +50,7 @@ var Cell = cell.Module(
 	k8sClient.Cell,
 	cmk8s.ResourcesCell,
 
-	kvstore.Cell(kvstore.EtcdBackendName),
+	kvstore.Cell,
 	cell.Provide(func(ss syncstate.SyncState) *kvstore.ExtraOptions {
 		return &kvstore.ExtraOptions{
 			BootstrapComplete: ss.WaitChannel(),

--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -39,10 +39,7 @@ var Cell = cell.Module(
 	cell.Invoke(cmtypes.ClusterInfo.Validate),
 
 	pprof.Cell,
-	cell.Config(pprof.Config{
-		PprofAddress: option.PprofAddress,
-		PprofPort:    option.PprofPortClusterMesh,
-	}),
+	cell.Config(pprofConfig),
 	controller.Cell,
 
 	gops.Cell(defaults.GopsPortApiserver),
@@ -80,3 +77,9 @@ var Cell = cell.Module(
 	cell.Invoke(registerHooks),
 	externalWorkloadsCell,
 )
+
+var pprofConfig = pprof.Config{
+	Pprof:        false,
+	PprofAddress: option.PprofAddress,
+	PprofPort:    option.PprofPortClusterMesh,
+}

--- a/clustermesh-apiserver/etcdinit/root.go
+++ b/clustermesh-apiserver/etcdinit/root.go
@@ -218,6 +218,7 @@ func InitEtcdLocal() (returnErr error) {
 	}()
 
 	// With the etcd server process launched, we need to construct an etcd client
+	//exhaustruct:ignore // Not all etcd config options are required.
 	config := clientv3.Config{
 		Context:   ctx,
 		Endpoints: []string{loopbackEndpoint},

--- a/clustermesh-apiserver/kvstoremesh/cells.go
+++ b/clustermesh-apiserver/kvstoremesh/cells.go
@@ -30,10 +30,7 @@ var Cell = cell.Module(
 	cell.Invoke(registerClusterInfoValidator),
 
 	pprof.Cell,
-	cell.Config(pprof.Config{
-		PprofAddress: option.PprofAddress,
-		PprofPort:    option.PprofPortKVStoreMesh,
-	}),
+	cell.Config(pprofConfig),
 	controller.Cell,
 
 	gops.Cell(defaults.GopsPortKVStoreMesh),
@@ -56,3 +53,9 @@ var Cell = cell.Module(
 
 	cell.Invoke(func(*kvstoremesh.KVStoreMesh) {}),
 )
+
+var pprofConfig = pprof.Config{
+	Pprof:        false,
+	PprofAddress: option.PprofAddress,
+	PprofPort:    option.PprofPortKVStoreMesh,
+}

--- a/clustermesh-apiserver/kvstoremesh/cells.go
+++ b/clustermesh-apiserver/kvstoremesh/cells.go
@@ -44,7 +44,7 @@ var Cell = cell.Module(
 
 	APIServerCell,
 
-	kvstore.Cell(kvstore.EtcdBackendName),
+	kvstore.Cell,
 	cell.Provide(func(ss syncstate.SyncState) *kvstore.ExtraOptions {
 		return &kvstore.ExtraOptions{
 			BootstrapComplete: ss.WaitChannel(),

--- a/operator/api/cell.go
+++ b/operator/api/cell.go
@@ -26,7 +26,7 @@ var ServerCell = cell.Module(
 	"cilium-operator-api",
 	"Cilium Operator API Server",
 
-	cell.Config(Config{}),
+	cell.Config(defaultConfig),
 	cell.Provide(newServer),
 	cell.Invoke(func(Server) {}),
 )
@@ -36,5 +36,9 @@ type Config struct {
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {
-	flags.String(OperatorAPIServeAddr, OperatorAPIServeAddrDefault, "Address to serve API requests")
+	flags.String(OperatorAPIServeAddr, def.OperatorAPIServeAddr, "Address to serve API requests")
+}
+
+var defaultConfig = Config{
+	OperatorAPIServeAddr: OperatorAPIServeAddrDefault,
 }

--- a/operator/auth/cell.go
+++ b/operator/auth/cell.go
@@ -18,7 +18,7 @@ var Cell = cell.Module(
 	"auth-identity",
 	"Cilium Mutual Authentication Identity management",
 	spire.Cell,
-	cell.Config(Config{}),
+	cell.Config(defaultConfig),
 	cell.Invoke(registerIdentityWatcher),
 )
 
@@ -30,4 +30,8 @@ type Config struct {
 // Flags implements cell.Flagger interface.
 func (cfg Config) Flags(flags *pflag.FlagSet) {
 	flags.Bool(mutualAuthEnabled, cfg.Enabled, "Enable mutual authentication in Cilium")
+}
+
+var defaultConfig = Config{
+	Enabled: false,
 }

--- a/operator/pkg/ciliumendpointslice/cell.go
+++ b/operator/pkg/ciliumendpointslice/cell.go
@@ -64,12 +64,12 @@ var Cell = cell.Module(
 type Config struct {
 	CESMaxCEPsInCES             int      `mapstructure:"ces-max-ciliumendpoints-per-ces"`
 	CESSlicingMode              string   `mapstructure:"ces-slice-mode"`
-	CESWriteQPSLimit            float64  `mapstructure:"ces-write-qps-limit"`
-	CESWriteQPSBurst            int      `mapstructure:"ces-write-qps-burst"`
-	CESEnableDynamicRateLimit   bool     `mapstructure:"ces-enable-dynamic-rate-limit"`
-	CESDynamicRateLimitNodes    []string `mapstructure:"ces-dynamic-rate-limit-nodes"`
-	CESDynamicRateLimitQPSLimit []string `mapstructure:"ces-dynamic-rate-limit-qps-limit"`
-	CESDynamicRateLimitQPSBurst []string `mapstructure:"ces-dynamic-rate-limit-qps-burst"`
+	CESWriteQPSLimit            float64  `mapstructure:"ces-write-qps-limit" exhaustruct:"optional"`
+	CESWriteQPSBurst            int      `mapstructure:"ces-write-qps-burst" exhaustruct:"optional"`
+	CESEnableDynamicRateLimit   bool     `mapstructure:"ces-enable-dynamic-rate-limit" exhaustruct:"optional"`
+	CESDynamicRateLimitNodes    []string `mapstructure:"ces-dynamic-rate-limit-nodes" exhaustruct:"optional"`
+	CESDynamicRateLimitQPSLimit []string `mapstructure:"ces-dynamic-rate-limit-qps-limit" exhaustruct:"optional"`
+	CESDynamicRateLimitQPSBurst []string `mapstructure:"ces-dynamic-rate-limit-qps-burst" exhaustruct:"optional"`
 	CESDynamicRateLimitConfig   string   `mapstructure:"ces-rate-limits"`
 }
 

--- a/operator/pkg/ciliumendpointslice/rate_limit_test.go
+++ b/operator/pkg/ciliumendpointslice/rate_limit_test.go
@@ -33,6 +33,8 @@ func TestSingleDynamicRateLimit(t *testing.T) {
 	p := params{
 		Logger: log,
 		Cfg: Config{
+			CESMaxCEPsInCES:           100,
+			CESSlicingMode:            identityMode,
 			CESDynamicRateLimitConfig: "[{\"nodes\": 5, \"limit\": 15.0, \"burst\": 30}]",
 		},
 	}
@@ -69,6 +71,8 @@ func TestMultipleUnsortedDynamicRateLimit(t *testing.T) {
 	p := params{
 		Logger: log,
 		Cfg: Config{
+			CESMaxCEPsInCES:           100,
+			CESSlicingMode:            identityMode,
 			CESDynamicRateLimitConfig: string(rlJson),
 		},
 	}

--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -30,7 +30,7 @@ var Cell = cell.Module(
 	}),
 	cell.ProvidePrivate(idsMgrProvider),
 
-	cell.Config(common.Config{}),
+	cell.Config(common.DefaultConfig),
 	cell.Config(wait.TimeoutConfigDefault),
 
 	metrics.Metric(NewMetrics),

--- a/pkg/clustermesh/common/clustermesh.go
+++ b/pkg/clustermesh/common/clustermesh.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/cilium/hive/cell"
-	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
@@ -19,15 +18,6 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
-
-type Config struct {
-	// ClusterMeshConfig is the path to the clustermesh configuration directory.
-	ClusterMeshConfig string
-}
-
-func (def Config) Flags(flags *pflag.FlagSet) {
-	flags.String("clustermesh-config", def.ClusterMeshConfig, "Path to the ClusterMesh configuration directory")
-}
 
 type StatusFunc func() *models.RemoteCluster
 type RemoteClusterCreatorFunc func(name string, status StatusFunc) RemoteCluster

--- a/pkg/clustermesh/common/config.go
+++ b/pkg/clustermesh/common/config.go
@@ -13,7 +13,21 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
 )
+
+type Config struct {
+	// ClusterMeshConfig is the path to the clustermesh configuration directory.
+	ClusterMeshConfig string
+}
+
+func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.String("clustermesh-config", def.ClusterMeshConfig, "Path to the ClusterMesh configuration directory")
+}
+
+var DefaultConfig = Config{
+	ClusterMeshConfig: "",
+}
 
 // clusterLifecycle is the interface to implement in order to receive cluster
 // configuration lifecycle events. This is implemented by the ClusterMesh.

--- a/pkg/clustermesh/kvstoremesh/cell.go
+++ b/pkg/clustermesh/kvstoremesh/cell.go
@@ -20,7 +20,7 @@ var Cell = cell.Module(
 		newAPIClustersHandler,
 	),
 
-	cell.Config(common.Config{}),
+	cell.Config(common.DefaultConfig),
 	store.Cell,
 
 	metrics.Metric(common.MetricsProvider("")),

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh.go
@@ -39,8 +39,9 @@ type Config struct {
 }
 
 var DefaultConfig = Config{
-	PerClusterReadyTimeout: 15 * time.Second,
-	GlobalReadyTimeout:     10 * time.Minute,
+	PerClusterReadyTimeout:      15 * time.Second,
+	GlobalReadyTimeout:          10 * time.Minute,
+	DisableDrainOnDisconnection: false,
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
@@ -544,7 +544,7 @@ func TestRemoteClusterRemoveShutdown(t *testing.T) {
 
 		cell.Provide(
 			func() types.ClusterInfo { return types.ClusterInfo{ID: 10, Name: "local"} },
-			func() Config { return Config{} },
+			func() Config { return DefaultConfig },
 			func() promise.Promise[kvstore.BackendOperations] {
 				clr, clp := promise.New[kvstore.BackendOperations]()
 				clr.Resolve(kvstore.Client())
@@ -718,14 +718,22 @@ func TestRemoteClusterSync(t *testing.T) {
 		{
 			name: "remote cluster fails to connect",
 			// use very low timeouts to speed up the test since we expect failures
-			config:  Config{PerClusterReadyTimeout: 1 * time.Millisecond, GlobalReadyTimeout: 1 * time.Millisecond},
+			config: Config{
+				PerClusterReadyTimeout:      1 * time.Millisecond,
+				GlobalReadyTimeout:          1 * time.Millisecond,
+				DisableDrainOnDisconnection: false,
+			},
 			connect: false,
 			sync:    false,
 		},
 		{
 			name: "remote cluster connects but fails to sync",
 			// use a low timeout only for global sync to avoid racing the connected signal
-			config:  Config{PerClusterReadyTimeout: 5 * time.Second, GlobalReadyTimeout: 1 * time.Millisecond},
+			config: Config{
+				PerClusterReadyTimeout:      5 * time.Second,
+				GlobalReadyTimeout:          1 * time.Millisecond,
+				DisableDrainOnDisconnection: false,
+			},
 			connect: true,
 			sync:    false,
 		},

--- a/pkg/clustermesh/operator/cell.go
+++ b/pkg/clustermesh/operator/cell.go
@@ -29,7 +29,7 @@ var Cell = cell.Module(
 		newAPIClustersHandler,
 	),
 
-	cell.Config(common.Config{}),
+	cell.Config(common.DefaultConfig),
 	cell.Config(wait.TimeoutConfigDefault),
 
 	metrics.Metric(NewMetrics),

--- a/pkg/kvstore/cell.go
+++ b/pkg/kvstore/cell.go
@@ -21,79 +21,68 @@ import (
 )
 
 // Cell returns a cell which provides a promise for the global kvstore client.
-// The parameter allows to customize the default backend, which can be either
-// set to a specific value (e.g., in the case of clustermesh-apiserver) or
-// left unset.
-var Cell = func(defaultBackend string) cell.Cell {
-	return cell.Module(
-		"kvstore-client",
-		"KVStore Client",
+var Cell = cell.Module(
+	"kvstore-client",
+	"KVStore Client",
 
-		cell.Config(config{
-			KVStore:                           defaultBackend,
-			KVStoreConnectivityTimeout:        defaults.KVstoreConnectivityTimeout,
-			KVStoreLeaseTTL:                   defaults.KVstoreLeaseTTL,
-			KVStorePeriodicSync:               defaults.KVstorePeriodicSync,
-			KVstoreMaxConsecutiveQuorumErrors: defaults.KVstoreMaxConsecutiveQuorumErrors,
-		}),
+	cell.Config(defaultConfig),
 
-		cell.Provide(func(lc cell.Lifecycle, shutdowner hive.Shutdowner, cfg config, opts *ExtraOptions) promise.Promise[BackendOperations] {
-			resolver, promise := promise.New[BackendOperations]()
-			if cfg.KVStore == "" {
-				log.Info("Skipping connection to kvstore, as not configured")
-				resolver.Reject(errors.New("kvstore not configured"))
-				return promise
-			}
-
-			// Propagate the options to the global variables for backward compatibility
-			option.Config.KVStore = cfg.KVStore
-			option.Config.KVStoreOpt = cfg.KVStoreOpt
-			option.Config.KVstoreConnectivityTimeout = cfg.KVStoreConnectivityTimeout
-			option.Config.KVstoreLeaseTTL = cfg.KVStoreLeaseTTL
-			option.Config.KVstorePeriodicSync = cfg.KVStorePeriodicSync
-			option.Config.KVstoreMaxConsecutiveQuorumErrors = cfg.KVstoreMaxConsecutiveQuorumErrors
-
-			ctx, cancel := context.WithCancel(context.Background())
-			var wg sync.WaitGroup
-
-			lc.Append(cell.Hook{
-				OnStart: func(cell.HookContext) error {
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
-
-						log := log.WithField(logfields.BackendName, cfg.KVStore)
-						log.Info("Establishing connection to kvstore")
-						backend, errCh := NewClient(ctx, cfg.KVStore, cfg.KVStoreOpt, opts)
-
-						if err, isErr := <-errCh; isErr {
-							log.WithError(err).Error("Failed to establish connection to kvstore")
-							resolver.Reject(fmt.Errorf("failed connecting to kvstore: %w", err))
-							shutdowner.Shutdown(hive.ShutdownWithError(err))
-							return
-						}
-
-						log.Info("Connection to kvstore successfully established")
-						resolver.Resolve(backend)
-					}()
-					return nil
-				},
-				OnStop: func(cell.HookContext) error {
-					cancel()
-					wg.Wait()
-
-					// We don't explicitly close the backend here, because that would
-					// attempt to revoke the lease, causing all entries associated
-					// with that lease to be deleted. This would not be the
-					// behavior expected by the consumers of this cell.
-					return nil
-				},
-			})
-
+	cell.Provide(func(lc cell.Lifecycle, shutdowner hive.Shutdowner, cfg config, opts *ExtraOptions) promise.Promise[BackendOperations] {
+		resolver, promise := promise.New[BackendOperations]()
+		if cfg.KVStore == "" {
+			log.Info("Skipping connection to kvstore, as not configured")
+			resolver.Reject(errors.New("kvstore not configured"))
 			return promise
-		}),
-	)
-}
+		}
+
+		// Propagate the options to the global variables for backward compatibility
+		option.Config.KVStore = cfg.KVStore
+		option.Config.KVStoreOpt = cfg.KVStoreOpt
+		option.Config.KVstoreConnectivityTimeout = cfg.KVStoreConnectivityTimeout
+		option.Config.KVstoreLeaseTTL = cfg.KVStoreLeaseTTL
+		option.Config.KVstorePeriodicSync = cfg.KVStorePeriodicSync
+		option.Config.KVstoreMaxConsecutiveQuorumErrors = cfg.KVstoreMaxConsecutiveQuorumErrors
+
+		ctx, cancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
+
+		lc.Append(cell.Hook{
+			OnStart: func(cell.HookContext) error {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+
+					log := log.WithField(logfields.BackendName, cfg.KVStore)
+					log.Info("Establishing connection to kvstore")
+					backend, errCh := NewClient(ctx, cfg.KVStore, cfg.KVStoreOpt, opts)
+
+					if err, isErr := <-errCh; isErr {
+						log.WithError(err).Error("Failed to establish connection to kvstore")
+						resolver.Reject(fmt.Errorf("failed connecting to kvstore: %w", err))
+						shutdowner.Shutdown(hive.ShutdownWithError(err))
+						return
+					}
+
+					log.Info("Connection to kvstore successfully established")
+					resolver.Resolve(backend)
+				}()
+				return nil
+			},
+			OnStop: func(cell.HookContext) error {
+				cancel()
+				wg.Wait()
+
+				// We don't explicitly close the backend here, because that would
+				// attempt to revoke the lease, causing all entries associated
+				// with that lease to be deleted. This would not be the
+				// behavior expected by the consumers of this cell.
+				return nil
+			},
+		})
+
+		return promise
+	}),
+)
 
 type config struct {
 	KVStore                           string
@@ -122,6 +111,15 @@ func (def config) Flags(flags *pflag.FlagSet) {
 
 	flags.Uint(option.KVstoreMaxConsecutiveQuorumErrorsName, def.KVstoreMaxConsecutiveQuorumErrors,
 		"Max acceptable kvstore consecutive quorum errors before recreating the etcd connection")
+}
+
+var defaultConfig = config{
+	KVStore:                           EtcdBackendName,
+	KVStoreOpt:                        make(map[string]string),
+	KVStoreConnectivityTimeout:        defaults.KVstoreConnectivityTimeout,
+	KVStoreLeaseTTL:                   defaults.KVstoreLeaseTTL,
+	KVStorePeriodicSync:               defaults.KVstorePeriodicSync,
+	KVstoreMaxConsecutiveQuorumErrors: defaults.KVstoreMaxConsecutiveQuorumErrors,
 }
 
 // GlobalUserMgmtClientPromiseCell provides a promise returning the global kvstore client to perform users

--- a/pkg/kvstore/dummy.go
+++ b/pkg/kvstore/dummy.go
@@ -7,8 +7,15 @@ import (
 	"context"
 	"testing"
 
+	client "go.etcd.io/etcd/client/v3"
+
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/time"
+)
+
+var (
+	// etcdDummyAddress can be overwritten from test invokers using ldflags
+	etcdDummyAddress = "http://127.0.0.1:4002"
 )
 
 // SetupDummy sets up kvstore for tests. A lock mechanism it used to prevent
@@ -84,4 +91,13 @@ func SetupDummyWithConfigOpts(tb testing.TB, dummyBackend string, opts map[strin
 			tb.Fatal("Timed out waiting to acquire the kvstore lock")
 		}
 	}
+}
+
+func EtcdDummyAddress() string {
+	return etcdDummyAddress
+}
+
+func (e *etcdModule) setConfigDummy() {
+	e.config = &client.Config{}
+	e.config.Endpoints = []string{etcdDummyAddress}
 }

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -84,9 +84,6 @@ var (
 	// the etcd server
 	initialConnectionTimeout = 15 * time.Minute
 
-	// etcdDummyAddress can be overwritten from test invokers using ldflags
-	etcdDummyAddress = "http://127.0.0.1:4002"
-
 	etcdInstance = newEtcdModule()
 
 	// etcd3ClientLogger is the logger used for the underlying etcd clients. We
@@ -94,10 +91,6 @@ var (
 	// automatically creating a new one, which comes with a significant memory cost.
 	etcd3ClientLogger *zap.Logger
 )
-
-func EtcdDummyAddress() string {
-	return etcdDummyAddress
-}
 
 func newEtcdModule() backendModule {
 	return &etcdModule{
@@ -160,11 +153,6 @@ func (e *etcdModule) createInstance() backendModule {
 
 func (e *etcdModule) getName() string {
 	return EtcdBackendName
-}
-
-func (e *etcdModule) setConfigDummy() {
-	e.config = &client.Config{}
-	e.config.Endpoints = []string{etcdDummyAddress}
 }
 
 func (e *etcdModule) setConfig(opts map[string]string) error {


### PR DESCRIPTION
Explicitly initialize the default flags for configuring components like
kvstoremesh and the operator.

Towards: #34134
