### PR TITLE
ci: clean disk only on ubuntu-latest runners

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -84,6 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup Disk space in runner
+        if: runner.name == 'ubuntu-latest'
         uses: ./.github/actions/disk-cleanup
 
       - name: Set Environment Variables

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -360,6 +360,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup Disk space in runner
+        if: runner.name == 'ubuntu-latest'
         uses: ./.github/actions/disk-cleanup
 
       - name: Set Environment Variables

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -261,6 +261,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup Disk space in runner
+        if: runner.name == 'ubuntu-latest'
         uses: ./.github/actions/disk-cleanup
 
       - name: Set Environment Variables

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -212,6 +212,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup Disk space in runner
+        if: runner.name == 'ubuntu-latest'
         uses: ./.github/actions/disk-cleanup
 
       - name: Set Environment Variables

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -101,6 +101,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup Disk space in runner
+        if: runner.name == 'ubuntu-latest'
         uses: ./.github/actions/disk-cleanup
 
       - name: Set Environment Variables

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -358,6 +358,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup Disk space in runner
+        if: runner.name == 'ubuntu-latest'
         uses: ./.github/actions/disk-cleanup
 
       - name: Set Environment Variables

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -198,6 +198,7 @@ jobs:
           persist-credentials: true
 
       - name: Cleanup Disk space in runner
+        if: runner.name == 'ubuntu-latest'
         uses: ./.github/actions/disk-cleanup
 
       - name: Set Environment Variables


### PR DESCRIPTION
As these workflows can pick type of runner to run on, when running on instance ubuntu-latest-4cores-16gb it's not required to clean up disk as it has 150GB of disk.
