### PR TITLE
v1.14 Backports 2024-09-30

### DIFF
--- a/images/scripts/update-cilium-envoy-image.sh
+++ b/images/scripts/update-cilium-envoy-image.sh
@@ -17,7 +17,7 @@ github_repo="cilium/proxy"
 github_branch="main"
 image="quay.io/cilium/cilium-envoy"
 
-latest_commit_sha="$(curl -s https://api.github.com/repos/${github_repo}/commits/${github_branch} | jq -r '.sha')"
+latest_commit_sha="$(curl -s https://api.github.com/repos/${github_repo}/commits/${github_branch} | jq -r --exit-status '.sha')"
 envoy_version="$(curl -s https://raw.githubusercontent.com/${github_repo}/"${latest_commit_sha}"/ENVOY_VERSION)"
 
 image_tag="${envoy_version//envoy-/v}-${latest_commit_sha}"
@@ -30,17 +30,18 @@ fi
 
 echo "Latest image from branch ${github_branch}: ${image_full}"
 
-echo "Updating image in ./images/cilium/Dockerfile"
-sed -i -E "s|(FROM ${image}:)(.*)(@sha256:[0-9a-z]*)( as cilium-envoy)|\1${image_tag}@${image_sha256}\4|" ./images/cilium/Dockerfile
+DOCKERFILEPATH="./images/cilium/Dockerfile"
+echo "Updating image in ${DOCKERFILEPATH}"
+sed -i -E "s|(FROM ${image}:)(.*)(@sha256:[0-9a-z]*)( as cilium-envoy)|\1${image_tag}@${image_sha256}\4|" ${DOCKERFILEPATH}
 
-echo "Updating image in ./install/kubernetes/cilium/values.yaml.tmpl"
-# Using tr to workaround matching the multiline regex with sed
-# yq would change formatting: https://github.com/mikefarah/yq/issues/465
-# use of envoy.image.override (which would allow match in one line) isn't optimal either
-< ./install/kubernetes/cilium/values.yaml.tmpl tr '\n' '\f' |
-  sed -E "s|(# -- Envoy container image\..*tag: \")(v[0-9a-zA-Z\.-]*)(\")|\1${image_tag}\3|" |
-  sed -E "s|(# -- Envoy container image\..*digest: \")(sha256:[0-9a-z]*)(\")|\1${image_sha256}\3|" |
-  tr '\f' '\n' > ./install/kubernetes/cilium/values.yaml.tmpl_tmp &&
-  mv ./install/kubernetes/cilium/values.yaml.tmpl_tmp ./install/kubernetes/cilium/values.yaml.tmpl
+MAKEFILEPATH="./install/kubernetes/Makefile.values"
+echo "Updating image in ${MAKEFILEPATH}"
+sed -i -E "s|export[[:space:]]+CILIUM_ENVOY_VERSION:=.*|export CILIUM_ENVOY_VERSION:=${image_tag}|" ${MAKEFILEPATH}
+sed -i -E "s|export[[:space:]]+CILIUM_ENVOY_DIGEST:=.*|export CILIUM_ENVOY_DIGEST:=${image_sha256}|" ${MAKEFILEPATH}
 
-echo "Please don't forget to execute 'make -C Documentation update-helm-values && make -C install/kubernetes'"
+if git diff --exit-code ./install/kubernetes/Makefile.values ./images/cilium/Dockerfile &>/dev/null ; then
+  echo "The envoy image is already up to date"
+else
+  echo "Updated the envoy image to be a latest version"
+  echo "Please don't forget to execute 'make -C Documentation update-helm-values && make -C install/kubernetes'"
+fi

--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -50,6 +50,11 @@ export CILIUM_NODEINIT_VERSION:=c54c7edeab7fde4da68e59acd319ab24af242c3f
 export CILIUM_NODEINIT_DIGEST:=sha256:8d7b41c4ca45860254b3c19e20210462ef89479bb6331d6760c4e609d651b29c
 
 # renovate: datasource=docker
+export CILIUM_ENVOY_REPO:=quay.io/cilium/cilium-envoy
+export CILIUM_ENVOY_VERSION:=v1.29.9-1726784081-a90146d13b4cd7d168d573396ccf2b3db5a3b047
+export CILIUM_ENVOY_DIGEST:=sha256:9762041c3760de226a8b00cc12f27dacc28b7691ea926748f9b5c18862db503f
+
+# renovate: datasource=docker
 export ETCD_REPO:=quay.io/coreos/etcd
 export ETCD_VERSION:=v3.5.4
 export ETCD_DIGEST:=sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1857,10 +1857,10 @@ envoy:
   # -- Envoy container image.
   image:
     override: ~
-    repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.29.9-1726784081-a90146d13b4cd7d168d573396ccf2b3db5a3b047"
+    repository: "${CILIUM_ENVOY_REPO}"
+    tag: "${CILIUM_ENVOY_VERSION}"
     pullPolicy: "${PULL_POLICY}"
-    digest: "sha256:9762041c3760de226a8b00cc12f27dacc28b7691ea926748f9b5c18862db503f"
+    digest: "${CILIUM_ENVOY_DIGEST}"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.


### PR DESCRIPTION
 * [ ] #27725 (@weizhoublue) :warning: resolved conflicts
    * The goal is to allow renovate to run post upgrade task while patching cilium-envoy image.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 27725
```
