### PR TITLE
Add new batched iterator type in pkg/bpf

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -10,10 +10,14 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"iter"
+	"math"
 	"os"
 	"path"
 	"reflect"
 	"strings"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/ebpf"
 	"github.com/sirupsen/logrus"
@@ -749,6 +753,239 @@ func (m *Map) DumpReliablyWithCallback(cb DumpCallback, stats *DumpStats) error 
 	}
 
 	return ErrMaxLookup
+}
+
+// BatchIterator provides a typed wrapper *Map that allows for batched iteration
+// of bpf maps.
+type BatchIterator[KT, VT any] struct {
+	m    *Map
+	err  error
+	keys []KT
+	vals []VT
+
+	chunkSize      int
+	maxDumpRetries uint32
+
+	// Iteration stats
+	batchSize int
+
+	opts *ebpf.BatchOptions
+}
+
+// NewBatchIterator returns a typed wrapper for *Map that allows for
+// iterating (i.e. "dumping") the map using the bpf batch api.
+//
+// Unlike the general *Map dump functions, this must read into slices of
+// a concrete type (such as struct, or other scalar type), rather than into
+// pointers. This is because there is currently no safe way to allocate a
+// contiguous slice of key/value elements from either the underlying generic
+// pointer types or from MapKey/MapValue interface types.
+//
+// This means that attempting to use the pointer types that implement
+// MapKey/MapValue will fail upon iteration (via the Err() function).
+//
+// Example usage:
+//
+//	m := NewMap("cilium_test",
+//		ebpf.Hash,
+//		&TestKey{}, 	// *TestKey implements MapKey.
+//		&TestValue{}, 	// *TestValue implements MapValue.
+//		mapSize,
+//		BPF_F_NO_PREALLOC,
+//	)
+//
+//	// Note: TestKey & TestValue are not pointer types!
+//	iter := NewBatchIterator[TestKey, TestValue](m)
+//	for k, v := range iter {
+//		// ...
+//	}
+//
+// Following iteration, any unresolved errors encountered when iterating
+// the bpf map can be accessed via the Err() function.
+func NewBatchIterator[KT, VT any](m *Map) *BatchIterator[KT, VT] {
+	return &BatchIterator[KT, VT]{
+		m: m,
+	}
+}
+
+// Err returns errors encountered during the previous iteration when
+// IterateAll(...) is called.
+//
+// If the iterator is reused, the error will be reset,
+func (kvs BatchIterator[KT, VT]) Err() error {
+	return kvs.err
+}
+
+func (bi BatchIterator[KT, VT]) maxBatchedRetries() int {
+	if bi.maxDumpRetries > 0 {
+		return int(bi.maxDumpRetries)
+	}
+	return defaultBatchedRetries
+}
+
+const defaultBatchedRetries = 3
+
+type BatchIteratorOpt[KT any, VT any] func(*BatchIterator[KT, VT]) *BatchIterator[KT, VT]
+
+// WithEBPFBatchOpts returns a batch iterator option that allows for overriding
+// BPF_MAP_LOOKUP_BATCH options.
+func WithEBPFBatchOpts[KT, VT any](opts *ebpf.BatchOptions) BatchIteratorOpt[KT, VT] {
+	return func(in *BatchIterator[KT, VT]) *BatchIterator[KT, VT] {
+		in.opts = opts
+		return in
+	}
+}
+
+// WithMaxRetries returns a batch iterator option that allows overriding the default
+// max batch retries.
+//
+// Unless the starting chunk size is set to be the map size, it is possible for iteration
+// to fail with ENOSPC if the passed allocated chunk array size is not big enough to accommodate
+// a the bpf maps underlying hashmaps bucket size.
+//
+// If this happens, BatchIterator will automatically attempt to double the batch size and
+// retry the iteration from the same place - up to a number of retries.
+func WithMaxRetries[KT, VT any](retries uint32) BatchIteratorOpt[KT, VT] {
+	return func(in *BatchIterator[KT, VT]) *BatchIterator[KT, VT] {
+		in.maxDumpRetries = retries
+		return in
+	}
+}
+
+// WithStartingChunkSize returns a batch iterator option that allows overriding the dynamically
+// chosen starting chunk size.
+func WithStartingChunkSize[KT, VT any](size int) BatchIteratorOpt[KT, VT] {
+	return func(in *BatchIterator[KT, VT]) *BatchIterator[KT, VT] {
+		in.chunkSize = size
+		if in.chunkSize <= 0 {
+			in.chunkSize = 8
+		}
+		return in
+	}
+}
+
+// CountAll is a helper function that returns the count of all elements in a batched
+// iterator.
+func CountAll[KT, VT any](ctx context.Context, iter *BatchIterator[KT, VT]) (int, error) {
+	c := 0
+	for range iter.IterateAll(ctx) {
+		c++
+	}
+	return c, iter.Err()
+}
+
+func startingChunkSize(maxEntries int) int {
+	bucketSize := math.Sqrt(float64(maxEntries * 2))
+	nearest2 := math.Log2(bucketSize)
+	return int(math.Pow(2, math.Ceil(nearest2)))
+}
+
+func checkBatchType[T any]() error {
+	var kv T
+	if kind := reflect.TypeOf(kv).Kind(); kind != reflect.Struct {
+		return fmt.Errorf("BatchIterator: generic type(s) must be of kind struct, got: %s", kind)
+	}
+	return nil
+}
+
+// IterateAll returns an iterate Seq2 type which can be used to iterate a map
+// using the batched API.
+// In the case of a the iteration failing due to insufficient batch buffer size,
+// this will attempt to grow the buffer by a factor of 2 (up to a default: 3 amount
+// of retries) and re-attempt the iteration.
+// If the number of failures exceeds max retries, then iteration will stop and an error
+// will be returned via Err().
+//
+// All other errors will result in immediate termination of iterator.
+//
+// If the iteration fails, then the Err() function will return the error that caused the failure.
+func (bi *BatchIterator[KT, VT]) IterateAll(ctx context.Context, opts ...BatchIteratorOpt[KT, VT]) iter.Seq2[KT, VT] {
+	if bi.err = checkBatchType[KT](); bi.err != nil {
+		return nil
+	}
+
+	if bi.err = checkBatchType[VT](); bi.err != nil {
+		return nil
+	}
+
+	bi.chunkSize = startingChunkSize(int(bi.m.MaxEntries()))
+
+	for _, opt := range opts {
+		if opt != nil {
+			bi = opt(bi)
+		}
+	}
+
+	// reset values
+	bi.err = nil
+	bi.batchSize = 0
+	bi.keys = make([]KT, bi.chunkSize)
+	bi.vals = make([]VT, bi.chunkSize)
+
+	processed := 0
+	var cursor ebpf.MapBatchCursor
+	return func(yield func(KT, VT) bool) {
+		if bi.Err() != nil {
+			return
+		}
+
+	iterate:
+		for {
+			if ctx.Err() != nil {
+				bi.err = ctx.Err()
+				return
+			}
+		retry:
+			for retry := range bi.maxBatchedRetries() {
+				// Attempt to read batch into buffer.
+				c, batchErr := bi.m.BatchLookup(&cursor, bi.keys, bi.vals, nil)
+				bi.batchSize = c
+
+				done := errors.Is(batchErr, ebpf.ErrKeyNotExist)
+				// Lookup batch on LRU hash map may fail if the buffer passed is not big enough to
+				// accommodate the largest bucket size in the LRU map [1]
+				// Because bucket size, in general, cannot be known, we approximate a good starting
+				// buffer size from the approximation of how many entries there should be in the map
+				// before expect to see a hash map collision: sqrt(max_entries * 2)
+				//
+				// If we receive ENOSPC failures, we will try to recover by growing the batch buffer
+				// size (up to some max number of retries - default: 3) and retrying the iteration.
+				//
+				// [1] https://elixir.bootlin.com/linux/latest/source/kernel/bpf/hashtab.c#L1776
+				//
+				// Note: If this failure happens during the bpf syscall, it is expected that the underlying
+				// cursor will not have been swapped - meaning that we can retry the iteration at the same cursor.
+				if errors.Is(batchErr, unix.ENOSPC) {
+					if retry == bi.maxBatchedRetries()-1 {
+						bi.err = batchErr
+					} else {
+						bi.chunkSize *= 2
+						bi.keys = make([]KT, bi.chunkSize)
+						bi.vals = make([]VT, bi.chunkSize)
+					}
+					continue retry
+				} else if !done && batchErr != nil {
+					// If we're not done, and we didn't hit a ENOSPC then stop iteration and record
+					// the error.
+					bi.err = fmt.Errorf("failed to iterate map: %w", batchErr)
+					return
+				}
+
+				// Yield all received pairs.
+				for i := range bi.batchSize {
+					processed++
+					if !yield(bi.keys[i], bi.vals[i]) {
+						break iterate
+					}
+				}
+
+				if done {
+					break iterate
+				}
+				break retry // finish retry loop for this batch.
+			}
+		}
+	}
 }
 
 // Dump returns the map (type map[string][]string) which contains all

