### PR TITLE
policy: Use 'insertOldIfNotExists() in addDependentOnEntry()

### DIFF
--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -636,9 +636,7 @@ func (ms *mapState) AddDependent(owner Key, dependent Key, changes ChangeState) 
 // addDependentOnEntry adds 'dependent' to the set of dependent keys of 'e'.
 func (ms *mapState) addDependentOnEntry(owner Key, e MapStateEntry, dependent Key, changes ChangeState) {
 	if _, exists := e.dependents[dependent]; !exists {
-		if changes.Old != nil {
-			changes.Old[owner] = e
-		}
+		changes.insertOldIfNotExists(owner, e)
 		e.AddDependent(dependent)
 		ms.insert(owner, e)
 	}
@@ -828,9 +826,7 @@ func (ms *mapState) addKeyWithChanges(key Key, entry MapStateEntry, changes Chan
 		}
 
 		// Save old value before any changes, if desired
-		if changes.Old != nil {
-			changes.insertOldIfNotExists(key, oldEntry)
-		}
+		changes.insertOldIfNotExists(key, oldEntry)
 
 		// Compare for datapath equalness before merging, as the old entry is updated in
 		// place!
@@ -1368,8 +1364,11 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, feat
 	ms.addKeyWithChanges(newKey, newEntry, changes)
 }
 
-// insertIfNotExists only inserts `key=value` if `key` does not exist in keys already
-// returns 'true' if 'key=entry' was added to 'keys'
+// insertIfNotExists only inserts an entry in 'changes.Old' if 'key' does not exist in there already
+// and 'key' does not already exist in 'changes.Adds'. This prevents recording "old" values for
+// newly added keys. When an entry is updated, we are called before the key is added to
+// 'changes.Adds' so we'll record the old value as expected.
+// Returns 'true' if an old entry was added.
 func (changes *ChangeState) insertOldIfNotExists(key Key, entry MapStateEntry) bool {
 	if changes == nil || changes.Old == nil {
 		return false


### PR DESCRIPTION
Keep the oldest changed value in 'addDependentOnEntry()' by using 'insertOldIfNotExists()' rather than modifying 'changes.Old' directly. Changes in tests are due to the way 'insertOldIfNotExists()' filters out new entries (not adding an 'old' entry if the key exists in 'changes.Adds'). Test changes are in the 'deletes' field due to the test internally setting a 'deletes' key for each key in 'changes.Old'.

Old key values are used when reverting a failed endpoint update, prior to this fix that revert may have produced incorrect results.

> Backporter note: Release branches need unit test changes due to visibility policy tests in `pkg/policy/mapstate_test.go`. Main branch is not affected due to the deprecated visibility annotation code and tests having been removed.

```release-note
Fixed bug in tracking policy changes that could have resulted in revert not woking in failure cases as expected.
```
