### PR TITLE
CODEOWNERS: let cilium/ipsec cover .github/actions/ipsec

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -235,6 +235,7 @@
 /.github/ariane-config.yaml @cilium/github-sec @cilium/ci-structure
 /.github/renovate.json5 @cilium/github-sec @cilium/ci-structure
 /.github/actions/ @cilium/github-sec @cilium/ci-structure
+/.github/actions/ipsec/ @cilium/ipsec @cilium/github-sec @cilium/ci-structure
 /.github/actions/kvstore/ @cilium/sig-clustermesh @cilium/kvstore @cilium/github-sec @cilium/ci-structure
 /.github/workflows/ @cilium/github-sec @cilium/ci-structure
 /.github/workflows/auto-approve.yaml @cilium/cilium-maintainers


### PR DESCRIPTION
Added by https://github.com/cilium/cilium/pull/35323.