### PR TITLE
[v1.16] .github: do not push floating tag from PRs

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -99,7 +99,7 @@ jobs:
           else
             tag=${{ github.sha }}
           fi
-          if [ "${{ github.ref_name }}" == "${{ github.event.repository.default_branch }}" ]; then
+          if [[ "${{ github.event_name == 'push' }}" == "true" && "${{ github.ref_name }}" == "${{ github.event.repository.default_branch }}" ]]; then
             floating_tag=latest
             echo floating_tag=${floating_tag} >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
* [x] #35227

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
35227
```
