### PR TITLE
.github: remove retention days for image digests

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -202,7 +202,6 @@ jobs:
         with:
           name: image-digest-output.txt-${{ steps.tag.outputs.tag }}
           path: image-digest-output.txt
-          retention-days: 10
 
       # Upload artifact digests
       - name: Upload artifact digests
@@ -210,4 +209,3 @@ jobs:
         with:
           name: Makefile.digests-${{ steps.tag.outputs.tag }}
           path: Makefile.digests
-          retention-days: 10


### PR DESCRIPTION
It is useful to keep the image digests as long as possible, thus this commit removes the retention period of 10 days.