### PR TITLE
wireguard: Move private key generation to start

### DIFF
--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -170,12 +170,7 @@ func newWireguardAgent(lc cell.Lifecycle, sysctl sysctl.Sysctl) *wg.Agent {
 			log.Fatalf("failed to initialize WireGuard: %s", err)
 		}
 
-		lc.Append(cell.Hook{
-			OnStop: func(cell.HookContext) error {
-				wgAgent.Close()
-				return nil
-			},
-		})
+		lc.Append(wgAgent)
 	} else {
 		// Delete WireGuard device from previous run (if such exists)
 		link.DeleteByName(wgTypes.IfaceName)


### PR DESCRIPTION
"cilium_wg0.key" files were appearing in tests that were just doing "hive.New(Agent).Populate" due to NewAgent() doing naughty side-effectful things.

To fix this, add Start & Stop hooks to "Agent" and move the key generation to the Start hook.
