### PR TITLE
endpoint/policy: Keep internals separate

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -481,7 +481,7 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 	stats.mapSync.Start()
 	// Nothing to do if the desired policy is already fully realized.
 	if e.realizedPolicy != e.desiredPolicy {
-		if e.realizedPolicy.GetPolicyMap().Empty() {
+		if e.realizedPolicy.Empty() {
 			// Realized policy is empty, sync with the dump from the datapath
 			var policyMapDump policy.MapStateMap
 			policyMapDump, err = e.dumpPolicyMapToMapStateMap()
@@ -870,7 +870,7 @@ type policyMapPressureUpdater interface {
 }
 
 func (e *Endpoint) updatePolicyMapPressureMetric() {
-	value := float64(e.realizedPolicy.GetPolicyMap().Len()) / float64(e.policyMap.MaxEntries())
+	value := float64(e.realizedPolicy.Len()) / float64(e.policyMap.MaxEntries())
 	e.PolicyMapPressureUpdater.Update(PolicyMapPressureEvent{
 		Value:      value,
 		EndpointID: e.ID,
@@ -1050,7 +1050,7 @@ func (e *Endpoint) applyPolicyMapChanges(regenContext *regenerationContext, hasN
 	// Add policy map entries before deleting to avoid transient drops
 	errors := 0
 	for keyToAdd := range changes.Adds {
-		entry, exists := e.desiredPolicy.GetPolicyMap().Get(keyToAdd)
+		entry, exists := e.desiredPolicy.Get(keyToAdd)
 		if !exists {
 			e.getLogger().WithFields(logrus.Fields{
 				logfields.AddedPolicyID: keyToAdd,

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -481,8 +481,17 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 	stats.mapSync.Start()
 	// Nothing to do if the desired policy is already fully realized.
 	if e.realizedPolicy != e.desiredPolicy {
-		// Diffs between the maps are expected here, so do not bother collecting them
-		_, _, err = e.syncPolicyMapWith(e.realizedPolicy.GetPolicyMap(), false)
+		if e.realizedPolicy.GetPolicyMap().Empty() {
+			// Realized policy is empty, sync with the dump from the datapath
+			var policyMapDump policy.MapStateMap
+			policyMapDump, err = e.dumpPolicyMapToMapStateMap()
+			if err != nil {
+				return 0, err
+			}
+			_, _, err = e.syncPolicyMapWith(policyMapDump, false)
+		} else {
+			err = e.syncPolicyMap()
+		}
 	}
 	stats.mapSync.End(err == nil)
 	if err != nil {
@@ -662,16 +671,6 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 		if err != nil {
 			return err
 		}
-
-		// Synchronize the in-memory realized state with BPF map entries,
-		// so that any potential discrepancy between desired and realized
-		// state would be dealt with by the following e.syncPolicyMapWith.
-		pm, err := e.dumpPolicyMapToMapState()
-		if err != nil {
-			return err
-		}
-		e.realizedPolicy.SetPolicyMap(pm)
-		e.updatePolicyMapPressureMetric()
 	}
 
 	if e.isProperty(PropertySkipBPFRegeneration) {
@@ -896,17 +895,12 @@ func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key) bool {
 		return false
 	}
 
-	entry, ok := e.realizedPolicy.GetPolicyMap().Get(keyToDelete)
-	// Operation was successful, remove from realized state.
-	if ok {
-		e.realizedPolicy.DeleteMapState(keyToDelete)
-		e.updatePolicyMapPressureMetric()
+	e.updatePolicyMapPressureMetric()
 
-		e.PolicyDebug(logrus.Fields{
-			logfields.BPFMapKey:   keyToDelete,
-			logfields.BPFMapValue: entry,
-		}, "deletePolicyKey")
-	}
+	e.PolicyDebug(logrus.Fields{
+		logfields.BPFMapKey: keyToDelete,
+	}, "deletePolicyKey")
+
 	return true
 }
 
@@ -928,8 +922,6 @@ func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry)
 		return false
 	}
 
-	// Operation was successful, add to realized state.
-	e.realizedPolicy.InsertMapState(keyToAdd, entry)
 	e.updatePolicyMapPressureMetric()
 
 	e.PolicyDebug(logrus.Fields{
@@ -1089,58 +1081,69 @@ func (e *Endpoint) applyPolicyMapChanges(regenContext *regenerationContext, hasN
 	return nil
 }
 
-// syncPolicyMapWith updates the bpf policy map state based on the
-// difference between the given 'realized' and desired policy state without
+// syncPolicyMap updates the bpf policy map state based on the
+// difference between the realized and desired policy state without
 // dumping the bpf policy map.
-// Changes are synced to endpoint's realized policy mapstate, 'realized' is
-// not modified.
-func (e *Endpoint) syncPolicyMapWith(realized policy.MapState, withDiffs bool) (diffCount int, diffs []policy.MapChange, err error) {
+// Only called when desired and realized policies are not the same.
+func (e *Endpoint) syncPolicyMap() error {
 	errors := 0
 
 	// Add policy map entries before deleting to avoid transient drops
-	var adds []policy.MapChange
-	e.desiredPolicy.GetPolicyMap().ForEach(func(keyToAdd policy.Key, entry policy.MapStateEntry) bool {
-		if oldEntry, ok := realized.Get(keyToAdd); !ok || !oldEntry.DatapathEqual(&entry) {
-			adds = append(adds, policy.MapChange{
-				Add:   true,
-				Key:   keyToAdd,
-				Value: entry,
-			})
-		}
-		return true
-	})
-	for _, add := range adds {
-		if oldEntry, ok := realized.Get(add.Key); !ok || !oldEntry.DatapathEqual(&add.Value) {
-			if !e.addPolicyKey(add.Key, add.Value) {
-				errors++
-			}
-			diffCount++
-			if withDiffs {
-				diffs = append(diffs, add)
-			}
+	for k, v := range e.desiredPolicy.Updated(e.realizedPolicy) {
+		if !e.addPolicyKey(k, v) {
+			errors++
+			break
 		}
 	}
-	var deletes []policy.MapChange
+
 	// Delete policy keys present in the realized state, but not present in the desired state
-	realized.ForEach(func(keyToDelete policy.Key, entry policy.MapStateEntry) bool {
-		// If key that is in realized state is not in desired state, just remove it.
-		if _, ok := e.desiredPolicy.GetPolicyMap().Get(keyToDelete); !ok {
-			deletes = append(deletes, policy.MapChange{
-				Key:   keyToDelete,
-				Value: entry,
+	for k := range e.desiredPolicy.Missing(e.realizedPolicy) {
+		if !e.deletePolicyKey(k) {
+			errors++
+			break
+		}
+	}
+
+	if errors > 0 {
+		return fmt.Errorf("syncPolicyMap failed")
+	}
+	return nil
+}
+
+// syncPolicyMapWith updates the bpf policy map state based on the
+// difference between a realized MapStateMap from a recent policy map dump
+// and desired policy state.
+func (e *Endpoint) syncPolicyMapWith(realized policy.MapStateMap, withDiffs bool) (diffCount int, diffs []policy.MapChange, err error) {
+	errors := 0
+
+	// Add policy map entries before deleting to avoid transient drops
+	for k, v := range e.desiredPolicy.UpdatedMap(realized) {
+		if !e.addPolicyKey(k, v) {
+			errors++
+			break
+		}
+		diffCount++
+		if withDiffs {
+			diffs = append(diffs, policy.MapChange{
+				Add:   true,
+				Key:   k,
+				Value: v,
 			})
 		}
-		return true
-	})
-	for _, del := range deletes {
-		if _, ok := e.desiredPolicy.GetPolicyMap().Get(del.Key); !ok {
-			if !e.deletePolicyKey(del.Key) {
-				errors++
-			}
-			diffCount++
-			if withDiffs {
-				diffs = append(diffs, del)
-			}
+	}
+
+	// Delete policy keys present in the realized state, but not present in the desired state
+	for k, v := range e.desiredPolicy.MissingMap(realized) {
+		if !e.deletePolicyKey(k) {
+			errors++
+			break
+		}
+		diffCount++
+		if withDiffs {
+			diffs = append(diffs, policy.MapChange{
+				Key:   k,
+				Value: v,
+			})
 		}
 	}
 
@@ -1150,8 +1153,10 @@ func (e *Endpoint) syncPolicyMapWith(realized policy.MapState, withDiffs bool) (
 	return diffCount, diffs, err
 }
 
-func (e *Endpoint) dumpPolicyMapToMapState() (policy.MapState, error) {
-	currentMap, insert := policy.NewMapStateWithInsert()
+// dumpPolicyMapToMapStateMap dumps the current bpf policy map for this endpoint
+// into a MapStateMap.
+func (e *Endpoint) dumpPolicyMapToMapStateMap() (policy.MapStateMap, error) {
+	currentMap := make(policy.MapStateMap)
 
 	cb := func(policymapKey *policymap.PolicyKey, policymapEntry *policymap.PolicyEntry) {
 		// Convert from policymap.Key to policy.Key
@@ -1164,7 +1169,7 @@ func (e *Endpoint) dumpPolicyMapToMapState() (policy.MapState, error) {
 			IsDeny:    policymapEntry.IsDeny(),
 			AuthType:  policy.AuthType(policymapEntry.AuthType),
 		}
-		insert(policyKey, policyEntry)
+		currentMap[policyKey] = policyEntry
 	}
 	err := e.policyMap.DumpValid(cb)
 
@@ -1191,7 +1196,7 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 		return nil
 	}
 
-	currentMap, err := e.dumpPolicyMapToMapState()
+	currentMap, err := e.dumpPolicyMapToMapStateMap()
 	// If map is unable to be dumped, attempt to close map and open it again.
 	// See GH-4229.
 	if err != nil {
@@ -1211,7 +1216,7 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 		}
 
 		// Try to dump again, fail if error occurs.
-		currentMap, err = e.dumpPolicyMapToMapState()
+		currentMap, err = e.dumpPolicyMapToMapStateMap()
 		if err != nil {
 			return err
 		}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1086,26 +1086,36 @@ func (e *Endpoint) applyPolicyMapChanges(regenContext *regenerationContext, hasN
 // dumping the bpf policy map.
 // Only called when desired and realized policies are not the same.
 func (e *Endpoint) syncPolicyMap() error {
-	errors := 0
+	addErrors, deleteErrors := 0, 0
 
 	// Add policy map entries before deleting to avoid transient drops
 	for k, v := range e.desiredPolicy.Updated(e.realizedPolicy) {
 		if !e.addPolicyKey(k, v) {
-			errors++
-			break
+			addErrors++
 		}
 	}
 
 	// Delete policy keys present in the realized state, but not present in the desired state
 	for k := range e.desiredPolicy.Missing(e.realizedPolicy) {
 		if !e.deletePolicyKey(k) {
-			errors++
-			break
+			deleteErrors++
 		}
 	}
 
-	if errors > 0 {
-		return fmt.Errorf("syncPolicyMap failed")
+	// Retry adds after deletes. If policy map became full, there might be some space if any
+	// keys were deleted
+	if addErrors > 0 {
+		addErrors = 0
+		// Add policy map entries before deleting to avoid transient drops
+		for k, v := range e.desiredPolicy.Updated(e.realizedPolicy) {
+			if !e.addPolicyKey(k, v) {
+				addErrors++
+			}
+		}
+	}
+
+	if addErrors > 0 || deleteErrors > 0 {
+		return fmt.Errorf("syncRealizedPolicyMap failed")
 	}
 	return nil
 }
@@ -1114,13 +1124,13 @@ func (e *Endpoint) syncPolicyMap() error {
 // difference between a realized MapStateMap from a recent policy map dump
 // and desired policy state.
 func (e *Endpoint) syncPolicyMapWith(realized policy.MapStateMap, withDiffs bool) (diffCount int, diffs []policy.MapChange, err error) {
-	errors := 0
+	addErrors, deleteErrors := 0, 0
 
 	// Add policy map entries before deleting to avoid transient drops
 	for k, v := range e.desiredPolicy.UpdatedMap(realized) {
 		if !e.addPolicyKey(k, v) {
-			errors++
-			break
+			addErrors++
+			continue
 		}
 		diffCount++
 		if withDiffs {
@@ -1131,12 +1141,19 @@ func (e *Endpoint) syncPolicyMapWith(realized policy.MapStateMap, withDiffs bool
 			})
 		}
 	}
+	if addErrors > 0 {
+		// Retrying adds below, so clear collected state
+		diffCount = 0
+		if withDiffs {
+			diffs = diffs[:0]
+		}
+	}
 
 	// Delete policy keys present in the realized state, but not present in the desired state
 	for k, v := range e.desiredPolicy.MissingMap(realized) {
 		if !e.deletePolicyKey(k) {
-			errors++
-			break
+			deleteErrors++
+			continue
 		}
 		diffCount++
 		if withDiffs {
@@ -1147,8 +1164,28 @@ func (e *Endpoint) syncPolicyMapWith(realized policy.MapStateMap, withDiffs bool
 		}
 	}
 
-	if errors > 0 {
-		err = fmt.Errorf("syncPolicyMap failed")
+	// Retry adds after deletes. If policy map became full, there might be some space if any
+	// keys were deleted
+	if addErrors > 0 {
+		addErrors = 0
+		for k, v := range e.desiredPolicy.UpdatedMap(realized) {
+			if !e.addPolicyKey(k, v) {
+				addErrors++
+				continue
+			}
+			diffCount++
+			if withDiffs {
+				diffs = append(diffs, policy.MapChange{
+					Add:   true,
+					Key:   k,
+					Value: v,
+				})
+			}
+		}
+	}
+
+	if addErrors > 0 || deleteErrors > 0 {
+		err = fmt.Errorf("syncPolicyMapWith failed")
 	}
 	return diffCount, diffs, err
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -796,7 +796,7 @@ func (e *Endpoint) Allows(id identity.NumericIdentity) bool {
 
 	keyToLookup := policy.IngressKey().WithIdentity(id)
 
-	v, ok := e.desiredPolicy.GetPolicyMap().Get(keyToLookup)
+	v, ok := e.desiredPolicy.Get(keyToLookup)
 	return ok && !v.IsDeny
 }
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -978,10 +978,7 @@ func (e *Endpoint) GetRealizedPolicyRuleLabelsForKey(key policyTypes.Key) (
 	e.mutex.RLock()
 	defer e.mutex.RUnlock()
 
-	entry, ok := e.realizedPolicy.GetPolicyMap().Get(key)
-	if !ok {
-		return nil, 0, false
-	}
-
-	return entry.DerivedFromRules, e.policyRevision, true
+	var err error
+	derivedFrom, err = e.realizedPolicy.GetPolicyMap().GetRuleLabels(key)
+	return derivedFrom, e.policyRevision, err == nil
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -986,6 +986,6 @@ func (e *Endpoint) GetRealizedPolicyRuleLabelsForKey(key policyTypes.Key) (
 	defer e.mutex.RUnlock()
 
 	var err error
-	derivedFrom, err = e.realizedPolicy.GetPolicyMap().GetRuleLabels(key)
+	derivedFrom, err = e.realizedPolicy.GetRuleLabels(key)
 	return derivedFrom, e.policyRevision, err == nil
 }

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -161,10 +161,9 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 		closer()
 
 		haveIDs := make(sets.Set[identity.NumericIdentity], testfactor)
-		res.endpointPolicy.GetPolicyMap().ForEach(func(k policy.Key, _ policy.MapStateEntry) bool {
+		for k := range res.endpointPolicy.Entries() {
 			haveIDs.Insert(k.Identity)
-			return true
-		})
+		}
 
 		// It is okay if we have *more* IDs than allocatedIDs, since we may have propagated
 		// an ID change through the policy system but not yet added to the extra list we're

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -329,10 +329,9 @@ func (obtained LabelArrayListMap) Equals(expected LabelArrayListMap) bool {
 
 func (e *Endpoint) GetDesiredPolicyRuleLabels() LabelArrayListMap {
 	desiredLabels := make(LabelArrayListMap)
-	e.desiredPolicy.GetPolicyMap().ForEach(func(key policy.Key, entry policy.MapStateEntry) bool {
-		desiredLabels[key] = entry.GetRuleLabels()
-		return true
-	})
+	for k := range e.desiredPolicy.Entries() {
+		desiredLabels[k], _ = e.desiredPolicy.GetRuleLabels(k)
+	}
 	return desiredLabels
 }
 
@@ -393,7 +392,6 @@ func TestRedirectWithDeny(t *testing.T) {
 	expected := policy.MapStateMap{
 		mapKeyAllowAllE: {},
 		mapKeyAllL7: {
-			IsDeny:    false,
 			ProxyPort: httpPort,
 		},
 		mapKeyFoo: {
@@ -413,14 +411,14 @@ func TestRedirectWithDeny(t *testing.T) {
 
 	// Redirect for the HTTP port should have been added, but there should be a deny for Foo on
 	// that port, as it is shadowed by the deny rule
-	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
+	if !ep.desiredPolicy.Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(expected))
+			ep.desiredPolicy.Diff(expected))
 	}
 
 	// Check that the redirect is realized
 	require.Len(t, ep.desiredPolicy.Redirects, 1)
-	require.Equal(t, 4, ep.desiredPolicy.GetPolicyMap().Len())
+	require.Equal(t, 4, ep.desiredPolicy.Len())
 
 	// Pretend that something failed and revert the changes
 	s.datapathRegenCtxt.revertStack.Revert()
@@ -429,9 +427,9 @@ func TestRedirectWithDeny(t *testing.T) {
 	expected = policy.MapStateMap{}
 
 	// Check that the state before addRedirects is restored
-	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
+	if !ep.desiredPolicy.Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(expected))
+			ep.desiredPolicy.Diff(expected))
 	}
 }
 
@@ -540,14 +538,14 @@ func TestRedirectWithPriority(t *testing.T) {
 		mapKeyFooL7:     labels.LabelArrayList{lblsL4AllowListener1, lblsL4L7AllowListener2Priority1}, // lblsL4AllowPort80
 		mapKeyAllL7:     labels.LabelArrayList{lblsL4AllowPort80},                                     // lblsL4AllowListener1, lblsL4L7AllowListener2Priority1
 	})
-	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
+	if !ep.desiredPolicy.Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(expected))
+			ep.desiredPolicy.Diff(expected))
 	}
 
 	// Check that the redirect is realized
 	require.Len(t, ep.desiredPolicy.Redirects, 2)
-	require.Equal(t, 3, ep.desiredPolicy.GetPolicyMap().Len())
+	require.Equal(t, 3, ep.desiredPolicy.Len())
 
 	// Pretend that something failed and revert the changes
 	s.datapathRegenCtxt.revertStack.Revert()
@@ -556,9 +554,9 @@ func TestRedirectWithPriority(t *testing.T) {
 	expected = policy.MapStateMap{}
 
 	// Check that the state before addRedirects is restored
-	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
+	if !ep.desiredPolicy.Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(expected))
+			ep.desiredPolicy.Diff(expected))
 	}
 }
 
@@ -595,14 +593,14 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 		mapKeyFooL7:     labels.LabelArrayList{lblsL4L7AllowListener1Priority1, lblsL4L7AllowListener2Priority1}, // lblsL4AllowPort80
 		mapKeyAllL7:     labels.LabelArrayList{lblsL4AllowPort80},                                                // lblsL4L7AllowListener1Priority1, lblsL4L7AllowListener2Priority1
 	})
-	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
+	if !ep.desiredPolicy.Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(expected))
+			ep.desiredPolicy.Diff(expected))
 	}
 
 	// Check that the redirect is realized
 	require.Len(t, ep.desiredPolicy.Redirects, 2)
-	require.Equal(t, 3, ep.desiredPolicy.GetPolicyMap().Len())
+	require.Equal(t, 3, ep.desiredPolicy.Len())
 
 	// Pretend that something failed and revert the changes
 	s.datapathRegenCtxt.revertStack.Revert()
@@ -611,8 +609,8 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 	expected = policy.MapStateMap{}
 
 	// Check that the state before addRedirects is restored
-	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
+	if !ep.desiredPolicy.Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
-			ep.desiredPolicy.GetPolicyMap().Diff(expected))
+			ep.desiredPolicy.Diff(expected))
 	}
 }

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -482,7 +482,6 @@ func TestRedirectWithPriority(t *testing.T) {
 		},
 		mapKeyFooL7: {
 			ProxyPort:        crd2Port,
-			Listener:         "/cec2/listener2",
 			DerivedFromRules: labels.LabelArrayList{lblsL4AllowListener1, lblsL4L7AllowListener2Priority1},
 		},
 		mapKeyAllL7: {
@@ -540,7 +539,6 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 		},
 		mapKeyFooL7: {
 			ProxyPort:        crd1Port,
-			Listener:         "/cec1/listener1",
 			DerivedFromRules: labels.LabelArrayList{lblsL4L7AllowListener1Priority1, lblsL4L7AllowListener2Priority1},
 		},
 		mapKeyAllL7: {

--- a/pkg/labels/arraylist.go
+++ b/pkg/labels/arraylist.go
@@ -3,7 +3,10 @@
 
 package labels
 
-import "sort"
+import (
+	"fmt"
+	"sort"
+)
 
 // LabelArrayList is an array of LabelArrays. It is primarily intended as a
 // simple collection
@@ -35,14 +38,68 @@ func (ls LabelArrayList) GetModel() [][]string {
 // Equals returns true if the label arrays lists have the same label arrays in the same order.
 func (ls LabelArrayList) Equals(b LabelArrayList) bool {
 	if len(ls) != len(b) {
+		fmt.Printf("LEN DIFFERS: obtained %v, expected %v\n", ls, b)
 		return false
 	}
 	for l := range ls {
 		if !ls[l].Equals(b[l]) {
+			fmt.Printf("LABEL ARRAY %d DIFFERS: obtained %v, expected %v\n",
+				l, ls[l], b[l])
 			return false
 		}
 	}
 	return true
+}
+
+// Diff returns the string of differences between 'ls' and 'expected' LabelArrayList with
+// '+ ' or '- ' for obtaining something unexpected, or not obtaining the expected, respectively.
+// For use in debugging. Assumes sorted LabelArrayLists.
+func (ls LabelArrayList) Diff(expected LabelArrayList) (res string) {
+	res += ""
+	i := 0
+	j := 0
+	for i < len(ls) && j < len(expected) {
+		if ls[i].Equals(expected[j]) {
+			i++
+			j++
+			continue
+		}
+		if ls[i].Less(expected[j]) {
+			// obtained has an unexpected labelArray
+			res += "    + " + ls[i].String() + "\n"
+			i++
+		}
+		for j < len(expected) && expected[j].Less(ls[i]) {
+			// expected has a missing labelArray
+			res += "    - " + expected[j].String() + "\n"
+			j++
+		}
+	}
+	for i < len(ls) {
+		// obtained has an unexpected labelArray
+		res += "    + " + ls[i].String() + "\n"
+		i++
+	}
+	for j < len(expected) {
+		// expected has a missing labelArray
+		res += "    - " + expected[j].String() + "\n"
+		j++
+	}
+
+	return res
+}
+
+// GetModel returns the LabelArrayList as a [][]string. Each member LabelArray
+// becomes a []string.
+func (ls LabelArrayList) String() string {
+	res := ""
+	for _, v := range ls {
+		if res != "" {
+			res += ", "
+		}
+		res += v.String()
+	}
+	return res
 }
 
 // Sort sorts the LabelArrayList in-place, but also returns the sorted list

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -352,16 +352,16 @@ var (
 	mapKeyAllowAllE_ = EgressKey()
 	// Desired map entries for no L7 redirect / redirect to Proxy
 	mapEntryL7None_ = func(lbls ...labels.LabelArray) MapStateEntry {
-		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), 0, "", 0, false, DefaultAuthType, AuthTypeDisabled).WithOwners()
+		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), 0, 0, false, DefaultAuthType, AuthTypeDisabled).WithOwners()
 	}
 	mapEntryL7Auth_ = func(at AuthType, lbls ...labels.LabelArray) MapStateEntry {
-		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), 0, "", 0, false, ExplicitAuthType, at).WithOwners()
+		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), 0, 0, false, ExplicitAuthType, at).WithOwners()
 	}
 	mapEntryL7Deny_ = func(lbls ...labels.LabelArray) MapStateEntry {
-		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), 0, "", 0, true, DefaultAuthType, AuthTypeDisabled).WithOwners()
+		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), 0, 0, true, DefaultAuthType, AuthTypeDisabled).WithOwners()
 	}
 	mapEntryL7Proxy = func(lbls ...labels.LabelArray) MapStateEntry {
-		entry := NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), 1, "", 0, false, DefaultAuthType, AuthTypeDisabled).WithOwners()
+		entry := NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), 1, 0, false, DefaultAuthType, AuthTypeDisabled).WithOwners()
 		entry.ProxyPort = 1
 		return entry
 	}
