### PR TITLE
[v1.16] loader: Wait for LocalNodeConfiguration to be set

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -370,9 +370,9 @@ func (l *loader) reinitializeXDPLocked(ctx context.Context, extraCArgs []string,
 // and reinsertion of the object into the kernel as well as an atomic program replacement
 // at the XDP hook. extraCArgs can be passed-in in order to alter BPF code defines.
 func (l *loader) ReinitializeXDP(ctx context.Context, extraCArgs []string) error {
+	devices := l.getNodeConfig().DeviceNames()
 	l.compilationLock.Lock()
 	defer l.compilationLock.Unlock()
-	devices := l.nodeConfig.Load().DeviceNames()
 	return l.reinitializeXDPLocked(ctx, extraCArgs, devices)
 }
 


### PR DESCRIPTION
Some code paths end up calling into the loader before Reinitialize() has been called and it has the LocalNodeConfiguration to work with.

One of such paths was fixed in f9b91fb28d5b, but unfortunately there were more. This adds an explicit wait loop around loading the "nodeConfig" to wait for Reinitialize() to finish.

The issue pointed to by #34019 was reproduced with a 10 pods doing DNS requests and repeatedly restarting the cilium-agents while having a 10 second sleep in Reinitialize() to force the timing problem. With this fix the retry load loop is hit and once Reinitialize() finishes the regenerations proceeded normally.

Fixes: #34019
Fixes: f9b91fb28d5b ("endpoint: Init DNS history trigger only when datapath is ready for it")

```release-note
Fix panic in endpoint regeneration when DNS requests are processed during early initialization. 
```
