### PR TITLE
daemon: Fix error logic flow for pod store being out of date

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -458,6 +458,9 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 				err = errors.Join(err, err2)
 			} else {
 				pod = newPod
+				// Clear the error so the code can proceed below as we've
+				// succeeded here.
+				err = nil
 			}
 		}
 


### PR DESCRIPTION
In the endpoint creation path, if Cilium does not have the K8s Pod
reference in the local store, then the logic is to fetch the latest from
the apiserver directly. However, in the case that the fetch succeeds,
the error variable is not clear. This results in Cilium continuing in
the "unhappy" path, even though it should be the "happy" path.

Relevant log msgs from a sysdump displaying this behavior:

```
level=info msg="Create endpoint request" addressing="&{10.0.0.133 ba039cfd-7061-4c45-8526-1a5f569d16de default   }" containerID=3bed19eb3aabbb100ec39037a364cf1cbb10ca2666c14faec9893a2dc129844a containerInterface=eth0 datapathConfiguration="&{false false false false false <nil>}" interface=lxc5c692ead6e7a k8sPodName=default/nginx-static-pod-master-node k8sUID=cc8a369e7eac1fc96b6e3b51830c86e9 labels="[]" subsys=daemon sync-build=true
level=warning msg="Detected outdated Pod UID during Endpoint creation. Endpoint creation cannot proceed with an outdated Pod store. Attempting to fetch latest Pod." k8sPodName=default/nginx-static-pod-master-node k8sUID=cc8a369e7eac1fc96b6e3b51830c86e9 subsys=daemon
level=warning msg="Timeout occurred waiting for Pod store, fetching latest Pod via the apiserver." k8sPodName=default/nginx-static-pod-master-node k8sUID=cc8a369e7eac1fc96b6e3b51830c86e9 subsys=daemon
level=warning msg="Unable to fetch kubernetes labels" ciliumEndpointName=/ containerID= containerInterface= datapathPolicyRevision=0 desiredPolicyRevision=0 endpointID=0 error="pod store outdated" ipv4= ipv6= k8sPodName=/ subsys=api
```

Fixes: f6606c6ccd ("daemon,endpoint,cni: Pass pod UID through CNI ADD")
Signed-off-by: Chris Tarazi <chris@isovalent.com>

---

Fixes: https://github.com/cilium/cilium/issues/34197
