### PR TITLE
[v1.16] policy: Port Range Match Label Fix

### DIFF
--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -8,14 +8,18 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	stdlog "log"
 	"net/netip"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/container/bitlpm"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
@@ -23,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 var (
@@ -1834,6 +1839,194 @@ func Test_EnsureEntitiesSelectableByCIDR(t *testing.T) {
 				t.Logf("Policy Trace: \n%s\n", logBuffer.String())
 				t.Errorf("Policy test, %q, obtained didn't match expected for endpoint %s", tt.test, labelsFoo)
 			}
+		})
+	}
+}
+
+func mapStateAllowsKey(ms *mapState, key Key) bool {
+	var ok bool
+	ms.denies.trie.Ancestors(key.PrefixLength(), key,
+		func(_ uint, _ bitlpm.Key[types.Key], idMap map[identity.NumericIdentity]MapStateEntry) bool {
+			if _, exists := idMap[identity.NumericIdentity(key.Identity)]; exists {
+				ok = true
+			}
+			return true
+		})
+	if ok {
+		return false
+	}
+	ms.allows.trie.Ancestors(key.PrefixLength(), key,
+		func(_ uint, _ bitlpm.Key[types.Key], idMap map[identity.NumericIdentity]MapStateEntry) bool {
+
+			if _, exists := idMap[identity.NumericIdentity(key.Identity)]; exists {
+				ok = true
+			}
+			return true
+		})
+	return ok
+}
+
+func TestEgressPortRangePrecedence(t *testing.T) {
+	td := newTestData()
+	identityCache := identity.IdentityMap{
+		identity.NumericIdentity(100): labelsA,
+	}
+	td.sc.UpdateIdentities(identityCache, nil, &sync.WaitGroup{})
+	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(100), labelsA)
+
+	type portRange struct {
+		startPort, endPort uint16
+		isAllow            bool
+	}
+	tests := []struct {
+		name       string
+		rules      []portRange
+		rangeTests []portRange
+	}{
+		{
+			name: "deny range (1-1024) covers port allow (80)",
+			rules: []portRange{
+				{80, 0, true},
+				{1, 1024, false},
+			},
+			rangeTests: []portRange{
+				{79, 81, false},
+				{1023, 1025, false},
+			},
+		},
+		{
+			name: "deny port (80) in broader allow range (1-1024)",
+			rules: []portRange{
+				{80, 0, false},
+				{1, 1024, true},
+			},
+			rangeTests: []portRange{
+				{1, 2, true},
+				{79, 0, true},
+				{80, 0, false},
+				{81, 0, true},
+				{1023, 1024, true},
+				{1025, 1026, false},
+			},
+		},
+		{
+			name: "wildcard deny (*) covers broad allow range (1-1024)",
+			rules: []portRange{
+				{0, 0, false},
+				{1, 1024, true},
+			},
+			rangeTests: []portRange{
+				{1, 2, false},
+				{1023, 1025, false},
+			},
+		},
+		{
+			name: "wildcard allow (*) has an deny range hole (1-1024)",
+			rules: []portRange{
+				{0, 0, true},
+				{1, 1024, false},
+			},
+			rangeTests: []portRange{
+				{1, 2, false},
+				{1023, 1024, false},
+				{1025, 1026, true},
+				{65534, 0, true},
+			},
+		},
+		{
+			name: "two allow ranges (80-90, 90-100) with overlapping deny (85-95)",
+			rules: []portRange{
+				{80, 90, true},
+				{85, 95, false},
+				{90, 100, true},
+			},
+			rangeTests: []portRange{
+				{79, 0, false},
+				{80, 84, true},
+				{85, 95, false},
+				{96, 100, true},
+				{101, 0, true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &rule{
+				Rule: api.Rule{
+					EndpointSelector: endpointSelectorA,
+				},
+			}
+			for _, rul := range tt.rules {
+				pp := api.PortProtocol{
+					Port:     fmt.Sprintf("%d", rul.startPort),
+					EndPort:  int32(rul.endPort),
+					Protocol: api.ProtoTCP,
+				}
+				if rul.isAllow {
+					tr.Rule.Egress = append(tr.Rule.Egress, api.EgressRule{
+						EgressCommonRule: api.EgressCommonRule{
+							ToEndpoints: []api.EndpointSelector{endpointSelectorA},
+						},
+						ToPorts: []api.PortRule{{
+							Ports: []api.PortProtocol{pp},
+						}},
+					})
+				} else {
+					tr.Rule.EgressDeny = append(tr.Rule.EgressDeny, api.EgressDenyRule{
+						EgressCommonRule: api.EgressCommonRule{
+							ToEndpoints: []api.EndpointSelector{endpointSelectorA},
+						},
+						ToPorts: []api.PortDenyRule{{
+							Ports: []api.PortProtocol{pp},
+						}},
+					})
+				}
+			}
+			buffer := new(bytes.Buffer)
+			ctxFromA := SearchContext{From: labelsA, Trace: TRACE_VERBOSE}
+			ctxFromA.Logging = stdlog.New(buffer, "", 0)
+			defer t.Log(buffer)
+
+			require.NoError(t, tr.Sanitize())
+			state := traceState{}
+			res, err := tr.resolveEgressPolicy(td.testPolicyContext, &ctxFromA, &state, NewL4PolicyMap(), nil, nil)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			repo := newPolicyDistillery(td.sc)
+			repo.MustAddList(api.Rules{&tr.Rule})
+			repo = repo.WithLogBuffer(buffer)
+			ms, err := repo.distillPolicy(DummyOwner{}, labelsA, identity)
+
+			require.NoError(t, err)
+			require.NotNil(t, ms)
+			mapStateP, ok := ms.(*mapState)
+			require.True(t, ok, "failed type coercion")
+
+			for _, rt := range tt.rangeTests {
+				for i := rt.startPort; i <= rt.endPort; i++ {
+					ctxFromA.DPorts = []*models.Port{{Port: i, Protocol: models.PortProtocolTCP}}
+					key := Key{
+						Identity:         identity.ID.Uint32(),
+						DestPort:         i,
+						Nexthdr:          uint8(u8proto.TCP),
+						TrafficDirection: trafficdirection.Egress.Uint8(),
+					}
+					if rt.isAllow {
+						// IngressCoversContext just checks the "From" labels of the search context.
+						require.Equalf(t, api.Allowed.String(), res.IngressCoversContext(&ctxFromA).String(), "Requesting port %d", i)
+
+						require.Truef(t, mapStateAllowsKey(mapStateP, key), "key (%v) not allowed", key)
+					} else {
+						// IngressCoversContext just checks the "From" labels of the search context.
+						require.Equalf(t, api.Denied.String(), res.IngressCoversContext(&ctxFromA).String(), "Requesting port %d", i)
+						require.Falsef(t, mapStateAllowsKey(mapStateP, key), "key (%v) allowed", key)
+
+					}
+				}
+			}
+
 		})
 	}
 }

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1121,7 +1121,7 @@ type L4PolicyMap interface {
 	Upsert(port string, endPort uint16, protocol string, l4 *L4Filter)
 	Delete(port string, endPort uint16, protocol string)
 	ExactLookup(port string, endPort uint16, protocol string) *L4Filter
-	LongestPrefixMatch(port string, protocol string) *L4Filter
+	MatchesLabels(port, protocol string, labels labels.LabelArray) (match, isDeny bool)
 	Detach(selectorCache *SelectorCache)
 	IngressCoversContext(ctx *SearchContext) api.Decision
 	EgressCoversContext(ctx *SearchContext) api.Decision
@@ -1287,34 +1287,32 @@ func (l4M *l4PolicyMap) ExactLookup(port string, endPort uint16, protocol string
 	return nil
 }
 
-// LongestPrefixMatch looks up an L4Filter by protocol/port that contains the port and protocol
-// by longest prefix match. If a named port is passed, then a simple lookup in the named port
-// map is used, not a prefix match.
-func (l4M *l4PolicyMap) LongestPrefixMatch(port string, protocol string) *L4Filter {
+// MatchesLabels checks if a given port, protocol, and labels matches
+// any Rule in the L4PolicyMap.
+func (l4M *l4PolicyMap) MatchesLabels(port, protocol string, labels labels.LabelArray) (match, isDeny bool) {
 	if iana.IsSvcName(port) {
-		return l4M.namedPortMap[port+"/"+protocol]
+		l4 := l4M.namedPortMap[port+"/"+protocol]
+		if l4 != nil {
+			return l4.matchesLabels(labels)
+		}
+		return
 	}
+
 	portU, protoU := parsePortProtocol(port, protocol)
-	portProtoMap, ok := l4M.rangePortMap.LongestPrefixMatch(makePolicyMapKey(portU, 0xffff, protoU))
-	if !ok {
-		return nil
-	}
-	var (
-		shortestPortRange uint16 = 0xffff
-		lastL4            *L4Filter
-	)
-	// Use the smallest port range
-	for k, v := range portProtoMap {
-		// single port match
-		if k.endPort <= k.port {
-			return v
-		}
-		if shortestPortRange > (k.endPort - k.port) {
-			lastL4 = v
-			shortestPortRange = (k.endPort - k.port)
-		}
-	}
-	return lastL4
+	l4PortProtoKeys := make(map[portProtoKey]struct{})
+	l4M.rangePortMap.Ancestors(32, makePolicyMapKey(portU, 0xffff, protoU),
+		func(_ uint, _ uint32, portProtoMap map[portProtoKey]*L4Filter) bool {
+			for k, v := range portProtoMap {
+				if _, ok := l4PortProtoKeys[k]; !ok {
+					match, isDeny = v.matchesLabels(labels)
+					if isDeny {
+						return false
+					}
+				}
+			}
+			return true
+		})
+	return
 }
 
 // ForEach iterates over all L4Filters in the l4PolicyMap.
@@ -1491,36 +1489,16 @@ func (l4M *l4PolicyMap) containsAllL3L4(labels labels.LabelArray, ports []*model
 			portStr = strconv.FormatUint(uint64(l4Ctx.Port), 10)
 		}
 		lwrProtocol := l4Ctx.Protocol
-		var isUDPDeny, isTCPDeny, isSCTPDeny bool
 		switch lwrProtocol {
 		case "", models.PortProtocolANY:
-			tcpFilter := l4M.LongestPrefixMatch(portStr, "TCP")
-			tcpmatch := tcpFilter != nil
-			if tcpmatch {
-				tcpmatch, isTCPDeny = tcpFilter.matchesLabels(labels)
-			}
-
-			udpFilter := l4M.LongestPrefixMatch(portStr, "UDP")
-			udpmatch := udpFilter != nil
-			if udpmatch {
-				udpmatch, isUDPDeny = udpFilter.matchesLabels(labels)
-			}
-
-			sctpFilter := l4M.LongestPrefixMatch(portStr, "SCTP")
-			sctpmatch := sctpFilter != nil
-			if sctpmatch {
-				sctpmatch, isSCTPDeny = sctpFilter.matchesLabels(labels)
-			}
-
+			tcpmatch, isTCPDeny := l4M.MatchesLabels(portStr, "TCP", labels)
+			udpmatch, isUDPDeny := l4M.MatchesLabels(portStr, "UDP", labels)
+			sctpmatch, isSCTPDeny := l4M.MatchesLabels(portStr, "SCTP", labels)
 			if (!tcpmatch && !udpmatch && !sctpmatch) || (isTCPDeny && isUDPDeny && isSCTPDeny) {
 				return api.Denied
 			}
 		default:
-			filter := l4M.LongestPrefixMatch(portStr, lwrProtocol)
-			if filter == nil {
-				return api.Denied
-			}
-			matches, isDeny := filter.matchesLabels(labels)
+			matches, isDeny := l4M.MatchesLabels(portStr, lwrProtocol, labels)
 			if !matches || isDeny {
 				return api.Denied
 			}


### PR DESCRIPTION
The original port range changes for EgressCoversContext
inadvertantly undid implicit logic underlying
using the go builtin map. That is that deny entries
would always be correctly identified by label, based
on the fact that no more than one port-protocol key
could match a given set of labels. After the introduction
of port ranges this implicit assumption was false,
but no logic to prioritize deny entries over allows
was introduced. Instead the code naively looked up
the longest prefix match rule by port-protocol.
This works most of the time, but fails for deny
entries of lesser port-protocol prefix matches
when a longer prefix allow is present.
    
This commit introduces a new method on the
L4PolicyMap `MatchesLabels` that looks up applicable
rules by label using the longest prefix match
lookup by port-protocol, but correctly finds
deny entries that may have lower port-protocol
precedence.

```release-note
policy: Fix policy cache covers context lookup.
```

