### PR TITLE
ipsec: Simplify XFRM IN policies and templates

### DIFF
--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -220,38 +220,39 @@ func (n *linuxNodeHandler) enableIPSecIPv4DoSubnetEncryption(newNode *nodeTypes.
 		if err != nil {
 			statesUpdated = false
 		}
-
-		// insert fwd rule
-		params = ipsec.NewIPSecParamaters(template)
-		params.Dir = ipsec.IPSecDirFwd
-		params.SourceSubnet = wildcardCIDR
-		params.DestSubnet = wildcardCIDR
-		params.SourceTunnelIP = &net.IP{}
-		params.DestTunnelIP = &localIP
-		spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
-		errs = errors.Join(errs, upsertIPsecLog(n.log, err, "fwd IPv4", params.SourceSubnet, params.DestSubnet, spi, nodeID))
-
-		params = ipsec.NewIPSecParamaters(template)
-		params.Dir = ipsec.IPSecDirIn
-		params.SourceSubnet = wildcardCIDR
-		params.DestSubnet = wildcardCIDR
-		params.SourceTunnelIP = &remoteCiliumInternalIP
-		params.DestTunnelIP = &localCiliumInternalIP
-		spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
-		errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in CiliumInternalIPv4", params.SourceSubnet, params.DestSubnet, spi, nodeID))
-		if err != nil {
-			statesUpdated = false
-		}
-
-		// we just need to update the tunnel ips here...
-		params.SourceTunnelIP = &remoteNodeInternalIP
-		params.DestTunnelIP = &localNodeInternalIP
-		spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
-		errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in NodeInternalIPv4", params.SourceSubnet, params.DestSubnet, spi, nodeID))
-		if err != nil {
-			statesUpdated = false
-		}
 	}
+
+	// insert fwd rule
+	params := ipsec.NewIPSecParamaters(template)
+	params.Dir = ipsec.IPSecDirFwd
+	params.SourceSubnet = wildcardCIDR
+	params.DestSubnet = wildcardCIDR
+	params.SourceTunnelIP = &net.IP{}
+	params.DestTunnelIP = &localIP
+	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
+	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "fwd IPv4", params.SourceSubnet, params.DestSubnet, spi, nodeID))
+
+	params = ipsec.NewIPSecParamaters(template)
+	params.Dir = ipsec.IPSecDirIn
+	params.SourceSubnet = wildcardCIDR
+	params.DestSubnet = wildcardCIDR
+	params.SourceTunnelIP = &remoteCiliumInternalIP
+	params.DestTunnelIP = &localCiliumInternalIP
+	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
+	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in CiliumInternalIPv4", params.SourceSubnet, params.DestSubnet, spi, nodeID))
+	if err != nil {
+		statesUpdated = false
+	}
+
+	// we just need to update the tunnel ips here...
+	params.SourceTunnelIP = &remoteNodeInternalIP
+	params.DestTunnelIP = &localNodeInternalIP
+	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
+	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in NodeInternalIPv4", params.SourceSubnet, params.DestSubnet, spi, nodeID))
+	if err != nil {
+		statesUpdated = false
+	}
+
 	return statesUpdated, errs
 }
 
@@ -467,39 +468,39 @@ func (n *linuxNodeHandler) enableIPSecIPv6DoSubnetEncryption(newNode *nodeTypes.
 		if err != nil {
 			statesUpdated = false
 		}
+	}
 
