### PR TITLE
Fix `LB{4,6}_SKIP_MAP` map creations

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -99,6 +99,7 @@ struct {
 	__type(value, __u8);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, CILIUM_LB_SKIP_MAP_MAX_ENTRIES);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
 } LB6_SKIP_MAP __section_maps_btf;
 #endif /* ENABLE_IPV6 */
 

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -178,6 +178,7 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #define LB4_MAGLEV_MAP_OUTER test_cilium_lb4_maglev_outer
 #define LB6_MAGLEV_MAP_OUTER test_cilium_lb6_maglev_outer
 #define LB4_SKIP_MAP test_cilium_skip_lb4
+#define LB6_SKIP_MAP test_cilium_skip_lb6
 #define THROTTLE_MAP test_cilium_throttle
 #define THROTTLE_MAP_SIZE 65536
 #define ENABLE_ARP_RESPONDER

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -259,6 +259,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	cDefinesMap["LB4_REVERSE_NAT_SK_MAP"] = lbmap.SockRevNat4MapName
 	cDefinesMap["LB4_REVERSE_NAT_SK_MAP_SIZE"] = fmt.Sprintf("%d", lbmap.MaxSockRevNat4MapEntries)
 	cDefinesMap["LB4_SKIP_MAP"] = lbmap.SkipLB4MapName
+	cDefinesMap["LB6_SKIP_MAP"] = lbmap.SkipLB6MapName
 
 	if option.Config.EnableSessionAffinity {
 		cDefinesMap["ENABLE_SESSION_AFFINITY"] = "1"

--- a/pkg/maps/lbmap/skip_lb_map.go
+++ b/pkg/maps/lbmap/skip_lb_map.go
@@ -42,34 +42,32 @@ type SkipLBMap interface {
 func NewSkipLBMap() (SkipLBMap, error) {
 	skipLBMap := &skipLBMap{}
 
-	if option.Config.EnableLocalRedirectPolicy {
-		if option.Config.EnableIPv4 {
-			skipLBMap.bpfMap4 = ebpf.NewMap(&ebpf.MapSpec{
-				Name:       SkipLB4MapName,
-				Type:       ebpf.Hash,
-				KeySize:    uint32(unsafe.Sizeof(SkipLB4Key{})),
-				ValueSize:  uint32(unsafe.Sizeof(SkipLB4Value{})),
-				MaxEntries: SkipLBMapMaxEntries,
-				Flags:      bpf.BPF_F_NO_PREALLOC,
-				Pinning:    ebpf.PinByName},
-			)
-			if err := skipLBMap.bpfMap4.OpenOrCreate(); err != nil {
-				return nil, fmt.Errorf("failed to open or create %s: %w", SkipLB4MapName, err)
-			}
+	if option.Config.EnableIPv4 {
+		skipLBMap.bpfMap4 = ebpf.NewMap(&ebpf.MapSpec{
+			Name:       SkipLB4MapName,
+			Type:       ebpf.Hash,
+			KeySize:    uint32(unsafe.Sizeof(SkipLB4Key{})),
+			ValueSize:  uint32(unsafe.Sizeof(SkipLB4Value{})),
+			MaxEntries: SkipLBMapMaxEntries,
+			Flags:      bpf.BPF_F_NO_PREALLOC,
+			Pinning:    ebpf.PinByName},
+		)
+		if err := skipLBMap.bpfMap4.OpenOrCreate(); err != nil {
+			return nil, fmt.Errorf("failed to open or create %s: %w", SkipLB4MapName, err)
 		}
-		if option.Config.EnableIPv6 {
-			skipLBMap.bpfMap6 = ebpf.NewMap(&ebpf.MapSpec{
-				Name:       SkipLB6MapName,
-				Type:       ebpf.Hash,
-				KeySize:    uint32(unsafe.Sizeof(SkipLB6Key{})),
-				ValueSize:  uint32(unsafe.Sizeof(SkipLB6Value{})),
-				MaxEntries: SkipLBMapMaxEntries,
-				Flags:      bpf.BPF_F_NO_PREALLOC,
-				Pinning:    ebpf.PinByName},
-			)
-			if err := skipLBMap.bpfMap6.OpenOrCreate(); err != nil {
-				return nil, fmt.Errorf("failed to open or create %s: %w", SkipLB6MapName, err)
-			}
+	}
+	if option.Config.EnableIPv6 {
+		skipLBMap.bpfMap6 = ebpf.NewMap(&ebpf.MapSpec{
+			Name:       SkipLB6MapName,
+			Type:       ebpf.Hash,
+			KeySize:    uint32(unsafe.Sizeof(SkipLB6Key{})),
+			ValueSize:  uint32(unsafe.Sizeof(SkipLB6Value{})),
+			MaxEntries: SkipLBMapMaxEntries,
+			Flags:      bpf.BPF_F_NO_PREALLOC,
+			Pinning:    ebpf.PinByName},
+		)
+		if err := skipLBMap.bpfMap6.OpenOrCreate(); err != nil {
+			return nil, fmt.Errorf("failed to open or create %s: %w", SkipLB6MapName, err)
 		}
 	}
 


### PR DESCRIPTION
Follow up to https://github.com/cilium/cilium/pull/34388. See commits for details. Fixes a couple flakes.

```release-note
Fix a race condition that would cause errors related to maps `LB{4,6}_SKIP_MAP` when loading programs.
```
