### PR TITLE
.github: bump timeout for runtime tests

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -345,7 +345,7 @@ jobs:
 
       - name: Runtime tests
         if: ${{ matrix.focus == 'agent' || matrix.focus == 'datapath' }}
-        timeout-minutes: 20
+        timeout-minutes: 30
         shell: bash
         run: |
           cat > test/cilium-ssh-config.txt << EOF


### PR DESCRIPTION
The tests are timing out recently, this commit bumps it for more 10 minutes.