### PR TITLE
fix dnsproxy data race

### DIFF
--- a/pkg/fqdn/dnsproxy/shared_client_test.go
+++ b/pkg/fqdn/dnsproxy/shared_client_test.go
@@ -1,0 +1,499 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dnsproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cilium/dns"
+	"golang.org/x/net/nettest"
+	"golang.org/x/sync/errgroup"
+)
+
+var (
+	clients = NewSharedClients()
+)
+
+func TestSharedClientSync(t *testing.T) {
+	dns.HandleFunc("miek.nl.", HelloServer)
+	defer dns.HandleRemove("miek.nl.")
+
+	s, addrstr, err := runUDPServer(":0")
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+
+	m := new(dns.Msg)
+	m.SetQuestion("miek.nl.", dns.TypeSOA)
+
+	c, closer := clients.GetSharedClient("client-key", new(dns.Client), addrstr)
+	defer closer()
+	r, _, err := c.ExchangeShared(m)
+	if err != nil {
+		t.Fatalf("failed to exchange: %v", err)
+	}
+	if r == nil {
+		t.Fatal("response is nil")
+	}
+	if r.Rcode != dns.RcodeSuccess {
+		t.Errorf("failed to get an valid answer\n%v", r)
+	}
+	// And now another ExchangeAsync on the same shared client
+	r, _, err = c.ExchangeShared(m)
+	if err != nil {
+		t.Errorf("failed to exchange: %v", err)
+	}
+	if r == nil || r.Rcode != dns.RcodeSuccess {
+		t.Errorf("failed to get an valid answer\n%v", r)
+	}
+
+	// Now get the shared client again and make sure it is still the same client
+	c2, closer2 := clients.GetSharedClient("client-key", new(dns.Client), addrstr)
+	defer closer2()
+
+	if c2 != c {
+		t.Fatal("client not really shared")
+	}
+	m.Id = uint16(42)
+	r, _, err = c2.ExchangeShared(m)
+	if err != nil {
+		t.Errorf("failed to exchange: %v", err)
+	}
+	if r == nil || r.Rcode != dns.RcodeSuccess {
+		t.Errorf("failed to get an valid answer\n%v", r)
+	}
+}
+
+func TestSharedClientConcurrentSync(t *testing.T) {
+	dns.HandleFunc("miek.nl.", HelloServer)
+	defer dns.HandleRemove("miek.nl.")
+
+	s, addrstr, err := runUDPServer(":0")
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+
+	conf := &dns.Client{
+		Timeout: 2 * time.Second,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	eg, _ := errgroup.WithContext(ctx)
+	f1 := func(id uint16) error {
+		m := new(dns.Msg)
+		m.SetQuestion("miek.nl.", dns.TypeSOA)
+		m.Id = id
+
+		c, closer := clients.GetSharedClient("concurrent-client", conf, addrstr)
+		defer closer()
+		r, _, err := c.ExchangeShared(m)
+		if err != nil {
+			return fmt.Errorf("%v: failed to exchange: %w", id, err)
+		}
+		if r == nil {
+			return fmt.Errorf("%v: response is nil", id)
+		}
+		if r.Id != id {
+			return fmt.Errorf("incorrect id (%d != %d)", r.Id, id)
+		}
+		if r.Rcode != dns.RcodeSuccess {
+			return fmt.Errorf("%v: failed to get an valid answer\n%v", id, r)
+		}
+		return nil
+	}
+
+	// If we don't set a limit, it's possible that the 250 goroutines overwhelm the single read
+	// goroutine to the point that the OS receive buffer fills up and we drop packets.
+	eg.SetLimit(50)
+	for id := uint16(1); id <= 250; id++ {
+		eg.Go(func() error { return f1(id) })
+	}
+	err = eg.Wait()
+	if err != nil {
+		t.Errorf("failed: %v", err)
+	}
+}
+
+func TestSharedClientLocalAddress(t *testing.T) {
+	dns.HandleFunc("miek.nl.", HelloServerEchoAddrPort)
+	defer dns.HandleRemove("miek.nl.")
+
+	s, addrstr, err := runUDPServer(":0")
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+
+	m := new(dns.Msg)
+	m.SetQuestion("miek.nl.", dns.TypeSOA)
+
+	c, closer := clients.GetSharedClient("", new(dns.Client), addrstr)
+	defer closer()
+
+	c.Dialer = &net.Dialer{LocalAddr: &net.UDPAddr{IP: net.ParseIP("0.0.0.0")}}
+
+	r, _, err := c.ExchangeShared(m)
+	if err != nil {
+		t.Fatalf("failed to exchange: %v", err)
+	}
+	laddr := c.conn.LocalAddr()
+	if r == nil {
+		t.Fatalf("No response")
+	}
+	if r.Rcode != dns.RcodeSuccess {
+		t.Errorf("failed to get an valid answer\n%v", r)
+	}
+	if len(r.Extra) != 1 {
+		t.Fatalf("failed to get additional answers\n%v", r)
+	}
+	txt := r.Extra[0].(*dns.TXT)
+	if txt == nil {
+		t.Errorf("invalid TXT response\n%v", txt)
+	}
+	if len(txt.Txt) != 1 || !strings.Contains(txt.Txt[0], laddr.String()) {
+		t.Errorf("invalid TXT response\n%v", txt.Txt)
+	}
+}
+
+func TestSharedClientSyncBadID(t *testing.T) {
+	dns.HandleFunc("miek.nl.", HelloServerBadID)
+	defer dns.HandleRemove("miek.nl.")
+
+	s, addrstr, err := runUDPServer(":0")
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+
+	m := new(dns.Msg)
+	m.SetQuestion("miek.nl.", dns.TypeSOA)
+
+	// Test with client.Exchange, the plain Exchange function is just a wrapper, so
+	// we don't need to test that separately.
+	conf := &dns.Client{
+		Timeout: 10 * time.Millisecond,
+	}
+
+	_, _, closer, err := clients.Exchange("", conf, m, addrstr)
+	defer closer()
+
+	if err == nil || !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Errorf("query did not time out")
+	}
+}
+
+func TestSharedClientSyncBadThenGoodID(t *testing.T) {
+	dns.HandleFunc("miek.nl.", HelloServerBadThenGoodID)
+	defer dns.HandleRemove("miek.nl.")
+
+	s, addrstr, err := runUDPServer(":0")
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+
+	m := new(dns.Msg)
+	m.SetQuestion("miek.nl.", dns.TypeSOA)
+
+	r, _, closer, err := clients.ExchangeContext(context.TODO(), "", new(dns.Client), m, addrstr)
+	defer closer()
+
+	if err != nil {
+		t.Fatalf("failed to exchange: %v", err)
+	}
+	if r == nil {
+		t.Fatalf("No response")
+	}
+	if r.Id != m.Id {
+		t.Errorf("failed to get response with expected Id")
+	}
+}
+
+func TestSharedClientSyncTCPBadID(t *testing.T) {
+	dns.HandleFunc("miek.nl.", HelloServerBadID)
+	defer dns.HandleRemove("miek.nl.")
+
+	s, addrstr, err := runTCPServer(":0")
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+
+	m := new(dns.Msg)
+	m.SetQuestion("miek.nl.", dns.TypeSOA)
+
+	c, closer := clients.GetSharedClient("", new(dns.Client), addrstr)
+	defer closer()
+
+	c.Net = "tcp"
+	c.Timeout = 10 * time.Millisecond
+
+	// ExchangeShared does not pass through bad IDs, they will be filtered out just like
+	// for UDP and the request should time out
+	if _, _, err := c.ExchangeShared(m); err == nil || !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Errorf("query did not time out")
+	}
+}
+
+func TestSharedClientEDNS0(t *testing.T) {
+	dns.HandleFunc("miek.nl.", HelloServer)
+	defer dns.HandleRemove("miek.nl.")
+
+	s, addrstr, err := runUDPServer(":0")
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+
+	m := new(dns.Msg)
+	m.SetQuestion("miek.nl.", dns.TypeDNSKEY)
+
+	m.SetEdns0(2048, true)
+
+	c, closer := clients.GetSharedClient("", new(dns.Client), addrstr)
+	defer closer()
+
+	r, _, err := c.ExchangeShared(m)
+	if err != nil {
+		t.Fatalf("failed to exchange: %v", err)
+	}
+
+	if r != nil && r.Rcode != dns.RcodeSuccess {
+		t.Errorf("failed to get a valid answer\n%v", r)
+	}
+}
+
+// Validates the transmission and parsing of local dns.EDNS0 options.
+func TestSharedClientEDNS0Local(t *testing.T) {
+	optStr1 := "1979:0x0707"
+	optStr2 := strconv.Itoa(dns.EDNS0LOCALSTART) + ":0x0601"
+
+	handler := func(w dns.ResponseWriter, req *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(req)
+
+		m.Extra = make([]dns.RR, 1, 2)
+		m.Extra[0] = &dns.TXT{Hdr: dns.RR_Header{Name: m.Question[0].Name, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: 0}, Txt: []string{"Hello local edns"}}
+
+		// If the local options are what we expect, then reflect them back.
+		ec1 := req.Extra[0].(*dns.OPT).Option[0].(*dns.EDNS0_LOCAL).String()
+		ec2 := req.Extra[0].(*dns.OPT).Option[1].(*dns.EDNS0_LOCAL).String()
+		if ec1 == optStr1 && ec2 == optStr2 {
+			m.Extra = append(m.Extra, req.Extra[0])
+		}
+
+		w.WriteMsg(m)
+	}
+
+	dns.HandleFunc("miek.nl.", handler)
+	defer dns.HandleRemove("miek.nl.")
+
+	s, addrstr, err := runUDPServer(":0")
+	if err != nil {
+		t.Fatalf("unable to run test server: %s", err)
+	}
+	defer s.Shutdown()
+
+	m := new(dns.Msg)
+	m.SetQuestion("miek.nl.", dns.TypeTXT)
+
+	// Add two local edns options to the query.
+	ec1 := &dns.EDNS0_LOCAL{Code: 1979, Data: []byte{7, 7}}
+	ec2 := &dns.EDNS0_LOCAL{Code: dns.EDNS0LOCALSTART, Data: []byte{6, 1}}
+	o := &dns.OPT{Hdr: dns.RR_Header{Name: ".", Rrtype: dns.TypeOPT}, Option: []dns.EDNS0{ec1, ec2}}
+	m.Extra = append(m.Extra, o)
+
+	c, closer := clients.GetSharedClient("", new(dns.Client), addrstr)
+	defer closer()
+
+	r, _, err := c.ExchangeShared(m)
+	if err != nil {
+		t.Fatalf("failed to exchange: %s", err)
+	}
+
+	if r == nil {
+		t.Fatal("response is nil")
+	}
+	if r.Rcode != dns.RcodeSuccess {
+		t.Fatal("failed to get a valid answer")
+	}
+
+	txt := r.Extra[0].(*dns.TXT).Txt[0]
+	if txt != "Hello local edns" {
+		t.Error("Unexpected result for miek.nl", txt, "!= Hello local edns")
+	}
+
+	// Validate the local options in the reply.
+	got := r.Extra[1].(*dns.OPT).Option[0].(*dns.EDNS0_LOCAL).String()
+	if got != optStr1 {
+		t.Errorf("failed to get local edns0 answer; got %s, expected %s", got, optStr1)
+	}
+
+	got = r.Extra[1].(*dns.OPT).Option[1].(*dns.EDNS0_LOCAL).String()
+	if got != optStr2 {
+		t.Errorf("failed to get local edns0 answer; got %s, expected %s", got, optStr2)
+	}
+}
+
+func TestSharedTimeout(t *testing.T) {
+	// Set up a dummy UDP server that won't respond
+	addr, err := net.ResolveUDPAddr("udp", ":0")
+	if err != nil {
+		t.Fatalf("unable to resolve local udp address: %v", err)
+	}
+	conn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer conn.Close()
+	addrstr := conn.LocalAddr().String()
+
+	// Message to send
+	m := new(dns.Msg)
+	m.SetQuestion("miek.nl.", dns.TypeTXT)
+
+	runTest := func(name string, exchange func(m *dns.Msg, addr string, timeout time.Duration) (*dns.Msg, time.Duration, error)) {
+		t.Run(name, func(t *testing.T) {
+			start := time.Now()
+
+			timeout := time.Millisecond
+			// Need some more slack for the goroutines to close
+			allowable := timeout + 50*time.Millisecond
+
+			_, _, err := exchange(m, addrstr, timeout)
+			if err == nil {
+				t.Errorf("no timeout using dns.Client.%s", name)
+			}
+
+			length := time.Since(start)
+			if length > allowable {
+				t.Errorf("exchange took longer %v than specified Timeout %v", length, allowable)
+			}
+		})
+	}
+	runTest("ExchangeShared", func(m *dns.Msg, addr string, timeout time.Duration) (*dns.Msg, time.Duration, error) {
+		c, closer := clients.GetSharedClient("", &dns.Client{Timeout: timeout}, addrstr)
+		defer closer()
+
+		return c.ExchangeShared(m)
+	})
+	runTest("ExchangeSharedContext", func(m *dns.Msg, addr string, timeout time.Duration) (*dns.Msg, time.Duration, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		c, closer := clients.GetSharedClient("", new(dns.Client), addrstr)
+		defer closer()
+
+		return c.ExchangeSharedContext(ctx, m)
+	})
+}
+
+func HelloServer(w dns.ResponseWriter, q *dns.Msg) {
+	r := &dns.Msg{}
+	r.SetReply(q)
+
+	r.Extra = make([]dns.RR, 1)
+	r.Extra[0] = &dns.TXT{Hdr: dns.RR_Header{Name: q.Question[0].Name, Rrtype: dns.TypeTXT, Class: dns.ClassINET}, Txt: []string{"Hello world"}}
+	w.WriteMsg(r)
+}
+
+func HelloServerBadID(w dns.ResponseWriter, q *dns.Msg) {
+	r := &dns.Msg{}
+	r.SetReply(q)
+	r.Id++
+
+	r.Extra = make([]dns.RR, 1)
+	r.Extra[0] = &dns.TXT{Hdr: dns.RR_Header{Name: q.Question[0].Name, Rrtype: dns.TypeTXT, Class: dns.ClassINET}, Txt: []string{"Hello world"}}
+	w.WriteMsg(r)
+}
+
+func HelloServerBadThenGoodID(w dns.ResponseWriter, q *dns.Msg) {
+	r := &dns.Msg{}
+	r.SetReply(q)
+	r.Id++
+
+	r.Extra = make([]dns.RR, 1)
+	r.Extra[0] = &dns.TXT{Hdr: dns.RR_Header{Name: q.Question[0].Name, Rrtype: dns.TypeTXT, Class: dns.ClassINET}, Txt: []string{"Hello world"}}
+	w.WriteMsg(r)
+
+	r.Id--
+	w.WriteMsg(r)
+}
+
+func HelloServerEchoAddrPort(w dns.ResponseWriter, q *dns.Msg) {
+	r := &dns.Msg{}
+	r.SetReply(q)
+
+	raddr := w.RemoteAddr().String()
+	r.Extra = make([]dns.RR, 1)
+	r.Extra[0] = &dns.TXT{Hdr: dns.RR_Header{Name: q.Question[0].Name, Rrtype: dns.TypeTXT, Class: dns.ClassINET}, Txt: []string{raddr}}
+	w.WriteMsg(r)
+}
+
+func runUDPServer(addr string) (*dns.Server, string, error) {
+	pc, err := nettest.NewLocalPacketListener("udp")
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to udp listen: %w", err)
+	}
+	laddr := pc.LocalAddr().String()
+
+	ready := make(chan error, 1)
+	s := &dns.Server{
+		PacketConn: pc,
+		NotifyStartedFunc: func() {
+			ready <- nil
+		},
+	}
+
+	go func() {
+		ready <- s.ActivateAndServe()
+		pc.Close()
+	}()
+
+	// Wait until the server is ready.
+	if err := <-ready; err != nil {
+		return nil, "", err
+	}
+	return s, laddr, nil
+}
+
+func runTCPServer(addr string) (*dns.Server, string, error) {
+	l, err := nettest.NewLocalListener("tcp")
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to tcp listen: %w", err)
+	}
+	laddr := l.Addr().String()
+
+	ready := make(chan error, 1)
+	s := &dns.Server{
+		Listener: l,
+		NotifyStartedFunc: func() {
+			ready <- nil
+		},
+	}
+
+	go func() {
+		ready <- s.ActivateAndServe()
+		l.Close()
+	}()
+
+	// Wait until the server is ready.
+	if err := <-ready; err != nil {
+		return nil, "", err
+	}
+	return s, laddr, nil
+}
+

