### PR TITLE
endpoint: remove deprecated and unused (*Endpoint).HasBPFPolicyMap

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -46,12 +46,6 @@ var (
 	syncAddressIdentityMappingControllerGroup   = controller.NewGroup("sync-address-identity-mapping")
 )
 
-// HasBPFPolicyMap returns true if policy map changes should be collected
-// Deprecated: use (e *Endpoint).IsProperty(PropertySkipBPFPolicy)
-func (e *Endpoint) HasBPFPolicyMap() bool {
-	return !e.IsProperty(PropertySkipBPFPolicy)
-}
-
 // GetNamedPort returns the port for the given name.
 func (e *Endpoint) GetNamedPort(ingress bool, name string, proto u8proto.U8proto) uint16 {
 	if ingress {

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -73,7 +73,6 @@ type PolicyOwner interface {
 	GetID() uint64
 	LookupRedirectPort(ingress bool, protocol string, port uint16, listener string) (uint16, error)
 	GetRealizedRedirects() map[string]uint16
-	HasBPFPolicyMap() bool
 	GetNamedPort(ingress bool, name string, proto u8proto.U8proto) uint16
 	PolicyDebug(fields logrus.Fields, msg string)
 }

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -163,10 +163,6 @@ func (d DummyOwner) GetRealizedRedirects() map[string]uint16 {
 	}
 }
 
-func (d DummyOwner) HasBPFPolicyMap() bool {
-	return true
-}
-
 func (d DummyOwner) GetNamedPort(ingress bool, name string, proto u8proto.U8proto) uint16 {
 	return 80
 }


### PR DESCRIPTION
The last remaining caller was removed in commit 18706de50325 ("policy: Sync incremental updates"). The method is deprecated, so let's remove it.
