### PR TITLE
bpf/lib/icmpv6.h: cleanup hardcoded ICMPv6 types

### DIFF
--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -17,6 +17,7 @@
 #define ICMP6_ND_OPTS (sizeof(struct ipv6hdr) + sizeof(struct icmp6hdr) + sizeof(struct in6_addr))
 
 #define ICMP6_UNREACH_MSG_TYPE		1
+#define ICMP6_TIME_EXCEEDED_TYPE	3
 #define ICMP6_PARAM_ERR_MSG_TYPE	4
 #define ICMP6_ECHO_REQUEST_MSG_TYPE	128
 #define ICMP6_ECHO_REPLY_MSG_TYPE	129
@@ -109,7 +110,7 @@ send_icmp6_ndisc_adv(struct __ctx_buff *ctx, int nh_off,
 		return DROP_INVALID;
 
 	/* fill icmp6hdr */
-	icmp6hdr.icmp6_type = 136;
+	icmp6hdr.icmp6_type = ICMP6_NA_MSG_TYPE;
 	icmp6hdr.icmp6_code = 0;
 	icmp6hdr.icmp6_cksum = icmp6hdr_old.icmp6_cksum;
 	icmp6hdr.icmp6_dataun.un_data32[0] = 0;
@@ -191,7 +192,7 @@ static __always_inline int __icmp6_send_time_exceeded(struct __ctx_buff *ctx,
 	upper = (data + 48);
 
 	/* fill icmp6hdr */
-	icmp6hoplim->icmp6_type = 3;
+	icmp6hoplim->icmp6_type = ICMP6_TIME_EXCEEDED_TYPE;
 	icmp6hoplim->icmp6_code = 0;
 	icmp6hoplim->icmp6_cksum = 0;
 	icmp6hoplim->icmp6_dataun.un_data32[0] = 0;


### PR DESCRIPTION
Cleanup hardcoded ICMPv6 values. Add missing `ICMP6_TIME_EXCEEDED_TYPE` definition.