### PR TITLE
docs: Improve dev workflow for renovate

### DIFF
--- a/Documentation/contributing/development/renovate.rst
+++ b/Documentation/contributing/development/renovate.rst
@@ -23,15 +23,25 @@ errors in the configuration.
 #. Make some changes to the Renovate configuration in ``.github/renovate.json5``.
 #. Run the renovate image against the new configuration.
 
-   .. code-block:: shell-session
+.. tabs::
 
-      docker run -ti -e LOG_LEVEL=debug \
-                 -e GITHUB_COM_TOKEN="$(gh auth token)" \
-                 -v /tmp:/tmp \
-                 -v $(pwd):/usr/src/app \
-                 docker.io/renovate/renovate:full \
-                 renovate --platform=local \
-      | tee renovate.log
+   .. group-tab:: Simple
+
+      .. code-block:: shell-session
+
+         make renovate-local
+
+   .. group-tab:: Advanced
+
+      .. code-block:: shell-session
+
+         docker run -ti -e LOG_LEVEL=debug \
+                    -e GITHUB_COM_TOKEN="$(gh auth token)" \
+                    -v /tmp:/tmp \
+                    -v $(pwd):/usr/src/app \
+                    docker.io/renovate/renovate:slim \
+                    renovate --platform=local \
+         | tee renovate.log
 
 This approach is based on the `Local platform guide <https://docs.renovatebot.com/modules/platform/local/>`__
 provided by Renovate. See that guide for more details about usage and

--- a/Makefile
+++ b/Makefile
@@ -530,3 +530,13 @@ run_bpf_tests: ## Build and run the BPF unit tests using the cilium-builder cont
 
 run-builder: ## Drop into a shell inside a container running the cilium-builder image.
 	DOCKER_ARGS=-it contrib/scripts/builder.sh bash
+
+.PHONY: renovate-local
+renovate-local: ## Run a local linter for the renovate configuration
+	$(CONTAINER_ENGINE) run --rm -ti \
+		-e LOG_LEVEL=debug \
+		-e GITHUB_COM_TOKEN="$(gh auth token)" \
+		-v /tmp:/tmp \
+		-v $(ROOT_DIR):/usr/src/app \
+		docker.io/renovate/renovate:slim \
+			renovate --platform=local


### PR DESCRIPTION
The make target is more discoverable and easier to use, and we can
switch to the 'slim' image while we're at it which will speed up the
time to run the linter especially on slow Internet connections.

Suggested-by: @chancez 