### PR TITLE
sysctl: allow uppercase letters

### DIFF
--- a/pkg/datapath/linux/sysctl/sysctl.go
+++ b/pkg/datapath/linux/sysctl/sysctl.go
@@ -270,7 +270,7 @@ func (ay *directSysctl) ReadInt(name string) (int64, error) {
 }
 
 // parameterElemRx matches an element of a sysctl parameter.
-var parameterElemRx = regexp.MustCompile(`\A[-0-9_a-z]+\z`)
+var parameterElemRx = regexp.MustCompile(`(?i)\A[-0-9_a-z]+\z`)
 
 // parameterPath returns the path to the sysctl file for parameter name.
 //

--- a/pkg/datapath/linux/sysctl/sysctl_test.go
+++ b/pkg/datapath/linux/sysctl/sysctl_test.go
@@ -53,6 +53,10 @@ func TestFullPath(t *testing.T) {
 			name:        "invalid.char$",
 			expectedErr: true,
 		},
+		{
+			name:     "Foo.Bar",
+			expected: "/proc/sys/Foo/Bar",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
sysctl names potentially contain uppercase letters (a typical example would be network interface names). Support them in the regex.

Fixes: https://github.com/cilium/cilium/issues/34287

```release-note
Fix "invalid sysctl parameter" error when Cilium needs to modify a sysctl with capital letters in its name.
```
