### PR TITLE
bpf: tests: de-dup IPv4 header validation

### DIFF
--- a/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
@@ -4,6 +4,7 @@
 #include "common.h"
 
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 /*
@@ -207,14 +208,7 @@ int overlay_to_lxc_syn_check(struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)BACKEND_MAC, ETH_ALEN) != 0)
 		test_fatal("dst MAC has changed")
 
-	if (l3->saddr != CLIENT_NODE_IP)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != BACKEND_IP)
-		test_fatal("dst IP has changed");
-
-	if (l3->check != bpf_htons(0x4111))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, CLIENT_NODE_IP, BACKEND_IP));
 
 	if (l4->source != CLIENT_INTER_CLUSTER_SNAT_PORT)
 		test_fatal("src port has changed");
@@ -304,14 +298,7 @@ int lxc_to_overlay_ack_check(struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)BACKEND_ROUTER_MAC, ETH_ALEN) != 0)
 		test_fatal("dst MAC has changed");
 
-	if (l3->saddr != BACKEND_IP)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != CLIENT_NODE_IP)
-		test_fatal("dst IP has changed");
-
-	if (l3->check != bpf_htons(0x4111))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, BACKEND_IP, CLIENT_NODE_IP));
 
 	if (l4->source != BACKEND_PORT)
 		test_fatal("src port has changed");
@@ -403,14 +390,7 @@ int overlay_to_lxc_ack_check(struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)BACKEND_MAC, ETH_ALEN) != 0)
 		test_fatal("dst MAC has changed")
 
-	if (l3->saddr != CLIENT_NODE_IP)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != BACKEND_IP)
-		test_fatal("dst IP has changed");
-
-	if (l3->check != bpf_htons(0x4111))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, CLIENT_NODE_IP, BACKEND_IP));
 
 	if (l4->source != CLIENT_INTER_CLUSTER_SNAT_PORT)
 		test_fatal("src port has changed");

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
@@ -5,6 +5,7 @@
 
 #include <bpf/ctx/skb.h>
 #include "linux/if_ether.h"
+#include "pktcheck.h"
 #include "pktgen.h"
 #include "mock_skb_metadata.h"
 
@@ -243,14 +244,7 @@ int from_overlay_syn_check(struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)BACKEND_MAC, ETH_ALEN) != 0)
 		test_fatal("dst MAC is not the backend MAC")
 
-	if (l3->saddr != CLIENT_NODE_IP)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != BACKEND_IP)
-		test_fatal("dst IP has changed");
-
-	if (l3->check != bpf_htons(0x4212))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, CLIENT_NODE_IP, BACKEND_IP));
 
 	if (l4->source != CLIENT_INTER_CLUSTER_SNAT_PORT)
 		test_fatal("src port has changed");
@@ -337,14 +331,7 @@ int to_overlay_synack_check(struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)BACKEND_ROUTER_MAC, ETH_ALEN) != 0)
 		test_fatal("dst MAC has changed")
 
-	if (l3->saddr != BACKEND_IP)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != CLIENT_NODE_IP)
-		test_fatal("dst IP has changed");
-
-	if (l3->check != bpf_htons(0x4112))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, BACKEND_IP, CLIENT_NODE_IP));
 
 	if (l4->source != BACKEND_PORT)
 		test_fatal("src port has changed");
@@ -412,14 +399,7 @@ int from_overlay_ack_check(struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)BACKEND_MAC, ETH_ALEN) != 0)
 		test_fatal("dst MAC is not the backend MAC")
 
-	if (l3->saddr != CLIENT_NODE_IP)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != BACKEND_IP)
-		test_fatal("dst IP has changed");
-
-	if (l3->check != bpf_htons(0x4212))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, CLIENT_NODE_IP, BACKEND_IP));
 
 	if (l4->source != CLIENT_INTER_CLUSTER_SNAT_PORT)
 		test_fatal("src port has changed");

--- a/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
@@ -4,6 +4,7 @@
 #include "common.h"
 
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 /*
@@ -208,14 +209,7 @@ int lxc_to_overlay_syn_check(struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)CLIENT_ROUTER_MAC, ETH_ALEN) != 0)
 		test_fatal("dst MAC has changed")
 
-	if (l3->saddr != CLIENT_IP)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != BACKEND_IP)
-		test_fatal("dst IP hasn't been NATed to remote backend IP");
-
-	if (l3->check != bpf_htons(0xf968))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, CLIENT_IP, BACKEND_IP));
 
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");
@@ -318,14 +312,7 @@ int overlay_to_lxc_synack_check(struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)CLIENT_MAC, ETH_ALEN) != 0)
 		test_fatal("dst MAC has changed")
 
-	if (l3->saddr != FRONTEND_IP)
-		test_fatal("src IP is not service frontend IP");
-
-	if (l3->daddr != CLIENT_IP)
-		test_fatal("dst IP is not client IP");
-
-	if (l3->check != bpf_htons(0x402))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, FRONTEND_IP, CLIENT_IP));
 
 	if (l4->source != FRONTEND_PORT)
 		test_fatal("src port is not service frontend port");
@@ -409,14 +396,7 @@ int lxc_to_overlay_ack_check(struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)CLIENT_ROUTER_MAC, ETH_ALEN) != 0)
 		test_fatal("dst MAC has changed")
 
-	if (l3->saddr != CLIENT_IP)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != BACKEND_IP)
-		test_fatal("dst IP hasn't been NATed to remote backend IP");
-
-	if (l3->check != bpf_htons(0xf968))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, CLIENT_IP, BACKEND_IP));
 
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");

--- a/bpf/tests/ipsec_from_host_generic.h
+++ b/bpf/tests/ipsec_from_host_generic.h
@@ -3,6 +3,7 @@
 
 #include "common.h"
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 #define ROUTER_IP
 #undef ROUTER_IP
@@ -159,14 +160,7 @@ int ipv4_ipsec_from_host_check(__maybe_unused const struct __ctx_buff *ctx)
 	if ((void *)l3 + sizeof(struct iphdr) > data_end)
 		test_fatal("l3 out of bounds");
 
-	if (l3->saddr != v4_pod_one)
-		test_fatal("src IP was changed");
-
-	if (l3->daddr != v4_pod_two)
-		test_fatal("dest IP was changed");
-
-	if (l3->check != bpf_htons(0xf948))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_ESP, v4_pod_one, v4_pod_two));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 

--- a/bpf/tests/ipsec_from_lxc_generic.h
+++ b/bpf/tests/ipsec_from_lxc_generic.h
@@ -3,6 +3,7 @@
 
 #include "common.h"
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 #define ROUTER_IP
 #undef ROUTER_IP
@@ -171,11 +172,7 @@ int ipv4_from_lxc_encrypt_check(__maybe_unused const struct __ctx_buff *ctx)
 	if ((void *)l3 + sizeof(struct iphdr) > data_end)
 		test_fatal("l3 out of bounds");
 
-	if (l3->saddr != v4_pod_one)
-		test_fatal("src IP was changed");
-
-	if (l3->daddr != v4_pod_two)
-		test_fatal("dest IP was changed");
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, v4_pod_one, v4_pod_two));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 

--- a/bpf/tests/ipsec_from_network_generic.h
+++ b/bpf/tests/ipsec_from_network_generic.h
@@ -13,6 +13,7 @@
 
 #include "common.h"
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 #define ROUTER_IP
 #define SECLABEL
@@ -153,14 +154,7 @@ int ipv4_not_decrypted_ipsec_from_network_check(__maybe_unused const struct __ct
 	if ((void *)l3 + sizeof(struct iphdr) > data_end)
 		test_fatal("l3 out of bounds");
 
-	if (l3->saddr != v4_pod_one)
-		test_fatal("src IP was changed");
-
-	if (l3->daddr != v4_pod_two)
-		test_fatal("dest IP was changed");
-
-	if (l3->check != bpf_htons(0xf948))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_ESP, v4_pod_one, v4_pod_two));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 
@@ -393,14 +387,7 @@ int ipv4_decrypted_ipsec_from_network_check(__maybe_unused const struct __ctx_bu
 	if ((void *)l3 + sizeof(struct iphdr) > data_end)
 		test_fatal("l3 out of bounds");
 
-	if (l3->saddr != v4_pod_one)
-		test_fatal("src IP was changed");
-
-	if (l3->daddr != v4_pod_two)
-		test_fatal("dest IP was changed");
-
-	if (l3->check != bpf_htons(0xf968))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, v4_pod_one, v4_pod_two));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 

--- a/bpf/tests/ipsec_from_overlay_generic.h
+++ b/bpf/tests/ipsec_from_overlay_generic.h
@@ -13,6 +13,7 @@
 
 #include "common.h"
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 #define ROUTER_IP
 #define SECLABEL
@@ -186,14 +187,7 @@ int ipv4_not_decrypted_ipsec_from_overlay_check(__maybe_unused const struct __ct
 	if ((void *)l3 + sizeof(struct iphdr) > data_end)
 		test_fatal("l3 out of bounds");
 
-	if (l3->saddr != v4_pod_one)
-		test_fatal("src IP was changed");
-
-	if (l3->daddr != v4_pod_two)
-		test_fatal("dest IP was changed");
-
-	if (l3->check != bpf_htons(0xf948))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_ESP, v4_pod_one, v4_pod_two));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 
@@ -426,14 +420,7 @@ int ipv4_decrypted_ipsec_from_overlay_check(__maybe_unused const struct __ctx_bu
 	if ((void *)l3 + sizeof(struct iphdr) > data_end)
 		test_fatal("l3 out of bounds");
 
-	if (l3->saddr != v4_pod_one)
-		test_fatal("src IP was changed");
-
-	if (l3->daddr != v4_pod_two)
-		test_fatal("dest IP was changed");
-
-	if (l3->check != bpf_htons(0xfa68))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, v4_pod_one, v4_pod_two));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 

--- a/bpf/tests/pktcheck.h
+++ b/bpf/tests/pktcheck.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+#include <bpf/compiler.h>
+#include <bpf/builtins.h>
+#include <bpf/helpers.h>
+
+#include <lib/endian.h>
+
+#include <linux/byteorder.h>
+#include <linux/ip.h>
+#include <linux/in.h>
+
+static __always_inline
+int pktcheck__validate_ipv4(struct iphdr *ip4, __u8 nexthdr, __be32 saddr, __be32 daddr)
+{
+	if (ip4->protocol != nexthdr)
+		return -1;
+	if (ip4->saddr != saddr)
+		return -1;
+	if (ip4->daddr != daddr)
+		return -1;
+
+	/* Skip csum validation if options are present */
+	if (ip4->ihl * 4 == sizeof(*ip4)) {
+		if (csum_fold(csum_diff(NULL, 0, ip4, sizeof(*ip4), 0)))
+			return -1;
+	}
+
+	return 0;
+}

