### PR TITLE
chore(plugins): replace deprecated CNI function

### DIFF
--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -79,8 +79,7 @@ func WithEPConfigurator(cfg EndpointConfigurator) Option {
 	}
 }
 
-// NewCmd creates a new Cmd instance, whose Add, Del and Check methods can be
-// passed to skel.PluginMain
+// NewCmd creates a new Cmd instance with Add, Del and Check methods
 func NewCmd(opts ...Option) *Cmd {
 	cmd := &Cmd{
 		cfg: &DefaultConfigurator{},
@@ -89,6 +88,15 @@ func NewCmd(opts ...Option) *Cmd {
 		opt(cmd)
 	}
 	return cmd
+}
+
+// CNIFuncs returns the CNI functions supported by Cilium that can be passed to skel.PluginMainFuncs
+func (cmd *Cmd) CNIFuncs() skel.CNIFuncs {
+	return skel.CNIFuncs{
+		Add:   cmd.Add,
+		Del:   cmd.Del,
+		Check: cmd.Check,
+	}
 }
 
 type CmdState struct {

--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -19,9 +19,7 @@ func init() {
 
 func main() {
 	c := cmd.NewCmd()
-	skel.PluginMain(c.Add,
-		c.Check,
-		c.Del,
+	skel.PluginMainFuncs(c.CNIFuncs(),
 		cniVersion.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0"),
 		"Cilium CNI plugin "+version.Version)
 }


### PR DESCRIPTION
This pull request replaces the deprecated skel.PluginMain with its skel.PluginMainFuncs counterpart It adds a new function to the Cmd structure to convert the CNI methods into a standardized structure that can be passed to skel.PluginMain

If the CNI vendored repo is updated, there's a few other deprecated items introduced that could be cleaned aswell.