### PR TITLE
policy: Add ResourcesWatcher interface to policy directory

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1685,7 +1685,7 @@ type daemonParams struct {
 	IdentityAllocator      identitycell.CachingIdentityAllocator
 	Policy                 *policy.Repository
 	IPCache                *ipcache.IPCache
-	DirectoryPolicyWatcher *policyDirectory.PolicyResourcesWatcher
+	DirectoryPolicyWatcher policyDirectory.ResourcesWatcher
 	DirReadStatus          policyDirectory.DirectoryWatcherReadStatus
 	CNIConfigManager       cni.CNIConfigManager
 	SwaggerSpec            *server.Spec

--- a/pkg/policy/directory/cell.go
+++ b/pkg/policy/directory/cell.go
@@ -46,6 +46,10 @@ type PolicyWatcherParams struct {
 	Logger     logrus.FieldLogger
 }
 
+type ResourcesWatcher interface {
+	WatchDirectoryPolicyResources(ctx context.Context, policyManager PolicyManager)
+}
+
 type PolicyResourcesWatcher struct {
 	params PolicyWatcherParams
 	cfg    Config
@@ -68,7 +72,7 @@ func (cfg Config) Flags(flags *pflag.FlagSet) {
 	flags.String(staticCNPPath, defaultConfig.StaticCNPPath, "Directory path to watch and load static cilium network policy yaml files.")
 }
 
-func newDirectoryPolicyResourcesWatcher(p PolicyWatcherParams, cfg Config) *PolicyResourcesWatcher {
+func newDirectoryPolicyResourcesWatcher(p PolicyWatcherParams, cfg Config) ResourcesWatcher {
 	if cfg.StaticCNPPath == "" {
 		close(p.ReadStatus)
 		return nil


### PR DESCRIPTION
Related to modularizing network policies:
- https://github.com/cilium/cilium/issues/23767
- https://github.com/cilium/cilium/issues/33360

Note: No user facing changes. No changes to the code behavior.

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>