### PR TITLE
bpf: Policy map precedence by LPM prefix length

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -394,15 +394,21 @@ struct policy_key {
 struct policy_entry {
 	__be16		proxy_port;
 	__u8		deny:1,
-			wildcard_protocol:1, /* protocol is fully wildcarded */
-			wildcard_dport:1, /* dport is fully wildcarded */
-			pad:5;
+			pad:7;
 	__u8		auth_type;
-	__u16		pad1;
+	__u8		lpm_prefix_length; /* map key protocol and dport prefix length */
+	__u8		pad1;
 	__u16		pad2;
 	__u64		packets;
 	__u64		bytes;
 };
+
+/*
+ * LPM_FULL_PREFIX_BITS is the maximum length in 'lpm_prefix_bits' when none of the protocol or
+ * dport bits in the key are wildcarded.
+ */
+#define LPM_PROTO_PREFIX_BITS 8                             /* protocol specified */
+#define LPM_FULL_PREFIX_BITS (LPM_PROTO_PREFIX_BITS + 16)   /* protocol and dport specified */
 
 struct auth_key {
 	__u32       local_sec_label;

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -89,7 +89,10 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 	}
 #endif /* ALLOW_ICMP_FRAG_NEEDED || ENABLE_ICMP_RULE */
 
-	/* Policy match precedence:
+	/* Policy match precedence: Entries with longer prefix lengths get precedence. If both
+	 * entries have the same prefix length, then the one with non-wildcard L3 is chosen.
+	 * This is an extension of the following to fully support arbitrarily masked ports:
+	 *
 	 * 1. id/proto/port  (L3/L4)
 	 * 2. ANY/proto/port (L4-only)
 	 * 3. id/proto/ANY   (L3-proto)
@@ -99,10 +102,6 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 	 */
 
 	/* Start with L3/L4 lookup.
-	 * LPM precedence order with L3:
-	 * 1. id/proto/port
-	 * 3. id/proto/ANY (check L4-only match first)
-	 * 5. id/ANY/ANY   (check proto match first)
 	 *
 	 * Note: Untracked fragments always have zero ports in the tuple so they can
 	 * only match entries that have fully wildcarded ports.
@@ -112,7 +111,7 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 	/* This is a full L3/L4 match if port is not wildcarded,
 	 * need to check for L4-only policy first if it is.
 	 */
-	if (likely(policy && !policy->wildcard_dport)) {
+	if (likely(policy && policy->lpm_prefix_length == LPM_FULL_PREFIX_BITS)) {
 		cilium_dbg3(ctx, DBG_L4_CREATE, remote_id, local_id,
 			    dport << 16 | proto);
 		*match_type = POLICY_MATCH_L3_L4;		/* 1. id/proto/port */
@@ -121,40 +120,27 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 
 	/* L4-only lookup. */
 	key.sec_label = 0;
-	/* LPM precedence order without L3:
-	 * 2. ANY/proto/port
-	 * 4. ANY/proto/ANY
-	 * 6. ANY/ANY/ANY   == allow-all as L3 is zeroed in this lookup,
-	 *                     defer this until L3 match has been ruled out below.
-	 *
+	/*
 	 * Untracked fragments always have zero ports in the tuple so they can
 	 * only match entries that have fully wildcarded ports.
 	 */
 	l4policy = map_lookup_elem(map, &key);
 
-	if (likely(l4policy && !l4policy->wildcard_dport)) {
-		*match_type = POLICY_MATCH_L4_ONLY;		/* 2. ANY/proto/port */
-		goto check_l4_policy;
-	}
-
-	if (likely(policy && !policy->wildcard_protocol)) {
-		*match_type = POLICY_MATCH_L3_PROTO;		/* 3. id/proto/ANY */
-		goto check_policy;
-	}
-
-	if (likely(l4policy && !l4policy->wildcard_protocol)) {
-		*match_type = POLICY_MATCH_PROTO_ONLY;		/* 4. ANY/proto/ANY */
+	if (likely(l4policy &&
+		   (!policy || l4policy->lpm_prefix_length > policy->lpm_prefix_length))) {
+		__u8 p_len = l4policy->lpm_prefix_length;
+		*match_type =
+			p_len == 0 ? POLICY_MATCH_ALL :					/* 6. ANY/ANY/ANY */
+		  p_len <= LPM_PROTO_PREFIX_BITS ? POLICY_MATCH_PROTO_ONLY :	/* 4. ANY/proto/ANY */
+			POLICY_MATCH_L4_ONLY;						/* 2. ANY/proto/port */
 		goto check_l4_policy;
 	}
 
 	if (likely(policy)) {
-		*match_type = POLICY_MATCH_L3_ONLY;		/* 5. id/ANY/ANY */
+		__u8 p_len = policy->lpm_prefix_length;
+		*match_type = p_len > 0 ? POLICY_MATCH_L3_PROTO :	/* 3. id/proto/ANY */
+			POLICY_MATCH_L3_ONLY;				/* 5. id/ANY/ANY */
 		goto check_policy;
-	}
-
-	if (likely(l4policy)) {
-		*match_type = POLICY_MATCH_ALL;			/* 6. ANY/ANY/ANY */
-		goto check_l4_policy;
 	}
 
 	if (is_untracked_fragment)

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -57,8 +57,6 @@ type policyEntryFlags uint8
 
 const (
 	policyFlagDeny policyEntryFlags = 1 << iota
-	policyFlagWildcardNexthdr
-	policyFlagWildcardDestPort
 )
 
 func (pef policyEntryFlags) is(pf policyEntryFlags) bool {
@@ -73,12 +71,6 @@ func (pef policyEntryFlags) String() string {
 		str = append(str, "Deny")
 	} else {
 		str = append(str, "Allow")
-	}
-	if pef.is(policyFlagWildcardNexthdr) {
-		str = append(str, "WildcardProtocol")
-	}
-	if pef.is(policyFlagWildcardDestPort) {
-		str = append(str, "WildcardPort")
 	}
 
 	return strings.Join(str, ", ")
@@ -102,7 +94,7 @@ func (pe PolicyEntry) IsDeny() bool {
 }
 
 func (pe *PolicyEntry) String() string {
-	return fmt.Sprintf("%d %d %d", pe.GetProxyPort(), pe.Packets, pe.Bytes)
+	return fmt.Sprintf("%d %d %d %d", pe.GetProxyPort(), pe.LPMPrefixLength, pe.Packets, pe.Bytes)
 }
 
 func (pe *PolicyEntry) New() bpf.MapValue { return &PolicyEntry{} }
@@ -167,7 +159,8 @@ type PolicyEntry struct {
 	ProxyPortNetwork uint16           `align:"proxy_port"` // In network byte-order
 	Flags            policyEntryFlags `align:"deny"`
 	AuthType         uint8            `align:"auth_type"`
-	Pad1             uint16           `align:"pad1"`
+	LPMPrefixLength  uint8            `align:"lpm_prefix_length"`
+	Pad1             uint8            `align:"pad1"`
 	Pad2             uint16           `align:"pad2"`
 	Packets          uint64           `align:"packets"`
 	Bytes            uint64           `align:"bytes"`
@@ -179,9 +172,7 @@ func (pe *PolicyEntry) GetProxyPort() uint16 {
 }
 
 type policyEntryFlagParams struct {
-	IsDeny             bool
-	IsWildcardNexthdr  bool
-	IsWildcardDestPort bool
+	IsDeny bool
 }
 
 // getPolicyEntryFlags returns a policyEntryFlags from the policyEntryFlagParams.
@@ -190,12 +181,6 @@ func getPolicyEntryFlags(p policyEntryFlagParams) policyEntryFlags {
 
 	if p.IsDeny {
 		flags |= policyFlagDeny
-	}
-	if p.IsWildcardNexthdr {
-		flags |= policyFlagWildcardNexthdr
-	}
-	if p.IsWildcardDestPort {
-		flags |= policyFlagWildcardDestPort
 	}
 
 	return flags
@@ -336,11 +321,12 @@ func NewKey(trafficDirection trafficdirection.TrafficDirection, id identity.Nume
 
 // newEntry returns a PolicyEntry representing the specified parameters in
 // network byte-order.
-func newEntry(authType uint8, proxyPort uint16, flags policyEntryFlags) PolicyEntry {
+func newEntry(authType uint8, proxyPort uint16, prefixLen uint8, flags policyEntryFlags) PolicyEntry {
 	return PolicyEntry{
 		ProxyPortNetwork: byteorder.HostToNetwork16(proxyPort),
 		Flags:            flags,
 		AuthType:         authType,
+		LPMPrefixLength:  prefixLen,
 	}
 }
 
@@ -348,11 +334,8 @@ func newEntry(authType uint8, proxyPort uint16, flags policyEntryFlags) PolicyEn
 // network byte-order.
 // This is separated out to be used in unit testing.
 func newAllowEntry(key PolicyKey, authType uint8, proxyPort uint16) PolicyEntry {
-	pef := getPolicyEntryFlags(policyEntryFlagParams{
-		IsWildcardNexthdr:  key.Nexthdr == 0,
-		IsWildcardDestPort: key.DestPortNetwork == 0,
-	})
-	return newEntry(authType, proxyPort, pef)
+	prefixLen := uint8(key.Prefixlen - StaticPrefixBits)
+	return newEntry(authType, proxyPort, prefixLen, 0)
 }
 
 // newDenyEntry returns a deny PolicyEntry for the specified parameters in
@@ -360,11 +343,10 @@ func newAllowEntry(key PolicyKey, authType uint8, proxyPort uint16) PolicyEntry 
 // This is separated out to be used in unit testing.
 func newDenyEntry(key PolicyKey) PolicyEntry {
 	pef := getPolicyEntryFlags(policyEntryFlagParams{
-		IsDeny:             true,
-		IsWildcardNexthdr:  key.Nexthdr == 0,
-		IsWildcardDestPort: key.DestPortNetwork == 0,
+		IsDeny: true,
 	})
-	return newEntry(0, 0, pef)
+	prefixLen := uint8(key.Prefixlen - StaticPrefixBits)
+	return newEntry(0, 0, prefixLen, pef)
 }
 
 // AllowKey pushes an entry into the PolicyMap for the given PolicyKey k.

--- a/pkg/maps/policymap/policymap_test.go
+++ b/pkg/maps/policymap/policymap_test.go
@@ -174,6 +174,7 @@ func TestPolicyMapWildcarding(t *testing.T) {
 		op               opType
 		id               identity.NumericIdentity
 		dport            uint16
+		dportPrefixLen   uint8
 		proto            u8proto.U8proto
 		trafficDirection trafficdirection.TrafficDirection
 		authType         int
@@ -185,75 +186,85 @@ func TestPolicyMapWildcarding(t *testing.T) {
 	}{
 		{
 			name: "Allow, no wildcarding, no redirection",
-			args: args{allow, 42, 80, 6, ingress, 0, 0},
+			args: args{allow, 42, 80, 16, 6, ingress, 0, 0},
 		},
 		{
 			name: "Allow, no wildcarding, with redirection and auth",
-			args: args{allow, 42, 80, 6, ingress, 1, 23767},
+			args: args{allow, 42, 80, 16, 6, ingress, 1, 23767},
 		},
 		{
 			name: "Allow, wildcarded port, no redirection",
-			args: args{allow, 42, 0, 6, ingress, 0, 0},
+			args: args{allow, 42, 0, 0, 6, ingress, 0, 0},
 		},
 		{
 			name: "Allow, wildcarded protocol, no redirection",
-			args: args{allow, 42, 0, 0, ingress, 0, 0},
+			args: args{allow, 42, 0, 0, 0, ingress, 0, 0},
 		},
 		{
 			name: "Deny, no wildcarding, no redirection",
-			args: args{deny, 42, 80, 6, ingress, 0, 0},
+			args: args{deny, 42, 80, 16, 6, ingress, 0, 0},
+		},
+		{
+			name: "Deny, partially wildcarded port, no redirection",
+			args: args{deny, 42, 80, 15, 6, ingress, 0, 0},
 		},
 		{
 			name: "Deny, no wildcarding, no redirection",
-			args: args{deny, 42, 80, 6, ingress, 0, 0},
+			args: args{deny, 42, 80, 16, 6, ingress, 0, 0},
 		},
 		{
 			name: "Deny, wildcarded port, no redirection",
-			args: args{deny, 42, 0, 6, ingress, 0, 0},
+			args: args{deny, 42, 0, 0, 6, ingress, 0, 0},
 		},
 		{
 			name: "Deny, wildcarded protocol, no redirection",
-			args: args{deny, 42, 0, 0, ingress, 0, 0},
+			args: args{deny, 42, 0, 0, 0, ingress, 0, 0},
 		},
 		{
 			name: "Allow, wildcarded id, no port wildcarding, no redirection",
-			args: args{allow, 0, 80, 6, ingress, 0, 0},
+			args: args{allow, 0, 80, 16, 6, ingress, 0, 0},
 		},
 		{
 			name: "Allow, wildcarded id, no port wildcarding, with redirection and auth",
-			args: args{allow, 0, 80, 6, ingress, 1, 23767},
+			args: args{allow, 0, 80, 16, 6, ingress, 1, 23767},
 		},
 		{
 			name: "Allow, wildcarded id, wildcarded port, no redirection",
-			args: args{allow, 0, 0, 6, ingress, 0, 0},
+			args: args{allow, 0, 0, 0, 6, ingress, 0, 0},
+		},
+		{
+			name: "Allow, wildcarded id, partially wildcarded port, no redirection",
+			args: args{allow, 0, 80, 10, 6, ingress, 0, 0},
 		},
 		{
 			name: "Allow, wildcarded id, wildcarded protocol, no redirection",
-			args: args{allow, 0, 0, 0, ingress, 0, 0},
+			args: args{allow, 0, 0, 0, 0, ingress, 0, 0},
 		},
 		{
 			name: "Deny, wildcarded id, no port wildcarding, no redirection",
-			args: args{deny, 0, 80, 6, ingress, 0, 0},
+			args: args{deny, 0, 80, 16, 6, ingress, 0, 0},
 		},
 		{
 			name: "Deny, wildcarded id, no port wildcarding, no redirection",
-			args: args{deny, 0, 80, 6, ingress, 0, 0},
+			args: args{deny, 0, 80, 16, 6, ingress, 0, 0},
 		},
 		{
 			name: "Deny, wildcarded id, wildcarded port, no redirection",
-			args: args{deny, 0, 0, 6, ingress, 0, 0},
+			args: args{deny, 0, 0, 0, 6, ingress, 0, 0},
 		},
 		{
 			name: "Deny, wildcarded id, wildcarded protocol, no redirection",
-			args: args{deny, 0, 0, 0, ingress, 0, 0},
+			args: args{deny, 0, 0, 0, 0, ingress, 0, 0},
 		},
 	}
 	for _, tt := range tests {
 		// Validate test data
 		if tt.args.proto == 0 {
 			require.Equal(t, uint16(0), tt.args.dport, "Test: %s data error: dport must be wildcarded when protocol is wildcarded", tt.name)
+			require.Equal(t, uint8(0), tt.args.dportPrefixLen, "Test: %s data error: dport prefix length must be 0 when protocol is wildcarded", tt.name)
 		}
 		if tt.args.dport == 0 {
+			require.Equal(t, uint8(0), tt.args.dportPrefixLen, "Test: %s data error: dport prefix length must be 0 when dport is wildcarded", tt.name)
 			require.Equal(t, uint16(0), tt.args.proxyPort, "Test: %s data error: proxyPort must be zero when dport is wildcarded", tt.name)
 		}
 		if tt.args.op == deny {
@@ -262,7 +273,7 @@ func TestPolicyMapWildcarding(t *testing.T) {
 		}
 
 		// Get key
-		key := NewKey(tt.args.trafficDirection, tt.args.id, tt.args.proto, tt.args.dport, SinglePortPrefixLen)
+		key := NewKey(tt.args.trafficDirection, tt.args.id, tt.args.proto, tt.args.dport, tt.args.dportPrefixLen)
 
 		// Compure entry & validate key and entry
 		var entry PolicyEntry
@@ -283,20 +294,22 @@ func TestPolicyMapWildcarding(t *testing.T) {
 
 		require.Equal(t, uint32(tt.args.id), key.Identity)
 		require.Equal(t, uint8(tt.args.proto), key.Nexthdr)
+
+		// key and entry need to agree on the prefix length
+		require.Equal(t, StaticPrefixBits+uint32(entry.LPMPrefixLength), key.Prefixlen)
+
 		if key.Nexthdr == 0 {
-			require.Equal(t, policyFlagWildcardNexthdr, entry.Flags&policyFlagWildcardNexthdr)
 			require.Equal(t, uint16(0), key.DestPortNetwork)
-			require.Equal(t, policyFlagWildcardDestPort, entry.Flags&policyFlagWildcardDestPort)
 			require.Equal(t, StaticPrefixBits, key.Prefixlen)
+			require.Equal(t, uint8(0), entry.LPMPrefixLength)
 		} else {
-			require.Equal(t, policyEntryFlags(0), entry.Flags&policyFlagWildcardNexthdr)
 			if key.DestPortNetwork == 0 {
-				require.Equal(t, policyFlagWildcardDestPort, entry.Flags&policyFlagWildcardDestPort)
 				require.Equal(t, StaticPrefixBits+NexthdrBits, key.Prefixlen)
+				require.Equal(t, uint8(NexthdrBits), entry.LPMPrefixLength)
 			} else {
 				require.Equal(t, uint16(tt.args.dport), byteorder.NetworkToHost16(key.DestPortNetwork))
-				require.Equal(t, policyEntryFlags(0), entry.Flags&policyFlagWildcardDestPort)
-				require.Equal(t, StaticPrefixBits+FullPrefixBits, key.Prefixlen)
+				require.Equal(t, StaticPrefixBits+NexthdrBits+uint32(tt.args.dportPrefixLen), key.Prefixlen)
+				require.Equal(t, uint8(NexthdrBits)+tt.args.dportPrefixLen, entry.LPMPrefixLength)
 			}
 		}
 	}

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1387,24 +1387,12 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
-				},
 			}),
 			wantAdds: Keys{
 				ingressKey(1, 3, 64, 10): struct{}{},
-				ingressKey(1, 3, 80, 16): struct{}{},
 			},
 			wantDeletes: Keys{},
-			wantOld: MapStateMap{
-				ingressKey(0, 3, 80, 0): { // Dependents changed
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
-				},
-			},
+			wantOld:     MapStateMap{},
 		},
 		{
 			name: "test-15b-reverse - L3 port-range allow KV should not overwrite a wildcard deny entry",
@@ -1434,15 +1422,9 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
-				},
 			}),
 			wantAdds: Keys{
 				ingressKey(0, 3, 80, 16): struct{}{},
-				ingressKey(1, 3, 80, 16): struct{}{},
 			},
 			wantDeletes: Keys{},
 			wantOld:     MapStateMap{},


### PR DESCRIPTION
Policy map key can have nexthdr and destination port fields wildcarded. Cilium datapath typically performs two policy map lookups, one with the L3 identity mapped from the relevant IP address (destination or source IP for egress or ingress policy, respectively). Datapath chooses between the two policy entries based on two booleans in the policy entry: 'wildcarded_protocol' and 'wildcarded_dport'. The problem is that 'wildcarded_dport' is set only if the destination port is fully wildcarded, so partially wildcarded port is considered as "not wildcarded" for this logic.

Fix this for partially wildcarded ports by always choosing between L4-only and L3 policy matches by the key prefix length so that the most specific entry is always selected, selecting the entry with a specific identity if the prefix lengths are the same. That is, choose the policy with specific L3 if the prefixes are the same length, otherwise choose the policy with the longer prefix.

LPM map key already contains the prefix length, but unfortunately LPM map lookup does not return the map key. This is why we store an 8-bit version of the prefix length in the policy map entry, which is as follows:

0: both nexthdr and destination port fully wildcarded
8: nexthdr specified but port fully wildcarded
24: both nexthdr and destination port specified (no wildcarding)

Values between 8 and 24 represent the less or more wildcarded destination port.

Previously used wildcarded_protocol and wildcarded_dport flags are removed as redundant.

Before this change the precedence between the following two rules:

1. \<ID\>/TCP/80/15 -- L3 <ID> specified, TCP port 80 partially wildcarded (ports 80-81)
2. */TCP/80/16 -- L3 wildcarded, TCP port 80 not wildcarded

would have resulted in selecting the policy with \<ID\> specified even when it's destination port is partially wildcarded, while the L4-only rule has no wildcarding in it's destination port.

If the entries above were allow (1) and deny (3), Cilium agent masked this behavior by adding an additional deny entry in this case:

3. \<ID\>/TCP/80/16 -- L3 \<ID\> specified, TCP port 80 not wildcarded

This masks the incorrect behavior for allow/deny case, since the non-wildcarded key (3) is given precedence by the datapath.

There is no such additional entry logic in the allow/allow case, so if the more specific L4-only policy entry has L7 policy, and the less specific L3 policy not, then matching traffic would not be sent to the L7 proxy for policy enforcement.

After this change the policy with less L4 wildcarding (the more specific L4) is given precedence, with L3 rule being selected when prefixes are of the same length. This allows for simplifying policy map computation by avoiding the need to add additional entries in cases where deny already has the longer prefix length.

This change makes no difference for keys which only have the destination port fully specified or fully wildcarded, so this only affects policies with port ranges as enabled in Cilium 1.16.

Removal of the additional deny entries enabled by this change make `BenchmarkRegenerateCIDRDenyPolicyRules` ~10% faster due to reduced allocations.

Fixes: #23885

```release-note
Cilium datapath now gives precedence for the more specific allow rule with L7 rules when rules with port ranges are present.
```
