### PR TITLE
Compact policy key

### DIFF
--- a/cilium-dbg/cmd/helpers.go
+++ b/cilium-dbg/cmd/helpers.go
@@ -346,15 +346,15 @@ func updatePolicyKey(pa *PolicyUpdateArgs, add bool) {
 				err       error
 			)
 			if pa.isDeny {
-				err = policyMap.Deny(pa.label, pa.port, policymap.SinglePortMask, u8p, pa.trafficDirection)
+				err = policyMap.Deny(pa.trafficDirection, pa.label, u8p, pa.port, policymap.SinglePortPrefixLen)
 			} else {
-				err = policyMap.Allow(pa.label, pa.port, policymap.SinglePortMask, u8p, pa.trafficDirection, authType, proxyPort)
+				err = policyMap.Allow(pa.trafficDirection, pa.label, u8p, pa.port, policymap.SinglePortPrefixLen, authType, proxyPort)
 			}
 			if err != nil {
 				Fatalf("Cannot add policy key '%s': %s\n", entry, err)
 			}
 		} else {
-			if err := policyMap.Delete(pa.label, pa.port, policymap.SinglePortMask, u8p, pa.trafficDirection); err != nil {
+			if err := policyMap.Delete(pa.trafficDirection, pa.label, u8p, pa.port, policymap.SinglePortPrefixLen); err != nil {
 				Fatalf("Cannot delete policy key '%s': %s\n", entry, err)
 			}
 		}

--- a/cilium-dbg/cmd/helpers.go
+++ b/cilium-dbg/cmd/helpers.go
@@ -206,14 +206,14 @@ type PolicyUpdateArgs struct {
 	trafficDirection trafficdirection.TrafficDirection
 
 	// label represents the identity of the label provided as argument.
-	label uint32
+	label identity.NumericIdentity
 
 	// port represents the port associated with the command, if specified.
 	port uint16
 
 	// protocols represents the set of protocols associated with the
 	// command, if specified.
-	protocols []uint8
+	protocols []u8proto.U8proto
 
 	isDeny bool
 }
@@ -286,10 +286,10 @@ func parsePolicyUpdateArgsHelper(args []string, isDeny bool) (*PolicyUpdateArgs,
 	if err != nil {
 		return nil, fmt.Errorf("Failed to convert %s", args[2])
 	}
-	label := uint32(peerLbl)
+	label := identity.NumericIdentity(peerLbl)
 
 	port := uint16(0)
-	protos := []uint8{}
+	protos := []u8proto.U8proto{}
 	if len(args) > 3 {
 		pp, err := parseL4PortsSlice([]string{args[3]})
 		if err != nil {
@@ -300,10 +300,10 @@ func parsePolicyUpdateArgsHelper(args []string, isDeny bool) (*PolicyUpdateArgs,
 			proto, _ := u8proto.ParseProtocol(pp[0].Protocol)
 			if proto == 0 {
 				for _, proto := range u8proto.ProtoIDs {
-					protos = append(protos, uint8(proto))
+					protos = append(protos, proto)
 				}
 			} else {
-				protos = append(protos, uint8(proto))
+				protos = append(protos, proto)
 			}
 		}
 	}

--- a/cilium-dbg/cmd/helpers_test.go
+++ b/cilium-dbg/cmd/helpers_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -553,15 +554,15 @@ func TestParseTrafficString(t *testing.T) {
 }
 
 func TestParsePolicyUpdateArgsHelper(t *testing.T) {
-	sortProtos := func(ints []uint8) {
+	sortProtos := func(ints []u8proto.U8proto) {
 		sort.Slice(ints, func(i, j int) bool {
 			return ints[i] < ints[j]
 		})
 	}
 
-	allProtos := []uint8{}
+	allProtos := []u8proto.U8proto{}
 	for _, proto := range u8proto.ProtoIDs {
-		allProtos = append(allProtos, uint8(proto))
+		allProtos = append(allProtos, proto)
 	}
 
 	tests := []struct {
@@ -569,9 +570,9 @@ func TestParsePolicyUpdateArgsHelper(t *testing.T) {
 		invalid          bool
 		mapBaseName      string
 		trafficDirection trafficdirection.TrafficDirection
-		peerLbl          uint32
+		peerLbl          identity.NumericIdentity
 		port             uint16
-		protos           []uint8
+		protos           []u8proto.U8proto
 		isDeny           bool
 	}{
 		{
@@ -581,7 +582,7 @@ func TestParsePolicyUpdateArgsHelper(t *testing.T) {
 			trafficDirection: trafficdirection.Ingress,
 			peerLbl:          12345,
 			port:             0,
-			protos:           []uint8{0},
+			protos:           []u8proto.U8proto{u8proto.ANY},
 		},
 		{
 			args:             []string{"123", "egress", "12345", "1/tcp"},
@@ -590,7 +591,7 @@ func TestParsePolicyUpdateArgsHelper(t *testing.T) {
 			trafficDirection: trafficdirection.Egress,
 			peerLbl:          12345,
 			port:             1,
-			protos:           []uint8{uint8(u8proto.TCP)},
+			protos:           []u8proto.U8proto{u8proto.TCP},
 		},
 		{
 			args:             []string{"123", "ingress", "12345", "1"},
@@ -619,7 +620,7 @@ func TestParsePolicyUpdateArgsHelper(t *testing.T) {
 			trafficDirection: trafficdirection.Ingress,
 			peerLbl:          12345,
 			port:             0,
-			protos:           []uint8{0},
+			protos:           []u8proto.U8proto{u8proto.ANY},
 		},
 		{
 			args:             []string{"123", "egress", "12345", "1/tcp"},
@@ -629,7 +630,7 @@ func TestParsePolicyUpdateArgsHelper(t *testing.T) {
 			trafficDirection: trafficdirection.Egress,
 			peerLbl:          12345,
 			port:             1,
-			protos:           []uint8{uint8(u8proto.TCP)},
+			protos:           []u8proto.U8proto{u8proto.TCP},
 		},
 		{
 			args:             []string{"123", "ingress", "12345", "1"},

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1129,7 +1129,7 @@ func (e *Endpoint) updatePolicyMapPressureMetric() {
 func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool) bool {
 	// Convert from policy.Key to policymap.Key
 	policymapKey := policymap.NewKey(keyToDelete.Identity, keyToDelete.DestPort, keyToDelete.PortMask(),
-		keyToDelete.Nexthdr, keyToDelete.TrafficDirection)
+		keyToDelete.Nexthdr, keyToDelete.TrafficDirection())
 
 	// Do not error out if the map entry was already deleted from the bpf map.
 	// Incremental updates depend on this being OK in cases where identity change
@@ -1163,7 +1163,7 @@ func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool) boo
 func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry, incremental bool) bool {
 	// Convert from policy.Key to policymap.Key
 	policymapKey := policymap.NewKey(keyToAdd.Identity, keyToAdd.DestPort, keyToAdd.PortMask(),
-		keyToAdd.Nexthdr, keyToAdd.TrafficDirection)
+		keyToAdd.Nexthdr, keyToAdd.TrafficDirection())
 
 	var err error
 	if entry.IsDeny {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1128,8 +1128,7 @@ func (e *Endpoint) updatePolicyMapPressureMetric() {
 
 func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool) bool {
 	// Convert from policy.Key to policymap.Key
-	policymapKey := policymap.NewKey(keyToDelete.Identity, keyToDelete.DestPort, keyToDelete.PortMask(),
-		keyToDelete.Nexthdr, keyToDelete.TrafficDirection())
+	policymapKey := policymap.NewKey(keyToDelete.TrafficDirection(), keyToDelete.Identity, keyToDelete.Nexthdr, keyToDelete.DestPort, keyToDelete.PortPrefixLen())
 
 	// Do not error out if the map entry was already deleted from the bpf map.
 	// Incremental updates depend on this being OK in cases where identity change
@@ -1162,8 +1161,7 @@ func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool) boo
 
 func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry, incremental bool) bool {
 	// Convert from policy.Key to policymap.Key
-	policymapKey := policymap.NewKey(keyToAdd.Identity, keyToAdd.DestPort, keyToAdd.PortMask(),
-		keyToAdd.Nexthdr, keyToAdd.TrafficDirection())
+	policymapKey := policymap.NewKey(keyToAdd.TrafficDirection(), keyToAdd.Identity, keyToAdd.Nexthdr, keyToAdd.DestPort, keyToAdd.PortPrefixLen())
 
 	var err error
 	if entry.IsDeny {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1395,12 +1395,9 @@ func (e *Endpoint) dumpPolicyMapToMapState() (policy.MapState, error) {
 	cb := func(key bpf.MapKey, value bpf.MapValue) {
 		policymapKey := key.(*policymap.PolicyKey)
 		// Convert from policymap.Key to policy.Key
-		policyKey := policy.NewKey(
-			trafficdirection.TrafficDirection(policymapKey.TrafficDirection),
-			identity.NumericIdentity(policymapKey.Identity),
-			u8proto.U8proto(policymapKey.Nexthdr),
-			policymapKey.GetDestPort(),
-			policymapKey.GetPortPrefixLen())
+		policyKey := policy.KeyForDirection(trafficdirection.TrafficDirection(policymapKey.TrafficDirection)).
+			WithIdentity(identity.NumericIdentity(policymapKey.Identity)).
+			WithPortProtoPrefix(u8proto.U8proto(policymapKey.Nexthdr), policymapKey.GetDestPort(), policymapKey.GetPortPrefixLen())
 		policymapEntry := value.(*policymap.PolicyEntry)
 		// Convert from policymap.PolicyEntry to policy.MapStateEntry.
 		policyEntry := policy.MapStateEntry{

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -53,7 +53,6 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
@@ -788,11 +787,7 @@ func (e *Endpoint) Allows(id identity.NumericIdentity) bool {
 	e.unconditionalRLock()
 	defer e.runlock()
 
-	keyToLookup := policy.Key{
-		Identity:         uint32(id),
-		InvertedPortMask: 0xffff, // this is a wildcard
-		TrafficDirection: trafficdirection.Ingress.Uint8(),
-	}
+	keyToLookup := policy.IngressL3OnlyKey(uint32(id))
 
 	v, ok := e.desiredPolicy.GetPolicyMap().Get(keyToLookup)
 	return ok && !v.IsDeny

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -787,7 +787,7 @@ func (e *Endpoint) Allows(id identity.NumericIdentity) bool {
 	e.unconditionalRLock()
 	defer e.runlock()
 
-	keyToLookup := policy.IngressL3OnlyKey(id)
+	keyToLookup := policy.IngressKey().WithIdentity(id)
 
 	v, ok := e.desiredPolicy.GetPolicyMap().Get(keyToLookup)
 	return ok && !v.IsDeny

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -787,7 +787,7 @@ func (e *Endpoint) Allows(id identity.NumericIdentity) bool {
 	e.unconditionalRLock()
 	defer e.runlock()
 
-	keyToLookup := policy.IngressL3OnlyKey(uint32(id))
+	keyToLookup := policy.IngressL3OnlyKey(id)
 
 	v, ok := e.desiredPolicy.GetPolicyMap().Get(keyToLookup)
 	return ok && !v.IsDeny

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -34,6 +34,7 @@ import (
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 	"github.com/cilium/cilium/pkg/types"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 type EndpointSuite struct {
@@ -553,7 +554,7 @@ func TestProxyID(t *testing.T) {
 	id, port, proto := e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true}, "")
 	require.NotEqual(t, "", id)
 	require.Equal(t, uint16(8080), port)
-	require.Equal(t, uint8(6), proto)
+	require.Equal(t, u8proto.TCP, proto)
 
 	endpointID, ingress, protocol, port, listener, err := policy.ParseProxyID(id)
 	require.Equal(t, uint16(123), endpointID)
@@ -566,7 +567,7 @@ func TestProxyID(t *testing.T) {
 	id, port, proto = e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true, L7Parser: policy.ParserTypeCRD}, "test-listener")
 	require.NotEqual(t, "", id)
 	require.Equal(t, uint16(8080), port)
-	require.Equal(t, uint8(6), proto)
+	require.Equal(t, u8proto.TCP, proto)
 	endpointID, ingress, protocol, port, listener, err = policy.ParseProxyID(id)
 	require.Equal(t, uint16(123), endpointID)
 	require.Equal(t, true, ingress)
@@ -579,7 +580,7 @@ func TestProxyID(t *testing.T) {
 	id, port, proto = e.proxyID(&policy.L4Filter{PortName: "foobar", Protocol: api.ProtoTCP, Ingress: true}, "")
 	require.Equal(t, "", id)
 	require.Equal(t, uint16(0), port)
-	require.Equal(t, uint8(0), proto)
+	require.Equal(t, u8proto.ANY, proto)
 }
 
 func TestEndpoint_GetK8sPodLabels(t *testing.T) {

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -187,7 +187,7 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 		res.endpointPolicy.ConsumeMapChanges()
 		haveIDs := make(sets.Set[identity.NumericIdentity], testfactor)
 		res.endpointPolicy.GetPolicyMap().ForEach(func(k policy.Key, _ policy.MapStateEntry) bool {
-			haveIDs.Insert(identity.NumericIdentity(k.Identity))
+			haveIDs.Insert(k.Identity)
 			return true
 		})
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -54,8 +54,8 @@ func setupRedirectSuite(tb testing.TB) *RedirectSuite {
 	<-s.mgr.InitIdentityAllocator(nil)
 
 	identityCache := identity.IdentityMap{
-		identity.NumericIdentity(identityFoo): labelsFoo,
-		identity.NumericIdentity(identityBar): labelsBar,
+		identityFoo: labelsFoo,
+		identityBar: labelsBar,
 	}
 
 	s.do.idmgr = identitymanager.NewIdentityManager()
@@ -209,7 +209,7 @@ func (s *RedirectSuite) NewTestEndpoint(t *testing.T) *Endpoint {
 	ep := NewTestEndpointWithState(t, s.do, s.do, testipcache.NewMockIPCache(), s.rsp, s.mgr, 12345, StateRegenerating)
 	ep.SetPropertyValue(PropertyFakeEndpoint, false)
 
-	epIdentity, _, err := s.mgr.AllocateIdentity(context.Background(), labelsBar.Labels(), true, identity.NumericIdentity(identityBar))
+	epIdentity, _, err := s.mgr.AllocateIdentity(context.Background(), labelsBar.Labels(), true, identityBar)
 	require.Nil(t, err)
 	ep.SetIdentity(epIdentity, true)
 
@@ -245,7 +245,7 @@ func TestAddVisibilityRedirects(t *testing.T) {
 
 	_, err, _, _ = ep.addNewRedirects(cmp)
 	require.Nil(t, err)
-	v, ok := ep.desiredPolicy.GetPolicyMap().Get(policy.IngressKey(0, uint8(u8proto.TCP), 80, 0))
+	v, ok := ep.desiredPolicy.GetPolicyMap().Get(policy.IngressKey(0, u8proto.TCP, 80, 0))
 	require.Equal(t, true, ok)
 	require.Equal(t, httpPort, v.ProxyPort)
 
@@ -261,7 +261,7 @@ func TestAddVisibilityRedirects(t *testing.T) {
 
 	d, err, _, _ := ep.addNewRedirects(cmp)
 	require.Nil(t, err)
-	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.IngressKey(0, uint8(u8proto.TCP), 80, 0))
+	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.IngressKey(0, u8proto.TCP, 80, 0))
 	require.Equal(t, true, ok)
 	// Check that proxyport was updated accordingly.
 	require.Equal(t, kafkaPort, v.ProxyPort)
@@ -280,15 +280,15 @@ func TestAddVisibilityRedirects(t *testing.T) {
 	realizedRedirects := ep.GetRealizedRedirects()
 	d2, err, _, _ := ep.addNewRedirects(cmp)
 	require.Nil(t, err)
-	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.IngressKey(0, uint8(u8proto.TCP), 80, 0))
+	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.IngressKey(0, u8proto.TCP, 80, 0))
 	require.Equal(t, true, ok)
 	require.Equal(t, kafkaPort, v.ProxyPort)
 
-	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.IngressKey(0, uint8(u8proto.TCP), 80, 0))
+	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.IngressKey(0, u8proto.TCP, 80, 0))
 	require.Equal(t, true, ok)
 	require.Equal(t, kafkaPort, v.ProxyPort)
 
-	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.EgressKey(0, uint8(u8proto.TCP), 80, 0))
+	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.EgressKey(0, u8proto.TCP, 80, 0))
 	require.Equal(t, true, ok)
 	require.Equal(t, httpPort, v.ProxyPort)
 	pID := policy.ProxyID(ep.ID, false, u8proto.TCP.String(), uint16(80), "")
@@ -322,13 +322,13 @@ func TestAddVisibilityRedirects(t *testing.T) {
 
 var (
 	// Identity, labels, selectors for an endpoint named "foo"
-	identityFoo = uint32(100)
+	identityFoo = identity.NumericIdentity(100)
 	labelsFoo   = labels.ParseSelectLabelArray("foo", "red")
 	selectFoo_  = api.NewESFromLabels(labels.ParseSelectLabel("foo"))
 	selectRed_  = api.NewESFromLabels(labels.ParseSelectLabel("red"))
 	denyFooL3__ = selectFoo_
 
-	identityBar = uint32(200)
+	identityBar = identity.NumericIdentity(200)
 
 	labelsBar  = labels.ParseSelectLabelArray("bar", "blue")
 	selectBar_ = api.NewESFromLabels(labels.ParseSelectLabel("bar"))

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -245,7 +245,7 @@ func TestAddVisibilityRedirects(t *testing.T) {
 
 	_, err, _, _ = ep.addNewRedirects(cmp)
 	require.Nil(t, err)
-	v, ok := ep.desiredPolicy.GetPolicyMap().Get(policy.IngressKey(0, u8proto.TCP, 80, 0))
+	v, ok := ep.desiredPolicy.GetPolicyMap().Get(policy.IngressKey().WithTCPPort(80))
 	require.Equal(t, true, ok)
 	require.Equal(t, httpPort, v.ProxyPort)
 
@@ -261,7 +261,7 @@ func TestAddVisibilityRedirects(t *testing.T) {
 
 	d, err, _, _ := ep.addNewRedirects(cmp)
 	require.Nil(t, err)
-	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.IngressKey(0, u8proto.TCP, 80, 0))
+	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.IngressKey().WithTCPPort(80))
 	require.Equal(t, true, ok)
 	// Check that proxyport was updated accordingly.
 	require.Equal(t, kafkaPort, v.ProxyPort)
@@ -280,15 +280,15 @@ func TestAddVisibilityRedirects(t *testing.T) {
 	realizedRedirects := ep.GetRealizedRedirects()
 	d2, err, _, _ := ep.addNewRedirects(cmp)
 	require.Nil(t, err)
-	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.IngressKey(0, u8proto.TCP, 80, 0))
+	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.IngressKey().WithTCPPort(80))
 	require.Equal(t, true, ok)
 	require.Equal(t, kafkaPort, v.ProxyPort)
 
-	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.IngressKey(0, u8proto.TCP, 80, 0))
+	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.IngressKey().WithTCPPort(80))
 	require.Equal(t, true, ok)
 	require.Equal(t, kafkaPort, v.ProxyPort)
 
-	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.EgressKey(0, u8proto.TCP, 80, 0))
+	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.EgressKey().WithTCPPort(80))
 	require.Equal(t, true, ok)
 	require.Equal(t, httpPort, v.ProxyPort)
 	pID := policy.ProxyID(ep.ID, false, u8proto.TCP.String(), uint16(80), "")
@@ -367,10 +367,10 @@ var (
 		policy.LabelAllowAnyEgress,
 		labels.LabelSourceReserved)}
 
-	mapKeyAllL7     = policy.IngressKey(0, 6, 80, 0)
-	mapKeyFoo       = policy.IngressL3OnlyKey(identityFoo)
-	mapKeyFooL7     = policy.IngressKey(identityFoo, 6, 80, 0)
-	mapKeyAllowAllE = policy.EgressL3OnlyKey(0)
+	mapKeyAllL7     = policy.IngressKey().WithTCPPort(80)
+	mapKeyFoo       = policy.IngressKey().WithIdentity(identityFoo)
+	mapKeyFooL7     = policy.IngressKey().WithIdentity(identityFoo).WithTCPPort(80)
+	mapKeyAllowAllE = policy.EgressKey()
 )
 
 // combineL4L7 returns a new PortRule that refers to the specified l4 ports and

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1624,7 +1624,7 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 
 		port := l4.Port
 		if port == 0 && l4.PortName != "" {
-			port = ep.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
+			port = ep.GetNamedPort(l4.Ingress, l4.PortName, l4.U8Proto)
 			if port == 0 {
 				return true // Skip if a named port can not be resolved (yet)
 			}

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -20,18 +20,13 @@ import (
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
-const (
-	udpProto = uint8(u8proto.UDP)
-	tcpProto = uint8(u8proto.TCP)
-)
-
 func TestSetPortRulesForID(t *testing.T) {
 	re.InitRegexCompileLRU(1)
 	rules := policy.L7DataMap{}
 	epID := uint64(1)
 	pea := perEPAllow{}
 	cache := make(regexCache)
-	udpProtoPort8053 := restore.MakeV2PortProto(8053, udpProto)
+	udpProtoPort8053 := restore.MakeV2PortProto(8053, u8proto.UDP)
 
 	rules[new(MockCachedSelector)] = &policy.PerSelectorPolicy{
 		L7Rules: api.L7Rules{
@@ -92,7 +87,7 @@ func TestSetPortRulesForIDFromUnifiedFormat(t *testing.T) {
 	epID := uint64(1)
 	pea := perEPAllow{}
 	cache := make(regexCache)
-	udpProtoPort8053 := restore.MakeV2PortProto(8053, udpProto)
+	udpProtoPort8053 := restore.MakeV2PortProto(8053, u8proto.UDP)
 	rules[new(MockCachedSelector)] = regexp.MustCompile("^.*[.]cilium[.]io$")
 	rules[new(MockCachedSelector)] = regexp.MustCompile("^.*[.]cilium[.]io$")
 

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -1028,7 +1028,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		p.sendRefused(scopedLog, w, request)
 		return
 	}
-	targetServerPortProto := restore.MakeV2PortProto(targetServer.Port(), uint8(proto))
+	targetServerPortProto := restore.MakeV2PortProto(targetServer.Port(), proto)
 
 	// Ignore invalid IP - getter will handle invalid value.
 	targetServerID := identity.GetWorldIdentityFromIP(targetServer.Addr())

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -133,7 +133,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 	s.proxy.lookupTargetDNSServer = func(w dns.ResponseWriter) (network u8proto.U8proto, server netip.AddrPort, err error) {
 		return u8proto.UDP, DNSServerListenerAddr.AddrPort(), nil
 	}
-	dstPortProto = restore.MakeV2PortProto(uint16(DNSServerListenerAddr.Port), udpProto)
+	dstPortProto = restore.MakeV2PortProto(uint16(DNSServerListenerAddr.Port), u8proto.UDP)
 
 	tb.Cleanup(func() {
 		for epID := range s.proxy.allowed {
@@ -267,11 +267,11 @@ var (
 	dstID2           = identity.NumericIdentity(2002)
 	dstID3           = identity.NumericIdentity(3003)
 	dstID4           = identity.NumericIdentity(4004)
-	dstPortProto     = restore.MakeV2PortProto(53, udpProto) // Set below when we setup the server!
+	dstPortProto     = restore.MakeV2PortProto(53, u8proto.UDP) // Set below when we setup the server!
 	udpProtoPort53   = dstPortProto
-	udpProtoPort54   = restore.MakeV2PortProto(54, udpProto)
-	udpProtoPort8053 = restore.MakeV2PortProto(8053, udpProto)
-	tcpProtoPort53   = restore.MakeV2PortProto(53, tcpProto)
+	udpProtoPort54   = restore.MakeV2PortProto(54, u8proto.UDP)
+	udpProtoPort8053 = restore.MakeV2PortProto(8053, u8proto.UDP)
+	tcpProtoPort53   = restore.MakeV2PortProto(53, u8proto.TCP)
 )
 
 func TestRejectFromDifferentEndpoint(t *testing.T) {
@@ -943,18 +943,18 @@ func TestFullPathDependence(t *testing.T) {
 
 	expected := `
 	{
-		"` + restore.MakeV2PortProto(53, tcpProto).String() + `":[{
+		"` + restore.MakeV2PortProto(53, u8proto.TCP).String() + `":[{
 			"Re":"^(?:sub[.]ubuntu[.]com[.])$",
 			"IPs":{"::":{}}
 		}],
-		"` + restore.MakeV2PortProto(53, udpProto).String() + `":[{
+		"` + restore.MakeV2PortProto(53, u8proto.UDP).String() + `":[{
 			"Re":"^(?:[-a-zA-Z0-9_]*[.]ubuntu[.]com[.]|aws[.]amazon[.]com[.])$",
 			"IPs":{"::":{}}
 		},{
 			"Re":"^(?:cilium[.]io[.])$",
 			"IPs":{"127.0.0.1":{},"127.0.0.2":{}}
 		}],
-		"` + restore.MakeV2PortProto(54, udpProto).String() + `":[{
+		"` + restore.MakeV2PortProto(54, u8proto.UDP).String() + `":[{
 			"Re":"^(?:example[.]com[.])$",
 			"IPs":null
 		}]

--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -14,6 +14,8 @@ import (
 	"net/netip"
 	"sort"
 	"testing"
+
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 // PortProtoV2 is 1 value at bit position 24.
@@ -31,11 +33,11 @@ const PortProtoV2 = 1 << 24
 // This works because Version 1 will naturally encode
 // no values at postions 16-31 as the original Version 1
 // was a uint16. Version 2 enforces a 1 value at the 24th
-// bit position, so it will alway be legible.
+// bit position, so it will always be legible.
 type PortProto uint32
 
 // MakeV2PortProto returns a Version 2 port protocol.
-func MakeV2PortProto(port uint16, proto uint8) PortProto {
+func MakeV2PortProto(port uint16, proto u8proto.U8proto) PortProto {
 	return PortProto(PortProtoV2 | (uint32(proto) << 16) | uint32(port))
 }
 

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -253,7 +253,7 @@ func TestIPCacheNamedPorts(t *testing.T) {
 		Namespace: "default",
 		PodName:   "app1",
 		NamedPorts: types.NamedPortMap{
-			"http": types.PortProto{Port: 80, Proto: uint8(u8proto.TCP)},
+			"http": types.PortProto{Port: 80, Proto: u8proto.TCP},
 			"dns":  types.PortProto{Port: 53},
 		},
 	}
@@ -281,10 +281,10 @@ func TestIPCacheNamedPorts(t *testing.T) {
 	npm := IPIdentityCache.GetNamedPorts()
 	require.NotNil(t, npm)
 	require.Equal(t, 2, npm.Len())
-	port, err := npm.GetNamedPort("http", uint8(6))
+	port, err := npm.GetNamedPort("http", u8proto.TCP)
 	require.Nil(t, err)
 	require.Equal(t, uint16(80), port)
-	port, err = npm.GetNamedPort("dns", uint8(0))
+	port, err = npm.GetNamedPort("dns", u8proto.ANY)
 	require.Nil(t, err)
 	require.Equal(t, uint16(53), port)
 
@@ -307,7 +307,7 @@ func TestIPCacheNamedPorts(t *testing.T) {
 		Namespace: "testing",
 		PodName:   "app2",
 		NamedPorts: types.NamedPortMap{
-			"https": types.PortProto{Port: 443, Proto: uint8(u8proto.TCP)},
+			"https": types.PortProto{Port: 443, Proto: u8proto.TCP},
 			"dns":   types.PortProto{Port: 53},
 		},
 	}
@@ -334,13 +334,13 @@ func TestIPCacheNamedPorts(t *testing.T) {
 	npm = IPIdentityCache.GetNamedPorts()
 	require.NotNil(t, npm)
 	require.Equal(t, 3, npm.Len())
-	port, err = npm.GetNamedPort("http", uint8(6))
+	port, err = npm.GetNamedPort("http", u8proto.TCP)
 	require.Nil(t, err)
 	require.Equal(t, uint16(80), port)
-	port, err = npm.GetNamedPort("dns", uint8(0))
+	port, err = npm.GetNamedPort("dns", u8proto.ANY)
 	require.Nil(t, err)
 	require.Equal(t, uint16(53), port)
-	port, err = npm.GetNamedPort("https", uint8(6))
+	port, err = npm.GetNamedPort("https", u8proto.TCP)
 	require.Nil(t, err)
 	require.Equal(t, uint16(443), port)
 
@@ -350,10 +350,10 @@ func TestIPCacheNamedPorts(t *testing.T) {
 	require.NotNil(t, npm)
 	require.Equal(t, 2, npm.Len())
 
-	port, err = npm.GetNamedPort("dns", uint8(0))
+	port, err = npm.GetNamedPort("dns", u8proto.ANY)
 	require.Nil(t, err)
 	require.Equal(t, uint16(53), port)
-	port, err = npm.GetNamedPort("https", uint8(6))
+	port, err = npm.GetNamedPort("https", u8proto.TCP)
 	require.Nil(t, err)
 	require.Equal(t, uint16(443), port)
 
@@ -429,7 +429,7 @@ func TestIPCacheNamedPorts(t *testing.T) {
 	endpointIPs := []string{"192.168.0.1", "20.3.75.3", "27.2.2.2", "127.0.0.1", "127.0.0.1"}
 	identities := []identityPkg.NumericIdentity{5, 67, 29, 29, 29}
 	k8sMeta.NamedPorts = types.NamedPortMap{
-		"http2": types.PortProto{Port: 8080, Proto: uint8(u8proto.TCP)},
+		"http2": types.PortProto{Port: 8080, Proto: u8proto.TCP},
 	}
 
 	for index := range endpointIPs {
@@ -441,7 +441,7 @@ func TestIPCacheNamedPorts(t *testing.T) {
 		require.Nil(t, err)
 		npm = IPIdentityCache.GetNamedPorts()
 		require.NotNil(t, npm)
-		port, err := npm.GetNamedPort("http2", uint8(6))
+		port, err := npm.GetNamedPort("http2", u8proto.TCP)
 		require.Nil(t, err)
 		require.Equal(t, uint16(8080), port)
 		// only the first changes named ports, as they are all the same
@@ -526,7 +526,7 @@ func benchmarkIPCacheUpsert(b *testing.B, num int) {
 		Namespace: "default",
 		PodName:   "app",
 		NamedPorts: types.NamedPortMap{
-			"http": types.PortProto{Port: 80, Proto: uint8(u8proto.TCP)},
+			"http": types.PortProto{Port: 80, Proto: u8proto.TCP},
 			"dns":  types.PortProto{Port: 53},
 		},
 	}

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -238,7 +238,7 @@ func (k *K8sCiliumEndpointsWatcher) endpointUpdated(oldEndpoint, endpoint *types
 		}
 		k8sMeta.NamedPorts[port.Name] = ciliumTypes.PortProto{
 			Port:  port.Port,
-			Proto: uint8(p),
+			Proto: p,
 		}
 	}
 

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -971,7 +971,7 @@ func (k *K8sPodWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPo
 			}
 			k8sMeta.NamedPorts[port.Name] = ciliumTypes.PortProto{
 				Port:  uint16(port.ContainerPort),
-				Proto: uint8(p),
+				Proto: p,
 			}
 		}
 	}

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -139,6 +139,15 @@ func (k *PolicyKey) GetPortMask() uint16 {
 	return ^portLen
 }
 
+// GetPortPrefixLen returns the prefix length applicable to the port in the key
+func (k *PolicyKey) GetPortPrefixLen() uint8 {
+	prefixLen := k.Prefixlen - StaticPrefixBits
+	if prefixLen <= NexthdrBits {
+		return 0
+	}
+	return uint8(prefixLen - NexthdrBits)
+}
+
 const (
 	sizeofPolicyKey = int(unsafe.Sizeof(PolicyKey{}))
 	sizeofPrefixlen = int(unsafe.Sizeof(PolicyKey{}.Prefixlen))

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -45,7 +45,7 @@ func setupPolicyMapPrivilegedTestSuite(tb testing.TB) *PolicyMap {
 func TestPolicyMapDumpToSlice(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 
-	fooEntry := newKey(1, 1, 1, 1, SinglePortPrefixLen)
+	fooEntry := NewKey(1, 1, 1, 1, SinglePortPrefixLen)
 	err := testMap.AllowKey(fooEntry, 0, 0)
 	require.Nil(t, err)
 
@@ -56,7 +56,7 @@ func TestPolicyMapDumpToSlice(t *testing.T) {
 	require.EqualValues(t, fooEntry, dump[0].Key)
 
 	// Special case: allow-all entry
-	barEntry := newKey(0, 0, 0, 0, 0)
+	barEntry := NewKey(0, 0, 0, 0, 0)
 	err = testMap.AllowKey(barEntry, 0, 0)
 	require.Nil(t, err)
 
@@ -67,7 +67,7 @@ func TestPolicyMapDumpToSlice(t *testing.T) {
 
 func TestDeleteNonexistentKey(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
-	key := newKey(trafficdirection.Ingress, 27, u8proto.TCP, 80, SinglePortPrefixLen)
+	key := NewKey(trafficdirection.Ingress, 27, u8proto.TCP, 80, SinglePortPrefixLen)
 	err := testMap.Map.Delete(&key)
 	require.NotNil(t, err)
 	var errno unix.Errno
@@ -78,7 +78,7 @@ func TestDeleteNonexistentKey(t *testing.T) {
 func TestDenyPolicyMapDumpToSlice(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 
-	fooKey := newKey(1, 1, 1, 1, SinglePortPrefixLen)
+	fooKey := NewKey(1, 1, 1, 1, SinglePortPrefixLen)
 	fooEntry := newDenyEntry(fooKey)
 	err := testMap.DenyKey(fooKey)
 	require.Nil(t, err)
@@ -91,7 +91,7 @@ func TestDenyPolicyMapDumpToSlice(t *testing.T) {
 	require.EqualValues(t, fooEntry, dump[0].PolicyEntry)
 
 	// Special case: deny-all entry
-	barKey := newKey(0, 0, 0, 0, 0)
+	barKey := NewKey(0, 0, 0, 0, 0)
 	err = testMap.DenyKey(barKey)
 	require.Nil(t, err)
 

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -45,7 +45,7 @@ func setupPolicyMapPrivilegedTestSuite(tb testing.TB) *PolicyMap {
 func TestPolicyMapDumpToSlice(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 
-	fooEntry := newKey(1, 1, SinglePortMask, 1, 1)
+	fooEntry := newKey(1, 1, 1, 1, SinglePortPrefixLen)
 	err := testMap.AllowKey(fooEntry, 0, 0)
 	require.Nil(t, err)
 
@@ -56,7 +56,7 @@ func TestPolicyMapDumpToSlice(t *testing.T) {
 	require.EqualValues(t, fooEntry, dump[0].Key)
 
 	// Special case: allow-all entry
-	barEntry := newKey(0, 0, SinglePortMask, 0, 0)
+	barEntry := newKey(0, 0, 0, 0, 0)
 	err = testMap.AllowKey(barEntry, 0, 0)
 	require.Nil(t, err)
 
@@ -67,7 +67,7 @@ func TestPolicyMapDumpToSlice(t *testing.T) {
 
 func TestDeleteNonexistentKey(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
-	key := newKey(27, 80, SinglePortMask, u8proto.TCP, trafficdirection.Ingress)
+	key := newKey(trafficdirection.Ingress, 27, u8proto.TCP, 80, SinglePortPrefixLen)
 	err := testMap.Map.Delete(&key)
 	require.NotNil(t, err)
 	var errno unix.Errno
@@ -78,7 +78,7 @@ func TestDeleteNonexistentKey(t *testing.T) {
 func TestDenyPolicyMapDumpToSlice(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 
-	fooKey := newKey(1, 1, SinglePortMask, 1, 1)
+	fooKey := newKey(1, 1, 1, 1, SinglePortPrefixLen)
 	fooEntry := newDenyEntry(fooKey)
 	err := testMap.DenyKey(fooKey)
 	require.Nil(t, err)
@@ -91,7 +91,7 @@ func TestDenyPolicyMapDumpToSlice(t *testing.T) {
 	require.EqualValues(t, fooEntry, dump[0].PolicyEntry)
 
 	// Special case: deny-all entry
-	barKey := newKey(0, 0, SinglePortMask, 0, 0)
+	barKey := newKey(0, 0, 0, 0, 0)
 	err = testMap.DenyKey(barKey)
 	require.Nil(t, err)
 

--- a/pkg/maps/policymap/policymap_test.go
+++ b/pkg/maps/policymap/policymap_test.go
@@ -263,8 +263,7 @@ func TestPolicyMapWildcarding(t *testing.T) {
 		}
 
 		// Get key
-		key := newKey(uint32(tt.args.id), uint16(tt.args.dport), SinglePortMask, u8proto.U8proto(tt.args.proto),
-			trafficdirection.TrafficDirection(tt.args.trafficDirection))
+		key := newKey(trafficdirection.TrafficDirection(tt.args.trafficDirection), uint32(tt.args.id), u8proto.U8proto(tt.args.proto), uint16(tt.args.dport), SinglePortPrefixLen)
 
 		// Compure entry & validate key and entry
 		var entry PolicyEntry

--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -56,7 +56,7 @@ func CorrelatePolicy(endpointGetter getters.EndpointGetter, f *flowpb.Flow) {
 	}
 
 	derivedFrom, rev, ok := lookupPolicyForKey(epInfo,
-		policy.NewKey(uint8(direction), uint32(remoteIdentity), uint8(proto), dport, 0),
+		policy.NewKey(direction, remoteIdentity, proto, dport, 0),
 		f.GetPolicyMatchType())
 	if !ok {
 		logger.WithFields(logrus.Fields{

--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -56,7 +56,7 @@ func CorrelatePolicy(endpointGetter getters.EndpointGetter, f *flowpb.Flow) {
 	}
 
 	derivedFrom, rev, ok := lookupPolicyForKey(epInfo,
-		policy.NewKey(direction, remoteIdentity, proto, dport, 0),
+		policy.KeyForDirection(direction).WithIdentity(remoteIdentity).WithPortProto(proto, dport),
 		f.GetPolicyMatchType())
 	if !ok {
 		logger.WithFields(logrus.Fields{
@@ -157,7 +157,7 @@ func lookupPolicyForKey(ep getters.EndpointInfo, key policy.Key, matchType uint3
 		//    - port: 80
 		//      protocol: TCP // protocol is optional for this match.
 		derivedFrom, rev, ok = ep.GetRealizedPolicyRuleLabelsForKey(
-			policy.NewKey(key.TrafficDirection(), 0, key.Nexthdr, key.DestPort, 0))
+			policy.KeyForDirection(key.TrafficDirection()).WithPortProto(key.Nexthdr, key.DestPort))
 	case monitorAPI.PolicyMatchProtoOnly:
 		// Check for protocol-only policies.
 		//
@@ -169,7 +169,7 @@ func lookupPolicyForKey(ep getters.EndpointInfo, key policy.Key, matchType uint3
 		//  - ports:
 		//    - protocol: TCP
 		derivedFrom, rev, ok = ep.GetRealizedPolicyRuleLabelsForKey(
-			policy.NewKey(key.TrafficDirection(), 0, key.Nexthdr, 0, 0))
+			policy.KeyForDirection(key.TrafficDirection()).WithProto(key.Nexthdr))
 	case monitorAPI.PolicyMatchL3Only:
 		// Check for L3 policy rules.
 		//
@@ -182,7 +182,7 @@ func lookupPolicyForKey(ep getters.EndpointInfo, key policy.Key, matchType uint3
 		//      matchLabels:
 		//        app: client
 		derivedFrom, rev, ok = ep.GetRealizedPolicyRuleLabelsForKey(
-			policy.NewL3OnlyKey(key.TrafficDirection(), key.Identity))
+			policy.KeyForDirection(key.TrafficDirection()).WithIdentity(key.Identity))
 	case monitorAPI.PolicyMatchAll:
 		// Check for allow-all policy rules.
 		//
@@ -193,7 +193,7 @@ func lookupPolicyForKey(ep getters.EndpointInfo, key policy.Key, matchType uint3
 		//  ingress:
 		//  - {}
 		derivedFrom, rev, ok = ep.GetRealizedPolicyRuleLabelsForKey(
-			policy.NewL3OnlyKey(key.TrafficDirection(), 0))
+			policy.KeyForDirection(key.TrafficDirection()))
 	}
 
 	return derivedFrom, rev, ok

--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -156,12 +156,8 @@ func lookupPolicyForKey(ep getters.EndpointInfo, key policy.Key, matchType uint3
 		//  - ports:
 		//    - port: 80
 		//      protocol: TCP // protocol is optional for this match.
-		derivedFrom, rev, ok = ep.GetRealizedPolicyRuleLabelsForKey(policy.Key{
-			Identity:         0,
-			DestPort:         key.DestPort,
-			Nexthdr:          key.Nexthdr,
-			TrafficDirection: key.TrafficDirection,
-		})
+		derivedFrom, rev, ok = ep.GetRealizedPolicyRuleLabelsForKey(
+			policy.NewKey(key.TrafficDirection(), 0, key.Nexthdr, key.DestPort, 0))
 	case monitorAPI.PolicyMatchProtoOnly:
 		// Check for protocol-only policies.
 		//
@@ -173,7 +169,7 @@ func lookupPolicyForKey(ep getters.EndpointInfo, key policy.Key, matchType uint3
 		//  - ports:
 		//    - protocol: TCP
 		derivedFrom, rev, ok = ep.GetRealizedPolicyRuleLabelsForKey(
-			policy.NewKey(key.TrafficDirection, 0, key.Nexthdr, 0, 0))
+			policy.NewKey(key.TrafficDirection(), 0, key.Nexthdr, 0, 0))
 	case monitorAPI.PolicyMatchL3Only:
 		// Check for L3 policy rules.
 		//
@@ -186,7 +182,7 @@ func lookupPolicyForKey(ep getters.EndpointInfo, key policy.Key, matchType uint3
 		//      matchLabels:
 		//        app: client
 		derivedFrom, rev, ok = ep.GetRealizedPolicyRuleLabelsForKey(
-			policy.NewL3OnlyKey(key.TrafficDirection, key.Identity))
+			policy.NewL3OnlyKey(key.TrafficDirection(), key.Identity))
 	case monitorAPI.PolicyMatchAll:
 		// Check for allow-all policy rules.
 		//
@@ -197,7 +193,7 @@ func lookupPolicyForKey(ep getters.EndpointInfo, key policy.Key, matchType uint3
 		//  ingress:
 		//  - {}
 		derivedFrom, rev, ok = ep.GetRealizedPolicyRuleLabelsForKey(
-			policy.NewL3OnlyKey(key.TrafficDirection, 0))
+			policy.NewL3OnlyKey(key.TrafficDirection(), 0))
 	}
 
 	return derivedFrom, rev, ok

--- a/pkg/policy/correlation/correlation_test.go
+++ b/pkg/policy/correlation/correlation_test.go
@@ -61,7 +61,7 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	policyLabel := utils.GetPolicyLabels("foo-namespace", "web-policy", "1234-5678", utils.ResourceTypeCiliumNetworkPolicy)
-	policyKey := policy.EgressKey(remoteIdentity, uint8(u8proto.TCP), uint16(dstPort), 0)
+	policyKey := policy.EgressKey(identity.NumericIdentity(remoteIdentity), u8proto.TCP, uint16(dstPort), 0)
 	ep := &testutils.FakeEndpointInfo{
 		ID:           uint64(localID),
 		Identity:     identity.NumericIdentity(localIdentity),
@@ -176,7 +176,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyMatchType: monitorAPI.PolicyMatchL4Only,
 	}
 
-	policyKey = policy.NewKey(trafficdirection.Egress.Uint8(), 0, uint8(u8proto.TCP), uint16(dstPort), 0)
+	policyKey = policy.NewKey(trafficdirection.Egress, 0, u8proto.TCP, uint16(dstPort), 0)
 	ep = &testutils.FakeEndpointInfo{
 		ID:           uint64(localID),
 		IPv4:         net.ParseIP(localIP),
@@ -199,7 +199,7 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check port-only rule.
-	policyKey = policy.NewKey(trafficdirection.Egress.Uint8(), 0, uint8(u8proto.ANY), uint16(dstPort), 0)
+	policyKey = policy.NewKey(trafficdirection.Egress, 0, u8proto.ANY, uint16(dstPort), 0)
 	ep = &testutils.FakeEndpointInfo{
 		ID:           uint64(localID),
 		IPv4:         net.ParseIP(localIP),
@@ -250,7 +250,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyMatchType: monitorAPI.PolicyMatchProtoOnly,
 	}
 
-	policyKey = policy.NewKey(trafficdirection.Egress.Uint8(), 0, uint8(u8proto.TCP), 0, 0)
+	policyKey = policy.NewKey(trafficdirection.Egress, 0, u8proto.TCP, 0, 0)
 	ep = &testutils.FakeEndpointInfo{
 		ID:           uint64(localID),
 		IPv4:         net.ParseIP(localIP),
@@ -301,7 +301,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyMatchType: monitorAPI.PolicyMatchAll,
 	}
 
-	policyKey = policy.NewKey(trafficdirection.Egress.Uint8(), 0, uint8(u8proto.ANY), 0, 0)
+	policyKey = policy.NewKey(trafficdirection.Egress, 0, u8proto.ANY, 0, 0)
 	ep = &testutils.FakeEndpointInfo{
 		ID:           uint64(localID),
 		IPv4:         net.ParseIP(localIP),
@@ -352,7 +352,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyMatchType: monitorAPI.PolicyMatchL3Only,
 	}
 
-	policyKey = policy.IngressL3OnlyKey(localIdentity)
+	policyKey = policy.IngressL3OnlyKey(identity.NumericIdentity(localIdentity))
 	ep = &testutils.FakeEndpointInfo{
 		ID:           uint64(remoteID),
 		Identity:     identity.NumericIdentity(remoteIdentity),
@@ -452,8 +452,8 @@ func TestCorrelatePolicy(t *testing.T) {
 
 	policyLabel = utils.GetPolicyLabels("", "ccnp", "1234-5678", utils.ResourceTypeCiliumClusterwideNetworkPolicy)
 	policyKey = policy.NewKey(
-		trafficdirection.Egress.Uint8(), uint32(remoteIdentity),
-		uint8(u8proto.TCP), uint16(dstPort), 0)
+		trafficdirection.Egress, identity.NumericIdentity(remoteIdentity),
+		u8proto.TCP, uint16(dstPort), 0)
 	ep = &testutils.FakeEndpointInfo{
 		ID:           uint64(localID),
 		Identity:     identity.NumericIdentity(localIdentity),

--- a/pkg/policy/correlation/correlation_test.go
+++ b/pkg/policy/correlation/correlation_test.go
@@ -25,11 +25,11 @@ import (
 
 func TestCorrelatePolicy(t *testing.T) {
 	localIP := "1.2.3.4"
-	localIdentity := uint64(1234)
-	localID := uint64(12)
+	localIdentity := uint32(1234)
+	localID := uint32(12)
 	remoteIP := "5.6.7.8"
-	remoteIdentity := uint64(5678)
-	remoteID := uint64(56)
+	remoteIdentity := uint32(5678)
+	remoteID := uint32(56)
 	dstPort := uint32(443)
 
 	flow := &flowpb.Flow{
@@ -50,25 +50,20 @@ func TestCorrelatePolicy(t *testing.T) {
 			},
 		},
 		Source: &flowpb.Endpoint{
-			ID:       uint32(localID),
-			Identity: uint32(localIdentity),
+			ID:       localID,
+			Identity: localIdentity,
 		},
 		Destination: &flowpb.Endpoint{
-			ID:       uint32(remoteID),
-			Identity: uint32(remoteIdentity),
+			ID:       remoteID,
+			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
 
 	policyLabel := utils.GetPolicyLabels("foo-namespace", "web-policy", "1234-5678", utils.ResourceTypeCiliumNetworkPolicy)
-	policyKey := policy.Key{
-		Identity:         uint32(remoteIdentity),
-		DestPort:         uint16(dstPort),
-		Nexthdr:          uint8(u8proto.TCP),
-		TrafficDirection: trafficdirection.Egress.Uint8(),
-	}
+	policyKey := policy.EgressKey(remoteIdentity, uint8(u8proto.TCP), uint16(dstPort), 0)
 	ep := &testutils.FakeEndpointInfo{
-		ID:           localID,
+		ID:           uint64(localID),
 		Identity:     identity.NumericIdentity(localIdentity),
 		IPv4:         net.ParseIP(localIP),
 		PodName:      "xwing",
@@ -134,12 +129,12 @@ func TestCorrelatePolicy(t *testing.T) {
 			},
 		},
 		Source: &flowpb.Endpoint{
-			ID:       uint32(localID),
-			Identity: uint32(localIdentity),
+			ID:       localID,
+			Identity: localIdentity,
 		},
 		Destination: &flowpb.Endpoint{
-			ID:       uint32(remoteID),
-			Identity: uint32(remoteIdentity),
+			ID:       remoteID,
+			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
@@ -171,24 +166,19 @@ func TestCorrelatePolicy(t *testing.T) {
 			},
 		},
 		Source: &flowpb.Endpoint{
-			ID:       uint32(localID),
-			Identity: uint32(localIdentity),
+			ID:       localID,
+			Identity: localIdentity,
 		},
 		Destination: &flowpb.Endpoint{
-			ID:       uint32(remoteID),
-			Identity: uint32(remoteIdentity),
+			ID:       remoteID,
+			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL4Only,
 	}
 
-	policyKey = policy.Key{
-		Identity:         uint32(0),
-		DestPort:         uint16(dstPort),
-		Nexthdr:          uint8(u8proto.TCP),
-		TrafficDirection: trafficdirection.Egress.Uint8(),
-	}
+	policyKey = policy.NewKey(trafficdirection.Egress.Uint8(), 0, uint8(u8proto.TCP), uint16(dstPort), 0)
 	ep = &testutils.FakeEndpointInfo{
-		ID:           localID,
+		ID:           uint64(localID),
 		IPv4:         net.ParseIP(localIP),
 		PodName:      "xwing",
 		PodNamespace: "default",
@@ -209,14 +199,9 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check port-only rule.
-	policyKey = policy.Key{
-		Identity:         uint32(0),
-		DestPort:         uint16(dstPort),
-		Nexthdr:          uint8(u8proto.ANY),
-		TrafficDirection: trafficdirection.Egress.Uint8(),
-	}
+	policyKey = policy.NewKey(trafficdirection.Egress.Uint8(), 0, uint8(u8proto.ANY), uint16(dstPort), 0)
 	ep = &testutils.FakeEndpointInfo{
-		ID:           localID,
+		ID:           uint64(localID),
 		IPv4:         net.ParseIP(localIP),
 		PodName:      "xwing",
 		PodNamespace: "default",
@@ -255,25 +240,19 @@ func TestCorrelatePolicy(t *testing.T) {
 			},
 		},
 		Source: &flowpb.Endpoint{
-			ID:       uint32(localID),
-			Identity: uint32(localIdentity),
+			ID:       localID,
+			Identity: localIdentity,
 		},
 		Destination: &flowpb.Endpoint{
-			ID:       uint32(remoteID),
-			Identity: uint32(remoteIdentity),
+			ID:       remoteID,
+			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchProtoOnly,
 	}
 
-	policyKey = policy.Key{
-		Identity:         uint32(0),
-		DestPort:         uint16(0),
-		InvertedPortMask: 0xffff, // this is a wildcard
-		Nexthdr:          uint8(u8proto.TCP),
-		TrafficDirection: trafficdirection.Egress.Uint8(),
-	}
+	policyKey = policy.NewKey(trafficdirection.Egress.Uint8(), 0, uint8(u8proto.TCP), 0, 0)
 	ep = &testutils.FakeEndpointInfo{
-		ID:           localID,
+		ID:           uint64(localID),
 		IPv4:         net.ParseIP(localIP),
 		PodName:      "xwing",
 		PodNamespace: "default",
@@ -312,25 +291,19 @@ func TestCorrelatePolicy(t *testing.T) {
 			},
 		},
 		Source: &flowpb.Endpoint{
-			ID:       uint32(localID),
-			Identity: uint32(localIdentity),
+			ID:       localID,
+			Identity: localIdentity,
 		},
 		Destination: &flowpb.Endpoint{
-			ID:       uint32(remoteID),
-			Identity: uint32(remoteIdentity),
+			ID:       remoteID,
+			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchAll,
 	}
 
-	policyKey = policy.Key{
-		Identity:         uint32(0),
-		DestPort:         uint16(0),
-		InvertedPortMask: 0xffff, // this is a wildcard
-		Nexthdr:          uint8(u8proto.ANY),
-		TrafficDirection: trafficdirection.Egress.Uint8(),
-	}
+	policyKey = policy.NewKey(trafficdirection.Egress.Uint8(), 0, uint8(u8proto.ANY), 0, 0)
 	ep = &testutils.FakeEndpointInfo{
-		ID:           localID,
+		ID:           uint64(localID),
 		IPv4:         net.ParseIP(localIP),
 		PodName:      "xwing",
 		PodNamespace: "default",
@@ -369,25 +342,19 @@ func TestCorrelatePolicy(t *testing.T) {
 			},
 		},
 		Source: &flowpb.Endpoint{
-			ID:       uint32(localID),
-			Identity: uint32(localIdentity),
+			ID:       localID,
+			Identity: localIdentity,
 		},
 		Destination: &flowpb.Endpoint{
-			ID:       uint32(remoteID),
-			Identity: uint32(remoteIdentity),
+			ID:       remoteID,
+			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3Only,
 	}
 
-	policyKey = policy.Key{
-		Identity:         uint32(localIdentity),
-		DestPort:         0,
-		InvertedPortMask: 0xffff, // this is a wildcard
-		Nexthdr:          0,
-		TrafficDirection: trafficdirection.Ingress.Uint8(),
-	}
+	policyKey = policy.IngressL3OnlyKey(localIdentity)
 	ep = &testutils.FakeEndpointInfo{
-		ID:           remoteID,
+		ID:           uint64(remoteID),
 		Identity:     identity.NumericIdentity(remoteIdentity),
 		IPv4:         net.ParseIP(remoteIP),
 		PodName:      "xwing",
@@ -436,12 +403,12 @@ func TestCorrelatePolicy(t *testing.T) {
 			},
 		},
 		Source: &flowpb.Endpoint{
-			ID:       uint32(localID),
-			Identity: uint32(localIdentity),
+			ID:       localID,
+			Identity: localIdentity,
 		},
 		Destination: &flowpb.Endpoint{
-			ID:       uint32(remoteID),
-			Identity: uint32(remoteIdentity),
+			ID:       remoteID,
+			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3Only,
 	}
@@ -473,25 +440,22 @@ func TestCorrelatePolicy(t *testing.T) {
 			},
 		},
 		Source: &flowpb.Endpoint{
-			ID:       uint32(localID),
-			Identity: uint32(localIdentity),
+			ID:       localID,
+			Identity: localIdentity,
 		},
 		Destination: &flowpb.Endpoint{
-			ID:       uint32(remoteID),
-			Identity: uint32(remoteIdentity),
+			ID:       remoteID,
+			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
 
 	policyLabel = utils.GetPolicyLabels("", "ccnp", "1234-5678", utils.ResourceTypeCiliumClusterwideNetworkPolicy)
-	policyKey = policy.Key{
-		Identity:         uint32(remoteIdentity),
-		DestPort:         uint16(dstPort),
-		Nexthdr:          uint8(u8proto.TCP),
-		TrafficDirection: trafficdirection.Egress.Uint8(),
-	}
+	policyKey = policy.NewKey(
+		trafficdirection.Egress.Uint8(), uint32(remoteIdentity),
+		uint8(u8proto.TCP), uint16(dstPort), 0)
 	ep = &testutils.FakeEndpointInfo{
-		ID:           localID,
+		ID:           uint64(localID),
 		Identity:     identity.NumericIdentity(localIdentity),
 		IPv4:         net.ParseIP(localIP),
 		PodName:      "xwing",

--- a/pkg/policy/correlation/correlation_test.go
+++ b/pkg/policy/correlation/correlation_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -61,7 +60,7 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	policyLabel := utils.GetPolicyLabels("foo-namespace", "web-policy", "1234-5678", utils.ResourceTypeCiliumNetworkPolicy)
-	policyKey := policy.EgressKey(identity.NumericIdentity(remoteIdentity), u8proto.TCP, uint16(dstPort), 0)
+	policyKey := policy.EgressKey().WithIdentity(identity.NumericIdentity(remoteIdentity)).WithTCPPort(uint16(dstPort))
 	ep := &testutils.FakeEndpointInfo{
 		ID:           uint64(localID),
 		Identity:     identity.NumericIdentity(localIdentity),
@@ -176,7 +175,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyMatchType: monitorAPI.PolicyMatchL4Only,
 	}
 
-	policyKey = policy.NewKey(trafficdirection.Egress, 0, u8proto.TCP, uint16(dstPort), 0)
+	policyKey = policy.EgressKey().WithTCPPort(uint16(dstPort))
 	ep = &testutils.FakeEndpointInfo{
 		ID:           uint64(localID),
 		IPv4:         net.ParseIP(localIP),
@@ -199,7 +198,7 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check port-only rule.
-	policyKey = policy.NewKey(trafficdirection.Egress, 0, u8proto.ANY, uint16(dstPort), 0)
+	policyKey = policy.EgressKey().WithPort(uint16(dstPort))
 	ep = &testutils.FakeEndpointInfo{
 		ID:           uint64(localID),
 		IPv4:         net.ParseIP(localIP),
@@ -250,7 +249,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyMatchType: monitorAPI.PolicyMatchProtoOnly,
 	}
 
-	policyKey = policy.NewKey(trafficdirection.Egress, 0, u8proto.TCP, 0, 0)
+	policyKey = policy.EgressKey().WithProto(u8proto.TCP)
 	ep = &testutils.FakeEndpointInfo{
 		ID:           uint64(localID),
 		IPv4:         net.ParseIP(localIP),
@@ -301,7 +300,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyMatchType: monitorAPI.PolicyMatchAll,
 	}
 
-	policyKey = policy.NewKey(trafficdirection.Egress, 0, u8proto.ANY, 0, 0)
+	policyKey = policy.EgressKey()
 	ep = &testutils.FakeEndpointInfo{
 		ID:           uint64(localID),
 		IPv4:         net.ParseIP(localIP),
@@ -352,7 +351,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyMatchType: monitorAPI.PolicyMatchL3Only,
 	}
 
-	policyKey = policy.IngressL3OnlyKey(identity.NumericIdentity(localIdentity))
+	policyKey = policy.IngressKey().WithIdentity(identity.NumericIdentity(localIdentity))
 	ep = &testutils.FakeEndpointInfo{
 		ID:           uint64(remoteID),
 		Identity:     identity.NumericIdentity(remoteIdentity),
@@ -451,9 +450,7 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	policyLabel = utils.GetPolicyLabels("", "ccnp", "1234-5678", utils.ResourceTypeCiliumClusterwideNetworkPolicy)
-	policyKey = policy.NewKey(
-		trafficdirection.Egress, identity.NumericIdentity(remoteIdentity),
-		u8proto.TCP, uint16(dstPort), 0)
+	policyKey = policy.EgressKey().WithIdentity(identity.NumericIdentity(remoteIdentity)).WithTCPPort(uint16(dstPort))
 	ep = &testutils.FakeEndpointInfo{
 		ID:           uint64(localID),
 		Identity:     identity.NumericIdentity(localIdentity),

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -1848,7 +1848,7 @@ func Test_EnsureEntitiesSelectableByCIDR(t *testing.T) {
 func mapStateAllowsKey(ms *mapState, key Key) bool {
 	var ok bool
 	ms.denies.trie.Ancestors(key.PrefixLength(), key,
-		func(_ uint, _ bitlpm.Key[types.Key], is IDSet) bool {
+		func(_ uint, _ bitlpm.Key[types.LPMKey], is IDSet) bool {
 			if _, exists := is.ids[identity.NumericIdentity(key.Identity)]; exists {
 				ok = true
 			}
@@ -1858,7 +1858,7 @@ func mapStateAllowsKey(ms *mapState, key Key) bool {
 		return false
 	}
 	ms.allows.trie.Ancestors(key.PrefixLength(), key,
-		func(_ uint, _ bitlpm.Key[types.Key], is IDSet) bool {
+		func(_ uint, _ bitlpm.Key[types.LPMKey], is IDSet) bool {
 
 			if _, exists := is.ids[identity.NumericIdentity(key.Identity)]; exists {
 				ok = true

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -133,14 +133,14 @@ func TestCachePopulation(t *testing.T) {
 
 var (
 	// Identity, labels, selectors for an endpoint named "foo"
-	identityFoo = uint32(100)
+	identityFoo = identity.NumericIdentity(100)
 	labelsFoo   = labels.ParseSelectLabelArray("foo", "blue")
 	selectFoo_  = api.NewESFromLabels(labels.ParseSelectLabel("foo"))
 	allowFooL3_ = selectFoo_
 	denyFooL3__ = selectFoo_
 
 	// Identity, labels, selectors for an endpoint named "bar"
-	identityBar = uint32(200)
+	identityBar = identity.NumericIdentity(200)
 	labelsBar   = labels.ParseSelectLabelArray("bar", "blue")
 	selectBar_  = api.NewESFromLabels(labels.ParseSelectLabel("bar"))
 	allowBarL3_ = selectBar_
@@ -464,8 +464,8 @@ func Test_MergeL3(t *testing.T) {
 	SetPolicyEnabled(option.DefaultEnforcement)
 
 	identityCache := identity.IdentityMap{
-		identity.NumericIdentity(identityFoo): labelsFoo,
-		identity.NumericIdentity(identityBar): labelsBar,
+		identityFoo: labelsFoo,
+		identityBar: labelsBar,
 	}
 	selectorCache := testNewSelectorCache(identityCache)
 
@@ -488,8 +488,8 @@ func Test_MergeL3(t *testing.T) {
 				mapKeyAllowBar__: mapEntryL7None_(lblsL3__AllowBar),
 			}),
 			authResult{
-				identity.NumericIdentity(identityBar): AuthTypes{},
-				identity.NumericIdentity(identityFoo): AuthTypes{},
+				identityBar: AuthTypes{},
+				identityFoo: AuthTypes{},
 			},
 		},
 		{
@@ -500,8 +500,8 @@ func Test_MergeL3(t *testing.T) {
 				mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow),
 			}),
 			authResult{
-				identity.NumericIdentity(identityBar): AuthTypes{},
-				identity.NumericIdentity(identityFoo): AuthTypes{},
+				identityBar: AuthTypes{},
+				identityFoo: AuthTypes{},
 			},
 		},
 		{
@@ -512,8 +512,8 @@ func Test_MergeL3(t *testing.T) {
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
 			}),
 			authResult{
-				identity.NumericIdentity(identityBar): AuthTypes{AuthTypeAlwaysFail: struct{}{}},
-				identity.NumericIdentity(identityFoo): AuthTypes{},
+				identityBar: AuthTypes{AuthTypeAlwaysFail: struct{}{}},
+				identityFoo: AuthTypes{},
 			},
 		},
 		{
@@ -525,8 +525,8 @@ func Test_MergeL3(t *testing.T) {
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
 			}),
 			authResult{
-				identity.NumericIdentity(identityBar): AuthTypes{AuthTypeAlwaysFail: struct{}{}, AuthTypeSpire: struct{}{}},
-				identity.NumericIdentity(identityFoo): AuthTypes{AuthTypeSpire: struct{}{}},
+				identityBar: AuthTypes{AuthTypeAlwaysFail: struct{}{}, AuthTypeSpire: struct{}{}},
+				identityFoo: AuthTypes{AuthTypeSpire: struct{}{}},
 			},
 		},
 		{
@@ -537,8 +537,8 @@ func Test_MergeL3(t *testing.T) {
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
 			}),
 			authResult{
-				identity.NumericIdentity(identityBar): AuthTypes{AuthTypeAlwaysFail: struct{}{}},
-				identity.NumericIdentity(identityFoo): AuthTypes{},
+				identityBar: AuthTypes{AuthTypeAlwaysFail: struct{}{}},
+				identityFoo: AuthTypes{},
 			},
 		},
 		{
@@ -549,8 +549,8 @@ func Test_MergeL3(t *testing.T) {
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeSpire, lblsL3__AllowBar),
 			}),
 			authResult{
-				identity.NumericIdentity(identityBar): AuthTypes{AuthTypeSpire: struct{}{}},
-				identity.NumericIdentity(identityFoo): AuthTypes{AuthTypeSpire: struct{}{}},
+				identityBar: AuthTypes{AuthTypeSpire: struct{}{}},
+				identityFoo: AuthTypes{AuthTypeSpire: struct{}{}},
 			},
 		},
 		{
@@ -561,8 +561,8 @@ func Test_MergeL3(t *testing.T) {
 				mapKeyAllow___L4: mapEntryL7Auth_(AuthTypeSpire, lbls__L4__Allow),
 			}),
 			authResult{
-				identity.NumericIdentity(identityBar): AuthTypes{AuthTypeSpire: struct{}{}},
-				identity.NumericIdentity(identityFoo): AuthTypes{AuthTypeSpire: struct{}{}},
+				identityBar: AuthTypes{AuthTypeSpire: struct{}{}},
+				identityFoo: AuthTypes{AuthTypeSpire: struct{}{}},
 			},
 		},
 		{
@@ -574,8 +574,8 @@ func Test_MergeL3(t *testing.T) {
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeSpire, lblsL3__AllowBar),
 			}),
 			authResult{
-				identity.NumericIdentity(identityBar): AuthTypes{AuthTypeSpire: struct{}{}},
-				identity.NumericIdentity(identityFoo): AuthTypes{AuthTypeSpire: struct{}{}},
+				identityBar: AuthTypes{AuthTypeSpire: struct{}{}},
+				identityFoo: AuthTypes{AuthTypeSpire: struct{}{}},
 			},
 		},
 		{
@@ -587,8 +587,8 @@ func Test_MergeL3(t *testing.T) {
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeDisabled, lblsL3__AllowBar),
 			}),
 			authResult{
-				identity.NumericIdentity(identityBar): AuthTypes{},
-				identity.NumericIdentity(identityFoo): AuthTypes{},
+				identityBar: AuthTypes{},
+				identityFoo: AuthTypes{},
 			},
 		},
 		{
@@ -601,8 +601,8 @@ func Test_MergeL3(t *testing.T) {
 				mapKeyAllowBarL4: mapEntryL7Auth_(AuthTypeAlwaysFail, lbls__L4__Allow, lblsL3__AllowBar),
 			}),
 			authResult{
-				identity.NumericIdentity(identityBar): AuthTypes{AuthTypeAlwaysFail: struct{}{}},
-				identity.NumericIdentity(identityFoo): AuthTypes{},
+				identityBar: AuthTypes{AuthTypeAlwaysFail: struct{}{}},
+				identityFoo: AuthTypes{},
 			},
 		},
 		{
@@ -615,8 +615,8 @@ func Test_MergeL3(t *testing.T) {
 				mapKeyAllowBarL4: mapEntryL7Auth_(AuthTypeAlwaysFail, lblsL3L4AllowBar, lbls__L4__Allow, lblsL3__AllowBar),
 			}),
 			authResult{
-				identity.NumericIdentity(identityBar): AuthTypes{AuthTypeAlwaysFail: struct{}{}},
-				identity.NumericIdentity(identityFoo): AuthTypes{},
+				identityBar: AuthTypes{AuthTypeAlwaysFail: struct{}{}},
+				identityFoo: AuthTypes{},
 			},
 		},
 	}
@@ -1319,8 +1319,8 @@ func Test_AllowAll(t *testing.T) {
 	SetPolicyEnabled(option.DefaultEnforcement)
 
 	identityCache := identity.IdentityMap{
-		identity.NumericIdentity(identityFoo): labelsFoo,
-		identity.NumericIdentity(identityBar): labelsBar,
+		identityFoo: labelsFoo,
+		identityBar: labelsBar,
 	}
 	selectorCache := testNewSelectorCache(identityCache)
 	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
@@ -1381,7 +1381,7 @@ var (
 
 	cpyRule                   = *ruleL3DenyWorld
 	ruleL3DenyWorldWithLabels = (&cpyRule).WithLabels(labels.LabelWorld.LabelArray())
-	worldReservedID           = identity.ReservedIdentityWorld.Uint32()
+	worldReservedID           = identity.ReservedIdentityWorld
 	mapKeyL3WorldIngress      = IngressL3OnlyKey(worldReservedID)
 	mapKeyL3WorldEgress       = EgressL3OnlyKey(worldReservedID)
 	mapEntryDeny              = MapStateEntry{
@@ -1436,8 +1436,8 @@ var (
 			ToCIDRSet: api.CIDRRuleSlice{worldSubnetRule},
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
-	mapKeyL3SubnetIngress = IngressL3OnlyKey(worldSubnetIdentity.Uint32())
-	mapKeyL3SubnetEgress  = EgressL3OnlyKey(worldSubnetIdentity.Uint32())
+	mapKeyL3SubnetIngress = IngressL3OnlyKey(worldSubnetIdentity)
+	mapKeyL3SubnetEgress  = EgressL3OnlyKey(worldSubnetIdentity)
 
 	ruleL3DenySmallerSubnet = api.NewRule().WithIngressDenyRules([]api.IngressDenyRule{{
 		IngressCommonRule: api.IngressCommonRule{
@@ -1459,8 +1459,8 @@ var (
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
 
-	mapKeyL3SmallerSubnetIngress = IngressL3OnlyKey(worldIPIdentity.Uint32())
-	mapKeyL3SmallerSubnetEgress  = EgressL3OnlyKey(worldIPIdentity.Uint32())
+	mapKeyL3SmallerSubnetIngress = IngressL3OnlyKey(worldIPIdentity)
+	mapKeyL3SmallerSubnetEgress  = EgressL3OnlyKey(worldIPIdentity)
 
 	ruleL3AllowHostEgress = api.NewRule().WithEgressRules([]api.EgressRule{{
 		EgressCommonRule: api.EgressCommonRule{
@@ -1468,14 +1468,14 @@ var (
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
 
-	mapKeyL3UnknownIngress = IngressL3OnlyKey(identity.IdentityUnknown.Uint32())
+	mapKeyL3UnknownIngress = IngressL3OnlyKey(identity.IdentityUnknown)
 	derivedFrom            = labels.LabelArrayList{
 		labels.LabelArray{
 			labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowAnyIngress, labels.LabelSourceReserved),
 		},
 	}
 	mapEntryL3UnknownIngress          = NewMapStateEntry(nil, derivedFrom, 0, "", 0, false, ExplicitAuthType, AuthTypeDisabled)
-	mapKeyL3HostEgress                = EgressL3OnlyKey(identity.ReservedIdentityHost.Uint32())
+	mapKeyL3HostEgress                = EgressL3OnlyKey(identity.ReservedIdentityHost)
 	ruleL3L4Port8080ProtoAnyDenyWorld = api.NewRule().WithIngressDenyRules([]api.IngressDenyRule{
 		{
 			ToPorts: api.PortDenyRules{
@@ -1516,19 +1516,19 @@ var (
 	mapKeyL3L4Port8080ProtoSCTPWorldIngress = IngressKey(worldReservedID, 132, 8080, 0)
 	mapKeyL3L4Port8080ProtoSCTPWorldEgress  = EgressKey(worldReservedID, 132, 8080, 0)
 
-	mapKeyL3L4Port8080ProtoTCPWorldSNIngress  = IngressKey(worldSubnetIdentity.Uint32(), 6, 8080, 0)
-	mapKeyL3L4Port8080ProtoTCPWorldSNEgress   = EgressKey(worldSubnetIdentity.Uint32(), 6, 8080, 0)
-	mapKeyL3L4Port8080ProtoUDPWorldSNIngress  = IngressKey(worldSubnetIdentity.Uint32(), 17, 8080, 0)
-	mapKeyL3L4Port8080ProtoUDPWorldSNEgress   = EgressKey(worldSubnetIdentity.Uint32(), 17, 8080, 0)
-	mapKeyL3L4Port8080ProtoSCTPWorldSNIngress = IngressKey(worldSubnetIdentity.Uint32(), 132, 8080, 0)
-	mapKeyL3L4Port8080ProtoSCTPWorldSNEgress  = EgressKey(worldSubnetIdentity.Uint32(), 132, 8080, 0)
+	mapKeyL3L4Port8080ProtoTCPWorldSNIngress  = IngressKey(worldSubnetIdentity, 6, 8080, 0)
+	mapKeyL3L4Port8080ProtoTCPWorldSNEgress   = EgressKey(worldSubnetIdentity, 6, 8080, 0)
+	mapKeyL3L4Port8080ProtoUDPWorldSNIngress  = IngressKey(worldSubnetIdentity, 17, 8080, 0)
+	mapKeyL3L4Port8080ProtoUDPWorldSNEgress   = EgressKey(worldSubnetIdentity, 17, 8080, 0)
+	mapKeyL3L4Port8080ProtoSCTPWorldSNIngress = IngressKey(worldSubnetIdentity, 132, 8080, 0)
+	mapKeyL3L4Port8080ProtoSCTPWorldSNEgress  = EgressKey(worldSubnetIdentity, 132, 8080, 0)
 
-	mapKeyL3L4Port8080ProtoTCPWorldIPIngress  = IngressKey(worldIPIdentity.Uint32(), 6, 8080, 0)
-	mapKeyL3L4Port8080ProtoTCPWorldIPEgress   = EgressKey(worldIPIdentity.Uint32(), 6, 8080, 0)
-	mapKeyL3L4Port8080ProtoUDPWorldIPIngress  = IngressKey(worldIPIdentity.Uint32(), 17, 8080, 0)
-	mapKeyL3L4Port8080ProtoUDPWorldIPEgress   = EgressKey(worldIPIdentity.Uint32(), 17, 8080, 0)
-	mapKeyL3L4Port8080ProtoSCTPWorldIPIngress = IngressKey(worldIPIdentity.Uint32(), 132, 8080, 0)
-	mapKeyL3L4Port8080ProtoSCTPWorldIPEgress  = EgressKey(worldIPIdentity.Uint32(), 132, 8080, 0)
+	mapKeyL3L4Port8080ProtoTCPWorldIPIngress  = IngressKey(worldIPIdentity, 6, 8080, 0)
+	mapKeyL3L4Port8080ProtoTCPWorldIPEgress   = EgressKey(worldIPIdentity, 6, 8080, 0)
+	mapKeyL3L4Port8080ProtoUDPWorldIPIngress  = IngressKey(worldIPIdentity, 17, 8080, 0)
+	mapKeyL3L4Port8080ProtoUDPWorldIPEgress   = EgressKey(worldIPIdentity, 17, 8080, 0)
+	mapKeyL3L4Port8080ProtoSCTPWorldIPIngress = IngressKey(worldIPIdentity, 132, 8080, 0)
+	mapKeyL3L4Port8080ProtoSCTPWorldIPEgress  = EgressKey(worldIPIdentity, 132, 8080, 0)
 
 	ruleL3AllowWorldSubnet = api.NewRule().WithIngressRules([]api.IngressRule{{
 		ToPorts: api.PortRules{
@@ -1570,14 +1570,14 @@ var (
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
 	mapKeyAnyIngress                        = IngressL3OnlyKey(0)
-	mapKeyL4AnyPortProtoWorldIPIngress      = IngressL3OnlyKey(worldIPIdentity.Uint32())
-	mapKeyL4AnyPortProtoWorldIPEgress       = EgressL3OnlyKey(worldIPIdentity.Uint32())
-	mapKeyL4Port8080ProtoTCPWorldIPIngress  = IngressKey(worldIPIdentity.Uint32(), 6, 8080, 0)
-	mapKeyL4Port8080ProtoTCPWorldIPEgress   = EgressKey(worldIPIdentity.Uint32(), 6, 8080, 0)
-	mapKeyL4Port8080ProtoUDPWorldIPIngress  = IngressKey(worldIPIdentity.Uint32(), 17, 8080, 0)
-	mapKeyL4Port8080ProtoUDPWorldIPEgress   = EgressKey(worldIPIdentity.Uint32(), 17, 8080, 0)
-	mapKeyL4Port8080ProtoSCTPWorldIPIngress = IngressKey(worldIPIdentity.Uint32(), 132, 8080, 0)
-	mapKeyL4Port8080ProtoSCTPWorldIPEgress  = EgressKey(worldIPIdentity.Uint32(), 132, 8080, 0)
+	mapKeyL4AnyPortProtoWorldIPIngress      = IngressL3OnlyKey(worldIPIdentity)
+	mapKeyL4AnyPortProtoWorldIPEgress       = EgressL3OnlyKey(worldIPIdentity)
+	mapKeyL4Port8080ProtoTCPWorldIPIngress  = IngressKey(worldIPIdentity, 6, 8080, 0)
+	mapKeyL4Port8080ProtoTCPWorldIPEgress   = EgressKey(worldIPIdentity, 6, 8080, 0)
+	mapKeyL4Port8080ProtoUDPWorldIPIngress  = IngressKey(worldIPIdentity, 17, 8080, 0)
+	mapKeyL4Port8080ProtoUDPWorldIPEgress   = EgressKey(worldIPIdentity, 17, 8080, 0)
+	mapKeyL4Port8080ProtoSCTPWorldIPIngress = IngressKey(worldIPIdentity, 132, 8080, 0)
+	mapKeyL4Port8080ProtoSCTPWorldIPEgress  = EgressKey(worldIPIdentity, 132, 8080, 0)
 	mapEntryL4WorldIPDependentsIngressDeny  = MapStateEntry{
 		ProxyPort:        0,
 		IsDeny:           true,
@@ -1616,8 +1616,8 @@ var (
 			FromCIDR: api.CIDRSlice{worldSubnet},
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
-	mapKeyL3L4NamedPortHTTPProtoTCPWorldSubNetIngress = IngressKey(worldSubnetIdentity.Uint32(), 6, 80, 0)
-	mapKeyL3L4NamedPortHTTPProtoTCPWorldIPIngress     = IngressKey(worldIPIdentity.Uint32(), 6, 80, 0)
+	mapKeyL3L4NamedPortHTTPProtoTCPWorldSubNetIngress = IngressKey(worldSubnetIdentity, 6, 80, 0)
+	mapKeyL3L4NamedPortHTTPProtoTCPWorldIPIngress     = IngressKey(worldIPIdentity, 6, 80, 0)
 
 	ruleL3AllowWorldSubnetPortRange = api.NewRule().WithIngressRules([]api.IngressRule{{
 		ToPorts: api.PortRules{
@@ -1640,16 +1640,16 @@ var (
 			FromCIDR: api.CIDRSlice{worldSubnet},
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
-	mapKeyL3L4Port64To127ProtoTCPWorldSubNetIngress = IngressKey(worldSubnetIdentity.Uint32(), 6, 64, 10)
-	mapKeyL3L4Port5ProtoTCPWorldSubNetIngress       = IngressKey(worldSubnetIdentity.Uint32(), 6, 5, 0)
-	mapKeyL3L4Port6To7ProtoTCPWorldSubNetIngress    = IngressKey(worldSubnetIdentity.Uint32(), 6, 6, 15)
-	mapKeyL3L4Port8To9ProtoTCPWorldSubNetIngress    = IngressKey(worldSubnetIdentity.Uint32(), 6, 8, 15)
-	mapKeyL3L4Port10ProtoTCPWorldSubNetIngress      = IngressKey(worldSubnetIdentity.Uint32(), 6, 10, 0)
-	mapKeyL3L4Port64To127ProtoTCPWorldIPIngress     = IngressKey(worldIPIdentity.Uint32(), 6, 64, 10)
-	mapKeyL3L4Port5ProtoTCPWorldIPIngress           = IngressKey(worldIPIdentity.Uint32(), 6, 5, 0)
-	mapKeyL3L4Port6To7ProtoTCPWorldIPIngress        = IngressKey(worldIPIdentity.Uint32(), 6, 6, 15)
-	mapKeyL3L4Port8To9ProtoTCPWorldIPIngress        = IngressKey(worldIPIdentity.Uint32(), 6, 8, 15)
-	mapKeyL3L4Port10ProtoTCPWorldIPIngress          = IngressKey(worldIPIdentity.Uint32(), 6, 10, 0)
+	mapKeyL3L4Port64To127ProtoTCPWorldSubNetIngress = IngressKey(worldSubnetIdentity, 6, 64, 10)
+	mapKeyL3L4Port5ProtoTCPWorldSubNetIngress       = IngressKey(worldSubnetIdentity, 6, 5, 0)
+	mapKeyL3L4Port6To7ProtoTCPWorldSubNetIngress    = IngressKey(worldSubnetIdentity, 6, 6, 15)
+	mapKeyL3L4Port8To9ProtoTCPWorldSubNetIngress    = IngressKey(worldSubnetIdentity, 6, 8, 15)
+	mapKeyL3L4Port10ProtoTCPWorldSubNetIngress      = IngressKey(worldSubnetIdentity, 6, 10, 0)
+	mapKeyL3L4Port64To127ProtoTCPWorldIPIngress     = IngressKey(worldIPIdentity, 6, 64, 10)
+	mapKeyL3L4Port5ProtoTCPWorldIPIngress           = IngressKey(worldIPIdentity, 6, 5, 0)
+	mapKeyL3L4Port6To7ProtoTCPWorldIPIngress        = IngressKey(worldIPIdentity, 6, 6, 15)
+	mapKeyL3L4Port8To9ProtoTCPWorldIPIngress        = IngressKey(worldIPIdentity, 6, 8, 15)
+	mapKeyL3L4Port10ProtoTCPWorldIPIngress          = IngressKey(worldIPIdentity, 6, 10, 0)
 )
 
 func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
@@ -1849,7 +1849,7 @@ func mapStateAllowsKey(ms *mapState, key Key) bool {
 	var ok bool
 	ms.denies.trie.Ancestors(key.PrefixLength(), key,
 		func(_ uint, _ bitlpm.Key[types.LPMKey], is IDSet) bool {
-			if _, exists := is.ids[identity.NumericIdentity(key.Identity)]; exists {
+			if _, exists := is.ids[key.Identity]; exists {
 				ok = true
 			}
 			return true
@@ -1860,7 +1860,7 @@ func mapStateAllowsKey(ms *mapState, key Key) bool {
 	ms.allows.trie.Ancestors(key.PrefixLength(), key,
 		func(_ uint, _ bitlpm.Key[types.LPMKey], is IDSet) bool {
 
-			if _, exists := is.ids[identity.NumericIdentity(key.Identity)]; exists {
+			if _, exists := is.ids[key.Identity]; exists {
 				ok = true
 			}
 			return true
@@ -2009,7 +2009,7 @@ func TestEgressPortRangePrecedence(t *testing.T) {
 			for _, rt := range tt.rangeTests {
 				for i := rt.startPort; i <= rt.endPort; i++ {
 					ctxFromA.DPorts = []*models.Port{{Port: i, Protocol: models.PortProtocolTCP}}
-					key := EgressKey(identity.ID.Uint32(), uint8(u8proto.TCP), i, 0)
+					key := EgressKey(identity.ID, u8proto.TCP, i, 0)
 					if rt.isAllow {
 						// IngressCoversContext just checks the "From" labels of the search context.
 						require.Equalf(t, api.Allowed.String(), res.IngressCoversContext(&ctxFromA).String(), "Requesting port %d", i)

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 func FuzzResolveEgressPolicy(f *testing.F) {
@@ -64,10 +65,11 @@ func FuzzAccumulateMapChange(f *testing.F) {
 		if err != nil {
 			t.Skip()
 		}
-		proto, err := ff.GetByte()
+		protoUint8, err := ff.GetByte()
 		if err != nil {
 			t.Skip()
 		}
+		proto := u8proto.U8proto(protoUint8)
 		dir := trafficdirection.Ingress
 		redirect, err := ff.GetBool()
 		if err != nil {
@@ -81,7 +83,7 @@ func FuzzAccumulateMapChange(f *testing.F) {
 		if redirect {
 			proxyPort = 1
 		}
-		key := NewKey(dir.Uint8(), 0, proto, port, 0)
+		key := NewKey(dir, 0, proto, port, 0)
 		value := NewMapStateEntry(csFoo, nil, proxyPort, "", 0, deny, DefaultAuthType, AuthTypeDisabled)
 		policyMaps := MapChanges{}
 		policyMaps.AccumulateMapChanges(csFoo, adds, deletes, []Key{key}, value)

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -81,7 +81,7 @@ func FuzzAccumulateMapChange(f *testing.F) {
 		if redirect {
 			proxyPort = 1
 		}
-		key := Key{DestPort: port, Nexthdr: proto, TrafficDirection: dir.Uint8()}
+		key := NewKey(dir.Uint8(), 0, proto, port, 0)
 		value := NewMapStateEntry(csFoo, nil, proxyPort, "", 0, deny, DefaultAuthType, AuthTypeDisabled)
 		policyMaps := MapChanges{}
 		policyMaps.AccumulateMapChanges(csFoo, adds, deletes, []Key{key}, value)

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -83,7 +83,7 @@ func FuzzAccumulateMapChange(f *testing.F) {
 		if redirect {
 			proxyPort = 1
 		}
-		key := NewKey(dir, 0, proto, port, 0)
+		key := KeyForDirection(dir).WithPortProto(proto, port)
 		value := NewMapStateEntry(csFoo, nil, proxyPort, "", 0, deny, DefaultAuthType, AuthTypeDisabled)
 		policyMaps := MapChanges{}
 		policyMaps.AccumulateMapChanges(csFoo, adds, deletes, []Key{key}, value)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -573,7 +573,7 @@ func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redir
 	var keysToAdd []Key
 	for _, mp := range PortRangeToMaskedPorts(port, l4.EndPort) {
 		keysToAdd = append(keysToAdd,
-			NewKey(direction, 0, proto, mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
+			KeyForDirection(direction).WithPortProtoPrefix(proto, mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
 	}
 
 	// find the L7 rules for the wildcard entry, if any
@@ -1629,7 +1629,7 @@ func (l4Policy *L4Policy) AccumulateMapChanges(l4 *L4Filter, cs CachedSelector, 
 		var keysToAdd []Key
 		for _, mp := range PortRangeToMaskedPorts(port, l4.EndPort) {
 			keysToAdd = append(keysToAdd,
-				NewKey(direction, 0, proto, mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
+				KeyForDirection(direction).WithPortProtoPrefix(proto, mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
 		}
 		value := NewMapStateEntry(cs, derivedFrom, proxyPort, listener, priority, isDeny, hasAuth, authType)
 

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -545,7 +545,7 @@ type ChangeState struct {
 // needs no lock.
 func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redirects map[string]uint16, changes ChangeState) {
 	port := l4.Port
-	proto := uint8(l4.U8Proto)
+	proto := l4.U8Proto
 
 	direction := trafficdirection.Egress
 	if l4.Ingress {
@@ -573,7 +573,7 @@ func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redir
 	var keysToAdd []Key
 	for _, mp := range PortRangeToMaskedPorts(port, l4.EndPort) {
 		keysToAdd = append(keysToAdd,
-			NewKey(direction.Uint8(), 0, proto, mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
+			NewKey(direction, 0, proto, mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
 	}
 
 	// find the L7 rules for the wildcard entry, if any
@@ -651,15 +651,15 @@ func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redir
 		}
 		for _, id := range idents {
 			for _, keyToAdd := range keysToAdd {
-				keyToAdd.Identity = id.Uint32()
+				keyToAdd.Identity = id
 				p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
 				// If Cilium is in dual-stack mode then the "World" identity
 				// needs to be split into two identities to represent World
 				// IPv6 and IPv4 traffic distinctly from one another.
 				if id == identity.ReservedIdentityWorld && option.Config.IsDualStack() {
-					keyToAdd.Identity = identity.ReservedIdentityWorldIPv4.Uint32()
+					keyToAdd.Identity = identity.ReservedIdentityWorldIPv4
 					p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
-					keyToAdd.Identity = identity.ReservedIdentityWorldIPv6.Uint32()
+					keyToAdd.Identity = identity.ReservedIdentityWorldIPv6
 					p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
 				}
 			}
@@ -1578,7 +1578,7 @@ func (l4 *L4Policy) removeUser(user *EndpointPolicy) {
 // present in both 'adds' and 'deletes'.
 func (l4Policy *L4Policy) AccumulateMapChanges(l4 *L4Filter, cs CachedSelector, adds, deletes []identity.NumericIdentity) {
 	port := uint16(l4.Port)
-	proto := uint8(l4.U8Proto)
+	proto := l4.U8Proto
 	derivedFrom := l4.RuleOrigin[cs]
 
 	direction := trafficdirection.Egress
@@ -1629,7 +1629,7 @@ func (l4Policy *L4Policy) AccumulateMapChanges(l4 *L4Filter, cs CachedSelector, 
 		var keysToAdd []Key
 		for _, mp := range PortRangeToMaskedPorts(port, l4.EndPort) {
 			keysToAdd = append(keysToAdd,
-				NewKey(direction.Uint8(), 0, proto, mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
+				NewKey(direction, 0, proto, mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
 		}
 		value := NewMapStateEntry(cs, derivedFrom, proxyPort, listener, priority, isDeny, hasAuth, authType)
 
@@ -1754,6 +1754,6 @@ type ProxyPolicy interface {
 	GetL7Parser() L7ParserType
 	GetIngress() bool
 	GetPort() uint16
-	GetProtocol() uint8
+	GetProtocol() u8proto.U8proto
 	GetListener() string
 }

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -1179,7 +1179,7 @@ func (ms *mapState) revertChanges(identities Identities, changes ChangeState) {
 // See https://docs.google.com/spreadsheets/d/1WANIoZGB48nryylQjjOw6lKjI80eVgPShrdMTMalLEw#gid=2109052536 for details
 func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStateEntry, identities Identities, features policyFeatures, changes ChangeState) {
 	// Sanity check on the newKey
-	if newKey.TrafficDirection >= trafficdirection.Invalid.Uint8() {
+	if newKey.TrafficDirection() >= trafficdirection.Invalid.Uint8() {
 		log.WithFields(logrus.Fields{
 			logfields.Stacktrace:       hclog.Stacktrace(),
 			logfields.TrafficDirection: newKey.TrafficDirection,
@@ -1193,7 +1193,7 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 	}
 
 	// If we have a deny "all" we don't accept any kind of map entry.
-	if _, ok := ms.denies.Lookup(allKey[newKey.TrafficDirection]); ok {
+	if _, ok := ms.denies.Lookup(allKey[newKey.TrafficDirection()]); ok {
 		return
 	}
 
@@ -1475,7 +1475,7 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 //  5. ID/proto/*
 //     ( ID/proto/port can not be superset of anything )
 func IsSuperSetOf(k, other Key) int {
-	if k.TrafficDirection != other.TrafficDirection {
+	if k.TrafficDirection() != other.TrafficDirection() {
 		return 0 // TrafficDirection must match for 'k' to be a superset of 'other'
 	}
 	if k.Identity == 0 {
@@ -1798,7 +1798,7 @@ func (ms *mapState) addVisibilityKeys(e PolicyOwner, redirectPort uint16, visMet
 
 	// Find Wildcarded L4 allows, i.e., L3-only entries
 	if !haveL4OnlyKey && !addL4OnlyKey {
-		ms.allows.ForEachKeyWithPortProto(allKey[key.TrafficDirection], func(k Key, v MapStateEntry) bool {
+		ms.allows.ForEachKeyWithPortProto(allKey[key.TrafficDirection()], func(k Key, v MapStateEntry) bool {
 			if k.Identity != 0 {
 				k2 := key
 				k2.Identity = k.Identity
@@ -1828,7 +1828,7 @@ func (ms *mapState) addVisibilityKeys(e PolicyOwner, redirectPort uint16, visMet
 
 	// Find Wildcarded L4 denies, i.e., L3-only entries
 	if addL4OnlyKey {
-		ms.denies.ForEachKeyWithPortProto(allKey[key.TrafficDirection], func(k Key, v MapStateEntry) bool {
+		ms.denies.ForEachKeyWithPortProto(allKey[key.TrafficDirection()], func(k Key, v MapStateEntry) bool {
 			if k.Identity != 0 {
 				k2 := key
 				k2.Identity = k.Identity
@@ -1960,13 +1960,13 @@ func (ms *mapState) getIdentities(log *logrus.Logger, denied bool) (ingIdentitie
 			// not be added to these sets.
 			return true
 		}
-		switch trafficdirection.TrafficDirection(policyMapKey.TrafficDirection) {
+		switch trafficdirection.TrafficDirection(policyMapKey.TrafficDirection()) {
 		case trafficdirection.Ingress:
 			ingIdentities = append(ingIdentities, int64(policyMapKey.Identity))
 		case trafficdirection.Egress:
 			egIdentities = append(egIdentities, int64(policyMapKey.Identity))
 		default:
-			td := trafficdirection.TrafficDirection(policyMapKey.TrafficDirection)
+			td := trafficdirection.TrafficDirection(policyMapKey.TrafficDirection())
 			log.WithField(logfields.TrafficDirection, td).
 				Errorf("Unexpected traffic direction present in policy map state for endpoint")
 		}

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -174,11 +174,11 @@ func (e MapStateEntry) WithDependents(keys ...Key) MapStateEntry {
 }
 
 func TestPolicyKeyTrafficDirection(t *testing.T) {
-	k := Key{TrafficDirection: trafficdirection.Ingress.Uint8()}
+	k := IngressL3OnlyKey(0)
 	require.True(t, k.IsIngress())
 	require.Equal(t, false, k.IsEgress())
 
-	k = Key{TrafficDirection: trafficdirection.Egress.Uint8()}
+	k = EgressL3OnlyKey(0)
 	require.Equal(t, false, k.IsIngress())
 	require.True(t, k.IsEgress())
 }
@@ -3166,7 +3166,7 @@ func identityIsSupersetOf(primaryIdentity, compareIdentity uint32, identities Id
 }
 
 func (v *validator) isSupersetOf(a, d Key, identities Identities) {
-	if a.TrafficDirection != d.TrafficDirection {
+	if a.TrafficDirection() != d.TrafficDirection() {
 		panic("TrafficDirection mismatch")
 	}
 	if !identityIsSupersetOf(a.Identity, d.Identity, identities) {
@@ -3177,7 +3177,7 @@ func (v *validator) isSupersetOf(a, d Key, identities Identities) {
 }
 
 func (v *validator) isSupersetOrSame(a, d Key, identities Identities) {
-	if a.TrafficDirection != d.TrafficDirection {
+	if a.TrafficDirection() != d.TrafficDirection() {
 		panic("TrafficDirection mismatch")
 	}
 	if !(a.Identity == d.Identity ||
@@ -3189,7 +3189,7 @@ func (v *validator) isSupersetOrSame(a, d Key, identities Identities) {
 }
 
 func (v *validator) isAnyOrSame(a, d Key, identities Identities) {
-	if a.TrafficDirection != d.TrafficDirection {
+	if a.TrafficDirection() != d.TrafficDirection() {
 		panic("TrafficDirection mismatch")
 	}
 	if !(a.Identity == d.Identity || a.Identity == 0) {
@@ -3200,7 +3200,7 @@ func (v *validator) isAnyOrSame(a, d Key, identities Identities) {
 }
 
 func (v *validator) isBroader(a, d Key) {
-	if a.TrafficDirection != d.TrafficDirection {
+	if a.TrafficDirection() != d.TrafficDirection() {
 		panic("TrafficDirection mismatch")
 	}
 
@@ -3211,7 +3211,7 @@ func (v *validator) isBroader(a, d Key) {
 }
 
 func (v *validator) isBroaderOrEqual(a, d Key) {
-	if a.TrafficDirection != d.TrafficDirection {
+	if a.TrafficDirection() != d.TrafficDirection() {
 		panic("TrafficDirection mismatch")
 	}
 

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -23,104 +23,104 @@ func Test_IsSuperSetOf(t *testing.T) {
 		subSet   Key
 		res      int
 	}{
-		{key(0, 0, 0, 0), key(0, 0, 0, 0), 0},
-		{key(0, 0, 0, 0), key(42, 0, 6, 0), 1},
-		{key(0, 0, 0, 0), key(42, 80, 6, 0), 1},
-		{key(0, 0, 0, 0), key(42, 0, 0, 0), 1},
-		{key(0, 0, 6, 0), key(42, 0, 6, 0), 3}, // port is the same
-		{key(0, 0, 6, 0), key(42, 80, 6, 0), 2},
-		{keyWithPortMask(0, 64, 0xffc0, 6, 0), key(42, 80, 6, 0), 2}, // port range 64-127,80
-		{key(0, 80, 6, 0), key(42, 80, 6, 0), 3},
-		{keyWithPortMask(0, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 3}, // port ranges are the same
-		{key(0, 80, 6, 0), key(42, 80, 17, 0), 0},                                        // proto is different
-		{key(2, 80, 6, 0), key(42, 80, 6, 0), 0},                                         // id is different
-		{key(0, 8080, 6, 0), key(42, 80, 6, 0), 0},                                       // port is different
-		{keyWithPortMask(0, 64, 0xffc0, 6, 0), key(42, 8080, 6, 0), 0},                   // port range is different from port
-		{key(42, 0, 0, 0), key(42, 0, 0, 0), 0},                                          // same key
-		{key(42, 0, 0, 0), key(42, 0, 6, 0), 4},
-		{key(42, 0, 0, 0), key(42, 80, 6, 0), 4},
-		{keyWithPortMask(42, 64, 0xffc0, 0, 0), key(42, 80, 6, 0), 4}, // port range 64-127,80
-		{key(42, 0, 0, 0), key(42, 0, 17, 0), 4},
-		{key(42, 0, 0, 0), key(42, 80, 17, 0), 4},
-		{keyWithPortMask(42, 64, 0xffc0, 0, 0), key(42, 80, 17, 0), 4},
-		{key(42, 0, 6, 0), key(42, 0, 6, 0), 0}, // same key
-		{key(42, 0, 6, 0), key(42, 80, 6, 0), 5},
-		{keyWithPortMask(42, 64, 0xffc0, 6, 0), key(42, 80, 6, 0), 5},
-		{key(42, 0, 6, 0), key(42, 8080, 6, 0), 5},
-		{key(42, 80, 6, 0), key(42, 80, 6, 0), 0},                                          // same key
-		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 0},  // same key
-		{key(42, 80, 6, 0), key(42, 8080, 6, 0), 0},                                        // different port
-		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(42, 128, 0xff80, 6, 0), 0}, // different port ranges
-		{key(42, 80, 6, 0), key(42, 80, 17, 0), 0},                                         // different proto
-		{key(42, 80, 6, 0), key(42, 8080, 17, 0), 0},                                       // different port and proto
+		{IngressL3OnlyKey(0), IngressL3OnlyKey(0), 0},
+		{IngressL3OnlyKey(0), IngressKey(42, 6, 0, 0), 1},
+		{IngressL3OnlyKey(0), IngressKey(42, 6, 80, 0), 1},
+		{IngressL3OnlyKey(0), IngressL3OnlyKey(42), 1},
+		{IngressKey(0, 6, 0, 0), IngressKey(42, 6, 0, 0), 3}, // port is the same
+		{IngressKey(0, 6, 0, 0), IngressKey(42, 6, 80, 0), 2},
+		{IngressKey(0, 6, 64, 10), IngressKey(42, 6, 80, 0), 2}, // port range 64-127,80
+		{IngressKey(0, 6, 80, 0), IngressKey(42, 6, 80, 0), 3},
+		{IngressKey(0, 6, 64, 10), IngressKey(42, 6, 64, 10), 3},  // port ranges are the same
+		{IngressKey(0, 6, 80, 0), IngressKey(42, 17, 80, 0), 0},   // proto is different
+		{IngressKey(2, 6, 80, 0), IngressKey(42, 6, 80, 0), 0},    // id is different
+		{IngressKey(0, 6, 8080, 0), IngressKey(42, 6, 80, 0), 0},  // port is different
+		{IngressKey(0, 6, 64, 10), IngressKey(42, 6, 8080, 0), 0}, // port range is different from port
+		{IngressL3OnlyKey(42), IngressL3OnlyKey(42), 0},           // same key
+		{IngressL3OnlyKey(42), IngressKey(42, 6, 0, 0), 4},
+		{IngressL3OnlyKey(42), IngressKey(42, 6, 80, 0), 4},
+		{IngressKey(42, 0, 64, 10), IngressKey(42, 6, 80, 0), 4}, // port range 64-127,80
+		{IngressL3OnlyKey(42), IngressKey(42, 17, 0, 0), 4},
+		{IngressL3OnlyKey(42), IngressKey(42, 17, 80, 0), 4},
+		{IngressKey(42, 0, 64, 10), IngressKey(42, 17, 80, 0), 4},
+		{IngressKey(42, 6, 0, 0), IngressKey(42, 6, 0, 0), 0}, // same key
+		{IngressKey(42, 6, 0, 0), IngressKey(42, 6, 80, 0), 5},
+		{IngressKey(42, 6, 64, 10), IngressKey(42, 6, 80, 0), 5},
+		{IngressKey(42, 6, 0, 0), IngressKey(42, 6, 8080, 0), 5},
+		{IngressKey(42, 6, 80, 0), IngressKey(42, 6, 80, 0), 0},    // same key
+		{IngressKey(42, 6, 64, 10), IngressKey(42, 6, 64, 10), 0},  // same key
+		{IngressKey(42, 6, 80, 0), IngressKey(42, 6, 8080, 0), 0},  // different port
+		{IngressKey(42, 6, 64, 10), IngressKey(42, 6, 128, 10), 0}, // different port ranges
+		{IngressKey(42, 6, 80, 0), IngressKey(42, 17, 80, 0), 0},   // different proto
+		{IngressKey(42, 6, 80, 0), IngressKey(42, 17, 8080, 0), 0}, // different port and proto
 
 		// increasing specificity for a L3/L4 key
-		{key(0, 0, 0, 0), key(42, 80, 6, 0), 1},
-		{keyWithPortMask(0, 64, 0xffc0, 0, 0), key(42, 80, 6, 0), 1},
-		{key(0, 0, 6, 0), key(42, 80, 6, 0), 2},
-		{keyWithPortMask(0, 64, 0xffc0, 6, 0), key(42, 80, 6, 0), 2},
-		{key(0, 80, 6, 0), key(42, 80, 6, 0), 3},
-		{keyWithPortMask(0, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 3},
-		{key(42, 0, 0, 0), key(42, 80, 6, 0), 4},
-		{keyWithPortMask(42, 64, 0xffc0, 0, 0), key(42, 80, 6, 0), 4},
-		{key(42, 0, 6, 0), key(42, 80, 6, 0), 5},
-		{keyWithPortMask(42, 64, 0xffc0, 6, 0), key(42, 80, 6, 0), 5},
-		{key(42, 80, 6, 0), key(42, 80, 6, 0), 0},                                         // same key
-		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 0}, // same key
+		{IngressL3OnlyKey(0), IngressKey(42, 6, 80, 0), 1},
+		{IngressKey(0, 0, 64, 10), IngressKey(42, 6, 80, 0), 1},
+		{IngressKey(0, 6, 0, 0), IngressKey(42, 6, 80, 0), 2},
+		{IngressKey(0, 6, 64, 10), IngressKey(42, 6, 80, 0), 2},
+		{IngressKey(0, 6, 80, 0), IngressKey(42, 6, 80, 0), 3},
+		{IngressKey(0, 6, 64, 10), IngressKey(42, 6, 64, 10), 3},
+		{IngressL3OnlyKey(42), IngressKey(42, 6, 80, 0), 4},
+		{IngressKey(42, 0, 64, 10), IngressKey(42, 6, 80, 0), 4},
+		{IngressKey(42, 6, 0, 0), IngressKey(42, 6, 80, 0), 5},
+		{IngressKey(42, 6, 64, 10), IngressKey(42, 6, 80, 0), 5},
+		{IngressKey(42, 6, 80, 0), IngressKey(42, 6, 80, 0), 0},   // same key
+		{IngressKey(42, 6, 64, 10), IngressKey(42, 6, 64, 10), 0}, // same key
 
 		// increasing specificity for a L3-only key
-		{key(0, 0, 0, 0), key(42, 0, 0, 0), 1},
-		{keyWithPortMask(0, 64, 0xffc0, 0, 0), key(42, 0, 0, 0), 1},
-		{key(0, 0, 6, 0), key(42, 0, 0, 0), 0},                                            // not a superset
-		{key(0, 80, 6, 0), key(42, 0, 0, 0), 0},                                           // not a superset
-		{keyWithPortMask(0, 64, 0xffc0, 6, 0), key(42, 0, 0, 0), 0},                       // not a superset
-		{key(42, 0, 0, 0), key(42, 0, 0, 0), 0},                                           // same key
-		{key(42, 0, 6, 0), key(42, 0, 0, 0), 0},                                           // not a superset
-		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 0, 0), 0}, // not a superset
-		{key(42, 80, 6, 0), key(42, 0, 0, 0), 0},                                          // not a superset
-		{keyWithPortMask(42, 64, 0xffc0, 6, 0), key(42, 0, 0, 0), 0},                      // not a superset
+		{IngressL3OnlyKey(0), IngressL3OnlyKey(42), 1},
+		{IngressKey(0, 0, 64, 10), IngressL3OnlyKey(42), 1},
+		{IngressKey(0, 6, 0, 0), IngressL3OnlyKey(42), 0},         // not a superset
+		{IngressKey(0, 6, 80, 0), IngressL3OnlyKey(42), 0},        // not a superset
+		{IngressKey(0, 6, 64, 10), IngressL3OnlyKey(42), 0},       // not a superset
+		{IngressL3OnlyKey(42), IngressL3OnlyKey(42), 0},           // same key
+		{IngressKey(42, 6, 0, 0), IngressL3OnlyKey(42), 0},        // not a superset
+		{IngressKey(42, 6, 64, 10), IngressKey(42, 0, 64, 10), 0}, // not a superset
+		{IngressKey(42, 6, 80, 0), IngressL3OnlyKey(42), 0},       // not a superset
+		{IngressKey(42, 6, 64, 10), IngressL3OnlyKey(42), 0},      // not a superset
 
 		// increasing specificity for a L3/proto key
-		{key(0, 0, 0, 0), key(42, 0, 6, 0), 1}, // wildcard
-		{keyWithPortMask(0, 64, 0xffc0, 0, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 1},
-		{key(0, 0, 6, 0), key(42, 0, 6, 0), 3},                                           // ports are the same
-		{keyWithPortMask(0, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 3}, // port ranges are the same
-		{key(0, 80, 6, 0), key(42, 0, 6, 0), 0},                                          // not a superset
-		{key(0, 80, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 0},                     // not a superset
-		{key(42, 0, 0, 0), key(42, 0, 6, 0), 4},
-		{keyWithPortMask(42, 64, 0xffc0, 0, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 4},
-		{key(42, 0, 6, 0), key(42, 0, 6, 0), 0},                                           // same key
-		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 0}, // same key
-		{key(42, 80, 6, 0), key(42, 0, 6, 0), 0},                                          // not a superset
-		{key(42, 80, 6, 0), keyWithPortMask(42, 64, 0xffc0, 6, 0), 0},                     // not a superset
+		{IngressL3OnlyKey(0), IngressKey(42, 6, 0, 0), 1}, // wildcard
+		{IngressKey(0, 0, 64, 10), IngressKey(42, 6, 64, 10), 1},
+		{IngressKey(0, 6, 0, 0), IngressKey(42, 6, 0, 0), 3},     // ports are the same
+		{IngressKey(0, 6, 64, 10), IngressKey(42, 6, 64, 10), 3}, // port ranges are the same
+		{IngressKey(0, 6, 80, 0), IngressKey(42, 6, 0, 0), 0},    // not a superset
+		{IngressKey(0, 6, 80, 0), IngressKey(42, 6, 64, 10), 0},  // not a superset
+		{IngressL3OnlyKey(42), IngressKey(42, 6, 0, 0), 4},
+		{IngressKey(42, 0, 64, 10), IngressKey(42, 6, 64, 10), 4},
+		{IngressKey(42, 6, 0, 0), IngressKey(42, 6, 0, 0), 0},     // same key
+		{IngressKey(42, 6, 64, 10), IngressKey(42, 6, 64, 10), 0}, // same key
+		{IngressKey(42, 6, 80, 0), IngressKey(42, 6, 0, 0), 0},    // not a superset
+		{IngressKey(42, 6, 80, 0), IngressKey(42, 6, 64, 10), 0},  // not a superset
 
 		// increasing specificity for a proto-only key
-		{key(0, 0, 0, 0), key(0, 0, 6, 0), 1},
-		{keyWithPortMask(0, 64, 0xffc0, 0, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 1},
-		{key(0, 0, 6, 0), key(0, 0, 6, 0), 0},                                            // same key
-		{keyWithPortMask(0, 64, 0xffc0, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0},  // same key
-		{key(0, 80, 6, 0), key(0, 0, 6, 0), 0},                                           // not a superset
-		{key(0, 80, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0},                      // not a superset
-		{key(42, 0, 0, 0), key(0, 0, 6, 0), 0},                                           // not a superset
-		{keyWithPortMask(42, 64, 0xffc0, 0, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0}, // not a superset
-		{key(42, 0, 6, 0), key(0, 0, 6, 0), 0},                                           // not a superset
-		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0}, // not a superset
-		{key(42, 80, 6, 0), key(0, 0, 6, 0), 0},                                          // not a superset
-		{key(42, 80, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0},                     // not a superset
+		{IngressL3OnlyKey(0), IngressKey(0, 6, 0, 0), 1},
+		{IngressKey(0, 0, 64, 10), IngressKey(0, 6, 64, 10), 1},
+		{IngressKey(0, 6, 0, 0), IngressKey(0, 6, 0, 0), 0},      // same key
+		{IngressKey(0, 6, 64, 10), IngressKey(0, 6, 64, 10), 0},  // same key
+		{IngressKey(0, 6, 80, 0), IngressKey(0, 6, 0, 0), 0},     // not a superset
+		{IngressKey(0, 6, 80, 0), IngressKey(0, 6, 64, 10), 0},   // not a superset
+		{IngressL3OnlyKey(42), IngressKey(0, 6, 0, 0), 0},        // not a superset
+		{IngressKey(42, 0, 64, 10), IngressKey(0, 6, 64, 10), 0}, // not a superset
+		{IngressKey(42, 6, 0, 0), IngressKey(0, 6, 0, 0), 0},     // not a superset
+		{IngressKey(42, 6, 64, 10), IngressKey(0, 6, 64, 10), 0}, // not a superset
+		{IngressKey(42, 6, 80, 0), IngressKey(0, 6, 0, 0), 0},    // not a superset
+		{IngressKey(42, 6, 80, 0), IngressKey(0, 6, 64, 10), 0},  // not a superset
 
 		// increasing specificity for a L4-only key
-		{key(0, 0, 0, 0), key(0, 80, 6, 0), 1},
-		{keyWithPortMask(0, 64, 0xffc0, 0, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 1},
-		{key(0, 0, 6, 0), key(0, 80, 6, 0), 2},
-		{keyWithPortMask(0, 64, 0xffc0, 6, 0), key(0, 80, 6, 0), 2},
-		{key(0, 80, 6, 0), key(0, 80, 6, 0), 0},                                          // same key
-		{keyWithPortMask(0, 64, 0xffc0, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0},  // same key
-		{key(42, 0, 0, 0), key(0, 80, 6, 0), 0},                                          // not a superset
-		{keyWithPortMask(42, 64, 0xffc0, 0, 0), key(0, 80, 6, 0), 0},                     // not a superset
-		{key(42, 0, 6, 0), key(0, 80, 6, 0), 0},                                          // not a superset
-		{keyWithPortMask(42, 64, 0xffc0, 6, 0), key(0, 80, 6, 0), 0},                     // not a superset
-		{key(42, 80, 6, 0), key(0, 80, 6, 0), 0},                                         // not a superset
-		{keyWithPortMask(42, 64, 0xffc0, 6, 0), keyWithPortMask(0, 64, 0xffc0, 6, 0), 0}, // not a superset
+		{IngressL3OnlyKey(0), IngressKey(0, 6, 80, 0), 1},
+		{IngressKey(0, 0, 64, 10), IngressKey(0, 6, 64, 10), 1},
+		{IngressKey(0, 6, 0, 0), IngressKey(0, 6, 80, 0), 2},
+		{IngressKey(0, 6, 64, 10), IngressKey(0, 6, 80, 0), 2},
+		{IngressKey(0, 6, 80, 0), IngressKey(0, 6, 80, 0), 0},    // same key
+		{IngressKey(0, 6, 64, 10), IngressKey(0, 6, 64, 10), 0},  // same key
+		{IngressL3OnlyKey(42), IngressKey(0, 6, 80, 0), 0},       // not a superset
+		{IngressKey(42, 0, 64, 10), IngressKey(0, 6, 80, 0), 0},  // not a superset
+		{IngressKey(42, 6, 0, 0), IngressKey(0, 6, 80, 0), 0},    // not a superset
+		{IngressKey(42, 6, 64, 10), IngressKey(0, 6, 80, 0), 0},  // not a superset
+		{IngressKey(42, 6, 80, 0), IngressKey(0, 6, 80, 0), 0},   // not a superset
+		{IngressKey(42, 6, 64, 10), IngressKey(0, 6, 64, 10), 0}, // not a superset
 
 	}
 	for i, tt := range tests {
@@ -199,7 +199,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		identity.NumericIdentity(identityFoo): labelsFoo,
 	}
 	selectorCache := testNewSelectorCache(identityCache)
-	testMapState := func(initMap map[Key]MapStateEntry) *mapState {
+	testMapState := func(initMap MapStateMap) *mapState {
 		return newMapState().withState(initMap, selectorCache)
 	}
 
@@ -211,38 +211,24 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		name                  string
 		ms, want              *mapState
 		wantAdds, wantDeletes Keys
-		wantOld               map[Key]MapStateEntry
+		wantOld               MapStateMap
 		args                  args
 	}{
 		{
 			name: "test-1 - no KV added, map should remain the same",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         0,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: 0,
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressL3OnlyKey(0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			}),
 			args: args{
-				key: Key{
-					InvertedPortMask: 0xffff,
-				},
+				key:   IngressL3OnlyKey(0),
 				entry: MapStateEntry{},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         0,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: 0,
-				}: {
+			want: testMapState(MapStateMap{
+				IngressL3OnlyKey(0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
@@ -250,168 +236,97 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			}),
 			wantAdds:    Keys{},
 			wantDeletes: Keys{},
-			wantOld:     map[Key]MapStateEntry{},
+			wantOld:     MapStateMap{},
 		},
 		{
 			name: "test-2a - L3 allow KV should not overwrite deny entry",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressL3OnlyKey(1),
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			wantAdds: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressL3OnlyKey(1): struct{}{},
 			},
 			wantDeletes: Keys{},
-			wantOld:     map[Key]MapStateEntry{},
+			wantOld:     MapStateMap{},
 		},
 		{
 			name: "test-2b - L3 port-range allow KV should not overwrite deny entry",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressKey(1, 3, 64, 10), // port range 64-127 (64/10)
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			wantAdds: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressKey(1, 3, 64, 10): struct{}{},
 			},
 			wantDeletes: Keys{},
-			wantOld:     map[Key]MapStateEntry{},
+			wantOld:     MapStateMap{},
 		},
 		{
 			name: "test-3a - L3-L4 allow KV should not overwrite deny entry",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressKey(1, 3, 80, 0),
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
@@ -419,45 +334,27 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			}),
 			wantAdds:    Keys{},
 			wantDeletes: Keys{},
-			wantOld:     map[Key]MapStateEntry{},
+			wantOld:     MapStateMap{},
 		},
 		{
 			name: "test-3b - L3-L4 port-range allow KV should not overwrite deny entry",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressKey(1, 3, 64, 10), // port range 64-127 (64/10)
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
@@ -465,63 +362,38 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			}),
 			wantAdds:    Keys{},
 			wantDeletes: Keys{},
-			wantOld:     map[Key]MapStateEntry{},
+			wantOld:     MapStateMap{},
 		},
 		{
 			name: "test-4a - L3-L4 deny KV should overwrite allow entry",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressKey(1, 3, 80, 0),
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			wantAdds: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressKey(1, 3, 80, 0): struct{}{},
 			},
 			wantDeletes: Keys{},
-			wantOld: map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			wantOld: MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
@@ -530,69 +402,36 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-4b - L3-L4 port-range deny KV should overwrite allow entry",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressKey(1, 3, 64, 10), // port range 64-127 (64/10)
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			wantAdds: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressKey(1, 3, 64, 10): struct{}{},
 			},
 			wantDeletes: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressKey(1, 3, 80, 0): struct{}{},
 			},
-			wantOld: map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			wantOld: MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
@@ -601,133 +440,66 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-5a - L3 deny KV should overwrite all L3-L4 allow and L3 allow entries for the same L3",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         2,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(2, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         2,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressL3OnlyKey(2): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressL3OnlyKey(1),
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-				{
-					Identity:         2,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(2, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         2,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressL3OnlyKey(2): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			}),
 			wantAdds: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressL3OnlyKey(1): struct{}{},
 			},
 			wantDeletes: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressKey(1, 3, 80, 0): struct{}{},
 			},
-			wantOld: map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			wantOld: MapStateMap{
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
@@ -736,133 +508,66 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-5b - L3 port-range deny KV should overwrite all L3-L4 allow and L3 allow entries for the same L3",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         2,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(2, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         2,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(2, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressKey(1, 3, 64, 10), // port range 64-127 (64/10)
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-				{
-					Identity:         2,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(2, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         2,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(2, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			}),
 			wantAdds: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressKey(1, 3, 64, 10): struct{}{},
 			},
 			wantDeletes: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressKey(1, 3, 80, 0): struct{}{},
 			},
-			wantOld: map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			wantOld: MapStateMap{
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
@@ -871,294 +576,153 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-6a - L3 egress deny KV should not overwrite any existing ingress allow",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         2,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(2, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         2,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressL3OnlyKey(2): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Egress.Uint8(),
-				},
+				key: EgressL3OnlyKey(1),
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: {
+				EgressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-				{
-					Identity:         2,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(2, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         2,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressL3OnlyKey(2): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			}),
 			wantAdds: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: struct{}{},
+				EgressL3OnlyKey(1): struct{}{},
 			},
 			wantDeletes: Keys{},
-			wantOld:     map[Key]MapStateEntry{},
+			wantOld:     MapStateMap{},
 		},
 		{
 			name: "test-6b - L3 egress port-range deny KV should not overwrite any existing ingress allow",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         2,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(2, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         2,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(2, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Egress.Uint8(),
-				},
+				key: EgressKey(1, 3, 64, 10), // port range 64-127 (64/10)
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: {
+				EgressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-				{
-					Identity:         2,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(2, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         2,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(2, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			}),
 			wantAdds: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: struct{}{},
+				EgressKey(1, 3, 64, 10): struct{}{},
 			},
 			wantDeletes: Keys{},
-			wantOld:     map[Key]MapStateEntry{},
+			wantOld:     MapStateMap{},
 		},
 		{
 			name: "test-7a - L3 ingress deny KV should not be overwritten by a L3-L4 ingress allow",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressKey(1, 3, 80, 0),
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
@@ -1166,45 +730,27 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			}),
 			wantAdds:    Keys{},
 			wantDeletes: Keys{},
-			wantOld:     map[Key]MapStateEntry{},
+			wantOld:     MapStateMap{},
 		},
 		{
 			name: "test-7b - L3 ingress deny KV should not be overwritten by a L3-L4 port-range ingress allow",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressKey(1, 3, 64, 10), // port range 64-127 (64/10)
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
@@ -1212,30 +758,19 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			}),
 			wantAdds:    Keys{},
 			wantDeletes: Keys{},
-			wantOld:     map[Key]MapStateEntry{},
+			wantOld:     MapStateMap{},
 		},
 		{
 			name: "test-8a - L3 ingress deny KV should not be overwritten by a L3-L4-L7 ingress allow",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressKey(1, 3, 80, 0),
 				entry: MapStateEntry{
 					ProxyPort:        8080,
 					priority:         8080,
@@ -1243,14 +778,8 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           false,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
@@ -1258,31 +787,19 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			}),
 			wantAdds:    Keys{},
 			wantDeletes: Keys{},
-			wantOld:     map[Key]MapStateEntry{},
+			wantOld:     MapStateMap{},
 		},
 		{
 			name: "test-8b - L3 ingress deny KV should not be overwritten by a L3-L4-L7 port-range ingress allow",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressKey(1, 3, 64, 10), // port range 64-127 (64/10)
 				entry: MapStateEntry{
 					ProxyPort:        8080,
 					priority:         8080,
@@ -1290,14 +807,8 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					IsDeny:           false,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
@@ -1305,17 +816,12 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			}),
 			wantAdds:    Keys{},
 			wantDeletes: Keys{},
-			wantOld:     map[Key]MapStateEntry{},
+			wantOld:     MapStateMap{},
 		},
 		{
 			name: "test-9a - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
@@ -1323,56 +829,28 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressL3OnlyKey(1),
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			wantAdds: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressL3OnlyKey(1): struct{}{},
 			},
 			wantDeletes: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressKey(1, 3, 80, 0): struct{}{},
 			},
-			wantOld: map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			wantOld: MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
@@ -1382,14 +860,8 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-9b - L3 ingress deny KV should overwrite a L3-L4-L7 port-range ingress allow",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
@@ -1397,58 +869,28 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressL3OnlyKey(1),
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			wantAdds: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressL3OnlyKey(1): struct{}{},
 			},
 			wantDeletes: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressKey(1, 3, 64, 10): struct{}{},
 			},
-			wantOld: map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			wantOld: MapStateMap{
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
@@ -1458,97 +900,49 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-10a - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow and a L3-L4 deny",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressL3OnlyKey(1),
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			wantAdds: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressL3OnlyKey(1): struct{}{},
 			},
 			wantDeletes: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
-				Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressKey(1, 3, 80, 0): struct{}{},
+				IngressKey(1, 3, 80, 0): struct{}{},
 			},
-			wantOld: map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			wantOld: MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
@@ -1557,103 +951,49 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-10b - L3 ingress deny KV should overwrite a L3-L4-L7 port-range ingress allow and a L3-L4 port-range deny",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressL3OnlyKey(1),
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressL3OnlyKey(1): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			wantAdds: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressL3OnlyKey(1): struct{}{},
 			},
 			wantDeletes: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
-				Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressKey(1, 3, 64, 10): struct{}{},
+				IngressKey(1, 3, 64, 10): struct{}{},
 			},
-			wantOld: map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			wantOld: MapStateMap{
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
@@ -1662,63 +1002,35 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-11a - L3 ingress allow should not be allowed if there is a L3 'all' deny",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				EgressKey(1, 3, 80, 0): {
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         0,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressL3OnlyKey(0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         100,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressL3OnlyKey(100),
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				EgressKey(1, 3, 80, 0): {
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         0,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressL3OnlyKey(0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
@@ -1726,69 +1038,39 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			}),
 			wantAdds:    Keys{},
 			wantDeletes: Keys{},
-			wantOld:     map[Key]MapStateEntry{},
+			wantOld:     MapStateMap{},
 		},
 		{
 			name: "test-11b - L3 ingress allow should not be allowed if there is a L3 'all' deny",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				EgressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         0,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressL3OnlyKey(0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         100,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressL3OnlyKey(100),
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				EgressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         0,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressL3OnlyKey(0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
@@ -1796,39 +1078,24 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			}),
 			wantAdds:    Keys{},
 			wantDeletes: Keys{},
-			wantOld:     map[Key]MapStateEntry{},
+			wantOld:     MapStateMap{},
 		},
 		{
 			name: "test-12a - inserting a L3 'all' deny should delete all entries for that direction",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         5,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(1, 3, 5, 0): {
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         100,
-					DestPort:         5,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: {
+				EgressKey(100, 3, 5, 0): {
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
@@ -1836,37 +1103,20 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         0,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressL3OnlyKey(0),
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         0,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressL3OnlyKey(0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-				{
-					Identity:         100,
-					DestPort:         5,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: {
+				EgressKey(100, 3, 5, 0): {
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
@@ -1874,46 +1124,20 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				},
 			}),
 			wantAdds: Keys{
-				Key{
-					Identity:         0,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressL3OnlyKey(0): struct{}{},
 			},
 			wantDeletes: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
-				Key{
-					Identity:         1,
-					DestPort:         5,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressKey(1, 3, 80, 0): struct{}{},
+				IngressKey(1, 3, 5, 0):  struct{}{},
 			},
-			wantOld: map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			wantOld: MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         5,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(1, 3, 5, 0): {
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
@@ -1923,38 +1147,20 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-12b - inserting a L3 'all' deny should delete all entries for that direction (including port ranges)",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         4,
-					InvertedPortMask: ^uint16(0xfffc), // port range 4-7
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(1, 3, 4, 14): {
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         100,
-					DestPort:         4,
-					InvertedPortMask: ^uint16(0xfffc), // port range 4-7
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: {
+				EgressKey(100, 3, 4, 14): {
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
@@ -1962,38 +1168,20 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         0,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressL3OnlyKey(0),
 				entry: MapStateEntry{
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         0,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressL3OnlyKey(0): {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-				{
-					Identity:         100,
-					DestPort:         4,
-					InvertedPortMask: ^uint16(0xfffc), // port range 4-7
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: {
+				EgressKey(100, 3, 4, 14): {
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
@@ -2001,50 +1189,20 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				},
 			}),
 			wantAdds: Keys{
-				Key{
-					Identity:         0,
-					DestPort:         0,
-					InvertedPortMask: 0xffff,
-					Nexthdr:          0,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressL3OnlyKey(0): struct{}{},
 			},
 			wantDeletes: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
-				Key{
-					Identity:         1,
-					DestPort:         4,
-					InvertedPortMask: ^uint16(0xfffc), // port range 4-7
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressKey(1, 3, 64, 10): struct{}{},
+				IngressKey(1, 3, 4, 14):  struct{}{},
 			},
-			wantOld: map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0), // port range 64-127
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			wantOld: MapStateMap{
+				IngressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				{
-					Identity:         1,
-					DestPort:         4,
-					InvertedPortMask: ^uint16(0xfffc), // port range 4-7
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+				IngressKey(1, 3, 4, 14): {
 					ProxyPort:        8080,
 					priority:         8080,
 					DerivedFromRules: nil,
@@ -2054,59 +1212,34 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-13a - L3-L4-L7 ingress allow should overwrite a L3-L4-L7 ingress allow due to lower priority",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort: 8080,
 					priority:  8080,
 					Listener:  "listener1",
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressKey(1, 3, 80, 0),
 				entry: MapStateEntry{
 					ProxyPort: 9090,
 					priority:  1,
 					Listener:  "listener2",
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort: 9090,
 					priority:  1,
 					Listener:  "listener2",
 				},
 			}),
 			wantAdds: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressKey(1, 3, 80, 0): struct{}{},
 			},
 			wantDeletes: Keys{},
-			wantOld: map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			wantOld: MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort: 8080,
 					priority:  8080,
 					Listener:  "listener1",
@@ -2115,64 +1248,34 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-13b - L3-L4-L7 port-range ingress allow should overwrite a L3-L4-L7 port-range ingress allow due to lower priority",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0),
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 64, 10): {
 					ProxyPort: 8080,
 					priority:  8080,
 					Listener:  "listener1",
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0),
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressKey(1, 3, 64, 10),
 				entry: MapStateEntry{
 					ProxyPort: 9090,
 					priority:  1,
 					Listener:  "listener2",
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0),
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressKey(1, 3, 64, 10): {
 					ProxyPort: 9090,
 					priority:  1,
 					Listener:  "listener2",
 				},
 			}),
 			wantAdds: Keys{
-				Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0),
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: struct{}{},
+				IngressKey(1, 3, 64, 10): struct{}{},
 			},
 			wantDeletes: Keys{},
-			wantOld: map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0),
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			wantOld: MapStateMap{
+				IngressKey(1, 3, 64, 10): {
 					ProxyPort: 8080,
 					priority:  8080,
 					Listener:  "listener1",
@@ -2181,38 +1284,23 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-14a - L4-L7 ingress allow should overwrite a L3-L4-L7 ingress allow due to lower priority on the same port",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort: 8080,
 					priority:  8080,
 					Listener:  "listener1",
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressKey(1, 3, 80, 0),
 				entry: MapStateEntry{
 					ProxyPort: 8080,
 					priority:  1,
 					Listener:  "listener1",
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort: 8080,
 					priority:  1,
 					Listener:  "listener1",
@@ -2220,13 +1308,8 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			}),
 			wantAdds:    Keys{},
 			wantDeletes: Keys{},
-			wantOld: map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         80,
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			wantOld: MapStateMap{
+				IngressKey(1, 3, 80, 0): {
 					ProxyPort: 8080,
 					priority:  8080,
 					Listener:  "listener1",
@@ -2235,41 +1318,23 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		},
 		{
 			name: "test-14b - L4-L7 port-range ingress allow should overwrite a L3-L4-L7 port-range ingress allow due to lower priority on the same port",
-			ms: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0),
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			ms: testMapState(MapStateMap{
+				IngressKey(1, 3, 64, 10): {
 					ProxyPort: 8080,
 					priority:  8080,
 					Listener:  "listener1",
 				},
 			}),
 			args: args{
-				key: Key{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0),
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				},
+				key: IngressKey(1, 3, 64, 10),
 				entry: MapStateEntry{
 					ProxyPort: 8080,
 					priority:  1,
 					Listener:  "listener1",
 				},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0),
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			want: testMapState(MapStateMap{
+				IngressKey(1, 3, 64, 10): {
 					ProxyPort: 8080,
 					priority:  1,
 					Listener:  "listener1",
@@ -2277,14 +1342,8 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			}),
 			wantAdds:    Keys{},
 			wantDeletes: Keys{},
-			wantOld: map[Key]MapStateEntry{
-				{
-					Identity:         1,
-					DestPort:         64,
-					InvertedPortMask: ^uint16(0xffc0),
-					Nexthdr:          3,
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: {
+			wantOld: MapStateMap{
+				IngressKey(1, 3, 64, 10): {
 					ProxyPort: 8080,
 					priority:  8080,
 					Listener:  "listener1",
@@ -2296,10 +1355,10 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		changes := ChangeState{
 			Adds:    make(Keys),
 			Deletes: make(Keys),
-			Old:     make(map[Key]MapStateEntry),
+			Old:     make(MapStateMap),
 		}
 		// copy the starting point
-		ms := testMapState(make(map[Key]MapStateEntry, tt.ms.Len()))
+		ms := testMapState(make(MapStateMap, tt.ms.Len()))
 		tt.ms.ForEach(func(k Key, v MapStateEntry) bool {
 			ms.insert(k, v, selectorCache)
 			return true
@@ -2318,53 +1377,39 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 	}
 }
 
-func testKey(id int, port uint16, proto uint8, direction trafficdirection.TrafficDirection) Key {
-	var invertedPortMask uint16
-	if port == 0 {
-		invertedPortMask = 0xffff
-	}
-	return Key{
-		Identity:         uint32(id),
-		DestPort:         port,
-		InvertedPortMask: invertedPortMask,
-		Nexthdr:          proto,
-		TrafficDirection: direction.Uint8(),
-	}
+func testIngressKey(id uint32, port uint16, proto uint8) Key {
+	return IngressKey(id, proto, port, 0)
 }
 
-func testIngressKey(id int, port uint16, proto uint8) Key {
-	return testKey(id, port, proto, trafficdirection.Ingress)
+func testEgressKey(id uint32, port uint16, proto uint8) Key {
+	return EgressKey(id, proto, port, 0)
 }
 
-func testEgressKey(id int, port uint16, proto uint8) Key {
-	return testKey(id, port, proto, trafficdirection.Egress)
+func DNSUDPEgressKey(id uint32) Key {
+	return EgressKey(id, 17, 53, 0)
 }
 
-func DNSUDPEgressKey(id int) Key {
-	return testEgressKey(id, 53, 17)
-}
-
-func DNSTCPEgressKey(id int) Key {
-	return testEgressKey(id, 53, 6)
+func DNSTCPEgressKey(id uint32) Key {
+	return EgressKey(id, 6, 53, 0)
 }
 
 func HostIngressKey() Key {
-	return testIngressKey(1, 0, 0)
+	return IngressL3OnlyKey(1)
 }
 
 func AnyIngressKey() Key {
-	return testIngressKey(0, 0, 0)
+	return IngressL3OnlyKey(0)
 }
 
 func AnyEgressKey() Key {
 	return testEgressKey(0, 0, 0)
 }
 
-func HttpIngressKey(id int) Key {
+func HttpIngressKey(id uint32) Key {
 	return testIngressKey(id, 80, 6)
 }
 
-func HttpEgressKey(id int) Key {
+func HttpEgressKey(id uint32) Key {
 	return testEgressKey(id, 80, 6)
 }
 
@@ -2410,7 +1455,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		identity.NumericIdentity(identityFoo): labelsFoo,
 	}
 	selectorCache := testNewSelectorCache(identityCache)
-	testMapState := func(initMap map[Key]MapStateEntry) *mapState {
+	testMapState := func(initMap MapStateMap) *mapState {
 		return newMapState().withState(initMap, selectorCache)
 	}
 
@@ -2434,22 +1479,22 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		deletes   Keys
 	}{{
 		name: "test-1a - Adding L3-deny to an existing allow-all with L4-only allow redirect map state entries",
-		setup: testMapState(map[Key]MapStateEntry{
+		setup: testMapState(MapStateMap{
 			AnyIngressKey():   allowEntry(0),
 			HttpIngressKey(0): allowEntry(12345, nil),
 		}),
 		args: []args{
 			{cs: csFoo, adds: []int{41}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: testMapState(map[Key]MapStateEntry{
-			AnyIngressKey():          allowEntry(0),
-			testIngressKey(41, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(41)),
-			HttpIngressKey(0):        allowEntry(12345, nil),
-			HttpIngressKey(41):       denyEntry(0).WithOwners(testIngressKey(41, 0, 0)),
+		state: testMapState(MapStateMap{
+			AnyIngressKey():      allowEntry(0),
+			IngressL3OnlyKey(41): denyEntry(0, csFoo).WithDependents(HttpIngressKey(41)),
+			HttpIngressKey(0):    allowEntry(12345, nil),
+			HttpIngressKey(41):   denyEntry(0).WithOwners(IngressL3OnlyKey(41)),
 		}),
 		adds: Keys{
-			testIngressKey(41, 0, 0): {},
-			HttpIngressKey(41):       {},
+			IngressL3OnlyKey(41): {},
+			HttpIngressKey(41):   {},
 		},
 		deletes: Keys{},
 	}, {
@@ -2458,17 +1503,17 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{42}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: testMapState(map[Key]MapStateEntry{
-			AnyIngressKey():          allowEntry(0),
-			testIngressKey(41, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(41)),
-			testIngressKey(42, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(42)),
-			HttpIngressKey(0):        allowEntry(12345, nil),
-			HttpIngressKey(41):       denyEntry(0).WithOwners(testIngressKey(41, 0, 0)),
-			HttpIngressKey(42):       denyEntry(0).WithOwners(testIngressKey(42, 0, 0)),
+		state: testMapState(MapStateMap{
+			AnyIngressKey():      allowEntry(0),
+			IngressL3OnlyKey(41): denyEntry(0, csFoo).WithDependents(HttpIngressKey(41)),
+			IngressL3OnlyKey(42): denyEntry(0, csFoo).WithDependents(HttpIngressKey(42)),
+			HttpIngressKey(0):    allowEntry(12345, nil),
+			HttpIngressKey(41):   denyEntry(0).WithOwners(IngressL3OnlyKey(41)),
+			HttpIngressKey(42):   denyEntry(0).WithOwners(IngressL3OnlyKey(42)),
 		}),
 		adds: Keys{
-			testIngressKey(42, 0, 0): {},
-			HttpIngressKey(42):       {},
+			IngressL3OnlyKey(42): {},
+			HttpIngressKey(42):   {},
 		},
 		deletes: Keys{},
 	}, {
@@ -2477,23 +1522,23 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: nil, deletes: []int{42}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: testMapState(map[Key]MapStateEntry{
-			AnyIngressKey():          allowEntry(0),
-			testIngressKey(41, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(41)),
-			HttpIngressKey(0):        allowEntry(12345, nil),
-			HttpIngressKey(41):       denyEntry(0).WithOwners(testIngressKey(41, 0, 0)),
+		state: testMapState(MapStateMap{
+			AnyIngressKey():      allowEntry(0),
+			IngressL3OnlyKey(41): denyEntry(0, csFoo).WithDependents(HttpIngressKey(41)),
+			HttpIngressKey(0):    allowEntry(12345, nil),
+			HttpIngressKey(41):   denyEntry(0).WithOwners(IngressL3OnlyKey(41)),
 		}),
 		adds: Keys{},
 		deletes: Keys{
-			testIngressKey(42, 0, 0): {},
-			HttpIngressKey(42):       {},
+			IngressL3OnlyKey(42): {},
+			HttpIngressKey(42):   {},
 		},
 	}, {
 		name: "test-2a - Adding 2 identities, and deleting a nonexisting key on an empty state",
 		args: []args{
 			{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			HttpIngressKey(42): denyEntry(0, csFoo),
 			HttpIngressKey(43): denyEntry(0, csFoo),
 		}),
@@ -2508,7 +1553,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csBar, adds: []int{42, 44}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			HttpIngressKey(42): denyEntry(0, csFoo, csBar),
 			HttpIngressKey(43): denyEntry(0, csFoo),
 			HttpIngressKey(44): denyEntry(0, csBar),
@@ -2523,7 +1568,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			HttpIngressKey(42): denyEntry(0, csBar),
 			HttpIngressKey(43): denyEntry(0, csFoo),
 			HttpIngressKey(44): denyEntry(0, csBar),
@@ -2536,7 +1581,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			HttpIngressKey(42): denyEntry(0, csBar),
 			HttpIngressKey(43): denyEntry(0, csFoo),
 			HttpIngressKey(44): denyEntry(0, csBar),
@@ -2549,7 +1594,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csBar, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			HttpIngressKey(43): denyEntry(0, csFoo),
 			HttpIngressKey(44): denyEntry(0, csBar),
 		}),
@@ -2563,7 +1608,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csBar, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			HttpIngressKey(43): denyEntry(0, csFoo),
 			HttpIngressKey(44): denyEntry(0, csBar),
 		}),
@@ -2572,7 +1617,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 	}, {
 		continued: false,
 		name:      "test-3a - egress allow with deny-L3",
-		setup: testMapState(map[Key]MapStateEntry{
+		setup: testMapState(MapStateMap{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
@@ -2581,7 +1626,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
@@ -2595,7 +1640,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 			{cs: csBar, adds: []int{43}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
 			{cs: csBar, adds: []int{43}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
@@ -2613,7 +1658,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
@@ -2628,7 +1673,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 	}, {
 		continued: false,
 		name:      "test-4a - Add L7 skipped due to covering L3 deny",
-		setup: testMapState(map[Key]MapStateEntry{
+		setup: testMapState(MapStateMap{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
@@ -2636,7 +1681,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{42}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
@@ -2650,7 +1695,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 			{cs: csFoo, adds: []int{42}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
@@ -2659,23 +1704,23 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		deletes: Keys{},
 	}, {
 		name: "test-5 - Adding L3-deny to an existing allow-all",
-		setup: testMapState(map[Key]MapStateEntry{
+		setup: testMapState(MapStateMap{
 			AnyIngressKey(): allowEntry(0),
 		}),
 		args: []args{
 			{cs: csFoo, adds: []int{41}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: testMapState(map[Key]MapStateEntry{
-			AnyIngressKey():          allowEntry(0),
-			testIngressKey(41, 0, 0): denyEntry(0, csFoo),
+		state: testMapState(MapStateMap{
+			AnyIngressKey():      allowEntry(0),
+			IngressL3OnlyKey(41): denyEntry(0, csFoo),
 		}),
 		adds: Keys{
-			testIngressKey(41, 0, 0): {},
+			IngressL3OnlyKey(41): {},
 		},
 		deletes: Keys{},
 	}, {
 		name: "test-6 - Multiple dependent entries",
-		setup: testMapState(map[Key]MapStateEntry{
+		setup: testMapState(MapStateMap{
 			AnyEgressKey():     allowEntry(0),
 			HttpEgressKey(0):   allowEntry(12345, nil),
 			DNSUDPEgressKey(0): allowEntry(12346, nil),
@@ -2683,7 +1728,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{41}, deletes: []int{}, port: 0, proto: 0, ingress: false, redirect: false, deny: true},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			AnyEgressKey():          allowEntry(0),
 			testEgressKey(41, 0, 0): denyEntry(0, csFoo).WithDependents(HttpEgressKey(41), DNSUDPEgressKey(41)),
 			HttpEgressKey(0):        allowEntry(12345, nil),
@@ -2735,11 +1780,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 			if x.cs != nil {
 				cs = x.cs
 			}
-			var invertedPortMask uint16
-			if x.port == 0 {
-				invertedPortMask = 0xffff
-			}
-			key := Key{DestPort: x.port, InvertedPortMask: invertedPortMask, Nexthdr: x.proto, TrafficDirection: dir.Uint8()}
+			key := NewKey(dir.Uint8(), 0, x.proto, x.port, 0)
 			var proxyPort uint16
 			if x.redirect {
 				proxyPort = 1
@@ -2764,7 +1805,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		identity.NumericIdentity(identityFoo): labelsFoo,
 	}
 	selectorCache := testNewSelectorCache(identityCache)
-	testMapState := func(initMap map[Key]MapStateEntry) *mapState {
+	testMapState := func(initMap MapStateMap) *mapState {
 		return newMapState().withState(initMap, selectorCache)
 	}
 
@@ -2792,7 +1833,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			HttpIngressKey(42): allowEntry(0, csFoo),
 			HttpIngressKey(43): allowEntry(0, csFoo),
 		}),
@@ -2807,7 +1848,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		args: []args{
 			{cs: csBar, adds: []int{42, 44}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			HttpIngressKey(42): allowEntry(0, csFoo, csBar),
 			HttpIngressKey(43): allowEntry(0, csFoo),
 			HttpIngressKey(44): allowEntry(0, csBar),
@@ -2822,7 +1863,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			HttpIngressKey(42): allowEntry(0, csBar),
 			HttpIngressKey(43): allowEntry(0, csFoo),
 			HttpIngressKey(44): allowEntry(0, csBar),
@@ -2835,7 +1876,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			HttpIngressKey(42): allowEntry(0, csBar),
 			HttpIngressKey(43): allowEntry(0, csFoo),
 			HttpIngressKey(44): allowEntry(0, csBar),
@@ -2848,7 +1889,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		args: []args{
 			{cs: csBar, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			HttpIngressKey(43): allowEntry(0, csFoo),
 			HttpIngressKey(44): allowEntry(0, csBar),
 		}),
@@ -2862,7 +1903,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		args: []args{
 			{cs: csBar, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			HttpIngressKey(43): allowEntry(0, csFoo),
 			HttpIngressKey(44): allowEntry(0, csBar),
 		}),
@@ -2877,7 +1918,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			AnyIngressKey():     allowEntry(0, nil),
 			HostIngressKey():    allowEntry(0, nil),
 			DNSUDPEgressKey(42): allowEntry(0, csBar),
@@ -2896,7 +1937,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			AnyIngressKey():     allowEntry(0, nil),
 			HostIngressKey():    allowEntry(0, nil),
 			DNSUDPEgressKey(42): allowEntry(0, csBar),
@@ -2928,7 +1969,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{cs: csFoo, adds: []int{}, deletes: []int{44}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 			{cs: csFoo, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			HttpEgressKey(44): allowEntry(1, csFoo),
 		}),
 		adds: Keys{
@@ -2943,7 +1984,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{cs: csFoo, adds: []int{43}, proto: 6, hasAuth: ExplicitAuthType, authType: AuthTypeSpire},
 			{cs: csBar, adds: []int{43}, port: 80, proto: 6, redirect: true},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			testEgressKey(43, 0, 0):  allowEntry(0, csFoo).WithAuthType(AuthTypeAlwaysFail),
 			testEgressKey(43, 0, 6):  allowEntry(0, csFoo).WithAuthType(AuthTypeSpire),
 			testEgressKey(43, 80, 6): allowEntry(1, csBar).WithDefaultAuthType(AuthTypeSpire),
@@ -2962,7 +2003,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{cs: csFoo, adds: []int{43}, proto: 6, hasAuth: ExplicitAuthType, authType: AuthTypeSpire},
 			{cs: csFoo, adds: []int{43}, hasAuth: ExplicitAuthType, authType: AuthTypeAlwaysFail},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			testEgressKey(43, 0, 0):  allowEntry(0, csFoo).WithAuthType(AuthTypeAlwaysFail),
 			testEgressKey(43, 0, 6):  allowEntry(0, csFoo).WithAuthType(AuthTypeSpire),
 			testEgressKey(43, 80, 6): allowEntry(1, csBar).WithDefaultAuthType(AuthTypeSpire),
@@ -2980,7 +2021,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{cs: csFoo, adds: []int{43}, hasAuth: ExplicitAuthType, authType: AuthTypeSpire},
 			{cs: csWildcard, adds: []int{0}, port: 80, proto: 6, redirect: true},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			testEgressKey(43, 0, 0):  allowEntry(0, csFoo).WithAuthType(AuthTypeSpire),
 			testEgressKey(43, 80, 6): allowEntry(1, csFoo).WithDefaultAuthType(AuthTypeSpire),
 			testEgressKey(0, 80, 6):  allowEntry(1, csWildcard),
@@ -2998,7 +2039,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{cs: csWildcard, adds: []int{0}, port: 80, proto: 6, redirect: true},
 			{cs: csFoo, adds: []int{43}, hasAuth: ExplicitAuthType, authType: AuthTypeSpire},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			testEgressKey(43, 0, 0):  allowEntry(0, csFoo).WithAuthType(AuthTypeSpire),
 			testEgressKey(43, 80, 6): allowEntry(1, csFoo).WithDefaultAuthType(AuthTypeSpire),
 			testEgressKey(0, 80, 6):  allowEntry(1, csWildcard),
@@ -3016,7 +2057,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{cs: csFoo, adds: []int{43}, proto: 6, hasAuth: ExplicitAuthType, authType: AuthTypeSpire},
 			{cs: csWildcard, adds: []int{0}, port: 80, proto: 6, redirect: true},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			testEgressKey(43, 0, 6):  allowEntry(0, csFoo).WithAuthType(AuthTypeSpire),
 			testEgressKey(43, 80, 6): allowEntry(1, csFoo).WithDefaultAuthType(AuthTypeSpire),
 			testEgressKey(0, 80, 6):  allowEntry(1, csWildcard),
@@ -3034,7 +2075,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{cs: csWildcard, adds: []int{0}, port: 80, proto: 6, redirect: true},
 			{cs: csFoo, adds: []int{43}, proto: 6, hasAuth: ExplicitAuthType, authType: AuthTypeSpire},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			testEgressKey(43, 0, 6):  allowEntry(0, csFoo).WithAuthType(AuthTypeSpire),
 			testEgressKey(43, 80, 6): allowEntry(1, csFoo).WithDefaultAuthType(AuthTypeSpire),
 			testEgressKey(0, 80, 6):  allowEntry(1, csWildcard),
@@ -3079,11 +2120,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			if x.cs != nil {
 				cs = x.cs
 			}
-			var invertedPortMask uint16
-			if x.port == 0 {
-				invertedPortMask = 0xffff
-			}
-			key := Key{DestPort: x.port, InvertedPortMask: invertedPortMask, Nexthdr: x.proto, TrafficDirection: dir.Uint8()}
+			key := NewKey(dir.Uint8(), 0, x.proto, x.port, 0)
 			var proxyPort uint16
 			if x.redirect {
 				proxyPort = 1
@@ -3111,7 +2148,7 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 		identity.NumericIdentity(identityFoo): labelsFoo,
 	}
 	selectorCache := testNewSelectorCache(identityCache)
-	testMapState := func(initMap map[Key]MapStateEntry) *mapState {
+	testMapState := func(initMap MapStateMap) *mapState {
 		return newMapState().withState(initMap, selectorCache)
 	}
 
@@ -3126,14 +2163,14 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 	}{
 		{
 			name: "test-1 - Add HTTP ingress visibility - allow-all",
-			ms: testMapState(map[Key]MapStateEntry{
+			ms: testMapState(MapStateMap{
 				AnyIngressKey(): allowEntry(0),
 			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: testMapState(map[Key]MapStateEntry{
+			want: testMapState(MapStateMap{
 				AnyIngressKey():   allowEntry(0),
 				HttpIngressKey(0): allowEntryD(12345, visibilityDerivedFrom, nil),
 			}),
@@ -3149,60 +2186,60 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 		},
 		{
 			name: "test-3 - Add HTTP ingress visibility - L4-allow",
-			ms: testMapState(map[Key]MapStateEntry{
+			ms: testMapState(MapStateMap{
 				HttpIngressKey(0): allowEntryD(0, labels.LabelArrayList{testLabels}),
 			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: testMapState(map[Key]MapStateEntry{
+			want: testMapState(MapStateMap{
 				HttpIngressKey(0): allowEntryD(12345, labels.LabelArrayList{visibilityDerivedFromLabels, testLabels}, nil),
 			}),
 		},
 		{
 			name: "test-4 - Add HTTP ingress visibility - L3/L4-allow",
-			ms: testMapState(map[Key]MapStateEntry{
+			ms: testMapState(MapStateMap{
 				HttpIngressKey(123): allowEntryD(0, labels.LabelArrayList{testLabels}, csBar),
 			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: testMapState(map[Key]MapStateEntry{
+			want: testMapState(MapStateMap{
 				HttpIngressKey(123): allowEntryD(12345, labels.LabelArrayList{visibilityDerivedFromLabels, testLabels}, csBar),
 			}),
 		},
 		{
 			name: "test-5 - Add HTTP ingress visibility - L3-allow (host)",
-			ms: testMapState(map[Key]MapStateEntry{
+			ms: testMapState(MapStateMap{
 				HostIngressKey(): allowEntry(0),
 			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: testMapState(map[Key]MapStateEntry{
+			want: testMapState(MapStateMap{
 				HostIngressKey():  allowEntry(0).WithDependents(HttpIngressKey(1)),
 				HttpIngressKey(1): allowEntryD(12345, labels.LabelArrayList{visibilityDerivedFromLabels}).WithOwners(HostIngressKey()),
 			}),
 		},
 		{
 			name: "test-6 - Add HTTP ingress visibility - L3/L4-allow on different port",
-			ms: testMapState(map[Key]MapStateEntry{
+			ms: testMapState(MapStateMap{
 				testIngressKey(123, 88, 6): allowEntryD(0, labels.LabelArrayList{testLabels}, csBar),
 			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: testMapState(map[Key]MapStateEntry{
+			want: testMapState(MapStateMap{
 				testIngressKey(123, 88, 6): allowEntryD(0, labels.LabelArrayList{testLabels}, csBar),
 			}),
 		},
 		{
 			name: "test-7 - Add HTTP ingress visibility - allow-all + L4-deny (no change)",
-			ms: testMapState(map[Key]MapStateEntry{
+			ms: testMapState(MapStateMap{
 				AnyIngressKey():   allowEntry(0),
 				HttpIngressKey(0): denyEntry(0),
 			}),
@@ -3210,31 +2247,31 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: testMapState(map[Key]MapStateEntry{
+			want: testMapState(MapStateMap{
 				AnyIngressKey():   allowEntry(0),
 				HttpIngressKey(0): denyEntry(0),
 			}),
 		},
 		{
 			name: "test-8 - Add HTTP ingress visibility - allow-all + L3-deny",
-			ms: testMapState(map[Key]MapStateEntry{
-				AnyIngressKey():           allowEntry(0),
-				testIngressKey(234, 0, 0): denyEntry(0, csFoo),
+			ms: testMapState(MapStateMap{
+				AnyIngressKey():       allowEntry(0),
+				IngressL3OnlyKey(234): denyEntry(0, csFoo),
 			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: testMapState(map[Key]MapStateEntry{
-				AnyIngressKey():           allowEntry(0),
-				testIngressKey(234, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(234)),
-				HttpIngressKey(0):         allowEntryD(12345, visibilityDerivedFrom, nil),
-				HttpIngressKey(234):       denyEntry(0, csFoo).WithOwners(testIngressKey(234, 0, 0)),
+			want: testMapState(MapStateMap{
+				AnyIngressKey():       allowEntry(0),
+				IngressL3OnlyKey(234): denyEntry(0, csFoo).WithDependents(HttpIngressKey(234)),
+				HttpIngressKey(0):     allowEntryD(12345, visibilityDerivedFrom, nil),
+				HttpIngressKey(234):   denyEntry(0, csFoo).WithOwners(IngressL3OnlyKey(234)),
 			}),
 		},
 		{
 			name: "test-9 - Add HTTP ingress visibility - allow-all + L3/L4-deny",
-			ms: testMapState(map[Key]MapStateEntry{
+			ms: testMapState(MapStateMap{
 				AnyIngressKey():     allowEntry(0),
 				HttpIngressKey(132): denyEntry(0, csBar),
 			}),
@@ -3242,7 +2279,7 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: testMapState(map[Key]MapStateEntry{
+			want: testMapState(MapStateMap{
 				AnyIngressKey():     allowEntry(0),
 				HttpIngressKey(132): denyEntry(0, csBar),
 				HttpIngressKey(0):   allowEntryD(12345, visibilityDerivedFrom, nil),
@@ -3250,14 +2287,14 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 		},
 		{
 			name: "test-10 - Add HTTP egress visibility",
-			ms: testMapState(map[Key]MapStateEntry{
+			ms: testMapState(MapStateMap{
 				AnyEgressKey(): allowEntry(0),
 			}),
 			args: args{
 				redirectPort: 12346,
 				visMeta:      VisibilityMetadata{Ingress: false, Port: 80, Proto: u8proto.TCP},
 			},
-			want: testMapState(map[Key]MapStateEntry{
+			want: testMapState(MapStateMap{
 				AnyEgressKey():   allowEntry(0),
 				HttpEgressKey(0): allowEntryD(12346, visibilityDerivedFrom, nil),
 			}),
@@ -3265,7 +2302,7 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 	}
 	for _, tt := range tests {
 		old := ChangeState{
-			Old: make(map[Key]MapStateEntry),
+			Old: make(MapStateMap),
 		}
 		tt.ms.ForEach(func(k Key, v MapStateEntry) bool {
 			old.insertOldIfNotExists(k, v)
@@ -3273,14 +2310,14 @@ func TestMapState_AddVisibilityKeys(t *testing.T) {
 		})
 		changes := ChangeState{
 			Adds: make(Keys),
-			Old:  make(map[Key]MapStateEntry),
+			Old:  make(MapStateMap),
 		}
 		tt.ms.addVisibilityKeys(DummyOwner{}, tt.args.redirectPort, &tt.args.visMeta, selectorCache, changes)
 		tt.ms.validatePortProto(t)
 		require.True(t, tt.ms.Equals(tt.want), "%s:\n%s", tt.name, tt.ms.Diff(tt.want))
 		// Find new and updated entries
 		wantAdds := make(Keys)
-		wantOld := make(map[Key]MapStateEntry)
+		wantOld := make(MapStateMap)
 
 		for k, v := range old.Old {
 			if _, ok := tt.ms.Get(k); !ok {
@@ -3313,7 +2350,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 		identity.NumericIdentity(identityFoo): labelsFoo,
 	}
 	selectorCache := testNewSelectorCache(identityCache)
-	testMapState := func(initMap map[Key]MapStateEntry) *mapState {
+	testMapState := func(initMap MapStateMap) *mapState {
 		return newMapState().withState(initMap, selectorCache)
 	}
 
@@ -3337,16 +2374,16 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 		setup     *mapState
 		visArgs   []visArgs
 		visAdds   Keys
-		visOld    map[Key]MapStateEntry
+		visOld    MapStateMap
 		args      []args // changes applied, in order
 		state     MapState
 		adds      Keys
 		deletes   Keys
 	}{{
 		name: "test-1a - Adding identity to deny with visibilty",
-		setup: testMapState(map[Key]MapStateEntry{
-			AnyIngressKey():           allowEntry(0),
-			testIngressKey(234, 0, 0): denyEntry(0, csFoo),
+		setup: testMapState(MapStateMap{
+			AnyIngressKey():       allowEntry(0),
+			IngressL3OnlyKey(234): denyEntry(0, csFoo),
 		}),
 		visArgs: []visArgs{{
 			redirectPort: 12345,
@@ -3356,23 +2393,23 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			HttpIngressKey(0):   {},
 			HttpIngressKey(234): {},
 		},
-		visOld: map[Key]MapStateEntry{
-			testIngressKey(234, 0, 0): denyEntry(0, csFoo),
+		visOld: MapStateMap{
+			IngressL3OnlyKey(234): denyEntry(0, csFoo),
 		},
 		args: []args{
 			{cs: csFoo, adds: []int{235}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: testMapState(map[Key]MapStateEntry{
-			AnyIngressKey():           allowEntry(0),
-			testIngressKey(234, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(234)),
-			testIngressKey(235, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(235)),
-			HttpIngressKey(0):         allowEntryD(12345, visibilityDerivedFrom, nil),
-			HttpIngressKey(234):       denyEntry(0).WithOwners(testIngressKey(234, 0, 0)),
-			HttpIngressKey(235):       denyEntry(0).WithOwners(testIngressKey(235, 0, 0)),
+		state: testMapState(MapStateMap{
+			AnyIngressKey():       allowEntry(0),
+			IngressL3OnlyKey(234): denyEntry(0, csFoo).WithDependents(HttpIngressKey(234)),
+			IngressL3OnlyKey(235): denyEntry(0, csFoo).WithDependents(HttpIngressKey(235)),
+			HttpIngressKey(0):     allowEntryD(12345, visibilityDerivedFrom, nil),
+			HttpIngressKey(234):   denyEntry(0).WithOwners(IngressL3OnlyKey(234)),
+			HttpIngressKey(235):   denyEntry(0).WithOwners(IngressL3OnlyKey(235)),
 		}),
 		adds: Keys{
-			testIngressKey(235, 0, 0): {},
-			HttpIngressKey(235):       {},
+			IngressL3OnlyKey(235): {},
+			HttpIngressKey(235):   {},
 		},
 		deletes: Keys{},
 	}, {
@@ -3381,16 +2418,16 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: nil, deletes: []int{235}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: testMapState(map[Key]MapStateEntry{
-			AnyIngressKey():           allowEntry(0),
-			testIngressKey(234, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(234)),
-			HttpIngressKey(0):         allowEntryD(12345, visibilityDerivedFrom, nil),
-			HttpIngressKey(234):       denyEntry(0).WithOwners(testIngressKey(234, 0, 0)),
+		state: testMapState(MapStateMap{
+			AnyIngressKey():       allowEntry(0),
+			IngressL3OnlyKey(234): denyEntry(0, csFoo).WithDependents(HttpIngressKey(234)),
+			HttpIngressKey(0):     allowEntryD(12345, visibilityDerivedFrom, nil),
+			HttpIngressKey(234):   denyEntry(0).WithOwners(IngressL3OnlyKey(234)),
 		}),
 		adds: Keys{},
 		deletes: Keys{
-			testIngressKey(235, 0, 0): {},
-			HttpIngressKey(235):       {},
+			IngressL3OnlyKey(235): {},
+			HttpIngressKey(235):   {},
 		},
 	}, {
 		name: "test-2a - Adding 2 identities, and deleting a nonexisting key on an empty state",
@@ -3401,21 +2438,21 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Parser: ParserTypeHTTP, Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: testMapState(map[Key]MapStateEntry{
-			testIngressKey(235, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(235)),
-			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
-			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(235, 0, 0)),
-			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
+		state: testMapState(MapStateMap{
+			IngressL3OnlyKey(235): allowEntry(0, csFoo).WithDependents(HttpIngressKey(235)),
+			IngressL3OnlyKey(236): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
+			HttpIngressKey(235):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(IngressL3OnlyKey(235)),
+			HttpIngressKey(236):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(IngressL3OnlyKey(236)),
 		}),
 		adds: Keys{
-			testIngressKey(235, 0, 0): {},
-			HttpIngressKey(235):       {},
-			testIngressKey(236, 0, 0): {},
-			HttpIngressKey(236):       {},
+			IngressL3OnlyKey(235): {},
+			HttpIngressKey(235):   {},
+			IngressL3OnlyKey(236): {},
+			HttpIngressKey(236):   {},
 		},
 		deletes: Keys{
-			testIngressKey(235, 0, 0): {}, // changed dependents
-			testIngressKey(236, 0, 0): {}, // changed dependents
+			IngressL3OnlyKey(235): {}, // changed dependents
+			IngressL3OnlyKey(236): {}, // changed dependents
 		},
 	}, {
 		continued: true,
@@ -3427,20 +2464,20 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Parser: ParserTypeHTTP, Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: testMapState(map[Key]MapStateEntry{
-			testIngressKey(235, 0, 0): allowEntry(0, csFoo, csBar).WithDependents(HttpIngressKey(235)),
-			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
-			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(235, 0, 0)),
-			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
-			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
-			HttpIngressKey(237):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(237, 0, 0)),
+		state: testMapState(MapStateMap{
+			IngressL3OnlyKey(235): allowEntry(0, csFoo, csBar).WithDependents(HttpIngressKey(235)),
+			IngressL3OnlyKey(236): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
+			HttpIngressKey(235):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(IngressL3OnlyKey(235)),
+			HttpIngressKey(236):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(IngressL3OnlyKey(236)),
+			IngressL3OnlyKey(237): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
+			HttpIngressKey(237):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(IngressL3OnlyKey(237)),
 		}),
 		adds: Keys{
-			testIngressKey(237, 0, 0): {},
-			HttpIngressKey(237):       {},
+			IngressL3OnlyKey(237): {},
+			HttpIngressKey(237):   {},
 		},
 		deletes: Keys{
-			testIngressKey(237, 0, 0): {}, // changed dependents
+			IngressL3OnlyKey(237): {}, // changed dependents
 		},
 	}, {
 		continued: true,
@@ -3452,13 +2489,13 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Parser: ParserTypeHTTP, Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: testMapState(map[Key]MapStateEntry{
-			testIngressKey(235, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(235)),
-			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
-			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(235, 0, 0)),
-			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
-			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
-			HttpIngressKey(237):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(237, 0, 0)),
+		state: testMapState(MapStateMap{
+			IngressL3OnlyKey(235): allowEntry(0, csBar).WithDependents(HttpIngressKey(235)),
+			IngressL3OnlyKey(236): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
+			HttpIngressKey(235):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(IngressL3OnlyKey(235)),
+			HttpIngressKey(236):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(IngressL3OnlyKey(236)),
+			IngressL3OnlyKey(237): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
+			HttpIngressKey(237):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(IngressL3OnlyKey(237)),
 		}),
 		adds:    Keys{},
 		deletes: Keys{},
@@ -3472,13 +2509,13 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Parser: ParserTypeHTTP, Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: testMapState(map[Key]MapStateEntry{
-			testIngressKey(235, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(235)),
-			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
-			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(235, 0, 0)),
-			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
-			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
-			HttpIngressKey(237):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(237, 0, 0)),
+		state: testMapState(MapStateMap{
+			IngressL3OnlyKey(235): allowEntry(0, csBar).WithDependents(HttpIngressKey(235)),
+			IngressL3OnlyKey(236): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
+			HttpIngressKey(235):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(IngressL3OnlyKey(235)),
+			HttpIngressKey(236):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(IngressL3OnlyKey(236)),
+			IngressL3OnlyKey(237): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
+			HttpIngressKey(237):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(IngressL3OnlyKey(237)),
 		}),
 		adds:    Keys{},
 		deletes: Keys{},
@@ -3492,16 +2529,16 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Parser: ParserTypeHTTP, Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: testMapState(map[Key]MapStateEntry{
-			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
-			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
-			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
-			HttpIngressKey(237):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(237, 0, 0)),
+		state: testMapState(MapStateMap{
+			IngressL3OnlyKey(236): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
+			HttpIngressKey(236):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(IngressL3OnlyKey(236)),
+			IngressL3OnlyKey(237): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
+			HttpIngressKey(237):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(IngressL3OnlyKey(237)),
 		}),
 		adds: Keys{},
 		deletes: Keys{
-			testIngressKey(235, 0, 0): {},
-			HttpIngressKey(235):       {},
+			IngressL3OnlyKey(235): {},
+			HttpIngressKey(235):   {},
 		},
 	}, {
 		continued: true,
@@ -3513,18 +2550,18 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Parser: ParserTypeHTTP, Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: testMapState(map[Key]MapStateEntry{
-			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
-			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
-			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
-			HttpIngressKey(237):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(237, 0, 0)),
+		state: testMapState(MapStateMap{
+			IngressL3OnlyKey(236): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
+			HttpIngressKey(236):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(IngressL3OnlyKey(236)),
+			IngressL3OnlyKey(237): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
+			HttpIngressKey(237):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(IngressL3OnlyKey(237)),
 		}),
 		adds:    Keys{},
 		deletes: Keys{},
 	}, {
 		continued: false,
 		name:      "test-3a - egress HTTP proxy (setup)",
-		setup: testMapState(map[Key]MapStateEntry{
+		setup: testMapState(MapStateMap{
 			AnyIngressKey():  allowEntry(0),
 			HostIngressKey(): allowEntry(0),
 			HttpEgressKey(0): allowEntry(0),
@@ -3547,7 +2584,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			HttpIngressKey(0): {},
 			HttpEgressKey(0):  {},
 		},
-		visOld: map[Key]MapStateEntry{
+		visOld: MapStateMap{
 			// Old value for the modified entry
 			HttpEgressKey(0): allowEntry(0),
 		},
@@ -3555,7 +2592,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			AnyIngressKey():  allowEntry(0),
 			HostIngressKey(): allowEntry(0),
 			// Entry added solely due to visibility annotation has a 'nil' owner
@@ -3590,7 +2627,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 				visMeta:      VisibilityMetadata{Parser: ParserTypeHTTP, Ingress: false, Port: 53, Proto: u8proto.UDP},
 			},
 		},
-		state: testMapState(map[Key]MapStateEntry{
+		state: testMapState(MapStateMap{
 			AnyIngressKey():     allowEntry(0),
 			HostIngressKey():    allowEntry(0),
 			HttpIngressKey(0):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(nil),
@@ -3628,7 +2665,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			tt.visAdds = make(Keys)
 		}
 		if tt.visOld == nil {
-			tt.visOld = make(map[Key]MapStateEntry)
+			tt.visOld = make(MapStateMap)
 		}
 		if tt.adds == nil {
 			tt.adds = make(Keys)
@@ -3647,7 +2684,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 		changes := ChangeState{
 			Adds:    make(Keys),
 			Deletes: make(Keys),
-			Old:     make(map[Key]MapStateEntry),
+			Old:     make(MapStateMap),
 		}
 		for _, arg := range tt.visArgs {
 			policyMapState.addVisibilityKeys(DummyOwner{}, arg.redirectPort, &arg.visMeta, selectorCache, changes)
@@ -3666,11 +2703,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			if x.cs != nil {
 				cs = x.cs
 			}
-			var invertedPortMask uint16
-			if x.port == 0 {
-				invertedPortMask = 0xffff
-			}
-			key := Key{DestPort: x.port, InvertedPortMask: invertedPortMask, Nexthdr: x.proto, TrafficDirection: dir.Uint8()}
+			key := NewKey(dir.Uint8(), 0, x.proto, x.port, 0)
 			var proxyPort uint16
 			if x.redirect {
 				proxyPort = 1
@@ -3682,7 +2715,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 		changes = ChangeState{
 			Adds:    adds,
 			Deletes: deletes,
-			Old:     make(map[Key]MapStateEntry),
+			Old:     make(MapStateMap),
 		}
 
 		// Visibilty redirects need to be re-applied after consumeMapChanges()
@@ -3872,11 +2905,11 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		// allow-allow insertions do not need tests as their affect on one another does not matter.
 	}
 	for _, tt := range tests {
-		anyIngressKey := key(0, 0, 0, 0)
+		anyIngressKey := IngressL3OnlyKey(0)
 		allowEntry := MapStateEntry{}
-		aKey := key(tt.aIdentity, tt.aPort, tt.aProto, 0)
+		aKey := IngressKey(tt.aIdentity, tt.aProto, tt.aPort, 0)
 		aEntry := MapStateEntry{IsDeny: tt.aIsDeny}
-		bKey := key(tt.bIdentity, tt.bPort, tt.bProto, 0)
+		bKey := IngressKey(tt.bIdentity, tt.bProto, tt.bPort, 0)
 		bEntry := MapStateEntry{IsDeny: tt.bIsDeny}
 		expectedKeys := newMapState()
 		if tt.outcome&insertAllowAll > 0 {
@@ -3903,7 +2936,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 			expectedKeys.denies.upsert(bKey, bEntry.asDeny(), selectorCache)
 		}
 		if tt.outcome&insertAWithBProto > 0 {
-			aKeyWithBProto := key(tt.aIdentity, tt.bPort, tt.bProto, 0)
+			aKeyWithBProto := IngressKey(tt.aIdentity, tt.bProto, tt.bPort, 0)
 			aEntryCpy := MapStateEntry{IsDeny: tt.aIsDeny}
 			aEntryCpy.owners = map[MapStateOwner]struct{}{aKey: {}}
 			aEntryWithDep := aEntry.WithDependents(aKeyWithBProto)
@@ -3916,7 +2949,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 			}
 		}
 		if tt.outcome&insertAasB > 0 {
-			aKeyWithBProto := key(tt.aIdentity, tt.bPort, tt.bProto, 0)
+			aKeyWithBProto := IngressKey(tt.aIdentity, tt.bProto, tt.bPort, 0)
 			bEntryWithOwner := bEntry.WithOwners(bKey)
 			bEntryWithDep := bEntry.WithDependents(aKeyWithBProto)
 			if tt.bIsDeny {
@@ -3928,7 +2961,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 			}
 		}
 		if tt.outcome&insertBWithAProto > 0 {
-			bKeyWithBProto := key(tt.bIdentity, tt.aPort, tt.aProto, 0)
+			bKeyWithBProto := IngressKey(tt.bIdentity, tt.aProto, tt.aPort, 0)
 			bEntryCpy := MapStateEntry{IsDeny: tt.bIsDeny}
 			bEntryCpy.owners = map[MapStateOwner]struct{}{bKey: {}}
 			bEntryWithDep := bEntry.WithDependents(bKeyWithBProto)
@@ -3941,7 +2974,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 			}
 		}
 		if tt.outcome&insertBWithAProtoAsDeny > 0 {
-			bKeyWithAProto := key(tt.bIdentity, tt.aPort, tt.aProto, 0)
+			bKeyWithAProto := IngressKey(tt.bIdentity, tt.aProto, tt.aPort, 0)
 			bEntryAsDeny := bEntry.WithOwners(aKey).asDeny()
 			aEntryWithDep := aEntry.WithDependents(bKeyWithAProto)
 			expectedKeys.denies.upsert(aKey, aEntryWithDep, selectorCache)
@@ -3974,12 +3007,12 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 	// This should result in both entries being inserted with
 	// no changes, as they do not affect one another anymore.
 	for _, tt := range tests {
-		anyIngressKey := key(0, 0, 0, 0)
-		anyEgressKey := key(0, 0, 0, 1)
+		anyIngressKey := IngressL3OnlyKey(0)
+		anyEgressKey := EgressL3OnlyKey(0)
 		allowEntry := MapStateEntry{}
-		aKey := key(tt.aIdentity, tt.aPort, tt.aProto, 0)
+		aKey := IngressKey(tt.aIdentity, tt.aProto, tt.aPort, 0)
 		aEntry := MapStateEntry{IsDeny: tt.aIsDeny}
-		bKey := key(tt.bIdentity, tt.bPort, tt.bProto, 1)
+		bKey := EgressKey(tt.bIdentity, tt.bProto, tt.bPort, 0)
 		bEntry := MapStateEntry{IsDeny: tt.bIsDeny}
 		expectedKeys := newMapState()
 		if tt.outcome&insertAllowAll > 0 {

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1377,19 +1377,19 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 	}
 }
 
-func testIngressKey(id uint32, port uint16, proto uint8) Key {
+func testIngressKey(id identity.NumericIdentity, port uint16, proto u8proto.U8proto) Key {
 	return IngressKey(id, proto, port, 0)
 }
 
-func testEgressKey(id uint32, port uint16, proto uint8) Key {
+func testEgressKey(id identity.NumericIdentity, port uint16, proto u8proto.U8proto) Key {
 	return EgressKey(id, proto, port, 0)
 }
 
-func DNSUDPEgressKey(id uint32) Key {
+func DNSUDPEgressKey(id identity.NumericIdentity) Key {
 	return EgressKey(id, 17, 53, 0)
 }
 
-func DNSTCPEgressKey(id uint32) Key {
+func DNSTCPEgressKey(id identity.NumericIdentity) Key {
 	return EgressKey(id, 6, 53, 0)
 }
 
@@ -1405,11 +1405,11 @@ func AnyEgressKey() Key {
 	return testEgressKey(0, 0, 0)
 }
 
-func HttpIngressKey(id uint32) Key {
+func HttpIngressKey(id identity.NumericIdentity) Key {
 	return testIngressKey(id, 80, 6)
 }
 
-func HttpEgressKey(id uint32) Key {
+func HttpEgressKey(id identity.NumericIdentity) Key {
 	return testEgressKey(id, 80, 6)
 }
 
@@ -1464,7 +1464,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		adds     []int
 		deletes  []int
 		port     uint16
-		proto    uint8
+		proto    u8proto.U8proto
 		ingress  bool
 		redirect bool
 		deny     bool
@@ -1780,7 +1780,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 			if x.cs != nil {
 				cs = x.cs
 			}
-			key := NewKey(dir.Uint8(), 0, x.proto, x.port, 0)
+			key := NewKey(dir, 0, x.proto, x.port, 0)
 			var proxyPort uint16
 			if x.redirect {
 				proxyPort = 1
@@ -1814,7 +1814,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		adds     []int
 		deletes  []int
 		port     uint16
-		proto    uint8
+		proto    u8proto.U8proto
 		ingress  bool
 		redirect bool
 		deny     bool
@@ -2120,7 +2120,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			if x.cs != nil {
 				cs = x.cs
 			}
-			key := NewKey(dir.Uint8(), 0, x.proto, x.port, 0)
+			key := NewKey(dir, 0, x.proto, x.port, 0)
 			var proxyPort uint16
 			if x.redirect {
 				proxyPort = 1
@@ -2359,7 +2359,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 		adds     []int
 		deletes  []int
 		port     uint16
-		proto    uint8
+		proto    u8proto.U8proto
 		ingress  bool
 		redirect bool
 		deny     bool
@@ -2703,7 +2703,7 @@ func TestMapState_AccumulateMapChangesOnVisibilityKeys(t *testing.T) {
 			if x.cs != nil {
 				cs = x.cs
 			}
-			key := NewKey(dir.Uint8(), 0, x.proto, x.port, 0)
+			key := NewKey(dir, 0, x.proto, x.port, 0)
 			var proxyPort uint16
 			if x.redirect {
 				proxyPort = 1
@@ -2751,9 +2751,9 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		worldSubnetIdentity:            lblWorldSubnet.LabelArray(), // "192.0.2.0/24"
 	}
 
-	reservedWorldID := identity.ReservedIdentityWorld.Uint32()
-	worldIPID := worldIPIdentity.Uint32()
-	worldSubnetID := worldSubnetIdentity.Uint32()
+	reservedWorldID := identity.ReservedIdentityWorld
+	worldIPID := worldIPIdentity
+	worldSubnetID := worldSubnetIdentity
 	selectorCache := testNewSelectorCache(identityCache)
 	type action uint16
 	const (
@@ -2780,12 +2780,12 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 	tests := []struct {
 		name                 string
 		withAllowAll         withAllowAll
-		aIdentity, bIdentity uint32
+		aIdentity, bIdentity identity.NumericIdentity
 		aIsDeny, bIsDeny     bool
 		aPort                uint16
-		aProto               uint8
+		aProto               u8proto.U8proto
 		bPort                uint16
-		bProto               uint8
+		bProto               u8proto.U8proto
 		outcome              action
 	}{
 		// deny-allow insertions
@@ -3101,7 +3101,7 @@ func prefixesContainsAny(a, b []netip.Prefix) bool {
 // the compared identity. This means that either that primary identity is 0 (i.e. it is a superset
 // of every other identity), or one of the subnets of the primary identity fully contains or is
 // equal to one of the subnets in the compared identity (note:this covers cases like "reserved:world").
-func identityIsSupersetOf(primaryIdentity, compareIdentity uint32, identities Identities) bool {
+func identityIsSupersetOf(primaryIdentity, compareIdentity identity.NumericIdentity, identities Identities) bool {
 	// If the identities are equal then neither is a superset (for the purposes of our business logic).
 	if primaryIdentity == compareIdentity {
 		return false

--- a/pkg/policy/proxyid.go
+++ b/pkg/policy/proxyid.go
@@ -61,7 +61,7 @@ func ProxyID(endpointID uint16, ingress bool, protocol string, port uint16, list
 
 // ProxyIDFromKey returns a unique string to identify a proxy mapping.
 func ProxyIDFromKey(endpointID uint16, key Key, listener string) string {
-	return ProxyID(endpointID, key.TrafficDirection == trafficdirection.Ingress.Uint8(), u8proto.U8proto(key.Nexthdr).String(), key.DestPort, listener)
+	return ProxyID(endpointID, key.TrafficDirection() == trafficdirection.Ingress.Uint8(), u8proto.U8proto(key.Nexthdr).String(), key.DestPort, listener)
 }
 
 // ParseProxyID parses a proxy ID returned by ProxyID and returns its components.

--- a/pkg/policy/proxyid.go
+++ b/pkg/policy/proxyid.go
@@ -61,7 +61,7 @@ func ProxyID(endpointID uint16, ingress bool, protocol string, port uint16, list
 
 // ProxyIDFromKey returns a unique string to identify a proxy mapping.
 func ProxyIDFromKey(endpointID uint16, key Key, listener string) string {
-	return ProxyID(endpointID, key.TrafficDirection() == trafficdirection.Ingress.Uint8(), u8proto.U8proto(key.Nexthdr).String(), key.DestPort, listener)
+	return ProxyID(endpointID, key.TrafficDirection() == trafficdirection.Ingress, u8proto.U8proto(key.Nexthdr).String(), key.DestPort, listener)
 }
 
 // ParseProxyID parses a proxy ID returned by ProxyID and returns its components.

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -5,6 +5,8 @@ package policy
 
 import (
 	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 // selectorPolicy is a structure which contains the resolved policy for a
@@ -64,7 +66,7 @@ type PolicyOwner interface {
 	LookupRedirectPort(ingress bool, protocol string, port uint16, listener string) (uint16, error)
 	GetRealizedRedirects() map[string]uint16
 	HasBPFPolicyMap() bool
-	GetNamedPort(ingress bool, name string, proto uint8) uint16
+	GetNamedPort(ingress bool, name string, proto u8proto.U8proto) uint16
 	PolicyDebug(fields logrus.Fields, msg string)
 }
 

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -457,8 +457,8 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 		policyMapState: newMapState().withState(MapStateMap{
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
-			EgressL3OnlyKey(0):      allowEgressMapStateEntry,
-			IngressKey(0, 6, 80, 0): rule1MapStateEntry,
+			EgressKey():                  allowEgressMapStateEntry,
+			IngressKey().WithTCPPort(80): rule1MapStateEntry,
 		}, td.sc),
 	}
 
@@ -618,12 +618,12 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 		policyMapState: newMapState().withState(MapStateMap{
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
-			EgressL3OnlyKey(0): allowEgressMapStateEntry,
-			IngressKey(identity.ReservedIdentityWorld, 6, 80, 0):     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
-			IngressKey(identity.ReservedIdentityWorldIPv4, 6, 80, 0): rule1MapStateEntry.WithOwners(cachedSelectorWorldV4, cachedSelectorWorld),
-			IngressKey(identity.ReservedIdentityWorldIPv6, 6, 80, 0): rule1MapStateEntry.WithOwners(cachedSelectorWorldV6, cachedSelectorWorld),
-			IngressKey(192, 6, 80, 0):                                rule1MapStateEntry,
-			IngressKey(194, 6, 80, 0):                                rule1MapStateEntry,
+			EgressKey(): allowEgressMapStateEntry,
+			IngressKey().WithIdentity(identity.ReservedIdentityWorld).WithTCPPort(80):     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
+			IngressKey().WithIdentity(identity.ReservedIdentityWorldIPv4).WithTCPPort(80): rule1MapStateEntry.WithOwners(cachedSelectorWorldV4, cachedSelectorWorld),
+			IngressKey().WithIdentity(identity.ReservedIdentityWorldIPv6).WithTCPPort(80): rule1MapStateEntry.WithOwners(cachedSelectorWorldV6, cachedSelectorWorld),
+			IngressKey().WithIdentity(192).WithTCPPort(80):                                rule1MapStateEntry,
+			IngressKey().WithIdentity(194).WithTCPPort(80):                                rule1MapStateEntry,
 		}, td.sc),
 	}
 
@@ -631,11 +631,11 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	// maps on the policy got cleared
 
 	require.Equal(t, Keys{
-		IngressKey(192, 6, 80, 0): {},
-		IngressKey(194, 6, 80, 0): {},
+		ingressKey(192, 6, 80, 0): {},
+		ingressKey(194, 6, 80, 0): {},
 	}, adds)
 	require.Equal(t, Keys{
-		IngressKey(193, 6, 80, 0): {},
+		ingressKey(193, 6, 80, 0): {},
 	}, deletes)
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -619,11 +619,11 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
 			EgressL3OnlyKey(0): allowEgressMapStateEntry,
-			IngressKey(uint32(identity.ReservedIdentityWorld), 6, 80, 0):     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
-			IngressKey(uint32(identity.ReservedIdentityWorldIPv4), 6, 80, 0): rule1MapStateEntry.WithOwners(cachedSelectorWorldV4, cachedSelectorWorld),
-			IngressKey(uint32(identity.ReservedIdentityWorldIPv6), 6, 80, 0): rule1MapStateEntry.WithOwners(cachedSelectorWorldV6, cachedSelectorWorld),
-			IngressKey(192, 6, 80, 0): rule1MapStateEntry,
-			IngressKey(194, 6, 80, 0): rule1MapStateEntry,
+			IngressKey(identity.ReservedIdentityWorld, 6, 80, 0):     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
+			IngressKey(identity.ReservedIdentityWorldIPv4, 6, 80, 0): rule1MapStateEntry.WithOwners(cachedSelectorWorldV4, cachedSelectorWorld),
+			IngressKey(identity.ReservedIdentityWorldIPv6, 6, 80, 0): rule1MapStateEntry.WithOwners(cachedSelectorWorldV6, cachedSelectorWorld),
+			IngressKey(192, 6, 80, 0):                                rule1MapStateEntry,
+			IngressKey(194, 6, 80, 0):                                rule1MapStateEntry,
 		}, td.sc),
 	}
 

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 )
 
 func GenerateL3IngressDenyRules(numRules int) (api.Rules, identity.IdentityMap) {
@@ -455,11 +454,11 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 			IngressPolicyEnabled: true,
 		},
 		PolicyOwner: DummyOwner{},
-		policyMapState: newMapState().withState(map[Key]MapStateEntry{
+		policyMapState: newMapState().withState(MapStateMap{
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
-			{TrafficDirection: trafficdirection.Egress.Uint8(), InvertedPortMask: 0xffff /* This is a wildcard */}: allowEgressMapStateEntry,
-			{DestPort: 80, Nexthdr: 6}: rule1MapStateEntry,
+			EgressL3OnlyKey(0):      allowEgressMapStateEntry,
+			IngressKey(0, 6, 80, 0): rule1MapStateEntry,
 		}, td.sc),
 	}
 
@@ -616,15 +615,15 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 			IngressPolicyEnabled: true,
 		},
 		PolicyOwner: DummyOwner{},
-		policyMapState: newMapState().withState(map[Key]MapStateEntry{
+		policyMapState: newMapState().withState(MapStateMap{
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
-			{TrafficDirection: trafficdirection.Egress.Uint8(), InvertedPortMask: 0xffff /* This is a wildcard */}: allowEgressMapStateEntry,
-			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}:                           rule1MapStateEntry.WithOwners(cachedSelectorWorld),
-			{Identity: uint32(identity.ReservedIdentityWorldIPv4), DestPort: 80, Nexthdr: 6}:                       rule1MapStateEntry.WithOwners(cachedSelectorWorldV4, cachedSelectorWorld),
-			{Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, Nexthdr: 6}:                       rule1MapStateEntry.WithOwners(cachedSelectorWorldV6, cachedSelectorWorld),
-			{Identity: 192, DestPort: 80, Nexthdr: 6}:                                                              rule1MapStateEntry,
-			{Identity: 194, DestPort: 80, Nexthdr: 6}:                                                              rule1MapStateEntry,
+			EgressL3OnlyKey(0): allowEgressMapStateEntry,
+			IngressKey(uint32(identity.ReservedIdentityWorld), 6, 80, 0):     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
+			IngressKey(uint32(identity.ReservedIdentityWorldIPv4), 6, 80, 0): rule1MapStateEntry.WithOwners(cachedSelectorWorldV4, cachedSelectorWorld),
+			IngressKey(uint32(identity.ReservedIdentityWorldIPv6), 6, 80, 0): rule1MapStateEntry.WithOwners(cachedSelectorWorldV6, cachedSelectorWorld),
+			IngressKey(192, 6, 80, 0): rule1MapStateEntry,
+			IngressKey(194, 6, 80, 0): rule1MapStateEntry,
 		}, td.sc),
 	}
 
@@ -632,11 +631,11 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	// maps on the policy got cleared
 
 	require.Equal(t, Keys{
-		{Identity: 192, DestPort: 80, Nexthdr: 6}: {},
-		{Identity: 194, DestPort: 80, Nexthdr: 6}: {},
+		IngressKey(192, 6, 80, 0): {},
+		IngressKey(194, 6, 80, 0): {},
 	}, adds)
 	require.Equal(t, Keys{
-		{Identity: 193, DestPort: 80, Nexthdr: 6}: {},
+		IngressKey(193, 6, 80, 0): {},
 	}, deletes)
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 )
 
 var (
@@ -763,12 +762,10 @@ func TestMapStateWithIngress(t *testing.T) {
 //
 // Returning true for either return value indicates all traffic is allowed.
 func (p *EndpointPolicy) allowsIdentity(identity identity.NumericIdentity) (ingress, egress bool) {
-	key := IngressL3OnlyKey(uint32(identity))
-
 	if !p.IngressPolicyEnabled {
 		ingress = true
 	} else {
-		key.TrafficDirection = trafficdirection.Ingress.Uint8()
+		key := IngressL3OnlyKey(uint32(identity))
 		if v, exists := p.policyMapState.Get(key); exists && !v.IsDeny {
 			ingress = true
 		}
@@ -777,7 +774,7 @@ func (p *EndpointPolicy) allowsIdentity(identity identity.NumericIdentity) (ingr
 	if !p.EgressPolicyEnabled {
 		egress = true
 	} else {
-		key.TrafficDirection = trafficdirection.Egress.Uint8()
+		key := EgressL3OnlyKey(uint32(identity))
 		if v, exists := p.policyMapState.Get(key); exists && !v.IsDeny {
 			egress = true
 		}

--- a/pkg/policy/types/types.go
+++ b/pkg/policy/types/types.go
@@ -23,64 +23,51 @@ type Key struct {
 	// DestPort is the port at L4 to / from which traffic is allowed, in
 	// host-byte order.
 	DestPort uint16
-	// invertedPortMask is the mask that should be applied to the DestPort to
-	// define a range of ports for the policy-key, encoded as the bitwise inverse
-	// of its true/useful value. This is done so that the default value of the
-	// Key is a full port mask (that is, "0" represents 0xffff), as that is
-	// the most likely value to be used. invertedPortMask is also, conveniently,
-	// the number or ports on top of DestPort that define that range. That is
-	// the end port is equal to the DestPort added to the invertedPortMask.
-	//
-	// It is **not** the prefix that is applied for the BPF key entries.
-	// That value is calculated in the maps/policymap package.
-	//
-	// For example:
-	// range 2-3 would be DestPort:2 and invertedPortMask:0x1 (i.e 0xfffe)
-	// range 32768-49151 would be DestPort:32768 and invertedPortMask:0x3fff (i.e. 0xc000)
-	invertedPortMask uint16
 	// NextHdr is the protocol which is allowed.
 	Nexthdr uint8
-	// TrafficDirection indicates in which direction Identity is allowed
-	// communication (egress or ingress).
-	trafficDirection uint8
+	// bits contains the TrafficDirection in the highest bit and the port prefix length in the 5 lowest bits.
+	bits uint8
 }
+
+const (
+	directionBitShift = 7
+	directionBitMask  = uint8(1) << directionBitShift
+)
 
 // NewKey returns an ingress key for the given parameters
 func NewKey(direction uint8, identity uint32, proto uint8, port uint16, prefixLen uint8) Key {
+	if direction > 1 {
+		direction = 1
+	}
 	// Sanity check for test convenience, so that most times prefix can be passed as 0
 	if port == 0 {
 		prefixLen = 0
-	} else if port != 0 && prefixLen == 0 {
+	} else if port != 0 && prefixLen == 0 || prefixLen > 16 {
 		prefixLen = 16
 	}
 	return Key{
-		trafficDirection: direction,
-		Identity:         identity,
-		Nexthdr:          proto,
-		DestPort:         port,
-		invertedPortMask: uint16(0xffff) >> prefixLen,
+		Identity: identity,
+		Nexthdr:  proto,
+		DestPort: port,
+		bits:     direction<<directionBitShift | prefixLen,
 	}
 }
 
+// TrafficDirection() returns the direction of the Key, 0 == ingress, 1 == egress
 func (k Key) TrafficDirection() uint8 {
-	return k.trafficDirection
+	return k.bits >> directionBitShift
 }
 
-// PortMask returns the bitwise mask that should be applied
-// to the DestPort.
-func (k Key) PortMask() uint16 {
-	return ^k.invertedPortMask
-}
-
+// PortPrefixLen returns the length of the bitwise mask that should be applied to the DestPort.
 func (k Key) PortPrefixLen() uint8 {
-	return uint8(bits.LeadingZeros16(k.invertedPortMask))
+	return k.bits & ^directionBitMask
 }
 
 // String returns a string representation of the Key
 func (k Key) String() string {
 	dPort := strconv.FormatUint(uint64(k.DestPort), 10)
-	if k.DestPort != 0 && k.invertedPortMask != 0 {
-		dPort += "-" + strconv.FormatUint(uint64(k.DestPort+k.invertedPortMask), 10)
+	if k.DestPort != 0 && k.PortPrefixLen() < 16 {
+		dPort += "-" + strconv.FormatUint(uint64(k.DestPort+k.EndPort()), 10)
 	}
 	return "Identity=" + strconv.FormatUint(uint64(k.Identity), 10) +
 		",DestPort=" + dPort +
@@ -100,7 +87,7 @@ func (k Key) IsEgress() bool {
 
 // EndPort returns the end-port of the Key based on the Mask.
 func (k Key) EndPort() uint16 {
-	return k.DestPort + k.invertedPortMask
+	return k.DestPort + uint16(0xffff)>>k.PortPrefixLen()
 }
 
 // PortProtoIsBroader returns true if the receiver Key has broader
@@ -108,65 +95,42 @@ func (k Key) EndPort() uint16 {
 // that covers the argument Key's port-protocol and is larger.
 // An equal port-protocol will return false.
 func (k Key) PortProtoIsBroader(c Key) bool {
-	if k.Nexthdr == 0 && c.Nexthdr != 0 {
-		return k.PortIsEqual(c) || k.PortIsBroader(c)
-	}
-	return k.Nexthdr == c.Nexthdr && k.PortIsBroader(c)
+	// Port is wildcarded when protocol is wildcarded
+	return k.Nexthdr == 0 && c.Nexthdr != 0 || k.Nexthdr == c.Nexthdr && k.PortIsBroader(c)
 }
 
 // PortProtoIsEqual returns true if the port-protocols of the
 // two keys are exactly equal.
 func (k Key) PortProtoIsEqual(c Key) bool {
-	return k.DestPort == c.DestPort &&
-		k.invertedPortMask == c.invertedPortMask &&
-		k.Nexthdr == c.Nexthdr
+	return k.Nexthdr == c.Nexthdr && k.PortIsEqual(c)
 }
 
 // PortIsBroader returns true if the receiver Key's
 // port range covers the argument Key's port range,
 // but returns false if they are equal.
 func (k Key) PortIsBroader(c Key) bool {
-	if k.DestPort == 0 && c.DestPort != 0 {
-		return true
-	}
-	if k.DestPort != 0 && c.DestPort == 0 {
-		return false
-	}
-	kEP := k.EndPort()
-	cEP := c.EndPort()
-	return k.DestPort <= c.DestPort && kEP >= cEP &&
-		// The port ranges cannot be exactly equal.
-		(k.DestPort != c.DestPort || kEP != cEP)
+	// Broader port must have shorter prefix and a common part needs to be the same
+	kPrefixLen := k.PortPrefixLen()
+	cPrefixLen := c.PortPrefixLen()
+	return kPrefixLen < cPrefixLen &&
+		k.DestPort^c.DestPort&(uint16(0xffff)<<(16-kPrefixLen)) == 0
 }
 
 // PortIsEqual returns true if the port ranges
 // between the two keys are exactly equal.
 func (k Key) PortIsEqual(c Key) bool {
-	return k.DestPort == c.DestPort &&
-		k.invertedPortMask == c.invertedPortMask
+	return k.DestPort == c.DestPort && k.bits<<1 == c.bits<<1 // ignore traffic direction
 }
 
 // PrefixLength returns the prefix lenth of the key
 // for indexing it for the userspace cache (not the
 // BPF map or datapath).
 func (k Key) PrefixLength() uint {
-	keyPrefix := MapStatePrefixLen
-	portPrefix := uint(16)
-	if k.DestPort != 0 {
-		// It is not possible for k.InvertedPortMask
-		// to be incorrectly set, but even if
-		// it was the default value of "0" is
-		// what we want.
-		portPrefix = uint(bits.TrailingZeros16(k.PortMask()))
+	if k.Nexthdr == 0 {
+		return 1 // direction always specified
 	}
-	keyPrefix -= portPrefix
-	// If the port is fully wildcarded then
-	// we can also wildcard the protocol
-	// (if it is also wildcarded).
-	if portPrefix == 16 && k.Nexthdr == 0 {
-		keyPrefix -= 8
-	}
-	return keyPrefix
+	// 1 bit from direction bit + 8 bits for the protocol when `k.Nexthdr' != 0
+	return 9 + uint(k.PortPrefixLen())
 }
 
 // CommonPrefix implements the CommonPrefix method for the
@@ -174,12 +138,13 @@ func (k Key) PrefixLength() uint {
 // saved as a simple map per TrafficDirection-Protocol-Port index
 // key.
 func (k Key) CommonPrefix(b Key) uint {
-	v := bits.LeadingZeros8(k.TrafficDirection() ^ b.TrafficDirection())
-	if v != 8 {
-		return uint(v)
+	// if direction bits are different then there is nothing in common
+	if (k.bits^b.bits)>>directionBitShift != 0 {
+		return 0
 	}
-	v += bits.LeadingZeros8(k.Nexthdr ^ b.Nexthdr)
-	if v != 16 {
+	v := 1 + bits.LeadingZeros8(k.Nexthdr^b.Nexthdr)
+	// if protocols are different then there is no need to look at the ports
+	if v < 9 {
 		return uint(v)
 	}
 	return uint(v + bits.LeadingZeros16(k.DestPort^b.DestPort))
@@ -188,13 +153,14 @@ func (k Key) CommonPrefix(b Key) uint {
 // BitValueAt implements the BitValueAt method for the
 // bitlpm.Key interface.
 func (k Key) BitValueAt(i uint) uint8 {
-	if i < 8 {
-		return min(k.TrafficDirection()&(1<<(7-i)), 1)
+	switch {
+	case i == 0:
+		return k.bits >> directionBitShift
+	case i < 9:
+		return (k.Nexthdr >> (8 - i)) & 1
+	default:
+		return uint8(k.DestPort>>(24-i)) & 1
 	}
-	if i < 16 {
-		return min(k.Nexthdr&(1<<(7-(i-8))), 1)
-	}
-	return uint8(min(k.DestPort&(1<<(15-(i-16))), 1))
 }
 
 // Value implements the Value method for the

--- a/pkg/policy/types/types_test.go
+++ b/pkg/policy/types/types_test.go
@@ -14,13 +14,13 @@ import (
 )
 
 func TestKeyMask(t *testing.T) {
-	key := NewKey(0, 0, 0, 0, 0)
+	key := IngressKey()
 	require.Equal(t, trafficdirection.Ingress, key.TrafficDirection())
 	require.Equal(t, uint8(0), key.PortPrefixLen())
 	require.Equal(t, uint16(0), key.DestPort)
 	require.Equal(t, uint16(0xffff), key.EndPort())
 
-	key = NewKey(1, 42, 6, 80, 16)
+	key = EgressKey().WithIdentity(42).WithTCPPort(80)
 	require.Equal(t, trafficdirection.Egress, key.TrafficDirection())
 	require.Equal(t, identity.NumericIdentity(42), key.Identity)
 	require.Equal(t, u8proto.TCP, key.Nexthdr)
@@ -29,7 +29,7 @@ func TestKeyMask(t *testing.T) {
 	require.Equal(t, uint16(80), key.EndPort())
 
 	// for convenience in testing, 0 prefix len gets translated to 16 when port is non-zero
-	key = NewKey(1, 42, 17, 80, 0)
+	key = EgressKey().WithIdentity(42).WithUDPPortPrefix(80, 0)
 	require.Equal(t, trafficdirection.Egress, key.TrafficDirection())
 	require.Equal(t, identity.NumericIdentity(42), key.Identity)
 	require.Equal(t, u8proto.UDP, key.Nexthdr)
@@ -37,7 +37,7 @@ func TestKeyMask(t *testing.T) {
 	require.Equal(t, uint16(80), key.DestPort)
 	require.Equal(t, uint16(80), key.EndPort())
 
-	key = NewKey(1, 42, 132, 80, 14)
+	key = EgressKey().WithIdentity(42).WithSCTPPortPrefix(80, 14)
 	require.Equal(t, trafficdirection.Egress, key.TrafficDirection())
 	require.Equal(t, identity.NumericIdentity(42), key.Identity)
 	require.Equal(t, u8proto.SCTP, key.Nexthdr)

--- a/pkg/policy/types/types_test.go
+++ b/pkg/policy/types/types_test.go
@@ -7,33 +7,40 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 func TestKeyMask(t *testing.T) {
 	key := NewKey(0, 0, 0, 0, 0)
-	require.Equal(t, uint8(0), key.TrafficDirection())
+	require.Equal(t, trafficdirection.Ingress, key.TrafficDirection())
 	require.Equal(t, uint8(0), key.PortPrefixLen())
 	require.Equal(t, uint16(0), key.DestPort)
 	require.Equal(t, uint16(0xffff), key.EndPort())
 
 	key = NewKey(1, 42, 6, 80, 16)
-	require.Equal(t, uint8(1), key.TrafficDirection())
-	require.Equal(t, uint32(42), key.Identity)
+	require.Equal(t, trafficdirection.Egress, key.TrafficDirection())
+	require.Equal(t, identity.NumericIdentity(42), key.Identity)
+	require.Equal(t, u8proto.TCP, key.Nexthdr)
 	require.Equal(t, uint8(16), key.PortPrefixLen())
 	require.Equal(t, uint16(80), key.DestPort)
 	require.Equal(t, uint16(80), key.EndPort())
 
 	// for convenience in testing, 0 prefix len gets translated to 16 when port is non-zero
-	key = NewKey(1, 42, 6, 80, 0)
-	require.Equal(t, uint8(1), key.TrafficDirection())
-	require.Equal(t, uint32(42), key.Identity)
+	key = NewKey(1, 42, 17, 80, 0)
+	require.Equal(t, trafficdirection.Egress, key.TrafficDirection())
+	require.Equal(t, identity.NumericIdentity(42), key.Identity)
+	require.Equal(t, u8proto.UDP, key.Nexthdr)
 	require.Equal(t, uint8(16), key.PortPrefixLen())
 	require.Equal(t, uint16(80), key.DestPort)
 	require.Equal(t, uint16(80), key.EndPort())
 
-	key = NewKey(1, 42, 6, 80, 14)
-	require.Equal(t, uint8(1), key.TrafficDirection())
-	require.Equal(t, uint32(42), key.Identity)
+	key = NewKey(1, 42, 132, 80, 14)
+	require.Equal(t, trafficdirection.Egress, key.TrafficDirection())
+	require.Equal(t, identity.NumericIdentity(42), key.Identity)
+	require.Equal(t, u8proto.SCTP, key.Nexthdr)
 	require.Equal(t, uint8(14), key.PortPrefixLen())
 	require.Equal(t, uint16(80), key.DestPort)
 	require.Equal(t, uint16(83), key.EndPort())

--- a/pkg/policy/types/types_test.go
+++ b/pkg/policy/types/types_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestKeyMask(t *testing.T) {
 	key := NewKey(0, 0, 0, 0, 0)
-	require.Equal(t, uint8(0), key.TrafficDirection)
+	require.Equal(t, uint8(0), key.TrafficDirection())
 	require.Equal(t, uint8(0), key.PortPrefixLen())
 	require.Equal(t, uint16(0), key.PortMask())
 }

--- a/pkg/policy/types/types_test.go
+++ b/pkg/policy/types/types_test.go
@@ -13,5 +13,28 @@ func TestKeyMask(t *testing.T) {
 	key := NewKey(0, 0, 0, 0, 0)
 	require.Equal(t, uint8(0), key.TrafficDirection())
 	require.Equal(t, uint8(0), key.PortPrefixLen())
-	require.Equal(t, uint16(0), key.PortMask())
+	require.Equal(t, uint16(0), key.DestPort)
+	require.Equal(t, uint16(0xffff), key.EndPort())
+
+	key = NewKey(1, 42, 6, 80, 16)
+	require.Equal(t, uint8(1), key.TrafficDirection())
+	require.Equal(t, uint32(42), key.Identity)
+	require.Equal(t, uint8(16), key.PortPrefixLen())
+	require.Equal(t, uint16(80), key.DestPort)
+	require.Equal(t, uint16(80), key.EndPort())
+
+	// for convenience in testing, 0 prefix len gets translated to 16 when port is non-zero
+	key = NewKey(1, 42, 6, 80, 0)
+	require.Equal(t, uint8(1), key.TrafficDirection())
+	require.Equal(t, uint32(42), key.Identity)
+	require.Equal(t, uint8(16), key.PortPrefixLen())
+	require.Equal(t, uint16(80), key.DestPort)
+	require.Equal(t, uint16(80), key.EndPort())
+
+	key = NewKey(1, 42, 6, 80, 14)
+	require.Equal(t, uint8(1), key.TrafficDirection())
+	require.Equal(t, uint32(42), key.Identity)
+	require.Equal(t, uint8(14), key.PortPrefixLen())
+	require.Equal(t, uint16(80), key.DestPort)
+	require.Equal(t, uint16(83), key.EndPort())
 }

--- a/pkg/policy/types/types_test.go
+++ b/pkg/policy/types/types_test.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyMask(t *testing.T) {
+	key := NewKey(0, 0, 0, 0, 0)
+	require.Equal(t, uint8(0), key.TrafficDirection)
+	require.Equal(t, uint8(0), key.PortPrefixLen())
+	require.Equal(t, uint16(0), key.PortMask())
+}

--- a/pkg/policy/visibility.go
+++ b/pkg/policy/visibility.go
@@ -225,8 +225,8 @@ func (v *VisibilityMetadata) GetPort() uint16 {
 }
 
 // GetProtocol returns the protocol where the VisibilityMetadata applies.
-func (v *VisibilityMetadata) GetProtocol() uint8 {
-	return uint8(v.Proto)
+func (v *VisibilityMetadata) GetProtocol() u8proto.U8proto {
+	return v.Proto
 }
 
 // GetListener returns the optional listener name.

--- a/pkg/proxy/endpoint/endpoint.go
+++ b/pkg/proxy/endpoint/endpoint.go
@@ -6,6 +6,7 @@ package endpoint
 import (
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 // EndpointInfoSource returns information about an endpoint being proxied.
@@ -15,7 +16,7 @@ type EndpointInfoSource interface {
 	GetIPv4Address() string
 	GetIPv6Address() string
 	ConntrackNameLocked() string
-	GetNamedPort(ingress bool, name string, proto uint8) uint16
+	GetNamedPort(ingress bool, name string, proto u8proto.U8proto) uint16
 }
 
 // EndpointUpdater returns information about an endpoint being proxied and

--- a/pkg/proxy/endpoint/test/updater_mock.go
+++ b/pkg/proxy/endpoint/test/updater_mock.go
@@ -6,6 +6,7 @@ package test
 import (
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 type ProxyUpdaterMock struct {
@@ -20,7 +21,7 @@ func (m *ProxyUpdaterMock) GetIPv4Address() string { return m.Ipv4 }
 
 func (m *ProxyUpdaterMock) GetIPv6Address() string { return m.Ipv6 }
 
-func (m *ProxyUpdaterMock) GetNamedPort(bool, string, uint8) uint16 { return 0 }
+func (m *ProxyUpdaterMock) GetNamedPort(bool, string, u8proto.U8proto) uint16 { return 0 }
 
 func (m *ProxyUpdaterMock) ConntrackNameLocked() string { return "global" }
 

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -209,8 +209,8 @@ func (p *fakeProxyPolicy) GetPort() uint16 {
 	return uint16(80)
 }
 
-func (p *fakeProxyPolicy) GetProtocol() uint8 {
-	return uint8(u8proto.UDP)
+func (p *fakeProxyPolicy) GetProtocol() u8proto.U8proto {
+	return u8proto.UDP
 }
 
 func (p *fakeProxyPolicy) GetListener() string {

--- a/pkg/proxy/redirect.go
+++ b/pkg/proxy/redirect.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/revert"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 // RedirectImplementation is the generic proxy redirect interface that each
@@ -45,7 +46,7 @@ type Redirect struct {
 	rules policy.L7DataMap
 }
 
-func newRedirect(localEndpoint endpoint.EndpointUpdater, name string, listener *ProxyPort, port uint16, proto uint8) *Redirect {
+func newRedirect(localEndpoint endpoint.EndpointUpdater, name string, listener *ProxyPort, port uint16, proto u8proto.U8proto) *Redirect {
 	return &Redirect{
 		name:          name,
 		listener:      listener,

--- a/pkg/types/portmap.go
+++ b/pkg/types/portmap.go
@@ -25,8 +25,8 @@ var (
 // PortProto is a pair of port number and protocol and is used as the
 // value type in named port maps.
 type PortProto struct {
-	Port  uint16 // non-0
-	Proto uint8  // 0 for any
+	Proto u8proto.U8proto // 0 for any
+	Port  uint16          // non-0
 }
 
 // NamedPortMap maps port names to port numbers and protocols.
@@ -63,7 +63,7 @@ func (pps PortProtoSet) Delete(pp PortProto) bool {
 // define the same name with different values.
 type NamedPortMultiMap interface {
 	// GetNamedPort returns the port number for the named port, if any.
-	GetNamedPort(name string, proto uint8) (uint16, error)
+	GetNamedPort(name string, proto u8proto.U8proto) (uint16, error)
 	// Len returns the number of Name->PortProtoSet mappings known.
 	Len() int
 }
@@ -142,7 +142,7 @@ func newPortProto(port int, protocol string) (pp PortProto, err error) {
 		return pp, fmt.Errorf("Port number %d out of 16-bit range", port)
 	}
 	return PortProto{
-		Proto: uint8(u8p),
+		Proto: u8p,
 		Port:  uint16(port),
 	}, nil
 }
@@ -162,7 +162,7 @@ func (npm NamedPortMap) AddPort(name string, port int, protocol string) error {
 }
 
 // GetNamedPort returns the port number for the named port, if any.
-func (npm NamedPortMap) GetNamedPort(name string, proto uint8) (uint16, error) {
+func (npm NamedPortMap) GetNamedPort(name string, proto u8proto.U8proto) (uint16, error) {
 	if npm == nil {
 		return 0, ErrNilMap
 	}
@@ -180,7 +180,7 @@ func (npm NamedPortMap) GetNamedPort(name string, proto uint8) (uint16, error) {
 }
 
 // GetNamedPort returns the port number for the named port, if any.
-func (npm *namedPortMultiMap) GetNamedPort(name string, proto uint8) (uint16, error) {
+func (npm *namedPortMultiMap) GetNamedPort(name string, proto u8proto.U8proto) (uint16, error) {
 	if npm == nil {
 		return 0, ErrNilMap
 	}

--- a/pkg/types/portmap_test.go
+++ b/pkg/types/portmap_test.go
@@ -37,7 +37,7 @@ func TestPolicyValidateName(t *testing.T) {
 func TestPolicyNewPortProto(t *testing.T) {
 	np, err := newPortProto(80, "tcp")
 	require.Nil(t, err)
-	require.Equal(t, PortProto{Port: uint16(80), Proto: uint8(6)}, np)
+	require.Equal(t, PortProto{Port: uint16(80), Proto: u8proto.TCP}, np)
 
 	_, err = newPortProto(88888, "tcp")
 	require.NotNil(t, err)
@@ -49,7 +49,7 @@ func TestPolicyNewPortProto(t *testing.T) {
 
 	np, err = newPortProto(88, "")
 	require.Nil(t, err)
-	require.Equal(t, PortProto{Port: uint16(88), Proto: uint8(6)}, np)
+	require.Equal(t, PortProto{Port: uint16(88), Proto: u8proto.TCP}, np)
 }
 
 func TestPolicyNamedPortMap(t *testing.T) {
@@ -71,15 +71,15 @@ func TestPolicyNamedPortMap(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, uint8(17), uint8(proto))
 
-	port, err := npm.GetNamedPort("dns", uint8(proto))
+	port, err := npm.GetNamedPort("dns", proto)
 	require.Nil(t, err)
 	require.Equal(t, uint16(53), port)
 
-	port, err = npm.GetNamedPort("dns", uint8(6))
+	port, err = npm.GetNamedPort("dns", u8proto.TCP)
 	require.Equal(t, ErrIncompatibleProtocol, err)
 	require.Equal(t, uint16(0), port)
 
-	port, err = npm.GetNamedPort("unknown", uint8(proto))
+	port, err = npm.GetNamedPort("unknown", proto)
 	require.Equal(t, ErrUnknownNamedPort, err)
 	require.Equal(t, uint16(0), port)
 }
@@ -190,7 +190,7 @@ func TestPolicyNamedPortMultiMapUpdate(t *testing.T) {
 
 	pod1PortsOld := map[string]PortProto{}
 	pod1PortsNew := map[string]PortProto{
-		"http": {80, uint8(u8proto.TCP)},
+		"http": {u8proto.TCP, 80},
 	}
 
 	// Insert http=80/TCP from pod1
@@ -202,23 +202,23 @@ func TestPolicyNamedPortMultiMapUpdate(t *testing.T) {
 	require.Equal(t, false, changed)
 
 	// Assert http=80/TCP
-	port, err := npm.GetNamedPort("http", uint8(u8proto.TCP))
+	port, err := npm.GetNamedPort("http", u8proto.TCP)
 	require.Nil(t, err)
 	require.Equal(t, uint16(80), port)
 
 	pod2PortsOld := map[string]PortProto{}
 	pod2PortsNew := map[string]PortProto{
-		"http": {8080, uint8(u8proto.UDP)},
+		"http": {u8proto.UDP, 8080},
 	}
 
 	// Insert http=8080/UDP from pod2, retain http=80/TCP from pod1
 	changed = npm.Update(pod2PortsOld, pod2PortsNew)
 	require.Equal(t, true, changed)
 
-	port, err = npm.GetNamedPort("http", uint8(u8proto.TCP))
+	port, err = npm.GetNamedPort("http", u8proto.TCP)
 	require.Nil(t, err)
 	require.Equal(t, uint16(80), port)
-	port, err = npm.GetNamedPort("http", uint8(u8proto.UDP))
+	port, err = npm.GetNamedPort("http", u8proto.UDP)
 	require.Nil(t, err)
 	require.Equal(t, uint16(8080), port)
 
@@ -230,7 +230,7 @@ func TestPolicyNamedPortMultiMapUpdate(t *testing.T) {
 	changed = npm.Update(pod1PortsOld, pod1PortsNew)
 	require.Equal(t, true, changed)
 
-	port, err = npm.GetNamedPort("http", uint8(u8proto.UDP))
+	port, err = npm.GetNamedPort("http", u8proto.UDP)
 	require.Nil(t, err)
 	require.Equal(t, uint16(8080), port)
 }


### PR DESCRIPTION
Make MapState `Key` type smaller so that it fits into 64 bits, and only use the non-Identity part (32 bits) in `bitlpm.Trie`. These changes make a mapstate benchmark >10% faster due to more efficient use of memory.

While we are at it, change the Key types like so:
- direction: `uint8` -> `trafficdirection.TrafficDirection`
- identity: `uint32` -> `identity.NumericIdentity`
- protocol: `uint8` -> `u8proto.U8proto`

This change adds type safety and eliminates a lot of type conversions throughout the code base.

Finally, add builder-style helpers for creating `Key`s.

Note: Please review by commit, as the first commits contain quite a bit of refactoring, the later commits contain the more interesting changes that are easier to review in isolation.
