### PR TITLE
.github: add missing export in variable

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -262,7 +262,7 @@ jobs:
         env:
           CONTAINER_IMAGE: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${{ steps.docker_build_release_builder.outputs.digest }}
         run: |
-          VOLUME=$PWD/api/v1
+          export VOLUME=$PWD/api/v1
           make -C ../cilium-base-branch/api/v1
 
       - name: Commit changes by amending previous commit


### PR DESCRIPTION
The VOLUME environment variable is required so that it's available to child processes.

Fixes: 49efc885b93e (".github: run scripts from trusted source code")