### PR TITLE
fix to forbid IPAM ENI with TUNNEL routing and segfault with also IPSec

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1530,6 +1530,10 @@ func initEnv(vp *viper.Viper) {
 		)
 	}
 
+	if option.Config.IPAM == ipamOption.IPAMENI && option.Config.TunnelingEnabled() {
+		log.Fatalf("Cannot specify IPAM mode %s in tunnel mode.", option.Config.IPAM)
+	}
+
 	if option.Config.IPAM == ipamOption.IPAMMultiPool {
 		if option.Config.TunnelingEnabled() {
 			log.Fatalf("Cannot specify IPAM mode %s in tunnel mode.", option.Config.IPAM)

--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -55,6 +55,9 @@ func (n *linuxNodeHandler) getLinkLocalIP(family int) (net.IP, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(addr) == 0 {
+		return nil, fmt.Errorf("error retrieving link local IP (family %d): no addresses found", family)
+	}
 	return addr[0].IPNet.IP, nil
 }
 


### PR DESCRIPTION
This PR includes two commits to fix the segfault caused by the combination IPAM ENI and TUNNEL routing with IPSEC.
IPAM ENI is not expected to work with TUNNEL routing, but only with NATIVE/DIRECT, at least from my understanding.

The final result is as follows:
1. fixed indexing of empty slice -> no more segfault
2. prevent agent startup and return a fatal if IPAM ENI and TUNNEL routing are both enabled.

Let me know in case I missed something :smiley: 

Fix: #15883

```release-note
Fix parameter check to forbid IPAM ENI with TUNNEL routing, and prevent agent segfault when also IPSec is enabled.
```