--- a/bpf/tests/session_affinity_test.c
+++ b/bpf/tests/session_affinity_test.c
@@ -3,6 +3,7 @@
 
 #include "bpf/ctx/xdp.h"
 #include "common.h"
+#include "pktcheck.h"
 #include "pktgen.h"
 
 #define ENABLE_IPV4
@@ -211,7 +212,7 @@ int test1_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	data += sizeof(struct iphdr);
 
-	if (l3->daddr != BACKEND_IP2) test_fatal("dst ip != backend IP");
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, IPV4_DIRECT_ROUTING, BACKEND_IP2));
 
 	if (data + sizeof(struct tcphdr) > data_end)
 		test_fatal("ctx doesn't fit tcphdr");

--- a/bpf/tests/skip_tunnel_from_host.c
+++ b/bpf/tests/skip_tunnel_from_host.c
@@ -2,6 +2,7 @@
 /* Copyright Authors of Cilium */
 #include "common.h"
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 /*
@@ -204,14 +205,7 @@ check_ctx(const struct __ctx_buff *ctx, __u32 expected_result, bool v4)
 		if ((void *)l3 + sizeof(struct iphdr) > data_end)
 			test_fatal("l3 out of bounds");
 
-		if (l3->saddr != SRC_IPV4)
-			test_fatal("src IP was changed");
-
-		if (l3->daddr != DST_IPV4)
-			test_fatal("dest IP was changed");
-
-		if (l3->check != bpf_htons(0xa611))
-			test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+		assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, SRC_IPV4, DST_IPV4));
 
 		l4 = (void *)l3 + sizeof(struct iphdr);
 	} else {

--- a/bpf/tests/skip_tunnel_from_lxc.c
+++ b/bpf/tests/skip_tunnel_from_lxc.c
@@ -2,6 +2,7 @@
 /* Copyright Authors of Cilium */
 #include "common.h"
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 /*
@@ -185,14 +186,7 @@ check_ctx(const struct __ctx_buff *ctx, __u32 expected_result, bool v4)
 		if ((void *)l3 + sizeof(struct iphdr) > data_end)
 			test_fatal("l3 out of bounds");
 
-		if (l3->saddr != SRC_IPV4)
-			test_fatal("src IP was changed");
-
-		if (l3->daddr != DST_IPV4)
-			test_fatal("dest IP was changed");
-
-		if (l3->check != bpf_htons(0xf968))
-			test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+		assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, SRC_IPV4, DST_IPV4));
 
 		l4 = (void *)l3 + sizeof(struct iphdr);
 	} else {

--- a/bpf/tests/skip_tunnel_nodeport_revnat.c
+++ b/bpf/tests/skip_tunnel_nodeport_revnat.c
@@ -2,6 +2,7 @@
 /* Copyright Authors of Cilium */
 #include "common.h"
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 /*
@@ -342,11 +343,7 @@ check_ctx(const struct __ctx_buff *ctx, bool v4, __u32 expected_result)
 		/*
 		 * We don't have revDNAT, so the reply source should stay the same.
 		 */
