### PR TITLE
docs: tuning: XDP LB also supports tunnel routing

### DIFF
--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -660,7 +660,6 @@ is dramatically increased. The kube-proxy replacement at the XDP layer is
 
 * Kernel >= 4.19.57, >= 5.1.16, >= 5.2
 * Native XDP supported driver, check :ref:`our driver list <XDP acceleration>`
-* Direct-routing configuration
 * eBPF-based kube-proxy replacement
 
 To enable the XDP Acceleration, check out :ref:`our getting started guide <XDP acceleration>` which also contains instructions for setting it


### PR DESCRIPTION
Tunnel routing support for the XDP LB was added back in v1.14, update the docs. This was missed in https://github.com/cilium/cilium/pull/27091.