### PR TITLE
.github: extend timeout for tests-ipsec-upgrade workflow

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -134,7 +134,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
 
-    timeout-minutes: 35
+    timeout-minutes: 45
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0


### PR DESCRIPTION
Extend timeout for the tests-ipsec-upgrade workflow from 35 to 45 min, as we sometimes hit this limit.
