### PR TITLE
cilium-cli: Show config.cilium.io annotations on configmap

### DIFF
--- a/cilium-cli/status/k8s_test.go
+++ b/cilium-cli/status/k8s_test.go
@@ -128,6 +128,10 @@ func (c *k8sStatusMockClient) GetDeployment(_ context.Context, namespace, name s
 	return c.deployment[namespace+"/"+name], nil
 }
 
+func (c *k8sStatusMockClient) GetConfigMap(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.ConfigMap, error) {
+	return &corev1.ConfigMap{}, nil
+}
+
 func (c *k8sStatusMockClient) ListPods(_ context.Context, _ string, options metav1.ListOptions) (*corev1.PodList, error) {
 	return c.podList[options.LabelSelector], nil
 }

--- a/cilium-cli/status/status.go
+++ b/cilium-cli/status/status.go
@@ -140,6 +140,8 @@ type Status struct {
 	// For Helm mode only.
 	HelmChartVersion string `json:"helm_chart_version,omitempty"`
 
+	ConfigErrors []string `json:"config_errors,omitempty"`
+
 	mutex *lock.Mutex
 }
 
@@ -430,6 +432,14 @@ func (s *Status) Format() string {
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", header, deployment, pod, err)
 				header = ""
 			}
+		}
+	}
+
+	header = "Configuration:"
+	for _, msg := range s.ConfigErrors {
+		for _, line := range strings.Split(msg, "\n") {
+			fmt.Fprintf(w, "%s\t \t%s\n", header, line)
+			header = ""
 		}
 	}
 

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -18,6 +18,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - cilium-config
+  verbs:
+   # allow patching of the configmap to set annotations
+  - patch
 {{- if hasKey .Values "disableEndpointCRD" }}
 {{- if not .Values.disableEndpointCRD }}
 {{- if (and .Values.operator.unmanagedPodWatcher.restart (ne (.Values.operator.unmanagedPodWatcher.intervalSeconds | int64) 0 ) ) }}


### PR DESCRIPTION
Add support for showing config.cilium.io annotations in configmaps/cilium-config in "cilium status". This allows informing the user of a non-fatal misconfigured or unsupported configuration.

Example output with annotation {"config.cilium.io/example": "This is an example warning"}:
```
  $ cilium status
  ...
  Configuration:                This is an example warning
```