@@ -1478,7 +1478,7 @@ var (
 			labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowAnyIngress, labels.LabelSourceReserved),
 		},
 	}
-	mapEntryL3UnknownIngress          = NewMapStateEntry(nil, derivedFrom, 0, "", 0, false, ExplicitAuthType, AuthTypeDisabled)
+	mapEntryL3UnknownIngress          = NewMapStateEntry(nil, derivedFrom, 0, 0, false, ExplicitAuthType, AuthTypeDisabled)
 	mapKeyL3HostEgress                = EgressKey().WithIdentity(identity.ReservedIdentityHost)
 	ruleL3L4Port8080ProtoAnyDenyWorld = api.NewRule().WithIngressDenyRules([]api.IngressDenyRule{
 		{

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -85,7 +85,7 @@ func FuzzAccumulateMapChange(f *testing.F) {
 			proxyPort = 1
 		}
 		key := KeyForDirection(dir).WithPortProto(proto, port)
-		value := NewMapStateEntry(csFoo, nil, proxyPort, "", 0, deny, DefaultAuthType, AuthTypeDisabled)
+		value := NewMapStateEntry(csFoo, nil, proxyPort, 0, deny, DefaultAuthType, AuthTypeDisabled)
 		policyMaps := MapChanges{}
 		policyMaps.AccumulateMapChanges(csFoo, adds, deletes, []Key{key}, value)
 		policyMaps.SyncMapChanges(versioned.LatestTx)

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -45,12 +45,12 @@ func FuzzDenyPreferredInsert(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		keys := newMapState()
 		key := Key{}
-		entry := MapStateEntry{}
+		entry := mapStateEntry{}
 		ff := fuzz.NewConsumer(data)
 		ff.GenerateStruct(keys)
 		ff.GenerateStruct(&key)
 		ff.GenerateStruct(&entry)
-		keys.denyPreferredInsert(key, entry, allFeatures)
+		keys.insertWithChanges(key, entry, allFeatures, ChangeState{})
 	})
 }
 
@@ -85,9 +85,9 @@ func FuzzAccumulateMapChange(f *testing.F) {
 			proxyPort = 1
 		}
 		key := KeyForDirection(dir).WithPortProto(proto, port)
-		value := NewMapStateEntry(csFoo, nil, proxyPort, 0, deny, DefaultAuthType, AuthTypeDisabled)
+		value := newMapStateEntry(csFoo, nil, proxyPort, 0, deny, DefaultAuthType, AuthTypeDisabled)
 		policyMaps := MapChanges{}
-		policyMaps.AccumulateMapChanges(csFoo, adds, deletes, []Key{key}, value)
+		policyMaps.AccumulateMapChanges(adds, deletes, []Key{key}, value)
 		policyMaps.SyncMapChanges(versioned.LatestTx)
 	})
 }

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -625,7 +625,7 @@ func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, chang
 				continue
 			}
 		}
