### PR TITLE
clustermesh: fix flaky TestRemoteClusterStatus integration test

### DIFF
--- a/pkg/clustermesh/operator/remote_cluster_test.go
+++ b/pkg/clustermesh/operator/remote_cluster_test.go
@@ -156,9 +156,9 @@ func TestRemoteClusterStatus(t *testing.T) {
 
 				assert.True(c, status.Synced.Services, "Services should be synced")
 				if tt.expectedMCSAPISync {
-					require.True(t, status.Synced.ServiceExports != nil && *status.Synced.ServiceExports, "Service Exports should be synced")
+					assert.True(c, status.Synced.ServiceExports != nil && *status.Synced.ServiceExports, "Service Exports should be synced")
 				} else {
-					require.Nil(t, status.Synced.ServiceExports, "Service Exports should not be considered for syncing")
+					assert.Nil(c, status.Synced.ServiceExports, "Service Exports should not be considered for syncing")
 				}
 
 				if tt.expectedServiceSync {


### PR DESCRIPTION
The test incorrectly referenced the global testing.T variable from assertions inside an EventuallyWithT block, hence possibly causing the entire check to immediately fail. Let's fix this by using the scoped collect variable instead.

Fixes: 9145efdacf56 ("clustermesh: add service export read path in clustermesh/operator")