### PR TITLE
Revert "fix: support validation of stringToString values in ConfigMap"

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -4216,8 +4216,6 @@ func validateConfigMap(cmd *cobra.Command, m map[string]interface{}) error {
 			_, err = cast.ToUint32E(value)
 		case "uint64":
 			_, err = cast.ToUint64E(value)
-		case "stringToString":
-			_, err = cast.ToStringMapStringE(value)
 		default:
 			log.Warnf("Unable to validate option %s value of type %s", key, t)
 		}


### PR DESCRIPTION
This reverts commit c57bfb6b9c52f5ef0b80b4ee77653dad485cd675.

This commit introduces a regression as reported by https://github.com/cilium/cilium/issues/34129. Thus we need to revert the commit.

cc @alex-berger @joestringer