### PR TITLE
Fix Hubble exporter config uses wrong separator

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -974,8 +974,8 @@ data:
 {{- if .Values.hubble.export.static.enabled }}
   hubble-export-file-path: {{ .Values.hubble.export.static.filePath | quote }}
   hubble-export-fieldmask: {{ .Values.hubble.export.static.fieldMask | join " " | quote }}
-  hubble-export-allowlist: {{ .Values.hubble.export.static.allowList | join "," | quote }}
-  hubble-export-denylist: {{ .Values.hubble.export.static.denyList | join "," | quote }}
+  hubble-export-allowlist: {{ .Values.hubble.export.static.allowList | join " " | quote }}
+  hubble-export-denylist: {{ .Values.hubble.export.static.denyList | join " " | quote }}
 {{- end }}
 {{- if .Values.hubble.export.dynamic.enabled }}
   hubble-flowlogs-config-path: /flowlog-config/flowlogs.yaml


### PR DESCRIPTION
Fixes: #34391

```release-note
Fix Hubble exporter config uses wrong separator
```
