### PR TITLE
bugtool: collect `cilium-dbg bpf frag list` output

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -454,6 +454,7 @@ func ciliumInfoCommands(cmdDir string, k8sPods []string) []string {
 		"cilium-dbg bgp route-policies",
 		"cilium-dbg troubleshoot kvstore",
 		"cilium-dbg troubleshoot clustermesh",
+		"cilium-dbg bpf frag list",
 	}
 
 	return append(k8sPerPodCopyCommands(commands, k8sPods), k8sPerPodCopyStateDir(cmdDir, k8sPods)...)


### PR DESCRIPTION
Pick up the formatted output from https://github.com/cilium/cilium/pull/34751.