### PR TITLE
Envoy wait for ipcache initialization

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1055,7 +1055,7 @@
    * - :spelling:ignore:`envoy.image`
      - Envoy container image.
      - object
-     - ``{"digest":"sha256:1b477ce9f8fb5d9c8c570ce2d12e331d09cb4d5d3ae1dcefa37517cb7bb984f1","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.29.7-1723642513-538a08d6c6e25001a582ea9efe0fde398f12a974","useDigest":true}``
+     - ``{"digest":"sha256:2c2c21ea6219636c4a41207d8bdd91b962b62a4b7a7f407e344419d22f52f063","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy-dev","tag":"9b873ab8a413000c4dfb184cd031ce10184f1891","useDigest":true}``
    * - :spelling:ignore:`envoy.livenessProbe.failureThreshold`
      - failure threshold of liveness probe
      - int

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -729,6 +729,8 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	if len(oldIngressIPs) > 0 {
 		log.WithField(logfields.Ingress, oldIngressIPs).Info("Restored ingress IPs")
 	}
+	// Mark the ipcache as initialized so that anyone waiting for it can continue
+	d.ipcache.MarkInitialized()
 
 	// Read the service IDs of existing services from the BPF map and
 	// reserve them. This must be done *before* connecting to the

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:445ba6795b3a3b0fe46976a22
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.29.7-1723642513-538a08d6c6e25001a582ea9efe0fde398f12a974@sha256:1b477ce9f8fb5d9c8c570ce2d12e331d09cb4d5d3ae1dcefa37517cb7bb984f1 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy-dev:9b873ab8a413000c4dfb184cd031ce10184f1891@sha256:2c2c21ea6219636c4a41207d8bdd91b962b62a4b7a7f407e344419d22f52f063 as cilium-envoy
 
 #
 # Hubble CLI

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -313,7 +313,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:1b477ce9f8fb5d9c8c570ce2d12e331d09cb4d5d3ae1dcefa37517cb7bb984f1","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.29.7-1723642513-538a08d6c6e25001a582ea9efe0fde398f12a974","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:2c2c21ea6219636c4a41207d8bdd91b962b62a4b7a7f407e344419d22f52f063","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy-dev","tag":"9b873ab8a413000c4dfb184cd031ce10184f1891","useDigest":true}` | Envoy container image. |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | envoy.log.format | string | `"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"` | The format string to use for laying out the log message metadata of Envoy. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1860,10 +1860,10 @@ envoy:
   # -- Envoy container image.
   image:
     override: ~
-    repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.29.7-1723642513-538a08d6c6e25001a582ea9efe0fde398f12a974"
+    repository: "quay.io/cilium/cilium-envoy-dev"
+    tag: "9b873ab8a413000c4dfb184cd031ce10184f1891"
     pullPolicy: "IfNotPresent"
-    digest: "sha256:1b477ce9f8fb5d9c8c570ce2d12e331d09cb4d5d3ae1dcefa37517cb7bb984f1"
+    digest: "sha256:2c2c21ea6219636c4a41207d8bdd91b962b62a4b7a7f407e344419d22f52f063"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1857,10 +1857,10 @@ envoy:
   # -- Envoy container image.
   image:
     override: ~
-    repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.29.7-1723642513-538a08d6c6e25001a582ea9efe0fde398f12a974"
+    repository: "quay.io/cilium/cilium-envoy-dev"
+    tag: "9b873ab8a413000c4dfb184cd031ce10184f1891"
     pullPolicy: "${PULL_POLICY}"
-    digest: "sha256:1b477ce9f8fb5d9c8c570ce2d12e331d09cb4d5d3ae1dcefa37517cb7bb984f1"
+    digest: "sha256:2c2c21ea6219636c4a41207d8bdd91b962b62a4b7a7f407e344419d22f52f063"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -66,6 +66,10 @@ type NPHDSCache struct {
 
 type IPCacheEventSource interface {
 	AddListener(ipcache.IPIdentityMappingListener)
+
+	// Initialized returns a channel that is closed when ipcache has been (re)initialized upon
+	// restart or during a fresh bootstrap
+	Initialized() <-chan struct{}
 }
 
 func newNPHDSCache(ipcache IPCacheEventSource) NPHDSCache {

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -231,7 +231,7 @@ func StartXDSServer(ipcache IPCacheEventSource, envoySocketDir string) (*XDSServ
 		SecretTypeURL:             sdsConfig,
 		NetworkPolicyTypeURL:      npdsConfig,
 		NetworkPolicyHostsTypeURL: nphdsConfig,
-	}, 5*time.Second)
+	}, 5*time.Second, ipcache.Initialized())
 
 	return &XDSServer{
 		socketPath:             xdsSocketPath,

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -52,6 +52,10 @@ type IPCacheManager interface {
 	// AddListener is required for envoy.StartXDSServer()
 	AddListener(ipcache.IPIdentityMappingListener)
 
+	// Initialized returns a channel that is closed when ipcache has been (re)initialized upon
+	// restart or during a fresh bootstrap
+	Initialized() <-chan struct{}
+
 	LookupByIP(IP string) (ipcache.Identity, bool)
 }
 

--- a/pkg/testutils/ipcache/ipcache.go
+++ b/pkg/testutils/ipcache/ipcache.go
@@ -17,6 +17,13 @@ import (
 
 type MockIPCache struct{}
 
+// Initialized returns a closed channel so that potential waiters can continue immediately.
+func (m *MockIPCache) Initialized() <-chan struct{} {
+	initialized := make(chan struct{})
+	close(initialized)
+	return initialized
+}
+
 func (m *MockIPCache) GetNamedPorts() types.NamedPortMultiMap {
 	return nil
 }


### PR DESCRIPTION
Wait until ipcache has been re-pinned and initialized before serving any resources to Envoy. This allows Envoy reopening the ipcache at the right time.

```release-note
Cilium Agent now waits until ipcache has been re-pinned and initialized before starting service resources to Envoy.
```
