### PR TITLE
fqdn: Wait for onging updates before releasing response

### DIFF
--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -38,5 +38,6 @@ type EndpointDNSInfo struct {
 type IPCache interface {
 	UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64)
 	RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64)
+	GetPendingRevision() (revision uint64)
 	WaitForRevision(ctx context.Context, rev uint64) error
 }

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -274,6 +274,13 @@ func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Tim
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
+		if ipcacheRevision == 0 {
+			log.WithFields(logrus.Fields{
+				"updatedDNSNames": updatedDNSNames,
+				"ipcacheRevision": ipcacheRevision,
+			}).Warn("FQDN: WaitForRevision ZERO")
+		}
+
 		return n.config.IPCache.WaitForRevision(ctx, ipcacheRevision)
 	})
 	return g
@@ -322,6 +329,12 @@ func (n *NameManager) updateDNSIPs(lookupTime time.Time, updatedDNSIPs map[strin
 		updated := n.updateIPsForName(lookupTime, dnsName, lookupIPs.IPs, lookupIPs.TTL)
 
 		// The IPs didn't change. No more to be done for this dnsName
+		//
+		// NOTE: This can happen due to RegisterFQDNSelector() already having updated the
+		// cached IPs. In this case 'updatedMetadata' can remain empty, leading to
+		// updateMetadata() returning a ZERO ipcacheRevision to wait for, even though the
+		// actual update may still be in progress. In this case we'll release the DNS
+		// response back to the source pod too soon!
 		if !updated && n.bootstrapCompleted {
 			log.WithFields(logrus.Fields{
 				"dnsName":   dnsName,
@@ -348,6 +361,10 @@ func (n *NameManager) updateDNSIPs(lookupTime time.Time, updatedDNSIPs map[strin
 			// If no selectors care about this name, then skip IPCache updates
 			// for this name.
 			// If any selectors/ are added later, ipcache insertion will happen then.
+			log.WithFields(logrus.Fields{
+				"dnsName":   dnsName,
+				"lookupIPs": lookupIPs,
+			}).Debug("FQDN: No selectors care about this name")
 			continue
 		}
 
@@ -399,6 +416,7 @@ func ipcacheResource(dnsName string) ipcacheTypes.ResourceID {
 
 // updateMetadata updates (i.e. upserts or removes) the metadata in IPCache for
 // each (name, IP) pair provided in nameToMetadata.
+// Returns ipcache revision number to wait for to have the updates applied.
 func (n *NameManager) updateMetadata(nameToMetadata map[string]nameMetadata) (ipcacheRevision uint64) {
 	var ipcacheUpserts, ipcacheRemovals []ipcache.MU
 
@@ -411,7 +429,7 @@ func (n *NameManager) updateMetadata(nameToMetadata map[string]nameMetadata) (ip
 				"name":     dnsName,
 				"prefixes": metadata.addrs,
 				"labels":   metadata.labels,
-			}).Debug("Updating prefix labels in IPCache")
+			}).Debug("FQDN: Updating prefix labels in IPCache")
 		}
 
 		for _, addr := range metadata.addrs {
@@ -439,6 +457,13 @@ func (n *NameManager) updateMetadata(nameToMetadata map[string]nameMetadata) (ip
 	}
 	if len(ipcacheRemovals) > 0 {
 		ipcacheRevision = n.config.IPCache.RemoveMetadataBatch(ipcacheRemovals...)
+	}
+	// Since the same updates may originate from multiple callers concurrently, only the first
+	// caller gets to actually make the updates, while both of them may depend on the changes to
+	// have applied before thay can continue. If there are no upserts or removals return the
+	// revision of the latest pending revision instead of zero.
+	if ipcacheRevision == 0 {
+		ipcacheRevision = n.config.IPCache.GetPendingRevision()
 	}
 
 	return ipcacheRevision

--- a/pkg/fqdn/name_manager_test.go
+++ b/pkg/fqdn/name_manager_test.go
@@ -74,6 +74,10 @@ func (m *mockIPCache) RemoveMetadataBatch(updates ...ipcache.MU) (revision uint6
 	return 0
 }
 
+func (m *mockIPCache) GetPendingRevision() (revision uint64) {
+	return 0
+}
+
 func (m *mockIPCache) WaitForRevision(ctx context.Context, rev uint64) error {
 	return nil
 }

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -595,6 +595,10 @@ func (ipc *IPCache) RemoveIdentityOverride(cidr netip.Prefix, identityLabels lab
 	ipc.RemoveMetadata(cidr, resource, overrideIdentity(true), identityLabels)
 }
 
+func (ipc *IPCache) GetPendingRevision() (revision uint64) {
+	return ipc.metadata.getPendingRevision()
+}
+
 // WaitForRevision will block until the desired revision has been reached (or passed).
 // It can be used in concert with the revision number returned by Upsert* calls to
 // ensure that an update has been applied.

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -133,6 +133,21 @@ func (m *metadata) dequeuePrefixUpdates() (modifiedPrefixes []netip.Prefix, revi
 	return
 }
 
+// getPendingRevision returns the most recent queue revision number to wait for when there are no
+// new changes to enqueue. Caller should wait for the returned version to have been applied whenever
+// there may have been concurrent updates that may be significant to the caller.
+func (m *metadata) getPendingRevision() uint64 {
+	m.queuedChangesMU.Lock()
+	defer m.queuedChangesMU.Unlock()
+
+	if len(m.queuedPrefixes) == 0 {
+		// The queue is empty, so the previous revision is the currently pending one.
+		return m.queuedRevision - 1
+	}
+	// There are queued prefixes, return the revision for them
+	return m.queuedRevision
+}
+
 // enqueuePrefixUpdates queues prefixes for label injection. It returns the "next"
 // queue revision number, which can be passed to waitForRevision.
 func (m *metadata) enqueuePrefixUpdates(prefixes ...netip.Prefix) uint64 {
@@ -142,12 +157,22 @@ func (m *metadata) enqueuePrefixUpdates(prefixes ...netip.Prefix) uint64 {
 	for _, prefix := range prefixes {
 		m.queuedPrefixes[prefix] = struct{}{}
 	}
+
+	if len(m.queuedPrefixes) == 0 {
+		// The queue is empty, but must wait for the previous revision.
+		// The prefixes the caller depends on might have been enqueued previously instead.
+		return m.queuedRevision - 1
+	}
 	return m.queuedRevision
 }
 
 // setInjectectRevision updates the injected revision to a new value and
 // wakes all waiters.
 func (m *metadata) setInjectedRevision(rev uint64) {
+	log.WithFields(logrus.Fields{
+		"ipcacheRevision": rev,
+	}).Debug("setInjectedRevision")
+
 	m.injectedRevisionCond.L.Lock()
 	m.injectedRevision = rev
 	m.injectedRevisionCond.Broadcast()
@@ -170,14 +195,25 @@ func (m *metadata) waitForRevision(ctx context.Context, rev uint64) error {
 	})
 	defer cleanupCancellation()
 
+	log.WithFields(logrus.Fields{
+		"ipcacheRevision": rev,
+	}).Debug("waitForRevision...")
+
 	m.injectedRevisionCond.L.Lock()
 	defer m.injectedRevisionCond.L.Unlock()
 	for m.injectedRevision < rev {
 		m.injectedRevisionCond.Wait()
 		if ctx.Err() != nil {
+			log.WithError(ctx.Err()).WithFields(logrus.Fields{
+				"ipcacheRevision": rev,
+			}).Debug("waitForRevision aborted")
 			return ctx.Err()
 		}
 	}
+
+	log.WithFields(logrus.Fields{
+		"ipcacheRevision": rev,
+	}).Debug("waitForRevision DONE")
 
 	return nil
 }
@@ -464,6 +500,8 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 	// Recalculate policy first before upserting into the ipcache.
 	if len(idsToAdd) > 0 {
 		ipc.UpdatePolicyMaps(ctx, idsToAdd, nil)
+	} else {
+		log.Debugf("no idsToAdd, skipping UpdatePolicyMaps")
 	}
 
 	ipc.mutex.Lock()
@@ -560,11 +598,16 @@ func (ipc *IPCache) UpdatePolicyMaps(ctx context.Context, addedIdentities, delet
 		ipc.PolicyHandler.UpdateIdentities(nil, deletedIdentities, &wg)
 	}
 	if len(addedIdentities) != 0 {
+		log.Debugf("Calling UpdateIdentities with %v", addedIdentities)
 		ipc.PolicyHandler.UpdateIdentities(addedIdentities, nil, &wg)
 	}
 
+	log.Debug("Calling UpdatePolicyMaps...")
 	policyImplementedWG := ipc.DatapathHandler.UpdatePolicyMaps(ctx, &wg)
+	log.Debug("Waiting for UpdatePolicyMaps to complete...")
+
 	policyImplementedWG.Wait()
+	log.Debug("UpdatePolicyMaps DONE")
 }
 
 // resolveIdentity will either return a previously-allocated identity for the

--- a/pkg/testutils/ipcache/ipcache.go
+++ b/pkg/testutils/ipcache/ipcache.go
@@ -67,6 +67,10 @@ func (m *MockIPCache) RemoveMetadataBatch(updates ...ipcache.MU) (revision uint6
 	return 0
 }
 
+func (m *MockIPCache) GetPendingRevision() (revision uint64) {
+	return 0
+}
+
 func (m *MockIPCache) WaitForRevision(ctx context.Context, rev uint64) error {
 	return nil
 }


### PR DESCRIPTION
Ipcache may be seemingly up-to-date, but the operations to that effect may still be ongoing. If that is the case, wait for the current ipcache revision instead of the revision 0.

```release-note
Fixed a bug where DNS proxy may have returned the DNS response too early due to a race with ipcache.
```
