### PR TITLE
feat(helm): allow setting resources for spire agent and server workloads

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -112,6 +112,10 @@
      - Security context to be added to spire agent pods. SecurityContext holds pod-level security attributes and common container settings. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
      - object
      - ``{}``
+   * - :spelling:ignore:`authentication.mutual.spire.install.agent.resources`
+     - container resource limits & requests
+     - object
+     - ``{}``
    * - :spelling:ignore:`authentication.mutual.spire.install.agent.securityContext`
      - Security context to be added to spire agent containers. SecurityContext holds pod-level security attributes and common container settings. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
      - object
@@ -194,6 +198,10 @@
      - ``{}``
    * - :spelling:ignore:`authentication.mutual.spire.install.server.podSecurityContext`
      - Security context to be added to spire server pods. SecurityContext holds pod-level security attributes and common container settings. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+     - object
+     - ``{}``
+   * - :spelling:ignore:`authentication.mutual.spire.install.server.resources`
+     - container resource limits & requests
      - object
      - ``{}``
    * - :spelling:ignore:`authentication.mutual.spire.install.server.securityContext`

--- a/USERS.md
+++ b/USERS.md
@@ -665,6 +665,12 @@ Users (Alphabetically)
       L: https://schubergphilis.com/en
       Q: @stimmerman @shoekstra @mbaumann
 
+    * N: SDV Services
+      D: SDV Services uses Cilium to host Wordpress multi-tenant the cloud-native way and also as the CNI for customer Kubernetes clusters.
+      U: CNI, Networking, NetworkPolicy, Hubble, IPAM, Kubernetes services
+      L: https://sdvservices.nl
+      Q: @Sjouke de Vries
+
     * N: SI Analytics
       D: SI Analytics uses Cilium as CNI in self-managed Kubernetes clusters in on-prem DCs. And also use Cilium as CNI in its GKE dataplane v2 based clusters.
       U: CNI, Network Policies, Hubble

--- a/USERS.md
+++ b/USERS.md
@@ -665,12 +665,6 @@ Users (Alphabetically)
       L: https://schubergphilis.com/en
       Q: @stimmerman @shoekstra @mbaumann
 
-    * N: SDV Services
-      D: SDV Services uses Cilium to host Wordpress multi-tenant the cloud-native way and also as the CNI for customer Kubernetes clusters.
-      U: CNI, Networking, NetworkPolicy, Hubble, IPAM, Kubernetes services
-      L: https://sdvservices.nl
-      Q: @Sjouke de Vries
-
     * N: SI Analytics
       D: SI Analytics uses Cilium as CNI in self-managed Kubernetes clusters in on-prem DCs. And also use Cilium as CNI in its GKE dataplane v2 based clusters.
       U: CNI, Network Policies, Hubble

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -78,6 +78,7 @@ contributors across the globe, there is almost always someone available to help.
 | authentication.mutual.spire.install.agent.labels | object | `{}` | SPIRE agent labels |
 | authentication.mutual.spire.install.agent.nodeSelector | object | `{}` | SPIRE agent nodeSelector configuration ref: ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | authentication.mutual.spire.install.agent.podSecurityContext | object | `{}` | Security context to be added to spire agent pods. SecurityContext holds pod-level security attributes and common container settings. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod |
+| authentication.mutual.spire.install.agent.resources | object | `{}` | container resource limits & requests |
 | authentication.mutual.spire.install.agent.securityContext | object | `{}` | Security context to be added to spire agent containers. SecurityContext holds pod-level security attributes and common container settings. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container |
 | authentication.mutual.spire.install.agent.serviceAccount | object | `{"create":true,"name":"spire-agent"}` | SPIRE agent service account |
 | authentication.mutual.spire.install.agent.skipKubeletVerification | bool | `true` | SPIRE Workload Attestor kubelet verification. |
