### PR TITLE
cilium-cli: enabling pod-to-pod-with-l7-policy-encryption for IPv6+IPSec

### DIFF
--- a/cilium-cli/connectivity/tests/encryption.go
+++ b/cilium-cli/connectivity/tests/encryption.go
@@ -251,14 +251,7 @@ func (s *podToPodEncryption) Run(ctx context.Context, t *check.Test) {
 		t.Debug("Encapsulation before WG encryption")
 	}
 
-	e, ok := t.Context().Feature(features.EncryptionPod)
-	isIPSec := ok && e.Enabled && e.Mode == "ipsec"
-
 	t.ForEachIPFamily(func(ipFam features.IPFamily) {
-		if isIPSec && ipFam == features.IPFamilyV6 {
-			t.Debugf("Inactive IPv6 test with IPSec, see https://github.com/cilium/cilium/issues/35485")
-			return
-		}
 		testNoTrafficLeak(ctx, t, s, client, &server, &clientHost, &serverHost, requestHTTP, ipFam, assertNoLeaks, true, wgEncap)
 	})
 }


### PR DESCRIPTION
This PR enables the pod-to-pod-with-l7-policy-encryption IPv6 tests for IPSec.
In #35173, the MTU patch is delivered and the IPv4 test is enabled.
In #35485 we discussed the potential flakes observed, and in #36962 we patched the bpftrace script.

```release-note
Enable pod-to-pod-with-l7-policy-encryption connectivity test for IPv6+IPSec
```
