### PR TITLE
hubble/filters: use netip types

### DIFF
--- a/pkg/hubble/parser/sock/parser.go
+++ b/pkg/hubble/parser/sock/parser.go
@@ -5,7 +5,6 @@ package sock
 
 import (
 	"fmt"
-	"net"
 	"net/netip"
 	"strings"
 
@@ -76,20 +75,19 @@ func (p *Parser) Decode(data []byte, decoded *flowpb.Flow) error {
 	}
 
 	ipVersion := decodeIPVersion(sock.Flags)
-	epIP, ok := p.decodeEndpointIP(sock.CgroupId, ipVersion)
-	if !ok && p.skipUnknownCGroupIDs {
+	srcIP := p.decodeEndpointIP(sock.CgroupId, ipVersion)
+	if !srcIP.IsValid() && p.skipUnknownCGroupIDs {
 		// Skip events for which we cannot determine the endpoint ip based on
 		// the numeric cgroup id, since those events do not provide much value
 		// to end users.
 		return errors.ErrEventSkipped
 	}
+	srcPort := uint16(0) // source port is not known for TraceSock events
 
 	// Ignore invalid IPs - getters will handle invalid values.
 	// IPs can be empty for Ethernet-only packets.
 	dstIP, _ := netipx.FromStdIP(sock.IP())
 	dstPort := sock.DstPort
-	srcIP, _ := netipx.FromStdIP(epIP)
-	srcPort := uint16(0) // source port is not known for TraceSock events
 
 	datapathContext := common.DatapathContext{
 		SrcIP:      srcIP,
@@ -133,7 +131,7 @@ func decodeIPVersion(flags uint8) flowpb.IPVersion {
 	return flowpb.IPVersion_IPv4
 }
 
-func (p *Parser) decodeEndpointIP(cgroupId uint64, ipVersion flowpb.IPVersion) (ip net.IP, ok bool) {
+func (p *Parser) decodeEndpointIP(cgroupId uint64, ipVersion flowpb.IPVersion) netip.Addr {
 	if p.cgroupGetter != nil {
 		if m := p.cgroupGetter.GetPodMetadataForContainer(cgroupId); m != nil {
 			scopedLog := p.log.WithFields(logrus.Fields{
@@ -146,20 +144,18 @@ func (p *Parser) decodeEndpointIP(cgroupId uint64, ipVersion flowpb.IPVersion) (
 				isIPv6 := strings.Contains(podIP, ":")
 				if isIPv6 && ipVersion == flowpb.IPVersion_IPv6 ||
 					!isIPv6 && ipVersion == flowpb.IPVersion_IPv4 {
-					ip = net.ParseIP(podIP)
-					if ip == nil {
-						scopedLog.WithField(logfields.IPAddr, podIP).Debug("failed to parse pod IP")
-						return nil, false
+					ip, err := netip.ParseAddr(podIP)
+					if err != nil {
+						scopedLog.WithField(logfields.IPAddr, podIP).WithError(err).Debug("failed to parse pod IP")
+						return netip.Addr{}
 					}
-
-					return ip, true
+					return ip
 				}
 			}
 			scopedLog.Debug("no matching IP for pod")
 		}
 	}
-
-	return nil, false
+	return netip.Addr{}
 }
 
 func decodeL3(srcIP, dstIP netip.Addr, ipVersion flowpb.IPVersion) *flowpb.IP {


### PR DESCRIPTION
Use the more modern `netip` types for IP addresses/prefixes. This allows simplifying the code a bit and avoid some unnecessary conversions for APIs already expecting `netip` types.

For #24246