### PR TITLE
pkg/dynamicconfig: Add support for multiple sources

### DIFF
--- a/pkg/dynamicconfig/cell.go
+++ b/pkg/dynamicconfig/cell.go
@@ -7,6 +7,8 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
 	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/option/resolver"
 )
 
 // Cell provides a reflector of cilium configs to DynamicConfigMap table.
@@ -43,13 +45,21 @@ var Cell = cell.Module(
 )
 
 var defaultConfig = config{
-	EnableDynamicConfig: false,
+	EnableDynamicConfig:    false,
+	ConfigSources:          `[{"kind":"config-map","namespace":"kube-system","name":"cilium-config"}]`, // See pkg/option/resolver.go for the JSON definition
+	ConfigSourcesOverrides: `{"allowConfigKeys":null,"denyConfigKeys":null}`,
 }
 
 type config struct {
-	EnableDynamicConfig bool
+	EnableDynamicConfig    bool
+	ConfigSources          string
+	ConfigSourcesOverrides string
 }
 
 func (c config) Flags(flags *pflag.FlagSet) {
 	flags.Bool("enable-dynamic-config", c.EnableDynamicConfig, "Enables support for dynamic agent config")
+	flags.String(resolver.ConfigSources, c.ConfigSources, "Ordered list of configuration sources")
+	flags.MarkHidden(resolver.ConfigSources)
+	flags.String(resolver.ConfigSourcesOverrides, c.ConfigSourcesOverrides, "List of configuration keys that are allowed and not allowed to be overridden. Allowed config keys takes precedence over deny config keys.")
+	flags.MarkHidden(resolver.ConfigSourcesOverrides)
 }

