### PR TITLE
Endpoint redirect cleanup

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -679,101 +679,23 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 	// Mark the desired policy as ready when done before the lock is released
 	defer e.desiredPolicy.Ready()
 
+	var (
+		desiredRedirects map[string]uint16
+		finalizeFunc     revert.FinalizeFunc
+		revertFunc       revert.RevertFunc
+	)
+	// Get currently realized redirects
+	previouslyRealizedRedirects := e.GetRealizedRedirects()
+
 	// Apply pending policy map changes so that desired map is up-to-date before
-	// we update network policies and sync the maps below.
-	err = e.applyPolicyMapChanges(e.desiredPolicy != e.realizedPolicy)
-	if err != nil {
-		return err
-	}
-
-	// We cannot obtain the rules while e.mutex is held, because obtaining
-	// fresh DNSRules requires the IPCache lock (which must not be taken while
-	// holding e.mutex to avoid deadlocks). Therefore, rules are obtained
-	// before the call to runPreCompilationSteps.
-	e.OnDNSPolicyUpdateLocked(rules)
-
-	// If dry mode is enabled, no further changes to BPF maps are performed
-	if e.isProperty(PropertyFakeEndpoint) && e.isProperty(PropertySkipBPFPolicy) {
-		_ = e.updateAndOverrideEndpointOptions(nil)
-
-		// Dry mode needs Network Policy Updates, but the proxy wait group must
-		// not be initialized, as there is no proxy ACKing the changes.
-		if err, _ = e.updateNetworkPolicy(nil); err != nil {
-			return err
-		}
-
-		if err = e.writeHeaderfile(nextDir); err != nil {
-			return fmt.Errorf("Unable to write header file: %w", err)
-		}
-
-		if logging.CanLogAt(log.Logger, logrus.DebugLevel) {
-			log.WithField(logfields.EndpointID, e.ID).Debug("Skipping bpf updates due to dry mode")
-		}
-		return nil
-	}
-
-	// Endpoints without policy maps only need Network Policy Updates
-	if e.isProperty(PropertySkipBPFPolicy) {
-		if logging.CanLogAt(log.Logger, logrus.DebugLevel) {
-			log.WithField(logfields.EndpointID, e.ID).Debug("Ingress Endpoint skipping bpf regeneration")
-		}
-
-		if e.SecurityIdentity != nil {
-			_ = e.updateAndOverrideEndpointOptions(nil)
-
-			if logging.CanLogAt(log.Logger, logrus.DebugLevel) {
-				log.WithField(logfields.EndpointID, e.ID).Debug("Ingress Endpoint updating Network policy")
-			}
-
-			stats.proxyPolicyCalculation.Start()
-			err, networkPolicyRevertFunc := e.updateNetworkPolicy(datapathRegenCtxt.proxyWaitGroup)
-			stats.proxyPolicyCalculation.End(err == nil)
-			if err != nil {
-				return err
-			}
-			datapathRegenCtxt.revertStack.Push(networkPolicyRevertFunc)
-		}
-		return nil
-	}
-
-	firstRegen := false
-
-	if e.policyMap == nil {
-		firstRegen = true
-		e.policyMap, err = policymap.OpenOrCreate(e.policyMapPath())
-		if err != nil {
-			return err
-		}
-
-		// Synchronize the in-memory realized state with BPF map entries,
-		// so that any potential discrepancy between desired and realized
-		// state would be dealt with by the following e.syncPolicyMap.
-		pm, err := e.dumpPolicyMapToMapState()
-		if err != nil {
-			return err
-		}
-		e.realizedPolicy.SetPolicyMap(pm)
-		e.updatePolicyMapPressureMetric()
-	}
-
-	// Only generate & populate policy map if a security identity is set up for
-	// this endpoint.
+	// syncing the maps below.
 	if e.SecurityIdentity != nil {
-
 		_ = e.updateAndOverrideEndpointOptions(nil)
 
-		// Walk the L4Policy to add new redirects and update the desired policy for existing redirects.
-		// Do this before updating the bpf policy maps, so that the proxies are ready when new traffic
-		// is redirected to them.
-		var (
-			desiredRedirects map[string]uint16
-			finalizeFunc     revert.FinalizeFunc
-			revertFunc       revert.RevertFunc
-		)
-		// Get currently realized redirects
-		previouslyRealizedRedirects := e.GetRealizedRedirects()
-
-		if e.desiredPolicy != nil {
+		// Walk the L4Policy to add new redirects and update the desired policy for existing
+		// redirects.  Do this before updating the bpf policy maps, so that the proxies are
+		// ready when new traffic is redirected to them.
+		if e.desiredPolicy != nil && !e.isProperty(PropertySkipBPFPolicy) {
 			stats.proxyConfiguration.Start()
 			// Deny policies do not support redirects
 			desiredRedirects, err, finalizeFunc, revertFunc = e.addNewRedirects(datapathRegenCtxt.proxyWaitGroup)
@@ -797,22 +719,68 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 			})
 		}
 
-		// Configure the new network policy with the proxies.
+		// Apply incremental changes to desiredPolicy and Configure the new network policy
+		// with the proxies.
 		//
-		// This must be done after adding new redirects above, as waiting for policy update ACKs is
-		// disabled when there are no listeners, which is the case before the first redirect is added.
+		// If we have a new policy, it is likely that incremental updates were applied to
+		// the old policy while we were waiting for the endpoint lock. If we were to sync
+		// policy maps without applying incremental updates first we could be flapping
+		// network policy backwards just to be updating it again after applying incremental
+		// updates later.
 		//
