### PR TITLE
WIP: Add support for FIPS compliance

### DIFF
--- a/.github/workflows/build-go-caches.yaml
+++ b/.github/workflows/build-go-caches.yaml
@@ -102,6 +102,7 @@ jobs:
           fi
           contrib/scripts/builder.sh make GOARCH=amd64 NOSTRIP=1 ${{ matrix.make-target }} -j $(nproc) || exit 1
           contrib/scripts/builder.sh make GOARCH=amd64 LOCKDEBUG=1 RACE=1 ${{ matrix.make-target }} -j $(nproc) || exit 1
+          contrib/scripts/builder.sh make GOARCH=amd64 FIPS=1 ${{ matrix.make-target }} -j $(nproc) || exit 1
           contrib/scripts/builder.sh make GOARCH=amd64 ${{ matrix.make-target }} -j $(nproc) || exit 1
 
       - name: Reset cache ownership to GitHub runners user

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -2,7 +2,8 @@ name: Image CI Build
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request_target:
+  # TODO(hemanthmalla): Remove this change after testing
+  pull_request:
     types:
       - opened
       - synchronize
@@ -195,6 +196,22 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
+      - name: CI FIPS Compliant Build ${{ matrix.name }}
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        id: docker_build_ci_fips
+        with:
+          provenance: false
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.tag.outputs.fips_tag }}
+          target: release
+          no-cache: true
+          build-args: |
+            MODIFIERS="FIPS=1"
+            OPERATOR_VARIANT=${{ matrix.name }}
+
       - name: CI Build ${{ matrix.name }}
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         id: docker_build_ci
@@ -238,21 +255,6 @@ jobs:
           target: release
           build-args: |
             MODIFIERS="NOSTRIP=1"
-            OPERATOR_VARIANT=${{ matrix.name }}
-
-      - name: CI FIPS Compliant Build ${{ matrix.name }}
-        uses: docker/build-push-action@32945a339266b759abcbdc89316275140b0fc960 # v6.8.0
-        id: docker_build_ci_fips
-        with:
-          provenance: false
-          context: .
-          file: ${{ matrix.dockerfile }}
-          push: true
-          platforms: linux/amd64
-          tags: ${{ steps.tag.outputs.fips_tag }}
-          target: release
-          build-args: |
-            MODIFIERS="FIPS=1"
             OPERATOR_VARIANT=${{ matrix.name }}
 
       - name: Sign Container Images

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -121,20 +121,24 @@ jobs:
           normal_tag="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${tag}"
           race_tag="${normal_tag}-race"
           unstripped_tag="${normal_tag}-unstripped"
+          fips_tag="${normal_tag}-fips"
 
           if [ -n "${floating_tag}" ]; then
             floating_normal_tag="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${floating_tag}"
             floating_race_tag="${floating_normal_tag}-race"
             floating_unstripped_tag="${floating_normal_tag}-unstripped"
+            floating_fips_tag="${floating_normal_tag}-fips"
 
             normal_tag="${normal_tag},${floating_normal_tag}"
             race_tag="${race_tag},${floating_race_tag}"
             unstripped_tag="${unstripped_tag},${floating_unstripped_tag}"
+            fips_tag="${fips_tag},${floating_fips_tag}"
           fi
 
           echo normal_tag=${normal_tag} >> $GITHUB_OUTPUT
           echo race_tag=${race_tag} >> $GITHUB_OUTPUT
           echo unstripped_tag=${unstripped_tag} >> $GITHUB_OUTPUT
+          echo fips_tag=${fips_tag} >> $GITHUB_OUTPUT
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
@@ -236,11 +240,27 @@ jobs:
             MODIFIERS="NOSTRIP=1"
             OPERATOR_VARIANT=${{ matrix.name }}
 
+      - name: CI FIPS Compliant Build ${{ matrix.name }}
+        uses: docker/build-push-action@32945a339266b759abcbdc89316275140b0fc960 # v6.8.0
+        id: docker_build_ci_fips
+        with:
+          provenance: false
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.tag.outputs.fips_tag }}
+          target: release
+          build-args: |
+            MODIFIERS="FIPS=1"
+            OPERATOR_VARIANT=${{ matrix.name }}
+
       - name: Sign Container Images
         run: |
           cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci.outputs.digest }}
           cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_detect_race_condition.outputs.digest }}
           cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_unstripped.outputs.digest }}
+          cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_fips.outputs.digest }}
 
       - name: Generate SBOM
         if: ${{ matrix.name != 'cilium-cli' }}
