### PR TITLE
docs: Clarify instructions for bumping K8s to avoid forks

### DIFF
--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -450,7 +450,10 @@ Minor version
 
 #. Run ``git add vendor/ test/provision/manifest/ Documentation/ && git commit -sam "Update k8s tests and libraries to v1.28.0-rc.0"``
 
-#. Submit all your changes into a new PR.
+#. Submit all your changes into a new PR. Ensure the PR is opened against a
+   branch in ``cilium/cilium`` and *not* a fork. Otherwise, CI is not triggered
+   properly. Please open a thread on #development if you do not have
+   permissions to create a branch in ``cilium/cilium``.
 
 #. Ensure that the target CI workflows are running and passing after updating
    the target k8s versions in the GitHub action workflows.

--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -418,7 +418,13 @@ Minor version
    - ``Documentation/network/kubernetes/compatibility.rst``
    - ``Documentation/network/kubernetes/requirements.rst``
 
-#. Update the Kubernetes version with the newer version in``test/test_suite_test.go``.
+#. Update the Kubernetes version with the newer version in
+   - ``test/test_suite_test.go``.
+   - ``.github/actions/ginkgo/main-prs.yaml``
+   - ``.github/actions/ginkgo/main-scheduled.yaml``
+   - ``.github/actions/set-env-variables/action.yml``
+   - ``contrib/scripts/devcontainer-setup.sh``
+   - ``.github/actions/ginkgo/main-focus.yaml``
 
 #. Add the new coredns files specific for the Kubernetes version,
    for ``1.19`` is ``test/provision/manifest/1.19``. The coredns deployment


### PR DESCRIPTION
Opening a PR against a branch on a fork won't properly test all of the
changes in the PR because parts of the CI suite don't pick up the
changes in the workflows for security reasons.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
