### PR TITLE
cilium-cli: use agent container name rather than process name

### DIFF
--- a/cilium-cli/connectivity/check/metricssource.go
+++ b/cilium-cli/connectivity/check/metricssource.go
@@ -6,7 +6,7 @@ package check
 import (
 	"fmt"
 
-	"github.com/cilium/cilium/pkg/components"
+	"github.com/cilium/cilium/cilium-cli/defaults"
 )
 
 const prometheusContainerPortName = "prometheus"
@@ -32,7 +32,7 @@ func (ct *ConnectivityTest) CiliumAgentMetrics() MetricsSource {
 	}
 
 	source := MetricsSource{
-		Name: components.CiliumAgentName,
+		Name: defaults.AgentContainerName,
 	}
 
 	// Retrieve the container port value for Prometheus.
@@ -40,7 +40,7 @@ func (ct *ConnectivityTest) CiliumAgentMetrics() MetricsSource {
 		source.Pods = append(source.Pods, p)
 		// parse all the containers
 		for _, c := range p.Pod.Spec.Containers {
-			if c.Name == components.CiliumAgentName {
+			if c.Name == defaults.AgentContainerName {
 				// parse all the container ports
 				for _, port := range c.Ports {
 					if port.Name == prometheusContainerPortName {

--- a/cilium-cli/connectivity/check/metricssource_test.go
+++ b/cilium-cli/connectivity/check/metricssource_test.go
@@ -6,10 +6,10 @@ package check
 import (
 	"testing"
 
-	"github.com/cilium/cilium/pkg/components"
-
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/cilium/cilium/cilium-cli/defaults"
 )
 
 func TestConnectivityTestCiliumAgentMetrics(t *testing.T) {
@@ -18,7 +18,7 @@ func TestConnectivityTestCiliumAgentMetrics(t *testing.T) {
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name: components.CiliumAgentName,
+						Name: defaults.AgentContainerName,
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          prometheusContainerPortName,
@@ -37,7 +37,7 @@ func TestConnectivityTestCiliumAgentMetrics(t *testing.T) {
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name: components.CiliumAgentName,
+						Name: defaults.AgentContainerName,
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          "peer-service",
@@ -57,10 +57,10 @@ func TestConnectivityTestCiliumAgentMetrics(t *testing.T) {
 	}{
 		"nominal case": {
 			ct: ConnectivityTest{ciliumPods: map[string]Pod{
-				components.CiliumAgentName: ciliumPod,
+				defaults.AgentContainerName: ciliumPod,
 			}},
 			want: MetricsSource{
-				Name: components.CiliumAgentName,
+				Name: defaults.AgentContainerName,
 				Pods: []Pod{ciliumPod},
 				Port: "9962",
 			},
@@ -70,7 +70,7 @@ func TestConnectivityTestCiliumAgentMetrics(t *testing.T) {
 			want: MetricsSource{},
 		},
 		"no prometheus container port": {
-			ct:   ConnectivityTest{ciliumPods: map[string]Pod{components.CiliumAgentName: podWithPrometheusMissing}},
+			ct:   ConnectivityTest{ciliumPods: map[string]Pod{defaults.AgentContainerName: podWithPrometheusMissing}},
 			want: MetricsSource{},
 		},
 	}

--- a/cilium-cli/connectivity/check/result_test.go
+++ b/cilium-cli/connectivity/check/result_test.go
@@ -6,11 +6,11 @@ package check
 import (
 	"testing"
 
-	"github.com/cilium/cilium/pkg/components"
-
 	prommodel "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/cilium/cilium/cilium-cli/defaults"
 )
 
 func TestExpectMetricsToIncrease(t *testing.T) {
@@ -19,7 +19,7 @@ func TestExpectMetricsToIncrease(t *testing.T) {
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name: components.CiliumAgentName,
+						Name: defaults.AgentContainerName,
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          "prometheus",
@@ -118,7 +118,7 @@ func TestExpectMetricsToIncrease(t *testing.T) {
 		"metric name not present in the metrics before, counters should be set 0": {
 			metrics: "cilium_forward_count_total",
 			source: MetricsSource{
-				Name: components.CiliumAgentName,
+				Name: defaults.AgentContainerName,
 				Pods: []Pod{ciliumPod},
 				Port: "9962",
 			},


### PR DESCRIPTION
Use `defaults.AgentContainerName` instead of `components.CiliumAgentName`. Both have the same value ("cilium-agent") currently, but the former makes it more obvious that we're interested in the name of the Cilium agent container.