### PR TITLE
docs/cert-manager: bump from 1.10 to 1.16, use config.enableGatewayAPI

### DIFF
--- a/Documentation/network/servicemesh/tls-cert.rst
+++ b/Documentation/network/servicemesh/tls-cert.rst
@@ -38,11 +38,11 @@ Create TLS Certificate and Private Key
         .. code-block:: shell-session
 
             $ helm repo add jetstack https://charts.jetstack.io
-            $ helm install cert-manager jetstack/cert-manager --version v1.10.0 \
+            $ helm install cert-manager jetstack/cert-manager --version v1.16.1 \
                 --namespace cert-manager \
-                --set installCRDs=true \
                 --create-namespace \
-                --set "extraArgs={--feature-gates=ExperimentalGatewayAPISupport=true}"
+                --set crds.enabled=true \
+                --set config.enableGatewayAPI=true
 
         Now, create a CA Issuer:
 


### PR DESCRIPTION
Hi!

The feature gate `ExperimentalGatewayAPISupport` is enabled by default in cert-manager 1.15, so I propose to update the documentation around that. I also propose to update the cert-manager version from 1.10 ([unsupported](https://cert-manager.io/docs/releases/)) to 1.16 (released a couple of days ago).

For context, in cert-manager 1.14 and older, this feature flag was enough to enable the feature. But with cert-manager 1.15, you now need to pass the flag --enable-gateway-api (or the config field `enableGatewayAPI: true`) to turn on the Gateway API support. The recommended approach is to use the config field, that's why I propose to use `--set config.enableGatewayAPI=true`.

Upstream ref: https://github.com/cert-manager/website/issues/1586

