### PR TITLE
version: Don't create k8s client if --client is specified

### DIFF
--- a/cilium-cli/cli/cmd.go
+++ b/cilium-cli/cli/cmd.go
@@ -38,6 +38,10 @@ func NewCiliumCommand(hooks api.Hooks) *cobra.Command {
 			switch cmd.Name() {
 			case "completion", "help":
 				return nil
+			case "version":
+				if clientFlag, err := cmd.Flags().GetBool("client"); err == nil && clientFlag {
+					return nil
+				}
 			}
 
 			c, err := k8s.NewClient(contextName, "", namespace)


### PR DESCRIPTION
Don't initialize k8s client in the version command if --client flag is specified so that the command succeeds even if .kube/config does not exist.