### PR TITLE
.github: extend timeout for tests-e2e-upgrade workflow

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -396,7 +396,7 @@ jobs:
           #   misc: 'bpf.datapathMode=netkit-l2,bpf.masquerade=true'
           #   skip-upgrade: 'true'
 
-    timeout-minutes: 45
+    timeout-minutes: 55
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0


### PR DESCRIPTION
Extend timeout for the tests-e2e-upgrade workflow, as currently we sometimes hit this limit in some jobs. 

Looks like it was lowered a bit too much in https://github.com/cilium/cilium/pull/34806

(e.g. https://github.com/cilium/cilium/actions/runs/11592950244/job/32283500641 - timeout while collecting sysdump)