### PR TITLE
labeler: Add cilium-cli label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,8 @@
+# Add 'cilium-cli' label to any file changes in 'cilium-cli/'
+cilium-cli:
+- changed-files:
+  - any-glob-to-any-file:
+    - cilium-cli/**
 # Add 'hubble-cli' label to any file changes in 'hubble/'
 hubble-cli:
 - changed-files:


### PR DESCRIPTION
Add 'cilium-cli' label to pull requests that modify files under cilium-cli/ directory to make it easier to generate release notes for cilium-cli.