### PR TITLE
[WIP] [IPsec] Support Decryption of VXLAN-in-ESP and ESP-in-VXLAN traffic

### DIFF
--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -227,6 +227,7 @@ func (n *linuxNodeHandler) enableIPSecIPv4DoSubnetEncryption(newNode *nodeTypes.
 		params.DestSubnet = wildcardCIDR
 		params.SourceTunnelIP = &net.IP{}
 		params.DestTunnelIP = &localIP
+		params.Optional = true
 		spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
 		errs = errors.Join(errs, upsertIPsecLog(n.log, err, "fwd IPv4", params.SourceSubnet, params.DestSubnet, spi, nodeID))
 
@@ -305,6 +306,7 @@ func (n *linuxNodeHandler) enableIPSecIPv4Do(newNode *nodeTypes.Node, nodeID uin
 	params.DestSubnet = wildcardCIDR
 	params.SourceTunnelIP = &net.IP{}
 	params.DestTunnelIP = &localIP
+	params.Optional = true
 	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
 	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "fwd IPv4", params.SourceSubnet, params.DestSubnet, spi, nodeID))
 
@@ -375,6 +377,7 @@ func (n *linuxNodeHandler) enableIPSecIPv4Do(newNode *nodeTypes.Node, nodeID uin
 	params.DestSubnet = wildcardCIDR
 	params.SourceTunnelIP = &net.IP{}
 	params.DestTunnelIP = &localUnderlayIP
+	params.Optional = true
 	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
 	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "fwd IPv4", params.SourceSubnet, params.DestSubnet, spi, nodeID))
 
@@ -474,6 +477,7 @@ func (n *linuxNodeHandler) enableIPSecIPv6DoSubnetEncryption(newNode *nodeTypes.
 		params.DestSubnet = wildcardCIDR6
 		params.SourceTunnelIP = &net.IP{}
 		params.DestTunnelIP = &localIP
+		params.Optional = true
 		spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
 		errs = errors.Join(errs, upsertIPsecLog(n.log, err, "fwd IPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
 		if err != nil {
@@ -554,6 +558,7 @@ func (n *linuxNodeHandler) enableIPSecIPv6Do(newNode *nodeTypes.Node, nodeID uin
 	params.DestSubnet = wildcardCIDR6
 	params.SourceTunnelIP = &net.IP{}
 	params.DestTunnelIP = &localIP
+	params.Optional = true
 	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
 	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "fwd IPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
 	if err != nil {

--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -406,7 +406,7 @@ func (n *linuxNodeHandler) enableIPSecIPv4Do(newNode *nodeTypes.Node, nodeID uin
 	params.ReqID = ipsec.EncryptedOverlayReqID
 	params.Dir = ipsec.IPSecDirFwd
 	params.SourceSubnet = wildcardCIDR
-	params.DestSubnet = wildcardCIDR
+	params.DestSubnet = localOverlayIPExactMatch
 	params.SourceTunnelIP = &net.IP{}
 	params.DestTunnelIP = &localUnderlayIP
 	params.Optional = true

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -376,6 +376,7 @@ func TestUpsertIPSecEndpointFwd(t *testing.T) {
 		DestTunnelIP:   &local.IP,
 		ZeroOutputMark: false,
 		RemoteRebooted: false,
+		Optional:       true,
 		ReqID:          DefaultReqID,
 	}
 


### PR DESCRIPTION
This pull request implements the ability for a Cilium node to decrypt both ESP-in-VXLAN and VXLAN-in-ESP traffic. 

This change is motivated by the ultimate goal of moving to VXLAN-in-ESP traffic, which encryptions the security ID in the VXLAN header. 

A node must handle both traffic types for upgrade scenarios. 
For instance, during a roll-out a node may see ESP-in-VXLAN traffic (legacy node) along side VXLAN-in-ESP traffic (upgraded node). A node which has not been upgraded needs to handle both. 

To be clear, this PR introduces the ability for a node to handle both.
A later PR at a later release will actually implement the ESP-in-VXLAN traffic, such that the upgrade path will come naturally. 

```release-note
Updates XFRM policies to support the decryption of VXLAN-in-ESP traffic (encrypted overlay) 
```
