### PR TITLE
ipam: Avoid empty CIDR in ENI mode

### DIFF
--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -683,8 +683,14 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 		for _, eni := range a.store.ownNode.Status.ENI.ENIs {
 			if eni.ID == ipInfo.Resource {
 				result.PrimaryMAC = eni.MAC
-				result.CIDRs = []string{eni.VPC.PrimaryCIDR}
-				result.CIDRs = append(result.CIDRs, eni.VPC.CIDRs...)
+				if len(eni.VPC.PrimaryCIDR) > 0 {
+					result.CIDRs = append(result.CIDRs, eni.VPC.PrimaryCIDR)
+				}
+				for _, otherCidr := range eni.VPC.CIDRs {
+					if len(otherCidr) > 0 {
+						result.CIDRs = append(result.CIDRs, otherCidr)
+					}
+				}
 				// Add manually configured Native Routing CIDR
 				if a.conf.IPv4NativeRoutingCIDR != nil {
 					result.CIDRs = append(result.CIDRs, a.conf.IPv4NativeRoutingCIDR.String())


### PR DESCRIPTION
In some cases, there might be race condition between Instance Manager (running in operator) and IPAM (running in agent) modules, which could lead to IP details are not populated properly, and hence cause the below fatal error. This commit is to make sure that we don't add empty CIDR into the allocation result. Just a note that once the CRD is update, the existing resync process will kick off and perform the needful.

```
time="2024-10-22T22:48:31Z" level=fatal msg="failed to start: daemon creation failed: failed to coalesce CIDRs: invalid CIDR address: " subsys=daemon
```

Relates: https://github.com/cilium/cilium/issues/32855