### PR TITLE
cli: Allow changing Kube Service type for connectivity tests

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -132,6 +132,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.ExternalCIDR, "external-cidr", "1.0.0.0/8", "CIDR to use as external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalIP, "external-ip", "1.1.1.1", "IP to use as external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalOtherIP, "external-other-ip", "1.0.0.1", "Other IP to use as external target in connectivity tests")
+	cmd.Flags().StringVar(&params.ServiceType, "service-type", "NodePort", "Type of Kubernetes Services created for connectivity tests")
 	cmd.Flags().StringSliceVar(&params.NodeCIDRs, "node-cidr", nil, "one or more CIDRs that cover all nodes in the cluster")
 	cmd.Flags().StringVar(&params.JunitFile, "junit-file", "", "Generate junit report and write to file")
 	cmd.Flags().Var(option.NewNamedMapOptions("junit-property", &params.JunitProperties, nil), "junit-property", "Add key=value properties to the generated junit file")

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -68,6 +68,7 @@ type Parameters struct {
 	ExternalIP             string
 	ExternalDeploymentPort int
 	ExternalOtherIP        string
+	ServiceType            string
 	EchoServerHostPort     int
 	PodCIDRs               []podCIDRs
 	NodeCIDRs              []string


### PR DESCRIPTION
This PR replaces https://github.com/cilium/cilium-cli/pull/2653

# Description
The goal of this PR is to allow users to change the type of Services created by automated connectivity tests. 

The default type is hardcoded to `NodePort` which is not necessarily the best choice for everyone. For example, we are currently setting up a [GateKeeper rule](https://open-policy-agent.github.io/gatekeeper-library/website/validation/block-nodeport-services) to block `NodePort` service creation in all of our clusters, mainly for security, performance and practicality reasons (for more context, see for instance https://oteemo.com/think-nodeport-kubernetes/).

The newly added parameter looks like this (and still has `NodePort` as the default):
```
      --service-type string             Type of Kubernetes Services created for connectivity tests (default "NodePort")
```

# Testing
- [x] Ran the tests without setting `--service-type`, verified that `NodePort` services were still being created
- [x] Ran the tests with `--service-type=ClusterIP`, verified that `ClusterIP` services were properly created:
```
$ kubectl -n cilium-test get svc echo-other-node
NAME              TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
echo-other-node   ClusterIP   10.x.x.x        <none>        8080/TCP   4m23s
```
- [x] Ran the tests with an invalid value `--service-type=FAIL`, verified that the tests failed with a clear error:
```
connectivity test failed: Service "echo-same-node" is invalid: spec.type: Unsupported value: "FAIL": supported values: "ClusterIP", "ExternalName", "LoadBalancer", "NodePort"
```

---

```release-note
cli: Allow changing Kube Service type for connectivity tests
```
