### PR TITLE
ci: datapath-verifier: bump lvh images

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -87,25 +87,25 @@ jobs:
       matrix:
         include:
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '5.4-20240710.064909'
+          - kernel: '5.4-20241010.074256'
             ci-kernel: '54'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: 'rhel8-20240710.064909'
+          - kernel: 'rhel8-20240730.211420'
             ci-kernel: '54'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '5.10-20240710.064909'
+          - kernel: '5.10-20241010.074256'
             ci-kernel: '510'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '5.15-20240710.064909'
+          - kernel: '5.15-20241010.074256'
             ci-kernel: '510'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '6.1-20240710.064909'
+          - kernel: '6.1-20241010.074256'
             ci-kernel: '61'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '6.6-20240710.064909'
+          - kernel: '6.6-20241010.074256'
             ci-kernel: '61'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: 'bpf-next-20240711.013133'
+          - kernel: 'bpf-next-20241018.013308'
             ci-kernel: 'netnext'
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Manually bump the lvh images to the latest versions selected by renovate
(https://github.com/cilium/cilium/pull/35434).