-		// Do this before updating the bpf policy maps below, so that the proxy listeners have a chance to be
-		// ready when new traffic is redirected to them.
-		// note: unlike regeneratePolicy, updateNetworkPolicy requires the endpoint read lock
-		stats.proxyPolicyCalculation.Start()
-		err, networkPolicyRevertFunc := e.updateNetworkPolicy(datapathRegenCtxt.proxyWaitGroup)
-		stats.proxyPolicyCalculation.End(err == nil)
+		// This must be done after adding new redirects, as waiting for policy update
+		// ACKs is disabled when there are no listeners, which is the case before the first
+		// redirect is added.
+		//
+		// Do this before updating the bpf policy maps (later), so that the proxy listeners
+		// have a chance to be ready when new traffic is redirected to them.  Note that it
+		// is possible for further incremental changes to be applied before and after the
+		// bpf policy maps have been synchronized for the new policy.
+		//
+		err = e.applyPolicyMapChanges(regenContext, e.desiredPolicy != e.realizedPolicy)
 		if err != nil {
 			return err
 		}
-		datapathRegenCtxt.revertStack.Push(networkPolicyRevertFunc)
+	}
 
+	// We cannot obtain the rules while e.mutex is held, because obtaining
+	// fresh DNSRules requires the IPCache lock (which must not be taken while
+	// holding e.mutex to avoid deadlocks). Therefore, rules are obtained
+	// before the call to runPreCompilationSteps.
+	e.OnDNSPolicyUpdateLocked(rules)
+
+	// If dry mode is enabled, no further changes to BPF maps are performed
+	if e.isProperty(PropertySkipBPFPolicy) {
+		if e.isProperty(PropertyFakeEndpoint) {
+			if err = e.writeHeaderfile(nextDir); err != nil {
+				return fmt.Errorf("Unable to write header file: %w", err)
+			}
+		}
+		return nil
+	}
+	firstRegen := false
+
+	if e.policyMap == nil {
+		firstRegen = true
+		e.policyMap, err = policymap.OpenOrCreate(e.policyMapPath())
+		if err != nil {
+			return err
+		}
+
+		// Synchronize the in-memory realized state with BPF map entries,
+		// so that any potential discrepancy between desired and realized
+		// state would be dealt with by the following e.syncPolicyMap.
+		pm, err := e.dumpPolicyMapToMapState()
+		if err != nil {
+			return err
+		}
+		e.realizedPolicy.SetPolicyMap(pm)
+		e.updatePolicyMapPressureMetric()
+	}
+
+	// Only generate & populate policy map if a security identity is set up for
+	// this endpoint.
+	if e.SecurityIdentity != nil {
 		// Synchronously try to update PolicyMap for this endpoint. If any
 		// part of updating the PolicyMap fails, bail out and do not generate
 		// BPF. Unfortunately, this means that the map will be in an inconsistent
@@ -1129,60 +1097,101 @@ func (e *Endpoint) ApplyPolicyMapChanges(proxyWaitGroup *completion.WaitGroup) e
 
 	e.PolicyDebug(nil, "ApplyPolicyMapChanges")
 
-	err := e.applyPolicyMapChanges(false)
-	if err != nil {
-		return err
-	}
-
-	// Only update Envoy if there are envoy redirects.
-	// This is safe to do here, since a PolicyMapChange cannot
-	// cause an envoy redirect to appear or disappear. It only allows for
-	// incremental updates. Thus, we don't need to worry about stale
-	// policy not being cleaned up.
-	//
-	// Note: we must always do this, even if there are no pending incremental changes, because
-	// the incremental changes may have been already applied by `e.applyPolicyMapChanges()` during
-	// a regeneration, but not yet applied to Envoy. If there were pending policymap changes, we will
-	// *always* get a corresponding call to `.ApplyPolicyMapChanges()`, so callers depend on this
-	// to push changes to Envoy.
-	if e.desiredPolicy.L4Policy.HasEnvoyRedirect() || e.isIngress {
-		// Ignoring the revertFunc; keep all successful changes even if some fail.
-		e.getLogger().Debug("Endpoint has envoy redirects, applying changes to Envoy")
-		err, _ = e.updateNetworkPolicy(proxyWaitGroup)
-	} else {
-		e.getLogger().Debug("Endpoint has no envoy redirects, skipping Envoy update")
-	}
-
-	return err
+	return e.applyPolicyMapChanges(&regenerationContext{
+		datapathRegenerationContext: &datapathRegenerationContext{
+			proxyWaitGroup: proxyWaitGroup,
+		},
+	}, false)
 }
 
 // applyPolicyMapChanges applies any incremental policy map changes
 // collected on the desired policy.
