### PR TITLE
policy: Policy Map Overflow Lockdown

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -119,6 +119,7 @@ cilium-agent [flags]
       --enable-dynamic-lifecycle-manager                          Enables support for dynamic lifecycle management
       --enable-encryption-strict-mode                             Enable encryption strict mode
       --enable-endpoint-health-checking                           Enable connectivity health checking between virtual endpoints (default true)
+      --enable-endpoint-lockdown-on-policy-overflow               When an endpoint's policy map overflows, shutdown all (ingress and egress) network traffic for that endpoint.
       --enable-endpoint-routes                                    Use per endpoint routes instead of routing via cilium_host
       --enable-envoy-config                                       Enable Envoy Config CRDs
       --enable-external-ips                                       Enable k8s service externalIPs feature (requires enabling enable-node-port)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1172,6 +1172,10 @@
      - Enable connectivity health checking between virtual endpoints.
      - bool
      - ``true``
+   * - :spelling:ignore:`endpointLockdownOnMapOverflow`
+     - Enable endpoint lockdown on policy map overflow.
+     - bool
+     - ``false``
    * - :spelling:ignore:`endpointRoutes.enabled`
      - Enable use of per endpoint routes instead of routing via the cilium_host interface.
      - bool

--- a/Documentation/security/policy/lifecycle.rst
+++ b/Documentation/security/policy/lifecycle.rst
@@ -125,9 +125,12 @@ the endpoint out of "lockdown" when it detects that the policy map is no
 longer overflowing. When an endpoint is locked down all network traffic,
 both egress and ingress, will be dropped. Cilium will log a warning that
 the endpoint has been locked down.
-  
+
 If this option is enabled, cluster operators should closely monitor the
 metric the bpf map pressure metric of the ``cilium_policy_*`` maps. See
-`Policymap pressure and overflow`_ for more details.
+`Policymap pressure and overflow`_ for more details. They can use this metric
+to create an alert for increased memory pressure on the policy map as well
+as alert for a lockdown if ``enable-lockdown-endpoint-on-policy-overflow``
+is set to "true" (any ``bpf_map_pressure`` above a value of ``1.0``).
 
 .. _Policymap pressure and overflow: /operations/troubleshooting.html#policymap-pressure-and-overflow

--- a/Documentation/security/policy/lifecycle.rst
+++ b/Documentation/security/policy/lifecycle.rst
@@ -110,3 +110,24 @@ those rules will be dropped.  Otherwise, if the policy enforcement
 mode is ``never`` or ``default``, all ingress (resp. egress) traffic
 is allowed to (resp. from) initializing endpoints.  Otherwise, all
 ingress (resp. egress) traffic is dropped.
+
+
+.. _lockdown_mode:
+
+Lockdown Mode
+-------------
+
+If the Cilium agent option ``enable-lockdown-endpoint-on-policy-overflow``
+is set to "true" Cilium will put an endpoint into "lockdown" if the policy
+map cannot accommodate all of the required policy map entries required
+(that is, the policy map for the endpoint is overflowing). Cilium will put
+the endpoint out of "lockdown" when it detects that the policy map is no
+longer overflowing. When an endpoint is locked down all network traffic,
+both egress and ingress, will be dropped. Cilium will log a warning that
+the endpoint has been locked down.
+  
+If this option is enabled, cluster operators should closely monitor the
+metric the bpf map pressure metric of the ``cilium_policy_*`` maps. See
+`Policymap pressure and overflow`_ for more details.
+
+.. _Policymap pressure and overflow: /operations/troubleshooting.html#policymap-pressure-and-overflow

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -73,6 +73,7 @@ Klusters
 KubeVersion
 Lando
 Leblond
+Lockdown
 Lund
 Lx
 Majkowski
@@ -504,6 +505,7 @@ loadbalancers
 loadbalancing
 loadinfo
 localhost
+lockdown
 lockless
 logfile
 lookups

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1052,6 +1052,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.LBSourceRangeAllTypes, false, "Propagate loadbalancerSourceRanges to all corresponding service types")
 	option.BindEnv(vp, option.LBSourceRangeAllTypes)
 
