### PR TITLE
fix: repository value renovate update workflow

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -288,7 +288,7 @@ jobs:
       - name: Push changes into PR
         env:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
-          repository:  ${{ startsWith(github.head_ref, 'renovate/') && github.repository || github.event.pull_request.head.repo.full_name }}
+          repository:  ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' || steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
         run: |
           git diff HEAD^


### PR DESCRIPTION
github.head_ref is only available when the workflow context is pull_request or pull_request_target cf https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs

since head_ref was nil, the conditional `${{ startsWith(github.head_ref, 'renovate/') && github.repository || github.event.pull_request.head.repo.full_name }}` would then point to `pull_request.head.repo.full_name` which was also nil because of the context being workflow_dispatch and not pull_request_target or pull_request

this commit revert the repository conditional creation to `github.event.pull_request.head.repo.full_name || github.repository`, as `github.repository` will only be used out of a pull request event (here, workflow_dispatch), and the only workflow_dispatch context usage would be coming from renovate branches that are protected by renovate environment

fixes https://github.com/cilium/cilium/pull/34650

```release-note
fix: repository nil value handled on workflow_dispatch context for renovate updates
```
