### PR TITLE
Update Network Policy Secret management to use SDS

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -167,6 +167,7 @@ cilium-agent [flags]
       --enable-node-selector-labels                               Enable use of node label based identity
       --enable-pmtu-discovery                                     Enable path MTU discovery to send ICMP fragmentation-needed replies to the client
       --enable-policy string                                      Enable policy enforcement (default "default")
+      --enable-policy-secrets-sync                                Enables Envoy secret sync for Secrets used in CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy
       --enable-recorder                                           Enable BPF datapath pcap recorder
       --enable-route-mtu-for-cni-chaining                         Enable route MTU for pod netns when CNI chaining is used
       --enable-sctp                                               Enable SCTP support (beta)
@@ -332,6 +333,7 @@ cilium-agent [flags]
       --policy-audit-mode                                         Enable policy audit (non-drop) mode
       --policy-cidr-match-mode strings                            The entities that can be selected by CIDR policy. Supported values: 'nodes'
       --policy-queue-size int                                     Size of queues for policy-related events (default 100)
+      --policy-secrets-namespace string                           PolicySecretsNamesapce is the namespace having secrets used in CNP and CCNP
       --pprof                                                     Enable serving pprof debugging API
       --pprof-address string                                      Address that pprof listens on (default "localhost")
       --pprof-port uint16                                         Port that pprof listens on (default 6060)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -52,6 +52,7 @@ cilium-agent hive [flags]
       --enable-k8s-endpoint-slice                                 Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
       --enable-l2-pod-announcements                               Enable announcing Pod IPs with Gratuitous ARP
       --enable-monitor                                            Enable the monitor unix domain socket server (default true)
+      --enable-policy-secrets-sync                                Enables Envoy secret sync for Secrets used in CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy
       --enable-route-mtu-for-cni-chaining                         Enable route MTU for pod netns when CNI chaining is used
       --enable-service-topology                                   Enable support for service topology aware hints
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
@@ -136,6 +137,7 @@ cilium-agent hive [flags]
       --nat-map-stats-entries int                                 Number k top stats entries to store locally in statedb (default 32)
       --nat-map-stats-interval duration                           Interval upon which nat maps are iterated for stats (default 30s)
       --nodeport-addresses strings                                A whitelist of CIDRs to limit which IPs are used for NodePort. If not set, primary IPv4 and/or IPv6 address of each native device is used.
+      --policy-secrets-namespace string                           PolicySecretsNamesapce is the namespace having secrets used in CNP and CCNP
       --pprof                                                     Enable serving pprof debugging API
       --pprof-address string                                      Address that pprof listens on (default "localhost")
       --pprof-port uint16                                         Port that pprof listens on (default 6060)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -58,6 +58,7 @@ cilium-agent hive dot-graph [flags]
       --enable-k8s-endpoint-slice                                 Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
       --enable-l2-pod-announcements                               Enable announcing Pod IPs with Gratuitous ARP
       --enable-monitor                                            Enable the monitor unix domain socket server (default true)
+      --enable-policy-secrets-sync                                Enables Envoy secret sync for Secrets used in CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy
       --enable-route-mtu-for-cni-chaining                         Enable route MTU for pod netns when CNI chaining is used
       --enable-service-topology                                   Enable support for service topology aware hints
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
@@ -141,6 +142,7 @@ cilium-agent hive dot-graph [flags]
       --nat-map-stats-entries int                                 Number k top stats entries to store locally in statedb (default 32)
       --nat-map-stats-interval duration                           Interval upon which nat maps are iterated for stats (default 30s)
       --nodeport-addresses strings                                A whitelist of CIDRs to limit which IPs are used for NodePort. If not set, primary IPv4 and/or IPv6 address of each native device is used.
+      --policy-secrets-namespace string                           PolicySecretsNamesapce is the namespace having secrets used in CNP and CCNP
       --pprof                                                     Enable serving pprof debugging API
       --pprof-address string                                      Address that pprof listens on (default "localhost")
       --pprof-port uint16                                         Port that pprof listens on (default 6060)

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -60,6 +60,7 @@ cilium-operator-alibabacloud [flags]
       --enable-node-ipam                                     Enable Node IPAM
       --enable-node-port                                     Enable NodePort type services by Cilium
       --enable-node-selector-labels                          Enable use of node label based identity
+      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by tls-interception-secrets-namespace flag)
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
@@ -122,6 +123,7 @@ cilium-operator-alibabacloud [flags]
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -40,6 +40,7 @@ cilium-operator-alibabacloud hive [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-node-port                                     Enable NodePort type services by Cilium
+      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by tls-interception-secrets-namespace flag)
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
@@ -86,6 +87,7 @@ cilium-operator-alibabacloud hive [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -46,6 +46,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-node-port                                     Enable NodePort type services by Cilium
+      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by tls-interception-secrets-namespace flag)
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
@@ -91,6 +92,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -64,6 +64,7 @@ cilium-operator-aws [flags]
       --enable-node-ipam                                     Enable Node IPAM
       --enable-node-port                                     Enable NodePort type services by Cilium
       --enable-node-selector-labels                          Enable use of node label based identity
+      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by tls-interception-secrets-namespace flag)
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --eni-gc-interval duration                             Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
       --eni-gc-tags map                                      Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected
