### PR TITLE
Policy add deny rule test and benchmark

### DIFF
--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 )
 
-func GenerateL3IngressDenyRules(numRules int) api.Rules {
+func GenerateL3IngressDenyRules(numRules int) (api.Rules, identity.IdentityMap) {
 	parseFooLabel := labels.ParseSelectLabel("k8s:foo")
 	fooSelector := api.NewESFromLabels(parseFooLabel)
 	barSelector := api.NewESFromLabels(labels.ParseSelectLabel("bar"))
@@ -39,7 +39,8 @@ func GenerateL3IngressDenyRules(numRules int) api.Rules {
 		rule.Sanitize()
 		rules = append(rules, &rule)
 	}
-	return rules
+
+	return rules, generateNumIdentities(3000)
 }
 
 func GenerateL3EgressDenyRules(numRules int) api.Rules {

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -4,12 +4,17 @@
 package policy
 
 import (
+	"fmt"
+	"net/netip"
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
@@ -68,41 +73,162 @@ func GenerateL3EgressDenyRules(numRules int) api.Rules {
 	return rules
 }
 
-func GenerateCIDRDenyRules(numRules int) api.Rules {
+// generate a CIDR identity for each unique CIDR rule in 'rules'
+func generateCIDRIdentities(rules api.Rules) identity.IdentityMap {
+	c := make(identity.IdentityMap, len(rules))
+	prefixes := make(map[string]identity.NumericIdentity)
+	id := identity.IdentityScopeLocal
+	addPrefix := func(prefix string) {
+		if _, exists := prefixes[prefix]; !exists {
+			lbls := labels.GetCIDRLabels(netip.MustParsePrefix(prefix))
+			id++
+			c[id] = lbls.LabelArray()
+			prefixes[prefix] = id
+		}
+	}
+	for _, rule := range rules {
+		for _, egress := range rule.Egress {
+			for _, toCIDR := range egress.ToCIDR {
+				addPrefix(string(toCIDR))
+			}
+		}
+		for _, egress := range rule.EgressDeny {
+			for _, toCIDR := range egress.ToCIDR {
+				addPrefix(string(toCIDR))
+			}
+		}
+		for _, egress := range rule.Ingress {
+			for _, toCIDR := range egress.FromCIDR {
+				addPrefix(string(toCIDR))
+			}
+		}
+		for _, egress := range rule.IngressDeny {
+			for _, toCIDR := range egress.FromCIDR {
+				addPrefix(string(toCIDR))
+			}
+		}
+	}
+	return c
+}
+
+func GenerateCIDRDenyRules(numRules int) (api.Rules, identity.IdentityMap) {
 	parseFooLabel := labels.ParseSelectLabel("k8s:foo")
 	fooSelector := api.NewESFromLabels(parseFooLabel)
-	//barSelector := api.NewESFromLabels(labels.ParseSelectLabel("bar"))
 
-	// Change ingRule and rule in the for-loop below to change what type of rules
-	// are added into the policy repository.
-	egDenyRule := api.EgressDenyRule{
-		EgressCommonRule: api.EgressCommonRule{
-			ToCIDR: []api.CIDR{api.CIDR("10.2.3.0/24"), api.CIDR("ff02::/64")},
-		},
-		/*ToRequires:  []api.EndpointSelector{barSelector},
-		ToPorts: []api.PortRule{
-			{
-				Ports: []api.PortProtocol{
-					{
-						Port:     "8080",
-						Protocol: api.ProtoTCP,
+	egRule := func(i int) api.EgressRule {
+		port := fmt.Sprintf("%d", 80+i%97)
+		prefix := []string{"8", "16", "24", "28", "32"}[i%5]
+		var net string
+		switch prefix {
+		case "8":
+			net = []string{"10.0.0.0", "192.0.0.0", "244.0.0.0"}[i%3]
+		case "16":
+			pat := []string{"10.%d.0.0", "192.%d.0.0", "244.%d.0.0"}[i%3]
+			net = fmt.Sprintf(pat, i%17)
+		case "24":
+			pat := []string{"10.%d.%d.0", "192.%d.%d.0", "244.%d.%d.0"}[i%3]
+			net = fmt.Sprintf(pat, i%17, i%121)
+		case "28":
+			pat := []string{"10.%d.%d.%d", "192.%d.%d.%d", "244.%d.%d.%d"}[i%3]
+			net = fmt.Sprintf(pat, i%17, i%121, i%16<<4)
+		case "32":
+			pat := []string{"10.%d.%d.%d", "192.%d.%d.%d", "244.%d.%d.%d"}[i%3]
+			net = fmt.Sprintf(pat, i%17, i%121, i%255)
+		}
+		cidr := net + "/" + prefix
+		return api.EgressRule{
+			EgressCommonRule: api.EgressCommonRule{
+				ToCIDR: []api.CIDR{api.CIDR(cidr)},
+			},
+			ToPorts: []api.PortRule{
+				{
+					Ports: []api.PortProtocol{
+						{
+							Port:     port,
+							Protocol: api.ProtoTCP,
+						},
 					},
 				},
 			},
-		},*/
+		}
+	}
+
+	egDenyRule := func(i int) api.EgressDenyRule {
+		port := fmt.Sprintf("%d", 80+i%131)
+		prefix := []string{"8", "16", "24", "28", "32"}[(i+21)%5]
+		var net string
+		switch prefix {
+		case "8":
+			net = []string{"10.0.0.0", "192.0.0.0", "244.0.0.0"}[i%3]
+		case "16":
+			pat := []string{"10.%d.0.0", "192.%d.0.0", "244.%d.0.0"}[i%3]
+			net = fmt.Sprintf(pat, i%23)
+		case "24":
+			pat := []string{"10.%d.%d.0", "192.%d.%d.0", "244.%d.%d.0"}[i%3]
+			net = fmt.Sprintf(pat, i%23, i%119)
+		case "28":
+			pat := []string{"10.%d.%d.%d", "192.%d.%d.%d", "244.%d.%d.%d"}[i%3]
+			net = fmt.Sprintf(pat, i%23, i%119, i%15<<4)
+		case "32":
+			pat := []string{"10.%d.%d.%d", "192.%d.%d.%d", "244.%d.%d.%d"}[i%3]
+			net = fmt.Sprintf(pat, i%23, i%119, i%253)
+		}
+		cidr := net + "/" + prefix
+		return api.EgressDenyRule{
+			EgressCommonRule: api.EgressCommonRule{
+				ToCIDR: []api.CIDR{api.CIDR(cidr)},
+			},
+			ToPorts: []api.PortDenyRule{
+				{
+					Ports: []api.PortProtocol{
+						{
+							Port:     port,
+							Protocol: api.ProtoTCP,
+						},
+					},
+				},
+			},
+		}
 	}
 
 	var rules api.Rules
 	for i := 1; i <= numRules; i++ {
-
+		uuid := k8stypes.UID(fmt.Sprintf("12bba160-ddca-13e8-%04x-0800273b04ff", i))
 		rule := api.Rule{
 			EndpointSelector: fooSelector,
-			EgressDeny:       []api.EgressDenyRule{egDenyRule},
+			Egress:           []api.EgressRule{egRule(i)},
+			EgressDeny:       []api.EgressDenyRule{egDenyRule(i + 773)},
+			Labels:           utils.GetPolicyLabels("default", fmt.Sprintf("cidr-%d", i), uuid, utils.ResourceTypeCiliumNetworkPolicy),
 		}
 		rule.Sanitize()
 		rules = append(rules, &rule)
 	}
-	return rules
+	return rules, generateCIDRIdentities(rules)
+}
+
+func BenchmarkRegenerateCIDRDenyPolicyRules(b *testing.B) {
+	td := newTestData()
+	td.bootstrapRepo(GenerateCIDRDenyRules, 1000, b)
+	ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
+	b.ReportAllocs()
+	b.ResetTimer()
+	n := 0
+	for i := 0; i < b.N; i++ {
+		epPolicy := ip.DistillPolicy(DummyOwner{}, false)
+		n += epPolicy.policyMapState.Len()
+	}
+	ip.Detach()
+	fmt.Printf("Number of MapState entries: %d\n", n/b.N)
+}
+
+func TestRegenerateCIDRDenyPolicyRules(t *testing.T) {
+	td := newTestData()
+	td.bootstrapRepo(GenerateCIDRDenyRules, 10, t)
+	ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
+	epPolicy := ip.DistillPolicy(DummyOwner{}, false)
+	n := epPolicy.policyMapState.Len()
+	ip.Detach()
+	assert.True(t, n > 0)
 }
 
 func TestL3WithIngressDenyWildcard(t *testing.T) {


### PR DESCRIPTION
 * [ ] #33313 (@jrajahalme)

This is a partial backport of #33313, backporting only the new test and benchmark. This is being backported for comparison purposes between 1.16 and the forthcoming 1.17.

Add test and benchmark with a mix of deny and allow CIDR rules.
Add identity for each CIDR so that 'toMapState' has some work to do.

Run the new benchmark like this:
```
$ go test ./pkg/policy/... -bench BenchmarkRegenerateCIDRDenyPolicyRules -run ^$
```
Note: To run just the matching benchmark and run no tests, `-run ^$` is used as `^$` is a regular expression that does not match any tests.