### PR TITLE
Filter chain gen breaks when TLS in different ns use the same host

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -136,6 +136,7 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 	}
 
 	cecTranslator := translation.NewCECTranslator(
+		params.Logger,
 		params.GatewayApiConfig.GatewayAPISecretsNamespace,
 		params.GatewayApiConfig.EnableGatewayAPIProxyProtocol,
 		params.GatewayApiConfig.EnableGatewayAPIAppProtocol,

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -309,7 +309,7 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 
 	logger := hivetest.Logger(t)
 
-	cecTranslator := translation.NewCECTranslator("", false, false, true, 60, false, nil, false, false, 0)
+	cecTranslator := translation.NewCECTranslator(logger, "", false, false, true, 60, false, nil, false, false, 0)
 	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, false, string(corev1.ServiceExternalTrafficPolicyCluster))
 
 	r := &gatewayReconciler{

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -113,6 +113,7 @@ func registerReconciler(params ingressParams) error {
 	}
 
 	cecTranslator := translation.NewCECTranslator(
+		params.Logger,
 		params.IngressConfig.IngressSecretsNamespace,
 		params.IngressConfig.EnableIngressProxyProtocol,
 		false,

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -61,7 +61,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -117,7 +117,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -173,7 +173,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -217,7 +217,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -287,7 +287,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -354,7 +354,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -408,7 +408,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -490,7 +490,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -548,7 +548,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -589,7 +589,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -648,7 +648,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -704,7 +704,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -744,7 +744,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -785,7 +785,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{"test.acme.io/"}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -870,7 +870,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -935,7 +935,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -977,7 +977,7 @@ func TestReconcile(t *testing.T) {
 			).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
@@ -1035,7 +1035,7 @@ func TestReconcile(t *testing.T) {
 			}).
 			Build()
 
-		cecTranslator := translation.NewCECTranslator(testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
+		cecTranslator := translation.NewCECTranslator(logger, testCiliumSecretsNamespace, testUseProxyProtocol, false, false, testDefaultTimeout, false, nil, false, false, 0)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(cecTranslator, false)
 
 		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)

--- a/operator/pkg/model/ingestion/ingress.go
+++ b/operator/pkg/model/ingestion/ingress.go
@@ -81,8 +81,9 @@ func Ingress(ing networkingv1.Ingress, defaultSecretNamespace, defaultSecretName
 					Timeout: timeout,
 				},
 			},
-			Port:    insecureListenerPort,
-			Service: getService(ing),
+			CreatedOn: ing.CreationTimestamp.Time,
+			Port:      insecureListenerPort,
+			Service:   getService(ing),
 		}
 
 		l.Sources = model.AddSource(l.Sources, sourceResource)
