### PR TITLE
Fix replace rule to 0.0.0.0/0 for ENI

### DIFF
--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -88,11 +88,13 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, compat bool, host bool) e
 	if info.Masquerade && info.IpamMode == ipamOption.IPAMENI {
 		// Lookup a VPC specific table for all traffic from an endpoint to the
 		// CIDR configured for the VPC on which the endpoint has the IP on.
+		// ReplaceRule function doesn't handle all zeros cidr and return `file exists` error,
+		// so we need to normalize the rule to cidr here and in Delete
 		for _, cidr := range info.IPv4CIDRs {
 			if err := route.ReplaceRule(route.Rule{
 				Priority: egressPriority,
 				From:     &ipWithMask,
-				To:       &cidr,
+				To:       normalizeRuleToCIDR(&cidr),
 				Table:    tableID,
 				Protocol: linux_defaults.RTProto,
 			}); err != nil {
@@ -206,7 +208,7 @@ func Delete(ip netip.Addr, compat bool) error {
 			egress := route.Rule{
 				Priority: priority,
 				From:     ipWithMask,
-				To:       cidr,
+				To:       normalizeRuleToCIDR(cidr),
 			}
 			if err := deleteRule(egress); err != nil {
 				return fmt.Errorf("unable to delete egress rule with ip %s: %w", ipWithMask.String(), err)
@@ -313,4 +315,12 @@ func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (int, error) {
 // ENI interface number.
 func computeTableIDFromIfaceNumber(num int) int {
 	return linux_defaults.RouteTableInterfacesOffset + num
+}
+
+// normalizeRuleToCIDR returns nil when passed cidr is zeroes only cidr
+func normalizeRuleToCIDR(cidr *net.IPNet) *net.IPNet {
+	if cidr.IP.IsUnspecified() {
+		return nil
+	}
+	return cidr
 }


### PR DESCRIPTION
When using ENI, routing rules are added for VPC CIDRs and `ipv4-native-routing-cidr`. 
If `ipv4-native-routing-cidr` is not specified, the correct routing tables are used only for internal VPC networks, while all other traffic uses the default routing table. This issue, described in the [related issue](https://github.com/cilium/cilium/issues/18179), can cause traffic to enter and exit through different interfaces, potentially leading to packet drops due to security group rules.

To resolve this issue, I attempted to use the `ipv4-native-routing-cidr: 0.0.0.0/0` configuration. Unfortunately, this led to an error during agent startup.

```
time="2024-08-18T09:36:37Z" level=info msg="Native routing CIDR contains VPC CIDR, ignoring autodetected VPC CIDRs." ipv4-native-routing-cidr=0.0.0.0/0 subsys=ipam vpc-cidr=172.27.0.0/20
time="2024-08-18T09:36:37Z" level=info msg="All required IPs are available in CRD-backed allocation pool" available=16 name=m0-stage2 required=8 subsys=ipam

time="2024-08-18T09:36:37Z" level=error msg="Start hook failed" error="daemon creation failed: failed to configure router IP rules and routes: unable to install ip rule: file exists" function="cmd.newDaemonPromise.func1 (cmd/daemon_main.go:1707)" subsys=hive

time="2024-08-18T09:36:37Z" level=fatal msg="failed to start: daemon creation failed: failed to configure router IP rules and routes: unable to install ip rule: file exists" subsys=daemon
```

Disabling masquerading avoids this issue too, but masquerading is required for egressGateway and may be enabled and configured as `ipMasqAgent.config.nonMasqueradeCIDRs: [0.0.0.0/0]`
<!-- Description of change -->

Fixes: [#18179](https://github.com/cilium/cilium/issues/18179) when using `ipv4-native-routing-cidr: 0.0.0.0/0`

```release-note
Fix handling of route replace rules in ENI IPAM mode when `ipv4-native-routing-cidr` is set to `0.0.0.0/0`.
```
