### PR TITLE
Add concurrency to e2e-upgrade tests

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -588,7 +588,24 @@ jobs:
             --include-conn-disrupt-test \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --flush-ct \
+            --test "seq-.*" \
+            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
+            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+            --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
+            --junit-property github_job_step="Run tests upgrade 2 (${{ matrix.name }})" \
+            "${EXTRA[@]}"
+
+          # --flush-ct interrupts the flows, so we need to set up again.
+          cilium connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup \
+            --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
+            --conn-disrupt-dispatch-interval 0ms
+
+          cilium connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+            --include-conn-disrupt-test \
+            --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
+            --flush-ct \
             --test-concurrency=${{ env.test_concurrency }} \
+            --test "!seq-.*" \
             --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
@@ -631,6 +648,23 @@ jobs:
             --include-conn-disrupt-test \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --flush-ct \
+            --test "seq-.*" \
+            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
+            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+            --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
+            --junit-property github_job_step="Run tests upgrade 2 (${{ matrix.name }})" \
+            "${EXTRA[@]}"
+
+          # --flush-ct interrupts the flows, so we need to set up again.
+          cilium connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup \
+            --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
+            --conn-disrupt-dispatch-interval 0ms
+
+          cilium connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+            --include-conn-disrupt-test \
+            --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
+            --flush-ct \
+            --test "!seq-.*" \
             --test-concurrency=${{ env.test_concurrency }} \
             --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -569,12 +569,12 @@ jobs:
           kubectl get pods --all-namespaces -o wide
           kubectl -n kube-system exec daemonset/cilium -- cilium status
 
-      - name: Test Cilium ${{ matrix.skip-upgrade != 'true' && 'after upgrade' }}
-        shell: bash
+      - name: Setup Cilium CLI flags
+        id: cli-flags
         run: |
           EXTRA=()
           if [ "${{ matrix.secondary-network }}" = "true" ]; then
-            EXTRA+=("--secondary-network-iface=eth1")
+            EXTRA+=("\"--secondary-network-iface=eth1\"")
           fi
 
           # it's fine to ignore the "No egress gateway found" drop reason as this may be caused by the kind=echo pods
@@ -582,38 +582,48 @@ jobs:
           #
           # The actual connectivity test will ensure that the map is in sync with the policy and that egressgw traffic
           # always go through the correct gateway
-          EXTRA+=("--expected-drop-reasons=+No egress gateway found")
+          EXTRA+=("\"--expected-drop-reasons=+No egress gateway found\"")
 
-          cilium connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-            --include-conn-disrupt-test \
-            --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
+          echo flags="--include-unsafe-tests \
+            --collect-sysdump-on-failure \
             --flush-ct \
+            --sysdump-hubble-flows-count=1000000 \
+            --sysdump-hubble-flows-timeout=5m \
+            --sysdump-output-filename \"cilium-sysdump-${{ matrix.name }}-<ts>\" \
+            --junit-file \"cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml\" \
+            --junit-property github_job_step=\"Run tests upgrade 2 (${{ matrix.name }})\" \
+            ${EXTRA[@]}" >> $GITHUB_OUTPUT
+
+      - name: Test Cilium ${{ matrix.skip-upgrade != 'true' && 'after upgrade' }}
+        shell: bash
+        run: |
+          cilium connectivity test \
+            --include-conn-disrupt-test \
+            --test "no-interrupted-connections" \
+            --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
+            ${{ steps.cli-flags.outputs.flags }}
+
+      - name: Run sequential Cilium tests
+        shell: bash
+        run: |
+          cilium connectivity test \
             --test "seq-.*" \
-            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
-            --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
-            --junit-property github_job_step="Run tests upgrade 2 (${{ matrix.name }})" \
-            "${EXTRA[@]}"
+            ${{ steps.cli-flags.outputs.flags }}
 
-          # --flush-ct interrupts the flows, so we need to set up again.
-          cilium connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup \
-            --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
-            --conn-disrupt-dispatch-interval 0ms
-
-          cilium connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-            --include-conn-disrupt-test \
-            --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
-            --flush-ct \
+      - name: Run concurrent Cilium tests
+        shell: bash
+        run: |
+          cilium connectivity test \
             --test-concurrency=${{ env.test_concurrency }} \
             --test "!seq-.*" \
-            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
-            --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
-            --junit-property github_job_step="Run tests upgrade 2 (${{ matrix.name }})" \
-            "${EXTRA[@]}"
+            ${{ steps.cli-flags.outputs.flags }}
 
