### PR TITLE
.github: do not update github runners for bpf workflows

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -657,6 +657,24 @@
       "matchUpdateTypes": [
         "major"
       ],
+    },
+    {
+      "enabled": false,
+      "matchFileNames": [
+        ".github/workflows/documentation.yaml"
+      ],
+      "matchDepTypes": [
+        "github-runner",
+      ],
+      "matchPackageNames": [
+        "ubuntu",
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      matchBaseBranches: [
+        "v1.15"
+      ]
     }
   ],
   "kubernetes": {


### PR DESCRIPTION
GH workflows that use clang require the libtinfo5 library which is currently unavailable in ubuntu 24.04. Thus, we should not automatically update these runners on these files to avoid breaking CI.