-func (e *Endpoint) applyPolicyMapChanges(hasNewPolicy bool) error {
-	errors := 0
-
+// Endpoint's Envoy NetworkPolicy is also updated if needed.
+// Endpoint must be locked
+func (e *Endpoint) applyPolicyMapChanges(regenContext *regenerationContext, hasNewPolicy bool) error {
 	e.PolicyDebug(nil, "applyPolicyMapChanges")
 
-	//  Note that after successful endpoint regeneration the
-	//  desired and realized policies are the same pointer. During
-	//  the bpf regeneration possible incremental updates are
-	//  collected on the newly computed desired policy, which is
-	//  not fully realized yet. This is why we get the map changes
-	//  from the desired policy here.
-	//  ConsumeMapChanges() applies the incremental updates to the
-	//  desired policy and only returns changes that need to be
-	//  applied to the Endpoint's bpf policy map.
+	// Always update Envoy if policy has changed
+	updateEnvoy := hasNewPolicy
+
+	// Note that after successful endpoint regeneration the desired and realized policies are
+	// the same pointer. During the bpf regeneration possible incremental updates are collected
+	// on the newly computed desired policy, which is not fully realized yet. This is why we get
+	// the map changes from the desired policy here.
+
+	// ConsumeMapChanges() applies the incremental updates to the desired policy and only
+	// returns changes that need to be applied to the Endpoint's bpf policy map.
 	closer, changes := e.desiredPolicy.ConsumeMapChanges()
 	defer closer()
 
-	if changes.Empty() {
-		// no changes, nothing to do
-		return nil
+	hasEnvoyRedirect := e.desiredPolicy.L4Policy.HasEnvoyRedirect()
+	if !changes.Empty() {
+		// updateEnvoy if there were any mapChanges, but only if the endpoint has Envoy
+		// redirects, or is an Ingress endpoint, which needs to enforce also the full L3/4
+		// policy.
+		//
+		// Even if there are no changes, we update the proxyWaitGroup for any in-progress
+		// NetworkPolicy update to be done if the endpoint has envoy redirects, so that the
+		// the expected policy is in place.
+		//
+		// 'updateEnvoy' is already set to 'true' if policy changed. In that case there can
+		// be new redirects and a full policy map update even if there were no incremental
+		// updates.
+		updateEnvoy = updateEnvoy || hasEnvoyRedirect || e.isIngress
 	}
+
+	stats := &regenContext.Stats
+	datapathRegenCtxt := regenContext.datapathRegenerationContext
+	var err error
+
+	proxyWaitGroup := datapathRegenCtxt.proxyWaitGroup
 
 	// Ingress endpoint does not need to wait.
 	// This also lets daemon/cmd integration tests to proceed
 	if e.isProperty(PropertySkipBPFPolicy) {
+		if logging.CanLogAt(log.Logger, logrus.DebugLevel) {
+			log.WithField(logfields.EndpointID, e.ID).Debug("Ingress Endpoint updating Network policy")
+		}
+		proxyWaitGroup = nil
+	}
+
+	// Configure the new network policy with the proxies.
+	//
+	// This must be done after adding new redirects, as waiting for policy update ACKs is
+	// disabled when there are no listeners, which is the case before the first redirect is
+	// added.
+	//
+	// Do this before updating the bpf policy maps below, so that the proxy listeners have a
+	// chance to be ready when new traffic is redirected to them.
+	// NOTE: unlike regeneratePolicy, UpdateNetworkPolicy requires the endpoint read lock for
+	// 'e.desiredPolicy' access.
+	if !e.IsProxyDisabled() {
+		if updateEnvoy {
+			e.getLogger().
+				WithField(logfields.SelectorCacheVersion, e.desiredPolicy.VersionHandle).
+				Debug("applyPolicyMapChanges: Updating Envoy NetworkPolicy")
+			stats.proxyPolicyCalculation.Start()
+			var rf revert.RevertFunc
+			err, rf = e.proxy.UpdateNetworkPolicy(e, &e.desiredPolicy.L4Policy, e.desiredPolicy.IngressPolicyEnabled, e.desiredPolicy.EgressPolicyEnabled, proxyWaitGroup)
+			stats.proxyPolicyCalculation.End(err == nil)
+			if err == nil {
+				datapathRegenCtxt.revertStack.Push(rf)
+			}
+		} else if hasEnvoyRedirect {
+			// Wait for a possible ongoing update to be done if there were no current changes.
+			e.getLogger().
+				WithField(logfields.SelectorCacheVersion, e.desiredPolicy.VersionHandle).
+				Debug("applyPolicyMapChanges: Using current Networkpolicy")
+			e.proxy.UseCurrentNetworkPolicy(e, &e.desiredPolicy.L4Policy, proxyWaitGroup)
+		}
+	}
+
+	// Ingress endpoint has no bpf policy maps, so return before applying changes to bpf.
+	if e.isProperty(PropertySkipBPFPolicy) {
+
+		if logging.CanLogAt(log.Logger, logrus.DebugLevel) {
+			log.WithField(logfields.EndpointID, e.ID).Debug("Skipping bpf updates due to dry mode")
+		}
 		return nil
 	}
 
@@ -1193,11 +1202,8 @@ func (e *Endpoint) applyPolicyMapChanges(hasNewPolicy bool) error {
 	}
 
 	// Add policy map entries before deleting to avoid transient drops
+	errors := 0
 	for keyToAdd := range changes.Adds {
-		// AddVisibilityKeys() records changed keys in both 'deletes' (old value) and 'adds' (new value).
-		// Remove the key from 'deletes' to keep the new entry.
-		delete(changes.Deletes, keyToAdd)
-
 		entry, exists := e.desiredPolicy.GetPolicyMap().Get(keyToAdd)
 		if !exists {
 			e.getLogger().WithFields(logrus.Fields{
@@ -1218,7 +1224,7 @@ func (e *Endpoint) applyPolicyMapChanges(hasNewPolicy bool) error {
 	}
 
 	if errors > 0 {
-		return fmt.Errorf("updating desired PolicyMap state failed")
+		return fmt.Errorf("updating bpf policy maps failed")
 	}
 	if len(changes.Adds)+len(changes.Deletes) > 0 {
 		e.getLogger().WithFields(logrus.Fields{
@@ -1226,7 +1232,6 @@ func (e *Endpoint) applyPolicyMapChanges(hasNewPolicy bool) error {
 			logfields.DeletedPolicyID: changes.Deletes,
 		}).Debug("Applied policy map updates due to identity changes")
 	}
-
 	return nil
 }
 
@@ -1347,13 +1352,6 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 	// this round.
 	if e.getState() != StateReady {
 		return nil
-	}
-
-	// Apply pending policy map changes first so that desired map is up-to-date before
-	// we diff the maps below.
-	err := e.applyPolicyMapChanges(false)
-	if err != nil {
-		return err
 	}
 
 	currentMap, err := e.dumpPolicyMapToMapState()

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -138,11 +138,13 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 	}()
 
 	stats := new(regenerationStatistics)
+	datapathRegenCtxt := new(datapathRegenerationContext)
 	// Continuously compute policy for the pod and ensure we never missed an incremental update.
 	for {
 		t.Log("Calculating policy...")
-		res, err := ep.regeneratePolicy(stats)
+		res, err := ep.regeneratePolicy(stats, datapathRegenCtxt)
 		assert.NoError(t, err)
+		res.endpointPolicy = res.selectorPolicy.Consume(&ep, nil)
 
 		// Sleep a random amount, so we accumulate some changes
 		// This does not slow down the test, since we always generate testFactor identities.

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -16,7 +16,7 @@ import (
 // EndpointProxy defines any L7 proxy with which an Endpoint must interact.
 type EndpointProxy interface {
 	CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, localEndpoint endpoint.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc)
-	RemoveRedirect(id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
+	RemoveRedirect(id string)
 	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
 	UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
 	RemoveNetworkPolicy(ep endpoint.EndpointInfoSource)
@@ -49,8 +49,7 @@ func (f *FakeEndpointProxy) CreateOrUpdateRedirect(ctx context.Context, l4 polic
 }
 
 // RemoveRedirect does nothing.
-func (f *FakeEndpointProxy) RemoveRedirect(id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc) {
-	return nil, nil, nil
+func (f *FakeEndpointProxy) RemoveRedirect(id string) {
 }
 
 // UseCurrentNetworkPolicy does nothing.

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -18,6 +18,7 @@ type EndpointProxy interface {
 	CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, localEndpoint endpoint.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc)
 	RemoveRedirect(id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
 	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
+	UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
 	RemoveNetworkPolicy(ep endpoint.EndpointInfoSource)
 }
 
@@ -50,6 +51,10 @@ func (f *FakeEndpointProxy) CreateOrUpdateRedirect(ctx context.Context, l4 polic
 // RemoveRedirect does nothing.
 func (f *FakeEndpointProxy) RemoveRedirect(id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc) {
 	return nil, nil, nil
+}
+
+// UseCurrentNetworkPolicy does nothing.
+func (f *FakeEndpointProxy) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
 }
 
 // UpdateNetworkPolicy does nothing.

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -102,6 +102,10 @@ func (r *RedirectSuiteProxy) RemoveRedirect(id string, wg *completion.WaitGroup)
 	return nil, nil, nil
 }
 
+// UseCurrentNetworkPolicy does nothing.
+func (f *RedirectSuiteProxy) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
+}
+
 // UpdateNetworkPolicy does nothing.
 func (r *RedirectSuiteProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
 	return nil, nil

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -30,11 +30,12 @@ import (
 )
 
 type RedirectSuite struct {
-	oldPolicyEnable string
-	mgr             *cache.CachingIdentityAllocator
-	do              *DummyOwner
-	rsp             *RedirectSuiteProxy
-	stats           *regenerationStatistics
+	oldPolicyEnable   string
+	mgr               *cache.CachingIdentityAllocator
+	do                *DummyOwner
+	rsp               *RedirectSuiteProxy
+	stats             *regenerationStatistics
+	datapathRegenCtxt *datapathRegenerationContext
 }
 
 func setupRedirectSuite(tb testing.TB) *RedirectSuite {
@@ -69,10 +70,11 @@ func setupRedirectSuite(tb testing.TB) *RedirectSuite {
 			"crd/cec1/listener1":            crd1Port,
 			"crd/cec2/listener2":            crd2Port,
 		},
-		redirectPortUserMap: make(map[uint16][]string),
+		redirects: make(map[string]uint16),
 	}
 
 	s.stats = new(regenerationStatistics)
+	s.datapathRegenCtxt = new(datapathRegenerationContext)
 
 	tb.Cleanup(func() {
 		s.do.idmgr.RemoveAll()
@@ -86,20 +88,20 @@ func setupRedirectSuite(tb testing.TB) *RedirectSuite {
 // RedirectSuiteProxy implements EndpointProxy. It is used for testing the
 // functions related to generating proxy redirects for a given Endpoint.
 type RedirectSuiteProxy struct {
-	parserProxyPortMap  map[string]uint16
-	redirectPortUserMap map[uint16][]string
+	parserProxyPortMap map[string]uint16
+	redirects          map[string]uint16
 }
 
 // CreateOrUpdateRedirect returns the proxy port for the given L7Parser from the
 // ProxyPolicy parameter.
 func (r *RedirectSuiteProxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, localEndpoint endpoint.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 	pp := r.parserProxyPortMap[l4.GetL7Parser().String()+l4.GetListener()]
-	return pp, nil, func() { log.Infof("FINALIZER CALLED") }, nil
+	return pp, nil, func() { r.redirects[id] = pp }, nil
 }
 
-// RemoveRedirect does nothing.
-func (r *RedirectSuiteProxy) RemoveRedirect(id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc) {
-	return nil, nil, nil
+// RemoveRedirect removes a redirect from the map
+func (r *RedirectSuiteProxy) RemoveRedirect(id string) {
+	delete(r.redirects, id)
 }
 
 // UseCurrentNetworkPolicy does nothing.
@@ -300,6 +302,21 @@ func (s *RedirectSuite) testMapState(initMap policy.MapStateMap) policy.MapState
 	return policy.NewMapState().WithState(initMap)
 }
 
+func (s *RedirectSuite) computePolicyForTest(t *testing.T, ep *Endpoint, cmp *completion.WaitGroup) {
+	res, err := ep.regeneratePolicy(s.stats, s.datapathRegenCtxt)
+	require.NoError(t, err)
+
+	oldDesiredPolicy := ep.desiredPolicy
+	s.datapathRegenCtxt.revertStack.Push(func() error {
+		ep.desiredPolicy = oldDesiredPolicy
+		return nil
+	})
+	ep.setDesiredPolicy(res, s.datapathRegenCtxt)
+
+	// This will also remove old redirects
+	s.datapathRegenCtxt.finalizeList.Finalize()
+}
+
 func TestRedirectWithDeny(t *testing.T) {
 	s := setupRedirectSuite(t)
 	ep := s.NewTestEndpoint(t)
@@ -310,41 +327,18 @@ func TestRedirectWithDeny(t *testing.T) {
 		ruleL4L7Allow.WithEndpointSelector(selectBar_),
 	})
 
-	res, err := ep.regeneratePolicy(s.stats)
-	require.NoError(t, err)
-	err = ep.setDesiredPolicy(res)
-	require.NoError(t, err)
-
-	expected := s.testMapState(policy.MapStateMap{
-		mapKeyAllowAllE: {
-			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
-		},
-		mapKeyFoo: {
-			IsDeny:           true,
-			DerivedFromRules: labels.LabelArrayList{lblsL3DenyFoo},
-		},
-	})
-	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
-		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(expected))
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cmp := completion.NewWaitGroup(ctx)
-
-	realizedRedirects := ep.GetRealizedRedirects()
-	desiredRedirects, err, finalizeFunc, revertFunc := ep.addNewRedirects(cmp)
-	require.NoError(t, err)
-	finalizeFunc()
+	s.computePolicyForTest(t, ep, cmp)
 
 	// Redirect is still created, even if all MapState entries may have been overridden by a
 	// deny entry.  A new FQDN redirect may have no MapState entries as the associated CIDR
 	// identities may match no numeric IDs yet, so we can not count the number of added MapState
 	// entries and make any conclusions from it.
-	require.Len(t, desiredRedirects, 1)
+	require.Len(t, ep.desiredPolicy.Redirects, 1)
 
-	expected2 := s.testMapState(policy.MapStateMap{
+	expected := s.testMapState(policy.MapStateMap{
 		mapKeyAllowAllE: {
 			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
 		},
@@ -365,27 +359,26 @@ func TestRedirectWithDeny(t *testing.T) {
 
 	// Redirect for the HTTP port should have been added, but there should be a deny for Foo on
 	// that port, as it is shadowed by the deny rule
-	if !ep.desiredPolicy.GetPolicyMap().Equals(expected2) {
+	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(expected2))
+			ep.desiredPolicy.GetPolicyMap().Diff(expected))
 	}
 
-	// Keep only desired redirects
-	ep.removeOldRedirects(desiredRedirects, realizedRedirects, cmp)
-
-	// Check that the redirect is still realized
-	require.Len(t, desiredRedirects, 1)
+	// Check that the redirect is realized
+	require.Len(t, ep.desiredPolicy.Redirects, 1)
 	require.Equal(t, 4, ep.desiredPolicy.GetPolicyMap().Len())
 
 	// Pretend that something failed and revert the changes
-	revertFunc()
+	s.datapathRegenCtxt.revertStack.Revert()
+	require.Empty(t, ep.desiredPolicy.Redirects)
+
+	expected = s.testMapState(map[policy.Key]policy.MapStateEntry{})
 
 	// Check that the state before addRedirects is restored
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
 			ep.desiredPolicy.GetPolicyMap().Diff(expected))
 	}
-	require.Equal(t, 2, ep.desiredPolicy.GetPolicyMap().Len())
 }
 
 var (
@@ -473,39 +466,17 @@ func TestRedirectWithPriority(t *testing.T) {
 		ruleL4L7AllowListener2Priority1.WithEndpointSelector(selectBar_),
 	})
 
-	res, err := ep.regeneratePolicy(s.stats)
-	require.NoError(t, err)
-	err = ep.setDesiredPolicy(res)
-	require.NoError(t, err)
-
-	expected := s.testMapState(policy.MapStateMap{
-		mapKeyAllowAllE: {
-			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
-		},
-		mapKeyAllL7: {
-			DerivedFromRules: labels.LabelArrayList{lblsL4AllowPort80},
-		},
-	})
-	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
-		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(expected))
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cmp := completion.NewWaitGroup(ctx)
-
-	realizedRedirects := ep.GetRealizedRedirects()
-	desiredRedirects, err, finalizeFunc, revertFunc := ep.addNewRedirects(cmp)
-	require.NoError(t, err)
-	finalizeFunc()
+	s.computePolicyForTest(t, ep, cmp)
 
 	// Check that all redirects have been created.
-	require.Equal(t, crd2Port, desiredRedirects["12345:ingress:TCP:80:/cec2/listener2"])
-	require.Equal(t, crd1Port, desiredRedirects["12345:ingress:TCP:80:/cec1/listener1"])
-	require.Len(t, desiredRedirects, 2)
+	require.Equal(t, crd2Port, ep.desiredPolicy.Redirects["12345:ingress:TCP:80:/cec2/listener2"])
+	require.Equal(t, crd1Port, ep.desiredPolicy.Redirects["12345:ingress:TCP:80:/cec1/listener1"])
+	require.Len(t, ep.desiredPolicy.Redirects, 2)
 
-	expected2 := s.testMapState(policy.MapStateMap{
+	expected := s.testMapState(policy.MapStateMap{
 		mapKeyAllowAllE: {
 			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
 		},
@@ -518,27 +489,26 @@ func TestRedirectWithPriority(t *testing.T) {
 			DerivedFromRules: labels.LabelArrayList{lblsL4AllowPort80},
 		},
 	})
-	if !ep.desiredPolicy.GetPolicyMap().Equals(expected2) {
+	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(expected2))
+			ep.desiredPolicy.GetPolicyMap().Diff(expected))
 	}
 
-	// Keep only desired redirects
-	ep.removeOldRedirects(desiredRedirects, realizedRedirects, cmp)
-
-	// Check that the redirect is still realized
-	require.Len(t, desiredRedirects, 2)
+	// Check that the redirect is realized
+	require.Len(t, ep.desiredPolicy.Redirects, 2)
 	require.Equal(t, 3, ep.desiredPolicy.GetPolicyMap().Len())
 
 	// Pretend that something failed and revert the changes
-	revertFunc()
+	s.datapathRegenCtxt.revertStack.Revert()
+	require.Empty(t, ep.desiredPolicy.Redirects)
+
+	expected = s.testMapState(map[policy.Key]policy.MapStateEntry{})
 
 	// Check that the state before addRedirects is restored
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
 			ep.desiredPolicy.GetPolicyMap().Diff(expected))
 	}
-	require.Equal(t, 2, ep.desiredPolicy.GetPolicyMap().Len())
 }
 
 func TestRedirectWithEqualPriority(t *testing.T) {
@@ -554,39 +524,17 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 		ruleL4L7AllowListener2Priority1.WithEndpointSelector(selectBar_),
 	})
 
-	res, err := ep.regeneratePolicy(s.stats)
-	require.NoError(t, err)
-	err = ep.setDesiredPolicy(res)
-	require.NoError(t, err)
-
-	expected := s.testMapState(policy.MapStateMap{
-		mapKeyAllowAllE: {
-			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
-		},
-		mapKeyAllL7: {
-			DerivedFromRules: labels.LabelArrayList{lblsL4AllowPort80},
-		},
-	})
-	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
-		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(expected))
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cmp := completion.NewWaitGroup(ctx)
-
-	realizedRedirects := ep.GetRealizedRedirects()
-	desiredRedirects, err, finalizeFunc, revertFunc := ep.addNewRedirects(cmp)
-	require.NoError(t, err)
-	finalizeFunc()
+	s.computePolicyForTest(t, ep, cmp)
 
 	// Check that all redirects have been created.
-	require.Equal(t, crd2Port, desiredRedirects["12345:ingress:TCP:80:/cec2/listener2"])
-	require.Equal(t, crd1Port, desiredRedirects["12345:ingress:TCP:80:/cec1/listener1"])
-	require.Len(t, desiredRedirects, 2)
+	require.Equal(t, crd2Port, ep.desiredPolicy.Redirects["12345:ingress:TCP:80:/cec2/listener2"])
+	require.Equal(t, crd1Port, ep.desiredPolicy.Redirects["12345:ingress:TCP:80:/cec1/listener1"])
+	require.Len(t, ep.desiredPolicy.Redirects, 2)
 
-	expected2 := s.testMapState(policy.MapStateMap{
+	expected := s.testMapState(policy.MapStateMap{
 		mapKeyAllowAllE: {
 			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
 		},
@@ -599,25 +547,24 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 			DerivedFromRules: labels.LabelArrayList{lblsL4AllowPort80},
 		},
 	})
-	if !ep.desiredPolicy.GetPolicyMap().Equals(expected2) {
+	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(expected2))
+			ep.desiredPolicy.GetPolicyMap().Diff(expected))
 	}
 
-	// Keep only desired redirects
-	ep.removeOldRedirects(desiredRedirects, realizedRedirects, cmp)
-
-	// Check that the redirect is still realized
-	require.Len(t, desiredRedirects, 2)
+	// Check that the redirect is realized
+	require.Len(t, ep.desiredPolicy.Redirects, 2)
 	require.Equal(t, 3, ep.desiredPolicy.GetPolicyMap().Len())
 
 	// Pretend that something failed and revert the changes
-	revertFunc()
+	s.datapathRegenCtxt.revertStack.Revert()
+	require.Empty(t, ep.desiredPolicy.Redirects)
+
+	expected = s.testMapState(map[policy.Key]policy.MapStateEntry{})
 
 	// Check that the state before addRedirects is restored
 	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
 			ep.desiredPolicy.GetPolicyMap().Diff(expected))
 	}
-	require.Equal(t, 2, ep.desiredPolicy.GetPolicyMap().Len())
 }

--- a/pkg/envoy/secretsync_test.go
+++ b/pkg/envoy/secretsync_test.go
@@ -438,3 +438,7 @@ func (*fakeXdsServer) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
 func (*fakeXdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced bool, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
 	panic("unimplemented")
 }
+
+func (*fakeXdsServer) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
+	panic("unimplemented")
+}

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -74,6 +74,10 @@ type AckingResourceMutator interface {
 	// method call.
 	Upsert(typeURL string, resourceName string, resource proto.Message, nodeIDs []string, wg *completion.WaitGroup, callback func(error)) AckingResourceMutatorRevertFunc
 
+	// UseCurrent inserts a completion that allows the caller to wait for the current
+	// version of the given typeURL to be ACKed.
+	UseCurrent(typeURL string, nodeIDs []string, wg *completion.WaitGroup)
+
 	// DeleteNode frees resources held for the named node
 	DeleteNode(nodeID string)
 
@@ -164,6 +168,29 @@ func (m *AckingResourceMutatorWrapper) addVersionCompletion(typeURL string, vers
 		comp.remainingNodesResources[nodeID] = nil
 	}
 	m.pendingCompletions[c] = comp
+}
+
+// UseCurrent adds a completion to the WaitGroup if the current
+// version of the cached resource has not been acked yet, allowing the
+// caller to wait for the ACK.
+func (m *AckingResourceMutatorWrapper) UseCurrent(typeURL string, nodeIDs []string, wg *completion.WaitGroup) {
+	m.locker.Lock()
+	defer m.locker.Unlock()
+
+	wait := wg != nil
+
+	if m.restoring {
+		// Do not wait for acks when restoring state
+		log.WithFields(logrus.Fields{
+			logfields.XDSTypeURL: typeURL,
+		}).Debug("UseCurrent: Restoring, skipping wait for ACK")
+
+		wait = false
+	}
+
+	if wait {
+		m.useCurrent(typeURL, nodeIDs, wg, nil)
+	}
 }
 
 // DeleteNode frees resources held for the named nodes

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -119,18 +119,6 @@ func TestUpsertSingleNode(t *testing.T) {
 	require.Equal(t, uint64(2), acker.ackedVersions[node0])
 }
 
