### PR TITLE
feat(cilium-cli-clustermesh): Improve --destination-context option for connecting multiple remote contexts

### DIFF
--- a/cilium-cli/cli/clustermesh.go
+++ b/cilium-cli/cli/clustermesh.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/cilium-cli/clustermesh"
+	"github.com/cilium/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium/cilium-cli/status"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 )
@@ -322,13 +324,17 @@ func newCmdClusterMeshDisconnectWithHelm() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().StringVar(&params.DestinationContext, "destination-context", "", "Kubernetes configuration context of destination cluster")
+	cmd.Flags().StringVar(&params.ConnectionMode, "connection-mode", defaults.ClusterMeshConnectionModeBidirectional,
+		fmt.Sprintf("Connection mode: %s, %s or %s", defaults.ClusterMeshConnectionModeUnicast, defaults.ClusterMeshConnectionModeBidirectional, defaults.ClusterMeshConnectionModeMesh))
+	cmd.Flags().StringSliceVar(&params.DestinationContext, "destination-context", []string{}, "Comma separated list of Kubernetes configuration contexts of destination cluster")
 
 	return cmd
 }
 
 func addCommonConnectFlags(cmd *cobra.Command, params *clustermesh.Parameters) {
-	cmd.Flags().StringVar(&params.DestinationContext, "destination-context", "", "Kubernetes configuration context of destination cluster")
+	cmd.Flags().StringVar(&params.ConnectionMode, "connection-mode", defaults.ClusterMeshConnectionModeBidirectional,
+		fmt.Sprintf("Connection mode: %s, %s or %s", defaults.ClusterMeshConnectionModeUnicast, defaults.ClusterMeshConnectionModeBidirectional, defaults.ClusterMeshConnectionModeMesh))
+	cmd.Flags().StringSliceVar(&params.DestinationContext, "destination-context", []string{}, "Comma separated list of Kubernetes configuration contexts of destination cluster")
 	cmd.Flags().StringSliceVar(&params.DestinationEndpoints, "destination-endpoint", []string{}, "IP of ClusterMesh service of destination cluster")
 	cmd.Flags().StringSliceVar(&params.SourceEndpoints, "source-endpoint", []string{}, "IP of ClusterMesh service of source cluster")
 }

