### PR TITLE
fix add spi=0 to ipSecKeysRemovalTime

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -1063,7 +1063,6 @@ func LoadIPSecKeys(log *slog.Logger, r io.Reader) (int, uint8, error) {
 	scanner.Split(bufio.ScanLines)
 	for scanner.Scan() {
 		var (
-			oldSpi     uint8
 			aeadKey    []byte
 			authKey    []byte
 			esn        bool
@@ -1146,12 +1145,10 @@ func LoadIPSecKeys(log *slog.Logger, r io.Reader) (int, uint8, error) {
 		ipSecKey.Spi = spi
 		ipSecKey.ESN = esn
 
-		if ipSecKeysGlobal[""] != nil {
-			oldSpi = ipSecKeysGlobal[""].Spi
+		if oldKey, ok := ipSecKeysGlobal[""]; ok {
+			ipSecKeysRemovalTime[oldKey.Spi] = time.Now()
 		}
 		ipSecKeysGlobal[""] = ipSecKey
-
-		ipSecKeysRemovalTime[oldSpi] = time.Now()
 		ipSecCurrentKeySPI = spi
 	}
 	return keyLen, spi, nil


### PR DESCRIPTION
This commit prevents the `LoadIPSecKeys` function to add to the `ipSecKeysRemovalTime` map the value SPI 0. To the best of my understanding, we don't allow to provide a key with spi=0, which will cause cilium to return an error with the proper "invalid spi value" message. At this point, the 1st time that an IPsec key is loaded, this function performs an unneeded update of the map with the key=0 and value=time.Now(), which will never be removed.