### PR TITLE
pkg/ciliumidentity: Fix cell config

### DIFF
--- a/operator/pkg/ciliumidentity/cell.go
+++ b/operator/pkg/ciliumidentity/cell.go
@@ -17,14 +17,19 @@ var Cell = cell.Module(
 	"Cilium Identity Controller Operator",
 	cell.Invoke(registerController),
 	metrics.Metric(NewMetrics),
+	cell.Config(defaultConfig),
 )
 
 type config struct {
-	EnableOperatorManageCIDs bool
+	EnableOperatorManageCIDs bool `mapstructure:"operator-manages-identities"`
 }
 
 func (c config) Flags(flags *pflag.FlagSet) {
 	flags.Bool("operator-manages-identities", c.EnableOperatorManageCIDs, "Enables operator to manage Cilium Identities by running a Cilium Identity controller")
+}
+
+var defaultConfig = config{
+	EnableOperatorManageCIDs: false,
 }
 
 // SharedConfig contains the configuration that is shared between


### PR DESCRIPTION
ciliumidentity cell config struct has been introduced in a previous commit to enable the management of Cilium Identities from the operator. However, an instnace of the new config type has not been registered into the cell with cell.Config. This makes the cell not usable, since when it is added into the operator hive (to be done in a future commit), the operator is not able to startup correctly anymore:

```
level=error msg="Invoke failed" error="missing dependencies for function \"github.com/cilium/cilium/operator/pkg/ciliumidentity\".registerController\n\t/go/src/github.com/cilium/cilium/operator/pkg/ciliumidentity/controller.go:92:\nmissing type:\n\t- ciliumidentity.config (did you mean to Provide it?)" function="ciliumidentity.registerController (pkg/ciliumidentity/controller.go:92)"
time=2024-09-03T13:53:39Z level=info msg=Stopping
```

Moreover, since the config struct field `EnableOperatorManageCIDs` does not match exactly the related config option name
`operator-manages-identities`, a mapstructure tag should be added to the field, so that the hive can correctly load the option value into the struct.

Fixes: 78463ff993 ("pkg/ciliumidentity: Use cell flag for EnableOperatorManageCIDs")
