### PR TITLE
Revert "Fixed Cilium CLI fatal error: concurrent map read and map write"

### DIFF
--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -38,7 +38,8 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	_ "k8s.io/client-go/plugin/pkg/client/auth" // Register all auth providers (azure, gcp, oidc, openstack, ..）
+	"k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth" // Register all auth providers (azure, gcp, oidc, openstack, ..).
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/transport/spdy"
@@ -66,9 +67,8 @@ type Client struct {
 
 func NewClient(contextName, kubeconfig, ciliumNamespace string) (*Client, error) {
 	// Register the Cilium types in the default scheme.
-	scheme := runtime.NewScheme()
-	_ = ciliumv2.AddToScheme(scheme)
-	_ = ciliumv2alpha1.AddToScheme(scheme)
+	_ = ciliumv2.AddToScheme(scheme.Scheme)
+	_ = ciliumv2alpha1.AddToScheme(scheme.Scheme)
 
 	restClientGetter := genericclioptions.ConfigFlags{
 		Context:    &contextName,


### PR DESCRIPTION
This reverts commit cb318104f34421d1c36a6e021c92e91e2b512d3a.

The end-to-end upgrade workflow is failing since this commit was merged in main.