### PR TITLE
envoy: support tls session ticket keys

### DIFF
--- a/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
@@ -1089,7 +1089,7 @@ func TestCiliumEnvoyConfigTCPProxyTermination(t *testing.T) {
 }
 
 func checkCiliumXDS(t *testing.T, cs *envoy_config_core.ConfigSource) {
-	assert.NotNil(t, cs)
+	require.NotNil(t, cs)
 	assert.Equal(t, envoy_config_core.ApiVersion_V3, cs.ResourceApiVersion)
 	acs := cs.GetApiConfigSource()
 	assert.NotNil(t, acs)
@@ -1305,6 +1305,90 @@ func TestCiliumEnvoyConfigCombinedValidationContext(t *testing.T) {
 	checkCiliumXDS(t, sdsConfig.SdsConfig)
 	// Check that secret name was qualified
 	assert.Equal(t, "namespace/name/validation_context", sdsConfig.Name)
+
+	assert.Len(t, chain.Filters, 1)
+	assert.Equal(t, "envoy.filters.network.http_connection_manager", chain.Filters[0].Name)
+	message, err := chain.Filters[0].GetTypedConfig().UnmarshalNew()
+	require.NoError(t, err)
+	assert.NotNil(t, message)
+	hcm, ok := message.(*envoy_config_http.HttpConnectionManager)
+	assert.True(t, ok)
+	assert.NotNil(t, hcm)
+}
+
+var ciliumEnvoyConfigTlsSessionTicketKeys = `apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: sessionticket-keys
+spec:
+  version_info: "0"
+  resources:
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+    name: sessionticket-keys
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 10000
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          rds:
+            route_config_name: local_route
+          http_filters:
+          - name: envoy.filters.http.router
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          require_client_certificate: true
+          session_ticket_keys_sds_secret_config:
+            name: sessionticketkeys
+`
+
+func TestCiliumEnvoyConfigTlsSessionTicketKeys(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	parser := cecResourceParser{
+		logger:        logger,
+		portAllocator: NewMockPortAllocator(),
+	}
+
+	jsonBytes, err := yaml.YAMLToJSON([]byte(ciliumEnvoyConfigTlsSessionTicketKeys))
+	require.NoError(t, err)
+	cec := &cilium_v2.CiliumEnvoyConfig{}
+	err = json.Unmarshal(jsonBytes, cec)
+	require.NoError(t, err)
+	assert.Len(t, cec.Spec.Resources, 1)
+	assert.Equal(t, "type.googleapis.com/envoy.config.listener.v3.Listener", cec.Spec.Resources[0].TypeUrl)
+
+	resources, err := parser.parseResources("namespace", "name", cec.Spec.Resources, false, false, true)
+	require.NoError(t, err)
+
+	require.Len(t, resources.Listeners, 1)
+	assert.Equal(t, "namespace/name/sessionticket-keys", resources.Listeners[0].Name)
+	assert.Equal(t, uint32(10000), resources.Listeners[0].Address.GetSocketAddress().GetPortValue())
+	assert.Len(t, resources.Listeners[0].FilterChains, 1)
+	chain := resources.Listeners[0].FilterChains[0]
+
+	assert.NotNil(t, chain.TransportSocket)
+	assert.Equal(t, "envoy.transport_sockets.tls", chain.TransportSocket.Name)
+	msg, err := chain.TransportSocket.GetTypedConfig().UnmarshalNew()
+	require.NoError(t, err)
+	assert.NotNil(t, msg)
+	tls, ok := msg.(*envoy_config_tls.DownstreamTlsContext)
+	assert.True(t, ok)
+	assert.NotNil(t, tls)
+
+	//
+	// Check that missing SDS config sources are automatically filled in
+	//
+	sdsConfig := tls.GetSessionTicketKeysSdsSecretConfig()
+	assert.NotNil(t, sdsConfig)
+	checkCiliumXDS(t, sdsConfig.SdsConfig)
+	// Check that secret name was qualified
+	assert.Equal(t, "namespace/name/sessionticketkeys", sdsConfig.Name)
 
 	assert.Len(t, chain.Filters, 1)
 	assert.Equal(t, "envoy.filters.network.http_connection_manager", chain.Filters[0].Name)

--- a/pkg/envoy/secretsync.go
+++ b/pkg/envoy/secretsync.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	envoy_config_core_v3 "github.com/cilium/proxy/go/envoy/config/core/v3"
-	envoy_entensions_tls_v3 "github.com/cilium/proxy/go/envoy/extensions/transport_sockets/tls/v3"
+	envoy_extensions_tls_v3 "github.com/cilium/proxy/go/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -76,7 +76,7 @@ func (r *secretSyncer) upsertK8sSecretV1(ctx context.Context, secret *slim_corev
 	}
 
 	resource := Resources{
-		Secrets: []*envoy_entensions_tls_v3.Secret{k8sToEnvoySecret(secret)},
+		Secrets: []*envoy_extensions_tls_v3.Secret{k8sToEnvoySecret(secret)},
 	}
 	return r.envoyXdsServer.UpsertEnvoyResources(ctx, resource)
 }
