### PR TITLE
run cilium operator as non-root

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2823,7 +2823,7 @@
    * - :spelling:ignore:`operator.securityContext`
      - Security context to be added to cilium-operator pods
      - object
-     - ``{}``
+     - ``{"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}``
    * - :spelling:ignore:`operator.setNodeNetworkStatus`
      - Set Node condition NetworkUnavailable to 'false' with the reason 'CiliumIsUp' for nodes that have a healthy Cilium pod.
      - bool

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -91,3 +91,8 @@ ENV DEBUG_HOLD=${DEBUG_HOLD}
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/cilium-${OPERATOR_VARIANT} /usr/bin/cilium-${OPERATOR_VARIANT}-bin
 COPY --from=debug-tools /go/bin/dlv /usr/bin/dlv
 COPY --from=debug-tools /out/${TARGETOS}/${TARGETARCH}/bin/debug-wrapper /usr/bin/cilium-${OPERATOR_VARIANT}
+RUN addgroup -g 1000 cilium-operator
+RUN adduser -D -u 1000 -G cilium-operator cilium-operator
+USER cilium-operator
+
+

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2645,8 +2645,10 @@ operator:
   #     memory: 128Mi
 
   # -- Security context to be added to cilium-operator pods
-  securityContext: {}
-  # runAsUser: 0
+  securityContext: 
+    runAsNonRoot: true
+    runAsGroup: 1000
+    runAsUser: 1000
 
   # -- Interval for endpoint garbage collection.
   endpointGCInterval: "5m0s"


### PR DESCRIPTION
Currently fails with:

```
time="2024-09-05T10:19:06Z" level=info msg="Cilium Operator 1.17.0-dev 04f033e39c 2024-09-04T23:25:39+00:00 go version go1.23.0 linux/arm64" subsys=cilium-operator-generic
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="pprof.init.func1 (pkg/pprof/cell.go:48)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=1.181926ms function="pprof.init.func1 (pkg/pprof/cell.go:48)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="gops.registerGopsHooks (pkg/gops/cell.go:38)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=95.167µs function="gops.registerGopsHooks (pkg/gops/cell.go:38)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="metrics.registerMetricsManager (.../operator/metrics/metrics.go:72)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=511.171µs function="metrics.registerMetricsManager (.../operator/metrics/metrics.go:72)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="types.ClusterInfo.InitClusterIDMax (.../clustermesh/types/types.go:39)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=33.875µs function="types.ClusterInfo.InitClusterIDMax (.../clustermesh/types/types.go:39)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="types.ClusterInfo.Validate (.../clustermesh/types/option.go:50)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=17.917µs function="types.ClusterInfo.Validate (.../clustermesh/types/option.go:50)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="cmd.registerOperatorHooks (cmd/root.go:344)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=357.378µs function="cmd.registerOperatorHooks (cmd/root.go:344)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="controller.Init (pkg/controller/cell.go:71)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=31.167µs function="controller.Init (pkg/controller/cell.go:71)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="api.init.func1 (.../operator/api/cell.go:31)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=4.834331ms function="api.init.func1 (.../operator/api/cell.go:31)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="apis.createCRDs (.../k8s/apis/cell.go:62)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=45.792µs function="apis.createCRDs (.../k8s/apis/cell.go:62)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="bgpv2.registerBGPResourceManager (pkg/bgpv2/manager.go:80)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=112.751µs function="bgpv2.registerBGPResourceManager (pkg/bgpv2/manager.go:80)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="lbipam.init.func1 (pkg/lbipam/cell.go:28)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=72.751µs function="lbipam.init.func1 (pkg/lbipam/cell.go:28)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="nodeipam.registerNodeSvcLBReconciler (pkg/nodeipam/cell.go:42)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=213.335µs function="nodeipam.registerNodeSvcLBReconciler (pkg/nodeipam/cell.go:42)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="auth.registerIdentityWatcher (.../operator/auth/watcher.go:42)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=89.709µs function="auth.registerIdentityWatcher (.../operator/auth/watcher.go:42)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="endpointslicesync.registerEndpointSliceSync (.../clustermesh/endpointslicesync/endpointslicesync.go:15)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=60.625µs function="endpointslicesync.registerEndpointSliceSync (.../clustermesh/endpointslicesync/endpointslicesync.go:15)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="mcsapi.initMCSAPIController (.../clustermesh/mcsapi/cell.go:87)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=24.834µs function="mcsapi.initMCSAPIController (.../clustermesh/mcsapi/cell.go:87)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="cmd.registerLegacyOnLeader (cmd/root.go:500)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=86.084µs function="cmd.registerLegacyOnLeader (cmd/root.go:500)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="identitygc.registerGC (.../operator/identitygc/gc.go:87)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=68.292µs function="identitygc.registerGC (.../operator/identitygc/gc.go:87)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="ciliumidentity.registerController (pkg/ciliumidentity/controller.go:92)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=72µs function="ciliumidentity.registerController (pkg/ciliumidentity/controller.go:92)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="doublewrite.registerDoubleWriteMetricReporter (.../operator/doublewrite/metricreporter.go:61)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=42.584µs function="doublewrite.registerDoubleWriteMetricReporter (.../operator/doublewrite/metricreporter.go:61)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="ciliumendpointslice.registerController (pkg/ciliumendpointslice/controller.go:78)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=169.543µs function="ciliumendpointslice.registerController (pkg/ciliumendpointslice/controller.go:78)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="endpointgc.registerGC (.../operator/endpointgc/gc.go:59)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=44.709µs function="endpointgc.registerGC (.../operator/endpointgc/gc.go:59)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="gateway-api.initGatewayAPIController (pkg/gateway-api/cell.go:112)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=96.293µs function="gateway-api.initGatewayAPIController (pkg/gateway-api/cell.go:112)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="ingress.registerReconciler (pkg/ingress/cell.go:99)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=119.376µs function="ingress.registerReconciler (pkg/ingress/cell.go:99)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="secretsync.initSecretSyncReconciliation (pkg/secretsync/cell.go:54)"
time=2024-09-05T10:19:06Z level=debug msg="CRD is not present, will not handle it" module=operator.operator-controlplane.leader-lifecycle.gateway-api optionalGVK="gateway.networking.k8s.io/v1alpha2, Kind=tlsroutes"
time=2024-09-05T10:19:06Z level=debug msg="CRD is not present, will not handle it" module=operator.operator-controlplane.leader-lifecycle.gateway-api optionalGVK="multicluster.x-k8s.io/v1alpha1, Kind=serviceimports"
time=2024-09-05T10:19:06Z level=debug msg="Skipping secret sync initialization as no registrations are available" module=operator.operator-controlplane.leader-lifecycle.secret-sync
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=6.035091ms function="secretsync.initSecretSyncReconciliation (pkg/secretsync/cell.go:54)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="ciliumenvoyconfig.registerL7LoadBalancingController (pkg/ciliumenvoyconfig/cell.go:47)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=50.792µs function="ciliumenvoyconfig.registerL7LoadBalancingController (pkg/ciliumenvoyconfig/cell.go:47)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="networkpolicy.registerPolicyValidator (pkg/networkpolicy/cell.go:69)"
time="2024-09-05T10:19:06Z" level=info msg="Registering CNP / CCNP validator" subsys=network-policy-validator
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=122.501µs function="networkpolicy.registerPolicyValidator (pkg/networkpolicy/cell.go:69)"
time=2024-09-05T10:19:06Z level=debug msg=Invoking function="health.metricPublisher (.../hive/health/metrics.go:48)"
time=2024-09-05T10:19:06Z level=debug msg=Invoked duration=32.666µs function="health.metricPublisher (.../hive/health/metrics.go:48)"
time=2024-09-05T10:19:06Z level=info msg=Starting
time="2024-09-05T10:19:06Z" level=info msg="Started gops server" address="127.0.0.1:9891" subsys=gops
time=2024-09-05T10:19:06Z level=debug msg="Executing start hook" function="gops.registerGopsHooks.func1 (pkg/gops/cell.go:43) (operator.operator-infra.gops)"
time="2024-09-05T10:19:06Z" level=fatal msg="failed to start: open /1: permission denied" subsys=cilium-operator-generic
time=2024-09-05T10:19:06Z level=error msg="Start hook failed" function="gops.registerGopsHooks.func1 (pkg/gops/cell.go:43) (operator.operator-infra.gops)" error="open /1: permission denied"
time=2024-09-05T10:19:06Z level=error msg="Start failed" error="open /1: permission denied" duration=96.376µs
time=2024-09-05T10:19:06Z level=info msg=Stopping
```