### PR TITLE
.github: prevent failure when deleting GitHub Actions cache

### DIFF
--- a/.github/workflows/ci-images-cache-cleaner.yaml
+++ b/.github/workflows/ci-images-cache-cleaner.yaml
@@ -69,14 +69,15 @@ jobs:
           mkdir -p /tmp/.cache/${{ matrix.name }}
 
       - name: Clean ${{ matrix.name }} Golang cache from GitHub
+        shell: bash
         run: |
           gh extension install actions/gh-actions-cache
 
           REPO=${{ github.repository }}
           set +e
-          gh actions-cache delete ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ matrix.name }}-${{ github.sha }} -R $REPO -B main --confirm
-          gh actions-cache delete ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ matrix.name }}- -R $REPO -B main --confirm
-          gh actions-cache delete ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}- -R $REPO -B main --confirm
-          gh actions-cache delete ${{ runner.os }}-go- -R $REPO -B main --confirm
+          gh actions-cache delete ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ matrix.name }}-${{ github.sha }} -R $REPO -B main --confirm || true
+          gh actions-cache delete ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ matrix.name }}- -R $REPO -B main --confirm || true
+          gh actions-cache delete ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}- -R $REPO -B main --confirm || true
+          gh actions-cache delete ${{ runner.os }}-go- -R $REPO -B main --confirm || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added `|| true` to `gh actions-cache delete` commands to ensure the workflow continues even if cache deletion fails.

Fixes: 8cdb2dc10a22 (".github/workflows: fix ci image cache cleaner")

I don't know why it [failed](https://github.com/cilium/cilium/actions/runs/10827425618/job/30040553624) as this is an example provided in the documentation :confused:  https://github.com/actions/cache/blob/main/tips-and-workarounds.md#force-deletion-of-caches-overriding-default-cache-eviction-policy