### PR TITLE
metrics: extract metrics rest api handler from daemon

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -290,7 +290,7 @@ Makefile* @cilium/build
 /daemon/cmd/hubble.go @cilium/sig-hubble
 /daemon/cmd/ipcache* @cilium/ipcache
 /daemon/cmd/kube_proxy* @cilium/sig-datapath
-/daemon/cmd/metrics.go @cilium/metrics
+/daemon/cmd/bootstrap_statistics.go @cilium/metrics
 /daemon/cmd/policy* @cilium/sig-policy
 /daemon/cmd/state.go @cilium/endpoint
 /daemon/cmd/cells*.go @cilium/sig-foundations

--- a/daemon/cmd/api_handlers.go
+++ b/daemon/cmd/api_handlers.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/api/v1/server/restapi/endpoint"
-	"github.com/cilium/cilium/api/v1/server/restapi/metrics"
 	"github.com/cilium/cilium/api/v1/server/restapi/policy"
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/option"
@@ -38,8 +37,6 @@ type handlersOut struct {
 	EndpointPatchEndpointIDHandler       endpoint.PatchEndpointIDHandler
 	EndpointPatchEndpointIDLabelsHandler endpoint.PatchEndpointIDLabelsHandler
 	EndpointPutEndpointIDHandler         endpoint.PutEndpointIDHandler
-
-	MetricsGetMetricsHandler metrics.GetMetricsHandler
 
 	PolicyDeleteFqdnCacheHandler      policy.DeleteFqdnCacheHandler
 	PolicyDeletePolicyHandler         policy.DeletePolicyHandler
@@ -136,9 +133,6 @@ func ciliumAPIHandlers(dp promise.Promise[*Daemon], cfg *option.DaemonConfig, _ 
 
 	// /cgroup-dump-metadata
 	out.DaemonGetCgroupDumpMetadataHandler = wrapAPIHandler(dp, getCgroupDumpMetadataHandler)
-
-	// metrics
-	out.MetricsGetMetricsHandler = wrapAPIHandler(dp, getMetricsHandler)
 
 	// /fqdn/cache
 	out.PolicyGetFqdnCacheHandler = wrapAPIHandler(dp, getFqdnCacheHandler)

--- a/daemon/cmd/bootstrap_statistics.go
+++ b/daemon/cmd/bootstrap_statistics.go
@@ -4,27 +4,10 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/go-openapi/runtime/middleware"
-
-	restapi "github.com/cilium/cilium/api/v1/server/restapi/metrics"
-	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/spanstat"
 	"github.com/cilium/cilium/pkg/time"
 )
-
-func getMetricsHandler(_ *Daemon, params restapi.GetMetricsParams) middleware.Responder {
-	metrics, err := metrics.DumpMetrics()
-	if err != nil {
-		return api.Error(
-			restapi.GetMetricsInternalServerErrorCode,
-			fmt.Errorf("Cannot gather metrics from daemon"))
-	}
-
-	return restapi.NewGetMetricsOK().WithPayload(metrics)
-}
 
 type bootstrapStatistics struct {
 	overall         spanstat.SpanStat

--- a/pkg/metrics/api.go
+++ b/pkg/metrics/api.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+import (
+	"fmt"
+
+	"github.com/go-openapi/runtime/middleware"
+
+	restapi "github.com/cilium/cilium/api/v1/server/restapi/metrics"
+	"github.com/cilium/cilium/pkg/api"
+)
+
+type metricsRestApiHandler struct{}
+
+func newMetricsRestApiHandler() restapi.GetMetricsHandler {
+	return &metricsRestApiHandler{}
+}
+
+func (h *metricsRestApiHandler) Handle(params restapi.GetMetricsParams) middleware.Responder {
+	metrics, err := dumpMetrics()
+	if err != nil {
+		return api.Error(
+			restapi.GetMetricsInternalServerErrorCode,
+			fmt.Errorf("cannot gather metrics from daemon"))
+	}
+
+	return restapi.NewGetMetricsOK().WithPayload(metrics)
+}

--- a/pkg/metrics/cell.go
+++ b/pkg/metrics/cell.go
@@ -23,6 +23,7 @@ var Cell = cell.Module("metrics", "Metrics",
 		// phase are emitted as metrics.
 		FlushLoggingMetrics()
 	}),
+	cell.Provide(newMetricsRestApiHandler),
 )
 
 // Metric constructs a new metric cell.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1562,9 +1562,9 @@ func Unregister(c prometheus.Collector) bool {
 	return false
 }
 
-// DumpMetrics gets the current Cilium metrics and dumps all into a
+// dumpMetrics gets the current Cilium metrics and dumps all into a
 // models.Metrics structure.If metrics cannot be retrieved, returns an error
-func DumpMetrics() ([]*models.Metric, error) {
+func dumpMetrics() ([]*models.Metric, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	reg, err := registry.Await(ctx)


### PR DESCRIPTION
Currently, the metrics rest api handler is implemented as part of the daemon itself.

To further minimize the number of dependencies on the daemon, this commit extracts the metrics rest api handler into the metrics hive cell.

The `bootstrapStatistics` remain in the daemon package and are renamed to `boostrap_statistics.go` accordingly (Will be removed eventually once the daemon startup is fully modularized).