@@ -88,7 +88,7 @@ func (r *secretSyncer) deleteK8sSecretV1(ctx context.Context, key resource.Key) 
 	}
 
 	resource := Resources{
-		Secrets: []*envoy_entensions_tls_v3.Secret{
+		Secrets: []*envoy_extensions_tls_v3.Secret{
 			{
 				// For deletion, only the name is required.
 				Name: getEnvoySecretName(key.Namespace, key.Name),
@@ -99,17 +99,17 @@ func (r *secretSyncer) deleteK8sSecretV1(ctx context.Context, key resource.Key) 
 }
 
 // k8sToEnvoySecret converts k8s secret object to envoy TLS secret object
-func k8sToEnvoySecret(secret *slim_corev1.Secret) *envoy_entensions_tls_v3.Secret {
+func k8sToEnvoySecret(secret *slim_corev1.Secret) *envoy_extensions_tls_v3.Secret {
 	if secret == nil {
 		return nil
 	}
-	envoySecret := &envoy_entensions_tls_v3.Secret{
+	envoySecret := &envoy_extensions_tls_v3.Secret{
 		Name: getEnvoySecretName(secret.GetNamespace(), secret.GetName()),
 	}
 
 	if len(secret.Data[tlsCrtAttribute]) > 0 || len(secret.Data[tlsKeyAttribute]) > 0 {
-		envoySecret.Type = &envoy_entensions_tls_v3.Secret_TlsCertificate{
-			TlsCertificate: &envoy_entensions_tls_v3.TlsCertificate{
+		envoySecret.Type = &envoy_extensions_tls_v3.Secret_TlsCertificate{
+			TlsCertificate: &envoy_extensions_tls_v3.TlsCertificate{
 				CertificateChain: &envoy_config_core_v3.DataSource{
 					Specifier: &envoy_config_core_v3.DataSource_InlineBytes{
 						InlineBytes: secret.Data[tlsCrtAttribute],
@@ -123,8 +123,8 @@ func k8sToEnvoySecret(secret *slim_corev1.Secret) *envoy_entensions_tls_v3.Secre
 			},
 		}
 	} else if len(secret.Data[caCrtAttribute]) > 0 {
-		envoySecret.Type = &envoy_entensions_tls_v3.Secret_ValidationContext{
-			ValidationContext: &envoy_entensions_tls_v3.CertificateValidationContext{
+		envoySecret.Type = &envoy_extensions_tls_v3.Secret_ValidationContext{
+			ValidationContext: &envoy_extensions_tls_v3.CertificateValidationContext{
 				TrustedCa: &envoy_config_core_v3.DataSource{
 					Specifier: &envoy_config_core_v3.DataSource_InlineBytes{
 						InlineBytes: secret.Data[caCrtAttribute],

--- a/pkg/envoy/secretsync.go
+++ b/pkg/envoy/secretsync.go
@@ -24,6 +24,17 @@ const (
 	// Key for CA certificate is fixed as 'ca.crt' even though is not as "standard"
 	// as 'tls.crt' and 'tls.key' are via k8s tls secret type.
 	caCrtAttribute = "ca.crt"
+
+	// Key for the TLS session ticket key is fixed as 'tls.sessionticket.key' even though is not as "standard"
+	// as 'tls.crt' and 'tls.key' are via k8s tls secret type.
+	//
+	// The value must contain exactly 80 bytes of cryptographically-secure random data.
+	//
+	// In addition to the main key that is used to encrypt new sessions, up to 9 additional keys
+	// can be defined. All keys are candidates for decrypting received tickets. This allows for
+	// easy rotation of keys by, for example, putting the new key first, and the previous key second.
+	// Additional keys are defined by using the Secret key 'tls.sessionticket.key.[1-9]'
+	tlsSessionTicketKeyAttribute = "tls.sessionticket.key"
 )
 
 // secretSyncer is responsible to sync K8s TLS Secrets in pre-defined namespaces
@@ -107,7 +118,8 @@ func k8sToEnvoySecret(secret *slim_corev1.Secret) *envoy_extensions_tls_v3.Secre
 		Name: getEnvoySecretName(secret.GetNamespace(), secret.GetName()),
 	}
 
-	if len(secret.Data[tlsCrtAttribute]) > 0 || len(secret.Data[tlsKeyAttribute]) > 0 {
+	switch {
+	case len(secret.Data[tlsCrtAttribute]) > 0 || len(secret.Data[tlsKeyAttribute]) > 0:
 		envoySecret.Type = &envoy_extensions_tls_v3.Secret_TlsCertificate{
 			TlsCertificate: &envoy_extensions_tls_v3.TlsCertificate{
 				CertificateChain: &envoy_config_core_v3.DataSource{
@@ -122,7 +134,8 @@ func k8sToEnvoySecret(secret *slim_corev1.Secret) *envoy_extensions_tls_v3.Secre
 				},
 			},
 		}
-	} else if len(secret.Data[caCrtAttribute]) > 0 {
+
+	case len(secret.Data[caCrtAttribute]) > 0:
 		envoySecret.Type = &envoy_extensions_tls_v3.Secret_ValidationContext{
 			ValidationContext: &envoy_extensions_tls_v3.CertificateValidationContext{
 				TrustedCa: &envoy_config_core_v3.DataSource{
@@ -133,6 +146,13 @@ func k8sToEnvoySecret(secret *slim_corev1.Secret) *envoy_extensions_tls_v3.Secre
 				// TODO: Consider support for other ValidationContext config.
 			},
 		}
+
+	case len(secret.Data[tlsSessionTicketKeyAttribute]) > 0:
+		envoySecret.Type = &envoy_extensions_tls_v3.Secret_SessionTicketKeys{
+			SessionTicketKeys: &envoy_extensions_tls_v3.TlsSessionTicketKeys{
+				Keys: getTLSSessionTicketKeys(secret.Data),
+			},
+		}
 	}
 
 	return envoySecret
@@ -140,4 +160,52 @@ func k8sToEnvoySecret(secret *slim_corev1.Secret) *envoy_extensions_tls_v3.Secre
 
 func getEnvoySecretName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
+}
+
+func getTLSSessionTicketKeys(data map[string]slim_corev1.Bytes) []*envoy_config_core_v3.DataSource {
+	datasourceKeys := []*envoy_config_core_v3.DataSource{}
+
+	if len(data[tlsSessionTicketKeyAttribute]) != 80 {
+		log.
+			WithField("size", len(data[tlsSessionTicketKeyAttribute])).
+			WithField("key", tlsSessionTicketKeyAttribute).
+			Debug("Skipping TLS session ticket key due to not matching size of 80 chars")
+
+		// Skipping all additional keys
+		return nil
+	}
+
+	// main session encryption key
+	datasourceKeys = append(datasourceKeys, &envoy_config_core_v3.DataSource{
+		Specifier: &envoy_config_core_v3.DataSource_InlineBytes{
+			InlineBytes: data[tlsSessionTicketKeyAttribute],
+		},
+	})
+
+	// additional keys
+	for i := 1; i <= 9; i++ {
+		key := fmt.Sprintf("%s.%d", tlsSessionTicketKeyAttribute, i)
+
+		if len(data[key]) == 0 {
+			continue
+		}
+
+		if len(data[key]) != 80 {
+			log.
+				WithField("size", len(data[key])).
+				WithField("key", key).
+				Debug("Skipping TLS session ticket key due to not matching size of 80 chars")
+
+			// Skipping all additional keys
+			continue
+		}
+
+		datasourceKeys = append(datasourceKeys, &envoy_config_core_v3.DataSource{
+			Specifier: &envoy_config_core_v3.DataSource_InlineBytes{
+				InlineBytes: data[key],
+			},
+		})
+	}
+
+	return datasourceKeys
 }

--- a/pkg/envoy/secretsync_test.go
+++ b/pkg/envoy/secretsync_test.go
@@ -58,6 +58,166 @@ func Test_k8sSecretToEnvoySecretValidationContext(t *testing.T) {
 	require.Nil(t, envoySecret.GetTlsCertificate())
 }
 
+func testSessionKey(i byte) []byte {
+	b := make([]byte, 80)
+	b[0] = i
+	return b
+}
+
+func Test_k8sSecretToEnvoySecretTlsSessionKeys(t *testing.T) {
+	envoySecret := k8sToEnvoySecret(&slim_corev1.Secret{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "dummy-secret",
+			Namespace: "dummy-namespace",
+		},
+		Data: map[string]slim_corev1.Bytes{
+			"tls.sessionticket.key":   testSessionKey(0),
+			"tls.sessionticket.key.1": testSessionKey(1),
+			"tls.sessionticket.key.2": testSessionKey(2),
+			"tls.sessionticket.key.3": testSessionKey(3),
+			"tls.sessionticket.key.4": testSessionKey(4),
+		},
+		Type: slim_corev1.SecretTypeOpaque,
+	})
+
+	require.Equal(t, "dummy-namespace/dummy-secret", envoySecret.Name)
+	require.Len(t, envoySecret.GetSessionTicketKeys().Keys, 5)
+
+	require.Equal(t, testSessionKey(0), envoySecret.GetSessionTicketKeys().Keys[0].GetInlineBytes())
+	require.Equal(t, testSessionKey(1), envoySecret.GetSessionTicketKeys().Keys[1].GetInlineBytes())
+	require.Equal(t, testSessionKey(2), envoySecret.GetSessionTicketKeys().Keys[2].GetInlineBytes())
+	require.Equal(t, testSessionKey(3), envoySecret.GetSessionTicketKeys().Keys[3].GetInlineBytes())
+	require.Equal(t, testSessionKey(4), envoySecret.GetSessionTicketKeys().Keys[4].GetInlineBytes())
+
+	require.Nil(t, envoySecret.GetTlsCertificate())
+	require.Nil(t, envoySecret.GetValidationContext())
+}
+
+func Test_k8sSecretToEnvoySecretTlsSessionKeys_FirstKeyMandatory(t *testing.T) {
+	envoySecret := k8sToEnvoySecret(&slim_corev1.Secret{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "dummy-secret",
+			Namespace: "dummy-namespace",
+		},
+		Data: map[string]slim_corev1.Bytes{
+			"tls.sessionticket.key.1": testSessionKey(1),
+			"tls.sessionticket.key.2": testSessionKey(2),
+			"tls.sessionticket.key.3": testSessionKey(3),
+			"tls.sessionticket.key.4": testSessionKey(4),
+		},
+		Type: slim_corev1.SecretTypeOpaque,
+	})
+
+	require.Equal(t, "dummy-namespace/dummy-secret", envoySecret.Name)
+
+	require.Nil(t, envoySecret.GetSessionTicketKeys())
+	require.Nil(t, envoySecret.GetTlsCertificate())
+	require.Nil(t, envoySecret.GetValidationContext())
+}
+
+func Test_k8sSecretToEnvoySecretTlsSessionKeys_Max10Keys(t *testing.T) {
+	envoySecret := k8sToEnvoySecret(&slim_corev1.Secret{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "dummy-secret",
+			Namespace: "dummy-namespace",
+		},
+		Data: map[string]slim_corev1.Bytes{
+			"tls.sessionticket.key":    testSessionKey(0),
+			"tls.sessionticket.key.1":  testSessionKey(1),
+			"tls.sessionticket.key.2":  testSessionKey(2),
+			"tls.sessionticket.key.3":  testSessionKey(3),
+			"tls.sessionticket.key.4":  testSessionKey(4),
+			"tls.sessionticket.key.5":  testSessionKey(5),
+			"tls.sessionticket.key.6":  testSessionKey(6),
+			"tls.sessionticket.key.7":  testSessionKey(7),
+			"tls.sessionticket.key.8":  testSessionKey(8),
+			"tls.sessionticket.key.9":  testSessionKey(9),
+			"tls.sessionticket.key.10": testSessionKey(10),
+		},
+		Type: slim_corev1.SecretTypeOpaque,
+	})
+
+	require.Equal(t, "dummy-namespace/dummy-secret", envoySecret.Name)
+
+	require.Len(t, envoySecret.GetSessionTicketKeys().Keys, 10)
+
+	require.Equal(t, testSessionKey(0), envoySecret.GetSessionTicketKeys().Keys[0].GetInlineBytes())
+	require.Equal(t, testSessionKey(1), envoySecret.GetSessionTicketKeys().Keys[1].GetInlineBytes())
+	require.Equal(t, testSessionKey(2), envoySecret.GetSessionTicketKeys().Keys[2].GetInlineBytes())
+	require.Equal(t, testSessionKey(3), envoySecret.GetSessionTicketKeys().Keys[3].GetInlineBytes())
+	require.Equal(t, testSessionKey(4), envoySecret.GetSessionTicketKeys().Keys[4].GetInlineBytes())
+	require.Equal(t, testSessionKey(5), envoySecret.GetSessionTicketKeys().Keys[5].GetInlineBytes())
+	require.Equal(t, testSessionKey(6), envoySecret.GetSessionTicketKeys().Keys[6].GetInlineBytes())
+	require.Equal(t, testSessionKey(7), envoySecret.GetSessionTicketKeys().Keys[7].GetInlineBytes())
+	require.Equal(t, testSessionKey(8), envoySecret.GetSessionTicketKeys().Keys[8].GetInlineBytes())
+	require.Equal(t, testSessionKey(9), envoySecret.GetSessionTicketKeys().Keys[9].GetInlineBytes())
+
+	require.Nil(t, envoySecret.GetTlsCertificate())
+	require.Nil(t, envoySecret.GetValidationContext())
+}
+
+func Test_k8sSecretToEnvoySecretTlsSessionKeys_SkipAdditionalKeysOnMainKeySizeIssue(t *testing.T) {
+	envoySecret := k8sToEnvoySecret(&slim_corev1.Secret{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "dummy-secret",
+			Namespace: "dummy-namespace",
+		},
+		Data: map[string]slim_corev1.Bytes{
+			"tls.sessionticket.key":   []byte{}, // not 80 bytes
+			"tls.sessionticket.key.1": testSessionKey(1),
+			"tls.sessionticket.key.2": testSessionKey(2),
+			"tls.sessionticket.key.3": testSessionKey(3),
+			"tls.sessionticket.key.4": testSessionKey(4),
+		},
+		Type: slim_corev1.SecretTypeOpaque,
+	})
+
+	require.Equal(t, "dummy-namespace/dummy-secret", envoySecret.Name)
+
+	require.Nil(t, envoySecret.GetSessionTicketKeys())
+	require.Nil(t, envoySecret.GetTlsCertificate())
+	require.Nil(t, envoySecret.GetValidationContext())
+}
+
+func Test_k8sSecretToEnvoySecretTlsSessionKeys_SkipAdditionalKeyOnSizeIssue(t *testing.T) {
+	envoySecret := k8sToEnvoySecret(&slim_corev1.Secret{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "dummy-secret",
+			Namespace: "dummy-namespace",
+		},
+		Data: map[string]slim_corev1.Bytes{
+			"tls.sessionticket.key":    testSessionKey(0),
+			"tls.sessionticket.key.1":  testSessionKey(1),
+			"tls.sessionticket.key.2":  testSessionKey(2),
+			"tls.sessionticket.key.3":  []byte{}, // not 80 bytes -> will be skipped
+			"tls.sessionticket.key.4":  testSessionKey(4),
+			"tls.sessionticket.key.5":  testSessionKey(5),
+			"tls.sessionticket.key.6":  testSessionKey(6),
+			"tls.sessionticket.key.7":  make([]byte, 90), // not 80 bytes -> will be skipped
+			"tls.sessionticket.key.8":  testSessionKey(8),
+			"tls.sessionticket.key.9":  testSessionKey(9),
+			"tls.sessionticket.key.10": testSessionKey(10),
+		},
+		Type: slim_corev1.SecretTypeOpaque,
+	})
+
+	require.Equal(t, "dummy-namespace/dummy-secret", envoySecret.Name)
+
+	require.Len(t, envoySecret.GetSessionTicketKeys().Keys, 8)
+
+	require.Equal(t, testSessionKey(0), envoySecret.GetSessionTicketKeys().Keys[0].GetInlineBytes())
+	require.Equal(t, testSessionKey(1), envoySecret.GetSessionTicketKeys().Keys[1].GetInlineBytes())
+	require.Equal(t, testSessionKey(2), envoySecret.GetSessionTicketKeys().Keys[2].GetInlineBytes())
+	require.Equal(t, testSessionKey(4), envoySecret.GetSessionTicketKeys().Keys[3].GetInlineBytes())
+	require.Equal(t, testSessionKey(5), envoySecret.GetSessionTicketKeys().Keys[4].GetInlineBytes())
+	require.Equal(t, testSessionKey(6), envoySecret.GetSessionTicketKeys().Keys[5].GetInlineBytes())
+	require.Equal(t, testSessionKey(8), envoySecret.GetSessionTicketKeys().Keys[6].GetInlineBytes())
+	require.Equal(t, testSessionKey(9), envoySecret.GetSessionTicketKeys().Keys[7].GetInlineBytes())
+
+	require.Nil(t, envoySecret.GetTlsCertificate())
+	require.Nil(t, envoySecret.GetValidationContext())
+}
+
 func TestHandleSecretEvent(t *testing.T) {
 	tests := []struct {
 		name                 string

--- a/pkg/envoy/secretsync_test.go
+++ b/pkg/envoy/secretsync_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 )
 
-func Test_k8sToEnvoySecret(t *testing.T) {
+func Test_k8sSecretToEnvoySecretTlsCertificate(t *testing.T) {
 	envoySecret := k8sToEnvoySecret(&slim_corev1.Secret{
 		ObjectMeta: slim_metav1.ObjectMeta{
 			Name:      "dummy-secret",
@@ -33,12 +33,29 @@ func Test_k8sToEnvoySecret(t *testing.T) {
 			"tls.crt": []byte{1, 2, 3},
 			"tls.key": []byte{4, 5, 6},
 		},
-		Type: "kubernetes.io/tls",
+		Type: slim_corev1.SecretTypeTLS,
 	})
 
 	require.Equal(t, "dummy-namespace/dummy-secret", envoySecret.Name)
 	require.Equal(t, []byte{1, 2, 3}, envoySecret.GetTlsCertificate().GetCertificateChain().GetInlineBytes())
 	require.Equal(t, []byte{4, 5, 6}, envoySecret.GetTlsCertificate().GetPrivateKey().GetInlineBytes())
+}
+
+func Test_k8sSecretToEnvoySecretValidationContext(t *testing.T) {
+	envoySecret := k8sToEnvoySecret(&slim_corev1.Secret{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "dummy-secret",
+			Namespace: "dummy-namespace",
+		},
+		Data: map[string]slim_corev1.Bytes{
+			"ca.crt": []byte{1, 2, 3},
+		},
+		Type: slim_corev1.SecretTypeOpaque,
+	})
+
+	require.Equal(t, "dummy-namespace/dummy-secret", envoySecret.Name)
+	require.Equal(t, []byte{1, 2, 3}, envoySecret.GetValidationContext().TrustedCa.GetInlineBytes())
+	require.Nil(t, envoySecret.GetTlsCertificate())
 }
 
 func TestHandleSecretEvent(t *testing.T) {


### PR DESCRIPTION
Currently, K8s -> Envoy secret sync only supports the following cases.

* K8s Secret of type `TLS` -> Envoy Secret of type `TLSCertificate`
* K8s Secret of type `Opaque` with key `ca.crt` -> Envoy Secret of type `CertificateValidationContext`

This commit adds support for the case where `TLSSessionTicketKeys`.

It requires a K8s Secret of type `Opaque` where the encryption key is stored in the data field with key `tls.sessionticket.key`.

In addition, there's support for 9 additional keys that are (in addition to the encryption key) to decrypt sessions (support for key rotation). These should be stored in the data field with keys `tls.sessionticket.key.[1-9]).

As per [Envoys documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-msg-extensions-transport-sockets-tls-v3-tlssessionticketkeys), each key needs to align with the following spec.

```
Each key must contain exactly 80 bytes of cryptographically-secure random data. For example, the output of openssl rand 80.
```

Note: In addition, this PR adds support for Envoy resource name-qualification and cilium xds config injection for TLS Session Ticket Keys implementation via SDS (TLS Downstreamcontext)