### PR TITLE
bpf: host: fix HostFW egress path in to-netdev for non-host traffic

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -517,6 +517,14 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx, __u32 src_sec_identity,
 			return ret;
 	}
 
+	/* The code below only cares about host-originating yes/no,
+	 * and currently breaks when being passed a fine-grained pod src_sec_identity.
+	 *
+	 * Restore old behavior for now, and clean it up once we have tests.
+	 */
+	if (src_sec_identity != HOST_ID)
+		src_sec_identity = 0;
+
 	srcid = resolve_srcid_ipv6(ctx, ip6, src_sec_identity,
 				   &ipcache_srcid, true);
 
@@ -963,6 +971,14 @@ handle_to_netdev_ipv4(struct __ctx_buff *ctx, __u32 src_sec_identity,
 
 	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
+
+	/* The code below only cares about host-originating yes/no,
+	 * and currently breaks when being passed a fine-grained pod src_sec_identity.
+	 *
+	 * Restore old behavior for now, and clean it up once we have tests.
+	 */
+	if (src_sec_identity != HOST_ID)
+		src_sec_identity = 0;
 
 	src_id = resolve_srcid_ipv4(ctx, ip4, src_sec_identity,
 				    &ipcache_srcid, true);

--- a/bpf/tests/hostfw_host_iptables.c
+++ b/bpf/tests/hostfw_host_iptables.c
@@ -1,0 +1,403 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4			1
+#define ENABLE_HOST_FIREWALL		1
+
+#define POD_SEC_IDENTITY		112233
+
+#define NODE_IP				v4_node_one
+#define NODE_PORT			bpf_htons(50000)
+#define NODE_SNAT_PORT			bpf_htons(50001)
+
+#define SERVER_IP			v4_ext_one
+#define SERVER_PORT			bpf_htons(80)
+
+static volatile const __u8 *node_mac = mac_one;
+static volatile const __u8 *server_mac = mac_two;
+
+#define SECCTX_FROM_IPCACHE 1
+
+#include "bpf_host.c"
+
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/policy.h"
+
+#define FROM_NETDEV	0
+#define TO_NETDEV	1
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 2);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_from_netdev,
+		[TO_NETDEV] = &cil_to_netdev,
+	},
+};
+
+/* Send a request from pod to external endpoint. Emulate that it was
+ * SNATed by our iptables setup by setting the .saddr to NODE_IP and
+ * marking the packet with MARK_MAGIC_IDENTITY (rather than MARK_MAGIC_HOST).
+ *
+ * Also send a reply.
+ *
+ * The egress path should create a CT entry, but apply no egress network policy.
+ * The ingress path should apply no ingress network policy.
+ */
+PKTGEN("tc", "hostfw_iptables_host_ipv4_01_pod")
+int hostfw_iptables_host_ipv4_01_pod_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *udp;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	udp = pktgen__push_ipv4_udp_packet(&builder,
+					   (__u8 *)node_mac, (__u8 *)server_mac,
+					   NODE_IP, SERVER_IP,
+					   NODE_SNAT_PORT, SERVER_PORT);
+	if (!udp)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "hostfw_iptables_host_ipv4_01_pod")
+int hostfw_iptables_host_ipv4_01_pod_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v4_add_entry(NODE_IP, 0, 0, ENDPOINT_F_HOST, HOST_ID,
+			      (__u8 *)node_mac, (__u8 *)node_mac);
+	ipcache_v4_add_entry(NODE_IP, 0, HOST_ID, 0, 0);
+	ipcache_v4_add_world_entry();
+
+	set_identity_mark(ctx, POD_SEC_IDENTITY, MARK_MAGIC_IDENTITY);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hostfw_iptables_host_ipv4_01_pod")
+int hostfw_iptables_host_ipv4_01_pod_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Check whether HostFW created a CT entry */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = NODE_IP,
+		.saddr   = SERVER_IP,
+		.dport   = SERVER_PORT,
+		.sport   = NODE_SNAT_PORT,
+		.nexthdr = IPPROTO_UDP,
+		.flags = TUPLE_F_OUT,
+	};
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	assert(ct_entry->packets == 1);
+
+	test_finish();
+}
+
+PKTGEN("tc", "hostfw_iptables_host_ipv4_02_pod")
+int hostfw_iptables_host_ipv4_02_pod_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *udp;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	udp = pktgen__push_ipv4_udp_packet(&builder,
+					   (__u8 *)server_mac, (__u8 *)node_mac,
+					   SERVER_IP, NODE_IP,
+					   SERVER_PORT, NODE_SNAT_PORT);
+	if (!udp)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "hostfw_iptables_host_ipv4_02_pod")
+int hostfw_iptables_host_ipv4_02_pod_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hostfw_iptables_host_ipv4_02_pod")
+int hostfw_iptables_host_ipv4_02_pod_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Check whether HostFW updated the CT entry */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = NODE_IP,
+		.saddr   = SERVER_IP,
+		.dport   = SERVER_PORT,
+		.sport   = NODE_SNAT_PORT,
+		.nexthdr = IPPROTO_UDP,
+		.flags = TUPLE_F_OUT,
+	};
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	assert(ct_entry->packets == 2);
+
+	test_finish();
+}
+
+/* Send a request from host to external endpoint.
+ *
+ * The egress path should apply egress network policy and drop the packet.
+ */
+PKTGEN("tc", "hostfw_iptables_host_ipv4_03_host")
+int hostfw_iptables_host_ipv4_03_host_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *udp;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	udp = pktgen__push_ipv4_udp_packet(&builder,
+					   (__u8 *)node_mac, (__u8 *)server_mac,
+					   NODE_IP, SERVER_IP,
+					   NODE_PORT, SERVER_PORT);
+	if (!udp)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "hostfw_iptables_host_ipv4_03_host")
+int hostfw_iptables_host_ipv4_03_host_setup(struct __ctx_buff *ctx)
+{
+	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hostfw_iptables_host_ipv4_03_host")
+int hostfw_iptables_host_ipv4_03_host_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_DROP);
+
+	test_finish();
+}
+
+/* Send a request from host to external endpoint. Also send a reply.
+ *
+ * The egress path should apply egress network policy, and let the packet pass.
+ * The ingress path should skip ingress network policy.
+ */
+PKTGEN("tc", "hostfw_iptables_host_ipv4_04_host")
+int hostfw_iptables_host_ipv4_04_host_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *udp;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	udp = pktgen__push_ipv4_udp_packet(&builder,
+					   (__u8 *)node_mac, (__u8 *)server_mac,
+					   NODE_IP, SERVER_IP,
+					   NODE_PORT, SERVER_PORT);
+	if (!udp)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "hostfw_iptables_host_ipv4_04_host")
+int hostfw_iptables_host_ipv4_04_host_setup(struct __ctx_buff *ctx)
+{
+	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
+
+	policy_add_egress_allow_all_entry();
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hostfw_iptables_host_ipv4_04_host")
+int hostfw_iptables_host_ipv4_04_host_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Check whether HostFW created a CT entry */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = NODE_IP,
+		.saddr   = SERVER_IP,
+		.dport   = SERVER_PORT,
+		.sport   = NODE_PORT,
+		.nexthdr = IPPROTO_UDP,
+		.flags = TUPLE_F_OUT,
+	};
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	assert(ct_entry->packets == 1);
+
+	test_finish();
+}
+
+PKTGEN("tc", "hostfw_iptables_host_ipv4_05_host")
+int hostfw_iptables_host_ipv4_05_host_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *udp;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	udp = pktgen__push_ipv4_udp_packet(&builder,
+					   (__u8 *)server_mac, (__u8 *)node_mac,
+					   SERVER_IP, NODE_IP,
+					   SERVER_PORT, NODE_PORT);
+	if (!udp)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "hostfw_iptables_host_ipv4_05_host")
+int hostfw_iptables_host_ipv4_05_host_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hostfw_iptables_host_ipv4_05_host")
+int hostfw_iptables_host_ipv4_05_host_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Check whether HostFW updated the CT entry */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = NODE_IP,
+		.saddr   = SERVER_IP,
+		.dport   = SERVER_PORT,
+		.sport   = NODE_PORT,
+		.nexthdr = IPPROTO_UDP,
+		.flags = TUPLE_F_OUT,
+	};
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	assert(ct_entry->packets == 2);
+
+	policy_delete_egress_entry();
+
+	test_finish();
+}

