### PR TITLE
helm: Add Common label to all cilium resources

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -936,6 +936,10 @@
      - Remove the CNI configuration and binary files on agent shutdown. Enable this if you're removing Cilium from the cluster. Disable this to prevent the CNI configuration file from being removed during agent upgrade, which can cause nodes to go unmanageable.
      - bool
      - ``false``
+   * - :spelling:ignore:`commonLabels`
+     - commonLabels allows users to add common labels for all Cilium resources.
+     - object
+     - ``{}``
    * - :spelling:ignore:`conntrackGCInterval`
      - Configure how frequently garbage collection should occur for the datapath connection tracking table.
      - string

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -236,6 +236,7 @@ cnp
 codebase
 codeowner
 codeowners
+commonLabels
 compat
 config
 configMap

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -73,6 +73,15 @@ CRD_FILES := $(shell find $(ROOT_DIR)/examples/crds/*/ -type f)
 CRDS := $(foreach path,$(patsubst %.yaml,%,$(CRD_FILES)),$(shell basename $(path)))
 lint:
 	$(ECHO_CHECK)
+	$(QUIET)grep -RL --exclude validate.yaml .Values.commonLabels $(ROOT_DIR)/$(RELATIVE_DIR)/cilium/templates/*.yaml $(ROOT_DIR)/$(RELATIVE_DIR)/cilium/templates/**/*.yaml >> missing_label
+	$(QUIET)if [ -s missing_label ]; then \
+		echo "These files are missing the .Values.commonLabels, please add them and submit your changes" ; \
+		cat missing_label ; \
+		rm -f missing_label ; \
+		exit 1; \
+	else \
+		rm -f missing_label ; \
+	fi;
 	$(QUIET)for crd in $(CRDS); do \
 		grep -q $$crd $(CHART_FILE) \
 		|| (echo -e "$$crd not found in $(CHART_FILE).\nPlease update the chart to include $$crd."; exit 1); \

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -284,6 +284,7 @@ contributors across the globe, there is almost always someone available to help.
 | cni.logFile | string | `"/var/run/cilium/cilium-cni.log"` | Configure the log file for CNI logging with retention policy of 7 days. Disable CNI file logging by setting this field to empty explicitly. |
 | cni.resources | object | `{"requests":{"cpu":"100m","memory":"10Mi"}}` | Specifies the resources for the cni initContainer |
 | cni.uninstall | bool | `false` | Remove the CNI configuration and binary files on agent shutdown. Enable this if you're removing Cilium from the cluster. Disable this to prevent the CNI configuration file from being removed during agent upgrade, which can cause nodes to go unmanageable. |
+| commonLabels | object | `{}` | commonLabels allows users to add common labels for all Cilium resources. |
 | conntrackGCInterval | string | `"0s"` | Configure how frequently garbage collection should occur for the datapath connection tracking table. |
 | conntrackGCMaxInterval | string | `""` | Configure the maximum frequency for the garbage collection of the connection tracking table. Only affects the automatic computation for the frequency and has no effect when 'conntrackGCInterval' is set. This can be set to more frequently clean up unused identities created from ToFQDN policies. |
 | crdWaitTimeout | string | `"5m"` | Configure timeout in which Cilium will exit if CRDs are not available |

--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -12,6 +12,9 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
 - apiGroups:
   - networking.k8s.io

--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrolebinding.yaml
@@ -9,6 +9,9 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -25,6 +25,9 @@ metadata:
     k8s-app: cilium
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-agent
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- if .Values.keepDeprecatedLabels }}
     kubernetes.io/cluster-service: "true"
     {{- if and .Values.gke.enabled (eq (include "cilium.namespace" .) "kube-system" ) }}
@@ -73,6 +76,9 @@ spec:
         k8s-app: cilium
         app.kubernetes.io/name: cilium-agent
         app.kubernetes.io/part-of: cilium
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if .Values.keepDeprecatedLabels }}
         kubernetes.io/cluster-service: "true"
         {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/dashboards-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/dashboards-configmap.yaml
@@ -12,6 +12,9 @@ metadata:
     k8s-app: cilium
     app.kubernetes.io/name: cilium-agent
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- if $.Values.dashboards.label }}
     {{ $.Values.dashboards.label }}: {{ ternary $.Values.dashboards.labelValue "1" (not (empty $.Values.dashboards.labelValue)) | quote }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/role.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/role.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
 - apiGroups:
   - ""

--- a/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/install/kubernetes/cilium/templates/cilium-agent/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/service.yaml
@@ -14,6 +14,9 @@ metadata:
     k8s-app: cilium
     app.kubernetes.io/name: cilium-agent
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   clusterIP: None
   type: ClusterIP

--- a/install/kubernetes/cilium/templates/cilium-agent/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/serviceaccount.yaml
@@ -4,6 +4,10 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.cilium.name | quote }}
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if or .Values.serviceAccounts.cilium.annotations .Values.annotations }}
   annotations:
     {{- with .Values.annotations }}