-          # --flush-ct interrupts the flows, so we need to set up again.
-          cilium connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup \
+      - name: Setup conn dirstupt tests after a flush-ct Cilium tests
+        shell: bash
+        run: |
+          cilium connectivity test \
+            --include-conn-disrupt-test \
+            --conn-disrupt-test-setup \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --conn-disrupt-dispatch-interval 0ms
 
@@ -632,45 +642,28 @@ jobs:
         if: ${{ matrix.skip-upgrade != 'true' }}
         shell: bash
         run: |
-          EXTRA=()
-          if [ "${{ matrix.secondary-network }}" = "true" ]; then
-            EXTRA+=("--secondary-network-iface=eth1")
-          fi
-
-          # it's fine to ignore the "No egress gateway found" drop reason as this may be caused by the kind=echo pods
-          # sending traffic while the egressgw policy map is still being populated.
-          #
-          # The actual connectivity test will ensure that the map is in sync with the policy and that egressgw traffic
-          # always go through the correct gateway
-          EXTRA+=("--expected-drop-reasons=+No egress gateway found")
-
-          cilium connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+          cilium connectivity test \
             --include-conn-disrupt-test \
+            --test "no-interrupted-connections" \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
-            --flush-ct \
+            ${{ steps.cli-flags.outputs.flags }}
+
+      - name: Run sequential Cilium tests
+        if: ${{ matrix.skip-upgrade != 'true' }}
+        shell: bash
+        run: |
+          cilium connectivity test \
             --test "seq-.*" \
-            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
-            --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
-            --junit-property github_job_step="Run tests upgrade 2 (${{ matrix.name }})" \
-            "${EXTRA[@]}"
+            ${{ steps.cli-flags.outputs.flags }}
 
-          # --flush-ct interrupts the flows, so we need to set up again.
-          cilium connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup \
-            --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
-            --conn-disrupt-dispatch-interval 0ms
-
-          cilium connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-            --include-conn-disrupt-test \
-            --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
-            --flush-ct \
-            --test "!seq-.*" \
+      - name: Run concurrent Cilium tests
+        if: ${{ matrix.skip-upgrade != 'true' }}
+        shell: bash
+        run: |
+          cilium connectivity test \
             --test-concurrency=${{ env.test_concurrency }} \
-            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
-            --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
-            --junit-property github_job_step="Run tests upgrade 2 (${{ matrix.name }})" \
-            "${EXTRA[@]}"
+            --test "!seq-.*" \
+            ${{ steps.cli-flags.outputs.flags }}
 
       - name: Fetch artifacts
         if: ${{ !success() }}

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -56,6 +56,9 @@ concurrency:
     }}
   cancel-in-progress: true
 
+env:
+  test_concurrency: 5
+
 jobs:
   echo-inputs:
     if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -391,7 +394,7 @@ jobs:
           #   misc: 'bpf.datapathMode=netkit-l2,bpf.masquerade=true'
           #   skip-upgrade: 'true'
 
-    timeout-minutes: 90
+    timeout-minutes: 45
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
@@ -585,6 +588,7 @@ jobs:
             --include-conn-disrupt-test \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --flush-ct \
+            --test-concurrency=${{ env.test_concurrency }} \
             --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
@@ -627,6 +631,7 @@ jobs:
             --include-conn-disrupt-test \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --flush-ct \
+            --test-concurrency=${{ env.test_concurrency }} \
             --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \

