### PR TITLE
feat(clustermesh): Deploy in parallel the connections

### DIFF
--- a/cilium-cli/cli/clustermesh.go
+++ b/cilium-cli/cli/clustermesh.go
@@ -337,4 +337,5 @@ func addCommonConnectFlags(cmd *cobra.Command, params *clustermesh.Parameters) {
 	cmd.Flags().StringSliceVar(&params.DestinationContext, "destination-context", []string{}, "Comma separated list of Kubernetes configuration contexts of destination cluster")
 	cmd.Flags().StringSliceVar(&params.DestinationEndpoints, "destination-endpoint", []string{}, "IP of ClusterMesh service of destination cluster")
 	cmd.Flags().StringSliceVar(&params.SourceEndpoints, "source-endpoint", []string{}, "IP of ClusterMesh service of source cluster")
+	cmd.Flags().IntVar(&params.Parallel, "parallel", 1, "Number of parallel connection of destination cluster")
 }


### PR DESCRIPTION
Context: If you manage multiple Kubernetes clusters, it can be beneficial to parallelize the connection processes. However, running `helm upgrade` in parallel consumes significant CPU resources. Therefore, it's important to customize the resource limits accordingly.

Example of cli for 2 connections in parallel:
`cilium clustermesh connect --destination-context kindB,kindC,kindD,kindE --parallel 2`

By default `--parallel=1`

How it works:
* A connection is created for the current context.
* Only Remote context connections are created in parallel.

An improvement could be to parallelize both the current context and the remote contexts. However, it seems like a lot of work for minimal gain.

Example of log with timestamp (7 clusters kind and `--parallel=5`):

```
Wed, 25 Sep 2024 07:30:53 GMT ℹ️ Configuring Cilium in cluster kind-cmesh1 to connect to cluster kind-cmesh2,kind-cmesh3,kind-cmesh4,kind-cmesh5,kind-cmesh6,kind-cmesh7
Wed, 25 Sep 2024 07:31:00 GMT ℹ️ Configuring Cilium in cluster kind-cmesh6 to connect to cluster kind-cmesh2,kind-cmesh3,kind-cmesh4,kind-cmesh5,kind-cmesh7,kind-cmesh1
Wed, 25 Sep 2024 07:31:00 GMT ℹ️ Configuring Cilium in cluster kind-cmesh5 to connect to cluster kind-cmesh2,kind-cmesh3,kind-cmesh4,kind-cmesh6,kind-cmesh7,kind-cmesh1
Wed, 25 Sep 2024 07:31:00 GMT ℹ️ Configuring Cilium in cluster kind-cmesh3 to connect to cluster kind-cmesh2,kind-cmesh4,kind-cmesh5,kind-cmesh6,kind-cmesh7,kind-cmesh1
Wed, 25 Sep 2024 07:31:00 GMT ℹ️ Configuring Cilium in cluster kind-cmesh2 to connect to cluster kind-cmesh3,kind-cmesh4,kind-cmesh5,kind-cmesh6,kind-cmesh7,kind-cmesh1
Wed, 25 Sep 2024 07:31:00 GMT ℹ️ Configuring Cilium in cluster kind-cmesh4 to connect to cluster kind-cmesh2,kind-cmesh3,kind-cmesh5,kind-cmesh6,kind-cmesh7,kind-cmesh1
Wed, 25 Sep 2024 07:31:16 GMT ℹ️ Configuring Cilium in cluster kind-cmesh7 to connect to cluster kind-cmesh2,kind-cmesh3,kind-cmesh4,kind-cmesh5,kind-cmesh6,kind-cmesh1
Wed, 25 Sep 2024 07:31:29 GMT ✅ Connected clusters kind-cmesh2, kind-cmesh3, kind-cmesh4, kind-cmesh5, kind-cmesh6, kind-cmesh7, and kind-cmesh1!
```

* The first line is the current context (it takes 7 seconds)
* The 5 next lines are the connection parallels
* When one connection is finished (after 16 seconds), it creates connection for the cluster (kind-cmesh7). It takes 14 seconds.

In total it took 36 seconds (estimated with no parallel: 7x7 = ~49 seconds)

Example of log with timestamp (7 clusters kind and `--parallel=3`):

```
Wed, 25 Sep 2024 07:31:07 GMT ℹ️ Configuring Cilium in cluster kind-cmesh1 to connect to cluster kind-cmesh2,kind-cmesh3,kind-cmesh4,kind-cmesh5,kind-cmesh6,kind-cmesh7
Wed, 25 Sep 2024 07:31:13 GMT ℹ️ Configuring Cilium in cluster kind-cmesh4 to connect to cluster kind-cmesh2,kind-cmesh3,kind-cmesh5,kind-cmesh6,kind-cmesh7,kind-cmesh1
Wed, 25 Sep 2024 07:31:13 GMT ℹ️ Configuring Cilium in cluster kind-cmesh2 to connect to cluster kind-cmesh3,kind-cmesh4,kind-cmesh5,kind-cmesh6,kind-cmesh7,kind-cmesh1
Wed, 25 Sep 2024 07:31:13 GMT ℹ️ Configuring Cilium in cluster kind-cmesh3 to connect to cluster kind-cmesh2,kind-cmesh4,kind-cmesh5,kind-cmesh6,kind-cmesh7,kind-cmesh1
Wed, 25 Sep 2024 07:31:24 GMT ℹ️ Configuring Cilium in cluster kind-cmesh5 to connect to cluster kind-cmesh2,kind-cmesh3,kind-cmesh4,kind-cmesh6,kind-cmesh7,kind-cmesh1
Wed, 25 Sep 2024 07:31:25 GMT ℹ️ Configuring Cilium in cluster kind-cmesh6 to connect to cluster kind-cmesh2,kind-cmesh3,kind-cmesh4,kind-cmesh5,kind-cmesh7,kind-cmesh1
Wed, 25 Sep 2024 07:31:25 GMT ℹ️ Configuring Cilium in cluster kind-cmesh7 to connect to cluster kind-cmesh2,kind-cmesh3,kind-cmesh4,kind-cmesh5,kind-cmesh6,kind-cmesh1
Wed, 25 Sep 2024 07:31:40 GMT ✅ Connected clusters kind-cmesh2, kind-cmesh3, kind-cmesh4, kind-cmesh5, kind-cmesh6, kind-cmesh7, and kind-cmesh1!
```
* The first line is the current context (it takes 6 seconds)
* The 3 next lines are the connection parallels
* When one connection is finished (after 11 seconds), it creates connection for the cluster kind-cmesh5
* Similar with kind-cmesh6 and kind-cmesh7 (it takes 15 seconds)

In total it took 33 seconds (better option than 5 parallels because the server only has 4 vCPU)

Test on 64 EKS clusters with `--parallel=7` and Pulumi (on 8vCPU): 132s (about 7 + 9*14): [Youtube](https://www.youtube.com/watch?v=TNgptskSJI4)


Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number
