### PR TITLE
Documentation: Add instructions on accessing the Hubble API with TLS

### DIFF
--- a/Documentation/observability/hubble/hubble-cli.rst
+++ b/Documentation/observability/hubble/hubble-cli.rst
@@ -86,3 +86,8 @@ dropped:
 
 Feel free to further inspect the traffic. To get help for the ``observe``
 command, use ``hubble help observe``.
+
+Next Steps
+==========
+
+* :ref:`hubble_api_tls`

--- a/Documentation/observability/hubble/setup.rst
+++ b/Documentation/observability/hubble/setup.rst
@@ -189,8 +189,13 @@ You can also query the flow API and look for flows:
    ``hubble help observe`` as well as ``hubble config`` for  configuring Hubble
    CLI.
 
+.. note::
+
+   If you have :ref:`enabled TLS<hubble_enable_tls>` then you will need to specify additional flags to :ref:`access the Hubble API<hubble_api_tls>`.
+
 Next Steps
 ==========
 
- * :ref:`hubble_cli`
- * :ref:`hubble_ui`
+* :ref:`hubble_cli`
+* :ref:`hubble_ui`
+* :ref:`hubble_enable_tls`


### PR DESCRIPTION
As the title says, add instructions on how to connect to the Hubble API using TLS with Hubble CLI

```release-note
Documentation: Add instructions on accessing the Hubble API with TLS
```
