### PR TITLE
fix: support validation of stringToString values in ConfigMap

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -4214,6 +4214,8 @@ func validateConfigMap(cmd *cobra.Command, m map[string]interface{}) error {
 			_, err = cast.ToUint32E(value)
 		case "uint64":
 			_, err = cast.ToUint64E(value)
+		case "stringToString":
+			_, err = command.ToStringMapStringE(value)
 		default:
 			log.Warnf("Unable to validate option %s value of type %s", key, t)
 		}


### PR DESCRIPTION
This is the second attempt to fix https://github.com/cilium/cilium/issues/33095, the first attempt lead to regression https://github.com/cilium/cilium/issues/34129 and was reverted in https://github.com/cilium/cilium/pull/34277.

 This time using command.ToStringMapStringE(...) instead of cast.ToStringMapStringE(...) to properly support non JSON encoded, comma separated key value encoding.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #33095

```release-note
add support for validation of stringToString values in ConfigMap
```
