### PR TITLE
v1.16 Backports 2024-10-22

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -218,7 +218,6 @@ jobs:
         with:
           name: image-digest-output.txt-${{ steps.tag.outputs.tag }}
           path: image-digest-output.txt
-          retention-days: 10
 
       # Upload artifact digests
       - name: Upload artifact digests
@@ -226,4 +225,3 @@ jobs:
         with:
           name: Makefile.digests-${{ steps.tag.outputs.tag }}
           path: Makefile.digests
-          retention-days: 10

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -221,10 +221,10 @@ jobs:
           dir="/tmp/generated/ginkgo"
           cd ${dir}
           jq --argjson prs "$(jq '.["k8s-version"]' ${k8s_versions_to_run})" \
-            --argfile focus main-focus.json \
-            '.include |= map(select(.["k8s-version"] as $k | $prs[] | select($k == .))) + $focus.include |
+            --slurpfile focus main-focus.json \
+            '.include |= map(select(.["k8s-version"] as $k | $prs[] | select($k == .))) + $focus[0].include |
             . + {"k8s-version": $prs} |
-            .focus = $focus.focus | .exclude = $focus.exclude' \
+            .focus = $focus[0].focus | .exclude = $focus[0].exclude' \
             main-k8s-versions.json> /tmp/merged.json
           echo "Generated matrix:"
           cat /tmp/merged.json

--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -74,7 +74,7 @@ jobs:
           sudo cp ${TMP_DIR}/e2e.test /usr/local/bin/e2e.test
           sudo cp ${TMP_DIR}/kubectl /usr/local/bin/kubectl
           sudo cp ${TMP_DIR}/kind /usr/local/bin/kind
-          sudo chmod +x /usr/local/bin/*
+          sudo chmod +x /usr/local/bin/ginkgo /usr/local/bin/e2e.test /usr/local/bin/kubectl /usr/local/bin/kind
           sudo rm -rf ${TMP_DIR}
 
       - name: Create multi node cluster

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -74,7 +74,7 @@ jobs:
           sudo cp ${TMP_DIR}/e2e.test /usr/local/bin/e2e.test
           sudo cp ${TMP_DIR}/kubectl /usr/local/bin/kubectl
           sudo cp ${TMP_DIR}/kind /usr/local/bin/kind
-          sudo chmod +x /usr/local/bin/*
+          sudo chmod +x /usr/local/bin/ginkgo /usr/local/bin/e2e.test /usr/local/bin/kubectl /usr/local/bin/kind
           sudo rm -rf ${TMP_DIR}
 
       - name: Create multi node cluster

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -92,7 +92,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          sudo apt update && sudo apt install -y --no-install-recommends build-essential make libncurses5
+          sudo apt update && sudo apt install -y --no-install-recommends build-essential make
 
       - name: Checkout context ref (trusted)
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1

--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1504,7 +1504,7 @@ and selected service endpoint.
     Jan 13 13:47:20.932: default/mediabot:38750 (ID:5618) <> default/nginx (ID:35772) pre-xlate-rev TRACED (TCP)
 
 Socket LB tracing with Hubble requires cilium agent to detect pod cgroup paths.
-If you see a warning message in cilium agent ``No valid cgroup base path found: socket load-balancing tracing with Hubble will not work.``,
+If you see a warning message in cilium agent ``Failed to setup socket load-balancing tracing with Hubble.``,
 you can trace packets using ``cilium-dbg monitor`` instead.
 
 .. note::

--- a/Documentation/operations/performance/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/performance/scalability/identity-relevant-labels.rst
@@ -57,6 +57,7 @@ Label                                      Description
 ``reserved:.*``                            Include all ``reserved:`` labels
 ``any:io\.kubernetes\.pod\.namespace``     Include all ``io.kubernetes.pod.namespace`` labels
 ``any:io\.cilium\.k8s\.namespace\.labels`` Include all ``io.cilium.k8s.namespace.labels`` labels
+``any:io\.cilium\.k8s\.policy\.cluster``   Include all ``io.cilium.k8s.policy.cluster`` labels
 ``any:app\.kubernetes\.io``                Include all ``app.kubernetes.io`` labels
 ========================================== =====================================================
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -72,6 +72,18 @@ nodeport_add_tunnel_encap(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 	if (ctx_is_skb())
 		src_ip = 0;
 
+	/* Append L2 hdr before redirecting to tunnel netdev.
+	 * Otherwise, the kernel will drop such request in
+	 * https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/core/filter.c?h=v6.7.4#n2147
+	 */
+	if (ETH_HLEN == 0) {
+		int ret;
+
+		ret = add_l2_hdr(ctx);
+		if (ret != 0)
+			return ret;
+	}
+
 	return __encap_with_nodeid(ctx, src_ip, src_port, dst_ip,
 				   src_sec_identity, dst_sec_identity, NOT_VTEP_DST,
 				   ct_reason, monitor, ifindex);