--- a/install/kubernetes/cilium/templates/cilium-agent/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/servicemonitor.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: {{ .Values.prometheus.serviceMonitor.namespace | default (include "cilium.namespace" .) }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- with .Values.prometheus.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-ca-bundle-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ca-bundle-configmap.yaml
@@ -5,6 +5,11 @@ kind: {{ .Values.tls.caBundle.useSecret | ternary "Secret" "ConfigMap" }}
 metadata:
   name: {{ .Values.tls.caBundle.name }}
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
 {{ .Values.tls.caBundle.useSecret | ternary "stringData" "data" }}:
   {{ .Values.tls.caBundle.key }}: |
     {{- .Values.tls.caBundle.content | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-ca-secret.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ca-secret.yaml
@@ -11,6 +11,10 @@ kind: Secret
 metadata:
   name: {{ .commonCASecretName }}
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   ca.crt: {{ .commonCA.Cert | b64enc }}
   ca.key: {{ .commonCA.Key  | b64enc }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -90,6 +90,10 @@ kind: ConfigMap
 metadata:
   name: cilium-config
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
 {{- if .Values.etcd.enabled }}
   # The kvstore configuration is used to enable use of a kvstore for state

--- a/install/kubernetes/cilium/templates/cilium-envoy/configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/configmap.yaml
@@ -7,6 +7,10 @@ kind: ConfigMap
 metadata:
   name: cilium-envoy-config
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.envoy.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -15,6 +15,9 @@ metadata:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-envoy
     name: cilium-envoy
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -46,6 +49,9 @@ spec:
         name: cilium-envoy
         app.kubernetes.io/name: cilium-envoy
         app.kubernetes.io/part-of: cilium
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.envoy.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/service.yaml
@@ -20,6 +20,9 @@ metadata:
     app.kubernetes.io/name: cilium-envoy
     app.kubernetes.io/part-of: cilium
     io.cilium/app: proxy
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   clusterIP: None
   type: ClusterIP

--- a/install/kubernetes/cilium/templates/cilium-envoy/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/serviceaccount.yaml
@@ -5,6 +5,10 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.envoy.name | quote }}
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if or .Values.serviceAccounts.envoy.annotations .Values.envoy.annotations }}
   annotations:
     {{- with .Values.envoy.annotations }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/servicemonitor.yaml
@@ -9,6 +9,9 @@ metadata:
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-envoy
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- with .Values.envoy.prometheus.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-flowlog-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-flowlog-configmap.yaml
@@ -5,6 +5,10 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.hubble.export.dynamic.config.configMapName }}
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   flowlogs.yaml: |
     flowLogs:

--- a/install/kubernetes/cilium/templates/cilium-gateway-api-class.yaml
+++ b/install/kubernetes/cilium/templates/cilium-gateway-api-class.yaml
@@ -4,6 +4,10 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: cilium
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   controllerName: io.cilium/gateway-controller
   description: The default Cilium GatewayClass

--- a/install/kubernetes/cilium/templates/cilium-ingress-class.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-class.yaml
@@ -7,6 +7,10 @@ metadata:
   annotations:
     ingressclass.kubernetes.io/is-default-class: "true"
   {{- end}}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   controller: cilium.io/ingress-controller
 {{- end}}

--- a/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
@@ -6,8 +6,12 @@ metadata:
   namespace: {{ include "cilium.namespace" . }}
   labels:
     cilium.io/ingress: "true"
+    app.kubernetes.io/part-of: cilium
     {{- if .Values.ingressController.service.labels }}
     {{- toYaml .Values.ingressController.service.labels | nindent 4 }}
+    {{- end }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- if .Values.ingressController.service.annotations }}
   annotations:
