### PR TITLE
Revert "bpf: nodeport: don't track L2 addr for connection to local backend"

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1351,14 +1351,13 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 			return DROP_UNKNOWN_CT;
 		}
 
+		ret = neigh_record_ip6(ctx);
+		if (ret < 0)
+			return ret;
 		if (backend_local) {
 			ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
 			return CTX_ACT_OK;
 		}
-
-		ret = neigh_record_ip6(ctx);
-		if (ret < 0)
-			return ret;
 	}
 
 	/* TX request to remote backend: */
@@ -2909,14 +2908,16 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 			return DROP_UNKNOWN_CT;
 		}
 
+		/* Neighbour tracking is needed for local backend until
+		 * https://github.com/cilium/cilium/issues/24062 is resolved.
+		 */
+		ret = neigh_record_ip4(ctx);
+		if (ret < 0)
+			return ret;
 		if (backend_local) {
 			ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
 			return CTX_ACT_OK;
 		}
-
-		ret = neigh_record_ip4(ctx);
-		if (ret < 0)
-			return ret;
 	}
 
 	/* TX request to remote backend: */


### PR DESCRIPTION
This reverts commit 3d96cb5c98600d46c5203c822812d4a6ffbeb168.

This causes problems when the local backend's reply traffic is revDNATed in from_container by tail-calling in to CILIUM_CALL_IPV*_NODEPORT_REVNAT. On an older kernel without HAVE_FIB_NEIGH, the first reply packet potentially encounters BPF_FIB_LKUP_RET_NO_NEIGH and wants to obtain the client's MAC address from the neighbour map. So if we don't cache the client's MAC adress in the request path, the reply will get dropped with DROP_NO_FIB and BPF_FIB_MAP_NO_NEIGH.

This will be resolved once https://github.com/cilium/cilium/issues/24062 has been fully addressed and such reply traffic first passes through the host network stack. But until then re-introduce the neighbour tracking, even for configs where it already shouldn't be required any longer.

```release-note
Fix a bug in Cilium's kube-proxy replacement, where replies by a local backend are dropped with DROP_NO_FIB.
```
