### PR TITLE
Envoy simplify listener setup

### DIFF
--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -411,7 +411,7 @@ func (m *AckingResourceMutatorWrapper) HandleResourceVersionAck(ackVersion uint6
 							ackLog.Debugf("completing ACK: %v", pending)
 							comp.Complete(nil)
 						} else {
-							ackLog.Debugf("completing NACK: %v", pending)
+							ackLog.Warningf("completing NACK: %v", pending)
 							comp.Complete(&ProxyError{Err: ErrNackReceived, Detail: detail})
 						}
 						continue

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -262,6 +262,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 	streamLog.Info("starting xDS stream processing")
 
 	nodeIP := ""
+	firstRequest := true
 
 	if s.restorerPromise != nil {
 		restorer, err := s.restorerPromise.Await(ctx)
@@ -299,7 +300,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			req := recv.Interface().(*envoy_service_discovery.DiscoveryRequest)
 
 			// only require Node to exist in the first request
-			if nodeIP == "" {
+			if firstRequest {
 				id := req.GetNode().GetId()
 				streamLog = streamLog.WithField(logfields.XDSClientNode, id)
 				var err error
@@ -308,6 +309,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 					streamLog.WithError(err).Error("invalid Node in xDS request")
 					return ErrInvalidNodeFormat
 				}
+				streamLog.WithFields(getXDSRequestFields(req)).Info("Received first request in a new xDS stream")
 			}
 
 			requestLog := streamLog.WithFields(getXDSRequestFields(req))
@@ -355,7 +357,7 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			watcher := s.watchers[typeURL]
 
 			if nonce == 0 && versionInfo > 0 {
-				requestLog.Debugf("xDS was restarted, setting nonce to %d", versionInfo)
+				requestLog.Infof("xDS was restarted, setting nonce to %d", versionInfo)
 				nonce = versionInfo
 			}
 
@@ -369,8 +371,8 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				if ackObserver != nil {
 					requestLog.Debug("notifying observers of ACKs")
 					ackObserver.HandleResourceVersionAck(versionInfo, nonce, nodeIP, state.resourceNames, typeURL, detail)
-				} else {
-					requestLog.Debug("ACK received but no observers are waiting for ACKs")
+				} else if firstRequest {
+					requestLog.Info("ACK received but no observers are waiting for ACKs")
 				}
 				if versionInfo < nonce {
 					// versions after VersionInfo, upto and including ResponseNonce are NACKed
@@ -397,8 +399,10 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				requestLog.Debugf("starting watch on %d resources", len(req.GetResourceNames()))
 				go watcher.WatchResources(ctx, typeURL, versionInfo, nodeIP, req.GetResourceNames(), respCh)
 			} else {
-				requestLog.Debug("received invalid nonce in xDS request; ignoring request")
+				requestLog.Warning("received invalid nonce in xDS request; ignoring request")
 			}
+			firstRequest = false
+
 		default: // Pending watch response.
 			state := &typeStates[chosen]
 			state.pendingWatchCancel()

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -399,7 +399,8 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				requestLog.Debugf("starting watch on %d resources", len(req.GetResourceNames()))
 				go watcher.WatchResources(ctx, typeURL, versionInfo, nodeIP, req.GetResourceNames(), respCh)
 			} else {
-				requestLog.Warning("received invalid nonce in xDS request; ignoring request")
+				requestLog.Warning("received invalid nonce in xDS request")
+				return ErrInvalidResponseNonce
 			}
 			firstRequest = false
 

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -784,6 +784,7 @@ func (s *xdsServer) addListener(name string, listenerConf func() *envoy_config_l
 		if isProxyListener {
 			s.proxyListeners++
 		}
+		log.WithField(logfields.Listener, name).Infof("Envoy: Upserting new listener")
 	}
 	listener.count++
 	listener.mutex.Lock() // needed for other than 'count'
@@ -1032,6 +1033,7 @@ func (s *xdsServer) removeListener(name string, wg *completion.WaitGroup, isProx
 				s.proxyListeners--
 			}
 			delete(s.listeners, name)
