### PR TITLE
datapath: remove migrated datapathParams members

### DIFF
--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -230,10 +230,6 @@ type datapathParams struct {
 
 	ConfigWriter types.ConfigWriter
 
-	TunnelConfig tunnel.Config
-
-	Loader types.Loader
-
 	NodeManager nodeManager.NodeManager
 
 	Orchestrator types.Orchestrator


### PR DESCRIPTION
`TunnelConfig` is no longer needed since commit 579445b6b29b ("Orchestrator: Get values from hive instead of arguments").

`Loader` is no longer needed since commit 198ae3ac77cb ("Separate loader from Datapath interface").