### PR TITLE
 ci, scale: Add EGW masquerade delay scale test

### DIFF
--- a/.github/actions/cl2-modules/egw/README.md
+++ b/.github/actions/cl2-modules/egw/README.md
@@ -1,0 +1,137 @@
+# egw
+
+This directory contains utilities for performing scale tests on Cilium's Egress
+Gateway feature.
+
+An additional docker image is utilized to perform the test, which can be found
+within the [cilium/scaffolding](https://github.com/cilium/scaffolding/tree/main/egw-scale-utils)
+repository.
+
+## Pod Masquerade Delay
+
+This test measures the amount of time it takes for a Pod's network traffic to
+be masqueraded through an EGW node to an external target.
+
+### Test Overview
+
+At a high-level, the test works by creating an EGW policy to target a workload
+Pod that attempts to open a TCP connection to a pre-deployed external target.
+If the pre-deployed external target sees that the source address of the TCP
+connection is the pre-set EGW Node IP, then the external target will reply
+with "pong" and close the connection. If the source address is not the pre-set
+EGW Node IP, then the external target will close the connection without sending
+any reply traffic.
+
+When the client connects to the external target and does not receive any reply
+traffic, the connection attempt is deemed a "miss". The client will continue
+to connect to the external target until it receives "pong" in reply, allowing
+for the implementation delay of an EGW policy for a new Pod to be measured.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Client's Datapath
+    participant EGW Node
+    participant External Target
+    note right of Client: Before EGW Policy is in effect
+    Client-->>+Client's Datapath: Connect to target via TCP
+    Client's Datapath-->>+External Target: Forward connection
+    External Target->>+Client: Accept and close connection
+    note right of Client: After EGW Policy is in effect
+    Client->>+Client's Datapath: Connect to target via TCP
+    Client's Datapath-->>+EGW Node: Forward connection
+    EGW Node-->>+External Target: Masquerade connection
+    External Target->>+EGW Node: Send "pong" and close connection
+    EGW Node-->>+Client: Send "pong" and close connection
+```
+
+A baseline test can be executed by running the test without deploying the
+EGW Policy and by configuring the external target to always respond with
+"pong" to any incoming requests.
+
+### Client Pod Metrics
+
+| Name                                            | Description                                                                                              |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `egw_scale_test_leaked_requests_total`          | The total number of leaked requests a client made when trying to access the external target.             |
+| `egw_scale_test_masquerade_delay_seconds_total` | The number of seconds between a client pod starting and hitting the external target.                     |
+| `egw_scale_test_failed_tests_total`             | Incremented when a client Pod is unable to connect to the external target after a preconfigured timeout. |
+
+### Environment Details
+
+The cluster needs to be created with four types of nodes:
+
+1. At least one Node for the EGW clients to be deployed onto, labeled with
+   `role.scaffolding/egw-client: true`.
+2. At least one node to act as the EGW Node, labeled with
+   `role.scaffolding/egw-node: true`.
+3. A node to deploy the external target onto, labeled with
+   `cilium.io/no-schedule "true"`. This label will prevent Cilium from being
+   scheduled onto the node, tricking Cilium Agents running on other nodes into
+   believing the node is external to the cluster.
+4. A node to deploy monitoring infrastructure onto, to isolate
+   monitoring-related traffic and resource usage from the test, labeled
+   with `role.scaffolding/monitoring: true`.
+
+### Test Set Up
+
+After the cluster is created, use the `preflight.sh` script to perform setup tasks.
+
+The components of the test rely on two pieces of information to be hardcoded
+into their manifests:
+
+1. The address of the dedicated EGW Node, which the external target uses
+   to differentiate masqueraded versus non-masqueraded traffic.
+2. The address of the external target, which is needed by the client to send
+   requests and needed by the EGW Policy to understand the destination CIDR
+   of outgoing connections that needs to be masqueraded.
+
+Grabbing and hardcoding these two addresses ahead of time simplifies the
+test execution and limits the overall scope of components under test.
+For instance, using a hardcoded address for the external target allows
+for the client to make a direct connection without the need for a Service
+or DNS.
+
+The `preflight.sh` script will grab the two addresses, fill out manifest
+templates and apply the EGW policy.
+
+**If running a baseline test, execute `preflight.sh baseline`,
+which will cause the preflight script to configure the manifests for a baseline
+test and skip applying the EGW policy.**
+
+### Test Execution
+
+The test is executed via [ClusterLoader2](https://github.com/kubernetes/perf-tests/tree/master/clusterloader2).
+The config for the test is named `config.yml`. It executes the following steps
+to run the test:
+
+0. Deploy a PodMonitor to target the Prometheus endpoint of test client Pods.
+1. Deploy the external target Pod and wait for it to be running and ready.
+2. Deploy a single test client Pod and wait for it to be ready. Timeouts are
+   configured in a way where, if the client Pod is unable to successfully
+   connect to the external target through EGW, the test will fail. This
+   step ensures that the EGW policy has been plumbed into the datapath.
+3. Deploy `N` test client Pods and wait for them to be ready. The number
+   of deployed client pods and the rate at which they are deployed can be
+   configured. See the next section for details.
+4. Sleep, to allow for the metrics exposed by each client Pod to be scraped.
+5. Collect and export metrics. See the next section for details regarding
+   the metrics which are exported.
+
+### Test Metrics
+
+| Name                                     | Description                                                                                                                   |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `EGW Total Number of Client Pods`        | The total number of client pods that were deployed during the test.                                                           |
+| `EGW Total Number of Failed Client Pods` | The total number of client pods that were unable to connect to the external target through EGW within the configured timeout. |
+| `EGW Leaked Pings - Nth Percentile`      | The Nth percentile of pings that were leaked across all client pods.                                                          |
+| `EGW Leaked Pings - Total`               | The total number of pings that were leaked across all client pods.                                                            |
+| `EGW Masquerade Delay - Nth Percentile`  | The Nth percentile of the masquerade delay across all client pods.                                                            |
+
+### Test Configuration
+
+The following environment variables are available to modify the CL2 config:
+
+1. `CL2_NUM_EGW_CLIENTS`: The total number of client Pods which the test will
+   deploy.
+2. `CL2_EGW_CLIENTS_QPS`: The number of client Pods to deploy per second.

--- a/.github/actions/cl2-modules/egw/config.yaml
+++ b/.github/actions/cl2-modules/egw/config.yaml
@@ -1,0 +1,165 @@
+{{$NumEGWClients := DefaultParam .CL2_NUM_EGW_CLIENTS 9}}
+{{$QPS := DefaultParam .CL2_EGW_CLIENTS_QPS 3}}
+{{$ADDITIONAL_MEASUREMENT_MODULES := DefaultParam .CL2_ADDITIONAL_MEASUREMENT_MODULES nil}}
+
+name: egw-scale-test-masq-delay
+namespace:
+  number: 1
+  deleteAutomanagedNamespaces: false
+tuningSets:
+- name: Uniform1qps
+  qpsLoad:
+    qps: 1
+- name: UniformParamqps
+  qpsLoad:
+    qps: {{$QPS}}
+steps:
+- name: Create External Target Pod
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: 1
+    tuningSet: Uniform1qps
+    objectBundle:
+    - basename: egw-external-target
+      objectTemplatePath: manifests/external-target-pod.yaml
+- name: Wait for external target pod to be running
+  measurements:
+  - Identifier: WaitForRunningPods
+    Method: WaitForRunningPods
+    Params:
+      labelSelector: app.kubernetes.io/name=egw-external-target
+      desiredPodCount: 1
+      timeout: 60s
+- name: Create bootstrap EGW client Pod
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: 1
+    tuningSet: Uniform1qps
+    objectBundle:
+    - basename: egw-client-pod-bootstrap
+      objectTemplatePath: manifests/client-pod.yaml
+      templateFillMap:
+        ClientIsBootstrap: "true"
+        ClientConnectTimeout: "60s"
+- name: Wait for EGW bootstrap pod to be running
+  measurements:
+  - Identifier: WaitForRunningPods
+    Method: WaitForRunningPods
+    Params:
+      labelSelector: app.kubernetes.io/name=egw-client,scaffolding.cilium.io/egw-client-is-bootstrap=true
+      desiredPodCount: 1
+      timeout: 55s
+
+{{if $ADDITIONAL_MEASUREMENT_MODULES}}
+{{range $ADDITIONAL_MEASUREMENT_MODULES}}
+- module:
+    path: {{.}}
+    params:
+      action: start
+{{end}}
+{{end}}
+
+- name: Start measurements
+  measurements:
+  - Identifier: EGWMasqueradeDelayMetrics
+    Method: GenericPrometheusQuery
+    Params:
+      action: start
+      metricName: "EGW Masquerade Delay Metrics"
+      metricVersion: v1
+      unit: s
+      queries:
+      - name: EGW Masquerade Delay - 50th Percentile
+        query: quantile(0.5, egw_scale_test_masquerade_delay_seconds_total)
+      - name: EGW Masquerade Delay - 90th Percentile
+        query: quantile(0.9, egw_scale_test_masquerade_delay_seconds_total)
+      - name: EGW Masquerade Delay - 95th Percentile
+        query: quantile(0.95, egw_scale_test_masquerade_delay_seconds_total)
+      - name: EGW Masquerade Delay - 99th Percentile
+        query: quantile(0.99, egw_scale_test_masquerade_delay_seconds_total)
+  - Identifier: EGWLeakedPingsMetrics
+    Method: GenericPrometheusQuery
+    Params:
+      action: start
+      metricName: "EGW Leaked Pings Metrics"
+      metricVersion: v1
+      unit: count
+      queries:
+      - name: EGW Leaked Pings - 50th Percentile
+        query: quantile(0.5, egw_scale_test_leaked_requests_total)
+      - name: EGW Leaked Pings - 90th Percentile
+        query: quantile(0.9, egw_scale_test_leaked_requests_total)
+      - name: EGW Leaked Pings - 95th Percentile
+        query: quantile(0.95, egw_scale_test_leaked_requests_total)
+      - name: EGW Leaked Pings - 99th Percentile
+        query: quantile(0.99, egw_scale_test_leaked_requests_total)
+      - name: EGW Leaked Pings - Total
+        query: sum(egw_scale_test_leaked_requests_total)
+  - Identifier: EGWPodCountMetrics
+    Method: GenericPrometheusQuery
+    Params:
+      action: start
+      metricName: "EGW Pod Count Metrics"
+      metricVersion: v1
+      unit: pod
+      queries:
+      - name: EGW Total Number of Client Pods
+        query: count(count(egw_scale_test_masquerade_delay_seconds_total) by (pod))
+      - name: EGW Total Number of Failed Client Pods
+        query: count(count(egw_scale_test_masquerade_delay_seconds_total==0) by (pod))
+        threshold: 0
+- name: Create EGW client Pods
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: {{$NumEGWClients}}
+    tuningSet: UniformParamqps
+    objectBundle:
+    - basename: egw-client-pod
+      objectTemplatePath: manifests/client-pod.yaml
+      templateFillMap:
+        ClientIsBootstrap: "false"
+        ClientConnectTimeout: "295s"
+- name: Wait for EGW Client pods to be running
+  measurements:
+  - Identifier: WaitForRunningPods
+    Method: WaitForRunningPods
+    Params:
+      labelSelector: app.kubernetes.io/name=egw-client,scaffolding.cilium.io/egw-client-is-bootstrap=false
+      desiredPodCount: {{$NumEGWClients}}
+      timeout: 300s
+- name: Sleep to allow scraping
+  measurements:
+  - Identifier: SleepTwiceScrapeInterval
+    Method: Sleep
+    Params:
+      duration: 30s
+- name: Collect metrics
+  measurements:
+  - Identifier: EGWMasqueradeDelayMetrics
+    Method: GenericPrometheusQuery
+    Params:
+      action: gather
+  - Identifier: EGWLeakedPingsMetrics
+    Method: GenericPrometheusQuery
+    Params:
+      action: gather
+  - Identifier: EGWPodCountMetrics
+    Method: GenericPrometheusQuery
+    Params:
+      action: gather
+
+{{if $ADDITIONAL_MEASUREMENT_MODULES}}
+{{range $ADDITIONAL_MEASUREMENT_MODULES}}
+- module:
+    path: {{.}}
+    params:
+      action: gather
+{{end}}
+{{end}}
+

--- a/.github/actions/cl2-modules/egw/manifests/client-pod.tmpl.yaml
+++ b/.github/actions/cl2-modules/egw/manifests/client-pod.tmpl.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{.Name}}
+  labels:
+    app.kubernetes.io/name: egw-client
+    scaffolding.cilium.io/egw-client-is-bootstrap: "{{.ClientIsBootstrap}}"
+spec:
+  nodeSelector:
+    role.scaffolding/egw-client: "true"
+  containers:
+  - name: egw-client
+    image: quay.io/cilium/egw-scale-utils:${EGW_IMAGE_TAG}
+    imagePullPolicy: IfNotPresent
+    args:
+      - "client"
+      - "--external-target-addr=${EGW_EXTERNAL_TARGET_ADDR}:1337"
+      - "--test-timeout={{.ClientConnectTimeout}}"
+    ports:
+    - name: prometheus
+      containerPort: 2112
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    readinessProbe:
+      httpGet:
+        path: "/readyz"
+        port: 2112
+      initialDelaySeconds: 5
+      periodSeconds: 1

--- a/.github/actions/cl2-modules/egw/manifests/egw-policy.tmpl.yaml
+++ b/.github/actions/cl2-modules/egw/manifests/egw-policy.tmpl.yaml
@@ -1,0 +1,15 @@
+apiVersion: cilium.io/v2
+kind: CiliumEgressGatewayPolicy
+metadata:
+  name: egw-scale-test-route-external
+spec:
+  selectors:
+  - podSelector:
+      matchLabels:
+        app.kubernetes.io/name: egw-client
+  destinationCIDRs:
+  - "${EGW_EXTERNAL_TARGET_CIDR}"
+  egressGateway:
+    nodeSelector:
+      matchLabels:
+        role.scaffolding/egw-node: "true"

--- a/.github/actions/cl2-modules/egw/manifests/external-target-pod.tmpl.yaml
+++ b/.github/actions/cl2-modules/egw/manifests/external-target-pod.tmpl.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: egw-external-target
+  labels:
+    app.kubernetes.io/name: egw-external-target
+spec:
+  hostNetwork: true
+  nodeSelector:
+    cilium.io/no-schedule: "true"
+  tolerations:
+  - key: node.kubernetes.io/not-ready
+    operator: Exists
+    effect: NoSchedule
+  - key: cilium.io/no-schedule
+    operator: Exists
+    effect: NoSchedule
+  containers:
+  - name: external-target
+    image: quay.io/cilium/egw-scale-utils:${EGW_IMAGE_TAG}
+    imagePullPolicy: IfNotPresent
+    ports:
+    - containerPort: 1337
+    args:
+      - "external-target"
+      - "--allowed-cidr=${EGW_ALLOWED_CIDR}"
+      - "--listen-port=1337"

--- a/.github/actions/cl2-modules/egw/preflight.sh
+++ b/.github/actions/cl2-modules/egw/preflight.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -xeo pipefail
+
+if [ -z "${EGW_IMAGE_TAG}"]; then
+    echo "FATAL: \$EGW_IMAGE_TAG must be defined"
+    exit 1
+fi
+
+fill_template() {
+    echo $EGW_EXTERNAL_TARGET_CIDR
+    cat $1 | envsubst | tee > "${1//\.tmpl/}"
+}
+
+get_node_internal_ip() {
+    kubectl get node -l $1 -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}'
+}
+
+if [ "$1" != "baseline" ]; then
+    external_target_ip=$(get_node_internal_ip "role.scaffolding/egw-node=true")
+    export EGW_ALLOWED_CIDR="${external_target_ip}/32"
+else
+    export EGW_ALLOWED_CIDR="0.0.0.0/0"
+fi
+
+egw_node_ip=$(get_node_internal_ip "cilium.io/no-schedule=true")
+export EGW_EXTERNAL_TARGET_CIDR="${egw_node_ip}/32"
+export EGW_EXTERNAL_TARGET_ADDR="${egw_node_ip}"
+
+for template in ./manifests/*.tmpl.yaml; do
+    fill_template $template
+done
+
+if [ "$1" != "baseline" ]; then
+    kubectl apply -f ./manifests/egw-policy.yaml
+else
+    kubectl delete --ignore-not-found \
+        ciliumegressgatewaypolicies.cilium.io/egw-scale-test-route-external
+fi

--- a/.github/actions/cl2-modules/egw/prom-extra-podmons/podmonitor.yaml
+++ b/.github/actions/cl2-modules/egw/prom-extra-podmons/podmonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: egw-client
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: egw-client
+      scaffolding.cilium.io/egw-client-is-bootstrap: "false"
+  namespaceSelector:
+    any: true
+  podMetricsEndpoints:
+  - port: prometheus
+    interval: 5s

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -86,6 +86,9 @@ triggers:
   /scale-clustermesh:
     workflows:
     - scale-test-clustermesh.yaml
+  /scale-egw:
+    workflows:
+    - scale-test-egw.yaml
   /net-perf-gke:
     workflows:
     - net-perf-gke.yaml

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -1,0 +1,512 @@
+name: Scale Test Egress Gateway (scale-egw)
+
+on:
+  schedule:
+    - cron: "27 0 * * 1-5"
+
+  workflow_dispatch:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: true
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: true
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: true
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        default: "{}"
+      num-clients:
+        description: "Number of clients to create to connect to the external target through EGW"
+        required: false
+        default: 100
+        type: number
+      client-qps:
+        description: "Number of client pods to create per second"
+        required: false
+        default: 20
+        type: number
+
+# For testing uncomment following lines:
+#  push:
+#    branches:
+#      - your_branch_name
+
+permissions:
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To be able to request the JWT from GitHub's OIDC provider
+  id-token: write
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # To be able to set commit status
+  statuses: write
+
+concurrency:
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - workflow_dispatch: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing, such that re-runs will cancel the previous run.
+  group: |
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+    }}
+  cancel-in-progress: true
+
+env:
+  # renovate: datasource=golang-version depName=go
+  go_version: 1.23.4
+  # renovate: datasource=github-releases depName=eksctl-io/eksctl
+  eksctl_version: v0.198.0
+  # renovate: datasource=github-releases depName=kubernetes/kubernetes
+  kubectl_version: v1.31.4
+  # renovate: datasource=docker depName=google/cloud-sdk
+  gcloud_version: 503.0.0
+
+  # Hosted under quay.io/cilium/egw-scale-utils and built by
+  # a workflow in cilium/scaffolding.
+  # renovate: datasource=git-refs depName=https://github.com/cilium/scaffolding branch=main
+  egw_utils_ref: 147e53d962f818eec901549c29be48b70b02b8d7
+  test_name: egw
+  cluster_name: ${{ github.run_id }}-${{ github.run_attempt }}
+  AWS_SSH_KEY: ~/.ssh/id_aws.pub
+  AWS_SSH_KEY_PRIVATE: ~/.ssh/id_aws
+
+jobs:
+  echo-inputs:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    name: Echo Workflow Dispatch Inputs
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Echo Workflow Dispatch Inputs
+        run: |
+          echo '${{ tojson(inputs) }}'
+
+  commit-status-start:
+    name: Commit Status Start
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set initial commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+
+  install-and-scaletest:
+    runs-on: ubuntu-24.04
+    name: Install and Scale Test
+    timeout-minutes: 150
+    strategy:
+      fail-fast: false
+      matrix:
+        test_type:
+          - md-bs # Abbreviated "masquerade delay - baseline"
+          - md
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up job variables
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] ; then
+            SHA="${{ inputs.SHA }}"
+          else
+            SHA="${{ github.sha }}"
+          fi
+
+          # The SHA under test will have its helm chart checked out at the following
+          # path right before the step where Cilium is installed.
+          CILIUM_INSTALL_DEFAULTS="--chart-directory=untrusted/install/kubernetes/cilium \
+            --wait=false \
+            --set=hubble.enbaled=true \
+            --set=pprof.enabled=true \
+            --set=prometheus.enabled=true \
+            --set=cluster.name=${{ env.cluster_name }} \
+            --set=egressGateway.enabled=true \
+            --set=bpf.masquerade=true \
+            --set=kubeProxyReplacement=true \
+            --set=l7Proxy=false \
+            --set=egressMasqueradeInterfaces="" \
+            --set=eni.enabled=true \
+            --set=ipam.mode=eni \
+            --set=eni.awsEnablePrefixDelegation=true \
+            --set=image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci:${SHA} \
+            --set=operator.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator-aws-ci:${SHA} \
+            --set=hubble.relay.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci:${SHA} \
+            --nodes-without-cilium"
+
+          OWNER="${{ github.ref_name }}"
+          OWNER="${OWNER//[.\/]/-}"
+
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ] ; then
+            NUM_CLIENT_PODS="${{ inputs.num-clients }}"
+            CLIENT_QPS="${{ inputs.client-qps }}"
+          else
+            NUM_CLIENT_PODS="100"
+            CLIENT_QPS="20"
+          fi
+
+          # The m5.large instance type can support 29 Pods.
+          # See https://github.com/awslabs/amazon-eks-ami/blob/main/templates/shared/runtime/eni-max-pods.txt.
+          # Changing the instance type also requires changing the hardcoded value below!
+          NODE_INSTANCE_TYPE="m5.large"
+          NUM_CLIENT_NODES="$(((NUM_CLIENT_PODS / 29) + 2))"
+
+          TEST_NAME="${{ env.test_name }}-${{ matrix.test_type }}-${NUM_CLIENT_PODS}-${CLIENT_QPS}"
+          CLUSTER_NAME="${TEST_NAME}-${{ env.cluster_name }}"
+
+          eks_version_and_region=$(yq '.include | sort_by(.version) | reverse | .[0] | "\(.version),\(.region)"' .github/actions/eks/k8s-versions.yaml)
+          EKS_VERSION=$(echo $eks_version_and_region | cut -d',' -f1)
+          EKS_REGION=$(echo $eks_version_and_region | cut -d',' -f2)
+
+          echo sha=${SHA} >> $GITHUB_OUTPUT
+          echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
+          echo owner=${OWNER} >> $GITHUB_OUTPUT
+          echo test_name=${TEST_NAME} >> $GITHUB_OUTPUT
+          echo cluster_name=${CLUSTER_NAME} >> $GITHUB_OUTPUT
+          echo num_client_pods=${NUM_CLIENT_PODS} >> $GITHUB_OUTPUT
+          echo num_client_nodes=${NUM_CLIENT_NODES} >> $GITHUB_OUTPUT
+          echo node_instance_type=${NODE_INSTANCE_TYPE} >> $GITHUB_OUTPUT
+          echo client_qps=${CLIENT_QPS} >> $GITHUB_OUTPUT
+          echo eks_version=${EKS_VERSION} >> $GITHUB_OUTPUT
+          echo eks_region=${EKS_REGION} >> $GITHUB_OUTPUT
+
+      - name: Wait for images to be available
+        timeout-minutes: 30
+        shell: bash
+        run: |
+          for image in cilium-ci operator-aws-ci hubble-relay-ci ; do
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+          done
+
+      - name: Ensure EGW scale utils image is available
+        shell: bash
+        run: |
+          # Run this seprate from the other "Wait for images to be available" step to help with debugging.
+          if ! docker manifest inspect quay.io/cilium/egw-scale-utils:${{ env.egw_utils_ref }} ; then
+            echo "FATAL: egw-scale-utils image with ref ${{ env.egw_utils_ref }} is not available, exiting"
+            exit 1
+          fi
+
+      - name: Install Go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: ${{ env.go_version }}
+
+      - name: Setup gcloud credentials
+        uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_PERF_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_PERF_SA }}
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
+        with:
+          project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
+          version: ${{ env.gcloud_version }}
+
+      - name: Install kubectl
+        run: |
+          curl -sLO "https://dl.k8s.io/release/${{ env.kubectl_version }}/bin/linux/amd64/kubectl"
+          curl -sLO "https://dl.k8s.io/${{ env.kubectl_version }}/bin/linux/amd64/kubectl.sha256"
+          echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
+          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+          kubectl version --client
+
+      - name: Install eksctl CLI
+        run: |
+          curl -LO "https://github.com/eksctl-io/eksctl/releases/download/${{ env.eksctl_version }}/eksctl_$(uname -s)_amd64.tar.gz"
+          sudo tar xzvfC eksctl_$(uname -s)_amd64.tar.gz /usr/bin
+          rm eksctl_$(uname -s)_amd64.tar.gz
+
+      - name: Set up AWS CLI credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: ${{ secrets.AWS_PR_ASSUME_ROLE }}
+          aws-region: ${{ steps.vars.outputs.eks_region }}
+
+      - name: Run aws configure
+        run: |
+          aws configure set aws_access_key_id ${{ env.AWS_ACCESS_KEY_ID }}
+          aws configure set aws_secret_access_key ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws configure set aws_session_token ${{ env.AWS_SESSION_TOKEN }}
+          aws configure set default.region ${{ steps.vars.outputs.eks_region }}
+
+      - name: Display version info of installed tools
+        run: |
+          echo "--- go ---"
+          go version
+          echo "--- kubectl ---"
+          kubectl version --client
+          echo "--- eksctl ---"
+          eksctl version
+          echo "--- gcloud ---"
+          gcloud version
+
+      - name: Clone ClusterLoader2
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: kubernetes/perf-tests
+          # Avoid using renovate to update this dependency because: (1)
+          # perf-tests does not tag or release, so renovate will pull
+          # all updates to the default branch and (2) continually
+          # updating CL2 may impact the stability of the scale test
+          # results.
+          ref: ce821d6232cee6719dd86e7e68eee361e337e92a
+          persist-credentials: false
+          sparse-checkout: clusterloader2
+          path: perf-tests
+
+      - name: Generate SSH keypair
+        run: |
+          ssh-keygen -f ${{ env.AWS_SSH_KEY_PRIVATE }} -P ""
+
+      - name: Create EKS cluster
+        shell: bash
+        id: deploy-cluster
+        run: |
+          cat <<EOF > eks-config.yaml
+          apiVersion: eksctl.io/v1alpha5
+          kind: ClusterConfig
+
+          metadata:
+            name: ${{ steps.vars.outputs.cluster_name }}
+            region: ${{ steps.vars.outputs.eks_region }}
+            version: "${{ steps.vars.outputs.eks_version }}"
+            tags:
+              usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
+              owner: "${{ steps.vars.outputs.owner }}"
+
+          managedNodeGroups:
+          - name: ng-amd64-client
+            instanceTypes:
+            - ${{ steps.vars.outputs.node_instance_type }}
+            desiredCapacity: ${{ steps.vars.outputs.num_client_nodes }}
+            spot: false
+            privateNetworking: true
+            volumeType: "gp3"
+            volumeSize: 20
+            ssh:
+              allow: true
+              publicKeyPath: ${{ env.AWS_SSH_KEY }}
+            taints:
+            - key: "node.cilium.io/agent-not-ready"
+              value: "true"
+              effect: "NoExecute"
+            labels:
+              role.scaffolding/egw-client: "true"
+          - name: ng-amd64-egw-node
+            instanceTypes:
+            - ${{ steps.vars.outputs.node_instance_type }}
+            desiredCapacity: 1
+            spot: false
+            privateNetworking: true
+            volumeType: "gp3"
+            volumeSize: 20
+            ssh:
+              allow: true
+              publicKeyPath: ${{ env.AWS_SSH_KEY }}
+            taints:
+            - key: "node.cilium.io/agent-not-ready"
+              value: "true"
+              effect: "NoExecute"
+            labels:
+              role.scaffolding/egw-node: "true"
+          - name: ng-amd64-heapster
+            instanceTypes:
+            - ${{ steps.vars.outputs.node_instance_type }}
+            desiredCapacity: 1
+            spot: false
+            privateNetworking: true
+            volumeType: "gp3"
+            volumeSize: 20
+            ssh:
+              allow: true
+              publicKeyPath: ${{ env.AWS_SSH_KEY }}
+            taints:
+            - key: "node.cilium.io/agent-not-ready"
+              value: "true"
+              effect: "NoExecute"
+            labels:
+              role.scaffolding/monitoring: "true"
+          - name: ng-amd64-no-cilium
+            instanceTypes:
+            - ${{ steps.vars.outputs.node_instance_type }}
+            desiredCapacity: 1
+            spot: false
+            privateNetworking: true
+            volumeType: "gp3"
+            volumeSize: 20
+            ssh:
+              allow: true
+              publicKeyPath: ${{ env.AWS_SSH_KEY }}
+            taints:
+            - key: "cilium.io/no-schedule"
+              value: "true"
+              effect: "NoSchedule"
+            labels:
+              cilium.io/no-schedule: "true"
+          EOF
+
+          eksctl create cluster -f ./eks-config.yaml
+
+      - name: Install Cilium CLI
+        uses: cilium/cilium-cli@99ff3d9edd4050d7b5c9d1f51dcf6ebeeb613d15 # v0.16.15
+        with:
+          skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
+          image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
+          image-tag: ${{ inputs.SHA || github.sha }}
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout context ref (NOT TRUSTED)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ steps.vars.outputs.SHA }}
+          persist-credentials: false
+          path: untrusted
+          sparse-checkout: |
+            install/kubernetes/cilium
+
+      - name: Install Cilium
+        run: |
+          cilium install --dry-run-helm-values ${{ steps.vars.outputs.cilium_install_defaults }}
+          cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
+
+      - name: Delete context ref
+        run: |
+          rm -rf untrusted/
+
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
+
+      - name: Run preflight steps
+        shell: bash
+        working-directory: ./.github/actions/cl2-modules/egw
+        env:
+          EGW_IMAGE_TAG: ${{ env.egw_utils_ref }}
+        run: |
+          if [[ "${{ matrix.test_type }}" == "md-bs" ]]; then
+            ./preflight.sh baseline
+          else
+            ./preflight.sh
+          fi
+
+          cat ./manifests/*
+
+      - name: Run CL2
+        id: run-cl2
+        working-directory: ./perf-tests/clusterloader2
+        shell: bash
+        timeout-minutes: 40
+        env:
+          CL2_PROMETHEUS_PVC_ENABLED: "false"
+          CL2_ENABLE_PVS: "false"
+          CL2_PROMETHEUS_SCRAPE_CILIUM_OPERATOR: "true"
+          CL2_PROMETHEUS_SCRAPE_CILIUM_AGENT: "true"
+          CL2_PROMETHEUS_MEMORY_SCALE_FACTOR: "2.0"
+          CL2_PROMETHEUS_NODE_SELECTOR: 'role.scaffolding/monitoring: "true"'
+          CL2_NUM_EGW_CLIENTS: "${{ steps.vars.outputs.num_client_pods }}"
+          CL2_EGW_CLIENTS_QPS: "${{ steps.vars.outputs.client_qps }}"
+          CL2_MEDIAN_BOOTSTRAP_THRESHOLD: "80" # Takes a bit for ENI interfaces to be added
+        run: |
+          mkdir ./report
+
+          # CL2 hardcodes module paths to live in next to the config, even
+          # if the path given is relative.
+          cp ../../.github/actions/cl2-modules/cilium-agent-pprofs.yaml ../../.github/actions/cl2-modules/egw
+          cp ../../.github/actions/cl2-modules/cilium-metrics.yaml ../../.github/actions/cl2-modules/egw
+          echo \
+            '{"CL2_ADDITIONAL_MEASUREMENT_MODULES": ["./cilium-agent-pprofs.yaml", "./cilium-metrics.yaml"]}' \
+            > modules.yaml
+
+          go run ./cmd/clusterloader.go \
+            -v=2 \
+            --testconfig=../../.github/actions/cl2-modules/egw/config.yaml \
+            --prometheus-additional-monitors-path=../../.github/actions/cl2-modules/egw/prom-extra-podmons \
+            --provider=aws \
+            --enable-prometheus-server \
+            --tear-down-prometheus-server=false \
+            --report-dir=./report \
+            --experimental-prometheus-snapshot-to-report-dir=true \
+            --kubeconfig=$HOME/.kube/config \
+            --testoverrides=./testing/prometheus/not-scrape-kube-proxy.yaml \
+            --testoverrides=./modules.yaml \
+            2>&1 | tee cl2-output.txt
+
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "features-${{ matrix.test_type }}"
+
+      - name: Get sysdump
+        if: ${{ always() && steps.install-cilium.outcome != 'skipped' && steps.install-cilium.outcome != 'cancelled' }}
+        run: |
+          cilium status
+          cilium sysdump \
+            --output-filename cilium-sysdump-final \
+            --extra-label-selectors=app.kubernetes.io/name=egw-client \
+            --extra-label-selectors=app.kubernetes.io/name=egw-external-target
+          sudo chmod +r cilium-sysdump-final.zip
+
+      - name: Upload sysdump
+        if: ${{ !success() && steps.install-cilium.outcome != 'skipped' && steps.install-cilium.outcome != 'cancelled' }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: cilium-sysdump
+          path: cilium-sysdump-final.zip
+          retention-days: 5
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ matrix.test_type }}
+          path: features-*.json
+
+      - name: Cleanup cluster
+        if: ${{ always() && steps.deploy-cluster.outcome != 'skipped' }}
+        run: |
+          eksctl delete cluster --name ${{ steps.vars.outputs.cluster_name }} --region ${{ steps.vars.outputs.eks_region }}
+
+      - name: Export results and sysdump to GS bucket
+        if: ${{ always() && steps.run-cl2.outcome != 'skipped' && steps.run-cl2.outcome != 'cancelled' }}
+        uses: cilium/scale-tests-action/export-results@511e3d9dbf06f6dbde8d1af6834eb1fcab38ca05 # main
+        with:
+          test_name: ${{ steps.vars.outputs.test_name }}
+          results_bucket: ${{ env.GCP_PERF_RESULTS_BUCKET }}
+          artifacts: ./perf-tests/clusterloader2/report/*
+          other_files: cilium-sysdump-final.zip ./perf-tests/clusterloader2/cl2-output.txt
+
+  commit-status-final:
+    if: ${{ always() }}
+    name: Commit Status Final
+    needs: install-and-scaletest
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set final commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+          status: ${{ needs.install-and-scaletest.result }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

 ci, scale: Add EGW masquerade delay scale test

This commit introduces a new scale test for Egress Gateway. At a high
level, the scale test creates a series of Pods that attempt to
communicate to an external target through an EGW node. Metrics are
tracked by each client to record the client's experience in connecting
to the external target, such as how long it took for a connection to be
masqueraded through an EGW node, and how many connections could be
established before masquerading took place.

An extended description of the benchmark can be found in the
[cilium/scaffolding][1] repository, which hosts the benchmark's tooling.

The GHA workflow in this commit creates an EKS cluster to host the test.
A node is deployed without Cilium to host the external target. Nodes
hosting client Pods are configured to have a pod limit of 100, which
respects the upstream Kubernetes guidelines of 110 pods per node while
adding some buffer. Cilium is installed with prefix delegation enabled
to help limit the number of nodes that are required to be deployed. The
workflow will run the masquerade delay test, as well as the masquerade
delay baseline test. The latter is the exact same test as the former,
but with no EGW policy deployed, causing client pods to connect directly
to the external target without being routed through an EGW node.

[1]: https://github.com/cilium/scaffolding/blob/main/egw-scale-utils/README.md

```release-note
Add EGW masquerade delay scale test
```

The initial implementation of the test creates 100 client pods over the course of five seconds. These numbers will be tuned in subsequent PRs after further testing and feedback.

I used a temporary commit to test the workflow to ensure it was behaving properly. The successful run can be found here: https://github.com/cilium/cilium/actions/runs/10512891463. Results:

### Masquerade Delay

The number of seconds it took for each client Pod to connect to the external target through an EGW node. The timer started as soon as the client Pod's container was started. In the baseline test, no EGW policy was deployed and the external target accepted connections from any source IP. In the load test, an EGW policy was deployed and the external target only accepted connections from the designated EGW node.

#### Baseline - No EGW Policy

```json
{
  "version": "v1",
  "dataItems": [
    {
      "data": {
        "EGW Masquerade Delay - 50th Percentile": 0.0010267105,
        "EGW Masquerade Delay - 90th Percentile": 0.0034434174000000013,
        "EGW Masquerade Delay - 95th Percentile": 0.005646346649999996,
        "EGW Masquerade Delay - 99th Percentile": 0.018027556570000037
      },
      "unit": "s"
    }
  ]
}
```

#### Load - With EGW Policy

```json
{
  "version": "v1",
  "dataItems": [
    {
      "data": {
        "EGW Masquerade Delay - 50th Percentile": 0.0015355405,
        "EGW Masquerade Delay - 90th Percentile": 0.2568452291,
        "EGW Masquerade Delay - 95th Percentile": 0.3358767087499999,
        "EGW Masquerade Delay - 99th Percentile": 0.4642393707800009
      },
      "unit": "s"
    }
  ]
}
```

### Leaked Pings

The number of connections that were made to the external target directly from the client Pod before traffic was routed through an EGW node. Connections are made on a 50ms interval. This metric is not applicable to the baseline test. Percentiles are per client (the 99th percentile of the number of leaked pings of a client is 9), while the total count is the summation of all leaked pings across all clients (there were 84 leaked pings in total from the 100 clients).

```json
{
  "version": "v1",
  "dataItems": [
    {
      "data": {
        "EGW Leaked Pings - 50th Percentile": 0,
        "EGW Leaked Pings - 90th Percentile": 5,
        "EGW Leaked Pings - 95th Percentile": 6,
        "EGW Leaked Pings - 99th Percentile": 9.030000000000015,
        "EGW Leaked Pings - Total": 84
      },
      "unit": "count"
    }
  ]
}
```

### Pod Counts

These metrics track the number of pods that either successfully connected to the external target or were unable to establish a connection to the external target after a predefined timeout (295s).

#### Baseline

```json
{
  "version": "v1",
  "dataItems": [
    {
      "data": {
        "EGW Total Number of Client Pods": 100
      },
      "unit": "pod"
    }
  ]
}
```

#### Load

```json
{
  "version": "v1",
  "dataItems": [
    {
      "data": {
        "EGW Total Number of Client Pods": 100
      },
      "unit": "pod"
    }
  ]
}
```