### PR TITLE
connectivity: Introdue Multicast connectivity test

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -152,6 +152,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.DNSTestServerImage, "dns-test-server-image", defaults.ConnectivityDNSTestServerImage, "Image path to use for CoreDNS")
 	cmd.Flags().StringVar(&params.TestConnDisruptImage, "test-conn-disrupt-image", defaults.ConnectivityTestConnDisruptImage, "Image path to use for connection disruption tests")
 	cmd.Flags().StringVar(&params.FRRImage, "frr-image", defaults.ConnectivityTestFRRImage, "Image path to use for FRR")
+	cmd.Flags().StringVar(&params.SocatImage, "socat-image", defaults.ConnectivityTestSocatImage, "Image path to use for multicast tests")
 
 	cmd.Flags().UintVar(&params.Retry, "retry", defaults.ConnectRetry, "Number of retries on connection failure to external targets")
 	cmd.Flags().DurationVar(&params.RetryDelay, "retry-delay", defaults.ConnectRetryDelay, "Delay between retries for external targets")

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -250,6 +250,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		localRedirectPolicyWithNodeDNS{},
 		noFragmentation{},
 		bgpControlPlane{},
+		multicast{},
 	}
 	return injectTests(tests, connTests...)
 }

--- a/cilium-cli/connectivity/builder/multicast.go
+++ b/cilium-cli/connectivity/builder/multicast.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+
+	"github.com/cilium/cilium/pkg/versioncheck"
+)
+
+type multicast struct{}
+
+func (t multicast) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("multicast", ct).
+		WithCondition(func() bool {
+			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion)
+		}).
+		WithCondition(func() bool {
+			return ct.Params().IncludeUnsafeTests
+		}).
+		WithFeatureRequirements(
+			features.RequireEnabled(features.Multicast),
+		).
+		WithScenarios(tests.SocatMulticast())
+}

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -63,6 +63,7 @@ type Parameters struct {
 	JSONMockImage          string
 	TestConnDisruptImage   string
 	FRRImage               string
+	SocatImage             string
 	AgentDaemonSetName     string
 	DNSTestServerImage     string
 	IncludeUnsafeTests     bool

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -31,6 +31,10 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 )
 
+const (
+	socatMulticastTestMsg = "Multicast test message"
+)
+
 // ConnectivityTest is the root context of the connectivity test suite
 // and holds all resources belonging to it. It implements interface
 // ConnectivityTest and is instantiated once at the start of the program,
@@ -71,6 +75,8 @@ type ConnectivityTest struct {
 	lrpClientPods        map[string]Pod
 	lrpBackendPods       map[string]Pod
 	frrPods              []Pod
+	socatServerPods      []Pod
+	socatClientPods      []Pod
 
 	hostNetNSPodsByNode      map[string]Pod
 	secondaryNetworkNodeIPv4 map[string]string // node name => secondary ip
@@ -211,6 +217,8 @@ func NewConnectivityTest(
 		clientCPPods:             make(map[string]Pod),
 		lrpClientPods:            make(map[string]Pod),
 		lrpBackendPods:           make(map[string]Pod),
+		socatServerPods:          []Pod{},
+		socatClientPods:          []Pod{},
 		perfClientPods:           []Pod{},
 		perfServerPod:            []Pod{},
 		PerfResults:              []common.PerfSummary{},
@@ -1076,6 +1084,14 @@ func (ct *ConnectivityTest) PerfClientPods() []Pod {
 	return ct.perfClientPods
 }
 
+func (ct *ConnectivityTest) SocatServerPods() []Pod {
+	return ct.socatServerPods
+}
+
+func (ct *ConnectivityTest) SocatClientPods() []Pod {
+	return ct.socatClientPods
+}
+
 func (ct *ConnectivityTest) EchoPods() map[string]Pod {
 	return ct.echoPods
 }
@@ -1209,4 +1225,27 @@ func (ct *ConnectivityTest) EchoServicePrefixes(ipFamily features.IPFamily) []ne
 		}
 	}
 	return res
