### PR TITLE
Chart: Introduce value to override target namespace

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2532,6 +2532,10 @@
      - Agent container name.
      - string
      - ``"cilium"``
+   * - :spelling:ignore:`namespaceOverride`
+     - namespaceOverride allows to override the destination namespace for Cilium resources. This property allows to use Cilium as part of an Umbrella Chart with different targets.
+     - string
+     - ``""``
    * - :spelling:ignore:`nat.mapStatsEntries`
      - Number of the top-k SNAT map connections to track in Cilium statedb.
      - int

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -542,6 +542,7 @@ myCA
 mysql
 nameError
 namespace
+namespaceOverride
 namespaced
 namespaces
 nat

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -683,6 +683,7 @@ contributors across the globe, there is almost always someone available to help.
 | monitor | object | `{"enabled":false}` | cilium-monitor sidecar. |
 | monitor.enabled | bool | `false` | Enable the cilium-monitor sidecar. |
 | name | string | `"cilium"` | Agent container name. |
+| namespaceOverride | string | `""` | namespaceOverride allows to override the destination namespace for Cilium resources. This property allows to use Cilium as part of an Umbrella Chart with different targets. |
 | nat.mapStatsEntries | int | `32` | Number of the top-k SNAT map connections to track in Cilium statedb. |
 | nat.mapStatsInterval | string | `"30s"` | Interval between how often SNAT map is counted for stats. |
 | nat46x64Gateway | object | `{"enabled":false}` | Configure standalone NAT46/NAT64 gateway |

--- a/install/kubernetes/cilium/files/spire/init.bash
+++ b/install/kubernetes/cilium/files/spire/init.bash
@@ -22,9 +22,9 @@ echo "Spire Server is up, initializing cilium spire entries..."
 AGENT_SPIFFE_ID="spiffe://{{ .Values.authentication.mutual.spire.trustDomain }}/ns/{{ .Values.authentication.mutual.spire.install.namespace }}/sa/spire-agent"
 AGENT_SELECTORS="-selector k8s_psat:agent_ns:{{ .Values.authentication.mutual.spire.install.namespace }} -selector k8s_psat:agent_sa:spire-agent"
 CILIUM_AGENT_SPIFFE_ID="spiffe://{{ .Values.authentication.mutual.spire.trustDomain }}/cilium-agent"
-CILIUM_AGENT_SELECTORS="-selector k8s:ns:{{ .Release.Namespace }} -selector k8s:sa:{{ .Values.serviceAccounts.cilium.name }}"
+CILIUM_AGENT_SELECTORS="-selector k8s:ns:{{ include "cilium.namespace" . }} -selector k8s:sa:{{ .Values.serviceAccounts.cilium.name }}"
 CILIUM_OPERATOR_SPIFFE_ID="spiffe://{{ .Values.authentication.mutual.spire.trustDomain }}/cilium-operator"
-CILIUM_OPERATOR_SELECTORS="-selector k8s:ns:{{ .Release.Namespace }} -selector k8s:sa:{{ .Values.serviceAccounts.operator.name }}"
+CILIUM_OPERATOR_SELECTORS="-selector k8s:ns:{{ include "cilium.namespace" . }} -selector k8s:sa:{{ .Values.serviceAccounts.operator.name }}"
 
 while pgrep spire-server > /dev/null;
 do

