### PR TITLE
hubble: remove outdated //go:build go1.18 tag

### DIFF
--- a/hubble/main.go
+++ b/hubble/main.go
@@ -1,10 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Hubble
 
-// Ensure build fails on versions of Go that are not supported by Hubble.
-// This build tag should be kept in sync with the version specified in go.mod.
-//go:build go1.18
-
 package main
 
 import (


### PR DESCRIPTION
This used to be needed to keep Go versioning in sync but has since been dropped from the Cilium code base since commit 66377a3b2fc1 ("Don't enforce Go version using //go:build in main.go files"). When hubble CLI was imported, the //go:build tag wasn't adjusted accordingly.

This build tag also leads to a rather unhelpful error message when compiling with an outdated Go versions, e.g.

    package github.com/cilium/cilium/hubble: build constraints exclude all Go files in ...

Nothing in the error messages indicates that this is due to an outdated Go toolchain version and this has been a source of confusion several times for several developers.