### PR TITLE
chore: add versioning for drop notify messages

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -566,12 +566,16 @@ enum {
 	.source		= EVENT_SOURCE,	\
 	.hash		= get_hash(ctx)   /* Avoids hash recalculation, assumes hash has been already calculated */
 
-#define __notify_pktcap_hdr(o, c)	\
+#define __notify_pktcap_hdr(o, c, v)	\
 	.len_orig	= (o),		\
 	.len_cap	= (c),		\
-	.version	= NOTIFY_CAPTURE_VER
+	.version	= (v)
 
-/* Capture notifications version. Must be incremented when format changes. */
+/* Base capture notifications version.
+ * Must be incremented when the format of NOTIFY_CAPTURE_HDR changes.
+ *
+ * Individual notify messages may evolve independently, specifying their own versions.
+ */
 #define NOTIFY_CAPTURE_VER 1
 
 #ifndef TRACE_PAYLOAD_LEN

--- a/bpf/lib/dbg.h
+++ b/bpf/lib/dbg.h
@@ -220,7 +220,7 @@ static __always_inline void cilium_dbg_capture2(struct __ctx_buff *ctx, __u8 typ
 	__u64 cap_len = min_t(__u64, TRACE_PAYLOAD_LEN, ctx_len);
 	struct debug_capture_msg msg = {
 		__notify_common_hdr(CILIUM_NOTIFY_DBG_CAPTURE, type),
-		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_CAPTURE_VER),
 		.arg1	= arg1,
 		.arg2	= arg2,
 	};

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -77,7 +77,7 @@ int __send_drop_notify(struct __ctx_buff *ctx)
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_DROP, (__u8)error),
-		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_CAPTURE_VER),
 		.src_label	= ctx_load_meta(ctx, 0),
 		.dst_label	= ctx_load_meta(ctx, 1),
 		.dst_id		= ctx_load_meta(ctx, 3),

--- a/bpf/lib/policy_log.h
+++ b/bpf/lib/policy_log.h
@@ -94,7 +94,7 @@ send_policy_verdict_notify(struct __ctx_buff *ctx, __u32 remote_label, __u16 dst
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_POLICY_VERDICT, 0),
-		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_CAPTURE_VER),
 		.remote_label	= remote_label,
 		.verdict	= verdict,
 		.dst_port	= bpf_ntohs(dst_port),

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -222,7 +222,7 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_CAPTURE_VER),
 		.src_label	= src,
 		.dst_label	= dst,
 		.dst_id		= dst_id,
@@ -266,7 +266,7 @@ send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_CAPTURE_VER),
 		.src_label	= src,
 		.dst_label	= dst,
 		.dst_id		= dst_id,
@@ -312,7 +312,7 @@ send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_CAPTURE_VER),
 		.src_label	= src,
 		.dst_label	= dst,
 		.dst_id		= dst_id,

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -108,12 +108,12 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 
 	switch eventType {
 	case monitorAPI.MessageTypeDrop:
-		packetOffset = monitor.DropNotifyLen
 		dn = &monitor.DropNotify{}
 		if err := monitor.DecodeDropNotify(data, dn); err != nil {
 			return fmt.Errorf("failed to parse drop: %w", err)
 		}
 		eventSubType = dn.SubType
+		packetOffset = (int)(dn.DataOffset())
 	case monitorAPI.MessageTypeTrace:
 		tn = &monitor.TraceNotify{}
 		if err := monitor.DecodeTraceNotify(data, tn); err != nil {

--- a/pkg/monitor/datapath_drop_test.go
+++ b/pkg/monitor/datapath_drop_test.go
@@ -16,7 +16,7 @@ import (
 func TestDecodeDropNotify(t *testing.T) {
 	// This check on the struct length constant is there to ensure that this
 	// test is updated when the struct changes.
-	require.Equal(t, 36, DropNotifyLen)
+	require.Equal(t, 36, DropNotifyV1Len)
 
 	input := DropNotify{
 		Type:     0x00,
@@ -24,7 +24,8 @@ func TestDecodeDropNotify(t *testing.T) {
 		Source:   0x02_03,
 		Hash:     0x04_05_06_07,
 		OrigLen:  0x08_09_0a_0b,
-		CapLen:   0x0c_0d_0e_10,
+		CapLen:   0x0c_0d,
+		Version:  0x01,
 		SrcLabel: 0x11_12_13_14,
 		DstLabel: 0x15_16_17_18,
 		DstID:    0x19_1a_1b_1c,


### PR DESCRIPTION
Related: #35057

Aligns the control-plane drop notify struct with the dataplane struct, which contains a version field. This is modeled on a similar change to trace notify, which is versioned.

Also changed `__notify_pktcap_hdr` function to accept a version, as the version for each notification can evolve independently.

Similar change was done in https://github.com/cilium/cilium/pull/9321

---

When making changes to the datapath structs produced, we need to be congnizant of how these messages are consumed. Below considers the most interesting/problematic cases and their result:

1. For the upgrade case:
- dataplane format is the same
- cap field value is handled correctly in control-plane

2. For Downgrade case:
- dataplane format is the same
- cap field value is handled as it currently is

Future version iterations to consider downgrade cases.

```release-note
Add versioning to drop notify events.
```
