### PR TITLE
k8s: support for loadbalancer svc ip mode

### DIFF
--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -229,7 +229,7 @@ func ParseService(svc *slim_corev1.Service, nodePortAddrs []netip.Addr) (Service
 
 	if expType.canExpose(slim_corev1.ServiceTypeLoadBalancer) {
 		for _, ip := range svc.Status.LoadBalancer.Ingress {
-			if ip.IP != "" {
+			if ip.IP != "" && ip.IPMode == nil || *ip.IPMode == slim_corev1.LoadBalancerIPModeVIP {
 				loadBalancerIPs = append(loadBalancerIPs, ip.IP)
 			}
 		}


### PR DESCRIPTION
This patch implements [KEP-1860](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1860-kube-proxy-IP-node-binding) for cilium kube-proxy replacement. This feature has been an alpha feature since K8s [1.29](https://kubernetes.io/blog/2023/12/18/kubernetes-1-29-feature-loadbalancer-ip-mode-alpha/) and recently became a beta feature in [1.30](https://kubernetes.io/blog/2024/04/17/kubernetes-v1-30-release/#make-kubernetes-aware-of-the-loadbalancer-behaviour-sig-network-https-github-com-kubernetes-community-tree-master-sig-network).

In a word, kube-proxy should only perform loadbalancing for LoadbalancerIP when the IPMode is "VIP" or empty.