### PR TITLE
hive/metrics: Adds hive degraded status labeled by modules

### DIFF
--- a/pkg/hive/health/metrics.go
+++ b/pkg/hive/health/metrics.go
@@ -18,7 +18,8 @@ import (
 )
 
 type Metrics struct {
-	HealthStatusGauge metric.Vec[metric.Gauge]
+	HealthStatusGauge         metric.Vec[metric.Gauge]
+	DegradedHealthStatusGauge metric.DeletableVec[metric.Gauge]
 }
 
 func newMetrics() *Metrics {
@@ -30,10 +31,18 @@ func newMetrics() *Metrics {
 			Name:       "status",
 			Help:       "Counts of health status levels of Hive components",
 		}, []string{"status"}),
+
+		DegradedHealthStatusGauge: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: "cilium",
+			Subsystem: "hive",
+			Name:      "degraded_status",
+			Help:      "Counts degraded health status levels of Hive components labeled by modules",
+			Disabled:  true,
+		}, []string{"module"}),
 	}
 }
 
-type publishFunc func(map[types.Level]uint64)
+type publishFunc func(map[types.Level]uint64, map[string]uint64)
 
 type metricPublisherParams struct {
 	cell.In
@@ -44,12 +53,23 @@ type metricPublisherParams struct {
 	Metrics  *Metrics
 }
 
-// metricPublisher periodically publishes the hive module health metric (hive_health_status_levels).
+// metricPublisher periodically publishes the hive module health metric
+// * cilium_hive_status
+// * cilium_hive_degraded_status
 func metricPublisher(p metricPublisherParams) {
 	// Performs the actual writing to the metric. Extracted to make testing easy.
-	publish := func(stats map[types.Level]uint64) {
+	publish := func(stats map[types.Level]uint64, degradedModuleCount map[string]uint64) {
 		for l, v := range stats {
 			p.Metrics.HealthStatusGauge.WithLabelValues(strings.ToLower(string(l))).Set(float64(v))
+		}
+		for k, v := range degradedModuleCount {
+			// If the module is healthy attempt to remove any associated metrics with that module
+			if v == 0 {
+				p.Metrics.DegradedHealthStatusGauge.DeleteLabelValues(k)
+				continue
+			}
+
+			p.Metrics.DegradedHealthStatusGauge.WithLabelValues(k).Set(float64(v))
 		}
 	}
 
@@ -68,13 +88,34 @@ func publishJob(ctx context.Context, p metricPublisherParams, publish publishFun
 	limiter := rate.NewLimiter(15*time.Second, 3)
 	defer limiter.Stop() // Avoids leaking a goroutine.
 
+	idToStatus := make(map[string]uint64)
 	it, watch := p.Table.AllWatch(p.DB.ReadTxn())
 	for {
 		stats := make(map[types.Level]uint64)
+		// Reset health ID status counts
+		for k := range idToStatus {
+			idToStatus[k] = 0
+		}
+
 		for obj := range it {
 			stats[obj.Level]++
+
+			_, ok := idToStatus[obj.ID.Module.String()]
+			if obj.Level == types.LevelDegraded {
+				idToStatus[obj.ID.Module.String()]++
+			} else if !ok {
+				idToStatus[obj.ID.Module.String()] = 0
+			}
 		}
-		publish(stats)
+
+		publish(stats, idToStatus)
+
+		// Removed old IDs
+		for k, v := range idToStatus {
+			if v == 0 {
+				delete(idToStatus, k)
+			}
+		}
 
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
Adds `cilium_hive_degraded_status` metric to count degraded health status levels of Hive components labeled by modules. It improves the monitoring effectiveness by exposing the affected modules instead of the general count.

Fixes: https://github.com/cilium/cilium/issues/34823

```release-note
Adds `cilium_hive_degraded_status` metric to count degraded health status levels of Hive components labeled by modules. ```
