### PR TITLE
Fix panic in ipsec/xfrm_collector.go

### DIFF
--- a/pkg/datapath/linux/ipsec/xfrm_collector.go
+++ b/pkg/datapath/linux/ipsec/xfrm_collector.go
@@ -55,8 +55,9 @@ type xfrmCollector struct {
 	nbXFRMPolsDesc   *prometheus.Desc
 }
 
-func NewXFRMCollector() prometheus.Collector {
+func NewXFRMCollector(log *slog.Logger) prometheus.Collector {
 	return &xfrmCollector{
+		log: log,
 		xfrmErrorDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(metrics.Namespace, subsystem, "xfrm_error"),
 			"Total number of xfrm errors",

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -149,7 +149,7 @@ func newNodeHandler(
 		nodeIDs:                idpool.NewIDPool(minNodeID, maxNodeID),
 		nodeIDsByIPs:           map[string]uint16{},
 		nodeIPsByIDs:           map[uint16]sets.Set[string]{},
-		ipsecMetricCollector:   ipsec.NewXFRMCollector(),
+		ipsecMetricCollector:   ipsec.NewXFRMCollector(log),
 		prefixClusterMutatorFn: func(node *nodeTypes.Node) []cmtypes.PrefixClusterOpts { return nil },
 		nodeNeighborQueue:      nbq,
 		ipsecUpdateNeeded:      map[nodeTypes.Identity]bool{},


### PR DESCRIPTION
Fixes: #34643

```release-note
Fix agent panic when IPsec is enabled but XFRM stats are not exposed by the kernel.
```
