### PR TITLE
workflows/ingress: Run basic checks

### DIFF
--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -417,6 +417,14 @@ jobs:
             -enable-http-debug \
             -stop-on-failure
 
+      - name: Run basic CLI tests
+        shell: bash
+        run: |
+          cilium connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
+            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+            --test 'packet-drops'
+
       - name: Post-test information gathering
         if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |


### PR DESCRIPTION
This workflow doesn't run the CLI connectivity tests, so it's missing some basic checks such as unexpected packet drops. This commit adds it.

The check-log-errors test should also be enabled, but it is currently failing because there are errors in logs whenever enabling Ingress. It can be added once those errors are fixed.