### PR TITLE
refactor: Use error definition in github.com/cilium/ebpf instead of using hard-corded error message

### DIFF
--- a/cilium-cli/connectivity/tests/multicast.go
+++ b/cilium-cli/connectivity/tests/multicast.go
@@ -14,6 +14,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/cilium/ebpf"
+
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node/addressing"
@@ -24,8 +26,6 @@ import (
 )
 
 const (
-	notExistMsg          = "does not exist"
-	alreadyExistMsg      = "already exists"
 	testMulticastGroupIP = "239.255.9.9"
 	testSocatPort        = 6666
 )
@@ -263,7 +263,7 @@ func (s *socatMulticast) addAllNodes(ctx context.Context, t *check.Test) error {
 			cmd := []string{"cilium-dbg", "bpf", "multicast", "subscriber", "list", testMulticastGroupIP}
 			_, stdErr, err := client.ExecInPodWithStderr(ctx, pod.Namespace, pod.Name, defaults.AgentContainerName, cmd)
 			if err != nil {
-				if !strings.Contains(stdErr.String(), notExistMsg) {
+				if !strings.Contains(stdErr.String(), ebpf.ErrKeyNotExist.Error()) {
 					errMsg := fmt.Sprintf("Error: %v, Stderr: %s", err, stdErr.String())
 					errCh <- errors.New(errMsg)
 					t.Fatalf("Fatal error occurred while checking multicast group %s in %s", testMulticastGroupIP, pod.Spec.NodeName)
@@ -286,7 +286,7 @@ func (s *socatMulticast) addAllNodes(ctx context.Context, t *check.Test) error {
 					_, stdErr, err := client.ExecInPodWithStderr(ctx, pod.Namespace, pod.Name, defaults.AgentContainerName, cmd)
 					if err == nil {
 						s.addNotSubscribePodAddress(pod.Spec.NodeName, ip)
-					} else if !strings.Contains(stdErr.String(), alreadyExistMsg) {
+					} else if !strings.Contains(stdErr.String(), ebpf.ErrKeyExist.Error()) {
 						errMsg := fmt.Sprintf("Error: %v, Stderr: %s", err, stdErr.String())
 						errCh <- errors.New(errMsg)
 						t.Fatalf("Fatal error occurred while adding node %s to multicast group %s in %s", ip.IP, testMulticastGroupIP, pod.Spec.NodeName)
@@ -324,7 +324,7 @@ func (s *socatMulticast) delGroup(ctx context.Context, t *check.Test, nodeName s
 			cmd := []string{"cilium-dbg", "bpf", "multicast", "group", "delete", testMulticastGroupIP}
 			_, stdErr, err := client.ExecInPodWithStderr(ctx, ciliumPod.Namespace, ciliumPod.Name, defaults.AgentContainerName, cmd)
 			if err != nil {
-				if !strings.Contains(stdErr.String(), notExistMsg) {
+				if !strings.Contains(stdErr.String(), ebpf.ErrKeyNotExist.Error()) {
 					errMsg := fmt.Sprintf("Error: %v while deleting Multicast Group for test %s, Stderr: %s", err, testMulticastGroupIP, stdErr.String())
 					return errors.New(errMsg)
 				}
@@ -351,7 +351,7 @@ func (s *socatMulticast) delSubscriber(ctx context.Context, t *check.Test, nodeN
 			cmd := []string{"cilium-dbg", "bpf", "multicast", "subscriber", "delete", testMulticastGroupIP, subscriberIP}
 			_, stdErr, err := client.ExecInPodWithStderr(ctx, ciliumPod.Namespace, ciliumPod.Name, defaults.AgentContainerName, cmd)
 			if err != nil {
-				if !strings.Contains(stdErr.String(), notExistMsg) {
+				if !strings.Contains(stdErr.String(), ebpf.ErrKeyNotExist.Error()) {
 					errMsg := fmt.Sprintf("Error: %v while removing %s from Multicast Group %s Stderr: %s", err, subscriberIP, testMulticastGroupIP, stdErr.String())
 					return errors.New(errMsg)
 				}

--- a/cilium-cli/multicast/multicast.go
+++ b/cilium-cli/multicast/multicast.go
@@ -18,6 +18,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/cilium/ebpf"
+
 	"github.com/cilium/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium/cilium-cli/k8s"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -29,15 +31,13 @@ import (
 // in cilium/cilium repository.
 
 const (
-	padding         = 3
-	minWidth        = 5
-	paddingChar     = ' '
-	alreadyExistMsg = "already exists"
-	notExistMsg     = "does not exist"
+	padding     = 3
+	minWidth    = 5
+	paddingChar = ' '
 )
 
 var (
-	errMissingGroup = errors.New(notExistMsg)
+	errMissingGroup = ebpf.ErrKeyNotExist
 )
 
 type Multicast struct {
@@ -236,7 +236,7 @@ func (m *Multicast) getGroupForSubscriberList(ctx context.Context, pod corev1.Po
 	cmd := []string{"cilium-dbg", "bpf", "multicast", "subscriber", "list", target, "-o", "json"}
 	outputByte, stdErr, err := m.client.ExecInPodWithStderr(ctx, pod.Namespace, pod.Name, defaults.AgentContainerName, cmd)
 	if err != nil {
-		if strings.Contains(stdErr.String(), notExistMsg) {
+		if strings.Contains(stdErr.String(), ebpf.ErrKeyNotExist.Error()) {
 			fmt.Fprintf(m.params.Writer, "Multicast group %s does not exist in %s\n", target, pod.Spec.NodeName)
 			return nil, errMissingGroup
 		}
@@ -465,7 +465,7 @@ func (m *Multicast) AddAllNodes() error {
 			cmd := []string{"cilium-dbg", "bpf", "multicast", "subscriber", "list", m.params.MulticastGroupIP}
 			_, stdErr, err := m.client.ExecInPodWithStderr(ctx, pod.Namespace, pod.Name, defaults.AgentContainerName, cmd)
 			if err != nil {
-				if !strings.Contains(stdErr.String(), notExistMsg) {
+				if !strings.Contains(stdErr.String(), ebpf.ErrKeyNotExist.Error()) {
 					errMsg := fmt.Sprintf("Error: %v, Stderr: %s", err, stdErr.String())
 					errCh <- errors.New(errMsg)
 					fmt.Fprintf(m.params.Writer, "Fatal error occurred while checking multicast group %s in %s\n", m.params.MulticastGroupIP, pod.Spec.NodeName)
@@ -492,7 +492,7 @@ func (m *Multicast) AddAllNodes() error {
 					if err == nil {
 						cnt++
 						nodeLists = append(nodeLists, ipToNodeMap[ip])
-					} else if !strings.Contains(stdErr.String(), alreadyExistMsg) {
+					} else if !strings.Contains(stdErr.String(), ebpf.ErrKeyExist.Error()) {
 						errMsg := fmt.Sprintf("Error: %v, Stderr: %s", err, stdErr.String())
 						errCh <- errors.New(errMsg)
 						fmt.Fprintf(m.params.Writer, "Unable to add node %s to multicast group %s in %s by fatal error\n", ip.IP, m.params.MulticastGroupIP, pod.Spec.NodeName)
@@ -558,7 +558,7 @@ func (m *Multicast) DelAllNodes() error {
 			cmd := []string{"cilium-dbg", "bpf", "multicast", "group", "delete", m.params.MulticastGroupIP}
 			_, stdErr, err := m.client.ExecInPodWithStderr(ctx, pod.Namespace, pod.Name, defaults.AgentContainerName, cmd)
 			if err != nil {
-				if !strings.Contains(stdErr.String(), notExistMsg) {
+				if !strings.Contains(stdErr.String(), ebpf.ErrKeyNotExist.Error()) {
 					errMsg := fmt.Sprintf("Error: %v, Stderr: %s", err, stdErr.String())
 					errCh <- errors.New(errMsg)
 					fmt.Fprintf(m.params.Writer, "Unable to delete multicast group %s in %s by fatal error\n", m.params.MulticastGroupIP, pod.Spec.NodeName)


### PR DESCRIPTION
Use error definition of github.com/cilium/ebpf, in which the bpf map errors are defined.

This commit is refactoring of https://github.com/cilium/cilium/commit/31652abc9c2d782f8cb395fe0333e2acee3c092d and https://github.com/cilium/cilium/commit/88ebd10726a19a2253c09552c905091c7e5b467f .

