### PR TITLE
hooks: support concurrent tests run

### DIFF
--- a/cilium-cli/api/api.go
+++ b/cilium-cli/api/api.go
@@ -74,7 +74,7 @@ var _ Hooks = &NopHooks{}
 func (*NopHooks) AddSysdumpFlags(*pflag.FlagSet)                                  {}
 func (*NopHooks) AddSysdumpTasks(*sysdump.Collector) error                        { return nil }
 func (*NopHooks) AddConnectivityTestFlags(*pflag.FlagSet)                         {}
-func (*NopHooks) AddConnectivityTests(*check.ConnectivityTest) error              { return nil }
+func (*NopHooks) AddConnectivityTests(...*check.ConnectivityTest) error           { return nil }
 func (*NopHooks) DetectFeatures(context.Context, *check.ConnectivityTest) error   { return nil }
 func (*NopHooks) SetupAndValidate(context.Context, *check.ConnectivityTest) error { return nil }
 func (*NopHooks) InitializeCommand(*cobra.Command)                                {}

--- a/cilium-cli/connectivity/suite.go
+++ b/cilium-cli/connectivity/suite.go
@@ -16,7 +16,7 @@ import (
 type Hooks interface {
 	check.SetupHooks
 	// AddConnectivityTests is an hook to register additional connectivity tests.
-	AddConnectivityTests(ct *check.ConnectivityTest) error
+	AddConnectivityTests(cts ...*check.ConnectivityTest) error
 }
 
 func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) error {


### PR DESCRIPTION
The Hooks.AddConnectivityTests method signature changed to support concurrent test run.