--- a/pkg/dynamicconfig/reflectors.go
+++ b/pkg/dynamicconfig/reflectors.go
@@ -45,7 +45,7 @@ func configMapReflector(name string, cs k8sClient.Clientset, t statedb.RWTable[D
 			var entries []DynamicConfig
 			cm := o.(*v1.ConfigMap).DeepCopy()
 			for k, v := range cm.Data {
-				dc := DynamicConfig{Key: Key{Name: k, Source: cm.Name}, Value: v}
+				dc := DynamicConfig{Key: Key{Name: k, Source: cm.Name}, Value: v, Priority: priorities[name]}
 				entries = append(entries, dc)
 			}
 			return entries

--- a/pkg/dynamicconfig/reflectors.go
+++ b/pkg/dynamicconfig/reflectors.go
@@ -4,56 +4,116 @@
 package dynamicconfig
 
 import (
+	"encoding/json"
+	"fmt"
 	"iter"
+	"log/slog"
+	"slices"
+	"strings"
 
 	"github.com/cilium/statedb"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	apivalidation "k8s.io/apimachinery/pkg/util/validation"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/k8s"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option/resolver"
 )
 
-var (
-	CiliumConfigMap          = "cilium-config"
-	CiliumConfigMapNamespace = "kube-system"
-
-	// Lower number means higher priority
-	// When adding a new source, the source priority needs to be updated here
-	priorities = map[string]int{
-		CiliumConfigMap: 0,
-	}
+const (
+	metadataName = "metadata.name="
 )
 
-func NewConfigMapReflector(cs k8sClient.Clientset, t statedb.RWTable[DynamicConfig], c config) []k8s.ReflectorConfig[DynamicConfig] {
+func NewConfigMapReflector(cs k8sClient.Clientset, t statedb.RWTable[DynamicConfig], c config, l *slog.Logger) []k8s.ReflectorConfig[DynamicConfig] {
 	if !cs.IsEnabled() || !c.EnableDynamicConfig {
 		return []k8s.ReflectorConfig[DynamicConfig]{}
 	}
-
-	return []k8s.ReflectorConfig[DynamicConfig]{
-		configMapReflector(CiliumConfigMap, cs, t),
+	sources, overrides, err := parseConfigs(c)
+	if err != nil {
+		l.Error("Failed to process configs", logfields.Error, err)
+		return []k8s.ReflectorConfig[DynamicConfig]{}
 	}
+
+	var reflectors = make([]k8s.ReflectorConfig[DynamicConfig], 0, len(sources))
+	sLen := len(sources)
+	for i, source := range sources {
+
+		var reflector k8s.ReflectorConfig[DynamicConfig]
+		switch source.Kind {
+		case resolver.KindConfigMap:
+			reflector = configMapReflector(source.Name, source.Namespace, cs, t, i, sLen, overrides)
+		case resolver.KindNodeConfig:
+			reflector = ciliumNodeConfigReflector(source.Name, source.Namespace, cs, t, i, sLen, overrides)
+		case resolver.KindNode:
+			reflector = ciliumNodeReflector(source.Name, cs, t, l, i, sLen, overrides)
+		}
+
+		reflectors = append(reflectors, reflector)
+	}
+
+	return reflectors
 }
 
-func configMapReflector(name string, cs k8sClient.Clientset, t statedb.RWTable[DynamicConfig]) k8s.ReflectorConfig[DynamicConfig] {
+func parseConfigs(c config) ([]resolver.ConfigSource, resolver.ConfigOverride, error) {
+	var sources []resolver.ConfigSource
+	if err := json.Unmarshal([]byte(c.ConfigSources), &sources); err != nil {
+		return nil, resolver.ConfigOverride{}, fmt.Errorf("error during unmarshall config-sources: %w", err)
+	}
+
+	var overrides resolver.ConfigOverride
+	if err := json.Unmarshal([]byte(c.ConfigSourcesOverrides), &overrides); err != nil {
+		return nil, resolver.ConfigOverride{}, fmt.Errorf("error during unmarshall config-sources: %w", err)
+	}
+	return sources, overrides, nil
+}
+
+func getPriorityForKey(key string, overrides resolver.ConfigOverride, index int, sourceLen int) int {
+	// The first source have no restriction for overrides
+	if index == 0 {
+		return sourceLen
+	}
+
+	// If the len(AllowConfigKeys) > 0, DenyConfigKeys should be ignored
+	if len(overrides.AllowConfigKeys) > 0 {
+		if slices.Contains(overrides.AllowConfigKeys, key) {
+			return sourceLen - index
+		}
+		return sourceLen + index
+	}
+
+	// If the AllowConfigKeys is empty, check DenyConfigKeys
+	if len(overrides.DenyConfigKeys) > 0 && slices.Contains(overrides.DenyConfigKeys, key) {
+		return sourceLen + index
+	}
+
+	return sourceLen - index
+}
+
+func configMapReflector(name string, namespace string, cs k8sClient.Clientset, t statedb.RWTable[DynamicConfig], index int, sourceLen int, overrides resolver.ConfigOverride) k8s.ReflectorConfig[DynamicConfig] {
 	return k8s.ReflectorConfig[DynamicConfig]{
-		Name:  "cm-" + name,
+		Name:  "cm-" + name + "-" + namespace,
 		Table: t,
 		TransformMany: func(o any) []DynamicConfig {
-			var entries []DynamicConfig
 			cm := o.(*v1.ConfigMap).DeepCopy()
+			var entries = make([]DynamicConfig, 0, len(cm.Data))
 			for k, v := range cm.Data {
-				dc := DynamicConfig{Key: Key{Name: k, Source: cm.Name}, Value: v, Priority: priorities[name]}
+				priority := getPriorityForKey(k, overrides, index, sourceLen)
+				dc := DynamicConfig{Key: Key{Name: k, Source: cm.Name}, Value: v, Priority: priority}
 				entries = append(entries, dc)
 			}
 			return entries
 		},
 		ListerWatcher: utils.ListerWatcherWithModifiers(
-			utils.ListerWatcherFromTyped[*v1.ConfigMapList](cs.CoreV1().ConfigMaps(CiliumConfigMapNamespace)),
+			utils.ListerWatcherFromTyped[*v1.ConfigMapList](cs.CoreV1().ConfigMaps(namespace)),
 			func(opts *metav1.ListOptions) {
-				opts.FieldSelector = fields.ParseSelectorOrDie("metadata.name=" + name).String()
+				opts.FieldSelector = fields.ParseSelectorOrDie(metadataName + name).String()
 			},
 		),
 		QueryAll: func(txn statedb.ReadTxn, t statedb.Table[DynamicConfig]) iter.Seq2[DynamicConfig, statedb.Revision] {
@@ -65,4 +125,95 @@ func configMapReflector(name string, cs k8sClient.Clientset, t statedb.RWTable[D
 			)
 		},
 	}
+}
+func ciliumNodeConfigReflector(name string, namespace string, cs k8sClient.Clientset, t statedb.RWTable[DynamicConfig], index int, sourceLen int, overrides resolver.ConfigOverride) k8s.ReflectorConfig[DynamicConfig] {
+	return k8s.ReflectorConfig[DynamicConfig]{
+		Name:  "cnc-" + name + "-" + namespace,
+		Table: t,
+		TransformMany: func(o any) []DynamicConfig {
+			cnc := o.(*ciliumv2.CiliumNodeConfig).DeepCopy()
+			var entries = make([]DynamicConfig, 0, len(cnc.Spec.Defaults))
+			for k, v := range cnc.Spec.Defaults {
+				priority := getPriorityForKey(k, overrides, index, sourceLen)
+				dc := DynamicConfig{Key: Key{Name: k, Source: cnc.Name}, Value: v, Priority: priority}
+				entries = append(entries, dc)
+			}
+			return entries
+		},
+		ListerWatcher: utils.ListerWatcherWithModifiers(
+			utils.ListerWatcherFromTyped[*ciliumv2.CiliumNodeConfigList](cs.CiliumV2().CiliumNodeConfigs(namespace)),
+			func(opts *metav1.ListOptions) {
+				opts.FieldSelector = fields.ParseSelectorOrDie(metadataName + name).String()
+			},
+		),
+		QueryAll: func(txn statedb.ReadTxn, t statedb.Table[DynamicConfig]) iter.Seq2[DynamicConfig, statedb.Revision] {
+			return statedb.Filter(
+				t.All(txn),
+				func(dc DynamicConfig) bool {
+					return dc.Key.Source == name
+				},
+			)
+		},
+	}
+}
+
+func ciliumNodeReflector(name string, cs k8sClient.Clientset, t statedb.RWTable[DynamicConfig], l *slog.Logger, index int, sourceLen int, overrides resolver.ConfigOverride) k8s.ReflectorConfig[DynamicConfig] {
+	return k8s.ReflectorConfig[DynamicConfig]{
+		Name:  "node-" + name,
+		Table: t,
+		TransformMany: func(o any) []DynamicConfig {
+			var entries []DynamicConfig
+			node := o.(*corev1.Node).DeepCopy()
+
+			for k, v := range parseNodeConfig(node, l) {
+				priority := getPriorityForKey(k, overrides, index, sourceLen)
+				dc := DynamicConfig{Key: Key{Name: k, Source: node.Name}, Value: v, Priority: priority}
+				entries = append(entries, dc)
+			}
+			return entries
+		},
+		ListerWatcher: utils.ListerWatcherWithModifiers(
+			utils.ListerWatcherFromTyped[*corev1.NodeList](cs.Slim().CoreV1().Nodes()),
+			func(opts *metav1.ListOptions) {
+				opts.FieldSelector = fields.ParseSelectorOrDie(metadataName + name).String()
+			},
+		),
+		QueryAll: func(txn statedb.ReadTxn, t statedb.Table[DynamicConfig]) iter.Seq2[DynamicConfig, statedb.Revision] {
+			return statedb.Filter(
+				t.All(txn),
+				func(dc DynamicConfig) bool {
+					return dc.Key.Source == name
+				},
+			)
+		},
+	}
+}
+
+// parseNodeConfig returns a map of overridable fields from the Node object
+// It allows annotation or labels with config.cilium.io/K=V
+func parseNodeConfig(node *corev1.Node, logger *slog.Logger) map[string]string {
+	out := map[string]string{}
+	read := func(in map[string]string) {
+		for k, v := range in {
+			if !strings.HasPrefix(k, annotation.ConfigPrefix) {
+				continue
+			}
+
+			s := strings.SplitN(k, "/", 2)
+			if len(s) != 2 {
+				logger.Warn("Detected invalid format in annotation, expected config.cilium.io/KEY=VALUE. Skipping", logfields.ConfigAnnotation, k)
+				continue
+			}
+			key := s[1]
+			if errs := apivalidation.IsConfigMapKey(key); len(errs) > 0 {
+				logger.Warn("Detected invalid key. Skipping", logfields.ConfigAnnotation, k, logfields.Error, errs)
+				continue
+			}
+			out[key] = v
+		}
+	}
+
+	read(node.Labels)
+	read(node.Annotations)
+	return out
 }

--- a/pkg/dynamicconfig/reflectors_test.go
+++ b/pkg/dynamicconfig/reflectors_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dynamicconfig
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/option/resolver"
+)
+
+const key = "key"
+
+func TestGetPriorityForKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		overrides resolver.ConfigOverride
+		index     int
+		sourceLen int
+		expected  int
+	}{
+		{
+			name:      "no_overrides",
+			key:       key,
+			overrides: resolver.ConfigOverride{AllowConfigKeys: []string{}, DenyConfigKeys: []string{}},
+			index:     0,
+			sourceLen: 5,
+			expected:  5,
+		},
+		{
+			name:      "key_in_allow",
+			key:       key,
+			overrides: resolver.ConfigOverride{AllowConfigKeys: []string{key}, DenyConfigKeys: []string{}},
+			index:     2,
+			sourceLen: 5,
+			expected:  3, // sourceLen - index
+		},
+		{
+			name:      "key_not_in_allow",
+			key:       "key2",
+			overrides: resolver.ConfigOverride{AllowConfigKeys: []string{key}, DenyConfigKeys: []string{}},
+			index:     2,
+			sourceLen: 5,
+			expected:  7, // sourceLen + index
+		},
+		{
+			name:      "key_in_deny",
+			key:       key,
+			overrides: resolver.ConfigOverride{AllowConfigKeys: []string{}, DenyConfigKeys: []string{key}},
+			index:     1,
+			sourceLen: 5,
+			expected:  6, // sourceLen + index
+		},
+		{
+			name:      "key_not_in_deny",
+			key:       key,
+			overrides: resolver.ConfigOverride{AllowConfigKeys: []string{}, DenyConfigKeys: []string{"key2"}},
+			index:     1,
+			sourceLen: 5,
+			expected:  4, // sourceLen - index
+		},
+		{
+			name:      "allow_has_precedence_over_deny",
+			key:       key,
+			overrides: resolver.ConfigOverride{AllowConfigKeys: []string{key}, DenyConfigKeys: []string{key}},
+			index:     1,
+			sourceLen: 5,
+			expected:  4, // sourceLen - index, allow is considered
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := getPriorityForKey(tt.key, tt.overrides, tt.index, tt.sourceLen)
+			if actual != tt.expected {
+				t.Errorf("getPriorityForKey(%s, %v, %d, %d) = %d; expected %d", tt.key, tt.overrides, tt.index, tt.sourceLen, actual, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseNodeConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		node *corev1.Node
+		want map[string]string
+	}{
+		{
+			name: "valid_labels_annotation",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						annotation.ConfigPrefix + "/key1": "value1",
+					},
+					Annotations: map[string]string{
+						annotation.ConfigPrefix + "/key2": "value2",
+					},
+				},
+			},
+			want: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "invalid_annotation_format",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"invalidkey": "value",
+					},
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "invalid_config_key",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"prefix/invalid/key": "value",
+					},
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "valid_and_invalid_annotation",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotation.ConfigPrefix + "/key1": "value1",
+						"invalidkey":                      "value2",
+						"prefix/invalid/key":              "value3",
+					},
+				},
+			},
+			want: map[string]string{
+				"key1": "value1",
+			},
+		},
+		{
+			name: "no_relevant_annotations_or_labels",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{"some/label": "value"},
+					Annotations: map[string]string{"some/annotation": "value"},
+				},
+			},
+			want: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := slog.New(logging.SlogNopHandler)
+			got := parseNodeConfig(tt.node, logger)
+
+			if len(got) != len(tt.want) {
+				t.Errorf("parseNodeConfig() got %v, want %v", got, tt.want)
+			}
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("parseNodeConfig() got[%v] = %v, want %v", k, got[k], v)
+				}
+			}
+		})
+	}
+}

