### PR TITLE
CiliumEnvoyConfig handling for experimental control-plane

### DIFF
--- a/pkg/ciliumenvoyconfig/cec_resource_parser.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/proxy"
 )
 
 const (
@@ -64,14 +63,14 @@ type parserParams struct {
 	Logger    logrus.FieldLogger
 	Lifecycle cell.Lifecycle
 
-	Proxy          *proxy.Proxy
+	PortAllocator  PortAllocator
 	LocalNodeStore *node.LocalNodeStore
 }
 
 func newCECResourceParser(params parserParams) *cecResourceParser {
 	parser := &cecResourceParser{
 		logger:        params.Logger,
-		portAllocator: params.Proxy,
+		portAllocator: params.PortAllocator,
 	}
 
 	// Retrieve Ingress IPs from local Node.

--- a/pkg/ciliumenvoyconfig/cell.go
+++ b/pkg/ciliumenvoyconfig/cell.go
@@ -19,10 +19,12 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/synced"
+	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -51,7 +53,10 @@ var Cell = cell.Module(
 			return k8s.EndpointsResource(lc, cfg, cs)
 		},
 	),
+	cell.ProvidePrivate(newPortAllocator),
 	cell.Config(cecConfig{}),
+
+	experimentalCell,
 )
 
 type cecConfig struct {
@@ -75,8 +80,9 @@ type reconcilerParams struct {
 	K8sResourceSynced *synced.Resources
 	K8sAPIGroups      *synced.APIGroups
 
-	Config  cecConfig
-	Manager ciliumEnvoyConfigManager
+	Config    cecConfig
+	ExpConfig experimental.Config
+	Manager   ciliumEnvoyConfigManager
 
 	CECResources   resource.Resource[*ciliumv2.CiliumEnvoyConfig]
 	CCECResources  resource.Resource[*ciliumv2.CiliumClusterwideEnvoyConfig]
@@ -86,7 +92,7 @@ type reconcilerParams struct {
 }
 
 func registerCECK8sReconciler(params reconcilerParams) {
-	if !option.Config.EnableL7Proxy || !option.Config.EnableEnvoyConfig {
+	if !option.Config.EnableL7Proxy || !option.Config.EnableEnvoyConfig || params.ExpConfig.EnableExperimentalLB {
 		return
 	}
 
@@ -162,4 +168,8 @@ type managerParams struct {
 func newCECManager(params managerParams) ciliumEnvoyConfigManager {
 	return newCiliumEnvoyConfigManager(params.Logger, params.PolicyUpdater, params.ServiceManager, params.XdsServer,
 		params.BackendSyncer, params.ResourceParser, params.Config.EnvoyConfigTimeout, params.Services, params.Endpoints)
+}
+
+func newPortAllocator(proxy *proxy.Proxy) PortAllocator {
+	return proxy
 }

--- a/pkg/ciliumenvoyconfig/exp_cec.go
+++ b/pkg/ciliumenvoyconfig/exp_cec.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumenvoyconfig
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+	"github.com/cilium/statedb/part"
+	"github.com/cilium/statedb/reconciler"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/cilium/cilium/pkg/envoy"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+)
+
+type CEC struct {
+	Name k8sTypes.NamespacedName
+	Spec *ciliumv2.CiliumEnvoyConfigSpec
+
+	Selector         labels.Selector `json:"-"`
+	SelectsLocalNode bool
+	Listeners        part.Map[string, uint16]
+
+	// FrontendsRevision is the latest revision of [experimental.Frontend] from
+	// which the [Resources.Endpoints] were updated. This is used to coordinate
+	// updates between the reflector and the backendController.
+	FrontendsRevision statedb.Revision
+
+	// Resources is the parsed envoy.Resources.
+	Resources envoy.Resources `json:"-"`
+
+	// ReconciledResources is the last successfully reconciled resources.
+	// Updated by the reconciliation operations.
+	ReconciledResources *envoy.Resources `json:"-"`
+
+	// Status is the reconciliation status of [Resources] towards Envoy.
+	Status reconciler.Status
+}
+
+func (cec *CEC) Clone() *CEC {
+	cec2 := *cec
+	return &cec2
+}
+
+func (cec *CEC) SetStatus(newStatus reconciler.Status) *CEC {
+	cec.Status = newStatus
+	return cec
+}
+
+func (cec *CEC) GetStatus() reconciler.Status {
+	return cec.Status
+}
+
+func (*CEC) TableHeader() []string {
+	return []string{
+		"Name",
+		"Selected",
+		"NodeSelector",
+		"Services",
+		"BackendServices",
+		"Listeners",
+		"Status",
+		"StatusKind",
+	}
+}
+
+func (cec *CEC) TableRow() []string {
+	var services, beServices, listeners []string
+	for _, svcl := range cec.Spec.Services {
+		services = append(services, svcl.Namespace+"/"+svcl.Name)
+	}
+	for _, svcl := range cec.Spec.BackendServices {
+		beServices = append(beServices, svcl.Namespace+"/"+svcl.Name)
+	}
+	for name, port := range cec.Listeners.All() {
+		listeners = append(listeners, fmt.Sprintf("%s:%d", name, port))
+	}
+	return []string{
+		cec.Name.String(),
+		strconv.FormatBool(cec.SelectsLocalNode),
+		cec.Selector.String(),
+		strings.Join(services, ", "),
+		strings.Join(beServices, ", "),
+		strings.Join(listeners, ", "),
+		cec.Status.String(),
+		string(cec.Status.Kind),
+	}
+}
+
+type CECName = k8sTypes.NamespacedName
+
+var (
+	CECTableName = "ciliumenvoyconfigs"
+
+	cecNameIndex = statedb.Index[*CEC, CECName]{
+		Name: "name",
+		FromObject: func(obj *CEC) index.KeySet {
+			return index.NewKeySet(index.String(obj.Name.String()))
+		},
+		FromKey: index.Stringer[k8sTypes.NamespacedName],
+		Unique:  true,
+	}
+
+	CECByName = cecNameIndex.Query
+
+	cecServiceIndex = statedb.Index[*CEC, loadbalancer.ServiceName]{
+		Name: "service",
+		FromObject: func(obj *CEC) index.KeySet {
+			keys := make([]index.Key, len(obj.Spec.Services))
+			for i, svcl := range obj.Spec.Services {
+				keys[i] = index.String(
+					loadbalancer.ServiceName{
+						Namespace: svcl.Namespace,
+						Name:      svcl.Name,
+					}.String(),
+				)
+			}
+			return index.NewKeySet(keys...)
+		},
+		FromKey: func(key loadbalancer.ServiceName) index.Key {
+			return index.String(key.String())
+		},
+		Unique: false,
+	}
+
+	CECByServiceName = cecServiceIndex.Query
+)
+
+func NewCECTable(db *statedb.DB) (statedb.RWTable[*CEC], error) {
+	tbl, err := statedb.NewTable(
+		CECTableName,
+		cecNameIndex,
+		cecServiceIndex,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return tbl, db.RegisterTable(tbl)
+}

--- a/pkg/ciliumenvoyconfig/exp_cell.go
+++ b/pkg/ciliumenvoyconfig/exp_cell.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumenvoyconfig
+
+import (
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/pkg/envoy"
+)
+
+var (
+	// experimentalCell implements handling of the Cilium(Clusterwide)EnvoyConfig handling
+	// and backend synchronization towards Envoy against the experimental load-balancing
+	// control-plane (pkg/loadbalancer/experimental). It is dormant unless 'enable-experimental-lb'
+	// is set, in which case the other implementation is disabled and this is enabled.
+	experimentalCell = cell.Module(
+		"experimental",
+		"CiliumEnvoyConfig integration with the experimental LB control-plane",
+
+		// Bridge the external dependencies to the internal APIs. In tests
+		// mocks are used for these.
+		cell.ProvidePrivate(
+			newPolicyTrigger,
+			func(xds envoy.XDSServer) resourceMutator { return xds },
+		),
+
+		experimentalTableCells,
+		experimentalControllerCells,
+	)
+
+	experimentalControllerCells = cell.Group(
+		cell.Provide(
+			newCECController,
+		),
+		cell.Invoke((*cecController).setWriter),
+		cell.Invoke(registerEnvoyReconciler),
+	)
+
+	experimentalTableCells = cell.Group(
+		cell.ProvidePrivate(
+			NewCECTable,
+			statedb.RWTable[*CEC].ToTable,
+			newNodeLabels,
+			cecListerWatchers,
+		),
+		cell.Invoke(
+			registerCECReflector,
+		),
+	)
+)

--- a/pkg/ciliumenvoyconfig/exp_controller.go
+++ b/pkg/ciliumenvoyconfig/exp_controller.go
@@ -1,0 +1,546 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumenvoyconfig
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"log/slog"
+	"maps"
+	"slices"
+	"strconv"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	envoy_config_core "github.com/cilium/proxy/go/envoy/config/core/v3"
+	envoy_config_endpoint "github.com/cilium/proxy/go/envoy/config/endpoint/v3"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/part"
+	"github.com/cilium/statedb/reconciler"
+	"github.com/cilium/stream"
+	"google.golang.org/protobuf/proto"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/envoy"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type cecControllerParams struct {
+	cell.In
+
+	DB             *statedb.DB
+	JobGroup       job.Group
+	Log            *slog.Logger
+	ExpConfig      experimental.Config
+	LocalNodeStore *node.LocalNodeStore
+
+	NodeLabels    *nodeLabels
+	CECs          statedb.RWTable[*CEC]
+	EnvoySyncer   resourceMutator
+	PolicyTrigger policyTrigger
+}
+
+type resourceMutator interface {
+	DeleteEnvoyResources(context.Context, envoy.Resources) error
+	UpdateEnvoyResources(context.Context, envoy.Resources, envoy.Resources) error
+}
+
+type policyTrigger interface {
+	TriggerPolicyUpdates()
+}
+
+type cecController struct {
+	params cecControllerParams
+	writer *experimental.Writer
+}
+
+type cecControllerOut struct {
+	cell.Out
+
+	C    *cecController
+	Hook experimental.ServiceHook `group:"service-hooks"`
+}
+
+func newNodeLabels() *nodeLabels {
+	nl := &nodeLabels{}
+	lbls := map[string]string{}
+	nl.Store(&lbls)
+	return nl
+}
+
+func newCECController(params cecControllerParams) cecControllerOut {
+	if !params.ExpConfig.EnableExperimentalLB {
+		return cecControllerOut{}
+	}
+
+	c := &cecController{params, nil}
+	params.JobGroup.Add(job.OneShot("proxy-redirect-controller", c.proxyRedirectController))
+	params.JobGroup.Add(job.OneShot("backends-controller", c.backendController))
+	params.JobGroup.Add(job.OneShot("node-label-controller", c.nodeLabelController))
+	return cecControllerOut{
+		C:    c,
+		Hook: c.onServiceUpsert,
+	}
+}
+
+func (c *cecController) setWriter(w *experimental.Writer) {
+	if c != nil {
+		c.writer = w
+	}
+}
+
+// proxyRedirectController watches for changed CECs and updates the proxy redirect in services.
+func (c *cecController) proxyRedirectController(ctx context.Context, health cell.Health) error {
+	wtxn := c.params.DB.WriteTxn(c.params.CECs)
+	changeIter, err := c.params.CECs.Changes(wtxn)
+	wtxn.Commit()
+	if err != nil {
+		return err
+	}
+
+	svcs := c.writer.Services()
+	limiter := rate.NewLimiter(50*time.Millisecond, 3)
+	listeners := part.Set[uint16]{}
+
+	for {
+		wtxn := c.writer.WriteTxn()
+		changes, watch := changeIter.Next(wtxn)
+		oldListeners := listeners
+		for change := range changes {
+			cec := change.Object
+			if !change.Deleted && cec.Status.Kind != reconciler.StatusKindDone {
+				// Only process the CEC once it has been reconciled towards Envoy to avoid
+				// setting redirects before Envoy is ready.
+				continue
+			}
+
+			for _, port := range cec.Listeners.All() {
+				if change.Deleted {
+					listeners = listeners.Delete(port)
+				} else {
+					listeners = listeners.Set(port)
+				}
+			}
+
+			for _, svcl := range cec.Spec.Services {
+				svc, _, found := svcs.Get(wtxn, experimental.ServiceByName(svcl.ServiceName()))
+				if found && (change.Deleted || !getProxyRedirect(cec, svcl).Equal(svc.ProxyRedirect)) {
+					// Do an upsert to call into onServiceUpsert() to update the L7ProxyPort.
+					c.writer.UpsertService(wtxn, svc.Clone())
+				}
+			}
+		}
+		wtxn.Commit()
+
+		// When listeners change trigger the policy updates.
+		if !oldListeners.Equal(listeners) {
+			// TODO: Policy does not need to be recomputed for this, but if we do not 'force'
+			// the bpf maps are not updated with the new proxy ports either. Move from the
+			// simple boolean to an enum that can more selectively skip regeneration steps (like
+			// we do for the datapath recompilations already?)
+			c.params.PolicyTrigger.TriggerPolicyUpdates()
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-watch:
+		}
+
+		if err := limiter.Wait(ctx); err != nil {
+			return err
+		}
+	}
+}
+
+// backendController watches the frontends (that are associated with backends) for changes
+// and recomputes the endpoints resource. Frontends are watched as the services in CiliumEnvoyConfig
+// can specify frontend ports to filter by.
+func (c *cecController) backendController(ctx context.Context, health cell.Health) error {
+	frontends := c.writer.Frontends()
+	wtxn := c.params.DB.WriteTxn(frontends)
+	changeIter, err := c.writer.Frontends().Changes(wtxn)
+	wtxn.Commit()
+	if err != nil {
+		return err
+	}
+
+	limiter := rate.NewLimiter(50*time.Millisecond, 3)
+
+	for {
+		// Iterate over the changes to collect the services that reference changed backends.
+		wtxn := c.params.DB.WriteTxn(c.params.CECs)
+		services := sets.New[loadbalancer.ServiceName]()
+		changes, watch := changeIter.Next(wtxn)
+		for change := range changes {
+			services.Insert(change.Object.ServiceName)
+		}
+
+		// Find all CECs that reference those services and recompute their backends.
+		visited := sets.New[CECName]()
+		for serviceName := range services {
+			for cec := range c.params.CECs.List(wtxn, CECByServiceName(serviceName)) {
+				if visited.Has(cec.Name) {
+					continue
+				}
+				visited.Insert(cec.Name)
+				cec = cec.Clone()
+				if updateBackends(cec, wtxn, frontends) {
+					c.params.CECs.Insert(wtxn, cec)
+				}
+			}
+		}
+		wtxn.Commit()
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-watch:
+		}
+
+		if err := limiter.Wait(ctx); err != nil {
+			return err
+		}
+	}
+}
+
+// nodeLabelController updates the [SelectsLocalNode] when node labels change.
+func (c *cecController) nodeLabelController(ctx context.Context, health cell.Health) error {
+	localNodeChanges := stream.ToChannel(ctx, c.params.LocalNodeStore)
+
+	for localNode := range localNodeChanges {
+		newLabels := localNode.Labels
+		oldLabels := *c.params.NodeLabels.Load()
+
+		if !maps.Equal(newLabels, oldLabels) {
+			c.params.Log.Debug("Labels changed", "old", oldLabels, "new", newLabels)
+
+			// Since the labels changed, recompute 'SelectsLocalNode'
+			// for all CECs.
+			wtxn := c.params.DB.WriteTxn(c.params.CECs)
+
+			// Store the new labels so the reflector can compute 'SelectsLocalNode'
+			// on the fly. The reflector may already update 'SelectsLocalNode' to the
+			// correct value, so the recomputation that follows may be duplicate for
+			// some CECs, but that's fine. This is updated with the CEC table lock held
+			// and read by CEC reflector with the table lock which ensures consistency.
+			// With the Table[Node] changes in https://github.com/cilium/cilium/pull/32144
+			// this can be removed and we can instead read the labels directly from the node
+			// table.
+			labelSet := labels.Set(newLabels)
+			c.params.NodeLabels.Store(&newLabels)
+
+			for cec := range c.params.CECs.All(wtxn) {
+				if cec.Selector != nil {
+					selects := cec.Selector.Matches(labelSet)
+					if selects != cec.SelectsLocalNode {
+						cec = cec.Clone()
+						cec.SelectsLocalNode = selects
+						cec.Status = reconciler.StatusPending()
+						c.params.CECs.Insert(wtxn, cec)
+					}
+				}
+			}
+			wtxn.Commit()
+		}
+	}
+	return nil
+}
+
+// updateBackends recomputes the endpoint resources. Returns true if updated.
+func updateBackends(cec *CEC, txn statedb.ReadTxn, fes statedb.Table[*experimental.Frontend]) bool {
+	revision := fes.Revision(txn)
+	if cec.FrontendsRevision > revision {
+		// Already computed with a newer revision. This is used to coordinate between
+		// the reflector and the backend controller.
+		return false
+	}
+	cec.FrontendsRevision = revision
+
+	services := map[loadbalancer.ServiceName]sets.Set[string]{}
+	for _, l := range cec.Spec.Services {
+		name := l.ServiceName()
+		ports := services[name]
+		if ports == nil {
+			ports = sets.New[string]()
+			services[name] = ports
+		}
+		for _, p := range l.Ports {
+			ports.Insert(strconv.Itoa(int(p)))
+		}
+	}
+	for _, l := range cec.Spec.BackendServices {
+		name := l.ServiceName()
+		ports := services[name]
+		if ports == nil {
+			ports = sets.New[string]()
+			services[name] = ports
+		}
+		for _, p := range l.Ports {
+			ports.Insert(p)
+		}
+	}
+	assignments := []*envoy_config_endpoint.ClusterLoadAssignment{}
+	for svc, ports := range services {
+		assignments = append(
+			assignments,
+			backendsToLoadAssignments(
+				svc,
+				ports,
+				fes.List(txn, experimental.FrontendByServiceName(svc)))...)
+	}
+	if assignmentsEqual(cec.Resources.Endpoints, assignments) {
+		return false
+	}
+	cec.Resources.Endpoints = assignments
+	cec.Status = reconciler.StatusPending()
+	return true
+}
+
+func backendsToLoadAssignments(
+	serviceName loadbalancer.ServiceName,
+	ports sets.Set[string],
+	frontends iter.Seq2[*experimental.Frontend, statedb.Revision]) []*envoy_config_endpoint.ClusterLoadAssignment {
+	var endpoints []*envoy_config_endpoint.ClusterLoadAssignment
+
+	// Partition backends by port name.
+	backendMap := map[string]map[string]*experimental.Backend{}
+	backendMap[anyPort] = nil
+	for fe := range frontends {
+		portName := anyPort
+		// If ports are specified, only pick frontends with matching port or port name.
+		if ports.Len() > 0 {
+			switch {
+			case ports.Has(string(fe.PortName)):
+				portName = string(fe.PortName)
+			case ports.Has(strconv.Itoa(int(fe.Address.Port))):
+				portName = strconv.Itoa(int(fe.Address.Port))
+			case ports.Has(strconv.Itoa(int(fe.ServicePort))):
+				portName = strconv.Itoa(int(fe.ServicePort))
+			default:
+				continue
+			}
+		}
+		for _, beWithRev := range fe.Backends {
+			be := beWithRev.Backend
+			if be.State != loadbalancer.BackendStateActive {
+				continue
+			}
+			backends := backendMap[portName]
+			if backends == nil {
+				backends = map[string]*experimental.Backend{}
+				backendMap[portName] = backends
+			}
+			backends[be.L3n4Addr.String()] = be
+		}
+	}
+
+	for _, port := range slices.Sorted(maps.Keys(backendMap)) {
+		bes := backendMap[port]
+		var lbEndpoints []*envoy_config_endpoint.LbEndpoint
+		for _, addr := range slices.Sorted(maps.Keys(bes)) {
+			be := bes[addr]
+
+			// The below is to make sure that UDP and SCTP are not allowed instead of comparing with lb.TCP
+			// The reason is to avoid extra dependencies with ongoing work to differentiate protocols in datapath,
+			// which might add more values such as lb.Any, lb.None, etc.
+			if be.Protocol == loadbalancer.UDP || be.Protocol == loadbalancer.SCTP {
+				continue
+			}
+
+			lbEndpoints = append(lbEndpoints, &envoy_config_endpoint.LbEndpoint{
+				HostIdentifier: &envoy_config_endpoint.LbEndpoint_Endpoint{
+					Endpoint: &envoy_config_endpoint.Endpoint{
+						Address: &envoy_config_core.Address{
+							Address: &envoy_config_core.Address_SocketAddress{
+								SocketAddress: &envoy_config_core.SocketAddress{
+									Address: be.AddrCluster.String(),
+									PortSpecifier: &envoy_config_core.SocketAddress_PortValue{
+										PortValue: uint32(be.Port),
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+		}
+
+		endpoint := &envoy_config_endpoint.ClusterLoadAssignment{
+			ClusterName: fmt.Sprintf("%s:%s", serviceName.String(), port),
+			Endpoints: []*envoy_config_endpoint.LocalityLbEndpoints{
+				{
+					LbEndpoints: lbEndpoints,
+				},
+			},
+		}
+		endpoints = append(endpoints, endpoint)
+
+		// for backward compatibility, if any port is allowed, publish one more
+		// endpoint having cluster name as service name.
+		if port == anyPort {
+			endpoints = append(endpoints, &envoy_config_endpoint.ClusterLoadAssignment{
+				ClusterName: serviceName.String(),
+				Endpoints: []*envoy_config_endpoint.LocalityLbEndpoints{
+					{
+						LbEndpoints: lbEndpoints,
+					},
+				},
+			})
+		}
+	}
+	return endpoints
+}
+
+// assignmentsEqual returns false if the cluster load assignments are not equal. Equal assignments but in different
+// order are assumed non-equal.
+func assignmentsEqual(a []*envoy_config_endpoint.ClusterLoadAssignment, b []*envoy_config_endpoint.ClusterLoadAssignment) bool {
+
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !proto.Equal(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func getProxyRedirect(cec *CEC, svcl *ciliumv2.ServiceListener) *experimental.ProxyRedirect {
+	var port uint16
+	if svcl.Listener != "" {
+		// Listener names are qualified after parsing, so qualify the listener reference as well for it to match
+		svcListener, _ := api.ResourceQualifiedName(
+			cec.Name.Namespace, cec.Name.Name, svcl.Listener, api.ForceNamespace)
+		port, _ = cec.Listeners.Get(svcListener)
+	} else {
+		for _, p := range cec.Listeners.All() {
+			port = p
+			break
+		}
+	}
+	if port == 0 {
+		return nil
+	}
+	return &experimental.ProxyRedirect{
+		ProxyPort: port,
+		Ports:     svcl.Ports,
+	}
+}
+
+// onServiceUpsert is called when the service is upserted, but before it is committed.
+// We set the proxy port on the service if there's a matching CEC.
+func (c *cecController) onServiceUpsert(txn statedb.ReadTxn, svc *experimental.Service) {
+	// Look up if there is a CiliumEnvoyConfig that references this service.
+	cec, _, found := c.params.CECs.Get(txn, CECByServiceName(svc.Name))
+	if !found {
+		c.params.Log.Debug("onServiceUpsert: CEC not found", "name", svc.Name)
+		svc.ProxyRedirect = nil
+		return
+	}
+
+	// Find the service listener that referenced this service.
+	var svcl *ciliumv2.ServiceListener
+	for _, l := range cec.Spec.Services {
+		if l.Namespace == svc.Name.Namespace && l.Name == svc.Name.Name {
+			svcl = l
+			break
+		}
+	}
+	if svcl == nil {
+		return
+	}
+
+	pr := getProxyRedirect(cec, svcl)
+	c.params.Log.Debug("Setting proxy redirection (on service upsert)",
+		"namespace", svcl.Namespace,
+		"name", svcl.Name,
+		"ProxyRedirect", pr,
+		"Listener", svcl.Listener)
+	svc.ProxyRedirect = pr
+}
+
+type policyTriggerWrapper struct{ updater *policy.Updater }
+
+func (p policyTriggerWrapper) TriggerPolicyUpdates() {
+	p.updater.TriggerPolicyUpdates(true, "Envoy Listeners changed")
+}
+
+func newPolicyTrigger(log *slog.Logger, updater *policy.Updater) policyTrigger {
+	return policyTriggerWrapper{updater}
+}
+
+type envoyOps struct {
+	log *slog.Logger
+	xds resourceMutator
+}
+
+// Delete implements reconciler.Operations.
+func (ops *envoyOps) Delete(ctx context.Context, _ statedb.ReadTxn, cec *CEC) error {
+	if prev := cec.ReconciledResources; prev != nil {
+		// Perform the deletion with the resources that were last successfully reconciled
+		// instead of whatever the latest one is (which would have not been pushed to Envoy).
+		return ops.xds.DeleteEnvoyResources(ctx, *prev)
+	}
+	return nil
+}
+
+// Prune implements reconciler.Operations.
+func (ops *envoyOps) Prune(ctx context.Context, txn statedb.ReadTxn, objects iter.Seq2[*CEC, statedb.Revision]) error {
+	return nil
+}
+
+// Update implements reconciler.Operations.
+func (ops *envoyOps) Update(ctx context.Context, txn statedb.ReadTxn, cec *CEC) error {
+	var prevResources envoy.Resources
+	if cec.ReconciledResources != nil {
+		prevResources = *cec.ReconciledResources
+	}
+
+	var err error
+	if cec.SelectsLocalNode {
+		resources := cec.Resources
+		err := ops.xds.UpdateEnvoyResources(ctx, prevResources, resources)
+		if err == nil {
+			cec.ReconciledResources = &resources
+		}
+	} else if cec.ReconciledResources != nil {
+		// The local node no longer selected and it had been reconciled to envoy previously.
+		// Delete the resources and forget.
+		err = ops.xds.DeleteEnvoyResources(ctx, prevResources)
+		if err == nil {
+			cec.ReconciledResources = nil
+		}
+	}
+	return err
+}
+
+var _ reconciler.Operations[*CEC] = &envoyOps{}
+
+func registerEnvoyReconciler(log *slog.Logger, xds resourceMutator, params reconciler.Params, cecs statedb.RWTable[*CEC]) error {
+	ops := &envoyOps{
+		log: log, xds: xds,
+	}
+	_, err := reconciler.Register(
+		params,
+		cecs,
+		(*CEC).Clone,
+		(*CEC).SetStatus,
+		(*CEC).GetStatus,
+		ops,
+		nil,
+		reconciler.WithoutPruning(),
+	)
+	return err
+}

--- a/pkg/ciliumenvoyconfig/exp_reflector.go
+++ b/pkg/ciliumenvoyconfig/exp_reflector.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumenvoyconfig
+
+import (
+	"iter"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/part"
+	"github.com/cilium/statedb/reconciler"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/pkg/k8s"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/k8s/synced"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/promise"
+)
+
+// Types for the ListerWatchers of the CEC resources. Abstracted so that tests can
+// inject custom ones.
+type (
+	cecListerWatcher  cache.ListerWatcher
+	ccecListerWatcher cache.ListerWatcher
+
+	listerWatchers struct {
+		cec  cecListerWatcher
+		ccec ccecListerWatcher
+	}
+)
+
+func cecListerWatchers(cs client.Clientset) (out struct {
+	cell.Out
+	LW listerWatchers
+}) {
+	if cs.IsEnabled() {
+		out.LW.cec = utils.ListerWatcherFromTyped(cs.CiliumV2().CiliumEnvoyConfigs(""))
+		out.LW.ccec = utils.ListerWatcherFromTyped(cs.CiliumV2().CiliumClusterwideEnvoyConfigs())
+	}
+	return
+}
+
+type nodeLabels struct {
+	atomic.Pointer[map[string]string]
+}
+
+func registerCECReflector(
+	ecfg experimental.Config,
+	p *cecResourceParser,
+	crdSync promise.Promise[synced.CRDSync],
+	nodeLabels *nodeLabels,
+	log *slog.Logger,
+	lws listerWatchers,
+	g job.Group,
+	db *statedb.DB,
+	tbl statedb.RWTable[*CEC],
+	frontends statedb.Table[*experimental.Frontend],
+) error {
+	if lws.cec == nil || !ecfg.EnableExperimentalLB {
+		return nil
+	}
+	transform := func(txn statedb.ReadTxn, obj any) (*CEC, bool) {
+		var (
+			objMeta *metav1.ObjectMeta
+			spec    *ciliumv2.CiliumEnvoyConfigSpec
+		)
+
+		switch cecObj := obj.(type) {
+		case *ciliumv2.CiliumEnvoyConfig:
+			objMeta = &cecObj.ObjectMeta
+			spec = &cecObj.Spec
+		case *ciliumv2.CiliumClusterwideEnvoyConfig:
+			objMeta = &cecObj.ObjectMeta
+			spec = &cecObj.Spec
+		}
+
+		selectsLocalNode := true
+		selector := labels.Everything()
+		if spec.NodeSelector != nil {
+			var err error
+			selector, err = slim_metav1.LabelSelectorAsSelector(spec.NodeSelector)
+			if err != nil {
+				log.Warn("Skipping CiliumEnvoyConfig due to invalid NodeSelector",
+					"namespace", objMeta.GetNamespace(),
+					"name", objMeta.GetName(),
+					logfields.Error, err)
+				return nil, false
+			}
+			selectsLocalNode = selector.Matches(labels.Set(*nodeLabels.Load()))
+		}
+
+		resources, err := p.parseResources(
+			objMeta.GetNamespace(),
+			objMeta.GetName(),
+			spec.Resources,
+			len(spec.Services) > 0,
+			useOriginalSourceAddress(objMeta),
+			true,
+		)
+		if err != nil {
+			log.Warn("Skipping CiliumEnvoyConfig due to malformed xDS resources",
+				"namespace", objMeta.GetNamespace(),
+				"name", objMeta.GetName(),
+				logfields.Error, err)
+			return nil, false
+		}
+
+		var listeners part.Map[string, uint16]
+		for _, l := range resources.Listeners {
+			var proxyPort uint16
+			if addr := l.GetAddress(); addr != nil {
+				if sa := addr.GetSocketAddress(); sa != nil {
+					proxyPort = uint16(sa.GetPortValue())
+					listeners = listeners.Set(l.Name, proxyPort)
+				}
+			}
+		}
+
+		cec := &CEC{
+			Name: k8sTypes.NamespacedName{
+				Name:      objMeta.GetName(),
+				Namespace: objMeta.GetNamespace(),
+			},
+			Selector:         selector,
+			SelectsLocalNode: selectsLocalNode,
+			Spec:             spec,
+			Resources:        resources,
+			Listeners:        listeners,
+			Status:           reconciler.StatusPending(),
+		}
+
+		// Fill in the endpoints
+		updateBackends(cec, txn, frontends)
+
+		return cec, true
+	}
+
+	// CiliumEnvoyConfig reflection
+	err := k8s.RegisterReflector(
+		g,
+		db,
+		k8s.ReflectorConfig[*CEC]{
+			Name:          "cec",
+			Table:         tbl,
+			ListerWatcher: lws.cec,
+			Transform:     transform,
+			QueryAll: func(txn statedb.ReadTxn, tbl statedb.Table[*CEC]) iter.Seq2[*CEC, statedb.Revision] {
+				return statedb.Filter(
+					tbl.All(txn),
+					func(cec *CEC) bool { return cec.Name.Namespace != "" },
+				)
+			},
+			CRDSync: crdSync,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	// CiliumClusterwideEnvoyConfig reflection
+	return k8s.RegisterReflector(
+		g,
+		db,
+		k8s.ReflectorConfig[*CEC]{
+			Name:          "ccec",
+			Table:         tbl,
+			ListerWatcher: lws.ccec,
+			Transform:     transform,
+			QueryAll: func(txn statedb.ReadTxn, tbl statedb.Table[*CEC]) iter.Seq2[*CEC, statedb.Revision] {
+				return statedb.Filter(
+					tbl.All(txn),
+					func(cec *CEC) bool { return cec.Name.Namespace == "" },
+				)
+			},
+			CRDSync: crdSync,
+		},
+	)
+}

--- a/pkg/ciliumenvoyconfig/exp_test.go
+++ b/pkg/ciliumenvoyconfig/exp_test.go
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumenvoyconfig
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"os"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/cilium/statedb"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	daemonk8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/envoy"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/synced"
+	"github.com/cilium/cilium/pkg/k8s/testutils"
+	"github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func TestScript(t *testing.T) {
+	version.Force(testutils.DefaultVersion)
+	setup := func(t testing.TB, args []string) *script.Engine {
+		fakeEnvoy := &fakeEnvoySyncerAndPolicyTrigger{}
+		var lns *node.LocalNodeStore
+
+		h := hive.New(
+			client.FakeClientCell,
+			daemonk8s.ResourcesCell,
+			experimental.Cell,
+			cell.Provide(
+				tables.NewNodeAddressTable,
+				statedb.RWTable[tables.NodeAddress].ToTable,
+				func() *option.DaemonConfig {
+					return &option.DaemonConfig{
+						EnableIPv4:        true,
+						EnableIPv6:        true,
+						SockRevNatEntries: 1000,
+						LBMapEntries:      1000,
+					}
+				},
+				func() *experimental.TestConfig {
+					return &experimental.TestConfig{}
+				},
+			),
+			cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
+
+			cell.Module("cec-test", "test",
+				// cecResourceParser and its friends.
+				cell.Group(
+					cell.Provide(
+						newCECResourceParser,
+						func() PortAllocator { return staticPortAllocator{} },
+					),
+					node.LocalNodeStoreCell,
+					cell.Invoke(func(lns_ *node.LocalNodeStore) { lns = lns_ }),
+				),
+				experimentalTableCells,
+				experimentalControllerCells,
+
+				cell.ProvidePrivate(
+					func() promise.Promise[synced.CRDSync] {
+						r, p := promise.New[synced.CRDSync]()
+						r.Resolve(synced.CRDSync{})
+						return p
+					},
+					func() resourceMutator { return fakeEnvoy },
+					func() policyTrigger { return fakeEnvoy },
+				),
+			),
+		)
+
+		flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+		h.RegisterFlags(flags)
+		flags.Set("enable-experimental-lb", "true")
+
+		log := hivetest.Logger(t)
+		t.Cleanup(func() {
+			assert.NoError(t, h.Stop(log, context.TODO()))
+		})
+		cmds, err := h.ScriptCommands(log)
+		require.NoError(t, err, "ScriptCommands")
+		maps.Insert(cmds, maps.All(script.DefaultCmds()))
+
+		cmds["envoy"] = script.Command(
+			script.CmdUsage{Summary: "Show last Envoy resources", Args: "file"},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) != 1 {
+					return nil, fmt.Errorf("expected output filename")
+				}
+				f, err := os.OpenFile(s.Path(args[0]), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+				if err != nil {
+					return nil, err
+				}
+				defer f.Close()
+				_, err = fmt.Fprintf(f, "policy-trigger-count: %d\n", fakeEnvoy.policyTriggerCount.Load())
+				if err != nil {
+					return nil, err
+				}
+				for _, info := range fakeEnvoy.all() {
+					if info.res == nil {
+						_, err = fmt.Fprintf(f, "%s: count=%d listeners=<nil> endpoints=<nil>\n", info.name, info.count)
+						if err != nil {
+							return nil, err
+						}
+						continue
+					}
+					var listeners, endpoints []string
+					for _, l := range info.res.Listeners {
+						listeners = append(listeners,
+							fmt.Sprintf("%s/%d", l.Name, l.Address.GetSocketAddress().GetPortValue()))
+					}
+					sort.Strings(listeners)
+					for _, cla := range info.res.Endpoints {
+						for _, eps := range cla.Endpoints {
+							backends := make([]string, 0, len(eps.LbEndpoints))
+							for _, lep := range eps.LbEndpoints {
+								ep := lep.GetEndpoint()
+								sa := ep.Address.GetSocketAddress()
+								backends = append(backends, fmt.Sprintf("%s:%d", sa.Address, sa.GetPortValue()))
+							}
+							endpoints = append(endpoints, cla.ClusterName+"="+strings.Join(backends, ","))
+						}
+					}
+					sort.Strings(endpoints)
+					_, err = fmt.Fprintf(f, "%s: count=%d listeners=%s endpoints=%s\n", info.name, info.count, strings.Join(listeners, ","), strings.Join(endpoints, ","))
+					if err != nil {
+						return nil, err
+					}
+				}
+				return nil, nil
+			},
+		)
+		cmds["set-node-labels"] = script.Command(
+			script.CmdUsage{Summary: "Set local node labels", Args: "key=value..."},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				labels := map[string]string{}
+				for _, arg := range args {
+					key, value, found := strings.Cut(arg, "=")
+					if !found {
+						return nil, fmt.Errorf("bad key=value: %q", arg)
+					}
+					labels[key] = value
+				}
+				lns.Update(func(n *node.LocalNode) {
+					n.Labels = labels
+					s.Logf("Labels set to %v\n", labels)
+				})
+				return nil, nil
+			})
+
+		return &script.Engine{
+			Cmds: cmds,
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	scripttest.Test(t,
+		ctx,
+		setup,
+		[]string{},
+		"testdata/*.txtar")
+
+}
+
+type resourceStore struct {
+	count atomic.Int32
+	res   atomic.Pointer[envoy.Resources]
+}
+
+func (r *resourceStore) incr(res *envoy.Resources) {
+	r.count.Add(1)
+	r.res.Store(res)
+}
+
+type fakeEnvoySyncerAndPolicyTrigger struct {
+	update, delete     resourceStore
+	policyTriggerCount atomic.Int32
+}
+
+type resourceInfo struct {
+	name  string
+	count int32
+	res   *envoy.Resources
+}
+
+func (f *fakeEnvoySyncerAndPolicyTrigger) all() []resourceInfo {
+	return []resourceInfo{
+		{"update", f.update.count.Load(), f.update.res.Load()},
+		{"delete", f.delete.count.Load(), f.delete.res.Load()},
+	}
+}
+
+// DeleteResources implements envoySyncer.
+func (f *fakeEnvoySyncerAndPolicyTrigger) DeleteEnvoyResources(ctx context.Context, res envoy.Resources) error {
+	f.delete.incr(&res)
+	return nil
+}
+
+// UpdateResources implements envoySyncer.
+func (f *fakeEnvoySyncerAndPolicyTrigger) UpdateEnvoyResources(ctx context.Context, old envoy.Resources, new envoy.Resources) error {
+	f.update.incr(&new)
+	return nil
+}
+
+var _ resourceMutator = &fakeEnvoySyncerAndPolicyTrigger{}
+
+// TriggerPolicyUpdates implements policyTrigger.
+func (f *fakeEnvoySyncerAndPolicyTrigger) TriggerPolicyUpdates() {
+	f.policyTriggerCount.Add(1)
+}
+
+var _ policyTrigger = &fakeEnvoySyncerAndPolicyTrigger{}
+
+type staticPortAllocator struct{}
+
+// AckProxyPort implements PortAllocator.
+func (s staticPortAllocator) AckProxyPort(ctx context.Context, name string) error {
+	return nil
+}
+
+// AllocateCRDProxyPort implements PortAllocator.
+func (s staticPortAllocator) AllocateCRDProxyPort(name string) (uint16, error) {
+	return 1000, nil
+}
+
+// ReleaseProxyPort implements PortAllocator.
+func (s staticPortAllocator) ReleaseProxyPort(name string) error {
+	return nil
+}
+
+var _ PortAllocator = staticPortAllocator{}

--- a/pkg/ciliumenvoyconfig/testdata/anyport.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/anyport.txtar
@@ -1,0 +1,172 @@
+# Test handling of CiliumEnvoyConfig, without specifying service ports
+
+# Start the hive and wait for tables to be synchronized before adding k8s objects.
+hive start
+db initialized
+
+# Start with clean state.
+db cmp services services_empty.table
+db cmp ciliumenvoyconfigs cec_empty.table
+
+# Set up the services and endpoints
+k8s add service.yaml endpointslice.yaml
+db cmp services services.table
+
+# Add the CiliumEnvoyConfig and wait for it to be ingested.
+k8s add cec.yaml
+db cmp ciliumenvoyconfigs cec.table
+
+# Check that both services are now redirected to proxy.
+db cmp services services_redirected.table
+
+# Check BPF maps. The service should have L7 redirect set.
+lb-maps dump lbmaps.out
+* cmp lbmaps.out lbmaps.expected
+
+# Check that right updates towards Envoy happened.
+envoy envoy.out
+* cmp envoy.out envoy1.expected
+
+# Test the processing other way around, e.g. CEC exists before
+# the service. Start by dropping the backends.
+k8s delete endpointslice.yaml
+
+# Backends towards Envoy should be dropped.
+envoy envoy.out
+* cmp envoy.out envoy2.expected
+
+# Drop the service
+k8s delete service.yaml
+db cmp services services_empty.table
+
+# Add back the service and endpoints
+k8s add service.yaml endpointslice.yaml
+db cmp services services_redirected.table
+
+# Check again that updates happened.
+envoy envoy.out
+* cmp envoy.out envoy3.expected
+
+# Cleanup. Remove CEC and check that proxy redirect is gone.
+k8s delete cec.yaml
+db cmp services services.table
+db cmp ciliumenvoyconfigs cec_empty.table
+
+# The listener should now be deleted.
+envoy envoy.out
+* cmp envoy.out envoy4.expected
+
+# ---------------------------------------------
+
+-- services_empty.table --
+Name        ProxyRedirect
+
+-- services.table --
+Name        ProxyRedirect
+test/echo   
+
+-- services_redirected.table --
+Name        ProxyRedirect
+test/echo   1000
+
+-- cec_empty.table --
+Name    Services
+
+-- cec.table --
+Name                    Services
+test/envoy-lb-listener  test/echo
+
+-- cec.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: envoy-lb-listener
+  namespace: test
+spec:
+  services:
+    - name: echo
+      namespace: test
+      listener: envoy-lb-listener
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: envoy-lb-listener
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: smtp
+    nodePort: 30725
+    port: 25
+    protocol: TCP
+    targetPort: 25
+  selector:
+    name: echo
+  type: NodePort
+status:
+  loadBalancer: {}
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps1
+  namespace: test
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+- name: smtp
+  port: 25
+  protocol: TCP
+
+-- lbmaps.expected --
+BE: ID=1 ADDR=10.244.1.1:8080 STATE=active
+BE: ID=2 ADDR=10.244.1.1:25 STATE=active
+REV: ID=1 ADDR=10.96.50.104:80
+REV: ID=2 ADDR=10.96.50.104:25
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=0 BEID=59395 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
+SVC: ID=2 ADDR=10.96.50.104:25 SLOT=0 BEID=59395 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
+SVC: ID=2 ADDR=10.96.50.104:25 SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
+-- envoy1.expected --
+policy-trigger-count: 1
+update: count=1 listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=10.244.1.1:25,10.244.1.1:8080,test/echo=10.244.1.1:25,10.244.1.1:8080
+delete: count=0 listeners=<nil> endpoints=<nil>
+-- envoy2.expected --
+policy-trigger-count: 1
+update: count=2 listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=,test/echo=
+delete: count=0 listeners=<nil> endpoints=<nil>
+-- envoy3.expected --
+policy-trigger-count: 1
+update: count=3 listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=10.244.1.1:25,10.244.1.1:8080,test/echo=10.244.1.1:25,10.244.1.1:8080
+delete: count=0 listeners=<nil> endpoints=<nil>
+-- envoy4.expected --
+policy-trigger-count: 2
+update: count=3 listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=10.244.1.1:25,10.244.1.1:8080,test/echo=10.244.1.1:25,10.244.1.1:8080
+delete: count=1 listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=10.244.1.1:25,10.244.1.1:8080,test/echo=10.244.1.1:25,10.244.1.1:8080

--- a/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
@@ -1,0 +1,146 @@
+# Test handling of CiliumClusterwideEnvoyConfig
+
+# Start the hive and wait for tables to be synchronized before adding k8s objects.
+hive start
+db initialized
+
+# Start with clean state.
+db cmp services services_empty.table
+db cmp ciliumenvoyconfigs cec_empty.table
+
+# Set up the services and endpoints
+k8s add service.yaml endpointslice.yaml
+db cmp services services.table
+
+# Add the CiliumClusterwideEnvoyConfig and wait for it to be ingested.
+k8s add ccec.yaml
+db cmp ciliumenvoyconfigs cec.table
+
+# Check that both services are now redirected to proxy.
+db cmp services services_redirected.table
+
+# Check that right updates towards Envoy happened.
+envoy envoy.out
+* cmp envoy.out envoy1.expected
+
+# Test the processing other way around, e.g. CEC exists before
+# the service.
+k8s delete service.yaml endpointslice.yaml
+db cmp services services_empty.table
+
+# Backends towards Envoy should be updated.
+envoy envoy.out
+* cmp envoy.out envoy2.expected
+
+# Add back the service and endpoints
+k8s add service.yaml endpointslice.yaml
+db cmp services services_redirected.table
+
+# Check again that updates happened.
+envoy envoy.out
+* cmp envoy.out envoy3.expected
+
+# Cleanup. Remove CEC and check that proxy redirect is gone.
+k8s delete ccec.yaml
+db cmp services services.table
+db cmp ciliumenvoyconfigs cec_empty.table
+
+# The listener should now be deleted.
+envoy envoy.out
+* cmp envoy.out envoy4.expected
+
+# ---------------------------------------------
+
+-- services_empty.table --
+Name        ProxyRedirect
+
+-- services.table --
+Name        ProxyRedirect
+test/echo2    
+
+-- services_redirected.table --
+Name        ProxyRedirect
+test/echo2  1000
+
+-- cec_empty.table --
+Name    Services
+
+-- cec.table --
+Name                  Selected  Services    Listeners
+/envoy-lb-listener-2  true      test/echo2  /envoy-lb-listener-2/envoy-lb-listener-2:1000
+
+-- ccec.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideEnvoyConfig
+metadata:
+  name: envoy-lb-listener-2
+spec:
+  services:
+    - name: echo2
+      namespace: test
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: envoy-lb-listener-2
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo2
+  namespace: test
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo2
+  type: NodePort
+status:
+  loadBalancer: {}
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo2
+  name: echo2-eps1
+  namespace: test
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd76
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.2
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: tcp
+  port: 8081
+  protocol: TCP
+
+-- envoy1.expected --
+policy-trigger-count: 1
+update: count=1 listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=,test/echo2=
+delete: count=0 listeners=<nil> endpoints=<nil>
+-- envoy2.expected --
+policy-trigger-count: 1
+update: count=1 listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=,test/echo2=
+delete: count=0 listeners=<nil> endpoints=<nil>
+-- envoy3.expected --
+policy-trigger-count: 1
+update: count=1 listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=,test/echo2=
+delete: count=0 listeners=<nil> endpoints=<nil>
+-- envoy4.expected --
+policy-trigger-count: 2
+update: count=1 listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=,test/echo2=
+delete: count=1 listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=,test/echo2=

--- a/pkg/ciliumenvoyconfig/testdata/labels.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/labels.txtar
@@ -1,0 +1,83 @@
+# Test handling of node label based selection of CECs
+
+# Start the hive and wait for tables to be synchronized before adding k8s objects.
+hive start
+db initialized
+
+set-node-labels foo=a
+
+# Add CECs with foo=a and foo=b node selectors
+k8s add cec_a.yaml cec_b.yaml
+
+# CEC with foo=a should be selected.
+db cmp ciliumenvoyconfigs cec_a.table
+envoy envoy.out
+* cmp envoy.out envoy_a.expected
+
+# Update the node labels to flip the selected CECs
+set-node-labels foo=b
+
+# CEC with foo=b should be selected.
+db cmp ciliumenvoyconfigs cec_b.table
+envoy envoy.out
+* cmp envoy.out envoy_b.expected
+
+# ---------------------------------------------
+
+-- cec_empty.table --
+Name    Services
+
+-- cec_a.table --
+Name                    Selected  NodeSelector  StatusKind
+test/envoy-a            true      foo=a         Done
+test/envoy-b            false     foo=b         Done
+
+-- cec_b.table --
+Name                    Selected  NodeSelector  StatusKind
+test/envoy-a            false     foo=a         Done
+test/envoy-b            true      foo=b         Done
+
+-- cec_a.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: envoy-a
+  namespace: test
+spec:
+  nodeSelector:
+    matchLabels:
+      foo: a
+  services:
+    - name: a
+      namespace: test
+      listener: listener
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: envoy-lb-listener
+
+-- cec_b.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: envoy-b
+  namespace: test
+spec:
+  nodeSelector:
+    matchLabels:
+      foo: b
+  services:
+    - name: b
+      namespace: test
+      listener: listener
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: envoy-lb-listener
+
+-- envoy_a.expected --
+policy-trigger-count: 1
+update: count=1 listeners=test/envoy-a/envoy-lb-listener/1000 endpoints=test/a:*=,test/a=
+delete: count=0 listeners=<nil> endpoints=<nil>
+-- envoy_b.expected --
+policy-trigger-count: 1
+update: count=2 listeners=test/envoy-b/envoy-lb-listener/1000 endpoints=test/b:*=,test/b=
+delete: count=1 listeners=test/envoy-a/envoy-lb-listener/1000 endpoints=test/a:*=,test/a=

--- a/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
@@ -1,0 +1,174 @@
+# Test handling of CiliumEnvoyConfig
+
+# Start the hive and wait for tables to be synchronized before adding k8s objects.
+hive start
+db initialized
+
+# Start with clean state.
+db cmp services services_empty.table
+db cmp ciliumenvoyconfigs cec_empty.table
+
+# Set up the services and endpoints
+k8s add service.yaml endpointslice.yaml
+db cmp services services.table
+
+# Add the CiliumEnvoyConfig and wait for it to be ingested.
+k8s add cec.yaml
+db cmp ciliumenvoyconfigs cec.table
+
+# Check that both services are now redirected to proxy.
+db cmp services services_redirected.table
+
+# Check BPF maps. The service should have L7 redirect set.
+lb-maps dump lbmaps.out
+* cmp lbmaps.out lbmaps.expected
+
+# Check that right updates towards Envoy happened.
+envoy envoy.out
+* cmp envoy.out envoy1.expected
+
+# Test the processing other way around, e.g. CEC exists before
+# the service. Start by dropping the backends.
+k8s delete endpointslice.yaml
+
+# Backends towards Envoy should be dropped.
+envoy envoy.out
+* cmp envoy.out envoy2.expected
+
+# Drop the service
+k8s delete service.yaml
+db cmp services services_empty.table
+
+# Add back the service and endpoints
+k8s add service.yaml endpointslice.yaml
+db cmp services services_redirected.table
+
+# Check again that updates happened.
+envoy envoy.out
+* cmp envoy.out envoy3.expected
+
+# Cleanup. Remove CEC and check that proxy redirect is gone.
+k8s delete cec.yaml
+db cmp services services.table
+db cmp ciliumenvoyconfigs cec_empty.table
+
+# The listener should now be deleted.
+envoy envoy.out
+* cmp envoy.out envoy4.expected
+
+# ---------------------------------------------
+
+-- services_empty.table --
+Name        ProxyRedirect
+
+-- services.table --
+Name        ProxyRedirect
+test/echo   
+
+-- services_redirected.table --
+Name        ProxyRedirect
+test/echo   1000 (ports: [80])
+
+-- cec_empty.table --
+Name    Services
+
+-- cec.table --
+Name                    Services
+test/envoy-lb-listener  test/echo
+
+-- cec.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: envoy-lb-listener
+  namespace: test
+spec:
+  services:
+    - name: echo
+      namespace: test
+      listener: envoy-lb-listener
+      ports:
+      - 80
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: envoy-lb-listener
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: smtp
+    nodePort: 30725
+    port: 25
+    protocol: TCP
+    targetPort: 25
+  selector:
+    name: echo
+  type: NodePort
+status:
+  loadBalancer: {}
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps1
+  namespace: test
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+- name: smtp
+  port: 25
+  protocol: TCP
+
+-- lbmaps.expected --
+BE: ID=1 ADDR=10.244.1.1:8080 STATE=active
+BE: ID=2 ADDR=10.244.1.1:25 STATE=active
+REV: ID=1 ADDR=10.96.50.104:80
+REV: ID=2 ADDR=10.96.50.104:25
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=0 BEID=59395 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
+SVC: ID=2 ADDR=10.96.50.104:25 SLOT=0 BEID=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=10.96.50.104:25 SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- envoy1.expected --
+policy-trigger-count: 1
+update: count=1 listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=,test/echo:80=10.244.1.1:8080,test/echo=
+delete: count=0 listeners=<nil> endpoints=<nil>
+-- envoy2.expected --
+policy-trigger-count: 1
+update: count=2 listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=,test/echo=
+delete: count=0 listeners=<nil> endpoints=<nil>
+-- envoy3.expected --
+policy-trigger-count: 1
+update: count=3 listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=,test/echo:80=10.244.1.1:8080,test/echo=
+delete: count=0 listeners=<nil> endpoints=<nil>
+-- envoy4.expected --
+policy-trigger-count: 2
+update: count=3 listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=,test/echo:80=10.244.1.1:8080,test/echo=
+delete: count=1 listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=,test/echo:80=10.244.1.1:8080,test/echo=

--- a/pkg/dynamicconfig/reflectors.go
+++ b/pkg/dynamicconfig/reflectors.go
@@ -100,7 +100,7 @@ func configMapReflector(name string, namespace string, cs k8sClient.Clientset, t
 	return k8s.ReflectorConfig[DynamicConfig]{
 		Name:  "cm-" + name + "-" + namespace,
 		Table: t,
-		TransformMany: func(o any) []DynamicConfig {
+		TransformMany: func(_ statedb.ReadTxn, o any) []DynamicConfig {
 			cm := o.(*v1.ConfigMap).DeepCopy()
 			var entries = make([]DynamicConfig, 0, len(cm.Data))
 			for k, v := range cm.Data {
@@ -130,7 +130,7 @@ func ciliumNodeConfigReflector(name string, namespace string, cs k8sClient.Clien
 	return k8s.ReflectorConfig[DynamicConfig]{
 		Name:  "cnc-" + name + "-" + namespace,
 		Table: t,
-		TransformMany: func(o any) []DynamicConfig {
+		TransformMany: func(_ statedb.ReadTxn, o any) []DynamicConfig {
 			cnc := o.(*ciliumv2.CiliumNodeConfig).DeepCopy()
 			var entries = make([]DynamicConfig, 0, len(cnc.Spec.Defaults))
 			for k, v := range cnc.Spec.Defaults {
@@ -161,7 +161,7 @@ func ciliumNodeReflector(name string, cs k8sClient.Clientset, t statedb.RWTable[
 	return k8s.ReflectorConfig[DynamicConfig]{
 		Name:  "node-" + name,
 		Table: t,
-		TransformMany: func(o any) []DynamicConfig {
+		TransformMany: func(_ statedb.ReadTxn, o any) []DynamicConfig {
 			var entries []DynamicConfig
 			node := o.(*corev1.Node).DeepCopy()
 

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1957,7 +1957,7 @@ type Resources struct {
 	Endpoints []*envoy_config_endpoint.ClusterLoadAssignment
 
 	// Callback functions that are called if the corresponding Listener change was successfully acked by Envoy
-	PortAllocationCallbacks map[string]func(context.Context) error
+	PortAllocationCallbacks map[string]func(context.Context) error `json:"-"`
 }
 
 // ListenersAddedOrDeleted returns 'true' if a listener is added or removed when updating from 'old'

--- a/pkg/k8s/apis/cilium.io/v2/cec_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cec_types.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -104,6 +105,13 @@ type Service struct {
 	Ports []string `json:"number,omitempty"`
 }
 
+func (l *Service) ServiceName() loadbalancer.ServiceName {
+	return loadbalancer.ServiceName{
+		Namespace: l.Namespace,
+		Name:      l.Name,
+	}
+}
+
 type ServiceListener struct {
 	// Name is the name of a destination Kubernetes service that identifies traffic
 	// to be redirected.
@@ -133,6 +141,13 @@ type ServiceListener struct {
 	//
 	// +kubebuilder:validation:Optional
 	Listener string `json:"listener"`
+}
+
+func (l *ServiceListener) ServiceName() loadbalancer.ServiceName {
+	return loadbalancer.ServiceName{
+		Namespace: l.Namespace,
+		Name:      l.Name,
+	}
 }
 
 // +kubebuilder:pruning:PreserveUnknownFields

--- a/pkg/k8s/statedb_test.go
+++ b/pkg/k8s/statedb_test.go
@@ -211,7 +211,7 @@ func testStateDBReflector(t *testing.T, p reflectorTestParams) {
 
 	var transformFunc k8s.TransformFunc[*testObject]
 	if p.doTransform {
-		transformFunc = func(a any) (obj *testObject, ok bool) {
+		transformFunc = func(_ statedb.ReadTxn, a any) (obj *testObject, ok bool) {
 			transformCalled.Store(true)
 			obj = a.(*testObject).DeepCopy()
 			obj.Transform = "transform"
@@ -220,7 +220,7 @@ func testStateDBReflector(t *testing.T, p reflectorTestParams) {
 	}
 	var transformManyFunc k8s.TransformManyFunc[*testObject]
 	if p.doTransformMany {
-		transformManyFunc = func(a any) (objs []*testObject) {
+		transformManyFunc = func(_ statedb.ReadTxn, a any) (objs []*testObject) {
 			transformCalled.Store(true)
 			obj := a.(*testObject).DeepCopy()
 			obj.Transform = "transform-many"

--- a/pkg/loadbalancer/experimental/benchmark_test.go
+++ b/pkg/loadbalancer/experimental/benchmark_test.go
@@ -48,9 +48,10 @@ func benchmark_UpsertServiceAndFrontends(b *testing.B, numObjects int) {
 				Source: source.Kubernetes,
 			},
 			experimental.FrontendParams{
-				Address:  *loadbalancer.NewL3n4Addr(loadbalancer.TCP, addrCluster, 12345, loadbalancer.ScopeExternal),
-				Type:     loadbalancer.SVCTypeClusterIP,
-				PortName: "foo",
+				Address:     *loadbalancer.NewL3n4Addr(loadbalancer.TCP, addrCluster, 12345, loadbalancer.ScopeExternal),
+				Type:        loadbalancer.SVCTypeClusterIP,
+				PortName:    "foo",
+				ServicePort: 12345,
 			},
 		)
 	}
@@ -227,9 +228,10 @@ func BenchmarkReplaceService(b *testing.B) {
 				Source: source.Kubernetes,
 			},
 			experimental.FrontendParams{
-				Address:  l3n4Addr,
-				Type:     loadbalancer.SVCTypeClusterIP,
-				PortName: "",
+				Address:     l3n4Addr,
+				Type:        loadbalancer.SVCTypeClusterIP,
+				PortName:    "",
+				ServicePort: l3n4Addr.Port,
 			},
 		)
 	}

--- a/pkg/loadbalancer/experimental/bpf_reconciler.go
+++ b/pkg/loadbalancer/experimental/bpf_reconciler.go
@@ -529,7 +529,7 @@ func (ops *BPFOps) updateFrontend(fe *Frontend) error {
 		SessionAffinity:  svc.SessionAffinity,
 		IsRoutable:       isRoutable,
 		CheckSourceRange: len(svc.SourceRanges) > 0,
-		L7LoadBalancer:   svc.L7ProxyPort != 0,
+		L7LoadBalancer:   svc.ProxyRedirect.Redirects(fe.ServicePort),
 		LoopbackHostport: svc.LoopbackHostPort,
 		Quarantined:      false,
 	})
@@ -713,8 +713,8 @@ func (ops *BPFOps) upsertMaster(svcKey lbmap.ServiceKey, svcVal lbmap.ServiceVal
 	if svc.SessionAffinity {
 		svcVal.SetSessionAffinityTimeoutSec(uint32(svc.SessionAffinityTimeout.Seconds()))
 	}
-	if svc.L7ProxyPort != 0 {
-		svcVal.SetL7LBProxyPort(svc.L7ProxyPort)
+	if svc.ProxyRedirect.Redirects(fe.ServicePort) {
+		svcVal.SetL7LBProxyPort(svc.ProxyRedirect.ProxyPort)
 	}
 	return ops.upsertService(svcKey, svcVal)
 }

--- a/pkg/loadbalancer/experimental/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/experimental/bpf_reconciler_test.go
@@ -58,7 +58,7 @@ var baseService = Service{
 	IntTrafficPolicy:       loadbalancer.SVCTrafficPolicyLocal,
 	SessionAffinity:        false,
 	SessionAffinityTimeout: 0,
-	L7ProxyPort:            0,
+	ProxyRedirect:          nil,
 	LoopbackHostPort:       false,
 }
 
@@ -387,7 +387,9 @@ var proxyTestCases = []testCase{
 			// from how the backend ID is normally stored (host byte-order). Hence to make this
 			// work on both little and big-endian machine's the port is set to a value that's the
 			// same in both byte orders.
-			svc.L7ProxyPort = 0x0a0a // 2570
+			svc.ProxyRedirect = &ProxyRedirect{
+				ProxyPort: 0x0a0a, // 2570
+			}
 			return false, []Backend{baseBackend}
 		},
 		[]MapDump{

--- a/pkg/loadbalancer/experimental/frontend.go
+++ b/pkg/loadbalancer/experimental/frontend.go
@@ -32,6 +32,12 @@ type FrontendParams struct {
 	// PortName if set will select only backends with matching
 	// port name.
 	PortName loadbalancer.FEPortName
+
+	// ServicePort is the associated "ClusterIP" port of this frontend.
+	// Same as [Address.L4Addr.Port] except when [Type] NodePort or
+	// LoadBalancer. This is used to match frontends with the [Ports] of
+	// [Service.ProxyRedirect].
+	ServicePort uint16
 }
 
 type Frontend struct {

--- a/pkg/loadbalancer/experimental/service.go
+++ b/pkg/loadbalancer/experimental/service.go
@@ -4,6 +4,8 @@
 package experimental
 
 import (
+	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -49,9 +51,9 @@ type Service struct {
 	SessionAffinity        bool
 	SessionAffinityTimeout time.Duration
 
-	// L7ProxyPort if set redirects the traffic going to the frontends associated
-	// with this service to a layer 7 proxy running locally on this node.
-	L7ProxyPort uint16
+	// ProxyRedirect if non-nil redirects the traffic going to the frontends
+	// towards a locally running proxy.
+	ProxyRedirect *ProxyRedirect
 
 	// HealthCheckNodePort defines on which port the node runs a HTTP health
 	// check server which may be used by external loadbalancers to determine
@@ -72,6 +74,41 @@ type Service struct {
 	Properties part.Map[string, any]
 }
 
+type ProxyRedirect struct {
+	ProxyPort uint16
+
+	// Ports if non-empty will only redirect a frontend with a matching port.
+	Ports []uint16
+}
+
+func (pr *ProxyRedirect) Redirects(port uint16) bool {
+	if pr == nil {
+		return false
+	}
+	return len(pr.Ports) == 0 || slices.Contains(pr.Ports, port)
+}
+
+func (pr *ProxyRedirect) Equal(other *ProxyRedirect) bool {
+	switch {
+	case pr == nil && other == nil:
+		return true
+	case pr != nil && other != nil:
+		return pr.ProxyPort == other.ProxyPort && slices.Equal(pr.Ports, other.Ports)
+	default:
+		return false
+	}
+}
+
+func (pr *ProxyRedirect) String() string {
+	if pr == nil {
+		return ""
+	}
+	if len(pr.Ports) > 0 {
+		return fmt.Sprintf("%d (ports: %v)", pr.ProxyPort, pr.Ports)
+	}
+	return strconv.FormatUint(uint64(pr.ProxyPort), 10)
+}
+
 // Clone returns a shallow clone of the service, e.g. for updating a service with UpsertService. Fields that are references
 // (e.g. Labels or Annotations) must be further cloned if mutated.
 func (svc *Service) Clone() *Service {
@@ -89,7 +126,7 @@ func (svc *Service) TableHeader() []string {
 		"ExtTrafficPolicy",
 		"IntTrafficPolicy",
 		"SessionAffinity",
-		"L7ProxyPort",
+		"ProxyRedirect",
 		"HealthCheckNodePort",
 		"LoopbackHostPort",
 		"SourceRanges",
@@ -125,7 +162,7 @@ func (svc *Service) TableRow() []string {
 		string(svc.ExtTrafficPolicy),
 		string(svc.IntTrafficPolicy),
 		sessionAffinity,
-		strconv.FormatUint(uint64(svc.L7ProxyPort), 10),
+		svc.ProxyRedirect.String(),
 		strconv.FormatUint(uint64(svc.HealthCheckNodePort), 10),
 		showBool(svc.LoopbackHostPort),
 		showSourceRanges(svc.SourceRanges),

--- a/pkg/loadbalancer/experimental/testdata/clusterip.txtar
+++ b/pkg/loadbalancer/experimental/testdata/clusterip.txtar
@@ -22,8 +22,8 @@ db cmp backends backends_empty.table
 #####
 
 -- services.table --
-Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   L7ProxyPort   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/echo   k8s                  Cluster            Cluster                              0             0                     false              
+Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+test/echo   k8s                  Cluster            Cluster                              0                     false              
 
 -- frontends.table --
 Address               Type        ServiceName   PortName   Backends                     Status
@@ -34,7 +34,7 @@ Address             State    Instances          NodeName          ZoneID
 10.244.1.1:80/TCP   active   test/echo (http)   nodeport-worker   0
 
 -- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   L7ProxyPort   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
 
 -- frontends_empty.table --
 Address               Type        ServiceName   PortName   Status  Backends

--- a/pkg/loadbalancer/experimental/testdata/dualstack.txtar
+++ b/pkg/loadbalancer/experimental/testdata/dualstack.txtar
@@ -49,8 +49,8 @@ Address NodePort Primary DeviceName
 2001::1 true     true    test
 
 -- services.table --
-Name                     Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   L7ProxyPort   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-default/echo-dualstack   k8s                  Cluster            Cluster                              0             0                     false              
+Name                     Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+default/echo-dualstack   k8s                  Cluster            Cluster                              0                     false              
 
 -- frontends-ipv4.table --
 Address                     Type        ServiceName              PortName   Backends                                                                       Status
@@ -86,7 +86,7 @@ Address                        State    Instances                       NodeName
 [fd00:10:244:2::a314]:80/TCP   active   default/echo-dualstack (http)   dual-stack-worker2   0
 
 -- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   L7ProxyPort   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
 
 -- frontends_empty.table --
 Address               Type        ServiceName   PortName   Status  Backends

--- a/pkg/loadbalancer/experimental/testdata/graceful-termination.txtar
+++ b/pkg/loadbalancer/experimental/testdata/graceful-termination.txtar
@@ -29,8 +29,8 @@ db cmp backends backends_empty.table
 #####
 
 -- services.table --
-Name                     Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   L7ProxyPort   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/graceful-term-svc   k8s                  Cluster            Cluster                              0             0                     false              
+Name                     Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+test/graceful-term-svc   k8s                  Cluster            Cluster                              0                     false              
 
 -- frontends.table --
 Address                 Type        ServiceName              Backends                              Status
@@ -49,7 +49,7 @@ Address                 State         Instances                NodeName         
 10.244.0.112:8081/TCP   terminating   test/graceful-term-svc   graceful-term-control-plane   0
 
 -- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   L7ProxyPort   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
 
 -- frontends_empty.table --
 Address               Type        ServiceName   PortName   Status  Backends

--- a/pkg/loadbalancer/experimental/testdata/hostport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/hostport.txtar
@@ -35,8 +35,8 @@ Address NodePort Primary DeviceName
 1.1.1.1 true     true    test
 
 -- services.table --
-Name                                           Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   L7ProxyPort   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-default/my-app-85f46c4bd9-nnk25/host-port/4444 k8s                  Cluster            Cluster                              0             0                     false
+Name                                           Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+default/my-app-85f46c4bd9-nnk25/host-port/4444 k8s                  Cluster            Cluster                              0                     false
 
 -- frontends.table --
 Address           Type        ServiceName                                     PortName   Backends                      Status
@@ -47,7 +47,7 @@ Address                        State    Instances                               
 10.244.1.113:80/TCP            active   default/my-app-85f46c4bd9-nnk25/host-port/4444                       0
 
 -- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   L7ProxyPort   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
 
 -- frontends_empty.table --
 Address               Type        ServiceName   PortName   Status  Backends

--- a/pkg/loadbalancer/experimental/testdata/multiport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/multiport.txtar
@@ -22,8 +22,8 @@ db cmp backends backends_empty.table
 #####
 
 -- services.table --
-Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   L7ProxyPort   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/echo   k8s                  Cluster            Cluster                              0             0                     false              
+Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+test/echo   k8s                  Cluster            Cluster                              0                     false              
 
 -- frontends.table --
 
@@ -37,7 +37,7 @@ Address              State    Instances           NodeName          ZoneID
 10.244.1.1:443/TCP   active   test/echo (https)   nodeport-worker   0
 
 -- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   L7ProxyPort   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
 
 -- frontends_empty.table --
 Address               Type        ServiceName   PortName   Status  Backends

--- a/pkg/loadbalancer/experimental/testdata/nodeport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport.txtar
@@ -49,12 +49,12 @@ Address NodePort Primary DeviceName
 1.1.1.1 true     true    test
 
 -- services.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   L7ProxyPort   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/echo    k8s                  Cluster            Cluster                              0             0                     false              
-test/echo2   k8s                  Cluster            Cluster                              0             0                     false              
+Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+test/echo    k8s                  Cluster            Cluster                              0                     false              
+test/echo2   k8s                  Cluster            Cluster                              0                     false              
 
 -- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   L7ProxyPort   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
 
 
 -- frontends1.table --

--- a/pkg/loadbalancer/experimental/testdata/pruning.txtar
+++ b/pkg/loadbalancer/experimental/testdata/pruning.txtar
@@ -41,8 +41,8 @@ lb-maps cmp lbmaps-empty.dump
 #####
 
 -- services.table --
-Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   L7ProxyPort   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/echo   k8s                  Cluster            Cluster                              0             0                     false              
+Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+test/echo   k8s                  Cluster            Cluster                              0                     false              
 
 -- frontends.table --
 Address               Type        ServiceName   PortName   Backends                     Status
@@ -53,7 +53,7 @@ Address             State    Instances          NodeName          ZoneID
 10.244.1.1:80/TCP   active   test/echo (http)   nodeport-worker   0
 
 -- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   L7ProxyPort   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
 
 -- frontends_empty.table --
 Address               Type        ServiceName   PortName   Status  Backends

--- a/pkg/loadbalancer/experimental/testdata/source-ranges.txtar
+++ b/pkg/loadbalancer/experimental/testdata/source-ranges.txtar
@@ -22,8 +22,8 @@ db cmp backends backends_empty.table
 #####
 
 -- services.table --
-Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   L7ProxyPort   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/echo   k8s                  Cluster            Cluster                              0             0                     false              10.0.0.0/8
+Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+test/echo   k8s                  Cluster            Cluster                              0                     false              10.0.0.0/8
 
 -- frontends.table --
 Address               Type          ServiceName   PortName   Backends                     Status
@@ -35,7 +35,7 @@ Address             State    Instances          NodeName          ZoneID
 10.244.1.1:80/TCP   active   test/echo (http)   nodeport-worker   0
 
 -- services_empty.table --
-Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   L7ProxyPort   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
 
 -- frontends_empty.table --
 Address               Type        ServiceName   PortName   Status  Backends

--- a/pkg/loadbalancer/experimental/writer.go
+++ b/pkg/loadbalancer/experimental/writer.go
@@ -200,6 +200,9 @@ func (w *Writer) updateServiceReferences(txn WriteTxn, svc *Service) error {
 }
 
 func (w *Writer) newFrontend(txn statedb.ReadTxn, params FrontendParams, svc *Service) *Frontend {
+	if params.ServicePort == 0 {
+		params.ServicePort = params.Address.Port
+	}
 	fe := &Frontend{
 		FrontendParams: params,
 		service:        svc,

--- a/pkg/loadbalancer/experimental/writer_test.go
+++ b/pkg/loadbalancer/experimental/writer_test.go
@@ -112,6 +112,7 @@ func TestWriter_Service_UpsertDelete(t *testing.T) {
 				ServiceName: name,
 				Address:     frontend,
 				Type:        loadbalancer.SVCTypeClusterIP,
+				ServicePort: frontend.Port,
 			},
 		)
 		require.NoError(t, err, "UpsertServiceAndFrontends")
@@ -229,8 +230,9 @@ func TestWriter_Backend_UpsertDelete(t *testing.T) {
 				Source: source.Kubernetes,
 			},
 			experimental.FrontendParams{
-				Address: frontend,
-				Type:    loadbalancer.SVCTypeClusterIP,
+				Address:     frontend,
+				Type:        loadbalancer.SVCTypeClusterIP,
+				ServicePort: frontend.Port,
 			})
 
 		require.NoError(t, err, "UpsertService failed")
@@ -407,6 +409,7 @@ func TestWriter_Initializers(t *testing.T) {
 			ServiceName: name,
 			Address:     addr,
 			Type:        loadbalancer.SVCTypeClusterIP,
+			ServicePort: 12345,
 		},
 	)
 	require.NoError(t, err, "UpsertServiceAndFrontends")


### PR DESCRIPTION
This implements the CiliumEnvoyConfig handling against the experimental load-balancing control-plane (pkg/loadbalancer/experimental).

The `exp_cec.go` defines the `Table[CEC]` containing the envoy configs. The CEC object defines the full desired envoy Resources, including backends. Changes to the object are reconciled against the XDS server. 

The main moving parts around `Table[CEC]` are:
- Reflector: reflects the CiliumEnvoyConfig and CiliumClusterwideEnvoyConfig into Table[CEC]. The backends are filled in on the fly.
- Backend controller: Updates backends in the CEC object when they change
- Node label controller: Recomputes which CECs are selected when node labels change
- Proxy redirect controller: Watches `Table[CEC]` and sets the service L7 redirects accordingly.
- Reconciler: calls UpdateEnvoyResources/DeleteEnvoyResources to reconcile changes in the resources.

The implementation is tested with hive/script and builds on top of the test commands provided by the load-balancer control-plane:

- `testdata/namespaced.txtar`: Tests CiliumEnvoyConfig and validates calls towards Envoy and the LB BPF map contents
- `testdata/clusterwide.txtar`: Similar to namespaced.txtar but testing CiliumClusterwideEnvoyConfig
- `testdata/anyport.txtar`: Tests CiliumEnvoyConfig without port filtering
- `testdata/labels.txtar`: Tests selection of CiliumEnvoyConfigs based on node labels
