### PR TITLE
.github/labeler: add exclusive cilium-cli label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,10 +3,20 @@ cilium-cli:
 - changed-files:
   - any-glob-to-any-file:
     - cilium-cli/**
+# Add 'cilium-cli-exclusive' label if the changed files are only in 'cilium-cli'
+cilium-cli-exclusive:
+- changed-files:
+  - all-globs-to-all-files:
+    - cilium-cli/**
 # Add 'hubble-cli' label to any file changes in 'hubble/'
 hubble-cli:
 - changed-files:
   - any-glob-to-any-file:
+    - hubble/**
+# Add 'hubble-cli-exclusive' label if the changed files are only in 'hubble'
+hubble-cli-exclusive:
+- changed-files:
+  - all-globs-to-all-files:
     - hubble/**
 sig/policy:
 - changed-files:


### PR DESCRIPTION
As we have merged cilium-cli into cilium repository, we don't need to generate release note labels for PRs that are specific for cilium-cli when preparing the release notes for cilium. The same logic applies for hubble-cli.

When generating the release notes for cilium we will exclude all PRs that have the cilium-cli-exclusive and hubble-cli-exclusive labels.