### PR TITLE
Fix upgrade documentation at Helm template generation: "agent: Invalid type. Expected: boolean, given: object"

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -443,7 +443,7 @@ Generate the latest ConfigMap
 
     helm template cilium \
       --namespace=kube-system \
-      --set agent.enabled=false \
+      --set agent=false \
       --set config.enabled=true \
       --set operator.enabled=false \
       > cilium-configmap.yaml
@@ -561,7 +561,7 @@ The cilium preflight manifest requires etcd support and can be built with:
     helm template cilium \
       --namespace=kube-system \
       --set preflight.enabled=true \
-      --set agent.enabled=false \
+      --set agent=false \
       --set config.enabled=false \
       --set operator.enabled=false \
       --set etcd.enabled=true \


### PR DESCRIPTION
Using `agent.enabled=false` producing the following error:
```
helm template cilium/cilium   \
   --namespace=kube-system   \
   --set agent.enabled=false \
   --set config.enabled=true \
   --set operator.enabled=false   > cilium-configmap.yaml
coalesce.go:237: warning: skipped value for cilium.agent: Not a table.
Error: values don't meet the specifications of the schema(s) in the following chart(s):
cilium:
- agent: Invalid type. Expected: boolean, given: object
```

```release-note
docs: Change invalid Helm option --agent.enabled with --agent=false in upgrade documentation
```