### PR TITLE
iptables: periodically run rules reconciliation to fix possible drifts

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mattn/go-shellwords"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	"k8s.io/utils/clock"
 
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/byteorder"
@@ -265,6 +266,7 @@ type Manager struct {
 }
 
 type reconcilerParams struct {
+	clock          clock.WithTicker
 	localNodeStore *node.LocalNodeStore
 	db             *statedb.DB
 	devices        statedb.Table[*tables.Device]
@@ -300,6 +302,7 @@ func newIptablesManager(p params) datapath.IptablesManager {
 		cfg:        p.Cfg,
 		sharedCfg:  p.SharedCfg,
 		reconcilerParams: reconcilerParams{
+			clock:          clock.RealClock{},
 			localNodeStore: p.LocalNodeStore,
 			db:             p.DB,
 			devices:        p.Devices,

--- a/pkg/datapath/iptables/reconciler.go
+++ b/pkg/datapath/iptables/reconciler.go
@@ -154,7 +154,7 @@ func reconciliationLoop(
 
 	// Use a ticker to limit how often the desired state is reconciled to avoid doing
 	// lots of operations when e.g. ipset updates.
-	ticker := time.NewTicker(minReconciliationInterval)
+	ticker := params.clock.NewTicker(minReconciliationInterval)
 	defer ticker.Stop()
 
 	// stateChanged is true when the desired state has changed or when reconciling it
@@ -283,7 +283,7 @@ stop:
 			} else {
 				close(req.updated)
 			}
-		case <-ticker.C:
+		case <-ticker.C():
 			if !stateChanged {
 				continue
 			}

--- a/pkg/datapath/iptables/reconciler_test.go
+++ b/pkg/datapath/iptables/reconciler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
 	"k8s.io/apimachinery/pkg/util/sets"
+	baseclocktest "k8s.io/utils/clock/testing"
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -33,6 +34,7 @@ func TestReconciliationLoop(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	var (
+		clock   = baseclocktest.NewFakeClock(time.Now())
 		db      *statedb.DB
 		devices statedb.RWTable[*tables.Device]
 		store   *node.LocalNodeStore
@@ -61,6 +63,7 @@ func TestReconciliationLoop(t *testing.T) {
 				db.RegisterTable(devices_)
 				health = health_.NewScope("iptables-reconciler-test")
 				params = &reconcilerParams{
+					clock:          clock,
 					localNodeStore: store_,
 					db:             db_,
 					devices:        devices_,
@@ -370,6 +373,11 @@ func TestReconciliationLoop(t *testing.T) {
 
 			// wait for reconciler to react to the update
 			assert.Eventuallyf(t, func() bool {
+				// Advance the clock, to trigger the ticker responsible to perform the update.
+				// This is called for every step to prevent the possibility of race conditions
+				// caused by the ticker channel being selected before the actual event.
+				clock.Step(200 * time.Millisecond)
+
 				mu.Lock()
 				defer mu.Unlock()
 				if err := assertIptablesState(state, tc.expected); err != nil {


### PR DESCRIPTION
07b336f42f25 ("iptables: Add rules runtime reconciliation") introduced a reconciler to manage the configuration of iptables rules and react to updates of external facing network devices and local node parameters.
    
As an additional measure to ensure eventual consistency of the iptables rules, let's also periodically rerun the full reconciliation process. This aims to fix possible inconsistencies caused by external modifications, such as due to startup race conditions between Cilium and kube-proxy. The reconciliation interval is currently configured to 30 minutes to limit the amount of additional churn, and the reconciliation gets automatically rescheduled if it had already been triggered in the same period.
