### PR TITLE
ui: drop CORS headers from api response

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-ui/_nginx.tpl
+++ b/install/kubernetes/cilium/templates/hubble-ui/_nginx.tpl
@@ -13,24 +13,12 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
 
-        # CORS
-        add_header Access-Control-Allow-Methods "GET, POST, PUT, HEAD, DELETE, OPTIONS";
-        add_header Access-Control-Allow-Origin *;
-        add_header Access-Control-Max-Age 1728000;
-        add_header Access-Control-Expose-Headers content-length,grpc-status,grpc-message;
-        add_header Access-Control-Allow-Headers range,keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout;
-        if ($request_method = OPTIONS) {
-            return 204;
-        }
-        # /CORS
-
         location {{ .Values.hubble.ui.baseUrl }}api {
             {{- if not (eq .Values.hubble.ui.baseUrl "/") }}
             rewrite ^{{ (trimSuffix "/" .Values.hubble.ui.baseUrl) }}(/.*)$ $1 break;
             {{- end }}
             proxy_http_version 1.1;
             proxy_pass_request_headers on;
-            proxy_hide_header Access-Control-Allow-Origin;
             {{- if eq .Values.hubble.ui.baseUrl "/" }}
             proxy_pass http://127.0.0.1:8090;
             {{- else }}


### PR DESCRIPTION
This change improves security: without CORS headers browsers will prevent calling Hubble UI backend API from another domain, only page (origin) where Hubble UI is served from will be able to call API.
