### PR TITLE
[v1.15] Revert "bpf: nodeport: don't track L2 addr for connection to local backend"

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1441,14 +1441,13 @@ redo:
 			return DROP_UNKNOWN_CT;
 		}
 
+		ret = neigh_record_ip6(ctx);
+		if (ret < 0)
+			return ret;
 		if (backend_local) {
 			ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
 			return CTX_ACT_OK;
 		}
-
-		ret = neigh_record_ip6(ctx);
-		if (ret < 0)
-			return ret;
 	}
 
 	/* TX request to remote backend: */
@@ -3010,14 +3009,14 @@ redo:
 			return DROP_UNKNOWN_CT;
 		}
 
+		ret = neigh_record_ip4(ctx);
+		if (ret < 0)
+			return ret;
 		if (backend_local) {
 			ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
 			return CTX_ACT_OK;
 		}
 
-		ret = neigh_record_ip4(ctx);
-		if (ret < 0)
-			return ret;
 	}
 
 	/* TX request to remote backend: */


### PR DESCRIPTION
This reverts commit 3d96cb5c98600d46c5203c822812d4a6ffbeb168.

This causes problems when the local backend's reply traffic is revDNATed in from_container by tail-calling in to CILIUM_CALL_IPV*_NODEPORT_REVNAT. On an older kernel without HAVE_FIB_NEIGH, the first reply packet potentially encounters BPF_FIB_LKUP_RET_NO_NEIGH and wants to obtain the client's MAC address from the neighbour map. So if we don't cache the client's MAC adress in the request path, the reply will get dropped with DROP_NO_FIB and BPF_FIB_MAP_NO_NEIGH.

This will be resolved once https://github.com/cilium/cilium/issues/24062 has been fully addressed and such reply traffic first passes through the host network stack. But until then re-introduce the neighbour tracking, even for configs where it already shouldn't be required any longer.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
