### PR TITLE
[DRAFT][RFC] L2 announce: add IPv6 support

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1018,14 +1018,18 @@ static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx, __u32
 #endif /* ENABLE_IPSEC && TUNNEL_MODE */
 
 #ifdef ENABLE_L2_ANNOUNCEMENTS
-static __always_inline int handle_l2_announcement(struct __ctx_buff *ctx)
+static __always_inline int handle_l2_announcement(struct __ctx_buff *ctx,
+						struct ipv6hdr* ip6)
 {
 	union macaddr mac = THIS_INTERFACE_MAC;
 	union macaddr smac;
-	__be32 sip;
-	__be32 tip;
-	struct l2_responder_v4_key key;
-	struct l2_responder_v4_stats *stats;
+	__be32 __maybe_unused sip;
+	__be32 __maybe_unused tip;
+	union v6addr __maybe_unused sip6;
+	union v6addr __maybe_unused tip6;
+	struct l2_responder_v4_key __maybe_unused  key;
+	struct l2_responder_v6_key __maybe_unused  key6;
+	struct l2_responder_stats *stats;
 	int ret;
 	__u32 index = RUNTIME_CONFIG_AGENT_LIVENESS;
 	__u64 *time;
@@ -1041,22 +1045,37 @@ static __always_inline int handle_l2_announcement(struct __ctx_buff *ctx)
 	if (ktime_get_ns() - (*time) > L2_ANNOUNCEMENTS_MAX_LIVENESS)
 		return CTX_ACT_OK;
 
-	if (!arp_validate(ctx, &mac, &smac, &sip, &tip))
-		return CTX_ACT_OK;
+	if (!ip6) {
+		if (!arp_validate(ctx, &mac, &smac, &sip, &tip))
+			return CTX_ACT_OK;
 
-	key.ip4 = tip;
-	key.ifindex = ctx->ingress_ifindex;
-	stats = map_lookup_elem(&L2_RESPONDER_MAP4, &key);
-	if (!stats)
-		return CTX_ACT_OK;
+		key.ip4 = tip;
+		key.ifindex = ctx->ingress_ifindex;
+		stats = map_lookup_elem(&L2_RESPONDER_MAP4, &key);
+		if (!stats)
+			return CTX_ACT_OK;
 
-	ret = arp_respond(ctx, &mac, tip, &smac, sip, 0);
+		ret = arp_respond(ctx, &mac, tip, &smac, sip, 0);
+	} else {
+
+		if (!icmp6_ndisc_validate(ctx, ip6, &mac, &smac, &sip6, &tip6))
+			return CTX_ACT_OK;
+
+		key6.ip6 = tip6;
+		key6.ifindex = ctx->ingress_ifindex;
+		stats = map_lookup_elem(&L2_RESPONDER_MAP6, &key6);
+		if (!stats)
+			return CTX_ACT_OK;
+		int l3_off = (__u8*)ip6 - (__u8*)ctx_data(ctx);
+		ret = send_icmp6_ndisc_adv(ctx, l3_off, &mac, false);
+	}
 
 	if (ret == CTX_ACT_REDIRECT)
 		__sync_fetch_and_add(&stats->responses_sent, 1);
 
 	return ret;
-};
+}
+
 #endif
 
 static __always_inline int
@@ -1076,6 +1095,7 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 	int __maybe_unused hdrlen = 0;
 	__u8 __maybe_unused next_proto = 0;
 	__s8 __maybe_unused ext_err = 0;
+	__u8 __maybe_unused next_hdr;
 	int ret;
 
 #ifdef ENABLE_IPSEC
@@ -1148,7 +1168,7 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 		send_trace_notify(ctx, obs_point, UNKNOWN_ID, UNKNOWN_ID, TRACE_EP_ID_UNKNOWN,
 				  ctx->ingress_ifindex, trace.reason, trace.monitor);
 		#ifdef ENABLE_L2_ANNOUNCEMENTS
