### PR TITLE
ci: Introduce CILIUM_INSTALL_NET_PERF_EXTRA_ARGS env var

### DIFF
--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -232,6 +232,8 @@ jobs:
             CILIUM_INSTALL_DEFAULTS+=" --helm-set=encryption.enabled=true --helm-set=encryption.type=wireguard"
           fi
 
+          CILIUM_INSTALL_DEFAULTS+=" ${{ env.CILIUM_INSTALL_NET_PERF_EXTRA_ARGS }}"
+
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo owner=${OWNER} >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Introduce the CILIUM_INSTALL_NET_PERF_EXTRA_ARGS env var to allow for instances of this workflow to provide additional installation arguments, such as setting feature-gates.