### PR TITLE
cilium-cli: remove copying of loop variables

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -861,7 +861,6 @@ func (ct *ConnectivityTest) getNodes(ctx context.Context) error {
 	}
 
 	for _, node := range nodeList.Items {
-		node := node
 		if canNodeRunCilium(&node) {
 			if isControlPlane(&node) {
 				ct.controlPlaneNodes[node.ObjectMeta.Name] = node.DeepCopy()

--- a/cilium-cli/connectivity/tests/client.go
+++ b/cilium-cli/connectivity/tests/client.go
@@ -29,16 +29,12 @@ func (s *clientToClient) Run(ctx context.Context, t *check.Test) {
 	ct := t.Context()
 
 	for _, src := range ct.ClientPods() {
-		src := src // copy to avoid memory aliasing when using reference
-
 		for _, dst := range ct.ClientPods() {
 			if src.Pod.Status.PodIP == dst.Pod.Status.PodIP {
 				// Currently we only get flows once per IP,
 				// skip pings to self.
 				continue
 			}
-
-			dst := dst // copy to avoid memory aliasing when using reference
 
 			t.ForEachIPFamily(func(ipFam features.IPFamily) {
 				t.NewAction(s, fmt.Sprintf("ping-%s-%d", ipFam, i), &src, &dst, ipFam).Run(func(a *check.Action) {

--- a/cilium-cli/connectivity/tests/egressgateway.go
+++ b/cilium-cli/connectivity/tests/egressgateway.go
@@ -206,11 +206,7 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 	// Ping hosts (pod to host connectivity). Should not get masqueraded with egress IP
 	i := 0
 	for _, client := range ct.ClientPods() {
-		client := client
-
 		for _, dst := range ct.HostNetNSPodsByNode() {
-			dst := dst
-
 			t.NewAction(s, fmt.Sprintf("ping-%d", i), &client, &dst, features.IPFamilyV4).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, ct.PingCommand(dst, features.IPFamilyV4))
 			})
@@ -221,8 +217,6 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 	// DNS query (pod to service connectivity). Should not get masqueraded with egress IP
 	i = 0
 	for _, client := range ct.ClientPods() {
-		client := client
-
 		kubeDNSService, err := ct.K8sClient().GetService(ctx, "kube-system", "kube-dns", metav1.GetOptions{})
 		if err != nil {
 			t.Fatal("Cannot get kube-dns service")
@@ -238,8 +232,6 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 	// Traffic matching an egress gateway policy should leave the cluster masqueraded with the egress IP (pod to external service using DNS)
 	i = 0
 	for _, client := range ct.ClientPods() {
-		client := client
-
 		for _, externalEchoSvc := range ct.EchoExternalServices() {
 			externalEcho := externalEchoSvc.ToEchoIPService()
 
@@ -258,8 +250,6 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 	// Traffic matching an egress gateway policy should leave the cluster masqueraded with the egress IP (pod to external service)
 	i = 0
 	for _, client := range ct.ClientPods() {
-		client := client
-
 		for _, externalEcho := range ct.ExternalEchoPods() {
 			externalEcho := externalEcho.ToEchoIPPod()
 
@@ -279,8 +269,6 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 	// the reply traffic should not be SNATed with the egress IP
 	i = 0
 	for _, client := range ct.ExternalEchoPods() {
-		client := client
-
 		for _, node := range ct.Nodes() {
 			for _, echo := range ct.EchoServices() {
 				// convert the service to a ServiceExternalIP as we want to access it through its external IP
@@ -304,8 +292,6 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 		// running (while in tunneling mode we would need the external node to send the traffic over the tunnel)
 		i = 0
 		for _, client := range ct.ExternalEchoPods() {
-			client := client
-
 			for _, echo := range ct.EchoPods() {
 				t.NewAction(s, fmt.Sprintf("curl-echo-pod-%d", i), &client, echo, features.IPFamilyV4).Run(func(a *check.Action) {
 					a.ExecInPod(ctx, ct.CurlCommand(echo, features.IPFamilyV4))
@@ -391,8 +377,6 @@ func (s *egressGatewayExcludedCIDRs) Run(ctx context.Context, t *check.Test) {
 	// node IP where the pod is running rather than with the egress IP(pod to external service)
 	i := 0
 	for _, client := range ct.ClientPods() {
-		client := client
-
 		for _, externalEcho := range ct.ExternalEchoPods() {
 			externalEcho := externalEcho.ToEchoIPPod()
 

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -140,7 +140,6 @@ func (n *noUnexpectedPacketDrops) Run(ctx context.Context, t *check.Test) {
 	}
 
 	for _, pod := range ct.CiliumPods() {
-		pod := pod
 		t.NewGenericAction(n, fmt.Sprintf("%s/%s", pod.K8sClient.ClusterName(), pod.NodeName())).Run(func(a *check.Action) {
 			stdout, err := pod.K8sClient.ExecInPod(ctx, pod.Pod.Namespace, pod.Pod.Name, defaults.AgentContainerName, cmd)
 			if err != nil {
@@ -180,7 +179,6 @@ func (n *noErrorsInLogs) allCiliumPods(ctx context.Context, ct *check.Connectivi
 
 		cluster := client.ClusterName()
 		for _, pod := range pods.Items {
-			pod := pod
 			output[podID{Cluster: cluster, Namespace: pod.Namespace, Name: pod.Name}] = podInfo{
 				client: client, containers: n.podContainers(&pod),
 			}

--- a/cilium-cli/connectivity/tests/externalworkload.go
+++ b/cilium-cli/connectivity/tests/externalworkload.go
@@ -26,8 +26,6 @@ func (s *podToExternalWorkload) Run(ctx context.Context, t *check.Test) {
 	ct := t.Context()
 
 	for _, pod := range ct.ClientPods() {
-		pod := pod // copy to avoid memory aliasing when using reference
-
 		for _, wl := range ct.ExternalWorkloads() {
 			t.NewAction(s, fmt.Sprintf("ping-%d", i), &pod, wl, features.IPFamilyV4).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, ct.PingCommand(wl, features.IPFamilyV4))

--- a/cilium-cli/connectivity/tests/health.go
+++ b/cilium-cli/connectivity/tests/health.go
@@ -32,7 +32,6 @@ func (s *ciliumHealth) Name() string {
 
 func (s *ciliumHealth) Run(ctx context.Context, t *check.Test) {
 	for name, pod := range t.Context().CiliumPods() {
-		pod := pod
 		t.NewGenericAction(s, name).Run(func(_ *check.Action) {
 			runHealthProbe(ctx, t, &pod)
 		})

--- a/cilium-cli/connectivity/tests/host.go
+++ b/cilium-cli/connectivity/tests/host.go
@@ -33,11 +33,7 @@ func (s *podToHost) Run(ctx context.Context, t *check.Test) {
 	var addrType string
 
 	for _, pod := range ct.ClientPods() {
-		pod := pod // copy to avoid memory aliasing when using reference
-
 		for _, node := range ct.Nodes() {
-			node := node // copy to avoid memory aliasing when using reference
-
 			t.ForEachIPFamily(func(ipFam features.IPFamily) {
 				for _, addr := range node.Status.Addresses {
 					if features.GetIPFamily(addr.Address) != ipFam {
@@ -87,7 +83,6 @@ func (s *podToControlPlaneHost) Name() string {
 func (s *podToControlPlaneHost) Run(ctx context.Context, t *check.Test) {
 	ct := t.Context()
 	for _, pod := range ct.ControlPlaneClientPods() {
-		pod := pod
 		for _, node := range ct.ControlPlaneNodes() {
 			t.ForEachIPFamily(func(ipFam features.IPFamily) {
 				for _, addr := range node.Status.Addresses {
@@ -136,11 +131,7 @@ func (s *podToHostPort) Run(ctx context.Context, t *check.Test) {
 	ct := t.Context()
 
 	for _, client := range ct.ClientPods() {
-		client := client // copy to avoid memory aliasing when using reference
-
 		for _, echo := range ct.EchoPods() {
-			echo := echo // copy to avoid memory aliasing when using reference
-
 			baseURL := fmt.Sprintf("%s://%s:%d%s", echo.Scheme(), echo.Pod.Status.HostIP, ct.Params().EchoServerHostPort, echo.Path())
 			ep := check.HTTPEndpoint(echo.Name(), baseURL)
 			t.NewAction(s, fmt.Sprintf("curl-%d", i), &client, ep, features.IPFamilyAny).Run(func(a *check.Action) {
@@ -181,7 +172,6 @@ func (s *hostToPod) Run(ctx context.Context, t *check.Test) {
 			continue
 		}
 
-		src := src // copy to avoid memory aliasing when using reference
 		for _, dst := range ct.EchoPods() {
 			t.ForEachIPFamily(func(ipFam features.IPFamily) {
 				t.NewAction(s, fmt.Sprintf("curl-%s-%d", ipFam, i), &src, dst, ipFam).Run(func(a *check.Action) {

--- a/cilium-cli/connectivity/tests/ipsec_xfrm.go
+++ b/cilium-cli/connectivity/tests/ipsec_xfrm.go
@@ -69,7 +69,6 @@ func (n *noIPsecXfrmErrors) collectXfrmErrors(ctx context.Context, t *check.Test
 	cmd := []string{"cilium", "metrics", "list", "-ojson", "-pcilium_ipsec_xfrm_error"}
 
 	for _, pod := range ct.CiliumPods() {
-		pod := pod
 		encryptStatus, err := pod.K8sClient.ExecInPod(ctx, pod.Pod.Namespace, pod.Pod.Name, defaults.AgentContainerName, cmd)
 		if err != nil {
 			t.Fatalf("Unable to get cilium ipsec xfrm error metrics: %s", err)

--- a/cilium-cli/connectivity/tests/k8s.go
+++ b/cilium-cli/connectivity/tests/k8s.go
@@ -28,7 +28,6 @@ func (s *podToK8sLocal) Run(ctx context.Context, t *check.Test) {
 	ct := t.Context()
 	k8sSvc := ct.K8sService()
 	for _, pod := range ct.ControlPlaneClientPods() {
-		pod := pod // copy to avoid memory aliasing when using reference
 		t.NewAction(s, fmt.Sprintf("curl-k8s-from-pod-%s", pod.Name()), &pod, k8sSvc, features.IPFamilyAny).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, ct.CurlCommand(k8sSvc, features.IPFamilyAny))
 			a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{

--- a/cilium-cli/connectivity/tests/lrp.go
+++ b/cilium-cli/connectivity/tests/lrp.go
@@ -74,11 +74,7 @@ func (s lrp) Run(ctx context.Context, t *check.Test) {
 	// Tests client pods to LRP frontend connectivity: traffic gets redirected
 	// to the LRP backends.
 	for _, pod := range t.Context().LrpClientPods() {
-		pod := pod
-
 		for _, policy := range policies {
-			policy := policy
-
 			if policy.Spec.SkipRedirectFromBackend != s.skipRedirectFromBackend {
 				continue
 			}
@@ -95,11 +91,7 @@ func (s lrp) Run(ctx context.Context, t *check.Test) {
 	// Tests LRP backend pods to LRP frontend connectivity: traffic gets redirected
 	// based on the configured skipRedirectFromBackend flag.
 	for _, pod := range t.Context().LrpBackendPods() {
-		pod := pod
-
 		for _, policy := range policies {
-			policy := policy
-
 			if policy.Spec.SkipRedirectFromBackend != s.skipRedirectFromBackend {
 				continue
 			}
@@ -213,8 +205,6 @@ func (s lrpWithNodeDNS) Run(ctx context.Context, t *check.Test) {
 
 	i := 0
 	for _, client := range ct.ClientPods() {
-		client := client
-
 		for _, externalEchoSvc := range ct.EchoExternalServices() {
 			externalEcho := externalEchoSvc.ToEchoIPService()
 

--- a/cilium-cli/connectivity/tests/pod.go
+++ b/cilium-cli/connectivity/tests/pod.go
@@ -50,7 +50,6 @@ func (s *podToPod) Run(ctx context.Context, t *check.Test) {
 	ct := t.Context()
 
 	for _, client := range ct.ClientPods() {
-		client := client // copy to avoid memory aliasing when using reference
 		if !hasAllLabels(client, s.sourceLabels) {
 			continue
 		}
@@ -109,7 +108,6 @@ func (s *podToPodWithEndpoints) Run(ctx context.Context, t *check.Test) {
 	ct := t.Context()
 
 	for _, client := range ct.ClientPods() {
-		client := client // copy to avoid memory aliasing when using reference
 		if !hasAllLabels(client, s.sourceLabels) {
 			continue
 		}

--- a/cilium-cli/connectivity/tests/service.go
+++ b/cilium-cli/connectivity/tests/service.go
@@ -43,7 +43,6 @@ func (s *podToService) Run(ctx context.Context, t *check.Test) {
 	ct := t.Context()
 
 	for _, pod := range ct.ClientPods() {
-		pod := pod // copy to avoid memory aliasing when using reference
 		if !hasAllLabels(pod, s.sourceLabels) {
 			continue
 		}
@@ -96,7 +95,6 @@ func (s *podToIngress) Run(ctx context.Context, t *check.Test) {
 	ct := t.Context()
 
 	for _, pod := range ct.ClientPods() {
-		pod := pod // copy to avoid memory aliasing when using reference
 		if !hasAllLabels(pod, s.sourceLabels) {
 			continue
 		}
@@ -135,11 +133,8 @@ func (s *podToRemoteNodePort) Run(ctx context.Context, t *check.Test) {
 	var i int
 
 	for _, pod := range t.Context().ClientPods() {
-		pod := pod // copy to avoid memory aliasing when using reference
-
 		for _, svc := range t.Context().EchoServices() {
 			for _, node := range t.Context().Nodes() {
-				node := node // copy to avoid memory aliasing when using reference
 				remote := true
 				for _, addr := range node.Status.Addresses {
 					if pod.Pod.Status.HostIP == addr.Address {
@@ -179,12 +174,8 @@ func (s *podToLocalNodePort) Run(ctx context.Context, t *check.Test) {
 	var i int
 
 	for _, pod := range t.Context().ClientPods() {
-		pod := pod // copy to avoid memory aliasing when using reference
-
 		for _, svc := range t.Context().EchoServices() {
 			for _, node := range t.Context().Nodes() {
-				node := node // copy to avoid memory aliasing when using reference
-
 				for _, addr := range node.Status.Addresses {
 					if pod.Pod.Status.HostIP == addr.Address {
 						// If src and dst pod are running on the same node,
@@ -290,8 +281,6 @@ func (s *outsideToNodePort) Run(ctx context.Context, t *check.Test) {
 
 	for _, svc := range t.Context().EchoServices() {
 		for _, node := range t.Context().Nodes() {
-			node := node // copy to avoid memory aliasing when using reference
-
 			curlNodePort(ctx, s, t, fmt.Sprintf("curl-%d", i), &clientPod, svc, node, validateFlows, t.Context().Params().SecondaryNetworkIface != "")
 			i++
 		}
@@ -317,7 +306,6 @@ func (s *outsideToIngressService) Run(ctx context.Context, t *check.Test) {
 	for _, svc := range t.Context().IngressService() {
 		t.NewAction(s, fmt.Sprintf("curl-ingress-service-%d", i), &clientPod, svc, features.IPFamilyAny).Run(func(a *check.Action) {
 			for _, node := range t.Context().Nodes() {
-				node := node
 				a.ExecInPod(ctx, t.Context().CurlCommand(svc.ToNodeportService(node), features.IPFamilyAny))
 
 				a.ValidateFlows(ctx, clientPod, a.GetEgressRequirements(check.FlowParameters{

--- a/cilium-cli/connectivity/tests/to-cidr.go
+++ b/cilium-cli/connectivity/tests/to-cidr.go
@@ -39,8 +39,6 @@ func (s *podToCIDR) Run(ctx context.Context, t *check.Test) {
 
 		var i int
 		for _, src := range ct.ClientPods() {
-			src := src // copy to avoid memory aliasing when using reference
-
 			t.NewAction(s, fmt.Sprintf("%s-%d", ep.Name(), i), &src, ep, features.IPFamilyAny).Run(func(a *check.Action) {
 				opts := s.rc.CurlOptions(ep, features.IPFamilyAny, src, ct.Params())
 				a.ExecInPod(ctx, ct.CurlCommand(ep, features.IPFamilyAny, opts...))

--- a/cilium-cli/connectivity/tests/world.go
+++ b/cilium-cli/connectivity/tests/world.go
@@ -45,8 +45,6 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 	ct := t.Context()
 
 	for _, client := range ct.ClientPods() {
-		client := client // copy to avoid memory aliasing when using reference
-
 		// With http, over port 80.
 		httpOpts := s.rc.CurlOptions(http, features.IPFamilyAny, client, ct.Params())
 		t.NewAction(s, fmt.Sprintf("http-to-%s-%d", extTarget, i), &client, http, features.IPFamilyAny).Run(func(a *check.Action) {
@@ -97,8 +95,6 @@ func (s *podToWorld2) Run(ctx context.Context, t *check.Test) {
 	ct := t.Context()
 
 	for _, client := range ct.ClientPods() {
-		client := client // copy to avoid memory aliasing when using reference
-
 		// With https, over port 443.
 		t.NewAction(s, fmt.Sprintf("https-cilium-io-%d", i), &client, https, features.IPFamilyAny).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, ct.CurlCommand(https, features.IPFamilyAny))
@@ -151,8 +147,6 @@ func (s *podToWorldWithTLSIntercept) Run(ctx context.Context, t *check.Test) {
 	}
 
 	for _, client := range ct.ClientPods() {
-		client := client // copy to avoid memory aliasing when using reference
-
 		// With https, over port 443.
 		t.NewAction(s, fmt.Sprintf("https-to-%s-%d", extTarget, i), &client, https, features.IPFamilyAny).Run(func(a *check.Action) {
 			a.WriteDataToPod(ctx, "/tmp/test-ca.crt", caBundle)

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -2900,7 +2900,6 @@ func (c *Collector) submitClusterMeshAPIServerDbgTasks(pods *corev1.PodList) err
 	}
 
 	for _, pod := range pods.Items {
-		pod := pod
 		for _, task := range tasks {
 			if !podIsRunningAndHasContainer(&pod, task.container) {
 				continue


### PR DESCRIPTION
Since Go 1.22, for loop iteration variables have per-iteration scope, so
copying them is no longer necessary.

See https://go.dev/doc/go1.22#language and
https://go.dev/blog/loopvar-preview for details.

---

Note that I've dropped the changes which were the initial motivation for the PR due to an invalid assumption, see https://github.com/cilium/cilium/pull/34944#pullrequestreview-2312903491. The remaining commit was done as a cleanup and can be applied regardless.