### PR TITLE
bgpv1: fix reconciliation of services with shared VIPs

### DIFF
--- a/pkg/bgpv1/manager/reconciler/service.go
+++ b/pkg/bgpv1/manager/reconciler/service.go
@@ -42,6 +42,15 @@ type LBServiceReconcilerMetadata map[resource.Key][]*types.Path
 
 type localServices map[k8s.ServiceID]struct{}
 
+// pathReference holds reference information about an advertised path
+type pathReference struct {
+	count uint32
+	path  *types.Path
+}
+
+// pathReferencesMap holds path references of resources producing path advertisement, indexed by path's NLRI string
+type pathReferencesMap map[string]*pathReference
+
 func NewServiceReconciler(diffStore store.DiffStore[*slim_corev1.Service], epDiffStore store.DiffStore[*k8s.Endpoints]) LBServiceReconcilerOut {
 	if diffStore == nil {
 		return LBServiceReconcilerOut{}
@@ -89,10 +98,13 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, p ReconcileParams) er
 		return err
 	}
 
+	// compute existing path to resource references
+	pathRefs := r.computePathReferences(r.getMetadata(p.CurrentServer))
+
 	if r.requiresFullReconciliation(p) {
-		return r.fullReconciliation(ctx, p.CurrentServer, p.DesiredConfig, ls)
+		return r.fullReconciliation(ctx, p.CurrentServer, p.DesiredConfig, ls, pathRefs)
 	}
