### PR TITLE
k8s: Add "service.cilium.io/type"

### DIFF
--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -122,6 +122,15 @@ const (
 	// service is ignored and not installed into their datapath.
 	ServiceNodeExposure = ServicePrefix + "/node"
 
+	// ServiceTypeExposure is the annotation name used to mark what service type
+	// to provision (only single type is allowed; allowed types: "ClusterIP",
+	// "NodePort" and "LoadBalancer").
+	//
+	// For example, a LoadBalancer service includes ClusterIP and NodePort (unless
+	// allocateLoadBalancerNodePorts is set to false). To avoid provisioning
+	// the latter two, one can set the annotation with the value "LoadBalancer".
+	ServiceTypeExposure = ServicePrefix + "/type"
+
 	// ProxyVisibility / ProxyVisibilityAlias is the annotation name used to
 	// indicate whether proxy visibility should be enabled for a given pod (i.e.,
 	// all traffic for the pod is redirected to the proxy for the given port /


### PR DESCRIPTION
The new annotation is used to instruct which single service type to provision (i.e., to add to the BPF LB maps).

For example, if a user creates a K8s LoadBalancer service, then the following corresponding services will be provisioned:
  - LoadBalancer,
  - ClusterIP,
  - NodePort (unless "allocateLoadBalancerNodePorts" is set to "false"). provisioning

Sometimes a user wants to create only a LoadBalancer service w/o creating ClusterIP (e.g., to reduce BPF maps memory pressure if ClusterIP is not intended to be used).