@@ -87,6 +99,18 @@ nodeport_add_tunnel_encap_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_p
 	/* Let kernel choose the outer source ip */
 	if (ctx_is_skb())
 		src_ip = 0;
+
+	/* Append L2 hdr before redirecting to tunnel netdev.
+	 * Otherwise, the kernel will drop such request in
+	 * https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/core/filter.c?h=v6.7.4#n2147
+	 */
+	if (ETH_HLEN == 0) {
+		int ret;
+
+		ret = add_l2_hdr(ctx);
+		if (ret != 0)
+			return ret;
+	}
 
 	return __encap_with_nodeid_opt(ctx, src_ip, src_port, dst_ip,
 				       src_sec_identity, dst_sec_identity, NOT_VTEP_DST,
@@ -1194,17 +1218,6 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 #ifdef TUNNEL_MODE
 	if (tunnel_endpoint) {
 		__be16 src_port;
-
-#if __ctx_is == __ctx_skb
-		{
-			/* See the corresponding v4 path for details */
-			bool l2_hdr_required = false;
-
-			ret = maybe_add_l2_hdr(ctx, ENCAP_IFINDEX, &l2_hdr_required);
-			if (ret != 0)
-				goto drop_err;
-		}
-#endif
 
 		src_port = tunnel_gen_src_port_v6(&tuple);
 
@@ -2742,20 +2755,6 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 #ifdef TUNNEL_MODE
 	if (tunnel_endpoint) {
 		__be16 src_port;
-
-#if __ctx_is == __ctx_skb
-		{
-			/* Append L2 hdr before redirecting to tunnel netdev.
-			 * Otherwise, the kernel will drop such request in
-			 * https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/core/filter.c?h=v6.7.4#n2147
-			 */
-			bool l2_hdr_required = false;
-
-			ret = maybe_add_l2_hdr(ctx, ENCAP_IFINDEX, &l2_hdr_required);
-			if (ret != 0)
-				goto drop_err;
-		}
-#endif
 
 		src_port = tunnel_gen_src_port_v4(&tuple);
 

--- a/bpf/tests/tc_nodeport_l3_dev_lb_dsr_geneve_lb.c
+++ b/bpf/tests/tc_nodeport_l3_dev_lb_dsr_geneve_lb.c
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ETH_HLEN		0
+#define ENABLE_IPV4		1
+#define ENABLE_IPV6		1
+#define ENABLE_NODEPORT		1
+#define ENABLE_DSR		1
+#define DSR_ENCAP_IPIP		2
+#define DSR_ENCAP_GENEVE	3
+#define DSR_ENCAP_MODE		DSR_ENCAP_GENEVE
+#define ENCAP_IFINDEX		42
+
+#define DISABLE_LOOPBACK_LB	1
+
+#define CLIENT_IP		v4_ext_one
+#define CLIENT_IPV6		{ .addr = { 0x1, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+#define CLIENT_PORT		__bpf_htons(111)
+
+#define FRONTEND_IP		v4_svc_one
+#define FRONTEND_IPV6		{ .addr = { 0x5, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+#define FRONTEND_PORT		tcp_svc_one
+
+#define BACKEND_IP		v4_pod_one
+#define BACKEND_IPV6		{ .addr = { 0x3, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+#define BACKEND_PORT		__bpf_htons(8080)
+
+#define REMOTE_NODE_IP		v4_node_one
+
+static volatile const __u8 *client_mac = mac_one;
+/* this matches the default node_config.h: */
+static volatile const __u8 lb_mac[ETH_ALEN] = { 0xce, 0x72, 0xa7, 0x03, 0x88, 0x56 };
+
+#define ctx_redirect mock_ctx_redirect
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
+{
+	if (ifindex != ENCAP_IFINDEX)
+		return -1;
+
+	return CTX_ACT_REDIRECT;
+}
+
+#define SECCTX_FROM_IPCACHE 1
+
+#include <bpf_host.c>
+
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+
+#define FROM_NETDEV	0
+#define TO_NETDEV	1
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 2);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_from_netdev,
+		[TO_NETDEV] = &cil_to_netdev,
+	},
+};
+
+/* Test that a SVC request that is LBed to a DSR remote backend
+ * - gets DNATed,
+ * - has IP Option inserted,
+ * - gets redirected back out by TC
+ */
+PKTGEN("tc", "ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd")
+int ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)lb_mac,
+					  CLIENT_IP, FRONTEND_IP,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd")
+int ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd_setup(struct __ctx_buff *ctx)
+{
+	void *data = (void *)(long)ctx->data;
+	void *data_end = (void *)(long)ctx->data_end;
+	__u64 flags = BPF_F_ADJ_ROOM_FIXED_GSO;
+	__u16 revnat_id = 1;
+
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, 1, revnat_id);
+	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, 1, 124,
+			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, REMOTE_NODE_IP, 0);
+
+	/* Strip L2 header to emulate L3 packet: */
+	if ((void *)data + __ETH_HLEN + __ETH_HLEN <= data_end)
+		memcpy(data, data + __ETH_HLEN, __ETH_HLEN);
+
+	skb_adjust_room(ctx, -__ETH_HLEN, BPF_ADJ_ROOM_MAC, flags);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd")
+int ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd_check(__maybe_unused struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(*l3);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != BACKEND_IP)
+		test_fatal("dst IP hasn't been NATed to remote backend IP");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been NATed to backend port");
+
+	test_finish();
+}
+
+/* Test that a SVC request that is LBed to a DSR remote backend
+ * - gets DNATed,
+ * - has IPv6 Extension inserted,
+ * - gets redirected back out by TC
+ */
+PKTGEN("tc", "ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd")
+int ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd_pktgen(struct __ctx_buff *ctx)
+{
+	union v6addr frontend_ip = FRONTEND_IPV6;
+	union v6addr client_ip = CLIENT_IPV6;
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)lb_mac,
+					  (__u8 *)&client_ip, (__u8 *)&frontend_ip,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd")
+int ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd_setup(struct __ctx_buff *ctx)
+{
+	void *data = (void *)(long)ctx->data;
+	void *data_end = (void *)(long)ctx->data_end;
+	__u64 flags = BPF_F_ADJ_ROOM_FIXED_GSO;
+	union v6addr frontend_ip = FRONTEND_IPV6;
+	union v6addr backend_ip = BACKEND_IPV6;
+	__u16 revnat_id = 1;
+
+	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, 1, revnat_id);
+	lb_v6_add_backend(&frontend_ip, FRONTEND_PORT, 1, 124,
+			  &backend_ip, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	ipcache_v6_add_entry(&backend_ip, 0, 112233, REMOTE_NODE_IP, 0);
+
+	/* Strip L2 header to emulate L3 packet: */
+	if ((void *)data + __ETH_HLEN + __ETH_HLEN <= data_end)
+		memcpy(data, data + __ETH_HLEN, __ETH_HLEN);
+
+	skb_adjust_room(ctx, -__ETH_HLEN, BPF_ADJ_ROOM_MAC, flags);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd")
+int ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd_check(__maybe_unused struct __ctx_buff *ctx)
+{
+	union v6addr backend_ip = BACKEND_IPV6;
+	union v6addr client_ip = CLIENT_IPV6;
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(*l3);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (!ipv6_addr_equals((union v6addr *)&l3->saddr, &client_ip))
+		test_fatal("src IP has changed");
+	if (!ipv6_addr_equals((union v6addr *)&l3->daddr, &backend_ip))
+		test_fatal("dst IP hasn't been NATed to remote backend IP");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been NATed to backend port");
+
+	test_finish();
+}

--- a/pkg/bgpv1/manager/reconciler/service.go
+++ b/pkg/bgpv1/manager/reconciler/service.go
@@ -42,6 +42,15 @@ type LBServiceReconcilerMetadata map[resource.Key][]*types.Path
 
 type localServices map[k8s.ServiceID]struct{}
 
+// pathReference holds reference information about an advertised path
+type pathReference struct {
+	count uint32
+	path  *types.Path
+}
+
+// pathReferencesMap holds path references of resources producing path advertisement, indexed by path's NLRI string
+type pathReferencesMap map[string]*pathReference
+
 func NewServiceReconciler(diffStore store.DiffStore[*slim_corev1.Service], epDiffStore store.DiffStore[*k8s.Endpoints]) LBServiceReconcilerOut {
 	if diffStore == nil {
 		return LBServiceReconcilerOut{}
@@ -89,10 +98,13 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, p ReconcileParams) er
 		return err
 	}
 
+	// compute existing path to resource references
+	pathRefs := r.computePathReferences(r.getMetadata(p.CurrentServer))
+
 	if r.requiresFullReconciliation(p) {
-		return r.fullReconciliation(ctx, p.CurrentServer, p.DesiredConfig, ls)
+		return r.fullReconciliation(ctx, p.CurrentServer, p.DesiredConfig, ls, pathRefs)
 	}
-	return r.svcDiffReconciliation(ctx, p.CurrentServer, p.DesiredConfig, ls)
+	return r.svcDiffReconciliation(ctx, p.CurrentServer, p.DesiredConfig, ls, pathRefs)
 }
 
 func (r *ServiceReconciler) getMetadata(sc *instance.ServerWithConfig) LBServiceReconcilerMetadata {
@@ -171,18 +183,18 @@ func hasLocalEndpoints(svc *slim_corev1.Service, ls localServices) bool {
 
 // fullReconciliation reconciles all services, this is a heavy operation due to the potential amount of services and
 // thus should be avoided if partial reconciliation is an option.
-func (r *ServiceReconciler) fullReconciliation(ctx context.Context, sc *instance.ServerWithConfig, newc *v2alpha1api.CiliumBGPVirtualRouter, ls localServices) error {
+func (r *ServiceReconciler) fullReconciliation(ctx context.Context, sc *instance.ServerWithConfig, newc *v2alpha1api.CiliumBGPVirtualRouter, ls localServices, pathRefs pathReferencesMap) error {
 	toReconcile, toWithdraw, err := r.fullReconciliationServiceList(sc)
 	if err != nil {
 		return err
 	}
 	for _, svc := range toReconcile {
-		if err := r.reconcileService(ctx, sc, newc, svc, ls); err != nil {
+		if err := r.reconcileService(ctx, sc, newc, svc, ls, pathRefs); err != nil {
 			return fmt.Errorf("failed to reconcile service %s/%s: %w", svc.Namespace, svc.Name, err)
 		}
 	}
 	for _, svc := range toWithdraw {
-		if err := r.withdrawService(ctx, sc, svc); err != nil {
+		if err := r.withdrawService(ctx, sc, svc, pathRefs); err != nil {
 			return fmt.Errorf("failed to withdraw service %s/%s: %w", svc.Namespace, svc.Name, err)
 		}
 	}
@@ -191,19 +203,19 @@ func (r *ServiceReconciler) fullReconciliation(ctx context.Context, sc *instance
 
 // svcDiffReconciliation performs reconciliation, only on services which have been created, updated or deleted since
 // the last diff reconciliation.
-func (r *ServiceReconciler) svcDiffReconciliation(ctx context.Context, sc *instance.ServerWithConfig, newc *v2alpha1api.CiliumBGPVirtualRouter, ls localServices) error {
+func (r *ServiceReconciler) svcDiffReconciliation(ctx context.Context, sc *instance.ServerWithConfig, newc *v2alpha1api.CiliumBGPVirtualRouter, ls localServices, pathRefs pathReferencesMap) error {
 	toReconcile, toWithdraw, err := r.diffReconciliationServiceList(sc)
 	if err != nil {
 		return err
 	}
 	for _, svc := range toReconcile {
-		if err := r.reconcileService(ctx, sc, newc, svc, ls); err != nil {
+		if err := r.reconcileService(ctx, sc, newc, svc, ls, pathRefs); err != nil {
 			return fmt.Errorf("failed to reconcile service %s/%s: %w", svc.Namespace, svc.Name, err)
 		}
 	}
 	// Loop over the deleted services
 	for _, svcKey := range toWithdraw {
-		if err := r.withdrawService(ctx, sc, svcKey); err != nil {
+		if err := r.withdrawService(ctx, sc, svcKey, pathRefs); err != nil {
 			return fmt.Errorf("failed to withdraw service %s: %w", svcKey, err)
 		}
 	}
@@ -409,18 +421,18 @@ func (r *ServiceReconciler) lbSvcDesiredRoutes(svc *slim_corev1.Service, ls loca
 }
 
 // reconcileService gets the desired routes of a given service and makes sure that is what is being announced.
-func (r *ServiceReconciler) reconcileService(ctx context.Context, sc *instance.ServerWithConfig, newc *v2alpha1api.CiliumBGPVirtualRouter, svc *slim_corev1.Service, ls localServices) error {
+func (r *ServiceReconciler) reconcileService(ctx context.Context, sc *instance.ServerWithConfig, newc *v2alpha1api.CiliumBGPVirtualRouter, svc *slim_corev1.Service, ls localServices, pathRefs pathReferencesMap) error {
 
 	desiredRoutes, err := r.svcDesiredRoutes(newc, svc, ls)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve svc desired routes: %w", err)
 	}
-	return r.reconcileServiceRoutes(ctx, sc, svc, desiredRoutes)
+	return r.reconcileServiceRoutes(ctx, sc, svc, desiredRoutes, pathRefs)
 }
 
 // reconcileServiceRoutes ensures that desired routes of a given service are announced,
 // adding missing announcements or withdrawing unwanted ones.
-func (r *ServiceReconciler) reconcileServiceRoutes(ctx context.Context, sc *instance.ServerWithConfig, svc *slim_corev1.Service, desiredRoutes []netip.Prefix) error {
+func (r *ServiceReconciler) reconcileServiceRoutes(ctx context.Context, sc *instance.ServerWithConfig, svc *slim_corev1.Service, desiredRoutes []netip.Prefix, pathRefs pathReferencesMap) error {
 	serviceAnnouncements := r.getMetadata(sc)
 	svcKey := resource.NewKey(svc)
 
@@ -431,15 +443,12 @@ func (r *ServiceReconciler) reconcileServiceRoutes(ctx context.Context, sc *inst
 		}) != -1 {
 			continue
 		}
-
 		// Advertise the new cidr
-		advertPathResp, err := sc.Server.AdvertisePath(ctx, types.PathRequest{
-			Path: types.NewPathForPrefix(desiredCidr),
-		})
+		path, err := r.advertisePath(ctx, sc, pathRefs, desiredCidr)
 		if err != nil {
-			return fmt.Errorf("failed to advertise service route %v: %w", desiredCidr, err)
+			return err
 		}
-		serviceAnnouncements[svcKey] = append(serviceAnnouncements[svcKey], advertPathResp.Path)
+		serviceAnnouncements[svcKey] = append(serviceAnnouncements[svcKey], path)
 	}
 
 	// Loop over announcements in reverse order so we can delete entries without effecting iteration.
@@ -451,11 +460,9 @@ func (r *ServiceReconciler) reconcileServiceRoutes(ctx context.Context, sc *inst
 		}) != -1 {
 			continue
 		}
-
-		if err := sc.Server.WithdrawPath(ctx, types.PathRequest{Path: announcement}); err != nil {
-			return fmt.Errorf("failed to withdraw service route %s: %w", announcement.NLRI, err)
+		if err := r.withdrawPath(ctx, sc, pathRefs, announcement); err != nil {
+			return err
 		}
-
 		// Delete announcement from slice
 		serviceAnnouncements[svcKey] = slices.Delete(serviceAnnouncements[svcKey], i, i+1)
 	}
@@ -463,16 +470,17 @@ func (r *ServiceReconciler) reconcileServiceRoutes(ctx context.Context, sc *inst
 }
 
 // withdrawService removes all announcements for the given service
-func (r *ServiceReconciler) withdrawService(ctx context.Context, sc *instance.ServerWithConfig, key resource.Key) error {
+func (r *ServiceReconciler) withdrawService(ctx context.Context, sc *instance.ServerWithConfig, key resource.Key, pathRefs pathReferencesMap) error {
 	serviceAnnouncements := r.getMetadata(sc)
 	advertisements := serviceAnnouncements[key]
 	// Loop in reverse order so we can delete without effect to the iteration.
 	for i := len(advertisements) - 1; i >= 0; i-- {
 		advertisement := advertisements[i]
-		if err := sc.Server.WithdrawPath(ctx, types.PathRequest{Path: advertisement}); err != nil {
+
+		if err := r.withdrawPath(ctx, sc, pathRefs, advertisement); err != nil {
 			// Persist remaining advertisements
 			serviceAnnouncements[key] = advertisements
-			return fmt.Errorf("failed to withdraw deleted service route: %v: %w", advertisement.NLRI, err)
+			return err
 		}
 
 		// Delete the advertisement after each withdraw in case we error half way through
@@ -487,6 +495,62 @@ func (r *ServiceReconciler) withdrawService(ctx context.Context, sc *instance.Se
 
 func (r *ServiceReconciler) diffID(asn uint32) string {
 	return fmt.Sprintf("%s-%d", r.Name(), asn)
+}
+
+func (r *ServiceReconciler) advertisePath(ctx context.Context, sc *instance.ServerWithConfig, pathRefs pathReferencesMap, prefix netip.Prefix) (*types.Path, error) {
+	if ref, exists := pathRefs[prefix.String()]; exists && ref.count > 0 {
+		// path already advertised for another resource
+		ref.count += 1
+		return ref.path, nil
+	}
+
+	advertPathResp, err := sc.Server.AdvertisePath(ctx, types.PathRequest{
+		Path: types.NewPathForPrefix(prefix),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to advertise service route %v: %w", prefix, err)
+	}
+
+	// set only in case of no error
+	pathRefs[prefix.String()] = &pathReference{
+		count: 1,
+		path:  advertPathResp.Path,
+	}
+	return advertPathResp.Path, nil
+}
+
+func (r *ServiceReconciler) withdrawPath(ctx context.Context, sc *instance.ServerWithConfig, pathRefs pathReferencesMap, path *types.Path) error {
+	if ref, exists := pathRefs[path.NLRI.String()]; exists && ref.count > 1 {
+		// path still needs to be advertised for another resource
+		ref.count -= 1
+		return nil
+	}
+
+	if err := sc.Server.WithdrawPath(ctx, types.PathRequest{Path: path}); err != nil {
+		return fmt.Errorf("failed to withdraw service route %s: %w", path.NLRI, err)
+	}
+
+	// delete only in case of no error
+	delete(pathRefs, path.NLRI.String())
+	return nil
+}
+
+func (r *ServiceReconciler) computePathReferences(metadata LBServiceReconcilerMetadata) pathReferencesMap {
+	pathRefs := make(pathReferencesMap)
+	for _, resPaths := range metadata {
+		for _, path := range resPaths {
+			ref, exists := pathRefs[path.NLRI.String()]
+			if !exists {
+				pathRefs[path.NLRI.String()] = &pathReference{
+					count: 1,
+					path:  path,
+				}
+			} else {
+				ref.count += 1
+			}
+		}
+	}
+	return pathRefs
 }
 
 func serviceLabelSet(svc *slim_corev1.Service) labels.Labels {

--- a/pkg/bgpv1/manager/reconciler/service_test.go
+++ b/pkg/bgpv1/manager/reconciler/service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
@@ -605,6 +606,28 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 				},
 			},
 		},
+		// service VIP sharing, delete one of the services
+		{
+			name:               "svc-vip-sharing",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised: map[resource.Key][]string{
+				svc1Name: {
+					ingressV4Prefix,
+				},
+				svc2NonDefaultName: {
+					ingressV4Prefix,
+				},
+			},
+			deletedServices: []resource.Key{
+				svc1Name,
+			},
+			updated: map[resource.Key][]string{
+				svc2NonDefaultName: {
+					ingressV4Prefix,
+				},
+			},
+		},
 	}
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
@@ -729,6 +752,8 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 				}
 			}
 
+			// validate that advertised paths match expected metadata
+			validateAdvertisedPrefixesMatch(t, testSC, tt.updated)
 		})
 	}
 }
@@ -1388,6 +1413,8 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 				}
 			}
 
+			// validate that advertised paths match expected metadata
+			validateAdvertisedPrefixesMatch(t, testSC, tt.updated)
 		})
 	}
 }
@@ -2045,6 +2072,8 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 				}
 			}
 