+}
+
+// Multicast packet sender
+// This command exits with exit code 0
+// WITHOUT waiting for a second after receiving a packet.
+func (ct *ConnectivityTest) SocatServer1secCommand(peer TestPeer, port int, group string) []string {
+	addr := peer.Address(features.IPFamilyV4)
+	cmdStr := fmt.Sprintf("timeout 5 socat STDIO UDP4-RECVFROM:%d,ip-add-membership=%s:%s", port, group, addr)
+	cmd := strings.Fields(cmdStr)
+	return cmd
+}
+
+// Multicast packet receiver
+func (ct *ConnectivityTest) SocatClientCommand(port int, group string) []string {
+	portStr := fmt.Sprintf("%d", port)
+	cmdStr := fmt.Sprintf(`for i in $(seq 1 10000); do echo "%s" | socat - UDP-DATAGRAM:%s:%s; sleep 0.1; done`, socatMulticastTestMsg, group, portStr)
+	cmd := []string{"/bin/sh", "-c", cmdStr}
+	return cmd
+}
+
+func (ct *ConnectivityTest) KillMulticastTestSender() []string {
+	cmd := []string{"pkill", "-f", socatMulticastTestMsg}
+	return cmd
 }

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -1042,6 +1042,34 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 		}
 	}
 
+	if ct.Features[features.Multicast].Enabled {
+		_, err = ct.clients.src.GetDeployment(ctx, ct.params.TestNamespace, socatClientDeploymentName, metav1.GetOptions{})
+		if err != nil {
+			ct.Logf("✨ [%s] Deploying %s deployment...", ct.clients.src.ClusterName(), socatClientDeploymentName)
+			ds := NewSocatClientDeployment(ct.params)
+			_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(socatClientDeploymentName), metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create service account %s: %w", socatClientDeploymentName, err)
+			}
+			_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, ds, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create deployment %s: %w", socatClientDeploymentName, err)
+			}
+		}
+	}
+
+	if ct.Features[features.Multicast].Enabled {
+		_, err = ct.clients.src.GetDaemonSet(ctx, ct.params.TestNamespace, socatServerDaemonsetName, metav1.GetOptions{})
+		if err != nil {
+			ct.Logf("✨ [%s] Deploying %s daemonset...", ct.clients.src.ClusterName(), socatServerDaemonsetName)
+			ds := NewSocatServerDaemonSet(ct.params)
+			_, err = ct.clients.src.CreateDaemonSet(ctx, ct.params.TestNamespace, ds, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create daemonset %s: %w", socatServerDaemonsetName, err)
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -1202,6 +1230,10 @@ func (ct *ConnectivityTest) deploymentList() (srcList []string, dstList []string
 		srcList = append(srcList, lrpBackendDeploymentName)
 	}
 
+	if ct.Features[features.Multicast].Enabled {
+		srcList = append(srcList, socatClientDeploymentName)
+	}
+
 	return srcList, dstList
 }
 
@@ -1212,6 +1244,8 @@ func (ct *ConnectivityTest) deleteDeployments(ctx context.Context, client *k8s.C
 	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, clientDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, client2DeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, client3DeploymentName, metav1.DeleteOptions{})
+	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, socatClientDeploymentName, metav1.DeleteOptions{})
+	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, socatServerDaemonsetName, metav1.DeleteOptions{}) // Q:Daemonset in here is OK?
 	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, echoSameNodeDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, echoOtherNodeDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, clientDeploymentName, metav1.DeleteOptions{})
