### PR TITLE
operator: Skip reconcile for non-GAMMA xRoutes without a Cilium-managed Gateway

### DIFF
--- a/operator/pkg/gateway-api/httproute.go
+++ b/operator/pkg/gateway-api/httproute.go
@@ -128,7 +128,7 @@ func (r *httpRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		// Watch for changes to HTTPRoute
 		For(&gatewayv1.HTTPRoute{},
-			builder.WithPredicates(predicate.NewPredicateFuncs(r.hasGatewayParent()))).
+			builder.WithPredicates(predicate.NewPredicateFuncs(r.hasMatchingGatewayParent()))).
 		// Watch for changes to Backend services
 		Watches(&corev1.Service{}, r.enqueueRequestForBackendService()).
 		// Watch for changes to Reference Grants
@@ -146,7 +146,8 @@ func (r *httpRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return builder.Complete(r)
 }
 
-func (r *httpRouteReconciler) hasGatewayParent() func(object client.Object) bool {
+func (r *httpRouteReconciler) hasMatchingGatewayParent() func(object client.Object) bool {
+	hasMatchingControllerFn := hasMatchingController(context.Background(), r.Client, controllerName, r.logger)
 	return func(obj client.Object) bool {
 		hr, ok := obj.(*gatewayv1.HTTPRoute)
 		if !ok {
@@ -154,7 +155,17 @@ func (r *httpRouteReconciler) hasGatewayParent() func(object client.Object) bool
 		}
 
 		for _, parent := range hr.Spec.ParentRefs {
-			if helpers.IsGateway(parent) {
+			if !helpers.IsGateway(parent) {
+				continue
+			}
+			gw := &gatewayv1.Gateway{}
+			if err := r.Client.Get(context.Background(), types.NamespacedName{
+				Namespace: helpers.NamespaceDerefOr(parent.Namespace, hr.Namespace),
+				Name:      string(parent.Name),
+			}, gw); err != nil {
+				continue
+			}
+			if hasMatchingControllerFn(gw) {
 				return true
 			}
 		}

--- a/operator/pkg/gateway-api/httproute_test.go
+++ b/operator/pkg/gateway-api/httproute_test.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/hive/hivetest"
+)
+
+// We test this here and not in httproute_reconcile_test.go because calling
+// Reconcile() directly won't invoke the hasMatchingGatewayParent() predicate.
+func Test_httpRouteReconciler_hasMatchingGatewayParent(t *testing.T) {
+	scheme := testScheme()
+
+	tests := []struct {
+		name     string
+		objects  []client.Object
+		route    *gatewayv1.HTTPRoute
+		expected bool
+	}{
+		{
+			name: "matching gateway parent",
+			objects: []client.Object{
+				&gatewayv1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-gateway",
+						Namespace: "default",
+					},
+					Spec: gatewayv1.GatewaySpec{
+						GatewayClassName: "cilium",
+					},
+				},
+				&gatewayv1.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cilium",
+					},
+					Spec: gatewayv1.GatewayClassSpec{
+						ControllerName: "io.cilium/gateway-controller",
+					},
+				},
+			},
+			route: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-route",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name: "my-gateway",
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "no matching gateway parent - different controller",
+			objects: []client.Object{
+				&gatewayv1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-gateway",
+						Namespace: "default",
+					},
+					Spec: gatewayv1.GatewaySpec{
+						GatewayClassName: "other",
+					},
+				},
+				&gatewayv1.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "other",
+					},
+					Spec: gatewayv1.GatewayClassSpec{
+						ControllerName: "other.io/gateway-controller",
+					},
+				},
+			},
+			route: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-route",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name: "my-gateway",
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:    "no gateway parent",
+			objects: []client.Object{},
+			route: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-route",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "cross namespace gateway parent",
+			objects: []client.Object{
+				&gatewayv1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-gateway",
+						Namespace: "other",
+					},
+					Spec: gatewayv1.GatewaySpec{
+						GatewayClassName: "cilium",
+					},
+				},
+				&gatewayv1.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cilium",
+					},
+					Spec: gatewayv1.GatewayClassSpec{
+						ControllerName: "io.cilium/gateway-controller",
+					},
+				},
+			},
+			route: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-route",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "my-gateway",
+								Namespace: ptr.To[gatewayv1.Namespace]("other"),
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "non-gateway parent ref",
+			objects: []client.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-service",
+						Namespace: "default",
+					},
+				},
+			},
+			route: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-route",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:  "my-service",
+								Group: ptr.To[gatewayv1.Group](""),
+								Kind:  ptr.To[gatewayv1.Kind]("Service"),
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake client with test objects
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.objects...).
+				Build()
+
+			r := &httpRouteReconciler{
+				Client: c,
+				logger: hivetest.Logger(t),
+			}
+
+			result := r.hasMatchingGatewayParent()(tt.route)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

This is a revival of https://github.com/cilium/cilium/pull/34753.

As of 1.16.3, the Cilium Gateway API operator currently makes several assumptions around it being the only Gateway API reconciler in a given cluster; deploying the Cilium operator alongside another Gateway API operator causes an infinite back-and-forth loop of reconciliation.

This PR makes the following changes:
- adds logic to the (non-GAMMA) xRoute reconcilers to check for the existence of the Cilium gateway operator class
- ~~adds a test to ensure that the HTTPRoute reconciler does not update HTTPRoutes that do not have a cilium-managed Gateway in its parentRefs~~
- ~~updates the `non-existent gateway` test to ensure that the operator correctly errors without updating the status when a malformed HTTPRoute is encountered~~

(The above-mentioned tests have been removed in the most current iteration of this PR since the logic has been moved out of the reconciliation functions and into the builder predicates.)

Fixes: https://github.com/cilium/cilium/issues/34754

```release-note
operator: don't reconcile non-GAMMA xRoutes without a Cilium-managed Gateway
```
