### PR TITLE
install/kubernetes: fix Operator's clusterrole for pods deletion

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -18,15 +18,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  resourceNames:
-  - cilium-config
-  verbs:
-   # allow patching of the configmap to set annotations
-  - patch
 {{- if hasKey .Values "disableEndpointCRD" }}
 {{- if not .Values.disableEndpointCRD }}
 {{- if (and .Values.operator.unmanagedPodWatcher.restart (ne (.Values.operator.unmanagedPodWatcher.intervalSeconds | int64) 0 ) ) }}
@@ -36,6 +27,15 @@ rules:
 {{- end }}
 {{- end }}
 {{- end }}
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - cilium-config
+  verbs:
+   # allow patching of the configmap to set annotations
+  - patch
 {{- if or .Values.operator.removeNodeTaints .Values.operator.setNodeNetworkStatus (include "hasDuration" .Values.operator.endpointGCInterval) }}
 - apiGroups:
   - ""


### PR DESCRIPTION
The clusterrole for Cilium Operator got broken with the introduction of a0409f02caeb as it moved the "delete" operation to the configmap/cilium-config instead of keeping it into pods. This was causing the CI to fail with the error:

level=warning msg=\"Unable to restart pod\" error=\"pods \\\"coredns-6f6b679f8f-zmhtv\\\" is forbidden: User \\\"system:serviceaccount:kube-system:cilium-operator\\\" cannot delete resource \\\"pods\\\" in API group \\\"\\\" in the namespace \\\"kube-system\\\"\"
k8sPodName=kube-system/coredns-6f6b679f8f-zmhtv
subsys=cilium-operator-generic"

Fixes: a0409f02caeb ("cilium-cli: Show config annotations in status")