### PR TITLE
bgpv2: defining reconciler names and priorities constants

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/crd_status.go
+++ b/pkg/bgpv1/manager/reconcilerv2/crd_status.go
@@ -134,11 +134,11 @@ func NewStatusReconciler(in StatusReconcilerIn) StatusReconcilerOut {
 }
 
 func (r *StatusReconciler) Name() string {
-	return "CiliumBGPNodeConfigStatusReconciler"
+	return CRDStatusReconcilerName
 }
 
 func (r *StatusReconciler) Priority() int {
-	return 50
+	return CRDStatusReconcilerPriority
 }
 
 func (r *StatusReconciler) Reconcile(ctx context.Context, params StateReconcileParams) error {

--- a/pkg/bgpv1/manager/reconcilerv2/neighbor.go
+++ b/pkg/bgpv1/manager/reconcilerv2/neighbor.go
@@ -128,7 +128,7 @@ func (r *NeighborReconciler) deleteMetadata(i *instance.BGPInstance, instanceNam
 }
 
 func (r *NeighborReconciler) Name() string {
-	return "Neighbor"
+	return NeighborReconcilerName
 }
 
 // Priority of neighbor reconciler is higher than pod/service announcements.
@@ -136,7 +136,7 @@ func (r *NeighborReconciler) Name() string {
 // into gobgp RIB before neighbors are added. So, gobgp can send out all prefixes
 // within initial update message exchange with neighbors before sending EOR marker.
 func (r *NeighborReconciler) Priority() int {
-	return 60
+	return NeighborReconcilerPriority
 }
 
 func (r *NeighborReconciler) Init(_ *instance.BGPInstance) error {

--- a/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
@@ -57,11 +57,11 @@ func NewPodCIDRReconciler(params PodCIDRReconcilerIn) PodCIDRReconcilerOut {
 }
 
 func (r *PodCIDRReconciler) Name() string {
-	return "PodCIDR"
+	return PodCIDRReconcilerName
 }
 
 func (r *PodCIDRReconciler) Priority() int {
-	return 30
+	return PodCIDRReconcilerPriority
 }
 
 func (r *PodCIDRReconciler) Init(_ *instance.BGPInstance) error {

--- a/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool.go
@@ -69,11 +69,11 @@ func NewPodIPPoolReconciler(in PodIPPoolReconcilerIn) PodIPPoolReconcilerOut {
 }
 
 func (r *PodIPPoolReconciler) Name() string {
-	return "PodIPPool"
+	return PodIPPoolReconcilerName
 }
 
 func (r *PodIPPoolReconciler) Priority() int {
-	return 50
+	return PodIPPoolReconcilerPriority
 }
 
 func (r *PodIPPoolReconciler) Init(_ *instance.BGPInstance) error {

--- a/pkg/bgpv1/manager/reconcilerv2/reconcilers.go
+++ b/pkg/bgpv1/manager/reconcilerv2/reconcilers.go
@@ -15,6 +15,23 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
 
+const (
+	NeighborReconcilerName  = "Neighbor"
+	PodIPPoolReconcilerName = "PodIPPool"
+	ServiceReconcilerName   = "Service"
+	PodCIDRReconcilerName   = "PodCIDR"
+)
+
+// Reconciler Priorities, lower number means higher priority. It is used to determine the
+// order in which reconcilers are called. Reconcilers are called from lowest to highest on
+// each Reconcile event.
+const (
+	NeighborReconcilerPriority  = 60
+	PodIPPoolReconcilerPriority = 50
+	ServiceReconcilerPriority   = 40
+	PodCIDRReconcilerPriority   = 30
+)
+
 type ReconcileParams struct {
 	BGPInstance   *instance.BGPInstance
 	DesiredConfig *v2alpha1.CiliumBGPNodeInstance

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -87,11 +87,11 @@ func (r *ServiceReconciler) setMetadata(i *instance.BGPInstance, metadata Servic
 }
 
 func (r *ServiceReconciler) Name() string {
-	return "Service"
+	return ServiceReconcilerName
 }
 
 func (r *ServiceReconciler) Priority() int {
-	return 40
+	return ServiceReconcilerPriority
 }
 
 func (r *ServiceReconciler) Init(i *instance.BGPInstance) error {

--- a/pkg/bgpv1/manager/reconcilerv2/state_reconcilers.go
+++ b/pkg/bgpv1/manager/reconcilerv2/state_reconcilers.go
@@ -14,6 +14,11 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
 )
 
+const (
+	CRDStatusReconcilerName     = "CiliumBGPNodeConfigStatusReconciler"
+	CRDStatusReconcilerPriority = 50
+)
+
 type StateReconcileParams struct {
 	// ConfigMode is the current configuration mode of BGP control plane
 	// This is required by some reconcilers to determine if they need to run or not.


### PR DESCRIPTION
Defining reconciler names and priorities at one place to avoid mistakes in order in which reconcilers are expected to run.

