### PR TITLE
test(notify): add tests to compare flow proto parsed from notify events

### DIFF
--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/byteorder"
@@ -60,11 +61,13 @@ var (
 	hostEP   = uint16(0x1092)
 	remoteIP = netip.MustParseAddr("5.6.7.8")
 	remoteID = identity.NumericIdentity(5678)
+	xlatedIP = netip.MustParseAddr("10.11.12.13")
 	srcMAC   = net.HardwareAddr{1, 2, 3, 4, 5, 6}
 	dstMAC   = net.HardwareAddr{7, 8, 9, 0, 1, 2}
 
-	egressTuple  = ipTuple{src: localIP, dst: remoteIP}
-	ingressTuple = ipTuple{src: remoteIP, dst: localIP}
+	egressTuple       = ipTuple{src: localIP, dst: remoteIP}
+	ingressTuple      = ipTuple{src: remoteIP, dst: localIP}
+	xlatedEgressTuple = ipTuple{src: xlatedIP, dst: remoteIP}
 
 	fooBarLabel           = labels.LabelArrayList{labels.ParseLabelArray("foo=bar")}
 	remotePolicyKey       = policy.EgressKey().WithIdentity(remoteID)
@@ -1456,6 +1459,317 @@ func TestDecode_DropNotify(t *testing.T) {
 					ID: uint32(localEP),
 				},
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			want := proto.Clone(template)
+			proto.Merge(want, tc.want)
+
+			data, err := testutils.CreateL3L4Payload(tc.event,
+				&layers.Ethernet{
+					SrcMAC:       srcMAC,
+					DstMAC:       dstMAC,
+					EthernetType: layers.EthernetTypeIPv4,
+				},
+				&layers.IPv4{SrcIP: tc.ipTuple.src.AsSlice(), DstIP: tc.ipTuple.dst.AsSlice()},
+			)
+			if err != nil {
+				t.Fatalf("Unexpected error from CreateL3L4Payload(%T, ...): %v", tc.event, err)
+			}
+
+			got := &flowpb.Flow{}
+			if err := parser.Decode(data, got); err != nil {
+				t.Fatalf("Unexpected error from Decode(data, %T): %v", got, err)
+			}
+
+			opts := []cmp.Option{
+				protocmp.Transform(),
+				protocmp.IgnoreFields(&flowpb.Flow{}, "reply"),
+			}
+			if diff := cmp.Diff(want, got, opts...); diff != "" {
+				t.Errorf("Unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDecode_TraceNotify(t *testing.T) {
+	parser, err := New(log, defaultEndpointGetter, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	template := &flowpb.Flow{
+		EventType:   &flowpb.CiliumEventType{Type: 4},
+		Summary:     flowpb.IPVersion_IPv4.String(),
+		Type:        flowpb.FlowType_L3_L4,
+		Verdict:     flowpb.Verdict_FORWARDED,
+		Source:      &flowpb.Endpoint{},
+		Destination: &flowpb.Endpoint{},
+		Ethernet: &flowpb.Ethernet{
+			Source:      srcMAC.String(),
+			Destination: dstMAC.String(),
+		},
+		IP: &flowpb.IP{
+			IpVersion:   flowpb.IPVersion_IPv4,
+			Source:      localIP.String(),
+			Destination: remoteIP.String(),
+		},
+		TraceObservationPoint: flowpb.TraceObservationPoint_TO_ENDPOINT,
+	}
+
+	testCases := []struct {
+		name    string
+		event   any
+		ipTuple ipTuple
+		want    *flowpb.Flow
+	}{
+		{
+			name: "v0_unknown",
+			event: monitor.TraceNotifyV0{
+				Type:     byte(monitorAPI.MessageTypeTrace),
+				ObsPoint: monitorAPI.TraceToLxc,
+			},
+			ipTuple: egressTuple,
+			want: &flowpb.Flow{
+				Source:      &flowpb.Endpoint{ID: 1234},
+				IsReply:     wrapperspb.Bool(false),
+				TraceReason: flowpb.TraceReason_NEW,
+			},
+		},
+		{
+			name: "v0_to_lxc",
+			event: monitor.TraceNotifyV0{
+				Type:     byte(monitorAPI.MessageTypeTrace),
+				Source:   localEP,
+				ObsPoint: monitorAPI.TraceToLxc,
+			},
+			ipTuple: egressTuple,
+			want: &flowpb.Flow{
+				Source:           &flowpb.Endpoint{ID: 1234},
+				IsReply:          wrapperspb.Bool(false),
+				TraceReason:      flowpb.TraceReason_NEW,
+				TrafficDirection: flowpb.TrafficDirection_EGRESS,
+			},
+		},
+		{
+			name: "v1_to_network",
+			event: monitor.TraceNotifyV1{
+				TraceNotifyV0: monitor.TraceNotifyV0{
+					Type:     byte(monitorAPI.MessageTypeTrace),
+					Source:   hostEP,
+					ObsPoint: monitorAPI.TraceToNetwork,
+					Version:  monitor.TraceNotifyVersion1,
+				},
+				OrigIP: types.IPv6{1, 2, 3, 4}, // localIP
+			},
+			ipTuple: xlatedEgressTuple,
+			want: &flowpb.Flow{
+				EventType: &flowpb.CiliumEventType{
+					SubType: 11,
+				},
+				IP: &flowpb.IP{
+					SourceXlated: xlatedIP.String(),
+				},
+				Source:                &flowpb.Endpoint{ID: 1234},
+				IsReply:               wrapperspb.Bool(false),
+				TraceReason:           flowpb.TraceReason_NEW,
+				TrafficDirection:      flowpb.TrafficDirection_EGRESS,
+				TraceObservationPoint: flowpb.TraceObservationPoint_TO_NETWORK,
+			},
+		},
+		{
+			name: "v0_to_lxc_reply",
+			event: monitor.TraceNotifyV0{
+				Type:     byte(monitorAPI.MessageTypeTrace),
+				Source:   localEP,
+				ObsPoint: monitorAPI.TraceToLxc,
+				Reason:   monitor.TraceReasonCtReply,
+			},
+			ipTuple: xlatedEgressTuple,
+			want: &flowpb.Flow{
+				IP: &flowpb.IP{
+					Source: xlatedIP.String(),
+				},
+				TrafficDirection:      flowpb.TrafficDirection_EGRESS,
+				TraceObservationPoint: flowpb.TraceObservationPoint_TO_ENDPOINT,
+				IsReply:               wrapperspb.Bool(true),
+				TraceReason:           flowpb.TraceReason_REPLY,
+			},
+		},
+		{
+			name: "v0_to_host",
+			event: monitor.TraceNotifyV0{
+				Type:     byte(monitorAPI.MessageTypeTrace),
+				Source:   localEP,
+				ObsPoint: monitorAPI.TraceToHost,
+			},
+			ipTuple: ingressTuple,
+			want: &flowpb.Flow{
+				EventType: &flowpb.CiliumEventType{
+					SubType: 2,
+				},
+				IP: &flowpb.IP{
+					Source:      remoteIP.String(),
+					Destination: localIP.String(),
+				},
+				Destination:           &flowpb.Endpoint{ID: 1234},
+				IsReply:               wrapperspb.Bool(false),
+				TraceReason:           flowpb.TraceReason_NEW,
+				TrafficDirection:      flowpb.TrafficDirection_INGRESS,
+				TraceObservationPoint: flowpb.TraceObservationPoint_TO_HOST,
+			},
+		},
+		{
+			name: "v0_to_host_reply",
+			event: monitor.TraceNotifyV0{
+				Type:     byte(monitorAPI.MessageTypeTrace),
+				Source:   localEP,
+				ObsPoint: monitorAPI.TraceToHost,
+				Reason:   monitor.TraceReasonCtReply,
+			},
+			ipTuple: ingressTuple,
+			want: &flowpb.Flow{
+				EventType: &flowpb.CiliumEventType{
+					SubType: 2,
+				},
+				IP: &flowpb.IP{
+					Source:      remoteIP.String(),
+					Destination: localIP.String(),
+				},
+				Destination:           &flowpb.Endpoint{ID: 1234},
+				TrafficDirection:      flowpb.TrafficDirection_EGRESS,
+				TraceObservationPoint: flowpb.TraceObservationPoint_TO_HOST,
+				IsReply:               wrapperspb.Bool(true),
+				TraceReason:           flowpb.TraceReason_REPLY,
+			},
+		},
+		{
+			name: "v0_from_lxc",
+			event: monitor.TraceNotifyV0{
+				Type:     byte(monitorAPI.MessageTypeTrace),
+				Source:   localEP,
+				ObsPoint: monitorAPI.TraceFromLxc,
+				Reason:   monitor.TraceReasonUnknown,
+			},
+			ipTuple: egressTuple,
+			want: &flowpb.Flow{
+				EventType: &flowpb.CiliumEventType{
+					SubType: 5,
+				},
+				Source:                &flowpb.Endpoint{ID: 1234},
+				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
+			},
+		},
+		{
+			name: "v0_from_lxc_encrypted",
+			event: monitor.TraceNotifyV0{
+				Type:     byte(monitorAPI.MessageTypeTrace),
+				Source:   localEP,
+				ObsPoint: monitorAPI.TraceFromLxc,
+				Reason:   monitor.TraceReasonUnknown,
+			},
+			ipTuple: egressTuple,
+			want: &flowpb.Flow{
+				EventType: &flowpb.CiliumEventType{
+					SubType: 5,
+				},
+				Source:                &flowpb.Endpoint{ID: 1234},
+				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
+			},
+		},
+		{
+			name: "v0_unknown_encrypted",
+			event: monitor.TraceNotifyV0{
+				Type:     byte(monitorAPI.MessageTypeTrace),
+				Source:   localEP,
+				ObsPoint: monitorAPI.TraceFromLxc,
+				Reason:   monitor.TraceReasonUnknown,
+			},
+			ipTuple: egressTuple,
+			want: &flowpb.Flow{
+				EventType: &flowpb.CiliumEventType{
+					SubType: 5,
+				},
+				Source:                &flowpb.Endpoint{ID: 1234},
+				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
+			},
+		},
+		{
+			name: "v0_from_lxc_unknown_encrypted",
+			event: monitor.TraceNotifyV0{
+				Type:     byte(monitorAPI.MessageTypeTrace),
+				Source:   localEP,
+				ObsPoint: monitorAPI.TraceFromLxc,
+				Reason:   monitor.TraceReasonUnknown | monitor.TraceReasonEncryptMask,
+			},
+			ipTuple: egressTuple,
+			want: &flowpb.Flow{
+				EventType: &flowpb.CiliumEventType{
+					SubType: 5,
+				},
+				IP: &flowpb.IP{
+					Encrypted: true,
+				},
+				Source:                &flowpb.Endpoint{ID: 1234},
+				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
+			},
+		},
+		{
+			name: "v0_to_stack_encrypt_overlay",
+			event: monitor.TraceNotifyV0{
+				Type:     byte(monitorAPI.MessageTypeTrace),
+				Source:   hostEP,
+				ObsPoint: monitorAPI.TraceToStack,
+				Reason:   monitor.TraceReasonEncryptOverlay,
+			},
+			ipTuple: egressTuple,
+			want: &flowpb.Flow{
+				EventType: &flowpb.CiliumEventType{
+					SubType: 3,
+				},
+				Source:                &flowpb.Endpoint{ID: 1234},
+				TraceReason:           flowpb.TraceReason_ENCRYPT_OVERLAY,
+				TrafficDirection:      flowpb.TrafficDirection_EGRESS,
+				TraceObservationPoint: flowpb.TraceObservationPoint_TO_STACK,
+			},
+		},
+		{
+			name: "v0_to_stack_srv6_decap",
+			event: monitor.TraceNotifyV0{
+				Type:     byte(monitorAPI.MessageTypeTrace),
+				Source:   hostEP,
+				ObsPoint: monitorAPI.TraceToStack,
+				Reason:   monitor.TraceReasonSRv6Decap,
+			},
+			ipTuple: egressTuple,
+			want: &flowpb.Flow{
+				EventType: &flowpb.CiliumEventType{
+					SubType: 3,
+				},
+				Source:                &flowpb.Endpoint{ID: 1234},
+				TraceReason:           flowpb.TraceReason_SRV6_DECAP,
+				TrafficDirection:      flowpb.TrafficDirection_INGRESS,
+				TraceObservationPoint: flowpb.TraceObservationPoint_TO_STACK,
+			},
+		},
+		{
+			name: "v0_to_stack_srv6_encap",
+			event: monitor.TraceNotifyV0{
+				Type:     byte(monitorAPI.MessageTypeTrace),
+				Source:   localEP,
+				ObsPoint: monitorAPI.TraceToStack,
+				Reason:   monitor.TraceReasonSRv6Encap,
+			},
+			ipTuple: egressTuple,
+			want: &flowpb.Flow{
+				EventType: &flowpb.CiliumEventType{
+					SubType: 3,
+				},
+				Source:                &flowpb.Endpoint{ID: 1234},
+				TraceReason:           flowpb.TraceReason_SRV6_ENCAP,
+				TrafficDirection:      flowpb.TrafficDirection_EGRESS,
+				TraceObservationPoint: flowpb.TraceObservationPoint_TO_STACK,
 			},
 		},
 	}

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -1805,3 +1805,94 @@ func TestDecode_TraceNotify(t *testing.T) {
 		})
 	}
 }
+
+func TestDecode_PolicyVerdictNotify(t *testing.T) {
+	parser, err := New(log, defaultEndpointGetter, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	template := &flowpb.Flow{
+		EventType:   &flowpb.CiliumEventType{Type: 5},
+		Summary:     flowpb.IPVersion_IPv4.String(),
+		Type:        flowpb.FlowType_L3_L4,
+		Verdict:     flowpb.Verdict_FORWARDED,
+		Source:      &flowpb.Endpoint{},
+		Destination: &flowpb.Endpoint{},
+		Ethernet: &flowpb.Ethernet{
+			Source:      srcMAC.String(),
+			Destination: dstMAC.String(),
+		},
+		IP: &flowpb.IP{
+			IpVersion:   flowpb.IPVersion_IPv4,
+			Source:      localIP.String(),
+			Destination: remoteIP.String(),
+		},
+		IsReply: wrapperspb.Bool(false),
+	}
+
+	testCases := []struct {
+		name    string
+		event   any
+		ipTuple ipTuple
+		want    *flowpb.Flow
+	}{
+		{
+			name: "egress",
+			event: monitor.PolicyVerdictNotify{
+				Type:        byte(monitorAPI.MessageTypePolicyVerdict),
+				Source:      localEP,
+				Flags:       monitorAPI.PolicyEgress,
+				RemoteLabel: identity.NumericIdentity(remoteID),
+			},
+			ipTuple: egressTuple,
+			want: &flowpb.Flow{
+				Source:           &flowpb.Endpoint{ID: 1234},
+				Destination:      &flowpb.Endpoint{Identity: 5678},
+				TrafficDirection: flowpb.TrafficDirection_EGRESS,
+			},
+		},
+		{
+			name: "ingresss",
+			event: monitor.PolicyVerdictNotify{
+				Type:   byte(monitorAPI.MessageTypePolicyVerdict),
+				Source: localEP,
+				Flags:  monitorAPI.PolicyIngress,
+			},
+			ipTuple: egressTuple,
+			want: &flowpb.Flow{
+				Source:           &flowpb.Endpoint{ID: 1234},
+				TrafficDirection: flowpb.TrafficDirection_INGRESS,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			want := proto.Clone(template)
+			proto.Merge(want, tc.want)
+
+			data, err := testutils.CreateL3L4Payload(tc.event,
+				&layers.Ethernet{
+					SrcMAC:       srcMAC,
+					DstMAC:       dstMAC,
+					EthernetType: layers.EthernetTypeIPv4,
+				},
+				&layers.IPv4{SrcIP: tc.ipTuple.src.AsSlice(), DstIP: tc.ipTuple.dst.AsSlice()},
+			)
+			if err != nil {
+				t.Fatalf("Unexpected error from CreateL3L4Payload(%T, ...): %v", tc.event, err)
+			}
+
+			got := &flowpb.Flow{}
+			if err := parser.Decode(data, got); err != nil {
+				t.Fatalf("Unexpected error from Decode(data, %T): %v", got, err)
+			}
+
+			opts := []cmp.Option{
+				protocmp.Transform(),
+				protocmp.IgnoreFields(&flowpb.Flow{}, "reply"),
+			}
+			if diff := cmp.Diff(want, got, opts...); diff != "" {
+				t.Errorf("Unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Related: #35057

Diffing the flow proto provides more clarity how a change to the notification or parsing has affected the output.

Note: no release note
