### PR TITLE
WIP: Add support for automatic port-forwarding in Hubble CLI (kubectl)

### DIFF
--- a/hubble/cmd/common/config/flags.go
+++ b/hubble/cmd/common/config/flags.go
@@ -28,6 +28,11 @@ const (
 	KeyBasicAuthPassword = "basic-auth-password"  // string
 	KeyTimeout           = "timeout"              // time.Duration
 	KeyRequestTimeout    = "request-timeout"      // time.Duration
+	KeyAutoPortForward   = "auto-port-forward"    // bool
+	KeyPortForward       = "port-forward"         // uint16
+	KeyK8sContextName    = "k8s-context"          // string
+	KeyK8sNamespace      = "k8s-namespace"        // string
+	KeyK8sKubeconfig     = "k8s-kubeconfig"       // string
 )
 
 // GlobalFlags are flags that apply to any command.
@@ -47,8 +52,8 @@ func initGlobalFlags() {
 }
 
 func initServerFlags() {
-	ServerFlags.String(KeyServer, defaults.ServerAddress, "Address of a Hubble server. Ignored when --input-file is provided.")
-	ServerFlags.Duration(KeyTimeout, defaults.DialTimeout, "Hubble server dialing timeout")
+	ServerFlags.String(KeyServer, defaults.ServerAddress, "Address of a Hubble server. Ignored when --input-file or --auto-port-forward is provided.")
+	ServerFlags.Duration(KeyTimeout, defaults.DialTimeout, "Hubble server and port-forward dialing timeout")
 	ServerFlags.Duration(KeyRequestTimeout, defaults.RequestTimeout, "Unary Request timeout. Only applies to non-streaming RPCs (ServerStatus, ListNodes, ListNamespaces).")
 	ServerFlags.Bool(
 		KeyTLS,
@@ -95,5 +100,30 @@ func initServerFlags() {
 		KeyBasicAuthPassword,
 		"",
 		"Specify a password for basic auth",
+	)
+	ServerFlags.Bool(
+		KeyAutoPortForward,
+		false,
+		"Automatically forward the relay port to the local machine. Analoguous to running: 'cilium hubble port-forward'.",
+	)
+	ServerFlags.Uint16(
+		KeyPortForward,
+		4245,
+		"Local port to forward to. This option is only considered when --auto-port-forward is set.",
+	)
+	ServerFlags.String(
+		KeyK8sContextName,
+		"",
+		"Kubernetes configuration context. This option is only considered when --auto-port-forward is set.",
+	)
+	ServerFlags.String(
+		KeyK8sNamespace,
+		"kube-system",
+		"Namespace Cilium is running in. This option is only considered when --auto-port-forward is set.",
+	)
+	ServerFlags.String(
+		KeyK8sKubeconfig,
+		"",
+		"Path to the kubeconfig file. This option is only considered when --auto-port-forward is set.",
 	)
 }

--- a/hubble/cmd/common/conn/conn.go
+++ b/hubble/cmd/common/conn/conn.go
@@ -5,15 +5,21 @@ package conn
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
+	"os/exec"
 	"strings"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/hubble/cmd/common/config"
+	"github.com/cilium/cilium/hubble/cmd/common/k8s"
 	"github.com/cilium/cilium/hubble/pkg/defaults"
+	"github.com/cilium/cilium/hubble/pkg/logger"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -76,4 +82,131 @@ func New(ctx context.Context, target string, dialTimeout time.Duration) (*grpc.C
 		return nil, fmt.Errorf("failed to connect to '%s': %w", target, err)
 	}
 	return conn, nil
+}
+
+// NewWithFlags creates a new gRPC client connection, optionally with kubectl port-forwarding to the
+// hubble-relay service, using flags to extract the required information.
+func NewWithFlags(ctx context.Context, vp *viper.Viper) (conn *grpc.ClientConn, cleanup func() error, err error) {
+	var cleanupFns []func() error
+	server := vp.GetString(config.KeyServer)
+	dialTimeout := vp.GetDuration(config.KeyTimeout)
+
+	// if auto port forward is enabled, query the k8s api for the hubble-relay svc port
+	// and launch a kubectl port-forward process
+	if vp.GetBool(config.KeyAutoPortForward) {
+		// inspired by: cilium-cli/hubble/relay.go:RelayPortForwardCommand()
+		// TODO: should we try to consolidate with cilium-cli ?
+		// TODO: second iteration: replace with native port-forward using k8s client (ProxyTCP())
+		k8sContextName := vp.GetString(config.KeyK8sContextName)
+		k8sKubeconfig := vp.GetString(config.KeyK8sKubeconfig)
+		k8sNamespace := vp.GetString(config.KeyK8sNamespace)
+		localPort := vp.GetUint16(config.KeyPortForward)
+
+		k8sClient, err := k8s.NewClient(k8sContextName, k8sKubeconfig)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		logger.Logger.Debug("Querying kubernetes API for hubble-relay service")
+		relaySvc, err := k8sClient.GetService(ctx, k8sNamespace, "hubble-relay", metav1.GetOptions{})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// TODO: re-using grpc dial timeout, should we hardcode this or have another flag?
+		portForwardAddr, portForwardCleanup, err := kubectlPortForward(ctx, k8sNamespace, k8sContextName, dialTimeout, int(localPort), int(relaySvc.Spec.Ports[0].Port))
+		if err != nil {
+			return nil, nil, err
+		}
+		server = portForwardAddr
+		cleanupFns = append(cleanupFns, portForwardCleanup)
+	}
+
+	conn, err = New(ctx, server, dialTimeout)
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanupFns = append(cleanupFns, conn.Close)
+
+	cleanup = func() error {
+		var err error
+		for i := len(cleanupFns) - 1; i >= 0; i-- {
+			err = errors.Join(err, cleanupFns[i]())
+		}
+		return err
+	}
+	return conn, cleanup, nil
+}
+
+func kubectlPortForward(ctx context.Context, namespace, contextName string, dialTimeout time.Duration, local, remote int) (addr string, cleanup func() error, err error) {
+	localAddr := fmt.Sprintf("127.0.0.1:%d", local)
+
+	logger.Logger.Debug("Checking if port is already opened for port forwarding", "addr", localAddr)
+	if err := doTCPProbe(localAddr, dialTimeout); err == nil {
+		return "", nil, fmt.Errorf("cannot setup port-forwarding: already listening: %s", localAddr)
+	}
+
+	args := []string{
+		"port-forward",
+		"-n", namespace,
+		"svc/hubble-relay",
+		"--address", "127.0.0.1",
+		fmt.Sprintf("%d:%d", local, remote)}
+	if contextName != "" {
+		args = append([]string{"--context", contextName}, args...)
+	}
+
+	logger.Logger.Debug("Launching kubectl command", "args", args)
+	// TODO: is there a cleaner/more succint way to handle this?
+	ctx, cancel := context.WithCancel(ctx)
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	cleanup = func() error {
+		logger.Logger.Debug("Cleaning up kubectl command", "args", args)
+		cancel()
+		return cmd.Wait()
+	}
+	defer func() {
+		if err != nil {
+			cleanup()
+		}
+	}()
+	if err := cmd.Start(); err != nil {
+		return "", nil, err
+	}
+
+	maxRetries := 10
+	retryInterval := time.Second
+	retries := 0
+	for {
+		if retries > maxRetries {
+			return "", nil, fmt.Errorf("cannot setup port-forwarding: max retry reached (%d)", maxRetries)
+		}
+		select {
+		case <-ctx.Done():
+			return "", nil, ctx.Err()
+		case <-time.After(retryInterval):
+		}
+		retries += 1
+
+		// TODO: we should race both the probe and the process state to allow failing early
+		if err := doTCPProbe(localAddr, dialTimeout); err == nil {
+			logger.Logger.Debug("Port forwarding established")
+			break
+		}
+		logger.Logger.Debug("Cannot setup port-forwarding: dial failed: will retry",
+			"addr", localAddr, "retries", retries, "maxRetries", maxRetries)
+	}
+
+	return localAddr, cleanup, nil
+}
+
+func doTCPProbe(addr string, timeout time.Duration) error {
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return err
+	}
+	if err := conn.Close(); err != nil {
+		logger.Logger.Error("Unexpected error closing TCP socket", "addr", addr, "err", err)
+	}
+	return nil
 }

