### PR TITLE
ci-clustermesh-upgrade: Increment timeout between rollouts to 10min

### DIFF
--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -615,8 +615,8 @@ jobs:
           kubectl --context ${{ env.contextName2 }} rollout restart -n kube-system ds/cilium
 
           # Wait until all agents successfully restarted before scaling the replicas again
-          kubectl --context ${{ env.contextName1 }} rollout status -n kube-system ds/cilium --timeout=5m
-          kubectl --context ${{ env.contextName2 }} rollout status -n kube-system ds/cilium --timeout=5m
+          kubectl --context ${{ env.contextName1 }} rollout status -n kube-system ds/cilium --timeout=10m
+          kubectl --context ${{ env.contextName2 }} rollout status -n kube-system ds/cilium --timeout=10m
 
       - name: Scale the clustermesh-apiserver replicas back to 1
         if: ${{ !matrix.external-kvstore }}


### PR DESCRIPTION
Currently, the ClusterMesh upgrade test sets an explicit timeout of 5min to wait for the Cilium Agent DaemonSet to become ready between the rollouts.

In some cases, the Pods aren't ready after 5min. Therefore, this commit increases the timeout to 10min.
