### PR TITLE
clustermesh: add MCS-API ServiceImport controller

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -332,7 +332,14 @@ rules:
   - delete
 {{- end }}
 {{- end }}
-{{- if or .Values.clustermesh.enableEndpointSliceSynchronization .Values.clustermesh.enableMCSAPISupport }}
+{{- if .Values.clustermesh.enableMCSAPISupport }}
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceimports/status
+  verbs:
+  - update
+  - patch
 - apiGroups:
   - multicluster.x-k8s.io
   resources:
@@ -341,6 +348,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceexports/status
+  verbs:
+  - update
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/pkg/clustermesh/mcsapi/service_controller.go
+++ b/pkg/clustermesh/mcsapi/service_controller.go
@@ -236,6 +236,7 @@ func (r *mcsAPIServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// However we operate on the ServiceImport (and ServiceExport) name rather than
 		// the derived service name so we say that we own ServiceImport here
 		// and always derive the name in the Reconcile function anyway.
+		Named("ServiceMCSAPI").
 		For(&mcsapiv1alpha1.ServiceImport{}).
 		// Watch for changes to ServiceExport
 		Watches(&mcsapiv1alpha1.ServiceExport{}, &handler.EnqueueRequestForObject{}).

--- a/pkg/clustermesh/mcsapi/serviceimport_controller.go
+++ b/pkg/clustermesh/mcsapi/serviceimport_controller.go
@@ -1,0 +1,519 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mcsapi
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	k8sApiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	controllerruntime "github.com/cilium/cilium/operator/pkg/controller-runtime"
+	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
+	"github.com/cilium/cilium/pkg/clustermesh/operator"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+const (
+	conditionTypeReady = "Ready"
+)
+
+// mcsAPIServiceImportReconciler is a controller that automatically creates
+// ServiceImport from ServiceExport (and their corresponding Services) from
+// remote clusters and the local cluster. It also handles ServiceExport status
+// since we have all the info here to do so.
+type mcsAPIServiceImportReconciler struct {
+	client.Client
+	Logger logrus.FieldLogger
+
+	cluster                    string
+	globalServiceExports       *operator.GlobalServiceExportCache
+	remoteClusterServiceSource *remoteClusterServiceExportSource
+}
+
+func newMCSAPIServiceImportReconciler(mgr ctrl.Manager, logger logrus.FieldLogger, cluster string, globalServiceExports *operator.GlobalServiceExportCache, remoteClusterServiceSource *remoteClusterServiceExportSource) *mcsAPIServiceImportReconciler {
+	return &mcsAPIServiceImportReconciler{
+		Client:                     mgr.GetClient(),
+		Logger:                     logger,
+		cluster:                    cluster,
+		globalServiceExports:       globalServiceExports,
+		remoteClusterServiceSource: remoteClusterServiceSource,
+	}
+}
+
+func (r *mcsAPIServiceImportReconciler) getSvcExport(ctx context.Context, req ctrl.Request) (*mcsapiv1alpha1.ServiceExport, error) {
+	var svcExport mcsapiv1alpha1.ServiceExport
+	if err := r.Client.Get(ctx, req.NamespacedName, &svcExport); err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+	return &svcExport, nil
+}
+
+func (r *mcsAPIServiceImportReconciler) getSvcImportBase(ctx context.Context, req ctrl.Request) (*mcsapiv1alpha1.ServiceImport, bool, error) {
+	var svcImport mcsapiv1alpha1.ServiceImport
+	if err := r.Client.Get(ctx, req.NamespacedName, &svcImport); err != nil {
+		if k8sApiErrors.IsNotFound(err) {
+			return &mcsapiv1alpha1.ServiceImport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      req.Name,
+					Namespace: req.Namespace,
+				},
+			}, false, nil
+		}
+		return nil, false, err
+	}
+	return &svcImport, true, nil
+}
+
+func (r *mcsAPIServiceImportReconciler) getLocalService(ctx context.Context, req ctrl.Request) (*corev1.Service, error) {
+	var svc corev1.Service
+	if err := r.Client.Get(ctx, req.NamespacedName, &svc); err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+	return &svc, nil
+}
+
+func (r *mcsAPIServiceImportReconciler) doesNamespaceExist(ctx context.Context, req ctrl.Request) (bool, error) {
+	var ns corev1.Namespace
+	key := types.NamespacedName{Name: req.Namespace}
+
+	if err := r.Client.Get(ctx, key, &ns); err != nil {
+		return false, client.IgnoreNotFound(err)
+	}
+	return true, nil
+}
+
+func fromServiceToMCSAPIServiceSpec(svc *corev1.Service, cluster string, svcExport *mcsapiv1alpha1.ServiceExport) *mcsapitypes.MCSAPIServiceSpec {
+	ports := make([]mcsapiv1alpha1.ServicePort, 0, len(svc.Spec.Ports))
+	for _, port := range svc.Spec.Ports {
+		ports = append(ports, mcsapiv1alpha1.ServicePort{
+			Name:        port.Name,
+			Protocol:    port.Protocol,
+			AppProtocol: port.AppProtocol,
+			Port:        port.Port,
+		})
+	}
+	mcsAPISvcType := mcsapiv1alpha1.ClusterSetIP
+	if svc.Spec.ClusterIP == corev1.ClusterIPNone {
+		mcsAPISvcType = mcsapiv1alpha1.Headless
+	}
+	mcsAPISvcSpec := &mcsapitypes.MCSAPIServiceSpec{
+		Cluster:                 cluster,
+		Name:                    svc.Name,
+		Namespace:               svc.Namespace,
+		ExportCreationTimestamp: svcExport.CreationTimestamp,
+		Ports:                   ports,
+		Type:                    mcsAPISvcType,
+		SessionAffinity:         svc.Spec.SessionAffinity,
+		SessionAffinityConfig:   svc.Spec.SessionAffinityConfig.DeepCopy(),
+	}
+	return mcsAPISvcSpec
+}
+
+type portMerge struct {
+	mcsapiv1alpha1.ServicePort
+
+	cluster                 string
+	ExportCreationTimestamp metav1.Time
+}
+
+// orderSvcExportByPriority order the service export by priority (oldest to newest
+// service exports). If export times of two service exports are equal
+// it also sort by cluster name.
+func orderSvcExportByPriority(svcExportByCluster operator.ServiceExportsByCluster) []*mcsapitypes.MCSAPIServiceSpec {
+	return slices.SortedFunc(maps.Values(svcExportByCluster), func(a, b *mcsapitypes.MCSAPIServiceSpec) int {
+		if a.ExportCreationTimestamp.Equal(&b.ExportCreationTimestamp) {
+			return strings.Compare(a.Cluster, b.Cluster)
+		}
+		if a.ExportCreationTimestamp.Before(&b.ExportCreationTimestamp) {
+			return -1
+		}
+		return 1
+	})
+}
+
+func isSimilarPort(a, b mcsapiv1alpha1.ServicePort) bool {
+	return a.Port == b.Port && a.Protocol == b.Protocol
+}
+
+// checkDuplicatedPortNameConflict check if port has a duplicated port name in portsByName.
+func checkDuplicatedPortNameConflict(port portMerge, portsByName map[string]portMerge) string {
+	portByName, foundPortByName := portsByName[port.Name]
+	if foundPortByName && !isSimilarPort(port.ServicePort, portByName.ServicePort) {
+		return fmt.Sprintf(
+			"Duplicated port name \"%s\". Using port definition \"%v\" from oldest service export in cluster \"%s\".",
+			port.Name, portByName, portByName.cluster,
+		)
+	}
+
+	return ""
+}
+
+func checkPortConflict(port, olderPort portMerge) string {
+	if port.Name != olderPort.Name {
+		return fmt.Sprintf(
+			"Conflicting port name on \"%v\". Using the port name \"%s\" from oldest service export in cluster \"%s\".",
+			port, olderPort.Name, olderPort.cluster,
+		)
+	}
+	if ptr.Deref(port.AppProtocol, "") != ptr.Deref(olderPort.AppProtocol, "") {
+		return fmt.Sprintf(
+			"Conflicting appProtocol on \"%v\". Using the appProtocol \"%s\" from oldest service export in cluster \"%s\".",
+			port, ptr.Deref(olderPort.AppProtocol, ""), olderPort.cluster,
+		)
+	}
+	return ""
+}
+
+// mergePorts merge all the ports into a map while doing conflict resolution
+// with the oldest CreationTimestamp. It also return if it detects any conflict
+func mergePorts(orderedSvcExports []*mcsapitypes.MCSAPIServiceSpec) ([]portMerge, string) {
+	conflict := ""
+	ports := []portMerge{}
+	portsByName := map[string]portMerge{}
+	for _, svcExport := range orderedSvcExports {
+		for _, port := range svcExport.Ports {
+			portMergeValue := portMerge{
+				ServicePort:             port,
+				cluster:                 svcExport.Cluster,
+				ExportCreationTimestamp: svcExport.ExportCreationTimestamp,
+			}
+
+			conflictDuplicatedPortName := checkDuplicatedPortNameConflict(portMergeValue, portsByName)
+			if conflict == "" {
+				conflict = conflictDuplicatedPortName
+			}
+			if conflictDuplicatedPortName != "" {
+				continue
+			}
+
+			portIndex := slices.IndexFunc(ports, func(currPort portMerge) bool {
+				return isSimilarPort(port, currPort.ServicePort)
+			})
+			if portIndex == -1 {
+				// We don't override any port in portsByName so that this map
+				// always keep the values from the oldest service export
+				// exporting that port name
+				portsByName[port.Name] = portMergeValue
+				ports = append(ports, portMergeValue)
+			} else if conflict == "" {
+				conflict = checkPortConflict(portMergeValue, ports[portIndex])
+			}
+		}
+	}
+	return ports, conflict
+}
+
+func mergedPortsToMCSPorts(mergedPorts []portMerge) []mcsapiv1alpha1.ServicePort {
+	ports := make([]mcsapiv1alpha1.ServicePort, 0, len(mergedPorts))
+	for _, port := range mergedPorts {
+		ports = append(ports, port.ServicePort)
+	}
+	return ports
+}
+
+func getServiceImportStatus(svcExportByCluster operator.ServiceExportsByCluster) mcsapiv1alpha1.ServiceImportStatus {
+	clusters := []mcsapiv1alpha1.ClusterStatus{}
+	clusterNames := slices.Collect(maps.Keys(svcExportByCluster))
+	slices.Sort(clusterNames)
+	for _, cluster := range clusterNames {
+		clusters = append(clusters, mcsapiv1alpha1.ClusterStatus{
+			Cluster: cluster,
+		})
+	}
+	return mcsapiv1alpha1.ServiceImportStatus{Clusters: clusters}
+}
+
+// checkConflictExport check if there are any conflict to be added on
+// the ServiceExport object. This function does not check for conflict on the
+// ports field this aspect should be done by mergePorts
+func checkConflictExport(orderedSvcExports []*mcsapitypes.MCSAPIServiceSpec) string {
+	clusterCount := len(orderedSvcExports)
+
+	getTypeFunc := func(svcSpec *mcsapitypes.MCSAPIServiceSpec) string {
+		return string(svcSpec.Type)
+	}
+	getSessionAffinityFunc := func(svcSpec *mcsapitypes.MCSAPIServiceSpec) string {
+		return string(svcSpec.SessionAffinity)
+	}
+	getSessionAffinityConfigFunc := func(svcSpec *mcsapitypes.MCSAPIServiceSpec) string {
+		if svcSpec.SessionAffinityConfig == nil ||
+			svcSpec.SessionAffinityConfig.ClientIP == nil ||
+			svcSpec.SessionAffinityConfig.ClientIP.TimeoutSeconds == nil {
+			return ""
+		}
+		return string(*svcSpec.SessionAffinityConfig.ClientIP.TimeoutSeconds)
+	}
+	getterFuncs := []struct {
+		name       string
+		getterFunc func(svcSpec *mcsapitypes.MCSAPIServiceSpec) string
+	}{
+		{
+			name: "type", getterFunc: getTypeFunc,
+		},
+		{
+			name: "sessionAffinity", getterFunc: getSessionAffinityFunc,
+		},
+		{
+			name: "sessionAffinityConfig.clientIP", getterFunc: getSessionAffinityConfigFunc,
+		},
+	}
+	for i, svcExport := range orderedSvcExports[1:] {
+		for _, getterStruct := range getterFuncs {
+			oldestField := getterStruct.getterFunc(orderedSvcExports[0])
+			if oldestField == getterStruct.getterFunc(svcExport) {
+				continue
+			}
+
+			conflictCount := 1
+			if i+1 < len(orderedSvcExports) {
+				for _, otherSvcExport := range orderedSvcExports[i+1:] {
+					if oldestField != getterStruct.getterFunc(otherSvcExport) {
+						conflictCount += 1
+					}
+				}
+			}
+
+			if conflictCount > 0 {
+				return fmt.Sprintf(
+					"Conflicting %s. %d/%d clusters disagree. Using \"%s\" from oldest service export in cluster \"%s\".",
+					getterStruct.name, conflictCount, clusterCount, oldestField, orderedSvcExports[0].Cluster,
+				)
+			}
+		}
+	}
+
+	return ""
+}
+
+func (r *mcsAPIServiceImportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	nsExists, err := r.doesNamespaceExist(ctx, req)
+	if err != nil {
+		return controllerruntime.Fail(err)
+	}
+	if !nsExists {
+		return controllerruntime.Success()
+	}
+
+	svcImport, svcImportExists, err := r.getSvcImportBase(ctx, req)
+	if err != nil {
+		return controllerruntime.Fail(err)
+	}
+	svcExport, err := r.getSvcExport(ctx, req)
+	if err != nil {
+		return controllerruntime.Fail(err)
+	}
+
+	svcExportByCluster := r.globalServiceExports.GetServiceExportByCluster(req.NamespacedName)
+	if len(svcExportByCluster) == 0 && svcExport == nil {
+		if svcImportExists {
+			return controllerruntime.Fail(r.Client.Delete(ctx, svcImport))
+		}
+		return controllerruntime.Success()
+	}
+
+	if svcExport != nil {
+		localSvc, err := r.getLocalService(ctx, req)
+		if err != nil {
+			return controllerruntime.Fail(err)
+		}
+		if localSvc == nil {
+			if meta.SetStatusCondition(&svcExport.Status.Conditions, metav1.Condition{
+				Type:    mcsapiv1alpha1.ServiceExportValid,
+				Status:  metav1.ConditionFalse,
+				Reason:  "NoService",
+				Message: "Service doesn't exist",
+			}) {
+				meta.RemoveStatusCondition(&svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportConflict)
+				meta.RemoveStatusCondition(&svcExport.Status.Conditions, conditionTypeReady)
+				if err := r.Client.Status().Update(ctx, svcExport); err != nil {
+					return controllerruntime.Fail(err)
+				}
+			}
+			return controllerruntime.Success()
+		}
+		localSvcSpec := fromServiceToMCSAPIServiceSpec(localSvc, r.cluster, svcExport)
+		if svcExportByCluster == nil {
+			svcExportByCluster = operator.ServiceExportsByCluster{}
+		}
+		svcExportByCluster[r.cluster] = localSvcSpec
+
+		if localSvc.Spec.Type == corev1.ServiceTypeExternalName {
+			if meta.SetStatusCondition(&svcExport.Status.Conditions, metav1.Condition{
+				Type:    mcsapiv1alpha1.ServiceExportValid,
+				Status:  metav1.ConditionFalse,
+				Reason:  "ServiceType",
+				Message: "Service type ExternalName is not supported",
+			}) {
+				meta.RemoveStatusCondition(&svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportConflict)
+				meta.RemoveStatusCondition(&svcExport.Status.Conditions, conditionTypeReady)
+				if err := r.Client.Status().Update(ctx, svcExport); err != nil {
+					return controllerruntime.Fail(err)
+				}
+			}
+			return controllerruntime.Success()
+		}
+	}
+
+	orderedSvcExports := orderSvcExportByPriority(svcExportByCluster)
+	mergedPorts, conflictMsg := mergePorts(orderedSvcExports)
+
+	if svcExport != nil {
+		changedCondition := meta.SetStatusCondition(&svcExport.Status.Conditions, metav1.Condition{
+			Type:    mcsapiv1alpha1.ServiceExportValid,
+			Status:  metav1.ConditionTrue,
+			Reason:  mcsapiv1alpha1.ServiceExportValid,
+			Message: "Service is Valid for export",
+		})
+
+		if conflictMsg == "" {
+			conflictMsg = checkConflictExport(orderedSvcExports)
+		}
+		if conflictMsg != "" {
+			changedCondition = meta.SetStatusCondition(&svcExport.Status.Conditions, metav1.Condition{
+				Type:    mcsapiv1alpha1.ServiceExportConflict,
+				Status:  metav1.ConditionTrue,
+				Reason:  mcsapiv1alpha1.ServiceExportConflict,
+				Message: conflictMsg,
+			}) || changedCondition
+		}
+		readyStatus := metav1.ConditionFalse
+		if conflictMsg == "" {
+			readyStatus = metav1.ConditionTrue
+			changedCondition = meta.RemoveStatusCondition(&svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportConflict) || changedCondition
+		}
+		changedCondition = meta.SetStatusCondition(&svcExport.Status.Conditions, metav1.Condition{
+			Type:   conditionTypeReady,
+			Status: readyStatus,
+			Reason: conditionTypeReady,
+		}) || changedCondition
+		if changedCondition {
+			if err := r.Client.Status().Update(ctx, svcExport); err != nil {
+				return controllerruntime.Fail(err)
+			}
+		}
+	}
+
+	oldestClusterSvc := orderedSvcExports[0]
+	svcImport.Spec.Ports = mergedPortsToMCSPorts(mergedPorts)
+	svcImport.Spec.Type = oldestClusterSvc.Type
+	svcImport.Spec.SessionAffinity = oldestClusterSvc.SessionAffinity
+	svcImport.Spec.SessionAffinityConfig = oldestClusterSvc.SessionAffinityConfig.DeepCopy()
+
+	svcImport, err = r.createOrUpdateServiceImport(ctx, svcImport)
+	if err != nil {
+		return controllerruntime.Fail(err)
+	}
+
+	newStatus := getServiceImportStatus(svcExportByCluster)
+	if !reflect.DeepEqual(svcImport.Status, newStatus) {
+		svcImport.Status = newStatus
+		if err := r.Client.Status().Update(ctx, svcImport); err != nil {
+			return controllerruntime.Fail(err)
+		}
+	}
+	return controllerruntime.Success()
+}
+
+func (r *mcsAPIServiceImportReconciler) createOrUpdateServiceImport(ctx context.Context, desiredSvcImport *mcsapiv1alpha1.ServiceImport) (*mcsapiv1alpha1.ServiceImport, error) {
+	svcImport := &mcsapiv1alpha1.ServiceImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      desiredSvcImport.Name,
+			Namespace: desiredSvcImport.Namespace,
+		},
+	}
+
+	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, svcImport, func() error {
+		svcImport.Spec = desiredSvcImport.Spec
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create or update ServiceImport: %w", err)
+	}
+
+	r.Logger.Debug(fmt.Sprintf("ServiceImport %s has been %s", client.ObjectKeyFromObject(svcImport), result))
+
+	return svcImport, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *mcsAPIServiceImportReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&mcsapiv1alpha1.ServiceImport{}).
+		// Watch for changes to ServiceExport
+		Watches(&mcsapiv1alpha1.ServiceExport{}, &handler.EnqueueRequestForObject{}).
+		// Watch for changes to Services
+		Watches(&corev1.Service{}, &handler.EnqueueRequestForObject{}).
+		// Watch for changes to Namespace to requeue remote service exports
+		Watches(&corev1.Namespace{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+			requests := []ctrl.Request{}
+			for _, name := range r.globalServiceExports.GetServiceExportsName(obj.GetName()) {
+				requests = append(requests, ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: obj.GetName(),
+						Name:      name,
+					},
+				})
+			}
+
+			return requests
+		})).
+		// Watch changes to external services
+		WatchesRawSource(r.remoteClusterServiceSource).
+		Complete(r)
+}
+
+// remoteClusterServiceExportSource is a source to watch remote cluster service exports.
+// The actual type returned by the watch is a ServiceExport to match the interface
+// needed by a regular controller-runtime controller. This prevents us from
+// implementing a more complicated/hands-on pattern of controller.
+type remoteClusterServiceExportSource struct {
+	Logger logrus.FieldLogger
+
+	ctx   context.Context
+	queue workqueue.TypedRateLimitingInterface[ctrl.Request]
+}
+
+func (s *remoteClusterServiceExportSource) onClusterServiceExportEvent(svcExport *mcsapitypes.MCSAPIServiceSpec) {
+	if s.ctx == nil || s.queue == nil {
+		// At this point the controller is not started yet and the namespace
+		// watcher will enqueue any initial state from remote clusters
+		// on start.
+		return
+	}
+
+	s.Logger.
+		WithField(logfields.K8sNamespace, svcExport.Namespace).
+		WithField("ServiceExport", svcExport.Name).
+		Debug("Queueing update from remote cluster")
+	s.queue.Add(ctrl.Request{NamespacedName: types.NamespacedName{
+		Name:      svcExport.Name,
+		Namespace: svcExport.Namespace,
+	}})
+}
+
+func (s *remoteClusterServiceExportSource) Start(
+	ctx context.Context,
+	queue workqueue.TypedRateLimitingInterface[ctrl.Request],
+) error {
+	s.ctx = ctx
+	s.queue = queue
+	return nil
+}

