### PR TITLE
v1.15 Backports 2024-10-28

### DIFF
--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -183,7 +183,6 @@ jobs:
           # KubeProxy|kube-proxy : kube-proxy specifics
           # LoadBalancer|GCE|ExternalIP : require a cloud provider, some of them are GCE specifics
           # Netpol|NetworkPolicy : network policies, demand significant resources and use to be slow, better to run in a different job
-          # Aggregator : Flaky, https://github.com/cilium/cilium/issues/24622.
           # same.port.number.but.different.protocols|HostPort|should.serve.endpoints.on.same.port.and.different.protocols : #9207
           # rejected : Kubernetes expect Services without endpoints associated to REJECT the connection to notify the client, Cilium silently drops the packet
           # externalTrafficPolicy : needs investigation
@@ -193,7 +192,7 @@ jobs:
           export E2E_REPORT_DIR=${PWD}/_artifacts
           /usr/local/bin/ginkgo --nodes=25                \
             --focus="\[Conformance\]|\[sig-network\]"     \
-            --skip="Feature|Federation|PerformanceDNS|DualStack|Disruptive|Serial|KubeProxy|kube-proxy|ExternalIP|LoadBalancer|GCE|Netpol|NetworkPolicy|Aggregator|rejected|externalTrafficPolicy|HostPort|same.port.number.but.different.protocols|should.serve.endpoints.on.same.port.and.different.protocols"   \
+            --skip="Feature|Federation|PerformanceDNS|DualStack|Disruptive|Serial|KubeProxy|kube-proxy|ExternalIP|LoadBalancer|GCE|Netpol|NetworkPolicy|rejected|externalTrafficPolicy|HostPort|same.port.number.but.different.protocols|should.serve.endpoints.on.same.port.and.different.protocols"   \
             /usr/local/bin/e2e.test                       \
             --                                            \
             --kubeconfig=${PWD}/_artifacts/kubeconfig.conf     \

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -330,7 +330,6 @@ is dramatically increased. The kube-proxy replacement at the XDP layer is
 
 * Kernel >= 4.19.57, >= 5.1.16, >= 5.2
 * Native XDP supported driver, check :ref:`our driver list <XDP acceleration>`
-* Direct-routing configuration
 * eBPF-based kube-proxy replacement
 
 To enable the XDP Acceleration, check out :ref:`our getting started guide <XDP acceleration>` which also contains instructions for setting it

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -12,6 +12,19 @@
 #include "l3.h"
 
 static __always_inline int
+add_l2_hdr(struct __ctx_buff *ctx __maybe_unused)
+{
+	__u16 proto = ctx_get_protocol(ctx);
+
+	if (ctx_change_head(ctx, __ETH_HLEN, 0))
+		return DROP_INVALID;
+	if (eth_store_proto(ctx, proto, 0) < 0)
+		return DROP_WRITE_ERROR;
+
+	return 0;
+}
+
+static __always_inline int
 maybe_add_l2_hdr(struct __ctx_buff *ctx __maybe_unused,
 		 __u32 ifindex __maybe_unused,
 		 bool *l2_hdr_required __maybe_unused)
@@ -25,12 +38,7 @@ maybe_add_l2_hdr(struct __ctx_buff *ctx __maybe_unused,
 		/* The packet is going to be redirected from L3 to L2
 		 * device, so we need to create L2 header first.
 		 */
-		__u16 proto = ctx_get_protocol(ctx);
-
-		if (ctx_change_head(ctx, __ETH_HLEN, 0))
-			return DROP_INVALID;
-		if (eth_store_proto(ctx, proto, 0) < 0)
-			return DROP_WRITE_ERROR;
+		return add_l2_hdr(ctx);
 	}
 	return 0;
 }

