### PR TITLE
Refactor endpoint and policy packages to separate test code from production code

### DIFF
--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -215,7 +215,7 @@ func (ds *DaemonSuite) prepareEndpoint(t *testing.T, identity *identity.Identity
 	if qa {
 		testEndpointID = testQAEndpointID
 	}
-	e := endpoint.NewTestEndpointWithState(t, ds.d, ds.d, testipcache.NewMockIPCache(), ds.d.l7Proxy, ds.d.identityAllocator, testEndpointID, endpoint.StateWaitingForIdentity)
+	e := endpoint.NewTestEndpointWithState(ds.d, ds.d, testipcache.NewMockIPCache(), ds.d.l7Proxy, ds.d.identityAllocator, testEndpointID, endpoint.StateWaitingForIdentity)
 	e.SetPropertyValue(endpoint.PropertyFakeEndpoint, false)
 	e.SetPropertyValue(endpoint.PropertyWithouteBPFDatapath, true)
 	e.SetPropertyValue(endpoint.PropertySkipBPFPolicy, true)

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -21,7 +21,7 @@ import (
 func TestWriteInformationalComments(t *testing.T) {
 	s := setupEndpointSuite(t)
 
-	e := NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
+	e := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
 
 	var f bytes.Buffer
 	err := e.writeInformationalComments(&f)
@@ -35,7 +35,7 @@ func BenchmarkWriteHeaderfile(b *testing.B) {
 
 	s := setupEndpointSuite(b)
 
-	e := NewTestEndpointWithState(b, s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
+	e := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
 	configWriter := &config.HeaderfileWriter{}
 	cfg := datapath.LocalNodeConfiguration{}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -15,7 +15,6 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-	"testing"
 
 	"github.com/cilium/hive/cell"
 	"github.com/sirupsen/logrus"
@@ -544,7 +543,7 @@ func (e *Endpoint) waitForProxyCompletions(proxyWaitGroup *completion.WaitGroup)
 }
 
 // NewTestEndpointWithState creates a new endpoint useful for testing purposes
-func NewTestEndpointWithState(_ testing.TB, owner regeneration.Owner, policyGetter policyRepoGetter, namedPortsGetter namedPortsGetter, proxy EndpointProxy, allocator cache.IdentityAllocator, ID uint16, state State) *Endpoint {
+func NewTestEndpointWithState(owner regeneration.Owner, policyGetter policyRepoGetter, namedPortsGetter namedPortsGetter, proxy EndpointProxy, allocator cache.IdentityAllocator, ID uint16, state State) *Endpoint {
 	endpointQueueName := "endpoint-" + strconv.FormatUint(uint64(ID), 10)
 	ep := createEndpoint(owner, policyGetter, namedPortsGetter, proxy, allocator, ID, "")
 	ep.SetPropertyValue(PropertyFakeEndpoint, true)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -543,6 +543,8 @@ func (e *Endpoint) waitForProxyCompletions(proxyWaitGroup *completion.WaitGroup)
 }
 
 // NewTestEndpointWithState creates a new endpoint useful for testing purposes
+//
+// Note: This function is intended for testing purposes only and should not be used in production code.
 func NewTestEndpointWithState(owner regeneration.Owner, policyGetter policyRepoGetter, namedPortsGetter namedPortsGetter, proxy EndpointProxy, allocator cache.IdentityAllocator, ID uint16, state State) *Endpoint {
 	endpointQueueName := "endpoint-" + strconv.FormatUint(uint64(ID), 10)
 	ep := createEndpoint(owner, policyGetter, namedPortsGetter, proxy, allocator, ID, "")

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -256,7 +256,7 @@ func TestEndpointDatapathOptions(t *testing.T) {
 func TestEndpointUpdateLabels(t *testing.T) {
 	s := setupEndpointSuite(t)
 
-	e := NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
+	e := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
 
 	// Test that inserting identity labels works
 	rev := e.replaceIdentityLabels(labels.LabelSourceAny, labels.Map2Labels(map[string]string{"foo": "bar", "zip": "zop"}, "cilium"))
@@ -297,7 +297,7 @@ func TestEndpointUpdateLabels(t *testing.T) {
 func TestEndpointState(t *testing.T) {
 	s := setupEndpointSuite(t)
 
-	e := NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
+	e := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
 	e.unconditionalLock()
 	defer e.unlock()
 
@@ -688,7 +688,7 @@ func TestEndpointEventQueueDeadlockUponStop(t *testing.T) {
 		option.Config.EndpointQueueSize = oldQueueSize
 	}()
 
-	ep := NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+	ep := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 
 	ep.properties[PropertyFakeEndpoint] = true
 	ep.properties[PropertySkipBPFPolicy] = true
@@ -764,7 +764,7 @@ func TestEndpointEventQueueDeadlockUponStop(t *testing.T) {
 func BenchmarkEndpointGetModel(b *testing.B) {
 	s := setupEndpointSuite(b)
 
-	e := NewTestEndpointWithState(b, s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 123, StateWaitingForIdentity)
+	e := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 123, StateWaitingForIdentity)
 
 	for i := 0; i < 256; i++ {
 		e.LogStatusOK(BPF, "Hello World!")

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -24,7 +24,7 @@ func TestEndpointLogFormat(t *testing.T) {
 
 	// Default log format is text
 	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
-	ep := NewTestEndpointWithState(t, do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+	ep := NewTestEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 
 	_, ok := ep.getLogger().Logger.Formatter.(*logrus.TextFormatter)
 	require.True(t, ok)
@@ -35,7 +35,7 @@ func TestEndpointLogFormat(t *testing.T) {
 		logging.SetLogFormat(logging.LogFormatText)
 	}()
 	do = &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
-	ep = NewTestEndpointWithState(t, do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+	ep = NewTestEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 
 	_, ok = ep.getLogger().Logger.Formatter.(*logrus.JSONFormatter)
 	require.True(t, ok)
@@ -45,7 +45,7 @@ func TestPolicyLog(t *testing.T) {
 	setupEndpointSuite(t)
 
 	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
-	ep := NewTestEndpointWithState(t, do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+	ep := NewTestEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 
 	// Initially nil
 	policyLogger := ep.getPolicyLogger()

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -205,7 +205,7 @@ const (
 )
 
 func (s *RedirectSuite) NewTestEndpoint(t *testing.T) *Endpoint {
-	ep := NewTestEndpointWithState(t, s.do, s.do, testipcache.NewMockIPCache(), s.rsp, s.mgr, 12345, StateRegenerating)
+	ep := NewTestEndpointWithState(s.do, s.do, testipcache.NewMockIPCache(), s.rsp, s.mgr, 12345, StateRegenerating)
 	ep.SetPropertyValue(PropertyFakeEndpoint, false)
 
 	epIdentity, _, err := s.mgr.AllocateIdentity(context.Background(), labelsBar.Labels(), true, identityBar)

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -60,7 +60,7 @@ func (s *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdentit
 	repo := s.GetPolicyRepository()
 	repo.GetPolicyCache().LocalEndpointIdentityAdded(identity)
 
-	ep := NewTestEndpointWithState(nil, s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), id, StateReady)
+	ep := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), id, StateReady)
 	// Random network ID and docker endpoint ID with 59 hex chars + 5 strID = 64 hex chars
 	ep.dockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID
 	ep.dockerEndpointID = "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -39,7 +39,7 @@ func TestMarkAndSweep(t *testing.T) {
 	healthyEndpointIDs := []uint16{1, 3, 5, 7}
 	allEndpointIDs := append(healthyEndpointIDs, endpointIDToDelete)
 	for _, id := range allEndpointIDs {
-		ep := endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), id, endpoint.StateReady)
+		ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), id, endpoint.StateReady)
 		err := mgr.expose(ep)
 		require.NoError(t, err)
 	}

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -460,7 +460,7 @@ func TestLookupCiliumID(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 
 	mgr := New(&dummyEpSyncher{}, nil, nil)
-	ep := endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 2, endpoint.StateReady)
+	ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 2, endpoint.StateReady)
 	type args struct {
 		id uint16
 	}
@@ -550,7 +550,7 @@ func TestLookupIPv4(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 
 	mgr := New(&dummyEpSyncher{}, nil, nil)
-	ep := endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 4, endpoint.StateReady)
+	ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 4, endpoint.StateReady)
 	type args struct {
 		ip string
 	}
@@ -773,7 +773,7 @@ func TestUpdateReferences(t *testing.T) {
 func TestRemove(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 	mgr := New(&dummyEpSyncher{}, nil, nil)
-	ep := endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 7, endpoint.StateReady)
+	ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 7, endpoint.StateReady)
 	type args struct{}
 	type want struct{}
 	tests := []struct {
@@ -813,7 +813,7 @@ func TestHasGlobalCT(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 
 	mgr := New(&dummyEpSyncher{}, nil, nil)
-	ep := endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+	ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 	type want struct {
 		result bool
 	}
@@ -837,7 +837,7 @@ func TestHasGlobalCT(t *testing.T) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep = endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 				ep.ID = 0
 				ep.Options = nil
 			},
@@ -857,7 +857,7 @@ func TestHasGlobalCT(t *testing.T) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep = endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 				ep.ID = 0
 				ep.Options = nil
 			},
@@ -875,7 +875,7 @@ func TestHasGlobalCT(t *testing.T) {
 func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 	mgr := New(&dummyEpSyncher{}, nil, nil)
-	ep := endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+	ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 	type args struct {
 		ctx    context.Context
 		rev    uint64
@@ -913,7 +913,7 @@ func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep = endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 			},
 		},
 		{
@@ -939,7 +939,7 @@ func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep = endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 			},
 		},
 		{
@@ -965,7 +965,7 @@ func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep = endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 			},
 		},
 	}
@@ -998,7 +998,7 @@ func TestMissingNodeLabelsUpdate(t *testing.T) {
 	require.False(t, ok)
 
 	// Create host endpoint and expose it in the endpoint manager.
-	ep := endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+	ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 	ep.SetIsHost(true)
 	ep.ID = hostEPID
 	require.NoError(t, mgr.expose(ep))
@@ -1035,7 +1035,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 		{
 			name: "Add labels",
 			preTestRun: func() {
-				ep := endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 				ep.SetIsHost(true)
 				ep.ID = hostEPID
 				require.NoError(t, mgr.expose(ep))
@@ -1060,7 +1060,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 		{
 			name: "Update labels",
 			preTestRun: func() {
-				ep := endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 				ep.SetIsHost(true)
 				ep.ID = hostEPID
 				ep.OpLabels.Custom = labels.Labels{"k1": labels.NewLabel("k1", "v1", labels.LabelSourceK8s)}
@@ -1087,7 +1087,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 		{
 			name: "Ignore labels",
 			preTestRun: func() {
-				ep := endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
+				ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 				ep.SetIsHost(true)
 				ep.ID = hostEPID
 				ep.OpLabels.Custom = labels.Labels{"k1": labels.NewLabel("k1", "v1", labels.LabelSourceK8s)}

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -87,7 +87,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 			if s.restoring {
 				return nil, false, fmt.Errorf("No EPs available when restoring")
 			}
-			return endpoint.NewTestEndpointWithState(tb, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady), false, nil
+			return endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady), false, nil
 		},
 		// LookupSecIDByIP
 		func(ip netip.Addr) (ipcache.Identity, bool) {
@@ -879,7 +879,7 @@ func TestFullPathDependence(t *testing.T) {
 	require.False(t, allowed, "request was allowed when it should be rejected")
 
 	// Restore rules
-	ep1 := endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
+	ep1 := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
 	ep1.DNSRulesV2 = restored1
 	s.proxy.RestoreRules(ep1)
 	_, exists = s.proxy.restored[epID1]
@@ -925,7 +925,7 @@ func TestFullPathDependence(t *testing.T) {
 	require.True(t, allowed, "request was rejected when it should be allowed")
 
 	// Restore rules for epID3
-	ep3 := endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID3), endpoint.StateReady)
+	ep3 := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID3), endpoint.StateReady)
 	ep3.DNSRulesV2 = restored3
 	s.proxy.RestoreRules(ep3)
 	_, exists = s.proxy.restored[epID3]
@@ -1131,7 +1131,7 @@ func TestRestoredEndpoint(t *testing.T) {
 
 	// restore rules, set the mock to restoring state
 	s.restoring = true
-	ep1 := endpoint.NewTestEndpointWithState(t, s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
+	ep1 := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), uint16(epID1), endpoint.StateReady)
 	ep1.IPv4 = netip.MustParseAddr("127.0.0.1")
 	ep1.IPv6 = netip.MustParseAddr("::1")
 	ep1.DNSRulesV2 = restored

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -185,7 +185,7 @@ func TestParseNetworkPolicyIngress(t *testing.T) {
 			},
 		},
 	})
-	require.True(t, ingressL4Policy.Equals(t, expected), ingressL4Policy.Diff(t, expected))
+	require.True(t, ingressL4Policy.Equals(expected), ingressL4Policy.Diff(expected))
 	ingressL4Policy.Detach(repo.GetSelectorCache())
 
 	ctx.To = labels.LabelArray{
@@ -510,7 +510,7 @@ func TestParseNetworkPolicyEgress(t *testing.T) {
 			},
 		},
 	})
-	require.True(t, egressL4Policy.Equals(t, expected), egressL4Policy.Diff(t, expected))
+	require.True(t, egressL4Policy.Equals(expected), egressL4Policy.Diff(expected))
 	egressL4Policy.Detach(repo.GetSelectorCache())
 
 	ctx.From = labels.LabelArray{

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -185,7 +185,7 @@ func TestParseNetworkPolicyIngress(t *testing.T) {
 			},
 		},
 	})
-	require.True(t, ingressL4Policy.Equals(expected), ingressL4Policy.Diff(expected))
+	require.True(t, ingressL4Policy.TestingOnlyEquals(expected), ingressL4Policy.TestingOnlyDiff(expected))
 	ingressL4Policy.Detach(repo.GetSelectorCache())
 
 	ctx.To = labels.LabelArray{
@@ -510,7 +510,7 @@ func TestParseNetworkPolicyEgress(t *testing.T) {
 			},
 		},
 	})
-	require.True(t, egressL4Policy.Equals(expected), egressL4Policy.Diff(expected))
+	require.True(t, egressL4Policy.TestingOnlyEquals(expected), egressL4Policy.TestingOnlyDiff(expected))
 	egressL4Policy.Detach(repo.GetSelectorCache())
 
 	ctx.From = labels.LabelArray{

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-	"testing"
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	"github.com/sirupsen/logrus"
@@ -505,7 +504,7 @@ func (l4 *L4Filter) GetPort() uint16 {
 }
 
 // Equals returns true if two L4Filters are equal
-func (l4 *L4Filter) Equals(_ *testing.T, bL4 *L4Filter) bool {
+func (l4 *L4Filter) Equals(bL4 *L4Filter) bool {
 	if l4.Port == bL4.Port &&
 		l4.EndPort == bL4.EndPort &&
 		l4.PortName == bL4.PortName &&
@@ -1148,8 +1147,8 @@ type L4PolicyMap interface {
 	IngressCoversContext(ctx *SearchContext) api.Decision
 	EgressCoversContext(ctx *SearchContext) api.Decision
 	ForEach(func(l4 *L4Filter) bool)
-	Equals(t *testing.T, bMap L4PolicyMap) bool
-	Diff(t *testing.T, expectedMap L4PolicyMap) string
+	Equals(bMap L4PolicyMap) bool
+	Diff(expectedMap L4PolicyMap) string
 	Len() int
 }
 
@@ -1340,7 +1339,7 @@ func (l4M *l4PolicyMap) ForEach(fn func(l4 *L4Filter) bool) {
 }
 
 // Equals returns true if both L4PolicyMaps are equal.
-func (l4M *l4PolicyMap) Equals(_ *testing.T, bMap L4PolicyMap) bool {
+func (l4M *l4PolicyMap) Equals(bMap L4PolicyMap) bool {
 	if l4M.Len() != bMap.Len() {
 		return false
 	}
@@ -1351,14 +1350,14 @@ func (l4M *l4PolicyMap) Equals(_ *testing.T, bMap L4PolicyMap) bool {
 			port = fmt.Sprintf("%d", l4.Port)
 		}
 		l4B := bMap.ExactLookup(port, l4.EndPort, string(l4.Protocol))
-		equal = l4.Equals(nil, l4B)
+		equal = l4.Equals(l4B)
 		return equal
 	})
 	return equal
 }
 
 // Diff returns the difference between to L4PolicyMaps.
-func (l4M *l4PolicyMap) Diff(_ *testing.T, expected L4PolicyMap) (res string) {
+func (l4M *l4PolicyMap) Diff(expected L4PolicyMap) (res string) {
 	res += "Missing (-), Unexpected (+):\n"
 	expected.ForEach(func(eV *L4Filter) bool {
 		port := eV.PortName
@@ -1367,7 +1366,7 @@ func (l4M *l4PolicyMap) Diff(_ *testing.T, expected L4PolicyMap) (res string) {
 		}
 		oV := l4M.ExactLookup(port, eV.Port, string(eV.Protocol))
 		if oV != nil {
-			if !eV.Equals(nil, oV) {
+			if !eV.Equals(oV) {
 				res += "- " + eV.String() + "\n"
 				res += "+ " + oV.String() + "\n"
 			}

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1147,8 +1147,8 @@ type L4PolicyMap interface {
 	IngressCoversContext(ctx *SearchContext) api.Decision
 	EgressCoversContext(ctx *SearchContext) api.Decision
 	ForEach(func(l4 *L4Filter) bool)
-	Equals(bMap L4PolicyMap) bool
-	Diff(expectedMap L4PolicyMap) string
+	TestingOnlyEquals(bMap L4PolicyMap) bool
+	TestingOnlyDiff(expectedMap L4PolicyMap) string
 	Len() int
 }
 
@@ -1339,7 +1339,7 @@ func (l4M *l4PolicyMap) ForEach(fn func(l4 *L4Filter) bool) {
 }
 
 // Equals returns true if both L4PolicyMaps are equal.
-func (l4M *l4PolicyMap) Equals(bMap L4PolicyMap) bool {
+func (l4M *l4PolicyMap) TestingOnlyEquals(bMap L4PolicyMap) bool {
 	if l4M.Len() != bMap.Len() {
 		return false
 	}
@@ -1357,7 +1357,7 @@ func (l4M *l4PolicyMap) Equals(bMap L4PolicyMap) bool {
 }
 
 // Diff returns the difference between to L4PolicyMaps.
-func (l4M *l4PolicyMap) Diff(expected L4PolicyMap) (res string) {
+func (l4M *l4PolicyMap) TestingOnlyDiff(expected L4PolicyMap) (res string) {
 	res += "Missing (-), Unexpected (+):\n"
 	expected.ForEach(func(eV *L4Filter) bool {
 		port := eV.PortName

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -940,7 +940,7 @@ func TestMergeTLSHTTPPolicy(t *testing.T) {
 		},
 	}})
 
-	require.True(t, res.Equals(expected), res.Diff(expected))
+	require.True(t, res.TestingOnlyEquals(expected), res.TestingOnlyDiff(expected))
 	l4Filter := res.ExactLookup("443", 0, "TCP")
 	require.NotNil(t, l4Filter)
 	require.Equal(t, ParserTypeHTTP, l4Filter.L7Parser)
@@ -1052,7 +1052,7 @@ func TestMergeTLSSNIPolicy(t *testing.T) {
 	}})
 
 	require.EqualValues(t, expected, res)
-	require.True(t, res.Equals(expected), res.Diff(expected))
+	require.True(t, res.TestingOnlyEquals(expected), res.TestingOnlyDiff(expected))
 
 	l4Filter := res.ExactLookup("443", 0, "TCP")
 	require.NotNil(t, l4Filter)

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -940,7 +940,7 @@ func TestMergeTLSHTTPPolicy(t *testing.T) {
 		},
 	}})
 
-	require.True(t, res.Equals(t, expected), res.Diff(t, expected))
+	require.True(t, res.Equals(expected), res.Diff(expected))
 	l4Filter := res.ExactLookup("443", 0, "TCP")
 	require.NotNil(t, l4Filter)
 	require.Equal(t, ParserTypeHTTP, l4Filter.L7Parser)
@@ -1052,7 +1052,7 @@ func TestMergeTLSSNIPolicy(t *testing.T) {
 	}})
 
 	require.EqualValues(t, expected, res)
-	require.True(t, res.Equals(t, expected), res.Diff(t, expected))
+	require.True(t, res.Equals(expected), res.Diff(expected))
 
 	l4Filter := res.ExactLookup("443", 0, "TCP")
 	require.NotNil(t, l4Filter)

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -472,11 +472,11 @@ func TestL4PolicyMapPortRangeOverlaps(t *testing.T) {
 				l4Map.Upsert(altStartPort, altPR.endPort, "TCP", altFilter)
 				altL4 = l4Map.ExactLookup(altStartPort, altPR.endPort, "TCP")
 				require.NotNilf(t, altL4, "%d-%d range not found and it should have been", altPR.startPort, altPR.endPort)
-				require.True(t, altL4.Equals(nil, altFilter), "%d-%d range lookup returned a range of %d-%d",
+				require.True(t, altL4.Equals(altFilter), "%d-%d range lookup returned a range of %d-%d",
 					altPR.startPort, altPR.endPort, altL4.Port, altL4.EndPort)
 
 				gotMainFilter := l4Map.ExactLookup(startPort, portRange.endPort, "TCP")
-				require.Truef(t, gotMainFilter.Equals(nil, startFilter), "main range look up failed after %d-%d range upsert", altPR.startPort, altPR.endPort)
+				require.Truef(t, gotMainFilter.Equals(startFilter), "main range look up failed after %d-%d range upsert", altPR.startPort, altPR.endPort)
 
 				// Delete overlapping port range, and make sure it's not there.
 				l4Map.Delete(altStartPort, altPR.endPort, "TCP")
@@ -487,7 +487,7 @@ func TestL4PolicyMapPortRangeOverlaps(t *testing.T) {
 				require.Nil(t, altL4)
 
 				gotMainFilter = l4Map.ExactLookup(startPort, portRange.endPort, "TCP")
-				require.Truef(t, gotMainFilter.Equals(nil, startFilter), "main range look up failed after %d-%d range delete", altPR.startPort, altPR.endPort)
+				require.Truef(t, gotMainFilter.Equals(startFilter), "main range look up failed after %d-%d range delete", altPR.startPort, altPR.endPort)
 
 				// Put it back for the next iteration.
 				l4Map.Upsert(altStartPort, altPR.endPort, "TCP", altFilter)

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -660,7 +660,7 @@ func TestWildcardL4RulesIngressDeny(t *testing.T) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL4Kafka}},
 		},
 	})
-	require.True(t, policyDeny.Equals(expectedDenyPolicy), policyDeny.Diff(expectedDenyPolicy))
+	require.True(t, policyDeny.TestingOnlyEquals(expectedDenyPolicy), policyDeny.TestingOnlyDiff(expectedDenyPolicy))
 	policyDeny.Detach(repo.GetSelectorCache())
 }
 
@@ -818,7 +818,7 @@ func TestL3DependentL4EgressDenyFromRequires(t *testing.T) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{expectedCachedSelector: {nil}},
 		},
 	})
