### PR TITLE
ipsec: Remove deprecated upgrade code

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -327,6 +327,8 @@ communicating via the proxy must reconnect to re-establish connections.
   Cilium itself. This support, which had been previously deprecated as complicated
   and error prone, has now been removed. Refer to :ref:`k8s_install_etcd` for
   alternatives for running Cilium with Etcd.
+* For IPsec, support for a single key has been removed. Per-tunnel keys will
+  now be used regardless of the presence of the ``+`` sign in the secret.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -394,7 +394,7 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, nodeID uint1
 	var spi uint8
 	var errs error
 
-	errs = errors.Join(errs, ipsec.IPsecDefaultDropPolicy(n.log, false))
+	errs = errors.Join(errs, ipsec.IPsecDefaultDropPolicy(false))
 	errs = errors.Join(errs, upsertIPsecLog(n.log, errs, "default-drop IPv4", wildcardCIDR, wildcardCIDR, spi, 0))
 
 	// If we are the local node, we have much less work to do, handle this first.
@@ -588,7 +588,7 @@ func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, nodeID uint1
 	var errs error
 	var spi uint8
 
-	errs = errors.Join(errs, ipsec.IPsecDefaultDropPolicy(n.log, true))
+	errs = errors.Join(errs, ipsec.IPsecDefaultDropPolicy(true))
 	errs = errors.Join(errs, upsertIPsecLog(n.log, errs, "default-drop IPv6", wildcardCIDR, wildcardCIDR, spi, 0))
 
 	if newNode.IsLocal() {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -7,7 +7,6 @@ package ipsec
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"crypto/sha512"
@@ -20,7 +19,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -196,11 +194,6 @@ var (
 		Priority: defaultDropPriority,
 	}
 
-	// To attempt to remove any stale XFRM configs once at startup, after
-	// we've added the catch-all default-drop policy.
-	removeStaleIPv4XFRMOnce sync.Once
-	removeStaleIPv6XFRMOnce sync.Once
-
 	oldXFRMInMark *netlink.XfrmMark = &netlink.XfrmMark{
 		Value: linux_defaults.RouteMarkDecrypt,
 		Mask:  linux_defaults.IPsecMarkBitMask,
@@ -368,23 +361,10 @@ func xfrmStateReplace(log *slog.Logger, new *netlink.XfrmState, remoteRebooted b
 	// Check if the XFRM state already exists
 	for _, s := range states {
 		if xfrmIPEqual(s.Src, new.Src) && xfrmIPEqual(s.Dst, new.Dst) &&
-			xfrmMarkEqual(s.Mark, new.Mark) && s.Spi == new.Spi {
-			if !xfrmKeyEqual(&s, new) {
-				// The states are the same, including the SPI, but the
-				// encryption key changed. This is expected on upgrade because
-				// we changed the way we compute the per-node-pair key.
-				scopedLog.Info("Removing XFRM state with old IPsec key")
-				xfrmStateCache.XfrmStateDel(&s)
-				break
-			}
-			if !xfrmMarkEqual(s.OutputMark, new.OutputMark) {
-				// If only the output-marks differ, then we should be able
-				// to simply update the XFRM state atomically.
-				return xfrmStateCache.XfrmStateUpdate(new)
-			}
-			if remoteRebooted && new.ESN {
-				// This should happen only when a node reboots when the boot ID
-				// is used to compute the key (i.e., if ESN is also enabled).
+			xfrmMarkEqual(s.Mark, new.Mark) && xfrmMarkEqual(s.OutputMark, new.OutputMark) &&
+			s.Spi == new.Spi {
+			if remoteRebooted {
+				// This should happen only when a node reboots.
 				// We can safely perform a non-atomic swap of the XFRM state
 				// for both the IN and OUT directions because:
 				// - For the IN direction, we can't leak anything. At most
@@ -514,20 +494,6 @@ func xfrmMarkEqual(mark1, mark2 *netlink.XfrmMark) bool {
 		return false
 	}
 	return mark1 == nil || (mark1.Value == mark2.Value && mark1.Mask == mark2.Mask)
-}
-
-// Returns true if the two XFRM states have the same encryption key.
-func xfrmKeyEqual(s1, s2 *netlink.XfrmState) bool {
-	if (s1.Aead == nil) != (s2.Aead == nil) ||
-		(s1.Crypt == nil) != (s2.Crypt == nil) ||
-		(s1.Auth == nil) != (s2.Auth == nil) {
-		return false
-	}
-	if s1.Aead != nil {
-		return bytes.Equal(s1.Aead.Key, s2.Aead.Key)
-	}
-	return bytes.Equal(s1.Crypt.Key, s2.Crypt.Key) &&
-		bytes.Equal(s1.Auth.Key, s2.Auth.Key)
 }
 
 func ipSecReplaceStateIn(log *slog.Logger, params *IPSecParameters) (uint8, error) {
@@ -663,52 +629,15 @@ func IpSecReplacePolicyFwd(params *IPSecParameters) error {
 //
 // We do need to match on the mark because there is also traffic flowing
 // through XFRM that we don't want to encrypt (e.g., hostns traffic).
-func IPsecDefaultDropPolicy(log *slog.Logger, ipv6 bool) error {
-	log = log.With(logfields.LogSubsys, subsystem)
-
+func IPsecDefaultDropPolicy(ipv6 bool) error {
 	defaultDropPolicy := defaultDropPolicyIPv4
-	family := netlink.FAMILY_V4
 	if ipv6 {
 		defaultDropPolicy = defaultDropPolicyIPv6
-		family = netlink.FAMILY_V6
 	}
 
 	err := netlink.XfrmPolicyUpdate(defaultDropPolicy)
 
-	// We move the old XFRM OUT policy. This code can be removed in Cilium v1.17.
-	removeStaleXFRMOnce := &removeStaleIPv4XFRMOnce
-	if ipv6 {
-		removeStaleXFRMOnce = &removeStaleIPv6XFRMOnce
-	}
-	removeStaleXFRMOnce.Do(func() {
-		removeOldOutPolicy(log, family)
-	})
-
 	return err
-}
-
-// Removes the old XFRM OUT policy. We rely on the mark mask and its lower
-// priority to identify it. We can rely on the priority because it was lowered
-// to a specific number in a previous upgrade.
-func removeOldOutPolicy(log *slog.Logger, family int) {
-	policies, err := safenetlink.XfrmPolicyList(family)
-	if err != nil {
-		log.Error("Cannot get XFRM policies", logfields.Error, err)
-	}
-	for _, p := range policies {
-		if p.Dir == netlink.XFRM_DIR_OUT && p.Priority == oldXFRMOutPolicyPriority &&
-			p.Mark.Mask == linux_defaults.IPsecOldMarkMaskOut {
-			if err := netlink.XfrmPolicyDel(&p); err != nil {
-				log.Error("Failed to remove old XFRM policy",
-					logfields.Error, err,
-					logfields.SourceCIDR, p.Src,
-					logfields.DestinationCIDR, p.Dst,
-					logfields.TrafficDirection, getDirFromXfrmMark(p.Mark),
-					logfields.NodeID, getNodeIDAsHexFromXfrmMark(p.Mark),
-				)
-			}
-		}
-	}
 }
 
 // ipSecXfrmMarkSetSPI takes a XfrmMark base value, an SPI, returns the mark

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -114,25 +114,21 @@ func TestParseSPI(t *testing.T) {
 		input    string
 		expSPI   uint8
 		expOff   int
-		expESN   bool
 		expError bool
 	}{
-		{"254", 0, 0, false, true},
-		{"15", 15, 0, false, false},
-		{"3+", 3, 0, true, false},
-		{"abc", 0, 0, false, true},
-		{"0", 0, 0, false, true},
+		{"254", 0, 0, true},
+		{"15", 15, 0, false},
+		{"3+", 3, 0, false},
+		{"abc", 0, 0, true},
+		{"0", 0, 0, true},
 	}
 	for _, tc := range testCases {
-		spi, off, esn, err := parseSPI(log, tc.input)
+		spi, off, err := parseSPI(log, tc.input)
 		if spi != tc.expSPI {
 			t.Fatalf("For input %q, expected SPI %d, but got %d", tc.input, tc.expSPI, spi)
 		}
 		if off != tc.expOff {
 			t.Fatalf("For input %q, expected base offset %d, but got %d", tc.input, tc.expOff, off)
-		}
-		if esn != tc.expESN {
-			t.Fatalf("For input %q, expected ESN %t, but got %t", tc.input, tc.expESN, esn)
 		}
 		if tc.expError {
 			require.Error(t, err)

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -126,12 +126,8 @@ const (
 	// IPsecMarkBitMask is the mask used for the encrypt and decrypt bits.
 	IPsecMarkBitMask = 0x0F00
 
-	// IPsecOldMarkMaskOut is the mask that was previously used. It can be
-	// removed in Cilium v1.17.
-	IPsecOldMarkMaskOut = 0xFF00
-
 	// IPsecMarkMask is the mask required for the IPsec SPI, node ID, and encrypt/decrypt bits
-	IPsecMarkMaskOut = IPsecOldMarkMaskOut | IPsecMarkMaskNodeID
+	IPsecMarkMaskOut = 0xFF00 | IPsecMarkMaskNodeID
 
 	// IPsecMarkMaskIn is the mask required for the IPsec node ID and encrypt/decrypt bits
 	IPsecMarkMaskIn = IPsecMarkBitMask | IPsecMarkMaskNodeID


### PR DESCRIPTION
The first commit removes support for the global-key system in IPsec, which had been deprecated in v1.16. The second commit removes IPsec upgrade logic that isn't needed anymore. The third commit fixes the unit tests to support the per-tunnel-keys system.

```release-note
Remove support for the insecure, deprecated global IPsec key. Per-tunnel IPsec keys will now be used regardless of the IPsec secret format.
```