### PR TITLE
bpf: slim down EGW-related CT lookup in to-netdev

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1551,12 +1551,10 @@ skip_host_firewall:
 		void *data, *data_end;
 		struct iphdr *ip4;
 		struct ipv4_ct_tuple tuple = {};
-		struct ct_state ct_state = {};
-		enum ct_status ct_status;
-		bool has_l4_header = true;
 		int l4_off;
 		struct remote_endpoint_info *info;
 		struct endpoint_info *src_ep;
+		bool is_reply;
 
 		if (src_sec_identity == HOST_ID)
 			goto skip_egress_gateway;
@@ -1578,7 +1576,7 @@ skip_host_firewall:
 
 		l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
 		ret = ct_extract_ports4(ctx, ip4, l4_off, CT_EGRESS, &tuple,
-					&has_l4_header);
+					NULL);
 		if (IS_ERR(ret)) {
 			if (ret == DROP_CT_UNKNOWN_PROTO)
 				goto skip_egress_gateway;
@@ -1586,16 +1584,10 @@ skip_host_firewall:
 			goto drop_err;
 		}
 
-		__ipv4_ct_tuple_reverse(&tuple);
-		ret = ct_lazy_lookup4(get_ct_map4(&tuple),
-				      &tuple, ctx, ipv4_is_fragment(ip4),
-				      l4_off, has_l4_header, CT_EGRESS,
-				      SCOPE_FORWARD, CT_ENTRY_ANY,
-				      &ct_state, &trace.monitor);
-		if (IS_ERR(ret))
-			goto drop_err;
-
-		ct_status = (enum ct_status)ret;
+		/* Only handle outbound connections: */
+		is_reply = ct_is_reply4(get_ct_map4(&tuple), &tuple);
+		if (is_reply)
+			goto skip_egress_gateway;
 
 		src_ep = __lookup_ip4_endpoint(ip4->saddr);
 		if (src_ep)
@@ -1605,7 +1597,9 @@ skip_host_firewall:
 		if (info && info->sec_identity)
 			dst_sec_identity = info->sec_identity;
 
-		ret = egress_gw_handle_packet(ctx, &tuple, ct_status,
+		/* lower-level code expects CT tuple to be flipped: */
+		__ipv4_ct_tuple_reverse(&tuple);
+		ret = egress_gw_handle_packet(ctx, &tuple,
 					      src_sec_identity, dst_sec_identity,
 					      &trace);
 		if (IS_ERR(ret))


### PR DESCRIPTION
For EGW we currently perform a CT lookup in to-netdev, to decide whether a packet belongs to an outbound connection and thus is eligible for matching against EGW policies.

Note that we already skip this path for all packets that originate from HOST_ID, and so it's sufficient to focus on the case where the packet was previously handled by from-container.

As the CT lookup is performed with SCOPE_FORWARD, the possible results are
- CT_ESTABLISHED, for a packet belonging to an outbound connection (where from-container already created the CT entry), or
- CT_NEW, when the packet belongs to an inbound connection. Note that we don't need to consider the case of a re-opened outbound connection here, as from-container would have already re-initialized the CT entry.

To reduce BPF complexity and to avoid double-accounting (updating the statistics, connection flags, expiry time etc) in the CT entry, replace this CT lookup with a "raw" map lookup to determine whether the packet matches a CT entry in "reply" layout. If it doesn't, assume that the packet is a request.