### PR TITLE
sysdump: Collect crashed pod logs in cilium-test namespaces

### DIFF
--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -548,6 +548,30 @@ func (c *Collector) Run() error {
 				return nil
 			},
 		},
+		{
+			Description: "Collecting crashed test pod logs",
+			Quick:       false,
+			Task: func(ctx context.Context) error {
+				namespaces, err := c.Client.ListNamespaces(ctx, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to get namespaces")
+				}
+				for _, namespace := range namespaces.Items {
+					if !strings.HasPrefix(namespace.Name, defaults.ConnectivityCheckNamespace) {
+						continue
+					}
+
+					p, err := c.Client.ListPods(ctx, namespace.Name, metav1.ListOptions{})
+					if err != nil {
+						return fmt.Errorf("failed to get logs from Hubble certgen pods")
+					}
+					if err := c.SubmitLogsTasks(filterCrashedPods(p), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
+						return fmt.Errorf("failed to collect logs from Hubble certgen pods")
+					}
+				}
+				return nil
+			},
+		},
 	}
 
 	// task that needs to be executed "serially" (i.e: not concurrently with other tasks).
@@ -2986,6 +3010,17 @@ func AllPods(l *corev1.PodList) []*corev1.Pod {
 // FilterPods filters a list of pods by node names.
 func FilterPods(l *corev1.PodList, n []string) []*corev1.Pod {
 	return filterPods(l, func(po *corev1.Pod) bool { return slices.Contains(n, po.Spec.NodeName) })
+}
+
+func filterCrashedPods(l *corev1.PodList) []*corev1.Pod {
+	return filterPods(l, func(po *corev1.Pod) bool {
+		for _, containerStatus := range po.Status.ContainerStatuses {
+			if containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Reason == "CrashLoopBackOff" {
+				return true
+			}
+		}
+		return false
+	})
 }
 
 func filterPods(l *corev1.PodList, filter func(po *corev1.Pod) bool) []*corev1.Pod {


### PR DESCRIPTION
With this patch, cilium-cli sysdump collects pod logs with `CrashLoopBackOff` status in cilium-test* namespaces.

An example of use case is https://github.com/cilium/cilium/actions/runs/11574170010 which fails to run echo pods for connectivity test. Now that sysdump can collect logs of echo pods, we can easily find the cause by checking their logs:

```
# cat logs-echo-same-node-6c868b545b-l9hbr-echo-same-node-20241029-125929.log 

2024-10-29T12:57:35.817979304Z Error: EMFILE: too many open files, watch '/'
2024-10-29T12:57:35.817994894Z     at FSWatcher.<computed> (node:internal/fs/watchers:247:19)
2024-10-29T12:57:35.817997989Z     at Object.watch (node:fs:2469:36)
2024-10-29T12:57:35.818000935Z     at /usr/local/lib/node_modules/json-server/lib/cli/run.js:163:10 {
2024-10-29T12:57:35.818003890Z   errno: -24,
2024-10-29T12:57:35.818007367Z   syscall: 'watch',
2024-10-29T12:57:35.818010582Z   code: 'EMFILE',
2024-10-29T12:57:35.818014320Z   path: '/',
2024-10-29T12:57:35.818017526Z   filename: '/'
2024-10-29T12:57:35.818020291Z }
```