### PR TITLE
docs/ipsec: Remove KPR limitation

### DIFF
--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -365,9 +365,7 @@ Limitations
     * Transparent encryption is not currently supported when chaining Cilium on
       top of other CNI plugins. For more information, see :gh-issue:`15596`.
     * :ref:`HostPolicies` are not currently supported with IPsec encryption.
-    * IPsec encryption does not work when using :ref:`kube-proxy replacement
-      <kubeproxy-free>`. Be aware that other features may require a kube-proxy
-      free environment in which case they are mutual exclusive.
+    * IPsec encryption currently does not work with BPF Host Routing.
     * IPsec encryption is not currently supported in combination with IPv6-only clusters.
     * IPsec encryption is not supported on clusters or clustermeshes with more
       than 65535 nodes.


### PR DESCRIPTION
IPsec now works in combination with kube-proxy replacement. It is however still not supported with BPF Host Routing as we need to go through the Linux stack to perform the actual encryption and decryption.