### PR TITLE
policy: Add PolicyRepository interface

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -377,7 +377,7 @@ func LaunchAsEndpoint(baseCtx context.Context,
 }
 
 type policyRepoGetter interface {
-	GetPolicyRepository() *policy.Repository
+	GetPolicyRepository() policy.PolicyRepository
 }
 
 type routingConfigurer interface {

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -93,7 +93,7 @@ type Daemon struct {
 	l7Proxy          *proxy.Proxy
 	envoyXdsServer   envoy.XDSServer
 	svc              service.ServiceManager
-	policy           *policy.Repository
+	policy           policy.PolicyRepository
 	idmgr            identitymanager.IDManager
 
 	statusCollectMutex lock.RWMutex
@@ -184,7 +184,7 @@ type Daemon struct {
 }
 
 // GetPolicyRepository returns the policy repository of the daemon
-func (d *Daemon) GetPolicyRepository() *policy.Repository {
+func (d *Daemon) GetPolicyRepository() policy.PolicyRepository {
 	return d.policy
 }
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1573,7 +1573,7 @@ type daemonParams struct {
 	CertManager            certificatemanager.CertificateManager
 	SecretManager          certificatemanager.SecretManager
 	IdentityAllocator      identitycell.CachingIdentityAllocator
-	Policy                 *policy.Repository
+	Policy                 policy.PolicyRepository
 	IPCache                *ipcache.IPCache
 	DirectoryPolicyWatcher policyDirectory.ResourcesWatcher
 	DirReadStatus          policyDirectory.DirectoryWatcherReadStatus

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -59,7 +59,7 @@ type DaemonSuite struct {
 	oldPolicyEnabled string
 
 	// Owners interface mock
-	OnGetPolicyRepository  func() *policy.Repository
+	OnGetPolicyRepository  func() policy.PolicyRepository
 	OnGetNamedPorts        func() (npm types.NamedPortMultiMap)
 	OnQueueEndpointBuild   func(ctx context.Context, epID uint64) (func(), error)
 	OnGetCompilationLock   func() datapath.CompilationLock
@@ -242,7 +242,7 @@ func TestMinimumWorkerThreadsIsSet(t *testing.T) {
 	require.GreaterOrEqual(t, numWorkerThreads(), runtime.NumCPU())
 }
 
-func (ds *DaemonSuite) GetPolicyRepository() *policy.Repository {
+func (ds *DaemonSuite) GetPolicyRepository() policy.PolicyRepository {
 	if ds.OnGetPolicyRepository != nil {
 		return ds.OnGetPolicyRepository()
 	}

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -102,7 +102,7 @@ type configModifyEventHandlerParams struct {
 	Logger    logrus.FieldLogger
 
 	Orchestrator    datapath.Orchestrator
-	Policy          *policy.Repository
+	Policy          policy.PolicyRepository
 	EndpointManager endpointmanager.EndpointManager
 	L7Proxy         *proxy.Proxy
 }
@@ -161,7 +161,7 @@ type ConfigModifyEventHandler struct {
 	configModifyQueue *eventqueue.EventQueue
 
 	orchestrator    datapath.Orchestrator
-	policy          *policy.Repository
+	policy          policy.PolicyRepository
 	endpointManager endpointmanager.EndpointManager
 	l7Proxy         *proxy.Proxy
 }

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -84,7 +84,7 @@ type authManagerParams struct {
 	IdentityChanges stream.Observable[cache.IdentityChange]
 	NodeManager     nodeManager.NodeManager
 	EndpointManager endpointmanager.EndpointManager
-	PolicyRepo      *policy.Repository
+	PolicyRepo      policy.PolicyRepository
 }
 
 func registerAuthManager(params authManagerParams) (*AuthManager, error) {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -466,7 +466,7 @@ type namedPortsGetter interface {
 }
 
 type policyRepoGetter interface {
-	GetPolicyRepository() *policy.Repository
+	GetPolicyRepository() policy.PolicyRepository
 }
 
 // EndpointSyncControllerName returns the controller name to synchronize

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -39,11 +39,11 @@ import (
 
 type EndpointSuite struct {
 	orchestrator datapath.Orchestrator
-	repo         *policy.Repository
+	repo         policy.PolicyRepository
 	mgr          *cache.CachingIdentityAllocator
 
 	// Owners interface mock
-	OnGetPolicyRepository     func() *policy.Repository
+	OnGetPolicyRepository     func() policy.PolicyRepository
 	OnGetNamedPorts           func() (npm types.NamedPortMultiMap)
 	OnQueueEndpointBuild      func(ctx context.Context, epID uint64) (func(), error)
 	OnRemoveFromEndpointQueue func(epID uint64)
@@ -85,7 +85,7 @@ func setupEndpointSuite(tb testing.TB) *EndpointSuite {
 	return s
 }
 
-func (s *EndpointSuite) GetPolicyRepository() *policy.Repository {
+func (s *EndpointSuite) GetPolicyRepository() policy.PolicyRepository {
 	return s.repo
 }
 

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -45,10 +45,12 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 	repo := policy.NewPolicyRepository(fakeAllocator.GetIdentityCache(), nil, nil, nil)
 
 	defer func() {
-		repo.RepositoryChangeQueue.Stop()
-		repo.RuleReactionQueue.Stop()
-		repo.RepositoryChangeQueue.WaitToBeDrained()
-		repo.RuleReactionQueue.WaitToBeDrained()
+		repoChangeQueue := repo.GetRepositoryChangeQueue()
+		ruleReactionQueue := repo.GetRuleReactionQueue()
+		repoChangeQueue.Stop()
+		ruleReactionQueue.Stop()
+		repoChangeQueue.WaitToBeDrained()
+		ruleReactionQueue.WaitToBeDrained()
 	}()
 
 	addIdentity := func(labelKeys ...string) *identity.Identity {
@@ -179,9 +181,9 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 }
 
 type mockPolicyGetter struct {
-	repo *policy.Repository
+	repo policy.PolicyRepository
 }
 
-func (m *mockPolicyGetter) GetPolicyRepository() *policy.Repository {
+func (m *mockPolicyGetter) GetPolicyRepository() policy.PolicyRepository {
 	return m.repo
 }

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -125,12 +125,12 @@ func (d *DummyIdentityAllocatorOwner) GetNodeSuffix() string {
 
 // DummyOwner implements pkg/endpoint/regeneration/Owner. Used for unit testing.
 type DummyOwner struct {
-	repo  *policy.Repository
+	repo  policy.PolicyRepository
 	idmgr identitymanager.IDManager
 }
 
 // GetPolicyRepository returns the policy repository of the owner.
-func (d *DummyOwner) GetPolicyRepository() *policy.Repository {
+func (d *DummyOwner) GetPolicyRepository() policy.PolicyRepository {
 	return d.repo
 }
 
@@ -216,7 +216,8 @@ func (s *RedirectSuite) NewTestEndpoint(t *testing.T) *Endpoint {
 }
 
 func (s *RedirectSuite) AddRules(rules api.Rules) {
-	s.do.repo.MustAddList(rules)
+	repo := s.do.repo.(*policy.Repository)
+	repo.MustAddList(rules)
 }
 
 func (s *RedirectSuite) TearDownTest(t *testing.T) {

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -725,7 +725,7 @@ func (mgr *endpointManager) AddHostEndpoint(
 }
 
 type policyRepoGetter interface {
-	GetPolicyRepository() *policy.Repository
+	GetPolicyRepository() policy.PolicyRepository
 }
 
 // InitHostEndpointLabels initializes the host endpoint's labels with the

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -54,7 +54,7 @@ func (mgr *endpointManager) WaitEndpointRemoved(ep *endpoint.Endpoint) {
 }
 
 type EndpointManagerSuite struct {
-	repo *policy.Repository
+	repo policy.PolicyRepository
 }
 
 func setupEndpointManagerSuite(tb testing.TB) *EndpointManagerSuite {
@@ -64,7 +64,7 @@ func setupEndpointManagerSuite(tb testing.TB) *EndpointManagerSuite {
 	return s
 }
 
-func (s *EndpointManagerSuite) GetPolicyRepository() *policy.Repository {
+func (s *EndpointManagerSuite) GetPolicyRepository() policy.PolicyRepository {
 	return s.repo
 }
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -45,7 +45,7 @@ import (
 )
 
 type DNSProxyTestSuite struct {
-	repo         *policy.Repository
+	repo         policy.PolicyRepository
 	dnsTCPClient *dns.Client
 	dnsServer    *dns.Server
 	proxy        *DNSProxy
@@ -159,7 +159,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 	return s
 }
 
-func (s *DNSProxyTestSuite) GetPolicyRepository() *policy.Repository {
+func (s *DNSProxyTestSuite) GetPolicyRepository() policy.PolicyRepository {
 	return s.repo
 }
 

--- a/pkg/identity/cache/cell/cell.go
+++ b/pkg/identity/cache/cell/cell.go
@@ -57,7 +57,7 @@ type identityAllocatorParams struct {
 	cell.In
 
 	Lifecycle        cell.Lifecycle
-	PolicyRepository *policy.Repository
+	PolicyRepository policy.PolicyRepository
 	PolicyUpdater    *policy.Updater
 
 	Config config
@@ -119,7 +119,7 @@ func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
 // identityAllocatorOwner is used to break the circular dependency between
 // CachingIdentityAllocator and policy.Repository.
 type identityAllocatorOwner struct {
-	policy        *policy.Repository
+	policy        policy.PolicyRepository
 	policyUpdater *policy.Updater
 }
 

--- a/pkg/ipcache/cell/cell.go
+++ b/pkg/ipcache/cell/cell.go
@@ -28,7 +28,7 @@ type ipCacheParams struct {
 
 	Lifecycle              cell.Lifecycle
 	CacheIdentityAllocator cache.IdentityAllocator
-	PolicyRepository       *policy.Repository
+	PolicyRepository       policy.PolicyRepository
 	EndpointManager        endpointmanager.EndpointManager
 	CacheStatus            synced.CacheStatus
 }

--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -36,7 +36,7 @@ type policyRepoParams struct {
 	ClusterInfo     cmtypes.ClusterInfo
 }
 
-func newPolicyRepo(params policyRepoParams) *policy.Repository {
+func newPolicyRepo(params policyRepoParams) policy.PolicyRepository {
 	if option.Config.EnableWellKnownIdentities {
 		// Must be done before calling policy.NewPolicyRepository() below.
 		num := identity.InitWellKnownIdentities(option.Config, params.ClusterInfo)
@@ -73,7 +73,7 @@ type policyUpdaterParams struct {
 	cell.In
 
 	Lifecycle        cell.Lifecycle
-	PolicyRepository *policy.Repository
+	PolicyRepository policy.PolicyRepository
 	EndpointManager  endpointmanager.EndpointManager
 }
 

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -263,10 +263,10 @@ func TestGetRulesMatching(t *testing.T) {
 		To:   labels.ParseSelectLabelArray("bar"),
 	}
 
-	repo.Mutex.RLock()
+	repo.mutex.RLock()
 	// no rules loaded: Allows() => denied
 	require.Equal(t, api.Denied, repo.AllowsIngressRLocked(fooToBar))
-	repo.Mutex.RUnlock()
+	repo.mutex.RUnlock()
 
 	bar := labels.ParseSelectLabel("bar")
 	foo := labels.ParseSelectLabel("foo")
@@ -331,10 +331,10 @@ func TestDeniesIngress(t *testing.T) {
 		To:   labels.ParseSelectLabelArray("bar"),
 	}
 
-	repo.Mutex.RLock()
+	repo.mutex.RLock()
 	// no rules loaded: Allows() => denied
 	require.Equal(t, api.Denied, repo.AllowsIngressRLocked(fooToBar))
-	repo.Mutex.RUnlock()
+	repo.mutex.RUnlock()
 
 	tag1 := labels.LabelArray{labels.ParseLabel("tag1")}
 	rule1 := api.Rule{
@@ -430,10 +430,10 @@ func TestDeniesEgress(t *testing.T) {
 		To:   labels.ParseSelectLabelArray("bar"),
 	}
 
-	repo.Mutex.RLock()
+	repo.mutex.RLock()
 	// no rules loaded: Allows() => denied
 	require.Equal(t, api.Denied, repo.AllowsEgressRLocked(fooToBar))
-	repo.Mutex.RUnlock()
+	repo.mutex.RUnlock()
 
 	tag1 := labels.LabelArray{labels.ParseLabel("tag1")}
 	rule1 := api.Rule{
@@ -554,8 +554,8 @@ func TestWildcardL3RulesIngressDeny(t *testing.T) {
 		To: labels.ParseSelectLabelArray("id=foo"),
 	}
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 
 	policyDeny, err := repo.ResolveL4IngressPolicy(ctx)
 	require.NoError(t, err)
@@ -630,8 +630,8 @@ func TestWildcardL4RulesIngressDeny(t *testing.T) {
 		To: labels.ParseSelectLabelArray("id=foo"),
 	}
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 
 	policyDeny, err := repo.ResolveL4IngressPolicy(ctx)
 	require.NoError(t, err)
@@ -702,8 +702,8 @@ func TestL3DependentL4IngressDenyFromRequires(t *testing.T) {
 		To: labels.ParseSelectLabelArray("id=foo"),
 	}
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 
 	policyDeny, err := repo.ResolveL4IngressPolicy(ctx)
 	require.NoError(t, err)
@@ -774,8 +774,8 @@ func TestL3DependentL4EgressDenyFromRequires(t *testing.T) {
 		From: labels.ParseSelectLabelArray("id=foo"),
 	}
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 
 	logBuffer := new(bytes.Buffer)
 	policyDeny, err := repo.ResolveL4EgressPolicy(ctx.WithLogger(logBuffer))
@@ -901,8 +901,8 @@ func TestWildcardL3RulesEgressDeny(t *testing.T) {
 		From: labels.ParseSelectLabelArray("id=foo"),
 	}
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 
 	logBuffer := new(bytes.Buffer)
 	policyDeny, err := repo.ResolveL4EgressPolicy(ctx.WithLogger(logBuffer))
@@ -1005,8 +1005,8 @@ func TestWildcardL4RulesEgressDeny(t *testing.T) {
 		From: labels.ParseSelectLabelArray("id=foo"),
 	}
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 
 	logBuffer := new(bytes.Buffer)
 	policyDeny, err := repo.ResolveL4EgressPolicy(ctx.WithLogger(logBuffer))
@@ -1104,8 +1104,8 @@ func TestWildcardCIDRRulesEgressDeny(t *testing.T) {
 		From: labels.ParseSelectLabelArray("id=foo"),
 	}
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 
 	logBuffer := new(bytes.Buffer)
 	policyDeny, err := repo.ResolveL4EgressPolicy(ctx.WithLogger(logBuffer))
@@ -1170,8 +1170,8 @@ func TestWildcardL3RulesIngressDenyFromEntities(t *testing.T) {
 		To: labels.ParseSelectLabelArray("id=foo"),
 	}
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 
 	policyDeny, err := repo.ResolveL4IngressPolicy(ctx)
 	require.NoError(t, err)
@@ -1237,8 +1237,8 @@ func TestWildcardL3RulesEgressDenyToEntities(t *testing.T) {
 		From: labels.ParseSelectLabelArray("id=foo"),
 	}
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 
 	policyDeny, err := repo.ResolveL4EgressPolicy(ctx)
 	require.NoError(t, err)
@@ -1296,11 +1296,11 @@ func TestMinikubeGettingStartedDeny(t *testing.T) {
 		To:   labels.ParseSelectLabelArray("id=app1"),
 	}
 
-	repo.Mutex.RLock()
+	repo.mutex.RLock()
 	// no rules loaded: Allows() => denied
 	require.Equal(t, api.Denied, repo.AllowsIngressRLocked(fromApp2))
 	require.Equal(t, api.Denied, repo.AllowsIngressRLocked(fromApp3))
-	repo.Mutex.RUnlock()
+	repo.mutex.RUnlock()
 
 	selFromApp2 := api.NewESFromLabels(
 		labels.ParseSelectLabel("id=app2"),
@@ -1344,8 +1344,8 @@ func TestMinikubeGettingStartedDeny(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 
 	// L4 from app2 is restricted
 	logBuffer := new(bytes.Buffer)
@@ -1559,8 +1559,8 @@ Ingress verdict: denied
 
 	// Should still be allowed with the new FromRequires constraint
 	ctx = buildSearchCtx("baz", "bar", 80)
-	repo.Mutex.RLock()
+	repo.mutex.RLock()
 	verdict := repo.AllowsIngressRLocked(ctx)
-	repo.Mutex.RUnlock()
+	repo.mutex.RUnlock()
 	require.Equal(t, api.Denied, verdict)
 }

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -323,7 +323,7 @@ func (p *EndpointPolicy) ConsumeMapChanges() (closer func(), changes ChangeState
 }
 
 // NewEndpointPolicy returns an empty EndpointPolicy stub.
-func NewEndpointPolicy(repo *Repository) *EndpointPolicy {
+func NewEndpointPolicy(repo PolicyRepository) *EndpointPolicy {
 	return &EndpointPolicy{
 		selectorPolicy: newSelectorPolicy(repo.GetSelectorCache()),
 		policyMapState: NewMapState(),

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -238,8 +238,8 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 	_, _, err := repo.mustAdd(rule1)
 	require.NoError(t, err)
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
@@ -330,8 +330,9 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 	_, _, err := repo.mustAdd(rule1)
 	require.NoError(t, err)
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
+
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
@@ -425,8 +426,8 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	_, _, err := repo.mustAdd(rule1)
 	require.NoError(t, err)
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 
@@ -552,8 +553,8 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	_, _, err := repo.mustAdd(rule1)
 	require.NoError(t, err)
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -290,8 +290,8 @@ func TestL7WithIngressWildcard(t *testing.T) {
 	_, _, err := repo.mustAdd(rule1)
 	require.NoError(t, err)
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 	require.Equal(t, redirectTypeEnvoy, selPolicy.L4Policy.redirectTypes)
@@ -397,8 +397,9 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 	_, _, err := repo.mustAdd(rule1)
 	require.NoError(t, err)
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
+
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 
@@ -502,8 +503,8 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 	_, _, err := repo.mustAdd(rule1)
 	require.NoError(t, err)
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 
@@ -630,8 +631,8 @@ func TestMapStateWithIngress(t *testing.T) {
 	_, _, err := repo.mustAdd(rule1)
 	require.NoError(t, err)
 
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1639,8 +1639,8 @@ func expectResult(t *testing.T, expected, obtained api.Decision, buffer *bytes.B
 }
 
 func checkIngress(t *testing.T, repo *Repository, ctx *SearchContext, verdict api.Decision) {
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 
 	buffer := new(bytes.Buffer)
 	ctx.Logging = stdlog.New(buffer, "", 0)
@@ -1648,8 +1648,8 @@ func checkIngress(t *testing.T, repo *Repository, ctx *SearchContext, verdict ap
 }
 
 func checkEgress(t *testing.T, repo *Repository, ctx *SearchContext, verdict api.Decision) {
-	repo.Mutex.RLock()
-	defer repo.Mutex.RUnlock()
+	repo.mutex.RLock()
+	defer repo.mutex.RUnlock()
 
 	buffer := new(bytes.Buffer)
 	ctx.Logging = stdlog.New(buffer, "", 0)

--- a/pkg/policy/trigger.go
+++ b/pkg/policy/trigger.go
@@ -28,7 +28,7 @@ func (u *Updater) TriggerPolicyUpdates(force bool, reason string) {
 
 // NewUpdater returns a new Updater instance to handle triggering policy
 // updates ready for use.
-func NewUpdater(r *Repository, regen regenerator) *Updater {
+func NewUpdater(r PolicyRepository, regen regenerator) *Updater {
 	t, err := trigger.NewTrigger(trigger.Parameters{
 		Name:            "policy_update",
 		MetricsObserver: &TriggerMetrics{},
@@ -62,7 +62,7 @@ func NewUpdater(r *Repository, regen regenerator) *Updater {
 type Updater struct {
 	*trigger.Trigger
 
-	repo *Repository
+	repo PolicyRepository
 }
 
 type regenerator interface {


### PR DESCRIPTION
In this commit, a new interface (PolicyRepository) in pkg/policy is added, used and referenced outside pkg/policy.

The policy.Repository struct is refactored to exclude directly exporting struct fields, but to instead use accessor methods.

Related to modularizing network policies:
- https://github.com/cilium/cilium/issues/23767
- https://github.com/cilium/cilium/issues/33360

Note: No user facing changes. No changes to the code behavior.

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>