### PR TITLE
Allow delegated IPAM to specify uplink interface

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -255,6 +255,7 @@ cilium-agent [flags]
       --ignore-flags-drift-checker strings                        Ignores specified flags during drift checking
       --ingress-secrets-namespace string                          IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller
       --install-no-conntrack-iptables-rules                       Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.
+      --install-uplink-routes-for-delegated-ipam                  Install ingress/egress routes through uplink on host for Pods when working with delegated IPAM plugin.
       --ip-masq-agent-config-path string                          ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
       --ipam string                                               Backend to use for IPAM (default "cluster-pool")
       --ipam-cilium-node-update-rate duration                     Maximum rate at which the CiliumNode custom resource is updated (default 15s)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2408,6 +2408,10 @@
      - Maximum rate at which the CiliumNode custom resource is updated.
      - string
      - ``"15s"``
+   * - :spelling:ignore:`ipam.installUplinkRoutesForDelegatedIPAM`
+     - Install ingress/egress routes through uplink on host for Pods when working with delegated IPAM plugin.
+     - bool
+     - ``false``
    * - :spelling:ignore:`ipam.mode`
      - Configure IP Address Management mode. ref: https://docs.cilium.io/en/stable/network/concepts/ipam/
      - string

--- a/api/v1/models/daemon_configuration_status.go
+++ b/api/v1/models/daemon_configuration_status.go
@@ -56,6 +56,11 @@ type DaemonConfigurationStatus struct {
 	// Immutable configuration (read-only)
 	Immutable ConfigurationMap `json:"immutable,omitempty"`
 
+	// Install ingress/egress routes through uplink on host for Pods when working with
+	// delegated IPAM plugin.
+	//
+	InstallUplinkRoutesForDelegatedIPAM bool `json:"installUplinkRoutesForDelegatedIPAM,omitempty"`
+
 	// Comma-separated list of IP ports should be reserved in the workload network namespace
 	IPLocalReservedPorts string `json:"ipLocalReservedPorts,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2726,6 +2726,11 @@ definitions:
       egress-multi-home-ip-rule-compat:
         description: Configured compatibility mode for --egress-multi-home-ip-rule-compat
         type: boolean
+      installUplinkRoutesForDelegatedIPAM:
+        description: |
+          Install ingress/egress routes through uplink on host for Pods when working with
+          delegated IPAM plugin.
+        type: boolean
       daemonConfigurationMap:
         description: Config map which contains all the active daemon configurations
         additionalProperties:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2657,6 +2657,10 @@ func init() {
           "description": "Immutable configuration (read-only)",
           "$ref": "#/definitions/ConfigurationMap"
         },
+        "installUplinkRoutesForDelegatedIPAM": {
+          "description": "Install ingress/egress routes through uplink on host for Pods when working with\ndelegated IPAM plugin.\n",
+          "type": "boolean"
+        },
         "ipLocalReservedPorts": {
           "description": "Comma-separated list of IP ports should be reserved in the workload network namespace",
           "type": "string"
@@ -8428,6 +8432,10 @@ func init() {
         "immutable": {
           "description": "Immutable configuration (read-only)",
           "$ref": "#/definitions/ConfigurationMap"
+        },
+        "installUplinkRoutesForDelegatedIPAM": {
+          "description": "Install ingress/egress routes through uplink on host for Pods when working with\ndelegated IPAM plugin.\n",
+          "type": "boolean"
         },
         "ipLocalReservedPorts": {
           "description": "Comma-separated list of IP ports should be reserved in the workload network namespace",

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -944,6 +944,10 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 		"Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.")
 	option.BindEnv(vp, option.EgressMultiHomeIPRuleCompat)
 
+	flags.Bool(option.InstallUplinkRoutesForDelegatedIPAM, false,
+		"Install ingress/egress routes through uplink on host for Pods when working with delegated IPAM plugin.")
+	option.BindEnv(vp, option.InstallUplinkRoutesForDelegatedIPAM)
+
 	flags.Bool(option.InstallNoConntrackIptRules, defaults.InstallNoConntrackIptRules, "Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.")
 	option.BindEnv(vp, option.InstallNoConntrackIptRules)
 

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -376,12 +376,13 @@ func (h *getConfigHandler) Handle(params daemonapi.GetConfigParams) middleware.R
 			IPV4: option.Config.EnableIPv4Masquerade,
 			IPV6: option.Config.EnableIPv6Masquerade,
 		},
-		EgressMultiHomeIPRuleCompat: option.Config.EgressMultiHomeIPRuleCompat,
-		GROMaxSize:                  int64(h.bigTCPConfig.GetGROIPv6MaxSize()),
-		GSOMaxSize:                  int64(h.bigTCPConfig.GetGSOIPv6MaxSize()),
-		GROIPV4MaxSize:              int64(h.bigTCPConfig.GetGROIPv4MaxSize()),
-		GSOIPV4MaxSize:              int64(h.bigTCPConfig.GetGSOIPv4MaxSize()),
-		IPLocalReservedPorts:        h.getIPLocalReservedPorts(),
+		EgressMultiHomeIPRuleCompat:         option.Config.EgressMultiHomeIPRuleCompat,
+		InstallUplinkRoutesForDelegatedIPAM: option.Config.InstallUplinkRoutesForDelegatedIPAM,
+		GROMaxSize:                          int64(h.bigTCPConfig.GetGROIPv6MaxSize()),
+		GSOMaxSize:                          int64(h.bigTCPConfig.GetGSOIPv6MaxSize()),
+		GROIPV4MaxSize:                      int64(h.bigTCPConfig.GetGROIPv4MaxSize()),
+		GSOIPV4MaxSize:                      int64(h.bigTCPConfig.GetGSOIPv4MaxSize()),
+		IPLocalReservedPorts:                h.getIPLocalReservedPorts(),
 	}
 
 	cfg := &models.DaemonConfiguration{

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -652,6 +652,7 @@ contributors across the globe, there is almost always someone available to help.
 | installNoConntrackIptablesRules | bool | `false` | Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup. |
 | ipMasqAgent | object | `{"enabled":false}` | Configure the eBPF-based ip-masq-agent |
 | ipam.ciliumNodeUpdateRate | string | `"15s"` | Maximum rate at which the CiliumNode custom resource is updated. |
+| ipam.installUplinkRoutesForDelegatedIPAM | bool | `false` | Install ingress/egress routes through uplink on host for Pods when working with delegated IPAM plugin. |
 | ipam.mode | string | `"cluster-pool"` | Configure IP Address Management mode. ref: https://docs.cilium.io/en/stable/network/concepts/ipam/ |
 | ipam.multiPoolPreAllocation | string | `""` | Pre-allocation settings for IPAM in Multi-Pool mode |
 | ipam.operator.autoCreateCiliumPodIPPools | object | `{}` | IP pools to auto-create in multi-pool IPAM mode. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -852,6 +852,9 @@ data:
 {{- if and .Values.endpointRoutes .Values.endpointRoutes.enabled }}
   enable-endpoint-routes: {{ .Values.endpointRoutes.enabled | quote }}
 {{- end }}
+{{- if and .Values.ipam .Values.ipam.installUplinkRoutesForDelegatedIPAM }}
+  install-uplink-routes-for-delegated-ipam: {{ .Values.ipam.installUplinkRoutesForDelegatedIPAM | quote }}
+{{- end }}
 {{- if hasKey .Values.k8sNetworkPolicy "enabled" }}
   enable-k8s-networkpolicy: {{ .Values.k8sNetworkPolicy.enabled | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -3769,6 +3769,9 @@
         "ciliumNodeUpdateRate": {
           "type": "string"
         },
+        "installUplinkRoutesForDelegatedIPAM": {
+          "type": "boolean"
+        },
         "mode": {
           "type": "string"
         },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1909,6 +1909,8 @@ ipam:
   ciliumNodeUpdateRate: "15s"
   # -- Pre-allocation settings for IPAM in Multi-Pool mode
   multiPoolPreAllocation: ""
+  # -- Install ingress/egress routes through uplink on host for Pods when working with delegated IPAM plugin.
+  installUplinkRoutesForDelegatedIPAM: false
   operator:
     # @schema
     # type: [array, string]

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1920,6 +1920,8 @@ ipam:
   ciliumNodeUpdateRate: "15s"
   # -- Pre-allocation settings for IPAM in Multi-Pool mode
   multiPoolPreAllocation: ""
+  # -- Install ingress/egress routes through uplink on host for Pods when working with delegated IPAM plugin.
+  installUplinkRoutesForDelegatedIPAM: false
   operator:
     # @schema
     # type: [array, string]

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2496,7 +2496,8 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 	}
 	e.setState(StateDisconnecting, "Deleting endpoint")
 
-	if option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure || option.Config.IPAM == ipamOption.IPAMAlibabaCloud {
+	if option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure || option.Config.IPAM == ipamOption.IPAMAlibabaCloud ||
+		(option.Config.IPAM == ipamOption.IPAMDelegatedPlugin && option.Config.InstallUplinkRoutesForDelegatedIPAM) {
 		e.getLogger().WithFields(logrus.Fields{
 			"ep":     e.GetID(),
 			"ipAddr": e.GetIPv4Address(),

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1027,6 +1027,10 @@ const (
 	// Otherwise, it will use the old scheme.
 	EgressMultiHomeIPRuleCompat = "egress-multi-home-ip-rule-compat"
 
+	// Install ingress/egress routes through uplink on host for Pods when working with
+	// delegated IPAM plugin.
+	InstallUplinkRoutesForDelegatedIPAM = "install-uplink-routes-for-delegated-ipam"
+
 	// EnableCustomCallsName is the name of the option to enable tail calls
 	// for user-defined custom eBPF programs.
 	EnableCustomCallsName = "enable-custom-calls"
@@ -2101,6 +2105,10 @@ type DaemonConfig struct {
 	// Otherwise, it will use the old scheme.
 	EgressMultiHomeIPRuleCompat bool
 
+	// Install ingress/egress routes through uplink on host for Pods when working with
+	// delegated IPAM plugin.
+	InstallUplinkRoutesForDelegatedIPAM bool
+
 	// InstallNoConntrackIptRules instructs Cilium to install Iptables rules to skip netfilter connection tracking on all pod traffic.
 	InstallNoConntrackIptRules bool
 
@@ -2988,6 +2996,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.populateLoadBalancerSettings(vp)
 	c.EnableRuntimeDeviceDetection = vp.GetBool(EnableRuntimeDeviceDetection)
 	c.EgressMultiHomeIPRuleCompat = vp.GetBool(EgressMultiHomeIPRuleCompat)
+	c.InstallUplinkRoutesForDelegatedIPAM = vp.GetBool(InstallUplinkRoutesForDelegatedIPAM)
 
 	vlanBPFBypassIDs := vp.GetStringSlice(VLANBPFBypass)
 	c.VLANBPFBypass = make([]int, 0, len(vlanBPFBypassIDs))

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -211,15 +211,41 @@ func allocateIPsWithDelegatedPlugin(
 	// Safe to assume at most one IP per family. The K8s API docs say:
 	// "Pods may be allocated at most 1 value for each of IPv4 and IPv6"
 	// https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/
+	// Interface returned by IPAM should be treated as the uplink for the Pod as CNI spec introduced by:
+	// https://github.com/containernetworking/cni/pull/1137
+	masterMac := ""
+	for _, iface := range ipamResult.Interfaces {
+		if iface.Sandbox == "" && iface.Name != "" {
+			if uplink, err := safenetlink.LinkByName(iface.Name); err != nil {
+				return nil, releaseFunc, fmt.Errorf("failed to get uplink %q: %w", iface.Name, err)
+			} else {
+				masterMac = uplink.Attrs().HardwareAddr.String()
+			}
+			break
+		}
+	}
+	// Interface number could not be determined from IPAM result for now.
+	// Set a static value zero before we have a proper solution.
+	// option.Config.EgressMultiHomeIPRuleCompat also needs to be set to true.
 	for _, ipConfig := range ipamResult.IPs {
 		ipNet := ipConfig.Address
 		if ipv4 := ipNet.IP.To4(); ipv4 != nil {
 			ipam.Address.IPV4 = ipNet.String()
-			ipam.IPV4 = &models.IPAMAddressResponse{IP: ipv4.String()}
+			ipam.IPV4 = &models.IPAMAddressResponse{
+				IP:              ipv4.String(),
+				Gateway:         ipConfig.Gateway.String(),
+				MasterMac:       masterMac,
+				InterfaceNumber: "0",
+			}
 		} else if conf.Addressing.IPV6 != nil {
 			// assign ipam ipv6 address only if agent ipv6 config is enabled
 			ipam.Address.IPV6 = ipNet.String()
-			ipam.IPV6 = &models.IPAMAddressResponse{IP: ipNet.IP.String()}
+			ipam.IPV6 = &models.IPAMAddressResponse{
+				IP:              ipNet.IP.String(),
+				Gateway:         ipConfig.Gateway.String(),
+				MasterMac:       masterMac,
+				InterfaceNumber: "0",
+			}
 		}
 	}
 
@@ -660,8 +686,7 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 			res.Routes = append(res.Routes, routes...)
 		}
 
-		switch conf.IpamMode {
-		case ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
+		if needsEndpointRoutingOnHost(conf) {
 			err = interfaceAdd(ipConfig, ipam.IPV4, conf)
 			if err != nil {
 				return fmt.Errorf("unable to setup interface datapath: %w", err)
@@ -1037,4 +1062,18 @@ func loggerWithCNIArgs(logger *logrus.Entry, cniArgs *types.ArgsSpec) *logrus.En
 		logfields.K8sNamespace: cniArgs.K8S_POD_NAMESPACE,
 		logfields.K8sPodName:   cniArgs.K8S_POD_NAME,
 	})
+}
+
+// needsEndpointRoutingOnHost returns true if extra routes/rules need to be installed
+// on host for the Pod. This is needed for following IPAM modes:
+// - Cloud ENI IPAM modes.
+// - DelegatedPlugin mode with InstallUplinkRoutesForDelegatedIPAM set to true.
+func needsEndpointRoutingOnHost(conf *models.DaemonConfigurationStatus) bool {
+	switch conf.IpamMode {
+	case ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
+		return true
+	case ipamOption.IPAMDelegatedPlugin:
+		return conf.InstallUplinkRoutesForDelegatedIPAM
+	}
+	return false
 }


### PR DESCRIPTION
For the scenario where there are multiple interfaces on a Node and delegated IPAM is used to determine the IP and the uplink interface of a Pod.  The "interfaces" field can be used by IPAM plugin to pass uplink interface info to Cilium. And then Cilium can setup host routes for the Pod according to the uplink interface info.

The "interfaces" field is allowed to specify the related host interface according to the CNI spec and is already widely used by existing plugins, such as bridge and ptp plugin. It's actually not used by any IPAM plugin for now, but I think it's reasonable and conforms to the original definition of the field.

Motivations/Benefits of the PR for the native routing mode:

- More cloud(public or private) envs with multiple uplink can be easily ingregrated with Cilium without involving any cloud specific logic. A common way is provided for the case: "uplink interface" support.
- Cilium keeps full control of the Pod traffic. Cilium choose the implement of the "routing" for egress traffic, through Linux routes or eBPF forwarding rules or any other methods.

[- `interfaces`: An array of all interfaces created by the attachment, including any host-level interfaces:
](https://github.com/containernetworking/cni/blob/4c9ae43c0eaa85ec1ab27781e9b258f13e7fd0ca/SPEC.md?plain=1#L571)


[bridge.go
](https://github.com/containernetworking/plugins/blob/06ba001d846042799378f4cb76e085909bbf4723/plugins/main/bridge/bridge.go#L563)
``` go
	// Assume L2 interface only
	result := &current.Result{
		CNIVersion: current.ImplementedSpecVersion,
		Interfaces: []*current.Interface{
			brInterface,
			hostInterface,
			containerInterface,
		},
	}
```

bridge plugin result:

```json
{
    "ips": [
        {
          "address": "10.1.0.5/16",
          "gateway": "10.1.0.1",
          "interface": 2
        }
    ],
    "routes": [
      {
        "dst": "0.0.0.0/0"
      }
    ],
    "interfaces": [
        {
            "name": "cni0",
            "mac": "00:11:22:33:44:55"
        },
        {
            "name": "veth3243",
            "mac": "55:44:33:22:11:11"
        },
        {
            "name": "eth0",
            "mac": "99:88:77:66:55:44",
            "sandbox": "/var/run/netns/blue"
        }
    ],
    "dns": {
      "nameservers": [ "10.1.0.1" ]
    }
}
```

Fixes: #34604
