### PR TITLE
proxy: remove unused method from DatapathUpdater interface

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -53,7 +53,6 @@ const (
 
 type DatapathUpdater interface {
 	InstallProxyRules(proxyPort uint16, name string)
-	SupportsOriginalSourceAddr() bool
 	GetProxyPorts() map[string]uint16
 }
 

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -25,10 +25,6 @@ type MockDatapathUpdater struct{}
 func (m *MockDatapathUpdater) InstallProxyRules(proxyPort uint16, name string) {
 }
 
-func (m *MockDatapathUpdater) SupportsOriginalSourceAddr() bool {
-	return true
-}
-
 func (m *MockDatapathUpdater) GetProxyPorts() map[string]uint16 {
 	return nil
 }


### PR DESCRIPTION
The SupportsOriginalSourceAddr method is no longer needed as part of this interface since the removal of the datapath interface abstraction.