### PR TITLE
[IPsec] Support Decryption of VXLAN-in-ESP and ESP-in-VXLAN traffic

### DIFF
--- a/.github/actions/ipsec-key-rotate/action.yaml
+++ b/.github/actions/ipsec-key-rotate/action.yaml
@@ -5,10 +5,10 @@ inputs:
     required: true
     type: string
     description: "gcm(aes) or cbc(aes)"
-  encryption-overlay:
+  tunnel:
     required: true
     type: string
-    description: "'true' if encryption-overlay is enabled"
+    description: "the tunnel mode used, 'disabled' if native routing"
   nb-nodes:
     required: true
     type: string
@@ -39,14 +39,14 @@ runs:
         kubectl patch secret -n kube-system cilium-ipsec-keys -p="$data" -v=1
 
         # We have two keys per node, per direction, per IP family. So a two-nodes IPv4-only cluster
-        # will have four keys. If encryption-overlay is enabled, we have 4 more IPv4 keys for the
+        # will have four keys. If tunnel mode is enabled, we have 4 more IPv4 keys for the
         # overlay. During the key rotation, the number of keys doubles.
         exp_nb_keys=${{ inputs.nb-nodes }}
         ((exp_nb_keys*=2))
         if [[ "${{ inputs.ipv6 }}" == "true" ]]; then
           ((exp_nb_keys*=2))
         fi
-        if [[ "${{ inputs.encryption-overlay }}" == "true" ]]; then
+        if [[ "${{ inputs.tunnel }}" != "disabled" ]]; then
           ((exp_nb_keys+=4))
         fi
         ((exp_nb_keys*=2))

--- a/.github/actions/ipsec/configs.yaml
+++ b/.github/actions/ipsec/configs.yaml
@@ -59,7 +59,6 @@
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'vxlan'
-  encryption-overlay: 'true'
   key-one: 'gcm(aes)'
   key-two: 'gcm(aes)'
 - name: '8'

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -366,6 +366,7 @@ jobs:
         with:
           key-algo: "gcm(aes)"
           nb-nodes: 3
+          tunnel: "disabled"
           ipv6: false
 
       - name: Check conn-disrupt-test after rotating (${{ join(matrix.*, ', ') }})

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -328,7 +328,7 @@ jobs:
         uses: ./.github/actions/ipsec-key-rotate
         with:
           key-algo: ${{ matrix.key-two }}
-          encryption-overlay: ${{ matrix.encryption-overlay }}
+          tunnel: ${{ matrix.tunnel }}
           nb-nodes: 2
           ipv6: true
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1096,19 +1096,6 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 
 #ifdef ENABLE_IPSEC
 	if (!from_host) {
-#ifdef ENABLE_ENCRYPTED_OVERLAY
-		/* EncryptedOverlay XFRM policies set the output mark to the literal
-		 * MARK_MAGIC_DECRYPTED_OVERLAY value.
-		 *
-		 * If we see this here, its decrypted overlay traffic from these
-		 * XFRM policies. We can punt this directly to ingress side of vxlan
-		 * interface for decap.
-		 */
-		if (ctx->mark == MARK_MAGIC_DECRYPTED_OVERLAY) {
-			ret = ctx_redirect(ctx, ENCAP_IFINDEX, BPF_F_INGRESS);
-			return ret;
-		}
-#endif /* ENABLED_ENCRYPTED_OVERLAY */
 		/* If the packet needs decryption, we want to send it straight to the
 		 * stack. There's no need to run service handling logic, host firewall,
 		 * etc. on an encrypted packet.

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -730,7 +730,6 @@ enum metric_dir {
 /* used to identify encrypted overlay traffic post decryption.
  * therefore, SPI bit can be reused to not steal an additional magic mark value.
  */
-#define MARK_MAGIC_DECRYPTED_OVERLAY	0x1D00
 #define MARK_MAGIC_ENCRYPT		0x0E00
 #define MARK_MAGIC_IDENTITY		0x0F00 /* mark carries identity */
 #define MARK_MAGIC_TO_PROXY		0x0200

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -520,11 +520,6 @@ func ipSecReplaceStateIn(log *slog.Logger, params *IPSecParameters) (uint8, erro
 			Value: 0,
 			Mask:  linux_defaults.OutputMarkMask,
 		}
-	} else if params.ReqID == EncryptedOverlayReqID {
-		state.OutputMark = &netlink.XfrmMark{
-			Value: linux_defaults.RouteMarkDecryptedOverlay,
-			Mask:  linux_defaults.OutputMarkMask,
-		}
 	} else {
 		state.OutputMark = &netlink.XfrmMark{
 			Value: linux_defaults.RouteMarkDecrypt,

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -35,14 +35,6 @@ const (
 	// needs to decrypt a packet.
 	RouteMarkDecrypt = MagicMarkDecrypt
 
-	// RouteMarkDecryptedOverlay is the output mark used for EncryptedOverlay
-	// XFRM policies.
-	//
-	// When this mark is present on a packet it indicates that overlay traffic
-	// was decrypted by XFRM and should be forwarded to a tunnel device for
-	// decapsulation.
-	RouteMarkDecryptedOverlay = MagicMarkDecryptedOverlay
-
 	// RouteMarkEncrypt is the default route mark to use to indicate datapath
 	// needs to encrypt a packet.
 	RouteMarkEncrypt = MagicMarkEncrypt

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1336,12 +1336,6 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 		}
 	}
 
-	if !newConfig.EnableIPSecEncryptedOverlay {
-		if err := ipsec.DeleteXFRM(n.log, ipsec.EncryptedOverlayReqID); err != nil {
-			return fmt.Errorf("failed to delete encrypt overlay xfrm policies on node configuration change: %w", err)
-		}
-	}
-
 	var errs error
 	if !n.isInitialized {
 		n.isInitialized = true


### PR DESCRIPTION
This pull request implements the ability for a Cilium node to decrypt both ESP-in-VXLAN and VXLAN-in-ESP traffic. 

This change is motivated by the ultimate goal of moving to VXLAN-in-ESP traffic, which encrypts the security ID in the VXLAN header. 

A node must handle both traffic types for upgrade scenarios. 
For instance, during a roll-out a node may see ESP-in-VXLAN traffic (legacy node) along side VXLAN-in-ESP traffic (upgraded node). A node which has not been upgraded needs to handle both. 

To be clear, this PR introduces the ability for a node to handle both.
A later PR at a later release will actually implement the ESP-in-VXLAN traffic, such that the upgrade path will come naturally. 

```release-note
Updates XFRM policies to support the decryption of VXLAN-in-ESP traffic (encrypted overlay) 
```