@@ -266,12 +286,21 @@ jobs:
           output-file: ./sbom_ci_unstripped_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
           image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-unstripped
 
+      - name: Generate SBOM (fips)
+        if: ${{ matrix.name != 'cilium-cli' }}
+        uses: anchore/sbom-action@61119d458adab75f756bc0b9e4bde25725f86a7a # v0.17.2
+        with:
+          artifact-name: sbom_ci_fips_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          output-file: ./sbom_ci_fips_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-fips
+
       - name: Attach SBOM attestation to container image
         if: ${{ matrix.name != 'cilium-cli' }}
         run: |
           cosign attest -r -y --predicate sbom_ci_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci.outputs.digest }}
           cosign attest -r -y --predicate sbom_ci_race_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_detect_race_condition.outputs.digest }}
           cosign attest -r -y --predicate sbom_ci_unstripped_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_unstripped.outputs.digest }}
+          cosign attest -r -y --predicate sbom_ci_fips_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_fips.outputs.digest }}
 
       - name: CI Image Releases digests
         shell: bash
@@ -281,10 +310,13 @@ jobs:
             echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.floating_tag }}@${{ steps.docker_build_ci.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
             echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.floating_tag }}-race@${{ steps.docker_build_ci_detect_race_condition.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
             echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.floating_tag }}-unstripped@${{ steps.docker_build_ci_unstripped.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+            echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.floating_tag }}-fips@${{ steps.docker_build_ci_fips.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
           fi
           echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
           echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race@${{ steps.docker_build_ci_detect_race_condition.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
           echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-unstripped@${{ steps.docker_build_ci_unstripped.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-fips@${{ steps.docker_build_ci_fips.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+
 
       # Upload artifact digests
       - name: Upload artifact digests

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -388,6 +388,23 @@ jobs:
             host-fw: 'true'
             skip-upgrade: 'true'
 
+          - name: '24'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: '6.1-20240710.064909'
+            kube-proxy: 'none'
+            kpr: 'true'
+            devices: '{eth0,eth1}'
+            tunnel: 'vxlan'
+            lb-mode: 'snat'
+            egress-gateway: 'true'
+            host-fw: 'true'
+            lb-acceleration: 'testing-only'
+            ingress-controller: 'true'
+            bgp-control-plane: 'true'
+            fips: 'true'
+            skip-upgrade: 'true'
+
+
           # Example of a feature that is being introduced, and we want to test
           # it without performing an upgrade, we use skip-upgrade: 'true'
           # - name: '23'
@@ -425,6 +442,7 @@ jobs:
             SHA="${{ github.sha }}"
           fi
           echo sha=${SHA} >> $GITHUB_OUTPUT
+          echo fips_sha="${SHA}-fips"
           CILIUM_DOWNGRADE_VERSION=$(contrib/scripts/print-downgrade-version.sh stable)
           echo downgrade_version=${CILIUM_DOWNGRADE_VERSION} >> $GITHUB_OUTPUT
 
@@ -458,7 +476,7 @@ jobs:
         id: cilium-newest-config
         uses: ./.github/actions/cilium-config
         with:
-          image-tag: ${{ steps.vars.outputs.sha }}
+          image-tag: ${{ matrix.fips && steps.vars.outputs.fips_sha || steps.vars.outputs.sha }}
           chart-dir: './untrusted/cilium-newest/install/kubernetes/cilium'
           tunnel: ${{ matrix.tunnel }}
           devices: ${{ matrix.devices }}

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -186,6 +186,11 @@ ifneq ($(LOCKDEBUG),)
     GO_TAGS_FLAGS += lockdebug
 endif
 
+ifeq ($(FIPS),1)
+    GO_BUILD = GOEXPERIMENT=boringcrypto  $(GO_BUILD_WITH_CGO)
+    GO_BUILD_LDFLAGS += -linkmode external -extldflags "-static --enable-static-nss"
+endif
+
 GO_BUILD_FLAGS += -ldflags '$(GO_BUILD_LDFLAGS) $(EXTRA_GO_BUILD_LDFLAGS)' -tags=$(call join-with-comma,$(GO_TAGS_FLAGS)) $(EXTRA_GO_BUILD_FLAGS)
 GO_TEST_FLAGS += -tags=$(call join-with-comma,$(GO_TAGS_FLAGS))
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -187,6 +187,7 @@ ifneq ($(LOCKDEBUG),)
 endif
 
 ifeq ($(FIPS),1)
+    export FIPS=1
     GO_BUILD = GOEXPERIMENT=boringcrypto  $(GO_BUILD_WITH_CGO)
     GO_BUILD_LDFLAGS += -linkmode external -extldflags "-static --enable-static-nss"
 endif

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -92,7 +92,7 @@ endif
 	$(QUIET) $(CONTAINER_ENGINE) buildx build -f $(subst %,$$*,$(2)) \
 		$(DOCKER_BUILD_FLAGS) $(DOCKER_FLAGS) \
 		$(if $(BASE_IMAGE),--build-arg BASE_IMAGE=$(BASE_IMAGE),) \
-		--build-arg MODIFIERS="NOSTRIP=$${NOSTRIP} NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} RACE=${RACE} V=${V} LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} ${ADDITIONAL_MODIFIERS}" \
+		--build-arg MODIFIERS="NOSTRIP=$${NOSTRIP} FIPS=${FIPS} NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} RACE=${RACE} V=${V} LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} ${ADDITIONAL_MODIFIERS}" \
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
 		--build-arg OPERATOR_VARIANT=$(IMAGE_NAME) \
 		--build-arg DEBUG_HOLD=$(DEBUG_HOLD) \
@@ -113,6 +113,11 @@ endif
 $(1)-unstripped: NOSTRIP=1
 $(1)-unstripped: UNSTRIPPED=-unstripped
 $(1)-unstripped: $(1)
+	@echo
+
+$(1)-fips: FIPS=1
+$(1)-fips: NOSTRIP=1
+$(1)-fips: $(1)
 	@echo
 endef
 
@@ -151,3 +156,7 @@ docker-images-all-unstripped: docker-cilium-image-unstripped docker-plugin-image
 docker-operator-images-all: docker-operator-image docker-operator-aws-image docker-operator-azure-image docker-operator-alibabacloud-image docker-operator-generic-image ## Build all variants of cilium-operator images.
 
 docker-operator-images-all-unstripped: docker-operator-image-unstripped docker-operator-aws-image-unstripped docker-operator-azure-image-unstripped docker-operator-alibabacloud-image-unstripped docker-operator-generic-image-unstripped ## Build all variants of unstripped cilium-operator images.
+
+docker-operator-images-all-fips: docker-operator-image-fips docker-operator-aws-image-fips docker-operator-azure-image-fips docker-operator-alibabacloud-image-fips docker-operator-generic-image-fips ## Build all variants of fips cilium-operator images.
+
+docker-images-all-fips: docker-cilium-image-fips docker-plugin-image-fips docker-hubble-relay-image-fips docker-clustermesh-apiserver-image-fips docker-operator-images-all-fips ## Build all Cilium related fips docker images.

--- a/bugtool/fips.go
+++ b/bugtool/fips.go
@@ -1,0 +1,7 @@
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/cilium-dbg/fips.go
+++ b/cilium-dbg/fips.go
@@ -1,0 +1,7 @@
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/cilium-health/fips.go
+++ b/cilium-health/fips.go
@@ -1,0 +1,7 @@
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/clustermesh-apiserver/fips.go
+++ b/clustermesh-apiserver/fips.go
@@ -1,0 +1,7 @@
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/daemon/fips.go
+++ b/daemon/fips.go
@@ -1,0 +1,7 @@
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/hubble-relay/fips.go
+++ b/hubble-relay/fips.go
@@ -1,0 +1,7 @@
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/hubble/fips.go
+++ b/hubble/fips.go
@@ -1,0 +1,7 @@
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/operator/fips.go
+++ b/operator/fips.go
@@ -1,0 +1,7 @@
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/plugins/cilium-cni/fips.go
+++ b/plugins/cilium-cni/fips.go
@@ -1,0 +1,7 @@
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"

--- a/plugins/cilium-docker/fips.go
+++ b/plugins/cilium-docker/fips.go
@@ -1,0 +1,7 @@
+//go:build boringcrypto
+
+package main
+
+// Package fipsonly restricts all TLS configuration to FIPS-approved settings.
+// See https://github.com/golang/go/blob/master/src/crypto/tls/fipsonly/fipsonly.go
+import _ "crypto/tls/fipsonly"


### PR DESCRIPTION
Also restricts all TLS config to FIPS-approved settings.

Note : We (Author of this commit, Datadog Inc. or Cilium Maintainers) are not making any statements or representations about the suitability of this code in relation to the FIPS 140 standard. Interested users will have to evaluate for themselves whether the code is useful for their own purposes.

Fixes: #23919
