### PR TITLE
Fix runtime panic with L2 announcer name generation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -593,6 +593,7 @@ Makefile* @cilium/build
 /pkg/safeio @cilium/sig-agent
 /pkg/safetime/ @cilium/sig-agent
 /pkg/service @cilium/sig-lb
+/pkg/shortener @cilium/sig-foundations @cilium/sig-k8s
 /pkg/signal @cilium/sig-datapath
 /pkg/slices @cilium/sig-foundations
 /pkg/socketlb @cilium/loader

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/shortener"
 )
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -337,7 +338,7 @@ func isAttachable(_ context.Context, gw *gatewayv1.Gateway, route metav1.Object,
 func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.Gateway) error {
 	svcList := &corev1.ServiceList{}
 	if err := r.Client.List(ctx, svcList, client.MatchingLabels{
-		owningGatewayLabel: model.Shorten(gw.GetName()),
+		owningGatewayLabel: shortener.ShortenK8sResourceName(gw.GetName()),
 	}, client.InNamespace(gw.GetNamespace())); err != nil {
 		return err
 	}
@@ -379,7 +380,7 @@ func (r *gatewayReconciler) setStaticAddressStatus(ctx context.Context, gw *gate
 	}
 	svcList := &corev1.ServiceList{}
 	if err := r.Client.List(ctx, svcList, client.MatchingLabels{
-		owningGatewayLabel: model.Shorten(gw.GetName()),
+		owningGatewayLabel: shortener.ShortenK8sResourceName(gw.GetName()),
 	}, client.InNamespace(gw.GetNamespace())); err != nil {
 		return err
 	}

--- a/operator/pkg/model/helpers.go
+++ b/operator/pkg/model/helpers.go
@@ -4,8 +4,6 @@
 package model
 
 import (
-	"crypto/sha256"
-	"fmt"
 	"slices"
 	"strings"
 
@@ -109,39 +107,4 @@ func hostnameMatchesWildcardHostname(hostname, wildcardHostname string) bool {
 
 	wildcardMatch := strings.TrimSuffix(hostname, strings.TrimPrefix(wildcardHostname, allHosts))
 	return len(wildcardMatch) > 0
-}
-
-// Shorten shortens the string to 63 characters.
-// this is the implicit required for all the resource naming in k8s.
-func Shorten(s string) string {
-	if len(s) > 63 {
-		return s[:52] + "-" + encodeHash(hash(s))
-	}
-	return s
-}
-
-// encodeHash encodes the first 10 characters of the hex string.
-// https://github.com/kubernetes/kubernetes/blob/f0dcf0614036d8c3cd1c9f3b3cf8df4bb1d8e44e/staging/src/k8s.io/kubectl/pkg/util/hash/hash.go#L105
-func encodeHash(hex string) string {
-	enc := []rune(hex[:10])
-	for i := range enc {
-		switch enc[i] {
-		case '0':
-			enc[i] = 'g'
-		case '1':
-			enc[i] = 'h'
-		case '3':
-			enc[i] = 'k'
-		case 'a':
-			enc[i] = 'm'
-		case 'e':
-			enc[i] = 't'
-		}
-	}
-	return string(enc)
-}
-
-// hash hashes `data` with sha256 and returns the hex string
-func hash(data string) string {
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(data)))
 }

--- a/operator/pkg/model/translation/cec_translator.go
+++ b/operator/pkg/model/translation/cec_translator.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/shortener"
 	"github.com/cilium/cilium/pkg/slices"
 )
 
@@ -154,7 +155,7 @@ func (i *cecTranslator) getServicesWithPorts(namespace string, name string, m *m
 	return []*ciliumv2.ServiceListener{
 		{
 			Namespace: namespace,
-			Name:      model.Shorten(name),
+			Name:      shortener.ShortenK8sResourceName(name),
 			Ports:     ports,
 		},
 	}

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/operator/pkg/model/translation"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/shortener"
 )
 
 var _ translation.Translator = (*gatewayAPITranslator)(nil)
@@ -125,11 +126,11 @@ func getService(resource *model.FullyQualifiedResource, allPorts []uint32, label
 		})
 	}
 
