### PR TITLE
Add support for automatic port-forwarding in Hubble CLI

### DIFF
--- a/cilium-cli/connectivity/check/metrics.go
+++ b/cilium-cli/connectivity/check/metrics.go
@@ -12,7 +12,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 
-	"github.com/cilium/cilium/cilium-cli/k8s"
+	"github.com/cilium/cilium/pkg/k8s"
 )
 
 // metricsURLFormat is the path format to retrieve the metrics on the

--- a/cilium-cli/hubble/hubble.go
+++ b/cilium-cli/hubble/hubble.go
@@ -9,17 +9,11 @@ import (
 	"io"
 
 	"helm.sh/helm/v3/pkg/cli/values"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium/cilium-cli/internal/helm"
 	"github.com/cilium/cilium/cilium-cli/k8s"
 )
-
-type k8sHubbleImplementation interface {
-	GetService(ctx context.Context, namespace, name string, opts metav1.GetOptions) (*corev1.Service, error)
-}
 
 type Parameters struct {
 	Namespace     string
@@ -28,7 +22,6 @@ type Parameters struct {
 	UI            bool
 	UIPortForward int
 	Writer        io.Writer
-	Context       string // Only for 'kubectl' pass-through commands
 
 	// UIOpenBrowser will automatically open browser if true
 	UIOpenBrowser bool

--- a/cilium-cli/hubble/relay.go
+++ b/cilium-cli/hubble/relay.go
@@ -7,28 +7,16 @@ import (
 	"context"
 	"fmt"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/cilium/cilium/cilium-cli/internal/utils"
+	"github.com/cilium/cilium/cilium-cli/k8s"
 )
 
-func (p *Parameters) RelayPortForwardCommand(ctx context.Context, client k8sHubbleImplementation) error {
-	relaySvc, err := client.GetService(ctx, p.Namespace, "hubble-relay", metav1.GetOptions{})
+func (p *Parameters) RelayPortForwardCommand(ctx context.Context, k8sClient *k8s.Client) error {
+	// default to first port configured on the service when svcPort is set to 0
+	res, err := k8sClient.PortForwardService(ctx, p.Namespace, "hubble-relay", int32(p.PortForward), 0)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to port forward: %w", err)
 	}
-
-	args := []string{
-		"port-forward",
-		"-n", p.Namespace,
-		"svc/hubble-relay",
-		"--address", "127.0.0.1",
-		fmt.Sprintf("%d:%d", p.PortForward, relaySvc.Spec.Ports[0].Port)}
-
-	if p.Context != "" {
-		args = append([]string{"--context", p.Context}, args...)
-	}
-
-	_, err = utils.Exec(p, "kubectl", args...)
-	return err
+	p.Log("ℹ️  Hubble Relay is available at 127.0.0.1:%d", res.ForwardedPort.Local)
+	<-ctx.Done()
+	return nil
 }

--- a/cilium-cli/k8s/dialer.go
+++ b/cilium-cli/k8s/dialer.go
@@ -14,3 +14,12 @@ import (
 func (c *Client) PortForward(ctx context.Context, p k8s.PortForwardParameters) (*k8s.PortForwardResult, error) {
 	return k8s.NewPortForwarder(c.Clientset, c.Config).PortForward(ctx, p)
 }
+
+// PortForwardService executes in a goroutine a port forward command towards one of the pod behind a
+// service. If `localPort` is 0, a random port is selected. If `svcPort` is 0, uses the first port
+// configured on the service.
+//
+// To stop the port-forwarding, use the context by cancelling it.
+func (c *Client) PortForwardService(ctx context.Context, namespace, name string, localPort, svcPort int32) (*k8s.PortForwardServiceResult, error) {
+	return k8s.NewPortForwarder(c.Clientset, c.Config).PortForwardService(ctx, namespace, name, localPort, svcPort)
+}

--- a/cilium-cli/k8s/dialer.go
+++ b/cilium-cli/k8s/dialer.go
@@ -5,99 +5,12 @@ package k8s
 
 import (
 	"context"
-	"io"
-	"net/http"
-	"strings"
 
-	"k8s.io/client-go/tools/portforward"
-	"k8s.io/client-go/transport/spdy"
+	"github.com/cilium/cilium/pkg/k8s"
 )
-
-// ForwardedPort holds the remote and local mapped port.
-type ForwardedPort struct {
-	Local  uint16
-	Remote uint16
-}
-
-// PortForwardParameters are the needed parameters to call PortForward.
-// Ports value follow the kubectl syntax: <local-port>:<remote-port>
-// 5000 means 5000:5000 listening on 5000 port locally, forwarding to 5000 in the pod
-// 8888:5000 means listening on 8888 port locally, forwarding to 5000 in the pod
-// 0:5000 means listening on a random port locally, forwarding to 5000 in the pod
-// :5000 means listening on a random port locally, forwarding to 5000 in the pod
-type PortForwardParameters struct {
-	Namespace  string
-	Pod        string
-	Ports      []string
-	Addresses  []string
-	OutWriters OutWriters
-}
-
-// OutWriters holds the two io.Writer needed for the port forward
-// one for the output and for the errors.
-type OutWriters struct {
-	Out    io.Writer
-	ErrOut io.Writer
-}
-
-// PortForwardResult are the ports that have been forwarded.
-type PortForwardResult struct {
-	ForwardedPorts []ForwardedPort
-}
 
 // PortForward executes in a goroutine a port forward command.
 // To stop the port-forwarding, use the context by cancelling it
-func (c *Client) PortForward(ctx context.Context, p PortForwardParameters) (*PortForwardResult, error) {
-	req := c.Clientset.CoreV1().RESTClient().Post().Namespace(p.Namespace).
-		Resource("pods").Name(p.Pod).SubResource(strings.ToLower("PortForward"))
-
-	roundTripper, upgrader, err := spdy.RoundTripperFor(c.Config)
-	if err != nil {
-		return nil, err
-	}
-
-	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, req.URL())
-	stopChan, readyChan := make(chan struct{}, 1), make(chan struct{}, 1)
-	if len(p.Addresses) == 0 {
-		p.Addresses = []string{"localhost"}
-	}
-
-	pw, err := portforward.NewOnAddresses(dialer, p.Addresses, p.Ports, stopChan, readyChan, p.OutWriters.Out, p.OutWriters.ErrOut)
-	if err != nil {
-		return nil, err
-	}
-
-	errChan := make(chan error, 1)
-	go func() {
-		if err := pw.ForwardPorts(); err != nil {
-			errChan <- err
-		}
-	}()
-
-	go func() {
-		<-ctx.Done()
-		close(stopChan)
-	}()
-
-	select {
-	case <-pw.Ready:
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case err := <-errChan:
-		return nil, err
-	}
-
-	ports, err := pw.GetPorts()
-	if err != nil {
-		return nil, err
-	}
-
-	forwardedPorts := make([]ForwardedPort, 0, len(ports))
-	for _, port := range ports {
-		forwardedPorts = append(forwardedPorts, ForwardedPort{port.Local, port.Remote})
-	}
-
-	return &PortForwardResult{
-		ForwardedPorts: forwardedPorts,
-	}, nil
+func (c *Client) PortForward(ctx context.Context, p k8s.PortForwardParameters) (*k8s.PortForwardResult, error) {
+	return k8s.NewPortForwarder(c.Clientset, c.Config).PortForward(ctx, p)
 }

--- a/go.mod
+++ b/go.mod
@@ -129,6 +129,7 @@ require (
 	k8s.io/component-base v0.31.2
 	k8s.io/endpointslice v0.31.1
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/kubectl v0.31.1
 	k8s.io/utils v0.0.0-20240921022957-49e7df575cb6
 	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/controller-tools v0.16.3
@@ -320,7 +321,6 @@ require (
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
 	k8s.io/gengo/v2 v2.0.0-20240228010128-51d4e06bde70 // indirect
 	k8s.io/kube-openapi v0.0.0-20240423202451-8948a665c108 // indirect
-	k8s.io/kubectl v0.31.1 // indirect
 	oras.land/oras-go v1.2.5 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.17.2 // indirect

--- a/hubble/cmd/common/config/flags.go
+++ b/hubble/cmd/common/config/flags.go
@@ -28,6 +28,11 @@ const (
 	KeyBasicAuthPassword = "basic-auth-password"  // string
 	KeyTimeout           = "timeout"              // time.Duration
 	KeyRequestTimeout    = "request-timeout"      // time.Duration
+	KeyPortForward       = "port-forward"         // bool
+	KeyPortForwardPort   = "port-forward-port"    // uint16
+	KeyKubeContext       = "kube-context"         // string
+	KeyKubeNamespace     = "kube-namespace"       // string
+	KeyKubeconfig        = "kubeconfig"           // string
 )
 
 // GlobalFlags are flags that apply to any command.
@@ -47,7 +52,7 @@ func initGlobalFlags() {
 }
 
 func initServerFlags() {
-	ServerFlags.String(KeyServer, defaults.ServerAddress, "Address of a Hubble server. Ignored when --input-file is provided.")
+	ServerFlags.String(KeyServer, defaults.ServerAddress, "Address of a Hubble server. Ignored when --input-file or --port-forward is provided.")
 	ServerFlags.Duration(KeyTimeout, defaults.DialTimeout, "Hubble server dialing timeout")
 	ServerFlags.Duration(KeyRequestTimeout, defaults.RequestTimeout, "Unary Request timeout. Only applies to non-streaming RPCs (ServerStatus, ListNodes, ListNamespaces).")
 	ServerFlags.Bool(
@@ -95,5 +100,31 @@ func initServerFlags() {
 		KeyBasicAuthPassword,
 		"",
 		"Specify a password for basic auth",
+	)
+	ServerFlags.BoolP(
+		KeyPortForward,
+		"P",
+		false,
+		"Automatically forward the relay port to the local machine. Analoguous to running: 'cilium hubble port-forward'.",
+	)
+	ServerFlags.Uint16(
+		KeyPortForwardPort,
+		4245,
+		"Local port to forward to. 0 will select a random port. This option is only considered when --port-forward is set.",
+	)
+	ServerFlags.String(
+		KeyKubeContext,
+		"",
+		"Kubernetes configuration context. This option is only considered when --port-forward is set.",
+	)
+	ServerFlags.String(
+		KeyKubeNamespace,
+		"kube-system",
+		"Namespace Cilium is running in. This option is only considered when --port-forward is set.",
+	)
+	ServerFlags.String(
+		KeyKubeconfig,
+		"",
+		"Path to the kubeconfig file. This option is only considered when --port-forward is set.",
 	)
 }

--- a/hubble/cmd/common/conn/conn.go
+++ b/hubble/cmd/common/conn/conn.go
@@ -4,15 +4,20 @@
 package conn
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/cilium/cilium/hubble/cmd/common/config"
 	"github.com/cilium/cilium/hubble/pkg/defaults"
+	"github.com/cilium/cilium/hubble/pkg/logger"
+	"github.com/cilium/cilium/pkg/k8s"
 )
 
 // GRPCOptionFunc is a function that configures a gRPC dial option.
@@ -56,4 +61,59 @@ func New(target string) (*grpc.ClientConn, error) {
 		return nil, fmt.Errorf("failed to create gRPC client to '%s': %w", target, err)
 	}
 	return conn, nil
+}
+
+// NewWithFlags creates a new gRPC client connection, optionally port-forwarding to one of the
+// hubble-relay pods, using flags to extract the required information.
+func NewWithFlags(ctx context.Context, vp *viper.Viper) (*grpc.ClientConn, error) {
+	server := vp.GetString(config.KeyServer)
+
+	if vp.GetBool(config.KeyPortForward) {
+		kubeContext := vp.GetString(config.KeyKubeContext)
+		kubeconfig := vp.GetString(config.KeyKubeconfig)
+		kubeNamespace := vp.GetString(config.KeyKubeNamespace)
+		localPort := vp.GetUint16(config.KeyPortForwardPort)
+
+		pf, err := newPortForwarder(kubeContext, kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create k8s port forwader: %w", err)
+		}
+
+		// default to first port configured on the service when svcPort is set to 0
+		res, err := pf.PortForwardService(ctx, kubeNamespace, "hubble-relay", int32(localPort), 0)
+		if err != nil {
+			return nil, fmt.Errorf("failed to port forward: %w", err)
+		}
+
+		server = fmt.Sprintf("127.0.0.1:%d", res.ForwardedPort.Local)
+		logger.Logger.Debug("port-forward to hubble-relay pod running", "addr", server)
+	}
+
+	conn, err := New(server)
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+func newPortForwarder(context, kubeconfig string) (*k8s.PortForwarder, error) {
+	restClientGetter := genericclioptions.ConfigFlags{
+		Context:    &context,
+		KubeConfig: &kubeconfig,
+	}
+	rawKubeConfigLoader := restClientGetter.ToRawKubeConfigLoader()
+
+	config, err := rawKubeConfigLoader.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	pf := k8s.NewPortForwarder(clientset, config)
+	return pf, nil
 }

--- a/hubble/cmd/list/namespaces.go
+++ b/hubble/cmd/list/namespaces.go
@@ -25,8 +25,9 @@ func newNamespacesCommand(vp *viper.Viper) *cobra.Command {
 		Use:   "namespaces",
 		Short: "List namespaces with recent flows",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx := cmd.Context()
-			hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
+			ctx, cancel := context.WithCancel(cmd.Context())
+			defer cancel()
+			hubbleConn, err := conn.NewWithFlags(ctx, vp)
 			if err != nil {
 				return err
 			}

--- a/hubble/cmd/list/node.go
+++ b/hubble/cmd/list/node.go
@@ -32,13 +32,13 @@ func newNodeCommand(vp *viper.Viper) *cobra.Command {
 		Aliases: []string{"node"},
 		Short:   "List Hubble nodes",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx := cmd.Context()
-			hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
+			ctx, cancel := context.WithCancel(cmd.Context())
+			defer cancel()
+			hubbleConn, err := conn.NewWithFlags(ctx, vp)
 			if err != nil {
 				return err
 			}
 			defer hubbleConn.Close()
-
 			return runListNodes(ctx, cmd, hubbleConn)
 		},
 	}

--- a/hubble/cmd/observe/agent_events.go
+++ b/hubble/cmd/observe/agent_events.go
@@ -42,10 +42,10 @@ func newAgentEventsCommand(vp *viper.Viper) *cobra.Command {
 				return err
 			}
 
-			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, os.Kill)
 			defer cancel()
 
-			hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
+			hubbleConn, err := conn.NewWithFlags(ctx, vp)
 			if err != nil {
 				return err
 			}

--- a/hubble/cmd/observe/debug_events.go
+++ b/hubble/cmd/observe/debug_events.go
@@ -41,10 +41,10 @@ func newDebugEventsCommand(vp *viper.Viper) *cobra.Command {
 				return err
 			}
 
-			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, os.Kill)
 			defer cancel()
 
-			hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
+			hubbleConn, err := conn.NewWithFlags(ctx, vp)
 			if err != nil {
 				return err
 			}

--- a/hubble/cmd/observe/flows.go
+++ b/hubble/cmd/observe/flows.go
@@ -141,6 +141,9 @@ func getFlowFiltersYAML(req *observerpb.GetFlowsRequest) (string, error) {
 // GetHubbleClientFunc is primarily used to mock out the hubble client in some unit tests.
 var GetHubbleClientFunc = func(ctx context.Context, vp *viper.Viper) (client observerpb.ObserverClient, cleanup func() error, err error) {
 	if otherOpts.inputFile != "" {
+		if vp.GetBool(config.KeyPortForward) {
+			return nil, nil, fmt.Errorf("cannot use --input-file and --auto-port-forward together")
+		}
 		var f *os.File
 		if otherOpts.inputFile == "-" {
 			// read flows from stdin
@@ -159,7 +162,7 @@ var GetHubbleClientFunc = func(ctx context.Context, vp *viper.Viper) (client obs
 		return client, cleanup, nil
 	}
 	// read flows from a hubble server
-	hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
+	hubbleConn, err := conn.NewWithFlags(ctx, vp)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/hubble/cmd/observe_help.txt
+++ b/hubble/cmd/observe_help.txt
@@ -143,8 +143,13 @@ Flow Format Flags:
 Server Flags:
       --basic-auth-password string    Specify a password for basic auth
       --basic-auth-username string    Specify a username for basic auth
+      --kube-context string           Kubernetes configuration context. This option is only considered when --port-forward is set.
+      --kube-namespace string         Namespace Cilium is running in. This option is only considered when --port-forward is set. (default "kube-system")
+      --kubeconfig string             Path to the kubeconfig file. This option is only considered when --port-forward is set.
+  -P, --port-forward                  Automatically forward the relay port to the local machine. Analoguous to running: 'cilium hubble port-forward'.
+      --port-forward-port uint16      Local port to forward to. 0 will select a random port. This option is only considered when --port-forward is set. (default 4245)
       --request-timeout duration      Unary Request timeout. Only applies to non-streaming RPCs (ServerStatus, ListNodes, ListNamespaces). (default 12s)
-      --server string                 Address of a Hubble server. Ignored when --input-file is provided. (default "localhost:4245")
+      --server string                 Address of a Hubble server. Ignored when --input-file or --port-forward is provided. (default "localhost:4245")
       --timeout duration              Hubble server dialing timeout (default 5s)
       --tls                           Specify that TLS must be used when establishing a connection to a Hubble server.
                                       By default, TLS is only enabled if the server address starts with 'tls://'.

--- a/hubble/cmd/record/record.go
+++ b/hubble/cmd/record/record.go
@@ -59,10 +59,10 @@ protocols are TCP, UDP, SCTP, and ANY.`,
 				return err
 			}
 
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, os.Kill)
 			defer cancel()
 
-			hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
+			hubbleConn, err := conn.NewWithFlags(ctx, vp)
 			if err != nil {
 				return err
 			}

--- a/hubble/cmd/reflect/reflect.go
+++ b/hubble/cmd/reflect/reflect.go
@@ -26,9 +26,9 @@ func New(vp *viper.Viper) *cobra.Command {
 		Use:   "reflect",
 		Short: "Use gRPC reflection to explore Hubble's API",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
-			hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
+			hubbleConn, err := conn.NewWithFlags(ctx, vp)
 			if err != nil {
 				return err
 			}

--- a/hubble/cmd/status/status.go
+++ b/hubble/cmd/status/status.go
@@ -34,14 +34,14 @@ func New(vp *viper.Viper) *cobra.Command {
 		Short: "Display status of Hubble server",
 		Long: `Display shows the status of the Hubble server. This is intended as a basic
 connectivity health check.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx, cancel := context.WithCancel(cmd.Context())
+			defer cancel()
+			hubbleConn, err := conn.NewWithFlags(ctx, vp)
 			if err != nil {
 				return err
 			}
 			defer hubbleConn.Close()
-
 			return runStatus(ctx, cmd.OutOrStdout(), hubbleConn)
 		},
 	}

--- a/hubble/cmd/watch/peer.go
+++ b/hubble/cmd/watch/peer.go
@@ -26,10 +26,10 @@ func newPeerCommand(vp *viper.Viper) *cobra.Command {
 		Use:     "peers",
 		Aliases: []string{"peer"},
 		Short:   "Watch for Hubble peers updates",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			ctx, cancel := context.WithCancel(context.Background())
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
-			hubbleConn, err := conn.New(vp.GetString(config.KeyServer))
+			hubbleConn, err := conn.NewWithFlags(ctx, vp)
 			if err != nil {
 				return err
 			}

--- a/pkg/k8s/portforward.go
+++ b/pkg/k8s/portforward.go
@@ -5,14 +5,22 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
+	kutil "k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/podutils"
+
+	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 )
 
 // ForwardedPort holds the local and remote mapped ports.
@@ -114,4 +122,77 @@ func (pf *PortForwarder) PortForward(ctx context.Context, p PortForwardParameter
 	return &PortForwardResult{
 		ForwardedPorts: forwardedPorts,
 	}, nil
+}
+
+// PortForwardServiceResult are the ports that have been forwarded by PortForwardService.
+type PortForwardServiceResult struct {
+	ForwardedPort ForwardedPort
+}
+
+// PortForwardService executes in a goroutine a port forward command towards one of the pod behind a
+// service. If `localPort` is 0, a random port is selected. If `svcPort` is 0, uses the first port
+// configured on the service.
+//
+// To stop the port-forwarding, use the context by cancelling it.
+func (pf *PortForwarder) PortForwardService(ctx context.Context, namespace, name string, localPort, svcPort int32) (*PortForwardServiceResult, error) {
+	svc, err := pf.clientset.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service %q: %w", name, err)
+	}
+
+	pod, err := pf.getFirstPodForService(ctx, svc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service %q: %w", name, err)
+	}
+
+	if svcPort == 0 {
+		svcPort = svc.Spec.Ports[0].Port
+	}
+
+	containerPort, err := kutil.LookupContainerPortNumberByServicePort(*svc, *pod, svcPort)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup container port with service port %d: %w", svcPort, err)
+	}
+
+	p := PortForwardParameters{
+		Namespace:  pod.Namespace,
+		Pod:        pod.Name,
+		Ports:      []string{fmt.Sprintf("%d:%d", localPort, containerPort)},
+		Addresses:  nil, // default is localhost
+		OutWriters: OutWriters{Out: nil, ErrOut: nil},
+	}
+
+	res, err := pf.PortForward(ctx, p)
+	if err != nil {
+		return nil, fmt.Errorf("failed to port forward: %w", err)
+	}
+
+	return &PortForwardServiceResult{
+		ForwardedPort: res.ForwardedPorts[0],
+	}, nil
+}
+
+// getFirstPodForService returns the first pod in the list of pods matching the service selector,
+// sorted from most to less active (see `podutils.ActivePods` for more details).
+func (pf *PortForwarder) getFirstPodForService(ctx context.Context, svc *corev1.Service) (*corev1.Pod, error) {
+	selector := labels.SelectorFromSet(svc.Spec.Selector)
+	podList, err := pf.clientset.CoreV1().Pods(svc.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get list of pods for service %q: %w", svc.Name, err)
+	}
+	if len(podList.Items) == 0 {
+		return nil, fmt.Errorf("no pods found for service: %s", svc.Name)
+	}
+	if len(podList.Items) == 1 {
+		return &podList.Items[0], nil
+	}
+
+	pods := make([]*corev1.Pod, 0, len(podList.Items))
+	for _, pod := range podList.Items {
+		pods = append(pods, &pod)
+	}
+	sortBy := func(pods []*corev1.Pod) sort.Interface { return sort.Reverse(podutils.ActivePods(pods)) }
+	sort.Sort(sortBy(pods))
+
+	return pods[0], nil
 }

--- a/pkg/k8s/portforward.go
+++ b/pkg/k8s/portforward.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// ForwardedPort holds the local and remote mapped ports.
+type ForwardedPort struct {
+	Local  uint16
+	Remote uint16
+}
+
+// PortForwardParameters are the needed parameters to call PortForward.
+//
+// Ports value follow the kubectl syntax: <local-port>:<remote-port>:
+//   - 5000 means 5000:5000 listening on 5000 port locally, forwarding to 5000 in the pod
+//   - 8888:5000 means listening on 8888 port locally, forwarding to 5000 in the pod
+//   - 0:5000 means listening on a random port locally, forwarding to 5000 in the pod
+//   - :5000 means listening on a random port locally, forwarding to 5000 in the pod
+type PortForwardParameters struct {
+	Namespace  string
+	Pod        string
+	Ports      []string
+	Addresses  []string
+	OutWriters OutWriters
+}
+
+// OutWriters holds the two io.Writer used by the port forward.
+// These can be safely disabled by setting them to nil.
+type OutWriters struct {
+	Out    io.Writer
+	ErrOut io.Writer
+}
+
+// PortForwarder augments the k8s client-go PortForwarder with helper methods using a clientset.
+type PortForwarder struct {
+	clientset kubernetes.Interface
+	config    *rest.Config
+}
+
+// NewPortForwarder creates a new PortForwarder ready to use.
+func NewPortForwarder(clientset kubernetes.Interface, config *rest.Config) *PortForwarder {
+	return &PortForwarder{clientset: clientset, config: config}
+}
+
+// PortForwardResult are the ports that have been forwarded by PortForward.
+type PortForwardResult struct {
+	ForwardedPorts []ForwardedPort
+}
+
+// PortForward executes in a goroutine a port forward command.
+// To stop the port-forwarding, use the context by cancelling it.
+func (pf *PortForwarder) PortForward(ctx context.Context, p PortForwardParameters) (*PortForwardResult, error) {
+	req := pf.clientset.CoreV1().RESTClient().Post().Namespace(p.Namespace).
+		Resource("pods").Name(p.Pod).SubResource(strings.ToLower("PortForward"))
+
+	roundTripper, upgrader, err := spdy.RoundTripperFor(pf.config)
+	if err != nil {
+		return nil, err
+	}
+
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, req.URL())
+	stopChan, readyChan := make(chan struct{}, 1), make(chan struct{}, 1)
+	if len(p.Addresses) == 0 {
+		p.Addresses = []string{"localhost"}
+	}
+
+	pw, err := portforward.NewOnAddresses(dialer, p.Addresses, p.Ports, stopChan, readyChan, p.OutWriters.Out, p.OutWriters.ErrOut)
+	if err != nil {
+		return nil, err
+	}
+
+	errChan := make(chan error, 1)
+	go func() {
+		if err := pw.ForwardPorts(); err != nil {
+			errChan <- err
+		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		close(stopChan)
+	}()
+
+	select {
+	case <-pw.Ready:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case err := <-errChan:
+		return nil, err
+	}
+
+	ports, err := pw.GetPorts()
+	if err != nil {
+		return nil, err
+	}
+
+	forwardedPorts := make([]ForwardedPort, 0, len(ports))
+	for _, port := range ports {
+		forwardedPorts = append(forwardedPorts, ForwardedPort{port.Local, port.Remote})
+	}
+
+	return &PortForwardResult{
+		ForwardedPorts: forwardedPorts,
+	}, nil
+}

--- a/vendor/k8s.io/kubectl/pkg/util/apply.go
+++ b/vendor/k8s.io/kubectl/pkg/util/apply.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var metadataAccessor = meta.NewAccessor()
+
+// GetOriginalConfiguration retrieves the original configuration of the object
+// from the annotation, or nil if no annotation was found.
+func GetOriginalConfiguration(obj runtime.Object) ([]byte, error) {
+	annots, err := metadataAccessor.Annotations(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	if annots == nil {
+		return nil, nil
+	}
+
+	original, ok := annots[v1.LastAppliedConfigAnnotation]
+	if !ok {
+		return nil, nil
+	}
+
+	return []byte(original), nil
+}
+
+// SetOriginalConfiguration sets the original configuration of the object
+// as the annotation on the object for later use in computing a three way patch.
+func setOriginalConfiguration(obj runtime.Object, original []byte) error {
+	if len(original) < 1 {
+		return nil
+	}
+
+	annots, err := metadataAccessor.Annotations(obj)
+	if err != nil {
+		return err
+	}
+
+	if annots == nil {
+		annots = map[string]string{}
+	}
+
+	annots[v1.LastAppliedConfigAnnotation] = string(original)
+	return metadataAccessor.SetAnnotations(obj, annots)
+}
+
+// GetModifiedConfiguration retrieves the modified configuration of the object.
+// If annotate is true, it embeds the result as an annotation in the modified
+// configuration. If an object was read from the command input, it will use that
+// version of the object. Otherwise, it will use the version from the server.
+func GetModifiedConfiguration(obj runtime.Object, annotate bool, codec runtime.Encoder) ([]byte, error) {
+	// First serialize the object without the annotation to prevent recursion,
+	// then add that serialization to it as the annotation and serialize it again.
+	var modified []byte
+
+	// Otherwise, use the server side version of the object.
+	// Get the current annotations from the object.
+	annots, err := metadataAccessor.Annotations(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	if annots == nil {
+		annots = map[string]string{}
+	}
+
+	original := annots[v1.LastAppliedConfigAnnotation]
+	delete(annots, v1.LastAppliedConfigAnnotation)
+	if err := metadataAccessor.SetAnnotations(obj, annots); err != nil {
+		return nil, err
+	}
+
+	modified, err = runtime.Encode(codec, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	if annotate {
+		annots[v1.LastAppliedConfigAnnotation] = string(modified)
+		if err := metadataAccessor.SetAnnotations(obj, annots); err != nil {
+			return nil, err
+		}
+
+		modified, err = runtime.Encode(codec, obj)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Restore the object to its original condition.
+	annots[v1.LastAppliedConfigAnnotation] = original
+	if err := metadataAccessor.SetAnnotations(obj, annots); err != nil {
+		return nil, err
+	}
+
+	return modified, nil
+}
+
+// updateApplyAnnotation calls CreateApplyAnnotation if the last applied
+// configuration annotation is already present. Otherwise, it does nothing.
+func updateApplyAnnotation(obj runtime.Object, codec runtime.Encoder) error {
+	if original, err := GetOriginalConfiguration(obj); err != nil || len(original) <= 0 {
+		return err
+	}
+	return CreateApplyAnnotation(obj, codec)
+}
+
+// CreateApplyAnnotation gets the modified configuration of the object,
+// without embedding it again, and then sets it on the object as the annotation.
+func CreateApplyAnnotation(obj runtime.Object, codec runtime.Encoder) error {
+	modified, err := GetModifiedConfiguration(obj, false, codec)
+	if err != nil {
+		return err
+	}
+	return setOriginalConfiguration(obj, modified)
+}
+
+// CreateOrUpdateAnnotation creates the annotation used by
+// kubectl apply only when createAnnotation is true
+// Otherwise, only update the annotation when it already exists
+func CreateOrUpdateAnnotation(createAnnotation bool, obj runtime.Object, codec runtime.Encoder) error {
+	if createAnnotation {
+		return CreateApplyAnnotation(obj, codec)
+	}
+	return updateApplyAnnotation(obj, codec)
+}

--- a/vendor/k8s.io/kubectl/pkg/util/pod_port.go
+++ b/vendor/k8s.io/kubectl/pkg/util/pod_port.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+)
+
+// LookupContainerPortNumberByName find containerPort number by its named port name
+func LookupContainerPortNumberByName(pod v1.Pod, name string) (int32, error) {
+	for _, ctr := range pod.Spec.Containers {
+		for _, ctrportspec := range ctr.Ports {
+			if ctrportspec.Name == name {
+				return ctrportspec.ContainerPort, nil
+			}
+		}
+	}
+	for _, ctr := range pod.Spec.InitContainers {
+		for _, ctrportspec := range ctr.Ports {
+			if ctrportspec.Name == name {
+				return ctrportspec.ContainerPort, nil
+			}
+		}
+	}
+	return int32(-1), fmt.Errorf("Pod '%s' does not have a named port '%s'", pod.Name, name)
+}

--- a/vendor/k8s.io/kubectl/pkg/util/podutils/podutils.go
+++ b/vendor/k8s.io/kubectl/pkg/util/podutils/podutils.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podutils
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// IsPodAvailable returns true if a pod is available; false otherwise.
+// Precondition for an available pod is that it must be ready. On top
+// of that, there are two cases when a pod can be considered available:
+// 1. minReadySeconds == 0, or
+// 2. LastTransitionTime (is set) + minReadySeconds < current time
+func IsPodAvailable(pod *corev1.Pod, minReadySeconds int32, now metav1.Time) bool {
+	if !IsPodReady(pod) {
+		return false
+	}
+
+	c := getPodReadyCondition(pod.Status)
+	minReadySecondsDuration := time.Duration(minReadySeconds) * time.Second
+	if minReadySeconds == 0 || !c.LastTransitionTime.IsZero() && c.LastTransitionTime.Add(minReadySecondsDuration).Before(now.Time) {
+		return true
+	}
+	return false
+}
+
+// IsPodReady returns true if a pod is ready; false otherwise.
+func IsPodReady(pod *corev1.Pod) bool {
+	return isPodReadyConditionTrue(pod.Status)
+}
+
+func isPodDeleting(pod *corev1.Pod) bool {
+	return pod.DeletionTimestamp != nil
+}
+
+// IsPodReadyConditionTrue returns true if a pod is ready; false otherwise.
+func isPodReadyConditionTrue(status corev1.PodStatus) bool {
+	condition := getPodReadyCondition(status)
+	return condition != nil && condition.Status == corev1.ConditionTrue
+}
+
+// GetPodReadyCondition extracts the pod ready condition from the given status and returns that.
+// Returns nil if the condition is not present.
+func getPodReadyCondition(status corev1.PodStatus) *corev1.PodCondition {
+	_, condition := getPodCondition(&status, corev1.PodReady)
+	return condition
+}
+
+// GetPodCondition extracts the provided condition from the given status and returns that.
+// Returns nil and -1 if the condition is not present, and the index of the located condition.
+func getPodCondition(status *corev1.PodStatus, conditionType corev1.PodConditionType) (int, *corev1.PodCondition) {
+	if status == nil {
+		return -1, nil
+	}
+	return getPodConditionFromList(status.Conditions, conditionType)
+}
+
+// GetPodConditionFromList extracts the provided condition from the given list of condition and
+// returns the index of the condition and the condition. Returns -1 and nil if the condition is not present.
+func getPodConditionFromList(conditions []corev1.PodCondition, conditionType corev1.PodConditionType) (int, *corev1.PodCondition) {
+	if conditions == nil {
+		return -1, nil
+	}
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return i, &conditions[i]
+		}
+	}
+	return -1, nil
+}
+
+// ByLogging allows custom sorting of pods so the best one can be picked for getting its logs.
+type ByLogging []*corev1.Pod
+
+func (s ByLogging) Len() int      { return len(s) }
+func (s ByLogging) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func (s ByLogging) Less(i, j int) bool {
+	// 1. assigned < unassigned
+	if s[i].Spec.NodeName != s[j].Spec.NodeName && (len(s[i].Spec.NodeName) == 0 || len(s[j].Spec.NodeName) == 0) {
+		return len(s[i].Spec.NodeName) > 0
+	}
+	// 2. PodRunning < PodUnknown < PodPending
+	m := map[corev1.PodPhase]int{corev1.PodRunning: 0, corev1.PodUnknown: 1, corev1.PodPending: 2}
+	if m[s[i].Status.Phase] != m[s[j].Status.Phase] {
+		return m[s[i].Status.Phase] < m[s[j].Status.Phase]
+	}
+	// 3. ready < not ready
+	if IsPodReady(s[i]) != IsPodReady(s[j]) {
+		return IsPodReady(s[i])
+	}
+	// TODO: take availability into account when we push minReadySeconds information from deployment into pods,
+	//       see https://github.com/kubernetes/kubernetes/issues/22065
+	// 4. Been ready for more time < less time < empty time
+	if IsPodReady(s[i]) && IsPodReady(s[j]) && !podReadyTime(s[i]).Equal(podReadyTime(s[j])) {
+		return afterOrZero(podReadyTime(s[j]), podReadyTime(s[i]))
+	}
+	// 5. Pods with containers with higher restart counts < lower restart counts
+	if maxContainerRestarts(s[i]) != maxContainerRestarts(s[j]) {
+		return maxContainerRestarts(s[i]) > maxContainerRestarts(s[j])
+	}
+	// 6. older pods < newer pods < empty timestamp pods
+	if !s[i].CreationTimestamp.Equal(&s[j].CreationTimestamp) {
+		return afterOrZero(&s[j].CreationTimestamp, &s[i].CreationTimestamp)
+	}
+	return false
+}
+
+// ActivePods type allows custom sorting of pods so a controller can pick the best ones to delete.
+type ActivePods []*corev1.Pod
+
+func (s ActivePods) Len() int      { return len(s) }
+func (s ActivePods) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func (s ActivePods) Less(i, j int) bool {
+	// 1. Unassigned < assigned
+	// If only one of the pods is unassigned, the unassigned one is smaller
+	if s[i].Spec.NodeName != s[j].Spec.NodeName && (len(s[i].Spec.NodeName) == 0 || len(s[j].Spec.NodeName) == 0) {
+		return len(s[i].Spec.NodeName) == 0
+	}
+	// 2. PodPending < PodUnknown < PodRunning
+	m := map[corev1.PodPhase]int{corev1.PodPending: 0, corev1.PodUnknown: 1, corev1.PodRunning: 2}
+	if m[s[i].Status.Phase] != m[s[j].Status.Phase] {
+		return m[s[i].Status.Phase] < m[s[j].Status.Phase]
+	}
+	// 3. Not ready < ready
+	// If only one of the pods is not ready, the not ready one is smaller
+	if IsPodReady(s[i]) != IsPodReady(s[j]) {
+		return !IsPodReady(s[i])
+	}
+	// 4. Deleting < Not deleting
+	if isPodDeleting(s[i]) != isPodDeleting(s[j]) {
+		return isPodDeleting(s[i])
+	}
+	// 5. Older deletion timestamp < newer deletion timestamp
+	if isPodDeleting(s[i]) && isPodDeleting(s[j]) && !s[i].ObjectMeta.DeletionTimestamp.Equal(s[j].ObjectMeta.DeletionTimestamp) {
+		return s[i].ObjectMeta.DeletionTimestamp.Before(s[j].ObjectMeta.DeletionTimestamp)
+	}
+	// TODO: take availability into account when we push minReadySeconds information from deployment into pods,
+	//       see https://github.com/kubernetes/kubernetes/issues/22065
+	// 6. Been ready for empty time < less time < more time
+	// If both pods are ready, the latest ready one is smaller
+	if IsPodReady(s[i]) && IsPodReady(s[j]) && !podReadyTime(s[i]).Equal(podReadyTime(s[j])) {
+		return afterOrZero(podReadyTime(s[i]), podReadyTime(s[j]))
+	}
+	// 7. Pods with containers with higher restart counts < lower restart counts
+	if maxContainerRestarts(s[i]) != maxContainerRestarts(s[j]) {
+		return maxContainerRestarts(s[i]) > maxContainerRestarts(s[j])
+	}
+	// 8. Empty creation time pods < newer pods < older pods
+	if !s[i].CreationTimestamp.Equal(&s[j].CreationTimestamp) {
+		return afterOrZero(&s[i].CreationTimestamp, &s[j].CreationTimestamp)
+	}
+	return false
+}
+
+// afterOrZero checks if time t1 is after time t2; if one of them
+// is zero, the zero time is seen as after non-zero time.
+func afterOrZero(t1, t2 *metav1.Time) bool {
+	if t1.Time.IsZero() || t2.Time.IsZero() {
+		return t1.Time.IsZero()
+	}
+	return t1.After(t2.Time)
+}
+
+func podReadyTime(pod *corev1.Pod) *metav1.Time {
+	for _, c := range pod.Status.Conditions {
+		// we only care about pod ready conditions
+		if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+			return &c.LastTransitionTime
+		}
+	}
+	return &metav1.Time{}
+}
+
+func maxContainerRestarts(pod *corev1.Pod) int {
+	maxRestarts := 0
+	for _, c := range pod.Status.ContainerStatuses {
+		maxRestarts = max(maxRestarts, int(c.RestartCount))
+	}
+	return maxRestarts
+}
+
+// ContainerType and VisitContainers are taken from
+// https://github.com/kubernetes/kubernetes/blob/master/pkg/api/v1/pod/util.go
+// kubectl cannot directly import this due to project goals
+
+// ContainerType signifies container type
+type ContainerType int
+
+const (
+	// Containers is for normal containers
+	Containers ContainerType = 1 << iota
+	// InitContainers is for init containers
+	InitContainers
+	// EphemeralContainers is for ephemeral containers
+	EphemeralContainers
+)
+
+// AllContainers specifies that all containers be visited.
+const AllContainers ContainerType = (InitContainers | Containers | EphemeralContainers)
+
+// ContainerVisitor is called with each container spec, and returns true
+// if visiting should continue.
+type ContainerVisitor func(container *corev1.Container, containerType ContainerType) (shouldContinue bool)
+
+// VisitContainers invokes the visitor function with a pointer to every container
+// spec in the given pod spec with type set in mask. If visitor returns false,
+// visiting is short-circuited. VisitContainers returns true if visiting completes,
+// false if visiting was short-circuited.
+func VisitContainers(podSpec *corev1.PodSpec, mask ContainerType, visitor ContainerVisitor) bool {
+	if mask&InitContainers != 0 {
+		for i := range podSpec.InitContainers {
+			if !visitor(&podSpec.InitContainers[i], InitContainers) {
+				return false
+			}
+		}
+	}
+	if mask&Containers != 0 {
+		for i := range podSpec.Containers {
+			if !visitor(&podSpec.Containers[i], Containers) {
+				return false
+			}
+		}
+	}
+	if mask&EphemeralContainers != 0 {
+		for i := range podSpec.EphemeralContainers {
+			if !visitor((*corev1.Container)(&podSpec.EphemeralContainers[i].EphemeralContainerCommon), EphemeralContainers) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/vendor/k8s.io/kubectl/pkg/util/service_port.go
+++ b/vendor/k8s.io/kubectl/pkg/util/service_port.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// LookupContainerPortNumberByServicePort implements
+// the handling of resolving container named port, as well as ignoring targetPort when clusterIP=None
+// It returns an error when a named port can't find a match (with -1 returned), or when the service does not
+// declare such port (with the input port number returned).
+func LookupContainerPortNumberByServicePort(svc v1.Service, pod v1.Pod, port int32) (int32, error) {
+	for _, svcportspec := range svc.Spec.Ports {
+		if svcportspec.Port != port {
+			continue
+		}
+		if svc.Spec.ClusterIP == v1.ClusterIPNone {
+			return port, nil
+		}
+		if svcportspec.TargetPort.Type == intstr.Int {
+			if svcportspec.TargetPort.IntValue() == 0 {
+				// targetPort is omitted, and the IntValue() would be zero
+				return svcportspec.Port, nil
+			}
+			return int32(svcportspec.TargetPort.IntValue()), nil
+		}
+		return LookupContainerPortNumberByName(pod, svcportspec.TargetPort.String())
+	}
+	return port, fmt.Errorf("Service %s does not have a service port %d", svc.Name, port)
+}
+
+// LookupServicePortNumberByName find service port number by its named port name
+func LookupServicePortNumberByName(svc v1.Service, name string) (int32, error) {
+	for _, svcportspec := range svc.Spec.Ports {
+		if svcportspec.Name == name {
+			return svcportspec.Port, nil
+		}
+	}
+
+	return int32(-1), fmt.Errorf("Service '%s' does not have a named port '%s'", svc.Name, name)
+}

--- a/vendor/k8s.io/kubectl/pkg/util/umask.go
+++ b/vendor/k8s.io/kubectl/pkg/util/umask.go
@@ -1,0 +1,29 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// Umask is a wrapper for `unix.Umask()` on non-Windows platforms
+func Umask(mask int) (old int, err error) {
+	return unix.Umask(mask), nil
+}

--- a/vendor/k8s.io/kubectl/pkg/util/umask_windows.go
+++ b/vendor/k8s.io/kubectl/pkg/util/umask_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+)
+
+// Umask returns an error on Windows
+func Umask(mask int) (int, error) {
+	return 0, errors.New("platform and architecture is not supported")
+}

--- a/vendor/k8s.io/kubectl/pkg/util/util.go
+++ b/vendor/k8s.io/kubectl/pkg/util/util.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"crypto/md5"
+	"errors"
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ParseRFC3339 parses an RFC3339 date in either RFC3339Nano or RFC3339 format.
+func ParseRFC3339(s string, nowFn func() metav1.Time) (metav1.Time, error) {
+	if t, timeErr := time.Parse(time.RFC3339Nano, s); timeErr == nil {
+		return metav1.Time{Time: t}, nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return metav1.Time{}, err
+	}
+	return metav1.Time{Time: t}, nil
+}
+
+// HashObject returns the hash of a Object hash by a Codec
+func HashObject(obj runtime.Object, codec runtime.Codec) (string, error) {
+	data, err := runtime.Encode(codec, obj)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", md5.Sum(data)), nil
+}
+
+// ParseFileSource parses the source given.
+//
+//	Acceptable formats include:
+//	 1.  source-path: the basename will become the key name
+//	 2.  source-name=source-path: the source-name will become the key name and
+//	     source-path is the path to the key file.
+//
+// Key names cannot include '='.
+func ParseFileSource(source string) (keyName, filePath string, err error) {
+	numSeparators := strings.Count(source, "=")
+	switch {
+	case numSeparators == 0:
+		return path.Base(filepath.ToSlash(source)), source, nil
+	case numSeparators == 1 && strings.HasPrefix(source, "="):
+		return "", "", fmt.Errorf("key name for file path %v missing", strings.TrimPrefix(source, "="))
+	case numSeparators == 1 && strings.HasSuffix(source, "="):
+		return "", "", fmt.Errorf("file path for key name %v missing", strings.TrimSuffix(source, "="))
+	case numSeparators > 1:
+		return "", "", errors.New("key names or file paths cannot contain '='")
+	default:
+		components := strings.Split(source, "=")
+		return components[0], components[1], nil
+	}
+}
+
+// ParseLiteralSource parses the source key=val pair into its component pieces.
+// This functionality is distinguished from strings.SplitN(source, "=", 2) since
+// it returns an error in the case of empty keys, values, or a missing equals sign.
+func ParseLiteralSource(source string) (keyName, value string, err error) {
+	// leading equal is invalid
+	if strings.Index(source, "=") == 0 {
+		return "", "", fmt.Errorf("invalid literal source %v, expected key=value", source)
+	}
+	// split after the first equal (so values can have the = character)
+	items := strings.SplitN(source, "=", 2)
+	if len(items) != 2 {
+		return "", "", fmt.Errorf("invalid literal source %v, expected key=value", source)
+	}
+
+	return items[0], items[1], nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2547,9 +2547,11 @@ k8s.io/kube-openapi/pkg/validation/validate
 ## explicit; go 1.22.0
 k8s.io/kubectl/pkg/cmd/util
 k8s.io/kubectl/pkg/scheme
+k8s.io/kubectl/pkg/util
 k8s.io/kubectl/pkg/util/i18n
 k8s.io/kubectl/pkg/util/interrupt
 k8s.io/kubectl/pkg/util/openapi
+k8s.io/kubectl/pkg/util/podutils
 k8s.io/kubectl/pkg/util/templates
 k8s.io/kubectl/pkg/util/term
 k8s.io/kubectl/pkg/validation


### PR DESCRIPTION
Implement automatic (opt-in) port-forwarding capability in Hubble-cli.

As proposed in https://github.com/cilium/cilium/pull/35353, this uses native port-forwarding by introducing a new high-level PortForwarder type to add automatic port-forwarding to all commands that require a GRPC connection to hubble-relay.

Fixes: #34935

```release-note
Add support for automatic port-forwarding in Hubble CLI
Replace kubectl-based port-forwarding with native implementation in Cilium CLI
```

---

This also updates hubble port-forwarding commands in cilium-cli to replace the kubectl-based implementation, but we can also do that in a different PR if desired. Added bonus is we don't need to sleep in a goroutine before opening the browser to mitigate the kubectl spawn process delay, nice.
