### PR TITLE
[v1.16] images: fix path script and update base images

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -62,7 +62,7 @@ jobs:
           mkdir -p ../cilium-base-branch/images/runtime/
           cp ./images/runtime/update-cilium-runtime-image.sh ../cilium-base-branch/images/runtime/
           mkdir -p ../cilium-base-branch/images/builder/
-          cp ./images/builder/update-cilium-runtime-image.sh ../cilium-base-branch/images/builder/
+          cp ./images/builder/update-cilium-builder-image.sh ../cilium-base-branch/images/builder/
           mkdir -p ../cilium-base-branch/api/v1
           cp ./api/v1/Makefile ../cilium-base-branch/api/v1/
           cp ./Makefile.defs ../cilium-base-branch/Makefile.defs


### PR DESCRIPTION
The script doesn't exist under this directory, fix the path with the correct one.

Fixes: 49efc885b93e (".github: run scripts from trusted source code")

```upstream-prs
 34764
```
