### PR TITLE
contrib: allow l7proxy in egressgw config

### DIFF
--- a/contrib/testing/kind-egressgw-values.yaml
+++ b/contrib/testing/kind-egressgw-values.yaml
@@ -1,6 +1,5 @@
 bpf:
   masquerade: true
 kubeProxyReplacement: "true"
-l7Proxy: false
 egressGateway:
   enabled: true


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/32828 resolved the incompatibility in Cilium v1.16.