### PR TITLE
[v1.15] test/k8s: replace L7 visibility Pod annotations by L7 visibility policy

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -79,9 +79,6 @@ include:
     cliFocus: "K8sAgentPolicyTest Multi-node policy test validates ingress"
 
   ###
-  # K8sAgentPolicyTest Basic Test Traffic redirections to proxy Tests DNS proxy visibility without policy
-  # K8sAgentPolicyTest Basic Test Traffic redirections to proxy Tests HTTP proxy visibility without policy
-  # K8sAgentPolicyTest Basic Test Traffic redirections to proxy Tests proxy visibility interactions with policy lifecycle operations
   # K8sPolicyTestExtended Validate toEntities KubeAPIServer Allows connection to KubeAPIServer
   # K8sPolicyTestExtended Validate toEntities KubeAPIServer Denies connection to KubeAPIServer
   # K8sPolicyTestExtended Validate toEntities KubeAPIServer Still allows connection to KubeAPIServer with a duplicate policy

--- a/test/k8s/manifests/l7-policy-visibility.yaml
+++ b/test/k8s/manifests/l7-policy-visibility.yaml
@@ -1,0 +1,16 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "l7-visibility"
+spec:
+  endpointSelector:
+    matchLabels:
+      id: app1
+      zgroup: testapp
+  ingress:
+  - toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+      rules:
+        http: [{}]


### PR DESCRIPTION
Manual backport of the first commit in https://github.com/cilium/cilium/pull/35019 per https://github.com/cilium/cilium/pull/35019#pullrequestreview-2339937363

L7 visibility using Pod annotations is deprecated and the feature will be removed in Cilium 1.17. Switch `K8sAgentHubbleTest` still using it to use L7 visibility policy instead.