### PR TITLE
Add support for pod level Networking QoS classes with BW Manager and FQ

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -132,8 +132,9 @@ include:
   # K8sDatapathBandwidthTest Checks Bandwidth Rate-Limiting Checks Pod to Pod bandwidth, direct routing
   # K8sDatapathBandwidthTest Checks Bandwidth Rate-Limiting Checks Pod to Pod bandwidth, geneve tunneling
   # K8sDatapathBandwidthTest Checks Bandwidth Rate-Limiting Checks Pod to Pod bandwidth, vxlan tunneling
+  # K8sDatapathQosTest Checks Bandwidth QoS Classes High to Low Ratio
   - focus: "f10-agent-hubble-bandwidth"
-    cliFocus: "K8sAgentHubbleTest|K8sDatapathBandwidthTest"
+    cliFocus: "K8sAgentHubbleTest|K8sDatapathBandwidthTest|K8sDatapathQosTest"
 
   ###
   # K8sDatapathServicesTest Checks N/S loadbalancing ClusterIP cannot be accessed externally when access is disabled

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -184,6 +184,7 @@ battlestation
 bcc
 behaviour
 benchmarking
+besteffort
 bgp
 blackholing
 blockedConfigOverrides

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -349,7 +349,9 @@ struct edt_info {
 	__u64		bps;
 	__u64		t_last;
 	__u64		t_horizon_drop;
-	__u64		pad[4];
+	__u32		prio;
+	__u32		pad_32;
+	__u64		pad[3];
 };
 
 struct remote_endpoint_info {

--- a/bpf/lib/edt.h
+++ b/bpf/lib/edt.h
@@ -60,6 +60,8 @@ edt_sched_departure(struct __ctx_buff *ctx, __be16 proto)
 	info = map_lookup_elem(&THROTTLE_MAP, &aggregate);
 	if (!info)
 		return CTX_ACT_OK;
+	if (!info->bps)
+		goto out;
 
 	now = ktime_get_ns();
 	t = ctx->tstamp;
@@ -80,6 +82,12 @@ edt_sched_departure(struct __ctx_buff *ctx, __be16 proto)
 		return CTX_ACT_DROP;
 	WRITE_ONCE(info->t_last, t_next);
 	ctx->tstamp = t_next;
+out:
+	// TODO: Hack to avoid defaulting prio 0 when user doesn't specify anything.
+	// Priority set by user will always be 1 greater than what scheduler expects.
+	if (info->prio) {
+		ctx->priority = info->prio - 1;
+	}
 	return CTX_ACT_OK;
 }
 #else

--- a/pkg/datapath/fake/types/bandwidth.go
+++ b/pkg/datapath/fake/types/bandwidth.go
@@ -12,7 +12,7 @@ type BandwidthManager struct{}
 func (fbm *BandwidthManager) DeleteBandwidthLimit(endpointID uint16) {
 }
 
