### PR TITLE
policy: optimize policy selection

### DIFF
--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -63,6 +63,14 @@ func NewResourceID(kind ResourceKind, namespace, name string) ResourceID {
 	return ResourceID(str.String())
 }
 
+func (r ResourceID) Namespace() string {
+	parts := strings.SplitN(string(r), "/", 3)
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[1]
+}
+
 // TunnelPeer is the IP address of the host associated with this prefix. This is
 // typically used to establish a tunnel, e.g. in tunnel mode or for encryption.
 // This type implements ipcache.IPMetadata

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -326,7 +326,9 @@ func ParseToCiliumRule(namespace, name string, uid types.UID, r *api.Rule) *api.
 		retRule.EndpointSelector = api.NewESFromK8sLabelSelector("", r.EndpointSelector.LabelSelector)
 		// The PodSelector should only reflect to the same namespace
 		// the policy is being stored, thus we add the namespace to
-		// the MatchLabels map.
+		// the MatchLabels map. Additionally, Policy repository relies
+		// on this fact to properly choose correct network policies for
+		// a given Security Identity.
 		//
 		// Policies applying to all namespaces are a special case.
 		// Such policies can match on any traffic from Pods or Nodes,


### PR DESCRIPTION
Example results with 30k policies / 1k nodes / 6k identities / 30k pods churned over 1h duration:
Before:
![image](https://github.com/user-attachments/assets/9447e81d-2ecb-4c52-ad28-af457d7ea419)
After:
![image](https://github.com/user-attachments/assets/46e537ec-dd19-440e-847b-94bf59babc7b)

Results:
CPU usage: reduced from ~1 core to 0.4 
policy implementation: 99th percentile from 0.5s to 0.1s

```release-note
policy: add namespace index to the policy repository so we can skip trying to match namespace-specific rules for the non-matching namespaces.
```
