### PR TITLE
wireguard: Use dummy peer for allowed IP removal

### DIFF
--- a/Documentation/security/network/encryption-wireguard.rst
+++ b/Documentation/security/network/encryption-wireguard.rst
@@ -372,6 +372,14 @@ table are not subject to encryption with WireGuard and therefore assumed to be u
   encrypted only between intermediate Node (which received client request first)
   and destination Node.
 
+Known Issues
+==========================
+
+* Packets may be dropped when configuring the WireGuard device leading to
+  connectivity issues. This happens when endpoints are added or removed or
+  when node updates occur. In some cases this may lead to failed calls to
+  ``sendmsg`` and ``sendto``. See :gh-issue:`33159` for more details.
+
 Legal
 =====
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -802,7 +802,4 @@ const (
 
 	// Target identifies a target value
 	Target = "target"
-
-	// StaleIPs represents a set of stale IPs.
-	StaleIPs = "staleIPs"
 )

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"context"
+	"iter"
 	"maps"
 	"net"
 	"net/netip"
@@ -23,13 +24,17 @@ import (
 )
 
 type fakeWgClient struct {
-	peers map[wgtypes.Key]wgtypes.Peer
+	allowedIPs map[netip.Prefix]wgtypes.Key
+	peers      map[wgtypes.Key]wgtypes.Peer
 }
 
 func newFakeWgClient(peers ...wgtypes.Peer) *fakeWgClient {
-	wgc := &fakeWgClient{peers: make(map[wgtypes.Key]wgtypes.Peer)}
+	wgc := &fakeWgClient{
+		allowedIPs: make(map[netip.Prefix]wgtypes.Key),
+		peers:      make(map[wgtypes.Key]wgtypes.Peer),
+	}
 	for _, peer := range peers {
-		wgc.peers[peer.PublicKey] = peer
+		wgc.upsertPeer(peer.PublicKey, peer.Endpoint, peer.AllowedIPs)
 	}
 	return wgc
 }
