### PR TITLE
iptables: always warn about missing xt_socket module

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -400,6 +400,8 @@ func (m *Manager) Start(ctx cell.HookContext) error {
 	}
 
 	if err := m.modulesMgr.FindOrLoadModules("xt_socket"); err != nil {
+		m.logger.WithError(err).Warning("xt_socket kernel module could not be loaded")
+
 		if !m.sharedCfg.TunnelingEnabled {
 			// xt_socket module is needed to circumvent an explicit drop in ip_forward()
 			// logic for packets for which a local socket is found by ip early
@@ -416,8 +418,6 @@ func (m *Manager) Start(ctx cell.HookContext) error {
 			// We would not need the xt_socket at all if the datapath universally would
 			// set the "to proxy" skb mark bits on before the packet hits policy routing
 			// stage. Currently this is not true for endpoint routing modes.
-			m.logger.WithError(err).Warning("xt_socket kernel module could not be loaded")
-
 			if m.sharedCfg.EnableXTSocketFallback {
 				m.disableIPEarlyDemux()
 			}


### PR DESCRIPTION
Be consistent in how we treat the xt_socket module - if we attempt to load it, then we should also warn about any error.