### PR TITLE
renovate: fix API files generation using renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -86,7 +86,7 @@
     "^make -C Documentation update-helm-values$",
     "^make generate-k8s-api$",
     "^make manifests$",
-    "^make generate-apis$"
+    "^make GO='RUN_AS_NONROOT=1 contrib/scripts/builder.sh go' generate-apis$"
   ],
   "assignAutomerge": true,
   "packageRules": [
@@ -572,7 +572,7 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "make generate-apis"
+          "make GO='RUN_AS_NONROOT=1 contrib/scripts/builder.sh go' generate-apis"
         ],
         "executionMode": "update"
       }


### PR DESCRIPTION
When trying to use renovate to generate the API files, every time protobuf is updated for example, as renovate GitHub action didn't have Golang installed, the generation of files simply fail. Thus we will pass GO as the golang version available on the cilium builder image.

Fixes: c6fb9e4ed54b ("Makefile: generate API with protocolbuffers/protobuf update")