### PR TITLE
feat: actions for no cni eks cluster creations

### DIFF
--- a/.github/actions/setup-eks-nodegroup/action.yml
+++ b/.github/actions/setup-eks-nodegroup/action.yml
@@ -1,5 +1,5 @@
-name: Create an EKS cluster
-description: Create an EKS cluster
+name: Create EKS nodegroup
+description: Create EKS nodegroup
 inputs:
   cluster_name:
     description: ''
@@ -21,10 +21,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Create EKS cluster
+    - name: Create EKS nodegroup
       shell: bash
       run: |
-        cat <<EOF > eks-config.yaml
+        cat <<EOF > eks-nodegroups.yaml
         apiVersion: eksctl.io/v1alpha5
         kind: ClusterConfig
 
@@ -36,11 +36,23 @@ runs:
            usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
            owner: "${{ inputs.owner }}"
 
-        addonsConfig:
-          disableDefaultAddons: true
-        addons:
-          - name: coredns
-          - name: kube-proxy
+        managedNodeGroups:
+        - name: ng-amd64
+          instanceTypes:
+           - t3a.medium
+          desiredCapacity: 2
+          spot: ${{ inputs.spot }}
+          privateNetworking: true
+          volumeType: "gp3"
+          volumeSize: 10
+        - name: ng-arm64
+          instanceTypes:
+           - t4g.medium
+          desiredCapacity: 1
+          spot: ${{ inputs.spot }}
+          privateNetworking: true
+          volumeType: "gp3"
+          volumeSize: 10
         EOF
 
-        eksctl create cluster -f ./eks-config.yaml
+        eksctl create nodegroup -f ./eks-nodegroup.yaml

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -278,37 +278,6 @@ jobs:
             until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
-      - name: Make sure images available from cluster
-        run: |
-          kubectl create -f - <<EOF
-          apiVersion: batch/v1
-          kind: Job
-          metadata:
-            name: wait-for-images
-          spec:
-            completions: 1
-            backoffLimit: 3
-            template:
-              spec:
-                containers:
-                - name: wait-for-images
-                  image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci:${{ steps.vars.outputs.sha }}
-                  command: ["true"]
-                tolerations:
-                - key: "node.cilium.io/agent-not-ready"
-                  operator: "Equal"
-                  value: "true"
-                  effect: "NoExecute"
-                restartPolicy: Never
-          EOF
-
-          kubectl wait --for=condition=complete --timeout=10m job/wait-for-images
-
-      # This is a workaround for flake #16938.
-      - name: Remove AWS-CNI
-        run: |
-          kubectl -n kube-system delete daemonset aws-node
-
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
@@ -324,6 +293,15 @@ jobs:
         id: install-cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
+
+      - name: Create EKS nodegroups
+        uses: ./.github/actions/setup-eks-nodegroup
+        with:
+          cluster_name: ${{ env.clusterName }}
+          region: ${{ matrix.region }}
+          owner: "${{ steps.vars.outputs.owner }}"
+          version: ${{ matrix.version }}
+          spot: false
 
       - name: Wait for Cilium to be ready
         run: |


### PR DESCRIPTION
In this commit we add the new way to create an eks cluster without addons. We then use coredns and kube-proxy as the approach here is just to create the cluster without CNI so we can install cilium directly. We then added another action to create the nodegroups in a different step of the workflow.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: [#1515](https://github.com/isovalent/roadmap/issues/1515)

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
