### PR TITLE
pkg/map/stats: provide Observable[T] fields for nat iteration.

### DIFF
--- a/pkg/maps/nat/stats/stats.go
+++ b/pkg/maps/nat/stats/stats.go
@@ -8,7 +8,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"strconv"
+
+	"github.com/cilium/stream"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
@@ -41,7 +44,32 @@ type Stats struct {
 	config   Config
 	natMap4  nat.NatMap4
 	natMap6  nat.NatMap6
+
+	observable4 stream.Observable[TupleCountIterator]
+	next4       func(TupleCountIterator)
+	complete4   func(error)
+
+	observable6 stream.Observable[TupleCountIterator]
+	next6       func(TupleCountIterator)
+	complete6   func(error)
 }
+
+// Observable4 returns the state iteration observable for ipv4 nat.
+func (s *Stats) Observable4() stream.Observable[TupleCountIterator] {
+	return s.observable4
+}
+
+// Observable6 returns the state iteration observable for ipv6 nat.
+func (s *Stats) Observable6() stream.Observable[TupleCountIterator] {
+	return s.observable6
+}
+
+// TupleCountIterator is a k/v iterator type that allows for opaquely
+// accessing a set of snat tuple source port counts.
+// This is used by the exported Observable{4,6} streams to allow for
+// external consumers to iterate over the current set of nat map stats
+// following a countNat operation.
+type TupleCountIterator iter.Seq2[SNATTupleAccessor, uint16]
 
 // NatMapStats is a nat-map table entry key/value. This
 // contains a count of connection 3-tuple utilization.
@@ -127,6 +155,12 @@ func newStats(params params) (*Stats, error) {
 		db:       params.DB,
 		table:    params.Table,
 	}
+
+	m.observable4, m.next4, m.complete4 =
+		stream.Multicast[TupleCountIterator]()
+	m.observable6, m.next6, m.complete6 =
+		stream.Multicast[TupleCountIterator]()
+
 	params.Lifecycle.Append(cell.Hook{
 		OnStart: func(hc cell.HookContext) error {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*120)
@@ -161,11 +195,16 @@ func newStats(params params) (*Stats, error) {
 			}()
 			return params.Jobs.Start(hc)
 		},
+		OnStop: func(hc cell.HookContext) error {
+			m.complete4(nil)
+			m.complete6(nil)
+			return nil
+		},
 	})
 	return m, nil
 }
 
-func upsertStat[KT tupleKey](m *Stats, topk *topk[KT], family nat.IPFamily) error {
+func upsertStat(m *Stats, topk *topk, family nat.IPFamily) error {
 	tx := m.db.WriteTxn(m.table)
 	defer tx.Abort()
 
@@ -177,19 +216,20 @@ func upsertStat[KT tupleKey](m *Stats, topk *topk[KT], family nat.IPFamily) erro
 		}
 	}
 
