### PR TITLE
ci: skip certain workflows for changes only affecting cilium-cli

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -113,7 +113,7 @@ workflows:
   conformance-gateway-api.yaml:
     paths-ignore-regex: (test|Documentation|hubble)/
   conformance-ginkgo.yaml:
-    paths-ignore-regex: Documentation/
+    paths-ignore-regex: (cilium-cli|Documentation)/
   conformance-gke.yaml:
     paths-ignore-regex: (test|Documentation|hubble)/
   conformance-ingress.yaml:
@@ -121,7 +121,7 @@ workflows:
   conformance-multi-pool.yaml:
     paths-ignore-regex: (test|Documentation|hubble)/
   conformance-runtime.yaml:
-    paths-ignore-regex: Documentation/
+    paths-ignore-regex: (cilium-cli|Documentation)/
   integration-test.yaml:
     paths-ignore-regex: Documentation/
   tests-clustermesh-upgrade.yaml:

--- a/.github/workflows/hubble-cli.yaml
+++ b/.github/workflows/hubble-cli.yaml
@@ -1,7 +1,11 @@
 name: Hubble CLI tests
 
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - 'cilium-cli/**'
+      - 'Documentation/**'
+      - 'test/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Skip workflows that are not using cilium-cli for PRs that only affect cilium-cli. This should reduce CI pressure a bit for these PRs.

See commits for details.
