### PR TITLE
v1.15 Backports 2024-09-30

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -63,6 +63,8 @@ jobs:
           cp ./images/runtime/update-cilium-runtime-image.sh ../cilium-base-branch/images/runtime/
           mkdir -p ../cilium-base-branch/images/builder/
           cp ./images/builder/update-cilium-builder-image.sh ../cilium-base-branch/images/builder/
+          mkdir -p ../cilium-base-branch/images/scripts/
+          cp ./images/scripts/get-image-digest.sh ../cilium-base-branch/images/scripts/
 
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
@@ -172,10 +174,20 @@ jobs:
           retention-days: 1
 
       - name: Update Runtime Image
-        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        id: update-runtime-image
         run: |
-          ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${{ steps.docker_build_release_runtime.outputs.digest }}"
-          git commit -sam "images: update cilium-{runtime,builder}"
+          if [[ "${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}" == "true" ]]; then
+            ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${{ steps.docker_build_release_runtime.outputs.digest }}"
+          else
+            digest=$(../cilium-base-branch/images/scripts/get-image-digest.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}")
+            ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${digest}"
+          fi
+          if ! git diff --quiet; then
+            git commit -sam "images: update cilium-{runtime,builder}"
+            echo committed="true" >> $GITHUB_OUTPUT
+          else
+            echo committed="false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Generating image tag for Cilium-Builder
         id: builder-tag
@@ -257,25 +269,33 @@ jobs:
           path: image-digest
           retention-days: 1
 
-      - name: Update Runtime Images
-        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+      - name: Update Runtime Image
         run: |
-          ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${{ steps.docker_build_release_runtime.outputs.digest }}"
+          if [[ "${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}" == "true" ]]; then
+            ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${{ steps.docker_build_release_runtime.outputs.digest }}"
+          else
+            digest=$(../cilium-base-branch/images/scripts/get-image-digest.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}")
+            ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${digest}"
+          fi
 
       - name: Update Builder Images
-        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
         run: |
-          ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${{ steps.docker_build_release_builder.outputs.digest }}"
+          if [[ "${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}" == "true" ]]; then
+            ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${{ steps.docker_build_release_builder.outputs.digest }}"
+          else
+            digest=$(../cilium-base-branch/images/scripts/get-image-digest.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}")
+            ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${digest}"
+          fi
 
       - name: Commit changes by amending previous commit
         # Run this step in case we have committed the cilium-runtime changes before
-        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' && steps.update-runtime-image.outputs.committed == 'false' }}
         run: |
           git commit --amend -sam "images: update cilium-{runtime,builder}"
 
       - name: Commit changes
         # Run this step in case we have NOT committed the cilium-runtime changes before
-        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists != 'false' && steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        if: ${{ (steps.cilium-runtime-tag-in-repositories.outputs.exists != 'false' || steps.update-runtime-image.outputs.committed != 'false') && steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
         run: |
           git commit -sam "images: update cilium-{runtime,builder}"
 

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   check_changes:
     name: Deduce required tests from code changes
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     outputs:
       docs-tree: ${{ steps.docs-tree.outputs.src }}
     steps:


### PR DESCRIPTION
 * [x] #35107 (@aanm) :warning: resolved conflicts

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 35107
```

In addition to that, I also reverted partially https://github.com/cilium/cilium/pull/35092, specifically by switching back the documentation workflow to ubuntu 22.04, as with 24.04 the `Install LLVM and Clang prerequisites` job fails with:

```
E: Unable to locate package libtinfo5
```