### PR TITLE
adjust encryption bit while tracing outgoing wireguard-encrypted packets

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1524,14 +1524,14 @@ skip_host_firewall:
 	 * encrypted WireGuard UDP packets), we check whether the mark
 	 * is set before the redirect.
 	 */
-	trace.reason = TRACE_REASON_ENCRYPTED;
 	if ((ctx->mark & MARK_MAGIC_WG_ENCRYPTED) != MARK_MAGIC_WG_ENCRYPTED) {
 		ret = wg_maybe_redirect_to_encrypt(ctx, proto);
 		if (ret == CTX_ACT_REDIRECT)
 			return ret;
 		else if (IS_ERR(ret))
 			goto drop_err;
-		trace.reason = TRACE_REASON_UNKNOWN;
+	} else {
+		trace.reason |= TRACE_REASON_ENCRYPTED;
 	}
 
 #if defined(ENCRYPTION_STRICT_MODE)


### PR DESCRIPTION
With this PR we just set the tracing encryption bit rather than overwriting trace reasons, causing potential loss of information. Offending commit hash 8a6738765ea6d23de4dbf63e2c37048adea7e69b, PR https://github.com/cilium/cilium/pull/35183.

**_NOTE_**:  backport shouldn't be needed since the offending commit made it to pre-release only https://github.com/cilium/cilium/releases/tag/v1.17.0-pre.2.

```release-note
Fix incorrect trace reason for egress packets when WireGuard is used with Host Firewall.
```