### PR TITLE
[v1.16] .github: do not update github runners for bpf workflows

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build_commits:
     name: Check if build works for every commit
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 180
     steps:
       - name: Collect Workflow Telemetry


### PR DESCRIPTION
GH workflows that use clang require the libtinfo5 library which is currently unavailable in ubuntu 24.04. Thus, we should not automatically update these runners on these files to avoid breaking CI.