### PR TITLE
k8s: Convert service.cilium.io/node to annotation

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -379,7 +379,7 @@ To add a new service that should only be exposed to nodes with label ``service.c
   kind: Service
   metadata:
     name: example-service
-    labels:
+    annotations:
       service.cilium.io/node: beefy
   spec:
     selector:

--- a/pkg/k8s/node_test.go
+++ b/pkg/k8s/node_test.go
@@ -384,7 +384,7 @@ func TestParseNodeWithService(t *testing.T) {
 	objMeta := slim_metav1.ObjectMeta{
 		Name:      "foo",
 		Namespace: "bar",
-		Labels: map[string]string{
+		Annotations: map[string]string{
 			annotation.ServiceNodeExposure: "beefy",
 		},
 	}
@@ -406,7 +406,7 @@ func TestParseNodeWithService(t *testing.T) {
 		IntTrafficPolicy:         loadbalancer.SVCTrafficPolicyCluster,
 		FrontendIPs:              []net.IP{net.ParseIP("127.0.0.1")},
 		Selector:                 map[string]string{"foo": "bar"},
-		Labels:                   map[string]string{annotation.ServiceNodeExposure: "beefy"},
+		Annotations:              map[string]string{annotation.ServiceNodeExposure: "beefy"},
 		Ports:                    map[loadbalancer.FEPortName]*loadbalancer.L4Addr{},
 		NodePorts:                map[loadbalancer.FEPortName]NodePortToFrontend{},
 		LoadBalancerSourceRanges: map[string]*cidr.CIDR{},

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -432,14 +432,14 @@ func (k *K8sServiceWatcher) datapathSVCs(svc *k8s.Service, endpoints *k8s.Endpoi
 // checkServiceNodeExposure returns true if the service should be installed onto the
 // local node, and false if the node should ignore and not install the service.
 func (k *K8sServiceWatcher) checkServiceNodeExposure(svc *k8s.Service) (bool, error) {
-	if serviceLabelValue, serviceLabelExists := svc.Labels[annotation.ServiceNodeExposure]; serviceLabelExists {
+	if serviceAnnotationValue, serviceAnnotationExists := svc.Annotations[annotation.ServiceNodeExposure]; serviceAnnotationExists {
 		ln, err := k.localNodeStore.Get(context.Background())
 		if err != nil {
 			return false, fmt.Errorf("failed to retrieve local node: %w", err)
 		}
 
 		nodeLabelValue, nodeLabelExists := ln.Labels[annotation.ServiceNodeExposure]
-		if !nodeLabelExists || nodeLabelValue != serviceLabelValue {
+		if !nodeLabelExists || nodeLabelValue != serviceAnnotationValue {
 			return false, nil
 		}
 	}


### PR DESCRIPTION
Instead of using as a label.

This aligns better with K8s common practice to put configuration options within annotations instead of labels. Also, other service.cilium.io/* options are exposed as annotations.

Fixes: 55357a4b2c ("cilium, service: Introduce service.cilium.io/node label")