@@ -1413,6 +1447,35 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 		}
 		for _, pod := range frrPods.Items {
 			ct.frrPods = append(ct.frrPods, Pod{
+				K8sClient: ct.client,
+				Pod:       pod.DeepCopy(),
+			})
+		}
+	}
+
+	if ct.Features[features.Multicast].Enabled {
+		// socat client pods
+		socatCilentPods, err := ct.clients.src.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "name=" + socatClientDeploymentName})
+		if err != nil {
+			return fmt.Errorf("unable to list socat client pods: %w", err)
+		}
+		for _, pod := range socatCilentPods.Items {
+			ct.socatClientPods = append(ct.socatClientPods, Pod{
+				K8sClient: ct.client,
+				Pod:       pod.DeepCopy(),
+			})
+		}
+
+		// socat server pods
+		if err := WaitForDaemonSet(ctx, ct, ct.clients.src, ct.Params().TestNamespace, socatServerDaemonsetName); err != nil {
+			return err
+		}
+		socatServerPods, err := ct.clients.src.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "name=" + socatServerDaemonsetName})
+		if err != nil {
+			return fmt.Errorf("unable to list socat server pods: %w", err)
+		}
+		for _, pod := range socatServerPods.Items {
+			ct.socatServerPods = append(ct.socatServerPods, Pod{
 				K8sClient: ct.client,
 				Pod:       pod.DeepCopy(),
 			})

--- a/cilium-cli/connectivity/check/netshoot.go
+++ b/cilium-cli/connectivity/check/netshoot.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package check
+
+import appsv1 "k8s.io/api/apps/v1"
+
+const (
+	// SocatServerPort is the port on which the socat server listens.
+	socatServerDaemonsetName  = "socat-server-daemonset"
+	socatClientDeploymentName = "socat-client"
+)
+
+func NewSocatServerDaemonSet(params Parameters) *appsv1.DaemonSet {
+	ds := newDaemonSet(daemonSetParameters{
+		Name:    socatServerDaemonsetName,
+		Kind:    socatServerDaemonsetName,
+		Image:   params.SocatImage,
+		Command: []string{"/bin/sh", "-c", "sleep 10000000"},
+	})
+	return ds
+}
+
+func NewSocatClientDeployment(params Parameters) *appsv1.Deployment {
+	dep := newDeployment(deploymentParameters{
+		Name:     socatClientDeploymentName,
+		Kind:     socatClientDeploymentName,
+		Image:    params.SocatImage,
+		Replicas: 1,
+		Command:  []string{"/bin/sh", "-c", "sleep 10000000"},
+	})
+	return dep
+}

--- a/cilium-cli/connectivity/tests/multicast.go
+++ b/cilium-cli/connectivity/tests/multicast.go
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/node/addressing"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+const (
+	notExistMsg          = "does not exist"
+	alreadyExistMsg      = "already exists"
+	testMulticastGroupIP = "239.255.9.9"
+	testSocatPort        = 6666
+)
+
+// Having data to restore group and subscriber status after testing
+var NodeWithoutGroup []string
+var NotSubscribePodAddress map[string][]v2.NodeAddress
+var ipToPodMap lock.Map[v2.NodeAddress, string]
+var NodeWithoutGroupMu lock.RWMutex
+var NotSubscribePodAddressMu lock.RWMutex
+
+type socatMulticast struct {
+}
+
+func SocatMulticast() check.Scenario {
+	return &socatMulticast{}
+}
+
+func (s *socatMulticast) Name() string {
+	return "multicast"
+}
+
+func (s *socatMulticast) Run(ctx context.Context, t *check.Test) {
+	ct := t.Context()
+	defer func() {
+		s.cleanup(ctx, t)
+	}()
+	NotSubscribePodAddress = make(map[string][]v2.NodeAddress)
+
+	// Add all cilium nodes to the multicast group
+	if err := s.addAllNodes(ctx, t); err != nil {
+		t.Fatalf("Fatal error occurred while adding all cilium nodes to multicast group: %v", err)
+	}
+
+	bgCtx, cancelBg := context.WithCancel(ctx)
+	defer cancelBg()
+
+	var wg sync.WaitGroup
+
+	// Sender: Start repeated socat multicast client in the background)
+	for _, clientPod := range ct.SocatClientPods() {
+		wg.Add(1)
+		go func(pod check.Pod) {
+			defer wg.Done()
+			cmd := ct.SocatClientCommand(testSocatPort, testMulticastGroupIP)
+			doneCh := make(chan struct{})
+			go func() {
+				_, stdErr, err := pod.K8sClient.ExecInPodWithStderr(bgCtx, pod.Pod.Namespace, pod.Pod.Name, pod.Pod.Labels["name"], cmd)
+				if err != nil && !strings.Contains(err.Error(), "context canceled") {
+					errMsg := fmt.Sprintf("Error: %v, Stderr: %s", err, stdErr.String())
+					t.Logf("Error in background task for pod %s: %v", pod.Name(), errMsg)
+				}
+				close(doneCh)
+			}()
+			select {
+			case <-doneCh:
+				// Task finished normally
+			case <-bgCtx.Done():
+				// Context was cancelled, handle cleanup
+				cancelCmd := ct.KillMulticastTestSender()
+				_, _, err := pod.K8sClient.ExecInPodWithStderr(ctx, pod.Pod.Namespace, pod.Pod.Name, pod.Pod.Labels["name"], cancelCmd)
+				if err != nil {
+					t.Logf("Error cancelling command for pod %s: %v", pod.Name(), err)
+				}
+			}
+		}(clientPod)
+	}
+
+	// Receiver: Execute socat multicast server and check if multicast packets are coming in.
+	for _, socatServerPod := range ct.SocatServerPods() {
+		t.NewAction(s, "socat multicast", &socatServerPod, nil, features.IPFamilyV4).Run(func(a *check.Action) {
+			cmd := ct.SocatServer1secCommand(socatServerPod, testSocatPort, testMulticastGroupIP)
+			// The exit code of socat server command with timeout is 0 if a packet is received,
+			// and 124 if no packet is received.
+			a.ExecInPod(ctx, cmd)
+		})
+	}
+
+	cancelBg()
+	wg.Wait()
+}
+
+// Restore the state of the multicast group and subscriber after the test
+func (s *socatMulticast) cleanup(ctx context.Context, t *check.Test) {
+	ct := t.Context()
+	client := ct.K8sClient()
+	ciliumNodesList, err := client.ListCiliumNodes(ctx)
+	if err != nil {
+		t.Fatalf("Fatal error occurred while listing cilium nodes: %v", err)
+	}
+	ciliumNodes := ciliumNodesList.Items
+	for _, ciliumNode := range ciliumNodes {
+		if s.isNodeWithoutGroup(ciliumNode.Name) {
+			if err := s.delGroup(ctx, t, ciliumNode.Name); err != nil {
+				t.Fatalf("Fatal error occurred while deleting multicast group: %v", err)
+			}
+		} else {
+			for _, podAddress := range NotSubscribePodAddress[ciliumNode.Name] {
+				if s.isNotSubscribePodAddress(ciliumNode.Name, podAddress) {
+					if err := s.delSubscriber(ctx, t, ciliumNode.Name, podAddress.IP); err != nil {
+						t.Fatalf("Fatal error occurred while deleting subscriber: %v", err)
+					}
+				}
+			}
+		}
+	}
+}
+
+func (s *socatMulticast) addNodeWithoutGroup(nodeName string) {
+	NodeWithoutGroupMu.Lock()
+	defer NodeWithoutGroupMu.Unlock()
+	NodeWithoutGroup = append(NodeWithoutGroup, nodeName)
+}
+
+func (s *socatMulticast) isNodeWithoutGroup(nodeName string) bool {
+	NodeWithoutGroupMu.RLock()
+	defer NodeWithoutGroupMu.RUnlock()
+	for _, node := range NodeWithoutGroup {
+		if node == nodeName {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *socatMulticast) addNotSubscribePodAddress(nodeName string, podAddress v2.NodeAddress) {
+	NotSubscribePodAddressMu.Lock()
+	defer NotSubscribePodAddressMu.Unlock()
+	NotSubscribePodAddress[nodeName] = append(NotSubscribePodAddress[nodeName], podAddress)
+}
+
+func (s *socatMulticast) isNotSubscribePodAddress(nodeName string, podAddress v2.NodeAddress) bool {
+	NotSubscribePodAddressMu.RLock()
+	defer NotSubscribePodAddressMu.RUnlock()
+	for _, address := range NotSubscribePodAddress[nodeName] {
+		if address.IP == podAddress.IP {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *socatMulticast) getCiliumNode(ctx context.Context, t *check.Test, nodeName string) (v2.CiliumNode, error) {
+	ct := t.Context()
+	client := ct.K8sClient()
+	ciliumNodes, err := client.ListCiliumNodes(ctx)
+	if err != nil {
+		return v2.CiliumNode{}, err
+	}
+	var ciliumNode v2.CiliumNode
+	for _, node := range ciliumNodes.Items {
+		if node.Name == nodeName {
+			ciliumNode = node
+		}
+	}
+	return ciliumNode, nil
+}
+
+func (s *socatMulticast) getCiliumInternalIP(ctx context.Context, t *check.Test, nodeName string) (v2.NodeAddress, error) {
+	ciliumNode, err := s.getCiliumNode(ctx, t, nodeName)
+	if err != nil {
+		return v2.NodeAddress{}, fmt.Errorf("unable to get cilium node: %w", err)
+	}
+	addrs := ciliumNode.Spec.Addresses
+	var ciliumInternalIP v2.NodeAddress
+	for _, addr := range addrs {
+		if addr.AddrType() == addressing.NodeCiliumInternalIP {
+			ip, err := netip.ParseAddr(addr.IP)
+			if err != nil {
+				continue
+			}
+			if ip.Is4() {
+				ciliumInternalIP = addr
+			}
+		}
+	}
+	if ciliumInternalIP.IP == "" {
+		return v2.NodeAddress{}, fmt.Errorf("ciliumInternalIP not found")
+	}
+	return ciliumInternalIP, nil
+}
+
+// To record the correspondence between CiliumInternalIp and cilium-agent
+func (s *socatMulticast) populateMaps(ctx context.Context, t *check.Test, ciliumPods []corev1.Pod) error {
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(ciliumPods))
+	wg.Add(len(ciliumPods))
+
+	for _, ciliumPod := range ciliumPods {
+		go func(pod corev1.Pod) {
+			defer wg.Done()
+			ciliumInternalIP, err := s.getCiliumInternalIP(ctx, t, pod.Spec.NodeName)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			ipToPodMap.Store(ciliumInternalIP, pod.Name)
+		}(ciliumPod)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	var errRet error
+	for fetchData := range errCh {
+		errRet = errors.Join(errRet, fetchData)
+	}
+	return errRet
+}
+
+// create multicast group and add all cilium nodes to the multicast group for testing
+func (s *socatMulticast) addAllNodes(ctx context.Context, t *check.Test) error {
+	ct := t.Context()
+	client := ct.K8sClient()
+
+	ciliumPodsList, err := client.ListPods(ctx, ct.Params().CiliumNamespace, metav1.ListOptions{LabelSelector: defaults.AgentPodSelector})
+	if err != nil {
+		return err
+	}
+	ciliumPods := ciliumPodsList.Items
+
+	// Create a map of ciliumInternalIPs of all nodes
+	if err := s.populateMaps(ctx, t, ciliumPods); err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(ciliumPods))
+	wg.Add(len(ciliumPods))
+
+	for _, ciliumPod := range ciliumPods {
+		go func(pod corev1.Pod) {
+			defer wg.Done()
+			// If there are not specified multicast group, create it
+			cmd := []string{"cilium-dbg", "bpf", "multicast", "subscriber", "list", testMulticastGroupIP}
+			_, stdErr, err := client.ExecInPodWithStderr(ctx, pod.Namespace, pod.Name, defaults.AgentContainerName, cmd)
+			if err != nil {
+				if !strings.Contains(stdErr.String(), notExistMsg) {
+					errMsg := fmt.Sprintf("Error: %v, Stderr: %s", err, stdErr.String())
+					errCh <- errors.New(errMsg)
+					t.Fatalf("Fatal error occurred while checking multicast group %s in %s", testMulticastGroupIP, pod.Spec.NodeName)
+					return
+				}
+				s.addNodeWithoutGroup(pod.Spec.NodeName)
+				cmd = []string{"cilium-dbg", "bpf", "multicast", "group", "add", testMulticastGroupIP}
+				_, stdErr, err := client.ExecInPodWithStderr(ctx, pod.Namespace, pod.Name, defaults.AgentContainerName, cmd)
+				if err != nil {
+					errMsg := fmt.Sprintf("Error: %v, Stderr: %s", err, stdErr.String())
+					errCh <- errors.New(errMsg)
+					t.Fatalf("Fatal error occurred while creating multicast group %s in %s", testMulticastGroupIP, pod.Spec.NodeName)
+					return
+				}
+			}
+			// Add all ciliumInternalIPs of all nodes to the multicast group as subscribers
+			ipToPodMap.Range(func(ip v2.NodeAddress, podName string) bool {
+				if ip.IP != "" && pod.Name != podName { // My node itself does not need to be in a multicast group.
+					cmd = []string{"cilium-dbg", "bpf", "multicast", "subscriber", "add", testMulticastGroupIP, ip.IP}
+					_, stdErr, err := client.ExecInPodWithStderr(ctx, pod.Namespace, pod.Name, defaults.AgentContainerName, cmd)
+					if err == nil {
+						s.addNotSubscribePodAddress(pod.Spec.NodeName, ip)
+					} else if !strings.Contains(stdErr.String(), alreadyExistMsg) {
+						errMsg := fmt.Sprintf("Error: %v, Stderr: %s", err, stdErr.String())
+						errCh <- errors.New(errMsg)
+						t.Fatalf("Fatal error occurred while adding node %s to multicast group %s in %s", ip.IP, testMulticastGroupIP, pod.Spec.NodeName)
+						return false // Stop iteration
+					}
+				}
+				return true // Continue iteration
+			})
+		}(ciliumPod)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	var errRet error
+	for fetchData := range errCh {
+		errRet = errors.Join(errRet, fetchData)
+	}
+	return errRet
+}
+
+// Delete multicast group in designated node
+func (s *socatMulticast) delGroup(ctx context.Context, t *check.Test, nodeName string) error {
+	ct := t.Context()
+	client := ct.K8sClient()
+
+	ciliumPodsList, err := client.ListPods(ctx, ct.Params().CiliumNamespace, metav1.ListOptions{LabelSelector: defaults.AgentPodSelector})
+	if err != nil {
+		return err
+	}
+	ciliumPods := ciliumPodsList.Items
+
+	for _, ciliumPod := range ciliumPods {
+		if nodeName == ciliumPod.Spec.NodeName {
+			cmd := []string{"cilium-dbg", "bpf", "multicast", "group", "delete", testMulticastGroupIP}
+			_, stdErr, err := client.ExecInPodWithStderr(ctx, ciliumPod.Namespace, ciliumPod.Name, defaults.AgentContainerName, cmd)
+			if err != nil {
+				if !strings.Contains(stdErr.String(), notExistMsg) {
+					errMsg := fmt.Sprintf("Error: %v while deleting Multicast Group for test %s, Stderr: %s", err, testMulticastGroupIP, stdErr.String())
+					return errors.New(errMsg)
+				}
+			}
+			break
+		}
+	}
+	return nil
+}
+
+// Delete designated subscriber in designated node
+func (s *socatMulticast) delSubscriber(ctx context.Context, t *check.Test, nodeName string, subscriberIP string) error {
+	ct := t.Context()
+	client := ct.K8sClient()
+
+	ciliumPodsList, err := client.ListPods(ctx, ct.Params().CiliumNamespace, metav1.ListOptions{LabelSelector: defaults.AgentPodSelector})
+	if err != nil {
+		return err
+	}
+	ciliumPods := ciliumPodsList.Items
+
+	for _, ciliumPod := range ciliumPods {
+		if nodeName == ciliumPod.Spec.NodeName {
+			cmd := []string{"cilium-dbg", "bpf", "multicast", "subscriber", "delete", testMulticastGroupIP, subscriberIP}
+			_, stdErr, err := client.ExecInPodWithStderr(ctx, ciliumPod.Namespace, ciliumPod.Name, defaults.AgentContainerName, cmd)
+			if err != nil {
+				if !strings.Contains(stdErr.String(), notExistMsg) {
+					errMsg := fmt.Sprintf("Error: %v while removing %s from Multicast Group %s Stderr: %s", err, subscriberIP, testMulticastGroupIP, stdErr.String())
+					return errors.New(errMsg)
+				}
+			}
+			break
+		}
+	}
+	return nil
+}

--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -76,6 +76,8 @@ const (
 	ConnectivityTestConnDisruptImage = "quay.io/cilium/test-connection-disruption:v0.0.14@sha256:c3fd56e326ae16f6cb63dbb2e26b4e47ec07a123040623e11399a7fe1196baa0"
 	// renovate: datasource=docker
 	ConnectivityTestFRRImage = "quay.io/frrouting/frr:10.1.1@sha256:7c7901eb5611f12634395c949e59663e154b37cf006f32c7f4c8650884cdc0b1"
+	// renovate: datasource=docker
+	ConnectivityTestSocatImage = "docker.io/alpine/socat:1.7.4.4@sha256:93efcf633c5489b170404df25e289f811cabeea728a5367f0c9b1560982edf14"
 
 	ConfigMapName = "cilium-config"
 

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -80,6 +80,8 @@ const (
 	BGPControlPlane Feature = "enable-bgp-control-plane"
 
 	NodeLocalDNS Feature = "node-local-dns"
+
+	Multicast Feature = "multicast-enabled"
 )
 
 // Feature is the name of a Cilium Feature (e.g. l7-proxy, cni chaining mode etc)
@@ -319,6 +321,10 @@ func (fs Set) ExtractFromConfigMap(cm *v1.ConfigMap) {
 
 	fs[BGPControlPlane] = Status{
 		Enabled: cm.Data[string(BGPControlPlane)] == "true",
+	}
+
+	fs[Multicast] = Status{
+		Enabled: cm.Data[string(Multicast)] == "true",
 	}
 }
 


### PR DESCRIPTION
Introduces Multicast connectivity test, working with netshoot container.
Using socat for IGMP and UDP communication test.
Receivers are running as Daemonset and a sender is running as a Deployment which has 1 replicaset.

Operation was confirmed on the kind and kubeadm clusters.

This if follow up of https://github.com/cilium/cilium-cli/issues/2615 .

In addtion, this PR is related to https://github.com/cilium/cilium-cli/pull/2620 .
I want to implement a test scenario using multicast-subcommand after this is merged.

In addition, I'd like to put this test into GitHub CI.

<details>
<summary>related part of this command output (when 3 nodes)</summary>

```
[=] [cilium-test-1] Test [multicast] [100/103]
  [.] Action [multicast/multicast/socat multicast]
  🐛 Executing command [timeout 1 socat STDIO UDP4-RECVFROM:6666,ip-add-membership=239.255.9.9:10.244.0.10]
.  [.] Action [multicast/multicast/socat multicast]
  🐛 Executing command [timeout 1 socat STDIO UDP4-RECVFROM:6666,ip-add-membership=239.255.9.9:10.244.2.142]
.  [.] Action [multicast/multicast/socat multicast]
  🐛 Executing command [timeout 1 socat STDIO UDP4-RECVFROM:6666,ip-add-membership=239.255.9.9:10.244.1.88]
.  🐛 Finalizing Test multicast
  🐛 Finalizing Test host-firewall-ingress
  🐛 Finalizing Test host-firewall-egress
  🐛 Finalizing Test check-log-errors

✅ [cilium-test-1] All 1 tests (3 actions) successful, 102 tests skipped, 0 scenarios skipped.
```

</details>