### PR TITLE
bgpv2: relax mandatory PeerASN field in BGP peer configuration

### DIFF
--- a/pkg/bgpv1/gobgp/state.go
+++ b/pkg/bgpv1/gobgp/state.go
@@ -64,6 +64,10 @@ func (g *GoBGPServer) GetPeerState(ctx context.Context) (types.GetPeerStateRespo
 		}
 
 		if peer.State != nil {
+			if peer.Conf.PeerAsn == 0 { // if peerAsn is not set, use peer state peerAsn
+				peerState.PeerAsn = int64(peer.State.PeerAsn)
+			}
+
 			peerState.SessionState = toAgentSessionState(peer.State.SessionState).String()
 
 			// Uptime is time since session got established.

--- a/pkg/bgpv1/manager/reconcilerv2/crd_status.go
+++ b/pkg/bgpv1/manager/reconcilerv2/crd_status.go
@@ -220,8 +220,12 @@ func (r *StatusReconciler) getInstanceStatus(ctx context.Context, instance *inst
 		}
 
 		for _, runningPeerState := range peers.Peers {
-			if runningPeerState.PeerAddress != *configuredPeers.PeerAddress || runningPeerState.PeerAsn != *configuredPeers.PeerASN {
+			if runningPeerState.PeerAddress != *configuredPeers.PeerAddress {
 				continue
+			}
+
+			if *configuredPeers.PeerASN == 0 { // If PeerASN is not set, use the ASN from the running state
+				peerStatus.PeerASN = ptr.To[int64](runningPeerState.PeerAsn)
 			}
 
 			peerStatus.PeeringState = ptr.To[string](runningPeerState.SessionState)

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpclusterconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpclusterconfigs.yaml
@@ -83,12 +83,16 @@ spec:
                             minLength: 1
                             type: string
                           peerASN:
+                            default: 0
                             description: |-
                               PeerASN is the ASN of the peer BGP router.
                               Supports extended 32bit ASNs.
+
+                              If peerASN is 0, the BGP OPEN message validation of ASN will be disabled and
+                              ASN will be determined based on peer's OPEN message.
                             format: int64
                             maximum: 4294967295
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           peerAddress:
                             description: |-

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpnodeconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpnodeconfigs.yaml
@@ -102,7 +102,7 @@ spec:
                               Supports extended 32bit ASNs
                             format: int64
                             maximum: 4294967295
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           peerAddress:
                             description: |-

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.30.4"
+	CustomResourceDefinitionSchemaVersion = "1.30.5"
 )

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_cluster_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_cluster_types.go
@@ -108,9 +108,13 @@ type CiliumBGPPeer struct {
 	// PeerASN is the ASN of the peer BGP router.
 	// Supports extended 32bit ASNs.
 	//
+	// If peerASN is 0, the BGP OPEN message validation of ASN will be disabled and
+	// ASN will be determined based on peer's OPEN message.
+	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=4294967295
+	// +kubebuilder:default=0
 	PeerASN *int64 `json:"peerASN,omitempty"`
 
 	// PeerConfigRef is a reference to a peer configuration resource.

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_node_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_node_types.go
@@ -115,7 +115,7 @@ type CiliumBGPNodePeer struct {
 	// Supports extended 32bit ASNs
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=4294967295
 	PeerASN *int64 `json:"peerASN,omitempty"`
 


### PR DESCRIPTION
Users can decide to omit PeerASN field, in which case underlying implementation will not do ASN validation in BGP OPEN state. Once peering is established and runtime state like BGP CLI or CiliumBGPNodeConfig CRD status will reflect peer ASN.

Now if user does not specify PeerASN, 0 will be passed to Cilium BGP Control Plane.

