### PR TITLE
config: Remove superfluous warning on native routing CIDR

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3028,11 +3028,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 		}
 	}
 
-	if c.EnableIPv4 && ipv4NativeRoutingCIDR == "" && c.EnableAutoDirectRouting {
-		log.Warnf("If %s is enabled, then you are recommended to also configure %s. If %s is not configured, this may lead to pod to pod traffic being masqueraded, "+
-			"which can cause problems with performance, observability and policy", EnableAutoDirectRoutingName, IPv4NativeRoutingCIDR, IPv4NativeRoutingCIDR)
-	}
-
 	ipv6NativeRoutingCIDR := vp.GetString(IPv6NativeRoutingCIDR)
 
 	if ipv6NativeRoutingCIDR != "" {
@@ -3044,11 +3039,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 		if len(c.IPv6NativeRoutingCIDR.IP) != net.IPv6len {
 			log.Fatalf("%s must be an IPv6 CIDR", IPv6NativeRoutingCIDR)
 		}
-	}
-
-	if c.EnableIPv6 && ipv6NativeRoutingCIDR == "" && c.EnableAutoDirectRouting {
-		log.Warnf("If %s is enabled, then you are recommended to also configure %s. If %s is not configured, this may lead to pod to pod traffic being masqueraded, "+
-			"which can cause problems with performance, observability and policy", EnableAutoDirectRoutingName, IPv6NativeRoutingCIDR, IPv6NativeRoutingCIDR)
 	}
 
 	if c.DirectRoutingSkipUnreachable && !c.EnableAutoDirectRouting {


### PR DESCRIPTION
This commit removes a warning that was intended to warn the user that running in native routing mode without a correct native routing CIDR will lead to problems.

However, the conditions for the warning are not fully correct. There are native routing setups where the user does not need to specify a native routing CIDR, namely:

  1. The user is running in ENI or AlibabaCloud IPAM, where the native routing CIDR is auto-detected if not explicitly configured.
  2. The user is running with BPF ip-masq-agent where the native routing CIDR is optional (as there are other means of specifying exclusion CIDRs) (c.f. https://github.com/cilium/cilium/pull/27747)
  3. The user is not running with Cilium-based masquerading.

The existing warning did not trigger for case 1, as the if condition checked for `auto-direct-node-routes` rather than the `routing-mode` flag, and `auto-direct-node-routes` is not used on ENI/AlibabaCloud IPAM modes.

However, the warning would trigger for cases 2 and 3, which is incorrect. Cases 2 and 3 should not emit a warning either. And indeed already have a check on the native routing CIDR that handles all three cases correctly, namely `checkIPv{4,6}NativeRoutingCIDR` here:

https://github.com/cilium/cilium/blob/bc26c6d3a74e3bfbeb1149e5116de51c496dd254/pkg/option/config.go#L3451-L3476

Therefore, we can safely remove the warning in this commit, as the conditions are already covered by `checkIPv{4,6}NativeRoutingCIDR`. I have also manually tested that the check does take effect if one sets `routingMode=native` and `autoDirectNodeRoutes=true` without specifying a native routing CIDR.

Fixes: 6743d285e43f ("daemon: warn if auto direct node routes is set without a native routing CIDR")

*Note:* This commit also fixes an issue with the `Conformance Multi-Pool` workflow where this warning was wrongfully emitted (as that workflow uses BPF ip-masq-agent). Therefore, I have marked this PR to be backported to 1.16 and v1.15, as those versions do allow BPF ip-masq-agent to be run without an explicit native routing CIDR.