--- a/vendor/golang.org/x/net/nettest/conntest.go
+++ b/vendor/golang.org/x/net/nettest/conntest.go
@@ -1,0 +1,467 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package nettest
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"math/rand"
+	"net"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// MakePipe creates a connection between two endpoints and returns the pair
+// as c1 and c2, such that anything written to c1 is read by c2 and vice-versa.
+// The stop function closes all resources, including c1, c2, and the underlying
+// net.Listener (if there is one), and should not be nil.
+type MakePipe func() (c1, c2 net.Conn, stop func(), err error)
+
+// TestConn tests that a net.Conn implementation properly satisfies the interface.
+// The tests should not produce any false positives, but may experience
+// false negatives. Thus, some issues may only be detected when the test is
+// run multiple times. For maximal effectiveness, run the tests under the
+// race detector.
+func TestConn(t *testing.T, mp MakePipe) {
+	t.Run("BasicIO", func(t *testing.T) { timeoutWrapper(t, mp, testBasicIO) })
+	t.Run("PingPong", func(t *testing.T) { timeoutWrapper(t, mp, testPingPong) })
+	t.Run("RacyRead", func(t *testing.T) { timeoutWrapper(t, mp, testRacyRead) })
+	t.Run("RacyWrite", func(t *testing.T) { timeoutWrapper(t, mp, testRacyWrite) })
+	t.Run("ReadTimeout", func(t *testing.T) { timeoutWrapper(t, mp, testReadTimeout) })
+	t.Run("WriteTimeout", func(t *testing.T) { timeoutWrapper(t, mp, testWriteTimeout) })
+	t.Run("PastTimeout", func(t *testing.T) { timeoutWrapper(t, mp, testPastTimeout) })
+	t.Run("PresentTimeout", func(t *testing.T) { timeoutWrapper(t, mp, testPresentTimeout) })
+	t.Run("FutureTimeout", func(t *testing.T) { timeoutWrapper(t, mp, testFutureTimeout) })
+	t.Run("CloseTimeout", func(t *testing.T) { timeoutWrapper(t, mp, testCloseTimeout) })
+	t.Run("ConcurrentMethods", func(t *testing.T) { timeoutWrapper(t, mp, testConcurrentMethods) })
+}
+
+type connTester func(t *testing.T, c1, c2 net.Conn)
+
+func timeoutWrapper(t *testing.T, mp MakePipe, f connTester) {
+	t.Helper()
+	c1, c2, stop, err := mp()
+	if err != nil {
+		t.Fatalf("unable to make pipe: %v", err)
+	}
+	var once sync.Once
+	defer once.Do(func() { stop() })
+	timer := time.AfterFunc(time.Minute, func() {
+		once.Do(func() {
+			t.Error("test timed out; terminating pipe")
+			stop()
+		})
+	})
+	defer timer.Stop()
+	f(t, c1, c2)
+}
+
+// testBasicIO tests that the data sent on c1 is properly received on c2.
+func testBasicIO(t *testing.T, c1, c2 net.Conn) {
+	want := make([]byte, 1<<20)
+	rand.New(rand.NewSource(0)).Read(want)
+
+	dataCh := make(chan []byte)
+	go func() {
+		rd := bytes.NewReader(want)
+		if err := chunkedCopy(c1, rd); err != nil {
+			t.Errorf("unexpected c1.Write error: %v", err)
+		}
+		if err := c1.Close(); err != nil {
+			t.Errorf("unexpected c1.Close error: %v", err)
+		}
+	}()
+
+	go func() {
+		wr := new(bytes.Buffer)
+		if err := chunkedCopy(wr, c2); err != nil {
+			t.Errorf("unexpected c2.Read error: %v", err)
+		}
+		if err := c2.Close(); err != nil {
+			t.Errorf("unexpected c2.Close error: %v", err)
+		}
+		dataCh <- wr.Bytes()
+	}()
+
+	if got := <-dataCh; !bytes.Equal(got, want) {
+		t.Error("transmitted data differs")
+	}
+}
+
+// testPingPong tests that the two endpoints can synchronously send data to
+// each other in a typical request-response pattern.
+func testPingPong(t *testing.T, c1, c2 net.Conn) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	pingPonger := func(c net.Conn) {
+		defer wg.Done()
+		buf := make([]byte, 8)
+		var prev uint64
+		for {
+			if _, err := io.ReadFull(c, buf); err != nil {
+				if err == io.EOF {
+					break
+				}
+				t.Errorf("unexpected Read error: %v", err)
+			}
+
+			v := binary.LittleEndian.Uint64(buf)
+			binary.LittleEndian.PutUint64(buf, v+1)
+			if prev != 0 && prev+2 != v {
+				t.Errorf("mismatching value: got %d, want %d", v, prev+2)
+			}
+			prev = v
+			if v == 1000 {
+				break
+			}
+
+			if _, err := c.Write(buf); err != nil {
+				t.Errorf("unexpected Write error: %v", err)
+				break
+			}
+		}
+		if err := c.Close(); err != nil {
+			t.Errorf("unexpected Close error: %v", err)
+		}
+	}
+
+	wg.Add(2)
+	go pingPonger(c1)
+	go pingPonger(c2)
+
+	// Start off the chain reaction.
+	if _, err := c1.Write(make([]byte, 8)); err != nil {
+		t.Errorf("unexpected c1.Write error: %v", err)
+	}
+}
+
+// testRacyRead tests that it is safe to mutate the input Read buffer
+// immediately after cancelation has occurred.
+func testRacyRead(t *testing.T, c1, c2 net.Conn) {
+	go chunkedCopy(c2, rand.New(rand.NewSource(0)))
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	c1.SetReadDeadline(time.Now().Add(time.Millisecond))
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			b1 := make([]byte, 1024)
+			b2 := make([]byte, 1024)
+			for j := 0; j < 100; j++ {
+				_, err := c1.Read(b1)
+				copy(b1, b2) // Mutate b1 to trigger potential race
+				if err != nil {
+					checkForTimeoutError(t, err)
+					c1.SetReadDeadline(time.Now().Add(time.Millisecond))
+				}
+			}
+		}()
+	}
+}
+
+// testRacyWrite tests that it is safe to mutate the input Write buffer
+// immediately after cancelation has occurred.
+func testRacyWrite(t *testing.T, c1, c2 net.Conn) {
+	go chunkedCopy(io.Discard, c2)
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	c1.SetWriteDeadline(time.Now().Add(time.Millisecond))
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			b1 := make([]byte, 1024)
+			b2 := make([]byte, 1024)
+			for j := 0; j < 100; j++ {
+				_, err := c1.Write(b1)
+				copy(b1, b2) // Mutate b1 to trigger potential race
+				if err != nil {
+					checkForTimeoutError(t, err)
+					c1.SetWriteDeadline(time.Now().Add(time.Millisecond))
+				}
+			}
+		}()
+	}
+}
+
+// testReadTimeout tests that Read timeouts do not affect Write.
+func testReadTimeout(t *testing.T, c1, c2 net.Conn) {
+	go chunkedCopy(io.Discard, c2)
+
+	c1.SetReadDeadline(aLongTimeAgo)
+	_, err := c1.Read(make([]byte, 1024))
+	checkForTimeoutError(t, err)
+	if _, err := c1.Write(make([]byte, 1024)); err != nil {
+		t.Errorf("unexpected Write error: %v", err)
+	}
+}
+
+// testWriteTimeout tests that Write timeouts do not affect Read.
+func testWriteTimeout(t *testing.T, c1, c2 net.Conn) {
+	go chunkedCopy(c2, rand.New(rand.NewSource(0)))
+
+	c1.SetWriteDeadline(aLongTimeAgo)
+	_, err := c1.Write(make([]byte, 1024))
+	checkForTimeoutError(t, err)
+	if _, err := c1.Read(make([]byte, 1024)); err != nil {
+		t.Errorf("unexpected Read error: %v", err)
+	}
+}
+
+// testPastTimeout tests that a deadline set in the past immediately times out
+// Read and Write requests.
+func testPastTimeout(t *testing.T, c1, c2 net.Conn) {
+	go chunkedCopy(c2, c2)
+
+	testRoundtrip(t, c1)
+
+	c1.SetDeadline(aLongTimeAgo)
+	n, err := c1.Write(make([]byte, 1024))
+	if n != 0 {
+		t.Errorf("unexpected Write count: got %d, want 0", n)
+	}
+	checkForTimeoutError(t, err)
+	n, err = c1.Read(make([]byte, 1024))
+	if n != 0 {
+		t.Errorf("unexpected Read count: got %d, want 0", n)
+	}
+	checkForTimeoutError(t, err)
+
+	testRoundtrip(t, c1)
+}
+
+// testPresentTimeout tests that a past deadline set while there are pending
+// Read and Write operations immediately times out those operations.
+func testPresentTimeout(t *testing.T, c1, c2 net.Conn) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	wg.Add(3)
+
+	deadlineSet := make(chan bool, 1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(100 * time.Millisecond)
+		deadlineSet <- true
+		c1.SetReadDeadline(aLongTimeAgo)
+		c1.SetWriteDeadline(aLongTimeAgo)
+	}()
+	go func() {
+		defer wg.Done()
+		n, err := c1.Read(make([]byte, 1024))
+		if n != 0 {
+			t.Errorf("unexpected Read count: got %d, want 0", n)
+		}
+		checkForTimeoutError(t, err)
+		if len(deadlineSet) == 0 {
+			t.Error("Read timed out before deadline is set")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		var err error
+		for err == nil {
+			_, err = c1.Write(make([]byte, 1024))
+		}
+		checkForTimeoutError(t, err)
+		if len(deadlineSet) == 0 {
+			t.Error("Write timed out before deadline is set")
+		}
+	}()
+}
+
+// testFutureTimeout tests that a future deadline will eventually time out
+// Read and Write operations.
+func testFutureTimeout(t *testing.T, c1, c2 net.Conn) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	c1.SetDeadline(time.Now().Add(100 * time.Millisecond))
+	go func() {
+		defer wg.Done()
+		_, err := c1.Read(make([]byte, 1024))
+		checkForTimeoutError(t, err)
+	}()
+	go func() {
+		defer wg.Done()
+		var err error
+		for err == nil {
+			_, err = c1.Write(make([]byte, 1024))
+		}
+		checkForTimeoutError(t, err)
+	}()
+	wg.Wait()
+
+	go chunkedCopy(c2, c2)
+	resyncConn(t, c1)
+	testRoundtrip(t, c1)
+}
+
+// testCloseTimeout tests that calling Close immediately times out pending
+// Read and Write operations.
+func testCloseTimeout(t *testing.T, c1, c2 net.Conn) {
+	go chunkedCopy(c2, c2)
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	wg.Add(3)
+
+	// Test for cancelation upon connection closure.
+	c1.SetDeadline(neverTimeout)
+	go func() {
+		defer wg.Done()
+		time.Sleep(100 * time.Millisecond)
+		c1.Close()
+	}()
+	go func() {
+		defer wg.Done()
+		var err error
+		buf := make([]byte, 1024)
+		for err == nil {
+			_, err = c1.Read(buf)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		var err error
+		buf := make([]byte, 1024)
+		for err == nil {
+			_, err = c1.Write(buf)
+		}
+	}()
+}
+
+// testConcurrentMethods tests that the methods of net.Conn can safely
+// be called concurrently.
+func testConcurrentMethods(t *testing.T, c1, c2 net.Conn) {
+	if runtime.GOOS == "plan9" {
+		t.Skip("skipping on plan9; see https://golang.org/issue/20489")
+	}
+	go chunkedCopy(c2, c2)
+
+	// The results of the calls may be nonsensical, but this should
+	// not trigger a race detector warning.
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(7)
+		go func() {
+			defer wg.Done()
+			c1.Read(make([]byte, 1024))
+		}()
+		go func() {
+			defer wg.Done()
+			c1.Write(make([]byte, 1024))
+		}()
+		go func() {
+			defer wg.Done()
+			c1.SetDeadline(time.Now().Add(10 * time.Millisecond))
+		}()
+		go func() {
+			defer wg.Done()
+			c1.SetReadDeadline(aLongTimeAgo)
+		}()
+		go func() {
+			defer wg.Done()
+			c1.SetWriteDeadline(aLongTimeAgo)
+		}()
+		go func() {
+			defer wg.Done()
+			c1.LocalAddr()
+		}()
+		go func() {
+			defer wg.Done()
+			c1.RemoteAddr()
+		}()
+	}
+	wg.Wait() // At worst, the deadline is set 10ms into the future
+
+	resyncConn(t, c1)
+	testRoundtrip(t, c1)
+}
+
+// checkForTimeoutError checks that the error satisfies the Error interface
+// and that Timeout returns true.
+func checkForTimeoutError(t *testing.T, err error) {
+	t.Helper()
+	if nerr, ok := err.(net.Error); ok {
+		if !nerr.Timeout() {
+			if runtime.GOOS == "windows" && runtime.GOARCH == "arm64" && t.Name() == "TestTestConn/TCP/RacyRead" {
+				t.Logf("ignoring known failure mode on windows/arm64; see https://go.dev/issue/52893")
+			} else {
+				t.Errorf("got error: %v, want err.Timeout() = true", nerr)
+			}
+		}
+	} else {
+		t.Errorf("got %T: %v, want net.Error", err, err)
+	}
+}
+
+// testRoundtrip writes something into c and reads it back.
+// It assumes that everything written into c is echoed back to itself.
+func testRoundtrip(t *testing.T, c net.Conn) {
+	t.Helper()
+	if err := c.SetDeadline(neverTimeout); err != nil {
+		t.Errorf("roundtrip SetDeadline error: %v", err)
+	}
+
+	const s = "Hello, world!"
+	buf := []byte(s)
+	if _, err := c.Write(buf); err != nil {
+		t.Errorf("roundtrip Write error: %v", err)
+	}
+	if _, err := io.ReadFull(c, buf); err != nil {
+		t.Errorf("roundtrip Read error: %v", err)
+	}
+	if string(buf) != s {
+		t.Errorf("roundtrip data mismatch: got %q, want %q", buf, s)
+	}
+}
+
+// resyncConn resynchronizes the connection into a sane state.
+// It assumes that everything written into c is echoed back to itself.
+// It assumes that 0xff is not currently on the wire or in the read buffer.
+func resyncConn(t *testing.T, c net.Conn) {
+	t.Helper()
+	c.SetDeadline(neverTimeout)
+	errCh := make(chan error)
+	go func() {
+		_, err := c.Write([]byte{0xff})
+		errCh <- err
+	}()
+	buf := make([]byte, 1024)
+	for {
+		n, err := c.Read(buf)
+		if n > 0 && bytes.IndexByte(buf[:n], 0xff) == n-1 {
+			break
+		}
+		if err != nil {
+			t.Errorf("unexpected Read error: %v", err)
+			break
+		}
+	}
+	if err := <-errCh; err != nil {
+		t.Errorf("unexpected Write error: %v", err)
+	}
+}
+
+// chunkedCopy copies from r to w in fixed-width chunks to avoid
+// causing a Write that exceeds the maximum packet size for packet-based
+// connections like "unixpacket".
+// We assume that the maximum packet size is at least 1024.
+func chunkedCopy(w io.Writer, r io.Reader) error {
+	b := make([]byte, 1024)
+	_, err := io.CopyBuffer(struct{ io.Writer }{w}, struct{ io.Reader }{r}, b)
+	return err
+}

