### PR TITLE
cilium-cli/connectivity: fix nil-pointer dereference if minimum version can't be detected

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -5,6 +5,7 @@ package check
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"net"
@@ -904,13 +905,16 @@ func (ct *ConnectivityTest) DetectMinimumCiliumVersion(ctx context.Context) (*se
 	for name, ciliumPod := range ct.ciliumPods {
 		podVersion, err := ciliumPod.K8sClient.GetCiliumVersion(ctx, ciliumPod.Pod)
 		if err != nil {
-			return nil, fmt.Errorf("unable to parse cilium version on pod %q: %w", name, err)
+			return nil, fmt.Errorf("unable to parse Cilium version on pod %q: %w", name, err)
 		}
 		if minVersion == nil || podVersion.LT(*minVersion) {
 			minVersion = podVersion
 		}
 	}
 
+	if minVersion == nil {
+		return nil, errors.New("unable to detect minimum Cilium version")
+	}
 	return minVersion, nil
 }
 


### PR DESCRIPTION
Currently, when for some reason the minimum Cilium version cannot be detected from the running Cilium pods, a nil-pointer dereference will occur:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x242ef5b]

goroutine 100 [running]:
github.com/cilium/cilium-cli/connectivity/check.(*ConnectivityTest).detectCiliumVersion(0xc0003d8600, {0x39fb080?, 0xc000b8a800?})
	/cilium/connectivity/check/features.go:511 +0x37b
github.com/cilium/cilium-cli/connectivity/check.(*ConnectivityTest).SetupAndValidate(0xc0003d8600, {0x39fb080, 0xc000b8a800?}, 0xc001031f98)
	/cilium/connectivity/check/context.go:275 +0xd2
github.com/cilium/cilium-cli/connectivity.Run({0x39fb080, 0xc000b8a800}, 0xc0003d8600, 0xc001031fb0, 0xc001021f98?)
	/cilium/connectivity/suite.go:174 +0x68
github.com/cilium/cilium-cli/internal/cli/cmd.newCmdConnectivityTest.func1.2()
	/cilium/internal/cli/cmd/connectivity.go:93 +0xe9
created by github.com/cilium/cilium-cli/internal/cli/cmd.newCmdConnectivityTest.func1
	/cilium/internal/cli/cmd/connectivity.go:91 +0x61d
```

Fix this by returning an error from
`(*ConnectivityTest).DetectMinimumCiliumVersion` in case the minimum Cilium version couldn't be detected, so the
`(*ConnectivityTest).detectCiliumVersion` will not try to dereference the returned nil pointer and take the fallback path instead.

Fixes #35800