--- a/bpf/tests/lib/ipcache.h
+++ b/bpf/tests/lib/ipcache.h
@@ -22,6 +22,12 @@ __ipcache_v4_add_entry(__be32 addr, __u8 cluster_id, __u32 sec_identity,
 }
 
 static __always_inline void
+ipcache_v4_add_world_entry()
+{
+	__ipcache_v4_add_entry(v4_all, 0, WORLD_IPV4_ID, 0, 0, 0, 0);
+}
+
+static __always_inline void
 ipcache_v4_add_entry(__be32 addr, __u8 cluster_id, __u32 sec_identity,
 		     __u32 tunnel_ep, __u8 spi)
 {


### PR DESCRIPTION
When using iptables for masquerading, the HostFW egress path needs to differentiate between "host-originating traffic" and "pod-originating but masqueraded with a Host IP". This uses several mechanisms:
1. for host-originating traffic, the skb is marked with MARK_MAGIC_HOST by an iptables rule. The to-netdev program then selects the packet's **real** source identity as HOST_ID.
2. for other traffic, the resolve_srcid_ipv*() call in handle_to_netdev_ipv*() performs an ipcache lookup to resolve the "apparent" source identity.

The HostFW code then takes the following decisions:
1. for a packet that is **neither* originating from Host **nor** SNATed with a Host IP, skip the HostFW path.
2. for a packet that is **not** originating from Host **but** SNATed with a Host IP, create a CT entry but skip the HostFW policy. The CT entry is needed so that replies can match it and skip Ingress Network policy.
3. for a packet that is genuinely originating from Host, create a CT entry **and** apply HostFW policy.

Unfortunately this logic broke with commit
b0e0b0c773da ("bpf: propagate src sec id from ingress bpf_overlay to egress bpf_host"). With this change the to-netdev program now also extracts the actual identity from the skb->mark for pod-originating packets. When resolve_srcid_ipv*() receives this identity, it skips the ipcache lookup. And therefore ipv*_host_policy_egress_lookup() determines that the packet is not SNATed with a Host IP, and exits the HostFW path without creating the expected CT entry.

In short we take case (1), when we should take case (2). Thus inbound replies can't be matched against a CT entry, fall into scope of Ingress Network policy and are potentially dropped.

Quick-fix this problem by manually over-riding the source identity in the HostFW path, so that we again perform the needed ipcache lookup. This isn't pretty, but clearly restores old behavior and is straight-forward from a review perspective.

Fixes: #35535

```release-note
Fixed a bug where replies for pod-originating connections came into scope of HostFW Ingress Network policy. Applicable to configurations that use iptables for Masquerading.
```
