### PR TITLE
policy/api: don't write zero enableDefaultDeny field

### DIFF
--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -140,24 +140,28 @@ type Rule struct {
 // enforce omitempty on the EndpointSelector nested structures.
 func (r *Rule) MarshalJSON() ([]byte, error) {
 	type common struct {
-		Ingress           []IngressRule     `json:"ingress,omitempty"`
-		IngressDeny       []IngressDenyRule `json:"ingressDeny,omitempty"`
-		Egress            []EgressRule      `json:"egress,omitempty"`
-		EgressDeny        []EgressDenyRule  `json:"egressDeny,omitempty"`
-		Labels            labels.LabelArray `json:"labels,omitempty"`
-		EnableDefaultDeny DefaultDenyConfig `json:"enableDefaultDeny,omitempty"`
-		Description       string            `json:"description,omitempty"`
+		Ingress           []IngressRule      `json:"ingress,omitempty"`
+		IngressDeny       []IngressDenyRule  `json:"ingressDeny,omitempty"`
+		Egress            []EgressRule       `json:"egress,omitempty"`
+		EgressDeny        []EgressDenyRule   `json:"egressDeny,omitempty"`
+		Labels            labels.LabelArray  `json:"labels,omitempty"`
+		EnableDefaultDeny *DefaultDenyConfig `json:"enableDefaultDeny,omitempty"`
+		Description       string             `json:"description,omitempty"`
 	}
 
 	var a interface{}
 	ruleCommon := common{
-		Ingress:           r.Ingress,
-		IngressDeny:       r.IngressDeny,
-		Egress:            r.Egress,
-		EgressDeny:        r.EgressDeny,
-		Labels:            r.Labels,
-		EnableDefaultDeny: r.EnableDefaultDeny,
-		Description:       r.Description,
+		Ingress:     r.Ingress,
+		IngressDeny: r.IngressDeny,
+		Egress:      r.Egress,
+		EgressDeny:  r.EgressDeny,
+		Labels:      r.Labels,
+		Description: r.Description,
+	}
+
+	// TODO: convert this to `omitzero` when Go v1.24 is released
+	if r.EnableDefaultDeny.Egress != nil || r.EnableDefaultDeny.Ingress != nil {
+		ruleCommon.EnableDefaultDeny = &r.EnableDefaultDeny
 	}
 
 	// Only one of endpointSelector or nodeSelector is permitted.


### PR DESCRIPTION
Before this change, marshalling policy to a struct caused the line `... "enableDefaultDeny":{}, ...` to be written to json-marshalled network policy. This later caused problems when using cilium-cli with cluster versions that do not support the `enableDefaultDeny` field.

This can be replaced with a `omitzero` modifier on the json struct tag once go1.24 is released. Until then, we can work around this with a simple pointer instead.
