### PR TITLE
bpf: lxc: handle encap_and_redirect_lxc() result with switch statement

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -718,10 +718,14 @@ ct_recreate6:
 		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, 0, 0, encrypt_key,
 					     &key, SECLABEL_IPV6, *dst_sec_identity,
 					     &trace);
-		if (ret == CTX_ACT_OK)
+		switch (ret) {
+		case CTX_ACT_OK:
 			goto encrypt_to_stack;
-		else if (ret != DROP_NO_TUNNEL_ENDPOINT)
+		case DROP_NO_TUNNEL_ENDPOINT:
+			break;
+		default:
 			return ret;
+		}
 	}
 #endif
 	if (is_defined(ENABLE_HOST_ROUTING)) {
@@ -1260,29 +1264,24 @@ skip_vtep:
 		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, ip4->saddr,
 					     ip4->daddr, encrypt_key, &key,
 					     SECLABEL_IPV4, *dst_sec_identity, &trace);
-		if (ret == DROP_NO_TUNNEL_ENDPOINT)
-			goto maybe_pass_to_stack;
-		/* If not redirected noteably due to IPSEC then pass up to stack
-		 * for further processing.
-		 */
-		else if (ret == CTX_ACT_OK)
+		switch (ret) {
+		case CTX_ACT_OK:
+			/* IPsec, pass up to stack for XFRM processing. */
 			goto encrypt_to_stack;
+		case DROP_NO_TUNNEL_ENDPOINT:
+			/* Deliver via native device. */
+			break;
 #ifdef ENABLE_CLUSTER_AWARE_ADDRESSING
-		/* When we redirect, put cluster_id into mark */
-		else if (ret == CTX_ACT_REDIRECT) {
+		case CTX_ACT_REDIRECT:
 			ctx_set_cluster_id_mark(ctx, cluster_id);
+			fallthrough;
+#endif
+		default:
 			return ret;
 		}
-#endif
-		/* This is either redirect by encap code or an error has
-		 * occurred either way return and stack will consume ctx.
-		 */
-		else
-			return ret;
 	}
 #endif /* TUNNEL_MODE || ENABLE_HIGH_SCALE_IPCACHE */
 
-maybe_pass_to_stack: __maybe_unused;
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif = 0;
 


### PR DESCRIPTION
Clean up the goto statement for DROP_NO_TUNNEL_ENDPOINT in the IPv4 path, and spell the different cases out in more detail.