### PR TITLE
Bitlpm fixes and improvements

### DIFF
--- a/pkg/container/bitlpm/cidr.go
+++ b/pkg/container/bitlpm/cidr.go
@@ -31,14 +31,20 @@ func (c *CIDRTrie[T]) ExactLookup(cidr netip.Prefix) (T, bool) {
 }
 
 // LongestPrefixMatch returns the longest matched value for a given address.
-func (c *CIDRTrie[T]) LongestPrefixMatch(addr netip.Addr) (T, bool) {
+func (c *CIDRTrie[T]) LongestPrefixMatch(addr netip.Addr) (netip.Prefix, T, bool) {
 	if !addr.IsValid() {
+		var p netip.Prefix
 		var def T
-		return def, false
+		return p, def, false
 	}
 	bits := addr.BitLen()
 	prefix := netip.PrefixFrom(addr, bits)
-	return c.treeForFamily(prefix).LongestPrefixMatch(cidrKey(prefix))
+	k, v, ok := c.treeForFamily(prefix).LongestPrefixMatch(cidrKey(prefix))
+	if ok {
+		return k.Value(), v, ok
+	}
+	var p netip.Prefix
+	return p, v, ok
 }
 
 // Ancestors iterates over every CIDR pair that contains the CIDR argument.

--- a/pkg/container/bitlpm/cidr.go
+++ b/pkg/container/bitlpm/cidr.go
@@ -69,6 +69,13 @@ func (c *CIDRTrie[T]) Descendants(cidr netip.Prefix, fn func(k netip.Prefix, v T
 	})
 }
 
+// DescendantsShortestPrefixFirst iterates over every CIDR that is contained by the CIDR argument.
+func (c *CIDRTrie[T]) DescendantsShortestPrefixFirst(cidr netip.Prefix, fn func(k netip.Prefix, v T) bool) {
+	c.treeForFamily(cidr).DescendantsShortestPrefixFirst(uint(cidr.Bits()), cidrKey(cidr), func(prefix uint, k Key[netip.Prefix], v T) bool {
+		return fn(k.Value(), v)
+	})
+}
+
 // Upsert adds or updates the value for a given prefix.
 func (c *CIDRTrie[T]) Upsert(cidr netip.Prefix, v T) bool {
 	return c.treeForFamily(cidr).Upsert(uint(cidr.Bits()), cidrKey(cidr), v)

--- a/pkg/container/bitlpm/cidr.go
+++ b/pkg/container/bitlpm/cidr.go
@@ -54,6 +54,14 @@ func (c *CIDRTrie[T]) Ancestors(cidr netip.Prefix, fn func(k netip.Prefix, v T) 
 	})
 }
 
+// AncestorsLongestPrefixFirst iterates over every CIDR pair that contains the CIDR argument,
+// longest matching prefix first, then iterating towards the root of the trie.
+func (c *CIDRTrie[T]) AncestorsLongestPrefixFirst(cidr netip.Prefix, fn func(k netip.Prefix, v T) bool) {
+	c.treeForFamily(cidr).AncestorsLongestPrefixFirst(uint(cidr.Bits()), cidrKey(cidr), func(prefix uint, k Key[netip.Prefix], v T) bool {
+		return fn(k.Value(), v)
+	})
+}
+
 // Descendants iterates over every CIDR that is contained by the CIDR argument.
 func (c *CIDRTrie[T]) Descendants(cidr netip.Prefix, fn func(k netip.Prefix, v T) bool) {
 	c.treeForFamily(cidr).Descendants(uint(cidr.Bits()), cidrKey(cidr), func(prefix uint, k Key[netip.Prefix], v T) bool {

--- a/pkg/container/bitlpm/cidr_test.go
+++ b/pkg/container/bitlpm/cidr_test.go
@@ -71,6 +71,29 @@ loop:
 	t.Log(havePath)
 	assert.Equal(t, wantPath, havePath)
 
+	// Search should return the complete path to the prefix
+	// will look up 1.1.1.128/25.
+	wantPath = []string{
+		"last", // 1.1.1.129/32
+		"4b",   // 1.1.1.128/25
+		"3a",   // 1.1.1.0/24
+		"2a",   // 1.1.0.0/16
+		"1",    // 1.0.0.0/8
+		"0",    // 0.0.0.0/0
+	}
+
+	havePath = []string{}
+	trie.AncestorsLongestPrefixFirst(prefixes["last"], func(k netip.Prefix, v string) bool {
+		wantK := prefixes[v]
+		if wantK != k {
+			t.Errorf("Search(%s) returned an unexpected key-value pair: k %s v %s", prefixes["last"], k.String(), v)
+		}
+		havePath = append(havePath, v)
+		return true
+	})
+	t.Log(havePath)
+	assert.Equal(t, wantPath, havePath)
+
 	for _, tc := range []struct {
 		k string
 		v string

--- a/pkg/container/bitlpm/cidr_test.go
+++ b/pkg/container/bitlpm/cidr_test.go
@@ -42,7 +42,7 @@ loop:
 				continue loop
 			}
 		}
-		have, _ := trie.LongestPrefixMatch(prefixes[name].Addr())
+		_, have, _ := trie.LongestPrefixMatch(prefixes[name].Addr())
 		if have != name {
 			t.Errorf("LongestPrefixMatch(%s) returned %s want %s", prefixes[name].String(), have, name)
 		}
@@ -92,7 +92,8 @@ loop:
 			"0",
 		},
 	} {
-		v, ok := trie.LongestPrefixMatch(netip.MustParsePrefix(tc.k).Addr())
+		k, v, ok := trie.LongestPrefixMatch(netip.MustParsePrefix(tc.k).Addr())
+		assert.True(t, k.IsValid())
 		assert.True(t, ok)
 		assert.Equal(t, tc.v, v)
 	}

