### PR TITLE
container/set: fix bug in `Set[T].Equal`, increase test coverage

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -488,6 +488,7 @@ Makefile* @cilium/build
 /pkg/components/ @cilium/sig-agent
 /pkg/container/ @cilium/sig-foundations
 /pkg/container/bitlpm/ @cilium/ipcache @cilium/sig-policy
+/pkg/container/set/ @cilium/sig-policy
 /pkg/controller @cilium/sig-agent
 /pkg/counter @cilium/sig-datapath
 /pkg/crypto/ @cilium/sig-hubble @cilium/sig-policy

--- a/pkg/container/set/set.go
+++ b/pkg/container/set/set.go
@@ -157,16 +157,14 @@ func (s Set[T]) Equal(o Set[T]) bool {
 		return true
 	case 1:
 		return *s.single == *o.single
-	default:
-		// compare the elements of the maps
-		for member := range s.members {
-			if _, ok := o.members[member]; !ok {
-				return false
-			}
-			return true
+	}
+	// compare the elements of the maps
+	for member := range s.members {
+		if _, ok := o.members[member]; !ok {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 // Members returns an iterator for the members in the set.

--- a/pkg/container/set/set_test.go
+++ b/pkg/container/set/set_test.go
@@ -153,6 +153,8 @@ func TestSet(t *testing.T) {
 	require.False(t, set.Has(nil))
 
 	// Equal
+	item3 := test{3}
+	item4 := test{4}
 	require.True(t, Set[Member]{}.Equal(Set[Member]{}))
 	require.True(t, Set[Member]{}.Equal(NewSet[Member]()))
 	require.True(t, NewSet[Member]().Equal(NewSet[Member]()))
@@ -167,6 +169,7 @@ func TestSet(t *testing.T) {
 	require.False(t, NewSet(item1, item2).Equal(NewSet(item2)))
 	require.False(t, NewSet(item1).Equal(NewSet(item2, item1)))
 	require.True(t, NewSet(item1, item2).Equal(NewSet(item2, item1)))
+	require.False(t, NewSet(item1, item2, item3).Equal(NewSet(item1, item2, item4)))
 
 	// Clone
 	set = NewSet[Member](item1, emptyItem, nil)


### PR DESCRIPTION
Fix a bug in `Set[T].Equal` introduced in https://github.com/cilium/cilium/pull/34692. Also increase the test coverage to cover the single element case in all methods. Moreover, assign `pkg/container/set` to @cilium/sig-policy as this is the primary user of the package.

See commits for details.