### PR TITLE
feat: Add support for impersonation --as and --as-group flags

### DIFF
--- a/cilium-cli/api/api_test.go
+++ b/cilium-cli/api/api_test.go
@@ -23,7 +23,7 @@ func TestNamespaceContextValues(t *testing.T) {
 
 func TestK8sClientContextValues(t *testing.T) {
 	ctx := context.Background()
-	k8sClient, err := k8s.NewClient("", "", "")
+	k8sClient, err := k8s.NewClient("", "", "", "", []string{})
 	assert.NoError(t, err)
 	ctx = SetK8sClientContextValue(ctx, k8sClient)
 	result, ok := GetK8sClientContextValue(ctx)

--- a/cilium-cli/cli/clustermesh.go
+++ b/cilium-cli/cli/clustermesh.go
@@ -49,6 +49,8 @@ func newCmdClusterMeshStatus() *cobra.Command {
 		Long:  ``,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			params.Namespace = namespace
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroups
 
 			if params.Output == status.OutputJSON {
 				// Write status log messages to stderr to make sure they don't
@@ -116,6 +118,8 @@ func newCmdExternalWorkloadCreate() *cobra.Command {
 		Long:  ``,
 		RunE: func(_ *cobra.Command, args []string) error {
 			params.Namespace = namespace
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroups
 
 			if labels != "" {
 				params.Labels = parseLabels(labels)
@@ -151,6 +155,9 @@ func newCmdExternalWorkloadDelete() *cobra.Command {
 		Short: "Delete named external workloads",
 		Long:  ``,
 		RunE: func(_ *cobra.Command, args []string) error {
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroups
+
 			cm := clustermesh.NewK8sClusterMesh(k8sClient, params)
 			if err := cm.DeleteExternalWorkload(context.Background(), args); err != nil {
 				fatalf("Unable to remove external workloads: %s", err)
@@ -175,6 +182,8 @@ func newCmdExternalWorkloadInstall() *cobra.Command {
 		Long:  ``,
 		RunE: func(_ *cobra.Command, args []string) error {
 			params.Namespace = namespace
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroups
 
 			cm := clustermesh.NewK8sClusterMesh(k8sClient, params)
 			var writer io.Writer
@@ -217,6 +226,8 @@ func newCmdExternalWorkloadStatus() *cobra.Command {
 		Long:  ``,
 		RunE: func(_ *cobra.Command, args []string) error {
 			params.Namespace = namespace
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroups
 
 			cm := clustermesh.NewK8sClusterMesh(k8sClient, params)
 			if err := cm.ExternalWorkloadStatus(context.Background(), args); err != nil {
@@ -242,6 +253,8 @@ func newCmdClusterMeshEnableWithHelm() *cobra.Command {
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			params.Namespace = namespace
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroups
 			params.HelmReleaseName = helmReleaseName
 			ctx := context.Background()
 			params.EnableKVStoreMeshChanged = cmd.Flags().Changed("enable-kvstoremesh")
@@ -270,6 +283,8 @@ func newCmdClusterMeshDisableWithHelm() *cobra.Command {
 		Long:  ``,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			params.Namespace = namespace
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroups
 			params.HelmReleaseName = helmReleaseName
 			ctx := context.Background()
 			if err := clustermesh.DisableWithHelm(ctx, k8sClient, params); err != nil {
@@ -293,6 +308,8 @@ func newCmdClusterMeshConnectWithHelm() *cobra.Command {
 		Long:  ``,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			params.Namespace = namespace
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroups
 			params.HelmReleaseName = helmReleaseName
 			cm := clustermesh.NewK8sClusterMesh(k8sClient, params)
 			if err := cm.ConnectWithHelm(context.Background()); err != nil {
@@ -317,6 +334,8 @@ func newCmdClusterMeshDisconnectWithHelm() *cobra.Command {
 		Short: "Disconnect from a remote cluster",
 		Run: func(_ *cobra.Command, _ []string) {
 			params.Namespace = namespace
+			params.ImpersonateAs = impersonateAs
+			params.ImpersonateGroups = impersonateGroups
 			params.HelmReleaseName = helmReleaseName
 			cm := clustermesh.NewK8sClusterMesh(k8sClient, params)
 			if err := cm.DisconnectWithHelm(context.Background()); err != nil {

--- a/cilium-cli/cli/cmd.go
+++ b/cilium-cli/cli/cmd.go
@@ -15,10 +15,12 @@ import (
 )
 
 var (
-	contextName     string
-	namespace       string
-	helmReleaseName string
-	kubeConfig      string
+	contextName       string
+	namespace         string
+	impersonateAs     string
+	impersonateGroups []string
+	helmReleaseName   string
+	kubeConfig        string
 
 	k8sClient *k8s.Client
 )
@@ -45,7 +47,7 @@ func NewCiliumCommand(hooks api.Hooks) *cobra.Command {
 				}
 			}
 
-			c, err := k8s.NewClient(contextName, kubeConfig, namespace)
+			c, err := k8s.NewClient(contextName, kubeConfig, namespace, impersonateAs, impersonateGroups)
 			if err != nil {
 				return fmt.Errorf("unable to create Kubernetes client: %w", err)
 			}
@@ -84,6 +86,8 @@ cilium connectivity test`,
 
 	cmd.PersistentFlags().StringVar(&contextName, "context", "", "Kubernetes configuration context")
 	cmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "kube-system", "Namespace Cilium is running in")
+	cmd.PersistentFlags().StringVar(&impersonateAs, "as", "", "Username to impersonate for the operation. User could be a regular user or a service account in a namespace.")
+	cmd.PersistentFlags().StringArrayVar(&impersonateGroups, "as-group", []string{}, "Group to impersonate for the operation, this flag can be repeated to specify multiple groups.")
 	cmd.PersistentFlags().StringVar(&helmReleaseName, "helm-release-name", "cilium", "Helm release name")
 	cmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", "", "Path to the kubeconfig file")
 

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -55,6 +55,8 @@ var tests []string
 func RunE(hooks api.Hooks) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, _ []string) error {
 		params.CiliumNamespace = namespace
+		params.ImpersonateAs = impersonateAs
+		params.ImpersonateGroups = impersonateGroups
 
 		for _, test := range tests {
 			if strings.HasPrefix(test, "!") {

--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -111,6 +111,8 @@ type Parameters struct {
 	ConfigOverwrites     []string
 	Retries              int
 	Output               string
+	ImpersonateAs        string
+	ImpersonateGroups    []string
 
 	// EnableExternalWorkloads indicates whether externalWorkloads.enabled Helm value
 	// should be set to true. For Helm mode only.
@@ -495,7 +497,7 @@ func (k *K8sClusterMesh) extractAccessInformation(ctx context.Context, client k8
 func (k *K8sClusterMesh) getRemoteClients() ([]*k8s.Client, error) {
 	var remoteClients []*k8s.Client
 	for _, d := range k.params.DestinationContext {
-		remoteClient, err := k8s.NewClient(d, "", k.params.Namespace)
+		remoteClient, err := k8s.NewClient(d, "", k.params.Namespace, k.params.ImpersonateAs, k.params.ImpersonateGroups)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"unable to create Kubernetes client to access remote cluster %q: %w",

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -86,6 +86,8 @@ type Parameters struct {
 	NodesWithoutCiliumIPs  []nodesWithoutCiliumIP
 	JunitFile              string
 	JunitProperties        map[string]string
+	ImpersonateAs          string
+	ImpersonateGroups      []string
 
 	IncludeConnDisruptTest        bool
 	ConnDisruptTestSetup          bool

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -824,7 +824,7 @@ func (ct *ConnectivityTest) initClients(ctx context.Context) error {
 	if ct.params.MultiCluster != "" {
 		multiClusterClientLock.Lock()
 		defer multiClusterClientLock.Unlock()
-		dst, err := k8s.NewClient(ct.params.MultiCluster, "", ct.params.CiliumNamespace)
+		dst, err := k8s.NewClient(ct.params.MultiCluster, "", ct.params.CiliumNamespace, ct.params.ImpersonateAs, ct.params.ImpersonateGroups)
 		if err != nil {
 			return fmt.Errorf("unable to create Kubernetes client for remote cluster %q: %w", ct.params.MultiCluster, err)
 		}

--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -71,7 +71,7 @@ type Client struct {
 	HelmActionConfig   *action.Configuration
 }
 
-func NewClient(contextName, kubeconfig, ciliumNamespace string) (*Client, error) {
+func NewClient(contextName, kubeconfig, ciliumNamespace string, impersonateAs string, impersonateGroup []string) (*Client, error) {
 	restClientGetter := genericclioptions.ConfigFlags{
 		Context:    &contextName,
 		KubeConfig: &kubeconfig,
@@ -81,6 +81,13 @@ func NewClient(contextName, kubeconfig, ciliumNamespace string) (*Client, error)
 	config, err := rawKubeConfigLoader.ClientConfig()
 	if err != nil {
 		return nil, err
+	}
+
+	if impersonateAs != "" || len(impersonateGroup) > 0 {
+		config.Impersonate = rest.ImpersonationConfig{
+			UserName: impersonateAs,
+			Groups:   impersonateGroup,
+		}
 	}
 
 	rawConfig, err := rawKubeConfigLoader.RawConfig()


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

We use impersonation as cluster admins to elevate access to customer secrets and certain resources, and kubectl supports this with the --as or --as-group flags. Currently to use the cilium cli tool, we have to hand edit our kubeconfig to add as: <user> for our user, and then remember to remove it afterwords. Supporting impersonation directly in the Cilium cli tooling would make it much safer for us and align cilium with other kubectl flags.

**Note**: previously implemented and reviewed over in the cilium/cilium-cli: https://github.com/cilium/cilium-cli/pull/2696

Fixes: N/A

```release-note
Add cli support for impersonation --as and --as-group flags
```
