### PR TITLE
policy: Reduce logging

### DIFF
--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -33,7 +33,6 @@ import (
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -641,9 +640,6 @@ func TestL3DependentL7Etcd(t *testing.T) {
 }
 
 func (ds *DaemonSuite) testL3DependentL7(t *testing.T) {
-	logging.SetLogLevelToDebug()
-	defer logging.SetDefaultLogLevel()
-
 	// Prepare the identities necessary for testing
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := ds.d.identityAllocator.AllocateIdentity(context.Background(), qaBarLbls, true, identity.InvalidIdentity)

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -851,7 +851,6 @@ func TestMergeTLSTCPPolicy(t *testing.T) {
 	l4Filter := res.ExactLookup("443", 0, "TCP")
 	require.NotNil(t, l4Filter)
 	require.Equal(t, ParserTypeTLS, l4Filter.L7Parser)
-	log.Infof("res: %v", res)
 }
 
 func TestMergeTLSHTTPPolicy(t *testing.T) {
@@ -946,7 +945,6 @@ func TestMergeTLSHTTPPolicy(t *testing.T) {
 	l4Filter := res.ExactLookup("443", 0, "TCP")
 	require.NotNil(t, l4Filter)
 	require.Equal(t, ParserTypeHTTP, l4Filter.L7Parser)
-	log.Infof("res: %v", res)
 }
 
 func TestMergeTLSSNIPolicy(t *testing.T) {
@@ -1060,7 +1058,6 @@ func TestMergeTLSSNIPolicy(t *testing.T) {
 	l4Filter := res.ExactLookup("443", 0, "TCP")
 	require.NotNil(t, l4Filter)
 	require.Equal(t, ParserTypeHTTP, l4Filter.L7Parser)
-	log.Infof("res: %v", res)
 }
 
 func TestMergeListenerPolicy(t *testing.T) {
@@ -1196,7 +1193,6 @@ func TestMergeListenerPolicy(t *testing.T) {
 	l4Filter := res.ExactLookup("443", 0, "TCP")
 	require.NotNil(t, l4Filter)
 	require.Equal(t, ParserTypeCRD, l4Filter.L7Parser)
-	log.Infof("res: %v", res)
 
 	//
 	// namespace in policyContext (Namespaced policy): Can refer to EnvoyConfig
@@ -1278,7 +1274,6 @@ func TestMergeListenerPolicy(t *testing.T) {
 	l4Filter = res.ExactLookup("443", 0, "TCP")
 	require.NotNil(t, l4Filter)
 	require.Equal(t, ParserTypeCRD, l4Filter.L7Parser)
-	log.Infof("res: %v", res)
 
 	//
 	// namespace in policyContext (Namespaced policy): Can refer to Cluster-socoped
@@ -1361,7 +1356,6 @@ func TestMergeListenerPolicy(t *testing.T) {
 	l4Filter = res.ExactLookup("443", 0, "TCP")
 	require.NotNil(t, l4Filter)
 	require.Equal(t, ParserTypeCRD, l4Filter.L7Parser)
-	log.Infof("res: %v", res)
 }
 
 // Case 6: allow all at L3/L7 in one rule, and select an endpoint and allow all on L7

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -12,10 +12,12 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -215,6 +217,11 @@ func TestCreateL4FilterAuthRequired(t *testing.T) {
 }
 
 func TestCreateL4FilterMissingSecret(t *testing.T) {
+	// Suppress the expected warning logs for this test
+	oldLevel := logging.DefaultLogger.GetLevel()
+	logging.DefaultLogger.SetLevel(logrus.ErrorLevel)
+	defer logging.DefaultLogger.SetLevel(oldLevel)
+
 	td := newTestData()
 	tuple := api.PortProtocol{Port: "80", Protocol: api.ProtoTCP}
 	portrule := &api.PortRule{

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -834,13 +834,13 @@ func (p *Repository) computePolicyEnforcementAndRules(securityIdentity *identity
 
 	// If there only ingress default-allow rules, then insert a wildcard rule
 	if !hasIngressDefaultDeny && ingress {
-		log.WithField(logfields.Identity, securityIdentity).Info("Only default-allow policies, synthesizing ingress wildcard-allow rule")
+		log.WithField(logfields.Identity, securityIdentity).Debug("Only default-allow policies, synthesizing ingress wildcard-allow rule")
 		matchingRules = append(matchingRules, wildcardRule(securityIdentity.LabelArray, true /*ingress*/))
 	}
 
 	// Same for egress -- synthesize a wildcard rule
 	if !hasEgressDefaultDeny && egress {
-		log.WithField(logfields.Identity, securityIdentity).Info("Only default-allow policies, synthesizing egress wildcard-allow rule")
+		log.WithField(logfields.Identity, securityIdentity).Debug("Only default-allow policies, synthesizing egress wildcard-allow rule")
 		matchingRules = append(matchingRules, wildcardRule(securityIdentity.LabelArray, false /*egress*/))
 	}
 


### PR DESCRIPTION
Change non-informative info-level logs to debug level, suppress expected warning logs. Remove debug logs from tests to make the output more readable.
