### PR TITLE
test/helpers: Update operator lock error

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -241,7 +241,7 @@ const (
 	failedToListCRDs           = "the server could not find the requested resource"                   // cf. https://github.com/cilium/cilium/issues/16425
 	retrieveResLock            = "retrieving resource lock kube-system/cilium-operator-resource-lock" // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-871155492
 	failedToRelLockEmptyName   = "Failed to release lock: resource name may not be empty"             // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-985819560
-	failedToUpdateLock         = "Failed to update lock:"
+	failedToUpdateLock         = "Failed to update lock"
 	failedToReleaseLock        = "Failed to release lock:"
 	errorCreatingInitialLeader = "error initially creating leader election record:"
 	cantEnableJIT              = "bpf_jit_enable: no such file or directory"                             // Because we run tests in Kind.


### PR DESCRIPTION
The following error was observed in CI:

    level=error msg="Failed to update lock optimitically: Put \"https://10.122.164.1:443/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/cilium-operator-resource-lock?timeout=5s\": net/http: request canceled (Client.Timeout exceeded while awaiting headers), falling back to slow path" subsys=klog (1 occurrences)

It's a variant of the already allowed error "Failed to update lock: ". This commit updates the constant to match both cases.