### PR TITLE
endpoint: Delete the dirty data of old endpoint when create new endpoint

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -408,7 +408,8 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 		if err != nil {
 			return invalidDataError(ep, err)
 		} else if oldEp != nil {
-			return invalidDataError(ep, fmt.Errorf("IP %s is already in use", id))
+			oldEp.Logger("api").Warning("endpoint conflicted, delete it.")
+			d.deleteEndpoint(oldEp)
 		}
 	}
 


### PR DESCRIPTION

1, the CNI deletion and delelteendpoint is  asynchronous.
2, when the CNI deletion is completed, then for example we are update the cilium-agent pod or the pod is rebooted for internal bug, the data of the old endpoint will be a dirty data.  
3, For this case, I think we should delete it automatically like this patch。
4，Is there any negative impact? I think the uniqueness of the assigned ip is the first principle for and ipamd binary, so it should almost impossible to happen; so for this case, we just need to record it in log of warning.