--- a/pkg/clustermesh/mcsapi/serviceimport_controller_test.go
+++ b/pkg/clustermesh/mcsapi/serviceimport_controller_test.go
@@ -1,0 +1,815 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mcsapi
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8sApiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
+	"github.com/cilium/cilium/pkg/clustermesh/operator"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+const (
+	localClusterName  = "local"
+	remoteClusterName = "remote"
+)
+
+var (
+	olderTime = metav1.NewTime(time.Now().AddDate(0, 0, -1))
+	nowTime   = metav1.Now()
+	newerTime = metav1.NewTime(time.Now().AddDate(0, 0, 1))
+)
+
+func getServiceImport(client client.Client, key types.NamespacedName) (*mcsapiv1alpha1.ServiceImport, error) {
+	svcImport := mcsapiv1alpha1.ServiceImport{}
+	err := client.Get(context.Background(), key, &svcImport)
+	if err != nil {
+		return nil, err
+	}
+	return &svcImport, nil
+}
+
+func getServiceExport(client client.Client, key types.NamespacedName) (*mcsapiv1alpha1.ServiceExport, error) {
+	svcExport := mcsapiv1alpha1.ServiceExport{}
+	err := client.Get(context.Background(), key, &svcExport)
+	if err != nil {
+		return nil, err
+	}
+	return &svcExport, nil
+}
+
+func Test_mcsServiceImport_Reconcile(t *testing.T) {
+	var (
+		svcImportTestFixtures = []client.Object{
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+			},
+
+			&mcsapiv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "local-only",
+					Namespace:         "default",
+					CreationTimestamp: nowTime,
+				},
+			},
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "local-only",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Ports: []corev1.ServicePort{{
+						Port: 8000,
+					}},
+				},
+			},
+
+			&mcsapiv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "delete-local",
+					Namespace:         "default",
+					CreationTimestamp: nowTime,
+				},
+			},
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "delete-local",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					SessionAffinity: corev1.ServiceAffinityNone,
+				},
+			},
+
+			&mcsapiv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "basic",
+					Namespace:         "default",
+					CreationTimestamp: nowTime,
+				},
+			},
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Ports: []corev1.ServicePort{
+						{
+							Name: "named",
+							Port: 80,
+						}, {
+							Port: 4242,
+						},
+					},
+				},
+			},
+
+			&mcsapiv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "conflict-type-remove",
+					Namespace:         "default",
+					CreationTimestamp: olderTime,
+				},
+			},
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflict-type-remove",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					SessionAffinity: corev1.ServiceAffinityNone,
+				},
+			},
+
+			&mcsapiv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "conflict-type",
+					Namespace:         "default",
+					CreationTimestamp: nowTime,
+				},
+			},
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflict-type",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					SessionAffinity: corev1.ServiceAffinityNone,
+				},
+			},
+
+			&mcsapiv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "conflict-port-name",
+					Namespace:         "default",
+					CreationTimestamp: nowTime,
+				},
+			},
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflict-port-name",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Ports: []corev1.ServicePort{{
+						Port: 4242,
+					}},
+				},
+			},
+
+			&mcsapiv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "conflict-port-appprotocol",
+					Namespace:         "default",
+					CreationTimestamp: nowTime,
+				},
+			},
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflict-port-appprotocol",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Ports: []corev1.ServicePort{{
+						Port: 4242,
+					}},
+				},
+			},
+
+			&mcsapiv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "conflict-duplicated-port-name",
+					Namespace:         "default",
+					CreationTimestamp: nowTime,
+				},
+			},
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflict-duplicated-port-name",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					SessionAffinity: corev1.ServiceAffinityNone,
+					Ports: []corev1.ServicePort{{
+						Name: "myport",
+						Port: 4242,
+					}},
+				},
+			},
+
+			&mcsapiv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "conflict-session-affinity",
+					Namespace:         "default",
+					CreationTimestamp: nowTime,
+				},
+			},
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflict-session-affinity",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					SessionAffinity: corev1.ServiceAffinityNone,
+				},
+			},
+
+			&mcsapiv1alpha1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "conflict-session-affinity-config",
+					Namespace:         "default",
+					CreationTimestamp: nowTime,
+				},
+			},
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflict-session-affinity-config",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					SessionAffinity: corev1.ServiceAffinityClientIP,
+					SessionAffinityConfig: &corev1.SessionAffinityConfig{
+						ClientIP: &corev1.ClientIPConfig{TimeoutSeconds: ptr.To[int32](4242)},
+					},
+				},
+			},
+		}
+		remoteSvcImportTestFixtures = []*mcsapitypes.MCSAPIServiceSpec{
+			{
+				Cluster:                 remoteClusterName,
+				Name:                    "remote-only",
+				Namespace:               "default",
+				ExportCreationTimestamp: olderTime,
+				Type:                    mcsapiv1alpha1.ClusterSetIP,
+				SessionAffinity:         corev1.ServiceAffinityNone,
+			},
+			{
+				Cluster:                 remoteClusterName,
+				Name:                    "delete-remote",
+				Namespace:               "default",
+				ExportCreationTimestamp: olderTime,
+				Type:                    mcsapiv1alpha1.ClusterSetIP,
+				SessionAffinity:         corev1.ServiceAffinityNone,
+			},
+			{
+				Cluster:                 remoteClusterName,
+				Name:                    "unknown-ns",
+				Namespace:               "unknown",
+				ExportCreationTimestamp: olderTime,
+				Type:                    mcsapiv1alpha1.ClusterSetIP,
+				SessionAffinity:         corev1.ServiceAffinityNone,
+			},
+			{
+				Cluster:                 remoteClusterName,
+				Name:                    "basic",
+				Namespace:               "default",
+				ExportCreationTimestamp: olderTime,
+				Ports: []mcsapiv1alpha1.ServicePort{
+					{
+						Name: "named",
+						Port: 80,
+					}, {
+						Port: 4242,
+					},
+				},
+				Type:            mcsapiv1alpha1.ClusterSetIP,
+				SessionAffinity: corev1.ServiceAffinityNone,
+			},
+			{
+				Cluster:                 remoteClusterName,
+				Name:                    "multiple-clusters",
+				Namespace:               "default",
+				ExportCreationTimestamp: olderTime,
+				Type:                    mcsapiv1alpha1.ClusterSetIP,
+				SessionAffinity:         corev1.ServiceAffinityNone,
+			},
+			{
+				Cluster:                 remoteClusterName,
+				Name:                    "conflict-type-remove",
+				Namespace:               "default",
+				ExportCreationTimestamp: nowTime,
+				Type:                    mcsapiv1alpha1.Headless,
+				SessionAffinity:         corev1.ServiceAffinityNone,
+			},
+			{
+				Cluster:                 remoteClusterName,
+				Name:                    "conflict-type",
+				Namespace:               "default",
+				ExportCreationTimestamp: olderTime,
+				Type:                    mcsapiv1alpha1.Headless,
+				SessionAffinity:         corev1.ServiceAffinityNone,
+			},
+			{
+				Cluster:                 remoteClusterName,
+				Name:                    "conflict-port-name",
+				Namespace:               "default",
+				ExportCreationTimestamp: olderTime,
+				Ports: []mcsapiv1alpha1.ServicePort{
+					{Name: "remote", Port: 4242},
+				},
+				Type:            mcsapiv1alpha1.ClusterSetIP,
+				SessionAffinity: corev1.ServiceAffinityNone,
+			},
+			{
+				Cluster:                 remoteClusterName,
+				Name:                    "conflict-port-appprotocol",
+				Namespace:               "default",
+				ExportCreationTimestamp: olderTime,
+				Ports: []mcsapiv1alpha1.ServicePort{
+					{Port: 4242, AppProtocol: ptr.To("something-else")},
+				},
+				Type:            mcsapiv1alpha1.ClusterSetIP,
+				SessionAffinity: corev1.ServiceAffinityNone,
+			},
+			{
+				Cluster:                 remoteClusterName,
+				Name:                    "conflict-duplicated-port-name",
+				Namespace:               "default",
+				ExportCreationTimestamp: olderTime,
+				Ports: []mcsapiv1alpha1.ServicePort{
+					{Name: "myport", Port: 4243},
+				},
+				Type:            mcsapiv1alpha1.ClusterSetIP,
+				SessionAffinity: corev1.ServiceAffinityNone,
+			},
+			{
+				Cluster:                 remoteClusterName,
+				Name:                    "conflict-session-affinity",
+				Namespace:               "default",
+				ExportCreationTimestamp: olderTime,
+				Ports:                   []mcsapiv1alpha1.ServicePort{},
+				Type:                    mcsapiv1alpha1.ClusterSetIP,
+				SessionAffinity:         corev1.ServiceAffinityClientIP,
+			},
+			{
+				Cluster:                 remoteClusterName,
+				Name:                    "conflict-session-affinity-config",
+				Namespace:               "default",
+				ExportCreationTimestamp: olderTime,
+				Ports:                   []mcsapiv1alpha1.ServicePort{},
+				Type:                    mcsapiv1alpha1.ClusterSetIP,
+				SessionAffinity:         corev1.ServiceAffinityClientIP,
+				SessionAffinityConfig: &corev1.SessionAffinityConfig{
+					ClientIP: &corev1.ClientIPConfig{TimeoutSeconds: ptr.To[int32](42)},
+				},
+			},
+		}
+	)
+
+	c := fake.NewClientBuilder().
+		WithObjects(svcImportTestFixtures...).
+		WithStatusSubresource(&mcsapiv1alpha1.ServiceExport{}).
+		WithStatusSubresource(&mcsapiv1alpha1.ServiceImport{}).
+		WithScheme(testScheme()).
+		Build()
+	globalServiceExports := operator.NewGlobalServiceExportCache(metric.NewGauge(metric.GaugeOpts{}))
+	remoteClusterServiceSource := &remoteClusterServiceExportSource{Logger: logging.DefaultLogger}
+	for _, svcExport := range remoteSvcImportTestFixtures {
+		globalServiceExports.OnUpdate(svcExport)
+	}
+
+	r := &mcsAPIServiceImportReconciler{
+		Client:                     c,
+		Logger:                     logging.DefaultLogger,
+		cluster:                    localClusterName,
+		globalServiceExports:       globalServiceExports,
+		remoteClusterServiceSource: remoteClusterServiceSource,
+	}
+
+	t.Run("Service import creation with local-only", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "local-only",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		svcImport, err := getServiceImport(c, key)
+		require.NoError(t, err)
+		require.NotNil(t, svcImport)
+		require.Equal(t, mcsapiv1alpha1.ServiceImportSpec{
+			Ports: []mcsapiv1alpha1.ServicePort{{
+				Port: 8000,
+			}},
+			Type:                  mcsapiv1alpha1.ClusterSetIP,
+			SessionAffinity:       corev1.ServiceAffinityNone,
+			SessionAffinityConfig: nil,
+		}, svcImport.Spec)
+		require.Len(t, svcImport.Status.Clusters, 1)
+
+		svcExport, err := getServiceExport(c, key)
+		require.NoError(t, err)
+		require.NotNil(t, svcExport)
+		require.True(t, meta.IsStatusConditionTrue(svcExport.Status.Conditions, conditionTypeReady))
+		require.True(t, meta.IsStatusConditionTrue(svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportValid))
+		require.Nil(t, meta.FindStatusCondition(svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportConflict))
+	})
+
+	t.Run("Service import creation with remote-only", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "remote-only",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		svcImport, err := getServiceImport(c, key)
+		require.NoError(t, err)
+		require.NotNil(t, svcImport)
+		require.Len(t, svcImport.Status.Clusters, 1)
+		require.Equal(t, remoteClusterName, svcImport.Status.Clusters[0].Cluster)
+	})
+
+	t.Run("Service import creation with unknown ns", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "unknown-ns",
+			Namespace: "unknown",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		svcImport, err := getServiceImport(c, key)
+		require.True(t, k8sApiErrors.IsNotFound(err), "Service import shouldn't be created")
+		require.Nil(t, svcImport)
+	})
+
+	t.Run("Service import creation with unknown name", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "unknown",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		svcImport, err := getServiceImport(c, key)
+		require.True(t, k8sApiErrors.IsNotFound(err), "Service import shouldn't be created")
+		require.Nil(t, svcImport)
+	})
+
+	t.Run("Basic service import sync", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "basic",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		svcImport, err := getServiceImport(c, key)
+		require.NoError(t, err)
+		require.NotNil(t, svcImport)
+		require.Len(t, svcImport.Spec.Ports, 2)
+		require.ElementsMatch(t, svcImport.Spec.Ports, []mcsapiv1alpha1.ServicePort{
+			{
+				Port: 4242,
+			}, {
+				Name: "named",
+				Port: 80,
+			},
+		})
+		require.Len(t, svcImport.Status.Clusters, 2)
+		require.ElementsMatch(t, svcImport.Status.Clusters, []mcsapiv1alpha1.ClusterStatus{
+			{Cluster: localClusterName},
+			{Cluster: remoteClusterName},
+		})
+
+		svcExport, err := getServiceExport(c, key)
+		require.NoError(t, err)
+		require.NotNil(t, svcExport)
+		require.True(t, meta.IsStatusConditionTrue(svcExport.Status.Conditions, conditionTypeReady))
+		require.True(t, meta.IsStatusConditionTrue(svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportValid))
+		require.Nil(t, meta.FindStatusCondition(svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportConflict))
+	})
+
+	t.Run("Delete local service test", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "delete-local",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		svcImport, err := getServiceImport(c, key)
+		require.NoError(t, err)
+		require.NotNil(t, svcImport)
+
+		svcExport, err := getServiceExport(c, key)
+		require.NoError(t, err)
+		require.NotNil(t, svcExport)
+
+		require.NoError(t, c.Delete(context.Background(), svcExport))
+
+		result, err = r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		svcImport, err = getServiceImport(c, key)
+		require.True(t, k8sApiErrors.IsNotFound(err), "Service import shouldn't be created")
+		require.Nil(t, svcImport)
+	})
+
+	t.Run("Delete remote service test", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "delete-remote",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		svcImport, err := getServiceImport(c, key)
+		require.NoError(t, err)
+		require.NotNil(t, svcImport)
+
+		remoteSvcExport := globalServiceExports.GetServiceExportByCluster(key)[remoteClusterName]
+		globalServiceExports.OnDelete(remoteSvcExport)
+
+		result, err = r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		svcImport, err = getServiceImport(c, key)
+		require.True(t, k8sApiErrors.IsNotFound(err), "Service import shouldn't be created")
+		require.Nil(t, svcImport)
+	})
+
+	t.Run("Check ServiceImport status on multiple remote clusters", func(t *testing.T) {
+		otherClusterName := "other"
+		key := types.NamespacedName{
+			Name:      "multiple-clusters",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		svcImport, err := getServiceImport(c, key)
+		require.NoError(t, err)
+		require.NotNil(t, svcImport)
+		require.Len(t, svcImport.Status.Clusters, 1)
+		require.Equal(t, remoteClusterName, svcImport.Status.Clusters[0].Cluster)
+
+		globalServiceExports.OnUpdate(&mcsapitypes.MCSAPIServiceSpec{
+			Cluster:                 otherClusterName,
+			Name:                    "multiple-clusters",
+			Namespace:               "default",
+			ExportCreationTimestamp: olderTime,
+			Type:                    mcsapiv1alpha1.ClusterSetIP,
+			SessionAffinity:         corev1.ServiceAffinityNone,
+		})
+
+		result, err = r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		svcImport, err = getServiceImport(c, key)
+		require.NoError(t, err)
+		require.NotNil(t, svcImport)
+		require.Len(t, svcImport.Status.Clusters, 2)
+		require.ElementsMatch(t, svcImport.Status.Clusters, []mcsapiv1alpha1.ClusterStatus{
+			{
+				Cluster: remoteClusterName,
+			}, {
+				Cluster: otherClusterName,
+			},
+		})
+	})
+
+	t.Run("Check conflict removal", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "conflict-type-remove",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		svcImport, err := getServiceImport(c, key)
+		require.NoError(t, err)
+		require.NotNil(t, svcImport)
+		require.Equal(t, mcsapiv1alpha1.ClusterSetIP, svcImport.Spec.Type)
+
+		svcExport, err := getServiceExport(c, key)
+		require.NoError(t, err)
+		require.NotNil(t, svcExport)
+
+		require.True(t, meta.IsStatusConditionFalse(svcExport.Status.Conditions, conditionTypeReady))
+		require.True(t, meta.IsStatusConditionTrue(svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportValid))
+		require.True(t, meta.IsStatusConditionTrue(svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportConflict))
+
+		globalServiceExports.OnUpdate(&mcsapitypes.MCSAPIServiceSpec{
+			Cluster:                 remoteClusterName,
+			Name:                    "conflict-type-remove",
+			Namespace:               "default",
+			ExportCreationTimestamp: nowTime,
+			Type:                    mcsapiv1alpha1.ClusterSetIP,
+			SessionAffinity:         corev1.ServiceAffinityNone,
+		})
+
+		result, err = r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		svcImport, err = getServiceImport(c, key)
+		require.NoError(t, err)
+		require.NotNil(t, svcImport)
+		require.Equal(t, mcsapiv1alpha1.ClusterSetIP, svcImport.Spec.Type)
+
+		svcExport, err = getServiceExport(c, key)
+		require.NoError(t, err)
+		require.NotNil(t, svcExport)
+
+		require.True(t, meta.IsStatusConditionTrue(svcExport.Status.Conditions, conditionTypeReady))
+		require.True(t, meta.IsStatusConditionTrue(svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportValid))
+		require.Nil(t, meta.FindStatusCondition(svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportConflict))
+	})
+
+	conflictTests := []struct {
+		name                 string
+		remoteSvcImportValid func(*mcsapiv1alpha1.ServiceImport) bool
+		localSvcImportValid  func(*mcsapiv1alpha1.ServiceImport) bool
+	}{
+		{
+			name: "conflict-type",
+			remoteSvcImportValid: func(svcImport *mcsapiv1alpha1.ServiceImport) bool {
+				return svcImport.Spec.Type == mcsapiv1alpha1.Headless
+			},
+			localSvcImportValid: func(svcImport *mcsapiv1alpha1.ServiceImport) bool {
+				return svcImport.Spec.Type == mcsapiv1alpha1.ClusterSetIP
+			},
+		},
+		{
+			name: "conflict-port-name",
+			remoteSvcImportValid: func(svcImport *mcsapiv1alpha1.ServiceImport) bool {
+				return len(svcImport.Spec.Ports) == 1 && svcImport.Spec.Ports[0].Name == "remote"
+			},
+			localSvcImportValid: func(svcImport *mcsapiv1alpha1.ServiceImport) bool {
+				return len(svcImport.Spec.Ports) == 1 && svcImport.Spec.Ports[0].Name == ""
+			},
+		},
+		{
+			name: "conflict-port-appprotocol",
+			remoteSvcImportValid: func(svcImport *mcsapiv1alpha1.ServiceImport) bool {
+				return len(svcImport.Spec.Ports) == 1 && ptr.Deref(svcImport.Spec.Ports[0].AppProtocol, "") == "something-else"
+			},
+			localSvcImportValid: func(svcImport *mcsapiv1alpha1.ServiceImport) bool {
+				return len(svcImport.Spec.Ports) == 1 && ptr.Deref(svcImport.Spec.Ports[0].AppProtocol, "") == ""
+			},
+		},
+		{
+			name: "conflict-duplicated-port-name",
+			remoteSvcImportValid: func(svcImport *mcsapiv1alpha1.ServiceImport) bool {
+				return len(svcImport.Spec.Ports) == 1 && svcImport.Spec.Ports[0].Port == 4243
+			},
+			localSvcImportValid: func(svcImport *mcsapiv1alpha1.ServiceImport) bool {
+				return len(svcImport.Spec.Ports) == 1 && svcImport.Spec.Ports[0].Port == 4242
+			},
+		},
+		{
+			name: "conflict-session-affinity",
+			remoteSvcImportValid: func(svcImport *mcsapiv1alpha1.ServiceImport) bool {
+				return svcImport.Spec.SessionAffinity == corev1.ServiceAffinityClientIP
+			},
+			localSvcImportValid: func(svcImport *mcsapiv1alpha1.ServiceImport) bool {
+				return svcImport.Spec.SessionAffinity == corev1.ServiceAffinityNone
+			},
+		},
+		{
+			name: "conflict-session-affinity-config",
+			remoteSvcImportValid: func(svcImport *mcsapiv1alpha1.ServiceImport) bool {
+				return *svcImport.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds == 42
+			},
+			localSvcImportValid: func(svcImport *mcsapiv1alpha1.ServiceImport) bool {
+				return *svcImport.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds == 4242
+			},
+		},
+	}
+
+	for _, conflictTest := range conflictTests {
+		t.Run("Conflict test "+conflictTest.name+" with remote conflict", func(t *testing.T) {
+			key := types.NamespacedName{
+				Name:      conflictTest.name,
+				Namespace: "default",
+			}
+			result, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: key,
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+			svcImport, err := getServiceImport(c, key)
+			require.NoError(t, err)
+			require.NotNil(t, svcImport)
+			require.True(t, conflictTest.remoteSvcImportValid(svcImport))
+
+			svcExport, err := getServiceExport(c, key)
+			require.NoError(t, err)
+			require.NotNil(t, svcExport)
+
+			require.True(t, meta.IsStatusConditionFalse(svcExport.Status.Conditions, conditionTypeReady))
+			require.True(t, meta.IsStatusConditionTrue(svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportValid))
+			require.True(t, meta.IsStatusConditionTrue(svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportConflict))
+		})
+	}
+
+	for _, remoteFixture := range remoteSvcImportTestFixtures {
+		remoteFixture.ExportCreationTimestamp = newerTime
+	}
+
+	for _, conflictTest := range conflictTests {
+		t.Run("Conflict test "+conflictTest.name+" with local precedence", func(t *testing.T) {
+			key := types.NamespacedName{
+				Name:      conflictTest.name,
+				Namespace: "default",
+			}
+			result, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: key,
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+			svcImport, err := getServiceImport(c, key)
+			require.NoError(t, err)
+			require.NotNil(t, svcImport)
+			require.True(t, conflictTest.localSvcImportValid(svcImport))
+
+			svcExport, err := getServiceExport(c, key)
+			require.NoError(t, err)
+			require.NotNil(t, svcExport)
+
+			require.True(t, meta.IsStatusConditionFalse(svcExport.Status.Conditions, conditionTypeReady))
+			require.True(t, meta.IsStatusConditionTrue(svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportValid))
+			require.True(t, meta.IsStatusConditionTrue(svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportConflict))
+		})
+	}
+}