--- a/pkg/maps/nat/cell.go
+++ b/pkg/maps/nat/cell.go
@@ -109,12 +109,12 @@ var Cell = cell.Module(
 // to hive.
 type NatMap4 interface {
 	NatMap
-	ApplyBatch4(func([]tuple.TupleKey4, []NatEntry4, int)) (count int, err error)
+	DumpBatch4(func(tuple.TupleKey4, NatEntry4)) (count int, err error)
 }
 
 // NatMap6 describes ipv6 nat map behaviors, used for providing map
 // to hive.
 type NatMap6 interface {
 	NatMap
-	ApplyBatch6(func([]tuple.TupleKey6, []NatEntry6, int)) (count int, err error)
+	DumpBatch6(func(tuple.TupleKey6, NatEntry6)) (count int, err error)
 }

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -5,14 +5,10 @@ package nat
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"math"
 	"strings"
 
 	"github.com/cilium/ebpf"
-
-	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/bpf"
@@ -103,12 +99,6 @@ func NewMap(name string, family IPFamily, entries int) *Map {
 	}
 }
 
-func startingChunkSize(maxEntries int) int {
-	bucketSize := math.Sqrt(float64(maxEntries * 2))
-	nearest2 := math.Log2(bucketSize)
-	return int(math.Pow(2, math.Ceil(nearest2)))
-}
-
 // DumpBatch4 uses batch iteration to walk the map and applies fn for each batch of entries.
 func (m *Map) DumpBatch4(fn func(tuple.TupleKey4, NatEntry4)) (count int, err error) {
 	if m.family != IPv4 {
@@ -134,51 +124,6 @@ func (m *Map) DumpBatch6(fn func(tuple.TupleKey6, NatEntry6)) (count int, err er
 		fn(key, entry)
 	}
 	return count, nil
-}
-
-func applyBatchReliably[KeyType, EntryType any](m *Map, fn func([]KeyType, []EntryType, int)) (count int, err error) {
-	var chunkSize = uint32(startingChunkSize(int(m.MaxEntries())))
-	const maxRetries = 3
-	for i := 0; i < maxRetries; i++ {
-		count, err = applyBatch(m, fn, chunkSize)
-		if err != nil {
-			// Lookup batch on LRU hash map may fail if the buffer passed is not big enough to
-			// accommodate the largest bucket size in the LRU map [1]
-			// Because bucket size, in general, cannot be known, we take the number of entries until
-			// we expect to see a hash map collision: sqrt(max_entries * 2)
-			// Default NAT map size is 262144 -> 2^ceil(log2(sqrt(262144 * 2))) = 1024, with key + entry size
-			// being ~ 432 bits, this means we'll need to allocate 55kb to accommodate this iteration.
-			// To avoid unbounded growth, each ENOSPC will result in a doubling of the chuck chunkSize
-			// which will persist into subsequent calls of Stats, up to a maximum of 3 (fold-increase).
-			//
-			// [1] https://elixir.bootlin.com/linux/latest/source/kernel/bpf/hashtab.c#L1776
-			if errors.Is(err, unix.ENOSPC) {
-				chunkSize *= 2
-				continue
-			}
-			return 0, fmt.Errorf("failed to count nat map: %w", err)
-		}
-		break
-	}
-	return count, err
-}
-
-func applyBatch[TupleType any, EntryType any](m *Map, fn func([]TupleType, []EntryType, int), chunkSize uint32) (count int, err error) {
-	kout := make([]TupleType, chunkSize)
-	vout := make([]EntryType, chunkSize)
-
-	var cursor ebpf.MapBatchCursor
-	for {
-		c, batchErr := m.BatchLookup(&cursor, kout, vout, nil)
-		count += c
-		fn(kout, vout, c)
-		if batchErr != nil {
-			if errors.Is(batchErr, ebpf.ErrKeyNotExist) {
-				return count, nil // end of map, we're done iterating
-			}
-			return count, batchErr
-		}
-	}
 }
 
 func (m *Map) Delete(k bpf.MapKey) (deleted bool, err error) {

--- a/pkg/maps/nat/nat_batch_test.go
+++ b/pkg/maps/nat/nat_batch_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestApplyPatch(t *testing.T) {
+func TestDumpBatch4(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	m := NewMap("test_snat_map", IPv4, 1<<18) // approximate default map size.
 	m.family = IPv4
@@ -35,9 +35,7 @@ func TestApplyPatch(t *testing.T) {
 		err := m.Update(mapKey, mapValue)
 		assert.NoError(t, err)
 	}
-	count := 0
-	m.ApplyBatch4(func(tk []tuple.TupleKey4, ne []NatEntry4, c int) {
-		count += int(c)
-	})
+	count, err := m.DumpBatch4(func(tk tuple.TupleKey4, ne NatEntry4) {})
+	assert.NoError(t, err)
 	assert.Equal(t, 1024+1, count)
 }

--- a/pkg/maps/nat/stats/stats.go
+++ b/pkg/maps/nat/stats/stats.go
@@ -210,19 +210,18 @@ func (m *Stats) countNat(ctx context.Context) error {
 	var errs error
 	if m.natMap4 != nil {
 		tupleToPortCount := make(map[tuple.TupleKey4]uint16, 128)
-		_, err := m.natMap4.ApplyBatch4(func(keys []tuple.TupleKey4, vals []nat.NatEntry4, size int) {
-			for i := 0; i < size; i++ {
-				key := *keys[i].ToHost().(*tuple.TupleKey4)
-				if flagsIsIn(key.Flags) &&
-					(key.NextHeader == u8proto.TCP || key.NextHeader == u8proto.ICMP ||
-						key.NextHeader == u8proto.UDP) {
-					key.DestPort = 0
-					ports := tupleToPortCount[key]
-					ports++
-					tupleToPortCount[key] = ports
-				}
+		_, err := m.natMap4.DumpBatch4(func(k tuple.TupleKey4, _ nat.NatEntry4) {
+			key := *k.ToHost().(*tuple.TupleKey4)
+			if flagsIsIn(key.Flags) &&
+				(key.NextHeader == u8proto.TCP || key.NextHeader == u8proto.ICMP ||
+					key.NextHeader == u8proto.UDP) {
+				key.DestPort = 0
+				ports := tupleToPortCount[key]
+				ports++
+				tupleToPortCount[key] = ports
 			}
 		})
+
 		if err != nil {
 			log.WithError(err).
 				Error("failed to count ipv4 nat map entries, " +
@@ -238,17 +237,15 @@ func (m *Stats) countNat(ctx context.Context) error {
 	}
 	if m.natMap6 != nil {
 		tupleToPortCount := make(map[tuple.TupleKey6]uint16, 128)
-		_, err := m.natMap6.ApplyBatch6(func(keys []tuple.TupleKey6, vals []nat.NatEntry6, size int) {
-			for i := 0; i < size; i++ {
-				key := *keys[i].ToHost().(*tuple.TupleKey6)
-				if flagsIsIn(key.Flags) &&
-					(key.NextHeader == u8proto.TCP || key.NextHeader == u8proto.ICMPv6 ||
-						key.NextHeader == u8proto.UDP) {
-					key.DestPort = 0
-					ports := tupleToPortCount[key]
-					ports++
-					tupleToPortCount[key] = ports
-				}
+		_, err := m.natMap6.DumpBatch6(func(k tuple.TupleKey6, _ nat.NatEntry6) {
+			key := *k.ToHost().(*tuple.TupleKey6)
+			if flagsIsIn(key.Flags) &&
+				(key.NextHeader == u8proto.TCP || key.NextHeader == u8proto.ICMPv6 ||
+					key.NextHeader == u8proto.UDP) {
+				key.DestPort = 0
+				ports := tupleToPortCount[key]
+				ports++
+				tupleToPortCount[key] = ports
 			}
 		})
 		if err != nil {


### PR DESCRIPTION
**See** commit comments for details.

### Add new batched iterator type in pkg/bpf:
This is intended to provide a general approach to iterating maps using the "batched" API, and replace existing bespoke implementations in ctmap/nat to use the one generic approach.

### Follow up work
This PR will not change `pkg/maps/ctmap` to use this as @ysksuzuki is currently working on refactoring the ctmap gc code, which would likely cause large conflicts - so that will be a follow up to that work being done.

```go
// NewBatchIterator returns a typed wrapper for *Map that allows for
// iterating (i.e. "dumping") the map using the bpf batch api.
//
// Unlike the general *Map dump functions, this must reads into slices of
// a concrete type (such as struct, or other scalar type), rather than into
// pointers. This is because there is currently no safe way to allocate a
// contiguous slice of key/value elements from either the underlying generic
// pointer types or from MapKey/MapValue interface types.
//
// This means that attempting to use the pointer types that implement
// MapKey/MapValue will fail upon iteration (via the Err() function).
//
// Example usage:
//
//	m := NewMap("cilium_test",
//		ebpf.Hash,
//		&TestKey{}, 	// *TestKey implements MapKey.
//		&TestValue{}, 	// *TestValue implements MapValue.
//		mapSize,
//		BPF_F_NO_PREALLOC,
//	)
//
//	// Note: TestKey & TestValue are not pointer types!
//	iter := NewBatchIterator[TestKey, TestValue](m)
//	for k, v := range iter {
//		// ...
//	}
//
// Following iteration, any unresolved errors encountered when iterating
// the bpf map can be accessed via the Err() function.
```

### Design considerations

1. Using Generics: Most Cilium functions that abstract bpf map operations rely on the `MapKey` and `MapValue` interfaces, in particular the respective `New() MapKey` & `New() MapValue` interface functions which allow allocation of a key/value pointer type in an opaque manner.  For batched operations this doesn't work as we need to be able to allocate contiguous, non-indirect, slices of objects which are passed to the batched bpf syscalls for processing.  Thus this is done with a generic wrapper type, which is able to do such an allocations (i.e. `make([]T, batchSize)`).    The tradeoff is that, going back to the first problem, the generic type must not be a pointer/interface type, so even if the implentation of Map{Key,Value} is using the pointer handle for a type (i.e. is implemented with `func (k *someKeyType) Map() bpf.MapKey {...}`), we still need to use the serial struct type in this situation (i.e. `NewBatchIterator[someKeyType, someValueType]`).  Failing to do so will result in a runtime error.

2. Error Handling: The benefits of returning a seq.Iter2 type is that this will compose nicely with loops and other functional list operations in the future.  The downside is that batched iteration can fail, thus we need some kind of error collection mechanism.  With this I've opted to collect Errors with the `Err()` function.   Practically, this means that we need to actually use a iterator handle instead of just doing it purely functionally.

### Use batched iteration for ctmap GC to improve performance


**note:** I'm using pkg/bpf/ as a staging ground for hammering out a good API for a batched iterator, a follow up will be to open a PR to add this functionality in cilium/ebpf and then use that. 