### PR TITLE
daemon: Create IPsec and LRP maps early on startup

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -179,7 +179,7 @@ func (d *Daemon) initMaps() error {
 		log.WithError(err).Fatal("Unable to initialize service maps")
 	}
 
-	if err := policymap.InitCallMaps(option.Config.EnableEnvoyConfig); err != nil {
+	if err := policymap.InitCallMaps(); err != nil {
 		return fmt.Errorf("initializing policy map: %w", err)
 	}
 

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/maps/encrypt"
 	"github.com/cilium/cilium/pkg/maps/fragmap"
 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
 	"github.com/cilium/cilium/pkg/maps/ipmasq"
@@ -243,6 +244,12 @@ func (d *Daemon) initMaps() error {
 		}
 	}
 
+	if option.Config.EnableIPSec {
+		if err := encrypt.MapCreate(); err != nil {
+			return fmt.Errorf("initializing IPsec map: %w", err)
+		}
+	}
+
 	if !option.Config.RestoreState {
 		// If we are not restoring state, all endpoints can be
 		// deleted. Entries will be re-populated.
@@ -282,6 +289,11 @@ func (d *Daemon) initMaps() error {
 		if err := lbmap.InitMaglevMaps(option.Config.EnableIPv4, option.Config.EnableIPv6, uint32(option.Config.MaglevTableSize)); err != nil {
 			return fmt.Errorf("initializing maglev maps: %w", err)
 		}
+	}
+
+	_, err := lbmap.NewSkipLBMap()
+	if err != nil {
+		return fmt.Errorf("initializing local redirect policy maps: %w", err)
 	}
 
 	return nil

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -502,7 +502,7 @@ func InitMapInfo(maxEntries int) {
 }
 
 // InitCallMap creates the policy call maps in the kernel.
-func InitCallMaps(haveEgressCallMap bool) error {
+func InitCallMaps() error {
 	policyCallMap := bpf.NewMap(PolicyCallMapName,
 		ebpf.ProgramArray,
 		&CallKey{},
@@ -512,7 +512,7 @@ func InitCallMaps(haveEgressCallMap bool) error {
 	)
 	err := policyCallMap.Create()
 
-	if err == nil && haveEgressCallMap {
+	if err == nil {
 		policyEgressCallMap := bpf.NewMap(PolicyEgressCallMapName,
 			ebpf.ProgramArray,
 			&CallKey{},


### PR DESCRIPTION
We have some sort of race popping up in CI from time to time around the loading of some BPF maps:

    loading eBPF collection into the kernel: map cilium_encrypt_state: pin map to /sys/fs/bpf/tc/globals/cilium_encrypt_state: file exists

One approach to avoid this is to ensure such maps are always created early on agent startup instead of being created during endpoint creation (where concurrent program loadings can run into this race).

This commit therefore adds the two maps concerned by this issue to the `initMaps` method.

Fixes: https://github.com/cilium/cilium/issues/32387.
```
Avoid race that could result in an error log during creation of IPsec or LRP BPF maps.
```