### PR TITLE
Endpoint leave locking 1.14

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -730,19 +730,23 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 	return NewPatchEndpointIDOK()
 }
 
-func (d *Daemon) deleteEndpoint(ep *endpoint.Endpoint) int {
+func (d *Daemon) deleteEndpointRelease(ep *endpoint.Endpoint, noIPRelease bool) int {
 	// Cancel any ongoing endpoint creation
 	d.endpointCreations.CancelCreateRequest(ep)
 
 	scopedLog := log.WithField(logfields.EndpointID, ep.ID)
 	errs := d.deleteEndpointQuiet(ep, endpoint.DeleteConfig{
-		// If the IP is managed by an external IPAM, it does not need to be released
-		NoIPRelease: ep.DatapathConfiguration.ExternalIpam,
+		NoIPRelease: noIPRelease,
 	})
 	for _, err := range errs {
 		scopedLog.WithError(err).Warn("Ignoring error while deleting endpoint")
 	}
 	return len(errs)
+}
+
+func (d *Daemon) deleteEndpoint(ep *endpoint.Endpoint) int {
+	// If the IP is managed by an external IPAM, it does not need to be released
+	return d.deleteEndpointRelease(ep, ep.DatapathConfiguration.ExternalIpam)
 }
 
 // deleteEndpointQuiet sets the endpoint into disconnecting state and removes

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -96,6 +96,12 @@ func (d *Daemon) initHealth(spec *healthApi.Spec, cleaner *daemonCleanup) {
 							return fmt.Errorf("failed to restart endpoint (check failed: %w): %w", err, launchErr)
 						}
 						return launchErr
+					} else {
+						// Now that we relaunched, retry so that the cleanup and time
+						// to bring up the health endpoint does not skew the probing
+						if pingErr := client.PingEndpoint(); pingErr == nil {
+							lastSuccessfulPing = time.Now()
+						}
 					}
 				}
 				return err

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -142,6 +142,10 @@ func (d *Daemon) cleanupHealthEndpoint() {
 		d.deleteEndpointRelease(ep, true)
 	}
 
+	// The CNI plugin is not invoked for the health endpoint since it was
+	// spawned by the agent itself. The endpoint manager will only down the
+	// device, but not remove it. Hence we need to trigger final removal.
+
 	// Delete the process
 	health.KillEndpoint()
 

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -116,6 +116,8 @@ func (d *Daemon) initHealth(spec *healthApi.Spec, cleaner *daemonCleanup) {
 }
 
 func (d *Daemon) cleanupHealthEndpoint() {
+	log.Info("Cleaning up Cilium health endpoint")
+
 	// Delete the process
 	health.KillEndpoint()
 
@@ -140,5 +142,7 @@ func (d *Daemon) cleanupHealthEndpoint() {
 			log.WithError(err).Debug("Error occurred while deleting cilium-health endpoint")
 		}
 	}
+
+	// Remove health endpoint devices
 	health.CleanupEndpoint()
 }

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -116,13 +116,11 @@ func (d *Daemon) initHealth(spec *healthApi.Spec, cleaner *daemonCleanup) {
 }
 
 func (d *Daemon) cleanupHealthEndpoint() {
+	var ep *endpoint.Endpoint
+
 	log.Info("Cleaning up Cilium health endpoint")
 
-	// Delete the process
-	health.KillEndpoint()
-
 	// Clean up agent resources
-	var ep *endpoint.Endpoint
 	healthIPv4 := node.GetEndpointHealthIPv4()
 	healthIPv6 := node.GetEndpointHealthIPv6()
 	if healthIPv4 != nil {
@@ -135,13 +133,11 @@ func (d *Daemon) cleanupHealthEndpoint() {
 		log.Debug("Didn't find existing cilium-health endpoint to delete")
 	} else {
 		log.Debug("Removing existing cilium-health endpoint")
-		errs := d.deleteEndpointQuiet(ep, endpoint.DeleteConfig{
-			NoIPRelease: true,
-		})
-		for _, err := range errs {
-			log.WithError(err).Debug("Error occurred while deleting cilium-health endpoint")
-		}
+		d.deleteEndpointRelease(ep, true)
 	}
+
+	// Delete the process
+	health.KillEndpoint()
 
 	// Remove health endpoint devices
 	health.CleanupEndpoint()

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -112,8 +112,7 @@ func (d *Daemon) initHealth(spec *healthApi.Spec, cleaner *daemonCleanup) {
 	)
 
 	// Make sure to clean up the endpoint namespace when cilium-agent terminates
-	cleaner.cleanupFuncs.Add(health.KillEndpoint)
-	cleaner.cleanupFuncs.Add(health.CleanupEndpoint)
+	cleaner.cleanupFuncs.Add(d.cleanupHealthEndpoint)
 }
 
 func (d *Daemon) cleanupHealthEndpoint() {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -534,6 +534,10 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 	stats.waitingForLock.End(true)
 	defer e.owner.GetCompilationLock().RUnlock()
 
+	if err := e.aliveCtx.Err(); err != nil {
+		return 0, false, fmt.Errorf("endpoint was closed while waiting for datapath lock: %w", err)
+	}
+
 	datapathRegenCtxt.prepareForProxyUpdates(regenContext.parentContext)
 	defer datapathRegenCtxt.completionCancel()
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2350,6 +2350,12 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 
 	e.Stop()
 
+	// Wait for any pending endpoint regenerate() calls to finish. The
+	// latter bails out after taking the lock when it detects that the
+	// endpoint state is disconnecting.
+	e.buildMutex.Lock()
+	defer e.buildMutex.Unlock()
+
 	// Lock out any other writers to the endpoint.  In case multiple delete
 	// requests have been enqueued, have all of them except the first
 	// return here. Ignore the request if the endpoint is already


### PR DESCRIPTION
 * [ ] #33700 (@borkmann)

Backporting to stable releases as deleting endpoint without taking the locks could lead to redirects being deleted while regeneration is waiting for an ACK from Envoy for a Network Policy update. Depending on how events line up it is possible that the Envoy listener gets deleted before it progresses to send the ACK, which would leave the regeneration to wait until the 5.5 minute timeout and then spam the logs with regeneration failure messages.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 33700
```
