### PR TITLE
operator: impove handling taints in operator

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -132,6 +132,7 @@ cilium-operator-alibabacloud [flags]
       --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
+      --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
       --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
       --version                                              Print version information

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -140,6 +140,7 @@ cilium-operator-aws [flags]
       --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
+      --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
       --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
       --update-ec2-adapter-limit-via-api                     Use the EC2 API to update the instance type to adapter limits (default true)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -135,6 +135,7 @@ cilium-operator-azure [flags]
       --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
+      --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
       --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
       --version                                              Print version information

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -131,6 +131,7 @@ cilium-operator-generic [flags]
       --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
+      --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
       --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
       --version                                              Print version information

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -145,6 +145,7 @@ cilium-operator [flags]
       --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
+      --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
       --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
       --update-ec2-adapter-limit-via-api                     Use the EC2 API to update the instance type to adapter limits (default true)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)

--- a/clustermesh-apiserver/clustermesh/users_mgmt_test.go
+++ b/clustermesh-apiserver/clustermesh/users_mgmt_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/cilium/cilium/operator/watchers"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -62,13 +61,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestUsersManagement(t *testing.T) {
-	defer func() {
-		// force cleanup of goroutines run from initialization of watchers.nodeQueue,
-		// otherwise goleak complains
-		watchers.NodeQueueShutDown()
-		time.Sleep(50 * time.Millisecond)
-	}()
-
 	var client fakeUserMgmtClient
 	client.init()
 

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -255,6 +255,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(operatorOption.CiliumPodLabels, "k8s-app=cilium", "Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false")
 	option.BindEnv(vp, operatorOption.CiliumPodLabels)
 
