### PR TITLE
v1.16 Backports 2024-09-25

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -153,7 +153,7 @@ jobs:
           cmd: |
             cd /host/
             # Run with cgo disabled, LVH images don't ship with gcc.
-            CGO_ENABLED=0 go${{ env.go-version }} test -v -parallel=1 ./test/verifier -cilium-base-path /host -ci-kernel-version ${{ matrix.ci-kernel }}
+            CGO_ENABLED=0 go${{ env.go-version }} test -v -parallel=1 -timeout=20m ./test/verifier -cilium-base-path /host -ci-kernel-version ${{ matrix.ci-kernel }}
 
       - name: Fetch artifacts
         if: ${{ !success() }}

--- a/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
@@ -86,6 +86,7 @@ The ``CiliumBGPPeerConfig`` resource contains configuration options for:
 
 - :ref:`MD5 Password <bgp_peer_configuration_password>`
 - :ref:`Timers <bgp_peer_configuration_timers>`
+- :ref:`EBGP Multihop <bgp_ebgp_multihop>`
 - :ref:`Graceful Restart <bgp_peer_configuration_graceful_restart>`
 - :ref:`Transport <bgp_peer_configuration_transport>`
 - :ref:`Address Families <bgp_peer_configuration_afi>`
@@ -104,6 +105,7 @@ section, we will go over each configuration option.
         holdTimeSeconds: 9
         keepAliveTimeSeconds: 3
       authSecretRef: bgp-auth-secret
+      ebgpMultihop: 4
       gracefulRestart:
         enabled: true
         restartTimeSeconds: 15
@@ -203,6 +205,24 @@ possible values ``holdTimeSeconds=9`` and ``keepAliveTimeSeconds=3``.
         holdTimeSeconds: 9
         keepAliveTimeSeconds: 3
 
+.. _bgp_ebgp_multihop:
+
+EBGP Multihop
+-------------
+
+By default, IP TTL of the BGP packets is set to 1 in eBGP. Generally, it is
+encouraged to not change the TTL, but in some cases, you may need to change the
+TTL value. For example, when the BGP peer is a Route Server and located in a
+different subnet, you may need to set the TTL value to more than 1.
+
+.. code-block:: yaml
+
+    apiVersion: cilium.io/v2alpha1
+    kind: CiliumBGPPeerConfig
+    metadata:
+      name: cilium-peer
+    spec:
+      ebgpMultihop: 4 # <-- specify the TTL value
 
 .. _bgp_peer_configuration_graceful_restart:
 

--- a/Documentation/network/kubernetes/compatibility.rst
+++ b/Documentation/network/kubernetes/compatibility.rst
@@ -38,7 +38,7 @@ Kubernetes offerings using multiple Kubernetes versions. See the following links
 for the current test matrix for each cloud provider:
 
 - :git-tree:`AKS <.github/actions/azure/k8s-versions.yaml>`
-- :git-tree:`EKS <.github/actions/aws/k8s-versions.yaml>`
+- :git-tree:`EKS <.github/actions/eks/k8s-versions.yaml>`
 - :git-tree:`GKE <.github/actions/gke/k8s-versions.yaml>`
 
 Cilium CRD schema validation

--- a/Documentation/network/kubernetes/requirements.rst
+++ b/Documentation/network/kubernetes/requirements.rst
@@ -28,7 +28,7 @@ Kubernetes offerings using multiple Kubernetes versions. See the following links
 for the current test matrix for each cloud provider:
 
 - :git-tree:`AKS <.github/actions/azure/k8s-versions.yaml>`
-- :git-tree:`EKS <.github/actions/aws/k8s-versions.yaml>`
+- :git-tree:`EKS <.github/actions/eks/k8s-versions.yaml>`
 - :git-tree:`GKE <.github/actions/gke/k8s-versions.yaml>`
 
 System Requirements

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -65,6 +65,12 @@ __snat_create(const void *map, const void *tuple, const void *state)
 	return map_update_elem(map, tuple, state, BPF_NOEXIST);
 }
 
