### PR TITLE
[v1.14] hive: prevent goleak error due to race condition

### DIFF
--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -317,11 +317,9 @@ func (h *Hive) fatalOnTimeout(ctx context.Context) chan struct{} {
 
 		// Context was cancelled. Give 5 more seconds and then
 		// go fatal.
-		time.Sleep(5 * time.Second)
-
 		select {
 		case <-terminated:
-		default:
+		case <-time.After(5 * time.Second):
 			log.Fatal("Start or stop failed to finish on time, aborting forcefully.")
 		}
 	}()


### PR DESCRIPTION
[ upstream commit c49bf315e6fa917270c675eec005208fd9e1fdb4 ]

[ Backporter's notes: removed changes in pkg/hive/job/job.go as not belonging to change ]

Backport of one commit from https://github.com/cilium/cilium/pull/27395

The fatalOnTimeout function is responsible for ensuring that the hive startup and shutdown process completes within a predefined deadline, triggering a fatal error otherwise.

Yet, the current approach is characterized by a possible race condition, because the select statement picks one random case if multiple are ready at the same time. This is likely to happen during shutdown, as both the context and the terminated channel get closed practically together. If the context case is selected, then we wait for some additional time before either exiting (if terminated was closed in the meanwhile) or actually triggering the fatal error. This can possibly lead to flaky tests when goleak is used:

Goroutine 33747 in state sleep, with time.Sleep on top of the stack: goroutine 33747 [sleep]:
time.Sleep(0x12a05f200)
        /usr/lib/go-1.20/src/runtime/time.go:195 +0x135
github.com/cilium/cilium/pkg/hive.(*Hive).fatalOnTimeout.func1()
        /home/marco/Documents/isovalent/cilium/pkg/hive/hive.go:316 +0x7c
created by github.com/cilium/cilium/pkg/hive.(*Hive).fatalOnTimeout
        /home/marco/Documents/isovalent/cilium/pkg/hive/hive.go:305 +0xaa

Let's remove the sleep statement and use time.After in the subsequent select statement, so that the goroutine immediately exits as soon as the terminated channel is closed, whatever the case was initially picked.