+			// validate that advertised paths match expected metadata
+			validateAdvertisedPrefixesMatch(t, testSC, tt.updated)
 		})
 	}
 }
@@ -2393,6 +2422,8 @@ func TestServiceReconcilerWithExternalIPAndClusterIP(t *testing.T) {
 				}
 			}
 
+			// validate that advertised paths match expected metadata
+			validateAdvertisedPrefixesMatch(t, testSC, tt.updated)
 		})
 	}
 }
@@ -2403,4 +2434,39 @@ func containsLbClass(svcs []*slim_corev1.Service) bool {
 		}
 	}
 	return false
+}
+
+func validateAdvertisedPrefixesMatch(t *testing.T, testSC *instance.ServerWithConfig, expectedAdverts map[resource.Key][]string) {
+	expected := sets.New[string]()
+	for _, resourcePaths := range expectedAdverts {
+		for _, path := range resourcePaths {
+			expected.Insert(path)
+		}
+	}
+
+	advertised := sets.New[string]()
+	routes, err := testSC.Server.GetRoutes(context.Background(), &types.GetRoutesRequest{TableType: types.TableTypeLocRIB, Family: types.Family{
+		Afi:  types.AfiIPv4,
+		Safi: types.SafiUnicast,
+	}})
+	require.NoError(t, err)
+	for _, route := range routes.Routes {
+		for _, path := range route.Paths {
+			advertised.Insert(path.NLRI.String())
+		}
+	}
+	routes, _ = testSC.Server.GetRoutes(context.Background(), &types.GetRoutesRequest{TableType: types.TableTypeLocRIB, Family: types.Family{
+		Afi:  types.AfiIPv6,
+		Safi: types.SafiUnicast,
+	}})
+	require.NoError(t, err)
+	for _, route := range routes.Routes {
+		for _, path := range route.Paths {
+			advertised.Insert(path.NLRI.String())
+		}
+	}
+
+	if !advertised.Equal(expected) {
+		t.Fatalf("advertised prefixes do not match expected metadata, expected: %v, got: %v", expected, advertised)
+	}
 }

