### PR TITLE
cilium-cli: fix clustermesh endpointslice sync test

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1006,14 +1006,14 @@ func (ct *ConnectivityTest) DigCommand(peer TestPeer, ipFam features.IPFamily) [
 	return cmd
 }
 
-func (ct *ConnectivityTest) DigCommandService(peer TestPeer, ipFam features.IPFamily) []string {
-	cmd := []string{"dig"}
+func (ct *ConnectivityTest) NSLookupCommandService(peer TestPeer, ipFam features.IPFamily) []string {
+	cmd := []string{"nslookup"}
 	if ipFam == features.IPFamilyV4 {
-		cmd = append(cmd, "A")
+		cmd = append(cmd, "-type=A")
 	} else if ipFam == features.IPFamilyV6 {
-		cmd = append(cmd, "AAAA")
+		cmd = append(cmd, "-type=AAAA")
 	}
-	cmd = append(cmd, "+time=2", peer.Name())
+	cmd = append(cmd, "-timeout=2", peer.Address(features.IPFamilyAny))
 	return cmd
 }
 

--- a/cilium-cli/connectivity/tests/clustermesh-endpointslice-sync.go
+++ b/cilium-cli/connectivity/tests/clustermesh-endpointslice-sync.go
@@ -32,7 +32,7 @@ func (s *clusterMeshEndpointSliceSync) Run(ctx context.Context, t *check.Test) {
 
 	t.ForEachIPFamily(func(ipFam features.IPFamily) {
 		t.NewAction(s, fmt.Sprintf("dig-%s", ipFam), client, service, ipFam).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, ct.DigCommandService(service, ipFam))
+			a.ExecInPod(ctx, ct.NSLookupCommandService(service, ipFam))
 		})
 	})
 }


### PR DESCRIPTION
Currently, the clustermesh endpointslice synchronization test part of the connectivity suite does not work as expected, because dig always returns a 0 exit code regardless of whether an entry for the given address is found or not. Apparently, there's no way to tune this behavior by means of options.

Let's workaround this by using nslookup instead, which exits with code 1 in case of NXDOMAIN. Differently from dig, nslookup takes into account search domains by default, which is the desired behavior in this context. Finally, let's fix the queried address to be in the service-name.service-namespace form, as incorrect previously.

Fixes: b081bea18060 ("connectivity: add endpointslice clustermesh sync test")

<!-- Description of change -->

```release-note
Fix clustermesh endpointslice synchronization connectivity test
```