-			ret = handle_l2_announcement(ctx);
+			ret = handle_l2_announcement(ctx, NULL);
 		#else
 			ret = CTX_ACT_OK;
 		#endif
@@ -1159,6 +1179,13 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 		if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
 			return send_drop_notify_error(ctx, identity, DROP_INVALID,
 						      CTX_ACT_DROP, METRIC_INGRESS);
+#ifdef ENABLE_L2_ANNOUNCEMENTS
+		if (ip6->nexthdr == NEXTHDR_ICMP) {
+			ret = handle_l2_announcement(ctx, ip6);
+			if (ret != CTX_ACT_OK)
+				break;
+		}
+#endif /*ENABLE_L2_ANNOUNCEMENTS */
 
 		identity = resolve_srcid_ipv6(ctx, ip6, identity, &ipcache_srcid, from_host);
 		ctx_store_meta(ctx, CB_SRC_LABEL, identity);

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
-#if !defined(__LIB_ICMP6__) && defined(ENABLE_IPV6)
+#ifndef __LIB_ICMP6__
 #define __LIB_ICMP6__
 
 #include <linux/icmpv6.h>

--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -194,18 +194,32 @@ struct l2_responder_v4_key {
 	__u32 ifindex;
 };
 
-struct l2_responder_v4_stats {
+struct l2_responder_stats {
 	__u64 responses_sent;
 };
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, struct l2_responder_v4_key);
-	__type(value, struct l2_responder_v4_stats);
+	__type(value, struct l2_responder_stats);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, L2_RESPONSER_MAP4_SIZE);
 	__uint(map_flags, BPF_F_NO_PREALLOC);
 } L2_RESPONDER_MAP4 __section_maps_btf;
+
+struct l2_responder_v6_key {
+	union v6addr ip6;
+	__u32 ifindex;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, struct l2_responder_v6_key);
+	__type(value, struct l2_responder_stats);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, L2_RESPONSER_MAP6_SIZE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} L2_RESPONDER_MAP6 __section_maps_btf;
 
 #ifdef ENABLE_SRV6
 # define SRV6_VRF_MAP(IP_FAMILY)				\

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -156,6 +156,7 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #define NODE_MAP_V2 test_cilium_node_map
 #define ENCRYPT_MAP test_cilium_encrypt_state
 #define L2_RESPONDER_MAP4 test_cilium_l2_responder_v4
+#define L2_RESPONDER_MAP6 test_cilium_l2_responder_v6
 #define RATELIMIT_MAP test_cilium_ratelimit
 #define RATELIMIT_METRICS_MAP test_cilium_ratelimit_metrics
 #define TUNNEL_MAP test_cilium_tunnel_map
@@ -205,6 +206,7 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #define SRV6_POLICY_MAP_SIZE 16384
 #define SRV6_SID_MAP_SIZE 16384
 #define L2_RESPONSER_MAP4_SIZE 4096
