### PR TITLE
envoy: avoid syncing empty Envoy secret

### DIFF
--- a/pkg/envoy/secretsync.go
+++ b/pkg/envoy/secretsync.go
@@ -90,8 +90,13 @@ func (r *secretSyncer) upsertK8sSecretV1(ctx context.Context, secret *slim_corev
 		return errors.New("secret is nil")
 	}
 
+	envoySecret := k8sToEnvoySecret(secret)
+	if envoySecret == nil {
+		return nil
+	}
+
 	resource := Resources{
-		Secrets: []*envoy_extensions_tls_v3.Secret{k8sToEnvoySecret(secret)},
+		Secrets: []*envoy_extensions_tls_v3.Secret{envoySecret},
 	}
 	return r.envoyXdsServer.UpsertEnvoyResources(ctx, resource)
 }
@@ -168,6 +173,9 @@ func k8sToEnvoySecret(secret *slim_corev1.Secret) *envoy_extensions_tls_v3.Secre
 				},
 			},
 		}
+
+	default:
+		return nil
 	}
 
 	return envoySecret

--- a/pkg/envoy/secretsync_test.go
+++ b/pkg/envoy/secretsync_test.go
@@ -108,11 +108,7 @@ func Test_k8sSecretToEnvoySecretTlsSessionKeys_FirstKeyMandatory(t *testing.T) {
 		Type: slim_corev1.SecretTypeOpaque,
 	})
 
-	require.Equal(t, "dummy-namespace/dummy-secret", envoySecret.Name)
-
-	require.Nil(t, envoySecret.GetSessionTicketKeys())
-	require.Nil(t, envoySecret.GetTlsCertificate())
-	require.Nil(t, envoySecret.GetValidationContext())
+	require.Nil(t, envoySecret)
 }
 
 func Test_k8sSecretToEnvoySecretTlsSessionKeys_Max10Keys(t *testing.T) {
@@ -163,7 +159,7 @@ func Test_k8sSecretToEnvoySecretTlsSessionKeys_SkipAdditionalKeysOnMainKeySizeIs
 			Namespace: "dummy-namespace",
 		},
 		Data: map[string]slim_corev1.Bytes{
-			"tls.sessionticket.key":   []byte{}, // not 80 bytes
+			"tls.sessionticket.key":   make([]byte, 70), // not 80 bytes
 			"tls.sessionticket.key.1": testSessionKey(1),
 			"tls.sessionticket.key.2": testSessionKey(2),
 			"tls.sessionticket.key.3": testSessionKey(3),
@@ -174,7 +170,8 @@ func Test_k8sSecretToEnvoySecretTlsSessionKeys_SkipAdditionalKeysOnMainKeySizeIs
 
 	require.Equal(t, "dummy-namespace/dummy-secret", envoySecret.Name)
 
-	require.Nil(t, envoySecret.GetSessionTicketKeys())
+	require.NotNil(t, envoySecret.GetSessionTicketKeys())
+	require.Nil(t, envoySecret.GetSessionTicketKeys().Keys)
 	require.Nil(t, envoySecret.GetTlsCertificate())
 	require.Nil(t, envoySecret.GetValidationContext())
 }
@@ -235,6 +232,21 @@ func Test_k8sSecretToEnvoySecretGeneric(t *testing.T) {
 	require.Nil(t, envoySecret.GetValidationContext())
 	require.Nil(t, envoySecret.GetTlsCertificate())
 	require.Nil(t, envoySecret.GetSessionTicketKeys())
+}
+
+func Test_k8sSecretToEnvoySecretOpaque(t *testing.T) {
+	envoySecret := k8sToEnvoySecret(&slim_corev1.Secret{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "dummy-secret",
+			Namespace: "dummy-namespace",
+		},
+		Data: map[string]slim_corev1.Bytes{
+			"other": []byte{},
+		},
+		Type: slim_corev1.SecretTypeOpaque,
+	})
+
+	require.Nil(t, envoySecret)
 }
 
 func TestHandleSecretEvent(t *testing.T) {


### PR DESCRIPTION
Currently, the Envoy SecretSync on the Cilium Agent (sending K8s secrets from the K8s Secret namespace via xDS to Envoy) sends an "empty" Envoy secret resource if it's not possible to map the K8s secret into a corresponding Envoy secret type.

To avoid confusion, this refactoring doesn't sync K8s secrets that can't be mapped to a corresponding Envoy secret type.

Suggested-by: Yutaro Hayakawa <yutaro.hayakawa@isovalent.com>
