### PR TITLE
ci: fix native wireguard encryption

### DIFF
--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -119,6 +119,7 @@ jobs:
           - index: 5
             name: "native-wireguard"
             mode: "gke"
+            encryption: "wireguard"
 
           - index: 6
             name: "tunnel-wireguard"


### PR DESCRIPTION
While changing workflow, wireguard encryption was accidentally removed.

Fixes: #35268
