### PR TITLE
ipcache: Yet another refcounting fix with mix of APIs

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -30,36 +30,58 @@ import (
 
 // Identity is the identity representation of an IP<->Identity cache.
 type Identity struct {
-	// ID is the numeric identity
-	ID identity.NumericIdentity
+	// Note: The ordering of these fields is optimized to reduce padding
 
 	// Source is the source of the identity in the cache
 	Source source.Source
+
+	// overwrittenLegacySource contains the source of the original entry created
+	// via legacy API. This is preserved so that original source can be restored
+	// if the metadata API stops managing the entry.
+	overwrittenLegacySource source.Source
+
+	// ID is the numeric identity
+	ID identity.NumericIdentity
 
 	// This blank field ensures that the == operator cannot be used on this
 	// type, to avoid external packages accidentally comparing the private
 	// values below
 	_ []struct{}
 
+	// modifiedByLegacyAPI indicates that this entry touched by the legacy Upsert API.
+	// This informs the metadata subsystem to retain the original source and
+	// to clean up the entry if the legacy API already dropped its reference.
+	// upsertLocked will ensure that this field remains true once set. In other
+	// words, there is no way unset this field once set.
+	// This field is intended to be removed once cilium/cilium#21142 has been
+	// fully implemented and all entries are created via the new metadata API
+	modifiedByLegacyAPI bool
+
 	// shadowed determines if another entry overlaps with this one.
 	// Shadowed identities are not propagated to listeners by default.
 	// Most commonly set for Identity with Source = source.Generated when
 	// a pod IP (other source) has the same IP.
 	shadowed bool
-
-	// createdFromMetadata indicates that this entry was created via the new
-	// metadata API. This is needed to know if it is safe to delete
-	// an IPCache entry when no further metadata is associated with its prefix.
-	// This field is intended to be removed once cilium/cilium#21142 has been
-	// fully implemented and all entries are created via the new metadata API
-	createdFromMetadata bool
 }
 
 func (i Identity) equals(o Identity) bool {
 	return i.ID == o.ID &&
 		i.Source == o.Source &&
 		i.shadowed == o.shadowed &&
-		i.createdFromMetadata == o.createdFromMetadata
+		i.modifiedByLegacyAPI == o.modifiedByLegacyAPI &&
+		i.overwrittenLegacySource == o.overwrittenLegacySource
+}
+
+func (i Identity) exclusivelyOwnedByLegacyAPI() bool {
+	return i.modifiedByLegacyAPI && i.overwrittenLegacySource == ""
+}
+
+func (i Identity) exclusivelyOwnedByMetadataAPI() bool {
+	return !i.modifiedByLegacyAPI
+}
+
+func (i Identity) ownedByLegacyAndMetadataAPI() bool {
+	return i.modifiedByLegacyAPI && i.overwrittenLegacySource != ""
 }
 
 // IPKeyPair is the (IP, key) pair used of the identity
@@ -260,7 +282,7 @@ func (ipc *IPCache) getK8sMetadata(ip string) *K8sMetadata {
 func (ipc *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8sMetadata, newIdentity Identity) (namedPortsChanged bool, err error) {
 	ipc.mutex.Lock()
 	defer ipc.mutex.Unlock()
-	return ipc.upsertLocked(ip, hostIP, hostKey, k8sMeta, newIdentity, false /* !force */)
+	return ipc.upsertLocked(ip, hostIP, hostKey, k8sMeta, newIdentity, false /* !force */, true /* fromLegacyAPI */)
 }
 
 // upsertLocked adds / updates the provided IP and identity into the IPCache,
@@ -285,6 +307,7 @@ func (ipc *IPCache) upsertLocked(
 	k8sMeta *K8sMetadata,
 	newIdentity Identity,
 	force bool,
+	fromLegacyAPI bool,
 ) (namedPortsChanged bool, err error) {
 	var newNamedPorts types.NamedPortMap
 	if k8sMeta != nil {
@@ -317,10 +340,45 @@ func (ipc *IPCache) upsertLocked(
 
 	cachedIdentity, found := ipc.ipToIdentityCache[ip]
 	if found {
+		// If this is a legacy upsert call,  then we need to make sure that the
+		// overwrittenLegacySource is updated
+		if fromLegacyAPI {
+			switch {
+			case cachedIdentity.exclusivelyOwnedByMetadataAPI():
+				// If the entry was exclusively owned by the metadata API, then we
+				// want to preserve our source as the legacy source (so it can be
+				// restored by the metadata API later) - even if our upsert call is
+				// later rejected due to it being a low-precedence upsert.
+				newIdentity.overwrittenLegacySource = newIdentity.Source
+			case cachedIdentity.ownedByLegacyAndMetadataAPI():
+				// If the entry is owned by both APIs, then it will have overwrittenLegacySource
+				// already set. Thus, check if we should update it, otherwise just preserve it as is.
+				if source.AllowOverwrite(cachedIdentity.overwrittenLegacySource, newIdentity.Source) {
+					newIdentity.overwrittenLegacySource = newIdentity.Source
+				} else {
+					newIdentity.overwrittenLegacySource = cachedIdentity.overwrittenLegacySource
+				}
+			}
+		}
+
+		// Here we track if an entry was previously created via new asynchronous
+		// UpsertMetadata API or the old synchronous Upsert call and preserve that bit
+		if fromLegacyAPI || cachedIdentity.modifiedByLegacyAPI {
+			newIdentity.modifiedByLegacyAPI = true
+		}
+
 		if !force && !source.AllowOverwrite(cachedIdentity.Source, newIdentity.Source) {
 			metrics.IPCacheErrorsTotal.WithLabelValues(
 				metricTypeUpsert, metricErrorOverwrite,
 			).Inc()
+
+			// Even if this update is rejected, we want to update the modifiedByLegacyAPI
+			// and overwrittenLegacySource fields in case the low precedence source here
+			// needs to be restored later
+			cachedIdentity.modifiedByLegacyAPI = newIdentity.modifiedByLegacyAPI
+			cachedIdentity.overwrittenLegacySource = newIdentity.overwrittenLegacySource
+			ipc.ipToIdentityCache[ip] = cachedIdentity
+
 			return false, NewErrOverwrite(cachedIdentity.Source, newIdentity.Source)
 		}
 
@@ -334,16 +392,10 @@ func (ipc *IPCache) upsertLocked(
 			return false, nil
 		}
 
-		// Here we track if an entry was created via new asynchronous
-		// UpsertMetadata API or the old synchronous Upsert call.
-		// If an entry is ever touched via the old Upsert API, we want to keep
-		// createdFromMetadata set to false, and require that the entry
-		// manually is deleted via the Delete function.
-		if !cachedIdentity.createdFromMetadata {
-			newIdentity.createdFromMetadata = false
-		}
-
 		oldIdentity = &cachedIdentity
+	} else if fromLegacyAPI {
+		// If this is a new entry, inserted via legacy API, then track it as such
+		newIdentity.modifiedByLegacyAPI = true
 	}
 
 	// Endpoint IP identities take precedence over CIDR identities, so if the

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -295,7 +295,7 @@ func (ipc *IPCache) upsertLocked(
 	if option.Config.Debug {
 		scopedLog = log.WithFields(logrus.Fields{
 			logfields.IPAddr:   ip,
-			logfields.Identity: newIdentity,
+			logfields.Identity: &newIdentity,
 			logfields.Key:      hostKey,
 		})
 		if k8sMeta != nil {

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -361,13 +361,33 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 				break
 			}
 
-			// We can safely skip the ipcache upsert if the entry matches with
-			// the entry in the metadata cache exactly.
-			// Note that checking ID alone is insufficient, see GH-24502.
-			if oldID.ID == newID.ID && prefixInfo.Source() == oldID.Source &&
-				oldTunnelIP.Equal(prefixInfo.TunnelPeer().IP()) &&
-				oldEncryptionKey == prefixInfo.EncryptKey().Uint8() {
-				goto releaseIdentity
+			var newOverwrittenLegacySource source.Source
+			if entryExists {
+				// If an entry already exists for this prefix, then we want to
+				// retain its source, if it has been modified by the legacy API.
+				// This allows us to restore the original source if we remove all
+				// metadata for the prefix
+				switch {
+				case oldID.exclusivelyOwnedByLegacyAPI():
+					// This is the first time we have associated metadata for a
+					// modifiedByLegacyAPI=true entry. Store the old (legacy) source:
+					newOverwrittenLegacySource = oldID.Source
+				case oldID.ownedByLegacyAndMetadataAPI():
+					// The entry has modifiedByLegacyAPI=true, but has already been
+					// updated at least once by the metadata API. Retain the legacy
+					// source as is.
+					newOverwrittenLegacySource = oldID.overwrittenLegacySource
+				}
+
+				// We can safely skip the ipcache upsert if the entry matches with
+				// the entry in the metadata cache exactly.
+				// Note that checking ID alone is insufficient, see GH-24502.
+				if oldID.ID == newID.ID && prefixInfo.Source() == oldID.Source &&
+					oldID.overwrittenLegacySource == newOverwrittenLegacySource &&
+					oldTunnelIP.Equal(prefixInfo.TunnelPeer().IP()) &&
+					oldEncryptionKey == prefixInfo.EncryptKey().Uint8() {
+					goto releaseIdentity
+				}
 			}
 
 			// If this ID was newly allocated, we must add it to the SelectorCache
@@ -376,9 +396,11 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 			}
 			entriesToReplace[prefix] = ipcacheEntry{
 				identity: Identity{
-					ID:                  newID.ID,
-					Source:              prefixInfo.Source(),
-					createdFromMetadata: true,
+					ID:                      newID.ID,
+					Source:                  prefixInfo.Source(),
+					overwrittenLegacySource: newOverwrittenLegacySource,
+					// Note: `modifiedByLegacyAPI` and `shadowed` will be
+					// set by the upsert call itself
 				},
 				tunnelPeer: prefixInfo.TunnelPeer().IP(),
 				encryptKey: prefixInfo.EncryptKey().Uint8(),
@@ -401,14 +423,14 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 			// allocation from the prior InjectLabels() call by
 			// releasing the previous reference.
 			entry, entryToBeReplaced := entriesToReplace[prefix]
-			if !oldID.createdFromMetadata && entryToBeReplaced {
+			if oldID.exclusivelyOwnedByLegacyAPI() && entryToBeReplaced {
 				// If the previous ipcache entry for the prefix
 				// was not managed by this function, then the
 				// previous ipcache user to inject the IPCache
 				// entry retains its own reference to the
 				// Security Identity. Given that this function
-				// is going to assume responsibility for the
-				// IPCache entry now, this path must retain its
+				// is going to assume (non-exclusive) responsibility
+				// for the IPCache entry now, this path must retain its
 				// own reference to the Security Identity to
 				// ensure that if the other owner ever releases
 				// their reference, this reference stays live.
@@ -427,13 +449,40 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 			// subsystem using the old Upsert API, then we can safely remove
 			// the IPCache entry associated with this prefix.
 			if prefixInfo == nil {
-				if oldID.createdFromMetadata {
+				if oldID.exclusivelyOwnedByMetadataAPI() {
 					entriesToDelete[prefix] = oldID
-				} else {
+				} else if oldID.ownedByLegacyAndMetadataAPI() {
 					// If, on the other hand, this prefix *was* touched by
-					// another, Upsert-based system, flag this prefix as
-					// potentially eligible for deletion if all references
-					// are removed.
+					// another, Upsert-based system, then we want to restore
+					// the original (legacy) source. This ensures that the legacy
+					// Delete call (with the legacy source) will be able to remove
+					// it.
+					unmanagedEntry := ipcacheEntry{
+						identity: Identity{
+							ID:                  oldID.ID,
+							Source:              oldID.overwrittenLegacySource,
+							modifiedByLegacyAPI: true,
+						},
+						tunnelPeer: oldTunnelIP,
+						encryptKey: oldEncryptionKey,
+						force:      true, /* overwrittenLegacySource is lower precedence */
+					}
+					entriesToReplace[prefix] = unmanagedEntry
+
+					// In addition, flag this prefix as potentially eligible
+					// for deletion if all references are removed (i.e. the legacy
+					// Delete call already happened).
+					unmanagedPrefixes[prefix] = unmanagedEntry.identity
+
+					if option.Config.Debug {
+						log.WithFields(logrus.Fields{
+							logfields.Prefix:      prefix,
+							logfields.OldIdentity: oldID.ID,
+						}).Debug("Previously managed IPCache entry is now unmanaged")
+					}
+				} else if oldID.exclusivelyOwnedByLegacyAPI() {
+					// Even if we never actually overwrote the legacy-owned
+					// entry, we should still remove it if all references are removed.
 					unmanagedPrefixes[prefix] = oldID
 				}
 			}
@@ -478,6 +527,7 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 			meta,
 			entry.identity,
 			entry.force,
+			/* fromLegacyAPI */ false,
 		); err2 != nil {
 			// It's plausible to pull the same information twice
 			// from different sources, for instance in etcd mode


### PR DESCRIPTION
The internal use of IPCache has two APIs:

  - An older synchronous API (`AllocateCIDRs`/`ReleaseCIDRIdentitiesByCIDR`), which requires the caller to balance allocate and release calls.
  - A newer asynchronous API (`UpsertPrefixes`/`RemovePrefixes`), which delegates the reference counting responsibility to the ipcache itself.

Cilium v1.14 and v1.15 use a mix of the two APIs for CIDR identities, which historically has led to issues. See https://github.com/cilium/cilium/pull/27327 or https://github.com/cilium/cilium/pull/33120 for example. Cilium v1.16 and newer do not have these issues anymore, but the codepaths still exist. To ensure consistency across branches, this commit will be applied to all branches. 

This commit fixes two particular issues with the asynchronous API when an entry has been created by the legacy API.

## Issue 1: Legacy API leaks mixed-API IPCache entry

This issue can happen if an entry is first created via the legacy API, then overwritten by the metadata API. Consider the following sequence of events for a prefix `p`:

  1. `AllocateCIDRs(p)`: This inserts an IPCache entry for prefix `p` with source `generated`. The identity has now a refcount of one.
  2. `UpsertPrefixes(p, "custom-resource")`: This bumps the identity refcount to two and overwrites the IPCache entry for prefix `p` with source `custom-resource`
  3. `RemovePrefixes(p, "custom-resource")`: This decreases the identity refcount down to one again, but retains the existing IPCache entry with source `custom-resource` (it does not delete the entry if the identity refcount is non-zero).
  4. `ReleaseCIDRs(p)`: This decreases the identity refcount, making it reach zero. It attempts to remove the IPCache entry for source `generated`. But because `generated` has lower precedence than `custom-resource`, the deletion fails and the IPCache entry is leaked.

## Issue 2: Metadata API causes early release of mixed-API entry identities

Assuming all entries are managed by the metadata API, `InjectLabels` attempts to balance the identity reference count for managed identities by perform an identity allocation call for any to-be-upserted identity, followed by an allocation release call for any to-be-overwritten identity.

However, if the existing entry was created by the legacy API, then `InjectLabels` must not release the old identity (as this is the responsibility of the legacy API owner). PR https://github.com/cilium/cilium/pull/27327 added such logic which will skip identity release if two conditions are satisfied:

  1. The old entry was not created via the metadata API
  2. The old entry is about to be replaced by a new one (e.g. it has a new source).

However, because `RemovePrefixes` does not restore the legacy source as describe in Issue 1 above, the second condition is insufficient. Consider the following sequence of events:

  1. `AllocateCIDRs(p)`: refcount=1, source=generated
  2. `UpsertPrefixes(p, "custom-resource")`: refcount=2, source=custom-resource
  3. `RemovePrefixes(p, "custom-resource")`: refcount=1, source=custom-resource (!)
  4. `UpsertPrefixes(p, "custom-resource")`: refcount=1 (because condition 2 is not hit), source=custom-resource
  5. `ReleaseCIDRs(p)`: refcount=0. The identity is released early (it should have been kept alive due to it having associated metadata from step 3), while the IPCache entry is leaked (because the source of      the entry is `custom-resource`, see Issue 1).

## Proposed Solution

Both issues stem from the fact that our tracking of mixed API entries via `createdFromMetadata` is insufficient. A boolean cannot distinguish between the three states we actually have:

 1. The entry is exclusively owned by the legacy API
 2. The entry is exclusively owned by the metadata API
 3. The entry is is shared both APIs

These three states are kept track by two private fields in the IPCache entry:

 - A `modifiedByLegacyAPI` field which is set to true if the entry was ever touched by the legacy API.
 - A `overwrittenLegacySource` field which tracks the original source of the legacy entry before it was overwritten by a metadata API source

If neither fields are set, the entry is assumed to be exclusively owned by the metadata API. If only `modifiedByLegacyAPI=true`, then it is assumed to be exclusively owned by the legacy API. If both fields are set, then it is assumed to be shared by both APIs.

Note that once an entry has `modifiedByLegacyAPI=true`, it will never become false until deleted. This simplifies the code, as the metadata API already has the ability to clean up unmanaged entries.

The state diagram and actions between the state can then be described as follows:

```mermaid
stateDiagram-v2

    both: Shared Ownership
    metadata: Owned by Metadata API
    legacy : Owned by Legacy API
    released: Released

    [*] --> metadata: UpsertPrefixes()
    [*] --> legacy: AllocateCIDRs()
    legacy --> both: UpsertPrefixes() - bump refcount, use metadata source
    both --> legacy: RemovePrefixes() - decrease refcount, restore legacy source
    metadata --> both: AllocateCIDR() - bump refcount, taint entry, use higher precedence source
    legacy --> released: ReleaseCIDRs() - decrease refcount, remove entry if refcount=0
    both --> released: RemovePrefixes() - decrease refcount, remove entry if refcount=0
    metadata --> released: RemovePrefixes() - decrease refcount, remove entry if refcount=0
```

Issue 1 is fixed thanks to the transition `both --> legacy` which now restores the legacy source in in the call to `RemovePrefixes`.

Issue 2 is fixed thanks to the fact that we can now detect the transition `both --> legacy --> both`, which was previously impossible.