### PR TITLE
hubble: add a couple of "any interface" filter test cases

### DIFF
--- a/pkg/hubble/filters/network_interface_test.go
+++ b/pkg/hubble/filters/network_interface_test.go
@@ -24,7 +24,7 @@ func TestNetworkInterfaceFilter(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "nil",
+			name: "nil event",
 			args: args{
 				f: []*flowpb.FlowFilter{{
 					Interface: []*flowpb.NetworkInterface{
@@ -34,6 +34,35 @@ func TestNetworkInterfaceFilter(t *testing.T) {
 					},
 				}},
 				ev: nil,
+			},
+			want: false,
+		},
+		{
+			name: "empty filter (any interface) match",
+			args: args{
+				f: []*flowpb.FlowFilter{{
+					Interface: []*flowpb.NetworkInterface{
+						{},
+					},
+				}},
+				ev: &v1.Event{Event: &flowpb.Flow{
+					Interface: &flowpb.NetworkInterface{
+						Index: 1,
+						Name:  "eth1",
+					},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "empty filter (any interface) miss",
+			args: args{
+				f: []*flowpb.FlowFilter{{
+					Interface: []*flowpb.NetworkInterface{
+						{},
+					},
+				}},
+				ev: &v1.Event{Event: &flowpb.Flow{}},
 			},
 			want: false,
 		},


### PR DESCRIPTION
Explicit how a Hubble API user can request flows with "any interface" set, by setting a non-empty repeated interface filter (e.g. non-empty slice from Go) with a zero values filter. Like other filters, a logical inverse of this "any interface" filter can be queried using the same construction under the `GetFlowsRequest.blacklist` set of filters instead of `GetFlowsRequest.whitelist`.