### PR TITLE
BPF: Fix issue where set_identity_mark would correctly set mark value resulting in incorrectly SNATed VXLAN traffic.

### DIFF
--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -102,7 +102,7 @@ set_identity_mark(struct __sk_buff *ctx, __u32 identity, __u32 magic)
 	__u32 cluster_id_lower = cluster_id & 0xFF;
 	__u32 cluster_id_upper = ((cluster_id & 0xFFFFFF00) << (8 + IDENTITY_LEN));
 
-	ctx->mark |= magic;
+	ctx->mark = (magic & MARK_MAGIC_KEY_MASK);
 	ctx->mark &= MARK_MAGIC_KEY_MASK;
 	ctx->mark |= (identity & IDENTITY_MAX) << 16 | cluster_id_lower | cluster_id_upper;
 }

--- a/bpf/tests/bpf_skb_255_tests.c
+++ b/bpf/tests/bpf_skb_255_tests.c
@@ -42,6 +42,28 @@ int check_get_identity(struct __ctx_buff *ctx)
 	test_finish();
 }
 
+CHECK("tc", "set_identity_mark_bits")
+int set_identity_mark_bits(struct __ctx_buff *ctx)
+{
+	test_init();
+
+	set_identity_mark(ctx, 0x0, MARK_MAGIC_IDENTITY);
+	set_identity_mark(ctx, 0x0, MARK_MAGIC_OVERLAY);
+
+	if ((ctx->mark & MARK_MAGIC_HOST_MASK) != MARK_MAGIC_OVERLAY)
+		test_fatal("expected %x got %x", MARK_MAGIC_OVERLAY, ctx->mark);
+
+	set_identity_mark(ctx, 0x0, 0x000);
+	if ((ctx->mark & MARK_MAGIC_HOST_MASK) != 0)
+		test_fatal("expected %x got %x", 0, ctx->mark);
+
+	set_identity_mark(ctx, 0x0, MARK_MAGIC_HOST_MASK);
+	if ((ctx->mark & MARK_MAGIC_HOST_MASK) != MARK_MAGIC_HOST_MASK)
+		test_fatal("expected %x got %x", MARK_MAGIC_HOST_MASK, ctx->mark);
+
+	test_finish();
+}
+
 CHECK("tc", "set_and_get_cluster_id")
 int check_ctx_get_cluster_id_mark(struct __ctx_buff *ctx)
 {


### PR DESCRIPTION
This fixes issues where prior mark values would not be correctly
set if the mark set needed to remove bits. This was a result of set_identity_mark not correctly clearing the identity mark bits prior to setting the new magic mark value.  For example:

0x0f00 (`MARK_MAGIC_IDENTITY`) updated using `set_identity_mark` with magic=0x0400 (`MARK_MAGIC_OVERLAY`) would result in the mark remaining at: `0x0f00`, since 0x0400 would need to turn off bits to be set.  

set_identity_mark is used in various code paths such as bpf_host and bpf_overlay.  Most likely, this would affect any code path where we're going from `MARK_MAGIC_IDENTITY` -> any other mark value.

```release-note
Fix issue where bpf packet buffer mark would in some cases set incorrect mark value resulting in incorrectly SNATed traffic.
```