### PR TITLE
watchers: disable CRD to kvstore handover logic

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -322,6 +322,11 @@ communicating via the proxy must reconnect to re-establish connections.
 * The Cilium cluster name validation cannot be bypassed anymore, both for the local and
   remote clusters. The cluster name is strictly enforced to consist of at most 32 lower
   case alphanumeric characters and '-', start and end with an alphanumeric character.
+* Cilium could previously be run in a configuration where the Etcd instances
+  that distribute Cilium state between nodes would be managed in pod network by
+  Cilium itself. This support, which had been previously deprecated as complicated
+  and error prone, has now been removed. Refer to :ref:`k8s_install_etcd` for
+  alternatives for running Cilium with Etcd.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -514,6 +514,10 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Duration(option.KVstoreConnectivityTimeout, defaults.KVstoreConnectivityTimeout, "Time after which an incomplete kvstore operation  is considered failed")
 	option.BindEnv(vp, option.KVstoreConnectivityTimeout)
 
+	flags.Bool(option.KVstorePodNetworkSupport, defaults.KVstorePodNetworkSupport, "Enable the support for running the Cilium KVstore in pod network")
+	flags.MarkHidden(option.KVstorePodNetworkSupport)
+	option.BindEnv(vp, option.KVstorePodNetworkSupport)
+
 	flags.Var(option.NewNamedMapOptions(option.KVStoreOpt, &option.Config.KVStoreOpt, nil),
 		option.KVStoreOpt, "Key-value store options e.g. etcd.address=127.0.0.1:4001")
 	option.BindEnv(vp, option.KVStoreOpt)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -306,6 +306,10 @@ const (
 	// a kvstore path for too long.
 	KVStoreStaleLockTimeout = 30 * time.Second
 
+	// KVstorePodNetworkSupport represents whether to enable the support for
+	// running the Cilium KVstore in pod network.
+	KVstorePodNetworkSupport = false
+
 	// PolicyQueueSize is the default queue size for policy-related events.
 	PolicyQueueSize = 100
 

--- a/pkg/endpointcleanup/cleanup.go
+++ b/pkg/endpointcleanup/cleanup.go
@@ -63,7 +63,18 @@ type cleanup struct {
 }
 
 func registerCleanup(p params) {
-	if !p.Clientset.IsEnabled() || !p.Cfg.EnableStaleCiliumEndpointCleanup || p.DaemonCfg.DisableCiliumEndpointCRD {
+	if !p.Clientset.IsEnabled() || !p.Cfg.EnableStaleCiliumEndpointCleanup || p.DaemonCfg.DisableCiliumEndpointCRD ||
+		// When Cilium is configured in KVstore mode, and support for running the kvstore
+		// in pod network is disabled, we don't start the CiliumEndpoints informer at all.
+		// Hence, let's disable this GC logic as well, given that it would otherwise need
+		// to start it to populate the store content. Indeed, no one is expected to be
+		// watching them, and we can accept the possibility that we leak a few objects in
+		// very specific and rare circumstances [1], until the corresponding pod gets deleted.
+		// The respective kvstore entries, which are not taken into account here, will be
+		// instead eventually deleted when the corresponding lease expires.
+		//
+		// [1]: cilium/cilium#20350
+		p.DaemonCfg.KVstoreEnabledWithoutPodNetworkSupport() {
 		p.Logger.Info("Init procedure to clean up stale CiliumEndpoint disabled")
 		return
 	}

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -252,11 +252,13 @@ func (k *K8sPodWatcher) podsInit(asyncControllers *sync.WaitGroup) {
 		return cancel
 	}
 
-	// We will watch for pods on th entire cluster to keep existing
+	// We will watch for pods on the entire cluster to keep existing
 	// functionality untouched. If we are running with CiliumEndpoint CRD
 	// enabled then it means that we can simply watch for pods that are created
-	// for this node.
-	if !option.Config.DisableCiliumEndpointCRD {
+	// for this node. Similarly, we don't need to watch for all pods when the
+	// support for running the Cilium KVstore in pod network is disabled, as in
+	// that case we just rely on the KVStore data from the beginning.
+	if !option.Config.DisableCiliumEndpointCRD || option.Config.KVstoreEnabledWithoutPodNetworkSupport() {
 		watchNodePods()
 		return
 	}

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -19,6 +19,10 @@ func (f *fakeK8sWatcherConfiguration) K8sNetworkPolicyEnabled() bool {
 	return true
 }
 
+func (f *fakeK8sWatcherConfiguration) KVstoreEnabledWithoutPodNetworkSupport() bool {
+	return false
+}
+
 func Test_No_Resources_InitK8sSubsystem(t *testing.T) {
 	fakeClientSet, _ := client.NewFakeClientset()
 


### PR DESCRIPTION
When running in kvstore mode, Cilium currently still starts the CiliumNode and CiliumEndpoint informers, stopping them once connecting to etcd. Informers are then potentially restarted if the client disconnects from etcd again. This handover logic, which has been historically introduced to support running etcd in pod network, is known to be complex and fragile (as it can potentially lead to stale entries), and introduces extra load on the Kubernetes API Server during Cilium agent startup.

Considering that this handover logic is not needed when etcd runs outside of the cluster (or in host network) and support for running etcd in pod network has been officially deprecated in v1.16 \[1], let's disable it altogether. Still, let's keep it behind a hidden flag for the moment, to allow easily enabling it again in case of problems. If nothing unexpected comes up, we can then definitely remove it in the future. 

The same flag is used in the context of the pod watcher as well, to avoid switching to watching all the pods in the cluster (rather than only the ones hosted by the current node) when the CiliumEndpoint CRD is disabled. Indeed, this was again needed to support running etcd in pod network, but completely defeats the performance benefits associated with disabling the CiliumEndpoint CRD.     

\[1]: f99f10bd8843 ("docs: Deprecate support for podnetwork etcd")

---

When Cilium is configured in KVstore mode, and support for running the kvstore in pod network is disabled, we don't start the CiliumEndpoints informer at all. Hence, let's disable this GC logic as well, given that it would otherwise need to start it to populate the store content. Indeed, no one is expected to be watching them, and we can accept the possibility that we leak a few objects in very specific and rare circumstances \[1], until the corresponding pod gets deleted. The respective kvstore entries, which are not taken into account here, will be instead eventually deleted when the corresponding lease expires.
    
Even better, we could disable the CiliumEndpoint CRD altogether in this configuration, given that CiliumEndpoints are not expected to be used at all. However, that comes with extra risks, especially during the initial migration phase, when old agents may still watch them in case of restarts, and given that the feature is not really battle tested. Hence, let's go for this simpler, and safer, approach for the moment.

\[1]: cilium/cilium#20350

---

<!-- Description of change -->

```release-note
Disable deprecated support for running the Cilium KVStore in pod network
```
