### PR TITLE
[1.16] test: Skip envoy internal_address_config warning log

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -248,6 +248,7 @@ const (
 	delMissingService          = "Deleting no longer present service"                                    // cf. https://github.com/cilium/cilium/issues/29679
 	failedIpcacheRestore       = "Failed to restore existing identities from the previous ipcache"       // cf. https://github.com/cilium/cilium/issues/29328
 	podCIDRUnavailable         = " PodCIDR not available"                                                // cf. https://github.com/cilium/cilium/issues/29680
+	internalAddressConfigEnvoy = "internal_address_config is not configured."                            // cf. https://github.com/cilium/cilium/issues/34968
 	unableGetNode              = "Unable to get node resource"                                           // cf. https://github.com/cilium/cilium/issues/29710
 	disableSocketLBTracing     = "Disabling socket-LB tracing"                                           // cf. https://github.com/cilium/cilium/issues/29734
 	sessionAffinitySocketLB    = "Session affinity for host reachable services needs kernel"             // cf. https://github.com/cilium/cilium/issues/29736
@@ -337,7 +338,7 @@ var badLogMessages = map[string][]string{
 		podCIDRUnavailable, unableGetNode,
 		disableSocketLBTracing, sessionAffinitySocketLB, objectHasBeenModified, noBackendResponse,
 		unsupportedSocketLookup, legacyBGPFeature, etcdTimeout, endpointRestoreFailed,
-		failedPeerSync, unableRestoreRouterIP, routerIPReallocated,
+		failedPeerSync, internalAddressConfigEnvoy, unableRestoreRouterIP, routerIPReallocated,
 		cantFindIdentityInCache, kubeApiserverConnLost1, kubeApiserverConnLost2, heartbeatTimedOut,
 		keyAllocFailedFoundMaster, cantRecreateMasterKey, cantUpdateCRDIdentity,
 		cantDeleteFromPolicyMap, failedToListCRDs},


### PR DESCRIPTION
Conformance Gingko is currently broken in v1.16:

```
03:16:51 STEP: Running JustAfterEach block for EntireTestsuite K8sUpdates
FAIL: Found 1 k8s-app=cilium logs matching list of errors that must be investigated:
2024-09-20T03:16:36.098363018Z time="2024-09-20T03:16:36Z" level=warning msg="[internal_address_config is not configured. The existing default behaviour will trust RFC1918 IP addresses, but this will be changed in next release. Please explictily config internal address config as the migration step." subsys=envoy-misc threadID=324
```

Example runs: [here](https://github.com/cilium/cilium/actions/runs/11044819566/job/30681459552) and [here](https://github.com/cilium/cilium/actions/runs/11041056088/job/30670530170)

This is due to https://github.com/cilium/cilium/issues/34968

As already done for v1.15 in https://github.com/cilium/cilium/pull/34965, that warning should be skipped.