### PR TITLE
daemon: Reduce level of socket LB tracing warning

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -306,7 +306,7 @@ func probeKubeProxyReplacementOptions(sysctl sysctl.Sysctl) error {
 		if option.Config.EnableSocketLBTracing {
 			if probes.HaveProgramHelper(ebpf.CGroupSockAddr, asm.FnPerfEventOutput) != nil {
 				option.Config.EnableSocketLBTracing = false
-				log.Warn("Disabling socket-LB tracing as it requires kernel 5.7 or newer")
+				log.Info("Disabling socket-LB tracing as it requires kernel 5.7 or newer")
 			}
 		}
 


### PR DESCRIPTION
This warning is emitted when the kernel doesn't support socket-level LB tracing. That feature is however enabled by default and only kernels 5.7+ support it. That means this warning will be displayed by default to a lot of users.

This commit reduces the log level to Info to avoid that and to be consistent with other advanced features that are enabled by default.