@@ -101,6 +102,7 @@ func Ingress(ing networkingv1.Ingress, defaultSecretNamespace, defaultSecretName
 
 		l, ok := insecureListenerMap[host]
 		l.Port = insecureListenerPort
+		l.CreatedOn = ing.CreationTimestamp.Time
 		l.Sources = model.AddSource(l.Sources, sourceResource)
 		if !ok {
 			l.Name = "ing-" + ing.Name + "-" + ing.Namespace + "-" + host
@@ -284,6 +286,7 @@ func IngressPassthrough(ing networkingv1.Ingress, listenerPort uint32) []model.T
 
 		l, ok := tlsListenerMap[host]
 		l.Port = listenerPort
+		l.CreatedOn = ing.CreationTimestamp.Time
 		l.Sources = model.AddSource(l.Sources, sourceResource)
 		if !ok {
 			l.Name = "ing-" + ing.Name + "-" + ing.Namespace + "-" + host

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -76,6 +76,8 @@ type HTTPListener struct {
 	// This plaintext listener will override any other plaintext HTTP config in
 	// the final rendered Envoy Config.
 	ForceHTTPtoHTTPSRedirect bool
+	// CreatedOn tracks ingress creation time
+	CreatedOn time.Time
 }
 
 func (l HTTPListener) GetSources() []FullyQualifiedResource {
@@ -128,6 +130,8 @@ type TLSPassthroughListener struct {
 	Service *Service
 	// Infrastructure configuration
 	Infrastructure *Infrastructure
+	// CreatedOn tracks ingress creation time
+	CreatedOn time.Time
 }
 
 func (l TLSPassthroughListener) GetAnnotations() map[string]string {
@@ -181,6 +185,7 @@ type FullyQualifiedResource struct {
 type TLSSecret struct {
 	Name      string
 	Namespace string
+	CreatedOn time.Time
 }
 
 // DirectResponse holds configuration for a direct response.

--- a/operator/pkg/model/translation/cec_translator_test.go
+++ b/operator/pkg/model/translation/cec_translator_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	envoy_config_cluster_v3 "github.com/cilium/proxy/go/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/cilium/proxy/go/envoy/config/core/v3"
 	envoy_config_listener "github.com/cilium/proxy/go/envoy/config/listener/v3"
@@ -260,7 +261,8 @@ func TestSharedIngressTranslator_getListenerProxy(t *testing.T) {
 		secretsNamespace: "cilium-secrets",
 		useProxyProtocol: true,
 	}
-	res := i.getListener(&model.Model{
+	logger := hivetest.Logger(t)
+	res := i.getListener(logger, &model.Model{
 		HTTP: []model.HTTPListener{
 			{
 				TLS: []model.TLSSecret{
@@ -290,7 +292,8 @@ func TestSharedIngressTranslator_getListener(t *testing.T) {
 		secretsNamespace: "cilium-secrets",
 	}
 
-	res := i.getListener(&model.Model{
+	logger := hivetest.Logger(t)
+	res := i.getListener(logger, &model.Model{
 		HTTP: []model.HTTPListener{
 			{
 				TLS: []model.TLSSecret{

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	envoy_config_route_v3 "github.com/cilium/proxy/go/envoy/config/route/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -233,10 +234,12 @@ func Test_translator_Translate(t *testing.T) {
 			want: requestRedirectWithMultiHTTPListenersCiliumEnvoyConfig,
 		},
 	}
+
+	logger := hivetest.Logger(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			trans := &gatewayAPITranslator{
-				cecTranslator: translation.NewCECTranslator("cilium-secrets", false, false, true, 60, false, nil, false, false, 0),
+				cecTranslator: translation.NewCECTranslator(logger, "cilium-secrets", false, false, true, 60, false, nil, false, false, 0),
 			}
 			cec, _, _, err := trans.Translate(tt.args.m)
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
@@ -334,10 +337,11 @@ func Test_translator_TranslateResource(t *testing.T) {
 		},
 	}
 
+	logger := hivetest.Logger(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			trans := &gatewayAPITranslator{
-				cecTranslator: translation.NewCECTranslator("cilium-secrets", false, false, true, 60, false, nil, false, false, 0),
+				cecTranslator: translation.NewCECTranslator(logger, "cilium-secrets", false, false, true, 60, false, nil, false, false, 0),
 			}
 			cec, _, _, err := trans.Translate(tt.args.m)
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
@@ -368,10 +372,11 @@ func Test_translator_Translate_AppProtocol(t *testing.T) {
 			want: backendProtocolEnabledH2CHTTPListenersCiliumEnvoyConfig,
 		},
 	}
+	logger := hivetest.Logger(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			trans := &gatewayAPITranslator{
-				cecTranslator: translation.NewCECTranslator("cilium-secrets", false, true, true, 60, false, nil, false, false, 0),
+				cecTranslator: translation.NewCECTranslator(logger, "cilium-secrets", false, true, true, 60, false, nil, false, false, 0),
 			}
 			cec, _, _, err := trans.Translate(tt.args.m)
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
@@ -440,6 +445,8 @@ func Test_translator_Translate_HostNetwork(t *testing.T) {
 			want: basicHostPortHTTPListenersCiliumEnvoyConfig("0.0.0.0", 55555, &slim_metav1.LabelSelector{MatchLabels: map[string]slim_metav1.MatchLabelsValue{"a": "b"}}),
 		},
 	}
+
+	logger := hivetest.Logger(t)
 	for _, tt := range tests {
 		translatorCases := []struct {
 			name                 string
@@ -448,14 +455,14 @@ func Test_translator_Translate_HostNetwork(t *testing.T) {
 			{
 				name: "Without externalTrafficPolicy",
 				gatewayAPITranslator: &gatewayAPITranslator{
-					cecTranslator:      translation.NewCECTranslator("cilium-secrets", false, false, true, 60, true, tt.nodeLabelSelector, tt.ipv4Enabled, tt.ipv6Enabled, 0),
+					cecTranslator:      translation.NewCECTranslator(logger, "cilium-secrets", false, false, true, 60, true, tt.nodeLabelSelector, tt.ipv4Enabled, tt.ipv6Enabled, 0),
 					hostNetworkEnabled: true,
 				},
 			},
 			{
 				name: "With externalTrafficPolicy",
 				gatewayAPITranslator: &gatewayAPITranslator{
-					cecTranslator:         translation.NewCECTranslator("cilium-secrets", false, false, true, 60, true, tt.nodeLabelSelector, tt.ipv4Enabled, tt.ipv6Enabled, 0),
+					cecTranslator:         translation.NewCECTranslator(logger, "cilium-secrets", false, false, true, 60, true, tt.nodeLabelSelector, tt.ipv4Enabled, tt.ipv6Enabled, 0),
 					hostNetworkEnabled:    true,
 					externalTrafficPolicy: "Cluster",
 				},
@@ -504,10 +511,12 @@ func Test_translator_Translate_WithXffNumTrustedHops(t *testing.T) {
 			want: basicHTTPListenersCiliumEnvoyConfigWithXff,
 		},
 	}
+
+	logger := hivetest.Logger(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			trans := &gatewayAPITranslator{
-				cecTranslator:      translation.NewCECTranslator("cilium-secrets", false, false, true, 60, false, nil, false, false, 2),
+				cecTranslator:      translation.NewCECTranslator(logger, "cilium-secrets", false, false, true, 60, false, nil, false, false, 2),
 				hostNetworkEnabled: true,
 			}
 			cec, svc, ep, err := trans.Translate(tt.args.m)

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
@@ -6,6 +6,7 @@ package ingress
 import (
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -307,10 +308,11 @@ func Test_translator_Translate(t *testing.T) {
 		},
 	}
 
+	logger := hivetest.Logger(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			trans := &dedicatedIngressTranslator{
-				cecTranslator:      translation.NewCECTranslator("cilium-secrets", tt.args.useProxyProtocol, false, false, 60, tt.args.hostNetworkEnabled, tt.args.hostNetworkNodeLabelSelector, tt.args.ipv4Enabled, tt.args.ipv6Enabled, 0),
+				cecTranslator:      translation.NewCECTranslator(logger, "cilium-secrets", tt.args.useProxyProtocol, false, false, 60, tt.args.hostNetworkEnabled, tt.args.hostNetworkNodeLabelSelector, tt.args.ipv4Enabled, tt.args.ipv6Enabled, 0),
 				hostNetworkEnabled: tt.args.hostNetworkEnabled,
 			}
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: CS issue 1180

In the use case where a user defines ingresses using the same host with TLS secrets in different namespace, Envoy filter chain can't be correctly generated since Envoy uses solely the hostname in their configuration.

This PR attempts to address this issue by generating a filter chain that omits the duplicated hostname. This was achieved by tracking creation time in the secret models and if a situation is detected where the same hostname is used by two secrets in different namespaces, the first created ingress TLS secrets wins. Additionally, when/if this situation is detected an error will be issued in the logs.

> NOTE: We've added similar logic for passthrough filter
chain generation

Signed-off-by: Fernand Galiana <fernand.galiana@isovalent.com>