### PR TITLE
ipsec: Remove deprecated upgrade code

### DIFF
--- a/.github/actions/ipsec-key-rotate/action.yaml
+++ b/.github/actions/ipsec-key-rotate/action.yaml
@@ -5,14 +5,6 @@ inputs:
     required: true
     type: string
     description: "gcm(aes) or cbc(aes)"
-  key-type-one:
-    required: true
-    type: string
-    description: "'+' if we started with the per-tunnel key system"
-  key-type-two:
-    required: true
-    type: string
-    description: "'+' to rotate to the per-tunnel key system"
   encryption-overlay:
     required: true
     type: string
@@ -38,25 +30,10 @@ runs:
         echo "Updating IPsec secret with $data"
         kubectl patch secret -n kube-system cilium-ipsec-keys -p="$data" -v=1
 
-        # Compute number of expected keys during key rotation depending on
-        # whether we use the single-key system (1 key) or the per-tunnel
-        # keys system (8 keys, 2x2 IPv4 and 2x2 IPv6).
         # If encryption-overlay is enabled, we have 4 more IPv4 keys for the overlay.
-        # Transition from single-key to per-tunnel keys goes like this 1 > 9(13) > 8(12).
-        # Transition from per-tunnel to single-key goes like this 8(12) > 9(13) > 1.
-        # Transition from per-tunnel keys to per-tunnel keys goes like this 8(12) > 16(24) > 8(12).
-        exp_nb_keys=2
-        if [[ "${{ inputs.key-type-one }}" == "+" ]]; then
-          ((exp_nb_keys+=7))
-          if [[ "${{ inputs.encryption-overlay }}" == "true" ]]; then
-            ((exp_nb_keys+=4))
-          fi
-        fi
-        if [[ "${{ inputs.key-type-two }}" == "+" ]]; then
-          ((exp_nb_keys+=7))
-          if [[ "${{ inputs.encryption-overlay }}" == "true" ]]; then
-            ((exp_nb_keys+=4))
-          fi
+        exp_nb_keys=16
+        if [[ "${{ inputs.encryption-overlay }}" == "true" ]]; then
+          ((exp_nb_keys+=8))
         fi
 
         # Wait until key rotation starts
@@ -70,12 +47,9 @@ runs:
           sleep 30s
         done
 
-        exp_nb_keys=1
-        if [[ "${{ inputs.key-type-two }}" == "+" ]]; then
-          exp_nb_keys=8
-          if [[ "${{ inputs.encryption-overlay }}" == "true" ]]; then
-            exp_nb_keys=12
-          fi
+        exp_nb_keys=8
+        if [[ "${{ inputs.encryption-overlay }}" == "true" ]]; then
+          exp_nb_keys=12
         fi
 
         # Wait until key rotation completes

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -100,8 +100,6 @@ jobs:
             encryption-node: 'false'
             key-one: 'gcm(aes)'
             key-two: 'cbc(aes)'
-            key-type-one: '+'
-            key-type-two: '+'
 
           - name: '2'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -113,8 +111,6 @@ jobs:
             encryption-node: 'false'
             key-one: 'cbc(aes)'
             key-two: 'cbc(aes)'
-            key-type-one: '+'
-            key-type-two: ''
 
           - name: '3'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -127,8 +123,6 @@ jobs:
             endpoint-routes: 'true'
             key-one: 'gcm(aes)'
             key-two: 'gcm(aes)'
-            key-type-one: ''
-            key-type-two: '+'
 
           - name: '4'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -141,8 +135,6 @@ jobs:
             endpoint-routes: 'true'
             key-one: 'cbc(aes)'
             key-two: 'gcm(aes)'
-            key-type-one: ''
-            key-type-two: ''
 
           - name: '5'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -154,8 +146,6 @@ jobs:
             encryption-node: 'false'
             key-one: 'cbc(aes)'
             key-two: 'cbc(aes)'
-            key-type-one: '+'
-            key-type-two: '+'
 
           - name: '6'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -168,8 +158,6 @@ jobs:
             endpoint-routes: 'true'
             key-one: 'gcm(aes)'
             key-two: 'gcm(aes)'
-            key-type-one: '+'
-            key-type-two: '+'
 
           - name: '7'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -182,8 +170,6 @@ jobs:
             encryption-overlay: 'true'
             key-one: 'gcm(aes)'
             key-two: 'gcm(aes)'
-            key-type-one: '+'
-            key-type-two: '+'
 
           - name: '8'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -195,8 +181,6 @@ jobs:
             encryption-node: 'false'
             key-one: 'gcm(aes)'
             key-two: 'gcm(aes)'
