### PR TITLE
Add flag for enabling CiliumNodeConfig

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1020,6 +1020,10 @@
      - Enable CiliumEndpointSlice feature (deprecated, please use ``ciliumEndpointSlice.enabled`` instead).
      - bool
      - ``false``
+   * - :spelling:ignore:`enableCiliumNodeConfig`
+     - Enable config by CiliumNodeConfig objects
+     - bool
+     - ``true``
    * - :spelling:ignore:`enableCriticalPriorityClass`
      - Explicitly enable or disable priority class. .Capabilities.KubeVersion is unsettable in ``helm template`` calls, it depends on k8s libraries version that Helm was compiled against. This option allows to explicitly disable setting the priority class, which is useful for rendering charts for gke clusters in advance.
      - bool

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1151,6 +1151,10 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableInternalTrafficPolicy, defaults.EnableInternalTrafficPolicy, "Enable internal traffic policy")
 	option.BindEnv(vp, option.EnableInternalTrafficPolicy)
 
+	flags.Bool(option.EnableCiliumNodeConfig, defaults.EnableCiliumNodeConfig, "Enable configuring daemon by CiliumNodeConfig CRD")
+	flags.MarkHidden(option.EnableCiliumNodeConfig)
+	option.BindEnv(vp, option.EnableCiliumNodeConfig)
+
 	if err := vp.BindPFlags(flags); err != nil {
 		log.Fatalf("BindPFlags failed: %s", err)
 	}

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -305,6 +305,7 @@ contributors across the globe, there is almost always someone available to help.
 | egressGateway.enabled | bool | `false` | Enables egress gateway to redirect and SNAT the traffic that leaves the cluster. |
 | egressGateway.reconciliationTriggerInterval | string | `"1s"` | Time between triggers of egress gateway state reconciliations |
 | enableCiliumEndpointSlice | bool | `false` | Enable CiliumEndpointSlice feature (deprecated, please use `ciliumEndpointSlice.enabled` instead). |
+| enableCiliumNodeConfig | bool | `true` | Enable config by CiliumNodeConfig objects |
 | enableCriticalPriorityClass | bool | `true` | Explicitly enable or disable priority class. .Capabilities.KubeVersion is unsettable in `helm template` calls, it depends on k8s libraries version that Helm was compiled against. This option allows to explicitly disable setting the priority class, which is useful for rendering charts for gke clusters in advance. |
 | enableIPv4BIGTCP | bool | `false` | Enables IPv4 BIG TCP support which increases maximum IPv4 GSO/GRO limits for nodes and pods |
 | enableIPv4Masquerade | bool | `true` | Enables masquerading of IPv4 traffic leaving the node from endpoints. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -434,9 +434,22 @@ spec:
         command:
         - cilium-dbg
         - build-config
+        {{- if not .Values.enableCiliumNodeConfig }} # cnc not enabled
+        {{- if or (kindIs "invalid" .Values.daemon.configSources) }} # sources not specified
+        - "--source=config-map:cilium-config" # default configmap
+        {{ else }}
+        {{- $sourceStripped := .Values.daemon.configSources | replace ",cilium-node-config" "" | replace "cilium-node-config," "" | replace "cilium-node-config" ""  }}
+        {{- if eq (len $sourceStripped) 0 }} # sources had only cilium-node-config, default to configmap
+        - "--source=config-map:cilium-config"
+        {{- else }} # sources stripped from cilium-node-config
+        - "--source={{ $sourceStripped }}"
+        {{- end }}
+        {{- end }}
+        {{- else }}
         {{- if (not (kindIs "invalid" .Values.daemon.configSources)) }}
         - "--source={{.Values.daemon.configSources}}"
         {{- end }}
+        {{- end}}
         {{- if (not (kindIs "invalid" .Values.daemon.allowedConfigOverrides)) }}
         - "--allow-config-keys={{.Values.daemon.allowedConfigOverrides}}"
         {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1337,6 +1337,8 @@ data:
   nat-map-stats-interval: {{ .Values.nat.mapStatsInterval | quote }}
   enable-internal-traffic-policy: {{ .Values.enableInternalTrafficPolicy | quote }}
 
+  enable-ciliumnodeconfig: {{ .Values.enableCiliumNodeConfig | quote }}
+
 # Extra config allows adding arbitrary properties to the cilium config.
 # By putting it at the end of the ConfigMap, it's also possible to override existing properties.
 {{- if .Values.extraConfig }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1605,6 +1605,9 @@
     "enableCiliumEndpointSlice": {
       "type": "boolean"
     },
+    "enableCiliumNodeConfig": {
+      "type": "boolean"
+    },
     "enableCriticalPriorityClass": {
       "type": "boolean"
     },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3631,3 +3631,5 @@ authentication:
       connectionTimeout: 30s
 # -- Enable Internal Traffic Policy
 enableInternalTrafficPolicy: true
+# -- Enable config by CiliumNodeConfig objects
+enableCiliumNodeConfig: true

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3653,3 +3653,5 @@ authentication:
       connectionTimeout: 30s
 # -- Enable Internal Traffic Policy
 enableInternalTrafficPolicy: true
+# -- Enable config by CiliumNodeConfig objects
+enableCiliumNodeConfig: true

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -601,6 +601,9 @@ const (
 
 	// EnableIternalTrafficPolicy is the default value for option.EnableInternalTrafficPolicy
 	EnableInternalTrafficPolicy = true
+
+	// EnableCiliumNodeConfig enables configuring daemon by CiliumNodeConfig CRD
+	EnableCiliumNodeConfig = true
 )
 
 var (

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1314,6 +1314,9 @@ const (
 
 	// EnableExternalWorkloads enables the support for external workloads.
 	EnableExternalWorkloads = "enable-external-workloads"
+
+	// EnableCiliumNodeConfig enables configuring daemon by CiliumNodeConfig CRD
+	EnableCiliumNodeConfig = "enable-ciliumnodeconfig"
 )
 
 const (
@@ -2492,6 +2495,9 @@ type DaemonConfig struct {
 
 	// EnableInternalTrafficPolicy enables handling routing for services with internalTrafficPolicy configured
 	EnableInternalTrafficPolicy bool
+
+	// EnableCiliumNodeConfig enables configuring daemon by CiliumNodeConfig CRD
+	EnableCiliumNodeConfig bool
 }
 
 var (
@@ -2548,6 +2554,8 @@ var (
 		BPFConntrackAccountingEnabled: defaults.BPFConntrackAccountingEnabled,
 		EnableEnvoyConfig:             defaults.EnableEnvoyConfig,
 		EnableInternalTrafficPolicy:   defaults.EnableInternalTrafficPolicy,
+
+		EnableCiliumNodeConfig: defaults.EnableCiliumNodeConfig,
 	}
 )
 


### PR DESCRIPTION
This change adds flag that allows configuring Cilium installation to use or not use CiliumNodeConfig.