### PR TITLE
dbg: increase limit when safely reading envoy metrics via cilium-dbg

### DIFF
--- a/cilium-dbg/cmd/envoy_adminclient.go
+++ b/cilium-dbg/cmd/envoy_adminclient.go
@@ -44,7 +44,7 @@ func (a *envoyAdminClient) get(path string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := safeio.ReadAllLimit(resp.Body, safeio.MB)
+	body, err := safeio.ReadAllLimit(resp.Body, 100*safeio.MB)
 	if err != nil {
 		return "", fmt.Errorf("failed to read %q response: %w", path, err)
 	}


### PR DESCRIPTION
Currently, fetching the Envoy metrics via `cilium-dbg envoy admin metrics` can end up easily with the following exception.

```
/home/cilium# cilium-dbg envoy admin metrics
Error: cannot get metrics: failed to read "stats/prometheus" response: read limit reached
```

The reason is the current limit of 1MB when reading the response body with `safeio.ReadAllLimit`.

Therefore, this commit is increasing the limit to `100MB`.