-            key-type-one: '+'
-            key-type-two: '+'
 
     timeout-minutes: 75
     steps:
@@ -305,7 +289,7 @@ jobs:
             echo "Invalid key type"; exit 1
           fi
           kubectl create -n kube-system secret generic cilium-ipsec-keys \
-            --from-literal=keys="3${{ matrix.key-type-one }} ${key}"
+            --from-literal=keys="3+ ${key}"
 
           cilium install ${{ steps.cilium-config.outputs.config }}
           kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-server --timeout=300s
@@ -361,8 +345,6 @@ jobs:
         uses: ./.github/actions/ipsec-key-rotate
         with:
           key-algo: ${{ matrix.key-two }}
-          key-type-one: ${{ matrix.key-type-one }}
-          key-type-two: ${{ matrix.key-type-two }}
           encryption-overlay: ${{ matrix.encryption-overlay }}
 
       - name: Assert that no unencrypted packets are leaked during key rotation

--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -168,7 +168,7 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, nodeID uint1
 	wildcardIP := net.ParseIP(wildcardIPv4)
 	wildcardCIDR := &net.IPNet{IP: wildcardIP, Mask: net.IPv4Mask(0, 0, 0, 0)}
 
-	err := ipsec.IPsecDefaultDropPolicy(n.log, false)
+	err := ipsec.IPsecDefaultDropPolicy(false)
 	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "default-drop IPv4", wildcardCIDR, wildcardCIDR, spi, 0))
 
 	if newNode.IsLocal() {
@@ -303,7 +303,7 @@ func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, nodeID uint1
 	wildcardIP := net.ParseIP(wildcardIPv6)
 	wildcardCIDR := &net.IPNet{IP: wildcardIP, Mask: net.CIDRMask(0, 128)}
 
-	err := ipsec.IPsecDefaultDropPolicy(n.log, true)
+	err := ipsec.IPsecDefaultDropPolicy(true)
 	if err != nil {
 		errs = errors.Join(errs, fmt.Errorf("failed to create default drop policy IPv6: %w", err))
 	}

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -89,25 +89,21 @@ func TestParseSPI(t *testing.T) {
 		input    string
 		expSPI   uint8
 		expOff   int
-		expESN   bool
 		expError bool
 	}{
-		{"254", 0, 0, false, true},
-		{"15", 15, 0, false, false},
-		{"3+", 3, 0, true, false},
-		{"abc", 0, 0, false, true},
-		{"0", 0, 0, false, true},
+		{"254", 0, 0, true},
+		{"15", 15, 0, false},
+		{"3+", 3, 0, false},
+		{"abc", 0, 0, true},
+		{"0", 0, 0, true},
 	}
 	for _, tc := range testCases {
-		spi, off, esn, err := parseSPI(log, tc.input)
+		spi, off, err := parseSPI(log, tc.input)
 		if spi != tc.expSPI {
 			t.Fatalf("For input %q, expected SPI %d, but got %d", tc.input, tc.expSPI, spi)
 		}
 		if off != tc.expOff {
 			t.Fatalf("For input %q, expected base offset %d, but got %d", tc.input, tc.expOff, off)
-		}
-		if esn != tc.expESN {
-			t.Fatalf("For input %q, expected ESN %t, but got %t", tc.input, tc.expESN, esn)
 		}
 		if tc.expError {
 			require.Error(t, err)

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -38,8 +38,13 @@ func setupIPSecSuitePrivileged(tb testing.TB) *slog.Logger {
 	return log
 }
 
-var (
-	path           = "ipsec_keys_test"
+const (
+	path         = "ipsec_keys_test"
+	remoteNodeID = 1234
+	remoteBootID = "5f616d5f-aed6-4ac7-b237-123456789abc"
+)
+
+const (
 	keysDat        = []byte("1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n1 digest_null \"\" cipher_null \"\"\n")
 	keysAeadDat    = []byte("6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
 	keysAeadDat256 = []byte("6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f144434241343332312423222114131211 128\n")
@@ -65,7 +70,7 @@ func TestInvalidLoadKeys(t *testing.T) {
 	_, remote, err := net.ParseCIDR("1.2.3.4/16")
 	require.NoError(t, err)
 
-	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, 0, "remote-boot-id", IPSecDirBoth, false, false, DefaultReqID)
+	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, remoteNodeID, remoteBootID, IPSecDirBoth, false, false, DefaultReqID)
 	require.Error(t, err)
 }
 
@@ -135,7 +140,7 @@ func TestUpsertIPSecEquals(t *testing.T) {
 	ipSecKeysGlobal["1.2.3.4"] = key
 	ipSecKeysGlobal[""] = key
 
-	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, 0, "remote-boot-id", IPSecDirBoth, false, false, DefaultReqID)
+	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, remoteNodeID, remoteBootID, IPSecDirBoth, false, false, DefaultReqID)
 	require.NoError(t, err)
 
 	// Let's check that state was not added as source and destination are the same
@@ -159,7 +164,7 @@ func TestUpsertIPSecEquals(t *testing.T) {
 	ipSecKeysGlobal["1.2.3.4"] = key
 	ipSecKeysGlobal[""] = key
 
-	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, 0, "remote-boot-id", IPSecDirBoth, false, false, DefaultReqID)
+	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, remoteNodeID, remoteBootID, IPSecDirBoth, false, false, DefaultReqID)
 	require.NoError(t, err)
 
 	// Let's check that state was not added as source and destination are the same
@@ -191,7 +196,7 @@ func TestUpsertIPSecEndpoint(t *testing.T) {
 	ipSecKeysGlobal["1.2.3.4"] = key
 	ipSecKeysGlobal[""] = key
 
-	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, 0, "remote-boot-id", IPSecDirBoth, false, false, DefaultReqID)
+	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, remoteNodeID, remoteBootID, IPSecDirBoth, false, false, DefaultReqID)
 	require.NoError(t, err)
 
 	getState := &netlink.XfrmState{
@@ -235,11 +240,11 @@ func TestUpsertIPSecEndpoint(t *testing.T) {
 	ipSecKeysGlobal["1.2.3.4"] = key
 	ipSecKeysGlobal[""] = key
 
-	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, 0, "remote-boot-id", IPSecDirBoth, false, false, DefaultReqID)
+	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, remoteNodeID, remoteBootID, IPSecDirBoth, false, false, DefaultReqID)
 	require.NoError(t, err)
 
 	// Assert additional rule when tunneling is enabled is inserted
-	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, 0, "remote-boot-id", IPSecDirBoth, false, false, DefaultReqID)
+	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, remoteNodeID, remoteBootID, IPSecDirBoth, false, false, DefaultReqID)
 	require.NoError(t, err)
 	toProxyPolicy, err := netlink.XfrmPolicyGet(&netlink.XfrmPolicy{
 		Src: remote,
@@ -262,7 +267,7 @@ func TestUpsertIPSecKeyMissing(t *testing.T) {
 	_, remote, err := net.ParseCIDR("1.2.3.4/16")
 	require.NoError(t, err)
 
-	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, 0, "remote-boot-id", IPSecDirBoth, false, false, DefaultReqID)
+	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, remoteNodeID, remoteBootID, IPSecDirBoth, false, false, DefaultReqID)
 	require.ErrorContains(t, err, "unable to replace local state: IPSec key missing")
 }
 
