### PR TITLE
Policy track derived from rules better

### DIFF
--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -601,7 +601,7 @@ func TestRedirectWithPriority(t *testing.T) {
 			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
 		},
 		mapKeyAllL7: {
-			DerivedFromRules: labels.LabelArrayList{lblsL4AllowListener1, lblsL4AllowPort80, lblsL4L7AllowListener2Priority1},
+			DerivedFromRules: labels.LabelArrayList{lblsL4AllowPort80},
 		},
 	})
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
@@ -630,10 +630,10 @@ func TestRedirectWithPriority(t *testing.T) {
 		mapKeyFooL7: {
 			ProxyPort:        crd2Port,
 			Listener:         "/cec2/listener2",
-			DerivedFromRules: labels.LabelArrayList{lblsL4AllowListener1, lblsL4AllowPort80, lblsL4L7AllowListener2Priority1},
+			DerivedFromRules: labels.LabelArrayList{lblsL4AllowListener1, lblsL4L7AllowListener2Priority1},
 		},
 		mapKeyAllL7: {
-			DerivedFromRules: labels.LabelArrayList{lblsL4AllowListener1, lblsL4AllowPort80, lblsL4L7AllowListener2Priority1},
+			DerivedFromRules: labels.LabelArrayList{lblsL4AllowPort80},
 		},
 	})
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected2) {
@@ -682,7 +682,7 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
 		},
 		mapKeyAllL7: {
-			DerivedFromRules: labels.LabelArrayList{lblsL4L7AllowListener1Priority1, lblsL4AllowPort80, lblsL4L7AllowListener2Priority1},
+			DerivedFromRules: labels.LabelArrayList{lblsL4AllowPort80},
 		},
 	})
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
@@ -711,10 +711,10 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 		mapKeyFooL7: {
 			ProxyPort:        crd1Port,
 			Listener:         "/cec1/listener1",
-			DerivedFromRules: labels.LabelArrayList{lblsL4L7AllowListener1Priority1, lblsL4AllowPort80, lblsL4L7AllowListener2Priority1},
+			DerivedFromRules: labels.LabelArrayList{lblsL4L7AllowListener1Priority1, lblsL4L7AllowListener2Priority1},
 		},
 		mapKeyAllL7: {
-			DerivedFromRules: labels.LabelArrayList{lblsL4L7AllowListener1Priority1, lblsL4AllowPort80, lblsL4L7AllowListener2Priority1},
+			DerivedFromRules: labels.LabelArrayList{lblsL4AllowPort80},
 		},
 	})
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected2) {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -11,6 +11,9 @@ const (
 	// LogSubsys is the field denoting the subsystem when logging
 	LogSubsys = "subsys"
 
+	// Stacktrace is a field for a stacktrace
+	Stacktrace = "stacktrace"
+
 	// Signal is the field to print os signals on exit etc.
 	Signal = "signal"
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -1428,7 +1428,7 @@ var (
 
 	worldIPIdentity = localIdentity(16324)
 	worldIPCIDR     = api.CIDR("192.0.2.3/32")
-	lblWorldIP      = labels.ParseSelectLabelArray(fmt.Sprintf("%s:%s", labels.LabelSourceCIDR, worldIPCIDR))
+	lblWorldIP      = labels.GetCIDRLabels(netip.MustParsePrefix(string(worldIPCIDR)))
 	hostIPv4        = api.CIDR("172.19.0.1/32")
 	hostIPv6        = api.CIDR("fc00:c111::3/64")
 	lblHostIPv4CIDR = labels.GetCIDRLabels(netip.MustParsePrefix(string(hostIPv4)))
@@ -1686,7 +1686,7 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 	identityCache := identity.IdentityMap{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 		identity.ReservedIdentityWorld:        labels.LabelWorld.LabelArray(),
-		worldIPIdentity:                       lblWorldIP,                  // "192.0.2.3/32"
+		worldIPIdentity:                       lblWorldIP.LabelArray(),     // "192.0.2.3/32"
 		worldSubnetIdentity:                   lblWorldSubnet.LabelArray(), // "192.0.2.0/24"
 	}
 	selectorCache := testNewSelectorCache(identityCache)
@@ -1713,10 +1713,10 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 			mapKeyAnyIngress:             mapEntryAllow,
 			mapKeyL3WorldIngress:         mapEntryWorldDenyWithLabels,
 			mapKeyL3WorldEgress:          mapEntryWorldDenyWithLabels,
-			mapKeyL3SubnetIngress:        mapEntryDeny,
-			mapKeyL3SubnetEgress:         mapEntryDeny,
-			mapKeyL3SmallerSubnetIngress: mapEntryDeny,
-			mapKeyL3SmallerSubnetEgress:  mapEntryDeny,
+			mapKeyL3SubnetIngress:        mapEntryWorldDenyWithLabels,
+			mapKeyL3SubnetEgress:         mapEntryWorldDenyWithLabels,
+			mapKeyL3SmallerSubnetIngress: mapEntryWorldDenyWithLabels,
+			mapKeyL3SmallerSubnetEgress:  mapEntryWorldDenyWithLabels,
 		})}, {"deny_one_ip_with_a_larger_subnet", api.Rules{ruleAllowAllIngress, ruleL3DenySubnet, ruleL3AllowWorldIP}, testMapState(map[Key]MapStateEntry{
 			mapKeyAnyIngress:             mapEntryAllow,
 			mapKeyL3SubnetIngress:        mapEntryDeny,

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -690,21 +690,6 @@ func (e *MapStateEntry) HasDependent(key Key) bool {
 	return ok
 }
 
-// HasSameOwners returns true if both MapStateEntries
-// have the same owners as one another (which means that
-// one of the entries is redundant).
-func (e *MapStateEntry) HasSameOwners(bEntry *MapStateEntry) bool {
-	if len(e.owners) != len(bEntry.owners) {
-		return false
-	}
-	for owner := range e.owners {
-		if _, ok := bEntry.owners[owner]; !ok {
-			return false
-		}
-	}
-	return true
-}
-
 var worldNets = map[identity.NumericIdentity][]netip.Prefix{
 	identity.ReservedIdentityWorld: {
 		netip.PrefixFrom(netip.IPv4Unspecified(), 0),
@@ -901,22 +886,20 @@ func (ms *mapState) RemoveDependent(owner Key, dependent Key, identities Identit
 
 // Merge adds owners, dependents, and DerivedFromRules from a new 'entry' to an existing
 // entry 'e'. 'entry' is not modified.
-// IsDeny, ProxyPort, and AuthType are merged by giving precedence to deny over non-deny, proxy
-// redirection over no proxy redirection, and explicit auth type over default auth type.
+// Merge is only called if both entries are allow or deny entries, so deny precedence is not
+// considered here.
+// ProxyPort, and AuthType are merged by giving precedence to proxy redirection over no proxy
+// redirection, and explicit auth type over default auth type.
 func (e *MapStateEntry) Merge(entry *MapStateEntry) {
-	// Deny is sticky
-	if !e.IsDeny {
-		e.IsDeny = entry.IsDeny
+	// Bail out loudly if both entries are not denies or allows
+	if e.IsDeny != entry.IsDeny {
+		stacktrace := hclog.Stacktrace()
+		log.WithField(logfields.Stacktrace, stacktrace).
+			Errorf("MapStateEntry.Merge: both entries must be allows or denies")
+		return
 	}
-
-	// Deny entries have no proxy redirection nor auth requirement
-	if e.IsDeny {
-		e.ProxyPort = 0
-		e.Listener = ""
-		e.priority = 0
-		e.hasAuthType = DefaultAuthType
-		e.AuthType = AuthTypeDisabled
-	} else {
+	// Only allow entries have proxy redirection or auth requirement
+	if !e.IsDeny {
 		// Proxy port takes precedence, but may be updated due to priority
 		if entry.IsRedirectEntry() {
 			// Lower number has higher priority, but non-redirects have 0 priority
@@ -1059,12 +1042,8 @@ func (ms *mapState) addKeyWithChanges(key Key, entry MapStateEntry, identities I
 	// Keep all owners that need this entry so that it is deleted only if all the owners delete their contribution
 	var datapathEqual bool
 	oldEntry, exists := ms.Get(key)
-	if exists {
-		// Deny entry can only be overridden by another deny entry
-		if oldEntry.IsDeny && !entry.IsDeny {
-			return
-		}
-
+	// Only merge if both old and new are allows or denies
+	if exists && (oldEntry.IsDeny == entry.IsDeny) {
 		// Do nothing if entries are equal
 		if entry.DeepEqual(&oldEntry) {
 			return // nothing to do
@@ -1078,9 +1057,13 @@ func (ms *mapState) addKeyWithChanges(key Key, entry MapStateEntry, identities I
 		// Compare for datapath equalness before merging, as the old entry is updated in
 		// place!
 		datapathEqual = oldEntry.DatapathEqual(&entry)
+
 		oldEntry.Merge(&entry)
 		ms.insert(key, oldEntry, identities)
-	} else {
+	} else if !exists || entry.IsDeny {
+		// Insert a new entry if one did not exist or a deny entry is overwriting an allow
+		// entry.
+
 		// Newly inserted entries must have their own containers, so that they
 		// remain separate when new owners/dependents are added to existing entries
 		entry.DerivedFromRules = slices.Clone(entry.DerivedFromRules)
@@ -1237,8 +1220,9 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 				ms.validator.isBroaderOrEqual(k, newKey)
 				ms.validator.isAnyOrSame(k, newKey, identities)
 			}
-			// Identical key needs to be added if owners are different (to merge them).
-			if !(k == newKey && !v.HasSameOwners(&newEntry)) {
+			// No need to add if the keys are different or if they are the same and the entries are also the same.
+			// Identical key needs to be added if the entries are different (to merge them).
+			if k != newKey || v.DeepEqual(&newEntry) {
 				// If the ID of this iterated-deny-entry is ANY or equal of
 				// the new-entry and the iterated-deny-entry has a broader (or
 				// equal) port-protocol then we need not insert the new entry.
@@ -1331,7 +1315,7 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 				ms.validator.isAnyOrSame(newKey, k, identities)
 			}
 			// Identical key needs to remain if owners are different to merge them
-			if !(k == newKey && !v.HasSameOwners(&newEntry)) {
+			if k != newKey || v.DeepEqual(&newEntry) {
 				// If this iterated-deny-entry is a subset (or equal) of the
 				// new-entry and the new-entry has a broader (or equal)
 				// port-protocol the newKey will match all the packets the iterated
@@ -1360,38 +1344,35 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 		// Test for bailed case first so that we avoid unnecessary computation if entry is
 		// not going to be added, or is going to be changed to a deny entry.
 		bailed := false
-		changeToDeny := false
+		insertAsDeny := false
+		var denyEntry MapStateEntry
 		ms.denies.ForEachBroaderOrEqualKey(newKey, prefixes, func(k Key, v MapStateEntry) bool {
 			if ms.validator != nil {
 				ms.validator.isBroaderOrEqual(k, newKey)
 				ms.validator.isSupersetOrSame(k, newKey, identities)
 			}
-			// If the iterated-deny-entry is a superset (or equal) of the new-allow-entry we should bail it
+			// If the iterated-deny-entry is a wildcard or has the same identity then it
+			// can be bailed out.
 			if k.Identity == 0 || k.Identity == newKey.Identity {
-				// If the iterated-deny-entry is a datapath superset (or equal) of
-				// the new-entry and has a broader (or equal) port-protocol than the
-				// new-entry then the new entry should not be inserted.
 				bailed = true
 				return false
 			}
-			// if newKey is not bailed due to being covered in the datapath by a deny
-			// ANY entry, but is covered by a deny entry with a different ID, we must
-			// change this allow entry to a deny entry so that the covering deny policy
-			// is honored also for this ID in the datapath.
-			changeToDeny = true
+			// if any deny key covers this new allow key, then it needs to be inserted
+			// as deny, if not bailed out.
+			if !insertAsDeny {
+				insertAsDeny = true
+				denyEntry = NewMapStateEntry(k, v.DerivedFromRules, 0, "", 0, true, DefaultAuthType, AuthTypeDisabled)
+			} else {
+				// Collect the owners and labels of all the contributing deny rules
+				denyEntry.Merge(&v)
+			}
 			return true
 		})
-		if bailed || changeToDeny {
-			if bailed {
-				return
-			}
-			newEntry.IsDeny = true
-			newEntry.ProxyPort = 0
-			newEntry.Listener = ""
-			newEntry.priority = 0
-			newEntry.hasAuthType = DefaultAuthType
-			newEntry.AuthType = AuthTypeDisabled
-			ms.authPreferredInsert(newKey, newEntry, identities, features, changes)
+		if bailed {
+			return
+		}
+		if insertAsDeny {
+			ms.authPreferredInsert(newKey, denyEntry, identities, features, changes)
 			return
 		}
 

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -3714,7 +3714,7 @@ func (e MapStateEntry) asDeny() MapStateEntry {
 func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 	identityCache := identity.IdentityMap{
 		identity.ReservedIdentityWorld: labels.LabelWorld.LabelArray(),
-		worldIPIdentity:                lblWorldIP,                  // "192.0.2.3/32"
+		worldIPIdentity:                lblWorldIP.LabelArray(),     // "192.0.2.3/32"
 		worldSubnetIdentity:            lblWorldSubnet.LabelArray(), // "192.0.2.0/24"
 	}
 


### PR DESCRIPTION
MapStateEntry metadata was improperly merged when an allow entry and deny entry were merged. Fix this by only merging entries when they both are either allow or deny entries.

Add identical keys also when the entries are different regarding all other fields than just the owners. This way DerivedFromRules labels get merged also if the owning CachedSelectors happen to be the same but are used in rules with different labels.

When inserting an allow entry as a deny due to covering deny rule, DerivedFromRules was based on the allow rule, when it should be a combination of all the covering deny rules instead.

Add `MapStateEntry.DatapathAndDerivedFromEqual` to be used in testing via `mapState.Equal` and `mapState.Diff`. This will help find bugs in properly tracking the `DerivedFromRules` field, which has so far been ignored in testing when using `mapsState.Equal` and `mapState.Diff`.

Without these changes the resulting `DerivedFromRules` labels depended on the insertion order of MapState entries, causing intermittent test flakes due to essentially random iteration order of Go maps when test code was changed to care about the resulting `DerivedFromRules` labels by the 1st commit.

```release-note
Policy rule labels are tracked more accurately in endpoint policy maps.
```
