### PR TITLE
doc: warn not to run CLI conn. tests in production

### DIFF
--- a/Documentation/installation/cli-connectivity-test.rst
+++ b/Documentation/installation/cli-connectivity-test.rst
@@ -1,6 +1,8 @@
 Run the following command to validate that your cluster has proper network
 connectivity:
 
+.. include:: /operations/cli-conn-tests-warning.rst
+
 .. code-block:: shell-session
 
    $ cilium connectivity test

--- a/Documentation/operations/cli-conn-tests-warning.rst
+++ b/Documentation/operations/cli-conn-tests-warning.rst
@@ -1,0 +1,3 @@
+.. warning::
+
+   Do NOT run CLI connectivity tests on cluster running real workloads.

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -16,6 +16,7 @@ This upgrade guide is intended for Cilium running on Kubernetes. If you have
 questions, feel free to ping us on `Cilium Slack`_.
 
 .. include:: upgrade-warning.rst
+.. include:: cli-conn-tests-warning.rst
 
 .. _pre_flight:
 


### PR DESCRIPTION
The Cilium installation guide suggests to use CLI connectivity tests as a means to validate an (empty) installation.

Some users might incorrectly assume it's safe and the correct procedure to run CLI connectivity tests to validate an upgrade when - at least today - this is not the case.

Add a warning both in the installation and upgrade guide accordingly.