@@ -46,10 +50,13 @@ kind: Endpoints
 metadata:
   name: {{ .Values.ingressController.service.name }}
   namespace: {{ include "cilium.namespace" . }}
-  {{- if .Values.ingressController.service.labels }}
   labels:
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.ingressController.service.labels }}
     {{- toYaml .Values.ingressController.service.labels | nindent 4 }}
-  {{- end }}
+    {{- end }}
   {{- if .Values.ingressController.service.annotations }}
   annotations:
     {{- toYaml .Values.ingressController.service.annotations | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -13,6 +13,9 @@ metadata:
     app: cilium-node-init
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-node-init
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -39,6 +42,9 @@ spec:
         app: cilium-node-init
         app.kubernetes.io/part-of: cilium
         app.kubernetes.io/name: cilium-node-init
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.nodeinit.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/serviceaccount.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ .Values.serviceAccounts.nodeinit.name | quote }}
   namespace: {{ include "cilium.namespace" . }}
   {{- if or .Values.serviceAccounts.nodeinit.annotations .Values.nodeinit.annotations }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   annotations:
     {{- with .Values.nodeinit.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -9,6 +9,9 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
 - apiGroups:
   - ""

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrolebinding.yaml
@@ -9,6 +9,9 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/install/kubernetes/cilium/templates/cilium-operator/dashboards-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/dashboards-configmap.yaml
@@ -12,6 +12,9 @@ metadata:
     k8s-app: cilium
     app.kubernetes.io/name: cilium-operator
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- if $.Values.operator.dashboards.label }}
     {{ $.Values.operator.dashboards.label }}: {{ ternary $.Values.operator.dashboards.labelValue "1" (not (empty $.Values.operator.dashboards.labelValue)) | quote }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -14,6 +14,9 @@ metadata:
     name: cilium-operator
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-operator
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
   # for more details.
@@ -57,6 +60,9 @@ spec:
         name: cilium-operator
         app.kubernetes.io/part-of: cilium
         app.kubernetes.io/name: cilium-operator
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.operator.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/poddisruptionbudget.yaml
@@ -14,6 +14,9 @@ metadata:
     name: cilium-operator
     app.kubernetes.io/name: cilium-operator
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- with $component.maxUnavailable }}
   maxUnavailable: {{ . }}

--- a/install/kubernetes/cilium/templates/cilium-operator/role.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/role.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
 - apiGroups:
   - ""

--- a/install/kubernetes/cilium/templates/cilium-operator/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/rolebinding.yaml
@@ -5,6 +5,10 @@ kind: RoleBinding
 metadata:
   name: cilium-operator-ingress-secrets
   namespace: {{ .Values.ingressController.secretsNamespace.name | quote }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.operator.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-operator/secret.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/secret.yaml
@@ -9,6 +9,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   AZURE_CLIENT_ID: {{ default "" .Values.azure.clientID | b64enc | quote }}

--- a/install/kubernetes/cilium/templates/cilium-operator/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/service.yaml
@@ -13,6 +13,9 @@ metadata:
     name: cilium-operator
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-operator
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   clusterIP: None
   type: ClusterIP

--- a/install/kubernetes/cilium/templates/cilium-operator/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/serviceaccount.yaml
@@ -8,6 +8,10 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.operator.name | quote }}
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if or .Values.serviceAccounts.operator.annotations .Values.operator.annotations }}
   annotations:
     {{- with .Values.operator.annotations }}

--- a/install/kubernetes/cilium/templates/cilium-operator/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/servicemonitor.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-operator
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- with .Values.operator.prometheus.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -12,6 +12,9 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
 - apiGroups:
   - networking.k8s.io

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrolebinding.yaml
@@ -9,6 +9,9 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -5,6 +5,10 @@ metadata:
   name: cilium-pre-flight-check
   namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.preflight.annotations }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,6 +28,9 @@ spec:
         k8s-app: cilium-pre-flight-check
         app.kubernetes.io/name: cilium-pre-flight-check
         kubernetes.io/cluster-service: "true"
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.preflight.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -11,6 +11,9 @@ metadata:
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-pre-flight-check
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}    
 spec:
   selector:
     matchLabels:
