### PR TITLE
feat(clustermesh): Improve --destination-context for multiple clusters

### DIFF
--- a/cilium-cli/cli/clustermesh.go
+++ b/cilium-cli/cli/clustermesh.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/cilium-cli/clustermesh"
+	"github.com/cilium/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium/cilium-cli/status"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 )
@@ -322,13 +324,17 @@ func newCmdClusterMeshDisconnectWithHelm() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().StringVar(&params.DestinationContext, "destination-context", "", "Kubernetes configuration context of destination cluster")
+	cmd.Flags().StringVar(&params.ConnectionMode, "connection-mode", defaults.ClusterMeshConnectionModeBidirectional,
+		fmt.Sprintf("Connection mode: %s, %s or %s", defaults.ClusterMeshConnectionModeUnicast, defaults.ClusterMeshConnectionModeBidirectional, defaults.ClusterMeshConnectionModeMesh))
+	cmd.Flags().StringSliceVar(&params.DestinationContext, "destination-context", []string{}, "Comma separated list of Kubernetes configuration contexts of destination cluster")
 
 	return cmd
 }
 
 func addCommonConnectFlags(cmd *cobra.Command, params *clustermesh.Parameters) {
-	cmd.Flags().StringVar(&params.DestinationContext, "destination-context", "", "Kubernetes configuration context of destination cluster")
+	cmd.Flags().StringVar(&params.ConnectionMode, "connection-mode", defaults.ClusterMeshConnectionModeBidirectional,
+		fmt.Sprintf("Connection mode: %s, %s or %s", defaults.ClusterMeshConnectionModeUnicast, defaults.ClusterMeshConnectionModeBidirectional, defaults.ClusterMeshConnectionModeMesh))
+	cmd.Flags().StringSliceVar(&params.DestinationContext, "destination-context", []string{}, "Comma separated list of Kubernetes configuration contexts of destination cluster")
 	cmd.Flags().StringSliceVar(&params.DestinationEndpoints, "destination-endpoint", []string{}, "IP of ClusterMesh service of destination cluster")
 	cmd.Flags().StringSliceVar(&params.SourceEndpoints, "source-endpoint", []string{}, "IP of ClusterMesh service of source cluster")
 }

