### PR TITLE
policy: use MatchExpressions to implement CIDR Except rules

### DIFF
--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -54,6 +54,9 @@ var (
 	//go:embed manifests/client-egress-to-cidr-external-deny.yaml
 	clientEgressToCIDRExternalDenyPolicyYAML string
 
+	//go:embed manifests/client-egress-to-cidrgroup-external-deny.yaml
+	clientEgressToCIDRGroupExternalDenyPolicyYAML string
+
 	//go:embed manifests/client-egress-l7-http.yaml
 	clientEgressL7HTTPPolicyYAML string
 
@@ -210,6 +213,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		clientWithServiceAccountEgressToEchoDeny{},
 		clientEgressToEchoServiceAccountDeny{},
 		clientEgressToCidrDeny{},
+		clientEgressToCidrgroupDeny{},
 		clientEgressToCidrDenyDefault{},
 		clusterMeshEndpointSliceSync{},
 		health{},
@@ -275,6 +279,7 @@ func renderTemplates(param check.Parameters) (map[string]string, error) {
 		"clientEgressToCIDRExternalPolicyKNPYAML":          clientEgressToCIDRExternalPolicyKNPYAML,
 		"clientEgressToCIDRNodeKNPYAML":                    clientEgressToCIDRNodeKNPYAML,
 		"clientEgressToCIDRExternalDenyPolicyYAML":         clientEgressToCIDRExternalDenyPolicyYAML,
+		"clientEgressToCIDRGroupExternalDenyPolicyYAML":    clientEgressToCIDRGroupExternalDenyPolicyYAML,
 		"clientEgressL7HTTPPolicyYAML":                     clientEgressL7HTTPPolicyYAML,
 		"clientEgressL7HTTPPolicyPortRangeYAML":            clientEgressL7HTTPPolicyPortRangeYAML,
 		"clientEgressL7HTTPNamedPortPolicyYAML":            clientEgressL7HTTPNamedPortPolicyYAML,

--- a/cilium-cli/connectivity/builder/client_egress_to_cidrgroup_deny.go
+++ b/cilium-cli/connectivity/builder/client_egress_to_cidrgroup_deny.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type clientEgressToCidrgroupDeny struct{}
+
+func (t clientEgressToCidrgroupDeny) build(ct *check.ConnectivityTest, templates map[string]string) {
+	// This policy denies L3 traffic to ExternalCIDR except ExternalIP/32
+	// It does so using a CiliumCIDRGroup
+	newTest("client-egress-to-cidrgroup-deny", ct).
+		WithCiliumPolicy(allowAllEgressPolicyYAML). // Allow all egress traffic
+		WithCiliumPolicy(templates["clientEgressToCIDRGroupExternalDenyPolicyYAML"]).
+		WithScenarios(
+			tests.PodToCIDR(tests.WithRetryDestIP(ct.Params().ExternalIP)), // Denies all traffic to ExternalOtherIP, but allow ExternalIP
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Destination().Address(features.GetIPFamily(ct.Params().ExternalOtherIP)) == ct.Params().ExternalOtherIP {
+				return check.ResultPolicyDenyEgressDrop, check.ResultNone
+			}
+			if a.Destination().Address(features.GetIPFamily(ct.Params().ExternalIP)) == ct.Params().ExternalIP {
+				return check.ResultOK, check.ResultNone
+			}
+			return check.ResultDrop, check.ResultDrop
+		})
+}

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-cidrgroup-external-deny.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-cidrgroup-external-deny.yaml
@@ -1,0 +1,27 @@
+# This policy denies packets towards {{.ExternalOtherIP}}, but not {{.ExternalIP}}
+# Please note that if there is no other allowed rule, the policy
+# will be automatically denied {{.ExternalIP}} as well.
+
+apiVersion: "cilium.io/v2alpha1"
+kind: CiliumCIDRGroup
+metadata:
+  name: cilium-test-external-cidr
+spec:
+  externalCIDRs:
+    - "{{.ExternalCIDR}}"
+
+---
+
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-to-cidrgroup-deny
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egressDeny:
+  - toCIDRSet:
+    - cidrGroupRef: cilium-test-external-cidr
+      except:
+        - "{{.ExternalIP}}/32"

--- a/pkg/policy/api/cidr.go
+++ b/pkg/policy/api/cidr.go
@@ -4,11 +4,10 @@
 package api
 
 import (
-	"net"
 	"net/netip"
 	"strings"
 
-	"github.com/cilium/cilium/pkg/ip"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -22,6 +21,10 @@ type CIDR string
 var (
 	ipv4All = CIDR("0.0.0.0/0")
 	ipv6All = CIDR("::/0")
+
+	worldLabelNonDualStack = labels.Label{Source: labels.LabelSourceReserved, Key: labels.IDNameWorld}
+	worldLabelV4           = labels.Label{Source: labels.LabelSourceReserved, Key: labels.IDNameWorldIPv4}
+	worldLabelV6           = labels.Label{Source: labels.LabelSourceReserved, Key: labels.IDNameWorldIPv6}
 )
 
 // CIDRRule is a rule that specifies a CIDR prefix to/from which outside
@@ -136,52 +139,76 @@ type CIDRRuleSlice []CIDRRule
 
 // GetAsEndpointSelectors returns the provided CIDRRule slice as a slice of
 // endpoint selectors
+//
+// The ExceptCIDRs block is inserted as a negative match. Specifically, the
+// DoesNotExist qualifier. For example, the CIDRRule
+//
+//	cidr: 1.1.1.0/24
+//	exceptCIDRs: ["1.1.1.1/32"]
+//
+// results in the selector equivalent to "cidr:1.1.1.0/24 !cidr:1.1.1.1/32".
+//
+// This works because the label selectors will select numeric identities belonging only
+// to the shorter prefixes. However, longer prefixes will have a different numeric
+// identity, as the bpf ipcache is an LPM lookup. This essentially acts as a
+// "carve-out", using the LPM mechanism to exlude subsets of a larger prefix.
 func (s CIDRRuleSlice) GetAsEndpointSelectors() EndpointSelectorSlice {
-	cidrs := ComputeResultantCIDRSet(s)
-	ces := cidrs.GetAsEndpointSelectors()
+	ces := make(EndpointSelectorSlice, 0, len(s))
 
-	// expand cidrgroup selectors
 	for _, r := range s {
-		if r.CIDRGroupRef != "" {
-			ces = append(ces, NewESFromLabels(LabelForCIDRGroupRef(string(r.CIDRGroupRef))))
+		ls := slim_metav1.LabelSelector{
+			MatchExpressions: make([]slim_metav1.LabelSelectorRequirement, 0, 1+len(r.ExceptCIDRs)),
 		}
+
+		// add the "main" label:
+		// either a CIDR or CIDRGroupRef
+		if r.Cidr != "" {
+			var lbl labels.Label
+			switch r.Cidr {
+			case ipv4All:
+				if option.Config.IsDualStack() {
+					lbl = worldLabelV4
+				} else {
+					lbl = worldLabelNonDualStack
+				}
+			case ipv6All:
+				if option.Config.IsDualStack() {
+					lbl = worldLabelV6
+				} else {
+					lbl = worldLabelNonDualStack
+				}
+			default:
+				lbl, _ = labels.IPStringToLabel(string(r.Cidr))
+			}
+			ls.MatchExpressions = append(ls.MatchExpressions, slim_metav1.LabelSelectorRequirement{
+				Key:      lbl.GetExtendedKey(),
+				Operator: slim_metav1.LabelSelectorOpExists,
+			})
+		} else if r.CIDRGroupRef != "" {
+			lbl := LabelForCIDRGroupRef(string(r.CIDRGroupRef))
+			ls.MatchExpressions = append(ls.MatchExpressions, slim_metav1.LabelSelectorRequirement{
+				Key:      lbl.GetExtendedKey(),
+				Operator: slim_metav1.LabelSelectorOpExists,
+			})
+		} else {
+			// should never be hit, but paranoia
+			continue
+		}
+
+		// exclude any excepted CIDRs.
+		// Do so by inserting a "DoesNotExist" requirement for the given prefix key
+		for _, exceptCIDR := range r.ExceptCIDRs {
+			lbl, _ := labels.IPStringToLabel(string(exceptCIDR))
+			ls.MatchExpressions = append(ls.MatchExpressions, slim_metav1.LabelSelectorRequirement{
+				Key:      lbl.GetExtendedKey(),
+				Operator: slim_metav1.LabelSelectorOpDoesNotExist,
+			})
+		}
+
+		ces = append(ces, NewESFromK8sLabelSelector("", &ls))
 	}
 
 	return ces
-}
-
-// StringSlice returns the CIDRRuleSlice as a slice of strings.
-func (s CIDRRuleSlice) StringSlice() []string {
-	result := make([]string, 0, len(s))
-	for _, c := range s {
-		result = append(result, c.String())
-	}
-	return result
-}
-
-// ComputeResultantCIDRSet converts a slice of CIDRRules into a slice of
-// individual CIDRs. This expands the cidr defined by each CIDRRule, applies
-// the CIDR exceptions defined in "ExceptCIDRs", and forms a minimal set of
-// CIDRs that cover all of the CIDRRules.
-//
-// Assumes no error checking is necessary as CIDRRule.Sanitize already does this.
-func ComputeResultantCIDRSet(cidrs CIDRRuleSlice) CIDRSlice {
-	var allResultantAllowedCIDRs CIDRSlice
-	for _, s := range cidrs {
-		_, allowNet, _ := net.ParseCIDR(string(s.Cidr))
-
-		var removeSubnets []*net.IPNet
-		for _, t := range s.ExceptCIDRs {
-			_, removeSubnet, _ := net.ParseCIDR(string(t))
-			removeSubnets = append(removeSubnets, removeSubnet)
-		}
-		resultantAllowedCIDRs := ip.RemoveCIDRs([]*net.IPNet{allowNet}, removeSubnets)
-
-		for _, u := range resultantAllowedCIDRs {
-			allResultantAllowedCIDRs = append(allResultantAllowedCIDRs, CIDR(u.String()))
-		}
-	}
-	return allResultantAllowedCIDRs
 }
 
 // addrsToCIDRRules generates CIDRRules for the IPs passed in.

--- a/pkg/policy/cidr_test.go
+++ b/pkg/policy/cidr_test.go
@@ -63,7 +63,6 @@ func TestGetCIDRPrefixes(t *testing.T) {
 	// We have three CIDR instances in the ruleset, check that all exist
 	expectedCIDRStrings := []string{
 		"192.0.2.0/24",
-		"192.0.2.0/24",
 		"192.0.3.0/24",
 	}
 	expectedCIDRs := []netip.Prefix{}
@@ -71,7 +70,7 @@ func TestGetCIDRPrefixes(t *testing.T) {
 		cidr := netip.MustParsePrefix(ipStr)
 		expectedCIDRs = append(expectedCIDRs, cidr)
 	}
-	require.EqualValues(t, expectedCIDRs, GetCIDRPrefixes(rules))
+	require.ElementsMatch(t, expectedCIDRs, GetCIDRPrefixes(rules))
 
 	// Now, test with CIDRSets.
 	rules = api.Rules{
@@ -106,22 +105,15 @@ func TestGetCIDRPrefixes(t *testing.T) {
 
 	// Once exceptions apply, here are the list of CIDRs.
 	expectedCIDRStrings = []string{
-		"192.0.2.0/25",
-		// Not "192.0.2.128/25",
-		"10.128.0.0/9",
-		"10.64.0.0/10",
-		"10.32.0.0/11",
-		"10.16.0.0/12",
-		"10.8.0.0/13",
-		"10.4.0.0/14",
-		"10.2.0.0/15",
-		"10.1.0.0/16",
-		// Not "10.0.0.0/16",
+		"192.0.2.0/24",
+		"192.0.2.128/25",
+		"10.0.0.0/8",
+		"10.0.0.0/16",
 	}
 	expectedCIDRs = []netip.Prefix{}
 	for _, ipStr := range expectedCIDRStrings {
 		cidr := netip.MustParsePrefix(ipStr)
 		expectedCIDRs = append(expectedCIDRs, cidr)
 	}
-	require.EqualValues(t, expectedCIDRs, GetCIDRPrefixes(rules))
+	require.ElementsMatch(t, expectedCIDRs, GetCIDRPrefixes(rules))
 }


### PR DESCRIPTION
This change stops the manual "splitting" of Except cidrs within ToCIDRSet rules. Rather, it uses the DoesNotExist label selector on any excepted CIDRs.

Previously, any entries within the Except block would cause the selected CIDR to be "split" on bit boundaries. This example policy would cause *8* match entries to be created, rather than 1:

```yaml
toCIDRSet:
- cidr: 10.0.0.0/8
  except: 
    - 10.0.0.0/16
```

Starting from 3887fcc3e, CIDR identities are no longer special within the policymap. This means that CIDR selectors have the exactly expected effect, and we no longer synthesize smaller entries in the event of a covering policy rule.

Now that CIDR selectors work exactly as expected, we can exploit this fact, along with the LPM nature of the ipcache, to implement Except without splitting any CIDRs.

The above example now produces the label selector string `cidr:10.0.0.0/8 !cidr:10.0.0.0/16` which means "select all identities with the key cidr:10.0.0.0/8 but not with the key cidr:10.0.0.0/16". This means that all identities contained in prefix 10.0.0.0/16 will *never* be selected by the policymap, and will thus be dropped.

This also fixes a (never shipped) bug introduced in #33441 where Except blocks stopped working with CIDRGroupRef rules.

```release-note
CIDRGroup Except blocks now produce fewer PolicyMap entries, improving scalability.
```
