### PR TITLE
envoy: Bump envoy version from v1.30.4 to v1.30.6

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1247,7 +1247,7 @@
    * - :spelling:ignore:`envoy.image`
      - Envoy container image.
      - object
-     - ``{"digest":"sha256:f9c2a725a702d9fe4a4e038588a79e72955cf46c789914f940d906d65e92527e","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.30.4-1725856146-ae435a5bef3856f4de98fa360ecfa6a0f5b0f7a1","useDigest":true}``
+     - ``{"digest":"sha256:ca4a8d3c411837fb31915c14ed042f3e4313c5ce7f7f36d88480cd2f441e1b63","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.30.6-1726787755-2fbff8d20cec587edce5373642c6ffac216770d3","useDigest":true}``
    * - :spelling:ignore:`envoy.livenessProbe.failureThreshold`
      - failure threshold of liveness probe
      - int

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:7663c4c7dfb8db93fc5b71eb8
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-ARG CILIUM_ENVOY_IMAGE=quay.io/cilium/cilium-envoy:v1.30.4-1725856146-ae435a5bef3856f4de98fa360ecfa6a0f5b0f7a1@sha256:f9c2a725a702d9fe4a4e038588a79e72955cf46c789914f940d906d65e92527e
+ARG CILIUM_ENVOY_IMAGE=quay.io/cilium/cilium-envoy:v1.30.6-1726787755-2fbff8d20cec587edce5373642c6ffac216770d3@sha256:ca4a8d3c411837fb31915c14ed042f3e4313c5ce7f7f36d88480cd2f441e1b63
 
 FROM ${CILIUM_ENVOY_IMAGE} AS cilium-envoy
 

--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -37,8 +37,8 @@ export CILIUM_NODEINIT_DIGEST:=sha256:8d7b41c4ca45860254b3c19e20210462ef89479bb6
 
 # renovate: datasource=docker
 export CILIUM_ENVOY_REPO:=quay.io/cilium/cilium-envoy
-export CILIUM_ENVOY_VERSION:=v1.30.4-1725856146-ae435a5bef3856f4de98fa360ecfa6a0f5b0f7a1
-export CILIUM_ENVOY_DIGEST:=sha256:f9c2a725a702d9fe4a4e038588a79e72955cf46c789914f940d906d65e92527e
+export CILIUM_ENVOY_VERSION:=v1.30.6-1726787755-2fbff8d20cec587edce5373642c6ffac216770d3
+export CILIUM_ENVOY_DIGEST:=sha256:ca4a8d3c411837fb31915c14ed042f3e4313c5ce7f7f36d88480cd2f441e1b63
 
 # renovate: datasource=docker
 export HUBBLE_UI_BACKEND_REPO:=quay.io/cilium/hubble-ui-backend

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -361,7 +361,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:f9c2a725a702d9fe4a4e038588a79e72955cf46c789914f940d906d65e92527e","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.30.4-1725856146-ae435a5bef3856f4de98fa360ecfa6a0f5b0f7a1","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:ca4a8d3c411837fb31915c14ed042f3e4313c5ce7f7f36d88480cd2f441e1b63","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.30.6-1726787755-2fbff8d20cec587edce5373642c6ffac216770d3","useDigest":true}` | Envoy container image. |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | envoy.log.defaultLevel | string | Defaults to the default log level of the Cilium Agent - `info` | Default log level of Envoy application log that is configured if Cilium debug / verbose logging isn't enabled. This option allows to have a different log level than the Cilium Agent - e.g. lower it to `critical`. Possible values: trace, debug, info, warning, error, critical, off |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2236,9 +2236,9 @@ envoy:
     # @schema
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.30.4-1725856146-ae435a5bef3856f4de98fa360ecfa6a0f5b0f7a1"
+    tag: "v1.30.6-1726787755-2fbff8d20cec587edce5373642c6ffac216770d3"
     pullPolicy: "Always"
-    digest: "sha256:f9c2a725a702d9fe4a4e038588a79e72955cf46c789914f940d906d65e92527e"
+    digest: "sha256:ca4a8d3c411837fb31915c14ed042f3e4313c5ce7f7f36d88480cd2f441e1b63"
     useDigest: true
   # -- Additional containers added to the cilium Envoy DaemonSet.
   extraContainers: []


### PR DESCRIPTION
This commit is to bump envoy version to v1.30.6[^1][^2], mainly for the below CVEs:

- CVE-2024-7264: Update curl lib
- CVE-2024-45808: Malicious log injection via access logs
- CVE-2024-45806: Potential manipulate x-envoy headers from external sources
- CVE-2024-45809: Jwt filter crash in the clear route cache with remote JWKs
- CVE-2024-45810: Envoy crashes for LocalReply in http async client

Relates build: https://github.com/cilium/proxy/actions/runs/10950320860/job/30405341613

[^1]: https://github.com/envoyproxy/envoy/releases/tag/v1.30.5
[^2]: https://github.com/envoyproxy/envoy/releases/tag/v1.30.6