-	return r.svcDiffReconciliation(ctx, p.CurrentServer, p.DesiredConfig, ls)
+	return r.svcDiffReconciliation(ctx, p.CurrentServer, p.DesiredConfig, ls, pathRefs)
 }
 
 func (r *ServiceReconciler) getMetadata(sc *instance.ServerWithConfig) LBServiceReconcilerMetadata {
@@ -171,18 +183,18 @@ func hasLocalEndpoints(svc *slim_corev1.Service, ls localServices) bool {
 
 // fullReconciliation reconciles all services, this is a heavy operation due to the potential amount of services and
 // thus should be avoided if partial reconciliation is an option.
-func (r *ServiceReconciler) fullReconciliation(ctx context.Context, sc *instance.ServerWithConfig, newc *v2alpha1api.CiliumBGPVirtualRouter, ls localServices) error {
+func (r *ServiceReconciler) fullReconciliation(ctx context.Context, sc *instance.ServerWithConfig, newc *v2alpha1api.CiliumBGPVirtualRouter, ls localServices, pathRefs pathReferencesMap) error {
 	toReconcile, toWithdraw, err := r.fullReconciliationServiceList(sc)
 	if err != nil {
 		return err
 	}
 	for _, svc := range toReconcile {
-		if err := r.reconcileService(ctx, sc, newc, svc, ls); err != nil {
+		if err := r.reconcileService(ctx, sc, newc, svc, ls, pathRefs); err != nil {
 			return fmt.Errorf("failed to reconcile service %s/%s: %w", svc.Namespace, svc.Name, err)
 		}
 	}
 	for _, svc := range toWithdraw {
-		if err := r.withdrawService(ctx, sc, svc); err != nil {
+		if err := r.withdrawService(ctx, sc, svc, pathRefs); err != nil {
 			return fmt.Errorf("failed to withdraw service %s/%s: %w", svc.Namespace, svc.Name, err)
 		}
 	}
@@ -191,19 +203,19 @@ func (r *ServiceReconciler) fullReconciliation(ctx context.Context, sc *instance
 
 // svcDiffReconciliation performs reconciliation, only on services which have been created, updated or deleted since
 // the last diff reconciliation.
-func (r *ServiceReconciler) svcDiffReconciliation(ctx context.Context, sc *instance.ServerWithConfig, newc *v2alpha1api.CiliumBGPVirtualRouter, ls localServices) error {
+func (r *ServiceReconciler) svcDiffReconciliation(ctx context.Context, sc *instance.ServerWithConfig, newc *v2alpha1api.CiliumBGPVirtualRouter, ls localServices, pathRefs pathReferencesMap) error {
 	toReconcile, toWithdraw, err := r.diffReconciliationServiceList(sc)
 	if err != nil {
 		return err
 	}
 	for _, svc := range toReconcile {
-		if err := r.reconcileService(ctx, sc, newc, svc, ls); err != nil {
+		if err := r.reconcileService(ctx, sc, newc, svc, ls, pathRefs); err != nil {
 			return fmt.Errorf("failed to reconcile service %s/%s: %w", svc.Namespace, svc.Name, err)
 		}
 	}
 	// Loop over the deleted services
 	for _, svcKey := range toWithdraw {
-		if err := r.withdrawService(ctx, sc, svcKey); err != nil {
+		if err := r.withdrawService(ctx, sc, svcKey, pathRefs); err != nil {
 			return fmt.Errorf("failed to withdraw service %s: %w", svcKey, err)
 		}
 	}
@@ -409,18 +421,18 @@ func (r *ServiceReconciler) lbSvcDesiredRoutes(svc *slim_corev1.Service, ls loca
 }
 
 // reconcileService gets the desired routes of a given service and makes sure that is what is being announced.
-func (r *ServiceReconciler) reconcileService(ctx context.Context, sc *instance.ServerWithConfig, newc *v2alpha1api.CiliumBGPVirtualRouter, svc *slim_corev1.Service, ls localServices) error {
+func (r *ServiceReconciler) reconcileService(ctx context.Context, sc *instance.ServerWithConfig, newc *v2alpha1api.CiliumBGPVirtualRouter, svc *slim_corev1.Service, ls localServices, pathRefs pathReferencesMap) error {
 
 	desiredRoutes, err := r.svcDesiredRoutes(newc, svc, ls)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve svc desired routes: %w", err)
 	}
-	return r.reconcileServiceRoutes(ctx, sc, svc, desiredRoutes)
+	return r.reconcileServiceRoutes(ctx, sc, svc, desiredRoutes, pathRefs)
 }
 
 // reconcileServiceRoutes ensures that desired routes of a given service are announced,
 // adding missing announcements or withdrawing unwanted ones.
-func (r *ServiceReconciler) reconcileServiceRoutes(ctx context.Context, sc *instance.ServerWithConfig, svc *slim_corev1.Service, desiredRoutes []netip.Prefix) error {
+func (r *ServiceReconciler) reconcileServiceRoutes(ctx context.Context, sc *instance.ServerWithConfig, svc *slim_corev1.Service, desiredRoutes []netip.Prefix, pathRefs pathReferencesMap) error {
 	serviceAnnouncements := r.getMetadata(sc)
 	svcKey := resource.NewKey(svc)
 
@@ -431,15 +443,12 @@ func (r *ServiceReconciler) reconcileServiceRoutes(ctx context.Context, sc *inst
 		}) != -1 {
 			continue
 		}
-
 		// Advertise the new cidr
-		advertPathResp, err := sc.Server.AdvertisePath(ctx, types.PathRequest{
-			Path: types.NewPathForPrefix(desiredCidr),
-		})
+		path, err := r.advertisePath(ctx, sc, pathRefs, desiredCidr)
 		if err != nil {
-			return fmt.Errorf("failed to advertise service route %v: %w", desiredCidr, err)
+			return err
 		}
-		serviceAnnouncements[svcKey] = append(serviceAnnouncements[svcKey], advertPathResp.Path)
+		serviceAnnouncements[svcKey] = append(serviceAnnouncements[svcKey], path)
 	}
 
 	// Loop over announcements in reverse order so we can delete entries without effecting iteration.
@@ -451,11 +460,9 @@ func (r *ServiceReconciler) reconcileServiceRoutes(ctx context.Context, sc *inst
 		}) != -1 {
 			continue
 		}
-
-		if err := sc.Server.WithdrawPath(ctx, types.PathRequest{Path: announcement}); err != nil {
-			return fmt.Errorf("failed to withdraw service route %s: %w", announcement.NLRI, err)
+		if err := r.withdrawPath(ctx, sc, pathRefs, announcement); err != nil {
+			return err
 		}
-
 		// Delete announcement from slice
 		serviceAnnouncements[svcKey] = slices.Delete(serviceAnnouncements[svcKey], i, i+1)
 	}
@@ -463,16 +470,17 @@ func (r *ServiceReconciler) reconcileServiceRoutes(ctx context.Context, sc *inst
 }
 
 // withdrawService removes all announcements for the given service
-func (r *ServiceReconciler) withdrawService(ctx context.Context, sc *instance.ServerWithConfig, key resource.Key) error {
+func (r *ServiceReconciler) withdrawService(ctx context.Context, sc *instance.ServerWithConfig, key resource.Key, pathRefs pathReferencesMap) error {
 	serviceAnnouncements := r.getMetadata(sc)
 	advertisements := serviceAnnouncements[key]
 	// Loop in reverse order so we can delete without effect to the iteration.
 	for i := len(advertisements) - 1; i >= 0; i-- {
 		advertisement := advertisements[i]
-		if err := sc.Server.WithdrawPath(ctx, types.PathRequest{Path: advertisement}); err != nil {
+
+		if err := r.withdrawPath(ctx, sc, pathRefs, advertisement); err != nil {
 			// Persist remaining advertisements
 			serviceAnnouncements[key] = advertisements
-			return fmt.Errorf("failed to withdraw deleted service route: %v: %w", advertisement.NLRI, err)
+			return err
 		}
 
 		// Delete the advertisement after each withdraw in case we error half way through
@@ -487,6 +495,62 @@ func (r *ServiceReconciler) withdrawService(ctx context.Context, sc *instance.Se
 
 func (r *ServiceReconciler) diffID(asn uint32) string {
 	return fmt.Sprintf("%s-%d", r.Name(), asn)
+}
+
+func (r *ServiceReconciler) advertisePath(ctx context.Context, sc *instance.ServerWithConfig, pathRefs pathReferencesMap, prefix netip.Prefix) (*types.Path, error) {
+	if ref, exists := pathRefs[prefix.String()]; exists && ref.count > 0 {
+		// path already advertised for another resource
+		ref.count += 1
+		return ref.path, nil
+	}
+
+	advertPathResp, err := sc.Server.AdvertisePath(ctx, types.PathRequest{
+		Path: types.NewPathForPrefix(prefix),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to advertise service route %v: %w", prefix, err)
+	}
+
+	// set only in case of no error
+	pathRefs[prefix.String()] = &pathReference{
+		count: 1,
+		path:  advertPathResp.Path,
+	}
+	return advertPathResp.Path, nil
+}
+
+func (r *ServiceReconciler) withdrawPath(ctx context.Context, sc *instance.ServerWithConfig, pathRefs pathReferencesMap, path *types.Path) error {
+	if ref, exists := pathRefs[path.NLRI.String()]; exists && ref.count > 1 {
+		// path still needs to be advertised for another resource
+		ref.count -= 1
+		return nil
+	}
+
+	if err := sc.Server.WithdrawPath(ctx, types.PathRequest{Path: path}); err != nil {
+		return fmt.Errorf("failed to withdraw service route %s: %w", path.NLRI, err)
+	}
+
+	// delete only in case of no error
+	delete(pathRefs, path.NLRI.String())
+	return nil
+}
+
+func (r *ServiceReconciler) computePathReferences(metadata LBServiceReconcilerMetadata) pathReferencesMap {
+	pathRefs := make(pathReferencesMap)
+	for _, resPaths := range metadata {
+		for _, path := range resPaths {
+			ref, exists := pathRefs[path.NLRI.String()]
+			if !exists {
+				pathRefs[path.NLRI.String()] = &pathReference{
+					count: 1,
+					path:  path,
+				}
+			} else {
+				ref.count += 1
+			}
+		}
+	}
+	return pathRefs
 }
 
 func serviceLabelSet(svc *slim_corev1.Service) labels.Labels {

--- a/pkg/bgpv1/manager/reconciler/service_test.go
+++ b/pkg/bgpv1/manager/reconciler/service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
@@ -605,6 +606,28 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 				},
 			},
 		},
+		// service VIP sharing, delete one of the services
+		{
+			name:               "svc-vip-sharing",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised: map[resource.Key][]string{
+				svc1Name: {
+					ingressV4Prefix,
+				},
+				svc2NonDefaultName: {
+					ingressV4Prefix,
+				},
+			},
+			deletedServices: []resource.Key{
+				svc1Name,
+			},
+			updated: map[resource.Key][]string{
+				svc2NonDefaultName: {
+					ingressV4Prefix,
+				},
+			},
+		},
 	}
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
@@ -729,6 +752,8 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 				}
 			}
 
+			// validate that advertised paths match expected metadata
+			validateAdvertisedPrefixesMatch(t, testSC, tt.updated)
 		})
 	}
 }
@@ -1388,6 +1413,8 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 				}
 			}
 
+			// validate that advertised paths match expected metadata
+			validateAdvertisedPrefixesMatch(t, testSC, tt.updated)
 		})
 	}
 }
@@ -2045,6 +2072,8 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 				}
 			}
 
