### PR TITLE
Set go version to v1.23 in go.mod and fix codegen issue

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -183,7 +183,6 @@
         "golang-version"
       ],
       "matchUpdateTypes": [
-        "minor",
         "patch"
       ],
       matchBaseBranches: [

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -84,6 +84,11 @@ GO_BUILD_LDFLAGS ?=
 # go build/test -tags values
 GO_TAGS_FLAGS += osusergo
 
+# Keep the Go <=1.22 semantics for parsing type aliases.
+# This is needed for code generation (k8s protobuf, deep*) until 'gengo' has been fixed.
+GODEBUG += gotypesalias=0
+export GODEBUG
+
 # This is declared here as it is needed to change the covermode depending on if
 # RACE is specified.
 GOTEST_COVER_OPTS =

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/cilium
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6


### PR DESCRIPTION
```
Makefile.defs: Set GODEBUG to gotypesalias=0

    In Go v1.23 gotypesalias is set to 1, which changes the parsing of type
    aliases. This breaks our "generate-k8s-api" as k8s.io/gengo does not yet
    handle the new semantics.

    Work around this issue by setting gotypesalias=0 until the kubernetes
    tooling has fixed the issue.

    Signed-off-by: Jussi Maki <jussi@isovalent.com>

go.mod: Bump to v1.23

    Bump the Go version to v1.23 so that we can import Go v1.23 packages and use
    the new features.

    Signed-off-by: Jussi Maki <jussi@isovalent.com>
```