### PR TITLE
dynamicconfig: Add dynamic config cell module

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -453,6 +453,7 @@ Makefile* @cilium/build
 /pkg/defaults @cilium/sig-agent
 /pkg/debug @cilium/sig-agent
 /pkg/dial @cilium/sig-agent
+/pkg/dynamicconfig @cilium/sig-foundations
 /pkg/ebpf @cilium/sig-datapath
 /pkg/egressgateway/ @cilium/egress-gateway
 /pkg/endpoint/ @cilium/endpoint

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -95,6 +95,7 @@ cilium-agent [flags]
       --dnsproxy-concurrency-processing-grace-period duration     Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing
       --dnsproxy-enable-transparent-mode                          Enable DNS proxy transparent mode
       --dnsproxy-socket-linger-timeout int                        Timeout (in seconds) when closing the connection between the DNS proxy and the upstream server. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background (default 10)
+      --dynamic-config-map-name string                            Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
       --egress-masquerade-interfaces strings                      Limit iptables-based egress masquerading to interface selector

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -112,6 +112,7 @@ cilium-agent [flags]
       --enable-cilium-endpoint-slice                              Enable the CiliumEndpointSlice watcher in place of the CiliumEndpoint watcher (beta)
       --enable-cilium-health-api-server-access strings            List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-custom-calls                                       Enable tail call hooks for custom eBPF programs
+      --enable-dynamic-config                                     Enables support for dynamic agent config
       --enable-encryption-strict-mode                             Enable encryption strict mode
       --enable-endpoint-health-checking                           Enable connectivity health checking between virtual endpoints (default true)
       --enable-endpoint-routes                                    Use per endpoint routes instead of routing via cilium_host

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -37,6 +37,7 @@ cilium-agent hive [flags]
       --enable-bbr                                                Enable BBR for the bandwidth manager
       --enable-cilium-api-server-access strings                   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cilium-health-api-server-access strings            List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-dynamic-config                                     Enables support for dynamic agent config
       --enable-gateway-api                                        Enables Envoy secret sync for Gateway API related TLS secrets
       --enable-ingress-controller                                 Enables Envoy secret sync for Ingress controller related TLS secrets
       --enable-ipv4-big-tcp                                       Enable IPv4 BIG TCP option which increases device's maximum GRO/GSO limits for IPv4

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -29,6 +29,7 @@ cilium-agent hive [flags]
       --direct-routing-device string                              Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
       --disable-envoy-version-check                               Do not perform Envoy version check
       --disable-iptables-feeder-rules strings                     Chains to ignore when installing feeder rules.
+      --dynamic-config-map-name string                            Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
       --enable-active-connection-tracking                         Count open and active connections to services, grouped by zones defined in fixed-zone-mapping.

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -43,6 +43,7 @@ cilium-agent hive dot-graph [flags]
       --enable-bbr                                                Enable BBR for the bandwidth manager
       --enable-cilium-api-server-access strings                   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cilium-health-api-server-access strings            List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-dynamic-config                                     Enables support for dynamic agent config
       --enable-gateway-api                                        Enables Envoy secret sync for Gateway API related TLS secrets
       --enable-ingress-controller                                 Enables Envoy secret sync for Ingress controller related TLS secrets
       --enable-ipv4-big-tcp                                       Enable IPv4 BIG TCP option which increases device's maximum GRO/GSO limits for IPv4

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -35,6 +35,7 @@ cilium-agent hive dot-graph [flags]
       --direct-routing-device string                              Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
       --disable-envoy-version-check                               Do not perform Envoy version check
       --disable-iptables-feeder-rules strings                     Chains to ignore when installing feeder rules.
