### PR TITLE
Clean up FQDN cache before test scenarios that use DNS proxy

### DIFF
--- a/cilium-cli/connectivity/builder/client_egress_l7.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7.go
@@ -30,6 +30,7 @@ func clientEgressL7Test(ct *check.ConnectivityTest, templates map[string]string,
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithCiliumPolicy(clientEgressOnlyDNSPolicyYAML). // DNS resolution only
 		WithCiliumPolicy(templates[templateName]).       // L7 allow policy with HTTP introspection
+		WithCleanFqdnCache().
 		WithScenarios(
 			tests.PodToPod(),
 			tests.PodToWorld(tests.WithRetryDestPort(80), tests.WithRetryPodLabel("other", "client")),

--- a/cilium-cli/connectivity/builder/client_egress_l7_method.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_method.go
@@ -38,6 +38,7 @@ func clientEgressL7MethodTest(ct *check.ConnectivityTest, portRanges bool) {
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithCiliumPolicy(clientEgressOnlyDNSPolicyYAML). // DNS resolution only
 		WithCiliumPolicy(yamlFile).                      // L7 allow policy with HTTP introspection (POST only)
+		WithCleanFqdnCache().
 		WithScenarios(
 			tests.PodToPodWithEndpoints(tests.WithMethod("POST"), tests.WithDestinationLabelsOption(map[string]string{"other": "echo"})),
 			tests.PodToPodWithEndpoints(tests.WithDestinationLabelsOption(map[string]string{"first": "echo"})),

--- a/cilium-cli/connectivity/builder/client_egress_l7_named_port.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_named_port.go
@@ -17,6 +17,7 @@ func (t clientEgressL7NamedPort) build(ct *check.ConnectivityTest, templates map
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithCiliumPolicy(clientEgressOnlyDNSPolicyYAML).                      // DNS resolution only
 		WithCiliumPolicy(templates["clientEgressL7HTTPNamedPortPolicyYAML"]). // L7 allow policy with HTTP introspection (named port)
+		WithCleanFqdnCache().
 		WithScenarios(
 			tests.PodToPod(),
 			tests.PodToWorld(tests.WithRetryDestPort(80), tests.WithRetryPodLabel("other", "client")),

--- a/cilium-cli/connectivity/builder/client_egress_l7_tls_deny_without_headers.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_tls_deny_without_headers.go
@@ -20,6 +20,7 @@ func (t clientEgressL7TlsDenyWithoutHeaders) build(ct *check.ConnectivityTest, t
 		WithCABundleSecret().
 		WithCertificate("externaltarget-tls", ct.Params().ExternalTarget).
 		WithCiliumPolicy(templates["clientEgressL7TLSPolicyYAML"]). // L7 allow policy with TLS interception
+		WithCleanFqdnCache().
 		WithScenarios(tests.PodToWorldWithTLSIntercept()).
 		WithExpectations(func(_ *check.Action) (egress, ingress check.Result) {
 			return check.ResultDropCurlHTTPError, check.ResultNone

--- a/cilium-cli/connectivity/builder/client_egress_l7_tls_headers.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_tls_headers.go
@@ -32,6 +32,7 @@ func clientEgressL7TlsHeadersTest(ct *check.ConnectivityTest, templates map[stri
 		WithCABundleSecret().
 		WithCertificate("externaltarget-tls", ct.Params().ExternalTarget).
 		WithCiliumPolicy(yamlFile). // L7 allow policy with TLS interception
+		WithCleanFqdnCache().
 		WithScenarios(tests.PodToWorldWithTLSIntercept("-H", "X-Very-Secret-Token: 42")).
 		WithExpectations(func(_ *check.Action) (egress, ingress check.Result) {
 			return check.ResultOK, check.ResultNone

--- a/cilium-cli/connectivity/builder/dns_only.go
+++ b/cilium-cli/connectivity/builder/dns_only.go
@@ -16,6 +16,7 @@ func (t dnsOnly) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("dns-only", ct).
 		WithCiliumPolicy(clientEgressOnlyDNSPolicyYAML).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithCleanFqdnCache().
 		WithScenarios(
 			tests.PodToPod(),   // connects to other Pods directly, no DNS
 			tests.PodToWorld(), // resolves set domain-name defaults to one.one.one.one

--- a/cilium-cli/connectivity/builder/egress_gateway_with_l7_policy.go
+++ b/cilium-cli/connectivity/builder/egress_gateway_with_l7_policy.go
@@ -42,5 +42,6 @@ func (t egressGatewayWithL7Policy) build(ct *check.ConnectivityTest, templates m
 			features.RequireEnabled(features.L7Proxy),
 			features.RequireEnabled(features.NodeWithoutCilium),
 		).
+		WithCleanFqdnCache().
 		WithScenarios(tests.EgressGateway())
 }

--- a/cilium-cli/connectivity/builder/local_redirect_policy_with_nodedns.go
+++ b/cilium-cli/connectivity/builder/local_redirect_policy_with_nodedns.go
@@ -26,6 +26,7 @@ func (t localRedirectPolicyWithNodeDNS) build(ct *check.ConnectivityTest, templa
 			features.RequireEnabled(features.LocalRedirectPolicy),
 			features.RequireEnabled(features.KPRSocketLB),
 		).
+		WithCleanFqdnCache().
 		WithScenarios(
 			tests.LRPWithNodeDNS(),
 		)

--- a/cilium-cli/connectivity/builder/to_fqdns.go
+++ b/cilium-cli/connectivity/builder/to_fqdns.go
@@ -19,6 +19,7 @@ func (t toFqdns) build(ct *check.ConnectivityTest, templates map[string]string) 
 	newTest("to-fqdns", ct).
 		WithCiliumPolicy(templates["clientEgressToFQDNsPolicyYAML"]).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithCleanFqdnCache().
 		WithScenarios(
 			tests.PodToWorld(tests.WithRetryDestPort(80)),
 			tests.PodToWorld2(), // resolves cilium.io.

--- a/cilium-cli/connectivity/check/fqdn.go
+++ b/cilium-cli/connectivity/check/fqdn.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package check
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cilium/cilium/cilium-cli/defaults"
+)
+
+// WithCleanFqdnCache attaches a per-scenario setup callback to the test
+// which cleans FQDN cache.
+func (t *Test) WithCleanFqdnCache() *Test {
+	t.WithScenarioSetupFunc(cleanFqdnCache)
+	return t
+}
+
+// CleanFqdnCache cleans FQDN cache of the given node via its agent pod.
+// The function signature matches SetupFunc.
+func cleanFqdnCache(ctx context.Context, t *Test, ct *ConnectivityTest, s Scenario) error {
+	for _, cp := range ct.ciliumPods {
+		if err := cleanFqdnCacheOnAgent(ctx, ct, cp); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func cleanFqdnCacheOnAgent(ctx context.Context, log Logger, agent Pod) error {
+	log.Debugf("[%s] Cleaning FQDN cache on %s...",
+		agent.K8sClient.ClusterName(), agent.Name())
+
+	ctx, cancel := context.WithTimeout(ctx, ShortTimeout)
+	defer cancel()
+
+	if _, err := agent.K8sClient.ExecInPod(ctx, agent.Namespace(), agent.NameWithoutNamespace(),
+		defaults.AgentContainerName, []string{"cilium", "fqdn", "cache", "clean", "-f"}); err == nil {
+		return nil
+	} else {
+		log.Debugf("[%s] Error cleaning FQDN cache: %s", agent.K8sClient.ClusterName(), err)
+		return fmt.Errorf("failed to clean fqdn cache on %s: %w", agent.Name(), err)
+	}
+}


### PR DESCRIPTION
FQDN entries created in one scenario are currently sticking around in the cache. This means that subsequent scenarios don't start with a clean slate, and failing tests can pass depending on the set of tests being executed. This commit fixes the problem by adding a per-scenario setup callback to test harness and using it to clean FQDN cache on agents before every scenario that uses DNS proxy.