### PR TITLE
ci: add watch request thresholds

### DIFF
--- a/.github/actions/cl2-modules/cilium-metrics.yaml
+++ b/.github/actions/cl2-modules/cilium-metrics.yaml
@@ -6,6 +6,9 @@
 {{$MEDIAN_MEM_USAGE_THRESHOLD := DefaultParam .CL2_MEDIAN_MEM_USAGE_THRESHOLD 250}}
 {{$MEDIAN_BOOTSTRAP_THRESHOLD := DefaultParam .CL2_MEDIAN_BOOTSTRAP_THRESHOLD 5}}
 
+{{$DEFAULT_WATCH_THRESHOLD := .Nodes}}
+{{$DEFAULT_WATCH_THRESHOLD_INCREASE := 20}}
+
 steps:
   - name: {{$action}} Cilium Agent Policy implementation delay
     measurements:
@@ -91,3 +94,54 @@ steps:
         - name: Perc50
           query: quantile(0.5, cilium_agent_bootstrap_seconds_sum{scope="overall"})
           threshold: {{$MEDIAN_BOOTSTRAP_THRESHOLD}}
+
+    - Identifier: WatchRequestThresholds
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: Watch request thresholds
+        metricVersion: v1
+        unit: count
+        enableViolations: true
+        queries:
+        - name: Services
+          query: sum(apiserver_longrunning_requests{scope="cluster", verb="WATCH", resource="services"})
+          # TODO: Should be 2x not 3x - https://github.com/cilium/cilium/issues/35797
+          threshold: {{AddInt (MultiplyInt $DEFAULT_WATCH_THRESHOLD 3) $DEFAULT_WATCH_THRESHOLD_INCREASE}}
+        - name: EndpointSlices
+          query: sum(apiserver_longrunning_requests{scope="cluster", verb="WATCH", resource="endpointslices"})
+          # TODO: Should be 1x not 2x - https://github.com/cilium/cilium/issues/35797
+          threshold: {{AddInt (MultiplyInt $DEFAULT_WATCH_THRESHOLD 2) $DEFAULT_WATCH_THRESHOLD_INCREASE}}
+        - name: Endpoints
+          query: sum(apiserver_longrunning_requests{scope="cluster", verb="WATCH", resource="endpoints"})
+          threshold: {{$DEFAULT_WATCH_THRESHOLD_INCREASE}}
+        - name: Pods
+          query: sum(apiserver_longrunning_requests{scope="cluster", verb="WATCH", resource="pods"})
+          # There is no way to differentiate if we are watching all pods or node's pods easily
+          # Additionally, kubelet also watches node's pods.
+          threshold: {{AddInt (MultiplyInt $DEFAULT_WATCH_THRESHOLD 2) $DEFAULT_WATCH_THRESHOLD_INCREASE}}
+        - name: CCNPs
+          query: sum(apiserver_longrunning_requests{scope="cluster", verb="WATCH", resource="ciliumclusterwidenetworkpolicies"})
+          threshold: {{AddInt $DEFAULT_WATCH_THRESHOLD $DEFAULT_WATCH_THRESHOLD_INCREASE}}
+        - name: CNPs
+          query: sum(apiserver_longrunning_requests{scope="cluster", verb="WATCH", resource="ciliumnetworkpolicies"})
+          threshold: {{AddInt $DEFAULT_WATCH_THRESHOLD $DEFAULT_WATCH_THRESHOLD_INCREASE}}
+        - name: NetworkPolicies
+          query: sum(apiserver_longrunning_requests{scope="cluster", verb="WATCH", resource="networkpolicies"})
+          threshold: {{AddInt $DEFAULT_WATCH_THRESHOLD $DEFAULT_WATCH_THRESHOLD_INCREASE}}
+        - name: Namespaces
+          query: sum(apiserver_longrunning_requests{scope="cluster", verb="WATCH", resource="namespaces"})
+          threshold: {{AddInt $DEFAULT_WATCH_THRESHOLD $DEFAULT_WATCH_THRESHOLD_INCREASE}}
+        - name: CiliumIdentities
+          query: sum(apiserver_longrunning_requests{scope="cluster", verb="WATCH", resource="ciliumidentities"})
+          threshold: {{AddInt $DEFAULT_WATCH_THRESHOLD $DEFAULT_WATCH_THRESHOLD_INCREASE}}
+        - name: CiliumCIDRGroups
+          query: sum(apiserver_longrunning_requests{scope="cluster", verb="WATCH", resource="ciliumcidrgroups"})
+          threshold: {{AddInt $DEFAULT_WATCH_THRESHOLD $DEFAULT_WATCH_THRESHOLD_INCREASE}}
+        - name: CiliumEndpointsAndSlices
+          # We should only watch CEP or CES, but not both
+          query: sum(apiserver_longrunning_requests{scope="cluster", verb="WATCH", resource=~"ciliumendpoints|ciliumendpointslices"})
+          threshold: {{AddInt $DEFAULT_WATCH_THRESHOLD $DEFAULT_WATCH_THRESHOLD_INCREASE}}
+        - name: CiliumNodes
+          query: sum(apiserver_longrunning_requests{scope="cluster", verb="WATCH", resource="ciliumnodes"})
+          threshold: {{AddInt $DEFAULT_WATCH_THRESHOLD $DEFAULT_WATCH_THRESHOLD_INCREASE}}


### PR DESCRIPTION
Related: #35797

To prevent regressions with interactions with k8s apiserver, let's introduce checks to ensure we are not duplicating watchers to k8s apiservers.

Example output from run https://github.com/cilium/cilium/actions/runs/11703820585/job/32594959446:
```
metric: Watch request thresholds: Services, value: 317, threshold: 320 (upper bound)
metric: Watch request thresholds: Endpoints, value: 2, threshold: 10 (upper bound)
metric: Watch request thresholds: EndpointSlices, value: 212, threshold: 220 (upper bound)
metric: Watch request thresholds: Pods, value: 212, threshold: 220 (upper bound)
metric: Watch request thresholds: CCNPs, value: 105, threshold: 120 (upper bound)
metric: Watch request thresholds: CNPs, value: 105, threshold: 120 (upper bound)
metric: Watch request thresholds: NetworkPolicies, value: 103, threshold: 120 (upper bound)
metric: Watch request thresholds: Namespaces, value: 115, threshold: 120 (upper bound)
metric: Watch request thresholds: CiliumIdentities, value: 104, threshold: 120 (upper bound)
metric: Watch request thresholds: CiliumCIDRGroups, value: 103, threshold: 120 (upper bound)
metric: Watch request thresholds: CiliumEndpointsAndSlices, value: 105, threshold: 120 (upper bound)
metric: Watch request thresholds: CiliumNodes, value: 105, threshold: 120 (upper bound)
```