### PR TITLE
policy: Add config for enabling Cilium Clusterwide Network Policy

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1018,9 +1018,13 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.EnableK8sNetworkPolicy)
 	option.BindEnv(vp, option.EnableK8sNetworkPolicy)
 
-	flags.Bool(option.EnableCiliumNetworkPolicy, defaults.EnableCiliumNetworkPolicy, "Enable support for Cilium Network Policy and Cilium Clusterwide Network Policy")
+	flags.Bool(option.EnableCiliumNetworkPolicy, defaults.EnableCiliumNetworkPolicy, "Enable support for Cilium Network Policy")
 	flags.MarkHidden(option.EnableCiliumNetworkPolicy)
 	option.BindEnv(vp, option.EnableCiliumNetworkPolicy)
+
+	flags.Bool(option.EnableCiliumClusterwideNetworkPolicy, defaults.EnableCiliumClusterwideNetworkPolicy, "Enable support for Cilium Clusterwide Network Policy")
+	flags.MarkHidden(option.EnableCiliumClusterwideNetworkPolicy)
+	option.BindEnv(vp, option.EnableCiliumClusterwideNetworkPolicy)
 
 	flags.StringSlice(option.PolicyCIDRMatchMode, defaults.PolicyCIDRMatchMode, "The entities that can be selected by CIDR policy. Supported values: 'nodes'")
 	option.BindEnv(vp, option.PolicyCIDRMatchMode)

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -271,9 +271,13 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.KVstoreLeaseTTL)
 	option.BindEnv(vp, option.KVstoreLeaseTTL)
 
-	flags.Bool(option.EnableCiliumNetworkPolicy, defaults.EnableCiliumNetworkPolicy, "Enable support for Cilium Network Policy and Cilium Clusterwide Network Policy")
+	flags.Bool(option.EnableCiliumNetworkPolicy, defaults.EnableCiliumNetworkPolicy, "Enable support for Cilium Network Policy")
 	flags.MarkHidden(option.EnableCiliumNetworkPolicy)
 	option.BindEnv(vp, option.EnableCiliumNetworkPolicy)
+
+	flags.Bool(option.EnableCiliumClusterwideNetworkPolicy, defaults.EnableCiliumClusterwideNetworkPolicy, "Enable support for Cilium Clusterwide Network Policy")
+	flags.MarkHidden(option.EnableCiliumClusterwideNetworkPolicy)
+	option.BindEnv(vp, option.EnableCiliumClusterwideNetworkPolicy)
 
 	vp.BindPFlags(flags)
 }

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -736,7 +736,9 @@ func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 			log.WithError(err).WithField(logfields.LogSubsys, "CNPWatcher").Fatal(
 				"Cannot connect to Kubernetes apiserver ")
 		}
+	}
 
