### PR TITLE
renovate: Fix image updates for IPsec workflows

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,7 @@
     ".github/actions/ginkgo/**",
     ".github/actions/lvh-kind/**",
     ".github/actions/set-env-variables/action.yml",
+    ".github/actions/ipsec/configs.yml",
     ".github/workflows/**",
     ".github/ISSUE_TEMPLATE/bug_report.yaml",
     "cilium-cli/**",
@@ -717,7 +718,8 @@
     {
       "fileMatch": [
         "^\\.github/workflows/[^/]+\\.ya?ml$",
-        "^\\.github/actions/ginkgo/[^/]+\\.ya?ml$"
+        "^\\.github/actions/ginkgo/[^/]+\\.ya?ml$",
+        "^\\.github/actions/ipsec/[^/]+\\.ya?ml$"
       ],
       // This regex manages version strings in GitHub actions workflow files,
       // similar to the examples shown here:


### PR DESCRIPTION
The matrix configs for the two IPsec workflows were moved from the workflow themselves to a dedicated file in commit 06cfdb4b107b ("workflows: Generate IPsec matrix from config file").

We thus need to update the Renovate configuration such that it will know to look in the new, dedicated file with the configs and kernel versions.

Fixes: https://github.com/cilium/cilium/pull/35323.