### PR TITLE
metrics: Add metrics config test for Hubble.

### DIFF
--- a/pkg/hubble/exporter/metrics.go
+++ b/pkg/hubble/exporter/metrics.go
@@ -52,10 +52,10 @@ var (
 )
 
 func registerMetrics(exp *DynamicExporter) {
-	metrics.Register(&dynamicExporterGaugeCollector{exporter: exp})
-	metrics.Register(DynamicExporterReconfigurations)
-	metrics.Register(DynamicExporterConfigHash)
-	metrics.Register(DynamicExporterConfigLastApplied)
+	metrics.Registry.MustRegister(&dynamicExporterGaugeCollector{exporter: exp})
+	metrics.Registry.MustRegister(DynamicExporterReconfigurations)
+	metrics.Registry.MustRegister(DynamicExporterConfigHash)
+	metrics.Registry.MustRegister(DynamicExporterConfigLastApplied)
 }
 
 type dynamicExporterGaugeCollector struct {

--- a/pkg/hubble/metrics/metrics_test.go
+++ b/pkg/hubble/metrics/metrics_test.go
@@ -5,16 +5,25 @@ package metrics
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"sort"
 	"testing"
 	"time"
 
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/expfmt"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/util/workqueue"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/types"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
 
 func TestUninitializedMetrics(t *testing.T) {
@@ -45,4 +54,72 @@ func TestInitializedMetrics(t *testing.T) {
 		endpointDeletionHandler.queue.ShutDown()
 	})
 
+}
+
+func SetUpTestMetricsServer(reg *prometheus.Registry) *httptest.Server {
+	srv := httptest.NewServer(nil)
+	InitMetricsServerHandler(srv.Config, reg, false)
+	return srv
+}
+
+func ConfigureAndFetchMetrics(t *testing.T, testName string, metricCfg []string, exportedMetrics map[string][]string) {
+	t.Run(testName, func(t *testing.T) {
+		log := logrus.New()
+
+		reg := prometheus.NewPedanticRegistry()
+		srv := SetUpTestMetricsServer(reg)
+		defer srv.Close()
+
+		grpcMetrics := grpc_prometheus.NewServerMetrics()
+		InitMetrics(
+			reg,
+			api.ParseMetricList(metricCfg),
+			grpcMetrics)
+
+		flow := &pb.Flow{
+			EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+			L4: &pb.Layer4{
+				Protocol: &pb.Layer4_TCP{
+					TCP: &pb.TCP{},
+				},
+			},
+			Source:      &pb.Endpoint{Namespace: "foo"},
+			Destination: &pb.Endpoint{Namespace: "bar"},
+			Verdict:     pb.Verdict_DROPPED,
+			DropReason:  uint32(pb.DropReason_POLICY_DENIED),
+		}
+		enabledMetrics.ProcessFlow(context.TODO(), flow)
+
+		resp, err := http.Get("http://" + srv.Listener.Addr().String() + "/metrics")
+		require.Nil(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var parser expfmt.TextParser
+		mfMap, err := parser.TextToMetricFamilies(resp.Body)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for metricName, metricFamily := range mfMap {
+			_, ok := exportedMetrics[metricName]
+			require.NotEmpty(t, ok)
+
+			labels := []string{}
+			for _, labelPair := range metricFamily.Metric[0].Label {
+				labels = append(labels, *(labelPair.Name))
+			}
+			sort.Strings(labels)
+			require.Equal(t, labels, exportedMetrics[metricName])
+		}
+	})
+}
+
+func TestHubbleServerStandalone(t *testing.T) {
+	ConfigureAndFetchMetrics(
+		t,
+		"IsMetricServedDropWithOptions",
+		[]string{"drop:destinationContext=namespace;sourceContext=namespace", "flow:labelsContext=source_ip"},
+		map[string][]string{
+			"hubble_drop_total":            {"destination", "protocol", "reason", "source"},
+			"hubble_flows_processed_total": {"protocol", "source_ip", "subtype", "type", "verdict"}})
 }


### PR DESCRIPTION
Starts a standalone Hubble server and passes a metrics config, then fetches from the HTTP /metrics endpoint for validation.
Also splits metrics server creation and starting.

### Checklist

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!
