### PR TITLE
Initialize default flag configurations (agent)

### DIFF
--- a/cilium-dbg/cmd/build-config.go
+++ b/cilium-dbg/cmd/build-config.go
@@ -79,6 +79,8 @@ var defaultBuildConfigCfg = buildConfigCfg{
 		resolver.KindConfigMap + ":cilium-config",
 		resolver.KindNodeConfig + ":" + os.Getenv("CILIUM_K8S_NAMESPACE"),
 	},
+	AllowConfigKeys: []string{},
+	DenyConfigKeys:  []string{},
 }
 
 type buildConfig struct {

--- a/cilium-health/launch/launcher.go
+++ b/cilium-health/launch/launcher.go
@@ -48,6 +48,7 @@ func Launch(spec *healthApi.Spec, initialized <-chan struct{}) (*CiliumHealth, e
 	)
 
 	config := server.Config{
+		CiliumURI:     ciliumPkg.DefaultSockPath(),
 		Debug:         option.Config.Opts.IsEnabled(option.Debug),
 		ProbeInterval: serverProbeInterval,
 		ProbeDeadline: serverProbeDeadline,

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -81,10 +81,7 @@ var (
 
 		// Register the pprof HTTP handlers, to get runtime profiling data.
 		pprof.Cell,
-		cell.Config(pprof.Config{
-			PprofAddress: option.PprofAddressAgent,
-			PprofPort:    option.PprofPortAgent,
-		}),
+		cell.Config(pprofConfig),
 
 		// Runs the gops agent, a tool to diagnose Go processes.
 		gops.Cell(defaults.GopsPortAgent),
@@ -315,4 +312,10 @@ func configureAPIServer(cfg *option.DaemonConfig, s *server.Server, db *statedb.
 	mux.Handle("/", s.GetHandler())
 	mux.Handle("/statedb/", http.StripPrefix("/statedb", db.HTTPHandler()))
 	s.SetHandler(mux)
+}
+
+var pprofConfig = pprof.Config{
+	Pprof:        false,
+	PprofAddress: option.PprofAddressAgent,
+	PprofPort:    option.PprofPortAgent,
 }

--- a/daemon/cmd/cni/cell.go
+++ b/daemon/cmd/cni/cell.go
@@ -56,8 +56,13 @@ type CNIConfigManager interface {
 }
 
 var defaultConfig = Config{
-	CNIChainingMode: "none",
-	CNILogFile:      "/var/run/cilium/cilium-cni.log",
+	WriteCNIConfWhenReady: "",
+	ReadCNIConf:           "",
+	CNIChainingMode:       "none",
+	CNILogFile:            "/var/run/cilium/cilium-cni.log",
+	CNIExclusive:          false,
+	CNIChainingTarget:     "",
+	CNIExternalRouting:    false,
 }
 
 func (cfg Config) Flags(flags *pflag.FlagSet) {

--- a/daemon/cmd/cni/cni_test.go
+++ b/daemon/cmd/cni/cni_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestInstallCNIConfFile(t *testing.T) {
 	workdir := t.TempDir()
+	//exhaustruct:ignore
 	cfg := Config{
 		CNILogFile:            `/opt"/cni.log`,
 		CNIChainingMode:       "none",
@@ -47,6 +48,7 @@ func TestInstallCNIConfFile(t *testing.T) {
 }
 
 func TestRenderCNIConfUnchained(t *testing.T) {
+	//exhaustruct:ignore
 	cfg := Config{
 		CNILogFile: `/opt"/cni.log`,
 	}
@@ -63,6 +65,7 @@ func TestRenderCNIConfUnchained(t *testing.T) {
 }
 
 func TestRenderCNIConfChained(t *testing.T) {
+	//exhaustruct:ignore
 	cfg := Config{
 		CNILogFile:        `/opt"/cni.log`,
 		CNIChainingMode:   "testing",
@@ -232,6 +235,7 @@ func TestRenderCNIConfChained(t *testing.T) {
 
 func TestCleanupOtherCNI(t *testing.T) {
 	workdir := t.TempDir()
+	//exhaustruct:ignore
 	cfg := Config{
 		CNIExclusive:          true,
 		WriteCNIConfWhenReady: path.Join(workdir, "42-keep.json"),

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -1141,7 +1141,7 @@ func (d *Daemon) startStatusCollector(cleaner *daemonCleanup) {
 	d.statusResponse.AttachMode = d.getAttachModeStatus()
 	d.statusResponse.DatapathMode = d.getDatapathModeStatus()
 
-	d.statusCollector = status.NewCollector(probes, status.Config{StackdumpPath: "/run/cilium/state/agent.stack.gz"})
+	d.statusCollector = status.NewCollector(probes, status.DefaultConfig)
 
 	// Set up a signal handler function which prints out logs related to daemon status.
 	cleaner.cleanupFuncs.Add(func() {

--- a/pkg/controller/cell.go
+++ b/pkg/controller/cell.go
@@ -31,7 +31,7 @@ var (
 var Cell = cell.Module(
 	"controller",
 	"Controllers and Controller Lifecycle management",
-	cell.Config(Config{}),
+	cell.Config(defaultConfig),
 	metrics.Metric(NewMetrics),
 	cell.Invoke(Init),
 )
@@ -62,6 +62,10 @@ func (cfg Config) Flags(flags *pflag.FlagSet) {
 		"List of controller group names for which to to enable metrics. "+
 			"Accepts 'all' and 'none'. "+
 			"The set of controller group names available is not guaranteed to be stable between Cilium versions.")
+}
+
+var defaultConfig = Config{
+	ControllerGroupMetrics: []string{},
 }
 
 func Init(cfg Config, m Metrics) {

--- a/pkg/endpointcleanup/cell.go
+++ b/pkg/endpointcleanup/cell.go
@@ -18,7 +18,7 @@ var Cell = cell.Module(
 	cell.ProvidePrivate(func(epMgr endpointmanager.EndpointManager) localEndpointCache {
 		return epMgr
 	}),
-	cell.Config(Config{}),
+	cell.Config(defaultConfig),
 )
 
 type Config struct {
@@ -29,6 +29,10 @@ type Config struct {
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {
-	flags.Bool("enable-stale-cilium-endpoint-cleanup", true, "Enable running cleanup init procedure of local CiliumEndpoints which are not being managed.")
+	flags.Bool("enable-stale-cilium-endpoint-cleanup", def.EnableStaleCiliumEndpointCleanup, "Enable running cleanup init procedure of local CiliumEndpoints which are not being managed.")
 	flags.MarkHidden("enable-stale-cilium-endpoint-cleanup")
+}
+
+var defaultConfig = Config{
+	EnableStaleCiliumEndpointCleanup: true,
 }

--- a/pkg/policy/directory/cell.go
+++ b/pkg/policy/directory/cell.go
@@ -60,7 +60,9 @@ const (
 	staticCNPPath = "static-cnp-path"
 )
 
-var defaultConfig = Config{}
+var defaultConfig = Config{
+	StaticCNPPath: "", // Disabled
+}
 
 func (cfg Config) Flags(flags *pflag.FlagSet) {
 	flags.String(staticCNPPath, defaultConfig.StaticCNPPath, "Directory path to watch and load static cilium network policy yaml files.")

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -84,6 +84,13 @@ type Config struct {
 	StackdumpPath    string
 }
 
+var DefaultConfig = Config{
+	WarningThreshold: defaults.StatusCollectorWarningThreshold,
+	FailureThreshold: defaults.StatusCollectorFailureThreshold,
+	Interval:         defaults.StatusCollectorInterval,
+	StackdumpPath:    "/run/cilium/state/agent.stack.gz",
+}
+
 // NewCollector creates a collector and starts the given probes.
 //
 // Each probe runs in a separate goroutine.

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -30,6 +30,7 @@ func setUpTest(_ testing.TB) *StatusTestSuite {
 		Interval:         10 * time.Millisecond,
 		WarningThreshold: 20 * time.Millisecond,
 		FailureThreshold: 80 * time.Millisecond,
+		StackdumpPath:    "",
 	}
 	s.mutex.Unlock()
 


### PR DESCRIPTION
Explicitly initialize the default flags for configuring components in the
cilium-agent Pod like the daemon, local network connectivity health, and CLI.

Towards: #34134
