### PR TITLE
helm: add client auth to hubble server certificate

### DIFF
--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
@@ -54,6 +54,7 @@ spec:
                   - signing
                   - key encipherment
                   - server auth
+                  - client auth
                   validity: {{ $certValidityStr }}
                 {{- if .Values.hubble.relay.enabled }}
                 - name: hubble-relay-client-certs


### PR DESCRIPTION
Before this patch, it was not possible to connect to the TCP Hubble server from within the Cilium Pod when Hubble mTLS was enabled (the default).

This patch adds client authentication to the Hubble's server TLS certificate, so that we can locally query the Hubble server on TCP using its own certificate for mTLS authentication. This can be used with the Hubble CLI with:

    kubectl exec -it -n kube-system ds/cilium -c cilium-agent -- \
        hubble observe --server localhost:4244 \
            --tls \
            --tls-ca-cert-files /var/lib/cilium/tls/hubble/client-ca.crt \
            --tls-client-cert-file /var/lib/cilium/tls/hubble/server.crt \
            --tls-client-key-file /var/lib/cilium/tls/hubble/server.key \
            --tls-server-name local.default.hubble-grpc.cilium.io

Before this patch, the above command would give the following error:

    failed to connect to 'localhost:4244': context deadline exceeded: connection error: desc = "error reading server preface: remote error: tls: bad certificate"