### PR TITLE
.github: remove libncurses5 from integration tests

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -92,7 +92,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          sudo apt update && sudo apt install -y --no-install-recommends build-essential make libncurses5
+          sudo apt update && sudo apt install -y --no-install-recommends build-essential make
 
       - name: Checkout context ref (trusted)
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1


### PR DESCRIPTION
This package was added in 7a301a48c55c ("introduce ARM github workflows") and it's no longer being used so we can remove it as it's not available in ubuntu-latest (24.04).