### PR TITLE
datapath: Allow skipping kernel module loading

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3188,6 +3188,10 @@
      - Configure what the response should be to traffic for a service without backends. "reject" only works on kernels >= 5.10, on lower kernels we fallback to "drop". Possible values:  - reject (default)  - drop
      - string
      - ``"reject"``
+   * - :spelling:ignore:`skipKernelModuleValidation`
+     - 
+     - bool
+     - ``false``
    * - :spelling:ignore:`sleepAfterInit`
      - Do not run Cilium agent when running with clean mode. Useful to completely uninstall Cilium as it will stop Cilium from starting and create artifacts in the node.
      - bool

--- a/Documentation/installation/k8s-install-talos-linux.rst
+++ b/Documentation/installation/k8s-install-talos-linux.rst
@@ -9,7 +9,7 @@
 **Prerequisites / Limitations**
 
   - Cilium's Talos Linux support is only tested with Talos versions ``>=1.5.0``.
-  - As Talos `does not allow loading Kernel modules`_ by Kubernetes workloads, ``SYS_MODULE`` needs to be dropped from the Cilium default capability list.
+  - As Talos `does not allow loading Kernel modules`_ by Kubernetes workloads, ``skipKernelModuleValidation`` should be set to ``true`` and ``SYS_MODULE`` can be dropped from the Cilium default Linux capability list.
 
 .. _`does not allow loading Kernel modules`: https://www.talos.dev/latest/learn-more/process-capabilities/
 
@@ -25,7 +25,7 @@
     - `Kubernetes Host Scope<k8s_hostscope>` IPAM mode as Talos, by default, assigns ``PodCIDRs`` to ``v1.Node`` resources
 
 .. _`Cilium Helm chart`: https://github.com/cilium/charts
-.. _`Deploying Cilium CNI guide`: https://www.talos.dev/v1.6/kubernetes-guides/network/deploying-cilium/
+.. _`Deploying Cilium CNI guide`: https://www.talos.dev/latest/kubernetes-guides/network/deploying-cilium/
 
 **Configure Talos Linux**
 
@@ -77,6 +77,7 @@ Talos Linux node on ``localhost:7445``.
       --set=cgroup.autoMount.enabled=false \\
       --set=cgroup.hostRoot=/sys/fs/cgroup \\
       --set=k8sServiceHost=localhost \\
-      --set=k8sServicePort=7445
+      --set=k8sServicePort=7445 \\
+      --set=skipKernelModuleValidation=true
 
-.. _KubePrism: https://www.talos.dev/v1.6/kubernetes-guides/configuration/kubeprism/
+.. _KubePrism: https://www.talos.dev/latest/kubernetes-guides/configuration/kubeprism/

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -847,6 +847,7 @@ contributors across the globe, there is almost always someone available to help.
 | serviceAccounts.hubblecertgen | object | `{"annotations":{},"automount":true,"create":true,"name":"hubble-generate-certs"}` | Hubblecertgen is used if hubble.tls.auto.method=cronJob |
 | serviceAccounts.nodeinit.enabled | bool | `false` | Enabled is temporary until https://github.com/cilium/cilium-cli/issues/1396 is implemented. Cilium CLI doesn't create the SAs for node-init, thus the workaround. Helm is not affected by this issue. Name and automount can be configured, if enabled is set to true. Otherwise, they are ignored. Enabled can be removed once the issue is fixed. Cilium-nodeinit DS must also be fixed. |
 | serviceNoBackendResponse | string | `"reject"` | Configure what the response should be to traffic for a service without backends. "reject" only works on kernels >= 5.10, on lower kernels we fallback to "drop". Possible values:  - reject (default)  - drop |
