### PR TITLE
envoy: possibility to configure separate default log level for Envoy 

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -184,6 +184,7 @@ cilium-agent [flags]
       --envoy-base-id uint                                        Envoy base ID
       --envoy-config-retry-interval duration                      Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated. (default 15s)
       --envoy-config-timeout duration                             Timeout that determines how long to wait for Envoy to N/ACK CiliumEnvoyConfig resources (default 2m0s)
+      --envoy-default-log-level string                            Default log level of Envoy application log that is configured if Cilium debug / verbose logging isn't enabled. If not defined, the default log level of the Cilium Agent is used.
       --envoy-keep-cap-netbindservice                             Keep capability NET_BIND_SERVICE for Envoy process
       --envoy-log string                                          Path to a separate Envoy log file, if any
       --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -52,6 +52,7 @@ cilium-agent hive [flags]
       --envoy-base-id uint                                        Envoy base ID
       --envoy-config-retry-interval duration                      Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated. (default 15s)
       --envoy-config-timeout duration                             Timeout that determines how long to wait for Envoy to N/ACK CiliumEnvoyConfig resources (default 2m0s)
+      --envoy-default-log-level string                            Default log level of Envoy application log that is configured if Cilium debug / verbose logging isn't enabled. If not defined, the default log level of the Cilium Agent is used.
       --envoy-keep-cap-netbindservice                             Keep capability NET_BIND_SERVICE for Envoy process
       --envoy-log string                                          Path to a separate Envoy log file, if any
       --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -58,6 +58,7 @@ cilium-agent hive dot-graph [flags]
       --envoy-base-id uint                                        Envoy base ID
       --envoy-config-retry-interval duration                      Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated. (default 15s)
       --envoy-config-timeout duration                             Timeout that determines how long to wait for Envoy to N/ACK CiliumEnvoyConfig resources (default 2m0s)
+      --envoy-default-log-level string                            Default log level of Envoy application log that is configured if Cilium debug / verbose logging isn't enabled. If not defined, the default log level of the Cilium Agent is used.
       --envoy-keep-cap-netbindservice                             Keep capability NET_BIND_SERVICE for Envoy process
       --envoy-log string                                          Path to a separate Envoy log file, if any
       --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1248,6 +1248,10 @@
      - interval between checks of the liveness probe
      - int
      - ``30``
+   * - :spelling:ignore:`envoy.log.defaultLevel`
+     - Default log level of Envoy application log that is configured if Cilium debug / verbose logging isn't enabled. This option allows to have a different log level than the Cilium Agent - e.g. lower it to ``critical``. Possible values: trace, debug, info, warning, error, critical, off
+     - string
+     - Defaults to the default log level of the Cilium Agent - ``info``
    * - :spelling:ignore:`envoy.log.format`
      - The format string to use for laying out the log message metadata of Envoy.
      - string

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -362,6 +362,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.image | object | `{"digest":"sha256:47bf8d5324241e37da93e995fa23c5b11ac83c430fa54b492c6547b85b3d4f72","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.30.4-1723547155-0cb6b7d34a032ee945a80495681ecf2ea109a54c","useDigest":true}` | Envoy container image. |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
+| envoy.log.defaultLevel | string | Defaults to the default log level of the Cilium Agent - `info` | Default log level of Envoy application log that is configured if Cilium debug / verbose logging isn't enabled. This option allows to have a different log level than the Cilium Agent - e.g. lower it to `critical`. Possible values: trace, debug, info, warning, error, critical, off |
 | envoy.log.format | string | `"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"` | The format string to use for laying out the log message metadata of Envoy. |
 | envoy.log.path | string | `""` | Path to a separate Envoy log file, if any. Defaults to /dev/stdout. |
 | envoy.maxConnectionDurationSeconds | int | `0` | Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable) |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1318,6 +1318,9 @@ data:
 {{- if .Values.envoy.log.path }}
   envoy-log: {{ .Values.envoy.log.path | quote }}
 {{- end }}
+{{- if .Values.envoy.log.defaultLevel }}
+  envoy-default-log-level: {{ .Values.envoy.log.defaultLevel | quote }}
+{{- end }}
 
   envoy-keep-cap-netbindservice: {{ .Values.envoy.securityContext.capabilities.keepCapNetBindService | quote }}
 

--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -80,6 +80,8 @@ spec:
         - '--log-level trace'
         {{- else if and (.Values.debug.enabled) (hasKey .Values.debug "verbose") (.Values.debug.verbose) (has "flow" ( splitList " " .Values.debug.verbose )) }}
         - '--log-level debug'
