### PR TITLE
[v1.16] ipam: Fix IPv4 native routing CIDR auto detection

### DIFF
--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -274,6 +274,7 @@ func (n *nodeStore) autoDetectIPv4NativeRoutingCIDR(localNodeStore *node.LocalNo
 			localNodeStore.Update(func(n *node.LocalNode) {
 				n.IPv4NativeRoutingCIDR = primaryCIDR
 			})
+			n.conf.SetIPv4NativeRoutingCIDR(primaryCIDR)
 		}
 		return true
 	} else {


### PR DESCRIPTION
BPF Masquerading relies on IPV4_SNAT_EXCLUSION_DST_CIDR datapath config value to know which destination CIDRs should not be SNATed for pod to pod traffic.

In case of IPAM modes "eni", "azure" or "alibabacloud", if "ipv4-native-routing-cidr" is not explicitly set, the exclusion destination CIDR is autodetected at runtime, specifically from the relevant cloud provider Status section in the CiliumNode CRD.

In commit #50e42f1659 the way that autodetection logic propagates that value was changed and it now relies on the LocalNodeStore to emit an update for the new IPv4 native routing CIDR value. But the datapath still reads the value stored in the global config option variable, thus it ignores the update from the autodetection logic.

To let the datapath configure the correct SNAT exclusion CIDR, restore the previous logic to update the global config option variable alongside the propagation of the updated value with LocalNodeStore.

Related: 50e42f1659 ("node: Add ip{v4,v6} native routing CIDR")
Fixes: #34615

```release-note
Fixes BPF Masquerading exclusion CIDR for IPAM modes "eni", "azure" and "alibabacloud".
```
