### PR TITLE
fix cli encryption status pernode output to display all nodes

### DIFF
--- a/cilium-cli/encrypt/status.go
+++ b/cilium-cli/encrypt/status.go
@@ -223,7 +223,10 @@ func printPerNodeStatus(nodeMap map[string]models.EncryptionStatus, ikProps ipse
 					IPsecKeyRotationInProgress: int64(ikProps.expectedCount) != st.Ipsec.KeysInUse,
 				}
 			}
-			return printJSONStatus(ns)
+			if err := printJSONStatus(ns); err != nil {
+				return err
+			}
+			continue
 		}
 
 		builder := strings.Builder{}
@@ -244,8 +247,9 @@ func printPerNodeStatus(nodeMap map[string]models.EncryptionStatus, ikProps ipse
 				builder.WriteString(fmt.Sprintf("\t%s: %d\n", k, v))
 			}
 		}
-		_, err := fmt.Println(builder.String())
-		return err
+		if _, err := fmt.Println(builder.String()); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
The `--per-node-details` flags provided to the `cilium-cli encryption status` command should output the status for all the nodes in a cluster. However, at the moment it only displays the status of the first node, as the function `printPerNodeStatus` stops after the 1st iteration. With this commit, the function should iterate through all the nodes in the cluster, print their statuses, and exit, returning errors if present.

Example on a 3-node kind cluster before the fix:

```bash
-> ./cli encryption status --per-node-details
Node: cilium-testing-worker
Encryption: IPsec
IPsec keys in use: 8
IPsec highest Seq. Number: N/A
IPsec expected key count: 8
IPsec key rotation in progress: false
IPsec per-node key: true
IPsec errors: 0
```

After the fix:

```bash
-> ./cli encryption status --per-node-details
Node: cilium-testing-worker2
Encryption: IPsec
IPsec keys in use: 8
IPsec highest Seq. Number: N/A
IPsec expected key count: 8
IPsec key rotation in progress: false
IPsec per-node key: true
IPsec errors: 0

Node: cilium-testing-worker
Encryption: IPsec
IPsec keys in use: 8
IPsec highest Seq. Number: N/A
IPsec expected key count: 8
IPsec key rotation in progress: false
IPsec per-node key: true
IPsec errors: 0

Node: cilium-testing-control-plane
Encryption: IPsec
IPsec keys in use: 8
IPsec highest Seq. Number: N/A
IPsec expected key count: 8
IPsec key rotation in progress: false
IPsec per-node key: true
IPsec errors: 0
```
Replacing the old PR in https://github.com/cilium/cilium-cli/pull/2739.

```release-note
Fix error in Cilium-cli that caused the encryption status per-node command to retrieve only the status of the 1st node.
```
