### PR TITLE
Improve speed on lint commits GH workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Cilium",
-  "image": "quay.io/cilium/cilium-builder:7b694b39bba39384642c6a174fe01761d022acb8@sha256:f5deee48758307a379db2d0eace398b51869a30c940c56d161930609ddc7b385",
+  "image": "quay.io/cilium/cilium-builder:9c24e4fd3756d758a036b9e459e166b57315f3d4@sha256:dadce102ae3c8988ec2c242715e85ca66176cc6fcbb9cb4a15e323488c1a6c90",
   "workspaceFolder": "/go/src/github.com/cilium/cilium",
   "workspaceMount": "source=${localWorkspaceFolder},target=/go/src/github.com/cilium/cilium,type=bind",
   "features": {

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -36,22 +36,58 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
+          cache: false
           # renovate: datasource=golang-version depName=go
           go-version: 1.23.1
 
+      # Load Golang cache build from GitHub
+      - name: Load Golang cache build from GitHub
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        id: go-cache
+        with:
+          path: /tmp/.cache/go
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      # Load CCache build from GitHub
+      - name: Load ccache cache build from GitHub
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        id: ccache-cache
+        with:
+          path: /tmp/.cache/ccache
+          key: ${{ runner.os }}-ccache-${{ hashFiles('bpf/**') }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-
+
+      - name: Create cache directories if they don't exist
+        if: ${{ steps.go-cache.outputs.cache-hit != 'true' || steps.ccache-cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.cache/go/.cache/go-build
+          mkdir -p /tmp/.cache/go/pkg
+          mkdir -p /tmp/.cache/ccache/.ccache
+
       - name: Check if build works for every commit
+        env:
+          CLANG: "ccache clang"
+          BUILDER_GOCACHE_DIR: "/tmp/.cache/go/.cache/go-build"
+          BUILDER_GOMODCACHE_DIR: "/tmp/.cache/go/pkg"
+          BUILDER_CCACHE_DIR: "/tmp/.cache/ccache/.ccache"
         run: |
           set -eu -o pipefail
           COMMITS=$(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
           for commit in $COMMITS ; do
             git checkout $commit || exit 1
-            contrib/scripts/builder.sh make build -j $(nproc) || exit 1
+            contrib/scripts/builder.sh make CLANG="${CLANG}" build -j $(nproc) || exit 1
           done
 
       - name: Check bpf code changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: bpf-tree
         with:
+          # If these filters are modified, also modify the step below where we
+          # do a git diff
           filters: |
             src:
               - 'bpf/**'
@@ -59,18 +95,38 @@ jobs:
       # Runs only if code under bpf/ is changed.
       - name: Check if datapath build works for every commit
         if: steps.bpf-tree.outputs.src == 'true'
+        env:
+          CLANG: "ccache clang"
+          BUILDER_GOCACHE_DIR: "/tmp/.cache/go/.cache/go-build"
+          BUILDER_GOMODCACHE_DIR: "/tmp/.cache/go/pkg"
+          BUILDER_CCACHE_DIR: "/tmp/.cache/ccache/.ccache"
         run: |
           set -eu -o pipefail
           COMMITS=$(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
           for commit in $COMMITS ; do
             git checkout $commit || exit 1
-            contrib/scripts/builder.sh make -C bpf build_all -j $(nproc) || exit 1
+            # Do not run make if there aren't any files modified in these
+            # directories from the previous commit to the current commit.
+            # If these filters are modified, also modify the step above where we
+            # run dorny/paths-filter.
+            if ! git diff --quiet HEAD^ bpf/ ; then
+              contrib/scripts/builder.sh make CLANG="${CLANG}" -C bpf build_all -j $(nproc) || exit 1
+            fi
           done
+
+      - name: Reset cache ownership to GitHub runners user
+        if: ${{ steps.go-cache.outputs.cache-hit != 'true' || steps.ccache-cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          sudo du -sh /tmp/.cache/
+          sudo chown $USER:$USER -R /tmp/.cache
 
       - name: Check test code changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: test-tree
         with:
+          # If these filters are modified, also modify the step below where we
+          # do a git diff
           filters: |
             src:
               - 'pkg/**'
@@ -107,7 +163,13 @@ jobs:
           COMMITS=$(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
           for commit in $COMMITS ; do
             git checkout $commit || exit 1
-            (make -C test build -j $(nproc) && make -C test build-darwin -j $(nproc)) || exit 1
+            # Do not run make if there aren't any files modified in these
+            # directories from the previous commit to the current commit.
+            # If these filters are modified, also modify the step above where we
+            # run dorny/paths-filter.
+            if ! git diff --quiet HEAD^ pkg/ test/ ; then
+              (make -C test build -j $(nproc) && make -C test build-darwin -j $(nproc)) || exit 1
+            fi
           done
 
       - name: Failed commit during the build

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -216,7 +216,7 @@ ifneq ($(BUILD_PERMUTATIONS),)
 define PERMUTATION_template =
 $(1)::
 	@$$(ECHO_CC) " [$(subst :,=1$(space),$(2))]"
-	$$(QUIET) $${CLANG} $(subst :,=1$(space),$(2)) $${CLANG_FLAGS} -c $(patsubst %.o,%.c,$(1)) -o /dev/null
+	$$(QUIET) $${CLANG} $(subst :,=1$(space),$(2)) $${CLANG_FLAGS} -c $(patsubst %.o,%.c,$(1)) -o $(1)
 endef
 endif
 

--- a/contrib/scripts/builder.sh
+++ b/contrib/scripts/builder.sh
@@ -12,8 +12,29 @@ if [ -n "${RUN_AS_NONROOT:-}" ]; then
     USER_OPTION="--user $(id -u):$(id -g)"
 fi
 
+MOUNT_GOCACHE_DIR=""
+
+if [ -n "${BUILDER_GOCACHE_DIR:-}" ]; then
+    MOUNT_GOCACHE_DIR="-v ${BUILDER_GOCACHE_DIR}:/root/.cache/go-build"
+fi
+
+MOUNT_GOMODCACHE_DIR=""
+
+if [ -n "${BUILDER_GOMODCACHE_DIR:-}" ]; then
+    MOUNT_GOMODCACHE_DIR="-v ${BUILDER_GOMODCACHE_DIR}:/go/pkg/mod"
+fi
+
+MOUNT_CCACHE_DIR=""
+
+if [ -n "${BUILDER_CCACHE_DIR:-}" ]; then
+    MOUNT_CCACHE_DIR="-v ${BUILDER_CCACHE_DIR}:/root/.ccache"
+fi
+
 docker run --rm \
 	$USER_OPTION \
+	$MOUNT_GOCACHE_DIR \
+	$MOUNT_GOMODCACHE_DIR \
+	$MOUNT_CCACHE_DIR \
 	-v "$PWD":/go/src/github.com/cilium/cilium \
 	-w /go/src/github.com/cilium/cilium \
 	${DOCKER_ARGS:+"$DOCKER_ARGS"} \

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -43,7 +43,8 @@ RUN \
       gcc \
       git \
       libc6-dev \
-      make && \
+      make \
+      ccache && \
     apt-get purge --auto-remove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:7b694b39bba39384642c6a174fe01761d022acb8@sha256:f5deee48758307a379db2d0eace398b51869a30c940c56d161930609ddc7b385
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:9c24e4fd3756d758a036b9e459e166b57315f3d4@sha256:dadce102ae3c8988ec2c242715e85ca66176cc6fcbb9cb4a15e323488c1a6c90
 ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:85aff327b358b84ecea2e06e1aebc5f8ad2b0d2b@sha256:7666e657b917f1cc1001ec2aa11f3b65bc67010568f29f0bd183e6efffa761e1
 #
 # cilium-envoy from github.com/cilium/proxy

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -12,7 +12,7 @@
 # https://raw.githubusercontent.com/GoogleContainerTools/distroless/main/cosign.pub
 ARG BASE_IMAGE=gcr.io/distroless/static-debian11:nonroot@sha256:63ebe035fbdd056ed682e6a87b286d07d3f05f12cb46f26b2b44fc10fc4a59ed
 ARG GOLANG_IMAGE=docker.io/library/golang:1.23.1@sha256:4a3c2bcd243d3dbb7b15237eecb0792db3614900037998c2cd6a579c46888c1e
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:7b694b39bba39384642c6a174fe01761d022acb8@sha256:f5deee48758307a379db2d0eace398b51869a30c940c56d161930609ddc7b385
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:9c24e4fd3756d758a036b9e459e166b57315f3d4@sha256:dadce102ae3c8988ec2c242715e85ca66176cc6fcbb9cb4a15e323488c1a6c90
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -4,7 +4,7 @@
 ARG BASE_IMAGE=scratch
 ARG GOLANG_IMAGE=docker.io/library/golang:1.23.1@sha256:4a3c2bcd243d3dbb7b15237eecb0792db3614900037998c2cd6a579c46888c1e
 ARG ALPINE_IMAGE=docker.io/library/alpine:3.20.3@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:7b694b39bba39384642c6a174fe01761d022acb8@sha256:f5deee48758307a379db2d0eace398b51869a30c940c56d161930609ddc7b385
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:9c24e4fd3756d758a036b9e459e166b57315f3d4@sha256:dadce102ae3c8988ec2c242715e85ca66176cc6fcbb9cb4a15e323488c1a6c90
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with


### PR DESCRIPTION
Using cache to improve the build times of lint commit. As an example, a PR with 3-4 commits was taking:

| Setup                                      | time    |
|--------------------------------------------|---------|
| baseline / main                                       | ~37m39s |
| w/ this PR changes - partial cache hit                    | ~5m23s  |
| w/ this PR changes - cache hit                            | ~2m49s  |
