### PR TITLE
nodeinit: remove workaround for Azure CNI bridge mode

### DIFF
--- a/install/kubernetes/cilium/files/nodeinit/startup.bash
+++ b/install/kubernetes/cilium/files/nodeinit/startup.bash
@@ -159,44 +159,6 @@ mkdir -p {{ .Values.nodeinit.bootstrapFile | dir | quote }}
 date > {{ .Values.nodeinit.bootstrapFile | quote }}
 {{- end }}
 
-{{- if .Values.azure.enabled }}
-# AKS: If azure-vnet is installed on the node, and (still) configured in bridge mode,
-# configure it as 'transparent' to be consistent with Cilium's CNI chaining config.
-# If the azure-vnet CNI config is not removed, kubelet will execute CNI CHECK commands
-# against it every 5 seconds and write 'bridge' to its state file, causing inconsistent
-# behaviour when Pods are removed.
-if [ -f /etc/cni/net.d/10-azure.conflist ]; then
-  echo "Ensuring azure-vnet is configured in 'transparent' mode..."
-  sed -i 's/"mode":\s*"bridge"/"mode":"transparent"/g' /etc/cni/net.d/10-azure.conflist
-fi
-
-# The azure0 interface being present means the node was booted with azure-vnet configured
-# in bridge mode. This means there might be ebtables rules and neight entries interfering
-# with pod connectivity if we deploy with Azure IPAM.
-if ip l show dev azure0 >/dev/null 2>&1; then
-
-  # In Azure IPAM mode, also remove the azure-vnet state file, otherwise ebtables rules get
-  # restored by the azure-vnet CNI plugin on every CNI CHECK, which can cause connectivity
-  # issues in Cilium-managed Pods. Since azure-vnet is no longer called on scheduling events,
-  # this file can be removed.
-  rm -f /var/run/azure-vnet.json
-
-  # This breaks connectivity for existing workload Pods when Cilium is scheduled, but we need
-  # to flush these to prevent Cilium-managed Pod IPs conflicting with Pod IPs previously allocated
-  # by azure-vnet. These ebtables DNAT rules contain fixed MACs that are no longer bound on the node,
-  # causing packets for these Pods to be redirected back out to the gateway, where they are dropped.
-  echo 'Flushing ebtables pre/postrouting rules in nat table.. (disconnecting non-Cilium Pods!)'
-  ebtables -t nat -F PREROUTING || true
-  ebtables -t nat -F POSTROUTING || true
-
-  # ip-masq-agent periodically injects PERM neigh entries towards the gateway
-  # for all other k8s nodes in the cluster. These are safe to flush, as ARP can
-  # resolve these nodes as usual. PERM entries will be automatically restored later.
-  echo 'Deleting all permanent neighbour entries on azure0...'
-  ip neigh show dev azure0 nud permanent | cut -d' ' -f1 | xargs -r -n1 ip neigh del dev azure0 to || true
-fi
-{{- end }}
-
 {{- if .Values.nodeinit.revertReconfigureKubelet }}
 rm -f /tmp/node-deinit.cilium.io
 {{- end }}


### PR DESCRIPTION
Azure CNI has defaulted to transparent mode since 2020 (see https://github.com/Azure/azure-container-networking/pull/709) and today all AKS clusters on a supported version (1.27 or later) are running in transparent mode.

Cilium no longer needs workarounds to force Azure CNI from bridge mode to transparent mode, so remove these steps from the nodeinit script.

```release-note
Remove workaround for Azure CNI bridge mode from nodeinit script.
```
