### PR TITLE
ingress: Remove generated CEC if empty

### DIFF
--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -88,8 +88,8 @@ func TestReconcile(t *testing.T) {
 
 		sharedCEC := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
-		require.NoError(t, err, "Attempt to cleanup shared CiliumEnvoyConfig will create an empty one")
-		require.Empty(t, sharedCEC.Spec.Resources)
+		require.Error(t, err, "Empty CiliumEnvoyConfig must be removed")
+		require.True(t, k8sApiErrors.IsNotFound(err))
 	})
 
 	t.Run("Reconcile of Ingress without specific IngressClassName will create resources if cilium IngressClass is the default", func(t *testing.T) {
@@ -144,8 +144,8 @@ func TestReconcile(t *testing.T) {
 
 		sharedCEC := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
-		require.NoError(t, err, "Attempt to cleanup shared CiliumEnvoyConfig will create an empty one")
-		require.Empty(t, sharedCEC.Spec.Resources)
+		require.Error(t, err, "Empty CiliumEnvoyConfig must be removed")
+		require.True(t, k8sApiErrors.IsNotFound(err))
 	})
 
 	t.Run("Reconcile of Ingress without specific IngressClassName won't create resources if cilium IngressClass is not the default", func(t *testing.T) {
@@ -381,8 +381,8 @@ func TestReconcile(t *testing.T) {
 
 		sharedCEC := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
-		require.NoError(t, err, "Attempt to cleanup shared CiliumEnvoyConfig will replace it with an empty one")
-		require.Empty(t, sharedCEC.Spec.Resources)
+		require.Error(t, err, "Empty CiliumEnvoyConfig must be removed")
+		require.True(t, k8sApiErrors.IsNotFound(err))
 	})
 
 	t.Run("Reconcile of a non-existent, potentially deleted, Cilium Ingress will try to cleanup any potentially existing shared resources", func(t *testing.T) {
@@ -423,8 +423,8 @@ func TestReconcile(t *testing.T) {
 
 		sharedCEC := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
-		require.NoError(t, err, "Attempt to cleanup shared CiliumEnvoyConfig will replace it with an empty one")
-		require.Empty(t, sharedCEC.Spec.Resources)
+		require.Error(t, err, "Empty CiliumEnvoyConfig must be removed")
+		require.True(t, k8sApiErrors.IsNotFound(err))
 	})
 
 	t.Run("Reconcile of non Cilium Ingress will cleanup any potentially existing resources (dedicated and shared) and reset the Ingress status", func(t *testing.T) {
@@ -517,8 +517,8 @@ func TestReconcile(t *testing.T) {
 
 		sharedCEC := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: testCiliumNamespace, Name: testDefaultLoadbalancingServiceName}, &sharedCEC)
-		require.NoError(t, err, "Attempt to cleanup shared CiliumEnvoyConfig will replace it with an empty one")
-		require.Empty(t, sharedCEC.Spec.Resources)
+		require.Error(t, err, "Empty CiliumEnvoyConfig must be removed")
+		require.True(t, k8sApiErrors.IsNotFound(err))
 
 		ingress := networkingv1.Ingress{}
 		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "test", Name: "test"}, &ingress)


### PR DESCRIPTION
In shared ingress mode, there might be the case that the last Ingress is removed, which leads to be error. This commit is to make sure that the empty generated CEC resource is removed instead.

```
2024-08-26T10:42:04.939184909Z time="2024-08-26T10:42:04Z" level=error msg="Reconciler error" Ingress="{other-node cilium-test-1}" controller=ingress controllerGroup=networking.k8s.io controllerKind=Ingress error="failed to create or update CiliumEnvoyConfig: CiliumEnvoyConfig.cilium.io \"cilium-ingress\" is invalid: spec.resources: Required value" name=other-node namespace=cilium-test-1 reconcileID="\"9ae75e32-e4d7-4767-9e19-ca619b7bf678\"" subsys=controller-runtime

```

Relates: https://github.com/cilium/cilium/pull/34463
