### PR TITLE
vendor: Bump StateDB to v0.2.6 and fix usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/cilium/linters v0.0.0-20240813102449-1dc28a34d923
 	github.com/cilium/lumberjack/v2 v2.3.0
 	github.com/cilium/proxy v0.0.0-20240723112637-48fa07fc1729
-	github.com/cilium/statedb v0.2.5
+	github.com/cilium/statedb v0.2.6
 	github.com/cilium/stream v0.0.0-20240816054136-71321e385273
 	github.com/cilium/workerpool v1.2.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7 h1:ocC6/1Gz6LJd0X
 github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7/go.mod h1:8nydvUTW+/9nVywCQ9bE/YGzb4EISALP4lKNpK3fFqo=
 github.com/cilium/proxy v0.0.0-20240723112637-48fa07fc1729 h1:/WvOQ7PL1JQpJM6oCFIDOr51QZvitwaFcZBhfN+n6Lo=
 github.com/cilium/proxy v0.0.0-20240723112637-48fa07fc1729/go.mod h1:fZVy2oOarwxD/PIWzpqQDpDXpqyuhmqQDRmvMzZ8PK0=
-github.com/cilium/statedb v0.2.5 h1:oDz6exRzkEJa8s8/Q49shufOb+/pNCap89rLNkLvrBo=
-github.com/cilium/statedb v0.2.5/go.mod h1:KPwsudjhZ90zoBguYMtssKpstR74jVKd/D+73PZy+sg=
+github.com/cilium/statedb v0.2.6 h1:O9kCwqf3JrPLkypLUYwbB1NzhXDz3CKr+2WqAUN0s6M=
+github.com/cilium/statedb v0.2.6/go.mod h1:KPwsudjhZ90zoBguYMtssKpstR74jVKd/D+73PZy+sg=
 github.com/cilium/stream v0.0.0-20240816054136-71321e385273 h1:lyP0p5AW9fnNWmUcQ/BKaOmBEyZ+VWY1mGT1CFWv2b0=
 github.com/cilium/stream v0.0.0-20240816054136-71321e385273/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.2.0 h1:Wc2iOPTvCgWKQXeq4L5tnx4QFEI+z5q1+bSpSS0cnAY=

--- a/pkg/k8s/statedb_test.go
+++ b/pkg/k8s/statedb_test.go
@@ -252,11 +252,8 @@ func testStateDBReflector(t *testing.T, p reflectorTestParams) {
 	}
 
 	// Wait until the table has been initialized.
-	require.Eventually(
-		t,
-		func() bool { return table.Initialized(db.ReadTxn()) },
-		time.Second,
-		5*time.Millisecond)
+	_, initWatch := table.Initialized(db.ReadTxn())
+	<-initWatch
 
 	// After initialization we should see the node that was created
 	// before starting.
@@ -381,11 +378,8 @@ func BenchmarkStateDBReflector(b *testing.B) {
 	}
 
 	// Wait until the table has been initialized.
-	require.Eventually(
-		b,
-		func() bool { return table.Initialized(db.ReadTxn()) },
-		time.Second,
-		5*time.Millisecond)
+	_, initWatch := table.Initialized(db.ReadTxn())
+	<-initWatch
 
 	const numObjects = 10000
 

