### PR TITLE
Non-transparent fallback for DNS proxy

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -280,7 +280,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 
 	// EncryptedOverlay feature must check the TunnelProtocol if enabled, since
 	// it only supports VXLAN right now.
-	if option.Config.EncryptionEnabled() && option.Config.EnableIPSecEncryptedOverlay {
+	if option.Config.EnableIPSec && option.Config.EnableIPSecEncryptedOverlay {
 		if !option.Config.TunnelingEnabled() {
 			return nil, nil, fmt.Errorf("EncryptedOverlay support requires VXLAN tunneling mode")
 		}

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -111,14 +111,15 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 		return fmt.Errorf("could not initialize regex LRU cache: %w", err)
 	}
 	dnsProxyConfig := dnsproxy.DNSProxyConfig{
-		Address:                "",
-		Port:                   port,
-		IPv4:                   option.Config.EnableIPv4,
-		IPv6:                   option.Config.EnableIPv6,
-		EnableDNSCompression:   option.Config.ToFQDNsEnableDNSCompression,
-		MaxRestoreDNSIPs:       option.Config.DNSMaxIPsPerRestoredRule,
-		ConcurrencyLimit:       option.Config.DNSProxyConcurrencyLimit,
-		ConcurrencyGracePeriod: option.Config.DNSProxyConcurrencyProcessingGracePeriod,
+		Address:                     "",
+		Port:                        port,
+		IPv4:                        option.Config.EnableIPv4,
+		IPv6:                        option.Config.EnableIPv6,
+		EnableDNSCompression:        option.Config.ToFQDNsEnableDNSCompression,
+		MaxRestoreDNSIPs:            option.Config.DNSMaxIPsPerRestoredRule,
+		ConcurrencyLimit:            option.Config.DNSProxyConcurrencyLimit,
+		ConcurrencyGracePeriod:      option.Config.DNSProxyConcurrencyProcessingGracePeriod,
+		AllowNonTransparentFallback: !option.Config.EncryptionEnabled(),
 	}
 	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy(dnsProxyConfig, d.lookupEPByIP, d.ipcache.LookupSecIDByIP, d.ipcache.LookupByIdentity,
 		d.notifyOnDNSMsg)

--- a/pkg/datapath/linux/bigtcp/bigtcp.go
+++ b/pkg/datapath/linux/bigtcp/bigtcp.go
@@ -224,7 +224,7 @@ func validateConfig(cfg UserConfig, daemonCfg *option.DaemonConfig) error {
 		if daemonCfg.TunnelingEnabled() {
 			return errors.New("BIG TCP is not supported in tunneling mode")
 		}
-		if daemonCfg.EncryptionEnabled() {
+		if daemonCfg.EnableIPSec {
 			return errors.New("BIG TCP is not supported with encryption enabled")
 		}
 		if daemonCfg.EnableHostLegacyRouting {

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -667,6 +667,10 @@ type DNSProxyConfig struct {
 	MaxRestoreDNSIPs       int
 	ConcurrencyLimit       int
 	ConcurrencyGracePeriod time.Duration
+	// When encryption is enabled, we cannot allow traffic to egress using the node IP, as it would
+	// be sent in plaintext. Without encryption, we can fall back to binding a non-transparent
+	// socket.
+	AllowNonTransparentFallback bool
 }
 
 // StartDNSProxy starts a proxy used for DNS L7 redirects that listens on
@@ -709,7 +713,7 @@ func StartDNSProxy(
 		cache:                    make(regexCache),
 		EnableDNSCompression:     dnsProxyConfig.EnableDNSCompression,
 		maxIPsPerRestoredDNSRule: dnsProxyConfig.MaxRestoreDNSIPs,
-		DNSClients:               NewSharedClients(),
+		DNSClients:               NewSharedClients(dnsProxyConfig.AllowNonTransparentFallback),
 	}
 	if dnsProxyConfig.ConcurrencyLimit > 0 {
 		p.ConcurrencyLimit = semaphore.NewWeighted(int64(dnsProxyConfig.ConcurrencyLimit))

--- a/pkg/fqdn/dnsproxy/shared_client_test.go
+++ b/pkg/fqdn/dnsproxy/shared_client_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	clients = NewSharedClients()
+	clients = NewSharedClients(false)
 )
 
 func TestSharedClientSync(t *testing.T) {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2409,9 +2409,9 @@ func (c *DaemonConfig) NodeEncryptionEnabled() bool {
 	return c.EncryptNode
 }
 
-// EncryptionEnabled returns true if encryption is enabled
+// EncryptionEnabled returns true if IPsec or WireGuard is enabled
 func (c *DaemonConfig) EncryptionEnabled() bool {
-	return c.EnableIPSec
+	return c.EnableIPSec || c.EnableWireguard
 }
 
 // IPv4Enabled returns true if IPv4 is enabled


### PR DESCRIPTION
Main commit msg:
```
When the DNS proxy runs in transparent mode, it tries to allocate a
socket on behalf of the pod, with the pod source IP and port. Since the
pod chose this source port in its own network namespace, there is no
guarantee that the port is also available in the host netns, where the
proxy lives. If this happens, the DNS query would fail with a "bind:
address already in use" error.

The most typical case of hitting this was already solved by adding the
wireguard and tunnel ports to the ipv4.local_reserved_ports list on pod
startup (at the CNI level), but this doesn't account for ports which are
bound on the node _after_ the pod is started.

Transparent mode ensures that the DNS traffic is categorized as pod
traffic and treated as such (by encryption etc). For this to work, it
would likely be enough to be IP-transparent, which opens up the avenue
of simply allocating a different source port in the case of a collision.
This, however, runs the risk of hijacking unrelated pod traffic on that
port, since the host netns has no visibility into which ports are being
used in the pod netns.

It's unclear how to solve this issue perfectly, thus add another 80/20
workaround: if we aren't using encryption but do use DNS transparent
mode, it's preferrable to lose transparency than to drop a DNS query.
```

Related: #31535

```release-note
Cilium's DNS proxy will now try to fall back to non-transparent mode when encountering a port collision when handling a DNS query, unless configured to use transport encryption.
```
