### PR TITLE
cilium-cli:fix --repository flag precedence with cached Helm charts

### DIFF
--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -4,6 +4,7 @@
 package defaults
 
 import (
+	"crypto/sha256"
 	"time"
 )
 
@@ -119,7 +120,9 @@ var (
 	Version string
 
 	// HelmRepository specifies Helm repository to download Cilium charts from.
-	HelmRepository = "https://helm.cilium.io"
+	HelmRepoIDLen    = 4
+	HelmRepository   = "https://helm.cilium.io"
+	HelmRepositoryID = sha256.Sum256([]byte(HelmRepository))
 
 	// CiliumScheduleAffinity is the node affinity to prevent Cilium from being schedule on
 	// nodes labeled with CiliumNoScheduleLabel.

--- a/cilium-cli/internal/helm/helm.go
+++ b/cilium-cli/internal/helm/helm.go
@@ -8,6 +8,7 @@ package helm
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -77,7 +78,8 @@ func newChartFromRemoteWithCache(ciliumVersion semver.Version, repository string
 		return nil, err
 	}
 
-	file := path.Join(cacheDir, fmt.Sprintf("cilium-%s.tgz", ciliumVersion))
+	hashID := sha256.Sum256([]byte(repository))
+	file := path.Join(cacheDir, fmt.Sprintf("cilium-%s-%x.tgz", ciliumVersion, hashID[:defaults.HelmRepoIDLen]))
 	if _, err = os.Stat(file); err != nil {
 		if !errors.Is(err, fs.ErrNotExist) {
 			return nil, err
@@ -105,6 +107,11 @@ func newChartFromRemoteWithCache(ciliumVersion semver.Version, repository string
 		}
 		if _, err = pull.Run(chartRef); err != nil {
 			return nil, err
+		}
+
+		downloadedFile := path.Join(cacheDir, fmt.Sprintf("cilium-%s.tgz", ciliumVersion))
+		if err := os.Rename(downloadedFile, file); err != nil {
+			return nil, fmt.Errorf("failed to rename downloaded chart: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Improves version identification by hashing the repository using SHA256. The first four characters of the hash are appended to filenames as a suffix, providing a unique identifier for each repository version.

Fixes: https://github.com/cilium/cilium/issues/35629

```release-note
Fix: cilium-cli install --repository flag respects repository even with cached versions.
```
