### PR TITLE
cilium: fix integer overflow in netkit probe on 32bit platform

### DIFF
--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"os"
 	"path/filepath"
@@ -495,7 +496,7 @@ var HaveNetkit = sync.OnceValue(func() error {
 		l, err := link.AttachNetkit(link.NetkitOptions{
 			Program:   prog,
 			Attach:    ebpf.AttachNetkitPrimary,
-			Interface: int(^uint32(0)),
+			Interface: math.MaxInt,
 		})
 		// We rely on this being checked during the syscall. With
 		// an otherwise correct payload we expect ENODEV here as


### PR DESCRIPTION
Fix the following error when compiling binaries on linux/386:
```
Error: ../pkg/datapath/linux/probes/probes.go:498:19: constant 4294967295 overflows int
```

Related to: https://github.com/cilium/cilium/pull/35551
For some reason, the Hubble-cli compile test did not fail in the linked PR, but it did in [mine](https://github.com/cilium/cilium/pull/35483) after a rebase here: https://github.com/cilium/cilium/actions/runs/11596542377/job/32288046467?pr=35483

cc @borkmann for validation


Repro when compiling hubble-cli:
```
$ cd hubble
$ env GOARCH=386 GOOS=linux make
GOOS=linux GOARCH=386 CGO_ENABLED=0 go build  -mod=vendor -ldflags ' -X "github.com/cilium/cilium/pkg/version.ciliumVersion=1.17.0-dev 24a858c572 2024-10-21T19:16:19-04:00" -s -w -X "github.com/cilium/cilium/pkg/envoy.requiredEnvoyVersionSHA=0fdfdb63f28d1701595e9374931c4c570a7f8771" ' -tags=osusergo   -ldflags "-w -s -X 'github.com/cilium/cilium/hubble/pkg.GitBranch=pr/devodev/hubble-auto-port-forward-native' -X 'github.com/cilium/cilium/hubble/pkg.GitHash=24a858c572' -X 'github.com/cilium/cilium/hubble/pkg.Version=1.17.0-dev'" -o ./hubble .
# github.com/cilium/cilium/pkg/datapath/linux/probes
../pkg/datapath/linux/probes/probes.go:498:19: constant 4294967295 overflows int

make: *** [hubble] Error 1
```
