### PR TITLE
ci: add network policy scale test

### DIFF
--- a/.github/actions/cl2-modules/netpol/cnp.yaml
+++ b/.github/actions/cl2-modules/netpol/cnp.yaml
@@ -1,0 +1,73 @@
+{{$deployments := .Deployments}}
+{{$cnps := .CNPs}}
+{{$dp :=  DivideInt .Index $cnps}}
+{{$cnpno :=  Mod .Index $cnps}}
+
+{{$CIDRs := 5}}
+{{$PORTs := 5}}
+{{$DNSs := 5}}
+
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{.Name}}
+  labels:
+    group: load
+spec:
+  endpointSelector:
+    matchLabels:
+      group: load
+      indexing: id-{{$dp}}
+  egress:
+{{if eq $cnpno 0}}
+# regular L3 policy
+  - toEndpoints:
+    - matchLabels:
+        indexing: id-{{RandIntRange 0 $deployments}}
+{{else if eq $cnpno 1}}
+# CIDR policy
+  - toCIDR:
+  {{ range $index := Loop $CIDRs }}
+    - 177.{{RandIntRange 1 255}}.{{RandIntRange 1 255}}.{{RandIntRange 1 255}}/32
+  {{ end }}
+{{else if eq $cnpno 2}}
+# L4 policy
+  - toEndpoints:
+    - matchLabels:
+        indexing: id-{{RandIntRange 0 $deployments}}
+    toPorts:
+    - ports:
+  {{ range $index := Loop $PORTs }}
+      - port: "{{RandIntRange 1 65000}}"
+        protocol: TCP
+  {{ end }}
+{{else if eq $cnpno 3}}
+# L4 CIDR policy
+  - toCIDR:
+  {{ range $index := Loop $CIDRs }}
+    - 177.{{RandIntRange 0 255}}.{{RandIntRange 1 255}}.{{RandIntRange 1 255}}/32
+  {{ end }}
+    toPorts:
+    - ports:
+  {{ range $index := Loop $PORTs }}
+      - port: "{{RandIntRange 1 65000}}"
+        protocol: TCP
+  {{ end }}
+{{else}}
+# FQDN policy
+  - toEndpoints:
+    - matchLabels:
+        "k8s:io.kubernetes.pod.namespace": kube-system
+        "k8s:k8s-app": kube-dns
+    toPorts:
+      - ports:
+         - port: "53"
+           protocol: ANY
+        rules:
+          dns:
+            - matchPattern: "*"
+  - toFQDNs:
+  {{ range $index := Loop $DNSs }}
+      - matchName: "{{RandIntRange 0 1000000}}.my-remote-service.com"
+  {{ end }}
+{{end}}

--- a/.github/actions/cl2-modules/netpol/config.yaml
+++ b/.github/actions/cl2-modules/netpol/config.yaml
@@ -1,0 +1,60 @@
+{{$PODS_PER_NODE := 30}}
+{{$PODS_PER_DEPLOYMENT := 5}}
+{{$CNPS_PER_DEPLOYMENT := 5}}
+{{$namespaces := MaxInt (DivideInt .Nodes 100) 1}}
+{{$TimeToLoad := MultiplyInt $namespaces 6}}
+# number of deployments is 30 * #nodes / 5
+# for 1 node -> 6 deployments x 1 namespace
+# for 100 nodes -> 600 deployments x 1 namespace
+# for 500 nodes -> 600 deployments x 5 namespaces
+# for 1000 nodes -> 600 deployments x 10 namespaces
+
+{{$totalPods := MultiplyInt .Nodes $PODS_PER_NODE}}
+{{$deployments := DivideInt $totalPods $PODS_PER_DEPLOYMENT}}
+{{$deploymentsPerNamespace := DivideInt $deployments $namespaces}}
+
+name: netpol
+namespace:
+  number: {{$namespaces}}
+  # Let's skip deleting namespaces at the end of test for now
+  deleteAutomanagedNamespaces: false
+tuningSets:
+- name: default
+  globalQPSLoad:
+    qps: 1
+    burst: 1
+- name: RandomizedSaturationTimeLimited
+  RandomizedTimeLimitedLoad:
+    timeLimit: {{$TimeToLoad}}m
+
+steps:
+- module:
+    path: ./modules/metrics.yaml
+    params:
+      action: start
+
+- module:
+    path: ../cilium-agent-pprofs.yaml
+    params:
+      action: start
+
+- module:
+    path: /modules/reconcile-objects.yaml
+    params:
+      actionName: "create"
+      namespaces: {{$namespaces}}
+      tuningSet: RandomizedSaturationTimeLimited
+      operationTimeout: 15m
+      replicasPerDeployment: {{$PODS_PER_DEPLOYMENT}}
+      deploymentsPerNamespace: {{$deploymentsPerNamespace}}
+      cnpsPerDeployment: {{$CNPS_PER_DEPLOYMENT}}
+
+- module:
+    path: ../cilium-agent-pprofs.yaml
+    params:
+      action: gather
+
+- module:
+    path: ./modules/metrics.yaml
+    params:
+      action: gather

