### PR TITLE
ctrl-runtime: lower severity of retryable reconcile errors

### DIFF
--- a/operator/pkg/controller-runtime/cell.go
+++ b/operator/pkg/controller-runtime/cell.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
-	"github.com/go-logr/logr"
 	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -70,7 +69,7 @@ func newManager(params managerParams) (ctrlRuntime.Manager, error) {
 		return proto.Equal(xdsResource1.Any, xdsResource2.Any)
 	})
 
-	ctrlRuntime.SetLogger(logr.FromSlogHandler(params.Logger.Handler()))
+	ctrlRuntime.SetLogger(newLogrFromSlog(params.Logger))
 
 	mgr, err := ctrlRuntime.NewManager(params.K8sClient.RestConfig(), ctrlRuntime.Options{
 		Scheme: params.Scheme,
@@ -78,7 +77,6 @@ func newManager(params managerParams) (ctrlRuntime.Manager, error) {
 		Metrics: metricsserver.Options{
 			BindAddress: "0",
 		},
-		Logger: logr.FromSlogHandler(params.Logger.Handler()),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new controller-runtime manager: %w", err)

--- a/operator/pkg/controller-runtime/log.go
+++ b/operator/pkg/controller-runtime/log.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package controllerruntime
+
+import (
+	"log/slog"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+func newLogrFromSlog(logger *slog.Logger) logr.Logger {
+	return logr.New(logSink{logr.FromSlogHandler(logger.Handler()).GetSink()})
+}
+
+type logSink struct{ logr.LogSink }
+
+func (w logSink) Error(err error, msg string, keysAndValues ...any) {
+	if msg == "Reconciler error" && isRetryableError(err) {
+		w.LogSink.Info(0, msg, append(keysAndValues, logfields.Error, err)...)
+		return
+	}
+
+	w.LogSink.Error(err, msg, keysAndValues...)
+}
+
+func (w logSink) WithValues(keysAndValues ...any) logr.LogSink {
+	return logSink{w.LogSink.WithValues(keysAndValues...)}
+}
+
+func (w logSink) WithName(name string) logr.LogSink {
+	return logSink{w.LogSink.WithName(name)}
+}
+
+// isRetryableError returns true if the error returned by the Reconcile
+// is likely transient, and will be addressed by a subsequent iteration.
+func isRetryableError(err error) bool {
+	return k8serrors.IsAlreadyExists(err) ||
+		k8serrors.IsConflict(err) ||
+		k8serrors.IsNotFound(err) ||
+		(k8serrors.IsForbidden(err) &&
+			k8serrors.HasStatusCause(err, corev1.NamespaceTerminatingCause))
+}

--- a/operator/pkg/controller-runtime/log_test.go
+++ b/operator/pkg/controller-runtime/log_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package controllerruntime
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+func newForbiddenError(cause metav1.CauseType) error {
+	return &k8serrors.StatusError{ErrStatus: metav1.Status{
+		Message: "forbidden error",
+		Status:  metav1.StatusFailure,
+		Code:    http.StatusForbidden,
+		Reason:  metav1.StatusReasonForbidden,
+		Details: &metav1.StatusDetails{
+			Causes: []metav1.StatusCause{{Type: cause}},
+		},
+	}}
+}
+
+func TestLogSink(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newLogrFromSlog(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			switch a.Key {
+			case "time":
+				return slog.Attr{}
+			case "err":
+				return slog.Attr{Key: logfields.Error, Value: a.Value}
+			}
+
+			return a
+		},
+	})))
+
+	tests := []struct {
+		logger   logr.Logger
+		msg      string
+		err      error
+		expected string
+	}{
+		{
+			logger:   logger,
+			err:      errors.New("foo"),
+			msg:      "Reconciler error",
+			expected: "level=ERROR msg=\"Reconciler error\" error=foo bar=baz",
+		},
+		{
+			logger:   logger.WithName("name").WithValues("qux", "fred"),
+			err:      errors.New("foo"),
+			msg:      "Reconciler error",
+			expected: "level=ERROR msg=\"Reconciler error\" qux=fred logger=name error=foo bar=baz",
+		},
+		{
+			logger:   logger,
+			err:      k8serrors.NewAlreadyExists(schema.GroupResource{Resource: "pod"}, "test"),
+			msg:      "Reconciler error",
+			expected: "level=INFO msg=\"Reconciler error\" bar=baz error=\"pod \\\"test\\\" already exists\"",
+		},
+		{
+			logger:   logger.WithName("name").WithValues("qux", "fred"),
+			msg:      "Reconciler error",
+			err:      k8serrors.NewAlreadyExists(schema.GroupResource{Resource: "pod"}, "test"),
+			expected: "level=INFO msg=\"Reconciler error\" qux=fred logger=name bar=baz error=\"pod \\\"test\\\" already exists\"",
+		},
+		{
+			logger:   logger.WithName("name").WithValues("qux", "fred"),
+			msg:      "Reconciler error",
+			err:      fmt.Errorf("foo: %w", k8serrors.NewAlreadyExists(schema.GroupResource{Resource: "pod"}, "test")),
+			expected: "level=INFO msg=\"Reconciler error\" qux=fred logger=name bar=baz error=\"foo: pod \\\"test\\\" already exists\"",
+		},
+		{
+			logger:   logger.WithName("name").WithValues("qux", "fred"),
+			msg:      "Reconciler error",
+			err:      k8serrors.NewNotFound(schema.GroupResource{Resource: "pod"}, "test"),
+			expected: "level=INFO msg=\"Reconciler error\" qux=fred logger=name bar=baz error=\"pod \\\"test\\\" not found\"",
+		},
+		{
+			logger:   logger.WithName("name").WithValues("qux", "fred"),
+			msg:      "Reconciler error",
+			err:      k8serrors.NewConflict(schema.GroupResource{Resource: "pod"}, "test", errors.New("foo")),
+			expected: "level=INFO msg=\"Reconciler error\" qux=fred logger=name bar=baz error=\"Operation cannot be fulfilled on pod \\\"test\\\": foo\"",
+		},
+		{
+			logger:   logger.WithName("name").WithValues("qux", "fred"),
+			msg:      "Reconciler error",
+			err:      newForbiddenError(corev1.NamespaceTerminatingCause),
+			expected: "level=INFO msg=\"Reconciler error\" qux=fred logger=name bar=baz error=\"forbidden error\"",
+		},
+		{
+			logger:   logger.WithName("name").WithValues("qux", "fred"),
+			msg:      "Reconciler error",
+			err:      newForbiddenError(metav1.CauseTypeFieldValueDuplicate),
+			expected: "level=ERROR msg=\"Reconciler error\" qux=fred logger=name error=\"forbidden error\" bar=baz",
+		},
+		{
+			logger:   logger.WithName("name").WithValues("qux", "fred"),
+			msg:      "Something else",
+			err:      k8serrors.NewConflict(schema.GroupResource{Resource: "pod"}, "test", errors.New("foo")),
+			expected: "level=ERROR msg=\"Something else\" qux=fred logger=name error=\"Operation cannot be fulfilled on pod \\\"test\\\": foo\" bar=baz",
+		},
+	}
+
+	for _, tt := range tests {
+		buf.Reset()
+		tt.logger.Error(tt.err, tt.msg, "bar", "baz")
+		assert.Equal(t, tt.expected, strings.TrimSuffix(buf.String(), "\n"))
+	}
+}


### PR DESCRIPTION
Controller runtime emits an error log whenever a reconcile function terminates with an error. However, reconciliation errors are harmless in most cases, as the subsequent iteration will normally pull the updated state and succeed. Still, this breaks the Cilium's assumption that error logs are emitted only in case of serious conditions, causing potential user confusion, as well as triggering the error logs check run as part of the E2E tests.

Let's introduce a wrapper responsible for converting "Reconciler error" messages to info level logs, when the returned error is likely to be transient. We specifically check the error type to avoid hiding unexpected ones, although more types could be added in the future if deemed helpful.