### PR TITLE
Revert "ci: increase verbosity of print-downgrade-script.sh"

### DIFF
--- a/contrib/scripts/print-downgrade-version.sh
+++ b/contrib/scripts/print-downgrade-version.sh
@@ -75,7 +75,7 @@ tag_exists() {
     local tag="refs/tags/${1}"
 
     # Check if the tag is already present locally.
-    if git rev-parse --verify --end-of-options "${tag}"; then
+    if git rev-parse --verify --end-of-options "${tag}" &> /dev/null; then
         return 0
     fi
 
@@ -95,10 +95,10 @@ tag_exists() {
     #   not work well, however, if the release manager pushes additional fixes
     #   on top of the prep commit.
     >&2 echo "INFO: tag '${tag}' not present locally, trying to fetch it from origin"
-    git fetch --depth=1 origin "+${tag}:${tag}" || true
+    git fetch --depth=1 origin "+${tag}:${tag}" &> /dev/null || true
 
     # Retry after the fetch attempt.
-    if git rev-parse --verify --end-of-options "${tag}"; then
+    if git rev-parse --verify --end-of-options "${tag}" &> /dev/null; then
         return 0
     fi
 


### PR DESCRIPTION
This reverts commit 511277eac43cb8aa7293bce113b8282bdc837bfa.

As PR was from a fork, it didn't fail tests on PR.
