### PR TITLE
policy: Group policy and identity management cells

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -35,8 +35,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/gops"
-	identity "github.com/cilium/cilium/pkg/identity/cache/cell"
-	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	ipamcell "github.com/cilium/cilium/pkg/ipam/cell"
 	ipcache "github.com/cilium/cilium/pkg/ipcache/cell"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -56,8 +54,6 @@ import (
 	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/option"
 	policy "github.com/cilium/cilium/pkg/policy/cell"
-	policyDirectory "github.com/cilium/cilium/pkg/policy/directory"
-	policyK8s "github.com/cilium/cilium/pkg/policy/k8s"
 	"github.com/cilium/cilium/pkg/pprof"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/recorder"
@@ -163,10 +159,6 @@ var (
 		// be synced
 		k8sSynced.Cell,
 
-		// IdentityManager maintains the set of identities and a count of its
-		// users.
-		identitymanager.Cell,
-
 		// EndpointManager maintains a collection of the locally running endpoints.
 		endpointmanager.Cell,
 
@@ -224,9 +216,6 @@ var (
 		// Auth is responsible for authenticating a request if required by a policy.
 		auth.Cell,
 
-		// Provides IdentityAllocators (Responsible for allocating security identities)
-		identity.Cell,
-
 		// IPCache cell provides IPCache (IP to identity mappings)
 		ipcache.Cell,
 
@@ -241,13 +230,6 @@ var (
 
 		// Provides PolicyRepository (List of policy rules)
 		policy.Cell,
-
-		// K8s policy resource watcher cell. It depends on the half-initialized daemon which is
-		// resolved by newDaemonPromise()
-		policyK8s.Cell,
-
-		// Directory policy watcher cell.
-		policyDirectory.Cell,
 
 		// ClusterMesh is the Cilium's multicluster implementation.
 		cell.Config(cmtypes.DefaultClusterInfo),

--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -6,89 +6,32 @@ package policycell
 import (
 	"github.com/cilium/hive/cell"
 
-	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
-	"github.com/cilium/cilium/pkg/endpointmanager"
-	"github.com/cilium/cilium/pkg/envoy"
-	"github.com/cilium/cilium/pkg/identity"
+	identityCache "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
-	"github.com/cilium/cilium/pkg/metrics"
-	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/policy"
+	policyDirectory "github.com/cilium/cilium/pkg/policy/directory"
+	policyK8s "github.com/cilium/cilium/pkg/policy/k8s"
+	policyRepo "github.com/cilium/cilium/pkg/policy/repository"
 )
 
-// Cell provides the PolicyRepository and PolicyUpdater.
+// Cell is a parent cell for security policy and identity management.
 var Cell = cell.Module(
 	"policy",
-	"Contains policy rules",
+	"Contains cells that make up security policy and identity management",
 
-	cell.Provide(newPolicyRepo),
-	cell.Provide(newPolicyUpdater),
+	// Provides the PolicyRepository and PolicyUpdater.
+	policyRepo.Cell,
+
+	// K8s policy resource watcher cell. It depends on the half-initialized daemon which is
+	// resolved by newDaemonPromise()
+	policyK8s.Cell,
+
+	// Directory policy watcher cell.
+	policyDirectory.Cell,
+
+	// Provides IdentityAllocators (Responsible for allocating security identities)
+	identityCache.Cell,
+
+	// IdentityManager maintains the set of identities and a count of its
+	// users.
+	identitymanager.Cell,
 )
-
-type policyRepoParams struct {
-	cell.In
-
-	Lifecycle       cell.Lifecycle
-	CertManager     certificatemanager.CertificateManager
-	SecretManager   certificatemanager.SecretManager
-	IdentityManager *identitymanager.IdentityManager
-	ClusterInfo     cmtypes.ClusterInfo
-}
-
-func newPolicyRepo(params policyRepoParams) *policy.Repository {
-	if option.Config.EnableWellKnownIdentities {
-		// Must be done before calling policy.NewPolicyRepository() below.
-		num := identity.InitWellKnownIdentities(option.Config, params.ClusterInfo)
-		metrics.Identity.WithLabelValues(identity.WellKnownIdentityType).Add(float64(num))
-		identity.WellKnown.ForEach(func(i *identity.Identity) {
-			for labelSource := range i.Labels.CollectSources() {
-				metrics.IdentityLabelSources.WithLabelValues(labelSource).Inc()
-			}
-		})
-	}
-
-	// policy repository: maintains list of active Rules and their subject
-	// security identities. Also constructs the SelectorCache, a precomputed
-	// cache of label selector -> identities for policy peers.
-	policyRepo := policy.NewStoppedPolicyRepository(
-		identity.ListReservedIdentities(), // Load SelectorCache with reserved identities
-		params.CertManager,
-		params.SecretManager,
-		params.IdentityManager,
-	)
-	policyRepo.SetEnvoyRulesFunc(envoy.GetEnvoyHTTPRules)
-
-	params.Lifecycle.Append(cell.Hook{
-		OnStart: func(hc cell.HookContext) error {
-			policyRepo.Start()
-			return nil
-		},
-	})
-
-	return policyRepo
-}
-
-type policyUpdaterParams struct {
-	cell.In
-
-	Lifecycle        cell.Lifecycle
-	PolicyRepository *policy.Repository
-	EndpointManager  endpointmanager.EndpointManager
-}
-
-func newPolicyUpdater(params policyUpdaterParams) *policy.Updater {
-	// policyUpdater: forces policy recalculation on all endpoints.
-	// Called for various events, such as named port changes
-	// or certain identity updates.
-	policyUpdater := policy.NewUpdater(params.PolicyRepository, params.EndpointManager)
-
-	params.Lifecycle.Append(cell.Hook{
-		OnStop: func(hc cell.HookContext) error {
-			policyUpdater.Shutdown()
-			return nil
-		},
-	})
-
-	return policyUpdater
-}

--- a/pkg/policy/repository/cell.go
+++ b/pkg/policy/repository/cell.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policycell
+
+import (
+	"github.com/cilium/hive/cell"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/envoy"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+// Cell provides the PolicyRepository and PolicyUpdater.
+var Cell = cell.Module(
+	"policy-repository",
+	"Contains policy rules",
+
+	cell.Provide(newPolicyRepo),
+	cell.Provide(newPolicyUpdater),
+)
+
+type policyRepoParams struct {
+	cell.In
+
+	Lifecycle       cell.Lifecycle
+	CertManager     certificatemanager.CertificateManager
+	SecretManager   certificatemanager.SecretManager
+	IdentityManager *identitymanager.IdentityManager
+	ClusterInfo     cmtypes.ClusterInfo
+}
+
+func newPolicyRepo(params policyRepoParams) *policy.Repository {
+	if option.Config.EnableWellKnownIdentities {
+		// Must be done before calling policy.NewPolicyRepository() below.
+		num := identity.InitWellKnownIdentities(option.Config, params.ClusterInfo)
+		metrics.Identity.WithLabelValues(identity.WellKnownIdentityType).Add(float64(num))
+		identity.WellKnown.ForEach(func(i *identity.Identity) {
+			for labelSource := range i.Labels.CollectSources() {
+				metrics.IdentityLabelSources.WithLabelValues(labelSource).Inc()
+			}
+		})
+	}
+
+	// policy repository: maintains list of active Rules and their subject
+	// security identities. Also constructs the SelectorCache, a precomputed
+	// cache of label selector -> identities for policy peers.
+	policyRepo := policy.NewStoppedPolicyRepository(
+		identity.ListReservedIdentities(), // Load SelectorCache with reserved identities
+		params.CertManager,
+		params.SecretManager,
+		params.IdentityManager,
+	)
+	policyRepo.SetEnvoyRulesFunc(envoy.GetEnvoyHTTPRules)
+
+	params.Lifecycle.Append(cell.Hook{
+		OnStart: func(hc cell.HookContext) error {
+			policyRepo.Start()
+			return nil
+		},
+	})
+
+	return policyRepo
+}
+
+type policyUpdaterParams struct {
+	cell.In
+
+	Lifecycle        cell.Lifecycle
+	PolicyRepository *policy.Repository
+	EndpointManager  endpointmanager.EndpointManager
+}
+
+func newPolicyUpdater(params policyUpdaterParams) *policy.Updater {
+	// policyUpdater: forces policy recalculation on all endpoints.
+	// Called for various events, such as named port changes
+	// or certain identity updates.
+	policyUpdater := policy.NewUpdater(params.PolicyRepository, params.EndpointManager)
+
+	params.Lifecycle.Append(cell.Hook{
+		OnStop: func(hc cell.HookContext) error {
+			policyUpdater.Shutdown()
+			return nil
+		},
+	})
+
+	return policyUpdater
+}


### PR DESCRIPTION
Move policy.Cell to policy/repository.Cell, so that policy.Cell can serve as the parent cell that includes cells:
- policy repository
- policy k8s cell
- policy directory
- identity cache (allocator)
- identity manager

Related to: https://github.com/cilium/cilium/issues/33360

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>