### PR TITLE
endpoint: Add parent ifindex to endpoint and endpoint map

### DIFF
--- a/api/v1/models/endpoint_change_request.go
+++ b/api/v1/models/endpoint_change_request.go
@@ -79,6 +79,9 @@ type EndpointChangeRequest struct {
 	// Network namespace cookie
 	NetnsCookie string `json:"netns-cookie,omitempty"`
 
+	// Index of network device from which an IP was used as endpoint IP. Only relevant for ENI environments.
+	ParentInterfaceIndex int64 `json:"parent-interface-index,omitempty"`
+
 	// Process ID of the workload belonging to this endpoint
 	Pid int64 `json:"pid,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1395,6 +1395,11 @@ definitions:
       interface-index:
         description: Index of network device in host netns
         type: integer
+      parent-interface-index:
+        description: >-
+          Index of network device from which an IP was used as endpoint IP.
+          Only relevant for ENI environments.
+        type: integer
       container-interface-name:
         description: Name of network device in container netns
         type: string

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2895,6 +2895,10 @@ func init() {
           "description": "Network namespace cookie",
           "type": "string"
         },
+        "parent-interface-index": {
+          "description": "Index of network device from which an IP was used as endpoint IP. Only relevant for ENI environments.",
+          "type": "integer"
+        },
         "pid": {
           "description": "Process ID of the workload belonging to this endpoint",
           "type": "integer"
@@ -8669,6 +8673,10 @@ func init() {
         "netns-cookie": {
           "description": "Network namespace cookie",
           "type": "string"
+        },
+        "parent-interface-index": {
+          "description": "Index of network device from which an IP was used as endpoint IP. Only relevant for ENI environments.",
+          "type": "integer"
         },
         "pid": {
           "description": "Process ID of the workload belonging to this endpoint",

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -336,7 +336,8 @@ struct endpoint_info {
 	mac_t		mac;
 	mac_t		node_mac;
 	__u32		sec_id;
-	__u32		pad[3];
+	__u32		parent_ifindex;
+	__u32		pad[2];
 };
 
 struct edt_id {

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -62,6 +62,7 @@ func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, p
 	ep := createEndpoint(owner, policyGetter, namedPortsGetter, proxy, allocator, uint16(base.ID), base.InterfaceName)
 	ep.ifIndex = int(base.InterfaceIndex)
 	ep.containerIfName = base.ContainerInterfaceName
+	ep.parentIfIndex = int(base.ParentInterfaceIndex)
 	if base.ContainerName != "" {
 		ep.containerName.Store(&base.ContainerName)
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -112,6 +112,10 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 		fmt.Fprintf(fw, " * Container Interface: %s\n", e.containerIfName)
 	}
 
+	if e.parentIfIndex != 0 {
+		fmt.Fprintf(fw, " * Parent Interface IfIndex: %d\n", e.parentIfIndex)
+	}
+
 	if option.Config.EnableIPv6 {
 		fmt.Fprintf(fw, " * IPv6 address: %s\n", e.IPv6.String())
 	}

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -42,6 +42,7 @@ type epInfoCache struct {
 	options                *option.IntOptions
 	lxcMAC                 mac.MAC
 	ifIndex                int
+	parentIfIndex          int
 	netNsCookie            uint64
 
 	// endpoint is used to get the endpoint's logger.
@@ -74,6 +75,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		options:                e.Options.DeepCopy(),
 		lxcMAC:                 e.mac,
 		ifIndex:                e.ifIndex,
+		parentIfIndex:          e.parentIfIndex,
 		netNsCookie:            e.NetNsCookie,
 
 		endpoint: e,
@@ -83,6 +85,10 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 
 func (ep *epInfoCache) GetIfIndex() int {
 	return ep.ifIndex
+}
+
+func (ep *epInfoCache) GetParentIfIndex() int {
+	return ep.parentIfIndex
 }
 
 func (ep *epInfoCache) LXCMac() mac.MAC {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -191,6 +191,10 @@ type Endpoint struct {
 	// Immutable after Endpoint creation.
 	containerIfName string
 
+	// parentIfIndex is the interface index of the network device over which traffic
+	// with the source endpoints IP should egress when that traffic is not masqueraded.
+	parentIfIndex int
+
 	// disableLegacyIdentifiers disables lookup using legacy endpoint identifiers
 	// (container name, container id, pod name) for this endpoint.
 	// Immutable after Endpoint creation.
@@ -493,6 +497,11 @@ func (e *Endpoint) UpdateController(name string, params controller.ControllerPar
 // GetIfIndex returns the ifIndex for this endpoint.
 func (e *Endpoint) GetIfIndex() int {
 	return e.ifIndex
+}
+
+// GetParentIfIndex returns the parentIfIndex for this endpoint.
+func (e *Endpoint) GetParentIfIndex() int {
+	return e.parentIfIndex
 }
 
 // LXCMac returns the LXCMac for this endpoint.

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -58,6 +58,7 @@ type EndpointFrontend interface {
 	LXCMac() mac.MAC
 	GetNodeMAC() mac.MAC
 	GetIfIndex() int
+	GetParentIfIndex() int
 	GetID() uint64
 	IPv4Address() netip.Addr
 	IPv6Address() netip.Addr
@@ -97,18 +98,19 @@ func GetBPFValue(e EndpointFrontend) (*EndpointInfo, error) {
 
 	// Both lxc and node mac can be nil for the case of L3/NOARP devices.
 	info := &EndpointInfo{
-		IfIndex: uint32(e.GetIfIndex()),
-		LxcID:   uint16(e.GetID()),
-		MAC:     mac,
-		NodeMAC: nodeMAC,
-		SecID:   e.GetIdentity().Uint32(), // Host byte-order
+		IfIndex:       uint32(e.GetIfIndex()),
+		LxcID:         uint16(e.GetID()),
+		MAC:           mac,
+		NodeMAC:       nodeMAC,
+		SecID:         e.GetIdentity().Uint32(), // Host byte-order
+		ParentIfIndex: uint32(e.GetParentIfIndex()),
 	}
 
 	return info, nil
 
 }
 
-type pad3uint32 [3]uint32
+type pad2uint32 [2]uint32
 
 // EndpointInfo represents the value of the endpoints BPF map.
 //
@@ -119,11 +121,12 @@ type EndpointInfo struct {
 	LxcID   uint16 `align:"lxc_id"`
 	Flags   uint32 `align:"flags"`
 	// go alignment
-	_       uint32
-	MAC     mac.Uint64MAC `align:"mac"`
-	NodeMAC mac.Uint64MAC `align:"node_mac"`
-	SecID   uint32        `align:"sec_id"`
-	Pad     pad3uint32    `align:"pad"`
+	_             uint32
+	MAC           mac.Uint64MAC `align:"mac"`
+	NodeMAC       mac.Uint64MAC `align:"node_mac"`
+	SecID         uint32        `align:"sec_id"`
+	ParentIfIndex uint32        `align:"parent_ifindex"`
+	Pad           pad2uint32    `align:"pad"`
 }
 
 type EndpointKey struct {

--- a/plugins/cilium-cni/cmd/endpoint.go
+++ b/plugins/cilium-cni/cmd/endpoint.go
@@ -4,6 +4,8 @@
 package cmd
 
 import (
+	"strconv"
+
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/sirupsen/logrus"
 
@@ -86,6 +88,14 @@ func (c *defaultEndpointConfiguration) PrepareEndpoint(ipam *models.IPAMResponse
 	if c.Conf.IpamMode == ipamOption.IPAMDelegatedPlugin {
 		// Prevent cilium agent from trying to release the IP when the endpoint is deleted.
 		ep.DatapathConfiguration.ExternalIpam = true
+	}
+
+	if c.Conf.IpamMode == ipamOption.IPAMENI {
+		var err error
+		ep.ParentInterfaceIndex, err = strconv.ParseInt(ipam.IPV4.InterfaceNumber, 10, 64)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	state := &CmdState{


### PR DESCRIPTION
This commit adds a new field to the endpoint struct called the parent interface index. It records the ifindex of the ENI interface to which the endpoint "belongs". The IP of the endpoint is assigned from this ENI interface and all non-masquerade traffic from the endpoint should route through this interface. The value is only relevant for ENI environments and is set to 0 for non-ENI environments.

In a followup, the parent ifindex will be used by datapath changes to ensure that reply traffic from ENI endpoints is always routed back through the correct ENI interface.