### PR TITLE
.github: Add e2e test for experimental LB control-plane

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -25,6 +25,9 @@ inputs:
   lb-acceleration:
     description: 'KPR acceleration'
     default: ''
+  lb-experimental:
+    description: 'Enable experimental LB control-plane'
+    default: 'false'
   encryption:
     description: '"ipsec", "wireguard" or empty'
     default: ''
@@ -86,6 +89,7 @@ runs:
             --helm-set=authentication.mutual.spire.enabled=${{ inputs.mutual-auth }} \
             --nodes-without-cilium \
             --helm-set-string=kubeProxyReplacement=${{ inputs.kpr }} \
+            --helm-set=loadBalancer.experimental=${{ inputs.lb-experimental }} \
             --set='${{ inputs.misc }}'"
 
           IMAGE=""

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -101,7 +101,7 @@ jobs:
       job_name: 'Setup & Test'
     strategy:
       fail-fast: false
-      max-parallel: 25
+      max-parallel: 26
       matrix:
         include:
           - name: '1'
@@ -411,6 +411,14 @@ jobs:
             ciliumendpointslice: 'true'
             endpoint-routes: 'true'
             skip-upgrade: 'true'
+
+          - name: '26'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: 'bpf-20241104.074922'
+            kube-proxy: 'none'
+            kpr: 'true'
+            devices: '{eth0,eth1}'
+            lb-experimental: 'true'
 
           # Example of a feature that is being introduced, and we want to test
           # it without performing an upgrade, we use skip-upgrade: 'true'

--- a/cilium-cli/connectivity/check/wait.go
+++ b/cilium-cli/connectivity/check/wait.go
@@ -18,7 +18,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium/cilium-cli/k8s"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
@@ -237,14 +236,14 @@ func WaitForServiceEndpoints(ctx context.Context, log Logger, agent Pod, service
 
 func checkServiceEndpoints(ctx context.Context, agent Pod, service Service, backends uint, families []features.IPFamily) error {
 	buffer, err := agent.K8sClient.ExecInPod(ctx, agent.Namespace(), agent.NameWithoutNamespace(),
-		defaults.AgentContainerName, []string{"cilium", "service", "list", "--output=json"})
+		defaults.AgentContainerName, []string{"cilium-dbg", "bpf", "lb", "list", "--output=json"})
 	if err != nil {
 		return fmt.Errorf("failed to query service list: %w", err)
 	}
 
-	var services []*models.Service
-	if err := json.Unmarshal(buffer.Bytes(), &services); err != nil {
-		return fmt.Errorf("failed to unmarshal service list output: %w", err)
+	lbEntries := map[string][]string{}
+	if err := json.Unmarshal(buffer.Bytes(), &lbEntries); err != nil {
+		return fmt.Errorf("failed to unmarshal bpf lb list output: %w", err)
 	}
 
 	type l3n4 struct {
@@ -253,11 +252,22 @@ func checkServiceEndpoints(ctx context.Context, agent Pod, service Service, back
 	}
 
 	found := make(map[l3n4]uint)
-	for _, svc := range services {
-		found[l3n4{
-			addr: svc.Spec.FrontendAddress.IP,
-			port: svc.Spec.FrontendAddress.Port,
-		}] = uint(len(svc.Spec.BackendAddresses))
+	for fe, bes := range lbEntries {
+		addrPort, _, _ := strings.Cut(fe, " ")
+		i := strings.LastIndexByte(addrPort, ':')
+		if i < 0 {
+			return fmt.Errorf("failed to parse %q as addr:port", fe)
+		}
+		addr := addrPort[:i]
+		addr = strings.ReplaceAll(addr, "[", "")
+		addr = strings.ReplaceAll(addr, "]", "")
+		portS := addrPort[i+1:]
+		port, _ := strconv.ParseUint(portS, 10, 16)
+		l3n4 := l3n4{
+			addr: addr,
+			port: uint16(port),
+		}
+		found[l3n4] = uint(len(bes))
 	}
 
 	for _, ip := range service.Service.Spec.ClusterIPs {


### PR DESCRIPTION
First commits changes `cilium-cli` to use the `cilium-dbg bpf lb` commands to check if node has synchronized services. This makes it work both with the current control-plane and the experimental one.

Second commit adds a test case to the matrix to run conformance tests with the experimental control-plane (pkg/loadbalancer/experimental).
