### PR TITLE
bgpv2: fix reconciliation of services with shared VIPs

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool.go
@@ -113,33 +113,15 @@ func (r *PodIPPoolReconciler) reconcilePaths(ctx context.Context, p ReconcilePar
 	}
 
 	metadata := r.getMetadata(p.BGPInstance)
-	for poolKey, desiredPoolAFPaths := range poolsAFPaths {
-		currentPoolAFPaths, exists := metadata.PoolAFPaths[poolKey]
-		if !exists && len(desiredPoolAFPaths) == 0 {
-			// No paths to reconcile for this pool.
-			continue
-		}
 
-		updatedPoolAFPaths, rErr := ReconcileAFPaths(&ReconcileAFPathsParams{
-			Logger: r.logger.WithFields(
-				logrus.Fields{
-					types.InstanceLogField:  p.DesiredConfig.Name,
-					types.PodIPPoolLogField: poolKey,
-				}),
-			Ctx:          ctx,
-			Router:       p.BGPInstance.Router,
-			DesiredPaths: desiredPoolAFPaths,
-			CurrentPaths: currentPoolAFPaths,
-		})
+	metadata.PoolAFPaths, err = ReconcileResourceAFPaths(ReconcileResourceAFPathsParams{
+		Logger:                 r.logger.WithField(types.InstanceLogField, p.DesiredConfig.Name),
+		Ctx:                    ctx,
+		Router:                 p.BGPInstance.Router,
+		DesiredResourceAFPaths: poolsAFPaths,
+		CurrentResourceAFPaths: metadata.PoolAFPaths,
+	})
 
-		if rErr == nil && len(desiredPoolAFPaths) == 0 {
-			// No paths left for this pool.
-			delete(metadata.PoolAFPaths, poolKey)
-		} else {
-			metadata.PoolAFPaths[poolKey] = updatedPoolAFPaths
-		}
-		err = errors.Join(err, rErr)
-	}
 	r.setMetadata(p.BGPInstance, metadata)
 	return err
 }

--- a/pkg/bgpv1/types/fake_router.go
+++ b/pkg/bgpv1/types/fake_router.go
@@ -5,10 +5,14 @@ package types
 
 import "context"
 
-type FakeRouter struct{}
+type FakeRouter struct {
+	paths map[string]*Path
+}
 
 func NewFakeRouter() Router {
-	return &FakeRouter{}
+	return &FakeRouter{
+		paths: make(map[string]*Path),
+	}
 }
 
 func (f *FakeRouter) Stop() {}
@@ -31,10 +35,13 @@ func (f *FakeRouter) ResetNeighbor(ctx context.Context, r ResetNeighborRequest) 
 
 func (f *FakeRouter) AdvertisePath(ctx context.Context, p PathRequest) (PathResponse, error) {
 	path := p.Path
+	f.paths[path.NLRI.String()] = path
 	return PathResponse{path}, nil
 }
 
 func (f *FakeRouter) WithdrawPath(ctx context.Context, p PathRequest) error {
+	path := p.Path
+	delete(f.paths, path.NLRI.String())
 	return nil
 }
 
@@ -51,7 +58,14 @@ func (f *FakeRouter) GetPeerState(ctx context.Context) (GetPeerStateResponse, er
 }
 
 func (f *FakeRouter) GetRoutes(ctx context.Context, r *GetRoutesRequest) (*GetRoutesResponse, error) {
-	return nil, nil
+	var routes []*Route
+	for _, path := range f.paths {
+		routes = append(routes, &Route{
+			Prefix: path.NLRI.String(),
+			Paths:  []*Path{path},
+		})
+	}
+	return &GetRoutesResponse{Routes: routes}, nil
 }
 
 func (f *FakeRouter) GetRoutePolicies(ctx context.Context) (*GetRoutePoliciesResponse, error) {

--- a/pkg/bgpv1/types/log.go
+++ b/pkg/bgpv1/types/log.go
@@ -42,4 +42,7 @@ const (
 
 	// PolicyLogField is used as key for BGP policy in the log field.
 	PolicyLogField = "policy"
+
+	// ResourceLogField is used as key for k8s resource in the log field.
+	ResourceLogField = "resource"
 )


### PR DESCRIPTION
As multiple services can share the same VIP (e.g. using `lbipam.cilium.io/sharing-key`), the service reconciliation logic needs to be adapted to not withdraw a route to VIP that is still in use by some other service.

To address that, this change introduces resource reference counting by reconciling service advertisements.

This fix is specific to BGPv2 service reconciliation only.

Part of https://github.com/cilium/cilium/issues/35018 (BGPv2 only)

