### PR TITLE
ingress: Avoid opening of port 80 for TLSPassthrough only

### DIFF
--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -46,6 +46,7 @@ func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 	var sourceResource model.FullyQualifiedResource
 	var modelService *model.Service
 	var cecName string
+	var tlsOnly bool
 
 	if len(m.HTTP) == 0 {
 		name = fmt.Sprintf("%s-%s", ciliumIngressPrefix, m.TLSPassthrough[0].Sources[0].Name)
@@ -53,6 +54,7 @@ func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 		sourceResource = m.TLSPassthrough[0].Sources[0]
 		modelService = m.TLSPassthrough[0].Service
 		cecName = fmt.Sprintf("%s-%s-%s", ciliumIngressPrefix, namespace, m.TLSPassthrough[0].Sources[0].Name)
+		tlsOnly = true
 	} else {
 		name = fmt.Sprintf("%s-%s", ciliumIngressPrefix, m.HTTP[0].Sources[0].Name)
 		namespace = m.HTTP[0].Sources[0].Namespace
@@ -71,29 +73,40 @@ func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 	// Set the name to avoid any breaking change during upgrade.
 	cec.Name = cecName
 
-	dedicatedService := d.getService(sourceResource, modelService)
+	dedicatedService := d.getService(sourceResource, modelService, tlsOnly)
 
 	return cec, dedicatedService, getEndpoints(sourceResource), err
 }
 
-func (d *dedicatedIngressTranslator) getService(resource model.FullyQualifiedResource, service *model.Service) *corev1.Service {
+func (d *dedicatedIngressTranslator) getService(resource model.FullyQualifiedResource, service *model.Service, tlsOnly bool) *corev1.Service {
 	serviceType := corev1.ServiceTypeLoadBalancer
 	clusterIP := ""
 	if d.hostNetworkEnabled {
 		serviceType = corev1.ServiceTypeClusterIP
 	}
 
-	ports := []corev1.ServicePort{
-		{
-			Name:     "http",
-			Protocol: "TCP",
-			Port:     80,
-		},
-		{
-			Name:     "https",
-			Protocol: "TCP",
-			Port:     443,
-		},
+	var ports []corev1.ServicePort
+	if tlsOnly {
+		ports = []corev1.ServicePort{
+			{
+				Name:     "https",
+				Protocol: "TCP",
+				Port:     443,
+			},
+		}
+	} else {
+		ports = []corev1.ServicePort{
+			{
+				Name:     "http",
+				Protocol: "TCP",
+				Port:     80,
+			},
+			{
+				Name:     "https",
+				Protocol: "TCP",
+				Port:     443,
+			},
+		}
 	}
 
 	if service != nil {


### PR DESCRIPTION
In TLSPassthrough only, port 80 is not required to be exposed in LB service.
