### PR TITLE
enabling cli pod-to-pod-with-l7-policy-encryption for v1.15 and v1.16

### DIFF
--- a/cilium-cli/connectivity/tests/encryption.go
+++ b/cilium-cli/connectivity/tests/encryption.go
@@ -203,26 +203,6 @@ func isWgEncap(t *check.Test) bool {
 	return true
 }
 
-// checkIPSecPodToPod checks whether in case of IPSec being enabled and used
-// during the podToPodEncryption test it should be executed or skipped due to:
-//
-// 1. missing backporting of the commit in previous versions;
-// 2. usage of IPv6, for which the test is flaky (see https://github.com/cilium/cilium/issues/35485).
-//
-// Once the above reasons are fixed, this function can be removed.
-func checkIPSecPodToPod(t *check.Test, ipFam features.IPFamily) error {
-	if e, ok := t.Context().Feature(features.EncryptionPod); !(ok && e.Enabled && e.Mode == "ipsec") {
-		return nil
-	}
-	if !versioncheck.MustCompile(">=1.17.0")(t.Context().CiliumVersion) {
-		return fmt.Errorf("enabling test for IPSec requires backporting")
-	}
-	if ipFam == features.IPFamilyV6 {
-		return fmt.Errorf("inactive IPv6 test with IPSec, see https://github.com/cilium/cilium/issues/35485")
-	}
-	return nil
-}
-
 // PodToPodEncryption is a test case which checks the following:
 //   - There is a connectivity between pods on different nodes when any
 //     encryption mode is on (either WireGuard or IPsec).
@@ -271,9 +251,12 @@ func (s *podToPodEncryption) Run(ctx context.Context, t *check.Test) {
 		t.Debug("Encapsulation before WG encryption")
 	}
 
+	e, ok := t.Context().Feature(features.EncryptionPod)
+	isIPSec := ok && e.Enabled && e.Mode == "ipsec"
+
 	t.ForEachIPFamily(func(ipFam features.IPFamily) {
-		if err := checkIPSecPodToPod(t, ipFam); err != nil {
-			t.Debugf("Skipping test: %v", err)
+		if isIPSec && ipFam == features.IPFamilyV6 {
+			t.Debugf("Inactive IPv6 test with IPSec, see https://github.com/cilium/cilium/issues/35485")
 			return
 		}
 		testNoTrafficLeak(ctx, t, s, client, &server, &clientHost, &serverHost, requestHTTP, ipFam, assertNoLeaks, true, wgEncap)


### PR DESCRIPTION
PR to enable the cli `pod-to-pod-with-l7-policy-encryption` test with IPSec also for v1.15 and v1.16.
Backports of #35173 have beed done in #35586 and #35543 respectively.

```release-note
Enabling IPSec pod-to-pod-with-l7-policy-encryption connectivity test for v1.15 and v1.16.
```
