### PR TITLE
envoy: support generic envoy secret for k8s->envoy secretsync

### DIFF
--- a/pkg/envoy/secretsync.go
+++ b/pkg/envoy/secretsync.go
@@ -35,6 +35,10 @@ const (
 	// easy rotation of keys by, for example, putting the new key first, and the previous key second.
 	// Additional keys are defined by using the Secret key 'tls.sessionticket.key.[1-9]'
 	tlsSessionTicketKeyAttribute = "tls.sessionticket.key"
+
+	// Key for a generic Envoy secret is fixed as 'generic' even though is not as "standard"
+	// as 'tls.crt' and 'tls.key' are via k8s tls secret type.
+	genericSecretAttribute = "generic"
 )
 
 // secretSyncer is responsible to sync K8s TLS Secrets in pre-defined namespaces
@@ -151,6 +155,17 @@ func k8sToEnvoySecret(secret *slim_corev1.Secret) *envoy_extensions_tls_v3.Secre
 		envoySecret.Type = &envoy_extensions_tls_v3.Secret_SessionTicketKeys{
 			SessionTicketKeys: &envoy_extensions_tls_v3.TlsSessionTicketKeys{
 				Keys: getTLSSessionTicketKeys(secret.Data),
+			},
+		}
+
+	case len(secret.Data[genericSecretAttribute]) > 0:
+		envoySecret.Type = &envoy_extensions_tls_v3.Secret_GenericSecret{
+			GenericSecret: &envoy_extensions_tls_v3.GenericSecret{
+				Secret: &envoy_config_core_v3.DataSource{
+					Specifier: &envoy_config_core_v3.DataSource_InlineBytes{
+						InlineBytes: secret.Data[genericSecretAttribute],
+					},
+				},
 			},
 		}
 	}

--- a/pkg/envoy/secretsync_test.go
+++ b/pkg/envoy/secretsync_test.go
@@ -218,6 +218,25 @@ func Test_k8sSecretToEnvoySecretTlsSessionKeys_SkipAdditionalKeyOnSizeIssue(t *t
 	require.Nil(t, envoySecret.GetValidationContext())
 }
 
+func Test_k8sSecretToEnvoySecretGeneric(t *testing.T) {
+	envoySecret := k8sToEnvoySecret(&slim_corev1.Secret{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "dummy-secret",
+			Namespace: "dummy-namespace",
+		},
+		Data: map[string]slim_corev1.Bytes{
+			"generic": []byte{1, 2, 3},
+		},
+		Type: slim_corev1.SecretTypeOpaque,
+	})
+
+	require.Equal(t, "dummy-namespace/dummy-secret", envoySecret.Name)
+	require.Equal(t, []byte{1, 2, 3}, envoySecret.GetGenericSecret().Secret.GetInlineBytes())
+	require.Nil(t, envoySecret.GetValidationContext())
+	require.Nil(t, envoySecret.GetTlsCertificate())
+	require.Nil(t, envoySecret.GetSessionTicketKeys())
+}
+
 func TestHandleSecretEvent(t *testing.T) {
 	tests := []struct {
 		name                 string


### PR DESCRIPTION
Currently, K8s -> Envoy secret sync does not support syncing generic secrets.

As this is desired in some cases with CEC, this commit adds this support. K8s secret are synced as Generic Envoy secret, if they are of type `Opaque` and have the generic secret in the data field with key `generic.secret`.

See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/secret.proto#envoy-v3-api-msg-extensions-transport-sockets-tls-v3-genericsecret