### PR TITLE
datapath, netkit: Allow ARP passthrough on host when using netkit

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -372,6 +372,20 @@ jobs:
             secondary-network: 'true'
             ingress-controller: 'true'
 
+          - name: '23'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: 'bpf-20240711.013133'
+            misc: 'bpf.datapathMode=netkit,bpf.masquerade=true'
+            kube-proxy: 'none'
+            kpr: 'true'
+            ipv6: 'true'
+            tunnel: 'disabled'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
+            ingress-controller: 'true'
+            host-fw: 'true'
+            skip-upgrade: 'true'
+
           # Example of a feature that is being introduced, and we want to test
           # it without performing an upgrade, we use skip-upgrade: 'true'
           # - name: '23'

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -1096,7 +1096,7 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, devices []strin
 
 	fmt.Fprintf(fw, "#define HOST_EP_ID %d\n", uint32(hostEndpointID))
 
-	if option.Config.DatapathMode != datapathOption.DatapathModeNetkit {
+	if e.IsHost() || option.Config.DatapathMode != datapathOption.DatapathModeNetkit {
 		if e.RequireARPPassthrough() {
 			fmt.Fprint(fw, "#define ENABLE_ARP_PASSTHROUGH 1\n")
 		} else {


### PR DESCRIPTION
When using the `netkit` datapath mode neither `ENABLE_ARP_PASSTHROUGH` nor `ENABLE_ARP_RESPONDER` is set for any endpoint. When host firewall is enabled all ARP messages are blocked to and from the netdev. Make an exception for host endpoints to ensure connectivity is maintained between the host and the outside world. Additionally, add test coverage for netkit combined with host firewall.

Fixes: #34230
Fixes: 68953415f03a ("cilium, connector: Add netkit connector")

```release-note
netkit: Allow ARP packets through when using host firewall.
```
