### PR TITLE
treewide: Add wrapper for `netlink` functions that may fail with `ErrDumpInterrupted`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -452,6 +452,8 @@ endif
 	$(QUIET) contrib/scripts/check-legacy-header-guard.sh
 	@$(ECHO_CHECK) contrib/scripts/check-logrus.sh
 	$(QUIET) contrib/scripts/check-logrus.sh
+	@$(ECHO_CHECK) contrib/scripts/check-safenetlink.sh
+	$(QUIET) contrib/scripts/check-safenetlink.sh
 
 pprof-heap: ## Get Go pprof heap profile.
 	$(QUIET)$(GO) tool pprof http://localhost:6060/debug/pprof/heap

--- a/bugtool/cmd/ethtool_linux.go
+++ b/bugtool/cmd/ethtool_linux.go
@@ -8,11 +8,11 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/vishvananda/netlink"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 )
 
 func ethtoolCommands() []string {
-	links, err := netlink.LinkList()
+	links, err := safenetlink.LinkList()
 	if err != nil {
 		return nil
 	}

--- a/cilium-dbg/cmd/bpf_multicast_subscribers.go
+++ b/cilium-dbg/cmd/bpf_multicast_subscribers.go
@@ -11,10 +11,10 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
-	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/defaults"
 	maps_multicast "github.com/cilium/cilium/pkg/maps/multicast"
 )
@@ -90,7 +90,7 @@ cilium-dbg bpf multicast subscriber add 229.0.0.1 10.100.0.1
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf multicast subscriber add")
 
-		link, err := netlink.LinkByName(defaults.VxlanDevice)
+		link, err := safenetlink.LinkByName(defaults.VxlanDevice)
 		if err != nil {
 			Fatalf("Failed to get cilium_vxlan device %q: %s", defaults.VxlanDevice, err)
 		}

--- a/cilium-dbg/cmd/encrypt_flush.go
+++ b/cilium-dbg/cmd/encrypt_flush.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/common/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
 )
 
@@ -64,11 +65,11 @@ func runXFRMFlush() {
 		}
 	}
 
-	states, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+	states, err := safenetlink.XfrmStateList(netlink.FAMILY_ALL)
 	if err != nil {
 		Fatalf("Failed to retrieve XFRM states: %s", err)
 	}
-	policies, err := netlink.XfrmPolicyList(netlink.FAMILY_ALL)
+	policies, err := safenetlink.XfrmPolicyList(netlink.FAMILY_ALL)
 	if err != nil {
 		Fatalf("Failed to retrieve XFRM policies: %s", err)
 	}