-	if !assert.True(t, policyDeny.Equals(expectedDenyPolicy), policyDeny.Diff(expectedDenyPolicy)) {
+	if !assert.True(t, policyDeny.TestingOnlyEquals(expectedDenyPolicy), policyDeny.TestingOnlyDiff(expectedDenyPolicy)) {
 		t.Errorf("Policy doesn't match expected:\n%s", logBuffer.String())
 	}
 	policyDeny.Detach(repo.GetSelectorCache())
@@ -946,8 +946,8 @@ func TestWildcardL3RulesEgressDeny(t *testing.T) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsICMPv6}},
 		},
 	})
-	require.Truef(t, policyDeny.Equals(expectedDenyPolicy),
-		"%s\nResolved policy did not match expected:\n%s", policyDeny.Diff(expectedDenyPolicy), logBuffer.String())
+	require.Truef(t, policyDeny.TestingOnlyEquals(expectedDenyPolicy),
+		"%s\nResolved policy did not match expected:\n%s", policyDeny.TestingOnlyDiff(expectedDenyPolicy), logBuffer.String())
 	policyDeny.Detach(repo.GetSelectorCache())
 }
 
@@ -1038,7 +1038,7 @@ func TestWildcardL4RulesEgressDeny(t *testing.T) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL3DNS}},
 		},
 	})
