### PR TITLE
bpf: Ensure BPF host routing works with tunnel

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1261,7 +1261,7 @@ skip_vtep:
 					     ip4->daddr, encrypt_key, &key,
 					     SECLABEL_IPV4, *dst_sec_identity, &trace);
 		if (ret == DROP_NO_TUNNEL_ENDPOINT)
-			goto pass_to_stack;
+			goto maybe_pass_to_stack;
 		/* If not redirected noteably due to IPSEC then pass up to stack
 		 * for further processing.
 		 */
@@ -1281,6 +1281,8 @@ skip_vtep:
 			return ret;
 	}
 #endif /* TUNNEL_MODE || ENABLE_HIGH_SCALE_IPCACHE */
+
+maybe_pass_to_stack: __maybe_unused;
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif = 0;
 


### PR DESCRIPTION
Fixes: #35023 

```release-note
Fix an issue where pod-to-world traffic goes up stack when BPF host routing is enabled with tunnel.
```