### PR TITLE
docs: update default identity label filters

### DIFF
--- a/Documentation/operations/performance/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/performance/scalability/identity-relevant-labels.rst
@@ -57,6 +57,7 @@ Label                                      Description
 ``reserved:.*``                            Include all ``reserved:`` labels
 ``io\.kubernetes\.pod\.namespace``         Include all ``io.kubernetes.pod.namespace`` labels
 ``io\.cilium\.k8s\.namespace\.labels``     Include all ``io.cilium.k8s.namespace.labels`` labels
+``io\.cilium\.k8s\.policy\.cluster``       Include all ``io.cilium.k8s.policy.cluster`` labels
 ``app\.kubernetes\.io``                    Include all ``app.kubernetes.io`` labels
 ========================================== =====================================================
 


### PR DESCRIPTION
PR #31178 added "io.cilium.k8s.policy.cluster" label to default ones that are propagated even when strict filters are applied.

Fixes: #31178
