### PR TITLE
cilium-dbg: Add sysdump command

### DIFF
--- a/Documentation/cmdref/cilium-dbg.md
+++ b/Documentation/cmdref/cilium-dbg.md
@@ -48,6 +48,7 @@ CLI for interacting with the local Cilium Agent
 * [cilium-dbg service](cilium-dbg_service.md)	 - Manage services & loadbalancers
 * [cilium-dbg statedb](cilium-dbg_statedb.md)	 - Inspect StateDB
 * [cilium-dbg status](cilium-dbg_status.md)	 - Display status of daemon
+* [cilium-dbg sysdump](cilium-dbg_sysdump.md)	 - Provide instructions on dumping cluster-wide system state
 * [cilium-dbg troubleshoot](cilium-dbg_troubleshoot.md)	 - Run troubleshooting utilities to check control-plane connectivity
 * [cilium-dbg version](cilium-dbg_version.md)	 - Print version information
 

--- a/cilium-dbg/cmd/sysdump.go
+++ b/cilium-dbg/cmd/sysdump.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	errNoSysdump = "cilium-dbg sysdump cannot perform this action, you need a different tool.\nSee https://docs.cilium.io/en/stable/operations/troubleshooting/#reporting-a-problem\n"
+
+	sysdumpCmd = &cobra.Command{
+		Use:   "sysdump",
+		Short: "Provide instructions on dumping cluster-wide system state",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintf(os.Stderr, "%s\n", errNoSysdump)
+			os.Exit(1)
+		},
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(sysdumpCmd)
+}


### PR DESCRIPTION
This command, expected to be run inside the Cilium container, simply
informs users with a friendly message that they are using the wrong tool
to dump clusterwide state, and provides a link about how to do so.

Suggested-by: André Martins <andre@cilium.io>
