### PR TITLE
config: fix disabling config 'Debug'

### DIFF
--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -251,10 +251,13 @@ func (h *ConfigModifyEventHandler) configModify(params daemonapi.PatchConfigPara
 
 func (h *ConfigModifyEventHandler) changedOption(key string, value option.OptionSetting, _ interface{}) {
 	if key == option.Debug {
-		// Set the debug toggle (this can be a no-op)
+		// Set the log level of the agent (this can be a no-op)
 		if option.Config.Opts.IsEnabled(option.Debug) {
 			logging.SetLogLevelToDebug()
+		} else {
+			logging.SetDefaultLogLevel()
 		}
+
 		// Reflect log level change to proxies
 		// Might not be initialized yet
 		if option.Config.EnableL7Proxy {


### PR DESCRIPTION
Currently, disabling the config property `Debug`
(`cilium-dbg config Debug=disable`) doesn't change the log level of the Cilium Agent (and proxies) back to the default log level. The log level stays at `debug`.

The reason is that #16021 changed the logging API from accepting the loglevel to explicit methods to enable debug level or reset it to the defaut log level. Hence it no longer supports toggling the log level.

This commit fixes this by explicitly reset the log level of the default logger by calling `logging.SetDefaultLogLevel()` if the config option `Debug` is disabled.