### PR TITLE
LB-IPAM: Pass `lbipamConfig` struct to controller

### DIFF
--- a/operator/pkg/lbipam/cell.go
+++ b/operator/pkg/lbipam/cell.go
@@ -91,6 +91,7 @@ func newLBIPAMCell(params lbipamCellParams) *LBIPAM {
 		poolClient:   params.Clientset.CiliumV2alpha1().CiliumLoadBalancerIPPools(),
 		svcClient:    params.Clientset.Slim().CoreV1(),
 		jobGroup:     params.JobGroup,
+		config:       params.Config,
 	})
 
 	lbIPAM.jobGroup.Add(


### PR DESCRIPTION
Fixes: 2cfeb0a2727b ("LB-IPAM: Add flag to ignore services without LBClass set")

This commit ensures that the `--lbipam-require-lb-class` actually has an effect on the LB-IPAM controller by assigning the parsed `lbipamConfig` struct to field `config` of the `lbIPAMParams` struct which is used to initialize the LB-IPAM controller.

```release-note
Make flag that instructs LB-IPAM to only allocate IPs for services with .Spec.LoadBalancerClass specified functional
```
This is a follow-up for #33351 

## Guidelines

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) -- already there "APPUiO by VSHN"
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number
