### PR TITLE
bugtool: deprecate flag `k8s-mode`

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -27,30 +27,26 @@ cilium-bugtool [OPTIONS] [flags]
 ### Options
 
 ```
-      --archive                              Create archive when false skips deletion of the output directory (default true)
-      --archive-prefix string                String to prefix to name of archive if created (e.g., with cilium pod-name)
-  -o, --archiveType string                   Archive type: tar | gz (default "tar")
-      --cilium-agent-container-name string   Name of the Cilium Agent main container (when k8s-mode is true) (default "cilium-agent")
-      --config string                        Configuration to decide what should be run (default "./.cilium-bugtool.config")
-      --dry-run                              Create configuration file of all commands that would have been executed
-      --enable-markdown                      Dump output of commands in markdown format
-      --envoy-dump                           When set, dump envoy configuration from unix socket (default true)
-      --envoy-metrics                        When set, dump envoy prometheus metrics from unix socket (default true)
-      --exclude-object-files                 Exclude per-endpoint object files. Template object files will be kept
-      --exec-timeout duration                The default timeout for any cmd execution in seconds (default 30s)
-      --get-pprof                            When set, only gets the pprof traces from the cilium-agent binary
-  -h, --help                                 help for cilium-bugtool
-  -H, --host string                          URI to server-side API
-      --hubble-metrics                       When set, hubble prometheus metrics (default true)
-      --hubble-metrics-port int              Port to query for hubble metrics (default 9965)
-      --k8s-label string                     Kubernetes label for Cilium pod (default "k8s-app=cilium")
-      --k8s-mode                             Require Kubernetes pods to be found or fail
-      --k8s-namespace string                 Kubernetes namespace for Cilium pod (default "kube-system")
-      --parallel-workers int                 Maximum number of parallel worker tasks, use 0 for number of CPUs
-      --pprof-debug int                      Debug pprof args
-      --pprof-port int                       Pprof port to connect to. Known Cilium component ports are agent:6060, operator:6061, apiserver:6063 (default 6060)
-      --pprof-trace-seconds int              Amount of seconds used for pprof CPU traces (default 180)
-  -t, --tmp string                           Path to store extracted files. Use '-' to send to stdout. (default "/tmp")
+      --archive                   Create archive when false skips deletion of the output directory (default true)
+      --archive-prefix string     String to prefix to name of archive if created (e.g., with cilium pod-name)
+  -o, --archiveType string        Archive type: tar | gz (default "tar")
+      --config string             Configuration to decide what should be run (default "./.cilium-bugtool.config")
+      --dry-run                   Create configuration file of all commands that would have been executed
+      --enable-markdown           Dump output of commands in markdown format
+      --envoy-dump                When set, dump envoy configuration from unix socket (default true)
+      --envoy-metrics             When set, dump envoy prometheus metrics from unix socket (default true)
+      --exclude-object-files      Exclude per-endpoint object files. Template object files will be kept
+      --exec-timeout duration     The default timeout for any cmd execution in seconds (default 30s)
+      --get-pprof                 When set, only gets the pprof traces from the cilium-agent binary
+  -h, --help                      help for cilium-bugtool
+  -H, --host string               URI to server-side API
+      --hubble-metrics            When set, hubble prometheus metrics (default true)
+      --hubble-metrics-port int   Port to query for hubble metrics (default 9965)
+      --parallel-workers int      Maximum number of parallel worker tasks, use 0 for number of CPUs
+      --pprof-debug int           Debug pprof args
+      --pprof-port int            Pprof port to connect to. Known Cilium component ports are agent:6060, operator:6061, apiserver:6063 (default 6060)
+      --pprof-trace-seconds int   Amount of seconds used for pprof CPU traces (default 180)
+  -t, --tmp string                Path to store extracted files. Use '-' to send to stdout. (default "/tmp")
 ```
 
 ### SEE ALSO

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -354,6 +354,12 @@ Agent Options
 * The ``CONNTRACK_LOCAL`` option has been deprecated and will be removed in a
   future release.
 
