### PR TITLE
workflows/clustermesh: Improve naming of on-failure sysdumps

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -333,7 +333,8 @@ jobs:
             --multi-cluster=${{ env.contextName2 }} \
             --external-target=google.com. \
             --include-unsafe-tests \
-            --collect-sysdump-on-failure"
+            --collect-sysdump-on-failure \
+            --sysdump-output-filename 'cilium-sysdump-${{ matrix.name }}-<ts>'" \
 
           # Skip external traffic (e.g. 1.1.1.1 and www.google.com) tests as IPv6 is not supported
           # in GitHub runners: https://github.com/actions/runner-images/issues/668


### PR DESCRIPTION
Sysdumps collected on failures are currently not named in any special way in the ClusterMesh workflow. They end up having names like:

    cilium-sysdump-20241104-095153.zip

which, among all sysdumps collected can be a bit painful to navigate.

This commit fixes that by including the name of the matrix entry in the sysdump name.