### PR TITLE
.github: bump timeout for release GH workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
   release:
     name: Release
     environment: release-tool
-    timeout-minutes: 10
+    timeout-minutes: 40
     runs-on: ubuntu-22.04
     steps:
       - name: Install Go


### PR DESCRIPTION
Certain releases might require a long time to generate the release notes, thus 10 minutes is not sufficient to complete the release step.