### PR TITLE
lbipam: nodeipam: introduce a common config to set the default ipam

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -38,6 +38,7 @@ cilium-operator-alibabacloud [flags]
       --config-dir string                                    Configuration directory that contains a file for each option
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
   -D, --debug                                                Enable debugging mode
+      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
@@ -93,7 +94,6 @@ cilium-operator-alibabacloud [flags]
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
       --kvstore string                                       Key-value store type
       --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
-      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -24,6 +24,7 @@ cilium-operator-alibabacloud hive [flags]
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
@@ -69,7 +70,6 @@ cilium-operator-alibabacloud hive [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -30,6 +30,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
@@ -74,7 +75,6 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -41,6 +41,7 @@ cilium-operator-aws [flags]
       --config-dir string                                    Configuration directory that contains a file for each option
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
   -D, --debug                                                Enable debugging mode
+      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --ec2-api-endpoint string                              AWS API endpoint for the EC2 service
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
@@ -101,7 +102,6 @@ cilium-operator-aws [flags]
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
       --kvstore string                                       Key-value store type
       --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
-      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -24,6 +24,7 @@ cilium-operator-aws hive [flags]
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
@@ -69,7 +70,6 @@ cilium-operator-aws hive [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -30,6 +30,7 @@ cilium-operator-aws hive dot-graph [flags]
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
@@ -74,7 +75,6 @@ cilium-operator-aws hive dot-graph [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -41,6 +41,7 @@ cilium-operator-azure [flags]
       --config-dir string                                    Configuration directory that contains a file for each option
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
   -D, --debug                                                Enable debugging mode
+      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
@@ -96,7 +97,6 @@ cilium-operator-azure [flags]
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
       --kvstore string                                       Key-value store type
       --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
-      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -24,6 +24,7 @@ cilium-operator-azure hive [flags]
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
@@ -69,7 +70,6 @@ cilium-operator-azure hive [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -30,6 +30,7 @@ cilium-operator-azure hive dot-graph [flags]
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
@@ -74,7 +75,6 @@ cilium-operator-azure hive dot-graph [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -37,6 +37,7 @@ cilium-operator-generic [flags]
       --config-dir string                                    Configuration directory that contains a file for each option
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
   -D, --debug                                                Enable debugging mode
+      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
@@ -92,7 +93,6 @@ cilium-operator-generic [flags]
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
       --kvstore string                                       Key-value store type
       --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
-      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -24,6 +24,7 @@ cilium-operator-generic hive [flags]
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
@@ -69,7 +70,6 @@ cilium-operator-generic hive [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -30,6 +30,7 @@ cilium-operator-generic hive dot-graph [flags]
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
@@ -74,7 +75,6 @@ cilium-operator-generic hive dot-graph [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -46,6 +46,7 @@ cilium-operator [flags]
       --config-dir string                                    Configuration directory that contains a file for each option
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
   -D, --debug                                                Enable debugging mode
+      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --ec2-api-endpoint string                              AWS API endpoint for the EC2 service
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
@@ -106,7 +107,6 @@ cilium-operator [flags]
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
       --kvstore string                                       Key-value store type
       --kvstore-opt map                                      Key-value store options e.g. etcd.address=127.0.0.1:4001
-      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
       --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -24,6 +24,7 @@ cilium-operator hive [flags]
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
@@ -69,7 +70,6 @@ cilium-operator hive [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -30,6 +30,7 @@ cilium-operator hive dot-graph [flags]
       --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
       --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
@@ -74,7 +75,6 @@ cilium-operator hive dot-graph [flags]
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
       --kube-proxy-replacement string                        Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
-      --lbipam-require-lb-class                              Require the LoadBalancerClass field to be set on services for LB-IPAM to start assigning IPs
       --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -12,10 +12,6 @@
      - Description
      - Type
      - Default
-   * - :spelling:ignore:`LBIPAM.requireLBClass`
-     - requireLBClass tells LB-IPAM to only allocate IPs to services with a specific LoadBalancer class. ref: https://docs.cilium.io/en/stable/network/lb-ipam/#loadbalancerclass
-     - bool
-     - ``false``
    * - :spelling:ignore:`MTU`
      - Configure the underlying network MTU to overwrite auto-detected MTU. This value doesn't change the host network interface MTU i.e. eth0 or ens0. It changes the MTU for cilium_net@cilium_host, cilium_host@cilium_net, cilium_vxlan and lxc_health interfaces.
      - int
@@ -964,6 +960,10 @@
      - Configure verbosity levels for debug logging This option is used to enable debug messages for operations related to such sub-system such as (e.g. kvstore, envoy, datapath or policy), and flow is for enabling debug messages emitted per request, message and connection. Multiple values can be set via a space-separated string (e.g. "datapath envoy").  Applicable values: - flow - kvstore - envoy - datapath - policy
      - string
      - ``nil``
+   * - :spelling:ignore:`defaultLBServiceIPAM`
+     - defaultLBServiceIPAM indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set. Applicable values: lbipam, nodeipam, none @schema type: [string] @schema
+     - string
+     - ``"lbipam"``
    * - :spelling:ignore:`directRoutingSkipUnreachable`
      - Enable skipping of PodCIDR routes between worker nodes if the worker nodes are in a different L2 network segment.
      - bool

--- a/Documentation/network/lb-ipam.rst
+++ b/Documentation/network/lb-ipam.rst
@@ -409,13 +409,13 @@ load balancer class by setting the following configuration in the Helm chart or 
             $ helm upgrade cilium |CHART_RELEASE| \\
                --namespace kube-system \\
                --reuse-values \\
-               --set LBIPAM.requireLBClass=true
+               --set defaultLBServiceIPAM=none
 
     .. group-tab:: ConfigMap
 
         .. code-block:: yaml
 
-            lbipam-require-lb-class: true
+            default-lb-service-ipam: none
 
 Requesting IPs
 --------------

--- a/Documentation/network/node-ipam.rst
+++ b/Documentation/network/node-ipam.rst
@@ -47,9 +47,10 @@ annotation is a
 Enable and use Node IPAM
 ------------------------
 
-To use this feature your service must be of type ``LoadBalancer`` and have the
+To use this feature your Service must be of type ``LoadBalancer`` and have the
 `loadBalancerClass <https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class>`__
-set to ``io.cilium/node``.
+set to ``io.cilium/node``. You can also allow set ``defaultLBServiceIPAM``
+to ``nodeipam`` to use this feature on a Service that doesn't specify a loadBalancerClass.
 
 Cilium's node IPAM is disabled by default.
 To install Cilium with the node IPAM, run:

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -280,6 +280,7 @@ decrypted
 deepcopy
 deletetopic
 demux
+defaultLBServiceIPAM
 denylist
 dereference
 deserialization
@@ -465,6 +466,7 @@ kvstoremesh
 kvstores
 lan
 latencies
+lbipam
 leia
 len
 libbpf
@@ -571,6 +573,7 @@ nodeX
 nodegroup
 nodeid
 nodeinit
+nodeipam
 observability
 onData
 onwards
@@ -652,7 +655,6 @@ repo
 repos
 reproducibility
 requireIPv
-requireLBClass
 resync
 retpoline
 retransmission

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -53,7 +53,6 @@ contributors across the globe, there is almost always someone available to help.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| LBIPAM.requireLBClass | bool | `false` | requireLBClass tells LB-IPAM to only allocate IPs to services with a specific LoadBalancer class. ref: https://docs.cilium.io/en/stable/network/lb-ipam/#loadbalancerclass |
 | MTU | int | `0` | Configure the underlying network MTU to overwrite auto-detected MTU. This value doesn't change the host network interface MTU i.e. eth0 or ens0. It changes the MTU for cilium_net@cilium_host, cilium_host@cilium_net, cilium_vxlan and lxc_health interfaces. |
 | affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-agent. |
 | agent | bool | `true` | Install the cilium agent resources. |
@@ -291,6 +290,7 @@ contributors across the globe, there is almost always someone available to help.
 | dashboards | object | `{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null}` | Grafana dashboards for cilium-agent grafana can import dashboards based on the label and value ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards |
 | debug.enabled | bool | `false` | Enable debug logging |
 | debug.verbose | string | `nil` | Configure verbosity levels for debug logging This option is used to enable debug messages for operations related to such sub-system such as (e.g. kvstore, envoy, datapath or policy), and flow is for enabling debug messages emitted per request, message and connection. Multiple values can be set via a space-separated string (e.g. "datapath envoy").  Applicable values: - flow - kvstore - envoy - datapath - policy |
+| defaultLBServiceIPAM | string | `"lbipam"` | defaultLBServiceIPAM indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set. Applicable values: lbipam, nodeipam, none @schema type: [string] @schema |
 | directRoutingSkipUnreachable | bool | `false` | Enable skipping of PodCIDR routes between worker nodes if the worker nodes are in a different L2 network segment. |
 | disableEndpointCRD | bool | `false` | Disable the usage of CiliumEndpoint CRD. |
 | dnsPolicy | string | `""` | DNS policy for Cilium agent pods. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1068,9 +1068,7 @@ data:
   enable-node-ipam: "true"
 {{- end }}
 
-{{- if .Values.LBIPAM.requireLBClass }}
-  lbipam-require-lb-class: "true"
-{{- end }}
+  default-lb-service-ipam: "{{ .Values.defaultLBServiceIPAM }}"
 
 {{- if .Values.apiRateLimit }}
   api-rate-limit: {{ .Values.apiRateLimit | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1,13 +1,5 @@
 {
   "properties": {
-    "LBIPAM": {
-      "properties": {
-        "requireLBClass": {
-          "type": "boolean"
-        }
-      },
-      "type": "object"
-    },
     "MTU": {
       "type": "integer"
     },
@@ -1552,6 +1544,9 @@
         }
       },
       "type": "object"
+    },
+    "defaultLBServiceIPAM": {
+      "type": "string"
     },
     "directRoutingSkipUnreachable": {
       "type": "boolean"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1874,14 +1874,16 @@ ipam:
     # refill the bucket up to the burst size capacity.
     # @default -- `4.0`
     externalAPILimitQPS: ~
+# -- defaultLBServiceIPAM indicates the default LoadBalancer Service IPAM when
+# no LoadBalancer class is set. Applicable values: lbipam, nodeipam, none
+# @schema
+# type: [string]
+# @schema
+defaultLBServiceIPAM: lbipam
 nodeIPAM:
   # -- Configure Node IPAM
   # ref: https://docs.cilium.io/en/stable/network/node-ipam/
   enabled: false
-LBIPAM:
-  # -- requireLBClass tells LB-IPAM to only allocate IPs to services with a specific LoadBalancer class.
-  # ref: https://docs.cilium.io/en/stable/network/lb-ipam/#loadbalancerclass
-  requireLBClass: false
 # @schema
 # type: [null, string]
 # @schema

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1884,14 +1884,16 @@ ipam:
     # refill the bucket up to the burst size capacity.
     # @default -- `4.0`
     externalAPILimitQPS: ~
+# -- defaultLBServiceIPAM indicates the default LoadBalancer Service IPAM when
+# no LoadBalancer class is set. Applicable values: lbipam, nodeipam, none
+# @schema
+# type: [string]
+# @schema
+defaultLBServiceIPAM: lbipam
 nodeIPAM:
   # -- Configure Node IPAM
   # ref: https://docs.cilium.io/en/stable/network/node-ipam/
   enabled: false
-LBIPAM:
-  # -- requireLBClass tells LB-IPAM to only allocate IPs to services with a specific LoadBalancer class.
-  # ref: https://docs.cilium.io/en/stable/network/lb-ipam/#loadbalancerclass
-  requireLBClass: false
 # @schema
 # type: [null, string]
 # @schema

--- a/operator/pkg/lbipam/cell.go
+++ b/operator/pkg/lbipam/cell.go
@@ -30,19 +30,18 @@ var Cell = cell.Module(
 	metrics.Metric(newMetrics),
 	// Register configuration flags
 	cell.Config(lbipamConfig{
-		LBIPAMRequireLBClass: false,
-		EnableLBIPAM:         true,
+		EnableLBIPAM: true,
+	}),
+	cell.Config(SharedConfig{
+		DefaultLBServiceIPAM: DefaultLBClassLBIPAM,
 	}),
 )
 
 type lbipamConfig struct {
-	LBIPAMRequireLBClass bool
-	EnableLBIPAM         bool
+	EnableLBIPAM bool
 }
 
 func (lc lbipamConfig) Flags(flags *pflag.FlagSet) {
-	flags.BoolVar(&lc.LBIPAMRequireLBClass, "lbipam-require-lb-class", lc.LBIPAMRequireLBClass, "Require the LoadBalancerClass field to "+
-		"be set on services for LB-IPAM to start assigning IPs")
 	flags.BoolVar(&lc.EnableLBIPAM, "enable-lb-ipam", lc.EnableLBIPAM, "Enable LB IPAM")
 }
 
@@ -63,7 +62,8 @@ type lbipamCellParams struct {
 
 	Metrics *ipamMetrics
 
-	Config lbipamConfig
+	Config       lbipamConfig
+	SharedConfig SharedConfig
 }
 
 func newLBIPAMCell(params lbipamCellParams) *LBIPAM {
@@ -92,6 +92,7 @@ func newLBIPAMCell(params lbipamCellParams) *LBIPAM {
 		svcClient:    params.Clientset.Slim().CoreV1(),
 		jobGroup:     params.JobGroup,
 		config:       params.Config,
+		defaultIPAM:  params.SharedConfig.DefaultLBServiceIPAM == DefaultLBClassLBIPAM,
 	})
 
 	lbIPAM.jobGroup.Add(
@@ -102,4 +103,24 @@ func newLBIPAMCell(params lbipamCellParams) *LBIPAM {
 	)
 
 	return lbIPAM
+}
+
+const (
+	DefaultLBClassLBIPAM   = "lbipam"
+	DefaulLBClasstNodeIPAM = "nodeipam"
+)
+
+// SharedConfig contains the configuration that is shared between
+// this module and others.
+// It is a temporary solution meant to avoid polluting this module with a direct
+// dependency on global operator configurations.
+type SharedConfig struct {
+	// DefaultLBServiceIPAM indicate the default LoadBalancer Service IPAM
+	DefaultLBServiceIPAM string
+}
+
+func (sc SharedConfig) Flags(flags *pflag.FlagSet) {
+	flags.StringVar(&sc.DefaultLBServiceIPAM, "default-lb-service-ipam", sc.DefaultLBServiceIPAM,
+		"Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set."+
+			"Applicable values: lbipam, nodeipam, none")
 }

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -83,7 +83,8 @@ type lbIPAMParams struct {
 
 	metrics *ipamMetrics
 
-	config lbipamConfig
+	config      lbipamConfig
+	defaultIPAM bool
 }
 
 func newLBIPAM(params lbIPAMParams) *LBIPAM {
@@ -1130,10 +1131,8 @@ func (ipam *LBIPAM) isResponsibleForSVC(svc *slim_core_v1.Service) bool {
 		return false
 	}
 
-	// If no load balancer class is specified, we will assume that we are responsible for the service
-	// unless we have been configured to require a load balancer class.
 	if svc.Spec.LoadBalancerClass == nil {
-		return !ipam.lbIPAMParams.config.LBIPAMRequireLBClass
+		return ipam.lbIPAMParams.defaultIPAM
 	}
 
 	if !slices.Contains(ipam.lbClasses, *svc.Spec.LoadBalancerClass) {

--- a/operator/pkg/lbipam/lbipam_fixture_test.go
+++ b/operator/pkg/lbipam/lbipam_fixture_test.go
@@ -264,8 +264,9 @@ func mkTestFixture(ipv4Enabled, ipv6Enabled bool) newFixture {
 
 			metrics: newMetrics(),
 
-			poolClient: poolClient,
-			svcClient:  svcClient,
+			poolClient:  poolClient,
+			svcClient:   svcClient,
+			defaultIPAM: true,
 		}),
 	}
 }

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -2164,7 +2164,7 @@ func TestRequiredLBClass(t *testing.T) {
 	fixture := mkTestFixture(true, true)
 
 	// Enable the requirement for a specific LBClass and set a class to look for
-	fixture.lbipam.config.LBIPAMRequireLBClass = true
+	fixture.lbipam.defaultIPAM = false
 	fixture.lbipam.lbClasses = []string{cilium_api_v2alpha1.BGPLoadBalancerClass}
 
 	fixture.UpsertPool(t, poolA)

--- a/operator/pkg/nodeipam/cell.go
+++ b/operator/pkg/nodeipam/cell.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/pflag"
 	ctrlRuntime "sigs.k8s.io/controller-runtime"
 
+	"github.com/cilium/cilium/operator/pkg/lbipam"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 )
 
@@ -29,6 +30,7 @@ type nodeipamCellParams struct {
 	Clientset          k8sClient.Clientset
 	CtrlRuntimeManager ctrlRuntime.Manager
 	Config             nodeIpamConfig
+	SharedConfig       lbipam.SharedConfig
 }
 
 type nodeIpamConfig struct {
@@ -44,7 +46,11 @@ func registerNodeSvcLBReconciler(params nodeipamCellParams) error {
 		return nil
 	}
 
-	if err := newNodeSvcLBReconciler(params.CtrlRuntimeManager, params.Logger).SetupWithManager(params.CtrlRuntimeManager); err != nil {
+	if err := newNodeSvcLBReconciler(
+		params.CtrlRuntimeManager,
+		params.Logger,
+		params.SharedConfig.DefaultLBServiceIPAM == lbipam.DefaulLBClasstNodeIPAM,
+	).SetupWithManager(params.CtrlRuntimeManager); err != nil {
 		return fmt.Errorf("Failed to register NodeSvcLBReconciler: %w", err)
 	}
 

--- a/operator/pkg/nodeipam/nodesvclb.go
+++ b/operator/pkg/nodeipam/nodesvclb.go
@@ -35,15 +35,17 @@ var (
 
 type nodeSvcLBReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
-	Logger logrus.FieldLogger
+	Scheme      *runtime.Scheme
+	DefaultIPAM bool
+	Logger      logrus.FieldLogger
 }
 
-func newNodeSvcLBReconciler(mgr ctrl.Manager, logger logrus.FieldLogger) *nodeSvcLBReconciler {
+func newNodeSvcLBReconciler(mgr ctrl.Manager, logger logrus.FieldLogger, defaultIpam bool) *nodeSvcLBReconciler {
 	return &nodeSvcLBReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Logger: logger,
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		DefaultIPAM: defaultIpam,
+		Logger:      logger,
 	}
 }
 
@@ -162,8 +164,10 @@ func (r nodeSvcLBReconciler) isServiceSupported(svc *corev1.Service) bool {
 	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
 		return false
 	}
-	return svc.Spec.LoadBalancerClass != nil &&
-		*svc.Spec.LoadBalancerClass == nodeSvcLBClass
+	if svc.Spec.LoadBalancerClass == nil {
+		return r.DefaultIPAM
+	}
+	return *svc.Spec.LoadBalancerClass == nodeSvcLBClass
 }
 
 // getEndpointSliceNodes returns the set of node names if eTP=Local. If eTP=Cluster

--- a/operator/pkg/nodeipam/nodesvclb_test.go
+++ b/operator/pkg/nodeipam/nodesvclb_test.go
@@ -14,6 +14,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -108,8 +109,8 @@ var (
 				Labels:    map[string]string{discoveryv1.LabelServiceName: "ipv4-internal"},
 			},
 			Endpoints: []discoveryv1.Endpoint{
-				{NodeName: stringPtr("node-1")},
-				{NodeName: stringPtr("node-2"), Conditions: discoveryv1.EndpointConditions{Ready: boolPtr(false)}},
+				{NodeName: ptr.To("node-1")},
+				{NodeName: ptr.To("node-2"), Conditions: discoveryv1.EndpointConditions{Ready: ptr.To(false)}},
 			},
 		},
 		&corev1.Service{
@@ -132,8 +133,8 @@ var (
 				Labels:    map[string]string{discoveryv1.LabelServiceName: "ipv4-external"},
 			},
 			Endpoints: []discoveryv1.Endpoint{
-				{NodeName: stringPtr("node-1")},
-				{NodeName: stringPtr("node-2")},
+				{NodeName: ptr.To("node-1")},
+				{NodeName: ptr.To("node-2")},
 			},
 		},
 		&corev1.Service{
@@ -156,7 +157,7 @@ var (
 				Labels:    map[string]string{discoveryv1.LabelServiceName: "ipv6-internal"},
 			},
 			Endpoints: []discoveryv1.Endpoint{
-				{NodeName: stringPtr("node-2")},
+				{NodeName: ptr.To("node-2")},
 			},
 		},
 		&corev1.Service{
@@ -179,8 +180,8 @@ var (
 				Labels:    map[string]string{discoveryv1.LabelServiceName: "ipv6-external"},
 			},
 			Endpoints: []discoveryv1.Endpoint{
-				{NodeName: stringPtr("node-1")},
-				{NodeName: stringPtr("node-2")},
+				{NodeName: ptr.To("node-1")},
+				{NodeName: ptr.To("node-2")},
 			},
 		},
 		&corev1.Service{
@@ -203,9 +204,9 @@ var (
 				Labels:    map[string]string{discoveryv1.LabelServiceName: "dualstack-external"},
 			},
 			Endpoints: []discoveryv1.Endpoint{
-				{NodeName: stringPtr("node-1")},
-				{NodeName: stringPtr("node-2")},
-				{NodeName: stringPtr("does-not-exist")},
+				{NodeName: ptr.To("node-1")},
+				{NodeName: ptr.To("node-2")},
+				{NodeName: ptr.To("does-not-exist")},
 			},
 		},
 		&corev1.Service{
@@ -241,8 +242,8 @@ var (
 				Labels:    map[string]string{discoveryv1.LabelServiceName: "not-supported-1"},
 			},
 			Endpoints: []discoveryv1.Endpoint{
-				{NodeName: stringPtr("node-1")},
-				{NodeName: stringPtr("node-2")},
+				{NodeName: ptr.To("node-1")},
+				{NodeName: ptr.To("node-2")},
 			},
 		},
 		&corev1.Service{
@@ -266,8 +267,8 @@ var (
 				Labels:    map[string]string{discoveryv1.LabelServiceName: "not-supported-2"},
 			},
 			Endpoints: []discoveryv1.Endpoint{
-				{NodeName: stringPtr("node-1")},
-				{NodeName: stringPtr("node-2")},
+				{NodeName: ptr.To("node-1")},
+				{NodeName: ptr.To("node-2")},
 			},
 		},
 		&corev1.Service{
@@ -334,14 +335,7 @@ var (
 	}
 )
 
-func stringPtr(str string) *string {
-	return &str
-}
-func boolPtr(boolean bool) *bool {
-	return &boolean
-}
-
-func Test_httpRouteReconciler_Reconcile(t *testing.T) {
+func Test_nodeIPAM_Reconcile(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithObjects(nodeSvcLbFixtures...).
 		WithStatusSubresource(&corev1.Service{}).
@@ -422,7 +416,6 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, svc.Status.LoadBalancer.Ingress[1].IP, "42.0.0.2")
 	})
 
-	//
 	t.Run("external traffic policy cluster", func(t *testing.T) {
 		key := types.NamespacedName{
 			Name:      "etp-cluster",
@@ -445,7 +438,7 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 	})
 }
 
-func Test_CiliumResources_Reconcile(t *testing.T) {
+func Test_nodeIPAM_CiliumResources_Reconcile(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithObjects(nodeSvcLabelFixtures...).
 		WithStatusSubresource(&corev1.Service{}).
@@ -528,7 +521,6 @@ func Test_CiliumResources_Reconcile(t *testing.T) {
 
 		require.Error(t, err)
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
-
 	})
 
 	t.Run("Ensure Warning raised if no Nodes found using configured label selector", func(t *testing.T) {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

Introduce a new `defaultLBServiceIPAM` values to be able to set the default LB Service IPAM to LBIPAM (default), NodeIPAM or disabled. This new option also replaces the existing `LBIPAM.requireLBClass` which is only LBIPAM specific and fortunately not yet included in any stable release so far.

It also includes an additional cleanup commit that fixes a few minor issues in the NodeIPAM tests.

Fixes: #33282

```release-note
Introduce an option to control if NodeIPAM or LBIPAM should be the the default Service LoadBalancer
```
