### PR TITLE
[v1.16] gha: fix incorrect go version in lint-build-commits workflow

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           cache: false
           # renovate: datasource=golang-version depName=go
-          go-version: 1.23.1
+          go-version: 1.22.8
 
       # Load Golang cache build from GitHub
       - name: Load Golang cache build from GitHub


### PR DESCRIPTION
The Go version configured in the workflow got unintentionally bumped to 1.23 while backporting [1]. Let's revert it back to 1.22, while updating the patch version to reflect the change introduced by [2] in all other workflows.

\[1]: 0883901cd41a (".github: install golang action after checkout")
\[2]: 957aa72ce4d8 ("chore(deps): update go to v1.22.8")

Fixes: 98aab621c383 (".github: install golang action after checkout")