### PR TITLE
Reinitialize datapath in case IP{v4,v6}NativeRoutingCIDR is updated

### DIFF
--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -121,15 +121,20 @@ func (d *Daemon) getMasqueradingStatus() *models.Masquerading {
 		return s
 	}
 
+	localNode, err := d.nodeLocalStore.Get(context.TODO())
+	if err != nil {
+		return s
+	}
+
 	if option.Config.EnableIPv4 {
 		// SnatExclusionCidr is the legacy field, continue to provide
 		// it for the time being
-		s.SnatExclusionCidr = datapath.RemoteSNATDstAddrExclusionCIDRv4().String()
-		s.SnatExclusionCidrV4 = datapath.RemoteSNATDstAddrExclusionCIDRv4().String()
+		s.SnatExclusionCidr = datapath.RemoteSNATDstAddrExclusionCIDRv4(localNode).String()
+		s.SnatExclusionCidrV4 = datapath.RemoteSNATDstAddrExclusionCIDRv4(localNode).String()
 	}
 
 	if option.Config.EnableIPv6 {
-		s.SnatExclusionCidrV6 = datapath.RemoteSNATDstAddrExclusionCIDRv6().String()
+		s.SnatExclusionCidrV6 = datapath.RemoteSNATDstAddrExclusionCIDRv6(localNode).String()
 	}
 
 	if option.Config.EnableBPFMasquerade {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -643,7 +643,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 					// native-routing-cidr is optional with ip-masq-agent and may be nil
 					excludeCIDR = option.Config.IPv4NativeRoutingCIDR
 				} else {
-					excludeCIDR = datapath.RemoteSNATDstAddrExclusionCIDRv4()
+					excludeCIDR = cfg.NativeRoutingCIDRIPv4
 				}
 
 				if excludeCIDR != nil {
@@ -663,7 +663,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 
 					excludeCIDR = option.Config.IPv6NativeRoutingCIDR
 				} else {
-					excludeCIDR = datapath.RemoteSNATDstAddrExclusionCIDRv6()
+					excludeCIDR = cfg.NativeRoutingCIDRIPv6
 				}
 
 				if excludeCIDR != nil {

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -77,6 +77,8 @@ func newLocalNodeConfig(
 		CiliumInternalIPv6:           localNode.GetCiliumInternalIP(true),
 		AllocCIDRIPv4:                localNode.IPv4AllocCIDR,
 		AllocCIDRIPv6:                localNode.IPv6AllocCIDR,
+		NativeRoutingCIDRIPv4:        datapath.RemoteSNATDstAddrExclusionCIDRv4(localNode),
+		NativeRoutingCIDRIPv6:        datapath.RemoteSNATDstAddrExclusionCIDRv6(localNode),
 		LoopbackIPv4:                 node.GetIPv4Loopback(),
 		Devices:                      nativeDevices,
 		NodeAddresses:                statedb.Collect(nodeAddrsIter),

--- a/pkg/datapath/types/config.go
+++ b/pkg/datapath/types/config.go
@@ -118,23 +118,23 @@ type ConfigWriter interface {
 // RemoteSNATDstAddrExclusionCIDRv4 returns a CIDR for SNAT exclusion. Any
 // packet sent from a local endpoint to an IP address belonging to the CIDR
 // should not be SNAT'd.
-func RemoteSNATDstAddrExclusionCIDRv4() *cidr.CIDR {
-	if c := option.Config.IPv4NativeRoutingCIDR; c != nil {
-		// ipv4-native-routing-cidr is set, so use it
-		return c
+func RemoteSNATDstAddrExclusionCIDRv4(localNode node.LocalNode) *cidr.CIDR {
+	if localNode.IPv4NativeRoutingCIDR != nil {
+		// ipv4-native-routing-cidr is set or has been autodetected, so use it
+		return localNode.IPv4NativeRoutingCIDR
 	}
 
-	return node.GetIPv4AllocRange()
+	return localNode.IPv4AllocCIDR
 }
 
 // RemoteSNATDstAddrExclusionCIDRv6 returns a IPv6 CIDR for SNAT exclusion. Any
 // packet sent from a local endpoint to an IP address belonging to the CIDR
 // should not be SNAT'd.
-func RemoteSNATDstAddrExclusionCIDRv6() *cidr.CIDR {
-	if c := option.Config.IPv6NativeRoutingCIDR; c != nil {
-		// ipv6-native-routing-cidr is set, so use it
-		return c
+func RemoteSNATDstAddrExclusionCIDRv6(localNode node.LocalNode) *cidr.CIDR {
+	if localNode.IPv6NativeRoutingCIDR != nil {
+		// ipv6-native-routing-cidr is set or has been autodetected, so use it
+		return localNode.IPv6NativeRoutingCIDR
 	}
 
-	return node.GetIPv6AllocRange()
+	return localNode.IPv6AllocCIDR
 }

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -56,6 +56,12 @@ type LocalNodeConfiguration struct {
 	// Immutable at runtime.
 	AllocCIDRIPv6 *cidr.CIDR
 
+	// NativeRoutingCIDRIPv4 is the v4 CIDR in which pod IPs are routable.
+	NativeRoutingCIDRIPv4 *cidr.CIDR
+
+	// NativeRoutingCIDRIPv6 is the v4 CIDR in which pod IPs are routable.
+	NativeRoutingCIDRIPv6 *cidr.CIDR
+
 	// LoopbackIPv4 is the IPv4 loopback address.
 	// Immutable at runtime.
 	LoopbackIPv4 net.IP

--- a/pkg/datapath/types/zz_generated.deepequal.go
+++ b/pkg/datapath/types/zz_generated.deepequal.go
@@ -99,6 +99,22 @@ func (in *LocalNodeConfiguration) DeepEqual(other *LocalNodeConfiguration) bool 
 		}
 	}
 
+	if (in.NativeRoutingCIDRIPv4 == nil) != (other.NativeRoutingCIDRIPv4 == nil) {
+		return false
+	} else if in.NativeRoutingCIDRIPv4 != nil {
+		if !in.NativeRoutingCIDRIPv4.DeepEqual(other.NativeRoutingCIDRIPv4) {
+			return false
+		}
+	}
+
+	if (in.NativeRoutingCIDRIPv6 == nil) != (other.NativeRoutingCIDRIPv6 == nil) {
+		return false
+	} else if in.NativeRoutingCIDRIPv6 != nil {
+		if !in.NativeRoutingCIDRIPv6.DeepEqual(other.NativeRoutingCIDRIPv6) {
+			return false
+		}
+	}
+
 	if ((in.LoopbackIPv4 != nil) && (other.LoopbackIPv4 != nil)) || ((in.LoopbackIPv4 == nil) != (other.LoopbackIPv4 == nil)) {
 		in, other := &in.LoopbackIPv4, &other.LoopbackIPv4
 		if other == nil {


### PR DESCRIPTION
BPF Masquerading relies on IP{V4,V6}_SNAT_EXCLUSION_DST_CIDR datapath config value to know which destination CIDRs should not be SNATed for pod to pod traffic.

In case of IPAM modes "eni", "azure" or "alibabacloud", if "ipv4-native-routing-cidr" is not explicitly set, the exclusion destination CIDR is autodetected at runtime, specifically from the relevant cloud provider Status section in the CiliumNode CRD.

In commit 50e42f1659 the way that autodetection logic propagates that value was changed and it now relies on the LocalNodeStore to emit an update for the new IPv4 native routing CIDR value. But the datapath still reads the value stored in the global config option variable, thus it ignores the update from the autodetection logic.

To let the datapath configure the correct SNAT exclusion CIDR, let the loader rely on the local node store read by the orchestrator, instead of reading the global configuration options directly.

This guarantees that the datapath will be reinitialized in case of a runtime update to the IPv4NativeRoutingCIDR following the autodetection.

Furthermore, update the `cilium status` output to reflect the actual masquerading status reading the native routing CIDRs from the local node store.

```release-note
Fixes BPF Masquerading exclusion CIDR for IPAM modes "eni", "azure" and "alibabacloud".
```