-	if !assert.True(t, policyDeny.Equals(expectedDenyPolicy), policyDeny.Diff(expectedDenyPolicy)) {
+	if !assert.True(t, policyDeny.TestingOnlyEquals(expectedDenyPolicy), policyDeny.TestingOnlyDiff(expectedDenyPolicy)) {
 		t.Logf("%s", logBuffer.String())
 		t.Errorf("Resolved policy did not match expected")
 	}
@@ -1136,7 +1136,7 @@ func TestWildcardCIDRRulesEgressDeny(t *testing.T) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectors[0]: {labelsL3}},
 		},
 	})
-	if !assert.True(t, policyDeny.Equals(expectedDenyPolicy), policyDeny.Diff(expectedDenyPolicy)) {
+	if !assert.True(t, policyDeny.TestingOnlyEquals(expectedDenyPolicy), policyDeny.TestingOnlyDiff(expectedDenyPolicy)) {
 		t.Logf("%s", logBuffer.String())
 		t.Errorf("Resolved policy did not match expected: \n%s", err)
 	}

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -660,7 +660,7 @@ func TestWildcardL4RulesIngressDeny(t *testing.T) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL4Kafka}},
 		},
 	})
-	require.True(t, policyDeny.Equals(t, expectedDenyPolicy), policyDeny.Diff(t, expectedDenyPolicy))
+	require.True(t, policyDeny.Equals(expectedDenyPolicy), policyDeny.Diff(expectedDenyPolicy))
 	policyDeny.Detach(repo.GetSelectorCache())
 }
 