+	flags.Int(operatorOption.TaintSyncWorkers, 10, "Number of workers used to synchronize node tains and conditions")
+	option.BindEnv(vp, operatorOption.TaintSyncWorkers)
+
 	flags.Bool(operatorOption.RemoveCiliumNodeTaints, true, fmt.Sprintf("Remove node taint %q from Kubernetes nodes once Cilium is up and running", option.Config.AgentNotReadyNodeTaintValue()))
 	option.BindEnv(vp, operatorOption.RemoveCiliumNodeTaints)
 

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -197,6 +197,10 @@ const (
 	// with.
 	CiliumPodLabels = "cilium-pod-labels"
 
+	// TaintSyncWorkers is the number of workers used to synchronize
+	// taints and conditions in Kubernetes nodes.
+	TaintSyncWorkers = "taint-sync-workers"
+
 	// RemoveCiliumNodeTaints is the flag to define if the Cilium node taint
 	// should be removed in Kubernetes nodes.
 	RemoveCiliumNodeTaints = "remove-cilium-node-taints"
@@ -381,6 +385,10 @@ type OperatorConfig struct {
 	// with.
 	CiliumPodLabels string
 
+	// TaintSyncWorkers is the number of workers used to synchronize
+	// taints and conditions in Kubernetes nodes.
+	TaintSyncWorkers int
+
 	// RemoveCiliumNodeTaints is the flag to define if the Cilium node taint
 	// should be removed in Kubernetes nodes.
 	RemoveCiliumNodeTaints bool
@@ -420,6 +428,7 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 		c.ProxyIdleTimeoutSeconds = DefaultProxyIdleTimeoutSeconds
 	}
 	c.CiliumPodLabels = vp.GetString(CiliumPodLabels)
+	c.TaintSyncWorkers = vp.GetInt(TaintSyncWorkers)
 	c.RemoveCiliumNodeTaints = vp.GetBool(RemoveCiliumNodeTaints)
 	c.SetCiliumNodeTaints = vp.GetBool(SetCiliumNodeTaints)
 	c.SetCiliumIsUpCondition = vp.GetBool(SetCiliumIsUpCondition)

--- a/operator/watchers/cilium_node_gc.go
+++ b/operator/watchers/cilium_node_gc.go
@@ -22,7 +22,11 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
-var ciliumNodeGCControllerGroup = controller.NewGroup("cilium-node-gc")
+var (
+	ciliumNodeGCControllerGroup = controller.NewGroup("cilium-node-gc")
+
+	ctrlMgr = controller.NewManager()
+)
 
 // ciliumNodeGCCandidate keeps track of cilium nodes, which are candidate for GC.
 // Underlying there is a map with node name as key, and last marked timestamp as value.
@@ -58,7 +62,7 @@ func (c *ciliumNodeGCCandidate) Delete(nodeName string) {
 
 // RunCiliumNodeGC performs garbage collector for cilium node resource
 func RunCiliumNodeGC(ctx context.Context, wg *sync.WaitGroup, clientset k8sClient.Clientset, ciliumNodeStore cache.Store, interval time.Duration, logger *slog.Logger) {
-	nodesInit(wg, clientset.Slim(), ctx.Done())
+	nodesInit(wg, clientset.Slim(), ctx.Done(), logger)
 
 	// wait for k8s nodes synced is done
 	select {

--- a/operator/watchers/node_taint.go
+++ b/operator/watchers/node_taint.go
@@ -10,9 +10,9 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -20,12 +20,12 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/operator/option"
-	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	slimclientset "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned"
 	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	pkgOption "github.com/cilium/cilium/pkg/option"
@@ -37,6 +37,8 @@ const (
 	// ciliumNodeConditionReason is the condition name used by Cilium to set
 	// when the Network is setup in the node.
 	ciliumNodeConditionReason = "CiliumIsUp"
+
+	maxSilentRetries = 6
 )
 
 var (
@@ -53,14 +55,10 @@ var (
 
 	queueKeyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
 
-	ctrlMgr = controller.NewManager()
-
 	mno markNodeOptions
-
-	markK8sNodeControllerGroup = controller.NewGroup("mark-k8s-node-taints-conditions")
 )
 
-func checkTaintForNextNodeItem(c kubernetes.Interface, nodeGetter slimNodeGetter, workQueue workqueue.RateLimitingInterface, logger *slog.Logger) bool {
+func checkTaintForNextNodeItem(c kubernetes.Interface, nodeGetter slimNodeGetter, workQueue workqueue.TypedRateLimitingInterface[string], logger *slog.Logger) bool {
 	// Get the next 'key' from the queue.
 	key, quit := workQueue.Get()
 	if quit {
@@ -71,26 +69,39 @@ func checkTaintForNextNodeItem(c kubernetes.Interface, nodeGetter slimNodeGetter
 	// re-processing.
 	defer workQueue.Done(key)
 
-	success := checkAndMarkNode(c, nodeGetter, key.(string), mno, logger)
-	if !success {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err := checkAndMarkNode(ctx, c, nodeGetter, key, mno, logger)
+	handleErr(err, key, workQueue, logger)
+	return true
+}
+
+func handleErr(err error, key string, workQueue workqueue.TypedRateLimitingInterface[string], logger *slog.Logger) {
+	if err == nil {
+		if workQueue.NumRequeues(key) >= maxSilentRetries {
+			logger.Info("Successfully updated tains and conditions for the node", logfields.NodeName, key)
+		}
 		workQueue.Forget(key)
-		return true
+		return
 	}
 
-	// If the event was processed correctly then forget it from the queue.
-	// If we don't do this, the next ".Get()" will always return this 'key'.
-	// It also depends on if the queue has a rate-limiter (not used in this
-	// program)
-	workQueue.Forget(key)
-	return true
+	if workQueue.NumRequeues(key) < maxSilentRetries {
+		logger.Debug("Error updating taints and conditions for the node, will retry", logfields.NodeName, key, logfields.Error, err)
+	} else {
+		logger.Warn("Multiple consecutive retries of updating taints and conditions for a node failed, will retry", logfields.NodeName, key, logfields.Error, err)
+	}
+	workQueue.AddRateLimited(key)
 }
 
 // checkAndMarkNode checks if the node contains a Cilium pod in running state
 // so that it can set the taints / conditions of the node
-func checkAndMarkNode(c kubernetes.Interface, nodeGetter slimNodeGetter, nodeName string, options markNodeOptions, logger *slog.Logger) bool {
+func checkAndMarkNode(ctx context.Context, c kubernetes.Interface, nodeGetter slimNodeGetter, nodeName string, options markNodeOptions, logger *slog.Logger) error {
 	node, err := nodeGetter.GetK8sSlimNode(nodeName)
-	if node == nil || err != nil {
-		return false
+	if err != nil {
+		return err
+	}
+	if node == nil {
+		return nil
 	}
 
 	// should we remove the taint?
@@ -99,26 +110,33 @@ func checkAndMarkNode(c kubernetes.Interface, nodeGetter slimNodeGetter, nodeNam
 		if (options.RemoveNodeTaint && hasAgentNotReadyTaint(node)) ||
 			(options.SetCiliumIsUpCondition && !HasCiliumIsUpCondition(node)) {
 			logger.Info("Cilium pod running for node; marking accordingly", logfields.NodeName, node.GetName())
-
-			markNode(c, nodeGetter, node.GetName(), options, true, logger)
+			return markNode(ctx, c, nodeGetter, node.GetName(), options, true, logger)
 		}
 	} else if scheduled { // Taint nodes where the pod is scheduled but not running
 		if options.SetNodeTaint && !hasAgentNotReadyTaint(node) {
 			logger.Info("Cilium pod scheduled but not running for node; setting taint", logfields.NodeName, node.GetName())
-			markNode(c, nodeGetter, node.GetName(), options, false, logger)
+			return markNode(ctx, c, nodeGetter, node.GetName(), options, false, logger)
 		}
 	}
-	return true
+	return nil
+}
+
+func ciliumPodHandler(obj interface{}, queue workqueue.TypedRateLimitingInterface[string], logger *slog.Logger) {
+	if pod := informer.CastInformerEvent[slim_corev1.Pod](obj); pod != nil {
+		nodeName := pod.Spec.NodeName
+		// Pod might not yet be scheduled to a node
+		if nodeName != "" {
+			queue.Add(nodeName)
+		}
+	}
 }
 
 // ciliumPodsWatcher starts up a pod watcher to handle pod events.
-func ciliumPodsWatcher(wg *sync.WaitGroup, clientset k8sClient.Clientset, stopCh <-chan struct{}, logger *slog.Logger) {
-	ciliumQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cilium-pod-queue")
-
+func ciliumPodsWatcher(wg *sync.WaitGroup, slimClient slimclientset.Interface, queue workqueue.TypedRateLimitingInterface[string], stopCh <-chan struct{}, logger *slog.Logger) {
 	ciliumPodInformer := informer.NewInformerWithStore(
 		k8sUtils.ListerWatcherWithModifier(
 			k8sUtils.ListerWatcherFromTyped[*slim_corev1.PodList](
-				clientset.Slim().CoreV1().Pods(option.Config.CiliumK8sNamespace),
+				slimClient.CoreV1().Pods(option.Config.CiliumK8sNamespace),
 			),
 			func(options *metav1.ListOptions) {
 				options.LabelSelector = option.Config.CiliumPodLabels
@@ -127,74 +145,23 @@ func ciliumPodsWatcher(wg *sync.WaitGroup, clientset k8sClient.Clientset, stopCh
 		0,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				key, _ := queueKeyFunc(obj)
-				ciliumQueue.Add(key)
+				ciliumPodHandler(obj, queue, logger)
 			},
 			UpdateFunc: func(_, newObj interface{}) {
-				key, _ := queueKeyFunc(newObj)
-				ciliumQueue.Add(key)
+				ciliumPodHandler(newObj, queue, logger)
 			},
 		},
 		transformToCiliumPod,
 		ciliumPodsStore,
 	)
 
-	nodeGetter := &nodeGetter{}
-
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		// Do not use the k8sClient provided by the nodesInit function since we
-		// need a k8s client that can update node structures and not simply
-		// watch for node events.
-		for processNextCiliumPodItem(clientset, nodeGetter, ciliumQueue, logger) {
-		}
-	}()
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		defer ciliumQueue.ShutDown()
-
 		ciliumPodInformer.Run(stopCh)
 	}()
-}
 
-func processNextCiliumPodItem(c kubernetes.Interface, nodeGetter slimNodeGetter, workQueue workqueue.RateLimitingInterface, logger *slog.Logger) bool {
-	// Get the next 'key' from the queue.
-	key, quit := workQueue.Get()
-	if quit {
-		return false
-	}
-	// Done marks item as done processing, and if it has been marked as dirty
-	// again while it was being processed, it will be re-added to the queue for
-	// re-processing.
-	defer workQueue.Done(key)
-
-	podInterface, exists, err := ciliumPodsStore.GetByKey(key.(string))
-	if err != nil && !k8sErrors.IsNotFound(err) {
-		return true
-	}
-	if !exists || podInterface == nil {
-		workQueue.Forget(key)
-		return true
-	}
-
-	pod := podInterface.(*slim_corev1.Pod)
-	nodeName := pod.Spec.NodeName
-
-	success := checkAndMarkNode(c, nodeGetter, nodeName, mno, logger)
-	if !success {
-		workQueue.Forget(key)
-		return true
-	}
-
-	// If the event was processed correctly then forget it from the queue.
-	// If we don't do this, the next ".Get()" will always return this 'key'.
-	// It also depends on if the queue has a rate-limiter (not used in this
-	// program)
-	workQueue.Forget(key)
-	return true
+	cache.WaitForCacheSync(stopCh, ciliumPodInformer.HasSynced)
 }
 
 // nodeHasCiliumPod determines if a the node has a Cilium agent pod scheduled
@@ -451,35 +418,27 @@ type markNodeOptions struct {
 
 // markNode marks the Kubernetes node depending on the modes that it is passed
 // on.
-func markNode(c kubernetes.Interface, nodeGetter slimNodeGetter, nodeName string, options markNodeOptions, running bool, logger *slog.Logger) {
-	ctrlName := fmt.Sprintf("mark-k8s-node-%s-taints-conditions", nodeName)
+func markNode(ctx context.Context, c kubernetes.Interface, nodeGetter slimNodeGetter, nodeName string, options markNodeOptions, running bool, logger *slog.Logger) error {
+	if running && options.RemoveNodeTaint {
+		err := removeNodeTaint(ctx, c, nodeGetter, nodeName, logger)
+		if err != nil {
+			return err
+		}
+	}
+	if running && options.SetCiliumIsUpCondition {
+		err := setNodeNetworkUnavailableFalse(ctx, c, nodeGetter, nodeName, logger)
+		if err != nil {
+			return err
+		}
+	}
+	if !running && options.SetNodeTaint {
+		err := setNodeTaint(ctx, c, nodeGetter, nodeName, logger)
+		if err != nil {
+			return err
+		}
+	}
 
-	ctrlMgr.UpdateController(ctrlName,
-		controller.ControllerParams{
-			Group: markK8sNodeControllerGroup,
-			DoFunc: func(ctx context.Context) error {
-				if running && options.RemoveNodeTaint {
-					err := removeNodeTaint(ctx, c, nodeGetter, nodeName, logger)
-					if err != nil {
-						return err
-					}
-				}
-				if running && options.SetCiliumIsUpCondition {
-					err := setNodeNetworkUnavailableFalse(ctx, c, nodeGetter, nodeName, logger)
-					if err != nil {
-						return err
-					}
-				}
-				if !running && options.SetNodeTaint {
-					err := setNodeTaint(ctx, c, nodeGetter, nodeName, logger)
-					if err != nil {
-						return err
-					}
-				}
-
-				return nil
-			},
-		})
+	return nil
 }
 
 // HandleNodeTolerationAndTaints remove node
@@ -489,17 +448,24 @@ func HandleNodeTolerationAndTaints(wg *sync.WaitGroup, clientset k8sClient.Clien
 		SetNodeTaint:           option.Config.SetCiliumNodeTaints,
 		SetCiliumIsUpCondition: option.Config.SetCiliumIsUpCondition,
 	}
-	nodesInit(wg, clientset.Slim(), stopCh)
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		// Do not use the k8sClient provided by the nodesInit function since we
-		// need a k8s client that can update node structures and not simply
-		// watch for node events.
-		for checkTaintForNextNodeItem(clientset, &nodeGetter{}, nodeQueue, logger) {
-		}
-	}()
+	nodesInit(wg, clientset.Slim(), stopCh, logger)
+	// ciliumPodWatcher blocks waiting for cache sync.
+	// we need to do it before starting worker threads
+	// so checkAndMarkNode has cilium-pod information.
+	// Additionally, we pass nodeQueue to ciliumPodWatcher.
+	// that was initialized in nodesInit.
+	ciliumPodsWatcher(wg, clientset.Slim(), nodeQueue, stopCh, logger)
 
-	ciliumPodsWatcher(wg, clientset, stopCh, logger)
+	for i := 1; i <= option.Config.TaintSyncWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Do not use the k8sClient provided by the nodesInit function since we
+			// need a k8s client that can update node structures and not simply
+			// watch for node events.
+			for checkTaintForNextNodeItem(clientset, &nodeGetter{}, nodeQueue, logger) {
+			}
+		}()
+	}
 }


### PR DESCRIPTION
Previously, during each upgrade of Cilium, operator had to taint and
untaint nodes whenever Cilium was scheduled and then running.
Hovewer, at large clusters, this resulted in multiple parallel requests
that were rate-limited on client-go in case of low qps.
This resulted in a huge queue of updates pending with stale node
information.
While simple mitigation of increasing qps works, we should cap max
number of requests that operator issues at a given time to reduce
staleness of node information. Additionally, it prevents starving other
clients of client-go.

This commit introduces workers that synchronize taint information
instead of relying on unbounded number of controllers.
Additionally, we merge node and pod update queues into a single
workqueue.

```release-note
operator: improve the responsiveness of tainting and setting conditions on k8s nodes
```