--- a/cilium-dbg/cmd/encrypt_status.go
+++ b/cilium-dbg/cmd/encrypt_status.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/common/ipsec"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 )
 
 const (
@@ -78,7 +79,7 @@ func dumpIPsecStatus() (models.EncryptionStatus, error) {
 		Mode:  models.EncryptionStatusModeIPsec,
 		Ipsec: &models.IPsecStatus{},
 	}
-	xfrmStates, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+	xfrmStates, err := safenetlink.XfrmStateList(netlink.FAMILY_ALL)
 	if err != nil {
 		return models.EncryptionStatus{}, fmt.Errorf("cannot get xfrm state: %w", err)
 	}
@@ -186,7 +187,7 @@ func maxSequenceNumber() (string, error) {
 }
 
 func isDecryptionInterface(link netlink.Link) (bool, error) {
-	filters, err := netlink.FilterList(link, tcFilterParentIngress)
+	filters, err := safenetlink.FilterList(link, tcFilterParentIngress)
 	if err != nil {
 		return false, err
 	}
@@ -204,7 +205,7 @@ func isDecryptionInterface(link netlink.Link) (bool, error) {
 }
 
 func getDecryptionInterfaces() ([]string, error) {
-	links, err := netlink.LinkList()
+	links, err := safenetlink.LinkList()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list interfaces: %w", err)
 	}

--- a/cilium-dbg/cmd/post_uninstall_cleanup.go
+++ b/cilium-dbg/cmd/post_uninstall_cleanup.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/common"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
@@ -150,7 +151,7 @@ func newCiliumCleanup(bpfOnly bool) ciliumCleanup {
 	}
 
 	tcFilters := map[string][]*netlink.BpfFilter{}
-	links, err := netlink.LinkList()
+	links, err := safenetlink.LinkList()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 	} else {
@@ -451,7 +452,7 @@ func findRoutesAndLinks() (map[int]netlink.Route, map[int]netlink.Link, error) {
 	routesToRemove := map[int]netlink.Route{}
 	linksToRemove := map[int]netlink.Link{}
 
-	if routes, err := netlink.RouteList(nil, netlink.FAMILY_V4); err == nil {
+	if routes, err := safenetlink.RouteList(nil, netlink.FAMILY_V4); err == nil {
 		for _, r := range routes {
 			link, err := netlink.LinkByIndex(r.LinkIndex)
 			if err != nil {
@@ -471,7 +472,7 @@ func findRoutesAndLinks() (map[int]netlink.Route, map[int]netlink.Link, error) {
 		}
 	}
 
-	if links, err := netlink.LinkList(); err == nil {
+	if links, err := safenetlink.LinkList(); err == nil {
 		for _, link := range links {
 			linkName := link.Attrs().Name
 			if !linkMatch(linkName) {
@@ -508,7 +509,7 @@ func getTCFilters(link netlink.Link) ([]*netlink.BpfFilter, error) {
 	allFilters := []*netlink.BpfFilter{}
 
 	for _, parent := range []uint32{tcFilterParentIngress, tcFilterParentEgress} {
-		filters, err := netlink.FilterList(link, parent)
+		filters, err := safenetlink.FilterList(link, parent)
 		if err != nil {
 			return nil, err
 		}

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -107,7 +108,7 @@ func configureHealthRouting(routes []route.Route, dev string) error {
 
 // configureHealthInterface is meant to be run inside the health service netns
 func configureHealthInterface(ifName string, ip4Addr, ip6Addr *net.IPNet) error {
-	link, err := netlink.LinkByName(ifName)
+	link, err := safenetlink.LinkByName(ifName)
 	if err != nil {
 		return err
 	}
@@ -135,7 +136,7 @@ func configureHealthInterface(ifName string, ip4Addr, ip6Addr *net.IPNet) error 
 		return err
 	}
 
-	lo, err := netlink.LinkByName("lo")
+	lo, err := safenetlink.LinkByName("lo")
 	if err != nil {
 		return err
 	}
@@ -193,7 +194,7 @@ func CleanupEndpoint() {
 	case datapathOption.DatapathModeVeth, datapathOption.DatapathModeNetkit, datapathOption.DatapathModeNetkitL2:
 		for _, iface := range []string{legacyHealthName, healthName} {
 			scopedLog := log.WithField(logfields.Interface, iface)
-			if link, err := netlink.LinkByName(iface); err == nil {
+			if link, err := safenetlink.LinkByName(iface); err == nil {
 				err = netlink.LinkDel(link)
 				if err != nil {
 					scopedLog.WithError(err).Infof("Couldn't delete cilium-health %s device",

--- a/contrib/scripts/check-safenetlink.sh
+++ b/contrib/scripts/check-safenetlink.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Authors of Cilium
+
+set -eu
+
+# List based on https://github.com/vishvananda/netlink/pull/1018
+MATCHES=(
+    "netlink.AddrList"
+    "netlink.BridgeVlanList"
+    "netlink.ChainList"
+    "netlink.ClassList"
+    "netlink.ConntrackTableList"
+    "netlink.DevLinkGetDeviceList"
+    "netlink.DevLinkGetAllPortList"
+    "netlink.DevlinkGetDeviceParams"
+    "netlink.FilterList"
+    "netlink.FouList"
+    "netlink.GenlFamilyList"
+    "netlink.GTPPDPList"
+    "netlink.LinkByName"
+    "netlink.LinkByAlias"
+    "netlink.LinkList"
+    "netlink.LinkSubscribeWithOptions"
+    "netlink.NeighList"
+    "netlink.NeighProxyList"
+    "netlink.NeighListExecute"
+    "netlink.LinkGetProtinfo"
+    "netlink.QdiscList"
+    "netlink.RdmaLinkList"
+    "netlink.RdmaLinkByName"
+    "netlink.RdmaLinkDel"
+    "netlink.RouteList"
+    "netlink.RouteListFiltered"
+    "netlink.RouteListFilteredIter"
+    "netlink.RouteSubscribeWithOptions"
+    "netlink.RuleList"
+    "netlink.RuleListFiltered"
+    "netlink.SocketGet"
+    "netlink.SocketDiagTCPInfo"
+    "netlink.SocketDiagTCP"
+    "netlink.SocketDiagUDPInfo"
+    "netlink.SocketDiagUDP"
+    "netlink.UnixSocketDiagInfo"
+    "netlink.UnixSocketDiag"
+    "netlink.SocketXDPGetInfo"
+    "netlink.SocketDiagXDP"
+    "netlink.VDPAGetDevList"
+    "netlink.VDPAGetDevConfigList"
+    "netlink.VDPAGetMGMTDevList"
+    "netlink.XfrmPolicyList"
+    "netlink.XfrmStateList"
+)
+
+EXCLUDED_DIRS=(
+  ".git"
+  "_build"
+  "contrib"
+  "Documentation"
+  "externalversions"
+  "examples"
+  "install"
+  "test"
+  "vendor"
+
+  "safenetlink"
+)
+
+find_match() {
+  local target="."
+
+  MATCHES_ORED=$(printf '|\W%s\(' "${MATCHES[@]}")
+  MATCHES_ORED=${MATCHES_ORED:1}
+
+  # shellcheck disable=2046
+  grep "$@" -r --include \*.go \
+       $(printf "%s\n" "${EXCLUDED_DIRS[@]}" \
+         | xargs -I{} echo '--exclude-dir={}') \
+       --exclude \*_test.go \
+       -E "$MATCHES_ORED" \
+       "$target"
+  return $?
+}
+
+
+check() {
+  if find_match ; then
+    >&2 echo "Found unprotected netlink call(s) that can may fail with netlink.ErrDumpInterrupted. Please use the safenetlink package for these function calls instead.";
+    exit 1
+  fi
+}
+
+main() {
+  check
+}
+
+main "$@"

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -209,7 +210,7 @@ func (d *Daemon) init() error {
 // `cilium_host` interface is the given restored IP. If the given IP is nil,
 // then it attempts to clear all IPs from the interface.
 func removeOldRouterState(ipv6 bool, restoredIP net.IP) error {
-	l, err := netlink.LinkByName(defaults.HostDevice)
+	l, err := safenetlink.LinkByName(defaults.HostDevice)
 	if errors.As(err, &netlink.LinkNotFoundError{}) {
 		// There's no old state remove as the host device doesn't exist.
 		// This is always the case when the agent is started for the first time.
@@ -223,7 +224,7 @@ func removeOldRouterState(ipv6 bool, restoredIP net.IP) error {
 	if ipv6 {
 		family = netlink.FAMILY_V6
 	}
-	addrs, err := netlink.AddrList(l, family)
+	addrs, err := safenetlink.AddrList(l, family)
 	if err != nil {
 		return resiliency.Retryable(err)
 	}

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -44,7 +45,7 @@ import (
 // The filter should take a link and, if found, return the index of that
 // interface, if not found return -1.
 func listFilterIfs(filter func(netlink.Link) int) (map[int]netlink.Link, error) {
-	ifs, err := netlink.LinkList()
+	ifs, err := safenetlink.LinkList()
 	if err != nil {
 		return nil, err
 	}
@@ -343,7 +344,7 @@ func setupRouteToVtepCidr() error {
 		Table: linux_defaults.RouteTableVtep,
 	}
 
-	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, filter, netlink.RT_FILTER_TABLE)
+	routes, err := safenetlink.RouteListFiltered(netlink.FAMILY_V4, filter, netlink.RT_FILTER_TABLE)
 	if err != nil {
 		return fmt.Errorf("failed to list routes: %w", err)
 	}

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -12,11 +12,11 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
-	"github.com/vishvananda/netlink"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -52,7 +52,7 @@ type endpointRestoreState struct {
 
 // checkLink returns an error if a link with linkName does not exist.
 func checkLink(linkName string) error {
-	_, err := netlink.LinkByName(linkName)
+	_, err := safenetlink.LinkByName(linkName)
 	return err
 }
 

--- a/pkg/datapath/connector/netkit.go
+++ b/pkg/datapath/connector/netkit.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/datapath/link"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/netns"
@@ -94,7 +95,7 @@ func SetupNetkitWithNames(lxcIfName, peerIfName string, mtu, groIPv6MaxSize, gso
 		return nil, nil, err
 	}
 
-	peer, err := netlink.LinkByName(peerIfName)
+	peer, err := safenetlink.LinkByName(peerIfName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to lookup netkit peer just created: %w", err)
 	}
@@ -109,7 +110,7 @@ func SetupNetkitWithNames(lxcIfName, peerIfName string, mtu, groIPv6MaxSize, gso
 		return nil, nil, fmt.Errorf("unable to set MTU to %q: %w", peerIfName, err)
 	}
 
-	hostNetkit, err := netlink.LinkByName(lxcIfName)
+	hostNetkit, err := safenetlink.LinkByName(lxcIfName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to lookup netkit just created: %w", err)
 	}

--- a/pkg/datapath/connector/veth.go
+++ b/pkg/datapath/connector/veth.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/datapath/link"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
@@ -98,7 +99,7 @@ func SetupVethWithNames(lxcIfName, peerIfName string, mtu, groIPv6MaxSize, gsoIP
 		return nil, nil, err
 	}
 
-	peer, err := netlink.LinkByName(peerIfName)
+	peer, err := safenetlink.LinkByName(peerIfName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to lookup veth peer just created: %w", err)
 	}
@@ -107,7 +108,7 @@ func SetupVethWithNames(lxcIfName, peerIfName string, mtu, groIPv6MaxSize, gsoIP
 		return nil, nil, fmt.Errorf("unable to set MTU to %q: %w", peerIfName, err)
 	}
 
-	hostVeth, err := netlink.LinkByName(lxcIfName)
+	hostVeth, err := safenetlink.LinkByName(lxcIfName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to lookup veth just created: %w", err)
 	}

--- a/pkg/datapath/garp/garp.go
+++ b/pkg/datapath/garp/garp.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -89,7 +90,7 @@ func send(iface *net.Interface, ip netip.Addr) error {
 // The reason not to use net.InterfaceByName directly is to avoid potential
 // deadlocks (#15051).
 func interfaceByName(name string) (*net.Interface, error) {
-	link, err := netlink.LinkByName(name)
+	link, err := safenetlink.LinkByName(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/modules"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -1207,7 +1208,7 @@ func (m *Manager) installMasqueradeRules(
 			family = netlink.FAMILY_V6
 		}
 		initialPass := true
-		if routes, err := netlink.RouteList(nil, family); err == nil {
+		if routes, err := safenetlink.RouteList(nil, family); err == nil {
 		nextPass:
 			for _, r := range routes {
 				var link netlink.Link

--- a/pkg/datapath/l2responder/l2responder.go
+++ b/pkg/datapath/l2responder/l2responder.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/datapath/garp"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/ebpf"
 	"github.com/cilium/cilium/pkg/maps/l2respondermap"
@@ -288,7 +289,9 @@ func (clr *cachingLinkResolver) LinkIndex(name string) (int, error) {
 		return idx, nil
 	}
 
-	link, err := clr.nl.LinkByName(name)
+	link, err := safenetlink.WithRetryResult(func() (netlink.Link, error) {
+		return clr.nl.LinkByName(name)
+	})
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/datapath/link/link.go
+++ b/pkg/datapath/link/link.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/time"
@@ -32,7 +33,7 @@ var (
 //
 // Returns nil if the interface does not exist.
 func DeleteByName(ifName string) error {
-	iface, err := netlink.LinkByName(ifName)
+	iface, err := safenetlink.LinkByName(ifName)
 	if errors.As(err, &netlink.LinkNotFoundError{}) {
 		return nil
 	}
@@ -50,7 +51,7 @@ func DeleteByName(ifName string) error {
 
 // Rename renames a network link
 func Rename(curName, newName string) error {
-	link, err := netlink.LinkByName(curName)
+	link, err := safenetlink.LinkByName(curName)
 	if err != nil {
 		return err
 	}
@@ -59,7 +60,7 @@ func Rename(curName, newName string) error {
 }
 
 func GetHardwareAddr(ifName string) (mac.MAC, error) {
-	iface, err := netlink.LinkByName(ifName)
+	iface, err := safenetlink.LinkByName(ifName)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +68,7 @@ func GetHardwareAddr(ifName string) (mac.MAC, error) {
 }
 
 func GetIfIndex(ifName string) (uint32, error) {
-	iface, err := netlink.LinkByName(ifName)
+	iface, err := safenetlink.LinkByName(ifName)
 	if err != nil {
 		return 0, err
 	}
@@ -99,7 +100,7 @@ func NewLinkCache() *LinkCache {
 }
 
 func (c *LinkCache) syncCache() error {
-	links, err := netlink.LinkList()
+	links, err := safenetlink.LinkList()
 	if err != nil {
 		return err
 	}

--- a/pkg/datapath/linux/bandwidth/ops.go
+++ b/pkg/datapath/linux/bandwidth/ops.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/statedb/reconciler"
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/types"
 )
@@ -53,7 +54,7 @@ func (ops *ops) Update(ctx context.Context, txn statedb.ReadTxn, q *tables.Bandw
 	device := link.Attrs().Name
 
 	// Check if the qdiscs are already set up as expected.
-	qdiscs, err := netlink.QdiscList(link)
+	qdiscs, err := safenetlink.QdiscList(link)
 	if err != nil {
 		return fmt.Errorf("QdiscList: %w", err)
 	}
@@ -130,7 +131,7 @@ func (ops *ops) Update(ctx context.Context, txn statedb.ReadTxn, q *tables.Bandw
 	ops.log.Info("Setting qdisc", "qdisc", which, "device", device)
 
 	// Set the fq parameters
-	qdiscs, err = netlink.QdiscList(link)
+	qdiscs, err = safenetlink.QdiscList(link)
 	if err != nil {
 		return fmt.Errorf("QdiscList: %w", err)
 	}

--- a/pkg/datapath/linux/bigtcp/bigtcp.go
+++ b/pkg/datapath/linux/bigtcp/bigtcp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -115,7 +116,7 @@ func (c *Configuration) GetGSOIPv4MaxSize() int {
 // If an error is returned the caller is responsible for rolling back
 // any partial changes.
 func setGROGSOIPv6MaxSize(log *slog.Logger, userConfig UserConfig, device string, GROMaxSize, GSOMaxSize int) error {
-	link, err := netlink.LinkByName(device)
+	link, err := safenetlink.LinkByName(device)
 	if err != nil {
 		log.Warn("Link does not exist", logfields.Device, device, logfields.Error, err)
 		return nil
@@ -143,7 +144,7 @@ func setGROGSOIPv6MaxSize(log *slog.Logger, userConfig UserConfig, device string
 // If an error is returned the caller is responsible for rolling back
 // any partial changes.
 func setGROGSOIPv4MaxSize(log *slog.Logger, userConfig UserConfig, device string, GROMaxSize, GSOMaxSize int) error {
-	link, err := netlink.LinkByName(device)
+	link, err := safenetlink.LinkByName(device)
 	if err != nil {
 		log.Warn("Link does not exist", logfields.Device, device, logfields.Error, err)
 		return nil
@@ -169,7 +170,7 @@ func setGROGSOIPv4MaxSize(log *slog.Logger, userConfig UserConfig, device string
 }
 
 func haveIPv4MaxSize() bool {
-	link, err := netlink.LinkByName(probeDevice)
+	link, err := safenetlink.LinkByName(probeDevice)
 	if err != nil {
 		return false
 	}
@@ -180,7 +181,7 @@ func haveIPv4MaxSize() bool {
 }
 
 func haveIPv6MaxSize() bool {
-	link, err := netlink.LinkByName(probeDevice)
+	link, err := safenetlink.LinkByName(probeDevice)
 	if err != nil {
 		return false
 	}
@@ -193,7 +194,7 @@ func haveIPv6MaxSize() bool {
 func probeTSOMaxSize(log *slog.Logger, devices []string) int {
 	maxSize := math.IntMin(bigTCPGSOMaxSize, bigTCPGROMaxSize)
 	for _, device := range devices {
-		link, err := netlink.LinkByName(device)
+		link, err := safenetlink.LinkByName(device)
 		if err == nil {
 			tso := link.Attrs().TSOMaxSize
 			tsoMax := int(tso)

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/inctimer"
@@ -648,7 +649,7 @@ func makeNetlinkFuncs() (*netlinkFuncs, error) {
 	return &netlinkFuncs{
 		RouteSubscribe: func(ch chan<- netlink.RouteUpdate, done <-chan struct{}, errorCallback func(error)) error {
 			h := vns.NsHandle(cur.FD())
-			return netlink.RouteSubscribeWithOptions(ch, done,
+			return safenetlink.RouteSubscribeWithOptions(ch, done,
 				netlink.RouteSubscribeOptions{
 					ListExisting:  false,
 					ErrorCallback: errorCallback,
@@ -666,7 +667,7 @@ func makeNetlinkFuncs() (*netlinkFuncs, error) {
 		},
 		LinkSubscribe: func(ch chan<- netlink.LinkUpdate, done <-chan struct{}, errorCallback func(error)) error {
 			h := vns.NsHandle(cur.FD())
-			return netlink.LinkSubscribeWithOptions(ch, done,
+			return safenetlink.LinkSubscribeWithOptions(ch, done,
 				netlink.LinkSubscribeOptions{
 					ListExisting:  false,
 					ErrorCallback: errorCallback,

--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
@@ -52,11 +53,11 @@ func (n *linuxNodeHandler) getDefaultEncryptionInterface() string {
 
 func (n *linuxNodeHandler) getLinkLocalIP(family int) (net.IP, error) {
 	iface := n.getDefaultEncryptionInterface()
-	link, err := netlink.LinkByName(iface)
+	link, err := safenetlink.LinkByName(iface)
 	if err != nil {
 		return nil, err
 	}
-	addr, err := netlink.AddrList(link, family)
+	addr, err := safenetlink.AddrList(link, family)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/datapath/linux/ipsec/xfrm_collector.go
+++ b/pkg/datapath/linux/ipsec/xfrm_collector.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/common/ipsec"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 )
@@ -127,7 +128,7 @@ func (x *xfrmCollector) collectErrors(ch chan<- prometheus.Metric) {
 }
 
 func (x *xfrmCollector) collectConfigStats(ch chan<- prometheus.Metric) {
-	states, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+	states, err := safenetlink.XfrmStateList(netlink.FAMILY_ALL)
 	if err != nil {
 		x.log.Error("Failed to retrieve XFRM states to compute Prometheus metrics", logfields.Error, err)
 		return
@@ -142,7 +143,7 @@ func (x *xfrmCollector) collectConfigStats(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(x.nbXFRMStatesDesc, prometheus.GaugeValue, float64(nbStatesIn), labelDirIn)
 	ch <- prometheus.MustNewConstMetric(x.nbXFRMStatesDesc, prometheus.GaugeValue, float64(nbStatesOut), labelDirOut)
 
-	policies, err := netlink.XfrmPolicyList(netlink.FAMILY_ALL)
+	policies, err := safenetlink.XfrmPolicyList(netlink.FAMILY_ALL)
 	if err != nil {
 		x.log.Error("Failed to retrieve XFRM policies to compute Prometheus metrics", logfields.Error, err)
 		return

--- a/pkg/datapath/linux/ipsec/xfrm_state_cache.go
+++ b/pkg/datapath/linux/ipsec/xfrm_state_cache.go
@@ -7,6 +7,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"k8s.io/utils/clock"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
@@ -31,7 +32,7 @@ func (c *xfrmStateListCache) XfrmStateList() ([]netlink.XfrmState, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	if c.isExpired() {
-		result, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+		result, err := safenetlink.XfrmStateList(netlink.FAMILY_ALL)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/datapath/linux/netdevice/netdevice.go
+++ b/pkg/datapath/linux/netdevice/netdevice.go
@@ -9,15 +9,17 @@ import (
 
 	"github.com/vishvananda/netlink"
 	"go4.org/netipx"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 )
 
 func GetIfaceFirstIPv4Address(ifaceName string) (netip.Addr, error) {
-	dev, err := netlink.LinkByName(ifaceName)
+	dev, err := safenetlink.LinkByName(ifaceName)
 	if err != nil {
 		return netip.Addr{}, err
 	}
 
-	addrs, err := netlink.AddrList(dev, netlink.FAMILY_V4)
+	addrs, err := safenetlink.AddrList(dev, netlink.FAMILY_V4)
 	if err != nil {
 		return netip.Addr{}, err
 	}
@@ -45,13 +47,13 @@ func GetIfaceWithIPv4Address(ip netip.Addr) (string, error) {
 }
 
 func getIfaceWithIPv4Address(ip netip.Addr) (string, error) {
-	links, err := netlink.LinkList()
+	links, err := safenetlink.LinkList()
 	if err != nil {
 		return "", err
 	}
 
 	for _, l := range links {
-		addrs, err := netlink.AddrList(l, netlink.FAMILY_V4)
+		addrs, err := safenetlink.AddrList(l, netlink.FAMILY_V4)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/datapath/linux/probes/managed_neighbors.go
+++ b/pkg/datapath/linux/probes/managed_neighbors.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/netns"
 )
 
@@ -70,7 +71,7 @@ func haveManagedNeighbors() (outer error) {
 		return fmt.Errorf("failed to add neighbor: %w", err)
 	}
 
-	nl, err := netlink.NeighList(veth.Index, 0)
+	nl, err := safenetlink.NeighList(veth.Index, 0)
 	if err != nil {
 		return fmt.Errorf("failed to list neighbors: %w", err)
 	}

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -19,7 +20,7 @@ import (
 // CheckRequirements checks that minimum kernel requirements are met for
 // configuring the BPF datapath.
 func CheckRequirements(log *slog.Logger) error {
-	_, err := netlink.RuleList(netlink.FAMILY_V4)
+	_, err := safenetlink.RuleList(netlink.FAMILY_V4)
 	if errors.Is(err, unix.EAFNOSUPPORT) {
 		log.Error("Policy routing:NOT OK. "+
 			"Please enable kernel configuration item CONFIG_IP_MULTIPLE_TABLES",

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -87,7 +88,7 @@ func ipFamily(ip net.IP) int {
 // Lookup attempts to find the linux route based on the route specification.
 // If the route exists, the route is returned, otherwise an error is returned.
 func Lookup(route Route) (*Route, error) {
-	link, err := netlink.LinkByName(route.Device)
+	link, err := safenetlink.LinkByName(route.Device)
 	if err != nil {
 		return nil, fmt.Errorf("unable to find interface '%s' of route: %w", route.Device, err)
 	}
@@ -139,7 +140,7 @@ func lookup(route *netlink.Route) *netlink.Route {
 		filter |= netlink.RT_FILTER_OIF
 	}
 
-	routes, err := netlink.RouteListFiltered(ipFamily(route.Dst.IP), route, filter)
+	routes, err := safenetlink.RouteListFiltered(ipFamily(route.Dst.IP), route, filter)
 	if err != nil {
 		return nil
 	}
@@ -237,7 +238,7 @@ func deleteNexthopRoute(route Route, link netlink.Link, routerNet *net.IPNet) er
 func Upsert(route Route) error {
 	var nexthopRouteCreated bool
 
-	link, err := netlink.LinkByName(route.Device)
+	link, err := safenetlink.LinkByName(route.Device)
 	if err != nil {
 		return fmt.Errorf("unable to lookup interface %s: %w", route.Device, err)
 	}
@@ -289,7 +290,7 @@ func Upsert(route Route) error {
 // Delete deletes a Linux route. An error is returned if the route does not
 // exist or if the route could not be deleted.
 func Delete(route Route) error {
-	link, err := netlink.LinkByName(route.Device)
+	link, err := safenetlink.LinkByName(route.Device)
 	if err != nil {
 		return fmt.Errorf("unable to lookup interface %s: %w", route.Device, err)
 	}
@@ -378,7 +379,7 @@ func (r Rule) String() string {
 }
 
 func lookupRule(spec Rule, family int) (bool, error) {
-	rules, err := netlink.RuleList(family)
+	rules, err := safenetlink.RuleList(family)
 	if err != nil {
 		return false, err
 	}
@@ -454,7 +455,7 @@ func ListRules(family int, filter *Rule) ([]netlink.Rule, error) {
 		nlFilter.Dst = filter.To
 		nlFilter.Table = filter.Table
 	}
-	return netlink.RuleListFiltered(family, &nlFilter, mask)
+	return safenetlink.RuleListFiltered(family, &nlFilter, mask)
 }
 
 // ReplaceRule add or replace rule in the routing table using a mark to indicate
@@ -504,7 +505,7 @@ func DeleteRule(family int, spec Rule) error {
 }
 
 func lookupDefaultRoute(family int) (netlink.Route, error) {
-	routes, err := netlink.RouteListFiltered(family, &netlink.Route{Dst: nil}, netlink.RT_FILTER_DST)
+	routes, err := safenetlink.RouteListFiltered(family, &netlink.Route{Dst: nil}, netlink.RT_FILTER_DST)
 	if err != nil {
 		return netlink.Route{}, fmt.Errorf("Unable to list direct routes: %w", err)
 	}
@@ -527,7 +528,7 @@ func lookupDefaultRoute(family int) (netlink.Route, error) {
 func DeleteRouteTable(table, family int) error {
 	var routeErr error
 
-	routes, err := netlink.RouteListFiltered(family, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
+	routes, err := safenetlink.RouteListFiltered(family, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
 	if err != nil {
 		return fmt.Errorf("Unable to list table %d routes: %w", table, err)
 	}

--- a/pkg/datapath/linux/routing/migrate.go
+++ b/pkg/datapath/linux/routing/migrate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/revert"
 )
 
@@ -579,16 +580,16 @@ type migrator struct {
 // forwards all RPDB operations to netlink.
 type defaultRPDB struct{}
 
-func (defaultRPDB) RuleList(family int) ([]netlink.Rule, error) { return netlink.RuleList(family) }
+func (defaultRPDB) RuleList(family int) ([]netlink.Rule, error) { return safenetlink.RuleList(family) }
 func (defaultRPDB) RuleAdd(rule *netlink.Rule) error            { return netlink.RuleAdd(rule) }
 func (defaultRPDB) RuleDel(rule *netlink.Rule) error            { return netlink.RuleDel(rule) }
 func (defaultRPDB) RouteListFiltered(family int, filter *netlink.Route, mask uint64) ([]netlink.Route, error) {
-	return netlink.RouteListFiltered(family, filter, mask)
+	return safenetlink.RouteListFiltered(family, filter, mask)
 }
 func (defaultRPDB) RouteAdd(route *netlink.Route) error     { return netlink.RouteAdd(route) }
 func (defaultRPDB) RouteDel(route *netlink.Route) error     { return netlink.RouteDel(route) }
 func (defaultRPDB) RouteReplace(route *netlink.Route) error { return netlink.RouteReplace(route) }
-func (defaultRPDB) LinkList() ([]netlink.Link, error)       { return netlink.LinkList() }
+func (defaultRPDB) LinkList() ([]netlink.Link, error)       { return safenetlink.LinkList() }
 func (defaultRPDB) LinkByIndex(ifindex int) (netlink.Link, error) {
 	return netlink.LinkByIndex(ifindex)
 }

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging"
@@ -278,7 +279,7 @@ func deleteRule(r route.Rule) error {
 func retrieveIfIndexFromMAC(mac mac.MAC, mtu int) (int, error) {
 	var link netlink.Link
 
-	links, err := netlink.LinkList()
+	links, err := safenetlink.LinkList()
 	if err != nil {
 		return -1, fmt.Errorf("unable to list interfaces: %w", err)
 	}

--- a/pkg/datapath/linux/safenetlink/netlink_linux.go
+++ b/pkg/datapath/linux/safenetlink/netlink_linux.go
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package safenetlink
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+
+	"github.com/cilium/cilium/pkg/resiliency"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+const (
+	netlinkRetryInterval = 1 * time.Millisecond
+	netlinkRetryMax      = 30
+)
+
+// WithRetry runs the netlinkFunc. If netlinkFunc returns netlink.ErrDumpInterrupted, the function is retried.
+// If success or any other error is returned, WithRetry returns immediately, propagating the error.
+func WithRetry(netlinkFunc func() error) error {
+	return resiliency.Retry(context.Background(), netlinkRetryInterval, netlinkRetryMax, func(ctx context.Context, retries int) (bool, error) {
+		err := netlinkFunc()
+		if errors.Is(err, netlink.ErrDumpInterrupted) {
+			return false, nil // retry
+		}
+
+		return true, err
+	})
+}
+
+// WithRetryResult works like WithRetry, but allows netlinkFunc to have a return value besides the error
+func WithRetryResult[T any](netlinkFunc func() (T, error)) (out T, err error) {
+	err = WithRetry(func() error {
+		out, err = netlinkFunc()
+		return err
+	})
+	return out, err
+}
+
+// AddrList wraps netlink.AddrList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
+	return WithRetryResult(func() ([]netlink.Addr, error) {
+		return netlink.AddrList(link, family)
+	})
+}
+
+// BridgeVlanList wraps netlink.BridgeVlanList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func BridgeVlanList() (map[int32][]*nl.BridgeVlanInfo, error) {
+	return WithRetryResult(func() (map[int32][]*nl.BridgeVlanInfo, error) {
+		return netlink.BridgeVlanList()
+	})
+}
+
+// ChainList wraps netlink.ChainList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func ChainList(link netlink.Link, parent uint32) ([]netlink.Chain, error) {
+	return WithRetryResult(func() ([]netlink.Chain, error) {
+		return netlink.ChainList(link, parent)
+	})
+}
+
+// ClassList wraps netlink.ClassList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func ClassList(link netlink.Link, parent uint32) ([]netlink.Class, error) {
+	return WithRetryResult(func() ([]netlink.Class, error) {
+		return netlink.ClassList(link, parent)
+	})
+}
+
+// ConntrackTableList wraps netlink.ConntrackTableList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func ConntrackTableList(table netlink.ConntrackTableType, family netlink.InetFamily) ([]*netlink.ConntrackFlow, error) {
+	return WithRetryResult(func() ([]*netlink.ConntrackFlow, error) {
+		return netlink.ConntrackTableList(table, family)
+	})
+}
+
+// DevLinkGetDeviceList wraps netlink.DevLinkGetDeviceList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func DevLinkGetDeviceList() ([]*netlink.DevlinkDevice, error) {
+	return WithRetryResult(func() ([]*netlink.DevlinkDevice, error) {
+		return netlink.DevLinkGetDeviceList()
+	})
+}
+
+// DevLinkGetAllPortList wraps netlink.DevLinkGetAllPortList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func DevLinkGetAllPortList() ([]*netlink.DevlinkPort, error) {
+	return WithRetryResult(func() ([]*netlink.DevlinkPort, error) {
+		return netlink.DevLinkGetAllPortList()
+	})
+}
+
+// DevlinkGetDeviceParams wraps netlink.DevlinkGetDeviceParams, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func DevlinkGetDeviceParams(bus string, device string) ([]*netlink.DevlinkParam, error) {
+	return WithRetryResult(func() ([]*netlink.DevlinkParam, error) {
+		return netlink.DevlinkGetDeviceParams(bus, device)
+	})
+}
+
+// FilterList wraps netlink.FilterList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func FilterList(link netlink.Link, parent uint32) ([]netlink.Filter, error) {
+	return WithRetryResult(func() ([]netlink.Filter, error) {
+		return netlink.FilterList(link, parent)
+	})
+}
+
+// FouList wraps netlink.FouList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func FouList(fam int) ([]netlink.Fou, error) {
+	return WithRetryResult(func() ([]netlink.Fou, error) {
+		return netlink.FouList(fam)
+	})
+}
+
+// GenlFamilyList wraps netlink.GenlFamilyList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func GenlFamilyList() ([]*netlink.GenlFamily, error) {
+	return WithRetryResult(func() ([]*netlink.GenlFamily, error) {
+		return netlink.GenlFamilyList()
+	})
+}
+
+// GTPPDPList wraps netlink.GTPPDPList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func GTPPDPList() ([]*netlink.PDP, error) {
+	return WithRetryResult(func() ([]*netlink.PDP, error) {
+		return netlink.GTPPDPList()
+	})
+}
+
+// LinkByName wraps netlink.LinkByName, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func LinkByName(name string) (netlink.Link, error) {
+	return WithRetryResult(func() (netlink.Link, error) {
+		return netlink.LinkByName(name)
+	})
+}
+
+// LinkByAlias wraps netlink.LinkByAlias, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func LinkByAlias(alias string) (netlink.Link, error) {
+	return WithRetryResult(func() (netlink.Link, error) {
+		return netlink.LinkByAlias(alias)
+	})
+}
+
+// LinkList wraps netlink.LinkList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func LinkList() ([]netlink.Link, error) {
+	return WithRetryResult(func() ([]netlink.Link, error) {
+		return netlink.LinkList()
+	})
+}
+
+// LinkSubscribeWithOptions wraps netlink.LinkSubscribeWithOptions, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func LinkSubscribeWithOptions(ch chan<- netlink.LinkUpdate, done <-chan struct{}, options netlink.LinkSubscribeOptions) error {
+	return WithRetry(func() error {
+		return netlink.LinkSubscribeWithOptions(ch, done, options)
+	})
+}
+
+// NeighList wraps netlink.NeighList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func NeighList(linkIndex, family int) ([]netlink.Neigh, error) {
+	return WithRetryResult(func() ([]netlink.Neigh, error) {
+		return netlink.NeighList(linkIndex, family)
+	})
+}
+
+// NeighProxyList wraps netlink.NeighProxyList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func NeighProxyList(linkIndex, family int) ([]netlink.Neigh, error) {
+	return WithRetryResult(func() ([]netlink.Neigh, error) {
+		return netlink.NeighProxyList(linkIndex, family)
+	})
+}
+
+// NeighListExecute wraps netlink.NeighListExecute, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func NeighListExecute(msg netlink.Ndmsg) ([]netlink.Neigh, error) {
+	return WithRetryResult(func() ([]netlink.Neigh, error) {
+		return netlink.NeighListExecute(msg)
+	})
+}
+
+// LinkGetProtinfo wraps netlink.LinkGetProtinfo, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func LinkGetProtinfo(link netlink.Link) (netlink.Protinfo, error) {
+	return WithRetryResult(func() (netlink.Protinfo, error) {
+		return netlink.LinkGetProtinfo(link)
+	})
+}
+
+// QdiscList wraps netlink.QdiscList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func QdiscList(link netlink.Link) ([]netlink.Qdisc, error) {
+	return WithRetryResult(func() ([]netlink.Qdisc, error) {
+		return netlink.QdiscList(link)
+	})
+}
+
+// RdmaLinkList wraps netlink.RdmaLinkList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func RdmaLinkList() ([]*netlink.RdmaLink, error) {
+	return WithRetryResult(func() ([]*netlink.RdmaLink, error) {
+		return netlink.RdmaLinkList()
+	})
+}
+
+// RdmaLinkByName wraps netlink.RdmaLinkByName, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func RdmaLinkByName(name string) (*netlink.RdmaLink, error) {
+	return WithRetryResult(func() (*netlink.RdmaLink, error) {
+		return netlink.RdmaLinkByName(name)
+	})
+}
+
+// RdmaLinkDel wraps netlink.RdmaLinkDel, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func RdmaLinkDel(name string) error {
+	return WithRetry(func() error {
+		return netlink.RdmaLinkDel(name)
+	})
+}
+
+// RouteList wraps netlink.RouteList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func RouteList(link netlink.Link, family int) ([]netlink.Route, error) {
+	return WithRetryResult(func() ([]netlink.Route, error) {
+		return netlink.RouteList(link, family)
+	})
+}
+
+// RouteListFiltered wraps netlink.RouteListFiltered, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func RouteListFiltered(family int, filter *netlink.Route, filterMask uint64) ([]netlink.Route, error) {
+	return WithRetryResult(func() ([]netlink.Route, error) {
+		return netlink.RouteListFiltered(family, filter, filterMask)
+	})
+}
+
+// RouteListFilteredIter wraps netlink.RouteListFilteredIter, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func RouteListFilteredIter(family int, filter *netlink.Route, filterMask uint64, f func(netlink.Route) (cont bool)) error {
+	return WithRetry(func() error {
+		return netlink.RouteListFilteredIter(family, filter, filterMask, f)
+	})
+}
+
+// RouteSubscribeWithOptions wraps netlink.RouteSubscribeWithOptions, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func RouteSubscribeWithOptions(ch chan<- netlink.RouteUpdate, done <-chan struct{}, options netlink.RouteSubscribeOptions) error {
+	return WithRetry(func() error {
+		return netlink.RouteSubscribeWithOptions(ch, done, options)
+	})
+}
+
+// RuleList wraps netlink.RuleList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func RuleList(family int) ([]netlink.Rule, error) {
+	return WithRetryResult(func() ([]netlink.Rule, error) {
+		return netlink.RuleList(family)
+	})
+}
+
+// RuleListFiltered wraps netlink.RuleListFiltered, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func RuleListFiltered(family int, filter *netlink.Rule, filterMask uint64) ([]netlink.Rule, error) {
+	return WithRetryResult(func() ([]netlink.Rule, error) {
+		return netlink.RuleListFiltered(family, filter, filterMask)
+	})
+}
+
+// SocketGet wraps netlink.SocketGet, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func SocketGet(local, remote net.Addr) (*netlink.Socket, error) {
+	return WithRetryResult(func() (*netlink.Socket, error) {
+		return netlink.SocketGet(local, remote)
+	})
+}
+
+// SocketDiagTCPInfo wraps netlink.SocketDiagTCPInfo, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func SocketDiagTCPInfo(family uint8) ([]*netlink.InetDiagTCPInfoResp, error) {
+	return WithRetryResult(func() ([]*netlink.InetDiagTCPInfoResp, error) {
+		return netlink.SocketDiagTCPInfo(family)
+	})
+}
+
+// SocketDiagTCP wraps netlink.SocketDiagTCP, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func SocketDiagTCP(family uint8) ([]*netlink.Socket, error) {
+	return WithRetryResult(func() ([]*netlink.Socket, error) {
+		return netlink.SocketDiagTCP(family)
+	})
+}
+
+// SocketDiagUDPInfo wraps netlink.SocketDiagUDPInfo, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func SocketDiagUDPInfo(family uint8) ([]*netlink.InetDiagUDPInfoResp, error) {
+	return WithRetryResult(func() ([]*netlink.InetDiagUDPInfoResp, error) {
+		return netlink.SocketDiagUDPInfo(family)
+	})
+}
+
+// SocketDiagUDP wraps netlink.SocketDiagUDP, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func SocketDiagUDP(family uint8) ([]*netlink.Socket, error) {
+	return WithRetryResult(func() ([]*netlink.Socket, error) {
+		return netlink.SocketDiagUDP(family)
+	})
+}
+
+// UnixSocketDiagInfo wraps netlink.UnixSocketDiagInfo, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func UnixSocketDiagInfo() ([]*netlink.UnixDiagInfoResp, error) {
+	return WithRetryResult(func() ([]*netlink.UnixDiagInfoResp, error) {
+		return netlink.UnixSocketDiagInfo()
+	})
+}
+
+// UnixSocketDiag wraps netlink.UnixSocketDiag, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func UnixSocketDiag() ([]*netlink.UnixSocket, error) {
+	return WithRetryResult(func() ([]*netlink.UnixSocket, error) {
+		return netlink.UnixSocketDiag()
+	})
+}
+
+// SocketXDPGetInfo wraps netlink.SocketXDPGetInfo, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func SocketXDPGetInfo(ino uint32, cookie uint64) (*netlink.XDPDiagInfoResp, error) {
+	return WithRetryResult(func() (*netlink.XDPDiagInfoResp, error) {
+		return netlink.SocketXDPGetInfo(ino, cookie)
+	})
+}
+
+// SocketDiagXDP wraps netlink.SocketDiagXDP, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func SocketDiagXDP() ([]*netlink.XDPDiagInfoResp, error) {
+	return WithRetryResult(func() ([]*netlink.XDPDiagInfoResp, error) {
+		return netlink.SocketDiagXDP()
+	})
+}
+
+// VDPAGetDevList wraps netlink.VDPAGetDevList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func VDPAGetDevList() ([]*netlink.VDPADev, error) {
+	return WithRetryResult(func() ([]*netlink.VDPADev, error) {
+		return netlink.VDPAGetDevList()
+	})
+}
+
+// VDPAGetDevConfigList wraps netlink.VDPAGetDevConfigList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func VDPAGetDevConfigList() ([]*netlink.VDPADevConfig, error) {
+	return WithRetryResult(func() ([]*netlink.VDPADevConfig, error) {
+		return netlink.VDPAGetDevConfigList()
+	})
+}
+
+// VDPAGetMGMTDevList wraps netlink.VDPAGetMGMTDevList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func VDPAGetMGMTDevList() ([]*netlink.VDPAMGMTDev, error) {
+	return WithRetryResult(func() ([]*netlink.VDPAMGMTDev, error) {
+		return netlink.VDPAGetMGMTDevList()
+	})
+}
+
+// XfrmPolicyList wraps netlink.XfrmPolicyList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func XfrmPolicyList(family int) ([]netlink.XfrmPolicy, error) {
+	return WithRetryResult(func() ([]netlink.XfrmPolicy, error) {
+		return netlink.XfrmPolicyList(family)
+	})
+}
+
+// XfrmStateList wraps netlink.XfrmStateList, but retries the call automatically
+// if netlink.ErrDumpInterrupted is returned
+func XfrmStateList(family int) ([]netlink.XfrmState, error) {
+	return WithRetryResult(func() ([]netlink.XfrmState, error) {
+		return netlink.XfrmStateList(family)
+	})
+}

--- a/pkg/datapath/linux/safenetlink/netlink_linux_test.go
+++ b/pkg/datapath/linux/safenetlink/netlink_linux_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package safenetlink
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func Test_withRetryResult(t *testing.T) {
+	// Test eventually successful
+	retries := 0
+	out, err := WithRetryResult(func() (string, error) {
+		if retries < 3 {
+			retries++
+			return "", netlink.ErrDumpInterrupted
+		}
+
+		return "success", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "success", out)
+	require.Equal(t, 3, retries)
+
+	// Test eventually fails
+	retries = 0
+	out, err = WithRetryResult(func() (string, error) {
+		if retries < 3 {
+			retries++
+			return "", netlink.ErrDumpInterrupted
+		}
+
+		return "failure", io.ErrUnexpectedEOF
+	})
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	require.Equal(t, "failure", out)
+	require.Equal(t, 3, retries)
+
+	// Test eventually times out
+	out, err = WithRetryResult(func() (string, error) {
+		return "", netlink.ErrDumpInterrupted
+	})
+	require.True(t, wait.Interrupted(err))
+	require.Empty(t, out)
+}

--- a/pkg/datapath/linux/safenetlink/netlink_unspecified.go
+++ b/pkg/datapath/linux/safenetlink/netlink_unspecified.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !linux
+
+// This file duplicates the stubs that exist in vishvananda/netlink outside the linux build. Not all
+// functions defined in found in netlink_linux.go are present here, because not all have a stub in
+// vishvananda/netlink, and thus some of the necessary function signature types are missing outside
+// the linux build.
+
+package safenetlink
+
+import (
+	"net"
+
+	"github.com/vishvananda/netlink"
+)
+
+func AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func ChainList(link netlink.Link, parent uint32) ([]netlink.Chain, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func ClassList(link netlink.Link, parent uint32) ([]netlink.Class, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func ConntrackTableList(table netlink.ConntrackTableType, family netlink.InetFamily) ([]*netlink.ConntrackFlow, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func FilterList(link netlink.Link, parent uint32) ([]netlink.Filter, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func FouList(fam int) ([]netlink.Fou, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func GenlFamilyList() ([]*netlink.GenlFamily, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func LinkByName(name string) (netlink.Link, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func LinkByAlias(alias string) (netlink.Link, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func LinkList() ([]netlink.Link, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func NeighList(linkIndex, family int) ([]netlink.Neigh, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func NeighProxyList(linkIndex, family int) ([]netlink.Neigh, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func LinkGetProtinfo(link netlink.Link) (netlink.Protinfo, error) {
+	return netlink.Protinfo{}, netlink.ErrNotImplemented
+}
+
+func QdiscList(link netlink.Link) ([]netlink.Qdisc, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func RdmaLinkDel(name string) error {
+	return netlink.ErrNotImplemented
+}
+
+func RouteList(link netlink.Link, family int) ([]netlink.Route, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func RouteListFiltered(family int, filter *netlink.Route, filterMask uint64) ([]netlink.Route, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func RouteListFilteredIter(family int, filter *netlink.Route, filterMask uint64, f func(netlink.Route) (cont bool)) error {
+	return netlink.ErrNotImplemented
+}
+
+func RuleList(family int) ([]netlink.Rule, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func RuleListFiltered(family int, filter *netlink.Rule, filterMask uint64) ([]netlink.Rule, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func SocketGet(local, remote net.Addr) (*netlink.Socket, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func SocketDiagTCPInfo(family uint8) ([]*netlink.InetDiagTCPInfoResp, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func SocketDiagTCP(family uint8) ([]*netlink.Socket, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func SocketDiagUDPInfo(family uint8) ([]*netlink.InetDiagUDPInfoResp, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func SocketDiagUDP(family uint8) ([]*netlink.Socket, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func UnixSocketDiagInfo() ([]*netlink.UnixDiagInfoResp, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func UnixSocketDiag() ([]*netlink.UnixSocket, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func SocketXDPGetInfo(ino uint32, cookie uint64) (*netlink.XDPDiagInfoResp, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func SocketDiagXDP() ([]*netlink.XDPDiagInfoResp, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func XfrmPolicyList(family int) ([]netlink.XfrmPolicy, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
+func XfrmStateList(family int) ([]netlink.XfrmState, error) {
+	return nil, netlink.ErrNotImplemented
+}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -16,12 +16,12 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/vishvananda/netlink"
 
-	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/alignchecker"
 	"github.com/cilium/cilium/pkg/datapath/linux/ethtool"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -33,7 +33,6 @@ import (
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/socketlb"
-	"github.com/cilium/cilium/pkg/time"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
@@ -42,10 +41,6 @@ const (
 	netdevHeaderFileName = "netdev_config.h"
 	// preFilterHeaderFileName is the name of the header file used for bpf_xdp.c.
 	preFilterHeaderFileName = "filter_config.h"
-	// retry configuration for linkList()
-	linkListMaxTries         = 15
-	linkListMinRetryInterval = 100 * time.Millisecond
-	linkListMaxRetryInterval = 10 * time.Second
 )
 
 func (l *loader) writeNetdevHeader(dir string) error {
@@ -146,11 +141,11 @@ func addENIRules(sysSettings []tables.Sysctl) ([]tables.Sysctl, error) {
 
 func cleanIngressQdisc(devices []string) error {
 	for _, iface := range devices {
-		link, err := netlink.LinkByName(iface)
+		link, err := safenetlink.LinkByName(iface)
 		if err != nil {
 			return fmt.Errorf("failed to retrieve link %s by name: %w", iface, err)
 		}
-		qdiscs, err := netlink.QdiscList(link)
+		qdiscs, err := safenetlink.QdiscList(link)
 		if err != nil {
 			return fmt.Errorf("failed to retrieve qdisc list of link %s: %w", iface, err)
 		}
@@ -167,28 +162,6 @@ func cleanIngressQdisc(devices []string) error {
 		}
 	}
 	return nil
-}
-
-// netlink.LinkList() can return a transient kernel interrupt error.
-// This function will retry the call with a backoff if an error is returned.
-func linkList() ([]netlink.Link, error) {
-	var last_error error
-	for try := 0; try < linkListMaxTries; try++ {
-		links, err := netlink.LinkList()
-		if err == nil {
-			return links, nil
-		}
-		last_error = err
-		sleep := backoff.CalculateDuration(
-			linkListMinRetryInterval,
-			linkListMaxRetryInterval,
-			2.0,
-			false,
-			try)
-		time.Sleep(sleep)
-	}
-
-	return nil, fmt.Errorf("Could not load links: %w", last_error)
 }
 
 // reinitializeIPSec is used to recompile and load encryption network programs.
@@ -212,7 +185,7 @@ func (l *loader) reinitializeIPSec() error {
 		// received encrypted packets. This logic will attach to all
 		// !veth devices.
 		interfaces = nil
-		links, err := linkList()
+		links, err := safenetlink.LinkList()
 		if err != nil {
 			return err
 		}
@@ -249,7 +222,7 @@ func (l *loader) reinitializeIPSec() error {
 
 	var errs error
 	for _, iface := range interfaces {
-		device, err := netlink.LinkByName(iface)
+		device, err := safenetlink.LinkByName(iface)
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf("retrieving device %s: %w", iface, err))
 			continue
@@ -285,7 +258,7 @@ func reinitializeOverlay(ctx context.Context, tunnelConfig tunnel.Config) error 
 	}
 
 	iface := tunnelConfig.DeviceName()
-	link, err := netlink.LinkByName(iface)
+	link, err := safenetlink.LinkByName(iface)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve link for interface %s: %w", iface, err)
 	}
@@ -325,7 +298,7 @@ func reinitializeWireguard(ctx context.Context) (err error) {
 		return
 	}
 
-	link, err := netlink.LinkByName(wgTypes.IfaceName)
+	link, err := safenetlink.LinkByName(wgTypes.IfaceName)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve link for interface %s: %w", wgTypes.IfaceName, err)
 	}

--- a/pkg/datapath/loader/tc.go
+++ b/pkg/datapath/loader/tc.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/ebpf/link"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -132,7 +133,7 @@ func attachTCProgram(device netlink.Link, prog *ebpf.Program, progName string, p
 // removeTCFilters removes all tc filters from the given interface.
 // Direction is passed as netlink.HANDLE_MIN_{INGRESS,EGRESS} via parent.
 func removeTCFilters(device netlink.Link, parent uint32) error {
-	filters, err := netlink.FilterList(device, parent)
+	filters, err := safenetlink.FilterList(device, parent)
 	if err != nil {
 		return err
 	}
@@ -149,7 +150,7 @@ func removeTCFilters(device netlink.Link, parent uint32) error {
 // hasCiliumTCFilters returns true if device has Cilium-managed bpf filters
 // for the given direction (parent).
 func hasCiliumTCFilters(device netlink.Link, parent uint32) (bool, error) {
-	filters, err := netlink.FilterList(device, parent)
+	filters, err := safenetlink.FilterList(device, parent)
 	if err != nil {
 		return false, fmt.Errorf("listing tc filters for device %s, direction %d: %w", device.Attrs().Name, parent, err)
 	}

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/xdp"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/mac"
@@ -60,7 +61,7 @@ func xdpAttachedModeToFlag(mode uint32) link.XDPAttachFlags {
 // bpffsBase is typically set to /sys/fs/bpf/cilium, but can be a temp directory
 // during tests.
 func maybeUnloadObsoleteXDPPrograms(xdpDevs []string, xdpMode xdp.Mode, bpffsBase string) {
-	links, err := netlink.LinkList()
+	links, err := safenetlink.LinkList()
 	if err != nil {
 		log.WithError(err).Warn("Failed to list links for XDP unload")
 	}
@@ -96,7 +97,7 @@ func maybeUnloadObsoleteXDPPrograms(xdpDevs []string, xdpMode xdp.Mode, bpffsBas
 
 // xdpCompileArgs derives compile arguments for bpf_xdp.c.
 func xdpCompileArgs(xdpDev string, extraCArgs []string) ([]string, error) {
-	link, err := netlink.LinkByName(xdpDev)
+	link, err := safenetlink.LinkByName(xdpDev)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +154,7 @@ func compileAndLoadXDPProg(ctx context.Context, xdpDev string, xdpMode xdp.Mode,
 		return err
 	}
 
-	iface, err := netlink.LinkByName(xdpDev)
+	iface, err := safenetlink.LinkByName(xdpDev)
 	if err != nil {
 		return fmt.Errorf("retrieving device %s: %w", xdpDev, err)
 	}
@@ -285,7 +286,7 @@ func attachXDPProgram(iface netlink.Link, prog *ebpf.Program, progName, bpffsDir
 // bpffsBase is typically /sys/fs/bpf/cilium, but can be overridden to a tempdir
 // during tests.
 func DetachXDP(ifaceName string, bpffsBase, progName string) error {
-	iface, err := netlink.LinkByName(ifaceName)
+	iface, err := safenetlink.LinkByName(ifaceName)
 	if err != nil {
 		return fmt.Errorf("getting link '%s' by name: %w", ifaceName, err)
 	}

--- a/pkg/datapath/tunnel/tunnel.go
+++ b/pkg/datapath/tunnel/tunnel.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/spf13/pflag"
-	"github.com/vishvananda/netlink"
 
 	dpcfgdef "github.com/cilium/cilium/pkg/datapath/linux/config/defines"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/defaults"
 )
 
@@ -162,7 +162,7 @@ func (cfg Config) datapathConfigProvider() (dpcfgdef.NodeOut, dpcfgdef.NodeFnOut
 		defines["TUNNEL_PORT"] = fmt.Sprintf("%d", cfg.Port())
 
 		definesFn = func() (dpcfgdef.Map, error) {
-			tunnelDev, err := netlink.LinkByName(cfg.DeviceName())
+			tunnelDev, err := safenetlink.LinkByName(cfg.DeviceName())
 			if err != nil {
 				return nil, fmt.Errorf("failed to retrieve device info for %q: %w", cfg.DeviceName(), err)
 			}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -1336,7 +1337,7 @@ func CheckHealth(ep *Endpoint) error {
 		})
 		return nil
 	}
-	_, err := netlink.LinkByName(iface)
+	_, err := safenetlink.LinkByName(iface)
 	var linkNotFoundError netlink.LinkNotFoundError
 	if errors.As(err, &linkNotFoundError) {
 		return fmt.Errorf("Endpoint is invalid: %w", err)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/datapath/linux/bandwidth"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	dptypes "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -2543,7 +2544,7 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 // setDown sets the Endpoint's underlying interface down. If the interface
 // cannot be retrieved, returns nil.
 func (e *Endpoint) setDown() error {
-	link, err := netlink.LinkByName(e.HostInterface())
+	link, err := safenetlink.LinkByName(e.HostInterface())
 	if errors.As(err, &netlink.LinkNotFoundError{}) {
 		// No interface, nothing to do.
 		return nil

--- a/pkg/ipam/crd_eni.go
+++ b/pkg/ipam/crd_eni.go
@@ -14,6 +14,7 @@ import (
 
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/backoff"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/defaults"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -134,7 +135,7 @@ const (
 
 func waitForNetlinkDevices(configByMac configMap) (linkByMac linkMap, err error) {
 	for try := 0; try < waitForNetlinkDevicesMaxTries; try++ {
-		links, err := netlink.LinkList()
+		links, err := safenetlink.LinkList()
 		if err != nil {
 			log.WithError(err).Warn("failed to obtain eni link list - retrying")
 		} else {

--- a/pkg/ipam/pool.go
+++ b/pkg/ipam/pool.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/ipam/service/ipallocator"
 	"github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/lock"
@@ -331,7 +332,7 @@ func cleanupUnreachableRoutes(podCIDR string) error {
 		return errors.New("unknown pod cidr family")
 	}
 
-	routes, err := netlink.RouteListFiltered(family, &netlink.Route{
+	routes, err := safenetlink.RouteListFiltered(family, &netlink.Route{
 		Table: unix.RT_TABLE_MAIN,
 		Type:  unix.RTN_UNREACHABLE,
 	}, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_TYPE)

--- a/pkg/mac/mac_linux.go
+++ b/pkg/mac/mac_linux.go
@@ -8,11 +8,13 @@ import (
 	"net"
 
 	"github.com/vishvananda/netlink"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 )
 
 // HasMacAddr returns true if the given network interface has L2 addr.
 func HasMacAddr(iface string) bool {
-	link, err := netlink.LinkByName(iface)
+	link, err := safenetlink.LinkByName(iface)
 	if err != nil {
 		return false
 	}
@@ -26,7 +28,7 @@ func LinkHasMacAddr(link netlink.Link) bool {
 
 // ReplaceMacAddressWithLinkName replaces the MAC address of the given link
 func ReplaceMacAddressWithLinkName(ifName, macAddress string) error {
-	l, err := netlink.LinkByName(ifName)
+	l, err := safenetlink.LinkByName(ifName)
 	if err != nil {
 		if errors.As(err, &netlink.LinkNotFoundError{}) {
 			return nil

--- a/pkg/mtu/endpoint_updater.go
+++ b/pkg/mtu/endpoint_updater.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/datapath/connector"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/defaults"
 	healthDefaults "github.com/cilium/cilium/pkg/health/defaults"
@@ -285,7 +286,7 @@ func defaultRouteHook(routeMTUs []RouteMTU) error {
 		return err
 	}
 
-	links, err := netlink.LinkList()
+	links, err := safenetlink.LinkList()
 	if err != nil {
 		return err
 	}
@@ -299,7 +300,7 @@ func defaultRouteHook(routeMTUs []RouteMTU) error {
 
 		netlink.LinkSetMTU(link, defaultRouteMTU.DeviceMTU)
 
-		routes, err := netlink.RouteList(link, netlink.FAMILY_ALL)
+		routes, err := safenetlink.RouteList(link, netlink.FAMILY_ALL)
 		if err != nil {
 			return fmt.Errorf("netlink.RouteList failed: %w", err)
 		}

--- a/pkg/multicast/multicast.go
+++ b/pkg/multicast/multicast.go
@@ -7,9 +7,9 @@ import (
 	"net"
 	"net/netip"
 
-	"github.com/vishvananda/netlink"
 	"golang.org/x/net/ipv6"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -168,7 +168,7 @@ func (a Address) SolicitedNodeMaddr() netip.Addr {
 // The reason not to use net.InterfaceByName directly is to avoid potential
 // deadlocks (#15051).
 func interfaceByName(name string) (*net.Interface, error) {
-	link, err := netlink.LinkByName(name)
+	link, err := safenetlink.LinkByName(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node/address_linux.go
+++ b/pkg/node/address_linux.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/ip"
 )
 
@@ -31,7 +32,7 @@ func firstGlobalAddr(intf string, preferredIP net.IP, family int, preferPublic b
 	}
 
 	if intf != "" && intf != "undefined" {
-		link, err = netlink.LinkByName(intf)
+		link, err = safenetlink.LinkByName(intf)
 		if err != nil {
 			link = nil
 		} else {
@@ -40,7 +41,7 @@ func firstGlobalAddr(intf string, preferredIP net.IP, family int, preferPublic b
 	}
 
 retryInterface:
-	addr, err := netlink.AddrList(link, family)
+	addr, err := safenetlink.AddrList(link, family)
 	if err != nil {
 		return nil, err
 	}
@@ -167,11 +168,11 @@ func firstGlobalV6Addr(intf string, preferredIP net.IP, preferPublic bool) (net.
 // getCiliumHostIPsFromNetDev returns the first IPv4 link local and returns
 // it
 func getCiliumHostIPsFromNetDev(devName string) (ipv4GW, ipv6Router net.IP) {
-	hostDev, err := netlink.LinkByName(devName)
+	hostDev, err := safenetlink.LinkByName(devName)
 	if err != nil {
 		return nil, nil
 	}
-	addrs, err := netlink.AddrList(hostDev, netlink.FAMILY_ALL)
+	addrs, err := safenetlink.AddrList(hostDev, netlink.FAMILY_ALL)
 	if err != nil {
 		return nil, nil
 	}

--- a/pkg/node/ip_linux.go
+++ b/pkg/node/ip_linux.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/vishvananda/netlink"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 )
 
 func init() {
@@ -18,7 +20,7 @@ func initExcludedIPs() {
 	prefixes := []string{
 		"docker",
 	}
-	links, err := netlink.LinkList()
+	links, err := safenetlink.LinkList()
 	if err != nil {
 		return
 	}
@@ -48,7 +50,7 @@ func initExcludedIPs() {
 				continue
 			}
 		}
-		addr, err := netlink.AddrList(l, netlink.FAMILY_ALL)
+		addr, err := safenetlink.AddrList(l, netlink.FAMILY_ALL)
 		if err != nil {
 			continue
 		}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -597,12 +598,12 @@ func requireFromProxyRoutes() (fromIngressProxy, fromEgressProxy bool) {
 
 // getCiliumNetIPv6 retrieves the first IPv6 address from the cilium_net device.
 func getCiliumNetIPv6() (net.IP, error) {
-	link, err := netlink.LinkByName(defaults.SecondHostDevice)
+	link, err := safenetlink.LinkByName(defaults.SecondHostDevice)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find link '%s': %w", defaults.SecondHostDevice, err)
 	}
 
-	addrList, err := netlink.AddrList(link, netlink.FAMILY_V6)
+	addrList, err := safenetlink.AddrList(link, netlink.FAMILY_V6)
 	if err == nil && len(addrList) > 0 {
 		return addrList[0].IP, nil
 	}

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/lock"
@@ -186,7 +187,7 @@ func (a *Agent) Init(ipcache *ipcache.IPCache) error {
 	linkMTU := mtuConfig.DeviceMTU - mtu.WireguardOverhead
 
 	// try to remove any old tun devices created by userspace mode
-	link, _ := netlink.LinkByName(types.IfaceName)
+	link, _ := safenetlink.LinkByName(types.IfaceName)
 	if _, isTuntap := link.(*netlink.Tuntap); isTuntap {
 		_ = netlink.LinkDel(link)
 	}
@@ -252,7 +253,7 @@ func (a *Agent) mtuReconciler(ctx context.Context, health cell.Health) error {
 	for {
 		mtuRoute, _, watch, found := a.mtuTable.GetWatch(a.db.ReadTxn(), mtu.MTURouteIndex.Query(mtu.DefaultPrefixV4))
 		if found {
-			link, err := netlink.LinkByName(types.IfaceName)
+			link, err := safenetlink.LinkByName(types.IfaceName)
 			if err != nil {
 				health.Degraded("failed to get WireGuard link", err)
 				retry = true

--- a/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
+++ b/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/client"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
@@ -61,7 +62,7 @@ func (f *GenericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.Plug
 	defer ns.Close()
 
 	if err = ns.Do(func() error {
-		links, err := netlink.LinkList()
+		links, err := safenetlink.LinkList()
 		if err != nil {
 			return err
 		}
@@ -87,14 +88,14 @@ func (f *GenericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.Plug
 				return fmt.Errorf("unable to retrieve index of veth peer %s: %w", vethHostName, err)
 			}
 
-			addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+			addrs, err := safenetlink.AddrList(link, netlink.FAMILY_V4)
 			if err == nil && len(addrs) > 0 {
 				vethIP = addrs[0].IPNet.IP.String()
 			} else if err != nil {
 				pluginCtx.Logger.WithError(err).WithField(logfields.Interface, link.Attrs().Name).Warn("No valid IPv4 address found")
 			}
 
-			addrsv6, err := netlink.AddrList(link, netlink.FAMILY_V6)
+			addrsv6, err := safenetlink.AddrList(link, netlink.FAMILY_V6)
 			if err == nil && len(addrsv6) > 0 {
 				if len(addrsv6) == 1 {
 					vethIPv6 = addrsv6[0].IPNet.IP.String()
@@ -119,7 +120,7 @@ func (f *GenericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.Plug
 		}
 
 		if pluginCtx.NetConf.EnableRouteMTU || pluginCtx.CiliumConf.EnableRouteMTUForCNIChaining {
-			routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
+			routes, err := safenetlink.RouteList(nil, netlink.FAMILY_V4)
 			if err != nil {
 				err = fmt.Errorf("unable to list the IPv4 routes: %w", err)
 				return err
@@ -135,7 +136,7 @@ func (f *GenericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.Plug
 				}
 			}
 
-			routes, err = netlink.RouteList(nil, netlink.FAMILY_V6)
+			routes, err = safenetlink.RouteList(nil, netlink.FAMILY_V6)
 			if err != nil {
 				err = fmt.Errorf("unable to list the IPv6 routes: %w", err)
 				return err

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -285,7 +286,7 @@ func addIPConfigToLink(ip netip.Addr, routes []route.Route, rules []route.Rule, 
 }
 
 func configureIface(ipam *models.IPAMResponse, ifName string, state *CmdState) (string, error) {
-	l, err := netlink.LinkByName(ifName)
+	l, err := safenetlink.LinkByName(ifName)
 	if err != nil {
 		return "", fmt.Errorf("failed to lookup %q: %w", ifName, err)
 	}
@@ -958,12 +959,12 @@ func verifyInterface(netnsPinPath, ifName string, expected *cniTypesV1.Result) e
 	}
 	defer ns.Close()
 	return ns.Do(func() error {
-		link, err := netlink.LinkByName(ifName)
+		link, err := safenetlink.LinkByName(ifName)
 		if err != nil {
 			return fmt.Errorf("cannot find container link %v", ifName)
 		}
 
-		addrList, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+		addrList, err := safenetlink.AddrList(link, netlink.FAMILY_ALL)
 		if err != nil {
 			return fmt.Errorf("failed to list link addresses: %w", err)
 		}


### PR DESCRIPTION
According to the kernel docs[^1], the kernel can return incomplete results for netlink state dumps if the state changes while we are dumping it. The result is then marked by `NLM_F_DUMP_INTR`. The `vishvananda/netlink` library returned `EINTR` since v1.2.1, but more recent versions have changed it such that it returns `netlink.ErrDumpInterrupted` instead[^2].

These interruptions seem common in high-churn environments. If the error occurs, it is in most cases best to just try again.  Therefore, this commit adds a wrapper for all `netlink` functions marked to return `ErrDumpInterrupted` that retries the function up to 30 times until it either succeeds or returns a different error.

While may call sites do have their own high-level retry mechanism (see e.g. https://github.com/cilium/cilium/pull/32099), the logged error message can still cause CI to fail (e.g. https://github.com/cilium/cilium/pull/35259). Long high-level retry intervals can also become problematic: For example, if the routing setup fails due to `NLM_F_DUMP_INTR` during an CNI ADD invocation, the retry adds add several seconds of additional delay to an already overloaded system, instead of resolving the issue quickly.

The last commit adds an additional linter that nudges developers to use this new `safenetlink` package for function calls that can be interrupted. This ensures that we don't have to add retries in all subsystems individually.

**Review per commit**

[^1]: https://docs.kernel.org/userspace-api/netlink/intro.html
[^2]: https://github.com/vishvananda/netlink/pull/1018