--- a/hubble/cmd/common/k8s/client.go
+++ b/hubble/cmd/common/k8s/client.go
@@ -1,0 +1,142 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport/spdy"
+
+	"github.com/cilium/cilium/pkg/safeio"
+)
+
+// Slim version of: https://github.com/cilium/cilium/tree/v1.17.0-pre.1/cilium-cli/k8s/client.go
+type Client struct {
+	Clientset kubernetes.Interface
+	Config    *rest.Config
+}
+
+func NewClient(contextName, kubeconfig string) (*Client, error) {
+	restClientGetter := genericclioptions.ConfigFlags{
+		Context:    &contextName,
+		KubeConfig: &kubeconfig,
+	}
+	rawKubeConfigLoader := restClientGetter.ToRawKubeConfigLoader()
+
+	config, err := rawKubeConfigLoader.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		Clientset: clientset,
+		Config:    config,
+	}, nil
+}
+
+func (c *Client) GetService(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Service, error) {
+	return c.Clientset.CoreV1().Services(namespace).Get(ctx, name, opts)
+}
+
+// TODO: Consider replacing kubectl-based port-forwarding with native impl using k8s client
+func (c *Client) ProxyTCP(ctx context.Context, namespace, name string, port uint16, handler func(io.ReadWriteCloser) error) error {
+	request := c.Clientset.CoreV1().RESTClient().Post().
+		Resource(corev1.ResourcePods.String()).
+		Namespace(namespace).
+		Name(name).
+		SubResource("portforward")
+
+	transport, upgrader, err := spdy.RoundTripperFor(c.Config)
+	if err != nil {
+		return fmt.Errorf("creating round tripper: %w", err)
+	}
+
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, request.URL())
+
+	const portForwardProtocolV1Name = "portforward.k8s.io"
+	conn, proto, err := dialer.Dial(portForwardProtocolV1Name)
+	if err != nil {
+		return fmt.Errorf("connecting: %w", err)
+	}
+
+	defer conn.Close()
+	if proto != portForwardProtocolV1Name {
+		return fmt.Errorf("unable to negotiate protocol: client supports %q, server returned %q", portForwardProtocolV1Name, proto)
+	}
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			// Close aborts all remaining streams, and unblocks read operations.
+			conn.Close()
+		case <-conn.CloseChan():
+		}
+	}()
+
+	return stream(conn, port, handler)
+}
+
+// The following is an adapted version of part of the client-go's port-forward connection handling implementation:
+// https://github.com/kubernetes/client-go/blob/4ebe42d8c9c18f464fcc7b4f15b3a632db4cbdb2/tools/portforward/portforward.go#L335-L416
+func stream(conn httpstream.Connection, port uint16, handler func(io.ReadWriteCloser) error) error {
+	headers := http.Header{}
+	headers.Set(corev1.StreamType, corev1.StreamTypeError)
+	headers.Set(corev1.PortHeader, strconv.FormatUint(uint64(port), 10))
+
+	errorStream, err := conn.CreateStream(headers)
+	if err != nil {
+		return fmt.Errorf("creating error stream: %w", err)
+	}
+	// we're not writing to this stream
+	errorStream.Close()
+	defer conn.RemoveStreams(errorStream)
+
+	errorDone := make(chan error)
+	go func() {
+		defer close(errorDone)
+		message, err := safeio.ReadAllLimit(errorStream, safeio.KB)
+		switch {
+		case err != nil:
+			errorDone <- fmt.Errorf("reading from error stream: %w", err)
+		case len(message) > 0:
+			errorDone <- errors.New(string(message))
+		}
+	}()
+
+	headers.Set(corev1.StreamType, corev1.StreamTypeData)
+	dataStream, err := conn.CreateStream(headers)
+	if err != nil {
+		return fmt.Errorf("creating data stream: %w", err)
+	}
+	defer conn.RemoveStreams(dataStream)
+
+	dataDone := make(chan error)
+	go func() {
+		defer close(dataDone)
+		if err := handler(dataStream); err != nil {
+			dataDone <- err
+		}
+	}()
+
+	// Wait for both goroutines to terminate
+	err = <-dataDone
+	if err2 := <-errorDone; err2 != nil {
+		err = err2
+	}
+
+	return err
+}

