### PR TITLE
docs: network policy: remove SCTP from `missing features` list

### DIFF
--- a/Documentation/network/kubernetes/policy.rst
+++ b/Documentation/network/kubernetes/policy.rst
@@ -50,8 +50,6 @@ Known missing features for Kubernetes Network Policy:
 +===============================+===================+
 | ``ipBlock`` set with a pod IP | :gh-issue:`9209`  |
 +-------------------------------+-------------------+
-| SCTP                          | :gh-issue:`5719`  |
-+-------------------------------+-------------------+
 
 As of v1.15, ``ipBlock`` can now optionally select :ref:`node IPs <cidr_select_nodes>`. Previously,
 nodes were excluded from ``ipBlock``; see :gh-issue:`20550`.


### PR DESCRIPTION
The `policy enforcement` bullet in the referenced issue (https://github.com/cilium/cilium/issues/5719) is completed. Looks like the network policy support was added with https://github.com/cilium/cilium/pull/20033.