### PR TITLE
wireguard trace reason encrypted

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1072,6 +1072,8 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 	void __maybe_unused *data, *data_end;
 	struct ipv6hdr __maybe_unused *ip6;
 	struct iphdr __maybe_unused *ip4;
+	int __maybe_unused l4_off = 0;
+	__u8 __maybe_unused next_proto = 0;
 	__s8 __maybe_unused ext_err = 0;
 	int ret;
 
@@ -1170,6 +1172,15 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 		}
 # endif /* defined(ENABLE_HOST_FIREWALL) && !defined(ENABLE_MASQUERADE_IPV6) */
 
+#ifdef ENABLE_WIREGUARD
+		if (!from_host) {
+			next_proto = ip6->nexthdr;
+			l4_off = ETH_HLEN + ipv6_hdrlen(ctx, &next_proto);
+			if (ctx_is_wireguard(ctx, l4_off, next_proto, ipcache_srcid))
+				trace.reason = TRACE_REASON_ENCRYPTED;
+		}
+#endif /* ENABLE_WIREGUARD */
+
 		send_trace_notify(ctx, obs_point, ipcache_srcid, UNKNOWN_ID, TRACE_EP_ID_UNKNOWN,
 				  ctx->ingress_ifindex, trace.reason, trace.monitor);
 
@@ -1203,6 +1214,15 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 			ctx_store_meta(ctx, CB_IPCACHE_SRC_LABEL, ipcache_srcid);
 		}
 # endif /* defined(ENABLE_HOST_FIREWALL) && !defined(ENABLE_MASQUERADE_IPV4) */
+
+#ifdef ENABLE_WIREGUARD
+		if (!from_host) {
+			next_proto = ip4->protocol;
+			l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
+			if (ctx_is_wireguard(ctx, l4_off, next_proto, ipcache_srcid))
+				trace.reason = TRACE_REASON_ENCRYPTED;
+		}
+#endif /* ENABLE_WIREGUARD */
 
 		send_trace_notify(ctx, obs_point, ipcache_srcid, UNKNOWN_ID, TRACE_EP_ID_UNKNOWN,
 				  ctx->ingress_ifindex, trace.reason, trace.monitor);

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1522,12 +1522,14 @@ skip_host_firewall:
 	 * encrypted WireGuard UDP packets), we check whether the mark
 	 * is set before the redirect.
 	 */
+	trace.reason = TRACE_REASON_ENCRYPTED;
 	if ((ctx->mark & MARK_MAGIC_WG_ENCRYPTED) != MARK_MAGIC_WG_ENCRYPTED) {
 		ret = wg_maybe_redirect_to_encrypt(ctx, proto);
 		if (ret == CTX_ACT_REDIRECT)
 			return ret;
 		else if (IS_ERR(ret))
 			goto drop_err;
+		trace.reason = TRACE_REASON_UNKNOWN;
 	}
 
 #if defined(ENCRYPTION_STRICT_MODE)

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1159,15 +1159,16 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 
 		identity = resolve_srcid_ipv6(ctx, ip6, identity, &ipcache_srcid, from_host);
 		ctx_store_meta(ctx, CB_SRC_LABEL, identity);