+      --dynamic-config-map-name string                            Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
       --enable-active-connection-tracking                         Count open and active connections to services, grouped by zones defined in fixed-zone-mapping.

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -39,6 +39,7 @@ cilium-operator-alibabacloud [flags]
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
   -D, --debug                                                Enable debugging mode
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --dynamic-config-map-name string                       Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -25,6 +25,7 @@ cilium-operator-alibabacloud hive [flags]
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --dynamic-config-map-name string                       Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -31,6 +31,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --dynamic-config-map-name string                       Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -42,6 +42,7 @@ cilium-operator-aws [flags]
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
   -D, --debug                                                Enable debugging mode
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --dynamic-config-map-name string                       Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --ec2-api-endpoint string                              AWS API endpoint for the EC2 service
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -25,6 +25,7 @@ cilium-operator-aws hive [flags]
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --dynamic-config-map-name string                       Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -31,6 +31,7 @@ cilium-operator-aws hive dot-graph [flags]
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --dynamic-config-map-name string                       Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -42,6 +42,7 @@ cilium-operator-azure [flags]
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
   -D, --debug                                                Enable debugging mode
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --dynamic-config-map-name string                       Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -25,6 +25,7 @@ cilium-operator-azure hive [flags]
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --dynamic-config-map-name string                       Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -31,6 +31,7 @@ cilium-operator-azure hive dot-graph [flags]
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --dynamic-config-map-name string                       Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -38,6 +38,7 @@ cilium-operator-generic [flags]
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
   -D, --debug                                                Enable debugging mode
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --dynamic-config-map-name string                       Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -25,6 +25,7 @@ cilium-operator-generic hive [flags]
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --dynamic-config-map-name string                       Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -31,6 +31,7 @@ cilium-operator-generic hive dot-graph [flags]
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --dynamic-config-map-name string                       Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -47,6 +47,7 @@ cilium-operator [flags]
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
   -D, --debug                                                Enable debugging mode
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --dynamic-config-map-name string                       Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --ec2-api-endpoint string                              AWS API endpoint for the EC2 service
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -25,6 +25,7 @@ cilium-operator hive [flags]
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --dynamic-config-map-name string                       Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -31,6 +31,7 @@ cilium-operator hive dot-graph [flags]
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --dynamic-config-map-name string                       Specifies the name of the ConfigMap to be used for dynamic configuration (default "cilium-config")
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/dial"
+	"github.com/cilium/cilium/pkg/dynamicconfig"
 	"github.com/cilium/cilium/pkg/egressgateway"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointcleanup"
@@ -274,6 +275,9 @@ var (
 
 		// Provide pcap recorder
 		recorder.Cell,
+
+		// Provides a wrapper of the cilium config that can be watched dynamically
+		dynamicconfig.Cell,
 	)
 )
 

--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -82,6 +82,14 @@ var (
 					},
 				)
 			},
+			func(lc cell.Lifecycle, cs client.Clientset, c k8s.Config) (DynamicConfigMapResource, error) {
+				return k8s.ConfigMapResource(
+					lc, cs,
+					func(opts *metav1.ListOptions) {
+						opts.FieldSelector = fields.ParseSelectorOrDie("metadata.name=" + c.DynamicConfigMapName).String()
+					},
+				)
+			},
 		),
 	)
 
@@ -149,6 +157,10 @@ type ServiceNonHeadless resource.Resource[*slim_corev1.Service]
 // EndpointsNonHeadless is a resource.Resource[*slim_corev1.Service] but one which will only stream updates for
 // Endpoints from non headless Services.
 type EndpointsNonHeadless resource.Resource[*k8s.Endpoints]