@@ -818,7 +818,7 @@ func TestL3DependentL4EgressDenyFromRequires(t *testing.T) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{expectedCachedSelector: {nil}},
 		},
 	})
-	if !assert.True(t, policyDeny.Equals(t, expectedDenyPolicy), policyDeny.Diff(t, expectedDenyPolicy)) {
+	if !assert.True(t, policyDeny.Equals(expectedDenyPolicy), policyDeny.Diff(expectedDenyPolicy)) {
 		t.Errorf("Policy doesn't match expected:\n%s", logBuffer.String())
 	}
 	policyDeny.Detach(repo.GetSelectorCache())
@@ -946,8 +946,8 @@ func TestWildcardL3RulesEgressDeny(t *testing.T) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsICMPv6}},
 		},
 	})
-	require.Truef(t, policyDeny.Equals(t, expectedDenyPolicy),
-		"%s\nResolved policy did not match expected:\n%s", policyDeny.Diff(t, expectedDenyPolicy), logBuffer.String())
+	require.Truef(t, policyDeny.Equals(expectedDenyPolicy),
+		"%s\nResolved policy did not match expected:\n%s", policyDeny.Diff(expectedDenyPolicy), logBuffer.String())
 	policyDeny.Detach(repo.GetSelectorCache())
 }
 