@@ -64,22 +69,79 @@ func (f *fakeWgClient) ConfigureDevice(name string, cfg wgtypes.Config) error {
 
 	for _, peer := range cfg.Peers {
 		if peer.Remove {
+			for _, ip := range f.peers[peer.PublicKey].AllowedIPs {
+				delete(f.allowedIPs, ipnetToPrefix(ip))
+			}
 			delete(f.peers, peer.PublicKey)
 			continue
 		}
 
-		if !peer.ReplaceAllowedIPs {
+		if peer.ReplaceAllowedIPs {
 			return unix.ENOTSUP
 		}
 
-		f.peers[peer.PublicKey] = wgtypes.Peer{
-			PublicKey:  peer.PublicKey,
-			Endpoint:   peer.Endpoint,
-			AllowedIPs: peer.AllowedIPs,
-		}
+		f.upsertPeer(peer.PublicKey, peer.Endpoint, peer.AllowedIPs)
 	}
 
 	return nil
+}
+
+func (f *fakeWgClient) upsertPeer(pubKey wgtypes.Key, endpoint *net.UDPAddr, allowedIPs []net.IPNet) {
+	for _, ip := range allowedIPs {
+		// Steal the IP from another peer potentially.
+		if key, exists := f.allowedIPs[ipnetToPrefix(ip)]; exists && key != pubKey {
+			oldPeer := f.peers[key]
+			oldPeer.AllowedIPs = filterAllowedIPs(oldPeer.AllowedIPs, []net.IPNet{ip})
+			f.peers[key] = oldPeer
+		}
+
+		f.allowedIPs[ipnetToPrefix(ip)] = pubKey
+	}
+
+	f.peers[pubKey] = wgtypes.Peer{
+		PublicKey:  pubKey,
+		Endpoint:   endpoint,
+		AllowedIPs: mergeAllowedIPs(f.peers[pubKey].AllowedIPs, allowedIPs),
+	}
+}
+
+func mergeAllowedIPs(a, b []net.IPNet) []net.IPNet {
+	mergedMap := map[netip.Prefix]net.IPNet{}
+
+	for _, ip := range a {
+		mergedMap[ipnetToPrefix(ip)] = ip
+	}
+
+	for _, ip := range b {
+		mergedMap[ipnetToPrefix(ip)] = ip
+	}
+
+	merged := make([]net.IPNet, 0, len(mergedMap))
+
+	for _, ip := range mergedMap {
+		merged = append(merged, ip)
+	}
+
+	return merged
+}
+
+func filterAllowedIPs(ips []net.IPNet, filter []net.IPNet) []net.IPNet {
+	filterMap := map[netip.Prefix]net.IPNet{}
+
+	for _, ip := range filter {
+		filterMap[ipnetToPrefix(ip)] = ip
+	}
+
+	var filtered []net.IPNet
+	for _, ip := range ips {
+		if _, ok := filterMap[ipnetToPrefix(ip)]; ok {
+			continue
+		}
+
+		filtered = append(filtered, ip)
+	}
+
+	return filtered
 }
 
 var (
@@ -88,10 +150,13 @@ var (
 	k8s1NodeIPv4 = net.ParseIP("192.168.60.11")
 	k8s1NodeIPv6 = net.ParseIP("fd01::b")
 
-	k8s2NodeName = "k8s2"
-	k8s2PubKey   = "lH+Xsa0JClu1syeBVbXN0LZNQVB6rTPBzbzWOHwQLW4="
-	k8s2NodeIPv4 = net.ParseIP("192.168.60.12")
-	k8s2NodeIPv6 = net.ParseIP("fd01::c")
+	k8s2NodeName   = "k8s2"
+	k8s2PubKey     = "lH+Xsa0JClu1syeBVbXN0LZNQVB6rTPBzbzWOHwQLW4="
+	k8s2PubKey2    = "lH+Xsa0JClu1syeBVbXN0LZNQVB6rTPBzbzWOHwQLW5="
+	k8s2NodeIPv4   = net.ParseIP("192.168.60.12")
+	k8s2NodeIPv4_2 = net.ParseIP("192.168.60.13")
+	k8s2NodeIPv6   = net.ParseIP("fd01::c")
+	k8s2NodeIPv6_2 = net.ParseIP("fd01::c")
 
 	pod1IPv4Str = "10.0.0.1"
 	pod1IPv4    = iputil.IPToPrefix(net.ParseIP(pod1IPv4Str))
@@ -111,8 +176,8 @@ var (
 	pod4IPv6    = iputil.IPToPrefix(net.ParseIP(pod4IPv6Str))
 )
 
-func containsIP(allowedIPs []net.IPNet, ipnet *net.IPNet) bool {
-	for _, allowedIP := range allowedIPs {
+func containsIP(allowedIPs iter.Seq[net.IPNet], ipnet *net.IPNet) bool {
+	for allowedIP := range allowedIPs {
 		if cidr.Equal(&allowedIP, ipnet) {
 			return true
 		}
@@ -125,14 +190,12 @@ func newTestAgent(ctx context.Context, wgClient wireguardClient) (*Agent, *ipcac
 		Context: ctx,
 	})
 	wgAgent := &Agent{
-		wgClient:           wgClient,
-		ipCache:            ipCache,
-		listenPort:         types.ListenPort,
-		peerByNodeName:     map[string]*peerConfig{},
-		nodeNameByNodeIP:   map[string]string{},
-		nodeNameByPubKey:   map[wgtypes.Key]string{},
-		restoredPeers:      map[wgtypes.Key][]net.IPNet{},
-		restoredAllowedIPs: map[netip.Prefix]wgtypes.Key{},
+		wgClient:         wgClient,
+		ipCache:          ipCache,
+		listenPort:       types.ListenPort,
+		peerByNodeName:   map[string]*peerConfig{},
+		nodeNameByNodeIP: map[string]string{},
+		nodeNameByPubKey: map[wgtypes.Key]string{},
 	}
 	ipCache.AddListener(wgAgent)
 	return wgAgent, ipCache
@@ -159,12 +222,12 @@ func TestAgent_PeerConfig(t *testing.T) {
 	require.EqualValues(t, k8s1NodeIPv6, k8s1.nodeIPv6)
 	require.Equal(t, k8s1PubKey, k8s1.pubKey.String())
 	require.Len(t, k8s1.allowedIPs, 6)
-	require.Equal(t, true, containsIP(k8s1.allowedIPs, iputil.IPToPrefix(k8s1NodeIPv4)))
-	require.Equal(t, true, containsIP(k8s1.allowedIPs, iputil.IPToPrefix(k8s1NodeIPv6)))
-	require.Equal(t, true, containsIP(k8s1.allowedIPs, pod1IPv4))
-	require.Equal(t, true, containsIP(k8s1.allowedIPs, pod1IPv6))
-	require.Equal(t, true, containsIP(k8s1.allowedIPs, pod2IPv4))
-	require.Equal(t, true, containsIP(k8s1.allowedIPs, pod2IPv6))
+	require.Equal(t, true, containsIP(maps.Values(k8s1.allowedIPs), iputil.IPToPrefix(k8s1NodeIPv4)))
+	require.Equal(t, true, containsIP(maps.Values(k8s1.allowedIPs), iputil.IPToPrefix(k8s1NodeIPv6)))
+	require.Equal(t, true, containsIP(maps.Values(k8s1.allowedIPs), pod1IPv4))
+	require.Equal(t, true, containsIP(maps.Values(k8s1.allowedIPs), pod1IPv6))
+	require.Equal(t, true, containsIP(maps.Values(k8s1.allowedIPs), pod2IPv4))
+	require.Equal(t, true, containsIP(maps.Values(k8s1.allowedIPs), pod2IPv6))
 
 	// Tests that IPCache updates are blocked by a concurrent UpdatePeer.
 	// We test this by issuing an UpdatePeer request while holding
@@ -228,20 +291,20 @@ func TestAgent_PeerConfig(t *testing.T) {
 	require.EqualValues(t, k8s1NodeIPv6, k8s1.nodeIPv6)
 	require.Equal(t, k8s1PubKey, k8s1.pubKey.String())
 	require.Len(t, k8s1.allowedIPs, 4)
-	require.Equal(t, true, containsIP(k8s1.allowedIPs, iputil.IPToPrefix(k8s1NodeIPv4)))
-	require.Equal(t, true, containsIP(k8s1.allowedIPs, iputil.IPToPrefix(k8s1NodeIPv6)))
-	require.Equal(t, true, containsIP(k8s1.allowedIPs, pod2IPv4))
-	require.Equal(t, true, containsIP(k8s1.allowedIPs, pod2IPv6))
+	require.Equal(t, true, containsIP(maps.Values(k8s1.allowedIPs), iputil.IPToPrefix(k8s1NodeIPv4)))
+	require.Equal(t, true, containsIP(maps.Values(k8s1.allowedIPs), iputil.IPToPrefix(k8s1NodeIPv6)))
+	require.Equal(t, true, containsIP(maps.Values(k8s1.allowedIPs), pod2IPv4))
+	require.Equal(t, true, containsIP(maps.Values(k8s1.allowedIPs), pod2IPv6))
 
 	k8s2 := wgAgent.peerByNodeName[k8s2NodeName]
 	require.EqualValues(t, k8s2NodeIPv4, k8s2.nodeIPv4)
 	require.EqualValues(t, k8s2NodeIPv6, k8s2.nodeIPv6)
 	require.Equal(t, k8s2PubKey, k8s2.pubKey.String())
 	require.Len(t, k8s2.allowedIPs, 4)
-	require.Equal(t, true, containsIP(k8s2.allowedIPs, iputil.IPToPrefix(k8s2NodeIPv4)))
-	require.Equal(t, true, containsIP(k8s2.allowedIPs, iputil.IPToPrefix(k8s2NodeIPv6)))
-	require.Equal(t, true, containsIP(k8s2.allowedIPs, pod3IPv4))
-	require.Equal(t, true, containsIP(k8s2.allowedIPs, pod3IPv6))
+	require.Equal(t, true, containsIP(maps.Values(k8s2.allowedIPs), iputil.IPToPrefix(k8s2NodeIPv4)))
+	require.Equal(t, true, containsIP(maps.Values(k8s2.allowedIPs), iputil.IPToPrefix(k8s2NodeIPv6)))
+	require.Equal(t, true, containsIP(maps.Values(k8s2.allowedIPs), pod3IPv4))
+	require.Equal(t, true, containsIP(maps.Values(k8s2.allowedIPs), pod3IPv6))
 
 	// Tests that duplicate public keys are rejected (k8s2 imitates k8s1)
 	err = wgAgent.UpdatePeer(k8s2NodeName, k8s1PubKey, k8s2NodeIPv4, k8s2NodeIPv6)
@@ -273,10 +336,10 @@ func TestAgent_PeerConfig_WithEncryptNode(t *testing.T) {
 	require.EqualValues(t, k8s1NodeIPv6, k8s1.nodeIPv6)
 	require.Equal(t, k8s1PubKey, k8s1.pubKey.String())
 	require.Len(t, k8s1.allowedIPs, 4)
-	require.Equal(t, true, containsIP(k8s1.allowedIPs, pod1IPv4))
-	require.Equal(t, true, containsIP(k8s1.allowedIPs, pod2IPv4))
-	require.Equal(t, true, containsIP(k8s1.allowedIPs, iputil.IPToPrefix(k8s1NodeIPv4)))
-	require.Equal(t, true, containsIP(k8s1.allowedIPs, iputil.IPToPrefix(k8s1NodeIPv6)))
+	require.Equal(t, true, containsIP(maps.Values(k8s1.allowedIPs), pod1IPv4))
+	require.Equal(t, true, containsIP(maps.Values(k8s1.allowedIPs), pod2IPv4))
+	require.Equal(t, true, containsIP(maps.Values(k8s1.allowedIPs), iputil.IPToPrefix(k8s1NodeIPv4)))
+	require.Equal(t, true, containsIP(maps.Values(k8s1.allowedIPs), iputil.IPToPrefix(k8s1NodeIPv6)))
 }
 
 func TestAgent_AllowedIPsRestoration(t *testing.T) {
@@ -284,10 +347,13 @@ func TestAgent_AllowedIPsRestoration(t *testing.T) {
 
 	k8s1NodeIPv4Pfx, k8s1NodeIPv6Pfx := iputil.IPToPrefix(k8s1NodeIPv4), iputil.IPToPrefix(k8s1NodeIPv6)
 	k8s2NodeIPv4Pfx, k8s2NodeIPv6Pfx := iputil.IPToPrefix(k8s2NodeIPv4), iputil.IPToPrefix(k8s2NodeIPv6)
+	k8s2NodeIPv4_2_Pfx, k8s2NodeIPv6_2_Pfx := iputil.IPToPrefix(k8s2NodeIPv4_2), iputil.IPToPrefix(k8s2NodeIPv6_2)
 
 	key1, err := wgtypes.ParseKey(k8s1PubKey)
 	require.NoError(t, err, "Failed to parse WG key")
 	key2, err := wgtypes.ParseKey(k8s2PubKey)
+	require.NoError(t, err, "Failed to parse WG key")
+	key2_2, err := wgtypes.ParseKey(k8s2PubKey2)
 	require.NoError(t, err, "Failed to parse WG key")
 
 	wgClient := newFakeWgClient(wgtypes.Peer{
@@ -306,11 +372,9 @@ func TestAgent_AllowedIPsRestoration(t *testing.T) {
 		allowedIPs := wgClient.peers[key].AllowedIPs
 		require.Len(t, allowedIPs, len(ips), "AllowedIPs not updated correctly")
 		for _, ip := range ips {
-			require.True(t, containsIP(allowedIPs, ip), "AllowedIPs does not contain %s", ip.String())
+			require.True(t, containsIP(slices.Values(allowedIPs), ip), "AllowedIPs does not contain %s", ip.String())
 		}
 	}
-
-	require.NoError(t, wgAgent.restoreFromDevice(types.IfaceName), "Failed to restore from device")
 
 	ipCache.Upsert(pod1IPv4Str, k8s1NodeIPv4, 0, nil, ipcache.Identity{ID: 1, Source: source.Kubernetes})
 	ipCache.Upsert(pod1IPv6Str, k8s1NodeIPv6, 0, nil, ipcache.Identity{ID: 1, Source: source.Kubernetes})
@@ -346,4 +410,20 @@ func TestAgent_AllowedIPsRestoration(t *testing.T) {
 	require.NoError(t, wgAgent.RestoreFinished(nil))
 	assertAllowedIPs(key1, pod2IPv4, pod1IPv6, pod2IPv6, k8s1NodeIPv4Pfx, k8s1NodeIPv6Pfx)
 	assertAllowedIPs(key2, pod4IPv4, pod4IPv6, k8s2NodeIPv4Pfx, k8s2NodeIPv6Pfx)
+
+	// Ensure that a public key change results in deletion of the old peer entry.
+	err = wgAgent.UpdatePeer(k8s2NodeName, k8s2PubKey2, k8s2NodeIPv4, k8s2NodeIPv6)
+	require.Nil(t, err)
+	assertAllowedIPs(key1, pod2IPv4, pod1IPv6, pod2IPv6, k8s1NodeIPv4Pfx, k8s1NodeIPv6Pfx)
+	assertAllowedIPs(key2_2, pod4IPv4, pod4IPv6, k8s2NodeIPv4Pfx, k8s2NodeIPv6Pfx)
+
+	// Ensure that a node IP change gets reflected
+	err = wgAgent.UpdatePeer(k8s2NodeName, k8s2PubKey2, k8s2NodeIPv4_2, k8s2NodeIPv6_2)
+	require.Nil(t, err)
+	assertAllowedIPs(key1, pod2IPv4, pod1IPv6, pod2IPv6, k8s1NodeIPv4Pfx, k8s1NodeIPv6Pfx)
+	assertAllowedIPs(key2_2, pod4IPv4, pod4IPv6, k8s2NodeIPv4_2_Pfx, k8s2NodeIPv6_2_Pfx)
+
+	// Ensure that a node IP change gets reflected
+	err = wgAgent.UpdatePeer(k8s2NodeName, wgDummyPeerKey.String(), k8s2NodeIPv4_2, k8s2NodeIPv6_2)
+	require.Error(t, err, "node %q is not allowed to use the dummy peer key", k8s2NodeName)
 }


### PR DESCRIPTION
Recent flakes in the "Network performance GKE" tests, in particular those that use wireguard, uncovered an issue where updates to a peer's allowed IPs can cause connectivity issues. In the best case this may just result in dropped packets while in the worst case may lead to failed calls to `sendto`/`sendmsg` (see GH-33159 for more detail on some of the symptoms observed while running netperf).
    
This issue happens when `ReplaceAllowedIPs` is set, as it causes the wireguard driver to completely clear the set of allowed IPs for a peer before the set is rebuilt. This leaves a gap where packets sent or received at that time will appear to not have a peer associated with them. The current implementation sets `ReplaceAllowedIPs` every time `updatePeerByConfig` is called, but we can avoid ever needing to use it.

This commit uses a "dummy peer" as a way to remove allowed IPs from a peer rather than using `ReplaceAllowedIPs`. We use `peerConfig` to track any pending IP inserts and removals and split these into two different sets of updates in `updatePeerByConfig`. The first call to `ConfigureDevice()` adds any IPs that are pending insertion. Next, any IPs that are pending removal are moved to the "dummy peer" before removing the dummy peer altogether, the net effect being that the IP is removed from the original peer's list of allowed IPs.
    
This commit mostly sidesteps the issue that GH-34095 ("wireguard: restore allowedIPs upong agent restart") set out to solve since we only ever explicitly remove allowed IPs, meaning we can do away with a lot of the accounting previously done by `restoredPeers` and `restoredAllowedIPs`. However, we retain the behavior in `RestoreFinished()` that removes stale peers and allowed IPs.

## Testing
I performed the steps outlined in #33159 in a local kind cluster both before and after applying the change contained in this PR. I ran `netperf` manually while executing this script which induces failure by forcing lots of calls to `updatePeerByConfig`.

```bash
#!/bin/bash

count=100
for i in $(seq $count); do
	kubectl label --overwrite nodes kind-control-plane kill-netperf=true
	kubectl label --overwrite nodes kind-control-plane kill-netperf=false
done
```
### Before
`netperf` fails every time consistently within seconds.

```bash
jrife@jrife-kvm:~/code/cilium$ kubectl exec -it -n cilium-test-1 perf-client-other-node-749b79954c-hpgts -- bash
[root@perf-client-other-node-749b79954c-hpgts netperf]# /usr/local/bin/netperf -H 10.244.0.108 -l 5m -t UDP_STREAM -- -R 1 -m 1024
MIGRATED UDP STREAM TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to 10.244.0.108 () port 0 AF_INET
send_data: data send error: No route to host (errno 113)
netperf: send_omni: send_data failed: No route to host
```

### After
`netperf` runs to completion.

```bash
[root@perf-client-other-node-749b79954c-hpgts netperf]# /usr/local/bin/netperf -H 10.244.0.108 -l 30s -t UDP_STREAM -- -R 1 -m 1024
MIGRATED UDP STREAM TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to 10.244.0.108 () port 0 AF_INET
Socket  Message  Elapsed      Messages                
Size    Size     Time         Okay Errors   Throughput
bytes   bytes    secs            #      #   10^6bits/sec

212992    1024   30.00     1196041      0     326.60
212992           30.00     1072058            292.74
```

Fixes: #33159 

```release-note
wireguard: Fix issue where updates to a WireGuard device's configuration caused connectivity blips.
```
