### PR TITLE
endpoint: Use nanoseconds in policy logs

### DIFF
--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -155,6 +155,7 @@ func (e *Endpoint) updatePolicyLogger(fields map[string]interface{}) {
 			}
 			policyLog.SetOutput(lumberjackLogger)
 			policyLog.SetLevel(logrus.DebugLevel)
+			policyLog.SetFormatter(logging.GetFormatter(logging.DefaultLogFormatTimestamp))
 		})
 		policyLogger = logrus.NewEntry(policyLog)
 	}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -218,6 +218,7 @@ func GetFormatter(format LogFormat) logrus.Formatter {
 	case LogFormatTextTimestamp:
 		return &logrus.TextFormatter{
 			DisableTimestamp: false,
+			TimestampFormat:  time.RFC3339Nano,
 			DisableColors:    true,
 		}
 	case LogFormatJSON:


### PR DESCRIPTION
So far policy logs have only logged timestamps on a second accuracy. This makes it hard to correlate endpoint policy logs with the agent and/or Envoy logs. Change endpoint policy logs to also use nanoseconds like the daemon logs already do.
