### PR TITLE
github: Pass the workflow step timeout to go test

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -305,6 +305,7 @@ jobs:
               --contact https://github.com/cilium/community/blob/main/roles/Maintainers.md \
               --report-output report.yaml \
               -test.run "TestConformance" \
+              -test.timeout=29m \
               -json \
             | tparse -progress
           else
@@ -319,6 +320,7 @@ jobs:
               --exempt-features "${{ steps.vars.outputs.exempt-features }}" \
               --allow-crds-mismatch \
               -test.run "TestConformance" \
+              -test.timeout=29m \
               -test.skip "${{ steps.vars.outputs.skipped_tests }}" \
               -json \
             | tparse -progress


### PR DESCRIPTION
Pass the workflow step timeout (less 1 minute for incidentals) to go test, as its default (10 minutes) has been exceeded causing unnecessary test flakes.

Example failure:
```
10m 27s
Run if [ false == "true" ]; then
=== RUN   TestConformance
...
panic: test timed out after 10m0s
running tests:
	TestConformance (10m0s)
```
