### PR TITLE
bpf: wireguard: block non-wireguard traffic from entering the overlay network

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -614,6 +614,13 @@ int cil_from_overlay(struct __ctx_buff *ctx)
  * non-IPSec mode.
  */
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
+#ifdef ENABLE_WIREGUARD
+	if (!decrypted)
+		return send_drop_notify_error_ext(ctx, src_sec_identity, 
+						  DROP_UNENCRYPTED_TRAFFIC,
+						  ext_err, CTX_ACT_DROP,
+						  METRIC_INGRESS);
+#endif
 
 	switch (proto) {
 #if defined(ENABLE_IPV4) || defined(ENABLE_IPV6)

--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -13,6 +13,7 @@
 #include "lib/trace.h"
 #include "lib/drop.h"
 #include "lib/nodeport.h"
+#include "bpf/helpers.h"
 
 /* to-wireguard is attached as a tc egress filter to the cilium_wg0 device.
  */
@@ -46,6 +47,18 @@ int cil_to_wireguard(struct __ctx_buff *ctx)
 
 out:
 #endif /* ENABLE_NODEPORT */
+
+	return TC_ACT_OK;
+}
+
+/* from-wireguard is attached as a tc ingress filter to the cilium_wg0 device.
+ */
+__section_entry
+int cil_from_wireguard(struct __ctx_buff *ctx)
+{
+	bpf_clear_meta(ctx);
+
+	ctx->mark = MARK_MAGIC_DECRYPT;
 
 	return TC_ACT_OK;
 }

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -215,6 +215,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		health{},
 		northSouthLoadbalancing{},
 		podToPodEncryption{},
+		podToPodEncryptionInjection{},
 		nodeToNodeEncryption{},
 		egressGateway{},
 		egressGatewayExcludedCidrs{},

