### PR TITLE
helm: fix envoy prometheus metrics scraping with servicemonitor

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -26,10 +26,6 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if and .Values.envoy.prometheus.enabled (not .Values.envoy.prometheus.serviceMonitor.enabled) }}
-        prometheus.io/port: "{{ .Values.envoy.prometheus.port }}"
-        prometheus.io/scrape: "true"
-        {{- end }}
         {{- if .Values.envoy.rollOutPods }}
         # ensure pods roll when configmap updates
         cilium.io/cilium-envoy-configmap-checksum: {{ include (print $.Template.BasePath "/cilium-envoy/configmap.yaml") . | sha256sum | quote }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/service.yaml
@@ -1,0 +1,33 @@
+{{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
+{{- if and $envoyDS (not .Values.preflight.enabled) .Values.envoy.prometheus.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-envoy
+  namespace: {{ .Release.Namespace }}
+  {{- if or (not .Values.envoy.prometheus.serviceMonitor.enabled) .Values.envoy.annotations }}
+  annotations:
+  {{- if not .Values.envoy.prometheus.serviceMonitor.enabled }}
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ .Values.envoy.prometheus.port | quote }}
+  {{- end }}
+  {{- with .Values.envoy.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  labels:
+    k8s-app: cilium-envoy
+    app.kubernetes.io/name: cilium-envoy
+    app.kubernetes.io/part-of: cilium
+    io.cilium/app: proxy
+spec:
+  clusterIP: None
+  type: ClusterIP
+  selector:
+    k8s-app: cilium-envoy
+  ports:
+  - name: envoy-metrics
+    port: {{ .Values.envoy.prometheus.port }}
+    protocol: TCP
+    targetPort: envoy-metrics
+{{- end }}


### PR DESCRIPTION
Removing the duplicated Prometheus metrics scrape annotations with #33803 fixed the issue reported with #32747 (duplicated envoy metrics in daemonset mode), but introduced a new issue when using the CRD `ServiceMonitor` instead of the annotations (ServiceMonitor is referencing the deleted Service (was mixed up with PodMonitor))

Therefore, this commit re-adds the K8s `Service` and removes the Prometheus scrape annotations on the Envoy DaemonSet Pods-template instead.

This way, all cases should be covered:

* Envoy Daemonset & Prom ServiceMonitor: Create ServiceMonitor & Service without annotations
* Envoy DaemonSet & Prom Annotations: Create Service with annotations (No ServiceMonitor)
* Envoy Embedded & Prom ServiceMonitor: Create Agent ServiceMonitor with Envoy endpoints configured) & add Envoy ports to Agent Service
* Envoy Embedded & Prom Annotations: Create Service with annotations (for Envoy in Agent templates) (No ServiceMonitor)

In all cases no Prometheus scraping annotations for Envoy are placed on the Pod itself (not to mix up with the ones for the Agent)

Fixes: #34425