--- a/pkg/dynamicconfig/table.go
+++ b/pkg/dynamicconfig/table.go
@@ -49,8 +49,9 @@ func (k Key) String() string {
 }
 
 type DynamicConfig struct {
-	Key   Key
-	Value string
+	Key      Key
+	Value    string
+	Priority int
 }
 
 func (d DynamicConfig) TableHeader() []string {
@@ -66,7 +67,7 @@ func (d DynamicConfig) TableRow() []string {
 	return []string{
 		d.Key.Name,
 		d.Key.Source,
-		strconv.Itoa(priorities[d.Key.Source]),
+		strconv.Itoa(d.Priority),
 		d.Value,
 	}
 }
@@ -126,15 +127,6 @@ func WatchKey(txn statedb.ReadTxn, table statedb.Table[DynamicConfig], key strin
 
 func sortByPriority(entries []DynamicConfig) {
 	sort.Slice(entries, func(i, j int) bool {
-		return getPriority(entries[i].Key.Source) < getPriority(entries[j].Key.Source)
+		return entries[i].Priority < entries[j].Priority
 	})
-}
-
-func getPriority(name string) int {
-	priority, found := priorities[name]
-
-	if !found {
-		return len(priorities) + 1
-	}
-	return priority
 }

--- a/pkg/option/resolver/resolver.go
+++ b/pkg/option/resolver/resolver.go
@@ -7,6 +7,7 @@ package resolver
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"os"
@@ -34,12 +35,19 @@ const (
 	KindConfigMap  = "config-map"
 	KindNode       = "node"
 	KindNodeConfig = "cilium-node-config"
+
+	ConfigSources          = "config-sources"
+	ConfigSourcesOverrides = "config-sources-overrides"
 )
 
 type ConfigSource struct {
-	Kind      string // one of config-map, overrides, node
-	Namespace string // The namespace for the ConfigMap or CiliumNodeConfigs
-	Name      string // The name of the ConfigMap or Node, unused for Overrides
+	Kind      string `json:"kind"`      // one of KindConfigMap, KindNodeConfig, KindNode
+	Namespace string `json:"namespace"` // The namespace for the ConfigMap, CiliumNodeConfigs or empty for Node
+	Name      string `json:"name"`      // The name of the ConfigMap or Node, unused for Overrides
+}
+type ConfigOverride struct {
+	AllowConfigKeys []string `json:"allowConfigKeys"` // List of configuration keys that are allowed to be overridden (e.g. set from not the first source. Takes precedence over deny-config-keys
+	DenyConfigKeys  []string `json:"denyConfigKeys"`  // List of configuration keys that are not allowed to be overridden (e.g. set from not the first source. If allow-config-keys is set, this field is ignored"
 }
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "option-resolver")
@@ -50,7 +58,7 @@ func (cs *ConfigSource) String() string {
 
 func ResolveConfigurations(ctx context.Context, client client.Clientset, nodeName string, sources []ConfigSource, allowConfigKeys, denyConfigKeys []string) (map[string]string, error) {
 	config := map[string]string{}
-	sourceDescriptions := []string{} // We want to keep track of which sources we actually use
+	var sourceDescriptions []ConfigSource // We want to keep track of which unique sources we actually use in order of source priority
 
 	// matchKeys is a set of keys that are either allowed or denied
 	var matchKeys sets.Set[string]
@@ -89,7 +97,18 @@ func ResolveConfigurations(ctx context.Context, client client.Clientset, nodeNam
 		}
 	}
 
-	config["config-sources"] = strings.Join(sourceDescriptions, ",")
+	sConfigJson, err := json.Marshal(sourceDescriptions)
+	if err != nil {
+		return config, fmt.Errorf("encoding to JSON %s: %w", ConfigSources, err)
+	}
+
+	oConfigJson, err := json.Marshal(ConfigOverride{AllowConfigKeys: allowConfigKeys, DenyConfigKeys: denyConfigKeys})
+	if err != nil {
+		return config, fmt.Errorf("encoding to JSON %s: %w", ConfigSourcesOverrides, err)
+	}
+
+	config[ConfigSources] = string(sConfigJson)
+	config[ConfigSourcesOverrides] = string(oConfigJson)
 
 	return config, nil
 }
@@ -159,7 +178,7 @@ func WriteConfigurations(ctx context.Context, destDir string, data map[string]st
 	return nil
 }
 
-func ReadConfigSource(ctx context.Context, client client.Clientset, nodeName string, source ConfigSource) (config map[string]string, descriptions []string, err error) {
+func ReadConfigSource(ctx context.Context, client client.Clientset, nodeName string, source ConfigSource) (config map[string]string, sources []ConfigSource, err error) {
 	log.WithFields(logrus.Fields{
 		logfields.ConfigSource: source.String(),
 	}).Infof("Reading configuration from %s", source.String())
@@ -174,7 +193,7 @@ func ReadConfigSource(ctx context.Context, client client.Clientset, nodeName str
 	return nil, nil, fmt.Errorf("invalid source kind %s", source.Kind)
 }
 
-func readNodeOverrides(ctx context.Context, client client.Clientset, nodeName string) (map[string]string, []string, error) {
+func readNodeOverrides(ctx context.Context, client client.Clientset, nodeName string) (map[string]string, []ConfigSource, error) {
 	node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get Node %s: %w", nodeName, err)
@@ -211,10 +230,11 @@ func readNodeOverrides(ctx context.Context, client client.Clientset, nodeName st
 	if len(out) == 0 {
 		return nil, nil, nil
 	}
-	return out, []string{fmt.Sprintf("%s:%s", KindNode, nodeName)}, nil
+
+	return out, []ConfigSource{{Kind: KindNode, Namespace: "", Name: nodeName}}, nil
 }
 
-func readConfigMap(ctx context.Context, client client.Clientset, source ConfigSource) (map[string]string, []string, error) {
+func readConfigMap(ctx context.Context, client client.Clientset, source ConfigSource) (map[string]string, []ConfigSource, error) {
 	cm, err := client.CoreV1().ConfigMaps(source.Namespace).Get(ctx, source.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -228,12 +248,12 @@ func readConfigMap(ctx context.Context, client client.Clientset, source ConfigSo
 	if len(cm.Data) == 0 {
 		return nil, nil, nil
 	}
-	return cm.Data, []string{source.String()}, nil
+	return cm.Data, []ConfigSource{source}, nil
 }
 
 // readNodeConfigsAllVersions read node configurations for versions v2 and v2alpha1 of CiliumNodeConfig CRD.
 // TODO depreciate CNC on v2alpha1 https://github.com/cilium/cilium/issues/31982
-func readNodeConfigsAllVersions(ctx context.Context, client client.Clientset, nodeName, namespace, name string) (map[string]string, []string, error) {
+func readNodeConfigsAllVersions(ctx context.Context, client client.Clientset, nodeName, namespace, name string) (map[string]string, []ConfigSource, error) {
 	var errv2, errv2alpha1 error
 
 	nodeConfigv2, descv2, errv2 := readNodeConfigs(ctx, client, nodeName, namespace, name)
@@ -259,7 +279,13 @@ func readNodeConfigsAllVersions(ctx context.Context, client client.Clientset, no
 		maps.Copy(nodeConfigv2alpha1, nodeConfigv2)
 	}
 
-	descv2 = append(descv2, descv2alpha1...)
+	addedSources := sets.New[ConfigSource](descv2...)
+	for _, source := range descv2alpha1 {
+		if !addedSources.Has(source) {
+			descv2 = append(descv2, source)
+		}
+		addedSources.Insert(source)
+	}
 
 	return nodeConfigv2alpha1, descv2, nil
 }
@@ -267,7 +293,7 @@ func readNodeConfigsAllVersions(ctx context.Context, client client.Clientset, no
 // readNodeConfigs reads all the CiliumNodeConfig in v2 objects and returns a flattened map
 // of any key overrides that apply to this node.
 // TODO remove me when CiliumNodeConfig v2alpha1 is deprecated
-func readNodeConfigs(ctx context.Context, client client.Clientset, nodeName, namespace, name string) (map[string]string, []string, error) {
+func readNodeConfigs(ctx context.Context, client client.Clientset, nodeName, namespace, name string) (map[string]string, []ConfigSource, error) {
 	var overrides []ciliumv2.CiliumNodeConfig
 
 	// Retrieve CNCs if the name is not provided
@@ -352,9 +378,9 @@ func readNodeConfigs(ctx context.Context, client client.Clientset, nodeName, nam
 		}
 	}
 
-	var sourceDescriptions []string
+	var sourceDescriptions []ConfigSource
 	for _, name := range matchingNames {
-		sourceDescriptions = append(sourceDescriptions, fmt.Sprintf("%s:%s/%s", KindNodeConfig, namespace, name))
+		sourceDescriptions = append(sourceDescriptions, ConfigSource{Kind: KindNodeConfig, Namespace: namespace, Name: name})
 	}
 
 	return out, sourceDescriptions, nil
@@ -363,7 +389,7 @@ func readNodeConfigs(ctx context.Context, client client.Clientset, nodeName, nam
 // readNodeConfigsv2alpha1 reads all the CiliumNodeConfig in v2alpha1 objects and returns a flattened map
 // of any key overrides that apply to this node.
 // TODO depreciate CNC on v2alpha1 https://github.com/cilium/cilium/issues/31982
-func readNodeConfigsv2alpha1(ctx context.Context, client client.Clientset, nodeName, namespace, name string) (map[string]string, []string, error) {
+func readNodeConfigsv2alpha1(ctx context.Context, client client.Clientset, nodeName, namespace, name string) (map[string]string, []ConfigSource, error) {
 	var overrides []ciliumv2alpha1.CiliumNodeConfig
 
 	// Retrieve CNCs if the name is not provided
@@ -447,9 +473,9 @@ func readNodeConfigsv2alpha1(ctx context.Context, client client.Clientset, nodeN
 		}
 	}
 
-	var sourceDescriptions []string
+	var sourceDescriptions []ConfigSource
 	for _, name := range matchingNames {
-		sourceDescriptions = append(sourceDescriptions, fmt.Sprintf("%s:%s/%s", KindNodeConfig, namespace, name))
+		sourceDescriptions = append(sourceDescriptions, ConfigSource{Kind: KindNodeConfig, Namespace: namespace, Name: name})
 	}
 
 	return out, sourceDescriptions, nil

--- a/pkg/option/resolver/resolver_test.go
+++ b/pkg/option/resolver/resolver_test.go
@@ -169,13 +169,14 @@ func TestResolveConfigurations(t *testing.T) {
 
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(config).To(gomega.Equal(map[string]string{
-		"cm-key":         "cm-val",
-		"anno-key":       "anno-val",
-		"cnc-key":        "cnc-val",
-		"cnc-key-2":      "cnc-val-2",
-		"cnc-key-v2":     "cnc-val-v2",
-		"cnc-key-2-v2":   "cnc-val-2-v2",
-		"config-sources": "config-map:test-ns/cm,cilium-node-config:test-ns/test-1-v2,cilium-node-config:test-ns/test-1,node:nodename,cilium-node-config:test-ns/specific,cilium-node-config:test-ns/specific-v2",
+		"cm-key":                   "cm-val",
+		"anno-key":                 "anno-val",
+		"cnc-key":                  "cnc-val",
+		"cnc-key-2":                "cnc-val-2",
+		"cnc-key-v2":               "cnc-val-v2",
+		"cnc-key-2-v2":             "cnc-val-2-v2",
+		"config-sources":           "[{\"kind\":\"config-map\",\"namespace\":\"test-ns\",\"name\":\"cm\"},{\"kind\":\"cilium-node-config\",\"namespace\":\"test-ns\",\"name\":\"test-1-v2\"},{\"kind\":\"cilium-node-config\",\"namespace\":\"test-ns\",\"name\":\"test-1\"},{\"kind\":\"node\",\"namespace\":\"\",\"name\":\"nodename\"},{\"kind\":\"cilium-node-config\",\"namespace\":\"test-ns\",\"name\":\"specific\"},{\"kind\":\"cilium-node-config\",\"namespace\":\"test-ns\",\"name\":\"specific-v2\"}]",
+		"config-sources-overrides": "{\"allowConfigKeys\":null,\"denyConfigKeys\":null}",
 	}))
 }
 
@@ -243,9 +244,10 @@ func TestWithBlockedFields(t *testing.T) {
 		sources, []string{"allowed-key"}, nil)
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(config).To(gomega.Equal(map[string]string{
-		"cm-key":         "cm-val",
-		"allowed-key":    "allowed-val",
-		"config-sources": "config-map:test-ns/cm,cilium-node-config:test-ns/test-1",
+		"cm-key":                   "cm-val",
+		"allowed-key":              "allowed-val",
+		"config-sources":           "[{\"kind\":\"config-map\",\"namespace\":\"test-ns\",\"name\":\"cm\"},{\"kind\":\"cilium-node-config\",\"namespace\":\"test-ns\",\"name\":\"test-1\"}]",
+		"config-sources-overrides": "{\"allowConfigKeys\":[\"allowed-key\"],\"denyConfigKeys\":null}",
 	}))
 
 	// Test that blocked-key is blocked
@@ -254,9 +256,10 @@ func TestWithBlockedFields(t *testing.T) {
 		sources, nil, []string{"blocked-key", "cm-key"})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(config).To(gomega.Equal(map[string]string{
-		"cm-key":         "cm-val",
-		"allowed-key":    "allowed-val",
-		"config-sources": "config-map:test-ns/cm,cilium-node-config:test-ns/test-1",
+		"cm-key":                   "cm-val",
+		"allowed-key":              "allowed-val",
+		"config-sources":           "[{\"kind\":\"config-map\",\"namespace\":\"test-ns\",\"name\":\"cm\"},{\"kind\":\"cilium-node-config\",\"namespace\":\"test-ns\",\"name\":\"test-1\"}]",
+		"config-sources-overrides": "{\"allowConfigKeys\":null,\"denyConfigKeys\":[\"blocked-key\",\"cm-key\"]}",
 	}))
 
 }


### PR DESCRIPTION
Add support for multiple sources ( ConfigMap, CiliumNodeConfig, NodeConfig) and supporting allowing/denying overriding keys.

The first commit updates the pkg/resolver to a standard JSON format of config-sources and allow/deny overriding keys. 
It refactors the current implementation of the DynamicConfig Table to store the priority to support configurable sources and expose the priority part of the cilium-dbg. 

The priority works the following way, the lower the number, the higher the priority. If a key should not be allowed to be overridden its priority will be the len(sources) + priority(index of the source). Similarly, the priority is calculated using the len(sources) - priority(index of the source)

Fixes: https://github.com/cilium/cilium/issues/34541
