### PR TITLE
Cilium status JSON output: fix error encoding

### DIFF
--- a/cilium-cli/status/status.go
+++ b/cilium-cli/status/status.go
@@ -5,6 +5,7 @@ package status
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"text/tabwriter"
@@ -77,6 +78,29 @@ type ErrorCount struct {
 type ErrorCountMap map[string]*ErrorCount
 
 type ErrorCountMapMap map[string]ErrorCountMap
+
+// custom marshaling for ErrorCount
+func (e *ErrorCount) MarshalJSON() ([]byte, error) {
+	// create an alias to avoid recursion
+	type Alias ErrorCount
+	return json.Marshal(&struct {
+		Errors   []string
+		Warnings []string
+		*Alias
+	}{
+		Errors:   errorsToStrings(e.Errors),
+		Warnings: errorsToStrings(e.Warnings),
+		Alias:    (*Alias)(e),
+	})
+}
+
+func errorsToStrings(errs []error) []string {
+	strs := make([]string, len(errs))
+	for i, err := range errs {
+		strs[i] = err.Error()
+	}
+	return strs
+}
 
 // Status is the overall status of Cilium
 type Status struct {

--- a/cilium-cli/status/status_test.go
+++ b/cilium-cli/status/status_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package status
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestErrorCountMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *ErrorCount
+		expected string
+	}{
+		{
+			name: "No errors or warnings",
+			input: &ErrorCount{
+				Errors:   nil,
+				Warnings: nil,
+				Disabled: false,
+			},
+			expected: `{
+ "Errors": [],
+ "Warnings": [],
+ "Disabled": false
+}`,
+		},
+		{
+			name: "With errors and warnings",
+			input: &ErrorCount{
+				Errors:   []error{fmt.Errorf("error 1"), fmt.Errorf("error 2")},
+				Warnings: []error{fmt.Errorf("warning 1")},
+				Disabled: false,
+			},
+			expected: `{
+ "Errors": [
+  "error 1",
+  "error 2"
+ ],
+ "Warnings": [
+  "warning 1"
+ ],
+ "Disabled": false
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := json.MarshalIndent(tt.input, "", " ")
+			if err != nil {
+				t.Fatalf("unexpected error during marshaling: %v", err)
+			}
+
+			if string(actual) != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, string(actual))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

Currently, the JSON output from `cilium status -o json` does not actually marshal the errors correctly.
eg. From summary -
```
Errors:                cilium             cilium          2 pods of DaemonSet cilium are not ready
                       cilium             cilium          daemonset cilium is rolling out - 2 out of 4 pods updated
Warnings:              cilium             cilium-c94lk    pod is pending
                       cilium             cilium-x9s8v    pod is pending
```

But the JSON output would be -
```
 "errors": {
  "cilium": {
   "cilium-c94lk": {
    "Errors": null,
    "Warnings": [
     {}
    ],
    "Disabled": false
   },
   "cilium-x9s8v": {
    "Errors": null,
    "Warnings": [
     {}
    ],
    "Disabled": false
   }
```

After this change, the errors and warnings will be correctly marshaled into JSON format.

```release-note
Correctly format `cilium status -o json` CLI output for errors and warnings
```