--- a/pkg/clustermesh/operator/clustermesh.go
+++ b/pkg/clustermesh/operator/clustermesh.go
@@ -72,10 +72,10 @@ type ClusterMesh interface {
 	RegisterClusterServiceDeleteHook(clusterServiceDeleteHook func(*serviceStore.ClusterService))
 	// RegisterClusterServiceExportUpdateHook register a hook when a service export in the mesh is updated.
 	// This should NOT be called after the Start hook.
-	RegisterClusterServiceExportUpdateHook(clusterServiceUpdateHook func(*mcsapitypes.MCSAPIServiceSpec))
+	RegisterClusterServiceExportUpdateHook(clusterServiceExportUpdateHook func(*mcsapitypes.MCSAPIServiceSpec))
 	// RegisterClusterServiceExportDeleteHook register a hook when a service export in the mesh is deleted.
 	// This should NOT be called after the Start hook.
-	RegisterClusterServiceExportDeleteHook(clusterServiceDeleteHook func(*mcsapitypes.MCSAPIServiceSpec))
+	RegisterClusterServiceExportDeleteHook(clusterServiceExportDeleteHook func(*mcsapitypes.MCSAPIServiceSpec))
 
 	ServicesSynced(ctx context.Context) error
 	GlobalServices() *common.GlobalServiceCache


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

This adds the last needed MCS-API controller to sync ServiceImport from remote clusters in the clustermesh. This PR also  comes with an example that will be later used in the user documentation, small fixes to the helm deployment so that this controller is able to patch statuses and a small typo fix with the interface that was added for this controller in previous commits.

Fixes: #32712
Related to #27902

```release-note
clustermesh: add Multi-cluster Service API support
```
