### PR TITLE
ipsec: Fix key derivation regression due to boot IDs

### DIFF
--- a/.github/actions/ipsec-key-rotate/action.yaml
+++ b/.github/actions/ipsec-key-rotate/action.yaml
@@ -5,14 +5,6 @@ inputs:
     required: true
     type: string
     description: "gcm(aes) or cbc(aes)"
-  key-type-one:
-    required: true
-    type: string
-    description: "'+' if we started with the per-tunnel key system"
-  key-type-two:
-    required: true
-    type: string
-    description: "'+' to rotate to the per-tunnel key system"
   encryption-overlay:
     required: true
     type: string
@@ -33,30 +25,14 @@ runs:
         else
           echo "Invalid key type"; exit 1
         fi
-        data="{\"stringData\":{\"keys\":\"$((($KEYID+1)))${{ inputs.key-type-two }} ${key}\"}}"
+        data="{\"stringData\":{\"keys\":\"$((($KEYID+1)))+ ${key}\"}}"
 
         echo "Updating IPsec secret with $data"
         kubectl patch secret -n kube-system cilium-ipsec-keys -p="$data" -v=1
 
-        # Compute number of expected keys during key rotation depending on
-        # whether we use the single-key system (1 key) or the per-tunnel
-        # keys system (8 keys, 2x2 IPv4 and 2x2 IPv6).
-        # If encryption-overlay is enabled, we have 4 more IPv4 keys for the overlay.
-        # Transition from single-key to per-tunnel keys goes like this 1 > 9(13) > 8(12).
-        # Transition from per-tunnel to single-key goes like this 8(12) > 9(13) > 1.
-        # Transition from per-tunnel keys to per-tunnel keys goes like this 8(12) > 16(24) > 8(12).
-        exp_nb_keys=2
-        if [[ "${{ inputs.key-type-one }}" == "+" ]]; then
-          ((exp_nb_keys+=7))
-          if [[ "${{ inputs.encryption-overlay }}" == "true" ]]; then
-            ((exp_nb_keys+=4))
-          fi
-        fi
-        if [[ "${{ inputs.key-type-two }}" == "+" ]]; then
-          ((exp_nb_keys+=7))
-          if [[ "${{ inputs.encryption-overlay }}" == "true" ]]; then
-            ((exp_nb_keys+=4))
-          fi
+        exp_nb_keys=16
+        if [[ "${{ inputs.encryption-overlay }}" == "true" ]]; then
+          ((exp_nb_keys+=8))
         fi
 
         # Wait until key rotation starts
@@ -70,12 +46,9 @@ runs:
           sleep 30s
         done
 
-        exp_nb_keys=1
-        if [[ "${{ inputs.key-type-two }}" == "+" ]]; then
-          exp_nb_keys=8
-          if [[ "${{ inputs.encryption-overlay }}" == "true" ]]; then
-            exp_nb_keys=12
-          fi
+        exp_nb_keys=8
+        if [[ "${{ inputs.encryption-overlay }}" == "true" ]]; then
+          exp_nb_keys=12
         fi
 
         # Wait until key rotation completes

--- a/.github/actions/ipsec-key-rotate/action.yaml
+++ b/.github/actions/ipsec-key-rotate/action.yaml
@@ -9,6 +9,14 @@ inputs:
     required: true
     type: string
     description: "'true' if encryption-overlay is enabled"
+  nb-nodes:
+    required: true
+    type: string
+    description: "Number of nodes in the cluster or clustermesh"
+  ipv6:
+    required: true
+    type: boolean
+    description: "Whether IPv6 is enabled. Note IPv4 is always enabled if IPsec is enabled."
 runs:
   using: composite
   steps:
@@ -30,10 +38,18 @@ runs:
         echo "Updating IPsec secret with $data"
         kubectl patch secret -n kube-system cilium-ipsec-keys -p="$data" -v=1
 
-        exp_nb_keys=16
-        if [[ "${{ inputs.encryption-overlay }}" == "true" ]]; then
-          ((exp_nb_keys+=8))
+        # We have two keys per node, per direction, per IP family. So a two-nodes IPv4-only cluster
+        # will have four keys. If encryption-overlay is enabled, we have 4 more IPv4 keys for the
+        # overlay. During the key rotation, the number of keys doubles.
+        exp_nb_keys=${{ inputs.nb-nodes }}
+        ((exp_nb_keys*=2))
+        if [[ "${{ inputs.ipv6 }}" == "true" ]]; then
+          ((exp_nb_keys*=2))
         fi
