### PR TITLE
Add an experimental xDS client

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -619,6 +619,7 @@ Makefile* @cilium/build
 /pkg/wireguard @cilium/wireguard
 /pkg/version/ @cilium/sig-agent
 /pkg/versioncheck/ @cilium/sig-agent
+/pkg/xds/ @cilium/envoy
 /plugins/cilium-cni/ @cilium/sig-k8s
 /plugins/cilium-docker/ @cilium/docker
 /README.rst @cilium/docs-structure

--- a/pkg/envoy/xds/cache.go
+++ b/pkg/envoy/xds/cache.go
@@ -59,11 +59,11 @@ func NewCache() *Cache {
 	}
 }
 
-// tx inserts/updates a set of resources, then deletes a set of resources, then
+// TX inserts/updates a set of resources, then deletes a set of resources, then
 // increases the cache's version number atomically if the cache is actually
 // changed.
 // The version after updating the set is returned.
-func (c *Cache) tx(typeURL string, upsertedResources map[string]proto.Message, deletedNames []string) (version uint64, updated bool, revert ResourceMutatorRevertFunc) {
+func (c *Cache) TX(typeURL string, upsertedResources map[string]proto.Message, deletedNames []string) (version uint64, updated bool, revert ResourceMutatorRevertFunc) {
 	c.locker.Lock()
 	defer c.locker.Unlock()
 
@@ -141,7 +141,7 @@ func (c *Cache) tx(typeURL string, upsertedResources map[string]proto.Message, d
 		c.NotifyNewResourceVersionRLocked(typeURL, c.version)
 
 		revert = func() (version uint64, updated bool) {
-			version, updated, _ = c.tx(typeURL, revertUpsertedResources, revertDeletedNames)
+			version, updated, _ = c.TX(typeURL, revertUpsertedResources, revertDeletedNames)
 			return
 		}
 	} else {
@@ -152,11 +152,11 @@ func (c *Cache) tx(typeURL string, upsertedResources map[string]proto.Message, d
 }
 
 func (c *Cache) Upsert(typeURL string, resourceName string, resource proto.Message) (version uint64, updated bool, revert ResourceMutatorRevertFunc) {
-	return c.tx(typeURL, map[string]proto.Message{resourceName: resource}, nil)
+	return c.TX(typeURL, map[string]proto.Message{resourceName: resource}, nil)
 }
 
 func (c *Cache) Delete(typeURL string, resourceName string) (version uint64, updated bool, revert ResourceMutatorRevertFunc) {
-	return c.tx(typeURL, nil, []string{resourceName})
+	return c.TX(typeURL, nil, []string{resourceName})
 }
 
 func (c *Cache) Clear(typeURL string) (version uint64, updated bool) {

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -519,7 +519,7 @@ func TestUpdateRequestResources(t *testing.T) {
 	}()
 
 	// Create version 2 with resources 0 and 1.
-	v, mod, _ = cache.tx(typeURL, map[string]proto.Message{
+	v, mod, _ = cache.TX(typeURL, map[string]proto.Message{
 		resources[0].Name: resources[0],
 		resources[1].Name: resources[1],
 	}, nil)

--- a/pkg/xds/experimental/client/cell.go
+++ b/pkg/xds/experimental/client/cell.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xdsclient
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/cilium/cilium/pkg/node"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	corepb "github.com/cilium/proxy/go/envoy/config/core/v3"
+	"github.com/spf13/pflag"
+	"google.golang.org/grpc"
+
+	core_v1 "k8s.io/api/core/v1"
+)
+
+type Config struct {
+	ServerAddr string `mapstructure:"xds-server-address"`
+	UseSOTW    bool   `mapstructure:"xds-use-sotw-protocol"`
+	NodeID     string `mapstructure:"xds-node-id"`
+}
+
+var defaultConfig = Config{
+	ServerAddr: "",
+	UseSOTW:    true,
+	NodeID:     "",
+}
+
+type DialOptionsProvider interface {
+	GRPCOptions(context.Context) ([]grpc.DialOption, error)
+}
+
+type NodeProvider interface {
+	Node(nodeID, zone string) *corepb.Node
+}
+
+// Cell defines a new module for xDS client.
+// Cell requires providing:
+// * DialOptionsProvider for configuring Dial Options for gRPC connection.
+// * NodeProvider for building xds Node
+var Cell = cell.Module(
+	"xds-client",
+	"Client library handling xds DiscoveryRequests with gRPC transport protocol",
+
+	cell.Provide(newConnectionOptions),
+	cell.Provide(newXDSClient),
+	cell.Invoke(runXDSClient),
+	cell.Config(defaultConfig),
+)
+
+// Flags implements Flagger interface
+func (conf Config) Flags(flags *pflag.FlagSet) {
+	flags.String("xds-server-address", conf.ServerAddr, "Address of xDS server")
+	flags.Bool("xds-use-sotw-protocol", conf.UseSOTW, "Use State Of The World, non-incremental version of xDS protocol")
+	flags.String("xds-node-id", conf.NodeID, "NodeID for xDS client")
+}
+
+type input struct {
+	cell.In
+
+	Config              Config
+	ConnectionConfig    ConnectionOptions
+	JobGroup            job.Group
+	GRPCOptionsProvider DialOptionsProvider
+	NodeBuilder         NodeProvider
+	Log                 *slog.Logger
+	LocalNodeStore      *node.LocalNodeStore
+}
+
+func newConnectionOptions() ConnectionOptions {
+	return Defaults
+}
+
+// newXDSClient creates and a new instance of xDS client. XDS Server Address is
+// required to create the client.
+func newXDSClient(in input) (Client, error) {
+	in.Log.Info("Init XDS client", "address", in.Config.ServerAddr)
+	if in.Config.ServerAddr == "" {
+		// Disabled
+		return nil, fmt.Errorf("xDS Server address was not provided")
+	}
+	return NewClient(in.Log, in.Config.UseSOTW, &in.ConnectionConfig), nil
+}
+
+// runXDSClient adds a one shot job to wait for other dependencies to be
+// initialized to create gRPC connection and run the client. When all
+// dependencies are initialized the client is started.
+func runXDSClient(in input, cl Client) {
+	in.JobGroup.Add(job.OneShot("xds-client-run", func(ctx context.Context, _ cell.Health) error {
+		localNode, err := in.LocalNodeStore.Get(context.TODO())
+		if err != nil {
+			return fmt.Errorf("Failed to get LocalNodeStore: %w", err)
+		}
+		zone := localNode.Labels[core_v1.LabelTopologyZone]
+		in.Log.Info("Get local node", "zone", zone)
+		if zone == "" {
+			return fmt.Errorf("zone is nil")
+		}
+		nodeID := localNode.Name
+		if in.Config.NodeID != "" {
+			nodeID = in.Config.NodeID
+		}
+
+		node := in.NodeBuilder.Node(nodeID, zone)
+		gOps, err := in.GRPCOptionsProvider.GRPCOptions(ctx)
+		if err != nil {
+			return fmt.Errorf("Error providing Options for GRPC connection: %w", err)
+		}
+		conn, err := grpc.NewClient(in.Config.ServerAddr, gOps...)
+		if err != nil {
+			return fmt.Errorf("Failed to create grpc Client: %w", err)
+		}
+		defer conn.Close()
+		in.Log.Info("Successfully run xDS client")
+		return cl.Run(ctx, node, conn)
+	},
+		job.WithRetry(3, &job.ExponentialBackoff{Min: 1 * time.Second, Max: 5 * time.Minute}),
+	))
+}

--- a/pkg/xds/experimental/client/cell_test.go
+++ b/pkg/xds/experimental/client/cell_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+package xdsclient
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/node"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+
+	discoverypb "github.com/cilium/proxy/go/envoy/service/discovery/v3"
+	core_v1 "k8s.io/api/core/v1"
+)
+
+func TestCell_SuccessfullyRunClient(t *testing.T) {
+	var testXDSClient Client
+	hLog := hivetest.Logger(t)
+	nodeId := "xds-test-node-id"
+	h := hive.New(
+		cell.Provide(NewDefaultNodeProvider),
+		cell.Provide(NewInsecureGRPCOptionsProvider),
+		node.LocalNodeStoreCell,
+		Cell,
+		cell.Invoke(func(localNodeStore *node.LocalNodeStore) {
+			localNodeStore.Update(func(n *node.LocalNode) {
+				hLog.Info("Update localNodeStore")
+				n.Name = "node1"
+				if n.Labels == nil {
+					n.Labels = make(map[string]string)
+				}
+				n.Labels[core_v1.LabelTopologyZone] = "zone"
+			})
+
+		}),
+		cell.Invoke(func(c Client) { testXDSClient = c }),
+	)
+	hive.AddConfigOverride(
+		h,
+		func(cfg *Config) {
+			cfg.ServerAddr = "dns:///fake-server.com:443"
+			cfg.NodeID = nodeId
+		})
+
+	if err := h.Populate(hLog); err != nil {
+		t.Fatalf("Failed to populate: %s", err)
+	}
+
+	if err := h.Start(hLog, context.TODO()); err != nil {
+		t.Fatalf("Failed to start: %s", err)
+	}
+	t.Cleanup(func() {
+		if err := h.Stop(hLog, context.TODO()); err != nil {
+			t.Fatalf("Failed to stop: %s", err)
+		}
+	})
+
+	if testXDSClient == nil {
+		t.Fatalf("XDS client is nil")
+	}
+	sotwClient := testXDSClient.(*XDSClient[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse])
+	if sotwClient == nil {
+		t.Errorf("Client is not state of the world xDS client")
+	}
+	checkFn := func() error {
+		if sotwClient.node == nil {
+			return fmt.Errorf("Node for xDS client was not set")
+		}
+		return nil
+	}
+	waitForCondition(context.Background(), t, checkFn)
+	if sotwClient.node.Id != nodeId {
+		t.Fatalf("NodeId mismatch: got %v, want %v", sotwClient.node.Id, nodeId)
+	}
+}
+
+func TestCell_NoServerProvided(t *testing.T) {
+	var testXDSClient Client
+	hLog := hivetest.Logger(t)
+	h := hive.New(
+		cell.Provide(NewDefaultNodeProvider),
+		cell.Provide(NewInsecureGRPCOptionsProvider),
+		node.LocalNodeStoreCell,
+		Cell,
+		cell.Invoke(func(localNodeStore *node.LocalNodeStore) {
+			localNodeStore.Update(func(n *node.LocalNode) {
+				hLog.Info("Update localNodeStore")
+				n.Name = "node1"
+				if n.Labels == nil {
+					n.Labels = make(map[string]string)
+				}
+				n.Labels[core_v1.LabelTopologyZone] = "zone"
+			})
+
+		}),
+		cell.Invoke(func(c Client) { testXDSClient = c }),
+	)
+
+	if err := h.Start(hLog, context.TODO()); err == nil {
+		t.Fatal("hive start should failed due to server misconfiguration")
+	}
+	t.Cleanup(func() {
+		if err := h.Stop(hLog, context.TODO()); err != nil {
+			t.Fatalf("Failed to stop: %s", err)
+		}
+	})
+
+	if testXDSClient != nil {
+		t.Fatalf("XDS client should be nil")
+	}
+}

--- a/pkg/xds/experimental/client/client.go
+++ b/pkg/xds/experimental/client/client.go
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xdsclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/cilium/cilium/pkg/backoff"
+	"github.com/cilium/cilium/pkg/envoy/xds"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+
+	corepb "github.com/cilium/proxy/go/envoy/config/core/v3"
+	discoverypb "github.com/cilium/proxy/go/envoy/service/discovery/v3"
+)
+
+// requestConstraint is a constraint for request messages in xDS protocol.
+type requestConstraint interface {
+	*discoverypb.DiscoveryRequest | *discoverypb.DeltaDiscoveryRequest
+}
+
+// responseConstraint is a constraint for response messages in xDS protocol.
+type responseConstraint interface {
+	*discoverypb.DiscoveryResponse | *discoverypb.DeltaDiscoveryResponse
+	GetTypeUrl() string
+}
+
+// transport is a common generic interface of xDS gRPC client.
+type transport[req requestConstraint, resp responseConstraint] interface {
+	Send(req) error
+	Recv() (resp, error)
+}
+
+// nameToResource maps a resource name to a proto representation of the resource.
+type nameToResource map[string]proto.Message
+
+// tx represents a transaction prepared based on {Delta,}DiscoveryResponse.
+type tx struct {
+	typeUrl string
+	updated nameToResource
+	deleted []string
+}
+
+type txs []tx
+
+// getter specifies function to retrieve all resources of given type url.
+type getter func(typeUrl string) (*xds.VersionedResources, error)
+
+// flavour specifies a common interface for implementations specific to sotw or
+// delta protocol version. It is primarily used by XDSClient.
+type flavour[ReqT requestConstraint, RespT responseConstraint] interface {
+	// transport constructs an instance of a transport based on the provided xDS ADS gRPC client.
+	transport(ctx context.Context, client discoverypb.AggregatedDiscoveryServiceClient) (transport[ReqT, RespT], error)
+
+	// prepareObsReq creates a request based on parameters used in Observe calls.
+	// get may be used to obtain the current contents of clients cache.
+	prepareObsReq(obsReq *observeRequest, node *corepb.Node, get getter) (request ReqT, err error)
+
+	// tx prepares a list of transactions based on a given response.
+	// get may be used to obtain the current contents of clients cache.
+	tx(resp RespT, get getter) (transactions txs, err error)
+
+	// ack constructs request serving as ACKnowledgment of the given response.
+	ack(node *corepb.Node, resp RespT, resourceNames []string) (request ReqT)
+
+	// nack constructs request serving to inform the xDS server that their last
+	// response was Not ACKnowledged.
+	nack(node *corepb.Node, resp RespT, detail error) (request ReqT)
+}
+
+// Client is the public interface of xDS client.
+type Client interface {
+	// Observe adds resources of given type url and names to the attention set
+	// of the client.
+	Observe(ctx context.Context, typeUrl string, resourceNames []string) error
+
+	// AddResourceWatcher registers a callback cb that will be invoked every
+	// time a resource with given type url changes. Function returns a callback
+	// to deregister the watcher.
+	AddResourceWatcher(typeUrl string, cb WatcherCallback) func()
+
+	// Run initialize the node and start an AggregatedDiscoverService stream.
+	// Requests and responses are processed until provided Context ctx is
+	// done or non-retriable error occurs.
+	Run(ctx context.Context, node *corepb.Node, conn grpc.ClientConnInterface) error
+}
+
+// XDSClient implements Client.
+var _ Client = (*XDSClient[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse])(nil)
+var _ Client = (*XDSClient[*discoverypb.DeltaDiscoveryRequest, *discoverypb.DeltaDiscoveryResponse])(nil)
+
+// observeRequest is an internal representation of call to Observe method.
+type observeRequest struct {
+	// For example: "type.googleapis.com/envoy.config.listener.v3.Listener"
+	typeUrl       string
+	resourceNames []string
+}
+
+// XDSClient is a common part of xDS gRPC client implementation using flavour to
+// implement xDS protocol version specific behaviors.
+type XDSClient[ReqT requestConstraint, RespT responseConstraint] struct {
+	log  *slog.Logger
+	opts ConnectionOptions
+
+	observeQueue  chan *observeRequest
+	responseQueue chan RespT
+
+	node *corepb.Node
+	xds  flavour[ReqT, RespT]
+
+	// cache stores versioned resources.
+	cache *xds.Cache
+	// watchers manages callbacks with notification when cache state changes.
+	watchers *callbackManager
+}
+
+// NewClient creates a new instance of XDSClient using sotw or delta protocol
+// flavour based on options opts.
+func NewClient(log *slog.Logger, useSOTW bool, opts *ConnectionOptions) Client {
+	if useSOTW {
+		return newClient[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse](log, opts, &sotw{})
+	}
+	return newClient[*discoverypb.DeltaDiscoveryRequest, *discoverypb.DeltaDiscoveryResponse](log, opts, &delta{})
+}
+
+func newClient[ReqT requestConstraint, RespT responseConstraint](log *slog.Logger, opts *ConnectionOptions, flavour flavour[ReqT, RespT]) *XDSClient[ReqT, RespT] {
+	cache := xds.NewCache()
+
+	return &XDSClient[ReqT, RespT]{
+		log:           log,
+		opts:          *opts,
+		observeQueue:  make(chan *observeRequest, 1),
+		responseQueue: make(chan RespT, 1),
+		xds:           flavour,
+		cache:         cache,
+		watchers:      newCallbackManager(log.With(logfields.Hint, "watchers"), cache),
+	}
+}
+
+// Run initialize the node and start an AggregatedDiscoverService stream. Then
+// requests and responses are processed until provided Context ctx is done or
+// non-retriable error occurs.
+func (c *XDSClient[ReqT, RespT]) Run(ctx context.Context, node *corepb.Node, conn grpc.ClientConnInterface) error {
+	// node is used to identify a client to xDS server. Nodes's value is retried
+	// from LocalNodeStore and it needs to be late initialized.
+	c.node = proto.Clone(node).(*corepb.Node)
+	c.log.Info("starting xDS client with node", "Id", c.node.Id, "Cluster", c.node.Cluster, "Agent", c.node.UserAgentName)
+	backoff := backoff.Exponential{
+		Min:        c.opts.RetryBackoff.Min,
+		Max:        c.opts.RetryBackoff.Max,
+		ResetAfter: c.opts.RetryBackoff.Reset,
+		Jitter:     true,
+		Name:       "xds-client-conn",
+	}
+	client := discoverypb.NewAggregatedDiscoveryServiceClient(conn)
+
+	for {
+		err := c.process(ctx, client)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if !c.opts.RetryConnection {
+			return err
+		}
+		c.log.Error("Retrying connection", logfields.Error, err)
+		err = backoff.Wait(ctx)
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				return fmt.Errorf("connection retry backoff: %w", err)
+			}
+		}
+	}
+}
+
+// process creates a transport, sends initial requests and spins up two additional goroutines:
+//   - fetchResponses which passes objects from Recv calls onto a queue
+//   - loop which processes responses queued up by fetchResponses goroutine, and
+//     processes requests queued up by calls to Observe method
+//
+// If any of the goroutines fails with non-retryable error, or terminates, it
+// will stop the transport (by cancelling its context) and wait for all
+// goroutines started by it to finish processing.
+func (c *XDSClient[ReqT, RespT]) process(parentCtx context.Context, client discoverypb.AggregatedDiscoveryServiceClient) error {
+	ctx, cancel := context.WithCancel(parentCtx)
+
+	trans, err := c.xds.transport(ctx, client)
+	if err != nil {
+		cancel()
+		return fmt.Errorf("start transport: %w", err)
+	}
+
+	errRespCh := make(chan error, 1)
+	go c.fetchResponses(ctx, errRespCh, trans)
+	errLoopCh := make(chan error, 1)
+	go c.loop(ctx, errLoopCh, trans)
+
+	defer func() {
+		cancel()
+		<-errLoopCh
+		<-errRespCh
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err, ok := <-errRespCh:
+			if !ok {
+				return fmt.Errorf("process responses: terminated")
+			}
+			if c.isRetriableErr(err) {
+				continue
+			}
+			return fmt.Errorf("process responses: %w", err)
+		case err, ok := <-errLoopCh:
+			if !ok {
+				return fmt.Errorf("process loop: terminated")
+			}
+			if c.isRetriableErr(err) {
+				continue
+			}
+			return fmt.Errorf("process loop: %w", err)
+		}
+	}
+}
+
+// isRetriableErr checks if the connection is not terminated and code is
+// temporary (configured with opts.IsRetriable).
+func (c *XDSClient[ReqT, RespT]) isRetriableErr(err error) bool {
+	if errors.Is(err, io.EOF) {
+		return false
+	}
+	return c.opts.IsRetriable(status.Code(err))
+}
+
+// fetchResponses will pass messages from Recv() calls to queue until Context ctx is done.
+func (c *XDSClient[ReqT, RespT]) fetchResponses(ctx context.Context, errCh chan error, trans transport[ReqT, RespT]) {
+	defer close(errCh)
+	log := c.log.With(logfields.Hint, "fetch-responses")
+	backoff := backoff.Exponential{
+		Min:        c.opts.RetryBackoff.Min,
+		Max:        c.opts.RetryBackoff.Max,
+		ResetAfter: c.opts.RetryBackoff.Reset,
+		Jitter:     true,
+		Name:       "xds-client-fetch-responses",
+	}
+	for {
+		resp, err := trans.Recv()
+		if err != nil {
+			log.Error("Failed to receive message", logfields.Error, err)
+			err = fmt.Errorf("recv: %w", err)
+			select {
+			case <-ctx.Done():
+				return
+			case errCh <- err:
+				backoff.Wait(ctx)
+			}
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case c.responseQueue <- resp:
+		}
+	}
+}
+
+func (c *XDSClient[ReqT, RespT]) getAllResources(typeUrl string) (*xds.VersionedResources, error) {
+	return c.cache.GetResources(typeUrl, 0, "", nil)
+}
+
+// Observe adds resourceNames to watched resources of a given typeUrl.
+// It will be sent to a server asynchronously.
+func (c *XDSClient[ReqT, RespT]) Observe(ctx context.Context, typeUrl string, resourceNames []string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case c.observeQueue <- &observeRequest{typeUrl: typeUrl, resourceNames: resourceNames}:
+	}
+	return nil
+}
+
+// loop will process responses from transport trans until Context ctx is done.
+// Errors are logged and processing continues.
+func (c *XDSClient[ReqT, RespT]) loop(ctx context.Context, errCh chan error, trans transport[ReqT, RespT]) {
+	defer close(errCh)
+	log := c.log.With(logfields.Hint, "loop")
+	backoff := backoff.Exponential{
+		Min:        c.opts.RetryBackoff.Min,
+		Max:        c.opts.RetryBackoff.Max,
+		ResetAfter: c.opts.RetryBackoff.Reset,
+		Jitter:     true,
+		Name:       "xds-client-loop",
+	}
+	log.Info("start processing loop")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case obsReq, ok := <-c.observeQueue:
+			log.Debug("got observe msg from the queue", logfields.Request, obsReq)
+			if !ok {
+				return
+			}
+			err := c.handleObserve(trans, obsReq)
+			if err != nil {
+				log.Error("Failed to handle observe",
+					logfields.Request, obsReq,
+					logfields.Error, err)
+				select {
+				case <-ctx.Done():
+					return
+				case errCh <- err:
+					backoff.Wait(ctx)
+				}
+			}
+		case resp, ok := <-c.responseQueue:
+			if !ok {
+				return
+			}
+			log.Debug("Receive", logfields.Response, resp)
+			err := c.handleResponse(trans, resp)
+			if err != nil {
+				log.Error("Failed to handle response", logfields.Error, err)
+				select {
+				case <-ctx.Done():
+					return
+				case errCh <- err:
+				}
+				req := c.xds.nack(c.node, resp, err)
+				err = trans.Send(req)
+				if err != nil {
+					log.Error("Failed to send NACK", logfields.Error, err)
+				}
+				backoff.Wait(ctx)
+			}
+		}
+	}
+}
+
+// handleObserve creates a flavour-specific request based on observeRequest and sends it on given transport trans.
+func (c *XDSClient[ReqT, RespT]) handleObserve(trans transport[ReqT, RespT], obsReq *observeRequest) error {
+	req, err := c.xds.prepareObsReq(obsReq, c.node, c.getAllResources)
+	if err != nil {
+		return fmt.Errorf("prepare observe request: %w", err)
+	}
+	c.log.Debug("Send", logfields.Request, req)
+
+	err = trans.Send(req)
+	if err != nil {
+		return fmt.Errorf("send: %w", err)
+	}
+	return nil
+}
+
+// handleResponse creates transactions based on flavour-specific responses, applies them to cache.
+func (c *XDSClient[ReqT, RespT]) handleResponse(trans transport[ReqT, RespT], resp RespT) error {
+	transactions, err := c.xds.tx(resp, c.getAllResources)
+	if err != nil {
+		return fmt.Errorf("tx: %w", err)
+	}
+	for _, transaction := range transactions {
+		c.log.Debug("cache TX: start", logfields.XDSTypeURL, transaction.typeUrl, "upserted", transaction.updated, "deleted", transaction.deleted)
+		ver, updated, _ := c.cache.TX(transaction.typeUrl, transaction.updated, transaction.deleted)
+		c.log.Debug("cache TX: end", transaction.typeUrl, transaction.typeUrl, logfields.XDSCachedVersion, ver, "updated", updated)
+	}
+	req := c.xds.ack(c.node, resp, nil)
+
+	c.log.Debug("Send", "req", req)
+	err = trans.Send(req)
+	if err != nil {
+		return fmt.Errorf("ACK send: %w", err)
+	}
+	return nil
+}
+
+func (c *XDSClient[ReqT, RespT]) AddResourceWatcher(typeUrl string, cb WatcherCallback) func() {
+	id := c.watchers.Add(typeUrl, cb)
+	cancel := func() {
+		c.watchers.Remove(id)
+
+	}
+	return cancel
+}

