### PR TITLE
bpf: Type LoadBalancer Service over SRv6 L3VPN

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1978,7 +1978,7 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, int ifindex, __u32 src_la
 
 skip_policy_enforcement:
 	if (ret == CT_NEW) {
-#if defined(ENABLE_NODEPORT) && defined(ENABLE_IPSEC)
+#if defined(ENABLE_NODEPORT) && (defined(ENABLE_IPSEC) || defined(ENABLE_SRV6))
 		/* Needed for hostport support, until
 		 * https://github.com/cilium/cilium/issues/32897 is fixed.
 		 */

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -26,6 +26,7 @@
 #include "stubs.h"
 #include "proxy_hairpin.h"
 #include "fib.h"
+#include "srv6.h"
 
 #define nodeport_nat_egress_ipv4_hook(ctx, ip4, info, tuple, l4_off, ext_err) CTX_ACT_OK
 #define nodeport_rev_dnat_ingress_ipv4_hook(ctx, ip4, tuple, tunnel_endpoint, src_sec_identity, \
@@ -2406,6 +2407,7 @@ nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	bool allow_neigh_map = true;
 	bool check_revdnat = true;
 	bool has_l4_header;
+	__u32 *vrf_id __maybe_unused = NULL;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
@@ -2434,6 +2436,17 @@ nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 
 	if (!check_revdnat)
 		goto out;
+
+#if defined(ENABLE_SRV6) && defined(IS_BPF_LXC)
+	/* Determine if packet belongs to a VRF before we do NAT.
+	 * This is needed because we determine the VRF membership
+	 * based on the source address of the packet. This should
+	 * be fixed in the future by determining the VRF membership
+	 * based on the IP address-agnostic way such as ingress
+	 * interface index.
+	 */
+	vrf_id = srv6_lookup_vrf4(ip4->saddr, ip4->daddr);
+#endif
 
 	ret = nodeport_rev_dnat_ingress_ipv4_hook(ctx, ip4, &tuple, &tunnel_endpoint,
 						  &src_sec_identity, &dst_sec_identity);
@@ -2475,6 +2488,20 @@ out:
 	return CTX_ACT_OK;
 
 redirect:
+#if defined(ENABLE_SRV6) && defined(IS_BPF_LXC)
+	if (vrf_id) {
+		union v6addr *sid;
+		/* Do policy lookup if it belongs to a VRF */
+		sid = srv6_lookup_policy4(*vrf_id, ip4->daddr);
+		if (sid) {
+			/* If there's a policy, tailcall to the H.Encaps logic */
+			srv6_store_meta_sid(ctx, sid);
+			return tail_call_internal(ctx, CILIUM_CALL_SRV6_ENCAP,
+						  ext_err);
+		}
+	}
+#endif /* ENABLE_SRV6 */
+
 	fib_params.l.ipv4_src = ip4->saddr;
 	fib_params.l.ipv4_dst = ip4->daddr;
 

--- a/bpf/lib/srv6.h
+++ b/bpf/lib/srv6.h
@@ -64,9 +64,9 @@ srv6_lookup_policy4(__u32 vrf_id, __be32 dip)
  */
 #  define SRV6_VRF_STATIC_PREFIX6						\
 	(8 * (sizeof(struct srv6_vrf_key6) - sizeof(struct bpf_lpm_trie_key)\
-	      - 4))
+	      - 16))
 #  define SRV6_VRF_PREFIX6_LEN(PREFIX) (SRV6_VRF_STATIC_PREFIX6 + (PREFIX))
