### PR TITLE
Docs: make ToServices selectors work for in-cluster services too

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -256,15 +256,9 @@ accessible from endpoints that have both labels ``env=prod`` and
 Services based
 --------------
 
-.. note::
-
-	Services based rules rules will only take effect on Kubernetes services
-        without a selector.
-
 Traffic from pods to services running in your cluster can be allowed via
 ``toServices`` statements in Egress rules. Currently Kubernetes
-`Services without a Selector
-<https://kubernetes.io/docs/concepts/services-networking/service/#services-without-selectors>`_
+`Services <https://kubernetes.io/docs/concepts/services-networking/service>`_
 are supported when defined by their name and namespace or label selector.
 For services backed by pods, use `Endpoints Based` rules on the backend pod
 labels.
@@ -288,8 +282,8 @@ namespace ``default``.
         .. literalinclude:: ../../../examples/policies/l3/service/service.json
 
 This example shows how to allow all endpoints with the label ``id=app2``
-to talk to all endpoints of all kubernetes services without selectors which
-have ``external:yes`` set as the label.
+to talk to all endpoints of all kubernetes services which
+have ``serviceName:myservice`` set as the label.
 
 .. only:: html
 
@@ -304,12 +298,6 @@ have ``external:yes`` set as the label.
 .. only:: epub or latex
 
         .. literalinclude:: ../../../examples/policies/l3/service/service-labels.json
-
-Limitations
-~~~~~~~~~~~
-
-``toServices`` statements must not be combined with ``toPorts`` statements in the
-same rule. If a rule combines both these statements, the policy is rejected.
 
 .. _Entities based:
 

--- a/examples/policies/l3/service/service-labels.json
+++ b/examples/policies/l3/service/service-labels.json
@@ -12,7 +12,7 @@
                     "k8sServiceSelector": {
                         "selector": {
                             "matchLabels": {
-                                "external": "yes"
+                                "serviceName": "myservice"
                             }
                         }
                     }

--- a/examples/policies/l3/service/service-labels.yaml
+++ b/examples/policies/l3/service/service-labels.yaml
@@ -11,4 +11,4 @@ spec:
     - k8sServiceSelector:
         selector:
           matchLabels:
-            external: "yes"
+            serviceName: myservice


### PR DESCRIPTION
Part of  https://github.com/cilium/cilium/pull/34208

Env
``` shell
# kubectl get pods -o wide           
NAME                              READY   STATUS    RESTARTS   AGE   IP             NODE                 NOMINATED NODE   READINESS GATES
details-v1-6448f9bdc8-p7b7l       1/1     Running   0          18d   10.244.2.208   kind-worker2         <none>           <none>
nginx-77b4fdf86c-968pb            1/1     Running   0          10d   10.244.2.219   kind-worker2         <none>           <none>
nginx-77b4fdf86c-bfj9w            1/1     Running   0          10d   10.244.0.32    kind-control-plane   <none>           <none>
nginx-77b4fdf86c-wg8dx            1/1     Running   0          10d   10.244.1.69    kind-worker          <none>           <none>
productpage-v1-65b8499c86-jbq8b   1/1     Running   0          18d   10.244.1.13    kind-worker          <none>           <none>
ratings-v1-56687d6766-c2pv5       1/1     Running   0          18d   10.244.2.173   kind-worker2         <none>           <none>
reviews-v1-5c785db578-c4p6v       1/1     Running   0          18d   10.244.2.13    kind-worker2         <none>           <none>
reviews-v2-6d8c88978b-6cc9k       1/1     Running   0          18d   10.244.2.212   kind-worker2         <none>           <none>
reviews-v3-678b968858-2kkwb       1/1     Running   0          18d   10.244.1.95    kind-worker          <none>           <none>

```

Access
``` shell
# kubectl exec -it nginx-77b4fdf86c-968pb -- curl 10.244.2.208:9080/details/1
{"id":1,"author":"William Shakespeare","year":1595,"type":"paperback","pages":200,"publisher":"PublisherA","language":"English","ISBN-10":"1234567890","ISBN-13":"123-1234567890"}

#
# kubectl exec -it nginx-77b4fdf86c-968pb -- curl 10.244.1.13:9080                      
<!DOCTYPE html>
<html>
  <head>
    <title>Simple Bookstore App</title>
<meta charset="utf-8">
<meta http-equiv="X-UA-Compatible" content="IE=edge">
<meta name="viewport" content="width=device-width, initial-scale=1">

<!-- Latest compiled and minified CSS -->
<link rel="stylesheet" href="static/bootstrap/css/bootstrap.min.css">

<!-- Optional theme -->
<link rel="stylesheet" href="static/bootstrap/css/bootstrap-theme.min.css">

  </head>
  <body>
    
    
<p>
    <h3>Hello! This is a simple bookstore application consisting of three services as shown below</h3>
</p>
......
....
```



Test
``` shell
# cat to_services.yaml             
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  name: "l4-rule"
spec:
  endpointSelector:
    matchLabels:
      app: nginx
  egress:
    - toServices:
      - k8sServiceSelector:
          selector:
            matchLabels:
              app: "details"
      toPorts:
      - ports:
        - port: "9080"
          protocol: TCP
#  k apply -f to_services.yaml 
ciliumnetworkpolicy.cilium.io/l4-rule created

```
Access
```shell 
# kubectl exec -it nginx-77b4fdf86c-968pb -- curl 10.244.2.208:9080/details/1
{"id":1,"author":"William Shakespeare","year":1595,"type":"paperback","pages":200,"publisher":"PublisherA","language":"English","ISBN-10":"1234567890","ISBN-13":"123-1234567890"}#                                                                                                                         

# kubectl exec -it nginx-77b4fdf86c-968pb -- curl 10.244.1.13:9080           
curl: (28) Failed to connect to 10.244.1.13 port 9080 after 129288 ms: Couldn't connect to server
command terminated with exit code 28

```
hubble
```

hubble observe -f --to-port 9080
Oct 29 06:46:44.262: default/nginx-77b4fdf86c-968pb:59604 (ID:7824) <> default/productpage-v1-65b8499c86-jbq8b:9080 (ID:9909) from-endpoint FORWARDED (TCP Flags: SYN)
Oct 29 06:46:44.262: default/nginx-77b4fdf86c-968pb:59604 (ID:7824) <> default/productpage-v1-65b8499c86-jbq8b:9080 (ID:9909) policy-verdict:none EGRESS DENIED (TCP Flags: SYN)
Oct 29 06:46:44.262: default/nginx-77b4fdf86c-968pb:59604 (ID:7824) <> default/productpage-v1-65b8499c86-jbq8b:9080 (ID:9909) Policy denied DROPPED (TCP Flags: SYN)
Oct 29 06:46:45.273: default/nginx-77b4fdf86c-968pb:59604 (ID:7824) <> default/productpage-v1-65b8499c86-jbq8b:9080 (ID:9909) from-endpoint FORWARDED (TCP Flags: SYN)
Oct 29 06:46:45.273: default/nginx-77b4fdf86c-968pb:59604 (ID:7824) <> default/productpage-v1-65b8499c86-jbq8b:9080 (ID:9909) policy-verdict:none EGRESS DENIED (TCP Flags: SYN)

```