@@ -27,6 +30,9 @@ spec:
         k8s-app: cilium-pre-flight-check-deployment
         kubernetes.io/cluster-service: "true"
         app.kubernetes.io/name: cilium-pre-flight-check
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.preflight.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/poddisruptionbudget.yaml
@@ -14,6 +14,9 @@ metadata:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-pre-flight-check
     kubernetes.io/cluster-service: "true"
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- with $component.maxUnavailable }}
   maxUnavailable: {{ . }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/serviceaccount.yaml
@@ -4,6 +4,10 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.preflight.name | quote }}
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if or .Values.serviceAccounts.preflight.annotations .Values.preflight.annotations }}
   annotations:
     {{- with .Values.preflight.annotations }}

--- a/install/kubernetes/cilium/templates/cilium-resource-quota.yaml
+++ b/install/kubernetes/cilium/templates/cilium-resource-quota.yaml
@@ -22,6 +22,11 @@ kind: ResourceQuota
 metadata:
   name: cilium-operator-resource-quota
   namespace: {{ include "cilium.namespace" . }}
+  labels:
+    app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   hard:
     pods: {{ .Values.resourceQuotas.operator.hard.pods | quote }}

--- a/install/kubernetes/cilium/templates/cilium-secrets-namespace.yaml
+++ b/install/kubernetes/cilium/templates/cilium-secrets-namespace.yaml
@@ -11,4 +11,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ $name | quote }}
+  labels:
+    app.kubernetes.io/part-of: cilium
+    {{- with $.Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end}}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
@@ -5,6 +5,9 @@ metadata:
   name: clustermesh-apiserver
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
@@ -5,6 +5,9 @@ metadata:
   name: clustermesh-apiserver
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -15,6 +15,9 @@ metadata:
     k8s-app: clustermesh-apiserver
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: clustermesh-apiserver
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.clustermesh.apiserver.replicas }}
   selector:
@@ -34,6 +37,9 @@ spec:
         app.kubernetes.io/part-of: cilium
         app.kubernetes.io/name: clustermesh-apiserver
         k8s-app: clustermesh-apiserver
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.clustermesh.apiserver.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/metrics-service.yaml
@@ -16,6 +16,10 @@ metadata:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: clustermesh-apiserver
     app.kubernetes.io/component: metrics
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 spec:
   clusterIP: None
   type: ClusterIP

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/poddisruptionbudget.yaml
@@ -13,6 +13,10 @@ metadata:
     k8s-app: clustermesh-apiserver
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: clustermesh-apiserver
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 spec:
   {{- with $component.maxUnavailable }}
   maxUnavailable: {{ . }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
@@ -8,6 +8,10 @@ metadata:
     k8s-app: clustermesh-apiserver
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: clustermesh-apiserver
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
   {{- if or .Values.clustermesh.apiserver.service.annotations .Values.clustermesh.annotations }}
   annotations:
     {{- with .Values.clustermesh.annotations }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/serviceaccount.yaml
@@ -4,6 +4,11 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- if or .Values.serviceAccounts.clustermeshApiserver.annotations .Values.clustermesh.annotations }}
   annotations:
     {{- with .Values.clustermesh.annotations }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
@@ -11,6 +11,9 @@ metadata:
   namespace: {{ .Values.clustermesh.apiserver.metrics.serviceMonitor.namespace | default (include "cilium.namespace" .) }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- with .Values.clustermesh.apiserver.metrics.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
@@ -5,6 +5,10 @@ kind: Certificate
 metadata:
   name: clustermesh-apiserver-admin-cert
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/client-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/client-secret.yaml
@@ -5,6 +5,10 @@ kind: Certificate
 metadata:
   name: clustermesh-apiserver-client-cert
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/local-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/local-secret.yaml
@@ -5,6 +5,10 @@ kind: Certificate
 metadata:
   name: clustermesh-apiserver-local-cert
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/remote-secret.yaml
@@ -5,6 +5,10 @@ kind: Certificate
 metadata:
   name: clustermesh-apiserver-remote-cert
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
@@ -6,6 +6,10 @@ metadata:
   name: clustermesh-apiserver-server-cert
   namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/cronjob.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/cronjob.yaml
@@ -11,6 +11,9 @@ metadata:
   labels:
     k8s-app: clustermesh-apiserver-generate-certs
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   schedule: {{ .Values.clustermesh.apiserver.tls.auto.schedule | quote }}
   concurrencyPolicy: Forbid

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/job.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/job.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: {{ include "cilium.namespace" . }}
   labels:
     k8s-app: clustermesh-apiserver-generate-certs
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     app.kubernetes.io/part-of: cilium
   annotations:
     "helm.sh/hook": post-install,post-upgrade

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/role.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/role.yaml
@@ -10,6 +10,9 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
   - apiGroups:
       - ""

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/rolebinding.yaml
@@ -10,6 +10,9 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/serviceaccount.yaml
@@ -4,6 +4,10 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if or .Values.serviceAccounts.clustermeshcertgen.annotations .Values.clustermesh.annotations }}
   annotations:
     {{- with .Values.serviceAccounts.clustermeshcertgen.annotations }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/admin-secret.yaml
@@ -8,6 +8,10 @@ kind: Secret
 metadata:
   name: clustermesh-apiserver-admin-cert
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/client-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/client-secret.yaml
@@ -8,6 +8,10 @@ kind: Secret
 metadata:
   name: clustermesh-apiserver-client-cert
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/local-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/local-secret.yaml
@@ -8,6 +8,10 @@ kind: Secret
 metadata:
   name: clustermesh-apiserver-local-cert
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/remote-secret.yaml
@@ -8,6 +8,10 @@ kind: Secret
 metadata:
   name: clustermesh-apiserver-remote-cert
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
@@ -10,6 +10,10 @@ kind: Secret
 metadata:
   name: clustermesh-apiserver-server-cert
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/admin-secret.yaml
@@ -5,6 +5,10 @@ kind: Secret
 metadata:
   name: clustermesh-apiserver-admin-cert
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/client-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/client-secret.yaml
@@ -6,6 +6,10 @@ metadata:
   name: clustermesh-apiserver-client-cert
   namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.clustermesh.annotations }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/remote-secret.yaml
