### PR TITLE
kvstore: drop support for ca-file field in etcd client config

### DIFF
--- a/pkg/kvstore/etcd_debug.go
+++ b/pkg/kvstore/etcd_debug.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	client "go.etcd.io/etcd/client/v3"
+	clientyaml "go.etcd.io/etcd/client/v3/yaml"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"sigs.k8s.io/yaml"
@@ -54,7 +55,7 @@ func EtcdDbg(ctx context.Context, cfgfile string, dialer EtcdDbgDialer, w io.Wri
 	iw := newIndentedWriter(w, 0)
 
 	iw.Println("📄 Configuration path: %s", cfgfile)
-	cfg, err := newConfig(cfgfile)
+	cfg, err := clientyaml.NewConfig(cfgfile)
 	if err != nil {
 		iw.Println("❌ Cannot parse etcd configuration: %s", err)
 		return


### PR DESCRIPTION
The usage of the `ca-file` field was removed in etcd v3.4. Support in Cilium was deprecated in 1.7 by commit 50867c809d58 ("etcd: use ca-file field from etcd option if available") with targeted removal in Cilium 1.8. Enough time has passed since then. Remove the backwards compatibility wrapper.

```release-note
Drop support for the ca-file field in etcd client config, deprecated in Cilium 1.7.
```
