### PR TITLE
policy: Wait on sync.WaitGroup only after adding to it

### DIFF
--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -536,6 +536,8 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted identity.IdentityMap, w
 
 	if updated {
 		// Launch a waiter that holds the new version as long as needed for users to have grabbed it
+		sc.queueNotifiedUsersCommit(txn, wg)
+
 		go func(version *versioned.VersionHandle) {
 			wg.Wait()
 			log.WithFields(logrus.Fields{
@@ -544,7 +546,6 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted identity.IdentityMap, w
 			version.Close()
 		}(txn.GetVersionHandle())
 
-		sc.queueNotifiedUsersCommit(txn, wg)
 		txn.Commit()
 	}
 }


### PR DESCRIPTION
Call `queueNotifiedUsersCommit(..., wg)` before starting go routing waiting on `wg`, as `queueNotifiedUsersCommit()` does `wg.Add(1)`. This makes it impossible to hit this bug:

```
2024-10-03T08:45:07.562242086Z panic: sync: WaitGroup is reused before previous Wait has returned
2024-10-03T08:45:07.562251423Z
2024-10-03T08:45:07.562358242Z goroutine 11033 [running]:
2024-10-03T08:45:07.562532947Z sync.(*WaitGroup).Wait(0xc0041bfe90?)
2024-10-03T08:45:07.562538587Z 	/usr/local/go/src/sync/waitgroup.go:120 +0x74
2024-10-03T08:45:07.562541644Z github.com/cilium/cilium/pkg/policy.(*SelectorCache).UpdateIdentities.func1(0xc01829a4c0)
2024-10-03T08:45:07.562544629Z 	/go/src/github.com/cilium/cilium/pkg/policy/selectorcache.go:540 +0x3a
2024-10-03T08:45:07.562547444Z created by github.com/cilium/cilium/pkg/policy.(*SelectorCache).UpdateIdentities in goroutine 357
2024-10-03T08:45:07.562550470Z 	/go/src/github.com/cilium/cilium/pkg/policy/selectorcache.go:539 +0xd54
```

Fixes: #34205