+
+// DynamicConfigMapResource is a resource.Resource[*v1.ConfigMap] but one which will only stream updates for
+// the ConfigMap configured in k8s.Config.DynamicConfigMapName.
+type DynamicConfigMapResource resource.Resource[*v1.ConfigMap]
 
 // Resources is a convenience struct to group all the agent k8s resources as cell constructor parameters.
 type Resources struct {

--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -37,6 +37,7 @@ rules:
   - pods
   - endpoints
   - nodes
+  - configmaps
   verbs:
   - get
   - list

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -37,6 +37,7 @@ rules:
   - pods
   - endpoints
   - nodes
+  - configmaps
   verbs:
   - get
   - list

--- a/pkg/dynamicconfig/cell.go
+++ b/pkg/dynamicconfig/cell.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dynamicconfig
+
+import (
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
+	"github.com/spf13/pflag"
+)
+
+var Cell = cell.Module(
+	"cilium-agent-dynamic-config",
+	"Cilium Agent dynamic config map controller",
+
+	cell.ProvidePrivate(NewConfigTable),
+	cell.Provide(
+		statedb.RWTable[*ConfigEntry].ToTable,
+		ProvideConfigTableGetter,
+	),
+	cell.Invoke(
+		statedb.RegisterTable[*ConfigEntry],
+		registerController,
+	),
+	cell.Config(defaultConfig),
+)
+
+var defaultConfig = config{
+	EnableDynamicConfig: false,
+}
+
+type config struct {
+	EnableDynamicConfig bool
+}
+
+func (c config) Flags(flags *pflag.FlagSet) {
+	flags.Bool("enable-dynamic-config", c.EnableDynamicConfig, "Enables support for dynamic agent config")
+}

--- a/pkg/dynamicconfig/controller.go
+++ b/pkg/dynamicconfig/controller.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dynamicconfig
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+)
+
+type controllerParams struct {
+	cell.In
+
+	Logger           *slog.Logger
+	JobGroup         job.Group
+	Config           config
+	StateDB          *statedb.DB
+	DynamicConfigMap k8s.DynamicConfigMapResource
+}
+
+type Controller struct {
+	logger *slog.Logger
+
+	jobGroup         job.Group
+	db               *statedb.DB
+	configTable      statedb.RWTable[*ConfigEntry]
+	dynamicConfigMap k8s.DynamicConfigMapResource
+}
+
+func registerController(table statedb.RWTable[*ConfigEntry], params controllerParams) {
+	if !params.Config.EnableDynamicConfig {
+		return
+	}
+
+	c := &Controller{
+		logger:           params.Logger,
+		jobGroup:         params.JobGroup,
+		db:               params.StateDB,
+		configTable:      table,
+		dynamicConfigMap: params.DynamicConfigMap,
+	}
+
+	c.jobGroup.Add(job.OneShot("cilium-config-cm-watcher", c.processConfigChanges))
+}
+
+func (c Controller) processConfigChanges(ctx context.Context, _ cell.Health) error {
+	for event := range c.dynamicConfigMap.Events(ctx) {
+		switch event.Kind {
+		case resource.Upsert:
+			c.computeChanges(event.Object)
+		}
+		event.Done(nil)
+	}
+	return nil
+}
+
+func (c Controller) computeChanges(newConfigMap *v1.ConfigMap) {
+	var entries []ConfigEntry
+	for k, v := range newConfigMap.Data {
+		entries = append(entries, NewConfigEntry(k, v))
+	}
+	c.upsertEntry(entries)
+}

