### PR TITLE
k8s: Reflector fixes and ListerWatcher test utilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/cilium/linters v0.0.0-20240730094540-199a06d02f99
 	github.com/cilium/lumberjack/v2 v2.3.0
 	github.com/cilium/proxy v0.0.0-20240723112637-48fa07fc1729
-	github.com/cilium/statedb v0.2.4
+	github.com/cilium/statedb v0.2.5
 	github.com/cilium/stream v0.0.0-20240226091623-f979d32855f8
 	github.com/cilium/workerpool v1.2.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7 h1:ocC6/1Gz6LJd0X
 github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7/go.mod h1:8nydvUTW+/9nVywCQ9bE/YGzb4EISALP4lKNpK3fFqo=
 github.com/cilium/proxy v0.0.0-20240723112637-48fa07fc1729 h1:/WvOQ7PL1JQpJM6oCFIDOr51QZvitwaFcZBhfN+n6Lo=
 github.com/cilium/proxy v0.0.0-20240723112637-48fa07fc1729/go.mod h1:fZVy2oOarwxD/PIWzpqQDpDXpqyuhmqQDRmvMzZ8PK0=
-github.com/cilium/statedb v0.2.4 h1:jCyXGcsiXgpJSfpfRRGKd+TD3U1teeDtOnqCyErsHsI=
-github.com/cilium/statedb v0.2.4/go.mod h1:KPwsudjhZ90zoBguYMtssKpstR74jVKd/D+73PZy+sg=
+github.com/cilium/statedb v0.2.5 h1:oDz6exRzkEJa8s8/Q49shufOb+/pNCap89rLNkLvrBo=
+github.com/cilium/statedb v0.2.5/go.mod h1:KPwsudjhZ90zoBguYMtssKpstR74jVKd/D+73PZy+sg=
 github.com/cilium/stream v0.0.0-20240226091623-f979d32855f8 h1:j6VF1s6gz3etRH5ObCr0UUyJblP9cK5fbgkQTz8fTRA=
 github.com/cilium/stream v0.0.0-20240226091623-f979d32855f8/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.2.0 h1:Wc2iOPTvCgWKQXeq4L5tnx4QFEI+z5q1+bSpSS0cnAY=

--- a/pkg/k8s/resource/testutils.go
+++ b/pkg/k8s/resource/testutils.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resource
+
+import (
+	"fmt"
+
+	"github.com/cilium/stream"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/cilium/cilium/pkg/k8s/testutils"
+)
+
+// EventStreamFromFiles returns an observable stream of events created from decoding the
+// given slice of files and emitted as Upserts.
+func EventStreamFromFiles[T runtime.Object](paths []string) func() stream.Observable[Event[T]] {
+	src := make(chan Event[T], 1)
+	src <- Event[T]{
+		Kind: Sync,
+		Done: func(error) {},
+	}
+	go func() {
+		for _, path := range paths {
+			rawObj, err := testutils.DecodeFile(path)
+			if err != nil {
+				panic(err)
+			}
+			obj := rawObj.(T)
+			src <- Event[T]{
+				Kind:   Upsert,
+				Key:    NewKey(obj),
+				Object: obj,
+				Done: func(err error) {
+					if err != nil {
+						panic(fmt.Sprintf("Event.Done called with error: %s", err))
+					}
+				},
+			}
+		}
+	}()
+	return func() stream.Observable[Event[T]] { return stream.FromChannel(src) }
+}

--- a/pkg/k8s/testutils/decoder.go
+++ b/pkg/k8s/testutils/decoder.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testutils
+
+import (
+	"os"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	mcsapi_fake "sigs.k8s.io/mcs-api/pkg/client/clientset/versioned/fake"
+
+	cilium_fake "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/fake"
+	slim_apiextclientsetscheme "github.com/cilium/cilium/pkg/k8s/slim/k8s/apiextensions-client/clientset/versioned/scheme"
+	slim_fake "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/fake"
+)
+
+var (
+	// Scheme for object types used in Cilium.
+	// The scheme can be extended by init() functions since [Decoder] is
+	// lazily constructed.
+	Scheme = runtime.NewScheme()
+
+	decoderOnce sync.Once
+	decoder     runtime.Decoder
+)
+
+// Decoder returns an object decoder for Cilium and Slim objects.
+// The [DecodeObject] and [DecodeFile] functions are provided as
+// shorthands for decoding from bytes and files respectively.
+func Decoder() runtime.Decoder {
+	decoderOnce.Do(func() {
+		decoder = serializer.NewCodecFactory(Scheme).UniversalDeserializer()
+	})
+	return decoder
+}
+
+func init() {
+	// Add corev1, discovery* and networking.
+	slim_fake.AddToScheme(Scheme)
+
+	// Add apiextensionsv1
+	slim_apiextclientsetscheme.AddToScheme(Scheme)
+
+	// Add ciliumv2 and ciliumv2alpha1
+	cilium_fake.AddToScheme(Scheme)
+
+	// Add gateway*
+	gatewayv1.Install(Scheme)
+	gatewayv1alpha2.Install(Scheme)
+	gatewayv1beta1.Install(Scheme)
+
+	// Add multiclusterv1alpha1
+	mcsapi_fake.AddToScheme(Scheme)
+}
+
+func DecodeObject(bytes []byte) (runtime.Object, error) {
+	obj, _, err := Decoder().Decode(bytes, nil, nil)
+	return obj, err
+}
+
+func DecodeFile(path string) (runtime.Object, error) {
+	bs, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return DecodeObject(bs)
+}