+			log.WithField(logfields.Listener, name).Infof("Envoy: Deleting listener")
 			listenerRevertFunc = s.listenerMutator.Delete(ListenerTypeURL, name, []string{"127.0.0.1"}, wg, nil)
 		}
 	} else {

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -79,18 +79,6 @@ const (
 	adminListenerName     = "envoy-admin-listener"
 )
 
-type Listener struct {
-	// must hold the xdsServer.mutex when accessing 'count'
-	count uint
-
-	// mutex is needed when accessing the fields below.
-	// xdsServer.mutex is not needed, but if taken it must be taken before 'mutex'
-	mutex   lock.RWMutex
-	acked   bool
-	nacked  bool
-	waiters []*completion.Completion
-}
-
 // XDSServer provides a high-lever interface to manage resources published using the xDS gRPC API.
 type XDSServer interface {
 	// AddListener adds a listener to a running Envoy proxy.
@@ -166,11 +154,11 @@ type xdsServer struct {
 	// Manages it's own locking
 	secretMutator xds.AckingResourceMutator
 
-	// listeners is the set of names of listeners that have been added by
+	// listenerCount is the set of names of listeners that have been added by
 	// calling AddListener.
 	// mutex must be held when accessing this.
 	// Value holds the number of redirects using the listener named by the key.
-	listeners map[string]*Listener
+	listenerCount map[string]uint
 
 	// proxyListeners is the count of redirection proxy listeners in 'listeners'.
 	// When this is zero, cilium should not wait for NACKs/ACKs from envoy.
@@ -225,7 +213,7 @@ type xdsServerConfig struct {
 func newXDSServer(restorerPromise promise.Promise[endpointstate.Restorer], ipCache IPCacheEventSource, localEndpointStore *LocalEndpointStore, config xdsServerConfig) (*xdsServer, error) {
 	return &xdsServer{
 		restorerPromise:    restorerPromise,
-		listeners:          make(map[string]*Listener),
+		listenerCount:      make(map[string]uint),
 		ipCache:            ipCache,
 		localEndpointStore: localEndpointStore,
 
@@ -777,41 +765,6 @@ func (s *xdsServer) addListener(name string, listenerConf func() *envoy_config_l
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	listener := s.listeners[name]
-	if listener == nil {
-		listener = &Listener{}
-		s.listeners[name] = listener
-		if isProxyListener {
-			s.proxyListeners++
-		}
-		log.WithField(logfields.Listener, name).Infof("Envoy: Upserting new listener")
-	}
-	listener.count++
-	listener.mutex.Lock() // needed for other than 'count'
-	if listener.count > 1 && !listener.nacked {
-		log.Debugf("Envoy: Reusing listener: %s", name)
-		call := true
-		if !listener.acked {
-			// Listener not acked yet, add a completion to the waiter's list
-			log.Debugf("Envoy: Waiting for a non-acknowledged reused listener: %s", name)
-			listener.waiters = append(listener.waiters, wg.AddCompletionWithCallback(cb))
-			call = false
-		}
-		listener.mutex.Unlock()
-
-		// call the callback with nil error if the listener was acked already
-		if call && cb != nil {
-			cb(nil)
-		}
-		return
-	}
-	// Try again after a NACK, potentially with a different port number, etc.
-	if listener.nacked {
-		listener.acked = false
-		listener.nacked = false
-	}
-	listener.mutex.Unlock() // Listener locked again in callbacks below
-
 	listenerConfig := listenerConf()
 	if option.Config.EnableBPFTProxy {
 		// Envoy since 1.20.0 uses SO_REUSEPORT on listeners by default.
@@ -827,26 +780,18 @@ func (s *xdsServer) addListener(name string, listenerConf func() *envoy_config_l
 		return
 	}
 
+	count := s.listenerCount[name]
+	if count == 0 {
+		if isProxyListener {
+			s.proxyListeners++
+		}
+		log.WithField(logfields.Listener, name).Infof("Envoy: Upserting new listener")
+	}
+	count++
+	s.listenerCount[name] = count
+
 	s.listenerMutator.Upsert(ListenerTypeURL, name, listenerConfig, []string{"127.0.0.1"}, wg,
 		func(err error) {
-			// listener might have already been removed, so we can't look again
-			// but we still need to complete all the completions in case
-			// someone is still waiting!
-			listener.mutex.Lock()
-			if err == nil {
-				// Allow future users to not need to wait
-				listener.acked = true
-			} else {
-				// Prevent further reuse of a failed listener
-				listener.nacked = true
-			}
-			// Pass the completion result to all the additional waiters.
-			for _, waiter := range listener.waiters {
-				_ = waiter.Complete(err)
-			}
-			listener.waiters = nil
-			listener.mutex.Unlock()
-
 			if cb != nil {
 				cb(err)
 			}
@@ -1025,16 +970,18 @@ func (s *xdsServer) removeListener(name string, wg *completion.WaitGroup, isProx
 	var listenerRevertFunc xds.AckingResourceMutatorRevertFunc
 
 	s.mutex.Lock()
-	listener, ok := s.listeners[name]
-	if ok && listener != nil {
-		listener.count--
-		if listener.count == 0 {
+	count := s.listenerCount[name]
+	if count > 0 {
+		count--
+		if count == 0 {
 			if isProxyListener {
 				s.proxyListeners--
 			}
-			delete(s.listeners, name)
+			delete(s.listenerCount, name)
 			log.WithField(logfields.Listener, name).Infof("Envoy: Deleting listener")
 			listenerRevertFunc = s.listenerMutator.Delete(ListenerTypeURL, name, []string{"127.0.0.1"}, wg, nil)
+		} else {
+			s.listenerCount[name] = count
 		}
 	} else {
 		// Bail out if this listener does not exist
@@ -1050,8 +997,7 @@ func (s *xdsServer) removeListener(name string, wg *completion.WaitGroup, isProx
 				s.proxyListeners++
 			}
 		}
-		listener.count++
-		s.listeners[name] = listener
+		s.listenerCount[name] = s.listenerCount[name] + 1
 		s.mutex.Unlock()
 	}
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -753,7 +753,7 @@ func (p *Proxy) createNewRedirect(
 
 	scopedLog.
 		WithField(logfields.Object, logfields.Repr(redirect)).
-		Debug("Created new proxy instance")
+		Info("Created new proxy instance")
 
 	p.redirects[id] = redirect
 	p.updateRedirectMetrics()


### PR DESCRIPTION
Rely on xDS cache for listener creation rather than reference counting. After this the listener reference counting is only used for deleting the listener when the reference count gets to zero.
    
Do not ignore xDS messages with invalid nonce, as that could lead to a stalled stream. Cancel the stream instead so that Envoy would reopen a new one.

Listeners are only created when first needed and deleted when not needed any more. Log these events so that they are visible without debug logs.
