### PR TITLE
.github: install golang action after checkout

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -26,18 +26,18 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "github-actions@users.noreply.github.com"
 
-      - name: Install Go
-        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
-        with:
-          # renovate: datasource=golang-version depName=go
-          go-version: 1.23.1
-
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          # renovate: datasource=golang-version depName=go
+          go-version: 1.23.1
 
       - name: Check if build works for every commit
         run: |


### PR DESCRIPTION
The Golang GitHub Action relies on a cache keyed by the `go.sum` file. If the repository is not checked out, the action can't access the cache. To resolve this, we will move the repository checkout step before the Golang setup.