### PR TITLE
gateway-api: Sync up with latest version upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,7 @@ require (
 	k8s.io/utils v0.0.0-20240902221715-702e33fdd3c3
 	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/controller-tools v0.16.3
-	sigs.k8s.io/gateway-api v1.2.0-rc1
+	sigs.k8s.io/gateway-api v1.2.0-rc1.0.20240923191000-5c5fc388829d
 	sigs.k8s.io/mcs-api v0.1.1-0.20240903161117-2c773b78635e
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1132,8 +1132,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 h1:2770sDpzrjjsA
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.19.0 h1:nWVM7aq+Il2ABxwiCizrVDSlmDcshi9llbaFbC0ji/Q=
 sigs.k8s.io/controller-runtime v0.19.0/go.mod h1:iRmWllt8IlaLjvTTDLhRBXIEtkCK6hwVBJJsYS9Ajf4=
-sigs.k8s.io/gateway-api v1.2.0-rc1 h1:ZcqCEype0Mrt3ax46t2QB+VSm8ic4/WUQkbcc6xtAOI=
-sigs.k8s.io/gateway-api v1.2.0-rc1/go.mod h1:EpNfEXNjiYfUJypf0eZ0P5iXA9ekSGWaS1WgPaM42X0=
+sigs.k8s.io/gateway-api v1.2.0-rc1.0.20240923191000-5c5fc388829d h1:FZvkIACA+ke1SEbOiYyr3bfWr6QwJcrFYxEKyT6BAaQ=
+sigs.k8s.io/gateway-api v1.2.0-rc1.0.20240923191000-5c5fc388829d/go.mod h1:EpNfEXNjiYfUJypf0eZ0P5iXA9ekSGWaS1WgPaM42X0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kind v0.23.0 h1:8fyDGWbWTeCcCTwA04v4Nfr45KKxbSPH1WO9K+jVrBg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2655,7 +2655,7 @@ sigs.k8s.io/controller-tools/pkg/schemapatcher
 sigs.k8s.io/controller-tools/pkg/schemapatcher/internal/yaml
 sigs.k8s.io/controller-tools/pkg/version
 sigs.k8s.io/controller-tools/pkg/webhook
-# sigs.k8s.io/gateway-api v1.2.0-rc1
+# sigs.k8s.io/gateway-api v1.2.0-rc1.0.20240923191000-5c5fc388829d
 ## explicit; go 1.22.0
 sigs.k8s.io/gateway-api/apis/v1
 sigs.k8s.io/gateway-api/apis/v1alpha2

--- a/vendor/sigs.k8s.io/gateway-api/conformance/conformance.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/conformance.go
@@ -45,7 +45,8 @@ import (
 func DefaultOptions(t *testing.T) suite.ConformanceOptions {
 	cfg, err := config.GetConfig()
 	require.NoError(t, err, "error loading Kubernetes config")
-	client, err := client.New(cfg, client.Options{})
+	clientOptions := client.Options{}
+	client, err := client.New(cfg, clientOptions)
 	require.NoError(t, err, "error initializing Kubernetes client")
 
 	// This clientset is needed in addition to the client only because
@@ -79,6 +80,7 @@ func DefaultOptions(t *testing.T) suite.ConformanceOptions {
 		AllowCRDsMismatch:          *flags.AllowCRDsMismatch,
 		CleanupBaseResources:       *flags.CleanupBaseResources,
 		Client:                     client,
+		ClientOptions:              clientOptions,
 		Clientset:                  clientset,
 		ConformanceProfiles:        conformanceProfiles,
 		Debug:                      *flags.ShowDebug,

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/gateway-with-attached-routes-with-port-8080.yaml
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/gateway-with-attached-routes-with-port-8080.yaml
@@ -26,7 +26,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: http-route-4
+  name: http-route-4-port-8080
   namespace: gateway-conformance-infra
 spec:
   parentRefs:

--- a/vendor/sigs.k8s.io/gateway-api/conformance/utils/suite/suite.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/utils/suite/suite.go
@@ -56,6 +56,7 @@ import (
 // conformance tests.
 type ConformanceTestSuite struct {
 	Client                   client.Client
+	ClientOptions            client.Options
 	Clientset                clientset.Interface
 	RESTClient               *rest.RESTClient
 	RestConfig               *rest.Config
@@ -123,6 +124,7 @@ type ConformanceTestSuite struct {
 // Options can be used to initialize a ConformanceTestSuite.
 type ConformanceOptions struct {
 	Client               client.Client
+	ClientOptions        client.Options
 	Clientset            clientset.Interface
 	RestConfig           *rest.Config
 	GatewayClassName     string
@@ -234,6 +236,7 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 
 	suite := &ConformanceTestSuite{
 		Client:           options.Client,
+		ClientOptions:    options.ClientOptions,
 		Clientset:        options.Clientset,
 		RestConfig:       options.RestConfig,
 		RoundTripper:     roundTripper,
@@ -398,7 +401,7 @@ func (suite *ConformanceTestSuite) setClientsetForTest(test ConformanceTest) err
 			strings.Join(featureNames, ","),
 		},
 		"::")
-	client, err := client.New(suite.RestConfig, client.Options{})
+	client, err := client.New(suite.RestConfig, suite.ClientOptions)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The main goal is to avoid some flakes with below PR

Relates: https://github.com/kubernetes-sigs/gateway-api/pull/3350
