### PR TITLE
MAINTAINERS: Update affiliations

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -45,7 +45,7 @@ to learn how to level up through the project.
  * [Nicolas Busseneau] (Isovalent)
  * [Nirmoy Das] (AMD)
  * [Paul Chaignon] (Isovalent)
- * [Quentin Monnet] (Isovalent)
+ * [Quentin Monnet] (Hedgehog)
  * [Robin Hahling] (Isovalent)
  * [Sebastian Wicki] (Isovalent)
  * [Tam Mach] (Isovalent)


### PR DESCRIPTION
Affiliations matter because they are used for [the company block vote limits](https://github.com/cilium/community/blob/main/GOVERNANCE.md#company-block-vote-limit). The only affiliation I found that needed updating was Quentin's.