### PR TITLE
envoy: prevent logging envoy version on every version check

### DIFF
--- a/pkg/envoy/versioncheck.go
+++ b/pkg/envoy/versioncheck.go
@@ -22,8 +22,6 @@ func checkEnvoyVersion(envoyVersionFunc func() (string, error)) error {
 		return fmt.Errorf("failed to retrieve Envoy version: %w", err)
 	}
 
-	log.Infof("Envoy: Version %s", envoyVersion)
-
 	// Make sure Envoy version matches the required one
 	if !strings.HasPrefix(envoyVersion, requiredEnvoyVersionSHA) {
 		return fmt.Errorf("envoy version %s does not match with required version %s", envoyVersion, requiredEnvoyVersionSHA)


### PR DESCRIPTION
Currently, the Envoy version gets logged on level `info` on every Envoy version check iteration (default 5min).

```
time="2024-08-15T09:18:38Z" level=info msg="Envoy: Version 0cb6b7d34a032ee945a80495681ecf2ea109a54c/1.30.4/Distribution/RELEASE/BoringSSL" subsys=envoy-manager
time="2024-08-15T09:23:38Z" level=info msg="Envoy: Version 0cb6b7d34a032ee945a80495681ecf2ea109a54c/1.30.4/Distribution/RELEASE/BoringSSL" subsys=envoy-manager
time="2024-08-15T09:28:38Z" level=info msg="Envoy: Version 0cb6b7d34a032ee945a80495681ecf2ea109a54c/1.30.4/Distribution/RELEASE/BoringSSL" subsys=envoy-manager
```

This is unnecessary, as the same information already gets logged on level `debug`.

Note: If a user is interested in checking the Envoy version itself, there are other options than checking for this log message in the Cilium Agent log (Checking envoy image version (daemonset), calling `cilium-envoy --version` from within Cilium Agent pod (embedded), or use cilium-dbg (https://github.com/cilium/cilium/pull/34398))