-		if (l3->saddr != DST_IPV4)
-			test_fatal("src IP was changed");
-
-		if (l3->daddr != SRC_IPV4)
-			test_fatal("dest IP was not rev snatted");
+		assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, DST_IPV4, SRC_IPV4));
 
 		l4 = (void *)l3 + sizeof(struct iphdr);
 	} else {

--- a/bpf/tests/tc_host_encrypted_overlay.c
+++ b/bpf/tests/tc_host_encrypted_overlay.c
@@ -4,6 +4,7 @@
 #include "common.h"
 
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 /* Enable code paths under test */
@@ -163,14 +164,7 @@ int tc_host_encrypted_overlay_01_check(const struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)node1_mac, ETH_ALEN) != 0)
 		test_fatal("dst MAC has not been updated")
 
-	if (l3->saddr != NODE1_IP)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != NODE2_IP)
-		test_fatal("dst IP has changed");
-
-	if (l3->check != bpf_htons(0x7da4))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_UDP, NODE1_IP, NODE2_IP));
 
 	if (l4->source != NODE1_TUNNEL_SPORT)
 		test_fatal("src port has changed");

--- a/bpf/tests/tc_lxc_lb4_no_backend.c
+++ b/bpf/tests/tc_lxc_lb4_no_backend.c
@@ -4,6 +4,7 @@
 #include "common.h"
 
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 /* Enable code paths under test */
@@ -124,10 +125,8 @@ int lxc_no_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 	assert(l3->version == 4);
 	assert(l3->tos == 0);
 	assert(l3->ttl == 64);
