### PR TITLE
policy: remove unnecessary map operations

### DIFF
--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -878,14 +878,14 @@ func (ms *mapState) RemoveDependent(owner Key, dependent Key, identities Identit
 	if e, exists := ms.allows.Lookup(owner); exists {
 		changes.insertOldIfNotExists(owner, e)
 		e.RemoveDependent(dependent)
-		ms.denies.delete(owner, identities)
+		// update the value in the allows map
 		ms.allows.upsert(owner, e, identities)
 		return
 	}
 	if e, exists := ms.denies.Lookup(owner); exists {
 		changes.insertOldIfNotExists(owner, e)
 		e.RemoveDependent(dependent)
-		ms.allows.delete(owner, identities)
+		// update the value in the denies map
 		ms.denies.upsert(owner, e, identities)
 	}
 }


### PR DESCRIPTION
Remove redundant map operations.

If key exists in the allows map, then the entry is an allow entry, and updates in the denies map are not necessary, and the other way around.
