### PR TITLE
endpoint: Place IngressIPs to endpoints map

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -333,7 +333,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		/* Let through packets to the node-ip so they are
 		 * processed by the local ip stack.
 		 */
-		if (ep->flags & ENDPOINT_F_HOST)
+		if (ep->flags & ENDPOINT_MASK_HOST_DELIVERY)
 			return CTX_ACT_OK;
 
 #ifdef ENABLE_HOST_ROUTING
@@ -755,7 +755,7 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		/* Let through packets to the node-ip so they are processed by
 		 * the local ip stack.
 		 */
-		if (ep->flags & ENDPOINT_F_HOST)
+		if (ep->flags & ENDPOINT_MASK_HOST_DELIVERY)
 			return CTX_ACT_OK;
 
 #ifdef ENABLE_HOST_ROUTING

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -668,7 +668,7 @@ ct_recreate6:
 		ep = lookup_ip6_endpoint(ip6);
 		if (ep) {
 #if defined(ENABLE_HOST_ROUTING) || defined(ENABLE_ROUTING)
-			if (ep->flags & ENDPOINT_F_HOST) {
+			if (ep->flags & ENDPOINT_MASK_HOST_DELIVERY) {
 				if (is_defined(ENABLE_ROUTING)) {
 # ifdef HOST_IFINDEX
 					goto to_host;
@@ -1174,7 +1174,7 @@ ct_recreate4:
 		ep = __lookup_ip4_endpoint(daddr);
 		if (ep) {
 #if defined(ENABLE_HOST_ROUTING) || defined(ENABLE_ROUTING)
-			if (ep->flags & ENDPOINT_F_HOST) {
+			if (ep->flags & ENDPOINT_MASK_HOST_DELIVERY) {
 				if (is_defined(ENABLE_ROUTING)) {
 # ifdef HOST_IFINDEX
 					goto to_host;

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -140,7 +140,7 @@ not_esp:
 
 	/* Deliver to local (non-host) endpoint: */
 	ep = lookup_ip6_endpoint(ip6);
-	if (ep && !(ep->flags & ENDPOINT_F_HOST))
+	if (ep && !(ep->flags & ENDPOINT_MASK_HOST_DELIVERY))
 		return ipv6_local_delivery(ctx, l3_off, *identity, MARK_MAGIC_IDENTITY,
 					   ep, METRIC_INGRESS, false, true);
 
@@ -247,7 +247,7 @@ static __always_inline int handle_inter_cluster_revsnat(struct __ctx_buff *ctx,
 	ep = lookup_ip4_endpoint(ip4);
 	if (ep) {
 		/* We don't support inter-cluster SNAT from host */
-		if (ep->flags & ENDPOINT_F_HOST)
+		if (ep->flags & ENDPOINT_MASK_HOST_DELIVERY)
 			return ipv4_host_delivery(ctx, ip4);
 
 		return ipv4_local_delivery(ctx, ETH_HLEN, src_sec_identity,
@@ -448,7 +448,7 @@ not_esp:
 
 	/* Deliver to local (non-host) endpoint: */
 	ep = lookup_ip4_endpoint(ip4);
-	if (ep && !(ep->flags & ENDPOINT_F_HOST))
+	if (ep && !(ep->flags & ENDPOINT_MASK_HOST_DELIVERY))
 		return ipv4_local_delivery(ctx, ETH_HLEN, *identity, MARK_MAGIC_IDENTITY,
 					   ip4, ep, METRIC_INGRESS, false, true, 0);
 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -325,7 +325,9 @@ struct tunnel_value {
 	__u16 pad;
 } __packed;
 
-#define ENDPOINT_F_HOST		1 /* Special endpoint representing local host */
+#define ENDPOINT_F_HOST			1 /* Special endpoint representing local host */
+#define ENDPOINT_F_ATHOSTNS		2 /* Endpoint located at the host networking namespace */
+#define ENDPOINT_MASK_HOST_DELIVERY	(ENDPOINT_F_HOST | ENDPOINT_F_ATHOSTNS)
 
 /* Value of endpoint map */
 struct endpoint_info {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -396,6 +396,17 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 
 	// Skip BPF if the endpoint has no policy map
 	if e.isProperty(PropertySkipBPFPolicy) {
+		// Ingress endpoint needs entries in the endpoints map so that the return traffic,
+		// ARP, and IPv6 ND are delivered to the host stack in all datapath configurations.
+		if e.isProperty(PropertyAtHostNS) {
+			stats.mapSync.Start()
+			err = lxcmap.WriteEndpoint(datapathRegenCtxt.epInfoCache)
+			stats.mapSync.End(err == nil)
+			if err != nil {
+				return 0, fmt.Errorf("Exposing endpoint in endpoints BPF map failed: %w", err)
+			}
+		}
+
 		// Allow another builder to start while we wait for the proxy
 		if regenContext.DoneFunc != nil {
 			regenContext.DoneFunc()
@@ -632,6 +643,11 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 
 	// If dry mode is enabled, no further changes to BPF maps are performed
 	if e.isProperty(PropertySkipBPFPolicy) {
+		// Ingress endpoint needs epInfoCache for endpointmap population
+		if e.isProperty(PropertyAtHostNS) {
+			datapathRegenCtxt.epInfoCache = e.createEpInfoCache(currentDir)
+		}
+
 		if e.isProperty(PropertyFakeEndpoint) {
 			if err = e.writeHeaderfile(nextDir); err != nil {
 				return fmt.Errorf("Unable to write header file: %w", err)

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -177,3 +177,7 @@ func (ep *epInfoCache) GetPolicyVerdictLogFilter() uint32 {
 func (ep *epInfoCache) IsHost() bool {
 	return ep.endpoint.IsHost()
 }
+
+func (ep *epInfoCache) IsAtHostNS() bool {
+	return false
+}

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -38,6 +38,7 @@ type epInfoCache struct {
 	requireEgressProg      bool
 	requireRouting         bool
 	requireEndpointRoute   bool
+	atHostNS               bool
 	policyVerdictLogFilter uint32
 	options                *option.IntOptions
 	lxcMAC                 mac.MAC
@@ -55,7 +56,21 @@ type epInfoCache struct {
 
 // Must be called when endpoint is still locked.
 func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
-	ep := &epInfoCache{
+	if e.isProperty(PropertyAtHostNS) {
+		return &epInfoCache{
+			revision: e.nextPolicyRevision,
+
+			id:       e.GetID(),
+			identity: e.getIdentity(),
+			mac:      e.GetNodeMAC(),
+			ipv4:     e.IPv4Address(),
+			ipv6:     e.IPv6Address(),
+			atHostNS: true,
+
+			endpoint: e,
+		}
+	}
+	return &epInfoCache{
 		revision: e.nextPolicyRevision,
 
 		epdir:                  epdir,
@@ -78,7 +93,6 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 
 		endpoint: e,
 	}
-	return ep
 }
 
 func (ep *epInfoCache) GetIfIndex() int {
@@ -179,5 +193,5 @@ func (ep *epInfoCache) IsHost() bool {
 }
 
 func (ep *epInfoCache) IsAtHostNS() bool {
-	return false
+	return ep.atHostNS
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -72,6 +72,10 @@ const (
 	// means that it doesn't have any datapath bpf programs regenerated.
 	PropertyFakeEndpoint = "property-fake-endpoint"
 
+	// PropertyAtHostNS is used for endpoints that are reached via the host networking
+	// namespace, but have their own IP(s) from the node's pod CIDR range
+	PropertyAtHostNS = "property-at-host-network-namespace"
+
 	// PropertyWithouteBPFDatapath marks the endpoint that doesn't contain a
 	// eBPF datapath program.
 	PropertyWithouteBPFDatapath = "property-without-bpf-endpoint"
@@ -488,7 +492,7 @@ func (e *Endpoint) LXCMac() mac.MAC {
 }
 
 func (e *Endpoint) IsAtHostNS() bool {
-	return false
+	return e.isProperty(PropertyAtHostNS)
 }
 
 func (e *Endpoint) IsHost() bool {
@@ -615,10 +619,19 @@ func CreateIngressEndpoint(owner regeneration.Owner, policyGetter policyRepoGett
 	ep.DatapathConfiguration = NewDatapathConfiguration()
 
 	ep.isIngress = true
+
 	// An ingress endpoint is defined without a veth interface and no bpf
 	// programs or maps are created for it. Thus, we will set its properties
 	// to not have a bpf policy map nor a bpf datapath.
+
+	// Ingress endpoint is reachable via the host networking namespace
+	// Host delivery flag is set in lxcmap
+	ep.properties[PropertyAtHostNS] = true
+
+	// Ingress endpoint has no bpf policy maps
 	ep.properties[PropertySkipBPFPolicy] = true
+
+	// Ingress endpoint has no bpf programs
 	ep.properties[PropertyWithouteBPFDatapath] = true
 
 	// node.GetIngressIPv4 has been parsed with net.ParseIP() and may be in IPv4 mapped IPv6

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -487,6 +487,10 @@ func (e *Endpoint) LXCMac() mac.MAC {
 	return e.mac
 }
 
+func (e *Endpoint) IsAtHostNS() bool {
+	return false
+}
+
 func (e *Endpoint) IsHost() bool {
 	return e.isHost
 }

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -50,6 +50,10 @@ func LXCMap() *bpf.Map {
 const (
 	// EndpointFlagHost indicates that this endpoint represents the host
 	EndpointFlagHost = 1
+
+	// EndpointFlagAtHostNS indicates that this endpoint is located at the host networking
+	// namespace
+	EndpointFlagAtHostNS = 2
 )
 
 // EndpointFrontend is the interface to implement for an object to synchronize
@@ -62,6 +66,7 @@ type EndpointFrontend interface {
 	IPv4Address() netip.Addr
 	IPv6Address() netip.Addr
 	GetIdentity() identity.NumericIdentity
+	IsAtHostNS() bool
 }
 
 // GetBPFKeys returns all keys which should represent this endpoint in the BPF
@@ -102,6 +107,10 @@ func GetBPFValue(e EndpointFrontend) (*EndpointInfo, error) {
 		MAC:     mac,
 		NodeMAC: nodeMAC,
 		SecID:   e.GetIdentity().Uint32(), // Host byte-order
+	}
+
+	if e.IsAtHostNS() {
+		info.Flags |= EndpointFlagAtHostNS
 	}
 
 	return info, nil


### PR DESCRIPTION
Cilium agent manages Ingress endpoint for the purpose of policy generation for Cilium Ingress. The Ingress endpoint has IPs from the node's CIDR range like any other endpoint, but it does not have any representation at the bpf datapath, as it is only used for policy enforcement and for IP addressing at the Envoy proxy. Due to the lacking bpf datapath representation IPv6 ND does not currently work for the Ingress IPs, which causes IPv6 communication with backends not working.

Fix this by introducing minimal bpf datapath representation for the Ingress endpoint via Ingress endpoint entries in the lxcmap, which is used by the IPV6 ND implementation in the Cilium bpf datapath to enable ND advertisements to be sent when ND request for the Ingress IPv6 has been received.

A new endpoint flag ENDPOINT_F_ATHOSTNS is added to inform the datapath to deliver endpoint's traffic to the host stack, but for which ARP and IPv6 ND are still served by the bpf datapath due to the endpoint's IP being from the node's IP allocation CIDR range.

Fixes: #32980

```release-note
Ingress endpoint is now included in the lxcmap so that ARP and ND6 work for them.
```