-		entry := NewMapStateEntry(cs, l4.RuleOrigin[cs], proxyPort, listener, priority, isDenyRule, hasAuth, authType)
+		entry := NewMapStateEntry(cs, l4.RuleOrigin[cs], proxyPort, priority, isDenyRule, hasAuth, authType)
 
 		if cs.IsWildcard() {
 			for _, keyToAdd := range keysToAdd {
@@ -1636,7 +1636,7 @@ func (l4Policy *L4Policy) AccumulateMapChanges(l4 *L4Filter, cs CachedSelector, 
 			keysToAdd = append(keysToAdd,
 				KeyForDirection(direction).WithPortProtoPrefix(proto, mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
 		}
-		value := NewMapStateEntry(cs, derivedFrom, proxyPort, listener, priority, isDeny, hasAuth, authType)
+		value := NewMapStateEntry(cs, derivedFrom, proxyPort, priority, isDeny, hasAuth, authType)
 
 		if option.Config.Debug {
 			authString := "default"

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1619,12 +1619,16 @@ func (l4Policy *L4Policy) AccumulateMapChanges(l4 *L4Filter, cs CachedSelector, 
 			var err error
 			proxyPort, err = epPolicy.LookupRedirectPort(l4.Ingress, string(l4.Protocol), port, listener)
 			if err != nil {
-				// This happens for new redirects that have not been realized
-				// yet. The accumulated changes should only be consumed after new
-				// redirects have been realized. ConsumeMapChanges then maps this
-				// invalid value to the real redirect port before the entry is
-				// visible to the endpoint package.
-				proxyPort = unrealizedRedirectPort
+				log.WithFields(logrus.Fields{
+					logfields.EndpointSelector: cs,
+					logfields.Port:             port,
+					logfields.Protocol:         proto,
+					logfields.TrafficDirection: direction,
+					logfields.IsRedirect:       redirect,
+					logfields.Listener:         listener,
+					logfields.ListenerPriority: priority,
+				}).Warn("AccumulateMapChanges: Missing redirect.")
+				continue
 			}
 		}
 		var keysToAdd []Key

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -123,7 +123,7 @@ func TestParserTypeMerge(t *testing.T) {
 			require.Error(t, err)
 		}
 		if res != tt.c {
-			fmt.Printf("Merge %s with %s, expecting %s\n", tt.a, tt.b, tt.c)
+			t.Logf("Merge %s with %s, expecting %s\n", tt.a, tt.b, tt.c)
 		}
 		require.Equal(t, tt.c, res)
 	}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -232,6 +232,9 @@ func (msm *mapStateMap) forID(k Key, idSet IDSet, f func(Key, mapStateEntry) boo
 
 // NarrowerKeysWithWildcardID iterates over ANY keys with narrower port/proto's in the trie.
 // Equal port/protos are not included.
+// New keys with the protocol/port of the iterated keys can be safely added during iteration as this
+// operation does not change the trie, but only adds elements to the idSet that is not used after
+// yielding.
 func (msm *mapStateMap) NarrowerKeysWithWildcardID(key Key) iter.Seq2[Key, mapStateEntry] {
 	return func(yield func(Key, mapStateEntry) bool) {
 		iter := msm.trie.DescendantIterator(key.PrefixLength(), key)
@@ -292,6 +295,8 @@ func (msm *mapStateMap) NarrowerKeys(key Key) iter.Seq2[Key, mapStateEntry] {
 }
 
 // NarrowerOrEqualKeys iterates over narrower or equal keys in the trie.
+// Iterated keys can be safely deleted during iteration due to DescendantIterator holding enough
+// state that allows iteration to be continued even if the current trie node is removed.
 func (msm *mapStateMap) NarrowerOrEqualKeys(key Key) iter.Seq2[Key, mapStateEntry] {
 	return func(yield func(Key, mapStateEntry) bool) {
 		iter := msm.trie.DescendantIterator(key.PrefixLength(), key)
@@ -452,6 +457,33 @@ func newMapStateEntry(cs MapStateOwner, derivedFrom labels.LabelArrayList, proxy
 		hasAuthType:      hasAuth,
 		derivedFromRules: derivedFrom,
 		owners:           set.NewSet(cs),
+	}
+}
+
+// dependentOf returns a new mapStateEntry that is a copy of 'e', but has 'ownerKey' as the sole
+// owner, and has no dependent keys.
+func (e *mapStateEntry) dependentOf(ownerKey Key) mapStateEntry {
+	return mapStateEntry{
+		MapStateEntry:    e.MapStateEntry,
+		priority:         e.priority,
+		hasAuthType:      e.hasAuthType,
+		derivedFromRules: slices.Clone(e.derivedFromRules),
+		owners:           set.NewSet[MapStateOwner](ownerKey),
+	}
+}
+
+// dependentFrom returns a new mapStateEntry that is a copy of 'e', but has 'ownerKey' as the sole
+// owner, and has no dependent keys.
+func (e mapStateEntry) authOverrideFrom(ownerKey Key, entry *mapStateEntry) mapStateEntry {
+	lbls := slices.Clone(e.derivedFromRules)
+	lbls.MergeSorted(entry.derivedFromRules)
+
+	return mapStateEntry{
+		MapStateEntry:    e.MapStateEntry.WithAuthType(entry.AuthType),
+		priority:         e.priority,
+		hasAuthType:      DefaultAuthType,
+		derivedFromRules: lbls,
+		owners:           set.NewSet[MapStateOwner](ownerKey),
 	}
 }
 
@@ -831,6 +863,11 @@ func (e *mapStateEntry) deepEqual(o *mapStateEntry) bool {
 	return true
 }
 
+func (e MapStateEntry) WithAuthType(authType AuthType) MapStateEntry {
+	e.AuthType = authType
+	return e
+}
+
 // String returns a string representation of the MapStateEntry
 func (e MapStateEntry) String() string {
 	return "ProxyPort=" + strconv.FormatUint(uint64(e.ProxyPort), 10) +
@@ -845,11 +882,6 @@ func (e mapStateEntry) String() string {
 		",priority=" + strconv.FormatUint(uint64(e.priority), 10) +
 		",owners=" + e.owners.String() +
 		",dependents=" + fmt.Sprintf("%v", e.dependents)
-}
-
-type keyValue struct {
-	key   Key
-	value mapStateEntry
 }
 
 // addKeyWithChanges adds a 'key' with value 'entry' to 'keys' keeping track of incremental changes in 'adds' and 'deletes', and any changed or removed old values in 'old', if not nil.
@@ -972,32 +1004,49 @@ func (ms *mapState) revertChanges(changes ChangeState) {
 	}
 }
 
-func (ms *mapState) insertUpdates(newKey Key, newEntry *mapStateEntry, updates []keyValue, changes ChangeState) {
-	for _, update := range updates {
-		if ms.addKeyWithChanges(update.key, update.value, changes) {
-			// Identities can be deleted incrementally so we need to track the
-			// added keys by adding a dependency to the owning entry with the
-			// same identity so that this update can be reverted when the
-			// identity is removed.
+// insertDependentOfKey adds a dependent entry to 'k' with the more specific port/proto of 'newKey'
+// to ensure 'v' takes precedence.
+// Called only for 'k' with specific identity and with broader protocol/port than l4-only 'newKey'.
+func (ms *mapState) insertDependentOfKey(k Key, v mapStateEntry, newKey Key, changes ChangeState) {
+	// Compute narrower 'key' with identity of 'k'
+	key := newKey.WithIdentity(k.Identity)
+	if ms.addKeyWithChanges(key, v.dependentOf(k), changes) {
+		ms.addDependentOnEntry(k, v, key, changes)
+	}
+}
 
-			// updates always have a single owner of type 'Key'
-			owner, found := update.value.owners.Get()
-			if !found {
-				log.Errorf("mapstate update has no owner")
-				continue
-			}
-			ownerKey, ok := owner.(Key)
-			if !ok {
-				log.Errorf("mapstate update owner is not of type Key")
-				continue
-			}
-			if ownerKey == newKey {
-				newEntry.AddDependent(update.key)
-			} else if update.key != ownerKey {
-				// dependency is only added if the update's key is not the owner itself
-				ms.AddDependent(ownerKey, update.key, changes)
-			}
-		}
+// insertDependentOfNewKey adds a dependent entry to 'newKey' with the more specific port/proto of
+// 'k' to ensure 'newEntry' takes precedence.
+// Called only for L4-only 'k' with narrower protocol/port than 'newKey' with a specific identity.
+func (ms *mapState) insertDependentOfNewKey(newKey Key, newEntry *mapStateEntry, k Key, changes ChangeState) {
+	// Compute narrower 'key' with identity of 'newKey'
+	key := k.WithIdentity(newKey.Identity)
+	if ms.addKeyWithChanges(key, newEntry.dependentOf(newKey), changes) {
+		newEntry.AddDependent(key)
+	}
+}
+
+// insertAuthOverrideFromKey adds a dependent entry to 'k' with the more specific port/proto of
+// 'newKey' and with override auth type from 'v' to ensure auth type of 'v' is used for identity of
+// 'k' also when the traffic matches the L4-only 'newKey'.
+// Called only for 'k' with specific identity and with broader protocol/port than L4-only 'newKey'.
+func (ms *mapState) insertAuthOverrideFromKey(k Key, v mapStateEntry, newKey Key, newEntry mapStateEntry, changes ChangeState) {
+	// Compute narrower 'key' with identity of 'k'
+	key := newKey.WithIdentity(k.Identity)
+	if ms.addKeyWithChanges(key, newEntry.authOverrideFrom(k, &v), changes) {
+		ms.addDependentOnEntry(k, v, key, changes)
+	}
+}
+
+// insertAuthOverrideKey adds a dependent entry to 'newKey' with the more specific port/proto of 'k'
+// and with override auth type from 'newEntry' to ensure auth type of 'newEntry' is used for
+// identity of 'newKey' also when the traffic matches the L4-only 'k'.
+// Called only for L4-only 'k' with narrower protocol/port than 'newKey' with a specific identity.
+func (ms *mapState) insertAuthOverrideFromNewKey(newKey Key, newEntry *mapStateEntry, k Key, v mapStateEntry, changes ChangeState) {
+	// Compute narrower 'key' with identity of 'newKey'
+	key := k.WithIdentity(newKey.Identity)
+	if ms.addKeyWithChanges(key, v.authOverrideFrom(newKey, newEntry), changes) {
+		newEntry.AddDependent(key)
 	}
 }
 
@@ -1005,15 +1054,40 @@ func (ms *mapState) insertWithChanges(key Key, entry mapStateEntry, features pol
 	ms.denyPreferredInsertWithChanges(key, entry, features, changes)
 }
 
-// denyPreferredInsertWithChanges contains the most important business logic for policy insertions. It inserts
-// a key and entry into the map by giving preference to deny entries, and L3-only deny entries over L3-L4 allows.
+// denyPreferredInsertWithChanges contains the most important business logic for policy
+// insertions. It inserts a key and entry into the map by giving preference to deny entries, and
+// L3-only deny entries over L3-L4 allows.
+//
+// Since bpf datapath denies by default, we only need to add deny entries to carve out more specific
+// holes to less specific allow rules. But since we don't if allow entries will be added later
+// (e.g., incrementally due to FQDN rules), we must generally add deny entries even if there are no
+// allow entries yet.
+//
+// Note on bailed or deleted entries: In general, if we bail out due to being covered by an existing
+// entry, or delete an entry due to being covered by the new one, we would want this action reversed
+// if the existing entry or this new one is incremantally removed, respectively.
+// Generally, whenever a deny entry covers an allow entry (i.e., covering key has broader or equal
+// protocol/port, and the keys have the same identity, or the covering key has wildcard identity (ID
+// == 0)).
+// Secondly, only keys with a specific identity (ID != 0) can be incrementally added or deleted.
+// Finally, due to the selector cache being transactional, when an identity is removed, all keys
+// with that identity are incrementally deleted.
+// Hence, if a covering key is incrementally deleted, it is a key with a specific identity, and all
+// keys covered by it will be deleted as well, so there is no situation where this bailed-out or
+// deleted key should be reinstated due to the covering key being incrementally deleted.
+//
+// Note on added dependent L3/4 entries: Since the datapath always gives precedence to the matching
+// entry with the most specific L4 (narrower protocol/port), we need to add L3/4 entries e.g., when
+// precedence would be given to a narrower allow entry with the wildcard identity (L4-only key),
+// while precedence should be given to the deny entry with a specific identity and broader L4 when
+// the given packet matches both of them. To force the datapath to give precedence to the deny entry
+// we add a new dependent deny entry with the identity of the (broader) deny entry and the L4
+// protocol and port of the (narrower) L4-only key. The added key is marked as a dependent entry of
+// the key with a specific identity (rather than the l4-only key), so that the dependent added entry
+// is also deleted when the identity of its owner key is (incrementally) removed.
+//
 // Incremental changes performed are recorded in 'changes'.
 func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry mapStateEntry, features policyFeatures, changes ChangeState) {
-	// Since bpf datapath denies by default, we only need to add deny entries to carve out more
-	// specific holes to less specific allow rules. But since we don't if allow entries will be
-	// added later (e.g., incrementally due to FQDN rules), we must generally add deny entries
-	// even if there are no allow entries yet.
-
 	// Bail if covered by a deny key
 	if !ms.denies.Empty() {
 		for k := range ms.denies.BroaderOrEqualKeys(newKey) {
@@ -1025,65 +1099,51 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry mapState
 	}
 
 	if newEntry.IsDeny {
-		// Delete entries covered by the new deny entry
-		var deletes []Key
 		// Delete covered allow entries.
 		for k := range ms.allows.NarrowerOrEqualKeys(newKey) {
-			deletes = append(deletes, k)
+			ms.deleteKeyWithChanges(k, nil, changes)
 		}
 		// Delete covered deny entries, except for identical keys that need to be merged.
 		for k := range ms.denies.NarrowerKeys(newKey) {
-			deletes = append(deletes, k)
-		}
-		for _, key := range deletes {
-			ms.deleteKeyWithChanges(key, nil, changes)
+			ms.deleteKeyWithChanges(k, nil, changes)
 		}
 
-		// Add L3/4 deny entries for more specific allow keys with the wildcard
-		// identity as the more specific allow would otherwise take precedence in
-		// the datapath.
+		// Add L3/4 deny entry for each more specific allow key with the wildcard identity
+		// as the more specific allow would otherwise take precedence in the datapath over
+		// the less specific 'newKey' with a specific identity.
 		//
-		// Only (partially) wildcarded port can have narrower keys.
+		// Skip when 'newKey' has no port wildcarding, as then there can't be any narrower
+		// keys.
 		if newKey.Identity != 0 && newKey.HasPortWildcard() {
-			var updates []keyValue
 			for k := range ms.allows.NarrowerKeysWithWildcardID(newKey) {
-				updates = append(updates, keyValue{
-					key:   k.WithIdentity(newKey.Identity),
-					value: newMapStateEntry(newKey, newEntry.derivedFromRules, 0, 0, true, DefaultAuthType, AuthTypeDisabled),
-				})
+				ms.insertDependentOfNewKey(newKey, &newEntry, k, changes)
 			}
-			ms.insertUpdates(newKey, &newEntry, updates, changes)
+		}
+	} else {
+		// newEntry is an allow entry.
+		// NOTE: We do not delete redundant allow entries.
+
+		// Avoid allocs in this block if there are no deny enties
+		if !ms.denies.Empty() {
+			// Add L3/4 deny entries for broader deny keys with a specific identity as
+			// the narrower L4-only allow would otherwise take precedence in the
+			// datapath.
+			if newKey.Identity == 0 && newKey.Nexthdr != 0 { // L4-only newKey
+				for k, v := range ms.denies.BroaderKeysWithSpecificID(newKey) {
+					ms.insertDependentOfKey(k, v, newKey, changes)
+				}
+			}
 		}
 
-		ms.addKeyWithChanges(newKey, newEntry, changes)
-		return
-	} // else newEntry is an allow entry
-
-	// NOTE: We do not delete redundant allow entries.
-
-	// Avoid allocs in this block if there are no deny enties
-	if !ms.denies.Empty() {
-		// Add L3/4 deny entries for broader deny keys with a specific identity as the
-		// narrower L4-only allow would otherwise take precedence in the datapath.
-		if newKey.Identity == 0 && newKey.Nexthdr != 0 { // L4-only newKey
-			var updates []keyValue
-			for k, v := range ms.denies.BroaderKeysWithSpecificID(newKey) {
-				updates = append(updates, keyValue{
-					key:   newKey.WithIdentity(k.Identity),
-					value: newMapStateEntry(k, v.derivedFromRules, 0, 0, true, DefaultAuthType, AuthTypeDisabled),
-				})
-			}
-			ms.insertUpdates(newKey, &newEntry, updates, changes)
+		// Checking for auth feature here is faster than calling 'authPreferredInsert' and
+		// checking for it there.
+		if features.contains(authRules) {
+			ms.authPreferredInsert(newKey, newEntry, changes)
+			return
 		}
 	}
 
-	// Checking for auth feature here is faster than calling 'authPreferredInsert' and checking
-	// for it there.
-	if !features.contains(authRules) {
-		ms.addKeyWithChanges(newKey, newEntry, changes)
-		return
-	}
-	ms.authPreferredInsert(newKey, newEntry, changes)
+	ms.addKeyWithChanges(newKey, newEntry, changes)
 }
 
 // overrideAuthType sets the AuthType of 'v' to that of 'newKey', saving the old entry in 'changes'.
@@ -1121,18 +1181,11 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry mapStateEntry, chan
 		// and there is a key with broader port/proto for a specific identity that
 		// has an explicit auth type.
 		if newKey.Identity == 0 && newKey.Nexthdr != 0 { // L4-only newKey
-			var updates []keyValue
 			for k, v := range ms.allows.BroaderKeysWithSpecificID(newKey) {
 				if v.hasAuthType == ExplicitAuthType {
-					update := keyValue{
-						key:   newKey.WithIdentity(k.Identity),
-						value: newMapStateEntry(k, v.derivedFromRules, newEntry.ProxyPort, newEntry.priority, false, DefaultAuthType, v.AuthType),
-					}
-					update.value.derivedFromRules.MergeSorted(newEntry.derivedFromRules)
-					updates = append(updates, update)
+					ms.insertAuthOverrideFromKey(k, v, newKey, newEntry, changes)
 				}
 			}
-			ms.insertUpdates(newKey, &newEntry, updates, changes)
 		}
 	} else { // New entry has an explicit auth type
 		// Check if the new key is the most specific covering key of any other key
@@ -1194,18 +1247,11 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry mapStateEntry, chan
 			//
 			// Only (partially) wildcarded port can have narrower keys.
 			if newKey.HasPortWildcard() {
-				var updates []keyValue
 				for k, v := range ms.allows.NarrowerKeysWithWildcardID(newKey) {
 					if v.hasAuthType == DefaultAuthType {
-						update := keyValue{
-							key:   k.WithIdentity(newKey.Identity),
-							value: newMapStateEntry(newKey, newEntry.derivedFromRules, v.ProxyPort, v.priority, false, DefaultAuthType, newEntry.AuthType),
-						}
-						update.value.derivedFromRules.MergeSorted(v.derivedFromRules)
-						updates = append(updates, update)
+						ms.insertAuthOverrideFromNewKey(newKey, &newEntry, k, v, changes)
 					}
 				}
-				ms.insertUpdates(newKey, &newEntry, updates, changes)
 			}
 		}
 	}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -79,6 +79,7 @@ type MapState interface {
 	GetIdentities(*logrus.Logger) ([]int64, []int64)
 	GetDenyIdentities(*logrus.Logger) ([]int64, []int64)
 	Len() int
+	Empty() bool
 
 	// private accessors
 	deniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool
@@ -599,6 +600,11 @@ func (ms *mapState) delete(k Key) {
 // argument returns false. It returns false iff the iteration was cut short.
 func (ms *mapState) ForEach(f func(Key, MapStateEntry) (cont bool)) (complete bool) {
 	return ms.allows.ForEach(f) && ms.denies.ForEach(f)
+}
+
+// Empty returns 'true' if there are no entries in the map
+func (ms *mapState) Empty() bool {
+	return ms.allows.Len() == 0 && ms.denies.Len() == 0
 }
 
 // Len returns the length of the map

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -4,6 +4,7 @@
 package policy
 
 import (
+	"errors"
 	"fmt"
 	"iter"
 	"maps"
@@ -70,6 +71,7 @@ const (
 // MapState is a map interface for policy maps
 type MapState interface {
 	Get(Key) (MapStateEntry, bool)
+	GetRuleLabels(Key) (labels.LabelArrayList, error)
 
 	// ForEach allows iteration over the MapStateEntries. It returns true if
 	// the iteration was not stopped early by the callback.
@@ -94,8 +96,8 @@ type MapState interface {
 	deleteKeyWithChanges(key Key, owner MapStateOwner, changes ChangeState)
 
 	// For testing from other packages only
-	Equals(MapState) bool
-	Diff(expected MapState) string
+	Equals(MapStateMap) bool
+	Diff(expected MapStateMap) string
 	WithState(initMap MapStateMap) MapState
 }
 
@@ -425,9 +427,9 @@ type MapStateEntry struct {
 	// AuthType is non-zero when authentication is required for the traffic to be allowed.
 	AuthType AuthType
 
-	// DerivedFromRules tracks the policy rules this entry derives from
+	// derivedFromRules tracks the policy rules this entry derives from.
 	// In sorted order.
-	DerivedFromRules labels.LabelArrayList
+	derivedFromRules labels.LabelArrayList
 
 	// owners collects the keys in the map and selectors in the policy that require this key to be present.
 	// TODO: keep track which selector needed the entry to be deny, redirect, or just allow.
@@ -453,12 +455,16 @@ func NewMapStateEntry(cs MapStateOwner, derivedFrom labels.LabelArrayList, proxy
 	return MapStateEntry{
 		ProxyPort:        proxyPort,
 		priority:         priority,
-		DerivedFromRules: derivedFrom,
+		derivedFromRules: derivedFrom,
 		IsDeny:           deny,
 		hasAuthType:      hasAuth,
 		AuthType:         authType,
 		owners:           set.NewSet(cs),
 	}
+}
+
+func (e *MapStateEntry) GetRuleLabels() labels.LabelArrayList {
+	return e.derivedFromRules
 }
 
 // AddDependent adds 'key' to the set of dependent keys.
@@ -533,6 +539,19 @@ func (ms *mapState) Get(k Key) (MapStateEntry, bool) {
 	return ms.allows.Lookup(k)
 }
 
+var errMissingKey = errors.New("Key not found")
+
+// GetRuleLabels returns the list of labels of the rules that contributed
+// to the entry at this key.
+// The returned LabelArrayList is shallow-copied and therefore must not be mutated.
+func (ms *mapState) GetRuleLabels(k Key) (ls labels.LabelArrayList, err error) {
+	entry, ok := ms.Get(k)
+	if !ok {
+		return nil, errMissingKey
+	}
+	return entry.GetRuleLabels(), nil
+}
+
 // insert the Key and MapStateEntry into the MapState
 func (ms *mapState) insert(k Key, v MapStateEntry) {
 	if k.DestPort == 0 && k.PortPrefixLen() > 0 {
@@ -587,16 +606,29 @@ func (ms *mapState) Len() int {
 	return ms.allows.Len() + ms.denies.Len()
 }
 
-// Equals determines if this MapState is equal to the
-// argument MapState
-// Only used for testing, but also from the endpoint package!
-func (msA *mapState) Equals(msB MapState) bool {
+// equalsWithLabels determines if this mapState is equal to the
+// argument MapState. Only compares datapath visible fields and derivedFromLabels.
+// Only used for testing.
+func (msA *mapState) equalsWithLabels(msB *mapState) bool {
 	if msA.Len() != msB.Len() {
 		return false
 	}
 	return msA.ForEach(func(kA Key, vA MapStateEntry) bool {
 		vB, ok := msB.Get(kA)
 		return ok && (&vB).DatapathAndDerivedFromEqual(&vA)
+	})
+}
+
+// Equals determines if this MapState is equal to the
+// argument MapState. Only compares datapath visible fields.
+// Only used for testing, but also from the endpoint package!
+func (msA *mapState) Equals(msB MapStateMap) bool {
+	if msA.Len() != len(msB) {
+		return false
+	}
+	return msA.ForEach(func(kA Key, vA MapStateEntry) bool {
+		vB, ok := msB[kA]
+		return ok && (&vB).DatapathEqual(&vA)
 	})
 }
 
@@ -617,21 +649,20 @@ func (msA *mapState) DeepEquals(msB *mapState) bool {
 // Diff returns the string of differences between 'obtained' and 'expected' prefixed with
 // '+ ' or '- ' for obtaining something unexpected, or not obtaining the expected, respectively.
 // For use in debugging.
-func (obtained *mapState) Diff(expected MapState) (res string) {
+func (obtained *mapState) Diff(expected MapStateMap) (res string) {
 	res += "Missing (-), Unexpected (+):\n"
-	expected.ForEach(func(kE Key, vE MapStateEntry) bool {
+	for kE, vE := range expected {
 		if vO, ok := obtained.Get(kE); ok {
-			if !(&vO).DatapathAndDerivedFromEqual(&vE) {
+			if !(&vO).DatapathEqual(&vE) {
 				res += "- " + kE.String() + ": " + vE.String() + "\n"
 				res += "+ " + kE.String() + ": " + vO.String() + "\n"
 			}
 		} else {
 			res += "- " + kE.String() + ": " + vE.String() + "\n"
 		}
-		return true
-	})
+	}
 	obtained.ForEach(func(kE Key, vE MapStateEntry) bool {
-		if _, ok := expected.Get(kE); !ok {
+		if _, ok := expected[kE]; !ok {
 			res += "+ " + kE.String() + ": " + vE.String() + "\n"
 		}
 		return true
@@ -751,8 +782,8 @@ func (e *MapStateEntry) merge(entry *MapStateEntry) {
 	}
 
 	// merge DerivedFromRules
-	if len(entry.DerivedFromRules) > 0 {
-		e.DerivedFromRules.MergeSorted(entry.DerivedFromRules)
+	if len(entry.derivedFromRules) > 0 {
+		e.derivedFromRules.MergeSorted(entry.derivedFromRules)
 	}
 }
 
@@ -781,7 +812,7 @@ func (e *MapStateEntry) DatapathAndDerivedFromEqual(o *MapStateEntry) bool {
 	}
 
 	return e.IsDeny == o.IsDeny && e.ProxyPort == o.ProxyPort && e.AuthType == o.AuthType &&
-		e.DerivedFromRules.DeepEqual(&o.DerivedFromRules)
+		e.derivedFromRules.DeepEqual(&o.derivedFromRules)
 }
 
 // DeepEqual is a manually generated deepequal function, deeply comparing the
@@ -798,7 +829,7 @@ func (e *MapStateEntry) DeepEqual(o *MapStateEntry) bool {
 		return false
 	}
 
-	if !e.DerivedFromRules.DeepEqual(&o.DerivedFromRules) {
+	if !e.derivedFromRules.DeepEqual(&o.derivedFromRules) {
 		return false
 	}
 
@@ -825,7 +856,7 @@ func (e MapStateEntry) String() string {
 	return "ProxyPort=" + strconv.FormatUint(uint64(e.ProxyPort), 10) +
 		",IsDeny=" + strconv.FormatBool(e.IsDeny) +
 		",AuthType=" + e.AuthType.String() +
-		",DerivedFromRules=" + fmt.Sprintf("%v", e.DerivedFromRules) +
+		",derivedFromRules=" + fmt.Sprintf("%v", e.derivedFromRules) +
 		",priority=" + strconv.FormatUint(uint64(e.priority), 10) +
 		",owners=" + e.owners.String() +
 		",dependents=" + fmt.Sprintf("%v", e.dependents)
@@ -877,7 +908,7 @@ func (ms *mapState) addKeyWithChanges(key Key, entry MapStateEntry, changes Chan
 		// entry.
 		// Newly inserted entries must have their own containers, so that they
 		// remain separate when new owners/dependents are added to existing entries
-		entry.DerivedFromRules = slices.Clone(entry.DerivedFromRules)
+		entry.derivedFromRules = slices.Clone(entry.derivedFromRules)
 		entry.owners = entry.owners.Clone()
 		entry.dependents = maps.Clone(entry.dependents)
 
@@ -1050,7 +1081,7 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 			for k := range ms.allows.NarrowerKeysWithWildcardID(newKey) {
 				updates = append(updates, keyValue{
 					key:   k.WithIdentity(newKey.Identity),
-					value: NewMapStateEntry(newKey, newEntry.DerivedFromRules, 0, 0, true, DefaultAuthType, AuthTypeDisabled),
+					value: NewMapStateEntry(newKey, newEntry.derivedFromRules, 0, 0, true, DefaultAuthType, AuthTypeDisabled),
 				})
 			}
 			ms.insertUpdates(newKey, &newEntry, updates, changes)
@@ -1071,7 +1102,7 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 			for k, v := range ms.denies.BroaderKeysWithSpecificID(newKey) {
 				updates = append(updates, keyValue{
 					key:   newKey.WithIdentity(k.Identity),
-					value: NewMapStateEntry(k, v.DerivedFromRules, 0, 0, true, DefaultAuthType, AuthTypeDisabled),
+					value: NewMapStateEntry(k, v.derivedFromRules, 0, 0, true, DefaultAuthType, AuthTypeDisabled),
 				})
 			}
 			ms.insertUpdates(newKey, &newEntry, updates, changes)
@@ -1127,9 +1158,9 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, chan
 				if v.hasAuthType == ExplicitAuthType {
 					update := keyValue{
 						key:   newKey.WithIdentity(k.Identity),
-						value: NewMapStateEntry(k, v.DerivedFromRules, newEntry.ProxyPort, newEntry.priority, false, DefaultAuthType, v.AuthType),
+						value: NewMapStateEntry(k, v.derivedFromRules, newEntry.ProxyPort, newEntry.priority, false, DefaultAuthType, v.AuthType),
 					}
-					update.value.DerivedFromRules.MergeSorted(newEntry.DerivedFromRules)
+					update.value.derivedFromRules.MergeSorted(newEntry.derivedFromRules)
 					updates = append(updates, update)
 				}
 			}
@@ -1200,9 +1231,9 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, chan
 					if v.hasAuthType == DefaultAuthType {
 						update := keyValue{
 							key:   k.WithIdentity(newKey.Identity),
-							value: NewMapStateEntry(newKey, newEntry.DerivedFromRules, v.ProxyPort, v.priority, false, DefaultAuthType, newEntry.AuthType),
+							value: NewMapStateEntry(newKey, newEntry.derivedFromRules, v.ProxyPort, v.priority, false, DefaultAuthType, newEntry.AuthType),
 						}
-						update.value.DerivedFromRules.MergeSorted(v.DerivedFromRules)
+						update.value.derivedFromRules.MergeSorted(v.derivedFromRules)
 						updates = append(updates, update)
 					}
 				}
@@ -1227,8 +1258,8 @@ func (changes *ChangeState) insertOldIfNotExists(key Key, entry MapStateEntry) b
 		// Only insert the old entry if the entry was not first added on this round of
 		// changes.
 		if _, added := changes.Adds[key]; !added {
-			// new containers to keep this entry separate from the one that may remain in 'keys'
-			entry.DerivedFromRules = slices.Clone(entry.DerivedFromRules)
+			// Clone to keep this entry separate from the one that may remain in 'keys'
+			entry.derivedFromRules = slices.Clone(entry.derivedFromRules)
 			entry.owners = entry.owners.Clone()
 			entry.dependents = maps.Clone(entry.dependents)
 

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -600,6 +600,20 @@ func (msA *mapState) Equals(msB MapState) bool {
 	})
 }
 
+// DeepEquals determines if this MapState is equal to the
+// argument MapState
+// Only used for testing, but also from the endpoint package!
+// internal indices are ignored, only the mapstate entries are checked for!
+func (msA *mapState) DeepEquals(msB *mapState) bool {
+	if msA.Len() != msB.Len() {
+		return false
+	}
+	return msA.ForEach(func(kA Key, vA MapStateEntry) bool {
+		vB, ok := msB.Get(kA)
+		return ok && (&vB).DeepEqual(&vA)
+	})
+}
+
 // Diff returns the string of differences between 'obtained' and 'expected' prefixed with
 // '+ ' or '- ' for obtaining something unexpected, or not obtaining the expected, respectively.
 // For use in debugging.
@@ -608,6 +622,31 @@ func (obtained *mapState) Diff(expected MapState) (res string) {
 	expected.ForEach(func(kE Key, vE MapStateEntry) bool {
 		if vO, ok := obtained.Get(kE); ok {
 			if !(&vO).DatapathAndDerivedFromEqual(&vE) {
+				res += "- " + kE.String() + ": " + vE.String() + "\n"
+				res += "+ " + kE.String() + ": " + vO.String() + "\n"
+			}
+		} else {
+			res += "- " + kE.String() + ": " + vE.String() + "\n"
+		}
+		return true
+	})
+	obtained.ForEach(func(kE Key, vE MapStateEntry) bool {
+		if _, ok := expected.Get(kE); !ok {
+			res += "+ " + kE.String() + ": " + vE.String() + "\n"
+		}
+		return true
+	})
+	return res
+}
+
+// diff returns the string of differences between 'obtained' and 'expected' prefixed with
+// '+ ' or '- ' for obtaining something unexpected, or not obtaining the expected, respectively.
+// For use in debugging.
+func (obtained *mapState) diff(expected *mapState) (res string) {
+	res += "Missing (-), Unexpected (+):\n"
+	expected.ForEach(func(kE Key, vE MapStateEntry) bool {
+		if vO, ok := obtained.Get(kE); ok {
+			if !(&vO).DeepEqual(&vE) {
 				res += "- " + kE.String() + ": " + vE.String() + "\n"
 				res += "+ " + kE.String() + ": " + vO.String() + "\n"
 			}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -841,6 +841,13 @@ func (ms *mapState) addKeyWithChanges(key Key, entry MapStateEntry, changes Chan
 		entry.DerivedFromRules = slices.Clone(entry.DerivedFromRules)
 		entry.owners = entry.owners.Clone()
 		entry.dependents = maps.Clone(entry.dependents)
+
+		// Save old value before any changes, if any
+		if exists {
+			changes.insertOldIfNotExists(key, oldEntry)
+		}
+
+		// Callers already have cloned the containers, no need to do it again here
 		ms.insert(key, entry)
 	} else {
 		// Do not record and incremental add if nothing was done

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -963,7 +963,7 @@ func (ms *mapState) deleteKeyWithChanges(key Key, owner MapStateOwner, changes C
 			} else {
 				// 'owner' was not found, do not change anything
 				if oldAdded {
-					delete(changes.Old, key)
+					delete(changes.old, key)
 				}
 				return
 			}
@@ -1003,7 +1003,7 @@ func (ms *mapState) revertChanges(changes ChangeState) {
 		ms.denies.delete(k)
 	}
 	// 'old' contains all the original values of both modified and deleted entries
-	for k, v := range changes.Old {
+	for k, v := range changes.old {
 		ms.insert(k, v)
 	}
 }
@@ -1251,10 +1251,10 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, chan
 // 'changes.Adds' so we'll record the old value as expected.
 // Returns 'true' if an old entry was added.
 func (changes *ChangeState) insertOldIfNotExists(key Key, entry MapStateEntry) bool {
-	if changes == nil || changes.Old == nil {
+	if changes == nil || changes.old == nil {
 		return false
 	}
-	if _, exists := changes.Old[key]; !exists {
+	if _, exists := changes.old[key]; !exists {
 		// Only insert the old entry if the entry was not first added on this round of
 		// changes.
 		if _, added := changes.Adds[key]; !added {
@@ -1263,7 +1263,7 @@ func (changes *ChangeState) insertOldIfNotExists(key Key, entry MapStateEntry) b
 			entry.owners = entry.owners.Clone()
 			entry.dependents = maps.Clone(entry.dependents)
 
-			changes.Old[key] = entry
+			changes.old[key] = entry
 			return true
 		}
 	}
@@ -1463,7 +1463,7 @@ func (mc *MapChanges) consumeMapChanges(p *EndpointPolicy, features policyFeatur
 	changes := ChangeState{
 		Adds:    make(Keys, len(mc.synced)),
 		Deletes: make(Keys, len(mc.synced)),
-		Old:     make(map[Key]MapStateEntry, len(mc.synced)),
+		old:     make(map[Key]MapStateEntry, len(mc.synced)),
 	}
 
 	for i := range mc.synced {

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -698,12 +698,13 @@ func (ms *mapState) AddDependent(owner Key, dependent Key, changes ChangeState) 
 	}
 }
 
-// addDependentOnEntry adds 'dependent' to the set of dependent keys of 'e'.
+// addDependentOnEntry adds 'dependent' to the set of dependent keys of 'e', where 'e' already
+// exists in 'ms'.
 func (ms *mapState) addDependentOnEntry(owner Key, e mapStateEntry, dependent Key, changes ChangeState) {
 	if _, exists := e.dependents[dependent]; !exists {
 		changes.insertOldIfNotExists(owner, e)
 		e.AddDependent(dependent)
-		ms.insert(owner, e)
+		ms.updateExisting(owner, e)
 	}
 }
 
@@ -870,7 +871,7 @@ func (ms *mapState) addKeyWithChanges(key Key, entry mapStateEntry, changes Chan
 		// place!
 		datapathEqual = oldEntry.MapStateEntry == entry.MapStateEntry
 		oldEntry.merge(&entry)
-		ms.insert(key, oldEntry)
+		ms.updateExisting(key, oldEntry)
 	} else if !exists || entry.IsDeny {
 		// Insert a new entry if one did not exist or a deny entry is overwriting an allow
 		// entry.

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1212,7 +1212,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		changes := ChangeState{
 			Adds:    make(Keys),
 			Deletes: make(Keys),
-			Old:     make(MapStateMap),
+			old:     make(MapStateMap),
 		}
 		// copy the starting point
 		ms := testMapState(make(MapStateMap, tt.ms.Len()))
@@ -1226,7 +1226,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		require.Truef(t, ms.DeepEquals(tt.want), "%s: MapState mismatch:\n%s", tt.name, ms.diff(tt.want))
 		require.EqualValuesf(t, tt.wantAdds, changes.Adds, "%s: Adds mismatch", tt.name)
 		require.EqualValuesf(t, tt.wantDeletes, changes.Deletes, "%s: Deletes mismatch", tt.name)
-		require.EqualValuesf(t, tt.wantOld, changes.Old, "%s: OldValues mismatch allows", tt.name)
+		require.EqualValuesf(t, tt.wantOld, changes.old, "%s: OldValues mismatch allows", tt.name)
 
 		// Revert changes and check that we get the original mapstate
 		ms.revertChanges(changes)

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -2129,10 +2129,6 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		insertAllowAll = action(1 << iota)
 		insertA
 		insertB
-		insertAWithBProto
-		insertAasB // Proto and entry from B
-		insertBWithAProto
-		insertBWithAProtoAsDeny
 		worldIPl3only        // Do not expect L4 keys for IP covered by a subnet
 		worldIPProtoOnly     // Do not expect port keys for IP covered by a subnet
 		worldSubnetl3only    // Do not expect L4 keys for IP subnet
@@ -2181,8 +2177,8 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		{"deny-allow: b superset a L3-only, b L3L4; IP allow not inserted", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 0, 80, 6, insertAllowAll | insertBoth | worldIPl3only},
 		{"deny-allow: b superset a L3-only, b L3L4; without allow-all, IP allow not inserted", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 0, 80, 6, insertBoth | worldIPl3only},
 
-		{"deny-allow: a superset a L4, b L3-only", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 6, 0, 0, insertAllowAll | insertBoth | insertBWithAProtoAsDeny},
-		{"deny-allow: a superset a L4, b L3-only; without allow-all", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 6, 0, 0, insertBoth | insertBWithAProtoAsDeny},
+		{"deny-allow: a superset a L4, b L3-only", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 6, 0, 0, insertAllowAll | insertBoth},
+		{"deny-allow: a superset a L4, b L3-only; without allow-all", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 0, 6, 0, 0, insertBoth},
 
 		{"deny-allow: b superset a L4, b L3-only", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 6, 0, 0, insertAllowAll | insertBoth},
 		{"deny-allow: b superset a L4, b L3-only; without allow-all", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 6, 0, 0, insertBoth},
@@ -2199,14 +2195,14 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		{"deny-allow: b superset a L4, b L3L4", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 6, 80, 6, insertAllowAll | insertBoth | worldIPProtoOnly},
 		{"deny-allow: b superset a L4, b L3L4; without allow-all", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 0, 6, 80, 6, insertBoth | worldIPProtoOnly},
 
-		{"deny-allow: a superset a L3L4, b L3-only", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 80, 6, 0, 0, insertAllowAll | insertBoth | insertBWithAProtoAsDeny},
-		{"deny-allow: a superset a L3L4, b L3-only; without allow-all", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 80, 6, 0, 0, insertBoth | insertBWithAProtoAsDeny},
+		{"deny-allow: a superset a L3L4, b L3-only", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 80, 6, 0, 0, insertAllowAll | insertBoth},
+		{"deny-allow: a superset a L3L4, b L3-only; without allow-all", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 80, 6, 0, 0, insertBoth},
 
 		{"deny-allow: b superset a L3L4, b L3-only", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 80, 6, 0, 0, insertAllowAll | insertBoth},
 		{"deny-allow: b superset a L3L4, b L3-only; without allow-all", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 80, 6, 0, 0, insertBoth},
 
-		{"deny-allow: a superset a L3L4, b L4", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 80, 6, 0, 6, insertAllowAll | insertBoth | insertBWithAProtoAsDeny},
-		{"deny-allow: a superset a L3L4, b L4; without allow-all", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 80, 6, 0, 6, insertBoth | insertBWithAProtoAsDeny},
+		{"deny-allow: a superset a L3L4, b L4", WithAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 80, 6, 0, 6, insertAllowAll | insertBoth},
+		{"deny-allow: a superset a L3L4, b L4; without allow-all", WithoutAllowAll, reservedWorldSelections, worldSubnetSelections, true, false, 80, 6, 0, 6, insertBoth},
 
 		{"deny-allow: b superset a L3L4, b L4", WithAllowAll, worldIPSelections, worldSubnetSelections, true, false, 80, 6, 0, 6, insertAllowAll | insertBoth},
 		{"deny-allow: b superset a L3L4, b L4 without allow-all", WithoutAllowAll, worldIPSelections, worldSubnetSelections, true, false, 80, 6, 0, 6, insertBoth},
@@ -2333,121 +2329,9 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 				expectedKeys.insert(bKey, bEntry)
 			}
 		}
-		if tt.outcome&insertAasB > 0 {
-			for _, bKey := range bKeys {
-				for _, idA := range tt.aIdentities {
-					if tt.outcome&worldIPl3only > 0 && idA == worldIPIdentity &&
-						(tt.bProto != 0 || tt.bPort != 0) {
-						continue
-					}
-					if tt.outcome&worldIPProtoOnly > 0 && idA == worldIPIdentity &&
-						(tt.bPort != 0) {
-						continue
-					}
-					if tt.outcome&worldSubnetl3only > 0 && idA == worldSubnetIdentity &&
-						(tt.bProto != 0 || tt.bPort != 0) {
-						continue
-					}
-					if tt.outcome&worldSubnetProtoOnly > 0 && idA == worldSubnetIdentity &&
-						(tt.bPort != 0) {
-						continue
-					}
-					aKeyWithBProto := IngressKey().WithIdentity(idA).WithPortProto(tt.bProto, tt.bPort)
-					bEntryWithOwner := bEntry.WithOwners(bKey)
-					bEntryWithDep := bEntry.WithDependents(aKeyWithBProto)
-
-					expectedKeys.insert(bKey, bEntryWithDep)
-					expectedKeys.insert(aKeyWithBProto, bEntryWithOwner)
-				}
-			}
-		}
-		if tt.outcome&insertBWithAProto > 0 {
-			for _, idB := range tt.bIdentities {
-				if tt.outcome&worldIPl3only > 0 && idB == worldIPIdentity &&
-					(tt.aProto != 0 || tt.aPort != 0) {
-					continue
-				}
-				if tt.outcome&worldIPProtoOnly > 0 && idB == worldIPIdentity &&
-					(tt.aPort != 0) {
-					continue
-				}
-				if tt.outcome&worldSubnetl3only > 0 && idB == worldSubnetIdentity &&
-					(tt.aProto != 0 || tt.aPort != 0) {
-					continue
-				}
-				if tt.outcome&worldSubnetProtoOnly > 0 && idB == worldSubnetIdentity &&
-					(tt.aPort != 0) {
-					continue
-				}
-				bKey := IngressKey().WithIdentity(idB).WithPortProto(tt.bProto, tt.bPort)
-				bKeyWithAProto := bKey.WithPortProto(tt.aProto, tt.aPort)
-				bEntryWithProto := bEntry.WithOwners(bKey)
-				bEntryWithDep := bEntry.WithDependents(bKeyWithAProto)
-
-				expectedKeys.insert(bKey, bEntryWithDep)
-				expectedKeys.insert(bKeyWithAProto, bEntryWithProto)
-			}
-		}
 		if tt.outcome&insertA > 0 {
 			for _, aKey := range aKeys {
 				expectedKeys.insert(aKey, aEntry)
-			}
-		}
-		if tt.outcome&insertAWithBProto > 0 {
-			for _, idA := range tt.aIdentities {
-				if tt.outcome&worldIPl3only > 0 && idA == worldIPIdentity &&
-					(tt.bProto != 0 || tt.bPort != 0) {
-					continue
-				}
-				if tt.outcome&worldIPProtoOnly > 0 && idA == worldIPIdentity &&
-					(tt.bPort != 0) {
-					continue
-				}
-				if tt.outcome&worldSubnetl3only > 0 && idA == worldSubnetIdentity &&
-					(tt.bProto != 0 || tt.bPort != 0) {
-					continue
-				}
-				if tt.outcome&worldSubnetProtoOnly > 0 && idA == worldSubnetIdentity &&
-					(tt.bPort != 0) {
-					continue
-				}
-				aKey := IngressKey().WithIdentity(idA).WithPortProto(tt.aProto, tt.aPort)
-				aKeyWithBProto := aKey.WithPortProto(tt.bProto, tt.bPort)
-				aEntryWithProto := aEntry.WithOwners(aKey)
-				aEntryWithDep := aEntry.WithDependents(aKeyWithBProto)
-
-				expectedKeys.insert(aKey, aEntryWithDep)
-				expectedKeys.insert(aKeyWithBProto, aEntryWithProto)
-			}
-		}
-		if tt.outcome&insertBWithAProtoAsDeny > 0 {
-			for _, aKey := range aKeys {
-				for _, idB := range tt.bIdentities {
-					if tt.outcome&worldIPl3only > 0 && idB == worldIPIdentity &&
-						(tt.aProto != 0 || tt.aPort != 0) {
-						continue
-					}
-					if tt.outcome&worldIPProtoOnly > 0 && idB == worldIPIdentity &&
-						(tt.aPort != 0) {
-						continue
-					}
-					if tt.outcome&worldSubnetl3only > 0 && idB == worldSubnetIdentity &&
-						(tt.aProto != 0 || tt.aPort != 0) {
-						continue
-					}
-					if tt.outcome&worldSubnetProtoOnly > 0 && idB == worldSubnetIdentity &&
-						(tt.aPort != 0) {
-						continue
-					}
-					bKey := IngressKey().WithIdentity(idB).WithPortProto(tt.bProto, tt.bPort)
-					bKeyWithAProto := bKey.WithPortProto(tt.aProto, tt.aPort)
-					bEntryAsDeny := bEntry.WithOwners(aKey).asDeny()
-					aEntryWithDep := aEntry
-
-					aEntryWithDep.AddDependent(bKeyWithAProto)
-					expectedKeys.insert(aKey, aEntryWithDep)
-					expectedKeys.insert(bKeyWithAProto, bEntryAsDeny)
-				}
 			}
 		}
 		if tt.outcome&insertDenyWorld > 0 {

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -112,22 +112,14 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 		{
 			name: "test-1 - no KV added, map should remain the same",
 			ms: testMapState(MapStateMap{
-				IngressKey(): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
-				},
+				IngressKey(): {},
 			}),
 			args: args{
 				key:   IngressKey(),
 				entry: MapStateEntry{},
 			},
 			want: testMapState(MapStateMap{
-				IngressKey(): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
-				},
+				IngressKey(): {},
 			}),
 			wantAdds:    Keys{},
 			wantDeletes: Keys{},
@@ -1352,14 +1344,14 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 
 		ms.denyPreferredInsertWithChanges(tt.args.key, tt.args.entry, denyRules, changes)
 		ms.validatePortProto(t)
-		require.Truef(t, ms.Equals(tt.want), "%s: MapState mismatch:\n%s", tt.name, ms.Diff(tt.want))
+		require.Truef(t, ms.DeepEquals(tt.want), "%s: MapState mismatch:\n%s", tt.name, ms.diff(tt.want))
 		require.EqualValuesf(t, tt.wantAdds, changes.Adds, "%s: Adds mismatch", tt.name)
 		require.EqualValuesf(t, tt.wantDeletes, changes.Deletes, "%s: Deletes mismatch", tt.name)
 		require.EqualValuesf(t, tt.wantOld, changes.Old, "%s: OldValues mismatch allows", tt.name)
 
 		// Revert changes and check that we get the original mapstate
 		ms.revertChanges(changes)
-		require.Truef(t, ms.Equals(tt.ms), "%s: MapState mismatch:\n%s", tt.name, ms.Diff(tt.ms))
+		require.Truef(t, ms.DeepEquals(tt.ms), "%s: MapState mismatch:\n%s", tt.name, ms.diff(tt.ms))
 	}
 }
 
@@ -1436,14 +1428,14 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		name      string
 		setup     *mapState
 		args      []args // changes applied, in order
-		state     MapState
+		state     *mapState
 		adds      Keys
 		deletes   Keys
 	}{{
 		name: "test-0 - Adding L4-only redirect allow key to an existing allow-all with L3-only deny",
 		setup: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():      allowEntry(0),
-			ingressL3OnlyKey(41): denyEntry(0),
+			ingressL3OnlyKey(41): denyEntry(0, csFoo),
 		}),
 		args: []args{
 			{cs: csFoo, adds: []int{0}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: true, deny: false},
@@ -1451,7 +1443,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 		state: testMapState(map[Key]MapStateEntry{
 			AnyIngressKey():      allowEntry(0),
 			ingressL3OnlyKey(41): denyEntry(0, csFoo).WithDependents(HttpIngressKey(41)),
-			HttpIngressKey(0):    allowEntry(1, nil),
+			HttpIngressKey(0):    allowEntry(1, csFoo),
 			HttpIngressKey(41):   denyEntry(0).WithOwners(ingressL3OnlyKey(41)),
 		}),
 		adds: Keys{
@@ -1784,7 +1776,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 			handle.Close()
 		}
 		policyMapState.validatePortProto(t)
-		require.True(t, policyMapState.Equals(tt.state), "%s (MapState):\n%s", tt.name, policyMapState.Diff(tt.state))
+		require.True(t, policyMapState.DeepEquals(tt.state), "%s (MapState):\n%s", tt.name, policyMapState.diff(tt.state))
 		require.EqualValues(t, tt.adds, changes.Adds, tt.name+" (adds)")
 		require.EqualValues(t, tt.deletes, changes.Deletes, tt.name+" (deletes)")
 	}
@@ -1905,7 +1897,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		continued bool // Start from the end state of the previous test
 		name      string
 		args      []args // changes applied, in order
-		state     MapState
+		state     *mapState
 		adds      Keys
 		deletes   Keys
 	}{{
@@ -2102,8 +2094,8 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{cs: csWildcard, adds: []int{0}, port: 80, proto: 6, redirect: true},
 		},
 		state: testMapState(MapStateMap{
-			egressKey(43, 0, 0, 0):  allowEntry(0, csFoo).WithAuthType(AuthTypeSpire),
-			egressKey(43, 6, 80, 0): allowEntry(1, csFoo).WithDefaultAuthType(AuthTypeSpire),
+			egressKey(43, 0, 0, 0):  allowEntry(0, csFoo).WithDependents(egressKey(43, 6, 80, 0)).WithAuthType(AuthTypeSpire),
+			egressKey(43, 6, 80, 0): allowEntry(1, csFoo).WithOwners(egressKey(43, 0, 0, 0)).WithDefaultAuthType(AuthTypeSpire),
 			egressKey(0, 6, 80, 0):  allowEntry(1, csWildcard),
 		}),
 		adds: Keys{
@@ -2120,8 +2112,8 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{cs: csFoo, adds: []int{43}, hasAuth: ExplicitAuthType, authType: AuthTypeSpire},
 		},
 		state: testMapState(MapStateMap{
-			egressKey(43, 0, 0, 0):  allowEntry(0, csFoo).WithAuthType(AuthTypeSpire),
-			egressKey(43, 6, 80, 0): allowEntry(1, csFoo).WithDefaultAuthType(AuthTypeSpire),
+			egressKey(43, 0, 0, 0):  allowEntry(0, csFoo).WithDependents(egressKey(43, 6, 80, 0)).WithAuthType(AuthTypeSpire),
+			egressKey(43, 6, 80, 0): allowEntry(1, csFoo).WithOwners(egressKey(43, 0, 0, 0)).WithDefaultAuthType(AuthTypeSpire),
 			egressKey(0, 6, 80, 0):  allowEntry(1, csWildcard),
 		}),
 		adds: Keys{
@@ -2138,8 +2130,8 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{cs: csWildcard, adds: []int{0}, port: 80, proto: 6, redirect: true},
 		},
 		state: testMapState(MapStateMap{
-			egressKey(43, 6, 0, 0):  allowEntry(0, csFoo).WithAuthType(AuthTypeSpire),
-			egressKey(43, 6, 80, 0): allowEntry(1, csFoo).WithDefaultAuthType(AuthTypeSpire),
+			egressKey(43, 6, 0, 0):  allowEntry(0, csFoo).WithDependents(egressKey(43, 6, 80, 0)).WithAuthType(AuthTypeSpire),
+			egressKey(43, 6, 80, 0): allowEntry(1, csFoo).WithOwners(egressKey(43, 6, 0, 0)).WithDefaultAuthType(AuthTypeSpire),
 			egressKey(0, 6, 80, 0):  allowEntry(1, csWildcard),
 		}),
 		adds: Keys{
@@ -2156,8 +2148,8 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{cs: csFoo, adds: []int{43}, proto: 6, hasAuth: ExplicitAuthType, authType: AuthTypeSpire},
 		},
 		state: testMapState(MapStateMap{
-			egressKey(43, 6, 0, 0):  allowEntry(0, csFoo).WithAuthType(AuthTypeSpire),
-			egressKey(43, 6, 80, 0): allowEntry(1, csFoo).WithDefaultAuthType(AuthTypeSpire),
+			egressKey(43, 6, 0, 0):  allowEntry(0, csFoo).WithDependents(egressKey(43, 6, 80, 0)).WithAuthType(AuthTypeSpire),
+			egressKey(43, 6, 80, 0): allowEntry(1, csFoo).WithOwners(egressKey(43, 6, 0, 0)).WithDefaultAuthType(AuthTypeSpire),
 			egressKey(0, 6, 80, 0):  allowEntry(1, csWildcard),
 		}),
 		adds: Keys{
@@ -2222,7 +2214,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			handle.Close()
 		}
 		policyMapState.validatePortProto(t)
-		require.True(t, policyMapState.Equals(tt.state), "%s (MapState):\n%s", tt.name, policyMapState.Diff(tt.state))
+		require.True(t, policyMapState.DeepEquals(tt.state), "%s (MapState):\n%s", tt.name, policyMapState.diff(tt.state))
 		require.EqualValues(t, tt.adds, changes.Adds, tt.name+" (adds)")
 		require.EqualValues(t, tt.deletes, changes.Deletes, tt.name+" (deletes)")
 	}

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1111,7 +1111,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				ingressKey(1, 3, 80, 0): {
 					ProxyPort: 8080,
 					priority:  8080,
-					Listener:  "listener1",
 				},
 			}),
 			args: args{
@@ -1119,14 +1118,12 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				entry: MapStateEntry{
 					ProxyPort: 9090,
 					priority:  1,
-					Listener:  "listener2",
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
 					ProxyPort: 9090,
 					priority:  1,
-					Listener:  "listener2",
 				},
 			}),
 			wantAdds: Keys{
@@ -1137,7 +1134,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				ingressKey(1, 3, 80, 0): {
 					ProxyPort: 8080,
 					priority:  8080,
-					Listener:  "listener1",
 				},
 			},
 		},
@@ -1147,7 +1143,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				ingressKey(1, 3, 64, 10): {
 					ProxyPort: 8080,
 					priority:  8080,
-					Listener:  "listener1",
 				},
 			}),
 			args: args{
@@ -1155,14 +1150,12 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				entry: MapStateEntry{
 					ProxyPort: 9090,
 					priority:  1,
-					Listener:  "listener2",
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressKey(1, 3, 64, 10): {
 					ProxyPort: 9090,
 					priority:  1,
-					Listener:  "listener2",
 				},
 			}),
 			wantAdds: Keys{
@@ -1173,7 +1166,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				ingressKey(1, 3, 64, 10): {
 					ProxyPort: 8080,
 					priority:  8080,
-					Listener:  "listener1",
 				},
 			},
 		},
@@ -1183,7 +1175,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				ingressKey(1, 3, 80, 0): {
 					ProxyPort: 8080,
 					priority:  8080,
-					Listener:  "listener1",
 				},
 			}),
 			args: args{
@@ -1191,14 +1182,12 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				entry: MapStateEntry{
 					ProxyPort: 8080,
 					priority:  1,
-					Listener:  "listener1",
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
 					ProxyPort: 8080,
 					priority:  1,
-					Listener:  "listener1",
 				},
 			}),
 			wantAdds:    Keys{},
@@ -1207,7 +1196,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				ingressKey(1, 3, 80, 0): {
 					ProxyPort: 8080,
 					priority:  8080,
-					Listener:  "listener1",
 				},
 			},
 		},
@@ -1217,7 +1205,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				ingressKey(1, 3, 64, 10): {
 					ProxyPort: 8080,
 					priority:  8080,
-					Listener:  "listener1",
 				},
 			}),
 			args: args{
@@ -1225,14 +1212,12 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				entry: MapStateEntry{
 					ProxyPort: 8080,
 					priority:  1,
-					Listener:  "listener1",
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressKey(1, 3, 64, 10): {
 					ProxyPort: 8080,
 					priority:  1,
-					Listener:  "listener1",
 				},
 			}),
 			wantAdds:    Keys{},
@@ -1241,7 +1226,6 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				ingressKey(1, 3, 64, 10): {
 					ProxyPort: 8080,
 					priority:  8080,
-					Listener:  "listener1",
 				},
 			},
 		},
@@ -1419,7 +1403,6 @@ func testEntry(proxyPort uint16, deny bool, authType AuthType, owners ...MapStat
 	return MapStateEntry{
 		ProxyPort: proxyPort,
 		priority:  proxyPort,
-		Listener:  "",
 		AuthType:  authType,
 		IsDeny:    deny,
 		owners:    set.NewSet(owners...),
@@ -1792,7 +1775,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 			if x.redirect {
 				proxyPort = 1
 			}
-			value := NewMapStateEntry(cs, nil, proxyPort, "", 0, x.deny, DefaultAuthType, AuthTypeDisabled)
+			value := NewMapStateEntry(cs, nil, proxyPort, 0, x.deny, DefaultAuthType, AuthTypeDisabled)
 			policyMaps.AccumulateMapChanges(cs, adds, deletes, []Key{key}, value)
 		}
 		policyMaps.SyncMapChanges(versioned.LatestTx)
@@ -2230,7 +2213,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			if x.redirect {
 				proxyPort = 1
 			}
-			value := NewMapStateEntry(cs, nil, proxyPort, "", 0, x.deny, x.hasAuth, x.authType)
+			value := NewMapStateEntry(cs, nil, proxyPort, 0, x.deny, x.hasAuth, x.authType)
 			policyMaps.AccumulateMapChanges(cs, adds, deletes, []Key{key}, value)
 		}
 		policyMaps.SyncMapChanges(versioned.LatestTx)
@@ -2249,7 +2232,6 @@ func (e MapStateEntry) asDeny() MapStateEntry {
 	if !e.IsDeny {
 		e.IsDeny = true
 		e.ProxyPort = 0
-		e.Listener = ""
 		e.priority = 0
 		e.hasAuthType = DefaultAuthType
 		e.AuthType = AuthTypeDisabled

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -128,29 +128,25 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-2a - L3 allow KV should not overwrite deny entry",
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			args: args{
 				key: ingressL3OnlyKey(1),
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds: Keys{
@@ -163,29 +159,25 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-2b - L3 port-range allow KV should not overwrite deny entry",
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			args: args{
 				key: ingressKey(1, 3, 64, 10), // port range 64-127 (64/10)
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds: Keys{
@@ -198,24 +190,21 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-3a - L3-L4 allow KV should not overwrite deny entry",
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			args: args{
 				key: ingressKey(1, 3, 80, 0),
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds:    Keys{},
@@ -226,24 +215,21 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-3b - L3-L4 port-range allow KV should not overwrite deny entry",
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			args: args{
 				key: ingressKey(1, 3, 64, 10), // port range 64-127 (64/10)
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds:    Keys{},
@@ -254,24 +240,21 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-4a - L3-L4 deny KV should overwrite allow entry",
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			}),
 			args: args{
 				key: ingressKey(1, 3, 80, 0),
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds: Keys{
@@ -280,9 +263,8 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			wantDeletes: Keys{},
 			wantOld: MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			},
 		},
@@ -290,24 +272,21 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-4b - L3-L4 port-range deny KV should overwrite allow entry",
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			}),
 			args: args{
 				key: ingressKey(1, 3, 64, 10), // port range 64-127 (64/10)
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds: Keys{
@@ -318,9 +297,8 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 			wantOld: MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			},
 		},
@@ -328,49 +306,41 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-5a - L3 deny KV should overwrite all L3-L4 allow and L3 allow entries for the same L3",
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressKey(2, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressL3OnlyKey(2): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			}),
 			args: args{
 				key: ingressL3OnlyKey(1),
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 				ingressKey(2, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressL3OnlyKey(2): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			}),
 			wantAdds: Keys{
@@ -381,14 +351,12 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 			wantOld: MapStateMap{
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			},
 		},
@@ -396,49 +364,41 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-5b - L3 port-range deny KV should overwrite all L3-L4 allow and L3 allow entries for the same L3",
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressKey(2, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressKey(2, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			}),
 			args: args{
 				key: ingressKey(1, 3, 64, 10), // port range 64-127 (64/10)
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 				ingressKey(2, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressKey(2, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			}),
 			wantAdds: Keys{
@@ -449,14 +409,12 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 			wantOld: MapStateMap{
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			},
 		},
@@ -464,59 +422,49 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-6a - L3 egress deny KV should not overwrite any existing ingress allow",
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressKey(2, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressL3OnlyKey(2): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			}),
 			args: args{
 				key: egressL3OnlyKey(1),
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				egressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 				ingressKey(2, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressL3OnlyKey(2): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			}),
 			wantAdds: Keys{
@@ -529,59 +477,49 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-6b - L3 egress port-range deny KV should not overwrite any existing ingress allow",
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressKey(2, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressKey(2, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			}),
 			args: args{
 				key: egressKey(1, 3, 64, 10), // port range 64-127 (64/10)
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				egressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 				ingressKey(2, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 				ingressKey(2, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			}),
 			wantAdds: Keys{
@@ -594,24 +532,21 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-7a - L3 ingress deny KV should not be overwritten by a L3-L4 ingress allow",
 			ms: testMapState(MapStateMap{
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			args: args{
 				key: ingressKey(1, 3, 80, 0),
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds:    Keys{},
@@ -622,24 +557,21 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-7b - L3 ingress deny KV should not be overwritten by a L3-L4 port-range ingress allow",
 			ms: testMapState(MapStateMap{
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			args: args{
 				key: ingressKey(1, 3, 64, 10), // port range 64-127 (64/10)
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds:    Keys{},
@@ -650,25 +582,22 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-8a - L3 ingress deny KV should not be overwritten by a L3-L4-L7 ingress allow",
 			ms: testMapState(MapStateMap{
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			args: args{
 				key: ingressKey(1, 3, 80, 0),
 				entry: MapStateEntry{
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds:    Keys{},
@@ -679,25 +608,22 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-8b - L3 ingress deny KV should not be overwritten by a L3-L4-L7 port-range ingress allow",
 			ms: testMapState(MapStateMap{
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			args: args{
 				key: ingressKey(1, 3, 64, 10), // port range 64-127 (64/10)
 				entry: MapStateEntry{
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds:    Keys{},
@@ -708,25 +634,22 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-9a - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow",
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 			}),
 			args: args{
 				key: ingressL3OnlyKey(1),
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds: Keys{
@@ -737,10 +660,9 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 			wantOld: MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 			},
 		},
@@ -748,25 +670,22 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-9b - L3 ingress deny KV should overwrite a L3-L4-L7 port-range ingress allow",
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 			}),
 			args: args{
 				key: ingressL3OnlyKey(1),
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds: Keys{
@@ -777,10 +696,9 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 			wantOld: MapStateMap{
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 			},
 		},
@@ -788,30 +706,26 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-10a - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow and a L3-L4 deny",
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			args: args{
 				key: ingressL3OnlyKey(1),
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds: Keys{
@@ -823,15 +737,13 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 			wantOld: MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			},
 		},
@@ -839,30 +751,26 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-10b - L3 ingress deny KV should overwrite a L3-L4-L7 port-range ingress allow and a L3-L4 port-range deny",
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			args: args{
 				key: ingressL3OnlyKey(1),
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressL3OnlyKey(1): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds: Keys{
@@ -874,15 +782,13 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 			wantOld: MapStateMap{
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			},
 		},
@@ -890,36 +796,31 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-11a - L3 ingress allow should not be allowed if there is a L3 'all' deny",
 			ms: testMapState(MapStateMap{
 				egressKey(1, 3, 80, 0): {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 				IngressKey(): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			args: args{
 				key: ingressL3OnlyKey(100),
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			},
 			want: testMapState(MapStateMap{
 				egressKey(1, 3, 80, 0): {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 				IngressKey(): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds:    Keys{},
@@ -930,36 +831,31 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-11b - L3 ingress allow should not be allowed if there is a L3 'all' deny",
 			ms: testMapState(MapStateMap{
 				egressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 				IngressKey(): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			args: args{
 				key: ingressKey(100, 0, 0, 0),
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 0,
+					IsDeny:    false,
 				},
 			},
 			want: testMapState(MapStateMap{
 				egressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 				IngressKey(): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds:    Keys{},
@@ -970,43 +866,37 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-12a - inserting a L3 'all' deny should delete all entries for that direction",
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 				ingressKey(1, 3, 5, 0): {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 				egressKey(100, 3, 5, 0): {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    true,
 				},
 			}),
 			args: args{
 				key: IngressKey(),
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			},
 			want: testMapState(MapStateMap{
 				IngressKey(): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 				egressKey(100, 3, 5, 0): {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds: Keys{
@@ -1018,16 +908,14 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 			wantOld: MapStateMap{
 				ingressKey(1, 3, 80, 0): {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 				ingressKey(1, 3, 5, 0): {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 			},
 		},
@@ -1035,43 +923,37 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			name: "test-12b - inserting a L3 'all' deny should delete all entries for that direction (including port ranges)",
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 				ingressKey(1, 3, 4, 14): {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 				egressKey(100, 3, 4, 14): {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    true,
 				},
 			}),
 			args: args{
 				key: IngressKey(),
 				entry: MapStateEntry{
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 			},
 			want: testMapState(MapStateMap{
 				IngressKey(): {
-					ProxyPort:        0,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 0,
+					IsDeny:    true,
 				},
 				egressKey(100, 3, 4, 14): {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           true,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    true,
 				},
 			}),
 			wantAdds: Keys{
@@ -1083,16 +965,14 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 			wantOld: MapStateMap{
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 				ingressKey(1, 3, 4, 14): {
-					ProxyPort:        8080,
-					priority:         8080,
-					DerivedFromRules: nil,
-					IsDeny:           false,
+					ProxyPort: 8080,
+					priority:  8080,
+					IsDeny:    false,
 				},
 			},
 		},
@@ -1225,7 +1105,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			ms: testMapState(MapStateMap{
 				ingressKey(0, 3, 80, 0): {
 					ProxyPort:        0,
-					DerivedFromRules: nil,
+					derivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
@@ -1233,19 +1113,19 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: ingressKey(1, 3, 64, 10), // port range 64-127 (64/10)
 				entry: MapStateEntry{
 					ProxyPort:        0,
-					DerivedFromRules: nil,
+					derivedFromRules: nil,
 					IsDeny:           false,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
-					DerivedFromRules: nil,
+					derivedFromRules: nil,
 					IsDeny:           false,
 				},
 				ingressKey(0, 3, 80, 0): {
 					ProxyPort:        0,
-					DerivedFromRules: nil,
+					derivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
@@ -1260,7 +1140,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			ms: testMapState(MapStateMap{
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
-					DerivedFromRules: nil,
+					derivedFromRules: nil,
 					IsDeny:           false,
 				},
 			}),
@@ -1268,19 +1148,19 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: ingressKey(0, 3, 80, 0),
 				entry: MapStateEntry{
 					ProxyPort:        0,
-					DerivedFromRules: nil,
+					derivedFromRules: nil,
 					IsDeny:           true,
 				},
 			},
 			want: testMapState(MapStateMap{
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
-					DerivedFromRules: nil,
+					derivedFromRules: nil,
 					IsDeny:           false,
 				},
 				ingressKey(0, 3, 80, 0): {
 					ProxyPort:        0,
-					DerivedFromRules: nil,
+					derivedFromRules: nil,
 					IsDeny:           true,
 				},
 			}),
@@ -1296,7 +1176,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				ingressKey(0, 3, 80, 0): {
 					ProxyPort:        8080,
 					priority:         8080,
-					DerivedFromRules: nil,
+					derivedFromRules: nil,
 					IsDeny:           false,
 				},
 			}),
@@ -1304,7 +1184,7 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				key: ingressKey(1, 3, 64, 10), // port range 64-127 (64/10)
 				entry: MapStateEntry{
 					ProxyPort:        0,
-					DerivedFromRules: nil,
+					derivedFromRules: nil,
 					IsDeny:           false,
 				},
 			},
@@ -1312,12 +1192,12 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 				ingressKey(0, 3, 80, 0): {
 					ProxyPort:        8080,
 					priority:         8080,
-					DerivedFromRules: nil,
+					derivedFromRules: nil,
 					IsDeny:           false,
 				},
 				ingressKey(1, 3, 64, 10): { // port range 64-127 (64/10)
 					ProxyPort:        0,
-					DerivedFromRules: nil,
+					derivedFromRules: nil,
 					IsDeny:           false,
 				},
 			}),
@@ -2600,7 +2480,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 		}
 		outcomeKeys.validatePortProto(t)
 
-		require.True(t, expectedKeys.Equals(outcomeKeys), "%s (MapState):\n%s", tt.name, outcomeKeys.Diff(expectedKeys))
+		require.True(t, expectedKeys.equalsWithLabels(outcomeKeys), "%s (MapState):\n%s", tt.name, outcomeKeys.diff(expectedKeys))
 
 		// Test also with reverse insertion order
 		outcomeKeys = newMapState()
@@ -2617,7 +2497,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 			outcomeKeys.denyPreferredInsert(anyIngressKey, allowEntry, allFeatures)
 		}
 		outcomeKeys.validatePortProto(t)
-		require.True(t, expectedKeys.Equals(outcomeKeys), "%s (in reverse) (MapState):\n%s", tt.name, outcomeKeys.Diff(expectedKeys))
+		require.True(t, expectedKeys.equalsWithLabels(outcomeKeys), "%s (in reverse) (MapState):\n%s", tt.name, outcomeKeys.diff(expectedKeys))
 	}
 	// Now test all cases with different traffic directions.
 	// This should result in both entries being inserted with
@@ -2661,7 +2541,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 			outcomeKeys.denyPreferredInsert(bKey, bEntry, allFeatures)
 		}
 		outcomeKeys.validatePortProto(t)
-		require.True(t, expectedKeys.Equals(outcomeKeys), "%s different traffic directions (MapState):\n%s", tt.name, outcomeKeys.Diff(expectedKeys))
+		require.True(t, expectedKeys.equalsWithLabels(outcomeKeys), "%s different traffic directions (MapState):\n%s", tt.name, outcomeKeys.diff(expectedKeys))
 
 		// Test also with reverse insertion order
 		outcomeKeys = newMapState()
@@ -2677,7 +2557,7 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 			outcomeKeys.denyPreferredInsert(anyIngressKey, allowEntry, allFeatures)
 		}
 		outcomeKeys.validatePortProto(t)
-		require.True(t, expectedKeys.Equals(outcomeKeys), "%s different traffic directions (in reverse) (MapState):\n%s", tt.name, outcomeKeys.Diff(expectedKeys))
+		require.True(t, expectedKeys.equalsWithLabels(outcomeKeys), "%s different traffic directions (in reverse) (MapState):\n%s", tt.name, outcomeKeys.diff(expectedKeys))
 	}
 }
 

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -4,7 +4,6 @@
 package policy
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -2183,6 +2182,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 	policyMapState := newMapState()
 
 	for _, tt := range tests {
+		t.Log(tt.name)
 		policyMaps := MapChanges{}
 		if !tt.continued {
 			policyMapState = newMapState()
@@ -2599,17 +2599,6 @@ func TestMapState_denyPreferredInsertWithSubnets(t *testing.T) {
 			outcomeKeys.denyPreferredInsert(bKey, bEntry, allFeatures)
 		}
 		outcomeKeys.validatePortProto(t)
-		if !expectedKeys.Equals(outcomeKeys) {
-			fmt.Println("OUTCOME KEYS:")
-			fmt.Println("DENIES:")
-			for k, v := range outcomeKeys.denies.entries {
-				fmt.Printf("%v: %v\n", k, v)
-			}
-			fmt.Println("ALLOWS:")
-			for k, v := range outcomeKeys.allows.entries {
-				fmt.Printf("%v: %v\n", k, v)
-			}
-		}
 
 		require.True(t, expectedKeys.Equals(outcomeKeys), "%s (MapState):\n%s", tt.name, outcomeKeys.Diff(expectedKeys))
 

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -286,8 +286,8 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
+	require.Truef(t, policy.policyMapState.equalsWithLabels(expectedEndpointPolicy.policyMapState),
+		policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, &expectedEndpointPolicy, policy)
@@ -382,8 +382,8 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
+	require.Truef(t, policy.policyMapState.equalsWithLabels(expectedEndpointPolicy.policyMapState),
+		policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, &expectedEndpointPolicy, policy)
@@ -492,8 +492,8 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
+	require.Truef(t, policy.policyMapState.equalsWithLabels(expectedEndpointPolicy.policyMapState),
+		policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, &expectedEndpointPolicy, policy)
@@ -666,8 +666,8 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
+	require.Truef(t, policy.policyMapState.equalsWithLabels(expectedEndpointPolicy.policyMapState),
+		policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, &expectedEndpointPolicy, policy)

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -193,7 +193,7 @@ func BenchmarkRegenerateCIDRDenyPolicyRules(b *testing.B) {
 		epPolicy.Ready()
 	}
 	ip.Detach()
-	fmt.Printf("Number of MapState entries: %d\n", n/b.N)
+	b.Logf("Number of MapState entries: %d\n", n/b.N)
 }
 
 func TestRegenerateCIDRDenyPolicyRules(t *testing.T) {

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -434,8 +434,8 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	policy := selPolicy.DistillPolicy(DummyOwner{}, nil, false)
 	policy.Ready()
 
-	rule1MapStateEntry := NewMapStateEntry(td.wildcardCachedSelector, labels.LabelArrayList{ruleLabel}, 0, "", 0, true, DefaultAuthType, AuthTypeDisabled)
-	allowEgressMapStateEntry := NewMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, "", 0, false, ExplicitAuthType, AuthTypeDisabled)
+	rule1MapStateEntry := NewMapStateEntry(td.wildcardCachedSelector, labels.LabelArrayList{ruleLabel}, 0, 0, true, DefaultAuthType, AuthTypeDisabled)
+	allowEgressMapStateEntry := NewMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, 0, false, ExplicitAuthType, AuthTypeDisabled)
 
 	expectedEndpointPolicy := EndpointPolicy{
 		selectorPolicy: &selectorPolicy{
@@ -592,8 +592,8 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	cachedSelectorTest := td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
 	require.NotNil(t, cachedSelectorTest)
 
-	rule1MapStateEntry := NewMapStateEntry(cachedSelectorTest, labels.LabelArrayList{ruleLabel}, 0, "", 0, true, DefaultAuthType, AuthTypeDisabled)
-	allowEgressMapStateEntry := NewMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, "", 0, false, ExplicitAuthType, AuthTypeDisabled)
+	rule1MapStateEntry := NewMapStateEntry(cachedSelectorTest, labels.LabelArrayList{ruleLabel}, 0, 0, true, DefaultAuthType, AuthTypeDisabled)
+	allowEgressMapStateEntry := NewMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, 0, false, ExplicitAuthType, AuthTypeDisabled)
 
 	expectedEndpointPolicy := EndpointPolicy{
 		selectorPolicy: &selectorPolicy{

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -286,8 +286,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.equalsWithLabels(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
+	require.Truef(t, policy.policyMapState.deepEquals(expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, &expectedEndpointPolicy, policy)
@@ -382,8 +381,7 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.equalsWithLabels(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
+	require.Truef(t, policy.policyMapState.deepEquals(expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, &expectedEndpointPolicy, policy)
@@ -434,8 +432,8 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	policy := selPolicy.DistillPolicy(DummyOwner{}, nil, false)
 	policy.Ready()
 
-	rule1MapStateEntry := NewMapStateEntry(td.wildcardCachedSelector, labels.LabelArrayList{ruleLabel}, 0, 0, true, DefaultAuthType, AuthTypeDisabled)
-	allowEgressMapStateEntry := NewMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, 0, false, ExplicitAuthType, AuthTypeDisabled)
+	rule1MapStateEntry := newMapStateEntry(td.wildcardCachedSelector, labels.LabelArrayList{ruleLabel}, 0, 0, true, DefaultAuthType, AuthTypeDisabled)
+	allowEgressMapStateEntry := newMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, 0, false, ExplicitAuthType, AuthTypeDisabled)
 
 	expectedEndpointPolicy := EndpointPolicy{
 		selectorPolicy: &selectorPolicy{
@@ -464,7 +462,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 			IngressPolicyEnabled: true,
 		},
 		PolicyOwner: DummyOwner{},
-		policyMapState: newMapState().withState(MapStateMap{
+		policyMapState: newMapState().withState(map[Key]mapStateEntry{
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
 			EgressKey():                  allowEgressMapStateEntry,
@@ -492,8 +490,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.equalsWithLabels(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
+	require.Truef(t, policy.policyMapState.deepEquals(expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, &expectedEndpointPolicy, policy)
@@ -592,8 +589,8 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	cachedSelectorTest := td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
 	require.NotNil(t, cachedSelectorTest)
 
-	rule1MapStateEntry := NewMapStateEntry(cachedSelectorTest, labels.LabelArrayList{ruleLabel}, 0, 0, true, DefaultAuthType, AuthTypeDisabled)
-	allowEgressMapStateEntry := NewMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, 0, false, ExplicitAuthType, AuthTypeDisabled)
+	rule1MapStateEntry := newMapStateEntry(cachedSelectorTest, labels.LabelArrayList{ruleLabel}, 0, 0, true, DefaultAuthType, AuthTypeDisabled)
+	allowEgressMapStateEntry := newMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, 0, false, ExplicitAuthType, AuthTypeDisabled)
 
 	expectedEndpointPolicy := EndpointPolicy{
 		selectorPolicy: &selectorPolicy{
@@ -629,7 +626,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 			IngressPolicyEnabled: true,
 		},
 		PolicyOwner: DummyOwner{},
-		policyMapState: newMapState().withState(MapStateMap{
+		policyMapState: newMapState().withState(map[Key]mapStateEntry{
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
 			EgressKey(): allowEgressMapStateEntry,
@@ -666,8 +663,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.equalsWithLabels(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
+	require.Truef(t, policy.policyMapState.deepEquals(expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, &expectedEndpointPolicy, policy)

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -343,8 +343,8 @@ func TestL7WithIngressWildcard(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
+	require.Truef(t, policy.policyMapState.equalsWithLabels(expectedEndpointPolicy.policyMapState),
+		policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, &expectedEndpointPolicy, policy)
@@ -455,8 +455,8 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
+	require.Truef(t, policy.policyMapState.equalsWithLabels(expectedEndpointPolicy.policyMapState),
+		policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, &expectedEndpointPolicy, policy)
@@ -563,8 +563,8 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
+	require.Truef(t, policy.policyMapState.equalsWithLabels(expectedEndpointPolicy.policyMapState),
+		policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, &expectedEndpointPolicy, policy)
@@ -750,8 +750,8 @@ func TestMapStateWithIngress(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.Equals(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.Diff(expectedEndpointPolicy.policyMapState))
+	require.Truef(t, policy.policyMapState.equalsWithLabels(expectedEndpointPolicy.policyMapState),
+		policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -509,8 +509,8 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 	policy := selPolicy.DistillPolicy(DummyOwner{}, testRedirects, false)
 	policy.Ready()
 
-	rule1MapStateEntry := NewMapStateEntry(td.wildcardCachedSelector, labels.LabelArrayList{ruleLabel}, 0, "", 0, false, DefaultAuthType, AuthTypeDisabled)
-	allowEgressMapStateEntry := NewMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, "", 0, false, ExplicitAuthType, AuthTypeDisabled)
+	rule1MapStateEntry := NewMapStateEntry(td.wildcardCachedSelector, labels.LabelArrayList{ruleLabel}, 0, 0, false, DefaultAuthType, AuthTypeDisabled)
+	allowEgressMapStateEntry := NewMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, 0, false, ExplicitAuthType, AuthTypeDisabled)
 
 	expectedEndpointPolicy := EndpointPolicy{
 		Redirects: testRedirects,
@@ -669,8 +669,8 @@ func TestMapStateWithIngress(t *testing.T) {
 	cachedSelectorTest := td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
 	require.NotNil(t, cachedSelectorTest)
 
-	rule1MapStateEntry := NewMapStateEntry(cachedSelectorTest, labels.LabelArrayList{ruleLabel}, 0, "", 0, false, DefaultAuthType, AuthTypeDisabled)
-	allowEgressMapStateEntry := NewMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, "", 0, false, ExplicitAuthType, AuthTypeDisabled)
+	rule1MapStateEntry := NewMapStateEntry(cachedSelectorTest, labels.LabelArrayList{ruleLabel}, 0, 0, false, DefaultAuthType, AuthTypeDisabled)
+	allowEgressMapStateEntry := NewMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, 0, false, ExplicitAuthType, AuthTypeDisabled)
 
 	expectedEndpointPolicy := EndpointPolicy{
 		Redirects: testRedirects,

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -343,8 +343,7 @@ func TestL7WithIngressWildcard(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.equalsWithLabels(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
+	require.Truef(t, policy.policyMapState.deepEquals(expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, &expectedEndpointPolicy, policy)
@@ -455,8 +454,7 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.equalsWithLabels(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
+	require.Truef(t, policy.policyMapState.deepEquals(expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, &expectedEndpointPolicy, policy)
@@ -509,8 +507,8 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 	policy := selPolicy.DistillPolicy(DummyOwner{}, testRedirects, false)
 	policy.Ready()
 
-	rule1MapStateEntry := NewMapStateEntry(td.wildcardCachedSelector, labels.LabelArrayList{ruleLabel}, 0, 0, false, DefaultAuthType, AuthTypeDisabled)
-	allowEgressMapStateEntry := NewMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, 0, false, ExplicitAuthType, AuthTypeDisabled)
+	rule1MapStateEntry := newMapStateEntry(td.wildcardCachedSelector, labels.LabelArrayList{ruleLabel}, 0, 0, false, DefaultAuthType, AuthTypeDisabled)
+	allowEgressMapStateEntry := newMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, 0, false, ExplicitAuthType, AuthTypeDisabled)
 
 	expectedEndpointPolicy := EndpointPolicy{
 		Redirects: testRedirects,
@@ -539,7 +537,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 			EgressPolicyEnabled:  false,
 		},
 		PolicyOwner: DummyOwner{},
-		policyMapState: newMapState().withState(MapStateMap{
+		policyMapState: newMapState().withState(map[Key]mapStateEntry{
 			EgressKey():                  allowEgressMapStateEntry,
 			IngressKey().WithTCPPort(80): rule1MapStateEntry,
 		}),
@@ -563,8 +561,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.equalsWithLabels(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
+	require.Truef(t, policy.policyMapState.deepEquals(expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.Equal(t, &expectedEndpointPolicy, policy)
@@ -669,8 +666,8 @@ func TestMapStateWithIngress(t *testing.T) {
 	cachedSelectorTest := td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
 	require.NotNil(t, cachedSelectorTest)
 
-	rule1MapStateEntry := NewMapStateEntry(cachedSelectorTest, labels.LabelArrayList{ruleLabel}, 0, 0, false, DefaultAuthType, AuthTypeDisabled)
-	allowEgressMapStateEntry := NewMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, 0, false, ExplicitAuthType, AuthTypeDisabled)
+	rule1MapStateEntry := newMapStateEntry(cachedSelectorTest, labels.LabelArrayList{ruleLabel}, 0, 0, false, DefaultAuthType, AuthTypeDisabled)
+	allowEgressMapStateEntry := newMapStateEntry(nil, labels.LabelArrayList{ruleLabelAllowAnyEgress}, 0, 0, false, ExplicitAuthType, AuthTypeDisabled)
 
 	expectedEndpointPolicy := EndpointPolicy{
 		Redirects: testRedirects,
@@ -713,7 +710,7 @@ func TestMapStateWithIngress(t *testing.T) {
 			EgressPolicyEnabled:  false,
 		},
 		PolicyOwner: DummyOwner{},
-		policyMapState: newMapState().withState(MapStateMap{
+		policyMapState: newMapState().withState(map[Key]mapStateEntry{
 			EgressKey(): allowEgressMapStateEntry,
 			IngressKey().WithIdentity(identity.ReservedIdentityWorld).WithTCPPort(80):     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
 			IngressKey().WithIdentity(identity.ReservedIdentityWorldIPv4).WithTCPPort(80): rule1MapStateEntry.WithOwners(cachedSelectorWorld, cachedSelectorWorldV4),
@@ -750,8 +747,7 @@ func TestMapStateWithIngress(t *testing.T) {
 	policy.policyMapChanges.mutex = lock.Mutex{}
 	policy.policyMapChanges.firstVersion = 0
 	// policyMapState cannot be compared via DeepEqual
-	require.Truef(t, policy.policyMapState.equalsWithLabels(expectedEndpointPolicy.policyMapState),
-		policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
+	require.Truef(t, policy.policyMapState.deepEquals(expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(expectedEndpointPolicy.policyMapState))
 	policy.policyMapState = nil
 	expectedEndpointPolicy.policyMapState = nil
 	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
@@ -836,7 +832,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: newMapState().withState(MapStateMap{
+				PolicyMapState: newMapState().withState(map[Key]mapStateEntry{
 					IngressKey(): {},
 				}),
 			},
@@ -853,7 +849,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: newMapState().withState(MapStateMap{
+				PolicyMapState: newMapState().withState(map[Key]mapStateEntry{
 					EgressKey(): {},
 				}),
 			},
@@ -870,8 +866,8 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: newMapState().withState(MapStateMap{
-					IngressKey(): {IsDeny: true},
+				PolicyMapState: newMapState().withState(map[Key]mapStateEntry{
+					IngressKey(): {MapStateEntry: MapStateEntry{IsDeny: true}},
 				}),
 			},
 			args: args{
@@ -887,8 +883,8 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: false,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: newMapState().withState(MapStateMap{
-					IngressKey(): {IsDeny: true},
+				PolicyMapState: newMapState().withState(map[Key]mapStateEntry{
+					IngressKey(): {MapStateEntry: MapStateEntry{IsDeny: true}},
 				}),
 			},
 			args: args{
@@ -904,8 +900,8 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: newMapState().withState(MapStateMap{
-					EgressKey(): {IsDeny: true},
+				PolicyMapState: newMapState().withState(map[Key]mapStateEntry{
+					EgressKey(): {MapStateEntry: MapStateEntry{IsDeny: true}},
 				}),
 			},
 			args: args{
@@ -921,8 +917,8 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  false,
 				},
-				PolicyMapState: newMapState().withState(MapStateMap{
-					EgressKey(): {IsDeny: true},
+				PolicyMapState: newMapState().withState(map[Key]mapStateEntry{
+					EgressKey(): {MapStateEntry: MapStateEntry{IsDeny: true}},
 				}),
 			},
 			args: args{

--- a/pkg/policy/types/types.go
+++ b/pkg/policy/types/types.go
@@ -132,6 +132,8 @@ func (k Key) WithIdentity(nid identity.NumericIdentity) Key {
 
 // TrafficDirection() returns the direction of the Key, 0 == ingress, 1 == egress
 func (k LPMKey) TrafficDirection() trafficdirection.TrafficDirection {
+	// Note that 0 and 1 are the only possible return values, the shift below reduces the byte
+	// to a single bit.
 	return trafficdirection.TrafficDirection(k.bits >> directionBitShift)
 }
 


### PR DESCRIPTION
Fixes due to redirects being now created before mapstate is computed:
- Remove listener from MapStateEntry, was only needed to generate proxyID for proxy port retrieval. Now proxy port is already available before MapStateEntries are created, so the listener name is no longer needed
- Remove placeholder 'unrealizedRedirectPort', which was only needed when new redirects were created after mapstate had already been computed

Fixes: #35350

Save the old entry value when overridden by deny. MapStateEntry merge logic was simplified by only calling merge() if both entries are allows or denies. Now the caller overrides an allow with deny by overwriting it, but that branch missed the storing of the old value.

Fixes: #34437

Keep policy MapState internals private to the policy package. Replace the `MapState` interface with a limited set of accessor functions on `EndpointPolicy`. This way the endpoint does need direct access to the MapState map with the policy package internal bookkeeping.

Do not update the realized policy from the endpoint package when applying map changes to bpf policy maps. This is possible since the realized policy is either the same as the desired policy (when applying incremental changes) or the pending desired policy from which the changes are being applied is going to replace the old realized policy when the endpoint regeneration succeeds. If the endpoint regeneration fails, we also need to have the prior realized policy intact as the "last known good policy" which can be restored against a fresh dump of the policy map.

This also fixes the problem where MapStateEntries inserted from the endpoint package were missing the internal bookkeeping, like "owners", "derivedFromRules", etc.

Simplify `denyPreferredInsertWithChanges` by updating mapstate directly when iterating and simplify insertion of dependent keys with helpers and by using normal `if/else` structure.

Removal of the `Listener` field together with structural changes to keep mapstate internals private speed up `BenchmarkRegenerateCIDRDenyPolicyRules` by ~17% (~25% less memory used with ~12% less allocations)