### PR TITLE
daemon: move policy trifecta leftovers (policy, ipcache & identityallocator)  to respective cells

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/gops"
+	identity "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	ipamcell "github.com/cilium/cilium/pkg/ipam/cell"
 	ipcache "github.com/cilium/cilium/pkg/ipcache/cell"
@@ -222,8 +223,8 @@ var (
 		// Auth is responsible for authenticating a request if required by a policy.
 		auth.Cell,
 
-		// Provides the different types of IdentityAllocators
-		cell.Provide(newIdentityAllocator),
+		// Provides IdentityAllocators (Responsible for allocating security identities)
+		identity.Cell,
 
 		// IPCache cell provides IPCache (IP to identity mappings)
 		ipcache.Cell,

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	ipamcell "github.com/cilium/cilium/pkg/ipam/cell"
+	ipcache "github.com/cilium/cilium/pkg/ipcache/cell"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
@@ -221,11 +222,11 @@ var (
 		// Auth is responsible for authenticating a request if required by a policy.
 		auth.Cell,
 
-		// Provides the IPCache
-		cell.Provide(newIPCache),
-
 		// Provides the different types of IdentityAllocators
 		cell.Provide(newIdentityAllocator),
+
+		// IPCache cell provides IPCache (IP to identity mappings)
+		ipcache.Cell,
 
 		// IPAM provides IP address management.
 		ipamcell.Cell,

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -52,6 +52,7 @@ import (
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/option"
+	policy "github.com/cilium/cilium/pkg/policy/cell"
 	policyDirectory "github.com/cilium/cilium/pkg/policy/directory"
 	policyK8s "github.com/cilium/cilium/pkg/policy/k8s"
 	"github.com/cilium/cilium/pkg/pprof"
@@ -223,12 +224,6 @@ var (
 		// Provides the IPCache
 		cell.Provide(newIPCache),
 
-		// Provides PolicyRepository
-		cell.Provide(newPolicyRepo),
-
-		// Provides PolicyUpdater
-		cell.Provide(newPolicyUpdater),
-
 		// Provides the different types of IdentityAllocators
 		cell.Provide(newIdentityAllocator),
 
@@ -240,6 +235,9 @@ var (
 
 		// ServiceCache holds the list of known services correlated with the matching endpoints.
 		k8s.ServiceCacheCell,
+
+		// Provides PolicyRepository (List of policy rules)
+		policy.Cell,
 
 		// K8s policy resource watcher cell. It depends on the half-initialized daemon which is
 		// resolved by newDaemonPromise()

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/hubble/observer"
 	"github.com/cilium/cilium/pkg/identity"
+	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -139,7 +140,7 @@ type Daemon struct {
 
 	endpointRestoreComplete chan struct{}
 
-	identityAllocator CachingIdentityAllocator
+	identityAllocator identitycell.CachingIdentityAllocator
 
 	ipcache *ipcache.IPCache
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -63,6 +63,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/exporter/exporteroption"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/identity"
+	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -1668,7 +1669,7 @@ type daemonParams struct {
 	EndpointManager        endpointmanager.EndpointManager
 	CertManager            certificatemanager.CertificateManager
 	SecretManager          certificatemanager.SecretManager
-	IdentityAllocator      CachingIdentityAllocator
+	IdentityAllocator      identitycell.CachingIdentityAllocator
 	Policy                 *policy.Repository
 	IPCache                *ipcache.IPCache
 	DirectoryPolicyWatcher *policyDirectory.PolicyResourcesWatcher

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -6,120 +6,29 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/netip"
 	"sync"
 
-	"github.com/cilium/hive/cell"
-	"github.com/cilium/stream"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/google/uuid"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/policy"
 	"github.com/cilium/cilium/pkg/api"
-	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/eventqueue"
-	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
-	"github.com/cilium/cilium/pkg/node"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	policyAPI "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/safetime"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
 )
-
-type identityAllocatorParams struct {
-	cell.In
-
-	Lifecycle        cell.Lifecycle
-	PolicyRepository *policy.Repository
-	PolicyUpdater    *policy.Updater
-}
-
-type identityAllocatorOut struct {
-	cell.Out
-
-	IdentityAllocator      CachingIdentityAllocator
-	CacheIdentityAllocator cache.IdentityAllocator
-	RemoteIdentityWatcher  clustermesh.RemoteIdentityWatcher
-	IdentityObservable     stream.Observable[cache.IdentityChange]
-}
-
-func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
-	// iao: updates SelectorCache and regenerates endpoints when
-	// identity allocation / deallocation has occurred.
-	iao := &identityAllocatorOwner{
-		policy:        params.PolicyRepository,
-		policyUpdater: params.PolicyUpdater,
-	}
-
-	// Allocator: allocates local and cluster-wide security identities.
-	idAlloc := cache.NewCachingIdentityAllocator(iao)
-	idAlloc.EnableCheckpointing()
-
-	params.Lifecycle.Append(cell.Hook{
-		OnStop: func(hc cell.HookContext) error {
-			idAlloc.Close()
-			return nil
-		},
-	})
-
-	return identityAllocatorOut{
-		IdentityAllocator:      idAlloc,
-		CacheIdentityAllocator: idAlloc,
-		RemoteIdentityWatcher:  idAlloc,
-		IdentityObservable:     idAlloc,
-	}
-}
-
-// identityAllocatorOwner is used to break the circular dependency between
-// CachingIdentityAllocator and policy.Repository.
-type identityAllocatorOwner struct {
-	policy        *policy.Repository
-	policyUpdater *policy.Updater
-}
-
-// UpdateIdentities informs the policy package of all identity changes
-// and also triggers policy updates.
-//
-// The caller is responsible for making sure the same identity is not
-// present in both 'added' and 'deleted'.
-func (iao *identityAllocatorOwner) UpdateIdentities(added, deleted identity.IdentityMap) {
-	wg := &sync.WaitGroup{}
-	iao.policy.GetSelectorCache().UpdateIdentities(added, deleted, wg)
-	// Wait for update propagation to endpoints before triggering policy updates
-	wg.Wait()
-	iao.policyUpdater.TriggerPolicyUpdates(false, "one or more identities created or deleted")
-}
-
-// GetNodeSuffix returns the suffix to be appended to kvstore keys of this
-// agent
-func (iao *identityAllocatorOwner) GetNodeSuffix() string {
-	var ip net.IP
-
-	switch {
-	case option.Config.EnableIPv4:
-		ip = node.GetIPv4()
-	case option.Config.EnableIPv6:
-		ip = node.GetIPv6()
-	}
-
-	if ip == nil {
-		log.Fatal("Node IP not available yet")
-	}
-
-	return ip.String()
-}
 
 // PolicyAddEvent is a wrapper around the parameters for policyAdd.
 type PolicyAddEvent struct {

--- a/pkg/identity/cache/cell/cell.go
+++ b/pkg/identity/cache/cell/cell.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package identitycachecell
+
+import (
+	"log"
+	"net"
+	"sync"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/stream"
+
+	"github.com/cilium/cilium/pkg/clustermesh"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+// Cell provides the IdentityAllocator for allocating security identities
+var Cell = cell.Module(
+	"identity",
+	"Allocating and managing security identities",
+
+	cell.Provide(newIdentityAllocator),
+)
+
+// CachingIdentityAllocator provides an abstraction over the concrete type in
+// pkg/identity/cache so that the underlying implementation can be mocked out
+// in unit tests.
+type CachingIdentityAllocator interface {
+	cache.IdentityAllocator
+	clustermesh.RemoteIdentityWatcher
+
+	InitIdentityAllocator(versioned.Interface) <-chan struct{}
+
+	// RestoreLocalIdentities reads in the checkpointed local allocator state
+	// from disk and allocates a reference to every previously existing identity.
+	//
+	// Once all identity-allocating objects are synchronized (e.g. network policies,
+	// remote nodes), call ReleaseRestoredIdentities to release the held references.
+	RestoreLocalIdentities() (map[identity.NumericIdentity]*identity.Identity, error)
+
+	// ReleaseRestoredIdentities releases any identities that were restored, reducing their reference
+	// count and cleaning up as necessary.
+	ReleaseRestoredIdentities()
+
+	Close()
+}
+
+type identityAllocatorParams struct {
+	cell.In
+
+	Lifecycle        cell.Lifecycle
+	PolicyRepository *policy.Repository
+	PolicyUpdater    *policy.Updater
+}
+
+type identityAllocatorOut struct {
+	cell.Out
+
+	IdentityAllocator      CachingIdentityAllocator
+	CacheIdentityAllocator cache.IdentityAllocator
+	RemoteIdentityWatcher  clustermesh.RemoteIdentityWatcher
+	IdentityObservable     stream.Observable[cache.IdentityChange]
+}
+
+func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
+	// iao: updates SelectorCache and regenerates endpoints when
+	// identity allocation / deallocation has occurred.
+	iao := &identityAllocatorOwner{
+		policy:        params.PolicyRepository,
+		policyUpdater: params.PolicyUpdater,
+	}
+
+	// Allocator: allocates local and cluster-wide security identities.
+	idAlloc := cache.NewCachingIdentityAllocator(iao)
+	idAlloc.EnableCheckpointing()
+
+	params.Lifecycle.Append(cell.Hook{
+		OnStop: func(hc cell.HookContext) error {
+			idAlloc.Close()
+			return nil
+		},
+	})
+
+	return identityAllocatorOut{
+		IdentityAllocator:      idAlloc,
+		CacheIdentityAllocator: idAlloc,
+		RemoteIdentityWatcher:  idAlloc,
+		IdentityObservable:     idAlloc,
+	}
+}
+
+// identityAllocatorOwner is used to break the circular dependency between
+// CachingIdentityAllocator and policy.Repository.
+type identityAllocatorOwner struct {
+	policy        *policy.Repository
+	policyUpdater *policy.Updater
+}
+
+// UpdateIdentities informs the policy package of all identity changes
+// and also triggers policy updates.
+//
+// The caller is responsible for making sure the same identity is not
+// present in both 'added' and 'deleted'.
+func (iao *identityAllocatorOwner) UpdateIdentities(added, deleted identity.IdentityMap) {
+	wg := &sync.WaitGroup{}
+	iao.policy.GetSelectorCache().UpdateIdentities(added, deleted, wg)
+	// Wait for update propagation to endpoints before triggering policy updates
+	wg.Wait()
+	iao.policyUpdater.TriggerPolicyUpdates(false, "one or more identities created or deleted")
+}
+
+// GetNodeSuffix returns the suffix to be appended to kvstore keys of this
+// agent
+func (iao *identityAllocatorOwner) GetNodeSuffix() string {
+	var ip net.IP
+
+	switch {
+	case option.Config.EnableIPv4:
+		ip = node.GetIPv4()
+	case option.Config.EnableIPv6:
+		ip = node.GetIPv6()
+	}
+
+	if ip == nil {
+		log.Fatal("Node IP not available yet")
+	}
+
+	return ip.String()
+}

--- a/pkg/ipcache/cell/cell.go
+++ b/pkg/ipcache/cell/cell.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcachecell
+
+import (
+	"context"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/k8s/synced"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+// Cell provides the IPCache that manages the IP to identity mappings.
+var Cell = cell.Module(
+	"ipcache",
+	"Managing IP to identity mappings",
+
+	cell.Provide(newIPCache),
+)
+
+type ipCacheParams struct {
+	cell.In
+
+	Lifecycle              cell.Lifecycle
+	CacheIdentityAllocator cache.IdentityAllocator
+	PolicyRepository       *policy.Repository
+	EndpointManager        endpointmanager.EndpointManager
+	CacheStatus            synced.CacheStatus
+}
+
+func newIPCache(params ipCacheParams) *ipcache.IPCache {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// IPCache: aggregates node-local prefix labels and allocates
+	// local identities. Generates incremental updates, pushes
+	// to endpoints.
+	ipc := ipcache.NewIPCache(&ipcache.Configuration{
+		Context:           ctx,
+		IdentityAllocator: params.CacheIdentityAllocator,
+		PolicyHandler:     params.PolicyRepository.GetSelectorCache(),
+		DatapathHandler:   params.EndpointManager,
+		CacheStatus:       params.CacheStatus,
+	})
+
+	params.Lifecycle.Append(cell.Hook{
+		OnStop: func(hc cell.HookContext) error {
+			cancel()
+
+			return ipc.Shutdown()
+		},
+	})
+
+	return ipc
+}

--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policycell
+
+import (
+	"github.com/cilium/hive/cell"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/envoy"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+// Cell provides the PolicyRepository and PolicyUpdater.
+var Cell = cell.Module(
+	"policy",
+	"Contains policy rules",
+
+	cell.Provide(newPolicyRepo),
+	cell.Provide(newPolicyUpdater),
+)
+
+type policyRepoParams struct {
+	cell.In
+
+	Lifecycle       cell.Lifecycle
+	CertManager     certificatemanager.CertificateManager
+	SecretManager   certificatemanager.SecretManager
+	IdentityManager *identitymanager.IdentityManager
+	ClusterInfo     cmtypes.ClusterInfo
+}
+
+func newPolicyRepo(params policyRepoParams) *policy.Repository {
+	if option.Config.EnableWellKnownIdentities {
+		// Must be done before calling policy.NewPolicyRepository() below.
+		num := identity.InitWellKnownIdentities(option.Config, params.ClusterInfo)
+		metrics.Identity.WithLabelValues(identity.WellKnownIdentityType).Add(float64(num))
+		identity.WellKnown.ForEach(func(i *identity.Identity) {
+			for labelSource := range i.Labels.CollectSources() {
+				metrics.IdentityLabelSources.WithLabelValues(labelSource).Inc()
+			}
+		})
+	}
+
+	// policy repository: maintains list of active Rules and their subject
+	// security identities. Also constructs the SelectorCache, a precomputed
+	// cache of label selector -> identities for policy peers.
+	policyRepo := policy.NewStoppedPolicyRepository(
+		identity.ListReservedIdentities(), // Load SelectorCache with reserved identities
+		params.CertManager,
+		params.SecretManager,
+		params.IdentityManager,
+	)
+	policyRepo.SetEnvoyRulesFunc(envoy.GetEnvoyHTTPRules)
+
+	params.Lifecycle.Append(cell.Hook{
+		OnStart: func(hc cell.HookContext) error {
+			policyRepo.Start()
+			return nil
+		},
+	})
+
+	return policyRepo
+}
+
+type policyUpdaterParams struct {
+	cell.In
+
+	Lifecycle        cell.Lifecycle
+	PolicyRepository *policy.Repository
+	EndpointManager  endpointmanager.EndpointManager
+}
+
+func newPolicyUpdater(params policyUpdaterParams) *policy.Updater {
+	// policyUpdater: forces policy recalculation on all endpoints.
+	// Called for various events, such as named port changes
+	// or certain identity updates.
+	policyUpdater := policy.NewUpdater(params.PolicyRepository, params.EndpointManager)
+
+	params.Lifecycle.Append(cell.Hook{
+		OnStop: func(hc cell.HookContext) error {
+			policyUpdater.Shutdown()
+			return nil
+		},
+	})
+
+	return policyUpdater
+}


### PR DESCRIPTION
Please review the individual commits.

Follow-up of #34332