### PR TITLE
gha: fix permissions of update label backport PR workflow

### DIFF
--- a/.github/workflows/update-label-backport-pr.yaml
+++ b/.github/workflows/update-label-backport-pr.yaml
@@ -22,6 +22,7 @@
         runs-on: ubuntu-latest
         permissions:
           pull-requests: write # Adding and removing labels
+          repository-projects: read # Additionally required by `gh pr edit`
         env:
           body: ${{ inputs.pr-body }}
         steps:


### PR DESCRIPTION
The `gh pr edit` command appears to require repository-projects=read permissions \[1]. Although the permission is not strictly required in case of public repositories, let's still grant it for completeness, and to prevent problems in case of private forks.

\[1]: https://github.com/cli/cli/issues/6274