--- a/.github/actions/cl2-modules/netpol/deployment.yaml
+++ b/.github/actions/cl2-modules/netpol/deployment.yaml
@@ -1,0 +1,30 @@
+{{$CpuRequest := DefaultParam .CpuRequest "5m"}}
+{{$MemoryRequest := DefaultParam .MemoryRequest "20M"}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Name}}
+  labels:
+    group: load
+    indexing: id-{{.Index}}
+spec:
+  replicas: {{.Replicas}}
+  selector:
+    matchLabels:
+      name: {{.Name}}
+  template:
+    metadata:
+      labels:
+        group: load
+        name: {{.Name}}
+        indexing: id-{{.Index}}
+    spec:
+      containers:
+      - image: "registry.k8s.io/pause:3.9"
+        name: {{.Name}}
+        resources:
+          requests:
+            cpu: {{$CpuRequest}}
+            memory: {{$MemoryRequest}}
+      terminationGracePeriodSeconds: 1

--- a/.github/actions/cl2-modules/netpol/modules/metrics.yaml
+++ b/.github/actions/cl2-modules/netpol/modules/metrics.yaml
@@ -1,0 +1,59 @@
+{{$action := .action}}
+
+{{$NETPOL_LATENCY_THRESHOLD := DefaultParam .CL2_NETPOL_LATENCY_THRESHOLD 0.1}}
+{{$MEDIAN_CPU_USAGE_THRESHOLD := DefaultParam .CL2_NETPOL_MEDIAN_CPU_USAGE_THRESHOLD 0.2}}
+{{$MEDIAN_MEM_USAGE_THRESHOLD := DefaultParam .CL2_NETPOL_MEDIAN_MEM_USAGE_THRESHOLD 450}}
+
+steps:
+  - name: {{$action}} Cilium Agent Policy implementation delay
+    measurements:
+    - Identifier: PolicyImplementationDelay
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: NetPol Policy Implementation Delay
+        metricVersion: v1
+        unit: s
+        enableViolations: true
+        queries:
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(rate(cilium_policy_implementation_delay_bucket[%v])) by (le))
+          threshold: {{$NETPOL_LATENCY_THRESHOLD}}
+        - name: Perc90
+          query: histogram_quantile(0.90, sum(rate(cilium_policy_implementation_delay_bucket[%v])) by (le))
+        - name: Perc50
+          query: histogram_quantile(0.50, sum(rate(cilium_policy_implementation_delay_bucket[%v])) by (le))
+
+    - Identifier: CiliumCPUUsage
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: NetPol Average CPU Usage
+        metricVersion: v1
+        unit: cpu
+        enableViolations: true
+        queries:
+        - name: Perc99
+          query: quantile(0.99, avg_over_time(rate(cilium_process_cpu_seconds_total[1m])[%v:10s]))
+        - name: Perc90
+          query: quantile(0.90, avg_over_time(rate(cilium_process_cpu_seconds_total[1m])[%v:10s]))
+        - name: Perc50
+          query: quantile(0.50, avg_over_time(rate(cilium_process_cpu_seconds_total[1m])[%v:10s]))
+          threshold: {{$MEDIAN_CPU_USAGE_THRESHOLD}}
+
+    - Identifier: CiliumMemUsage
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: NetPol Max Memory Usage
+        metricVersion: v1
+        unit: MB
+        enableViolations: true
+        queries:
+        - name: Perc99
+          query: quantile(0.99, max_over_time(cilium_process_resident_memory_bytes[%v]) / 1024 / 1024)
+        - name: Perc90
+          query: quantile(0.90, max_over_time(cilium_process_resident_memory_bytes[%v]) / 1024 / 1024)
+        - name: Perc50
+          query: quantile(0.5, max_over_time(cilium_process_resident_memory_bytes[%v]) / 1024 / 1024)
+          threshold: {{$MEDIAN_MEM_USAGE_THRESHOLD}}