+static __always_inline __maybe_unused int
+__snat_delete(const void *map, const void *tuple)
+{
+	return map_delete_elem(map, tuple);
+}
+
 struct ipv4_nat_entry {
 	struct nat_entry common;
 	union {
@@ -158,6 +164,19 @@ struct ipv4_nat_entry *snat_v4_lookup(const struct ipv4_ct_tuple *tuple)
 	return __snat_lookup(&SNAT_MAPPING_IPV4, tuple);
 }
 
+static __always_inline void
+set_v4_rtuple(const struct ipv4_ct_tuple *otuple,
+	      const struct ipv4_nat_entry *ostate,
+	      struct ipv4_ct_tuple *rtuple)
+{
+	rtuple->flags = TUPLE_F_IN;
+	rtuple->nexthdr = otuple->nexthdr;
+	rtuple->saddr = otuple->daddr;
+	rtuple->daddr = ostate->to_saddr;
+	rtuple->sport = otuple->dport;
+	rtuple->dport = ostate->to_sport;
+}
+
 static __always_inline int snat_v4_new_mapping(struct __ctx_buff *ctx, void *map,
 					       struct ipv4_ct_tuple *otuple,
 					       struct ipv4_nat_entry *ostate,
@@ -179,11 +198,7 @@ static __always_inline int snat_v4_new_mapping(struct __ctx_buff *ctx, void *map
 	/* .to_sport is selected below */
 
 	/* This tuple matches reply traffic for the SNATed connection: */
-	rtuple.flags = TUPLE_F_IN;
-	rtuple.nexthdr = otuple->nexthdr;
-	rtuple.saddr = otuple->daddr;
-	rtuple.daddr = ostate->to_saddr;
-	rtuple.sport = otuple->dport;
+	set_v4_rtuple(otuple, ostate, &rtuple);
 	/* .dport is selected below */
 
 	port = __snat_try_keep_port(target->min_port,
@@ -281,8 +296,30 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 	}
 
 	if (*state) {
-		barrier_data(*state);
-		return 0;
+		int ret;
+		struct ipv4_ct_tuple rtuple = {};
+
+		if (target->addr == (*state)->to_saddr &&
+		    needs_ct == (*state)->common.needs_ct) {
+			barrier_data(*state);
+			return 0;
+		}
+
+		/* Recreate the SNAT and RevSNAT entries if the source IP is stale.
+		 * Otherwise, the packet will be erroneously SNATed with the stale
+		 * source IP.
+		 */
+		ret = __snat_delete(map, tuple);
+		if (IS_ERR(ret))
+			return ret;
+
+		set_v4_rtuple(tuple, *state, &rtuple);
+		*state = __snat_lookup(map, &rtuple);
+		if (*state)
+			/* snat_v4_new_mapping will create new RevSNAT entry even if deleting
+			 * the old RevSNAT entry fails. We would leave it behind though.
+			 */
+			__snat_delete(map, &rtuple);
 	}
 
 	*state = tmp;
@@ -1037,6 +1074,19 @@ struct ipv6_nat_entry *snat_v6_lookup(const struct ipv6_ct_tuple *tuple)
 	return __snat_lookup(&SNAT_MAPPING_IPV6, tuple);
 }
 
+static __always_inline void
+set_v6_rtuple(const struct ipv6_ct_tuple *otuple,
+	      const struct ipv6_nat_entry *ostate,
+	      struct ipv6_ct_tuple *rtuple)
+{
+	rtuple->flags = TUPLE_F_IN;
+	rtuple->nexthdr = otuple->nexthdr;
+	rtuple->saddr = otuple->daddr;
+	rtuple->daddr = ostate->to_saddr;
+	rtuple->sport = otuple->dport;
+	rtuple->dport = ostate->to_sport;
+}
+
 static __always_inline int snat_v6_new_mapping(struct __ctx_buff *ctx,
 					       struct ipv6_ct_tuple *otuple,
 					       struct ipv6_nat_entry *ostate,
@@ -1057,11 +1107,7 @@ static __always_inline int snat_v6_new_mapping(struct __ctx_buff *ctx,
 	ostate->to_saddr = target->addr;
 	/* .to_sport is selected below */
 
-	rtuple.flags = TUPLE_F_IN;
-	rtuple.nexthdr = otuple->nexthdr;
-	rtuple.saddr = otuple->daddr;
-	rtuple.daddr = ostate->to_saddr;
-	rtuple.sport = otuple->dport;
+	set_v6_rtuple(otuple, ostate, &rtuple);
 	/* .dport is selected below */
 
 	port = __snat_try_keep_port(target->min_port,
@@ -1146,8 +1192,24 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 	}
 
 	if (*state) {
-		barrier_data(*state);
-		return 0;
+		int ret;
+		struct ipv6_ct_tuple rtuple = {};
+
+		if (ipv6_addr_equals(&target->addr, &(*state)->to_saddr) &&
+		    needs_ct == (*state)->common.needs_ct) {
+			barrier_data(*state);
+			return 0;
+		}
+
+		/* See comment in snat_v4_nat_handle_mapping */
+		ret = __snat_delete(&SNAT_MAPPING_IPV6, tuple);
+		if (IS_ERR(ret))
+			return ret;
+
+		set_v6_rtuple(tuple, *state, &rtuple);
+		*state = snat_v6_lookup(&rtuple);
+		if (*state)
+			__snat_delete(&SNAT_MAPPING_IPV6, &rtuple);
 	}
 
 	*state = tmp;

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -84,7 +84,7 @@ set_identity_mark(struct __sk_buff *ctx, __u32 identity, __u32 magic)
 	__u32 cluster_id_lower = cluster_id & 0xFF;
 	__u32 cluster_id_upper = ((cluster_id & 0xFFFFFF00) << (8 + IDENTITY_LEN));
 
-	ctx->mark |= magic;
+	ctx->mark = (magic & MARK_MAGIC_KEY_MASK);
 	ctx->mark &= MARK_MAGIC_KEY_MASK;
 	ctx->mark |= (identity & IDENTITY_MAX) << 16 | cluster_id_lower | cluster_id_upper;
 }

--- a/bpf/tests/bpf_skb_255_tests.c
+++ b/bpf/tests/bpf_skb_255_tests.c
@@ -42,6 +42,28 @@ int check_get_identity(struct __ctx_buff *ctx)
 	test_finish();
 }
 
+CHECK("tc", "set_identity_mark_bits")
+int set_identity_mark_bits(struct __ctx_buff *ctx)
+{
+	test_init();
+
+	set_identity_mark(ctx, 0x0, MARK_MAGIC_IDENTITY);
+	set_identity_mark(ctx, 0x0, MARK_MAGIC_OVERLAY);
+
+	if ((ctx->mark & MARK_MAGIC_HOST_MASK) != MARK_MAGIC_OVERLAY)
+		test_fatal("expected %x got %x", MARK_MAGIC_OVERLAY, ctx->mark);
+
+	set_identity_mark(ctx, 0x0, 0x000);
+	if ((ctx->mark & MARK_MAGIC_HOST_MASK) != 0)
+		test_fatal("expected %x got %x", 0, ctx->mark);
+
+	set_identity_mark(ctx, 0x0, MARK_MAGIC_HOST_MASK);
+	if ((ctx->mark & MARK_MAGIC_HOST_MASK) != MARK_MAGIC_HOST_MASK)
+		test_fatal("expected %x got %x", MARK_MAGIC_HOST_MASK, ctx->mark);
+
+	test_finish();
+}
+
 CHECK("tc", "set_and_get_cluster_id")
 int check_ctx_get_cluster_id_mark(struct __ctx_buff *ctx)
 {

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -172,6 +172,118 @@ int egressgw_snat2_check(struct __ctx_buff *ctx)
 	return ret;
 }
 
+/* Test that a packet matching an egress gateway policy on the to-netdev program
+ * gets correctly SNATed with the desired egress IP of the policy, event if the
+ * packet hits a stale NAT entry.
+ */
+PKTGEN("tc", "tc_egressgw_tuple_collision1")
+int egressgw_tuple_collision1_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+		});
+}
+
+SETUP("tc", "tc_egressgw_tuple_collision1")
+int egressgw_tuple_collision1_setup(struct __ctx_buff *ctx)
+{
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
+				  GATEWAY_NODE_IP, EGRESS_IP);
+
+	/* Jump into the entrypoint */
+	ctx_egw_done_set(ctx);
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_tuple_collision1")
+int egressgw_tuple_collision1_check(const struct __ctx_buff *ctx)
+{
+	int ret = egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+			.packets = 1,
+			.status_code = CTX_ACT_OK
+		});
+
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0Xffffff, 24);
+
+	return ret;
+}
+
+PKTGEN("tc", "tc_egressgw_tuple_collision2")
+int egressgw_tuple_collision2_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+		});
+}
+
+SETUP("tc", "tc_egressgw_tuple_collision2")
+int egressgw_tuple_collision2_setup(struct __ctx_buff *ctx)
+{
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
+				  GATEWAY_NODE_IP, EGRESS_IP3);
+
+	/* Jump into the entrypoint */
+	ctx_egw_done_set(ctx);
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_tuple_collision2")
+int egressgw_tuple_collision2_check(const struct __ctx_buff *ctx)
+{
+	return egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+			.tuple_collision = true,
+			.packets = 2,
+			.status_code = CTX_ACT_OK
+		});
+}
+
+/* Test that a packet matching an egress gateway policy on the from-netdev program
+ * gets correctly revSNATed and connection tracked, even if the packet hits a
+ * stale NAT entry.
+ */
+PKTGEN("tc", "tc_egressgw_tuple_collision2_reply")
+int egressgw_tuple_collision2_reply_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+			.tuple_collision = true,
+			.dir = CT_INGRESS,
+		});
+}
+
+SETUP("tc", "tc_egressgw_tuple_collision2_reply")
+int egressgw_tuple_collision2_reply_setup(struct __ctx_buff *ctx)
+{
+	/* install ipcache entry for the CLIENT_IP: */
+	ipcache_v4_add_entry(CLIENT_IP, 0, 0, CLIENT_NODE_IP, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_tuple_collision2_reply")
+int egressgw_tuple_collision2_reply_check(const struct __ctx_buff *ctx)
+{
+	int ret = egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+			.dir = CT_INGRESS,
+			.packets = 3,
+			.status_code = CTX_ACT_REDIRECT,
+		});
+
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0Xffffff, 24);
+
+	return ret;
+}
+
 /* Test that a packet matching an excluded CIDR egress gateway policy on the
  * to-netdev program does not get SNATed with the egress IP of the policy.
  */

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/metrics-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/metrics-server-secret.yaml
@@ -29,4 +29,9 @@ spec:
   duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
   privateKey:
     rotationPolicy: Always
