### PR TITLE
Adding the --generate-ssh-keys parameter to the AKS section to fix the creation of AKS Cluster.

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -77,7 +77,8 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
            az aks create \
              --resource-group "${AZURE_RESOURCE_GROUP}" \
              --name "${NAME}" \
-             --network-plugin none
+             --network-plugin none \
+             --generate-ssh-keys
 
            # Get the credentials to access the cluster with kubectl
            az aks get-credentials --resource-group "${AZURE_RESOURCE_GROUP}" --name "${NAME}"


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

<!-- Description of change -->
The getting started section for the Azure Kubernetes Service was missing a parameter in the command.
Without the "--generate-ssh-keys" parameter is not possible to create the AKS Cluster as shown in the following print:
![image](https://github.com/user-attachments/assets/158953d6-4da4-4ea6-955a-e509a1d822c5)
The change included the required parameter for users to be able to create the AKS Cluster.

```release-note
docs: Add parameter to generate SSH keys for AKS "getting started" steps.
```
