### PR TITLE
helm: template function compatibility for automatic lookup

### DIFF
--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -129,9 +129,9 @@ To override the namespace and configMap when using `auto`:
 `.Values.k8sServiceLookupNamespace` and `.Values.k8sServiceLookupConfigMapName`
 */}}
 {{- define "k8sServiceHost" }}
-  {{- if eq .Values.k8sServiceHost "auto" }}
-    {{- $configmapName := default "cluster-info" .Values.k8sServiceLookupConfigMapName }}
-    {{- $configmapNamespace := default "kube-public" .Values.k8sServiceLookupNamespace }}
+  {{- $configmapName := default "cluster-info" .Values.k8sServiceLookupConfigMapName }}
+  {{- $configmapNamespace := default "kube-public" .Values.k8sServiceLookupNamespace }}
+  {{- if and (eq .Values.k8sServiceHost "auto") (lookup "v1" "ConfigMap" $configmapNamespace $configmapName) }}
     {{- $configmap := (lookup "v1" "ConfigMap" $configmapNamespace $configmapName) }}
     {{- $kubeconfig := get $configmap.data "kubeconfig" }}
     {{- $k8sServer := get ($kubeconfig | fromYaml) "clusters" | mustFirst | dig "cluster" "server" "" }}
@@ -149,9 +149,9 @@ To override the namespace and configMap when using `auto`:
 `.Values.k8sServiceLookupNamespace` and `.Values.k8sServiceLookupConfigMapName`
 */}}
 {{- define "k8sServicePort" }}
-  {{- if eq .Values.k8sServiceHost "auto" }}
-    {{- $configmapName := default "cluster-info" .Values.k8sServiceLookupConfigMapName }}
-    {{- $configmapNamespace := default "kube-public" .Values.k8sServiceLookupNamespace }}
+  {{- $configmapName := default "cluster-info" .Values.k8sServiceLookupConfigMapName }}
+  {{- $configmapNamespace := default "kube-public" .Values.k8sServiceLookupNamespace }}
+  {{- if and (eq .Values.k8sServiceHost "auto") (lookup "v1" "ConfigMap" $configmapNamespace $configmapName) }}
     {{- $configmap := (lookup "v1" "ConfigMap" $configmapNamespace $configmapName) }}
     {{- $kubeconfig := get $configmap.data "kubeconfig" }}
     {{- $k8sServer := get ($kubeconfig | fromYaml) "clusters" | mustFirst | dig "cluster" "server" "" }}


### PR DESCRIPTION
This commit ensures that the `helm template` function does not error when the configuration is set to
```
k8sServiceHost: auto
```
Fixes: #35094

```release-note
helm template function no longer errors when using k8sServiceHost: auto
```
