### PR TITLE
Revert "sysdump: collect Cilium profiling data as first task"

### DIFF
--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -1227,6 +1227,20 @@ func (c *Collector) Run() error {
 		},
 		{
 			CreatesSubtasks: true,
+			Description:     "Collecting profiling data from Cilium pods",
+			Quick:           false,
+			Task: func(_ context.Context) error {
+				if !c.Options.Profiling {
+					return nil
+				}
+				if err := c.SubmitProfilingGopsSubtasks(c.CiliumPods, ciliumAgentContainerName); err != nil {
+					return fmt.Errorf("failed to collect profiling data from Cilium pods: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			CreatesSubtasks: true,
 			Description:     "Collecting profiling data from Cilium Operator pods",
 			Quick:           false,
 			Task: func(_ context.Context) error {
@@ -1442,19 +1456,6 @@ func (c *Collector) Run() error {
 		tasks = append(tasks, ciliumTasks...)
 
 		serialTasks = append(serialTasks, Task{
-			CreatesSubtasks: true,
-			Description:     "Collecting profiling data from Cilium pods",
-			Quick:           false,
-			Task: func(_ context.Context) error {
-				if !c.Options.Profiling {
-					return nil
-				}
-				if err := c.SubmitProfilingGopsSubtasks(c.CiliumPods, ciliumAgentContainerName); err != nil {
-					return fmt.Errorf("failed to collect profiling data from Cilium pods: %w", err)
-				}
-				return nil
-			},
-		}, Task{
 			CreatesSubtasks: true,
 			Description:     "Collecting tracing data from Cilium pods",
 			Quick:           false,


### PR DESCRIPTION
This reverts commit d34a7b3849864b557e9c1cf7cd716d7f70f91f51.

The reverted commit moved the collection of Cilium profiling data as first task, to prevent it from being impacted by the other sysdump collection tasks. However, the current approach has the unintended consequence of collecting each pprof sequentially, hence taking a significant amount of time, proportional to the number of nodes (approximately one hour with 100 nodes). Let's revert this for now, while figuring out a better approach to achieve the same goal.

Reported-by: Marcel Zieba <marcel.zieba@isovalent.com>