@@ -5,6 +5,10 @@ kind: Secret
 metadata:
   name: clustermesh-apiserver-remote-cert
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/server-secret.yaml
@@ -5,6 +5,10 @@ kind: Secret
 metadata:
   name: clustermesh-apiserver-server-cert
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
@@ -14,6 +14,10 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 data:
   users.yaml: |
     users:

--- a/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
@@ -9,6 +9,11 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
 data:
   {{- $kvstoremesh := and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled }}
   {{- $override := ternary (printf "https://clustermesh-apiserver.%s.svc:2379" (include "cilium.namespace" .)) "" $kvstoremesh }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/kvstoremesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/kvstoremesh-secret.yaml
@@ -5,6 +5,11 @@ kind: Secret
 metadata:
   name: cilium-kvstoremesh
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
@@ -9,6 +9,11 @@ kind: ConfigMap
 metadata:
   name: hubble-relay-config
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.hubble.relay.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -12,6 +12,10 @@ metadata:
     k8s-app: hubble-relay
     app.kubernetes.io/name: hubble-relay
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 spec:
   replicas: {{ .Values.hubble.relay.replicas }}
   selector:
@@ -39,6 +43,9 @@ spec:
         k8s-app: hubble-relay
         app.kubernetes.io/name: hubble-relay
         app.kubernetes.io/part-of: cilium
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.hubble.relay.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/metrics-service.yaml
@@ -5,12 +5,17 @@ apiVersion: v1
 metadata:
   name: hubble-relay-metrics
   namespace: {{ include "cilium.namespace" . }}
+
   {{- with .Values.hubble.relay.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     k8s-app: hubble-relay
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 spec:
   clusterIP: None
   type: ClusterIP

--- a/install/kubernetes/cilium/templates/hubble-relay/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/poddisruptionbudget.yaml
@@ -13,6 +13,10 @@ metadata:
     k8s-app: hubble-relay
     app.kubernetes.io/name: hubble-relay
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 spec:
   {{- with $component.maxUnavailable }}
   maxUnavailable: {{ . }}

--- a/install/kubernetes/cilium/templates/hubble-relay/service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/service.yaml
@@ -16,6 +16,10 @@ metadata:
     k8s-app: hubble-relay
     app.kubernetes.io/name: hubble-relay
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 spec:
   type: {{ .Values.hubble.relay.service.type | quote }}
   selector:

--- a/install/kubernetes/cilium/templates/hubble-relay/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/serviceaccount.yaml
@@ -4,6 +4,11 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.relay.name | quote }}
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- if or .Values.serviceAccounts.relay.annotations .Values.hubble.relay.annotations }}
   annotations:
     {{- with .Values.hubble.relay.annotations }}