+| skipKernelModuleValidation | bool | `false` |  |
 | sleepAfterInit | bool | `false` | Do not run Cilium agent when running with clean mode. Useful to completely uninstall Cilium as it will stop Cilium from starting and create artifacts in the node. |
 | socketLB | object | `{"enabled":false}` | Configure socket LB |
 | socketLB.enabled | bool | `false` | Enable socket LB |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -650,6 +650,7 @@ data:
 {{- end }}
 
   enable-xt-socket-fallback: {{ .Values.enableXTSocketFallback | quote }}
+  skip-kernel-module-validation: {{ .Values.skipKernelModuleValidation | quote }}
 {{- if or (.Values.azure.enabled) (.Values.eni.enabled) (.Values.gke.enabled) (ne $cniChainingMode "none") }}
   install-no-conntrack-iptables-rules: "false"
 {{- else }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -5245,6 +5245,9 @@
     "serviceNoBackendResponse": {
       "type": "string"
     },
+    "skipKernelModuleValidation": {
+      "type": "boolean"
+    },
     "sleepAfterInit": {
       "type": "boolean"
     },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -967,6 +967,11 @@ gatewayAPI:
 # properly. See documentation for details on when this can be disabled:
 # https://docs.cilium.io/en/stable/operations/system_requirements/#linux-kernel.
 enableXTSocketFallback: true
+# -- Skip Cilium's kernel module validation. Only enable this flag if all
+# required kernel modules are completely loaded on the underlying OS. Enabling
+# this allows Cilium to run without the Linux capability SYS_MODULE, which is
+# required on some container-optimized OSs like Talos Linux.
+skipKernelModuleValidation: false
 encryption:
   # -- Enable transparent network encryption.
   enabled: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -975,6 +975,13 @@ gatewayAPI:
 # properly. See documentation for details on when this can be disabled:
 # https://docs.cilium.io/en/stable/operations/system_requirements/#linux-kernel.
 enableXTSocketFallback: true
+
+# -- Skip Cilium's kernel module validation. Only enable this flag if all
+# required kernel modules are completely loaded on the underlying OS. Enabling
+# this allows Cilium to run without the Linux capability SYS_MODULE, which is
+# required on some container-optimized OSs like Talos Linux.
+skipKernelModuleValidation: false
+
 encryption:
   # -- Enable transparent network encryption.
   enabled: false

--- a/pkg/datapath/iptables/cell.go
+++ b/pkg/datapath/iptables/cell.go
@@ -34,6 +34,7 @@ var Cell = cell.Module(
 			EnableIPv4:                  cfg.EnableIPv4,
 			EnableIPv6:                  cfg.EnableIPv6,
 			EnableXTSocketFallback:      cfg.EnableXTSocketFallback,
+			SkipKernelModuleValidation:  cfg.SkipKernelModuleValidation,
 			EnableBPFTProxy:             cfg.EnableBPFTProxy,
 			InstallNoConntrackIptRules:  cfg.InstallNoConntrackIptRules,
 			EnableEndpointRoutes:        cfg.EnableEndpointRoutes,
@@ -88,6 +89,7 @@ type SharedConfig struct {
 	EnableIPv4                  bool
 	EnableIPv6                  bool
 	EnableXTSocketFallback      bool
+	SkipKernelModuleValidation  bool
 	EnableBPFTProxy             bool
 	InstallNoConntrackIptRules  bool
 	EnableEndpointRoutes        bool

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -365,14 +365,14 @@ func (m *Manager) Start(ctx cell.HookContext) error {
 		m.disableIPEarlyDemux()
 	}
 
-	if err := m.modulesMgr.FindOrLoadModules(
+	if err := m.modulesMgr.FindOrLoadModules(m.sharedCfg.SkipKernelModuleValidation,
 		"ip_tables", "iptable_nat", "iptable_mangle", "iptable_raw", "iptable_filter",
 	); err != nil {
 		m.logger.WithError(err).Warning(
 			"iptables modules could not be initialized. It probably means that iptables is not available on this system")
 	}
 
-	if err := m.modulesMgr.FindOrLoadModules(
+	if err := m.modulesMgr.FindOrLoadModules(m.sharedCfg.SkipKernelModuleValidation,
 		"ip6_tables", "ip6table_mangle", "ip6table_raw", "ip6table_filter",
 	); err != nil {
 		if m.sharedCfg.EnableIPv6 {
@@ -400,7 +400,7 @@ func (m *Manager) Start(ctx cell.HookContext) error {
 		}
 	}
 
-	if err := m.modulesMgr.FindOrLoadModules("xt_socket"); err != nil {
+	if err := m.modulesMgr.FindOrLoadModules(m.sharedCfg.SkipKernelModuleValidation, "xt_socket"); err != nil {
 		m.logger.WithError(err).Warning("xt_socket kernel module could not be loaded")
 
 		if !m.sharedCfg.TunnelingEnabled {
@@ -419,6 +419,7 @@ func (m *Manager) Start(ctx cell.HookContext) error {
 			// We would not need the xt_socket at all if the datapath universally would
 			// set the "to proxy" skb mark bits on before the packet hits policy routing
 			// stage. Currently this is not true for endpoint routing modes.
+
 			if m.sharedCfg.EnableXTSocketFallback {
 				m.disableIPEarlyDemux()
 			}

--- a/pkg/datapath/linux/modules/modules.go
+++ b/pkg/datapath/linux/modules/modules.go
@@ -10,7 +10,13 @@ import (
 
 	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/slices"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "modules")
 )
 
 // Manager stores information about loaded modules and provides a search operation.
@@ -30,8 +36,12 @@ func (m *Manager) FindModules(expectedNames ...string) (bool, []string) {
 }
 
 // FindOrLoadModules checks whether the given kernel modules are loaded and
-// tries to load those which are not.
-func (m *Manager) FindOrLoadModules(expectedNames ...string) error {
+// tries to load those which are not. Skip this validation if instructed to do so.
+func (m *Manager) FindOrLoadModules(skipValidation bool, expectedNames ...string) error {
+	if skipValidation {
+		log.Warningf("skipped validating and loading the following kernel modules: %s)", expectedNames)
+		return nil
+	}
 	found, diff := m.FindModules(expectedNames...)
 	if found {
 		return nil

--- a/pkg/datapath/linux/modules/modules_linux_privileged_test.go
+++ b/pkg/datapath/linux/modules/modules_linux_privileged_test.go
@@ -20,16 +20,29 @@ func TestFindOrLoadModules(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	testCases := []struct {
-		modulesToFind []string
-		expectedErr   bool
+		skipValidation bool
+		modulesToFind  []string
+		expectedErr    bool
 	}{
 		{
-			modulesToFind: []string{"bridge"},
-			expectedErr:   false,
+			skipValidation: false,
+			modulesToFind:  []string{"bridge"},
+			expectedErr:    false,
 		},
 		{
-			modulesToFind: []string{"foo", "bar"},
-			expectedErr:   true,
+			skipValidation: false,
+			modulesToFind:  []string{"foo", "bar"},
+			expectedErr:    true,
+		},
+		{
+			skipValidation: true,
+			modulesToFind:  []string{"bridge"},
+			expectedErr:    false,
+		},
+		{
+			skipValidation: true,
+			modulesToFind:  []string{"foo", "bar"},
+			expectedErr:    false,
 		},
 	}
 
@@ -48,7 +61,7 @@ func TestFindOrLoadModules(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		err := manager.FindOrLoadModules(tc.modulesToFind...)
+		err := manager.FindOrLoadModules(tc.skipValidation, tc.modulesToFind...)
 		if tc.expectedErr && err == nil {
 			t.Fatal("expected error from FindOrLoadModules but none found")
 		}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -740,6 +740,9 @@ const (
 	// EnableXTSocketFallbackName is the name of the EnableXTSocketFallback option
 	EnableXTSocketFallbackName = "enable-xt-socket-fallback"
 
+	// SkipKernelModuleValidationName is the name of the SkipKernelModuleValidation option
+	SkipKernelModuleValidationName = "skip-kernel-module-validation"
+
 	// EnableAutoDirectRoutingName is the name for the EnableAutoDirectRouting option
 	EnableAutoDirectRoutingName = "auto-direct-node-routes"
 
@@ -1732,6 +1735,10 @@ type DaemonConfig struct {
 	// EnableXTSocketFallback allows disabling of kernel's ip_early_demux
 	// sysctl option if `xt_socket` kernel module is not available.
 	EnableXTSocketFallback bool
+
+	// SkipKernelModuleValidation instructs Cilium to skip all kernel module
+	// loads, assuming they're already loaded.
+	SkipKernelModuleValidation bool
 
 	// EnableBPFTProxy enables implementing proxy redirection via BPF
 	// mechanisms rather than iptables rules.
@@ -2821,6 +2828,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableSocketLBPodConnectionTermination = vp.GetBool(EnableSocketLBPodConnectionTermination)
 	c.EnableBPFTProxy = vp.GetBool(EnableBPFTProxy)
 	c.EnableXTSocketFallback = vp.GetBool(EnableXTSocketFallbackName)
+	c.SkipKernelModuleValidation = vp.GetBool(SkipKernelModuleValidationName)
 	c.EnableAutoDirectRouting = vp.GetBool(EnableAutoDirectRoutingName)
 	c.DirectRoutingSkipUnreachable = vp.GetBool(DirectRoutingSkipUnreachableName)
 	c.EnableEndpointRoutes = vp.GetBool(EnableEndpointRoutes)


### PR DESCRIPTION
On some (often container-optimized) operating systems like Talos Linux workload isn't allowed to make use of CAP_SYS_MODULE. In such cases, Cilium can't actually load any required kernel modules (like ip_tables, xt_socket, etc.), even though it needs them to run properly.

Before this change, Cilium tried to load the kernel modules, and if it wasn't successful, it issued a warning ('xt_socket') or an error ('ip_tables', etc.). After that, depending on the outcome, it either didn't install a specific iptables rule ('xt_socket') or ignored this fact and still installed various iptables rules. This commit doesn't change this behavior but at least allows advanced users, via an optional (and by default disabled) flag, to instruct Cilium not to even try to load any kernel modules. **It's then up to the OS/user to ensure all required modules are loaded before Cilium is started!**

```release-note
datapath: Allow skipping kernel module loading
```

Before (`skipKernelModuleValidation=false` (default case), unchanged behaviour):
```bash
time="2024-10-29T09:51:46.40150825Z" level=warning msg="iptables modules could not be initialized. It probably means that iptables is not available on this system" error="could not load modu
le ip_tables: exit status 1" subsys=iptables
time="2024-10-29T09:51:46.402358584Z" level=debug msg="ip6tables kernel modules could not be loaded, so IPv6 cannot be used" error="could not load module ip6_tables: exit status 1" subsys=ip
tables
time="2024-10-29T09:51:46.4031345Z" level=warning msg="xt_socket kernel module could not be loaded" error="could not load module xt_socket: exit status 1" subsys=iptables
```


After (`skipKernelModuleValidation=true`):
```bash
time="2024-10-29T11:27:37.904587885Z" level=warning msg="skipped validating and loading the following kernel modules: [ip_tables iptable_nat iptable_mangle iptable_raw iptable_filter])" subs
ys=modules
time="2024-10-29T11:27:37.90460826Z" level=warning msg="skipped validating and loading the following kernel modules: [ip6_tables ip6table_mangle ip6table_raw ip6table_filter])" subsys=module
s
time="2024-10-29T11:27:37.90465701Z" level=warning msg="skipped validating and loading the following kernel modules: [xt_socket])" subsys=modules
```

I print it as a warning as this could be significant if somebody configures `skipKernelModuleValidation=true` but isn't 100% aware of the impact.