### PR TITLE
.github/build-images-base: checkout base branch to get scripts

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -57,6 +57,12 @@ jobs:
       - name: Cleanup Disk space in runner
         uses: ./.github/actions/disk-cleanup
 
+      - name: Checkout base branch (trusted)
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          ref: ${{ github.base_ref }}
+          persist-credentials: false
+
       - name: Copy scripts to trusted directory
         run: |
           mkdir -p ../cilium-base-branch/images/runtime/


### PR DESCRIPTION
We need to checkout the base branch, instead of the default branch, to checkout the right scripts to generate the source code respectively of the stable branch the GH workflow is running from otherwise we will always run the scripts from the main branch from stable branches.

Fixes: ada2560b4775 (".github: run scripts from trusted source code")