### PR TITLE
.github: specify cache-dependency-path in lint-workflows

### DIFF
--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -38,6 +38,7 @@ jobs:
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
+          cache-dependency-path: "src/github.com/cilium/cilium/*.sum"
           # renovate: datasource=golang-version depName=go
           go-version: 1.23.1
 


### PR DESCRIPTION
The Golang GitHub Action relies on a cache keyed by the `go.sum` file. If the repository is not checked out in the default directory, the action can't access the cache.
To resolve this, we will set the right directory with the 'cache-dependency-path' flag to point to the directory that contains the checked out source code on the previous step.