### PR TITLE
bgpv2: Introduce a condition to indicate nodeSelector conflicts

### DIFF
--- a/operator/pkg/bgpv2/cluster.go
+++ b/operator/pkg/bgpv2/cluster.go
@@ -15,7 +15,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_labels "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
@@ -36,7 +35,7 @@ func (b *BGPResourceManager) reconcileBGPClusterConfigs(ctx context.Context) err
 
 func (b *BGPResourceManager) reconcileBGPClusterConfig(ctx context.Context, config *v2alpha1.CiliumBGPClusterConfig) error {
 	// get nodes which match node selector for given cluster config
-	matchingNodes, err := b.getMatchingNodes(config.Spec.NodeSelector, config)
+	matchingNodes, conflictingClusterConfigs, err := b.getMatchingNodes(config)
 	if err != nil {
 		return err
 	}
@@ -64,6 +63,9 @@ func (b *BGPResourceManager) reconcileBGPClusterConfig(ctx context.Context, conf
 		updateStatus = true
 	}
 	if changed := b.updateMissingPeerConfigsCondition(config, missingPCs); changed {
+		updateStatus = true
+	}
+	if changed := b.updateConflictingClusterConfigsCondition(config, conflictingClusterConfigs); changed {
 		updateStatus = true
 	}
 
@@ -107,6 +109,21 @@ func (b *BGPResourceManager) missingPeerConfigs(config *v2alpha1.CiliumBGPCluste
 	}
 	slices.Sort(missing)
 	return slices.Compact(missing)
+}
+
+func (b *BGPResourceManager) updateConflictingClusterConfigsCondition(config *v2alpha1.CiliumBGPClusterConfig, conflictingClusterConfigs sets.Set[string]) bool {
+	cond := meta_v1.Condition{
+		Type:               v2alpha1.BGPClusterConfigConditionConflictingClusterConfigs,
+		Status:             meta_v1.ConditionFalse,
+		ObservedGeneration: config.Generation,
+		LastTransitionTime: meta_v1.Now(),
+		Reason:             "ConflictingClusterConfigs",
+	}
+	if conflictingClusterConfigs.Len() != 0 {
+		cond.Status = meta_v1.ConditionTrue
+		cond.Message = fmt.Sprintf("Selecting the same node(s) with ClusterConfig(s): %v", sets.List(conflictingClusterConfigs))
+	}
+	return meta.SetStatusCondition(&config.Status.Conditions, cond)
 }
 
 func (b *BGPResourceManager) updateMissingPeerConfigsCondition(config *v2alpha1.CiliumBGPClusterConfig, missingPCs []string) bool {
@@ -251,28 +268,39 @@ func toNodeBGPInstance(clusterBGPInstances []v2alpha1.CiliumBGPInstance, overrid
 }
 
 // getMatchingNodes returns a map of node names that match the given cluster config's node selector.
-func (b *BGPResourceManager) getMatchingNodes(nodeSelector *slim_meta_v1.LabelSelector, config *v2alpha1.CiliumBGPClusterConfig) (sets.Set[string], error) {
-	labelSelector, err := slim_meta_v1.LabelSelectorAsSelector(nodeSelector)
+func (b *BGPResourceManager) getMatchingNodes(config *v2alpha1.CiliumBGPClusterConfig) (sets.Set[string], sets.Set[string], error) {
+	labelSelector, err := slim_meta_v1.LabelSelectorAsSelector(config.Spec.NodeSelector)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// find nodes that match the cluster config's node selector
 	matchingNodes := sets.New[string]()
 
+	// find ClusterConfigs that has the conflicting node selector
+	conflictingClusterConfigs := sets.New[string]()
+
 	for _, n := range b.ciliumNodeStore.List() {
 		// nil node selector means match all nodes
-		if nodeSelector == nil || labelSelector.Matches(slim_labels.Set(n.Labels)) {
-			err := b.validNodeSelection(n, config)
+		if config.Spec.NodeSelector == nil || labelSelector.Matches(slim_labels.Set(n.Labels)) {
+			nc, exists, err := b.nodeConfigStore.GetByKey(resource.Key{Name: n.Name})
 			if err != nil {
 				b.logger.Error(fmt.Sprintf("skipping node %s", n.Name), logfields.Error, err)
 				continue
 			}
+
+			if exists && !isOwner(nc.GetOwnerReferences(), config) {
+				// Node is already selected by another cluster config. Figure out which one.
+				ownerName := ownerClusterConfigName(nc.GetOwnerReferences())
+				conflictingClusterConfigs.Insert(ownerName)
+				continue
+			}
+
 			matchingNodes.Insert(n.Name)
 		}
 	}
 
-	return matchingNodes, nil
+	return matchingNodes, conflictingClusterConfigs, nil
 }
 
 // deleteStaleNodeConfigs deletes node configs that are not in the expected list for given cluster.
@@ -297,20 +325,6 @@ func (b *BGPResourceManager) deleteStaleNodeConfigs(ctx context.Context, expecte
 	return err
 }
 
-// validNodeSelection checks if the node is already present in another cluster config.
-func (b *BGPResourceManager) validNodeSelection(node *cilium_api_v2.CiliumNode, config *v2alpha1.CiliumBGPClusterConfig) error {
-	existingBGPNodeConfig, exists, err := b.nodeConfigStore.GetByKey(resource.Key{Name: node.Name})
-	if err != nil {
-		return err
-	}
-
-	if exists && !isOwner(existingBGPNodeConfig.GetOwnerReferences(), config) {
-		return fmt.Errorf("BGPResourceManager node config %s already exist", existingBGPNodeConfig.Name)
-	}
-
-	return nil
-}
-
 // isOwner checks if the expected is present in owners list.
 func isOwner(owners []meta_v1.OwnerReference, config *v2alpha1.CiliumBGPClusterConfig) bool {
 	for _, owner := range owners {
@@ -319,4 +333,14 @@ func isOwner(owners []meta_v1.OwnerReference, config *v2alpha1.CiliumBGPClusterC
 		}
 	}
 	return false
+}
+
+// ownerClusterConfigName returns the name of the ClusterConfig that owns the object
+func ownerClusterConfigName(owners []meta_v1.OwnerReference) string {
+	for _, owner := range owners {
+		if owner.APIVersion == v2alpha1.SchemeGroupVersion.String() && owner.Kind == v2alpha1.BGPCCKindDefinition {
+			return owner.Name
+		}
+	}
+	return ""
 }

--- a/operator/pkg/bgpv2/cluster_test.go
+++ b/operator/pkg/bgpv2/cluster_test.go
@@ -6,14 +6,19 @@ package bgpv2
 import (
 	"context"
 	"maps"
+	"regexp"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/utils/ptr"
 
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -780,6 +785,307 @@ func TestClusterConfigConditions(t *testing.T) {
 				}
 
 				assert.Empty(ct, missing, "Missing conditions: %v", missing)
+			}, time.Second*3, time.Millisecond*100)
+		})
+	}
+}
+
+func TestConflictingClusterConfigCondition(t *testing.T) {
+	nodes := []*cilium_api_v2.CiliumNode{
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "node-0",
+				Labels: map[string]string{
+					"rack":             "rack0",
+					"complete-overlap": "true",
+					"partial-overlap0": "true",
+				},
+			},
+		},
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "node-1",
+				Labels: map[string]string{
+					"rack":             "rack1",
+					"complete-overlap": "true",
+					"partial-overlap0": "true",
+					"partial-overlap1": "true",
+				},
+			},
+		},
+		{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "node-2",
+				Labels: map[string]string{
+					"rack":             "rack2",
+					"complete-overlap": "true",
+					"partial-overlap1": "true",
+				},
+			},
+		},
+	}
+
+	type clusterConfig struct {
+		name     string
+		selector *slim_meta_v1.LabelSelector
+	}
+
+	// sortRelation sorts the relation in a deterministic way.
+	sortRelation := func(a, b [2]string) int {
+		slices.Sort(a[:])
+		slices.Sort(b[:])
+		return strings.Compare(a[0]+a[1], b[0]+b[1])
+	}
+
+	tests := []struct {
+		name           string
+		clusterConfigs []clusterConfig
+
+		// conflictingRelations is a list of pairs of cluster config
+		// names that are expected to have a conflict.
+		conflictingRelations [][2]string
+	}{
+		{
+			name: "ConflictingClusterConfig False",
+			clusterConfigs: []clusterConfig{
+				{
+					name: "cluster-config-0",
+					selector: &slim_meta_v1.LabelSelector{
+						MatchLabels: map[string]string{
+							"rack": "rack0",
+						},
+					},
+				},
+				{
+					name: "cluster-config-1",
+					selector: &slim_meta_v1.LabelSelector{
+						MatchLabels: map[string]string{
+							"rack": "rack1",
+						},
+					},
+				},
+				{
+					name: "cluster-config-2",
+					selector: &slim_meta_v1.LabelSelector{
+						MatchLabels: map[string]string{
+							"rack": "rack2",
+						},
+					},
+				},
+			},
+			conflictingRelations: [][2]string{},
+		},
+		{
+			name: "ConflictingClusterConfig True complete overlap",
+			clusterConfigs: []clusterConfig{
+				{
+					name: "cluster-config-0",
+					selector: &slim_meta_v1.LabelSelector{
+						MatchLabels: map[string]string{
+							"complete-overlap": "true",
+						},
+					},
+				},
+				{
+					name: "cluster-config-1",
+					selector: &slim_meta_v1.LabelSelector{
+						MatchLabels: map[string]string{
+							"complete-overlap": "true",
+						},
+					},
+				},
+			},
+			conflictingRelations: [][2]string{
+				{"cluster-config-0", "cluster-config-1"},
+			},
+		},
+		{
+			name: "ConflictingClusterConfig True complete overlap with nil",
+			clusterConfigs: []clusterConfig{
+				{
+					name:     "cluster-config-0",
+					selector: nil,
+				},
+				{
+					name:     "cluster-config-1",
+					selector: nil,
+				},
+			},
+			conflictingRelations: [][2]string{
+				{"cluster-config-0", "cluster-config-1"},
+			},
+		},
+		{
+			name: "ConflictingClusterConfig True partial overlap",
+			clusterConfigs: []clusterConfig{
+				{
+					name: "cluster-config-0",
+					selector: &slim_meta_v1.LabelSelector{
+						MatchLabels: map[string]string{
+							"partial-overlap0": "true",
+						},
+					},
+				},
+				{
+					name: "cluster-config-1",
+					selector: &slim_meta_v1.LabelSelector{
+						MatchLabels: map[string]string{
+							"partial-overlap1": "true",
+						},
+					},
+				},
+			},
+			conflictingRelations: [][2]string{
+				{"cluster-config-0", "cluster-config-1"},
+			},
+		},
+		{
+			name: "ConflictingClusterConfig True partial overlap of four configs",
+			clusterConfigs: []clusterConfig{
+				{
+					name: "cluster-config-0",
+					selector: &slim_meta_v1.LabelSelector{
+						MatchLabels: map[string]string{
+							"partial-overlap0": "true",
+						},
+					},
+				},
+				{
+					name: "cluster-config-1",
+					selector: &slim_meta_v1.LabelSelector{
+						MatchLabels: map[string]string{
+							"rack": "rack0",
+						},
+					},
+				},
+				{
+					name: "cluster-config-2",
+					selector: &slim_meta_v1.LabelSelector{
+						MatchLabels: map[string]string{
+							"rack": "rack1",
+						},
+					},
+				},
+				{
+					name: "cluster-config-3",
+					selector: &slim_meta_v1.LabelSelector{
+						MatchLabels: map[string]string{
+							"rack": "rack2",
+						},
+					},
+				},
+			},
+			conflictingRelations: [][2]string{
+				{"cluster-config-0", "cluster-config-1"},
+				{"cluster-config-0", "cluster-config-2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+			defer cancel()
+
+			f, watchersReady := newFixture(ctx, require.New(t))
+
+			tlog := hivetest.Logger(t)
+			f.hive.Start(tlog, ctx)
+			defer f.hive.Stop(tlog, ctx)
+
+			watchersReady()
+
+			// Setup resources
+			for _, node := range nodes {
+				upsertNode(req, ctx, f, node)
+			}
+
+			for _, config := range tt.clusterConfigs {
+				clusterConfig := &cilium_api_v2alpha1.CiliumBGPClusterConfig{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Name: config.name,
+						// Fake client doesn't set UID. Assign it manually.
+						UID: uuid.NewUUID(),
+					},
+					Spec: cilium_api_v2alpha1.CiliumBGPClusterConfigSpec{
+						NodeSelector: config.selector,
+						BGPInstances: []cilium_api_v2alpha1.CiliumBGPInstance{
+							{
+								Peers: []cilium_api_v2alpha1.CiliumBGPPeer{},
+							},
+						},
+					},
+				}
+				upsertBGPCC(req, ctx, f, clusterConfig)
+			}
+
+			require.EventuallyWithT(t, func(ct *assert.CollectT) {
+				configs, err := f.bgpcClient.List(ctx, meta_v1.ListOptions{})
+				if !assert.NoError(ct, err, "Cannot list cluster configs") {
+					return
+				}
+
+				// Here we collect all conflicting configs from all cluster configs.
+				// Since we detect the conflict by checking the owner reference of
+				// the node config, the cluster config observes the conflict depends
+				// on the node config creation order. So we need to check all cluster
+				// configs to get the entire view of the conflicts.
+				conflictingRelations := [][2]string{}
+				for _, config := range configs.Items {
+					cond := meta.FindStatusCondition(
+						config.Status.Conditions,
+						cilium_api_v2alpha1.BGPClusterConfigConditionConflictingClusterConfigs,
+					)
+					if !assert.NotNil(ct, cond, "Condition not found") {
+						return
+					}
+
+					if len(tt.conflictingRelations) == 0 {
+						if !assert.Equal(ct, meta_v1.ConditionFalse, cond.Status, "Expected condition to be false") {
+							return
+						}
+						return
+					}
+
+					if cond.Status == meta_v1.ConditionFalse {
+						continue
+					}
+
+					expr, err := regexp.Compile(
+						`Selecting the same node\(s\) with ClusterConfig\(s\): \[(.*)\]`,
+					)
+					if !assert.NoError(ct, err, "Error during regexp match") {
+						return
+					}
+
+					match := expr.FindSubmatch([]byte(cond.Message))
+					if !assert.Len(ct, match, 2, "Invalid number of match") {
+						return
+					}
+
+					for _, conflictingConfig := range strings.Split(string(match[1]), " ") {
+						relation := [2]string{config.Name, conflictingConfig}
+						conflictingRelations = append(conflictingRelations, relation)
+					}
+				}
+
+				// Short circuit if the number of conflict relations is not the same.
+				if !assert.Len(ct, conflictingRelations, len(tt.conflictingRelations), "Exexpected number of conflicts") {
+					return
+				}
+
+				// Sort the conflicting relations to make the comparison deterministic.
+				slices.SortFunc(conflictingRelations, sortRelation)
+				slices.SortFunc(tt.conflictingRelations, sortRelation)
+
+				// Compare the conflicting relations.
+				for i := 0; i < len(tt.conflictingRelations); i++ {
+					if !assert.ElementsMatch(ct, tt.conflictingRelations[i], conflictingRelations[i]) {
+						return
+					}
+				}
 			}, time.Second*3, time.Millisecond*100)
 		})
 	}

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_cluster_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_cluster_types.go
@@ -159,4 +159,6 @@ const (
 	BGPClusterConfigConditionNoMatchingNode = "cilium.io/NoMatchingNode"
 	// Referenced peer configs are missing
 	BGPClusterConfigConditionMissingPeerConfigs = "cilium.io/MissingPeerConfigs"
+	// ClusterConfig with conflicting nodeSelector present
+	BGPClusterConfigConditionConflictingClusterConfigs = "cilium.io/ConflictingClusterConfig"
 )


### PR DESCRIPTION
A node in the cluster can only be selected by one CiliumBGPClusterConfig. However, API-wise it is still possible. Such an error has been reported in the operator's log. This PR introduces a new condition `ConflictingClusterConfig` to the CiliumBGPClusterConfig which reports the error in the condition for better trouble shooting experience.

Note that this PR removes the `BGPResourceManager node config XXX already exist` error we mention in the doc. The corresponding document update will be covered in the separate PR with the description of other conditions we've introduced recently.

```release-note
bgpv2: Introduce a condition to indicate nodeSelector conflicts
```