-	shortenName := model.Shorten(resource.Name)
+	shortenName := shortener.ShortenK8sResourceName(resource.Name)
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      model.Shorten(ciliumGatewayPrefix + resource.Name),
+			Name:      shortener.ShortenK8sResourceName(ciliumGatewayPrefix + resource.Name),
 			Namespace: resource.Namespace,
 			Labels: mergeMap(map[string]string{
 				owningGatewayLabel: shortenName,
@@ -155,11 +156,11 @@ func getService(resource *model.FullyQualifiedResource, allPorts []uint32, label
 }
 
 func getEndpoints(resource model.FullyQualifiedResource, labels, annotations map[string]string) *corev1.Endpoints {
-	shortedName := model.Shorten(resource.Name)
+	shortedName := shortener.ShortenK8sResourceName(resource.Name)
 
 	return &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      model.Shorten(ciliumGatewayPrefix + resource.Name),
+			Name:      shortener.ShortenK8sResourceName(ciliumGatewayPrefix + resource.Name),
 			Namespace: resource.Namespace,
 			Labels: mergeMap(map[string]string{
 				owningGatewayLabel: shortedName,
@@ -208,7 +209,7 @@ func decorateCEC(cec *ciliumv2.CiliumEnvoyConfig, resource *model.FullyQualified
 		cec.Labels = make(map[string]string)
 	}
 	cec.Labels = mergeMap(cec.Labels, labels)
-	cec.Labels[gatewayNameLabel] = model.Shorten(resource.Name)
+	cec.Labels[gatewayNameLabel] = shortener.ShortenK8sResourceName(resource.Name)
 	cec.Annotations = mergeMap(cec.Annotations, annotations)
 
 	return nil

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
+	"github.com/cilium/cilium/pkg/shortener"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -348,7 +349,7 @@ func registerSecretSyncer(params syncerParams) error {
 
 	for ns := range namespaces {
 		jobGroup.Add(job.Observer(
-			fmt.Sprintf("k8s-secrets-resource-events-%s", ns),
+			shortener.ShortenK8sResourceName(fmt.Sprintf("k8s-secrets-resource-events-%s", ns)),
 			secretSyncer.handleSecretEvent,
 			newK8sSecretResource(params.Lifecycle, params.K8sClientset, ns),
 		))

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -37,6 +37,7 @@ import (
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/shortener"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -740,7 +741,7 @@ func (l2a *L2Announcer) addSelectedService(svc *slim_corev1.Service, byPolicies 
 
 	// kick off leader election job
 	l2a.scopedGroup.Add(job.OneShot(
-		fmt.Sprintf("leader-election-%s-%s", svc.Namespace, svc.Name),
+		shortener.ShortenHiveJobName(fmt.Sprintf("leader-election-%s-%s", svc.Namespace, svc.Name)),
 		ss.serviceLeaderElection),
 	)
 }

--- a/pkg/shortener/shortener.go
+++ b/pkg/shortener/shortener.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package shortener
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+const (
+	// Maximum characters in a K8s resource name
+	k8sMaxResourceNameLength = 63
+)
+
+func ShortenK8sResourceName(s string) string {
+	return shorten(s, k8sMaxResourceNameLength)
+}
+
+// Shorten shortens the string to the arbitrary number of characters.
+func shorten(s string, length int) string {
+	if len(s) > length {
+		return s[:length-10-1] + "-" + encodeHash(hash(s))
+	}
+	return s
+}
+
+// encodeHash encodes the first 10 characters of the hex string.
+// https://github.com/kubernetes/kubernetes/blob/f0dcf0614036d8c3cd1c9f3b3cf8df4bb1d8e44e/staging/src/k8s.io/kubectl/pkg/util/hash/hash.go#L105
+func encodeHash(hex string) string {
+	enc := []rune(hex[:10])
+	for i := range enc {
+		switch enc[i] {
+		case '0':
+			enc[i] = 'g'
+		case '1':
+			enc[i] = 'h'
+		case '3':
+			enc[i] = 'k'
+		case 'a':
+			enc[i] = 'm'
+		case 'e':
+			enc[i] = 't'
+		}
+	}
+	return string(enc)
+}
+
+// hash hashes `data` with sha256 and returns the hex string
+func hash(data string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(data)))
+}

--- a/pkg/shortener/shortener.go
+++ b/pkg/shortener/shortener.go
@@ -11,10 +11,17 @@ import (
 const (
 	// Maximum characters in a K8s resource name
 	k8sMaxResourceNameLength = 63
+
+	// Maximum characters in a Hive job name
+	hiveMaxJobNameLength = 100
 )
 
 func ShortenK8sResourceName(s string) string {
 	return shorten(s, k8sMaxResourceNameLength)
+}
+
+func ShortenHiveJobName(s string) string {
+	return shorten(s, hiveMaxJobNameLength)
 }
 
 // Shorten shortens the string to the arbitrary number of characters.

--- a/pkg/shortener/shortener_test.go
+++ b/pkg/shortener/shortener_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package shortener
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShorten(t *testing.T) {
+	limit := k8sMaxResourceNameLength
+
+	// Shorter than limit
+	shorterName := "short"
+
+	// Equal to limit
+	equalName := "l" + strings.Repeat("o", limit-3) + "ng"
+
+	// Longer than limit
+	longerName := "very-l" + strings.Repeat("o", limit) + "ng"
+
+	shorterResult0 := shorten(shorterName, limit)
+	equalResult0 := shorten(equalName, limit)
+	longerResult0 := shorten(longerName, limit)
+
+	assert.Equal(t, shorterName, shorterResult0, "Shorter name wasn't kept as is")
+	assert.Equal(t, equalName, equalResult0, "Equal name wasn't kept as is")
+	assert.Len(t, longerResult0, 63, "Longer name wasn't shortened")
+
+	t.Logf("Shorter Name: %s", shorterResult0)
+	t.Logf("Equal Name  : %s", equalResult0)
+	t.Logf("Longer Name : %s", longerResult0)
+	t.Logf("Limit       : %s", strings.Repeat("=", limit))
+
+	shorterResult1 := shorten(shorterName, limit)
+	equalResult1 := shorten(equalName, limit)
+	longerResult1 := shorten(longerName, limit)
+
+	assert.Equal(t, shorterResult0, shorterResult1, "Shorter name wasn't matched with previous result")
+	assert.Equal(t, equalResult0, equalResult1, "Equal name wasn't matched with previous result")
+	assert.Equal(t, longerResult0, longerResult1, "Longer name wasn't matched with previous result")
+}


### PR DESCRIPTION
Since we upgrade the `hive` in [this PR](https://github.com/cilium/cilium/pull/34920), ConformanceGatewayAPI is failing consistently because the L2 announcer is hitting the newly introduced Job name limit.

```
2024-09-24T19:58:20.700855025Z panic: invalid job name: "leader-election-gateway-conformance-infra-cilium-gateway-http-listener-isolation-with-hostname-h56mb54hf8", expected to match "^[a-z][a-z0-9_\\-]{0,100}$"
2024-09-24T19:58:20.700873208Z 
2024-09-24T19:58:20.700876094Z goroutine 356 [running]:
2024-09-24T19:58:20.700878689Z github.com/cilium/hive/job.OneShot({0xc000ded1f0, 0x69}, 0xc0008cb470, {0x0, 0x0, 0x0})
2024-09-24T19:58:20.700881274Z 	/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/oneshot.go:27 +0xe5
2024-09-24T19:58:20.700892354Z github.com/cilium/cilium/pkg/l2announcer.(*L2Announcer).addSelectedService(0xc00208a240, 0xc002a5f0e0, {0xc0015486e0, 0x1, 0x1})
2024-09-24T19:58:20.700898256Z 	/go/src/github.com/cilium/cilium/pkg/l2announcer/l2announcer.go:742 +0x29f
2024-09-24T19:58:20.700919395Z github.com/cilium/cilium/pkg/l2announcer.(*L2Announcer).upsertPolicy(0xc00208a240, {0x4a2a990, 0xc0007a9ad0}, 0xc0027ae2c0)
2024-09-24T19:58:20.700922020Z 	/go/src/github.com/cilium/cilium/pkg/l2announcer/l2announcer.go:559 +0xe65
2024-09-24T19:58:20.700928001Z github.com/cilium/cilium/pkg/l2announcer.(*L2Announcer).upsertLocalNode(0xc00208a240, {0x4a2a990, 0xc0007a9ad0}, 0xc0008e69f0?)
2024-09-24T19:58:20.700931167Z 	/go/src/github.com/cilium/cilium/pkg/l2announcer/l2announcer.go:859 +0x4d7
2024-09-24T19:58:20.700940654Z github.com/cilium/cilium/pkg/l2announcer.(*L2Announcer).processLocalNodeEvent(0x0?, {0x4a2a990?, 0xc0007a9ad0?}, {{0x435984f, 0x6}, {{0xc0028ca330, 0x14}, {0x0, 0x0}}, 0xc00123f808, ...})
2024-09-24T19:58:20.700955522Z 	/go/src/github.com/cilium/cilium/pkg/l2announcer/l2announcer.go:808 +0x52
2024-09-24T19:58:20.700963447Z github.com/cilium/cilium/pkg/l2announcer.(*L2Announcer).run(0xc00208a240, {0x4a2a990, 0xc0007a9ad0}, {0xc002b0fd78?, 0x4afcaf?})
2024-09-24T19:58:20.700970981Z 	/go/src/github.com/cilium/cilium/pkg/l2announcer/l2announcer.go:164 +0x41d
2024-09-24T19:58:20.701000025Z github.com/cilium/hive/job.(*jobOneShot).start(0xc001e28cc0, {0x4a2a990, 0xc0007a9ad0}, 0x0?, {0x4a33960, 0xc001e28c00}, {{{0xc000df99e0, 0x1, 0x1}}, 0xc000edc5d0, ...})
2024-09-24T19:58:20.701005265Z 	/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/oneshot.go:140 +0x503
2024-09-24T19:58:20.701012609Z created by github.com/cilium/hive/job.(*group).Start.func1 in goroutine 1
2024-09-24T19:58:20.701019973Z 	/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/job.go:161 +0x174
```

Fixes: #34920 

```release-note
Fix runtime panic with L2announcer name generation
```
