### PR TITLE
.github: increase concurrent jobs in tests-e2e-upgrade

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -98,7 +98,7 @@ jobs:
       job_name: 'Setup & Test'
     strategy:
       fail-fast: false
-      max-parallel: 22
+      max-parallel: 23
       matrix:
         include:
           - name: '1'


### PR DESCRIPTION
We currently have 23 configurations that we want to test but only 22 possible parallel executions. This makes one of the tests to be executed at a later stage increase the time of test execution in total.

Fixes: c60ea3251360 ("datapath, netkit: Allow ARP passthrough on host when using netkit")
