### PR TITLE
MAINTAINERS: New emeritus committers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -54,8 +54,6 @@ to learn how to level up through the project.
  * [Tobias Klauser] (Isovalent)
  * [Tom Hadlaw] (Isovalent)
  * [Vlad Ungureanu] (Palantir)
- * [Weilong Cui] (Google)
- * [Yongkun Gui] (Google)
  * [Yutaro Hayakawa] (Isovalent)
 
 ## Cilium & Hubble Emeritus Committers
@@ -66,6 +64,8 @@ We would like to acknowledge previous committers and their huge contributions to
  * [Ilya Dmitrichenko] (Docker)
  * [Ray Bejjani]
  * [Tom Payne]
+ * [Weilong Cui] (Google)
+ * [Yongkun Gui] (Google)
  * [Zang Li] (Google)
 
 


### PR DESCRIPTION
@Weil0ng and @anfernee have agreed yesterday to step down from the committer role. This commit makes them emeritus committers and accesses will subsequently be removed.