### PR TITLE
Add an empty Dockerfile for cilium-cli

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -42,27 +42,39 @@ jobs:
         include:
           - name: cilium
             dockerfile: ./images/cilium/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+          - name: cilium-cli
+            dockerfile: ./cilium-cli/Dockerfile
+            platforms: linux/amd64
 
           - name: operator-aws
             dockerfile: ./images/operator/Dockerfile
+            platforms: linux/amd64,linux/arm64
 
           - name: operator-azure
             dockerfile: ./images/operator/Dockerfile
+            platforms: linux/amd64,linux/arm64
 
           - name: operator-alibabacloud
             dockerfile: ./images/operator/Dockerfile
+            platforms: linux/amd64,linux/arm64
 
           - name: operator-generic
             dockerfile: ./images/operator/Dockerfile
+            platforms: linux/amd64,linux/arm64
 
           - name: hubble-relay
             dockerfile: ./images/hubble-relay/Dockerfile
+            platforms: linux/amd64,linux/arm64
 
           - name: clustermesh-apiserver
             dockerfile: ./images/clustermesh-apiserver/Dockerfile
+            platforms: linux/amd64,linux/arm64
 
           - name: docker-plugin
             dockerfile: ./images/cilium-docker-plugin/Dockerfile
+            platforms: linux/amd64,linux/arm64
 
     steps:
       - name: Checkout default branch (trusted)
@@ -154,7 +166,7 @@ jobs:
           # re-pushing the image tags when we only want to re-create the Golang
           # docker cache after the workflow "Image CI Cache Cleaner" was terminated.
           push: ${{ github.event_name == 'push' }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platforms }}
           tags: |
             quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.floating_tag }}
             quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
@@ -281,7 +293,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platforms }}
           tags: |
             quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
           target: release

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -275,6 +275,7 @@ Makefile* @cilium/build
 /cilium-dbg/ @cilium/cli
 /cilium-dbg/cmd/encrypt* @cilium/ipsec @cilium/cli
 /cilium-dbg/cmd/preflight_k8s_valid_cnp.go @cilium/sig-k8s
+/cilium-cli/* @cilium/cli
 /cilium-health/ @cilium/sig-agent
 /cilium-health/cmd/ @cilium/sig-agent @cilium/cli
 /clustermesh-apiserver @cilium/sig-clustermesh

--- a/cilium-cli/Dockerfile
+++ b/cilium-cli/Dockerfile
@@ -1,0 +1,5 @@
+# syntax=docker/dockerfile:1.9@sha256:fe40cf4e92cd0c467be2cfc30657a680ae2398318afd50b0c80585784c604f28
+
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+FROM ubuntu AS release


### PR DESCRIPTION
Add an empty Dockerfile for cilium-cli so that the cilium-cli image gets built as a part of the CI. I'd like to run the full CI on #34178 without using a temporary commit. Otherwise the pull request looks too red.