### PR TITLE
ipsec: guard vxlan-in-esp policies by routing mode correctly.

### DIFF
--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -320,7 +320,7 @@ func (n *linuxNodeHandler) enableIPSecIPv4Do(newNode *nodeTypes.Node, nodeID uin
 		statesUpdated = false
 	}
 
-	if n.datapathConfig.TunnelDevice == "" {
+	if n.nodeConfig.RoutingMode != option.RoutingModeTunnel {
 		return statesUpdated, errs
 	}
 

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -99,5 +99,6 @@ func newLocalNodeConfig(
 		IPv4PodSubnets:               cidr.NewCIDRSlice(config.IPv4PodSubnets),
 		IPv6PodSubnets:               cidr.NewCIDRSlice(config.IPv6PodSubnets),
 		XDPConfig:                    xdpConfig,
+		RoutingMode:                  config.RoutingMode,
 	}, common.MergeChannels(devsWatch, addrsWatch, directRoutingDevWatch, mtuWatch), nil
 }

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -174,6 +174,10 @@ type LocalNodeConfiguration struct {
 	// XDPConfig holds configuration options to determine how the node should
 	// handle XDP programs.
 	XDPConfig xdp.Config
+
+	// RoutingMode is the current routing mode of the local node.
+	// Can be 'native' or 'tunnel'.
+	RoutingMode string
 }
 
 func (cfg *LocalNodeConfiguration) DeviceNames() []string {

--- a/pkg/datapath/types/zz_generated.deepequal.go
+++ b/pkg/datapath/types/zz_generated.deepequal.go
@@ -255,5 +255,9 @@ func (in *LocalNodeConfiguration) DeepEqual(other *LocalNodeConfiguration) bool 
 		return false
 	}
 
+	if in.RoutingMode != other.RoutingMode {
+		return false
+	}
+
 	return true
 }


### PR DESCRIPTION
See commit message for details. 

```release-note
Fix a potential issue where VXLAN-in-ESP policies are installed erroneously when EGW is enabled. 
```
