### PR TITLE
policy: test with stopped repository

### DIFF
--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -40,7 +40,7 @@ func localIdentity(n uint32) identity.NumericIdentity {
 
 }
 func TestCacheManagement(t *testing.T) {
-	repo := NewPolicyRepository(nil, nil, nil, nil)
+	repo := NewStoppedPolicyRepository(nil, nil, nil, nil)
 	cache := repo.policyCache
 	identity := ep1.GetSecurityIdentity()
 	require.Equal(t, identity, ep2.GetSecurityIdentity())
@@ -76,7 +76,7 @@ func TestCacheManagement(t *testing.T) {
 }
 
 func TestCachePopulation(t *testing.T) {
-	repo := NewPolicyRepository(nil, nil, nil, nil)
+	repo := NewStoppedPolicyRepository(nil, nil, nil, nil)
 	repo.revision.Store(42)
 	cache := repo.policyCache
 
@@ -413,7 +413,7 @@ type policyDistillery struct {
 
 func newPolicyDistillery(selectorCache *SelectorCache) *policyDistillery {
 	ret := &policyDistillery{
-		Repository: NewPolicyRepository(nil, nil, nil, nil),
+		Repository: NewStoppedPolicyRepository(nil, nil, nil, nil),
 	}
 	ret.selectorCache = selectorCache
 	return ret

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -55,9 +55,8 @@ type testData struct {
 
 func newTestData() *testData {
 	td := &testData{
-		sc:   testNewSelectorCache(nil),
-		repo: NewPolicyRepository(nil, nil, nil, nil),
-
+		sc:                testNewSelectorCache(nil),
+		repo:              NewStoppedPolicyRepository(nil, nil, nil, nil),
 		testPolicyContext: &testPolicyContextType{},
 	}
 	td.testPolicyContext.sc = td.sc
@@ -81,7 +80,7 @@ func newTestData() *testData {
 // resetRepo clears only the policy repository.
 // Some tests rely on the accumulated state, but a clean repo.
 func (td *testData) resetRepo() *Repository {
-	td.repo = NewPolicyRepository(nil, nil, nil, nil)
+	td.repo = NewStoppedPolicyRepository(nil, nil, nil, nil)
 	td.repo.selectorCache = td.sc
 	return td.repo
 }

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -2509,7 +2509,7 @@ func TestDefaultAllow(t *testing.T) {
 func TestReplaceByResource(t *testing.T) {
 	// don't use the full testdata() here, since we want to watch
 	// selectorcache changes carefully
-	repo := NewPolicyRepository(nil, nil, nil, nil)
+	repo := NewStoppedPolicyRepository(nil, nil, nil, nil)
 	sc := testNewSelectorCache(nil)
 	repo.selectorCache = sc
 	assert.Len(t, sc.selectors, 0)


### PR DESCRIPTION
Unit tests do not need the event queues running, this cuts off ~1000 goroutines, which makes debugging test issues easier.