@@ -1038,7 +1038,7 @@ func TestWildcardL4RulesEgressDeny(t *testing.T) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL3DNS}},
 		},
 	})
-	if !assert.True(t, policyDeny.Equals(t, expectedDenyPolicy), policyDeny.Diff(t, expectedDenyPolicy)) {
+	if !assert.True(t, policyDeny.Equals(expectedDenyPolicy), policyDeny.Diff(expectedDenyPolicy)) {
 		t.Logf("%s", logBuffer.String())
 		t.Errorf("Resolved policy did not match expected")
 	}
@@ -1136,7 +1136,7 @@ func TestWildcardCIDRRulesEgressDeny(t *testing.T) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectors[0]: {labelsL3}},
 		},
 	})
-	if !assert.True(t, policyDeny.Equals(t, expectedDenyPolicy), policyDeny.Diff(t, expectedDenyPolicy)) {
+	if !assert.True(t, policyDeny.Equals(expectedDenyPolicy), policyDeny.Diff(expectedDenyPolicy)) {
 		t.Logf("%s", logBuffer.String())
 		t.Errorf("Resolved policy did not match expected: \n%s", err)
 	}

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -820,7 +820,7 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsL7}},
 		},
 	})
-	require.True(t, policy.Equals(t, expectedPolicy), policy.Diff(t, expectedPolicy))
+	require.True(t, policy.Equals(expectedPolicy), policy.Diff(expectedPolicy))
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -978,7 +978,7 @@ func TestWildcardL4RulesIngress(t *testing.T) {
 			},
 		},
 	})
