### PR TITLE
ci: fix check generated documentation

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -66,7 +66,6 @@ jobs:
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html
-
   check-generated-documentation:
     name: Check generated documentation
     if: ${{ github.event_name != 'merge_group' }}
@@ -76,34 +75,12 @@ jobs:
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           persist-credentials: false
+          # Needed to detect missing redirects
       - name: Install Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           # renovate: datasource=golang-version depName=go
           go-version: 1.22.8
-
-      - name: Set clang directory
-        id: set_clang_dir
-        run: echo "clang_dir=$HOME/.clang" >> $GITHUB_OUTPUT
-
-      - name: Cache LLVM and Clang
-        id: cache-llvm
-        uses: actions/cache@2cdf405574d6ef1f33a1d12acccd3ae82f47b3f2 # v4.1.0
-        with:
-          path: ${{ steps.set_clang_dir.outputs.clang_dir }}
-          key: llvm-10.0
-
-      - name: Install LLVM and Clang prerequisites
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libtinfo5
-
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@e0a8dc9cb8a22e8a7696e8a91a4e9581bec13181 # v2.0.5
-        with:
-          version: "10.0"
-          directory: ${{ steps.set_clang_dir.outputs.clang_dir }}
-          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
 
       # Building Cilium as precondition to generate documentation artifacts.
       - name: Build Cilium


### PR DESCRIPTION
Currently, checking the generated docu fails on v1.15 with the following error.

```
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package libtinfo5
```

https://github.com/cilium/cilium/actions/runs/11208917248/job/31153329067

This occurs after updating ubuntu from ubuntu-22 to ubuntu-24.

It looks like that setting up clang and LLVM in this check is only performed on the v1.15 branch.

Therefore, this commit is removing the steps.