### PR TITLE
ci: switch most remaining workflows to new IPsec key system

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -293,7 +293,7 @@ jobs:
 
       - name: Create custom IPsec secret
         run: |
-          kubectl create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="15 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
+          kubectl create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="15+ rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 
       - name: Install Cilium with encryption
         run: |

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -498,7 +498,7 @@ jobs:
       - name: Create the IPSec secret in both clusters
         if: matrix.encryption == 'ipsec'
         run: |
-          SECRET="3 rfc4106(gcm(aes)) $(openssl rand -hex 20) 128"
+          SECRET="3+ rfc4106(gcm(aes)) $(openssl rand -hex 20) 128"
           kubectl --context ${{ env.contextName1 }} create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="${SECRET}"
           kubectl --context ${{ env.contextName2 }} create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="${SECRET}"
 

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -299,7 +299,7 @@ jobs:
       - name: Create custom IPsec secret
         if: ${{ matrix.config.type == 'ipsec' || matrix.config.type == 'tunnel-ipsec' }}
         run: |
-          kubectl create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="15 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
+          kubectl create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="15+ rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 
       - name: Install Cilium
         id: install-cilium

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -284,7 +284,7 @@ jobs:
       - name: Create the IPSec secret in both clusters
         if: matrix.encryption == 'ipsec'
         run: |
-          SECRET="3 rfc4106(gcm(aes)) $(openssl rand -hex 20) 128"
+          SECRET="3+ rfc4106(gcm(aes)) $(openssl rand -hex 20) 128"
           kubectl --context ${{ env.contextName1 }} create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="${SECRET}"
           kubectl --context ${{ env.contextName2 }} create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="${SECRET}"
 


### PR DESCRIPTION
```
The global IPsec key system is deprecated [0], prefer the new per-tunnel
key system. This switches most workflows over to the new system, except
conformance-eks which needs [1] addressed first.

[0] https://github.com/cilium/cilium/pull/33504
[1] https://github.com/cilium/cilium/issues/32040
``` 