--- a/pkg/bgpv1/test/adverts_test.go
+++ b/pkg/bgpv1/test/adverts_test.go
@@ -637,6 +637,34 @@ func Test_LBEgressAdvertisementWithLoadBalancerIP(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:         "add service-c - VIP shared with service-b",
+			srvName:             "service-c",
+			ingressIP:           "dddd::1",
+			op:                  "add",
+			expectedRouteEvents: []routeEvent{}, // no event, shared VIP already advertised
+		},
+		{
+			description:         "withdraw service-b - shared VIP",
+			srvName:             "service-b",
+			ingressIP:           "",
+			op:                  "update",
+			expectedRouteEvents: []routeEvent{}, // no event, shared VIP still advertised for service-c
+		},
+		{
+			description: "withdraw service-c - shared VIP",
+			srvName:     "service-c",
+			ingressIP:   "",
+			op:          "update",
+			expectedRouteEvents: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "dddd::1",
+					prefixLen:   128,
+					isWithdrawn: true, // withdrawal, shared VIP no longer used by any service
+				},
+			},
+		},
 	}
 
 	testCtx, testDone := context.WithTimeout(context.Background(), maxTestDuration)

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -1126,8 +1126,9 @@ func (m *manager) StartNodeNeighborLinkUpdater(nh datapath.NodeNeighbors) {
 
 					log.Debugf("Refreshing node neighbor link for %s", e.node.Name)
 					hr := sc.NewScope(e.node.Name)
-					if errs = errors.Join(errs, nh.NodeNeighborRefresh(ctx, *e.node, e.refresh)); errs != nil {
-						hr.Degraded("Failed node neighbor link update", errs)
+					if err := nh.NodeNeighborRefresh(ctx, *e.node, e.refresh); err != nil {
+						hr.Degraded("Failed node neighbor link update", err)
+						errs = errors.Join(errs, err)
 					} else {
 						hr.OK("Node neighbor link update successful")
 					}

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -59,8 +59,9 @@ func (l4rule *PerSelectorPolicy) covers(l3l4rule *PerSelectorPolicy) bool {
 	if l3l4IsRedirect && !l4OnlyIsRedirect {
 		// Can not skip if l3l4-rule is redirect while l4-only is not
 		return false
-	} else if l3l4IsRedirect && l4OnlyIsRedirect && l3l4rule.Listener != l4rule.Listener {
-		// L3l4 rule has a different listener, it can not be skipped
+	} else if l3l4IsRedirect && l4OnlyIsRedirect &&
+		(l3l4rule.Listener != l4rule.Listener || l3l4rule.Priority != l4rule.Priority) {
+		// L3l4 rule has a different listener or priority, it can not be skipped
 		return false
 	}
 
@@ -586,9 +587,10 @@ func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redir
 		wildcardRule = l4.PerSelectorPolicies[l4.wildcard]
 	}
 
+	isL4Wildcard := (l4.Port != 0 || l4.PortName != "") && l4.wildcard != nil
 	for cs, currentRule := range l4.PerSelectorPolicies {
 		// have wildcard and this is an L3L4 key?
-		isL3L4withWildcardPresent := (l4.Port != 0 || l4.PortName != "") && l4.wildcard != nil && cs != l4.wildcard
+		isL3L4withWildcardPresent := isL4Wildcard && cs != l4.wildcard
 
 		if isL3L4withWildcardPresent && wildcardRule.covers(currentRule) {
 			logger.WithField(logfields.EndpointSelector, cs).Debug("ToMapState: Skipping L3/L4 key due to existing L4-only key")
@@ -598,6 +600,7 @@ func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redir
 		isDenyRule := currentRule != nil && currentRule.IsDeny
 		isRedirect := currentRule.IsRedirect()
 		listener := currentRule.GetListener()
+		priority := currentRule.GetPriority()
 		if !isDenyRule && isL3L4withWildcardPresent && !isRedirect {
 			// Inherit the redirect status from the wildcard rule.
 			// This is now needed as 'covers()' can pass non-redirect L3L4 rules
@@ -606,6 +609,7 @@ func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redir
 			// L4-only rule.
 			isRedirect = wildcardRule.IsRedirect()
 			listener = wildcardRule.GetListener()
+			priority = wildcardRule.GetPriority()
 		}
 		hasAuth, authType := currentRule.GetAuthType()
 		var proxyPort uint16
@@ -621,7 +625,7 @@ func (l4 *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, redir
 				continue
 			}
 		}
-		entry := NewMapStateEntry(cs, l4.RuleOrigin[cs], proxyPort, currentRule.GetListener(), currentRule.GetPriority(), isDenyRule, hasAuth, authType)
+		entry := NewMapStateEntry(cs, l4.RuleOrigin[cs], proxyPort, listener, priority, isDenyRule, hasAuth, authType)
 
 		if cs.IsWildcard() {
 			for _, keyToAdd := range keysToAdd {


### PR DESCRIPTION
 * [ ] #35179 (@wedaly)
 * [x] #35337 (@julianwiedmann)
 * [x] #35165 (@julianwiedmann)
 * [ ] #35400 (@sayboras)
 * [x] #35399 (@aanm)
 * [x] #35408 (@aanm)
 * [ ] #35381 (@jrajahalme)
 * [x] #35333 (@rastislavs)
 * [x] #35422 (@marseel) :warning: resolved conflicts
   * added `any:` prefix as with other labels because commit 1918908a174d ("Improve identity-relevant-labels.rst page") which removed these prefixes across all docs wasn't backported to `v1.16`.
 * [x] #35457 (@aanm)

PRs skipped due to conflicts:

 * #33972 (@darox)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 35179 35337 35165 35400 35399 35408 35381 35333 35422 35457
```
