### PR TITLE
policy: Reduce allocs when keeping track of owners

### DIFF
--- a/pkg/container/set/set.go
+++ b/pkg/container/set/set.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package set
+
+import (
+	"fmt"
+	"iter"
+	"maps"
+)
+
+type empty struct{}
+
+// Set contains zero, one, or more members. Zero or one members do not consume any additional
+// storage, more than one members are held in an non-exported membersMap.
+type Set[T comparable] struct {
+	single  *T
+	members map[T]empty
+}
+
+// Empty returns 'true' if the set is empty.
+func (s Set[T]) Empty() bool {
+	return s.single == nil && s.members == nil
+}
+
+// Len returns the number of members in the set.
+func (s Set[T]) Len() int {
+	if s.single != nil {
+		return 1
+	}
+	return len(s.members)
+}
+
+func (s Set[T]) String() string {
+	if s.single != nil {
+		return fmt.Sprintf("%v", s.single)
+	}
+	res := ""
+	for m := range s.members {
+		if res != "" {
+			res += ","
+		}
+		res += fmt.Sprintf("%v", m)
+	}
+	return res
+}
+
+// NewSet returns a Set initialized to contain the members in 'members'.
+func NewSet[T comparable](members ...T) Set[T] {
+	s := Set[T]{}
+	for _, member := range members {
+		s.Insert(member)
+	}
+	return s
+}
+
+// Has returns 'true' if 'member' is in the set.
+func (s Set[T]) Has(member T) bool {
+	if s.single != nil {
+		return *s.single == member
+	}
+	_, ok := s.members[member]
+	return ok
+}
+
+// Insert inserts a member to the set.
+// Returns 'true' when '*s' value has changed,
+// so that if it is stored by value the caller must knows to update the stored value.
+func (s *Set[T]) Insert(member T) (changed bool) {
+	switch s.Len() {
+	case 0:
+		s.single = &member
+		return true
+	case 1:
+		if member == *s.single {
+			return false
+		}
+		s.members = make(map[T]empty, 2)
+		s.members[*s.single] = empty{}
+		s.single = nil
+		s.members[member] = empty{}
+		return true
+	default:
+		s.members[member] = empty{}
+		return false
+	}
+}
+
+// Merge inserts members in 'o' into to the set 's'.
+// Returns 'true' when '*s' value has changed,
+// so that if it is stored by value the caller must knows to update the stored value.
+func (s *Set[T]) Merge(sets ...Set[T]) (changed bool) {
+	for _, other := range sets {
+		for m := range other.Members() {
+			changed = s.Insert(m) || changed
+		}
+	}
+	return changed
+}
+
+// Remove removes a member from the set.
+// Returns 'true' when '*s' value was changed, so that if it is stored by value the caller knows to
+// update the stored value.
+func (s *Set[T]) Remove(member T) (changed bool) {
+	length := s.Len()
+	switch length {
+	case 0:
+	case 1:
+		if *s.single == member {
+			s.single = nil
+			return true
+		}
+	case 2:
+		delete(s.members, member)
+		if len(s.members) == 1 {
+			for m := range s.members {
+				s.single = &m
+			}
+			s.members = nil
+			return true
+		}
+	default:
+		delete(s.members, member)
+	}
+	return false
+}
+
+// RemoveSets removes one or more Sets from the receiver set.
+// Returns 'true' when '*s' value was changed, so that if it is stored by value the caller knows to
+// update the stored value.
+func (s *Set[T]) RemoveSets(sets ...Set[T]) (changed bool) {
+	for _, other := range sets {
+		for m := range other.Members() {
+			changed = s.Remove(m) || changed
+		}
+	}
+	return changed
+}
+
+// Clear makes the set '*s' empty.
+func (s *Set[T]) Clear() {
+	s.single = nil
+	s.members = nil
+}
+
+// Equal returns 'true' if the receiver and argument sets are the same.
+func (s Set[T]) Equal(o Set[T]) bool {
+	sLen := s.Len()
+	oLen := o.Len()
+
+	if sLen != oLen {
+		return false
+	}
+
+	switch sLen {
+	case 0:
+		return true
+	case 1:
+		return *s.single == *o.single
+	default:
+		// compare the elements of the maps
+		for member := range s.members {
+			if _, ok := o.members[member]; !ok {
+				return false
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// Members returns an iterator for the members in the set.
+func (s Set[T]) Members() iter.Seq[T] {
+	return func(yield func(m T) bool) {
+		if s.single != nil {
+			yield(*s.single)
+		} else {
+			for member := range s.members {
+				if !yield(member) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// MembersOfType return an iterator for each member of type M in the set.
+func MembersOfType[M any, T comparable](s Set[T]) iter.Seq[M] {
+	return func(yield func(m M) bool) {
+		if s.single != nil {
+			if v, ok := any(*s.single).(M); ok {
+				yield(v)
+			}
+		} else {
+			for m := range s.members {
+				if v, ok := any(m).(M); ok {
+					if !yield(v) {
+						return
+					}
+				}
+			}
+		}
+	}
+}
+
+// Get returns any one member from the set.
+// Useful when it is known that the set has only one element.
+func (s Set[T]) Get() (m T, found bool) {
+	length := s.Len()
+
+	switch length {
+	case 0:
+	case 1:
+		m = *s.single
+	default:
+		for m = range s.members {
+			break
+		}
+	}
+	return m, length > 0
+}
+
+// Clone returns a copy of the set.
+func (s Set[T]) Clone() Set[T] {
+	if s.members != nil {
+		return Set[T]{members: maps.Clone(s.members)}
+	}
+	return s // singular value or empty Set
+}

--- a/pkg/container/set/set_test.go
+++ b/pkg/container/set/set_test.go
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package set
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func (t empty) String() string { return "" }
+
+type test struct{ c int }
+
+func (t test) String() string { return "" }
+
+type Member fmt.Stringer
+
+func TestSet(t *testing.T) {
+	require.True(t, Set[Member]{}.Empty())
+	require.True(t, NewSet[Member]().Empty())
+	require.False(t, NewSet[Member](nil).Empty())
+	require.Equal(t, 1, NewSet[Member](nil).Len())
+
+	var emptyItem empty
+	var alsoEmptyItem empty
+
+	require.False(t, NewSet[Member](emptyItem).Empty())
+	require.Equal(t, 1, NewSet[Member](emptyItem).Len())
+
+	require.Equal(t, 2, NewSet[Member](emptyItem, nil).Len())
+	require.Equal(t, 2, NewSet[Member](nil, emptyItem).Len())
+
+	// item and item2 are the same
+	require.Equal(t, 2, NewSet[Member](emptyItem, nil, alsoEmptyItem).Len())
+	require.Equal(t, 2, NewSet[Member](nil, alsoEmptyItem, emptyItem).Len())
+
+	item1 := test{1}
+	item2 := test{2}
+	set := NewSet[Member]()
+	require.True(t, set.Empty())
+	require.True(t, set.Insert(nil))
+	require.Equal(t, 1, set.Len())
+	require.True(t, set.Insert(item1))
+	require.Equal(t, 2, set.Len())
+	require.False(t, set.Insert(emptyItem))
+	require.Equal(t, 3, set.Len())
+	require.False(t, set.Insert(item1))
+	require.Equal(t, 3, set.Len())
+	require.False(t, set.Insert(item2))
+	require.Equal(t, 4, set.Len())
+
+	require.True(t, set.Has(alsoEmptyItem))
+	require.True(t, set.Has(emptyItem))
+	require.True(t, set.Has(nil))
+	require.True(t, set.Has(item1))
+	require.True(t, set.Has(item2))
+
+	// remove item1 using a duplicate
+	require.False(t, set.Remove(test{1})) // storage for set itself not changed
+	require.Equal(t, 3, set.Len())
+
+	var item1Seen, item2Seen, nilSeen, emptySeen bool
+	for m := range set.Members() {
+		if m == item1 {
+			item1Seen = true
+		}
+		if m == item2 {
+			item2Seen = true
+		}
+		if m == nil {
+			nilSeen = true
+		}
+		if m == emptyItem {
+			emptySeen = true
+		}
+	}
+	require.False(t, item1Seen)
+	require.True(t, item2Seen)
+	require.True(t, nilSeen)
+	require.True(t, emptySeen)
+
+	// remove nil item
+	require.False(t, set.Remove(nil)) // storage for set itself not changed
+	require.Equal(t, 2, set.Len())
+
+	// remove nil again
+	require.False(t, set.Remove(nil)) // storage for set itself not changed
+	require.Equal(t, 2, set.Len())
+
+	item1Seen = false
+	item2Seen = false
+	nilSeen = false
+	emptySeen = false
+	for m := range set.Members() {
+		if m == item1 {
+			item1Seen = true
+		}
+		if m == item2 {
+			item2Seen = true
+		}
+		if m == nil {
+			nilSeen = true
+		}
+		if m == emptyItem {
+			emptySeen = true
+		}
+	}
+	require.False(t, item1Seen)
+	require.True(t, item2Seen)
+	require.False(t, nilSeen)
+	require.True(t, emptySeen)
+
+	// remove empty item, storage should change from map to a singular item
+	require.True(t, set.Remove(alsoEmptyItem))
+	require.Equal(t, 1, set.Len())
+
+	// remove last item
+	require.True(t, set.Remove(item2))
+	require.Equal(t, 0, set.Len())
+	require.True(t, set.Empty())
+
+	// nil handling corner cases
+
+	// nil inserted as first item, correctly shifted to the internal map after another item is
+	// inserted
+	set = Set[Member]{}
+	require.True(t, set.Empty())
+	require.Equal(t, 0, set.Len())
+	require.False(t, set.Has(nil))
+
+	require.True(t, set.Insert(nil))
+	require.False(t, set.Empty())
+	require.Equal(t, 1, set.Len())
+	require.True(t, set.Has(nil))
+
+	require.True(t, set.Insert(item1))
+	require.Equal(t, 2, set.Len())
+	require.True(t, set.Has(nil))
+	require.True(t, set.Has(item1))
+
+	// nil left as the last item
+	require.True(t, set.Remove(item1))
+	require.Equal(t, 1, set.Len())
+	require.False(t, set.Empty())
+	require.True(t, set.Has(nil))
+	require.False(t, set.Has(item1))
+
+	require.True(t, set.Remove(nil))
+	require.True(t, set.Empty())
+	require.False(t, set.Has(nil))
+
+	// Equal
+	require.True(t, Set[Member]{}.Equal(Set[Member]{}))
+	require.True(t, Set[Member]{}.Equal(NewSet[Member]()))
+	require.True(t, NewSet[Member]().Equal(NewSet[Member]()))
+	require.False(t, NewSet[Member]().Equal(NewSet[Member](nil)))
+	require.False(t, NewSet[Member](nil).Equal(NewSet[Member]()))
+	require.True(t, NewSet[Member](nil).Equal(NewSet[Member](nil)))
+	require.True(t, NewSet[Member](nil, item1).Equal(NewSet[Member](item1, nil)))
+	require.False(t, NewSet[Member]().Equal(NewSet[Member](item2)))
+	require.False(t, NewSet[Member](item1).Equal(NewSet[Member]()))
+	require.False(t, NewSet(item1).Equal(NewSet(item2)))
+	require.False(t, NewSet(item1).Equal(NewSet(item2)))
+	require.False(t, NewSet(item1, item2).Equal(NewSet(item2)))
+	require.False(t, NewSet(item1).Equal(NewSet(item2, item1)))
+	require.True(t, NewSet(item1, item2).Equal(NewSet(item2, item1)))
+
+	// Clone
+	set = NewSet[Member](item1, emptyItem, nil)
+	set2 := set.Clone()
+	require.True(t, set2.Equal(set))
+	// modify set, set2 not changed
+	require.False(t, set.Remove(nil))
+	require.False(t, set2.Equal(set))
+	require.True(t, set2.Has(nil))
+
+	set = NewSet[Member](item1)
+	set2 = set.Clone()
+	require.True(t, set2.Equal(set))
+	// Trying to remove non-existing item changes nothing
+	require.False(t, set.Remove(nil))
+	require.True(t, set2.Equal(set))
+	require.True(t, set.Has(item1))
+	require.True(t, set2.Has(item1))
+	// modify set2, set not changed
+	require.True(t, set2.Remove(item1))
+	require.False(t, set.Equal(set2)) // storage changed
+	require.True(t, set.Has(item1))
+	require.False(t, set2.Has(item1))
+
+	// Insert a set into another
+	set = NewSet[Member](nil)
+	set2 = NewSet[Member](emptyItem, item2, item1)
+	require.True(t, set.Merge(set2)) // storage changed from single item to a map
+	require.Equal(t, 4, set.Len())
+	require.Equal(t, 3, set2.Len())
+	require.True(t, set.Has(item2))
+	require.False(t, set2.Has(nil))
+
+	// Typed Members sees only the selected type elements
+	emptySeen = false
+	otherSeen := false
+	require.Equal(t, 4, set.Len())
+	for m := range MembersOfType[empty](set) {
+		if m == emptyItem {
+			emptySeen = true
+		} else {
+			otherSeen = true
+		}
+	}
+	require.True(t, emptySeen)
+	require.False(t, otherSeen)
+
+	// Clear
+	set.Clear()
+	require.True(t, set.Empty())
+
+	// Get, empty set2 by Get/Remove
+	ok := true
+	for ok {
+		var item Member
+		if item, ok = set2.Get(); ok {
+			require.NotNil(t, item)
+			len := set2.Len()
+			set2.Remove(item)
+			require.True(t, set2.Len() < len)
+		}
+	}
+	require.True(t, set2.Empty())
+}

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -1395,19 +1395,16 @@ var (
 		ProxyPort:        0,
 		DerivedFromRules: labels.LabelArrayList{nil},
 		IsDeny:           true,
-		owners:           map[MapStateOwner]struct{}{},
 	}
 	mapEntryAllow = MapStateEntry{
 		ProxyPort:        0,
 		DerivedFromRules: labels.LabelArrayList{nil},
-		owners:           map[MapStateOwner]struct{}{},
 	}
 	worldLabelArrayList         = labels.LabelArrayList{labels.LabelWorld.LabelArray()}
 	mapEntryWorldDenyWithLabels = MapStateEntry{
 		ProxyPort:        0,
 		DerivedFromRules: worldLabelArrayList,
 		IsDeny:           true,
-		owners:           map[MapStateOwner]struct{}{},
 	}
 
 	worldIPIdentity = localIdentity(16324)

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -661,17 +661,17 @@ func (ms *mapState) RemoveDependent(owner Key, dependent Key, changes ChangeStat
 	}
 }
 
-// Merge adds owners, dependents, and DerivedFromRules from a new 'entry' to an existing
+// merge adds owners, dependents, and DerivedFromRules from a new 'entry' to an existing
 // entry 'e'. 'entry' is not modified.
 // Merge is only called if both entries are allow or deny entries, so deny precedence is not
 // considered here.
 // ProxyPort, and AuthType are merged by giving precedence to proxy redirection over no proxy
 // redirection, and explicit auth type over default auth type.
-func (e *MapStateEntry) Merge(entry *MapStateEntry) {
+func (e *MapStateEntry) merge(entry *MapStateEntry) {
 	// Bail out loudly if both entries are not denies or allows
 	if e.IsDeny != entry.IsDeny {
 		log.WithField(logfields.Stacktrace, hclog.Stacktrace()).
-			Errorf("MapStateEntry.Merge: both entries must be allows or denies")
+			Errorf("MapStateEntry.merge: both entries must be allows or denies")
 		return
 	}
 	// Only allow entries have proxy redirection or auth requirement
@@ -832,7 +832,7 @@ func (ms *mapState) addKeyWithChanges(key Key, entry MapStateEntry, changes Chan
 		// place!
 		datapathEqual = oldEntry.DatapathEqual(&entry)
 
-		oldEntry.Merge(&entry)
+		oldEntry.merge(&entry)
 		ms.insert(key, oldEntry)
 	} else if !exists || entry.IsDeny {
 		// Insert a new entry if one did not exist or a deny entry is overwriting an allow
@@ -1109,7 +1109,7 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 				denyEntry = NewMapStateEntry(k, v.DerivedFromRules, 0, "", 0, true, DefaultAuthType, AuthTypeDisabled)
 			} else {
 				// Collect the owners and labels of all the contributing deny rules
-				denyEntry.Merge(&v)
+				denyEntry.merge(&v)
 			}
 			return true
 		})


### PR DESCRIPTION
Store single owners directly in the `MapStateEntry` and switch to a map only when more than one owner is needed. This is done with the new `ifset.Set`.

Instead of a map of MapStateOwner interfaces, the Owners member of MapStateEntry is now a `ifset.Set`, which can hold a single interface value directly, or a more in a map. The new `ifset.Set` type uses an unexported `memberMap` type for its internal map, so the Set can hold any interface values (including empty interface value `nil`).

With this change the `BenchmarkRegenerateCIDRDenyPolicyRules` benchmark runs ~11% faster and uses ~15% less memory with ~9% less allocs than with the prior map only version.