+  isCA: false
+  usages:
+    - signing
+    - key encipherment
+    - server auth
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
@@ -19,4 +19,9 @@ spec:
   duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
   privateKey:
     rotationPolicy: Always
+  isCA: false
+  usages:
+    - signing
+    - key encipherment
+    - client auth
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
@@ -28,4 +28,9 @@ spec:
   duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
   privateKey:
     rotationPolicy: Always
+  isCA: false
+  usages:
+    - signing
+    - key encipherment
+    - server auth
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
@@ -29,4 +29,10 @@ spec:
   duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
   privateKey:
     rotationPolicy: Always
+  isCA: false
+  usages:
+    - signing
+    - key encipherment
+    - server auth
+    - client auth
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
@@ -19,4 +19,9 @@ spec:
   duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
   privateKey:
     rotationPolicy: Always
+  isCA: false
+  usages:
+    - signing
+    - key encipherment
+    - client auth
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
@@ -54,6 +54,7 @@ spec:
                   - signing
                   - key encipherment
                   - server auth
+                  - client auth
                   validity: {{ $certValidityStr }}
                 {{- if .Values.hubble.relay.enabled }}
                 - name: hubble-relay-client-certs

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -652,6 +652,11 @@ func (ipam *LBIPAM) stripOrImportIngresses(sv *ServiceView) (statusModified bool
 				IP:     ip,
 				Origin: lbRange,
 			})