--- a/.github/actions/cl2-modules/netpol/modules/reconcile-objects.yaml
+++ b/.github/actions/cl2-modules/netpol/modules/reconcile-objects.yaml
@@ -1,0 +1,54 @@
+{{$actionName := printf "%s objects" .actionName}}
+{{$namespaces := .namespaces}}
+{{$tuningSet := .tuningSet}}
+{{$operationTimeout := .operationTimeout}}
+{{$deploymentsPerNamespace := .deploymentsPerNamespace}}
+{{$replicasPerDeployment := .replicasPerDeployment}}
+{{$cnpsPerDeployment := .cnpsPerDeployment }}
+
+steps:
+- name: Starting measurement for '{{$actionName}}'
+  measurements:
+  - Method: WaitForControlledPodsRunning
+    Instances:
+    - Identifier: WaitForRunningDeployments
+      Params:
+        apiVersion: apps/v1
+        kind: Deployment
+    Params:
+      action: start
+      checkIfPodsAreUpdated: true
+      labelSelector: group = load
+      operationTimeout: {{$operationTimeout}}
+
+- name: {{$actionName}}
+  phases:
+  - namespaceRange:
+      min: 1
+      max: {{$namespaces}}
+    replicasPerNamespace: {{$deploymentsPerNamespace}}
+    tuningSet: {{$tuningSet}}
+    objectBundle:
+    - basename: small-deployment
+      objectTemplatePath: deployment.yaml
+      templateFillMap:
+        Replicas: {{$replicasPerDeployment}}
+  - namespaceRange:
+      min: 1
+      max: {{$namespaces}}
+    replicasPerNamespace: {{MultiplyInt $deploymentsPerNamespace $cnpsPerDeployment}}
+    tuningSet: {{$tuningSet}}
+    objectBundle:
+    - basename: small-deployment-cnp
+      objectTemplatePath: cnp.yaml
+      templateFillMap:
+        Deployments: {{$deploymentsPerNamespace}}
+        CNPs: {{$cnpsPerDeployment}}
+
+- name: Waiting for '{{$actionName}}' to be completed
+  measurements:
+  - Method: WaitForControlledPodsRunning
+    Instances:
+    - Identifier: WaitForRunningDeployments
+    Params:
+      action: gather

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -325,6 +325,7 @@ jobs:
           ./clusterloader \
             -v=2 \
             --testconfig=./testing/load/config.yaml \
+            --testconfig=./testing/custom/netpol/config.yaml \
             --provider=gce \
             --enable-prometheus-server \
             --tear-down-prometheus-server=false \


### PR DESCRIPTION
Add network policy scale-test that creates 600 identities, 3k pods, 3k network policies and measures policy implementation delay, cpu and mem usage.
Each security identitity is subject to 5 network policies. It includes policies: L3, L4, L4 CIDR, L3 CIDR, FQDN.

```release-note
ci: add network policy scale test
```
