### PR TITLE
pkg/redirectpolicy: Delete unused variable in getAndUpsertPolicySvcCo…

### DIFF
--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -499,10 +499,6 @@ func (rpm *Manager) getAndUpsertPolicySvcConfig(config *LRPConfig) error {
 
 	case svcFrontendNamedPorts:
 		// Get service frontends with the clusterIP and the policy config named ports.
-		ports := make([]string, len(config.frontendMappings))
-		for i, mapping := range config.frontendMappings {
-			ports[i] = mapping.fePort
-		}
 		ip := rpm.svcCache.GetServiceFrontendIP(*config.serviceID, lb.SVCTypeClusterIP)
 		if ip == nil {
 			// The LRP will be applied when the selected service is added later.


### PR DESCRIPTION
In the handler of case svcFrontendNamedPorts, the "ports" is allocated and assigned with values, but never used. Thus, delete the related code.

Fixes: e7bb8a7eadb5 ("k8s/cilium Event handlers and processing logic for LRPs")