+			// validate that advertised paths match expected metadata
+			validateAdvertisedPrefixesMatch(t, testSC, tt.updated)
 		})
 	}
 }
@@ -2393,6 +2422,8 @@ func TestServiceReconcilerWithExternalIPAndClusterIP(t *testing.T) {
 				}
 			}
 
+			// validate that advertised paths match expected metadata
+			validateAdvertisedPrefixesMatch(t, testSC, tt.updated)
 		})
 	}
 }
@@ -2403,4 +2434,39 @@ func containsLbClass(svcs []*slim_corev1.Service) bool {
 		}
 	}
 	return false
+}
+
+func validateAdvertisedPrefixesMatch(t *testing.T, testSC *instance.ServerWithConfig, expectedAdverts map[resource.Key][]string) {
+	expected := sets.New[string]()
+	for _, resourcePaths := range expectedAdverts {
+		for _, path := range resourcePaths {
+			expected.Insert(path)
+		}
+	}
+
+	advertised := sets.New[string]()
+	routes, err := testSC.Server.GetRoutes(context.Background(), &types.GetRoutesRequest{TableType: types.TableTypeLocRIB, Family: types.Family{
+		Afi:  types.AfiIPv4,
+		Safi: types.SafiUnicast,
+	}})
+	require.NoError(t, err)
+	for _, route := range routes.Routes {
+		for _, path := range route.Paths {
+			advertised.Insert(path.NLRI.String())
+		}
+	}
+	routes, _ = testSC.Server.GetRoutes(context.Background(), &types.GetRoutesRequest{TableType: types.TableTypeLocRIB, Family: types.Family{
+		Afi:  types.AfiIPv6,
+		Safi: types.SafiUnicast,
+	}})
+	require.NoError(t, err)
+	for _, route := range routes.Routes {
+		for _, path := range route.Paths {
+			advertised.Insert(path.NLRI.String())
+		}
+	}
+
+	if !advertised.Equal(expected) {
+		t.Fatalf("advertised prefixes do not match expected metadata, expected: %v, got: %v", expected, advertised)
+	}
 }

