### PR TITLE
endpoint: stop regenerating all endpoints on every identity allocation; switch to periodic regens instead.

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -187,6 +187,7 @@ cilium-agent [flags]
       --encryption-strict-mode-cidr string                        In strict-mode encryption, all unencrypted traffic coming from this CIDR and going to this same CIDR will be dropped
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
       --endpoint-queue-size int                                   Size of EventQueue per-endpoint (default 25)
+      --endpoint-regen-interval duration                          Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable (default 2m0s)
       --envoy-base-id uint                                        Envoy base ID
       --envoy-config-retry-interval duration                      Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated. (default 15s)
       --envoy-config-timeout duration                             Timeout that determines how long to wait for Envoy to N/ACK CiliumEnvoyConfig resources (default 2m0s)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -57,6 +57,7 @@ cilium-agent hive [flags]
       --enable-service-topology                                   Enable support for service topology aware hints
       --enable-xt-socket-fallback                                 Enable fallback for missing xt_socket module (default true)
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
+      --endpoint-regen-interval duration                          Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable (default 2m0s)
       --envoy-base-id uint                                        Envoy base ID
       --envoy-config-retry-interval duration                      Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated. (default 15s)
       --envoy-config-timeout duration                             Timeout that determines how long to wait for Envoy to N/ACK CiliumEnvoyConfig resources (default 2m0s)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -63,6 +63,7 @@ cilium-agent hive dot-graph [flags]
       --enable-service-topology                                   Enable support for service topology aware hints
       --enable-xt-socket-fallback                                 Enable fallback for missing xt_socket module (default true)
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
+      --endpoint-regen-interval duration                          Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable (default 2m0s)
       --envoy-base-id uint                                        Envoy base ID
       --envoy-config-retry-interval duration                      Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated. (default 15s)
       --envoy-config-timeout duration                             Timeout that determines how long to wait for Envoy to N/ACK CiliumEnvoyConfig resources (default 2m0s)

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -433,6 +433,9 @@ Name                                     Labels                                 
 ``identity_gc_latency``                  ``outcome``, ``identity_type``                     Enabled    Duration of the last successful identity GC run
 ``ipcache_errors_total``                 ``type``, ``error``                                Enabled    Number of errors interacting with the ipcache
 ``ipcache_events_total``                 ``type``                                           Enabled    Number of events interacting with the ipcache
+``identity_cache_timer_duration``        ``name``                                           Enabled    Seconds required to execute periodic policy processes. ``name="id-alloc-update-policy-maps"`` is the time taken to apply incremental updates to the BPF policy maps.
+``identity_cache_timer_trigger_latency`` ``name``                                           Enabled    Seconds spent waiting for a previous process to finish before starting the next round. ``name="id-alloc-update-policy-maps"`` is the time waiting before applying incremental updates to the BPF policy maps.
+``identity_cache_timer_trigger_folds``   ``name``                                           Enabled    Number of timer triggers that were coalesced in to one execution. ``name="id-alloc-update-policy-maps"`` applies the incremental updates to the BPF policy maps.
 ======================================== ================================================== ========== ========================================================
 
 Events external to Cilium

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -390,6 +390,9 @@ Added Metrics
 Removed Metrics
 ~~~~~~~~~~~~~~~
 * ``cilium_cidrgroup_translation_time_stats_seconds`` has been removed, as the measured code path no longer exists.
+* ``cilium_triggers_policy_update_total`` has been removed.
+* ``cilium_triggers_policy_update_folds`` has been removed.
+* ``cilium_triggers_policy_update_call_duration`` has been removed.
 
 Changed Metrics
 ~~~~~~~~~~~~~~~

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -383,6 +383,9 @@ Added Metrics
 * ``cilium_node_health_connectivity_latency_seconds``
 * ``cilium_operator_unmanaged_pods``
 * ``cilium_policy_selector_match_count_max``