+	flags.Bool(option.EnableEndpointLockdownOnPolicyOverflow, false, "When an endpoint's policy map overflows, shutdown all (ingress and egress) network traffic for that endpoint.")
+	option.BindEnv(vp, option.EnableEndpointLockdownOnPolicyOverflow)
+
 	if err := vp.BindPFlags(flags); err != nil {
 		log.Fatalf("BindPFlags failed: %s", err)
 	}

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -343,6 +343,7 @@ contributors across the globe, there is almost always someone available to help.
 | encryption.type | string | `"ipsec"` | Encryption method. Can be either ipsec or wireguard. |
 | encryption.wireguard.persistentKeepalive | string | `"0s"` | Controls WireGuard PersistentKeepalive option. Set 0s to disable. |
 | endpointHealthChecking.enabled | bool | `true` | Enable connectivity health checking between virtual endpoints. |
+| endpointLockdownOnMapOverflow | bool | `false` | Enable endpoint lockdown on policy map overflow. |
 | endpointRoutes.enabled | bool | `false` | Enable use of per endpoint routes instead of routing via the cilium_host interface. |
 | eni.awsEnablePrefixDelegation | bool | `false` | Enable ENI prefix delegation |
 | eni.awsReleaseExcessIPs | bool | `false` | Release IPs not used from the ENI |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -861,6 +861,7 @@ data:
 {{- if hasKey .Values.k8sNetworkPolicy "enabled" }}
   enable-k8s-networkpolicy: {{ .Values.k8sNetworkPolicy.enabled | quote }}
 {{- end }}
+  enable-endpoint-lockdown-on-policy-overflow: {{ .Values.endpointLockdownOnMapOverflow | quote }}
 {{- if .Values.cni.configMap }}
   read-cni-conf: {{ .Values.cni.confFileMountPath }}/{{ .Values.cni.configMapKey }}
 {{- if .Values.cni.customConf  }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1737,6 +1737,9 @@
       },
       "type": "object"
     },
