### PR TITLE
versioned: Never clean up current version

### DIFF
--- a/pkg/container/versioned/value.go
+++ b/pkg/container/versioned/value.go
@@ -280,7 +280,10 @@ func (v *Coordinator) clean() {
 	// 'keepVersion' is the current version if there are no outstanding VersionHandles
 	keepVersion := v.version
 	if len(v.versions) > 0 {
-		keepVersion = v.versions[0].version
+		// otherwise it is the oldest version for which there is an outstanding handle, if
+		// older than the current version, as if there was an implicit outstanding handle
+		// for the current version.
+		keepVersion = min(v.version, v.versions[0].version)
 	}
 
 	// Call the cleaner for 'keepVersion' only if not already called for this 'keepVersion'.


### PR DESCRIPTION
Current version of a versioned.Value is the latest committed version. This version should never be cleaned off, as then no value would be available. Currently this can happen if there is a new transaction in progress due to a missing check between the oldest handle version (for the new transaction) and the current version. Add this check using 'min()'.

This fixes the following warning log:
      2024-10-03T06:14:48.362931495Z time="2024-10-03T06:14:48.361323126Z" level=warning msg="GetVersionHandle: Handle to a stale version requested, returning oldest valid version instead" oldVersion=1 stacktrace="\<stacktrace redacted\>" subsys=policy version=2

In the above log 'oldVersion' (1) was the current version that was cleaned off due to the oldest version handle being for a new, non-committed transaction for version 2.

When this line was logged, a handle for version 2 was returned, resulting in a race between the use of that version and that version being committed. Never cleaning off the current version makes sure this does not happen.

Fixes: #34205
