### PR TITLE
cilium-cli: Ignore "No egress gateway found" drops

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -581,13 +581,6 @@ jobs:
             EXTRA+=("\"--secondary-network-iface=eth1\"")
           fi
 
-          # it's fine to ignore the "No egress gateway found" drop reason as this may be caused by the kind=echo pods
-          # sending traffic while the egressgw policy map is still being populated.
-          #
-          # The actual connectivity test will ensure that the map is in sync with the policy and that egressgw traffic
-          # always go through the correct gateway
-          EXTRA+=("\"--expected-drop-reasons=+No egress gateway found\"")
-
           if [ "${{ matrix.encryption-strict-mode }}" = "true" ]; then
             # "Test Cilium after upgrade" ran strict-mode-encryption test which caused temporary drops.
             EXTRA+=("\"--expected-drop-reasons=+Traffic is unencrypted\"")

--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -160,6 +160,7 @@ var (
 		"Host datapath not ready",
 		"Unknown ICMPv4 code",
 		"Forbidden ICMPv6 message",
+		"No egress gateway found",
 	}
 
 	ExpectedXFRMErrors = []string{


### PR DESCRIPTION
Those drops currently need to be ignored in all tests involving the egress gateway, so we might as well ignore them by default in the connectivity tests.