-		if (from_host) {
+
 # if defined(ENABLE_HOST_FIREWALL) && !defined(ENABLE_MASQUERADE_IPV6)
+		if (from_host) {
 			/* If we don't rely on BPF-based masquerading, we need
 			 * to pass the srcid from ipcache to host firewall. See
 			 * comment in ipv6_host_policy_egress() for details.
 			 */
 			ctx_store_meta(ctx, CB_IPCACHE_SRC_LABEL, ipcache_srcid);
-# endif /* defined(ENABLE_HOST_FIREWALL) && !defined(ENABLE_MASQUERADE_IPV6) */
 		}
+# endif /* defined(ENABLE_HOST_FIREWALL) && !defined(ENABLE_MASQUERADE_IPV6) */
 
 		send_trace_notify(ctx, obs_point, ipcache_srcid, UNKNOWN_ID, TRACE_EP_ID_UNKNOWN,
 				  ctx->ingress_ifindex, trace.reason, trace.monitor);
@@ -1192,15 +1193,16 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 		identity = resolve_srcid_ipv4(ctx, ip4, identity, &ipcache_srcid,
 					      from_host);
 		ctx_store_meta(ctx, CB_SRC_LABEL, identity);
-		if (from_host) {
+
 # if defined(ENABLE_HOST_FIREWALL) && !defined(ENABLE_MASQUERADE_IPV4)
+		if (from_host) {
 			/* If we don't rely on BPF-based masquerading, we need
 			 * to pass the srcid from ipcache to host firewall. See
 			 * comment in ipv4_host_policy_egress() for details.
 			 */
 			ctx_store_meta(ctx, CB_IPCACHE_SRC_LABEL, ipcache_srcid);
-# endif /* defined(ENABLE_HOST_FIREWALL) && !defined(ENABLE_MASQUERADE_IPV4) */
 		}
+# endif /* defined(ENABLE_HOST_FIREWALL) && !defined(ENABLE_MASQUERADE_IPV4) */
 
 		send_trace_notify(ctx, obs_point, ipcache_srcid, UNKNOWN_ID, TRACE_EP_ID_UNKNOWN,
 				  ctx->ingress_ifindex, trace.reason, trace.monitor);

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -14,6 +14,47 @@
 #include "identity.h"
 
 #include "lib/proxy.h"
+#include "lib/l4.h"
+
+/* ctx_is_wireguard is used to check whether ctx is a WireGuard network packet.
+ * This function returns true in case all the following conditions are satisfied:
+ *
+ * - ctx is a UDP packet;
+ * - L4 dport == WG_PORT;
+ * - L4 sport == dport;
+ * - valid identity in cluster.
+ */
+static __always_inline bool
+ctx_is_wireguard(struct __ctx_buff *ctx, int l4_off, __u8 protocol, __u32 identity)
+{
+	struct {
+		__be16 sport;
+		__be16 dport;
+	} l4;
+
+	/* Non-UDP packets. */
+	if (protocol != IPPROTO_UDP)
+		return false;
+
+	/* Unable to retrieve L4 ports. */
+	if (l4_load_ports(ctx, l4_off + UDP_SPORT_OFF, &l4.sport) < 0)
+		return false;
+
+	/* Packet is not for cilium@WireGuard.*/
+	if (l4.dport != bpf_htons(WG_PORT))
+		return false;
+
+	/* Packet does not come from cilium@WireGuard. */
+	if (l4.sport != l4.dport)
+		return false;
+
+	/* Identity not in cluster. */
+	if (!identity_is_cluster(identity))
+		return false;
+
+	/* Cilium-related WireGuard packet to be traced as encrypted. */
+	return true;
+}
 
 static __always_inline int
 wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -284,6 +284,7 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 
 #ifdef ENABLE_WIREGUARD
 # define WG_IFINDEX	42
+# define WG_PORT    51871
 # ifdef ENCRYPTION_STRICT_MODE
 #  define STRICT_IPV4_NET	0
 #  define STRICT_IPV4_NET_SIZE	8

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -308,6 +308,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 			return fmt.Errorf("getting %s ifindex: %w", wgtypes.IfaceName, err)
 		}
 		cDefinesMap["WG_IFINDEX"] = fmt.Sprintf("%d", ifindex)
+		cDefinesMap["WG_PORT"] = fmt.Sprintf("%d", wgtypes.ListenPort)
 
 		if option.Config.EncryptNode {
 			cDefinesMap["ENABLE_NODE_ENCRYPTION"] = "1"


### PR DESCRIPTION
This PR introduces the TRACE_REASON_ENCRYPT reason when tracing a WireGuard-encrypted packet, alongside the needed logic in the ingress path.
Each commit should contain a brief description of the changes applied.
The resulting output after applying this PR should look as follows:

```bash
# WireGuard with Overlay
1:<- endpoint 1756 flow 0x0 , identity 12670->unknown state unknown ifindex 0 orig-ip 0.0.0.0: 10.244.1.196 -> 10.244.2.22 EchoRequest
2:-> overlay flow 0x0 , identity 12670->7292 state new ifindex cilium_vxlan orig-ip 0.0.0.0: 10.244.1.196 -> 10.244.2.22 EchoRequest
3--> network encrypted  flow 0x9597ef3d , identity unknown->unknown state new ifindex eth0 orig-ip 0.0.0.0: 172.18.0.4:51871 -> 172.18.0.2:51871 udp
4-<- network encrypted  flow 0x9597ef3d , identity remote-node->unknown state new ifindex eth0 orig-ip 0.0.0.0: 172.18.0.2:51871 -> 172.18.0.4:51871 udp
5:<- overlay flow 0x0 , identity 7292->unknown state unknown ifindex cilium_vxlan orig-ip 0.0.0.0: 10.244.2.22 -> 10.244.1.196 EchoReply
6:-> endpoint 1756 flow 0x0 , identity 7292->12670 state reply ifindex lxcfe422d25f340 orig-ip 10.244.2.22: 10.244.2.22 -> 10.244.1.196 EchoReply

# WireGuard with Native Routing
1:<- endpoint 2379 flow 0x0 , identity 16125->unknown state unknown ifindex 0 orig-ip 0.0.0.0: 10.244.2.39 -> 10.244.1.72 EchoRequest
2:-> stack flow 0x0 , identity 16125->34030 state new ifindex 0 orig-ip 0.0.0.0: 10.244.2.39 -> 10.244.1.72 EchoRequest
3:-> 0: 10.244.2.39 -> 10.244.1.72 EchoRequest
4--> network encrypted  flow 0x0 , identity unknown->unknown state new ifindex eth0 orig-ip 0.0.0.0: 172.18.0.2:51871 -> 172.18.0.3:51871 udp
5-<- network encrypted  flow 0x0 , remote-node->unknown state new ifindex eth0 orig-ip 0.0.0.0: 172.18.0.3:51871 -> 172.18.0.2:51871 udp
6:<- host flow 0x0 , identity world->unknown state unknown ifindex cilium_wg0 orig-ip 0.0.0.0: 10.244.1.72 -> 10.244.2.39 EchoReply
7:-> endpoint 2379 flow 0x0 , identity 34030->16125 state reply ifindex lxc27ddb3574bfb orig-ip 10.244.1.72: 10.244.1.72 -> 10.244.2.39 EchoReply
```

Notice how lines 3-4 in Overlay and 4-5 in Native Routing have the `encrypted` flag.

This still does not solve all the Hubble/Cilium-dbg observability, as all the information concerning the inner packets (endpoint) are lost at the time of the tracing event. The purpose of this PR is to align the behavior with IPSec. See the linked issue below with the discussion.

Fixes: #34659

```release-note
Add logic to detect and trace WireGuard encrypted ingress/egress packets.
```
