### PR TITLE
bpf: remove CB_POLICY logic

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1679,8 +1679,6 @@ skip_ipsec_nodeport_revdnat:
 		goto out;
 	}
 
-	policy_clear_mark(ctx);
-
 	switch (proto) {
 # if defined ENABLE_ARP_PASSTHROUGH || defined ENABLE_ARP_RESPONDER
 	case bpf_htons(ETH_P_ARP):

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1552,8 +1552,6 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, int ifindex, __u32 src_
 	__u8 audited = 0;
 	__u8 auth_type = 0;
 
-	policy_clear_mark(ctx);
-
 	ipv6_addr_copy(&orig_sip, (union v6addr *)&ip6->saddr);
 
 	ct_buffer = map_lookup_elem(&CT_TAIL_CALL_BUFFER6, &zero);
@@ -1865,8 +1863,6 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, int ifindex, __u32 src_la
 	__u8 audited = 0;
 	__u8 auth_type = 0;
 	__u32 zero = 0;
-
-	policy_clear_mark(ctx);
 
 	orig_sip = ip4->saddr;
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -559,7 +559,6 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		}
 		/* proxy_port remains 0 in this case */
 
-		policy_mark_skip(ctx);
 		break;
 	default:
 		return DROP_UNKNOWN_CT;
@@ -1010,7 +1009,6 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		}
 		/* proxy_port remains 0 in this case */
 
-		policy_mark_skip(ctx);
 		break;
 	default:
 		return DROP_UNKNOWN_CT;

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -830,13 +830,13 @@ enum {
 #define CB_CLUSTER_ID_EGRESS	CB_IFINDEX	/* Alias, non-overlapping */
 #define CB_HSIPC_ADDR_V4	CB_IFINDEX	/* Alias, non-overlapping */
 #define CB_TRACED		CB_IFINDEX	/* Alias, non-overlapping */
-	CB_POLICY,
-#define	CB_ADDR_V6_2		CB_POLICY	/* Alias, non-overlapping */
-#define CB_SRV6_SID_3		CB_POLICY	/* Alias, non-overlapping */
-#define	CB_CLUSTER_ID_INGRESS	CB_POLICY	/* Alias, non-overlapping */
-#define CB_HSIPC_PORT		CB_POLICY	/* Alias, non-overlapping */
-#define CB_DSR_SRC_LABEL	CB_POLICY	/* Alias, non-overlapping */
-#define CB_NAT_FLAGS		CB_POLICY	/* Alias, non-overlapping */
+	CB_2,
+#define	CB_ADDR_V6_2		CB_2		/* Alias, non-overlapping */
+#define CB_SRV6_SID_3		CB_2		/* Alias, non-overlapping */
+#define	CB_CLUSTER_ID_INGRESS	CB_2		/* Alias, non-overlapping */
+#define CB_HSIPC_PORT		CB_2		/* Alias, non-overlapping */
+#define CB_DSR_SRC_LABEL	CB_2		/* Alias, non-overlapping */
+#define CB_NAT_FLAGS		CB_2		/* Alias, non-overlapping */
 	CB_3,
 #define	CB_ADDR_V6_3		CB_3		/* Alias, non-overlapping */
 #define	CB_FROM_HOST		CB_3		/* Alias, non-overlapping */

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -157,12 +157,6 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 		goto check_l4_policy;
 	}
 
-	/* TODO: Consider skipping policy lookup in this case? */
-	if (ctx_load_meta(ctx, CB_POLICY)) {
-		*proxy_port = 0;
-		return CTX_ACT_OK;
-	}
-
 	if (is_untracked_fragment)
 		return DROP_FRAG_NOSUPPORT;
 
@@ -300,9 +294,4 @@ static __always_inline int policy_can_egress4(struct __ctx_buff *ctx, const void
 	return policy_can_egress(ctx, map, src_id, dst_id, ETH_P_IP, tuple->dport,
 				 tuple->nexthdr, l4_off, match_type, audited,
 				 ext_err, proxy_port);
-}
-
-static __always_inline void policy_clear_mark(struct __ctx_buff *ctx)
-{
-	ctx_store_meta(ctx, CB_POLICY, 0);
 }

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -302,18 +302,6 @@ static __always_inline int policy_can_egress4(struct __ctx_buff *ctx, const void
 				 ext_err, proxy_port);
 }
 
-/**
- * Mark ctx to skip policy enforcement
- * @arg ctx	packet
- *
- * Will cause the packet to ignore the policy enforcement verdict for allow rules and
- * be considered accepted despite of the policy outcome. Has no effect on deny rules.
- */
-static __always_inline void policy_mark_skip(struct __ctx_buff *ctx)
-{
-	ctx_store_meta(ctx, CB_POLICY, 1);
-}
-
 static __always_inline void policy_clear_mark(struct __ctx_buff *ctx)
 {
 	ctx_store_meta(ctx, CB_POLICY, 0);


### PR DESCRIPTION
The `CB_POLICY` flag doesn't appear to have any relevant users left, remove it. It's unclear at what point in the past this stopped being useful - even https://github.com/cilium/cilium/issues/18811 was questioning why this flag is still needed.