--- a/pkg/k8s/testutils/decoder_test.go
+++ b/pkg/k8s/testutils/decoder_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+)
+
+func TestDecodeFile(t *testing.T) {
+	// Slim CoreV1 objects can be decoded.
+	obj, err := DecodeFile("testdata/service.yaml")
+	require.NoError(t, err, "DecodeFile service.yaml")
+	require.IsType(t, &slim_corev1.Service{}, obj)
+
+	// Cilium objects can be decoded.
+	obj, err = DecodeFile("testdata/ciliumnode.yaml")
+	require.NoError(t, err, "DecodeFile ciliumnode.yaml")
+	require.IsType(t, &cilium_v2.CiliumNode{}, obj)
+}

--- a/pkg/k8s/testutils/fake_listerwatcher.go
+++ b/pkg/k8s/testutils/fake_listerwatcher.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testutils
+
+import (
+	"slices"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// FakeListerWatcher implements a fake cache.ListerWatcher that can be fed
+// objects directly, or from YAML files or strings. The YAML data is decoded
+// with a schema that covers the Cilium CRDs and Slim schemas.
+type FakeListerWatcher struct {
+	watcher        *watch.FakeWatcher
+	initialObjects []runtime.Object
+	added          sets.Set[types.NamespacedName]
+}
+
+func NewFakeListerWatcher(objs ...runtime.Object) *FakeListerWatcher {
+	return &FakeListerWatcher{
+		watcher:        watch.NewFakeWithChanSize(1, false),
+		added:          sets.New[types.NamespacedName](),
+		initialObjects: objs,
+	}
+}
+
+func getNamespacedName(obj runtime.Object) types.NamespacedName {
+	m, err := meta.Accessor(obj)
+	if err != nil {
+		panic(err)
+	}
+	return types.NamespacedName{Namespace: m.GetNamespace(), Name: m.GetName()}
+}
+
+func (f *FakeListerWatcher) Upsert(obj runtime.Object) {
+	name := getNamespacedName(obj)
+	if f.added.Has(name) {
+		f.watcher.Modify(obj)
+	} else {
+		f.watcher.Add(obj)
+		f.added.Insert(name)
+	}
+}
+
+func (f *FakeListerWatcher) Delete(obj runtime.Object) {
+	f.watcher.Delete(obj)
+	f.added.Delete(getNamespacedName(obj))
+}
+
+func (f *FakeListerWatcher) Stop() {
+	f.watcher.Stop()
+}
+
+func (f *FakeListerWatcher) UpsertFromFile(path string) error {
+	if obj, err := DecodeFile(path); err == nil {
+		f.Upsert(obj)
+		return nil
+	} else {
+		return err
+	}
+}
+
+func (f *FakeListerWatcher) DeleteFromFile(path string) error {
+	if obj, err := DecodeFile(path); err == nil {
+		f.Delete(obj)
+		return nil
+	} else {
+		return err
+	}
+}
+
+func (f *FakeListerWatcher) UpsertFromText(content string) error {
+	if obj, err := DecodeObject([]byte(content)); err == nil {
+		f.Upsert(obj)
+		return nil
+	} else {
+		return err
+	}
+}
+
+func (f *FakeListerWatcher) DeleteFromText(content string) error {
+	if obj, err := DecodeObject([]byte(content)); err == nil {
+		f.Delete(obj)
+		return nil
+	} else {
+		return err
+	}
+}
+
+// fakeList looks enough like a list that the client-go meta machinery can deal with it
+// (at least as far as Informer/Reflector goes).
+type fakeList struct {
+	v1.TypeMeta `json:",inline"`
+	v1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items       []runtime.Object `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (f *fakeList) DeepCopyObject() runtime.Object {
+	f2 := *f
+	f2.Items = slices.Clone(f.Items)
+	return &f2
+}
+
+// List implements cache.ListerWatcher.
+func (f *FakeListerWatcher) List(options v1.ListOptions) (runtime.Object, error) {
+	var list fakeList
+	list.Items = f.initialObjects
+	return &list, nil
+
+}
+
+// Watch implements cache.ListerWatcher.
+func (f *FakeListerWatcher) Watch(options v1.ListOptions) (watch.Interface, error) {
+	return f.watcher, nil
+}

--- a/pkg/k8s/testutils/fake_listerwatcher_test.go
+++ b/pkg/k8s/testutils/fake_listerwatcher_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/cilium/cilium/pkg/inctimer"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func TestFakeListerWatcher(t *testing.T) {
+	lw := NewFakeListerWatcher()
+
+	// Fake always returns an empty list.
+	obj, err := lw.List(v1.ListOptions{})
+	require.NoError(t, err, "List")
+
+	// The returned "List" object should be iterable with the meta tooling.
+	// (side-note: this will reflect on the object to find "Items" field).
+	meta.EachListItem(obj, func(o runtime.Object) error {
+		t.Fatalf("Unexpected callback in EachListItem")
+		return nil
+	})
+
+	watcher, err := lw.Watch(v1.ListOptions{})
+	require.NoError(t, err, "Watch")
+
+	results := watcher.ResultChan()
+
+	// There should be nothing yet.
+	select {
+	case obj := <-results:
+		t.Fatalf("unexpected object in ResultChan: %v", obj)
+	default:
+	}
+
+	// Insert an object via file.
+	err = lw.UpsertFromFile("testdata/ciliumnode.yaml")
+	require.NoError(t, err, "UpsertFromFile ciliumnode.yaml")
+
+	// We should be now able to receive the object
+	select {
+	case ev := <-results:
+		require.Equal(t, ev.Type, watch.Added)
+		obj := ev.Object
+		require.NotNil(t, obj, "object nil")
+		require.IsType(t, &cilium_v2.CiliumNode{}, obj)
+	case <-inctimer.After(time.Second):
+		t.Fatalf("timed out waiting for object")
+	}
+
+	// Second time we'll get a modify.
+	err = lw.UpsertFromFile("testdata/ciliumnode.yaml")
+	require.NoError(t, err, "UpsertFromFile ciliumnode.yaml")
+	select {
+	case ev := <-results:
+		require.Equal(t, ev.Type, watch.Modified)
+		obj := ev.Object
+		require.NotNil(t, obj, "object nil")
+		require.IsType(t, &cilium_v2.CiliumNode{}, obj)
+	case <-inctimer.After(time.Second):
+		t.Fatalf("timed out waiting for object")
+	}
+
+	err = lw.DeleteFromFile("testdata/ciliumnode.yaml")
+	require.NoError(t, err, "DeleteFromFile ciliumnode.yaml")
+
+	select {
+	case ev := <-results:
+		require.Equal(t, ev.Type, watch.Deleted)
+		obj := ev.Object
+		require.NotNil(t, obj, "object nil")
+		require.IsType(t, &cilium_v2.CiliumNode{}, obj)
+	case <-inctimer.After(time.Second):
+		t.Fatalf("timed out waiting for object")
+	}
+
+	watcher.Stop()
+}

--- a/pkg/k8s/testutils/testdata/ciliumnode.yaml
+++ b/pkg/k8s/testutils/testdata/ciliumnode.yaml
@@ -1,0 +1,43 @@
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  creationTimestamp: "2024-08-12T10:08:17Z"
+  generation: 1
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: kind-worker
+    kubernetes.io/os: linux
+  name: kind-worker
+  ownerReferences:
+  - apiVersion: v1
+    kind: Node
+    name: kind-worker
+    uid: 7dffbc53-de44-459b-a0d8-d238e994e68d
+  resourceVersion: "839"
+  uid: 089469fd-62bb-4999-955d-7a674938c4bd
+spec:
+  addresses:
+  - ip: 172.19.0.2
+    type: InternalIP
+  - ip: fc00:c111::2
+    type: InternalIP
+  - ip: 10.244.1.2
+    type: CiliumInternalIP
+  - ip: fd00:10:244:1::b8a4
+    type: CiliumInternalIP
+  alibaba-cloud: {}
+  azure: {}
+  bootid: 9b075bb6-4124-4ae3-8dd0-ddddfb809a76
+  encryption: {}
+  eni: {}
+  health:
+    ipv4: 10.244.1.242
+    ipv6: fd00:10:244:1::a50a
+  ingress: {}
+  ipam:
+    podCIDRs:
+    - 10.244.1.0/24
+    - fd00:10:244:1::/64
+    pools: {}

--- a/pkg/k8s/testutils/testdata/service.yaml
+++ b/pkg/k8s/testutils/testdata/service.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "9153"
+    prometheus.io/scrape: "true"
+  creationTimestamp: "2024-08-12T10:05:32Z"
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: CoreDNS
+  name: kube-dns
+  namespace: kube-system
+  resourceVersion: "270"
+  uid: b0fe5703-f639-4ce6-b02b-06b4eee2e62a
+spec:
+  clusterIP: 10.96.0.10
+  clusterIPs:
+  - 10.96.0.10
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+    targetPort: 53
+  - name: metrics
+    port: 9153
+    protocol: TCP
+    targetPort: 9153
+  selector:
+    k8s-app: kube-dns
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/vendor/github.com/cilium/statedb/CODEOWNERS
+++ b/vendor/github.com/cilium/statedb/CODEOWNERS
@@ -1,0 +1,12 @@
+# Code owners groups assigned to this repository and a brief description of their areas:
+# @cilium/ci-structure       Continuous integration, testing
+# @cilium/contributing       Developer documentation & tools
+# @cilium/github-sec         GitHub security (handling of secrets, consequences of pull_request_target, etc.)
+# @cilium/sig-foundations    Core libraries and guidance to overall software architecture.
+
+# The following filepaths should be sorted so that more specific paths occur
+# after the less specific paths, otherwise the ownership for the specific paths
+# is not properly picked up in Github.
+* @cilium/sig-foundations
+/.github/workflows/ @cilium/github-sec @cilium/ci-structure @cilium/sig-foundations
+/CODEOWNERS @cilium/contributing @cilium/sig-foundations

--- a/vendor/github.com/cilium/statedb/part/tree.go
+++ b/vendor/github.com/cilium/statedb/part/tree.go
@@ -95,6 +95,17 @@ func (t *Tree[T]) Insert(key []byte, value T) (old T, hadOld bool, tree *Tree[T]
 	return
 }
 
+// Modify a value in the tree. If the key does not exist the modify
+// function is called with the zero value for T. It is up to the
+// caller to not mutate the value in-place and to return a clone.
+// Returns the old value if it exists.
+func (t *Tree[T]) Modify(key []byte, mod func(T) T) (old T, hadOld bool, tree *Tree[T]) {
+	txn := t.Txn()
+	old, hadOld = txn.Modify(key, mod)
+	tree = txn.Commit()
+	return
+}
+
 // Delete the given key from the tree.
 // Returns the old value if it exists and the new tree.
 func (t *Tree[T]) Delete(key []byte) (old T, hadOld bool, tree *Tree[T]) {

--- a/vendor/github.com/cilium/statedb/types.go
+++ b/vendor/github.com/cilium/statedb/types.go
@@ -151,6 +151,17 @@ type RWTable[Obj any] interface {
 	// revision.
 	Insert(WriteTxn, Obj) (oldObj Obj, hadOld bool, err error)
 
+	// Modify an existing object or insert a new object into the table. If an old object
+	// exists the [merge] function is called with the old and new objects.
+	//
+	// Modify is semantically equal to Get + Insert, but avoids extra lookups making
+	// it significantly more efficient.
+	//
+	// Possible errors:
+	// - ErrTableNotLockedForWriting: table was not locked for writing
+	// - ErrTransactionClosed: the write transaction already committed or aborted
+	Modify(txn WriteTxn, new Obj, merge func(old, new Obj) Obj) (oldObj Obj, hadOld bool, err error)
+
 	// CompareAndSwap compares the existing object's revision against the
 	// given revision and if equal it replaces the object.
 	//

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -531,7 +531,7 @@ github.com/cilium/proxy/go/envoy/type/tracing/v3
 github.com/cilium/proxy/go/envoy/type/v3
 github.com/cilium/proxy/go/envoy/watchdog/v3
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.2.4
+# github.com/cilium/statedb v0.2.5
 ## explicit; go 1.22.0
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
This adds `pkg/k8s/testutils` package with a decoding utilities and a fake ListerWatcher. These
give a more direct way of writing tests that consume K8s objects than going through the client-go
fake client/tracker. The decoder functions can decode slim and cilium objects from files on disk.

The StateDB k8s reflector tests are reimplemented with the new test utilities and a benchmark is added.

Additionally minor fixes to the reflector to allow using multiple reflectors per table and to transforming
the k8s object into multiple StateDB objects and to be able to merge the existing and new object
(StateDB version is bumped for the Modify() support).