### PR TITLE
Remove note about TLSRoute being required by Cilium

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/installation.rst
+++ b/Documentation/network/servicemesh/gateway-api/installation.rst
@@ -16,17 +16,13 @@ Prerequisites
     - `HTTPRoute <https://gateway-api.sigs.k8s.io/api-types/httproute/>`_
     - `GRPCRoute <https://gateway-api.sigs.k8s.io/api-types/grpcroute/>`_
     - `ReferenceGrant <https://gateway-api.sigs.k8s.io/api-types/referencegrant/>`_
+
+  If you wish to use the TLSRoute functionality, you'll also need to install the TLSRoute resource.
+  If this CRD is not installed, then Cilium will disable TLSRoute support.
+
     - `TLSRoute (experimental) <https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1alpha2.TLSRoute/>`_
 
-    .. admonition:: warning
-        :class: attention
-
-        An issue in Gateway API requires Cilium having the experimental CRDs to
-        be installed in order to use Gateway API. The issue is being tracked
-        `here <https://github.com/kubernetes-sigs/gateway-api/issues/3080>`__.
-
-        To install the experimental CRDs, please refer to
-        the `Gateway API documentation <https://gateway-api.sigs.k8s.io/guides/#install-experimental-channel>`__.
+  You can install the required CRDs like this:
 
     .. code-block:: shell-session
 
@@ -35,6 +31,10 @@ Prerequisites
         $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
         $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
         $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+
+  And add TLSRoute with this snippet.
+    .. code-block:: shell-session
+
         $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
 
 * By default, the Gateway API controller creates a service of LoadBalancer type,


### PR DESCRIPTION
The requirement for TLSRoute to be installed when
enabling Gateway API functions was removed in
PR #34212, so this caveat can now be removed.