-#  define SRV6_VRF_IPV6_PREFIX SRV6_VRF_PREFIX6_LEN(32)
+#  define SRV6_VRF_IPV6_PREFIX SRV6_VRF_PREFIX6_LEN(128)
 static __always_inline __u32*
 srv6_lookup_vrf6(const struct in6_addr *sip, const struct in6_addr *dip)
 {
@@ -83,7 +83,7 @@ srv6_lookup_vrf6(const struct in6_addr *sip, const struct in6_addr *dip)
  */
 # define SRV6_POLICY_STATIC_PREFIX6						\
 	(8 * (sizeof(struct srv6_policy_key6) - sizeof(struct bpf_lpm_trie_key)	\
-	      - 4))
+	      - 16))
 # define SRV6_POLICY_PREFIX6_LEN(PREFIX) (SRV6_POLICY_STATIC_PREFIX6 + (PREFIX))
 # define SRV6_POLICY_IPV6_PREFIX SRV6_POLICY_PREFIX6_LEN(128)
 

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -148,6 +148,7 @@ enum pkt_layer {
 
 	/* IPv6 extension headers */
 	PKT_LAYER_IPV6_HOP_BY_HOP,
+	PKT_LAYER_IPV6_ROUTING,
 	PKT_LAYER_IPV6_AUTH,
 	PKT_LAYER_IPV6_DEST,
 
@@ -327,6 +328,10 @@ struct ipv6_opt_hdr *pktgen__append_ipv6_extension_header(struct pktgen *builder
 	case NEXTHDR_HOP:
 		length = (0 + 1) << 3;
 		hdr = pktgen__push_rawhdr(builder, length, PKT_LAYER_IPV6_HOP_BY_HOP);
+		break;
+	case NEXTHDR_ROUTING:
+		hdr = pktgen__push_rawhdr(builder, length, PKT_LAYER_IPV6_ROUTING);
+		hdrlen = length;
 		break;
 	case NEXTHDR_AUTH:
 		length = (2 + 2) << 2;
@@ -852,6 +857,9 @@ static __always_inline void pktgen__finish_ipv6(const struct pktgen *builder, in
 	case PKT_LAYER_IPV6_HOP_BY_HOP:
 		ipv6_layer->nexthdr = NEXTHDR_HOP;
 		break;
+	case PKT_LAYER_IPV6_ROUTING:
+		ipv6_layer->nexthdr = NEXTHDR_ROUTING;
+		break;
 	case PKT_LAYER_IPV6_AUTH:
 		ipv6_layer->nexthdr = NEXTHDR_AUTH;
 		break;
@@ -903,6 +911,9 @@ static __always_inline void pktgen__finish_ipv6_opt(const struct pktgen *builder
 	switch (builder->layers[i + 1]) {
 	case PKT_LAYER_IPV6_HOP_BY_HOP:
 		ipv6_opt_layer->nexthdr = NEXTHDR_HOP;
+		break;
+	case PKT_LAYER_IPV6_ROUTING:
+		ipv6_opt_layer->nexthdr = NEXTHDR_ROUTING;
 		break;
 	case PKT_LAYER_IPV6_AUTH:
 		ipv6_opt_layer->nexthdr = NEXTHDR_AUTH;
@@ -1040,6 +1051,7 @@ void pktgen__finish(const struct pktgen *builder)
 			break;
 
 		case PKT_LAYER_IPV6_HOP_BY_HOP:
+		case PKT_LAYER_IPV6_ROUTING:
 		case PKT_LAYER_IPV6_AUTH:
 		case PKT_LAYER_IPV6_DEST:
 			pktgen__finish_ipv6_opt(builder, i);

--- a/bpf/tests/tc_srv6_decap.c
+++ b/bpf/tests/tc_srv6_decap.c
@@ -1,0 +1,613 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+#include <bpf/ctx/skb.h>
+#include <linux/in.h>
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_SRV6
+#ifdef TUNNEL_MODE
+#undef TUNNEL_MODE
+#endif
+#define ENABLE_HOST_ROUTING
+#define ENABLE_NODEPORT
+
+/* Test SRH encap. Reduced encap code path is a subset of SRH encap */
+#define ENABLE_SRV6_SRH_ENCAP
+
+#include "bpf_host.c"
+#include "lib/ipcache.h"
+#include "lib/endpoint.h"
+#include "lib/lb.h"
+
+#define FROM_NETDEV 0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_from_netdev,
+	},
+};
+
+#define POD_IPV4 v4_pod_one
+#define POD_IPV6 v6_pod_one
+#define EXT_IPV4 v4_ext_one
+#define EXT_IPV6 v6_pod_two
+#define OUTER_SRC v6_node_one
+#define SID v6_node_two
+#define ROUTER_MAC mac_one
+#define POD_MAC mac_two
+#define SERVICE_IPV4 v4_svc_one
+#define SERVICE_IPV6 v6_node_three
+#define CLIENT_PORT __bpf_htons(12345)
+#define SERVICE_PORT __bpf_htons(80)
+
+PKTGEN("tc", "tc_srv6_decap_to_pod_ipv4")
+int srv6_decap_to_pod_ipv4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct ethhdr *l2;
+	struct ipv6hdr *outer_l3;
+	struct srv6_srh *srh;
+	struct iphdr *inner_l3;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_FAIL;
+
+	/* We don't set mac addresses. It doesn't matter. */
+
+	outer_l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!outer_l3)
+		return TEST_FAIL;
+
+	memcpy(outer_l3->daddr.s6_addr, (const void *)SID, sizeof(SID));
+	memcpy(outer_l3->saddr.s6_addr, (const void *)OUTER_SRC, sizeof(OUTER_SRC));
+
+	srh = (struct srv6_srh *)pktgen__append_ipv6_extension_header(&builder,
+			NEXTHDR_ROUTING, sizeof(*srh) + sizeof(union v6addr));
+	if (!srh)
+		return TEST_FAIL;
+
+	srh->rthdr.nexthdr = IPPROTO_IPIP; /* Inner IP */
+	srh->rthdr.hdrlen = 2;             /* 24B (excluding first 8B) */
+	srh->rthdr.type = 4;               /* Segment Routing Header */
+	srh->rthdr.segments_left = 0;      /* Single SID */
+	srh->first_segment = 0;            /* Single SID */
+	srh->flags = 0;
+	srh->reserved = 0;
+
+	/* Copy SID */
+	memcpy(srh->segments, (const void *)SID, sizeof(SID));
+
+	inner_l3 = pktgen__push_default_iphdr(&builder);
+	if (!inner_l3)
+		return TEST_FAIL;
+
+	inner_l3->saddr = EXT_IPV4;
+	inner_l3->daddr = POD_IPV4;
+
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_FAIL;
+
+	/* We don't set ports. It doesn't matter. */
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_FAIL;
+
+	pktgen__finish(&builder);
+
+	return TEST_PASS;
+}
+
+SETUP("tc", "tc_srv6_decap_to_pod_ipv4")
+int srv6_decap_to_pod_ipv4_setup(struct __ctx_buff *ctx __maybe_unused)
+{
+	union v6addr sid;
+	__u32 vrf_id = 1;
+
+	memcpy(sid.addr, (const void *)SID, sizeof(sid.addr));
+
+	map_update_elem(&SRV6_SID_MAP, &sid, &vrf_id, 0);
+
+	endpoint_v4_add_entry(POD_IPV4, 12345, 100, 0, 0,
+			      (__u8 *)POD_MAC, (__u8 *)ROUTER_MAC);
+
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+
+	return TEST_FAIL;
+}
+
+CHECK("tc", "tc_srv6_decap_to_pod_ipv4")
+int srv6_decap_to_pod_ipv4_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	void *data;
+	void *data_end;
+	union v6addr sid;
+	__u32 *status_code;
+	struct ethhdr *eth;
+	struct iphdr *ipv4;
+
+	memcpy(sid.addr, (const void *)SID, sizeof(sid.addr));
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data +
+		sizeof(__u32) +
+		sizeof(struct ethhdr) +
+		sizeof(struct iphdr) > data_end)
+		test_fatal("status code + eth + ipv4 out of bounds");
+
+	status_code = data;
+	eth = (struct ethhdr *)(status_code + 1);
+	ipv4 = (struct iphdr *)(eth + 1);
+
+	/* Ensure the packet is delivered to the Pod with the right MAC and IP */
+
+	/* There's no policy call map entry, so drop is expected */
+	if (*status_code != TC_ACT_SHOT)
+		test_fatal("unexpected status code");
+
+	if (memcmp(eth->h_dest, (__u8 *)POD_MAC, ETH_ALEN) != 0)
+		test_fatal("unexpected eth->h_dest");
+
+	if (memcmp(eth->h_source, (__u8 *)ROUTER_MAC, ETH_ALEN) != 0)
+		test_fatal("unexpected eth->h_source");
+
+	if (eth->h_proto != __bpf_htons(ETH_P_IP))
+		test_fatal("unexpected eth->h_proto");
+
+	if (ipv4->saddr != EXT_IPV4)
+		test_fatal("unexpected ipv4->saddr");
+
+	if (ipv4->daddr != POD_IPV4)
+		test_fatal("unexpected ipv4->daddr");
+
+	if (ipv4->protocol != IPPROTO_TCP)
+		test_fatal("unexpected ipv4->protocol");
+
+	test_finish();
+
+	return TEST_PASS;
+}
+
+PKTGEN("tc", "tc_srv6_decap_to_pod_ipv6")
+int srv6_decap_to_pod_ipv6_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct ethhdr *l2;
+	struct ipv6hdr *outer_l3;
+	struct srv6_srh *srh;
+	struct ipv6hdr *inner_l3;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_FAIL;
+
+	/* We don't set mac addresses. It doesn't matter. */
+
+	outer_l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!outer_l3)
+		return TEST_FAIL;
+
+	memcpy(outer_l3->daddr.s6_addr, (const void *)SID, sizeof(SID));
+	memcpy(outer_l3->saddr.s6_addr, (const void *)OUTER_SRC, sizeof(OUTER_SRC));
+
+	srh = (struct srv6_srh *)pktgen__append_ipv6_extension_header(&builder,
+			NEXTHDR_ROUTING, sizeof(*srh) + sizeof(union v6addr));
+	if (!srh)
+		return TEST_FAIL;
+
+	srh->rthdr.nexthdr = IPPROTO_IPV6; /* Inner IPv6 */
+	srh->rthdr.hdrlen = 2;             /* 24B (excluding first 8B) */
+	srh->rthdr.type = 4;               /* Segment Routing Header */
+	srh->rthdr.segments_left = 0;      /* Single SID */
+	srh->first_segment = 0;            /* Single SID */
+	srh->flags = 0;
+	srh->reserved = 0;
+
+	/* Copy SID */
+	memcpy(srh->segments, (const void *)SID, sizeof(SID));
+
+	inner_l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!inner_l3)
+		return TEST_FAIL;
+
+	memcpy(inner_l3->daddr.s6_addr, (const void *)POD_IPV6, sizeof(POD_IPV6));
+	memcpy(inner_l3->saddr.s6_addr, (const void *)EXT_IPV6, sizeof(EXT_IPV6));
+
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_FAIL;
+
+	/* We don't set ports. It doesn't matter. */
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_FAIL;
+
+	pktgen__finish(&builder);
+
+	return TEST_PASS;
+}
+
+SETUP("tc", "tc_srv6_decap_to_pod_ipv6")
+int srv6_decap_to_pod_ipv6_setup(struct __ctx_buff *ctx __maybe_unused)
+{
+	union v6addr sid;
+	__u32 vrf_id = 1;
+
+	memcpy(sid.addr, (const void *)SID, sizeof(sid.addr));
+
+	map_update_elem(&SRV6_SID_MAP, &sid, &vrf_id, 0);
+
+	endpoint_v6_add_entry((const union v6addr *)POD_IPV6, 12345, 100, 0, 0,
+			      (__u8 *)POD_MAC, (__u8 *)ROUTER_MAC);
+
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+
+	return TEST_FAIL;
+}
+
+CHECK("tc", "tc_srv6_decap_to_pod_ipv6")
+int srv6_decap_to_pod_ipv6_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	void *data;
+	void *data_end;
+	union v6addr sid;
+	__u32 *status_code;
+	struct ethhdr *eth;
+	struct ipv6hdr *ipv6;
+
+	memcpy(sid.addr, (const void *)SID, sizeof(sid.addr));
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data +
+		sizeof(__u32) +
+		sizeof(struct ethhdr) +
+		sizeof(struct ipv6hdr) > data_end)
+		test_fatal("status code + eth + ipv6 out of bounds");
+
+	status_code = data;
+	eth = (struct ethhdr *)(status_code + 1);
+	ipv6 = (struct ipv6hdr *)(eth + 1);
+
+	/* Ensure the packet is delivered to the Pod with the right MAC and IP */
+
+	/* There's no policy call map entry, so drop is expected */
+	if (*status_code != TC_ACT_SHOT)
+		test_fatal("unexpected status code");
+
+	if (memcmp(eth->h_dest, (__u8 *)POD_MAC, ETH_ALEN) != 0)
+		test_fatal("unexpected eth->h_dest");
+
+	if (memcmp(eth->h_source, (__u8 *)ROUTER_MAC, ETH_ALEN) != 0)
+		test_fatal("unexpected eth->h_source");
+
+	if (eth->h_proto != __bpf_htons(ETH_P_IPV6))
+		test_fatal("unexpected eth->h_proto");
+
+	if (!ipv6_addr_equals((const union v6addr *)&ipv6->saddr, (const union v6addr *)EXT_IPV6))
+		test_fatal("unexpected ipv6->saddr");
+
+	if (!ipv6_addr_equals((const union v6addr *)&ipv6->daddr, (const union v6addr *)POD_IPV6))
+		test_fatal("unexpected ipv6->daddr");
+
+	if (ipv6->nexthdr != IPPROTO_TCP)
+		test_fatal("unexpected ipv6->nexthdr");
+
+	test_finish();
+
+	return TEST_PASS;
+}
+
+PKTGEN("tc", "tc_srv6_decap_to_service_ipv4")
+int srv6_decap_to_service_ipv4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct ethhdr *l2;
+	struct ipv6hdr *outer_l3;
+	struct srv6_srh *srh;
+	struct iphdr *inner_l3;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_FAIL;
+
+	/* We don't set mac addresses. It doesn't matter. */
+
+	outer_l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!outer_l3)
+		return TEST_FAIL;
+
+	memcpy(outer_l3->daddr.s6_addr, (const void *)SID, sizeof(SID));
+	memcpy(outer_l3->saddr.s6_addr, (const void *)OUTER_SRC, sizeof(OUTER_SRC));
+
+	srh = (struct srv6_srh *)pktgen__append_ipv6_extension_header(&builder,
+			NEXTHDR_ROUTING, sizeof(*srh) + sizeof(union v6addr));
+	if (!srh)
+		return TEST_FAIL;
+
+	srh->rthdr.nexthdr = IPPROTO_IPIP; /* Inner IP */
+	srh->rthdr.hdrlen = 2;             /* 24B (excluding first 8B) */
+	srh->rthdr.type = 4;               /* Segment Routing Header */
+	srh->rthdr.segments_left = 0;      /* Single SID */
+	srh->first_segment = 0;            /* Single SID */
+	srh->flags = 0;
+	srh->reserved = 0;
+
+	/* Copy SID */
+	memcpy(srh->segments, (const void *)SID, sizeof(SID));
+
+	inner_l3 = pktgen__push_default_iphdr(&builder);
+	if (!inner_l3)
+		return TEST_FAIL;
+
+	inner_l3->saddr = EXT_IPV4;
+	inner_l3->daddr = SERVICE_IPV4;
+
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_FAIL;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = SERVICE_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_FAIL;
+
+	pktgen__finish(&builder);
+
+	return TEST_PASS;
+}
+
+SETUP("tc", "tc_srv6_decap_to_service_ipv4")
+int srv6_decap_to_service_ipv4_setup(struct __ctx_buff *ctx __maybe_unused)
+{
+	union v6addr sid;
+	__u32 vrf_id = 1;
+
+	memcpy(sid.addr, (const void *)SID, sizeof(sid.addr));
+
+	map_update_elem(&SRV6_SID_MAP, &sid, &vrf_id, 0);
+
+	lb_v4_add_service(SERVICE_IPV4, SERVICE_PORT, 1, 1);
+	lb_v4_add_backend(SERVICE_IPV4, SERVICE_PORT, 1, 124,
+			  POD_IPV4, SERVICE_PORT, IPPROTO_TCP, 0);
+
+	endpoint_v4_add_entry(POD_IPV4, 12345, 100, 0, 0,
+			      (__u8 *)POD_MAC, (__u8 *)ROUTER_MAC);
+
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+
+	return TEST_FAIL;
+}
+
+CHECK("tc", "tc_srv6_decap_to_service_ipv4")
+int srv6_decap_to_service_ipv4_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	void *data;
+	void *data_end;
+	union v6addr sid;
+	__u32 *status_code;
+	struct ethhdr *eth;
+	struct iphdr *ipv4;
+
+	memcpy(sid.addr, (const void *)SID, sizeof(sid.addr));
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data +
+		sizeof(__u32) +
+		sizeof(struct ethhdr) +
+		sizeof(struct iphdr) > data_end)
+		test_fatal("status code + eth + ipv4 out of bounds");
+
+	status_code = data;
+	eth = (struct ethhdr *)(status_code + 1);
+	ipv4 = (struct iphdr *)(eth + 1);
+
+	/* Ensure the packet is delivered to the Pod with the right MAC and IP */
+
+	/* There's no policy call map entry, so drop is expected */
+	if (*status_code != TC_ACT_SHOT)
+		test_fatal("unexpected status code");
+
+	if (memcmp(eth->h_dest, (__u8 *)POD_MAC, ETH_ALEN) != 0)
+		test_fatal("unexpected eth->h_dest");
+
+	if (memcmp(eth->h_source, (__u8 *)ROUTER_MAC, ETH_ALEN) != 0)
+		test_fatal("unexpected eth->h_source");
+
+	if (eth->h_proto != __bpf_htons(ETH_P_IP))
+		test_fatal("unexpected eth->h_proto");
+
+	if (ipv4->saddr != EXT_IPV4)
+		test_fatal("unexpected ipv4->saddr");
+
+	if (ipv4->daddr != POD_IPV4)
+		test_fatal("unexpected ipv4->daddr");
+
+	if (ipv4->protocol != IPPROTO_TCP)
+		test_fatal("unexpected ipv4->protocol");
+
+	test_finish();
+
+	return TEST_PASS;
+}
+
+PKTGEN("tc", "tc_srv6_decap_to_service_ipv6")
+int srv6_decap_to_service_ipv6_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct ethhdr *l2;
+	struct ipv6hdr *outer_l3;
+	struct srv6_srh *srh;
+	struct ipv6hdr *inner_l3;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_FAIL;
+
+	/* We don't set mac addresses. It doesn't matter. */
+
+	outer_l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!outer_l3)
+		return TEST_FAIL;
+
+	memcpy(outer_l3->daddr.s6_addr, (const void *)SID, sizeof(SID));
+	memcpy(outer_l3->saddr.s6_addr, (const void *)OUTER_SRC, sizeof(OUTER_SRC));
+
+	srh = (struct srv6_srh *)pktgen__append_ipv6_extension_header(&builder,
+			NEXTHDR_ROUTING, sizeof(*srh) + sizeof(union v6addr));
+	if (!srh)
+		return TEST_FAIL;
+
+	srh->rthdr.nexthdr = IPPROTO_IPV6; /* Inner IPv6 */
+	srh->rthdr.hdrlen = 2;             /* 24B (excluding first 8B) */
+	srh->rthdr.type = 4;               /* Segment Routing Header */
+	srh->rthdr.segments_left = 0;      /* Single SID */
+	srh->first_segment = 0;            /* Single SID */
+	srh->flags = 0;
+	srh->reserved = 0;
+
+	/* Copy SID */
+	memcpy(srh->segments, (const void *)SID, sizeof(SID));
+
+	inner_l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!inner_l3)
+		return TEST_FAIL;
+
+	memcpy(inner_l3->daddr.s6_addr, (const void *)POD_IPV6, sizeof(POD_IPV6));
+	memcpy(inner_l3->saddr.s6_addr, (const void *)EXT_IPV6, sizeof(EXT_IPV6));
+
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_FAIL;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = SERVICE_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_FAIL;
+
+	pktgen__finish(&builder);
+
+	return TEST_PASS;
+}
+
+SETUP("tc", "tc_srv6_decap_to_service_ipv6")
+int srv6_decap_to_service_ipv6_setup(struct __ctx_buff *ctx __maybe_unused)
+{
+	union v6addr sid;
+	__u32 vrf_id = 1;
+
+	memcpy(sid.addr, (const void *)SID, sizeof(sid.addr));
+
+	map_update_elem(&SRV6_SID_MAP, &sid, &vrf_id, 0);
+
+	lb_v6_add_service((const union v6addr *)SERVICE_IPV6, SERVICE_PORT, 1, 1);
+	lb_v6_add_backend((const union v6addr *)SERVICE_IPV6, SERVICE_PORT, 1, 124,
+			  (const union v6addr *)POD_IPV6, SERVICE_PORT, IPPROTO_TCP, 0);
+
+	endpoint_v6_add_entry((const union v6addr *)POD_IPV6, 12345, 100, 0, 0,
+			      (__u8 *)POD_MAC, (__u8 *)ROUTER_MAC);
+
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+
+	return TEST_FAIL;
+}
+
+CHECK("tc", "tc_srv6_decap_to_service_ipv6")
+int srv6_decap_to_service_ipv6_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	void *data;
+	void *data_end;
+	union v6addr sid;
+	__u32 *status_code;
+	struct ethhdr *eth;
+	struct ipv6hdr *ipv6;
+
+	memcpy(sid.addr, (const void *)SID, sizeof(sid.addr));
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data +
+		sizeof(__u32) +
+		sizeof(struct ethhdr) +
+		sizeof(struct ipv6hdr) > data_end)
+		test_fatal("status code + eth + ipv6 out of bounds");
+
+	status_code = data;
+	eth = (struct ethhdr *)(status_code + 1);
+	ipv6 = (struct ipv6hdr *)(eth + 1);
+
+	/* Ensure the packet is delivered to the Pod with the right MAC and IP */
+
+	/* There's no policy call map entry, so drop is expected */
+	if (*status_code != TC_ACT_SHOT)
+		test_fatal("unexpected status code");
+
+	if (memcmp(eth->h_dest, (__u8 *)POD_MAC, ETH_ALEN) != 0)
+		test_fatal("unexpected eth->h_dest");
+
+	if (memcmp(eth->h_source, (__u8 *)ROUTER_MAC, ETH_ALEN) != 0)
+		test_fatal("unexpected eth->h_source");
+
+	if (eth->h_proto != __bpf_htons(ETH_P_IPV6))
+		test_fatal("unexpected eth->h_proto");
+
+	if (!ipv6_addr_equals((const union v6addr *)&ipv6->saddr, (const union v6addr *)EXT_IPV6))
+		test_fatal("unexpected ipv6->saddr");
+
+	if (!ipv6_addr_equals((const union v6addr *)&ipv6->daddr, (const union v6addr *)POD_IPV6))
+		test_fatal("unexpected ipv6->daddr");
+
+	if (ipv6->nexthdr != IPPROTO_TCP)
+		test_fatal("unexpected ipv6->protocol");
+
+	test_finish();
+
+	return TEST_PASS;
+}

