### PR TITLE
renovate: Skip gateway-api go packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -229,7 +229,9 @@
         // master branch to the latest release. Ignore this dependency until a
         // v2 release is out which is tracked with the following upstream issue:
         // https://github.com/google/go-licenses/issues/205
-        "github.com/google/go-licenses"
+        "github.com/google/go-licenses",
+        // We update this dependency manually together with conformance test changes
+        "sigs.k8s.io/gateway-api"
       ],
       "matchPackagePatterns": [
         // We can't update these libraries until github.com/shoenig/go-m1cpu


### PR DESCRIPTION
The latest version from upstream is normally either having some breaking changes [^1] or new conformance test [^2], so it's better to update this package manually.

[^1]: https://github.com/cilium/cilium/issues/34266
[^2]: https://github.com/cilium/cilium/pull/33926#issuecomment-2268953017