@@ -130,6 +131,7 @@ cilium-operator-aws [flags]
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -40,6 +40,7 @@ cilium-operator-aws hive [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-node-port                                     Enable NodePort type services by Cilium
+      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by tls-interception-secrets-namespace flag)
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
@@ -86,6 +87,7 @@ cilium-operator-aws hive [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -46,6 +46,7 @@ cilium-operator-aws hive dot-graph [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-node-port                                     Enable NodePort type services by Cilium
+      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by tls-interception-secrets-namespace flag)
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
@@ -91,6 +92,7 @@ cilium-operator-aws hive dot-graph [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -63,6 +63,7 @@ cilium-operator-azure [flags]
       --enable-node-ipam                                     Enable Node IPAM
       --enable-node-port                                     Enable NodePort type services by Cilium
       --enable-node-selector-labels                          Enable use of node label based identity
+      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by tls-interception-secrets-namespace flag)
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
@@ -125,6 +126,7 @@ cilium-operator-azure [flags]
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -40,6 +40,7 @@ cilium-operator-azure hive [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-node-port                                     Enable NodePort type services by Cilium
+      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by tls-interception-secrets-namespace flag)
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
@@ -86,6 +87,7 @@ cilium-operator-azure hive [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -46,6 +46,7 @@ cilium-operator-azure hive dot-graph [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-node-port                                     Enable NodePort type services by Cilium
+      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by tls-interception-secrets-namespace flag)
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
@@ -91,6 +92,7 @@ cilium-operator-azure hive dot-graph [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -59,6 +59,7 @@ cilium-operator-generic [flags]
       --enable-node-ipam                                     Enable Node IPAM
       --enable-node-port                                     Enable NodePort type services by Cilium
       --enable-node-selector-labels                          Enable use of node label based identity
+      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by tls-interception-secrets-namespace flag)
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
@@ -121,6 +122,7 @@ cilium-operator-generic [flags]
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -40,6 +40,7 @@ cilium-operator-generic hive [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-node-port                                     Enable NodePort type services by Cilium
+      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by tls-interception-secrets-namespace flag)
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
@@ -86,6 +87,7 @@ cilium-operator-generic hive [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -46,6 +46,7 @@ cilium-operator-generic hive dot-graph [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-node-port                                     Enable NodePort type services by Cilium
+      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by tls-interception-secrets-namespace flag)
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
@@ -91,6 +92,7 @@ cilium-operator-generic hive dot-graph [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -69,6 +69,7 @@ cilium-operator [flags]
       --enable-node-ipam                                     Enable Node IPAM
       --enable-node-port                                     Enable NodePort type services by Cilium
       --enable-node-selector-labels                          Enable use of node label based identity
+      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by tls-interception-secrets-namespace flag)
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --eni-gc-interval duration                             Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
       --eni-gc-tags map                                      Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected
@@ -135,6 +136,7 @@ cilium-operator [flags]
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
       --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -40,6 +40,7 @@ cilium-operator hive [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-node-port                                     Enable NodePort type services by Cilium
+      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by tls-interception-secrets-namespace flag)
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
@@ -86,6 +87,7 @@ cilium-operator hive [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -46,6 +46,7 @@ cilium-operator hive dot-graph [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-node-port                                     Enable NodePort type services by Cilium
+      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by tls-interception-secrets-namespace flag)
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
@@ -91,6 +92,7 @@ cilium-operator hive dot-graph [flags]
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
+      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3231,7 +3231,7 @@
    * - :spelling:ignore:`tls`
      - Configure TLS configuration in the agent.
      - object
-     - ``{"ca":{"cert":"","certValidityDuration":1095,"key":""},"caBundle":{"enabled":false,"key":"ca.crt","name":"cilium-root-ca.crt","useSecret":false},"secretsBackend":"local"}``
+     - ``{"ca":{"cert":"","certValidityDuration":1095,"key":""},"caBundle":{"enabled":false,"key":"ca.crt","name":"cilium-root-ca.crt","useSecret":false},"secretSync":{"enabled":true,"secretsNamespace":{"create":true,"enabled":true,"name":"cilium-secrets"}},"secretsBackend":"local"}``
    * - :spelling:ignore:`tls.ca`
      - Base64 encoded PEM values for the CA certificate and private key. This can be used as common CA to generate certificates used by hubble and clustermesh components. It is neither required nor used when cert-manager is used to generate the certificates.
      - object
@@ -3268,6 +3268,30 @@
      - Use a Secret instead of a ConfigMap.
      - bool
      - ``false``
+   * - :spelling:ignore:`tls.secretSync`
+     - Configures settings for synchronization of TLS Interception Secrets
+     - object
+     - ``{"enabled":true,"secretsNamespace":{"create":true,"enabled":true,"name":"cilium-secrets"}}``
+   * - :spelling:ignore:`tls.secretSync.enabled`
+     - Enable synchronization of Secrets for TLS Interception. If disabled and tls.secretsBackend is set to 'k8s', then secrets will be read directly by the agent.
+     - bool
+     - ``true``
+   * - :spelling:ignore:`tls.secretSync.secretsNamespace`
+     - This configures secret synchronization for secrets used in CiliumNetworkPolicies
+     - object
+     - ``{"create":true,"enabled":true,"name":"cilium-secrets"}``
+   * - :spelling:ignore:`tls.secretSync.secretsNamespace.create`
+     - Create secrets namespace for TLS Interception secrets.
+     - bool
+     - ``true``
+   * - :spelling:ignore:`tls.secretSync.secretsNamespace.enabled`
+     - Enable secret sync, which will make sure all TLS secrets used by TLS Interception are synced to secretsNamespace.name. If disabled, TLS secrets must be maintained externally.
+     - bool
+     - ``true``
+   * - :spelling:ignore:`tls.secretSync.secretsNamespace.name`
+     - Name of TLS Interception secret namespace.
+     - string
+     - ``"cilium-secrets"``
    * - :spelling:ignore:`tls.secretsBackend`
      - This configures how the Cilium agent loads the secrets used TLS-aware CiliumNetworkPolicies (namely the secrets referenced by terminatingTLS and originatingTLS). Possible values:   - local   - k8s
      - string

--- a/Documentation/security/tls-visibility.rst
+++ b/Documentation/security/tls-visibility.rst
@@ -24,24 +24,20 @@ for example, understanding which S3 buckets are being accessed by an given appli
 .. include:: gsg_requirements.rst
 
 
-Edit the ClusterRole for Cilium to give it access to Kubernetes secrets
+To ensure that the Cilium agent has the correct permissions to perform TLS Interception, please set the following values
+in your Helm chart settings:
+
+.. code-block:: YAML
+
+    tls:
+      secretsBackend: k8s
+      secretSync:
+        enabled: true
 
 
-.. code-block:: shell-session
-
-    $ kubectl edit clusterrole cilium -n kube-system
-
-Add the following section at the end of the file:
-
-
-.. code-block:: yaml
-
-  - apiGroups:
-    - ""
-    resources:
-    - secrets
-    verbs:
-    - get
+This will set up Cilium so that the Cilium Operator will synchronize any secrets referenced in CiliumNetworkPolicy (or
+CiliumClusterwideNetworkPolicy) to a ``cilium-secrets`` namespace, and grant the Cilium agent read access to Secrets for
+that namespace only.
 
 
 Deploy the Demo Application
@@ -101,7 +97,7 @@ requires four primary steps:
 
 1) Create an internal certificate authority by generating a CA private key and CA certificate.
 
-2) For any destination where TLS inspection is desired (e.g., artii.herokuapp.com in the example below),
+2) For any destination where TLS inspection is desired (e.g., httpbin.org in the example below),
    generate a private key and certificate signing request with a common name that matches the destination DNS
    name.
 
@@ -165,23 +161,23 @@ Create Private Key and Certificate Signing Request for a Given DNS Name
 -----------------------------------------------------------------------
 
 Generate an internal private key and certificate signing with a common name that matches the DNS name
-of the destination service to be intercepted for inspection (in this example, use ``artii.herokuapp.com``).
+of the destination service to be intercepted for inspection (in this example, use ``httpbin.org``).
 
 First create the private key:
 
 .. code-block:: shell-session
 
-    $ openssl genrsa -out internal-artii.key 2048
+    $ openssl genrsa -out internal-httpbin.key 2048
 
 Next, create a certificate signing request, specifying the DNS name of the destination service
 for the common name field when prompted.  All other prompts can be filled with any value.
 
 .. code-block:: shell-session
 
-    $ openssl req -new -key internal-artii.key -out internal-artii.csr
+    $ openssl req -new -key internal-httpbin.key -out internal-httpbin.csr
 
 The only field that must be a specific value is ensuring that ``Common Name`` is the exact DNS
-destination ``artii.herokuapp.com`` that will be provided to the client.
+destination ``httpbin.org`` that will be provided to the client.
 
 
 This example workflow will work for any DNS
@@ -191,17 +187,17 @@ name as long as the toFQDNs rule in the policy YAML (below) is also updated to m
 Use CA to Generate a Signed Certificate for the DNS Name
 --------------------------------------------------------
 
-Use the internal CA private key to create a signed certificate for artii.herokuapp.com named ``internal-artii.crt``.
+Use the internal CA private key to create a signed certificate for httpbin.org named ``internal-httpbin.crt``.
 
 .. code-block:: shell-session
 
-    $ openssl x509 -req -days 360 -in internal-artii.csr -CA myCA.crt -CAkey myCA.key -CAcreateserial -out internal-artii.crt -sha256
+    $ openssl x509 -req -days 360 -in internal-httpbin.csr -CA myCA.crt -CAkey myCA.key -CAcreateserial -out internal-httpbin.crt -sha256
 
 Next we create a Kubernetes secret that includes both the private key and signed certificates for the destination service:
 
 .. code-block:: shell-session
 
-    $ kubectl create secret tls artii-tls-data -n kube-system --cert=internal-artii.crt --key=internal-artii.key
+    $ kubectl create secret tls httpbin-tls-data -n kube-system --cert=internal-httpbin.crt --key=internal-httpbin.key
 
 Add the Internal CA as a Trusted CA Inside the Client Pod
 ---------------------------------------------------------
@@ -260,18 +256,18 @@ have not told Cilium which traffic we want to intercept and inspect.   This is d
 the same Cilium Network Policy constructs that are used for other Cilium Network Policies.
 
 The following Cilium network policy indicates that Cilium should perform HTTP-aware inspect
-of communication between the ``mediabot`` pod to ``artii.herokuapp.com``.
+of communication between the ``mediabot`` pod to ``httpbin.org``.
 
 .. literalinclude:: ../../examples/kubernetes-tls-inspection/l7-visibility-tls.yaml
 
 Let's take a closer look at the policy:
 
 * The ``endpointSelector`` means that this policy will only apply to pods with labels ``class: mediabot, org:empire`` to have the egress access.
-* The first egress section uses ``toFQDNs: matchName`` specification to allow TCP port 443 egress to ``artii.herokuapp.com``.
+* The first egress section uses ``toFQDNs: matchName`` specification to allow TCP port 443 egress to ``httpbin.org``.
 * The ``http`` section below the toFQDNs rule
   indicates that such connections should be parsed as HTTP, with a policy of ``{}`` which will allow all requests.
 * The ``terminatingTLS`` and ``originatingTLS`` sections indicate that TLS interception should be used to terminate the initial TLS connection
-  from mediabot and initiate a new out-bound TLS connection to ``artii.herokuapp.com``.
+  from mediabot and initiate a new out-bound TLS connection to ``httpbin.org``.
 * The second egress section allows ``mediabot`` pods to access ``kube-dns`` service. Note that
   ``rules: dns`` instructs Cilium to inspect and allow DNS lookups matching specified patterns.
   In this case, inspect and allow all DNS queries.
@@ -290,7 +286,7 @@ Let's apply the policy:
 Demonstrating TLS Inspection
 ============================
 
-Recall that the policy we pushed will allow all HTTPS requests from ``mediabot`` to ``artii.herokuapp.com``, but will parse all data at
+Recall that the policy we pushed will allow all HTTPS requests from ``mediabot`` to ``httpbin.org``, but will parse all data at
 the HTTP-layer, meaning that cilium monitor will report each HTTP request and response.
 
 To see this, open a new window and run the following command to identity the name of the
@@ -302,22 +298,22 @@ Then start running cilium-dbg monitor in "L7 mode" to monitor for HTTP requests 
 
     $ kubectl exec -it -n kube-system cilium-d5x8v -- cilium-dbg monitor -t l7
 
-Next in the original window, from the ``mediabot`` pod we can access ``artii.herokuapp.com`` via HTTPS:
+Next in the original window, from the ``mediabot`` pod we can access ``httpbin.org`` via HTTPS:
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it mediabot -- curl -sL 'https://artii.herokuapp.com/fonts_list'
+    $ kubectl exec -it mediabot -- curl -sL 'https://httpbin.org/anything'
     ...
     ...
 
-    $ kubectl exec -it mediabot -- curl -sL 'https://artii.herokuapp.com/make?text=cilium&font=univers'
+    $ kubectl exec -it mediabot -- curl -sL 'https://httpbin.org/headers'
     ...
     ...
 
 Looking back at the cilium-dbg monitor window, you will see each individual HTTP request and response.  For example::
 
-    -> Request http from 2585 ([k8s:class=mediabot k8s:org=empire k8s:io.kubernetes.pod.namespace=default k8s:io.cilium.k8s.policy.serviceaccount=default k8s:io.cilium.k8s.policy.cluster=default]) to 0 ([reserved:world]), identity 24948->2, verdict Forwarded GET https://artii.herokuapp.com/fonts_list => 0
-    -> Response http to 2585 ([k8s:io.kubernetes.pod.namespace=default k8s:io.cilium.k8s.policy.serviceaccount=default k8s:io.cilium.k8s.policy.cluster=default k8s:class=mediabot k8s:org=empire]) from 0 ([reserved:world]), identity 24948->2, verdict Forwarded GET https://artii.herokuapp.com/fonts_list => 200
+    -> Request http from 2585 ([k8s:class=mediabot k8s:org=empire k8s:io.kubernetes.pod.namespace=default k8s:io.cilium.k8s.policy.serviceaccount=default k8s:io.cilium.k8s.policy.cluster=default]) to 0 ([reserved:world]), identity 24948->2, verdict Forwarded GET https://httpbin.org/anything => 0
+    -> Response http to 2585 ([k8s:io.kubernetes.pod.namespace=default k8s:io.cilium.k8s.policy.serviceaccount=default k8s:io.cilium.k8s.policy.cluster=default k8s:class=mediabot k8s:org=empire]) from 0 ([reserved:world]), identity 24948->2, verdict Forwarded GET https://httpbin.org/anything => 200
 
 Refer to :ref:`l4_policy` and :ref:`l7_policy` to learn more about Cilium L4 and L7 network policies.
 
@@ -329,4 +325,4 @@ Clean-up
    $ kubectl delete -f \ |SCM_WEB|\/examples/kubernetes-dns/dns-sw-app.yaml
    $ kubectl delete cnp l7-visibility-tls
    $ kubectl delete secret -n kube-system tls-orig-data
-   $ kubectl delete secret -n kube-system artii-tls-data
+   $ kubectl delete secret -n kube-system httpbin-tls-data

--- a/Documentation/security/tls-visibility.rst
+++ b/Documentation/security/tls-visibility.rst
@@ -35,7 +35,7 @@ in your Helm chart settings:
         enabled: true
 
 
-This will set up Cilium so that the Cilium Operator will synchronize any secrets referenced in CiliumNetworkPolicy (or
+This configures Cilium so that the Cilium Operator will synchronize any secrets referenced in CiliumNetworkPolicy (or
 CiliumClusterwideNetworkPolicy) to a ``cilium-secrets`` namespace, and grant the Cilium agent read access to Secrets for
 that namespace only.
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -689,6 +689,7 @@ scalable
 sctl
 seccomp
 secretName
+secretsBackend
 secretsNamespace
 selftest
 selftests

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -384,6 +384,7 @@ hostonlyifs
 hostscope
 hq
 http
+httpbin
 httpd
 https
 hubble

--- a/cilium-cli/connectivity/builder/client_egress_l7_set_header.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_set_header.go
@@ -31,7 +31,7 @@ func clientEgressL7SetHeaderTest(ct *check.ConnectivityTest, templates map[strin
 	// Test L7 HTTP with a header replace set in the policy
 	newTest(testName, ct).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
-		WithFeatureRequirements(features.RequireEnabled(features.SecretBackendK8s)).
+		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretBackendK8s)).
 		WithSecret(&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "header-match",

--- a/cilium-cli/connectivity/builder/client_egress_l7_tls_deny_without_headers.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_tls_deny_without_headers.go
@@ -16,7 +16,7 @@ func (t clientEgressL7TlsDenyWithoutHeaders) build(ct *check.ConnectivityTest, t
 	// Fail to load site due to missing headers.
 	newTest("client-egress-l7-tls-deny-without-headers", ct).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
-		WithFeatureRequirements(features.RequireEnabled(features.SecretBackendK8s)).
+		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretBackendK8s)).
 		WithCABundleSecret().
 		WithCertificate("externaltarget-tls", ct.Params().ExternalTarget).
 		WithCiliumPolicy(templates["clientEgressL7TLSPolicyYAML"]). // L7 allow policy with TLS interception

--- a/cilium-cli/connectivity/builder/client_egress_l7_tls_headers.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_tls_headers.go
@@ -28,7 +28,7 @@ func clientEgressL7TlsHeadersTest(ct *check.ConnectivityTest, templates map[stri
 	// Test L7 HTTPS interception using an egress policy on the clients.
 	newTest(testName, ct).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
-		WithFeatureRequirements(features.RequireEnabled(features.SecretBackendK8s)).
+		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretBackendK8s)).
 		WithCABundleSecret().
 		WithCertificate("externaltarget-tls", ct.Params().ExternalTarget).
 		WithCiliumPolicy(yamlFile). // L7 allow policy with TLS interception

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -87,8 +87,11 @@ func (ct *ConnectivityTest) extractFeaturesFromClusterRole(ctx context.Context, 
 		return err
 	}
 
-	result[features.SecretBackendK8s] = features.Status{
-		Enabled: canAccessK8sResourceSecret(cr),
+	// This could be enabled via configmap check, so only check if it's not enabled already.
+	if !result[features.PolicySecretBackendK8s].Enabled {
+		result[features.PolicySecretBackendK8s] = features.Status{
+			Enabled: canAccessK8sResourceSecret(cr),
+		}
 	}
 	return nil
 }
@@ -197,8 +200,10 @@ func (ct *ConnectivityTest) extractFeaturesFromK8sCluster(ctx context.Context, r
 	}
 }
 
-const ciliumNetworkPolicyCRDName = "ciliumnetworkpolicies.cilium.io"
-const ciliumClusterwideNetworkPolicyCRDName = "ciliumclusterwidenetworkpolicies.cilium.io"
+const (
+	ciliumNetworkPolicyCRDName            = "ciliumnetworkpolicies.cilium.io"
+	ciliumClusterwideNetworkPolicyCRDName = "ciliumclusterwidenetworkpolicies.cilium.io"
+)
 
 func (ct *ConnectivityTest) extractFeaturesFromCRDs(ctx context.Context, result features.Set) error {
 	check := func(name string) (features.Status, error) {

--- a/examples/kubernetes-tls-inspection/l7-visibility-tls.yaml
+++ b/examples/kubernetes-tls-inspection/l7-visibility-tls.yaml
@@ -10,7 +10,7 @@ spec:
       class: mediabot
   egress:
   - toFQDNs:
-    - matchName: "artii.herokuapp.com"
+    - matchName: "httpbin.org"
     toPorts:
     - ports:
       - port: "443"
@@ -18,7 +18,7 @@ spec:
       terminatingTLS:
         secret:
           namespace: "kube-system"
-          name: "artii-tls-data"
+          name: "httpbin-tls-data"
       originatingTLS:
         secret:
           namespace: "kube-system"

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -857,7 +857,7 @@ contributors across the globe, there is almost always someone available to help.
 | sysctlfix | object | `{"enabled":true}` | Configure sysctl override described in #20072. |
 | sysctlfix.enabled | bool | `true` | Enable the sysctl override. When enabled, the init container will mount the /proc of the host so that the `sysctlfix` utility can execute. |
 | terminationGracePeriodSeconds | int | `1` | Configure termination grace period for cilium-agent DaemonSet. |
-| tls | object | `{"ca":{"cert":"","certValidityDuration":1095,"key":""},"caBundle":{"enabled":false,"key":"ca.crt","name":"cilium-root-ca.crt","useSecret":false},"secretsBackend":"local"}` | Configure TLS configuration in the agent. |
+| tls | object | `{"ca":{"cert":"","certValidityDuration":1095,"key":""},"caBundle":{"enabled":false,"key":"ca.crt","name":"cilium-root-ca.crt","useSecret":false},"secretSync":{"enabled":true,"secretsNamespace":{"create":true,"enabled":true,"name":"cilium-secrets"}},"secretsBackend":"local"}` | Configure TLS configuration in the agent. |
 | tls.ca | object | `{"cert":"","certValidityDuration":1095,"key":""}` | Base64 encoded PEM values for the CA certificate and private key. This can be used as common CA to generate certificates used by hubble and clustermesh components. It is neither required nor used when cert-manager is used to generate the certificates. |
 | tls.ca.cert | string | `""` | Optional CA cert. If it is provided, it will be used by cilium to generate all other certificates. Otherwise, an ephemeral CA is generated. |
 | tls.ca.certValidityDuration | int | `1095` | Generated certificates validity duration in days. This will be used for auto generated CA. |
@@ -867,6 +867,12 @@ contributors across the globe, there is almost always someone available to help.
 | tls.caBundle.key | string | `"ca.crt"` | Entry of the ConfigMap containing the CA trust bundle. |
 | tls.caBundle.name | string | `"cilium-root-ca.crt"` | Name of the ConfigMap containing the CA trust bundle. |
 | tls.caBundle.useSecret | bool | `false` | Use a Secret instead of a ConfigMap. |
+| tls.secretSync | object | `{"enabled":true,"secretsNamespace":{"create":true,"enabled":true,"name":"cilium-secrets"}}` | Configures settings for synchronization of TLS Interception Secrets |
+| tls.secretSync.enabled | bool | `true` | Enable synchronization of Secrets for TLS Interception. If disabled and tls.secretsBackend is set to 'k8s', then secrets will be read directly by the agent. |
+| tls.secretSync.secretsNamespace | object | `{"create":true,"enabled":true,"name":"cilium-secrets"}` | This configures secret synchronization for secrets used in CiliumNetworkPolicies |
+| tls.secretSync.secretsNamespace.create | bool | `true` | Create secrets namespace for TLS Interception secrets. |
+| tls.secretSync.secretsNamespace.enabled | bool | `true` | Enable secret sync, which will make sure all TLS secrets used by TLS Interception are synced to secretsNamespace.name. If disabled, TLS secrets must be maintained externally. |
+| tls.secretSync.secretsNamespace.name | string | `"cilium-secrets"` | Name of TLS Interception secret namespace. |
 | tls.secretsBackend | string | `"local"` | This configures how the Cilium agent loads the secrets used TLS-aware CiliumNetworkPolicies (namely the secrets referenced by terminatingTLS and originatingTLS). Possible values:   - local   - k8s |
 | tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for agent scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | tunnelPort | int | Port 8472 for VXLAN, Port 6081 for Geneve | Configure VXLAN and Geneve tunnel port. |

--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -82,7 +82,7 @@ rules:
   # until we figure out how to avoid "get" inside the preflight, and then
   # should be removed ideally.
   - get
-{{- if eq "k8s" .Values.tls.secretsBackend }}
+{{- if and (eq "k8s" .Values.tls.secretsBackend) (not .Values.tls.secretSync.enabled) }}
 - apiGroups:
   - ""
   resources:

--- a/install/kubernetes/cilium/templates/cilium-agent/role.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/role.yaml
@@ -114,3 +114,27 @@ rules:
   - list
   - watch
 {{- end}}
+
+{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create .Values.tls.secretSync.enabled .Values.tls.secretSync.secretsNamespace.name ( eq "k8s" .Values.tls.secretsBackend )}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-tlsinterception-secrets
+  namespace: {{ .Values.tls.secretSync.secretsNamespace.name | quote }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}  
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
@@ -108,3 +108,22 @@ subjects:
   name: {{ .Values.serviceAccounts.cilium.name | quote }}
   namespace: {{ include "cilium.namespace" . }}
 {{- end}}
+
+{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create .Values.tls.secretSync.enabled .Values.tls.secretSync.secretsNamespace.name ( eq "k8s" .Values.tls.secretsBackend )}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-tlsinterception-secrets
+  namespace: {{ .Values.tls.secretSync.secretsNamespace.name | quote }}
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-tlsinterception-secrets
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccounts.cilium.name | quote }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -283,6 +283,11 @@ data:
   gateway-api-hostnetwork-nodelabelselector: {{ include "mapToString" .Values.gatewayAPI.hostNetwork.nodes.matchLabels | quote }}
 {{- end }}
 
+{{- if and (eq "k8s" .Values.tls.secretsBackend) .Values.tls.secretSync.enabled }}
+  enable-policy-secrets-sync: "true"
+  policy-secrets-namespace: {{ .Values.tls.secretSync.secretsNamespace.name | quote}}
+{{- end }}
+
 {{- if hasKey .Values "loadBalancer" }}
 {{- if eq .Values.loadBalancer.l7.backend "envoy" }}
   loadbalancer-l7: "envoy"

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -87,7 +87,7 @@ rules:
   resources:
   # to check apiserver connectivity
   - namespaces
-{{- if or .Values.ingressController.enabled .Values.gatewayAPI.enabled .Values.bgpControlPlane.enabled }}
+{{- if or .Values.ingressController.enabled .Values.gatewayAPI.enabled .Values.bgpControlPlane.enabled .Values.tls.secretSync.enabled }}
   - secrets
 {{- end }}
   verbs:

--- a/install/kubernetes/cilium/templates/cilium-operator/role.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/role.yaml
@@ -47,3 +47,28 @@ rules:
   - update
   - patch
 {{- end }}
+
+{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create .Values.tls.secretSync.enabled .Values.tls.secretSync.secretsNamespace.name ( eq "k8s" .Values.tls.secretsBackend )}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-operator-tlsinterception-secrets
+  namespace: {{ .Values.tls.secretSync.secretsNamespace.name | quote }}
+  {{- with .Values.operator.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/part-of: cilium
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - update
+  - patch
+{{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/rolebinding.yaml
@@ -43,3 +43,26 @@ subjects:
   name: {{ .Values.serviceAccounts.operator.name | quote }}
   namespace: {{ include "cilium.namespace" . }}
 {{- end }}
+
+{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create .Values.tls.secretSync.enabled .Values.tls.secretSync.secretsNamespace.name ( eq "k8s" .Values.tls.secretsBackend )}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-operator-tlsinterception-secrets
+  namespace: {{ .Values.tls.secretSync.secretsNamespace.name | quote }}
+  {{- with .Values.operator.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/part-of: cilium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-operator-tlsinterception-secrets
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccounts.operator.name | quote }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/cilium-secrets-namespace.yaml
+++ b/install/kubernetes/cilium/templates/cilium-secrets-namespace.yaml
@@ -1,5 +1,5 @@
 {{- $secretNamespaces := dict -}}
-{{- range $cfg := tuple .Values.ingressController .Values.gatewayAPI .Values.envoyConfig .Values.bgpControlPlane -}}
+{{- range $cfg := tuple .Values.ingressController .Values.gatewayAPI .Values.envoyConfig .Values.bgpControlPlane .Values.tls.secretSync -}}
 {{- if and $cfg.enabled $cfg.secretsNamespace.create $cfg.secretsNamespace.name -}}
 {{- $_ := set $secretNamespaces $cfg.secretsNamespace.name 1 -}}
 {{- end -}}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -5317,6 +5317,28 @@
           },
           "type": "object"
         },
+        "secretSync": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "secretsNamespace": {
+              "properties": {
+                "create": {
+                  "type": "boolean"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
         "secretsBackend": {
           "type": "string"
         }

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2520,6 +2520,20 @@ tls:
   #   - local
   #   - k8s
   secretsBackend: local
+  # -- Configures settings for synchronization of TLS Interception Secrets
+  secretSync:
+    # -- Enable synchronization of Secrets for TLS Interception. If disabled and
+    # tls.secretsBackend is set to 'k8s', then secrets will be read directly by the agent.
+    enabled: true
+    # -- This configures secret synchronization for secrets used in CiliumNetworkPolicies
+    secretsNamespace:
+      # -- Create secrets namespace for TLS Interception secrets.
+      create: true
+      # -- Name of TLS Interception secret namespace.
+      name: cilium-secrets
+      # -- Enable secret sync, which will make sure all TLS secrets used by TLS Interception are synced to secretsNamespace.name.
+      # If disabled, TLS secrets must be maintained externally.
+      enabled: true
   # -- Base64 encoded PEM values for the CA certificate and private key.
   # This can be used as common CA to generate certificates used by hubble and clustermesh components.
   # It is neither required nor used when cert-manager is used to generate the certificates.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2536,6 +2536,20 @@ tls:
   #   - local
   #   - k8s
   secretsBackend: local
+  # -- Configures settings for synchronization of TLS Interception Secrets
+  secretSync:
+    # -- Enable synchronization of Secrets for TLS Interception. If disabled and
+    # tls.secretsBackend is set to 'k8s', then secrets will be read directly by the agent.
+    enabled: true
+    # -- This configures secret synchronization for secrets used in CiliumNetworkPolicies
+    secretsNamespace:
+      # -- Create secrets namespace for TLS Interception secrets.
+      create: true
+      # -- Name of TLS Interception secret namespace.
+      name: cilium-secrets
+      # -- Enable secret sync, which will make sure all TLS secrets used by TLS Interception are synced to secretsNamespace.name.
+      # If disabled, TLS secrets must be maintained externally.
+      enabled: true
   # -- Base64 encoded PEM values for the CA certificate and private key.
   # This can be used as common CA to generate certificates used by hubble and clustermesh components.
   # It is neither required nor used when cert-manager is used to generate the certificates.

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -264,6 +264,10 @@ var (
 			// Informational policy validation.
 			networkpolicy.Cell,
 
+			// Synchronizes Secrets referenced in CiliumNetworkPolicy to the configured secret
+			// namespace.
+			networkpolicy.SecretSyncCell,
+
 			// Provide the logic to map DNS names matching Kubernetes services to the
 			// corresponding ClusterIP, without depending on CoreDNS. Leveraged by etcd
 			// and clustermesh.

--- a/operator/pkg/networkpolicy/helpers/helpers.go
+++ b/operator/pkg/networkpolicy/helpers/helpers.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"log/slog"
+
+	"github.com/cilium/cilium/pkg/policy/api"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// GetReferencedTLSSecretsFromPortRules finds all TLS Secrets referenced by a set of port rules.
+func GetReferencedTLSSecretsFromPortRules(ports api.PortRules, logger *slog.Logger) []reconcile.Request {
+	var reqs []reconcile.Request
+
+	for _, port := range ports {
+		if port.TerminatingTLS != nil && port.TerminatingTLS.Secret != nil {
+			s := types.NamespacedName{
+				Namespace: port.TerminatingTLS.Secret.Namespace,
+				Name:      port.TerminatingTLS.Secret.Name,
+			}
+			reqs = append(reqs, reconcile.Request{NamespacedName: s})
+			logger.Debug("Enqueued secret reconciliation for network policy", "secret", s)
+		}
+
+		if port.OriginatingTLS != nil && port.OriginatingTLS.Secret != nil {
+			s := types.NamespacedName{
+				Namespace: port.OriginatingTLS.Secret.Namespace,
+				Name:      port.OriginatingTLS.Secret.Name,
+			}
+			reqs = append(reqs, reconcile.Request{NamespacedName: s})
+			logger.Debug("Enqueued secret reconciliation for network policy", "secret", s)
+		}
+	}
+
+	return reqs
+}
+
+// GetReferencedSecretsFromHeaderRules finds all Header Secrets referenced by a set of port rules.
+func GetReferencedSecretsFromHeaderRules(ports api.PortRules, logger *slog.Logger) []reconcile.Request {
+	var reqs []reconcile.Request
+
+	for _, port := range ports {
+		if port.Rules == nil {
+			continue
+		}
+
+		for _, httpRule := range port.Rules.HTTP {
+			for _, hm := range httpRule.HeaderMatches {
+				if hm.Secret != nil {
+					s := types.NamespacedName{
+						Namespace: hm.Secret.Namespace,
+						Name:      hm.Secret.Name,
+					}
+					reqs = append(reqs, reconcile.Request{NamespacedName: s})
+				}
+			}
+		}
+	}
+
+	return reqs
+}
+
+// IsSecretReferencedByPortRule checks if a given Secret is referenced in any rule
+// in the supplied set of PortRules, whether that is in a TLS or header-value sense.
+func IsSecretReferencedByPortRule(ports api.PortRules, logger *slog.Logger, secretName types.NamespacedName) bool {
+	for _, port := range ports {
+
+		// First, check for TLS Secrets
+		if port.TerminatingTLS != nil && port.TerminatingTLS.Secret != nil {
+			if secretName.Namespace == port.TerminatingTLS.Secret.Namespace &&
+				secretName.Name == port.TerminatingTLS.Secret.Name {
+				return true
+			}
+		}
+		if port.OriginatingTLS != nil && port.OriginatingTLS.Secret != nil {
+			if secretName.Namespace == port.OriginatingTLS.Secret.Namespace &&
+				secretName.Name == port.OriginatingTLS.Secret.Name {
+				return true
+			}
+		}
+
+		// Otherwise, check for HTTP header secrets
+		if port.Rules == nil {
+			continue
+		}
+
+		for _, httpRule := range port.Rules.HTTP {
+			for _, hm := range httpRule.HeaderMatches {
+				if hm.Secret != nil {
+					if secretName.Namespace == hm.Secret.Namespace &&
+						secretName.Name == hm.Secret.Name {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}

--- a/operator/pkg/networkpolicy/secretsync.go
+++ b/operator/pkg/networkpolicy/secretsync.go
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package networkpolicy
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlRuntime "sigs.k8s.io/controller-runtime"
+
+	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/operator/pkg/networkpolicy/helpers"
+	"github.com/cilium/cilium/operator/pkg/secretsync"
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy/api"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// SecretSyncCell manages the Network Policy related controllers.
+var SecretSyncCell = cell.Module(
+	"netpol-secretsync-watcher",
+	"Watches network policy updates for TLS secrets to sync",
+
+	cell.Config(networkPolicyConfig{
+		EnablePolicySecretsSync: false,
+		PolicySecretsNamespace:  "cilium-secrets",
+	}),
+	cell.Provide(registerCNPSecretSync),
+	cell.Provide(registerCCNPSecretSync),
+)
+
+type networkPolicyConfig struct {
+	EnablePolicySecretsSync bool
+	PolicySecretsNamespace  string
+}
+
+func (r networkPolicyConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool("enable-policy-secrets-sync", r.EnablePolicySecretsSync, "Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by tls-interception-secrets-namespace flag)")
+	flags.String("policy-secrets-namespace", r.PolicySecretsNamespace, "Namespace where secrets used in TLS Interception will be synced to.")
+}
+
+type networkPolicyParams struct {
+	cell.In
+
+	Logger             *slog.Logger
+	K8sClient          k8sClient.Clientset
+	CtrlRuntimeManager ctrlRuntime.Manager
+	Scheme             *runtime.Scheme
+
+	AgentConfig         *option.DaemonConfig
+	OperatorConfig      *operatorOption.OperatorConfig
+	NetworkPolicyConfig networkPolicyConfig
+}
+
+// registerCNPSecretSync registers the Network Policy controllers for secret synchronization based on TLS secrets referenced
+// by a CNP resource.
+func registerCNPSecretSync(params networkPolicyParams) secretsync.SecretSyncRegistrationOut {
+	if !params.NetworkPolicyConfig.EnablePolicySecretsSync {
+		return secretsync.SecretSyncRegistrationOut{}
+	}
+
+	return secretsync.SecretSyncRegistrationOut{
+		SecretSyncRegistration: &secretsync.SecretSyncRegistration{
+			RefObject:            &cilium_api_v2.CiliumNetworkPolicy{},
+			RefObjectEnqueueFunc: EnqueueTLSSecrets(params.CtrlRuntimeManager.GetClient(), params.Logger),
+			RefObjectCheckFunc:   IsReferencedByCiliumNetworkPolicy,
+			SecretsNamespace:     params.NetworkPolicyConfig.PolicySecretsNamespace,
+		},
+	}
+}
+
+// registerCCNPSecretSync registers the Network Policy controllers for secret synchronization based on TLS secrets referenced
+// by a CCNP resource.
+func registerCCNPSecretSync(params networkPolicyParams) secretsync.SecretSyncRegistrationOut {
+	if !params.NetworkPolicyConfig.EnablePolicySecretsSync {
+		return secretsync.SecretSyncRegistrationOut{}
+	}
+
+	return secretsync.SecretSyncRegistrationOut{
+		SecretSyncRegistration: &secretsync.SecretSyncRegistration{
+			RefObject:            &cilium_api_v2.CiliumClusterwideNetworkPolicy{},
+			RefObjectEnqueueFunc: EnqueueTLSSecrets(params.CtrlRuntimeManager.GetClient(), params.Logger),
+			RefObjectCheckFunc:   IsReferencedByCiliumClusterwideNetworkPolicy,
+			SecretsNamespace:     params.NetworkPolicyConfig.PolicySecretsNamespace,
+		},
+	}
+}
+
+// EnqueueTLSSecrets returns a map function that, given a CiliumNetworkPolicy or CilumClusterwideNetworkPolicy,
+// will return a slice of requests for any Secrets referenced in that CiliumNetworkPolicy.
+//
+// This includes both TLS secrets (Origination or Termination), plus Secrets used for storing header values.
+func EnqueueTLSSecrets(c client.Client, logger *slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+		scopedLog := logger.With(logfields.Controller, "secrets", logfields.Resource, obj.GetName())
+
+		objName := types.NamespacedName{
+			Namespace: obj.GetNamespace(),
+			Name:      obj.GetName(),
+		}
+		scopedLog = scopedLog.With("networkPolicyObject", objName)
+		var specs []*api.Rule
+
+		switch o := obj.(type) {
+		case *cilium_api_v2.CiliumNetworkPolicy:
+			if o.Spec != nil {
+				specs = append(specs, o.Spec)
+			}
+			if len(o.Specs) > 0 {
+				specs = append(specs, o.Specs...)
+			}
+			scopedLog = scopedLog.With("networkPolicyKind", "CiliumNetworkPolicy")
+		case *cilium_api_v2.CiliumClusterwideNetworkPolicy:
+			if o.Spec != nil {
+				specs = append(specs, o.Spec)
+			}
+			if len(o.Specs) > 0 {
+				specs = append(specs, o.Specs...)
+			}
+			scopedLog = scopedLog.With("networkPolicyKind", "CiliumClusterwideNetworkPolicy")
+		}
+
+		var reqs []reconcile.Request
+		for _, rule := range specs {
+			for _, egress := range rule.Egress {
+				reqs = append(reqs, helpers.GetReferencedTLSSecretsFromPortRules(egress.ToPorts, scopedLog)...)
+				reqs = append(reqs, helpers.GetReferencedSecretsFromHeaderRules(egress.ToPorts, scopedLog)...)
+			}
+			for _, ingress := range rule.Ingress {
+				reqs = append(reqs, helpers.GetReferencedTLSSecretsFromPortRules(ingress.ToPorts, scopedLog)...)
+				reqs = append(reqs, helpers.GetReferencedSecretsFromHeaderRules(ingress.ToPorts, scopedLog)...)
+			}
+		}
+		return reqs
+	})
+}
+
+func IsReferencedByCiliumNetworkPolicy(ctx context.Context, c client.Client, logger *slog.Logger, obj *corev1.Secret) bool {
+	scopedLog := logger.With(logfields.Controller, "netpol-cnp-secretsync", logfields.Resource, obj.GetName())
+
+	secretName := types.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+
+	cnpList := &cilium_api_v2.CiliumNetworkPolicyList{}
+	if err := c.List(ctx, cnpList); err != nil {
+		scopedLog.Warn("Unable to list CiliumNetworkPolicies", logfields.Error, err)
+		return false
+	}
+
+	for _, cnp := range cnpList.Items {
+
+		var rules []*api.Rule
+
+		if cnp.Spec != nil {
+			rules = append(rules, cnp.Spec)
+		}
+
+		if len(cnp.Specs) > 0 {
+			rules = append(rules, cnp.Specs...)
+		}
+
+		for _, rule := range rules {
+			for _, egress := range rule.Egress {
+				if helpers.IsSecretReferencedByPortRule(egress.ToPorts, scopedLog, secretName) {
+					return true
+				}
+			}
+			for _, ingress := range rule.Ingress {
+				if helpers.IsSecretReferencedByPortRule(ingress.ToPorts, scopedLog, secretName) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func IsReferencedByCiliumClusterwideNetworkPolicy(ctx context.Context, c client.Client, logger *slog.Logger, obj *corev1.Secret) bool {
+	scopedLog := logger.With(logfields.Controller, "netpol-ccnp-secretsync", logfields.Resource, obj.GetName())
+
+	secretName := types.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+
+	ccnpList := &cilium_api_v2.CiliumClusterwideNetworkPolicyList{}
+	if err := c.List(ctx, ccnpList); err != nil {
+		scopedLog.Warn("Unable to list CiliumClusterwideNetworkPolicies", logfields.Error, err)
+		return false
+	}
+
+	for _, ccnp := range ccnpList.Items {
+
+		var rules []*api.Rule
+
+		if ccnp.Spec != nil {
+			rules = append(rules, ccnp.Spec)
+		}
+
+		if len(ccnp.Specs) > 0 {
+			rules = append(rules, ccnp.Specs...)
+		}
+
+		for _, rule := range rules {
+			for _, egress := range rule.Egress {
+				if helpers.IsSecretReferencedByPortRule(egress.ToPorts, scopedLog, secretName) {
+					return true
+				}
+			}
+			for _, ingress := range rule.Ingress {
+				if helpers.IsSecretReferencedByPortRule(ingress.ToPorts, scopedLog, secretName) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/crypto/certificatemanager/certificate_manager.go
+++ b/pkg/crypto/certificatemanager/certificate_manager.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/cilium/hive/cell"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -26,12 +27,13 @@ var Cell = cell.Module(
 )
 
 type CertificateManager interface {
-	GetTLSContext(ctx context.Context, tlsCtx *api.TLSContext, ns string) (ca, public, private string, err error)
+	GetTLSContext(ctx context.Context, tlsCtx *api.TLSContext, ns string) (ca, public, private string, fromFile bool, err error)
 }
 
 type SecretManager interface {
-	GetSecrets(ctx context.Context, secret *api.Secret, ns string) (string, map[string][]byte, error)
+	GetSecrets(ctx context.Context, secret *api.Secret, ns string) (string, map[string][]byte, bool, error)
 	GetSecretString(ctx context.Context, secret *api.Secret, ns string) (string, error)
+	SetSecretSyncNamespace(ns string)
 }
 
 var defaultManagerConfig = managerConfig{
@@ -51,25 +53,41 @@ func (mc managerConfig) Flags(flags *pflag.FlagSet) {
 // Manager will manage the way certificates are retrieved based in the given
 // k8sClient and rootPath.
 type manager struct {
-	rootPath  string
-	k8sClient k8sClient.Clientset
+	rootPath            string
+	k8sClient           k8sClient.Clientset
+	secretSyncNamespace string
+	Logger              logrus.FieldLogger
 }
 
 // NewManager returns a new manager.
-func NewManager(cfg managerConfig, clientset k8sClient.Clientset) (CertificateManager, SecretManager) {
+func NewManager(cfg managerConfig, clientset k8sClient.Clientset, logger logrus.FieldLogger) (CertificateManager, SecretManager) {
 	m := &manager{
 		rootPath:  cfg.CertificatesDirectory,
 		k8sClient: clientset,
+		Logger:    logger,
 	}
+
+	m.Logger.Debug("certificate-manager starting")
 
 	return m, m
 }
 
+// SetSecretSyncNamespace sets the configured secret synchronization namespace.
+// Not calling this will disable using secret synchronization, and means that the agent must have
+// read access to the secrets used in policy directly.
+// Secret Synchronization config includes granting access to the policy-secrets-namespace, configured
+// in the envoy Cell.
+func (m *manager) SetSecretSyncNamespace(ns string) {
+	m.secretSyncNamespace = ns
+}
+
 // GetSecrets returns either local or k8s secrets, giving precedence for local secrets if configured.
-// The 'ns' parameter is used as the secret namespace if 'secret.Namespace' is an empty string.
-func (m *manager) GetSecrets(ctx context.Context, secret *api.Secret, ns string) (string, map[string][]byte, error) {
+// It also returns a boolean indicating if the values were read from disk or not.
+// The 'ns' parameter is used as the secret namespace if 'secret.Namespace' is an empty string, and is
+// expected to be set as the same namespace as the source object (most likely a CNP or CCNP).
+func (m *manager) GetSecrets(ctx context.Context, secret *api.Secret, ns string) (string, map[string][]byte, bool, error) {
 	if secret == nil {
-		return "", nil, fmt.Errorf("Secret must not be nil")
+		return "", nil, false, fmt.Errorf("Secret must not be nil")
 	}
 
 	if secret.Namespace != "" {
@@ -77,7 +95,7 @@ func (m *manager) GetSecrets(ctx context.Context, secret *api.Secret, ns string)
 	}
 
 	if secret.Name == "" {
-		return ns, nil, fmt.Errorf("Missing Secret name")
+		return ns, nil, false, fmt.Errorf("Missing Secret name")
 	}
 	nsName := filepath.Join(ns, secret.Name)
 
@@ -98,12 +116,19 @@ func (m *manager) GetSecrets(ctx context.Context, secret *api.Secret, ns string)
 		}
 		// Return the (latest) error only if no secrets were found
 		if len(secrets) == 0 && ioErr != nil {
-			return nsName, nil, ioErr
+			// Files read from disk, so bool returnval is true
+			return nsName, nil, true, ioErr
 		}
-		return nsName, secrets, nil
+		// Files read from disk, so bool returnval is true
+		return nsName, secrets, true, nil
 	}
-	secrets, err := m.k8sClient.GetSecrets(ctx, ns, secret.Name)
-	return nsName, secrets, err
+
+	// If the secret is _not_ being read from the filesystem, then we don't want to inspect it at all, because
+	// that will require the agent to have more access than it needs. So we return an empty `secrets` map.
+	// The plan here is to deprecate reading from file entirely, at which all this code will be removed.
+	// TODO(youngnick): Deprecate and remove reading from file for secrets.
+	emptySecrets := make(map[string][]byte)
+	return nsName, emptySecrets, false, nil
 }
 
 const (
@@ -114,10 +139,17 @@ const (
 
 // GetTLSContext returns a new ca, public and private certificates found based
 // in the given api.TLSContext.
-func (m *manager) GetTLSContext(ctx context.Context, tlsCtx *api.TLSContext, ns string) (ca, public, private string, err error) {
-	name, secrets, err := m.GetSecrets(ctx, tlsCtx.Secret, ns)
+func (m *manager) GetTLSContext(ctx context.Context, tlsCtx *api.TLSContext, ns string) (ca, public, private string, fromFile bool, err error) {
+	name, secrets, fromFile, err := m.GetSecrets(ctx, tlsCtx.Secret, ns)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", false, err
+	}
+
+	// If the certificate hasn't been read from a file, we're going to be inserting a reference to an SDS secret instead,
+	// so we don't need to validate the values. Envoy will handle validation.
+	if !fromFile {
+		m.Logger.WithField("secret", name).Debug("Secret being read from Kubernetes")
+		return "", "", "", fromFile, nil
 	}
 
 	caName := caDefaultName
@@ -128,7 +160,7 @@ func (m *manager) GetTLSContext(ctx context.Context, tlsCtx *api.TLSContext, ns 
 	if ok {
 		ca = string(caBytes)
 	} else if tlsCtx.TrustedCA != "" {
-		return "", "", "", fmt.Errorf("Trusted CA %s not found in secret %s", caName, name)
+		return "", "", "", false, fmt.Errorf("Trusted CA %s not found in secret %s", caName, name)
 	}
 
 	publicName := publicDefaultName
@@ -139,7 +171,7 @@ func (m *manager) GetTLSContext(ctx context.Context, tlsCtx *api.TLSContext, ns 
 	if ok {
 		public = string(publicBytes)
 	} else if tlsCtx.Certificate != "" {
-		return "", "", "", fmt.Errorf("Certificate %s not found in secret %s", publicName, name)
+		return "", "", "", false, fmt.Errorf("Certificate %s not found in secret %s", publicName, name)
 	}
 
 	privateName := privateDefaultName
@@ -150,19 +182,23 @@ func (m *manager) GetTLSContext(ctx context.Context, tlsCtx *api.TLSContext, ns 
 	if ok {
 		private = string(privateBytes)
 	} else if tlsCtx.PrivateKey != "" {
-		return "", "", "", fmt.Errorf("Private Key %s not found in secret %s", privateName, name)
+		return "", "", "", false, fmt.Errorf("Private Key %s not found in secret %s", privateName, name)
 	}
 
 	if caBytes == nil && publicBytes == nil && privateBytes == nil {
-		return "", "", "", fmt.Errorf("TLS certificates not found in secret %s ", name)
+		return "", "", "", false, fmt.Errorf("TLS certificates not found in secret %s ", name)
 	}
 
-	return ca, public, private, nil
+	// TODO(youngnick): Follow up PR that will change this to a deprecation warning once we actually
+	// mark read-from-file as deprecated.
+	m.Logger.WithField("secret", name).Debug("Secret read from file")
+	return ca, public, private, fromFile, nil
 }
 
 // GetSecretString returns a secret string stored in a k8s secret
 func (m *manager) GetSecretString(ctx context.Context, secret *api.Secret, ns string) (string, error) {
-	name, secrets, err := m.GetSecrets(ctx, secret, ns)
+	// TODO: Update this and to handle read-from-file
+	name, secrets, _, err := m.GetSecrets(ctx, secret, ns)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -103,9 +103,6 @@ type secretSyncConfig struct {
 
 	EnableGatewayAPI           bool
 	GatewayAPISecretsNamespace string
-
-	EnablePolicySecretsSync bool
-	PolicySecretsNamespace  string
 }
 
 func (r secretSyncConfig) Flags(flags *pflag.FlagSet) {
@@ -114,8 +111,6 @@ func (r secretSyncConfig) Flags(flags *pflag.FlagSet) {
 	flags.String("ingress-secrets-namespace", r.IngressSecretsNamespace, "IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller")
 	flags.Bool("enable-gateway-api", false, "Enables Envoy secret sync for Gateway API related TLS secrets")
 	flags.String("gateway-api-secrets-namespace", r.GatewayAPISecretsNamespace, "GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API")
-	flags.Bool("enable-policy-secrets-sync", r.EnablePolicySecretsSync, "Enables Envoy secret sync for Secrets used in CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy")
-	flags.String("policy-secrets-namespace", r.PolicySecretsNamespace, "PolicySecretsNamesapce is the namespace having secrets used in CNP and CCNP")
 }
 
 type xdsServerParams struct {
@@ -136,6 +131,8 @@ type xdsServerParams struct {
 	// Depend on ArtifactCopier to enforce init order and ensure that the additional artifacts are copied
 	// before starting the xDS server (and starting to configure Envoy).
 	ArtifactCopier *ArtifactCopier
+
+	SecretManager certificatemanager.SecretManager
 }
 
 func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
@@ -155,7 +152,8 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 			useFullTLSContext:             params.EnvoyProxyConfig.UseFullTLSContext,
 			proxyXffNumTrustedHopsIngress: params.EnvoyProxyConfig.ProxyXffNumTrustedHopsIngress,
 			proxyXffNumTrustedHopsEgress:  params.EnvoyProxyConfig.ProxyXffNumTrustedHopsEgress,
-		})
+		},
+		params.SecretManager)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Envoy xDS server: %w", err)
 	}
@@ -331,21 +329,14 @@ func registerSecretSyncer(params syncerParams) error {
 	namespaces := map[string]struct{}{}
 
 	for namespace, cond := range map[string]func() bool{
-		params.Config.EnvoySecretsNamespace:      func() bool { return option.Config.EnableEnvoyConfig },
-		params.Config.IngressSecretsNamespace:    func() bool { return params.Config.EnableIngressController },
-		params.Config.GatewayAPISecretsNamespace: func() bool { return params.Config.EnableGatewayAPI },
-		params.Config.PolicySecretsNamespace:     func() bool { return params.Config.EnablePolicySecretsSync },
+		params.Config.EnvoySecretsNamespace:           func() bool { return option.Config.EnableEnvoyConfig },
+		params.Config.IngressSecretsNamespace:         func() bool { return params.Config.EnableIngressController },
+		params.Config.GatewayAPISecretsNamespace:      func() bool { return params.Config.EnableGatewayAPI },
+		params.SecretManager.GetSecretSyncNamespace(): func() bool { return params.SecretManager.PolicySecretSyncEnabled() },
 	} {
 		if len(namespace) > 0 && cond() {
 			namespaces[namespace] = struct{}{}
 		}
-	}
-
-	// Policy secret syncing requires notifying the included xDSServer of the configured value,
-	// so it can be correctly used by the code.
-	if params.Config.EnablePolicySecretsSync {
-		params.XdsServer.SetPolicySecretSyncNamespace(params.Config.PolicySecretsNamespace)
-		params.SecretManager.SetSecretSyncNamespace(params.Config.PolicySecretsNamespace)
 	}
 
 	if len(namespaces) == 0 {

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -102,6 +102,9 @@ type secretSyncConfig struct {
 
 	EnableGatewayAPI           bool
 	GatewayAPISecretsNamespace string
+
+	EnablePolicySecretsSync bool
+	PolicySecretsNamespace  string
 }
 
 func (r secretSyncConfig) Flags(flags *pflag.FlagSet) {
@@ -110,6 +113,8 @@ func (r secretSyncConfig) Flags(flags *pflag.FlagSet) {
 	flags.String("ingress-secrets-namespace", r.IngressSecretsNamespace, "IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller")
 	flags.Bool("enable-gateway-api", false, "Enables Envoy secret sync for Gateway API related TLS secrets")
 	flags.String("gateway-api-secrets-namespace", r.GatewayAPISecretsNamespace, "GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API")
+	flags.Bool("enable-policy-secrets-sync", r.EnablePolicySecretsSync, "Enables Envoy secret sync for Secrets used in CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy")
+	flags.String("policy-secrets-namespace", r.PolicySecretsNamespace, "PolicySecretsNamesapce is the namespace having secrets used in CNP and CCNP")
 }
 
 type xdsServerParams struct {
@@ -327,6 +332,7 @@ func registerSecretSyncer(params syncerParams) error {
 		params.Config.EnvoySecretsNamespace:      func() bool { return option.Config.EnableEnvoyConfig },
 		params.Config.IngressSecretsNamespace:    func() bool { return params.Config.EnableIngressController },
 		params.Config.GatewayAPISecretsNamespace: func() bool { return params.Config.EnableGatewayAPI },
+		params.Config.PolicySecretsNamespace:     func() bool { return params.Config.EnablePolicySecretsSync },
 	} {
 		if len(namespace) > 0 && cond() {
 			namespaces[namespace] = struct{}{}

--- a/pkg/envoy/embedded_envoy_test.go
+++ b/pkg/envoy/embedded_envoy_test.go
@@ -62,7 +62,8 @@ func TestEnvoy(t *testing.T) {
 			envoySocketDir:    testRunDir,
 			proxyGID:          1337,
 			httpNormalizePath: true,
-		})
+		},
+		nil)
 	require.NotNil(t, xdsServer)
 	require.NoError(t, err)
 
@@ -167,7 +168,7 @@ func TestEnvoyNACK(t *testing.T) {
 			envoySocketDir:    testRunDir,
 			proxyGID:          1337,
 			httpNormalizePath: true,
-		})
+		}, nil)
 	require.NotNil(t, xdsServer)
 	require.NoError(t, err)
 	err = xdsServer.start()

--- a/pkg/envoy/secretsync_test.go
+++ b/pkg/envoy/secretsync_test.go
@@ -234,14 +234,34 @@ func Test_k8sSecretToEnvoySecretGeneric(t *testing.T) {
 	require.Nil(t, envoySecret.GetSessionTicketKeys())
 }
 
-func Test_k8sSecretToEnvoySecretOpaque(t *testing.T) {
+func Test_k8sSecretToEnvoySecretOtherValue(t *testing.T) {
 	envoySecret := k8sToEnvoySecret(&slim_corev1.Secret{
 		ObjectMeta: slim_metav1.ObjectMeta{
 			Name:      "dummy-secret",
 			Namespace: "dummy-namespace",
 		},
 		Data: map[string]slim_corev1.Bytes{
-			"other": []byte{},
+			"value": []byte{1, 2, 3},
+		},
+		Type: slim_corev1.SecretTypeOpaque,
+	})
+
+	require.Equal(t, "dummy-namespace/dummy-secret", envoySecret.Name)
+	require.Equal(t, []byte{1, 2, 3}, envoySecret.GetGenericSecret().Secret.GetInlineBytes())
+	require.Nil(t, envoySecret.GetValidationContext())
+	require.Nil(t, envoySecret.GetTlsCertificate())
+	require.Nil(t, envoySecret.GetSessionTicketKeys())
+}
+
+func Test_k8sSecretToEnvoySecretOtherMultiValues(t *testing.T) {
+	envoySecret := k8sToEnvoySecret(&slim_corev1.Secret{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "dummy-secret",
+			Namespace: "dummy-namespace",
+		},
+		Data: map[string]slim_corev1.Bytes{
+			"value":      []byte{1, 2, 3},
+			"othervalue": []byte{1, 2, 3},
 		},
 		Type: slim_corev1.SecretTypeOpaque,
 	})

--- a/pkg/envoy/secretsync_test.go
+++ b/pkg/envoy/secretsync_test.go
@@ -454,3 +454,11 @@ func (*fakeXdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *p
 func (*fakeXdsServer) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
 	panic("unimplemented")
 }
+
+func (*fakeXdsServer) GetPolicySecretSyncNamespace() string {
+	panic("unimplemented")
+}
+
+func (*fakeXdsServer) SetPolicySecretSyncNamespace(string) {
+	panic("unimplemented")
+}

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/completion"
@@ -120,6 +121,14 @@ type XDSServer interface {
 	// RemoveAllNetworkPolicies removes all network policies from the set published
 	// to L7 proxies.
 	RemoveAllNetworkPolicies()
+
+	// GetPolicySecretSyncNamespace gets the configured secret sync namespace,
+	// where secrets referenced in Network Policy will be synchronized to.
+	GetPolicySecretSyncNamespace() string
+
+	// SetPolicySecretSyncNamespace sets the secret sync namespace,
+	// where secrets referenced in Network Policy will be synchronized to.
+	SetPolicySecretSyncNamespace(string)
 }
 
 type xdsServer struct {
@@ -205,6 +214,7 @@ type xdsServerConfig struct {
 	httpRetryTimeout              int
 	httpNormalizePath             bool
 	useFullTLSContext             bool
+	policySecretSyncNamespace     string
 	proxyXffNumTrustedHopsIngress uint32
 	proxyXffNumTrustedHopsEgress  uint32
 }
@@ -316,7 +326,7 @@ func (s *xdsServer) newSocketListener() (*net.UnixListener, error) {
 	}
 
 	// Make the socket accessible by owner and group only.
-	if err = os.Chmod(s.socketPath, 0660); err != nil {
+	if err = os.Chmod(s.socketPath, 0o660); err != nil {
 		return nil, fmt.Errorf("failed to change mode of xDS listen socket at %s: %w", s.socketPath, err)
 	}
 	// Change the group to ProxyGID allowing access from any process from that group.
@@ -357,7 +367,6 @@ func GetUpstreamCodecFilter() *envoy_config_http.HttpFilter {
 }
 
 func (s *xdsServer) getHttpFilterChainProto(clusterName string, tls bool, isIngress bool) *envoy_config_listener.FilterChain {
-
 	requestTimeout := int64(s.config.httpRequestTimeout) // seconds
 	idleTimeout := int64(s.config.httpIdleTimeout)       // seconds
 	maxGRPCTimeout := int64(s.config.httpMaxGRPCTimeout) // seconds
@@ -1317,24 +1326,38 @@ var CiliumXDSConfigSource = &envoy_config_core.ConfigSource{
 	},
 }
 
-// toEnvoyFullTLSContext converts a "policy" TLS context (i.e., from a CiliumNetworkPolicy or
-// CiliumClusterwideNetworkPolicy) into a "cilium envoy" TLS context (i.e., for the Cilium proxy plugin for Envoy).
-//
-// Deprecated: This includes both the CA *and* the cert/key. You almost certainly don't want this. Use
-// toEnvoyOriginatingTLSContext or toEnvoyTerminatingTLSContext instead.
-// x-ref: https://github.com/cilium/cilium/issues/31761
-func toEnvoyFullTLSContext(tls *policy.TLSContext) *cilium.TLSContext {
-	return &cilium.TLSContext{
-		TrustedCa:        tls.TrustedCA,
-		CertificateChain: tls.CertificateChain,
-		PrivateKey:       tls.PrivateKey,
-	}
-}
-
 // toEnvoyOriginatingTLSContext converts a "policy" TLS context (i.e., from a CiliumNetworkPolicy or
 // CiliumClusterwideNetworkPolicy) for originating TLS (i.e., verifying TLS connections from *outside*) into a "cilium
 // envoy" TLS context (i.e., for the Cilium proxy plugin for Envoy).
-func toEnvoyOriginatingTLSContext(tls *policy.TLSContext) *cilium.TLSContext {
+//
+// useFullTLSContext is used to retain an old, buggy behavior where Secrets may contain a `ca.crt` field as well, which can
+// lead Envoy to enforce client TLS between the client pod and the interception point in Envoy. In this case,
+// Secrets will be sent to Envoy via the old, inline-in-NPDS method, and _not_ via SDS, and so this method will
+// return whatever is in the *policy.TLSContext.
+func toEnvoyOriginatingTLSContext(tls *policy.TLSContext, policySecretsNamespace string, useFullTLSContext bool) *cilium.TLSContext {
+	if !tls.FromFile && policySecretsNamespace != "" {
+		// If values are not present in these fields, then we should be using SDS,
+		// and Secret should be populated.
+		if tls.Secret.String() != "/" {
+			return &cilium.TLSContext{
+				ValidationContextSdsSecret: namespacedNametoSyncedSDSSecretName(tls.Secret, policySecretsNamespace),
+			}
+		}
+		// This code _should_ be unreachable, because NetworkPolicy input validation does not allow
+		// the Secret fields to be empty, so panic.
+		panic("SDS Policy secrets cannot be empty, this should not be possible, please log an issue")
+	}
+
+	// If we are not using a synchronized secret or are reading from file, useFullTLSContext
+	// matters.
+	if useFullTLSContext {
+		return &cilium.TLSContext{
+			CertificateChain: tls.CertificateChain,
+			PrivateKey:       tls.PrivateKey,
+			TrustedCa:        tls.TrustedCA,
+		}
+	}
+
 	return &cilium.TLSContext{
 		TrustedCa: tls.TrustedCA,
 	}
@@ -1343,11 +1366,46 @@ func toEnvoyOriginatingTLSContext(tls *policy.TLSContext) *cilium.TLSContext {
 // toEnvoyTerminatingTLSContext converts a "policy" TLS context (i.e., from a CiliumNetworkPolicy or
 // CiliumClusterwideNetworkPolicy) for terminating TLS (i.e., providing a valid cert to clients *inside*) into a "cilium
 // envoy" TLS context (i.e., for the Cilium proxy plugin for Envoy).
-func toEnvoyTerminatingTLSContext(tls *policy.TLSContext) *cilium.TLSContext {
+//
+// useFullTLSContext is used to retain an old, buggy behavior where Secrets may contain a `ca.crt` field as well, which can
+// lead Envoy to enforce client TLS between the client pod and the interception point in Envoy. In this case,
+// Secrets will be sent to Envoy via the old, inline-in-NPDS method, and _not_ via SDS, and so this method will
+// return whatever is in the *policy.TLSContext.
+func toEnvoyTerminatingTLSContext(tls *policy.TLSContext, policySecretsNamespace string, useFullTLSContext bool) *cilium.TLSContext {
+	if !tls.FromFile && policySecretsNamespace != "" {
+		// If the values have been read from Kubernetes, then we should be using SDS,
+		// and Secret should be populated.
+		if tls.Secret.String() != "/" {
+			return &cilium.TLSContext{
+				TlsSdsSecret: namespacedNametoSyncedSDSSecretName(tls.Secret, policySecretsNamespace),
+			}
+		}
+		// This code _should_ be unreachable, because NetworkPolicy input validation does not allow
+		// the Secret fields to be empty, so panic.
+		panic("SDS Policy secrets cannot be empty, this should not be possible, please log an issue")
+	}
+
+	// If we are not using a synchronized secret or are reading from file, useFullTLSContext
+	// matters.
+	if useFullTLSContext {
+		return &cilium.TLSContext{
+			CertificateChain: tls.CertificateChain,
+			PrivateKey:       tls.PrivateKey,
+			TrustedCa:        tls.TrustedCA,
+		}
+	}
+
 	return &cilium.TLSContext{
 		CertificateChain: tls.CertificateChain,
 		PrivateKey:       tls.PrivateKey,
 	}
+}
+
+func namespacedNametoSyncedSDSSecretName(namespacedName types.NamespacedName, policySecretsNamespace string) string {
+	if policySecretsNamespace == "" {
+		return fmt.Sprintf("%s/%s", namespacedName.Namespace, namespacedName.Name)
+	}
+	return fmt.Sprintf("%s/%s-%s", policySecretsNamespace, namespacedName.Namespace, namespacedName.Name)
 }
 
 func GetEnvoyHTTPRules(secretManager certificatemanager.SecretManager, l7Rules *api.L7Rules, ns string) (*cilium.HttpNetworkPolicyRules, bool) {
@@ -1374,7 +1432,7 @@ func GetEnvoyHTTPRules(secretManager certificatemanager.SecretManager, l7Rules *
 	return nil, true
 }
 
-func getPortNetworkPolicyRule(version *versioned.VersionHandle, sel policy.CachedSelector, wildcard bool, l7Parser policy.L7ParserType, l7Rules *policy.PerSelectorPolicy, useFullTLSContext bool) (*cilium.PortNetworkPolicyRule, bool) {
+func getPortNetworkPolicyRule(version *versioned.VersionHandle, sel policy.CachedSelector, wildcard bool, l7Parser policy.L7ParserType, l7Rules *policy.PerSelectorPolicy, useFullTLSContext bool, policySecretsNamespace string) (*cilium.PortNetworkPolicyRule, bool) {
 	r := &cilium.PortNetworkPolicyRule{}
 
 	// Optimize the policy if the endpoint selector is a wildcard by
@@ -1400,25 +1458,21 @@ func getPortNetworkPolicyRule(version *versioned.VersionHandle, sel policy.Cache
 		return r, false
 	}
 
-	if useFullTLSContext {
-		// Intentionally retain compatibility with older, buggy behaviour. In this mode the full contents of the
-		// Kubernetes secret identified by TLS context is copied into the downstream/upstream TLS context. For the
-		// downstream (i.e., in-cluster pod) this could include a CA bundle if a ca.crt key is present in the secret,
-		// which may incorrectly lead Envoy to require client certificates.
-		if l7Rules.TerminatingTLS != nil {
-			r.DownstreamTlsContext = toEnvoyFullTLSContext(l7Rules.TerminatingTLS)
-		}
-		if l7Rules.OriginatingTLS != nil {
-			r.UpstreamTlsContext = toEnvoyFullTLSContext(l7Rules.OriginatingTLS)
-		}
-	} else {
-		if l7Rules.TerminatingTLS != nil {
-			r.DownstreamTlsContext = toEnvoyTerminatingTLSContext(l7Rules.TerminatingTLS)
-		}
-		if l7Rules.OriginatingTLS != nil {
-			r.UpstreamTlsContext = toEnvoyOriginatingTLSContext(l7Rules.OriginatingTLS)
-		}
+	// If secret synchronization is disabled, policySecretsNamespace will be the empty string.
+	//
+	// In that case, useFullTLSContext is used to retain an old, buggy behavior where Secrets may contain a `ca.crt` field as well,
+	// which can lead Envoy to enforce client TLS between the client pod and the interception point in Envoy. In this case,
+	// Secrets will be sent to Envoy via the old, inline-in-NPDS method, and _not_ via SDS.
+	//
+	// If secret synchronization is enabled, useFullTLSContext is unused, as SDS handling can handle Secrets with extra
+	// keys correctly.
+	if l7Rules.TerminatingTLS != nil {
+		r.DownstreamTlsContext = toEnvoyTerminatingTLSContext(l7Rules.TerminatingTLS, policySecretsNamespace, useFullTLSContext)
 	}
+	if l7Rules.OriginatingTLS != nil {
+		r.UpstreamTlsContext = toEnvoyOriginatingTLSContext(l7Rules.OriginatingTLS, policySecretsNamespace, useFullTLSContext)
+	}
+
 	if len(l7Rules.ServerNames) > 0 {
 		r.ServerNames = make([]string, 0, len(l7Rules.ServerNames))
 		for sni := range l7Rules.ServerNames {
@@ -1544,7 +1598,7 @@ func getWildcardNetworkPolicyRule(version *versioned.VersionHandle, selectors po
 	}
 }
 
-func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4PolicyMap, policyEnforced bool, useFullTLSContext bool, dir string) []*cilium.PortNetworkPolicy {
+func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4PolicyMap, policyEnforced bool, useFullTLSContext bool, dir string, policySecretsNamespace string) []*cilium.PortNetworkPolicy {
 	// TODO: integrate visibility with enforced policy
 	if !policyEnforced {
 		// Always allow all ports
@@ -1613,7 +1667,7 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 				// then the proxy may need to drop some allowed l3 due to l7 rules potentially
 				// being different between the selectors.
 				wildcard := nSelectors == 1 || sel.IsWildcard()
-				rule, cs := getPortNetworkPolicyRule(version, sel, wildcard, l4.L7Parser, l7, useFullTLSContext)
+				rule, cs := getPortNetworkPolicyRule(version, sel, wildcard, l4.L7Parser, l7, useFullTLSContext, policySecretsNamespace)
 				if rule != nil {
 					if !cs {
 						canShortCircuit = false
@@ -1679,7 +1733,7 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 
 // getNetworkPolicy converts a network policy into a cilium.NetworkPolicy.
 func getNetworkPolicy(ep endpoint.EndpointUpdater, ips []string, l4Policy *policy.L4Policy,
-	ingressPolicyEnforced, egressPolicyEnforced, useFullTLSContext bool,
+	ingressPolicyEnforced, egressPolicyEnforced, useFullTLSContext bool, policySecretsNamespace string,
 ) *cilium.NetworkPolicy {
 	p := &cilium.NetworkPolicy{
 		EndpointIps:      ips,
@@ -1693,8 +1747,8 @@ func getNetworkPolicy(ep endpoint.EndpointUpdater, ips []string, l4Policy *polic
 		ingressMap = l4Policy.Ingress.PortRules
 		egressMap = l4Policy.Egress.PortRules
 	}
-	p.IngressPerPortPolicies = getDirectionNetworkPolicy(ep, ingressMap, ingressPolicyEnforced, useFullTLSContext, "ingress")
-	p.EgressPerPortPolicies = getDirectionNetworkPolicy(ep, egressMap, egressPolicyEnforced, useFullTLSContext, "egress")
+	p.IngressPerPortPolicies = getDirectionNetworkPolicy(ep, ingressMap, ingressPolicyEnforced, useFullTLSContext, "ingress", policySecretsNamespace)
+	p.EgressPerPortPolicies = getDirectionNetworkPolicy(ep, egressMap, egressPolicyEnforced, useFullTLSContext, "egress", policySecretsNamespace)
 
 	return p
 }
@@ -1756,7 +1810,7 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *pol
 		return nil, func() error { return nil }
 	}
 
-	networkPolicy := getNetworkPolicy(ep, ips, policy, ingressPolicyEnforced, egressPolicyEnforced, s.config.useFullTLSContext)
+	networkPolicy := getNetworkPolicy(ep, ips, policy, ingressPolicyEnforced, egressPolicyEnforced, s.config.useFullTLSContext, s.config.policySecretSyncNamespace)
 
 	// First, validate the policy
 	err := networkPolicy.Validate()
@@ -1852,6 +1906,14 @@ func (s *xdsServer) GetNetworkPolicies(resourceNames []string) (map[string]*cili
 		}
 	}
 	return networkPolicies, nil
+}
+
+func (s *xdsServer) SetPolicySecretSyncNamespace(ns string) {
+	s.config.policySecretSyncNamespace = ns
+}
+
+func (s *xdsServer) GetPolicySecretSyncNamespace() string {
+	return s.config.policySecretSyncNamespace
 }
 
 // Resources contains all Envoy resources parsed from a CiliumEnvoyConfig CRD

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -121,14 +121,6 @@ type XDSServer interface {
 	// RemoveAllNetworkPolicies removes all network policies from the set published
 	// to L7 proxies.
 	RemoveAllNetworkPolicies()
-
-	// GetPolicySecretSyncNamespace gets the configured secret sync namespace,
-	// where secrets referenced in Network Policy will be synchronized to.
-	GetPolicySecretSyncNamespace() string
-
-	// SetPolicySecretSyncNamespace sets the secret sync namespace,
-	// where secrets referenced in Network Policy will be synchronized to.
-	SetPolicySecretSyncNamespace(string)
 }
 
 type xdsServer struct {
@@ -194,6 +186,8 @@ type xdsServer struct {
 	restorerPromise promise.Promise[endpointstate.Restorer]
 
 	localEndpointStore *LocalEndpointStore
+
+	secretManager certificatemanager.SecretManager
 }
 
 func toAny(pb proto.Message) *anypb.Any {
@@ -214,13 +208,12 @@ type xdsServerConfig struct {
 	httpRetryTimeout              int
 	httpNormalizePath             bool
 	useFullTLSContext             bool
-	policySecretSyncNamespace     string
 	proxyXffNumTrustedHopsIngress uint32
 	proxyXffNumTrustedHopsEgress  uint32
 }
 
 // newXDSServer creates a new xDS GRPC server.
-func newXDSServer(restorerPromise promise.Promise[endpointstate.Restorer], ipCache IPCacheEventSource, localEndpointStore *LocalEndpointStore, config xdsServerConfig) (*xdsServer, error) {
+func newXDSServer(restorerPromise promise.Promise[endpointstate.Restorer], ipCache IPCacheEventSource, localEndpointStore *LocalEndpointStore, config xdsServerConfig, secretManager certificatemanager.SecretManager) (*xdsServer, error) {
 	return &xdsServer{
 		restorerPromise:    restorerPromise,
 		listenerCount:      make(map[string]uint),
@@ -230,6 +223,7 @@ func newXDSServer(restorerPromise promise.Promise[endpointstate.Restorer], ipCac
 		socketPath:    getXDSSocketPath(config.envoySocketDir),
 		accessLogPath: getAccessLogSocketPath(config.envoySocketDir),
 		config:        config,
+		secretManager: secretManager,
 	}, nil
 }
 
@@ -1833,7 +1827,7 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *pol
 		return nil, func() error { return nil }
 	}
 
-	networkPolicy := getNetworkPolicy(ep, ips, policy, ingressPolicyEnforced, egressPolicyEnforced, s.config.useFullTLSContext, s.config.policySecretSyncNamespace)
+	networkPolicy := getNetworkPolicy(ep, ips, policy, ingressPolicyEnforced, egressPolicyEnforced, s.config.useFullTLSContext, s.secretManager.GetSecretSyncNamespace())
 
 	// First, validate the policy
 	err := networkPolicy.Validate()
@@ -1929,14 +1923,6 @@ func (s *xdsServer) GetNetworkPolicies(resourceNames []string) (map[string]*cili
 		}
 	}
 	return networkPolicies, nil
-}
-
-func (s *xdsServer) SetPolicySecretSyncNamespace(ns string) {
-	s.config.policySecretSyncNamespace = ns
-}
-
-func (s *xdsServer) GetPolicySecretSyncNamespace() string {
-	return s.config.policySecretSyncNamespace
 }
 
 // Resources contains all Envoy resources parsed from a CiliumEnvoyConfig CRD

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1118,14 +1118,15 @@ func getKafkaL7Rules(l7Rules []kafka.PortRule) *cilium.KafkaNetworkPolicyRules {
 	return rules
 }
 
-func getSecretString(secretManager certificatemanager.SecretManager, hdr *api.HeaderMatch, ns string) (string, error) {
+func getSecretString(secretManager certificatemanager.SecretManager, hdr *api.HeaderMatch, ns string) (string, bool, error) {
 	value := ""
 	var err error
+	var fromFile bool
 	if hdr.Secret != nil {
 		if secretManager == nil {
 			err = fmt.Errorf("HeaderMatches: Nil secretManager")
 		} else {
-			value, err = secretManager.GetSecretString(context.TODO(), hdr.Secret, ns)
+			value, fromFile, err = secretManager.GetSecretString(context.TODO(), hdr.Secret, ns)
 		}
 	}
 	// Only use Value if secret was not obtained
@@ -1137,10 +1138,10 @@ func getSecretString(secretManager certificatemanager.SecretManager, hdr *api.He
 		}
 	}
 
-	return value, err
+	return value, fromFile, err
 }
 
-func getHTTPRule(secretManager certificatemanager.SecretManager, h *api.PortRuleHTTP, ns string) (*cilium.HttpNetworkPolicyRule, bool) {
+func getHTTPRule(secretManager certificatemanager.SecretManager, h *api.PortRuleHTTP, ns string, policySecretsNamespace string) (*cilium.HttpNetworkPolicyRule, bool) {
 	// Count the number of header matches we need
 	cnt := len(h.Headers) + len(h.HeaderMatches)
 	if h.Path != "" {
@@ -1237,7 +1238,7 @@ func getHTTPRule(secretManager certificatemanager.SecretManager, h *api.PortRule
 			mismatch_action = cilium.HeaderMatch_FAIL_ON_MISMATCH
 		}
 		// Fetch the secret
-		value, err := getSecretString(secretManager, hdr, ns)
+		value, fromFile, err := getSecretString(secretManager, hdr, ns)
 		if err != nil {
 			log.WithError(err).Warning("Failed fetching K8s Secret, header match will fail")
 			// Envoy treats an empty exact match value as matching ANY value; adding
@@ -1268,7 +1269,20 @@ func getHTTPRule(secretManager certificatemanager.SecretManager, h *api.PortRule
 						},
 					})
 				} else {
-					// Only header presence needed
+					// Value is empty, but could be we need to set an SDS value for it instead
+					if !fromFile {
+						// Need to add a HeaderMatch so we can specify the SDS value here.
+						log.Debugf("HeaderMatches: Adding %s because SDS value is required", hdr.Name)
+						headerMatches = append(headerMatches, &cilium.HeaderMatch{
+							MismatchAction: mismatch_action,
+							Name:           hdr.Name,
+							ValueSdsSecret: namespacedNametoSyncedSDSSecretName(types.NamespacedName{
+								Namespace: hdr.Secret.Namespace,
+								Name:      hdr.Secret.Name,
+							}, policySecretsNamespace),
+						})
+					}
+					// Check for header presence in headers
 					headers = append(headers, &envoy_config_route.HeaderMatcher{
 						Name:                 hdr.Name,
 						HeaderMatchSpecifier: &envoy_config_route.HeaderMatcher_PresentMatch{PresentMatch: true},
@@ -1276,11 +1290,22 @@ func getHTTPRule(secretManager certificatemanager.SecretManager, h *api.PortRule
 				}
 			} else {
 				log.Debugf("HeaderMatches: Adding %s", hdr.Name)
-				headerMatches = append(headerMatches, &cilium.HeaderMatch{
-					MismatchAction: mismatch_action,
-					Name:           hdr.Name,
-					Value:          value,
-				})
+				if !fromFile && hdr.Secret != nil {
+					headerMatches = append(headerMatches, &cilium.HeaderMatch{
+						MismatchAction: mismatch_action,
+						Name:           hdr.Name,
+						ValueSdsSecret: namespacedNametoSyncedSDSSecretName(types.NamespacedName{
+							Namespace: hdr.Secret.Namespace,
+							Name:      hdr.Secret.Name,
+						}, policySecretsNamespace),
+					})
+				} else {
+					headerMatches = append(headerMatches, &cilium.HeaderMatch{
+						MismatchAction: mismatch_action,
+						Name:           hdr.Name,
+						Value:          value,
+					})
+				}
 			}
 		}
 	}
@@ -1408,7 +1433,7 @@ func namespacedNametoSyncedSDSSecretName(namespacedName types.NamespacedName, po
 	return fmt.Sprintf("%s/%s-%s", policySecretsNamespace, namespacedName.Namespace, namespacedName.Name)
 }
 
-func GetEnvoyHTTPRules(secretManager certificatemanager.SecretManager, l7Rules *api.L7Rules, ns string) (*cilium.HttpNetworkPolicyRules, bool) {
+func GetEnvoyHTTPRules(secretManager certificatemanager.SecretManager, l7Rules *api.L7Rules, ns string, policySecretsNamespace string) (*cilium.HttpNetworkPolicyRules, bool) {
 	if len(l7Rules.HTTP) > 0 { // Just cautious. This should never be false.
 		// Assume none of the rules have side-effects so that rule evaluation can
 		// be stopped as soon as the first allowing rule is found. 'canShortCircuit'
@@ -1418,7 +1443,7 @@ func GetEnvoyHTTPRules(secretManager certificatemanager.SecretManager, l7Rules *
 		httpRules := make([]*cilium.HttpNetworkPolicyRule, 0, len(l7Rules.HTTP))
 		for _, l7 := range l7Rules.HTTP {
 			var cs bool
-			rule, cs := getHTTPRule(secretManager, &l7, ns)
+			rule, cs := getHTTPRule(secretManager, &l7, ns, policySecretsNamespace)
 			httpRules = append(httpRules, rule)
 			if !cs {
 				canShortCircuit = false
@@ -1497,7 +1522,7 @@ func getPortNetworkPolicyRule(version *versioned.VersionHandle, sel policy.Cache
 				httpRules = l7Rules.EnvoyHTTPRules
 				canShortCircuit = l7Rules.CanShortCircuit
 			} else {
-				httpRules, canShortCircuit = GetEnvoyHTTPRules(nil, &l7Rules.L7Rules, "")
+				httpRules, canShortCircuit = GetEnvoyHTTPRules(nil, &l7Rules.L7Rules, "", policySecretsNamespace)
 			}
 			r.L7 = &cilium.PortNetworkPolicyRule_HttpRules{
 				HttpRules: httpRules,

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -536,8 +536,8 @@ func (m mockSecretManagerInlineSecrets) GetSecretString(_ context.Context, secre
 	return "somevalue", nil
 }
 
-func (m mockSecretManagerInlineSecrets) SetSecretSyncNamespace(ns string) {
-	// unimplemented
+func (m mockSecretManagerInlineSecrets) PolicySecretSyncEnabled() bool {
+	return false
 }
 
 func (m mockSecretManagerInlineSecrets) GetSecretSyncNamespace() string {
@@ -551,8 +551,8 @@ func (m mockSecretManagerSDSSecrets) GetSecretString(_ context.Context, secret *
 	return "", nil
 }
 
-func (m mockSecretManagerSDSSecrets) SetSecretSyncNamespace(ns string) {
-	// unimplemented
+func (m mockSecretManagerSDSSecrets) PolicySecretSyncEnabled() bool {
+	return true
 }
 
 func (m mockSecretManagerSDSSecrets) GetSecretSyncNamespace() string {

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -453,7 +453,7 @@ var L4Policy2 = &policy.L4Policy{
 }
 
 func TestGetHTTPRule(t *testing.T) {
-	obtained, canShortCircuit := getHTTPRule(nil, PortRuleHTTP1, "")
+	obtained, canShortCircuit := getHTTPRule(nil, PortRuleHTTP1, "", "")
 	require.Equal(t, ExpectedHeaders1, obtained.Headers)
 	require.True(t, canShortCircuit)
 }

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -134,7 +134,7 @@ type PolicyRepository interface {
 	Release(rs ruleSlice)
 	ReplaceByResourceLocked(rules api.Rules, resource ipcachetypes.ResourceID) (newRules ruleSlice, oldRules ruleSlice, revision uint64)
 	SearchRLocked(lbls labels.LabelArray) api.Rules
-	SetEnvoyRulesFunc(f func(certificatemanager.SecretManager, *api.L7Rules, string) (*cilium.HttpNetworkPolicyRules, bool))
+	SetEnvoyRulesFunc(f func(certificatemanager.SecretManager, *api.L7Rules, string, string) (*cilium.HttpNetworkPolicyRules, bool))
 	Start()
 }
 
@@ -178,7 +178,7 @@ type Repository struct {
 	certManager   certificatemanager.CertificateManager
 	secretManager certificatemanager.SecretManager
 
-	getEnvoyHTTPRules func(certificatemanager.SecretManager, *api.L7Rules, string) (*cilium.HttpNetworkPolicyRules, bool)
+	getEnvoyHTTPRules func(certificatemanager.SecretManager, *api.L7Rules, string, string) (*cilium.HttpNetworkPolicyRules, bool)
 }
 
 // Lock acquiers the lock of the whole policy tree.
@@ -219,7 +219,7 @@ func (p *Repository) GetAuthTypes(localID, remoteID identity.NumericIdentity) Au
 	return p.policyCache.GetAuthTypes(localID, remoteID)
 }
 
-func (p *Repository) SetEnvoyRulesFunc(f func(certificatemanager.SecretManager, *api.L7Rules, string) (*cilium.HttpNetworkPolicyRules, bool)) {
+func (p *Repository) SetEnvoyRulesFunc(f func(certificatemanager.SecretManager, *api.L7Rules, string, string) (*cilium.HttpNetworkPolicyRules, bool)) {
 	p.getEnvoyHTTPRules = f
 }
 
@@ -227,7 +227,7 @@ func (p *Repository) GetEnvoyHTTPRules(l7Rules *api.L7Rules, ns string) (*cilium
 	if p.getEnvoyHTTPRules == nil {
 		return nil, true
 	}
-	return p.getEnvoyHTTPRules(p.secretManager, l7Rules, ns)
+	return p.getEnvoyHTTPRules(p.secretManager, l7Rules, ns, p.secretManager.GetSecretSyncNamespace())
 }
 
 // GetPolicyCache() returns the policy cache used by the Repository

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -42,7 +42,7 @@ type PolicyContext interface {
 	// GetTLSContext resolves the given 'api.TLSContext' into CA
 	// certs and the public and private keys, using secrets from
 	// k8s or from the local file system.
-	GetTLSContext(tls *api.TLSContext) (ca, public, private string, fromFile bool, err error)
+	GetTLSContext(tls *api.TLSContext) (ca, public, private string, inlineSecrets bool, err error)
 
 	// GetEnvoyHTTPRules translates the given 'api.L7Rules' into
 	// the protobuf representation the Envoy can consume. The bool
@@ -81,7 +81,7 @@ func (p *policyContext) GetSelectorCache() *SelectorCache {
 }
 
 // GetTLSContext() returns data for TLS Context via a CertificateManager
-func (p *policyContext) GetTLSContext(tls *api.TLSContext) (ca, public, private string, fromFile bool, err error) {
+func (p *policyContext) GetTLSContext(tls *api.TLSContext) (ca, public, private string, inlineSecrets bool, err error) {
 	if p.repo.certManager == nil {
 		return "", "", "", false, fmt.Errorf("No Certificate Manager set on Policy Repository")
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -540,7 +540,6 @@ func (kub *Kubectl) ParallelResourceDelete(namespace, resource string, names []s
 			if !res.WasSuccessful() {
 				ginkgoext.By("Unable to delete %s %s with '%s': %s",
 					resource, name, cmd, res.OutputPrettyPrint())
-
 			}
 			wg.Done()
 		}(name)
@@ -584,7 +583,6 @@ func (kub *Kubectl) CleanNamespace(namespace string) {
 		go func(resource string) {
 			kub.DeleteAllResourceInNamespace(namespace, resource)
 			wg.Done()
-
 		}(resource)
 	}
 	wg.Wait()
@@ -1115,7 +1113,6 @@ func (kub *Kubectl) GetPodNamesContext(ctx context.Context, namespace string, la
 	podNamesCtx, cancel := context.WithTimeout(ctx, ShortCommandTimeout)
 	defer cancel()
 	err := kub.ExecuteContext(podNamesCtx, cmd, stdout, nil)
-
 	if err != nil {
 		return nil, fmt.Errorf(
 			"could not find pods in namespace '%v' with label '%v': %w", namespace, label, err)
@@ -1123,7 +1120,7 @@ func (kub *Kubectl) GetPodNamesContext(ctx context.Context, namespace string, la
 
 	out := strings.Trim(stdout.String(), "\n")
 	if len(out) == 0 {
-		//Small hack. String split always return an array with an empty string
+		// Small hack. String split always return an array with an empty string
 		return []string{}, nil
 	}
 	return strings.Split(out, " "), nil
@@ -1398,7 +1395,6 @@ func (kub *Kubectl) NamespaceDelete(name string) *CmdRes {
 	}
 	return kub.ExecShort(fmt.Sprintf(
 		"%[1]s get namespace %[2]s -o json | tr -d \"\\n\" | sed \"s/\\\"finalizers\\\": \\[[^]]\\+\\]/\\\"finalizers\\\": []/\" | %[1]s replace --raw /api/v1/namespaces/%[2]s/finalize -f -", KubectlCmd, name))
-
 }
 
 // EnsureNamespaceExists creates a namespace, ignoring the AlreadyExists error.
@@ -1608,9 +1604,8 @@ func (kub *Kubectl) waitForSinglePod(checkStatus checkPodStatusFunc, namespace s
 // the timeout was exceeded.
 func (kub *Kubectl) WaitForServiceEndpoints(namespace string, filter string, service string, timeout time.Duration) error {
 	body := func() bool {
-		var jsonPath = fmt.Sprintf("{.items[?(@.metadata.name == '%s')].subsets[0].ports[0].port}", service)
+		jsonPath := fmt.Sprintf("{.items[?(@.metadata.name == '%s')].subsets[0].ports[0].port}", service)
 		data, err := kub.GetEndpoints(namespace, filter).Filter(jsonPath)
-
 		if err != nil {
 			kub.Logger().WithError(err)
 			return false
@@ -2770,7 +2765,7 @@ func (kub *Kubectl) CiliumInstall(filename string, options map[string]string) er
 		return err
 	}
 
-	res = kub.Apply(ApplyOptions{FilePath: filename, Force: true, Namespace: CiliumNamespace})
+	res = kub.Apply(ApplyOptions{FilePath: filename, Force: true})
 	if !res.WasSuccessful() {
 		return res.GetErr("Unable to apply YAML")
 	}
@@ -3414,7 +3409,7 @@ func (kub *Kubectl) CiliumCheckReport(ctx context.Context) {
 	pods, _ := kub.GetCiliumPods()
 	fmt.Fprintf(CheckLogs, "Cilium pods: %v\n", pods)
 
-	var policiesFilter = `{range .items[*]}{.metadata.namespace}{"::"}{.metadata.name}{" "}{end}`
+	policiesFilter := `{range .items[*]}{.metadata.namespace}{"::"}{.metadata.name}{" "}{end}`
 	netpols := kub.ExecContextShort(ctx, fmt.Sprintf(
 		"%s get netpol -o jsonpath='%s' --all-namespaces",
 		KubectlCmd, policiesFilter))
@@ -3444,18 +3439,18 @@ func (kub *Kubectl) CiliumCheckReport(ctx context.Context) {
 	}
 	table.Flush()
 
-	var controllersFilter = `{range .controllers[*]}{.name}{"="}{.status.consecutive-failure-count}::{.status.last-failure-msg}{"\n"}{end}`
+	controllersFilter := `{range .controllers[*]}{.name}{"="}{.status.consecutive-failure-count}::{.status.last-failure-msg}{"\n"}{end}`
 	var failedControllers string
 	for _, pod := range pods {
-		var prefix = ""
+		prefix := ""
 		status := kub.CiliumExecContext(ctx, pod, "cilium-dbg status --all-controllers -o json")
 		result, err := status.Filter(controllersFilter)
 		if err != nil {
 			kub.Logger().WithError(err).Error("Cannot filter controller status output")
 			continue
 		}
-		var total = 0
-		var failed = 0
+		total := 0
+		failed := 0
 		for name, data := range result.KVOutput() {
 			total++
 			status := strings.SplitN(data, "::", 2)
@@ -3534,7 +3529,6 @@ func (kub *Kubectl) ValidateListOfErrorsInLogs(duration time.Duration, blacklist
 				err = os.WriteFile(
 					fmt.Sprintf("%s/%s", testPath, file),
 					[]byte(logs), LogPerm)
-
 				if err != nil {
 					kub.Logger().WithError(err).Errorf("Cannot create %s", CiliumTestLog)
 				}
@@ -3877,7 +3871,6 @@ func (kub *Kubectl) CiliumPreFlightCheck() error {
 			return false
 		}
 		return true
-
 	}
 	if err := RepeatUntilTrue(body, &TimeoutConfig{Timeout: HelperTimeout}); err != nil {
 		return fmt.Errorf("Cilium validation failed: %w: Last polled error: %s", err, lastError)
@@ -3907,7 +3900,7 @@ func (kub *Kubectl) ciliumStatusPreFlightCheck() error {
 
 func (kub *Kubectl) ciliumControllersPreFlightCheck() error {
 	ginkgoext.By("Performing Cilium controllers preflight check")
-	var controllersFilter = `{range .controllers[*]}{.name}{"="}{.status.consecutive-failure-count}{"\n"}{end}`
+	controllersFilter := `{range .controllers[*]}{.name}{"="}{.status.consecutive-failure-count}{"\n"}{end}`
 	ciliumPods, err := kub.GetCiliumPods()
 	if err != nil {
 		return fmt.Errorf("cannot retrieve cilium pods: %w", err)
@@ -3933,8 +3926,8 @@ func (kub *Kubectl) ciliumControllersPreFlightCheck() error {
 
 func (kub *Kubectl) ciliumHealthPreFlightCheck() error {
 	ginkgoext.By("Performing Cilium health check")
-	var nodesFilter = `{.nodes[*].name}`
-	var statusPaths = []string{
+	nodesFilter := `{.nodes[*].name}`
+	statusPaths := []string{
 		".host.primary-address.icmp.status",
 		".host.primary-address.http.status",
 		".host.secondary-addresses[*].icmp.status",
@@ -4036,7 +4029,6 @@ func (kub *Kubectl) fillServiceCache() error {
 		return err
 	}
 	err = svcRes.Unmarshal(&cache.services)
-
 	if err != nil {
 		return fmt.Errorf("Unable to unmarshal K8s services: %w", err)
 	}
@@ -4762,7 +4754,7 @@ func hasIPAddress(output []string) (bool, string) {
 }
 
 func (kub *Kubectl) ensureKubectlVersion() error {
-	//check current kubectl version
+	// check current kubectl version
 	type Version struct {
 		ClientVersion struct {
 			Major string `json:"major"`
@@ -4788,7 +4780,7 @@ func (kub *Kubectl) ensureKubectlVersion() error {
 	})
 	versionstring := fmt.Sprintf("%s.%s", v.ClientVersion.Major, minor)
 	if versionstring == GetCurrentK8SEnv() {
-		//version available on host is matching current env
+		// version available on host is matching current env
 		return nil
 	}
 


### PR DESCRIPTION
This PR migrates Network Policy Secret handling to use SDS instead of inlining the secrets inside NPDS.

This has a few advantages:
- Changes to policy Secrets will no longer require a policy recalculation to take effect
- We can use the existing secret syncing functionality to reduce the scope of access that the Agent requires to Secrets (so that it no longer requires access to all Secrets in the cluster for secret use in NetworkPolicy to work)
- Reducing the size of NPDS updates (by not inlining) should hopefully speed up sending this config, and help with memory use at large scale.


Some background on using secrets in NetworkPolicy:

There are two ways you can use a Secret in NetworkPolicy, for TLS interception (both termination and origination), and for storing the value of a header that you want to match or add.

TLS Interception seems to be more common, but both are currently implemented.

One additional piece of functionality that this PR preserves is the ability to read "Secrets" specified in CiliumNetworkPolicy via files on the filesystem of the Agent. This functionality was built when Cilium was more focused on non-Kubernetes use cases, and should probably be deprecated and then removed at a later date. Removing this will _substantially_ simplify the code.

This PR also includes all the requisite Helm changes to track secret syncing (similarly to Ingress, Gateway API, and BGP config), and updates the connectivity tests in cilium-cli to use all the new values and functionality correctly.

It also updates the existing TLS Interception docs for the changes, and makes them so that they work (the example app `artii.herokuapp.com` is down, this replaces that with `httpbin.org`.)

Fixes: #24020 

```release-note
Cilium now sends TLS Interception and Header manipulation secrets referenced in CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy by reference using SDS, using the same secret synchronization method used for Ingress, Gateway API, and BGP control plane secrets.
```

For reviewers, reviewing by commits will definitely be easier for this one.

Sorry about the size, this turned out to be a _much_ bigger change than anticipated.