+        {{- else if .Values.envoy.log.defaultLevel }}
+        - '--log-level {{ .Values.envoy.log.defaultLevel }}'
         {{- else }}
         - '--log-level info'
         {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1982,6 +1982,24 @@
         },
         "log": {
           "properties": {
+            "defaultLevel": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "enum": [
+                    "trace",
+                    "debug",
+                    "info",
+                    "warning",
+                    "error",
+                    "critical",
+                    "off"
+                  ]
+                }
+              ]
+            },
             "format": {
               "type": "string"
             },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2198,6 +2198,16 @@ envoy:
     format: "[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"
     # -- Path to a separate Envoy log file, if any. Defaults to /dev/stdout.
     path: ""
+    # @schema
+    # oneOf:
+    # - type: [null]
+    # - enum: [trace,debug,info,warning,error,critical,off]
+    # @schema
+    # -- Default log level of Envoy application log that is configured if Cilium debug / verbose logging isn't enabled.
+    # This option allows to have a different log level than the Cilium Agent - e.g. lower it to `critical`.
+    # Possible values: trace, debug, info, warning, error, critical, off
+    # @default -- Defaults to the default log level of the Cilium Agent - `info`
+    defaultLevel: ~
   # -- Time in seconds after which a TCP connection attempt times out
   connectTimeoutSeconds: 2
   # -- ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for Envoy

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2211,6 +2211,16 @@ envoy:
     format: "[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"
     # -- Path to a separate Envoy log file, if any. Defaults to /dev/stdout.
     path: ""
+    # @schema
+    # oneOf:
+    # - type: [null]
+    # - enum: [trace,debug,info,warning,error,critical,off]
+    # @schema
+    # -- Default log level of Envoy application log that is configured if Cilium debug / verbose logging isn't enabled.
+    # This option allows to have a different log level than the Cilium Agent - e.g. lower it to `critical`.
+    # Possible values: trace, debug, info, warning, error, critical, off
+    # @default -- Defaults to the default log level of the Cilium Agent - `info`
+    defaultLevel: ~
   # -- Time in seconds after which a TCP connection attempt times out
   connectTimeoutSeconds: 2
   # -- ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for Envoy

--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -66,18 +66,24 @@ func EnableTracing() {
 	tracing = true
 }
 
