### PR TITLE
hive/k8s: Add OnDemand[T] and the OnDemandTable

### DIFF
--- a/pkg/hive/ondemand.go
+++ b/pkg/hive/ondemand.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package hive
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// OnDemand provides access to a resource on-demand.
+// On first call to Acquire() the resource is started (cell.Lifecycle.Start).
+// If the starting of the resource fails Acquire() returns the error from Start().
+// When all references are Release()'d the resource is stopped (cell.Lifecycle.Stop),
+// and again failure from Stop() is returned.
+type OnDemand[Resource any] interface {
+	// Acquire a resource. On the first call to Acquire() the underlying
+	// resource is started with the provided context that aborts the start
+	// if the context is cancelled. On failure to start the resulting error
+	// is returned.
+	Acquire(context.Context) (Resource, error)
+
+	// Release a resource. When the last acquired reference to the resource
+	// is released the resource is stopped. If stopping the resource fails
+	// the error is returned.
+	Release(resource Resource) error
+}
+
+type onDemand[Resource any] struct {
+	mu       lock.Mutex
+	log      *slog.Logger
+	refCount int
+	resource Resource
+	hook     cell.HookInterface
+}
+
+// NewOnDemand wraps a resource that will be started and stopped on-demand.
+// The resource and the lifecycle hooks are provided separately, but can
+// of course be the same thing. They're separate to support the use-case
+// where the resource is a state object (e.g. StateDB table) and the hook is
+// a job group that populates the object.
+func NewOnDemand[Resource any](log *slog.Logger, resource Resource, hook cell.HookInterface) OnDemand[Resource] {
+	return &onDemand[Resource]{
+		log:      log,
+		refCount: 0,
+		resource: resource,
+		hook:     hook,
+	}
+}
+
+// Acquire implements OnDemand.
+func (o *onDemand[Resource]) Acquire(ctx context.Context) (r Resource, err error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if o.refCount == 0 {
+		// This is the first acquisition of the resource. Start it.
+		if err = o.hook.Start(ctx); err != nil {
+			return r, fmt.Errorf("failed to start resource %T: %w", r, err)
+		}
+	}
+
+	o.refCount++
+	return o.resource, nil
+}
+
+// Release implements OnDemand.
+func (o *onDemand[Resource]) Release(r Resource) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if o.refCount <= 0 {
+		return fmt.Errorf("BUG: OnDemand.Release called with refCount <= 0")
+	}
+
+	o.refCount--
+	if o.refCount == 0 {
+		if err := o.hook.Stop(context.Background()); err != nil {
+			return fmt.Errorf("failed to stop resource %T: %w", r, err)
+		}
+	}
+	return nil
+}
+
+var _ OnDemand[cell.Hook] = &onDemand[cell.Hook]{}
+
+type staticOnDemand[Resource any] struct {
+	resource Resource
+}
+
+// Acquire implements OnDemand.
+func (s *staticOnDemand[Resource]) Acquire(context.Context) (Resource, error) {
+	return s.resource, nil
+}
+
+// Release implements OnDemand.
+func (s *staticOnDemand[Resource]) Release(Resource) error {
+	return nil
+}
+
+var _ OnDemand[struct{}] = &staticOnDemand[struct{}]{}
+
+// NewStaticOnDemand creates an on-demand resource that is "static",
+// i.e. always running and not started or stopped.
+func NewStaticOnDemand[Resource any](resource Resource) OnDemand[Resource] {
+	return &staticOnDemand[Resource]{resource}
+}

