### PR TITLE
cilium-dbg: Show deleted objects when watching StateDB tables

### DIFF
--- a/Documentation/cmdref/cilium-dbg_statedb_bandwidth-edts.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_bandwidth-edts.md
@@ -11,9 +11,9 @@ cilium-dbg statedb bandwidth-edts [flags]
 ### Options
 
 ```
-  -h, --help             help for bandwidth-edts
-  -o, --output string    Output format, one of: table, json or yaml (default "table")
-  -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
+  -h, --help            help for bandwidth-edts
+  -o, --output string   Output format, one of: table, json or yaml (default "table")
+  -w, --watch           Watch for changes
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_statedb_bandwidth-qdiscs.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_bandwidth-qdiscs.md
@@ -11,9 +11,9 @@ cilium-dbg statedb bandwidth-qdiscs [flags]
 ### Options
 
 ```
-  -h, --help             help for bandwidth-qdiscs
-  -o, --output string    Output format, one of: table, json or yaml (default "table")
-  -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
+  -h, --help            help for bandwidth-qdiscs
+  -o, --output string   Output format, one of: table, json or yaml (default "table")
+  -w, --watch           Watch for changes
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_statedb_devices.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_devices.md
@@ -11,9 +11,9 @@ cilium-dbg statedb devices [flags]
 ### Options
 
 ```
-  -h, --help             help for devices
-  -o, --output string    Output format, one of: table, json or yaml (default "table")
-  -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
+  -h, --help            help for devices
+  -o, --output string   Output format, one of: table, json or yaml (default "table")
+  -w, --watch           Watch for changes
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_statedb_experimental_backends.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_experimental_backends.md
@@ -11,9 +11,9 @@ cilium-dbg statedb experimental backends [flags]
 ### Options
 
 ```
-  -h, --help             help for backends
-  -o, --output string    Output format, one of: table, json or yaml (default "table")
-  -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
+  -h, --help            help for backends
+  -o, --output string   Output format, one of: table, json or yaml (default "table")
+  -w, --watch           Watch for changes
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_statedb_experimental_cilium-configs.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_experimental_cilium-configs.md
@@ -11,9 +11,9 @@ cilium-dbg statedb experimental cilium-configs [flags]
 ### Options
 
 ```
-  -h, --help             help for cilium-configs
-  -o, --output string    Output format, one of: table, json or yaml (default "table")
-  -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
+  -h, --help            help for cilium-configs
+  -o, --output string   Output format, one of: table, json or yaml (default "table")
+  -w, --watch           Watch for changes
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_statedb_experimental_frontends.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_experimental_frontends.md
@@ -11,9 +11,9 @@ cilium-dbg statedb experimental frontends [flags]
 ### Options
 
 ```
-  -h, --help             help for frontends
-  -o, --output string    Output format, one of: table, json or yaml (default "table")
-  -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
+  -h, --help            help for frontends
+  -o, --output string   Output format, one of: table, json or yaml (default "table")
+  -w, --watch           Watch for changes
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_statedb_experimental_services.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_experimental_services.md
@@ -11,9 +11,9 @@ cilium-dbg statedb experimental services [flags]
 ### Options
 
 ```
-  -h, --help             help for services
-  -o, --output string    Output format, one of: table, json or yaml (default "table")
-  -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
+  -h, --help            help for services
+  -o, --output string   Output format, one of: table, json or yaml (default "table")
+  -w, --watch           Watch for changes
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_statedb_health.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_health.md
@@ -11,9 +11,9 @@ cilium-dbg statedb health [flags]
 ### Options
 
 ```
-  -h, --help             help for health
-  -o, --output string    Output format, one of: table, json or yaml (default "table")
-  -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
+  -h, --help            help for health
+  -o, --output string   Output format, one of: table, json or yaml (default "table")
+  -w, --watch           Watch for changes
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_statedb_ipsets.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_ipsets.md
@@ -11,9 +11,9 @@ cilium-dbg statedb ipsets [flags]
 ### Options
 
 ```
-  -h, --help             help for ipsets
-  -o, --output string    Output format, one of: table, json or yaml (default "table")
-  -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
+  -h, --help            help for ipsets
+  -o, --output string   Output format, one of: table, json or yaml (default "table")
+  -w, --watch           Watch for changes
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_statedb_l2-announce.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_l2-announce.md
@@ -11,9 +11,9 @@ cilium-dbg statedb l2-announce [flags]
 ### Options
 
 ```
-  -h, --help             help for l2-announce
-  -o, --output string    Output format, one of: table, json or yaml (default "table")
-  -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
+  -h, --help            help for l2-announce
+  -o, --output string   Output format, one of: table, json or yaml (default "table")
+  -w, --watch           Watch for changes
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_statedb_nat-stats.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_nat-stats.md
@@ -11,9 +11,9 @@ cilium-dbg statedb nat-stats [flags]
 ### Options
 
 ```
-  -h, --help             help for nat-stats
-  -o, --output string    Output format, one of: table, json or yaml (default "table")
-  -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
+  -h, --help            help for nat-stats
+  -o, --output string   Output format, one of: table, json or yaml (default "table")
+  -w, --watch           Watch for changes
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_statedb_node-addresses.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_node-addresses.md
@@ -11,9 +11,9 @@ cilium-dbg statedb node-addresses [flags]
 ### Options
 
 ```
-  -h, --help             help for node-addresses
-  -o, --output string    Output format, one of: table, json or yaml (default "table")
-  -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
+  -h, --help            help for node-addresses
+  -o, --output string   Output format, one of: table, json or yaml (default "table")
+  -w, --watch           Watch for changes
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_statedb_routes.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_routes.md
@@ -11,9 +11,9 @@ cilium-dbg statedb routes [flags]
 ### Options
 
 ```
-  -h, --help             help for routes
-  -o, --output string    Output format, one of: table, json or yaml (default "table")
-  -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
+  -h, --help            help for routes
+  -o, --output string   Output format, one of: table, json or yaml (default "table")
+  -w, --watch           Watch for changes
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_statedb_sysctl.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_sysctl.md
@@ -11,9 +11,9 @@ cilium-dbg statedb sysctl [flags]
 ### Options
 
 ```
-  -h, --help             help for sysctl
-  -o, --output string    Output format, one of: table, json or yaml (default "table")
-  -w, --watch duration   Watch for new changes with the given interval (e.g. --watch=100ms)
+  -h, --help            help for sysctl
+  -o, --output string   Output format, one of: table, json or yaml (default "table")
+  -w, --watch           Watch for changes
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
This switches the "cilium-dbg statedb" implementation to using the new /changes API in order to also show deleted objects when watching a table with one of the "cilium-dbg statedb" commands. A deleted object is shown using the ANSI strikethrough escapes. With the changes API we don't need to actively poll anymore, so the "--watch" flag no longer takes the poll interval as parameter.

Since I can't "paste" the striken out line, here's a screenshot:

![image](https://github.com/user-attachments/assets/c3071fc4-51c9-46e8-915c-da2cd1465d14)

What do you think about using the ANSI codes for this? This should work fine for pretty much any terminal and it looks nice,
and it only shows up with `--watch`, so it not being "copy-pasteable" is probably not that big of a deal.

Also currently I opted for not supporting `--watch` with `--output=json` etc. If we see use-case for streaming the table changes as JSON we could also consider making it supported and just marshaling the `Change[Obj]` struct. It'd be slightly confusing as the JSON structure would be different with `--watch` (e.g. `Change[Obj]` instead of `Obj`). WDYT?
