### PR TITLE
docs: Update examples for CNP L7 Host

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -744,9 +744,12 @@ spec:
                                       type: array
                                     host:
                                       description: "Host is an extended POSIX regex
-                                        matched against the host header of a request,
-                                        e.g. \"foo.com\" \n If omitted or empty, the
-                                        value of the host header is ignored."
+                                        matched against the host header of a request.
+                                        Examples: \n - foo.bar.com will match the
+                                        host fooXbar.com or foo-bar.com - foo\\.bar\\.com
+                                        will only match the host foo.bar.com \n If
+                                        omitted or empty, the value of the host header
+                                        is ignored."
                                       format: idn-hostname
                                       type: string
                                     method:
@@ -2382,9 +2385,12 @@ spec:
                                       type: array
                                     host:
                                       description: "Host is an extended POSIX regex
-                                        matched against the host header of a request,
-                                        e.g. \"foo.com\" \n If omitted or empty, the
-                                        value of the host header is ignored."
+                                        matched against the host header of a request.
+                                        Examples: \n - foo.bar.com will match the
+                                        host fooXbar.com or foo-bar.com - foo\\.bar\\.com
+                                        will only match the host foo.bar.com \n If
+                                        omitted or empty, the value of the host header
+                                        is ignored."
                                       format: idn-hostname
                                       type: string
                                     method:
@@ -3799,9 +3805,12 @@ spec:
                                         type: array
                                       host:
                                         description: "Host is an extended POSIX regex
-                                          matched against the host header of a request,
-                                          e.g. \"foo.com\" \n If omitted or empty,
-                                          the value of the host header is ignored."
+                                          matched against the host header of a request.
+                                          Examples: \n - foo.bar.com will match the
+                                          host fooXbar.com or foo-bar.com - foo\\.bar\\.com
+                                          will only match the host foo.bar.com \n
+                                          If omitted or empty, the value of the host
+                                          header is ignored."
                                         format: idn-hostname
                                         type: string
                                       method:
@@ -5460,9 +5469,12 @@ spec:
                                         type: array
                                       host:
                                         description: "Host is an extended POSIX regex
-                                          matched against the host header of a request,
-                                          e.g. \"foo.com\" \n If omitted or empty,
-                                          the value of the host header is ignored."
+                                          matched against the host header of a request.
+                                          Examples: \n - foo.bar.com will match the
+                                          host fooXbar.com or foo-bar.com - foo\\.bar\\.com
+                                          will only match the host foo.bar.com \n
+                                          If omitted or empty, the value of the host
+                                          header is ignored."
                                         format: idn-hostname
                                         type: string
                                       method:

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -748,9 +748,12 @@ spec:
                                       type: array
                                     host:
                                       description: "Host is an extended POSIX regex
-                                        matched against the host header of a request,
-                                        e.g. \"foo.com\" \n If omitted or empty, the
-                                        value of the host header is ignored."
+                                        matched against the host header of a request.
+                                        Examples: \n - foo.bar.com will match the
+                                        host fooXbar.com or foo-bar.com - foo\\.bar\\.com
+                                        will only match the host foo.bar.com \n If
+                                        omitted or empty, the value of the host header
+                                        is ignored."
                                       format: idn-hostname
                                       type: string
                                     method:
@@ -2386,9 +2389,12 @@ spec:
                                       type: array
                                     host:
                                       description: "Host is an extended POSIX regex
-                                        matched against the host header of a request,
-                                        e.g. \"foo.com\" \n If omitted or empty, the
-                                        value of the host header is ignored."
+                                        matched against the host header of a request.
+                                        Examples: \n - foo.bar.com will match the
+                                        host fooXbar.com or foo-bar.com - foo\\.bar\\.com
+                                        will only match the host foo.bar.com \n If
+                                        omitted or empty, the value of the host header
+                                        is ignored."
                                       format: idn-hostname
                                       type: string
                                     method:
@@ -3803,9 +3809,12 @@ spec:
                                         type: array
                                       host:
                                         description: "Host is an extended POSIX regex
-                                          matched against the host header of a request,
-                                          e.g. \"foo.com\" \n If omitted or empty,
-                                          the value of the host header is ignored."
+                                          matched against the host header of a request.
+                                          Examples: \n - foo.bar.com will match the
+                                          host fooXbar.com or foo-bar.com - foo\\.bar\\.com
+                                          will only match the host foo.bar.com \n
+                                          If omitted or empty, the value of the host
+                                          header is ignored."
                                         format: idn-hostname
                                         type: string
                                       method:
@@ -5464,9 +5473,12 @@ spec:
                                         type: array
                                       host:
                                         description: "Host is an extended POSIX regex
-                                          matched against the host header of a request,
-                                          e.g. \"foo.com\" \n If omitted or empty,
-                                          the value of the host header is ignored."
+                                          matched against the host header of a request.
+                                          Examples: \n - foo.bar.com will match the
+                                          host fooXbar.com or foo-bar.com - foo\\.bar\\.com
+                                          will only match the host foo.bar.com \n
+                                          If omitted or empty, the value of the host
+                                          header is ignored."
                                         format: idn-hostname
                                         type: string
                                       method:

--- a/pkg/policy/api/http.go
+++ b/pkg/policy/api/http.go
@@ -82,7 +82,10 @@ type PortRuleHTTP struct {
 	Method string `json:"method,omitempty"`
 
 	// Host is an extended POSIX regex matched against the host header of a
-	// request, e.g. "foo.com"
+	// request. Examples:
+	//
+	// - foo.bar.com will match the host fooXbar.com or foo-bar.com
+	// - foo\.bar\.com will only match the host foo.bar.com
 	//
 	// If omitted or empty, the value of the host header is ignored.
 	//


### PR DESCRIPTION
This is to add examples to clarify on regex matching on L7 host.

