### PR TITLE
Fixed Cilium CLI fatal error: concurrent map read and map write

### DIFF
--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	_ "k8s.io/client-go/plugin/pkg/client/auth" // Register all auth providers (azure, gcp, oidc, openstack, ..).
+	_ "k8s.io/client-go/plugin/pkg/client/auth" // Register all auth providers (azure, gcp, oidc, openstack, ..）
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/transport/spdy"
@@ -52,6 +52,12 @@ import (
 	"github.com/cilium/cilium/pkg/safeio"
 	"github.com/cilium/cilium/pkg/versioncheck"
 )
+
+func init() {
+	// Register the Cilium types in the default scheme.
+	_ = ciliumv2.AddToScheme(scheme.Scheme)
+	_ = ciliumv2alpha1.AddToScheme(scheme.Scheme)
+}
 
 type Client struct {
 	Clientset          kubernetes.Interface
@@ -66,10 +72,6 @@ type Client struct {
 }
 
 func NewClient(contextName, kubeconfig, ciliumNamespace string) (*Client, error) {
-	// Register the Cilium types in the default scheme.
-	_ = ciliumv2.AddToScheme(scheme.Scheme)
-	_ = ciliumv2alpha1.AddToScheme(scheme.Scheme)
-
 	restClientGetter := genericclioptions.ConfigFlags{
 		Context:    &contextName,
 		KubeConfig: &kubeconfig,


### PR DESCRIPTION
Multiple goroutines accessing the same type registration in scheme.Scheme and performing type conversions can lead to concurrent read-write operations on the map.

Scheme only needs to be registered once, not multiple times, so it can be registered during initialization.

Fixes #35222




```release-note
Fixed Cilium CLI fatal error: concurrent map read and map write
```