+        if [[ "${{ inputs.encryption-overlay }}" == "true" ]]; then
+          ((exp_nb_keys+=4))
+        fi
+        ((exp_nb_keys*=2))
 
         # Wait until key rotation starts
         # We expect the amount of keys in use to grow during rotation.
@@ -46,10 +62,9 @@ runs:
           sleep 30s
         done
 
-        exp_nb_keys=8
-        if [[ "${{ inputs.encryption-overlay }}" == "true" ]]; then
-          exp_nb_keys=12
-        fi
+        # After the key rotation is finished and old keys are cleaned up, the number of keys is
+        # halved.
+        ((exp_nb_keys/=2))
 
         # Wait until key rotation completes
         # By default the key rotation cleanup delay is 5min, let's sleep 4min before actively polling

--- a/.github/actions/ipsec/configs.yaml
+++ b/.github/actions/ipsec/configs.yaml
@@ -6,8 +6,6 @@
   tunnel: 'vxlan'
   key-one: 'gcm(aes)'
   key-two: 'cbc(aes)'
-  key-type-one: '+'
-  key-type-two: '+'
 - name: '2'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   kernel: '5.4-20240710.064909'
@@ -16,8 +14,6 @@
   tunnel: 'disabled'
   key-one: 'cbc(aes)'
   key-two: 'cbc(aes)'
-  key-type-one: '+'
-  key-type-two: ''
 - name: '3'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   kernel: '5.10-20240710.064909'
@@ -27,8 +23,6 @@
   endpoint-routes: 'true'
   key-one: 'gcm(aes)'
   key-two: 'gcm(aes)'
-  key-type-one: ''
-  key-type-two: '+'
 - name: '4'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   kernel: 'bpf-next-20240711.013133'
@@ -38,8 +32,6 @@
   endpoint-routes: 'true'
   key-one: 'cbc(aes)'
   key-two: 'gcm(aes)'
-  key-type-one: ''
-  key-type-two: ''
 - name: '5'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   kernel: '5.4-20240710.064909'
@@ -48,8 +40,6 @@
   tunnel: 'disabled'
   key-one: 'cbc(aes)'
   key-two: 'cbc(aes)'
-  key-type-one: '+'
-  key-type-two: '+'
 - name: '6'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   kernel: '5.10-20240710.064909'
@@ -61,8 +51,6 @@
   ingress-controller: 'true'
   key-one: 'gcm(aes)'
   key-two: 'gcm(aes)'
-  key-type-one: '+'
-  key-type-two: '+'
 - name: '7'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   kernel: '5.15-20240710.064909'
@@ -72,8 +60,6 @@
   encryption-overlay: 'true'
   key-one: 'gcm(aes)'
   key-two: 'gcm(aes)'
-  key-type-one: '+'
-  key-type-two: '+'
 - name: '8'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   kernel: 'bpf-next-20240711.013133'
@@ -84,5 +70,3 @@
   ingress-controller: 'true'
   key-one: 'gcm(aes)'
   key-two: 'gcm(aes)'
-  key-type-one: '+'
-  key-type-two: '+'

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -359,8 +359,6 @@ jobs:
         uses: ./.github/actions/ipsec-key-rotate
         with:
           key-algo: "gcm(aes)"
-          key-type-one: ""
-          key-type-two: ""
 
       - name: Check conn-disrupt-test after rotating (${{ join(matrix.*, ', ') }})
         if: ${{ matrix.ipsec == true }}

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -359,6 +359,8 @@ jobs:
         uses: ./.github/actions/ipsec-key-rotate
         with:
           key-algo: "gcm(aes)"
+          nb-nodes: 3
+          ipv6: false
 
       - name: Check conn-disrupt-test after rotating (${{ join(matrix.*, ', ') }})
         if: ${{ matrix.ipsec == true }}

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -267,7 +267,7 @@ jobs:
         shell: bash
         run: |
           KEYID=15
