### PR TITLE
[v1.14] envoy: Switch to image with timestamp tag

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1055,7 +1055,7 @@
    * - :spelling:ignore:`envoy.image`
      - Envoy container image.
      - object
-     - ``{"digest":"sha256:c6fd14e5b1a516a0676234e9fe4a17b4499af07d5f62b55e32c211182b94ad3d","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.29.7-f6633c9bb87d5a75bd14bfcad7def882bb6c5e63","useDigest":true}``
+     - ``{"digest":"sha256:1b477ce9f8fb5d9c8c570ce2d12e331d09cb4d5d3ae1dcefa37517cb7bb984f1","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.29.7-1723642513-538a08d6c6e25001a582ea9efe0fde398f12a974","useDigest":true}``
    * - :spelling:ignore:`envoy.livenessProbe.failureThreshold`
      - failure threshold of liveness probe
      - int

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:445ba6795b3a3b0fe46976a22
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.29.7-f6633c9bb87d5a75bd14bfcad7def882bb6c5e63@sha256:c6fd14e5b1a516a0676234e9fe4a17b4499af07d5f62b55e32c211182b94ad3d as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.29.7-1723642513-538a08d6c6e25001a582ea9efe0fde398f12a974@sha256:1b477ce9f8fb5d9c8c570ce2d12e331d09cb4d5d3ae1dcefa37517cb7bb984f1 as cilium-envoy
 
 #
 # Hubble CLI

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -313,7 +313,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:c6fd14e5b1a516a0676234e9fe4a17b4499af07d5f62b55e32c211182b94ad3d","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.29.7-f6633c9bb87d5a75bd14bfcad7def882bb6c5e63","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:1b477ce9f8fb5d9c8c570ce2d12e331d09cb4d5d3ae1dcefa37517cb7bb984f1","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.29.7-1723642513-538a08d6c6e25001a582ea9efe0fde398f12a974","useDigest":true}` | Envoy container image. |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | envoy.log.format | string | `"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"` | The format string to use for laying out the log message metadata of Envoy. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1861,9 +1861,9 @@ envoy:
   image:
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.29.7-f6633c9bb87d5a75bd14bfcad7def882bb6c5e63"
+    tag: "v1.29.7-1723642513-538a08d6c6e25001a582ea9efe0fde398f12a974"
     pullPolicy: "IfNotPresent"
-    digest: "sha256:c6fd14e5b1a516a0676234e9fe4a17b4499af07d5f62b55e32c211182b94ad3d"
+    digest: "sha256:1b477ce9f8fb5d9c8c570ce2d12e331d09cb4d5d3ae1dcefa37517cb7bb984f1"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1858,9 +1858,9 @@ envoy:
   image:
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.29.7-f6633c9bb87d5a75bd14bfcad7def882bb6c5e63"
+    tag: "v1.29.7-1723642513-538a08d6c6e25001a582ea9efe0fde398f12a974"
     pullPolicy: "${PULL_POLICY}"
-    digest: "sha256:c6fd14e5b1a516a0676234e9fe4a17b4499af07d5f62b55e32c211182b94ad3d"
+    digest: "sha256:1b477ce9f8fb5d9c8c570ce2d12e331d09cb4d5d3ae1dcefa37517cb7bb984f1"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.


### PR DESCRIPTION
As renovate is comparing the tag versions from left to right, using the tag with timestamp will enable any updates in cilium/proxy, not just only for envoy version changes like what we have right  now.

Relates: #34381 
