### PR TITLE
 ipam: Validate CiliumNode resource in ENI mode

### DIFF
--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"slices"
 	"strconv"
 	"sync"
 
@@ -332,6 +333,49 @@ func (n *nodeStore) deleteLocalNodeResource() {
 	n.mutex.Unlock()
 }
 
+// validateENIConfig validates the ENI configuration in the CiliumNode resource
+// and returns an error if the configuration is not fully set.
+func validateENIConfig(node *ciliumv2.CiliumNode) error {
+	// Check if the VPC CIDR is set for all ENIs
+	for _, eni := range node.Status.ENI.ENIs {
+		if len(eni.VPC.PrimaryCIDR) == 0 {
+			return fmt.Errorf("VPC Primary CIDR not set for ENI %s", eni.ID)
+		}
+
+		for _, c := range eni.VPC.CIDRs {
+			if len(c) == 0 {
+				return fmt.Errorf("VPC CIDR not set for ENI %s", eni.ID)
+			}
+		}
+	}
+
+	// Check if all pool resource IPs are present in the status
+	eniIPMap := map[string][]string{}
+	for k, v := range node.Spec.IPAM.Pool {
+		eniIPMap[v.Resource] = append(eniIPMap[v.Resource], k)
+	}
+
+	for eni, addresses := range eniIPMap {
+		eniFound := false
+		for _, sENI := range node.Status.ENI.ENIs {
+			if eni == sENI.ID {
+				for _, addr := range addresses {
+					if !slices.Contains(sENI.Addresses, addr) {
+						return fmt.Errorf("ENI %s does not have address %s", eni, addr)
+					}
+				}
+				eniFound = true
+			}
+		}
+
+		if !eniFound {
+			return fmt.Errorf("ENI %s not found in status", eni)
+		}
+	}
+
+	return nil
+}
+
 // updateLocalNodeResource is called when the CiliumNode resource representing
 // the local node has been added or updated. It updates the available IPs based
 // on the custom resource passed into the function.
