### PR TITLE
cilium-cli status: fail fast on terminal error

### DIFF
--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -80,7 +80,7 @@ type k8sClusterMeshImplementation interface {
 	CreateCiliumExternalWorkload(ctx context.Context, cew *ciliumv2.CiliumExternalWorkload, opts metav1.CreateOptions) (*ciliumv2.CiliumExternalWorkload, error)
 	DeleteCiliumExternalWorkload(ctx context.Context, name string, opts metav1.DeleteOptions) error
 	ListCiliumEndpoints(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error)
-	CiliumLogs(ctx context.Context, namespace, pod string, since time.Time) (string, error)
+	CiliumLogs(ctx context.Context, namespace, pod string, since time.Time, previous bool) (string, error)
 }
 
 type K8sClusterMesh struct {

--- a/cilium-cli/connectivity/check/policy.go
+++ b/cilium-cli/connectivity/check/policy.go
@@ -370,7 +370,7 @@ func (t *Test) deleteResources(ctx context.Context) error {
 // filter is applied on each line of output.
 func (t *Test) CiliumLogs(ctx context.Context) {
 	for _, pod := range t.Context().ciliumPods {
-		log, err := pod.K8sClient.CiliumLogs(ctx, pod.Pod.Namespace, pod.Pod.Name, t.startTime)
+		log, err := pod.K8sClient.CiliumLogs(ctx, pod.Pod.Namespace, pod.Pod.Name, t.startTime, false)
 		if err != nil {
 			t.Fatalf("Error reading Cilium logs: %s", err)
 		}

--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -313,11 +313,12 @@ func (c *Client) PodLogs(namespace, name string, opts *corev1.PodLogOptions) *re
 	return c.Clientset.CoreV1().Pods(namespace).GetLogs(name, opts)
 }
 
-func (c *Client) CiliumLogs(ctx context.Context, namespace, pod string, since time.Time) (string, error) {
+func (c *Client) CiliumLogs(ctx context.Context, namespace, pod string, since time.Time, previous bool) (string, error) {
 	opts := &corev1.PodLogOptions{
 		Container:  defaults.AgentContainerName,
 		Timestamps: true,
 		SinceTime:  &metav1.Time{Time: since},
+		Previous:   previous,
 	}
 	req := c.PodLogs(namespace, pod, opts)
 	podLogs, err := req.Stream(ctx)

--- a/cilium-cli/status/k8s_test.go
+++ b/cilium-cli/status/k8s_test.go
@@ -140,7 +140,7 @@ func (c *k8sStatusMockClient) ListCiliumEndpoints(_ context.Context, _ string, o
 	return c.ciliumEndpointList[options.LabelSelector], nil
 }
 
-func (c *k8sStatusMockClient) CiliumLogs(_ context.Context, _, _ string, _ time.Time) (string, error) {
+func (c *k8sStatusMockClient) CiliumLogs(_ context.Context, _, _ string, _ time.Time, _ bool) (string, error) {
 	return "[error] a sample cilium-agent error message", nil
 }
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #34537


* Allow the `cilium status --wait` command to fail fast when there is a terminal error and not continue to retry.
* Allow collection of previous cilium agent container logs when there are restarts.

Testing -

Intentionally introduce a panic in the cilium agent to induce CrashLoopBackOff state.
Build and run `cilium status --wait`, it fails fast with the logs printed in the output:
```
    /¯¯\
 /¯¯\__/¯¯\    Cilium:             3 errors
 \__/¯¯\__/    Operator:           OK
 /¯¯\__/¯¯\    Envoy DaemonSet:    OK
 \__/¯¯\__/    Hubble Relay:       disabled
    \__/       ClusterMesh:        disabled

DaemonSet              cilium             Desired: 2, Unavailable: 2/2
DaemonSet              cilium-envoy       Desired: 2, Ready: 2/2, Available: 2/2
Deployment             cilium-operator    Desired: 1, Ready: 1/1, Available: 1/1
Containers:            cilium             Running: 2
                       cilium-envoy       Running: 2
                       cilium-operator    Running: 1
Cluster Pods:          0/0 managed by Cilium
Helm chart version:    1.17.0-dev
Image versions         cilium             localhost:5000/cilium/cilium-dev:local: 2
                       cilium-envoy       quay.io/cilium/cilium-envoy:v1.30.4-1725856146-ae435a5bef3856f4de98fa360ecfa6a0f5b0f7a1@sha256:f9c2a725a702d9fe4a4e038588a79e72955cf46c789914f940d906d65e92527e: 2
                       cilium-operator    localhost:5000/cilium/operator-generic:local: 1
Errors:                cilium             cilium          2 pods of DaemonSet cilium are not ready
                       cilium             cilium-dr4ql    unable to retrieve cilium status: container cilium-agent is in CrashLoopBackOff, exited with code 2: time="2024-09-26T04:55:38.054243877Z" level=debug msg="Skipped reading configuration file" error="Config File \"cilium\" Not Found in \"[/root]\"" subsys=config
time="2024-09-26T04:55:38.05457721Z" level=info msg="Memory available for map entries (0.003% of 4108660736B): 10271651B" subsys=config
time="2024-09-26T04:55:38.054587502Z" level=debug msg="Total memory for default map entries: 149422080" subsys=config
panic: Inducing crashloopbackoff

goroutine 1 [running]:
github.com/cilium/cilium/pkg/option.(*DaemonConfig).calculateDynamicBPFMapSizes(0x6bbde60, 0x3d2f8eb?, 0xf4e53000, 0x56d200?)
    /go/src/github.com/cilium/cilium/pkg/option/config.go:3928 +0x140
github.com/cilium/cilium/pkg/option.(*DaemonConfig).calculateBPFMapSizes(0x6bbde60, 0x40006ed6c0)
    /go/src/github.com/cilium/cilium/pkg/option/config.go:3879 +0x344
github.com/cilium/cilium/pkg/option.(*DaemonConfig).Populate(0x6bbde60, 0x40006ed6c0)
    /go/src/github.com/cilium/cilium/pkg/option/config.go:3298 +0x26e4
github.com/cilium/cilium/daemon/cmd.initDaemonConfig(0x40006ed6c0)
    /go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:1206 +0x54
github.com/cilium/cilium/daemon/cmd.NewAgentCmd.func3()
    /go/src/github.com/cilium/cilium/daemon/cmd/root.go:72 +0x24
github.com/spf13/cobra.(*Command).preRun(...)
    /go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:1019
github.com/spf13/cobra.(*Command).execute(0x4000760008, {0x4000140010, 0x1, 0x1})
    /go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:929 +0x424
github.com/spf13/cobra.(*Command).ExecuteC(0x4000760008)
    /go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:1117 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
    /go/src/github.com/cilium/cil
    cilium    cilium-ndpqt    unable to retrieve cilium status: container cilium-agent is in CrashLoopBackOff, exited with code 2: time="2024-09-26T04:55:57.162269969Z" level=debug msg="Skipped reading configuration file" error="Config File \"cilium\" Not Found in \"[/root]\"" subsys=config
time="2024-09-26T04:55:57.162573178Z" level=info msg="Memory available for map entries (0.003% of 4108660736B): 10271651B" subsys=config
time="2024-09-26T04:55:57.162586803Z" level=debug msg="Total memory for default map entries: 149422080" subsys=config
panic: Inducing crashloopbackoff
```
