### PR TITLE
Use netip conversion functions from go4.org/netipx package

### DIFF
--- a/daemon/cmd/hostips-sync.go
+++ b/daemon/cmd/hostips-sync.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
+	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/identity"
@@ -192,7 +193,7 @@ func (s *syncHostIPs) sync(addrs statedb.Iterator[tables.NodeAddress]) error {
 
 		lbls := ipIDLblsPair.Labels
 		if ipIDLblsPair.ID.IsWorld() {
-			p := netip.PrefixFrom(ippkg.MustAddrFromIP(ipIDLblsPair.IP), 0)
+			p := netip.PrefixFrom(netipx.MustFromStdIP(ipIDLblsPair.IP), 0)
 			s.params.IPCache.OverrideIdentity(p, lbls, source.Local, daemonResourceID)
 		} else {
 			s.params.IPCache.UpsertLabels(ippkg.IPToNetPrefix(ipIDLblsPair.IP),

--- a/pkg/bpf/endpoint.go
+++ b/pkg/bpf/endpoint.go
@@ -8,8 +8,8 @@ import (
 	"net"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	ippkg "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/types"
+	"go4.org/netipx"
 )
 
 // Must be in sync with ENDPOINT_KEY_* in <bpf/lib/common.h>
@@ -62,7 +62,7 @@ func (k EndpointKey) ToIP() net.IP {
 func (k EndpointKey) String() string {
 	if ip := k.ToIP(); ip != nil {
 		addrCluster := cmtypes.AddrClusterFrom(
-			ippkg.MustAddrFromIP(ip),
+			netipx.MustFromStdIP(ip),
 			uint32(k.ClusterID),
 		)
 		return addrCluster.String() + ":" + fmt.Sprintf("%d", k.Key)

--- a/pkg/bpf/endpoint.go
+++ b/pkg/bpf/endpoint.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"net"
 
+	"go4.org/netipx"
+
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/types"
-	"go4.org/netipx"
 )
 
 // Must be in sync with ENDPOINT_KEY_* in <bpf/lib/common.h>

--- a/pkg/clustermesh/types/addressing.go
+++ b/pkg/clustermesh/types/addressing.go
@@ -15,7 +15,6 @@ import (
 	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/cidr"
-	ippkg "github.com/cilium/cilium/pkg/ip"
 )
 
 //
@@ -147,10 +146,10 @@ func MustParseAddrCluster(s string) AddrCluster {
 	return addrCluster
 }
 
-// AddrClusterFromIP parses the given net.IP using ip.AddrFromIP and returns
+// AddrClusterFromIP parses the given net.IP using netipx.FromStdIP and returns
 // AddrCluster with ClusterID = 0.
 func AddrClusterFromIP(ip net.IP) (AddrCluster, bool) {
-	addr, ok := ippkg.AddrFromIP(ip)
+	addr, ok := netipx.FromStdIP(ip)
 	if !ok {
 		return AddrCluster{}, false
 	}
@@ -364,7 +363,7 @@ func PrefixClusterFromCIDR(c *cidr.CIDR, opts ...PrefixClusterOpts) PrefixCluste
 		return PrefixCluster{}
 	}
 
-	addr, ok := ippkg.AddrFromIP(c.IP)
+	addr, ok := netipx.FromStdIP(c.IP)
 	if !ok {
 		return PrefixCluster{}
 	}

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
+	"go4.org/netipx"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/datapath"
@@ -21,7 +22,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/datapath/types"
-	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/maps/authmap"
 	fakeauthmap "github.com/cilium/cilium/pkg/maps/authmap/fake"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
@@ -105,8 +105,8 @@ func fakeDevices(db *statedb.DB, devices statedb.RWTable[*tables.Device]) stated
 		HardwareAddr: []byte{1, 2, 3, 4, 5, 6},
 		Flags:        net.FlagUp,
 		Addrs: []tables.DeviceAddress{
-			{Addr: ip.MustAddrFromIP(fakeTypes.IPv4NodePortAddress), Scope: unix.RT_SCOPE_UNIVERSE},
-			{Addr: ip.MustAddrFromIP(fakeTypes.IPv6NodePortAddress), Scope: unix.RT_SCOPE_UNIVERSE},
+			{Addr: netipx.MustFromStdIP(fakeTypes.IPv4NodePortAddress), Scope: unix.RT_SCOPE_UNIVERSE},
+			{Addr: netipx.MustFromStdIP(fakeTypes.IPv6NodePortAddress), Scope: unix.RT_SCOPE_UNIVERSE},
 		},
 		Type:     "test",
 		Selected: true,
@@ -119,8 +119,8 @@ func fakeDevices(db *statedb.DB, devices statedb.RWTable[*tables.Device]) stated
 		HardwareAddr: []byte{2, 3, 4, 5, 6, 7},
 		Flags:        net.FlagUp,
 		Addrs: []tables.DeviceAddress{
-			{Addr: ip.MustAddrFromIP(fakeTypes.IPv4InternalAddress), Scope: unix.RT_SCOPE_UNIVERSE},
-			{Addr: ip.MustAddrFromIP(fakeTypes.IPv6InternalAddress), Scope: unix.RT_SCOPE_UNIVERSE},
+			{Addr: netipx.MustFromStdIP(fakeTypes.IPv4InternalAddress), Scope: unix.RT_SCOPE_UNIVERSE},
+			{Addr: netipx.MustFromStdIP(fakeTypes.IPv6InternalAddress), Scope: unix.RT_SCOPE_UNIVERSE},
 
 			{Addr: netip.MustParseAddr("10.0.0.4"), Scope: unix.RT_SCOPE_UNIVERSE, Secondary: true},
 			{Addr: netip.MustParseAddr("f00d::3"), Scope: unix.RT_SCOPE_UNIVERSE, Secondary: true},

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
 	vns "github.com/vishvananda/netns"
+	"go4.org/netipx"
 	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -29,7 +30,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/inctimer"
-	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/netns"
 	"github.com/cilium/cilium/pkg/option"
@@ -387,7 +387,7 @@ func (dc *devicesController) processUpdates(
 
 func deviceAddressFromAddrUpdate(upd netlink.AddrUpdate) tables.DeviceAddress {
 	return tables.DeviceAddress{
-		Addr:      ip.MustAddrFromIP(upd.LinkAddress.IP),
+		Addr:      netipx.MustFromStdIP(upd.LinkAddress.IP),
 		Secondary: upd.Flags&unix.IFA_F_SECONDARY != 0,
 
 		// ifaddrmsg.ifa_scope is uint8, vishvananda/netlink has wrong type
@@ -683,7 +683,7 @@ func makeNetlinkFuncs() (*netlinkFuncs, error) {
 func ipnetToPrefix(family int, ipn *net.IPNet) netip.Prefix {
 	if ipn != nil {
 		cidr, _ := ipn.Mask.Size()
-		return netip.PrefixFrom(ip.MustAddrFromIP(ipn.IP), cidr)
+		return netip.PrefixFrom(netipx.MustFromStdIP(ipn.IP), cidr)
 	}
 	return netip.PrefixFrom(zeroAddr(family), 0)
 }

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	"go4.org/netipx"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
@@ -165,7 +166,7 @@ func Delete(ip netip.Addr, compat bool) error {
 		return errors.New("IP not compatible")
 	}
 
-	ipWithMask := iputil.AddrToIPNet(ip)
+	ipWithMask := netipx.AddrIPNet(ip)
 
 	scopedLog := log.WithFields(logrus.Fields{
 		"ip": ipWithMask.String(),

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
@@ -27,7 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
-	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -563,12 +563,12 @@ func (l *loader) reloadEndpoint(ep datapath.Endpoint, spec *ebpf.CollectionSpec)
 			logfields.Interface: device,
 		})
 		if ip := ep.IPv4Address(); ip.IsValid() {
-			if err := upsertEndpointRoute(ep, *iputil.AddrToIPNet(ip)); err != nil {
+			if err := upsertEndpointRoute(ep, *netipx.AddrIPNet(ip)); err != nil {
 				scopedLog.WithError(err).Warn("Failed to upsert route")
 			}
 		}
 		if ip := ep.IPv6Address(); ip.IsValid() {
-			if err := upsertEndpointRoute(ep, *iputil.AddrToIPNet(ip)); err != nil {
+			if err := upsertEndpointRoute(ep, *netipx.AddrIPNet(ip)); err != nil {
 				scopedLog.WithError(err).Warn("Failed to upsert route")
 			}
 		}
@@ -701,11 +701,11 @@ func (l *loader) ReloadDatapath(ctx context.Context, ep datapath.Endpoint, cfg *
 func (l *loader) Unload(ep datapath.Endpoint) {
 	if ep.RequireEndpointRoute() {
 		if ip := ep.IPv4Address(); ip.IsValid() {
-			removeEndpointRoute(ep, *iputil.AddrToIPNet(ip))
+			removeEndpointRoute(ep, *netipx.AddrIPNet(ip))
 		}
 
 		if ip := ep.IPv6Address(); ip.IsValid() {
-			removeEndpointRoute(ep, *iputil.AddrToIPNet(ip))
+			removeEndpointRoute(ep, *netipx.AddrIPNet(ip))
 		}
 	}
 

--- a/pkg/datapath/tables/direct_routing_device_test.go
+++ b/pkg/datapath/tables/direct_routing_device_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/require"
+	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/inctimer"
-	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	"github.com/cilium/cilium/pkg/node/types"
@@ -125,7 +125,7 @@ func TestDirectRoutingDevice(t *testing.T) {
 	// If one of the devices matches the K8s Node IP, it is returned.
 	want.Addrs = []DeviceAddress{
 		{
-			Addr: ip.MustAddrFromIP(testIP),
+			Addr: netipx.MustFromStdIP(testIP),
 		},
 	}
 	tctx, cancel = context.WithTimeout(ctx, time.Millisecond)

--- a/pkg/datapath/tables/node_address_test.go
+++ b/pkg/datapath/tables/node_address_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/hive"
-	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -312,8 +312,8 @@ func TestNodeAddress(t *testing.T) {
 		Name:  "cilium_host",
 		Flags: net.FlagUp,
 		Addrs: []DeviceAddress{
-			{Addr: ip.MustAddrFromIP(ciliumHostIP), Scope: RT_SCOPE_UNIVERSE},
-			{Addr: ip.MustAddrFromIP(ciliumHostIPLinkScoped), Scope: RT_SCOPE_LINK},
+			{Addr: netipx.MustFromStdIP(ciliumHostIP), Scope: RT_SCOPE_UNIVERSE},
+			{Addr: netipx.MustFromStdIP(ciliumHostIPLinkScoped), Scope: RT_SCOPE_LINK},
 		},
 		Selected: false,
 	})
@@ -410,9 +410,9 @@ func TestNodeAddressHostDevice(t *testing.T) {
 		Flags: net.FlagUp,
 		Addrs: []DeviceAddress{
 			// <SITE
-			{Addr: ip.MustAddrFromIP(ciliumHostIP), Scope: RT_SCOPE_UNIVERSE},
+			{Addr: netipx.MustFromStdIP(ciliumHostIP), Scope: RT_SCOPE_UNIVERSE},
 			// >SITE, but included
-			{Addr: ip.MustAddrFromIP(ciliumHostIPLinkScoped), Scope: RT_SCOPE_LINK},
+			{Addr: netipx.MustFromStdIP(ciliumHostIPLinkScoped), Scope: RT_SCOPE_LINK},
 			// >SITE, skipped
 			{Addr: netip.MustParseAddr("10.0.0.1"), Scope: RT_SCOPE_HOST},
 		},
@@ -605,8 +605,8 @@ func TestNodeAddressWhitelist(t *testing.T) {
 				Name:  "cilium_host",
 				Flags: net.FlagUp,
 				Addrs: []DeviceAddress{
-					{Addr: ip.MustAddrFromIP(ciliumHostIP), Scope: RT_SCOPE_UNIVERSE},
-					{Addr: ip.MustAddrFromIP(ciliumHostIPLinkScoped), Scope: RT_SCOPE_LINK},
+					{Addr: netipx.MustFromStdIP(ciliumHostIP), Scope: RT_SCOPE_UNIVERSE},
+					{Addr: netipx.MustFromStdIP(ciliumHostIPLinkScoped), Scope: RT_SCOPE_LINK},
 				},
 				Selected: false,
 			})

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -9,11 +9,11 @@ package endpoint
 import (
 	"context"
 	"fmt"
-	"net/netip"
 	"sort"
 	"strconv"
 
 	"github.com/sirupsen/logrus"
+	"go4.org/netipx"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -50,14 +50,6 @@ func (e *Endpoint) GetLabelsModel() (*models.LabelConfiguration, error) {
 	}
 	e.runlock()
 	return &cfg, nil
-}
-
-func parsePrefixOrAddr(ip string) (netip.Addr, error) {
-	prefix, err := netip.ParsePrefix(ip)
-	if err != nil {
-		return netip.ParseAddr(ip)
-	}
-	return prefix.Addr(), nil
 }
 
 // NewEndpointFromChangeModel creates a new endpoint from a request
@@ -115,7 +107,7 @@ func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, p
 
 	if base.Addressing != nil {
 		if ip := base.Addressing.IPV6; ip != "" {
-			ip6, err := parsePrefixOrAddr(ip)
+			ip6, err := netipx.ParsePrefixOrAddr(ip)
 			if err != nil {
 				return nil, err
 			}
@@ -127,7 +119,7 @@ func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, p
 		}
 
 		if ip := base.Addressing.IPV4; ip != "" {
-			ip4, err := parsePrefixOrAddr(ip)
+			ip4, err := netipx.ParsePrefixOrAddr(ip)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	"go4.org/netipx"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -37,7 +38,6 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
-	ippkg "github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/labels"
@@ -630,8 +630,8 @@ func CreateIngressEndpoint(owner regeneration.Owner, policyGetter policyRepoGett
 	ep.properties[PropertyWithouteBPFDatapath] = true
 
 	// node.GetIngressIPv4 has been parsed with net.ParseIP() and may be in IPv4 mapped IPv6
-	// address format. Use ippkg.AddrFromIP() to make sure we get a plain IPv4 address.
-	ep.IPv4, _ = ippkg.AddrFromIP(node.GetIngressIPv4())
+	// address format. Use netipx.FromStdIP() to make sure we get a plain IPv4 address.
+	ep.IPv4, _ = netipx.FromStdIP(node.GetIngressIPv4())
 	ep.IPv6, _ = netip.AddrFromSlice(node.GetIngressIPv6())
 
 	ep.setState(StateWaitingForIdentity, "Ingress Endpoint creation")

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/sirupsen/logrus"
+	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
@@ -24,7 +25,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging"
@@ -810,7 +810,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 				}
 
 				ID := e.SecurityIdentity.ID
-				hostIP, ok := ip.AddrFromIP(node.GetIPv4())
+				hostIP, ok := netipx.FromStdIP(node.GetIPv4())
 				if !ok {
 					return controller.NewExitReason("Failed to convert node IPv4 address")
 				}

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cilium/dns"
 	"github.com/sirupsen/logrus"
+	"go4.org/netipx"
 	"golang.org/x/sync/semaphore"
 	"golang.org/x/sys/unix"
 
@@ -27,7 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/proxy/ipfamily"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
-	ippkt "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -1249,12 +1249,12 @@ func ExtractMsgDetails(msg *dns.Msg) (qname string, responseIPs []netip.Addr, TT
 		switch ans := ans.(type) {
 		case *dns.A:
 			// Parsing of the DNS message does the IP validation for us.
-			responseIPs = append(responseIPs, ippkt.MustAddrFromIP(ans.A))
+			responseIPs = append(responseIPs, netipx.MustFromStdIP(ans.A))
 			if TTL > ans.Hdr.Ttl {
 				TTL = ans.Hdr.Ttl
 			}
 		case *dns.AAAA:
-			responseIPs = append(responseIPs, ippkt.MustAddrFromIP(ans.AAAA))
+			responseIPs = append(responseIPs, netipx.MustFromStdIP(ans.AAAA))
 			if TTL > ans.Hdr.Ttl {
 				TTL = ans.Hdr.Ttl
 			}

--- a/pkg/hubble/parser/sock/parser.go
+++ b/pkg/hubble/parser/sock/parser.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"go4.org/netipx"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/parser/common"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
-	ippkg "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -86,9 +86,9 @@ func (p *Parser) Decode(data []byte, decoded *flowpb.Flow) error {
 
 	// Ignore invalid IPs - getters will handle invalid values.
 	// IPs can be empty for Ethernet-only packets.
-	dstIP, _ := ippkg.AddrFromIP(sock.IP())
+	dstIP, _ := netipx.FromStdIP(sock.IP())
 	dstPort := sock.DstPort
-	srcIP, _ := ippkg.AddrFromIP(epIP)
+	srcIP, _ := netipx.FromStdIP(epIP)
 	srcPort := uint16(0) // source port is not known for TraceSock events
 
 	datapathContext := common.DatapathContext{

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/sirupsen/logrus"
+	"go4.org/netipx"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
@@ -18,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/parser/common"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
-	ippkg "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -173,7 +173,7 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	if tn != nil && ip != nil {
 		if !tn.OriginalIP().IsUnspecified() {
 			// Ignore invalid IP - getters will handle invalid value.
-			srcIP, _ = ippkg.AddrFromIP(tn.OriginalIP())
+			srcIP, _ = netipx.FromStdIP(tn.OriginalIP())
 			// On SNAT the trace notification has OrigIP set to the pre
 			// translation IP and the source IP parsed from the header is the
 			// post translation IP. The check is here because sometimes we get
@@ -330,8 +330,8 @@ func decodeEthernet(ethernet *layers.Ethernet) *pb.Ethernet {
 func decodeIPv4(ipv4 *layers.IPv4) (ip *pb.IP, src, dst netip.Addr) {
 	// Ignore invalid IPs - getters will handle invalid values.
 	// IPs can be empty for Ethernet-only packets.
-	src, _ = ippkg.AddrFromIP(ipv4.SrcIP)
-	dst, _ = ippkg.AddrFromIP(ipv4.DstIP)
+	src, _ = netipx.FromStdIP(ipv4.SrcIP)
+	dst, _ = netipx.FromStdIP(ipv4.DstIP)
 	return &pb.IP{
 		Source:      ipv4.SrcIP.String(),
 		Destination: ipv4.DstIP.String(),
@@ -342,8 +342,8 @@ func decodeIPv4(ipv4 *layers.IPv4) (ip *pb.IP, src, dst netip.Addr) {
 func decodeIPv6(ipv6 *layers.IPv6) (ip *pb.IP, src, dst netip.Addr) {
 	// Ignore invalid IPs - getters will handle invalid values.
 	// IPs can be empty for Ethernet-only packets.
-	src, _ = ippkg.AddrFromIP(ipv6.SrcIP)
-	dst, _ = ippkg.AddrFromIP(ipv6.DstIP)
+	src, _ = netipx.FromStdIP(ipv6.SrcIP)
+	dst, _ = netipx.FromStdIP(ipv6.DstIP)
 	return &pb.IP{
 		Source:      ipv6.SrcIP.String(),
 		Destination: ipv6.DstIP.String(),

--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -57,18 +57,6 @@ func ParsePrefixes(cidrs []string) (valid []netip.Prefix, invalid []string, erro
 	return valid, invalid, errors
 }
 
-// AddrToIPNet is a convenience helper to convert a netip.Addr to a *net.IPNet
-// with a mask corresponding to the addresses's bit length.
-func AddrToIPNet(addr netip.Addr) *net.IPNet {
-	if !addr.IsValid() {
-		return nil
-	}
-	return &net.IPNet{
-		IP:   addr.AsSlice(),
-		Mask: net.CIDRMask(addr.BitLen(), addr.BitLen()),
-	}
-}
-
 // IPToNetPrefix is a convenience helper for migrating from the older 'net'
 // standard library types to the newer 'netip' types. Use this to plug the new
 // types in newer code into older types in older code during the migration.

--- a/pkg/ip/cidr_test.go
+++ b/pkg/ip/cidr_test.go
@@ -11,24 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAddrToIPNet(t *testing.T) {
-	_, v4IPNet, err := net.ParseCIDR("1.1.1.1/32")
-	assert.NoError(t, err)
-	_, v6IPNet, err := net.ParseCIDR("::ff/128")
-	assert.NoError(t, err)
-
-	ip4 := netip.MustParseAddr("1.1.1.1")
-	assert.NoError(t, err)
-	assert.Equal(t, v4IPNet, AddrToIPNet(ip4))
-
-	ip6 := netip.MustParseAddr("::ff")
-	assert.NoError(t, err)
-	assert.Equal(t, v6IPNet, AddrToIPNet(ip6))
-
-	var nilNet *net.IPNet
-	assert.Equal(t, nilNet, AddrToIPNet(netip.Addr{}))
-}
-
 func TestIPToNetPrefix(t *testing.T) {
 	v4, _, err := net.ParseCIDR("1.1.1.1/32")
 	assert.NoError(t, err)

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -305,7 +305,7 @@ func PrefixToIps(prefixCidr string, maxIPs int) ([]string, error) {
 	}
 	netWithRange := ipNetToRange(*ipNet)
 	// Ensure last IP in the prefix is included
-	for ip := *netWithRange.First; len(prefixIps) < maxIPs || maxIPs == 0; ip = GetNextIP(ip) {
+	for ip := *netWithRange.First; len(prefixIps) < maxIPs || maxIPs == 0; ip = getNextIP(ip) {
 		prefixIps = append(prefixIps, ip.String())
 		if ip.Equal(*netWithRange.Last) {
 			break
@@ -368,9 +368,9 @@ func getPreviousIP(ip net.IP) net.IP {
 	return previousIP
 }
 
-// GetNextIP returns the next IP from the given IP address. If the given IP is
+// getNextIP returns the next IP from the given IP address. If the given IP is
 // the last IP of a v4 or v6 range, the same IP is returned.
-func GetNextIP(ip net.IP) net.IP {
+func getNextIP(ip net.IP) net.IP {
 	if ip.Equal(upperIPv4) || ip.Equal(upperIPv6) {
 		return ip
 	}
@@ -595,7 +595,7 @@ func rangeToCIDRs(firstIP, lastIP net.IP) []*net.IPNet {
 	if bytes.Compare(*lastIPSpanning, lastIP) > 0 {
 		// Split on the next IP of the last IP so that the left list of IPs
 		// of the partition include the lastIP.
-		nextFirstRangeIP := GetNextIP(lastIP)
+		nextFirstRangeIP := getNextIP(lastIP)
 		var bitLen int
 		if nextFirstRangeIP.To4() != nil {
 			bitLen = ipv4BitLen

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -901,31 +901,6 @@ func GetIPFromListByFamily(ipList []net.IP, v4Family bool) net.IP {
 	return nil
 }
 
-// AddrFromIP converts a net.IP to netip.Addr using netip.AddrFromSlice, but preserves
-// the original address family. It assumes given net.IP is not an IPv4 mapped IPv6
-// address.
-//
-// The problem behind this is that when we convert the IPv4 net.IP address with
-// netip.AddrFromSlice, the address is interpreted as an IPv4 mapped IPv6 address in some
-// cases.
-//
-// For example, when we do netip.AddrFromSlice(net.ParseIP("1.1.1.1")), it is interpreted
-// as an IPv6 address "::ffff:1.1.1.1". This is because 1) net.IP created with
-// net.ParseIP(IPv4 string) holds IPv4 address as an IPv4 mapped IPv6 address internally
-// and 2) netip.AddrFromSlice recognizes address family with length of the slice (4-byte =
-// IPv4 and 16-byte = IPv6).
-//
-// By using AddrFromIP, we can preserve the address family, but since we cannot distinguish
-// IPv4 and IPv4 mapped IPv6 address only from net.IP value (see #37921 on golang/go) we
-// need an assumption that given net.IP is not an IPv4 mapped IPv6 address.
-func AddrFromIP(ip net.IP) (netip.Addr, bool) {
-	addr, ok := netip.AddrFromSlice(ip)
-	if !ok {
-		return addr, ok
-	}
-	return addr.Unmap(), ok
-}
-
 // MustAddrsFromIPs converts a slice of net.IP to a slice of netip.Addr. It assumes
 // the input slice contains only valid IP addresses and always returns a slice
 // containing valid netip.Addr.

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -11,6 +11,8 @@ import (
 	"net/netip"
 	"sort"
 
+	"go4.org/netipx"
+
 	"github.com/cilium/cilium/pkg/slices"
 )
 
@@ -924,23 +926,13 @@ func AddrFromIP(ip net.IP) (netip.Addr, bool) {
 	return addr.Unmap(), ok
 }
 
-// MustAddrFromIP is the same as AddrFromIP except that it assumes the input is
-// a valid IP address and always returns a valid netip.Addr.
-func MustAddrFromIP(ip net.IP) netip.Addr {
-	addr, ok := AddrFromIP(ip)
-	if !ok {
-		panic("addr is not a valid IP address")
-	}
-	return addr
-}
-
 // MustAddrsFromIPs converts a slice of net.IP to a slice of netip.Addr. It assumes
 // the input slice contains only valid IP addresses and always returns a slice
 // containing valid netip.Addr.
 func MustAddrsFromIPs(ips []net.IP) []netip.Addr {
 	addrs := make([]netip.Addr, 0, len(ips))
 	for _, ip := range ips {
-		addrs = append(addrs, MustAddrFromIP(ip))
+		addrs = append(addrs, netipx.MustFromStdIP(ip))
 	}
 	return addrs
 }

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -984,42 +984,6 @@ func TestGetIPAtIndex(t *testing.T) {
 	}
 }
 
-func TestAddrFromIP(t *testing.T) {
-	type args struct {
-		ip       net.IP
-		wantAddr netip.Addr
-		wantOk   bool
-	}
-
-	tests := []args{
-		{
-			net.ParseIP("10.0.0.1"),
-			netip.MustParseAddr("10.0.0.1"),
-			true,
-		},
-		{
-			net.ParseIP("a::1"),
-			netip.MustParseAddr("a::1"),
-			true,
-		},
-		{
-			net.ParseIP("::ffff:10.0.0.1"),
-			netip.MustParseAddr("10.0.0.1"),
-			true,
-		},
-	}
-	for _, tt := range tests {
-		addr, ok := AddrFromIP(tt.ip)
-		if ok != tt.wantOk {
-			t.Errorf("AddrFromIP(net.IP(%v)) should success", []byte(tt.ip))
-		}
-
-		if addr != tt.wantAddr {
-			t.Errorf("AddrFromIP(net.IP(%v)) = %v want %v", []byte(tt.ip), addr, tt.wantAddr)
-		}
-	}
-}
-
 func TestMustAddrsFromIPs(t *testing.T) {
 	type args struct {
 		ips   []net.IP

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -547,47 +547,47 @@ func TestPreviousIP(t *testing.T) {
 func TestNextIP(t *testing.T) {
 	expectedNext := net.ParseIP("10.0.0.0")
 	ip := net.ParseIP("9.255.255.255")
-	nextIP := GetNextIP(ip)
+	nextIP := getNextIP(ip)
 	require.EqualValues(t, expectedNext, nextIP)
 
 	// Check that overflow does not occur.
 	ip = net.ParseIP("255.255.255.255")
-	nextIP = GetNextIP(ip)
+	nextIP = getNextIP(ip)
 	expectedNext = ip
 	require.EqualValues(t, expectedNext, nextIP)
 
 	ip = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
-	nextIP = GetNextIP(ip)
+	nextIP = getNextIP(ip)
 	expectedNext = ip
 	require.EqualValues(t, expectedNext, nextIP)
 
 	ip = []byte{0xa, 0, 0, 0}
-	nextIP = GetNextIP(ip)
+	nextIP = getNextIP(ip)
 	expectedNext = []byte{0xa, 0, 0, 1}
 	require.EqualValues(t, expectedNext, nextIP)
 
 	ip = []byte{0xff, 0xff, 0xff, 0xff}
-	nextIP = GetNextIP(ip)
+	nextIP = getNextIP(ip)
 	expectedNext = []byte{0xff, 0xff, 0xff, 0xff}
 	require.EqualValues(t, expectedNext, nextIP)
 
 	ip = net.ParseIP("10.0.0.0")
-	nextIP = GetNextIP(ip)
+	nextIP = getNextIP(ip)
 	expectedNext = net.ParseIP("10.0.0.1")
 	require.EqualValues(t, expectedNext, nextIP)
 
 	ip = net.ParseIP("0:0:0:0:ffff:ffff:ffff:ffff")
-	nextIP = GetNextIP(ip)
+	nextIP = getNextIP(ip)
 	expectedNext = net.ParseIP("0:0:0:1:0:0:0:0")
 	require.EqualValues(t, expectedNext, nextIP)
 
 	ip = net.ParseIP("ffff:ffff:ffff:fffe:ffff:ffff:ffff:ffff")
-	nextIP = GetNextIP(ip)
+	nextIP = getNextIP(ip)
 	expectedNext = net.ParseIP("ffff:ffff:ffff:ffff:0:0:0:0")
 	require.EqualValues(t, expectedNext, nextIP)
 
 	ip = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe")
-	nextIP = GetNextIP(ip)
+	nextIP = getNextIP(ip)
 	expectedNext = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
 	require.EqualValues(t, expectedNext, nextIP)
 }

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
 	"github.com/sirupsen/logrus"
+	"go4.org/netipx"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -40,7 +41,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -712,7 +712,7 @@ func (k *K8sPodWatcher) genServiceMappings(pod *slim_corev1.Pod, podIPs []string
 					}
 					loopbackHostport = true
 				}
-				nodeAddrAll = []netip.Addr{ip.MustAddrFromIP(feIP)}
+				nodeAddrAll = []netip.Addr{netipx.MustFromStdIP(feIP)}
 			} else {
 				iter := k.nodeAddrs.List(k.db.ReadTxn(), datapathTables.NodeAddressNodePortIndex.Query(true))
 				for addr, _, ok := iter.Next(); ok; addr, _, ok = iter.Next() {

--- a/pkg/maps/tunnel/tunnel.go
+++ b/pkg/maps/tunnel/tunnel.go
@@ -9,11 +9,11 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/ebpf"
-	ippkg "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/types"
 )
@@ -85,7 +85,7 @@ type TunnelKey struct {
 func (k TunnelKey) String() string {
 	if ip := k.toIP(); ip != nil {
 		addrCluster := cmtypes.AddrClusterFrom(
-			ippkg.MustAddrFromIP(ip),
+			netipx.MustFromStdIP(ip),
 			uint32(k.ClusterID),
 		)
 		return addrCluster.String()

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/vishvananda/netlink"
+	"go4.org/netipx"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -34,7 +35,6 @@ import (
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
-	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/hooks"
@@ -224,7 +224,7 @@ func addIPConfigToLink(ip netip.Addr, routes []route.Route, rules []route.Rule, 
 		logfields.Interface: ifName,
 	}).Debug("Configuring link")
 
-	addr := &netlink.Addr{IPNet: iputil.AddrToIPNet(ip)}
+	addr := &netlink.Addr{IPNet: netipx.AddrIPNet(ip)}
 	if ip.Is6() {
 		addr.Flags = unix.IFA_F_NODAD
 	}
@@ -370,7 +370,7 @@ func prepareIP(ipAddr string, state *CmdState, mtu int) (*cniTypesV1.IPConfig, [
 	}
 
 	return &cniTypesV1.IPConfig{
-		Address: *iputil.AddrToIPNet(ip),
+		Address: *netipx.AddrIPNet(ip),
 		Gateway: gwIP,
 	}, rt, nil
 }


### PR DESCRIPTION
Use the conversion functions already provided in the `go4.org/netipx` package instead of re-implementing them in `pkg/ip`.

See individual commit messages for details.

For #24246