### PR TITLE
helm: set key usages for hubble certificates with cert-manager

### DIFF
--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/metrics-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/metrics-server-secret.yaml
@@ -29,4 +29,9 @@ spec:
   duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
   privateKey:
     rotationPolicy: Always
+  isCA: false
+  usages:
+    - signing
+    - key encipherment
+    - server auth
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
@@ -19,4 +19,9 @@ spec:
   duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
   privateKey:
     rotationPolicy: Always
+  isCA: false
+  usages:
+    - signing
+    - key encipherment
+    - client auth
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
@@ -28,4 +28,9 @@ spec:
   duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
   privateKey:
     rotationPolicy: Always
+  isCA: false
+  usages:
+    - signing
+    - key encipherment
+    - server auth
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
@@ -29,4 +29,10 @@ spec:
   duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
   privateKey:
     rotationPolicy: Always
+  isCA: false
+  usages:
+    - signing
+    - key encipherment
+    - server auth
+    - client auth
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
@@ -19,4 +19,9 @@ spec:
   duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
   privateKey:
     rotationPolicy: Always
+  isCA: false
+  usages:
+    - signing
+    - key encipherment
+    - client auth
 {{- end }}


### PR DESCRIPTION
<del>_Marking as draft waiting on https://github.com/cilium/cilium/pull/34934 to be merged._</del>

Copied the usages from the certgen (aka tls-cronjob).