### PR TITLE
CI-Runtime: Allow passing extra cilium options.

### DIFF
--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -336,7 +336,8 @@ jobs:
 
       - name: Install Cilium on VM
         run: |
-          cilium clustermesh vm install install-external-workload.sh --config debug
+          extra_args=${{ env.CILIUM_RUNTIME_EXTRA_ARGS }}
+          cilium clustermesh vm install install-external-workload.sh --config debug$([ ! -z $extra_args ] && echo ",${extra_args}")
           gcloud compute scp install-external-workload.sh ${{ env.vmName }}-${{ matrix.vmIndex }}:~/ --zone ${{ matrix.zone }}
           gcloud compute ssh ${{ env.vmName }}-${{ matrix.vmIndex }} --zone ${{ matrix.zone }} \
             --command "~/install-external-workload.sh"

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -370,7 +370,8 @@ jobs:
           -cilium.hubble-relay-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
           -cilium.hubble-relay-tag=${{ steps.vars.outputs.sha }} \
           -cilium.operator-suffix=-ci \
-          -cilium.SSHConfig="cat ./cilium-ssh-config.txt"
+          -cilium.SSHConfig="cat ./cilium-ssh-config.txt" \
+          -cilium.extra-opts="${{ env.CILIUM_RUNTIME_EXTRA_ARGS }}"
 
       - name: Runtime privileged tests
         if: ${{ matrix.focus == 'privileged' }}

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -337,7 +337,7 @@ jobs:
             export VMUSER=root
             echo '127.0.0.1 localhost' >> /etc/hosts
             echo '::1 localhost' >> /etc/hosts
-            /tmp/provision/runtime_install.sh
+            /tmp/provision/runtime_install.sh ${{ env.CILIUM_RUNTIME_EXTRA_ARGS }}
             service docker restart
 
       - name: Runtime tests

--- a/contrib/systemd/cilium
+++ b/contrib/systemd/cilium
@@ -23,6 +23,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
 # Check more cli options using cilium-agent -h
 CILIUM_IMAGE=cilium/cilium:latest
 CILIUM_OPTS=--kvstore etcd --kvstore-opt etcd.address=127.0.0.1:4001
+CILIUM_EXTRA_OPTS=
 CILIUM_OPERATOR_OPTS=--kvstore etcd --kvstore-opt etcd.address=127.0.0.1:4001 --k8s-kubeconfig-path=/home/vagrant/.kube/config
 
 HOME=/home/vagrant

--- a/contrib/systemd/cilium.service
+++ b/contrib/systemd/cilium.service
@@ -7,7 +7,7 @@ Requires=docker.service cilium-docker.service
 Type=simple
 LimitCORE=infinity
 EnvironmentFile=-/etc/sysconfig/cilium
-ExecStart=/usr/bin/cilium-agent $CILIUM_OPTS
+ExecStart=/usr/bin/cilium-agent $CILIUM_OPTS $CILIUM_EXTRA_OPTS
 Restart=on-failure
 
 [Install]

--- a/contrib/systemd/cilium.service-with-docker
+++ b/contrib/systemd/cilium.service-with-docker
@@ -9,7 +9,7 @@ RemainAfterExit=yes
 TimeoutStartSec=0
 LimitCORE=infinity
 EnvironmentFile=-/etc/sysconfig/cilium
