### PR TITLE
bpf: lxc: don't clear CB_POLICY prior to local delivery

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -679,7 +679,7 @@ ct_recreate6:
 				goto pass_to_stack;
 			}
 #endif /* ENABLE_HOST_ROUTING || ENABLE_ROUTING */
-			policy_clear_mark(ctx);
+
 			/* If the packet is from L7 LB it is coming from the host */
 			return ipv6_local_delivery(ctx, ETH_HLEN, SECLABEL_IPV6,
 						   MARK_MAGIC_IDENTITY, ep,
@@ -1186,7 +1186,7 @@ ct_recreate4:
 				goto pass_to_stack;
 			}
 #endif /* ENABLE_HOST_ROUTING || ENABLE_ROUTING */
-			policy_clear_mark(ctx);
+
 			/* If the packet is from L7 LB it is coming from the host */
 			return ipv4_local_delivery(ctx, ETH_HLEN, SECLABEL_IPV4,
 						   MARK_MAGIC_IDENTITY, ip4,


### PR DESCRIPTION
CB_POLICY aliases with CB_CLUSTER_ID_INGRESS, which already gets set when delivering via tail-call in l3_local_delivery(). On the other hand when delivering via stack, the to-container program doesn't trust any of the skb->cb[] content and already clears it at program entry.

Therefore it's safe to remove these helper calls.