--- a/vendor/golang.org/x/net/nettest/nettest.go
+++ b/vendor/golang.org/x/net/nettest/nettest.go
@@ -1,0 +1,344 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package nettest provides utilities for network testing.
+package nettest
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	stackOnce               sync.Once
+	ipv4Enabled             bool
+	canListenTCP4OnLoopback bool
+	ipv6Enabled             bool
+	canListenTCP6OnLoopback bool
+	unStrmDgramEnabled      bool
+	rawSocketSess           bool
+
+	aLongTimeAgo = time.Unix(233431200, 0)
+	neverTimeout = time.Time{}
+
+	errNoAvailableInterface = errors.New("no available interface")
+	errNoAvailableAddress   = errors.New("no available address")
+)
+
+func probeStack() {
+	if _, err := RoutedInterface("ip4", net.FlagUp); err == nil {
+		ipv4Enabled = true
+	}
+	if ln, err := net.Listen("tcp4", "127.0.0.1:0"); err == nil {
+		ln.Close()
+		canListenTCP4OnLoopback = true
+	}
+	if _, err := RoutedInterface("ip6", net.FlagUp); err == nil {
+		ipv6Enabled = true
+	}
+	if ln, err := net.Listen("tcp6", "[::1]:0"); err == nil {
+		ln.Close()
+		canListenTCP6OnLoopback = true
+	}
+	rawSocketSess = supportsRawSocket()
+	switch runtime.GOOS {
+	case "aix":
+		// Unix network isn't properly working on AIX 7.2 with
+		// Technical Level < 2.
+		out, _ := exec.Command("oslevel", "-s").Output()
+		if len(out) >= len("7200-XX-ZZ-YYMM") { // AIX 7.2, Tech Level XX, Service Pack ZZ, date YYMM
+			ver := string(out[:4])
+			tl, _ := strconv.Atoi(string(out[5:7]))
+			unStrmDgramEnabled = ver > "7200" || (ver == "7200" && tl >= 2)
+		}
+	default:
+		unStrmDgramEnabled = true
+	}
+}
+
+func unixStrmDgramEnabled() bool {
+	stackOnce.Do(probeStack)
+	return unStrmDgramEnabled
+}
+
+// SupportsIPv4 reports whether the platform supports IPv4 networking
+// functionality.
+func SupportsIPv4() bool {
+	stackOnce.Do(probeStack)
+	return ipv4Enabled
+}
+
+// SupportsIPv6 reports whether the platform supports IPv6 networking
+// functionality.
+func SupportsIPv6() bool {
+	stackOnce.Do(probeStack)
+	return ipv6Enabled
+}
+
+// SupportsRawSocket reports whether the current session is available
+// to use raw sockets.
+func SupportsRawSocket() bool {
+	stackOnce.Do(probeStack)
+	return rawSocketSess
+}
+
+// TestableNetwork reports whether network is testable on the current
+// platform configuration.
+//
+// See func Dial of the standard library for the supported networks.
+func TestableNetwork(network string) bool {
+	ss := strings.Split(network, ":")
+	switch ss[0] {
+	case "ip+nopriv":
+		// This is an internal network name for testing on the
+		// package net of the standard library.
+		switch runtime.GOOS {
+		case "android", "fuchsia", "hurd", "ios", "js", "nacl", "plan9", "wasip1", "windows":
+			return false
+		}
+	case "ip", "ip4", "ip6":
+		switch runtime.GOOS {
+		case "fuchsia", "hurd", "js", "nacl", "plan9", "wasip1":
+			return false
+		default:
+			if os.Getuid() != 0 {
+				return false
+			}
+		}
+	case "unix", "unixgram":
+		switch runtime.GOOS {
+		case "android", "fuchsia", "hurd", "ios", "js", "nacl", "plan9", "wasip1", "windows":
+			return false
+		case "aix":
+			return unixStrmDgramEnabled()
+		}
+	case "unixpacket":
+		switch runtime.GOOS {
+		case "aix", "android", "fuchsia", "hurd", "darwin", "ios", "js", "nacl", "plan9", "wasip1", "windows", "zos":
+			return false
+		}
+	}
+	switch ss[0] {
+	case "tcp4", "udp4", "ip4":
+		return SupportsIPv4()
+	case "tcp6", "udp6", "ip6":
+		return SupportsIPv6()
+	}
+	return true
+}
+
+// TestableAddress reports whether address of network is testable on
+// the current platform configuration.
+func TestableAddress(network, address string) bool {
+	switch ss := strings.Split(network, ":"); ss[0] {
+	case "unix", "unixgram", "unixpacket":
+		// Abstract unix domain sockets, a Linux-ism.
+		if address[0] == '@' && runtime.GOOS != "linux" {
+			return false
+		}
+	}
+	return true
+}
+
+// NewLocalListener returns a listener which listens to a loopback IP
+// address or local file system path.
+//
+// The provided network must be "tcp", "tcp4", "tcp6", "unix" or
+// "unixpacket".
+func NewLocalListener(network string) (net.Listener, error) {
+	stackOnce.Do(probeStack)
+	switch network {
+	case "tcp":
+		if canListenTCP4OnLoopback {
+			if ln, err := net.Listen("tcp4", "127.0.0.1:0"); err == nil {
+				return ln, nil
+			}
+		}
+		if canListenTCP6OnLoopback {
+			return net.Listen("tcp6", "[::1]:0")
+		}
+	case "tcp4":
+		if canListenTCP4OnLoopback {
+			return net.Listen("tcp4", "127.0.0.1:0")
+		}
+	case "tcp6":
+		if canListenTCP6OnLoopback {
+			return net.Listen("tcp6", "[::1]:0")
+		}
+	case "unix", "unixpacket":
+		path, err := LocalPath()
+		if err != nil {
+			return nil, err
+		}
+		return net.Listen(network, path)
+	}
+	return nil, fmt.Errorf("%s is not supported on %s/%s", network, runtime.GOOS, runtime.GOARCH)
+}
+
+// NewLocalPacketListener returns a packet listener which listens to a
+// loopback IP address or local file system path.
+//
+// The provided network must be "udp", "udp4", "udp6" or "unixgram".
+func NewLocalPacketListener(network string) (net.PacketConn, error) {
+	stackOnce.Do(probeStack)
+	switch network {
+	case "udp":
+		if canListenTCP4OnLoopback {
+			if c, err := net.ListenPacket("udp4", "127.0.0.1:0"); err == nil {
+				return c, nil
+			}
+		}
+		if canListenTCP6OnLoopback {
+			return net.ListenPacket("udp6", "[::1]:0")
+		}
+	case "udp4":
+		if canListenTCP4OnLoopback {
+			return net.ListenPacket("udp4", "127.0.0.1:0")
+		}
+	case "udp6":
+		if canListenTCP6OnLoopback {
+			return net.ListenPacket("udp6", "[::1]:0")
+		}
+	case "unixgram":
+		path, err := LocalPath()
+		if err != nil {
+			return nil, err
+		}
+		return net.ListenPacket(network, path)
+	}
+	return nil, fmt.Errorf("%s is not supported on %s/%s", network, runtime.GOOS, runtime.GOARCH)
+}
+
+// LocalPath returns a local path that can be used for Unix-domain
+// protocol testing.
+func LocalPath() (string, error) {
+	dir := ""
+	if runtime.GOOS == "darwin" {
+		dir = "/tmp"
+	}
+	f, err := os.CreateTemp(dir, "go-nettest")
+	if err != nil {
+		return "", err
+	}
+	path := f.Name()
+	f.Close()
+	os.Remove(path)
+	return path, nil
+}
+
+// MulticastSource returns a unicast IP address on ifi when ifi is an
+// IP multicast-capable network interface.
+//
+// The provided network must be "ip", "ip4" or "ip6".
+func MulticastSource(network string, ifi *net.Interface) (net.IP, error) {
+	switch network {
+	case "ip", "ip4", "ip6":
+	default:
+		return nil, errNoAvailableAddress
+	}
+	if ifi == nil || ifi.Flags&net.FlagUp == 0 || ifi.Flags&net.FlagMulticast == 0 {
+		return nil, errNoAvailableAddress
+	}
+	ip, ok := hasRoutableIP(network, ifi)
+	if !ok {
+		return nil, errNoAvailableAddress
+	}
+	return ip, nil
+}
+
+// LoopbackInterface returns an available logical network interface
+// for loopback test.
+func LoopbackInterface() (*net.Interface, error) {
+	ift, err := net.Interfaces()
+	if err != nil {
+		return nil, errNoAvailableInterface
+	}
+	for _, ifi := range ift {
+		if ifi.Flags&net.FlagLoopback != 0 && ifi.Flags&net.FlagUp != 0 {
+			return &ifi, nil
+		}
+	}
+	return nil, errNoAvailableInterface
+}
+
+// RoutedInterface returns a network interface that can route IP
+// traffic and satisfies flags.
+//
+// The provided network must be "ip", "ip4" or "ip6".
+func RoutedInterface(network string, flags net.Flags) (*net.Interface, error) {
+	switch network {
+	case "ip", "ip4", "ip6":
+	default:
+		return nil, errNoAvailableInterface
+	}
+	ift, err := net.Interfaces()
+	if err != nil {
+		return nil, errNoAvailableInterface
+	}
+	for _, ifi := range ift {
+		if ifi.Flags&flags != flags {
+			continue
+		}
+		if _, ok := hasRoutableIP(network, &ifi); !ok {
+			continue
+		}
+		return &ifi, nil
+	}
+	return nil, errNoAvailableInterface
+}
+
+func hasRoutableIP(network string, ifi *net.Interface) (net.IP, bool) {
+	ifat, err := ifi.Addrs()
+	if err != nil {
+		return nil, false
+	}
+	for _, ifa := range ifat {
+		switch ifa := ifa.(type) {
+		case *net.IPAddr:
+			if ip, ok := routableIP(network, ifa.IP); ok {
+				return ip, true
+			}
+		case *net.IPNet:
+			if ip, ok := routableIP(network, ifa.IP); ok {
+				return ip, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func routableIP(network string, ip net.IP) (net.IP, bool) {
+	if !ip.IsLoopback() && !ip.IsLinkLocalUnicast() && !ip.IsGlobalUnicast() {
+		return nil, false
+	}
+	switch network {
+	case "ip4":
+		if ip := ip.To4(); ip != nil {
+			return ip, true
+		}
+	case "ip6":
+		if ip.IsLoopback() { // addressing scope of the loopback address depends on each implementation
+			return nil, false
+		}
+		if ip := ip.To16(); ip != nil && ip.To4() == nil {
+			return ip, true
+		}
+	default:
+		if ip := ip.To4(); ip != nil {
+			return ip, true
+		}
+		if ip := ip.To16(); ip != nil {
+			return ip, true
+		}
+	}
+	return nil, false
+}

--- a/vendor/golang.org/x/net/nettest/nettest_stub.go
+++ b/vendor/golang.org/x/net/nettest/nettest_stub.go
@@ -1,0 +1,11 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !windows && !zos
+
+package nettest
+
+func supportsRawSocket() bool {
+	return false
+}

--- a/vendor/golang.org/x/net/nettest/nettest_unix.go
+++ b/vendor/golang.org/x/net/nettest/nettest_unix.go
@@ -1,0 +1,21 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || zos
+
+package nettest
+
+import "syscall"
+
+func supportsRawSocket() bool {
+	for _, af := range []int{syscall.AF_INET, syscall.AF_INET6} {
+		s, err := syscall.Socket(af, syscall.SOCK_RAW, 0)
+		if err != nil {
+			continue
+		}
+		syscall.Close(s)
+		return true
+	}
+	return false
+}

--- a/vendor/golang.org/x/net/nettest/nettest_windows.go
+++ b/vendor/golang.org/x/net/nettest/nettest_windows.go
@@ -1,0 +1,26 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package nettest
+
+import "syscall"
+
+func supportsRawSocket() bool {
+	// From http://msdn.microsoft.com/en-us/library/windows/desktop/ms740548.aspx:
+	// Note: To use a socket of type SOCK_RAW requires administrative privileges.
+	// Users running Winsock applications that use raw sockets must be a member of
+	// the Administrators group on the local computer, otherwise raw socket calls
+	// will fail with an error code of WSAEACCES. On Windows Vista and later, access
+	// for raw sockets is enforced at socket creation. In earlier versions of Windows,
+	// access for raw sockets is enforced during other socket operations.
+	for _, af := range []int{syscall.AF_INET, syscall.AF_INET6} {
+		s, err := syscall.Socket(af, syscall.SOCK_RAW, 0)
+		if err != nil {
+			continue
+		}
+		syscall.Closesocket(s)
+		return true
+	}
+	return false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1653,6 +1653,7 @@ golang.org/x/net/internal/socks
 golang.org/x/net/internal/timeseries
 golang.org/x/net/ipv4
 golang.org/x/net/ipv6
+golang.org/x/net/nettest
 golang.org/x/net/netutil
 golang.org/x/net/proxy
 golang.org/x/net/trace


### PR DESCRIPTION
Please see the commit messages for details.

This pulls in the https://pkg.go.dev/golang.org/x/net/nettest package as a dependency, let me know if I need to separate adding that dependency into a new commit.

Fixes: #33897 

```release-note
The cilium dnsproxy now handles EDNS0 large buffersize advertisements better.
```