@@ -99,6 +100,7 @@ contributors across the globe, there is almost always someone available to help.
 | authentication.mutual.spire.install.server.labels | object | `{}` | SPIRE server labels |
 | authentication.mutual.spire.install.server.nodeSelector | object | `{}` | SPIRE server nodeSelector configuration ref: ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | authentication.mutual.spire.install.server.podSecurityContext | object | `{}` | Security context to be added to spire server pods. SecurityContext holds pod-level security attributes and common container settings. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod |
+| authentication.mutual.spire.install.server.resources | object | `{}` | container resource limits & requests |
 | authentication.mutual.spire.install.server.securityContext | object | `{}` | Security context to be added to spire server containers. SecurityContext holds pod-level security attributes and common container settings. ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container |
 | authentication.mutual.spire.install.server.service.annotations | object | `{}` | Annotations to be added to the SPIRE server service |
 | authentication.mutual.spire.install.server.service.labels | object | `{}` | Labels to be added to the SPIRE server service |

--- a/install/kubernetes/cilium/templates/spire/agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/daemonset.yaml
@@ -81,6 +81,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+          {{- with .Values.authentication.mutual.spire.install.agent.resources }}
+          resources:
+            {{- toYaml . | trim | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /live

--- a/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
@@ -65,6 +65,10 @@ spec:
         args:
         - -config
         - /run/spire/config/server.conf
+        {{- with .Values.authentication.mutual.spire.install.server.resources }}
+        resources:
+          {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
         ports:
         - name: grpc
           containerPort: 8081

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -125,6 +125,9 @@
                         "annotations": {
                           "type": "object"
                         },
+                        "resources": {
+                          "type": "object"
+                        },
                         "image": {
                           "properties": {
                             "digest": {
@@ -281,6 +284,9 @@
                           "type": "object"
                         },
                         "annotations": {
+                          "type": "object"
+                        },
+                        "resources": {
                           "type": "object"
                         },
                         "ca": {

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -125,9 +125,6 @@
                         "annotations": {
                           "type": "object"
                         },
-                        "resources": {
-                          "type": "object"
-                        },
                         "image": {
                           "properties": {
                             "digest": {
@@ -161,6 +158,9 @@
                           "type": "object"
                         },
                         "podSecurityContext": {
+                          "type": "object"
+                        },
+                        "resources": {
                           "type": "object"
                         },
                         "securityContext": {
@@ -286,9 +286,6 @@
                         "annotations": {
                           "type": "object"
                         },
-                        "resources": {
-                          "type": "object"
-                        },
                         "ca": {
                           "properties": {
                             "keyType": {
@@ -368,6 +365,9 @@
                           "type": "object"
                         },
                         "podSecurityContext": {
+                          "type": "object"
+                        },
+                        "resources": {
                           "type": "object"
                         },
                         "securityContext": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3498,6 +3498,8 @@ authentication:
           annotations: {}
           # -- SPIRE agent labels
           labels: {}
+          # -- container resource limits & requests
+          resources: {}
           # -- SPIRE Workload Attestor kubelet verification.
           skipKubeletVerification: true
           # -- SPIRE agent tolerations configuration
@@ -3551,6 +3553,8 @@ authentication:
           annotations: {}
           # -- SPIRE server labels
           labels: {}
+          # -- container resource limits & requests
+          resources: {}
           # SPIRE server service configuration
           service:
             # -- Service type for the SPIRE server service

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3520,6 +3520,8 @@ authentication:
           annotations: {}
           # -- SPIRE agent labels
           labels: {}
+          # -- container resource limits & requests
+          resources: {}
           # -- SPIRE Workload Attestor kubelet verification.
           skipKubeletVerification: true
           # -- SPIRE agent tolerations configuration
@@ -3573,6 +3575,8 @@ authentication:
           annotations: {}
           # -- SPIRE server labels
           labels: {}
+          # -- container resource limits & requests
+          resources: {}
           # SPIRE server service configuration
           service:
             # -- Service type for the SPIRE server service


### PR DESCRIPTION
Added `resources`  to the helm values for `authentication.mutual.spire.install.agent` and `authentication.mutual.spire.install.server`. 
