### PR TITLE
.github: remove CI tests from PR runs if not required

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -4,16 +4,13 @@ allowed-teams:
 triggers:
   /test:
     workflows:
-    - conformance-aks.yaml
     - conformance-aws-cni.yaml
     - conformance-clustermesh.yaml
     - conformance-e2e.yaml
     - conformance-ipsec-e2e.yaml
     - conformance-eks.yaml
     - conformance-externalworkloads.yaml
-    - conformance-gateway-api.yaml
     - conformance-ginkgo.yaml
-    - conformance-gke.yaml
     - conformance-ingress.yaml
     - conformance-multi-pool.yaml
     - conformance-runtime.yaml


### PR DESCRIPTION
Non-required jobs are not providing too much value in PR runs since if they value it won't block the PR from being merged. Thus, we should removed them from PR runs.