### PR TITLE
tests: run ipsec tests sequentially and other tests concurrently

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -392,7 +392,7 @@ jobs:
             # privileged tests.
             go${{ env.go-version}} install github.com/jstemmer/go-junit-report/v2@7fde4641acef5b92f397a8baf8309d1a45d608cc
             export GOTEST_FORMATTER="/root/go/bin/go-junit-report -set-exit-code -iocopy -out test/runtime.xml"
-            make tests-privileged NO_COLOR=1 GO=go${{ env.go-version }}
+            make SKIP_COVERAGE=1 tests-privileged NO_COLOR=1 GO=go${{ env.go-version }}
 
       - name: Debug failure on VM
         # Only debug the failure on the LVH that have Cilium running as a service,

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ $(SUBDIRS): force ## Execute default make target(make all) for the provided subd
 
 tests-privileged: ## Run Go tests including ones that require elevated privileges.
 	@$(ECHO_CHECK) running privileged tests...
-	PRIVILEGED_TESTS=true PATH=$(PATH):$(ROOT_DIR)/bpf $(GO_TEST) -p 1 $(TEST_LDFLAGS) \
+	PRIVILEGED_TESTS=true PATH=$(PATH):$(ROOT_DIR)/bpf $(GO_TEST) $(TEST_LDFLAGS) \
 		$(TESTPKGS) $(GOTEST_BASE) $(GOTEST_COVER_OPTS) | $(GOTEST_FORMATTER)
 	$(MAKE) generate-cov
 

--- a/Makefile
+++ b/Makefile
@@ -109,10 +109,14 @@ endif
 
 generate-cov: ## Generate HTML coverage report at coverage-all.html.
 	-@# Remove generated code from coverage
+ifneq ($(SKIP_COVERAGE),)
+	@echo "Skipping generate-cov because SKIP_COVERAGE is set."
+else
 	$(QUIET) grep -Ev '(^github.com/cilium/cilium/api/v1)|(generated.deepcopy.go)|(^github.com/cilium/cilium/pkg/k8s/client/)' \
 		coverage.out > coverage.out.tmp
 	$(QUIET)$(GO) tool cover -html=coverage.out.tmp -o=coverage-all.html
 	$(QUIET) rm coverage.out.tmp
+endif
 	@rmdir ./daemon/1 ./daemon/1_backup 2> /dev/null || true
 
 integration-tests: start-kvstores ## Run Go tests including ones that are marked as integration tests.


### PR DESCRIPTION
The commit 0c0800c8b312 removed the concurrency of test execution for all runtime privileged tests. This was unnecessary and caused the tests to take longer time to complete. With this commit we will run all tests concurrently except the flaky tests that were related with the ipsec packages.

Fixes: 0c0800c8b312 ("ci: make runtime privileged tests not run in parallel")

Also skip coverage report as we are not using on GH workflows.