### PR TITLE
.github: remove use of deprecated --disable-check cilium-cli option

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -77,7 +77,6 @@ runs:
       run: |
         DEFAULTS="--wait \
             --chart-directory=${{ inputs.chart-dir }} \
-            --disable-check=minimum-version \
             --helm-set=debug.enabled=true \
             --helm-set=debug.verbose=envoy \
             --helm-set=hubble.eventBufferCapacity=65535 \

--- a/.github/actions/helm-default/action.yaml
+++ b/.github/actions/helm-default/action.yaml
@@ -28,7 +28,6 @@ runs:
         fi
 
         CILIUM_INSTALL_DEFAULTS="--chart-directory=${{ inputs.chart-dir }} \
-          --disable-check=minimum-version \
           --helm-set=debug.enabled=true \
           --helm-set=debug.verbose=envoy \
           --helm-set=bpf.monitorAggregation=none \

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -169,7 +169,6 @@ jobs:
           #   down the rollout process and highlight possible connection disruption
           #   occurring in the meanwhile.
           CILIUM_INSTALL_DEFAULTS=" \
-            --disable-check=minimum-version \
             --set=debug.enabled=true \
             --set=bpf.monitorAggregation=medium \
             --set=hubble.enabled=true \


### PR DESCRIPTION
The `--disable-check` flag to `cilium install` has been deprecated and no longer performs any validation checks since commit 16b91de9e121 ("cilium-cli: Deprecate --disable-check flag").