-// UseCurrent adds a completion to the WaitGroup if the current
-// version of the cached resource has not been acked yet, allowing the
-// caller to wait for the ACK.
-func (m *AckingResourceMutatorWrapper) UseCurrent(typeURL string, nodeIDs []string, wg *completion.WaitGroup) {
-	m.locker.Lock()
-	defer m.locker.Unlock()
-
-	if wg != nil {
-		m.useCurrent(typeURL, nodeIDs, wg, nil)
-	}
-}
-
 func TestUseCurrent(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -119,6 +119,8 @@ type XDSServer interface {
 	//
 	// Only used for testing
 	GetNetworkPolicies(resourceNames []string) (map[string]*cilium.NetworkPolicy, error)
+	// UseCurrentNetworkPolicy waits for any pending update on NetworkPolicy to be acked.
+	UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
 	// UpdateNetworkPolicy adds or updates a network policy in the set published to L7 proxies.
 	// When the proxy acknowledges the network policy update, it will result in
 	// a subsequent call to the endpoint's OnProxyPolicyUpdate() function.
@@ -1585,8 +1587,6 @@ func getWildcardNetworkPolicyRule(version *versioned.VersionHandle, selectors po
 }
 
 func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4PolicyMap, policyEnforced bool, useFullTLSContext bool, dir string) []*cilium.PortNetworkPolicy {
-	version := ep.GetPolicyVersionHandle()
-
 	// TODO: integrate visibility with enforced policy
 	if !policyEnforced {
 		// Always allow all ports
@@ -1596,6 +1596,8 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 	if l4Policy == nil || l4Policy.Len() == 0 {
 		return nil
 	}
+
+	version := ep.GetPolicyVersionHandle()
 
 	PerPortPolicies := make([]*cilium.PortNetworkPolicy, 0, l4Policy.Len())
 	l4Policy.ForEach(func(l4 *policy.L4Filter) bool {
@@ -1753,6 +1755,23 @@ func getNodeIDs(ep endpoint.EndpointUpdater, policy *policy.L4Policy) []string {
 		nodeIDs = append(nodeIDs, "127.0.0.2")
 	}
 	return nodeIDs
+}
+
+func (s *xdsServer) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	// If there are no listeners configured, the local node's Envoy proxy won't
+	// query for network policies and therefore will never ACK them, and we'd
+	// wait forever.
+	if s.proxyListeners == 0 {
+		wg = nil
+	}
+
+	nodeIDs := getNodeIDs(ep, policy)
+
+	// only wait for the most current policy to be acked when no (new) policy is given
+	s.NetworkPolicyMutator.UseCurrent(NetworkPolicyTypeURL, nodeIDs, wg)
 }
 
 func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy,

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1806,8 +1806,6 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *pol
 		return fmt.Errorf("error validating generated NetworkPolicy for Endpoint %d: %w", ep.GetID(), err), nil
 	}
 
-	nodeIDs := getNodeIDs(ep, policy)
-
 	// If there are no listeners configured, the local node's Envoy proxy won't
 	// query for network policies and therefore will never ACK them, and we'd
 	// wait forever.
@@ -1826,6 +1824,7 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *pol
 		}
 	}
 	epID := ep.GetID()
