### PR TITLE
.github: fix lvh-kind warnings

### DIFF
--- a/.github/actions/lvh-kind/action.yaml
+++ b/.github/actions/lvh-kind/action.yaml
@@ -26,9 +26,12 @@ runs:
       with:
         test-name: ${{ inputs.test-name }}
         image-version: ${{ inputs.kernel }}
+        images-folder-parent: "/tmp"
         host-mount: ./
         cpu: 4
         mem: 12G
+        # renovate: datasource=github-tags depName=cilium/little-vm-helper
+        lvh-version: "v0.0.19"
         install-dependencies: 'true'
         port-forward: '6443:6443'
         ssh-connect-wait-retries: 600

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -756,6 +756,20 @@
         "\/\/ renovate: datasource=(?<datasource>.*?)\\s+.+Image = \"(?<depName>.*):(?<currentValue>.*)@(?<currentDigest>sha256:[a-f0-9]+)\"",
         "\/\/ renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+Version = \"(?<currentValue>.*)\""
       ]
+    },
+    {
+      "fileMatch": [
+        ".github/actions/lvh-kind/action.yaml",
+        ".github/workflows/conformance-ginkgo.yaml",
+        ".github/workflows/conformance-runtime.yaml",
+        ".github/workflows/tests-datapath-verifier.yaml",
+      ],
+      // These regexes manage version and digest strings in shell scripts,
+      // similar to the examples shown here:
+      //   https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+lvh-version: \"(?<currentValue>.*)\""
+      ]
     }
   ]
 }

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -298,9 +298,12 @@ jobs:
           test-name: datapath-conformance
           install-dependencies: true
           image-version: ${{ matrix.kernel }}
+          images-folder-parent: "/tmp"
           host-mount: ./
           cpu: 4
           mem: 12G
+          # renovate: datasource=github-tags depName=cilium/little-vm-helper
+          lvh-version: "v0.0.19"
           cmd: |
             git config --global --add safe.directory /host
             mv /host/helm /usr/bin

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -269,7 +269,10 @@ jobs:
           # renovate: datasource=docker depName=quay.io/lvh-images/kind
           image-version: "bpf-next-20240711.013133@sha256:5a2e78c14809c33d6fbae7762ec73b293aaa5e9b485226292348782bae1a3ed1"
           host-mount: ./
+          images-folder-parent: "/tmp"
           cpu: 4
+          # renovate: datasource=github-tags depName=cilium/little-vm-helper
+          lvh-version: "v0.0.19"
           mem: 12G
 
       # Load Ginkgo build from GitHub

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -129,7 +129,10 @@ jobs:
           image: 'complexity-test'
           image-version: ${{ matrix.kernel }}
           host-mount: ./
+          images-folder-parent: "/tmp"
           cpu: 4
+          # renovate: datasource=github-tags depName=cilium/little-vm-helper
+          lvh-version: "v0.0.19"
           install-dependencies: 'true'
           cmd: |
             for i in {1..5}; do curl "https://golang.org" > /dev/null 2>&1 && break || sleep 5; echo "Waiting for systemd-resolved to be ready..."; done


### PR DESCRIPTION
There are some warnings from the lvh-kind GitHub action. This commit fixes them.

Also, add renovate configuration to update the lvh-kind action version automatically.