--- a/cilium-cli/connectivity/builder/pod_to_pod_encryption_injection.go
+++ b/cilium-cli/connectivity/builder/pod_to_pod_encryption_injection.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type podToPodEncryptionInjection struct{}
+
+func (t podToPodEncryptionInjection) build(ct *check.ConnectivityTest, _ map[string]string) {
+	// Encryption checks are always executed as a sanity check, asserting whether
+	// unencrypted packets shall, or shall not, be observed based on the feature set.
+	newTest("pod-to-pod-encryption-injection", ct).
+		WithCondition(func() bool { return !ct.Params().SingleNode }).
+		WithFeatureRequirements(
+			features.RequireEnabled(features.NodeWithoutCilium),
+		).
+		WithScenarios(
+			tests.PodToPodEncryptionInjection(features.RequireEnabled(features.EncryptionPod)),
+		)
+}

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -4,6 +4,7 @@
 package check
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -1000,6 +1001,22 @@ func (ct *ConnectivityTest) PingCommand(peer TestPeer, ipFam features.IPFamily, 
 	cmd = append(cmd, extraArgs...)
 
 	cmd = append(cmd, peer.Address(ipFam))
+
+	return cmd
+}
+
+func (ct *ConnectivityTest) SendUDPCommand(peer TestPeer, ipFam features.IPFamily, payload []byte) []string {
+	// Encode bytes to \x00 format
+	var result []byte
+	buff := bytes.NewBuffer(result)
+
+	for _, b := range payload {
+		fmt.Fprintf(buff, "\\x%02x", b)
+	}
+
+	innerCmd := fmt.Sprintf("echo -en \"%s\" | nc -u -w 1 [%s] %d && echo \"finished sending\"", buff.String(), peer.Address(ipFam), 8472)
+
+	cmd := []string{"sh", "-c", innerCmd}
 
 	return cmd
 }

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -316,12 +316,7 @@ func (l *loader) reinitializeOverlay(ctx context.Context, tunnelConfig tunnel.Co
 }
 
 func (l *loader) reinitializeWireguard(ctx context.Context) (err error) {
-	// to-wireguard bpf is only used for rev-DNAT, which is only needed when NodePort, KPR, native routing and L7 proxy are enabled together
-	if !option.Config.EnableWireguard ||
-		!option.Config.EnableNodePort ||
-		!option.Config.EnableL7Proxy ||
-		option.Config.RoutingMode != option.RoutingModeNative ||
-		option.Config.KubeProxyReplacement != option.KubeProxyReplacementTrue {
+	if !option.Config.EnableWireguard {
 		return
 	}
 

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -49,7 +49,8 @@ const (
 	symbolFromHostEp       = "cil_from_host"
 	symbolToHostEp         = "cil_to_host"
 
-	symbolToWireguard = "cil_to_wireguard"
+	symbolToWireguard   = "cil_to_wireguard"
+	symbolFromWireguard = "cil_from_wireguard"
 
 	symbolFromHostNetdevXDP = "cil_xdp_entry"
 
@@ -650,6 +651,12 @@ func (l *loader) replaceWireguardDatapath(ctx context.Context, cArgs []string, i
 		linkDir, netlink.HANDLE_MIN_EGRESS, option.Config.EnableTCX); err != nil {
 		return fmt.Errorf("interface %s egress: %w", device, err)
 	}
+
+	if err := attachSKBProgram(device, obj.FromWireguard, symbolFromWireguard,
+		linkDir, netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
+		return fmt.Errorf("interface %s ingress: %w", device, err)
+	}
+
 	if err := commit(); err != nil {
 		return fmt.Errorf("committing bpf pins: %w", err)
 	}

--- a/pkg/datapath/loader/objects.go
+++ b/pkg/datapath/loader/objects.go
@@ -95,11 +95,12 @@ func (o *networkObjects) Close() {
 // wireguardObjects receives eBPF objects for attaching to Wireguard interfaces.
 // Objects originate from bpf_wireguard.c.
 type wireguardObjects struct {
-	ToWireguard *ebpf.Program `ebpf:"cil_to_wireguard"`
+	ToWireguard   *ebpf.Program `ebpf:"cil_to_wireguard"`
+	FromWireguard *ebpf.Program `ebpf:"cil_from_wireguard"`
 }
 
 func (o *wireguardObjects) Close() {
-	bpfClose(o.ToWireguard)
+	bpfClose(o.FromWireguard, o.ToWireguard)
 }
 
 func bpfClose(closers ...io.Closer) error {


### PR DESCRIPTION
I wanted to have a try on a solution for the scenario where an Cilium-external workload can inject packets to the overlay network. Therefore, all pods are reachable, even though WireGuard pod-to-pod encryption is enabled.

The current proposal for WireGuard while tunneling is enabled, is to mark all packet leaving the WireGuard interface as decrypted and only allow such packets in the `bpf_overlay` program to enter the overlay network.

Since I don't have an overview of all the different Cilium configuration this might break, I'd view this PR as more of an CFP with code. So pointers to situations where this approach fails are welcome. Also, since I'm introducing the `from-wireguard` program we might need to wait with is PR until https://github.com/cilium/cilium/issues/33676 is implemented first since I think we get into ordering trouble when we load multiple programs?

I'm currently looking into cleaning up the loading rules and vxlan packet construction. Then I'll have a look on how a native-routing test would look like. If anyone has suggestion on how to make the current vxlan packet injection less hacky, feel free suggest something.



Fixes: #25626 (only for tunnel + WireGuard)

```release-note
When WireGuard encryption and tunneling are enabled, block non-WireGuard traffic from entering the overlay network.
```


Alternatives considered:
* Have a IPv{4,6} filter on the `cil_from_netdev` program similar to the (egress) WireGuard strict mode: https://github.com/cilium/cilium/pull/21856. But since pushing the burden of maintaining a correct list of possible pod IPs to the user has its drawbacks, I aimed for a solution that 
  1. requires no user interaction
  2. can be enabled in all cases where WireGuard itself is enabled