-	require.True(t, policy.Equals(t, expectedPolicy), policy.Diff(t, expectedPolicy))
+	require.True(t, policy.Equals(expectedPolicy), policy.Diff(expectedPolicy))
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -1142,7 +1142,7 @@ func TestL3DependentL4EgressFromRequires(t *testing.T) {
 			},
 		},
 	})
-	if !assert.True(t, policy.Equals(t, expectedPolicy), policy.Diff(t, expectedPolicy)) {
+	if !assert.True(t, policy.Equals(expectedPolicy), policy.Diff(expectedPolicy)) {
 		t.Errorf("Policy doesn't match expected:\n%s", logBuffer.String())
 	}
 	policy.Detach(repo.GetSelectorCache())
@@ -1346,7 +1346,7 @@ func TestWildcardL3RulesEgress(t *testing.T) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL4}},
 		},
 	})
-	if !assert.True(t, policy.Equals(t, expectedPolicy), policy.Diff(t, expectedPolicy)) {
+	if !assert.True(t, policy.Equals(expectedPolicy), policy.Diff(expectedPolicy)) {
 		t.Logf("%s", logBuffer.String())
 		t.Errorf("Resolved policy did not match expected: \n%s", err)
 	}
@@ -1510,7 +1510,7 @@ func TestWildcardL4RulesEgress(t *testing.T) {
 			},
 		},
 	})