-	assert(l3->protocol == IPPROTO_ICMP);
 
-	if (l3->check != bpf_htons(0x4b8e))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_ICMP, FRONTEND_IP, CLIENT_IP));
 
 	l4 = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct iphdr);
 	if ((void *) l4 + sizeof(struct icmphdr) > data_end)

--- a/bpf/tests/tc_nodeport_l3_dev.c
+++ b/bpf/tests/tc_nodeport_l3_dev.c
@@ -5,6 +5,7 @@
 
 #include <bpf/ctx/skb.h>
 #include <bpf/helpers_skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 #define ETH_HLEN		0
@@ -168,14 +169,7 @@ int ipv4_l3_to_l2_fast_redirect_check(__maybe_unused const struct __ctx_buff *ct
 	if ((void *)l3 + sizeof(struct iphdr) > data_end)
 		test_fatal("l3 out of bounds");
 
-	if (l3->saddr != TEST_IP_REMOTE)
-		test_fatal("src IP was changed");
-
-	if (l3->daddr != TEST_IP_LOCAL)
-		test_fatal("dest IP was changed");
-
-	if (l3->check != bpf_htons(0xfa68))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, TEST_IP_REMOTE, TEST_IP_LOCAL));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 

--- a/bpf/tests/tc_nodeport_l3_dev_lb_dsr_geneve_lb.c
+++ b/bpf/tests/tc_nodeport_l3_dev_lb_dsr_geneve_lb.c
@@ -4,6 +4,7 @@
 #include "common.h"
 
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 /* Enable code paths under test */
@@ -162,11 +163,7 @@ int ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd_check(__maybe_unused struct __ctx_buf
 	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
 		test_fatal("l4 out of bounds");
 
-	if (l3->saddr != CLIENT_IP)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != BACKEND_IP)
-		test_fatal("dst IP hasn't been NATed to remote backend IP");
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, CLIENT_IP, BACKEND_IP));
 
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");

