### PR TITLE
cgroup: downgrade the socket LB tracing setup failure log to Info

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1643,14 +1643,15 @@ and selected service endpoint.
     Jan 13 13:47:20.932: default/mediabot:38750 (ID:5618) <> default/nginx (ID:35772) pre-xlate-rev TRACED (TCP)
 
 Socket LB tracing with Hubble requires cilium agent to detect pod cgroup paths.
-If you see a warning message in cilium agent ``Failed to setup socket load-balancing tracing with Hubble.``,
+If you see a message in cilium agent ``Failed to setup socket load-balancing tracing with Hubble.``,
 you can trace packets using ``cilium-dbg monitor`` instead.
 
 .. note::
 
-    In case of the warning log, please file a GitHub issue with the cgroup path
-    for any of your pods, obtained by running the following command on a Kubernetes
-    node in your cluster: ``sudo crictl inspectp -o=json $POD_ID | grep cgroup``.
+    If you observe the message about socket load-balancing setup failure in the logs,
+    please file a GitHub issue with the cgroup path for any of your pods,
+    obtained by running the following command on a Kubernetes node in your
+    cluster: ``sudo crictl inspectp -o=json $POD_ID | grep cgroup``.
 
 .. code-block:: shell-session
 

--- a/pkg/cgroups/manager/cell.go
+++ b/pkg/cgroups/manager/cell.go
@@ -37,7 +37,7 @@ func newCGroupManager(params cgroupManagerParams) CGroupManager {
 	if err != nil {
 		params.Logger.
 			WithError(err).
-			Warn("Failed to setup socket load-balancing tracing with Hubble. See the kubeproxy-free guide for more details.")
+			Info("Failed to setup socket load-balancing tracing with Hubble. See the kubeproxy-free guide for more details.")
 
 		return &noopCGroupManager{}
 	}


### PR DESCRIPTION
The failure log message doesn't indicate a serious problem and it's not actionable for users. (They can't fix it by adjusting the cilium configuration.) So this commit downgrades it to info.

The socket LB tracing is an optional feature for troubleshooting to see svc->backend translation trace messages.