--- a/pkg/bgpv1/test/adverts_test.go
+++ b/pkg/bgpv1/test/adverts_test.go
@@ -637,6 +637,34 @@ func Test_LBEgressAdvertisementWithLoadBalancerIP(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:         "add service-c - VIP shared with service-b",
+			srvName:             "service-c",
+			ingressIP:           "dddd::1",
+			op:                  "add",
+			expectedRouteEvents: []routeEvent{}, // no event, shared VIP already advertised
+		},
+		{
+			description:         "withdraw service-b - shared VIP",
+			srvName:             "service-b",
+			ingressIP:           "",
+			op:                  "update",
+			expectedRouteEvents: []routeEvent{}, // no event, shared VIP still advertised for service-c
+		},
+		{
+			description: "withdraw service-c - shared VIP",
+			srvName:     "service-c",
+			ingressIP:   "",
+			op:          "update",
+			expectedRouteEvents: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "dddd::1",
+					prefixLen:   128,
+					isWithdrawn: true, // withdrawal, shared VIP no longer used by any service
+				},
+			},
+		},
 	}
 
 	testCtx, testDone := context.WithTimeout(context.Background(), maxTestDuration)


### PR DESCRIPTION
As multiple services can share the same VIP (e.g. using `lbipam.cilium.io/sharing-key`), the service reconciliation logic needs to be adapted to not withdraw a route to VIP that is still in use by some other service.

To address that, this change introduces resource reference counting by reconciling service advertisements.

This fix is specific to BGPv1 service reconciliation, BGPv2 was fixed in https://github.com/cilium/cilium/pull/35166.

Fixes: #35018

