### PR TITLE
ci: fix build-images-base to not die in forks

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -40,9 +40,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  has-credentials:
+    name: Check for Quay secrets
+    runs-on: ubuntu-22.04
+    timeout-minutes: 2
+    outputs:
+      present: ${{ steps.secrets.outputs.present }}
+    steps:
+      - name: Check for secrets
+        id: secrets
+        env:
+          has_credentials: ${{ secrets.QUAY_BASE_RELEASE_USERNAME && secrets.QUAY_BASE_RELEASE_PASSWORD && 1 }}
+        if: ${{ env.has_credentials }}
+        run:
+          echo 'present=1' >> "$GITHUB_OUTPUT"
+
   build-and-push:
-    # Skip this workflow for branches that are created by renovate and event type is pull_request_target
-    if: ${{ ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
+    needs: has-credentials
+    # Skip this workflow for repositories without credentials and branches that are created by renovate where the event type is pull_request_target
+    if: ${{ needs.has-credentials.outputs.present && ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
     name: Build and Push Images
     timeout-minutes: 45
     environment: ${{ inputs.environment || 'release-base-images' }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Forks will not necessarily have secrets.QUAY_BASE_RELEASE_USERNAME & secrets.QUAY_BASE_RELEASE_PASSWORD.

The best outcome is to not run a job when the secrets are not set.

Fixes: #34949
