### PR TITLE
Remove ghc in GHA disk cleanup

### DIFF
--- a/.github/actions/disk-cleanup/action.yaml
+++ b/.github/actions/disk-cleanup/action.yaml
@@ -16,6 +16,8 @@ runs:
           /opt/microsoft/msedge \
           /opt/microsoft/powershell \
           /opt/pipx \
+          /opt/ghc \
+          /usr/local/.ghcup \
           /usr/lib/mono \
           /usr/local/julia* \
           /usr/local/lib/android \


### PR DESCRIPTION
We don't need Haskell for our CI.