### PR TITLE
envoy: fix log level mapping when changing log level via API

### DIFF
--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -64,7 +64,8 @@ func EnableTracing() {
 }
 
 func mapLogLevel(level logrus.Level) string {
-	if tracing {
+	// Set Envoy loglevel to trace if debug AND verbose Engoy logging is enabled
+	if level == logrus.DebugLevel && tracing {
 		return "trace"
 	}
 
@@ -72,6 +73,7 @@ func mapLogLevel(level logrus.Level) string {
 	if level == logrus.DebugLevel && !flowdebug.Enabled() {
 		level = logrus.InfoLevel
 	}
+
 	return envoyLevelMap[level]
 }
 


### PR DESCRIPTION
Currently, the Envoy log level is always incorrectly set to `trace` if `debug=false` but `debug.verbose=envoy`. The actual issue only occurs if one tries to disable debug logging via cilium-dbg with `cilium-dbg config Debug=disable`.

Therefore, this commit fixes this by taking the debug config property into account when mapping the agent log level to the Envoy log level.

Note: The issues doesn't occur at the initial startup in both Envoy operation modes.

* Standalone: Helm chart correctly sets the loglevel and [takes the debug config already into account](https://github.com/cilium/cilium/blob/main/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml#L83).
* Embedded: `EnableTracing` is called after the embedded Envoy process has been started

Related issue: https://github.com/cilium/cilium/pull/34401 (to be able to reproduce this (otherwise hidden) issue)