### PR TITLE
datapath: move policy map value prefix length to flags

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -394,11 +394,10 @@ struct policy_key {
 struct policy_entry {
 	__be16		proxy_port;
 	__u8		deny:1,
-			pad:7;
+			reserved:2, /* bits used in Cilium 1.16, keep unused for Cilium 1.17 */
+			lpm_prefix_length:5; /* map key protocol and dport prefix length */
 	__u8		auth_type;
-	__u8		lpm_prefix_length; /* map key protocol and dport prefix length */
-	__u8		pad1;
-	__u16		pad2;
+	__u32		pad1;
 	__u64		packets;
 	__u64		bytes;
 };

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1138,13 +1138,11 @@ func (e *Endpoint) syncPolicyMapWith(realized policy.MapState, withDiffs bool) (
 func (e *Endpoint) dumpPolicyMapToMapState() (policy.MapState, error) {
 	currentMap, insert := policy.NewMapStateWithInsert()
 
-	cb := func(key bpf.MapKey, value bpf.MapValue) {
-		policymapKey := key.(*policymap.PolicyKey)
+	cb := func(policymapKey *policymap.PolicyKey, policymapEntry *policymap.PolicyEntry) {
 		// Convert from policymap.Key to policy.Key
 		policyKey := policy.KeyForDirection(trafficdirection.TrafficDirection(policymapKey.TrafficDirection)).
 			WithIdentity(identity.NumericIdentity(policymapKey.Identity)).
 			WithPortProtoPrefix(u8proto.U8proto(policymapKey.Nexthdr), policymapKey.GetDestPort(), policymapKey.GetPortPrefixLen())
-		policymapEntry := value.(*policymap.PolicyEntry)
 		// Convert from policymap.PolicyEntry to policy.MapStateEntry.
 		policyEntry := policy.MapStateEntry{
 			ProxyPort: policymapEntry.GetProxyPort(),
@@ -1153,7 +1151,7 @@ func (e *Endpoint) dumpPolicyMapToMapState() (policy.MapState, error) {
 		}
 		insert(policyKey, policyEntry)
 	}
-	err := e.policyMap.DumpWithCallback(cb)
+	err := e.policyMap.DumpValid(cb)
 
 	return currentMap, err
 }

--- a/pkg/maps/policymap/policymap_test.go
+++ b/pkg/maps/policymap/policymap_test.go
@@ -296,20 +296,20 @@ func TestPolicyMapWildcarding(t *testing.T) {
 		require.Equal(t, uint8(tt.args.proto), key.Nexthdr)
 
 		// key and entry need to agree on the prefix length
-		require.Equal(t, StaticPrefixBits+uint32(entry.LPMPrefixLength), key.Prefixlen)
+		require.Equal(t, StaticPrefixBits+uint32(entry.GetPrefixLen()), key.Prefixlen)
 
 		if key.Nexthdr == 0 {
 			require.Equal(t, uint16(0), key.DestPortNetwork)
 			require.Equal(t, StaticPrefixBits, key.Prefixlen)
-			require.Equal(t, uint8(0), entry.LPMPrefixLength)
+			require.Equal(t, uint8(0), entry.GetPrefixLen())
 		} else {
 			if key.DestPortNetwork == 0 {
 				require.Equal(t, StaticPrefixBits+NexthdrBits, key.Prefixlen)
-				require.Equal(t, uint8(NexthdrBits), entry.LPMPrefixLength)
+				require.Equal(t, uint8(NexthdrBits), entry.GetPrefixLen())
 			} else {
 				require.Equal(t, uint16(tt.args.dport), byteorder.NetworkToHost16(key.DestPortNetwork))
 				require.Equal(t, StaticPrefixBits+NexthdrBits+uint32(tt.args.dportPrefixLen), key.Prefixlen)
-				require.Equal(t, uint8(NexthdrBits)+tt.args.dportPrefixLen, entry.LPMPrefixLength)
+				require.Equal(t, uint8(NexthdrBits)+tt.args.dportPrefixLen, entry.GetPrefixLen())
 			}
 		}
 	}


### PR DESCRIPTION
Move the prefix length field in the policy map value to the flags (same byte as 'deny') to a previously unused space. This cleans up padding space for future use.

Skip map entries with inconsistent prefix length field in value vs. key so that the entry will be rewritten with the correct prefix length field in the value. This fixes a potential issue in upgrade where a policy map entry may remain with zero valued prefix length in value leading to incorrect policy enforcement.

Fixes: #35150
