### PR TITLE
connectivity: switch clustermesh epslice sync test from dig to nslookup

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -654,7 +654,7 @@ func (ct *ConnectivityTest) detectNodeCIDRs(ctx context.Context) error {
 	}
 
 	if len(nodeIPs) == 0 {
-		return fmt.Errorf("detectNodeCIDRs failed: no node IPs disovered")
+		return fmt.Errorf("detectNodeCIDRs failed: no node IPs discovered")
 	}
 
 	// collapse set of IPs in to CIDRs
@@ -1006,14 +1006,14 @@ func (ct *ConnectivityTest) DigCommand(peer TestPeer, ipFam features.IPFamily) [
 	return cmd
 }
 
-func (ct *ConnectivityTest) DigCommandService(peer TestPeer, ipFam features.IPFamily) []string {
-	cmd := []string{"dig"}
+func (ct *ConnectivityTest) NsLookupCommandService(peer TestPeer, ipFam features.IPFamily) []string {
+	cmd := []string{"nslookup"}
 	if ipFam == features.IPFamilyV4 {
-		cmd = append(cmd, "A")
+		cmd = append(cmd, "-query=A")
 	} else if ipFam == features.IPFamilyV6 {
-		cmd = append(cmd, "AAAA")
+		cmd = append(cmd, "-query=AAAA")
 	}
-	cmd = append(cmd, "+time=2", peer.Name())
+	cmd = append(cmd, "-timeout=2", peer.Name())
 	return cmd
 }
 

--- a/cilium-cli/connectivity/tests/clustermesh-endpointslice-sync.go
+++ b/cilium-cli/connectivity/tests/clustermesh-endpointslice-sync.go
@@ -32,7 +32,7 @@ func (s *clusterMeshEndpointSliceSync) Run(ctx context.Context, t *check.Test) {
 
 	t.ForEachIPFamily(func(ipFam features.IPFamily) {
 		t.NewAction(s, fmt.Sprintf("dig-%s", ipFam), client, service, ipFam).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, ct.DigCommandService(service, ipFam))
+			a.ExecInPod(ctx, ct.NsLookupCommandService(service, ipFam))
 		})
 	})
 }


### PR DESCRIPTION
Dig doesn't fail (return code != 0) on an empty response from the DNS resolver/coredns. This made the endpointslicesync e2e test to be bogus/always succeed. To fix that we are switching to nslookup instead which does actually fail if the endpointslice are not synced from remote cluster/coredns answers an empty RRSET.

