### PR TITLE
bgpv2: fix cilium-dbg bgp filtering by ASN & route-policy dump format

### DIFF
--- a/cilium-dbg/cmd/bgp_route_policy_get.go
+++ b/cilium-dbg/cmd/bgp_route_policy_get.go
@@ -68,7 +68,7 @@ func printBGPRoutePoliciesTable(policies []*models.BgpRoutePolicy) {
 	fmt.Fprintln(w, "VRouter\tPolicy Name\tType\tMatch Peers\tMatch Prefixes (Min..Max Len)\tRIB Action\tPath Actions")
 	for _, policy := range policies {
 		fmt.Fprintf(w, "%d\t", policy.RouterAsn)
-		fmt.Fprintf(w, "%s\t", trimString(policy.Name, 40))
+		fmt.Fprintf(w, "%s\t", policy.Name)
 		fmt.Fprintf(w, "%s\t", policy.Type)
 
 		for i, stmt := range policy.Statements {
@@ -86,13 +86,6 @@ func printBGPRoutePoliciesTable(policies []*models.BgpRoutePolicy) {
 		}
 	}
 	w.Flush()
-}
-
-func trimString(str string, length int) string {
-	if len(str) <= length {
-		return str
-	}
-	return str[:length] + "..."
 }
 
 func formatStringArray(arr []string) string {

--- a/pkg/bgpv1/manager/manager.go
+++ b/pkg/bgpv1/manager/manager.go
@@ -603,7 +603,7 @@ func (m *BGPRouterManager) getRoutesFromServer(ctx context.Context, sc *instance
 func (m *BGPRouterManager) getRoutesV2(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error) {
 	// validate router ASN
 	if params.RouterAsn != nil {
-		if m.asnExistsInInstances(*params.RouterAsn) {
+		if !m.asnExistsInInstances(*params.RouterAsn) {
 			return nil, fmt.Errorf("virtual router with ASN %d does not exist", *params.RouterAsn)
 		}
 	}
@@ -724,7 +724,7 @@ func (m *BGPRouterManager) getRoutePoliciesV1(ctx context.Context, params restap
 func (m *BGPRouterManager) getRoutePoliciesV2(ctx context.Context, params restapi.GetBgpRoutePoliciesParams) ([]*models.BgpRoutePolicy, error) {
 	// validate router ASN
 	if params.RouterAsn != nil {
-		if m.asnExistsInInstances(*params.RouterAsn) {
+		if !m.asnExistsInInstances(*params.RouterAsn) {
 			return nil, fmt.Errorf("virtual router with ASN %d does not exist", *params.RouterAsn)
 		}
 	}


### PR DESCRIPTION
Fixes filtering by vrouter ASN for `cilium-dbg bgp routes` and `cilium-dbg bgp route-policies` CLI where filtering by ASN returned an error for valid local ASN numbers.

Also removes the printable length limit for policy names in the `cilium-dbg bgp route-policies` CLI to accommodate BGPv2 policy naming.