--- a/pkg/container/bitlpm/cidr_test.go
+++ b/pkg/container/bitlpm/cidr_test.go
@@ -5,6 +5,7 @@ package bitlpm
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"net/netip"
 	"reflect"
 	"testing"
@@ -206,6 +207,128 @@ func TestDescendants(t *testing.T) {
 	}
 }
 
+func TestDescendantsShortestPrefixFirst(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefixes map[int]netip.Prefix
+	}{
+		{
+			name: "all",
+			prefixes: map[int]netip.Prefix{
+				0:  netip.MustParsePrefix("0.0.0.0/0"),
+				1:  netip.MustParsePrefix("0.0.0.0/1"),
+				2:  netip.MustParsePrefix("0.0.0.0/2"),
+				3:  netip.MustParsePrefix("0.0.0.0/3"),
+				4:  netip.MustParsePrefix("0.0.0.0/4"),
+				5:  netip.MustParsePrefix("0.0.0.0/5"),
+				6:  netip.MustParsePrefix("0.0.0.0/6"),
+				7:  netip.MustParsePrefix("0.0.0.0/7"),
+				8:  netip.MustParsePrefix("0.0.0.0/8"),
+				9:  netip.MustParsePrefix("0.0.0.0/9"),
+				10: netip.MustParsePrefix("0.0.0.0/10"),
+				11: netip.MustParsePrefix("0.0.0.0/11"),
+				12: netip.MustParsePrefix("0.0.0.0/12"),
+				13: netip.MustParsePrefix("0.0.0.0/13"),
+				14: netip.MustParsePrefix("0.0.0.0/14"),
+				15: netip.MustParsePrefix("0.0.0.0/15"),
+				16: netip.MustParsePrefix("0.0.0.0/16"),
+				17: netip.MustParsePrefix("0.0.0.0/17"),
+				18: netip.MustParsePrefix("0.0.0.0/18"),
+				19: netip.MustParsePrefix("0.0.0.0/19"),
+				20: netip.MustParsePrefix("0.0.0.0/20"),
+				21: netip.MustParsePrefix("0.0.0.0/21"),
+				22: netip.MustParsePrefix("0.0.0.0/22"),
+				23: netip.MustParsePrefix("0.0.0.0/23"),
+				24: netip.MustParsePrefix("0.0.0.0/24"),
+				25: netip.MustParsePrefix("0.0.0.0/25"),
+				26: netip.MustParsePrefix("0.0.0.0/26"),
+				27: netip.MustParsePrefix("0.0.0.0/27"),
+				28: netip.MustParsePrefix("0.0.0.0/28"),
+				29: netip.MustParsePrefix("0.0.0.0/29"),
+				30: netip.MustParsePrefix("0.0.0.0/30"),
+				31: netip.MustParsePrefix("0.0.0.0/31"),
+				32: netip.MustParsePrefix("0.0.0.0/32"),
+			},
+		}, {
+			name: "sparse",
+			prefixes: map[int]netip.Prefix{
+				0:  netip.MustParsePrefix("0.0.0.0/0"),
+				16: netip.MustParsePrefix("0.0.0.0/16"),
+				32: netip.MustParsePrefix("0.0.0.0/32"),
+			},
+		}, {
+			name: "trie",
+			prefixes: map[int]netip.Prefix{
+				0:  netip.MustParsePrefix("0.0.0.0/0"),
+				1:  netip.MustParsePrefix("128.0.0.0/1"),
+				2:  netip.MustParsePrefix("64.0.0.0/2"),
+				3:  netip.MustParsePrefix("192.0.0.0/3"),
+				4:  netip.MustParsePrefix("32.0.0.0/4"),
+				5:  netip.MustParsePrefix("16.0.0.0/5"),
+				6:  netip.MustParsePrefix("48.0.0.0/6"),
+				7:  netip.MustParsePrefix("4.0.0.0/7"),
+				8:  netip.MustParsePrefix("1.0.0.0/8"),
+				9:  netip.MustParsePrefix("128.128.0.0/9"),
+				10: netip.MustParsePrefix("64.64.0.0/10"),
+				11: netip.MustParsePrefix("192.192.0.0/11"),
+				12: netip.MustParsePrefix("32.32.0.0/12"),
+				13: netip.MustParsePrefix("16.16.0.0/13"),
+				14: netip.MustParsePrefix("48.48.0.0/14"),
+				15: netip.MustParsePrefix("4.4.0.0/15"),
+				16: netip.MustParsePrefix("1.1.0.0/16"),
+				17: netip.MustParsePrefix("128.128.128.0/17"),
+				18: netip.MustParsePrefix("64.64.64.0/18"),
+				19: netip.MustParsePrefix("192.192.192.0/19"),
+				20: netip.MustParsePrefix("32.32.32.0/20"),
+				21: netip.MustParsePrefix("16.16.16.0/21"),
+				22: netip.MustParsePrefix("48.48.48.0/22"),
+				23: netip.MustParsePrefix("4.4.4.0/23"),
+				24: netip.MustParsePrefix("1.1.1.0/24"),
+				25: netip.MustParsePrefix("128.128.128.128/25"),
+				26: netip.MustParsePrefix("64.64.64.64/26"),
+				27: netip.MustParsePrefix("192.192.192.192/27"),
+				28: netip.MustParsePrefix("32.32.32.32/28"),
+				29: netip.MustParsePrefix("16.16.16.16/29"),
+				30: netip.MustParsePrefix("48.48.48.48/30"),
+				31: netip.MustParsePrefix("4.4.4.4/31"),
+				32: netip.MustParsePrefix("1.1.1.1/32"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Logf("Running test case %q", tt.name)
+		tr := NewCIDRTrie[string]()
+		for _, v := range tt.prefixes {
+			tr.Upsert(v, v.String())
+		}
+		for i := 0; i <= 32; i++ {
+			pref, ok := tt.prefixes[i]
+			if !ok {
+				// No such prefix
+				continue
+			}
+			expectedRes := make([]string, 0, 32-i)
+			for t := i; t <= 32; t++ {
+				p, ok := tt.prefixes[t]
+				if !ok {
+					continue
+				}
+				if pref.Contains(p.Addr()) {
+					expectedRes = append(expectedRes, p.String())
+				}
+			}
+			gotRes := make([]string, 0, 32-i)
+			tr.DescendantsShortestPrefixFirst(pref, func(_ netip.Prefix, v string) bool {
+				gotRes = append(gotRes, v)
+				return true
+			})
+			if !reflect.DeepEqual(expectedRes, gotRes) {
+				t.Fatalf("LPM Descendants prefix %s, expected to get %v, but got: %v", pref.String(), expectedRes, gotRes)
+			}
+		}
+	}
+}
+
 func TestBitValueAt(t *testing.T) {
 	for i, tc := range []struct {
 		v    netip.Prefix
@@ -316,4 +439,118 @@ func TestCommonPrefix(t *testing.T) {
 			}
 		})
 	}
+}
+
+func generatePrefix(b *testing.B, r *rand.Rand) netip.Prefix {
+	var addr4 [4]byte
+	prefixlen := r.IntN(33)
+	if prefixlen > 0 {
+		mask := ^uint32(0)
+		if prefixlen < 32 {
+			mask <<= (32 - prefixlen)
+		}
+		masked := r.Uint32() & mask
+		addr4[0] = byte(masked >> 24)
+		addr4[1] = byte(masked >> 16)
+		addr4[2] = byte(masked >> 8)
+		addr4[3] = byte(masked)
+	}
+	addr := netip.AddrFrom4(addr4)
+	assert.True(b, addr.IsValid())
+	p := netip.PrefixFrom(addr, prefixlen)
+	assert.True(b, p.IsValid())
+	assert.Equal(b, prefixlen, p.Bits())
+	return p
+}
+
+func generateCIDRs(b *testing.B, r *rand.Rand, n int) *CIDRTrie[struct{}] {
+	t := NewCIDRTrie[struct{}]()
+	for i := 0; i < n; i++ {
+		if !t.Upsert(generatePrefix(b, r), struct{}{}) {
+			n++
+		}
+	}
+	return t
+}
+
+func BenchmarkTraversal(b *testing.B) {
+	const (
+		nCIDRs      = 100000
+		prefixLen   = 16
+		randomSeed1 = uint64(42)
+		randomSeed2 = uint64(733)
+	)
+	r := rand.New(rand.NewPCG(randomSeed1, randomSeed2))
+	t := generateCIDRs(b, r, nCIDRs)
+	assert.Equal(b, uint(nCIDRs), t.Len())
+	rnd := r.Uint32()
+	prefix := netip.PrefixFrom(netip.AddrFrom4([4]byte{byte(rnd >> 24), byte(rnd >> 16), 0, 0}), prefixLen)
+	assert.True(b, prefix.IsValid())
+	assert.Equal(b, prefixLen, prefix.Bits())
+
+	b.Run("ancestors root-first", func(b *testing.B) {
+		n := 0
+
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			n = 0
+			t.Ancestors(prefix, func(k netip.Prefix, _ struct{}) bool {
+				n++
+				return true
+			})
+		}
+	})
+
+	b.Run("Ancestors longest-prefix-first", func(b *testing.B) {
+		n := 0
+		lastLen := 0
+
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			n = 0
+			lastLen = prefixLen
+			t.AncestorsLongestPrefixFirst(prefix, func(k netip.Prefix, _ struct{}) bool {
+				pLen := prefix.Bits()
+				assert.True(b, pLen <= lastLen)
+				lastLen = pLen
+				n++
+				return true
+			})
+		}
+	})
+
+	b.Run("descendants depth-first", func(b *testing.B) {
+		n := 0
+
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			n = 0
+			t.Descendants(prefix, func(k netip.Prefix, _ struct{}) bool {
+				n++
+				return true
+			})
+		}
+	})
+
+	b.Run("descendants shortest-prefix-first", func(b *testing.B) {
+		n := 0
+		lastLen := 0
+
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			n = 0
+			lastLen = 0
+			t.DescendantsShortestPrefixFirst(prefix, func(k netip.Prefix, _ struct{}) bool {
+				pLen := prefix.Bits()
+				assert.True(b, pLen >= lastLen)
+				lastLen = pLen
+				n++
+				return true
+			})
+		}
+	})
 }

