### PR TITLE
kvstore: Remove SessionID from kvstore Value

### DIFF
--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -401,8 +401,7 @@ func (k *kvstoreBackend) RunLocksGC(ctx context.Context, staleKeysPrevRound map[
 			// comparing ModRevision ensures the same client is still holding
 			// this lock since the last GC was called.
 			modRev.ModRevision == v.ModRevision &&
-			modRev.LeaseID == v.LeaseID &&
-			modRev.SessionID == v.SessionID {
+			modRev.LeaseID == v.LeaseID {
 			if err := k.backend.Delete(ctx, key); err == nil {
 				scopedLog.Warning("Forcefully removed distributed lock due to client staleness." +
 					" Please check the connectivity between the KVStore and the client with that lease ID.")
@@ -416,7 +415,6 @@ func (k *kvstoreBackend) RunLocksGC(ctx context.Context, staleKeysPrevRound map[
 		staleKeys[key] = kvstore.Value{
 			ModRevision: v.ModRevision,
 			LeaseID:     v.LeaseID,
-			SessionID:   v.SessionID,
 		}
 	}
 

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -156,7 +156,6 @@ func benchmarkRunLocksGC(b *testing.B, backendName string) {
 		oldestRev     = uint64(math.MaxUint64)
 		oldestLeaseID int64
 		oldestKey     string
-		sessionID     string
 	)
 	// Stale locks contains 2 locks, which is expected but we only want to GC
 	// the oldest one so we can unlock all the remaining clients waiting to hold
@@ -166,7 +165,6 @@ func benchmarkRunLocksGC(b *testing.B, backendName string) {
 			oldestKey = k
 			oldestRev = v.ModRevision
 			oldestLeaseID = v.LeaseID
-			sessionID = v.SessionID
 		}
 	}
 
@@ -175,7 +173,6 @@ func benchmarkRunLocksGC(b *testing.B, backendName string) {
 	staleLocks[oldestKey] = kvstore.Value{
 		ModRevision: oldestRev,
 		LeaseID:     oldestLeaseID,
-		SessionID:   sessionID,
 	}
 
 	// GC lock1 because it's the oldest lock being held.

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -15,7 +15,6 @@ type Value struct {
 	Data        []byte
 	ModRevision uint64
 	LeaseID     int64
-	SessionID   string
 }
 
 // KeyValuePairs is a map of key=value pairs


### PR DESCRIPTION
Consul support has been dropped, and the SessionID field was only used there. The etcd implementation does not have the same consept, so its currently fully unsued.

Not a bit change, but its a bit confusing while reading through the kvstore implementation :)

---

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: n/a

