### PR TITLE
datapath: Provide IptablesManager instead of *Manager

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
-	"github.com/cilium/cilium/pkg/datapath/iptables"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
@@ -1715,7 +1714,7 @@ type daemonParams struct {
 	CRDSyncPromise      promise.Promise[k8sSynced.CRDSync]
 	IdentityManager     *identitymanager.IdentityManager
 	Orchestrator        datapath.Orchestrator
-	IPTablesManager     *iptables.Manager
+	IPTablesManager     datapath.IptablesManager
 }
 
 func newDaemonPromise(params daemonParams) (promise.Promise[*Daemon], promise.Promise[policyK8s.PolicyManager]) {

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
-	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
@@ -57,7 +56,7 @@ var Cell = cell.Module(
 		func() authmap.Map { return fakeauthmap.NewFakeAuthMap() },
 		func() egressmap.PolicyMap { return nil },
 		func() *bigtcp.Configuration { return &bigtcp.Configuration{} },
-		func() *iptables.Manager { return &iptables.Manager{} },
+		func() types.IptablesManager { return &fakeTypes.FakeIptablesManager{} },
 		func() ipset.Manager { return &fakeTypes.IPSet{} },
 		func() types.BandwidthManager { return &fakeTypes.BandwidthManager{} },
 		func() types.IPsecKeyCustodian { return &ipsecKeyCustodian{} },

--- a/pkg/datapath/fake/types/iptables_manager.go
+++ b/pkg/datapath/fake/types/iptables_manager.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"net/netip"
+
+	datapath "github.com/cilium/cilium/pkg/datapath/types"
+)
+
+var _ datapath.IptablesManager = (*FakeIptablesManager)(nil)
+
+type FakeIptablesManager struct {
+}
+
+// NewIptablesManager returns a new fake IptablesManager
+func NewIptablesManager() *FakeIptablesManager {
+	return &FakeIptablesManager{}
+}
+
+func (f *FakeIptablesManager) InstallProxyRules(uint16, string) {
+}
+
+func (f *FakeIptablesManager) SupportsOriginalSourceAddr() bool {
+	return false
+}
+
+func (m *FakeIptablesManager) GetProxyPorts() map[string]uint16 {
+	return nil
+}
+
+func (m *FakeIptablesManager) InstallNoTrackRules(ip netip.Addr, port uint16) {
+}
+
+func (m *FakeIptablesManager) RemoveNoTrackRules(ip netip.Addr, port uint16) {
+}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/fqdn/proxy/ipfamily"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -291,7 +292,7 @@ type params struct {
 	Devices  statedb.Table[*tables.Device]
 }
 
-func newIptablesManager(p params) *Manager {
+func newIptablesManager(p params) datapath.IptablesManager {
 	iptMgr := &Manager{
 		logger:     p.Logger,
 		modulesMgr: p.ModulesMgr,

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -46,6 +46,19 @@ type Proxy interface {
 
 // IptablesManager manages iptables rules.
 type IptablesManager interface {
+	// InstallProxyRules creates the necessary datapath config (e.g., iptables
+	// rules for redirecting host proxy traffic on a specific ProxyPort)
+	InstallProxyRules(proxyPort uint16, name string)
+
+	// SupportsOriginalSourceAddr tells if the datapath supports
+	// use of original source addresses in proxy upstream
+	// connections.
+	SupportsOriginalSourceAddr() bool
+
+	// GetProxyPorts fetches the existing proxy ports configured in the
+	// datapath. Used early in bootstrap to reopen proxy ports.
+	GetProxyPorts() map[string]uint16
+
 	// InstallNoTrackRules is explicitly called when a pod has valid
 	// "policy.cilium.io/no-track-port" annotation.  When
 	// InstallNoConntrackIptRules flag is set, a super set of v4 NOTRACK

--- a/pkg/proxy/cell.go
+++ b/pkg/proxy/cell.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/spf13/pflag"
 
-	"github.com/cilium/cilium/pkg/datapath/iptables"
+	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/envoy"
 	monitoragent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/option"
@@ -46,7 +46,7 @@ type proxyParams struct {
 
 	Lifecycle             cell.Lifecycle
 	Config                ProxyConfig
-	IPTablesManager       *iptables.Manager
+	IPTablesManager       datapath.IptablesManager
 	EndpointInfoRegistry  logger.EndpointInfoRegistry
 	MonitorAgent          monitoragent.Agent
 	EnvoyProxyIntegration *envoyProxyIntegration
@@ -90,7 +90,7 @@ func newProxy(params proxyParams) *Proxy {
 type envoyProxyIntegrationParams struct {
 	cell.In
 
-	IPTablesManager *iptables.Manager
+	IptablesManager datapath.IptablesManager
 	XdsServer       envoy.XDSServer
 	AdminClient     *envoy.EnvoyAdminClient
 }
@@ -102,7 +102,7 @@ func newEnvoyProxyIntegration(params envoyProxyIntegrationParams) *envoyProxyInt
 
 	return &envoyProxyIntegration{
 		xdsServer:       params.XdsServer,
-		iptablesManager: params.IPTablesManager,
+		iptablesManager: params.IptablesManager,
 		adminClient:     params.AdminClient,
 	}
 }

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/completion"
-	"github.com/cilium/cilium/pkg/datapath/iptables"
+	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
@@ -28,7 +28,7 @@ type envoyRedirect struct {
 type envoyProxyIntegration struct {
 	adminClient     *envoy.EnvoyAdminClient
 	xdsServer       envoy.XDSServer
-	iptablesManager *iptables.Manager
+	iptablesManager datapath.IptablesManager
 }
 
 // createRedirect creates a redirect with corresponding proxy configuration. This will launch a proxy instance.


### PR DESCRIPTION
Provide the `datapath/types.IptablesManager` instead of `iptables.*Manager`, so that it can be replaced with the fake for testing.
