### PR TITLE
Revert 35183 pr/wireguard reason encrypted

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1522,14 +1522,12 @@ skip_host_firewall:
 	 * encrypted WireGuard UDP packets), we check whether the mark
 	 * is set before the redirect.
 	 */
-	trace.reason = TRACE_REASON_ENCRYPTED;
 	if ((ctx->mark & MARK_MAGIC_WG_ENCRYPTED) != MARK_MAGIC_WG_ENCRYPTED) {
 		ret = wg_maybe_redirect_to_encrypt(ctx, proto);
 		if (ret == CTX_ACT_REDIRECT)
 			return ret;
 		else if (IS_ERR(ret))
 			goto drop_err;
-		trace.reason = TRACE_REASON_UNKNOWN;
 	}
 
 #if defined(ENCRYPTION_STRICT_MODE)

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1072,8 +1072,6 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 	void __maybe_unused *data, *data_end;
 	struct ipv6hdr __maybe_unused *ip6;
 	struct iphdr __maybe_unused *ip4;
-	int __maybe_unused l4_off = 0;
-	__u8 __maybe_unused next_proto = 0;
 	__s8 __maybe_unused ext_err = 0;
 	int ret;
 
@@ -1172,15 +1170,6 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 		}
 # endif /* defined(ENABLE_HOST_FIREWALL) && !defined(ENABLE_MASQUERADE_IPV6) */
 
-#ifdef ENABLE_WIREGUARD
-		if (!from_host) {
-			next_proto = ip6->nexthdr;
-			l4_off = ETH_HLEN + ipv6_hdrlen(ctx, &next_proto);
-			if (ctx_is_wireguard(ctx, l4_off, next_proto, ipcache_srcid))
-				trace.reason = TRACE_REASON_ENCRYPTED;
-		}
-#endif /* ENABLE_WIREGUARD */
-
 		send_trace_notify(ctx, obs_point, ipcache_srcid, UNKNOWN_ID, TRACE_EP_ID_UNKNOWN,
 				  ctx->ingress_ifindex, trace.reason, trace.monitor);
 
@@ -1214,15 +1203,6 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 			ctx_store_meta(ctx, CB_IPCACHE_SRC_LABEL, ipcache_srcid);
 		}
 # endif /* defined(ENABLE_HOST_FIREWALL) && !defined(ENABLE_MASQUERADE_IPV4) */
-
-#ifdef ENABLE_WIREGUARD
-		if (!from_host) {
-			next_proto = ip4->protocol;
-			l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
-			if (ctx_is_wireguard(ctx, l4_off, next_proto, ipcache_srcid))
-				trace.reason = TRACE_REASON_ENCRYPTED;
-		}
-#endif /* ENABLE_WIREGUARD */
 
 		send_trace_notify(ctx, obs_point, ipcache_srcid, UNKNOWN_ID, TRACE_EP_ID_UNKNOWN,
 				  ctx->ingress_ifindex, trace.reason, trace.monitor);


### PR DESCRIPTION
Reverts partial commits from https://github.com/cilium/cilium/pull/35183, in particular:

1. 8a6738765ea6d23de4dbf63e2c37048adea7e69b
2. a6b4a3a578461583c6ff05e06acf8936f7a1f1bb

Needs to elaborate more:

1. ingress path is missing few checks on ipv6_hdrlen
2. egress path is not potentially preserving the trace reason
3. evaluate whether monitor=0 would be more appropriate