@@ -340,6 +384,11 @@ func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 	defer n.mutex.Unlock()
 
 	if n.conf.IPAMMode() == ipamOption.IPAMENI {
+		if err := validateENIConfig(node); err != nil {
+			log.WithError(err).Info("ENI state is not consistent yet")
+			return
+		}
+
 		if err := configureENIDevices(n.ownNode, node, n.mtuConfig); err != nil {
 			log.WithError(err).Errorf("Failed to update routes and rules for ENIs")
 		}

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -683,14 +683,8 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 		for _, eni := range a.store.ownNode.Status.ENI.ENIs {
 			if eni.ID == ipInfo.Resource {
 				result.PrimaryMAC = eni.MAC
-				if len(eni.VPC.PrimaryCIDR) > 0 {
-					result.CIDRs = append(result.CIDRs, eni.VPC.PrimaryCIDR)
-				}
-				for _, otherCidr := range eni.VPC.CIDRs {
-					if len(otherCidr) > 0 {
-						result.CIDRs = append(result.CIDRs, otherCidr)
-					}
-				}
+				result.CIDRs = []string{eni.VPC.PrimaryCIDR}
+				result.CIDRs = append(result.CIDRs, eni.VPC.CIDRs...)
 				// Add manually configured Native Routing CIDR
 				if a.conf.IPv4NativeRoutingCIDR != nil {
 					result.CIDRs = append(result.CIDRs, a.conf.IPv4NativeRoutingCIDR.String())

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -14,9 +14,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/trigger"
@@ -123,4 +125,213 @@ func TestMarkForReleaseNoAllocate(t *testing.T) {
 	cn.Status.IPAM.ReleaseIPs["1.1.1.3"] = ipamOption.IPAMMarkForRelease
 	sharedNodeStore.updateLocalNodeResource(cn)
 	require.Equal(t, ipamOption.IPAMDoNotRelease, string(cn.Status.IPAM.ReleaseIPs["1.1.1.3"]))
+}
+
+func Test_validateENIConfig(t *testing.T) {
+	type args struct {
+		node *ciliumv2.CiliumNode
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		want    string
+	}{
+		{
+			name: "Consistent ENI config",
+			args: args{
+				node: &ciliumv2.CiliumNode{
+					Spec: ciliumv2.NodeSpec{
+						IPAM: ipamTypes.IPAMSpec{
+							Pool: ipamTypes.AllocationMap{
+								"10.1.1.226": ipamTypes.AllocationIP{
+									Resource: "eni-1",
+								},
+							},
+						},
+					},
+					Status: ciliumv2.NodeStatus{
+						ENI: eniTypes.ENIStatus{
+							ENIs: map[string]eniTypes.ENI{
+								"eni-1": {
+									ID: "eni-1",
+									Addresses: []string{
+										"10.1.1.226",
+										"10.1.1.229",
+									},
+									VPC: eniTypes.AwsVPC{
+										ID:          "vpc-1",
+										PrimaryCIDR: "10.1.0.0/16",
+										CIDRs: []string{
+											"10.1.0.0/16",
+											"10.2.0.0/16",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Missing VPC Primary CIDR",
+			args: args{
+				node: &ciliumv2.CiliumNode{
+					Spec: ciliumv2.NodeSpec{
+						IPAM: ipamTypes.IPAMSpec{
+							Pool: ipamTypes.AllocationMap{
+								"10.1.1.226": ipamTypes.AllocationIP{
+									Resource: "eni-1",
+								},
+							},
+						},
+					},
+					Status: ciliumv2.NodeStatus{
+						ENI: eniTypes.ENIStatus{
+							ENIs: map[string]eniTypes.ENI{
+								"eni-1": {
+									ID: "eni-1",
+									Addresses: []string{
+										"10.1.1.226",
+										"10.1.1.229",
+									},
+									VPC: eniTypes.AwsVPC{
+										ID: "vpc-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			want:    "VPC Primary CIDR not set for ENI eni-1",
+		},
+		{
+			name: "VPC CIDRs contain invalid value",
+			args: args{
+				node: &ciliumv2.CiliumNode{
+					Spec: ciliumv2.NodeSpec{
+						IPAM: ipamTypes.IPAMSpec{
+							Pool: ipamTypes.AllocationMap{
+								"10.1.1.226": ipamTypes.AllocationIP{
+									Resource: "eni-1",
+								},
+							},
+						},
+					},
+					Status: ciliumv2.NodeStatus{
+						ENI: eniTypes.ENIStatus{
+							ENIs: map[string]eniTypes.ENI{
+								"eni-1": {
+									ID: "eni-1",
+									Addresses: []string{
+										"10.1.1.226",
+										"10.1.1.229",
+									},
+									VPC: eniTypes.AwsVPC{
+										ID:          "vpc-1",
+										PrimaryCIDR: "10.1.0.0/16",
+										CIDRs: []string{
+											"",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			want:    "VPC CIDR not set for ENI eni-1",
+		},
+		{
+			name: "ENI not found in status",
+			args: args{
+				node: &ciliumv2.CiliumNode{
+					Spec: ciliumv2.NodeSpec{
+						IPAM: ipamTypes.IPAMSpec{
+							Pool: ipamTypes.AllocationMap{
+								"10.1.1.226": ipamTypes.AllocationIP{
+									Resource: "eni-1",
+								},
+							},
+						},
+					},
+					Status: ciliumv2.NodeStatus{
+						ENI: eniTypes.ENIStatus{
+							ENIs: map[string]eniTypes.ENI{
+								"eni-2": {
+									ID: "eni-2",
+									Addresses: []string{
+										"10.1.1.226",
+										"10.1.1.229",
+									},
+									VPC: eniTypes.AwsVPC{
+										ID:          "vpc-1",
+										PrimaryCIDR: "10.1.0.0/16",
+										CIDRs: []string{
+											"10.1.0.0/16",
+											"10.2.0.0/16",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			want:    "ENI eni-1 not found in status",
+		},
+		{
+			name: "ENI IP not found in status",
+			args: args{
+				node: &ciliumv2.CiliumNode{
+					Spec: ciliumv2.NodeSpec{
+						IPAM: ipamTypes.IPAMSpec{
+							Pool: ipamTypes.AllocationMap{
+								"10.1.1.227": ipamTypes.AllocationIP{
+									Resource: "eni-1",
+								},
+							},
+						},
+					},
+					Status: ciliumv2.NodeStatus{
+						ENI: eniTypes.ENIStatus{
+							ENIs: map[string]eniTypes.ENI{
+								"eni-1": {
+									ID: "eni-1",
+									Addresses: []string{
+										"10.1.1.226",
+										"10.1.1.229",
+									},
+									VPC: eniTypes.AwsVPC{
+										ID:          "vpc-1",
+										PrimaryCIDR: "10.1.0.0/16",
+										CIDRs: []string{
+											"10.1.0.0/16",
+											"10.2.0.0/16",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			want:    "ENI eni-1 does not have address 10.1.1.227",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validateENIConfig(tt.args.node)
+			require.Equal(t, tt.wantErr, got != nil, "error: %v", got)
+			if tt.wantErr {
+				require.Equal(t, tt.want, got.Error())
+			}
+		})
+	}
 }


### PR DESCRIPTION
### Description

In some cases, there might be race condition between Instance Manager
(running in operator) and IPAM (running in agent) modules, which could
lead to IP details are not populated properly, and hence cause the below
fatal error. This commit is to make sure that we don't proceed if the
required CIDRs are not populated.

```
time="2024-10-22T22:48:31Z" level=fatal msg="failed to start: daemon creation failed: failed to coalesce CIDRs: invalid CIDR address: " subsys=daemon
```

Signed-off-by: Tam Mach <tam.mach@cilium.io>

----

### Testing

Testing was done locally by rapidly scaling up the cluster (to increase the likelihood of race condition), no agent restart was observed.

```shell
$ ksyslo $cilium_pod | grep "ENI state is not consistent yet"
Defaulted container "cilium-agent" out of: cilium-agent, config (init), mount-cgroup (init), apply-sysctl-overwrites (init), mount-bpf-fs (init), wait-for-node-init (init), clean-cilium-state (init), wait-for-kube-proxy (init), install-cni-binaries (init)
time="2024-11-05T14:26:13Z" level=warning msg="ENI state is not consistent yet" error="VPC Primary CIDR not set for ENI eni-08c59e332a31361c2" subsys=ipam
time="2024-11-05T14:26:13Z" level=warning msg="ENI state is not consistent yet" error="VPC Primary CIDR not set for ENI eni-08c59e332a31361c2" subsys=ipam
time="2024-11-05T14:27:49Z" level=warning msg="ENI state is not consistent yet" error="VPC Primary CIDR not set for ENI eni-0980fa15122c943cf" subsys=ipam
time="2024-11-05T14:27:53Z" level=warning msg="ENI state is not consistent yet" error="VPC Primary CIDR not set for ENI eni-0980fa15122c943cf" subsys=ipam
```

<details>
<summary>Scaling up the cluster</summary>

```shell
$ ksysgpo -l app.kubernetes.io/name=cilium-agent -o wide
NAME           READY   STATUS    RESTARTS   AGE   IP           NODE                                            NOMINATED NODE   READINESS GATES
cilium-4bws7   1/1     Running   0          62m   10.1.1.96    ip-10-1-1-96.ap-southeast-2.compute.internal    <none>           <none>
cilium-4gsj4   1/1     Running   0          39m   10.1.2.164   ip-10-1-2-164.ap-southeast-2.compute.internal   <none>           <none>
cilium-66dv4   1/1     Running   0          57m   10.1.2.193   ip-10-1-2-193.ap-southeast-2.compute.internal   <none>           <none>
cilium-6zlgz   1/1     Running   0          39m   10.1.1.191   ip-10-1-1-191.ap-southeast-2.compute.internal   <none>           <none>
cilium-7ppc9   1/1     Running   0          39m   10.1.0.156   ip-10-1-0-156.ap-southeast-2.compute.internal   <none>           <none>
cilium-7xj6z   1/1     Running   0          62m   10.1.0.126   ip-10-1-0-126.ap-southeast-2.compute.internal   <none>           <none>
cilium-889mh   1/1     Running   0          57m   10.1.2.90    ip-10-1-2-90.ap-southeast-2.compute.internal    <none>           <none>
cilium-8ntrx   1/1     Running   0          39m   10.1.2.145   ip-10-1-2-145.ap-southeast-2.compute.internal   <none>           <none>
cilium-97jxz   1/1     Running   0          62m   10.1.0.237   ip-10-1-0-237.ap-southeast-2.compute.internal   <none>           <none>
cilium-9pf5k   1/1     Running   0          39m   10.1.1.199   ip-10-1-1-199.ap-southeast-2.compute.internal   <none>           <none>
cilium-b2c2b   1/1     Running   0          39m   10.1.1.146   ip-10-1-1-146.ap-southeast-2.compute.internal   <none>           <none>
cilium-bssjx   1/1     Running   0          39m   10.1.1.175   ip-10-1-1-175.ap-southeast-2.compute.internal   <none>           <none>
cilium-c4h4j   1/1     Running   0          39m   10.1.0.111   ip-10-1-0-111.ap-southeast-2.compute.internal   <none>           <none>
cilium-cqmd6   1/1     Running   0          39m   10.1.2.16    ip-10-1-2-16.ap-southeast-2.compute.internal    <none>           <none>
cilium-dfphb   1/1     Running   0          39m   10.1.1.147   ip-10-1-1-147.ap-southeast-2.compute.internal   <none>           <none>
cilium-fc5dc   1/1     Running   0          39m   10.1.0.166   ip-10-1-0-166.ap-southeast-2.compute.internal   <none>           <none>
cilium-fg86w   1/1     Running   0          62m   10.1.1.17    ip-10-1-1-17.ap-southeast-2.compute.internal    <none>           <none>
cilium-fqm7v   1/1     Running   0          62m   10.1.1.4     ip-10-1-1-4.ap-southeast-2.compute.internal     <none>           <none>
cilium-gn589   1/1     Running   0          62m   10.1.0.131   ip-10-1-0-131.ap-southeast-2.compute.internal   <none>           <none>
cilium-h5jpr   1/1     Running   0          62m   10.1.2.9     ip-10-1-2-9.ap-southeast-2.compute.internal     <none>           <none>
cilium-hklxg   1/1     Running   0          57m   10.1.1.162   ip-10-1-1-162.ap-southeast-2.compute.internal   <none>           <none>
cilium-j49t9   1/1     Running   0          62m   10.1.2.38    ip-10-1-2-38.ap-southeast-2.compute.internal    <none>           <none>
cilium-j9msw   1/1     Running   0          57m   10.1.2.41    ip-10-1-2-41.ap-southeast-2.compute.internal    <none>           <none>
cilium-kkj2k   1/1     Running   0          62m   10.1.2.252   ip-10-1-2-252.ap-southeast-2.compute.internal   <none>           <none>
cilium-mclb2   1/1     Running   0          57m   10.1.1.176   ip-10-1-1-176.ap-southeast-2.compute.internal   <none>           <none>
cilium-mcs5c   1/1     Running   0          57m   10.1.0.19    ip-10-1-0-19.ap-southeast-2.compute.internal    <none>           <none>
cilium-nbbjs   1/1     Running   0          39m   10.1.2.76    ip-10-1-2-76.ap-southeast-2.compute.internal    <none>           <none>
cilium-nkh6r   1/1     Running   0          62m   10.1.1.61    ip-10-1-1-61.ap-southeast-2.compute.internal    <none>           <none>
cilium-pdcfn   1/1     Running   0          57m   10.1.2.47    ip-10-1-2-47.ap-southeast-2.compute.internal    <none>           <none>
cilium-q486w   1/1     Running   0          39m   10.1.0.42    ip-10-1-0-42.ap-southeast-2.compute.internal    <none>           <none>
cilium-q5h5p   1/1     Running   0          39m   10.1.1.204   ip-10-1-1-204.ap-southeast-2.compute.internal   <none>           <none>
cilium-sqfsb   1/1     Running   0          39m   10.1.1.131   ip-10-1-1-131.ap-southeast-2.compute.internal   <none>           <none>
cilium-tbd9v   1/1     Running   0          39m   10.1.0.5     ip-10-1-0-5.ap-southeast-2.compute.internal     <none>           <none>
cilium-tz867   1/1     Running   0          39m   10.1.0.64    ip-10-1-0-64.ap-southeast-2.compute.internal    <none>           <none>
cilium-vggbh   1/1     Running   0          39m   10.1.0.48    ip-10-1-0-48.ap-southeast-2.compute.internal    <none>           <none>
cilium-x24qh   1/1     Running   0          39m   10.1.2.190   ip-10-1-2-190.ap-southeast-2.compute.internal   <none>           <none>
cilium-x2jsk   1/1     Running   0          57m   10.1.0.244   ip-10-1-0-244.ap-southeast-2.compute.internal   <none>           <none>
cilium-xsxx4   1/1     Running   0          57m   10.1.1.158   ip-10-1-1-158.ap-southeast-2.compute.internal   <none>           <none>
cilium-z4qpz   1/1     Running   0          39m   10.1.2.215   ip-10-1-2-215.ap-southeast-2.compute.internal   <none>           <none>
```

</summary>