+	if legacy.clientset.IsEnabled() && option.Config.EnableCiliumClusterwideNetworkPolicy {
 		err = enableCCNPWatcher(legacy.ctx, &legacy.wg, legacy.clientset)
 		if err != nil {
 			log.WithError(err).WithField(logfields.LogSubsys, "CCNPWatcher").Fatal(

--- a/operator/pkg/networkpolicy/cell.go
+++ b/operator/pkg/networkpolicy/cell.go
@@ -72,8 +72,8 @@ func registerPolicyValidator(params PolicyParams) {
 		return
 	}
 
-	if !option.Config.EnableCiliumNetworkPolicy {
-		params.Logger.Infof("CNP / CCNP validator doesn't run when CNP / CCNP are disabled (%s=false)", option.EnableCiliumNetworkPolicy)
+	if !option.Config.EnableCiliumNetworkPolicy && !option.Config.EnableCiliumClusterwideNetworkPolicy {
+		params.Logger.Infof("CNP / CCNP validator doesn't run when CNP and CCNP are disabled (%s=false AND %s=false)", option.EnableCiliumNetworkPolicy, option.EnableCiliumClusterwideNetworkPolicy)
 		return
 	}
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -533,9 +533,12 @@ const (
 	// EnableK8sNetworkPolicy enables support for K8s NetworkPolicy.
 	EnableK8sNetworkPolicy = true
 
-	// EnableCiliumNetworkPolicy enables support for Cilium Network Policy and
-	// Cilium Clusterwide Network Policy.
+	// EnableCiliumNetworkPolicy enables support for Cilium Network Policy.
 	EnableCiliumNetworkPolicy = true
+
+	// EnableCiliumClusterwideNetworkPolicy enables support for Cilium Clusterwide
+	// Network Policy.
+	EnableCiliumClusterwideNetworkPolicy = true
 
 	// MaxConnectedClusters sets the maximum number of clusters that can be
 	// connected in a clustermesh.

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -51,7 +51,13 @@ func agentCRDResourceNames() []string {
 
 	if option.Config.EnableCiliumNetworkPolicy {
 		result = append(result, CRDResourceName(v2.CNPName))
+	}
+
+	if option.Config.EnableCiliumClusterwideNetworkPolicy {
 		result = append(result, CRDResourceName(v2.CCNPName))
+	}
+
+	if option.Config.EnableCiliumNetworkPolicy || option.Config.EnableCiliumClusterwideNetworkPolicy {
 		result = append(result, CRDResourceName(v2alpha1.CCGName))
 	}
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1099,9 +1099,12 @@ const (
 	// EnableK8sNetworkPolicy enables support for K8s NetworkPolicy.
 	EnableK8sNetworkPolicy = "enable-k8s-networkpolicy"
 
-	// EnableCiliumNetworkPolicy enables support for Cilium Network Policy and
-	// Cilium Clusterwide Network Policy.
+	// EnableCiliumNetworkPolicy enables support for Cilium Network Policy.
 	EnableCiliumNetworkPolicy = "enable-cilium-network-policy"
+
+	// EnableCiliumClusterwideNetworkPolicy enables support for Cilium Clusterwide
+	// Network Policy.
+	EnableCiliumClusterwideNetworkPolicy = "enable-cilium-clusterwide-network-policy"
 
 	// PolicyCIDRMatchMode defines the entities that CIDR selectors can reach
 	PolicyCIDRMatchMode = "policy-cidr-match-mode"
@@ -2181,9 +2184,12 @@ type DaemonConfig struct {
 	// EnableK8sNetworkPolicy enables support for K8s NetworkPolicy.
 	EnableK8sNetworkPolicy bool
 
-	// EnableCiliumNetworkPolicy Enable support for Cilium Network Policy and
-	// Cilium Clusterwide Network Policy.
+	// EnableCiliumNetworkPolicy enables support for Cilium Network Policy.
 	EnableCiliumNetworkPolicy bool
+
+	// EnableCiliumClusterwideNetworkPolicy enables support for Cilium Clusterwide
+	// Network Policy.
+	EnableCiliumClusterwideNetworkPolicy bool
 
 	// PolicyCIDRMatchMode is the list of entities that can be selected by CIDR policy.
 	// Currently supported values:
@@ -2263,13 +2269,14 @@ var (
 
 		K8sEnableLeasesFallbackDiscovery: defaults.K8sEnableLeasesFallbackDiscovery,
 
-		ExternalClusterIP:         defaults.ExternalClusterIP,
-		EnableVTEP:                defaults.EnableVTEP,
-		EnableBGPControlPlane:     defaults.EnableBGPControlPlane,
-		EnableK8sNetworkPolicy:    defaults.EnableK8sNetworkPolicy,
-		EnableCiliumNetworkPolicy: defaults.EnableCiliumNetworkPolicy,
-		PolicyCIDRMatchMode:       defaults.PolicyCIDRMatchMode,
-		MaxConnectedClusters:      defaults.MaxConnectedClusters,
+		ExternalClusterIP:                    defaults.ExternalClusterIP,
+		EnableVTEP:                           defaults.EnableVTEP,
+		EnableBGPControlPlane:                defaults.EnableBGPControlPlane,
+		EnableK8sNetworkPolicy:               defaults.EnableK8sNetworkPolicy,
+		EnableCiliumNetworkPolicy:            defaults.EnableCiliumNetworkPolicy,
+		EnableCiliumClusterwideNetworkPolicy: defaults.EnableCiliumClusterwideNetworkPolicy,
+		PolicyCIDRMatchMode:                  defaults.PolicyCIDRMatchMode,
+		MaxConnectedClusters:                 defaults.MaxConnectedClusters,
 
 		BPFEventsDropEnabled:          defaults.BPFEventsDropEnabled,
 		BPFEventsPolicyVerdictEnabled: defaults.BPFEventsPolicyVerdictEnabled,
@@ -3231,6 +3238,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.NodeLabels = vp.GetStringSlice(NodeLabels)
 
 	c.EnableCiliumNetworkPolicy = vp.GetBool(EnableCiliumNetworkPolicy)
+	c.EnableCiliumClusterwideNetworkPolicy = vp.GetBool(EnableCiliumClusterwideNetworkPolicy)
 
 	// Parse node label patterns
 	nodeLabelPatterns := vp.GetStringSlice(ExcludeNodeLabelPatterns)

--- a/pkg/policy/k8s/cell.go
+++ b/pkg/policy/k8s/cell.go
@@ -143,9 +143,15 @@ func startK8sPolicyWatcher(params PolicyWatcherParams) {
 		p.registerResourceWithSyncFn(ctx, k8sAPIGroupCiliumNetworkPolicyV2, func() bool {
 			return p.cnpSynced.Load() && p.cidrGroupSynced.Load()
 		})
+	}
+
+	if params.Config.EnableCiliumClusterwideNetworkPolicy {
 		p.registerResourceWithSyncFn(ctx, k8sAPIGroupCiliumClusterwideNetworkPolicyV2, func() bool {
 			return p.ccnpSynced.Load() && p.cidrGroupSynced.Load()
 		})
+	}
+
+	if params.Config.EnableCiliumNetworkPolicy || params.Config.EnableCiliumClusterwideNetworkPolicy {
 		p.registerResourceWithSyncFn(ctx, k8sAPIGroupCiliumCIDRGroupV2Alpha1, func() bool {
 			return p.cidrGroupSynced.Load()
 		})

--- a/pkg/policy/k8s/watcher.go
+++ b/pkg/policy/k8s/watcher.go
@@ -79,11 +79,15 @@ func (p *policyWatcher) watchResources(ctx context.Context) {
 		}
 		if p.config.EnableCiliumNetworkPolicy {
 			cnpEvents = p.ciliumNetworkPolicies.Events(ctx)
+		}
+		if p.config.EnableCiliumClusterwideNetworkPolicy {
 			ccnpEvents = p.ciliumClusterwideNetworkPolicies.Events(ctx)
-			// Cilium CDR Group CRD is only used with Cilium Network Policies.
+		}
+		if p.config.EnableCiliumNetworkPolicy || p.config.EnableCiliumClusterwideNetworkPolicy {
+			// Cilium CDR Group CRD is only used with CNP/CCNP.
 			// https://docs.cilium.io/en/latest/network/kubernetes/ciliumcidrgroup/
 			cidrGroupEvents = p.ciliumCIDRGroups.Events(ctx)
-			// Service Cache Notifications are only used with Cilium Network Policies.
+			// Service Cache Notifications are only used with CNP/CCNP.
 			serviceEvents = p.svcCacheNotifications
 		}
 


### PR DESCRIPTION
Related to modularizing network policies: #33360 

Previous config change that includes both CNP and CCNP in the same flag: https://github.com/cilium/cilium/pull/35049

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>