### PR TITLE
[v1.15] fix: Assign PodStore from Pod resource until cell migration is completed

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -660,6 +660,15 @@ func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 	ciliumNodeSynchronizer := newCiliumNodeSynchronizer(legacy.clientset, nodeManager, withKVStore)
 
 	if legacy.clientset.IsEnabled() {
+		// ciliumNodeSynchronizer uses operatorWatchers.PodStore for IPAM surge
+		// allocation. Initializing PodStore from Pod resource is temporary until
+		// ciliumNodeSynchronizer is migrated to a cell.
+		podStore, err := legacy.resources.Pods.Store(legacy.ctx)
+		if err != nil {
+			log.WithError(err).Fatal("Unable to retrieve Pod store from Pod resource watcher")
+		}
+		operatorWatchers.PodStore = podStore.CacheStore()
+
 		if err := ciliumNodeSynchronizer.Start(legacy.ctx, &legacy.wg); err != nil {
 			log.WithError(err).Fatal("Unable to setup cilium node synchronizer")
 		}

--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strconv"
 
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -56,4 +58,25 @@ func CiliumEndpointSliceResource(lc cell.Lifecycle, cs client.Clientset, opts ..
 		opts...,
 	)
 	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](lc, lw, resource.WithMetric("CiliumEndpointSlice")), nil
+}
+
+func PodResource(lc cell.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*slim_corev1.Pod], error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped[*slim_corev1.PodList](cs.Slim().CoreV1().Pods("")),
+		opts...,
+	)
+
+	indexers := cache.Indexers{
+		// Thix index is used for IPAM by the ciliumNodeSynchronizer.
+		PodNodeNameIndex: PodNodeNameIndexFunc,
+	}
+
+	return resource.New[*slim_corev1.Pod](lc, lw,
+			resource.WithMetric("Pod"),
+			resource.WithIndexers(indexers),
+		),
+		nil
 }

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	CiliumEndpointIndexIdentity = "identity"
+	PodNodeNameIndex            = "pod-node"
 )
 
 var (
@@ -36,7 +37,7 @@ var (
 			CiliumEndpointResource,
 			CiliumEndpointSliceResource,
 			k8s.CiliumNodeResource,
-			k8s.PodResource,
+			PodResource,
 		),
 	)
 )
@@ -54,4 +55,13 @@ type Resources struct {
 	CiliumEndpointSlices resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice]
 	CiliumNodes          resource.Resource[*cilium_api_v2.CiliumNode]
 	Pods                 resource.Resource[*slim_corev1.Pod]
+}
+
+// podNodeNameIndexFunc indexes pods by node name.
+func PodNodeNameIndexFunc(obj interface{}) ([]string, error) {
+	pod := obj.(*slim_corev1.Pod)
+	if pod.Spec.NodeName != "" {
+		return []string{pod.Spec.NodeName}, nil
+	}
+	return []string{}, nil
 }

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/cache"
 
+	operatorK8s "github.com/cilium/cilium/operator/k8s"
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/operator/watchers"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -291,7 +292,7 @@ func getPendingPodCount(nodeName string) (int, error) {
 	if watchers.PodStore == nil {
 		return pendingPods, fmt.Errorf("pod store uninitialized")
 	}
-	values, err := watchers.PodStore.(cache.Indexer).ByIndex(watchers.PodNodeNameIndex, nodeName)
+	values, err := watchers.PodStore.(cache.Indexer).ByIndex(operatorK8s.PodNodeNameIndex, nodeName)
 	if err != nil {
 		return pendingPods, fmt.Errorf("unable to access pod to node name index: %w", err)
 	}


### PR DESCRIPTION
Backport https://github.com/cilium/cilium/pull/34090 to 1.15

A couple of notes:
- There was only one small change I needed to do: I added [`PodResource`](https://github.com/cilium/cilium/blob/c3db8a5ba810327584b9f8438a8e9ec55cae69ef/operator/k8s/resource_ctors.go#L99-L120) to `operator/k8s/resource_ctors.go` which was created recently in https://github.com/cilium/cilium/pull/33021 and didn't exist in 1.15
- I also ignored the follow-up PR https://github.com/cilium/cilium/pull/34404

I tested the backport in our cluster running 1.15 and confirmed that "Unable to compute pending pods, will not surge-allocate" warnings were gone.

```upstream-prs
34090
```