### PR TITLE
fix: base image workflow trigger conditional

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -41,8 +41,8 @@ concurrency:
 
 jobs:
   build-and-push:
-    # Skip this workflow for branches that are created by renovate
-    if: "!startsWith(github.head_ref, 'renovate/')"
+    # Skip this workflow for branches that are created by renovate and event type is pull_request_target
+    if: ${{ ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
     name: Build and Push Images
     timeout-minutes: 45
     environment: ${{ inputs.environment || 'release-base-images' }}


### PR DESCRIPTION
This commit update the conditional for triggering base image update workflow on renovate branches. Workflow should be skipped when the event is pull_request_target and the branch is coming from renovate. With this update the workflow will be triggered on workflow_call for renovate branches as well.

Example of renovate PR's that will be fixed in the future with this commit: https://github.com/cilium/cilium/pull/34126

```release-note
fix: base image update workflow will now be triggered on renovate branches with a workflow_call event type
```