--- a/pkg/xds/experimental/client/client_delta.go
+++ b/pkg/xds/experimental/client/client_delta.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xdsclient
+
+import (
+	"context"
+	"fmt"
+
+	corepb "github.com/cilium/proxy/go/envoy/config/core/v3"
+	discoverypb "github.com/cilium/proxy/go/envoy/service/discovery/v3"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+type delta struct {
+}
+
+// delta implements flavour in delta protocol version.
+var _ flavour[*discoverypb.DeltaDiscoveryRequest, *discoverypb.DeltaDiscoveryResponse] = (*delta)(nil)
+
+// AggregatedDiscoveryService_DeltaAggregatedResourcesClient implements transport in delta protocol version.
+var _ transport[*discoverypb.DeltaDiscoveryRequest, *discoverypb.DeltaDiscoveryResponse] = (discoverypb.AggregatedDiscoveryService_DeltaAggregatedResourcesClient)(nil)
+
+func (delta *delta) transport(ctx context.Context, client discoverypb.AggregatedDiscoveryServiceClient) (transport[*discoverypb.DeltaDiscoveryRequest, *discoverypb.DeltaDiscoveryResponse], error) {
+	return client.DeltaAggregatedResources(ctx, grpc.WaitForReady(true))
+}
+
+func (delta *delta) prepareObsReq(obsReq *observeRequest, node *corepb.Node, _ getter) (*discoverypb.DeltaDiscoveryRequest, error) {
+	return &discoverypb.DeltaDiscoveryRequest{
+		Node:                   node,
+		TypeUrl:                obsReq.typeUrl,
+		ResourceNamesSubscribe: obsReq.resourceNames,
+	}, nil
+}
+
+func (delta *delta) tx(resp *discoverypb.DeltaDiscoveryResponse, _ getter) (txs, error) {
+	ret := make(nameToResource, len(resp.GetResources()))
+	for _, res := range resp.GetResources() {
+		name := res.GetName()
+		msg, _, err := parseResource(resp.GetTypeUrl(), res.GetResource())
+		if err != nil {
+			return nil, fmt.Errorf("parse resource: %w", err)
+		}
+		ret[name] = msg
+	}
+	return txs{{typeUrl: resp.GetTypeUrl(), updated: ret, deleted: resp.GetRemovedResources()}}, nil
+}
+
+func (delta *delta) ack(node *corepb.Node, resp *discoverypb.DeltaDiscoveryResponse, _ []string) *discoverypb.DeltaDiscoveryRequest {
+	return &discoverypb.DeltaDiscoveryRequest{
+		Node:          node,
+		ResponseNonce: resp.GetNonce(),
+		TypeUrl:       resp.GetTypeUrl(),
+	}
+}
+
+func (delta *delta) nack(node *corepb.Node, resp *discoverypb.DeltaDiscoveryResponse, detail error) *discoverypb.DeltaDiscoveryRequest {
+	return &discoverypb.DeltaDiscoveryRequest{
+		Node:          node,
+		ResponseNonce: resp.GetNonce(),
+		TypeUrl:       resp.GetTypeUrl(),
+		ErrorDetail: &statuspb.Status{
+			Code:    int32(codes.Unknown),
+			Message: detail.Error(),
+		},
+	}
+}

--- a/pkg/xds/experimental/client/client_sotw.go
+++ b/pkg/xds/experimental/client/client_sotw.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xdsclient
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+
+	corepb "github.com/cilium/proxy/go/envoy/config/core/v3"
+	discoverypb "github.com/cilium/proxy/go/envoy/service/discovery/v3"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/envoy"
+)
+
+type sotw struct {
+}
+
+// sotw implements flavour in sotw protocol version.
+var _ flavour[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse] = (*sotw)(nil)
+
+// AggregatedDiscoveryService_StreamAggregatedResourcesClient implements transport in sotw protocol version.
+var _ transport[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse] = (discoverypb.AggregatedDiscoveryService_StreamAggregatedResourcesClient)(nil)
+
+func (sotw *sotw) transport(ctx context.Context, client discoverypb.AggregatedDiscoveryServiceClient) (transport[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse], error) {
+	return client.StreamAggregatedResources(ctx, grpc.WaitForReady(true))
+}
+
+func (sotw *sotw) prepareObsReq(obsReq *observeRequest, node *corepb.Node, get getter) (*discoverypb.DiscoveryRequest, error) {
+	curr, err := get(obsReq.typeUrl)
+	if err != nil {
+		return nil, fmt.Errorf("get resources: %w", err)
+	}
+	reqResourceNames := sets.Set[string]{}
+	reqResourceNames.Insert(curr.ResourceNames...)
+	reqResourceNames.Insert(obsReq.resourceNames...)
+
+	return &discoverypb.DiscoveryRequest{
+		Node:          node,
+		TypeUrl:       obsReq.typeUrl,
+		ResourceNames: slices.Collect(maps.Keys(reqResourceNames)),
+	}, nil
+}
+
+func (sotw *sotw) tx(resp *discoverypb.DiscoveryResponse, get getter) (txs, error) {
+	typeUrl := resp.GetTypeUrl()
+	upsertedResources := make(nameToResource)
+	for _, res := range resp.GetResources() {
+		msg, name, err := parseResource(typeUrl, res)
+		if err != nil {
+			return nil, fmt.Errorf("parse resource: %w", err)
+		}
+		upsertedResources[name] = msg
+	}
+
+	var deletedResources []string
+	var err error
+	if typeUrl == envoy.ListenerTypeURL || typeUrl == envoy.ClusterTypeURL {
+		deletedResources, err = findMissing(typeUrl, upsertedResources, get)
+		if err != nil {
+			return nil, fmt.Errorf("delete listeners/clusters: %w", err)
+		}
+	}
+	transactions := txs{{typeUrl: typeUrl, updated: upsertedResources, deleted: deletedResources}}
+
+	if typeUrl == envoy.ClusterTypeURL {
+		deletedResources, err := findMissing(envoy.EndpointTypeURL, upsertedResources, get)
+		if err != nil {
+			return nil, fmt.Errorf("delete endpoints (after processing clusters): %w", err)
+		}
+		transactions = append(transactions, tx{typeUrl: envoy.EndpointTypeURL, deleted: deletedResources})
+	}
+	return transactions, nil
+}
+
+func findMissing(typeUrl string, curr nameToResource, get getter) ([]string, error) {
+	old, err := get(typeUrl)
+	if err != nil {
+		// In version 1.14 GetResources doesn't return any error for these arguments.
+		return nil, fmt.Errorf("get old resources: %w", err)
+	}
+	deletedResources := make([]string, 0, len(old.ResourceNames))
+	for _, name := range old.ResourceNames {
+		if _, ok := curr[name]; ok {
+			continue
+		}
+		deletedResources = append(deletedResources, name)
+	}
+	return deletedResources, nil
+}
+
+func (sotw *sotw) ack(node *corepb.Node, resp *discoverypb.DiscoveryResponse, resourceNames []string) *discoverypb.DiscoveryRequest {
+	return &discoverypb.DiscoveryRequest{
+		Node:          node,
+		VersionInfo:   resp.GetVersionInfo(),
+		ResponseNonce: resp.GetNonce(),
+		TypeUrl:       resp.GetTypeUrl(),
+		ResourceNames: resourceNames,
+	}
+}
+
+func (sotw *sotw) nack(node *corepb.Node, resp *discoverypb.DiscoveryResponse, detail error) *discoverypb.DiscoveryRequest {
+	return &discoverypb.DiscoveryRequest{
+		Node:          node,
+		ResponseNonce: resp.GetNonce(),
+		TypeUrl:       resp.GetTypeUrl(),
+		ErrorDetail: &statuspb.Status{
+			Code:    int32(codes.Unknown),
+			Message: detail.Error(),
+		},
+	}
+}