--- a/install/kubernetes/cilium/templates/hubble-relay/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/servicemonitor.yaml
@@ -5,6 +5,10 @@ metadata:
   name: hubble-relay
   namespace: {{ .Values.hubble.relay.prometheus.serviceMonitor.namespace | default (include "cilium.namespace" .) }}
   labels:
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
     {{- with .Values.hubble.relay.prometheus.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/clusterrole.yaml
@@ -9,6 +9,10 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 rules:
 - apiGroups:
   - networking.k8s.io

--- a/install/kubernetes/cilium/templates/hubble-ui/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/clusterrolebinding.yaml
@@ -9,6 +9,10 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/install/kubernetes/cilium/templates/hubble-ui/configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/configmap.yaml
@@ -5,6 +5,11 @@ kind: ConfigMap
 metadata:
   name: hubble-ui-nginx
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.hubble.ui.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -12,6 +12,10 @@ metadata:
     k8s-app: hubble-ui
     app.kubernetes.io/name: hubble-ui
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
     {{- with .Values.hubble.ui.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -38,6 +42,9 @@ spec:
         k8s-app: hubble-ui
         app.kubernetes.io/name: hubble-ui
         app.kubernetes.io/part-of: cilium
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.hubble.ui.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/ingress.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/ingress.yaml
@@ -9,6 +9,10 @@ metadata:
     k8s-app: hubble-ui
     app.kubernetes.io/name: hubble-ui
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
   {{- with .Values.hubble.ui.ingress.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/poddisruptionbudget.yaml
@@ -13,6 +13,10 @@ metadata:
     k8s-app: hubble-ui
     app.kubernetes.io/name: hubble-ui
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 spec:
   {{- with $component.maxUnavailable }}
   maxUnavailable: {{ . }}

--- a/install/kubernetes/cilium/templates/hubble-ui/service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: hubble-ui
   namespace: {{ include "cilium.namespace" . }}
   {{- if or .Values.hubble.ui.service.annotations  .Values.hubble.ui.annotations }}
+
   annotations:
     {{- with .Values.hubble.ui.annotations }}
       {{- toYaml . | nindent 4 }}
@@ -17,6 +18,10 @@ metadata:
     k8s-app: hubble-ui
     app.kubernetes.io/name: hubble-ui
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 spec:
   type: {{ .Values.hubble.ui.service.type | quote }}
   selector:

--- a/install/kubernetes/cilium/templates/hubble-ui/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/serviceaccount.yaml
@@ -4,6 +4,11 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.ui.name | quote }}
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- if or .Values.serviceAccounts.ui.annotations .Values.hubble.ui.annotations }}
   annotations:
     {{- with .Values.hubble.ui.annotations }}

--- a/install/kubernetes/cilium/templates/hubble/dashboards-configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble/dashboards-configmap.yaml
@@ -12,6 +12,11 @@ metadata:
     k8s-app: hubble
     app.kubernetes.io/name: hubble
     app.kubernetes.io/part-of: cilium
+    
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
     {{- if $.Values.hubble.metrics.dashboards.label }}
     {{ $.Values.hubble.metrics.dashboards.label }}: {{ ternary $.Values.hubble.metrics.dashboards.labelValue "1" (not (empty $.Values.hubble.metrics.dashboards.labelValue)) | quote }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/metrics-service.yaml
@@ -8,6 +8,10 @@ metadata:
     k8s-app: hubble
     app.kubernetes.io/name: hubble
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
   annotations:
     {{- with .Values.hubble.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/peer-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/peer-service.yaml
@@ -12,6 +12,10 @@ metadata:
     k8s-app: cilium
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: hubble-peer
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 spec:
   selector:
     k8s-app: cilium

--- a/install/kubernetes/cilium/templates/hubble/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/hubble/servicemonitor.yaml
@@ -6,6 +6,11 @@ metadata:
   namespace: {{ .Values.prometheus.serviceMonitor.namespace | default (include "cilium.namespace" .) }}
   labels:
     app.kubernetes.io/part-of: cilium
+    
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
     {{- with .Values.hubble.metrics.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/metrics-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/metrics-server-secret.yaml
@@ -6,6 +6,11 @@ kind: Certificate
 metadata:
   name: hubble-metrics-server-certs
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-client-secret.yaml
@@ -5,6 +5,10 @@ kind: Certificate
 metadata:
   name: hubble-relay-client-certs
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/relay-server-secret.yaml
@@ -5,6 +5,10 @@ kind: Certificate
 metadata:
   name: hubble-relay-server-certs
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/server-secret.yaml
@@ -6,6 +6,11 @@ kind: Certificate
 metadata:
   name: hubble-server-certs
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-certmanager/ui-client-certs.yaml
@@ -5,6 +5,10 @@ kind: Certificate
 metadata:
   name: hubble-ui-client-certs
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/cronjob.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/cronjob.yaml
@@ -8,6 +8,10 @@ metadata:
     k8s-app: hubble-generate-certs
     app.kubernetes.io/name: hubble-generate-certs
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
   {{- if or .Values.certgen.annotations.cronJob .Values.hubble.annotations }}
   annotations:
     {{- with .Values.hubble.annotations }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/job.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/job.yaml
@@ -9,6 +9,9 @@ metadata:
     k8s-app: hubble-generate-certs
     app.kubernetes.io/name: hubble-generate-certs
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     {{- with .Values.certgen.annotations.job }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/role.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/role.yaml
@@ -10,6 +10,10 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 rules:
   - apiGroups:
       - ""

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/rolebinding.yaml
@@ -10,6 +10,10 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/serviceaccount.yaml
@@ -4,6 +4,11 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- if or .Values.serviceAccounts.hubblecertgen.annotations .Values.hubble.annotations }}
   annotations:
     {{- with .Values.hubble.annotations }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/metrics-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/metrics-server-secret.yaml
@@ -10,6 +10,11 @@ kind: Secret
 metadata:
   name: hubble-metrics-server-certs
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/relay-client-secret.yaml
@@ -9,6 +9,11 @@ kind: Secret
 metadata:
   name: hubble-relay-client-certs
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/relay-server-secret.yaml
@@ -10,6 +10,11 @@ kind: Secret
 metadata:
   name: hubble-relay-server-certs
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/server-secret.yaml
@@ -10,6 +10,11 @@ kind: Secret
 metadata:
   name: hubble-server-certs
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/ui-client-certs.yaml
@@ -9,6 +9,12 @@ kind: Secret
 metadata:
   name: hubble-ui-client-certs
   namespace: {{ include "cilium.namespace" . }}
+
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/metrics-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/metrics-server-secret.yaml
@@ -4,6 +4,12 @@ kind: Secret
 metadata:
   name: hubble-metrics-server-certs
   namespace: {{ include "cilium.namespace" . }}
+  
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/relay-client-secret.yaml
@@ -4,6 +4,12 @@ kind: Secret
 metadata:
   name: hubble-relay-client-certs
   namespace: {{ include "cilium.namespace" . }}
+
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/relay-server-secret.yaml
@@ -4,6 +4,12 @@ kind: Secret
 metadata:
   name: hubble-relay-server-certs
   namespace: {{ include "cilium.namespace" . }}
+
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/server-secret.yaml
@@ -4,6 +4,11 @@ kind: Secret
 metadata:
   name: hubble-server-certs
   namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/ui-client-certs.yaml
@@ -4,6 +4,12 @@ kind: Secret
 metadata:
   name: hubble-ui-client-certs
   namespace: {{ include "cilium.namespace" . }}
+
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/spire/agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/clusterrole.yaml
@@ -3,6 +3,11 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.authentication.mutual.spire.install.agent.serviceAccount.name }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.authentication.mutual.spire.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/spire/agent/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/clusterrolebinding.yaml
@@ -4,6 +4,11 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.authentication.mutual.spire.install.agent.serviceAccount.name }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.authentication.mutual.spire.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/spire/agent/configmap.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/configmap.yaml
@@ -4,6 +4,11 @@ kind: ConfigMap
 metadata:
   name: spire-agent
   namespace: {{ .Values.authentication.mutual.spire.install.namespace }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- with .Values.authentication.mutual.spire.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/spire/agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/daemonset.yaml
@@ -15,6 +15,9 @@ metadata:
   {{- end }}
   labels:
     app: spire-agent
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.authentication.mutual.spire.install.agent.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -27,6 +30,9 @@ spec:
       namespace: {{ .Values.authentication.mutual.spire.install.namespace }}
       labels:
         app: spire-agent
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.authentication.mutual.spire.install.agent.labels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/spire/agent/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/serviceaccount.yaml
@@ -4,6 +4,10 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.authentication.mutual.spire.install.agent.serviceAccount.name }}
   namespace: {{ .Values.authentication.mutual.spire.install.namespace }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.authentication.mutual.spire.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/spire/bundle-configmap.yaml
+++ b/install/kubernetes/cilium/templates/spire/bundle-configmap.yaml
@@ -4,6 +4,10 @@ kind: ConfigMap
 metadata:
   name: spire-bundle
   namespace: {{ .Values.authentication.mutual.spire.install.namespace }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.authentication.mutual.spire.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/spire/namespace.yaml
+++ b/install/kubernetes/cilium/templates/spire/namespace.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.authentication.mutual.spire.install.namespace }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.authentication.mutual.spire.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/spire/server/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/clusterrole.yaml
@@ -4,6 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.authentication.mutual.spire.install.server.serviceAccount.name }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.authentication.mutual.spire.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/spire/server/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/clusterrolebinding.yaml
@@ -3,6 +3,10 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.authentication.mutual.spire.install.server.serviceAccount.name }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.authentication.mutual.spire.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/spire/server/configmap.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/configmap.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: spire-server
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   namespace: {{ .Values.authentication.mutual.spire.install.namespace }}
   {{- with .Values.authentication.mutual.spire.annotations }}
   annotations:

--- a/install/kubernetes/cilium/templates/spire/server/role.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/role.yaml
@@ -4,6 +4,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.authentication.mutual.spire.install.server.serviceAccount.name }}
   namespace: {{ .Values.authentication.mutual.spire.install.namespace }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.authentication.mutual.spire.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/spire/server/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/rolebinding.yaml
@@ -4,6 +4,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.authentication.mutual.spire.install.server.serviceAccount.name }}
   namespace: {{ .Values.authentication.mutual.spire.install.namespace }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.authentication.mutual.spire.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/spire/server/service.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/service.yaml
@@ -4,6 +4,10 @@ kind: Service
 metadata:
   name: spire-server
   namespace: {{ .Values.authentication.mutual.spire.install.namespace }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if or .Values.authentication.mutual.spire.install.server.service.annotations .Values.authentication.mutual.spire.annotations }}
   annotations:
     {{- with .Values.authentication.mutual.spire.annotations }}

--- a/install/kubernetes/cilium/templates/spire/server/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/serviceaccount.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.authentication.mutual.spire.install.server.serviceAccount.name }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   namespace: {{ .Values.authentication.mutual.spire.install.namespace }}
   {{- with .Values.authentication.mutual.spire.annotations }}
   annotations:

