### PR TITLE
option: Reduce log level for WG strict mode + IPv6

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2998,7 +2998,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	encryptionStrictModeEnabled := vp.GetBool(EnableEncryptionStrictMode)
 	if encryptionStrictModeEnabled {
 		if c.EnableIPv6 {
-			log.Warnf("WireGuard encryption strict mode only support IPv4. IPv6 traffic is not protected and can be leaked.")
+			log.Info("WireGuard encryption strict mode only supports IPv4. IPv6 traffic is not protected and can be leaked.")
 		}
 
 		strictCIDR := vp.GetString(EncryptionStrictModeCIDR)


### PR DESCRIPTION
WireGuard strict mode isn't supported with IPv6. At the moment, a warning is emitted if both are enabled at the same time, to warn the user that IPv6 traffic won't be protected.

There is however not much the user can do in this case to make the warning go away. Gray also pointed out that users should know that already as they've had to configure `encryption.strictMode.cidr` with an IPv4 CIDR. It is also documented in the guide. This commit therefore reduces the log to an Info level.

cc @benschlueter @3u13r 

```
Reduce log level of warning that cannot be avoided when running with IPv6 and WireGuard strict mode.
```