--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -4,6 +4,7 @@
 #include "common.h"
 
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 /* Enable code paths under test */
@@ -364,14 +365,7 @@ static __always_inline int check_reply(const struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) != 0)
 		test_fatal("dst MAC is not the client MAC")
 
-	if (l3->saddr != FRONTEND_IP)
-		test_fatal("src IP hasn't been RevNATed to frontend IP");
-
-	if (l3->daddr != CLIENT_IP)
-		test_fatal("dst IP has changed");
-
-	if (l3->check != bpf_htons(0x4baa))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, FRONTEND_IP, CLIENT_IP));
 
 	if (l4->source != FRONTEND_PORT)
 		test_fatal("src port hasn't been RevNATed to frontend port");
@@ -653,14 +647,7 @@ int nodeport_dsr_backend_redirect_reply_check(struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) != 0)
 		test_fatal("dst MAC is not the client MAC")
 
-	if (l3->saddr != BACKEND_IP)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != CLIENT_IP_2)
-		test_fatal("dst IP has changed");
-
-	if (l3->check != bpf_htons(0x3611))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, BACKEND_IP, CLIENT_IP_2));
 
 	if (l4->source != BACKEND_PORT)
 		test_fatal("src port has changed");

--- a/bpf/tests/tc_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_backend.c
@@ -4,6 +4,7 @@
 #include "common.h"
 
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 /* Enable code paths under test */
@@ -167,14 +168,7 @@ int nodeport_nat_backend_check(const struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)backend_mac, ETH_ALEN) != 0)
 		test_fatal("dst MAC is not the endpoint MAC")
 
-	if (l3->saddr != LB_IP)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != BACKEND_IP)
-		test_fatal("dst IP has changed");
-
-	if (l3->check != bpf_htons(0xa712))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, LB_IP, BACKEND_IP));
 
 	if (l4->source != LB_PORT)
 		test_fatal("src port has changed");

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -4,6 +4,7 @@
 #include "common.h"
 
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 /* Enable code paths under test */
@@ -262,14 +263,7 @@ int nodeport_local_backend_check(const struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)local_backend_mac, ETH_ALEN) != 0)
 		test_fatal("dst MAC is not the endpoint MAC")
 
