### PR TITLE
bpf: Refactor LRP per packet LB test to utilize helper functions. 

### DIFF
--- a/Documentation/network/kubernetes/local-redirect-policy.rst
+++ b/Documentation/network/kubernetes/local-redirect-policy.rst
@@ -531,8 +531,7 @@ When a local redirect policy is applied, cilium BPF datapath redirects traffic g
 However, for traffic originating from a node-local backend pod destined to the policy frontend, users may want to
 skip redirecting the traffic back to the node-local backend pod, and instead forward the traffic to the original frontend.
 This behavior can be enabled by setting the ``skipRedirectFromBackend`` flag to ``true`` in the local redirect policy spec.
-The configuration is supported with socket-based load-balancing and per packet based load-balancing, and requires ``SO_NETNS_COOKIE`` feature
-available in Linux kernel version >= 5.8.
+This configuration requires the ``SO_NETNS_COOKIE`` feature available in Linux kernel version >= 5.8.
 
 .. note::
 


### PR DESCRIPTION
Use helper functions from from `bpf/tests/lib/....` in  LRP loopback bpf test. 
Remove redundant details from LRP documentation.

```release-note
bpf: Refactor LRP per packet LB test to utilize helper functions. Remove redundant details from LRP documentation.
```

