### PR TITLE
sysctl: Replace dotted names with string slices

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -118,10 +118,9 @@ func configureHealthInterface(ifName string, ip4Addr, ip6Addr *net.IPNet) error 
 		// Use the direct sysctl without reconciliation of errors since we're in a different
 		// network namespace and thus can't use the normal sysctl API.
 		sysctl := sysctl.NewDirectSysctl(afero.NewOsFs(), option.Config.ProcFs)
-		name := fmt.Sprintf("net.ipv6.conf.%s.disable_ipv6", ifName)
 		// Ignore the error; if IPv6 is completely disabled
 		// then it's okay if we can't write the sysctl.
-		_ = sysctl.Enable(name)
+		_ = sysctl.EnableN([]string{"net", "ipv6", "conf", ifName, "disable_ipv6"})
 	} else {
 		if err = netlink.AddrAdd(link, &netlink.Addr{IPNet: ip6Addr}); err != nil {
 			return err

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -120,7 +120,7 @@ func configureHealthInterface(ifName string, ip4Addr, ip6Addr *net.IPNet) error 
 		sysctl := sysctl.NewDirectSysctl(afero.NewOsFs(), option.Config.ProcFs)
 		// Ignore the error; if IPv6 is completely disabled
 		// then it's okay if we can't write the sysctl.
-		_ = sysctl.EnableN([]string{"net", "ipv6", "conf", ifName, "disable_ipv6"})
+		_ = sysctl.Enable([]string{"net", "ipv6", "conf", ifName, "disable_ipv6"})
 	} else {
 		if err = netlink.AddrAdd(link, &netlink.Addr{IPNet: ip6Addr}); err != nil {
 			return err

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -423,7 +423,7 @@ func finishKubeProxyReplacementInit(sysctl sysctl.Sysctl, devices []*tables.Devi
 		// and the client IP is reachable via other device than the direct
 		// routing one.
 
-		if val, err := sysctl.Read(fmt.Sprintf("net.ipv4.conf.%s.rp_filter", directRoutingDevice)); err != nil {
+		if val, err := sysctl.ReadN([]string{"net", "ipv4", "conf", directRoutingDevice, "rp_filter"}); err != nil {
 			log.Warnf("Unable to read net.ipv4.conf.%s.rp_filter: %s. Ignoring the check",
 				directRoutingDevice, err)
 		} else {
@@ -519,7 +519,7 @@ func markHostExtension() {
 // Otherwise, if EnableAutoProtectNodePortRange == true, then append the nodeport
 // range to ip_local_reserved_ports.
 func checkNodePortAndEphemeralPortRanges(sysctl sysctl.Sysctl) error {
-	ephemeralPortRangeStr, err := sysctl.Read("net.ipv4.ip_local_port_range")
+	ephemeralPortRangeStr, err := sysctl.ReadN([]string{"net", "ipv4", "ip_local_port_range"})
 	if err != nil {
 		return fmt.Errorf("Unable to read net.ipv4.ip_local_port_range: %w", err)
 	}
@@ -551,7 +551,7 @@ func checkNodePortAndEphemeralPortRanges(sysctl sysctl.Sysctl) error {
 			nodePortRangeStr, ephemeralPortRangeStr)
 	}
 
-	reservedPortsStr, err := sysctl.Read("net.ipv4.ip_local_reserved_ports")
+	reservedPortsStr, err := sysctl.ReadN([]string{"net", "ipv4", "ip_local_reserved_ports"})
 	if err != nil {
 		return fmt.Errorf("Unable to read net.ipv4.ip_local_reserved_ports: %w", err)
 	}
@@ -597,7 +597,7 @@ func checkNodePortAndEphemeralPortRanges(sysctl sysctl.Sysctl) error {
 		reservedPortsStr += ","
 	}
 	reservedPortsStr += fmt.Sprintf("%d-%d", option.Config.NodePortMin, option.Config.NodePortMax)
-	if err := sysctl.Write("net.ipv4.ip_local_reserved_ports", reservedPortsStr); err != nil {
+	if err := sysctl.WriteN([]string{"net", "ipv4", "ip_local_reserved_ports"}, reservedPortsStr); err != nil {
 		return fmt.Errorf("Unable to addend nodeport range (%s) to net.ipv4.ip_local_reserved_ports: %w",
 			nodePortRangeStr, err)
 	}

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -423,7 +423,7 @@ func finishKubeProxyReplacementInit(sysctl sysctl.Sysctl, devices []*tables.Devi
 		// and the client IP is reachable via other device than the direct
 		// routing one.
 
-		if val, err := sysctl.ReadN([]string{"net", "ipv4", "conf", directRoutingDevice, "rp_filter"}); err != nil {
+		if val, err := sysctl.Read([]string{"net", "ipv4", "conf", directRoutingDevice, "rp_filter"}); err != nil {
 			log.Warnf("Unable to read net.ipv4.conf.%s.rp_filter: %s. Ignoring the check",
 				directRoutingDevice, err)
 		} else {
@@ -519,7 +519,7 @@ func markHostExtension() {
 // Otherwise, if EnableAutoProtectNodePortRange == true, then append the nodeport
 // range to ip_local_reserved_ports.
 func checkNodePortAndEphemeralPortRanges(sysctl sysctl.Sysctl) error {
-	ephemeralPortRangeStr, err := sysctl.ReadN([]string{"net", "ipv4", "ip_local_port_range"})
+	ephemeralPortRangeStr, err := sysctl.Read([]string{"net", "ipv4", "ip_local_port_range"})
 	if err != nil {
 		return fmt.Errorf("Unable to read net.ipv4.ip_local_port_range: %w", err)
 	}
@@ -551,7 +551,7 @@ func checkNodePortAndEphemeralPortRanges(sysctl sysctl.Sysctl) error {
 			nodePortRangeStr, ephemeralPortRangeStr)
 	}
 
-	reservedPortsStr, err := sysctl.ReadN([]string{"net", "ipv4", "ip_local_reserved_ports"})
+	reservedPortsStr, err := sysctl.Read([]string{"net", "ipv4", "ip_local_reserved_ports"})
 	if err != nil {
 		return fmt.Errorf("Unable to read net.ipv4.ip_local_reserved_ports: %w", err)
 	}
@@ -597,7 +597,7 @@ func checkNodePortAndEphemeralPortRanges(sysctl sysctl.Sysctl) error {
 		reservedPortsStr += ","
 	}
 	reservedPortsStr += fmt.Sprintf("%d-%d", option.Config.NodePortMin, option.Config.NodePortMax)
-	if err := sysctl.WriteN([]string{"net", "ipv4", "ip_local_reserved_ports"}, reservedPortsStr); err != nil {
+	if err := sysctl.Write([]string{"net", "ipv4", "ip_local_reserved_ports"}, reservedPortsStr); err != nil {
 		return fmt.Errorf("Unable to addend nodeport range (%s) to net.ipv4.ip_local_reserved_ports: %w",
 			nodePortRangeStr, err)
 	}

--- a/daemon/cmd/nodeport_linux_test.go
+++ b/daemon/cmd/nodeport_linux_test.go
@@ -28,17 +28,17 @@ func setupNodePortSuite(tb testing.TB) *NodePortSuite {
 
 	s := &NodePortSuite{}
 	s.sysctl = sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
-	prevEphemeralPortRange, err := s.sysctl.ReadN([]string{"net", "ipv4", "ip_local_port_range"})
+	prevEphemeralPortRange, err := s.sysctl.Read([]string{"net", "ipv4", "ip_local_port_range"})
 	require.Nil(tb, err)
 	s.prevEphemeralPortRange = prevEphemeralPortRange
-	prevReservedPortRanges, err := s.sysctl.ReadN([]string{"net", "ipv4", "ip_local_reserved_ports"})
+	prevReservedPortRanges, err := s.sysctl.Read([]string{"net", "ipv4", "ip_local_reserved_ports"})
 	require.Nil(tb, err)
 	s.prevReservedPortRanges = prevReservedPortRanges
 
 	tb.Cleanup(func() {
-		err = s.sysctl.WriteN([]string{"net", "ipv4", "ip_local_port_range"}, s.prevEphemeralPortRange)
+		err = s.sysctl.Write([]string{"net", "ipv4", "ip_local_port_range"}, s.prevEphemeralPortRange)
 		require.Nil(tb, err)
-		err = s.sysctl.WriteN([]string{"net", "ipv4", "ip_local_reserved_ports"}, s.prevReservedPortRanges)
+		err = s.sysctl.Write([]string{"net", "ipv4", "ip_local_reserved_ports"}, s.prevReservedPortRanges)
 		require.Nil(tb, err)
 	})
 
@@ -73,10 +73,10 @@ func TestCheckNodePortAndEphemeralPortRanges(t *testing.T) {
 		option.Config.NodePortMin = test.npMin
 		option.Config.NodePortMax = test.npMax
 		option.Config.EnableAutoProtectNodePortRange = test.autoProtect
-		err := s.sysctl.WriteN([]string{"net", "ipv4", "ip_local_port_range"},
+		err := s.sysctl.Write([]string{"net", "ipv4", "ip_local_port_range"},
 			fmt.Sprintf("%d %d", test.epMin, test.epMax))
 		require.Nil(t, err)
-		err = s.sysctl.WriteN([]string{"net", "ipv4", "ip_local_reserved_ports"}, test.resPorts)
+		err = s.sysctl.Write([]string{"net", "ipv4", "ip_local_reserved_ports"}, test.resPorts)
 		require.Nil(t, err)
 
 		err = checkNodePortAndEphemeralPortRanges(s.sysctl)
@@ -84,7 +84,7 @@ func TestCheckNodePortAndEphemeralPortRanges(t *testing.T) {
 			require.Condition(t, errorMatch(err, test.expErrMatch))
 		} else {
 			require.Nil(t, err)
-			resPorts, err := s.sysctl.ReadN([]string{"net", "ipv4", "ip_local_reserved_ports"})
+			resPorts, err := s.sysctl.Read([]string{"net", "ipv4", "ip_local_reserved_ports"})
 			require.Nil(t, err)
 			require.Equal(t, test.expResPorts, resPorts)
 		}

--- a/daemon/cmd/nodeport_linux_test.go
+++ b/daemon/cmd/nodeport_linux_test.go
@@ -28,17 +28,17 @@ func setupNodePortSuite(tb testing.TB) *NodePortSuite {
 
 	s := &NodePortSuite{}
 	s.sysctl = sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
-	prevEphemeralPortRange, err := s.sysctl.Read("net.ipv4.ip_local_port_range")
+	prevEphemeralPortRange, err := s.sysctl.ReadN([]string{"net", "ipv4", "ip_local_port_range"})
 	require.Nil(tb, err)
 	s.prevEphemeralPortRange = prevEphemeralPortRange
-	prevReservedPortRanges, err := s.sysctl.Read("net.ipv4.ip_local_reserved_ports")
+	prevReservedPortRanges, err := s.sysctl.ReadN([]string{"net", "ipv4", "ip_local_reserved_ports"})
 	require.Nil(tb, err)
 	s.prevReservedPortRanges = prevReservedPortRanges
 
 	tb.Cleanup(func() {
-		err = s.sysctl.Write("net.ipv4.ip_local_port_range", s.prevEphemeralPortRange)
+		err = s.sysctl.WriteN([]string{"net", "ipv4", "ip_local_port_range"}, s.prevEphemeralPortRange)
 		require.Nil(tb, err)
-		err = s.sysctl.Write("net.ipv4.ip_local_reserved_ports", s.prevReservedPortRanges)
+		err = s.sysctl.WriteN([]string{"net", "ipv4", "ip_local_reserved_ports"}, s.prevReservedPortRanges)
 		require.Nil(tb, err)
 	})
 
@@ -73,10 +73,10 @@ func TestCheckNodePortAndEphemeralPortRanges(t *testing.T) {
 		option.Config.NodePortMin = test.npMin
 		option.Config.NodePortMax = test.npMax
 		option.Config.EnableAutoProtectNodePortRange = test.autoProtect
-		err := s.sysctl.Write("net.ipv4.ip_local_port_range",
+		err := s.sysctl.WriteN([]string{"net", "ipv4", "ip_local_port_range"},
 			fmt.Sprintf("%d %d", test.epMin, test.epMax))
 		require.Nil(t, err)
-		err = s.sysctl.Write("net.ipv4.ip_local_reserved_ports", test.resPorts)
+		err = s.sysctl.WriteN([]string{"net", "ipv4", "ip_local_reserved_ports"}, test.resPorts)
 		require.Nil(t, err)
 
 		err = checkNodePortAndEphemeralPortRanges(s.sysctl)
@@ -84,7 +84,7 @@ func TestCheckNodePortAndEphemeralPortRanges(t *testing.T) {
 			require.Condition(t, errorMatch(err, test.expErrMatch))
 		} else {
 			require.Nil(t, err)
-			resPorts, err := s.sysctl.Read("net.ipv4.ip_local_reserved_ports")
+			resPorts, err := s.sysctl.ReadN([]string{"net", "ipv4", "ip_local_reserved_ports"})
 			require.Nil(t, err)
 			require.Equal(t, test.expResPorts, resPorts)
 		}

--- a/pkg/datapath/connector/add.go
+++ b/pkg/datapath/connector/add.go
@@ -46,5 +46,5 @@ func truncateString(epID string, maxLen uint) string {
 
 // DisableRpFilter tries to disable rpfilter on specified interface
 func DisableRpFilter(sysctl sysctl.Sysctl, ifName string) error {
-	return sysctl.DisableN([]string{"net", "ipv4", "conf", ifName, "rp_filter"})
+	return sysctl.Disable([]string{"net", "ipv4", "conf", ifName, "rp_filter"})
 }

--- a/pkg/datapath/connector/add.go
+++ b/pkg/datapath/connector/add.go
@@ -46,5 +46,5 @@ func truncateString(epID string, maxLen uint) string {
 
 // DisableRpFilter tries to disable rpfilter on specified interface
 func DisableRpFilter(sysctl sysctl.Sysctl, ifName string) error {
-	return sysctl.Disable(fmt.Sprintf("net.ipv4.conf.%s.rp_filter", ifName))
+	return sysctl.DisableN([]string{"net", "ipv4", "conf", ifName, "rp_filter"})
 }

--- a/pkg/datapath/fake/sysctl.go
+++ b/pkg/datapath/fake/sysctl.go
@@ -16,7 +16,15 @@ func (sysctl *Sysctl) Disable(name string) error {
 	return nil
 }
 
+func (sysctl *Sysctl) DisableN(name []string) error {
+	return nil
+}
+
 func (sysctl *Sysctl) Enable(name string) error {
+	return nil
+}
+
+func (sysctl *Sysctl) EnableN(name []string) error {
 	return nil
 }
 
@@ -24,7 +32,15 @@ func (sysctl *Sysctl) Write(name string, val string) error {
 	return nil
 }
 
+func (sysctl *Sysctl) WriteN(name []string, val string) error {
+	return nil
+}
+
 func (sysctl *Sysctl) WriteInt(name string, val int64) error {
+	return nil
+}
+
+func (sysctl *Sysctl) WriteIntN(name []string, val int64) error {
 	return nil
 }
 
@@ -36,6 +52,14 @@ func (sysctl *Sysctl) Read(name string) (string, error) {
 	return "", nil
 }
 
+func (sysctl *Sysctl) ReadN(name []string) (string, error) {
+	return "", nil
+}
+
 func (sysctl *Sysctl) ReadInt(name string) (int64, error) {
+	return int64(0), nil
+}
+
+func (sysctl *Sysctl) ReadIntN(name []string) (int64, error) {
 	return int64(0), nil
 }

--- a/pkg/datapath/fake/sysctl.go
+++ b/pkg/datapath/fake/sysctl.go
@@ -12,35 +12,19 @@ var _ sysctl.Sysctl = (*Sysctl)(nil)
 
 type Sysctl struct{}
 
-func (sysctl *Sysctl) Disable(name string) error {
+func (sysctl *Sysctl) Disable(name []string) error {
 	return nil
 }
 
-func (sysctl *Sysctl) DisableN(name []string) error {
+func (sysctl *Sysctl) Enable(name []string) error {
 	return nil
 }
 
-func (sysctl *Sysctl) Enable(name string) error {
+func (sysctl *Sysctl) Write(name []string, val string) error {
 	return nil
 }
 
-func (sysctl *Sysctl) EnableN(name []string) error {
-	return nil
-}
-
-func (sysctl *Sysctl) Write(name string, val string) error {
-	return nil
-}
-
-func (sysctl *Sysctl) WriteN(name []string, val string) error {
-	return nil
-}
-
-func (sysctl *Sysctl) WriteInt(name string, val int64) error {
-	return nil
-}
-
-func (sysctl *Sysctl) WriteIntN(name []string, val int64) error {
+func (sysctl *Sysctl) WriteInt(name []string, val int64) error {
 	return nil
 }
 
@@ -48,18 +32,10 @@ func (sysctl *Sysctl) ApplySettings(sysSettings []tables.Sysctl) error {
 	return nil
 }
 
-func (sysctl *Sysctl) Read(name string) (string, error) {
+func (sysctl *Sysctl) Read(name []string) (string, error) {
 	return "", nil
 }
 
-func (sysctl *Sysctl) ReadN(name []string) (string, error) {
-	return "", nil
-}
-
-func (sysctl *Sysctl) ReadInt(name string) (int64, error) {
-	return int64(0), nil
-}
-
-func (sysctl *Sysctl) ReadIntN(name []string) (int64, error) {
+func (sysctl *Sysctl) ReadInt(name []string) (int64, error) {
 	return int64(0), nil
 }

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -438,7 +438,7 @@ func (m *Manager) disableIPEarlyDemux() {
 		return
 	}
 
-	disabled := m.sysctl.DisableN([]string{"net", "ipv4", "ip_early_demux"}) == nil
+	disabled := m.sysctl.Disable([]string{"net", "ipv4", "ip_early_demux"}) == nil
 	if disabled {
 		m.ipEarlyDemuxDisabled = true
 		m.logger.Info("Disabled ip_early_demux to allow proxy redirection with original source/destination address without xt_socket support also in non-tunneled datapath modes.")

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -438,7 +438,7 @@ func (m *Manager) disableIPEarlyDemux() {
 		return
 	}
 
-	disabled := m.sysctl.Disable("net.ipv4.ip_early_demux") == nil
+	disabled := m.sysctl.DisableN([]string{"net", "ipv4", "ip_early_demux"}) == nil
 	if disabled {
 		m.ipEarlyDemuxDisabled = true
 		m.logger.Info("Disabled ip_early_demux to allow proxy redirection with original source/destination address without xt_socket support also in non-tunneled datapath modes.")

--- a/pkg/datapath/iptables/sysctl_linux.go
+++ b/pkg/datapath/iptables/sysctl_linux.go
@@ -8,14 +8,14 @@ import (
 )
 
 func enableIPForwarding(sysctl sysctl.Sysctl, ipv6 bool) error {
-	if err := sysctl.EnableN([]string{"net", "ipv4", "ip_forward"}); err != nil {
+	if err := sysctl.Enable([]string{"net", "ipv4", "ip_forward"}); err != nil {
 		return err
 	}
-	if err := sysctl.EnableN([]string{"net", "ipv4", "conf", "all", "forwarding"}); err != nil {
+	if err := sysctl.Enable([]string{"net", "ipv4", "conf", "all", "forwarding"}); err != nil {
 		return err
 	}
 	if ipv6 {
-		if err := sysctl.EnableN([]string{"net", "ipv6", "conf", "all", "forwarding"}); err != nil {
+		if err := sysctl.Enable([]string{"net", "ipv6", "conf", "all", "forwarding"}); err != nil {
 			return err
 		}
 	}

--- a/pkg/datapath/iptables/sysctl_linux.go
+++ b/pkg/datapath/iptables/sysctl_linux.go
@@ -8,14 +8,14 @@ import (
 )
 
 func enableIPForwarding(sysctl sysctl.Sysctl, ipv6 bool) error {
-	if err := sysctl.Enable("net.ipv4.ip_forward"); err != nil {
+	if err := sysctl.EnableN([]string{"net", "ipv4", "ip_forward"}); err != nil {
 		return err
 	}
-	if err := sysctl.Enable("net.ipv4.conf.all.forwarding"); err != nil {
+	if err := sysctl.EnableN([]string{"net", "ipv4", "conf", "all", "forwarding"}); err != nil {
 		return err
 	}
 	if ipv6 {
-		if err := sysctl.Enable("net.ipv6.conf.all.forwarding"); err != nil {
+		if err := sysctl.EnableN([]string{"net", "ipv6", "conf", "all", "forwarding"}); err != nil {
 			return err
 		}
 	}

--- a/pkg/datapath/linux/bandwidth/bandwidth.go
+++ b/pkg/datapath/linux/bandwidth/bandwidth.go
@@ -10,6 +10,7 @@ package bandwidth
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/bwmap"
@@ -108,7 +110,7 @@ func (m *manager) probe() error {
 	if !m.params.Config.EnableBandwidthManager {
 		return nil
 	}
-	if _, err := m.params.Sysctl.Read("net.core.default_qdisc"); err != nil {
+	if _, err := m.params.Sysctl.ReadN([]string{"net", "core", "default_qdisc"}); err != nil {
 		m.params.Log.Warn("BPF bandwidth manager could not read procfs. Disabling the feature.", logfields.Error, err)
 		return nil
 	}
@@ -158,32 +160,35 @@ func (m *manager) init() error {
 
 func setBaselineSysctls(p bandwidthManagerParams) error {
 	// Ensure interger type sysctls are no smaller than our baseline settings
-	baseIntSettings := map[string]int64{
-		"net.core.netdev_max_backlog":  1000,
-		"net.core.somaxconn":           4096,
-		"net.ipv4.tcp_max_syn_backlog": 4096,
+	baseIntSettings := []struct {
+		name []string
+		val  int64
+	}{
+		{[]string{"net", "core", "netdev_max_backlog"}, 1000},
+		{[]string{"net", "core", "somaxconn"}, 4096},
+		{[]string{"net", "ipv4", "tcp_max_syn_backlog"}, 4096},
 	}
 
-	for name, value := range baseIntSettings {
-		currentValue, err := p.Sysctl.ReadInt(name)
+	for _, setting := range baseIntSettings {
+		currentValue, err := p.Sysctl.ReadIntN(setting.name)
 		if err != nil {
-			return fmt.Errorf("read sysctl %s failed: %w", name, err)
+			return fmt.Errorf("read sysctl %s failed: %w", strings.Join(setting.name, "."), err)
 		}
 
 		scopedLog := p.Log.With(
-			logfields.SysParamName, name,
+			logfields.SysParamName, strings.Join(setting.name, "."),
 			logfields.SysParamValue, currentValue,
-			"baselineValue", value,
+			"baselineValue", setting.val,
 		)
 
-		if currentValue >= value {
+		if currentValue >= setting.val {
 			scopedLog.Info("Skip setting sysctl as it already meets baseline")
 			continue
 		}
 
 		scopedLog.Info("Setting sysctl to baseline for BPF bandwidth manager")
-		if err := p.Sysctl.WriteInt(name, value); err != nil {
-			return fmt.Errorf("set sysctl %s=%d failed: %w", name, value, err)
+		if err := p.Sysctl.WriteIntN(setting.name, setting.val); err != nil {
+			return fmt.Errorf("set sysctl %s=%d failed: %w", strings.Join(setting.name, "."), setting.val, err)
 		}
 	}
 
@@ -193,40 +198,21 @@ func setBaselineSysctls(p bandwidthManagerParams) error {
 		congctl = "bbr"
 	}
 
-	baseStringSettings := map[string]string{
-		"net.core.default_qdisc":          "fq",
-		"net.ipv4.tcp_congestion_control": congctl,
-	}
-
-	for name, value := range baseStringSettings {
-		p.Log.Info("Setting sysctl to baseline for BPF bandwidth manager",
-			logfields.SysParamName, name,
-			"baselineValue", value,
-		)
-
-		if err := p.Sysctl.Write(name, value); err != nil {
-			return fmt.Errorf("set sysctl %s=%s failed: %w", name, value, err)
-		}
-	}
-
-	// Extra settings
-	extraSettings := map[string]int64{
-		"net.ipv4.tcp_slow_start_after_idle": 0,
+	sysctls := []tables.Sysctl{
+		{Name: []string{"net", "core", "default_qdisc"}, Val: "fq"},
+		{Name: []string{"net", "ipv4", "tcp_congestion_control"}, Val: congctl},
 	}
 
 	// Few extra knobs which can be turned on along with pacing. EnableBBR
 	// also provides the right kernel dependency implicitly as well.
 	if p.Config.EnableBBR {
-		for name, value := range extraSettings {
-			p.Log.Info("Setting sysctl to baseline for BPF bandwidth manager",
-				logfields.SysParamName, name,
-				"baselineValue", value,
-			)
+		sysctls = append(sysctls, tables.Sysctl{
+			Name: []string{"net", "ipv4", "tcp_slow_start_after_idle"}, Val: "0",
+		})
+	}
 
-			if err := p.Sysctl.WriteInt(name, value); err != nil {
-				return fmt.Errorf("set sysctl %s=%d failed: %w", name, value, err)
-			}
-		}
+	if err := p.Sysctl.ApplySettings(sysctls); err != nil {
+		return fmt.Errorf("failed to apply sysctls: %w", err)
 	}
 
 	return nil

--- a/pkg/datapath/linux/bandwidth/bandwidth.go
+++ b/pkg/datapath/linux/bandwidth/bandwidth.go
@@ -110,7 +110,7 @@ func (m *manager) probe() error {
 	if !m.params.Config.EnableBandwidthManager {
 		return nil
 	}
-	if _, err := m.params.Sysctl.ReadN([]string{"net", "core", "default_qdisc"}); err != nil {
+	if _, err := m.params.Sysctl.Read([]string{"net", "core", "default_qdisc"}); err != nil {
 		m.params.Log.Warn("BPF bandwidth manager could not read procfs. Disabling the feature.", logfields.Error, err)
 		return nil
 	}
@@ -170,7 +170,7 @@ func setBaselineSysctls(p bandwidthManagerParams) error {
 	}
 
 	for _, setting := range baseIntSettings {
-		currentValue, err := p.Sysctl.ReadIntN(setting.name)
+		currentValue, err := p.Sysctl.ReadInt(setting.name)
 		if err != nil {
 			return fmt.Errorf("read sysctl %s failed: %w", strings.Join(setting.name, "."), err)
 		}
@@ -187,7 +187,7 @@ func setBaselineSysctls(p bandwidthManagerParams) error {
 		}
 
 		scopedLog.Info("Setting sysctl to baseline for BPF bandwidth manager")
-		if err := p.Sysctl.WriteIntN(setting.name, setting.val); err != nil {
+		if err := p.Sysctl.WriteInt(setting.name, setting.val); err != nil {
 			return fmt.Errorf("set sysctl %s=%d failed: %w", strings.Join(setting.name, "."), setting.val, err)
 		}
 	}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -832,7 +832,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 }
 
 func getEphemeralPortRangeMin(sysctl sysctl.Sysctl) (int, error) {
-	ephemeralPortRangeStr, err := sysctl.Read("net.ipv4.ip_local_port_range")
+	ephemeralPortRangeStr, err := sysctl.ReadN([]string{"net", "ipv4", "ip_local_port_range"})
 	if err != nil {
 		return 0, fmt.Errorf("unable to read net.ipv4.ip_local_port_range: %w", err)
 	}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -832,7 +832,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 }
 
 func getEphemeralPortRangeMin(sysctl sysctl.Sysctl) (int, error) {
-	ephemeralPortRangeStr, err := sysctl.ReadN([]string{"net", "ipv4", "ip_local_port_range"})
+	ephemeralPortRangeStr, err := sysctl.Read([]string{"net", "ipv4", "ip_local_port_range"})
 	if err != nil {
 		return 0, fmt.Errorf("unable to read net.ipv4.ip_local_port_range: %w", err)
 	}

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1401,17 +1401,17 @@ func TestArpPingHandlingIPv6(t *testing.T) {
 	tmpDir := t.TempDir()
 	option.Config.StateDir = tmpDir
 
-	baseTimeOld, err := s.sysctl.ReadN(baseIPv6Time)
+	baseTimeOld, err := s.sysctl.Read(baseIPv6Time)
 	require.NoError(t, err)
-	err = s.sysctl.WriteN(baseIPv6Time, fmt.Sprintf("%d", baseTime))
+	err = s.sysctl.Write(baseIPv6Time, fmt.Sprintf("%d", baseTime))
 	require.NoError(t, err)
-	defer func() { s.sysctl.WriteN(baseIPv6Time, baseTimeOld) }()
+	defer func() { s.sysctl.Write(baseIPv6Time, baseTimeOld) }()
 
-	mcastNumOld, err := s.sysctl.ReadN(mcastNumIPv6)
+	mcastNumOld, err := s.sysctl.Read(mcastNumIPv6)
 	require.NoError(t, err)
-	err = s.sysctl.WriteN(mcastNumIPv6, fmt.Sprintf("%d", mcastNum))
+	err = s.sysctl.Write(mcastNumIPv6, fmt.Sprintf("%d", mcastNum))
 	require.NoError(t, err)
-	defer func() { s.sysctl.WriteN(mcastNumIPv6, mcastNumOld) }()
+	defer func() { s.sysctl.Write(mcastNumIPv6, mcastNumOld) }()
 
 	// 1. Test whether another node in the same L2 subnet can be arpinged.
 	//    The other node is in the different netns reachable via the veth pair.
@@ -2028,17 +2028,17 @@ func TestArpPingHandlingForMultiDeviceIPv6(t *testing.T) {
 	tmpDir := t.TempDir()
 	option.Config.StateDir = tmpDir
 
-	baseTimeOld, err := s.sysctl.ReadN(baseIPv6Time)
+	baseTimeOld, err := s.sysctl.Read(baseIPv6Time)
 	require.NoError(t, err)
-	err = s.sysctl.WriteN(baseIPv6Time, fmt.Sprintf("%d", baseTime))
+	err = s.sysctl.Write(baseIPv6Time, fmt.Sprintf("%d", baseTime))
 	require.NoError(t, err)
-	defer func() { s.sysctl.WriteN(baseIPv6Time, baseTimeOld) }()
+	defer func() { s.sysctl.Write(baseIPv6Time, baseTimeOld) }()
 
-	mcastNumOld, err := s.sysctl.ReadN(mcastNumIPv6)
+	mcastNumOld, err := s.sysctl.Read(mcastNumIPv6)
 	require.NoError(t, err)
-	err = s.sysctl.WriteN(mcastNumIPv6, fmt.Sprintf("%d", mcastNum))
+	err = s.sysctl.Write(mcastNumIPv6, fmt.Sprintf("%d", mcastNum))
 	require.NoError(t, err)
-	defer func() { s.sysctl.WriteN(mcastNumIPv6, mcastNumOld) }()
+	defer func() { s.sysctl.Write(mcastNumIPv6, mcastNumOld) }()
 
 	// 1. Test whether another node with multiple paths can be arpinged.
 	//    Each node has two devices and the other node in the different netns
@@ -2425,17 +2425,17 @@ func TestArpPingHandlingIPv4(t *testing.T) {
 	tmpDir := t.TempDir()
 	option.Config.StateDir = tmpDir
 
-	baseTimeOld, err := s.sysctl.ReadN(baseIPv4Time)
+	baseTimeOld, err := s.sysctl.Read(baseIPv4Time)
 	require.NoError(t, err)
-	err = s.sysctl.WriteN(baseIPv4Time, fmt.Sprintf("%d", baseTime))
+	err = s.sysctl.Write(baseIPv4Time, fmt.Sprintf("%d", baseTime))
 	require.NoError(t, err)
-	defer func() { s.sysctl.WriteN(baseIPv4Time, baseTimeOld) }()
+	defer func() { s.sysctl.Write(baseIPv4Time, baseTimeOld) }()
 
-	mcastNumOld, err := s.sysctl.ReadN(mcastNumIPv4)
+	mcastNumOld, err := s.sysctl.Read(mcastNumIPv4)
 	require.NoError(t, err)
-	err = s.sysctl.WriteN(mcastNumIPv4, fmt.Sprintf("%d", mcastNum))
+	err = s.sysctl.Write(mcastNumIPv4, fmt.Sprintf("%d", mcastNum))
 	require.NoError(t, err)
-	defer func() { s.sysctl.WriteN(mcastNumIPv4, mcastNumOld) }()
+	defer func() { s.sysctl.Write(mcastNumIPv4, mcastNumOld) }()
 
 	// 1. Test whether another node in the same L2 subnet can be arpinged.
 	//    The other node is in the different netns reachable via the veth pair.
@@ -3049,17 +3049,17 @@ func TestArpPingHandlingForMultiDeviceIPv4(t *testing.T) {
 	tmpDir := t.TempDir()
 	option.Config.StateDir = tmpDir
 
-	baseTimeOld, err := s.sysctl.ReadN(baseIPv4Time)
+	baseTimeOld, err := s.sysctl.Read(baseIPv4Time)
 	require.NoError(t, err)
-	err = s.sysctl.WriteN(baseIPv4Time, fmt.Sprintf("%d", baseTime))
+	err = s.sysctl.Write(baseIPv4Time, fmt.Sprintf("%d", baseTime))
 	require.NoError(t, err)
-	defer func() { s.sysctl.WriteN(baseIPv4Time, baseTimeOld) }()
+	defer func() { s.sysctl.Write(baseIPv4Time, baseTimeOld) }()
 
-	mcastNumOld, err := s.sysctl.ReadN(mcastNumIPv4)
+	mcastNumOld, err := s.sysctl.Read(mcastNumIPv4)
 	require.NoError(t, err)
-	err = s.sysctl.WriteN(mcastNumIPv4, fmt.Sprintf("%d", mcastNum))
+	err = s.sysctl.Write(mcastNumIPv4, fmt.Sprintf("%d", mcastNum))
 	require.NoError(t, err)
-	defer func() { s.sysctl.WriteN(mcastNumIPv4, mcastNumOld) }()
+	defer func() { s.sysctl.Write(mcastNumIPv4, mcastNumOld) }()
 
 	// 1. Test whether another node with multiple paths can be arpinged.
 	//    Each node has two devices and the other node in the different netns

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -84,13 +84,16 @@ const (
 	dummyHostDeviceName     = "dummy_host"
 	dummyExternalDeviceName = "dummy_external"
 
-	baseIPv4Time = "net.ipv4.neigh.default.base_reachable_time_ms"
-	baseIPv6Time = "net.ipv6.neigh.default.base_reachable_time_ms"
-	baseTime     = 2500
+	baseTime = 2500
+	mcastNum = 6
+)
 
-	mcastNumIPv4 = "net.ipv4.neigh.default.mcast_solicit"
-	mcastNumIPv6 = "net.ipv6.neigh.default.mcast_solicit"
-	mcastNum     = 6
+var (
+	baseIPv4Time = []string{"net", "ipv4", "neigh", "default", "base_reachable_time_ms"}
+	baseIPv6Time = []string{"net", "ipv6", "neigh", "default", "base_reachable_time_ms"}
+
+	mcastNumIPv4 = []string{"net", "ipv4", "neigh", "default", "mcast_solicit"}
+	mcastNumIPv6 = []string{"net", "ipv6", "neigh", "default", "mcast_solicit"}
 )
 
 func setupLinuxPrivilegedBaseTestSuite(tb testing.TB, addressing datapath.NodeAddressing, enableIPv6, enableIPv4 bool) *linuxPrivilegedBaseTestSuite {
@@ -1398,17 +1401,17 @@ func TestArpPingHandlingIPv6(t *testing.T) {
 	tmpDir := t.TempDir()
 	option.Config.StateDir = tmpDir
 
-	baseTimeOld, err := s.sysctl.Read(baseIPv6Time)
+	baseTimeOld, err := s.sysctl.ReadN(baseIPv6Time)
 	require.NoError(t, err)
-	err = s.sysctl.Write(baseIPv6Time, fmt.Sprintf("%d", baseTime))
+	err = s.sysctl.WriteN(baseIPv6Time, fmt.Sprintf("%d", baseTime))
 	require.NoError(t, err)
-	defer func() { s.sysctl.Write(baseIPv6Time, baseTimeOld) }()
+	defer func() { s.sysctl.WriteN(baseIPv6Time, baseTimeOld) }()
 
-	mcastNumOld, err := s.sysctl.Read(mcastNumIPv6)
+	mcastNumOld, err := s.sysctl.ReadN(mcastNumIPv6)
 	require.NoError(t, err)
-	err = s.sysctl.Write(mcastNumIPv6, fmt.Sprintf("%d", mcastNum))
+	err = s.sysctl.WriteN(mcastNumIPv6, fmt.Sprintf("%d", mcastNum))
 	require.NoError(t, err)
-	defer func() { s.sysctl.Write(mcastNumIPv6, mcastNumOld) }()
+	defer func() { s.sysctl.WriteN(mcastNumIPv6, mcastNumOld) }()
 
 	// 1. Test whether another node in the same L2 subnet can be arpinged.
 	//    The other node is in the different netns reachable via the veth pair.
@@ -2025,17 +2028,17 @@ func TestArpPingHandlingForMultiDeviceIPv6(t *testing.T) {
 	tmpDir := t.TempDir()
 	option.Config.StateDir = tmpDir
 
-	baseTimeOld, err := s.sysctl.Read(baseIPv6Time)
+	baseTimeOld, err := s.sysctl.ReadN(baseIPv6Time)
 	require.NoError(t, err)
-	err = s.sysctl.Write(baseIPv6Time, fmt.Sprintf("%d", baseTime))
+	err = s.sysctl.WriteN(baseIPv6Time, fmt.Sprintf("%d", baseTime))
 	require.NoError(t, err)
-	defer func() { s.sysctl.Write(baseIPv6Time, baseTimeOld) }()
+	defer func() { s.sysctl.WriteN(baseIPv6Time, baseTimeOld) }()
 
-	mcastNumOld, err := s.sysctl.Read(mcastNumIPv6)
+	mcastNumOld, err := s.sysctl.ReadN(mcastNumIPv6)
 	require.NoError(t, err)
-	err = s.sysctl.Write(mcastNumIPv6, fmt.Sprintf("%d", mcastNum))
+	err = s.sysctl.WriteN(mcastNumIPv6, fmt.Sprintf("%d", mcastNum))
 	require.NoError(t, err)
-	defer func() { s.sysctl.Write(mcastNumIPv6, mcastNumOld) }()
+	defer func() { s.sysctl.WriteN(mcastNumIPv6, mcastNumOld) }()
 
 	// 1. Test whether another node with multiple paths can be arpinged.
 	//    Each node has two devices and the other node in the different netns
@@ -2422,17 +2425,17 @@ func TestArpPingHandlingIPv4(t *testing.T) {
 	tmpDir := t.TempDir()
 	option.Config.StateDir = tmpDir
 
-	baseTimeOld, err := s.sysctl.Read(baseIPv4Time)
+	baseTimeOld, err := s.sysctl.ReadN(baseIPv4Time)
 	require.NoError(t, err)
-	err = s.sysctl.Write(baseIPv4Time, fmt.Sprintf("%d", baseTime))
+	err = s.sysctl.WriteN(baseIPv4Time, fmt.Sprintf("%d", baseTime))
 	require.NoError(t, err)
-	defer func() { s.sysctl.Write(baseIPv4Time, baseTimeOld) }()
+	defer func() { s.sysctl.WriteN(baseIPv4Time, baseTimeOld) }()
 
-	mcastNumOld, err := s.sysctl.Read(mcastNumIPv4)
+	mcastNumOld, err := s.sysctl.ReadN(mcastNumIPv4)
 	require.NoError(t, err)
-	err = s.sysctl.Write(mcastNumIPv4, fmt.Sprintf("%d", mcastNum))
+	err = s.sysctl.WriteN(mcastNumIPv4, fmt.Sprintf("%d", mcastNum))
 	require.NoError(t, err)
-	defer func() { s.sysctl.Write(mcastNumIPv4, mcastNumOld) }()
+	defer func() { s.sysctl.WriteN(mcastNumIPv4, mcastNumOld) }()
 
 	// 1. Test whether another node in the same L2 subnet can be arpinged.
 	//    The other node is in the different netns reachable via the veth pair.
@@ -3046,17 +3049,17 @@ func TestArpPingHandlingForMultiDeviceIPv4(t *testing.T) {
 	tmpDir := t.TempDir()
 	option.Config.StateDir = tmpDir
 
-	baseTimeOld, err := s.sysctl.Read(baseIPv4Time)
+	baseTimeOld, err := s.sysctl.ReadN(baseIPv4Time)
 	require.NoError(t, err)
-	err = s.sysctl.Write(baseIPv4Time, fmt.Sprintf("%d", baseTime))
+	err = s.sysctl.WriteN(baseIPv4Time, fmt.Sprintf("%d", baseTime))
 	require.NoError(t, err)
-	defer func() { s.sysctl.Write(baseIPv4Time, baseTimeOld) }()
+	defer func() { s.sysctl.WriteN(baseIPv4Time, baseTimeOld) }()
 
-	mcastNumOld, err := s.sysctl.Read(mcastNumIPv4)
+	mcastNumOld, err := s.sysctl.ReadN(mcastNumIPv4)
 	require.NoError(t, err)
-	err = s.sysctl.Write(mcastNumIPv4, fmt.Sprintf("%d", mcastNum))
+	err = s.sysctl.WriteN(mcastNumIPv4, fmt.Sprintf("%d", mcastNum))
 	require.NoError(t, err)
-	defer func() { s.sysctl.Write(mcastNumIPv4, mcastNumOld) }()
+	defer func() { s.sysctl.WriteN(mcastNumIPv4, mcastNumOld) }()
 
 	// 1. Test whether another node with multiple paths can be arpinged.
 	//    Each node has two devices and the other node in the different netns

--- a/pkg/datapath/linux/sysctl/ops.go
+++ b/pkg/datapath/linux/sysctl/ops.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/spf13/afero"
 
@@ -29,7 +30,7 @@ type ops struct {
 
 func (ops *ops) Update(ctx context.Context, txn statedb.ReadTxn, s *tables.Sysctl) error {
 	log := ops.log.With(
-		logfields.SysParamName, s.Name,
+		logfields.SysParamName, strings.Join(s.Name, "."),
 		logfields.SysParamValue, s.Val,
 	)
 

--- a/pkg/datapath/linux/sysctl/sysctl.go
+++ b/pkg/datapath/linux/sysctl/sysctl.go
@@ -31,26 +31,22 @@ type Sysctl interface {
 	// Disable disables the given sysctl parameter.
 	// It blocks until the parameter has been actually set to "0",
 	// or timeouts after reconciliationTimeout.
-	Disable(name string) error
-	DisableN(name []string) error
+	Disable(name []string) error
 
 	// Enable enables the given sysctl parameter.
 	// It blocks until the parameter has been actually set to "1",
 	// or timeouts after reconciliationTimeout.
-	Enable(name string) error
-	EnableN(name []string) error
+	Enable(name []string) error
 
 	// Write writes the given sysctl parameter.
 	// It blocks until the parameter has been actually set to val,
 	// or timeouts after reconciliationTimeout.
-	Write(name string, val string) error
-	WriteN(name []string, val string) error
+	Write(name []string, val string) error
 
 	// WriteInt writes the given integer type sysctl parameter.
 	// It blocks until the parameter has been actually set to val,
 	// or timeouts after reconciliationTimeout.
-	WriteInt(name string, val int64) error
-	WriteIntN(name []string, val int64) error
+	WriteInt(name []string, val int64) error
 
 	// ApplySettings applies all settings in sysSettings.
 	// After applying all settings, it blocks until the parameters have been
@@ -58,12 +54,10 @@ type Sysctl interface {
 	ApplySettings(sysSettings []tables.Sysctl) error
 
 	// Read reads the given sysctl parameter.
-	Read(name string) (string, error)
-	ReadN(name []string) (string, error)
+	Read(name []string) (string, error)
 
 	// ReadInt reads the given sysctl parameter, return an int64 value.
-	ReadInt(name string) (int64, error)
-	ReadIntN(name []string) (int64, error)
+	ReadInt(name []string) (int64, error)
 }
 
 // reconcilingSysctl is a Sysctl implementation that uses reconciliation to
@@ -88,11 +82,7 @@ func newReconcilingSysctl(
 	return &reconcilingSysctl{db, settings, fs, cfg.ProcFs}
 }
 
-func (sysctl *reconcilingSysctl) Disable(name string) error {
-	return sysctl.DisableN(strings.Split(name, "."))
-}
-
-func (sysctl *reconcilingSysctl) DisableN(name []string) error {
+func (sysctl *reconcilingSysctl) Disable(name []string) error {
 	txn := sysctl.db.WriteTxn(sysctl.settings)
 	_, _, _ = sysctl.settings.Insert(txn, &tables.Sysctl{
 		Name:   name,
@@ -104,11 +94,7 @@ func (sysctl *reconcilingSysctl) DisableN(name []string) error {
 	return sysctl.waitForReconciliation(name)
 }
 
-func (sysctl *reconcilingSysctl) Enable(name string) error {
-	return sysctl.EnableN(strings.Split(name, "."))
-}
-
-func (sysctl *reconcilingSysctl) EnableN(name []string) error {
+func (sysctl *reconcilingSysctl) Enable(name []string) error {
 	txn := sysctl.db.WriteTxn(sysctl.settings)
 	_, _, _ = sysctl.settings.Insert(txn, &tables.Sysctl{
 		Name:   name,
@@ -120,11 +106,7 @@ func (sysctl *reconcilingSysctl) EnableN(name []string) error {
 	return sysctl.waitForReconciliation(name)
 }
 
-func (sysctl *reconcilingSysctl) Write(name string, val string) error {
-	return sysctl.WriteN(strings.Split(name, "."), val)
-}
-
-func (sysctl *reconcilingSysctl) WriteN(name []string, val string) error {
+func (sysctl *reconcilingSysctl) Write(name []string, val string) error {
 	txn := sysctl.db.WriteTxn(sysctl.settings)
 	_, _, _ = sysctl.settings.Insert(txn, &tables.Sysctl{
 		Name:   name,
@@ -136,11 +118,7 @@ func (sysctl *reconcilingSysctl) WriteN(name []string, val string) error {
 	return sysctl.waitForReconciliation(name)
 }
 
-func (sysctl *reconcilingSysctl) WriteInt(name string, val int64) error {
-	return sysctl.WriteIntN(strings.Split(name, "."), val)
-}
-
-func (sysctl *reconcilingSysctl) WriteIntN(name []string, val int64) error {
+func (sysctl *reconcilingSysctl) WriteInt(name []string, val int64) error {
 	txn := sysctl.db.WriteTxn(sysctl.settings)
 	_, _, _ = sysctl.settings.Insert(txn, &tables.Sysctl{
 		Name:   name,
@@ -167,11 +145,7 @@ func (sysctl *reconcilingSysctl) ApplySettings(sysSettings []tables.Sysctl) erro
 	return errors.Join(errs...)
 }
 
-func (sysctl *reconcilingSysctl) Read(name string) (string, error) {
-	return sysctl.ReadN(strings.Split(name, "."))
-}
-
-func (sysctl *reconcilingSysctl) ReadN(name []string) (string, error) {
+func (sysctl *reconcilingSysctl) Read(name []string) (string, error) {
 	path, err := parameterPath(sysctl.procFs, name)
 	if err != nil {
 		return "", err
@@ -185,12 +159,8 @@ func (sysctl *reconcilingSysctl) ReadN(name []string) (string, error) {
 	return val, nil
 }
 
-func (sysctl *reconcilingSysctl) ReadInt(name string) (int64, error) {
-	return sysctl.ReadIntN(strings.Split(name, "."))
-}
-
-func (sysctl *reconcilingSysctl) ReadIntN(name []string) (int64, error) {
-	val, err := sysctl.ReadN(name)
+func (sysctl *reconcilingSysctl) ReadInt(name []string) (int64, error) {
+	val, err := sysctl.Read(name)
 	if err != nil {
 		return -1, err
 	}
@@ -214,34 +184,22 @@ func NewDirectSysctl(fs afero.Fs, procFs string) Sysctl {
 	return &directSysctl{fs, procFs}
 }
 
-func (ay *directSysctl) Disable(name string) error {
+func (ay *directSysctl) Disable(name []string) error {
 	return ay.WriteInt(name, 0)
 }
 
-func (ay *directSysctl) DisableN(name []string) error {
-	return ay.WriteIntN(name, 0)
-}
-
-func (ay *directSysctl) Enable(name string) error {
+func (ay *directSysctl) Enable(name []string) error {
 	return ay.WriteInt(name, 1)
 }
 
-func (ay *directSysctl) EnableN(name []string) error {
-	return ay.WriteIntN(name, 1)
-}
-
-func (ay *directSysctl) Write(name string, value string) error {
-	return ay.WriteN(strings.Split(name, "."), value)
-}
-
-func (ay *directSysctl) WriteN(name []string, value string) error {
+func (ay *directSysctl) Write(name []string, value string) error {
 	path, err := parameterPath(ay.procFs, name)
 	if err != nil {
 		return err
 	}
 
 	// Check if the value is already set to the desired value.
-	val, err := ay.ReadN(name)
+	val, err := ay.Read(name)
 	if err != nil {
 		return fmt.Errorf("could not read the sysctl file %s: %w", path, err)
 	}
@@ -263,17 +221,13 @@ func (ay *directSysctl) WriteN(name []string, value string) error {
 	return nil
 }
 
-func (ay *directSysctl) WriteInt(name string, val int64) error {
+func (ay *directSysctl) WriteInt(name []string, val int64) error {
 	return ay.Write(name, strconv.FormatInt(val, 10))
-}
-
-func (ay *directSysctl) WriteIntN(name []string, val int64) error {
-	return ay.WriteN(name, strconv.FormatInt(val, 10))
 }
 
 func (ay *directSysctl) ApplySettings(sysSettings []tables.Sysctl) error {
 	for _, s := range sysSettings {
-		if err := ay.WriteN(s.Name, s.Val); err != nil {
+		if err := ay.Write(s.Name, s.Val); err != nil {
 			return err
 		}
 	}
@@ -281,11 +235,7 @@ func (ay *directSysctl) ApplySettings(sysSettings []tables.Sysctl) error {
 	return nil
 }
 
-func (ay *directSysctl) Read(name string) (string, error) {
-	return ay.ReadN(strings.Split(name, "."))
-}
-
-func (ay *directSysctl) ReadN(name []string) (string, error) {
+func (ay *directSysctl) Read(name []string) (string, error) {
 	path, err := parameterPath(ay.procFs, name)
 	if err != nil {
 		return "", err
@@ -305,12 +255,8 @@ func (ay *directSysctl) ReadN(name []string) (string, error) {
 	return strings.TrimRight(string(val), "\n"), nil
 }
 
-func (ay *directSysctl) ReadInt(name string) (int64, error) {
-	return ay.ReadIntN(strings.Split(name, "."))
-}
-
-func (ay *directSysctl) ReadIntN(name []string) (int64, error) {
-	val, err := ay.ReadN(name)
+func (ay *directSysctl) ReadInt(name []string) (int64, error) {
+	val, err := ay.Read(name)
 	if err != nil {
 		return -1, err
 	}

--- a/pkg/datapath/linux/sysctl/sysctl_test.go
+++ b/pkg/datapath/linux/sysctl/sysctl_test.go
@@ -109,7 +109,7 @@ func TestWaitForReconciliation(t *testing.T) {
 	t.Cleanup(func() { time.MaxInternalTimerDelay = 0 })
 
 	sysctl := &reconcilingSysctl{db, settings, nil, ""}
-	sysctl.Enable(paramName)
+	sysctl.EnableN([]string{paramName})
 
 	// waitForReconciliation should timeout
 	assert.Error(t, sysctl.waitForReconciliation([]string{paramName}))

--- a/pkg/datapath/linux/sysctl/sysctl_test.go
+++ b/pkg/datapath/linux/sysctl/sysctl_test.go
@@ -109,7 +109,7 @@ func TestWaitForReconciliation(t *testing.T) {
 	t.Cleanup(func() { time.MaxInternalTimerDelay = 0 })
 
 	sysctl := &reconcilingSysctl{db, settings, nil, ""}
-	sysctl.EnableN([]string{paramName})
+	sysctl.Enable([]string{paramName})
 
 	// waitForReconciliation should timeout
 	assert.Error(t, sysctl.waitForReconciliation([]string{paramName}))
@@ -188,33 +188,33 @@ func TestSysctl(t *testing.T) {
 	assert.NoError(t, hive.Start(tlog, context.Background()))
 
 	for _, s := range settings {
-		assert.NoError(t, sysctl.WriteN(s, "1"))
+		assert.NoError(t, sysctl.Write(s, "1"))
 
-		val, err := sysctl.ReadN(s)
+		val, err := sysctl.Read(s)
 		assert.NoError(t, err)
 		assert.Equal(t, "1", val, "unexpected value for parameter %q", s)
 	}
 
 	for _, s := range settings {
-		assert.NoError(t, sysctl.WriteIntN(s, 7))
+		assert.NoError(t, sysctl.WriteInt(s, 7))
 
-		val, err := sysctl.ReadIntN(s)
+		val, err := sysctl.ReadInt(s)
 		assert.NoError(t, err)
 		assert.Equal(t, int64(7), val, "unexpected value for parameter %q", s)
 	}
 
 	for _, s := range settings {
-		assert.NoError(t, sysctl.DisableN(s))
+		assert.NoError(t, sysctl.Disable(s))
 
-		val, err := sysctl.ReadN(s)
+		val, err := sysctl.Read(s)
 		assert.NoError(t, err)
 		assert.Equal(t, "0", val, "unexpected value for parameter %q", s)
 	}
 
 	for _, s := range settings {
-		assert.NoError(t, sysctl.EnableN(s))
+		assert.NoError(t, sysctl.Enable(s))
 
-		val, err := sysctl.ReadN(s)
+		val, err := sysctl.Read(s)
 		assert.NoError(t, err)
 		assert.Equal(t, "1", val, "unexpected value for parameter %q", s)
 	}
@@ -226,7 +226,7 @@ func TestSysctl(t *testing.T) {
 	}
 	assert.NoError(t, sysctl.ApplySettings(batch))
 	for _, s := range batch {
-		val, err := sysctl.ReadN(s.Name)
+		val, err := sysctl.Read(s.Name)
 		assert.NoError(t, err)
 		assert.Equal(t, s.Val, val, "unexpected value %q for parameter %q", val, s.Name)
 	}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -126,7 +126,7 @@ func addENIRules(sysSettings []tables.Sysctl) ([]tables.Sysctl, error) {
 	}
 
 	retSettings := append(sysSettings, tables.Sysctl{
-		Name:      fmt.Sprintf("net.ipv4.conf.%s.rp_filter", iface.Attrs().Name),
+		Name:      []string{"net", "ipv4", "conf", iface.Attrs().Name, "rp_filter"},
 		Val:       "2",
 		IgnoreErr: false,
 	})
@@ -397,11 +397,11 @@ func (l *loader) ReinitializeHostDev(ctx context.Context, mtu int) error {
 // restore from a previous Cilium run, or during regular Cilium operation.
 func (l *loader) Reinitialize(ctx context.Context, cfg *datapath.LocalNodeConfiguration, tunnelConfig tunnel.Config, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
 	sysSettings := []tables.Sysctl{
-		{Name: "net.core.bpf_jit_enable", Val: "1", IgnoreErr: true, Warn: "Unable to ensure that BPF JIT compilation is enabled. This can be ignored when Cilium is running inside non-host network namespace (e.g. with kind or minikube)"},
-		{Name: "net.ipv4.conf.all.rp_filter", Val: "0", IgnoreErr: false},
-		{Name: "net.ipv4.fib_multipath_use_neigh", Val: "1", IgnoreErr: true},
-		{Name: "kernel.unprivileged_bpf_disabled", Val: "1", IgnoreErr: true},
-		{Name: "kernel.timer_migration", Val: "0", IgnoreErr: true},
+		{Name: []string{"net", "core", "bpf_jit_enable"}, Val: "1", IgnoreErr: true, Warn: "Unable to ensure that BPF JIT compilation is enabled. This can be ignored when Cilium is running inside non-host network namespace (e.g. with kind or minikube)"},
+		{Name: []string{"net", "ipv4", "conf", "all", "rp_filter"}, Val: "0", IgnoreErr: false},
+		{Name: []string{"net", "ipv4", "fib_multipath_use_neigh"}, Val: "1", IgnoreErr: true},
+		{Name: []string{"kernel", "unprivileged_bpf_disabled"}, Val: "1", IgnoreErr: true},
+		{Name: []string{"kernel", "timer_migration"}, Val: "0", IgnoreErr: true},
 	}
 
 	// Lock so that endpoints cannot be built while we are compile base programs.
@@ -422,7 +422,7 @@ func (l *loader) Reinitialize(ctx context.Context, cfg *datapath.LocalNodeConfig
 		// interface (https://github.com/docker/libnetwork/issues/1720)
 		// Enable IPv6 for now
 		sysSettings = append(sysSettings,
-			tables.Sysctl{Name: "net.ipv6.conf.all.disable_ipv6", Val: "0", IgnoreErr: false})
+			tables.Sysctl{Name: []string{"net", "ipv6", "conf", "all", "disable_ipv6"}, Val: "0", IgnoreErr: false})
 	}
 
 	// BPF file system setup.
@@ -440,7 +440,7 @@ func (l *loader) Reinitialize(ctx context.Context, cfg *datapath.LocalNodeConfig
 		sysSettings = append(
 			sysSettings,
 			tables.Sysctl{
-				Name: "net.core.fb_tunnels_only_for_init_net", Val: "2", IgnoreErr: true,
+				Name: []string{"net", "core", "fb_tunnels_only_for_init_net"}, Val: "2", IgnoreErr: true,
 			},
 		)
 		if err := setupIPIPDevices(l.sysctl, option.Config.IPv4Enabled(), option.Config.IPv6Enabled()); err != nil {

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -44,14 +44,14 @@ func enableForwarding(sysctl sysctl.Sysctl, link netlink.Link) error {
 	sysSettings := make([]tables.Sysctl, 0, 5)
 	if option.Config.EnableIPv6 {
 		sysSettings = append(sysSettings, tables.Sysctl{
-			Name: fmt.Sprintf("net.ipv6.conf.%s.forwarding", ifName), Val: "1", IgnoreErr: false})
+			Name: []string{"net", "ipv6", "conf", ifName, "forwarding"}, Val: "1", IgnoreErr: false})
 	}
 	if option.Config.EnableIPv4 {
 		sysSettings = append(sysSettings, []tables.Sysctl{
-			{Name: fmt.Sprintf("net.ipv4.conf.%s.forwarding", ifName), Val: "1", IgnoreErr: false},
-			{Name: fmt.Sprintf("net.ipv4.conf.%s.rp_filter", ifName), Val: "0", IgnoreErr: false},
-			{Name: fmt.Sprintf("net.ipv4.conf.%s.accept_local", ifName), Val: "1", IgnoreErr: false},
-			{Name: fmt.Sprintf("net.ipv4.conf.%s.send_redirects", ifName), Val: "0", IgnoreErr: false},
+			{Name: []string{"net", "ipv4", "conf", ifName, "forwarding"}, Val: "1", IgnoreErr: false},
+			{Name: []string{"net", "ipv4", "conf", ifName, "rp_filter"}, Val: "0", IgnoreErr: false},
+			{Name: []string{"net", "ipv4", "conf", ifName, "accept_local"}, Val: "1", IgnoreErr: false},
+			{Name: []string{"net", "ipv4", "conf", ifName, "send_redirects"}, Val: "0", IgnoreErr: false},
 		}...)
 	}
 	if err := sysctl.ApplySettings(sysSettings); err != nil {

--- a/pkg/datapath/loader/netlink_test.go
+++ b/pkg/datapath/loader/netlink_test.go
@@ -6,7 +6,6 @@
 package loader
 
 import (
-	"fmt"
 	"net"
 	"testing"
 
@@ -79,22 +78,22 @@ func TestSetupDev(t *testing.T) {
 		err = enableForwarding(sysctl, dummy)
 		require.NoError(t, err)
 
-		enabledSettings := []string{
-			fmt.Sprintf("net.ipv6.conf.%s.forwarding", ifName),
-			fmt.Sprintf("net.ipv4.conf.%s.forwarding", ifName),
-			fmt.Sprintf("net.ipv4.conf.%s.accept_local", ifName),
+		enabledSettings := [][]string{
+			{"net", "ipv6", "conf", ifName, "forwarding"},
+			{"net", "ipv4", "conf", ifName, "forwarding"},
+			{"net", "ipv4", "conf", ifName, "accept_local"},
 		}
-		disabledSettings := []string{
-			fmt.Sprintf("net.ipv4.conf.%s.rp_filter", ifName),
-			fmt.Sprintf("net.ipv4.conf.%s.send_redirects", ifName),
+		disabledSettings := [][]string{
+			{"net", "ipv4", "conf", ifName, "rp_filter"},
+			{"net", "ipv4", "conf", ifName, "send_redirects"},
 		}
 		for _, setting := range enabledSettings {
-			s, err := sysctl.Read(setting)
+			s, err := sysctl.ReadN(setting)
 			require.NoError(t, err)
 			require.Equal(t, s, "1")
 		}
 		for _, setting := range disabledSettings {
-			s, err := sysctl.Read(setting)
+			s, err := sysctl.ReadN(setting)
 			require.NoError(t, err)
 			require.Equal(t, s, "0")
 		}

--- a/pkg/datapath/loader/netlink_test.go
+++ b/pkg/datapath/loader/netlink_test.go
@@ -88,12 +88,12 @@ func TestSetupDev(t *testing.T) {
 			{"net", "ipv4", "conf", ifName, "send_redirects"},
 		}
 		for _, setting := range enabledSettings {
-			s, err := sysctl.ReadN(setting)
+			s, err := sysctl.Read(setting)
 			require.NoError(t, err)
 			require.Equal(t, s, "1")
 		}
 		for _, setting := range disabledSettings {
-			s, err := sysctl.ReadN(setting)
+			s, err := sysctl.Read(setting)
 			require.NoError(t, err)
 			require.Equal(t, s, "0")
 		}

--- a/pkg/datapath/tables/sysctl.go
+++ b/pkg/datapath/tables/sysctl.go
@@ -4,6 +4,8 @@
 package tables
 
 import (
+	"strings"
+
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/index"
 	"github.com/cilium/statedb/reconciler"
@@ -13,7 +15,7 @@ var (
 	SysctlNameIndex = statedb.Index[*Sysctl, string]{
 		Name: "name",
 		FromObject: func(s *Sysctl) index.KeySet {
-			return index.NewKeySet(index.String(s.Name))
+			return index.NewKeySet(index.String(strings.Join(s.Name, ".")))
 		},
 		FromKey: index.String,
 		Unique:  true,
@@ -38,12 +40,12 @@ func (*Sysctl) TableHeader() []string {
 }
 
 func (s *Sysctl) TableRow() []string {
-	return []string{s.Name, s.Val, s.Status.String()}
+	return []string{strings.Join(s.Name, "."), s.Val, s.Status.String()}
 }
 
 // Sysctl is the representation of a kernel sysctl parameter.
 type Sysctl struct {
-	Name      string
+	Name      []string
 	Val       string
 	IgnoreErr bool
 

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -614,7 +614,7 @@ func (manager *Manager) relaxRPFilter() error {
 		if _, ok := ifSet[ifaceName]; !ok {
 			ifSet[ifaceName] = struct{}{}
 			sysSettings = append(sysSettings, tables.Sysctl{
-				Name:      fmt.Sprintf("net.ipv4.conf.%s.rp_filter", ifaceName),
+				Name:      []string{"net", "ipv4", "conf", ifaceName, "rp_filter"},
 				Val:       "2",
 				IgnoreErr: false,
 			})

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -549,16 +549,16 @@ func createTestInterface(tb testing.TB, sysctl sysctl.Sysctl, iface string, addr
 }
 
 func ensureRPFilterIsEnabled(tb testing.TB, sysctl sysctl.Sysctl, iface string) {
-	rpFilterSetting := fmt.Sprintf("net.ipv4.conf.%s.rp_filter", iface)
+	rpFilterSetting := []string{"net", "ipv4", "conf", iface, "rp_filter"}
 
 	for i := 0; i < 10; i++ {
-		if err := sysctl.Enable(rpFilterSetting); err != nil {
+		if err := sysctl.EnableN(rpFilterSetting); err != nil {
 			tb.Fatal(err)
 		}
 
 		time.Sleep(100 * time.Millisecond)
 
-		if val, err := sysctl.Read(rpFilterSetting); err == nil {
+		if val, err := sysctl.ReadN(rpFilterSetting); err == nil {
 			if val == "1" {
 				return
 			}
@@ -697,7 +697,7 @@ func assertRPFilter(t *testing.T, sysctl sysctl.Sysctl, rpFilterSettings []rpFil
 
 func tryAssertRPFilterSettings(sysctl sysctl.Sysctl, rpFilterSettings []rpFilterSetting) error {
 	for _, setting := range rpFilterSettings {
-		if val, err := sysctl.Read(fmt.Sprintf("net.ipv4.conf.%s.rp_filter", setting.iFaceName)); err != nil {
+		if val, err := sysctl.ReadN([]string{"net", "ipv4", "conf", setting.iFaceName, "rp_filter"}); err != nil {
 			return fmt.Errorf("failed to read rp_filter")
 		} else if val != setting.rpFilterSetting {
 			return fmt.Errorf("mismatched rp_filter iface: %s rp_filter: %s", setting.iFaceName, val)

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -552,13 +552,13 @@ func ensureRPFilterIsEnabled(tb testing.TB, sysctl sysctl.Sysctl, iface string) 
 	rpFilterSetting := []string{"net", "ipv4", "conf", iface, "rp_filter"}
 
 	for i := 0; i < 10; i++ {
-		if err := sysctl.EnableN(rpFilterSetting); err != nil {
+		if err := sysctl.Enable(rpFilterSetting); err != nil {
 			tb.Fatal(err)
 		}
 
 		time.Sleep(100 * time.Millisecond)
 
-		if val, err := sysctl.ReadN(rpFilterSetting); err == nil {
+		if val, err := sysctl.Read(rpFilterSetting); err == nil {
 			if val == "1" {
 				return
 			}
@@ -697,7 +697,7 @@ func assertRPFilter(t *testing.T, sysctl sysctl.Sysctl, rpFilterSettings []rpFil
 
 func tryAssertRPFilterSettings(sysctl sysctl.Sysctl, rpFilterSettings []rpFilterSetting) error {
 	for _, setting := range rpFilterSettings {
-		if val, err := sysctl.ReadN([]string{"net", "ipv4", "conf", setting.iFaceName, "rp_filter"}); err != nil {
+		if val, err := sysctl.Read([]string{"net", "ipv4", "conf", setting.iFaceName, "rp_filter"}); err != nil {
 			return fmt.Errorf("failed to read rp_filter")
 		} else if val != setting.rpFilterSetting {
 			return fmt.Errorf("mismatched rp_filter iface: %s rp_filter: %s", setting.iFaceName, val)

--- a/pkg/socketlb/socketlb.go
+++ b/pkg/socketlb/socketlb.go
@@ -107,7 +107,7 @@ func Enable(sysctl sysctl.Sysctl) error {
 	}
 
 	// v6 will be non-nil if v6 support is compiled out.
-	_, v6 := sysctl.ReadIntN([]string{"net", "ipv6", "conf", "all", "forwarding"})
+	_, v6 := sysctl.ReadInt([]string{"net", "ipv6", "conf", "all", "forwarding"})
 
 	if option.Config.EnableIPv6 ||
 		(option.Config.EnableIPv4 && v6 == nil) {

--- a/pkg/socketlb/socketlb.go
+++ b/pkg/socketlb/socketlb.go
@@ -107,7 +107,7 @@ func Enable(sysctl sysctl.Sysctl) error {
 	}
 
 	// v6 will be non-nil if v6 support is compiled out.
-	_, v6 := sysctl.ReadInt("net.ipv6.conf.all.forwarding")
+	_, v6 := sysctl.ReadIntN([]string{"net", "ipv6", "conf", "all", "forwarding"})
 
 	if option.Config.EnableIPv6 ||
 		(option.Config.EnableIPv4 && v6 == nil) {

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -257,7 +257,7 @@ func (a *Agent) Init(ipcache *ipcache.IPCache, mtuConfig mtu.MTU) error {
 	}
 
 	if option.Config.EnableIPv4 {
-		if err := a.sysctl.Disable(fmt.Sprintf("net.ipv4.conf.%s.rp_filter", types.IfaceName)); err != nil {
+		if err := a.sysctl.DisableN([]string{"net", "ipv4", "conf", types.IfaceName, "rp_filter"}); err != nil {
 			return fmt.Errorf("failed to disable rp_filter: %w", err)
 		}
 	}

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -257,7 +257,7 @@ func (a *Agent) Init(ipcache *ipcache.IPCache, mtuConfig mtu.MTU) error {
 	}
 
 	if option.Config.EnableIPv4 {
-		if err := a.sysctl.DisableN([]string{"net", "ipv4", "conf", types.IfaceName, "rp_filter"}); err != nil {
+		if err := a.sysctl.Disable([]string{"net", "ipv4", "conf", types.IfaceName, "rp_filter"}); err != nil {
 			return fmt.Errorf("failed to disable rp_filter: %w", err)
 		}
 	}

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -404,11 +404,13 @@ func reserveLocalIPPorts(conf *models.DaemonConfigurationStatus, sysctl sysctl.S
 	}
 
 	// Note: This setting applies to IPv4 and IPv6
-	const param = "net.ipv4.ip_local_reserved_ports"
-	var reserved = conf.IPLocalReservedPorts
+	var (
+		param    = []string{"net", "ipv4", "ip_local_reserved_ports"}
+		reserved = conf.IPLocalReservedPorts
+	)
 
 	// Append our reserved ports to the ones which might already be reserved.
-	existing, err := sysctl.Read(param)
+	existing, err := sysctl.ReadN(param)
 	if err != nil {
 		return err
 	}
@@ -419,7 +421,7 @@ func reserveLocalIPPorts(conf *models.DaemonConfigurationStatus, sysctl sysctl.S
 	if existing != "" {
 		reserved = existing + "," + reserved
 	}
-	return sysctl.Write(param, reserved)
+	return sysctl.WriteN(param, reserved)
 }
 
 func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
@@ -665,7 +667,7 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 			}
 
 			if ipv6IsEnabled(ipam) {
-				if err := sysctl.Disable("net.ipv6.conf.all.disable_ipv6"); err != nil {
+				if err := sysctl.DisableN([]string{"net", "ipv6", "conf", "all", "disable_ipv6"}); err != nil {
 					logger.WithError(err).Warn("unable to enable ipv6 on all interfaces")
 				}
 			}

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -410,7 +410,7 @@ func reserveLocalIPPorts(conf *models.DaemonConfigurationStatus, sysctl sysctl.S
 	)
 
 	// Append our reserved ports to the ones which might already be reserved.
-	existing, err := sysctl.ReadN(param)
+	existing, err := sysctl.Read(param)
 	if err != nil {
 		return err
 	}
@@ -421,7 +421,7 @@ func reserveLocalIPPorts(conf *models.DaemonConfigurationStatus, sysctl sysctl.S
 	if existing != "" {
 		reserved = existing + "," + reserved
 	}
-	return sysctl.WriteN(param, reserved)
+	return sysctl.Write(param, reserved)
 }
 
 func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
@@ -667,7 +667,7 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 			}
 
 			if ipv6IsEnabled(ipam) {
-				if err := sysctl.DisableN([]string{"net", "ipv6", "conf", "all", "disable_ipv6"}); err != nil {
+				if err := sysctl.Disable([]string{"net", "ipv6", "conf", "all", "disable_ipv6"}); err != nil {
 					logger.WithError(err).Warn("unable to enable ipv6 on all interfaces")
 				}
 			}


### PR DESCRIPTION
Sysctl is normally a CLI tool which uses a name composed of dotes to indicate settings. For example `net.ipv4.conf.all.rp_filter`. These same settings can also be read and written via the file system. To go from the dot variant to the file system variant we need to split the name on dots and then join them with slashes.

This gets complicated when parts of the name use dots not as a separator but as part of the directory name. For example `net.ipv4.conf.eth0.100.rp_filter`. In this case the desired output is `/proc/sys/net/ipv4/conf/eth0.100/rp_filter` so we can't just split on dots. The current sysctl package has no way to express this. To fix this we are switching to using a string slice to represent the name. Where every part of the slice will be joined by a slash, so we do not need to use a character as separator and can use dots in the name.

This PR modifies the API signature of the methods on the Sysctl interface to now take in a `name []string` instead of `name string`, requiring the  caller to split up the name instead of using a separator character.

Fixes: #34217

```release-note
Replace dotted sysctl names with string slices
```
