### PR TITLE
CESs will be created directly from Pods.

### DIFF
--- a/operator/pkg/ciliumendpointslice/pod.go
+++ b/operator/pkg/ciliumendpointslice/pod.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumendpointslice
+
+import (
+	//"context"
+	"net/netip"
+
+	"github.com/cilium/cilium/api/v1/models"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+
+	//"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	//"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
+)
+
+// Make CoreCEP from pods.
+// ConvertCEPToCoreCEP converts a CiliumEndpoint to a CoreCiliumEndpoint
+// containing only a minimal set of entities
+func ConvertPodToCoreCEP(pod *slim_corev1.Pod) *cilium_v2alpha1.CoreCiliumEndpoint {
+	// Copy Networking field into core CEP
+	var epNetworking *cilium_v2.EndpointNetworking
+	var addressPairs cilium_v2.AddressPairList
+	for _, podIP := range pod.Status.PodIPs {
+		ip, err := netip.ParseAddr(podIP.IP)
+		if err != nil {
+			// Handle the error, perhaps log it and continue
+			continue
+		}
+		if ip.Is4() {
+			addressPairs = append(addressPairs, &cilium_v2.AddressPair{
+				IPV4: ip.String(),
+				IPV6: "", // Empty string for IPv6 since this is an IPv4 address
+			})
+		} else if ip.Is6() {
+			addressPairs = append(addressPairs, &cilium_v2.AddressPair{
+				IPV4: "", // Empty string for IPv4 since this is an IPv6 address
+				IPV6: ip.String(),
+			})
+		}
+	}
+	//if pod.Status.PodIPs != nil {
+	epNetworking = &cilium_v2.EndpointNetworking{Addressing: addressPairs}
+	//}
+	//var identityID int64 = 0
+	//if pod.Status.Identity != nil {
+	//	identityID = pod.Status.Identity.ID
+	//}
+	var ports models.NamedPorts
+	for _, container := range pod.Spec.Containers {
+		for _, containerPort := range container.Ports {
+			ports = append(ports, &models.Port{
+				Name:     containerPort.Name,
+				Port:     uint16(containerPort.ContainerPort),
+				Protocol: string(containerPort.Protocol),
+			})
+		}
+	}
+	return &cilium_v2alpha1.CoreCiliumEndpoint{
+		Name:       pod.GetName(),
+		Networking: epNetworking,
+		Encryption: cilium_v2.EncryptionSpec{Key: int(node.GetEndpointEncryptKeyIndex())}, //TODO: Populate from the node object
+		//IdentityID: identityID,//from CID controller
+		NamedPorts: ports,
+	}
+}

--- a/operator/pkg/ciliumendpointslice/testutils/test_utils.go
+++ b/operator/pkg/ciliumendpointslice/testutils/test_utils.go
@@ -5,29 +5,15 @@ package testutils
 import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 )
 
 func CreateManagerEndpoint(name string, identity int64) capi_v2a1.CoreCiliumEndpoint {
 	return capi_v2a1.CoreCiliumEndpoint{
 		Name:       name,
 		IdentityID: identity,
-	}
-}
-
-func CreateStoreEndpoint(name string, namespace string, identity int64) *v2.CiliumEndpoint {
-	return &v2.CiliumEndpoint{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Status: v2.EndpointStatus{
-			Identity: &v2.EndpointIdentity{
-				ID: identity,
-			},
-			Networking: &v2.EndpointNetworking{},
-		},
 	}
 }
 
@@ -38,6 +24,18 @@ func CreateStoreEndpointSlice(name string, namespace string, endpoints []capi_v2
 		},
 		Namespace: namespace,
 		Endpoints: endpoints,
+	}
+}
+
+func CreateStorePod(name string, namespace string, identity int64) *slim_corev1.Pod {
+	return &slim_corev1.Pod{
+		TypeMeta: slim_metav1.TypeMeta{},
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec:   slim_corev1.PodSpec{},
+		Status: slim_corev1.PodStatus{},
 	}
 }
 

--- a/operator/pkg/ciliumidentity/cache.go
+++ b/operator/pkg/ciliumidentity/cache.go
@@ -142,6 +142,11 @@ func NewCIDUsageInPods() *CIDUsageInPods {
 	}
 }
 
+func (c *CIDUsageInPods) podUsesCID(podNamespacedName string) string {
+	cidName := c.podToCID[podNamespacedName]
+	return cidName
+}
+
 // AssignCIDToPod updates the pod to CID map and increments the CID usage.
 // It also decrements the previous CID usage and returns the CID name of
 // previously set CID and its usage count after decrementing the CID usage.


### PR DESCRIPTION
CESs will be created directly from Pods.
Previously, CiliumEndpoints (CEPs) were created from Pods. Then, from multiple CEPs, CiliumEndpoints were created. This commit removes CEPs in the CiliumOperator. The controller watches for pod events in the same way it previously watched for CEP events. The CESs are directly created from the pods.
CFP doc: https://docs.google.com/document/d/1yuqFz0NX71DKOIL0ftWQm0a7f6HFFnTGXtUQjHUXyxA/edit?usp=sharing
