### PR TITLE
AUTHORS: fix duplicate entries

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -41,6 +41,7 @@ Darren Mackintosh <unixdaddy@gmail.com>
 Darshan Chaudhary <deathbullet@gmail.com>
 David Chen <davidchen94@outlook.com> <yudechen@google.com>
 David Cheng <david.cheng@shopline.com>
+David Chosrova <dchosrova@gmail.com> David CHOSROVA <dchosrova@gmail.com>
 Dawn <lx1960753013@gmail.com>
 Devarshi Sathiya <devarshisathiya5@gmail.com>
 Divine Odazie <dodazie@gmail.com>
@@ -95,6 +96,8 @@ Madhu Challa <challa@gmail.com>
 Mahadev Panchal <mahadev.panchal@accuknox.com>
 Mandar U Jog <mjog@google.com> <mandarjog@gmail.com>
 Marc Stulz <m@footek.ch>
+Marcel Zięba <marcel.zieba@isovalent.com> Marcel Zieba <marseel@gmail.com>
+Marcel Zięba <marcel.zieba@isovalent.com> Marcel Zieba <marcel.zieba@isovalent.com>
 Matthew Gumport <me@gum.pt>
 Maxime Visonneau <maxime.visonneau@gmail.com>
 Michael Kashin <mmkashin@gmail.com>
@@ -138,6 +141,8 @@ Tony Lu <tonylu@linux.alibaba.com>
 Trevor Tao <trevor.tao@arm.com>
 Vance Li <vanceli@tencent.com> <liyannois@gmail.com>
 Vance Li <vanceli@tencent.com> vanceli <vanceli@tencent.com>
+Viktor Kurchenko <viktor.kurchenko@isovalent.com> viktor-kurchenko <viktor.kurchenko@isovalent.com>
+Viktor Kurchenko <viktor.kurchenko@isovalent.com> viktor-kurchenko <69600804+viktor-kurchenko@users.noreply.github.com>
 Ville Ojamo <bluikko@users.noreply.github.com> <14869000+bluikko@users.noreply.github.com>
 Vlad Ungureanu <vladu@palantir.com> <ungureanuvladvictor@gmail.com>
 Vipul Singh <vipul21sept@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -163,6 +163,7 @@ Christoph Puhl                          cpu@isovalent.com
 Chris Werner Rau                        cwrau@cwrau.info
 ChrsMark                                chrismarkou92@gmail.com
 Cilium Imagebot                         noreply@cilium.io
+Cilium Release Bot                      noreply@cilium.io
 Cintia Sanchez Garcia                   cynthiasg@icloud.com
 CJ Virtucio                             cjv287@gmail.com
 Claudia J. Kang                         claudiajkang@gmail.com
@@ -207,7 +208,6 @@ David Bouchare                          david.bouchare@datadoghq.com
 David Calvert                           david@0xdc.me
 David Cheng                             david.cheng@shopline.com
 David Chosrova                          dchosrova@gmail.com
-David CHOSROVA                          dchosrova@gmail.com
 David Donchez                           donch@dailymotion.com
 David Korczynski                        david@adalogics.com
 David Leadbeater                        dgl@dgl.cx
@@ -506,8 +506,7 @@ Manuel Rüger                            manuel@rueg.eu
 Manuel Stößel                           manuel.stoessel@t-systems.com
 Marc Barry                              4965634+marc-barry@users.noreply.github.com
 Marcelo Moreira de Mello                tchello.mello@gmail.com
-Marcel Zieba                            marcel.zieba@isovalent.com
-Marcel Zięba                            marseel@gmail.com
+Marcel Zięba                            marcel.zieba@isovalent.com
 Marcin Skarbek                          git@skarbek.name
 Marcin Swiderski                        forgems@gmail.com
 Marco Aurelio Caldas Miranda            17923899+macmiranda@users.noreply.github.com
@@ -842,7 +841,6 @@ vakr                                    vakr@microsoft.com
 Valas Valancius                         valas@google.com
 Vance Li                                vanceli@tencent.com
 Vigneshwaren Sunder                     vickymailed@gmail.com
-viktor-kurchenko                        viktor.kurchenko@isovalent.com
 Viktor Kurchenko                        viktor.kurchenko@isovalent.com
 Viktor Kuzmin                           kvaster@gmail.com
 Viktor Oreshkin                         imselfish@stek29.rocks


### PR DESCRIPTION
Those entries were caused by the merging of cilium-cli repository into cilium/cilium. With some changes in the .mailmap we are able to remove the duplicates from AUTHORS.
