### PR TITLE
Clean up after cilium-cli repo migration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -775,6 +775,15 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?)\\s+.+_REPO:=(?<depName>.*?)\\s+.+_VERSION:=(?<currentValue>.*)\\s+.+_DIGEST:=(?<currentDigest>sha256:[a-f0-9]+)"
       ]
+    },
+    {
+      "fileMatch": [
+        "^cilium-cli/defaults/defaults\\.go$"
+      ],
+      "matchStrings": [
+        "\/\/ renovate: datasource=(?<datasource>.*?)\\s+.+Image = \"(?<depName>.*):(?<currentValue>.*)@(?<currentDigest>sha256:[a-f0-9]+)\"",
+        "\/\/ renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+Version = \"(?<currentValue>.*)\""
+      ]
     }
   ]
 }

--- a/cilium-cli/Makefile
+++ b/cilium-cli/Makefile
@@ -15,31 +15,12 @@ endif
 GO_BUILD_LDFLAGS ?= $(STRIP_DEBUG) -X 'github.com/cilium/cilium/cilium-cli/defaults.CLIVersion=$(VERSION)'
 
 TEST_TIMEOUT ?= 5s
-RELEASE_UID ?= $(shell id -u)
-RELEASE_GID ?= $(shell id -g)
-
-# renovate: datasource=docker depName=golang
-GO_IMAGE_VERSION = 1.22.5-alpine3.19
-GO_IMAGE_SHA = sha256:48aac60d4f50477055967586f60391fb1f3cbdc2e176e36f1f7f3fd0f5380ef7
-
-# renovate: datasource=docker depName=golangci/golangci-lint
-GOLANGCILINT_WANT_VERSION = v1.59.1
-GOLANGCILINT_IMAGE_SHA = sha256:b5f8712114561f1e2fbe74d04ed07ddfd992768705033a6251f3c7b848eac38e
-GOLANGCILINT_VERSION = $(shell golangci-lint version --format short 2>/dev/null)
 
 $(TARGET):
 	$(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) \
 		-ldflags "$(GO_BUILD_LDFLAGS)" \
 		-o $(TARGET) \
 		./cmd/cilium
-
-release:
-	docker run \
-		--rm \
-		--workdir /cilium \
-		--volume `pwd`:/cilium docker.io/library/golang:$(GO_IMAGE_VERSION)@$(GO_IMAGE_SHA) \
-		sh -c "apk add --no-cache setpriv make git zip && \
-			/usr/bin/setpriv --reuid=$(RELEASE_UID) --regid=$(RELEASE_GID) --clear-groups make GOCACHE=/tmp/gocache local-release"
 
 local-release: clean
 	set -o errexit; \
@@ -97,14 +78,6 @@ tags: $$($(GO) list ./...)
 	@ctags $<
 	cscope -R -b -q
 
-ifneq (,$(findstring $(GOLANGCILINT_WANT_VERSION:v%=%),$(GOLANGCILINT_VERSION)))
-check:
-	golangci-lint run
-else
-check:
-	docker run --rm -v `pwd`:/app -w /app docker.io/golangci/golangci-lint:$(GOLANGCILINT_WANT_VERSION) golangci-lint run
-endif
-
-.PHONY: $(TARGET) release local-release install clean test bench check clean-tags tags
+.PHONY: $(TARGET) local-release install clean test bench check clean-tags tags
 
 -include Makefile.override


### PR DESCRIPTION
Clean up cilium-cli Makefile and migrate a missing rule to the renovate configuration.

See commits for details.
