### PR TITLE
fix: fix slice init length

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1079,7 +1079,7 @@ func (kub *Kubectl) GetAllPods(ctx context.Context, options ...ExecOptions) ([]v
 		return nil, err
 	}
 
-	pods := make([]v1.Pod, len(podsList.Items))
+	pods := make([]v1.Pod, 0, len(podsList.Items))
 	for _, item := range podsList.Items {
 		var pod v1.Pod
 		err = json.Unmarshal(item.Raw, &pod)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

The intention here should be to initialize a slice with a capacity of  len(podsList.Items)   rather than initializing the length of this slice.

```release-note
Fix bug in testsuite where a list of Pods was initialized with several empty elements rather than allocating the buffer with space for enough elements.
```
