### PR TITLE
gha: enable the log-errors check in the clustermesh upgrade workflow

### DIFF
--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -200,6 +200,7 @@ jobs:
             --flow-validation=disabled \
             --test='no-interrupted-connections' \
             --test='no-unexpected-packet-drops' \
+            --test='check-log-errors' \
             --test='no-policies/' \
             --test='no-policies-extra/' \
             --test='allow-all-except-world/' \


### PR DESCRIPTION
Extend the clustermesh upgrade/downgrade workflow to additionally assert that no error logs are emitted, as already done in most other workflows. This check was previously missing from the explicit allow list.