### PR TITLE
loader: reduce (*loader) state and API footprint

### DIFF
--- a/cilium-dbg/cmd/post_uninstall_cleanup.go
+++ b/cilium-dbg/cmd/post_uninstall_cleanup.go
@@ -550,8 +550,6 @@ func removeTCFilters(linkAndFilters map[string][]*netlink.BpfFilter) error {
 }
 
 func removeXDPAttachments(links []netlink.Link) error {
-	loader := loader.NewLoader(loader.Params{})
-
 	for _, link := range links {
 		if err := loader.DetachXDP(link.Attrs().Name, bpf.CiliumPath(), "cil_xdp_entry"); err != nil {
 			return err

--- a/cilium-dbg/cmd/post_uninstall_cleanup.go
+++ b/cilium-dbg/cmd/post_uninstall_cleanup.go
@@ -550,9 +550,7 @@ func removeTCFilters(linkAndFilters map[string][]*netlink.BpfFilter) error {
 }
 
 func removeXDPAttachments(links []netlink.Link) error {
-	loader := loader.NewLoader(loader.Params{
-		Config: loader.DefaultConfig,
-	})
+	loader := loader.NewLoader(loader.Params{})
 
 	for _, link := range links {
 		if err := loader.DetachXDP(link.Attrs().Name, bpf.CiliumPath(), "cil_xdp_entry"); err != nil {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -277,7 +277,7 @@ func (l *loader) reinitializeIPSec() error {
 	return nil
 }
 
-func (l *loader) reinitializeOverlay(ctx context.Context, tunnelConfig tunnel.Config) error {
+func reinitializeOverlay(ctx context.Context, tunnelConfig tunnel.Config) error {
 	// tunnelConfig.Protocol() can be one of tunnel.[Disabled, VXLAN, Geneve]
 	// if it is disabled, the overlay network programs don't have to be (re)initialized
 	if tunnelConfig.Protocol() == tunnel.Disabled {
@@ -308,14 +308,14 @@ func (l *loader) reinitializeOverlay(ctx context.Context, tunnelConfig tunnel.Co
 		opts = append(opts, fmt.Sprintf("-DSECLABEL_IPV6=%d", identity.ReservedIdentityWorld))
 	}
 
-	if err := l.replaceOverlayDatapath(ctx, opts, iface); err != nil {
+	if err := replaceOverlayDatapath(ctx, opts, iface); err != nil {
 		return fmt.Errorf("failed to load overlay programs: %w", err)
 	}
 
 	return nil
 }
 
-func (l *loader) reinitializeWireguard(ctx context.Context) (err error) {
+func reinitializeWireguard(ctx context.Context) (err error) {
 	// to-wireguard bpf is only used for rev-DNAT, which is only needed when NodePort, KPR, native routing and L7 proxy are enabled together
 	if !option.Config.EnableWireguard ||
 		!option.Config.EnableNodePort ||
@@ -337,14 +337,14 @@ func (l *loader) reinitializeWireguard(ctx context.Context) (err error) {
 		fmt.Sprintf("-DCALLS_MAP=cilium_calls_wireguard_%d", identity.ReservedIdentityWorld),
 	}
 
-	if err := l.replaceWireguardDatapath(ctx, opts, wgTypes.IfaceName); err != nil {
+	if err := replaceWireguardDatapath(ctx, opts, wgTypes.IfaceName); err != nil {
 		return fmt.Errorf("failed to load wireguard programs: %w", err)
 	}
 	return
 }
 
-func (l *loader) reinitializeXDPLocked(ctx context.Context, extraCArgs []string, devices []string, xdpConfig xdp.Config) error {
-	l.maybeUnloadObsoleteXDPPrograms(devices, xdpConfig.Mode(), bpf.CiliumPath())
+func reinitializeXDPLocked(ctx context.Context, extraCArgs []string, devices []string, xdpConfig xdp.Config) error {
+	maybeUnloadObsoleteXDPPrograms(devices, xdpConfig.Mode(), bpf.CiliumPath())
 	if xdpConfig.Disabled() {
 		return nil
 	}
@@ -380,7 +380,8 @@ func (l *loader) ReinitializeXDP(ctx context.Context, cfg *datapath.LocalNodeCon
 	l.compilationLock.Lock()
 	defer l.compilationLock.Unlock()
 	devices := cfg.DeviceNames()
-	return l.reinitializeXDPLocked(ctx, extraCArgs, devices, cfg.XDPConfig)
+
+	return reinitializeXDPLocked(ctx, extraCArgs, devices, cfg.XDPConfig)
 }
 
 func (l *loader) ReinitializeHostDev(ctx context.Context, mtu int) error {
@@ -514,7 +515,7 @@ func (l *loader) Reinitialize(ctx context.Context, cfg *datapath.LocalNodeConfig
 	}
 
 	extraArgs := []string{"-Dcapture_enabled=0"}
-	if err := l.reinitializeXDPLocked(ctx, extraArgs, devices, cfg.XDPConfig); err != nil {
+	if err := reinitializeXDPLocked(ctx, extraArgs, devices, cfg.XDPConfig); err != nil {
 		log.WithError(err).Fatal("Failed to compile XDP program")
 	}
 
@@ -537,11 +538,11 @@ func (l *loader) Reinitialize(ctx context.Context, cfg *datapath.LocalNodeConfig
 		}
 	}
 
-	if err := l.reinitializeOverlay(ctx, tunnelConfig); err != nil {
+	if err := reinitializeOverlay(ctx, tunnelConfig); err != nil {
 		return err
 	}
 
-	if err := l.reinitializeWireguard(ctx); err != nil {
+	if err := reinitializeWireguard(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/datapath/loader/cell.go
+++ b/pkg/datapath/loader/cell.go
@@ -5,7 +5,6 @@ package loader
 
 import (
 	"github.com/cilium/hive/cell"
-	"github.com/spf13/pflag"
 
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 )
@@ -14,7 +13,6 @@ var Cell = cell.Module(
 	"loader",
 	"Loader",
 
-	cell.Config(DefaultConfig),
 	cell.Provide(NewLoader),
 	cell.Provide(NewCompilationLock),
 )
@@ -22,27 +20,4 @@ var Cell = cell.Module(
 // NewLoader returns a new loader.
 func NewLoader(p Params) datapath.Loader {
 	return newLoader(p)
-}
-
-var DefaultConfig = Config{
-	// By default the masquerading IP is the primary IP address of the device in
-	// question.
-	DeriveMasqIPAddrFromDevice: "",
-}
-
-type Config struct {
-	// DeriveMasqIPAddrFromDevice specifies which device's IP addr is used for BPF masquerade.
-	// This is a hidden option and by default not set. Only needed in very specific setups
-	// with ECMP and multiple devices.
-	// See commit d204d789746b1389cc2ba02fdd55b81a2f55b76e for original context.
-	// This can be removed once https://github.com/cilium/cilium/issues/17158 is resolved.
-	DeriveMasqIPAddrFromDevice string
-}
-
-func (def Config) Flags(flags *pflag.FlagSet) {
-	const deriveFlag = "derive-masq-ip-addr-from-device"
-	flags.String(
-		deriveFlag, def.DeriveMasqIPAddrFromDevice,
-		"Device name from which Cilium derives the IP addr for BPF masquerade")
-	flags.MarkHidden(deriveFlag)
 }

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -70,8 +70,6 @@ var log = logging.DefaultLogger.WithField(logfields.LogSubsys, subsystem)
 // loader is a wrapper structure around operations related to compiling,
 // loading, and reloading datapath programs.
 type loader struct {
-	cfg Config
-
 	// templateCache is the cache of pre-compiled datapaths. Only set after
 	// a call to Reinitialize.
 	templateCache *objectCache
@@ -91,7 +89,6 @@ type loader struct {
 type Params struct {
 	cell.In
 
-	Config          Config
 	Sysctl          sysctl.Sysctl
 	Prefilter       datapath.PreFilter
 	CompilationLock datapath.CompilationLock
@@ -106,7 +103,6 @@ type Params struct {
 // newLoader returns a new loader.
 func newLoader(p Params) *loader {
 	return &loader{
-		cfg:               p.Config,
 		templateCache:     newObjectCache(p.ConfigWriter, filepath.Join(option.Config.StateDir, defaults.TemplatesDir)),
 		sysctl:            p.Sysctl,
 		hostDpInitialized: make(chan struct{}),
@@ -137,8 +133,8 @@ func removeEndpointRoute(ep datapath.Endpoint, ip net.IPNet) error {
 }
 
 func (l *loader) bpfMasqAddrs(ifName string, cfg *datapath.LocalNodeConfiguration) (masq4, masq6 netip.Addr) {
-	if l.cfg.DeriveMasqIPAddrFromDevice != "" {
-		ifName = l.cfg.DeriveMasqIPAddrFromDevice
+	if cfg.DeriveMasqIPAddrFromDevice != "" {
+		ifName = cfg.DeriveMasqIPAddrFromDevice
 	}
 
 	find := func(devName string) bool {

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -132,7 +132,7 @@ func removeEndpointRoute(ep datapath.Endpoint, ip net.IPNet) error {
 	})
 }
 
-func (l *loader) bpfMasqAddrs(ifName string, cfg *datapath.LocalNodeConfiguration) (masq4, masq6 netip.Addr) {
+func bpfMasqAddrs(ifName string, cfg *datapath.LocalNodeConfiguration) (masq4, masq6 netip.Addr) {
 	if cfg.DeriveMasqIPAddrFromDevice != "" {
 		ifName = cfg.DeriveMasqIPAddrFromDevice
 	}
@@ -171,7 +171,7 @@ func (l *loader) bpfMasqAddrs(ifName string, cfg *datapath.LocalNodeConfiguratio
 
 // hostRewrites calculates the changes necessary to attach the host endpoint
 // programs to different interfaces.
-func (l *loader) hostRewrites(cfg *datapath.LocalNodeConfiguration, ep datapath.Endpoint, ifName string) (map[string]uint64, map[string]string, error) {
+func hostRewrites(cfg *datapath.LocalNodeConfiguration, ep datapath.Endpoint, ifName string) (map[string]uint64, map[string]string, error) {
 	opts := ELFVariableSubstitutions(ep)
 	strings := ELFMapSubstitutions(ep)
 
@@ -201,7 +201,7 @@ func (l *loader) hostRewrites(cfg *datapath.LocalNodeConfiguration, ep datapath.
 	opts["NATIVE_DEV_IFINDEX"] = uint64(ifIndex)
 
 	if option.Config.EnableBPFMasquerade && ifName != defaults.SecondHostDevice {
-		ipv4, ipv6 := l.bpfMasqAddrs(ifName, cfg)
+		ipv4, ipv6 := bpfMasqAddrs(ifName, cfg)
 
 		if option.Config.EnableIPv4Masquerade && ipv4.IsValid() {
 			opts["IPV4_MASQUERADE"] = uint64(byteorder.NetIPv4ToHost32(ipv4.AsSlice()))
@@ -312,24 +312,19 @@ func removeObsoleteNetdevPrograms(devices []string) error {
 
 // reloadHostEndpoint (re)attaches programs from bpf_host.c to cilium_host,
 // cilium_net and external (native) devices.
-func (l *loader) reloadHostEndpoint(cfg *datapath.LocalNodeConfiguration, ep datapath.Endpoint, spec *ebpf.CollectionSpec) error {
+func reloadHostEndpoint(cfg *datapath.LocalNodeConfiguration, ep datapath.Endpoint, spec *ebpf.CollectionSpec) error {
 	// Replace programs on cilium_host.
 	if err := attachCiliumHost(ep, spec); err != nil {
 		return fmt.Errorf("attaching cilium_host: %w", err)
 	}
 
-	if err := l.attachCiliumNet(cfg, ep, spec); err != nil {
+	if err := attachCiliumNet(cfg, ep, spec); err != nil {
 		return fmt.Errorf("attaching cilium_host: %w", err)
 	}
 
-	if err := l.attachNetworkDevices(cfg, ep, spec); err != nil {
+	if err := attachNetworkDevices(cfg, ep, spec); err != nil {
 		return fmt.Errorf("attaching cilium_host: %w", err)
 	}
-
-	l.hostDpInitializedOnce.Do(func() {
-		log.Debug("Initialized host datapath")
-		close(l.hostDpInitialized)
-	})
 
 	return nil
 }
@@ -379,13 +374,13 @@ func attachCiliumHost(ep datapath.Endpoint, spec *ebpf.CollectionSpec) error {
 }
 
 // attachCiliumNet attaches programs from bpf_host.c to cilium_net.
-func (l *loader) attachCiliumNet(cfg *datapath.LocalNodeConfiguration, ep datapath.Endpoint, spec *ebpf.CollectionSpec) error {
+func attachCiliumNet(cfg *datapath.LocalNodeConfiguration, ep datapath.Endpoint, spec *ebpf.CollectionSpec) error {
 	net, err := netlink.LinkByName(defaults.SecondHostDevice)
 	if err != nil {
 		return fmt.Errorf("retrieving device %s: %w", defaults.SecondHostDevice, err)
 	}
 
-	consts, renames, err := l.hostRewrites(cfg, ep, defaults.SecondHostDevice)
+	consts, renames, err := hostRewrites(cfg, ep, defaults.SecondHostDevice)
 	if err != nil {
 		return err
 	}
@@ -419,7 +414,7 @@ func (l *loader) attachCiliumNet(cfg *datapath.LocalNodeConfiguration, ep datapa
 // attachNetworkDevices attaches programs from bpf_host.c to externally-facing
 // devices and the wireguard device. Attaches cil_from_netdev to ingress and
 // optionally cil_to_netdev to egress if enabled features require it.
-func (l *loader) attachNetworkDevices(cfg *datapath.LocalNodeConfiguration, ep datapath.Endpoint, spec *ebpf.CollectionSpec) error {
+func attachNetworkDevices(cfg *datapath.LocalNodeConfiguration, ep datapath.Endpoint, spec *ebpf.CollectionSpec) error {
 	devices := cfg.DeviceNames()
 
 	// Selectively attach bpf_host to cilium_wg0.
@@ -437,7 +432,7 @@ func (l *loader) attachNetworkDevices(cfg *datapath.LocalNodeConfiguration, ep d
 
 		linkDir := bpffsDeviceLinksDir(bpf.CiliumPath(), iface)
 
-		consts, renames, err := l.hostRewrites(cfg, ep, device)
+		consts, renames, err := hostRewrites(cfg, ep, device)
 		if err != nil {
 			return err
 		}
@@ -498,7 +493,7 @@ func (l *loader) attachNetworkDevices(cfg *datapath.LocalNodeConfiguration, ep d
 //
 // spec is modified by the method and it is the callers responsibility to copy
 // it if necessary.
-func (l *loader) reloadEndpoint(ep datapath.Endpoint, spec *ebpf.CollectionSpec) error {
+func reloadEndpoint(ep datapath.Endpoint, spec *ebpf.CollectionSpec) error {
 	device := ep.InterfaceName()
 
 	var obj lxcObjects
@@ -573,7 +568,7 @@ func (l *loader) reloadEndpoint(ep datapath.Endpoint, spec *ebpf.CollectionSpec)
 	return nil
 }
 
-func (l *loader) replaceOverlayDatapath(ctx context.Context, cArgs []string, iface string) error {
+func replaceOverlayDatapath(ctx context.Context, cArgs []string, iface string) error {
 	if err := compileOverlay(ctx, cArgs); err != nil {
 		return fmt.Errorf("compiling overlay program: %w", err)
 	}
@@ -616,7 +611,7 @@ func (l *loader) replaceOverlayDatapath(ctx context.Context, cArgs []string, ifa
 	return nil
 }
 
-func (l *loader) replaceWireguardDatapath(ctx context.Context, cArgs []string, iface string) (err error) {
+func replaceWireguardDatapath(ctx context.Context, cArgs []string, iface string) (err error) {
 	if err := compileWireguard(ctx, cArgs); err != nil {
 		return fmt.Errorf("compiling wireguard program: %w", err)
 	}
@@ -681,14 +676,20 @@ func (l *loader) ReloadDatapath(ctx context.Context, ep datapath.Endpoint, cfg *
 	if ep.IsHost() {
 		// Reload bpf programs on cilium_host and cilium_net.
 		stats.BpfLoadProg.Start()
-		err = l.reloadHostEndpoint(cfg, ep, spec)
+		err = reloadHostEndpoint(cfg, ep, spec)
 		stats.BpfLoadProg.End(err == nil)
+
+		l.hostDpInitializedOnce.Do(func() {
+			log.Debug("Initialized host datapath")
+			close(l.hostDpInitialized)
+		})
+
 		return hash, err
 	}
 
 	// Reload an lxc endpoint program.
 	stats.BpfLoadProg.Start()
-	err = l.reloadEndpoint(ep, spec)
+	err = reloadEndpoint(ep, spec)
 	stats.BpfLoadProg.End(err == nil)
 	return hash, err
 }

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -212,9 +212,7 @@ func TestBPFMasqAddrs(t *testing.T) {
 		option.Config.EnableIPv6Masquerade = old6
 	})
 
-	l := newTestLoader(t)
-
-	masq4, masq6 := l.bpfMasqAddrs("test", &localNodeConfig)
+	masq4, masq6 := bpfMasqAddrs("test", &localNodeConfig)
 	require.Equal(t, masq4.IsValid(), false)
 	require.Equal(t, masq6.IsValid(), false)
 
@@ -246,11 +244,11 @@ func TestBPFMasqAddrs(t *testing.T) {
 		},
 	}
 
-	masq4, masq6 = l.bpfMasqAddrs("test", &newConfig)
+	masq4, masq6 = bpfMasqAddrs("test", &newConfig)
 	require.Equal(t, masq4.String(), "1.0.0.1")
 	require.Equal(t, masq6.String(), "1000::1")
 
-	masq4, masq6 = l.bpfMasqAddrs("unknown", &newConfig)
+	masq4, masq6 = bpfMasqAddrs("unknown", &newConfig)
 	require.Equal(t, masq4.String(), "2.0.0.2")
 	require.Equal(t, masq6.String(), "2000::2")
 }

--- a/pkg/datapath/loader/util_test.go
+++ b/pkg/datapath/loader/util_test.go
@@ -58,7 +58,6 @@ func newTestLoader(tb testing.TB) *loader {
 	setupCompilationDirectories(tb)
 
 	l := newLoader(Params{
-		Config: DefaultConfig,
 		Sysctl: sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc"),
 	})
 	cw := configWriterForTest(tb)

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -59,7 +59,7 @@ func xdpAttachedModeToFlag(mode uint32) link.XDPAttachFlags {
 //
 // bpffsBase is typically set to /sys/fs/bpf/cilium, but can be a temp directory
 // during tests.
-func (l *loader) maybeUnloadObsoleteXDPPrograms(xdpDevs []string, xdpMode xdp.Mode, bpffsBase string) {
+func maybeUnloadObsoleteXDPPrograms(xdpDevs []string, xdpMode xdp.Mode, bpffsBase string) {
 	links, err := netlink.LinkList()
 	if err != nil {
 		log.WithError(err).Warn("Failed to list links for XDP unload")
@@ -87,7 +87,7 @@ func (l *loader) maybeUnloadObsoleteXDPPrograms(xdpDevs []string, xdpMode xdp.Mo
 			}
 		}
 		if !used {
-			if err := l.DetachXDP(link.Attrs().Name, bpffsBase, symbolFromHostNetdevXDP); err != nil {
+			if err := DetachXDP(link.Attrs().Name, bpffsBase, symbolFromHostNetdevXDP); err != nil {
 				log.WithError(err).Warn("Failed to detach obsolete XDP program")
 			}
 		}
@@ -284,7 +284,7 @@ func attachXDPProgram(iface netlink.Link, prog *ebpf.Program, progName, bpffsDir
 //
 // bpffsBase is typically /sys/fs/bpf/cilium, but can be overridden to a tempdir
 // during tests.
-func (l *loader) DetachXDP(ifaceName string, bpffsBase, progName string) error {
+func DetachXDP(ifaceName string, bpffsBase, progName string) error {
 	iface, err := netlink.LinkByName(ifaceName)
 	if err != nil {
 		return fmt.Errorf("getting link '%s' by name: %w", ifaceName, err)

--- a/pkg/datapath/loader/xdp_test.go
+++ b/pkg/datapath/loader/xdp_test.go
@@ -55,7 +55,7 @@ func TestMaybeUnloadObsoleteXDPPrograms(t *testing.T) {
 		err = attachXDPProgram(veth1, prog, symbolFromHostNetdevXDP, veth1LinkPath, link.XDPDriverMode)
 		require.NoError(t, err)
 
-		newTestLoader(t).maybeUnloadObsoleteXDPPrograms(
+		maybeUnloadObsoleteXDPPrograms(
 			[]string{"veth0"}, option.XDPModeLinkDriver, basePath,
 		)
 
@@ -183,7 +183,7 @@ func TestAttachXDPWithExistingLink(t *testing.T) {
 		require.NoError(t, err)
 
 		// Detach the program.
-		err = newTestLoader(t).DetachXDP(veth.Attrs().Name, basePath, "test")
+		err = DetachXDP(veth.Attrs().Name, basePath, "test")
 		require.NoError(t, err)
 
 		err = netlink.LinkDel(veth)
@@ -214,11 +214,11 @@ func TestDetachXDPWithPreviousAttach(t *testing.T) {
 		require.True(t, getLink(t, veth).Attrs().Xdp.Attached)
 
 		// Detach with the wrong name, leaving the program attached.
-		err = newTestLoader(t).DetachXDP(veth.Attrs().Name, basePath, "foo")
+		err = DetachXDP(veth.Attrs().Name, basePath, "foo")
 		require.NoError(t, err)
 		require.True(t, getLink(t, veth).Attrs().Xdp.Attached)
 
-		err = newTestLoader(t).DetachXDP(veth.Attrs().Name, basePath, "test")
+		err = DetachXDP(veth.Attrs().Name, basePath, "test")
 		require.NoError(t, err)
 		require.False(t, getLink(t, veth).Attrs().Xdp.Attached)
 

--- a/pkg/datapath/orchestrator/cells.go
+++ b/pkg/datapath/orchestrator/cells.go
@@ -13,6 +13,7 @@ var Cell = cell.Module(
 	"orchestrator",
 	"Orchestrator",
 
+	cell.Config(DefaultConfig),
 	cell.Provide(NewOrchestrator),
 )
 

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -41,6 +41,7 @@ func newLocalNodeConfig(
 	directRoutingDevTbl tables.DirectRoutingDevice,
 	devices statedb.Table[*tables.Device],
 	nodeAddresses statedb.Table[tables.NodeAddress],
+	masqInterface string,
 	xdpConfig xdp.Config,
 ) (datapath.LocalNodeConfiguration, <-chan struct{}, <-chan struct{}, <-chan struct{}, error) {
 	auxPrefixes := []*cidr.CIDR{}
@@ -78,6 +79,7 @@ func newLocalNodeConfig(
 		Devices:                      nativeDevices,
 		NodeAddresses:                statedb.Collect(nodeAddrsIter),
 		DirectRoutingDevice:          directRoutingDevice,
+		DeriveMasqIPAddrFromDevice:   masqInterface,
 		HostEndpointID:               node.GetEndpointID(),
 		DeviceMTU:                    mtu.GetDeviceMTU(),
 		RouteMTU:                     mtu.GetRouteMTU(),

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -25,7 +25,6 @@ type Loader interface {
 	EndpointHash(cfg EndpointConfiguration, lnCfg *LocalNodeConfiguration) (string, error)
 	ReinitializeHostDev(ctx context.Context, mtu int) error
 	Reinitialize(ctx context.Context, cfg *LocalNodeConfiguration, tunnelConfig tunnel.Config, iptMgr IptablesManager, p Proxy) error
-	DetachXDP(iface string, bpffsBase, progName string) error
 	WriteEndpointConfig(w io.Writer, cfg EndpointConfiguration, lnCfg *LocalNodeConfiguration) error
 }
 

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -74,6 +74,10 @@ type LocalNodeConfiguration struct {
 	// Mutable at runtime.
 	NodeAddresses []tables.NodeAddress
 
+	// DeriveMasqIPAddrFromDevice overrides the interface name to use for deriving
+	// the masquerading IP address for the node.
+	DeriveMasqIPAddrFromDevice string
+
 	// HostEndpointID is the endpoint ID assigned to the host endpoint.
 	// Immutable at runtime.
 	HostEndpointID uint64

--- a/pkg/datapath/types/zz_generated.deepequal.go
+++ b/pkg/datapath/types/zz_generated.deepequal.go
@@ -158,6 +158,9 @@ func (in *LocalNodeConfiguration) DeepEqual(other *LocalNodeConfiguration) bool 
 		}
 	}
 
+	if in.DeriveMasqIPAddrFromDevice != other.DeriveMasqIPAddrFromDevice {
+		return false
+	}
 	if in.HostEndpointID != other.HostEndpointID {
 		return false
 	}


### PR DESCRIPTION
```
loader: move DeriveMasqIPAddrFromInterface to datapath orchestrator config

This removes yet another way of passing in configuration to the loader and
sets it up so all unexported members of *loader can be made free functions
in a follow-up commit.
```

```
loader: reduce (*loader) state and API footprint

This commit removes *loader as the receiver of a list of unexported methods.
These should be made free functions instead, making their behaviours easier
to refactor and relocate into other packages.
```