### PR TITLE
k8s: Avoid panic while checking ip mode

### DIFF
--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -229,7 +229,7 @@ func ParseService(svc *slim_corev1.Service, nodePortAddrs []netip.Addr) (Service
 
 	if expType.canExpose(slim_corev1.ServiceTypeLoadBalancer) {
 		for _, ip := range svc.Status.LoadBalancer.Ingress {
-			if ip.IP != "" && ip.IPMode == nil || *ip.IPMode == slim_corev1.LoadBalancerIPModeVIP {
+			if ip.IP != "" && (ip.IPMode == nil || *ip.IPMode == slim_corev1.LoadBalancerIPModeVIP) {
 				loadBalancerIPs = append(loadBalancerIPs, ip.IP)
 			}
 		}

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -576,6 +576,57 @@ func TestParseService(t *testing.T) {
 		TopologyAware:            true,
 		Annotations:              map[string]string{"service.kubernetes.io/topology-aware-hints": "auto"},
 	}, svc)
+
+	// Same as the previous test, but LB service status is empty.
+	// This is to simulate the delay while waiting for cloud provider to assign IP.
+	k8sSvc = &slim_corev1.Service{
+		ObjectMeta: objMeta,
+		Spec: slim_corev1.ServiceSpec{
+			ClusterIP: "127.0.0.1",
+			Type:      slim_corev1.ServiceTypeLoadBalancer,
+			Ports: []slim_corev1.ServicePort{
+				{
+					Name:     "http",
+					Port:     80,
+					NodePort: 31111,
+					Protocol: slim_corev1.ProtocolTCP,
+				},
+				{
+					// NodePort should not be allocated for this entry.
+					Name:     "tftp",
+					Port:     69,
+					NodePort: 0,
+					Protocol: slim_corev1.ProtocolUDP,
+				},
+			},
+		},
+	}
+	id, svc = ParseService(k8sSvc, addrs)
+	require.EqualValues(t, ServiceID{Namespace: "bar", Name: "foo"}, id)
+	require.EqualValues(t, &Service{
+		FrontendIPs: []net.IP{net.ParseIP("127.0.0.1")},
+		Labels:      map[string]string{"foo": "bar"},
+		Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
+			"http": loadbalancer.NewL4Addr(loadbalancer.L4Type(slim_corev1.ProtocolTCP), uint16(80)),
+			"tftp": loadbalancer.NewL4Addr(loadbalancer.L4Type(slim_corev1.ProtocolUDP), uint16(69)),
+		},
+		ExtTrafficPolicy: loadbalancer.SVCTrafficPolicyCluster,
+		IntTrafficPolicy: loadbalancer.SVCTrafficPolicyCluster,
+		NodePorts: map[loadbalancer.FEPortName]NodePortToFrontend{
+			"http": {
+				zeroFE.String():     zeroFE,
+				internalFE.String(): internalFE,
+				nodePortFE.String(): nodePortFE,
+			},
+		},
+		LoadBalancerSourceRanges: map[string]*cidr.CIDR{},
+		K8sExternalIPs:           map[string]net.IP{},
+		LoadBalancerIPs:          map[string]net.IP{},
+		Type:                     loadbalancer.SVCTypeLoadBalancer,
+		ForwardingMode:           loadbalancer.SVCForwardingModeSNAT,
+		TopologyAware:            true,
+		Annotations:              map[string]string{"service.kubernetes.io/topology-aware-hints": "auto"},
+	}, svc)
 }
 
 func TestIsK8ServiceExternal(t *testing.T) {


### PR DESCRIPTION
Update if condition to avoid panic if ip mode is nil, as OR operator is having higher precedence than AND operator.

```
panic: runtime error: invalid memory address or nil pointer dereference
 [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x222dcb0]
 goroutine 444 [running]:
 github.com/cilium/cilium/pkg/k8s.ParseService(0x400308f0e0, {0x40030a8480, 0x3, 0x4})
     /go/src/github.com/cilium/cilium/pkg/k8s/service.go:232 +0x1320
 github.com/cilium/cilium/pkg/k8s.(*ServiceCache).UpdateService(0x4001f10c60, 0x400308f0e0, 0x400133f680)
     /go/src/github.com/cilium/cilium/pkg/k8s/service_cache.go:337 +0x1e8
 github.com/cilium/cilium/pkg/k8s/watchers.(*K8sServiceWatcher).upsertK8sServiceV1(0x40005f9400, 0x400308f0e0, 0x10?)
     /go/src/github.com/cilium/cilium/pkg/k8s/watchers/service.go:142 +0x30
 github.com/cilium/cilium/pkg/k8s/watchers.(*K8sServiceWatcher).serviceEventLoop(0x40005f9400, 0x400190be38, 0x400133f680)
     /go/src/github.com/cilium/cilium/pkg/k8s/watchers/service.go:130 +0x1f4
 created by github.com/cilium/cilium/pkg/k8s/watchers.(*K8sServiceWatcher).servicesInit in goroutine 1
     /go/src/github.com/cilium/cilium/pkg/k8s/watchers/service.go:101 +0x160
```
Reported-by: https://github.com/Truongnht
Fixes: ab8557c8accf85a78b2ec3a683f5808442568bd9

