### PR TITLE
Add concurrency to test-ipsec-upgrade

### DIFF
--- a/.github/actions/conn-disrupt-test-check/action.yaml
+++ b/.github/actions/conn-disrupt-test-check/action.yaml
@@ -16,6 +16,10 @@ inputs:
     required: false
     default: 'false'
     description: 'Run full connectivity test suite'
+  tests:
+    required: false
+    default: ''
+    description: 'Select which connectivity tests to run'
 
 runs:
   using: composite
@@ -23,12 +27,17 @@ runs:
     - name: Perform Conn Disrupt Test
       shell: bash
       run: |
-        TEST_ARG="no-interrupted-connections"
+        if [[ -n "${{ inputs.tests }}" ]]; then
+          TEST_ARG="${{ inputs.tests }}"
+        else
+          TEST_ARG="no-interrupted-connections"
+          EXTRA_ARG="--include-conn-disrupt-test"
+        fi
         if [[ "${{ inputs.full-test }}" == "true" ]]; then
           TEST_ARG=""
+          EXTRA_ARG="--include-conn-disrupt-test"
         fi
         ${{ inputs.cilium-cli }} connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-          --include-conn-disrupt-test \
           --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
           --conn-disrupt-test-xfrm-errors-path "./cilium-conn-disrupt-xfrm-errors" \
           --flush-ct \
@@ -38,4 +47,5 @@ runs:
           ${{ inputs.extra-connectivity-test-flags }} \
           --junit-property github_job_step="Run conn disrupt tests (${{ inputs.job-name }})" \
           --test "$TEST_ARG" \
-          --expected-xfrm-errors "+inbound_no_state"
+          --expected-xfrm-errors "+inbound_no_state" \
+          ${EXTRA_ARG}

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -321,7 +321,7 @@ jobs:
           cilium install \
             ${{ steps.cilium-stable-config.outputs.config }}
 
-          cilium status --wait
+          cilium status --wait --wait-duration=10m
           kubectl get pods --all-namespaces -o wide
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 
@@ -337,7 +337,7 @@ jobs:
           cilium upgrade \
             ${{ steps.cilium-newest-config.outputs.config }}
 
-          cilium status --wait
+          cilium status --wait --wait-duration=10m
           kubectl get pods --all-namespaces -o wide
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 
@@ -373,7 +373,7 @@ jobs:
           cilium upgrade \
             ${{ steps.cilium-stable-config.outputs.config }}
 
-          cilium status --wait
+          cilium status --wait --wait-duration=10m
           kubectl get pods --all-namespaces -o wide
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -56,6 +56,9 @@ concurrency:
     }}
   cancel-in-progress: true
 
+env:
+  test_concurrency: 5
+
 jobs:
   echo-inputs:
     if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -131,7 +134,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
 
-    timeout-minutes: 70
+    timeout-minutes: 35
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
@@ -338,12 +341,26 @@ jobs:
           kubectl get pods --all-namespaces -o wide
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 
-      - name: Run tests after upgrading (${{ join(matrix.*, ', ') }})
+      - name: Run connection interrupted tests after upgrading (${{ join(matrix.*, ', ') }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-upgrade-${{ matrix.name }}
-          full-test: 'true'
+
+      - name: Run sequential tests after upgrading (${{ join(matrix.*, ', ') }})
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
+        uses: ./.github/actions/conn-disrupt-test-check
+        with:
+          job-name: cilium-upgrade-${{ matrix.name }}
+          tests: 'seq-.*'
+
+      - name: Run concurrent tests after upgrading (${{ matrix.name }})
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
+        uses: ./.github/actions/conn-disrupt-test-check
+        with:
+          job-name: cilium-upgrade-${{ matrix.name }}
+          tests: '!seq-.*'
+          extra-connectivity-test-flags: "--test-concurrency=${{ env.test_concurrency }}"
 
       - name: Setup conn-disrupt-test before downgrading
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
@@ -360,12 +377,26 @@ jobs:
           kubectl get pods --all-namespaces -o wide
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 
-      - name: Check conn-disrupt-test after downgrading
+      - name: Run connection interrupted tests after downgrading (${{ join(matrix.*, ', ') }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-downgrade-${{ matrix.name }}
-          full-test: 'true'
+
+      - name: Run sequential tests after downgrading (${{ join(matrix.*, ', ') }})
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
+        uses: ./.github/actions/conn-disrupt-test-check
+        with:
+          job-name: cilium-downgrade-${{ matrix.name }}
+          tests: 'seq-.*'
+
+      - name: Run concurrent tests after downgrading (${{ matrix.name }})
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
+        uses: ./.github/actions/conn-disrupt-test-check
+        with:
+          job-name: cilium-downgrade-${{ matrix.name }}
+          tests: '!seq-.*'
+          extra-connectivity-test-flags: "--test-concurrency=${{ env.test_concurrency }}"
 
       - name: Fetch artifacts
         if: ${{ steps.vars.outputs.downgrade_version != '' && !success() }}


### PR DESCRIPTION
The changes on this PR helps to decrease the test run time significantly. During testing if this was possible, a lot of flakes were being caused by the egress-gateway, egress-gateway-with-l7-policy and from-cidr-host-netns tests which is why they run separately without concurrency and then all the other tests run parallel afterwards.

You can find 10 successful and unsuccessful runs in https://github.com/cilium/cilium/actions/runs/11496595336

**Note**: The failed runs from the link above were all caused due short timeouts which is fixed by the last commit.

| Name | Before    | After     | Time Decreased |
|-----------|-----------|-----------|----------------|
| Test 1    | 00:49:48  | 00:29:54  | -39.96%        |
| Test 2    | 00:00:23  | 00:00:19  | -17.39%        |
| Test 3    | 00:49:08  | 00:25:04  | -48.98%        |
| Test 4    | 00:00:23  | 00:00:21  | -8.7%        |
| Test 5    | 00:49:18  | 00:26:30  | -46.25%        |
| Test 6    | 00:00:22  | 00:00:23  | 4.55%        |
| Test 7    | 00:44:46  | 00:21:20  | -52.35%        |
| Test 8    | 00:00:19  | 00:00:21  | 10.35%        |
| Test 9    | 00:49:34  | 00:25:33  | -48.45%        |
| Test 10   | 00:00:22  | 00:00:19  | -13.64%        |