### PR TITLE
endpoint: make restore-rules caching private

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -268,7 +268,7 @@ func (e *Endpoint) addNewRedirects(selectorPolicy policy.SelectorPolicy, proxyWa
 		}
 
 		pp := newProxyPolicy(l4, listener, dstPort, dstProto)
-		proxyPort, err, finalizeFunc, revertFunc := e.proxy.CreateOrUpdateRedirect(e.aliveCtx, &pp, proxyID, e, proxyWaitGroup)
+		proxyPort, err, finalizeFunc, revertFunc := e.proxy.CreateOrUpdateRedirect(e.aliveCtx, &pp, proxyID, e.ID, proxyWaitGroup)
 		if err != nil {
 			// Skip redirects that can not be created or updated.  This
 			// can happen when a listener is missing, for example when
@@ -628,7 +628,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 	// fresh DNSRules requires the IPCache lock (which must not be taken while
 	// holding e.mutex to avoid deadlocks). Therefore, rules are obtained
 	// before the call to runPreCompilationSteps.
-	e.OnDNSPolicyUpdateLocked(rules)
+	e.setDNSRulesLocked(rules)
 
 	// If dry mode is enabled, no further changes to BPF maps are performed
 	if e.isProperty(PropertySkipBPFPolicy) {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -23,6 +23,7 @@ import (
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/eventqueue"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
@@ -984,4 +985,19 @@ func (e *Endpoint) GetRealizedPolicyRuleLabelsForKey(key policyTypes.Key) (
 	}
 
 	return entry.DerivedFromRules, e.policyRevision, true
+}
+
+// setDNSRulesLocked is called when the Endpoint's DNS policy has been updated.
+// endpoint lock must be held.
+func (e *Endpoint) setDNSRulesLocked(rules restore.DNSRules) {
+	e.DNSRulesV2 = rules
+	// Keep V1 in tact in case of a downgrade.
+	e.DNSRules = make(restore.DNSRules)
+	for pp, rules := range rules {
+		proto := pp.Protocol()
+		// Filter out non-UDP/TCP protocol
+		if proto == uint8(u8proto.TCP) || proto == uint8(u8proto.UDP) {
+			e.DNSRules[pp.ToV1()] = rules
+		}
+	}
 }

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -15,7 +15,7 @@ import (
 
 // EndpointProxy defines any L7 proxy with which an Endpoint must interact.
 type EndpointProxy interface {
-	CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, localEndpoint endpoint.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc)
+	CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, epID uint16, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc)
 	RemoveRedirect(id string)
 	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
 	UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
@@ -44,7 +44,7 @@ func (e *Endpoint) IsProxyDisabled() bool {
 type FakeEndpointProxy struct{}
 
 // CreateOrUpdateRedirect does nothing.
-func (f *FakeEndpointProxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, localEndpoint endpoint.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
+func (f *FakeEndpointProxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, epid uint16, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 	return
 }
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -94,7 +94,7 @@ type RedirectSuiteProxy struct {
 
 // CreateOrUpdateRedirect returns the proxy port for the given L7Parser from the
 // ProxyPolicy parameter.
-func (r *RedirectSuiteProxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, localEndpoint endpoint.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
+func (r *RedirectSuiteProxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, epID uint16, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 	pp := r.parserProxyPortMap[l4.GetL7Parser().String()+l4.GetListener()]
 	return pp, nil, func() { r.redirects[id] = pp }, nil
 }

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -38,12 +38,12 @@ type proxyRuleUpdater interface {
 
 // setRules replaces old l7 rules of a redirect with new ones.
 // TODO: Get rid of the duplication between 'currentRules' and 'r.rules'
-func (dr *dnsRedirect) setRules(wg *completion.WaitGroup, newRules policy.L7DataMap) error {
+func (dr *dnsRedirect) setRules(_ *completion.WaitGroup, newRules policy.L7DataMap) error {
 	log.WithFields(logrus.Fields{
 		"newRules":           newRules,
 		logfields.EndpointID: dr.redirect.endpointID,
 	}).Debug("DNS Proxy updating matchNames in allowed list during UpdateRules")
-	if err := dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPortProto, newRules); err != nil {
+	if err := dr.proxyRuleUpdater.UpdateAllowed(uint64(dr.redirect.endpointID), dr.redirect.dstPortProto, newRules); err != nil {
 		return err
 	}
 	dr.currentRules = copyRules(dr.redirect.rules)
@@ -65,8 +65,7 @@ func (dr *dnsRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc,
 
 // Close the redirect.
 func (dr *dnsRedirect) Close() {
-	dr.proxyRuleUpdater.UpdateAllowed(dr.redirect.endpointID, dr.redirect.dstPortProto, nil)
-	dr.redirect.localEndpoint.OnDNSPolicyUpdateLocked(nil)
+	dr.proxyRuleUpdater.UpdateAllowed(uint64(dr.redirect.endpointID), dr.redirect.dstPortProto, nil)
 	dr.currentRules = nil
 }
 
@@ -75,7 +74,7 @@ type dnsProxyIntegration struct {
 
 // createRedirect creates a redirect to the dns proxy. The redirect structure passed
 // in is safe to access for reading and writing.
-func (p *dnsProxyIntegration) createRedirect(r *Redirect, wg *completion.WaitGroup) (RedirectImplementation, error) {
+func (p *dnsProxyIntegration) createRedirect(r *Redirect, _ *completion.WaitGroup) (RedirectImplementation, error) {
 	dr := &dnsRedirect{
 		redirect:         r,
 		proxyRuleUpdater: DefaultDNSProxy,

--- a/pkg/proxy/endpoint/endpoint.go
+++ b/pkg/proxy/endpoint/endpoint.go
@@ -5,7 +5,6 @@ package endpoint
 
 import (
 	"github.com/cilium/cilium/pkg/container/versioned"
-	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -33,10 +32,6 @@ type EndpointUpdater interface {
 	// UpdateProxyStatistics updates the Endpoint's proxy statistics to account
 	// for a new observed flow with the given characteristics.
 	UpdateProxyStatistics(proxyType, l4Protocol string, port, proxyPort uint16, ingress, request bool, verdict accesslog.FlowVerdict)
-
-	// OnDNSPolicyUpdateLocked is called when the Endpoint's DNS policy has been updated.
-	// 'rules' is a fresh copy of the DNS rules passed to the callee.
-	OnDNSPolicyUpdateLocked(rules restore.DNSRules)
 
 	// GetPolicyVersionHandle returns the selector cache version handle held for Endpoint's
 	// desired policy, if any.

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/policy"
-	endpointtest "github.com/cilium/cilium/pkg/proxy/endpoint/test"
 	"github.com/cilium/cilium/pkg/proxy/types"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
@@ -226,18 +225,12 @@ func TestCreateOrUpdateRedirectMissingListener(t *testing.T) {
 	p, cleaner := proxyForTest()
 	defer cleaner()
 
-	ep := &endpointtest.ProxyUpdaterMock{
-		Id:   1000,
-		Ipv4: "10.0.0.1",
-		Ipv6: "f00d::1",
-	}
-
 	l4 := &fakeProxyPolicy{}
 
 	ctx := context.TODO()
 	wg := completion.NewWaitGroup(ctx)
 
-	proxyPort, err, finalizeFunc, revertFunc := p.CreateOrUpdateRedirect(ctx, l4, "dummy-proxy-id", ep, wg)
+	proxyPort, err, finalizeFunc, revertFunc := p.CreateOrUpdateRedirect(ctx, l4, "dummy-proxy-id", 1000, wg)
 	require.Equal(t, uint16(0), proxyPort)
 	require.Error(t, err)
 	require.Nil(t, finalizeFunc)

--- a/pkg/proxy/redirect.go
+++ b/pkg/proxy/redirect.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -36,8 +35,7 @@ type Redirect struct {
 	name           string
 	listener       *ProxyPort
 	dstPortProto   restore.PortProto
-	endpointID     uint64
-	localEndpoint  endpoint.EndpointUpdater
+	endpointID     uint16
 	implementation RedirectImplementation
 
 	// The following fields are updated while the redirect is alive, the
@@ -46,13 +44,12 @@ type Redirect struct {
 	rules policy.L7DataMap
 }
 
-func newRedirect(localEndpoint endpoint.EndpointUpdater, name string, listener *ProxyPort, port uint16, proto u8proto.U8proto) *Redirect {
+func newRedirect(epID uint16, name string, listener *ProxyPort, port uint16, proto u8proto.U8proto) *Redirect {
 	return &Redirect{
-		name:          name,
-		listener:      listener,
-		dstPortProto:  restore.MakeV2PortProto(port, proto),
-		endpointID:    localEndpoint.GetID(),
-		localEndpoint: localEndpoint,
+		name:         name,
+		listener:     listener,
+		dstPortProto: restore.MakeV2PortProto(port, proto),
+		endpointID:   epID,
 	}
 }
 


### PR DESCRIPTION
Previously, when DNS proxy redirects were deleted, we would also clear the special DNS rule cache. (The rule cache is so we can serve DNS traffic while endpoints are being restored on agent restart). However, now that redirects can only be changed during regeneration, and we always set the DNS rules directly during regen, we no longer need this callback.

So, clean up the interfaces. While we're at it, pass the endpoint ID as needed instead of the full endpoint.