--- a/pkg/hive/ondemand_test.go
+++ b/pkg/hive/ondemand_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package hive_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/hive"
+)
+
+type testResource struct {
+	start int
+	err   error
+}
+
+func (t *testResource) Start(cell.HookContext) error {
+	if t.err != nil {
+		return t.err
+	}
+	t.start++
+	return nil
+}
+func (t *testResource) Stop(cell.HookContext) error {
+	if t.err != nil {
+		return t.err
+	}
+	t.start--
+	return nil
+}
+
+func TestOnDemand(t *testing.T) {
+	ctx := context.TODO()
+	log := hivetest.Logger(t)
+
+	// Test without errors
+	t.Run("no-errors", func(t *testing.T) {
+		r := &testResource{}
+		or := hive.NewOnDemand(log, r, r)
+		assert.Zero(t, r.start, "expected zero start count")
+
+		ar1, err := or.Acquire(ctx)
+		assert.NoError(t, err, "Acquire")
+		assert.Same(t, r, ar1)
+		assert.Equal(t, 1, r.start, "unexpected start count")
+
+		ar2, err := or.Acquire(ctx)
+		assert.NoError(t, err, "Acquire")
+		assert.Same(t, r, ar2)
+		assert.Equal(t, 1, r.start, "unexpected start count")
+
+		err = or.Release(ar1)
+		assert.NoError(t, err, "Release")
+		assert.Equal(t, 1, r.start, "unexpected start count")
+
+		err = or.Release(ar2)
+		assert.NoError(t, err, "Release")
+		assert.Equal(t, 0, r.start, "unexpected start count")
+	})
+
+	testErr := errors.New("error")
+
+	// Test with start failure
+	t.Run("start-error", func(t *testing.T) {
+		r := &testResource{}
+		r.err = testErr
+		or := hive.NewOnDemand(log, r, r)
+
+		ar1, err := or.Acquire(ctx)
+		assert.ErrorIs(t, err, testErr)
+		assert.Nil(t, ar1)
+		assert.Equal(t, 0, r.start, "unexpected start count")
+	})
+
+	// Test with stop failure
+	t.Run("stop-error", func(t *testing.T) {
+		r := &testResource{}
+		r.err = nil
+		or := hive.NewOnDemand(log, r, r)
+
+		ar1, err := or.Acquire(ctx)
+		assert.NoError(t, err)
+		assert.Same(t, r, ar1)
+		assert.Equal(t, 1, r.start, "unexpected start count")
+
+		r.err = testErr
+		err = or.Release(ar1)
+		assert.ErrorIs(t, err, testErr)
+		assert.Equal(t, 1, r.start, "unexpected start count")
+	})
+}

--- a/pkg/k8s/statedb.go
+++ b/pkg/k8s/statedb.go
@@ -17,6 +17,8 @@ import (
 	"github.com/cilium/statedb"
 	"github.com/cilium/stream"
 
+	"github.com/cilium/cilium/pkg/k8s/synced"
+	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -94,6 +96,10 @@ type ReflectorConfig[Obj any] struct {
 	// Optional function to merge the new object with an existing object in the target
 	// table.
 	Merge MergeFunc[Obj]
+
+	// Optional promise for waiting for the CRD referenced by the [ListerWatcher] to
+	// be registered.
+	CRDSync promise.Promise[synced.CRDSync]
 }
 
 // JobName returns the name of the background reflector job.
@@ -125,6 +131,8 @@ type MergeFunc[Obj any] func(old Obj, new Obj) Obj
 
 const (
 	// DefaultBufferSize is the maximum number of objects to commit to the table in one write transaction.
+	// This limit does not apply to the initial listing (Replace()) which commits all listed objects in one
+	// transaction.
 	DefaultBufferSize = 10000
 
 	// DefaultBufferWaitTime is the amount of time to wait to fill the buffer before committing objects.
@@ -174,6 +182,14 @@ type k8sReflector[Obj any] struct {
 }
 
 func (r *k8sReflector[Obj]) run(ctx context.Context, health cell.Health) error {
+	if r.CRDSync != nil {
+		// Wait for the CRD to be registered.
+		health.OK("Waiting for CRD registration")
+		if _, err := r.CRDSync.Await(ctx); err != nil {
+			return err
+		}
+	}
+
 	type entry struct {
 		deleted   bool
 		name      string


### PR DESCRIPTION
This adds:
- Ability to wait for CRDSync in the k8s to StateDB reflector
- hive.OnDemand[T] utility for starting and stopping resources on-demand (refcounted) that adhere to cell.Lifecycle 
- k8s.OnDemandTable that reflects from k8s to StateDB table on-demand

The rational for this is to reproduce the lazyness of `Resource[T]` and allow us to start switching from `Resource[T]`
to `Table[T]` (or `OnDemand[Table[T]]` when needed).

See the commit messages for more details.