### PR TITLE
Limit FQDNS match name and pattern expressions to 255 characters

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -361,6 +361,7 @@ spec:
                             description: |-
                               MatchName matches literal DNS names. A trailing "." is automatically added
                               when missing.
+                            maxLength: 255
                             pattern: ^([-a-zA-Z0-9_]+[.]?)+$
                             type: string
                           matchPattern:
@@ -382,6 +383,7 @@ spec:
                               begins with "sub"
                                 sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
                                 blog.cilium.io, cilium.io and google.com do not
+                            maxLength: 255
                             pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                             type: string
                         type: object
@@ -673,6 +675,7 @@ spec:
                                       description: |-
                                         MatchName matches literal DNS names. A trailing "." is automatically added
                                         when missing.
+                                      maxLength: 255
                                       pattern: ^([-a-zA-Z0-9_]+[.]?)+$
                                       type: string
                                     matchPattern:
@@ -694,6 +697,7 @@ spec:
                                         begins with "sub"
                                           sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
                                           blog.cilium.io, cilium.io and google.com do not
+                                      maxLength: 255
                                       pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                                       type: string
                                   type: object
@@ -2387,6 +2391,7 @@ spec:
                                       description: |-
                                         MatchName matches literal DNS names. A trailing "." is automatically added
                                         when missing.
+                                      maxLength: 255
                                       pattern: ^([-a-zA-Z0-9_]+[.]?)+$
                                       type: string
                                     matchPattern:
@@ -2408,6 +2413,7 @@ spec:
                                         begins with "sub"
                                           sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
                                           blog.cilium.io, cilium.io and google.com do not
+                                      maxLength: 255
                                       pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                                       type: string
                                   type: object
@@ -3555,6 +3561,7 @@ spec:
                               description: |-
                                 MatchName matches literal DNS names. A trailing "." is automatically added
                                 when missing.
+                              maxLength: 255
                               pattern: ^([-a-zA-Z0-9_]+[.]?)+$
                               type: string
                             matchPattern:
@@ -3576,6 +3583,7 @@ spec:
                                 begins with "sub"
                                   sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
                                   blog.cilium.io, cilium.io and google.com do not
+                              maxLength: 255
                               pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                               type: string
                           type: object
@@ -3867,6 +3875,7 @@ spec:
                                         description: |-
                                           MatchName matches literal DNS names. A trailing "." is automatically added
                                           when missing.
+                                        maxLength: 255
                                         pattern: ^([-a-zA-Z0-9_]+[.]?)+$
                                         type: string
                                       matchPattern:
@@ -3888,6 +3897,7 @@ spec:
                                           begins with "sub"
                                             sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
                                             blog.cilium.io, cilium.io and google.com do not
+                                        maxLength: 255
                                         pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                                         type: string
                                     type: object
@@ -5583,6 +5593,7 @@ spec:
                                         description: |-
                                           MatchName matches literal DNS names. A trailing "." is automatically added
                                           when missing.
+                                        maxLength: 255
                                         pattern: ^([-a-zA-Z0-9_]+[.]?)+$
                                         type: string
                                       matchPattern:
@@ -5604,6 +5615,7 @@ spec:
                                           begins with "sub"
                                             sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
                                             blog.cilium.io, cilium.io and google.com do not
+                                        maxLength: 255
                                         pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                                         type: string
                                     type: object

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -364,6 +364,7 @@ spec:
                             description: |-
                               MatchName matches literal DNS names. A trailing "." is automatically added
                               when missing.
+                            maxLength: 255
                             pattern: ^([-a-zA-Z0-9_]+[.]?)+$
                             type: string
                           matchPattern:
@@ -385,6 +386,7 @@ spec:
                               begins with "sub"
                                 sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
                                 blog.cilium.io, cilium.io and google.com do not
+                            maxLength: 255
                             pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                             type: string
                         type: object
