### PR TITLE
CI: Update tested K8S versions

### DIFF
--- a/.github/actions/aws-cni/k8s-versions.yaml
+++ b/.github/actions/aws-cni/k8s-versions.yaml
@@ -1,15 +1,15 @@
 # List of k8s version for EKS tests
 ---
 include:
-  - version: "1.26"
-    region: us-west-1
-  - version: "1.27"
-    region: us-east-2
   - version: "1.28"
+    region: us-west-1
+  - version: "1.29"
+    region: us-east-2
+  - version: "1.30"
     region: ca-central-1
     default: true
     kpr: true
-  - version: "1.29"
+  - version: "1.31"
     region: us-east-1
     default: true
     wireguard: true

--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -1,13 +1,13 @@
 # List of k8s version for AKS tests
 ---
 include:
-  - version: "1.27"
+  - version: "1.29"
     location: westus2
     index: 1
-  - version: "1.28"
+  - version: "1.30"
     location: eastus2
     index: 2
-  - version: "1.29"
+  - version: "1.31"
     location: eastus
     index: 3
     default: true

--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -1,17 +1,17 @@
 # List of k8s version for EKS tests
 ---
 include:
-  - version: "1.26"
+  - version: "1.28"
     region: us-west-1
-  - version: "1.27"
+  - version: "1.29"
     region: us-east-2
     ipsec: true
-  - version: "1.28"
+  - version: "1.30"
     region: ca-central-1
     default: true
     ipsec: true
     kpr: true
-  - version: "1.29"
+  - version: "1.31"
     region: us-east-1
     ipsec: true
     default: true

--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,16 +1,16 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.26"
+  - version: "1.28"
     zone: us-west2-c
     vmIndex: 1
-  - version: "1.27"
+  - version: "1.29"
     zone: us-west3-a
     vmIndex: 2
-  - version: "1.28"
+  - version: "1.30"
     zone: us-east4-b
     vmIndex: 3
-  - version: "1.29"
+  - version: "1.31"
     zone: us-east1-c
     vmIndex: 4
     default: true

--- a/.github/actions/setup-eks-cluster/action.yml
+++ b/.github/actions/setup-eks-cluster/action.yml
@@ -38,6 +38,7 @@ runs:
 
         managedNodeGroups:
         - name: ng-amd64
+          amiFamily: AmazonLinux2
           instanceTypes:
            - t3.medium
           desiredCapacity: 1
@@ -50,6 +51,7 @@ runs:
              value: "true"
              effect: "NoExecute"
         - name: ng-arm64
+          amiFamily: AmazonLinux2
           instanceTypes:
            - t4g.medium
           desiredCapacity: 2


### PR DESCRIPTION
Update tested k8s versions for gke, aks, aws-cni, and eks

In order to support 1.30, and 1.31 on aws-cni and eks `amiFamily: AmazonLinux2`
is added to setup-eks-cluster actions. This will be removed once AmazonLinux2023 is [support](35529) is merged.

Workflow Runs with all supported versions:
aks : https://github.com/cilium/cilium/actions/runs/11679855008 
aws-cni : https://github.com/cilium/cilium/actions/runs/11665193779
eks : https://github.com/cilium/cilium/actions/runs/11665195477
gke : https://github.com/cilium/cilium/actions/runs/11680695828

