### PR TITLE
helm: Fix duplicate tunnel-protocol configuration in cilium-config co…

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1,6 +1,7 @@
 {{- if and ( or (.Values.agent) (.Values.operator.enabled) .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) (not .Values.preflight.enabled) }}
 {{- /*  Default values with backwards compatibility */ -}}
 {{- $defaultBpfMapDynamicSizeRatio := 0.0 -}}
+{{- $tunnelProto := ""}}
 {{- $defaultBpfMasquerade := "false" -}}
 {{- $defaultBpfClockProbe := "false" -}}
 {{- $defaultBpfTProxy := "false" -}}
@@ -83,6 +84,14 @@
 {{- if semverCompare ">=1.27-0" .Capabilities.KubeVersion.Version -}}
   {{- $defaultK8sClientQPS = 10 -}}
   {{- $defaultK8sClientBurst = 20 -}}
+{{- end -}}
+
+{{- if or (.Values.gke.enabled) (eq .Values.routingMode "native") -}}
+  {{- $tunnelProto = "" -}}
+{{- else if ne (.Values.tunnelProtocol) "" -}}
+  {{- $tunnelProto = .Values.tunnelProtocol -}}
+{{- else -}}
+  {{- $tunnelProto = "vxlan" -}}
 {{- end -}}
 ---
 apiVersion: v1
@@ -483,18 +492,14 @@ data:
     {{- fail (printf "RoutingMode must be set to tunnel when aksbyocni.enabled=true" )}}
   {{- end }}
   routing-mode: "tunnel"
-  tunnel-protocol: "vxlan"
 {{- else if .Values.routingMode }}
   routing-mode: {{ .Values.routingMode | quote }}
 {{- else }}
   # Default case
   routing-mode: "tunnel"
-  tunnel-protocol: "vxlan"
 {{- end }}
 
-{{- if .Values.tunnelProtocol }}
   tunnel-protocol: {{ .Values.tunnelProtocol | quote }}
-{{- end }}
 
 {{- if .Values.tunnelPort }}
   tunnel-port: {{ .Values.tunnelPort | quote }}


### PR DESCRIPTION


Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

<!-- Description of change -->

This updates updates the `cilium-config` configmap template to fix the potential for duplicate `tunnel-protocol` entries.

This is accomplished by removing the `tunnel-protocol` logic in earlier parts of the template (as they default to `vxlan`, which is considered to be the default setting in general). It then explicitly sets `vxlan` as the default value for `tunnel-protocol` in `values.yaml`.

By doing the above, it now results in only a single entry for `tunnel-protocol` and adjusts the values if it is set to something other than `vxlan` (i.e. `geneve`).

Fixes: #33456

```release-note
Simplify tunnel-protocol logic in helm templates to remove occurrence of duplicate entries. VXLAN is now explicitly set as the default value for `tunnel-protocol`.
```
