### PR TITLE
Miscellaneous improvements to the sysdump collection

### DIFF
--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -23,6 +23,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -901,6 +902,10 @@ func (c *Client) ListUnstructured(ctx context.Context, gvr schema.GroupVersionRe
 
 func (c *Client) ListEndpoints(ctx context.Context, o metav1.ListOptions) (*corev1.EndpointsList, error) {
 	return c.Clientset.CoreV1().Endpoints(corev1.NamespaceAll).List(ctx, o)
+}
+
+func (c *Client) ListEndpointSlices(ctx context.Context, o metav1.ListOptions) (*discoveryv1.EndpointSliceList, error) {
+	return c.Clientset.DiscoveryV1().EndpointSlices(corev1.NamespaceAll).List(ctx, o)
 }
 
 func (c *Client) ListIngressClasses(ctx context.Context, o metav1.ListOptions) (*networkingv1.IngressClassList, error) {

--- a/cilium-cli/sysdump/client.go
+++ b/cilium-cli/sysdump/client.go
@@ -12,6 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -71,6 +72,7 @@ type KubernetesClient interface {
 	ListDaemonSet(ctx context.Context, namespace string, o metav1.ListOptions) (*appsv1.DaemonSetList, error)
 	ListEvents(ctx context.Context, o metav1.ListOptions) (*corev1.EventList, error)
 	ListEndpoints(ctx context.Context, o metav1.ListOptions) (*corev1.EndpointsList, error)
+	ListEndpointSlices(ctx context.Context, o metav1.ListOptions) (*discoveryv1.EndpointSliceList, error)
 	ListIngressClasses(ctx context.Context, o metav1.ListOptions) (*networkingv1.IngressClassList, error)
 	ListIngresses(ctx context.Context, o metav1.ListOptions) (*networkingv1.IngressList, error)
 	ListNamespaces(ctx context.Context, o metav1.ListOptions) (*corev1.NamespaceList, error)

--- a/cilium-cli/sysdump/constants.go
+++ b/cilium-cli/sysdump/constants.go
@@ -97,6 +97,7 @@ const (
 	hubbleGenerateCertsCronJobFileName       = "hubble-generate-certs-cronjob-<ts>.yaml"
 	hubbleCertificatesFileName               = "hubble-certificates-<ts>.yaml"
 	kubernetesEndpointsFileName              = "k8s-endpoints-<ts>.yaml"
+	kubernetesEndpointSlicesFileName         = "k8s-endpointslices-<ts>.yaml"
 	kubernetesEventsFileName                 = "k8s-events-<ts>.yaml"
 	kubernetesEventsTableFileName            = "k8s-events-<ts>.html"
 	kubernetesLeasesFileName                 = "k8s-leases-<ts>.yaml"

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -520,6 +520,20 @@ func (c *Collector) Run() error {
 			},
 		},
 		{
+			Description: "Collecting Kubernetes endpointslices",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.ListEndpointSlices(ctx, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect Kubernetes endpointslices: %w", err)
+				}
+				if err := c.WriteYAML(kubernetesEndpointSlicesFileName, v); err != nil {
+					return fmt.Errorf("failed to collect Kubernetes endpointslices: %w", err)
+				}
+				return nil
+			},
+		},
+		{
 			Description: "Collecting Kubernetes leases",
 			Quick:       true,
 			Task: func(ctx context.Context) error {

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -1203,20 +1203,6 @@ func (c *Collector) Run() error {
 		},
 		{
 			CreatesSubtasks: true,
-			Description:     "Collecting profiling data from Cilium pods",
-			Quick:           false,
-			Task: func(_ context.Context) error {
-				if !c.Options.Profiling {
-					return nil
-				}
-				if err := c.SubmitProfilingGopsSubtasks(c.CiliumPods, ciliumAgentContainerName); err != nil {
-					return fmt.Errorf("failed to collect profiling data from Cilium pods: %w", err)
-				}
-				return nil
-			},
-		},
-		{
-			CreatesSubtasks: true,
 			Description:     "Collecting profiling data from Cilium Operator pods",
 			Quick:           false,
 			Task: func(_ context.Context) error {
@@ -1432,6 +1418,19 @@ func (c *Collector) Run() error {
 		tasks = append(tasks, ciliumTasks...)
 
 		serialTasks = append(serialTasks, Task{
+			CreatesSubtasks: true,
+			Description:     "Collecting profiling data from Cilium pods",
+			Quick:           false,
+			Task: func(_ context.Context) error {
+				if !c.Options.Profiling {
+					return nil
+				}
+				if err := c.SubmitProfilingGopsSubtasks(c.CiliumPods, ciliumAgentContainerName); err != nil {
+					return fmt.Errorf("failed to collect profiling data from Cilium pods: %w", err)
+				}
+				return nil
+			},
+		}, Task{
 			CreatesSubtasks: true,
 			Description:     "Collecting tracing data from Cilium pods",
 			Quick:           false,

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -163,6 +163,8 @@ type Collector struct {
 	NodeList []string
 	// CiliumPods is a list of Cilium agent pods running on nodes in NodeList.
 	CiliumPods []*corev1.Pod
+	// CiliumOperatorPods is the list of Cilium operator pods.
+	CiliumOperatorPods []*corev1.Pod
 	// CiliumConfigMap is a pointer to cilium-config ConfigMap.
 	CiliumConfigMap *corev1.ConfigMap
 	// additionalTasks keeps track of additional tasks added via AddTasks.
@@ -296,6 +298,16 @@ func NewCollector(
 			c.FeatureSet.ExtractFromConfigMap(c.CiliumConfigMap)
 			c.log("🔮 Detected Cilium features: %v", c.FeatureSet)
 		}
+	}
+
+	if c.Options.CiliumOperatorNamespace != "" {
+		pods, err := c.Client.ListPods(context.Background(), c.Options.CiliumOperatorNamespace, metav1.ListOptions{
+			LabelSelector: c.Options.CiliumOperatorLabelSelector,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get Cilium operator pods: %w", err)
+		}
+		c.CiliumOperatorPods = AllPods(pods)
 	}
 
 	if err := hooks.AddSysdumpTasks(c); err != nil {
@@ -1016,12 +1028,8 @@ func (c *Collector) Run() error {
 			CreatesSubtasks: true,
 			Description:     "Collecting the Cilium operator metrics",
 			Quick:           false,
-			Task: func(ctx context.Context) error {
-				pods, err := c.Client.ListPods(ctx, c.Options.CiliumOperatorNamespace, metav1.ListOptions{LabelSelector: defaults.OperatorPodSelector})
-				if err != nil {
-					return fmt.Errorf("failed to get the Cilium operator pods: %w", err)
-				}
-				err = c.SubmitMetricsSubtask(pods, defaults.OperatorContainerName, defaults.OperatorMetricsPortName)
+			Task: func(_ context.Context) error {
+				err := c.SubmitMetricsSubtask(c.CiliumOperatorPods, defaults.OperatorContainerName, defaults.OperatorMetricsPortName)
 				if err != nil {
 					return fmt.Errorf("failed to collect the Cilium operator metrics: %w", err)
 				}
@@ -1034,10 +1042,12 @@ func (c *Collector) Run() error {
 			Quick:           false,
 			Task: func(ctx context.Context) error {
 				// clustermesh-apiserver runs in the same namespace as operator
-				pods, err := c.Client.ListPods(ctx, c.Options.CiliumOperatorNamespace, metav1.ListOptions{LabelSelector: defaults.ClusterMeshPodSelector})
+				p, err := c.Client.ListPods(ctx, c.Options.CiliumOperatorNamespace, metav1.ListOptions{LabelSelector: defaults.ClusterMeshPodSelector})
 				if err != nil {
 					return fmt.Errorf("failed to get the Cilium clustermesh pods: %w", err)
 				}
+
+				pods := AllPods(p)
 
 				err = c.submitClusterMeshAPIServerDbgTasks(pods)
 				if err != nil {
@@ -1061,13 +1071,13 @@ func (c *Collector) Run() error {
 					defaults.ClusterMeshContainerName:            ciliumdef.GopsPortApiserver,
 					defaults.ClusterMeshKVStoreMeshContainerName: ciliumdef.GopsPortKVStoreMesh,
 				} {
-					err = c.SubmitGopsSubtasks(AllPods(pods), container)
+					err = c.SubmitGopsSubtasks(pods, container)
 					if err != nil {
 						return fmt.Errorf("failed to collect the Cilium clustermesh gops stats: %w", err)
 					}
 
 					if c.Options.Profiling {
-						err = c.SubmitStreamProfilingGopsSubtasks(AllPods(pods), container, port)
+						err = c.SubmitStreamProfilingGopsSubtasks(pods, container, port)
 						if err != nil {
 							return fmt.Errorf("failed to collect the Cilium clustermesh profiles: %w", err)
 						}
@@ -1140,13 +1150,7 @@ func (c *Collector) Run() error {
 			Description:     "Collecting gops stats from Cilium-operator pods",
 			Quick:           true,
 			Task: func(ctx context.Context) error {
-				p, err := c.Client.ListPods(ctx, c.Options.CiliumNamespace, metav1.ListOptions{
-					LabelSelector: c.Options.CiliumOperatorLabelSelector,
-				})
-				if err != nil {
-					return fmt.Errorf("failed to get cilium-operator pods: %w", err)
-				}
-				if err := c.SubmitGopsSubtasks(AllPods(p), ciliumOperatorContainerName); err != nil {
+				if err := c.SubmitGopsSubtasks(c.CiliumOperatorPods, ciliumOperatorContainerName); err != nil {
 					return fmt.Errorf("failed to collect cilium-operator gops stats: %w", err)
 				}
 				return nil
@@ -1261,13 +1265,7 @@ func (c *Collector) Run() error {
 			Description:     "Collecting logs from Cilium operator pods",
 			Quick:           false,
 			Task: func(ctx context.Context) error {
-				p, err := c.Client.ListPods(ctx, c.Options.CiliumNamespace, metav1.ListOptions{
-					LabelSelector: c.Options.CiliumOperatorLabelSelector,
-				})
-				if err != nil {
-					return fmt.Errorf("failed to get logs from Cilium operator pods")
-				}
-				if err := c.SubmitLogsTasks(AllPods(p), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
+				if err := c.SubmitLogsTasks(c.CiliumOperatorPods, c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
 					return fmt.Errorf("failed to collect logs from Cilium operator pods")
 				}
 				return nil
@@ -2842,10 +2840,10 @@ func (c *Collector) submitKVStoreTasks(ctx context.Context, pod *corev1.Pod) err
 }
 
 // SubmitMetricsSubtask submits tasks to collect metrics from pods.
-func (c *Collector) SubmitMetricsSubtask(pods *corev1.PodList, containerName, portName string) error {
-	for _, p := range pods.Items {
+func (c *Collector) SubmitMetricsSubtask(pods []*corev1.Pod, containerName, portName string) error {
+	for _, p := range pods {
 		p := p
-		if !podIsRunningAndHasContainer(&p, containerName) {
+		if !podIsRunningAndHasContainer(p, containerName) {
 			continue
 		}
 		err := c.Pool.Submit(fmt.Sprintf("metrics-%s-%s-%s", p.Name, containerName, portName), func(ctx context.Context) error {
@@ -2869,7 +2867,7 @@ func (c *Collector) SubmitMetricsSubtask(pods *corev1.PodList, containerName, po
 	return nil
 }
 
-func (c *Collector) submitClusterMeshAPIServerDbgTasks(pods *corev1.PodList) error {
+func (c *Collector) submitClusterMeshAPIServerDbgTasks(pods []*corev1.Pod) error {
 	tasks := []struct {
 		name      string
 		ext       string
@@ -2913,9 +2911,9 @@ func (c *Collector) submitClusterMeshAPIServerDbgTasks(pods *corev1.PodList) err
 		},
 	}
 
-	for _, pod := range pods.Items {
+	for _, pod := range pods {
 		for _, task := range tasks {
-			if !podIsRunningAndHasContainer(&pod, task.container) {
+			if !podIsRunningAndHasContainer(pod, task.container) {
 				continue
 			}
 
@@ -2950,7 +2948,7 @@ func (c *Collector) submitClusterMeshAPIServerDbgTasks(pods *corev1.PodList) err
 	return nil
 }
 
-func getPodMetricsPort(pod corev1.Pod, containerName, portName string) (int32, error) {
+func getPodMetricsPort(pod *corev1.Pod, containerName, portName string) (int32, error) {
 	for _, container := range pod.Spec.Containers {
 		if container.Name != containerName {
 			continue

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -1217,6 +1217,22 @@ func (c *Collector) Run() error {
 		},
 		{
 			CreatesSubtasks: true,
+			Description:     "Collecting profiling data from Cilium Operator pods",
+			Quick:           false,
+			Task: func(_ context.Context) error {
+				if !c.Options.Profiling {
+					return nil
+				}
+
+				err := c.SubmitStreamProfilingGopsSubtasks(c.CiliumOperatorPods, ciliumOperatorContainerName, ciliumdef.GopsPortOperator)
+				if err != nil {
+					return fmt.Errorf("failed to collect cilium-operator profiles: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			CreatesSubtasks: true,
 			Description:     "Collecting logs from Cilium pods",
 			Quick:           false,
 			Task: func(_ context.Context) error {

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -1146,8 +1146,8 @@ func (c *Collector) Run() error {
 				if err != nil {
 					return fmt.Errorf("failed to get cilium-operator pods: %w", err)
 				}
-				if err := c.SubmitGopsSubtasks(FilterPods(p, c.NodeList), ciliumOperatorContainerName); err != nil {
-					return fmt.Errorf("failed to collect Cilium gops: %w", err)
+				if err := c.SubmitGopsSubtasks(AllPods(p), ciliumOperatorContainerName); err != nil {
+					return fmt.Errorf("failed to collect cilium-operator gops stats: %w", err)
 				}
 				return nil
 			},

--- a/cilium-cli/sysdump/sysdump_test.go
+++ b/cilium-cli/sysdump/sysdump_test.go
@@ -21,6 +21,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -515,6 +516,10 @@ func (c *fakeClient) ListNamespaces(_ context.Context, _ metav1.ListOptions) (*c
 }
 
 func (c *fakeClient) ListEndpoints(_ context.Context, _ metav1.ListOptions) (*corev1.EndpointsList, error) {
+	panic("implement me")
+}
+
+func (c *fakeClient) ListEndpointSlices(_ context.Context, _ metav1.ListOptions) (*discoveryv1.EndpointSliceList, error) {
 	panic("implement me")
 }
 


### PR DESCRIPTION
Please refer to the individual commit messages for additional details.

* Collect Kubernetes EndpointSlice information;
* Always gather Cilium operator gops stats;
* Uniform the retrieval of Cilium operator pods, to ensure consistency and reduce API calls;
* Collect Cilium operator profiling data;
* Move Cilium profiling data collection as first task, to prevent interferences