### PR TITLE
[v1.15] ci: fix check generated documentation

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -70,7 +70,7 @@ jobs:
   check-generated-documentation:
     name: Check generated documentation
     if: ${{ github.event_name != 'merge_group' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0


### PR DESCRIPTION
Currently, checking the generated docu fails on v1.15 with the following error.

```
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package libtinfo5
```

https://github.com/cilium/cilium/actions/runs/11208917248/job/31153329067

This occurs after updating ubuntu from ubuntu-22 to ubuntu-24. https://github.com/cilium/cilium/pull/35092

Therefore, this commit reverts the update.