@@ -289,10 +294,10 @@ func TestUpdateExistingIPSecEndpoint(t *testing.T) {
 	ipSecKeysGlobal["1.2.3.4"] = key
 	ipSecKeysGlobal[""] = key
 
-	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, 0, "remote-boot-id", IPSecDirBoth, false, false, DefaultReqID)
+	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, remoteNodeID, remoteBootID, IPSecDirBoth, false, false, DefaultReqID)
 	require.NoError(t, err)
 
 	// test updateExisting (xfrm delete + add)
-	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, 0, "remote-boot-id", IPSecDirBoth, false, true, DefaultReqID)
+	_, err = UpsertIPsecEndpoint(log, local, remote, local.IP, remote.IP, remoteNodeID, remoteBootID, IPSecDirBoth, false, true, DefaultReqID)
 	require.NoError(t, err)
 }

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -126,12 +126,8 @@ const (
 	// IPsecMarkBitMask is the mask used for the encrypt and decrypt bits.
 	IPsecMarkBitMask = 0x0F00
 
-	// IPsecOldMarkMaskOut is the mask that was previously used. It can be
-	// removed in Cilium v1.17.
-	IPsecOldMarkMaskOut = 0xFF00
-
 	// IPsecMarkMask is the mask required for the IPsec SPI, node ID, and encrypt/decrypt bits
-	IPsecMarkMaskOut = IPsecOldMarkMaskOut | IPsecMarkMaskNodeID
+	IPsecMarkMaskOut = 0xFF00 | IPsecMarkMaskNodeID
 
 	// IPsecMarkMaskIn is the mask required for the IPsec node ID and encrypt/decrypt bits
 	IPsecMarkMaskIn = IPsecMarkBitMask | IPsecMarkMaskNodeID


### PR DESCRIPTION
```release-note
Remove support for the insecure, deprecated global IPsec key. Per-tunnel IPsec keys will now be used regardless of the IPsec secret format.
```