### PR TITLE
bgpv1: Cleanup BGP reconcilers setup

### DIFF
--- a/pkg/bgpv1/manager/manager.go
+++ b/pkg/bgpv1/manager/manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -54,6 +55,7 @@ type bgpRouterManagerParams struct {
 	cell.In
 	Logger           logrus.FieldLogger
 	JobGroup         job.Group
+	DaemonConfig     *option.DaemonConfig
 	ConfigMode       *mode.ConfigMode
 	Reconcilers      []reconciler.ConfigReconciler   `group:"bgp-config-reconciler"`
 	ReconcilersV2    []reconcilerv2.ConfigReconciler `group:"bgp-config-reconciler-v2"`
@@ -150,6 +152,10 @@ type BGPRouterManager struct {
 //
 // See BGPRouterManager for details.
 func NewBGPRouterManager(params bgpRouterManagerParams) agent.BGPRouterManager {
+	if !params.DaemonConfig.BGPControlPlaneEnabled() {
+		return &BGPRouterManager{}
+	}
+
 	activeReconcilers := reconciler.GetActiveReconcilers(params.Reconcilers)
 	activeReconcilersV2 := reconcilerv2.GetActiveReconcilers(params.Logger, params.ReconcilersV2)
 

--- a/pkg/bgpv1/manager/reconciler/reconciler.go
+++ b/pkg/bgpv1/manager/reconciler/reconciler.go
@@ -62,15 +62,15 @@ func GetActiveReconcilers(reconcilers []ConfigReconciler) []ConfigReconciler {
 		}
 		if existing, exists := recMap[r.Name()]; exists {
 			if existing.Priority() == r.Priority() {
-				log.Warnf("Skipping duplicate reconciler %s with the same priority (%d)", existing.Name(), existing.Priority())
+				log.Warnf("Skipping duplicate BGP v1 reconciler %s with the same priority (%d)", existing.Name(), existing.Priority())
 				continue
 			}
 			if existing.Priority() < r.Priority() {
-				log.Debugf("Skipping reconciler %s (priority %d) as it has lower priority than the existing one (%d)",
+				log.Debugf("Skipping BGP v1 reconciler %s (priority %d) as it has lower priority than the existing one (%d)",
 					r.Name(), r.Priority(), existing.Priority())
 				continue
 			}
-			log.Debugf("Overriding existing reconciler %s (priority %d) with higher priority one (%d)",
+			log.Debugf("Overriding existing BGP v1 reconciler %s (priority %d) with higher priority one (%d)",
 				existing.Name(), existing.Priority(), r.Priority())
 		}
 		recMap[r.Name()] = r
@@ -78,7 +78,7 @@ func GetActiveReconcilers(reconcilers []ConfigReconciler) []ConfigReconciler {
 
 	var activeReconcilers []ConfigReconciler
 	for _, r := range recMap {
-		log.Debugf("Adding BGP reconciler: %v (priority %d)", r.Name(), r.Priority())
+		log.Debugf("Adding BGP v1 reconciler: %v (priority %d)", r.Name(), r.Priority())
 		activeReconcilers = append(activeReconcilers, r)
 	}
 	sort.Slice(activeReconcilers, func(i, j int) bool {

--- a/pkg/bgpv1/manager/reconcilerv2/crd_status.go
+++ b/pkg/bgpv1/manager/reconcilerv2/crd_status.go
@@ -27,6 +27,7 @@ import (
 	k8s_client "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -49,10 +50,11 @@ type StatusReconciler struct {
 type StatusReconcilerIn struct {
 	cell.In
 
-	Job       job.Group
-	ClientSet k8s_client.Clientset
-	Logger    logrus.FieldLogger
-	LocalNode daemon_k8s.LocalCiliumNodeResource
+	DaemonConfig *option.DaemonConfig
+	Job          job.Group
+	ClientSet    k8s_client.Clientset
+	Logger       logrus.FieldLogger
+	LocalNode    daemon_k8s.LocalCiliumNodeResource
 }
 
 type StatusReconcilerOut struct {
@@ -62,6 +64,9 @@ type StatusReconcilerOut struct {
 }
 
 func NewStatusReconciler(in StatusReconcilerIn) StatusReconcilerOut {
+	if !in.DaemonConfig.BGPControlPlaneEnabled() {
+		return StatusReconcilerOut{}
+	}
 	// CRD Status reconciler is disabled if there is no kubernetes support
 	if !in.ClientSet.IsEnabled() {
 		return StatusReconcilerOut{}

--- a/pkg/bgpv1/manager/reconcilerv2/reconcilers.go
+++ b/pkg/bgpv1/manager/reconcilerv2/reconcilers.go
@@ -37,7 +37,7 @@ type ConfigReconciler interface {
 	Reconcile(ctx context.Context, params ReconcileParams) error
 }
 
-var ConfigReconcilers = cell.ProvidePrivate(
+var ConfigReconcilers = cell.Provide(
 	NewNeighborReconciler,
 	NewPodCIDRReconciler,
 	NewPodIPPoolReconciler,
@@ -53,15 +53,15 @@ func GetActiveReconcilers(log logrus.FieldLogger, reconcilers []ConfigReconciler
 		}
 		if existing, exists := recMap[r.Name()]; exists {
 			if existing.Priority() == r.Priority() {
-				log.Warnf("Skipping duplicate reconciler %s with the same priority (%d)", existing.Name(), existing.Priority())
+				log.Warnf("Skipping duplicate BGP v2 reconciler %s with the same priority (%d)", existing.Name(), existing.Priority())
 				continue
 			}
 			if existing.Priority() < r.Priority() {
-				log.Debugf("Skipping reconciler %s (priority %d) as it has lower priority than the existing one (%d)",
+				log.Debugf("Skipping BGP v2 reconciler %s (priority %d) as it has lower priority than the existing one (%d)",
 					r.Name(), r.Priority(), existing.Priority())
 				continue
 			}
-			log.Debugf("Overriding existing reconciler %s (priority %d) with higher priority one (%d)",
+			log.Debugf("Overriding existing BGP v2 reconciler %s (priority %d) with higher priority one (%d)",
 				existing.Name(), existing.Priority(), r.Priority())
 		}
 		recMap[r.Name()] = r
@@ -69,7 +69,7 @@ func GetActiveReconcilers(log logrus.FieldLogger, reconcilers []ConfigReconciler
 
 	var activeReconcilers []ConfigReconciler
 	for _, r := range recMap {
-		log.Debugf("Adding BGP reconciler: %v (priority %d)", r.Name(), r.Priority())
+		log.Debugf("Adding BGP v2 reconciler: %v (priority %d)", r.Name(), r.Priority())
 		activeReconcilers = append(activeReconcilers, r)
 	}
 	sort.Slice(activeReconcilers, func(i, j int) bool {


### PR DESCRIPTION
Ensure BGP reconcilers are not being set up and no BGP-related jobs start when BGP Control Plane is disabled.
Also, make distinction between v1 and v2 reconcilers in logs during the setup.

```release-note
bgpv1: Cleanup BGP reconcilers setup to ensure that no BGP CP jobs are started when BGP CP is disabled
```
