### PR TITLE
bpf: nat: recreate a NAT entry if the packet hits the stale entry

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -158,7 +158,7 @@ jobs:
           cmd: |
             cd /host/
             # Run with cgo disabled, LVH images don't ship with gcc.
-            CGO_ENABLED=0 go${{ env.go-version }} test -v -parallel=1 ./test/verifier -cilium-base-path /host -ci-kernel-version ${{ matrix.ci-kernel }}
+            CGO_ENABLED=0 go${{ env.go-version }} test -v -parallel=1 -timeout=20m ./test/verifier -cilium-base-path /host -ci-kernel-version ${{ matrix.ci-kernel }}
 
       - name: Fetch artifacts
         if: ${{ !success() }}

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -172,6 +172,118 @@ int egressgw_snat2_check(struct __ctx_buff *ctx)
 	return ret;
 }
 
+/* Test that a packet matching an egress gateway policy on the to-netdev program
+ * gets correctly SNATed with the desired egress IP of the policy, event if the
+ * packet hits a stale NAT entry.
+ */
+PKTGEN("tc", "tc_egressgw_tuple_collision1")
+int egressgw_tuple_collision1_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+		});
+}
+
+SETUP("tc", "tc_egressgw_tuple_collision1")
+int egressgw_tuple_collision1_setup(struct __ctx_buff *ctx)
+{
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
+				  GATEWAY_NODE_IP, EGRESS_IP);
+
+	/* Jump into the entrypoint */
+	ctx_egw_done_set(ctx);
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_tuple_collision1")
+int egressgw_tuple_collision1_check(const struct __ctx_buff *ctx)
+{
+	int ret = egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+			.packets = 1,
+			.status_code = CTX_ACT_OK
+		});
+
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0Xffffff, 24);
+
+	return ret;
+}
+
+PKTGEN("tc", "tc_egressgw_tuple_collision2")
+int egressgw_tuple_collision2_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+		});
+}
+
+SETUP("tc", "tc_egressgw_tuple_collision2")
+int egressgw_tuple_collision2_setup(struct __ctx_buff *ctx)
+{
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
+				  GATEWAY_NODE_IP, EGRESS_IP3);
+
+	/* Jump into the entrypoint */
+	ctx_egw_done_set(ctx);
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_tuple_collision2")
+int egressgw_tuple_collision2_check(const struct __ctx_buff *ctx)
+{
+	return egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+			.tuple_collision = true,
+			.packets = 2,
+			.status_code = CTX_ACT_OK
+		});
+}
+
+/* Test that a packet matching an egress gateway policy on the from-netdev program
+ * gets correctly revSNATed and connection tracked, even if the packet hits a
+ * stale NAT entry.
+ */
+PKTGEN("tc", "tc_egressgw_tuple_collision2_reply")
+int egressgw_tuple_collision2_reply_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+			.tuple_collision = true,
+			.dir = CT_INGRESS,
+		});
+}
+
+SETUP("tc", "tc_egressgw_tuple_collision2_reply")
+int egressgw_tuple_collision2_reply_setup(struct __ctx_buff *ctx)
+{
+	/* install ipcache entry for the CLIENT_IP: */
+	ipcache_v4_add_entry(CLIENT_IP, 0, 0, CLIENT_NODE_IP, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_tuple_collision2_reply")
+int egressgw_tuple_collision2_reply_check(const struct __ctx_buff *ctx)
+{
+	int ret = egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+			.dir = CT_INGRESS,
+			.packets = 3,
+			.status_code = CTX_ACT_REDIRECT,
+		});
+
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0Xffffff, 24);
+
+	return ret;
+}
+
 /* Test that a packet matching an excluded CIDR egress gateway policy on the
  * to-netdev program does not get SNATed with the egress IP of the policy.
  */


### PR DESCRIPTION
Currently `snat_v4_nat_handle_mapping` doesn't validate the matched NAT entry aligns with the desired source IP, and it ends up using an invalid Egress IP if the packet hits a stale NAT entry. This PR validates it, and recreates SNAT/revSNAT entries if the packet hits a stale entry with invalid source IP.


Note:
- The default timeout of go test is 10m. 40a2c76 extends to 20m for verifier test. https://pkg.go.dev/cmd/go#hdr-Testing_flags