### PR TITLE
experimental: Add health server support

### DIFF
--- a/pkg/ciliumenvoyconfig/exp_controller.go
+++ b/pkg/ciliumenvoyconfig/exp_controller.go
@@ -331,8 +331,7 @@ func backendsToLoadAssignments(
 				continue
 			}
 		}
-		for _, beWithRev := range fe.Backends {
-			be := beWithRev.Backend
+		for be := range fe.Backends {
 			if be.State != loadbalancer.BackendStateActive {
 				continue
 			}

--- a/pkg/loadbalancer/experimental/benchmark/benchmark.go
+++ b/pkg/loadbalancer/experimental/benchmark/benchmark.go
@@ -437,9 +437,10 @@ func checkTables(db *statedb.DB, writer *experimental.Writer, svcs []*slim_corev
 				if fe.Status.Kind != "Done" {
 					err = errors.Join(err, fmt.Errorf("Incorrect status for frontend #%06d, got %v, want %v", i, fe.Status.Kind, "Done"))
 				}
+				backends := slices.Collect(statedb.ToSeq(fe.Backends))
 				for wantAddr := range epSlices[i].Backends { // There is only one element in this map.
-					if fe.Backends[0].AddrCluster != wantAddr {
-						err = errors.Join(err, fmt.Errorf("Incorrect backend address for frontend #%06d, got %v, want %v", i, fe.Backends[0].AddrCluster, wantAddr))
+					if backends[0].AddrCluster != wantAddr {
+						err = errors.Join(err, fmt.Errorf("Incorrect backend address for frontend #%06d, got %v, want %v", i, backends[0].AddrCluster, wantAddr))
 					}
 				}
 

--- a/pkg/loadbalancer/experimental/bpf_reconciler.go
+++ b/pkg/loadbalancer/experimental/bpf_reconciler.go
@@ -964,7 +964,11 @@ func (ops *BPFOps) computeMaglevTable(svc *Service, bes []BackendWithRevision) (
 //
 // Backends are sorted to deterministically to keep the order stable in BPF maps
 // when updating.
-func sortedBackends(bes []BackendWithRevision) []BackendWithRevision {
+func sortedBackends(beIter iter.Seq2[*Backend, statedb.Revision]) []BackendWithRevision {
+	bes := []BackendWithRevision{}
+	for be, rev := range beIter {
+		bes = append(bes, BackendWithRevision{be, rev})
+	}
 	sort.Slice(bes, func(i, j int) bool {
 		a, b := bes[i], bes[j]
 		switch {

--- a/pkg/loadbalancer/experimental/cell.go
+++ b/pkg/loadbalancer/experimental/cell.go
@@ -40,6 +40,10 @@ var Cell = cell.Module(
 
 	// Provide the 'lb/' script commands for debugging and testing.
 	cell.Provide(scriptCommands),
+
+	// Health server runs an HTTP server for each service on port [HealthCheckNodePort]
+	// (when non-zero) and responds with the number of healthy backends.
+	healthServerCell,
 )
 
 // TablesCell provides the [Writer] API for configuring load-balancing and the

--- a/pkg/loadbalancer/experimental/config.go
+++ b/pkg/loadbalancer/experimental/config.go
@@ -40,28 +40,35 @@ type TestConfig struct {
 	// NodePortAlg mirrors option.Config.NodePortAlg. This can be removed when the NodePort config
 	// flags move away from option.DaemonConfig and can thus be set directly.
 	NodePortAlg string `mapstructure:"node-port-algorithm"`
+
+	// EnableHealthCheckNodePort is defined here to allow script tests to enable this.
+	// Can be removed once this option moves out from DaemonConfig into [Config].
+	EnableHealthCheckNodePort bool `mapstructure:"enable-health-check-nodeport"`
 }
 
 func (def TestConfig) Flags(flags *pflag.FlagSet) {
 	flags.Float32("lb-test-fault-probability", def.TestFaultProbability, "Probability for fault injection in LBMaps")
 	flags.String("node-port-algorithm", option.NodePortAlgRandom, "NodePort algorithm")
+	flags.Bool("enable-health-check-nodeport", false, "Enable the NodePort health check server")
 }
 
 // ExternalConfig are configuration options derived from external sources such as
 // DaemonConfig. This avoids direct access of larger configuration structs.
 type ExternalConfig struct {
-	ExternalClusterIP        bool
-	EnableSessionAffinity    bool
-	NodePortMin, NodePortMax uint16
-	NodePortAlg              string
+	ExternalClusterIP         bool
+	EnableSessionAffinity     bool
+	EnableHealthCheckNodePort bool
+	NodePortMin, NodePortMax  uint16
+	NodePortAlg               string
 }
 
 func newExternalConfig(cfg *option.DaemonConfig) ExternalConfig {
 	return ExternalConfig{
-		ExternalClusterIP:     cfg.ExternalClusterIP,
-		EnableSessionAffinity: cfg.EnableSessionAffinity,
-		NodePortMin:           uint16(cfg.NodePortMin),
-		NodePortMax:           uint16(cfg.NodePortMax),
-		NodePortAlg:           cfg.NodePortAlg,
+		ExternalClusterIP:         cfg.ExternalClusterIP,
+		EnableSessionAffinity:     cfg.EnableSessionAffinity,
+		EnableHealthCheckNodePort: cfg.EnableHealthCheckNodePort,
+		NodePortMin:               uint16(cfg.NodePortMin),
+		NodePortMax:               uint16(cfg.NodePortMax),
+		NodePortAlg:               cfg.NodePortAlg,
 	}
 }

--- a/pkg/loadbalancer/experimental/frontend.go
+++ b/pkg/loadbalancer/experimental/frontend.go
@@ -4,6 +4,7 @@
 package experimental
 
 import (
+	"iter"
 	"net/netip"
 	"strings"
 
@@ -50,7 +51,7 @@ type Frontend struct {
 	Status reconciler.Status
 
 	// Backends associated with the frontend.
-	Backends []BackendWithRevision
+	Backends iter.Seq2[*Backend, statedb.Revision]
 
 	// nodePortAddrs are the IP addresses on which to serve NodePort and HostPort
 	// services. Not set if [Type] is not NodePort or HostPort. These are updated
@@ -118,9 +119,9 @@ func (fe *Frontend) TableRow() []string {
 // showBackends returns the backends associated with a frontend in form
 // "1.2.3.4:80 (active), [2001::1]:443 (terminating)"
 // TODO: Skip showing the state?
-func showBackends(bes []BackendWithRevision) string {
+func showBackends(bes iter.Seq2[*Backend, statedb.Revision]) string {
 	var b strings.Builder
-	for i, be := range bes {
+	for be := range bes {
 		b.WriteString(be.L3n4Addr.String())
 		b.WriteString(" (")
 		state, err := be.State.String()
@@ -129,11 +130,11 @@ func showBackends(bes []BackendWithRevision) string {
 		}
 		b.WriteString(state)
 		b.WriteString(")")
-		if i != len(bes)-1 {
-			b.WriteString(", ")
-		}
+		b.WriteString(", ")
 	}
-	return b.String()
+	s := b.String()
+	s, _ = strings.CutSuffix(s, ", ")
+	return s
 }
 
 var (

--- a/pkg/loadbalancer/experimental/healthserver.go
+++ b/pkg/loadbalancer/experimental/healthserver.go
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package experimental
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	lb "github.com/cilium/cilium/pkg/loadbalancer"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// healthServerCell implements the support for the HealthCheckNodePort field.
+// For each service that has HealthCheckNodePort set to a non-zero value it
+// starts an HTTP server on that port and responds with the number of active
+// node-local backends. This allows external load-balancers to avoid directing
+// traffic to services that have no available backends.
+var healthServerCell = cell.Module(
+	"healthserver",
+	"Serves service health status to external load-balancers",
+	cell.Invoke(registerHealthServer),
+)
+
+type healthServerParams struct {
+	cell.In
+
+	Jobs      job.Group
+	Log       *slog.Logger
+	DB        *statedb.DB
+	Config    Config
+	ExtConfig ExternalConfig
+	Frontends statedb.Table[*Frontend]
+	Backends  statedb.Table[*Backend]
+	Writer    *Writer
+}
+
+// healthServer manages HTTP health check ports. For each added service,
+// it opens a HTTP server on the specified HealthCheckNodePort and either
+// responds with 200 OK if there are local endpoints for the service, or with
+// 503 Service Unavailable if the service does not have any local endpoints.
+type healthServer struct {
+	params        healthServerParams
+	serverByPort  map[uint16]*httpHealthServer
+	portByService map[lb.ServiceName]uint16
+	nodeName      string
+}
+
+func registerHealthServer(params healthServerParams) {
+	if !params.Config.EnableExperimentalLB || !params.ExtConfig.EnableHealthCheckNodePort {
+		return
+	}
+
+	s := &healthServer{
+		params:        params,
+		serverByPort:  map[uint16]*httpHealthServer{},
+		portByService: map[lb.ServiceName]uint16{},
+	}
+	params.Jobs.Add(job.OneShot("control-loop", s.controlLoop))
+}
+
+var (
+	// healthServerAddr is the IP address on which the health HTTP servers
+	// listen on.
+	healthServerAddr = cmtypes.MustParseAddrCluster("127.0.0.88")
+)
+
+func (s *healthServer) controlLoop(ctx context.Context, health cell.Health) error {
+	s.nodeName = nodeTypes.GetName()
+
+	// Watch services for changes to add and remove the listeners.
+	wtxn := s.params.DB.WriteTxn(s.params.Frontends)
+	frontendChanges, err := s.params.Frontends.Changes(wtxn)
+	wtxn.Commit()
+	if err != nil {
+		return err
+	}
+
+	// Limit the rate at which the change batches are processed.
+	limiter := rate.NewLimiter(100*time.Millisecond, 1)
+
+	defer s.cleanupListeners(ctx)
+
+	for {
+		if err := limiter.Wait(ctx); err != nil {
+			return err
+		}
+
+		changes, watch := frontendChanges.Next(s.params.DB.ReadTxn())
+		for change := range changes {
+			fe := change.Object
+			if fe.Type != lb.SVCTypeLoadBalancer {
+				continue
+			}
+
+			svc := fe.service
+			name := svc.Name
+			healthServiceName := name.AppendSuffix("-healthserver")
+			port := svc.HealthCheckNodePort
+
+			// Health server is only for LoadBalancer services with a local
+			// traffic policy.
+			needsServer := !change.Deleted &&
+				port > 0 &&
+				svc.ExtTrafficPolicy == lb.SVCTrafficPolicyLocal
+
+			// Check if a health checker server exists already for this service and remove it if port has changed
+			// or if the service is no longer applicable.
+			oldPort, exists := s.portByService[name]
+			if exists && (oldPort != port || !needsServer) {
+				s.removeListener(ctx, oldPort)
+				delete(s.portByService, name)
+				exists = false
+				wtxn := s.params.Writer.WriteTxn()
+				s.params.Writer.DeleteServiceAndFrontends(
+					wtxn,
+					healthServiceName,
+				)
+				wtxn.Commit()
+			}
+
+			if !needsServer || exists {
+				continue
+			}
+
+			s.serverByPort[port] = s.addListener(svc, port)
+			s.portByService[name] = port
+
+			// Create a NodePort service to expose the health server.
+			wtxn := s.params.Writer.WriteTxn()
+			s.params.Writer.UpsertServiceAndFrontends(
+				wtxn,
+				&Service{
+					Name:             healthServiceName,
+					Source:           source.Local,
+					ExtTrafficPolicy: lb.SVCTrafficPolicyLocal,
+					IntTrafficPolicy: lb.SVCTrafficPolicyLocal,
+				},
+				FrontendParams{
+					Address: lb.L3n4Addr{
+						AddrCluster: fe.Address.AddrCluster,
+						L4Addr: lb.L4Addr{
+							Protocol: lb.TCP,
+							Port:     port,
+						},
+						Scope: lb.ScopeExternal,
+					},
+					Type:        fe.Type,
+					ServiceName: healthServiceName,
+					ServicePort: port,
+				},
+			)
+			s.params.Writer.UpsertBackends(
+				wtxn,
+				healthServiceName,
+				source.Local,
+				BackendParams{
+					L3n4Addr: lb.L3n4Addr{
+						AddrCluster: healthServerAddr,
+						L4Addr: lb.L4Addr{
+							Protocol: lb.TCP,
+							Port:     port,
+						},
+						Scope: lb.ScopeInternal,
+					},
+					NodeName: s.nodeName,
+					State:    lb.BackendStateActive,
+				},
+			)
+			wtxn.Commit()
+		}
+		health.OK(fmt.Sprintf("%d health servers running", len(s.serverByPort)))
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-watch:
+		}
+	}
+}
+
+func (s *healthServer) cleanupListeners(ctx context.Context) {
+	for _, srv := range s.serverByPort {
+		srv.shutdown(ctx)
+	}
+}
+
+func (s *healthServer) addListener(svc *Service, port uint16) *httpHealthServer {
+	srv := &httpHealthServer{
+		nodeName: s.nodeName,
+		name:     svc.Name,
+		svc:      svc,
+		db:       s.params.DB,
+		backends: s.params.Backends,
+	}
+	srv.Server = http.Server{
+		Addr:    fmt.Sprintf("%s:%d", healthServerAddr.Addr().String(), port),
+		Handler: srv,
+	}
+	s.params.Jobs.Add(
+		job.OneShot(
+			fmt.Sprintf("listener-%d", port),
+			func(ctx context.Context, health cell.Health) error {
+				if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+					return err
+				}
+				return nil
+			},
+			job.WithRetry(-1, &job.ExponentialBackoff{
+				Min: 200 * time.Millisecond,
+				Max: 10 * time.Second,
+			}),
+		),
+	)
+
+	return srv
+}
+
+func (s *healthServer) removeListener(ctx context.Context, port uint16) {
+	if srv, ok := s.serverByPort[port]; ok {
+		srv.shutdown(ctx)
+		delete(s.serverByPort, port)
+	}
+}
+
+type healthResponseServiceName struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+// healthResponse represents the object returned by the health server
+type healthResponse struct {
+	Service        healthResponseServiceName `json:"service"`
+	LocalEndpoints int                       `json:"localEndpoints"`
+}
+
+type httpHealthServer struct {
+	http.Server
+
+	nodeName string
+	name     lb.ServiceName
+	svc      *Service
+	db       *statedb.DB
+	backends statedb.Table[*Backend]
+}
+
+func (h *httpHealthServer) getLocalEndpointCount() int {
+	if h.svc.ProxyRedirect != nil {
+		// Traffic is redirected to a proxy and thus we have no information on
+		// the actual backends. Return a synthetic single backend in this case.
+		return 1
+	}
+
+	txn := h.db.ReadTxn()
+
+	// Gather the backends. Since the service has traffic policy set to local the
+	// backends we find here are node local.
+	activeCount := 0
+	for be := range h.backends.List(txn, BackendByServiceName(h.name)) {
+		if be.State == lb.BackendStateActive {
+			activeCount++
+		}
+	}
+	return activeCount
+}
+
+func (h *httpHealthServer) shutdown(ctx context.Context) {
+	h.Server.Shutdown(ctx)
+}
+
+func (h *httpHealthServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Use headers and JSON output compatible with kube-proxy
+	response := healthResponse{
+		Service:        healthResponseServiceName{Namespace: h.name.Namespace, Name: h.name.Name},
+		LocalEndpoints: h.getLocalEndpointCount(),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Load-Balancing-Endpoint-Weight", strconv.Itoa(response.LocalEndpoints))
+
+	if response.LocalEndpoints == 0 {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/pkg/loadbalancer/experimental/script_test.go
+++ b/pkg/loadbalancer/experimental/script_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/maglev"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
@@ -39,6 +40,9 @@ func TestScript(t *testing.T) {
 
 	// pkg/k8s/endpoints.go uses this in ParseEndpointSlice*
 	option.Config.EnableK8sTerminatingEndpoint = true
+
+	// Set the node name
+	nodeTypes.SetName("testnode")
 
 	log := hivetest.Logger(t)
 

--- a/pkg/loadbalancer/experimental/testdata/healthserver.txtar
+++ b/pkg/loadbalancer/experimental/testdata/healthserver.txtar
@@ -1,0 +1,240 @@
+#! --enable-experimental-lb --enable-health-check-nodeport --lb-test-fault-probability=0.0
+
+# Start and wait for initialization.
+hive start
+db/initialized
+
+# Replace the port numbers
+cp service.yaml service2.yaml
+cp service.yaml service_no_health.yaml
+replace '$PORT' $PORT1 service.yaml
+replace '$PORT' $PORT2 service2.yaml
+replace '$PORT' 0 service_no_health.yaml
+replace '$PORT1' $PORT1 services.table
+replace '$PORT1' $PORT1 health_with_service.table
+replace '$PORT' $PORT1 frontends.table
+replace '$PORT' $PORT1 backends.table
+replace '$PORT' $PORT1 lbmaps.expected
+
+# HealthServer's jobs should be reported in module health
+db/cmp --grep=^loadbalancer health health_no_service.table
+
+# Add a node address, service and endpoints.
+db/insert node-addresses addrv4.yaml
+db/cmp node-addresses nodeaddrs.table
+k8s add service.yaml endpointslice.yaml
+db/cmp --grep=^loadbalancer health health_with_service.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table 
+
+# Check the BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
+
+# Validate health server response
+* http/get http://127.0.0.88:$PORT1 healthserver.actual
+cmp healthserver.expected healthserver.actual
+
+# Test changing the health check port
+k8s update service2.yaml
+
+# Check that the frontend for the health server is updated
+replace $PORT1 $PORT2 frontends.table
+db/cmp frontends frontends.table
+replace $PORT1 $PORT2 backends.table
+db/cmp backends backends.table
+
+# Check that $PORT2 now responds and old port does not.
+* http/get http://127.0.0.88:$PORT2 healthserver.actual
+cmp healthserver.expected healthserver.actual
+!* http/get http://127.0.0.88:$PORT1 healthserver.actual
+
+# Setting the traffic policy to Cluster makes the service
+# unqualified for health server, removing it.
+cp service2.yaml service2_tpcluster.yaml
+replace 'externalTrafficPolicy: Local' 'externalTrafficPolicy: Cluster' service2_tpcluster.yaml
+replace 'internalTrafficPolicy: Local' 'internalTrafficPolicy: Cluster' service2_tpcluster.yaml
+k8s update service2_tpcluster.yaml
+db/cmp frontends frontends_tpcluster.table
+
+# The health checker server should be down now.
+!* http/get http://127.0.0.88:$PORT2 healthserver.actual
+
+# Restore health checking for next test.
+k8s update service2.yaml
+* http/get http://127.0.0.88:$PORT2 healthserver.actual
+cmp healthserver.expected healthserver.actual
+
+# Test removing the health check port
+k8s update service_no_health.yaml
+
+# Both ports should now stop responding
+# "!*" means expect failure and retry if needed
+!* http/get http://127.0.0.88:$PORT2 healthserver.actual
+!* http/get http://127.0.0.88:$PORT1 healthserver.actual
+
+db/cmp frontends frontends_nohealthcheck.table
+db/cmp backends backends_nohealthcheck.table
+
+#####
+
+-- addrv4.yaml --
+addr: 1.1.1.1
+nodeport: true
+primary: true
+devicename: test
+
+-- health_no_service.table --
+Module                                   Component                   Level   Message                    Error   
+loadbalancer-experimental.healthserver   job-control-loop            OK      0 health servers running   
+loadbalancer-experimental.reconciler     job-reconcile               OK      OK, 0 object(s)            
+loadbalancer-experimental.reconciler     job-refresh                 OK      Next refresh in 30m0s      
+loadbalancer-experimental.reflector      job-reflector               OK      Running                    
+
+-- health_with_service.table --
+Module                                   Component                   Level   Message                    Error   
+loadbalancer-experimental.healthserver   job-control-loop            OK      1 health servers running   
+loadbalancer-experimental.healthserver   job-listener-$PORT1          OK      Running
+loadbalancer-experimental.reconciler     job-reconcile               OK      OK, 3 object(s)            
+loadbalancer-experimental.reconciler     job-refresh                 OK      Next refresh in 30m0s      
+loadbalancer-experimental.reflector      job-reflector               OK      Running                    
+
+-- nodeaddrs.table --
+Address NodePort Primary DeviceName
+1.1.1.1 true     true    test
+
+-- services.table --
+Name                   Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   HealthCheckNodePort   
+test/echo              k8s                  Local              Local              $PORT1
+test/echo-healthserver local                Local              Local              0
+
+-- frontends.table --
+Address               Type         ServiceName            PortName   Status  Backends
+10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active)
+172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active)
+172.16.1.1:$PORT/TCP  LoadBalancer test/echo-healthserver            Done    127.0.0.88:$PORT/TCP/i (active)
+
+-- frontends_nohealthcheck.table --
+Address               Type         ServiceName            PortName   Status  Backends
+10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active)
+172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active)
+
+-- frontends_tpcluster.table --
+Address               Type         ServiceName            PortName   Status  Backends
+10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
+172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
+
+-- frontends_empty.table --
+Address               Type        ServiceName   PortName   Status  Backends
+
+-- backends.table --
+Address                State    Instances              NodeName     ZoneID
+10.244.1.1:80/TCP      active   test/echo (http)       testnode     0
+10.244.1.2:80/TCP      active   test/echo (http)       testnode     0
+10.244.1.3:80/TCP      active   test/echo (http)       othernode    0
+10.244.1.4:80/TCP      active   test/echo (http)       othernode    0
+127.0.0.88:$PORT/TCP/i active   test/echo-healthserver testnode     0
+
+-- backends_nohealthcheck.table --
+Address               State    Instances              NodeName     ZoneID
+10.244.1.1:80/TCP     active   test/echo (http)       testnode     0
+10.244.1.2:80/TCP     active   test/echo (http)       testnode     0
+10.244.1.3:80/TCP     active   test/echo (http)       othernode    0
+10.244.1.4:80/TCP     active   test/echo (http)       othernode    0
+
+-- backends_empty.table --
+Address             State    Instances            NodeName           ZoneID
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: echo
+  namespace: test
+  resourceVersion: "741"
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  externalTrafficPolicy: Local
+  internalTrafficPolicy: Local
+  healthCheckNodePort: $PORT
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 172.16.1.1
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  annotations:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  generateName: echo-
+  generation: 3
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+  resourceVersion: "797"
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  nodeName: testnode
+- addresses:
+  - 10.244.1.2
+  nodeName: testnode
+- addresses:
+  - 10.244.1.3
+  nodeName: othernode
+- addresses:
+  - 10.244.1.4
+  nodeName: othernode
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- healthserver.expected --
+200 OK
+Content-Length=66
+Content-Type=application/json
+Date=<omitted>
+X-Content-Type-Options=nosniff
+X-Load-Balancing-Endpoint-Weight=4
+---
+{"service":{"namespace":"test","name":"echo"},"localEndpoints":4}
+-- lbmaps.expected --
+BE: ID=1 ADDR=10.244.1.1:80 STATE=active
+BE: ID=2 ADDR=10.244.1.2:80 STATE=active
+BE: ID=3 ADDR=127.0.0.88:$PORT STATE=active
+REV: ID=1 ADDR=10.96.50.104:80
+REV: ID=2 ADDR=172.16.1.1:80
+REV: ID=3 ADDR=172.16.1.1:$PORT
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=0 BEID=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable
+SVC: ID=2 ADDR=172.16.1.1:80 SLOT=0 BEID=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
+SVC: ID=2 ADDR=172.16.1.1:80 SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
+SVC: ID=2 ADDR=172.16.1.1:80 SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
+SVC: ID=3 ADDR=172.16.1.1:$PORT SLOT=0 BEID=0 COUNT=1 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
+SVC: ID=3 ADDR=172.16.1.1:$PORT SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal

--- a/pkg/loadbalancer/experimental/testdata/trafficpolicy.txtar
+++ b/pkg/loadbalancer/experimental/testdata/trafficpolicy.txtar
@@ -1,0 +1,103 @@
+#! --enable-experimental-lb
+
+# Start the test application
+hive start
+
+# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
+db/initialized
+
+# Create a LoadBalancer service with Local traffic policies and associate two backends 
+# to it, one of them on this node ("testnode") and one on another node.
+k8s add service.yaml endpointslice.yaml
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table 
+
+# Check the BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
+
+#####
+
+-- services.table --
+Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy
+test/echo   k8s                  Local              Local           
+
+-- frontends.table --
+Address               Type         ServiceName   PortName   Backends                     Status
+1.1.1.1:80/TCP        LoadBalancer test/echo     http       10.244.1.1:80/TCP (active)   Done
+10.96.50.104:80/TCP   ClusterIP    test/echo     http       10.244.1.1:80/TCP (active)   Done
+
+-- backends.table --
+Address             State    Instances          NodeName
+10.244.1.1:80/TCP   active   test/echo (http)   testnode
+10.244.2.1:80/TCP   active   test/echo (http)   othernode
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  resourceVersion: "741"
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  externalTrafficPolicy: Local
+  internalTrafficPolicy: Local
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 1.1.1.1
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+  resourceVersion: "797"
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+
+- addresses:
+  - 10.244.2.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: othernode
+    
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- lbmaps.expected --
+BE: ID=1 ADDR=10.244.1.1:80 STATE=active
+REV: ID=1 ADDR=10.96.50.104:80
+REV: ID=2 ADDR=1.1.1.1:80
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=0 BEID=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable
+SVC: ID=2 ADDR=1.1.1.1:80 SLOT=0 BEID=0 COUNT=1 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
+SVC: ID=2 ADDR=1.1.1.1:80 SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal

--- a/pkg/loadbalancer/experimental/writer.go
+++ b/pkg/loadbalancer/experimental/writer.go
@@ -6,6 +6,7 @@ package experimental
 import (
 	"fmt"
 	"io"
+	"iter"
 	"net/netip"
 	"strings"
 	"text/tabwriter"
@@ -18,11 +19,13 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/source"
 )
 
 // Writer provides validated write access to the service load-balancing state.
 type Writer struct {
+	nodeName  string
 	db        *statedb.DB
 	nodeAddrs statedb.Table[tables.NodeAddress]
 	svcs      statedb.RWTable[*Service]
@@ -57,6 +60,7 @@ func NewWriter(p writerParams) (*Writer, error) {
 		return nil, nil
 	}
 	w := &Writer{
+		nodeName:         nodeTypes.GetName(),
 		db:               p.DB,
 		bes:              p.Backends,
 		fes:              p.Frontends,
@@ -238,7 +242,7 @@ func (w *Writer) newFrontend(txn statedb.ReadTxn, params FrontendParams, svc *Se
 
 func (w *Writer) refreshFrontend(txn statedb.ReadTxn, fe *Frontend) {
 	fe.Status = reconciler.StatusPending()
-	fe.Backends = getBackendsForFrontend(txn, w.bes, fe)
+	fe.Backends = getBackendsForFrontend(txn, w.bes, w.nodeName, fe)
 
 	if fe.Type == loadbalancer.SVCTypeNodePort ||
 		fe.Type == loadbalancer.SVCTypeHostPort {
@@ -259,26 +263,34 @@ func (w *Writer) refreshFrontendsOfService(txn WriteTxn, name loadbalancer.Servi
 	return nil
 }
 
-func getBackendsForFrontend(txn statedb.ReadTxn, tbl statedb.Table[*Backend], fe *Frontend) []BackendWithRevision {
-	out := []BackendWithRevision{}
-	for be, rev := range tbl.List(txn, BackendByServiceName(fe.ServiceName)) {
-		if be.L3n4Addr.IsIPv6() != fe.Address.IsIPv6() {
-			continue
-		}
-		if fe.PortName != "" {
-			// A backend with specific port name requested. Look up what this backend
-			// is called for this service.
-			instance := be.GetInstance(fe.ServiceName)
-			if instance == nil {
+func getBackendsForFrontend(txn statedb.ReadTxn, tbl statedb.Table[*Backend], nodeName string, fe *Frontend) iter.Seq2[*Backend, statedb.Revision] {
+	onlyLocal := shouldUseLocalBackends(fe)
+	isIPv6 := fe.Address.IsIPv6()
+
+	return func(yield func(*Backend, statedb.Revision) bool) {
+		for be, rev := range tbl.List(txn, BackendByServiceName(fe.ServiceName)) {
+			if be.L3n4Addr.IsIPv6() != isIPv6 {
 				continue
 			}
-			if string(fe.PortName) != instance.PortName {
+			if onlyLocal && len(be.NodeName) != 0 && be.NodeName != nodeName {
 				continue
 			}
+			if fe.PortName != "" {
+				// A backend with specific port name requested. Look up what this backend
+				// is called for this service.
+				instance := be.GetInstance(fe.ServiceName)
+				if instance == nil {
+					continue
+				}
+				if string(fe.PortName) != instance.PortName {
+					continue
+				}
+			}
+			if !yield(be, rev) {
+				return
+			}
 		}
-		out = append(out, BackendWithRevision{be, rev})
 	}
-	return out
 }
 
 func (w *Writer) DeleteServiceAndFrontends(txn WriteTxn, name loadbalancer.ServiceName) error {
@@ -581,4 +593,44 @@ func (w *Writer) DebugDump(txn statedb.ReadTxn, to io.Writer) {
 	}
 
 	tw.Flush()
+}
+
+func isExtLocal(fe *Frontend) bool {
+	switch fe.Type {
+	case loadbalancer.SVCTypeNodePort, loadbalancer.SVCTypeLoadBalancer, loadbalancer.SVCTypeExternalIPs:
+		return fe.service.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal
+	default:
+		return false
+	}
+}
+
+func isIntLocal(fe *Frontend) bool {
+	/* FIXME if !option.Config.EnableInternalTrafficPolicy {
+		return false
+	}*/
+	switch fe.Type {
+	case loadbalancer.SVCTypeClusterIP, loadbalancer.SVCTypeNodePort, loadbalancer.SVCTypeLoadBalancer, loadbalancer.SVCTypeExternalIPs:
+		return fe.service.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal
+	default:
+		return false
+	}
+}
+
+func shouldUseLocalBackends(fe *Frontend) bool {
+	// When both traffic policies are Local, there is only the external scope, which
+	// should contain node-local backends only. Checking isExtLocal is still enough.
+	switch fe.Address.Scope {
+	case loadbalancer.ScopeExternal:
+		if fe.Type == loadbalancer.SVCTypeClusterIP {
+			// ClusterIP doesn't support externalTrafficPolicy and has only the
+			// external scope, which contains only node-local backends when
+			// internalTrafficPolicy=Local.
+			return isIntLocal(fe)
+		}
+		return isExtLocal(fe)
+	case loadbalancer.ScopeInternal:
+		return isIntLocal(fe)
+	default:
+		return false
+	}
 }

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -480,6 +480,14 @@ func (n ServiceName) String() string {
 	return n.Namespace + "/" + n.Name
 }
 
+func (n ServiceName) AppendSuffix(suffix string) ServiceName {
+	return ServiceName{
+		Namespace: n.Namespace,
+		Name:      n.Name + suffix,
+		Cluster:   n.Cluster,
+	}
+}
+
 // BackendID is the backend's ID.
 type BackendID uint32
 


### PR DESCRIPTION
This implements the HealthCheckNodePort functionality for running a HTTP health server that responds with the number of active backends a service has available.