### PR TITLE
ariane: don't run full test suite for BPF test changes

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -97,42 +97,42 @@ triggers:
 
 workflows:
   conformance-aks.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-aws-cni.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-clustermesh.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-delegated-ipam.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-ipsec-e2e.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-eks.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-externalworkloads.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-gateway-api.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-ginkgo.yaml:
-    paths-ignore-regex: (cilium-cli|Documentation|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|cilium-cli|Documentation|CODEOWNERS|USERS.md)/
   conformance-gke.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-ingress.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-multi-pool.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   conformance-runtime.yaml:
-    paths-ignore-regex: (cilium-cli|Documentation|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|cilium-cli|Documentation|CODEOWNERS|USERS.md)/
   integration-test.yaml:
-    paths-ignore-regex: (Documentation|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|Documentation|CODEOWNERS|USERS.md)/
   tests-clustermesh-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   tests-datapath-verifier.yaml:
     paths-regex: (bpf|test/verifier|vendor|images)/
   tests-l4lb.yaml:
     paths-regex: (bpf|daemon|images|pkg|test/l4lb|test/nat46x64|vendor)/
   tests-e2e-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   tests-ipsec-upgrade.yaml:
-    paths-ignore-regex: (test|Documentation|hubble|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|hubble|CODEOWNERS|USERS.md)/
   hubble-cli-integration-test.yaml:
-    paths-ignore-regex: (test|Documentation|CODEOWNERS|USERS.md)/
+    paths-ignore-regex: (bpf/complexity-tests|bpf/tests|test|Documentation|CODEOWNERS|USERS.md)/


### PR DESCRIPTION
The BPF complexity and integration tests have no impact on Cilium's runtime behaviour, avoid running all sorts of e2e tests on them.