### PR TITLE
.github: do not update github runners for bpf workflows

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -641,6 +641,22 @@
         "major",
         "minor"
       ],
+    },
+    {
+      "enabled": false,
+      "matchFileNames": [
+        ".github/workflows/lint-build-commits.yaml",
+        ".github/workflows/lint-bpf-checks.yaml"
+      ],
+      "matchDepTypes": [
+        "github-runner",
+      ],
+      "matchPackageNames": [
+        "ubuntu",
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
     }
   ],
   "kubernetes": {

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   build_commits:
     name: Check if build works for every commit
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 180
     steps:
       - name: Collect Workflow Telemetry


### PR DESCRIPTION
GH workflows that use clang require the libtinfo5 library which is currently unavailable in ubuntu 24.04. Thus, we should not automatically update these runners on these files to avoid breaking CI.