### PR TITLE
hubble: fix endpoint cluster name

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -660,13 +660,13 @@ func (e *Endpoint) GetID() uint64 {
 	return uint64(e.ID)
 }
 
-// GetLabels returns the labels as slice
-func (e *Endpoint) GetLabels() []string {
+// GetLabels returns the labels.
+func (e *Endpoint) GetLabels() labels.Labels {
 	if e.SecurityIdentity == nil {
-		return []string{}
+		return labels.Labels{}
 	}
 
-	return e.SecurityIdentity.Labels.GetModel()
+	return e.SecurityIdentity.Labels
 }
 
 // GetSecurityIdentity returns the security identity of the endpoint. It assumes

--- a/pkg/hubble/parser/common/endpoint.go
+++ b/pkg/hubble/parser/common/endpoint.go
@@ -139,11 +139,12 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 	if r.endpointGetter != nil {
 		if ep, ok := r.endpointGetter.GetEndpointInfo(ip); ok {
 			epIdentity := resolveIdentityConflict(ep.GetIdentity(), true)
+			labels := ep.GetLabels()
 			e := &pb.Endpoint{
 				ID:        uint32(ep.GetID()),
 				Identity:  epIdentity,
 				Namespace: ep.GetK8sNamespace(),
-				Labels:    SortAndFilterLabels(r.log, ep.GetLabels(), identity.NumericIdentity(epIdentity)),
+				Labels:    SortAndFilterLabels(r.log, labels.GetModel(), identity.NumericIdentity(epIdentity)),
 				PodName:   ep.GetK8sPodName(),
 			}
 			if pod := ep.GetPod(); pod != nil {

--- a/pkg/hubble/parser/common/endpoint.go
+++ b/pkg/hubble/parser/common/endpoint.go
@@ -141,11 +141,12 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 			epIdentity := resolveIdentityConflict(ep.GetIdentity(), true)
 			labels := ep.GetLabels()
 			e := &pb.Endpoint{
-				ID:        uint32(ep.GetID()),
-				Identity:  epIdentity,
-				Namespace: ep.GetK8sNamespace(),
-				Labels:    SortAndFilterLabels(r.log, labels.GetModel(), identity.NumericIdentity(epIdentity)),
-				PodName:   ep.GetK8sPodName(),
+				ID:          uint32(ep.GetID()),
+				Identity:    epIdentity,
+				ClusterName: (labels[k8sConst.PolicyLabelCluster]).Value,
+				Namespace:   ep.GetK8sNamespace(),
+				Labels:      SortAndFilterLabels(r.log, labels.GetModel(), identity.NumericIdentity(epIdentity)),
+				PodName:     ep.GetK8sPodName(),
 			}
 			if pod := ep.GetPod(); pod != nil {
 				workload, workloadTypeMeta, ok := utils.GetWorkloadMetaFromPod(pod)

--- a/pkg/hubble/parser/debug/parser.go
+++ b/pkg/hubble/parser/debug/parser.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/parser/common"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/monitor"
@@ -70,11 +71,12 @@ func (p *Parser) decodeEndpoint(id uint16) *flowpb.Endpoint {
 	epId := uint32(id)
 	if p.endpointGetter != nil {
 		if ep, ok := p.endpointGetter.GetEndpointInfoByID(id); ok {
+			labels := ep.GetLabels()
 			return &flowpb.Endpoint{
 				ID:        epId,
 				Identity:  uint32(ep.GetIdentity()),
 				Namespace: ep.GetK8sNamespace(),
-				Labels:    ep.GetLabels(),
+				Labels:    common.SortAndFilterLabels(p.log, labels.GetModel(), ep.GetIdentity()),
 				PodName:   ep.GetK8sPodName(),
 			}
 		}

--- a/pkg/hubble/parser/debug/parser.go
+++ b/pkg/hubble/parser/debug/parser.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/parser/common"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/monitor"
 	"github.com/cilium/cilium/pkg/monitor/api"
 )
@@ -73,11 +74,12 @@ func (p *Parser) decodeEndpoint(id uint16) *flowpb.Endpoint {
 		if ep, ok := p.endpointGetter.GetEndpointInfoByID(id); ok {
 			labels := ep.GetLabels()
 			return &flowpb.Endpoint{
-				ID:        epId,
-				Identity:  uint32(ep.GetIdentity()),
-				Namespace: ep.GetK8sNamespace(),
-				Labels:    common.SortAndFilterLabels(p.log, labels.GetModel(), ep.GetIdentity()),
-				PodName:   ep.GetK8sPodName(),
+				ID:          epId,
+				Identity:    uint32(ep.GetIdentity()),
+				ClusterName: (labels[k8sConst.PolicyLabelCluster]).Value,
+				Namespace:   ep.GetK8sNamespace(),
+				Labels:      common.SortAndFilterLabels(p.log, labels.GetModel(), ep.GetIdentity()),
+				PodName:     ep.GetK8sPodName(),
 			}
 		}
 	}

--- a/pkg/hubble/parser/debug/parser_test.go
+++ b/pkg/hubble/parser/debug/parser_test.go
@@ -104,10 +104,11 @@ func TestDecodeDebugEvent(t *testing.T) {
 			ev: &flowpb.DebugEvent{
 				Type: flowpb.DebugEventType_DBG_IP_ID_MAP_SUCCEED4,
 				Source: &flowpb.Endpoint{
-					ID:        1234,
-					Identity:  5678,
-					PodName:   "hubble-ui",
-					Namespace: "kube-system",
+					ID:          1234,
+					Identity:    5678,
+					PodName:     "hubble-ui",
+					ClusterName: "default",
+					Namespace:   "kube-system",
 					Labels: []string{
 						"k8s:app.kubernetes.io/name=hubble-ui",
 						"k8s:app.kubernetes.io/part-of=cilium",
@@ -138,10 +139,11 @@ func TestDecodeDebugEvent(t *testing.T) {
 			ev: &flowpb.DebugEvent{
 				Type: flowpb.DebugEventType_DBG_ICMP6_HANDLE,
 				Source: &flowpb.Endpoint{
-					ID:        1234,
-					Identity:  5678,
-					PodName:   "hubble-ui",
-					Namespace: "kube-system",
+					ID:          1234,
+					Identity:    5678,
+					PodName:     "hubble-ui",
+					ClusterName: "default",
+					Namespace:   "kube-system",
 					Labels: []string{
 						"k8s:app.kubernetes.io/name=hubble-ui",
 						"k8s:app.kubernetes.io/part-of=cilium",

--- a/pkg/hubble/parser/debug/parser_test.go
+++ b/pkg/hubble/parser/debug/parser_test.go
@@ -44,8 +44,16 @@ func TestDecodeDebugEvent(t *testing.T) {
 				return &testutils.FakeEndpointInfo{
 					ID:           1234,
 					Identity:     5678,
-					PodName:      "somepod",
-					PodNamespace: "default",
+					PodName:      "hubble-ui",
+					PodNamespace: "kube-system",
+					Labels: []string{
+						"k8s:io.cilium.k8s.policy.cluster=default",
+						"k8s:io.kubernetes.pod.namespace=kube-system",
+						"k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=kube-system",
+						"k8s:k8s-app=hubble-ui",
+						"k8s:app.kubernetes.io/name=hubble-ui",
+						"k8s:app.kubernetes.io/part-of=cilium",
+					},
 				}, true
 			}
 			return nil, false
@@ -98,8 +106,16 @@ func TestDecodeDebugEvent(t *testing.T) {
 				Source: &flowpb.Endpoint{
 					ID:        1234,
 					Identity:  5678,
-					PodName:   "somepod",
-					Namespace: "default",
+					PodName:   "hubble-ui",
+					Namespace: "kube-system",
+					Labels: []string{
+						"k8s:app.kubernetes.io/name=hubble-ui",
+						"k8s:app.kubernetes.io/part-of=cilium",
+						"k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=kube-system",
+						"k8s:io.cilium.k8s.policy.cluster=default",
+						"k8s:io.kubernetes.pod.namespace=kube-system",
+						"k8s:k8s-app=hubble-ui",
+					},
 				},
 				Hash:    wrapperspb.UInt32(705182630),
 				Arg1:    wrapperspb.UInt32(3909094154),
@@ -124,8 +140,16 @@ func TestDecodeDebugEvent(t *testing.T) {
 				Source: &flowpb.Endpoint{
 					ID:        1234,
 					Identity:  5678,
-					PodName:   "somepod",
-					Namespace: "default",
+					PodName:   "hubble-ui",
+					Namespace: "kube-system",
+					Labels: []string{
+						"k8s:app.kubernetes.io/name=hubble-ui",
+						"k8s:app.kubernetes.io/part-of=cilium",
+						"k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=kube-system",
+						"k8s:io.cilium.k8s.policy.cluster=default",
+						"k8s:io.kubernetes.pod.namespace=kube-system",
+						"k8s:k8s-app=hubble-ui",
+					},
 				},
 				Hash:    wrapperspb.UInt32(0x9dd55684),
 				Arg1:    wrapperspb.UInt32(129),

--- a/pkg/hubble/parser/getters/getters.go
+++ b/pkg/hubble/parser/getters/getters.go
@@ -76,7 +76,7 @@ type EndpointInfo interface {
 	GetIdentity() identity.NumericIdentity
 	GetK8sPodName() string
 	GetK8sNamespace() string
-	GetLabels() []string
+	GetLabels() labels.Labels
 	GetPod() *slim_corev1.Pod
 	GetRealizedPolicyRuleLabelsForKey(key policyTypes.Key) (derivedFrom labels.LabelArrayList, revision uint64, ok bool)
 }

--- a/pkg/hubble/parser/seven/parser.go
+++ b/pkg/hubble/parser/seven/parser.go
@@ -17,9 +17,11 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -326,11 +328,12 @@ func decodeEndpoint(endpoint accesslog.EndpointInfo, namespace, podName string) 
 	labels := endpoint.Labels.GetModel()
 	slices.Sort(labels)
 	return &flowpb.Endpoint{
-		ID:        uint32(endpoint.ID),
-		Identity:  uint32(endpoint.Identity),
-		Namespace: namespace,
-		Labels:    labels,
-		PodName:   podName,
+		ID:          uint32(endpoint.ID),
+		Identity:    uint32(endpoint.Identity),
+		ClusterName: endpoint.Labels.Get(string(source.Kubernetes) + "." + k8sConst.PolicyLabelCluster),
+		Namespace:   namespace,
+		Labels:      labels,
+		PodName:     podName,
 	}
 }
 

--- a/pkg/hubble/parser/seven/parser_test.go
+++ b/pkg/hubble/parser/seven/parser_test.go
@@ -102,3 +102,34 @@ func Test_decodeVerdict(t *testing.T) {
 	assert.Equal(t, flowpb.Verdict_REDIRECTED, decodeVerdict(accesslog.VerdictRedirected))
 	assert.Equal(t, flowpb.Verdict_VERDICT_UNKNOWN, decodeVerdict("bad"))
 }
+
+func Test_decodeEndpoint(t *testing.T) {
+	epi := accesslog.EndpointInfo{
+		ID:       1234,
+		Identity: 9876,
+		Labels: labels.ParseLabelArray(
+			"k8s:io.cilium.k8s.policy.cluster=default",
+			"k8s:io.kubernetes.pod.namespace=kube-system",
+			"k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=kube-system",
+			"k8s:k8s-app=hubble-ui",
+			"k8s:app.kubernetes.io/name=hubble-ui",
+			"k8s:app.kubernetes.io/part-of=cilium",
+		),
+	}
+	expected := &flowpb.Endpoint{
+		ID:        1234,
+		Identity:  9876,
+		Namespace: "kube-system",
+		Labels: []string{
+			"k8s:app.kubernetes.io/name=hubble-ui",
+			"k8s:app.kubernetes.io/part-of=cilium",
+			"k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=kube-system",
+			"k8s:io.cilium.k8s.policy.cluster=default",
+			"k8s:io.kubernetes.pod.namespace=kube-system",
+			"k8s:k8s-app=hubble-ui",
+		},
+		PodName: "hubble-ui",
+	}
+	ep := decodeEndpoint(epi, "kube-system", "hubble-ui")
+	assert.Equal(t, expected, ep)
+}

--- a/pkg/hubble/parser/seven/parser_test.go
+++ b/pkg/hubble/parser/seven/parser_test.go
@@ -117,9 +117,10 @@ func Test_decodeEndpoint(t *testing.T) {
 		),
 	}
 	expected := &flowpb.Endpoint{
-		ID:        1234,
-		Identity:  9876,
-		Namespace: "kube-system",
+		ID:          1234,
+		Identity:    9876,
+		ClusterName: "default",
+		Namespace:   "kube-system",
 		Labels: []string{
 			"k8s:app.kubernetes.io/name=hubble-ui",
 			"k8s:app.kubernetes.io/part-of=cilium",

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -1243,8 +1243,15 @@ func TestTraceNotifyLocalEndpoint(t *testing.T) {
 		Identity:     4567,
 		IPv4:         net.ParseIP("1.1.1.1"),
 		PodName:      "xwing",
-		PodNamespace: "default",
-		Labels:       []string{"a", "b", "c"},
+		PodNamespace: "kube-system",
+		Labels: []string{
+			"k8s:io.cilium.k8s.policy.cluster=default",
+			"k8s:io.kubernetes.pod.namespace=kube-system",
+			"k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=kube-system",
+			"k8s:org=alliance",
+			"k8s:class=xwing",
+			"k8s:app.kubernetes.io/name=xwing",
+		},
 	}
 	endpointGetter := &testutils.FakeEndpointGetter{
 		OnGetEndpointInfo: func(ip netip.Addr) (endpoint getters.EndpointInfo, ok bool) {
@@ -1280,7 +1287,7 @@ func TestTraceNotifyLocalEndpoint(t *testing.T) {
 	assert.Equal(t, uint32(ep.ID), f.Source.ID)
 	assert.Equal(t, uint32(v0.SrcLabel), f.Source.Identity)
 	assert.Equal(t, ep.PodNamespace, f.Source.Namespace)
-	assert.Equal(t, ep.Labels, f.Source.Labels)
+	assert.Equal(t, common.SortAndFilterLabels(log, ep.Labels, ep.Identity), f.Source.Labels)
 	assert.Equal(t, ep.PodName, f.Source.PodName)
 }
 

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -1286,6 +1286,7 @@ func TestTraceNotifyLocalEndpoint(t *testing.T) {
 
 	assert.Equal(t, uint32(ep.ID), f.Source.ID)
 	assert.Equal(t, uint32(v0.SrcLabel), f.Source.Identity)
+	assert.Equal(t, "default", f.GetSource().GetClusterName())
 	assert.Equal(t, ep.PodNamespace, f.Source.Namespace)
 	assert.Equal(t, common.SortAndFilterLabels(log, ep.Labels, ep.Identity), f.Source.Labels)
 	assert.Equal(t, ep.PodName, f.Source.PodName)

--- a/pkg/hubble/testutils/fake.go
+++ b/pkg/hubble/testutils/fake.go
@@ -450,8 +450,8 @@ func (e *FakeEndpointInfo) GetK8sNamespace() string {
 }
 
 // GetLabels returns the labels of the endpoint.
-func (e *FakeEndpointInfo) GetLabels() []string {
-	return e.Labels
+func (e *FakeEndpointInfo) GetLabels() labels.Labels {
+	return labels.NewLabelsFromModel(e.Labels)
 }
 
 // GetPod return the pod object of the endpoint.


### PR DESCRIPTION
Add endpoint cluster name info for local endpoints, debug events, and L7 flows. Follow-up PR of https://github.com/cilium/cilium/pull/32313 which added cluster name to remote endpoints for L3L4 flows.

Locally tested with the [Star Wars demo](https://docs.cilium.io/en/stable/gettingstarted/demo/):
<details>
  <summary>local endpoint</summary>

  ```console
% kubectl get pods --all-namespaces -o "custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,NODE:.spec.nodeName" | awk 'NR == 1 || /tiefighter|deathstar|cilium-[0-9a-z]+\s/ {print}'
NAMESPACE            NAME                                         NODE
default              deathstar-bf77cddc9-jpnls                    kind-worker
default              deathstar-bf77cddc9-q2q4p                    kind-control-plane
default              tiefighter                                    kind-worker
kube-system          cilium-5nsbl                                 kind-control-plane
kube-system          cilium-jxqxw                                 kind-worker
% kubectl exec tiefighter -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
Ship landed
% kubectl exec -n kube-system cilium-jxqxw -c cilium-agent -- hubble observe flows --from-pod tiefighter --to-pod deathstar --type trace --first 1 -o json | jq
{
  "flow": {
    "time": "2024-10-16T15:22:09.060066037Z",
    "uuid": "5e524183-b28d-4a01-a5dc-82128325e946",
    "verdict": "FORWARDED",
    "ethernet": {
      "source": "8a:37:ab:1d:35:f0",
      "destination": "ba:59:62:b6:08:01"
    },
    "IP": {
      "source": "10.244.1.249",
      "destination": "10.244.0.76",
      "ipVersion": "IPv4"
    },
    "l4": {
      "TCP": {
        "source_port": 56468,
        "destination_port": 80,
        "flags": {
          "SYN": true
        }
      }
    },
    "source": {
      "ID": 1250,
      "identity": 47651,
      "cluster_name": "kind-kind",
      "namespace": "default",
      "labels": [
        "k8s:app.kubernetes.io/name=tiefighter",
        "k8s:class=tiefighter",
        "k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=default",
        "k8s:io.cilium.k8s.policy.cluster=kind-kind",
        "k8s:io.cilium.k8s.policy.serviceaccount=default",
        "k8s:io.kubernetes.pod.namespace=default",
        "k8s:org=empire"
      ],
      "pod_name": "tiefighter"
    },
    "destination": {
      "identity": 21223,
      "cluster_name": "kind-kind",
      "namespace": "default",
      "labels": [
        "k8s:app.kubernetes.io/name=deathstar",
        "k8s:class=deathstar",
        "k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=default",
        "k8s:io.cilium.k8s.policy.cluster=kind-kind",
        "k8s:io.cilium.k8s.policy.serviceaccount=default",
        "k8s:io.kubernetes.pod.namespace=default",
        "k8s:org=empire"
      ],
      "pod_name": "deathstar-bf77cddc9-q2q4p"
    },
    "Type": "L3_L4",
    "node_name": "kind-kind/kind-worker",
    "node_labels": [
      "beta.kubernetes.io/arch=amd64",
      "beta.kubernetes.io/os=linux",
      "kubernetes.io/arch=amd64",
      "kubernetes.io/hostname=kind-worker",
      "kubernetes.io/os=linux"
    ],
    "event_type": {
      "type": 4,
      "sub_type": 4
    },
    "traffic_direction": "EGRESS",
    "trace_observation_point": "TO_OVERLAY",
    "trace_reason": "NEW",
    "is_reply": false,
    "interface": {
      "index": 4,
      "name": "cilium_vxlan"
    },
    "Summary": "TCP Flags: SYN"
  },
  "node_name": "kind-kind/kind-worker",
  "time": "2024-10-16T15:22:09.060066037Z"
}
  ```
</details>
<details>
  <summary>debug event</summary>

  ```console
% kubectl exec -it -n kube-system cilium-jxqxw -c cilium-agent -- cilium endpoint get -l k8s:app.kubernetes.io/name=tiefighter -o jsonpath='{[0].id}'
1250
% kubectl exec -it -n kube-system cilium-jxqxw -c cilium-agent -- cilium endpoint config 1250 Debug=true
Endpoint 1250 configuration updated successfully
% kubectl exec -n kube-system cilium-jxqxw -c cilium-agent -- hubble observe debug-events -f -o json | head -n1 | jq &
% kubectl exec tiefighter -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
{
  "debug_event": {
    "type": "DBG_CT_LOOKUP4_1",
    "source": {
      "ID": 1250,
      "identity": 47651,
      "cluster_name": "kind-kind",
      "namespace": "default",
      "labels": [
        "k8s:app.kubernetes.io/name=tiefighter",
        "k8s:class=tiefighter",
        "k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=default",
        "k8s:io.cilium.k8s.policy.cluster=kind-kind",
        "k8s:io.cilium.k8s.policy.serviceaccount=default",
        "k8s:io.kubernetes.pod.namespace=default",
        "k8s:org=empire"
      ],
      "pod_name": "tiefighter"
    },
    "hash": 635510294,
    "arg1": 4177654794,
    "arg2": 167796746,
    "arg3": 3522142,
    "message": "Conntrack lookup 1/2: src=10.244.1.249:48734 dst=10.96.0.10:53",
    "cpu": 0
  },
  "node_name": "kind-kind/kind-worker",
  "time": "2024-10-16T15:47:21.803847602Z"
}
Ship landed
  ```
</details>
<details>
  <summary>L7</summary>

  ```console
% kubectl exec tiefighter -- curl -s -XPOST deathstar.default.svc.cluster.local/v1/request-landing
Ship landed
% kubectl exec -n kube-system cilium-jxqxw -c cilium-agent -- hubble observe flows --from-pod tiefighter --to-pod deathstar --type l7 --first 1 -o json | jq
{
  "flow": {
    "time": "2024-10-16T15:50:01.789485280Z",
    "uuid": "52505121-81b9-4946-a02a-979c132b0096",
    "verdict": "FORWARDED",
    "IP": {
      "source": "10.244.1.249",
      "destination": "10.244.1.112",
      "ipVersion": "IPv4"
    },
    "l4": {
      "TCP": {
        "source_port": 36742,
        "destination_port": 80
      }
    },
    "source": {
      "ID": 1250,
      "identity": 47651,
      "cluster_name": "kind-kind",
      "namespace": "default",
      "labels": [
        "k8s:app.kubernetes.io/name=tiefighter",
        "k8s:class=tiefighter",
        "k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=default",
        "k8s:io.cilium.k8s.policy.cluster=kind-kind",
        "k8s:io.cilium.k8s.policy.serviceaccount=default",
        "k8s:io.kubernetes.pod.namespace=default",
        "k8s:org=empire"
      ],
      "pod_name": "tiefighter"
    },
    "destination": {
      "ID": 1947,
      "identity": 21223,
      "cluster_name": "kind-kind",
      "namespace": "default",
      "labels": [
        "k8s:app.kubernetes.io/name=deathstar",
        "k8s:class=deathstar",
        "k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=default",
        "k8s:io.cilium.k8s.policy.cluster=kind-kind",
        "k8s:io.cilium.k8s.policy.serviceaccount=default",
        "k8s:io.kubernetes.pod.namespace=default",
        "k8s:org=empire"
      ],
      "pod_name": "deathstar-bf77cddc9-jpnls",
      "workloads": [
        {
          "name": "deathstar",
          "kind": "Deployment"
        }
      ]
    },
    "Type": "L7",
    "node_name": "kind-kind/kind-worker",
    "node_labels": [
      "beta.kubernetes.io/arch=amd64",
      "beta.kubernetes.io/os=linux",
      "kubernetes.io/arch=amd64",
      "kubernetes.io/hostname=kind-worker",
      "kubernetes.io/os=linux"
    ],
    "l7": {
      "type": "REQUEST",
      "http": {
        "method": "POST",
        "url": "http://deathstar.default.svc.cluster.local/v1/request-landing",
        "protocol": "HTTP/1.1",
        "headers": [
          {
            "key": ":scheme",
            "value": "http"
          },
          {
            "key": "Accept",
            "value": "*/*"
          },
          {
            "key": "User-Agent",
            "value": "curl/7.88.1"
          },
          {
            "key": "X-Envoy-Internal",
            "value": "true"
          },
          {
            "key": "X-Request-Id",
            "value": "415b6302-ba7a-431e-93ab-59a9fd7d955a"
          }
        ]
      }
    },
    "event_type": {
      "type": 129
    },
    "traffic_direction": "INGRESS",
    "is_reply": false,
    "Summary": "HTTP/1.1 POST http://deathstar.default.svc.cluster.local/v1/request-landing"
  },
  "node_name": "kind-kind/kind-worker",
  "time": "2024-10-16T15:50:01.789485280Z"
}
  ```
</details>