### PR TITLE
[v1.15] bgpv1: Fix DiffStore to work with multiple server instances

### DIFF
--- a/pkg/bgpv1/manager/instance/instance.go
+++ b/pkg/bgpv1/manager/instance/instance.go
@@ -20,6 +20,9 @@ import (
 // struct is a dumb object. The calling code is required to keep the BgpServer's
 // configuration and associated configuration fields in sync.
 type ServerWithConfig struct {
+	// ASN is the local ASN number of the virtual router instance.
+	ASN uint32
+
 	// backed BgpServer configured in accordance to the accompanying
 	// CiliumBGPVirtualRouter configuration.
 	Server types.Router
@@ -50,6 +53,7 @@ func NewServerWithConfig(ctx context.Context, log *logrus.Entry, params types.Se
 		return nil, err
 	}
 	return &ServerWithConfig{
+		ASN:                params.Global.ASN,
 		Server:             s,
 		Config:             nil,
 		ReconcilerMetadata: make(map[string]any),

--- a/pkg/bgpv1/manager/reconciler/neighbor.go
+++ b/pkg/bgpv1/manager/reconciler/neighbor.go
@@ -53,6 +53,12 @@ func (r *NeighborReconciler) Priority() int {
 	return 60
 }
 
+func (r *NeighborReconciler) Init(_ *instance.ServerWithConfig) error {
+	return nil
+}
+
+func (r *NeighborReconciler) Cleanup(_ *instance.ServerWithConfig) {}
+
 func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
 	if p.DesiredConfig == nil {
 		return fmt.Errorf("attempted neighbor reconciliation with nil CiliumBGPPeeringPolicy")

--- a/pkg/bgpv1/manager/reconciler/pod_cidr.go
+++ b/pkg/bgpv1/manager/reconciler/pod_cidr.go
@@ -47,6 +47,12 @@ func (r *ExportPodCIDRReconciler) Priority() int {
 	return 30
 }
 
+func (r *ExportPodCIDRReconciler) Init(_ *instance.ServerWithConfig) error {
+	return nil
+}
+
+func (r *ExportPodCIDRReconciler) Cleanup(_ *instance.ServerWithConfig) {}
+
 func (r *ExportPodCIDRReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
 	if p.DesiredConfig == nil {
 		return fmt.Errorf("attempted pod CIDR advertisements reconciliation with nil CiliumBGPPeeringPolicy")

--- a/pkg/bgpv1/manager/reconciler/pod_ip_pool.go
+++ b/pkg/bgpv1/manager/reconciler/pod_ip_pool.go
@@ -61,6 +61,12 @@ func (r *PodIPPoolReconciler) Priority() int {
 	return 50
 }
 
+func (r *PodIPPoolReconciler) Init(_ *instance.ServerWithConfig) error {
+	return nil
+}
+
+func (r *PodIPPoolReconciler) Cleanup(_ *instance.ServerWithConfig) {}
+
 func (r *PodIPPoolReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
 	lp := r.populateLocalPools(p.CiliumNode)
 

--- a/pkg/bgpv1/manager/reconciler/preflight.go
+++ b/pkg/bgpv1/manager/reconciler/preflight.go
@@ -48,6 +48,12 @@ func (r *PreflightReconciler) Priority() int {
 	return 10
 }
 
+func (r *PreflightReconciler) Init(_ *instance.ServerWithConfig) error {
+	return nil
+}
+
+func (r *PreflightReconciler) Cleanup(_ *instance.ServerWithConfig) {}
+
 func (r *PreflightReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
 	var (
 		l = log.WithFields(

--- a/pkg/bgpv1/manager/reconciler/reconciler.go
+++ b/pkg/bgpv1/manager/reconciler/reconciler.go
@@ -28,6 +28,12 @@ type ConfigReconciler interface {
 	// Priority is used to determine the order in which reconcilers are called. Reconcilers are called from lowest to
 	// highest.
 	Priority() int
+	// Init is called upon virtual router instance creation. Reconcilers can initialize any instance-specific
+	// resources here, and clean them up upon Cleanup call.
+	Init(sc *instance.ServerWithConfig) error
+	// Cleanup is called upon virtual router instance deletion. When called, reconcilers are supposed
+	// to clean up all instance-specific resources saved outside the ReconcilerMetadata.
+	Cleanup(sc *instance.ServerWithConfig)
 	// Reconcile If the `Config` field in `params.sc` is nil the reconciler should unconditionally
 	// perform the reconciliation actions, as no previous configuration is present.
 	Reconcile(ctx context.Context, params ReconcileParams) error

--- a/pkg/bgpv1/manager/reconciler/route_policy.go
+++ b/pkg/bgpv1/manager/reconciler/route_policy.go
@@ -65,6 +65,12 @@ func (r *RoutePolicyReconciler) Priority() int {
 	return 70
 }
 
+func (r *RoutePolicyReconciler) Init(_ *instance.ServerWithConfig) error {
+	return nil
+}
+
+func (r *RoutePolicyReconciler) Cleanup(_ *instance.ServerWithConfig) {}
+
 func (r *RoutePolicyReconciler) Reconcile(ctx context.Context, params ReconcileParams) error {
 	l := log.WithFields(logrus.Fields{"component": "RoutePolicyReconciler"})
 

--- a/pkg/bgpv1/manager/store/diffstore_test.go
+++ b/pkg/bgpv1/manager/store/diffstore_test.go
@@ -24,6 +24,11 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/utils"
 )
 
+const (
+	testCallerID1 = "test1"
+	testCallerID2 = "test2"
+)
+
 type DiffStoreFixture struct {
 	diffStore DiffStore[*slimv1.Service]
 	signaler  *signaler.BGPCPSignaler
@@ -96,8 +101,17 @@ func TestDiffSignal(t *testing.T) {
 	fixture := newDiffStoreFixture()
 	tracker := fixture.slimCs.Tracker()
 
+	err := fixture.hive.Start(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-fixture.watching
+
+	fixture.diffStore.InitDiff(testCallerID1)
+	fixture.diffStore.InitDiff(testCallerID2)
+
 	// Add an initial object.
-	err := tracker.Add(&slimv1.Service{
+	err = tracker.Add(&slimv1.Service{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "service-a",
 		},
@@ -105,12 +119,6 @@ func TestDiffSignal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	err = fixture.hive.Start(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	<-fixture.watching
 
 	timer := time.NewTimer(5 * time.Second)
 	select {
@@ -120,15 +128,14 @@ func TestDiffSignal(t *testing.T) {
 		t.Fatal("No signal sent by diffstore")
 	}
 
-	upserted, deleted, err := fixture.diffStore.Diff()
+	// 1 upsert for the caller 1
+	upserted, deleted, err := fixture.diffStore.Diff(testCallerID1)
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	if len(upserted) != 1 {
 		t.Fatal("Initial upserted not one")
 	}
-
 	if len(deleted) != 0 {
 		t.Fatal("Initial deleted not zero")
 	}
@@ -152,15 +159,26 @@ func TestDiffSignal(t *testing.T) {
 		t.Fatal("No signal sent by diffstore")
 	}
 
-	upserted, deleted, err = fixture.diffStore.Diff()
+	// 1 upsert for the caller 1
+	upserted, deleted, err = fixture.diffStore.Diff(testCallerID1)
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	if len(upserted) != 1 {
 		t.Fatal("Runtime upserted not one")
 	}
+	if len(deleted) != 0 {
+		t.Fatal("Runtime deleted not zero")
+	}
 
+	// 2 upserts for the caller 2
+	upserted, deleted, err = fixture.diffStore.Diff(testCallerID2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(upserted) != 2 {
+		t.Fatal("Runtime upserted not two")
+	}
 	if len(deleted) != 0 {
 		t.Fatal("Runtime deleted not zero")
 	}
@@ -180,15 +198,26 @@ func TestDiffSignal(t *testing.T) {
 		t.Fatal("No signal sent by diffstore")
 	}
 
-	upserted, deleted, err = fixture.diffStore.Diff()
+	// 1 deleted for the caller 1
+	upserted, deleted, err = fixture.diffStore.Diff(testCallerID1)
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	if len(upserted) != 0 {
 		t.Fatal("Runtime upserted not zero")
 	}
+	if len(deleted) != 1 {
+		t.Fatal("Runtime deleted not one")
+	}
 
+	// 1 deleted for the caller 2
+	upserted, deleted, err = fixture.diffStore.Diff(testCallerID2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(upserted) != 0 {
+		t.Fatal("Runtime upserted not zero")
+	}
 	if len(deleted) != 1 {
 		t.Fatal("Runtime deleted not one")
 	}
@@ -209,6 +238,8 @@ func TestDiffUpsertCoalesce(t *testing.T) {
 		t.Fatal(err)
 	}
 	<-fixture.watching
+
+	fixture.diffStore.InitDiff(testCallerID1)
 
 	// Add first object
 	err = tracker.Add(&slimv1.Service{
@@ -242,7 +273,7 @@ func TestDiffUpsertCoalesce(t *testing.T) {
 		t.Fatal("No signal sent by diffstore")
 	}
 
-	upserted, deleted, err := fixture.diffStore.Diff()
+	upserted, deleted, err := fixture.diffStore.Diff(testCallerID1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -289,7 +320,7 @@ func TestDiffUpsertCoalesce(t *testing.T) {
 		t.Fatal("No signal sent by diffstore")
 	}
 
-	upserted, deleted, err = fixture.diffStore.Diff()
+	upserted, deleted, err = fixture.diffStore.Diff(testCallerID1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -348,7 +379,7 @@ func TestDiffUpsertCoalesce(t *testing.T) {
 		t.Fatal("No signal sent by diffstore")
 	}
 
-	upserted, deleted, err = fixture.diffStore.Diff()
+	upserted, deleted, err = fixture.diffStore.Diff(testCallerID1)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Author backport of https://github.com/cilium/cilium/pull/34177

[ upstream commit 4a9d01c8c362e7f01a50b320c203e25043817776 ]

[ backporter's notes: kept only BGPv1 changes, adapted service
  reconciler path, tests in lb_service_test.go and diffstore_test.go ]

As the same DiffStore instance is used to diff services when reconciling for multiple server instances (virtual routers), we need to differentiate the diff per instance (and to be future-proof per reconciler as well) for diff to work properly.

This introduces a new callerID argument to the Diff method of the DiffStore to provide caller-specific diff as well as InitDiff(callerID) and CleanupDiff(callerID) methods to initiate and cleanup caller-specific diffs. To wire this properly in the service reconcilers, new reconciler methods Init(instance) and Cleanup(instance) have been added to the reconciler API.

```release-note
BGPv1 + BGPv2: Fix incorrect service reconciliation in setups with multiple BGP instances (virtual routers)
```
