### PR TITLE
Fix deadlock in identity watcher

### DIFF
--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -584,6 +584,7 @@ func (k *kvstoreBackend) ListIDs(ctx context.Context) (identityIDs []idpool.ID, 
 }
 
 func (k *kvstoreBackend) ListAndWatch(ctx context.Context, handler allocator.CacheMutations, stopChan chan struct{}) {
+	ctx, cancel := context.WithCancel(ctx)
 	watcher := k.backend.ListAndWatch(ctx, k.idPrefix, 512)
 	for {
 		select {
@@ -640,6 +641,7 @@ func (k *kvstoreBackend) ListAndWatch(ctx context.Context, handler allocator.Cac
 	}
 
 abort:
+	cancel()
 	watcher.Stop()
 }
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -829,13 +829,13 @@ reList:
 				scopedLog.Debugf("Emitting list result as %s event for %s=%s", t, key.Key, key.Value)
 			}
 
-			queueStart := spanstat.Start()
-			w.Events <- KeyValueEvent{
+			if !w.emit(ctx, scope, KeyValueEvent{
 				Key:   string(key.Key),
 				Value: key.Value,
 				Typ:   t,
+			}) {
+				return
 			}
-			trackEventQueued(scope, t, queueStart.End(true).Total())
 		}
 
 		nextRev := revision + 1
@@ -843,7 +843,7 @@ reList:
 		// Send out deletion events for all keys that were deleted
 		// between our last known revision and the latest revision
 		// received via Get
-		localCache.RemoveDeleted(func(k string) {
+		if !localCache.RemoveDeleted(func(k string) bool {
 			event := KeyValueEvent{
 				Key: k,
 				Typ: EventTypeDelete,
@@ -852,15 +852,16 @@ reList:
 			if traceEnabled {
 				scopedLog.Debugf("Emitting EventTypeDelete event for %s", k)
 			}
-
-			queueStart := spanstat.Start()
-			w.Events <- event
-			trackEventQueued(scope, EventTypeDelete, queueStart.End(true).Total())
-		})
+			return w.emit(ctx, scope, event)
+		}) {
+			return
+		}
 
 		// Only send the list signal once
 		if !listSignalSent {
-			w.Events <- KeyValueEvent{Typ: EventTypeListDone}
+			if !w.emit(ctx, scope, KeyValueEvent{Typ: EventTypeListDone}) {
+				return
+			}
 			listSignalSent = true
 		}
 
@@ -873,6 +874,8 @@ reList:
 			case <-e.client.Ctx().Done():
 				return
 			case <-ctx.Done():
+				return
+			case <-w.stopWatch:
 				return
 			default:
 				goto recreateWatcher
@@ -942,10 +945,9 @@ reList:
 					if traceEnabled {
 						scopedLog.Debugf("Emitting %s event for %s=%s", event.Typ, event.Key, event.Value)
 					}
-
-					queueStart := spanstat.Start()
-					w.Events <- event
-					trackEventQueued(scope, event.Typ, queueStart.End(true).Total())
+					if !w.emit(ctx, scope, event) {
+						return
+					}
 				}
 			}
 		}

--- a/pkg/kvstore/watcher_cache.go
+++ b/pkg/kvstore/watcher_cache.go
@@ -17,13 +17,18 @@ func (wc watcherCache) Exists(key []byte) bool {
 	return false
 }
 
-func (wc watcherCache) RemoveDeleted(f func(string)) {
+// RemoveDeleted removes keys marked for deletion from the local cache exiting
+// early if the given function returns false.
+func (wc watcherCache) RemoveDeleted(f func(string) bool) bool {
 	for k, localKey := range wc {
 		if localKey.deletionMark {
-			f(k)
+			if !f(k) {
+				return false
+			}
 			delete(wc, k)
 		}
 	}
+	return true
 }
 
 func (wc watcherCache) MarkAllForDeletion() {


### PR DESCRIPTION
A backend disconnect will cause the receiver of the watcher events to exit. If this occurs while and the sender has enough events to fill the channel buffer deadlock can occur.

Fixes: #30797

```release-note
Fixes deadlock in identity watcher. This fixes an issue where a kvstore disconnect can cause the event receiver to exit and the event sender to get stuck forever.
```

Heres a fix for the above issue we are planning to rollout. @giorio94 I saw your comment about removing the stopChan all together. I wasn't confident making that refactor myself so here is a less intrusive change that fixes the issue for us. Feel free to use this as a jumping off point or close it if you prefer a different solution.