### PR TITLE
helm: Fix configmap unmarshal error on egressGateway.maxPolicyEntries

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1078,7 +1078,7 @@ data:
   egress-gateway-reconciliation-trigger-interval: {{ .Values.egressGateway.reconciliationTriggerInterval | quote }}
 {{- end }}
 {{- if .Values.egressGateway.maxPolicyEntries }}
-  egress-gateway-policy-map-max: {{ .Values.egressGateway.maxPolicyEntries }}
+  egress-gateway-policy-map-max: {{ .Values.egressGateway.maxPolicyEntries | quote }}
 {{- end }}
 
 {{- if hasKey .Values "vtep" }}


### PR DESCRIPTION
Fixes an issue in the `egressGateway.maxPolicyEntries` section of the Cilium helm chart, when given a value it will give an error failing to unmarshal the numeric value set in the helm values as the ConfigMap can only hold strings.

Error given when attempting to set `egressGateway.maxPolicyEntries=65536`
> ConfigMap in version "v1" cannot be handled as a ConfigMap: json: cannot unmarshal number into Go struct field ConfigMap.data of type string


This PR adds the missing `| quote ` in the configmap template so it may properly pass the validation.