### PR TITLE
docs: link to ariane-config.yaml for available triggers.

### DIFF
--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -59,6 +59,8 @@ them all at once:
 | v1.14            | /test-backport-1.14      |
 +------------------+--------------------------+
 
+More triggers can be found in `ariane-config.yaml <https://github.com/cilium/cilium/blob/main/.github/ariane-config.yaml>`_
+
 For a full list of GHA, see `GitHub Actions Page <https://github.com/cilium/cilium/actions>`_
 
 Using GitHub Actions for testing


### PR DESCRIPTION
docs: link to ariane-config.yaml for available triggers.

This change surfaces additional triggers to the
reader via the ariane-config file. These triggers are
helpful when seeking which specific workflows to initiate.

```release-note
Link ariane triggers in testing/CI documentation.
```