### PR TITLE
operator-id-management: agent waits for global identities

### DIFF
--- a/clustermesh-apiserver/clustermesh/vmmanager.go
+++ b/clustermesh-apiserver/clustermesh/vmmanager.go
@@ -105,7 +105,7 @@ func externalWorkloadsProvider(
 
 			mgr.ciliumExternalWorkloadStore = ewstore
 			mgr.backend = backend
-			mgr.identityAllocator = identityCache.NewCachingIdentityAllocator(mgr)
+			mgr.identityAllocator = identityCache.NewCachingIdentityAllocator(mgr, identityCache.AllocatorConfig{})
 			mgr.identityAllocator.InitIdentityAllocator(clientset)
 
 			if _, err = store.JoinSharedStore(store.Configuration{

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -69,7 +69,7 @@ func TestClusterMesh(t *testing.T) {
 	kvstore.SetupDummy(t, "etcd")
 
 	// The nils are only used by k8s CRD identities. We default to kvstore.
-	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
+	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{}, cache.AllocatorConfig{})
 	<-mgr.InitIdentityAllocator(nil)
 	t.Cleanup(mgr.Close)
 

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -136,7 +136,7 @@ func TestRemoteClusterRun(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 
 			// The nils are only used by k8s CRD identities. We default to kvstore.
-			allocator := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
+			allocator := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{}, cache.AllocatorConfig{})
 			<-allocator.InitIdentityAllocator(nil)
 
 			t.Cleanup(func() {
@@ -275,7 +275,7 @@ func TestRemoteClusterClusterIDChange(t *testing.T) {
 	ctx := context.Background()
 
 	// The nils are only used by k8s CRD identities. We default to kvstore.
-	allocator := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
+	allocator := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{}, cache.AllocatorConfig{})
 	<-allocator.InitIdentityAllocator(nil)
 
 	t.Cleanup(func() {

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -92,7 +92,7 @@ func setup(tb testing.TB) *ClusterMeshServicesTestSuite {
 
 	s.svcCache = k8s.NewServiceCache(db, nodeAddrs)
 
-	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
+	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{}, cache.AllocatorConfig{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	<-mgr.InitIdentityAllocator(nil)
 	dir := tb.TempDir()

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -57,7 +57,7 @@ func setupEndpointSuite(tb testing.TB) *EndpointSuite {
 	s := &EndpointSuite{
 		orchestrator: &fakeTypes.FakeOrchestrator{},
 		repo:         policy.NewPolicyRepository(nil, nil, nil, nil),
-		mgr:          cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{}),
+		mgr:          cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{}, cache.AllocatorConfig{}),
 	}
 
 	// GetConfig the default labels prefix filter

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -49,7 +49,7 @@ func setupRedirectSuite(tb testing.TB) *RedirectSuite {
 	// Setup dependencies for endpoint.
 	kvstore.SetupDummy(tb, "etcd")
 
-	s.mgr = cache.NewCachingIdentityAllocator(s.do)
+	s.mgr = cache.NewCachingIdentityAllocator(s.do, cache.AllocatorConfig{})
 	<-s.mgr.InitIdentityAllocator(nil)
 
 	identityCache := identity.IdentityMap{

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -251,7 +251,7 @@ func (d *DummySelectorCacheUser) IdentitySelectionCommit(*versioned.Tx) {
 
 // Setup identities, ports and endpoint IDs we will need
 var (
-	cacheAllocator          = cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
+	cacheAllocator          = cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{}, cache.AllocatorConfig{})
 	testSelectorCache       = policy.NewSelectorCache(cacheAllocator.GetIdentityCache())
 	dummySelectorCacheUser  = &DummySelectorCacheUser{}
 	DstID1Selector          = api.NewESFromLabels(labels.ParseSelectLabel("k8s:Dst1=test"))

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -5,13 +5,16 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/pkg/allocator"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
@@ -19,6 +22,9 @@ import (
 	cacheKey "github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/inctimer"
+	capi_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/identitybackend"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
@@ -26,17 +32,43 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-var fakeConfig = &option.DaemonConfig{
-	K8sNamespace: "kube-system",
+var (
+	fakeConfig = &option.DaemonConfig{
+		K8sNamespace: "kube-system",
+	}
+
+	testConfigs = []testConfig{
+		{
+			name: "disable_operator_manages_identities",
+			allocatorConfig: AllocatorConfig{
+				EnableOperatorManageCIDs: false,
+			},
+		},
+		{
+			name: "enable_operator_manages_identities",
+			allocatorConfig: AllocatorConfig{
+				EnableOperatorManageCIDs: true,
+			},
+		},
+	}
+)
+
+type testConfig struct {
+	name            string
+	allocatorConfig AllocatorConfig
 }
 
 func TestAllocateIdentityReserved(t *testing.T) {
 	testutils.IntegrationTest(t)
 	kvstore.SetupDummy(t, "etcd")
-	testAllocateIdentityReserved(t)
+	for _, testConfig := range testConfigs {
+		t.Run(testConfig.name, func(t *testing.T) {
+			testAllocateIdentityReserved(t, testConfig)
+		})
+	}
 }
 
-func testAllocateIdentityReserved(t *testing.T) {
+func testAllocateIdentityReserved(t *testing.T, testConfig testConfig) {
 	var (
 		lbls  labels.Labels
 		i     *identity.Identity
@@ -48,7 +80,7 @@ func testAllocateIdentityReserved(t *testing.T) {
 		labels.IDNameHost: labels.NewLabel(labels.IDNameHost, "", labels.LabelSourceReserved),
 	}
 
-	mgr := NewCachingIdentityAllocator(newDummyOwner())
+	mgr := NewCachingIdentityAllocator(newDummyOwner(), testConfig.allocatorConfig)
 	<-mgr.InitIdentityAllocator(nil)
 
 	require.True(t, identity.IdentityAllocationIsLocal(lbls))
@@ -216,13 +248,18 @@ func testEventWatcherBatching(t *testing.T) {
 func TestGetIdentityCache(t *testing.T) {
 	testutils.IntegrationTest(t)
 	kvstore.SetupDummy(t, "etcd")
-	testGetIdentityCache(t)
+
+	for _, testConfig := range testConfigs {
+		t.Run(testConfig.name, func(t *testing.T) {
+			testGetIdentityCache(t, testConfig)
+		})
+	}
 }
 
-func testGetIdentityCache(t *testing.T) {
+func testGetIdentityCache(t *testing.T, testConfig testConfig) {
 	identity.InitWellKnownIdentities(fakeConfig, cmtypes.ClusterInfo{Name: "default", ID: 5})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
-	mgr := NewCachingIdentityAllocator(newDummyOwner())
+	mgr := NewCachingIdentityAllocator(newDummyOwner(), testConfig.allocatorConfig)
 	<-mgr.InitIdentityAllocator(nil)
 	defer mgr.Close()
 	defer mgr.IdentityAllocator.DeleteAllKeys()
@@ -236,6 +273,7 @@ func TestAllocator(t *testing.T) {
 	testutils.IntegrationTest(t)
 	kvstore.SetupDummy(t, "etcd")
 	testAllocator(t)
+	testAllocatorOperatorIDManagement(t)
 }
 
 func testAllocator(t *testing.T) {
@@ -246,7 +284,7 @@ func testAllocator(t *testing.T) {
 	owner := newDummyOwner()
 	identity.InitWellKnownIdentities(fakeConfig, cmtypes.ClusterInfo{Name: "default", ID: 5})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
-	mgr := NewCachingIdentityAllocator(owner)
+	mgr := NewCachingIdentityAllocator(owner, AllocatorConfig{EnableOperatorManageCIDs: false})
 	<-mgr.InitIdentityAllocator(nil)
 	defer mgr.Close()
 	defer mgr.IdentityAllocator.DeleteAllKeys()
@@ -325,19 +363,173 @@ func testAllocator(t *testing.T) {
 	require.NotEqual(t, 0, owner.WaitUntilID(id3.ID))
 }
 
+func createCIDObj(id string, lbls labels.Labels) *capi_v2.CiliumIdentity {
+	k := &cacheKey.GlobalIdentity{LabelArray: lbls.LabelArray()}
+	selectedLabels, _ := identitybackend.SanitizeK8sLabels(k.GetAsMap())
+	return &capi_v2.CiliumIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   id,
+			Labels: selectedLabels,
+		},
+		SecurityLabels: k.GetAsMap(),
+	}
+}
+
+func testAllocatorOperatorIDManagement(t *testing.T) {
+	const testNamePrefix = "operator_id_management"
+
+	type testCase struct {
+		name           string
+		allocationMode string
+	}
+
+	testCases := []testCase{
+		{
+			name:           "kvstore_id",
+			allocationMode: option.IdentityAllocationModeKVstore,
+		},
+		{
+			name:           "crd_id",
+			allocationMode: option.IdentityAllocationModeCRD,
+		},
+		{
+			name:           "kvstore_double_wr_id",
+			allocationMode: option.IdentityAllocationModeDoubleWriteReadKVstore,
+		},
+		{
+			name:           "crd_double_wr_id",
+			allocationMode: option.IdentityAllocationModeDoubleWriteReadCRD,
+		},
+	}
+
+	for _, tc := range testCases {
+		testName := fmt.Sprintf("%s_%s", testNamePrefix, tc.name)
+		t.Run(testName, func(t *testing.T) {
+			option.Config.IdentityAllocationMode = tc.allocationMode
+			defer func() { option.Config.IdentityAllocationMode = option.IdentityAllocationModeKVstore }()
+
+			lbls1 := labels.NewLabelsFromSortedList("blah=%%//!!;id=foo;user=anna")
+
+			ctx := context.Background()
+			_, kubeClient := k8sClient.NewFakeClientset()
+
+			owner := newDummyOwner()
+			identity.InitWellKnownIdentities(fakeConfig, cmtypes.ClusterInfo{Name: "default", ID: 5})
+			mgr := NewCachingIdentityAllocator(owner, AllocatorConfig{EnableOperatorManageCIDs: true, maxAllocAttempts: 2})
+			<-mgr.InitIdentityAllocator(kubeClient)
+			defer mgr.Close()
+			defer mgr.IdentityAllocator.DeleteAllKeys()
+
+			// Verify that allocating an identity that doesn't exist will return an error.
+			id1a, isNew, err := mgr.AllocateIdentity(ctx, lbls1, false, identity.InvalidIdentity)
+			require.Nil(t, id1a)
+			require.Error(t, err)
+			require.False(t, isNew)
+
+			id := createCIDObj("1000", lbls1)
+
+			var err2 error
+			switch option.Config.IdentityAllocationMode {
+			case option.IdentityAllocationModeKVstore:
+				err = addIDKVStore(ctx, id.Name, lbls1)
+			case option.IdentityAllocationModeCRD:
+				_, err = kubeClient.CiliumV2().CiliumIdentities().Create(ctx, id, metav1.CreateOptions{})
+			case option.IdentityAllocationModeDoubleWriteReadKVstore, option.IdentityAllocationModeDoubleWriteReadCRD:
+				err2 = addIDKVStore(ctx, id.Name, lbls1)
+				_, err = kubeClient.CiliumV2().CiliumIdentities().Create(ctx, id, metav1.CreateOptions{})
+			}
+			require.NoError(t, err)
+			require.NoError(t, err2)
+
+			// Verify that the created CID is allocated, as an existing CID in the store.
+			var id2 *identity.Identity
+			err = testutils.WaitUntil(func() bool {
+				id2, isNew, err2 = mgr.AllocateIdentity(ctx, lbls1, false, identity.InvalidIdentity)
+				return id2 != nil && err2 == nil
+			}, 100*time.Millisecond)
+			require.NoError(t, err)
+			require.False(t, isNew)
+			require.EqualValues(t, lbls1.LabelArray(), id2.LabelArray)
+
+			// Repeat verification for the same lbls.
+			var id3 *identity.Identity
+			err = testutils.WaitUntil(func() bool {
+				id3, isNew, err2 = mgr.AllocateIdentity(ctx, lbls1, false, identity.InvalidIdentity)
+				return id3 != nil && err2 == nil
+			}, 100*time.Millisecond)
+			require.NoError(t, err)
+			require.False(t, isNew)
+			require.EqualValues(t, lbls1.LabelArray(), id3.LabelArray)
+
+			released, err := mgr.Release(ctx, id2, false)
+			require.NoError(t, err)
+			require.False(t, released)
+
+			switch option.Config.IdentityAllocationMode {
+			case option.IdentityAllocationModeKVstore:
+				err = removeIDKVStore(ctx, id.Name)
+			case option.IdentityAllocationModeCRD:
+				err = kubeClient.CiliumV2().CiliumIdentities().Delete(ctx, id.Name, metav1.DeleteOptions{})
+			case option.IdentityAllocationModeDoubleWriteReadKVstore, option.IdentityAllocationModeDoubleWriteReadCRD:
+				err = removeIDKVStore(ctx, id.Name)
+				err2 = kubeClient.CiliumV2().CiliumIdentities().Delete(ctx, id.Name, metav1.DeleteOptions{})
+			}
+			require.NoError(t, err)
+			require.NoError(t, err2)
+
+			// Verify that allocating an identity that doesn't exist will return an error
+			// after deleting the id from the store.
+			var id4 *identity.Identity
+			err = testutils.WaitUntil(func() bool {
+				id4, isNew, err2 = mgr.AllocateIdentity(ctx, lbls1, false, identity.InvalidIdentity)
+				return id4 == nil && err2 != nil
+			}, 100*time.Millisecond)
+			require.NoError(t, err)
+			require.False(t, isNew)
+
+			released, err = mgr.Release(ctx, id2, false)
+			require.NoError(t, err)
+			require.False(t, released)
+		})
+	}
+
+}
+
+func addIDKVStore(ctx context.Context, id string, lbls labels.Labels) error {
+	kvStoreClient := kvstore.Client()
+	key := &cacheKey.GlobalIdentity{LabelArray: lbls.LabelArray()}
+	idPrefix := path.Join(IdentitiesPath, "id")
+	keyPath := path.Join(idPrefix, id)
+	success, err := kvStoreClient.CreateOnly(ctx, keyPath, []byte(key.GetKey()), false)
+	if err != nil || !success {
+		return fmt.Errorf("unable to create master key '%s': %w", keyPath, err)
+	}
+	return nil
+}
+
+func removeIDKVStore(ctx context.Context, id string) error {
+	prefix := path.Join(IdentitiesPath, "id")
+	key := path.Join(prefix, id)
+	return kvstore.Client().Delete(ctx, key)
+}
+
 func TestLocalAllocation(t *testing.T) {
 	testutils.IntegrationTest(t)
 	kvstore.SetupDummy(t, "etcd")
-	testLocalAllocation(t)
+	for _, testConfig := range testConfigs {
+		t.Run(testConfig.name, func(t *testing.T) {
+			testLocalAllocation(t, testConfig)
+		})
+	}
 }
 
-func testLocalAllocation(t *testing.T) {
+func testLocalAllocation(t *testing.T, testConfig testConfig) {
 	lbls1 := labels.NewLabelsFromSortedList("cidr:192.0.2.3/32")
 
 	owner := newDummyOwner()
 	identity.InitWellKnownIdentities(fakeConfig, cmtypes.ClusterInfo{Name: "default", ID: 5})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
-	mgr := NewCachingIdentityAllocator(owner)
+	mgr := NewCachingIdentityAllocator(owner, testConfig.allocatorConfig)
 	<-mgr.InitIdentityAllocator(nil)
 	defer mgr.Close()
 	defer mgr.IdentityAllocator.DeleteAllKeys()
@@ -398,14 +590,18 @@ func testLocalAllocation(t *testing.T) {
 func TestAllocatorReset(t *testing.T) {
 	testutils.IntegrationTest(t)
 	kvstore.SetupDummy(t, "etcd")
-	testAllocatorReset(t)
+	for _, testConfig := range testConfigs {
+		t.Run(testConfig.name, func(t *testing.T) {
+			testAllocatorReset(t, testConfig)
+		})
+	}
 }
 
 // Test that we can close and reopen the allocator successfully.
-func testAllocatorReset(t *testing.T) {
+func testAllocatorReset(t *testing.T, testConfig testConfig) {
 	labels := labels.NewLabelsFromSortedList("id=bar;user=anna")
 	owner := newDummyOwner()
-	mgr := NewCachingIdentityAllocator(owner)
+	mgr := NewCachingIdentityAllocator(owner, testConfig.allocatorConfig)
 	testAlloc := func() {
 		id1a, _, err := mgr.AllocateIdentity(context.Background(), labels, false, identity.InvalidIdentity)
 		require.NotNil(t, id1a)
@@ -425,7 +621,15 @@ func testAllocatorReset(t *testing.T) {
 }
 
 func TestAllocateLocally(t *testing.T) {
-	mgr := NewCachingIdentityAllocator(newDummyOwner())
+	for _, testConfig := range testConfigs {
+		t.Run(testConfig.name, func(t *testing.T) {
+			testAllocateLocally(t, testConfig)
+		})
+	}
+}
+
+func testAllocateLocally(t *testing.T, testConfig testConfig) {
+	mgr := NewCachingIdentityAllocator(newDummyOwner(), testConfig.allocatorConfig)
 
 	cidrLbls := labels.NewLabelsFromSortedList("cidr:1.2.3.4/32")
 	podLbls := labels.NewLabelsFromSortedList("k8s:foo=bar")
@@ -445,8 +649,16 @@ func TestAllocateLocally(t *testing.T) {
 }
 
 func TestCheckpointRestore(t *testing.T) {
+	for _, testConfig := range testConfigs {
+		t.Run(testConfig.name, func(t *testing.T) {
+			testCheckpointRestore(t, testConfig)
+		})
+	}
+}
+
+func testCheckpointRestore(t *testing.T, testConfig testConfig) {
 	owner := newDummyOwner()
-	mgr := NewCachingIdentityAllocator(owner)
+	mgr := NewCachingIdentityAllocator(owner, testConfig.allocatorConfig)
 	defer mgr.Close()
 	dir := t.TempDir()
 	mgr.checkpointPath = filepath.Join(dir, CheckpointFile)
@@ -478,7 +690,7 @@ func TestCheckpointRestore(t *testing.T) {
 	err := mgr.checkpoint(context.TODO())
 	require.NoError(t, err)
 
-	newMgr := NewCachingIdentityAllocator(owner)
+	newMgr := NewCachingIdentityAllocator(owner, AllocatorConfig{})
 	defer newMgr.Close()
 	newMgr.checkpointPath = mgr.checkpointPath
 

--- a/pkg/identity/cache/cache_test.go
+++ b/pkg/identity/cache/cache_test.go
@@ -29,7 +29,15 @@ var (
 func TestLookupReservedIdentity(t *testing.T) {
 	testutils.IntegrationTest(t)
 
-	mgr := NewCachingIdentityAllocator(newDummyOwner())
+	for _, testConfig := range testConfigs {
+		t.Run(testConfig.name, func(t *testing.T) {
+			testLookupReservedIdentity(t, testConfig)
+		})
+	}
+}
+
+func testLookupReservedIdentity(t *testing.T, testConfig testConfig) {
+	mgr := NewCachingIdentityAllocator(newDummyOwner(), testConfig.allocatorConfig)
 	<-mgr.InitIdentityAllocator(nil)
 
 	hostID := identity.GetReservedID("host")

--- a/pkg/ipcache/ipcache_bench_test.go
+++ b/pkg/ipcache/ipcache_bench_test.go
@@ -26,7 +26,7 @@ func (d *dummyOwner) GetNodeSuffix() string {
 func BenchmarkInjectLabels(b *testing.B) {
 
 	ctx, cancel := context.WithCancel(context.Background())
-	alloc := cache.NewCachingIdentityAllocator(&dummyOwner{})
+	alloc := cache.NewCachingIdentityAllocator(&dummyOwner{}, cache.AllocatorConfig{})
 	//<-alloc.InitIdentityAllocator(nil)
 	PolicyHandler = &mockUpdater{
 		identities: make(map[identity.NumericIdentity]labels.LabelArray),


### PR DESCRIPTION
CFP: https://github.com/cilium/design-cfps/pull/59

Related work done in cilium-operator in
https://github.com/cilium/cilium/tree/main/operator/pkg/ciliumidentity.

Note: No user facing changes. The flag is disabled by default and hidden.

Introduce changes to agent's identity allocation system to support the case when operator is managing (create, update, delete) Cilium Identities.

Agent no longer creates Cilium Identities (global identities). Agent instead only gets identity from the local cache, which is populated by the Cilium Identities watcher events. In case identity is not found in the local cache, identity allocation will be retried. After a certain amount of retries, identity allocation will fail. This affects pod creation -- CNI fails and pod doesn’t get into ready state. This allows easier error detection in the identity management system. Cilium Identity is expected to exist for all pods, because operator creates them on pod object creation, before the pods are scheduled.

The Cilium Identity GC remains to be handled by operator without changes, for now. Agent no longer acquires reference to identities locally, and agent no longer removes the HeartBeatAnnotation ("io.cilium.heartbeat"). This isn’t a problem because GC will only delete Cilium Identities after they are no longer used in any Cilium Endpoints or Cilium Endpoint Slices. Practically, there shouldn’t be a case when operator GC deletes a Cilium Identity that is used by agent. But even if it happens, operator will recreate it immediately, because there are pods that match that identity, in the same way agents used to do. The plan is to eventually move GC to be part of the Cilium Identity controller in operator, at which point the HeartBeatAnnotation will be deprecated, and this concern will no longer exist.

**Strategy**
Including operator ID management in the existing allocator is a relatively small change and the first step towards adopting operator ID management. Over time, as there is proof that this feature is reliable and beneficial (additionally because of further enhancements that the feature enables), the goal would be to refactor the allocator code, to make it shorter, simpler and easier to extend, and eventually make the feature default. Until then, it makes sense not to decouple it from the current allocator implementation, because it would make it more difficult for other modifications/enhancements in the allocator to be applied (because there would be two implementations), while operator ID management implementation would anyway reuse nearly all the code of the current allocator implementation.

**Manual test**
Tested manually with the CID controller running (https://github.com/cilium/cilium/tree/main/operator/pkg/ciliumidentity) in cilium-operator and `operator-manages-identities` flag enabled for both cilium-agent and cilium-operator.

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>