### PR TITLE
docs: clean up stale kernel requirements

### DIFF
--- a/Documentation/network/kubernetes/bandwidth-manager.rst
+++ b/Documentation/network/kubernetes/bandwidth-manager.rst
@@ -47,10 +47,6 @@ bandwidth usage on the wire, and the node has already spent resources on
 processing the packet. ``kubernetes.io/ingress-bandwidth`` annotation is ignored
 by Cilium's bandwidth manager.
 
-.. note::
-
-   Bandwidth Manager requires a v5.1.x or more recent Linux kernel.
-
 .. include:: ../../installation/k8s-install-download-release.rst
 
 Cilium's bandwidth manager is disabled by default on new installations.

--- a/Documentation/network/kubernetes/local-redirect-policy.rst
+++ b/Documentation/network/kubernetes/local-redirect-policy.rst
@@ -38,15 +38,9 @@ the redirection.
 Prerequisites
 =============
 
-.. note::
-
-   Local Redirect Policy feature requires a v4.19.x or more recent Linux kernel.
-
 .. include:: ../../installation/k8s-install-download-release.rst
 
-The Cilium Local Redirect Policy feature relies on :ref:`kubeproxy-free`,
-follow the guide to create a new deployment. Enable the feature by setting
-the ``localRedirectPolicy`` value to ``true``.
+Enable the feature by setting the ``localRedirectPolicy`` value to ``true``.
 
 .. parsed-literal::
 

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -560,7 +560,6 @@ settings for the networking stack.
 
 **Requirements:**
 
-* Kernel >= 5.1
 * Direct-routing configuration or tunneling
 * eBPF-based kube-proxy replacement
 

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -265,7 +265,6 @@ enabled by upgrading to more recent kernel versions as detailed below.
 ====================================================== ===============================
 Cilium Feature                                         Minimum Kernel Version
 ====================================================== ===============================
-:ref:`bandwidth-manager`                               >= 5.1
 :ref:`egress-gateway`                                  >= 5.2
 VXLAN Tunnel Endpoint (VTEP) Integration               >= 5.2
 :ref:`encryption_wg`                                   >= 5.6

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -265,8 +265,6 @@ enabled by upgrading to more recent kernel versions as detailed below.
 ====================================================== ===============================
 Cilium Feature                                         Minimum Kernel Version
 ====================================================== ===============================
-:ref:`egress-gateway`                                  >= 5.2
-VXLAN Tunnel Endpoint (VTEP) Integration               >= 5.2
 :ref:`encryption_wg`                                   >= 5.6
 Full support for :ref:`session-affinity`               >= 5.7
 BPF-based proxy redirection                            >= 5.7


### PR DESCRIPTION
With Cilium v1.16 we raised & clarified the minimum kernel requirement, adjust the docs accordingly.