-func (fbm *BandwidthManager) UpdateBandwidthLimit(endpointID uint16, bytesPerSecond uint64) {
+func (fbm *BandwidthManager) UpdateBandwidthLimit(endpointID uint16, bytesPerSecond uint64, prio uint32) {
 }
 
 func (fbm *BandwidthManager) BBREnabled() bool {

--- a/pkg/datapath/linux/bandwidth/bandwidth.go
+++ b/pkg/datapath/linux/bandwidth/bandwidth.go
@@ -29,6 +29,8 @@ const (
 	EgressBandwidth = "kubernetes.io/egress-bandwidth"
 	// IngressBandwidth is the K8s Pod annotation.
 	IngressBandwidth = "kubernetes.io/ingress-bandwidth"
+	// Priority is the Cilium Pod priority annotation.
+	Priority = "bandwidth.cilium.io/priority"
 
 	// FqDefaultHorizon represents maximum allowed departure
 	// time delta in future. Given applications can set SO_TXTIME
@@ -66,12 +68,12 @@ func (m *manager) defines() (defines.Map, error) {
 	return cDefinesMap, nil
 }
 
-func (m *manager) UpdateBandwidthLimit(epID uint16, bytesPerSecond uint64) {
+func (m *manager) UpdateBandwidthLimit(epID uint16, bytesPerSecond uint64, prio uint32) {
 	if m.enabled {
 		txn := m.params.DB.WriteTxn(m.params.EdtTable)
 		m.params.EdtTable.Insert(
 			txn,
-			bwmap.NewEdt(epID, bytesPerSecond),
+			bwmap.NewEdt(epID, bytesPerSecond, prio),
 		)
 		txn.Commit()
 	}

--- a/pkg/datapath/linux/bandwidth/bandwidth.go
+++ b/pkg/datapath/linux/bandwidth/bandwidth.go
@@ -40,6 +40,19 @@ const (
 	// FqDefaultBuckets is the default 32k (2^15) bucket limit for bwm.
 	// Too low bucket limit can cause scalability issue.
 	FqDefaultBuckets = 15
+
+	// FQ priomap starting from index 0 is 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
+	// Constants below map priority levels to bands high, medium and low.
+	// TODO: These are picked arbitrarily for each QoS class amongst different possible
+	// values. Revisit to see if picking these values would have any unintended side effects.
+	// HACK: Increment prio values by 1 to allow for distinguishing between 0 prio and no prio set.
+
+	// GuaranteedQoSDefaultPriority prio value to classify packets to high prio band
+	GuaranteedQoSDefaultPriority = 6 + 1
+	// BurstableQoSDefaultPriority prio value to classify packets to medium prio band
+	BurstableQoSDefaultPriority = 8 + 1
+	// BestEffortQoSDefaultPriority prio value to classify packets to medium prio band
+	BestEffortQoSDefaultPriority = 5 + 1
 )
 
 type manager struct {

--- a/pkg/datapath/types/bandwidth.go
+++ b/pkg/datapath/types/bandwidth.go
@@ -32,6 +32,6 @@ type BandwidthManager interface {
 	BBREnabled() bool
 	Enabled() bool
 
-	UpdateBandwidthLimit(endpointID uint16, bytesPerSecond uint64)
+	UpdateBandwidthLimit(endpointID uint16, bytesPerSecond uint64, prio uint32)
 	DeleteBandwidthLimit(endpointID uint16)
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -213,6 +213,9 @@ type Endpoint struct {
 	// bps is the egress rate of the endpoint
 	bps uint64
 
+	// prio is the traffic priority of the endpoint
+	prio uint32
+
 	// mac is the MAC address of the endpoint
 	// Constant after endpoint creation / restoration.
 	mac mac.MAC // Container MAC address.
@@ -1781,12 +1784,12 @@ func (e *Endpoint) metadataResolver(ctx context.Context,
 		value, _ := annotation.Get(po, annotation.NoTrack, annotation.NoTrackAlias)
 		return value, nil
 	})
-	e.UpdateBandwidthPolicy(bwm, func(ns, podName string) (bandwidthEgress string, err error) {
+	e.UpdateBandwidthPolicy(bwm, func(ns, podName string) (bandwidthEgress string, prio string, err error) {
 		_, k8sMetadata, err := resolveMetadata(ns, podName)
 		if err != nil {
-			return "", filterResolveMetadataError(err)
+			return "", "", filterResolveMetadataError(err)
 		}
-		return k8sMetadata.Annotations[bandwidth.EgressBandwidth], nil
+		return k8sMetadata.Annotations[bandwidth.EgressBandwidth], k8sMetadata.Annotations[bandwidth.Priority], nil
 	})
 
 	// If 'baseLabels' are not set then 'controllerBaseLabels' only contains

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -895,7 +895,8 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity, newEndpoint bool)
 
 // AnnotationsResolverCB provides an implementation for resolving the pod
 // annotations.
-type AnnotationsResolverCB func(ns, podName string) (value string, err error)
+type AnnotationsResolverCB func(ns, podName string) (proxyVisibility string, err error)
+type AnnotationsResolverCBBW func(ns, podName string) (bw string, prio string, err error)
 
 // UpdateNoTrackRules updates the NOTRACK iptable rules for this endpoint. If anno
 // is empty, then any existing NOTRACK rules will be removed. If anno cannot be parsed,
@@ -919,7 +920,7 @@ func (e *Endpoint) UpdateNoTrackRules(annoCB AnnotationsResolverCB) {
 
 // UpdateBandwidthPolicy updates the egress bandwidth of this endpoint to
 // progagate the throttle rate to the BPF data path.
-func (e *Endpoint) UpdateBandwidthPolicy(bwm dptypes.BandwidthManager, annoCB AnnotationsResolverCB) {
+func (e *Endpoint) UpdateBandwidthPolicy(bwm dptypes.BandwidthManager, annoCB AnnotationsResolverCBBW) {
 	ch, err := e.eventQueue.Enqueue(eventqueue.NewEvent(&EndpointPolicyBandwidthEvent{
 		bwm:    bwm,
 		ep:     e,

--- a/pkg/maps/bwmap/bwmap.go
+++ b/pkg/maps/bwmap/bwmap.go
@@ -38,10 +38,12 @@ type EdtInfo struct {
 	Bps             uint64    `align:"bps"`
 	TimeLast        uint64    `align:"t_last"`
 	TimeHorizonDrop uint64    `align:"t_horizon_drop"`
-	Pad             [4]uint64 `align:"pad"`
+	Prio            uint32    `align:"prio"`
+	Pad32           uint32    `align:"pad_32"`
+	Pad             [3]uint64 `align:"pad"`
 }
 
-func (v *EdtInfo) String() string    { return fmt.Sprintf("%d", int(v.Bps)) }
+func (v *EdtInfo) String() string    { return fmt.Sprintf("%d, %d", int(v.Bps), int(v.Prio)) }
 func (v *EdtInfo) New() bpf.MapValue { return &EdtInfo{} }
 
 type throttleMap struct {

--- a/pkg/maps/bwmap/table.go
+++ b/pkg/maps/bwmap/table.go
@@ -29,6 +29,8 @@ type Edt struct {
 	// BytesPerSecond is the bandwidth limit for the endpoint.
 	BytesPerSecond uint64
 
+	Prio uint32
+
 	// TimeHorizonDrop is the maximum allowed departure time nanoseconds
 	// delta in future.
 	TimeHorizonDrop uint64
@@ -47,10 +49,11 @@ var EdtIDIndex = statedb.Index[Edt, uint16]{
 	Unique:     true,
 }
 
-func NewEdt(endpointID uint16, bytesPerSecond uint64) Edt {
+func NewEdt(endpointID uint16, bytesPerSecond uint64, prio uint32) Edt {
 	return Edt{
 		EndpointID:      endpointID,
 		BytesPerSecond:  bytesPerSecond,
+		Prio:            prio,
 		TimeHorizonDrop: uint64(DefaultDropHorizon),
 		Status:          reconciler.StatusPending(),
 	}
@@ -73,6 +76,7 @@ func (e Edt) BinaryValue() encoding.BinaryMarshaler {
 		Bps:             e.BytesPerSecond,
 		TimeLast:        0, // Used on the BPF-side
 		TimeHorizonDrop: e.TimeHorizonDrop,
+		Prio:            e.Prio,
 	}
 	return bpf.StructBinaryMarshaler{Target: &v}
 }
@@ -81,6 +85,7 @@ func (e Edt) TableHeader() []string {
 	return []string{
 		"EndpointID",
 		"BitsPerSecond",
+		"Prio",
 		"TimeHorizonDrop",
 		"Status",
 	}
@@ -93,6 +98,7 @@ func (e Edt) TableRow() []string {
 	return []string{
 		strconv.FormatUint(uint64(e.EndpointID), 10),
 		quantity.String(),
+		strconv.FormatUint(uint64(e.Prio), 10),
 		strconv.FormatUint(e.TimeHorizonDrop, 10),
 		e.Status.String(),
 	}

--- a/test/k8s/manifests/demo_qos.yaml
+++ b/test/k8s/manifests/demo_qos.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netperf-server
+spec:
+  selector:
+    matchLabels:
+      run: netperf-server
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: netperf-server
+    spec:
+      containers:
+      - name: netperf-server
+        image: cilium/netperf:0.0.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 12865
+      nodeSelector:
+        "cilium.io/ci-node": k8s1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netperf-high-prio-client
+spec:
+  selector:
+    matchLabels:
+      run: netperf-high-prio-client
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: netperf-high-prio-client
+      annotations:
+        bandwidth.cilium.io/priority: "6"
+    spec:
+      containers:
+      - name: netperf-high-prio-client
+        image: cilium/netperf:0.0.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 12865
+      nodeSelector:
+        "cilium.io/ci-node": k8s2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netperf-low-prio-client
+spec:
+  selector:
+    matchLabels:
+      run: netperf-low-prio-client
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: netperf-low-prio-client
+      annotations:
+        bandwidth.cilium.io/priority: "5"
+    spec:
+      containers:
+      - name: netperf-client
+        image: cilium/netperf:0.0.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 12865
+      nodeSelector:
+        "cilium.io/ci-node": k8s2
+

--- a/test/k8s/qos.go
+++ b/test/k8s/qos.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8sTest
+
+import (
+	"fmt"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+)
+
+var _ = SkipDescribeIf(helpers.DoesNotRunOnNetNextKernel, "K8sDatapathQosTest", func() {
+	var (
+		kubectl        *helpers.Kubectl
+		ciliumFilename string
+		demoYAML       string
+	)
+
+	BeforeAll(func() {
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+
+		demoYAML = helpers.ManifestGet(kubectl.BasePath(), "demo_qos.yaml")
+		res := kubectl.ApplyDefault(demoYAML)
+		res.ExpectSuccess("Unable to apply %s", demoYAML)
+	})
+
+	AfterAll(func() {
+		kubectl.Delete(demoYAML)
+		ExpectAllPodsTerminated(kubectl)
+
+		UninstallCiliumFromManifest(kubectl, ciliumFilename)
+		ExpectAllPodsTerminated(kubectl)
+
+		kubectl.CloseSSHClient()
+	})
+
+	Context("Checks Bandwidth QoS Classes", func() {
+		const (
+			testNetperfServer         = "run=netperf-server"
+			testNetperfHighPrioClient = "run=netperf-high-prio-client"
+			testNetperfLowPrioClient  = "run=netperf-low-prio-client"
+		)
+		var bwPrioResultsMap = map[string]float64{}
+
+		AfterFailed(func() {
+			kubectl.CiliumReport("cilium-dbg statedb bandwidth-edts", "cilium-dbg endpoint list")
+		})
+
+		JustAfterEach(func() {
+			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		})
+
+		waitForTestPods := func() {
+			podLabels := []string{
+				testNetperfServer,
+				testNetperfHighPrioClient,
+				testNetperfLowPrioClient,
+			}
+			for _, label := range podLabels {
+				err := kubectl.WaitforPods(helpers.DefaultNamespace,
+					fmt.Sprintf("-l %s", label), helpers.HelperTimeout)
+				Expect(err).Should(BeNil())
+			}
+		}
+
+		testNetperf := func(serverLabel string, fromLabel string) {
+			serverIPs, err := kubectl.GetPodsIPs(helpers.DefaultNamespace, serverLabel)
+			ExpectWithOffset(1, err).Should(BeNil(), "Cannot retrieve pod IPs for %s", serverLabel)
+			ExpectWithOffset(1, len(serverIPs)).To(Equal(int(1)), "Expected pod IPs mismatch")
+			for _, serverIP := range serverIPs {
+				pods, err := kubectl.GetPodNames(helpers.DefaultNamespace, fromLabel)
+				ExpectWithOffset(1, err).Should(BeNil(), "cannot retrieve pod names by filter %q",
+					fromLabel)
+				maxSessions := 100
+				cmd := helpers.SuperNetperf(maxSessions, serverIP, helpers.TCP_STREAM, "-l 120 -P 8 -- -m 1500000 -R 1")
+				By("Running %d netperf sessions from %s pod to pod with IP %s",
+					maxSessions, pods[0], serverIP)
+				res := kubectl.ExecPodCmd(helpers.DefaultNamespace, pods[0], cmd)
+				ExpectWithOffset(1, res).Should(helpers.CMDSuccess(),
+					"Request from %s pod to pod with IP %s failed", pods[0], serverIP)
+				By("Session test completed, netperf result raw: %s", res.SingleOut())
+				observedRate, err := res.FloatOutput()
+				Expect(err).Should(BeNil())
+				bwPrioResultsMap[fromLabel] = observedRate
+			}
+		}
+
+		It("High to Low Ratio", func() {
+			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+				"bandwidthManager.enabled": "true",
+			})
+			waitForTestPods()
+			go testNetperf(testNetperfServer, testNetperfLowPrioClient)
+			go testNetperf(testNetperfServer, testNetperfHighPrioClient)
+			// wait until bwPrioResultsMap has both high and low prio results
+			Eventually(func() bool {
+				return len(bwPrioResultsMap) == 2
+			}, "5m", "10s").Should(BeTrue())
+			// check if the ratio of high and low priority tput is around 1:9
+			Expect(bwPrioResultsMap[testNetperfHighPrioClient] / bwPrioResultsMap[testNetperfLowPrioClient]).
+				To(BeNumerically("~", 8, 10))
+		})
+	})
+})


### PR DESCRIPTION
Adds support for setting networking QoS classes for pods via an annotation `bandwidth.cilium.io/priority`. Annotation currently supports two kinds of values : 
* QoS class strings `Guaranteed`, `Burstable`, and `BestEffort` similar to [Kubernetes pod QoS](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/) 
* Priority level integers supported by the FQ scheduler (based on priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1 )

BW manager currently uses FQ packet scheduler which recently got support for priority bands in `6.7`.

This allows users to pick between three FQ priority bands low, medium and high. FQ uses a weighted round robin algorithm to avoid starvation. These weights are customizable and we can consider supporting custom weights in the future.

Default weights are as follows :
- high prio (band=0) packets get 90% of the bandwidth if they compete with low prio (band=2) packets.
- high prio packets get 75% of the bandwidth if they compete with medium prio (band=1) packets.

See https://github.com/torvalds/linux/commit/29f834aa326e659ed354c406056e94ea3d29706a for more details.

This PR also sets `Guaranteed` QoS class (FQ high priority band) for the host endpoint.

Tested this on an instance with 1 Gb/s max throughput, under contention notice the ~ 1:9 throughput split.

```
// On pod configured to use Band 0
bash-5.1# super_netperf 100 -t TCP_STREAM -H 10.42.1.83 -l 120 -P 8 -- -m 1500000 -R 1
912.94

// On pod configured to use Band 2
bash-5.1# super_netperf 100 -t TCP_STREAM -H 10.42.1.83 -l 120 -P 8 -- -m 1500000 -R 1
103.83
```

Based on @borkmann 's PoC https://github.com/cilium/cilium/pull/25618 

ToDo : 

- [ ]  Address ToDos from comments
- [ ]  Add an e2e test via connectivity perf tests

Closes: #24194
