### PR TITLE
.github: do not push floating tag from PRs

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -112,7 +112,7 @@ jobs:
           else
             tag=${{ github.sha }}
           fi
-          if [ "${{ github.ref_name }}" == "${{ github.event.repository.default_branch }}" ]; then
+          if [[ "${{ github.event_name == 'push' }}" == "true" && "${{ github.ref_name }}" == "${{ github.event.repository.default_branch }}" ]]; then
             floating_tag=latest
             echo floating_tag=${floating_tag} >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
With 5ce311271620, PRs started to push their changes into the 'latest' tag which would cause CI issues. With this commit we make sure the 'latest' tag only happens on "push" events for the default branch of the repository.

Fixes: 5ce311271620 (".github: simplify build-images-ci workflow")