### PR TITLE
identity: Allow registration of additional identity handlers

### DIFF
--- a/pkg/identity/cache/cell/cell.go
+++ b/pkg/identity/cache/cell/cell.go
@@ -60,6 +60,8 @@ type identityAllocatorParams struct {
 	PolicyRepository policy.PolicyRepository
 	PolicyUpdater    *policy.Updater
 
+	IdentityHandlers []identity.UpdateIdentities `group:"identity-handlers"`
+
 	Config config
 }
 
@@ -91,6 +93,8 @@ func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
 	iao := &identityAllocatorOwner{
 		policy:        params.PolicyRepository,
 		policyUpdater: params.PolicyUpdater,
+
+		identityHandlers: params.IdentityHandlers,
 	}
 
 	allocatorConfig := cache.AllocatorConfig{
@@ -121,6 +125,8 @@ func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
 type identityAllocatorOwner struct {
 	policy        policy.PolicyRepository
 	policyUpdater *policy.Updater
+
+	identityHandlers []identity.UpdateIdentities
 }
 
 // UpdateIdentities informs the policy package of all identity changes
@@ -130,6 +136,10 @@ type identityAllocatorOwner struct {
 // present in both 'added' and 'deleted'.
 func (iao *identityAllocatorOwner) UpdateIdentities(added, deleted identity.IdentityMap) {
 	wg := &sync.WaitGroup{}
+	for _, handler := range iao.identityHandlers {
+		handler.UpdateIdentities(added, deleted, wg)
+	}
+	// Invoke policy selector cache always as the last handler
 	iao.policy.GetSelectorCache().UpdateIdentities(added, deleted, wg)
 	// Wait for update propagation to endpoints before triggering policy updates
 	wg.Wait()

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"sync"
 
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
@@ -321,4 +322,9 @@ func IdentityAllocationIsLocal(lbls labels.Labels) bool {
 	// If there is only one label with the "reserved" source and a well-known
 	// key, the well-known identity for it can be allocated locally.
 	return LookupReservedIdentityByLabels(lbls) != nil
+}
+
+// UpdateIdentities is an interface to be called when identities change
+type UpdateIdentities interface {
+	UpdateIdentities(added, deleted IdentityMap, wg *sync.WaitGroup)
 }


### PR DESCRIPTION
This commit extends the identity cache cell with the ability to invoke additional identity handlers. This differs from the existing `stream.Observable[cache.IdentityChange]` (c.f. https://github.com/cilium/cilium/pull/26373) in that it contains all identities, not just the ones from the local cluster.

We are using a callback rather than an observable here, since consumers of observables can register themselves late, requiring  us to replay the current state from all remote cluster caches. This would require a rather convoluted solution. Therefore, we instead opt for a simpler solution were consumers statically register their interest at construction time via a callback. This ensures that they observe all identity updates that happen to occur, even before the cell is started.