### PR TITLE
helm: Render valid image specs when tag is empty

### DIFF
--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -15,14 +15,18 @@ image:
   digest: abcdefgh
 ```
 then `include "cilium.image" .Values.image`
-will return `quay.io/cilium/cilium:v1.10.1@abcdefgh`
+will return `quay.io/cilium/cilium:v1.10.1@abcdefgh`.
+Note that you can omit the tag by setting its value to `null` or `""` (in case
+your container engine doesn't support specifying both the tag and digest for
+instance).
 */}}
 {{- define "cilium.image" -}}
 {{- $digest := (.useDigest | default false) | ternary (printf "@%s" .digest) "" -}}
+{{- $tag := .tag | default "" | eq "" | ternary "" (printf ":%s" .tag) -}}
 {{- if .override -}}
 {{- printf "%s" .override -}}
 {{- else -}}
-{{- printf "%s:%s%s" .repository .tag $digest -}}
+{{- printf "%s%s%s" .repository $tag $digest -}}
 {{- end -}}
 {{- end -}}
 

--- a/install/kubernetes/cilium/templates/cilium-operator/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/cilium-operator/_helpers.tpl
@@ -31,6 +31,7 @@ Return cilium operator image
 {{- else -}}
 {{- $cloud := include "cilium.operator.cloud" . }}
 {{- $imageDigest := include "cilium.operator.imageDigestName" . }}
-{{- printf "%s-%s%s:%s%s" .Values.operator.image.repository $cloud .Values.operator.image.suffix .Values.operator.image.tag $imageDigest -}}
+{{- $tag := .Values.operator.image.tag | default "" | eq "" | ternary "" (printf ":%s" .Values.operator.image.tag) }}
+{{- printf "%s-%s%s%s%s" .Values.operator.image.repository $cloud .Values.operator.image.suffix $tag $imageDigest -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Trying to set an empty (`""`) or `null` tag would result in an invalid
image spec:

```
quay.io/cilium/cilium:@sha256:abc...
```

However, it can be necessary to specify images only by their digest in
case the container engine doesn't accept accept both a tag and digest
simultaneously [1].

This commit ensures that

```
image:
  repository: quay.io/cilium/cilium
  tag: null
  digest: sha256:abc...
```
renders properly as `quay.io/cilium/cilium@sha256:abc...`.

[1]: https://github.com/cri-o/cri-o/issues/8603

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
