### PR TITLE
bpf-tproxy: don't look for local 'established' UDP sockets

### DIFF
--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -49,6 +49,9 @@ assign_socket_udp(struct __ctx_buff *ctx,
 	struct bpf_sock *sk;
 	__u32 dbg_ctx;
 
+	if (established)
+		goto out;
+
 	sk = sk_lookup_udp(ctx, tuple, len, BPF_F_CURRENT_NETNS, 0);
 	if (!sk)
 		goto out;


### PR DESCRIPTION
While investigating CI test failures in PR #34154 involving L7 DNS rules in pods, I discovered that BPF tproxy redirection has no effect if there is a UDP socket listening on 0.0.0.0:53 on the host: the DNS request packet from the pod to kube-dns service is delivered to the socket listening on the host and not to the dnsproxy socket. This behavior is caused by BPF function __ctx_redirect_to_proxy() explicitly checking for a matching socket on the host before looking up the proxy socket indicated by policy, regardless of protocol (TCP vs UDP). In the case of TCP, this code path delivers packets to established sockets created by accept()ing connections on the listening proxy socket, and is required for L7 proxies (such as HTTP) to work. However, there is no such thing as established sockets in UDP: there is just the one listening UDP socket. So the check for a matching established local UDP socket makes no sense. This commit eliminates the check.

Fixes: #34360