### PR TITLE
pkg/node: fix repeated error reporting in neighbor-link-updater

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -1127,8 +1127,9 @@ func (m *manager) StartNodeNeighborLinkUpdater(nh datapath.NodeNeighbors) {
 
 					log.Debugf("Refreshing node neighbor link for %s", e.node.Name)
 					hr := sc.NewScope(e.node.Name)
-					if errs = errors.Join(errs, nh.NodeNeighborRefresh(ctx, *e.node, e.refresh)); errs != nil {
-						hr.Degraded("Failed node neighbor link update", errs)
+					if err := nh.NodeNeighborRefresh(ctx, *e.node, e.refresh); err != nil {
+						hr.Degraded("Failed node neighbor link update", err)
+						errs = errors.Join(errs, err)
 					} else {
 						hr.OK("Node neighbor link update successful")
 					}


### PR DESCRIPTION
Previously, neighbor-link-updater set the health status error for each neighboring node to a concatenation of all errors from all nodes processed so far.

Fix it by storing only the error from refreshing the particular node.

```release-note
Avoid duplicate errors in health status for node-neighbor-link-updater
```