### PR TITLE
ipam: allow /32 and /128 IP pools 

### DIFF
--- a/Documentation/network/concepts/ipam/multi-pool.rst
+++ b/Documentation/network/concepts/ipam/multi-pool.rst
@@ -71,7 +71,10 @@ New pools can be added at run-time. The list of CIDRs in each pool can also be
 extended at run-time. In-use CIDRs may not be removed from an existing pool, and
 existing pools may not be deleted if they are still in use by a Cilium node.
 The mask size of a pool is immutable and the same for all nodes. Neither restriction
-is enforced until :gh-issue:`26966` is resolved.
+is enforced until :gh-issue:`26966` is resolved. The first and last address of a
+``CiliumPodIPPool`` are reserved and cannot be allocated. Pools with less than 3
+addresses (/31, /32, /127, /128) do not have this limitation.
+
 
 Configuration
 *************

--- a/pkg/ipam/allocator/multipool/pool_allocator_test.go
+++ b/pkg/ipam/allocator/multipool/pool_allocator_test.go
@@ -476,19 +476,19 @@ func Test_addrsInPrefix(t *testing.T) {
 			want: big.NewInt(0),
 		},
 		{
-			name: "two",
-			args: netip.MustParsePrefix("10.0.0.0/30"),
+			name: "/32",
+			args: netip.MustParsePrefix("10.0.0.0/32"),
+			want: big.NewInt(1),
+		},
+		{
+			name: "/31",
+			args: netip.MustParsePrefix("10.0.0.0/31"),
 			want: big.NewInt(2),
 		},
 		{
-			name: "underflow /31",
-			args: netip.MustParsePrefix("10.0.0.0/31"),
-			want: big.NewInt(0),
-		},
-		{
-			name: "underflow /32",
-			args: netip.MustParsePrefix("10.0.0.0/32"),
-			want: big.NewInt(0),
+			name: "/30",
+			args: netip.MustParsePrefix("10.0.0.0/30"),
+			want: big.NewInt(2),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/ipam/service/ipallocator/allocator_test.go
+++ b/pkg/ipam/service/ipallocator/allocator_test.go
@@ -1,0 +1,122 @@
+package ipallocator
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func mustParseCidr(cidr string) *net.IPNet {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic(fmt.Errorf("net.ParseCIDR: %w", err))
+	}
+	return ipNet
+}
+
+func ipForBig(i *big.Int) net.IP {
+	return addIPOffset(i, 0)
+}
+
+func TestNewCIDRRange(t *testing.T) {
+	testCases := []struct {
+		name     string
+		ipNet    *net.IPNet
+		wantBase net.IP
+		wantMax  int
+	}{
+		{
+			name:     "IPv4 /27",
+			ipNet:    mustParseCidr("192.168.0.1/27"),
+			wantBase: net.ParseIP("192.168.0.1"),
+			wantMax:  30, // (2^(32-27) - 2
+		},
+		{
+			name:     "IPv4 /31",
+			ipNet:    mustParseCidr("192.168.0.1/31"),
+			wantBase: net.ParseIP("192.168.0.0"),
+			wantMax:  2, // 2^1
+		},
+		{
+			name:     "IPv4 /32",
+			ipNet:    mustParseCidr("192.168.0.1/32"),
+			wantBase: net.ParseIP("192.168.0.1"),
+			wantMax:  1, // 2^0
+		},
+		{
+			name:     "IPv6 /64",
+			ipNet:    mustParseCidr("2001:db8::1/64"),
+			wantBase: net.ParseIP("2001:db8::1"),
+			wantMax:  65534, // max(2^(128-64), 65536) - 2
+		},
+		{
+			name:     "IPv6 /120",
+			ipNet:    mustParseCidr("2001:db8::1/120"),
+			wantBase: net.ParseIP("2001:db8::1"),
+			wantMax:  254, // 2^(128-120) - 2
+		},
+		{
+			name:     "IPv6 /127",
+			ipNet:    mustParseCidr("2001:db8::1/127"),
+			wantBase: net.ParseIP("2001:db8::0"),
+			wantMax:  2, // 2^1
+		},
+		{
+			name:     "IPv6 /128",
+			ipNet:    mustParseCidr("2001:db8::1/128"),
+			wantBase: net.ParseIP("2001:db8::1"),
+			wantMax:  1, // 2^0
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := NewCIDRRange(tc.ipNet)
+			baseIP := ipForBig(actual.base)
+			require.Equal(t, tc.wantBase.String(), baseIP.String())
+			require.Equal(t, tc.wantMax, actual.max)
+		})
+	}
+}
+
+func TestRangeSize(t *testing.T) {
+	testCases := []struct {
+		name  string
+		ipNet *net.IPNet
+		want  int64
+	}{
+		{
+			name:  "IPv4 /27",
+			ipNet: mustParseCidr("192.168.0.0/27"),
+			want:  32,
+		},
+		{
+			name:  "IPv4 /32",
+			ipNet: mustParseCidr("192.168.0.0/32"),
+			want:  1,
+		},
+		{
+			name:  "IPv6 /64",
+			ipNet: mustParseCidr("2001:db8::/64"),
+			want:  65536,
+		},
+		{
+			name:  "IPv6 /120",
+			ipNet: mustParseCidr("2001:db8::/120"),
+			want:  256,
+		},
+		{
+			name:  "IPv6 /128",
+			ipNet: mustParseCidr("2001:db8::/128"),
+			want:  1,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := RangeSize(tc.ipNet)
+			require.Equal(t, tc.want, actual)
+		})
+	}
+}


### PR DESCRIPTION
This PR makes `CiliumPodIPPool`s that have mask /32 or /128 usable, not restricting the first and last addresses. This can be used to give Pods specific IP addresses. The only way to achieve this today is by requesting a /30 and blocking an unnecessary big chunk of the range.

Commits:
- **ipam: allow /32 and /128 IP pools**
- **documentation: IP pools with /32 or /128 clarification**


Related: https://github.com/cilium/cilium/issues/17026 (fixed IP proposal)
Related: https://github.com/cilium/cilium/issues/28637

```release-note
Multi-Pool IPAM now allows the use of /32 or /128 CIDRs in CiliumPodIPPools
```
