### PR TITLE
Replace k8s.io/utils/strings/slices by Go stdlib slices

### DIFF
--- a/operator/pkg/secretsync/secretsync.go
+++ b/operator/pkg/secretsync/secretsync.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/strings/slices"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/hubble/metrics/api/context.go
+++ b/pkg/hubble/metrics/api/context.go
@@ -5,11 +5,11 @@ package api
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/utils/strings/slices"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"

--- a/pkg/k8s/slim/k8s/apis/labels/selector.go
+++ b/pkg/k8s/slim/k8s/apis/labels/selector.go
@@ -7,6 +7,7 @@ package labels
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -15,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
-	stringslices "k8s.io/utils/strings/slices"
 
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/selection"
 )
@@ -283,7 +283,7 @@ func (r Requirement) Equal(x Requirement) bool {
 	if r.operator != x.operator {
 		return false
 	}
-	return stringslices.Equal(r.strValues, x.strValues)
+	return slices.Equal(r.strValues, x.strValues)
 }
 
 // Empty returns true if the internalSelector doesn't restrict selection space


### PR DESCRIPTION
Use the functionality provided by the Go standard library `slices` package since Go 1.21 instead of the k8s utils package.
