### PR TITLE
cilium-cli: set latest stable version based on stable.txt

### DIFF
--- a/cilium-cli/Makefile
+++ b/cilium-cli/Makefile
@@ -7,12 +7,16 @@ GO_TAGS ?=
 TARGET=cilium
 INSTALL = $(QUIET)install
 BINDIR ?= /usr/local/bin
-VERSION=$(shell git describe --tags --always)
+CLI_VERSION=$(shell git describe --tags --always)
+THIS_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+CILIUM_VERSION=$(shell cat $(THIS_DIR)/../stable.txt)
 STRIP_DEBUG=-w -s
 ifdef DEBUG
 	STRIP_DEBUG=
 endif
-GO_BUILD_LDFLAGS ?= $(STRIP_DEBUG) -X 'github.com/cilium/cilium/cilium-cli/defaults.CLIVersion=$(VERSION)'
+GO_BUILD_LDFLAGS ?= $(STRIP_DEBUG) \
+	-X 'github.com/cilium/cilium/cilium-cli/defaults.CLIVersion=$(CLI_VERSION)' \
+	-X 'github.com/cilium/cilium/cilium-cli/defaults.Version=$(CILIUM_VERSION)'
 
 TEST_TIMEOUT ?= 5s
 

--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -109,8 +109,9 @@ const (
 )
 
 var (
-	// renovate: datasource=github-releases depName=cilium/cilium
-	Version = "v1.16.1"
+	// Version is the default Cilium version to be installed. It is set during build based on
+	// the version in stable.txt.
+	Version string
 
 	// HelmRepository specifies Helm repository to download Cilium charts from.
 	HelmRepository = "https://helm.cilium.io"


### PR DESCRIPTION
Instead of letting renovate update the latest stable Cilium version, use the version defined in `stable.txt` during build.