### PR TITLE
ci: run privileged tests in parallel except for IPSec

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -389,7 +389,7 @@ jobs:
             go install golang.org/dl/go${{ env.go-version }}@latest
             go${{ env.go-version }} download
             go${{ env.go-version}} install github.com/mfridman/tparse@baf229e8494613f134bc0e1f4cb9dc9b12f66442
-            make tests-privileged GO=go${{ env.go-version }}
+            make SKIP_COVERAGE=1 tests-privileged GO=go${{ env.go-version }}
 
       - name: Debug failure on VM
         # Only debug the failure on the LVH that have Cilium running as a service,

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -388,11 +388,8 @@ jobs:
             # install the same Go toolchain version as current HEAD.
             go install golang.org/dl/go${{ env.go-version }}@latest
             go${{ env.go-version }} download
-            # Install go-junit-report to generate junit files for the
-            # privileged tests.
-            go${{ env.go-version}} install github.com/jstemmer/go-junit-report/v2@7fde4641acef5b92f397a8baf8309d1a45d608cc
-            export GOTEST_FORMATTER="/root/go/bin/go-junit-report -set-exit-code -iocopy -out test/runtime.xml"
-            make tests-privileged NO_COLOR=1 GO=go${{ env.go-version }}
+            go${{ env.go-version}} install github.com/mfridman/tparse@baf229e8494613f134bc0e1f4cb9dc9b12f66442
+            make tests-privileged GO=go${{ env.go-version }}
 
       - name: Debug failure on VM
         # Only debug the failure on the LVH that have Cilium running as a service,
@@ -425,7 +422,7 @@ jobs:
             test_results-*.tar.gz
 
       - name: Fetch JUnits
-        if: ${{ always() }}
+        if: ${{ always() && (matrix.focus == 'agent' || matrix.focus == 'datapath') }}
         shell: bash
         run: |
           mkdir -p cilium-junits
@@ -438,14 +435,14 @@ jobs:
           for filename in *.xml; do cp "${filename}" "../cilium-junits/${junit_filename}"; done;
 
       - name: Upload JUnits [junit]
-        if: ${{ always() }}
+        if: ${{ always() && (matrix.focus == 'agent' || matrix.focus == 'datapath') }}
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: cilium-junits-${{ matrix.focus }}
           path: cilium-junits/*.xml
 
       - name: Publish Test Results As GitHub Summary
-        if: ${{ always() }}
+        if: ${{ always() && (matrix.focus == 'agent' || matrix.focus == 'datapath') }}
         uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
         with:
           junit-directory: "cilium-junits"

--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,14 @@ endif
 
 generate-cov: ## Generate HTML coverage report at coverage-all.html.
 	-@# Remove generated code from coverage
+ifneq ($(SKIP_COVERAGE),)
+	@echo "Skipping generate-cov because SKIP_COVERAGE is set."
+else
 	$(QUIET) grep -Ev '(^github.com/cilium/cilium/api/v1)|(generated.deepcopy.go)|(^github.com/cilium/cilium/pkg/k8s/client/)' \
 		coverage.out > coverage.out.tmp
 	$(QUIET)$(GO) tool cover -html=coverage.out.tmp -o=coverage-all.html
 	$(QUIET) rm coverage.out.tmp
+endif
 	@rmdir ./daemon/1 ./daemon/1_backup 2> /dev/null || true
 
 integration-tests: start-kvstores ## Run Go tests including ones that are marked as integration tests.

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -1,3 +1,5 @@
+//go:build unparallel
+
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 

--- a/pkg/datapath/linux/ipsec/xfrm_state_cache.go
+++ b/pkg/datapath/linux/ipsec/xfrm_state_cache.go
@@ -70,10 +70,3 @@ func (c *xfrmStateListCache) invalidate() {
 	defer c.mutex.Unlock()
 	c.stateList = nil
 }
-
-func newTestableXfrmStateListCache(ttl time.Duration, clock clock.PassiveClock) *xfrmStateListCache {
-	return &xfrmStateListCache{
-		ttl:   ttl,
-		clock: clock,
-	}
-}

--- a/pkg/datapath/linux/ipsec/xfrm_state_cache_test.go
+++ b/pkg/datapath/linux/ipsec/xfrm_state_cache_test.go
@@ -1,3 +1,5 @@
+//go:build unparallel
+
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
@@ -13,8 +15,16 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 
+	"k8s.io/utils/clock"
 	baseclocktest "k8s.io/utils/clock/testing"
 )
+
+func newTestableXfrmStateListCache(ttl time.Duration, clock clock.PassiveClock) *xfrmStateListCache {
+	return &xfrmStateListCache{
+		ttl:   ttl,
+		clock: clock,
+	}
+}
 
 func TestXfrmStateListCache(t *testing.T) {
 	setupIPSecSuitePrivileged(t)


### PR DESCRIPTION
Small drawbacks of this approach:
- if one of the tests fails, it won't run IPSec tests
- we don't generate coverage report for IPSec tests

Additionally, switch from junit to tparse. 