### PR TITLE
CI: l4lb allow extra opts

### DIFF
--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -120,11 +120,11 @@ jobs:
       - name: Run LoadBalancing test
         id: lb-test
         run: |
-          cd ${{ github.workspace }}/test/l4lb && sudo ./test.sh ${{ env.QUAY_ORGANIZATION_DEV }} ${{ steps.vars.outputs.sha }}
+          cd ${{ github.workspace }}/test/l4lb && sudo ./test.sh ${{ env.QUAY_ORGANIZATION_DEV }} ${{ steps.vars.outputs.sha }} ${{ env.CILIUM_RUNTIME_EXTRA_ARGS }}
 
       - name: Run NAT46x64 test
         run: |
-          cd ${{ github.workspace }}/test/nat46x64 && sudo ./test.sh ${{ env.QUAY_ORGANIZATION_DEV }} ${{ steps.vars.outputs.sha }}
+          cd ${{ github.workspace }}/test/nat46x64 && sudo ./test.sh ${{ env.QUAY_ORGANIZATION_DEV }} ${{ steps.vars.outputs.sha }} ${{ env.CILIUM_RUNTIME_EXTRA_ARGS }}
 
       - name: Fetch DinD information
         if: ${{ !success() && steps.lb-test.outcome != 'skipped' }}

--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -7,6 +7,7 @@ export LC_NUMERIC=C
 
 IMG_OWNER=${1:-cilium}
 IMG_TAG=${2:-latest}
+CILIUM_EXTRA_ARGS=${3:-}
 
 ###########
 #  SETUP  #
@@ -72,7 +73,7 @@ docker exec -t lb-node \
     --bpf-lb-acceleration=native \
     --bpf-lb-mode=dsr \
     --devices="eth0,l4lb-veth1" \
-    --direct-routing-device=eth0
+    --direct-routing-device=eth0 ${CILIUM_EXTRA_ARGS}
 
 IFIDX=$(docker exec -i lb-node \
     /bin/sh -c 'echo $(( $(ip -o l show eth0 | awk "{print $1}" | cut -d: -f1) ))')

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -5,6 +5,7 @@ set -eu
 
 IMG_OWNER=${1:-cilium}
 IMG_TAG=${2:-latest}
+CILIUM_EXTRA_ARGS=${3:-}
 V=${V:-"0"} # Verbosity. 0 = quiet, 1 = loud
 if [ "$V" != "0" ]; then
     set -x
@@ -72,7 +73,7 @@ function cilium_install {
             --privileged=true \
             --network=host \
             "quay.io/${IMG_OWNER}/cilium-ci:${IMG_TAG}" \
-            cilium-agent "${CFG_COMMON[@]}" "$@"
+            cilium-agent "${CFG_COMMON[@]}" "$@" ${CILIUM_EXTRA_ARGS}
     result=1
     for i in $(seq 1 10); do
         if ${CILIUM_EXEC} cilium-dbg status --brief; then


### PR DESCRIPTION
Similar to recent changes to ci-{runtime,gingko,ext-workloads}, this allows the CILIUM_RUNTIME_EXTRA_ARGS to be propagated when installing Cilium for l4lb testing.