### PR TITLE
datapath: clarify comment for EncryptNode

### DIFF
--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -158,7 +158,7 @@ type LocalNodeConfiguration struct {
 	// EnableIPSecEncryptedOverlay enables IPSec routes for overlay traffic
 	EnableIPSecEncryptedOverlay bool
 
-	// EncryptNode enables encrypting NodeIP traffic requires EnableIPSec
+	// EncryptNode enables encrypting NodeIP traffic
 	EncryptNode bool
 
 	// IPv4PodSubnets is a list of IPv4 subnets that pod IPs are assigned from


### PR DESCRIPTION
`EncryptNode` is no longer limited to IPsec. And in fact it currently is *only* supported for Wireguard.