### PR TITLE
wireguard add check on ipv6_hdrlen for failures

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1172,14 +1172,15 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 		}
 # endif /* defined(ENABLE_HOST_FIREWALL) && !defined(ENABLE_MASQUERADE_IPV6) */
 
-#ifdef ENABLE_WIREGUARD
+# ifdef ENABLE_WIREGUARD
 		if (!from_host) {
 			next_proto = ip6->nexthdr;
 			hdrlen = ipv6_hdrlen(ctx, &next_proto);
-			if (ctx_is_wireguard(ctx, ETH_HLEN + hdrlen, next_proto, ipcache_srcid))
+			if (likely(hdrlen > 0) &&
+			    ctx_is_wireguard(ctx, ETH_HLEN + hdrlen, next_proto, ipcache_srcid))
 				trace.reason = TRACE_REASON_ENCRYPTED;
 		}
-#endif /* ENABLE_WIREGUARD */
+# endif /* ENABLE_WIREGUARD */
 
 		send_trace_notify(ctx, obs_point, ipcache_srcid, UNKNOWN_ID, TRACE_EP_ID_UNKNOWN,
 				  ctx->ingress_ifindex, trace.reason, trace.monitor);

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1072,7 +1072,7 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 	void __maybe_unused *data, *data_end;
 	struct ipv6hdr __maybe_unused *ip6;
 	struct iphdr __maybe_unused *ip4;
-	int __maybe_unused l4_off = 0;
+	int __maybe_unused hdrlen = 0;
 	__u8 __maybe_unused next_proto = 0;
 	__s8 __maybe_unused ext_err = 0;
 	int ret;
@@ -1175,8 +1175,8 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 #ifdef ENABLE_WIREGUARD
 		if (!from_host) {
 			next_proto = ip6->nexthdr;
-			l4_off = ETH_HLEN + ipv6_hdrlen(ctx, &next_proto);
-			if (ctx_is_wireguard(ctx, l4_off, next_proto, ipcache_srcid))
+			hdrlen = ipv6_hdrlen(ctx, &next_proto);
+			if (ctx_is_wireguard(ctx, ETH_HLEN + hdrlen, next_proto, ipcache_srcid))
 				trace.reason = TRACE_REASON_ENCRYPTED;
 		}
 #endif /* ENABLE_WIREGUARD */
@@ -1218,8 +1218,8 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 #ifdef ENABLE_WIREGUARD
 		if (!from_host) {
 			next_proto = ip4->protocol;
-			l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
-			if (ctx_is_wireguard(ctx, l4_off, next_proto, ipcache_srcid))
+			hdrlen = ipv4_hdrlen(ip4);
+			if (ctx_is_wireguard(ctx, ETH_HLEN + hdrlen, next_proto, ipcache_srcid))
 				trace.reason = TRACE_REASON_ENCRYPTED;
 		}
 #endif /* ENABLE_WIREGUARD */


### PR DESCRIPTION
This PR adds additional checks after the `ipv6_hdrlen` function call to make sure it didn't fail before continuing processing the packet with `ctx_is_wireguard`. In case of failure, stop trying to mark it as encrypted, but do not drop the packet. In case we need to drop it, it'll be in the following tailcall `handle_ipv6`, whose processing logic actually relies on that value.

Offending commit hash: a732cd732af64adfd52fa75153c3ffd6986c0d45
Offending PR: https://github.com/cilium/cilium/pull/35183

```release-note
add checks to ipv6_hdrlen return value usage during wireguard tracing in ingress path
```