--- a/bpf/tests/tc_srv6_encap.c
+++ b/bpf/tests/tc_srv6_encap.c
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+#include <bpf/ctx/skb.h>
+#include <linux/in.h>
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_SRV6
+#ifdef TUNNEL_MODE
+#undef TUNNEL_MODE
+#endif
+
+/* Test SRH encap. Reduced encap code path is a subset of SRH encap */
+#define ENABLE_SRV6_SRH_ENCAP
+
+#include "bpf_lxc.c"
+#include "lib/ipcache.h"
+#include "lib/policy.h"
+
+#define FROM_CONTAINER 0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_CONTAINER] = &cil_from_container,
+	},
+};
+
+#define POD_IPV4 v4_pod_one
+#define EXT_IPV4 v4_ext_one
+#define POD_IPV6 v6_pod_one
+#define EXT_IPV6 v6_node_one
+#define SID v6_node_two
+
+PKTGEN("tc", "tc_srv6_encap_from_pod_ipv4")
+int srv6_encap_from_pod_ipv4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_FAIL;
+
+	/* We don't set mac addresses. It doesn't matter. */
+
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_FAIL;
+
+	l3->saddr = POD_IPV4;
+	l3->daddr = EXT_IPV4;
+
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_FAIL;
+
+	/* We don't set ports. It doesn't matter. */
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_FAIL;
+
+	pktgen__finish(&builder);
+
+	return TEST_PASS;
+}
+
+SETUP("tc", "tc_srv6_encap_from_pod_ipv4")
+int srv6_encap_from_pod_ipv4_setup(struct __ctx_buff *ctx __maybe_unused)
+{
+	struct srv6_vrf_key4 vrf_key = {
+		.lpm = {SRV6_VRF_STATIC_PREFIX4, {} },
+		.src_ip = POD_IPV4,
+		.dst_cidr = 0,
+	};
+	struct srv6_policy_key4 policy_key = {
+		.lpm = {SRV6_POLICY_STATIC_PREFIX4 + 32, {} },
+		.vrf_id = 1,
+		.dst_cidr = EXT_IPV4,
+	};
+	union v6addr sid;
+	__u32 vrf_id = 1;
+
+	memcpy(&sid, (const void *)SID, sizeof(sid));
+	map_update_elem(&SRV6_VRF_MAP4, &vrf_key, &vrf_id, 0);
+	map_update_elem(&SRV6_POLICY_MAP4, &policy_key, &sid, 0);
+
+	/* We need this rule. Otherwise, network policy will drop the inner packet. */
+	policy_add_egress_allow_all_entry();
+
+	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+	return TEST_FAIL;
+}
+
+CHECK("tc", "tc_srv6_encap_from_pod_ipv4")
+int srv6_encap_from_pod_ipv4_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	void *data;
+	void *data_end;
+	union v6addr expected_sid;
+	__u32 *status_code;
+	struct ethhdr *eth;
+	struct ipv6hdr *ipv6;
+	struct srv6_srh *srh;
+	union v6addr *sid;
+	struct iphdr *ipv4;
+
+	memcpy(&expected_sid, (const void *)SID, sizeof(expected_sid));
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data +
+		sizeof(__u32) +
+		sizeof(struct ethhdr) +
+		sizeof(struct ipv6hdr) +
+		sizeof(struct srv6_srh) +
+		sizeof(union v6addr) +
+		sizeof(struct iphdr) > data_end)
+		test_fatal("status code + eth + ipv6 + srh + sid + ipv4 out of bounds");
+
+	status_code = data;
+	eth = (struct ethhdr *)(status_code + 1);
+	ipv6 = (struct ipv6hdr *)(eth + 1);
+	srh = (struct srv6_srh *)(ipv6 + 1);
+	sid = (union v6addr *)(srh + 1);
+	ipv4 = (struct iphdr *)(sid + 1);
+
+	if (*status_code != TC_ACT_OK)
+		test_fatal("unexpected status code");
+
+	if (eth->h_proto != __bpf_htons(ETH_P_IPV6))
+		test_fatal("unexpected eth->h_proto");
+
+	/* Destination address should be the SID */
+	if (!ipv6_addr_equals((union v6addr *)&ipv6->daddr, sid))
+		test_fatal("unexpected ipv6->daddr");
+
+	/* Nexthdr should be routing header */
+	if (ipv6->nexthdr != IPPROTO_ROUTING)
+		test_fatal("unexpected ipv6->nexthdr");
+
+	/* Nexthdr of routing header should be IPv4 */
+	if (srh->rthdr.nexthdr != IPPROTO_IPIP)
+		test_fatal("unexpected srh->rthdr.nexthdr");
+
+	/* Header length should be 2 (8 * 2 + 8 (first fixed 8B) = 24 bytes) */
+	if (srh->rthdr.hdrlen != 2)
+		test_fatal("unexpected srh->rthdr.hdr_len");
+
+	/* Routing header type should be 4 (Segment Routing Header) */
+	if (srh->rthdr.type != 4)
+		test_fatal("unexpected srh->rthdr.type");
+
+	/* Currently, only one segment is supported */
+	if (srh->rthdr.segments_left != 0)
+		test_fatal("unexpected srh->rthdr.segments_left");
+
+	/* First segment should be 0 */
+	if (srh->first_segment != 0)
+		test_fatal("unexpected srh->first_segment");
+
+	/* Check SID is the expected one */
+	if (!ipv6_addr_equals(sid, &expected_sid))
+		test_fatal("unexpected sid");
+
+	/* Check IPv4 header (just to make sure the encapsulation doesn't corrupt inner packet) */
+	if (ipv4->saddr != POD_IPV4)
+		test_fatal("unexpected ipv4->saddr");
+
+	if (ipv4->daddr != EXT_IPV4)
+		test_fatal("unexpected ipv4->daddr");
+
+	test_finish();
+
+	return TEST_PASS;
+}
+
+PKTGEN("tc", "tc_srv6_encap_from_pod_ipv6")
+int srv6_encap_from_pod_ipv6_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_FAIL;
+
+	/* We don't set mac addresses. It doesn't matter. */
+
+	l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!l3)
+		return TEST_FAIL;
+
+	memcpy(&l3->saddr, (const void *)POD_IPV6, sizeof(l3->saddr));
+	memcpy(&l3->daddr, (const void *)EXT_IPV6, sizeof(l3->daddr));
+
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_FAIL;
+
+	/* We don't set ports. It doesn't matter. */
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_FAIL;
+
+	pktgen__finish(&builder);
+
+	return TEST_PASS;
+}
+
+SETUP("tc", "tc_srv6_encap_from_pod_ipv6")
+int srv6_encap_from_pod_ipv6_setup(struct __ctx_buff *ctx __maybe_unused)
+{
+	struct srv6_vrf_key6 vrf_key = {
+		.lpm = {SRV6_VRF_STATIC_PREFIX6, {} },
+	};
+	struct srv6_policy_key6 policy_key = {
+		.lpm = {SRV6_POLICY_STATIC_PREFIX6 + 128, {} },
+		.vrf_id = 1,
+	};
+	union v6addr sid;
+	__u32 vrf_id = 1;
+
+	memcpy(&vrf_key.src_ip, (const void *)POD_IPV6, sizeof(union v6addr));
+	memset(&vrf_key.dst_cidr, 0, sizeof(union v6addr));
+	map_update_elem(&SRV6_VRF_MAP6, &vrf_key, &vrf_id, 0);
+
+	memcpy(&policy_key.dst_cidr, (const void *)EXT_IPV6, sizeof(union v6addr));
+	memcpy(&sid, (const void *)SID, sizeof(sid));
+	map_update_elem(&SRV6_POLICY_MAP6, &policy_key, &sid, 0);
+
+	/* We need this rule. Otherwise, network policy will drop the inner packet. */
+	policy_add_egress_allow_all_entry();
+
+	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
+	return TEST_FAIL;
+}
+
+CHECK("tc", "tc_srv6_encap_from_pod_ipv6")
+int srv6_encap_from_pod_ipv6_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	void *data;
+	void *data_end;
+	union v6addr expected_sid;
+	__u32 *status_code;
+	struct ethhdr *eth;
+	struct ipv6hdr *outer_ipv6;
+	struct srv6_srh *srh;
+	union v6addr *sid;
+	struct ipv6hdr *inner_ipv6;
+
+	memcpy(&expected_sid, (const void *)SID, sizeof(expected_sid));
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data +
+		sizeof(__u32) +
+		sizeof(struct ethhdr) +
+		sizeof(struct ipv6hdr) +
+		sizeof(struct srv6_srh) +
+		sizeof(union v6addr) +
+		sizeof(struct ipv6hdr) > data_end)
+		test_fatal("status code + eth + ipv6 + srh + sid + ipv6 out of bounds");
+
+	status_code = data;
+	eth = (struct ethhdr *)(status_code + 1);
+	outer_ipv6 = (struct ipv6hdr *)(eth + 1);
+	srh = (struct srv6_srh *)(outer_ipv6 + 1);
+	sid = (union v6addr *)(srh + 1);
+	inner_ipv6 = (struct ipv6hdr *)(sid + 1);
+
+	if (*status_code != TC_ACT_OK)
+		test_fatal("unexpected status code");
+
+	if (eth->h_proto != __bpf_htons(ETH_P_IPV6))
+		test_fatal("unexpected eth->h_proto");
+
+	/* Destination address should be the SID */
+	if (!ipv6_addr_equals((union v6addr *)&outer_ipv6->daddr, sid))
+		test_fatal("unexpected ipv6->daddr");
+
+	/* Nexthdr should be routing header */
+	if (outer_ipv6->nexthdr != IPPROTO_ROUTING)
+		test_fatal("unexpected ipv6->nexthdr");
+
+	/* Nexthdr of routing header should be IPv6 */
+	if (srh->rthdr.nexthdr != IPPROTO_IPV6)
+		test_fatal("unexpected srh->rthdr.nexthdr");
+
+	/* Header length should be 2 (8 * 2 + 8 (first fixed 8B) = 24 bytes) */
+	if (srh->rthdr.hdrlen != 2)
+		test_fatal("unexpected srh->rthdr.hdr_len");
+
+	/* Routing header type should be 4 (Segment Routing Header) */
+	if (srh->rthdr.type != 4)
+		test_fatal("unexpected srh->rthdr.type");
+
+	/* Currently, only one segment is supported */
+	if (srh->rthdr.segments_left != 0)
+		test_fatal("unexpected srh->rthdr.segments_left");
+
+	/* First segment should be 0 */
+	if (srh->first_segment != 0)
+		test_fatal("unexpected srh->first_segment");
+
+	/* Check SID is the expected one */
+	if (!ipv6_addr_equals(sid, &expected_sid))
+		test_fatal("unexpected sid");
+
+	/* Check IPv4 header (just to make sure the encapsulation doesn't corrupt inner packet) */
+	if (memcmp(&inner_ipv6->saddr, (const void *)POD_IPV6, sizeof(inner_ipv6->saddr)) != 0)
+		test_fatal("unexpected ipv6->saddr");
+
+	if (memcmp(&inner_ipv6->daddr, (const void *)EXT_IPV6, sizeof(inner_ipv6->daddr)) != 0)
+		test_fatal("unexpected ipv6->daddr");
+
+	test_finish();
+
+	return TEST_PASS;
+}


### PR DESCRIPTION
This PR introduces a support of type LoadBalancer Service over SRv6 L3VPN. A typical packet path would be like the following.

1. An SRv6-encapsulated packet comes to the Node. The inner packet destination is an LB VIP.
2. Decapsulate the packet (End.DT4) and load balance & DNAT it.
3. Forward the packet to the Pod and the Pod replies back.
4. Do RevDNAT the packet.
5. Encapsulate the packet with SRv6 (H.Encaps) and send it to the external network.

This implementation has following limitations.

- It only works for IPv4-only Services because we don't have a support for IPv6 VPN yet.
- It only works correctly for `externalTrafficPolicy=Local` Services because we don't have a logic for the node-to-node packet redirection over SRv6.
- It doesn't support L7 functionalities or IPSec since it performs RevDNAT and SRv6 encapsulation on bpf_lxc.

Please review commit by commit.

```release-note
bpf: Type LoadBalancer Service over SRv6 L3VPN
```
