### PR TITLE
metrics: fix bootstrap metric overall time

### DIFF
--- a/daemon/cmd/root.go
+++ b/daemon/cmd/root.go
@@ -17,13 +17,14 @@ import (
 	"github.com/cilium/cilium/pkg/version"
 )
 
-func NewAgentCmd(h *hive.Hive) *cobra.Command {
+func NewAgentCmd(hfn func() *hive.Hive) *cobra.Command {
+	bootstrapStats.overall.Start()
+	h := hfn()
+
 	rootCmd := &cobra.Command{
 		Use:   "cilium-agent",
 		Short: "Run the cilium agent",
 		Run: func(cobraCmd *cobra.Command, args []string) {
-			bootstrapStats.overall.Start()
-
 			if v, _ := cobraCmd.Flags().GetBool("version"); v {
 				fmt.Printf("%s %s\n", cobraCmd.Name(), version.Version)
 				os.Exit(0)

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -9,7 +9,8 @@ import (
 )
 
 func main() {
-	agentHive := hive.New(cmd.Agent)
-
-	cmd.Execute(cmd.NewAgentCmd(agentHive))
+	hiveFn := func() *hive.Hive {
+		return hive.New(cmd.Agent)
+	}
+	cmd.Execute(cmd.NewAgentCmd(hiveFn))
 }


### PR DESCRIPTION
When running 100 node scale test I've noticed there is a significant disproportion between bootstrapTime reported in logs and metrics. Metric was reporting ~3.6s while logging was showing ~13s. While I still don't know what impacts such a high hive bootstrap time, let's fix the metric first.

```release-note
Metrics: Fix the reporting of bootstrap metric "overall" scope as it was not capturing a part of initialization
```
