### PR TITLE
ServiceMonitor: Only create `envoy-metrics` block if Envoy is enabled

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
   # If it is not enabled, that means envoy runs inside cilium-agent and we'll monitor using same service
   {{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
   {{- if and (not $envoyDS) (not .Values.preflight.enabled) .Values.envoy.prometheus.enabled .Values.envoy.prometheus.serviceMonitor.enabled }}
-  {{- if .Values.envoy.prometheus.serviceMonitor.enabled }}
+  {{- if and .Values.envoy.enabled .Values.envoy.prometheus.serviceMonitor.enabled }}
   - port: envoy-metrics
     interval: {{ .Values.envoy.prometheus.serviceMonitor.interval | quote }}
     honorLabels: true


### PR DESCRIPTION
<!-- Description of change -->
This commit adds an additional condition to the "cilium-agent" ServiceMonitor definition to make sure that the entry for "envoy-metrics" is only created/remove when required.