### PR TITLE
bpf: lxc: fix up a typo in the L7 LB CT lookup

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -310,7 +310,7 @@ int NAME(struct __ctx_buff *ctx)						\
 		if (is_defined(ENABLE_L7_LB) && proxy_port)			\
 			scope = SCOPE_FORWARD;					\
 		if (is_defined(ENABLE_L7_LB) &&					\
-		    (ctx_load_meta(ctx, CB_FROM_HOST == FROM_HOST_L7_LB)))	\
+		    (ctx_load_meta(ctx, CB_FROM_HOST) == FROM_HOST_L7_LB))	\
 			scope = SCOPE_FORWARD;					\
 	}									\
 										\
@@ -371,7 +371,7 @@ int NAME(struct __ctx_buff *ctx)						\
 		if (is_defined(ENABLE_L7_LB) && proxy_port)			\
 			scope = SCOPE_FORWARD;					\
 		if (is_defined(ENABLE_L7_LB) &&					\
-		    (ctx_load_meta(ctx, CB_FROM_HOST == FROM_HOST_L7_LB)))	\
+		    (ctx_load_meta(ctx, CB_FROM_HOST) == FROM_HOST_L7_LB))	\
 			scope = SCOPE_FORWARD;					\
 	}									\
 										\


### PR DESCRIPTION
Fix up a subtle typo that was introduced by
043f2ea723f7 ("bpf: lxc: also reduce CT lookup scope after L7 service match").