### PR TITLE
operator: fix Test_performCiliumNodeGC

### DIFF
--- a/operator/watchers/cilium_node_gc_test.go
+++ b/operator/watchers/cilium_node_gc_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 
@@ -20,38 +21,29 @@ import (
 )
 
 func Test_performCiliumNodeGC(t *testing.T) {
-	validCN := &v2.CiliumNode{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "valid-node",
+	cns := []runtime.Object{
+		&v2.CiliumNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid-node",
+			},
 		},
-	}
-	invalidCN := &v2.CiliumNode{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "invalid-node",
+		&v2.CiliumNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "invalid-node",
+			},
 		},
-	}
-	invalidCNWithOwnerRef := &v2.CiliumNode{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "invalid-node-with-owner-ref",
-			OwnerReferences: []metav1.OwnerReference{
-				{},
+		&v2.CiliumNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "invalid-node-with-owner-ref",
+				OwnerReferences: []metav1.OwnerReference{{}},
 			},
 		},
 	}
 
-	fcn := fake.NewSimpleClientset(validCN, invalidCN, invalidCNWithOwnerRef).CiliumV2().CiliumNodes()
-
-	fCNStore := &cache.FakeCustomStore{
-		ListKeysFunc: func() []string {
-			return []string{"valid-node", "invalid-node"}
-		},
-		GetByKeyFunc: func(key string) (interface{}, bool, error) {
-			return &v2.CiliumNode{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: key,
-				},
-			}, true, nil
-		},
+	fcn := fake.NewSimpleClientset(cns...).CiliumV2().CiliumNodes()
+	fCNStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	for _, cn := range cns {
+		fCNStore.Add(cn)
 	}
 
 	interval := time.Nanosecond


### PR DESCRIPTION
Fix the test asserting that CNs with an owner reference are not GCed, which was previously skipped as the object was not part of the (fake) store. To this end, let's just populate the store using the same objects added to the fake client, for consistency.