### PR TITLE
fix: push PR changes out of pull request context

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -273,11 +273,12 @@ jobs:
 
       - name: Push changes into PR
         env:
-          REF: ${{ github.event.pull_request.head.ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository:  ${{ startsWith(github.head_ref, 'renovate/') && github.repository || github.event.pull_request.head.repo.full_name }}
         if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' || steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
         run: |
           git diff HEAD^
-          git push https://x-access-token:${{ steps.get_token.outputs.app_token }}@github.com/${{ github.event.pull_request.head.repo.full_name }}.git HEAD:"$REF"
+          git push https://x-access-token:${{ steps.get_token.outputs.app_token }}@github.com/${{ env.repository }}.git HEAD:${{ env.ref }}
 
   image-digests:
     name: Display Digests


### PR DESCRIPTION
Following #34372 renovate is now allowed to trigger the workflow under the workflow_call context. Unfortunately the repository name used in the step "Push changes into PR" is the one retrieved under a pull_request_target context. To fix this we extract the repository name into an environment variable and make it default to github.repository if the context is not one of a pull_request.

```release-note
Fix: push PR changes when renovate build images under the workflow_call context
```
