### PR TITLE
make: add hubble cli to kind-image-fast-agent

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -229,8 +229,12 @@ build-operator: ## Build cilium operator binary
 build-clustermesh-apiserver: ## Build cilium clustermesh-apiserver binary
 	$(QUIET)$(MAKE) -C clustermesh-apiserver  GOOS=linux
 
+.PHONY: build-hubble-cli
+build-hubble-cli: ## Build hubble cli binary
+	$(QUIET)$(MAKE) -C hubble GOOS=linux
+
 .PHONY: kind-image-fast-agent
-kind-image-fast-agent: kind-ready build-cli build-agent ## Build cilium cli and daemon binaries. Copy the bins and bpf files to kind nodes.
+kind-image-fast-agent: kind-ready build-cli build-agent build-hubble-cli ## Build cilium cli, daemon binaries, and hubble cli. Copy the bins and bpf files to kind nodes.
 	$(eval dst:=/cilium-binaries)
 	for cluster_name in $${KIND_CLUSTERS:-$(shell kind get clusters)}; do \
 		for node_name in $$(kind get nodes -n "$$cluster_name"); do \
@@ -248,6 +252,10 @@ kind-image-fast-agent: kind-ready build-cli build-agent ## Build cilium cli and 
 			docker exec $${node_name} rm -f "${dst}/cilium-agent"; \
 			docker cp "./daemon/cilium-agent" $${node_name}:"${dst}"; \
 			docker exec $${node_name} chmod +x "${dst}/cilium-agent"; \
+			\
+			docker exec $${node_name} rm -f "${dst}/hubble"; \
+			docker cp "./hubble/hubble" $${node_name}:"${dst}"; \
+			docker exec $${node_name} chmod +x "${dst}/hubble"; \
 		done; \
 		kubectl --context=kind-$${cluster_name} delete pods -n kube-system -l k8s-app=cilium --force; \
 	done

--- a/contrib/testing/kind-fast.yaml
+++ b/contrib/testing/kind-fast.yaml
@@ -11,6 +11,10 @@ extraVolumes:
   hostPath:
     path: /cilium-binaries/var/lib/cilium/bpf
     type: Directory
+- name: hubble-cli-binary
+  hostPath:
+    path: /cilium-binaries/hubble
+    type: File
 extraVolumeMounts:
 - name: cilium-dbg-binary
   mountPath: /usr/bin/cilium-dbg
@@ -20,6 +24,9 @@ extraVolumeMounts:
   readOnly: true
 - name: cilium-c-files
   mountPath: /var/lib/cilium/bpf
+- name: hubble-cli-binary
+  mountPath: /usr/bin/hubble
+  readOnly: true
 operator:
   extraVolumeMounts:
   - mountPath: /usr/bin/cilium-operator-generic


### PR DESCRIPTION
See the commit description.

Before this patch, testing a new Hubble CLI feature (e.g. a Hubble new filter) while developing needed either good knowledge of Hubble mTLS setup to work around the fact that Relay isn't enabled by `make kind-install-cilium-fast` or overriding some Helm values through `contrib/testing/kind-custom.yaml` or `ADDITIONAL_KIND_VALUES_FILE` (e.g. enabling Hubble Relay, disabling Hubble TLS).

Since most of the Hubble CLI changes can be tested using the Hubble CLI from the Cilium Pod, building and copying the Hubble CLI in the `kind-image-fast-agent` make target allow for fast iteration of Hubble CLI development.