### PR TITLE
cilium-cli: Run BGP tests sequentially

### DIFF
--- a/cilium-cli/connectivity/builder/bgp_control_plane.go
+++ b/cilium-cli/connectivity/builder/bgp_control_plane.go
@@ -13,7 +13,8 @@ import (
 type bgpControlPlane struct{}
 
 func (t bgpControlPlane) build(ct *check.ConnectivityTest, _ map[string]string) {
-	newTest("bgp-control-plane-v1", ct).
+	// prefix the test name with `seq-` to run it sequentially
+	newTest("seq-bgp-control-plane-v1", ct).
 		WithCondition(func() bool {
 			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion) && ct.Params().IncludeUnsafeTests
 		}).
@@ -23,7 +24,8 @@ func (t bgpControlPlane) build(ct *check.ConnectivityTest, _ map[string]string) 
 		).
 		WithScenarios(tests.BGPAdvertisements(1))
 
-	newTest("bgp-control-plane-v2", ct).
+	// prefix the test name with `seq-` to run it sequentially
+	newTest("seq-bgp-control-plane-v2", ct).
 		WithCondition(func() bool {
 			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion) && ct.Params().IncludeUnsafeTests
 		}).

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -1114,7 +1114,8 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 		}
 	}
 
-	if ct.Features[features.BGPControlPlane].Enabled && ct.Features[features.NodeWithoutCilium].Enabled {
+	if ct.Features[features.BGPControlPlane].Enabled && ct.Features[features.NodeWithoutCilium].Enabled && ct.params.TestConcurrency == 1 {
+		// BGP tests need to run sequentially, deploy only if BGP CP is enabled and test concurrency is disabled
 		_, err = ct.clients.src.GetDaemonSet(ctx, ct.params.TestNamespace, frrDaemonSetNameName, metav1.GetOptions{})
 		if err != nil {
 			ct.Logf("✨ [%s] Deploying %s daemonset...", ct.clients.src.ClusterName(), frrDaemonSetNameName)
@@ -1531,7 +1532,7 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 		}
 	}
 
-	if ct.Features[features.BGPControlPlane].Enabled && ct.Features[features.NodeWithoutCilium].Enabled {
+	if ct.Features[features.BGPControlPlane].Enabled && ct.Features[features.NodeWithoutCilium].Enabled && ct.params.TestConcurrency == 1 {
 		if err := WaitForDaemonSet(ctx, ct, ct.clients.src, ct.Params().TestNamespace, frrDaemonSetNameName); err != nil {
 			return err
 		}


### PR DESCRIPTION
BGP tests need to run sequentially since BGP CP uses cluster-scoped CRDs and the test inrfra uses same node-without-cilium to peer with. Run them sequentially and deploy the test FRR instance only when test concurrency is disabled.