+    "endpointLockdownOnMapOverflow": {
+      "type": "boolean"
+    },
     "endpointRoutes": {
       "properties": {
         "enabled": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1028,6 +1028,8 @@ endpointRoutes:
 k8sNetworkPolicy:
   # -- Enable support for K8s NetworkPolicy
   enabled: true
+# -- Enable endpoint lockdown on policy map overflow.
+endpointLockdownOnMapOverflow: false
 eni:
   # -- Enable Elastic Network Interface (ENI) integration.
   enabled: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1037,6 +1037,8 @@ endpointRoutes:
 k8sNetworkPolicy:
   # -- Enable support for K8s NetworkPolicy
   enabled: true
+# -- Enable endpoint lockdown on policy map overflow.
+endpointLockdownOnMapOverflow: false
 eni:
   # -- Enable Elastic Network Interface (ENI) integration.
   enabled: false

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -12,6 +12,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/google/renameio/v2"
@@ -37,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/time"
@@ -54,10 +56,32 @@ const (
 )
 
 var (
+	// ErrPolicyEntryMaxExceeded indicates that the BPF map backing the
+	// endpoint policy is too full to accommodate a given set of changes.
+	ErrPolicyEntryMaxExceeded = errors.New("policy map max entries limit exceeded")
+
+	// ErrComingOutOfLockdown indicates that the BPF map backing the
+	// endpoint policy is too full to accommodate a given set of changes.
+	ErrComingOutOfLockdown = errors.New("lockdown is no longer needed, but a full policy recomputation is needed")
+
 	handleNoHostInterfaceOnce sync.Once
 
 	syncPolicymapControllerGroup = controller.NewGroup("sync-policymap")
+
+	// allTrafficKeys specifies all of the policy Keys necessary to cover
+	// all (ingress and egress) network traffic.
+	allTrafficKeys []policy.Key
 )
+
+func init() {
+	for _, proto := range policyapi.SupportedProtocols() {
+		p := u8proto.ProtoIDs[strings.ToLower(string(proto))]
+		allTrafficKeys = append(allTrafficKeys,
+			policy.IngressKey().WithPortProtoPrefix(p, 0, 0),
+			policy.EgressKey().WithPortProtoPrefix(p, 0, 0),
+		)
+	}
+}
 
 // policyMapPath returns the path to the policy map of endpoint.
 func (e *Endpoint) policyMapPath() string {
@@ -374,7 +398,6 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 	defer datapathRegenCtxt.completionCancel()
 
 	err = e.runPreCompilationSteps(regenContext)
-
 	// Keep track of the side-effects of the regeneration that need to be
 	// reverted in case of failure.
 	// Also keep track of the regeneration finalization code that can't be
@@ -645,8 +668,8 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 		// have a chance to be ready when new traffic is redirected to them.  Note that it
 		// is possible for further incremental changes to be applied before and after the
 		// bpf policy maps have been synchronized for the new policy.
-		err = e.applyPolicyMapChanges(regenContext, e.desiredPolicy != e.realizedPolicy)
-		if err != nil {
+		err = e.applyPolicyMapChangesLocked(regenContext, e.desiredPolicy != e.realizedPolicy)
+		if err != nil && !errors.Is(err, ErrPolicyEntryMaxExceeded) {
 			return err
 		}
 	}
@@ -897,11 +920,28 @@ type policyMapPressureUpdater interface {
 }
 
 func (e *Endpoint) updatePolicyMapPressureMetric() {
-	value := float64(e.realizedPolicy.Len()) / float64(e.policyMap.MaxEntries())
+	// We want to use desiredPolicy, but it can be nil.
+	var policyLen float64
+	if e.desiredPolicy != nil {
+		policyLen = float64(e.desiredPolicy.Len())
+	}
+	value := policyLen / float64(e.policyMap.MaxEntries())
 	e.PolicyMapPressureUpdater.Update(PolicyMapPressureEvent{
 		Value:      value,
 		EndpointID: e.ID,
 	})
+}
+
+func (e *Endpoint) deletePolicyKeys(deletes, adds policy.Keys) int {
+	var errors int
+	for k := range deletes {
+		if _, ok := adds[k]; !ok {
+			if !e.deletePolicyKey(k) {
+				errors++
+			}
+		}
+	}
+	return errors
 }
 
 func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key) bool {
@@ -929,6 +969,25 @@ func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key) bool {
 	}, "deletePolicyKey")
 
 	return true
+}
+
+func (e *Endpoint) addPolicyKeys(adds policy.Keys) int {
+	var errors int
+	for keyToAdd := range adds {
+		entry, exists := e.desiredPolicy.Get(keyToAdd)
+		if !exists {
+			e.getLogger().WithFields(logrus.Fields{
+				logfields.AddedPolicyID: keyToAdd,
+			}).Warn("Tried adding policy map key not in policy")
+			continue
+		}
+
+		if !e.addPolicyKey(keyToAdd, entry) {
+			errors++
+		}
+
+	}
+	return errors
 }
 
 func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry) bool {
@@ -970,18 +1029,18 @@ func (e *Endpoint) ApplyPolicyMapChanges(proxyWaitGroup *completion.WaitGroup) e
 
 	e.PolicyDebug(nil, "ApplyPolicyMapChanges")
 
-	return e.applyPolicyMapChanges(&regenerationContext{
+	return e.applyPolicyMapChangesLocked(&regenerationContext{
 		datapathRegenerationContext: &datapathRegenerationContext{
 			proxyWaitGroup: proxyWaitGroup,
 		},
 	}, false)
 }
 
-// applyPolicyMapChanges applies any incremental policy map changes
-// collected on the desired policy.
-// Endpoint's Envoy NetworkPolicy is also updated if needed.
-// Endpoint must be locked
-func (e *Endpoint) applyPolicyMapChanges(regenContext *regenerationContext, hasNewPolicy bool) error {
+// applyPolicyMapChangesLocked applies any incremental policy map changes
+// collected on the desired policy. Endpoint's Envoy NetworkPolicy is also
+// updated if needed. Endpoint must be locked. It returns one special error
+// that must be considered, "ErrPolicyEntryMaxExceeded".
+func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext, hasNewPolicy bool) error {
 	e.PolicyDebug(nil, "applyPolicyMapChanges")
 
 	// Always update Envoy if policy has changed
@@ -996,6 +1055,13 @@ func (e *Endpoint) applyPolicyMapChanges(regenContext *regenerationContext, hasN
 	// returns changes that need to be applied to the Endpoint's bpf policy map.
 	closer, changes := e.desiredPolicy.ConsumeMapChanges()
 	defer closer()
+
+	if e.shouldLockdownLocked(changes.Size()) {
+		return e.startLockdownLocked()
+	}
+	if e.stopLockdownLocked() {
+		return ErrComingOutOfLockdown
+	}
 
 	hasEnvoyRedirect := e.desiredPolicy.L4Policy.HasEnvoyRedirect()
 	if !changes.Empty() {
@@ -1074,36 +1140,140 @@ func (e *Endpoint) applyPolicyMapChanges(regenContext *regenerationContext, hasN
 		return nil
 	}
 
-	// Add policy map entries before deleting to avoid transient drops
+	// Add policy map entries before deleting to avoid transient drops. If there
+	// isn't enough space to add all the entries before deleting some, then delete
+	// first. If e.realizedPolicy or e.policyMap is nil then the map has not been
+	// populated yet.
 	errors := 0
-	for keyToAdd := range changes.Adds {
-		entry, exists := e.desiredPolicy.Get(keyToAdd)
-		if !exists {
-			e.getLogger().WithFields(logrus.Fields{
-				logfields.AddedPolicyID: keyToAdd,
-			}).Warn("Tried adding policy map key not in policy")
-			continue
-		}
-
-		if !e.addPolicyKey(keyToAdd, entry) {
-			errors++
-		}
-	}
-
-	for keyToDelete := range changes.Deletes {
-		if !e.deletePolicyKey(keyToDelete) {
-			errors++
-		}
+	if e.realizedPolicy == nil || e.policyMap == nil ||
+		e.realizedPolicy.Len()+len(changes.Adds) <= int(e.policyMap.MaxEntries()) {
+		errors += e.addPolicyKeys(changes.Adds)
+		errors += e.deletePolicyKeys(changes.Deletes, changes.Adds)
+	} else {
+		errors += e.deletePolicyKeys(changes.Deletes, changes.Adds)
+		errors += e.addPolicyKeys(changes.Adds)
+		e.getLogger().WithFields(logrus.Fields{
+			logfields.EndpointID: e.ID,
+		}).Warn("A policy map update had to delete changes before it added them in order to prevent a map overflow, a transient drop may have occurred.")
 	}
 
 	if errors > 0 {
 		return fmt.Errorf("updating bpf policy maps failed")
 	}
-	if len(changes.Adds)+len(changes.Deletes) > 0 {
+	if len(changes.Adds) > 0 || len(changes.Deletes) > 0 {
 		e.getLogger().WithFields(logrus.Fields{
 			logfields.AddedPolicyID:   changes.Adds,
 			logfields.DeletedPolicyID: changes.Deletes,
 		}).Debug("Applied policy map updates due to identity changes")
+	}
+	return nil
+}
+
+// shouldLockdownLockdown returns true if the desiredPolicy, after changes,
+// will be larger than policymap.MaxEntries. The Endpoint must be locked.
+func (e *Endpoint) shouldLockdownLocked(changeSize int) bool {
+	// The desiredPolicy will be larger than the BPF maximum after
+	// the changes.
+	return e.desiredPolicy != nil && e.policyMap != nil &&
+		e.desiredPolicy.Len()+changeSize > int(e.policyMap.MaxEntries())
+}
+
+// startLockdownLocked initiates an endpoint lockdown, and returns an
+// error if it fails. The Endpoint must be locked.
+func (e *Endpoint) startLockdownLocked() error {
+	// We only need to go through the mechanics of
+	// lockdown once.
+	if !e.lockdown {
+		// Do nothing if lockdown mode is not enabled.
+		if !option.Config.EnableEndpointLockdownOnPolicyOverflow {
+			return nil
+		}
+
+		e.getLogger().WithFields(logrus.Fields{
+			logfields.EndpointID: e.ID,
+		}).Warnf("The policy map exceeds the max entries limit, %s is enabled, locking the endpoint down.",
+			option.EnableEndpointLockdownOnPolicyOverflow)
+
+		if err := e.endpointPolicyLockdown(); err != nil {
+			e.getLogger().WithFields(logrus.Fields{
+				logfields.EndpointID: e.ID,
+			}).WithError(err).Error("Failed to lockdown endpoint:" +
+				"Consider quarantining or shutting down this node.")
+			return err
+		}
+		e.lockdown = true
+		e.updatePolicyMapPressureMetric()
+	}
+	return ErrPolicyEntryMaxExceeded
+}
+
+// stopLockdownLocked stops an endpoint lockdown if the endpoint
+// is in lockdown. It returns true if it did stop a lockdown and
+// false if it did not.
+func (e *Endpoint) stopLockdownLocked() bool {
+	if e.lockdown {
+		e.forcePolicyCompute = true
+		e.lockdown = false
+		return true
+	}
+	return false
+}
+
+// endpointPolicyLockdown puts the endpoint policy map into a lockdown
+// mode. The bpf policy map is populated with deny all traffic entries,
+// and all other entries are deleted.
+func (e *Endpoint) endpointPolicyLockdown() error {
+	denyMap := make(map[policymap.PolicyKey]struct{}, len(allTrafficKeys))
+	for _, k := range allTrafficKeys {
+		denyMap[policymap.NewKey(k.TrafficDirection(), k.Identity, k.Nexthdr, k.DestPort, k.PortPrefixLen())] = struct{}{}
+	}
+	// realizedPolicy is not accurrate at this point, we need a dump
+	currentMap, err := e.dumpPolicyMapToMapStateMap()
+	if err != nil {
+		return fmt.Errorf("could not dump current map state: %w", err)
+	}
+
+	defer func() {
+		e.realizedPolicy = policy.NewEndpointPolicy(e.policyGetter.GetPolicyRepository())
+	}()
+
+	i := 0
+	addedDenyEntries := false
+	for k := range currentMap {
+		pmKey := policymap.NewKey(k.TrafficDirection(), k.Identity, k.Nexthdr, k.DestPort, k.PortPrefixLen())
+		if _, ok := denyMap[pmKey]; !ok {
+			err := e.policyMap.DeleteKey(pmKey)
+			var errno unix.Errno
+			errors.As(err, &errno)
+			if err != nil && errno != unix.ENOENT {
+				return fmt.Errorf("failed to delete policy key (%v) during lockdown: %w", pmKey, err)
+			}
+		}
+		// We can increment this, even if we did not delete a key,
+		// because the only non-deleted keys match what is already
+		// in the deny map, they will be replaced.
+		i++
+		// Once the length of the deny keys to be added has been deleted we can safely add them.
+		if i == len(denyMap) {
+			for denyKey := range denyMap {
+				e.policyMap.DenyKey(denyKey)
+				if err := e.policyMap.DenyKey(denyKey); err != nil {
+					return fmt.Errorf("failed to add deny all policy (%v): %w", denyKey, err)
+				}
+			}
+			addedDenyEntries = true
+		}
+	}
+	// This is not really possible, unless the max policy limit
+	// is set to a really low value in a custom build of Cilium,
+	// but it is worth having for testing purposes.
+	if !addedDenyEntries {
+		for denyKey := range denyMap {
+			e.policyMap.DenyKey(denyKey)
+			if err := e.policyMap.DenyKey(denyKey); err != nil {
+				return fmt.Errorf("failed to add deny all policy (%v): %w", denyKey, err)
+			}
+		}
 	}
 	return nil
 }
@@ -1114,6 +1284,13 @@ func (e *Endpoint) applyPolicyMapChanges(regenContext *regenerationContext, hasN
 // Only called when desired and realized policies are not the same.
 func (e *Endpoint) syncPolicyMap() error {
 	addErrors, deleteErrors := 0, 0
+
+	if e.shouldLockdownLocked(0) {
+		return e.startLockdownLocked()
+	}
+	if e.stopLockdownLocked() {
+		return ErrComingOutOfLockdown
+	}
 
 	// Add policy map entries before deleting to avoid transient drops
 	for k, v := range e.desiredPolicy.Updated(e.realizedPolicy) {
@@ -1152,6 +1329,15 @@ func (e *Endpoint) syncPolicyMap() error {
 // and desired policy state.
 func (e *Endpoint) syncPolicyMapWith(realized policy.MapStateMap, withDiffs bool) (diffCount int, diffs []policy.MapChange, err error) {
 	addErrors, deleteErrors := 0, 0
+
+	if e.shouldLockdownLocked(0) {
+		err = e.startLockdownLocked()
+		return
+	}
+	if e.stopLockdownLocked() {
+		err = ErrComingOutOfLockdown
+		return
+	}
 
 	// Add policy map entries before deleting to avoid transient drops
 	for k, v := range e.desiredPolicy.UpdatedMap(realized) {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -302,6 +302,10 @@ type Endpoint struct {
 	// Immutable after Endpoint creation.
 	K8sUID string
 
+	// lockdown indicates whether the endpoint is locked down or not do to
+	// a policy map overflow.
+	lockdown bool
+
 	// pod
 	pod atomic.Pointer[slim_corev1.Pod]
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1141,6 +1141,10 @@ const (
 
 	// EnableNonDefaultDenyPolicies allows policies to define whether they are operating in default-deny mode
 	EnableNonDefaultDenyPolicies = "enable-non-default-deny-policies"
+
+	// EnableEndpointLockdownOnPolicyOverflow enables endpoint lockdown when an endpoint's
+	// policy map overflows.
+	EnableEndpointLockdownOnPolicyOverflow = "enable-endpoint-lockdown-on-policy-overflow"
 )
 
 // Default string arguments
@@ -2243,6 +2247,10 @@ type DaemonConfig struct {
 
 	// EnableSourceIPVerification enables the source ip validation of connection from endpoints to endpoints
 	EnableSourceIPVerification bool
+
+	// EnableEndpointLockdownOnPolicyOverflow enables endpoint lockdown when an endpoint's
+	// policy map overflows.
+	EnableEndpointLockdownOnPolicyOverflow bool
 }
 
 var (
@@ -3279,6 +3287,9 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 
 	// Enable BGP control plane status reporting
 	c.EnableBGPControlPlaneStatusReport = vp.GetBool(EnableBGPControlPlaneStatusReport)
+
+	// Support failure-mode for policy map overflow
+	c.EnableEndpointLockdownOnPolicyOverflow = vp.GetBool(EnableEndpointLockdownOnPolicyOverflow)
 
 	// Parse node label patterns
 	nodeLabelPatterns := vp.GetStringSlice(ExcludeNodeLabelPatterns)

--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -28,6 +28,12 @@ func (l4 L4Proto) IsAny() bool {
 	return l4 == ProtoAny || string(l4) == ""
 }
 
+// SupportedProtocols returns the currently supported protocols in the policy
+// engine, excluding "ANY".
+func SupportedProtocols() []L4Proto {
+	return []L4Proto{ProtoTCP, ProtoUDP, ProtoSCTP}
+}
+
 // PortProtocol specifies an L4 port with an optional transport protocol
 type PortProtocol struct {
 	// Port can be an L4 port number, or a name in the form of "http"

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -527,6 +527,20 @@ func (c *ChangeState) Empty() bool {
 	return len(c.Adds)+len(c.Deletes)+len(c.old) == 0
 }
 
+// Size returns the total number of Adds minus
+// the total number of true Deletes (Deletes
+// that are not also in Adds). The return value
+// can be negative.
+func (c *ChangeState) Size() int {
+	deleteLen := 0
+	for k := range c.Deletes {
+		if _, ok := c.Adds[k]; !ok {
+			deleteLen++
+		}
+	}
+	return len(c.Adds) - deleteLen
+}
+
 // toMapState converts a single filter into a MapState entries added to 'p.PolicyMapState'.
 //
 // Note: It is possible for two selectors to select the same security ID.  To give priority to deny,


### PR DESCRIPTION
see commits for details.
```release-note
endpoint: Add an option to lock endpoints down (that is, drop all traffic) when their policy maps overflow.
```
