### PR TITLE
route: fix LogAttrs panic if NextHop is nil

### DIFF
--- a/pkg/datapath/linux/route/route.go
+++ b/pkg/datapath/linux/route/route.go
@@ -29,9 +29,14 @@ type Route struct {
 // LogAttrs returns the route attributes as slog attributes.
 // The return type is []any to match with signature of With().
 func (r *Route) LogAttrs() []any {
+	nexthop := "<nil>"
+	if r.Nexthop != nil {
+		nexthop = r.Nexthop.String()
+	}
+
 	return []any{
 		slog.String("prefix", r.Prefix.String()),
-		slog.String("nexthop", r.Nexthop.String()),
+		slog.String("nexthop", nexthop),
 		slog.String("local", r.Local.String()),
 		slog.String(logfields.Interface, r.Device),
 	}


### PR DESCRIPTION
Avoid calling String on the NextHop field when nil, as it would cause a panic (because the String method takes a value receiver).

Fixes: 698026d0155d ("linux: Switch linuxNodeHandler to use slog")

<!-- Description of change -->

```release-note
Fix possible panic occurring in case errors are returned while updating/deleting IPv6 routes 
```
