### PR TITLE
bpf: Fix `Prune` map operation leaking BPF map entries

### DIFF
--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -33,12 +33,19 @@ const (
 type TestKey struct {
 	Key uint32
 }
+type TestLPMKey struct {
+	PrefixLen uint32
+	Key       uint32
+}
 type TestValue struct {
 	Value uint32
 }
 
 func (k *TestKey) String() string { return fmt.Sprintf("key=%d", k.Key) }
 func (k *TestKey) New() MapKey    { return &TestKey{} }
+
+func (k *TestLPMKey) String() string { return fmt.Sprintf("len=%d, key=%d", k.PrefixLen, k.Key) }
+func (k *TestLPMKey) New() MapKey    { return &TestLPMKey{} }
 
 func (v *TestValue) String() string { return fmt.Sprintf("value=%d", v.Value) }
 func (v *TestValue) New() MapValue  { return &TestValue{} }


### PR DESCRIPTION
This fixes a bug in the `mapOps.Prune` implementation where it leaked entries during the prune operation. The cause for this was that the `Prune` implementation deleted entries while iterating over them, causing it to skip iterations at least in LPM tries.

This commit fixes the issue by first collecting all keys to delete, and then deleting them in a second phase. A unit test which produces the faulty behavior before the fix is also added to ensure we do not regress on this.