### PR TITLE
endpoint: Do not pass a function to WithFields

### DIFF
--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -179,7 +179,7 @@ func (e *Endpoint) updatePolicyLogger(fields map[string]interface{}) {
 		}
 
 		if e.SecurityIdentity != nil {
-			f[logfields.Identity] = e.SecurityIdentity.ID.StringID
+			f[logfields.Identity] = e.SecurityIdentity.ID
 		}
 
 		policyLogger = policyLogger.WithFields(f)


### PR DESCRIPTION
Logrus can not turn a function or a function pointer to a string, and will emit an error in the logs instead, like this:

time="2024-08-08T18:38:31Z" level=debug msg=applyPolicyMapChanges logrus_error="can not add field \"identity\", can not add field \"identity\", can not add field \"identity\"" containerID=2ba0422d7b datapathPolicyRevision=12 desiredPolicyRevision=13 endpointID=3752 identity=37644 ipv4=10.244.0.174 ipv6="fd00:10:244::510d" k8sPodName=cilium-test-1/client3-7f986c467b-vjm5w subsys=endpoint

In this case the error is seen three times due to logrus accumulating them even if they originate from the same "field".

Pass the number instead of the function to fix this.
