### PR TITLE
ipcache: fix expensive conflict logging for frequently used prefixes

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -225,7 +225,9 @@ func (m *metadata) upsertLocked(prefix netip.Prefix, src source.Source, resource
 		changed = changed || c
 	}
 
-	m.m[prefix].logConflicts(log.WithField(logfields.CIDR, prefix))
+	if m.m[prefix][resource].shouldLogConflicts() {
+		m.m[prefix].logConflicts(log.WithField(logfields.CIDR, prefix))
+	}
 
 	if !changed {
 		return nil

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -5,6 +5,7 @@ package ipcache
 
 import (
 	"context"
+	"fmt"
 	"net/netip"
 	"strconv"
 	"sync"

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -1258,3 +1258,15 @@ func Test_metadata_mergeParentLabels(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkManyResources(b *testing.B) {
+	m := newMetadata()
+
+	prefix := netip.MustParsePrefix("1.1.1.1/32")
+	lbls := labels.GetCIDRLabels(prefix)
+
+	for i := range b.N {
+		resource := types.NewResourceID(types.ResourceKindCNP, fmt.Sprintf("namespace_%d", i), "my-policy")
+		m.upsertLocked(prefix, source.Generated, resource, lbls)
+	}
+}

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -249,6 +249,10 @@ func (s prefixInfo) identityOverride() (lbls labels.Labels, hasOverride bool) {
 	return identities[0], true
 }
 
+func (ri resourceInfo) shouldLogConflicts() bool {
+	return bool(ri.identityOverride) || ri.tunnelPeer.IsValid() || ri.encryptKey.IsValid() || ri.requestedIdentity.IsValid()
+}
+
 func (s prefixInfo) logConflicts(scopedLog *logrus.Entry) {
 	var (
 		override           labels.Labels


### PR DESCRIPTION
Searching for conflicts when a given prefixes has a lot of resources is very expensive. Specifically, all resources must be sorted before checking for conflicts.
    
Given that most resources do not set metadata that can conflict, this is not necessary. So, skip searching for conflicts if the supplied resource cannot cause a conflict.


```release-note
Fixes slow policy import times when many network policies reference the same CIDR.
```