-func mapLogLevel(level logrus.Level) string {
+func mapLogLevel(agentLogLevel logrus.Level, defaultEnvoyLogLevel string) string {
 	// Set Envoy loglevel to trace if debug AND verbose Engoy logging is enabled
-	if level == logrus.DebugLevel && tracing {
+	if agentLogLevel == logrus.DebugLevel && tracing {
 		return "trace"
 	}
 
 	// Suppress the debug level if not debugging at flow level.
-	if level == logrus.DebugLevel && !flowdebug.Enabled() {
-		level = logrus.InfoLevel
+	if agentLogLevel == logrus.DebugLevel && !flowdebug.Enabled() {
+		return "info"
 	}
 
-	return envoyLevelMap[level]
+	// If defined, use explicit default log level for Envoy
+	if defaultEnvoyLogLevel != "" {
+		return defaultEnvoyLogLevel
+	}
+
+	// Fall back to current log level of the agent
+	return envoyLevelMap[agentLogLevel]
 }
 
 // Envoy manages a running Envoy proxy instance via the
@@ -91,6 +97,7 @@ type EmbeddedEnvoy struct {
 type embeddedEnvoyConfig struct {
 	runDir                   string
 	logPath                  string
+	defaultLogLevel          string
 	baseID                   uint64
 	keepCapNetBindService    bool
 	connectTimeout           int64
@@ -104,7 +111,7 @@ func startEmbeddedEnvoy(config embeddedEnvoyConfig) (*EmbeddedEnvoy, error) {
 	envoy := &EmbeddedEnvoy{
 		stopCh: make(chan struct{}),
 		errCh:  make(chan error, 1),
-		admin:  NewEnvoyAdminClientForSocket(GetSocketDir(config.runDir)),
+		admin:  NewEnvoyAdminClientForSocket(GetSocketDir(config.runDir), config.defaultLogLevel),
 	}
 
 	bootstrapFilePath := filepath.Join(config.runDir, "envoy", "bootstrap.pb")
@@ -156,7 +163,7 @@ func startEmbeddedEnvoy(config embeddedEnvoyConfig) (*EmbeddedEnvoy, error) {
 		}
 		defer logWriter.Close()
 
-		envoyArgs := []string{"-l", mapLogLevel(logging.GetLevel(logging.DefaultLogger)), "-c", bootstrapFilePath, "--base-id", strconv.FormatUint(config.baseID, 10), "--log-format", logFormat}
+		envoyArgs := []string{"-l", mapLogLevel(logging.GetLevel(logging.DefaultLogger), config.defaultLogLevel), "-c", bootstrapFilePath, "--base-id", strconv.FormatUint(config.baseID, 10), "--log-format", logFormat}
 		envoyStarterArgs := []string{}
 		if config.keepCapNetBindService {
 			envoyStarterArgs = append(envoyStarterArgs, "--keep-cap-net-bind-service", "--")

--- a/pkg/envoy/envoyadminclient.go
+++ b/pkg/envoy/envoyadminclient.go
@@ -56,7 +56,7 @@ func (a *EnvoyAdminClient) transact(query string) error {
 	if err != nil {
 		return err
 	}
-	ret := strings.Replace(string(body), "\r", "", -1)
+	ret := strings.ReplaceAll(string(body), "\r", "")
 	log.Debugf("Envoy: Admin response to %s: %s", query, ret)
 	return nil
 }

--- a/pkg/envoy/envoyadminclient.go
+++ b/pkg/envoy/envoyadminclient.go
@@ -18,16 +18,18 @@ import (
 )
 
 type EnvoyAdminClient struct {
-	adminURL string
-	unixPath string
-	level    string
+	adminURL        string
+	unixPath        string
+	currentLogLevel string
+	defaultLogLevel string
 }
 
-func NewEnvoyAdminClientForSocket(envoySocketDir string) *EnvoyAdminClient {
+func NewEnvoyAdminClientForSocket(envoySocketDir string, defaultLogLevel string) *EnvoyAdminClient {
 	return &EnvoyAdminClient{
 		// Needs to be provided to envoy (received as ':authority') - even though we Dial to a Unix domain socket.
-		adminURL: fmt.Sprintf("http://%s/", "envoy-admin"),
-		unixPath: getAdminSocketPath(envoySocketDir),
+		adminURL:        fmt.Sprintf("http://%s/", "envoy-admin"),
+		unixPath:        getAdminSocketPath(envoySocketDir),
+		defaultLogLevel: defaultLogLevel,
 	}
 }
 
@@ -60,10 +62,10 @@ func (a *EnvoyAdminClient) transact(query string) error {
 }
 
 // ChangeLogLevel changes Envoy log level to correspond to the logrus log level 'level'.
-func (a *EnvoyAdminClient) ChangeLogLevel(level logrus.Level) error {
-	envoyLevel := mapLogLevel(level)
+func (a *EnvoyAdminClient) ChangeLogLevel(agentLogLevel logrus.Level) error {
+	envoyLevel := mapLogLevel(agentLogLevel, a.defaultLogLevel)
 
-	if envoyLevel == a.level {
+	if envoyLevel == a.currentLogLevel {
 		log.Debugf("Envoy: Log level is already set as: %v", envoyLevel)
 		return nil
 	}
@@ -72,7 +74,7 @@ func (a *EnvoyAdminClient) ChangeLogLevel(level logrus.Level) error {
 	if err != nil {
 		log.WithError(err).Warnf("Envoy: Failed to set log level to: %v", envoyLevel)
 	} else {
-		a.level = envoyLevel
+		a.currentLogLevel = envoyLevel
 	}
 	return err
 }

--- a/pkg/envoy/xds_server_ondemand.go
+++ b/pkg/envoy/xds_server_ondemand.go
@@ -18,6 +18,7 @@ type onDemandXdsStarter struct {
 
 	runDir                   string
 	envoyLogPath             string
+	envoyDefaultLogLevel     string
 	envoyBaseID              uint64
 	keepCapNetBindService    bool
 	metricsListenerPort      int
@@ -64,6 +65,7 @@ func (o *onDemandXdsStarter) startEmbeddedEnvoy(wg *completion.WaitGroup) error 
 		_, startErr = startEmbeddedEnvoy(embeddedEnvoyConfig{
 			runDir:                   o.runDir,
 			logPath:                  o.envoyLogPath,
+			defaultLogLevel:          o.envoyDefaultLogLevel,
 			baseID:                   o.envoyBaseID,
 			keepCapNetBindService:    o.keepCapNetBindService,
 			connectTimeout:           o.connectTimeout,


### PR DESCRIPTION
Currently, the default log level of Envoy (Cilium Proxy) is aligned with the default log level of the Cilium Agent.

* default log level `info`
* debug log level: `debug`
* debug log level & verbose 'envoy': `trace`

There are cases, where level `info` for Envoy' accesslog is too verbose.

Therefore, this commit introduces the possibility to configure a different default log level for Envoy via Helm property `.envoy.log.defaultLevel` (e.g. lower it to `critical` or `error`).

The config option is optional and still falls back to use the current log level of the Cilium Agent default logger.

Note: Implemented for Embedded & DaemonSet mode