--- a/pkg/loadbalancer/experimental/writer_test.go
+++ b/pkg/loadbalancer/experimental/writer_test.go
@@ -415,9 +415,9 @@ func TestWriter_Initializers(t *testing.T) {
 	txn := p.DB.ReadTxn()
 	firstTxn := txn
 	require.Equal(t, 1, p.FrontendTable.NumObjects(txn), "expected one object")
-	require.False(t, p.FrontendTable.Initialized(txn), "expected frontends to be uninitialized")
-	require.False(t, p.BackendTable.Initialized(txn), "expected backends to be uninitialized")
-	require.False(t, p.ServiceTable.Initialized(txn), "expected services to be uninitialized")
+	require.NotEmpty(t, p.FrontendTable.PendingInitializers(txn), "expected frontends to be uninitialized")
+	require.NotEmpty(t, p.BackendTable.PendingInitializers(txn), "expected backends to be uninitialized")
+	require.NotEmpty(t, p.ServiceTable.PendingInitializers(txn), "expected services to be uninitialized")
 
 	wtxn = p.Writer.WriteTxn()
 	complete1(wtxn)
@@ -425,22 +425,22 @@ func TestWriter_Initializers(t *testing.T) {
 
 	// Still uninitialized as one initializer remaining.
 	txn = p.DB.ReadTxn()
-	require.False(t, p.FrontendTable.Initialized(txn), "expected frontends to be uninitialized")
-	require.False(t, p.BackendTable.Initialized(txn), "expected backends to be uninitialized")
-	require.False(t, p.ServiceTable.Initialized(txn), "expected services to be uninitialized")
+	require.NotEmpty(t, p.FrontendTable.PendingInitializers(txn), "expected frontends to be uninitialized")
+	require.NotEmpty(t, p.BackendTable.PendingInitializers(txn), "expected backends to be uninitialized")
+	require.NotEmpty(t, p.ServiceTable.PendingInitializers(txn), "expected services to be uninitialized")
 
 	wtxn = p.Writer.WriteTxn()
 	complete2(wtxn)
 	wtxn.Commit()
 
 	txn = p.DB.ReadTxn()
-	require.True(t, p.FrontendTable.Initialized(txn), "expected frontends to be initialized")
-	require.True(t, p.BackendTable.Initialized(txn), "expected backends to be initialized")
-	require.True(t, p.ServiceTable.Initialized(txn), "expected services to be initialized")
+	require.Empty(t, p.FrontendTable.PendingInitializers(txn), "expected frontends to be initialized")
+	require.Empty(t, p.BackendTable.PendingInitializers(txn), "expected backends to be initialized")
+	require.Empty(t, p.ServiceTable.PendingInitializers(txn), "expected services to be initialized")
 
 	// The original read transaction still shows the tables as uninitialized (since the data
 	// available to it is still incomplete).
-	require.False(t, p.FrontendTable.Initialized(firstTxn), "expected frontends to be uninitialized")
-	require.False(t, p.BackendTable.Initialized(firstTxn), "expected backends to be uninitialized")
-	require.False(t, p.ServiceTable.Initialized(firstTxn), "expected services to be uninitialized")
+	require.NotEmpty(t, p.FrontendTable.PendingInitializers(firstTxn), "expected frontends to be uninitialized")
+	require.NotEmpty(t, p.BackendTable.PendingInitializers(firstTxn), "expected backends to be uninitialized")
+	require.NotEmpty(t, p.ServiceTable.PendingInitializers(firstTxn), "expected services to be uninitialized")
 }

--- a/vendor/github.com/cilium/statedb/db.go
+++ b/vendor/github.com/cilium/statedb/db.go
@@ -93,7 +93,7 @@ type DB struct {
 	defaultHandle       Handle
 }
 
-type dbRoot = []tableEntry
+type dbRoot []tableEntry
 
 type Option func(*opts)
 

--- a/vendor/github.com/cilium/statedb/types.go
+++ b/vendor/github.com/cilium/statedb/types.go
@@ -31,8 +31,9 @@ type Table[Obj any] interface {
 	NumObjects(ReadTxn) int
 
 	// Initialized returns true if in this ReadTxn (snapshot of the database)
-	// the registered initializers have all been completed.
-	Initialized(ReadTxn) bool
+	// the registered initializers have all been completed. The returned
+	// watch channel will be closed when the table becomes initialized.
+	Initialized(ReadTxn) (bool, <-chan struct{})
 
 	// PendingInitializers returns the set of pending initializers that
 	// have not yet completed.
@@ -95,9 +96,9 @@ type Table[Obj any] interface {
 // Change is either an update or a delete of an object. Used by Changes() and
 // the Observable().
 type Change[Obj any] struct {
-	Object   Obj
-	Revision Revision
-	Deleted  bool
+	Object   Obj      `json:"obj"`
+	Revision Revision `json:"rev"`
+	Deleted  bool     `json:"deleted,omitempty"`
 }
 
 type ChangeIterator[Obj any] interface {
@@ -209,6 +210,7 @@ type RWTable[Obj any] interface {
 // the object type (the 'Obj' constraint).
 type TableMeta interface {
 	Name() TableName // The name of the table
+
 	tableEntry() tableEntry
 	tablePos() int
 	setTablePos(int)
@@ -217,6 +219,7 @@ type TableMeta interface {
 	primary() anyIndexer                   // The untyped primary indexer for the table
 	secondary() map[string]anyIndexer      // Secondary indexers (if any)
 	sortableMutex() internal.SortableMutex // The sortable mutex for locking the table for writing
+	anyChanges(txn WriteTxn) (anyChangeIterator, error)
 }
 
 // Iterator for iterating objects returned from queries.
@@ -397,6 +400,8 @@ type tableEntry struct {
 	deleteTrackers      *part.Tree[anyDeleteTracker]
 	revision            uint64
 	pendingInitializers []string
+	initialized         bool
+	initWatchChan       chan struct{}
 }
 
 func (t *tableEntry) numObjects() int {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -529,7 +529,7 @@ github.com/cilium/proxy/go/envoy/type/tracing/v3
 github.com/cilium/proxy/go/envoy/type/v3
 github.com/cilium/proxy/go/envoy/watchdog/v3
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.2.5
+# github.com/cilium/statedb v0.2.6
 ## explicit; go 1.22.0
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
Bump StateDB to version v0.2.6 to bring in fixes for the Changes() API (the returned watch channel is now harder to misuse) and the support for the /changes HTTP API with which we can implement streaming of deletes in "cilium-dbg statedb".