--- a/cilium-cli/connectivity/builder/egress_gateway.go
+++ b/cilium-cli/connectivity/builder/egress_gateway.go
@@ -12,7 +12,8 @@ import (
 type egressGateway struct{}
 
 func (t egressGateway) build(ct *check.ConnectivityTest, _ map[string]string) {
-	newTest("egress-gateway", ct).
+	// Prefix the test name with `seq-` to run it sequentially.
+	newTest("seq-egress-gateway", ct).
 		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
 		WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{
 			Name:            "cegp-sample-client",

--- a/cilium-cli/connectivity/builder/egress_gateway_with_l7_policy.go
+++ b/cilium-cli/connectivity/builder/egress_gateway_with_l7_policy.go
@@ -21,7 +21,8 @@ var clientEgressL7HTTPExternalYAML string
 type egressGatewayWithL7Policy struct{}
 
 func (t egressGatewayWithL7Policy) build(ct *check.ConnectivityTest, templates map[string]string) {
-	newTest("egress-gateway-with-l7-policy", ct).
+	// Prefix the test name with `seq-` to run it sequentially.
+	newTest("seq-egress-gateway-with-l7-policy", ct).
 		WithCondition(func() bool {
 			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion) && ct.Params().IncludeUnsafeTests
 		}).

--- a/cilium-cli/connectivity/builder/from_cidr_host_netns.go
+++ b/cilium-cli/connectivity/builder/from_cidr_host_netns.go
@@ -12,7 +12,8 @@ import (
 type fromCidrHostNetns struct{}
 
 func (t fromCidrHostNetns) build(ct *check.ConnectivityTest, templates map[string]string) {
-	newTest("from-cidr-host-netns", ct).
+	// Prefix the test name with `seq-` to run it sequentially.
+	newTest("seq-from-cidr-host-netns", ct).
 		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
 		WithFeatureRequirements(features.RequireEnabled(features.NodeWithoutCilium)).
 		WithCiliumPolicy(templates["echoIngressFromCIDRYAML"]).

--- a/cilium-cli/connectivity/check/wait.go
+++ b/cilium-cli/connectivity/check/wait.go
@@ -166,7 +166,7 @@ func WaitForServiceRetrieval(ctx context.Context, log Logger, client *k8s.Client
 func WaitForService(ctx context.Context, log Logger, client Pod, service Service) error {
 	log.Logf("⌛ [%s] Waiting for Service %s to become ready...", client.K8sClient.ClusterName(), service.Name())
 
-	ctx, cancel := context.WithTimeout(ctx, ShortTimeout)
+	ctx, cancel := context.WithTimeout(ctx, 2*ShortTimeout)
 	defer cancel()
 
 	if service.Service.Spec.ClusterIP == corev1.ClusterIPNone {

--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -89,7 +89,7 @@ const (
 	FlowWaitTimeout   = 10 * time.Second
 	FlowRetryInterval = 500 * time.Millisecond
 
-	PolicyWaitTimeout = 15 * time.Second
+	PolicyWaitTimeout = 30 * time.Second
 
 	ConnectRetry      = 3
 	ConnectRetryDelay = 3 * time.Second


### PR DESCRIPTION
The changes on this PR helps to decrease the test run time significantly. During testing if this was possible, a lot of flakes were being caused by the egress-gateway, egress-gateway-with-l7-policy and from-cidr-host-netns tests which is why they run separately without concurrency and then all the other tests run parallel afterwards.

You can find 6 successful runs in https://github.com/cilium/cilium/actions/runs/11220270835. The attempt #4 that failed was caused by a faulty connection to one.one.one.one.

| Name | Before    | After     | Time Decreased |
|-----------|-----------|-----------|----------------|
| Test 1    | 00:49:18  | 00:25:14  | -48.82%        |
| Test 2    | 00:46:53  | 00:24:37  | -47.49%        |
| Test 3    | 00:47:12  | 00:25:14  | -46.54%        |
| Test 4    | 00:55:41  | 00:32:41  | -41.30%        |
| Test 5    | 00:52:23  | 00:28:58  | -44.70%        |
| Test 6    | 01:07:00  | 00:38:44  | -42.19%        |
| Test 7    | 01:10:00  | 00:39:11  | -44.02%        |
| Test 8    | 00:56:24  | 00:32:19  | -42.70%        |
| Test 9    | 00:54:19  | 00:32:27  | -40.26%        |
| Test 10   | 00:48:46  | 00:25:52  | -46.96%        |
| Test 11   | 01:04:00  | 00:31:34  | -50.68%        |
| Test 12   | 01:03:00  | 00:37:17  | -40.82%        |
| Test 13   | 00:46:53  | 00:22:37  | -51.76%        |
| Test 14   | 01:01:00  | 00:37:01  | -39.32%        |
| Test 15   | 00:58:01  | 00:32:17  | -44.36%        |
| Test 16   | 01:02:00  | 00:35:16  | -43.12%        |
| Test 17   | 01:01:00  | 00:33:11  | -45.60%        |
| Test 18   | 00:59:33  | 00:31:09  | -47.69%        |
| Test 19   | 01:02:00  | 00:34:44  | -43.98%        |
| Test 20   | 01:04:00  | 00:35:07  | -45.13%        |
| Test 21   | 01:01:00  | 00:39:52  | -34.64%        |
| Test 22   | 01:05:00  | 00:35:15  | -45.77%        |
| Test 23   | 00:30:29  | 00:16:50  | -44.78%        |
