### PR TITLE
.github: Add disk-cleanup GHA to ipsec upgrade tests

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -197,6 +197,9 @@ jobs:
           # make tags available to print-downgrade-version.sh.
           persist-credentials: true
 
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
+
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 


### PR DESCRIPTION
Hitting issues with no more space in IPSec upgrade in this PR https://github.com/cilium/cilium/pull/34229 (https://github.com/cilium/cilium/actions/runs/10288626598/job/28666121184 scroll to the bottom). 