### PR TITLE
lbipam: Remove init done callback hooks

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -104,9 +104,6 @@ type LBIPAM struct {
 	pools        map[string]*cilium_api_v2alpha1.CiliumLoadBalancerIPPool
 	rangesStore  rangesStore
 	serviceStore serviceStore
-
-	// Only used during testing.
-	initDoneCallbacks []func()
 }
 
 func (ipam *LBIPAM) restart() {
@@ -134,13 +131,6 @@ func (ipam *LBIPAM) Run(ctx context.Context, health cell.Health) {
 
 	ipam.logger.Info("LB-IPAM initializing")
 	svcChan := ipam.initialize(ctx, poolChan)
-
-	for _, cb := range ipam.initDoneCallbacks {
-		if cb != nil {
-			cb()
-		}
-	}
-
 	ipam.logger.Info("LB-IPAM done initializing")
 
 	for {
@@ -264,12 +254,6 @@ func (ipam *LBIPAM) handleServiceEvent(ctx context.Context, event resource.Event
 		}
 	}
 	event.Done(err)
-}
-
-// RegisterOnReady registers a callback function which will be invoked when LBIPAM is done initializing.
-// Note: mainly used in the integration tests.
-func (ipam *LBIPAM) RegisterOnReady(cb func()) {
-	ipam.initDoneCallbacks = append(ipam.initDoneCallbacks, cb)
 }
 
 func (ipam *LBIPAM) poolOnUpsert(ctx context.Context, pool *cilium_api_v2alpha1.CiliumLoadBalancerIPPool) error {


### PR DESCRIPTION
In the past we used to have a hook for tests which were called when the init was done. This is no longer needed and can be removed.