### PR TITLE
Ensure log entries printed from config subsys honor config

### DIFF
--- a/clustermesh-apiserver/clustermesh/root.go
+++ b/clustermesh-apiserver/clustermesh/root.go
@@ -60,10 +60,8 @@ func NewCmd(h *hive.Hive) *cobra.Command {
 		PreRun: func(cmd *cobra.Command, args []string) {
 			// Overwrite the metrics namespace with the one specific for the ClusterMesh API Server
 			metrics.Namespace = metrics.CiliumClusterMeshAPIServerNamespace
+			option.Config.SetupLogging(h.Viper(), "clustermesh-apiserver")
 			option.Config.Populate(h.Viper())
-			if option.Config.Debug {
-				log.Logger.SetLevel(logrus.DebugLevel)
-			}
 			option.LogRegisteredOptions(h.Viper(), log)
 			log.Infof("Cilium ClusterMesh %s", version.Version)
 		},

--- a/clustermesh-apiserver/kvstoremesh/root.go
+++ b/clustermesh-apiserver/kvstoremesh/root.go
@@ -35,10 +35,8 @@ func NewCmd(h *hive.Hive) *cobra.Command {
 		PreRun: func(cmd *cobra.Command, args []string) {
 			// Overwrite the metrics namespace with the one specific for KVStoreMesh
 			metrics.Namespace = metrics.CiliumKVStoreMeshNamespace
+			option.Config.SetupLogging(h.Viper(), "kvstoremesh")
 			option.Config.Populate(h.Viper())
-			if err := logging.SetupLogging(option.Config.LogDriver, option.Config.LogOpt, "kvstoremesh", option.Config.Debug); err != nil {
-				log.Fatal(err)
-			}
 			option.LogRegisteredOptions(h.Viper(), log)
 			log.Infof("Cilium KVStoreMesh %s", version.Version)
 		},

--- a/clustermesh-apiserver/option/config.go
+++ b/clustermesh-apiserver/option/config.go
@@ -26,6 +26,8 @@ const (
 // are still accessed through the global DaemonConfig variable.
 type LegacyClusterMeshConfig struct {
 	Debug          bool
+	LogDriver      []string
+	LogOpt         map[string]string
 	CRDWaitTimeout time.Duration
 }
 
@@ -36,6 +38,8 @@ var DefaultLegacyClusterMeshConfig = LegacyClusterMeshConfig{
 
 func (def LegacyClusterMeshConfig) Flags(flags *pflag.FlagSet) {
 	flags.BoolP(option.DebugArg, "D", def.Debug, "Enable debugging mode")
+	flags.StringSlice(option.LogDriver, def.LogDriver, "Logging endpoints to use (example: syslog)")
+	flags.Var(option.NewNamedMapOptions(option.LogOpt, &option.Config.LogOpt, nil), option.LogOpt, "Log driver options (example: format=json)")
 	flags.Duration(option.CRDWaitTimeout, def.CRDWaitTimeout, "Cilium will exit if CRDs are not available within this duration upon startup")
 }
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1071,17 +1071,7 @@ func restoreExecPermissions(searchDir string, patterns ...string) error {
 	return err
 }
 
-func initLogging() {
-	// add hooks after setting up metrics in the option.Config
-	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook())
-
-	// Logging should always be bootstrapped first. Do not add any code above this!
-	if err := logging.SetupLogging(option.Config.LogDriver, logging.LogOptions(option.Config.LogOpt), "cilium-agent", option.Config.Debug); err != nil {
-		log.Fatal(err)
-	}
-}
-
-func initDaemonConfig(vp *viper.Viper) {
+func initDaemonConfigAndLogging(vp *viper.Viper) {
 	option.Config.SetMapElementSizes(
 		// for the conntrack and NAT element size we assume the largest possible
 		// key size, i.e. IPv6 keys
@@ -1090,7 +1080,11 @@ func initDaemonConfig(vp *viper.Viper) {
 		neighborsmap.SizeofNeighKey6+neighborsmap.SizeOfNeighValue,
 		lbmap.SizeofSockRevNat6Key+lbmap.SizeofSockRevNat6Value)
 
+	option.Config.SetupLogging(vp, "cilium-agent")
 	option.Config.Populate(vp)
+
+	// add hooks after setting up metrics in the option.Config
+	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook())
 
 	time.MaxInternalTimerDelay = vp.GetDuration(option.MaxInternalTimerDelay)
 }

--- a/daemon/cmd/root.go
+++ b/daemon/cmd/root.go
@@ -70,9 +70,8 @@ func NewAgentCmd(hfn func() *hive.Hive) *cobra.Command {
 		// Populate the config and initialize the logger early as these
 		// are shared by all commands.
 		func() {
-			initDaemonConfig(h.Viper())
+			initDaemonConfigAndLogging(h.Viper())
 		},
-		initLogging,
 	)
 
 	return rootCmd

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -365,16 +365,12 @@ func registerOperatorHooks(log *slog.Logger, lc cell.Lifecycle, llc *LeaderLifec
 
 func initEnv(vp *viper.Viper) {
 	// Prepopulate option.Config with options from CLI.
+	option.Config.SetupLogging(vp, binaryName)
 	option.Config.Populate(vp)
 	operatorOption.Config.Populate(vp)
 
 	// add hooks after setting up metrics in the option.Config
 	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook())
-
-	// Logging should always be bootstrapped first. Do not add any code above this!
-	if err := logging.SetupLogging(option.Config.LogDriver, logging.LogOptions(option.Config.LogOpt), binaryName, option.Config.Debug); err != nil {
-		log.Fatal(err)
-	}
 
 	option.LogRegisteredOptions(vp, log)
 	log.Infof("Cilium Operator %s", version.Version)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2729,7 +2729,30 @@ func (c *DaemonConfig) parseExcludedLocalAddresses(s []string) error {
 	return nil
 }
 
-// Populate sets all options with the values from viper
+// SetupLogging sets all logging-related options with the values from viper,
+// then setup logging based on these options and the given tag.
+//
+// This allows initializing logging as early as possible, then log entries
+// produced below in Populate can honor the requested logging configurations.
+func (c *DaemonConfig) SetupLogging(vp *viper.Viper, tag string) {
+	c.Debug = vp.GetBool(DebugArg)
+	c.LogDriver = vp.GetStringSlice(LogDriver)
+
+	if m, err := command.GetStringMapStringE(vp, LogOpt); err != nil {
+		log.Fatalf("unable to parse %s: %s", LogOpt, err)
+	} else {
+		c.LogOpt = m
+	}
+
+	if err := logging.SetupLogging(c.LogDriver, logging.LogOptions(c.LogOpt), tag, c.Debug); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Populate sets all non-logging options with the values from viper.
+//
+// This function may emit logs. Consider calling SetupLogging before this
+// to make sure that they honor logging-related options.
 func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	var err error
 
@@ -2749,7 +2772,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.ClusterName = vp.GetString(clustermeshTypes.OptClusterName)
 	c.MaxConnectedClusters = vp.GetUint32(clustermeshTypes.OptMaxConnectedClusters)
 	c.DatapathMode = vp.GetString(DatapathMode)
-	c.Debug = vp.GetBool(DebugArg)
 	c.DebugVerbose = vp.GetStringSlice(DebugVerbose)
 	c.EnableIPv4 = vp.GetBool(EnableIPv4Name)
 	c.EnableIPv6 = vp.GetBool(EnableIPv6Name)
@@ -2836,7 +2858,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.LabelPrefixFile = vp.GetString(LabelPrefixFile)
 	c.Labels = vp.GetStringSlice(Labels)
 	c.LibDir = vp.GetString(LibDir)
-	c.LogDriver = vp.GetStringSlice(LogDriver)
 	c.LogSystemLoadConfig = vp.GetBool(LogSystemLoadConfigName)
 	c.LoopbackIPv4 = vp.GetString(LoopbackIPv4)
 	c.LocalRouterIPv4 = vp.GetString(LocalRouterIPv4)
@@ -3121,12 +3142,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 		log.Fatalf("unable to parse %s: %s", KVStoreOpt, err)
 	} else {
 		c.KVStoreOpt = m
-	}
-
-	if m, err := command.GetStringMapStringE(vp, LogOpt); err != nil {
-		log.Fatalf("unable to parse %s: %s", LogOpt, err)
-	} else {
-		c.LogOpt = m
 	}
 
 	bpfEventsDefaultRateLimit := vp.GetUint32(BPFEventsDefaultRateLimit)


### PR DESCRIPTION
Previously:

```
ERROR 2024-08-30T08:12:43.551554643Z [resource.labels.containerName: cilium-agent] time="2024-08-30T08:12:43Z" level=info msg="Memory available for map entries (0.003% of 16778747904B): 41946869B" subsys=config
ERROR 2024-08-30T08:12:43.551576396Z [resource.labels.containerName: cilium-agent] time="2024-08-30T08:12:43Z" level=info msg="option bpf-ct-global-tcp-max set by dynamic sizing to 147181" subsys=config
ERROR 2024-08-30T08:12:43.551583030Z [resource.labels.containerName: cilium-agent] time="2024-08-30T08:12:43Z" level=info msg="option bpf-ct-global-any-max set by dynamic sizing to 73590" subsys=config
ERROR 2024-08-30T08:12:43.551590656Z [resource.labels.containerName: cilium-agent] time="2024-08-30T08:12:43Z" level=info msg="option bpf-nat-global-max set by dynamic sizing to 147181" subsys=config
ERROR 2024-08-30T08:12:43.551596179Z [resource.labels.containerName: cilium-agent] time="2024-08-30T08:12:43Z" level=info msg="option bpf-neigh-global-max set by dynamic sizing to 147181" subsys=config
ERROR 2024-08-30T08:12:43.551601442Z [resource.labels.containerName: cilium-agent] time="2024-08-30T08:12:43Z" level=info msg="option bpf-sock-rev-map-max set by dynamic sizing to 73590" subsys=config
INFO 2024-08-30T08:12:43.552747343Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":" --agent-health-port='9879'", "subsys":"daemon"}
INFO 2024-08-30T08:12:43.552771656Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":" --agent-labels=''", "subsys":"daemon"}
INFO 2024-08-30T08:12:43.552779882Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":" --agent-liveness-update-interval='1s'", "subsys":"daemon"}
INFO 2024-08-30T08:12:43.552786331Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":" --agent-not-ready-taint-key='node.cilium.io/agent-not-ready'", "subsys":"daemon"}
INFO 2024-08-30T08:12:43.552792162Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":" --allocator-list-timeout='3m0s'", "subsys":"daemon"}
INFO 2024-08-30T08:12:43.552797838Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":" --allow-icmp-frag-needed='true'", "subsys":"daemon"}
INFO 2024-08-30T08:12:43.552803098Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":" --allow-localhost='auto'", "subsys":"daemon"}
INFO 2024-08-30T08:12:43.552816255Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":" --annotate-k8s-node='false'", "subsys":"daemon"}
```

Now:

```
INFO 2024-08-30T12:43:45.089921545Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":"Memory available for map entries (0.003% of 16778747904B): 41946869B", "subsys":"config"}
INFO 2024-08-30T12:43:45.089962473Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":"option bpf-ct-global-tcp-max set by dynamic sizing to 147181", "subsys":"config"}
INFO 2024-08-30T12:43:45.089972237Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":"option bpf-ct-global-any-max set by dynamic sizing to 73590", "subsys":"config"}
INFO 2024-08-30T12:43:45.089979941Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":"option bpf-nat-global-max set by dynamic sizing to 147181", "subsys":"config"}
INFO 2024-08-30T12:43:45.089986757Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":"option bpf-neigh-global-max set by dynamic sizing to 147181", "subsys":"config"}
INFO 2024-08-30T12:43:45.089993161Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":"option bpf-sock-rev-map-max set by dynamic sizing to 73590", "subsys":"config"}
INFO 2024-08-30T12:43:45.091182490Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":" --agent-health-port='9879'", "subsys":"daemon"}
INFO 2024-08-30T12:43:45.091214633Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":" --agent-labels=''", "subsys":"daemon"}
INFO 2024-08-30T12:43:45.091222817Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":" --agent-liveness-update-interval='1s'", "subsys":"daemon"}
INFO 2024-08-30T12:43:45.091230225Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":" --agent-not-ready-taint-key='node.cilium.io/agent-not-ready'", "subsys":"daemon"}
INFO 2024-08-30T12:43:45.091236900Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":" --allocator-list-timeout='3m0s'", "subsys":"daemon"}
INFO 2024-08-30T12:43:45.091243285Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":" --allow-icmp-frag-needed='true'", "subsys":"daemon"}
INFO 2024-08-30T12:43:45.091249425Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":" --allow-localhost='auto'", "subsys":"daemon"}
INFO 2024-08-30T12:43:45.091256013Z [resource.labels.containerName: cilium-agent] {"level":"info", "msg":" --annotate-k8s-node='false'", "subsys":"daemon"}
```

```release-note
Log entries printed from config subsys during startup now honor logging config such as LogDriver, LogOpt or Debug.
```
