### PR TITLE
fix(cilium-cli/status): add helmReleaseName parameter

### DIFF
--- a/cilium-cli/cli/status.go
+++ b/cilium-cli/cli/status.go
@@ -25,6 +25,7 @@ func newCmdStatus() *cobra.Command {
 		Long:  ``,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			params.Namespace = namespace
+			params.HelmReleaseName = helmReleaseName
 
 			collector, err := status.NewK8sStatusCollector(k8sClient, params)
 			if err != nil {


### PR DESCRIPTION
The status command did not use the helmReleaseName set by the cli, causing it to do a lookup of a helm release with an empty string as helmReleaseName. This results in error and no version reported by the status command.

This commit adds the helmReleaseName parameter so the global value is inherited by the status command.

Fixes: #34747

```release-note
Fix missing Helm chart version for status command
```