### PR TITLE
hubble: Combine hubble and hubble-bin make targets

### DIFF
--- a/hubble/Makefile
+++ b/hubble/Makefile
@@ -19,9 +19,6 @@ GOARCH ?=
 all: hubble
 
 hubble:
-	$(MAKE) -C $(SUBDIRS_HUBBLE_CLI) hubble-bin
-
-hubble-bin:
 	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/cilium/hubble/pkg.GitHash=$(GIT_HASH)' -X 'github.com/cilium/cilium/hubble/pkg.Version=${VERSION}'" -o $(TARGET_DIR)/$(TARGET)$(EXT) $(SUBDIRS_HUBBLE_CLI)
 
 local-release: clean


### PR DESCRIPTION
There is no need for a make target that calls make in SUBDIRS_HUBBLE_CLI directory since the go build command already takes SUBDIRS_HUBBLE_CLI into account.