### PR TITLE
clustermesh: add guardrails for known broken ENI/aws-chaining + cluster ID combination

### DIFF
--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -150,6 +150,11 @@
 {{- if and (eq .Values.cluster.name "default") (ne (int .Values.cluster.id) 0) }}
   {{ fail "The cluster name is invalid: cannot use default value with cluster.id != 0" }}
 {{- end }}
+{{ if and
+    (or (and (ge (int .Values.cluster.id) 128) (le (int .Values.cluster.id) 255)) (and (ge (int .Values.cluster.id) 384) (le (int .Values.cluster.id) 511)))
+    (or .Values.eni.enabled .Values.alibabacloud.enabled (eq .Values.cni.chainingMode "aws-cni")) -}}
+  {{ fail "Cilium is currently affected by a bug that causes traffic matched by network policies to be incorrectly dropped when running in either ENI mode (both AWS and AlibabaCloud) or AWS VPC CNI chaining mode, if the cluster ID is 128-255 (and 384-511 when maxConnectedClusters=511). Please refer to https://github.com/cilium/cilium/issues/21330 for additional details." }}
+{{- end }}
 
 {{/* validate clustermesh-apiserver */}}
 {{- if .Values.clustermesh.useAPIServer }}

--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -6,7 +6,9 @@ package clustermesh
 import (
 	"github.com/cilium/hive/cell"
 
+	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
+	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/clustermesh/wait"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -14,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	nodemanager "github.com/cilium/cilium/pkg/node/manager"
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 var Cell = cell.Module(
@@ -36,6 +39,9 @@ var Cell = cell.Module(
 	metrics.Metric(NewMetrics),
 	metrics.Metric(common.MetricsProvider(subsystem)),
 
+	cell.Invoke(func(info types.ClusterInfo, dcfg *option.DaemonConfig, cnimgr cni.CNIConfigManager) error {
+		return info.ValidateBuggyClusterID(dcfg.IPAM, cnimgr.GetChainingMode())
+	}),
 	cell.Invoke(ipsetNotifier),
 	cell.Invoke(nodeManagerNotifier),
 )


### PR DESCRIPTION
Cilium is currently affected by a bug that causes traffic matched by network policies to be incorrectly dropped when running in either ENI mode (both AWS and AlibabaCloud) or AWS VPC CNI chaining mode, if the cluster ID is 128-255 (and 384-511 when maxConnectedClusters=511) [1]. Let's add validation both at the helm level and in the agent itself to prevent users from configuring Cilium in a configuration which is known to be broken.

\[1]: cilium/cilium#21330