### PR TITLE
docs-fix-bgp-url

### DIFF
--- a/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
@@ -178,7 +178,7 @@ Timers
 
 BGP Control Plane supports modifying the following BGP timer parameters. For
 more detailed description for each timer parameters, please refer to `RFC4271
-<https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class>`__.
+<https://datatracker.ietf.org/doc/html/rfc4271>`__.
 
 ================= ============================ ==========
 Name              Field                        Default


### PR DESCRIPTION
```release-note
docs: Fix incorrect link to RFC 4271 for BGP control plane timers.
```
