### PR TITLE
ci: run internal to NodePort test

### DIFF
--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -291,9 +291,11 @@ jobs:
           curl -s -v --connect-timeout 5 --max-time 20 --retry 3 --fail -- http://"$lb"/details/1
 
       - name: Run Sanity check (internal to NodePort)
-        if: ${{ matrix.kube-proxy-replacement == 'true' }}
         timeout-minutes: 5
         run: |
+          echo ${{ matrix.kube-proxy-replacement }}
+          echo ${{ matrix.kube-proxy-replacement == true }}
+          echo ${{ matrix.kube-proxy-replacement == 'true' }}
           if [ ${{ matrix.loadbalancer-mode }} = "dedicated" ]; then
             node_port=$(kubectl get svc cilium-ingress-basic-ingress -o jsonpath='{.spec.ports[?(@.port==80)].nodePort}')
           else


### PR DESCRIPTION
Currently, we were skipping internal to NodePort test for all matrix entries.

Fixes: #27304