-	if !assert.True(t, policy.Equals(t, expectedPolicy), policy.Diff(t, expectedPolicy)) {
+	if !assert.True(t, policy.Equals(expectedPolicy), policy.Diff(expectedPolicy)) {
 		t.Logf("%s", logBuffer.String())
 		t.Error("Resolved policy did not match expected")
 	}
@@ -1627,7 +1627,7 @@ func TestWildcardCIDRRulesEgress(t *testing.T) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectors[0]: {labelsL3}},
 		},
 	})
-	if !assert.True(t, policy.Equals(t, expectedPolicy), policy.Diff(t, expectedPolicy)) {
+	if !assert.True(t, policy.Equals(expectedPolicy), policy.Diff(expectedPolicy)) {
 		t.Logf("%s", logBuffer.String())
 		t.Error("Resolved policy did not match expected")
 	}
@@ -1782,7 +1782,7 @@ func TestWildcardL3RulesIngressFromEntities(t *testing.T) {
 		},
 	})
 
-	require.True(t, policy.Equals(t, expectedPolicy), policy.Diff(t, expectedPolicy))
+	require.True(t, policy.Equals(expectedPolicy), policy.Diff(expectedPolicy))
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -1934,7 +1934,7 @@ func TestWildcardL3RulesEgressToEntities(t *testing.T) {
 		},
 	})
 
-	require.True(t, policy.Equals(t, expectedPolicy), policy.Diff(t, expectedPolicy))
+	require.True(t, policy.Equals(expectedPolicy), policy.Diff(expectedPolicy))
 	policy.Detach(repo.GetSelectorCache())
 }
 

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -820,7 +820,7 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsL7}},
 		},
 	})
-	require.True(t, policy.Equals(expectedPolicy), policy.Diff(expectedPolicy))
+	require.True(t, policy.TestingOnlyEquals(expectedPolicy), policy.TestingOnlyDiff(expectedPolicy))
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -978,7 +978,7 @@ func TestWildcardL4RulesIngress(t *testing.T) {
 			},
 		},
 	})
-	require.True(t, policy.Equals(expectedPolicy), policy.Diff(expectedPolicy))
+	require.True(t, policy.TestingOnlyEquals(expectedPolicy), policy.TestingOnlyDiff(expectedPolicy))
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -1142,7 +1142,7 @@ func TestL3DependentL4EgressFromRequires(t *testing.T) {
 			},
 		},
 	})