--- a/bpf/tests/tc_nodeport_l3_dev_lb_dsr_geneve_lb.c
+++ b/bpf/tests/tc_nodeport_l3_dev_lb_dsr_geneve_lb.c
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ETH_HLEN		0
+#define ENABLE_IPV4		1
+#define ENABLE_IPV6		1
+#define ENABLE_NODEPORT		1
+#define ENABLE_DSR		1
+#define DSR_ENCAP_IPIP		2
+#define DSR_ENCAP_GENEVE	3
+#define DSR_ENCAP_MODE		DSR_ENCAP_GENEVE
+#define ENCAP_IFINDEX		42
+
+#define DISABLE_LOOPBACK_LB	1
+
+#define CLIENT_IP		v4_ext_one
+#define CLIENT_IPV6		{ .addr = { 0x1, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+#define CLIENT_PORT		__bpf_htons(111)
+
+#define FRONTEND_IP		v4_svc_one
+#define FRONTEND_IPV6		{ .addr = { 0x5, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+#define FRONTEND_PORT		tcp_svc_one
+
+#define BACKEND_IP		v4_pod_one
+#define BACKEND_IPV6		{ .addr = { 0x3, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+#define BACKEND_PORT		__bpf_htons(8080)
+
+#define REMOTE_NODE_IP		v4_node_one
+
+static volatile const __u8 *client_mac = mac_one;
+/* this matches the default node_config.h: */
+static volatile const __u8 lb_mac[ETH_ALEN] = { 0xce, 0x72, 0xa7, 0x03, 0x88, 0x56 };
+
+#define ctx_redirect mock_ctx_redirect
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
+{
+	if (ifindex != ENCAP_IFINDEX)
+		return -1;
+
+	return CTX_ACT_REDIRECT;
+}
+
+#define SECCTX_FROM_IPCACHE 1
+
+#include <bpf_host.c>
+
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+
+#define FROM_NETDEV	0
+#define TO_NETDEV	1
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 2);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_from_netdev,
+		[TO_NETDEV] = &cil_to_netdev,
+	},
+};
+
+/* Test that a SVC request that is LBed to a DSR remote backend
+ * - gets DNATed,
+ * - has IP Option inserted,
+ * - gets redirected back out by TC
+ */
+PKTGEN("tc", "ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd")
+int ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)lb_mac,
+					  CLIENT_IP, FRONTEND_IP,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd")
+int ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd_setup(struct __ctx_buff *ctx)
+{
+	void *data = (void *)(long)ctx->data;
+	void *data_end = (void *)(long)ctx->data_end;
+	__u64 flags = BPF_F_ADJ_ROOM_FIXED_GSO;
+	__u16 revnat_id = 1;
+
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, 1, revnat_id);
+	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, 1, 124,
+			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, REMOTE_NODE_IP, 0);
+
+	/* Strip L2 header to emulate L3 packet: */
+	if ((void *)data + __ETH_HLEN + __ETH_HLEN <= data_end)
+		memcpy(data, data + __ETH_HLEN, __ETH_HLEN);
+
+	skb_adjust_room(ctx, -__ETH_HLEN, BPF_ADJ_ROOM_MAC, flags);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd")
+int ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd_check(__maybe_unused struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(*l3);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != BACKEND_IP)
+		test_fatal("dst IP hasn't been NATed to remote backend IP");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been NATed to backend port");
+
+	test_finish();
+}
+
+/* Test that a SVC request that is LBed to a DSR remote backend
+ * - gets DNATed,
+ * - has IPv6 Extension inserted,
+ * - gets redirected back out by TC
+ */
+PKTGEN("tc", "ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd")
+int ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd_pktgen(struct __ctx_buff *ctx)
+{
+	union v6addr frontend_ip = FRONTEND_IPV6;
+	union v6addr client_ip = CLIENT_IPV6;
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)lb_mac,
+					  (__u8 *)&client_ip, (__u8 *)&frontend_ip,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd")
+int ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd_setup(struct __ctx_buff *ctx)
+{
+	void *data = (void *)(long)ctx->data;
+	void *data_end = (void *)(long)ctx->data_end;
+	__u64 flags = BPF_F_ADJ_ROOM_FIXED_GSO;
+	union v6addr frontend_ip = FRONTEND_IPV6;
+	union v6addr backend_ip = BACKEND_IPV6;
+	__u16 revnat_id = 1;
+
+	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, 1, revnat_id);
+	lb_v6_add_backend(&frontend_ip, FRONTEND_PORT, 1, 124,
+			  &backend_ip, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	ipcache_v6_add_entry(&backend_ip, 0, 112233, REMOTE_NODE_IP, 0);
+
+	/* Strip L2 header to emulate L3 packet: */
+	if ((void *)data + __ETH_HLEN + __ETH_HLEN <= data_end)
+		memcpy(data, data + __ETH_HLEN, __ETH_HLEN);
+
+	skb_adjust_room(ctx, -__ETH_HLEN, BPF_ADJ_ROOM_MAC, flags);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd")
+int ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd_check(__maybe_unused struct __ctx_buff *ctx)
+{
+	union v6addr backend_ip = BACKEND_IPV6;
+	union v6addr client_ip = CLIENT_IPV6;
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(*l3);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (!ipv6_addr_equals((union v6addr *)&l3->saddr, &client_ip))
+		test_fatal("src IP has changed");
+	if (!ipv6_addr_equals((union v6addr *)&l3->daddr, &backend_ip))
+		test_fatal("dst IP hasn't been NATed to remote backend IP");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been NATed to backend port");
+
+	test_finish();
+}

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -9,7 +9,7 @@ ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:a7339df5934d72e975c128441
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with
 # TARGETARCH
-FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} AS builder
+FROM --platform=${BUILDPLATFORM} ${CILIUM_BUILDER_IMAGE} AS builder
 
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -507,7 +507,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 	// Reinstall proxy rules for any running proxies if needed
 	if option.Config.EnableL7Proxy {
-		if err := p.ReinstallRoutingRules(); err != nil {
+		if err := p.ReinstallRoutingRules(o.LocalConfig().MtuConfig.GetRouteMTU()); err != nil {
 			return err
 		}
 

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -46,7 +46,7 @@ type PreFilter interface {
 // Proxy is any type which installs rules related to redirecting traffic to
 // a proxy.
 type Proxy interface {
-	ReinstallRoutingRules() error
+	ReinstallRoutingRules(mtu int) error
 	ReinstallIPTablesRules(ctx context.Context) error
 }
 

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -1268,8 +1268,8 @@ func bindToAddr(address string, port uint16, handler dns.Handler, ipv4, ipv6 boo
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to listen on %s: %w", ipFamily.UDPAddress, err)
 		}
-		sessionUDPFactory, ferr := NewSessionUDPFactory(ipFamily)
-		if ferr != nil {
+		sessionUDPFactory, err := NewSessionUDPFactory(ipFamily)
+		if err != nil {
 			return nil, 0, fmt.Errorf("failed to create UDP session factory for %s: %w", ipFamily.UDPAddress, err)
 		}
 		dnsServers = append(dnsServers, &dns.Server{

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -419,8 +419,13 @@ func (p *Proxy) SetProxyPort(name string, proxyType types.ProxyType, port uint16
 
 // ReinstallRoutingRules ensures the presence of routing rules and tables needed
 // to route packets to and from the L7 proxy.
-func (p *Proxy) ReinstallRoutingRules() error {
+func (p *Proxy) ReinstallRoutingRules(mtu int) error {
 	fromIngressProxy, fromEgressProxy := requireFromProxyRoutes()
+
+	// Use the provided mtu (RouteMTU) only with both ingress and egress proxy.
+	if !fromIngressProxy || !fromEgressProxy {
+		mtu = 0
+	}
 
 	if option.Config.EnableIPv4 {
 		if err := installToProxyRoutesIPv4(); err != nil {
@@ -428,7 +433,7 @@ func (p *Proxy) ReinstallRoutingRules() error {
 		}
 
 		if fromIngressProxy || fromEgressProxy {
-			if err := installFromProxyRoutesIPv4(node.GetInternalIPv4Router(), defaults.HostDevice, fromIngressProxy, fromEgressProxy); err != nil {
+			if err := installFromProxyRoutesIPv4(node.GetInternalIPv4Router(), defaults.HostDevice, fromIngressProxy, fromEgressProxy, mtu); err != nil {
 				return err
 			}
 		} else {
@@ -458,7 +463,7 @@ func (p *Proxy) ReinstallRoutingRules() error {
 			if err != nil {
 				return err
 			}
-			if err := installFromProxyRoutesIPv6(ipv6, defaults.HostDevice, fromIngressProxy, fromEgressProxy); err != nil {
+			if err := installFromProxyRoutesIPv6(ipv6, defaults.HostDevice, fromIngressProxy, fromEgressProxy, mtu); err != nil {
 				return err
 			}
 		} else {

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -123,7 +123,7 @@ var (
 
 // installFromProxyRoutesIPv4 configures routes and rules needed to redirect ingress
 // packets from the proxy.
-func installFromProxyRoutesIPv4(ipv4 net.IP, device string, fromIngressProxy, fromEgressProxy bool) error {
+func installFromProxyRoutesIPv4(ipv4 net.IP, device string, fromIngressProxy, fromEgressProxy bool, mtu int) error {
 	fromProxyToCiliumHostRoute4 := route.Route{
 		Table: linux_defaults.RouteTableFromProxy,
 		Prefix: net.IPNet{
@@ -139,6 +139,7 @@ func installFromProxyRoutesIPv4(ipv4 net.IP, device string, fromIngressProxy, fr
 		Nexthop: &ipv4,
 		Device:  device,
 		Proto:   linux_defaults.RTProto,
+		MTU:     mtu,
 	}
 
 	if fromIngressProxy {
@@ -183,7 +184,7 @@ func removeStaleProxyRulesIPv4() error {
 
 // installFromProxyRoutesIPv6 configures routes and rules needed to redirect ingress
 // packets from the proxy.
-func installFromProxyRoutesIPv6(ipv6 net.IP, device string, fromIngressProxy, fromEgressProxy bool) error {
+func installFromProxyRoutesIPv6(ipv6 net.IP, device string, fromIngressProxy, fromEgressProxy bool, mtu int) error {
 	fromProxyToCiliumHostRoute6 := route.Route{
 		Table: linux_defaults.RouteTableFromProxy,
 		Prefix: net.IPNet{
@@ -199,6 +200,7 @@ func installFromProxyRoutesIPv6(ipv6 net.IP, device string, fromIngressProxy, fr
 		Nexthop: &ipv6,
 		Device:  device,
 		Proto:   linux_defaults.RTProto,
+		MTU:     mtu,
 	}
 
 	if fromIngressProxy {

--- a/pkg/proxy/routes_test.go
+++ b/pkg/proxy/routes_test.go
@@ -5,17 +5,39 @@ package proxy
 
 import (
 	"net"
+	"slices"
 	"testing"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/netns"
 	"github.com/cilium/cilium/pkg/testutils"
 )
+
+const (
+	defaultMTU      = 0
+	withOverheadMTU = mtu.EthernetMTU - mtu.EncryptionIPsecOverhead
+)
+
+func filterDefaultRouteIPv4(t *testing.T, rt []netlink.Route) netlink.Route {
+	_, defaultDst4, _ := net.ParseCIDR("0.0.0.0/0")
+	i := slices.IndexFunc(rt, func(r netlink.Route) bool { return r.Dst.String() == defaultDst4.String() })
+	require.Greater(t, i, -1, "unable to retrieve default IPv4 route")
+	return rt[i]
+}
+
+func filterDefaultRouteIPv6(t *testing.T, rt []netlink.Route) netlink.Route {
+	_, defaultDst6, _ := net.ParseCIDR("::/0")
+	i := slices.IndexFunc(rt, func(r netlink.Route) bool { return r.Dst.String() == defaultDst6.String() })
+	require.Greater(t, i, -1, "unable to retrieve default IPv6 route")
+	return rt[i]
+}
 
 func TestRoutes(t *testing.T) {
 	testutils.PrivilegedTest(t)
@@ -86,7 +108,7 @@ func TestRoutes(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Install routes and rules the first time.
-				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName, true, true))
+				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName, true, true, defaultMTU))
 
 				rules, err := route.ListRules(netlink.FAMILY_V4, &fromIngressProxyRule)
 				assert.NoError(t, err)
@@ -98,10 +120,31 @@ func TestRoutes(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Len(t, rt, 2)
 
+				// Expect default route MTU set.
+				defaultRoute := filterDefaultRouteIPv4(t, rt)
+				assert.Equal(t, defaultMTU, defaultRoute.MTU)
+
 				// Ensure idempotence.
-				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName, true, true))
+				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName, true, true, defaultMTU))
 
 				// Remove routes installed before.
+				assert.NoError(t, removeFromProxyRoutesIPv4())
+
+				// Install routes and rules with non-default MTU -- this would happen with
+				// IPSec enabled and both ingress and egress policies in-place.
+				assert.NoError(t, installFromProxyRoutesIPv4(testIPv4, ifName, true, true, withOverheadMTU))
+
+				// Re-list the from proxy (2005) routing table, expect a single entry.
+				rt, err = netlink.RouteListFiltered(netlink.FAMILY_V4,
+					&netlink.Route{Table: linux_defaults.RouteTableFromProxy}, netlink.RT_FILTER_TABLE)
+				assert.NoError(t, err)
+				assert.Len(t, rt, 2)
+
+				// Expect default route to use the lower MTU.
+				defaultRoute = filterDefaultRouteIPv4(t, rt)
+				assert.Equal(t, withOverheadMTU, defaultRoute.MTU)
+
+				// Remove installed routes.
 				assert.NoError(t, removeFromProxyRoutesIPv4())
 
 				rules, err = route.ListRules(netlink.FAMILY_V4, &fromIngressProxyRule)
@@ -185,7 +228,7 @@ func TestRoutes(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Install routes and rules the first time.
-				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName, true, true))
+				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName, true, true, defaultMTU))
 
 				rules, err := route.ListRules(netlink.FAMILY_V6, &fromIngressProxyRule)
 				assert.NoError(t, err)
@@ -197,10 +240,31 @@ func TestRoutes(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Len(t, rt, 2)
 
+				// Expect default route MTU set.
+				defaultRoute := filterDefaultRouteIPv6(t, rt)
+				assert.Equal(t, defaultMTU, defaultRoute.MTU)
+
 				// Ensure idempotence.
-				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName, true, true))
+				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName, true, true, defaultMTU))
 
 				// Remove routes installed before.
+				assert.NoError(t, removeFromProxyRoutesIPv6())
+
+				// Install routes and rules with non-default MTU -- this would happen with
+				// IPSec enabled and both ingress and egress policies in-place.
+				assert.NoError(t, installFromProxyRoutesIPv6(testIPv6, ifName, true, true, withOverheadMTU))
+
+				// Re-list the from proxy (2005) routing table, expect a single entry.
+				rt, err = netlink.RouteListFiltered(netlink.FAMILY_V6,
+					&netlink.Route{Table: linux_defaults.RouteTableFromProxy}, netlink.RT_FILTER_TABLE)
+				assert.NoError(t, err)
+				assert.Len(t, rt, 2)
+
+				// Expect default route to use the lower MTU.
+				defaultRoute = filterDefaultRouteIPv6(t, rt)
+				assert.Equal(t, withOverheadMTU, defaultRoute.MTU)
+
+				// Remove installed routes.
 				assert.NoError(t, removeFromProxyRoutesIPv6())
 
 				rules, err = route.ListRules(netlink.FAMILY_V6, &fromIngressProxyRule)


### PR DESCRIPTION
 * [x] #33998 (@marseel)
 * [x] #35286 (@julianwiedmann) :warning: resolved conflicts
    - manually resolved conflict in skipped features
 * [x] #35165 (@julianwiedmann)
 * [x] #35351 (@learnitall)
 * [x] #35173 (@smagnani96) :warning: resolved conflicts
    - fixed MTU argument to `ReinstallRoutingRules` in `pkg/datapath/loader/base.go`
    - skipped changes in `cilium-cli`, as it is not present in the `v1.15` branch
 * [x] #35574 (@julianwiedmann)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 33998 35286 35165 35351 35173 35574
```
