### PR TITLE
cilium-cli: call sysdump hooks on connectivity test failure

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -74,7 +74,7 @@ func RunE(hooks api.Hooks) func(cmd *cobra.Command, args []string) error {
 
 		logger := check.NewConcurrentLogger(params.Writer, params.TestConcurrency)
 
-		connTests, err := newConnectivityTests(params, logger)
+		connTests, err := newConnectivityTests(params, hooks, logger)
 		if err != nil {
 			return err
 		}
@@ -224,7 +224,11 @@ func registerCommonFlags(flags *pflag.FlagSet) {
 	flags.Var(&params.DeploymentAnnotations, "deployment-pod-annotations", "Add annotations to the connectivity pods, e.g. '{\"client\":{\"foo\":\"bar\"}}'")
 }
 
-func newConnectivityTests(params check.Parameters, logger *check.ConcurrentLogger) ([]*check.ConnectivityTest, error) {
+func newConnectivityTests(
+	params check.Parameters,
+	hooks api.Hooks,
+	logger *check.ConcurrentLogger,
+) ([]*check.ConnectivityTest, error) {
 	if params.TestConcurrency < 1 {
 		fmt.Printf("--test-concurrency parameter value is invalid [%d], using 1 instead\n", params.TestConcurrency)
 		params.TestConcurrency = 1
@@ -240,7 +244,7 @@ func newConnectivityTests(params check.Parameters, logger *check.ConcurrentLogge
 		}
 		params.ExternalDeploymentPort += i
 		params.EchoServerHostPort += i
-		cc, err := check.NewConnectivityTest(k8sClient, params, defaults.CLIVersion, logger)
+		cc, err := check.NewConnectivityTest(k8sClient, params, hooks, defaults.CLIVersion, logger)
 		if err != nil {
 			return nil, err
 		}

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -244,7 +244,7 @@ func newConnectivityTests(
 		}
 		params.ExternalDeploymentPort += i
 		params.EchoServerHostPort += i
-		cc, err := check.NewConnectivityTest(k8sClient, params, hooks, defaults.CLIVersion, logger)
+		cc, err := check.NewConnectivityTest(k8sClient, params, hooks, logger)
 		if err != nil {
 			return nil, err
 		}

--- a/cilium-cli/cli/connectivity_test.go
+++ b/cilium-cli/cli/connectivity_test.go
@@ -76,7 +76,7 @@ func TestNewConnectivityTests(t *testing.T) {
 	}
 	for _, tt := range testCases {
 		// function to test
-		actual, err := newConnectivityTests(tt.params, check.NewConcurrentLogger(&bytes.Buffer{}, 1))
+		actual, err := newConnectivityTests(tt.params, &api.NopHooks{}, check.NewConcurrentLogger(&bytes.Buffer{}, 1))
 
 		require.NoError(t, err)
 		require.Equal(t, tt.expectedCount, len(actual))

--- a/cilium-cli/cli/sysdump.go
+++ b/cilium-cli/cli/sysdump.go
@@ -49,12 +49,9 @@ func newCmdSysdump(hooks sysdump.Hooks) *cobra.Command {
 			// Silence klog to avoid displaying "throttling" messages - those are expected.
 			klog.SetOutput(io.Discard)
 			// Collect the sysdump.
-			collector, err := sysdump.NewCollector(k8sClient, sysdumpOptions, time.Now(), defaults.CLIVersion)
+			collector, err := sysdump.NewCollector(k8sClient, sysdumpOptions, hooks, time.Now(), defaults.CLIVersion)
 			if err != nil {
 				return fmt.Errorf("failed to create sysdump collector: %w", err)
-			}
-			if err := hooks.AddSysdumpTasks(collector); err != nil {
-				return fmt.Errorf("failed to add custom tasks: %w", err)
 			}
 			if err = collector.Run(); err != nil {
 				return fmt.Errorf("failed to collect sysdump: %w", err)

--- a/cilium-cli/cli/sysdump.go
+++ b/cilium-cli/cli/sysdump.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
-	"github.com/cilium/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium/cilium-cli/sysdump"
 )
 
@@ -49,7 +48,7 @@ func newCmdSysdump(hooks sysdump.Hooks) *cobra.Command {
 			// Silence klog to avoid displaying "throttling" messages - those are expected.
 			klog.SetOutput(io.Discard)
 			// Collect the sysdump.
-			collector, err := sysdump.NewCollector(k8sClient, sysdumpOptions, hooks, time.Now(), defaults.CLIVersion)
+			collector, err := sysdump.NewCollector(k8sClient, sysdumpOptions, hooks, time.Now())
 			if err != nil {
 				return fmt.Errorf("failed to create sysdump collector: %w", err)
 			}

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/cilium-cli/connectivity/perf/common"
 	"github.com/cilium/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium/cilium-cli/k8s"
+	"github.com/cilium/cilium/cilium-cli/sysdump"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
@@ -46,6 +47,8 @@ type ConnectivityTest struct {
 
 	// Parameters to the test suite, specified by the CLI user.
 	params Parameters
+
+	sysdumpHooks sysdump.Hooks
 
 	logger *ConcurrentLogger
 
@@ -189,7 +192,13 @@ func (ct *ConnectivityTest) failedActions() []*Action {
 }
 
 // NewConnectivityTest returns a new ConnectivityTest.
-func NewConnectivityTest(client *k8s.Client, p Parameters, version string, logger *ConcurrentLogger) (*ConnectivityTest, error) {
+func NewConnectivityTest(
+	client *k8s.Client,
+	p Parameters,
+	sysdumpHooks sysdump.Hooks,
+	version string,
+	logger *ConcurrentLogger,
+) (*ConnectivityTest, error) {
 	if err := p.validate(); err != nil {
 		return nil, err
 	}
@@ -197,6 +206,7 @@ func NewConnectivityTest(client *k8s.Client, p Parameters, version string, logge
 	k := &ConnectivityTest{
 		client:                   client,
 		params:                   p,
+		sysdumpHooks:             sysdumpHooks,
 		logger:                   logger,
 		version:                  version,
 		ciliumPods:               make(map[string]Pod),

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -52,9 +52,6 @@ type ConnectivityTest struct {
 
 	logger *ConcurrentLogger
 
-	// version is the version string of the cilium-cli itself
-	version string
-
 	// Clients for source and destination clusters.
 	clients *deploymentClients
 
@@ -196,7 +193,6 @@ func NewConnectivityTest(
 	client *k8s.Client,
 	p Parameters,
 	sysdumpHooks sysdump.Hooks,
-	version string,
 	logger *ConcurrentLogger,
 ) (*ConnectivityTest, error) {
 	if err := p.validate(); err != nil {
@@ -208,7 +204,6 @@ func NewConnectivityTest(
 		params:                   p,
 		sysdumpHooks:             sysdumpHooks,
 		logger:                   logger,
-		version:                  version,
 		ciliumPods:               make(map[string]Pod),
 		echoPods:                 make(map[string]Pod),
 		echoExternalPods:         make(map[string]Pod),

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -935,7 +935,7 @@ func (t *Test) EgressGatewayNode() string {
 
 func (t *Test) collectSysdump() {
 	for _, client := range t.ctx.Clients() {
-		collector, err := sysdump.NewCollector(client, t.ctx.params.SysdumpOptions, t.ctx.sysdumpHooks, time.Now(), t.ctx.version)
+		collector, err := sysdump.NewCollector(client, t.ctx.params.SysdumpOptions, t.ctx.sysdumpHooks, time.Now())
 		if err != nil {
 			t.Failf("Failed to create sysdump collector: %v", err)
 			return

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -935,13 +935,10 @@ func (t *Test) EgressGatewayNode() string {
 
 func (t *Test) collectSysdump() {
 	for _, client := range t.ctx.Clients() {
-		collector, err := sysdump.NewCollector(client, t.ctx.params.SysdumpOptions, time.Now(), t.ctx.version)
+		collector, err := sysdump.NewCollector(client, t.ctx.params.SysdumpOptions, t.ctx.sysdumpHooks, time.Now(), t.ctx.version)
 		if err != nil {
 			t.Failf("Failed to create sysdump collector: %v", err)
 			return
-		}
-		if err := t.ctx.sysdumpHooks.AddSysdumpTasks(collector); err != nil {
-			t.Failf("Failed to add custom sysdump tasks: %w", err)
 		}
 		if err = collector.Run(); err != nil {
 			t.Failf("Failed to collect sysdump: %v", err)

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -940,7 +940,9 @@ func (t *Test) collectSysdump() {
 			t.Failf("Failed to create sysdump collector: %v", err)
 			return
 		}
-
+		if err := t.ctx.sysdumpHooks.AddSysdumpTasks(collector); err != nil {
+			t.Failf("Failed to add custom sysdump tasks: %w", err)
+		}
 		if err = collector.Run(); err != nil {
 			t.Failf("Failed to collect sysdump: %v", err)
 		}

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -172,8 +172,14 @@ type Collector struct {
 }
 
 // NewCollector returns a new sysdump collector.
-func NewCollector(k KubernetesClient, o Options, startTime time.Time, cliVersion string) (*Collector, error) {
-	c := Collector{
+func NewCollector(
+	k KubernetesClient,
+	o Options,
+	hooks Hooks,
+	startTime time.Time,
+	cliVersion string,
+) (*Collector, error) {
+	c := &Collector{
 		Client:     k,
 		Options:    o,
 		startTime:  startTime,
@@ -293,7 +299,11 @@ func NewCollector(k KubernetesClient, o Options, startTime time.Time, cliVersion
 		}
 	}
 
-	return &c, nil
+	if err := hooks.AddSysdumpTasks(c); err != nil {
+		return nil, fmt.Errorf("failed to add custom sysdump tasks: %w", err)
+	}
+
+	return c, nil
 }
 
 // GatherResourceUnstructured queries resources with the given GroupVersionResource, storing them in the file specified by fname.

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -177,7 +177,6 @@ func NewCollector(
 	o Options,
 	hooks Hooks,
 	startTime time.Time,
-	cliVersion string,
 ) (*Collector, error) {
 	c := &Collector{
 		Client:     k,
@@ -197,7 +196,7 @@ func NewCollector(
 		return nil, err
 	}
 	c.logDebug("Using %v as a temporary directory", c.sysdumpDir)
-	c.logTask("Collecting sysdump with cilium-cli version: %s, args: %s", cliVersion, os.Args[1:])
+	c.logTask("Collecting sysdump with cilium-cli version: %s, args: %s", defaults.CLIVersion, os.Args[1:])
 
 	if c.Options.CiliumNamespace == "" {
 		ns, err := detectCiliumNamespace(k)

--- a/cilium-cli/sysdump/sysdump_test.go
+++ b/cilium-cli/sysdump/sysdump_test.go
@@ -54,7 +54,7 @@ func TestSysdumpCollector(t *testing.T) {
 	}
 	startTime := time.Unix(946713600, 0)
 	timestamp := startTime.Format(timeFormat)
-	collector, err := NewCollector(&client, options, &nopHooks{}, startTime, "cilium-cli-version")
+	collector, err := NewCollector(&client, options, &nopHooks{}, startTime)
 	assert.NoError(t, err)
 	assert.Equal(t, "my-sysdump-"+timestamp, path.Base(collector.sysdumpDir))
 	tempFile := collector.AbsoluteTempPath("my-file-<ts>")
@@ -76,7 +76,7 @@ func TestNodeList(t *testing.T) {
 			},
 		},
 	}
-	collector, err := NewCollector(&client, options, &nopHooks{}, time.Now(), "cilium-cli-version")
+	collector, err := NewCollector(&client, options, &nopHooks{}, time.Now())
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"node-a", "node-b", "node-c"}, collector.NodeList)
 
@@ -84,7 +84,7 @@ func TestNodeList(t *testing.T) {
 		Writer:   io.Discard,
 		NodeList: "node-a,node-c",
 	}
-	collector, err = NewCollector(&client, options, &nopHooks{}, time.Now(), "cilium-cli-version")
+	collector, err = NewCollector(&client, options, &nopHooks{}, time.Now())
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"node-a", "node-c"}, collector.NodeList)
 }
@@ -112,7 +112,7 @@ func TestAddTasks(t *testing.T) {
 			},
 		},
 	}
-	collector, err := NewCollector(&client, options, &nopHooks{}, time.Now(), "cilium-cli-version")
+	collector, err := NewCollector(&client, options, &nopHooks{}, time.Now())
 	assert.NoError(t, err)
 	assert.Len(t, collector.additionalTasks, 0)
 	collector.AddTasks([]Task{{}, {}, {}})
@@ -120,7 +120,7 @@ func TestAddTasks(t *testing.T) {
 	collector.AddTasks([]Task{{}, {}, {}})
 	assert.Len(t, collector.additionalTasks, 6)
 
-	collector, err = NewCollector(&client, options, &extendingHooks{}, time.Now(), "cilium-cli-version")
+	collector, err = NewCollector(&client, options, &extendingHooks{}, time.Now())
 	assert.NoError(t, err)
 	assert.Len(t, collector.additionalTasks, 1)
 	assert.Equal(t, collector.additionalTasks[0].Description, "extended")
@@ -206,7 +206,7 @@ func TestKVStoreTask(t *testing.T) {
 		OutputFileName: "my-sysdump-<ts>",
 		Writer:         io.Discard,
 	}
-	collector, err := NewCollector(client, options, &nopHooks{}, time.Now(), "cilium-cli-version")
+	collector, err := NewCollector(client, options, &nopHooks{}, time.Now())
 	assert.NoError(err)
 	collector.submitKVStoreTasks(context.Background(), &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
The first commit ensures sysdump task hooks are registered also for sysdump captures on connectivity test failure, i.e. with `cilium connectivity test --collect-sysdump-on-failure`. 
The second commit slightly refactors the code base so the sysdump task extension is done during instantiation of the sysdump collector, avoiding cases like fixed in the first commit. It also adds some test coverage for the sysdump task hook registration mechanism.
The third commit simplifies some code wrt. CLI version.

See commit messages for details.
