### PR TITLE
Rework error handling logic in neighbor discovery

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"syscall"
 
@@ -42,6 +43,7 @@ import (
 	"github.com/cilium/cilium/pkg/node/manager"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	ciliumslices "github.com/cilium/cilium/pkg/slices"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -594,6 +596,8 @@ func (n *linuxNodeHandler) NodeUpdate(oldNode, newNode nodeTypes.Node) error {
 	return nil
 }
 
+var errNodeIPNotRoutable = errors.New("remote node IP is non-routable")
+
 func getNextHopIP(nodeIP net.IP, link netlink.Link) (nextHopIP net.IP, err error) {
 	// Figure out whether nodeIP is directly reachable (i.e. in the same L2)
 	routes, err := netlink.RouteGetWithOptions(nodeIP, &netlink.RouteGetOptions{Oif: link.Attrs().Name, FIBMatch: true})
@@ -601,7 +605,7 @@ func getNextHopIP(nodeIP net.IP, link netlink.Link) (nextHopIP net.IP, err error
 		return nil, fmt.Errorf("failed to retrieve route for remote node IP: %w", err)
 	}
 	if len(routes) == 0 {
-		return nil, fmt.Errorf("remote node IP is non-routable")
+		return nil, errNodeIPNotRoutable
 	}
 
 	nextHopIP = nodeIP
@@ -892,19 +896,42 @@ func (n *linuxNodeHandler) insertNeighbor(ctx context.Context, newNode *nodeType
 	links = n.neighDiscoveryLinks
 	n.neighLock.Unlock()
 
-	var errs error
+	var (
+		errV4, errV6 error
+		errs         []error
+	)
+
+	// "node IP not routable" on a subset of the discovery links should not be considered a failure.
+	// Propagate an error only if no next hop can be inserted for any links, otherwise filter away
+	// those intermediate errors.
+
+	isNotRoutableErr := func(err error) bool {
+		return errors.Is(err, errNodeIPNotRoutable)
+	}
+
 	if newNode.GetNodeIP(false).To4() != nil {
 		for _, l := range links {
-			errs = errors.Join(errs, n.insertNeighbor4(ctx, newNode, l, refresh))
+			errs = append(errs, n.insertNeighbor4(ctx, newNode, l, refresh))
 		}
-	}
-	if newNode.GetNodeIP(true).To16() != nil {
-		for _, l := range links {
-			errs = errors.Join(errs, n.insertNeighbor6(ctx, newNode, l, refresh))
+		if ciliumslices.AllMatch(errs, isNotRoutableErr) {
+			errV4 = fmt.Errorf("unable to determine next hop address for any neighbor discovery link: %w", errors.Join(errs...))
+		} else {
+			errV4 = errors.Join(slices.DeleteFunc(errs, isNotRoutableErr)...)
 		}
 	}
 
-	return errs
+	if newNode.GetNodeIP(true).To16() != nil {
+		for _, l := range links {
+			errs = append(errs, n.insertNeighbor6(ctx, newNode, l, refresh))
+		}
+		if ciliumslices.AllMatch(errs, isNotRoutableErr) {
+			errV6 = fmt.Errorf("unable to determine next hop address for any neighbor discovery link: %w", errors.Join(errs...))
+		} else {
+			errV6 = errors.Join(slices.DeleteFunc(errs, isNotRoutableErr)...)
+		}
+	}
+
+	return errors.Join(errV4, errV6)
 }
 
 func (n *linuxNodeHandler) InsertMiscNeighbor(newNode *nodeTypes.Node) {

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -131,3 +131,15 @@ func XorNil[T any](s1, s2 []T) bool {
 	return s1 == nil && s2 != nil ||
 		s1 != nil && s2 == nil
 }
+
+// AllMatch returns true if pred is true for each element in s, false otherwise.
+// May not evaluate on all elements if not necessary for determining the result.
+// If the slice is empty then true is returned and predicate is not evaluated.
+func AllMatch[T any](s []T, pred func(v T) bool) bool {
+	for _, v := range s {
+		if !pred(v) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -323,6 +323,63 @@ func TestXorNil(t *testing.T) {
 	}
 }
 
+func TestAllMatch(t *testing.T) {
+	testCases := []struct {
+		name     string
+		s        []bool
+		pred     func(v bool) bool
+		expected bool
+	}{
+		{
+			name:     "nil slice",
+			s:        nil,
+			pred:     func(v bool) bool { return v },
+			expected: true,
+		},
+		{
+			name:     "empty slice",
+			s:        []bool{},
+			pred:     func(v bool) bool { return v },
+			expected: true,
+		},
+		{
+			name:     "one true element",
+			s:        []bool{true},
+			pred:     func(v bool) bool { return v },
+			expected: true,
+		},
+		{
+			name:     "one false element",
+			s:        []bool{false},
+			pred:     func(v bool) bool { return v },
+			expected: false,
+		},
+		{
+			name:     "all true elements",
+			s:        []bool{true, true, true},
+			pred:     func(v bool) bool { return v },
+			expected: true,
+		},
+		{
+			name:     "all false elements",
+			s:        []bool{false, false, false},
+			pred:     func(v bool) bool { return v },
+			expected: false,
+		},
+		{
+			name:     "true and false elements",
+			s:        []bool{false, true, true},
+			pred:     func(v bool) bool { return v },
+			expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, AllMatch(tc.s, tc.pred))
+		})
+	}
+}
+
 // BenchmarkUnique runs the Unique function on a slice of size elements, where each element
 // has a probability of 20% of being a duplicate.
 // At each iteration the slice is restored to its original status and reshuffled, in order


### PR DESCRIPTION
When a new node is discovered, in case of a multi-devices environment, we loop over each neighbor discovery link to found the next hop IP for the given node. For each link, if a next hop is found, it is inserted in the related neighNextHopByNode4 map.

In this setup, it is possible that a node is reachable only by a subset of the neighbor discovery links. This case should not be considered an error, as long as the node is reachable by at least one link. Therefore, the errors handling logic is changed to propagate an error only when it is not possible to find a next hop for any link.

This also reduces the amount of memory used for joining all the strings related to the false error condition described above, besides reducing the amount of useless retry runs of the node-neighbor-link-updater controller.

Related: https://github.com/cilium/cilium/issues/34020