### PR TITLE
Add launch config for control plane tests in vscode, neovim dap

### DIFF
--- a/.nvim/nvim-dap.lua
+++ b/.nvim/nvim-dap.lua
@@ -1,5 +1,15 @@
 local dap = require('dap')
 
+dap.adapters.cilium_delve = {
+  type = 'server',
+  port = '${port}',
+  executable = {
+    command = 'dlv',
+    args = {'dap', '-l', '127.0.0.1:${port}'},
+    -- add this if on windows, otherwise server won't open successfully
+    -- detached = false
+  }
+}
 dap.adapters.cilium_kind_control_plane_1 = {
     type = "server",
     host = "127.0.0.1",
@@ -21,6 +31,21 @@ dap.adapters.cilium_operator_kind_worker_1 = {
     port = 23511
 }
 dap.configurations.go = {
+    {
+        name = "Debug unit tests in the current file",
+        type = "cilium_delve",
+        request = "launch",
+        mode = "test",
+        program = "./${relativeFileDirname}",
+    },
+    {
+        name = "Debug controlplane test (open test/controlplane/${test}/*.go first)",
+        type = "cilium_delve",
+        request = "launch",
+        mode = "test",
+        program = "./${relativeFileDirname}/../",
+        args = { "-test.v", "-test.run", "TestControlPlane/${fileDirname}"},
+    },
     {
         type = "cilium_kind_control_plane_1",
         request = "attach",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,14 @@
 			"program": "${relativeFileDirname}",
 		},
 		{
+			"name": "Launch controlplane test",
+			"type": "go",
+			"request": "launch",
+			"mode": "test",
+			"program": "${relativeFileDirname}/../",
+			"args": ["-test.v", "-test.run", "TestControlPlane/${fileDirname}"],
+		},
+		{
 			"name": "Attach to kind-control-plane-1",
 			"type": "go",
 			"request": "attach",


### PR DESCRIPTION
I found these useful to debug what was going on while developing a new control
plane test. If you start by editing one of the control plane test files, then
launch this configuration it'll run just the tests from this file.

This needs to be different from the standard Go test launch configuration
because these tests are run differently and are not defined in `*_test.go`.