--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -6,6 +6,13 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Return the namespace to use for namespaced resources.
+*/}}
+{{- define "cilium.namespace" -}}
+{{- .Values.namespaceOverride | default .Release.Namespace -}}
+{{- end -}}
+
+{{/*
 Render full image name from given values, e.g:
 ```
 image:
@@ -65,7 +72,7 @@ and `commonCASecretName` variables.
     {{- if and $crt $key }}
       {{- $ca = buildCustomCert $crt $key -}}
     {{- else }}
-      {{- with lookup "v1" "Secret" .Release.Namespace $secretName }}
+      {{- with lookup "v1" "Secret" (include "cilium.namespace" .) $secretName }}
         {{- $crt := index .data "ca.crt" }}
         {{- $key := index .data "ca.key" }}
         {{- $ca = buildCustomCert $crt $key -}}

--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.cilium.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cilium
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -27,7 +27,7 @@ metadata:
     app.kubernetes.io/name: cilium-agent
     {{- if .Values.keepDeprecatedLabels }}
     kubernetes.io/cluster-service: "true"
-    {{- if and .Values.gke.enabled (eq .Release.Namespace "kube-system" ) }}
+    {{- if and .Values.gke.enabled (eq (include "cilium.namespace" .) "kube-system" ) }}
       {{- fail "Invalid configuration: Installing Cilium on GKE with 'kubernetes.io/cluster-service' labels on 'kube-system' namespace causes Cilium DaemonSet to be removed by GKE. Either install Cilium on a different Namespace or install with '--set keepDeprecatedLabels=false'" }}
     {{- end }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/dashboards-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/dashboards-configmap.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ $dashboardName | trunc 63 | trimSuffix "-" }}
-  namespace: {{ $.Values.dashboards.namespace | default $.Release.Namespace }}
+  namespace: {{ $.Values.dashboards.namespace | default (include "cilium.namespace" $) }}
   labels:
     k8s-app: cilium
     app.kubernetes.io/name: cilium-agent

--- a/install/kubernetes/cilium/templates/cilium-agent/role.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cilium-config-agent
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cilium-config-agent
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -18,7 +18,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccounts.cilium.name | quote }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "cilium.namespace" . }}
 {{- end}}
 
 {{- if and .Values.agent (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create .Values.ingressController.enabled .Values.ingressController.secretsNamespace.name}}
@@ -41,7 +41,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccounts.cilium.name | quote }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "cilium.namespace" . }}
 {{- end }}
 
 {{- if and .Values.agent (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create .Values.gatewayAPI.enabled .Values.gatewayAPI.secretsNamespace.name}}
@@ -64,7 +64,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.cilium.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 {{- end}}
 
 {{- if and .Values.agent (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create .Values.envoyConfig.enabled .Values.envoyConfig.secretsNamespace.name}}
@@ -87,7 +87,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.cilium.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 {{- end}}
 
 {{- if and .Values.agent (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create .Values.bgpControlPlane.enabled .Values.bgpControlPlane.secretsNamespace.name}}
@@ -106,5 +106,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.cilium.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 {{- end}}

--- a/install/kubernetes/cilium/templates/cilium-agent/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/service.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cilium-agent
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -35,7 +35,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cilium-agent
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ .Values.envoy.prometheus.port | quote }}

--- a/install/kubernetes/cilium/templates/cilium-agent/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.cilium.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- if or .Values.serviceAccounts.cilium.annotations .Values.annotations }}
   annotations:
     {{- with .Values.annotations }}

--- a/install/kubernetes/cilium/templates/cilium-agent/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/servicemonitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: cilium-agent
-  namespace: {{ .Values.prometheus.serviceMonitor.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace | default (include "cilium.namespace" .) }}
   labels:
     app.kubernetes.io/part-of: cilium
     {{- with .Values.prometheus.serviceMonitor.labels }}
@@ -25,7 +25,7 @@ spec:
       app.kubernetes.io/name: cilium-agent
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+    - {{ include "cilium.namespace" . }}
   endpoints:
   - port: metrics
     interval: {{ .Values.prometheus.serviceMonitor.interval | quote }}

--- a/install/kubernetes/cilium/templates/cilium-ca-bundle-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ca-bundle-configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: {{ .Values.tls.caBundle.useSecret | ternary "Secret" "ConfigMap" }}
 metadata:
   name: {{ .Values.tls.caBundle.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 {{ .Values.tls.caBundle.useSecret | ternary "stringData" "data" }}:
   {{ .Values.tls.caBundle.key }}: |
     {{- .Values.tls.caBundle.content | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-ca-secret.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ca-secret.yaml
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .commonCASecretName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 data:
   ca.crt: {{ .commonCA.Cert | b64enc }}
   ca.key: {{ .commonCA.Key  | b64enc }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -89,7 +89,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cilium-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 data:
 {{- if .Values.etcd.enabled }}
   # The kvstore configuration is used to enable use of a kvstore for state
@@ -1346,7 +1346,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ip-masq-agent
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 data:
   config: |-
 {{ toJson .Values.ipMasqAgent.config | indent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/configmap.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cilium-envoy-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.envoy.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cilium-envoy
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.envoy.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cilium-envoy
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- if or (not .Values.envoy.prometheus.serviceMonitor.enabled) .Values.envoy.annotations }}
   annotations:
   {{- if not .Values.envoy.prometheus.serviceMonitor.enabled }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/serviceaccount.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.envoy.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- if or .Values.serviceAccounts.envoy.annotations .Values.envoy.annotations }}
   annotations:
     {{- with .Values.envoy.annotations }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/servicemonitor.yaml
@@ -5,7 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: cilium-envoy
-  namespace: {{ .Values.envoy.prometheus.serviceMonitor.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.envoy.prometheus.serviceMonitor.namespace | default (include "cilium.namespace" .) }}
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-envoy
@@ -27,7 +27,7 @@ spec:
       k8s-app: cilium-envoy
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+    - {{ include "cilium.namespace" . }}
   endpoints:
   - port: envoy-metrics
     interval: {{ .Values.envoy.prometheus.serviceMonitor.interval | quote }}

--- a/install/kubernetes/cilium/templates/cilium-flowlog-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-flowlog-configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.hubble.export.dynamic.config.configMapName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 data:
   flowlogs.yaml: |
     flowLogs:

--- a/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.ingressController.service.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   labels:
     cilium.io/ingress: "true"
     {{- if .Values.ingressController.service.labels }}
@@ -45,7 +45,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: {{ .Values.ingressController.service.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- if .Values.ingressController.service.labels }}
   labels:
     {{- toYaml .Values.ingressController.service.labels | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -4,7 +4,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: cilium-node-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.nodeinit.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.nodeinit.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- if or .Values.serviceAccounts.nodeinit.annotations .Values.nodeinit.annotations }}
   annotations:
     {{- with .Values.nodeinit.annotations }}

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.operator.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/dashboards-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/dashboards-configmap.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ $dashboardName | trunc 63 | trimSuffix "-" }}
-  namespace: {{ $.Values.operator.dashboards.namespace | default $.Release.Namespace }}
+  namespace: {{ $.Values.operator.dashboards.namespace | default (include "cilium.namespace" $) }}
   labels:
     k8s-app: cilium
     app.kubernetes.io/name: cilium-operator

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cilium-operator
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.operator.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-operator/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: cilium-operator
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.operator.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-operator/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/rolebinding.yaml
@@ -18,7 +18,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccounts.operator.name | quote }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "cilium.namespace" . }}
 {{- end }}
 
 {{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create .Values.gatewayAPI.enabled .Values.gatewayAPI.secretsNamespace.sync .Values.gatewayAPI.secretsNamespace.name }}
@@ -41,5 +41,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.operator.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/secret.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cilium-azure
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.operator.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-operator/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: cilium-operator
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.operator.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-operator/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/serviceaccount.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.operator.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- if or .Values.serviceAccounts.operator.annotations .Values.operator.annotations }}
   annotations:
     {{- with .Values.operator.annotations }}

--- a/install/kubernetes/cilium/templates/cilium-operator/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: cilium-operator
-  namespace: {{ .Values.operator.prometheus.serviceMonitor.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.operator.prometheus.serviceMonitor.namespace | default (include "cilium.namespace" .) }}
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-operator
@@ -26,7 +26,7 @@ spec:
       name: cilium-operator
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+    - {{ include "cilium.namespace" . }}
   endpoints:
   - port: metrics
     interval: {{ .Values.operator.prometheus.serviceMonitor.interval | quote }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.preflight.name | quote }} 
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cilium-pre-flight-check
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.preflight.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cilium-pre-flight-check
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.preflight.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: cilium-pre-flight-check
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.preflight.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.preflight.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- if or .Values.serviceAccounts.preflight.annotations .Values.preflight.annotations }}
   annotations:
     {{- with .Values.preflight.annotations }}

--- a/install/kubernetes/cilium/templates/cilium-resource-quota.yaml
+++ b/install/kubernetes/cilium/templates/cilium-resource-quota.yaml
@@ -1,10 +1,10 @@
-{{- if or .Values.resourceQuotas.enabled (and (ne .Release.Namespace "kube-system") .Values.gke.enabled) }}
+{{- if or .Values.resourceQuotas.enabled (and (ne (include "cilium.namespace" .) "kube-system") .Values.gke.enabled) }}
 {{- if .Values.agent }}
 apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: cilium-resource-quota
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 spec:
   hard:
     pods: {{ .Values.resourceQuotas.cilium.hard.pods | quote }}
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: cilium-operator-resource-quota
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 spec:
   hard:
     pods: {{ .Values.resourceQuotas.operator.hard.pods | quote }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -6,7 +6,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: clustermesh-apiserver
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/metrics-service.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: clustermesh-apiserver-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: clustermesh-apiserver
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: clustermesh-apiserver
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   labels:
     k8s-app: clustermesh-apiserver
     app.kubernetes.io/part-of: cilium

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- if or .Values.serviceAccounts.clustermeshApiserver.annotations .Values.clustermesh.annotations }}
   annotations:
     {{- with .Values.clustermesh.annotations }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
@@ -8,7 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: clustermesh-apiserver
-  namespace: {{ .Values.clustermesh.apiserver.metrics.serviceMonitor.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.clustermesh.apiserver.metrics.serviceMonitor.namespace | default (include "cilium.namespace" .) }}
   labels:
     app.kubernetes.io/part-of: cilium
     {{- with .Values.clustermesh.apiserver.metrics.serviceMonitor.labels }}
@@ -30,7 +30,7 @@ spec:
       app.kubernetes.io/component: metrics
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+    - {{ include "cilium.namespace" . }}
   endpoints:
   {{- if .Values.clustermesh.apiserver.metrics.enabled }}
   - port: apiserv-metrics

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: clustermesh-apiserver-admin-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/client-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/client-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: clustermesh-apiserver-client-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/local-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/local-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: clustermesh-apiserver-local-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/remote-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: clustermesh-apiserver-remote-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: clustermesh-apiserver-server-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -17,7 +17,7 @@ spec:
   dnsNames:
   - clustermesh-apiserver.cilium.io
   - "*.mesh.cilium.io"
-  - "clustermesh-apiserver.{{ .Release.Namespace }}.svc"
+  - "clustermesh-apiserver.{{ include "cilium.namespace" . }}.svc"
   {{- range $dns := .Values.clustermesh.apiserver.tls.server.extraDnsNames }}
   - {{ $dns | quote }}
   {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
@@ -21,7 +21,7 @@ spec:
             {{- end }}
             - "--ca-generate"
             - "--ca-reuse-secret"
-            - "--ca-secret-namespace={{ .Release.Namespace }}"
+            - "--ca-secret-namespace={{ include "cilium.namespace" . }}"
             - "--ca-secret-name=cilium-ca"
             - "--ca-common-name=Cilium CA"
           env:
@@ -29,12 +29,12 @@ spec:
               value: |
                 certs:
                 - name: clustermesh-apiserver-server-cert
-                  namespace: {{ .Release.Namespace }}
+                  namespace: {{ include "cilium.namespace" . }}
                   commonName: "clustermesh-apiserver.cilium.io"
                   hosts:
                   - "clustermesh-apiserver.cilium.io"
                   - "*.mesh.cilium.io"
-                  - "clustermesh-apiserver.{{ .Release.Namespace }}.svc"
+                  - "clustermesh-apiserver.{{ include "cilium.namespace" . }}.svc"
                   {{- range $dns := .Values.clustermesh.apiserver.tls.server.extraDnsNames }}
                   - {{ $dns | quote }}
                   {{- end }}
@@ -49,7 +49,7 @@ spec:
                   - server auth
                   validity: {{ $certValidityStr }}
                 - name: clustermesh-apiserver-admin-cert
-                  namespace: {{ .Release.Namespace }}
+                  namespace: {{ include "cilium.namespace" . }}
                   commonName: {{ include "clustermesh-apiserver-generate-certs.admin-common-name" . | quote }}
                   usage:
                   - signing
@@ -58,7 +58,7 @@ spec:
                   validity: {{ $certValidityStr }}
                 {{- if .Values.clustermesh.useAPIServer }}
                 - name: clustermesh-apiserver-remote-cert
-                  namespace: {{ .Release.Namespace }}
+                  namespace: {{ include "cilium.namespace" . }}
                   commonName: {{ include "clustermesh-apiserver-generate-certs.remote-common-name" . | quote }}
                   usage:
                   - signing
@@ -68,7 +68,7 @@ spec:
                 {{- end }}
                 {{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled }}
                 - name: clustermesh-apiserver-local-cert
-                  namespace: {{ .Release.Namespace }}
+                  namespace: {{ include "cilium.namespace" . }}
                   commonName: {{ include "clustermesh-apiserver-generate-certs.local-common-name" . | quote }}
                   usage:
                   - signing
@@ -78,7 +78,7 @@ spec:
                 {{- end }}
                 {{- if .Values.externalWorkloads.enabled }}
                 - name: clustermesh-apiserver-client-cert
-                  namespace: {{ .Release.Namespace }}
+                  namespace: {{ include "cilium.namespace" . }}
                   commonName: "externalworkload"
                   usage:
                   - signing

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/cronjob.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/cronjob.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: clustermesh-apiserver-generate-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/job.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/job.yaml
@@ -4,7 +4,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: clustermesh-apiserver-generate-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   labels:
     k8s-app: clustermesh-apiserver-generate-certs
     app.kubernetes.io/part-of: cilium

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/role.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: clustermesh-apiserver-generate-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: clustermesh-apiserver-generate-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -17,5 +17,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- if or .Values.serviceAccounts.clustermeshcertgen.annotations .Values.clustermesh.annotations }}
   annotations:
     {{- with .Values.serviceAccounts.clustermeshcertgen.annotations }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/admin-secret.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-admin-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/client-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/client-secret.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-client-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/local-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/local-secret.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-local-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/remote-secret.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-remote-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
@@ -2,14 +2,14 @@
 {{- $_ := include "cilium.ca.setup" . -}}
 {{- $cn := "clustermesh-apiserver.cilium.io" }}
 {{- $ip := concat (list "127.0.0.1" "::1") .Values.clustermesh.apiserver.tls.server.extraIpAddresses }}
-{{- $dns := concat (list $cn "*.mesh.cilium.io" (printf "clustermesh-apiserver.%s.svc" .Release.Namespace)) .Values.clustermesh.apiserver.tls.server.extraDnsNames }}
+{{- $dns := concat (list $cn "*.mesh.cilium.io" (printf "clustermesh-apiserver.%s.svc" (include "cilium.namespace" .))) .Values.clustermesh.apiserver.tls.server.extraDnsNames }}
 {{- $cert := genSignedCert $cn $ip $dns (.Values.clustermesh.apiserver.tls.auto.certValidityDuration | int) .commonCA -}}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-server-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/admin-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-admin-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/client-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/client-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-client-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/remote-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-remote-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/server-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: clustermesh-apiserver-server-cert
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: clustermesh-remote-users
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
@@ -4,14 +4,14 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cilium-clustermesh
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
   {{- $kvstoremesh := and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled }}
-  {{- $override := ternary (printf "https://clustermesh-apiserver.%s.svc:2379" .Release.Namespace) "" $kvstoremesh }}
+  {{- $override := ternary (printf "https://clustermesh-apiserver.%s.svc:2379" (include "cilium.namespace" .)) "" $kvstoremesh }}
   {{- range .Values.clustermesh.config.clusters }}
   {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain $override) | b64enc }}
   {{- /* The parenthesis around .tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}

--- a/install/kubernetes/cilium/templates/clustermesh-config/kvstoremesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/kvstoremesh-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cilium-kvstoremesh
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: hubble-relay-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.relay.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -16,7 +16,7 @@ metadata:
 data:
   config.yaml: |
     cluster-name: {{ .Values.cluster.name }}
-    peer-service: "hubble-peer.{{ .Release.Namespace }}.svc.{{ .Values.hubble.peerService.clusterDomain }}:{{ $peerSvcPort }}"
+    peer-service: "hubble-peer.{{ include "cilium.namespace" . }}.svc.{{ .Values.hubble.peerService.clusterDomain }}:{{ $peerSvcPort }}"
     listen-address: {{ include "hubble-relay.config.listenAddress" . }}
     gops: {{ .Values.hubble.relay.gops.enabled }}
     gops-port: {{ .Values.hubble.relay.gops.port | quote }}

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hubble-relay
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.relay.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble-relay/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/metrics-service.yaml
@@ -4,7 +4,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: hubble-relay-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.relay.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble-relay/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: hubble-relay
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.relay.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble-relay/service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: hubble-relay
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   annotations:
     {{- with .Values.hubble.relay.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble-relay/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.relay.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- if or .Values.serviceAccounts.relay.annotations .Values.hubble.relay.annotations }}
   annotations:
     {{- with .Values.hubble.relay.annotations }}

--- a/install/kubernetes/cilium/templates/hubble-relay/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: hubble-relay
-  namespace: {{ .Values.hubble.relay.prometheus.serviceMonitor.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.hubble.relay.prometheus.serviceMonitor.namespace | default (include "cilium.namespace" .) }}
   labels:
     {{- with .Values.hubble.relay.prometheus.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
@@ -23,7 +23,7 @@ spec:
       k8s-app: hubble-relay
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+    - {{ include "cilium.namespace" . }}
   endpoints:
   - port: metrics
     interval: {{ .Values.hubble.relay.prometheus.serviceMonitor.interval | quote }}

--- a/install/kubernetes/cilium/templates/hubble-ui/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/clusterrolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.ui.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: hubble-ui-nginx
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.ui.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: hubble-ui
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.ui.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble-ui/ingress.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/ingress.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: hubble-ui
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   labels:
     k8s-app: hubble-ui
     app.kubernetes.io/name: hubble-ui

--- a/install/kubernetes/cilium/templates/hubble-ui/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: hubble-ui
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.ui.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble-ui/service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: hubble-ui
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- if or .Values.hubble.ui.service.annotations  .Values.hubble.ui.annotations }}
   annotations:
     {{- with .Values.hubble.ui.annotations }}

--- a/install/kubernetes/cilium/templates/hubble-ui/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.ui.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- if or .Values.serviceAccounts.ui.annotations .Values.hubble.ui.annotations }}
   annotations:
     {{- with .Values.hubble.ui.annotations }}

--- a/install/kubernetes/cilium/templates/hubble/dashboards-configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble/dashboards-configmap.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ $dashboardName | trunc 63 | trimSuffix "-" }}
-  namespace: {{ $.Values.hubble.metrics.dashboards.namespace | default $.Release.Namespace }}
+  namespace: {{ $.Values.hubble.metrics.dashboards.namespace | default (include "cilium.namespace" $) }}
   labels:
     k8s-app: hubble
     app.kubernetes.io/name: hubble

--- a/install/kubernetes/cilium/templates/hubble/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/metrics-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hubble-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   labels:
     k8s-app: hubble
     app.kubernetes.io/name: hubble

--- a/install/kubernetes/cilium/templates/hubble/peer-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/peer-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hubble-peer
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/hubble/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: hubble
-  namespace: {{ .Values.prometheus.serviceMonitor.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace | default (include "cilium.namespace" .) }}
   labels:
     app.kubernetes.io/part-of: cilium
     {{- with .Values.hubble.metrics.serviceMonitor.labels }}
@@ -24,7 +24,7 @@ spec:
       k8s-app: hubble
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+    - {{ include "cilium.namespace" . }}
   endpoints:
   - port: hubble-metrics
     interval: {{ .Values.hubble.metrics.serviceMonitor.interval | quote }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/metrics-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/metrics-server-secret.yaml
@@ -5,7 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: hubble-metrics-server-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: hubble-relay-client-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: hubble-relay-server-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
@@ -5,7 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: hubble-server-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
@@ -4,7 +4,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: hubble-ui-client-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
@@ -32,7 +32,7 @@ spec:
             {{- end }}
             - "--ca-generate"
             - "--ca-reuse-secret"
-            - "--ca-secret-namespace={{ .Release.Namespace }}"
+            - "--ca-secret-namespace={{ include "cilium.namespace" . }}"
             - "--ca-secret-name=cilium-ca"
             - "--ca-common-name=Cilium CA"
           env:
@@ -40,7 +40,7 @@ spec:
               value: |
                 certs:
                 - name: hubble-server-certs
-                  namespace: {{ .Release.Namespace }}
+                  namespace: {{ include "cilium.namespace" . }}
                   commonName: {{ list "*" (.Values.cluster.name | replace "." "-") "hubble-grpc.cilium.io" | join "." | quote }}
                   hosts:
                   - {{ list "*" (.Values.cluster.name | replace "." "-") "hubble-grpc.cilium.io" | join "." | quote }}
@@ -57,7 +57,7 @@ spec:
                   validity: {{ $certValidityStr }}
                 {{- if .Values.hubble.relay.enabled }}
                 - name: hubble-relay-client-certs
-                  namespace: {{ .Release.Namespace }}
+                  namespace: {{ include "cilium.namespace" . }}
                   commonName: "*.hubble-relay.cilium.io"
                   hosts:
                   - "*.hubble-relay.cilium.io"
@@ -69,7 +69,7 @@ spec:
                 {{- end }}
                 {{- if and .Values.hubble.relay.enabled .Values.hubble.relay.tls.server.enabled }}
                 - name: hubble-relay-server-certs
-                  namespace: {{ .Release.Namespace }}
+                  namespace: {{ include "cilium.namespace" . }}
                   commonName: "*.hubble-relay.cilium.io"
                   hosts:
                   - "*.hubble-relay.cilium.io"
@@ -87,7 +87,7 @@ spec:
                 {{- end }}
                 {{- if and .Values.hubble.metrics.enabled .Values.hubble.metrics.tls.enabled }}
                 - name: hubble-metrics-server-certs
-                  namespace: {{ .Release.Namespace }}
+                  namespace: {{ include "cilium.namespace" . }}
                   commonName: {{ list (.Values.cluster.name | replace "." "-") "hubble-metrics.cilium.io" | join "." }} | quote }}
                   hosts:
                   - {{ list (.Values.cluster.name | replace "." "-") "hubble-metrics.cilium.io" | join "." }} | quote }}
@@ -105,7 +105,7 @@ spec:
                 {{- end }}
                 {{- if and .Values.hubble.ui.enabled .Values.hubble.relay.enabled .Values.hubble.relay.tls.server.enabled }}
                 - name: hubble-ui-client-certs
-                  namespace: {{ .Release.Namespace }}
+                  namespace: {{ include "cilium.namespace" . }}
                   commonName: "*.hubble-ui.cilium.io"
                   hosts:
                   - "*.hubble-ui.cilium.io"

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/cronjob.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/cronjob.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hubble-generate-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   labels:
     k8s-app: hubble-generate-certs
     app.kubernetes.io/name: hubble-generate-certs

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/job.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/job.yaml
@@ -4,7 +4,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: hubble-generate-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   labels:
     k8s-app: hubble-generate-certs
     app.kubernetes.io/name: hubble-generate-certs

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/role.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: hubble-generate-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: hubble-generate-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -17,5 +17,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- if or .Values.serviceAccounts.hubblecertgen.annotations .Values.hubble.annotations }}
   annotations:
     {{- with .Values.hubble.annotations }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/metrics-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/metrics-server-secret.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-metrics-server-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/relay-client-secret.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-relay-client-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/relay-server-secret.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-relay-server-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/server-secret.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-server-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/ui-client-certs.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-ui-client-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/metrics-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/metrics-server-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-metrics-server-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/relay-client-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-relay-client-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/relay-server-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-relay-server-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/server-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-server-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/ui-client-certs.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: hubble-ui-client-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -3914,6 +3914,12 @@
     "name": {
       "type": "string"
     },
+    "namespaceOverride": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "nat": {
       "properties": {
         "mapStatsEntries": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -5,6 +5,12 @@
 # @schema
 # type: [null, string]
 # @schema
+# -- namespaceOverride allows to override the destination namespace for Cilium resources.
+# This property allows to use Cilium as part of an Umbrella Chart with different targets.
+namespaceOverride: ""
+# @schema
+# type: [null, string]
+# @schema
 # -- upgradeCompatibility helps users upgrading to ensure that the configMap for
 # Cilium will not change critical values to ensure continued operation
 # This flag is not required for new installations.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2,6 +2,13 @@
 # @schema
 # type: [null, string]
 # @schema
+# -- namespaceOverride allows to override the destination namespace for Cilium resources.
+# This property allows to use Cilium as part of an Umbrella Chart with different targets.
+namespaceOverride: ""
+
+# @schema
+# type: [null, string]
+# @schema
 # -- upgradeCompatibility helps users upgrading to ensure that the configMap for
 # Cilium will not change critical values to ensure continued operation
 # This flag is not required for new installations.


### PR DESCRIPTION
The previous version solely relied on the `--namespace` parameter of Helm, making it difficult to use it alongside other dependencies in an Umbrella Chart.

The new, optional `namespaceOverride` value parameter, if set, takes precedence over the Release namespace for all contained resources.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes #20511

```release-note
Added Helm Chart value for overriding target namespace.
```