--- a/cilium-cli/clustermesh/clustermesh_test.go
+++ b/cilium-cli/clustermesh/clustermesh_test.go
@@ -5,6 +5,8 @@ package clustermesh
 
 import (
 	"context"
+	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,15 +17,447 @@ import (
 	"github.com/cilium/cilium/cilium-cli/k8s"
 )
 
+// Helper function to compare two slices of maps ignoring the order
+func equalClusterSlices(a, b []map[string]interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	bCopy := make([]map[string]interface{}, len(b))
+	copy(bCopy, b)
+
+	return slices.EqualFunc(a, bCopy, func(m1, m2 map[string]interface{}) bool {
+		for i, bm := range bCopy {
+			if reflect.DeepEqual(m1, bm) {
+				bCopy = append(bCopy[:i], bCopy[i+1:]...)
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func TestMergeClusters(t *testing.T) {
+	uu := map[string]struct {
+		oc            []map[string]interface{}
+		nc            []map[string]interface{}
+		exceptCluster string
+		err           error
+		e             map[string]interface{}
+	}{
+		"nil-new-one": {
+			oc: []map[string]interface{}{},
+			nc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+			},
+			e: map[string]interface{}{
+				"clustermesh": map[string]interface{}{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"clusters": []map[string]interface{}{
+							{
+								"ips":  []string{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+						},
+					},
+				},
+			},
+		},
+		"nil-new-some": {
+			oc: []map[string]interface{}{},
+			nc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.7"},
+					"name": "c2",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.8"},
+					"name": "c1",
+					"port": "32379",
+				},
+			},
+			e: map[string]interface{}{
+				"clustermesh": map[string]interface{}{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"clusters": []map[string]interface{}{
+							{
+								"ips":  []string{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+							{
+								"ips":  []string{"172.19.0.7"},
+								"name": "c2",
+								"port": "32379",
+							},
+							{
+								"ips":  []string{"172.19.0.8"},
+								"name": "c1",
+								"port": "32379",
+							},
+						},
+					},
+				},
+			},
+		},
+		"oc-new-some": {
+			oc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.5"},
+					"name": "c2",
+					"port": "32379"},
+				{
+					"ips":  []string{"172.19.0.4"},
+					"name": "c1",
+					"port": "32379"},
+			},
+			nc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.7"},
+					"name": "c4",
+					"port": "32379",
+				},
+			},
+			e: map[string]interface{}{
+				"clustermesh": map[string]interface{}{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"clusters": []map[string]interface{}{
+							{
+								"ips":  []string{"172.19.0.5"},
+								"name": "c2",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.4"},
+								"name": "c1",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+							{
+								"ips":  []string{"172.19.0.7"},
+								"name": "c4",
+								"port": "32379",
+							},
+						},
+					},
+				},
+			},
+		},
+		"already-there": {
+			oc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.5"},
+					"name": "c2",
+					"port": "32379"},
+				{
+					"ips":  []string{"172.19.0.4"},
+					"name": "c1",
+					"port": "32379"},
+			},
+			nc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+			},
+			e: map[string]interface{}{
+				"clustermesh": map[string]interface{}{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"clusters": []map[string]interface{}{
+							{
+								"ips":  []string{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+							{
+								"ips":  []string{"172.19.0.5"},
+								"name": "c2",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.4"},
+								"name": "c1",
+								"port": "32379"},
+						},
+					},
+				},
+			},
+		},
+		"already-there-partially": {
+			oc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.5"},
+					"name": "c2",
+					"port": "32379"},
+				{
+					"ips":  []string{"172.19.0.4"},
+					"name": "c1",
+					"port": "32379"},
+			},
+			nc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.7"},
+					"name": "c4",
+					"port": "32379",
+				},
+			},
+			e: map[string]interface{}{
+				"clustermesh": map[string]interface{}{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"clusters": []map[string]interface{}{
+							{
+								"ips":  []string{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+							{
+								"ips":  []string{"172.19.0.5"},
+								"name": "c2",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.4"},
+								"name": "c1",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.7"},
+								"name": "c4",
+								"port": "32379"},
+						},
+					},
+				},
+			},
+		},
+		"except-nc-changed": {
+			oc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.5"},
+					"name": "c2",
+					"port": "32379"},
+				{
+					"ips":  []string{"172.19.0.4"},
+					"name": "c1",
+					"port": "32379"},
+			},
+			nc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.8"},
+					"name": "c5",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.7"},
+					"name": "c4",
+					"port": "32379",
+				},
+			},
+			exceptCluster: "c4",
+			e: map[string]interface{}{
+				"clustermesh": map[string]interface{}{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"clusters": []map[string]interface{}{
+							{
+								"ips":  []string{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+							{
+								"ips":  []string{"172.19.0.5"},
+								"name": "c2",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.4"},
+								"name": "c1",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.8"},
+								"name": "c5",
+								"port": "32379"},
+						},
+					},
+				},
+			},
+		},
+		"except-nc-same": {
+			oc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.5"},
+					"name": "c2",
+					"port": "32379"},
+				{
+					"ips":  []string{"172.19.0.4"},
+					"name": "c1",
+					"port": "32379"},
+			},
+			nc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.7"},
+					"name": "c4",
+					"port": "32379",
+				},
+			},
+			exceptCluster: "c4",
+			e: map[string]interface{}{
+				"clustermesh": map[string]interface{}{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"clusters": []map[string]interface{}{
+							{
+								"ips":  []string{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+							{
+								"ips":  []string{"172.19.0.5"},
+								"name": "c2",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.4"},
+								"name": "c1",
+								"port": "32379"},
+						},
+					},
+				},
+			},
+		},
+		"except-oc": {
+			oc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.5"},
+					"name": "c2",
+					"port": "32379"},
+				{
+					"ips":  []string{"172.19.0.4"},
+					"name": "c1",
+					"port": "32379"},
+			},
+			nc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.7"},
+					"name": "c4",
+					"port": "32379",
+				},
+			},
+			exceptCluster: "c2",
+			e: map[string]interface{}{
+				"clustermesh": map[string]interface{}{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"clusters": []map[string]interface{}{
+							{
+								"ips":  []string{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+							{
+								"ips":  []string{"172.19.0.5"},
+								"name": "c2",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.4"},
+								"name": "c1",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.7"},
+								"name": "c4",
+								"port": "32379"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			ee, err := mergeClusters(u.oc, u.nc, u.exceptCluster)
+			if err != nil {
+				assert.Equal(t, u.err, err)
+				return
+			}
+
+			// Compare the clusters ignoring the order
+			expectedClusters := u.e["clustermesh"].(map[string]interface{})["config"].(map[string]interface{})["clusters"].([]map[string]interface{})
+			actualClusters := ee["clustermesh"].(map[string]interface{})["config"].(map[string]interface{})["clusters"].([]map[string]interface{})
+
+			assert.True(t, equalClusterSlices(expectedClusters, actualClusters))
+		})
+	}
+}
+
 func TestRemoveFromClustermeshConfig(t *testing.T) {
 	uu := map[string]struct {
-		vv      map[string]any
-		cluster string
-		err     error
-		e       map[string]any
+		vv       map[string]any
+		clusters []string
+		err      error
+		e        map[string]any
 	}{
 		"missing": {
-			cluster: "test1",
+			clusters: []string{"test1", "test2"},
 			e: map[string]any{
 				"clustermesh": map[string]any{
 					"config": map[string]any{
@@ -34,7 +468,7 @@ func TestRemoveFromClustermeshConfig(t *testing.T) {
 			},
 		},
 		"empty": {
-			cluster: "c2",
+			clusters: []string{"c1", "c2"},
 			vv: map[string]any{
 				"clustermesh": map[string]any{
 					"config": map[string]any{
@@ -52,7 +486,43 @@ func TestRemoveFromClustermeshConfig(t *testing.T) {
 			},
 		},
 		"connected": {
-			cluster: "c2",
+			clusters: []string{"c1", "c2"},
+			vv: map[string]any{
+				"clustermesh": map[string]any{
+					"config": map[string]any{
+						"clusters": []any{
+							map[string]any{
+								"ips":  []any{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+							map[string]any{
+								"ips":  []any{"172.19.0.4"},
+								"name": "c2",
+								"port": "32379"},
+							map[string]any{
+								"ips":  []any{"172.19.0.4"},
+								"name": "c1",
+								"port": "32379"},
+						},
+					},
+				},
+			},
+			e: map[string]any{
+				"clustermesh": map[string]any{
+					"config": map[string]any{
+						"clusters": []map[string]any{
+							{
+								"ips":  []any{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+						}, "enabled": true},
+				},
+			},
+		},
+		"partially-connected": {
+			clusters: []string{"c3", "c4"},
 			vv: map[string]any{
 				"clustermesh": map[string]any{
 					"config": map[string]any{
@@ -75,8 +545,8 @@ func TestRemoveFromClustermeshConfig(t *testing.T) {
 					"config": map[string]any{
 						"clusters": []map[string]any{
 							{
-								"ips":  []any{"172.19.0.6"},
-								"name": "c3",
+								"ips":  []any{"172.19.0.4"},
+								"name": "c2",
 								"port": "32379",
 							},
 						}, "enabled": true},
@@ -84,7 +554,7 @@ func TestRemoveFromClustermeshConfig(t *testing.T) {
 			},
 		},
 		"not-connected": {
-			cluster: "c4",
+			clusters: []string{"c1", "c4"},
 			vv: map[string]any{
 				"clustermesh": map[string]any{
 					"config": map[string]any{
@@ -127,7 +597,7 @@ func TestRemoveFromClustermeshConfig(t *testing.T) {
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
-			ee, err := removeFromClustermeshConfig(u.vv, u.cluster)
+			ee, err := removeFromClustermeshConfig(u.vv, u.clusters)
 			if err != nil {
 				assert.Equal(t, u.err, err)
 				return

--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -36,23 +36,26 @@ const (
 
 	HubbleGenerateCertsCronJobName = "hubble-generate-certs"
 
-	ClusterMeshDeploymentName             = "clustermesh-apiserver"
-	ClusterMeshBinaryName                 = "/usr/bin/clustermesh-apiserver"
-	ClusterMeshContainerName              = "apiserver"
-	ClusterMeshPodSelector                = "k8s-app=clustermesh-apiserver"
-	ClusterMeshMetricsPortName            = "apiserv-metrics"
-	ClusterMeshKVStoreMeshContainerName   = "kvstoremesh"
-	ClusterMeshKVStoreMeshMetricsPortName = "kvmesh-metrics"
-	ClusterMeshEtcdContainerName          = "etcd"
-	ClusterMeshEtcdMetricsPortName        = "etcd-metrics"
-	ClusterMeshServiceName                = "clustermesh-apiserver"
-	ClusterMeshSecretName                 = "cilium-clustermesh" // Secret which contains the clustermesh configuration
-	ClusterMeshKVStoreMeshSecretName      = "cilium-kvstoremesh" // Secret which contains the kvstoremesh configuration
-	ClusterMeshServerSecretName           = "clustermesh-apiserver-server-cert"
-	ClusterMeshAdminSecretName            = "clustermesh-apiserver-admin-cert"
-	ClusterMeshClientSecretName           = "clustermesh-apiserver-client-cert"
-	ClusterMeshRemoteSecretName           = "clustermesh-apiserver-remote-cert"
-	ClusterMeshExternalWorkloadSecretName = "clustermesh-apiserver-external-workload-cert"
+	ClusterMeshDeploymentName              = "clustermesh-apiserver"
+	ClusterMeshBinaryName                  = "/usr/bin/clustermesh-apiserver"
+	ClusterMeshContainerName               = "apiserver"
+	ClusterMeshPodSelector                 = "k8s-app=clustermesh-apiserver"
+	ClusterMeshMetricsPortName             = "apiserv-metrics"
+	ClusterMeshKVStoreMeshContainerName    = "kvstoremesh"
+	ClusterMeshKVStoreMeshMetricsPortName  = "kvmesh-metrics"
+	ClusterMeshEtcdContainerName           = "etcd"
+	ClusterMeshEtcdMetricsPortName         = "etcd-metrics"
+	ClusterMeshServiceName                 = "clustermesh-apiserver"
+	ClusterMeshSecretName                  = "cilium-clustermesh" // Secret which contains the clustermesh configuration
+	ClusterMeshKVStoreMeshSecretName       = "cilium-kvstoremesh" // Secret which contains the kvstoremesh configuration
+	ClusterMeshServerSecretName            = "clustermesh-apiserver-server-cert"
+	ClusterMeshAdminSecretName             = "clustermesh-apiserver-admin-cert"
+	ClusterMeshClientSecretName            = "clustermesh-apiserver-client-cert"
+	ClusterMeshRemoteSecretName            = "clustermesh-apiserver-remote-cert"
+	ClusterMeshExternalWorkloadSecretName  = "clustermesh-apiserver-external-workload-cert"
+	ClusterMeshConnectionModeBidirectional = "bidirectional"
+	ClusterMeshConnectionModeMesh          = "mesh"
+	ClusterMeshConnectionModeUnicast       = "unicast"
 
 	SPIREServerStatefulSetName = "spire-server"
 	SPIREServerConfigMapName   = "spire-server"


### PR DESCRIPTION
Improve the `--destination-context` option to enhance the flexibility of connecting multiple remote contexts.

This feature supports various connection modes (using the `--connection-mode` option):

* unicast: configures only the source context
![Unicast](https://github.com/user-attachments/assets/2e580a23-909c-4d3a-963d-838a4d002d83)

Example for connection of 4 clusters:
```
cilium clustermesh connect --connection-mode=unicast --context=kind-cmesh1 --destination-context=kind-cmesh2,kind-cmesh3,kind-cmesh4
✨ Extracting access information of cluster cmesh1...
🔑 Extracting secrets from cluster cmesh1...
⚠️  Service type NodePort detected! Service may fail when nodes are removed from the cluster!
ℹ️  Found ClusterMesh service IPs: [172.18.0.5]
✨ Extracting access information of cluster cmesh2...
🔑 Extracting secrets from cluster cmesh2...
⚠️  Service type NodePort detected! Service may fail when nodes are removed from the cluster!
ℹ️  Found ClusterMesh service IPs: [172.18.0.3]
⚠️ Cilium CA certificates do not match between clusters. Multicluster features will be limited!
✨ Extracting access information of cluster cmesh3...
🔑 Extracting secrets from cluster cmesh3...
⚠️  Service type NodePort detected! Service may fail when nodes are removed from the cluster!
ℹ️  Found ClusterMesh service IPs: [172.18.0.2]
⚠️ Cilium CA certificates do not match between clusters. Multicluster features will be limited!
✨ Extracting access information of cluster cmesh4...
🔑 Extracting secrets from cluster cmesh4...
⚠️  Service type NodePort detected! Service may fail when nodes are removed from the cluster!
ℹ️  Found ClusterMesh service IPs: [172.18.0.4]
⚠️ Cilium CA certificates do not match between clusters. Multicluster features will be limited!
ℹ️ Configuring Cilium in cluster kind-cmesh1 to connect to cluster kind-cmesh2,kind-cmesh3,kind-cmesh4
✅ Connected cluster kind-cmesh1 => kind-cmesh2!
✅ Connected cluster kind-cmesh1 => kind-cmesh3!
✅ Connected cluster kind-cmesh1 => kind-cmesh4!
```
Example for disconnection of 4 clusters:

```
cilium clustermesh disconnect --connection-mode=unicast --context=kind-cmesh1 --destination-context=kind-cmesh2,kind-cmesh3,kind-cmesh4
ℹ️ Configuring Cilium in cluster kind-cmesh1 to disconnect from cluster kind-cmesh2,kind-cmesh3,kind-cmesh4
✅ Disconnected clusters kind-cmesh1 x> kind-cmesh2!
✅ Disconnected clusters kind-cmesh1 x> kind-cmesh3!
✅ Disconnected clusters kind-cmesh1 x> kind-cmesh4!
```

* bidirectional (default value): configures the source context and its cluster in the destination contexts
![bidirectional](https://github.com/user-attachments/assets/624e54a8-e407-4720-b4d4-6ff5ff7684a0)

Example for connection of 4 clusters:

```
cilium clustermesh connect --connection-mode=bidirectional --context=kind-cmesh1 --destination-context=kind-cmesh2,kind-cmesh3,kind-cmesh4
✨ Extracting access information of cluster cmesh1...
🔑 Extracting secrets from cluster cmesh1...
⚠️  Service type NodePort detected! Service may fail when nodes are removed from the cluster!
ℹ️  Found ClusterMesh service IPs: [172.18.0.2]
✨ Extracting access information of cluster cmesh2...
🔑 Extracting secrets from cluster cmesh2...
⚠️  Service type NodePort detected! Service may fail when nodes are removed from the cluster!
ℹ️  Found ClusterMesh service IPs: [172.18.0.3]
⚠️ Cilium CA certificates do not match between clusters. Multicluster features will be limited!
✨ Extracting access information of cluster cmesh3...
🔑 Extracting secrets from cluster cmesh3...
⚠️  Service type NodePort detected! Service may fail when nodes are removed from the cluster!
ℹ️  Found ClusterMesh service IPs: [172.18.0.4]
⚠️ Cilium CA certificates do not match between clusters. Multicluster features will be limited!
✨ Extracting access information of cluster cmesh4...
🔑 Extracting secrets from cluster cmesh4...
⚠️  Service type NodePort detected! Service may fail when nodes are removed from the cluster!
ℹ️  Found ClusterMesh service IPs: [172.18.0.5]
⚠️ Cilium CA certificates do not match between clusters. Multicluster features will be limited!
ℹ️ Configuring Cilium in cluster kind-cmesh1 to connect to cluster kind-cmesh2,kind-cmesh3,kind-cmesh4
ℹ️ Configuring Cilium in cluster kind-cmesh2 to connect to cluster kind-cmesh1
ℹ️ Configuring Cilium in cluster kind-cmesh3 to connect to cluster kind-cmesh1
ℹ️ Configuring Cilium in cluster kind-cmesh4 to connect to cluster kind-cmesh1
✅ Connected cluster kind-cmesh1 <=> kind-cmesh2!
✅ Connected cluster kind-cmesh1 <=> kind-cmesh3!
✅ Connected cluster kind-cmesh1 <=> kind-cmesh4!
```

Example for disconnection of 4 clusters:

```
cilium clustermesh disconnect --connection-mode=bidirectional --context=kind-cmesh1 --destination-context=kind-cmesh2,kind-cmesh3,kind-cmesh4
ℹ️ Configuring Cilium in cluster kind-cmesh1 to disconnect from cluster kind-cmesh2,kind-cmesh3,kind-cmesh4
ℹ️ Configuring Cilium in cluster kind-cmesh2 to disconnect from cluster kind-cmesh1
ℹ️ Configuring Cilium in cluster kind-cmesh3 to disconnect from cluster kind-cmesh1
ℹ️ Configuring Cilium in cluster kind-cmesh4 to disconnect from cluster kind-cmesh1
✅ Disconnected clusters kind-cmesh1 <x> kind-cmesh2!
✅ Disconnected clusters kind-cmesh1 <x> kind-cmesh3!
✅ Disconnected clusters kind-cmesh1 <x> kind-cmesh4!
```


* mesh: configures both the source and destination contexts, including clusters in both.
![Mesh](https://github.com/user-attachments/assets/b074d865-cebb-4212-8882-6308ccdfbab8)

Example for connection of 4 clusters:

```
cilium clustermesh connect --connection-mode=mesh --context=kind-cmesh1 --destination-context=kind-cmesh2,kind-cmesh3,kind-cmesh4
✨ Extracting access information of cluster cmesh1...
🔑 Extracting secrets from cluster cmesh1...
⚠️  Service type NodePort detected! Service may fail when nodes are removed from the cluster!
ℹ️  Found ClusterMesh service IPs: [172.18.0.2]
✨ Extracting access information of cluster cmesh2...
🔑 Extracting secrets from cluster cmesh2...
⚠️  Service type NodePort detected! Service may fail when nodes are removed from the cluster!
ℹ️  Found ClusterMesh service IPs: [172.18.0.5]
⚠️ Cilium CA certificates do not match between clusters. Multicluster features will be limited!
✨ Extracting access information of cluster cmesh3...
🔑 Extracting secrets from cluster cmesh3...
⚠️  Service type NodePort detected! Service may fail when nodes are removed from the cluster!
ℹ️  Found ClusterMesh service IPs: [172.18.0.4]
⚠️ Cilium CA certificates do not match between clusters. Multicluster features will be limited!
✨ Extracting access information of cluster cmesh4...
🔑 Extracting secrets from cluster cmesh4...
⚠️  Service type NodePort detected! Service may fail when nodes are removed from the cluster!
ℹ️  Found ClusterMesh service IPs: [172.18.0.3]
⚠️ Cilium CA certificates do not match between clusters. Multicluster features will be limited!
ℹ️ Configuring Cilium in cluster kind-cmesh1 to connect to cluster kind-cmesh2,kind-cmesh3,kind-cmesh4
ℹ️ Configuring Cilium in cluster kind-cmesh2 to connect to cluster kind-cmesh3,kind-cmesh4,kind-cmesh1
ℹ️ Configuring Cilium in cluster kind-cmesh3 to connect to cluster kind-cmesh2,kind-cmesh4,kind-cmesh1
ℹ️ Configuring Cilium in cluster kind-cmesh4 to connect to cluster kind-cmesh2,kind-cmesh3,kind-cmesh1
✅ Connected clusters kind-cmesh2, kind-cmesh3, kind-cmesh4, and kind-cmesh1!
```
Example for disconnection of 4 clusters:

```
cilium clustermesh disconnect --connection-mode=mesh --context=kind-cmesh1 --destination-context=kind-cmesh2,kind-cmesh3,kind-cmesh4
ℹ️ Configuring Cilium in cluster kind-cmesh1 to disconnect from cluster kind-cmesh2,kind-cmesh3,kind-cmesh4
ℹ️ Configuring Cilium in cluster kind-cmesh2 to disconnect from cluster kind-cmesh3,kind-cmesh4,kind-cmesh1
ℹ️ Configuring Cilium in cluster kind-cmesh3 to disconnect from cluster kind-cmesh2,kind-cmesh4,kind-cmesh1
ℹ️ Configuring Cilium in cluster kind-cmesh4 to disconnect from cluster kind-cmesh2,kind-cmesh3,kind-cmesh1
✅ Disconnected clusters kind-cmesh2, kind-cmesh3, kind-cmesh4, and kind-cmesh1!
```

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!


