### PR TITLE
Policy mapstate cleanups redux

### DIFF
--- a/pkg/container/bitlpm/cidr.go
+++ b/pkg/container/bitlpm/cidr.go
@@ -54,12 +54,20 @@ func (c *CIDRTrie[T]) Ancestors(cidr netip.Prefix, fn func(k netip.Prefix, v T) 
 	})
 }
 
+func (c *CIDRTrie[T]) AncestorIterator(cidr netip.Prefix) Iterator[Key[netip.Prefix], T] {
+	return c.treeForFamily(cidr).AncestorIterator(uint(cidr.Bits()), cidrKey(cidr))
+}
+
 // AncestorsLongestPrefixFirst iterates over every CIDR pair that contains the CIDR argument,
 // longest matching prefix first, then iterating towards the root of the trie.
 func (c *CIDRTrie[T]) AncestorsLongestPrefixFirst(cidr netip.Prefix, fn func(k netip.Prefix, v T) bool) {
 	c.treeForFamily(cidr).AncestorsLongestPrefixFirst(uint(cidr.Bits()), cidrKey(cidr), func(prefix uint, k Key[netip.Prefix], v T) bool {
 		return fn(k.Value(), v)
 	})
+}
+
+func (c *CIDRTrie[T]) AncestorLongestPrefixFirstIterator(cidr netip.Prefix) Iterator[Key[netip.Prefix], T] {
+	return c.treeForFamily(cidr).AncestorLongestPrefixFirstIterator(uint(cidr.Bits()), cidrKey(cidr))
 }
 
 // Descendants iterates over every CIDR that is contained by the CIDR argument.
@@ -69,11 +77,19 @@ func (c *CIDRTrie[T]) Descendants(cidr netip.Prefix, fn func(k netip.Prefix, v T
 	})
 }
 
+func (c *CIDRTrie[T]) DescendantIterator(cidr netip.Prefix) Iterator[Key[netip.Prefix], T] {
+	return c.treeForFamily(cidr).DescendantIterator(uint(cidr.Bits()), cidrKey(cidr))
+}
+
 // DescendantsShortestPrefixFirst iterates over every CIDR that is contained by the CIDR argument.
 func (c *CIDRTrie[T]) DescendantsShortestPrefixFirst(cidr netip.Prefix, fn func(k netip.Prefix, v T) bool) {
 	c.treeForFamily(cidr).DescendantsShortestPrefixFirst(uint(cidr.Bits()), cidrKey(cidr), func(prefix uint, k Key[netip.Prefix], v T) bool {
 		return fn(k.Value(), v)
 	})
+}
+
+func (c *CIDRTrie[T]) DescendantShortestPrefixFirstIterator(cidr netip.Prefix) Iterator[Key[netip.Prefix], T] {
+	return c.treeForFamily(cidr).DescendantShortestPrefixFirstIterator(uint(cidr.Bits()), cidrKey(cidr))
 }
 
 // Upsert adds or updates the value for a given prefix.

--- a/pkg/container/bitlpm/cidr_test.go
+++ b/pkg/container/bitlpm/cidr_test.go
@@ -502,6 +502,20 @@ func BenchmarkTraversal(b *testing.B) {
 		}
 	})
 
+	b.Run("AncestorIterator root-first", func(b *testing.B) {
+		n := 0
+
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			iter := t.AncestorIterator(prefix)
+			n = 0
+			for ok, _, _ := iter.Next(); ok; ok, _, _ = iter.Next() {
+				n++
+			}
+		}
+	})
+
 	b.Run("Ancestors longest-prefix-first", func(b *testing.B) {
 		n := 0
 		lastLen := 0
@@ -512,12 +526,31 @@ func BenchmarkTraversal(b *testing.B) {
 			n = 0
 			lastLen = prefixLen
 			t.AncestorsLongestPrefixFirst(prefix, func(k netip.Prefix, _ struct{}) bool {
-				pLen := prefix.Bits()
+				pLen := k.Bits()
 				assert.LessOrEqual(b, pLen, lastLen)
 				lastLen = pLen
 				n++
 				return true
 			})
+		}
+	})
+
+	b.Run("AncestorLongestPrefixFirstIterator", func(b *testing.B) {
+		n := 0
+		lastLen := 0
+
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			iter := t.AncestorLongestPrefixFirstIterator(prefix)
+			n = 0
+			lastLen = prefixLen
+			for ok, k, _ := iter.Next(); ok; ok, k, _ = iter.Next() {
+				pLen := k.Value().Bits()
+				assert.LessOrEqual(b, pLen, lastLen)
+				lastLen = pLen
+				n++
+			}
 		}
 	})
 
@@ -535,6 +568,20 @@ func BenchmarkTraversal(b *testing.B) {
 		}
 	})
 
+	b.Run("DescendantIterator depth-first", func(b *testing.B) {
+		n := 0
+
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			iter := t.DescendantIterator(prefix)
+			n = 0
+			for ok, _, _ := iter.Next(); ok; ok, _, _ = iter.Next() {
+				n++
+			}
+		}
+	})
+
 	b.Run("descendants shortest-prefix-first", func(b *testing.B) {
 		n := 0
 		lastLen := 0
@@ -545,12 +592,31 @@ func BenchmarkTraversal(b *testing.B) {
 			n = 0
 			lastLen = 0
 			t.DescendantsShortestPrefixFirst(prefix, func(k netip.Prefix, _ struct{}) bool {
-				pLen := prefix.Bits()
+				pLen := k.Bits()
 				assert.GreaterOrEqual(b, pLen, lastLen)
 				lastLen = pLen
 				n++
 				return true
 			})
+		}
+	})
+
+	b.Run("DescendantShortestPrefixFirstIterator", func(b *testing.B) {
+		n := 0
+		lastLen := 0
+
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			iter := t.DescendantShortestPrefixFirstIterator(prefix)
+			n = 0
+			lastLen = 0
+			for ok, k, _ := iter.Next(); ok; ok, k, _ = iter.Next() {
+				pLen := k.Value().Bits()
+				assert.GreaterOrEqual(b, pLen, lastLen)
+				lastLen = pLen
+				n++
+			}
 		}
 	})
 }

--- a/pkg/policy/types/types.go
+++ b/pkg/policy/types/types.go
@@ -140,6 +140,10 @@ func (k LPMKey) PortPrefixLen() uint8 {
 	return k.bits & ^directionBitMask
 }
 
+func (k LPMKey) HasPortWildcard() bool {
+	return k.bits & ^directionBitMask < 16
+}
+
 // String returns a string representation of the Key
 func (k Key) String() string {
 	dPort := strconv.FormatUint(uint64(k.DestPort), 10)


### PR DESCRIPTION
Avoid unnecessary iteration for narrower keys when key has no port wildcarding.

Introduce `containers/bitlpm` explicit iterators that perform better when used from Go 1.23 iterators.

Use Go 1.23 iterators in policy mapstate computation to simplify for better readability.

> Note: Go 1.23 iterators in mapstate computation performed poorly when calling the existing bitlpm iteration functions from them. Likely related: https://github.com/golang/go/issues/66469
> "Explicit" bitlpm iterators perform much better than the previous ones, and when calling them from Go 1.23 iterators there is no performance degradation

With these changes `BenchmarkRegenerateCIDRDenyPolicyRules` benchmark does 48% fewer allocations, uses 33% less memory, and performs 23% faster.

`denyPreferredInsertWithChanges` that contains the main business logic for policy mapstate generation, becomes a lot simpler as result, and is that much easier to understand and maintain in the future.