### PR TITLE
policy: Do not record a change if nothing was done

### DIFF
--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -849,6 +849,9 @@ func (ms *mapState) addKeyWithChanges(key Key, entry MapStateEntry, changes Chan
 		entry.owners = maps.Clone(entry.owners)
 		entry.dependents = maps.Clone(entry.dependents)
 		ms.insert(key, entry)
+	} else {
+		// Do not record and incremental add if nothing was done
+		return
 	}
 
 	// Record an incremental Add if desired and entry is new or changed


### PR DESCRIPTION
addKeyWithChanges may skip adding an entry, for example when asked to
replace a deny entry with an allow entry. Fix this by not recording a
change if nothing was done.

Fixes: #34437