### PR TITLE
gateway-api: Sync up with the latest upstream v1.2.0-rc1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -132,8 +132,8 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20240902221715-702e33fdd3c3
 	sigs.k8s.io/controller-runtime v0.19.0
-	sigs.k8s.io/controller-tools v0.16.1
-	sigs.k8s.io/gateway-api v1.1.1-0.20240906002847-ff517b37b82e
+	sigs.k8s.io/controller-tools v0.16.3
+	sigs.k8s.io/gateway-api v1.2.0-rc1
 	sigs.k8s.io/mcs-api v0.1.1-0.20240903161117-2c773b78635e
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1132,8 +1132,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 h1:2770sDpzrjjsA
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.19.0 h1:nWVM7aq+Il2ABxwiCizrVDSlmDcshi9llbaFbC0ji/Q=
 sigs.k8s.io/controller-runtime v0.19.0/go.mod h1:iRmWllt8IlaLjvTTDLhRBXIEtkCK6hwVBJJsYS9Ajf4=
-sigs.k8s.io/gateway-api v1.1.1-0.20240906002847-ff517b37b82e h1:ip/MYMmcd0AAYGOLXzOuEWjrNRxkxDGLw29mA2kUcQA=
-sigs.k8s.io/gateway-api v1.1.1-0.20240906002847-ff517b37b82e/go.mod h1:mZWtxhYeQvDhdkgujCi8Ns067UN2+llZBwNBjFHM5rs=
+sigs.k8s.io/gateway-api v1.2.0-rc1 h1:ZcqCEype0Mrt3ax46t2QB+VSm8ic4/WUQkbcc6xtAOI=
+sigs.k8s.io/gateway-api v1.2.0-rc1/go.mod h1:EpNfEXNjiYfUJypf0eZ0P5iXA9ekSGWaS1WgPaM42X0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kind v0.23.0 h1:8fyDGWbWTeCcCTwA04v4Nfr45KKxbSPH1WO9K+jVrBg=

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwideenvoyconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwideenvoyconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumclusterwideenvoyconfigs.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumclusterwidenetworkpolicies.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumegressgatewaypolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumegressgatewaypolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumegressgatewaypolicies.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumendpoints.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumenvoyconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumenvoyconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumenvoyconfigs.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumexternalworkloads.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumexternalworkloads.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumexternalworkloads.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumidentities.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumidentities.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumidentities.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumlocalredirectpolicies.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumnetworkpolicies.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodeconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodeconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumnodeconfigs.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumnodes.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpadvertisements.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpadvertisements.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumbgpadvertisements.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpclusterconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpclusterconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumbgpclusterconfigs.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpnodeconfigoverrides.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpnodeconfigoverrides.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumbgpnodeconfigoverrides.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpnodeconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpnodeconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumbgpnodeconfigs.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeerconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeerconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumbgppeerconfigs.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumbgppeeringpolicies.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumcidrgroups.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumcidrgroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumcidrgroups.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumendpointslices.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumendpointslices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumendpointslices.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliuml2announcementpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliuml2announcementpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliuml2announcementpolicies.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumloadbalancerippools.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumloadbalancerippools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumloadbalancerippools.cilium.io
 spec:
   group: cilium.io

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumpodippools.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumpodippools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ciliumpodippools.cilium.io
 spec:
   group: cilium.io

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2639,7 +2639,7 @@ sigs.k8s.io/controller-runtime/pkg/webhook/admission
 sigs.k8s.io/controller-runtime/pkg/webhook/admission/metrics
 sigs.k8s.io/controller-runtime/pkg/webhook/conversion
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
-# sigs.k8s.io/controller-tools v0.16.1 => github.com/cilium/controller-tools v0.16.1-1
+# sigs.k8s.io/controller-tools v0.16.3 => github.com/cilium/controller-tools v0.16.1-1
 ## explicit; go 1.22.0
 sigs.k8s.io/controller-tools/cmd/controller-gen
 sigs.k8s.io/controller-tools/pkg/crd
@@ -2655,7 +2655,7 @@ sigs.k8s.io/controller-tools/pkg/schemapatcher
 sigs.k8s.io/controller-tools/pkg/schemapatcher/internal/yaml
 sigs.k8s.io/controller-tools/pkg/version
 sigs.k8s.io/controller-tools/pkg/webhook
-# sigs.k8s.io/gateway-api v1.1.1-0.20240906002847-ff517b37b82e
+# sigs.k8s.io/gateway-api v1.2.0-rc1
 ## explicit; go 1.22.0
 sigs.k8s.io/gateway-api/apis/v1
 sigs.k8s.io/gateway-api/apis/v1alpha2

--- a/vendor/sigs.k8s.io/gateway-api/conformance/apis/v1/conformancereport.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/apis/v1/conformancereport.go
@@ -46,6 +46,10 @@ type ConformanceReport struct {
 	// ProfileReports is a list of the individual reports for each conformance
 	// profile that was enabled for a test run.
 	ProfileReports []ProfileReport `json:"profiles"`
+
+	// SucceededProvisionalTests is a list of the names of the provisional tests that
+	// have been successfully run.
+	SucceededProvisionalTests []string `json:"succeededProvisionalTests,omitempty"`
 }
 
 // Implementation provides metadata information on the downstream

