### PR TITLE
ipam: Support for static IP allocation in AWS

### DIFF
--- a/pkg/alibabacloud/eni/node.go
+++ b/pkg/alibabacloud/eni/node.go
@@ -305,6 +305,11 @@ func (n *Node) AllocateIPs(ctx context.Context, a *ipam.AllocationAction) error 
 	return err
 }
 
+func (n *Node) AllocateStaticIP(ctx context.Context, staticIPTags ipamTypes.Tags) (string, error) {
+	// TODO, see https://github.com/cilium/cilium/issues/34094
+	return "", fmt.Errorf("not implemented")
+}
+
 // PrepareIPRelease prepares the release of ENI IPs.
 func (n *Node) PrepareIPRelease(excessIPs int, scopedLog *logrus.Entry) *ipam.ReleaseAction {
 	r := &ipam.ReleaseAction{}

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/api/helpers"
 	"github.com/cilium/cilium/pkg/aws/endpoints"
@@ -24,6 +23,8 @@ import (
 	ipPkg "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipam/option"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/spanstat"
 )
 
@@ -38,6 +39,8 @@ const (
 	// requires looking at the error message to get the actual reason. See SubnetFullErrMsgStr for example.
 	InvalidParameterValueStr = "InvalidParameterValue"
 )
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ec2")
 
 // Client represents an EC2 API client
 type Client struct {
@@ -414,6 +417,10 @@ func parseENI(iface *ec2_types.NetworkInterface, vpcs ipamTypes.VirtualNetworkMa
 		eni.Prefixes = append(eni.Prefixes, aws.ToString(prefix.Ipv4Prefix))
 	}
 
+	if iface.Association != nil && aws.ToString(iface.Association.PublicIp) != "" {
+		eni.PublicIP = aws.ToString(iface.Association.PublicIp)
+	}
+
 	for _, g := range iface.Groups {
 		if g.GroupId != nil {
 			eni.SecurityGroups = append(eni.SecurityGroups, aws.ToString(g.GroupId))
@@ -742,6 +749,55 @@ func (c *Client) UnassignENIPrefixes(ctx context.Context, eniID string, prefixes
 	_, err := c.ec2Client.UnassignPrivateIpAddresses(ctx, input)
 	c.metricsAPI.ObserveAPICall("UnassignPrivateIpAddresses", deriveStatus(err), sinceStart.Seconds())
 	return err
+}
+
+// AssociateEIP tries to find an Elastic IP Address with the given tags and associates it with the given instance
+func (c *Client) AssociateEIP(ctx context.Context, instanceID string, eipTags ipamTypes.Tags) (string, error) {
+	if len(eipTags) == 0 {
+		return "", fmt.Errorf("no EIP tags were provided")
+	}
+
+	filters := make([]ec2_types.Filter, 0, len(eipTags))
+	for k, v := range eipTags {
+		filters = append(filters, ec2_types.Filter{
+			Name:   aws.String(fmt.Sprintf("tag:%s", k)),
+			Values: []string{v},
+		})
+	}
+
+	describeAddressesInput := &ec2.DescribeAddressesInput{
+		Filters: filters,
+	}
+	c.limiter.Limit(ctx, "DescribeAddresses")
+	sinceStart := spanstat.Start()
+	addresses, err := c.ec2Client.DescribeAddresses(ctx, describeAddressesInput)
+	c.metricsAPI.ObserveAPICall("DescribeAddresses", deriveStatus(err), sinceStart.Seconds())
+	if err != nil {
+		return "", err
+	}
+	log.Infof("Found %d EIPs corresponding to tags %v", len(addresses.Addresses), eipTags)
+
+	for _, address := range addresses.Addresses {
+		// Only pick unassociated EIPs
+		if address.AssociationId == nil {
+			associateAddressInput := &ec2.AssociateAddressInput{
+				AllocationId:       address.AllocationId,
+				AllowReassociation: aws.Bool(false),
+				InstanceId:         aws.String(instanceID),
+			}
+			c.limiter.Limit(ctx, "AssociateAddress")
+			sinceStart = spanstat.Start()
+			association, err := c.ec2Client.AssociateAddress(ctx, associateAddressInput)
+			c.metricsAPI.ObserveAPICall("AssociateAddress", deriveStatus(err), sinceStart.Seconds())
+			if err != nil {
+				return "", err
+			}
+			log.Infof("Associated EIP %s with instance %s (association ID: %s)", *address.PublicIp, instanceID, *association.AssociationId)
+			return *address.PublicIp, nil
+		}
+	}
+
+	return "", fmt.Errorf("no unassociated EIPs found for tags %v", eipTags)
 }
 
 func createAWSTagSlice(tags map[string]string) []ec2_types.Tag {

--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -42,6 +42,7 @@ const (
 	AssignPrivateIpAddresses
 	UnassignPrivateIpAddresses
 	TagENI
+	AssociateEIP
 	MaxOperation
 )
 
@@ -569,6 +570,34 @@ func (e *API) GetInstance(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap,
 	}
 
 	return &instance, nil
+}
+
+func (e *API) AssociateEIP(ctx context.Context, instanceID string, eipTags ipamTypes.Tags) (string, error) {
+	e.rateLimit()
+	e.delaySim.Delay(AssociateEIP)
+
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	if err, ok := e.errors[AssociateEIP]; ok {
+		return "", err
+	}
+
+	ipAddr := "192.0.2.254"
+
+	// Assign the EIP to the ENI 0 of the instance
+	for iid, enis := range e.enis {
+		if iid == instanceID {
+			for _, eni := range enis {
+				if eni.Number == 0 {
+					eni.PublicIP = ipAddr
+					return ipAddr, nil
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("unable to find ENI 0 for instance %s", instanceID)
 }
 
 func (e *API) GetInstances(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap, subnets ipamTypes.SubnetMap) (*ipamTypes.InstanceMap, error) {

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -39,6 +39,7 @@ type EC2API interface {
 	AssignENIPrefixes(ctx context.Context, eniID string, prefixes int32) error
 	UnassignENIPrefixes(ctx context.Context, eniID string, prefixes []string) error
 	GetInstanceTypes(context.Context) ([]ec2_types.InstanceTypeInfo, error)
+	AssociateEIP(ctx context.Context, instanceID string, eipTags ipamTypes.Tags) (string, error)
 }
 
 // InstancesManager maintains the list of instances. It must be kept up to date

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -293,6 +293,10 @@ func (n *Node) AllocateIPs(ctx context.Context, a *ipam.AllocationAction) error 
 	return n.manager.api.AssignPrivateIpAddresses(ctx, a.InterfaceID, int32(a.IPv4.AvailableForAllocation))
 }
 
+func (n *Node) AllocateStaticIP(ctx context.Context, staticIPTags ipamTypes.Tags) (string, error) {
+	return n.manager.api.AssociateEIP(ctx, n.node.InstanceID(), staticIPTags)
+}
+
 func (n *Node) getSecurityGroupIDs(ctx context.Context, eniSpec eniTypes.ENISpec) ([]string, error) {
 	// 1. check explicit security groups associations via checking Spec.ENI.SecurityGroups
 	// 2. check if Spec.ENI.SecurityGroupTags is passed and if so filter by those
@@ -595,6 +599,12 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Ent
 			for _, ip := range e.Addresses {
 				available[ip] = ipamTypes.AllocationIP{Resource: e.ID}
 			}
+
+			// If the primary ENI has a public IP, we store it
+			if e.Number == 0 && e.PublicIP != "" {
+				stats.AssignedStaticIP = e.PublicIP
+			}
+
 			return nil
 		})
 	enis := len(n.enis)

--- a/pkg/aws/eni/types/types.go
+++ b/pkg/aws/eni/types/types.go
@@ -206,6 +206,11 @@ type ENI struct {
 	//
 	// +optional
 	Tags map[string]string `json:"tags,omitempty"`
+
+	// PublicIP is the public IP associated with the ENI
+	//
+	// +optional
+	PublicIP string `json:"public-ip,omitempty"`
 }
 
 func (e *ENI) DeepCopyInterface() types.Interface {

--- a/pkg/aws/eni/types/zz_generated.deepequal.go
+++ b/pkg/aws/eni/types/zz_generated.deepequal.go
@@ -163,6 +163,10 @@ func (in *ENI) DeepEqual(other *ENI) bool {
 		}
 	}
 
+	if in.PublicIP != other.PublicIP {
+		return false
+	}
+
 	return true
 }
 

--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -130,6 +130,11 @@ func (n *Node) AllocateIPs(ctx context.Context, a *ipam.AllocationAction) error 
 	}
 }
 
+func (n *Node) AllocateStaticIP(ctx context.Context, staticIPTags ipamTypes.Tags) (string, error) {
+	// TODO, see https://github.com/cilium/cilium/issues/34094
+	return "", fmt.Errorf("not implemented")
+}
+
 // CreateInterface is called to create a new interface. This operation is
 // currently not supported on Azure.
 func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationAction, scopedLog *logrus.Entry) (int, string, error) {

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -77,6 +77,8 @@ type NodeOperations interface {
 	// to perform the actual allocation.
 	AllocateIPs(ctx context.Context, allocation *AllocationAction) error
 
+	AllocateStaticIP(ctx context.Context, staticIPTags ipamTypes.Tags) (string, error)
+
 	// PrepareIPRelease is called to calculate whether any IP excess needs
 	// to be resolved. It behaves identical to PrepareIPAllocation but
 	// indicates a need to release IPs.

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -129,6 +129,10 @@ func (n *nodeOperationsMock) AllocateIPs(ctx context.Context, allocation *Alloca
 	return nil
 }
 
+func (n *nodeOperationsMock) AllocateStaticIP(ctx context.Context, staticIPTags ipamTypes.Tags) (string, error) {
+	return "", nil
+}
+
 func (n *nodeOperationsMock) PrepareIPRelease(excessIPs int, scopedLog *logrus.Entry) *ReleaseAction {
 	n.mutex.RLock()
 	excessIPs = math.IntMin(excessIPs, len(n.allocatedIPs))

--- a/pkg/ipam/stats/stats.go
+++ b/pkg/ipam/stats/stats.go
@@ -26,4 +26,7 @@ type InterfaceStats struct {
 	// RemainingAvailableIPv6InterfaceCount is the number of interfaces currently available
 	// for IPv6 address allocation.
 	RemainingAvailableIPv6InterfaceCount int
+
+	// AssignedStaticIP is the static IP address assigned to the node (ex: public Elastic IP address in AWS)
+	AssignedStaticIP string
 }

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -178,6 +178,13 @@ type IPAMSpec struct {
 	//
 	// +kubebuilder:validation:Minimum=0
 	MaxAboveWatermark int `json:"max-above-watermark,omitempty"`
+
+	// StaticIPTags are used to determine the pool of IPs from which to
+	// attribute a static IP to the node. For example in AWS this is used to
+	// filter Elastic IP Addresses.
+	//
+	// +optional
+	StaticIPTags map[string]string `json:"static-ip-tags,omitempty"`
 }
 
 // IPReleaseStatus defines the valid states in IP release handshake
@@ -230,6 +237,11 @@ type IPAMStatus struct {
 	//
 	// +optional
 	ReleaseIPv6s map[string]IPReleaseStatus `json:"release-ipv6s,omitempty"`
+
+	// AssignedStaticIP is the static IP assigned to the node (ex: public Elastic IP address in AWS)
+	//
+	// +optional
+	AssignedStaticIP string `json:"assigned-static-ip,omitempty"`
 }
 
 // IPAMPoolRequest is a request from the agent to the operator, indicating how

--- a/pkg/ipam/types/zz_generated.deepcopy.go
+++ b/pkg/ipam/types/zz_generated.deepcopy.go
@@ -151,6 +151,13 @@ func (in *IPAMSpec) DeepCopyInto(out *IPAMSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.StaticIPTags != nil {
+		in, out := &in.StaticIPTags, &out.StaticIPTags
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/ipam/types/zz_generated.deepequal.go
+++ b/pkg/ipam/types/zz_generated.deepequal.go
@@ -211,6 +211,26 @@ func (in *IPAMSpec) DeepEqual(other *IPAMSpec) bool {
 	if in.MaxAboveWatermark != other.MaxAboveWatermark {
 		return false
 	}
+	if ((in.StaticIPTags != nil) && (other.StaticIPTags != nil)) || ((in.StaticIPTags == nil) != (other.StaticIPTags == nil)) {
+		in, other := &in.StaticIPTags, &other.StaticIPTags
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for key, inValue := range *in {
+				if otherValue, present := (*other)[key]; !present {
+					return false
+				} else {
+					if inValue != otherValue {
+						return false
+					}
+				}
+			}
+		}
+	}
 
 	return true
 }
@@ -287,6 +307,10 @@ func (in *IPAMStatus) DeepEqual(other *IPAMStatus) bool {
 				}
 			}
 		}
+	}
+
+	if in.AssignedStaticIP != other.AssignedStaticIP {
+		return false
 	}
 
 	return true

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -455,6 +455,14 @@ spec:
                       get involved.
                     minimum: 0
                     type: integer
+                  static-ip-tags:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      StaticIPTags are used to determine the pool of IPs from which to
+                      attribute a static IP to the node. For example in AWS this is used to
+                      filter Elastic IP Addresses.
+                    type: object
                 type: object
               nodeidentity:
                 description: NodeIdentity is the Cilium numeric identity allocated
@@ -661,6 +669,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        public-ip:
+                          description: PublicIP is the public IP associated with the
+                            ENI
+                          type: string
                         security-groups:
                           description: SecurityGroups are the security groups associated
                             with the ENI
@@ -711,6 +723,10 @@ spec:
               ipam:
                 description: IPAM is the IPAM status of the node.
                 properties:
+                  assigned-static-ip:
+                    description: 'AssignedStaticIP is the static IP assigned to the
+                      node (ex: public Elastic IP address in AWS)'
+                    type: string
                   ipv6-used:
                     additionalProperties:
                       description: |-

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -443,6 +443,10 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode, ln
 				nodeResource.Spec.IPAM.PreAllocate = c.IPAM.PreAllocate
 			}
 
+			if len(c.IPAM.StaticIPTags) > 0 {
+				nodeResource.Spec.IPAM.StaticIPTags = c.IPAM.StaticIPTags
+			}
+
 			if c.ENI.FirstInterfaceIndex != nil {
 				nodeResource.Spec.ENI.FirstInterfaceIndex = c.ENI.FirstInterfaceIndex
 			}
@@ -507,6 +511,9 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode, ln
 			}
 			if c.IPAM.PreAllocate != 0 {
 				nodeResource.Spec.IPAM.PreAllocate = c.IPAM.PreAllocate
+			}
+			if len(c.IPAM.StaticIPTags) > 0 {
+				nodeResource.Spec.IPAM.StaticIPTags = c.IPAM.StaticIPTags
 			}
 			if c.Azure.InterfaceName != "" {
 				nodeResource.Spec.Azure.InterfaceName = c.Azure.InterfaceName
@@ -573,6 +580,10 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode, ln
 
 			if c.IPAM.PreAllocate != 0 {
 				nodeResource.Spec.IPAM.PreAllocate = c.IPAM.PreAllocate
+			}
+
+			if len(c.IPAM.StaticIPTags) > 0 {
+				nodeResource.Spec.IPAM.StaticIPTags = c.IPAM.StaticIPTags
 			}
 		}
 	}


### PR DESCRIPTION
# Description
This PR is a proposal for supporting static IP allocation as described in https://github.com/cilium/cilium/issues/34094.
The proposed abstraction is Cloud Provider agnostic. This PR implements the code path for AWS which is fully functional. The code for other Cloud Providers can be implemented later separately.

In this version of the implementation, we assume that users manually manage pools of static IP addresses (in this particular example, pools of AWS Elastic IP addresses) and assign different tags to differentiate the pools.
The main idea of this proposal is to add a new field (`static-ip-tags`) to the `ipam` section of the CNI spec. This will allow users to indicate that they want a static IP with given tags to be assigned to the node.
Example:
```json
"ipam": {
  "static-ip-tags": {
    "pool": "pool-a",
    "kubernetes_cluster": "cluster-1"
  }
}
```
When the Operator sees that `static-ip-tags` is set on the `CiliumNode` object, it makes the Cloud Provider API calls to retrieve the IPs with the given tags and associates the first found IP with the instance. It then updates the status of the `CiliumNode` object.

# Testing
I added some unit tests but also tried out the PR in a real AWS environment.
At first I manually allocated an EIP with tags `"anton": "test"` and `"kubernetes_cluster": "<MY_CLUSTER_NAME>"` in our AWS account. 
I then provisioned a node with the following CNI spec:
<pre>
$ sudo cat /etc/cni/net.d/10-generic-veth.conflist
{
  "cniVersion": "0.3.1",
  "name": "cilium",
  "plugins": [
    {
      "name": "cilium",
      "type": "cilium-cni",
      "eni": {
        "delete-on-termination": true,
        "first-interface-index": 1,
        "use-primary-address": false,
        "pre-allocate": 1,
        "min-allocate": 3
      },
      "ipam": {
        "pre-allocate": 1,
        "min-allocate": 3,
        <b>"static-ip-tags": {
          "anton": "test",
          "kubernetes_cluster": "<MY_CLUSTER_NAME>"
        }</b>
      }
    }
  ]
} 
</pre>

I then confirmed that the IPAM settings were successfully passed on to the `CiliumNode` CRD object:
```
$ kubectl get ciliumnode $MY_NODE_NAME -o=jsonpath='{.spec.ipam}' | jq
{
  "min-allocate": 3,
  "pool": {
    "100.xxx.xxx.xxx": {
      "resource": "eni-xxx"
    },
    "100.xxx.xxx.xxx": {
      "resource": "eni-xxx"
    }
  },
  "pools": {},
  "pre-allocate": 1,
  "static-ip-tags": {
    "anton": "test",
    "kubernetes_cluster": "<MY_CLUSTER_NAME>"
  }
}
```

The Operator saw that IPAM field and associated the EIP I created. Logs:
```
Found 1 EIPs corresponding to tags map[anton:test kubernetes_cluster:<MY_CLUSTER_NAME>]

Associated EIP 18.213.xxx.xxx with Instance i-xxxxf7517 (association ID: eipassoc-xxx)
```

It also updated the CRD resource status with the right IP address:
```
$ k get ciliumnode $MY_NODE_NAME -o=jsonpath='{.status.ipam}' | jq
{
  "assigned-static-ip": "18.213.xxx.xxx",
  "operator-status": {},
  "used": [...]
}
```

The EIP is successfully associated with the EC2 instance as well:
![image](https://github.com/user-attachments/assets/576046e6-9b9e-4d42-aef4-d54dc69b6473)