-	topk.popForEach(func(key KT, count, ith int) {
+	topk.popForEach(func(key SNATTupleAccessor, count, ith int) {
 		if ith == 1 {
 			m.metrics.updateLocalPorts(family, count, m.maxPorts)
 		}
-		extip, eip, proto, rport := key.tuple()
+		endpointIP, rport := key.GetEndpointAddr()
+		egressIP, _ := key.GetEgressAddr()
+		proto := key.GetProto()
 		_, _, err := m.table.Insert(tx, NatMapStats{
 			Type:       family.String(),
-			EgressIP:   eip,
-			EndpointIP: extip,
+			EgressIP:   egressIP.String(),
+			EndpointIP: endpointIP.String(),
 			RemotePort: rport,
-			Proto:      proto,
+			Proto:      proto.String(),
 			Count:      count,
-			Nth:        ith,
 		})
 		if err != nil {
 			errs = errors.Join(errs, err)
@@ -209,16 +249,16 @@ func flagsIsIn(flags uint8) bool {
 func (m *Stats) countNat(ctx context.Context) error {
 	var errs error
 	if m.natMap4 != nil {
-		tupleToPortCount := make(map[tuple.TupleKey4]uint16, 128)
+		tupleToPortCount := make(map[SNATTuple4]uint16, 128)
 		_, err := m.natMap4.DumpBatch4(func(k tuple.TupleKey4, _ nat.NatEntry4) {
 			key := *k.ToHost().(*tuple.TupleKey4)
 			if flagsIsIn(key.Flags) &&
 				(key.NextHeader == u8proto.TCP || key.NextHeader == u8proto.ICMP ||
 					key.NextHeader == u8proto.UDP) {
 				key.DestPort = 0
-				ports := tupleToPortCount[key]
+				ports := tupleToPortCount[SNATTuple4(key)]
 				ports++
-				tupleToPortCount[key] = ports
+				tupleToPortCount[SNATTuple4(key)] = ports
 			}
 		})
 
@@ -228,35 +268,39 @@ func (m *Stats) countNat(ctx context.Context) error {
 					"this may result in out of date nat-stats data and nat_endpoint_ metrics")
 			errs = errors.Join(errs, err)
 		} else {
-			topk := newTopK[key4](m.config.NatMapStatKStoredEntries)
+			m.next4(toIter(tupleToPortCount))
+			topk := newTopK(m.config.NatMapStatKStoredEntries)
 			for tupleKey, bucket := range tupleToPortCount {
-				topk.Push(key4(tupleKey), int(bucket))
+				topk.Push(tupleKey, int(bucket))
 			}
 			errors.Join(errs, upsertStat(m, topk, nat.IPv4))
 		}
+
 	}
 	if m.natMap6 != nil {
-		tupleToPortCount := make(map[tuple.TupleKey6]uint16, 128)
+		tupleToPortCount := make(map[SNATTuple6]uint16, 128)
 		_, err := m.natMap6.DumpBatch6(func(k tuple.TupleKey6, _ nat.NatEntry6) {
 			key := *k.ToHost().(*tuple.TupleKey6)
 			if flagsIsIn(key.Flags) &&
 				(key.NextHeader == u8proto.TCP || key.NextHeader == u8proto.ICMPv6 ||
 					key.NextHeader == u8proto.UDP) {
 				key.DestPort = 0
-				ports := tupleToPortCount[key]
+				ports := tupleToPortCount[SNATTuple6(key)]
 				ports++
-				tupleToPortCount[key] = ports
+				tupleToPortCount[SNATTuple6(key)] = ports
 			}
 		})
+
 		if err != nil {
 			log.WithError(err).
 				Error("failed to count ipv6 nat map entries, " +
 					"this may result in out of date nat-stats data and nat_endpoint_ metrics")
 			errs = errors.Join(errs, err)
 		} else {
-			topk := newTopK[key6](m.config.NatMapStatKStoredEntries)
+			m.next6(toIter(tupleToPortCount))
+			topk := newTopK(m.config.NatMapStatKStoredEntries)
 			for tupleKey, bucket := range tupleToPortCount {
-				topk.Push(key6(tupleKey), int(bucket))
+				topk.Push(tupleKey, int(bucket))
 			}
 			errors.Join(errs, upsertStat(m, topk, nat.IPv6))
 		}
@@ -264,39 +308,24 @@ func (m *Stats) countNat(ctx context.Context) error {
 	return errs
 }
 
-type tupleKey interface {
-	tuple() (extIP string, egressIP string, proto string, remotePort uint16)
-}
-
-type key4 tuple.TupleKey4
-type key6 tuple.TupleKey6
-
-func (k key4) tuple() (extIP string, egressIP string, proto string, remotePort uint16) {
-	return k.SourceAddr.String(), k.DestAddr.String(), k.NextHeader.String(), k.SourcePort
-}
-
-func (k key6) tuple() (extIP string, egressIP string, proto string, remotePort uint16) {
-	return k.SourceAddr.String(), k.DestAddr.String(), k.NextHeader.String(), k.SourcePort
-}
-
-type tupleBucket[KT tupleKey] struct {
-	key   KT
+type tupleBucket struct {
+	key   SNATTupleAccessor
 	count int
 }
 
-type topk[KT tupleKey] struct {
-	mq      *minQueue[KT]
+type topk struct {
+	mq      *minQueue
 	k, size int
 }
 
-func newTopK[KT tupleKey](k int) *topk[KT] {
-	mq := make(minQueue[KT], 0, k)
+func newTopK(k int) *topk {
+	mq := make(minQueue, 0, k)
 	heap.Init(&mq)
-	return &topk[KT]{mq: &mq, k: k}
+	return &topk{mq: &mq, k: k}
 }
 
-func (t *topk[KT]) Push(key KT, count int) {
-	heap.Push(t.mq, tupleBucket[KT]{key: key, count: count})
+func (t *topk) Push(key SNATTupleAccessor, count int) {
+	heap.Push(t.mq, tupleBucket{key: key, count: count})
 	t.size++
 	if t.size > t.k {
 		heap.Pop(t.mq)
@@ -304,31 +333,31 @@ func (t *topk[KT]) Push(key KT, count int) {
 	}
 }
 
-func (t *topk[KT]) popForEach(fn func(key KT, count, ith int)) {
+func (t *topk) popForEach(fn func(key SNATTupleAccessor, count, ith int)) {
 	for i := 0; i < t.size; i++ {
-		tuple := heap.Pop(t.mq).(tupleBucket[KT])
+		tuple := heap.Pop(t.mq).(tupleBucket)
 		fn(tuple.key, tuple.count, t.size-i)
 	}
 	t.size = 0
 }
 
-type minQueue[KT tupleKey] []tupleBucket[KT]
+type minQueue []tupleBucket
 
-func (pq minQueue[KT]) Len() int { return len(pq) }
+func (pq minQueue) Len() int { return len(pq) }
 
-func (pq minQueue[KT]) Less(i, j int) bool {
+func (pq minQueue) Less(i, j int) bool {
 	return pq[i].count < pq[j].count
 }
 
-func (pq minQueue[KT]) Swap(i, j int) {
+func (pq minQueue) Swap(i, j int) {
 	pq[i], pq[j] = pq[j], pq[i]
 }
 
-func (pq *minQueue[KT]) Push(x any) {
-	*pq = append(*pq, x.(tupleBucket[KT]))
+func (pq *minQueue) Push(x any) {
+	*pq = append(*pq, x.(tupleBucket))
 }
 
-func (pq *minQueue[KT]) Pop() any {
+func (pq *minQueue) Pop() any {
 	old := *pq
 	n := len(old)
 	item := old[n-1]

--- a/pkg/maps/nat/stats/stats_test.go
+++ b/pkg/maps/nat/stats/stats_test.go
@@ -25,16 +25,16 @@ import (
 )
 
 func Test_topk(t *testing.T) {
-	top5 := newTopK[key4](5)
+	top5 := newTopK(5)
 	for i := byte(0); i < 10; i++ {
 		ip := types.IPv4{10, 0, 0, i}
-		k := key4{
+		k := SNATTuple4{
 			DestAddr: ip,
 		}
 		top5.Push(k, int(i))
 	}
 	out := []int{}
-	top5.popForEach(func(key key4, count, ith int) { out = append(out, count) })
+	top5.popForEach(func(key SNATTupleAccessor, count, ith int) { out = append(out, count) })
 	assert.Equal(t, []int{5, 6, 7, 8, 9}, out)
 }
 
@@ -130,7 +130,6 @@ func Test_countNat(t *testing.T) {
 				default:
 					assert.FailNow(t, "unexpected family type")
 				}
-				assert.Equal(t, 8019-(o.Nth-1), int(o.RemotePort))
 				freq[o.Type]++
 			}
 			assert.Equal(t, 19, ms[nat.IPv4.String()])

--- a/pkg/maps/nat/stats/types.go
+++ b/pkg/maps/nat/stats/types.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package stats
+
+import (
+	"net/netip"
+
+	"github.com/cilium/cilium/pkg/tuple"
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+// snatTupleAccessor is an interface for safely accessing elements of the SNAT tuple.
+// Instead of passing the tuple directly, we use the snatTupleAccessor interface
+// which provide opaque access to SNAT specific data such as egress-ip and
+// endpoint-ip.
+//
+// This provides dual benefits of abstracting away concerns regarding snat
+// tuple direction, as well as ensuring data integrity by only providing a
+// opaque accessor to external observers.
+type SNATTupleAccessor interface {
+	GetEgressAddr() (netip.Addr, uint16)
+	GetEndpointAddr() (netip.Addr, uint16)
+	GetProto() u8proto.U8proto
+}
+
+// have constraint under different type such that we can use this for both
+// passing map[snatTupleConstraint]uint16 as well as using it as a regular
+// accessor interface type.
+type snatTupleConstraint interface {
+	comparable
+	SNATTupleAccessor
+}
+
+type SNATTuple4 tuple.TupleKey4
+type SNATTuple6 tuple.TupleKey6
+
+func (t SNATTuple4) getRelativeValues() (egressIP, endpointIP netip.Addr, egressPort, endpointPort uint16) {
+	switch t.Flags {
+	case tuple.TUPLE_F_IN:
+		return t.DestAddr.Addr(), t.SourceAddr.Addr(), t.DestPort, t.SourcePort
+	default:
+		return t.SourceAddr.Addr(), t.DestAddr.Addr(), t.DestPort, t.SourcePort
+	}
+}
+
+func (t SNATTuple6) getRelativeValues() (egressIP, endpointIP netip.Addr, egressPort, endpointPort uint16) {
+	switch t.Flags {
+	case tuple.TUPLE_F_IN:
+		return t.DestAddr.Addr(), t.SourceAddr.Addr(), t.DestPort, t.SourcePort
+	default:
+		return t.SourceAddr.Addr(), t.DestAddr.Addr(), t.DestPort, t.SourcePort
+	}
+}
+
+func (t SNATTuple4) GetProto() u8proto.U8proto {
+	return t.NextHeader
+}
+
+func (t SNATTuple4) GetEgressAddr() (netip.Addr, uint16) {
+	egressIP, _, egressPort, _ := t.getRelativeValues()
+	return egressIP, egressPort
+}
+
+func (t SNATTuple4) GetEndpointAddr() (netip.Addr, uint16) {
+	_, endpointIP, _, endpointPort := t.getRelativeValues()
+	return endpointIP, endpointPort
+}
+
+func (t SNATTuple6) GetEgressAddr() (netip.Addr, uint16) {
+	egressIP, _, egressPort, _ := t.getRelativeValues()
+	return egressIP, egressPort
+}
+
+func (t SNATTuple6) GetEndpointAddr() (netip.Addr, uint16) {
+	_, endpointIP, _, endpointPort := t.getRelativeValues()
+	return endpointIP, endpointPort
+}
+
+func (t SNATTuple6) GetProto() u8proto.U8proto {
+	return t.NextHeader
+}
+
+func toIter[T snatTupleConstraint](s map[T]uint16) TupleCountIterator {
+	return func(yield func(SNATTupleAccessor, uint16) bool) {
+		for k, v := range s {
+			yield(k, v)
+		}
+	}
+}


### PR DESCRIPTION
The data computed by nat-stats can be used by other cell modules to avoid having to do similar computations.

To allow for safely exposing stream.Observable hooks, this abstracts accessing the nat tuple |-> count bucket map into a interface.

Following computing the bucket count, observers can iterate the stats data by subscribing to the exported observable types in the nat-stats type.