### PR TITLE
srv6: flow label control

### DIFF
--- a/bpf/include/bpf/ctx/skb.h
+++ b/bpf/include/bpf/ctx/skb.h
@@ -57,9 +57,10 @@
 /* Avoid expensive calls into the kernel flow dissector if it's not an L4
  * hash. We currently only use the hash for debugging. If needed later, we
  * can map it to BPF_FUNC(get_hash_recalc) to get the L4 hash.
+ *
+ * bpf function get_hash_recalc from ../helpers_skb.h
  */
 #define get_hash(ctx)		ctx->hash
-#define get_hash_recalc(ctx)	get_hash(ctx)
 
 #define DEFINE_FUNC_CTX_POINTER(FIELD)						\
 static __always_inline void *							\

--- a/bpf/include/bpf/helpers_skb.h
+++ b/bpf/include/bpf/helpers_skb.h
@@ -11,6 +11,9 @@
 
 /* Only used helpers in Cilium go below. */
 
+/* Hash computation */
+static int BPF_FUNC(get_hash_recalc, struct __sk_buff *skb);
+
 /* Packet redirection */
 static int BPF_FUNC(redirect, int ifindex, __u32 flags);
 static int BPF_FUNC(redirect_neigh, int ifindex, struct bpf_redir_neigh *params,

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -562,7 +562,7 @@ enum {
 	.type		= (t),		\
 	.subtype	= (s),		\
 	.source		= EVENT_SOURCE,	\
-	.hash		= get_hash_recalc(ctx)
+	.hash		= get_hash(ctx)   /* Avoids hash recalculation, assumes hash has been already calculated */
 
 #define __notify_pktcap_hdr(o, c)	\
 	.len_orig	= (o),		\

--- a/bpf/lib/srv6.h
+++ b/bpf/lib/srv6.h
@@ -126,12 +126,18 @@ srv6_encapsulation(struct __ctx_buff *ctx, int growth, __u16 new_payload_len,
 		   __u8 nexthdr, union v6addr *saddr, struct in6_addr *sid)
 {
 	__u32 len = sizeof(struct ipv6hdr) - 2 * sizeof(struct in6_addr);
+	__u32 hash;
+
 	struct ipv6hdr new_ip6 = {
 		.version     = 0x6,
 		.payload_len = bpf_htons(new_payload_len),
 		.nexthdr     = nexthdr,
 		.hop_limit   = IPDEFTTL,
 	};
+
+	hash = get_hash_recalc(ctx);
+	new_ip6.flow_lbl[1] = (hash >> 16) & 0xff;
+	new_ip6.flow_lbl[2] = (hash >> 24) & 0xff;
 
 #ifdef ENABLE_SRV6_SRH_ENCAP
 	/* If reduced encapsulation is disabled, the next header will be the


### PR DESCRIPTION
This commit introduced IPv6 flow label control for SRv6 encapsulated packets. Currently IPv6 flow label is set to 0x0 value.

IPv6 flow label is used to perform ECMP load-balancing in the core of the network. Setting flow label provides entropy and allows packet flows to be correctly load balanced.

The commit introduces configurable flag that keeps the default behavior of flow label set to 0x0 value. As on option it enables TCP/UDP port based basic calculation of the flow label value that is set in the IPv6 header in case of SRv6 packet flow.

Fixes: https://github.com/cilium/cilium/issues/21961
```release-note
Fix missing flowlabel hash on SRv6 traffic.
```
