### PR TITLE
cilium-operator: don't reconcile non-GAMMA xRoutes without a Cilium-managed Gateway

### DIFF
--- a/operator/pkg/gateway-api/grpcroute_reconcile.go
+++ b/operator/pkg/gateway-api/grpcroute_reconcile.go
@@ -16,6 +16,7 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	controllerruntime "github.com/cilium/cilium/operator/pkg/controller-runtime"
+	helpers "github.com/cilium/cilium/operator/pkg/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/routechecks"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -64,6 +65,26 @@ func (r *grpcRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		Grants:    grants,
 		GRPCRoute: gr,
 	}
+
+        // Ignore routes without a Cilium-manged gateway
+        managedByCilium := false
+        for _, parent := range gr.Spec.ParentRefs {
+		if helpers.isGateway(parent) {
+			// get the gateway
+			gw, err := i.GetGateway(parent)
+			if err != nil {
+				return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to get Gateway: %w", err), original, gr)
+			}
+			if hasMatchingController(i.Ctx, i.Client, controllerName)(gw) {
+				managedByCilium = true
+				break
+			}
+		}
+        }
+        if !managedByCilium {
+                scopedLog.Info("No Cilium-managed Gateway found for GRPCRoute, skipping")
+                return controllerruntime.Success()
+        }
 
 	// gateway validators
 	for _, parent := range gr.Spec.ParentRefs {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #34754

```release-note
operator: don't reconcile non-GAMMA xRoutes without a Cilium-managed Gateway
```