--- a/pkg/xds/experimental/client/client_test.go
+++ b/pkg/xds/experimental/client/client_test.go
@@ -1,0 +1,942 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xdsclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	clusterpb "github.com/cilium/proxy/go/envoy/config/cluster/v3"
+	corepb "github.com/cilium/proxy/go/envoy/config/core/v3"
+	endpointpb "github.com/cilium/proxy/go/envoy/config/endpoint/v3"
+	listenerpb "github.com/cilium/proxy/go/envoy/config/listener/v3"
+	routepb "github.com/cilium/proxy/go/envoy/config/route/v3"
+	discoverypb "github.com/cilium/proxy/go/envoy/service/discovery/v3"
+	"github.com/google/go-cmp/cmp"
+	"go.uber.org/goleak"
+	grpcStatus "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/anypb"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/cilium/cilium/pkg/envoy"
+	"github.com/cilium/cilium/pkg/envoy/xds"
+)
+
+const useSOTW = true
+
+var sotw2str = map[bool]string{true: "sotw", false: "delta"}
+
+func testNode() *corepb.Node {
+	return new(corepb.Node)
+}
+
+func TestHandleResponse_StoresInCache(t *testing.T) {
+	testCases := []struct {
+		name             string
+		initialListeners []*listenerpb.Listener
+		finalListeners   []*listenerpb.Listener
+		initialClusters  []*clusterpb.Cluster
+		finalClusters    []*clusterpb.Cluster
+		initialEndpoints []*endpointpb.ClusterLoadAssignment
+		finalEndpoints   []*endpointpb.ClusterLoadAssignment
+		initialRoutes    []*routepb.RouteConfiguration
+		finalRoutes      []*routepb.RouteConfiguration
+	}{
+		{
+			name: "One_Listener",
+			finalListeners: []*listenerpb.Listener{
+				{
+					Name: "example listener",
+				},
+			},
+		},
+		{
+			name: "Two_Listeners",
+			finalListeners: []*listenerpb.Listener{
+				{
+					Name: "example listener 1",
+				},
+				{
+					Name: "example listener 2",
+				},
+			},
+		},
+		{
+			name: "Updated_Listener",
+			initialListeners: []*listenerpb.Listener{
+				{
+					Name: "example listener",
+				},
+			},
+			finalListeners: []*listenerpb.Listener{
+				{
+					Name: "example listener",
+					Address: &corepb.Address{
+						Address: &corepb.Address_SocketAddress{
+							SocketAddress: &corepb.SocketAddress{
+								Protocol: *corepb.SocketAddress_TCP.Enum(),
+								Address:  "123.234.0.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "One_Cluster",
+			finalClusters: []*clusterpb.Cluster{
+				{
+					Name: "example cluster",
+				},
+			},
+		},
+		{
+			name: "Two_Clusters",
+			finalClusters: []*clusterpb.Cluster{
+				{
+					Name: "example cluster 1",
+				},
+				{
+					Name: "example cluster 2",
+				},
+			},
+		},
+		{
+			name: "Updated_Cluster",
+			initialClusters: []*clusterpb.Cluster{
+				{
+					Name: "example cluster",
+				},
+			},
+			finalClusters: []*clusterpb.Cluster{
+				{
+					Name:           "example cluster",
+					ConnectTimeout: durationpb.New(time.Second),
+				},
+			},
+		},
+		{
+			name: "One_Endpoint",
+			finalEndpoints: []*endpointpb.ClusterLoadAssignment{
+				{
+					ClusterName: "example endpoint",
+				},
+			},
+		},
+		{
+			name: "Two_Endpoints",
+			finalEndpoints: []*endpointpb.ClusterLoadAssignment{
+				{
+					ClusterName: "example endpoint 1",
+				},
+				{
+					ClusterName: "example endpoint 2",
+				},
+			},
+		},
+		{
+			name: "Updated_Endpoint",
+			initialEndpoints: []*endpointpb.ClusterLoadAssignment{
+				{
+					ClusterName: "example endpoint",
+				},
+			},
+			finalEndpoints: []*endpointpb.ClusterLoadAssignment{
+				{
+					ClusterName: "example endpoint",
+					Policy: &endpointpb.ClusterLoadAssignment_Policy{
+						EndpointStaleAfter: durationpb.New(time.Minute),
+					},
+				},
+			},
+		},
+		{
+			name: "One_Route",
+			finalRoutes: []*routepb.RouteConfiguration{
+				{Name: "example route"},
+			},
+		},
+		{
+			name: "Two_Routes",
+			finalRoutes: []*routepb.RouteConfiguration{
+				{Name: "example route 1"},
+				{Name: "example route 2"},
+			},
+		},
+		{
+			name: "Updated_Route",
+			initialRoutes: []*routepb.RouteConfiguration{
+				{Name: "example route"},
+			},
+			finalRoutes: []*routepb.RouteConfiguration{
+				{
+					Name:                   "example route 1",
+					RequestHeadersToRemove: []string{"X-Remove"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := Defaults
+			c := NewClient(slog.Default(), useSOTW, &opts).(*XDSClient[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse])
+			c.node = testNode()
+			resp := new(discoverypb.DiscoveryResponse)
+			appendResource := func(src proto.Message) {
+				res, err := anypb.New(src)
+				if err != nil {
+					t.Fatalf("unexpected marshal err: %v", err)
+				}
+				resp.Resources = append(resp.Resources, res)
+			}
+			for _, l := range append(tc.initialListeners, tc.finalListeners...) {
+				appendResource(l)
+				resp.TypeUrl = envoy.ListenerTypeURL
+			}
+			for _, c := range append(tc.initialClusters, tc.finalClusters...) {
+				appendResource(c)
+				resp.TypeUrl = envoy.ClusterTypeURL
+			}
+			for _, e := range append(tc.initialEndpoints, tc.finalEndpoints...) {
+				appendResource(e)
+				resp.TypeUrl = envoy.EndpointTypeURL
+			}
+
+			err := c.handleResponse(new(fakeStream), resp)
+			if err != nil {
+				t.Fatalf("unexpected handleResponse err: %v", err)
+			}
+
+			checkResource := func(typeUrl, resName string) protoreflect.ProtoMessage {
+				verRes, err := c.cache.GetResources(typeUrl, 0, "", []string{resName})
+				if err != nil {
+					t.Fatalf("unexpected GetResources err: %v", err)
+				}
+				if len(verRes.Resources) != 1 {
+					t.Fatalf("len(resources) = %d, want = %d", len(verRes.Resources), 1)
+				}
+				if len(verRes.ResourceNames) != 1 {
+					t.Fatalf("len(resourceNames) = %d, want = %d", len(verRes.ResourceNames), 1)
+				}
+				if name := verRes.ResourceNames[0]; name != resName {
+					t.Errorf("resourceName = %q, want = %q", name, resName)
+				}
+				return verRes.Resources[0]
+			}
+
+			for _, res := range tc.finalListeners {
+				cacheRes := checkResource(envoy.ListenerTypeURL, res.Name)
+				wantAddr := res.GetAddress().GetSocketAddress().String()
+				gotAddr := cacheRes.(*listenerpb.Listener).GetAddress().GetSocketAddress().String()
+				if gotAddr != wantAddr {
+					t.Errorf("addr = %q, want = %q", gotAddr, wantAddr)
+				}
+			}
+
+			for _, res := range tc.finalClusters {
+				cacheRes := checkResource(envoy.ClusterTypeURL, res.Name)
+				wantConnectTimeout := res.ConnectTimeout.String()
+				gotConnectTimeout := cacheRes.(*clusterpb.Cluster).GetConnectTimeout().String()
+				if gotConnectTimeout != wantConnectTimeout {
+					t.Errorf("connectTimeout = %s, want = %s", gotConnectTimeout, wantConnectTimeout)
+				}
+			}
+
+			for _, res := range tc.finalEndpoints {
+				cacheRes := checkResource(envoy.EndpointTypeURL, res.ClusterName)
+				wantPolicy := res.GetPolicy().String()
+				gotPolicy := cacheRes.(*endpointpb.ClusterLoadAssignment).GetPolicy().String()
+				if gotPolicy != wantPolicy {
+					t.Errorf("policy = %s, want = %s", gotPolicy, wantPolicy)
+				}
+			}
+		})
+	}
+}
+
+func TestUpsertAndDeleteMissing_Listeners(t *testing.T) {
+	testCases := []struct {
+		name    string
+		initial []*listenerpb.Listener
+		updated []*listenerpb.Listener
+	}{
+		{
+			name: "no_changes",
+			initial: []*listenerpb.Listener{
+				{Name: "example listener"},
+			},
+			updated: []*listenerpb.Listener{
+				{Name: "example listener"},
+			},
+		},
+		{
+			name: "add_only",
+			initial: []*listenerpb.Listener{
+				{Name: "example listener"},
+			},
+			updated: []*listenerpb.Listener{
+				{Name: "example listener"},
+				{Name: "added listener"},
+			},
+		},
+		{
+			name: "remove_only",
+			initial: []*listenerpb.Listener{
+				{Name: "first listener"},
+				{Name: "second listener"},
+			},
+			updated: []*listenerpb.Listener{
+				{Name: "second listener"},
+			},
+		},
+		{
+			name: "add_and_remove",
+			initial: []*listenerpb.Listener{
+				{Name: "removed listener"},
+				{Name: "same listener"},
+			},
+			updated: []*listenerpb.Listener{
+				{Name: "same listener"},
+				{Name: "added listener"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := Defaults
+			c := NewClient(slog.Default(), useSOTW, &opts).(*XDSClient[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse])
+			c.node = testNode()
+			handleListenerResponse := func(listeners []*listenerpb.Listener) {
+				resp := new(discoverypb.DiscoveryResponse)
+				for _, l := range listeners {
+					res, err := anypb.New(l)
+					if err != nil {
+						t.Fatalf("unexpected marshal err: %v", err)
+					}
+					resp.Resources = append(resp.Resources, res)
+				}
+				resp.TypeUrl = envoy.ListenerTypeURL
+
+				err := c.handleResponse(new(fakeStream), resp)
+				if err != nil {
+					t.Fatalf("unexpected handleResponse err: %v", err)
+				}
+			}
+
+			handleListenerResponse(tc.initial)
+			handleListenerResponse(tc.updated)
+
+			wantNames := make([]string, len(tc.updated))
+			for i, l := range tc.updated {
+				wantNames[i] = l.Name
+			}
+
+			verRes, err := c.cache.GetResources(envoy.ListenerTypeURL, 0, "", nil)
+			if err != nil {
+				t.Fatalf("unexpected GetResources err: %v", err)
+			}
+			sort.Strings(wantNames)
+			sort.Strings(verRes.ResourceNames)
+			if diff := cmp.Diff(wantNames, verRes.ResourceNames); diff != "" {
+				t.Errorf("-got, +want: %s", diff)
+			}
+		})
+	}
+}
+
+func TestUpsertAndDeleteMissing_Endpoints(t *testing.T) {
+	testCases := []struct {
+		name             string
+		initialClusters  []*clusterpb.Cluster
+		initialEndpoints []*endpointpb.ClusterLoadAssignment
+		updatedClusters  []*clusterpb.Cluster
+		updatedEndpoints []*endpointpb.ClusterLoadAssignment
+		wantEndpoints    []string
+	}{
+		{
+			name: "no_changes",
+			initialClusters: []*clusterpb.Cluster{
+				{Name: "example"},
+			},
+			initialEndpoints: []*endpointpb.ClusterLoadAssignment{
+				{ClusterName: "example"},
+			},
+			updatedClusters: []*clusterpb.Cluster{
+				{Name: "example"},
+			},
+			updatedEndpoints: []*endpointpb.ClusterLoadAssignment{
+				{ClusterName: "example"},
+			},
+			wantEndpoints: []string{
+				"example",
+			},
+		},
+		{
+			name: "missing_cluster_deletes_endpoint",
+			initialClusters: []*clusterpb.Cluster{
+				{Name: "present"},
+				{Name: "missing"},
+			},
+			initialEndpoints: []*endpointpb.ClusterLoadAssignment{
+				{ClusterName: "present"},
+				{ClusterName: "missing"},
+			},
+			updatedClusters: []*clusterpb.Cluster{
+				{Name: "present"},
+			},
+			wantEndpoints: []string{
+				"present",
+			},
+		},
+		{
+			name: "missing_endpoint_has_no_effect",
+			initialClusters: []*clusterpb.Cluster{
+				{Name: "present"},
+				{Name: "missing"},
+			},
+			initialEndpoints: []*endpointpb.ClusterLoadAssignment{
+				{ClusterName: "present"},
+				{ClusterName: "missing"},
+			},
+			updatedClusters: []*clusterpb.Cluster{
+				{Name: "present"},
+				{Name: "missing"},
+			},
+			updatedEndpoints: []*endpointpb.ClusterLoadAssignment{
+				{ClusterName: "present"},
+			},
+			wantEndpoints: []string{
+				"present",
+				"missing",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := Defaults
+			c := NewClient(slog.Default(), useSOTW, &opts).(*XDSClient[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse])
+			c.node = testNode()
+			handleResponse := func(typeUrl string, clusters []*clusterpb.Cluster, endpoints []*endpointpb.ClusterLoadAssignment) {
+				if clusters == nil && endpoints == nil {
+					return
+				}
+				resp := new(discoverypb.DiscoveryResponse)
+				for _, l := range clusters {
+					res, err := anypb.New(l)
+					if err != nil {
+						t.Fatalf("unexpected marshal err: %v", err)
+					}
+					resp.Resources = append(resp.Resources, res)
+				}
+				for _, e := range endpoints {
+					res, err := anypb.New(e)
+					if err != nil {
+						t.Fatalf("unexpected marshal err: %v", err)
+					}
+					resp.Resources = append(resp.Resources, res)
+				}
+				resp.TypeUrl = typeUrl
+
+				err := c.handleResponse(new(fakeStream), resp)
+				if err != nil {
+					t.Fatalf("unexpected handleResponse err: %v", err)
+				}
+			}
+
+			handleResponse(envoy.ClusterTypeURL, tc.initialClusters, nil)
+			handleResponse(envoy.EndpointTypeURL, nil, tc.initialEndpoints)
+			handleResponse(envoy.ClusterTypeURL, tc.updatedClusters, nil)
+			handleResponse(envoy.EndpointTypeURL, nil, tc.updatedEndpoints)
+
+			verRes, err := c.cache.GetResources(envoy.EndpointTypeURL, 0, "", nil)
+			if err != nil {
+				t.Fatalf("unexpected GetResources err: %v", err)
+			}
+			sort.Strings(tc.wantEndpoints)
+			sort.Strings(verRes.ResourceNames)
+			if diff := cmp.Diff(tc.wantEndpoints, verRes.ResourceNames); diff != "" {
+				t.Errorf("+got, -want: %s", diff)
+			}
+		})
+	}
+}
+
+func TestHandleResponse_RejectsMismatchedTypes(t *testing.T) {
+	testCases := []struct {
+		name            string
+		res             *anypb.Any
+		overrideResType string
+		wantErr         string
+	}{
+		{
+			name:            "unknown",
+			res:             mustMarshalAny(&listenerpb.Listener{Name: "ok"}),
+			overrideResType: "wrong-type-url",
+			wantErr:         "mismatched typeUrls",
+		},
+		{
+			name: "listener_ok",
+			res:  mustMarshalAny(&listenerpb.Listener{Name: "ok"}),
+		},
+		{
+			name:    "listener_missing_name",
+			res:     mustMarshalAny(&listenerpb.Listener{StatPrefix: "stat_prefix"}),
+			wantErr: "missing name for ",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := Defaults
+			c := NewClient(slog.Default(), useSOTW, &opts).(*XDSClient[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse])
+			c.node = testNode()
+			resp := &discoverypb.DiscoveryResponse{
+				Resources: []*anypb.Any{tc.res},
+				TypeUrl:   envoy.ListenerTypeURL,
+			}
+			if tc.overrideResType != "" {
+				resp.Resources[0].TypeUrl = tc.overrideResType
+			}
+
+			err := c.handleResponse(new(fakeStream), resp)
+			if err != nil {
+				if tc.wantErr == "" {
+					t.Errorf("error occurred when none was expected")
+				} else if gotErr := err.Error(); !strings.Contains(gotErr, tc.wantErr) {
+					t.Errorf("error = %q, want = %q", gotErr, tc.wantErr)
+				}
+			} else if tc.wantErr != "" {
+				t.Errorf("expected an error to occur, want = %s", tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestRunReturnsNonRetriableErrors(t *testing.T) {
+	testCases := []struct {
+		name    string
+		sendErr error
+		recvErr error
+		wantErr string
+		retries bool
+	}{
+		{
+			name:    "Returns_Loop_EOF",
+			sendErr: io.EOF,
+			wantErr: "process loop: send: EOF",
+		},
+		{
+			name:    "Returns_Loop_Aborted",
+			sendErr: status.New(codes.Aborted, "").Err(),
+			wantErr: "process loop: send: rpc error: code = Aborted",
+		},
+		{
+			name:    "Returns_Recv_EOF",
+			recvErr: io.EOF,
+			wantErr: "process responses: recv: EOF",
+		},
+		{
+			name:    "Returns_Recv_Aborted",
+			recvErr: status.New(codes.Aborted, "").Err(),
+			wantErr: "process responses: recv: rpc error: code = Aborted",
+		},
+		{
+			name:    "Retries_Send_Unknown",
+			sendErr: status.New(codes.Unknown, "").Err(),
+			retries: true,
+		},
+		{
+			name:    "Retries_Recv_Unknown",
+			recvErr: status.New(codes.Unknown, "").Err(),
+			retries: true,
+		},
+	}
+
+	for sotw, name := range sotw2str {
+		t.Run(name, func(t *testing.T) {
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					defer goleak.VerifyNone(t)
+
+					opts := Defaults
+					opts.RetryBackoff.Min = time.Microsecond
+					opts.RetryBackoff.Max = time.Microsecond
+					c := NewClient(slog.Default(), sotw, &opts)
+					if sotw {
+						c.(*XDSClient[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse]).node = testNode()
+					} else {
+						c.(*XDSClient[*discoverypb.DeltaDiscoveryRequest, *discoverypb.DeltaDiscoveryResponse]).node = testNode()
+					}
+					ctx, cancel := context.WithCancel(context.TODO())
+
+					f := newFakeClient()
+
+					var gotErr error
+					done := make(chan bool)
+					go func() {
+						defer close(done)
+						defer cancel()
+						if sotw {
+							gotErr = c.(*XDSClient[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse]).process(ctx, f)
+						} else {
+							gotErr = c.(*XDSClient[*discoverypb.DeltaDiscoveryRequest, *discoverypb.DeltaDiscoveryResponse]).process(ctx, f)
+						}
+					}()
+
+					if tc.sendErr != nil {
+						err := c.Observe(ctx, "", nil)
+						if err != nil {
+							t.Fatalf("unexpected observe err: %v", err)
+						}
+						f.sendErrCh <- tc.sendErr
+					}
+					if tc.recvErr != nil {
+						f.recvCh <- tc.recvErr
+					}
+					if tc.retries {
+						// Send non-retriable error to confirm
+						if tc.sendErr != nil {
+							if sotw {
+								c.(*XDSClient[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse]).observeQueue <- &observeRequest{}
+							} else {
+								c.(*XDSClient[*discoverypb.DeltaDiscoveryRequest, *discoverypb.DeltaDiscoveryResponse]).observeQueue <- &observeRequest{}
+							}
+							select {
+							case f.sendErrCh <- io.EOF:
+							case <-done:
+								t.Fatalf("error was not retried")
+							}
+						}
+						if tc.recvErr != nil {
+							select {
+							case f.recvCh <- io.EOF:
+							case <-done:
+								t.Fatalf("error was not retried")
+							}
+						}
+					}
+
+					select {
+					case <-time.NewTimer(10 * time.Second).C:
+						t.Fatalf("test timeout: expected error to occur")
+					case <-done:
+					}
+
+					if tc.retries {
+						if !strings.Contains(gotErr.Error(), "EOF") {
+							t.Errorf("error = %v, want = %v (retry marker)", gotErr, io.EOF)
+						}
+					} else if !strings.Contains(gotErr.Error(), tc.wantErr) {
+						t.Errorf("error = %v, want = %v", gotErr, tc.wantErr)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestObserve(t *testing.T) {
+	testCases := []struct {
+		name              string
+		resourceNames     []string
+		currResourceNames []string
+	}{
+		{
+			name: "empty_cache_empty_req",
+		},
+		{
+			name:          "empty_cache_two_listeners_req",
+			resourceNames: []string{"listener_one", "listener_two"},
+		},
+		{
+			name:              "req_same_as_cache",
+			resourceNames:     []string{"listener_one", "listener_two"},
+			currResourceNames: []string{"listener_one", "listener_two"},
+		},
+		{
+			name:              "new_listener",
+			resourceNames:     []string{"listener_three"},
+			currResourceNames: []string{"listener_one", "listener_two"},
+		},
+		{
+			name:              "listener_already_in_cache",
+			resourceNames:     []string{"listener_one"},
+			currResourceNames: []string{"listener_one", "listener_two"},
+		},
+	}
+
+	for sotw, name := range sotw2str {
+		t.Run(name, func(t *testing.T) {
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					defer goleak.VerifyNone(t)
+
+					opts := Defaults
+					c := NewClient(slog.Default(), sotw, &opts)
+					ctx, cancel := context.WithCancel(context.TODO())
+
+					typeUrl := envoy.ListenerTypeURL
+					var cache *xds.Cache
+					if sotw {
+						sotwCl := c.(*XDSClient[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse])
+						sotwCl.node = testNode()
+						cache = sotwCl.cache
+					} else {
+						deltaCl := c.(*XDSClient[*discoverypb.DeltaDiscoveryRequest, *discoverypb.DeltaDiscoveryResponse])
+						deltaCl.node = testNode()
+						cache = deltaCl.cache
+					}
+					for _, rn := range tc.currResourceNames {
+						cache.Upsert(typeUrl, rn, &listenerpb.Listener{Name: rn})
+					}
+
+					f := newFakeClient()
+
+					done := make(chan bool)
+					go func() {
+						defer close(done)
+						if sotw {
+							c.(*XDSClient[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse]).process(ctx, f)
+						} else {
+							c.(*XDSClient[*discoverypb.DeltaDiscoveryRequest, *discoverypb.DeltaDiscoveryResponse]).process(ctx, f)
+						}
+					}()
+
+					err := c.Observe(ctx, typeUrl, tc.resourceNames)
+					if err != nil {
+						t.Fatalf("unexpected err: %v", err)
+					}
+
+					var gotResourceNames []string
+					var gotTypeUrl string
+					if sotw {
+						got := <-f.sendStreamCh
+						gotResourceNames = got.GetResourceNames()
+						gotTypeUrl = got.GetTypeUrl()
+					} else {
+						got := <-f.sendDeltaCh
+						gotResourceNames = got.GetResourceNamesSubscribe()
+						gotTypeUrl = got.GetTypeUrl()
+					}
+
+					cancel()
+					<-done
+
+					var wantResourceNames []string
+					if sotw {
+						wantResourceNames = append(tc.resourceNames, tc.currResourceNames...)
+						sort.Strings(wantResourceNames)
+						wantResourceNames = slices.Compact(wantResourceNames)
+					} else {
+						wantResourceNames = tc.resourceNames
+					}
+					sort.Strings(gotResourceNames)
+
+					if diff := cmp.Diff(wantResourceNames, gotResourceNames); diff != "" {
+						t.Errorf("mismatched resource names: +got, -want: %s", diff)
+					}
+					if typeUrl != gotTypeUrl {
+						t.Errorf("typeUrl = %s, want = %s", gotTypeUrl, typeUrl)
+					}
+				})
+			}
+		})
+	}
+}
+
+type FakeClientConn struct {
+	OnInvoke    func(ctx context.Context, method string, args interface{}, reply interface{}, opts ...grpc.CallOption) error
+	OnNewStream func(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error)
+}
+
+func (f *FakeClientConn) Invoke(ctx context.Context, method string, args interface{}, reply interface{}, opts ...grpc.CallOption) error {
+	return f.OnInvoke(ctx, method, args, reply, opts...)
+}
+
+func (f *FakeClientConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	return f.OnNewStream(ctx, desc, method, opts...)
+}
+
+var _ grpc.ClientConnInterface = (*FakeClientConn)(nil)
+
+func TestClientConnectionRetry(t *testing.T) {
+	for _, retry := range []bool{true, false} {
+		t.Run(fmt.Sprintf("retry=%v", retry), func(t *testing.T) {
+			defer goleak.VerifyNone(t)
+
+			opts := Defaults
+			opts.RetryBackoff.Min = time.Hour
+			opts.RetryBackoff.Max = time.Hour
+			opts.RetryConnection = retry
+			c := NewClient(slog.Default(), true, &opts)
+			c.(*XDSClient[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse]).node = testNode()
+			ctx, cancel := context.WithCancel(context.TODO())
+			defer cancel()
+
+			wantErr := fmt.Errorf("test err")
+			newStreamCh := make(chan bool)
+			defer close(newStreamCh)
+			fakeConn := &FakeClientConn{
+				OnNewStream: func(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+					newStreamCh <- true
+					return nil, wantErr
+				},
+			}
+
+			done := make(chan bool)
+			var gotError error
+			go func() {
+				defer close(done)
+				gotError = c.Run(ctx, testNode(), fakeConn)
+			}()
+			<-newStreamCh
+			if retry {
+				cancel()
+				<-done
+			} else {
+				<-done
+				cancel()
+			}
+
+			if retry {
+				wantErr = context.Canceled
+			}
+			if !errors.Is(gotError, wantErr) {
+				t.Errorf("error = %v, want = %v", gotError, wantErr)
+			}
+		})
+	}
+}
+
+func TestAckAndNack(t *testing.T) {
+	testCases := []struct {
+		name string
+		ack  bool
+	}{
+		{
+			name: "ACK",
+			ack:  true,
+		},
+		{
+			name: "NACK",
+			ack:  false,
+		},
+	}
+
+	for sotw, name := range sotw2str {
+		t.Run(name, func(t *testing.T) {
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					defer goleak.VerifyNone(t)
+
+					opts := Defaults
+					c := NewClient(slog.Default(), sotw, &opts)
+					if sotw {
+						c.(*XDSClient[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse]).node = testNode()
+					} else {
+						c.(*XDSClient[*discoverypb.DeltaDiscoveryRequest, *discoverypb.DeltaDiscoveryResponse]).node = testNode()
+					}
+					ctx, cancel := context.WithCancel(context.TODO())
+
+					typeUrl := envoy.ListenerTypeURL
+					nonce := "just-a-test"
+
+					lName := "listener-with-name-only"
+					if !tc.ack {
+						lName = ""
+					}
+					l, err := anypb.New(&listenerpb.Listener{Name: lName})
+					if err != nil {
+						t.Fatalf("unexpected anypb.New error = %v", err)
+					}
+					f := newFakeClient()
+
+					var gotErr error
+					done := make(chan bool)
+					go func() {
+						defer close(done)
+						if sotw {
+							gotErr = c.(*XDSClient[*discoverypb.DiscoveryRequest, *discoverypb.DiscoveryResponse]).process(ctx, f)
+						} else {
+							gotErr = c.(*XDSClient[*discoverypb.DeltaDiscoveryRequest, *discoverypb.DeltaDiscoveryResponse]).process(ctx, f)
+						}
+					}()
+
+					if sotw {
+						f.recvStreamCh <- &discoverypb.DiscoveryResponse{
+							TypeUrl:   typeUrl,
+							Resources: []*anypb.Any{l},
+							Nonce:     nonce,
+						}
+					} else {
+						f.recvDeltaCh <- &discoverypb.DeltaDiscoveryResponse{
+							TypeUrl: typeUrl,
+							Resources: []*discoverypb.Resource{
+								{
+									Name:     lName,
+									Resource: l,
+								},
+							},
+							Nonce: nonce,
+						}
+					}
+
+					var req interface {
+						GetResponseNonce() string
+						GetTypeUrl() string
+						GetErrorDetail() *grpcStatus.Status
+					}
+					if sotw {
+						req = <-f.sendStreamCh
+					} else {
+						req = <-f.sendDeltaCh
+					}
+
+					cancel()
+					<-done
+
+					if !errors.Is(gotErr, context.Canceled) && !strings.Contains(gotErr.Error(), "terminated") {
+						t.Errorf("unexpected error = %v", gotErr)
+					}
+
+					gotNonce := req.GetResponseNonce()
+					if gotNonce != nonce {
+						t.Errorf("nonce = %s, want = %s", gotNonce, nonce)
+					}
+					gotTypeUrl := req.GetTypeUrl()
+					if gotTypeUrl != typeUrl {
+						t.Errorf("typeUrl = %s, want = %s", gotTypeUrl, typeUrl)
+					}
+
+					errDetail := req.GetErrorDetail()
+					if tc.ack {
+						if errDetail != nil {
+							t.Errorf("error detail = %v, want = empty", errDetail)
+						}
+					} else {
+						if errDetail == nil {
+							t.Error("expected non-empty error detail")
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/pkg/xds/experimental/client/configproviders.go
+++ b/pkg/xds/experimental/client/configproviders.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+package xdsclient
+
+import (
+	"context"
+
+	corepb "github.com/cilium/proxy/go/envoy/config/core/v3"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// NewInsecureGRPCOptionsProvider creates dial options provider for insecure
+// GRPC connections.
+func NewInsecureGRPCOptionsProvider() DialOptionsProvider {
+	return &insecureGRPCOptionsProvider{}
+}
+
+// insecureGRPCOptionsProvider implements DialOptionsProvider
+type insecureGRPCOptionsProvider struct{}
+
+// GRPCOptions creates grpc Dial options with insecure credentials.
+func (g *insecureGRPCOptionsProvider) GRPCOptions(context.Context) ([]grpc.DialOption, error) {
+	return []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}, nil
+}
+
+// NewDefaultNodeProvider creates node provider for building default xds Node.
+func NewDefaultNodeProvider() NodeProvider {
+	return &defaultNodeProvider{}
+}
+
+// defaultNodeProvider implements NodeProvider
+type defaultNodeProvider struct{}
+
+// Node provides default Node with zone locality for xds client.
+func (*defaultNodeProvider) Node(nodeID, zone string) *corepb.Node {
+	locality := &corepb.Locality{
+		Zone: zone,
+	}
+	return &corepb.Node{
+		Id:            nodeID,
+		UserAgentName: "cilium-agent",
+		Locality:      locality,
+	}
+}

--- a/pkg/xds/experimental/client/fakes_test.go
+++ b/pkg/xds/experimental/client/fakes_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xdsclient
+
+import (
+	"context"
+	"time"
+
+	discoverypb "github.com/cilium/proxy/go/envoy/service/discovery/v3"
+	"google.golang.org/grpc"
+)
+
+type fakeStream struct {
+	grpc.ClientStream
+	OnSend func(*discoverypb.DiscoveryRequest) error
+	OnRecv func() (*discoverypb.DiscoveryResponse, error)
+}
+
+func (f *fakeStream) Send(r *discoverypb.DiscoveryRequest) error {
+	if f.OnSend != nil {
+		return f.OnSend(r)
+	}
+	return nil
+}
+
+func (f *fakeStream) Recv() (*discoverypb.DiscoveryResponse, error) {
+	if f.OnRecv != nil {
+		return f.OnRecv()
+	}
+	// Avoid hogging CPU during test
+	time.Sleep(time.Millisecond)
+	return nil, nil
+}
+
+var _ discoverypb.AggregatedDiscoveryService_StreamAggregatedResourcesClient = new(fakeStream)
+
+type fakeDelta struct {
+	grpc.ClientStream
+	OnSend func(*discoverypb.DeltaDiscoveryRequest) error
+	OnRecv func() (*discoverypb.DeltaDiscoveryResponse, error)
+}
+
+func (f *fakeDelta) Send(r *discoverypb.DeltaDiscoveryRequest) error {
+	return f.OnSend(r)
+}
+
+func (f *fakeDelta) Recv() (*discoverypb.DeltaDiscoveryResponse, error) {
+	return f.OnRecv()
+}
+
+var _ discoverypb.AggregatedDiscoveryService_DeltaAggregatedResourcesClient = new(fakeDelta)
+
+type fakeClient struct {
+	sendErrCh    chan error
+	sendStreamCh chan *discoverypb.DiscoveryRequest
+	sendDeltaCh  chan *discoverypb.DeltaDiscoveryRequest
+	recvCh       chan error
+	recvStreamCh chan *discoverypb.DiscoveryResponse
+	recvDeltaCh  chan *discoverypb.DeltaDiscoveryResponse
+}
+
+var _ discoverypb.AggregatedDiscoveryServiceClient = new(fakeClient)
+
+func newFakeClient() *fakeClient {
+	return &fakeClient{
+		sendErrCh:    make(chan error),
+		recvCh:       make(chan error),
+		sendStreamCh: make(chan *discoverypb.DiscoveryRequest),
+		sendDeltaCh:  make(chan *discoverypb.DeltaDiscoveryRequest),
+		recvStreamCh: make(chan *discoverypb.DiscoveryResponse),
+		recvDeltaCh:  make(chan *discoverypb.DeltaDiscoveryResponse),
+	}
+}
+
+func (f *fakeClient) StreamAggregatedResources(ctx context.Context, opts ...grpc.CallOption) (discoverypb.AggregatedDiscoveryService_StreamAggregatedResourcesClient, error) {
+	return &fakeStream{
+		OnSend: func(r *discoverypb.DiscoveryRequest) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case f.sendStreamCh <- r:
+				return nil
+			case err := <-f.sendErrCh:
+				return err
+			}
+		},
+		OnRecv: func() (*discoverypb.DiscoveryResponse, error) {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case r := <-f.recvStreamCh:
+				return r, nil
+			case err := <-f.recvCh:
+				return nil, err
+			}
+		},
+	}, nil
+}
+
+func (f *fakeClient) DeltaAggregatedResources(ctx context.Context, opts ...grpc.CallOption) (discoverypb.AggregatedDiscoveryService_DeltaAggregatedResourcesClient, error) {
+	return &fakeDelta{
+		OnSend: func(r *discoverypb.DeltaDiscoveryRequest) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case f.sendDeltaCh <- r:
+				return nil
+			case err := <-f.sendErrCh:
+				return err
+			}
+		},
+		OnRecv: func() (*discoverypb.DeltaDiscoveryResponse, error) {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case r := <-f.recvDeltaCh:
+				return r, nil
+			case err := <-f.recvCh:
+				return nil, err
+			}
+		},
+	}, nil
+}

--- a/pkg/xds/experimental/client/option.go
+++ b/pkg/xds/experimental/client/option.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xdsclient
+
+import (
+	"time"
+
+	"google.golang.org/grpc/codes"
+)
+
+type ConnectionOptions struct {
+	RetryBackoff    BackoffParams
+	RetryConnection bool
+	IsRetriable     func(code codes.Code) (retry bool)
+}
+
+type BackoffParams struct {
+	Min, Max, Reset time.Duration
+}
+
+var Defaults = ConnectionOptions{
+	RetryBackoff: BackoffParams{
+		Min:   time.Second,
+		Max:   time.Minute,
+		Reset: 2 * time.Minute,
+	},
+
+	IsRetriable: func(code codes.Code) bool {
+		switch code {
+		case codes.PermissionDenied, codes.Aborted, codes.Unauthenticated, codes.Unavailable, codes.Canceled:
+			return false
+		}
+		return true
+	},
+}

--- a/pkg/xds/experimental/client/parse.go
+++ b/pkg/xds/experimental/client/parse.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xdsclient
+
+import (
+	"fmt"
+
+	clusterpb "github.com/cilium/proxy/go/envoy/config/cluster/v3"
+	endpointpb "github.com/cilium/proxy/go/envoy/config/endpoint/v3"
+	listenerpb "github.com/cilium/proxy/go/envoy/config/listener/v3"
+	routepb "github.com/cilium/proxy/go/envoy/config/route/v3"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+func parseResource(typeUrl string, res *anypb.Any) (proto.Message, string, error) {
+	if typeUrl != res.GetTypeUrl() {
+		return nil, "", fmt.Errorf("mismatched typeUrls, got = %s, want = %s", res.GetTypeUrl(), typeUrl)
+	}
+	msg, err := res.UnmarshalNew()
+	if err != nil {
+		return nil, "", fmt.Errorf("resource typeUrl=%q: unmarshal: %w", typeUrl, err)
+	}
+	var name string
+	switch obj := msg.(type) {
+	case *listenerpb.Listener:
+		name = obj.GetName()
+	case *clusterpb.Cluster:
+		name = obj.GetName()
+	case *endpointpb.ClusterLoadAssignment:
+		name = obj.GetClusterName()
+	case *routepb.RouteConfiguration:
+		name = obj.GetName()
+	default:
+		return nil, "", fmt.Errorf("unhandled typeUrl=%q", typeUrl)
+	}
+	if name == "" {
+		return nil, "", fmt.Errorf("missing name for typeUrl=%q", typeUrl)
+	}
+	return msg, name, nil
+}

--- a/pkg/xds/experimental/client/parse_test.go
+++ b/pkg/xds/experimental/client/parse_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xdsclient
+
+import (
+	"strings"
+	"testing"
+
+	clusterpb "github.com/cilium/proxy/go/envoy/config/cluster/v3"
+	endpointpb "github.com/cilium/proxy/go/envoy/config/endpoint/v3"
+	listenerpb "github.com/cilium/proxy/go/envoy/config/listener/v3"
+	routepb "github.com/cilium/proxy/go/envoy/config/route/v3"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/cilium/cilium/pkg/envoy"
+)
+
+func TestParseResource(t *testing.T) {
+	const name = "test_name"
+	for _, tc := range []struct {
+		name    string
+		typeUrl string
+		res     *anypb.Any
+		wantErr string
+	}{
+		{
+			name:    "listener_ok",
+			typeUrl: envoy.ListenerTypeURL,
+			res:     mustMarshalAny(&listenerpb.Listener{Name: name}),
+		},
+		{
+			name:    "listener_missing_name",
+			typeUrl: envoy.ListenerTypeURL,
+			res:     mustMarshalAny(&listenerpb.Listener{Name: ""}),
+			wantErr: "missing name",
+		},
+		{
+			name:    "cluster_ok",
+			typeUrl: envoy.ClusterTypeURL,
+			res:     mustMarshalAny(&clusterpb.Cluster{Name: name}),
+		},
+		{
+			name:    "cluster_missing_name",
+			typeUrl: envoy.ClusterTypeURL,
+			res:     mustMarshalAny(&clusterpb.Cluster{Name: ""}),
+			wantErr: "missing name",
+		},
+		{
+			name:    "endpoint_ok",
+			typeUrl: envoy.EndpointTypeURL,
+			res:     mustMarshalAny(&endpointpb.ClusterLoadAssignment{ClusterName: name}),
+		},
+		{
+			name:    "endpoint_missing_name",
+			typeUrl: envoy.EndpointTypeURL,
+			res:     mustMarshalAny(&endpointpb.ClusterLoadAssignment{ClusterName: ""}),
+			wantErr: "missing name",
+		},
+		{
+			name:    "route_ok",
+			typeUrl: envoy.RouteTypeURL,
+			res:     mustMarshalAny(&routepb.RouteConfiguration{Name: name}),
+		},
+		{
+			name:    "route_missing_name",
+			typeUrl: envoy.RouteTypeURL,
+			res:     mustMarshalAny(&routepb.RouteConfiguration{Name: ""}),
+			wantErr: "missing name",
+		},
+		{
+			name:    "wrong_type_url",
+			typeUrl: envoy.ClusterTypeURL,
+			res:     mustMarshalAny(&listenerpb.Listener{Name: name}),
+			wantErr: "mismatched typeUrls",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			msg, parsedName, err := parseResource(tc.typeUrl, tc.res)
+			if err != nil {
+				if tc.wantErr == "" {
+					t.Fatalf("error = %v, want = nil", err)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error = %v, want = %s", err, tc.wantErr)
+				}
+				return
+			}
+			if tc.wantErr != "" {
+				t.Fatalf("error = nil, want = %s", tc.wantErr)
+			}
+			if msg == nil {
+				t.Error("unexpected nil msg")
+			}
+			if parsedName != name {
+				t.Errorf("parsedName = %s, want = %s", parsedName, name)
+			}
+		})
+	}
+}

--- a/pkg/xds/experimental/client/utils_test.go
+++ b/pkg/xds/experimental/client/utils_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+package xdsclient
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func mustMarshalAny(src proto.Message) *anypb.Any {
+	res, err := anypb.New(src)
+	if err != nil {
+		panic(fmt.Errorf("marshal any: %w", err))
+	}
+	return res
+}
+
+func waitForCondition(ctx context.Context, t *testing.T, f func() error) error {
+	stop := make(chan struct{})
+	timeout := time.NewTimer(time.Minute)
+	defer timeout.Stop()
+	var err error
+	wait.Until(func() {
+		t.Log("check function")
+		err = f()
+		if err == nil {
+			t.Log("condition met, exiting")
+			close(stop)
+			return
+		}
+		t.Log("condition not met")
+		select {
+		case <-ctx.Done():
+		case <-timeout.C:
+		default:
+			return
+		}
+
+		close(stop)
+	}, 5*time.Second, stop)
+	if err != nil {
+		return fmt.Errorf("Waiting for condition failed, timeout occurred")
+	}
+	return nil
+}

--- a/pkg/xds/experimental/client/watcher.go
+++ b/pkg/xds/experimental/client/watcher.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xdsclient
+
+import (
+	"log/slog"
+
+	"github.com/cilium/cilium/pkg/envoy/xds"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// watcherHandle is an identifier for watchers.
+type watcherHandle uint64
+
+// callbackManager is a helper structure for Client focused on [un]registering callbacks on resource changes.
+type callbackManager struct {
+	log *slog.Logger
+
+	src xds.ObservableResourceSource
+
+	// mux protects all fields below.
+	mux lock.Mutex
+	// watchers maps ID to an instance of a watcher.
+	watchers map[watcherHandle]*watcher
+	lastID   watcherHandle
+}
+
+func newCallbackManager(log *slog.Logger, src xds.ObservableResourceSource) *callbackManager {
+	return &callbackManager{
+		log:      log,
+		src:      src,
+		watchers: make(map[watcherHandle]*watcher),
+	}
+}
+
+// WatcherCallback will be called when a new version of a resource it was
+// registered on appears. res will contain all resources of this type.
+type WatcherCallback func(res *xds.VersionedResources)
+
+// Add registers a callback for a specified typeUrl.
+// Returned ID can be used to later unregister the callback.
+func (c *callbackManager) Add(typeUrl string, cb WatcherCallback) watcherHandle {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	c.lastID++
+
+	l := &watcher{
+		typeUrl:   typeUrl,
+		cb:        cb,
+		log:       c.log.With("listener-id", c.lastID),
+		resources: c.src,
+		trigger:   make(chan struct{}, 1),
+	}
+	go l.process()
+	c.src.AddResourceVersionObserver(l)
+	c.watchers[c.lastID] = l
+
+	return watcherHandle(c.lastID)
+}
+
+// Remove unregisters a callback with given ID. It does nothing if ID is not found.
+func (c *callbackManager) Remove(id watcherHandle) {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	l, ok := c.watchers[id]
+	if !ok {
+		// Not found or already deleted.
+		return
+	}
+	c.src.RemoveResourceVersionObserver(l)
+	delete(c.watchers, id)
+	close(l.trigger)
+}
+
+// watcher is a helper structure for callbackManager focused on handling
+// a single, registered callback.
+type watcher struct {
+	typeUrl string
+	cb      WatcherCallback
+	trigger chan struct{}
+
+	log       *slog.Logger
+	resources xds.ResourceSource
+}
+
+// watcher implements xds.ResourceVersionObserver.
+var _ xds.ResourceVersionObserver = (*watcher)(nil)
+
+// HandleNewResourceVersion implements xds.ResourceVersionObserver.
+// It triggers the callback process.
+func (w *watcher) HandleNewResourceVersion(typeUrl string, _ uint64) {
+	if typeUrl != w.typeUrl {
+		w.log.Error("Called with wrong type URL",
+			"got", typeUrl,
+			"want", w.typeUrl)
+		return
+	}
+	select {
+	case w.trigger <- struct{}{}:
+	default:
+		// As l.trigger is a buffered channel, it means that:
+		//   - process is currently executing a callback
+		//   - trigger is queued, so callback will be invoked right after the
+		//     current execution returns
+		//
+		// There is no need to queue another trigger as the current one will
+		// fetch the latest version of the resources. The result is the same as
+		// if we maneged to queue up another trigger.
+	}
+}
+
+// process waits for the trigger (new resource version) and invokes the callback
+// function. It needs to be done asynchronously from HandleNewResourceVersion,
+// because the cache invoking the function holds a lock on the resources.
+func (l *watcher) process() {
+	for range l.trigger {
+		resVer, err := l.resources.GetResources(l.typeUrl, 0, "", nil)
+		if err != nil {
+			l.log.Error("Failed to fetch resource", logfields.Error, err)
+			continue
+		}
+
+		l.log.Debug("Invoke callback")
+		l.cb(resVer)
+	}
+}

--- a/pkg/xds/experimental/client/watcher_test.go
+++ b/pkg/xds/experimental/client/watcher_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+package xdsclient
+
+import (
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/envoy/xds"
+)
+
+type fakeObservableResources struct {
+	OnAdd          func(xds.ResourceVersionObserver)
+	OnRemove       func(xds.ResourceVersionObserver)
+	OnGetResources func(string, uint64, []string) (*xds.VersionedResources, error)
+}
+
+func (f *fakeObservableResources) AddResourceVersionObserver(l xds.ResourceVersionObserver) {
+	f.OnAdd(l)
+}
+
+func (f *fakeObservableResources) RemoveResourceVersionObserver(l xds.ResourceVersionObserver) {
+	f.OnRemove(l)
+}
+
+func (f *fakeObservableResources) GetResources(typeUrl string, latestVersion uint64, _ string, resourceNames []string) (*xds.VersionedResources, error) {
+	return f.OnGetResources(typeUrl, latestVersion, resourceNames)
+}
+
+func (f *fakeObservableResources) EnsureVersion(typeUrl string, version uint64) {}
+
+var _ xds.ObservableResourceSource = (*fakeObservableResources)(nil)
+
+func TestWatcher_AddRemove(t *testing.T) {
+	var registeredObserver xds.ResourceVersionObserver
+	fObsRes := &fakeObservableResources{
+		OnAdd: func(rvo xds.ResourceVersionObserver) { registeredObserver = rvo },
+		OnRemove: func(rvo xds.ResourceVersionObserver) {
+			if rvo != registeredObserver {
+				t.Errorf("tried deregistering a different handler, got = %+v, want = %+v", rvo, registeredObserver)
+			}
+			registeredObserver = nil
+		},
+	}
+	w := newCallbackManager(slog.Default(), fObsRes)
+
+	typeUrl := "test-url"
+	cb := func(res *xds.VersionedResources) {}
+	id := w.Add(typeUrl, cb)
+	if registeredObserver == nil {
+		t.Error("expected callback to be registered")
+	}
+
+	w.Remove(123) // should do nothing (doesn't exist)
+	if registeredObserver == nil {
+		t.Error("expected callback to be registered")
+	}
+
+	w.Remove(id) // remove
+	if registeredObserver != nil {
+		t.Error("expected callback to not be registered")
+	}
+
+	w.Remove(id) // should do nothing (double removal)
+	if registeredObserver != nil {
+		t.Error("expected callback to not be registered")
+	}
+
+	id2 := w.Add(typeUrl, cb)
+	if id2 == id {
+		t.Errorf("expected a new ID to be allocated, got = %d, prevId = %d", id2, id)
+	}
+	w.Remove(id2)
+}
+
+func TestWatcher_ResourceCallback(t *testing.T) {
+	const testTypeUrl = "test-type-url"
+
+	testCases := []struct {
+		name    string
+		typeUrl string
+		want    *xds.VersionedResources
+		called  bool
+		err     error
+	}{
+		{
+			name:    "ok",
+			typeUrl: testTypeUrl,
+			called:  true,
+		},
+		{
+			name:    "wrong_type_url",
+			typeUrl: "different-url",
+			called:  false,
+		},
+		{
+			name:    "ignore_err",
+			typeUrl: testTypeUrl,
+			called:  false,
+			err:     fmt.Errorf("test err"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var registeredObserver xds.ResourceVersionObserver
+			getResources := make(chan any)
+			defer close(getResources)
+			fObsRes := &fakeObservableResources{
+				OnAdd: func(rvo xds.ResourceVersionObserver) { registeredObserver = rvo },
+				OnRemove: func(rvo xds.ResourceVersionObserver) {
+					if rvo != registeredObserver {
+						t.Errorf("tried deregistering a different handler, got = %+v, want = %+v", rvo, registeredObserver)
+					}
+					registeredObserver = nil
+				},
+				OnGetResources: func(_ string, _ uint64, _ []string) (*xds.VersionedResources, error) {
+					getResources <- nil
+					return tc.want, tc.err
+				},
+			}
+
+			w := newCallbackManager(slog.Default(), fObsRes)
+
+			cbCh := make(chan *xds.VersionedResources)
+			defer close(cbCh)
+			cb := func(res *xds.VersionedResources) {
+				cbCh <- res
+			}
+
+			id := w.Add(testTypeUrl, cb)
+
+			w.watchers[id].HandleNewResourceVersion(tc.typeUrl, 0)
+			if tc.called || tc.err != nil {
+				<-getResources
+			}
+			w.Remove(id)
+
+			if tc.called {
+				got := <-cbCh
+				if got != tc.want {
+					t.Errorf("versioned resource changed, got = %+v, want = %+v", got, tc.want)
+				}
+			} else if len(getResources) != 0 || len(cbCh) != 0 {
+				t.Error("unexpected callback")
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Part of https://github.com/cilium/design-cfps/pull/14

The only other xDS client written in Go that I'm aware of is https://github.com/grpc/grpc-go/tree/master/xds/internal/xdsclient (unfortunately it is behind `/internal`)

```release-note
Added an experimental xDS client library
```
