### PR TITLE
[v1.15] ipcache: Yet another refcounting fix with mix of APIs

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -303,7 +303,7 @@ func (ipc *IPCache) upsertLocked(
 	if option.Config.Debug {
 		scopedLog = log.WithFields(logrus.Fields{
 			logfields.IPAddr:   ip,
-			logfields.Identity: newIdentity,
+			logfields.Identity: &newIdentity,
 			logfields.Key:      hostKey,
 		})
 		if k8sMeta != nil {

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -31,36 +31,58 @@ import (
 
 // Identity is the identity representation of an IP<->Identity cache.
 type Identity struct {
-	// ID is the numeric identity
-	ID identity.NumericIdentity
+	// Note: The ordering of these fields is optimized to reduce padding
 
 	// Source is the source of the identity in the cache
 	Source source.Source
+
+	// overwrittenLegacySource contains the source of the original entry created
+	// via legacy API. This is preserved so that original source can be restored
+	// if the metadata API stops managing the entry.
+	overwrittenLegacySource source.Source
+
+	// ID is the numeric identity
+	ID identity.NumericIdentity
 
 	// This blank field ensures that the == operator cannot be used on this
 	// type, to avoid external packages accidentally comparing the private
 	// values below
 	_ []struct{}
 
+	// modifiedByLegacyAPI indicates that this entry touched by the legacy Upsert API.
+	// This informs the metadata subsystem to retain the original source and
+	// to clean up the entry if the legacy API already dropped its reference.
+	// upsertLocked will ensure that this field remains true once set. In other
+	// words, there is no way unset this field once set.
+	// This field is intended to be removed once cilium/cilium#21142 has been
+	// fully implemented and all entries are created via the new metadata API
+	modifiedByLegacyAPI bool
+
 	// shadowed determines if another entry overlaps with this one.
 	// Shadowed identities are not propagated to listeners by default.
 	// Most commonly set for Identity with Source = source.Generated when
 	// a pod IP (other source) has the same IP.
 	shadowed bool
-
-	// createdFromMetadata indicates that this entry was created via the new
-	// metadata API. This is needed to know if it is safe to delete
-	// an IPCache entry when no further metadata is associated with its prefix.
-	// This field is intended to be removed once cilium/cilium#21142 has been
-	// fully implemented and all entries are created via the new metadata API
-	createdFromMetadata bool
 }
 
 func (i Identity) equals(o Identity) bool {
 	return i.ID == o.ID &&
 		i.Source == o.Source &&
 		i.shadowed == o.shadowed &&
-		i.createdFromMetadata == o.createdFromMetadata
+		i.modifiedByLegacyAPI == o.modifiedByLegacyAPI &&
+		i.overwrittenLegacySource == o.overwrittenLegacySource
+}
+
+func (i Identity) exclusivelyOwnedByLegacyAPI() bool {
+	return i.modifiedByLegacyAPI && i.overwrittenLegacySource == ""
+}
+
+func (i Identity) exclusivelyOwnedByMetadataAPI() bool {
+	return !i.modifiedByLegacyAPI
+}
+
+func (i Identity) ownedByLegacyAndMetadataAPI() bool {
+	return i.modifiedByLegacyAPI && i.overwrittenLegacySource != ""
 }
 
 // IPKeyPair is the (IP, key) pair used of the identity
@@ -268,7 +290,7 @@ func (ipc *IPCache) getK8sMetadata(ip string) *K8sMetadata {
 func (ipc *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8sMetadata, newIdentity Identity) (namedPortsChanged bool, err error) {
 	ipc.mutex.Lock()
 	defer ipc.mutex.Unlock()
-	return ipc.upsertLocked(ip, hostIP, hostKey, k8sMeta, newIdentity, false /* !force */)
+	return ipc.upsertLocked(ip, hostIP, hostKey, k8sMeta, newIdentity, false /* !force */, true /* fromLegacyAPI */)
 }
 
 // upsertLocked adds / updates the provided IP and identity into the IPCache,
@@ -293,6 +315,7 @@ func (ipc *IPCache) upsertLocked(
 	k8sMeta *K8sMetadata,
 	newIdentity Identity,
 	force bool,
+	fromLegacyAPI bool,
 ) (namedPortsChanged bool, err error) {
 	var newNamedPorts types.NamedPortMap
 	if k8sMeta != nil {
@@ -325,10 +348,45 @@ func (ipc *IPCache) upsertLocked(
 
 	cachedIdentity, found := ipc.ipToIdentityCache[ip]
 	if found {
+		// If this is a legacy upsert call,  then we need to make sure that the
+		// overwrittenLegacySource is updated
+		if fromLegacyAPI {
+			switch {
+			case cachedIdentity.exclusivelyOwnedByMetadataAPI():
+				// If the entry was exclusively owned by the metadata API, then we
+				// want to preserve our source as the legacy source (so it can be
+				// restored by the metadata API later) - even if our upsert call is
+				// later rejected due to it being a low-precedence upsert.
+				newIdentity.overwrittenLegacySource = newIdentity.Source
+			case cachedIdentity.ownedByLegacyAndMetadataAPI():
+				// If the entry is owned by both APIs, then it will have overwrittenLegacySource
+				// already set. Thus, check if we should update it, otherwise just preserve it as is.
+				if source.AllowOverwrite(cachedIdentity.overwrittenLegacySource, newIdentity.Source) {
+					newIdentity.overwrittenLegacySource = newIdentity.Source
+				} else {
+					newIdentity.overwrittenLegacySource = cachedIdentity.overwrittenLegacySource
+				}
+			}
+		}
+
+		// Here we track if an entry was previously created via new asynchronous
+		// UpsertMetadata API or the old synchronous Upsert call and preserve that bit
+		if fromLegacyAPI || cachedIdentity.modifiedByLegacyAPI {
+			newIdentity.modifiedByLegacyAPI = true
+		}
+
 		if !force && !source.AllowOverwrite(cachedIdentity.Source, newIdentity.Source) {
 			metrics.IPCacheErrorsTotal.WithLabelValues(
 				metricTypeUpsert, metricErrorOverwrite,
 			).Inc()
+
+			// Even if this update is rejected, we want to update the modifiedByLegacyAPI
+			// and overwrittenLegacySource fields in case the low precedence source here
+			// needs to be restored later
+			cachedIdentity.modifiedByLegacyAPI = newIdentity.modifiedByLegacyAPI
+			cachedIdentity.overwrittenLegacySource = newIdentity.overwrittenLegacySource
+			ipc.ipToIdentityCache[ip] = cachedIdentity
+
 			return false, NewErrOverwrite(cachedIdentity.Source, newIdentity.Source)
 		}
 
@@ -342,16 +400,10 @@ func (ipc *IPCache) upsertLocked(
 			return false, nil
 		}
 
-		// Here we track if an entry was created via new asynchronous
-		// UpsertMetadata API or the old synchronous Upsert call.
-		// If an entry is ever touched via the old Upsert API, we want to keep
-		// createdFromMetadata set to false, and require that the entry
-		// manually is deleted via the Delete function.
-		if !cachedIdentity.createdFromMetadata {
-			newIdentity.createdFromMetadata = false
-		}
-
 		oldIdentity = &cachedIdentity
+	} else if fromLegacyAPI {
+		// If this is a new entry, inserted via legacy API, then track it as such
+		newIdentity.modifiedByLegacyAPI = true
 	}
 
 	// Endpoint IP identities take precedence over CIDR identities, so if the

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -296,21 +296,43 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 				break
 			}
 
-			// We can safely skip the ipcache upsert if the entry matches with
-			// the entry in the metadata cache exactly.
-			// Note that checking ID alone is insufficient, see GH-24502.
-			if oldID.ID == newID.ID && prefixInfo.Source() == oldID.Source &&
-				oldTunnelIP.Equal(prefixInfo.TunnelPeer().IP()) &&
-				oldEncryptionKey == prefixInfo.EncryptKey().Uint8() {
-				goto releaseIdentity
+			var newOverwrittenLegacySource source.Source
+			if entryExists {
+				// If an entry already exists for this prefix, then we want to
+				// retain its source, if it has been modified by the legacy API.
+				// This allows us to restore the original source if we remove all
+				// metadata for the prefix
+				switch {
+				case oldID.exclusivelyOwnedByLegacyAPI():
+					// This is the first time we have associated metadata for a
+					// modifiedByLegacyAPI=true entry. Store the old (legacy) source:
+					newOverwrittenLegacySource = oldID.Source
+				case oldID.ownedByLegacyAndMetadataAPI():
+					// The entry has modifiedByLegacyAPI=true, but has already been
+					// updated at least once by the metadata API. Retain the legacy
+					// source as is.
+					newOverwrittenLegacySource = oldID.overwrittenLegacySource
+				}
+
+				// We can safely skip the ipcache upsert if the entry matches with
+				// the entry in the metadata cache exactly.
+				// Note that checking ID alone is insufficient, see GH-24502.
+				if oldID.ID == newID.ID && prefixInfo.Source() == oldID.Source &&
+					oldID.overwrittenLegacySource == newOverwrittenLegacySource &&
+					oldTunnelIP.Equal(prefixInfo.TunnelPeer().IP()) &&
+					oldEncryptionKey == prefixInfo.EncryptKey().Uint8() {
+					goto releaseIdentity
+				}
 			}
 
 			idsToAdd[newID.ID] = newID.Labels.LabelArray()
 			entriesToReplace[prefix] = ipcacheEntry{
 				identity: Identity{
-					ID:                  newID.ID,
-					Source:              prefixInfo.Source(),
-					createdFromMetadata: true,
+					ID:                      newID.ID,
+					Source:                  prefixInfo.Source(),
+					overwrittenLegacySource: newOverwrittenLegacySource,
+					// Note: `modifiedByLegacyAPI` and `shadowed` will be
+					// set by the upsert call itself
 				},
 				tunnelPeer: prefixInfo.TunnelPeer().IP(),
 				encryptKey: prefixInfo.EncryptKey().Uint8(),
@@ -333,14 +355,14 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 			// allocation from the prior InjectLabels() call by
 			// releasing the previous reference.
 			entry, entryToBeReplaced := entriesToReplace[prefix]
-			if !oldID.createdFromMetadata && entryToBeReplaced {
+			if oldID.exclusivelyOwnedByLegacyAPI() && entryToBeReplaced {
 				// If the previous ipcache entry for the prefix
 				// was not managed by this function, then the
 				// previous ipcache user to inject the IPCache
 				// entry retains its own reference to the
 				// Security Identity. Given that this function
-				// is going to assume responsibility for the
-				// IPCache entry now, this path must retain its
+				// is going to assume (non-exclusive) responsibility
+				// for the IPCache entry now, this path must retain its
 				// own reference to the Security Identity to
 				// ensure that if the other owner ever releases
 				// their reference, this reference stays live.
@@ -359,13 +381,40 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 			// subsystem using the old Upsert API, then we can safely remove
 			// the IPCache entry associated with this prefix.
 			if prefixInfo == nil {
-				if oldID.createdFromMetadata {
+				if oldID.exclusivelyOwnedByMetadataAPI() {
 					entriesToDelete[prefix] = oldID
-				} else {
+				} else if oldID.ownedByLegacyAndMetadataAPI() {
 					// If, on the other hand, this prefix *was* touched by
-					// another, Upsert-based system, flag this prefix as
-					// potentially eligible for deletion if all references
-					// are removed.
+					// another, Upsert-based system, then we want to restore
+					// the original (legacy) source. This ensures that the legacy
+					// Delete call (with the legacy source) will be able to remove
+					// it.
+					unmanagedEntry := ipcacheEntry{
+						identity: Identity{
+							ID:                  oldID.ID,
+							Source:              oldID.overwrittenLegacySource,
+							modifiedByLegacyAPI: true,
+						},
+						tunnelPeer: oldTunnelIP,
+						encryptKey: oldEncryptionKey,
+						force:      true, /* overwrittenLegacySource is lower precedence */
+					}
+					entriesToReplace[prefix] = unmanagedEntry
+
+					// In addition, flag this prefix as potentially eligible
+					// for deletion if all references are removed (i.e. the legacy
+					// Delete call already happened).
+					unmanagedPrefixes[prefix] = unmanagedEntry.identity
+
+					if option.Config.Debug {
+						log.WithFields(logrus.Fields{
+							logfields.Prefix:      prefix,
+							logfields.OldIdentity: oldID.ID,
+						}).Debug("Previously managed IPCache entry is now unmanaged")
+					}
+				} else if oldID.exclusivelyOwnedByLegacyAPI() {
+					// Even if we never actually overwrote the legacy-owned
+					// entry, we should still remove it if all references are removed.
 					unmanagedPrefixes[prefix] = oldID
 				}
 			}
@@ -410,6 +459,7 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 			meta,
 			entry.identity,
 			entry.force,
+			/* fromLegacyAPI */ false,
 		); err2 != nil {
 			// It's plausible to pull the same information twice
 			// from different sources, for instance in etcd mode

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -506,6 +506,209 @@ func TestInjectLegacySecond(t *testing.T) {
 	assert.Equal(t, wantID, id.ID)
 }
 
+// TestInjectWithLegacyAPIToUnmanaged tests that entries inserted by the
+// legacy API are correctly handled when metadata is added and removed via
+// the new API. It emulates the following sequence:
+//  1. AllocateCIDRs(p)  -- owned by legacy API
+//  2. UpsertPrefixes(p) -- shared ownership
+//  3. RemovePrefixes(p) -- owned by legacy API
+//  4. UpsertPrefixes(p) -- shared ownership again
+//  5. RemovePrefixes(p) -- owned by legacy API
+//  6. releaseCIDRs(p)   -- legacy entry needs to be removed
+func TestInjectWithLegacyAPIToUnmanaged(t *testing.T) {
+	cancel := setupTest(t)
+	defer cancel()
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	// mimic the "restore cidr" logic from daemon.go
+	// for every ip -> identity mapping in the bpf ipcache
+	// - allocate that identity
+	// - insert the cidr=>identity mapping back in to the go ipcache
+	identities := make(map[netip.Prefix]*identity.Identity)
+	prefix := netip.MustParsePrefix("172.19.0.5/32")
+	_, err := IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix}, identities)
+	assert.NoError(t, err)
+
+	IPIdentityCache.upsertGeneratedIdentities(identities, nil)
+
+	// sanity check: ensure the cidr is correctly in the ipcache
+	id, ok := IPIdentityCache.LookupByIP(prefix.String())
+	assert.True(t, ok)
+	assert.Equal(t, source.Generated, id.Source)
+
+	// Check refcount
+	realID := IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.Background(), id.ID)
+	assert.Equal(t, 1, realID.ReferenceCount)
+
+	// Simulate UpsertPrefixes
+	resource := types.NewResourceID(
+		types.ResourceKindCNP, "default", "policy")
+	labels := labels.GetCIDRLabels(prefix)
+	IPIdentityCache.metadata.upsertLocked(prefix, source.CustomResource, resource, labels)
+	_, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{prefix})
+	assert.NoError(t, err)
+
+	// Ensure the source is now correctly understood in the ipcache
+	id, ok = IPIdentityCache.LookupByIP(prefix.String())
+	assert.True(t, ok)
+	assert.Equal(t, source.CustomResource, id.Source)
+
+	realID = IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.Background(), id.ID)
+	assert.Equal(t, 2, realID.ReferenceCount)
+
+	// Simulate RemovePrefixes
+	IPIdentityCache.metadata.remove(prefix, resource, labels)
+	_, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{prefix})
+	assert.NoError(t, err)
+
+	// Ensure the entry has been downgraded to the legacy source
+	id, ok = IPIdentityCache.LookupByIP(prefix.String())
+	assert.True(t, ok)
+	assert.Equal(t, source.Generated, id.Source)
+
+	realID = IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.Background(), id.ID)
+	assert.Equal(t, 1, realID.ReferenceCount)
+
+	// UpsertPrefixes again. This asserts that even thought the entry was touched by
+	// metadata at some point, we still properly upgrade it again
+	IPIdentityCache.metadata.upsertLocked(prefix, source.CustomResource, resource, labels)
+	_, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{prefix})
+	assert.NoError(t, err)
+
+	id, ok = IPIdentityCache.LookupByIP(prefix.String())
+	assert.True(t, ok)
+	assert.Equal(t, source.CustomResource, id.Source)
+	realID = IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.Background(), id.ID)
+	assert.Equal(t, 2, realID.ReferenceCount)
+
+	// RemovePrefixes
+	IPIdentityCache.metadata.remove(prefix, resource, labels)
+	_, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{prefix})
+	assert.NoError(t, err)
+
+	id, ok = IPIdentityCache.LookupByIP(prefix.String())
+	assert.True(t, ok)
+	assert.Equal(t, source.Generated, id.Source)
+	realID = IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.Background(), id.ID)
+	assert.Equal(t, 1, realID.ReferenceCount)
+
+	// Assert that releaseCIDRs works
+	IPIdentityCache.releaseCIDRIdentities(context.Background(), []netip.Prefix{prefix})
+
+	// Assert that ipcache has released its final reference to the identity
+	realID = IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.Background(), id.ID)
+	assert.True(t, realID == nil)
+	_, ok = IPIdentityCache.LookupByIP(prefix.String())
+	assert.False(t, ok)
+}
+
+// TestInjectWithMetadataAPIBeforeLegacyUpsert tests that entries inserted by the
+// metadata API are correctly handled when a legacy caller also attempts to
+// upsert them via AllocateCIDRs/UpsertGeneratedIdentities
+//  1. UpsertPrefixes(p) -- owned by metadata API
+//  2. AllocateCIDRs(p)  -- co-owned by both APIs
+//  3. RemovePrefixes(p) -- owned by legacy API
+//  4. UpsertPrefixes(p) -- shared ownership again
+//  5. releaseCIDRs(p)   -- shared ownership (but only managed by metadata)
+//  6. RemovePrefixes(p) -- entry is removed
+func TestInjectWithLegacyAPIForExistingIdentities(t *testing.T) {
+	cancel := setupTest(t)
+	defer cancel()
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	// Simulate UpsertPrefixes
+	prefix := netip.MustParsePrefix("172.19.0.5/32")
+	resource := types.NewResourceID(
+		types.ResourceKindCNP, "default", "policy")
+	labels := labels.GetCIDRLabels(prefix)
+	IPIdentityCache.metadata.upsertLocked(prefix, source.CustomResource, resource, labels)
+	_, err := IPIdentityCache.InjectLabels(ctx, []netip.Prefix{prefix})
+	assert.NoError(t, err)
+
+	// Ensure the entry is in IPCache with refcount=1
+	id, ok := IPIdentityCache.LookupByIP(prefix.String())
+	assert.True(t, ok)
+	assert.Equal(t, source.CustomResource, id.Source)
+	realID := IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.Background(), id.ID)
+	assert.Equal(t, 1, realID.ReferenceCount)
+
+	// Simulate AllocateCIDRs/UpsertGeneratedIdentities (e.g. due to FQDN lookups)
+	prefix2 := netip.MustParsePrefix("172.19.0.6/32")
+	identities := make(map[netip.Prefix]*identity.Identity)
+	usedIdentities, err := IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix, prefix2}, identities)
+	assert.NoError(t, err)
+	assert.Len(t, usedIdentities, 2)
+	assert.Len(t, identities, 1)
+	IPIdentityCache.upsertGeneratedIdentities(identities, usedIdentities)
+
+	// Ensure the entry is in IPCache with still the correct source and refcount=2
+	id, ok = IPIdentityCache.LookupByIP(prefix.String())
+	assert.True(t, ok)
+	assert.Equal(t, source.CustomResource, id.Source)
+	realID = IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.Background(), id.ID)
+	assert.Equal(t, 2, realID.ReferenceCount)
+
+	// Ensure the other entry is also IPCache with the legacy source
+	id2, ok := IPIdentityCache.LookupByIP(prefix2.String())
+	assert.True(t, ok)
+	assert.Equal(t, source.Generated, id2.Source)
+	realID2 := IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.Background(), id2.ID)
+	assert.Equal(t, 1, realID2.ReferenceCount)
+
+	// Simulate RemovePrefixes
+	IPIdentityCache.metadata.remove(prefix, resource, labels)
+	_, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{prefix})
+	assert.NoError(t, err)
+
+	// Ensure the entry has been downgraded to the legacy source
+	id, ok = IPIdentityCache.LookupByIP(prefix.String())
+	assert.True(t, ok)
+	assert.Equal(t, source.Generated, id.Source)
+	realID = IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.Background(), id.ID)
+	assert.Equal(t, 1, realID.ReferenceCount)
+
+	// Shared ownership again
+	IPIdentityCache.metadata.upsertLocked(prefix, source.CustomResource, resource, labels)
+	_, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{prefix})
+	assert.NoError(t, err)
+
+	// Ensure the entry source and refcount are bumped again
+	id, ok = IPIdentityCache.LookupByIP(prefix.String())
+	assert.True(t, ok)
+	assert.Equal(t, source.CustomResource, id.Source)
+	realID = IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.Background(), id.ID)
+	assert.Equal(t, 2, realID.ReferenceCount)
+
+	// Assert that releaseCIDRs decreases refcount
+	IPIdentityCache.releaseCIDRIdentities(context.Background(), []netip.Prefix{prefix, prefix2})
+
+	// prefix should have only the metadata owner left
+	id, ok = IPIdentityCache.LookupByIP(prefix.String())
+	assert.True(t, ok)
+	assert.Equal(t, source.CustomResource, id.Source)
+	realID = IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.Background(), id.ID)
+	assert.Equal(t, 1, realID.ReferenceCount)
+
+	// prefix2 should be removed
+	realID2 = IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.Background(), id2.ID)
+	assert.Nil(t, realID2)
+	_, ok = IPIdentityCache.LookupByIP(prefix2.String())
+	assert.False(t, ok)
+
+	// Simulate RemovePrefixes
+	IPIdentityCache.metadata.remove(prefix, resource, labels)
+	_, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{prefix})
+	assert.NoError(t, err)
+
+	// Assert that IPCache released its final reference to the identity
+	realID = IPIdentityCache.IdentityAllocator.LookupIdentityByID(context.Background(), id.ID)
+	assert.Nil(t, realID)
+	_, ok = IPIdentityCache.LookupByIP(prefix.String())
+	assert.False(t, ok)
+}
+
 func TestFilterMetadataByLabels(t *testing.T) {
 	cancel := setupTest(t)
 	defer cancel()


### PR DESCRIPTION
This is a custom backport of https://github.com/cilium/cilium/pull/34715. It contains additional fixes and unit test that only apply to v1.15 only. In particular, v1.15 seems to have contained already a partial fix in `upsertGeneratedIdentities`, but this version now brings it on par with the new tracking system.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
34715
```
