### PR TITLE
ci: Confromance E2E wait for images before matrix generation

### DIFF
--- a/.github/actions/wait-for-images/action.yaml
+++ b/.github/actions/wait-for-images/action.yaml
@@ -1,0 +1,32 @@
+name: Wait for images
+description: Wait for images
+inputs:
+  SHA:
+    description: 'inputs.sha'
+    required: true
+    default: 'incorrect-sha'
+  images:
+    description: 'list of images to wait for'
+    required: false
+    default: 'cilium-ci operator-generic-ci hubble-relay-ci cilium-cli-ci'
+runs:
+  using: composite
+  steps:
+    - name: Set environment variables
+      uses: ./.github/actions/set-env-variables
+    - name: Wait for images
+      shell: bash
+      run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          SHA="${{ inputs.SHA }}"
+        else
+          SHA="${{ github.sha }}"
+        fi
+
+        for image in ${{ inputs.images }} ; do
+          until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:$SHA &> /dev/null
+          do
+            echo "Waiting for quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:$SHA image to become available..."
+            sleep 45s
+          done
+        done

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -78,7 +78,23 @@ jobs:
         with:
           sha: ${{ inputs.SHA || github.sha }}
 
+  wait-for-images:
+    name: Wait for images
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+      - name: Wait for images
+        uses: ./.github/actions/wait-for-images
+        with:
+          SHA: ${{ inputs.SHA }}
+
   setup-and-test:
+    needs: [wait-for-images]
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER }}
     name: 'Setup & Test'
     env:
@@ -434,14 +450,6 @@ jobs:
           sparse-checkout: |
             install/kubernetes/cilium
             examples
-
-      - name: Wait for images to be available
-        timeout-minutes: 30
-        shell: bash
-        run: |
-          for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
-          done
 
       - name: Install Cilium
         shell: bash


### PR DESCRIPTION
Small improvement to reduce Github runners' time.

Example run: https://github.com/cilium/cilium/actions/runs/10722552842/job/29733789520
Also adds nice logging to see for which image we are waiting for:
```
Waiting for quay.io/cilium/cilium-ci:7962b12f51e0da78455c3528580a32e360aa4f53 image to become available...
Waiting for quay.io/cilium/cilium-ci:7962b12f51e0da78455c3528580a32e360aa4f53 image to become available...
Waiting for quay.io/cilium/cilium-ci:7962b12f51e0da78455c3528580a32e360aa4f53 image to become available...
Waiting for quay.io/cilium/cilium-cli-ci:7962b12f51e0da78455c3528580a32e360aa4f53 image to become available...
Waiting for quay.io/cilium/cilium-cli-ci:7962b12f51e0da78455c3528580a32e360aa4f53 image to become available...
Waiting for quay.io/cilium/cilium-cli-ci:7962b12f51e0da78455c3528580a32e360aa4f53 image to become available...
```

I will follow up with other workflows if this approach seems reasonable. 
We will also need some improvements for upgrade/downgrade workflows.