### PR TITLE
k8s: Workaround flake in TestStateDBReflector

### DIFF
--- a/pkg/k8s/statedb_test.go
+++ b/pkg/k8s/statedb_test.go
@@ -252,8 +252,13 @@ func testStateDBReflector(t *testing.T, p reflectorTestParams) {
 	}
 
 	// Wait until the table has been initialized.
-	_, initWatch := table.Initialized(db.ReadTxn())
-	<-initWatch
+	for {
+		initialized, initWatch := table.Initialized(db.ReadTxn())
+		if initialized {
+			break
+		}
+		<-initWatch
+	}
 
 	// After initialization we should see the node that was created
 	// before starting.
@@ -378,8 +383,13 @@ func BenchmarkStateDBReflector(b *testing.B) {
 	}
 
 	// Wait until the table has been initialized.
-	_, initWatch := table.Initialized(db.ReadTxn())
-	<-initWatch
+	for {
+		initialized, initWatch := table.Initialized(db.ReadTxn())
+		if initialized {
+			break
+		}
+		<-initWatch
+	}
 
 	const numObjects = 10000
 


### PR DESCRIPTION
A timing bug in closing of the table init channel
is sometimes causing the test to fail:
```
  statedb_test.go:263:
     Error Trace:    /.../pkg/k8s/statedb_test.go:263
                     /.../pkg/k8s/statedb_test.go:133
     Error:          Not equal:
                     expected: "obj1"
                     actual  : "garbage"

                     Diff:
                     --- Expected
                     +++ Actual
                     @@ -1 +1 @@
                     -obj1
                     +garbage
     Test:           TestStateDBReflector/TransformMany-QueryAll
  FAIL
```

The root cause for this is a bug in StateDB that causes the init watch channel to be closed too early. This is fixed in https://github.com/cilium/statedb/pull/53.

As it takes a bit of time until we've bumped the StateDB version, work around this issue by repeatedly checking if the table is initialized, so folks aren't exposed to the flake.
