### PR TITLE
CI: Remove CSPs and upgrades from /test

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -4,22 +4,18 @@ allowed-teams:
 triggers:
   /test:
     workflows:
-    - conformance-aws-cni.yaml
     - conformance-clustermesh.yaml
     - conformance-delegated-ipam.yaml
     - conformance-ipsec-e2e.yaml
-    - conformance-eks.yaml
     - conformance-externalworkloads.yaml
     - conformance-ginkgo.yaml
     - conformance-ingress.yaml
     - conformance-multi-pool.yaml
     - conformance-runtime.yaml
     - integration-test.yaml
-    - tests-clustermesh-upgrade.yaml
     - tests-datapath-verifier.yaml
     - tests-l4lb.yaml
     - tests-e2e-upgrade.yaml
-    - tests-ipsec-upgrade.yaml
     - hubble-cli-integration-test.yaml
   /ci-aks:
     workflows:


### PR DESCRIPTION
/test comments on PRs run repetitive tests that do not add value and are expensive. These tests can still be triggered via a comment (e.g. /ci-aws-cni, /ci-eks, /ci-clustermesh, but they will not run by default.

Related: #34688
Signed-off-by: Alvaro Uria <alvaro.uria@isovalent.com>