### PR TITLE
Document redirects.txt

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -79,6 +79,7 @@ jobs:
         with:
           persist-credentials: false
           # Needed to detect missing redirects
+          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -114,7 +114,7 @@ $(HELM_VALUES): FORCE
 	$(QUIET)printf '..\n  %s\n\n%s\n' "AUTO-GENERATED. Please DO NOT edit manually." "$$(cat $(TMP_FILE_3))" > $@
 	$(QUIET)$(RM) -- $(TMP_FILE_1) $(TMP_FILE_2) $(TMP_FILE_3)
 
-check: builder-image api-flaggen update-cmdref update-crdlist update-helm-values update-codeowners ## Validate command and Helm references, policy examples, and others.
+check: builder-image api-flaggen update-cmdref update-crdlist update-helm-values update-codeowners update-redirects ## Validate command and Helm references, policy examples, and others.
 	@$(ECHO_CHECK) cmdref
 	$(QUIET) ./check-cmdref.sh
 	@$(ECHO_CHECK) $(HELM_VALUES)
@@ -127,6 +127,8 @@ check: builder-image api-flaggen update-cmdref update-crdlist update-helm-values
 	$(QUIET) ./check-flaggen.sh
 	@$(ECHO_CHECK) crdlist.rst
 	$(QUIET) ./check-crdlist.sh
+	@$(ECHO_CHECK) redirects.txt
+	$(QUIET) ./check-redirects.sh
 
 ##@ Build
 

--- a/Documentation/check-redirects.sh
+++ b/Documentation/check-redirects.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+redirect_txt="${script_dir}/redirects.txt"
+
+if ! git diff --quiet -- "${redirect_txt}" ; then
+    git --no-pager diff "${redirect_txt}"
+    echo "HINT: to fix this, run 'make -C Documentation update-redirects'"
+    exit 1
+fi

--- a/Documentation/contributing/docs/docsframework.rst
+++ b/Documentation/contributing/docs/docsframework.rst
@@ -195,6 +195,21 @@ contexts, but never as ``Wireguard``. This filter is implemented in
 .. _spell-checker module: https://github.com/sphinx-contrib/spelling
 .. _builder: https://www.sphinx-doc.org/en/master/usage/builders
 
+Redirect checker/builder
+------------------------
+
+The build system relies on the Sphinx extension `sphinxext-rediraffe`_ (considered a
+`builder`_ in Sphinx) for redirects.
+
+The redirect checker uses the git history to determine if a file has been moved or deleted in order to validate that a redirect for the file has been created in ``Documentation/redirects.txt``.
+Redirects are defined as a mapping from the original source file location to the new location within the ``Documentation/`` directory. The extension uses the ``rediraffe_branch`` as the git ref to diff against to determine which files have been moved or deleted. Any changes prior to the ref specified by ``rediraffe_branch`` will not be detected.
+
+To add new entries to the ``redirects.txt``, run ``make -C Documentation update-redirects``.
+
+If a file has been deleted, or has been moved and is not similar enough to the original source file, then you must manually update ``redirects.txt`` with the correct mapping.
+
+.. _sphinxext-rediraffe: https://github.com/wpilibsuite/sphinxext-rediraffe
+
 :spelling:word:`rstcheck`
 -------------------------
 

--- a/Documentation/contributing/docs/docsframework.rst
+++ b/Documentation/contributing/docs/docsframework.rst
@@ -73,13 +73,14 @@ that they are all up-to-date:
 
 .. code-block:: makefile
 
-   check: builder-image api-flaggen update-cmdref update-crdlist update-helm-values update-codeowners
-   	./check-cmdref.sh
-   	./check-helmvalues.sh
-   	$(DOCKER_RUN) ./check-examples.sh   # Runs "cilium policy validate" and "yamllint"
-   	./check-codeowners.sh
-   	./check-flaggen.sh
-   	./check-crdlist.sh
+   check: builder-image api-flaggen update-cmdref update-crdlist update-helm-values update-codeowners update-redirects
+     ./check-cmdref.sh
+     ./check-helmvalues.sh
+     $(DOCKER_RUN) ./check-examples.sh # Runs "cilium policy validate" and "yamllint"
+     ./check-codeowners.sh
+     ./check-flaggen.sh
+     ./check-crdlist.sh
+     ./check-redirects.sh
 
 Regeneration happens when the different dependency targets for ``check`` are
 run. They are:
@@ -112,6 +113,13 @@ run. They are:
   - ``./update-codeowners.sh``
   - Synchronizes teams description from ``CODEOWNERS``
   - Generates ``Documentation/codeowners.rst``
+
+- ``update-redirects``
+
+  - ``make -C Documentation update-redirects``
+  - Automatically generates redirects based on moved files based on git history.
+  - Validates that all moved or deleted files have a redirect.
+  - Generates ``Documentation/redirects.txt``
 
 Other auto-generated contents include:
 


### PR DESCRIPTION
Follow up to https://github.com/cilium/cilium/pull/34233


Add some documentation describing `redirects.txt` and also update the `check` target to check redirects. Actually building the docs will also check this, but `make check` will do it without generating them.