-	if (l3->saddr != CLIENT_IP)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != BACKEND_IP_LOCAL)
-		test_fatal("dst IP hasn't been NATed to local backend IP");
-
-	if (l3->check != bpf_htons(0x4212))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, CLIENT_IP, BACKEND_IP_LOCAL));
 
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");
@@ -358,14 +352,7 @@ int nodeport_local_backend_reply_check(const struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) != 0)
 		test_fatal("dst MAC is not the client MAC")
 
-	if (l3->saddr != FRONTEND_IP_LOCAL)
-		test_fatal("src IP hasn't been revNATed to frontend IP");
-
-	if (l3->daddr != CLIENT_IP)
-		test_fatal("dst IP has changed");
-
-	if (l3->check != bpf_htons(0x4baa))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, FRONTEND_IP_LOCAL, CLIENT_IP));
 
 	if (l4->source != FRONTEND_PORT)
 		test_fatal("src port hasn't been revNATed to frontend port");
@@ -456,14 +443,7 @@ int nodeport_local_backend_redirect_check(const struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)local_backend_mac, ETH_ALEN) != 0)
 		test_fatal("dst MAC is not the endpoint MAC")
 
-	if (l3->saddr != CLIENT_IP_2)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != BACKEND_IP_LOCAL)
-		test_fatal("dst IP hasn't been NATed to local backend IP");
-
-	if (l3->check != bpf_htons(0x3711))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, CLIENT_IP_2, BACKEND_IP_LOCAL));
 
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");
@@ -554,14 +534,7 @@ int nodeport_local_backend_redirect_reply_check(const struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) != 0)
 		test_fatal("dst MAC is not the client MAC")
 
-	if (l3->saddr != BACKEND_IP_LOCAL)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != CLIENT_IP_2)
-		test_fatal("dst IP has changed");
-
-	if (l3->check != bpf_htons(0x3611))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, BACKEND_IP_LOCAL, CLIENT_IP_2));
 
 	if (l4->source != BACKEND_PORT)
 		test_fatal("src port has changed");
@@ -659,14 +632,7 @@ int nodeport_udp_local_backend_check(const struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)local_backend_mac, ETH_ALEN) != 0)
 		test_fatal("dst MAC is not the endpoint MAC")
 
-	if (l3->saddr != CLIENT_IP)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != BACKEND_IP_LOCAL)
-		test_fatal("dst IP hasn't been NATed to local backend IP");
-
-	if (l3->check != bpf_htons(0x4213))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_UDP, CLIENT_IP, BACKEND_IP_LOCAL));
 
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");
@@ -767,14 +733,7 @@ int nodeport_nat_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)remote_backend_mac, ETH_ALEN) != 0)
 		test_fatal("dst MAC is not the remote backend MAC")
 
-	if (l3->saddr != LB_IP)
-		test_fatal("src IP hasn't been NATed to LB IP");
-
-	if (l3->daddr != BACKEND_IP_REMOTE)
-		test_fatal("dst IP hasn't been NATed to remote backend IP");
-
-	if (l3->check != bpf_htons(0xa711))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, LB_IP, BACKEND_IP_REMOTE));
 
 	if (l4->source == CLIENT_PORT)
 		test_fatal("src port hasn't been NATed");
@@ -860,11 +819,7 @@ static __always_inline int check_reply(const struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) != 0)
 		test_fatal("dst MAC is not the client MAC")
 
-	if (l3->saddr != FRONTEND_IP_REMOTE)
-		test_fatal("src IP hasn't been RevNATed to frontend IP");
-
-	if (l3->daddr != CLIENT_IP)
-		test_fatal("dst IP hasn't been RevNATed to client IP");
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, FRONTEND_IP_REMOTE, CLIENT_IP));
 
 	if (l4->source != FRONTEND_PORT)
 		test_fatal("src port hasn't been RevNATed to frontend port");

