### PR TITLE
pkg/ciliumidentity: Fix DeleteUsedCIDIsRecreated test

### DIFF
--- a/operator/pkg/ciliumidentity/namespace.go
+++ b/operator/pkg/ciliumidentity/namespace.go
@@ -5,6 +5,7 @@ package ciliumidentity
 
 import (
 	"context"
+	"sync"
 
 	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -19,9 +20,11 @@ func nsResourceKey(namespace string) resource.Key {
 	return resource.Key{Name: namespace}
 }
 
-func (c *Controller) processNamespaceEvents(ctx context.Context) error {
+func (c *Controller) processNamespaceEvents(ctx context.Context, wg *sync.WaitGroup) error {
 	for event := range c.namespace.Events(ctx) {
 		switch event.Kind {
+		case resource.Sync:
+			wg.Done()
 		case resource.Upsert:
 			c.logger.Debug("Got Upsert Namespace event", logfields.K8sNamespace, event.Key.String())
 

--- a/operator/pkg/ciliumidentity/pod.go
+++ b/operator/pkg/ciliumidentity/pod.go
@@ -5,6 +5,7 @@ package ciliumidentity
 
 import (
 	"context"
+	"sync"
 
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -30,8 +31,13 @@ func (p PodItem) Meter(enqueuedLatency float64, processingLatency float64, isErr
 	metrics.meterLatency(LabelValuePod, enqueuedLatency, processingLatency)
 	metrics.markEvent(LabelValuePod, isErr)
 }
-func (c *Controller) processPodEvents(ctx context.Context) error {
+
+func (c *Controller) processPodEvents(ctx context.Context, wg *sync.WaitGroup) error {
 	for event := range c.pod.Events(ctx) {
+		if event.Kind == resource.Sync {
+			wg.Done()
+		}
+
 		if event.Kind == resource.Upsert || event.Kind == resource.Delete {
 			c.logger.Debug("Got Pod event", logfields.Type, event.Kind, logfields.K8sPodName, event.Key.String())
 			c.enqueueReconciliation(PodItem{podResourceKey(event.Object.Name, event.Object.Namespace)}, 0)

--- a/operator/pkg/ciliumidentity/reconciler.go
+++ b/operator/pkg/ciliumidentity/reconciler.go
@@ -111,36 +111,6 @@ func newReconciler(
 	return r, nil
 }
 
-// syncCESsOnStartup updates the cache of CID usage in CES for all the
-// existing CESs.
-func (r *reconciler) calcDesiredStateOnStartup() error {
-	r.syncCESsOnStartup()
-	return r.syncPodsOnStartup()
-}
-
-func (r *reconciler) syncCESsOnStartup() {
-	if !r.cesEnabled {
-		return
-	}
-
-	for _, ces := range r.cesStore.List() {
-		r.cidUsageInCES.ProcessCESUpsert(ces.Name, ces.Endpoints)
-	}
-}
-
-// syncPodsOnStartup ensures that all pods have a CID for their labels.
-func (r *reconciler) syncPodsOnStartup() error {
-	var lastError error
-
-	for _, pod := range r.podStore.List() {
-		if err := r.reconcilePod(podResourceKey(pod.Name, pod.Namespace)); err != nil {
-			lastError = err
-		}
-	}
-
-	return lastError
-}
-
 // reconcileCID ensures that the desired state for the CID is reached, by
 // comparing the CID in desired state cache and watcher's store and doing one of
 // the following:


### PR DESCRIPTION
Fixes the `TestDeleteUsedCIDIsRecreated` by re-working the fakeclientset. Encountered synchronization issues on the client so moved to only check the .List() instead of both. Removed the initial sync and ordered the initial event processing.

```
go test -c ./operator/pkg/ciliumidentity && stress -p 128 ./ciliumidentity.test -test.run 'TestDeleteUsedCIDIsRecreated' -test.timeout=10s
45h54m50s: 32618794 runs so far, 0 failures (0.00%), 128 active
```

Fixes: #35135
