### PR TITLE
cilium: add probe for netkit for more user friendly error when not supported

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -253,6 +253,16 @@ to change the packet scheduling algorithm.
 
         CONFIG_NET_SCH_FQ=m
 
+Requirements for Netkit Device Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :ref:`netkit` requires the following kernel configuration option
+to create netkit devices.
+
+::
+
+        CONFIG_NETKIT=y
+
 .. _advanced_features:
 
 Required Kernel Versions for Advanced Features

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1273,6 +1273,9 @@ func initEnv(vp *viper.Viper) {
 		// before netkit and supporting legacy tc in this context does
 		// not make any sense whatsoever.
 		option.Config.EnableTCX = true
+		if err := probes.HaveNetkit(); err != nil {
+			log.Fatal("netkit devices need kernel 6.7.0 or newer and CONFIG_NETKIT")
+		}
 	case datapathOption.DatapathModeLBOnly:
 		log.Info("Running in LB-only mode")
 		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -469,6 +469,51 @@ var HaveTCX = sync.OnceValue(func() error {
 	})
 })
 
+// HaveNetkit returns nil if the running kernel supports attaching bpf programs
+// to netkit devices.
+var HaveNetkit = sync.OnceValue(func() error {
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Type: ebpf.SchedCLS,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		License: "Apache-2.0",
+	})
+	if err != nil {
+		return err
+	}
+	defer prog.Close()
+
+	ns, err := netns.New()
+	if err != nil {
+		return fmt.Errorf("create netns: %w", err)
+	}
+	defer ns.Close()
+
+	return ns.Do(func() error {
+		l, err := link.AttachNetkit(link.NetkitOptions{
+			Program:   prog,
+			Attach:    ebpf.AttachNetkitPrimary,
+			Interface: int(^uint32(0)),
+		})
+		// We rely on this being checked during the syscall. With
+		// an otherwise correct payload we expect ENODEV here as
+		// an indication that the feature is present.
+		if errors.Is(err, unix.ENODEV) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("creating link: %w", err)
+		}
+		if err := l.Close(); err != nil {
+			return fmt.Errorf("closing link: %w", err)
+		}
+
+		return fmt.Errorf("unexpected success: %w", err)
+	})
+})
+
 // HaveOuterSourceIPSupport tests whether the kernel support setting the outer
 // source IP address via the bpf_skb_set_tunnel_key BPF helper. We can't rely
 // on the verifier to reject a program using the new support because the

--- a/pkg/datapath/linux/probes/probes_test.go
+++ b/pkg/datapath/linux/probes/probes_test.go
@@ -344,3 +344,12 @@ func TestHaveTCX(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestHaveNetkit(t *testing.T) {
+	testutils.PrivilegedTest(t)
+	testutils.SkipOnOldKernel(t, "6.7", "netkit bpf_link")
+
+	if err := HaveNetkit(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
(see commits)