--- a/hubble/cmd/list/namespaces.go
+++ b/hubble/cmd/list/namespaces.go
@@ -26,11 +26,11 @@ func newNamespacesCommand(vp *viper.Viper) *cobra.Command {
 		Short: "List namespaces with recent flows",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
-			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			hubbleConn, cleanup, err := conn.NewWithFlags(ctx, vp)
 			if err != nil {
 				return err
 			}
-			defer hubbleConn.Close()
+			defer cleanup()
 			return runListNamespaces(ctx, cmd, hubbleConn)
 		},
 	}

--- a/hubble/cmd/list/node.go
+++ b/hubble/cmd/list/node.go
@@ -33,11 +33,11 @@ func newNodeCommand(vp *viper.Viper) *cobra.Command {
 		Short:   "List Hubble nodes",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
-			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			hubbleConn, cleanup, err := conn.NewWithFlags(ctx, vp)
 			if err != nil {
 				return err
 			}
-			defer hubbleConn.Close()
+			defer cleanup()
 
 			return runListNodes(ctx, cmd, hubbleConn)
 		},

--- a/hubble/cmd/observe/agent_events.go
+++ b/hubble/cmd/observe/agent_events.go
@@ -45,11 +45,11 @@ func newAgentEventsCommand(vp *viper.Viper) *cobra.Command {
 			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
 			defer cancel()
 
-			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			hubbleConn, cleanup, err := conn.NewWithFlags(ctx, vp)
 			if err != nil {
 				return err
 			}
-			defer hubbleConn.Close()
+			defer cleanup()
 			client := observerpb.NewObserverClient(hubbleConn)
 			logger.Logger.Debug("Sending GetAgentEvents request", "request", req)
 			if err := getAgentEvents(ctx, client, req); err != nil {

--- a/hubble/cmd/observe/debug_events.go
+++ b/hubble/cmd/observe/debug_events.go
@@ -44,11 +44,11 @@ func newDebugEventsCommand(vp *viper.Viper) *cobra.Command {
 			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
 			defer cancel()
 
-			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			hubbleConn, cleanup, err := conn.NewWithFlags(ctx, vp)
 			if err != nil {
 				return err
 			}
-			defer hubbleConn.Close()
+			defer cleanup()
 			client := observerpb.NewObserverClient(hubbleConn)
 			logger.Logger.Debug("Sending GetDebugEvents request", "request", req)
 			if err := getDebugEvents(ctx, client, req); err != nil {

--- a/hubble/cmd/observe_help.txt
+++ b/hubble/cmd/observe_help.txt
@@ -141,11 +141,16 @@ Flow Format Flags:
       --numeric          Display all information in numeric form
 
 Server Flags:
+      --auto-port-forward             Automatically forward the relay port to the local machine. Analoguous to running: 'cilium hubble port-forward'.
       --basic-auth-password string    Specify a password for basic auth
       --basic-auth-username string    Specify a username for basic auth
+      --k8s-context string            Kubernetes configuration context. This option is only considered when --auto-port-forward is set.
+      --k8s-kubeconfig string         Path to the kubeconfig file. This option is only considered when --auto-port-forward is set.
+      --k8s-namespace string          Namespace Cilium is running in. This option is only considered when --auto-port-forward is set. (default "kube-system")
+      --port-forward uint16           Local port to forward to. This option is only considered when --auto-port-forward is set. (default 4245)
       --request-timeout duration      Unary Request timeout. Only applies to non-streaming RPCs (ServerStatus, ListNodes, ListNamespaces). (default 12s)
-      --server string                 Address of a Hubble server. Ignored when --input-file is provided. (default "localhost:4245")
-      --timeout duration              Hubble server dialing timeout (default 5s)
+      --server string                 Address of a Hubble server. Ignored when --input-file or --auto-port-forward is provided. (default "localhost:4245")
+      --timeout duration              Hubble server and port-forward dialing timeout (default 5s)
       --tls                           Specify that TLS must be used when establishing a connection to a Hubble server.
                                       By default, TLS is only enabled if the server address starts with 'tls://'.
       --tls-allow-insecure            Allows the client to skip verifying the server's certificate chain and host name.

--- a/hubble/cmd/record/record.go
+++ b/hubble/cmd/record/record.go
@@ -62,11 +62,11 @@ protocols are TCP, UDP, SCTP, and ANY.`,
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			hubbleConn, cleanup, err := conn.NewWithFlags(ctx, vp)
 			if err != nil {
 				return err
 			}
-			defer hubbleConn.Close()
+			defer cleanup()
 
 			return runRecord(ctx, hubbleConn, filters)
 		},

--- a/hubble/cmd/reflect/reflect.go
+++ b/hubble/cmd/reflect/reflect.go
@@ -28,11 +28,11 @@ func New(vp *viper.Viper) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			hubbleConn, cleanup, err := conn.NewWithFlags(ctx, vp)
 			if err != nil {
 				return err
 			}
-			defer hubbleConn.Close()
+			defer cleanup()
 			return runReflect(ctx, cmd, hubbleConn)
 		},
 		Hidden: true,

--- a/hubble/cmd/status/status.go
+++ b/hubble/cmd/status/status.go
@@ -36,11 +36,11 @@ func New(vp *viper.Viper) *cobra.Command {
 connectivity health check.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			hubbleConn, cleanup, err := conn.NewWithFlags(ctx, vp)
 			if err != nil {
 				return err
 			}
-			defer hubbleConn.Close()
+			defer cleanup()
 
 			return runStatus(ctx, cmd.OutOrStdout(), hubbleConn)
 		},

--- a/hubble/cmd/watch/peer.go
+++ b/hubble/cmd/watch/peer.go
@@ -29,11 +29,11 @@ func newPeerCommand(vp *viper.Viper) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			hubbleConn, err := conn.New(ctx, vp.GetString(config.KeyServer), vp.GetDuration(config.KeyTimeout))
+			hubbleConn, cleanup, err := conn.NewWithFlags(ctx, vp)
 			if err != nil {
 				return err
 			}
-			defer hubbleConn.Close()
+			defer cleanup()
 			return runPeer(ctx, peerpb.NewPeerClient(hubbleConn))
 		},
 	}


### PR DESCRIPTION
## Description

hubble: Implement automatic port-forwarding capability (opt-in)

Adds new server flag (and friends): --auto-port-forward that launches a kubectl port-forward process.

Re-use same worflow as `cilium hubble port-forward` as intial impl and consider re-placing both with native k8s client tcp port-forwarding in a subsequent change.

Fixes: #34935

## Release Notes

```release-note
TODO
```

### Checklist

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

