### PR TITLE
[v1.15] CODEOWNERS: switch cilium/tophat to cilium/committers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -220,7 +220,7 @@
 # The following filepaths should be sorted so that more specific paths occur
 # after the less specific paths, otherwise the ownership for the specific paths
 # is not properly picked up in Github.
-* @cilium/tophat
+* @cilium/committers
 /.github/ariane-config.yaml @cilium/github-sec @cilium/ci-structure
 /.github/workflows/auto-approve.yaml @cilium/cilium-maintainers
 /.github/workflows/*perf*.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure


### PR DESCRIPTION
[ upstream commit 290524d0d4fb32ea00d2f5bc9236329153b428a0 ]

Membership in `tophat` typically changes on a weekly basis, resulting in stale review approvals after a change-over. It's also a single source of failure in our review & merge machinery.

As tophat for stable branches is primarily meant to review for process conformity (backport criteria, correct formatting of the PR etc), pull in all of the committers instead to perform this important responsibility.

Note: if you can't find a single committer to approve your stable PR, it most likely shouldn't be merged.