--- a/bpf/tests/tc_nodeport_lb4_no_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_no_backend.c
@@ -4,6 +4,7 @@
 #include "common.h"
 
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 /* Enable code paths under test */
@@ -128,10 +129,8 @@ int nodeport_no_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 	assert(l3->version == 4);
 	assert(l3->tos == 0);
 	assert(l3->ttl == 64);
-	assert(l3->protocol == IPPROTO_ICMP);
 
-	if (l3->check != bpf_htons(0x4b8e))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_ICMP, FRONTEND_IP, CLIENT_IP));
 
 	l4 = data + sizeof(__u32) + sizeof(struct ethhdr) + sizeof(struct iphdr);
 	if ((void *) l4 + sizeof(struct icmphdr) > data_end)

--- a/bpf/tests/tc_nodeport_lb_terminating_backend.c
+++ b/bpf/tests/tc_nodeport_lb_terminating_backend.c
@@ -31,6 +31,7 @@
 #include "common.h"
 
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 static volatile const __u8 *client_mac = mac_one;
@@ -196,14 +197,7 @@ int tc_nodeport_lb_terminating_backend_0_check(const struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)local_backend_mac, ETH_ALEN) != 0)
 		test_fatal("dst MAC is not the endpoint MAC")
 
-	if (l3->saddr != CLIENT_IP)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != BACKEND_IP_LOCAL)
-		test_fatal("dst IP hasn't been NATed to local backend IP");
-
-	if (l3->check != bpf_htons(0x4213))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_UDP, CLIENT_IP, BACKEND_IP_LOCAL));
 
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");
@@ -303,14 +297,7 @@ int tc_nodeport_lb_terminating_backend_1_check(const struct __ctx_buff *ctx)
 	if (memcmp(l2->h_dest, (__u8 *)local_backend_mac, ETH_ALEN) != 0)
 		test_fatal("dst MAC is not the endpoint MAC")
 
-	if (l3->saddr != CLIENT_IP)
-		test_fatal("src IP has changed");
-
-	if (l3->daddr != BACKEND_IP_LOCAL)
-		test_fatal("dst IP hasn't been NATed to local backend IP");
-
-	if (l3->check != bpf_htons(0x4213))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_UDP, CLIENT_IP, BACKEND_IP_LOCAL));
 
 	if (l4->source != CLIENT_PORT)
 		test_fatal("src port has changed");

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -10,6 +10,7 @@
 #undef QUIET_CT
 
 #include <bpf/ctx/skb.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 /* Enable code paths under test*/
@@ -138,14 +139,7 @@ int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 	if ((void *)l3 + sizeof(struct iphdr) > data_end)
 		test_fatal("l3 out of bounds");
 
-	if (l3->saddr != IPV4_LOOPBACK)
-		test_fatal("src IP was not SNAT'ed");
-
-	if (l3->daddr != v4_pod_one)
-		test_fatal("dest IP hasn't been changed to the pod IP");
-
-	if (l3->check != bpf_htons(-0x4f02))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, IPV4_LOOPBACK, v4_pod_one));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 
@@ -266,14 +260,7 @@ int hairpin_flow_forward_ingress_check(__maybe_unused const struct __ctx_buff *c
 	if ((void *)l3 + sizeof(struct iphdr) > data_end)
 		test_fatal("l3 out of bounds");
 
-	if (l3->saddr != IPV4_LOOPBACK)
-		test_fatal("src IP changed");
-
-	if (l3->daddr != v4_pod_one)
-		test_fatal("dest IP changed");
-
-	if (l3->check != bpf_htons(-0x5002))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, IPV4_LOOPBACK, v4_pod_one));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 
@@ -380,11 +367,7 @@ int hairpin_flow_rev_check(__maybe_unused const struct __ctx_buff *ctx)
 	if ((void *)l3 + sizeof(struct iphdr) > data_end)
 		test_fatal("l3 out of bounds");
 
