### PR TITLE
maps/nat/stats: check the snat tuple direction as a bitmask.

### DIFF
--- a/pkg/maps/nat/stats/stats.go
+++ b/pkg/maps/nat/stats/stats.go
@@ -204,6 +204,10 @@ func upsertStat[KT tupleKey](m *Stats, topk *topk[KT], family nat.IPFamily) erro
 	return nil
 }
 
+func flagsIsIn(flags uint8) bool {
+	return flags&tuple.TUPLE_F_IN == tuple.TUPLE_F_IN
+}
+
 func (m *Stats) countNat(ctx context.Context) error {
 	var errs error
 	if m.natMap4 != nil {
@@ -211,7 +215,7 @@ func (m *Stats) countNat(ctx context.Context) error {
 		_, err := m.natMap4.ApplyBatch4(func(keys []tuple.TupleKey4, vals []nat.NatEntry4, size int) {
 			for i := 0; i < size; i++ {
 				key := *keys[i].ToHost().(*tuple.TupleKey4)
-				if key.Flags == tuple.TUPLE_F_IN &&
+				if flagsIsIn(key.Flags) &&
 					(key.NextHeader == u8proto.TCP || key.NextHeader == u8proto.ICMP ||
 						key.NextHeader == u8proto.UDP) {
 					key.DestPort = 0
@@ -239,7 +243,7 @@ func (m *Stats) countNat(ctx context.Context) error {
 		_, err := m.natMap6.ApplyBatch6(func(keys []tuple.TupleKey6, vals []nat.NatEntry6, size int) {
 			for i := 0; i < size; i++ {
 				key := *keys[i].ToHost().(*tuple.TupleKey6)
-				if key.Flags == tuple.TUPLE_F_IN &&
+				if flagsIsIn(key.Flags) &&
 					(key.NextHeader == u8proto.TCP || key.NextHeader == u8proto.ICMPv6 ||
 						key.NextHeader == u8proto.UDP) {
 					key.DestPort = 0


### PR DESCRIPTION
Previously this was doing a direct comparison agains the TUPLE_IN value. However this field is actually a flag bit set.

The non IN/OUT values appear to only be used for ctmap, not snat so this should have no outcome on functionality, however this makes this code future proof in case this assumption ever changes.