+	nodeIDs := getNodeIDs(ep, policy)
 	resourceName := strconv.FormatUint(epID, 10)
 	revertFunc := s.NetworkPolicyMutator.Upsert(NetworkPolicyTypeURL, resourceName, networkPolicy, nodeIDs, wg, callback)
 	revertUpdatedNetworkPolicyEndpoints := make(map[string]endpoint.EndpointUpdater, len(ips))

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -407,7 +407,7 @@ func (d *policyDistillery) WithLogBuffer(w io.Writer) *policyDistillery {
 func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.LabelArray, identity *identity.Identity) (MapState, error) {
 	sp := d.Repository.GetPolicyCache().insert(identity)
 	d.Repository.GetPolicyCache().UpdatePolicy(identity)
-	epp := sp.Consume(DummyOwner{})
+	epp := sp.Consume(DummyOwner{}, testRedirects)
 	if epp == nil {
 		return nil, errors.New("policy distillation failure")
 	}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -1399,11 +1399,6 @@ func (mc *MapChanges) consumeMapChanges(p *EndpointPolicy, features policyFeatur
 		Old:     make(map[Key]MapStateEntry, len(mc.synced)),
 	}
 
-	var redirects map[string]uint16
-	if p.PolicyOwner != nil {
-		redirects = p.PolicyOwner.GetRealizedRedirects()
-	}
-
 	for i := range mc.synced {
 		if mc.synced[i].Add {
 			// Redirect entries for unrealized redirects come in with an invalid
@@ -1413,7 +1408,7 @@ func (mc *MapChanges) consumeMapChanges(p *EndpointPolicy, features policyFeatur
 			if entry.ProxyPort == unrealizedRedirectPort {
 				var exists bool
 				proxyID := ProxyIDFromKey(uint16(p.PolicyOwner.GetID()), key, entry.Listener)
-				entry.ProxyPort, exists = redirects[proxyID]
+				entry.ProxyPort, exists = p.Redirects[proxyID]
 				if !exists {
 					log.WithFields(logrus.Fields{
 						logfields.PolicyKey:   key,

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -2744,7 +2744,7 @@ func TestDenyPreferredInsertLogic(t *testing.T) {
 	td.bootstrapRepo(GenerateCIDRDenyRules, 1000, t)
 	p, _ := td.repo.resolvePolicyLocked(fooIdentity)
 
-	epPolicy := p.DistillPolicy(DummyOwner{}, false)
+	epPolicy := p.DistillPolicy(DummyOwner{}, nil, false)
 	epPolicy.Ready()
 
 	n := epPolicy.policyMapState.Len()

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -188,7 +188,7 @@ func BenchmarkRegenerateCIDRDenyPolicyRules(b *testing.B) {
 	b.ResetTimer()
 	n := 0
 	for i := 0; i < b.N; i++ {
-		epPolicy := ip.DistillPolicy(DummyOwner{}, false)
+		epPolicy := ip.DistillPolicy(DummyOwner{}, nil, false)
 		n += epPolicy.policyMapState.Len()
 		epPolicy.Ready()
 	}
@@ -200,7 +200,7 @@ func TestRegenerateCIDRDenyPolicyRules(t *testing.T) {
 	td := newTestData()
 	td.bootstrapRepo(GenerateCIDRDenyRules, 10, t)
 	ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
-	epPolicy := ip.DistillPolicy(DummyOwner{}, false)
+	epPolicy := ip.DistillPolicy(DummyOwner{}, nil, false)
 	n := epPolicy.policyMapState.Len()
 	epPolicy.Ready()
 	ip.Detach()
@@ -242,7 +242,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 	defer repo.mutex.RUnlock()
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
-	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
+	policy := selPolicy.DistillPolicy(DummyOwner{}, nil, false)
 	policy.Ready()
 
 	expectedEndpointPolicy := EndpointPolicy{
@@ -335,7 +335,7 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
-	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
+	policy := selPolicy.DistillPolicy(DummyOwner{}, nil, false)
 	policy.Ready()
 
 	cachedSelectorHost := td.sc.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameHost])
@@ -431,7 +431,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 
-	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
+	policy := selPolicy.DistillPolicy(DummyOwner{}, nil, false)
 	policy.Ready()
 
 	rule1MapStateEntry := NewMapStateEntry(td.wildcardCachedSelector, labels.LabelArrayList{ruleLabel}, 0, "", 0, true, DefaultAuthType, AuthTypeDisabled)
@@ -558,7 +558,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 
-	policy := selPolicy.DistillPolicy(DummyOwner{}, false)
+	policy := selPolicy.DistillPolicy(DummyOwner{}, nil, false)
 	policy.Ready()
 
 	// Add new identity to test accumulation of MapChanges

--- a/pkg/proxy/crd.go
+++ b/pkg/proxy/crd.go
@@ -15,6 +15,5 @@ func (r *CRDRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc, 
 	return func() error { return nil }, nil
 }
 
-func (r *CRDRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc) {
-	return nil, func() error { return nil }
+func (r *CRDRedirect) Close() {
 }

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -64,12 +64,10 @@ func (dr *dnsRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc,
 }
 
 // Close the redirect.
-func (dr *dnsRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc) {
-	return func() {
-		dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPortProto, nil)
-		dr.redirect.localEndpoint.OnDNSPolicyUpdateLocked(nil)
-		dr.currentRules = nil
-	}, nil
+func (dr *dnsRedirect) Close() {
+	dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPortProto, nil)
+	dr.redirect.localEndpoint.OnDNSPolicyUpdateLocked(nil)
+	dr.currentRules = nil
 }
 
 type dnsProxyIntegration struct {

--- a/pkg/proxy/endpoint/endpoint.go
+++ b/pkg/proxy/endpoint/endpoint.go
@@ -38,5 +38,8 @@ type EndpointUpdater interface {
 	// 'rules' is a fresh copy of the DNS rules passed to the callee.
 	OnDNSPolicyUpdateLocked(rules restore.DNSRules)
 
+	// GetPolicyVersionHandle returns the selector cache version handle held for Endpoint's
+	// desired policy, if any.
+	// Must be called with Endpoint's read lock taken.
 	GetPolicyVersionHandle() *versioned.VersionHandle
 }

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -68,6 +68,10 @@ func (p *envoyProxyIntegration) UpdateNetworkPolicy(ep endpoint.EndpointUpdater,
 	return p.xdsServer.UpdateNetworkPolicy(ep, policy, ingressPolicyEnforced, egressPolicyEnforced, wg)
 }
 
+func (p *envoyProxyIntegration) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
+	p.xdsServer.UseCurrentNetworkPolicy(ep, policy, wg)
+}
+
 func (p *envoyProxyIntegration) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
 	p.xdsServer.RemoveNetworkPolicy(ep)
 }

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -82,13 +82,6 @@ func (k *envoyRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc
 }
 
 // Close the redirect.
-func (r *envoyRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc) {
-	revertFunc := r.xdsServer.RemoveListener(r.listenerName, wg)
-
-	return nil, func() error {
-		// Don't wait for an ACK for the reverted xDS updates.
-		// This is best-effort.
-		revertFunc(completion.NewCompletion(nil, nil))
-		return nil
-	}
+func (r *envoyRedirect) Close() {
+	r.xdsServer.RemoveListener(r.listenerName, nil)
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -902,6 +902,10 @@ func (p *Proxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.
 	return p.envoyIntegration.UpdateNetworkPolicy(ep, policy, ingressPolicyEnforced, egressPolicyEnforced, wg)
 }
 
+func (p *Proxy) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
+	p.envoyIntegration.UseCurrentNetworkPolicy(ep, policy, wg)
+}
+
 func (p *Proxy) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
 	p.envoyIntegration.RemoveNetworkPolicy(ep)
 }

--- a/pkg/proxy/redirect.go
+++ b/pkg/proxy/redirect.go
@@ -27,7 +27,7 @@ type RedirectImplementation interface {
 	// implementation. The implementation should .Add to the WaitGroup if the
 	// update is asynchronous and the update should not return until it is
 	// complete.
-	Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc)
+	Close()
 }
 
 type Redirect struct {


### PR DESCRIPTION
Rationalize sequence of events for policy update and applying incremental policy map updates:

- update proxy network policy right after `ConsumeMapChanges` in `applyPolicyMapChanges` so that it is more obvious that the selector cache version for bpf map updates and proxy network policy is the same on (as updated by ConsumeMapChanges)
- defer applying the incremental changes for the full policy map sync when a new policy has been computed, so that the proxy has had time to configure the new listeners and to apply the new network policy before getting traffic for them.
- create l7 redirects before incremental updates, so that the proxy ports are available for them

Keep realized redirects in EndpointPolicy:
- can create redirects before holding endpoint lock, no coordination needed between redirects of different policy instances (old vs. new)
- Create MapState after redirects so that proxy ports are available during MapState generation removing the need for a second pass to patch up proxy ports
- Move old redirect removal to happen after proxy ACKs the changes, removing the need for the 1st maps sync, as now the main map sync happens before redirects are removed 