--- a/pkg/dynamicconfig/controller_test.go
+++ b/pkg/dynamicconfig/controller_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dynamicconfig
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/health/types"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+var (
+	cmName    = "cilium-config"
+	namespace = "kube-system"
+)
+
+func TestComputeConfigMap(t *testing.T) {
+	dummyConfigMap := map[string]string{"key1": "value1", "key2": "value2"}
+
+	testCases := []struct {
+		name           string
+		cm             *v1.ConfigMap
+		expectedConfig map[string]string
+	}{
+		{
+			name:           "default",
+			cm:             buildConfigMap(dummyConfigMap),
+			expectedConfig: dummyConfigMap,
+		},
+		{
+			name:           "empty",
+			cm:             buildConfigMap(map[string]string{}),
+			expectedConfig: map[string]string{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, db, table, fakeClient, cmResource := fixture(t)
+			ctx := context.Background()
+
+			_, err := fakeClient.CoreV1().ConfigMaps(namespace).Create(ctx, tc.cm, metav1.CreateOptions{})
+			if err != nil {
+				t.Errorf("creating CofigMap: %v", err)
+			}
+
+			store, err := (*cmResource).Store(ctx)
+			if err != nil {
+				t.Errorf("init cmResource store: %v", err)
+			}
+
+			if err := testutils.WaitUntil(func() bool {
+				return len(store.List()) > 0
+			}, 2*time.Second); err != nil {
+				t.Errorf("waiting for configmap: %v", err)
+			}
+
+			var gotMap map[string]string
+			if err := testutils.WaitUntil(func() bool {
+				gotMap = iterToMap(table.All(db.ReadTxn()))
+				return len(gotMap) == len(tc.expectedConfig)
+			}, 2*time.Second); err != nil {
+				t.Errorf("waiting for confing table: %v", err)
+			}
+
+			if !reflect.DeepEqual(gotMap, tc.expectedConfig) {
+				t.Errorf("expectedConfig:\n%+v\ngot:\n%+v", tc.expectedConfig, gotMap)
+			}
+		})
+	}
+}
+
+func iterToMap(iter statedb.Iterator[*ConfigEntry]) map[string]string {
+	m := make(map[string]string)
+	for {
+		s, _, ok := iter.Next()
+		if !ok {
+			break
+		}
+		m[s.Key] = s.Value
+	}
+	return m
+}
+
+func buildConfigMap(data map[string]string) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: namespace,
+		},
+		Data: data,
+	}
+}
+
+func fixture(t *testing.T) (*hive.Hive, *statedb.DB, statedb.RWTable[*ConfigEntry], *k8sClient.FakeClientset, *k8s.DynamicConfigMapResource) {
+	var (
+		db              *statedb.DB
+		table           statedb.RWTable[*ConfigEntry]
+		ciliumConfigMap *k8s.DynamicConfigMapResource
+		fakeClient      *k8sClient.FakeClientset
+	)
+
+	h := hive.New(
+		k8sClient.FakeClientCell,
+		k8s.ResourcesCell,
+		cell.Provide(
+			NewConfigTable,
+			func(table statedb.RWTable[*ConfigEntry]) statedb.Table[*ConfigEntry] {
+				return table
+			},
+			func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
+				h := p.ForModule(cell.FullModuleID{"test"})
+				jg := jr.NewGroup(h)
+				lc.Append(jg)
+				return jg
+			},
+			func() config {
+				return config{
+					EnableDynamicConfig: true,
+				}
+			}),
+		cell.Invoke(
+			func(t statedb.RWTable[*ConfigEntry], p controllerParams, lcm k8s.DynamicConfigMapResource, db_ *statedb.DB, c *k8sClient.FakeClientset) error {
+				table = t
+				ciliumConfigMap = &lcm
+				db = db_
+				fakeClient = c
+				registerController(table, p)
+				return nil
+			},
+			statedb.RegisterTable[*ConfigEntry],
+		),
+	)
+
+	ctx := context.Background()
+	tLog := hivetest.Logger(t)
+	if err := h.Start(tLog, ctx); err != nil {
+		t.Fatalf("starting hive encountered: %s", err)
+	}
+	t.Cleanup(func() {
+		if err := h.Stop(tLog, ctx); err != nil {
+			t.Fatalf("stoping hive encountered: %s", err)
+		}
+	})
+
+	return h, db, table, fakeClient, ciliumConfigMap
+}

