### PR TITLE
v1.14 Backports 2024-10-07

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Cilium",
-  "image": "quay.io/cilium/cilium-builder:aa65b76872a236b21eb4dbc8959b12e7bdc8a90a@sha256:c3dfc8c33611ccd9587ea4df1a31a8a1eb9e4605a59133a47fe537dde8e0c004",
+  "image": "quay.io/cilium/cilium-builder:674cd7fe25caa1ed6135234b92ad55e2d567a9f2@sha256:7b2fd2c0fd3e73719d2089065d3d5604b7b18cd6edd700128fba2dc6d9e7bebb",
   "workspaceFolder": "/go/src/github.com/cilium/cilium",
   "workspaceMount": "source=${localWorkspaceFolder},target=/go/src/github.com/cilium/cilium,type=bind",
   "features": {

--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -286,20 +286,28 @@ jobs:
             ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${digest}"
           fi
 
-      - name: Commit changes by amending previous commit
-        # Run this step in case we have committed the cilium-runtime changes before
-        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' && steps.update-runtime-image.outputs.committed == 'false' }}
-        run: |
-          git commit --amend -sam "images: update cilium-{runtime,builder}"
-
       - name: Commit changes
-        # Run this step in case we have NOT committed the cilium-runtime changes before
-        if: ${{ (steps.cilium-runtime-tag-in-repositories.outputs.exists != 'false' || steps.update-runtime-image.outputs.committed != 'false') && steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        id: update-builder-image
         run: |
-          git commit -sam "images: update cilium-{runtime,builder}"
+          if [[ "${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}" == "true" ]]; then
+            ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${{ steps.docker_build_release_builder.outputs.digest }}"
+          else
+            digest=$(../cilium-base-branch/images/scripts/get-image-digest.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}")
+            ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${digest}"
+          fi
+          if ! git diff --quiet; then
+            if [[ "${{ steps.update-runtime-image.outputs.committed }}" == "true" ]]; then
+              git commit --amend -sam "images: update cilium-{runtime,builder}"
+            else
+              git commit -sam "images: update cilium-{runtime,builder}"
+            fi
+            echo committed="true" >> $GITHUB_OUTPUT
+          else
+            echo committed="false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Get token
-        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' || steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        if: ${{ steps.update-runtime-image.outputs.committed == 'true' || steps.update-builder-image.outputs.committed == 'true' }}
         id: get_token
         uses: cilium/actions-app-token@61a6271ce92ba02f49bf81c755685d59fb25a59a # v0.21.1
         with:
@@ -307,10 +315,10 @@ jobs:
           APP_ID: ${{ secrets.AUTO_COMMITTER_APP_ID }}
 
       - name: Push changes into PR
+        if: ${{ steps.update-runtime-image.outputs.committed == 'true' || steps.update-builder-image.outputs.committed == 'true' }}
         env:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository:  ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' || steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
         run: |
           git diff HEAD^
           git push https://x-access-token:${{ steps.get_token.outputs.app_token }}@github.com/${{ env.repository }}.git HEAD:${{ env.ref }}

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -147,7 +147,11 @@ jobs:
           BUILDER_CCACHE_DIR: "/tmp/.cache/ccache/.ccache"
         run: |
           set -eu -o pipefail
-          COMMITS=$(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
+          if [[ "${{ github.event_name == 'push' || github.event_name == 'workflow_run' }}" == "true" ]]; then
+            COMMITS=${{ github.sha }}
+          else
+            COMMITS=$(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
+          fi
           for commit in $COMMITS ; do
             git checkout $commit || exit 1
             # directories from the previous commit to the current commit.
@@ -180,7 +184,11 @@ jobs:
         if: steps.test-tree.outputs.src == 'true'
         run: |
           set -eu -o pipefail
-          COMMITS=$(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
+          if [[ "${{ github.event_name == 'push' || github.event_name == 'workflow_run' }}" == "true" ]]; then
+            COMMITS=${{ github.sha }}
+          else
+            COMMITS=$(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
+          fi
           for commit in $COMMITS ; do
             git checkout $commit || exit 1
             # Do not run make if there aren't any files modified in these

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -60,6 +60,10 @@ RUN CGO_ENABLED=0 go install github.com/go-delve/delve/cmd/dlv@latest
 
 WORKDIR /go/src/github.com/cilium/cilium/images/builder
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium/images/builder \
+    ./install-gitconfig.sh
+
+WORKDIR /go/src/github.com/cilium/cilium/images/builder
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium/images/builder \
     --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/go/pkg \
     ./build-debug-wrapper.sh

--- a/images/builder/install-gitconfig.sh
+++ b/images/builder/install-gitconfig.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+set -o nounset
+
+cat << EOF > "$HOME/.gitconfig"
+[safe]
+	directory = *
+EOF

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:aa65b76872a236b21eb4dbc8959b12e7bdc8a90a@sha256:c3dfc8c33611ccd9587ea4df1a31a8a1eb9e4605a59133a47fe537dde8e0c004
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:674cd7fe25caa1ed6135234b92ad55e2d567a9f2@sha256:7b2fd2c0fd3e73719d2089065d3d5604b7b18cd6edd700128fba2dc6d9e7bebb
 ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:0b9bdd61b48d4cb268671ecf9bc43f041f2c679b@sha256:42b8999f9b8d259f4f5ccc6c1c15dd0055a0eaee0a9aeecf33563553825d6973
 #
 # cilium-envoy from github.com/cilium/proxy

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -4,7 +4,7 @@
 ARG BASE_IMAGE=scratch
 ARG GOLANG_IMAGE=docker.io/library/golang:1.22.8@sha256:628529a29f130a8ab336b994be99d134ce98cd23b8f2052d8995678681e97ca2
 ARG ALPINE_IMAGE=docker.io/library/alpine:3.18.9@sha256:3ddf7bf1d408188f9849efbf4f902720ae08f5131bb39013518b918aa056d0de
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:aa65b76872a236b21eb4dbc8959b12e7bdc8a90a@sha256:c3dfc8c33611ccd9587ea4df1a31a8a1eb9e4605a59133a47fe537dde8e0c004
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:674cd7fe25caa1ed6135234b92ad55e2d567a9f2@sha256:7b2fd2c0fd3e73719d2089065d3d5604b7b18cd6edd700128fba2dc6d9e7bebb
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1983,10 +1983,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			testIngressKey(236, 0, 0): {},
 			HttpIngressKey(236):       {},
 		},
-		deletes: Keys{
-			testIngressKey(235, 0, 0): {}, // changed dependents
-			testIngressKey(236, 0, 0): {}, // changed dependents
-		},
+		deletes: Keys{},
 	}, {
 		continued: true,
 		name:      "test-2b - Adding Bar also selecting 235",
@@ -2009,9 +2006,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			testIngressKey(237, 0, 0): {},
 			HttpIngressKey(237):       {},
 		},
-		deletes: Keys{
-			testIngressKey(237, 0, 0): {}, // changed dependents
-		},
+		deletes: Keys{},
 	}, {
 		continued: true,
 		name:      "test-2c - Deleting 235 from Foo, remains on Bar and no deletes",

--- a/pkg/service/id_local.go
+++ b/pkg/service/id_local.go
@@ -87,9 +87,7 @@ func (alloc *IDAllocator) acquireLocalID(svc loadbalancer.L3n4Addr, desiredID ui
 	startingID := alloc.nextID
 	rollover := false
 	for {
-		if alloc.nextID == startingID && rollover {
-			break
-		} else if alloc.nextID == alloc.maxID {
+		if alloc.nextID == alloc.maxID {
 			alloc.nextID = alloc.initNextID
 			rollover = true
 		}
@@ -98,6 +96,10 @@ func (alloc *IDAllocator) acquireLocalID(svc loadbalancer.L3n4Addr, desiredID ui
 			svcID := alloc.addID(svc, alloc.nextID)
 			alloc.nextID++
 			return svcID, nil
+		}
+
+		if alloc.nextID == startingID && rollover {
+			break
 		}
 
 		alloc.nextID++


### PR DESCRIPTION
 * [ ] #35033 (@WeeNews) :warning: resolved conflicts
   * :information_source: Hit minor conflict due to different surrounding context in `service/id_test.go`. Accepted combination.
 * [ ] #35109 (@jrajahalme) :warning: resolved conflicts
    * :information_source: Hit minor conflict due to different surrounding context, accepted combination. Additionally updated the TestMapState_AccumulateMapChangesOnVisibilityKeys test, which has been removed in the meanwhile on main, applying the changes originally part of https://github.com/cilium/cilium/commit/137abf7b4b6a (from https://github.com/cilium/cilium/pull/35109).
 * [x] #35262 (@aanm) :warning: resolved conflicts
     * :information_source: Hit minor conflict due to different surrounding context (i.e., missing Update Protobuf APIs step); adapted accordingly.
 * [x] #35264 (@aanm)
 * [x] #31538 (@ti-mo, @aanm)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 35033 35109 35262 35264 31538
```
