### PR TITLE
renovate: Update allowedVersion for cilium-envoy

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -574,8 +574,8 @@
       "matchDepNames": [
         "quay.io/cilium/cilium-envoy"
       ],
-      "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-.*$",
-      "allowedVersions": "<1.29",
+      "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<revision>.*)$",
+      "allowedVersions": "/^v1\\.29\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
         "v1.15",
         "v1.14",
@@ -585,8 +585,8 @@
       "matchDepNames": [
         "quay.io/cilium/cilium-envoy"
       ],
-      "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-.*$",
-      "allowedVersions": "<1.30",
+      "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<revision>.*)$",
+      "allowedVersions": "/^v1\\.29\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
         "v1.16",
       ]
@@ -595,8 +595,8 @@
       "matchDepNames": [
         "quay.io/cilium/cilium-envoy"
       ],
-      "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-.*$",
-      "allowedVersions": "<1.31",
+      "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<revision>.*)$",
+      "allowedVersions": "/^v1\\.30\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
         "main",
       ]


### PR DESCRIPTION
This caters to the build id and revision in the versioning string.

Testing was done locally as per below, also trial run in GHA can be found [here](https://github.com/cilium/cilium/actions/runs/10956841097)

```
$ LOG_LEVEL=debug renovate --platform local
...
               {
                 "depName": "quay.io/cilium/cilium-envoy",
                 "currentValue": "v1.30.4-1725856146-ae435a5bef3856f4de98fa360ecfa6a0f5b0f7a1",
                 "currentDigest": "sha256:f9c2a725a702d9fe4a4e038588a79e72955cf46c789914f940d906d65e92527e",
                 "datasource": "docker",
                 "replaceString": "# renovate: datasource=docker\nexport CILIUM_ENVOY_REPO:=quay.io/cilium/cilium-envoy\nexport CILIUM_ENVOY_VERSION:=v1.30.4-1725856146-ae435a5bef3856f4de98fa360ecfa6a0f5b0f7a1\nexport CILIUM_ENVOY_DIGEST:=sha256:f9c2a725a702d9fe4a4e038588a79e72955cf46c789914f940d906d65e92527e",
                 "updates": [
                   {
                     "bucket": "latest",
                     "newVersion": "v1.30.6-1726787755-2fbff8d20cec587edce5373642c6ffac216770d3",
                     "newValue": "v1.30.6-1726787755-2fbff8d20cec587edce5373642c6ffac216770d3",
                     "newMajor": 1,
                     "newMinor": 30,
                     "newPatch": 6,
                     "updateType": "patch",
                     "newDigest": "sha256:ca4a8d3c411837fb31915c14ed042f3e4313c5ce7f7f36d88480cd2f441e1b63",
                     "branchName": "renovate/all-dependencies"
                   }
                 ],
                 "packageName": "quay.io/cilium/cilium-envoy",
                 "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<revision>.*)$",
                 "warnings": [],
                 "registryUrl": "https://quay.io",
                 "lookupName": "cilium/cilium-envoy",
                 "currentVersion": "v1.30.4-1725856146-ae435a5bef3856f4de98fa360ecfa6a0f5b0f7a1",
                 "isSingleVersion": true,
                 "fixedVersion": "v1.30.4-1725856146-ae435a5bef3856f4de98fa360ecfa6a0f5b0f7a1"
               },
...
```