--- a/pkg/dynamicconfig/table.go
+++ b/pkg/dynamicconfig/table.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dynamicconfig
+
+import (
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+const CiliumConfigTableName = "cilium-dynamic-config-table"
+
+var ConfigTableIndex = statedb.Index[*ConfigEntry, string]{
+	Name: "config-key",
+	FromObject: func(t *ConfigEntry) index.KeySet {
+		return index.NewKeySet(index.String(t.Key))
+	},
+	FromKey: index.String,
+	Unique:  true,
+}
+
+type ConfigEntry struct {
+	Key   string
+	Value string
+}
+
+type ConfigTableGetter interface {
+	Init()
+	Get(key string) (ConfigEntry, bool)
+	List() []ConfigEntry
+	Watch(key string) (ConfigEntry, <-chan struct{})
+}
+
+type SimpleConfigTableGetter struct {
+	db    *statedb.DB
+	table statedb.RWTable[*ConfigEntry]
+}
+
+// ProvideConfigTableGetter initializes and returns a ConfigTableGetter instance using the provided database and table.
+// It sets up a SimpleConfigTableGetter by supplying the StateDB and ConfigEntry table.
+//
+// The resulting ConfigTableGetter can be used as a dependency in a cell by including it in the cell's input parameters,
+//
+//	type struct {
+//	  Cell.In
+//	  ConfigTableGetter dynamicconfig.ConfigTableGetter
+//	}
+//
+// Alternatively, it can be accessed through the read-only StateDB, though this is not recommended:
+//
+//	statedb.Table[*dynamicconfig.ConfigEntry]
+func ProvideConfigTableGetter(db *statedb.DB, table statedb.RWTable[*ConfigEntry]) ConfigTableGetter {
+	return SimpleConfigTableGetter{db: db, table: table}
+}
+
+// Init monitors the configuration table until it contains at least one object.
+// If the table has any objects, the method exits immediately.
+// The method blocks until the table is populated with at least one entry.
+func (c SimpleConfigTableGetter) Init() {
+	for {
+		_, w := c.table.AllWatch(c.db.ReadTxn())
+		if c.table.NumObjects(c.db.ReadTxn()) > 0 {
+			return
+		}
+		<-w
+	}
+}
+
+// Get retrieves a configuration entry from the configuration table based on the provided key.
+// If the key is found, the method returns a ConfigEntry and boolean value of true to indicate success.
+// If the key is not found, the method returns an empty ConfigEntry and false.
+func (c SimpleConfigTableGetter) Get(key string) (ConfigEntry, bool) {
+	obj, _, found := c.table.Get(c.db.ReadTxn(), ConfigTableIndex.Query(key))
+	if !found {
+		return ConfigEntry{}, false
+	}
+	return NewConfigEntry(obj.Key, obj.Value), true
+}
+
+// List retrieves all entries and returns them as a slice of ConfigEntry,
+// or an empty slice if the table is empty.
+func (c SimpleConfigTableGetter) List() []ConfigEntry {
+	var entries []ConfigEntry
+	iter := c.table.All(c.db.ReadTxn())
+	for {
+		s, _, ok := iter.Next()
+		if !ok {
+			break
+		}
+		entries = append(entries, NewConfigEntry(s.Key, s.Value))
+	}
+	return entries
+}
+
+// Watch returns a ConfigEntry along with a watch channel. If the entry is found,
+// it returns a ConfigEntry, along with a channel that can be used to watch for
+// changes to the entry. If the entry is not found, it returns an empty ConfigEntry
+// and the watch channel. The watch channel is closed if the ConfigEntry changes.
+func (c SimpleConfigTableGetter) Watch(key string) (ConfigEntry, <-chan struct{}) {
+	obj, _, w, f := c.table.GetWatch(c.db.ReadTxn(), ConfigTableIndex.Query(key))
+	if !f {
+		return ConfigEntry{}, w
+	}
+	return NewConfigEntry(obj.Key, obj.Value), w
+}
+
+// NewConfigEntry creates and returns a new ConfigEntry instance with the specified key and value.
+func NewConfigEntry(key string, value string) ConfigEntry {
+	return ConfigEntry{
+		Key:   key,
+		Value: value,
+	}
+}
+func NewConfigTable() (statedb.RWTable[*ConfigEntry], error) {
+	return statedb.NewTable(
+		CiliumConfigTableName,
+		ConfigTableIndex,
+	)
+}
+
+func (c Controller) upsertEntry(entries []ConfigEntry) {
+	txn := c.db.WriteTxn(c.configTable)
+	defer txn.Commit()
+
+	for _, entry := range entries {
+		_, _, err := c.configTable.Insert(txn, &entry)
+		if err != nil {
+			c.logger.Error("Upsert internal db", logfields.Key, entry.Key, logfields.Error, err)
+		}
+	}
+}

--- a/pkg/dynamicconfig/table_test.go
+++ b/pkg/dynamicconfig/table_test.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dynamicconfig
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/pkg/hive"
+)
+
+const (
+	key   = "dummy_key"
+	value = "dummy_value"
+)
+
+var timeout = 2 * time.Second
+
+func TestConfigTableGetter_List(t *testing.T) {
+	db, ct, ctg := getterFixture(t)
+	initialEntries := []ConfigEntry{NewConfigEntry("a", "aa"), NewConfigEntry("b", "bb"), NewConfigEntry("c", "cc")}
+	for _, entry := range initialEntries {
+		upsertDummyEntry(db, ct, entry.Key, entry.Value)
+	}
+
+	entries := ctg.List()
+
+	if !reflect.DeepEqual(entries, initialEntries) {
+		t.Errorf("List() do not match: expected %v, got %v", initialEntries, entries)
+	}
+}
+
+func TestConfigTableGetter_Watch(t *testing.T) {
+	db, ct, ctg := getterFixture(t)
+	done := make(chan bool)
+	newValue := "newValue"
+
+	upsertDummyEntry(db, ct, key, value)
+
+	e, w := ctg.Watch(key)
+
+	if e.Key != key || e.Value != value {
+		t.Errorf("Entry mismatch for key %v: expected (key=%v, value=%v), but got (key=%v, value=%v)", key, key, value, e.Key, e.Value)
+	}
+
+	go waitFor(func() {
+		<-w
+		e, _ := ctg.Watch(key)
+		if e.Key != key || e.Value != newValue {
+			t.Errorf("Entry mismatch for key %v: expected (key=%v, value=%v), but got (key=%v, value=%v)", key, key, newValue, e.Key, e.Value)
+		}
+	}, done)
+
+	upsertDummyEntry(db, ct, key, newValue)
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal("ctg.Watch() failed to detect changes")
+	}
+}
+
+func TestConfigTableGetter_Get(t *testing.T) {
+	db, ct, ctg := getterFixture(t)
+
+	upsertDummyEntry(db, ct, key, value)
+
+	entry, found := ctg.Get(key)
+	if !found || entry.Value != value {
+		t.Errorf("Failed to retrieve the expected entry for key %v: found=%v, expected value=%v, got value=%v", key, found, value, entry.Value)
+	}
+}
+
+func TestConfigTableGetter_Init(t *testing.T) {
+	db, ct, ctg := getterFixture(t)
+
+	done := make(chan bool)
+	go waitFor(ctg.Init, done)
+
+	upsertDummyEntry(db, ct, key, value)
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal("ctg.Init() failed to initialize")
+	}
+}
+
+func getterFixture(t *testing.T) (*statedb.DB, statedb.RWTable[*ConfigEntry], ConfigTableGetter) {
+	var (
+		db    *statedb.DB
+		table statedb.RWTable[*ConfigEntry]
+		ctb   ConfigTableGetter
+	)
+
+	h := hive.New(
+		cell.Provide(
+			NewConfigTable,
+			ProvideConfigTableGetter,
+			func(table statedb.RWTable[*ConfigEntry]) statedb.Table[*ConfigEntry] {
+				return table
+			}),
+
+		cell.Invoke(
+			func(t statedb.RWTable[*ConfigEntry], db_ *statedb.DB, ctb_ ConfigTableGetter) error {
+				table = t
+				db = db_
+				ctb = ctb_
+				return nil
+			},
+			statedb.RegisterTable[*ConfigEntry],
+		),
+	)
+
+	ctx := context.Background()
+	tLog := hivetest.Logger(t)
+	if err := h.Start(tLog, ctx); err != nil {
+		t.Fatalf("starting hive encountered: %s", err)
+	}
+	t.Cleanup(func() {
+		if err := h.Stop(tLog, ctx); err != nil {
+			t.Fatalf("stoping hive encountered: %s", err)
+		}
+	})
+	return db, table, ctb
+}
+
+func waitFor(f func(), done chan bool) {
+	f()
+	done <- true
+}
+
+func upsertDummyEntry(db *statedb.DB, table statedb.RWTable[*ConfigEntry], k string, v string) {
+	txn := db.WriteTxn(table)
+	defer txn.Commit()
+
+	entry := NewConfigEntry(k, v)
+	_, _, _ = table.Insert(txn, &entry)
+}

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -7,16 +7,16 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/cilium/cilium/pkg/allocator"
-	"github.com/cilium/cilium/pkg/identity/key"
-
 	"github.com/cilium/hive/cell"
 	"github.com/spf13/pflag"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/cilium/cilium/pkg/allocator"
