### PR TITLE
net-perf-gke: Shorten the cluster name

### DIFF
--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -60,7 +60,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
+  clusterName: ${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cilium_cli_ci_version:
   test_name: gke-perf
   USE_GKE_GCLOUD_AUTH_PLUGIN: True


### PR DESCRIPTION
It's getting close to the 32-character limit. Drop repository_owner from the cluster name.