### PR TITLE
ci: datapath-verifier: also run on 6.6 kernel

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -102,6 +102,9 @@ jobs:
           - kernel: '6.1-20240710.064909'
             ci-kernel: '61'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
+          - kernel: '6.6-20240710.064909'
+            ci-kernel: '61'
+          # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: 'bpf-next-20240711.013133'
             ci-kernel: 'netnext'
     timeout-minutes: 60


### PR DESCRIPTION
6.6 is the latest longterm-stable kernel, give it the usual coverage in CI.

Use the 6.1 complexity configs for now, until we depend on any 6.6-specific kernel capabilities.
