### PR TITLE
[v1.16] github: update rhel8 LVH image to rhel8.6

### DIFF
--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -13,14 +13,14 @@ include:
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.29.8@sha256:d46b7aa29567e93b27f7531d258c372e829d7224b25e3fc6ffdefed12476d3aa"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "rhel8-20240404.144247@sha256:3d3510c373eb93a66518a30b715e6b3209a768ff816efe95d8da24107e90e70e"
+    kernel: "rhel8.6-20241031.113911@sha256:6ab9f8d7488a85f05a0142289ba460c58a5f1394b9aa91059a4ff9bfc2137cb2"
 
   - k8s-version: "1.28"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.28.13@sha256:45d319897776e11167e4698f6b14938eb4d52eb381d9e3d7a9086c16c69a8110"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "rhel8-20240404.144247@sha256:3d3510c373eb93a66518a30b715e6b3209a768ff816efe95d8da24107e90e70e"
+    kernel: "rhel8.6-20241031.113911@sha256:6ab9f8d7488a85f05a0142289ba460c58a5f1394b9aa91059a4ff9bfc2137cb2"
 
   - k8s-version: "1.27"
     ip-family: "dual"

--- a/.github/actions/ipsec/configs.yaml
+++ b/.github/actions/ipsec/configs.yaml
@@ -1,6 +1,6 @@
 - name: '1'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  kernel: 'rhel8-20240404.144247'
+  kernel: 'rhel8.6-20241031.113911'
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'vxlan'

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -87,7 +87,7 @@ jobs:
           - kernel: '5.4-20241010.074256'
             ci-kernel: '54'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: 'rhel8-20240730.211420'
+          - kernel: 'rhel8.6-20241031.113911'
             ci-kernel: '54'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: '5.10-20241010.074256'

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -103,7 +103,7 @@ jobs:
         include:
           - name: '1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: 'rhel8-20240404.144247'
+            kernel: 'rhel8.6-20241031.113911'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'
@@ -249,7 +249,7 @@ jobs:
 
           - name: '13'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: 'rhel8-20240404.144247'
+            kernel: 'rhel8.6-20241031.113911'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'


### PR DESCRIPTION
[ upstream commit 0eb46ada10527d3a1d3214fd83140c3dd9e58443 ]

When the LVH project started producing RHEL 8.9 images, the naming of the 8.6 images needed tweaking. Pick up the new naming scheme.