--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -94,7 +95,8 @@ type K8sClusterMesh struct {
 type Parameters struct {
 	Namespace            string
 	ServiceType          string
-	DestinationContext   string
+	DestinationContext   []string
+	ConnectionMode       string
 	Wait                 bool
 	WaitDuration         time.Duration
 	DestinationEndpoints []string
@@ -488,15 +490,18 @@ func (k *K8sClusterMesh) extractAccessInformation(ctx context.Context, client k8
 	return ai, nil
 }
 
-// getClientsForConnect returns a k8s.Client for the local and remote cluster, respectively
-func (k *K8sClusterMesh) getClientsForConnect() (*k8s.Client, *k8s.Client, error) {
-	remoteClient, err := k8s.NewClient(k.params.DestinationContext, "", k.params.Namespace)
-	if err != nil {
-		return nil, nil, fmt.Errorf(
-			"unable to create Kubernetes client to access remote cluster %q: %w",
-			k.params.DestinationContext, err)
+func (k *K8sClusterMesh) getRemoteClients() ([]*k8s.Client, error) {
+	var remoteClients []*k8s.Client
+	for _, d := range k.params.DestinationContext {
+		remoteClient, err := k8s.NewClient(d, "", k.params.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to create Kubernetes client to access remote cluster %q: %w",
+				d, err)
+		}
+		remoteClients = append(remoteClients, remoteClient)
 	}
-	return k.client.(*k8s.Client), remoteClient, nil
+	return remoteClients, nil
 }
 
 func (k *K8sClusterMesh) shallowExtractAccessInfo(ctx context.Context, c *k8s.Client) (*accessInformation, error) {
@@ -519,24 +524,16 @@ func (k *K8sClusterMesh) shallowExtractAccessInfo(ctx context.Context, c *k8s.Cl
 	}, nil
 }
 
-// connectAccessInit initializes a Kubernetes client for the local and remote cluster
-// and performs some validation that the two clusters can be connected via clustermesh
 func (k *K8sClusterMesh) getAccessInfoForConnect(
-	ctx context.Context, localClient, remoteClient *k8s.Client,
-) (*accessInformation, *accessInformation, error) {
-	aiRemote, err := k.extractAccessInformation(ctx, remoteClient, k.params.DestinationEndpoints, true, false)
+	ctx context.Context, client *k8s.Client, endpoints []string,
+) (*accessInformation, error) {
+	ai, err := k.extractAccessInformation(ctx, client, endpoints, true, false)
 	if err != nil {
-		k.Log("❌ Unable to retrieve access information of remote cluster %q: %s", remoteClient.ClusterName(), err)
-		return nil, nil, err
+		k.Log("❌ Unable to retrieve access information of cluster %q: %s", client.ClusterName(), err)
+		return nil, err
 	}
 
-	aiLocal, err := k.extractAccessInformation(ctx, localClient, k.params.SourceEndpoints, true, false)
-	if err != nil {
-		k.Log("❌ Unable to retrieve access information of local cluster %q: %s", k.client.ClusterName(), err)
-		return nil, nil, err
-	}
-
-	return aiLocal, aiRemote, nil
+	return ai, nil
 }
 
 // connectAccessInit initializes a Kubernetes client for the local and remote cluster
@@ -1589,23 +1586,35 @@ func (k *K8sClusterMesh) validateCAMatch(aiLocal, aiRemote *accessInformation) (
 	return true, nil
 }
 
-// ConnectWithHelm enables clustermesh using a Helm Upgrade
-// action. Certificates are generated via the Helm chart's cronJob
-// (certgen) mode. As with classic mode, only autodetected IP-based
-// clustermesh-apiserver Service endpoints are currently supported.
-func (k *K8sClusterMesh) ConnectWithHelm(ctx context.Context) error {
-	localRelease, err := getRelease(k.client.(*k8s.Client), k.params)
+// ClusterState holds the state during the processing of remote clusters.
+type ClusterState struct {
+	localOldClusters       []map[string]interface{}               // current clustermesh section of helm values
+	localNewClusters       []map[string]interface{}               // new clustermesh section of helm values
+	localHelmValues        map[string]interface{}                 // localOldClusters + localNewClusters => local helm values generated
+	remoteHelmValuesMesh   []map[string]interface{}               // helm values for all remote cluster in mesh mode
+	remoteHelmValuesBD     []map[string]interface{}               // helm values for all remote cluster bidirectional mode
+	remoteOldClustersAll   map[string][]map[string]interface{}    // current clustermesh sections of helm values for remote clusters
+	remoteHelmValuesDelete map[*k8s.Client]map[string]interface{} // helm values for all remote clusters to disconnect
+	remoteNewCluster       map[string]interface{}                 // local cluster to add to remote clusters
+	remoteClusterNames     []string                               // names of remote clusters for displaying logs
+	remoteClusterNamesAi   []string                               // names of remote clusters for remove sections
+}
+
+func processLocalClient(ctx context.Context, localRelease *release.Release) (*ClusterState, error) {
+	state := &ClusterState{}
+	var err error
+
+	state.localOldClusters, err = getOldClusters(localRelease.Config)
 	if err != nil {
-		k.Log("❌ Unable to find Helm release for the target cluster")
-		return err
+		return state, err
 	}
 
-	localClient, remoteClient, err := k.getClientsForConnect()
-	if err != nil {
-		return err
-	}
+	return state, nil
+}
 
-	aiLocal, aiRemote, err := k.getAccessInfoForConnect(ctx, localClient, remoteClient)
+func (k *K8sClusterMesh) processSingleRemoteClient(ctx context.Context, remoteClient *k8s.Client, aiLocal *accessInformation, state *ClusterState) error {
+	state.remoteClusterNames = append(state.remoteClusterNames, remoteClient.ClusterName())
+	aiRemote, err := k.getAccessInfoForConnect(ctx, remoteClient, k.params.DestinationEndpoints)
 	if err != nil {
 		return err
 	}
@@ -1623,13 +1632,9 @@ func (k *K8sClusterMesh) ConnectWithHelm(ctx context.Context) error {
 		k.Log("⚠️ Cilium CA certificates do not match between clusters. Multicluster features will be limited!")
 	}
 
-	// Get existing helm values for the local cluster
-	localHelmValues := localRelease.Config
 	// Expand those values to include the clustermesh configuration
-	localHelmValues, err = updateClustermeshConfig(localHelmValues, aiRemote, !match)
-	if err != nil {
-		return err
-	}
+	newCluster := getCluster(aiRemote, !match)
+	state.localNewClusters = append(state.localNewClusters, newCluster)
 
 	// Get existing helm values for the remote cluster
 	remoteRelease, err := getRelease(remoteClient, k.params)
@@ -1637,110 +1642,342 @@ func (k *K8sClusterMesh) ConnectWithHelm(ctx context.Context) error {
 		k.Log("❌ Unable to find Helm release for the remote cluster")
 		return err
 	}
-	remoteHelmValues := remoteRelease.Config
-	// Expand those values to include the clustermesh configuration
-	remoteHelmValues, err = updateClustermeshConfig(remoteHelmValues, aiLocal, !match)
+
+	remoteOldClusters, err := getOldClusters(remoteRelease.Config)
+	if err != nil {
+		return err
+	}
+	if state.remoteOldClustersAll == nil {
+		state.remoteOldClustersAll = make(map[string][]map[string]interface{})
+	}
+	state.remoteOldClustersAll[aiRemote.ClusterName] = remoteOldClusters
+
+	state.remoteNewCluster = getCluster(aiLocal, !match)
+	remoteHelmValues, err := mergeClusters(remoteOldClusters, []map[string]interface{}{state.remoteNewCluster}, "")
+	if err != nil {
+		return err
+	}
+	state.remoteHelmValuesBD = append(state.remoteHelmValuesBD, remoteHelmValues)
+	return nil
+}
+
+func (k *K8sClusterMesh) processRemoteClients(ctx context.Context, remoteClients []*k8s.Client, localClient *k8s.Client, state *ClusterState) error {
+	aiLocal, err := k.getAccessInfoForConnect(ctx, localClient, k.params.SourceEndpoints)
 	if err != nil {
 		return err
 	}
 
+	for _, remoteClient := range remoteClients {
+		err := k.processSingleRemoteClient(ctx, remoteClient, aiLocal, state)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func processRemoteHelmValuesMesh(state *ClusterState) error {
+	remoteNewClusters := append(state.localNewClusters, state.remoteNewCluster)
+	for clusterName, remoteOldClusters := range state.remoteOldClustersAll {
+		remoteHelmValues, err := mergeClusters(remoteOldClusters, remoteNewClusters, clusterName)
+		if err != nil {
+			return err
+		}
+		state.remoteHelmValuesMesh = append(state.remoteHelmValuesMesh, remoteHelmValues)
+	}
+	return nil
+}
+
+func (k *K8sClusterMesh) connectLocalWithHelm(ctx context.Context, localClient *k8s.Client, state *ClusterState) error {
+	var err error
+	state.localHelmValues, err = mergeClusters(state.localOldClusters, state.localNewClusters, "")
+	if err != nil {
+		return err
+	}
+
+	k.Log("ℹ️ Configuring Cilium in cluster %s to connect to cluster %s",
+		localClient.ClusterName(), strings.Join(state.remoteClusterNames, ","))
+	return k.helmUpgrade(ctx, localClient, state.localHelmValues)
+}
+
+func (k *K8sClusterMesh) helmUpgrade(ctx context.Context, client *k8s.Client, values map[string]interface{}) error {
 	upgradeParams := helm.UpgradeParameters{
 		Namespace:   k.params.Namespace,
 		Name:        k.params.HelmReleaseName,
-		Values:      localHelmValues,
+		Values:      values,
 		ResetValues: false,
 		ReuseValues: true,
 	}
 
-	// Enable clustermesh using a Helm Upgrade command against our target cluster
-	k.Log("ℹ️ Configuring Cilium in cluster '%s' to connect to cluster '%s'",
-		localClient.ClusterName(), remoteClient.ClusterName())
-	_, err = helm.Upgrade(ctx, localClient.HelmActionConfig, upgradeParams)
+	_, err := helm.Upgrade(ctx, client.HelmActionConfig, upgradeParams)
 	if err != nil {
 		return err
 	}
-
-	// Enable clustermesh using a Helm Upgrade command against the remote cluster
-	k.Log("ℹ️ Configuring Cilium in cluster '%s' to connect to cluster '%s'",
-		remoteClient.ClusterName(), localClient.ClusterName())
-	upgradeParams.Values = remoteHelmValues
-	_, err = helm.Upgrade(ctx, remoteClient.HelmActionConfig, upgradeParams)
-	if err != nil {
-		return err
-	}
-
-	k.Log("✅ Connected cluster %s and %s!", localClient.ClusterName(), remoteClient.ClusterName())
 	return nil
 }
 
-func (k *K8sClusterMesh) DisconnectWithHelm(ctx context.Context) error {
-	localRelease, err := getRelease(k.client.(*k8s.Client), k.params)
+func (k *K8sClusterMesh) checkConnectionMode() error {
+	validModes := []string{
+		defaults.ClusterMeshConnectionModeBidirectional,
+		defaults.ClusterMeshConnectionModeMesh,
+		defaults.ClusterMeshConnectionModeUnicast,
+	}
+
+	for _, mode := range validModes {
+		if k.params.ConnectionMode == mode {
+			return nil
+		}
+	}
+
+	k.Log("❌ %s is not a correct connection mode.", k.params.ConnectionMode)
+	k.Log("Available connection modes: %s", strings.Join(validModes, ", "))
+	return errors.New("Bad connection mode")
+}
+
+// ConnectWithHelm enables clustermesh using a Helm Upgrade
+// action. Certificates are generated via the Helm chart's cronJob
+// (certgen) mode. As with classic mode, only autodetected IP-based
+// clustermesh-apiserver Service endpoints are currently supported.
+func (k *K8sClusterMesh) ConnectWithHelm(ctx context.Context) error {
+	localClient := k.client.(*k8s.Client)
+	err := k.checkConnectionMode()
+	if err != nil {
+		return err
+	}
+
+	localRelease, err := getRelease(localClient, k.params)
 	if err != nil {
 		k.Log("❌ Unable to find Helm release for the target cluster")
 		return err
 	}
 
-	localClient, remoteClient, err := k.getClientsForConnect()
+	remoteClients, err := k.getRemoteClients()
 	if err != nil {
 		return err
 	}
-	aiLocal, err := k.shallowExtractAccessInfo(ctx, localClient)
+
+	clusterState, err := processLocalClient(ctx, localRelease)
 	if err != nil {
 		return err
 	}
-	aiRemote, err := k.shallowExtractAccessInfo(ctx, remoteClient)
+
+	err = k.processRemoteClients(ctx, remoteClients, localClient, clusterState)
+	if err != nil {
+		return err
+	}
+
+	err = processRemoteHelmValuesMesh(clusterState)
+	if err != nil {
+		return err
+	}
+
+	err = k.connectLocalWithHelm(ctx, localClient, clusterState)
+	if err != nil {
+		return err
+	}
+
+	err = k.connectRemoteWithHelm(ctx, localClient.ClusterName(), remoteClients, clusterState)
+	if err != nil {
+		return err
+	}
+	k.displayCompleteMessage(localClient, remoteClients, clusterState)
+	return nil
+}
+
+func (k *K8sClusterMesh) displayCompleteMessage(localClient *k8s.Client, remoteClients []*k8s.Client, state *ClusterState) {
+	switch k.params.ConnectionMode {
+	case defaults.ClusterMeshConnectionModeBidirectional:
+		for _, remoteClient := range remoteClients {
+			k.Log("✅ Connected cluster %s <=> %s!", localClient.ClusterName(), remoteClient.ClusterName())
+		}
+	case defaults.ClusterMeshConnectionModeMesh:
+		k.Log("✅ Connected clusters %s, and %s!", strings.Join(state.remoteClusterNames, ", "), localClient.ClusterName())
+	case defaults.ClusterMeshConnectionModeUnicast:
+		for _, remoteClient := range remoteClients {
+			k.Log("✅ Connected cluster %s => %s!", localClient.ClusterName(), remoteClient.ClusterName())
+		}
+	}
+}
+
+func (k *K8sClusterMesh) connectRemoteWithHelm(ctx context.Context, clusterName string, remoteClients []*k8s.Client, state *ClusterState) error {
+	var rc []*k8s.Client
+	var cn []string
+	var helmValues []map[string]interface{}
+
+	switch k.params.ConnectionMode {
+	case defaults.ClusterMeshConnectionModeBidirectional:
+		rc = remoteClients
+		helmValues = state.remoteHelmValuesBD
+		cn = []string{clusterName}
+	case defaults.ClusterMeshConnectionModeMesh:
+		rc = remoteClients
+		helmValues = state.remoteHelmValuesMesh
+		cn = append(state.remoteClusterNames, clusterName)
+	}
+
+	for i, remoteClient := range rc {
+		err := k.connectSingleRemoteWithHelm(ctx, remoteClient, cn, helmValues[i])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (k *K8sClusterMesh) connectSingleRemoteWithHelm(ctx context.Context, remoteClient *k8s.Client, clusterNames []string, helmValues map[string]interface{}) error {
+	clusterNamesExceptRemote := removeStringFromSlice(remoteClient.ClusterName(), clusterNames)
+	k.Log("ℹ️ Configuring Cilium in cluster %s to connect to cluster %s",
+		remoteClient.ClusterName(), strings.Join(clusterNamesExceptRemote, ","))
+	err := k.helmUpgrade(ctx, remoteClient, helmValues)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (k *K8sClusterMesh) getRemoteClusterNamesAi(ctx context.Context, remoteClients []*k8s.Client) (*ClusterState, error) {
+	state := &ClusterState{}
+
+	for _, remoteClient := range remoteClients {
+		aiRemote, err := k.shallowExtractAccessInfo(ctx, remoteClient)
+		if err != nil {
+			return state, err
+		}
+		state.remoteClusterNamesAi = append(state.remoteClusterNamesAi, aiRemote.ClusterName)
+	}
+
+	return state, nil
+}
+
+func (k *K8sClusterMesh) retrieveRemoteHelmValues(ctx context.Context, remoteClients []*k8s.Client, state *ClusterState) error {
+	aiLocal, err := k.shallowExtractAccessInfo(ctx, k.client.(*k8s.Client))
+	if err != nil {
+		return err
+	}
+	remoteClusterNames := []string{aiLocal.ClusterName}
+	if k.params.ConnectionMode == defaults.ClusterMeshConnectionModeMesh {
+		remoteClusterNames = append(remoteClusterNames, state.remoteClusterNamesAi...)
+	}
+	for _, remoteClient := range remoteClients {
+		remoteRelease, err := getRelease(remoteClient, k.params)
+		if err != nil {
+			k.Log("❌ Unable to find Helm release for the remote cluster")
+			return err
+		}
+		// Modify the clustermesh config to remove the intended cluster if any
+		remoteHelmValues, err := removeFromClustermeshConfig(remoteRelease.Config, remoteClusterNames)
+		if err != nil {
+			return err
+		}
+		if state.remoteHelmValuesDelete == nil {
+			state.remoteHelmValuesDelete = make(map[*k8s.Client]map[string]interface{})
+		}
+		state.remoteHelmValuesDelete[remoteClient] = remoteHelmValues
+		state.remoteClusterNames = append(state.remoteClusterNames, remoteClient.ClusterName())
+	}
+	return nil
+}
+
+func removeStringFromSlice(name string, names []string) []string {
+	namesCopy := append([]string{}, names...)
+	namesCopy = slices.DeleteFunc(namesCopy, func(n string) bool {
+		return n == name
+	})
+	return namesCopy
+}
+
+func (k *K8sClusterMesh) valueOfFromClusterName(clusterName string, remoteClusterName string, remoteClusterNames []string) string {
+	cn := clusterName
+	if k.params.ConnectionMode == defaults.ClusterMeshConnectionModeMesh {
+		clusterNamesExceptRemote := removeStringFromSlice(remoteClusterName, remoteClusterNames)
+		clusterNamesExceptRemote = append(clusterNamesExceptRemote, clusterName)
+		cn = strings.Join(clusterNamesExceptRemote, ",")
+	}
+	return cn
+}
+
+func (k *K8sClusterMesh) disconnectRemoteWithHelm(ctx context.Context, clusterName string, state *ClusterState) error {
+	if k.params.ConnectionMode == defaults.ClusterMeshConnectionModeUnicast {
+		return nil
+	}
+	for remoteClient, helmValues := range state.remoteHelmValuesDelete {
+		cn := k.valueOfFromClusterName(clusterName, remoteClient.ClusterName(), state.remoteClusterNames)
+		k.Log("ℹ️ Configuring Cilium in cluster %s to disconnect from cluster %s",
+			remoteClient.ClusterName(), cn)
+		err := k.helmUpgrade(ctx, remoteClient, helmValues)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (k *K8sClusterMesh) DisconnectWithHelm(ctx context.Context) error {
+	localClient := k.client.(*k8s.Client)
+	err := k.checkConnectionMode()
+	if err != nil {
+		return err
+	}
+
+	localRelease, err := getRelease(localClient, k.params)
+	if err != nil {
+		k.Log("❌ Unable to find Helm release for the target cluster")
+		return err
+	}
+
+	remoteClients, err := k.getRemoteClients()
+	if err != nil {
+		return err
+	}
+	clusterState, err := k.getRemoteClusterNamesAi(ctx, remoteClients)
 	if err != nil {
 		return err
 	}
 
 	// Modify the clustermesh config to remove the intended cluster if any
-	localHelmValues, err := removeFromClustermeshConfig(localRelease.Config, aiRemote.ClusterName)
+	localHelmValues, err := removeFromClustermeshConfig(localRelease.Config, clusterState.remoteClusterNamesAi)
 	if err != nil {
 		return err
 	}
 
-	// Get existing helm values for the remote cluster
-	remoteRelease, err := getRelease(remoteClient, k.params)
-	if err != nil {
-		k.Log("❌ Unable to find Helm release for the remote cluster")
-		return err
-	}
-	// Modify the clustermesh config to remove the intended cluster if any
-	remoteHelmValues, err := removeFromClustermeshConfig(remoteRelease.Config, aiLocal.ClusterName)
+	err = k.retrieveRemoteHelmValues(ctx, remoteClients, clusterState)
 	if err != nil {
 		return err
 	}
 
-	upgradeParams := helm.UpgradeParameters{
-		Namespace:   k.params.Namespace,
-		Name:        k.params.HelmReleaseName,
-		Values:      localHelmValues,
-		ResetValues: false,
-		ReuseValues: true,
+	k.Log("ℹ️ Configuring Cilium in cluster %s to disconnect from cluster %s",
+		localClient.ClusterName(), strings.Join(clusterState.remoteClusterNames, ","))
+	err = k.helmUpgrade(ctx, localClient, localHelmValues)
+	if err != nil {
+		return err
 	}
-
-	// Disconnect clustermesh using a Helm Upgrade command against our target cluster
-	k.Log("ℹ️ Configuring Cilium in cluster '%s' to disconnect from cluster '%s'",
-		localClient.ClusterName(), remoteClient.ClusterName())
-	if _, err = helm.Upgrade(ctx, localClient.HelmActionConfig, upgradeParams); err != nil {
+	err = k.disconnectRemoteWithHelm(ctx, localClient.ClusterName(), clusterState)
+	if err != nil {
 		return err
 	}
 
-	// Disconnect clustermesh using a Helm Upgrade command against the remote cluster
-	k.Log("ℹ️ Configuring Cilium in cluster '%s' to disconnect from cluster '%s'",
-		remoteClient.ClusterName(), localClient.ClusterName())
-	upgradeParams.Values = remoteHelmValues
-	if _, err = helm.Upgrade(ctx, remoteClient.HelmActionConfig, upgradeParams); err != nil {
-		return err
-	}
-	k.Log("✅ Disconnected clusters %s and %s!", localClient.ClusterName(), remoteClient.ClusterName())
+	k.displayDisconnectedCompleteMessage(localClient, remoteClients, clusterState)
 
 	return nil
 }
 
-func updateClustermeshConfig(
-	values map[string]interface{}, aiRemote *accessInformation, configTLS bool,
-) (map[string]interface{}, error) {
+func (k *K8sClusterMesh) displayDisconnectedCompleteMessage(localClient *k8s.Client, remoteClients []*k8s.Client, state *ClusterState) {
+	switch k.params.ConnectionMode {
+	case defaults.ClusterMeshConnectionModeBidirectional:
+		for _, remoteClient := range remoteClients {
+			k.Log("✅ Disconnected clusters %s <x> %s!", localClient.ClusterName(), remoteClient.ClusterName())
+		}
+	case defaults.ClusterMeshConnectionModeMesh:
+		k.Log("✅ Disconnected clusters %s, and %s!", strings.Join(state.remoteClusterNames, ", "), localClient.ClusterName())
+	case defaults.ClusterMeshConnectionModeUnicast:
+		for _, remoteClient := range remoteClients {
+			k.Log("✅ Disconnected clusters %s x> %s!", localClient.ClusterName(), remoteClient.ClusterName())
+		}
+	}
+}
+
+func getOldClusters(values map[string]interface{}) ([]map[string]interface{}, error) {
 	// get current clusters config slice, if it exists
 	c, found, err := unstructured.NestedFieldCopy(values, "clustermesh", "config", "clusters")
 	if err != nil {
@@ -1764,10 +2001,14 @@ func updateClustermeshConfig(
 		oldClusters = append(oldClusters, cluster)
 	}
 
+	return oldClusters, nil
+}
+
+func getCluster(ai *accessInformation, configTLS bool) map[string]interface{} {
 	remoteCluster := map[string]interface{}{
-		"name": aiRemote.ClusterName,
-		"ips":  []string{aiRemote.ServiceIPs[0]},
-		"port": aiRemote.ServicePort,
+		"name": ai.ClusterName,
+		"ips":  []string{ai.ServiceIPs[0]},
+		"port": ai.ServicePort,
 	}
 
 	// Only add TLS configuration if requested (probably because CA
@@ -1776,16 +2017,17 @@ func updateClustermeshConfig(
 	// renewed automatically and cross-cluster Hubble does not operate.
 	if configTLS {
 		remoteCluster["tls"] = map[string]interface{}{
-			"cert":   base64.StdEncoding.EncodeToString(aiRemote.ClientCert),
-			"key":    base64.StdEncoding.EncodeToString(aiRemote.ClientKey),
-			"caCert": base64.StdEncoding.EncodeToString(aiRemote.CA),
+			"cert":   base64.StdEncoding.EncodeToString(ai.ClientCert),
+			"key":    base64.StdEncoding.EncodeToString(ai.ClientKey),
+			"caCert": base64.StdEncoding.EncodeToString(ai.CA),
 		}
 	}
 
-	// allocate new cluster entries
-	newClusters := []map[string]interface{}{remoteCluster}
+	return remoteCluster
+}
 
-	// merge new clusters on top of old clusters
+func mergeClusters(
+	oldClusters []map[string]interface{}, newClusters []map[string]interface{}, exceptCluster string) (map[string]interface{}, error) {
 	clusters := map[string]map[string]interface{}{}
 	for _, c := range oldClusters {
 		name, ok := c["name"].(string)
@@ -1795,7 +2037,9 @@ func updateClustermeshConfig(
 		clusters[name] = c
 	}
 	for _, c := range newClusters {
-		clusters[c["name"].(string)] = c
+		if c["name"].(string) != exceptCluster {
+			clusters[c["name"].(string)] = c
+		}
 	}
 
 	outputClusters := make([]map[string]interface{}, 0)
@@ -1811,11 +2055,10 @@ func updateClustermeshConfig(
 			},
 		},
 	}
-
 	return newValues, nil
 }
 
-func removeFromClustermeshConfig(values map[string]any, clusterName string) (map[string]any, error) {
+func removeFromClustermeshConfig(values map[string]any, clusterNames []string) (map[string]any, error) {
 	// get current clusters config slice, if it exists
 	c, found, err := unstructured.NestedFieldCopy(values, "clustermesh", "config", "clusters")
 	if err != nil {
@@ -1836,7 +2079,7 @@ func removeFromClustermeshConfig(values map[string]any, clusterName string) (map
 			return nil, fmt.Errorf("existing clustermesh.config.clusters map is invalid")
 		}
 		name, ok := cluster["name"].(string)
-		if ok && name == clusterName {
+		if ok && slices.Contains(clusterNames, name) {
 			continue
 		}
 		outputClusters = append(outputClusters, cluster)

--- a/cilium-cli/clustermesh/clustermesh_test.go
+++ b/cilium-cli/clustermesh/clustermesh_test.go
@@ -5,6 +5,8 @@ package clustermesh
 
 import (
 	"context"
+	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,15 +17,447 @@ import (
 	"github.com/cilium/cilium/cilium-cli/k8s"
 )
 
+// Helper function to compare two slices of maps ignoring the order
+func equalClusterSlices(a, b []map[string]interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	bCopy := make([]map[string]interface{}, len(b))
+	copy(bCopy, b)
+
+	return slices.EqualFunc(a, bCopy, func(m1, m2 map[string]interface{}) bool {
+		for i, bm := range bCopy {
+			if reflect.DeepEqual(m1, bm) {
+				bCopy = append(bCopy[:i], bCopy[i+1:]...)
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func TestMergeClusters(t *testing.T) {
+	uu := map[string]struct {
+		oc            []map[string]interface{}
+		nc            []map[string]interface{}
+		exceptCluster string
+		err           error
+		e             map[string]interface{}
+	}{
+		"nil-new-one": {
+			oc: []map[string]interface{}{},
+			nc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+			},
+			e: map[string]interface{}{
+				"clustermesh": map[string]interface{}{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"clusters": []map[string]interface{}{
+							{
+								"ips":  []string{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+						},
+					},
+				},
+			},
+		},
+		"nil-new-some": {
+			oc: []map[string]interface{}{},
+			nc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.7"},
+					"name": "c2",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.8"},
+					"name": "c1",
+					"port": "32379",
+				},
+			},
+			e: map[string]interface{}{
+				"clustermesh": map[string]interface{}{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"clusters": []map[string]interface{}{
+							{
+								"ips":  []string{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+							{
+								"ips":  []string{"172.19.0.7"},
+								"name": "c2",
+								"port": "32379",
+							},
+							{
+								"ips":  []string{"172.19.0.8"},
+								"name": "c1",
+								"port": "32379",
+							},
+						},
+					},
+				},
+			},
+		},
+		"oc-new-some": {
+			oc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.5"},
+					"name": "c2",
+					"port": "32379"},
+				{
+					"ips":  []string{"172.19.0.4"},
+					"name": "c1",
+					"port": "32379"},
+			},
+			nc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.7"},
+					"name": "c4",
+					"port": "32379",
+				},
+			},
+			e: map[string]interface{}{
+				"clustermesh": map[string]interface{}{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"clusters": []map[string]interface{}{
+							{
+								"ips":  []string{"172.19.0.5"},
+								"name": "c2",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.4"},
+								"name": "c1",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+							{
+								"ips":  []string{"172.19.0.7"},
+								"name": "c4",
+								"port": "32379",
+							},
+						},
+					},
+				},
+			},
+		},
+		"already-there": {
+			oc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.5"},
+					"name": "c2",
+					"port": "32379"},
+				{
+					"ips":  []string{"172.19.0.4"},
+					"name": "c1",
+					"port": "32379"},
+			},
+			nc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+			},
+			e: map[string]interface{}{
+				"clustermesh": map[string]interface{}{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"clusters": []map[string]interface{}{
+							{
+								"ips":  []string{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+							{
+								"ips":  []string{"172.19.0.5"},
+								"name": "c2",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.4"},
+								"name": "c1",
+								"port": "32379"},
+						},
+					},
+				},
+			},
+		},
+		"already-there-partially": {
+			oc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.5"},
+					"name": "c2",
+					"port": "32379"},
+				{
+					"ips":  []string{"172.19.0.4"},
+					"name": "c1",
+					"port": "32379"},
+			},
+			nc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.7"},
+					"name": "c4",
+					"port": "32379",
+				},
+			},
+			e: map[string]interface{}{
+				"clustermesh": map[string]interface{}{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"clusters": []map[string]interface{}{
+							{
+								"ips":  []string{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+							{
+								"ips":  []string{"172.19.0.5"},
+								"name": "c2",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.4"},
+								"name": "c1",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.7"},
+								"name": "c4",
+								"port": "32379"},
+						},
+					},
+				},
+			},
+		},
+		"except-nc-changed": {
+			oc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.5"},
+					"name": "c2",
+					"port": "32379"},
+				{
+					"ips":  []string{"172.19.0.4"},
+					"name": "c1",
+					"port": "32379"},
+			},
+			nc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.8"},
+					"name": "c5",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.7"},
+					"name": "c4",
+					"port": "32379",
+				},
+			},
+			exceptCluster: "c4",
+			e: map[string]interface{}{
+				"clustermesh": map[string]interface{}{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"clusters": []map[string]interface{}{
+							{
+								"ips":  []string{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+							{
+								"ips":  []string{"172.19.0.5"},
+								"name": "c2",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.4"},
+								"name": "c1",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.8"},
+								"name": "c5",
+								"port": "32379"},
+						},
+					},
+				},
+			},
+		},
+		"except-nc-same": {
+			oc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.5"},
+					"name": "c2",
+					"port": "32379"},
+				{
+					"ips":  []string{"172.19.0.4"},
+					"name": "c1",
+					"port": "32379"},
+			},
+			nc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.7"},
+					"name": "c4",
+					"port": "32379",
+				},
+			},
+			exceptCluster: "c4",
+			e: map[string]interface{}{
+				"clustermesh": map[string]interface{}{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"clusters": []map[string]interface{}{
+							{
+								"ips":  []string{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+							{
+								"ips":  []string{"172.19.0.5"},
+								"name": "c2",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.4"},
+								"name": "c1",
+								"port": "32379"},
+						},
+					},
+				},
+			},
+		},
+		"except-oc": {
+			oc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.5"},
+					"name": "c2",
+					"port": "32379"},
+				{
+					"ips":  []string{"172.19.0.4"},
+					"name": "c1",
+					"port": "32379"},
+			},
+			nc: []map[string]interface{}{
+				{
+					"ips":  []string{"172.19.0.6"},
+					"name": "c3",
+					"port": "32379",
+				},
+				{
+					"ips":  []string{"172.19.0.7"},
+					"name": "c4",
+					"port": "32379",
+				},
+			},
+			exceptCluster: "c2",
+			e: map[string]interface{}{
+				"clustermesh": map[string]interface{}{
+					"config": map[string]interface{}{
+						"enabled": true,
+						"clusters": []map[string]interface{}{
+							{
+								"ips":  []string{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+							{
+								"ips":  []string{"172.19.0.5"},
+								"name": "c2",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.4"},
+								"name": "c1",
+								"port": "32379"},
+							{
+								"ips":  []string{"172.19.0.7"},
+								"name": "c4",
+								"port": "32379"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			ee, err := mergeClusters(u.oc, u.nc, u.exceptCluster)
+			if err != nil {
+				assert.Equal(t, u.err, err)
+				return
+			}
+
+			// Compare the clusters ignoring the order
+			expectedClusters := u.e["clustermesh"].(map[string]interface{})["config"].(map[string]interface{})["clusters"].([]map[string]interface{})
+			actualClusters := ee["clustermesh"].(map[string]interface{})["config"].(map[string]interface{})["clusters"].([]map[string]interface{})
+
+			assert.True(t, equalClusterSlices(expectedClusters, actualClusters))
+		})
+	}
+}
+
 func TestRemoveFromClustermeshConfig(t *testing.T) {
 	uu := map[string]struct {
-		vv      map[string]any
-		cluster string
-		err     error
-		e       map[string]any
+		vv       map[string]any
+		clusters []string
+		err      error
+		e        map[string]any
 	}{
 		"missing": {
-			cluster: "test1",
+			clusters: []string{"test1", "test2"},
 			e: map[string]any{
 				"clustermesh": map[string]any{
 					"config": map[string]any{
@@ -34,7 +468,7 @@ func TestRemoveFromClustermeshConfig(t *testing.T) {
 			},
 		},
 		"empty": {
-			cluster: "c2",
+			clusters: []string{"c1", "c2"},
 			vv: map[string]any{
 				"clustermesh": map[string]any{
 					"config": map[string]any{
@@ -52,7 +486,43 @@ func TestRemoveFromClustermeshConfig(t *testing.T) {
 			},
 		},
 		"connected": {
-			cluster: "c2",
+			clusters: []string{"c1", "c2"},
+			vv: map[string]any{
+				"clustermesh": map[string]any{
+					"config": map[string]any{
+						"clusters": []any{
+							map[string]any{
+								"ips":  []any{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+							map[string]any{
+								"ips":  []any{"172.19.0.4"},
+								"name": "c2",
+								"port": "32379"},
+							map[string]any{
+								"ips":  []any{"172.19.0.4"},
+								"name": "c1",
+								"port": "32379"},
+						},
+					},
+				},
+			},
+			e: map[string]any{
+				"clustermesh": map[string]any{
+					"config": map[string]any{
+						"clusters": []map[string]any{
+							{
+								"ips":  []any{"172.19.0.6"},
+								"name": "c3",
+								"port": "32379",
+							},
+						}, "enabled": true},
+				},
+			},
+		},
+		"partially-connected": {
+			clusters: []string{"c3", "c4"},
 			vv: map[string]any{
 				"clustermesh": map[string]any{
 					"config": map[string]any{
@@ -75,8 +545,8 @@ func TestRemoveFromClustermeshConfig(t *testing.T) {
 					"config": map[string]any{
 						"clusters": []map[string]any{
 							{
-								"ips":  []any{"172.19.0.6"},
-								"name": "c3",
+								"ips":  []any{"172.19.0.4"},
+								"name": "c2",
 								"port": "32379",
 							},
 						}, "enabled": true},
@@ -84,7 +554,7 @@ func TestRemoveFromClustermeshConfig(t *testing.T) {
 			},
 		},
 		"not-connected": {
-			cluster: "c4",
+			clusters: []string{"c1", "c4"},
 			vv: map[string]any{
 				"clustermesh": map[string]any{
 					"config": map[string]any{
@@ -127,7 +597,7 @@ func TestRemoveFromClustermeshConfig(t *testing.T) {
 	for k := range uu {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
-			ee, err := removeFromClustermeshConfig(u.vv, u.cluster)
+			ee, err := removeFromClustermeshConfig(u.vv, u.clusters)
 			if err != nil {
 				assert.Equal(t, u.err, err)
 				return

--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -36,23 +36,26 @@ const (
 
 	HubbleGenerateCertsCronJobName = "hubble-generate-certs"
 
-	ClusterMeshDeploymentName             = "clustermesh-apiserver"
-	ClusterMeshBinaryName                 = "/usr/bin/clustermesh-apiserver"
-	ClusterMeshContainerName              = "apiserver"
-	ClusterMeshPodSelector                = "k8s-app=clustermesh-apiserver"
-	ClusterMeshMetricsPortName            = "apiserv-metrics"
-	ClusterMeshKVStoreMeshContainerName   = "kvstoremesh"
-	ClusterMeshKVStoreMeshMetricsPortName = "kvmesh-metrics"
-	ClusterMeshEtcdContainerName          = "etcd"
-	ClusterMeshEtcdMetricsPortName        = "etcd-metrics"
-	ClusterMeshServiceName                = "clustermesh-apiserver"
-	ClusterMeshSecretName                 = "cilium-clustermesh" // Secret which contains the clustermesh configuration
-	ClusterMeshKVStoreMeshSecretName      = "cilium-kvstoremesh" // Secret which contains the kvstoremesh configuration
-	ClusterMeshServerSecretName           = "clustermesh-apiserver-server-cert"
-	ClusterMeshAdminSecretName            = "clustermesh-apiserver-admin-cert"
-	ClusterMeshClientSecretName           = "clustermesh-apiserver-client-cert"
-	ClusterMeshRemoteSecretName           = "clustermesh-apiserver-remote-cert"
-	ClusterMeshExternalWorkloadSecretName = "clustermesh-apiserver-external-workload-cert"
+	ClusterMeshDeploymentName              = "clustermesh-apiserver"
+	ClusterMeshBinaryName                  = "/usr/bin/clustermesh-apiserver"
+	ClusterMeshContainerName               = "apiserver"
+	ClusterMeshPodSelector                 = "k8s-app=clustermesh-apiserver"
+	ClusterMeshMetricsPortName             = "apiserv-metrics"
+	ClusterMeshKVStoreMeshContainerName    = "kvstoremesh"
+	ClusterMeshKVStoreMeshMetricsPortName  = "kvmesh-metrics"
+	ClusterMeshEtcdContainerName           = "etcd"
+	ClusterMeshEtcdMetricsPortName         = "etcd-metrics"
+	ClusterMeshServiceName                 = "clustermesh-apiserver"
+	ClusterMeshSecretName                  = "cilium-clustermesh" // Secret which contains the clustermesh configuration
+	ClusterMeshKVStoreMeshSecretName       = "cilium-kvstoremesh" // Secret which contains the kvstoremesh configuration
+	ClusterMeshServerSecretName            = "clustermesh-apiserver-server-cert"
+	ClusterMeshAdminSecretName             = "clustermesh-apiserver-admin-cert"
+	ClusterMeshClientSecretName            = "clustermesh-apiserver-client-cert"
+	ClusterMeshRemoteSecretName            = "clustermesh-apiserver-remote-cert"
+	ClusterMeshExternalWorkloadSecretName  = "clustermesh-apiserver-external-workload-cert"
+	ClusterMeshConnectionModeBidirectional = "bidirectional"
+	ClusterMeshConnectionModeMesh          = "mesh"
+	ClusterMeshConnectionModeUnicast       = "unicast"
 
 	SPIREServerStatefulSetName = "spire-server"
 	SPIREServerConfigMapName   = "spire-server"


### PR DESCRIPTION
Improve the `--destination-context` option to enhance the flexibility of connecting multiple remote contexts.

This feature supports various connection modes (using the `--connection-mode` option):

* unicast: configures only the source context
* bidirectional (default value): configures the source context and its cluster in the destination contexts
* mesh: configures both the source and destination contexts, including clusters in both.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