-ExecStart=/usr/bin/docker-run-cilium $CILIUM_OPTS
+ExecStart=/usr/bin/docker-run-cilium $CILIUM_OPTS $CILIUM_EXTRA_OPTS
 ExecStop=-/usr/bin/docker-run-cilium uninstall
 
 [Install]

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -41,6 +41,7 @@ type CiliumTestConfigType struct {
 	KubectlPath          string
 	RegistryCredentials  string
 	InstallHelmOverrides string
+	CiliumExtraOpts      string
 
 	// Multinode enables the running of tests that involve more than one
 	// node. If false, some tests will silently skip multinode checks.
@@ -102,6 +103,9 @@ func (c *CiliumTestConfigType) ParseFlags() {
 	flagset.StringVar(&c.InstallHelmOverrides, "cilium.install-helm-overrides", "",
 		"Comma separated list of cilium install helm --set overrides. "+
 			"*note*: This will take precedence over any other value set by the tests")
+	flagset.StringVar(&c.CiliumExtraOpts, "cilium.extra-opts", "",
+		"Extra options to pass to cilium install command, options will be passed as is to cilium-agent command "+
+			"for tests that start cilium directly.")
 
 	args := make([]string, 0, len(os.Args))
 	for index, flag := range os.Args {

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -779,6 +779,9 @@ func (s *SSHMeta) SetUpCiliumWithOptions(ciliumOpts string) error {
 	ciliumOpts += " --exclude-local-address=" + DockerBridgeIP + "/32"
 	ciliumOpts += " --exclude-local-address=" + FakeIPv4WorldAddress + "/32"
 	ciliumOpts += " --exclude-local-address=" + FakeIPv6WorldAddress + "/128"
+	if config.CiliumTestConfig.CiliumExtraOpts != "" {
+		ciliumOpts += " " + config.CiliumTestConfig.CiliumExtraOpts
+	}
 
 	// Get the current CILIUM_IMAGE from the service definition
 	res := s.Exec("grep CILIUM_IMAGE= /etc/sysconfig/cilium")

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+CILIUM_EXTRA_OPTS=${@}
+
 export CILIUM_DS_TAG="k8s-app=cilium"
 export KUBE_SYSTEM_NAMESPACE="kube-system"
 export KUBECTL="/usr/bin/kubectl"
@@ -132,7 +134,9 @@ else
     sudo cp ${PROVISIONSRC}/docker-run-cilium.sh /usr/bin/docker-run-cilium
 
     sudo mkdir -p /etc/sysconfig/
-    sed -e "s|CILIUM_IMAGE[^[:space:]]*$|CILIUM_IMAGE=${CILIUM_IMAGE}|" -e "s|HOME=/home/vagrant|HOME=/home/${VMUSER}|" contrib/systemd/cilium | sudo tee /etc/sysconfig/cilium
+    sed -e "s|CILIUM_IMAGE[^[:space:]]*$|CILIUM_IMAGE=${CILIUM_IMAGE}|" \
+        -e "s|HOME=/home/vagrant|HOME=/home/${VMUSER}|" \
+        -e "s|CILIUM_EXTRA_OPTS=.*|CILIUM_EXTRA_OPTS=${CILIUM_EXTRA_OPTS}|" contrib/systemd/cilium | sudo tee /etc/sysconfig/cilium
 
     sudo cp -f contrib/systemd/*.* /etc/systemd/system/
     # Use dockerized Cilium with runtime tests

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+CILIUM_EXTRA_OPTS=${@}
+
 if ! [[ -z $DOCKER_LOGIN && -z $DOCKER_PASSWORD ]]; then
     echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_LOGIN}" --password-stdin
 fi
@@ -31,7 +33,7 @@ cat /etc/resolv.conf
 service docker restart
 
 if [[ "${PROVISION_EXTERNAL_WORKLOAD}" == "false" ]]; then
-    "${PROVISIONSRC}"/compile.sh
+    "${PROVISIONSRC}"/compile.sh ${CILIUM_EXTRA_OPTS}
     "${PROVISIONSRC}"/wait-cilium-in-docker.sh
 else
     "${PROVISIONSRC}"/externalworkload_install.sh

--- a/test/provision/wait-cilium-in-docker.sh
+++ b/test/provision/wait-cilium-in-docker.sh
@@ -6,6 +6,7 @@ for ((i = 0 ; i < 12; i++)); do
         break
     fi
     sleep 5s
+    docker logs cilium | tail --lines=10
     echo "Waiting for Cilium daemon to come up..."
 done
 

--- a/test/provision/wait-cilium.sh
+++ b/test/provision/wait-cilium.sh
@@ -10,6 +10,7 @@ main() {
             break
         fi
         sleep 5s
+        docker logs cilium | tail --lines=10
         echo "Waiting for Cilium daemon to come up..."
     done
 


### PR DESCRIPTION
This change allows passing down of additional cilium options through various ci-runtime and ci-externalworkloads install paths.  This is exposed via the environment variable `${{ env.CILIUM_RUNTIME_EXTRA_ARGS }}` which allows for forked projects to pass their own option flags to ci-runtime tests.