+
+			// If the `ServiceView` has a sharing key, add the IP to the `rangeStore` index
+			if sv.SharingKey != "" {
+				ipam.rangesStore.AddServiceViewIPForSharingKey(sv.SharingKey, &sv.AllocatedIPs[len(sv.AllocatedIPs)-1])
+			}
 		}
 
 		newIngresses = append(newIngresses, ingress)

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -136,55 +136,51 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, p ReconcileParams) er
 }
 
 func (r *ServiceReconciler) reconcileServices(ctx context.Context, p ReconcileParams, ls sets.Set[resource.Key], fullReconcile bool) error {
-	var desiredSvcRoutePolicies ResourceRoutePolicyMap
-	var desiredSvcPaths ResourceAFPathsMap
-	var err error
+	var (
+		toReconcile []*slim_corev1.Service
+		toWithdraw  []resource.Key
+
+		desiredSvcRoutePolicies ResourceRoutePolicyMap
+		desiredSvcPaths         ResourceAFPathsMap
+
+		err error
+	)
 
 	if fullReconcile {
 		r.logger.Debug("performing all services reconciliation")
 
-		// Init diff in diffstores, so that it contains only changes since the last full reconciliation.
-		// Despite doing it in Init(), we still need this InitDiff to clean up the old diff when the instance is re-created
-		// by the preflight reconciler. Once Init() is called upon re-create by preflight, we can remove this.
-		r.svcDiffStore.InitDiff(r.diffID(p.BGPInstance.ASN))
-		r.epDiffStore.InitDiff(r.diffID(p.BGPInstance.ASN))
-
-		desiredSvcRoutePolicies, err = r.getAllRoutePolicies(p, ls)
-		if err != nil {
-			return err
-		}
-
-		// BGP configuration for service advertisement changed, we should reconcile all services.
-		desiredSvcPaths, err = r.getAllPaths(p, ls)
+		// get all services to reconcile and to withdraw.
+		toReconcile, toWithdraw, err = r.fullReconciliationServiceList(p)
 		if err != nil {
 			return err
 		}
 	} else {
 		r.logger.Debug("performing modified services reconciliation")
 
-		// get services to reconcile and to withdraw.
-		// Note : we should only call svc diff only once in a reconcile loop.
-		toReconcile, toWithdraw, err := r.diffReconciliationServiceList(p)
+		// get modified services to reconcile and to withdraw.
+		// Note: we should call svc diff only once in a reconcile loop.
+		toReconcile, toWithdraw, err = r.diffReconciliationServiceList(p)
 		if err != nil {
 			return err
 		}
+	}
 
-		desiredSvcRoutePolicies, err = r.getDiffRoutePolicies(p, toReconcile, toWithdraw, ls)
-		if err != nil {
-			return err
-		}
-
-		// BGP configuration is unchanged, only reconcile modified services.
-		desiredSvcPaths, err = r.getDiffPaths(p, toReconcile, toWithdraw, ls)
-		if err != nil {
-			return err
-		}
+	// get desired service route policies
+	desiredSvcRoutePolicies, err = r.getDesiredRoutePolicies(p, toReconcile, toWithdraw, ls)
+	if err != nil {
+		return err
 	}
 
 	// reconcile service route policies
 	err = r.reconcileSvcRoutePolicies(ctx, p, desiredSvcRoutePolicies)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile service route policies: %w", err)
+	}
+
+	// get desired service paths
+	desiredSvcPaths, err = r.getDesiredPaths(p, toReconcile, toWithdraw, ls)
+	if err != nil {
+		return err
 	}
 
 	// reconcile service paths
@@ -225,48 +221,7 @@ func (r *ServiceReconciler) reconcileSvcRoutePolicies(ctx context.Context, p Rec
 	return err
 }
 
