### PR TITLE
bugtool: dump all nft rules

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -122,6 +122,8 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		// tc
 		"tc qdisc show",
 		"tc -d -s qdisc show", // Show statistics on queuing disciplines
+		// nft
+		"nft -n list ruleset", // dump all nft rules
 	}
 
 	// LB and CT map for debugging services; using bpftool for a reliable dump

--- a/images/runtime/Dockerfile
+++ b/images/runtime/Dockerfile
@@ -29,7 +29,7 @@ FROM ${UBUNTU_IMAGE} AS rootfs
 
 # Change the number to force the generation of a new git-tree SHA. Useful when
 # we want to re-run 'apt-get upgrade' for stale images.
-ENV FORCE_BUILD=4
+ENV FORCE_BUILD=5
 
 # Update ubuntu packages to the most recent versions
 RUN apt-get update && \

--- a/images/runtime/install-runtime-deps.sh
+++ b/images/runtime/install-runtime-deps.sh
@@ -17,6 +17,8 @@ packages=(
   ipset
   kmod
   ca-certificates
+  # For debugging
+  nftables
 )
 
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
We dump all nft-iptables-compat rules, but we should also dump any native nft rules as well. This is because rules that are added with the `nft` binary directly do not show up in `iptables-save`, even when it is using the nftables backend.