### PR TITLE
ci: conformance-kind: enable test for REJECT on Service access

### DIFF
--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -186,7 +186,6 @@ jobs:
           # KubeProxy|kube-proxy : kube-proxy specifics
           # LoadBalancer|GCE|ExternalIP : require a cloud provider, some of them are GCE specifics
           # Netpol|NetworkPolicy : network policies, demand significant resources and use to be slow, better to run in a different job
-          # rejected : Kubernetes expect Services without endpoints associated to REJECT the connection to notify the client, Cilium silently drops the packet
           # externalTrafficPolicy : needs investigation
 
           # Run tests
@@ -194,7 +193,7 @@ jobs:
           export E2E_REPORT_DIR=${PWD}/_artifacts
           /usr/local/bin/ginkgo --nodes=25                \
             --focus="\[Conformance\]|\[sig-network\]"     \
-            --skip="Feature|Federation|PerformanceDNS|DualStack|Disruptive|Serial|KubeProxy|kube-proxy|ExternalIP|LoadBalancer|GCE|Netpol|NetworkPolicy|rejected|externalTrafficPolicy"   \
+            --skip="Feature|Federation|PerformanceDNS|DualStack|Disruptive|Serial|KubeProxy|kube-proxy|ExternalIP|LoadBalancer|GCE|Netpol|NetworkPolicy|externalTrafficPolicy"   \
             /usr/local/bin/e2e.test                       \
             --                                            \
             --kubeconfig=${PWD}/_artifacts/kubeconfig.conf     \

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -285,7 +285,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	if (!svc)
 		return -ENXIO;
 	if (svc->count == 0 && !lb4_svc_is_l7loadbalancer(svc))
-		return -EHOSTUNREACH;
+		return -ECONNREFUSED;
 
 	send_trace_sock_notify4(ctx_full, XLATE_PRE_DIRECTION_FWD, dst_ip,
 				bpf_ntohs(dst_port));
@@ -412,7 +412,7 @@ int cil_sock4_connect(struct bpf_sock_addr *ctx)
 #endif /* ENABLE_HEALTH_CHECK */
 
 	err = __sock4_xlate_fwd(ctx, ctx, false);
-	if (err == -EHOSTUNREACH || err == -ENOMEM) {
+	if (err == -EHOSTUNREACH || err == -ENOMEM || err == -ECONNREFUSED) {
 		try_set_retval(err);
 		return SYS_REJECT;
 	}
@@ -582,7 +582,7 @@ int cil_sock4_sendmsg(struct bpf_sock_addr *ctx)
 	int err;
 
 	err = __sock4_xlate_fwd(ctx, ctx, true);
-	if (err == -EHOSTUNREACH || err == -ENOMEM) {
+	if (err == -EHOSTUNREACH || err == -ENOMEM || err == -ECONNREFUSED) {
 		try_set_retval(err);
 		return SYS_REJECT;
 	}
@@ -988,7 +988,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	if (!svc)
 		return sock6_xlate_v4_in_v6(ctx, udp_only);
 	if (svc->count == 0 && !lb6_svc_is_l7loadbalancer(svc))
-		return -EHOSTUNREACH;
+		return -ECONNREFUSED;
 
 	send_trace_sock_notify6(ctx, XLATE_PRE_DIRECTION_FWD, &key.address,
 				bpf_ntohs(dst_port));
@@ -1086,7 +1086,7 @@ int cil_sock6_connect(struct bpf_sock_addr *ctx)
 #endif /* ENABLE_HEALTH_CHECK */
 
 	err = __sock6_xlate_fwd(ctx, false);
-	if (err == -EHOSTUNREACH || err == -ENOMEM) {
+	if (err == -EHOSTUNREACH || err == -ENOMEM || err == -ECONNREFUSED) {
 		try_set_retval(err);
 		return SYS_REJECT;
 	}
@@ -1183,7 +1183,7 @@ int cil_sock6_sendmsg(struct bpf_sock_addr *ctx)
 	int err;
 
 	err = __sock6_xlate_fwd(ctx, true);
-	if (err == -EHOSTUNREACH || err == -ENOMEM) {
+	if (err == -EHOSTUNREACH || err == -ENOMEM || err == -ECONNREFUSED) {
 		try_set_retval(err);
 		return SYS_REJECT;
 	}

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -297,7 +297,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	 * is from the host.
 	 */
 	if (sock4_skip_xlate(svc, orig_key.address))
-		return -EPERM;
+		return -ECONNREFUSED;
 
 #ifdef ENABLE_LOCAL_REDIRECT_POLICY
 	if (lb4_svc_is_localredirect(svc) &&
@@ -994,7 +994,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 				bpf_ntohs(dst_port));
 
 	if (sock6_skip_xlate(svc, &orig_key.address))
-		return -EPERM;
+		return -ECONNREFUSED;
 
 #if defined(ENABLE_LOCAL_REDIRECT_POLICY) && defined(HAVE_NETNS_COOKIE)
 	if (lb6_svc_is_localredirect(svc) &&


### PR DESCRIPTION
The desired behavior was implemented in
https://github.com/cilium/cilium/pull/28157, and this workflow should always be running in an environment where the feature is enabled by default.