### PR TITLE
Policy: fix ToServices performance regression

### DIFF
--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -450,8 +450,8 @@ type EndpointSlices struct {
 	epSlices map[string]*Endpoints
 }
 
-// newEndpointsSlices returns a new EndpointSlices
-func newEndpointsSlices() *EndpointSlices {
+// NewEndpointsSlices returns a new EndpointSlices
+func NewEndpointsSlices() *EndpointSlices {
 	return &EndpointSlices{
 		epSlices: map[string]*Endpoints{},
 	}

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -301,7 +301,7 @@ func (s *ServiceCache) GetEndpointsOfService(svcID ServiceID) *Endpoints {
 // Services are iterated in random order.
 // The ServiceCache is read-locked during this function call. The passed in
 // Service and Endpoints references are read-only.
-func (s *ServiceCache) ForEachService(yield func(svcID ServiceID, svc *Service, eps *Endpoints) bool) {
+func (s *ServiceCache) ForEachService(yield func(svcID ServiceID, svc *Service, eps *EndpointSlices) bool) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
@@ -310,8 +310,7 @@ func (s *ServiceCache) ForEachService(yield func(svcID ServiceID, svc *Service, 
 		if !ok {
 			continue
 		}
-		eps := ep.GetEndpoints()
-		if !yield(svcID, svc, eps) {
+		if !yield(svcID, svc, ep) {
 			return
 		}
 	}
@@ -454,7 +453,7 @@ func (s *ServiceCache) UpdateEndpoints(newEndpoints *Endpoints, swg *lock.Stoppa
 			return esID.ServiceID, newEndpoints
 		}
 	} else {
-		eps = newEndpointsSlices()
+		eps = NewEndpointsSlices()
 		s.endpoints[esID.ServiceID] = eps
 	}
 

--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -468,8 +468,8 @@ func TestForEachService(t *testing.T) {
 	}, 2*time.Second))
 
 	services := map[ServiceID]*Endpoints{}
-	svcCache.ForEachService(func(svcID ServiceID, svc *Service, eps *Endpoints) bool {
-		services[svcID] = eps
+	svcCache.ForEachService(func(svcID ServiceID, svc *Service, eps *EndpointSlices) bool {
+		services[svcID] = eps.GetEndpoints()
 		return true
 	})
 	require.Equal(t, map[ServiceID]*Endpoints{

--- a/pkg/policy/k8s/cell.go
+++ b/pkg/policy/k8s/cell.go
@@ -54,7 +54,7 @@ type PolicyManager interface {
 }
 
 type serviceCache interface {
-	ForEachService(func(svcID k8s.ServiceID, svc *k8s.Service, eps *k8s.Endpoints) bool)
+	ForEachService(func(svcID k8s.ServiceID, svc *k8s.Service, eps *k8s.EndpointSlices) bool)
 }
 
 type ipc interface {

--- a/pkg/policy/k8s/service.go
+++ b/pkg/policy/k8s/service.go
@@ -117,7 +117,7 @@ func (p *policyWatcher) updateToServicesPolicies(svcID k8s.ServiceID, newSVC, ol
 func (p *policyWatcher) resolveToServices(key resource.Key, cnp *types.SlimCNP) {
 	// We consult the service cache to obtain the service endpoints
 	// which are selected by the ToServices selectors found in the CNP.
-	p.svcCache.ForEachService(func(svcID k8s.ServiceID, svc *k8s.Service, eps *k8s.Endpoints) bool {
+	p.svcCache.ForEachService(func(svcID k8s.ServiceID, svc *k8s.Service, eps *k8s.EndpointSlices) bool {
 		if !p.isSelectableService(svc) {
 			return true // continue
 		}
@@ -259,14 +259,14 @@ func serviceRefMatches(ref *api.K8sServiceNamespace, svcID k8s.ServiceID) bool {
 type serviceEndpoints struct {
 	svcID k8s.ServiceID
 	svc   *k8s.Service
-	eps   *k8s.Endpoints
+	eps   *k8s.EndpointSlices
 
 	valid  bool
 	cached []api.CIDR
 }
 
 // newServiceEndpoints returns an initialized serviceEndpoints struct
-func newServiceEndpoints(svcID k8s.ServiceID, svc *k8s.Service, eps *k8s.Endpoints) *serviceEndpoints {
+func newServiceEndpoints(svcID k8s.ServiceID, svc *k8s.Service, eps *k8s.EndpointSlices) *serviceEndpoints {
 	return &serviceEndpoints{
 		svcID: svcID,
 		svc:   svc,
@@ -281,7 +281,7 @@ func (s *serviceEndpoints) endpoints() []api.CIDR {
 		return s.cached
 	}
 
-	prefixes := s.eps.Prefixes()
+	prefixes := s.eps.GetEndpoints().Prefixes()
 	s.cached = make([]api.CIDR, 0, len(prefixes))
 	for _, prefix := range prefixes {
 		s.cached = append(s.cached, api.CIDR(prefix.String()))

--- a/pkg/policy/k8s/service_test.go
+++ b/pkg/policy/k8s/service_test.go
@@ -56,9 +56,11 @@ type fakeService struct {
 
 type fakeServiceCache map[k8s.ServiceID]fakeService
 
-func (f fakeServiceCache) ForEachService(yield func(svcID k8s.ServiceID, svc *k8s.Service, eps *k8s.Endpoints) bool) {
+func (f fakeServiceCache) ForEachService(yield func(svcID k8s.ServiceID, svc *k8s.Service, eps *k8s.EndpointSlices) bool) {
 	for svcID, s := range f {
-		if !yield(svcID, s.svc, s.eps) {
+		eps := k8s.NewEndpointsSlices()
+		eps.Upsert("foo", s.eps)
+		if !yield(svcID, s.svc, eps) {
 			break
 		}
 	}


### PR DESCRIPTION
This PR contains two commits:

1: Make service iteration more efficient. It turns out that calling `eps.Endpoints()` is very allocation-heavy. Before this change, it was called for every service when iterating, which was unnecessary. Instead, leave this to the caller, who can do so only when necessary

2: Skip policy ToServices translation when policy has no ToServices selectors. We already track whether or not policies have a ToServices selector. When one does not, we do not need to try and translate services.

Fixes: #35273

```release-note
Fixes a performance regression when ingesting network policies in clusters with large numbers of Services.
```
