### PR TITLE
Make triggers less garbage intensive

### DIFF
--- a/pkg/trigger/trigger_test.go
+++ b/pkg/trigger/trigger_test.go
@@ -118,3 +118,19 @@ func TestShutdownFunc(t *testing.T) {
 		t.Errorf("timed out while waiting for shutdown func")
 	}
 }
+
+func BenchmarkUntriggeredTrigger(b *testing.B) {
+	b.ReportAllocs()
+
+	for range b.N {
+		tr, err := NewTrigger(Parameters{
+			TriggerFunc:   func(reasons []string) {},
+			ShutdownFunc:  func() {},
+			sleepInterval: time.Millisecond,
+		})
+		require.NoError(b, err)
+
+		time.Sleep(time.Millisecond * 50)
+		tr.Shutdown()
+	}
+}


### PR DESCRIPTION
The trigger waiter loop would allocate a `time.Timer` (via `inctimer.After`) per `sleepInterval` (1s) if not triggered, creating a bit of unnecessary garbage for the GC to collect.

Please see commit messages - we introduce a benchmark in the first commit, and improve it in the second commit.
