### PR TITLE
Fix missing edsClusterConfig in CiliumClusterwideEnvoyConfig for envoy-circuit-breaker.yaml example

### DIFF
--- a/examples/kubernetes/servicemesh/envoy/envoy-circuit-breaker.yaml
+++ b/examples/kubernetes/servicemesh/envoy/envoy-circuit-breaker.yaml
@@ -41,6 +41,8 @@ spec:
       connect_timeout: 5s
       lb_policy: ROUND_ROBIN
       type: EDS
+      edsClusterConfig:
+        serviceName: default/echo-service:8080
       circuit_breakers:
         thresholds:
         - priority: "DEFAULT"


### PR DESCRIPTION
### Description
This PR addresses an issue in the `examples/kubernetes/servicemesh/envoy/envoy-circuit-breaker.yaml` example, where the `CiliumClusterwideEnvoyConfig` in the `cluster` section is missing the `edsClusterConfig` field. Without this configuration, Envoy is unable to discover endpoints dynamically, leading to 503 errors due to the lack of upstreams.

### Changes
- Added the missing `edsClusterConfig` field to `CiliumClusterwideEnvoyConfig` in the `cluster` section.
  
### Testing
1. Deployed the modified `envoy-circuit-breaker.yaml` in a Kubernetes cluster.
2. Verified that Envoy correctly connects to upstreams without 503 errors.

### Impact
This fix ensures that the `envoy-circuit-breaker.yaml` example works as expected, enabling proper endpoint discovery and upstream connectivity.