### PR TITLE
CI: Add list and filter artifacts steps

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -355,16 +355,41 @@ jobs:
     runs-on: ubuntu-latest
     needs: installation-and-connectivity
     steps:
+      # TODO remove list and filter artifact steps if this PR https://github.com/actions/upload-artifact/pull/521 is merged
+      - name: List All Artifacts
+        id: list_artifacts
+        run: |
+          echo "Fetching artifacts"
+          curl --fail --show-error --silent \
+               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+               | jq -r '.artifacts[] | .name' > artifacts_list.json
+      - name: Filter Artifacts
+        id: filter_artifacts
+        run: |
+          echo "Filtered Artifacts starts with cilium-sysdumps:"
+          if grep -E "^cilium-sysdumps-" artifacts_list.json; then
+            echo "sysdumps=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-sysdumps-* artifacts found."
+          fi
+          echo "Filtered Artifacts starts with cilium-junits:"
+          if grep -E "^cilium-junits-" artifacts_list.json; then
+            echo "junits=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-junits-* artifacts found."
+          fi
       - name: Merge Sysdumps
-        if: ${{ needs.installation-and-connectivity.result == 'failure' }}
+        if: ${{ steps.filter_artifacts.outputs.sysdumps == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-sysdumps
           pattern: cilium-sysdumps-*
           retention-days: 5
           delete-merged: true
-        continue-on-error: true
       - name: Merge JUnits
+        if: ${{ steps.filter_artifacts.outputs.junits == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-junits

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -351,16 +351,41 @@ jobs:
     runs-on: ubuntu-latest
     needs: installation-and-connectivity
     steps:
+      # TODO remove list and filter artifact steps if this PR https://github.com/actions/upload-artifact/pull/521 is merged
+      - name: List All Artifacts
+        id: list_artifacts
+        run: |
+          echo "Fetching artifacts"
+          curl --fail --show-error --silent \
+               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+               | jq -r '.artifacts[] | .name' > artifacts_list.json
+      - name: Filter Artifacts
+        id: filter_artifacts
+        run: |
+          echo "Filtered Artifacts starts with cilium-sysdumps:"
+          if grep -E "^cilium-sysdumps-" artifacts_list.json; then
+            echo "sysdumps=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-sysdumps-* artifacts found."
+          fi
+          echo "Filtered Artifacts starts with cilium-junits:"
+          if grep -E "^cilium-junits-" artifacts_list.json; then
+            echo "junits=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-junits-* artifacts found."
+          fi
       - name: Merge Sysdumps
-        if: ${{ needs.installation-and-connectivity.result == 'failure' }}
+        if: ${{ steps.filter_artifacts.outputs.sysdumps == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-sysdumps
           pattern: cilium-sysdumps-*
           retention-days: 5
           delete-merged: true
-        continue-on-error: true
       - name: Merge JUnits
+        if: ${{ steps.filter_artifacts.outputs.junits == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-junits

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -636,16 +636,41 @@ jobs:
     runs-on: ubuntu-latest
     needs: installation-and-connectivity
     steps:
+      # TODO remove list and filter artifact steps if this PR https://github.com/actions/upload-artifact/pull/521 is merged
+      - name: List All Artifacts
+        id: list_artifacts
+        run: |
+          echo "Fetching artifacts"
+          curl --fail --show-error --silent \
+               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+               | jq -r '.artifacts[] | .name' > artifacts_list.json
+      - name: Filter Artifacts
+        id: filter_artifacts
+        run: |
+          echo "Filtered Artifacts starts with cilium-sysdumps:"
+          if grep -E "^cilium-sysdumps-" artifacts_list.json; then
+            echo "sysdumps=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-sysdumps-* artifacts found."
+          fi
+          echo "Filtered Artifacts starts with cilium-junits:"
+          if grep -E "^cilium-junits-" artifacts_list.json; then
+            echo "junits=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-junits-* artifacts found."
+          fi
       - name: Merge Sysdumps
-        if: ${{ needs.installation-and-connectivity.result == 'failure' }}
+        if: ${{ steps.filter_artifacts.outputs.sysdumps == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-sysdumps
           pattern: cilium-sysdumps-*
           retention-days: 5
           delete-merged: true
-        continue-on-error: true
       - name: Merge JUnits
+        if: ${{ steps.filter_artifacts.outputs.junits == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-junits

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -403,16 +403,41 @@ jobs:
     runs-on: ubuntu-latest
     needs: installation-and-connectivity
     steps:
+      # TODO remove list and filter artifact steps if this PR https://github.com/actions/upload-artifact/pull/521 is merged
+      - name: List All Artifacts
+        id: list_artifacts
+        run: |
+          echo "Fetching artifacts"
+          curl --fail --show-error --silent \
+               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+               | jq -r '.artifacts[] | .name' > artifacts_list.json
+      - name: Filter Artifacts
+        id: filter_artifacts
+        run: |
+          echo "Filtered Artifacts starts with cilium-sysdumps:"
+          if grep -E "^cilium-sysdumps-" artifacts_list.json; then
+            echo "sysdumps=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-sysdumps-* artifacts found."
+          fi
+          echo "Filtered Artifacts starts with cilium-junits:"
+          if grep -E "^cilium-junits-" artifacts_list.json; then
+            echo "junits=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-junits-* artifacts found."
+          fi
       - name: Merge Sysdumps
-        if: ${{ needs.installation-and-connectivity.result == 'failure' }}
+        if: ${{ steps.filter_artifacts.outputs.sysdumps == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-sysdumps
           pattern: cilium-sysdumps-*
           retention-days: 5
           delete-merged: true
-        continue-on-error: true
       - name: Merge JUnits
+        if: ${{ steps.filter_artifacts.outputs.junits == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-junits

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -415,16 +415,41 @@ jobs:
     runs-on: ubuntu-latest
     needs: installation-and-connectivity
     steps:
+      # TODO remove list and filter artifact steps if this PR https://github.com/actions/upload-artifact/pull/521 is merged
+      - name: List All Artifacts
+        id: list_artifacts
+        run: |
+          echo "Fetching artifacts"
+          curl --fail --show-error --silent \
+               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+               | jq -r '.artifacts[] | .name' > artifacts_list.json
+      - name: Filter Artifacts
+        id: filter_artifacts
+        run: |
+          echo "Filtered Artifacts starts with cilium-sysdumps:"
+          if grep -E "^cilium-sysdumps-" artifacts_list.json; then
+            echo "sysdumps=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-sysdumps-* artifacts found."
+          fi
+          echo "Filtered Artifacts starts with cilium-junits:"
+          if grep -E "^cilium-junits-" artifacts_list.json; then
+            echo "junits=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-junits-* artifacts found."
+          fi
       - name: Merge Sysdumps
-        if: ${{ needs.installation-and-connectivity.result == 'failure' }}
+        if: ${{ steps.filter_artifacts.outputs.sysdumps == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-sysdumps
           pattern: cilium-sysdumps-*
           retention-days: 5
           delete-merged: true
-        continue-on-error: true
       - name: Merge JUnits
+        if: ${{ steps.filter_artifacts.outputs.junits == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-junits

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -478,16 +478,41 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-and-test
     steps:
+      # TODO remove list and filter artifact steps if this PR https://github.com/actions/upload-artifact/pull/521 is merged
+      - name: List All Artifacts
+        id: list_artifacts
+        run: |
+          echo "Fetching artifacts"
+          curl --fail --show-error --silent \
+               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+               | jq -r '.artifacts[] | .name' > artifacts_list.json
+      - name: Filter Artifacts
+        id: filter_artifacts
+        run: |
+          echo "Filtered Artifacts starts with cilium-sysdumps:"
+          if grep -E "^cilium-sysdumps-" artifacts_list.json; then
+            echo "sysdumps=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-sysdumps-* artifacts found."
+          fi
+          echo "Filtered Artifacts starts with cilium-junits:"
+          if grep -E "^cilium-junits-" artifacts_list.json; then
+            echo "junits=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-junits-* artifacts found."
+          fi
       - name: Merge Sysdumps
-        if: ${{ needs.setup-and-test.result == 'failure' }}
+        if: ${{ steps.filter_artifacts.outputs.sysdumps == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-sysdumps
           pattern: cilium-sysdumps-*
           retention-days: 5
           delete-merged: true
-        continue-on-error: true
       - name: Merge JUnits
+        if: ${{ steps.filter_artifacts.outputs.junits == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-junits

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -364,16 +364,41 @@ jobs:
     runs-on: ubuntu-latest
     needs: installation-and-connectivity
     steps:
+      # TODO remove list and filter artifact steps if this PR https://github.com/actions/upload-artifact/pull/521 is merged
+      - name: List All Artifacts
+        id: list_artifacts
+        run: |
+          echo "Fetching artifacts"
+          curl --fail --show-error --silent \
+               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+               | jq -r '.artifacts[] | .name' > artifacts_list.json
+      - name: Filter Artifacts
+        id: filter_artifacts
+        run: |
+          echo "Filtered Artifacts starts with cilium-sysdumps:"
+          if grep -E "^cilium-sysdumps-" artifacts_list.json; then
+            echo "sysdumps=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-sysdumps-* artifacts found."
+          fi
+          echo "Filtered Artifacts starts with cilium-junits:"
+          if grep -E "^cilium-junits-" artifacts_list.json; then
+            echo "junits=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-junits-* artifacts found."
+          fi
       - name: Merge Sysdumps
-        if: ${{ needs.installation-and-connectivity.result == 'failure' }}
+        if: ${{ steps.filter_artifacts.outputs.sysdumps == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-sysdumps
           pattern: cilium-sysdumps-*
           retention-days: 5
           delete-merged: true
-        continue-on-error: true
       - name: Merge JUnits
+        if: ${{ steps.filter_artifacts.outputs.junits == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-junits

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -439,16 +439,41 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-and-test
     steps:
+      # TODO remove list and filter artifact steps if this PR https://github.com/actions/upload-artifact/pull/521 is merged
+      - name: List All Artifacts
+        id: list_artifacts
+        run: |
+          echo "Fetching artifacts"
+          curl --fail --show-error --silent \
+               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+               | jq -r '.artifacts[] | .name' > artifacts_list.json
+      - name: Filter Artifacts
+        id: filter_artifacts
+        run: |
+          echo "Filtered Artifacts starts with cilium-sysdumps:"
+          if grep -E "^cilium-sysdumps-" artifacts_list.json; then
+            echo "sysdumps=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-sysdumps-* artifacts found."
+          fi
+          echo "Filtered Artifacts starts with cilium-junits:"
+          if grep -E "^cilium-junits-" artifacts_list.json; then
+            echo "junits=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-junits-* artifacts found."
+          fi
       - name: Merge Sysdumps
-        if: ${{ needs.setup-and-test.result == 'failure' }}
+        if: ${{ steps.filter_artifacts.outputs.sysdumps == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-sysdumps
           pattern: cilium-sysdumps-*
           retention-days: 5
           delete-merged: true
-        continue-on-error: true
       - name: Merge JUnits
+        if: ${{ steps.filter_artifacts.outputs.junits == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-junits

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -456,16 +456,41 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-and-test
     steps:
+      # TODO remove list and filter artifact steps if this PR https://github.com/actions/upload-artifact/pull/521 is merged
+      - name: List All Artifacts
+        id: list_artifacts
+        run: |
+          echo "Fetching artifacts"
+          curl --fail --show-error --silent \
+               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+               | jq -r '.artifacts[] | .name' > artifacts_list.json
+      - name: Filter Artifacts
+        id: filter_artifacts
+        run: |
+          echo "Filtered Artifacts starts with cilium-sysdumps:"
+          if grep -E "^cilium-sysdumps-" artifacts_list.json; then
+            echo "sysdumps=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-sysdumps-* artifacts found."
+          fi
+          echo "Filtered Artifacts starts with cilium-junits:"
+          if grep -E "^cilium-junits-" artifacts_list.json; then
+            echo "junits=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-junits-* artifacts found."
+          fi
       - name: Merge Sysdumps
-        if: ${{ needs.setup-and-test.result == 'failure' }}
+        if: ${{ steps.filter_artifacts.outputs.sysdumps == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-sysdumps
           pattern: cilium-sysdumps-*
           retention-days: 5
           delete-merged: true
-        continue-on-error: true
       - name: Merge JUnits
+        if: ${{ steps.filter_artifacts.outputs.junits == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-junits

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -748,16 +748,41 @@ jobs:
     runs-on: ubuntu-latest
     needs: upgrade-and-downgrade
     steps:
+      # TODO remove list and filter artifact steps if this PR https://github.com/actions/upload-artifact/pull/521 is merged
+      - name: List All Artifacts
+        id: list_artifacts
+        run: |
+          echo "Fetching artifacts"
+          curl --fail --show-error --silent \
+               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+               | jq -r '.artifacts[] | .name' > artifacts_list.json
+      - name: Filter Artifacts
+        id: filter_artifacts
+        run: |
+          echo "Filtered Artifacts starts with cilium-sysdumps:"
+          if grep -E "^cilium-sysdumps-" artifacts_list.json; then
+            echo "sysdumps=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-sysdumps-* artifacts found."
+          fi
+          echo "Filtered Artifacts starts with cilium-junits:"
+          if grep -E "^cilium-junits-" artifacts_list.json; then
+            echo "junits=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-junits-* artifacts found."
+          fi
       - name: Merge Sysdumps
-        if: ${{ needs.upgrade-and-downgrade.result == 'failure' }}
+        if: ${{ steps.filter_artifacts.outputs.sysdumps == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-sysdumps
           pattern: cilium-sysdumps-*
           retention-days: 5
           delete-merged: true
-        continue-on-error: true
       - name: Merge JUnits
+        if: ${{ steps.filter_artifacts.outputs.junits == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-junits

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -668,16 +668,41 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-and-test
     steps:
+      # TODO remove list and filter artifact steps if this PR https://github.com/actions/upload-artifact/pull/521 is merged
+      - name: List All Artifacts
+        id: list_artifacts
+        run: |
+          echo "Fetching artifacts"
+          curl --fail --show-error --silent \
+               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+               | jq -r '.artifacts[] | .name' > artifacts_list.json
+      - name: Filter Artifacts
+        id: filter_artifacts
+        run: |
+          echo "Filtered Artifacts starts with cilium-sysdumps:"
+          if grep -E "^cilium-sysdumps-" artifacts_list.json; then
+            echo "sysdumps=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-sysdumps-* artifacts found."
+          fi
+          echo "Filtered Artifacts starts with cilium-junits:"
+          if grep -E "^cilium-junits-" artifacts_list.json; then
+            echo "junits=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-junits-* artifacts found."
+          fi
       - name: Merge Sysdumps
-        if: ${{ needs.setup-and-test.result == 'failure' }}
+        if: ${{ steps.filter_artifacts.outputs.sysdumps == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-sysdumps
           pattern: cilium-sysdumps-*
           retention-days: 5
           delete-merged: true
-        continue-on-error: true
       - name: Merge JUnits
+        if: ${{ steps.filter_artifacts.outputs.junits == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-junits

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -461,16 +461,41 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-and-test
     steps:
+      # TODO remove list and filter artifact steps if this PR https://github.com/actions/upload-artifact/pull/521 is merged
+      - name: List All Artifacts
+        id: list_artifacts
+        run: |
+          echo "Fetching artifacts"
+          curl --fail --show-error --silent \
+               -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+               | jq -r '.artifacts[] | .name' > artifacts_list.json
+      - name: Filter Artifacts
+        id: filter_artifacts
+        run: |
+          echo "Filtered Artifacts starts with cilium-sysdumps:"
+          if grep -E "^cilium-sysdumps-" artifacts_list.json; then
+            echo "sysdumps=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-sysdumps-* artifacts found."
+          fi
+          echo "Filtered Artifacts starts with cilium-junits:"
+          if grep -E "^cilium-junits-" artifacts_list.json; then
+            echo "junits=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::No matching cilium-junits-* artifacts found."
+          fi
       - name: Merge Sysdumps
-        if: ${{ needs.setup-and-test.result == 'failure' }}
+        if: ${{ steps.filter_artifacts.outputs.sysdumps == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-sysdumps
           pattern: cilium-sysdumps-*
           retention-days: 5
           delete-merged: true
-        continue-on-error: true
       - name: Merge JUnits
+        if: ${{ steps.filter_artifacts.outputs.junits == 'true' }}
         uses: actions/upload-artifact/merge@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: cilium-junits


### PR DESCRIPTION
This commit adds list and filter steps to the Merge and Upload Artifacts job This Merge steps fail if there are no artifacts matching the pattern
This job failed quite often, and even though it failed after another failure, it was still undesirable.
There is an upstream [PR](https://github.com/actions/upload-artifact/pull/521) to address this issue but it seems stale for a long time. We can always remove these changes if the upstream PR is merged.

Fixes: #35167
