### PR TITLE
lbipam: Fix importing services with shared IP

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -653,6 +653,11 @@ func (ipam *LBIPAM) stripOrImportIngresses(sv *ServiceView) (statusModified bool
 				IP:     ip,
 				Origin: lbRange,
 			})
+
+			// If the `ServiceView` has a sharing key, add the IP to the `rangeStore` index
+			if sv.SharingKey != "" {
+				ipam.rangesStore.AddServiceViewIPForSharingKey(sv.SharingKey, &sv.AllocatedIPs[len(sv.AllocatedIPs)-1])
+			}
 		}
 
 		newIngresses = append(newIngresses, ingress)


### PR DESCRIPTION
There was a bug in the LB-IPAM import logic. When one or more services share the same IP, and the agent restarts, the services would not share the IP anymore.

This happens because when the import logic allocated an IP, it did not register the sharing group if that service had a sharing key. This caused the non-import path which is called for the second service to conclude that the second service was the first service in the group so it would allocate a new IP.

This PR makes sure the import logic registers the sharing group when it allocates an IP.

Fixes: #30700

```release-note
Fixed bug in LB-IPAM where restarting the operator would unshare previously shared IPs between services
```
