### PR TITLE
bpf: ipsec: select fresh SPI when falling back to TUNNEL_MAP

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -384,7 +384,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		key.ip6.p4 = 0;
 		key.family = ENDPOINT_KEY_IPV6;
 
-		ret = encap_and_redirect_netdev(ctx, &key, encrypt_key, secctx, &trace);
+		ret = encap_and_redirect_netdev(ctx, &key, from_proxy, secctx, &trace);
 		if (ret != DROP_NO_TUNNEL_ENDPOINT)
 			return ret;
 	}
@@ -834,7 +834,7 @@ skip_vtep:
 		key.family = ENDPOINT_KEY_IPV4;
 
 		cilium_dbg(ctx, DBG_NETDEV_ENCAP4, key.ip4, secctx);
-		ret = encap_and_redirect_netdev(ctx, &key, encrypt_key, secctx, &trace);
+		ret = encap_and_redirect_netdev(ctx, &key, from_proxy, secctx, &trace);
 		if (ret != DROP_NO_TUNNEL_ENDPOINT)
 			return ret;
 	}

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -170,7 +170,7 @@ encap_and_redirect_lxc(struct __ctx_buff *ctx,
 
 static __always_inline int
 encap_and_redirect_netdev(struct __ctx_buff *ctx, struct tunnel_key *k,
-			  __u8 encrypt_key __maybe_unused,
+			  bool check_encrypt __maybe_unused,
 			  __u32 seclabel, const struct trace_ctx *trace)
 {
 	struct tunnel_value *tunnel;
@@ -180,9 +180,13 @@ encap_and_redirect_netdev(struct __ctx_buff *ctx, struct tunnel_key *k,
 		return DROP_NO_TUNNEL_ENDPOINT;
 
 #ifdef ENABLE_IPSEC
-	if (encrypt_key)
-		return set_ipsec_encrypt(ctx, encrypt_key, tunnel->ip4,
-					 seclabel, true, false);
+	if (check_encrypt && tunnel->key) {
+		__u8 encrypt_key = get_min_encrypt_key(tunnel->key);
+
+		if (encrypt_key)
+			return set_ipsec_encrypt(ctx, encrypt_key, tunnel->ip4,
+						 seclabel, true, false);
+	}
 #endif
 
 	return encap_and_redirect_with_nodeid(ctx, tunnel->ip4, 0, seclabel, 0,


### PR DESCRIPTION
If for some reason we fall back to the TUNNEL_MAP to select the remote tunnel_endpoint, respect the SPI in the map entry. And discard whatever SPI was selected earlier based on the ipcache entry.