### PR TITLE
ci: remove 1.13 from scheduled runs

### DIFF
--- a/.github/workflows/ariane-scheduled.yaml
+++ b/.github/workflows/ariane-scheduled.yaml
@@ -23,14 +23,12 @@ jobs:
         include:
         # DON'T USE hourModulo=0 to avoid running ariane scheduled-workflows
         # at the same time as regular main scheduled workflows
-          - branch: '1.13'
-            hourModulo: 1
           - branch: '1.14'
-            hourModulo: 2
+            hourModulo: 1
           - branch: '1.15'
-            hourModulo: 3
+            hourModulo: 2
           - branch: '1.16'
-            hourModulo: 4
+            hourModulo: 3
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch


### PR DESCRIPTION
As 1.13 is EOL, let's stop testing it.
