### PR TITLE
v1.16 Backports 2024-10-28

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/evanphx/json-patch v5.9.0+incompatible
 	github.com/fatih/color v1.17.0
 	github.com/fsnotify/fsnotify v1.7.0
+	github.com/go-logr/logr v1.4.1
 	github.com/go-openapi/errors v0.22.0
 	github.com/go-openapi/loads v0.22.0
 	github.com/go-openapi/runtime v0.28.0
@@ -183,7 +184,6 @@ require (
 	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/operator/pkg/controller-runtime/cell.go
+++ b/operator/pkg/controller-runtime/cell.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/bombsimon/logrusr/v4"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	"github.com/sirupsen/logrus"
@@ -70,7 +69,7 @@ func newManager(params managerParams) (ctrlRuntime.Manager, error) {
 		return proto.Equal(xdsResource1.Any, xdsResource2.Any)
 	})
 
-	ctrlRuntime.SetLogger(logrusr.New(params.Logger))
+	ctrlRuntime.SetLogger(newLogrFromLogrus(params.Logger))
 
 	mgr, err := ctrlRuntime.NewManager(params.K8sClient.RestConfig(), ctrlRuntime.Options{
 		Scheme: params.Scheme,
@@ -78,7 +77,6 @@ func newManager(params managerParams) (ctrlRuntime.Manager, error) {
 		Metrics: metricsserver.Options{
 			BindAddress: "0",
 		},
-		Logger: logrusr.New(params.Logger),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new controller-runtime manager: %w", err)

--- a/operator/pkg/controller-runtime/log.go
+++ b/operator/pkg/controller-runtime/log.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package controllerruntime
+
+import (
+	"github.com/bombsimon/logrusr/v4"
+	"github.com/go-logr/logr"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+func newLogrFromLogrus(logger logrus.FieldLogger) logr.Logger {
+	return logr.New(logSink{logrusr.New(logger).GetSink()})
+}
+
+type logSink struct{ logr.LogSink }
+
+func (w logSink) Error(err error, msg string, keysAndValues ...any) {
+	if msg == "Reconciler error" && isRetryableError(err) {
+		w.LogSink.Info(0, msg, append(keysAndValues, logfields.Error, err.Error())...)
+		return
+	}
+
+	w.LogSink.Error(err, msg, keysAndValues...)
+}
+
+func (w logSink) WithValues(keysAndValues ...any) logr.LogSink {
+	return logSink{w.LogSink.WithValues(keysAndValues...)}
+}
+
+func (w logSink) WithName(name string) logr.LogSink {
+	return logSink{w.LogSink.WithName(name)}
+}
+
+// isRetryableError returns true if the error returned by the Reconcile
+// is likely transient, and will be addressed by a subsequent iteration.
+func isRetryableError(err error) bool {
+	return k8serrors.IsAlreadyExists(err) ||
+		k8serrors.IsConflict(err) ||
+		k8serrors.IsNotFound(err) ||
+		(k8serrors.IsForbidden(err) &&
+			k8serrors.HasStatusCause(err, corev1.NamespaceTerminatingCause))
+}

--- a/operator/pkg/controller-runtime/log_test.go
+++ b/operator/pkg/controller-runtime/log_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package controllerruntime
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func newForbiddenError(cause metav1.CauseType) error {
+	return &k8serrors.StatusError{ErrStatus: metav1.Status{
+		Message: "forbidden error",
+		Status:  metav1.StatusFailure,
+		Code:    http.StatusForbidden,
+		Reason:  metav1.StatusReasonForbidden,
+		Details: &metav1.StatusDetails{
+			Causes: []metav1.StatusCause{{Type: cause}},
+		},
+	}}
+}
+
+func TestLogSink(t *testing.T) {
+	var buf bytes.Buffer
+	lgr := logrus.New()
+	lgr.SetOutput(&buf)
+	lgr.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
+
+	logger := newLogrFromLogrus(lgr)
+
+	tests := []struct {
+		logger   logr.Logger
+		msg      string
+		err      error
+		expected string
+	}{
+		{
+			logger:   logger,
+			err:      errors.New("foo"),
+			msg:      "Reconciler error",
+			expected: "level=error msg=\"Reconciler error\" bar=baz error=foo",
+		},
+		{
+			logger:   logger.WithName("name").WithValues("qux", "fred"),
+			err:      errors.New("foo"),
+			msg:      "Reconciler error",
+			expected: "level=error msg=\"Reconciler error\" bar=baz error=foo logger=name qux=fred",
+		},
+		{
+			logger:   logger,
+			err:      k8serrors.NewAlreadyExists(schema.GroupResource{Resource: "pod"}, "test"),
+			msg:      "Reconciler error",
+			expected: "level=info msg=\"Reconciler error\" bar=baz error=\"pod \\\"test\\\" already exists\"",
+		},
+		{
+			logger:   logger.WithName("name").WithValues("qux", "fred"),
+			msg:      "Reconciler error",
+			err:      k8serrors.NewAlreadyExists(schema.GroupResource{Resource: "pod"}, "test"),
+			expected: "level=info msg=\"Reconciler error\" bar=baz error=\"pod \\\"test\\\" already exists\" logger=name qux=fred",
+		},
+		{
+			logger:   logger.WithName("name").WithValues("qux", "fred"),
+			msg:      "Reconciler error",
+			err:      fmt.Errorf("foo: %w", k8serrors.NewAlreadyExists(schema.GroupResource{Resource: "pod"}, "test")),
+			expected: "level=info msg=\"Reconciler error\" bar=baz error=\"foo: pod \\\"test\\\" already exists\" logger=name qux=fred",
+		},
+		{
+			logger:   logger.WithName("name").WithValues("qux", "fred"),
+			msg:      "Reconciler error",
+			err:      k8serrors.NewNotFound(schema.GroupResource{Resource: "pod"}, "test"),
+			expected: "level=info msg=\"Reconciler error\" bar=baz error=\"pod \\\"test\\\" not found\" logger=name qux=fred",
+		},
+		{
+			logger:   logger.WithName("name").WithValues("qux", "fred"),
+			msg:      "Reconciler error",
+			err:      k8serrors.NewConflict(schema.GroupResource{Resource: "pod"}, "test", errors.New("foo")),
+			expected: "level=info msg=\"Reconciler error\" bar=baz error=\"Operation cannot be fulfilled on pod \\\"test\\\": foo\" logger=name qux=fred",
+		},
+		{
+			logger:   logger.WithName("name").WithValues("qux", "fred"),
+			msg:      "Reconciler error",
+			err:      newForbiddenError(corev1.NamespaceTerminatingCause),
+			expected: "level=info msg=\"Reconciler error\" bar=baz error=\"forbidden error\" logger=name qux=fred",
+		},
+		{
+			logger:   logger.WithName("name").WithValues("qux", "fred"),
+			msg:      "Reconciler error",
+			err:      newForbiddenError(metav1.CauseTypeFieldValueDuplicate),
+			expected: "level=error msg=\"Reconciler error\" bar=baz error=\"forbidden error\" logger=name qux=fred",
+		},
+		{
+			logger:   logger.WithName("name").WithValues("qux", "fred"),
+			msg:      "Something else",
+			err:      k8serrors.NewConflict(schema.GroupResource{Resource: "pod"}, "test", errors.New("foo")),
+			expected: "level=error msg=\"Something else\" bar=baz error=\"Operation cannot be fulfilled on pod \\\"test\\\": foo\" logger=name qux=fred",
+		},
+	}
+
+	for _, tt := range tests {
+		buf.Reset()
+		tt.logger.Error(tt.err, tt.msg, "bar", "baz")
+		assert.Equal(t, tt.expected, strings.TrimSuffix(buf.String(), "\n"))
+	}
+}


### PR DESCRIPTION
 * [x] #35364 (@giorio94) :warning: resolved conflicts
    * :information_source: Adapted the patch as the v1.16 tree still used logrus rather than slog; adapted the unit test to reflect the different output format (most notably, the lowercase keywords and the different key-values pairs order).

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 35364
```
