### PR TITLE
[v1.16] ginkgo: disable test for deprecated annotations-based L7 visibility

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -81,9 +81,6 @@ include:
     cliFocus: "K8sAgentPolicyTest Multi-node policy test validates ingress"
 
   ###
-  # K8sAgentPolicyTest Basic Test Traffic redirections to proxy Tests DNS proxy visibility without policy
-  # K8sAgentPolicyTest Basic Test Traffic redirections to proxy Tests HTTP proxy visibility without policy
-  # K8sAgentPolicyTest Basic Test Traffic redirections to proxy Tests proxy visibility interactions with policy lifecycle operations
   # K8sAgentPolicyTest Basic Test Traffic redirections to proxy Tests proxy visibility with L7 default-allow rules
   # K8sAgentPolicyTest Basic Test Traffic redirections to proxy Tests proxy visibility with L7 rules
   # K8sPolicyTestExtended Validate toEntities KubeAPIServer Allows connection to KubeAPIServer

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -18,8 +18,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/annotation"
-	"github.com/cilium/cilium/pkg/policy"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 )
@@ -135,13 +133,11 @@ var _ = SkipDescribeIf(func() bool {
 			var (
 				// track which app1 pod we care about, and its corresponding
 				// cilium pod.
-				app1Pod     string
-				app2Pod     string
-				ciliumPod   string
-				nodeName    string
-				appPods     map[string]string
-				app1PodIP   string
-				worldTarget = "http://vagrant-cache.ci.cilium.io"
+				app1Pod   string
+				ciliumPod string
+				nodeName  string
+				appPods   map[string]string
+				app1PodIP string
 			)
 
 			BeforeAll(func() {
@@ -153,14 +149,6 @@ var _ = SkipDescribeIf(func() bool {
 				for k, v := range podsNodes {
 					app1Pod = k
 					nodeName = v
-					break
-				}
-
-				podsNodes, err = kubectl.GetPodsNodes(namespaceForTest, "id=app2")
-				Expect(err).To(BeNil(), "error getting pod->node mapping")
-				Expect(len(podsNodes)).To(Equal(1))
-				for k := range podsNodes {
-					app2Pod = k
 					break
 				}
 
@@ -187,62 +175,29 @@ var _ = SkipDescribeIf(func() bool {
 			})
 
 			AfterEach(func() {
-				// Remove the proxy visibility annotation - this is done by specifying the annotation followed by a '-'.
-				kubectl.Exec(fmt.Sprintf("%s annotate pod %s -n %s %s-", helpers.KubectlCmd, appPods[helpers.App1], namespaceForTest, annotation.ProxyVisibility))
-				kubectl.Exec(fmt.Sprintf("%s annotate pod %s -n %s %s-", helpers.KubectlCmd, appPods[helpers.App2], namespaceForTest, annotation.ProxyVisibility))
 				cmd := fmt.Sprintf("%s delete --all cnp,ccnp,netpol -n %s", helpers.KubectlCmd, namespaceForTest)
 				_ = kubectl.Exec(cmd)
 			})
 
-			checkProxyRedirection := func(resource string, redirected bool, parser policy.L7ParserType, retryCurl bool) {
+			checkProxyHTTPRedirection := func(resource string) {
 				var (
-					not           = " "
-					filter        string // jsonpath filter
-					expect        string // expected result
-					curlCmd       string
 					hubbleTimeout = 10 * time.Second
 				)
 
-				if !redirected {
-					not = " not "
-				}
+				filter := "{.flow.destination.namespace} {.flow.l7.type} {.flow.l7.http.url} {.flow.l7.http.code} {.flow.l7.http.method}"
+				expect := fmt.Sprintf(
+					"%s RESPONSE %s 200 GET",
+					namespaceForTest,
+					fmt.Sprintf("http://%s/public", resource),
+				)
 
-				switch parser {
-				case policy.ParserTypeDNS:
-					// response DNS L7 flow
-					filter = "{.flow.destination.namespace} {.flow.l7.type} {.flow.l7.dns.query}"
-					expect = fmt.Sprintf(
-						"%s RESPONSE %s",
-						namespaceForTest,
-						"vagrant-cache.ci.cilium.io.",
-					)
-					if retryCurl {
-						curlCmd = helpers.CurlWithRetries(resource, 5, true)
-					} else {
-						curlCmd = helpers.CurlFail(resource)
-					}
-				case policy.ParserTypeHTTP:
-					filter = "{.flow.destination.namespace} {.flow.l7.type} {.flow.l7.http.url} {.flow.l7.http.code} {.flow.l7.http.method}"
-					expect = fmt.Sprintf(
-						"%s RESPONSE %s 200 GET",
-						namespaceForTest,
-						fmt.Sprintf("http://%s/public", resource),
-					)
-
-					if retryCurl {
-						curlCmd = helpers.CurlWithRetries(fmt.Sprintf("http://%s/public", resource), 5, true)
-					} else {
-						curlCmd = helpers.CurlFail(fmt.Sprintf("http://%s/public", resource))
-					}
-				default:
-					Fail(fmt.Sprintf("invalid parser type for proxy visibility: %s", parser))
-				}
+				curlCmd := helpers.CurlFail(fmt.Sprintf("http://%s/public", resource))
 
 				observeFile := fmt.Sprintf("hubble-observe-%s", uuid.New().String())
 
 				// curl commands are issued from the first k8s worker where all
 				// the app instances are running
-				By("Starting hubble observe and generating traffic which should%s redirect to proxy", not)
+				By("Starting hubble observe and generating traffic which should redirect to proxy")
 				ctx, cancel := context.WithCancel(context.Background())
 				hubbleRes, err := kubectl.HubbleObserveFollow(
 					ctx, ciliumPod,
@@ -267,78 +222,10 @@ var _ = SkipDescribeIf(func() bool {
 				time.Sleep(2 * time.Second)
 				res.ExpectSuccess("%q cannot curl %q", appPods[helpers.App2], resource)
 
-				By("Checking that aforementioned traffic was%sredirected to the proxy", not)
+				By("Checking that aforementioned traffic was redirected to the proxy")
 				err = hubbleRes.WaitUntilMatchFilterLineTimeout(filter, expect, hubbleTimeout)
-				if redirected {
-					ExpectWithOffset(1, err).To(BeNil(), "traffic was not redirected to the proxy when it should have been")
-				} else {
-					ExpectWithOffset(1, err).ToNot(BeNil(), "traffic was redirected to the proxy when it should have not been redirected")
-				}
-
-				if parser == policy.ParserTypeDNS && redirected {
-					By("Checking that Hubble is correctly annotating the DNS names")
-					res := kubectl.HubbleObserve(ciliumPod,
-						fmt.Sprintf("--last 1 --from-pod %s/%s --to-fqdn %q",
-							namespaceForTest, appPods[helpers.App2], "*.cilium.io"))
-					res.ExpectContainsFilterLine("{.flow.destination_names[0]}", "vagrant-cache.ci.cilium.io")
-				}
+				ExpectWithOffset(1, err).To(BeNil(), "traffic was not redirected to the proxy when it should have been")
 			}
-
-			proxyVisibilityTest := func(resource, podToAnnotate, anno string, parserType policy.L7ParserType, retryCurl bool) {
-				checkProxyRedirection(resource, false, parserType, retryCurl)
-
-				By("Annotating %s with %s", podToAnnotate, anno)
-				res := kubectl.Exec(fmt.Sprintf("%s annotate pod %s -n %s %s=\"%s\"", helpers.KubectlCmd, podToAnnotate, namespaceForTest, annotation.ProxyVisibility, anno))
-				res.ExpectSuccess("annotating pod with proxy visibility annotation failed")
-				Expect(kubectl.CiliumEndpointWaitReady()).To(BeNil())
-
-				checkProxyRedirection(resource, true, parserType, retryCurl)
-
-				By("Removing proxy visibility annotation on %s", podToAnnotate)
-				kubectl.Exec(fmt.Sprintf("%s annotate pod %s -n %s %s-", helpers.KubectlCmd, podToAnnotate, namespaceForTest, annotation.ProxyVisibility)).ExpectSuccess()
-				Expect(kubectl.CiliumEndpointWaitReady()).To(BeNil())
-
-				checkProxyRedirection(resource, false, parserType, retryCurl)
-			}
-
-			It("Tests HTTP proxy visibility without policy", func() {
-				proxyVisibilityTest(app1PodIP, app1Pod, "<Ingress/80/TCP/HTTP>", policy.ParserTypeHTTP, false)
-			})
-
-			It("Tests DNS proxy visibility without policy", func() {
-				proxyVisibilityTest(worldTarget, app2Pod, "<Egress/53/UDP/DNS>", policy.ParserTypeDNS, true)
-			})
-
-			It("Tests proxy visibility interactions with policy lifecycle operations", func() {
-				checkProxyRedirection(app1PodIP, false, policy.ParserTypeHTTP, false)
-
-				By("Annotating %s with <Ingress/80/TCP/HTTP>", app1Pod)
-				res := kubectl.Exec(fmt.Sprintf("%s annotate pod %s -n %s %s=\"<Ingress/80/TCP/HTTP>\"", helpers.KubectlCmd, app1Pod, namespaceForTest, annotation.ProxyVisibility))
-				res.ExpectSuccess("annotating pod with proxy visibility annotation failed")
-				Expect(kubectl.CiliumEndpointWaitReady()).To(BeNil())
-
-				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
-
-				By("Importing policy which selects app1")
-
-				_, err := kubectl.CiliumPolicyAction(
-					namespaceForTest, l3Policy, helpers.KubectlApply, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(),
-					"policy %s cannot be applied in %q namespace", l3Policy, namespaceForTest)
-
-				By("Checking that proxy visibility annotation is still applied even while a policy was imported")
-				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
-
-				_, err = kubectl.CiliumPolicyAction(
-					namespaceForTest, l3Policy, helpers.KubectlDelete, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(),
-					"policy %s cannot be deleted in %q namespace", l3Policy, namespaceForTest)
-
-				By("Checking that proxy visibility annotation is still applied after policy is removed")
-				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
-
-				By("Importing policy using named ports which selects app1; proxy-visibility annotation should remain")
-			})
 
 			It("Tests proxy visibility with L7 rules", func() {
 				By("Creating a l7 policy for the pod")
@@ -348,7 +235,7 @@ var _ = SkipDescribeIf(func() bool {
 					"policy %s cannot be applied in %q namespace", l3Policy, namespaceForTest)
 
 				By("Checking that traffic is proxied")
-				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
+				checkProxyHTTPRedirection(app1PodIP)
 
 				By("Checking that ping is blocked")
 				res := kubectl.ExecPodCmd(
@@ -365,7 +252,7 @@ var _ = SkipDescribeIf(func() bool {
 					"policy %s cannot be applied in %q namespace", l3Policy, namespaceForTest)
 
 				By("Checking that traffic is proxied")
-				checkProxyRedirection(app1PodIP, true, policy.ParserTypeHTTP, false)
+				checkProxyHTTPRedirection(app1PodIP)
 
 				By("Checking that ping is allowed")
 				res := kubectl.ExecPodCmd(


### PR DESCRIPTION
Follow-up for https://github.com/cilium/cilium/pull/35151 as suggested by @aanm.

Extracted from upstream commit 358477e24ae3b57f4d299d68563ea58940d8c438

Disable and delete the tests for annotations-based L7 visibility.