--- a/vendor/sigs.k8s.io/gateway-api/conformance/conformance.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/conformance.go
@@ -96,6 +96,7 @@ func DefaultOptions(t *testing.T) suite.ConformanceOptions {
 		SkipTests:                  skipTests,
 		SupportedFeatures:          supportedFeatures,
 		TimeoutConfig:              conformanceconfig.DefaultTimeoutConfig(),
+		SkipProvisionalTests:       *flags.SkipProvisionalTests,
 	}
 }
 

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/udproute-simple.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/udproute-simple.go
@@ -42,6 +42,7 @@ var UDPRouteTest = suite.ConformanceTest{
 		features.SupportUDPRoute,
 		features.SupportGateway,
 	},
+	Provisional: true,
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		t.Run("Simple UDP request matching UDPRoute should reach coredns backend", func(t *testing.T) {
 			namespace := "gateway-conformance-infra"

--- a/vendor/sigs.k8s.io/gateway-api/conformance/utils/flags/flags.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/utils/flags/flags.go
@@ -48,4 +48,5 @@ var (
 	AllowCRDsMismatch          = flag.Bool("allow-crds-mismatch", false, "Flag to allow the suite not to fail in case there is a mismatch between CRDs versions and channels.")
 	ConformanceProfiles        = flag.String("conformance-profiles", "", "Comma-separated list of the conformance profiles to run")
 	ReportOutput               = flag.String("report-output", "", "The file where to write the conformance report")
+	SkipProvisionalTests       = flag.Bool("skip-provisional-tests", false, "Whether to skip provisional tests")
 )

--- a/vendor/sigs.k8s.io/gateway-api/conformance/utils/suite/conformance.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/utils/suite/conformance.go
@@ -36,6 +36,7 @@ type ConformanceTest struct {
 	Slow        bool
 	Parallel    bool
 	Test        func(*testing.T, *ConformanceTestSuite)
+	Provisional bool
 }
 
 // Run runs an individual tests, applying and cleaning up the required manifests

--- a/vendor/sigs.k8s.io/gateway-api/conformance/utils/suite/profiles.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/utils/suite/profiles.go
@@ -126,7 +126,7 @@ var (
 	// MeshGRPCConformanceProfile is a ConformanceProfile that covers testing GRPC
 	// service mesh related functionality.
 	MeshGRPCConformanceProfile = ConformanceProfile{
-		Name: MeshHTTPConformanceProfileName,
+		Name: MeshGRPCConformanceProfileName,
 		CoreFeatures: sets.New(
 			features.SupportMesh,
 			features.SupportGRPCRoute,

--- a/vendor/sigs.k8s.io/gateway-api/conformance/utils/suite/reports.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/utils/suite/reports.go
@@ -18,7 +18,6 @@ package suite
 
 import (
 	"fmt"
-	"sort"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -38,10 +37,11 @@ type testResult struct {
 type resultType string
 
 var (
-	testSucceeded    resultType = "SUCCEEDED"
-	testFailed       resultType = "FAILED"
-	testSkipped      resultType = "SKIPPED"
-	testNotSupported resultType = "NOT_SUPPORTED"
+	testSucceeded          resultType = "SUCCEEDED"
+	testFailed             resultType = "FAILED"
+	testSkipped            resultType = "SKIPPED"
+	testNotSupported       resultType = "NOT_SUPPORTED"
+	testProvisionalSkipped resultType = "PROVISIONAL_SKIPPED"
 )
 
 type profileReportsMap map[ConformanceProfileName]confv1.ProfileReport
@@ -136,10 +136,7 @@ func (p profileReportsMap) compileResults(supportedFeaturesMap map[ConformancePr
 		supportedFeatures := supportedFeaturesMap[ConformanceProfileName(report.Name)]
 		if report.Extended != nil {
 			if supportedFeatures != nil {
-				supportedFeatures := supportedFeatures.UnsortedList()
-				sort.Slice(supportedFeatures, func(i, j int) bool {
-					return supportedFeatures[i] < supportedFeatures[j]
-				})
+				supportedFeatures := sets.List(supportedFeatures)
 				for _, f := range supportedFeatures {
 					report.Extended.SupportedFeatures = append(report.Extended.SupportedFeatures, string(f))
 				}
@@ -149,10 +146,7 @@ func (p profileReportsMap) compileResults(supportedFeaturesMap map[ConformancePr
 		unsupportedFeatures := unsupportedFeaturesMap[ConformanceProfileName(report.Name)]
 		if report.Extended != nil {
 			if unsupportedFeatures != nil {
-				unsupportedFeatures := unsupportedFeatures.UnsortedList()
-				sort.Slice(unsupportedFeatures, func(i, j int) bool {
-					return unsupportedFeatures[i] < unsupportedFeatures[j]
-				})
+				unsupportedFeatures := sets.List(unsupportedFeatures)
 				for _, f := range unsupportedFeatures {
 					report.Extended.UnsupportedFeatures = append(report.Extended.UnsupportedFeatures, string(f))
 				}

--- a/vendor/sigs.k8s.io/gateway-api/conformance/utils/suite/suite.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/utils/suite/suite.go
@@ -71,6 +71,7 @@ type ConformanceTestSuite struct {
 	SupportedFeatures        sets.Set[features.FeatureName]
 	TimeoutConfig            config.TimeoutConfig
 	SkipTests                sets.Set[string]
+	SkipProvisionalTests     bool
 	RunTest                  string
 	ManifestFS               []fs.FS
 	UsableNetworkAddresses   []v1beta1.GatewayAddress
@@ -144,6 +145,8 @@ type ConformanceOptions struct {
 	// SkipTests contains all the tests not to be run and can be used to opt out
 	// of specific tests
 	SkipTests []string
+	// SkipProvisionalTests indicates whether or not to skip provisional tests.
+	SkipProvisionalTests bool
 	// RunTest is a single test to run, mostly for development/debugging convenience.
 	RunTest string
 
@@ -248,6 +251,7 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 		TimeoutConfig:               options.TimeoutConfig,
 		SkipTests:                   sets.New(options.SkipTests...),
 		RunTest:                     options.RunTest,
+		SkipProvisionalTests:        options.SkipProvisionalTests,
 		ManifestFS:                  options.ManifestFS,
 		UsableNetworkAddresses:      options.UsableNetworkAddresses,
 		UnusableNetworkAddresses:    options.UnusableNetworkAddresses,
@@ -431,6 +435,9 @@ func (suite *ConformanceTestSuite) Run(t *testing.T, tests []ConformanceTest) er
 		if suite.SkipTests.Has(test.ShortName) {
 			res = testSkipped
 		}
+		if suite.SkipProvisionalTests && test.Provisional {
+			res = testProvisionalSkipped
+		}
 		if !suite.SupportedFeatures.HasAll(test.Features...) {
 			res = testNotSupported
 		}
@@ -486,15 +493,26 @@ func (suite *ConformanceTestSuite) Report() (*confv1.ConformanceReport, error) {
 	}
 	sort.Strings(testNames)
 	profileReports := newReports()
+	succeededProvisionalTestSet := sets.Set[string]{}
 	for _, tN := range testNames {
-		testResult := suite.results[tN]
-		conformanceProfiles := getConformanceProfilesForTest(testResult.test, suite.conformanceProfiles).UnsortedList()
+		tr := suite.results[tN]
+		if tr.result == testProvisionalSkipped {
+			continue
+		}
+		if tr.result == testSucceeded && tr.test.Provisional {
+			succeededProvisionalTestSet.Insert(tN)
+		}
+		conformanceProfiles := getConformanceProfilesForTest(tr.test, suite.conformanceProfiles).UnsortedList()
 		sort.Slice(conformanceProfiles, func(i, j int) bool {
 			return conformanceProfiles[i].Name < conformanceProfiles[j].Name
 		})
 		for _, profile := range conformanceProfiles {
-			profileReports.addTestResults(*profile, testResult)
+			profileReports.addTestResults(*profile, tr)
 		}
+	}
+	var succeededProvisionalTests []string
+	if len(succeededProvisionalTestSet) > 0 {
+		succeededProvisionalTests = sets.List(succeededProvisionalTestSet)
 	}
 
 	profileReports.compileResults(suite.extendedSupportedFeatures, suite.extendedUnsupportedFeatures)
@@ -504,12 +522,13 @@ func (suite *ConformanceTestSuite) Report() (*confv1.ConformanceReport, error) {
 			APIVersion: confv1.GroupVersion.String(),
 			Kind:       "ConformanceReport",
 		},
-		Date:              time.Now().Format(time.RFC3339),
-		Mode:              suite.mode,
-		Implementation:    suite.implementation,
-		GatewayAPIVersion: suite.apiVersion,
-		GatewayAPIChannel: suite.apiChannel,
-		ProfileReports:    profileReports.list(),
+		Date:                      time.Now().Format(time.RFC3339),
+		Mode:                      suite.mode,
+		Implementation:            suite.implementation,
+		GatewayAPIVersion:         suite.apiVersion,
+		GatewayAPIChannel:         suite.apiChannel,
+		ProfileReports:            profileReports.list(),
+		SucceededProvisionalTests: succeededProvisionalTests,
 	}, nil
 }
 

--- a/vendor/sigs.k8s.io/gateway-api/pkg/consts/consts.go
+++ b/vendor/sigs.k8s.io/gateway-api/pkg/consts/consts.go
@@ -27,7 +27,7 @@ const (
 
 	// BundleVersion is the value used for the "gateway.networking.k8s.io/bundle-version" annotation.
 	// These value must be updated during the release process.
-	BundleVersion = "v1.2.0-dev"
+	BundleVersion = "v1.2.0-rc1"
 
 	// ApprovalLink is the value used for the "api-approved.kubernetes.io" annotation.
 	// These value must be updated during the release process.


### PR DESCRIPTION
Support for https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.2.0-rc1