### PR TITLE
helm: also mount kvstoremesh-specific certificate into cilium-operator

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -362,7 +362,7 @@ spec:
               name: cilium-clustermesh
               optional: true
               # note: items are not explicitly listed here, since the entries of this secret
-              # depend on the peers configured, and that would cause a restart of all agents
+              # depend on the peers configured, and that would cause a restart of all operators
               # at every addition/removal. Leaving the field empty makes each secret entry
               # to be automatically projected into the volume as a file whose name is the key.
           - secret:
@@ -383,6 +383,29 @@ spec:
               items:
               - key: {{ .Values.tls.caBundle.key }}
                 path: common-etcd-client-ca.crt
+          {{- end }}
+          # note: we configure the volume for the kvstoremesh-specific certificate
+          # regardless of whether KVStoreMesh is enabled or not, so that it can be
+          # automatically mounted in case KVStoreMesh gets subsequently enabled,
+          # without requiring an operator restart.
+          - secret:
+              name: clustermesh-apiserver-local-cert
+              optional: true
+              items:
+              - key: tls.key
+                path: local-etcd-client.key
+              - key: tls.crt
+                path: local-etcd-client.crt
+          {{- if not .Values.tls.caBundle.enabled }}
+              - key: ca.crt
+                path: local-etcd-client-ca.crt
+          {{- else }}
+          - {{ .Values.tls.caBundle.useSecret | ternary "secret" "configMap" }}:
+              name: {{ .Values.tls.caBundle.name }}
+              optional: true
+              items:
+              - key: {{ .Values.tls.caBundle.key }}
+                path: local-etcd-client-ca.crt
           {{- end }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
In commit c464e66620a45f56f207d923f7d8f843e59b813e the kvstoremesh-specific certificate was mounted into cilium-agent. Since the recent addition of endpointslicesync the operator needs to connect to clustermesh components too meaning that the clustermesh config and secrets should be mirrored to the operator deployment as well. With the addition of the kvstoremesh secrets to the agent and not the operator this resulted into the code connecting to the kvstoremesh not working in the operator context which is now the default as well.

```release-note
Fix operator deployment connecting to clustermesh kvstoremesh when endpointslice sync or MCS-API Service exports is enabled
```
