### PR TITLE
Add CLI flag to specify --kubeconfig

### DIFF
--- a/cilium-cli/cli/cmd.go
+++ b/cilium-cli/cli/cmd.go
@@ -85,7 +85,7 @@ cilium connectivity test`,
 	cmd.PersistentFlags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "kube-system", "Namespace Cilium is running in")
 	cmd.PersistentFlags().StringVar(&helmReleaseName, "helm-release-name", "cilium", "Helm release name")
-	cmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", "", "absolute path to the kubeconfig file")
+	cmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", "", "Path to the kubeconfig file")
 
 	cmd.AddCommand(
 		newCmdBgp(),

--- a/cilium-cli/cli/cmd.go
+++ b/cilium-cli/cli/cmd.go
@@ -18,6 +18,7 @@ var (
 	contextName     string
 	namespace       string
 	helmReleaseName string
+	kubeConfig      string
 
 	k8sClient *k8s.Client
 )
@@ -44,7 +45,7 @@ func NewCiliumCommand(hooks api.Hooks) *cobra.Command {
 				}
 			}
 
-			c, err := k8s.NewClient(contextName, "", namespace)
+			c, err := k8s.NewClient(contextName, kubeConfig, namespace)
 			if err != nil {
 				return fmt.Errorf("unable to create Kubernetes client: %w", err)
 			}
@@ -84,6 +85,7 @@ cilium connectivity test`,
 	cmd.PersistentFlags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "kube-system", "Namespace Cilium is running in")
 	cmd.PersistentFlags().StringVar(&helmReleaseName, "helm-release-name", "cilium", "Helm release name")
+	cmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", "", "absolute path to the kubeconfig file")
 
 	cmd.AddCommand(
 		newCmdBgp(),


### PR DESCRIPTION
Add an optional `--kubeconfig` parameter to allow explicitly specifying the location of the Kubernetes configuration file.