+	"github.com/cilium/cilium/pkg/identity/key"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -162,6 +162,17 @@ func NamespaceResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*met
 		opts...,
 	)
 	return resource.New[*slim_corev1.Namespace](lc, lw, resource.WithMetric("Namespace")), nil
+}
+
+func ConfigMapResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*v1.ConfigMap], error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped[*v1.ConfigMapList](cs.CoreV1().ConfigMaps("")),
+		opts...,
+	)
+	return resource.New[*v1.ConfigMap](lc, lw, resource.WithMetric("ConfigMap")), nil
 }
 
 func LBIPPoolsResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool], error) {

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -43,11 +43,14 @@ type Config struct {
 	// the label is not present. For more details -
 	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2447-Make-kube-proxy-service-abstraction-optional
 	K8sServiceProxyName string
+
+	DynamicConfigMapName string
 }
 
 // DefaultConfig represents the default k8s resources config values.
 var DefaultConfig = Config{
 	EnableK8sEndpointSlice: true,
+	DynamicConfigMapName:   "cilium-config",
 }
 
 const (
@@ -59,6 +62,7 @@ const (
 func (def Config) Flags(flags *pflag.FlagSet) {
 	flags.Bool("enable-k8s-endpoint-slice", def.EnableK8sEndpointSlice, "Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it")
 	flags.String("k8s-service-proxy-name", def.K8sServiceProxyName, "Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)")
+	flags.String("dynamic-config-map-name", def.DynamicConfigMapName, "Specifies the name of the ConfigMap to be used for dynamic configuration")
 }
 
 // namespaceIndexFunc is an IndexFunc that indexes Namespace of Kubernetes


### PR DESCRIPTION
The agent will monitor the designated ConfigMap and automatically synchronize any changes with its in-memory database, StateDB. Create a new cell in the Agent that watches the configured ConfigMap and creates a StateDB table to store the key-value pairs. The Agent cell will expose the StateDB table through an interface.

```
The resulting ConfigTableGetter can be used as a dependency in a cell by including it in the cell's input parameters,

  type struct {
    Cell.In
    ConfigTableGetter dynamicconfig.ConfigTableGetter
  }

Alternatively, it can be accessed through the read-only StateDB, though this is not recommended:

statedb.Table[*dynamicconfig.ConfigEntry]
```
Related: https://github.com/cilium/cilium/issues/34101

```release-note
Add dynamic configuration for agents through ConfigMap.
```