### PR TITLE
job: Prepare job names for hive bump

### DIFF
--- a/operator/pkg/lbipam/cell.go
+++ b/operator/pkg/lbipam/cell.go
@@ -91,7 +91,7 @@ func newLBIPAMCell(params lbipamCellParams) *LBIPAM {
 	})
 
 	lbIPAM.jobGroup.Add(
-		job.OneShot("lbipam main", func(ctx context.Context, health cell.Health) error {
+		job.OneShot("lbipam-main", func(ctx context.Context, health cell.Health) error {
 			lbIPAM.Run(ctx, health)
 			return nil
 		}),

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -116,7 +116,7 @@ func (ipam *LBIPAM) restart() {
 
 	// Re-start the main goroutine
 	ipam.jobGroup.Add(
-		job.OneShot("lbipam main", func(ctx context.Context, health cell.Health) error {
+		job.OneShot("lbipam-main", func(ctx context.Context, health cell.Health) error {
 			ipam.Run(ctx, health)
 			return nil
 		}),

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -129,7 +129,7 @@ func registerAuthManager(params authManagerParams) (*AuthManager, error) {
 func registerReAuthenticationJob(jobGroup job.Group, mgr *AuthManager, authHandlers []authHandler) {
 	for _, ah := range authHandlers {
 		if ah != nil && ah.subscribeToRotatedIdentities() != nil {
-			jobGroup.Add(job.Observer("auth re-authentication", mgr.handleCertificateRotationEvent, stream.FromChannel(ah.subscribeToRotatedIdentities())))
+			jobGroup.Add(job.Observer("auth-re-authentication", mgr.handleCertificateRotationEvent, stream.FromChannel(ah.subscribeToRotatedIdentities())))
 		}
 	}
 }
@@ -143,7 +143,7 @@ func registerSignalAuthenticationJob(jobGroup job.Group, mgr *AuthManager, sm si
 		return fmt.Errorf("failed to set up signal channel for datapath authentication required events: %w", err)
 	}
 
-	jobGroup.Add(job.Observer("auth request-authentication", mgr.handleAuthRequest, stream.FromChannel(signalChannel)))
+	jobGroup.Add(job.Observer("auth-request-authentication", mgr.handleAuthRequest, stream.FromChannel(signalChannel)))
 
 	return nil
 }
@@ -162,8 +162,8 @@ func registerGCJobs(jobGroup job.Group, lifecycle cell.Lifecycle, mapGC *authMap
 		},
 	})
 
-	jobGroup.Add(job.Observer("auth gc-identity-events", mapGC.handleIdentityChange, identityChanges))
-	jobGroup.Add(job.Timer("auth gc-cleanup", mapGC.cleanup, cfg.MeshAuthGCInterval))
+	jobGroup.Add(job.Observer("auth-gc-identity-events", mapGC.handleIdentityChange, identityChanges))
+	jobGroup.Add(job.Timer("auth-gc-cleanup", mapGC.cleanup, cfg.MeshAuthGCInterval))
 }
 
 type authHandlerResult struct {

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -125,7 +125,7 @@ func newOrchestrator(params orchestratorParams) *orchestrator {
 	})
 
 	group := params.JobRegistry.NewGroup(params.Health)
-	group.Add(job.OneShot("Reinitialize", o.reconciler, job.WithShutdown()))
+	group.Add(job.OneShot("reinitialize", o.reconciler, job.WithShutdown()))
 	params.Lifecycle.Append(group)
 
 	return o

--- a/pkg/k8s/statedb.go
+++ b/pkg/k8s/statedb.go
@@ -98,8 +98,7 @@ type ReflectorConfig[Obj any] struct {
 
 // JobName returns the name of the background reflector job.
 func (cfg ReflectorConfig[Obj]) JobName() string {
-	var obj Obj
-	return fmt.Sprintf("k8s-reflector[%T]/%s", obj, cfg.Name)
+	return fmt.Sprintf("k8s-reflector-%s-%s", cfg.Table.Name(), cfg.Name)
 }
 
 // TransformFunc is an optional function to give to the Kubernetes reflector

--- a/pkg/k8s/statedb_test.go
+++ b/pkg/k8s/statedb_test.go
@@ -332,12 +332,18 @@ func testStateDBReflector(t *testing.T, p reflectorTestParams) {
 }
 
 func TestStateDBReflector_jobName(t *testing.T) {
-	cfg := k8s.ReflectorConfig[corev1.Node]{
-		Name: "test",
+	tbl, _ := statedb.NewTable(
+		"node",
+		testNameIndex,
+	)
+	cfg := k8s.ReflectorConfig[*testObject]{
+		Name:  "test",
+		Table: tbl,
 	}
+
 	assert.Equal(
 		t,
-		"k8s-reflector[v1.Node]/test",
+		"k8s-reflector-node-test",
 		cfg.JobName(),
 	)
 }

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -122,12 +122,12 @@ func NewL2Announcer(params l2AnnouncerParams) *L2Announcer {
 	if !params.DaemonConfig.EnableL2Announcements {
 		// If the L2 announcement feature is disabled, garbage collect any leases from previous runs when the feature
 		// might have been active. Just once, not on a timer.
-		announcer.params.JobGroup.Add(job.OneShot("l2-announcer lease-gc", announcer.leaseGC))
+		announcer.params.JobGroup.Add(job.OneShot("l2-announcer-lease-gc", announcer.leaseGC))
 		return announcer
 	}
 
-	announcer.params.JobGroup.Add(job.OneShot("l2-announcer run", announcer.run))
-	announcer.params.JobGroup.Add(job.Timer("l2-announcer lease-gc", func(ctx context.Context) error {
+	announcer.params.JobGroup.Add(job.OneShot("l2-announcer-run", announcer.run))
+	announcer.params.JobGroup.Add(job.Timer("l2-announcer-lease-gc", func(ctx context.Context) error {
 		return announcer.leaseGC(ctx, nil)
 	}, time.Minute))
 
@@ -740,7 +740,7 @@ func (l2a *L2Announcer) addSelectedService(svc *slim_corev1.Service, byPolicies 
 
 	// kick off leader election job
 	l2a.scopedGroup.Add(job.OneShot(
-		fmt.Sprintf("leader-election/%s/%s", svc.Namespace, svc.Name),
+		fmt.Sprintf("leader-election-%s-%s", svc.Namespace, svc.Name),
 		ss.serviceLeaderElection),
 	)
 }

--- a/pkg/service/reconciler.go
+++ b/pkg/service/reconciler.go
@@ -24,7 +24,7 @@ import (
 func registerServiceReconciler(p serviceReconcilerParams) {
 	sr := serviceReconciler(p)
 	g := p.Jobs.NewGroup(p.Health)
-	g.Add(job.OneShot("ServiceReconciler", sr.reconcileLoop))
+	g.Add(job.OneShot("service-reconciler", sr.reconcileLoop))
 	p.Lifecycle.Append(g)
 }
 


### PR DESCRIPTION
The new version of hive have a new format for the job names to ensure the names are compliant with the prometheus metrics. This PR ensures that all jobs are compliant with the new naming convention.


Manually checked the non-static ones
* https://github.com/cilium/cilium/blob/68e145cfd361201300878217e67e2302b3aadfa3/pkg/bpf/metrics.go#L47
* https://github.com/cilium/cilium/blob/4313a4e76890e1938f58a385a7fa3bc8a7ed9c58/pkg/l2announcer/l2announcer.go#L743
* https://github.com/cilium/cilium/blob/2bf8ae746efe113d36811ae36c14e96e527592cb/pkg/envoy/cell.go#L348
* https://github.com/cilium/cilium/blob/df79ac9f0fd493cd14ce6e65e89df52df8c6459d/pkg/datapath/linux/bandwidth/cell.go#L56

Script use to catch the static ones:
<details>


```
import glob
import re


def is_valid_name(name):
  pattern = r"^[a-z][a-z0-9_\-]{0,100}$"
  return bool(re.match(pattern, name))


def extract_names_from_file(filename):
  names = []
  with open(filename, 'r') as file:
    for line_number, line in enumerate(file, start=1):
      match = re.search(r'job\.(?:OneShot|Observer|Timer)\("([^"]+)', line)
      if match:
        name = match.group(1)
        names.append(name)
  return names

count=0
names =[]
for filename in glob.iglob("./" + '**/*.go', recursive=True):
  names = names + extract_names_from_file(filename)

print(names)
for name in names:
  if not is_valid_name(name):
    print(name)
```
</details>

Script used to catch non-static:
<details>

```
grep -rnP 'statedb\.Derive\(' .
grep -rnP 'job\.OneShot\(' .
grep -rnP 'job\.Timer\(' .
grep -rnP 'job\.Observer\(' .
```

</details>



See https://github.com/cilium/hive/pull/10.