### PR TITLE
cilium-cli: connectivity test: support every kind of resource for tests

### DIFF
--- a/cilium-cli/connectivity/tests/service.go
+++ b/cilium-cli/connectivity/tests/service.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 // PodToService sends an HTTP request from all client Pods
@@ -226,13 +225,6 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 				if f, ok := t.Context().Feature(features.Flavor); ok && f.Enabled && f.Mode == "gke" {
 					continue
 				}
-			}
-
-			//  Skip IPv6 requests when running on <1.14.0 Cilium with CNPs
-			if features.GetIPFamily(addr.Address) == features.IPFamilyV6 &&
-				versioncheck.MustCompile("<1.14.0")(t.Context().CiliumVersion) &&
-				(len(t.CiliumNetworkPolicies()) > 0 || len(t.KubernetesNetworkPolicies()) > 0) {
-				continue
 			}
 
 			// Manually construct an HTTP endpoint to override the destination IP

--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -1094,3 +1094,64 @@ func (c *Client) CreateEphemeralContainer(ctx context.Context, pod *corev1.Pod, 
 		ctx, pod.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "ephemeralcontainers",
 	)
 }
+
+type Object interface {
+	metav1.Object
+	runtime.Object
+}
+
+// ApplyGeneric uses server-side apply to merge changes to an arbitrary object.
+// Returns the applied object.
+func (c *Client) ApplyGeneric(ctx context.Context, obj Object) (*unstructured.Unstructured, error) {
+	gvk, resource, err := c.Describe(obj)
+	if err != nil {
+		return nil, fmt.Errorf("could not get Kubernetes API information for %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+
+	// Now, convert the object to an Unstructured
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		b, err := json.Marshal(obj)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert to unstructured (marshal): %w", err)
+		}
+		u = &unstructured.Unstructured{}
+		if err := json.Unmarshal(b, u); err != nil {
+			return nil, fmt.Errorf("failed to convert to unstructured (unmarshal): %w", err)
+		}
+	}
+
+	// Dragons: If we're passed a non-Unstructured object (e.g. v1.ConfigMap), it won't have
+	// the GVK set necessarily. So, use the retrieved GVK from the schema and add it.
+	// This is a no-op for Unstructured objects.
+	// TODO: use a proper codec + serializer
+	u.GetObjectKind().SetGroupVersionKind(gvk)
+
+	// clear ManagedFields; it is not allowed to specify them in a Patch
+	u.SetManagedFields(nil)
+
+	dynamicClient := c.DynamicClientset.Resource(resource).Namespace(obj.GetNamespace())
+	return dynamicClient.Apply(ctx, obj.GetName(), u, metav1.ApplyOptions{Force: true, FieldManager: "cilium-cli"})
+}
+
+func (c *Client) GetGeneric(ctx context.Context, namespace, name string, obj Object) (*unstructured.Unstructured, error) {
+	_, resource, err := c.Describe(obj)
+	if err != nil {
+		return nil, fmt.Errorf("could not get Kubernetes API information for %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+
+	dynamicClient := c.DynamicClientset.Resource(resource).Namespace(namespace)
+
+	return dynamicClient.Get(ctx, name, metav1.GetOptions{})
+}
+
+func (c *Client) DeleteGeneric(ctx context.Context, obj Object) error {
+	_, resource, err := c.Describe(obj)
+	if err != nil {
+		return fmt.Errorf("could not get Kubernetes API information for %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+	}
+
+	dynamicClient := c.DynamicClientset.Resource(resource).Namespace(obj.GetNamespace())
+
+	return dynamicClient.Delete(ctx, obj.GetName(), metav1.DeleteOptions{})
+}

--- a/cilium-cli/k8s/helpers.go
+++ b/cilium-cli/k8s/helpers.go
@@ -4,10 +4,15 @@
 package k8s
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func NewServiceAccount(name string) *corev1.ServiceAccount {
@@ -71,4 +76,28 @@ func NewTLSSecret(name, namespace string, data map[string][]byte) *corev1.Secret
 		Data: data,
 		Type: corev1.SecretTypeTLS,
 	}
+}
+
+// Describe returns the Kubernetes type and resource information for an object
+func (c *Client) Describe(obj runtime.Object) (gvk schema.GroupVersionKind, resource schema.GroupVersionResource, err error) {
+	// first, determine the GroupVersionKind and Resource for the given object
+	gvks, _, _ := scheme.Scheme.ObjectKinds(obj)
+	if len(gvks) != 1 {
+		err = fmt.Errorf("Could not get GroupVersionKind")
+		return
+	}
+
+	gvk = gvks[0]
+
+	// Convert the GroupVersionKind in to a Resource
+	restMapper, err := c.RESTClientGetter.ToRESTMapper()
+	if err != nil {
+		return
+	}
+	rm, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return
+	}
+	resource = rm.Resource
+	return
 }


### PR DESCRIPTION
The connectivity-test code allows for creating dependent resources as a part of tests (e.g. NetworkPolicies). However, the code as written requires new methods for every kind of resource.

This change converts this to use the dynamic client, which is resource-agnostic. That allows for creating arbitrary sets of resources, as well as mixing resource kinds in a single YAML file. It removes a lot of boilerplate and churn as new resources are needed.

Internally, it uses Server-Side Apply to reduce the number of k8s API calls necessary.
