### PR TITLE
fix(service): fix id allocator stuck in an infinite loop

### DIFF
--- a/pkg/service/id_local.go
+++ b/pkg/service/id_local.go
@@ -88,9 +88,7 @@ func (alloc *IDAllocator) acquireLocalID(svc loadbalancer.L3n4Addr, desiredID ui
 	startingID := alloc.nextID
 	rollover := false
 	for {
-		if alloc.nextID == startingID && rollover {
-			break
-		} else if alloc.nextID == alloc.maxID {
+		if alloc.nextID == alloc.maxID {
 			alloc.nextID = alloc.initNextID
 			rollover = true
 		}
@@ -99,6 +97,10 @@ func (alloc *IDAllocator) acquireLocalID(svc loadbalancer.L3n4Addr, desiredID ui
 			svcID := alloc.addID(svc, alloc.nextID)
 			alloc.nextID++
 			return svcID, nil
+		}
+
+		if alloc.nextID == startingID && rollover {
+			break
 		}
 
 		alloc.nextID++


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

Fixes: #35032

```release-note
Fixed bug where service id allocator would loop infinity when out of service ids
```