-          kubectl create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="${KEYID} rfc4106(gcm(aes)) $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64) 128"
+          kubectl create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="${KEYID}+ rfc4106(gcm(aes)) $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64) 128"
 
       - name: Wait for images to be available
         timeout-minutes: 30

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -230,7 +230,7 @@ jobs:
             echo "Invalid key type"; exit 1
           fi
           kubectl create -n kube-system secret generic cilium-ipsec-keys \
-            --from-literal=keys="3${{ matrix.key-type-one }} ${key}"
+            --from-literal=keys="3+ ${key}"
 
           cilium install ${{ steps.cilium-config.outputs.config }}
           kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-server --timeout=300s
@@ -304,8 +304,6 @@ jobs:
         uses: ./.github/actions/ipsec-key-rotate
         with:
           key-algo: ${{ matrix.key-two }}
-          key-type-one: ${{ matrix.key-type-one }}
-          key-type-two: ${{ matrix.key-type-two }}
           encryption-overlay: ${{ matrix.encryption-overlay }}
 
       - name: Assert that no unencrypted packets are leaked during key rotation

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -305,6 +305,8 @@ jobs:
         with:
           key-algo: ${{ matrix.key-two }}
           encryption-overlay: ${{ matrix.encryption-overlay }}
+          nb-nodes: 2
+          ipv6: true
 
       - name: Assert that no unencrypted packets are leaked during key rotation
         uses: ./.github/actions/bpftrace/check

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -102,7 +102,7 @@ jobs:
         id: generate-matrix
         run: |
           cd /tmp/generated/ipsec
-          jq '[.[] | del(."key-one", ."key-two", ."key-type-one", ."key-type-two") | . as $entry | [$entry + {mode: "minor"}, $entry + {mode: "patch"}]] | flatten' configs.json > matrix.json
+          jq '[.[] | del(."key-one", ."key-two") | . as $entry | [$entry + {mode: "minor"}, $entry + {mode: "patch"}]] | flatten' configs.json > matrix.json
           echo "Generated matrix:"
           cat /tmp/generated/ipsec/matrix.json
           echo "matrix=$(jq -c . < /tmp/generated/ipsec/matrix.json)" >> $GITHUB_OUTPUT

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -301,7 +301,7 @@ func deriveNodeIPsecKey(globalKey *ipSecKey, srcNodeIP, dstNodeIP net.IP, srcBoo
 // This is done such that, for each pair of nodes A, B, the key used for
 // decryption on A (XFRM IN) is the same key used for encryption on B (XFRM
 // OUT), and vice versa. And its ESN automatically resets on each node reboot.
-func getNodeIPsecKey(localNodeIP, remoteNodeIP net.IP, localBootID, remoteBootID string) *ipSecKey {
+func getNodeIPsecKey(localNodeIP, remoteNodeIP net.IP, srcBootID, dstBootID string) *ipSecKey {
 	globalKey := getGlobalIPsecKey(localNodeIP)
 	if globalKey == nil {
 		return nil
@@ -310,7 +310,7 @@ func getNodeIPsecKey(localNodeIP, remoteNodeIP net.IP, localBootID, remoteBootID
 		return globalKey
 	}
 
-	return deriveNodeIPsecKey(globalKey, localNodeIP, remoteNodeIP, localBootID, remoteBootID)
+	return deriveNodeIPsecKey(globalKey, localNodeIP, remoteNodeIP, srcBootID, dstBootID)
 }
 
 func ipSecNewState(keys *ipSecKey) *netlink.XfrmState {
@@ -538,7 +538,7 @@ func xfrmKeyEqual(s1, s2 *netlink.XfrmState) bool {
 }
 
 func ipSecReplaceStateIn(log *slog.Logger, params *IPSecParameters) (uint8, error) {
-	key := getNodeIPsecKey(*params.SourceTunnelIP, *params.DestTunnelIP, params.LocalBootID, params.RemoteBootID)
+	key := getNodeIPsecKey(*params.SourceTunnelIP, *params.DestTunnelIP, params.RemoteBootID, params.LocalBootID)
 	if key == nil {
 		return 0, fmt.Errorf("IPSec key missing")
 	}


### PR DESCRIPTION
See commit descriptions. This bug made it only into a pre-release for v1.17.

Fixes: #35210.
```release-note
Fix bug that would break all pod-to-pod connectivity when using the per-tunnel IPsec key system.
```