### PR TITLE
fix pod-to-pod MTU drop when both in+egress proxy and IPSec enabled

### DIFF
--- a/cilium-cli/connectivity/builder/pod_to_pod_encryption.go
+++ b/cilium-cli/connectivity/builder/pod_to_pod_encryption.go
@@ -29,13 +29,11 @@ func (t podToPodEncryption) build(ct *check.ConnectivityTest, _ map[string]strin
 		WithCondition(func() bool { return !ct.Params().SingleNode }).
 		WithFeatureRequirements(
 			features.RequireEnabled(features.L7Proxy),
-			// Once https://github.com/cilium/cilium/issues/33168 is fixed, we
-			// can enable for IPsec too.
-			features.RequireMode(features.EncryptionPod, "wireguard"),
+			features.RequireEnabled(features.EncryptionPod),
 		).
 		WithCiliumPolicy(clientsEgressL7HTTPFromAnyPolicyYAML).
 		WithCiliumPolicy(echoIngressL7HTTPFromAnywherePolicyYAML).
 		WithScenarios(
-			tests.PodToPodEncryption(features.RequireEnabled(features.EncryptionPod)),
+			tests.PodToPodEncryption(),
 		)
 }

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -552,7 +552,7 @@ func (l *loader) Reinitialize(ctx context.Context, cfg *datapath.LocalNodeConfig
 
 	// Reinstall proxy rules for any running proxies if needed
 	if option.Config.EnableL7Proxy {
-		if err := p.ReinstallRoutingRules(); err != nil {
+		if err := p.ReinstallRoutingRules(cfg.RouteMTU); err != nil {
 			return err
 		}
 	}

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -40,7 +40,7 @@ type PreFilter interface {
 // Proxy is any type which installs rules related to redirecting traffic to
 // a proxy.
 type Proxy interface {
-	ReinstallRoutingRules() error
+	ReinstallRoutingRules(mtu int) error
 }
 
 // IptablesManager manages iptables rules.

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -528,8 +528,13 @@ func (p *Proxy) SetProxyPort(name string, proxyType types.ProxyType, port uint16
 
 // ReinstallRoutingRules ensures the presence of routing rules and tables needed
 // to route packets to and from the L7 proxy.
-func (p *Proxy) ReinstallRoutingRules() error {
+func (p *Proxy) ReinstallRoutingRules(mtu int) error {
 	fromIngressProxy, fromEgressProxy := requireFromProxyRoutes()
+
+	// Use the provided mtu (RouteMTU) only with both ingress and egress proxy.
+	if !fromIngressProxy || !fromEgressProxy {
+		mtu = 0
+	}
 
 	if option.Config.EnableIPv4 {
 		if err := installToProxyRoutesIPv4(); err != nil {
@@ -537,7 +542,7 @@ func (p *Proxy) ReinstallRoutingRules() error {
 		}
 
 		if fromIngressProxy || fromEgressProxy {
-			if err := installFromProxyRoutesIPv4(node.GetInternalIPv4Router(), defaults.HostDevice, fromIngressProxy, fromEgressProxy); err != nil {
+			if err := installFromProxyRoutesIPv4(node.GetInternalIPv4Router(), defaults.HostDevice, fromIngressProxy, fromEgressProxy, mtu); err != nil {
 				return err
 			}
 		} else {
@@ -564,7 +569,7 @@ func (p *Proxy) ReinstallRoutingRules() error {
 			if err != nil {
 				return err
 			}
-			if err := installFromProxyRoutesIPv6(ipv6, defaults.HostDevice, fromIngressProxy, fromEgressProxy); err != nil {
+			if err := installFromProxyRoutesIPv6(ipv6, defaults.HostDevice, fromIngressProxy, fromEgressProxy, mtu); err != nil {
 				return err
 			}
 		} else {

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -121,7 +121,7 @@ var (
 
 // installFromProxyRoutesIPv4 configures routes and rules needed to redirect ingress
 // packets from the proxy.
-func installFromProxyRoutesIPv4(ipv4 net.IP, device string, fromIngressProxy, fromEgressProxy bool) error {
+func installFromProxyRoutesIPv4(ipv4 net.IP, device string, fromIngressProxy, fromEgressProxy bool, mtu int) error {
 	fromProxyToCiliumHostRoute4 := route.Route{
 		Table: linux_defaults.RouteTableFromProxy,
 		Prefix: net.IPNet{
@@ -137,6 +137,7 @@ func installFromProxyRoutesIPv4(ipv4 net.IP, device string, fromIngressProxy, fr
 		Nexthop: &ipv4,
 		Device:  device,
 		Proto:   linux_defaults.RTProto,
+		MTU:     mtu,
 	}
 
 	if fromIngressProxy {
@@ -176,7 +177,7 @@ func removeFromProxyRoutesIPv4() error {
 
 // installFromProxyRoutesIPv6 configures routes and rules needed to redirect ingress
 // packets from the proxy.
-func installFromProxyRoutesIPv6(ipv6 net.IP, device string, fromIngressProxy, fromEgressProxy bool) error {
+func installFromProxyRoutesIPv6(ipv6 net.IP, device string, fromIngressProxy, fromEgressProxy bool, mtu int) error {
 	fromProxyToCiliumHostRoute6 := route.Route{
 		Table: linux_defaults.RouteTableFromProxy,
 		Prefix: net.IPNet{
@@ -192,6 +193,7 @@ func installFromProxyRoutesIPv6(ipv6 net.IP, device string, fromIngressProxy, fr
 		Nexthop: &ipv6,
 		Device:  device,
 		Proto:   linux_defaults.RTProto,
+		MTU:     mtu,
 	}
 
 	if fromIngressProxy {

--- a/pkg/proxy/routes_test.go
+++ b/pkg/proxy/routes_test.go
@@ -5,16 +5,38 @@ package proxy
 
 import (
 	"net"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/testutils/netns"
 )
+
+const (
+	defaultMTU      = 0
+	withOverheadMTU = mtu.EthernetMTU - mtu.EncryptionIPsecOverhead
+)
+
+func filterDefaultRouteIPv4(t *testing.T, rt []netlink.Route) netlink.Route {
+	_, defaultDst4, _ := net.ParseCIDR("0.0.0.0/0")
+	i := slices.IndexFunc(rt, func(r netlink.Route) bool { return r.Dst.String() == defaultDst4.String() })
+	require.Greater(t, i, -1, "unable to retrieve default IPv4 route")
+	return rt[i]
+}
+
+func filterDefaultRouteIPv6(t *testing.T, rt []netlink.Route) netlink.Route {
+	_, defaultDst6, _ := net.ParseCIDR("::/0")
+	i := slices.IndexFunc(rt, func(r netlink.Route) bool { return r.Dst.String() == defaultDst6.String() })
+	require.Greater(t, i, -1, "unable to retrieve default IPv6 route")
+	return rt[i]
+}
 
 func TestRoutes(t *testing.T) {
 	testutils.PrivilegedTest(t)
@@ -72,7 +94,7 @@ func TestRoutes(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Install routes and rules the first time.
-				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName, true, true))
+				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName, true, true, defaultMTU))
 
 				rules, err := route.ListRules(netlink.FAMILY_V4, &fromIngressProxyRule)
 				assert.NoError(t, err)
@@ -84,10 +106,31 @@ func TestRoutes(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Len(t, rt, 2)
 
+				// Expect default route MTU set.
+				defaultRoute := filterDefaultRouteIPv4(t, rt)
+				assert.Equal(t, defaultMTU, defaultRoute.MTU)
+
 				// Ensure idempotence.
-				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName, true, true))
+				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName, true, true, defaultMTU))
 
 				// Remove routes installed before.
+				assert.NoError(t, removeFromProxyRoutesIPv4())
+
+				// Install routes and rules with non-default MTU -- this would happen with
+				// IPSec enabled and both ingress and egress policies in-place.
+				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName, true, true, withOverheadMTU))
+
+				// Re-list the from proxy (2005) routing table, expect a single entry.
+				rt, err = netlink.RouteListFiltered(netlink.FAMILY_V4,
+					&netlink.Route{Table: linux_defaults.RouteTableFromProxy}, netlink.RT_FILTER_TABLE)
+				assert.NoError(t, err)
+				assert.Len(t, rt, 2)
+
+				// Expect default route to use the lower MTU.
+				defaultRoute = filterDefaultRouteIPv4(t, rt)
+				assert.Equal(t, withOverheadMTU, defaultRoute.MTU)
+
+				// Remove installed routes.
 				assert.NoError(t, removeFromProxyRoutesIPv4())
 
 				rules, err = route.ListRules(netlink.FAMILY_V4, &fromIngressProxyRule)
@@ -159,7 +202,7 @@ func TestRoutes(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Install routes and rules the first time.
-				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName, true, true))
+				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName, true, true, defaultMTU))
 
 				rules, err := route.ListRules(netlink.FAMILY_V6, &fromIngressProxyRule)
 				assert.NoError(t, err)
@@ -171,10 +214,31 @@ func TestRoutes(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Len(t, rt, 2)
 
+				// Expect default route MTU set.
+				defaultRoute := filterDefaultRouteIPv6(t, rt)
+				assert.Equal(t, defaultMTU, defaultRoute.MTU)
+
 				// Ensure idempotence.
-				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName, true, true))
+				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName, true, true, defaultMTU))
 
 				// Remove routes installed before.
+				assert.NoError(t, removeFromProxyRoutesIPv6())
+
+				// Install routes and rules with non-default MTU -- this would happen with
+				// IPSec enabled and both ingress and egress policies in-place.
+				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName, true, true, withOverheadMTU))
+
+				// Re-list the from proxy (2005) routing table, expect a single entry.
+				rt, err = netlink.RouteListFiltered(netlink.FAMILY_V6,
+					&netlink.Route{Table: linux_defaults.RouteTableFromProxy}, netlink.RT_FILTER_TABLE)
+				assert.NoError(t, err)
+				assert.Len(t, rt, 2)
+
+				// Expect default route to use the lower MTU.
+				defaultRoute = filterDefaultRouteIPv6(t, rt)
+				assert.Equal(t, withOverheadMTU, defaultRoute.MTU)
+
+				// Remove installed routes.
 				assert.NoError(t, removeFromProxyRoutesIPv6())
 
 				rules, err = route.ListRules(netlink.FAMILY_V6, &fromIngressProxyRule)


### PR DESCRIPTION
This PR fixes the pod-to-pod traffic being dropped because of using a higher MTU value. This is caused by a non-configuration of the routes from proxy, in the routing table n. 2005 respectively. While the pod-to-pod route is being adjusted according to the IPSec overhead and the adjusted size of the authentication key, the from-proxy route is not changed as well.

This also enables the `pod-to-pod-with-l7-policy-encryption` test for IPSec in IPv4. Such test is therefore skipped if/for:
1.  IPv6, please refer to the follow-up issue #35485;
2. cilium version < 17.0.0, need to backport the fix before enabling the test.

Fixes: #33168

```release-note
Fix packet drops for pod-to-pod connections that pass through ingress & egress proxy when using IPsec, caused by MTU misconfiguration.
```