--- a/pkg/container/bitlpm/trie.go
+++ b/pkg/container/bitlpm/trie.go
@@ -30,7 +30,7 @@ type Trie[K, T any] interface {
 	ExactLookup(prefix uint, key K) (v T, ok bool)
 	// LongestPrefixMatch returns the longest prefix match for a specific
 	// key.
-	LongestPrefixMatch(key K) (v T, ok bool)
+	LongestPrefixMatch(key K) (k K, v T, ok bool)
 	// Ancestors iterates over every prefix-key pair that contains
 	// the prefix-key argument pair. If the Ancestors function argument
 	// returns false the iteration will stop. Ancestors will iterate
@@ -129,19 +129,16 @@ func (t *trie[K, T]) ExactLookup(prefixLen uint, k Key[K]) (ret T, found bool) {
 
 // LongestPrefixMatch returns the value for the key with the
 // longest prefix match of the argument key.
-func (t *trie[K, T]) LongestPrefixMatch(k Key[K]) (T, bool) {
-	// default return value
-	var (
-		empty T
-		ok    bool
-	)
-	ret := &empty
-	t.traverse(t.maxPrefix, k, func(currentNode *node[K, T], matchLen uint) bool {
-		ret = &currentNode.value
-		ok = true
+func (t *trie[K, T]) LongestPrefixMatch(k Key[K]) (key Key[K], value T, ok bool) {
+	var lpmNode *node[K, T]
+	t.traverse(t.maxPrefix, k, func(currentNode *node[K, T], _ uint) bool {
+		lpmNode = currentNode
 		return true
 	})
-	return *ret, ok
+	if lpmNode != nil {
+		return lpmNode.key, lpmNode.value, true
+	}
+	return
 }
 
 // Ancestors calls the function argument for every prefix/key/value in the trie

--- a/pkg/container/bitlpm/trie.go
+++ b/pkg/container/bitlpm/trie.go
@@ -243,7 +243,7 @@ func (t *trie[K, T]) traverse(prefixLen uint, k Key[K], fn func(currentNode *nod
 // key. If the match length is not exactly equal, or there is no child
 // to traverse to, or the node prefix is exactly equal to the
 // upsert prefix (these conditions are not mutually exclusive) then traversal
-// is finished. There are four possible insertion/replacement condtions
+// is finished. There are four possible insertion/replacement conditions
 // to consider:
 //  1. The node key is nil (that is, an empty children "slot"), in which
 //     case the previous key iterated over should be the upsert-key's
@@ -360,15 +360,18 @@ func (t *trie[K, T]) Upsert(prefixLen uint, k Key[K], value T) bool {
 		} else {
 			parent.children[bitVal] = upsertNode
 		}
+
+		upsertNode.children[0] = currentNode.children[0]
+		upsertNode.children[1] = currentNode.children[1]
+
 		// If we're not replacing an intermediate node
 		// then decrement this function's previous
 		// increment of `entries`.
 		if !currentNode.intermediate {
 			t.entries--
+			return false // count remains the same as before
 		}
-		upsertNode.children[0] = currentNode.children[0]
-		upsertNode.children[1] = currentNode.children[1]
-		return false
+		return true
 	}
 
 	// The upsert-node matches the current-node up to

--- a/pkg/container/bitlpm/unsigned.go
+++ b/pkg/container/bitlpm/unsigned.go
@@ -59,8 +59,13 @@ func (ut *UintTrie[K, T]) ExactLookup(prefix uint, k K) (T, bool) {
 	return ut.trie.ExactLookup(prefix, ut.getKey(k))
 }
 
-func (ut *UintTrie[K, T]) LongestPrefixMatch(k K) (T, bool) {
-	return ut.trie.LongestPrefixMatch(ut.getKey(k))
+func (ut *UintTrie[K, T]) LongestPrefixMatch(k K) (K, T, bool) {
+	k2, v, ok := ut.trie.LongestPrefixMatch(ut.getKey(k))
+	if ok {
+		return k2.Value(), v, ok
+	}
+	var empty K
+	return empty, v, ok
 }
 
 func (ut *UintTrie[K, T]) Ancestors(prefix uint, k K, fn func(prefix uint, key K, value T) bool) {

--- a/pkg/container/bitlpm/unsigned_test.go
+++ b/pkg/container/bitlpm/unsigned_test.go
@@ -375,7 +375,7 @@ func TestUnsignedLongestPrefixMatch(t *testing.T) {
 				// purpose of the loop condition as some tests
 				// overflow uint16 causing an infinite loop.
 				for p := uint(start); p <= uint(end); p++ {
-					got, _ := ut.LongestPrefixMatch(uint16(p))
+					_, got, _ := ut.LongestPrefixMatch(uint16(p))
 					if entry != got {
 						t.Fatalf("Looking up key %d, expected entry %q, but got %q", p, entry, got)
 					}
@@ -385,13 +385,13 @@ func TestUnsignedLongestPrefixMatch(t *testing.T) {
 			start := firstRange.start
 			end := lastRange.end
 			for p := uint(0); p < uint(start); p++ {
-				got, ok := ut.LongestPrefixMatch(uint16(p))
+				_, got, ok := ut.LongestPrefixMatch(uint16(p))
 				if ok {
 					t.Fatalf("Looking up key %d, expected no entry, but got %q", p, got)
 				}
 			}
 			for p := uint(end) + 1; p <= uint(65535); p++ {
-				got, ok := ut.LongestPrefixMatch(uint16(p))
+				_, got, ok := ut.LongestPrefixMatch(uint16(p))
 				if ok {
 					t.Fatalf("Looking up key %d, expected no entry, but got %q", p, got)
 				}
@@ -778,7 +778,7 @@ func BenchmarkTrieLongestPrefixMatch(b *testing.B) {
 	for i := uint32(0); i < 255; i++ {
 		upperOct := i << 8
 		for t := uint32(0); t < 255; t++ {
-			_, ok := tri.LongestPrefixMatch(0xffff_0000 | upperOct | t)
+			_, _, ok := tri.LongestPrefixMatch(0xffff_0000 | upperOct | t)
 			if !ok {
 				b.Fatal("expected valid lookup, but got nil")
 			}


### PR DESCRIPTION
Fix a bug in `pkg/container/bitlpm` `trie.Upsert` return value when changing an intermediate node to a non-intermediate one by returning `true` instead of `false`.

Return the matching key (if any) from `trie.LongestPrefixMatch` as the caller may need it.

Add new functions `AncestorsLongestPrefixFirst` and `DescendantsShortestPrefixFirst` which allow the caller to skip iterating non-interesting nodes when the iteration can be satisfied by a node closest to the search prefix/key towards the root (for `AncestorsLongestPrefixFirst`) or towards the leaves (for `DescendantsShortestPrefixFirst`)