### PR TITLE
bpf: tests: don't specify ETH_HLEN for L2 devices

### DIFF
--- a/bpf/tests/hairpin_sctp_flow.c
+++ b/bpf/tests/hairpin_sctp_flow.c
@@ -12,9 +12,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test*/
 #define ENABLE_IPV4
 #define ENABLE_SCTP

--- a/bpf/tests/l4lb_ipip_health_check_host.c
+++ b/bpf/tests/l4lb_ipip_health_check_host.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4		1
 #define ENABLE_IPV6		1

--- a/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
+++ b/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/xdp.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT

--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT

--- a/bpf/tests/tc_egressgw_redirect_from_overlay.c
+++ b/bpf/tests/tc_egressgw_redirect_from_overlay.c
@@ -12,9 +12,6 @@
 #undef SECLABEL_IPV4
 #undef SECLABEL_IPV6
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT

--- a/bpf/tests/tc_host_encrypted_overlay.c
+++ b/bpf/tests/tc_host_encrypted_overlay.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4			1
 #define ENABLE_IPSEC			1

--- a/bpf/tests/tc_l2_announcement.c
+++ b/bpf/tests/tc_l2_announcement.c
@@ -20,9 +20,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4
 #define ENABLE_L2_ANNOUNCEMENTS

--- a/bpf/tests/tc_lxc_lb4_no_backend.c
+++ b/bpf/tests/tc_lxc_lb4_no_backend.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4
 #undef ENABLE_PER_PACKET_LB

--- a/bpf/tests/tc_lxc_lb6_no_backend.c
+++ b/bpf/tests/tc_lxc_lb6_no_backend.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV6
 #undef ENABLE_PER_PACKET_LB

--- a/bpf/tests/tc_lxc_policy_drop.c
+++ b/bpf/tests/tc_lxc_policy_drop.c
@@ -8,9 +8,6 @@
 
 #define LXC_IPV4 (__be32)v4_pod_one
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4
 

--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT

--- a/bpf/tests/tc_nodeport_lb4_dsr_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_lb.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT

--- a/bpf/tests/tc_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_backend.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT

--- a/bpf/tests/tc_nodeport_lb4_no_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_no_backend.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT

--- a/bpf/tests/tc_nodeport_lb6_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb6_dsr_backend.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV6
 #define ENABLE_NODEPORT

--- a/bpf/tests/tc_nodeport_lb6_dsr_lb.c
+++ b/bpf/tests/tc_nodeport_lb6_dsr_lb.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV6
 #define ENABLE_NODEPORT

--- a/bpf/tests/tc_nodeport_lb6_no_backend.c
+++ b/bpf/tests/tc_nodeport_lb6_no_backend.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV6
 #define ENABLE_NODEPORT

--- a/bpf/tests/tc_nodeport_lb_terminating_backend.c
+++ b/bpf/tests/tc_nodeport_lb_terminating_backend.c
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 /* Copyright Authors of Cilium */
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4		1
 #define ENABLE_NODEPORT		1

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -12,9 +12,6 @@
 #include <bpf/ctx/skb.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test*/
 #define ENABLE_IPV4
 

--- a/bpf/tests/xdp_egressgw_reply.c
+++ b/bpf/tests/xdp_egressgw_reply.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/xdp.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT

--- a/bpf/tests/xdp_nodeport_lb4_dsr_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_dsr_lb.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/xdp.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT

--- a/bpf/tests/xdp_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_backend.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/xdp.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/xdp.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT

--- a/bpf/tests/xdp_nodeport_lb6_dsr_lb.c
+++ b/bpf/tests/xdp_nodeport_lb6_dsr_lb.c
@@ -6,9 +6,6 @@
 #include <bpf/ctx/xdp.h>
 #include "pktgen.h"
 
-/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
-#define ETH_HLEN 14
-
 /* Enable code paths under test */
 #define ENABLE_IPV6
 #define ENABLE_NODEPORT


### PR DESCRIPTION
This should be set by the default value that bpf/lib/eth.h provides. We only need to override it for L3 devices.