-	if (l3->saddr != v4_pod_one)
-		test_fatal("src IP changed");
-
-	if (l3->daddr != IPV4_LOOPBACK)
-		test_fatal("dest IP changed");
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, v4_pod_one, IPV4_LOOPBACK));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 
@@ -470,14 +453,7 @@ int hairpin_flow_reverse_ingress_check(const struct __ctx_buff *ctx)
 	if ((void *)l3 + sizeof(struct iphdr) > data_end)
 		test_fatal("l3 out of bounds");
 
-	if (l3->saddr != v4_svc_one)
-		test_fatal("src IP was not NAT'ed back to the svc IP");
-
-	if (l3->daddr != v4_pod_one)
-		test_fatal("dest IP hasn't been NAT'ed to the original source IP");
-
-	if (l3->check != bpf_htons(0x402))
-		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+	assert(!pktcheck__validate_ipv4(l3, IPPROTO_TCP, v4_svc_one, v4_pod_one));
 
 	l4 = (void *)l3 + sizeof(struct iphdr);
 

--- a/bpf/tests/tc_srv6_decap.c
+++ b/bpf/tests/tc_srv6_decap.c
@@ -4,6 +4,7 @@
 #include "common.h"
 #include <bpf/ctx/skb.h>
 #include <linux/in.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 /* Enable code paths under test */
@@ -174,14 +175,7 @@ int srv6_decap_to_pod_ipv4_check(const struct __ctx_buff *ctx __maybe_unused)
 	if (eth->h_proto != __bpf_htons(ETH_P_IP))
 		test_fatal("unexpected eth->h_proto");
 
-	if (ipv4->saddr != EXT_IPV4)
-		test_fatal("unexpected ipv4->saddr");
-
-	if (ipv4->daddr != POD_IPV4)
-		test_fatal("unexpected ipv4->daddr");
-
-	if (ipv4->protocol != IPPROTO_TCP)
-		test_fatal("unexpected ipv4->protocol");
+	assert(!pktcheck__validate_ipv4(ipv4, IPPROTO_TCP, EXT_IPV4, POD_IPV4));
 
 	test_finish();
 
@@ -455,14 +449,7 @@ int srv6_decap_to_service_ipv4_check(const struct __ctx_buff *ctx __maybe_unused
 	if (eth->h_proto != __bpf_htons(ETH_P_IP))
 		test_fatal("unexpected eth->h_proto");
 
-	if (ipv4->saddr != EXT_IPV4)
-		test_fatal("unexpected ipv4->saddr");
-
-	if (ipv4->daddr != POD_IPV4)
-		test_fatal("unexpected ipv4->daddr");
-
-	if (ipv4->protocol != IPPROTO_TCP)
-		test_fatal("unexpected ipv4->protocol");
+	assert(!pktcheck__validate_ipv4(ipv4, IPPROTO_TCP, EXT_IPV4, POD_IPV4));
 
 	test_finish();
 

--- a/bpf/tests/tc_srv6_encap.c
+++ b/bpf/tests/tc_srv6_encap.c
@@ -4,6 +4,7 @@
 #include "common.h"
 #include <bpf/ctx/skb.h>
 #include <linux/in.h>
+#include "pktcheck.h"
 #include "pktgen.h"
 
 /* Enable code paths under test */
@@ -181,11 +182,7 @@ int srv6_encap_from_pod_ipv4_check(const struct __ctx_buff *ctx __maybe_unused)
 		test_fatal("unexpected sid");
 
 	/* Check IPv4 header (just to make sure the encapsulation doesn't corrupt inner packet) */
-	if (ipv4->saddr != POD_IPV4)
-		test_fatal("unexpected ipv4->saddr");
-
-	if (ipv4->daddr != EXT_IPV4)
-		test_fatal("unexpected ipv4->daddr");
+	assert(!pktcheck__validate_ipv4(ipv4, IPPROTO_TCP, POD_IPV4, EXT_IPV4));
 
 	test_finish();
 


### PR DESCRIPTION
Clean up a lot of boilerplate code. Consistently validate the header checksum against the actual header content, replacing the current approach of comparing it against a stored golden value.
