### PR TITLE
cgroup: extract cgroup rest api handler from daemon

### DIFF
--- a/daemon/cmd/api_handlers.go
+++ b/daemon/cmd/api_handlers.go
@@ -21,9 +21,8 @@ import (
 type handlersOut struct {
 	cell.Out
 
-	DaemonGetCgroupDumpMetadataHandler daemon.GetCgroupDumpMetadataHandler
-	DaemonGetDebuginfoHandler          daemon.GetDebuginfoHandler
-	DaemonGetHealthzHandler            daemon.GetHealthzHandler
+	DaemonGetDebuginfoHandler daemon.GetDebuginfoHandler
+	DaemonGetHealthzHandler   daemon.GetHealthzHandler
 
 	EndpointDeleteEndpointHandler        endpoint.DeleteEndpointHandler
 	EndpointDeleteEndpointIDHandler      endpoint.DeleteEndpointIDHandler
@@ -130,9 +129,6 @@ func ciliumAPIHandlers(dp promise.Promise[*Daemon], cfg *option.DaemonConfig, _ 
 
 	// /debuginfo
 	out.DaemonGetDebuginfoHandler = wrapAPIHandler(dp, getDebugInfoHandler)
-
-	// /cgroup-dump-metadata
-	out.DaemonGetCgroupDumpMetadataHandler = wrapAPIHandler(dp, getCgroupDumpMetadataHandler)
 
 	// /fqdn/cache
 	out.PolicyGetFqdnCacheHandler = wrapAPIHandler(dp, getFqdnCacheHandler)

--- a/pkg/cgroups/manager/cell.go
+++ b/pkg/cgroups/manager/cell.go
@@ -16,6 +16,7 @@ var Cell = cell.Module(
 	"CGroup Manager",
 
 	cell.Provide(newCGroupManager),
+	cell.Provide(newGetCgroupDumpMetadataRestApiHandler),
 )
 
 type cgroupManagerParams struct {

--- a/pkg/cgroups/manager/rest_api.go
+++ b/pkg/cgroups/manager/rest_api.go
@@ -1,18 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package cmd
+package manager
 
 import (
 	"github.com/go-openapi/runtime/middleware"
 
 	"github.com/cilium/cilium/api/v1/models"
-	restapi "github.com/cilium/cilium/api/v1/server/restapi/daemon"
+	daemonrestapi "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 )
 
-func getCgroupDumpMetadataHandler(d *Daemon, params restapi.GetCgroupDumpMetadataParams) middleware.Responder {
+type getCgroupDumpMetadataRestApiHandler struct {
+	cgroupManager CGroupManager
+}
+
+func newGetCgroupDumpMetadataRestApiHandler(cgroupManager CGroupManager) daemonrestapi.GetCgroupDumpMetadataHandler {
+	return &getCgroupDumpMetadataRestApiHandler{
+		cgroupManager: cgroupManager,
+	}
+}
+
+func (h *getCgroupDumpMetadataRestApiHandler) Handle(params daemonrestapi.GetCgroupDumpMetadataParams) middleware.Responder {
 	resp := models.CgroupDumpMetadata{}
-	metadata := d.cgroupManager.DumpPodMetadata()
+	metadata := h.cgroupManager.DumpPodMetadata()
 
 	for _, pm := range metadata {
 		var respCms []*models.CgroupContainerMetadata
@@ -32,5 +42,5 @@ func getCgroupDumpMetadataHandler(d *Daemon, params restapi.GetCgroupDumpMetadat
 		resp.PodMetadatas = append(resp.PodMetadatas, respPm)
 	}
 
-	return restapi.NewGetCgroupDumpMetadataOK().WithPayload(&resp)
+	return daemonrestapi.NewGetCgroupDumpMetadataOK().WithPayload(&resp)
 }


### PR DESCRIPTION
Currently, the cgroup rest api handler is implemented as part of the daemon itself.

To further minimize the number of dependencies on the daemon, this commit extracts the cgroup rest api handler into the cgroup manager hive cell in package `pkg/cgroups/manager`.
