### PR TITLE
gha: Remove hostLegacyRouting in clustermesh

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -325,11 +325,6 @@ jobs:
           CILIUM_INSTALL_INGRESS=""
           if [ "${{ matrix.kube-proxy }}" == "none" ]; then
             CILIUM_INSTALL_INGRESS="--helm-set=ingressController.enabled=true"
-            # Once https://github.com/cilium/cilium/issues/31653 is fixed, we can remove tunnel check
-            # Use the legacy host routing in case of tunnel disabled
-            if [ "${{ matrix.tunnel }}" == "disabled" ]; then
-              CILIUM_INSTALL_INGRESS+=" --helm-set=bpf.hostLegacyRouting=true"
-            fi
           fi
 
           CONNECTIVITY_TEST_DEFAULTS="--hubble=false \

--- a/Documentation/network/servicemesh/ingress-known-issues.rst
+++ b/Documentation/network/servicemesh/ingress-known-issues.rst
@@ -5,8 +5,4 @@ Known Issues
   traffic can have issues with traffic to Envoy arriving on the same node as a
   backend Pod unless you set ``endpointRoutes.enabled`` to ``true`` in Helm.
   Fixing this issue is tracked in `#24318 <https://github.com/cilium/cilium/issues/24318>`_.
-* Similarly, you are using Native Routing, (no tunneling) and your Cilium install
-  sets the Helm ``bpf.masquerade`` value to ``true``,you can also have issues
-  with same-node backend routing. The workaround in this case is to set
-  ``hostLegacyRouting`` to ``true``. Fixing this issue is tracked in
-  `#31653 <https://github.com/cilium/cilium/issues/31653>`_.
+


### PR DESCRIPTION
Relates: https://github.com/cilium/cilium/pull/35098
Fixes: https://github.com/cilium/cilium/issues/31653