### PR TITLE
bgpv2,operator: Fix the race condition in the nodeSelector conflict detection logic

### DIFF
--- a/operator/pkg/bgpv2/manager.go
+++ b/operator/pkg/bgpv2/manager.go
@@ -140,6 +140,14 @@ func (b *BGPResourceManager) initializeJobs() {
 			return nil
 		}),
 
+		job.OneShot("bgpv2-operator-node-config-tracker", func(ctx context.Context, health cell.Health) error {
+			for e := range b.nodeConfig.Events(ctx) {
+				b.triggerReconcile()
+				e.Done(nil)
+			}
+			return nil
+		}),
+
 		job.OneShot("bgpv2-operator-node-config-override-tracker", func(ctx context.Context, health cell.Health) error {
 			for e := range b.nodeConfigOverride.Events(ctx) {
 				b.triggerReconcile()


### PR DESCRIPTION
Please see the commit description. The first commit should be backported to the v1.16 branch.

```release-note
bgpv2,operator: Fix the race condition in the nodeSelector conflict detection logic
```