+* ``cilium_identity_cache_timer_duration``
+* ``cilium_identity_cache_timer_trigger_latency``
+* ``cilium_identity_cache_timer_trigger_folds``
 
 Removed Metrics
 ~~~~~~~~~~~~~~~

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -121,14 +121,10 @@ func newConfigModifyEventHandler(params configModifyEventHandlerParams) *ConfigM
 
 	params.Lifecycle.Append(cell.Hook{
 		OnStart: func(hookContext cell.HookContext) error {
-			// Reuse policy.TriggerMetrics and PolicyTriggerInterval here since
-			// this is only triggered by agent configuration changes for now and
-			// should be counted in pol.TriggerMetrics.
 			rt, err := trigger.NewTrigger(trigger.Parameters{
-				Name:            "datapath-regeneration",
-				MetricsObserver: &policy.TriggerMetrics{},
-				MinInterval:     option.Config.PolicyTriggerInterval,
-				TriggerFunc:     eventHandler.datapathRegen,
+				Name:        "datapath-regeneration",
+				MinInterval: option.Config.PolicyTriggerInterval,
+				TriggerFunc: eventHandler.datapathRegen,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create datapath regeneration trigger: %w", err)

--- a/pkg/ciliumenvoyconfig/cec_manager.go
+++ b/pkg/ciliumenvoyconfig/cec_manager.go
@@ -100,7 +100,7 @@ func (r *cecManager) addCiliumEnvoyConfig(cecObjectMeta metav1.ObjectMeta, cecSp
 		// the bpf maps are not updated with the new proxy ports either. Move from the
 		// simple boolean to an enum that can more selectively skip regeneration steps (like
 		// we do for the datapath recompilations already?)
-		r.policyUpdater.TriggerPolicyUpdates(true, "Envoy Listeners added")
+		r.policyUpdater.TriggerPolicyUpdates("Envoy Listeners added")
 	}
 
 	return err
@@ -364,7 +364,7 @@ func (r *cecManager) updateCiliumEnvoyConfig(
 	}
 
 	if oldResources.ListenersAddedOrDeleted(&newResources) {
-		r.policyUpdater.TriggerPolicyUpdates(true, "Envoy Listeners added or deleted")
+		r.policyUpdater.TriggerPolicyUpdates("Envoy Listeners added or deleted")
 	}
 
 	return nil
@@ -458,7 +458,7 @@ func (r *cecManager) deleteCiliumEnvoyConfig(cecObjectMeta metav1.ObjectMeta, ce
 	}
 
 	if len(resources.Listeners) > 0 {
-		r.policyUpdater.TriggerPolicyUpdates(true, "Envoy Listeners deleted")
+		r.policyUpdater.TriggerPolicyUpdates("Envoy Listeners deleted")
 	}
 
 	return nil

--- a/pkg/ciliumenvoyconfig/exp_controller.go
+++ b/pkg/ciliumenvoyconfig/exp_controller.go
@@ -474,7 +474,7 @@ func (c *cecController) onServiceUpsert(txn statedb.ReadTxn, svc *experimental.S
 type policyTriggerWrapper struct{ updater *policy.Updater }
 
 func (p policyTriggerWrapper) TriggerPolicyUpdates() {
-	p.updater.TriggerPolicyUpdates(true, "Envoy Listeners changed")
+	p.updater.TriggerPolicyUpdates("Envoy Listeners changed")
 }
 
 func newPolicyTrigger(log *slog.Logger, updater *policy.Updater) policyTrigger {

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -220,6 +220,7 @@ func newDefaultEndpointManager(p endpointManagerParams) endpointManagerOut {
 		p.Lifecycle.Append(cell.Hook{
 			OnStart: func(cell.HookContext) error {
 				mgr.WithPeriodicEndpointGC(ctx, checker, p.Config.EndpointGCInterval)
+				mgr.WithPeriodicEndpointRegeneration(ctx, p.Config.EndpointRegenInterval)
 				return nil
 			},
 			OnStop: func(cell.HookContext) error {

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -149,6 +149,10 @@ type EndpointManager interface {
 	// regenerated.
 	RegenerateAllEndpoints(regenMetadata *regeneration.ExternalRegenerationMetadata) *sync.WaitGroup
 
+	// TriggerRegenerateAlEndpoints triggers a batched regeneration of all endpoints.
+	// Returns immediately.
+	TriggerRegenerateAllEndpoints()
+
 	// WaitForEndpointsAtPolicyRev waits for all endpoints which existed at the time
 	// this function is called to be at a given policy revision.
 	// New endpoints appearing while waiting are ignored.

--- a/pkg/endpointmanager/config.go
+++ b/pkg/endpointmanager/config.go
@@ -14,14 +14,21 @@ type EndpointManagerConfig struct {
 	// EndpointGCInterval is interval to attempt garbage collection of
 	// endpoints that are no longer alive and healthy.
 	EndpointGCInterval time.Duration
+
+	// EndpointRegenInterval is interval between periodic endpoint regenerations.
+	EndpointRegenInterval time.Duration
 }
 
 func (def EndpointManagerConfig) Flags(flags *pflag.FlagSet) {
 	flags.Duration(option.EndpointGCInterval, def.EndpointGCInterval,
 		"Periodically monitor local endpoint health via link status on this interval and garbage collect them if they become unhealthy, set to 0 to disable")
 	flags.MarkHidden(option.EndpointGCInterval)
+
+	flags.Duration(option.EndpointRegenInterval, def.EndpointRegenInterval,
+		"Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable")
 }
 
 var defaultEndpointManagerConfig = EndpointManagerConfig{
-	EndpointGCInterval: 5 * time.Minute,
+	EndpointGCInterval:    5 * time.Minute,
+	EndpointRegenInterval: 2 * time.Minute,
 }

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -131,6 +131,36 @@ func (mgr *endpointManager) WithPeriodicEndpointGC(ctx context.Context, checkHea
 	return mgr
 }
 
+// WithPeriodicEndpointRegeneration configures the EndpointManager to regenerate all (policy and configuration) state
+// of endpoints periodically.
+func (mgr *endpointManager) WithPeriodicEndpointRegeneration(ctx context.Context, interval time.Duration) *endpointManager {
+	mgr.controllers.UpdateController("endpoint-periodic-regeneration",
+		controller.ControllerParams{
+			Group: endpointGCControllerGroup,
+			DoFunc: func(ctx context.Context) error {
+				wg := mgr.RegenerateAllEndpoints(&regeneration.ExternalRegenerationMetadata{
+					Reason:            "periodic endpoint regeneration",
+					RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+				})
+
+				// Wait for wg to be done, unless ctx is cancelled.
+				dc := make(chan struct{})
+				go func() {
+					wg.Wait()
+					close(dc)
+				}()
+				select {
+				case <-dc:
+				case <-ctx.Done():
+				}
+				return ctx.Err()
+			},
+			RunInterval: interval,
+			Context:     ctx,
+		})
+	return mgr
+}
+
 // waitForProxyCompletions blocks until all proxy changes have been completed.
 func waitForProxyCompletions(proxyWaitGroup *completion.WaitGroup) error {
 	err := proxyWaitGroup.Context().Err()

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -42,6 +42,8 @@ var (
 	endpointGCControllerGroup = controller.NewGroup("endpoint-gc")
 )
 
+const regenEndpointControllerName = "endpoint-periodic-regeneration"
+
 // endpointManager is a structure designed for containing state about the
 // collection of locally running endpoints.
 type endpointManager struct {
@@ -134,7 +136,7 @@ func (mgr *endpointManager) WithPeriodicEndpointGC(ctx context.Context, checkHea
 // WithPeriodicEndpointRegeneration configures the EndpointManager to regenerate all (policy and configuration) state
 // of endpoints periodically.
 func (mgr *endpointManager) WithPeriodicEndpointRegeneration(ctx context.Context, interval time.Duration) *endpointManager {
-	mgr.controllers.UpdateController("endpoint-periodic-regeneration",
+	mgr.controllers.UpdateController(regenEndpointControllerName,
 		controller.ControllerParams{
 			Group: endpointGCControllerGroup,
 			DoFunc: func(ctx context.Context) error {
@@ -586,6 +588,12 @@ func (mgr *endpointManager) RegenerateAllEndpoints(regenMetadata *regeneration.E
 	}
 
 	return &wg
+}
+
+// TriggerRegenerateAllEndpoints triggers a batched, asynchronous regeneration of all endpoints
+// at the WithoutDatapath level.
+func (mgr *endpointManager) TriggerRegenerateAllEndpoints() {
+	mgr.controllers.TriggerController(regenEndpointControllerName)
 }
 
 // OverrideEndpointOpts applies the given options to all endpoints.

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -349,8 +349,8 @@ func NewCachingIdentityAllocator(owner IdentityAllocatorOwner, config AllocatorC
 
 	// Local identity cache can be created synchronously since it doesn't
 	// rely upon any external resources (e.g., external kvstore).
-	m.localIdentities = newLocalIdentityCache(identity.IdentityScopeLocal, identity.MinAllocatorLocalIdentity, identity.MaxAllocatorLocalIdentity, m.events)
-	m.localNodeIdentities = newLocalIdentityCache(identity.IdentityScopeRemoteNode, identity.MinAllocatorLocalIdentity, identity.MaxAllocatorLocalIdentity, m.events)
+	m.localIdentities = newLocalIdentityCache(identity.IdentityScopeLocal, identity.MinAllocatorLocalIdentity, identity.MaxAllocatorLocalIdentity)
+	m.localNodeIdentities = newLocalIdentityCache(identity.IdentityScopeRemoteNode, identity.MinAllocatorLocalIdentity, identity.MaxAllocatorLocalIdentity)
 
 	return m
 }
@@ -378,8 +378,6 @@ func (m *CachingIdentityAllocator) Close() {
 
 	m.IdentityAllocator.Delete()
 	if m.events != nil {
-		m.localIdentities.close()
-		m.localNodeIdentities.close()
 		close(m.events)
 		m.events = nil
 	}
@@ -429,10 +427,10 @@ func (m *CachingIdentityAllocator) AllocateLocalIdentity(lbls labels.Labels, not
 	var metricLabel string
 	switch scope := identity.ScopeForLabels(lbls); scope {
 	case identity.IdentityScopeLocal:
-		id, allocated, err = m.localIdentities.lookupOrCreate(lbls, oldNID, notifyOwner)
+		id, allocated, err = m.localIdentities.lookupOrCreate(lbls, oldNID)
 		metricLabel = identity.NodeLocalIdentityType
 	case identity.IdentityScopeRemoteNode:
-		id, allocated, err = m.localNodeIdentities.lookupOrCreate(lbls, oldNID, notifyOwner)
+		id, allocated, err = m.localNodeIdentities.lookupOrCreate(lbls, oldNID)
 		metricLabel = identity.RemoteNodeIdentityType
 	default:
 		log.WithFields(logrus.Fields{
@@ -726,16 +724,10 @@ func (m *CachingIdentityAllocator) ReleaseRestoredIdentities() {
 // identity again. This function may result in kvstore operations.
 // After the last user has released the ID, the returned lastUse value is true.
 func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Identity, notifyOwner bool) (released bool, err error) {
+	metricVal := identity.ClusterLocalIdentityType
 	defer func() {
 		if released {
 			// decrement metrics, trigger checkpoint if local
-			metricVal := identity.ClusterLocalIdentityType
-			switch id.ID.Scope() {
-			case identity.IdentityScopeLocal:
-				metricVal = identity.NodeLocalIdentityType
-			case identity.IdentityScopeRemoteNode:
-				metricVal = identity.RemoteNodeIdentityType
-			}
 			if metricVal != identity.ClusterLocalIdentityType && m.checkpointTrigger != nil {
 				m.checkpointTrigger.Trigger()
 			}
@@ -745,6 +737,7 @@ func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Ide
 			metrics.Identity.WithLabelValues(metricVal).Dec()
 		}
 
+		// Remove this ID from the selectorcache and any other identity "watchers"
 		if m.owner != nil && released && notifyOwner {
 			deleted := identity.IdentityMap{
 				id.ID: id.LabelArray,
@@ -758,11 +751,15 @@ func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Ide
 		return false, nil
 	}
 
+	// Release local identities
+	// will perform post-release cleanup actions above
 	switch identity.ScopeForLabels(id.Labels) {
 	case identity.IdentityScopeLocal:
-		return m.localIdentities.release(id, notifyOwner), nil
+		metricVal = identity.NodeLocalIdentityType
+		return m.localIdentities.release(id), nil
 	case identity.IdentityScopeRemoteNode:
-		return m.localNodeIdentities.release(id, notifyOwner), nil
+		metricVal = identity.RemoteNodeIdentityType
+		return m.localNodeIdentities.release(id), nil
 	}
 
 	// This will block until the kvstore can be accessed and all identities

--- a/pkg/identity/cache/cell/cell.go
+++ b/pkg/identity/cache/cell/cell.go
@@ -4,27 +4,41 @@
 package identitycachecell
 
 import (
-	"log"
+	"context"
+	"log/slog"
+	"maps"
 	"net"
+	"slices"
 	"sync"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 	"github.com/cilium/stream"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/clustermesh"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 )
 
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "identity-cache-cell")
+
 // Cell provides the IdentityAllocator for allocating security identities
 var Cell = cell.Module(
 	"identity",
 	"Allocating and managing security identities",
+
+	metrics.Metric(newIdentityCacheMetrics),
 
 	cell.Provide(newIdentityAllocator),
 	cell.Config(defaultConfig),
@@ -56,9 +70,13 @@ type CachingIdentityAllocator interface {
 type identityAllocatorParams struct {
 	cell.In
 
+	Log              *slog.Logger
+	Registry         job.Registry
+	Health           cell.Health
 	Lifecycle        cell.Lifecycle
 	PolicyRepository policy.PolicyRepository
-	PolicyUpdater    *policy.Updater
+	EPManager        endpointmanager.EndpointManager
+	Metrics          *identityCacheMetrics
 
 	IdentityHandlers []identity.UpdateIdentities `group:"identity-handlers"`
 
@@ -91,8 +109,8 @@ func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
 	// iao: updates SelectorCache and regenerates endpoints when
 	// identity allocation / deallocation has occurred.
 	iao := &identityAllocatorOwner{
-		policy:        params.PolicyRepository,
-		policyUpdater: params.PolicyUpdater,
+		policy:    params.PolicyRepository,
+		epmanager: params.EPManager,
 
 		identityHandlers: params.IdentityHandlers,
 	}
@@ -120,6 +138,12 @@ func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
 		},
 	})
 
+	iao.updatePolicyMaps = job.NewTrigger()
+	jg := params.Registry.NewGroup(params.Health, job.WithMetrics(params.Metrics), job.WithLogger(params.Log))
+	jg.Add(job.Timer("id-alloc-update-policy-maps", iao.doUpdatePolicyMaps,
+		/* no interval, only on trigger */ 0, job.WithTrigger(iao.updatePolicyMaps)))
+	params.Lifecycle.Append(jg)
+
 	return identityAllocatorOut{
 		IdentityAllocator:      idAlloc,
 		CacheIdentityAllocator: idAlloc,
@@ -131,27 +155,96 @@ func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
 // identityAllocatorOwner is used to break the circular dependency between
 // CachingIdentityAllocator and policy.Repository.
 type identityAllocatorOwner struct {
-	policy        policy.PolicyRepository
-	policyUpdater *policy.Updater
+	policy    policy.PolicyRepository
+	epmanager endpointmanager.EndpointManager
 
 	identityHandlers []identity.UpdateIdentities
+
+	// set of notification waitgroups to wait in for batched UpdatePolicyMaps,
+	// and a mutex to protect for writing
+	wgsLock lock.Mutex
+	wgs     []*sync.WaitGroup
+
+	updatePolicyMaps job.Trigger
 }
 
 // UpdateIdentities informs the policy package of all identity changes
-// and also triggers policy updates.
+// and also triggers policy updates. Updates to the endpoints are batched.
 //
 // The caller is responsible for making sure the same identity is not
 // present in both 'added' and 'deleted'.
 func (iao *identityAllocatorOwner) UpdateIdentities(added, deleted identity.IdentityMap) {
+	// Have we already seen this exact set of updates? If so, we can skip.
+	// This happens when a global identity is allocated locally (for an Endpoint).
+	// We will add the identity twice; once directly from the endpoint creation,
+	// and again from the global identity watcher (k8s or kvstore).
+	if iao.policy.GetSelectorCache().CanSkipUpdate(added, deleted) {
+		log.Debug("Skipping no-op identity update")
+		return
+	}
+
+	log.WithFields(logrus.Fields{
+		logfields.AddedPolicyID:   slices.Collect(maps.Keys(added)),
+		logfields.DeletedPolicyID: slices.Collect(maps.Keys(deleted)),
+	}).Info("Processing identity update")
+
 	wg := &sync.WaitGroup{}
 	for _, handler := range iao.identityHandlers {
 		handler.UpdateIdentities(added, deleted, wg)
 	}
 	// Invoke policy selector cache always as the last handler
+	// This synchronously updates the SelectorCache and queues an incremental
+	// update to any selectors. The waitgroup is closed when all endpoints
+	// have been notified.
 	iao.policy.GetSelectorCache().UpdateIdentities(added, deleted, wg)
-	// Wait for update propagation to endpoints before triggering policy updates
-	wg.Wait()
-	iao.policyUpdater.TriggerPolicyUpdates(false, "one or more identities created or deleted")
+
+	// Direct endpoints to consume pending incremental updates.
+	iao.wgsLock.Lock()
+	iao.wgs = append(iao.wgs, wg)
+	iao.wgsLock.Unlock()
+	iao.updatePolicyMaps.Trigger()
+}
+
+// doUpdatePolicyMaps is the function called by the trigger job; it waits on the
+// accumulated notification waitgroups, then triggers endpoints to consume
+// the incremental update.
+func (iao *identityAllocatorOwner) doUpdatePolicyMaps(ctx context.Context) error {
+	// take existing queue, make new empty queue, unlock
+	iao.wgsLock.Lock()
+	if len(iao.wgs) == 0 {
+		iao.wgsLock.Unlock()
+		return nil
+	}
+	wgs := iao.wgs
+	iao.wgs = nil
+	iao.wgsLock.Unlock()
+
+	log.WithField(logfields.Count, len(wgs)).Info("Incremental policy update: waiting for endpoint notifications to complete")
+
+	// Wait for all batched incremental updates to be finished with their notifications.
+	wdc := make(chan struct{})
+	go func() {
+		for _, wg := range wgs {
+			wg.Wait()
+		}
+		close(wdc)
+	}()
+	select {
+	case <-wdc:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	// UpdatePolicyMaps also waits for notifications to be complete, but we already waited :-)
+	noopWG := &sync.WaitGroup{}
+
+	// Direct all endpoints to consume the incremental changes and update policy.
+	// This returns a wg that is done when all endpoints have updated both their bpf
+	// policymaps as well as Envoy. (Or if ctx is closed).
+	log.Info("Incremental policy update: triggering UpdatePolicyMaps for all endpoints")
+	updatedWG := iao.epmanager.UpdatePolicyMaps(ctx, noopWG)
+	updatedWG.Wait()
+	return nil
 }
 
 // GetNodeSuffix returns the suffix to be appended to kvstore keys of this

--- a/pkg/identity/cache/cell/metrics.go
+++ b/pkg/identity/cache/cell/metrics.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package identitycachecell
+
+import (
+	"github.com/cilium/hive/job"
+
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type identityCacheMetrics struct {
+	TriggerLatency metric.Vec[metric.Observer]
+	TriggerFolds   metric.Vec[metric.Observer]
+	TimerDuration  metric.Vec[metric.Observer]
+}
+
+var _ job.Metrics = &identityCacheMetrics{}
+
+const subsystem = "identity_cache"
+
+func newIdentityCacheMetrics() *identityCacheMetrics {
+	return &identityCacheMetrics{
+		TriggerLatency: metric.NewHistogramVec(metric.HistogramOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "timer_trigger_latency",
+			Help:      "The total time spent waiting for a timer to be ready to start",
+		}, []string{"name"}),
+		TriggerFolds: metric.NewHistogramVec(metric.HistogramOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "timer_trigger_folds",
+			Help:      "The number of pending requests served by a single timer invocation",
+		}, []string{"name"}),
+		TimerDuration: metric.NewHistogramVec(metric.HistogramOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "timer_duration",
+			Help:      "The execution duration for a timer",
+		}, []string{"name"}),
+	}
+}
+
+func (m *identityCacheMetrics) TimerRunDuration(name string, duration time.Duration) {
+	m.TimerDuration.WithLabelValues(name).Observe(duration.Seconds())
+}
+
+func (m *identityCacheMetrics) TimerTriggerStats(name string, latency time.Duration, folds int) {
+	m.TriggerLatency.WithLabelValues(name).Observe(latency.Seconds())
+	m.TriggerFolds.WithLabelValues(name).Observe(float64(folds))
+}
+
+func (m *identityCacheMetrics) JobError(name string, err error) {
+}
+
+func (m *identityCacheMetrics) ObserverRunDuration(name string, duration time.Duration) {
+}
+
+func (m *identityCacheMetrics) OneShotRunDuration(name string, duration time.Duration) {
+}

--- a/pkg/identity/cache/local_test.go
+++ b/pkg/identity/cache/local_test.go
@@ -21,7 +21,7 @@ func TestBumpNextNumericIdentity(t *testing.T) {
 
 	minID, maxID := identity.NumericIdentity(1), identity.NumericIdentity(5)
 	scope := identity.NumericIdentity(0x42_00_00_00)
-	cache := newLocalIdentityCache(scope, minID, maxID, nil)
+	cache := newLocalIdentityCache(scope, minID, maxID)
 
 	for i := minID; i <= maxID; i++ {
 		require.Equal(t, i, cache.nextNumericIdentity)
@@ -37,14 +37,14 @@ func TestLocalIdentityCache(t *testing.T) {
 
 	minID, maxID := identity.NumericIdentity(1), identity.NumericIdentity(5)
 	scope := identity.NumericIdentity(0x42_00_00_00)
-	cache := newLocalIdentityCache(scope, minID, maxID, nil)
+	cache := newLocalIdentityCache(scope, minID, maxID)
 
 	identities := map[identity.NumericIdentity]*identity.Identity{}
 
 	// allocate identities for all available numeric identities with a
 	// unique label
 	for i := minID; i <= maxID; i++ {
-		id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}), identity.InvalidIdentity, false)
+		id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}), identity.InvalidIdentity)
 		require.NoError(t, err)
 		require.True(t, isNew)
 		require.Equal(t, scope+i, id.ID)
@@ -54,7 +54,7 @@ func TestLocalIdentityCache(t *testing.T) {
 	// allocate the same labels again. This must be successful and the same
 	// identities must be returned.
 	for i := minID; i <= maxID; i++ {
-		id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}), identity.InvalidIdentity, false)
+		id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}), identity.InvalidIdentity)
 		require.False(t, isNew)
 		require.NoError(t, err)
 
@@ -63,12 +63,12 @@ func TestLocalIdentityCache(t *testing.T) {
 	}
 
 	// Allocation must fail as we are out of IDs
-	_, _, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{"foo"}), identity.InvalidIdentity, false)
+	_, _, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{"foo"}), identity.InvalidIdentity)
 	require.Error(t, err)
 
 	// release all identities, this must decrement the reference count but not release the identities yet
 	for _, id := range identities {
-		require.False(t, cache.release(id, false))
+		require.False(t, cache.release(id))
 	}
 
 	// lookup must still be successful
@@ -80,12 +80,12 @@ func TestLocalIdentityCache(t *testing.T) {
 	// release the identities a second time, this must cause the identity
 	// to be forgotten
 	for _, id := range identities {
-		require.True(t, cache.release(id, false))
+		require.True(t, cache.release(id))
 	}
 
 	// allocate all identities again
 	for i := minID; i <= maxID; i++ {
-		id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}), identity.InvalidIdentity, false)
+		id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}), identity.InvalidIdentity)
 		require.NoError(t, err)
 		require.True(t, isNew)
 		identities[id.ID] = id
@@ -93,9 +93,9 @@ func TestLocalIdentityCache(t *testing.T) {
 
 	// release a random identity in the middle
 	randomID := identity.NumericIdentity(3) | scope
-	require.True(t, cache.release(identities[randomID], false))
+	require.True(t, cache.release(identities[randomID]))
 
-	id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{"foo"}), identity.InvalidIdentity, false)
+	id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{"foo"}), identity.InvalidIdentity)
 	require.NoError(t, err)
 	require.True(t, isNew)
 	// the selected numeric identity must be the one released before
@@ -105,17 +105,17 @@ func TestLocalIdentityCache(t *testing.T) {
 func TestOldNID(t *testing.T) {
 	minID, maxID := identity.NumericIdentity(1), identity.NumericIdentity(10)
 	scope := identity.NumericIdentity(0x42_00_00_00)
-	c := newLocalIdentityCache(scope, minID, maxID, nil)
+	c := newLocalIdentityCache(scope, minID, maxID)
 
 	// Request identity, it should work
 	l := labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.1/32"))
-	id, _, _ := c.lookupOrCreate(l, scope, false)
+	id, _, _ := c.lookupOrCreate(l, scope)
 	assert.NotNil(t, id)
 	assert.EqualValues(t, scope, id.ID)
 
 	// Re-request identity, it should not
 	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.2/32"))
-	id, _, _ = c.lookupOrCreate(l, scope, false)
+	id, _, _ = c.lookupOrCreate(l, scope)
 	assert.NotNil(t, id)
 	assert.EqualValues(t, scope+1, id.ID)
 
@@ -123,33 +123,33 @@ func TestOldNID(t *testing.T) {
 	c.withhold([]identity.NumericIdentity{scope + 2})
 
 	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.3/32"))
-	id, _, _ = c.lookupOrCreate(l, 0, false)
+	id, _, _ = c.lookupOrCreate(l, 0)
 	assert.NotNil(t, id)
 	assert.EqualValues(t, scope+3, id.ID)
 
 	// Request a withheld identity, it should succeed
 	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.4/32"))
-	id2, _, _ := c.lookupOrCreate(l, scope+2, false)
+	id2, _, _ := c.lookupOrCreate(l, scope+2)
 	assert.NotNil(t, id2)
 	assert.EqualValues(t, scope+2, id2.ID)
 
 	// Request a withheld and allocated identity, it should be ignored
 	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.5/32"))
-	id, _, _ = c.lookupOrCreate(l, scope+2, false)
+	id, _, _ = c.lookupOrCreate(l, scope+2)
 	assert.NotNil(t, id)
 	assert.EqualValues(t, scope+4, id.ID)
 
 	// Unwithhold and release an identity, requesting should now succeed
 	c.unwithhold([]identity.NumericIdentity{scope + 2})
-	c.release(id2, false)
+	c.release(id2)
 	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.6/32"))
-	id, _, _ = c.lookupOrCreate(l, scope+2, false)
+	id, _, _ = c.lookupOrCreate(l, scope+2)
 	assert.NotNil(t, id)
 	assert.EqualValues(t, scope+2, id.ID)
 
 	// Request an identity out of scope, it should not be honored
 	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.7/32"))
-	id, _, _ = c.lookupOrCreate(l, scope-2, false)
+	id, _, _ = c.lookupOrCreate(l, scope-2)
 	assert.NotNil(t, id)
 	assert.EqualValues(t, scope+5, id.ID)
 
@@ -157,7 +157,7 @@ func TestOldNID(t *testing.T) {
 	c.withhold([]identity.NumericIdentity{scope + 6, scope + 7, scope + 8, scope + 9, scope + 10})
 
 	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.8/32"))
-	id, _, _ = c.lookupOrCreate(l, scope-2, false)
+	id, _, _ = c.lookupOrCreate(l, scope-2)
 	assert.NotNil(t, id)
 	// actual value is random, just need it to succeed
 	assert.True(t, id.ID >= scope+6 && id.ID <= scope+10, "%d <= %d <= %d", scope+6, id.ID, scope+10)

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -157,7 +157,7 @@ func (k *K8sCiliumEndpointsWatcher) endpointUpdated(oldEndpoint, endpoint *types
 	var namedPortsChanged bool
 	defer func() {
 		if namedPortsChanged {
-			k.policyManager.TriggerPolicyUpdates(true, "Named ports added or updated")
+			k.policyManager.TriggerPolicyUpdates("Named ports added or updated")
 		}
 	}()
 	var ipsAdded []string
@@ -282,7 +282,7 @@ func (k *K8sCiliumEndpointsWatcher) endpointDeleted(endpoint *types.CiliumEndpoi
 			}
 		}
 		if namedPortsChanged {
-			k.policyManager.TriggerPolicyUpdates(true, "Named ports deleted")
+			k.policyManager.TriggerPolicyUpdates("Named ports deleted")
 		}
 	}
 	hubblemetrics.ProcessCiliumEndpointDeletion(endpoint)

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -914,7 +914,7 @@ func (k *K8sPodWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPo
 
 		// This happens at most once due to k8sMeta being the same for all podIPs in this loop
 		if namedPortsChanged {
-			k.policyManager.TriggerPolicyUpdates(true, "Named ports added or updated")
+			k.policyManager.TriggerPolicyUpdates("Named ports added or updated")
 		}
 	}()
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -75,7 +75,7 @@ type nodeManager interface {
 }
 
 type policyManager interface {
-	TriggerPolicyUpdates(force bool, reason string)
+	TriggerPolicyUpdates(reason string)
 }
 
 type svcManager interface {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -544,18 +544,6 @@ var (
 	// BPFMapCapacity is the max capacity of bpf maps, labelled by map group classification.
 	BPFMapCapacity = NoOpGaugeVec
 
-	// TriggerPolicyUpdateTotal is the metric to count total number of
-	// policy update triggers
-	TriggerPolicyUpdateTotal = NoOpCounterVec
-
-	// TriggerPolicyUpdateFolds is the current level folding that is
-	// happening when running policy update triggers
-	TriggerPolicyUpdateFolds = NoOpGauge
-
-	// TriggerPolicyUpdateCallDuration measures the latency and call
-	// duration of policy update triggers
-	TriggerPolicyUpdateCallDuration = NoOpObserverVec
-
 	// VersionMetric labelled by Cilium version
 	VersionMetric = NoOpGaugeVec
 
@@ -727,9 +715,6 @@ type LegacyMetrics struct {
 	BPFSyscallDuration               metric.Vec[metric.Observer]
 	BPFMapOps                        metric.Vec[metric.Counter]
 	BPFMapCapacity                   metric.Vec[metric.Gauge]
-	TriggerPolicyUpdateTotal         metric.Vec[metric.Counter]
-	TriggerPolicyUpdateFolds         metric.Gauge
-	TriggerPolicyUpdateCallDuration  metric.Vec[metric.Observer]
 	VersionMetric                    metric.Vec[metric.Gauge]
 	APILimiterWaitHistoryDuration    metric.Vec[metric.Observer]
 	APILimiterWaitDuration           metric.Vec[metric.Gauge]
@@ -1227,30 +1212,6 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Help:       "Capacity of map, tagged by map group. All maps with a capacity of 65536 are grouped under 'default'",
 		}, []string{LabelMapGroup}),
 
-		TriggerPolicyUpdateTotal: metric.NewCounterVec(metric.CounterOpts{
-			ConfigName: Namespace + "_" + SubsystemTriggers + "_policy_update_total",
-			Namespace:  Namespace,
-			Subsystem:  SubsystemTriggers,
-			Name:       "policy_update_total",
-			Help:       "Total number of policy update trigger invocations labeled by reason",
-		}, []string{"reason"}),
-
-		TriggerPolicyUpdateFolds: metric.NewGauge(metric.GaugeOpts{
-			ConfigName: Namespace + "_" + SubsystemTriggers + "_policy_update_folds",
-			Namespace:  Namespace,
-			Subsystem:  SubsystemTriggers,
-			Name:       "policy_update_folds",
-			Help:       "Current number of folds",
-		}),
-
-		TriggerPolicyUpdateCallDuration: metric.NewHistogramVec(metric.HistogramOpts{
-			ConfigName: Namespace + "_" + SubsystemTriggers + "_policy_update_call_duration_seconds",
-			Namespace:  Namespace,
-			Subsystem:  SubsystemTriggers,
-			Name:       "policy_update_call_duration_seconds",
-			Help:       "Duration of policy update trigger",
-		}, []string{LabelType}),
-
 		VersionMetric: metric.NewGaugeVec(metric.GaugeOpts{
 			ConfigName: Namespace + "_version",
 			Namespace:  Namespace,
@@ -1466,9 +1427,6 @@ func NewLegacyMetrics() *LegacyMetrics {
 	BPFSyscallDuration = lm.BPFSyscallDuration
 	BPFMapOps = lm.BPFMapOps
 	BPFMapCapacity = lm.BPFMapCapacity
-	TriggerPolicyUpdateTotal = lm.TriggerPolicyUpdateTotal
-	TriggerPolicyUpdateFolds = lm.TriggerPolicyUpdateFolds
-	TriggerPolicyUpdateCallDuration = lm.TriggerPolicyUpdateCallDuration
 	VersionMetric = lm.VersionMetric
 	APILimiterWaitHistoryDuration = lm.APILimiterWaitHistoryDuration
 	APILimiterWaitDuration = lm.APILimiterWaitDuration

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -855,6 +855,9 @@ const (
 	// endpoints that are no longer alive and healthy.
 	EndpointGCInterval = "endpoint-gc-interval"
 
+	// EndpointRegenInterval is the interval of the periodic endpoint regeneration loop.
+	EndpointRegenInterval = "endpoint-regen-interval"
+
 	// LoopbackIPv4 is the address to use for service loopback SNAT
 	LoopbackIPv4 = "ipv4-service-loopback-address"
 

--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -72,7 +72,6 @@ func newPolicyRepo(params policyRepoParams) policy.PolicyRepository {
 type policyUpdaterParams struct {
 	cell.In
 
-	Lifecycle        cell.Lifecycle
 	PolicyRepository policy.PolicyRepository
 	EndpointManager  endpointmanager.EndpointManager
 }
@@ -82,13 +81,6 @@ func newPolicyUpdater(params policyUpdaterParams) *policy.Updater {
 	// Called for various events, such as named port changes
 	// or certain identity updates.
 	policyUpdater := policy.NewUpdater(params.PolicyRepository, params.EndpointManager)
-
-	params.Lifecycle.Append(cell.Hook{
-		OnStop: func(hc cell.HookContext) error {
-			policyUpdater.Shutdown()
-			return nil
-		},
-	})
 
 	return policyUpdater
 }

--- a/pkg/policy/trigger.go
+++ b/pkg/policy/trigger.go
@@ -4,87 +4,37 @@
 package policy
 
 import (
-	"strings"
-	"sync"
-
-	"github.com/cilium/cilium/pkg/endpoint/regeneration"
-	"github.com/cilium/cilium/pkg/metrics"
-	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/time"
-	"github.com/cilium/cilium/pkg/trigger"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
-// TriggerPolicyUpdates triggers the policy update trigger.
-//
-// To follow what the trigger does, see NewUpdater.
-func (u *Updater) TriggerPolicyUpdates(force bool, reason string) {
-	if force {
-		log.Debugf("Artificially increasing policy revision to enforce policy recalculation")
-		u.repo.BumpRevision()
-	}
-
-	u.TriggerWithReason(reason)
+// TriggerPolicyUpdates force full policy recomputation before
+// regenerating all endpoints.
+// This artificially bumps the policy revision, invalidating
+// all cached policies. This is done when an additional resource
+// used in policy calculation has changed.
+func (u *Updater) TriggerPolicyUpdates(reason string) {
+	u.repo.BumpRevision()
+	log.WithField(logfields.Reason, reason).Info("Triggering full policy recalculation and regeneration of all endpoints")
+	u.regen.TriggerRegenerateAllEndpoints()
 }
 
 // NewUpdater returns a new Updater instance to handle triggering policy
 // updates ready for use.
 func NewUpdater(r PolicyRepository, regen regenerator) *Updater {
-	t, err := trigger.NewTrigger(trigger.Parameters{
-		Name:            "policy_update",
-		MetricsObserver: &TriggerMetrics{},
-		MinInterval:     option.Config.PolicyTriggerInterval,
-		// Triggers policy updates for every local endpoint.
-		// This may be called in a variety of situations: after policy changes,
-		// changes in agent configuration, changes in endpoint labels, and
-		// change of security identities.
-		TriggerFunc: func(reasons []string) {
-			log.Debug("Regenerating all endpoints")
-			reason := strings.Join(reasons, ", ")
-
-			regenerationMetadata := &regeneration.ExternalRegenerationMetadata{
-				Reason:            reason,
-				RegenerationLevel: regeneration.RegenerateWithoutDatapath,
-			}
-			regen.RegenerateAllEndpoints(regenerationMetadata)
-		},
-	})
-	if err != nil {
-		panic(err) // unreachable, only occurs if TriggerFunc is nil
-	}
 	return &Updater{
-		Trigger: t,
-		repo:    r,
+		regen: regen,
+		repo:  r,
 	}
 }
 
 // Updater is responsible for triggering policy updates, in order to perform
 // policy recalculation.
 type Updater struct {
-	*trigger.Trigger
-
-	repo PolicyRepository
+	repo  PolicyRepository
+	regen regenerator
 }
 
 type regenerator interface {
 	// RegenerateAllEndpoints should trigger a regeneration of all endpoints.
-	RegenerateAllEndpoints(*regeneration.ExternalRegenerationMetadata) *sync.WaitGroup
-}
-
-// TriggerMetrics handles the metrics for trigger policy recalculations.
-type TriggerMetrics struct{}
-
-func (p *TriggerMetrics) QueueEvent(reason string) {
-	if metrics.TriggerPolicyUpdateTotal.IsEnabled() {
-		metrics.TriggerPolicyUpdateTotal.WithLabelValues(reason).Inc()
-	}
-}
-
-func (p *TriggerMetrics) PostRun(duration, latency time.Duration, folds int) {
-	if metrics.TriggerPolicyUpdateCallDuration.IsEnabled() {
-		metrics.TriggerPolicyUpdateCallDuration.WithLabelValues("duration").Observe(duration.Seconds())
-		metrics.TriggerPolicyUpdateCallDuration.WithLabelValues("latency").Observe(latency.Seconds())
-	}
-	if metrics.TriggerPolicyUpdateFolds.IsEnabled() {
-		metrics.TriggerPolicyUpdateFolds.Set(float64(folds))
-	}
+	TriggerRegenerateAllEndpoints()
 }


### PR DESCRIPTION
Please review by commit.

Prior to this change, there were two possible ways a newly-allocated
identity would be added to the SelectorCache. The first was via the
ipcache, which allocates with `notifyOwner: false`, taking the
responsibility of propagating updates directly.

The IPCache first updates the SelectorCache, then triggers incremental
policy map updates on all endpoints. This works well.

Alternatively, an identity could be allocated by the global allocator.
In this case, `notifyOwner: true` was passed, and the allocator itself
took responsibility for updating the SelectorCache. This would
regenerate all endpoints, rather than merely applying incremental
updates. This also works, but is wasteful.

Finally, if a remote node allocates an identity, this will be
synchronized via the Allocator backend, sent on a watch channel,
inserted in to the SelectorCache, and all endpoints will be regenerated.

Regenerating all endpoints is quite wasteful; we have a functional
incremental policy update mechanism that exactly handles this case.
There were previously issues wherein Envoy would lose updates, but those
have been fixed. So, change it so *all* identity updates only trigger
incremental updates.

For resilience purposes, we now periodically regenerate all endpoints (default: every 2 minutes). We add a controller to the EndpointManager that handles this. Finally, the redundant PolicyUpdater has lost its trigger, and just delegates to the EndpointManager.