### PR TITLE
helm: set automountServiceAccountToken to false for hubble-relay sa

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-relay/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/serviceaccount.yaml
@@ -13,4 +13,5 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccounts.relay.automount }}
 {{- end }}


### PR DESCRIPTION
Pentest finding (and generically known security advises) point us to not mount service account tokens. The hubble-relay service account is not used in any (cluster)rolebindings defined and everything seems to work fine when automountServiceAccountToken is set to false.

```release-note
helm: set automountServiceAccountToken to false for hubble-relay sa
```