### PR TITLE
images: Use cilium-builder image instead of golang to build hubble

### DIFF
--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -17,7 +17,7 @@ ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:e526303fbcd4008bb4f6ccf18
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with
 # TARGETARCH
-FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} AS builder
+FROM --platform=${BUILDPLATFORM} ${CILIUM_BUILDER_IMAGE} AS builder
 
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS


### PR DESCRIPTION
The hubble image currently uses the golang docker image within the build stage. This commit modifies the build stage to use the cilium-builder image instead which contains the necessary tooling to allow for arm64 builds in CI workflows that run on amd64 machines.

See https://github.com/cilium/cilium/pull/35351 and https://github.com/cilium/cilium/issues/35324 for more context.