-	if !assert.True(t, policy.Equals(expectedPolicy), policy.Diff(expectedPolicy)) {
+	if !assert.True(t, policy.TestingOnlyEquals(expectedPolicy), policy.TestingOnlyDiff(expectedPolicy)) {
 		t.Errorf("Policy doesn't match expected:\n%s", logBuffer.String())
 	}
 	policy.Detach(repo.GetSelectorCache())
@@ -1346,7 +1346,7 @@ func TestWildcardL3RulesEgress(t *testing.T) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL4}},
 		},
 	})
-	if !assert.True(t, policy.Equals(expectedPolicy), policy.Diff(expectedPolicy)) {
+	if !assert.True(t, policy.TestingOnlyEquals(expectedPolicy), policy.TestingOnlyDiff(expectedPolicy)) {
 		t.Logf("%s", logBuffer.String())
 		t.Errorf("Resolved policy did not match expected: \n%s", err)
 	}
@@ -1510,7 +1510,7 @@ func TestWildcardL4RulesEgress(t *testing.T) {
 			},
 		},
 	})
-	if !assert.True(t, policy.Equals(expectedPolicy), policy.Diff(expectedPolicy)) {
+	if !assert.True(t, policy.TestingOnlyEquals(expectedPolicy), policy.TestingOnlyDiff(expectedPolicy)) {
 		t.Logf("%s", logBuffer.String())
 		t.Error("Resolved policy did not match expected")
 	}
@@ -1627,7 +1627,7 @@ func TestWildcardCIDRRulesEgress(t *testing.T) {
 			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectors[0]: {labelsL3}},
 		},
 	})
-	if !assert.True(t, policy.Equals(expectedPolicy), policy.Diff(expectedPolicy)) {
+	if !assert.True(t, policy.TestingOnlyEquals(expectedPolicy), policy.TestingOnlyDiff(expectedPolicy)) {
 		t.Logf("%s", logBuffer.String())
 		t.Error("Resolved policy did not match expected")
 	}
@@ -1782,7 +1782,7 @@ func TestWildcardL3RulesIngressFromEntities(t *testing.T) {
 		},
 	})
 
-	require.True(t, policy.Equals(expectedPolicy), policy.Diff(expectedPolicy))
+	require.True(t, policy.TestingOnlyEquals(expectedPolicy), policy.TestingOnlyDiff(expectedPolicy))
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -1934,7 +1934,7 @@ func TestWildcardL3RulesEgressToEntities(t *testing.T) {
 		},
 	})
 
-	require.True(t, policy.Equals(expectedPolicy), policy.Diff(expectedPolicy))
+	require.True(t, policy.TestingOnlyEquals(expectedPolicy), policy.TestingOnlyDiff(expectedPolicy))
 	policy.Detach(repo.GetSelectorCache())
 }
 


### PR DESCRIPTION
This pull request refactors the policy and endpoint packages to improve code clarity, reduce unnecessary complexity, and ensure clear distinction between production and test-specific code, addressing issue #34069.

Key Changes:

[1] Removed Unused testing.TB Parameters:
In the l4.go file, the unused testing.TB parameters were removed from test-related functions. This reduces unnecessary complexity and ensures these functions are cleaner and not tied to the testing package when it's not needed.

[2] Renamed Test-Specific Functions:
Renamed the Equals and Diff functions in l4.go to TestingOnlyEquals and TestingOnlyDiff, respectively. This change explicitly marks these functions as intended for testing purposes only, helping to prevent accidental use in production code.

[3] Clarifying Note in NewTestEndpointWithState:
Added a comment to the NewTestEndpointWithState function in the endpoint package, clearly indicating that this function is intended solely for testing purposes. This helps future developers quickly understand the function's purpose.

[4] Linting and Error Fixes:
Fixed several linting errors and addressed undefined references caused by the initial renaming of test-specific functions. All necessary functions were renamed appropriately, and the code passes linting checks.

Challenges Faced:
While we initially aimed to refactor parts of the kvstore package, the decision was ultimately made to focus on renaming functions and removing unnecessary parameters in the policy and endpoint packages. The final solution ensures that test-specific functions are clearly marked, simplifying future maintenance and reducing the risk of test code being accidentally used in production environments.

Regarding the kvstore package we attempted to move test-specific code into separate test files to better isolate testing logic from production code. However, this approach caused several undefined reference errors between packages, complicating access to internal functions. We also considered moving the test logic to utility files, but this did not resolve the accessibility issues.

Towards: #34069
Signed-off-by: Roy roykharman@gmail.com
Reviewed-by: Sameeh Jubran sameeh.j@gmail.com

```release-note
Refactored the endpoint and policy packages to separate test-specific code from production code.
```
