### PR TITLE
CI: Add channel arguments to GKE related workflows

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -47,7 +47,7 @@ triggers:
   /ci-eks:
     workflows:
     - conformance-eks.yaml
-  /ci-external-workloads:
+  /ci-external-workloads(?:\s+(versions=(all)|channel=(EXTENDED|REGULAR|STABLE|RAPID|NONE|extended|regular|stable|none)))?:
     workflows:
     - conformance-externalworkloads.yaml
   /ci-gateway-api:
@@ -56,7 +56,7 @@ triggers:
   /ci-ginkgo:
     workflows:
     - conformance-ginkgo.yaml
-  /ci-gke:
+  /ci-gke(?:\s+(versions=(all)|channel=(EXTENDED|REGULAR|STABLE|RAPID|NONE|extended|regular|stable|none)))?:
     workflows:
     - conformance-gke.yaml
   /ci-ingress:

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -113,7 +113,8 @@ jobs:
           # Use complete matrix in case of scheduled run
           # main -> event_name = schedule
           # other stable branches -> PR-number starting with v (e.g. v1.14)
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
+          VERSIONS=$(echo "${{ inputs.extra-args }}" | awk -F'=' '{print $2}')
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* || "$VERSIONS" == "all" ]];then
             jq '{ "include": [ .k8s[] ] }' gke.json > /tmp/matrix.json
           else
             jq '{ "include": [ .k8s[] | select(.default) ] }' gke.json > /tmp/matrix.json
@@ -140,12 +141,22 @@ jobs:
       - name: Filter Matrix
         id: set-matrix
         run: |
+          CHANNEL=$(echo ${{ inputs.extra-args }} | grep "channel" | awk -F'=' '{print $2}' | tr '[:lower:]' '[:upper:]')
+          if [ "$CHANNEL" == "" ];then
+            FILTER="channels.channel=REGULAR"
+          elif [ "$CHANNEL" == "NONE" ];then
+            FILTER=""
+          else
+            FILTER="channels.channel=$CHANNEL"
+          fi
+          echo $CHANNEL
+          echo $FILTER
           cp /tmp/matrix.json /tmp/result.json
           jq -c '.include[]' /tmp/matrix.json | while read i; do
             VERSION=$(echo $i | jq -r '.version')
             ZONE=$(echo $i | jq -r '.zone')
             gcloud --quiet container get-server-config \
-              --flatten="channels" \
+              --flatten="channels" --filter="$FILTER" \
               --format="yaml(channels.validVersions)" --zone $ZONE > /tmp/output
             if grep -q -F $VERSION /tmp/output; then
               echo "Version $VERSION is valid for zone $ZONE"

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -118,7 +118,8 @@ jobs:
           # Use complete matrix in case of scheduled run
           # main -> event_name = schedule
           # other stable branches -> PR-number starting with v (e.g. v1.14)
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
+          VERSIONS=$(echo ${{ inputs.extra-args }} | awk -F'=' '{print $2}')
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* || "$VERSIONS" == "all" ]];then
             cp gke.json /tmp/matrix.json
           else
             jq '{ "k8s": [ .k8s[] | select(.default) ], "config": .config}' gke.json > /tmp/matrix.json
@@ -145,12 +146,20 @@ jobs:
       - name: Filter Matrix
         id: set-matrix
         run: |
+          CHANNEL=$(echo ${{ inputs.extra-args }} | grep "channel" | awk -F'=' '{print $2}' | tr '[:lower:]' '[:upper:]')
+          if [ "$CHANNEL" == "" ];then
+            FILTER="channels.channel=REGULAR"
+          elif [ "$CHANNEL" == "NONE" ];then
+            FILTER=""
+          else
+            FILTER="channels.channel=$CHANNEL"
+          fi
           cp /tmp/matrix.json /tmp/result.json
           jq -c '.k8s[]' /tmp/matrix.json | while read i; do
             VERSION=$(echo $i | jq -r '.version')
             ZONE=$(echo $i | jq -r '.zone')
             gcloud --quiet container get-server-config \
-              --flatten="channels" \
+              --flatten="channels" --filter="$FILTER" \
               --format="yaml(channels.validVersions)" --zone $ZONE > /tmp/output
             if grep -q -F $VERSION /tmp/output; then
               echo "Version $VERSION is valid for zone $ZONE"


### PR DESCRIPTION
This PR adds Ariane extra-args to run all GKE versions with the argument versions=all. 
Normally, these run only on scheduled workflow runs.
Also, this PR adds an argument for the GKE channel, if channel=<name> versions given it
is filtered for that channel, and channel=none disables filtering. If no argument is given the default channel REGULAR is used.

The purpose of adding versions=all is to make it easy to test the running of all versions, 
and the purpose of adding channel=<name> is that scheduled tests fail without filtering versions with stable channels, especially during version updates on GKE. But at the same time, we want to keep the ability to run tests without channel filtering too.

Runs with arguments:
versions=all https://github.com/cilium/cilium/actions/runs/11515943731
channel=stable https://github.com/cilium/cilium/actions/runs/11515905320 
