### PR TITLE
lrp: define ENABLE_LOCAL_REDIRECT_POLICY regardless of socketLB setting

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -190,6 +190,8 @@ jobs:
             tunnel: 'geneve'
             endpoint-routes: 'true'
             misc: 'socketLB.enabled=false,nodePort.enabled=true,bpf.masquerade=true'
+            local-redirect-policy: 'true'
+            node-local-dns: 'true'
 
           - name: '9'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -213,6 +215,9 @@ jobs:
             tunnel: 'disabled'
             encryption: 'wireguard'
             encryption-node: 'false'
+            misc: 'socketLB.enabled=true'
+            local-redirect-policy: 'true'
+            node-local-dns: 'true'
 
           - name: '11'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -227,6 +232,9 @@ jobs:
             lb-mode: 'snat'
             egress-gateway: 'true'
             ingress-controller: 'true'
+            misc: 'socketLB.hostNamespaceOnly=true'
+            local-redirect-policy: 'true'
+            node-local-dns: 'true'
 
           - name: '12'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind

--- a/cilium-cli/connectivity/builder/local_redirect_policy_with_nodedns.go
+++ b/cilium-cli/connectivity/builder/local_redirect_policy_with_nodedns.go
@@ -24,7 +24,6 @@ func (t localRedirectPolicyWithNodeDNS) build(ct *check.ConnectivityTest, templa
 			features.RequireEnabled(features.NodeLocalDNS),
 			features.RequireEnabled(features.NodeWithoutCilium),
 			features.RequireEnabled(features.LocalRedirectPolicy),
-			features.RequireEnabled(features.KPRSocketLB),
 		).
 		WithScenarios(
 			tests.LRPWithNodeDNS(),

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -165,6 +165,7 @@ func (ct *ConnectivityTest) extractFeaturesFromCiliumStatus(ctx context.Context,
 			}
 			if f.SocketLB != nil {
 				result[features.KPRSocketLB] = features.Status{Enabled: f.SocketLB.Enabled}
+				result[features.KPRSocketLBHostnsOnly] = features.Status{Enabled: f.BpfSocketLBHostnsOnly}
 			}
 		}
 	}

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -30,6 +30,7 @@ const (
 	KPRGracefulTermination Feature = "kpr-graceful-termination"
 	KPRHostPort            Feature = "kpr-hostport"
 	KPRSocketLB            Feature = "kpr-socket-lb"
+	KPRSocketLBHostnsOnly  Feature = "kpr-socket-lb-hostns-only"
 	KPRNodePort            Feature = "kpr-nodeport"
 	KPRSessionAffinity     Feature = "kpr-session-affinity"
 

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -389,10 +389,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 			// always runs with "hostNetwork: true".
 			cDefinesMap["HOST_NETNS_COOKIE"] = fmt.Sprintf("%d", cookie)
 		}
+	}
 
-		if option.Config.EnableLocalRedirectPolicy {
-			cDefinesMap["ENABLE_LOCAL_REDIRECT_POLICY"] = "1"
-		}
+	if option.Config.EnableLocalRedirectPolicy {
+		cDefinesMap["ENABLE_LOCAL_REDIRECT_POLICY"] = "1"
 	}
 
 	cDefinesMap["NAT_46X64_PREFIX_0"] = "0"


### PR DESCRIPTION
LRP works with either SocketLB or the per-packet LB. So let the agent define ENABLE_LOCAL_REDIRECT_POLICY  regardless of socketLB setting.