+Bugtool Options
+~~~~~~~~~~~~~~~
+
+* The flag ``k8s-mode`` (and related flags ``cilium-agent-container-name``, ``k8s-namespace`` & ``k8s-label``)
+  have been deprecated and will be removed in a Cilium 1.18. Cilium CLI should be used to gather a sysdump from a K8s cluster.
+
 Added Metrics
 ~~~~~~~~~~~~~
 * ``cilium_node_health_connectivity_status``

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -117,17 +117,21 @@ func init() {
 	BugtoolRootCmd.Flags().IntVar(&traceSeconds, "pprof-trace-seconds", 180, "Amount of seconds used for pprof CPU traces")
 	BugtoolRootCmd.Flags().StringVarP(&archiveType, "archiveType", "o", "tar", "Archive type: tar | gz")
 	BugtoolRootCmd.Flags().BoolVar(&k8s, "k8s-mode", false, "Require Kubernetes pods to be found or fail")
+	BugtoolRootCmd.Flags().MarkDeprecated("k8s-mode", "This option is deprecated, and will be removed in v1.18")
 	BugtoolRootCmd.Flags().BoolVar(&dryRunMode, "dry-run", false, "Create configuration file of all commands that would have been executed")
 	BugtoolRootCmd.Flags().StringVarP(&dumpPath, "tmp", "t", defaultDumpPath, "Path to store extracted files. Use '-' to send to stdout.")
 	BugtoolRootCmd.Flags().StringVarP(&host, "host", "H", "", "URI to server-side API")
 	BugtoolRootCmd.Flags().StringVarP(&k8sNamespace, "k8s-namespace", "", "kube-system", "Kubernetes namespace for Cilium pod")
+	BugtoolRootCmd.Flags().MarkDeprecated("k8s-namespace", "This option is deprecated, and will be removed in v1.18")
 	BugtoolRootCmd.Flags().StringVarP(&k8sLabel, "k8s-label", "", "k8s-app=cilium", "Kubernetes label for Cilium pod")
+	BugtoolRootCmd.Flags().MarkDeprecated("k8s-label", "This option is deprecated, and will be removed in v1.18")
 	BugtoolRootCmd.Flags().DurationVarP(&execTimeout, "exec-timeout", "", 30*time.Second, "The default timeout for any cmd execution in seconds")
 	BugtoolRootCmd.Flags().StringVarP(&configPath, "config", "", "./.cilium-bugtool.config", "Configuration to decide what should be run")
 	BugtoolRootCmd.Flags().BoolVar(&enableMarkdown, "enable-markdown", false, "Dump output of commands in markdown format")
 	BugtoolRootCmd.Flags().StringVarP(&archivePrefix, "archive-prefix", "", "", "String to prefix to name of archive if created (e.g., with cilium pod-name)")
 	BugtoolRootCmd.Flags().IntVar(&parallelWorkers, "parallel-workers", 0, "Maximum number of parallel worker tasks, use 0 for number of CPUs")
 	BugtoolRootCmd.Flags().StringVarP(&ciliumAgentContainerName, "cilium-agent-container-name", "", "cilium-agent", "Name of the Cilium Agent main container (when k8s-mode is true)")
+	BugtoolRootCmd.Flags().MarkDeprecated("cilium-agent-container-name", "This option is deprecated, and will be removed in v1.18")
 	BugtoolRootCmd.Flags().BoolVar(&excludeObjectFiles, "exclude-object-files", false, "Exclude per-endpoint object files. Template object files will be kept")
 	BugtoolRootCmd.Flags().BoolVar(&hubbleMetrics, "hubble-metrics", true, "When set, hubble prometheus metrics")
 	BugtoolRootCmd.Flags().IntVar(&hubbleMetricsPort, "hubble-metrics-port", 9965, "Port to query for hubble metrics")
@@ -176,9 +180,7 @@ func removeIfEmpty(dir string) {
 
 func isValidArchiveType(archiveType string) bool {
 	switch archiveType {
-	case
-		"tar",
-		"gz":
+	case "tar", "gz":
 		return true
 	}
 	return false


### PR DESCRIPTION
Historically, the bugtool has support for fetching system information from a Cilium Agent via Kubernetes API. In these cases, the bugtool is running outside of the agent and the flag `k8s-mode=true` is set.

Nowadays, Cilium CLI (e.g. `cilium sysdump`) is used to gather information from Cilium running in a K8s cluster. In this case, the bugtool is always running within the agent.

Therefore, this commit deprecates the flag `k8s-mode` (and it's related flags `cilium-agent-container-name`, `k8s-namespace` & `k8s-label`). It will be completely removed with Cilium 1.18.