### PR TITLE
AKS ci: don't run LTS versions

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -131,7 +131,8 @@ jobs:
           jq -c '.include[]' /tmp/matrix.json | while read i; do
             VERSION=$(echo $i | jq -r '.version')
             LOCATION=$(echo $i | jq -r '.location')
-            az aks get-versions --location $LOCATION > /tmp/output
+            # Don't use LTS versions for AKS, it requires premium tier
+            az aks get-versions --location $LOCATION --query "values[?contains(capabilities.supportPlan,'KubernetesOfficial')].version" > /tmp/output
             if grep -q -F $VERSION /tmp/output; then
               echo "Version $VERSION is valid for location $LOCATION"
             else


### PR DESCRIPTION
LTS version requires premium tier and special way of creating cluster,
let's skip it for now. Ref:
https://learn.microsoft.com/en-us/azure/aks/long-term-support#create-a-cluster-with-lts-enabled

```release-note
ci: don't run AKS tests on LTS versions
```