### PR TITLE
experimental: ShadowInstances from many sources

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -67,6 +67,7 @@ import (
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/signal"
+	"github.com/cilium/cilium/pkg/source"
 )
 
 var (
@@ -306,6 +307,9 @@ var (
 		// configuration to describe, in form of prometheus metrics, which
 		// features are enabled on the agent.
 		features.Cell,
+
+		// Determines priorities of data sources.
+		source.Cell,
 	)
 )
 

--- a/pkg/ciliumenvoyconfig/exp_test.go
+++ b/pkg/ciliumenvoyconfig/exp_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -50,6 +51,7 @@ func TestScript(t *testing.T) {
 			cell.Provide(
 				tables.NewNodeAddressTable,
 				statedb.RWTable[tables.NodeAddress].ToTable,
+				source.NewSources,
 				func() *option.DaemonConfig {
 					return &option.DaemonConfig{
 						EnableIPv4:        true,

--- a/pkg/loadbalancer/experimental/benchmark_test.go
+++ b/pkg/loadbalancer/experimental/benchmark_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package experimental_test
+package experimental
 
 import (
 	"encoding/binary"
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/loadbalancer"
-	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
 	"github.com/cilium/cilium/pkg/source"
 )
 
@@ -43,11 +42,11 @@ func benchmark_UpsertServiceAndFrontends(b *testing.B, numObjects int) {
 		addrCluster, _ := types.AddrClusterFromIP(addr1[:])
 		p.Writer.UpsertServiceAndFrontends(
 			wtxn,
-			&experimental.Service{
+			&Service{
 				Name:   name,
 				Source: source.Kubernetes,
 			},
-			experimental.FrontendParams{
+			FrontendParams{
 				Address:     *loadbalancer.NewL3n4Addr(loadbalancer.TCP, addrCluster, 12345, loadbalancer.ScopeExternal),
 				Type:        loadbalancer.SVCTypeClusterIP,
 				PortName:    "foo",
@@ -70,11 +69,11 @@ func benchmark_UpsertServiceAndFrontends(b *testing.B, numObjects int) {
 			addrCluster, _ := types.AddrClusterFromIP(addr1[:])
 			p.Writer.UpsertServiceAndFrontends(
 				wtxn,
-				&experimental.Service{
+				&Service{
 					Name:   name,
 					Source: source.Kubernetes,
 				},
-				experimental.FrontendParams{
+				FrontendParams{
 					Address:  *loadbalancer.NewL3n4Addr(loadbalancer.TCP, addrCluster, 12345, loadbalancer.ScopeExternal),
 					Type:     loadbalancer.SVCTypeClusterIP,
 					PortName: "",
@@ -99,11 +98,11 @@ func BenchmarkInsertBackend(b *testing.B) {
 
 	p.Writer.UpsertServiceAndFrontends(
 		wtxn,
-		&experimental.Service{
+		&Service{
 			Name:   name,
 			Source: source.Kubernetes,
 		},
-		experimental.FrontendParams{
+		FrontendParams{
 			Address:  *loadbalancer.NewL3n4Addr(loadbalancer.TCP, addrCluster1, 12345, loadbalancer.ScopeExternal),
 			Type:     loadbalancer.SVCTypeClusterIP,
 			PortName: "",
@@ -125,7 +124,7 @@ func BenchmarkInsertBackend(b *testing.B) {
 				wtxn,
 				name,
 				source.Kubernetes,
-				experimental.BackendParams{
+				BackendParams{
 					L3n4Addr: beAddr,
 					State:    loadbalancer.BackendStateActive,
 				},
@@ -150,11 +149,11 @@ func BenchmarkReplaceBackend(b *testing.B) {
 
 	p.Writer.UpsertServiceAndFrontends(
 		wtxn,
-		&experimental.Service{
+		&Service{
 			Name:   name,
 			Source: source.Kubernetes,
 		},
-		experimental.FrontendParams{
+		FrontendParams{
 			Address:  *loadbalancer.NewL3n4Addr(loadbalancer.TCP, addrCluster1, 12345, loadbalancer.ScopeExternal),
 			Type:     loadbalancer.SVCTypeClusterIP,
 			PortName: "",
@@ -166,7 +165,7 @@ func BenchmarkReplaceBackend(b *testing.B) {
 		wtxn,
 		name,
 		source.Kubernetes,
-		experimental.BackendParams{
+		BackendParams{
 			L3n4Addr: beAddr,
 			State:    loadbalancer.BackendStateActive,
 		},
@@ -180,7 +179,7 @@ func BenchmarkReplaceBackend(b *testing.B) {
 			wtxn,
 			name,
 			source.Kubernetes,
-			experimental.BackendParams{
+			BackendParams{
 				L3n4Addr: beAddr,
 				State:    loadbalancer.BackendStateActive,
 			},
@@ -203,11 +202,11 @@ func BenchmarkReplaceService(b *testing.B) {
 
 	p.Writer.UpsertServiceAndFrontends(
 		wtxn,
-		&experimental.Service{
+		&Service{
 			Name:   name,
 			Source: source.Kubernetes,
 		},
-		experimental.FrontendParams{
+		FrontendParams{
 			Address:  l3n4Addr,
 			Type:     loadbalancer.SVCTypeClusterIP,
 			PortName: "",
@@ -223,11 +222,11 @@ func BenchmarkReplaceService(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		p.Writer.UpsertServiceAndFrontends(
 			wtxn,
-			&experimental.Service{
+			&Service{
 				Name:   name,
 				Source: source.Kubernetes,
 			},
-			experimental.FrontendParams{
+			FrontendParams{
 				Address:     l3n4Addr,
 				Type:        loadbalancer.SVCTypeClusterIP,
 				PortName:    "",

--- a/pkg/loadbalancer/experimental/bpf_reconciler.go
+++ b/pkg/loadbalancer/experimental/bpf_reconciler.go
@@ -955,8 +955,8 @@ func (ops *BPFOps) computeMaglevTable(svc *Service, bes []BackendWithRevision) (
 			return nil, fmt.Errorf("local id for address %s not found: %w", output.L3n4Addr.String(), err)
 		}
 		output.ID = loadbalancer.BackendID(id)
-		instance, ok := be.Instances.Get(svc.Name)
-		if !ok {
+		instance := be.GetInstance(svc.Name)
+		if instance == nil {
 			return nil, fmt.Errorf("instance of backend %q for service %q not found", be.String(), svc.Name.String())
 		}
 		output.Weight = instance.Weight

--- a/pkg/loadbalancer/experimental/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/experimental/bpf_reconciler_test.go
@@ -73,14 +73,17 @@ var baseFrontend = Frontend{
 	nodePortAddrs: nodePortAddrs,
 }
 
-var emptyInstances part.Map[loadbalancer.ServiceName, BackendInstance]
+var emptyInstances = func() part.Map[BackendInstanceKey, BackendInstance] {
+	part.RegisterKeyType(BackendInstanceKey.Key)
+	return part.Map[BackendInstanceKey, BackendInstance]{}
+}()
 
 var baseBackend = Backend{
 	L3n4Addr: backend1,
 	NodeName: "",
 	ZoneID:   0,
 	Instances: emptyInstances.Set(
-		testServiceName,
+		BackendInstanceKey{testServiceName, 0},
 		BackendInstance{
 			PortName: "",
 			Weight:   0,

--- a/pkg/loadbalancer/experimental/script_test.go
+++ b/pkg/loadbalancer/experimental/script_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/source"
 )
 
 func TestScript(t *testing.T) {
@@ -60,6 +61,7 @@ func TestScript(t *testing.T) {
 					func(cfg TestConfig) *TestConfig { return &cfg },
 					tables.NewNodeAddressTable,
 					statedb.RWTable[tables.NodeAddress].ToTable,
+					source.NewSources,
 					func(cfg TestConfig) *option.DaemonConfig {
 						return &option.DaemonConfig{
 							EnableIPv4:                   true,

--- a/pkg/loadbalancer/experimental/testdata/clusterip.txtar
+++ b/pkg/loadbalancer/experimental/testdata/clusterip.txtar
@@ -30,8 +30,8 @@ Address               Type        ServiceName   PortName   Backends             
 10.96.50.104:80/TCP   ClusterIP   test/echo     http       10.244.1.1:80/TCP (active)   Done
 
 -- backends.table --
-Address             State    Instances          NodeName          ZoneID
-10.244.1.1:80/TCP   active   test/echo (http)   nodeport-worker   0
+Address             State    Instances          Shadows        NodeName          ZoneID
+10.244.1.1:80/TCP   active   test/echo (http)   test/echo []   nodeport-worker   0
 
 -- services_empty.table --
 Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
@@ -40,7 +40,7 @@ Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionA
 Address               Type        ServiceName   PortName   Status  Backends
 
 -- backends_empty.table --
-Address             State    Instances            NodeName           ZoneID
+Address             State    Instances   Shadows          NodeName           ZoneID
 
 -- service.yaml --
 apiVersion: v1

--- a/pkg/service/reconciler_test.go
+++ b/pkg/service/reconciler_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/source"
 )
 
 type mockSyncNodePort struct {
@@ -57,6 +58,7 @@ func TestServiceReconciler(t *testing.T) {
 			cell.Provide(
 				tables.NewNodeAddressTable,
 				statedb.RWTable[tables.NodeAddress].ToTable,
+				source.NewSources,
 			),
 			cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
 			cell.Provide(func() syncNodePort { return mock }),

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -3,6 +3,10 @@
 
 package source
 
+import (
+	"github.com/cilium/hive/cell"
+)
+
 // Source describes the source of a definition
 type Source string
 
@@ -52,7 +56,25 @@ const (
 	// Directory is the source used for watching and reading
 	// cilium network policy files from specific directory.
 	Directory Source = "directory"
+
+	// Please remember to add your source to defaultSources below.
 )
+
+// Sources is a priority-sorted slice of sources.
+type Sources []Source
+
+var defaultSources Sources = []Source{
+	KubeAPIServer,
+	Local,
+	KVStore,
+	CustomResource,
+	Kubernetes,
+	ClusterMesh,
+	LocalAPI,
+	Generated,
+	Restored,
+	Unspec,
+}
 
 // AllowOverwrite returns true if new state from a particular source is allowed
 // to overwrite existing state from another source
@@ -107,6 +129,16 @@ func AllowOverwrite(existing, new Source) bool {
 	case Unspec:
 		return true
 	}
-
 	return true
+}
+
+var Cell = cell.Module(
+	"source",
+	"Definitions and priorities of data sources",
+	cell.Provide(NewSources),
+)
+
+// NewSources returns sources ordered from the most preferred.
+func NewSources() Sources {
+	return defaultSources
 }


### PR DESCRIPTION
This adds support for storing and reconciling multiple `BackendInstance`s for the same `Backend` and `ServiceName` as discussed on the #sig-lb Slack channel.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->