### PR TITLE
Bump StateDB to v0.3 with range-funcs

### DIFF
--- a/cilium-dbg/cmd/statedb.go
+++ b/cilium-dbg/cmd/statedb.go
@@ -128,7 +128,7 @@ func statedbTableCommand[Obj statedb.TableWritable](tableName string) *cobra.Com
 					changes := make(chan statedb.Change[Obj], 1)
 					go func() {
 						defer close(changes)
-						for change, _, ok := iter.Next(); ok; change, _, ok = iter.Next() {
+						for change := range iter {
 							changes <- change
 						}
 					}()
@@ -157,7 +157,7 @@ func statedbTableCommand[Obj statedb.TableWritable](tableName string) *cobra.Com
 			} else {
 				iter, errChan := table.LowerBound(context.Background(), statedb.ByRevision[Obj](0))
 				if iter != nil {
-					for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+					for obj := range iter {
 						err := outputter.writeObject(obj, false)
 						if err != nil {
 							return

--- a/daemon/cmd/hostips-sync.go
+++ b/daemon/cmd/hostips-sync.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"iter"
 	"net"
 	"net/netip"
 
@@ -119,7 +120,7 @@ func (s *syncHostIPs) loop(ctx context.Context, health cell.Health) error {
 // sync adds local host entries to bpf lxcmap, as well as ipcache, if
 // needed, and also notifies the daemon and network policy hosts cache if
 // changes were made.
-func (s *syncHostIPs) sync(addrs statedb.Iterator[tables.NodeAddress]) error {
+func (s *syncHostIPs) sync(addrs iter.Seq2[tables.NodeAddress, statedb.Revision]) error {
 	type ipIDLabel struct {
 		identity.IPIdentityPair
 		labels.Labels
@@ -137,7 +138,7 @@ func (s *syncHostIPs) sync(addrs statedb.Iterator[tables.NodeAddress]) error {
 		})
 	}
 
-	for addr, _, ok := addrs.Next(); ok; addr, _, ok = addrs.Next() {
+	for addr := range addrs {
 		if addr.DeviceName == tables.WildcardDeviceName {
 			continue
 		}

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/cilium/linters v0.0.0-20240813102449-1dc28a34d923
 	github.com/cilium/lumberjack/v2 v2.3.0
 	github.com/cilium/proxy v0.0.0-20240909042906-ae435a5bef38
-	github.com/cilium/statedb v0.2.6
+	github.com/cilium/statedb v0.3.0
 	github.com/cilium/stream v0.0.0-20240816054136-71321e385273
 	github.com/cilium/workerpool v1.2.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7 h1:ocC6/1Gz6LJd0X
 github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7/go.mod h1:8nydvUTW+/9nVywCQ9bE/YGzb4EISALP4lKNpK3fFqo=
 github.com/cilium/proxy v0.0.0-20240909042906-ae435a5bef38 h1:hbRPkcebWy1ZqqcnwiJJCFyzLa+xnXk6G/sM/eAsnrU=
 github.com/cilium/proxy v0.0.0-20240909042906-ae435a5bef38/go.mod h1:5L6S+WQ9v24ibJq38EMHEDljPrdx6PHqTDSHxRCJL2g=
-github.com/cilium/statedb v0.2.6 h1:O9kCwqf3JrPLkypLUYwbB1NzhXDz3CKr+2WqAUN0s6M=
-github.com/cilium/statedb v0.2.6/go.mod h1:KPwsudjhZ90zoBguYMtssKpstR74jVKd/D+73PZy+sg=
+github.com/cilium/statedb v0.3.0 h1:RpM6r1+gv8TY6V18DcrcMbGaoCBs0Vf9z7OxGCbPVaQ=
+github.com/cilium/statedb v0.3.0/go.mod h1:AvMKi/i8VISTCvymtkTKSkz1uLlzuiYeaF8jvJO8ymU=
 github.com/cilium/stream v0.0.0-20240816054136-71321e385273 h1:lyP0p5AW9fnNWmUcQ/BKaOmBEyZ+VWY1mGT1CFWv2b0=
 github.com/cilium/stream v0.0.0-20240816054136-71321e385273/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.2.0 h1:Wc2iOPTvCgWKQXeq4L5tnx4QFEI+z5q1+bSpSS0cnAY=

--- a/pkg/datapath/l2responder/l2responder_test.go
+++ b/pkg/datapath/l2responder/l2responder_test.go
@@ -107,7 +107,6 @@ func TestEmptyMapAddPartialSync(t *testing.T) {
 	changes, err := fix.proxyNeighborTable.Changes(txn)
 	assert.NoError(t, err)
 	txn.Commit()
-	defer changes.Close()
 
 	fix.mockNetlink.LinkByNameFn = func(name string) (netlink.Link, error) {
 		return &mockLink{
@@ -152,8 +151,6 @@ func TestEmptyMapAddDelPartialSync(t *testing.T) {
 	changes, err := fix.proxyNeighborTable.Changes(txn)
 	assert.NoError(t, err)
 	txn.Commit()
-
-	defer changes.Close()
 
 	txn = fix.stateDB.WriteTxn(fix.proxyNeighborTable)
 	_, _, err = fix.proxyNeighborTable.Delete(txn, &tables.L2AnnounceEntry{
@@ -294,8 +291,6 @@ func Test1RougeAddPartialSync(t *testing.T) {
 	changes, err := fix.proxyNeighborTable.Changes(txn)
 	assert.NoError(t, err)
 	txn.Commit()
-
-	defer changes.Close()
 
 	err = fix.respondermap.Create(ip3, ifidx1)
 	assert.NoError(t, err)

--- a/pkg/datapath/linux/bandwidth/ops.go
+++ b/pkg/datapath/linux/bandwidth/ops.go
@@ -6,6 +6,7 @@ package bandwidth
 import (
 	"context"
 	"fmt"
+	"iter"
 	"log/slog"
 
 	"github.com/cilium/statedb"
@@ -32,7 +33,7 @@ func (*ops) Delete(context.Context, statedb.ReadTxn, *tables.BandwidthQDisc) err
 }
 
 // Prune implements reconciler.Operations.
-func (*ops) Prune(context.Context, statedb.ReadTxn, statedb.Iterator[*tables.BandwidthQDisc]) error {
+func (*ops) Prune(context.Context, statedb.ReadTxn, iter.Seq2[*tables.BandwidthQDisc, statedb.Revision]) error {
 	// We don't touch qdiscs of other devices.
 	return nil
 }

--- a/pkg/datapath/linux/sysctl/ops.go
+++ b/pkg/datapath/linux/sysctl/ops.go
@@ -6,6 +6,7 @@ package sysctl
 import (
 	"context"
 	"fmt"
+	"iter"
 	"log/slog"
 	"strings"
 
@@ -72,7 +73,7 @@ func (ops *ops) Delete(context.Context, statedb.ReadTxn, *tables.Sysctl) error {
 	return nil
 }
 
-func (ops *ops) Prune(context.Context, statedb.ReadTxn, statedb.Iterator[*tables.Sysctl]) error {
+func (ops *ops) Prune(context.Context, statedb.ReadTxn, iter.Seq2[*tables.Sysctl, statedb.Revision]) error {
 	// sysctl settings not in the table will never be pruned, just ignored
 	return nil
 }

--- a/pkg/datapath/tables/node_address.go
+++ b/pkg/datapath/tables/node_address.go
@@ -265,8 +265,7 @@ func (n *nodeAddressController) register() {
 				}
 
 				// Do an immediate update to populate the table before it is read from.
-				devices := n.Devices.All(txn)
-				for dev, _, ok := devices.Next(); ok; dev, _, ok = devices.Next() {
+				for dev := range n.Devices.All(txn) {
 					n.update(txn, n.getAddressesFromDevice(dev), nil, dev.Name)
 					n.updateWildcardDevice(txn, dev, false)
 				}
@@ -302,15 +301,14 @@ func (n *nodeAddressController) updateK8sNodeIPs(node node.LocalNode) (updated b
 }
 
 func (n *nodeAddressController) run(ctx context.Context, reporter cell.Health) error {
-	defer n.deviceChanges.Close()
-
 	localNodeChanges := stream.ToChannel(ctx, n.LocalNode)
 	n.updateK8sNodeIPs(<-localNodeChanges)
 
 	limiter := rate.NewLimiter(nodeAddressControllerMinInterval, 1)
 	for {
 		txn := n.DB.WriteTxn(n.NodeAddresses)
-		for change, _, ok := n.deviceChanges.Next(); ok; change, _, ok = n.deviceChanges.Next() {
+		changes, watch := n.deviceChanges.Next(txn)
+		for change := range changes {
 			dev := change.Object
 
 			var new []NodeAddress
@@ -325,7 +323,7 @@ func (n *nodeAddressController) run(ctx context.Context, reporter cell.Health) e
 		select {
 		case <-ctx.Done():
 			return nil
-		case <-n.deviceChanges.Watch(n.DB.ReadTxn()):
+		case <-watch:
 		case localNode, ok := <-localNodeChanges:
 			if !ok {
 				localNodeChanges = nil
@@ -335,8 +333,7 @@ func (n *nodeAddressController) run(ctx context.Context, reporter cell.Health) e
 				// Recompute the node addresses as the k8s node IP has changed, which
 				// affects the prioritization.
 				txn := n.DB.WriteTxn(n.NodeAddresses)
-				devices := n.Devices.All(txn)
-				for dev, _, ok := devices.Next(); ok; dev, _, ok = devices.Next() {
+				for dev := range n.Devices.All(txn) {
 					n.update(txn, n.getAddressesFromDevice(dev), nil, dev.Name)
 					n.updateWildcardDevice(txn, dev, false)
 				}
@@ -365,7 +362,7 @@ func (n *nodeAddressController) updateWildcardDevice(txn statedb.WriteTxn, dev *
 
 	// Clear existing fallback addresses.
 	iter := n.NodeAddresses.List(txn, NodeAddressDeviceNameIndex.Query(WildcardDeviceName))
-	for addr, _, ok := iter.Next(); ok; addr, _, ok = iter.Next() {
+	for addr := range iter {
 		n.NodeAddresses.Delete(txn, addr)
 	}
 
@@ -395,8 +392,7 @@ func (n *nodeAddressController) updateFallbacks(txn statedb.ReadTxn, dev *Device
 	fallbacks := &n.fallbackAddresses
 	if deleted && fallbacks.fromDevice(dev) {
 		fallbacks.clear()
-		devices := n.Devices.All(txn)
-		for dev, _, ok := devices.Next(); ok; dev, _, ok = devices.Next() {
+		for dev := range n.Devices.All(txn) {
 			if strings.HasPrefix(dev.Name, "lxc") {
 				// Never pick the fallback from lxc* devices.
 				continue

--- a/pkg/datapath/tables/node_address_test.go
+++ b/pkg/datapath/tables/node_address_test.go
@@ -628,7 +628,7 @@ func TestNodeAddressWhitelist(t *testing.T) {
 			local := []string{}
 			nodePort := []string{}
 			fallback := []string{}
-			for addr, _, ok := iter.Next(); ok; addr, _, ok = iter.Next() {
+			for addr := range iter {
 				if addr.DeviceName == WildcardDeviceName {
 					fallback = append(fallback, addr.Addr.String())
 					continue

--- a/pkg/dynamicconfig/reflectors.go
+++ b/pkg/dynamicconfig/reflectors.go
@@ -4,6 +4,8 @@
 package dynamicconfig
 
 import (
+	"iter"
+
 	"github.com/cilium/statedb"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,7 +56,7 @@ func configMapReflector(name string, cs k8sClient.Clientset, t statedb.RWTable[D
 				opts.FieldSelector = fields.ParseSelectorOrDie("metadata.name=" + name).String()
 			},
 		),
-		QueryAll: func(txn statedb.ReadTxn, t statedb.Table[DynamicConfig]) statedb.Iterator[DynamicConfig] {
+		QueryAll: func(txn statedb.ReadTxn, t statedb.Table[DynamicConfig]) iter.Seq2[DynamicConfig, statedb.Revision] {
 			return statedb.Filter(
 				t.All(txn),
 				func(dc DynamicConfig) bool {

--- a/pkg/dynamicconfig/table_test.go
+++ b/pkg/dynamicconfig/table_test.go
@@ -130,8 +130,7 @@ func TestDynamicConfigMap(t *testing.T) {
 
 			gotMap := map[string]string{}
 			if err := testutils.WaitUntil(func() bool {
-				iter := dct.All(db.ReadTxn())
-				for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+				for obj := range dct.All(db.ReadTxn()) {
 					gotMap[obj.Key.String()] = obj.Value
 				}
 

--- a/pkg/hive/health/metrics.go
+++ b/pkg/hive/health/metrics.go
@@ -71,7 +71,7 @@ func publishJob(ctx context.Context, p metricPublisherParams, publish publishFun
 	it, watch := p.Table.AllWatch(p.DB.ReadTxn())
 	for {
 		stats := make(map[types.Level]uint64)
-		for obj, _, ok := it.Next(); ok; obj, _, ok = it.Next() {
+		for obj := range it {
 			stats[obj.Level]++
 		}
 		publish(stats)

--- a/pkg/hive/health/metrics_test.go
+++ b/pkg/hive/health/metrics_test.go
@@ -5,6 +5,7 @@ package health
 
 import (
 	"context"
+	"iter"
 	"testing"
 
 	"github.com/cilium/hive"
@@ -100,8 +101,8 @@ func Test_Metrics(t *testing.T) {
 	assert.Equal(t, resMetrics[types.LevelStopped], stopped)
 }
 
-func count(it statedb.Iterator[types.Status]) (ok uint64, degraded uint64, stopped uint64) {
-	for obj, _, hasMore := it.Next(); hasMore; obj, _, hasMore = it.Next() {
+func count(it iter.Seq2[types.Status, statedb.Revision]) (ok uint64, degraded uint64, stopped uint64) {
+	for obj := range it {
 		switch obj.Level {
 		case types.LevelOK:
 			ok++

--- a/pkg/hive/health/provider.go
+++ b/pkg/hive/health/provider.go
@@ -53,12 +53,7 @@ func (p *provider) Start(ctx cell.HookContext) error {
 func (p *provider) Stop(ctx cell.HookContext) error {
 	p.stopped.Store(true)
 	tx := p.db.ReadTxn()
-	iter := p.statusTable.All(tx)
-	for {
-		s, rev, ok := iter.Next()
-		if !ok {
-			break
-		}
+	for s, rev := range p.statusTable.All(tx) {
 		p.logger.Info(fmt.Sprintf("%s (rev=%d)", s.ID.String(), rev))
 	}
 	return nil
@@ -113,11 +108,7 @@ func (p *provider) ForModule(mid cell.FullModuleID) cell.Health {
 			q := PrimaryIndex.Query(types.HealthID(i.String()))
 			iter := p.statusTable.Prefix(tx, q)
 			var deleted int
-			for {
-				o, _, ok := iter.Next()
-				if !ok {
-					break
-				}
+			for o := range iter {
 				if _, _, err := p.statusTable.Delete(tx, types.Status{
 					ID: o.ID,
 				}); err != nil {

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -60,12 +60,12 @@ func New(cells ...cell.Cell) *Hive {
 		func(hp types.Provider, fmid cell.FullModuleID) cell.Health {
 			return hp.ForModule(fmid)
 		},
+		func(db *statedb.DB, mid cell.ModuleID) *statedb.DB {
+			return db.NewHandle(string(mid))
+		},
 	}
 	modulePrivateProviders := []cell.ModulePrivateProvider{
 		jobGroupProvider,
-		func(db *statedb.DB, mid cell.ModuleID) statedb.Handle {
-			return db.NewHandle(string(mid))
-		},
 	}
 	return upstream.NewWithOptions(
 		upstream.Options{

--- a/pkg/k8s/statedb_test.go
+++ b/pkg/k8s/statedb_test.go
@@ -6,6 +6,7 @@ package k8s_test
 import (
 	"context"
 	"fmt"
+	"iter"
 	"sync/atomic"
 	"testing"
 
@@ -192,7 +193,7 @@ func testStateDBReflector(t *testing.T, p reflectorTestParams) {
 
 	var queryAllFunc k8s.QueryAllFunc[*testObject]
 	if p.doQueryAll {
-		queryAllFunc = func(txn statedb.ReadTxn, tbl statedb.Table[*testObject]) statedb.Iterator[*testObject] {
+		queryAllFunc = func(txn statedb.ReadTxn, tbl statedb.Table[*testObject]) iter.Seq2[*testObject, statedb.Revision] {
 			// This method is called on the initial synchronization (e.g. Replace()) and whenever
 			// connection is lost to api-server and resynchronization is needed.
 			queryAllCalled.Store(true)

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -715,7 +715,7 @@ func (k *K8sPodWatcher) genServiceMappings(pod *slim_corev1.Pod, podIPs []string
 				nodeAddrAll = []netip.Addr{netipx.MustFromStdIP(feIP)}
 			} else {
 				iter := k.nodeAddrs.List(k.db.ReadTxn(), datapathTables.NodeAddressNodePortIndex.Query(true))
-				for addr, _, ok := iter.Next(); ok; addr, _, ok = iter.Next() {
+				for addr := range iter {
 					nodeAddrAll = append(nodeAddrAll, addr.Addr)
 				}
 				nodeAddrAll = append(nodeAddrAll, netip.IPv4Unspecified())

--- a/pkg/loadbalancer/experimental/backend.go
+++ b/pkg/loadbalancer/experimental/backend.go
@@ -117,9 +117,8 @@ func (be *Backend) TableRow() []string {
 
 func showInstances(instances part.Map[loadbalancer.ServiceName, BackendInstance]) string {
 	var b strings.Builder
-	iter := instances.All()
 	count := instances.Len()
-	for name, inst, ok := iter.Next(); ok; name, inst, ok = iter.Next() {
+	for name, inst := range instances.All() {
 		b.WriteString(name.String())
 		if inst.PortName != "" {
 			b.WriteString(" (")
@@ -134,22 +133,15 @@ func showInstances(instances part.Map[loadbalancer.ServiceName, BackendInstance]
 	return b.String()
 }
 
-func (be *Backend) forEachInstance(cb func(loadbalancer.ServiceName, BackendInstance)) {
-	iter := be.Instances.All()
-	for name, inst, ok := iter.Next(); ok; name, inst, ok = iter.Next() {
-		cb(name, inst)
-	}
-}
-
 func (be *Backend) serviceNameKeys() index.KeySet {
 	if be.Instances.Len() == 1 {
 		// Avoid allocating the slice.
-		name, _, _ := be.Instances.All().Next()
-		return index.NewKeySet(index.String(name.String()))
+		for name := range be.Instances.All() {
+			return index.NewKeySet(index.String(name.String()))
+		}
 	}
 	keys := make([]index.Key, 0, be.Instances.Len())
-	iter := be.Instances.All()
-	for name, _, ok := iter.Next(); ok; name, _, ok = iter.Next() {
+	for name := range be.Instances.All() {
 		keys = append(keys, index.String(name.String()))
 	}
 	return index.NewKeySet(keys...)

--- a/pkg/loadbalancer/experimental/bpf_reconciler.go
+++ b/pkg/loadbalancer/experimental/bpf_reconciler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"log/slog"
 	"net/netip"
 	"sort"
@@ -416,7 +417,7 @@ func (ops *bpfOps) pruneSourceRanges() error {
 }
 
 // Prune implements reconciler.Operations.
-func (ops *bpfOps) Prune(_ context.Context, _ statedb.ReadTxn, _ statedb.Iterator[*Frontend]) error {
+func (ops *bpfOps) Prune(_ context.Context, _ statedb.ReadTxn, _ iter.Seq2[*Frontend, statedb.Revision]) error {
 	ops.log.Info("Pruning")
 	return errors.Join(
 		ops.pruneRestoredIDs(),

--- a/pkg/loadbalancer/experimental/k8s_test.go
+++ b/pkg/loadbalancer/experimental/k8s_test.go
@@ -390,11 +390,10 @@ func sanitizeTables(dump []byte) []byte {
 }
 
 func checkTablesAndMaps(db *statedb.DB, writer *Writer, maps lbmaps, testDataPath string) bool {
-	iter := writer.Frontends().All(db.ReadTxn())
 	allDone := true
 	count := 0
-	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
-		if obj.Status.Kind != reconciler.StatusKindDone {
+	for fe := range writer.Frontends().All(db.ReadTxn()) {
+		if fe.Status.Kind != reconciler.StatusKindDone {
 			allDone = false
 		}
 		count++

--- a/pkg/loadbalancer/experimental/reflector.go
+++ b/pkg/loadbalancer/experimental/reflector.go
@@ -610,8 +610,7 @@ func upsertHostPort(params reflectorParams, wtxn WriteTxn, pod *slim_corev1.Pod)
 		Name:      pod.ObjectMeta.Name + "/host-port/",
 		Namespace: pod.ObjectMeta.Namespace,
 	}
-	iter := params.Writer.Services().Prefix(wtxn, ServiceByName(serviceNamePrefix))
-	for svc, _, ok := iter.Next(); ok; svc, _, ok = iter.Next() {
+	for svc := range params.Writer.Services().Prefix(wtxn, ServiceByName(serviceNamePrefix)) {
 		if updatedServices.Has(svc.Name) {
 			continue
 		}
@@ -632,8 +631,7 @@ func deleteHostPort(params reflectorParams, wtxn WriteTxn, pod *slim_corev1.Pod)
 		Name:      pod.ObjectMeta.Name + "/host-port/",
 		Namespace: pod.ObjectMeta.Namespace,
 	}
-	iter := params.Writer.Services().Prefix(wtxn, ServiceByName(serviceNamePrefix))
-	for svc, _, ok := iter.Next(); ok; svc, _, ok = iter.Next() {
+	for svc := range params.Writer.Services().Prefix(wtxn, ServiceByName(serviceNamePrefix)) {
 		// Delete this orphaned servicea and associated frontends. The backends will be removed
 		// when they become unreferenced.
 		err := params.Writer.DeleteServiceAndFrontends(wtxn, svc.Name)

--- a/pkg/loadbalancer/experimental/writer.go
+++ b/pkg/loadbalancer/experimental/writer.go
@@ -166,8 +166,7 @@ func (w *Writer) UpsertServiceAndFrontends(txn WriteTxn, svc *Service, fes ...Fr
 	}
 
 	// Delete orphan frontends
-	iter := w.fes.List(txn, FrontendByServiceName(svc.Name))
-	for fe, _, ok := iter.Next(); ok; fe, _, ok = iter.Next() {
+	for fe := range w.fes.List(txn, FrontendByServiceName(svc.Name)) {
 		if newAddrs.Has(fe.Address) {
 			continue
 		}
@@ -193,8 +192,7 @@ func (w *Writer) nodePortAddrs(txn statedb.ReadTxn) []netip.Addr {
 }
 
 func (w *Writer) updateServiceReferences(txn WriteTxn, svc *Service) error {
-	iter := w.fes.List(txn, FrontendByServiceName(svc.Name))
-	for fe, _, ok := iter.Next(); ok; fe, _, ok = iter.Next() {
+	for fe := range w.fes.List(txn, FrontendByServiceName(svc.Name)) {
 		fe = fe.Clone()
 		fe.service = svc
 		w.refreshFrontend(txn, fe)
@@ -227,8 +225,7 @@ func (w *Writer) refreshFrontend(txn statedb.ReadTxn, fe *Frontend) {
 }
 
 func (w *Writer) refreshFrontendsOfService(txn WriteTxn, name loadbalancer.ServiceName) error {
-	iter := w.fes.List(txn, FrontendByServiceName(name))
-	for fe, _, ok := iter.Next(); ok; fe, _, ok = iter.Next() {
+	for fe := range w.fes.List(txn, FrontendByServiceName(name)) {
 		fe = fe.Clone()
 		w.refreshFrontend(txn, fe)
 		if _, _, err := w.fes.Insert(txn, fe); err != nil {
@@ -240,8 +237,7 @@ func (w *Writer) refreshFrontendsOfService(txn WriteTxn, name loadbalancer.Servi
 
 func getBackendsForFrontend(txn statedb.ReadTxn, tbl statedb.Table[*Backend], fe *Frontend) []BackendWithRevision {
 	out := []BackendWithRevision{}
-	iter := tbl.List(txn, BackendByServiceName(fe.ServiceName))
-	for be, rev, ok := iter.Next(); ok; be, rev, ok = iter.Next() {
+	for be, rev := range tbl.List(txn, BackendByServiceName(fe.ServiceName)) {
 		if be.L3n4Addr.IsIPv6() != fe.Address.IsIPv6() {
 			continue
 		}
@@ -271,28 +267,22 @@ func (w *Writer) DeleteServiceAndFrontends(txn WriteTxn, name loadbalancer.Servi
 
 func (w *Writer) deleteService(txn WriteTxn, svc *Service) error {
 	// Delete the frontends
-	{
-		iter := w.fes.List(txn, FrontendByServiceName(svc.Name))
-		for fe, _, ok := iter.Next(); ok; fe, _, ok = iter.Next() {
-			if _, _, err := w.fes.Delete(txn, fe); err != nil {
-				return err
-			}
+	for fe := range w.fes.List(txn, FrontendByServiceName(svc.Name)) {
+		if _, _, err := w.fes.Delete(txn, fe); err != nil {
+			return err
 		}
 	}
 
 	// Release references to the backends
-	{
-		iter := w.bes.List(txn, BackendByServiceName(svc.Name))
-		for be, _, ok := iter.Next(); ok; be, _, ok = iter.Next() {
-			be, orphan := be.release(svc.Name)
-			if orphan {
-				if _, _, err := w.bes.Delete(txn, be); err != nil {
-					return err
-				}
-			} else {
-				if _, _, err := w.bes.Insert(txn, be); err != nil {
-					return err
-				}
+	for be := range w.bes.List(txn, BackendByServiceName(svc.Name)) {
+		be, orphan := be.release(svc.Name)
+		if orphan {
+			if _, _, err := w.bes.Delete(txn, be); err != nil {
+				return err
+			}
+		} else {
+			if _, _, err := w.bes.Insert(txn, be); err != nil {
+				return err
 			}
 		}
 	}
@@ -308,8 +298,7 @@ func (w *Writer) deleteService(txn WriteTxn, svc *Service) error {
 func (w *Writer) DeleteServicesBySource(txn WriteTxn, source source.Source) error {
 	// Iterating over all as this is a rare operation and it would be costly
 	// to always index by source.
-	iter := w.svcs.All(txn)
-	for svc, _, ok := iter.Next(); ok; svc, _, ok = iter.Next() {
+	for svc := range w.svcs.All(txn) {
 		if svc.Source == source {
 			if err := w.deleteService(txn, svc); err != nil {
 				return err
@@ -352,9 +341,8 @@ func (w *Writer) SetBackends(txn WriteTxn, name loadbalancer.ServiceName, source
 
 	// Release orphaned backends, e.g. all backends from this source referencing this
 	// service.
-	for orphan, _, ok := orphans.Next(); ok; orphan, _, ok = orphans.Next() {
-		iter := orphan.Instances.All()
-		for _, inst, ok := iter.Next(); ok; _, inst, ok = iter.Next() {
+	for orphan := range orphans {
+		for _, inst := range orphan.Instances.All() {
 			if inst.Source == source {
 				if err := w.removeBackendRef(txn, name, orphan); err != nil {
 					return err
@@ -407,7 +395,7 @@ func (w *Writer) SetBackendHealth(txn WriteTxn, addr loadbalancer.L3n4Addr, heal
 // computed state and the state of all instances.
 func computeBackendState(be *Backend) loadbalancer.BackendState {
 	instanceState := loadbalancer.BackendStateActive
-	be.forEachInstance(func(name loadbalancer.ServiceName, instance BackendInstance) {
+	for _, instance := range be.Instances.All() {
 		// The only states accepted from the instances are Active, Terminating or Maintenance.
 		// Quarantined can only be set via SetBackendHealth.
 		switch instance.State {
@@ -416,7 +404,7 @@ func computeBackendState(be *Backend) loadbalancer.BackendState {
 		case loadbalancer.BackendStateMaintenance:
 			instanceState = instance.State
 		}
-	})
+	}
 
 	if be.State == loadbalancer.BackendStateQuarantined &&
 		instanceState == loadbalancer.BackendStateActive {
@@ -464,9 +452,9 @@ func (w *Writer) updateBackends(txn WriteTxn, serviceName loadbalancer.ServiceNa
 			return nil, err
 		}
 
-		be.forEachInstance(func(name loadbalancer.ServiceName, _ BackendInstance) {
+		for name := range be.Instances.All() {
 			referencedServices.Insert(name)
-		})
+		}
 	}
 	return referencedServices, nil
 }
@@ -475,14 +463,13 @@ func (w *Writer) DeleteBackendsBySource(txn WriteTxn, source source.Source) erro
 	// Iterating over all as this is a rare operation and it would be costly
 	// to always index by source.
 	names := sets.New[loadbalancer.ServiceName]()
-	iter := w.bes.All(txn)
-	for be, _, ok := iter.Next(); ok; be, _, ok = iter.Next() {
-		be.forEachInstance(func(name loadbalancer.ServiceName, inst BackendInstance) {
+	for be := range w.bes.All(txn) {
+		for name, inst := range be.Instances.All() {
 			if inst.Source == source {
 				names.Insert(name)
 				w.removeBackendRef(txn, name, be)
 			}
-		})
+		}
 	}
 
 	// Mark the frontends of all referenced services as pending to reconcile the
@@ -519,11 +506,9 @@ func (w *Writer) ReleaseBackend(txn WriteTxn, name loadbalancer.ServiceName, add
 }
 
 func (w *Writer) ReleaseBackendsFromSource(txn WriteTxn, name loadbalancer.ServiceName, source source.Source) error {
-	bes := w.bes.List(txn, BackendByServiceName(name))
-	for be, _, ok := bes.Next(); ok; be, _, ok = bes.Next() {
-		iter := be.Instances.All()
-		for _, inst, ok := iter.Next(); ok; _, inst, ok = iter.Next() {
-			if inst.Source != source {
+	for be := range w.bes.List(txn, BackendByServiceName(name)) {
+		for instName, inst := range be.Instances.All() {
+			if inst.Source != source || instName != name {
 				continue
 			}
 			if err := w.removeBackendRef(txn, name, be); err != nil {
@@ -540,22 +525,19 @@ func (w *Writer) DebugDump(txn statedb.ReadTxn, to io.Writer) {
 
 	fmt.Fprintln(tw, "--- Services ---")
 	fmt.Fprintln(tw, strings.Join((*Service)(nil).TableHeader(), "\t"))
-	iter := w.svcs.All(txn)
-	for svc, _, ok := iter.Next(); ok; svc, _, ok = iter.Next() {
+	for svc := range w.svcs.All(txn) {
 		fmt.Fprintln(tw, strings.Join(svc.TableRow(), "\t"))
 	}
 
 	fmt.Fprintln(tw, "\n--- Frontends ---")
 	fmt.Fprintln(tw, strings.Join((*Frontend)(nil).TableHeader(), "\t"))
-	iterFe := w.fes.All(txn)
-	for fe, _, ok := iterFe.Next(); ok; fe, _, ok = iterFe.Next() {
+	for fe := range w.fes.All(txn) {
 		fmt.Fprintln(tw, strings.Join(fe.TableRow(), "\t"))
 	}
 
 	fmt.Fprintln(tw, "\n--- Backends ---")
 	fmt.Fprintln(tw, strings.Join((*Backend)(nil).TableHeader(), "\t"))
-	iterBe := w.bes.All(txn)
-	for be, _, ok := iterBe.Next(); ok; be, _, ok = iterBe.Next() {
+	for be := range w.bes.All(txn) {
 		fmt.Fprintln(tw, strings.Join(be.TableRow(), "\t"))
 	}
 

--- a/pkg/maps/nat/stats/stats.go
+++ b/pkg/maps/nat/stats/stats.go
@@ -171,8 +171,7 @@ func upsertStat[KT tupleKey](m *Stats, topk *topk[KT], family nat.IPFamily) erro
 	defer tx.Abort()
 
 	var errs error
-	iter := m.table.All(tx)
-	for entry, _, ok := iter.Next(); ok; entry, _, ok = iter.Next() {
+	for entry := range m.table.All(tx) {
 		if entry.Type == family.String() {
 			_, _, err := m.table.Delete(tx, entry)
 			errors.Join(errs, err)

--- a/pkg/maps/nat/stats/stats_test.go
+++ b/pkg/maps/nat/stats/stats_test.go
@@ -121,7 +121,7 @@ func Test_countNat(t *testing.T) {
 			assert.NoError(t, s.countNat(context.Background()))
 			it := s.table.All(s.db.ReadTxn())
 			freq := map[string]int{}
-			for o, _, ok := it.Next(); ok; o, _, ok = it.Next() {
+			for o := range it {
 				switch o.Type {
 				case "ipv4":
 					assert.Equal(t, fmt.Sprintf("10.0.0.%d", o.Count), o.EndpointIP)

--- a/test/controlplane/services/nodeport/nodeport.go
+++ b/test/controlplane/services/nodeport/nodeport.go
@@ -79,7 +79,7 @@ func validateExternalTrafficPolicyLocal(test *suite.ControlPlaneTest) error {
 
 	db, nodeAddrs := test.AgentDB()
 	iter := nodeAddrs.List(db.ReadTxn(), datapathTables.NodeAddressNodePortIndex.Query(true))
-	for addr, _, ok := iter.Next(); ok; addr, _, ok = iter.Next() {
+	for addr := range iter {
 		if addr.NodePort && addr.Addr.Is4() {
 			expectedFrontendIPs[addr.Addr.String()] = true
 		}

--- a/vendor/github.com/cilium/statedb/graveyard.go
+++ b/vendor/github.com/cilium/statedb/graveyard.go
@@ -5,9 +5,10 @@ package statedb
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"time"
 
-	"golang.org/x/exp/maps"
 	"golang.org/x/time/rate"
 )
 
@@ -83,7 +84,7 @@ func graveyardWorker(db *DB, ctx context.Context, gcRateLimitInterval time.Durat
 		}
 
 		// Dead objects found, do a write transaction against all tables with dead objects in them.
-		tablesToModify := maps.Keys(toBeDeleted)
+		tablesToModify := slices.Collect(maps.Keys(toBeDeleted))
 		txn = db.WriteTxn(tablesToModify[0], tablesToModify[1:]...).getTxn()
 		for meta, deadObjs := range toBeDeleted {
 			tableName := meta.Name()

--- a/vendor/github.com/cilium/statedb/index/seq.go
+++ b/vendor/github.com/cilium/statedb/index/seq.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package index
+
+import "iter"
+
+// Seq creates a KeySet from an iter.Seq[T] with the given indexing function.
+// Example usage:
+//
+//	var strings iter.Seq[string]
+//	keys := Seq[string](index.String, strings)
+func Seq[T any](
+	toKey func(T) Key,
+	seq iter.Seq[T],
+) KeySet {
+	keys := []Key{}
+	for v := range seq {
+		keys = append(keys, toKey(v))
+	}
+	return NewKeySet(keys...)
+}
+
+// Seq2 creates a KeySet from an iter.Seq2[A,B] with the given indexing function.
+// Example usage:
+//
+//	 var seq iter.Seq2[string, int]
+//		keys := Seq2(index.String, seq)
+func Seq2[A, B any](
+	toKey func(A) Key,
+	seq iter.Seq2[A, B],
+) KeySet {
+	keys := []Key{}
+	for a := range seq {
+		keys = append(keys, toKey(a))
+	}
+	return NewKeySet(keys...)
+}

--- a/vendor/github.com/cilium/statedb/index/set.go
+++ b/vendor/github.com/cilium/statedb/index/set.go
@@ -7,19 +7,18 @@ import "github.com/cilium/statedb/part"
 
 // Set creates a KeySet from a part.Set.
 func Set[T any](s part.Set[T]) KeySet {
-	iter := s.All()
 	toBytes := s.ToBytesFunc()
-
 	switch s.Len() {
 	case 0:
 		return NewKeySet()
 	case 1:
-		v, _ := iter.Next()
-		return NewKeySet(toBytes(v))
-
+		for v := range s.All() {
+			return NewKeySet(toBytes(v))
+		}
+		panic("BUG: Set.Len() == 1, but ranging returned nothing")
 	default:
 		keys := make([]Key, 0, s.Len())
-		for v, ok := iter.Next(); ok; v, ok = iter.Next() {
+		for v := range s.All() {
 			keys = append(keys, toBytes(v))
 		}
 		return NewKeySet(keys...)

--- a/vendor/github.com/cilium/statedb/index/string.go
+++ b/vendor/github.com/cilium/statedb/index/string.go
@@ -3,7 +3,10 @@
 
 package index
 
-import "fmt"
+import (
+	"fmt"
+	"iter"
+)
 
 func String(s string) Key {
 	return []byte(s)
@@ -27,4 +30,12 @@ func StringerSlice[T fmt.Stringer](ss []T) KeySet {
 		keys = append(keys, Stringer(s))
 	}
 	return NewKeySet(keys...)
+}
+
+func StringerSeq[T fmt.Stringer](seq iter.Seq[T]) KeySet {
+	return Seq[T](Stringer, seq)
+}
+
+func StringerSeq2[A fmt.Stringer, B any](seq iter.Seq2[A, B]) KeySet {
+	return Seq2[A, B](Stringer, seq)
 }

--- a/vendor/github.com/cilium/statedb/part/iterator.go
+++ b/vendor/github.com/cilium/statedb/part/iterator.go
@@ -5,12 +5,21 @@ package part
 
 import (
 	"bytes"
+	"slices"
 	"sort"
 )
 
 // Iterator for key and value pairs where value is of type T
 type Iterator[T any] struct {
 	next [][]*header[T] // sets of edges to explore
+}
+
+// Clone returns a copy of the iterator, allowing restarting
+// the iterator from scratch.
+func (it *Iterator[T]) Clone() *Iterator[T] {
+	// Since the iterator does not mutate the edge array elements themselves ([]*header[T])
+	// it is enough to do a shallow clone here.
+	return &Iterator[T]{slices.Clone(it.next)}
 }
 
 // Next returns the next key, value and true if the value exists,

--- a/vendor/github.com/cilium/statedb/reconciler/helpers.go
+++ b/vendor/github.com/cilium/statedb/reconciler/helpers.go
@@ -6,8 +6,7 @@ package reconciler
 import (
 	"errors"
 	"fmt"
-
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 var closedWatchChannel = func() <-chan struct{} {

--- a/vendor/github.com/cilium/statedb/reconciler/metrics.go
+++ b/vendor/github.com/cilium/statedb/reconciler/metrics.go
@@ -41,10 +41,10 @@ func (m *ExpVarMetrics) PruneDuration(moduleID cell.FullModuleID, duration time.
 
 func (m *ExpVarMetrics) PruneError(moduleID cell.FullModuleID, err error) {
 	m.PruneCountVar.Add(moduleID.String(), 1)
-	m.PruneTotalErrorsVar.Add(moduleID.String(), 1)
 
 	var intVar expvar.Int
 	if err != nil {
+		m.PruneTotalErrorsVar.Add(moduleID.String(), 1)
 		intVar.Set(1)
 	}
 	m.PruneCurrentErrorsVar.Set(moduleID.String(), &intVar)

--- a/vendor/github.com/cilium/statedb/reconciler/types.go
+++ b/vendor/github.com/cilium/statedb/reconciler/types.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"iter"
 	"log/slog"
 	"slices"
 	"strings"
@@ -76,7 +77,7 @@ type Operations[Obj any] interface {
 	//
 	// Unlike failed Update()'s a failed Prune() operation is not retried until
 	// the next full reconciliation round.
-	Prune(context.Context, statedb.ReadTxn, statedb.Iterator[Obj]) error
+	Prune(ctx context.Context, txn statedb.ReadTxn, objects iter.Seq2[Obj, statedb.Revision]) error
 }
 
 type BatchEntry[Obj any] struct {

--- a/vendor/github.com/cilium/statedb/types.go
+++ b/vendor/github.com/cilium/statedb/types.go
@@ -5,6 +5,7 @@ package statedb
 
 import (
 	"io"
+	"iter"
 
 	"github.com/cilium/statedb/index"
 	"github.com/cilium/statedb/internal"
@@ -43,20 +44,20 @@ type Table[Obj any] interface {
 	// increments in a write transaction on each Insert and Delete.
 	Revision(ReadTxn) Revision
 
-	// All returns an iterator for all objects in the table.
-	All(ReadTxn) Iterator[Obj]
+	// All returns a sequence of all objects in the table.
+	All(ReadTxn) iter.Seq2[Obj, Revision]
 
-	// AllWatch returns an iterator for all objects in the table and a watch
+	// AllWatch returns a sequence of all objects in the table and a watch
 	// channel that is closed when the table changes.
-	AllWatch(ReadTxn) (Iterator[Obj], <-chan struct{})
+	AllWatch(ReadTxn) (iter.Seq2[Obj, Revision], <-chan struct{})
 
-	// List returns an iterator for all objects matching the given query.
-	List(ReadTxn, Query[Obj]) Iterator[Obj]
+	// List returns sequence of objects matching the given query.
+	List(ReadTxn, Query[Obj]) iter.Seq2[Obj, Revision]
 
 	// ListWatch returns an iterator for all objects matching the given query
 	// and a watch channel that is closed if the query results are
 	// invalidated by a write to the table.
-	ListWatch(ReadTxn, Query[Obj]) (Iterator[Obj], <-chan struct{})
+	ListWatch(ReadTxn, Query[Obj]) (iter.Seq2[Obj, Revision], <-chan struct{})
 
 	// Get returns the first matching object for the query.
 	Get(ReadTxn, Query[Obj]) (obj Obj, rev Revision, found bool)
@@ -67,20 +68,20 @@ type Table[Obj any] interface {
 
 	// LowerBound returns an iterator for objects that have a key
 	// greater or equal to the query.
-	LowerBound(ReadTxn, Query[Obj]) Iterator[Obj]
+	LowerBound(ReadTxn, Query[Obj]) iter.Seq2[Obj, Revision]
 
 	// LowerBoundWatch returns an iterator for objects that have a key
 	// greater or equal to the query. The returned watch channel is closed
 	// when anything in the table changes as more fine-grained notifications
 	// are not possible with a lower bound search.
-	LowerBoundWatch(ReadTxn, Query[Obj]) (iter Iterator[Obj], watch <-chan struct{})
+	LowerBoundWatch(ReadTxn, Query[Obj]) (seq iter.Seq2[Obj, Revision], watch <-chan struct{})
 
 	// Prefix searches the table by key prefix.
-	Prefix(ReadTxn, Query[Obj]) Iterator[Obj]
+	Prefix(ReadTxn, Query[Obj]) iter.Seq2[Obj, Revision]
 
 	// PrefixWatch searches the table by key prefix. Returns an iterator and a watch
 	// channel that closes when the query results have become stale.
-	PrefixWatch(ReadTxn, Query[Obj]) (iter Iterator[Obj], watch <-chan struct{})
+	PrefixWatch(ReadTxn, Query[Obj]) (seq iter.Seq2[Obj, Revision], watch <-chan struct{})
 
 	// Changes returns an iterator for changes happening to the table.
 	// This uses the revision index to iterate over the objects in the order
@@ -95,6 +96,8 @@ type Table[Obj any] interface {
 
 // Change is either an update or a delete of an object. Used by Changes() and
 // the Observable().
+// The 'Revision' is carried also in the Change object so that it is also accessible
+// via Observable.
 type Change[Obj any] struct {
 	Object   Obj      `json:"obj"`
 	Revision Revision `json:"rev"`
@@ -102,17 +105,20 @@ type Change[Obj any] struct {
 }
 
 type ChangeIterator[Obj any] interface {
-	Iterator[Change[Obj]]
-
-	// Watch refreshes the iteration with a new query and returns a watch channel to wait
-	// for new changes after Next() has returned false.
-	Watch(ReadTxn) <-chan struct{}
-
-	// Close closes the iterator. This must be called when one is done using
-	// the iterator as a tracker is created for deleted objects and the
-	// deleted objects are held onto until all event iterators have observed
-	// the deletion.
-	Close()
+	// Next returns the sequence of unobserved changes up to the given ReadTxn (snapshot) and
+	// a watch channel.
+	//
+	// If changes are available Next returns a closed watch channel. Only once there are no further
+	// changes available will a proper watch channel be returned.
+	//
+	// Next can be called again without fully consuming the sequence to pull in new changes.
+	//
+	// The returned sequence is a single-use sequence and subsequent calls will return
+	// an empty sequence.
+	//
+	// If the transaction given to Next is a WriteTxn the modifications made in the
+	// transaction are not observed, that is, only committed changes can be observed.
+	Next(ReadTxn) (iter.Seq2[Change[Obj], Revision], <-chan struct{})
 }
 
 // RWTable provides methods for modifying the table under a write transaction

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -533,8 +533,8 @@ github.com/cilium/proxy/go/envoy/type/tracing/v3
 github.com/cilium/proxy/go/envoy/type/v3
 github.com/cilium/proxy/go/envoy/watchdog/v3
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.2.6
-## explicit; go 1.22.0
+# github.com/cilium/statedb v0.3.0
+## explicit; go 1.23
 github.com/cilium/statedb
 github.com/cilium/statedb/index
 github.com/cilium/statedb/internal


### PR DESCRIPTION
This bumps StateDB to v0.3.0 which brings in the `iter.Seq2` based API: https://github.com/cilium/statedb/pull/40.

Before:
```
  iter := tbl.All(db.ReadTxn())
  for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
    ...
  }
```

Now:
```
  for obj := range tbl.All(db.ReadTxn()) { 
    ... 
  }
```