### PR TITLE
Fix possible disruption of long running pod to node traffic on agent restart in kvstore mode

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1743,13 +1743,11 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 
 	if params.WGAgent != nil {
 		go func() {
-			select {
-			case <-d.nodeDiscovery.Registered:
-				// Wait until the kvstore synchronization completed, to avoid
-				// causing connectivity blips due incorrectly removing
-				// WireGuard peers that have not yet been discovered. The
-				// Registered channel is immediately closed in CRD mode.
-			case <-d.ctx.Done():
+			// Wait until the kvstore synchronization completed, to avoid
+			// causing connectivity blips due incorrectly removing
+			// WireGuard peers that have not yet been discovered.
+			// WaitForKVStoreSync returns immediately in CRD mode.
+			if err := d.nodeDiscovery.WaitForKVStoreSync(d.ctx); err != nil {
 				return
 			}
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1758,7 +1758,9 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 			// the collection of stale AllowedIPs entries too early, leading to
 			// the disruption of otherwise valid long running connections.
 			if option.Config.KVStore != "" {
-				ipcache.WaitForKVStoreSync()
+				if err := ipcache.WaitForKVStoreSync(d.ctx); err != nil {
+					return
+				}
 			}
 
 			if err := params.WGAgent.RestoreFinished(d.clustermesh); err != nil {

--- a/pkg/endpoint/regenerator.go
+++ b/pkg/endpoint/regenerator.go
@@ -24,8 +24,13 @@ var (
 	)
 )
 
+// KVStoreNodesWaitFn is the type of the function used to wait for synchronization
+// of all nodes from the kvstore.
+type KVStoreNodesWaitFn wait.Fn
+
 // Regenerator wraps additional functionalities for endpoint regeneration.
 type Regenerator struct {
+	nodesWaitFn   KVStoreNodesWaitFn
 	cmWaitFn      wait.Fn
 	cmWaitTimeout time.Duration
 
@@ -39,6 +44,7 @@ func newRegenerator(in struct {
 	Logger logrus.FieldLogger
 
 	Config      wait.TimeoutConfig
+	NodesWaitFn KVStoreNodesWaitFn
 	ClusterMesh *clustermesh.ClusterMesh
 }) *Regenerator {
 	waitFn := func(context.Context) error { return nil }
@@ -48,9 +54,14 @@ func newRegenerator(in struct {
 
 	return &Regenerator{
 		logger:        in.Logger,
+		nodesWaitFn:   in.NodesWaitFn,
 		cmWaitFn:      waitFn,
 		cmWaitTimeout: in.Config.ClusterMeshSyncTimeout,
 	}
+}
+
+func (r *Regenerator) WaitForKVStoreNodesSync(ctx context.Context) error {
+	return r.nodesWaitFn(ctx)
 }
 
 func (r *Regenerator) WaitForClusterMeshIPIdentitiesSync(ctx context.Context) error {

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -301,6 +301,12 @@ func (e *Endpoint) restoreIdentity(regenerator *Regenerator) error {
 		if err := ipcache.WaitForKVStoreSync(e.aliveCtx); err != nil {
 			return ErrNotAlive
 		}
+
+		// Additionally wait for node synchronization, as nodes also contribute
+		// entries to the ipcache map, most notably about the remote node IPs.
+		if err := regenerator.WaitForKVStoreNodesSync(e.aliveCtx); err != nil {
+			return ErrNotAlive
+		}
 	}
 
 	// Wait for ipcache and identities synchronization from all remote clusters,

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -298,7 +298,9 @@ func (e *Endpoint) restoreIdentity(regenerator *Regenerator) error {
 	// the ones with fixed identity (e.g. host endpoint), this ensures that
 	// the regenerated datapath always lookups from a ready ipcache map.
 	if option.Config.KVStore != "" {
-		ipcache.WaitForKVStoreSync()
+		if err := ipcache.WaitForKVStoreSync(e.aliveCtx); err != nil {
+			return ErrNotAlive
+		}
 	}
 
 	// Wait for ipcache and identities synchronization from all remote clusters,

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -437,10 +437,6 @@ func (iw *IPIdentityWatcher) selfDeletionProtection(ip string) bool {
 	return false
 }
 
-func (iw *IPIdentityWatcher) waitForInitialSync() {
-	<-iw.synced
-}
-
 var (
 	watcher     *IPIdentityWatcher
 	initialized = make(chan struct{})
@@ -460,7 +456,17 @@ func (ipc *IPCache) InitIPIdentityWatcher(ctx context.Context, factory storepkg.
 }
 
 // WaitForKVStoreSync waits until the ipcache has been synchronized from the kvstore
-func WaitForKVStoreSync() {
-	<-initialized
-	watcher.waitForInitialSync()
+func WaitForKVStoreSync(ctx context.Context) error {
+	select {
+	case <-initialized:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	select {
+	case <-watcher.synced:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }

--- a/pkg/nodediscovery/cell.go
+++ b/pkg/nodediscovery/cell.go
@@ -3,7 +3,11 @@
 
 package nodediscovery
 
-import "github.com/cilium/hive/cell"
+import (
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+)
 
 // The node discovery cell provides the local node configuration and node discovery
 // which communicate changes in local node information to the API server or KVStore.
@@ -13,4 +17,11 @@ var Cell = cell.Module(
 
 	// Node discovery communicates changes in local node information to the API server or KVStore
 	cell.Provide(NewNodeDiscovery),
+
+	// Provide the function used to wait for completion of node synchronization from
+	// the kvstore. This is provided as a separate type (rather than having the
+	// consumer depend on the whole NodeDiscovery object) to break an import loop.
+	cell.Provide(func(nd *NodeDiscovery) endpoint.KVStoreNodesWaitFn {
+		return nd.WaitForKVStoreSync
+	}),
 )

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -210,6 +210,17 @@ func (n *NodeDiscovery) WaitForLocalNodeInit() {
 	<-n.localStateInitialized
 }
 
+// WaitForKVStoreSync blocks until kvstore synchronization of node information
+// completed. It returns immediately in CRD mode.
+func (n *NodeDiscovery) WaitForKVStoreSync(ctx context.Context) error {
+	select {
+	case <-n.Registered:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func (n *NodeDiscovery) updateLocalNode(ln *node.LocalNode) {
 	if option.Config.KVStore != "" && !option.Config.JoinCluster {
 		n.ctrlmgr.UpdateController(


### PR DESCRIPTION
Currently, endpoint regeneration already explicitly waits for synchronization of ipcache information from the kvstore when     enabled. However, nodes contribute to the ipcache entries as well (most notably about the remote node IPs). Hence, let's additionally wait for node synchronization from kvstore before triggering regeneration, to prevent potentially breaking pod-to-node connectivity due to incomplete ipcache state.

While being there, let's also modify the corresponding ipcache logic to allow interrupting the wait operation if the given context expires, to prevent dangling go routines.

<!-- Description of change -->

```release-note
Fix possible disruption of long running pod to node traffic on agent restart in kvstore mode
```
