### PR TITLE
cli: bugfix connectivity perf command

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -1157,13 +1157,7 @@ func (ct *ConnectivityTest) deployPerf(ctx context.Context) error {
 
 // deploymentList returns 2 lists of Deployments to be used for running tests with.
 func (ct *ConnectivityTest) deploymentList() (srcList []string, dstList []string) {
-	if !ct.params.Perf {
-		srcList = []string{clientDeploymentName, client2DeploymentName, echoSameNodeDeploymentName}
-		if ct.params.MultiCluster == "" && !ct.params.SingleNode {
-			srcList = append(srcList, client3DeploymentName)
-		}
-	} else if ct.params.TestNamespaceIndex == 0 {
-		srcList = []string{}
+	if ct.params.Perf && ct.params.TestNamespaceIndex == 0 {
 		if ct.params.PerfParameters.PodNet {
 			srcList = append(srcList, perfClientDeploymentName)
 			srcList = append(srcList, perfClientAcrossDeploymentName)
@@ -1174,6 +1168,14 @@ func (ct *ConnectivityTest) deploymentList() (srcList []string, dstList []string
 			srcList = append(srcList, perfClientHostNetAcrossDeploymentName)
 			srcList = append(srcList, perfServerHostNetDeploymentName)
 		}
+		// Return early, we can't run regular connectivity tests
+		// along perf test
+		return
+	}
+
+	srcList = []string{clientDeploymentName, client2DeploymentName, echoSameNodeDeploymentName}
+	if ct.params.MultiCluster == "" && !ct.params.SingleNode {
+		srcList = append(srcList, client3DeploymentName)
 	}
 
 	if ct.params.IncludeConnDisruptTest && ct.params.TestNamespaceIndex == 0 {
@@ -1187,7 +1189,7 @@ func (ct *ConnectivityTest) deploymentList() (srcList []string, dstList []string
 		dstList = append(dstList, testConnDisruptClientDeploymentName)
 	}
 
-	if (ct.params.MultiCluster != "" || !ct.params.SingleNode) && !ct.params.Perf {
+	if ct.params.MultiCluster != "" || !ct.params.SingleNode {
 		dstList = append(dstList, echoOtherNodeDeploymentName)
 	}
 


### PR DESCRIPTION
Currently, regular connectivity tests and perf tests are still a bit coupled, but they can't be run concurrently.
In the case of LRP enabled, we were deploying only perf pods, but the validation of deployments was waiting for lrp pod too:
```
✨ Deploying perf-client deployment...
✨ Deploying perf-client-other-node deployment...
✨ Deploying perf-server deployment...
⌛ Waiting for deployment cilium-test-1/perf-client to become ready...
⌛ Waiting for deployment cilium-test-1/perf-client-other-node to become ready...
⌛ Waiting for deployment cilium-test-1/perf-server to become ready...
⌛ Waiting for deployment cilium-test-1/lrp-client to become ready...
timeout reached waiting for deployment cilium-test-1/lrp-client to become ready
```

As we have to separate functions for deploying deployments and validating deployments, we need to keep them in sync. Now in validation of deployments, return early in case of perf command, just like in a deploy function.

```release-note
cli: fix a case when connectivity perf command was hanging if LRP was enabled in the cluster
```