+#define L2_RESPONSER_MAP6_SIZE 4096
 #define POLICY_PROG_MAP_SIZE ENDPOINTS_MAP_SIZE
 #define IPV4_FRAG_DATAGRAMS_MAP test_cilium_ipv4_frag_datagrams
 #define CILIUM_IPV4_FRAG_MAP_MAX_ENTRIES 8192

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -65,6 +65,10 @@ static volatile const __u8 mac_zero[] =  {0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
 
 #define v4_all	IPV4(0, 0, 0, 0)
 
+/* IPv6 addresses for hosts, external to the cluster */
+static volatile const __section(".rodata") __u8 v6_ext_one[] = {0xfd, 0x03, 0, 0, 0, 0, 0, 0,
+					   0, 0, 0, 0, 0, 0, 0, 1};
+
 /* IPv6 addresses for pods in the cluster */
 static volatile const __section(".rodata") __u8 v6_pod_one[] = {0xfd, 0x04, 0, 0, 0, 0, 0, 0,
 					   0, 0, 0, 0, 0, 0, 0, 1};
@@ -80,6 +84,10 @@ static volatile const __section(".rodata") __u8 v6_node_two[] = {0xfd, 0x06, 0, 
 					   0, 0, 0, 0, 0, 0, 0, 2};
 static volatile const __section(".rodata") __u8 v6_node_three[] = {0xfd, 0x07, 0, 0, 0, 0, 0, 0,
 					   0, 0, 0, 0, 0, 0, 0, 3};
+
+/* IPv6 addresses for services in the cluster */
+static volatile const __section(".rodata") __u8 v6_svc_one[] = {0xfd, 0x10, 0, 0, 0, 0, 0, 0,
+					   0, 0, 0, 0, 0, 0, 0, 1};
 
 /* Source port to be used by a client */
 #define tcp_src_one	__bpf_htons(22330)

--- a/bpf/tests/tc_l2_announcement.c
+++ b/bpf/tests/tc_l2_announcement.c
@@ -157,7 +157,7 @@ SETUP("tc", "1_happy_path")
 int l2_announcement_arp_happy_path_setup(struct __ctx_buff *ctx)
 {
 	struct l2_responder_v4_key key;
-	struct l2_responder_v4_stats value = {0};
+	struct l2_responder_stats value = {0};
 	__u32 index;
 	__u64 time;
 

--- a/bpf/tests/tc_l2_announcement6.c
+++ b/bpf/tests/tc_l2_announcement6.c
@@ -49,7 +49,7 @@ struct {
  *                 +-------------------------------------------------------------------+
  */
 
-static volatile const __u8 mac_bcast[] =   {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+static volatile const __u8 mac_bcast[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 static __always_inline int build_packet(struct __ctx_buff *ctx)
 {
@@ -74,7 +74,7 @@ static __always_inline int build_packet(struct __ctx_buff *ctx)
 	l4->icmp6_code = 0;
 
 	l4->icmp6_router = 0;
-	l4->icmp6_solicited = 1;
+	l4->icmp6_solicited = 0;
 	l4->icmp6_override = 0;
 	l4->icmp6_ndiscreserved = 0;
 
@@ -149,7 +149,7 @@ int l2_announcement_nd_no_entry_check(__maybe_unused const struct __ctx_buff *ct
 	assert(icmp->icmp6_code == 0);
 
 	assert(icmp->icmp6_router == 0);
-	assert(icmp->icmp6_solicited == 1);
+	assert(icmp->icmp6_solicited == 0);
 	assert(icmp->icmp6_override == 0);
 	assert(icmp->icmp6_ndiscreserved == 0);
 

--- a/bpf/tests/tc_l2_announcement6.c
+++ b/bpf/tests/tc_l2_announcement6.c
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+/* Enable debug output */
+#define DEBUG
+
+/* Set THIS_INTERFACE_MAC equal to mac_two */
+#define THIS_INTERFACE_MAC { .addr = {0x13, 0x37, 0x13, 0x37, 0x13, 0x37} }
+
+#define SECCTX_FROM_IPCACHE 1
+
+/* Set the LXC source address to be the address of pod one */
+#define LXC_IPV4 (__be32)v6_pod_one
+
+/* Enable CT debug output */
+#undef QUIET_CT
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV6
+#define ENABLE_L2_ANNOUNCEMENTS
+
+#include <bpf_host.c>
+
+#define NS_MSG_SIZE (4 /* ICMP6: TYPE+CODE+CSUM */)
+#define NA_MSG_SIZE (4 /* ICMP6: TYPE+CODE+CSUM */ + 8 /* LL Address opt */)
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 2);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[0] = &cil_from_netdev,
+	},
+};
+
+/* Setup for this test:
+ * +-------------------------+   +--------------------------------------+    +--------------------------+
+ * |L2:mac_one, L3:v6_ext_one|---|  ND Request broadcast for v6_svc_one |--->|L2:mac_two, L3:v6_node_one|
+ * +-------------------------+   +--------------------------------------+    +--------------------------+
+ *             ^   +-------------------------------------------------------------------+    |
+ *             \---| ND Reply, SHR:mac_two, SIP:v6_svc_one, DHR:mac_one, DIP:v6_ext_one|---/
+ *                 +-------------------------------------------------------------------+
+ */
+
+static volatile const __u8 mac_bcast[] =   {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+
+static __always_inline int build_packet(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	volatile const __u8 *src = mac_one;
+	volatile const __u8 *dst = mac_bcast;
+	struct icmp6hdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_icmp6_packet(&builder,
+				    (__u8 *)src, (__u8 *)dst,
+				    (__u8 *)v6_ext_one, (__u8 *)v6_svc_one,
+				    ICMP6_NS_MSG_TYPE);
+	if (!l4)
+		return TEST_ERROR;
+
+	/* Set ND sol data */
+	l4->icmp6_type = ICMP6_NS_MSG_TYPE;
+	l4->icmp6_code = 0;
+
+	l4->icmp6_router = 0;
+	l4->icmp6_solicited = 1;
+	l4->icmp6_override = 0;
+	l4->icmp6_ndiscreserved = 0;
+
+	__u8 options[] = {0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1};
+	data = pktgen__push_data(&builder, (__u8 *)options, 8);
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+PKTGEN("tc", "0_no_entry")
+int l2_announcement_nd_no_entry_pktgen(struct __ctx_buff *ctx)
+{
+	return build_packet(ctx);
+}
+
+/* Test that sending a ND broadcast request without entries in the map.
+ */
+SETUP("tc", "0_no_entry")
+int l2_announcement_nd_no_entry_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, 0);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "0_no_entry")
+int l2_announcement_nd_no_entry_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void* data;
+	void* data_end;
+	__u32 *status_code;
+	struct ethhdr* l2;
+	struct ipv6hdr* l3;
+	struct icmp6hdr* icmp;
+	test_init();
+
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	/* The program should pass unknown ND messages to the stack */
+	assert(*status_code == TC_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void*)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	icmp = (void*)l3 + sizeof(struct ipv6hdr);
+	if ((void*)l3 + sizeof(struct ipv6hdr) + NS_MSG_SIZE > data_end)
+		test_fatal("l3 out of bounds");
+
+	/* L2 */
+	assert(memcmp(l2->h_source, (__u8 *)mac_one, ETH_ALEN) == 0);
+	assert(memcmp(l2->h_dest, (__u8 *)mac_bcast, ETH_ALEN) == 0);
+
+	/* IPv6 */
+	assert(memcmp(&l3->saddr, (void*)&v6_ext_one, sizeof(v6_ext_one)) == 0);
+	assert(memcmp(&l3->daddr, (void*)&v6_svc_one, sizeof(v6_svc_one)) == 0);
+	assert(l3->nexthdr == NEXTHDR_ICMP);
+
+	/* ICMPv6 + ND sol */
+	assert(icmp->icmp6_type == ICMP6_NS_MSG_TYPE);
+	assert(icmp->icmp6_code == 0);
+
+	assert(icmp->icmp6_router == 0);
+	assert(icmp->icmp6_solicited == 1);
+	assert(icmp->icmp6_override == 0);
+	assert(icmp->icmp6_ndiscreserved == 0);
+
+	test_finish();
+}
+
+PKTGEN("tc", "1_happy_path")
+int l2_announcement_nd_happy_path_pktgen(struct __ctx_buff *ctx)
+{
+	return build_packet(ctx);
+}
+
+/* Test that sending a ND broadcast request matching an entry in the
+ * L2_RESPONDER_MAP6 results in a valid ND reply.
+ */
+SETUP("tc", "1_happy_path")
+int l2_announcement_nd_happy_path_setup(struct __ctx_buff *ctx)
+{
+	struct l2_responder_v6_key key;
+	struct l2_responder_stats value = {0};
+	__u32 index;
+	__u64 time;
+
+	key.ifindex = 0;
+	memcpy(&key.ip6, (void*)&v6_svc_one, sizeof(v6_svc_one));
+	map_update_elem(&L2_RESPONDER_MAP6, &key, &value, BPF_ANY);
+
+	index = RUNTIME_CONFIG_AGENT_LIVENESS;
+	time = ktime_get_ns();
+	map_update_elem(&CONFIG_MAP, &index, &time, BPF_ANY);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, 0);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "1_happy_path")
+int l2_announcement_nd_happy_path_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void* data;
+	void* data_end;
+	__u32 *status_code;
+	struct ethhdr* l2;
+	struct ipv6hdr* l3;
+	struct icmp6hdr* icmp;
+	__u8* lla_opt;
+
+	test_init();
+
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	/* The program should pass unknown ND messages to the stack */
+	assert(*status_code == TC_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void*)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+	icmp = (void*)l3 + sizeof(struct ipv6hdr);
+	lla_opt = (void*)icmp + sizeof(struct icmp6hdr) + 2 /* Type + Length */;
+
+	if ((void*)l3 + sizeof(struct ipv6hdr) + NA_MSG_SIZE > data_end)
+		test_fatal("l3 out of bounds");
+
+	/* L2 */
+	assert(memcmp(l2->h_source, (__u8 *)mac_two, ETH_ALEN) == 0);
+	assert(memcmp(l2->h_dest, (__u8 *)mac_one, ETH_ALEN) == 0);
+
+	/* IPv6 */
+	assert(memcmp(&l3->saddr, (void*)&v6_svc_one, sizeof(v6_svc_one)) == 0);
+	assert(memcmp(&l3->daddr, (void*)&v6_ext_one, sizeof(v6_ext_one)) == 0);
+	assert(l3->nexthdr == NEXTHDR_ICMP);
+
+	/* ICMPv6 + NA sol */
+	assert(icmp->icmp6_type == ICMP6_NA_MSG_TYPE);
+	assert(icmp->icmp6_code == 0);
+
+	assert(icmp->icmp6_router == 0);
+	assert(icmp->icmp6_solicited == 1);
+	assert(icmp->icmp6_override == 1); /* Must override */
+	assert(icmp->icmp6_ndiscreserved == 0);
+
+	/* check Link layer address */
+	assert(memcmp(&lla_opt, (void*)&mac_two, sizeof(mac_two)));
+
+	test_finish();
+}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -46,6 +46,7 @@ import (
 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
 	"github.com/cilium/cilium/pkg/maps/ipmasq"
 	"github.com/cilium/cilium/pkg/maps/l2respondermap"
+	"github.com/cilium/cilium/pkg/maps/l2v6respondermap"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
@@ -214,12 +215,14 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	cDefinesMap["WORLD_CIDRS4_MAP_SIZE"] = fmt.Sprintf("%d", worldcidrsmap.MapMaxEntries)
 	cDefinesMap["POLICY_PROG_MAP_SIZE"] = fmt.Sprintf("%d", policymap.PolicyCallMaxEntries)
 	cDefinesMap["L2_RESPONSER_MAP4_SIZE"] = fmt.Sprintf("%d", l2respondermap.DefaultMaxEntries)
+	cDefinesMap["L2_RESPONSER_MAP6_SIZE"] = fmt.Sprintf("%d", l2v6respondermap.DefaultMaxEntries)
 
 	if option.Config.EnableIPSec {
 		cDefinesMap["ENCRYPT_MAP"] = encrypt.MapName
 	}
 
 	cDefinesMap["L2_RESPONDER_MAP4"] = l2respondermap.MapName
+	cDefinesMap["L2_RESPONDER_MAP6"] = l2v6respondermap.MapName
 	cDefinesMap["CT_CONNECTION_LIFETIME_TCP"] = fmt.Sprintf("%d", int64(option.Config.CTMapEntriesTimeoutTCP.Seconds()))
 	cDefinesMap["CT_CONNECTION_LIFETIME_NONTCP"] = fmt.Sprintf("%d", int64(option.Config.CTMapEntriesTimeoutAny.Seconds()))
 	cDefinesMap["CT_SERVICE_LIFETIME_TCP"] = fmt.Sprintf("%d", int64(option.Config.CTMapEntriesTimeoutSVCTCP.Seconds()))

--- a/pkg/maps/cells.go
+++ b/pkg/maps/cells.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/ctmap/gc"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
 	"github.com/cilium/cilium/pkg/maps/l2respondermap"
+	"github.com/cilium/cilium/pkg/maps/l2v6respondermap"
 	"github.com/cilium/cilium/pkg/maps/multicast"
 	"github.com/cilium/cilium/pkg/maps/nat"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
@@ -48,8 +49,9 @@ var Cell = cell.Module(
 	// Provides the node map which contains information about node IDs and their IP addresses.
 	nodemap.Cell,
 
-	// Provides access to the L2 responder map.
+	// Provides access to the L2 responder maps.
 	l2respondermap.Cell,
+	l2v6respondermap.Cell,
 
 	// Provides access to the multicast maps.
 	multicast.Cell,

--- a/pkg/maps/l2v6respondermap/l2_responder_map6.go
+++ b/pkg/maps/l2v6respondermap/l2_responder_map6.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package l2v6respondermap
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"unsafe"
+
+	"github.com/cilium/hive/cell"
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/ebpf"
+	"github.com/cilium/cilium/pkg/maps/l2respondermap"
+	"github.com/cilium/cilium/pkg/types"
+)
+
+const (
+	MapName           = "cilium_l2_responder_v6"
+	DefaultMaxEntries = 4096
+)
+
+var Cell = cell.Provide(NewMap)
+
+type Map interface {
+	Create(ip netip.Addr, ifIndex uint32) error
+	Lookup(ip netip.Addr, ifIndex uint32) (*l2respondermap.L2ResponderStats, error)
+	Delete(ip netip.Addr, ifIndex uint32) error
+	IterateWithCallback(cb IterateCallback) error
+}
+
+func NewMap(lifecycle cell.Lifecycle) (Map, error) {
+	return newMap(lifecycle, DefaultMaxEntries)
+}
+
+type l2V6ResponderMap struct {
+	*ebpf.Map
+}
+
+func newMap(lifecycle cell.Lifecycle, maxEntries int) (*l2V6ResponderMap, error) {
+	outerMap := &l2V6ResponderMap{}
+
+	lifecycle.Append(cell.Hook{
+		OnStart: func(hc cell.HookContext) error {
+			var (
+				m   *ebpf.Map
+				err error
+			)
+
+			if m, err = ebpf.LoadRegisterMap(MapName); err != nil {
+				m = ebpf.NewMap(&ebpf.MapSpec{
+					Name:       MapName,
+					Type:       ebpf.Hash,
+					KeySize:    uint32(unsafe.Sizeof(L2V6ResponderKey{})),
+					ValueSize:  uint32(unsafe.Sizeof(l2respondermap.L2ResponderStats{})),
+					MaxEntries: uint32(maxEntries),
+					Flags:      unix.BPF_F_NO_PREALLOC,
+					Pinning:    ebpf.PinByName,
+				})
+				if err := m.OpenOrCreate(); err != nil {
+					return err
+				}
+			}
+
+			outerMap.Map = m
+
+			return nil
+		},
+	})
+
+	return outerMap, nil
+}
+
+// Create creates a new entry for the given IP and IfIndex tuple.
+func (m *l2V6ResponderMap) Create(ip netip.Addr, ifIndex uint32) error {
+	key := newL2V6ResponderKey(ip, ifIndex)
+	return m.Map.Put(key, l2respondermap.L2ResponderStats{})
+}
+
+// Delete deletes the entry associated with the provided IP and IfIndex tuple.
+func (m *l2V6ResponderMap) Delete(ip netip.Addr, ifIndex uint32) error {
+	key := newL2V6ResponderKey(ip, ifIndex)
+	return m.Map.Delete(key)
+}
+
+// Lookup returns the stats object associated with the provided IP and IfIndex tuple.
+func (m *l2V6ResponderMap) Lookup(ip netip.Addr, ifIndex uint32) (*l2respondermap.L2ResponderStats, error) {
+	key := newL2V6ResponderKey(ip, ifIndex)
+	val := l2respondermap.L2ResponderStats{}
+
+	err := m.Map.Lookup(&key, &val)
+
+	return &val, err
+}
+
+// IterateCallback represents the signature of the callback function
+// expected by the IterateWithCallback method, which in turn is used to iterate
+// all the keys/values of a L2 responder map.
+type IterateCallback func(*L2V6ResponderKey, *l2respondermap.L2ResponderStats)
+
+// IterateWithCallback iterates through all the keys/values of a L2 responder map,
+// passing each key/value pair to the cb callback.
+func (m *l2V6ResponderMap) IterateWithCallback(cb IterateCallback) error {
+	return m.Map.IterateWithCallback(&L2V6ResponderKey{}, &l2respondermap.L2ResponderStats{},
+		func(k, v interface{}) {
+			key := k.(*L2V6ResponderKey)
+			value := v.(*l2respondermap.L2ResponderStats)
+			cb(key, value)
+		},
+	)
+}
+
+// L2V6ResponderKey implements the bpf.MapKey interface.
+//
+// Must be in sync with struct l2_responder_v4_key in <bpf/lib/maps.h>
+type L2V6ResponderKey struct {
+	IP      types.IPv6 `align:"address"`
+	IfIndex uint32     `align:"ifindex"`
+}
+
+func (k *L2V6ResponderKey) String() string {
+	return fmt.Sprintf("ip=%s, ifIndex=%d", net.IP(k.IP[:]), k.IfIndex)
+}
+
+func newL2V6ResponderKey(ip netip.Addr, ifIndex uint32) L2V6ResponderKey {
+	return L2V6ResponderKey{
+		IP:      types.IPv6(ip.As16()),
+		IfIndex: ifIndex,
+	}
+}


### PR DESCRIPTION
This (incomplete) patchset adds IPv6 support for L2 announcements, effectively removing one of the Beta limitations of the L2 announce feature.

The PR is in a RFC state, before I get any deeper. In particular, I would like to know if the overall approach makes sense. 

#### Notes:
 *  This PR removes the requirement to define `ENABLE_IPV6` [to compile (unused when not defined) ICMPv6 code.](https://github.com/cilium/cilium/blob/main/bpf/lib/icmp6.h#L4)

#### Missing work:
  * Make unit pass (untested)
  * Add support for gratuitous NA (see below)

#### Questions

* Not particulary happy with the golang code under `l2responder.go`. It's a bit ugly with the `if(v6) else ...`; I am new to golang, and I haven't seen this pattern used in Maps, but would it make sense to have a common interface for both `l2respondermap`s?
* To implement the Gratuitous Neighbour Advertisments (needed in `l2responder.go`), I am wondering if the best course of action is to take the current [garp cell](https://github.com/cilium/cilium/blob/main/pkg/datapath/garp/garp.go) and add the NA part (and probably rename it to something like `gneigh/gneigh.go`).
* Is there E2E coverage for L2 announce IPv4? I couldn't find it. 

Thanks