### PR TITLE
kvstore: remove obsolete key encoding/decoding methods

### DIFF
--- a/clustermesh-apiserver/clustermesh/root.go
+++ b/clustermesh-apiserver/clustermesh/root.go
@@ -108,7 +108,6 @@ func registerHooks(lc cell.Lifecycle, params parameters) error {
 
 type identitySynchronizer struct {
 	store        store.SyncStore
-	encoder      func([]byte) string
 	syncCallback func(context.Context)
 }
 
@@ -118,7 +117,7 @@ func newIdentitySynchronizer(ctx context.Context, cinfo cmtypes.ClusterInfo, bac
 		store.WSSWithSyncedKeyOverride(identityCache.IdentitiesPath))
 	go identitiesStore.Run(ctx)
 
-	return &identitySynchronizer{store: identitiesStore, encoder: backend.Encode, syncCallback: syncCallback}
+	return &identitySynchronizer{store: identitiesStore, syncCallback: syncCallback}
 }
 
 func parseLabelArrayFromMap(base map[string]string) labels.LabelArray {
@@ -147,7 +146,7 @@ func (is *identitySynchronizer) upsert(ctx context.Context, _ resource.Key, obj 
 	}
 
 	scopedLog.Info("Upserting identity in etcd")
-	kv := store.NewKVPair(identity.Name, is.encoder(labels))
+	kv := store.NewKVPair(identity.Name, string(labels))
 	if err := is.store.UpsertKey(ctx, kv); err != nil {
 		// The only errors surfaced by WorkqueueSyncStore are the unrecoverable ones.
 		log.WithError(err).Warning("Unable to upsert identity in etcd")

--- a/pkg/allocator/allocator_test.go
+++ b/pkg/allocator/allocator_test.go
@@ -42,10 +42,6 @@ func newDummyBackend() *dummyBackend {
 	}
 }
 
-func (d *dummyBackend) Encode(v string) string {
-	return v
-}
-
 func (d *dummyBackend) DeleteAllKeys(ctx context.Context) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
@@ -294,7 +290,7 @@ func testAllocator(t *testing.T, maxID idpool.ID) {
 		require.True(t, firstUse)
 
 		// refcnt must be 1
-		require.Equal(t, uint64(1), allocator.localKeys.keys[allocator.encodeKey(key)].refcnt)
+		require.Equal(t, uint64(1), allocator.localKeys.keys[key.GetKey()].refcnt)
 	}
 
 	saved := allocator.backoffTemplate.Factor
@@ -318,7 +314,7 @@ func testAllocator(t *testing.T, maxID idpool.ID) {
 		require.False(t, firstUse)
 
 		// refcnt must now be 2
-		require.Equal(t, uint64(2), allocator.localKeys.keys[allocator.encodeKey(key)].refcnt)
+		require.Equal(t, uint64(2), allocator.localKeys.keys[key.GetKey()].refcnt)
 	}
 
 	// Create a 2nd allocator, refill it
@@ -335,7 +331,7 @@ func testAllocator(t *testing.T, maxID idpool.ID) {
 		require.False(t, new)
 		require.True(t, firstUse)
 
-		localKey := allocator2.localKeys.keys[allocator.encodeKey(key)]
+		localKey := allocator2.localKeys.keys[key.GetKey()]
 		require.NotNil(t, localKey)
 
 		// refcnt in the 2nd allocator is 1
@@ -352,7 +348,7 @@ func testAllocator(t *testing.T, maxID idpool.ID) {
 	// refcnt should be back to 1
 	for i := idpool.ID(1); i <= maxID; i++ {
 		key := TestAllocatorKey(fmt.Sprintf("key%04d", i))
-		require.Equal(t, uint64(1), allocator.localKeys.keys[allocator.encodeKey(key)].refcnt)
+		require.Equal(t, uint64(1), allocator.localKeys.keys[key.GetKey()].refcnt)
 	}
 
 	rateLimiter := rate.NewLimiter(10*time.Second, 100)
@@ -367,7 +363,7 @@ func testAllocator(t *testing.T, maxID idpool.ID) {
 
 	for i := idpool.ID(1); i <= maxID; i++ {
 		key := TestAllocatorKey(fmt.Sprintf("key%04d", i))
-		require.NotContains(t, allocator.localKeys.keys, allocator.encodeKey(key))
+		require.NotContains(t, allocator.localKeys.keys, key.GetKey())
 	}
 
 	// running the GC should evict all entries
@@ -400,7 +396,7 @@ func TestObserveAllocatorChanges(t *testing.T) {
 		require.True(t, firstUse)
 
 		// refcnt must be 1
-		require.Equal(t, uint64(1), allocator.localKeys.keys[allocator.encodeKey(key)].refcnt)
+		require.Equal(t, uint64(1), allocator.localKeys.keys[key.GetKey()].refcnt)
 	}
 
 	// Subscribe to the changes. This should replay the current state.

--- a/pkg/allocator/cache.go
+++ b/pkg/allocator/cache.go
@@ -136,12 +136,12 @@ func (c *cache) OnUpsert(id idpool.ID, key AllocatorKey) {
 	defer c.mutex.Unlock()
 
 	if k, ok := c.nextCache[id]; ok {
-		delete(c.nextKeyCache, c.allocator.encodeKey(k))
+		delete(c.nextKeyCache, k.GetKey())
 	}
 
 	c.nextCache[id] = key
 	if key != nil {
-		c.nextKeyCache[c.allocator.encodeKey(key)] = id
+		c.nextKeyCache[key.GetKey()] = id
 	}
 
 	c.allocator.idPool.Remove(id)
@@ -219,7 +219,7 @@ func (c *cache) onDeleteLocked(id idpool.ID, key AllocatorKey, recreateMissingLo
 	}
 
 	if k, ok := c.nextCache[id]; ok && k != nil {
-		delete(c.nextKeyCache, c.allocator.encodeKey(k))
+		delete(c.nextKeyCache, k.GetKey())
 	}
 
 	delete(c.nextCache, id)
@@ -327,7 +327,7 @@ func (c *cache) foreach(cb RangeFunc) {
 func (c *cache) insert(key AllocatorKey, val idpool.ID) {
 	c.mutex.Lock()
 	c.nextCache[val] = key
-	c.nextKeyCache[c.allocator.encodeKey(key)] = val
+	c.nextKeyCache[key.GetKey()] = val
 	c.mutex.Unlock()
 }
 

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -430,7 +430,3 @@ func (c *crdBackend) ListAndWatch(ctx context.Context, handler allocator.CacheMu
 func (c *crdBackend) Status() (string, error) {
 	return "OK", nil
 }
-
-func (c *crdBackend) Encode(v string) string {
-	return v
-}

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -130,7 +130,7 @@ func benchmarkRunLocksGC(b *testing.B, backendName string) {
 			},
 			nil,
 		)
-		lock2, err = client.LockPath(context.Background(), allocatorName+"/locks/"+kvstore.Client().Encode([]byte(shortKey.GetKey())))
+		lock2, err = client.LockPath(context.Background(), allocatorName+"/locks/"+shortKey.GetKey())
 		require.NoError(b, err)
 		close(gotLock2)
 	}()

--- a/pkg/kvstore/allocator/doublewrite/backend.go
+++ b/pkg/kvstore/allocator/doublewrite/backend.go
@@ -259,8 +259,3 @@ func (d *doubleWriteBackend) Status() (string, error) {
 	}
 	return d.crdBackend.Status()
 }
-
-func (d *doubleWriteBackend) Encode(v string) string {
-	// Works for both CRD and etcd as the KVStore.
-	return v
-}

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -193,13 +193,6 @@ type BackendOperations interface {
 	// Close closes the kvstore client
 	Close()
 
-	// Encodes a binary slice into a character set that the backend
-	// supports
-	Encode(in []byte) string
-
-	// Decodes a key previously encoded back into the original binary slice
-	Decode(in string) ([]byte, error)
-
 	// ListAndWatch creates a new watcher which will watch the specified
 	// prefix for changes. Before doing this, it will list the current keys
 	// matching the prefix and report them as new keys. The Events channel is

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1549,16 +1549,6 @@ func (e *etcdClient) Close() {
 	e.lockLeaseManager.Wait()
 }
 
-// Encode encodes a binary slice into a character set that the backend supports
-func (e *etcdClient) Encode(in []byte) (out string) {
-	return string(in)
-}
-
-// Decode decodes a key previously encoded back into the original binary slice
-func (e *etcdClient) Decode(in string) (out []byte, err error) {
-	return []byte(in), nil
-}
-
 // ListAndWatch implements the BackendOperations.ListAndWatch using etcd
 func (e *etcdClient) ListAndWatch(ctx context.Context, prefix string, chanSize int) *Watcher {
 	w := newWatcher(prefix, chanSize)


### PR DESCRIPTION
The Consul backend had some special restrictions wrt. key encoding. That backend was removed in commit f323ffc16d79 ("kvstore: Remove Consul support"). The remaining etcd backend doesn't have these restrictions so the key encoding/decoding step can be omitted. All the decode/encode methods did was converting from `[]byte` to `string` and back or vice versa. This might have caused unnecessary allocations in some cases.