### PR TITLE
Fix wrongly spelled config option in error message

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -297,7 +297,7 @@ func createDirectRouteSpec(log *slog.Logger, CIDR *cidr.CIDR, nodeIP net.IP, ski
 				"gateway", routes[0].Gw.String())
 			addRoute = false
 		} else {
-			err = fmt.Errorf("route to destination %s contains gateway %s, must be directly reachable. Add `direct-node-routes-skip-unreachable` to skip unreachable routes",
+			err = fmt.Errorf("route to destination %s contains gateway %s, must be directly reachable. Add `direct-routing-skip-unreachable` to skip unreachable routes",
 				nodeIP, routes[0].Gw.String())
 		}
 		return


### PR DESCRIPTION
Seems like the config option has been renamed in the inital PR while it was reviewed but this instance has been missed.

See #32733

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
