### PR TITLE
ipcache: Remove metric for idempotent operations

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -386,9 +386,6 @@ func (ipc *IPCache) upsertLocked(
 		// and the host IP hasn't changed.
 		if cachedIdentity.equals(newIdentity) && oldHostIP.Equal(hostIP) &&
 			hostKey == oldHostKey && metaEqual {
-			metrics.IPCacheErrorsTotal.WithLabelValues(
-				metricTypeUpsert, metricErrorIdempotent,
-			).Inc()
 			return false, nil
 		}
 

--- a/pkg/ipcache/metrics.go
+++ b/pkg/ipcache/metrics.go
@@ -7,8 +7,7 @@ var (
 	metricTypeUpsert = "upsert"
 	metricTypeDelete = "delete"
 
-	metricErrorIdempotent = "idempotent_operation"
-	metricErrorInvalid    = "invalid_prefix"
-	metricErrorNoExist    = "no_such_prefix"
-	metricErrorOverwrite  = "cannot_overwrite_by_source"
+	metricErrorInvalid   = "invalid_prefix"
+	metricErrorNoExist   = "no_such_prefix"
+	metricErrorOverwrite = "cannot_overwrite_by_source"
 )


### PR DESCRIPTION
This metric was being counted and regularly reported in high-scale
clusters. The error field of the metric reported `idempotent_operation`,
but looking at the codepath we can see that there is no error and this
is an expected condition. We now know for sure that users hit this path
in production, no need to count it.

Reported-by: @soggiest

