### PR TITLE
v1.15 Backports 2024-09-25

### DIFF
--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -82,7 +82,7 @@ set_identity_mark(struct __sk_buff *ctx, __u32 identity, __u32 magic)
 	__u32 cluster_id_lower = cluster_id & 0xFF;
 	__u32 cluster_id_upper = ((cluster_id & 0xFFFFFF00) << (8 + IDENTITY_LEN));
 
-	ctx->mark |= magic;
+	ctx->mark = (magic & MARK_MAGIC_KEY_MASK);
 	ctx->mark &= MARK_MAGIC_KEY_MASK;
 	ctx->mark |= (identity & IDENTITY_MAX) << 16 | cluster_id_lower | cluster_id_upper;
 }

--- a/bpf/tests/bpf_skb_255_tests.c
+++ b/bpf/tests/bpf_skb_255_tests.c
@@ -42,6 +42,28 @@ int check_get_identity(struct __ctx_buff *ctx)
 	test_finish();
 }
 
+CHECK("tc", "set_identity_mark_bits")
+int set_identity_mark_bits(struct __ctx_buff *ctx)
+{
+	test_init();
+
+	set_identity_mark(ctx, 0x0, MARK_MAGIC_IDENTITY);
+	set_identity_mark(ctx, 0x0, MARK_MAGIC_OVERLAY);
+
+	if ((ctx->mark & MARK_MAGIC_HOST_MASK) != MARK_MAGIC_OVERLAY)
+		test_fatal("expected %x got %x", MARK_MAGIC_OVERLAY, ctx->mark);
+
+	set_identity_mark(ctx, 0x0, 0x000);
+	if ((ctx->mark & MARK_MAGIC_HOST_MASK) != 0)
+		test_fatal("expected %x got %x", 0, ctx->mark);
+
+	set_identity_mark(ctx, 0x0, MARK_MAGIC_HOST_MASK);
+	if ((ctx->mark & MARK_MAGIC_HOST_MASK) != MARK_MAGIC_HOST_MASK)
+		test_fatal("expected %x got %x", MARK_MAGIC_HOST_MASK, ctx->mark);
+
+	test_finish();
+}
+
 CHECK("tc", "set_and_get_cluster_id")
 int check_ctx_get_cluster_id_mark(struct __ctx_buff *ctx)
 {

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
@@ -19,4 +19,9 @@ spec:
   duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
   privateKey:
     rotationPolicy: Always
+  isCA: false
+  usages:
+    - signing
+    - key encipherment
+    - client auth
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
@@ -28,4 +28,9 @@ spec:
   duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
   privateKey:
     rotationPolicy: Always
+  isCA: false
+  usages:
+    - signing
+    - key encipherment
+    - server auth
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
@@ -29,4 +29,10 @@ spec:
   duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
   privateKey:
     rotationPolicy: Always
+  isCA: false
+  usages:
+    - signing
+    - key encipherment
+    - server auth
+    - client auth
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
@@ -19,4 +19,9 @@ spec:
   duration: {{ printf "%dh0m0s" (mul .Values.hubble.tls.auto.certValidityDuration 24) }}
   privateKey:
     rotationPolicy: Always
+  isCA: false
+  usages:
+    - signing
+    - key encipherment
+    - client auth
 {{- end }}

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -654,6 +654,11 @@ func (ipam *LBIPAM) stripOrImportIngresses(sv *ServiceView) (statusModified bool
 				IP:     ip,
 				Origin: lbRange,
 			})
+
+			// If the `ServiceView` has a sharing key, add the IP to the `rangeStore` index
+			if sv.SharingKey != "" {
+				ipam.rangesStore.AddServiceViewIPForSharingKey(sv.SharingKey, &sv.AllocatedIPs[len(sv.AllocatedIPs)-1])
+			}
 		}
 
 		newIngresses = append(newIngresses, ingress)

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -790,6 +790,81 @@ func TestAllocOnInit(t *testing.T) {
 	}
 }
 
+// TestAllocSharedOnInit tests that on init, ingress IPs on services which match configured pools are imported
+// and marked as allocated, and that services sharing IPs are allocated the same IP.
+func TestAllocSharedOnInit(t *testing.T) {
+	poolA := mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"})
+	fixture := mkTestFixture(true, true)
+	fixture.UpsertPool(t, poolA)
+
+	policy := slim_core_v1.IPFamilyPolicySingleStack
+	svcA := &slim_core_v1.Service{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Name:      "service-a",
+			Namespace: "default",
+			UID:       serviceAUID,
+			Annotations: map[string]string{
+				ciliumSvcLBISKAnnotation: "key-1",
+			},
+		},
+		Spec: slim_core_v1.ServiceSpec{
+			Type:           slim_core_v1.ServiceTypeLoadBalancer,
+			IPFamilyPolicy: &policy,
+			IPFamilies: []slim_core_v1.IPFamily{
+				slim_core_v1.IPv4Protocol,
+			},
+		},
+		Status: slim_core_v1.ServiceStatus{
+			LoadBalancer: slim_core_v1.LoadBalancerStatus{
+				Ingress: []slim_core_v1.LoadBalancerIngress{
+					{
+						IP: "10.0.10.123",
+					},
+				},
+			},
+		},
+	}
+	fixture.UpsertSvc(t, svcA)
+	svcA = fixture.GetSvc("default", "service-a")
+
+	svcB := &slim_core_v1.Service{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Name:      "service-b",
+			Namespace: "default",
+			UID:       serviceBUID,
+			Annotations: map[string]string{
+				ciliumSvcLBISKAnnotation: "key-1",
+			},
+		},
+		Spec: slim_core_v1.ServiceSpec{
+			Type:           slim_core_v1.ServiceTypeLoadBalancer,
+			IPFamilyPolicy: &policy,
+			IPFamilies: []slim_core_v1.IPFamily{
+				slim_core_v1.IPv4Protocol,
+			},
+		},
+		Status: slim_core_v1.ServiceStatus{
+			LoadBalancer: slim_core_v1.LoadBalancerStatus{
+				Ingress: []slim_core_v1.LoadBalancerIngress{
+					{
+						IP: "10.0.10.123",
+					},
+				},
+			},
+		},
+	}
+	fixture.UpsertSvc(t, svcB)
+	svcB = fixture.GetSvc("default", "service-b")
+
+	if svcA.Status.LoadBalancer.Ingress[0].IP != "10.0.10.123" {
+		t.Error("Expected service A to receive ingress IP 10.0.10.123 got ", svcA.Status.LoadBalancer.Ingress[0].IP)
+	}
+
+	if svcB.Status.LoadBalancer.Ingress[0].IP != "10.0.10.123" {
+		t.Error("Expected service B to receive ingress IP 10.0.10.123, got ", svcB.Status.LoadBalancer.Ingress[0].IP)
+	}
+}
+
 // TestPoolSelector tests that an IP Pool will only allocate IPs to services which match its service selector.
 // The selector in this case is a very simple label.
 func TestPoolSelectorBasic(t *testing.T) {


### PR DESCRIPTION
 * [x] #34783 (@dylandreimerink) :warning: resolved conflicts
   * Used `ciliumSvcLBISKAnnotation` instead of `annotation.LBIPAMSharingKey` as the latter is not defined in v1.15 branch
 * [x] #34946 (@kaworu) :warning: resolved conflicts
   * Dropped changes to `install/kubernetes/cilium/templates/hubble/tls-certmanager/metrics-server-secret.yaml`: file not present in v1.15 branch
 * [ ] #34789 (@tommyp1ckles)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 34783 34946 34789
```
