### PR TITLE
clustermesh/endpointslicesync: fix panic on failure in Test_meshEndpointSlice_Reconcile

### DIFF
--- a/pkg/clustermesh/endpointslicesync/endpointslice_test.go
+++ b/pkg/clustermesh/endpointslicesync/endpointslice_test.go
@@ -175,8 +175,8 @@ func Test_meshEndpointSlice_Reconcile(t *testing.T) {
 		var epList *discovery.EndpointSliceList
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			epList, err = getEndpointSlice(&fakeClient, svcName)
-			assert.NoError(t, err)
-			assert.Len(t, epList.Items, 1)
+			assert.NoError(c, err)
+			assert.Len(c, epList.Items, 1)
 		}, timeout, tick, "endpointslice is not reconciled correctly")
 
 		require.Equal(t, map[string]string{


### PR DESCRIPTION
When `require.EventuallyWithT` fails, due to not using the passed `*assert.CollectT` with the enclosed `assert` statements the test will continue running even if the conditions are not met. This leads to an index out of range panic in the successive `require.Equal` accessing `epList.Items[0]`.

Fixes: 6f9b8fd34bc4 ("clustermesh: use EventuallyWithT in endpointslicemeshsync")
Fixes: #34519