-func (r *ServiceReconciler) getAllRoutePolicies(p ReconcileParams, ls sets.Set[resource.Key]) (ResourceRoutePolicyMap, error) {
-	desiredSvcRoutePolicies := make(ResourceRoutePolicyMap)
-
-	// check for services which are no longer present
-	svcRoutePolicies := r.getMetadata(p.BGPInstance).ServiceRoutePolicies
-	for svcKey := range svcRoutePolicies {
-		_, exists, err := r.svcDiffStore.GetByKey(svcKey)
-		if err != nil {
-			return nil, fmt.Errorf("svcDiffStore.GetByKey(): %w", err)
-		}
-
-		// if the service no longer exists, withdraw it
-		if !exists {
-			desiredSvcRoutePolicies[svcKey] = nil
-		}
-	}
-
-	// check all services for route policies
-	svcList, err := r.svcDiffStore.List()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list services from svcDiffstore: %w", err)
-	}
-
-	for _, svc := range svcList {
-		svcKey := resource.Key{
-			Name:      svc.GetName(),
-			Namespace: svc.GetNamespace(),
-		}
-
-		// get desired route policies for the service
-		svcRoutePolicies, err := r.getDesiredSvcRoutePolicies(p, svc, ls)
-		if err != nil {
-			return nil, err
-		}
-
-		desiredSvcRoutePolicies[svcKey] = svcRoutePolicies
-	}
-
-	return desiredSvcRoutePolicies, nil
-}
-
-func (r *ServiceReconciler) getDiffRoutePolicies(p ReconcileParams, toUpdate []*slim_corev1.Service, toRemove []resource.Key, ls sets.Set[resource.Key]) (ResourceRoutePolicyMap, error) {
+func (r *ServiceReconciler) getDesiredRoutePolicies(p ReconcileParams, toUpdate []*slim_corev1.Service, toRemove []resource.Key, ls sets.Set[resource.Key]) (ResourceRoutePolicyMap, error) {
 	desiredSvcRoutePolicies := make(ResourceRoutePolicyMap)
 
 	for _, svc := range toUpdate {
@@ -445,68 +400,31 @@ func (r *ServiceReconciler) resolveSvcFromEndpoints(eps *k8s.Endpoints) (*slim_c
 	return r.svcDiffStore.GetByKey(k)
 }
 
-func (r *ServiceReconciler) getAllPaths(p ReconcileParams, ls sets.Set[resource.Key]) (ResourceAFPathsMap, error) {
-	desiredServiceAFPaths := make(ResourceAFPathsMap)
+func (r *ServiceReconciler) fullReconciliationServiceList(p ReconcileParams) (toReconcile []*slim_corev1.Service, toWithdraw []resource.Key, err error) {
+	// re-init diff in diffstores, so that it contains only changes since the last full reconciliation.
+	r.svcDiffStore.InitDiff(r.diffID(p.BGPInstance.ASN))
+	r.epDiffStore.InitDiff(r.diffID(p.BGPInstance.ASN))
 
 	// check for services which are no longer present
 	serviceAFPaths := r.getMetadata(p.BGPInstance).ServicePaths
 	for svcKey := range serviceAFPaths {
 		_, exists, err := r.svcDiffStore.GetByKey(svcKey)
 		if err != nil {
-			return nil, fmt.Errorf("svcDiffStore.GetByKey(): %w", err)
+			return nil, nil, fmt.Errorf("svcDiffStore.GetByKey(): %w", err)
 		}
 
 		// if the service no longer exists, withdraw it
 		if !exists {
-			desiredServiceAFPaths[svcKey] = nil
+			toWithdraw = append(toWithdraw, svcKey)
 		}
 	}
 
 	// check all services for advertisement
-	svcList, err := r.svcDiffStore.List()
+	toReconcile, err = r.svcDiffStore.List()
 	if err != nil {
-		return nil, fmt.Errorf("failed to list services from svcDiffstore: %w", err)
+		return nil, nil, fmt.Errorf("failed to list services from svcDiffstore: %w", err)
 	}
-
-	for _, svc := range svcList {
-		svcKey := resource.Key{
-			Name:      svc.GetName(),
-			Namespace: svc.GetNamespace(),
-		}
-
-		afPaths, err := r.getServiceAFPaths(p, svc, ls)
-		if err != nil {
-			return nil, err
-		}
-
-		desiredServiceAFPaths[svcKey] = afPaths
-	}
-
-	return desiredServiceAFPaths, nil
-}
-
-func (r *ServiceReconciler) getDiffPaths(p ReconcileParams, toReconcile []*slim_corev1.Service, toWithdraw []resource.Key, ls sets.Set[resource.Key]) (ResourceAFPathsMap, error) {
-	desiredServiceAFPaths := make(ResourceAFPathsMap)
-	for _, svc := range toReconcile {
-		svcKey := resource.Key{
-			Name:      svc.GetName(),
-			Namespace: svc.GetNamespace(),
-		}
-
-		afPaths, err := r.getServiceAFPaths(p, svc, ls)
-		if err != nil {
-			return nil, err
-		}
-
-		desiredServiceAFPaths[svcKey] = afPaths
-	}
-
-	for _, svcKey := range toWithdraw {
-		// for withdrawn services, we need to set paths to nil.
-		desiredServiceAFPaths[svcKey] = nil
-	}
-
-	return desiredServiceAFPaths, nil
+	return
 }
 
 // diffReconciliationServiceList returns a list of services to reconcile and to withdraw when
@@ -560,6 +478,30 @@ func (r *ServiceReconciler) diffReconciliationServiceList(p ReconcileParams) (to
 	)
 
 	return deduped, deleted, nil
+}
+
+func (r *ServiceReconciler) getDesiredPaths(p ReconcileParams, toReconcile []*slim_corev1.Service, toWithdraw []resource.Key, ls sets.Set[resource.Key]) (ResourceAFPathsMap, error) {
+	desiredServiceAFPaths := make(ResourceAFPathsMap)
+	for _, svc := range toReconcile {
+		svcKey := resource.Key{
+			Name:      svc.GetName(),
+			Namespace: svc.GetNamespace(),
+		}
+
+		afPaths, err := r.getServiceAFPaths(p, svc, ls)
+		if err != nil {
+			return nil, err
+		}
+
+		desiredServiceAFPaths[svcKey] = afPaths
+	}
+
+	for _, svcKey := range toWithdraw {
+		// for withdrawn services, we need to set paths to nil.
+		desiredServiceAFPaths[svcKey] = nil
+	}
+
+	return desiredServiceAFPaths, nil
 }
 
 func (r *ServiceReconciler) getServiceAFPaths(p ReconcileParams, svc *slim_corev1.Service, ls sets.Set[resource.Key]) (AFPathsMap, error) {

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -915,7 +915,7 @@ func setSoMarks(fd int, ipFamily ipfamily.IPFamily, secId identity.NumericIdenti
 func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	stat := ProxyRequestContext{DataSource: accesslog.DNSSourceProxy}
 	stat.TotalTime.Start()
-	requestID := request.Id // keep the original request ID
+	requestID := request.Id // save the original request ID
 	qname := string(request.Question[0].Name)
 	protocol := w.LocalAddr().Network()
 	epIPPort := w.RemoteAddr().String()
@@ -1081,7 +1081,6 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		SingleInflight: false,
 	}
 
-	request.Id = dns.Id() // force a random new ID for this request
 	response, _, closer, err := p.DNSClients.Exchange(key, conf, request, targetServerAddrStr)
 	defer closer()
 
@@ -1107,7 +1106,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServerAddrStr, response, protocol, true, &stat)
 
 	scopedLog.Debug("Responding to original DNS query")
-	// restore the ID to the one in the initial request so it matches what the requester expects.
+	// Ensure the ID matches the initial request - the upstream query may have changed the ID to avoid duplicates.
 	response.Id = requestID
 	response.Compress = p.EnableDNSCompression && shouldCompressResponse(request, response)
 	err = w.WriteMsg(response)

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -30,36 +30,58 @@ import (
 
 // Identity is the identity representation of an IP<->Identity cache.
 type Identity struct {
-	// ID is the numeric identity
-	ID identity.NumericIdentity
+	// Note: The ordering of these fields is optimized to reduce padding
 
 	// Source is the source of the identity in the cache
 	Source source.Source
+
+	// overwrittenLegacySource contains the source of the original entry created
+	// via legacy API. This is preserved so that original source can be restored
+	// if the metadata API stops managing the entry.
+	overwrittenLegacySource source.Source
+
+	// ID is the numeric identity
+	ID identity.NumericIdentity
 
 	// This blank field ensures that the == operator cannot be used on this
 	// type, to avoid external packages accidentally comparing the private
 	// values below
 	_ []struct{}
 
+	// modifiedByLegacyAPI indicates that this entry touched by the legacy Upsert API.
+	// This informs the metadata subsystem to retain the original source and
+	// to clean up the entry if the legacy API already dropped its reference.
+	// upsertLocked will ensure that this field remains true once set. In other
+	// words, there is no way unset this field once set.
+	// This field is intended to be removed once cilium/cilium#21142 has been
+	// fully implemented and all entries are created via the new metadata API
+	modifiedByLegacyAPI bool
+
 	// shadowed determines if another entry overlaps with this one.
 	// Shadowed identities are not propagated to listeners by default.
 	// Most commonly set for Identity with Source = source.Generated when
 	// a pod IP (other source) has the same IP.
 	shadowed bool
-
-	// createdFromMetadata indicates that this entry was created via the new
-	// metadata API. This is needed to know if it is safe to delete
-	// an IPCache entry when no further metadata is associated with its prefix.
-	// This field is intended to be removed once cilium/cilium#21142 has been
-	// fully implemented and all entries are created via the new metadata API
-	createdFromMetadata bool
 }
 
 func (i Identity) equals(o Identity) bool {
 	return i.ID == o.ID &&
 		i.Source == o.Source &&
 		i.shadowed == o.shadowed &&
-		i.createdFromMetadata == o.createdFromMetadata
+		i.modifiedByLegacyAPI == o.modifiedByLegacyAPI &&
+		i.overwrittenLegacySource == o.overwrittenLegacySource
+}
+
+func (i Identity) exclusivelyOwnedByLegacyAPI() bool {
+	return i.modifiedByLegacyAPI && i.overwrittenLegacySource == ""
+}
+
+func (i Identity) exclusivelyOwnedByMetadataAPI() bool {
+	return !i.modifiedByLegacyAPI
+}
+
+func (i Identity) ownedByLegacyAndMetadataAPI() bool {
+	return i.modifiedByLegacyAPI && i.overwrittenLegacySource != ""
 }
 
 // IPKeyPair is the (IP, key) pair used of the identity
@@ -260,7 +282,7 @@ func (ipc *IPCache) getK8sMetadata(ip string) *K8sMetadata {
 func (ipc *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8sMetadata, newIdentity Identity) (namedPortsChanged bool, err error) {
 	ipc.mutex.Lock()
 	defer ipc.mutex.Unlock()
-	return ipc.upsertLocked(ip, hostIP, hostKey, k8sMeta, newIdentity, false /* !force */)
+	return ipc.upsertLocked(ip, hostIP, hostKey, k8sMeta, newIdentity, false /* !force */, true /* fromLegacyAPI */)
 }
 
 // upsertLocked adds / updates the provided IP and identity into the IPCache,
@@ -285,6 +307,7 @@ func (ipc *IPCache) upsertLocked(
 	k8sMeta *K8sMetadata,
 	newIdentity Identity,
 	force bool,
+	fromLegacyAPI bool,
 ) (namedPortsChanged bool, err error) {
 	var newNamedPorts types.NamedPortMap
 	if k8sMeta != nil {
@@ -317,10 +340,45 @@ func (ipc *IPCache) upsertLocked(
 
 	cachedIdentity, found := ipc.ipToIdentityCache[ip]
 	if found {
+		// If this is a legacy upsert call,  then we need to make sure that the
+		// overwrittenLegacySource is updated
+		if fromLegacyAPI {
+			switch {
+			case cachedIdentity.exclusivelyOwnedByMetadataAPI():
+				// If the entry was exclusively owned by the metadata API, then we
+				// want to preserve our source as the legacy source (so it can be
+				// restored by the metadata API later) - even if our upsert call is
+				// later rejected due to it being a low-precedence upsert.
+				newIdentity.overwrittenLegacySource = newIdentity.Source
+			case cachedIdentity.ownedByLegacyAndMetadataAPI():
+				// If the entry is owned by both APIs, then it will have overwrittenLegacySource
+				// already set. Thus, check if we should update it, otherwise just preserve it as is.
+				if source.AllowOverwrite(cachedIdentity.overwrittenLegacySource, newIdentity.Source) {
+					newIdentity.overwrittenLegacySource = newIdentity.Source
+				} else {
+					newIdentity.overwrittenLegacySource = cachedIdentity.overwrittenLegacySource
+				}
+			}
+		}
+
+		// Here we track if an entry was previously created via new asynchronous
+		// UpsertMetadata API or the old synchronous Upsert call and preserve that bit
+		if fromLegacyAPI || cachedIdentity.modifiedByLegacyAPI {
+			newIdentity.modifiedByLegacyAPI = true
+		}
+
 		if !force && !source.AllowOverwrite(cachedIdentity.Source, newIdentity.Source) {
 			metrics.IPCacheErrorsTotal.WithLabelValues(
 				metricTypeUpsert, metricErrorOverwrite,
 			).Inc()
+
+			// Even if this update is rejected, we want to update the modifiedByLegacyAPI
+			// and overwrittenLegacySource fields in case the low precedence source here
+			// needs to be restored later
+			cachedIdentity.modifiedByLegacyAPI = newIdentity.modifiedByLegacyAPI
+			cachedIdentity.overwrittenLegacySource = newIdentity.overwrittenLegacySource
+			ipc.ipToIdentityCache[ip] = cachedIdentity
+
 			return false, NewErrOverwrite(cachedIdentity.Source, newIdentity.Source)
 		}
 
@@ -334,16 +392,10 @@ func (ipc *IPCache) upsertLocked(
 			return false, nil
 		}
 
-		// Here we track if an entry was created via new asynchronous
-		// UpsertMetadata API or the old synchronous Upsert call.
-		// If an entry is ever touched via the old Upsert API, we want to keep
-		// createdFromMetadata set to false, and require that the entry
-		// manually is deleted via the Delete function.
-		if !cachedIdentity.createdFromMetadata {
-			newIdentity.createdFromMetadata = false
-		}
-
 		oldIdentity = &cachedIdentity
+	} else if fromLegacyAPI {
+		// If this is a new entry, inserted via legacy API, then track it as such
+		newIdentity.modifiedByLegacyAPI = true
 	}
 
 	// Endpoint IP identities take precedence over CIDR identities, so if the

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -295,7 +295,7 @@ func (ipc *IPCache) upsertLocked(
 	if option.Config.Debug {
 		scopedLog = log.WithFields(logrus.Fields{
 			logfields.IPAddr:   ip,
-			logfields.Identity: newIdentity,
+			logfields.Identity: &newIdentity,
 			logfields.Key:      hostKey,
 		})
 		if k8sMeta != nil {

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -361,13 +361,33 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 				break
 			}
 
-			// We can safely skip the ipcache upsert if the entry matches with
-			// the entry in the metadata cache exactly.
-			// Note that checking ID alone is insufficient, see GH-24502.
-			if oldID.ID == newID.ID && prefixInfo.Source() == oldID.Source &&
-				oldTunnelIP.Equal(prefixInfo.TunnelPeer().IP()) &&
-				oldEncryptionKey == prefixInfo.EncryptKey().Uint8() {
-				goto releaseIdentity
+			var newOverwrittenLegacySource source.Source
+			if entryExists {
+				// If an entry already exists for this prefix, then we want to
+				// retain its source, if it has been modified by the legacy API.
+				// This allows us to restore the original source if we remove all
+				// metadata for the prefix
+				switch {
+				case oldID.exclusivelyOwnedByLegacyAPI():
+					// This is the first time we have associated metadata for a
+					// modifiedByLegacyAPI=true entry. Store the old (legacy) source:
+					newOverwrittenLegacySource = oldID.Source
+				case oldID.ownedByLegacyAndMetadataAPI():
+					// The entry has modifiedByLegacyAPI=true, but has already been
+					// updated at least once by the metadata API. Retain the legacy
+					// source as is.
+					newOverwrittenLegacySource = oldID.overwrittenLegacySource
+				}
+
+				// We can safely skip the ipcache upsert if the entry matches with
+				// the entry in the metadata cache exactly.
+				// Note that checking ID alone is insufficient, see GH-24502.
+				if oldID.ID == newID.ID && prefixInfo.Source() == oldID.Source &&
+					oldID.overwrittenLegacySource == newOverwrittenLegacySource &&
+					oldTunnelIP.Equal(prefixInfo.TunnelPeer().IP()) &&
+					oldEncryptionKey == prefixInfo.EncryptKey().Uint8() {
+					goto releaseIdentity
+				}
 			}
 
 			// If this ID was newly allocated, we must add it to the SelectorCache
@@ -376,9 +396,11 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 			}
 			entriesToReplace[prefix] = ipcacheEntry{
 				identity: Identity{
-					ID:                  newID.ID,
-					Source:              prefixInfo.Source(),
-					createdFromMetadata: true,
+					ID:                      newID.ID,
+					Source:                  prefixInfo.Source(),
+					overwrittenLegacySource: newOverwrittenLegacySource,
+					// Note: `modifiedByLegacyAPI` and `shadowed` will be
+					// set by the upsert call itself
 				},
 				tunnelPeer: prefixInfo.TunnelPeer().IP(),
 				encryptKey: prefixInfo.EncryptKey().Uint8(),
@@ -401,14 +423,14 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 			// allocation from the prior InjectLabels() call by
 			// releasing the previous reference.
 			entry, entryToBeReplaced := entriesToReplace[prefix]
-			if !oldID.createdFromMetadata && entryToBeReplaced {
+			if oldID.exclusivelyOwnedByLegacyAPI() && entryToBeReplaced {
 				// If the previous ipcache entry for the prefix
 				// was not managed by this function, then the
 				// previous ipcache user to inject the IPCache
 				// entry retains its own reference to the
 				// Security Identity. Given that this function
-				// is going to assume responsibility for the
-				// IPCache entry now, this path must retain its
+				// is going to assume (non-exclusive) responsibility
+				// for the IPCache entry now, this path must retain its
 				// own reference to the Security Identity to
 				// ensure that if the other owner ever releases
 				// their reference, this reference stays live.
@@ -427,13 +449,40 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 			// subsystem using the old Upsert API, then we can safely remove
 			// the IPCache entry associated with this prefix.
 			if prefixInfo == nil {
-				if oldID.createdFromMetadata {
+				if oldID.exclusivelyOwnedByMetadataAPI() {
 					entriesToDelete[prefix] = oldID
-				} else {
+				} else if oldID.ownedByLegacyAndMetadataAPI() {
 					// If, on the other hand, this prefix *was* touched by
-					// another, Upsert-based system, flag this prefix as
-					// potentially eligible for deletion if all references
-					// are removed.
+					// another, Upsert-based system, then we want to restore
+					// the original (legacy) source. This ensures that the legacy
+					// Delete call (with the legacy source) will be able to remove
+					// it.
+					unmanagedEntry := ipcacheEntry{
+						identity: Identity{
+							ID:                  oldID.ID,
+							Source:              oldID.overwrittenLegacySource,
+							modifiedByLegacyAPI: true,
+						},
+						tunnelPeer: oldTunnelIP,
+						encryptKey: oldEncryptionKey,
+						force:      true, /* overwrittenLegacySource is lower precedence */
+					}
+					entriesToReplace[prefix] = unmanagedEntry
+
+					// In addition, flag this prefix as potentially eligible
+					// for deletion if all references are removed (i.e. the legacy
+					// Delete call already happened).
+					unmanagedPrefixes[prefix] = unmanagedEntry.identity
+
+					if option.Config.Debug {
+						log.WithFields(logrus.Fields{
+							logfields.Prefix:      prefix,
+							logfields.OldIdentity: oldID.ID,
+						}).Debug("Previously managed IPCache entry is now unmanaged")
+					}
+				} else if oldID.exclusivelyOwnedByLegacyAPI() {
+					// Even if we never actually overwrote the legacy-owned
+					// entry, we should still remove it if all references are removed.
 					unmanagedPrefixes[prefix] = oldID
 				}
 			}
@@ -478,6 +527,7 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 			meta,
 			entry.identity,
 			entry.force,
+			/* fromLegacyAPI */ false,
 		); err2 != nil {
 			// It's plausible to pull the same information twice
 			// from different sources, for instance in etcd mode


### PR DESCRIPTION
 * [x] #34783 (@dylandreimerink)
 * [x] #34913 (@ysksuzuki)
 * [x] #34715 (@gandro)
 * [x] #34934 (@kaworu)
 * [x] #34941 (@bimmlerd)
 * [ ] #34922 (@fjvela)
 * [x] #34951 (@harsimran-pabla)
 * [x] #34959 (@rastislavs) :warning: resolved conflicts
   * Conflicts in `pkg/bgpv1/manager/reconcilerv2/service.go`: Fixed accepting incoming changes and using `BGPInstance.ASN` instead of `BGPInstance.Global.ASN`
 * [x] #34946 (@kaworu)
 * [ ] #34789 (@tommyp1ckles)
 * [x] #34976 (@rastislavs)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 34783 34913 34715 34934 34941 34922 34951 34959 34946 34789 34976
```
