### PR TITLE
operator/watchers: skip expensive debug log operations when disabled

### DIFF
--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -33,15 +33,14 @@ func k8sServiceHandler(ctx context.Context, cinfo cmtypes.ClusterInfo, shared bo
 		svc.Cluster = cinfo.Name
 		svc.ClusterID = cinfo.ID
 
-		scopedLog := log.With(
+		log.Debug("Kubernetes service definition changed",
 			logfields.K8sSvcName, event.ID.Name,
 			logfields.K8sNamespace, event.ID.Namespace,
-			"action", event.Action.String(),
-			"service", event.Service.String(),
-			"endpoints", event.Endpoints.String(),
+			"action", event.Action,
+			"service", event.Service,
+			"endpoints", event.Endpoints,
 			"shared", event.Service.Shared,
 		)
-		scopedLog.Debug("Kubernetes service definition changed")
 
 		if shared && !event.Service.Shared {
 			// The annotation may have been added, delete an eventual existing service
@@ -54,7 +53,11 @@ func k8sServiceHandler(ctx context.Context, cinfo cmtypes.ClusterInfo, shared bo
 			if err := kvs.UpsertKey(ctx, &svc); err != nil {
 				// An error is triggered only in case it concerns service marshaling,
 				// as kvstore operations are automatically re-tried in case of error.
-				scopedLog.Warn("Failed synchronizing service", logfields.Error, err)
+				log.Warn("Failed synchronizing service",
+					logfields.Error, err,
+					logfields.K8sSvcName, event.ID.Name,
+					logfields.K8sNamespace, event.ID.Namespace,
+				)
 			}
 
 		case k8s.DeleteService:


### PR DESCRIPTION
Slightly modify the service handler debug statement to skip the expensive computation of service-related log fields when debug logs are disabled, as not used at all. In particular, rendering services and endpoints into the corresponding string representation is demanding both in terms of CPU time and memory allocations. Passing the original object as parameter, rather than the stringified version, allows to delegate this operation to slog, which is then skipped if debug logs are disabled.
    
Additionally, let's also rework the warning log to only include the service name and namespace as parameter for simplicity, as it is never expected to occur (all temporary errors are retried internally).

Related: 52c06e1b3b05 ("Add checks to avoid use of logrus WithFields function in hot paths")