### PR TITLE
.github/actions: Update versions to 1.30

### DIFF
--- a/.github/actions/aws-cni/k8s-versions.yaml
+++ b/.github/actions/aws-cni/k8s-versions.yaml
@@ -1,15 +1,15 @@
 # List of k8s version for EKS tests
 ---
 include:
-  - version: "1.26"
-    region: us-west-1
   - version: "1.27"
     region: us-east-2
   - version: "1.28"
     region: ca-central-1
-    default: true
-    kpr: true
   - version: "1.29"
     region: us-east-1
+    kpr: true
     default: true
+  - version: "1.30"
+    region: us-west-1
     wireguard: true
+    default: true

--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -1,13 +1,13 @@
 # List of k8s version for AKS tests
 ---
 include:
-  - version: "1.27"
-    location: westus2
-    index: 1
   - version: "1.28"
     location: eastus2
-    index: 2
+    index: 1
   - version: "1.29"
     location: eastus
+    index: 2
+  - version: "1.30"
+    location: westus2
     index: 3
     default: true

--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -1,17 +1,16 @@
 # List of k8s version for EKS tests
 ---
 include:
-  - version: "1.26"
-    region: us-west-1
   - version: "1.27"
     region: us-east-2
-    ipsec: true
   - version: "1.28"
     region: ca-central-1
-    default: true
     ipsec: true
-    kpr: true
   - version: "1.29"
     region: us-east-1
+    ipsec: true
+    kpr: true
+  - version: "1.30"
+    region: us-west-1
     ipsec: true
     default: true

--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,16 +1,16 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.26"
-    zone: us-west2-c
-    vmIndex: 1
   - version: "1.27"
     zone: us-west3-a
-    vmIndex: 2
+    vmIndex: 1
   - version: "1.28"
     zone: us-east4-b
-    vmIndex: 3
+    vmIndex: 2
   - version: "1.29"
     zone: us-east1-c
-    vmIndex: 4
+    vmIndex: 3
+  - version: "1.30"
+    zone: us-west2-c
     default: true
+    vmIndex: 4


### PR DESCRIPTION
Adjust the default versions to cover the latest (1.30) version as well.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
