### PR TITLE
docs: Avoid using wildcard TLS certificate

### DIFF
--- a/Documentation/network/servicemesh/tls-cert.rst
+++ b/Documentation/network/servicemesh/tls-cert.rst
@@ -7,23 +7,29 @@ Create TLS Certificate and Private Key
 
         For demonstration purposes we will use a TLS certificate signed by a made-up,
         `self-signed <https://cert-manager.io/docs/faq/terminology/#what-does-self-signed-mean-is-my-ca-self-signed>`_
-        certificate authority (CA). One easy way to do this is with `minica <https://github.com/jsha/minica>`_.
+        certificate authority (CA). One easy way to do this is with `mkcert <https://github.com/FiloSottile/mkcert>`_.
         We want a certificate that will validate ``bookinfo.cilium.rocks`` and
         ``hipstershop.cilium.rocks``, as these are the host names used in this example.
 
         .. code-block:: shell-session
 
-            $ minica -domains '*.cilium.rocks'
+            $ mkcert bookinfo.cilium.rocks hispter.cilium.rocks
+            Note: the local CA is not installed in the system trust store.
+            Run "mkcert -install" for certificates to be trusted automatically ⚠️
 
-        On first run, ``minica`` generates a CA certificate and key (``minica.pem`` and
-        ``minica-key.pem``). It also creates a directory called ``_.cilium.rocks``
-        containing a key and certificate file that we will use for the TLS configuration.
+            Created a new certificate valid for the following names 📜
+             - "bookinfo.cilium.rocks"
+             - "hispter.cilium.rocks"
+
+            The certificate is at "./bookinfo.cilium.rocks+1.pem" and the key at "./bookinfo.cilium.rocks+1-key.pem" ✅
+
+            It will expire on 29 November 2026 🗓
 
         Create a Kubernetes secret with this demo key and certificate:
 
         .. code-block:: shell-session
 
-            $ kubectl create secret tls demo-cert --key=_.cilium.rocks/key.pem --cert=_.cilium.rocks/cert.pem
+            $ kubectl create secret tls demo-cert --key=bookinfo.cilium.rocks+1-key.pem --cert=bookinfo.cilium.rocks+1.pem
 
     .. group-tab:: cert-manager
 


### PR DESCRIPTION
This commit is to avoid using wildcard TLS certificate in Ingress and Gateway API docs. Additionally, minica is replaced by mkcert, which is more user-friendly in local dev (e.g. installing CA, multiple root stores, etc).
