### PR TITLE
.github: install ccache dependency prior to building.

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -50,6 +50,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+
+      - name: Install LLVM and Clang prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ccache
+
       # Load CCache build from GitHub
       - name: Load ccache cache build from GitHub
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2


### PR DESCRIPTION
lint: build-all-commits seems to be failing due to a missing dependency for ccache. This installs that via apt prior to running the linter.