-		params = ipsec.NewIPSecParamaters(template)
-		params.Dir = ipsec.IPSecDirFwd
-		params.SourceSubnet = wildcardCIDR6
-		params.DestSubnet = wildcardCIDR6
-		params.SourceTunnelIP = &net.IP{}
-		params.DestTunnelIP = &localIP
-		spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
-		errs = errors.Join(errs, upsertIPsecLog(n.log, err, "fwd IPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
-		if err != nil {
-			statesUpdated = false
-		}
+	params := ipsec.NewIPSecParamaters(template)
+	params.Dir = ipsec.IPSecDirFwd
+	params.SourceSubnet = wildcardCIDR6
+	params.DestSubnet = wildcardCIDR6
+	params.SourceTunnelIP = &net.IP{}
+	params.DestTunnelIP = &localIP
+	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
+	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "fwd IPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
+	if err != nil {
+		statesUpdated = false
+	}
 
-		params = ipsec.NewIPSecParamaters(template)
-		params.Dir = ipsec.IPSecDirIn
-		params.SourceSubnet = wildcardCIDR6
-		params.DestSubnet = wildcardCIDR6
-		params.SourceTunnelIP = &remoteCiliumInternalIP
-		params.DestTunnelIP = &localCiliumInternalIP
-		spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
-		errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in CiliumInternalIPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
-		if err != nil {
-			statesUpdated = false
-		}
+	params = ipsec.NewIPSecParamaters(template)
+	params.Dir = ipsec.IPSecDirIn
+	params.SourceSubnet = wildcardCIDR6
+	params.DestSubnet = wildcardCIDR6
+	params.SourceTunnelIP = &remoteCiliumInternalIP
+	params.DestTunnelIP = &localCiliumInternalIP
+	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
+	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in CiliumInternalIPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
+	if err != nil {
+		statesUpdated = false
+	}
 
-		// we just need to update the tunnel ips here...
-		params.SourceTunnelIP = &remoteNodeInternalIP
-		params.DestTunnelIP = &localNodeInternalIP
-		spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
-		errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in NodeInternalIPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
-		if err != nil {
-			statesUpdated = false
-		}
+	// we just need to update the tunnel ips here...
+	params.SourceTunnelIP = &remoteNodeInternalIP
+	params.DestTunnelIP = &localNodeInternalIP
+	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
+	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in NodeInternalIPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
+	if err != nil {
+		statesUpdated = false
 	}
 
 	return statesUpdated, errs

--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -233,7 +233,7 @@ func (n *linuxNodeHandler) enableIPSecIPv4DoSubnetEncryption(newNode *nodeTypes.
 
 		params = ipsec.NewIPSecParamaters(template)
 		params.Dir = ipsec.IPSecDirIn
-		params.SourceSubnet = cidr
+		params.SourceSubnet = wildcardCIDR
 		params.DestSubnet = wildcardCIDR
 		params.SourceTunnelIP = &remoteCiliumInternalIP
 		params.DestTunnelIP = &localCiliumInternalIP
@@ -271,7 +271,6 @@ func (n *linuxNodeHandler) enableIPSecIPv4Do(newNode *nodeTypes.Node, nodeID uin
 	localCiliumInternalIP := n.nodeConfig.CiliumInternalIPv4
 	localIP := localCiliumInternalIP
 
-	localCIDR := n.nodeConfig.AllocCIDRIPv4.IPNet
 	remoteCIDR := newNode.IPv4AllocCIDR.IPNet
 	if err := n.replaceNodeIPSecOutRoute(remoteCIDR); err != nil {
 		errs = errors.Join(errs, fmt.Errorf("failed to replace ipsec OUT (%q): %w", remoteCIDR.IP, err))
@@ -312,7 +311,7 @@ func (n *linuxNodeHandler) enableIPSecIPv4Do(newNode *nodeTypes.Node, nodeID uin
 	params = ipsec.NewIPSecParamaters(template)
 	params.Dir = ipsec.IPSecDirIn
 	params.SourceSubnet = wildcardCIDR
-	params.DestSubnet = localCIDR
+	params.DestSubnet = wildcardCIDR
 	params.SourceTunnelIP = &remoteIP
 	params.DestTunnelIP = &localIP
 	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
@@ -483,7 +482,7 @@ func (n *linuxNodeHandler) enableIPSecIPv6DoSubnetEncryption(newNode *nodeTypes.
 
 		params = ipsec.NewIPSecParamaters(template)
 		params.Dir = ipsec.IPSecDirIn
-		params.SourceSubnet = cidr
+		params.SourceSubnet = wildcardCIDR6
 		params.DestSubnet = wildcardCIDR6
 		params.SourceTunnelIP = &remoteCiliumInternalIP
 		params.DestTunnelIP = &localCiliumInternalIP
@@ -520,7 +519,6 @@ func (n *linuxNodeHandler) enableIPSecIPv6Do(newNode *nodeTypes.Node, nodeID uin
 	localCiliumInternalIP := n.nodeConfig.CiliumInternalIPv6
 	localIP := localCiliumInternalIP
 
-	localCIDR := n.nodeConfig.AllocCIDRIPv6.IPNet
 	remoteCIDR := newNode.IPv6AllocCIDR.IPNet
 	if err := n.replaceNodeIPSecOutRoute(remoteCIDR); err != nil {
 		errs = errors.Join(errs, fmt.Errorf("failed to replace ipsec OUT (%q): %w", remoteCIDR.IP, err))
@@ -564,7 +562,7 @@ func (n *linuxNodeHandler) enableIPSecIPv6Do(newNode *nodeTypes.Node, nodeID uin
 	params = ipsec.NewIPSecParamaters(template)
 	params.Dir = ipsec.IPSecDirIn
 	params.SourceSubnet = wildcardCIDR6
-	params.DestSubnet = localCIDR
+	params.DestSubnet = wildcardCIDR6
 	params.SourceTunnelIP = &remoteIP
 	params.DestTunnelIP = &localIP
 	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -596,8 +596,7 @@ func ipSecReplaceStateOut(log *slog.Logger, params *IPSecParameters) (uint8, err
 	return key.Spi, xfrmStateReplace(log, state, params.RemoteRebooted)
 }
 
-func _ipSecReplacePolicyIn(params *IPSecParameters, proxyMark bool, dir netlink.Dir) error {
-	optional := false
+func ipSecReplacePolicyIn(params *IPSecParameters) error {
 	// We can use the global IPsec key here because we are not going to
 	// actually use the secret itself.
 	key := getGlobalIPsecKey(params.DestSubnet.IP)
@@ -607,35 +606,11 @@ func _ipSecReplacePolicyIn(params *IPSecParameters, proxyMark bool, dir netlink.
 	key.ReqID = params.ReqID
 
 	policy := ipSecNewPolicy()
-	policy.Dir = dir
-	if dir == netlink.XFRM_DIR_IN {
-		policy.Src = params.SourceSubnet
-		policy.Dst = params.DestSubnet
-		policy.Mark = &netlink.XfrmMark{
-			Mask: linux_defaults.IPsecMarkBitMask,
-		}
-		if proxyMark {
-			// We require a policy to match on packets going to the proxy which are
-			// therefore carrying the proxy mark. We however don't need a policy
-			// for the encrypted packets because there is already a state matching
-			// them.
-			policy.Mark.Value = linux_defaults.RouteMarkToProxy
-			// We must mark the IN policy for the proxy optional simply because it
-			// is lacking a corresponding state.
-			optional = true
-		} else {
-			policy.Mark.Value = linux_defaults.RouteMarkDecrypt
-		}
-	}
-	ipSecAttachPolicyTempl(policy, key, *params.SourceTunnelIP, *params.DestTunnelIP, false, optional)
+	policy.Src = params.SourceSubnet
+	policy.Dst = params.DestSubnet
+	policy.Dir = netlink.XFRM_DIR_IN
+	ipSecAttachPolicyTempl(policy, key, *params.SourceTunnelIP, *params.DestTunnelIP, false, true)
 	return netlink.XfrmPolicyUpdate(policy)
-}
-
-func ipSecReplacePolicyIn(params *IPSecParameters) error {
-	if err := _ipSecReplacePolicyIn(params, true, netlink.XFRM_DIR_IN); err != nil {
-		return err
-	}
-	return _ipSecReplacePolicyIn(params, false, netlink.XFRM_DIR_IN)
 }
 
 func IpSecReplacePolicyFwd(params *IPSecParameters) error {

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -417,11 +417,11 @@ func TestUpsertIPSecEndpointFwd(t *testing.T) {
 	if !policyTmpl.Src.Equal(wildcardIPv4) {
 		t.Fatalf("Expected Src to be %s, but got %s", wildcardIPv4.String(), policyTmpl.Src.String())
 	}
-	if !policyTmpl.Dst.Equal(local.IP) {
-		t.Fatalf("Expected Dst to be %s, but got %s", local.IP.String(), policyTmpl.Dst.String())
+	if !policyTmpl.Dst.Equal(wildcardIPv4) {
+		t.Fatalf("Expected Dst to be %s, but got %s", wildcardIPv4.String(), policyTmpl.Dst.String())
 	}
 	require.Equal(t, netlink.XFRM_PROTO_ESP, policyTmpl.Proto)
-	require.Equal(t, params.ReqID, policyTmpl.Reqid)
+	require.Equal(t, 0, policyTmpl.Reqid)
 	require.Equal(t, netlink.XFRM_MODE_TUNNEL, policyTmpl.Mode)
 	require.Equal(t, 1, policyTmpl.Optional)
 }
@@ -505,10 +505,10 @@ func TestUpsertIPSecEndpointIn(t *testing.T) {
 
 	tmpls := []netlink.XfrmPolicyTmpl{
 		{
-			Src:   remote.IP,
-			Dst:   local.IP,
+			Src:   wildcardIPv4,
+			Dst:   wildcardIPv4,
 			Proto: netlink.XFRM_PROTO_ESP,
-			Reqid: params.ReqID,
+			Reqid: 0,
 			Mode:  netlink.XFRM_MODE_TUNNEL,
 		},
 	}
@@ -588,13 +588,13 @@ func TestUpsertIPSecEndpointIn(t *testing.T) {
 	policyTmpl = policy.Tmpls[0]
 	// l7 proxy policy has a wildcard source
 	if !policyTmpl.Src.Equal(wildcardIPv4) {
-		t.Fatalf("Expected Src to be %s, but got %s", remote.IP.String(), policyTmpl.Src.String())
+		t.Fatalf("Expected Src to be %s, but got %s", wildcardIPv4.String(), policyTmpl.Src.String())
 	}
-	if !policyTmpl.Dst.Equal(local.IP) {
-		t.Fatalf("Expected Dst to be %s, but got %s", local.IP.String(), policyTmpl.Dst.String())
+	if !policyTmpl.Dst.Equal(wildcardIPv4) {
+		t.Fatalf("Expected Dst to be %s, but got %s", wildcardIPv4.String(), policyTmpl.Dst.String())
 	}
 	require.Equal(t, netlink.XFRM_PROTO_ESP, policyTmpl.Proto)
-	require.Equal(t, params.ReqID, policyTmpl.Reqid)
+	require.Equal(t, 0, policyTmpl.Reqid)
 	require.Equal(t, netlink.XFRM_MODE_TUNNEL, policyTmpl.Mode)
 }
 

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -513,80 +513,27 @@ func TestUpsertIPSecEndpointIn(t *testing.T) {
 		},
 	}
 	policy, err := netlink.XfrmPolicyGet(&netlink.XfrmPolicy{
-		Src: remote,
-		Dst: local,
-		Dir: netlink.XFRM_DIR_IN,
-		Mark: &netlink.XfrmMark{
-			Mask:  linux_defaults.IPsecMarkBitMask,
-			Value: linux_defaults.RouteMarkDecrypt,
-		},
+		Src:   wildcardCIDRv4,
+		Dst:   wildcardCIDRv4,
+		Dir:   netlink.XFRM_DIR_IN,
 		Tmpls: tmpls,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, policy)
 
 	// ensure XFRM policy is as we want it...
-	if !policy.Src.IP.Equal(remote.IP) {
-		t.Fatalf("Expected Src to be %s, but got %s", remote.IP.String(), policy.Src.IP.String())
+	if !policy.Src.IP.Equal(wildcardIPv4) {
+		t.Fatalf("Expected Src to be %s, but got %s", wildcardIPv4.String(), policy.Src.IP.String())
 	}
-	if !policy.Dst.IP.Equal(local.IP) {
-		t.Fatalf("Expected Dst to be %s, but got %s", local.IP.String(), policy.Dst.IP.String())
+	if !policy.Dst.IP.Equal(wildcardIPv4) {
+		t.Fatalf("Expected Dst to be %s, but got %s", wildcardIPv4.String(), policy.Dst.IP.String())
 	}
 	require.Equal(t, netlink.XFRM_DIR_IN, policy.Dir)
-	require.Equal(t, uint32(linux_defaults.RouteMarkDecrypt), policy.Mark.Value)
-	require.Equal(t, uint32(linux_defaults.IPsecMarkBitMask), policy.Mark.Mask)
+	require.Nil(t, policy.Mark)
 	require.Len(t, policy.Tmpls, 1)
 
 	// ensure the template is correct as well...
 	policyTmpl := policy.Tmpls[0]
-	if !policyTmpl.Src.Equal(remote.IP) {
-		t.Fatalf("Expected Src to be %s, but got %s", remote.IP.String(), policyTmpl.Src.String())
-	}
-	if !policyTmpl.Dst.Equal(local.IP) {
-		t.Fatalf("Expected Dst to be %s, but got %s", local.IP.String(), policyTmpl.Dst.String())
-	}
-	require.Equal(t, netlink.XFRM_PROTO_ESP, policyTmpl.Proto)
-	require.Equal(t, params.ReqID, policyTmpl.Reqid)
-	require.Equal(t, netlink.XFRM_MODE_TUNNEL, policyTmpl.Mode)
-
-	// Confirm a policy was created for L7 traffic as well...
-	tmpls = []netlink.XfrmPolicyTmpl{
-		{
-			Src:   remote.IP,
-			Dst:   local.IP,
-			Proto: netlink.XFRM_PROTO_ESP,
-			Reqid: params.ReqID,
-			Mode:  netlink.XFRM_MODE_TUNNEL,
-		},
-	}
-	policy, err = netlink.XfrmPolicyGet(&netlink.XfrmPolicy{
-		Src: remote,
-		Dst: local,
-		Dir: netlink.XFRM_DIR_IN,
-		Mark: &netlink.XfrmMark{
-			Mask:  linux_defaults.IPsecMarkBitMask,
-			Value: linux_defaults.RouteMarkToProxy,
-		},
-		Tmpls: tmpls,
-	})
-	require.NoError(t, err)
-	require.NotNil(t, policy)
-
-	// ensure XFRM policy is as we want it...
-	if !policy.Src.IP.Equal(remote.IP) {
-		t.Fatalf("Expected Src to be %s, but got %s", remote.IP.String(), policy.Src.IP.String())
-	}
-	if !policy.Dst.IP.Equal(local.IP) {
-		t.Fatalf("Expected Dst to be %s, but got %s", local.IP.String(), policy.Dst.IP.String())
-	}
-	require.Equal(t, netlink.XFRM_DIR_IN, policy.Dir)
-	require.Equal(t, uint32(linux_defaults.RouteMarkToProxy), policy.Mark.Value)
-	require.Equal(t, uint32(linux_defaults.IPsecMarkBitMask), policy.Mark.Mask)
-	require.Len(t, policy.Tmpls, 1)
-
-	// ensure the template is correct as well...
-	policyTmpl = policy.Tmpls[0]
-	// l7 proxy policy has a wildcard source
 	if !policyTmpl.Src.Equal(wildcardIPv4) {
 		t.Fatalf("Expected Src to be %s, but got %s", wildcardIPv4.String(), policyTmpl.Src.String())
 	}


### PR DESCRIPTION
The first commit simplifies the optional templates used in most XFRM IN and FWD policies. The second commit simplifies the XFRM IN policies into a single policy. The third moves a bit of code around to avoid unnecessary XFRM policy updates. See commits for details.