### PR TITLE
renovate: add cilium-cli

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,6 +23,7 @@
     ".github/actions/set-env-variables/action.yml",
     ".github/workflows/**",
     ".github/ISSUE_TEMPLATE/bug_report.yaml",
+    "cilium-cli/**",
     "images/**",
     "examples/hubble/*",
     "go.mod",


### PR DESCRIPTION
Make sure renovate can update the cilium-cli Dockerfile. Otherwise we'll hit errors such as the following in Go update PRs [1]:

    #17 [builder 5/5] RUN make -C cilium-cli
    #17 0.259 make: Entering directory '/go/src/github.com/cilium/cilium/cilium-cli'
    #17 0.263 CGO_ENABLED=0 go build  \
    #17 0.263 	-ldflags "-w -s -X 'github.com/cilium/cilium/cilium-cli/defaults.CLIVersion=787faa8e'" \
    #17 0.263 	-o cilium \
    #17 0.263 	./cmd/cilium
    #17 0.267 go: ../go.mod requires go >= 1.23.0 (running go 1.22.5; GOTOOLCHAIN=local)
    #17 0.267 make: Leaving directory '/go/src/github.com/cilium/cilium/cilium-cli'
    #17 0.267 make: *** [Makefile:31: cilium] Error 1

[1] https://github.com/cilium/cilium/actions/runs/10523568379/job/29158520555?pr=34542