### PR TITLE
hubble-relay: Return underlying connection errors when connecting to peer manager

### DIFF
--- a/pkg/hubble/peer/types/client.go
+++ b/pkg/hubble/peer/types/client.go
@@ -56,7 +56,10 @@ func (b LocalClientBuilder) Client(target string) (Client, error) {
 	// this context.
 	conn, err := grpc.DialContext(ctx, target,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock())
+		grpc.WithBlock(),
+		grpc.WithReturnConnectionError(),
+		grpc.FailOnNonTempDialError(true),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +76,11 @@ type RemoteClientBuilder struct {
 
 // Client implements ClientBuilder.Client.
 func (b RemoteClientBuilder) Client(target string) (Client, error) {
-	opts := []grpc.DialOption{grpc.WithBlock()}
+	opts := []grpc.DialOption{
+		grpc.WithBlock(),
+		grpc.WithReturnConnectionError(),
+		grpc.FailOnNonTempDialError(true),
+	}
 	if b.TLSConfig == nil {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {


### PR DESCRIPTION
When connecting to the hubble peer manager ensure we return the underlying connection error so it's easier to diagnose connection related problems.

Currently the only error returned is the context timeout:

```
time="2024-09-18T21:13:13Z" level=warning msg="Failed to create peer client for peers synchronization; will try again after the timeout has expired" error="context deadline exceeded" subsys=hubble-relay target="hubble-peer.kube-system.svc.cluster.local.:443"
```

This will ensure the underlying connection level error is returned when the context is cancelled.

In the future we should switch to not using grpc.WithBlock at all which avoids many of these problems, but that requires more testing. In the short-term, lets set these dial options to improve things now, in-case the switch to non-blocking dials is delayed.

```release-note
hubble-relay: Return underlying connection errors when connecting to peer manager
```

I'm marking for backport to v1.15 and 1.16 because the change is small and will be a huge improvement in errors that users see returned in Hubble Relay logs when they have an issue with Hubble Relay connecting to cilium agent.
