### PR TITLE
ci: Update ref to cilium/scaffolding in ClusterMesh scale test workflow 

### DIFF
--- a/.github/workflows/scale-test-clustermesh.yaml
+++ b/.github/workflows/scale-test-clustermesh.yaml
@@ -60,7 +60,7 @@ env:
   # renovate: datasource=docker depName=google/cloud-sdk
   gcloud_version: 487.0.0
   # renovate: datasource=git-refs depName=https://github.com/cilium/scaffolding branch=main
-  cmapisrv_mock_ref: 93927fbee24f4aa3b1165ddc903e0ec638bae8a6
+  cmapisrv_mock_ref: 6854fc7bc36335d83fb3427e963c40f4bcf90da2
 
   test_name: scale-clustermesh
   cluster_name: ${{ github.run_id }}-${{ github.run_attempt }}


### PR DESCRIPTION
This commit manually updates the commit for cilium/scaffolding in the
clustermesh scale test. The commit currently in use has no associated
docker image, causing the workflow to fail. The docker image is missing
due to a failed build caused by recent changes in the scaffolding
repository's build workflow.