### PR TITLE
minor pkg/ip fixes

### DIFF
--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -9,11 +9,10 @@ import (
 	"math/big"
 	"net"
 	"net/netip"
+	"slices"
 	"sort"
 
 	"go4.org/netipx"
-
-	"github.com/cilium/cilium/pkg/slices"
 )
 
 const (
@@ -753,15 +752,8 @@ func PartitionCIDR(targetCIDR net.IPNet, excludeCIDR net.IPNet) ([]*net.IPNet, [
 // netip.Addr.Compare (i.e. IPv4 addresses show up before IPv6).
 // The slice is manipulated in-place destructively; it does not create a new slice.
 func KeepUniqueAddrs(addrs []netip.Addr) []netip.Addr {
-	return slices.SortedUniqueFunc(
-		addrs,
-		func(a, b netip.Addr) int {
-			return a.Compare(b)
-		},
-		func(a, b netip.Addr) bool {
-			return a == b
-		},
-	)
+	SortAddrList(addrs)
+	return slices.Compact(addrs)
 }
 
 var privateIPBlocks []*net.IPNet
@@ -847,15 +839,11 @@ func ListContainsIP(ipList []net.IP, ip net.IP) bool {
 
 // SortIPList sorts the provided net.IP slice in place.
 func SortIPList(ipList []net.IP) {
-	sort.Slice(ipList, func(i, j int) bool {
-		return bytes.Compare(ipList[i], ipList[j]) < 0
-	})
+	slices.SortFunc(ipList, func(a, b net.IP) int { return bytes.Compare(a, b) })
 }
 
 func SortAddrList(ipList []netip.Addr) {
-	sort.Slice(ipList, func(i, j int) bool {
-		return ipList[i].Compare(ipList[j]) < 0
-	})
+	slices.SortFunc(ipList, netip.Addr.Compare)
 }
 
 // getSortedIPList returns a new net.IP slice in which the IPs are sorted.

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -5,6 +5,7 @@ package ip
 
 import (
 	"math/big"
+	"math/rand/v2"
 	"net"
 	"net/netip"
 	"sort"
@@ -1046,4 +1047,29 @@ func TestPrefixToIpsWithMaxIPv4sExceedingRange(t *testing.T) {
 	ips, err := PrefixToIps(prefix, maxIPs)
 	require.Nil(t, err)
 	require.EqualValues(t, expectedIPs, ips)
+}
+
+func BenchmarkSortAddrList(b *testing.B) {
+	ip := [4]byte{}
+	r := rand.New(rand.NewPCG(42, 1337))
+	size := 1000
+
+	var lists [][]netip.Addr
+	for range b.N {
+		list := make([]netip.Addr, size)
+		for i := range size {
+			bits := r.Uint32()
+			ip[0] = byte(bits)
+			ip[1] = byte(bits >> 8)
+			ip[2] = byte(bits >> 16)
+			ip[3] = byte(bits >> 24)
+			list[i] = netip.AddrFrom4(ip)
+		}
+		lists = append(lists, list)
+	}
+
+	b.ResetTimer()
+	for i := range b.N {
+		SortAddrList(lists[i])
+	}
 }

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -13,12 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type IPTestSuite struct{}
-
-func setupIPTestSuite(_ testing.TB) *IPTestSuite {
-	return &IPTestSuite{}
-}
-
 func TestCountIPs(t *testing.T) {
 	tests := map[string]*big.Int{
 		"192.168.0.1/32": big.NewInt(0),
@@ -61,7 +55,7 @@ func TestFirstIP(t *testing.T) {
 	}
 }
 
-func (s *IPTestSuite) testIPNetsEqual(created, expected []*net.IPNet, t *testing.T) {
+func testIPNetsEqual(created, expected []*net.IPNet, t *testing.T) {
 	require.Len(t, created, len(expected))
 	for index := range created {
 		require.Equal(t, expected[index].String(), created[index].String())
@@ -69,7 +63,7 @@ func (s *IPTestSuite) testIPNetsEqual(created, expected []*net.IPNet, t *testing
 	}
 }
 
-func (s *IPTestSuite) testIPsEqual(created, expected net.IP, t *testing.T) {
+func testIPsEqual(created, expected net.IP, t *testing.T) {
 	require.Len(t, created, len(expected))
 	for k := range created {
 		require.Equal(t, expected[k], created[k])
@@ -87,8 +81,6 @@ func createIPRange(first string, last string) *netWithRange {
 }
 
 func TestRemoveRedundant(t *testing.T) {
-	s := setupIPTestSuite(t)
-
 	CIDRs := []*net.IPNet{
 		createIPNet("10.96.0.0", 12, ipv4BitLen),
 		createIPNet("10.112.0.0", 13, ipv4BitLen),
@@ -98,7 +90,7 @@ func TestRemoveRedundant(t *testing.T) {
 		createIPNet("10.112.0.0", 13, ipv4BitLen),
 	}
 	nonRedundantCIDRs := removeRedundantCIDRs(CIDRs)
-	s.testIPNetsEqual(nonRedundantCIDRs, expectedCIDRs, t)
+	testIPNetsEqual(nonRedundantCIDRs, expectedCIDRs, t)
 
 	CIDRs = []*net.IPNet{
 		createIPNet("10.96.0.0", 11, ipv4BitLen),
@@ -108,14 +100,14 @@ func TestRemoveRedundant(t *testing.T) {
 		createIPNet("10.96.0.0", 11, ipv4BitLen),
 	}
 	nonRedundantCIDRs = removeRedundantCIDRs(CIDRs)
-	s.testIPNetsEqual(nonRedundantCIDRs, expectedCIDRs, t)
+	testIPNetsEqual(nonRedundantCIDRs, expectedCIDRs, t)
 
 	CIDRs = []*net.IPNet{
 		createIPNet("10.112.0.0", 12, ipv4BitLen),
 		createIPNet("10.96.0.0", 11, ipv4BitLen),
 	}
 	nonRedundantCIDRs = removeRedundantCIDRs(CIDRs)
-	s.testIPNetsEqual(nonRedundantCIDRs, expectedCIDRs, t)
+	testIPNetsEqual(nonRedundantCIDRs, expectedCIDRs, t)
 
 	CIDRs = []*net.IPNet{
 		createIPNet("10.120.0.0", 13, ipv4BitLen),
@@ -130,7 +122,7 @@ func TestRemoveRedundant(t *testing.T) {
 		createIPNet("10.96.0.0", 11, ipv4BitLen),
 	}
 	nonRedundantCIDRs = removeRedundantCIDRs(CIDRs)
-	s.testIPNetsEqual(nonRedundantCIDRs, expectedCIDRs, t)
+	testIPNetsEqual(nonRedundantCIDRs, expectedCIDRs, t)
 
 	CIDRs = []*net.IPNet{
 		createIPNet("10.120.0.0", 13, ipv4BitLen),
@@ -146,12 +138,10 @@ func TestRemoveRedundant(t *testing.T) {
 		createIPNet("10.96.0.0", 11, ipv4BitLen),
 	}
 	nonRedundantCIDRs = removeRedundantCIDRs(CIDRs)
-	s.testIPNetsEqual(nonRedundantCIDRs, expectedCIDRs, t)
+	testIPNetsEqual(nonRedundantCIDRs, expectedCIDRs, t)
 }
 
 func TestRemoveCIDRs(t *testing.T) {
-	s := setupIPTestSuite(t)
-
 	allowCIDRs := []*net.IPNet{createIPNet("10.0.0.0", 8, ipv4BitLen)}
 	removeCIDRs := []*net.IPNet{createIPNet("10.96.0.0", 12, ipv4BitLen),
 		createIPNet("10.112.0.0", 13, ipv4BitLen),
@@ -161,14 +151,14 @@ func TestRemoveCIDRs(t *testing.T) {
 		createIPNet("10.64.0.0", 11, ipv4BitLen),
 		createIPNet("10.120.0.0", 13, ipv4BitLen)}
 	allowedCIDRs := RemoveCIDRs(allowCIDRs, removeCIDRs)
-	s.testIPNetsEqual(allowedCIDRs, expectedCIDRs, t)
+	testIPNetsEqual(allowedCIDRs, expectedCIDRs, t)
 
 	// Removing superset removes the allowed CIDR
 	allowCIDRs = []*net.IPNet{createIPNet("10.96.0.0", 12, ipv4BitLen)}
 	removeCIDRs = []*net.IPNet{createIPNet("10.0.0.0", 8, ipv4BitLen)}
 	expectedCIDRs = []*net.IPNet{}
 	allowedCIDRs = RemoveCIDRs(allowCIDRs, removeCIDRs)
-	s.testIPNetsEqual(allowedCIDRs, expectedCIDRs, t)
+	testIPNetsEqual(allowedCIDRs, expectedCIDRs, t)
 
 	allowCIDRs = []*net.IPNet{createIPNet("10.0.0.0", 8, ipv4BitLen)}
 	removeCIDRs = []*net.IPNet{createIPNet("10.96.0.0", 12, ipv4BitLen),
@@ -203,23 +193,23 @@ func TestRemoveCIDRs(t *testing.T) {
 		createIPNet("10.93.0.0", 30, ipv4BitLen),
 	}
 	allowedCIDRs = RemoveCIDRs(allowCIDRs, removeCIDRs)
-	s.testIPNetsEqual(allowedCIDRs, expectedCIDRs, t)
+	testIPNetsEqual(allowedCIDRs, expectedCIDRs, t)
 
 	// Cannot remove CIDRs that are of a different address family.
 	allowCIDRs = []*net.IPNet{createIPNet("10.0.0.0", 8, ipv4BitLen)}
 	removeCIDRs = []*net.IPNet{createIPNet("fd44:7089:ff32:712b::", 66, ipv6BitLen)}
 	allowedCIDRs = RemoveCIDRs(allowCIDRs, removeCIDRs)
-	s.testIPNetsEqual(allowedCIDRs, allowCIDRs, t)
+	testIPNetsEqual(allowedCIDRs, allowCIDRs, t)
 
 	allowCIDRs = []*net.IPNet{createIPNet("10.0.0.0", 8, ipv4BitLen)}
 	removeCIDRs = []*net.IPNet{createIPNet("a000::", 8, ipv6BitLen)}
 	allowedCIDRs = RemoveCIDRs(allowCIDRs, removeCIDRs)
-	s.testIPNetsEqual(allowedCIDRs, allowCIDRs, t)
+	testIPNetsEqual(allowedCIDRs, allowCIDRs, t)
 
 	allowCIDRs = []*net.IPNet{createIPNet("a000::", 8, ipv6BitLen)}
 	removeCIDRs = []*net.IPNet{createIPNet("10.0.0.0", 8, ipv4BitLen)}
 	allowedCIDRs = RemoveCIDRs(allowCIDRs, removeCIDRs)
-	s.testIPNetsEqual(allowedCIDRs, allowCIDRs, t)
+	testIPNetsEqual(allowedCIDRs, allowCIDRs, t)
 
 	//IPv6 tests
 	allowCIDRs = []*net.IPNet{createIPNet("fd44:7089:ff32:712b:ff00::", 64, ipv6BitLen)}
@@ -227,7 +217,7 @@ func TestRemoveCIDRs(t *testing.T) {
 	allowedCIDRs = RemoveCIDRs(allowCIDRs, removeCIDRs)
 	expectedCIDRs = []*net.IPNet{createIPNet("fd44:7089:ff32:712b:8000::", 65, ipv6BitLen),
 		createIPNet("fd44:7089:ff32:712b:4000::", 66, ipv6BitLen)}
-	s.testIPNetsEqual(allowedCIDRs, expectedCIDRs, t)
+	testIPNetsEqual(allowedCIDRs, expectedCIDRs, t)
 
 }
 
@@ -239,28 +229,26 @@ func TestRemoveSameCIDR(t *testing.T) {
 }
 
 func TestRemoveCIDRsEdgeCases(t *testing.T) {
-	s := setupIPTestSuite(t)
-
 	// Remote some /32s
 	allowCIDRs := []*net.IPNet{createIPNet("10.96.0.0", 30, ipv4BitLen)}
 	removeCIDRs := []*net.IPNet{createIPNet("10.96.0.0", 32, ipv4BitLen), createIPNet("10.96.0.1", 32, ipv4BitLen)}
 	expectedCIDRs := []*net.IPNet{createIPNet("10.96.0.2", 31, ipv4BitLen)}
 	allowedCIDRs := RemoveCIDRs(allowCIDRs, removeCIDRs)
-	s.testIPNetsEqual(allowedCIDRs, expectedCIDRs, t)
+	testIPNetsEqual(allowedCIDRs, expectedCIDRs, t)
 
 	// Remove some subnets
 	allowCIDRs = []*net.IPNet{createIPNet("10.96.0.0", 22, ipv4BitLen)}
 	removeCIDRs = []*net.IPNet{createIPNet("10.96.0.0", 24, ipv4BitLen), createIPNet("10.96.1.0", 24, ipv4BitLen)}
 	expectedCIDRs = []*net.IPNet{createIPNet("10.96.2.0", 23, ipv4BitLen)}
 	allowedCIDRs = RemoveCIDRs(allowCIDRs, removeCIDRs)
-	s.testIPNetsEqual(allowedCIDRs, expectedCIDRs, t)
+	testIPNetsEqual(allowedCIDRs, expectedCIDRs, t)
 
 	// Remove all subnets
 	allowCIDRs = []*net.IPNet{createIPNet("10.96.0.0", 23, ipv4BitLen)}
 	removeCIDRs = []*net.IPNet{createIPNet("10.96.0.0", 24, ipv4BitLen), createIPNet("10.96.1.0", 24, ipv4BitLen)}
 	expectedCIDRs = []*net.IPNet{}
 	allowedCIDRs = RemoveCIDRs(allowCIDRs, removeCIDRs)
-	s.testIPNetsEqual(allowedCIDRs, expectedCIDRs, t)
+	testIPNetsEqual(allowedCIDRs, expectedCIDRs, t)
 }
 
 func TestByteFunctions(t *testing.T) {
@@ -281,8 +269,6 @@ func TestByteFunctions(t *testing.T) {
 }
 
 func TestIPNetToRange(t *testing.T) {
-	s := setupIPTestSuite(t)
-
 	testRange := ipNetToRange(*createIPNet("192.0.128.0", 24, ipv4BitLen))
 	var expectedFirst, expectedLast []byte
 	expectedFirst = append(expectedFirst, v4Mappedv6Prefix...)
@@ -294,18 +280,18 @@ func TestIPNetToRange(t *testing.T) {
 	expectedLastIP := net.IP(expectedLast)
 	expectedRange := netWithRange{First: &expectedFirstIP, Last: &expectedLastIP}
 
-	s.checkRangesEqual(&expectedRange, &testRange, t)
+	checkRangesEqual(&expectedRange, &testRange, t)
 
 	// Check that all bits are masked correctly.
 	testRange = ipNetToRange(*createIPNet("192.0.128.255", 24, ipv4BitLen))
-	s.checkRangesEqual(&expectedRange, &testRange, t)
+	checkRangesEqual(&expectedRange, &testRange, t)
 
 	testRange = ipNetToRange(*createIPNet("fd44:7089:ff32:712b:ff00::", 64, ipv6BitLen))
 	testRange = ipNetToRange(*createIPNet("::ffff:0", 128, ipv6BitLen))
 
 }
 
-func (s *IPTestSuite) checkRangesEqual(range1, range2 *netWithRange, t *testing.T) {
+func checkRangesEqual(range1, range2 *netWithRange, t *testing.T) {
 	for l := range *range1.First {
 		require.Equal(t, (*range2.First)[l], (*range1.First)[l])
 	}
@@ -315,8 +301,6 @@ func (s *IPTestSuite) checkRangesEqual(range1, range2 *netWithRange, t *testing.
 }
 
 func TestNetsByRange(t *testing.T) {
-	s := setupIPTestSuite(t)
-
 	ranges := []*netWithRange{}
 
 	// Check sorting by last IP first
@@ -339,7 +323,7 @@ func TestNetsByRange(t *testing.T) {
 	// Ensure that length of ranges isn't modified first.
 	require.Equal(t, len(expectedRanges), len(ranges))
 	for k := range ranges {
-		s.checkRangesEqual(ranges[k], expectedRanges[k], t)
+		checkRangesEqual(ranges[k], expectedRanges[k], t)
 	}
 
 	ranges = []*netWithRange{createIPRange("10.0.0.0", "10.255.255.255"),
@@ -350,20 +334,18 @@ func TestNetsByRange(t *testing.T) {
 	// Ensure that length of ranges isn't modified first.
 	require.Equal(t, len(expectedRanges), len(ranges))
 	for k := range ranges {
-		s.checkRangesEqual(ranges[k], expectedRanges[k], t)
+		checkRangesEqual(ranges[k], expectedRanges[k], t)
 	}
 
 }
 
 func TestCoalesceCIDRs(t *testing.T) {
-	s := setupIPTestSuite(t)
-
 	cidrs := []*net.IPNet{createIPNet("192.0.128.0", 24, ipv4BitLen),
 		createIPNet("192.0.129.0", 24, ipv4BitLen)}
 	expected := []*net.IPNet{createIPNet("192.0.128.0", 23, ipv4BitLen)}
 	mergedV4CIDRs, mergedV6CIDRs := CoalesceCIDRs(cidrs)
 	require.Equal(t, 0, len(mergedV6CIDRs))
-	s.testIPNetsEqual(mergedV4CIDRs, expected, t)
+	testIPNetsEqual(mergedV4CIDRs, expected, t)
 
 	cidrs = []*net.IPNet{createIPNet("192.0.129.0", 24, ipv4BitLen),
 		createIPNet("192.0.130.0", 24, ipv4BitLen)}
@@ -371,7 +353,7 @@ func TestCoalesceCIDRs(t *testing.T) {
 		createIPNet("192.0.130.0", 24, ipv4BitLen)}
 	mergedV4CIDRs, mergedV6CIDRs = CoalesceCIDRs(cidrs)
 	require.Equal(t, 0, len(mergedV6CIDRs))
-	s.testIPNetsEqual(mergedV4CIDRs, expected, t)
+	testIPNetsEqual(mergedV4CIDRs, expected, t)
 
 	cidrs = []*net.IPNet{createIPNet("192.0.2.112", 30, ipv4BitLen),
 		createIPNet("192.0.2.116", 31, ipv4BitLen),
@@ -379,7 +361,7 @@ func TestCoalesceCIDRs(t *testing.T) {
 	expected = []*net.IPNet{createIPNet("192.0.2.112", 29, ipv4BitLen)}
 	mergedV4CIDRs, mergedV6CIDRs = CoalesceCIDRs(cidrs)
 	require.Equal(t, 0, len(mergedV6CIDRs))
-	s.testIPNetsEqual(mergedV4CIDRs, expected, t)
+	testIPNetsEqual(mergedV4CIDRs, expected, t)
 
 	cidrs = []*net.IPNet{createIPNet("192.0.2.112", 30, ipv4BitLen),
 		createIPNet("192.0.2.116", 32, ipv4BitLen),
@@ -389,7 +371,7 @@ func TestCoalesceCIDRs(t *testing.T) {
 		createIPNet("192.0.2.118", 31, ipv4BitLen)}
 	mergedV4CIDRs, mergedV6CIDRs = CoalesceCIDRs(cidrs)
 	require.Equal(t, 0, len(mergedV6CIDRs))
-	s.testIPNetsEqual(mergedV4CIDRs, expected, t)
+	testIPNetsEqual(mergedV4CIDRs, expected, t)
 
 	cidrs = []*net.IPNet{createIPNet("192.0.2.112", 31, ipv4BitLen),
 		createIPNet("192.0.2.116", 31, ipv4BitLen),
@@ -398,7 +380,7 @@ func TestCoalesceCIDRs(t *testing.T) {
 		createIPNet("192.0.2.116", 30, ipv4BitLen)}
 	mergedV4CIDRs, mergedV6CIDRs = CoalesceCIDRs(cidrs)
 	require.Equal(t, 0, len(mergedV6CIDRs))
-	s.testIPNetsEqual(mergedV4CIDRs, expected, t)
+	testIPNetsEqual(mergedV4CIDRs, expected, t)
 
 	cidrs = []*net.IPNet{createIPNet("192.0.1.254", 31, ipv4BitLen),
 		createIPNet("192.0.2.0", 28, ipv4BitLen),
@@ -425,20 +407,20 @@ func TestCoalesceCIDRs(t *testing.T) {
 		createIPNet("192.0.3.0", 28, ipv4BitLen)}
 	mergedV4CIDRs, mergedV6CIDRs = CoalesceCIDRs(cidrs)
 	require.Equal(t, 0, len(mergedV6CIDRs))
-	s.testIPNetsEqual(mergedV4CIDRs, expected, t)
+	testIPNetsEqual(mergedV4CIDRs, expected, t)
 
 	cidrs = []*net.IPNet{createIPNet("::", 0, ipv6BitLen),
 		createIPNet("fe80::1", 128, ipv6BitLen)}
 	expected = []*net.IPNet{createIPNet("::", 0, ipv6BitLen)}
 	_, mergedV6CIDRs = CoalesceCIDRs(cidrs)
-	s.testIPNetsEqual(mergedV6CIDRs, expected, t)
+	testIPNetsEqual(mergedV6CIDRs, expected, t)
 
 	// assert cidr_merge(['::/0', '::192.0.2.0/124', 'ff00::101']) == [IPNetwork('::/0')]
 	cidrs = []*net.IPNet{createIPNet("::", 0, ipv6BitLen),
 		createIPNet("::192.0.2.0", 124, ipv6BitLen),
 		createIPNet("ff00::101", 128, ipv6BitLen)}
 	_, mergedV6CIDRs = CoalesceCIDRs(cidrs)
-	s.testIPNetsEqual(mergedV6CIDRs, expected, t)
+	testIPNetsEqual(mergedV6CIDRs, expected, t)
 }
 
 func TestRangeToCIDRs(t *testing.T) {
@@ -515,33 +497,31 @@ func TestRangeToCIDRs(t *testing.T) {
 }
 
 func TestPreviousIP(t *testing.T) {
-	s := setupIPTestSuite(t)
-
 	ip := net.ParseIP("10.0.0.0")
 	expectedPrev := net.ParseIP("9.255.255.255")
 	prevIP := getPreviousIP(ip)
-	s.testIPsEqual(prevIP, expectedPrev, t)
+	testIPsEqual(prevIP, expectedPrev, t)
 
 	// Check that underflow does not occur.
 	ip = net.ParseIP("0.0.0.0")
 	prevIP = getPreviousIP(ip)
 	expectedPrev = ip
-	s.testIPsEqual(prevIP, expectedPrev, t)
+	testIPsEqual(prevIP, expectedPrev, t)
 
 	ip = net.ParseIP("::")
 	prevIP = getPreviousIP(ip)
 	expectedPrev = ip
-	s.testIPsEqual(prevIP, expectedPrev, t)
+	testIPsEqual(prevIP, expectedPrev, t)
 
 	ip = net.ParseIP("10.0.0.1")
 	prevIP = getPreviousIP(ip)
 	expectedPrev = net.ParseIP("10.0.0.0")
-	s.testIPsEqual(prevIP, expectedPrev, t)
+	testIPsEqual(prevIP, expectedPrev, t)
 
 	ip = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
 	expectedPrev = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe")
 	prevIP = getPreviousIP(ip)
-	s.testIPsEqual(prevIP, expectedPrev, t)
+	testIPsEqual(prevIP, expectedPrev, t)
 }
 
 func TestNextIP(t *testing.T) {
@@ -593,48 +573,44 @@ func TestNextIP(t *testing.T) {
 }
 
 func TestCreateSpanningCIDR(t *testing.T) {
-	s := setupIPTestSuite(t)
-
 	netRange := createIPRange("10.0.0.0", "10.255.255.255")
 	expectedSpanningCIDR := createIPNet("10.0.0.0", 8, ipv4BitLen)
 	spanningCIDR := createSpanningCIDR(*netRange)
-	s.testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, t)
+	testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, t)
 
 	netRange = createIPRange("10.0.0.0", "10.255.255.254")
 	expectedSpanningCIDR = createIPNet("10.0.0.0", 8, ipv4BitLen)
 	spanningCIDR = createSpanningCIDR(*netRange)
-	s.testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, t)
+	testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, t)
 
 	netRange = createIPRange("10.0.0.1", "10.0.0.1")
 	expectedSpanningCIDR = createIPNet("10.0.0.1", 32, ipv4BitLen)
 	spanningCIDR = createSpanningCIDR(*netRange)
-	s.testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, t)
+	testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, t)
 
 	netRange = createIPRange("10.0.0.1", "10.0.0.2")
 	expectedSpanningCIDR = createIPNet("10.0.0.0", 30, ipv4BitLen)
 	spanningCIDR = createSpanningCIDR(*netRange)
-	s.testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, t)
+	testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, t)
 
 	netRange = createIPRange("9.0.0.0", "10.0.0.0")
 	expectedSpanningCIDR = createIPNet("8.0.0.0", 6, ipv4BitLen)
 	spanningCIDR = createSpanningCIDR(*netRange)
-	s.testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, t)
+	testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, t)
 
 	netRange = createIPRange("FD44:7089:FF32:712B:FF00:0000:0000:0000", "FD44:7089:FF32:712B:FFFF:FFFF:FFFF:FFFF")
 	expectedSpanningCIDR = createIPNet("fd44:7089:ff32:712b:ff00::", 72, ipv6BitLen)
 	spanningCIDR = createSpanningCIDR(*netRange)
-	s.testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, t)
+	testIPNetsEqual([]*net.IPNet{expectedSpanningCIDR}, []*net.IPNet{&spanningCIDR}, t)
 
 }
 
 func TestPartitionCIDR(t *testing.T) {
-	s := setupIPTestSuite(t)
-
 	targetCIDR := createIPNet("10.0.0.0", 8, ipv4BitLen)
 	excludeCIDR := createIPNet("10.255.255.255", 32, ipv4BitLen)
 	left, exclude, right := PartitionCIDR(*targetCIDR, *excludeCIDR)
 	// Exclude should just contain exclude CIDR
-	s.testIPNetsEqual([]*net.IPNet{excludeCIDR}, exclude, t)
+	testIPNetsEqual([]*net.IPNet{excludeCIDR}, exclude, t)
 	// Nothing should be in right list.
 	require.Equal(t, 0, len(right))
 	expectedLeft := []*net.IPNet{createIPNet("10.0.0.0", 9, ipv4BitLen),
@@ -662,13 +638,13 @@ func TestPartitionCIDR(t *testing.T) {
 		createIPNet("10.255.255.252", 31, ipv4BitLen),
 		createIPNet("10.255.255.254", 32, ipv4BitLen),
 	}
-	s.testIPNetsEqual(expectedLeft, left, t)
+	testIPNetsEqual(expectedLeft, left, t)
 
 	targetCIDR = createIPNet("10.0.0.0", 8, ipv4BitLen)
 	excludeCIDR = createIPNet("10.0.0.0", 32, ipv4BitLen)
 	left, exclude, right = PartitionCIDR(*targetCIDR, *excludeCIDR)
 	// Exclude should just contain exclude CIDR
-	s.testIPNetsEqual([]*net.IPNet{excludeCIDR}, exclude, t)
+	testIPNetsEqual([]*net.IPNet{excludeCIDR}, exclude, t)
 	// Nothing should be in left list.
 	require.Equal(t, 0, len(left))
 	expectedRight := []*net.IPNet{createIPNet("10.128.0.0", 9, ipv4BitLen),
@@ -696,7 +672,7 @@ func TestPartitionCIDR(t *testing.T) {
 		createIPNet("10.0.0.2", 31, ipv4BitLen),
 		createIPNet("10.0.0.1", 32, ipv4BitLen),
 	}
-	s.testIPNetsEqual(expectedRight, right, t)
+	testIPNetsEqual(expectedRight, right, t)
 
 	// exclude is not in target CIDR and is to left.
 	targetCIDR = createIPNet("10.0.0.0", 8, ipv4BitLen)
@@ -704,7 +680,7 @@ func TestPartitionCIDR(t *testing.T) {
 	left, exclude, right = PartitionCIDR(*targetCIDR, *excludeCIDR)
 	require.Equal(t, 0, len(left))
 	require.Equal(t, 0, len(exclude))
-	s.testIPNetsEqual([]*net.IPNet{targetCIDR}, right, t)
+	testIPNetsEqual([]*net.IPNet{targetCIDR}, right, t)
 
 	// exclude is not in target CIDR and is to right.
 	targetCIDR = createIPNet("10.255.255.254", 32, ipv4BitLen)
@@ -712,7 +688,7 @@ func TestPartitionCIDR(t *testing.T) {
 	left, exclude, right = PartitionCIDR(*targetCIDR, *excludeCIDR)
 	require.Equal(t, 0, len(right))
 	require.Equal(t, 0, len(exclude))
-	s.testIPNetsEqual([]*net.IPNet{targetCIDR}, left, t)
+	testIPNetsEqual([]*net.IPNet{targetCIDR}, left, t)
 
 	// exclude CIDR larger than target CIDR
 	targetCIDR = createIPNet("10.96.0.0", 12, ipv4BitLen)
@@ -720,7 +696,7 @@ func TestPartitionCIDR(t *testing.T) {
 	left, exclude, right = PartitionCIDR(*targetCIDR, *excludeCIDR)
 	require.Equal(t, 0, len(left))
 	require.Equal(t, 0, len(right))
-	s.testIPNetsEqual([]*net.IPNet{targetCIDR}, exclude, t)
+	testIPNetsEqual([]*net.IPNet{targetCIDR}, exclude, t)
 
 	targetCIDR = createIPNet("fd44:7089:ff32:712b:ff00::", 64, ipv6BitLen)
 	excludeCIDR = createIPNet("fd44:7089:ff32:712b::", 66, ipv6BitLen)
@@ -729,8 +705,8 @@ func TestPartitionCIDR(t *testing.T) {
 
 	expectedCIDRs := []*net.IPNet{createIPNet("fd44:7089:ff32:712b:8000::", 65, ipv6BitLen),
 		createIPNet("fd44:7089:ff32:712b:4000::", 66, ipv6BitLen)}
-	s.testIPNetsEqual(expectedCIDRs, right, t)
-	s.testIPNetsEqual([]*net.IPNet{excludeCIDR}, exclude, t)
+	testIPNetsEqual(expectedCIDRs, right, t)
+	testIPNetsEqual([]*net.IPNet{excludeCIDR}, exclude, t)
 }
 
 func TestKeepUniqueAddrs(t *testing.T) {

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -84,24 +84,6 @@ func SortedUnique[S ~[]T, T cmp.Ordered](s S) S {
 	return slices.Compact(s)
 }
 
-// SortedUniqueFunc is like SortedUnique but allows the user to specify custom functions
-// for ordering (less function) and comparing (eq function) the elements in the slice.
-// This is useful in all the cases where SortedUnique cannot be used:
-// - for types that do not satisfy constraints.Ordered (e.g: composite types)
-// - when the user wants to customize how elements are compared (e.g: user wants to enforce reverse ordering)
-func SortedUniqueFunc[S ~[]T, T any](
-	s S,
-	less func(a, b T) int,
-	eq func(a, b T) bool,
-) S {
-	if len(s) < 2 {
-		return s
-	}
-
-	slices.SortFunc(s, less)
-	return slices.CompactFunc(s, eq)
-}
-
 // Diff returns a slice of elements which is the difference of a and b.
 // The returned slice keeps the elements in the same order found in the "a" slice.
 // Both input slices are considered as sets, that is, all elements are considered as

--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -4,7 +4,6 @@
 package slices
 
 import (
-	"cmp"
 	"fmt"
 	"math"
 	"math/rand/v2"
@@ -82,22 +81,6 @@ func TestSortedUnique(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			input := slices.Clone(tc.input)
 			got := SortedUnique(input)
-			assert.ElementsMatch(t, tc.expected, got)
-		})
-	}
-}
-
-func TestSortedUniqueFunc(t *testing.T) {
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			input := slices.Clone(tc.input)
-			got := SortedUniqueFunc(
-				input,
-				cmp.Compare,
-				func(a, b int) bool {
-					return a == b
-				},
-			)
 			assert.ElementsMatch(t, tc.expected, got)
 		})
 	}


### PR DESCRIPTION
A few small drive-by improvements to `pkg/ip`.


```
ip: remove unneeded IPTestSuite

Likely left over from a conversion from checkmate to go testing.
```
```
ip: benchmark SortAddrList

To create a baseline for the next commit.
```
```
ip: use stdlib slices package

This gives us a speedup of 30% in a microbenchmark for sorting IPs and
moves us closer to stdlib.

pkg: github.com/cilium/cilium/pkg/ip
                │     pre      │                post                 │
                │    sec/op    │   sec/op     vs base                │
SortAddrList-10   105.06µ ± 4%   72.75µ ± 1%  -30.75% (p=0.000 n=10)
```
```
slices: drop SortedUniqueFunc

The type constraints of slices.Sort and slices.Compact are different -
the former requires cmp.Ordered whereas the latter only needs
comparable. The only caller for SortedUniqueFunc was pkg/ip, for
[]netip.Addr. The usage is inefficient, though, since netip.Addr is
comparable, just not cmp.Ordered - the use of slices.CompactFunc is thus
unnecessary.

Since there's no consumers, and use can be needlessly inefficient, let's
just drop the function, even though it breaks API symmetry.
```