### PR TITLE
bpf: Enforce symmetric routing for endpoints with parent interfaces

### DIFF
--- a/api/v1/models/endpoint_change_request.go
+++ b/api/v1/models/endpoint_change_request.go
@@ -79,6 +79,9 @@ type EndpointChangeRequest struct {
 	// Network namespace cookie
 	NetnsCookie string `json:"netns-cookie,omitempty"`
 
+	// Index of network device from which an IP was used as endpoint IP. Only relevant for ENI environments.
+	ParentInterfaceIndex int64 `json:"parent-interface-index,omitempty"`
+
 	// Process ID of the workload belonging to this endpoint
 	Pid int64 `json:"pid,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1403,6 +1403,11 @@ definitions:
       interface-index:
         description: Index of network device in host netns
         type: integer
+      parent-interface-index:
+        description: >-
+          Index of network device from which an IP was used as endpoint IP.
+          Only relevant for ENI environments.
+        type: integer
       container-interface-name:
         description: Name of network device in container netns
         type: string

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2905,6 +2905,10 @@ func init() {
           "description": "Network namespace cookie",
           "type": "string"
         },
+        "parent-interface-index": {
+          "description": "Index of network device from which an IP was used as endpoint IP. Only relevant for ENI environments.",
+          "type": "integer"
+        },
         "pid": {
           "description": "Process ID of the workload belonging to this endpoint",
           "type": "integer"
@@ -8695,6 +8699,10 @@ func init() {
         "netns-cookie": {
           "description": "Network namespace cookie",
           "type": "string"
+        },
+        "parent-interface-index": {
+          "description": "Index of network device from which an IP was used as endpoint IP. Only relevant for ENI environments.",
+          "type": "integer"
         },
         "pid": {
           "description": "Process ID of the workload belonging to this endpoint",

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -338,7 +338,8 @@ struct endpoint_info {
 	mac_t		mac;
 	mac_t		node_mac;
 	__u32		sec_id;
-	__u32		pad[3];
+	__u32		parent_ifindex;
+	__u32		pad[2];
 };
 
 struct edt_id {

--- a/bpf/tests/eni_nlb_symetric_routing_host.c
+++ b/bpf/tests/eni_nlb_symetric_routing_host.c
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+/* Enable CT debug output */
+#undef QUIET_CT
+
+#define DEBUG
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+
+/* Enable code paths under test*/
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define ENABLE_ROUTING
+
+#define PRIMARY_IFACE 1
+#define SECONDARY_IFACE 2
+#define BACKEND_IFACE 123
+
+#define NATIVE_DEV_IFINDEX PRIMARY_IFACE
+
+#define BACKEND_EP_ID 127
+
+#define DEFAULT_ROUTE_MAC mac_one
+#define NODE_MAC mac_two
+#define LOCAL_BACKEND_MAC mac_three
+
+#define ctx_redirect mock_ctx_redirect
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__type(key, __u32);
+	__type(value, __u32);
+	__uint(max_entries, 1);
+} redirect_ifindex_map __section_maps_btf;
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
+{
+	__u32 key = 0;
+	__u32 *value = map_lookup_elem(&redirect_ifindex_map, &key);
+
+	if (value)
+		*value = ifindex;
+
+	return CTX_ACT_REDIRECT;
+}
+
+#include <bpf_host.c>
+
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+
+#define TO_NETDEV	0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[TO_NETDEV] = &cil_to_netdev,
+	},
+};
+
+/* Setup for this test:
+ *
+ * +-------World IP---------+    +----------Pod IP---------+
+ * | v4_ext_one:tcp_src_one | -> | v4_pod_one:tcp_dst_one |
+ * +------------------------+    +------------------------+
+ *          ^                            |
+ *          \---------------------------/
+ *
+ * This happens when in ENI mode and we get traffic via a NLB in ip-mode + preserve-client-ip.
+ * NLB NAT'ing is invisible to us, so we effectively see world to pod IP traffic.
+ * We need to make sure that in BPF masquerade mode, we do not masquerade the pod IP for the return traffic
+ * and route it out of the interface associated with the pod IP, even though egress traffic to
+ * the world is normally routed via the primary interface.
+ *
+ * This test simulates an original incoming packet already traversed the ingress path
+ * and was accepted, leaving a CT entry. We act as if the packet here is entering the
+ * cil_to_netdev on the wrong device, and we expect it to be redirected to the correct
+ * secondary device.
+ */
+
+/* Create a boring TCP packet */
+PKTGEN("tc", "eni_nlb_symetric_routing_egress_v4_setup")
+int eni_nlb_symetric_routing_egress_v4_setup_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)mac_zero, (__u8 *)mac_zero,
+					  v4_pod_one, v4_ext_one,
+					  tcp_dst_one, tcp_src_one);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+/* Setup IPCache / Endpoint map / CT state according to the scenario */
+SETUP("tc", "eni_nlb_symetric_routing_egress_v4_setup")
+int eni_nlb_symetric_routing_egress_v4_setup_setup(struct __ctx_buff *ctx)
+{
+	struct ipv4_ct_tuple ct = {
+		.daddr = v4_ext_one,
+		.saddr = v4_pod_one,
+		.dport = tcp_dst_one,
+		.sport = tcp_src_one,
+		.nexthdr = IPPROTO_TCP,
+		.flags = 1,
+	};
+	struct ct_state state = {0};
+
+	state.src_sec_id = WORLD_ID;
+
+	endpoint_v4_add_entry(v4_pod_one, BACKEND_IFACE, BACKEND_EP_ID, 0, 0,
+			      SECONDARY_IFACE, (__u8 *)LOCAL_BACKEND_MAC, (__u8 *)NODE_MAC);
+
+	ipcache_v4_add_entry(v4_pod_one, 0, SECLABEL, 0, 0);
+
+	ct_create4(&CT_MAP_TCP4, NULL, &ct, ctx, CT_INGRESS, &state, NULL);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "eni_nlb_symetric_routing_egress_v4_setup")
+int eni_nlb_symetric_routing_egress_v4_setup_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct iphdr *l3;
+	struct tcphdr *l4;
+	__u32 key = 0;
+	__u32 *redirect_ifindex;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	if (*status_code != TC_ACT_REDIRECT)
+		test_fatal("packet has not been redirected");
+
+	redirect_ifindex = map_lookup_elem(&redirect_ifindex_map, &key);
+	if (!redirect_ifindex)
+		test_fatal("redirect_ifindex not found");
+
+	if (*redirect_ifindex != SECONDARY_IFACE)
+		test_fatal("redirected to ifindex %d, expected %d", *redirect_ifindex,
+			   SECONDARY_IFACE);
+
+	l3 =  data + sizeof(__u32) + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->saddr != v4_pod_one)
+		test_fatal("src IP changed");
+
+	if (l3->daddr != v4_ext_one)
+		test_fatal("dest IP changed");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != tcp_dst_one)
+		test_fatal("src TCP port changed");
+
+	if (l4->dest != tcp_src_one)
+		test_fatal("dst TCP port changed");
+
+	test_finish();
+}

--- a/bpf/tests/hairpin_sctp_flow.c
+++ b/bpf/tests/hairpin_sctp_flow.c
@@ -95,7 +95,7 @@ int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 	/* Add an IPCache entry for pod 1 */
 	ipcache_v4_add_entry(v4_pod_one, 0, 112233, 0, 0);
 
-	endpoint_v4_add_entry(v4_pod_one, 0, 0, 0, 0, NULL, NULL);
+	endpoint_v4_add_entry(v4_pod_one, 0, 0, 0, 0, 0, NULL, NULL);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, 0);

--- a/bpf/tests/hostfw_host_iptables.c
+++ b/bpf/tests/hostfw_host_iptables.c
@@ -80,7 +80,7 @@ SETUP("tc", "hostfw_iptables_host_ipv4_01_pod")
 int hostfw_iptables_host_ipv4_01_pod_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(NODE_IP, 0, 0, ENDPOINT_F_HOST, HOST_ID,
-			      (__u8 *)node_mac, (__u8 *)node_mac);
+			      0, (__u8 *)node_mac, (__u8 *)node_mac);
 	ipcache_v4_add_entry(NODE_IP, 0, HOST_ID, 0, 0);
 	ipcache_v4_add_world_entry();
 

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
@@ -192,7 +192,7 @@ int from_overlay_syn_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "01_from_overlay_syn")
 int from_overlay_syn_setup(struct __ctx_buff *ctx)
 {
-	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFINDEX, 0, 0, 0,
+	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFINDEX, 0, 0, 0, 0,
 			      (__u8 *)BACKEND_MAC, (__u8 *)BACKEND_ROUTER_MAC);
 
 	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);

--- a/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
@@ -292,7 +292,7 @@ int from_overlay_synack_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "02_from_overlay_synack")
 int from_overlay_synack_setup(struct __ctx_buff *ctx)
 {
-	endpoint_v4_add_entry(CLIENT_IP, CLIENT_IFINDEX, 0, 0, 0,
+	endpoint_v4_add_entry(CLIENT_IP, CLIENT_IFINDEX, 0, 0, 0, 0,
 			      (__u8 *)CLIENT_MAC, (__u8 *)CLIENT_ROUTER_MAC);
 
 	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);

--- a/bpf/tests/ipsec_from_network_generic.h
+++ b/bpf/tests/ipsec_from_network_generic.h
@@ -343,7 +343,7 @@ int ipv4_decrypted_ipsec_from_network_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "ipv4_decrypted_ipsec_from_network")
 int ipv4_decrypted_ipsec_from_network_setup(struct __ctx_buff *ctx)
 {
-	endpoint_v4_add_entry(v4_pod_two, DEST_IFINDEX, DEST_LXC_ID, 0, 0,
+	endpoint_v4_add_entry(v4_pod_two, DEST_IFINDEX, DEST_LXC_ID, 0, 0, 0,
 			      (__u8 *)DEST_EP_MAC, (__u8 *)DEST_NODE_MAC);
 
 	ctx->mark = MARK_MAGIC_DECRYPT;

--- a/bpf/tests/ipsec_from_overlay_generic.h
+++ b/bpf/tests/ipsec_from_overlay_generic.h
@@ -376,7 +376,7 @@ int ipv4_decrypted_ipsec_from_overlay_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "ipv4_decrypted_ipsec_from_overlay")
 int ipv4_decrypted_ipsec_from_overlay_setup(struct __ctx_buff *ctx)
 {
-	endpoint_v4_add_entry(v4_pod_two, DEST_IFINDEX, DEST_LXC_ID, 0, 0,
+	endpoint_v4_add_entry(v4_pod_two, DEST_IFINDEX, DEST_LXC_ID, 0, 0, 0,
 			      (__u8 *)DEST_EP_MAC, (__u8 *)DEST_NODE_MAC);
 
 	ctx->mark = MARK_MAGIC_DECRYPT;

--- a/bpf/tests/lib/endpoint.h
+++ b/bpf/tests/lib/endpoint.h
@@ -3,7 +3,7 @@
 
 static __always_inline void
 endpoint_v4_add_entry(__be32 addr, __u32 ifindex, __u16 lxc_id, __u32 flags, __u32 sec_id,
-		      const __u8 *ep_mac_addr, const __u8 *node_mac_addr)
+		      __u32 parent_ifindex, const __u8 *ep_mac_addr, const __u8 *node_mac_addr)
 {
 	struct endpoint_key key = {
 		.ip4 = addr,
@@ -14,6 +14,7 @@ endpoint_v4_add_entry(__be32 addr, __u32 ifindex, __u16 lxc_id, __u32 flags, __u
 		.lxc_id = lxc_id,
 		.flags = flags,
 		.sec_id = sec_id,
+		.parent_ifindex = parent_ifindex,
 	};
 
 	if (ep_mac_addr)

--- a/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
+++ b/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
@@ -142,7 +142,7 @@ int nodeport_geneve_dsr_lb_xdp1_local_backend_setup(struct __ctx_buff *ctx)
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
 
 	/* add local backend */
-	endpoint_v4_add_entry(BACKEND_IP_LOCAL, 0, 0, 0, 0,
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, 0, 0, 0, 0, 0,
 			      (__u8 *)local_backend_mac, (__u8 *)node_mac);
 
 	ipcache_v4_add_entry(BACKEND_IP_LOCAL, 0, 112233, 0, 0);

--- a/bpf/tests/skip_lb_xlate_lrp_per_packet_lb.c
+++ b/bpf/tests/skip_lb_xlate_lrp_per_packet_lb.c
@@ -86,7 +86,7 @@ int v4_local_backend_to_service_setup(struct __ctx_buff *ctx)
 
 	/* Add an IPCache entry for the backend pod */
 	ipcache_v4_add_entry(V4_BACKEND_IP, 0, 112233, 0, 0);
-	endpoint_v4_add_entry(V4_BACKEND_IP, 0, 0, 0, 0, NULL, NULL);
+	endpoint_v4_add_entry(V4_BACKEND_IP, 0, 0, 0, 0, 0, NULL, NULL);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);

--- a/bpf/tests/skip_tunnel_nodeport_masq.c
+++ b/bpf/tests/skip_tunnel_nodeport_masq.c
@@ -124,7 +124,7 @@ setup(struct __ctx_buff *ctx, bool v4, bool flag_skip_tunnel)
 	 */
 
 	if (v4) {
-		endpoint_v4_add_entry(SRC_IPV4, 0, 0, 0, 0, (__u8 *)SRC_MAC, (__u8 *)SRC_MAC);
+		endpoint_v4_add_entry(SRC_IPV4, 0, 0, 0, 0, 0, (__u8 *)SRC_MAC, (__u8 *)SRC_MAC);
 		ipcache_v4_add_entry_with_flags(DST_IPV4,
 						0, REMOTE_NODE_ID, 0,
 						0, flag_skip_tunnel);

--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -178,7 +178,7 @@ SETUP("tc", "tc_egressgw_drop_no_egress_ip")
 int egressgw_drop_no_egress_ip_setup(struct __ctx_buff *ctx)
 {
 	ipcache_v4_add_entry_with_mask_size(v4_all, 0, WORLD_IPV4_ID, 0, 0, 0);
-	endpoint_v4_add_entry(GATEWAY_NODE_IP, 0, 0, ENDPOINT_F_HOST, 0, NULL, NULL);
+	endpoint_v4_add_entry(GATEWAY_NODE_IP, 0, 0, ENDPOINT_F_HOST, 0, 0, NULL, NULL);
 
 	create_ct_entry(ctx, client_port(TEST_DROP_NO_EGRESS_IP));
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, GATEWAY_NODE_IP,

--- a/bpf/tests/tc_host_encrypted_overlay.c
+++ b/bpf/tests/tc_host_encrypted_overlay.c
@@ -108,7 +108,7 @@ int tc_host_encrypted_overlay_01_setup(struct __ctx_buff *ctx)
 	__u32 encrypt_key = 0;
 
 	endpoint_v4_add_entry(POD1_IP, POD1_IFACE, 0, 0, POD1_SEC_IDENTITY,
-			      (__u8 *)pod1_mac, (__u8 *)node1_mac);
+			      0, (__u8 *)pod1_mac, (__u8 *)node1_mac);
 	node_v4_add_entry(NODE2_IP, NODE2_ID, NODE2_SPI);
 	map_update_elem(&ENCRYPT_MAP, &encrypt_key, &encrypt_value, BPF_ANY);
 

--- a/bpf/tests/tc_nodeport_l3_dev.c
+++ b/bpf/tests/tc_nodeport_l3_dev.c
@@ -110,7 +110,7 @@ int ipv4_l3_to_l2_fast_redirect_setup(struct __ctx_buff *ctx)
 	__u64 flags = BPF_F_ADJ_ROOM_FIXED_GSO;
 
 	endpoint_v4_add_entry(TEST_IP_LOCAL, 0, TEST_LXC_ID_LOCAL, 0, 0,
-			      (__u8 *)ep_mac, (__u8 *)node_mac);
+			      0, (__u8 *)ep_mac, (__u8 *)node_mac);
 
 	/* As commented in PKTGEN, now we strip the L2 header. Bpf helper
 	 * skb_adjust_room will use L2 header to overwrite L3 header, so we play

--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -187,7 +187,7 @@ SETUP("tc", "tc_nodeport_dsr_backend")
 int nodeport_dsr_backend_setup(struct __ctx_buff *ctx)
 {
 	/* add local backend */
-	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFACE, BACKEND_EP_ID, 0, 0,
+	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
 			      (__u8 *)backend_mac, (__u8 *)node_mac);
 
 	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, 0, 0);

--- a/bpf/tests/tc_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_backend.c
@@ -118,7 +118,7 @@ int nodeport_nat_backend_setup(struct __ctx_buff *ctx)
 	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, 1, 124,
 			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
 
-	endpoint_v4_add_entry(BACKEND_IP, 0, BACKEND_EP_ID, 0, 0,
+	endpoint_v4_add_entry(BACKEND_IP, 0, BACKEND_EP_ID, 0, 0, 0,
 			      (__u8 *)backend_mac, (__u8 *)node_mac);
 
 	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, 0, 0);

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -213,7 +213,7 @@ int nodeport_local_backend_setup(struct __ctx_buff *ctx)
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
 
 	/* add local backend */
-	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, BACKEND_EP_ID, 0, 0,
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
 			      (__u8 *)local_backend_mac, (__u8 *)node_mac);
 
 	ipcache_v4_add_entry(BACKEND_IP_LOCAL, 0, 112233, 0, 0);

--- a/bpf/tests/tc_nodeport_lb_terminating_backend.c
+++ b/bpf/tests/tc_nodeport_lb_terminating_backend.c
@@ -147,7 +147,7 @@ int tc_nodeport_lb_terminating_backend_0_setup(struct __ctx_buff *ctx)
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_UDP, 0);
 
 	/* add local backend */
-	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, BACKEND_EP_ID, 0, 0,
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
 			      (__u8 *)local_backend_mac, (__u8 *)node_mac);
 
 	ipcache_v4_add_entry(BACKEND_IP_LOCAL, 0, 112233, 0, 0);

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -104,7 +104,7 @@ int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 	/* Add an IPCache entry for pod 1 */
 	ipcache_v4_add_entry(v4_pod_one, 0, 112233, 0, 0);
 
-	endpoint_v4_add_entry(v4_pod_one, 0, 0, 0, 0, NULL, NULL);
+	endpoint_v4_add_entry(v4_pod_one, 0, 0, 0, 0, 0, NULL, NULL);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, 0);

--- a/bpf/tests/tc_srv6_decap.c
+++ b/bpf/tests/tc_srv6_decap.c
@@ -124,7 +124,7 @@ int srv6_decap_to_pod_ipv4_setup(struct __ctx_buff *ctx __maybe_unused)
 
 	map_update_elem(&SRV6_SID_MAP, &sid, &vrf_id, 0);
 
-	endpoint_v4_add_entry(POD_IPV4, 12345, 100, 0, 0,
+	endpoint_v4_add_entry(POD_IPV4, 12345, 100, 0, 0, 0,
 			      (__u8 *)POD_MAC, (__u8 *)ROUTER_MAC);
 
 	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
@@ -405,7 +405,7 @@ int srv6_decap_to_service_ipv4_setup(struct __ctx_buff *ctx __maybe_unused)
 	lb_v4_add_backend(SERVICE_IPV4, SERVICE_PORT, 1, 124,
 			  POD_IPV4, SERVICE_PORT, IPPROTO_TCP, 0);
 
-	endpoint_v4_add_entry(POD_IPV4, 12345, 100, 0, 0,
+	endpoint_v4_add_entry(POD_IPV4, 12345, 100, 0, 0, 0,
 			      (__u8 *)POD_MAC, (__u8 *)ROUTER_MAC);
 
 	tail_call_static(ctx, entry_call_map, FROM_NETDEV);

--- a/bpf/tests/xdp_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_backend.c
@@ -89,7 +89,7 @@ int nodeport_nat_backend_setup(struct __ctx_buff *ctx)
 			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
 
 	/* add local backend */
-	endpoint_v4_add_entry(BACKEND_IP, 0, 0, 0, 0, NULL, NULL);
+	endpoint_v4_add_entry(BACKEND_IP, 0, 0, 0, 0, 0, NULL, NULL);
 
 	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, 0, 0);
 

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -140,7 +140,7 @@ int nodeport_local_backend_setup(struct __ctx_buff *ctx)
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
 
 	/* add local backend */
-	endpoint_v4_add_entry(BACKEND_IP_LOCAL, 0, 0, 0, 0,
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, 0, 0, 0, 0, 0,
 			      (__u8 *)local_backend_mac, (__u8 *)node_mac);
 	ipcache_v4_add_entry(BACKEND_IP_LOCAL, 0, 112233, 0, 0);
 

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -63,6 +63,7 @@ func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, p
 	ep := createEndpoint(owner, policyGetter, namedPortsGetter, proxy, allocator, uint16(base.ID), base.InterfaceName)
 	ep.ifIndex = int(base.InterfaceIndex)
 	ep.containerIfName = base.ContainerInterfaceName
+	ep.parentIfIndex = int(base.ParentInterfaceIndex)
 	if base.ContainerName != "" {
 		ep.containerName.Store(&base.ContainerName)
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -112,6 +112,10 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 		fmt.Fprintf(fw, " * Container Interface: %s\n", e.containerIfName)
 	}
 
+	if e.parentIfIndex != 0 {
+		fmt.Fprintf(fw, " * Parent Interface IfIndex: %d\n", e.parentIfIndex)
+	}
+
 	if option.Config.EnableIPv6 {
 		fmt.Fprintf(fw, " * IPv6 address: %s\n", e.IPv6.String())
 	}

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -43,6 +43,7 @@ type epInfoCache struct {
 	options                *option.IntOptions
 	lxcMAC                 mac.MAC
 	ifIndex                int
+	parentIfIndex          int
 	netNsCookie            uint64
 
 	// endpoint is used to get the endpoint's logger.
@@ -89,6 +90,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		options:                e.Options.DeepCopy(),
 		lxcMAC:                 e.mac,
 		ifIndex:                e.ifIndex,
+		parentIfIndex:          e.parentIfIndex,
 		netNsCookie:            e.NetNsCookie,
 
 		endpoint: e,
@@ -97,6 +99,10 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 
 func (ep *epInfoCache) GetIfIndex() int {
 	return ep.ifIndex
+}
+
+func (ep *epInfoCache) GetParentIfIndex() int {
+	return ep.parentIfIndex
 }
 
 func (ep *epInfoCache) LXCMac() mac.MAC {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -196,6 +196,10 @@ type Endpoint struct {
 	// Immutable after Endpoint creation.
 	containerIfName string
 
+	// parentIfIndex is the interface index of the network device over which traffic
+	// with the source endpoints IP should egress when that traffic is not masqueraded.
+	parentIfIndex int
+
 	// disableLegacyIdentifiers disables lookup using legacy endpoint identifiers
 	// (container name, container id, pod name) for this endpoint.
 	// Immutable after Endpoint creation.
@@ -481,6 +485,11 @@ func (e *Endpoint) UpdateController(name string, params controller.ControllerPar
 // GetIfIndex returns the ifIndex for this endpoint.
 func (e *Endpoint) GetIfIndex() int {
 	return e.ifIndex
+}
+
+// GetParentIfIndex returns the parentIfIndex for this endpoint.
+func (e *Endpoint) GetParentIfIndex() int {
+	return e.parentIfIndex
 }
 
 // LXCMac returns the LXCMac for this endpoint.

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -59,7 +59,7 @@ var mtuMock = fakeMTU{}
 func TestAllocatedIPDump(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil)
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil, nil)
 	ipam.ConfigureAllocator()
 
 	allocv4, allocv6, status := ipam.Dump()
@@ -80,7 +80,7 @@ func TestExpirationTimer(t *testing.T) {
 
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil)
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil, nil)
 	ipam.ConfigureAllocator()
 
 	err := ipam.AllocateIP(ip, "foo", PoolDefault())
@@ -148,7 +148,7 @@ func TestAllocateNextWithExpiration(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	fakeMetadata := fakeMetadataFunc(func(owner string, family Family) (pool string, err error) { return "some-pool", nil })
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, fakeMetadata)
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, fakeMetadata, nil)
 	ipam.ConfigureAllocator()
 
 	// Allocate IPs and test expiration timer. 'pool' is empty in order to test

--- a/pkg/ipam/cell/cell.go
+++ b/pkg/ipam/cell/cell.go
@@ -8,6 +8,7 @@ import (
 
 	ipamrestapi "github.com/cilium/cilium/api/v1/server/restapi/ipam"
 	"github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	datapathTypes "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -47,10 +48,11 @@ type ipamParams struct {
 	Clientset           k8sClient.Clientset
 	IPAMMetadataManager ipamMetadata.Manager
 	NodeDiscovery       *nodediscovery.NodeDiscovery
+	Sysctl              sysctl.Sysctl
 }
 
 func newIPAddressManager(params ipamParams) *ipam.IPAM {
-	return ipam.NewIPAM(params.NodeAddressing, params.AgentConfig, params.NodeDiscovery, params.LocalNodeStore, params.K8sEventReporter, params.NodeResource, params.MTU, params.Clientset, params.IPAMMetadataManager)
+	return ipam.NewIPAM(params.NodeAddressing, params.AgentConfig, params.NodeDiscovery, params.LocalNodeStore, params.K8sEventReporter, params.NodeResource, params.MTU, params.Clientset, params.IPAMMetadataManager, params.Sysctl)
 }
 
 type ipamAPIHandlerParams struct {

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -100,7 +100,7 @@ func TestMarkForReleaseNoAllocate(t *testing.T) {
 		sharedNodeStore.ownNode = cn
 	})
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(fakeAddressing, conf, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil)
+	ipam := NewIPAM(fakeAddressing, conf, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil, nil)
 	ipam.ConfigureAllocator()
 	sharedNodeStore.updateLocalNodeResource(cn)
 

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -122,7 +122,7 @@ func (f fakePoolAllocator) RestoreFinished() {}
 func TestLock(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil)
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil, nil)
 	ipam.ConfigureAllocator()
 
 	// Since the IPs we have allocated to the endpoints might or might not
@@ -146,7 +146,7 @@ func TestLock(t *testing.T) {
 func TestExcludeIP(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil)
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, nil, nil)
 	ipam.ConfigureAllocator()
 
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
@@ -194,7 +194,7 @@ func TestIPAMMetadata(t *testing.T) {
 		}
 	})
 
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, fakeMetadata)
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, fakeMetadata, nil)
 	ipam.ConfigureAllocator()
 	ipam.IPv4Allocator = newFakePoolAllocator(map[string]string{
 		"default": "10.10.0.0/16",
@@ -253,7 +253,7 @@ func TestLegacyAllocatorIPAMMetadata(t *testing.T) {
 	fakeAddressing := fakeTypes.NewNodeAddressing()
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	fakeMetadata := fakeMetadataFunc(func(owner string, family Family) (pool string, err error) { return "some-pool", nil })
-	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, fakeMetadata)
+	ipam := NewIPAM(fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, fakeMetadata, nil)
 	ipam.ConfigureAllocator()
 
 	// AllocateIP requires explicit pool

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/lock"
@@ -115,6 +116,7 @@ type IPAM struct {
 	mtuConfig      MtuConfiguration
 	clientset      client.Clientset
 	nodeDiscovery  Owner
+	sysctl         sysctl.Sysctl
 }
 
 // DebugStatus implements debug.StatusObject to provide debug status collection

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -62,6 +62,7 @@ type EndpointFrontend interface {
 	LXCMac() mac.MAC
 	GetNodeMAC() mac.MAC
 	GetIfIndex() int
+	GetParentIfIndex() int
 	GetID() uint64
 	IPv4Address() netip.Addr
 	IPv6Address() netip.Addr
@@ -102,11 +103,12 @@ func GetBPFValue(e EndpointFrontend) (*EndpointInfo, error) {
 
 	// Both lxc and node mac can be nil for the case of L3/NOARP devices.
 	info := &EndpointInfo{
-		IfIndex: uint32(e.GetIfIndex()),
-		LxcID:   uint16(e.GetID()),
-		MAC:     mac,
-		NodeMAC: nodeMAC,
-		SecID:   e.GetIdentity().Uint32(), // Host byte-order
+		IfIndex:       uint32(e.GetIfIndex()),
+		LxcID:         uint16(e.GetID()),
+		MAC:           mac,
+		NodeMAC:       nodeMAC,
+		SecID:         e.GetIdentity().Uint32(), // Host byte-order
+		ParentIfIndex: uint32(e.GetParentIfIndex()),
 	}
 
 	if e.IsAtHostNS() {
@@ -117,7 +119,7 @@ func GetBPFValue(e EndpointFrontend) (*EndpointInfo, error) {
 
 }
 
-type pad3uint32 [3]uint32
+type pad2uint32 [2]uint32
 
 // EndpointInfo represents the value of the endpoints BPF map.
 //
@@ -128,11 +130,12 @@ type EndpointInfo struct {
 	LxcID   uint16 `align:"lxc_id"`
 	Flags   uint32 `align:"flags"`
 	// go alignment
-	_       uint32
-	MAC     mac.Uint64MAC `align:"mac"`
-	NodeMAC mac.Uint64MAC `align:"node_mac"`
-	SecID   uint32        `align:"sec_id"`
-	Pad     pad3uint32    `align:"pad"`
+	_             uint32
+	MAC           mac.Uint64MAC `align:"mac"`
+	NodeMAC       mac.Uint64MAC `align:"node_mac"`
+	SecID         uint32        `align:"sec_id"`
+	ParentIfIndex uint32        `align:"parent_ifindex"`
+	Pad           pad2uint32    `align:"pad"`
 }
 
 type EndpointKey struct {


### PR DESCRIPTION
In certain setups, such as AWS ENI, it is expected that non-masqueraded traffic from an endpoint always egresses via a designated interface. We call this interface its parent interface.

Normally, this is taken care of by routes and assumptions. We have routes that direct traffic to the parent interface, for pod-to-pod and CIDRs in the non-masquerade list.

However, there are cases such as when the AWS NLB is configured to run in "target type: ip" (balance traffic directly to pod IPs) and with the `preserve_client_ip` option enabled (do not SNAT the source IP) that the route based approach breaks down. In this case, Cilium sees world traffic directly to pod IPs, which normally can't happen, except
for the NLB transparent traffic modifications. For ingress traffic this is not an issue, but return traffic does not hit any of the routes that would direct it to the parent interface. Nor can we make a route since every possible public IP can be a source.

As a fix, this PR adds logic to the snat/fwd path to check if we see reply traffic from an endpoint with a parent interface egressing out of any interface other than the parent interface. If we do we redirect the traffic to the parent interface. The location of this logic is chosen so that its compatible with proxied traffic as well.

This is a pwru log from a manual test in EKS:
```
SKB                CPU PROCESS          NETNS      MARK/x        IFACE       PROTO  MTU   LEN   TUPLE FUNC
# Reply packet gets created in process
0xffff88d67b311f00 1   ~/bin/pwru:18652 4026533432 0               0         0x0000 8841  60    10.26.102.102:80->77.168.92.51:48766(tcp) __ip_local_out
0xffff88d67b311f00 1   ~/bin/pwru:18652 4026533432 0               0         0x0800 8841  60    10.26.102.102:80->77.168.92.51:48766(tcp) ip_output
# Gets routed to eth0 inside the pod
0xffff88d67b311f00 1   ~/bin/pwru:18652 4026533432 0            eth0:39      0x0800 8841  60    10.26.102.102:80->77.168.92.51:48766(tcp) ip_finish_output
[...]
0xffff88d67b311f00 1   ~/bin/pwru:18652 4026533432 0            eth0:39      0x0800 8921  74    10.26.102.102:80->77.168.92.51:48766(tcp) eth_type_trans
# Packet traverses the veth pair, now enters the host NS
0xffff88d67b311f00 1   ~/bin/pwru:18652 4026531992 0        ~007925156fc8:40 0x0800 8921  60    10.26.102.102:80->77.168.92.51:48766(tcp) netif_rx
[...]
0xffff88d67b311f00 1   ~/bin/pwru:18652 4026531992 b1980f00 ~007925156fc8:40 0x0800 8921  60    10.26.102.102:80->77.168.92.51:48766(tcp) ip_output
# Packet gets routed to eth0 of the host (expected for traffic to a world IP)
0xffff88d67b311f00 1   ~/bin/pwru:18652 4026531992 b1980f00      eth0:2      0x0800 8921  60    10.26.102.102:80->77.168.92.51:48766(tcp) nf_hook_slow
[...]
0xffff88d67b311f00 1   ~/bin/pwru:18652 4026531992 b1980f00      eth0:2      0x0800 8921  74    10.26.102.102:80->77.168.92.51:48766(tcp) __bpf_redirect
# The new logic kicks in, detects its reply traffic and redirects to eth1 (the parent interface for 10.26.102.102)
0xffff88d67b311f00 1   ~/bin/pwru:18652 4026531992 b1980f00     eth1:34      0x0800 8921  74    10.26.102.102:80->77.168.92.51:48766(tcp) dev_queue_xmit
[...]
# Packet actually is sent out
0xffff88d67b311f00 1   ~/bin/pwru:18652 4026531992 b1980f00     eth1:34      0x0800 8921  74    10.26.102.102:80->77.168.92.51:48766(tcp) dev_hard_start_xmit
[...]
0xffff88d67b311f00 3   ~/bin/pwru:18652 4026531992 b1980f00     eth1:34      0x0800 8921  74    10.26.102.102:80->77.168.92.51:48766(tcp) kfree_skbmem
```

