### PR TITLE
loader: de-dup LinkByName() calls for overlay / wireguard setup

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -308,7 +308,7 @@ func reinitializeOverlay(ctx context.Context, tunnelConfig tunnel.Config) error 
 		opts = append(opts, fmt.Sprintf("-DSECLABEL_IPV6=%d", identity.ReservedIdentityWorld))
 	}
 
-	if err := replaceOverlayDatapath(ctx, opts, iface); err != nil {
+	if err := replaceOverlayDatapath(ctx, opts, link); err != nil {
 		return fmt.Errorf("failed to load overlay programs: %w", err)
 	}
 
@@ -337,7 +337,7 @@ func reinitializeWireguard(ctx context.Context) (err error) {
 		fmt.Sprintf("-DCALLS_MAP=cilium_calls_wireguard_%d", identity.ReservedIdentityWorld),
 	}
 
-	if err := replaceWireguardDatapath(ctx, opts, wgTypes.IfaceName); err != nil {
+	if err := replaceWireguardDatapath(ctx, opts, link); err != nil {
 		return fmt.Errorf("failed to load wireguard programs: %w", err)
 	}
 	return

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -568,14 +568,9 @@ func reloadEndpoint(ep datapath.Endpoint, spec *ebpf.CollectionSpec) error {
 	return nil
 }
 
-func replaceOverlayDatapath(ctx context.Context, cArgs []string, iface string) error {
+func replaceOverlayDatapath(ctx context.Context, cArgs []string, device netlink.Link) error {
 	if err := compileOverlay(ctx, cArgs); err != nil {
 		return fmt.Errorf("compiling overlay program: %w", err)
-	}
-
-	device, err := netlink.LinkByName(iface)
-	if err != nil {
-		return fmt.Errorf("retrieving device %s: %w", iface, err)
 	}
 
 	spec, err := bpf.LoadCollectionSpec(overlayObj)
@@ -611,13 +606,9 @@ func replaceOverlayDatapath(ctx context.Context, cArgs []string, iface string) e
 	return nil
 }
 
-func replaceWireguardDatapath(ctx context.Context, cArgs []string, iface string) (err error) {
+func replaceWireguardDatapath(ctx context.Context, cArgs []string, device netlink.Link) (err error) {
 	if err := compileWireguard(ctx, cArgs); err != nil {
 		return fmt.Errorf("compiling wireguard program: %w", err)
-	}
-	device, err := netlink.LinkByName(iface)
-	if err != nil {
-		return fmt.Errorf("retrieving device %s: %w", iface, err)
 	}
 
 	spec, err := bpf.LoadCollectionSpec(wireguardObj)


### PR DESCRIPTION
Get rid of unnecessary error handling, and ensure that we operate on the same object.