### PR TITLE
ci: fix ginkgo by replace k8s v1.27 with v1.31

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -221,18 +221,36 @@ include:
 exclude:
   # The bandwidth test is disabled and hubble tests are not meant
   # to run on net-next.
-  - k8s-version: "1.30"
+  - k8s-version: "1.31"
     focus: "f10-agent-hubble-bandwidth"
 
   # These tests are meant to run with kube-proxy which is not available
   # with net-next
-  - k8s-version: "1.30"
+  - k8s-version: "1.31"
     focus: "f16-datapath-service-ew-2"
 
   # These tests are meant to run with kube-proxy which is not available
   # with net-next
-  - k8s-version: "1.30"
+  - k8s-version: "1.31"
     focus: "f17-datapath-service-ew-kube-proxy"
+
+  # These tests require an external node which is only available on 1.30
+  # / net-next so there's no point on running them
+  - k8s-version: "1.30"
+    focus: "f05-agent-policy-multi-node-2"
+
+  # These tests require kernel net-next so there's no point on running them
+  - k8s-version: "1.30"
+    focus: "f11-datapath-service-ns-tc"
+
+  - k8s-version: "1.30"
+    focus: "f12-datapath-service-ns-misc"
+
+  - k8s-version: "1.30"
+    focus: "f13-datapath-service-ns-xdp-1"
+
+  - k8s-version: "1.30"
+    focus: "f14-datapath-service-ns-xdp-2"
 
   # These tests require an external node which is only available on 1.29
   # / net-next so there's no point on running them
@@ -252,60 +270,42 @@ exclude:
   - k8s-version: "1.29"
     focus: "f14-datapath-service-ns-xdp-2"
 
-  # These tests require an external node which is only available on 1.28
-  # / net-next so there's no point on running them
-  - k8s-version: "1.28"
-    focus: "f05-agent-policy-multi-node-2"
-
-  # These tests require kernel net-next so there's no point on running them
-  - k8s-version: "1.28"
-    focus: "f11-datapath-service-ns-tc"
-
-  - k8s-version: "1.28"
-    focus: "f12-datapath-service-ns-misc"
-
-  - k8s-version: "1.28"
-    focus: "f13-datapath-service-ns-xdp-1"
-
-  - k8s-version: "1.28"
-    focus: "f14-datapath-service-ns-xdp-2"
-
   # These tests require are not intended to run on kernel 5.4, thus we can ignore them
-  - k8s-version: "1.27"
+  - k8s-version: "1.28"
     focus: "f01-agent-chaos"
 
-  - k8s-version: "1.27"
+  - k8s-version: "1.28"
     focus: "f03-agent-policy"
 
-  - k8s-version: "1.27"
+  - k8s-version: "1.28"
     focus: "f04-agent-policy-multi-node-1"
 
-  - k8s-version: "1.27"
+  - k8s-version: "1.28"
     focus: "f05-agent-policy-multi-node-2"
 
-  - k8s-version: "1.27"
+  - k8s-version: "1.28"
     focus: "f11-datapath-service-ns-tc"
 
-  - k8s-version: "1.27"
+  - k8s-version: "1.28"
     focus: "f12-datapath-service-ns-misc"
 
-  - k8s-version: "1.27"
+  - k8s-version: "1.28"
     focus: "f13-datapath-service-ns-xdp-1"
 
-  - k8s-version: "1.27"
+  - k8s-version: "1.28"
     focus: "f14-datapath-service-ns-xdp-2"
 
-  - k8s-version: "1.27"
+  - k8s-version: "1.28"
     focus: "f15-datapath-service-ew-1"
 
-  - k8s-version: "1.27"
+  - k8s-version: "1.28"
     focus: "f16-datapath-service-ew-2"
 
-  - k8s-version: "1.27"
+  - k8s-version: "1.28"
     focus: "f17-datapath-service-ew-kube-proxy"
 
-  - k8s-version: "1.27"
+  - k8s-version: "1.28"
     focus: "f18-datapath-bgp-lrp"
 
-  - k8s-version: "1.27"
+  - k8s-version: "1.28"
     focus: "f20-kafka"

--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -4,7 +4,7 @@ include:
   - k8s-version: "1.31"
     ip-family: "dual"
     # renovate: datasource=docker
-    kube-image: "quay.io/cilium/kindest-node:v1.31.0@sha256:7e3cb518db362bee6a507dd5c9aa288a979ee8899be88231cdd4e9ca4079ac30"
+    kube-image: "quay.io/cilium/kindest-node:v1.31.0@sha256:d2b2a8cd6fa282b9a4126938341a4d2924dfa96f60b1f983d519498c9cde1a99"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
     kernel: "bpf-next-20240711.013133@sha256:5a2e78c14809c33d6fbae7762ec73b293aaa5e9b485226292348782bae1a3ed1"
 

--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -13,7 +13,7 @@ include:
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.30.0@sha256:edcb457c0b2ecc69a0fa9b0878bdcfd4a0f1205340cf08bf36a03d3a94a16dd9"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "bpf-next-20240711.013133@sha256:5a2e78c14809c33d6fbae7762ec73b293aaa5e9b485226292348782bae1a3ed1"
+    kernel: "rhel8-20240404.144247@sha256:3d3510c373eb93a66518a30b715e6b3209a768ff816efe95d8da24107e90e70e"
 
   - k8s-version: "1.29"
     ip-family: "dual"

--- a/.github/actions/ginkgo/main-prs.yaml
+++ b/.github/actions/ginkgo/main-prs.yaml
@@ -1,6 +1,7 @@
 # This file contain which k8s-versions should be executed for each PR
 ---
 k8s-version:
+  - "1.31"
   - "1.30"
   - "1.29"
-  - "1.27"
+  - "1.28"

--- a/.github/actions/ginkgo/main-scheduled.yaml
+++ b/.github/actions/ginkgo/main-scheduled.yaml
@@ -1,7 +1,7 @@
 # This file contain which k8s-versions should be executed for on a regular basis
 ---
 k8s-version:
+  - "1.31"
   - "1.30"
   - "1.29"
   - "1.28"
-  - "1.27"


### PR DESCRIPTION
This commit removes k8s version 1.27 completely from the ginkgo workflow.