--- a/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
@@ -4,6 +4,10 @@ kind: StatefulSet
 metadata:
   name: spire-server
   namespace: {{ .Values.authentication.mutual.spire.install.namespace }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if or .Values.authentication.mutual.spire.install.server.annotations .Values.authentication.mutual.spire.annotations }}
   annotations:
     {{- with .Values.authentication.mutual.spire.annotations }}
@@ -28,6 +32,9 @@ spec:
     metadata:
       labels:
         app: spire-server
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.authentication.mutual.spire.install.server.labels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1483,6 +1483,12 @@
       },
       "type": "object"
     },
+    "commonLabels": {
+      "type": [
+        "null",
+        "object"
+      ]
+    },
     "conntrackGCInterval": {
       "type": "string"
     },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -9,6 +9,11 @@
 # This property allows to use Cilium as part of an Umbrella Chart with different targets.
 namespaceOverride: ""
 # @schema
+# type: [null, object]
+# @schema
+# -- commonLabels allows users to add common labels for all Cilium resources.
+commonLabels: {}
+# @schema
 # type: [null, string]
 # @schema
 # -- upgradeCompatibility helps users upgrading to ensure that the configMap for

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -5,6 +5,11 @@
 # -- namespaceOverride allows to override the destination namespace for Cilium resources.
 # This property allows to use Cilium as part of an Umbrella Chart with different targets.
 namespaceOverride: ""
+# @schema
+# type: [null, object]
+# @schema
+# -- commonLabels allows users to add common labels for all Cilium resources.
+commonLabels: {}
 
 # @schema
 # type: [null, string]


### PR DESCRIPTION
<!-- Description of change -->

By adding a common label to all resources, this allows users to easily find all cilium deployed resources. This makes it easy to write OPA policies for all cilium resources. 

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

```release-note
Add a commonLabel to all cilium deployed resources
```
