### PR TITLE
Service port compatibility check accounts for TCP/UDP differentiation

### DIFF
--- a/operator/pkg/lbipam/cell.go
+++ b/operator/pkg/lbipam/cell.go
@@ -88,6 +88,7 @@ func newLBIPAMCell(params lbipamCellParams) *LBIPAM {
 		lbClasses:    lbClasses,
 		ipv4Enabled:  option.Config.IPv4Enabled(),
 		ipv6Enabled:  option.Config.IPv6Enabled(),
+		lbProtoDiff:  option.Config.LBProtoDiffEnabled(),
 		poolClient:   params.Clientset.CiliumV2alpha1().CiliumLoadBalancerIPPools(),
 		svcClient:    params.Clientset.Slim().CoreV1(),
 		jobGroup:     params.JobGroup,

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -72,6 +72,7 @@ type lbIPAMParams struct {
 	lbClasses   []string
 	ipv4Enabled bool
 	ipv6Enabled bool
+	lbProtoDiff bool
 
 	poolClient poolClient
 	svcClient  client_typed_v1.ServicesGetter
@@ -554,7 +555,7 @@ func (ipam *LBIPAM) checkSharingGroupCompatibility(sv *ServiceView) bool {
 
 		for _, sharedView := range sharedViews {
 			if sv != sharedView {
-				if c, _ := sharedView.isCompatible(sv); !c {
+				if c, _ := sharedView.isCompatible(sv, ipam.lbProtoDiff); !c {
 					return false
 				}
 			}
@@ -858,7 +859,7 @@ func (ipam *LBIPAM) satisfySpecificIPRequests(sv *ServiceView) (statusModified b
 			compatible := true
 			incompatibilityReason := ""
 			for _, serviceView := range serviceViews {
-				if c, r := serviceView.isCompatible(sv); !c {
+				if c, r := serviceView.isCompatible(sv, ipam.lbProtoDiff); !c {
 					compatible = false
 					incompatibilityReason = r
 					break
@@ -951,7 +952,7 @@ func (ipam *LBIPAM) satisfyGenericIPv4Requests(sv *ServiceView) (statusModified 
 			// Check if the ports and external traffic policy of the current service is compatible with the existing `ServiceViews`
 			compatible := true
 			for _, serviceView := range serviceViews {
-				if c, _ := serviceView.isCompatible(sv); !c {
+				if c, _ := serviceView.isCompatible(sv, ipam.lbProtoDiff); !c {
 					compatible = false
 					break
 				}
@@ -1017,7 +1018,7 @@ func (ipam *LBIPAM) satisfyGenericIPv6Requests(sv *ServiceView) (statusModified 
 				// Check if the ports and external traffic policy of the current service is compatible with the existing `ServiceViews`
 				compatible := true
 				for _, serviceView := range serviceViews {
-					if c, _ := serviceView.isCompatible(sv); !c {
+					if c, _ := serviceView.isCompatible(sv, ipam.lbProtoDiff); !c {
 						compatible = false
 						break
 					}

--- a/operator/pkg/lbipam/service_store.go
+++ b/operator/pkg/lbipam/service_store.go
@@ -100,13 +100,13 @@ func (sv *ServiceView) isCompatible(osv *ServiceView) (bool, string) {
 		}
 	}
 
-	// Compatible services don't have any overlapping ports.
-	// NOTE: Normally we would also consider the protocol, but the Cilium datapath can't differentiate between
-	// 	     protocols, so we don't either for this purpose. https://github.com/cilium/cilium/issues/9207
+	// Compatible services don't have any overlapping ports with the same protocol.
+	// NOTE: The Cilium datapath can differentiate between protocols,thanks to the merge
+	//       of PR https://github.com/cilium/cilium/pull/33434.
 	for _, port1 := range sv.Ports {
 		for _, port2 := range osv.Ports {
-			if port1.Port == port2.Port {
-				return false, "same port"
+			if port1.Port == port2.Port && port1.Protocol == port2.Protocol && (port1.Protocol == slim_core_v1.ProtocolTCP || port1.Protocol == slim_core_v1.ProtocolUDP) {
+				return false, "same port and protocol"
 			}
 		}
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2402,6 +2402,11 @@ func (c *DaemonConfig) IPv6Enabled() bool {
 	return c.EnableIPv6
 }
 
+// LBProtoDiffEnabled returns true if LoadBalancerProtocolDifferentiation is enabled
+func (c *DaemonConfig) LBProtoDiffEnabled() bool {
+	return c.LoadBalancerProtocolDifferentiation
+}
+
 // IPv6NDPEnabled returns true if IPv6 NDP support is enabled
 func (c *DaemonConfig) IPv6NDPEnabled() bool {
 	return c.EnableIPv6NDP


### PR DESCRIPTION
fixes: #34677 

```release-note
Make LB-IPAM allow IP sharing between services with the same ports but different protocols
```