### PR TITLE
daemon: delete newPolicyTrifecta

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -229,6 +229,9 @@ var (
 		// Provides PolicyUpdater
 		cell.Provide(newPolicyUpdater),
 
+		// Provides the different types of IdentityAllocators
+		cell.Provide(newIdentityAllocator),
+
 		// IPAM provides IP address management.
 		ipamcell.Cell,
 

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -226,6 +226,9 @@ var (
 		// Provides PolicyRepository
 		cell.Provide(newPolicyRepo),
 
+		// Provides PolicyUpdater
+		cell.Provide(newPolicyUpdater),
+
 		// IPAM provides IP address management.
 		ipamcell.Cell,
 

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -220,8 +220,11 @@ var (
 		// Auth is responsible for authenticating a request if required by a policy.
 		auth.Cell,
 
-		// IPCache, policy.Repository and CachingIdentityAllocator.
+		// IPCache and CachingIdentityAllocator.
 		cell.Provide(newPolicyTrifecta),
+
+		// Provides PolicyRepository
+		cell.Provide(newPolicyRepo),
 
 		// IPAM provides IP address management.
 		ipamcell.Cell,

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -220,8 +220,8 @@ var (
 		// Auth is responsible for authenticating a request if required by a policy.
 		auth.Cell,
 
-		// IPCache and CachingIdentityAllocator.
-		cell.Provide(newPolicyTrifecta),
+		// Provides the IPCache
+		cell.Provide(newIPCache),
 
 		// Provides PolicyRepository
 		cell.Provide(newPolicyRepo),


### PR DESCRIPTION
This PR deletes the function `newPolicyTrifecta` in favor of dedicated functions that provide the individual components and define the dependencies between them.

* `newPolicyRepo`
* `newPolicyUpdater`
* `newIdentityAllocator`
* `newIPCache`

Please review the individual commits.

Note: Keeping the functions in the daemon package for the time being. Moving them into Hive Cells in the appropriate packages would still result in circular build dependencies.