@@ -676,6 +678,7 @@ spec:
                                       description: |-
                                         MatchName matches literal DNS names. A trailing "." is automatically added
                                         when missing.
+                                      maxLength: 255
                                       pattern: ^([-a-zA-Z0-9_]+[.]?)+$
                                       type: string
                                     matchPattern:
@@ -697,6 +700,7 @@ spec:
                                         begins with "sub"
                                           sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
                                           blog.cilium.io, cilium.io and google.com do not
+                                      maxLength: 255
                                       pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                                       type: string
                                   type: object
@@ -2390,6 +2394,7 @@ spec:
                                       description: |-
                                         MatchName matches literal DNS names. A trailing "." is automatically added
                                         when missing.
+                                      maxLength: 255
                                       pattern: ^([-a-zA-Z0-9_]+[.]?)+$
                                       type: string
                                     matchPattern:
@@ -2411,6 +2416,7 @@ spec:
                                         begins with "sub"
                                           sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
                                           blog.cilium.io, cilium.io and google.com do not
+                                      maxLength: 255
                                       pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                                       type: string
                                   type: object
@@ -3558,6 +3564,7 @@ spec:
                               description: |-
                                 MatchName matches literal DNS names. A trailing "." is automatically added
                                 when missing.
+                              maxLength: 255
                               pattern: ^([-a-zA-Z0-9_]+[.]?)+$
                               type: string
                             matchPattern:
@@ -3579,6 +3586,7 @@ spec:
                                 begins with "sub"
                                   sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
                                   blog.cilium.io, cilium.io and google.com do not
+                              maxLength: 255
                               pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                               type: string
                           type: object
@@ -3870,6 +3878,7 @@ spec:
                                         description: |-
                                           MatchName matches literal DNS names. A trailing "." is automatically added
                                           when missing.
+                                        maxLength: 255
                                         pattern: ^([-a-zA-Z0-9_]+[.]?)+$
                                         type: string
                                       matchPattern:
@@ -3891,6 +3900,7 @@ spec:
                                           begins with "sub"
                                             sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
                                             blog.cilium.io, cilium.io and google.com do not
+                                        maxLength: 255
                                         pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                                         type: string
                                     type: object
@@ -5586,6 +5596,7 @@ spec:
                                         description: |-
                                           MatchName matches literal DNS names. A trailing "." is automatically added
                                           when missing.
+                                        maxLength: 255
                                         pattern: ^([-a-zA-Z0-9_]+[.]?)+$
                                         type: string
                                       matchPattern:
@@ -5607,6 +5618,7 @@ spec:
                                           begins with "sub"
                                             sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
                                             blog.cilium.io, cilium.io and google.com do not
+                                        maxLength: 255
                                         pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                                         type: string
                                     type: object

--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -38,6 +38,7 @@ type FQDNSelector struct {
 	// MatchName matches literal DNS names. A trailing "." is automatically added
 	// when missing.
 	//
+	// +kubebuilder:validation:MaxLength=255
 	// +kubebuilder:validation:Pattern=`^([-a-zA-Z0-9_]+[.]?)+$`
 	// +kubebuilder:validation:OneOf
 	MatchName string `json:"matchName,omitempty"`
@@ -60,6 +61,7 @@ type FQDNSelector struct {
 	//   sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
 	//   blog.cilium.io, cilium.io and google.com do not
 	//
+	// +kubebuilder:validation:MaxLength=255
 	// +kubebuilder:validation:Pattern=`^([-a-zA-Z0-9_*]+[.]?)+$`
 	// +kubebuilder:validation:OneOf
 	MatchPattern string `json:"matchPattern,omitempty"`


### PR DESCRIPTION
DNS names are limited to 255 chars: https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.4 
DNS match pattern rules that are excessively long could cause Cilium agent to take a long time to process the rules. This change adds a strict limit of 255 to matchName and configurable limit to matchPattern with default 63.

Ref #21491

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #21491

```release-note
Limit FQDNS matchName and matchPattern length to 255 characters
```
