### PR TITLE
Document about multicast sub-command of cilium-cli

### DIFF
--- a/Documentation/network/multicast.rst
+++ b/Documentation/network/multicast.rst
@@ -94,6 +94,21 @@ Then, set the subscriber IP addresses in each ``cilium-agent``:
 
    This multicast subscriber IP addresses are different CiliumNode IP addresses than your own one.
 
+
+To make all nodes join a specified multicast group, use the ``cilium multicast`` command.
+You can also get information about multicast groups and subscribers cluster-wide.
+
+.. code-block:: shell-session
+   
+   ### make all nodes join the specified multicast group
+   $ cilium multicast add --group-ip 239.255.0.1
+   ### confirm the multicast groups and subscribers
+   $ cilium multicast list subscriber --all
+   Node               Group         Subscriber     Type
+   cl-worker          239.255.0.1   10.244.0.196   Remote Node
+   cl-control-plane   239.255.0.1   10.244.1.122   Remote Node
+
+
 When you want to remove multicast IP addresses and subscriber list, run the following commands in the ``cilium-agent``.
 
 .. code-block:: shell-session


### PR DESCRIPTION
# About this PR
Multicast sub-command is added in this commit.
(https://github.com/cilium/cilium/commit/31652abc9c2d782f8cb395fe0333e2acee3c092d) 

The purpose of this PR is to introduce how to use the multicast sub-command.

## In addtion
Currently,  a PR in which multicast connectivity-test is implemented is under review. (https://github.com/cilium/cilium/pull/34530)
