### PR TITLE
cilium-cli: connectivity: fix the local-redirect-policy flow validation

### DIFF
--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-cidr-lrp-frontend-deny.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-cidr-lrp-frontend-deny.yaml
@@ -1,0 +1,15 @@
+# This policy denies packets towards LRP frontend address
+# The packets to the LRP frontend will be dropped by this policy
+# if LRP skips the service translation for the packets from
+# LRP backend to frontend. (SkipRedirectFromBackend=true)
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-to-cidr-lrp-deny
+spec:
+  endpointSelector:
+    matchLabels:
+      lrp: backend
+  egressDeny:
+  - toCIDRSet:
+    - cidr: 169.254.169.255/32

--- a/cilium-cli/connectivity/tests/lrp.go
+++ b/cilium-cli/connectivity/tests/lrp.go
@@ -111,8 +111,7 @@ func (s lrp) Run(ctx context.Context, t *check.Test) {
 
 				if policy.Spec.SkipRedirectFromBackend {
 					a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
-						AltDstIP:   lf.Address(features.IPFamilyV4),
-						AltDstPort: lf.Port(),
+						RSTAllowed: true,
 					}))
 				}
 				i++


### PR DESCRIPTION
This PR fixes the flow validation failure in local-redirect-policy test. Currently local-redirect-policy expects check.ResultCurlTimeout if SkipRedirectFromBackend=true, and validates the flow for peer. However there's no valid flow from peer to the LRP frontend address 169.254.169.255, because it timedout. (SYN-ACK and FIN not found) This PR fixes this issue by explicitly denying the frontend address and expecting ResultPolicyDenyEgressDrop.

Fixes: cilium/cilium-cli#2733
