### PR TITLE
policy/correlation: Fix `PolicyMatchL3Proto` case

### DIFF
--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -144,6 +144,21 @@ func lookupPolicyForKey(ep getters.EndpointInfo, key policy.Key, matchType uint3
 		//    - port: 80
 		//      protocol: TCP
 		derivedFrom, rev, ok = ep.GetRealizedPolicyRuleLabelsForKey(key)
+	case monitorAPI.PolicyMatchL3Proto:
+		// Check for L3 policy rules with protocol (but no port).
+		//
+		// Consider the network policy:
+		//
+		// spec:
+		//  podSelector: {}
+		//  ingress:
+		//  - podSelector:
+		//      matchLabels:
+		//        app: client
+		//    ports:
+		//    - protocol: TCP
+		derivedFrom, rev, ok = ep.GetRealizedPolicyRuleLabelsForKey(
+			policy.KeyForDirection(key.TrafficDirection()).WithIdentity(key.Identity).WithProto(key.Nexthdr))
 	case monitorAPI.PolicyMatchL4Only:
 		// Check for port-specific rules.
 		// This covers the case where one or more identities are allowed by network policy.

--- a/pkg/policy/correlation/correlation_test.go
+++ b/pkg/policy/correlation/correlation_test.go
@@ -271,6 +271,57 @@ func TestCorrelatePolicy(t *testing.T) {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 
+	// check identity and protocol-only rule.
+	flow = &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
+			Type: monitorAPI.MessageTypePolicyVerdict,
+		},
+		Verdict:          flowpb.Verdict_FORWARDED,
+		TrafficDirection: flowpb.TrafficDirection_EGRESS,
+		IP: &flowpb.IP{
+			Source:      localIP,
+			Destination: remoteIP,
+		},
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
+			},
+		},
+		Source: &flowpb.Endpoint{
+			ID:       localID,
+			Identity: localIdentity,
+		},
+		Destination: &flowpb.Endpoint{
+			ID:       remoteID,
+			Identity: remoteIdentity,
+		},
+		PolicyMatchType: monitorAPI.PolicyMatchL3Proto,
+	}
+
+	policyKey = policy.EgressKey().WithIdentity(identity.NumericIdentity(remoteIdentity)).WithProto(u8proto.TCP)
+	ep = &testutils.FakeEndpointInfo{
+		ID:           uint64(localID),
+		IPv4:         net.ParseIP(localIP),
+		PodName:      "xwing",
+		PodNamespace: "default",
+		Labels:       []string{"a", "b", "c"},
+		PolicyMap: map[policy.Key]labels.LabelArrayList{
+			policyKey: {policyLabel},
+		},
+		PolicyRevision: 1,
+	}
+
+	CorrelatePolicy(endpointGetter, flow)
+
+	require.Nil(t, flow.EgressDeniedBy)
+	require.Nil(t, flow.IngressDeniedBy)
+	require.Nil(t, flow.IngressAllowedBy)
+	if diff := cmp.Diff(expected, flow.EgressAllowedBy, protocmp.Transform()); diff != "" {
+		t.Fatalf("not equal (-want +got):\n%s", diff)
+	}
+
 	// check allow-all rule.
 	flow = &flowpb.Flow{
 		EventType: &flowpb.CiliumEventType{


### PR DESCRIPTION
This commit fixes a bug in the policy correlation code where policies that only match a L3 identity and a L4 protocol (without a port) were previously not correlated.

This commit was manually tested in addition to the added unit test.

Ref: #35416 (fixes this on main, but v1.16 needs a different fix)