### PR TITLE
workflows/gateway-api: Cover IPsec with GatewayAPI

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -324,6 +324,17 @@ jobs:
             | tparse -progress
           fi
 
+      - name: Run basic CLI tests (${{ join(matrix.*, ', ') }})
+        shell: bash
+        run: |
+          mkdir -p cilium-junits
+          cilium connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
+            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+            --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
+            --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
+            --test 'allow-all-except-world,encryption,packet-drops'
+
       - name: Upload report artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -344,7 +344,7 @@ jobs:
         if: ${{ !success() }}
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: cilium-sysdump-out-${{ matrix.conformance-profile }}-${{ matrix.crd-channel }}
+          name: cilium-sysdump-out-${{ join(matrix.*, '-') }}
           path: cilium-sysdump-out-*.zip
           retention-days: 5
 

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -113,6 +113,9 @@ jobs:
           conformance-profile: false
         - crd-channel: experimental
           conformance-profile: true
+        - crd-channel: standard
+          conformance-profile: false
+          encryption: ipsec
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
@@ -220,7 +223,15 @@ jobs:
       - name: Install Cilium
         id: install-cilium
         run: |
-          cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
+          cilium_install_defaults="${{ steps.vars.outputs.cilium_install_defaults }}"
+          if [ ${{ matrix.encryption }} == "ipsec" ]; then
+            kubectl create -n kube-system secret generic cilium-ipsec-keys \
+              --from-literal=keys="3 rfc4106(gcm(aes)) $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64) 128"
+            cilium_install_defaults+=" --helm-set=encryption.enabled=true \
+              --helm-set=encryption.type=ipsec"
+          fi
+
+          cilium install $cilium_install_defaults
 
       - name: Wait for Cilium status to be ready
         run: |


### PR DESCRIPTION
First commit adds coverage for IPsec as a new matrix config. Second commit fixes an issue with the sysdump filenames. Last commit adds a few basic CLI tests to catch potential IPsec bugs.