### PR TITLE
bgpv2: Use instance name instead of ASN in Diff ID

### DIFF
--- a/pkg/bgpv1/manager/instance/fake_instance.go
+++ b/pkg/bgpv1/manager/instance/fake_instance.go
@@ -10,6 +10,7 @@ import (
 // NewFakeBGPInstance is fake BGP instance, to be used in unit tests.
 func NewFakeBGPInstance() *BGPInstance {
 	return &BGPInstance{
+		Name:     "fake-instance",
 		Config:   nil,
 		Router:   types.NewFakeRouter(),
 		Metadata: make(map[string]any),

--- a/pkg/bgpv1/manager/instance/instance.go
+++ b/pkg/bgpv1/manager/instance/instance.go
@@ -66,6 +66,7 @@ func NewServerWithConfig(ctx context.Context, log *logrus.Entry, params types.Se
 //
 // This is used in BGPv2 implementation.
 type BGPInstance struct {
+	Name      string
 	Global    types.BGPGlobal
 	ASN       uint32 // deprecated: use Global.ASN instead
 	CancelCtx context.CancelFunc
@@ -82,7 +83,7 @@ type BGPInstance struct {
 //
 // Canceling the provided context will kill the BGP instance along with calling the
 // underlying Router's Stop() method.
-func NewBGPInstance(ctx context.Context, log *logrus.Entry, params types.ServerParameters) (*BGPInstance, error) {
+func NewBGPInstance(ctx context.Context, log *logrus.Entry, name string, params types.ServerParameters) (*BGPInstance, error) {
 	gobgpCtx, cancel := context.WithCancel(ctx)
 	s, err := gobgp.NewGoBGPServer(gobgpCtx, log, params)
 	if err != nil {
@@ -91,6 +92,7 @@ func NewBGPInstance(ctx context.Context, log *logrus.Entry, params types.ServerP
 	}
 
 	return &BGPInstance{
+		Name:      name,
 		Global:    params.Global,
 		ASN:       params.Global.ASN,
 		CancelCtx: cancel,

--- a/pkg/bgpv1/manager/manager.go
+++ b/pkg/bgpv1/manager/manager.go
@@ -892,7 +892,7 @@ func (m *BGPRouterManager) registerBGPInstance(ctx context.Context,
 		StateNotification: make(types.StateNotificationCh, 1),
 	}
 
-	i, err := instance.NewBGPInstance(ctx, m.Logger.WithField(types.InstanceLogField, c.Name), globalConfig)
+	i, err := instance.NewBGPInstance(ctx, m.Logger.WithField(types.InstanceLogField, c.Name), c.Name, globalConfig)
 	if err != nil {
 		return fmt.Errorf("failed to start BGP instance: %w", err)
 	}

--- a/pkg/bgpv1/manager/reconcilerv2/neighbor_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/neighbor_test.go
@@ -237,7 +237,7 @@ func TestNeighborReconciler(t *testing.T) {
 				},
 			}
 
-			testInstance, err := instance.NewBGPInstance(context.Background(), logrus.WithField("unit_test", tt.name), srvParams)
+			testInstance, err := instance.NewBGPInstance(context.Background(), logrus.WithField("unit_test", tt.name), "test-instance", srvParams)
 			req.NoError(err)
 
 			t.Cleanup(func() {

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -98,15 +98,15 @@ func (r *ServiceReconciler) Init(i *instance.BGPInstance) error {
 	if i == nil {
 		return fmt.Errorf("BUG: service reconciler initialization with nil BGPInstance")
 	}
-	r.svcDiffStore.InitDiff(r.diffID(i.Global.ASN))
-	r.epDiffStore.InitDiff(r.diffID(i.Global.ASN))
+	r.svcDiffStore.InitDiff(r.diffID(i))
+	r.epDiffStore.InitDiff(r.diffID(i))
 	return nil
 }
 
 func (r *ServiceReconciler) Cleanup(i *instance.BGPInstance) {
 	if i != nil {
-		r.svcDiffStore.CleanupDiff(r.diffID(i.Global.ASN))
-		r.epDiffStore.CleanupDiff(r.diffID(i.Global.ASN))
+		r.svcDiffStore.CleanupDiff(r.diffID(i))
+		r.epDiffStore.CleanupDiff(r.diffID(i))
 	}
 }
 
@@ -411,8 +411,8 @@ func (r *ServiceReconciler) resolveSvcFromEndpoints(eps *k8s.Endpoints) (*slim_c
 
 func (r *ServiceReconciler) fullReconciliationServiceList(p ReconcileParams) (toReconcile []*slim_corev1.Service, toWithdraw []resource.Key, err error) {
 	// re-init diff in diffstores, so that it contains only changes since the last full reconciliation.
-	r.svcDiffStore.InitDiff(r.diffID(p.BGPInstance.Global.ASN))
-	r.epDiffStore.InitDiff(r.diffID(p.BGPInstance.Global.ASN))
+	r.svcDiffStore.InitDiff(r.diffID(p.BGPInstance))
+	r.epDiffStore.InitDiff(r.diffID(p.BGPInstance))
 
 	// check for services which are no longer present
 	serviceAFPaths := r.getMetadata(p.BGPInstance).ServicePaths
@@ -439,7 +439,7 @@ func (r *ServiceReconciler) fullReconciliationServiceList(p ReconcileParams) (to
 // diffReconciliationServiceList returns a list of services to reconcile and to withdraw when
 // performing partial (diff) service reconciliation.
 func (r *ServiceReconciler) diffReconciliationServiceList(p ReconcileParams) (toReconcile []*slim_corev1.Service, toWithdraw []resource.Key, err error) {
-	upserted, deleted, err := r.svcDiffStore.Diff(r.diffID(p.BGPInstance.Global.ASN))
+	upserted, deleted, err := r.svcDiffStore.Diff(r.diffID(p.BGPInstance))
 	if err != nil {
 		return nil, nil, fmt.Errorf("svc store diff: %w", err)
 	}
@@ -450,7 +450,7 @@ func (r *ServiceReconciler) diffReconciliationServiceList(p ReconcileParams) (to
 	// We don't handle service deletion here since we only see
 	// the key, we cannot resolve associated service, so we have
 	// nothing to do.
-	epsUpserted, _, err := r.epDiffStore.Diff(r.diffID(p.BGPInstance.Global.ASN))
+	epsUpserted, _, err := r.epDiffStore.Diff(r.diffID(p.BGPInstance))
 	if err != nil {
 		return nil, nil, fmt.Errorf("EPs store diff: %w", err)
 	}
@@ -834,8 +834,8 @@ func (r *ServiceReconciler) getClusterIPRoutePolicy(p ReconcileParams, peer stri
 	return policy, nil
 }
 
-func (r *ServiceReconciler) diffID(asn uint32) string {
-	return fmt.Sprintf("%s-%d", r.Name(), asn)
+func (r *ServiceReconciler) diffID(instance *instance.BGPInstance) string {
+	return fmt.Sprintf("%s-%s", r.Name(), instance.Name)
 }
 
 // checkServiceAdvertisement checks if the service advertisement is enabled in the advertisement.


### PR DESCRIPTION
As BGP instances are identified by name in `BGPRouterManager` for BGPv2, we should use instance name instead of ASN in DiffStore Diff ID for BGPv2.