### PR TITLE
bgpv2: Cleanup BGPInstance reconciler metadata

### DIFF
--- a/pkg/bgpv1/manager/instance/fake_instance.go
+++ b/pkg/bgpv1/manager/instance/fake_instance.go
@@ -10,9 +10,8 @@ import (
 // NewFakeBGPInstance is fake BGP instance, to be used in unit tests.
 func NewFakeBGPInstance() *BGPInstance {
 	return &BGPInstance{
-		Name:     "fake-instance",
-		Config:   nil,
-		Router:   types.NewFakeRouter(),
-		Metadata: make(map[string]any),
+		Name:   "fake-instance",
+		Config: nil,
+		Router: types.NewFakeRouter(),
 	}
 }

--- a/pkg/bgpv1/manager/instance/instance.go
+++ b/pkg/bgpv1/manager/instance/instance.go
@@ -68,11 +68,9 @@ func NewServerWithConfig(ctx context.Context, log *logrus.Entry, params types.Se
 type BGPInstance struct {
 	Name      string
 	Global    types.BGPGlobal
-	ASN       uint32 // deprecated: use Global.ASN instead
 	CancelCtx context.CancelFunc
 	Config    *v2alpha1api.CiliumBGPNodeInstance
 	Router    types.Router
-	Metadata  map[string]any
 }
 
 // NewBGPInstance will start an underlying BGP instance utilizing types.ServerParameters
@@ -94,10 +92,8 @@ func NewBGPInstance(ctx context.Context, log *logrus.Entry, name string, params 
 	return &BGPInstance{
 		Name:      name,
 		Global:    params.Global,
-		ASN:       params.Global.ASN,
 		CancelCtx: cancel,
 		Config:    nil,
 		Router:    s,
-		Metadata:  make(map[string]any),
 	}, nil
 }

--- a/pkg/bgpv1/manager/reconcilerv2/neighbor_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/neighbor_test.go
@@ -248,6 +248,8 @@ func TestNeighborReconciler(t *testing.T) {
 
 			// setup initial neighbors
 			neighborReconciler := NewNeighborReconciler(params).Reconciler
+			neighborReconciler.Init(testInstance)
+			defer neighborReconciler.Cleanup(testInstance)
 			reconcileParams := ReconcileParams{
 				BGPInstance:   testInstance,
 				DesiredConfig: nodeConfig,
@@ -259,8 +261,10 @@ func TestNeighborReconciler(t *testing.T) {
 			validatePeers(req, tt.neighbors, getRunningPeers(req, testInstance), tt.checks)
 
 			// update neighbors
+
 			params, nodeConfig = setupNeighbors(tt.newNeighbors)
-			neighborReconciler = NewNeighborReconciler(params).Reconciler
+			neighborReconciler.(*NeighborReconciler).PeerConfig = params.PeerConfig
+			neighborReconciler.(*NeighborReconciler).SecretStore = params.SecretStore
 			reconcileParams = ReconcileParams{
 				BGPInstance:   testInstance,
 				DesiredConfig: nodeConfig,

--- a/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
@@ -34,6 +34,7 @@ type PodCIDRReconcilerIn struct {
 type PodCIDRReconciler struct {
 	logger     logrus.FieldLogger
 	peerAdvert *CiliumPeerAdvertisement
+	metadata   map[string]PodCIDRReconcilerMetadata
 }
 
 // PodCIDRReconcilerMetadata is a map of advertisements per family, key is family type
@@ -52,6 +53,7 @@ func NewPodCIDRReconciler(params PodCIDRReconcilerIn) PodCIDRReconcilerOut {
 		Reconciler: &PodCIDRReconciler{
 			logger:     params.Logger.WithField(types.ReconcilerLogField, "PodCIDR"),
 			peerAdvert: params.PeerAdvert,
+			metadata:   make(map[string]PodCIDRReconcilerMetadata),
 		},
 	}
 }
@@ -64,11 +66,22 @@ func (r *PodCIDRReconciler) Priority() int {
 	return PodCIDRReconcilerPriority
 }
 
-func (r *PodCIDRReconciler) Init(_ *instance.BGPInstance) error {
+func (r *PodCIDRReconciler) Init(i *instance.BGPInstance) error {
+	if i == nil {
+		return fmt.Errorf("BUG: %s reconciler initialization with nil BGPInstance", r.Name())
+	}
+	r.metadata[i.Name] = PodCIDRReconcilerMetadata{
+		AFPaths:       make(AFPathsMap),
+		RoutePolicies: make(RoutePolicyMap),
+	}
 	return nil
 }
 
-func (r *PodCIDRReconciler) Cleanup(_ *instance.BGPInstance) {}
+func (r *PodCIDRReconciler) Cleanup(i *instance.BGPInstance) {
+	if i != nil {
+		delete(r.metadata, i.Name)
+	}
+}
 
 func (r *PodCIDRReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
 	if p.DesiredConfig == nil {
@@ -227,15 +240,9 @@ func (r *PodCIDRReconciler) getDesiredRoutePolicies(p ReconcileParams, desiredPe
 }
 
 func (r *PodCIDRReconciler) getMetadata(i *instance.BGPInstance) PodCIDRReconcilerMetadata {
-	if _, found := i.Metadata[r.Name()]; !found {
-		i.Metadata[r.Name()] = PodCIDRReconcilerMetadata{
-			AFPaths:       make(AFPathsMap),
-			RoutePolicies: make(RoutePolicyMap),
-		}
-	}
-	return i.Metadata[r.Name()].(PodCIDRReconcilerMetadata)
+	return r.metadata[i.Name]
 }
 
 func (r *PodCIDRReconciler) setMetadata(i *instance.BGPInstance, metadata PodCIDRReconcilerMetadata) {
-	i.Metadata[r.Name()] = metadata
+	r.metadata[i.Name] = metadata
 }


### PR DESCRIPTION
Replace global BGPv2 reconciler metadata kept in `BGPInstance` with metadata kept privately in individual reconcilers.