### PR TITLE
endpoint: Fix syncing of invalid policymap entries on upgrade

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1195,20 +1195,27 @@ func (e *Endpoint) syncPolicyMapWith(realized policy.MapStateMap, withDiffs bool
 func (e *Endpoint) dumpPolicyMapToMapStateMap() (policy.MapStateMap, error) {
 	currentMap := make(policy.MapStateMap)
 
-	cb := func(policymapKey *policymap.PolicyKey, policymapEntry *policymap.PolicyEntry) {
+	cb := func(key bpf.MapKey, value bpf.MapValue) {
+		policymapKey := key.(*policymap.PolicyKey)
 		// Convert from policymap.Key to policy.Key
 		policyKey := policy.KeyForDirection(trafficdirection.TrafficDirection(policymapKey.TrafficDirection)).
 			WithIdentity(identity.NumericIdentity(policymapKey.Identity)).
 			WithPortProtoPrefix(u8proto.U8proto(policymapKey.Nexthdr), policymapKey.GetDestPort(), policymapKey.GetPortPrefixLen())
+		policymapEntry := value.(*policymap.PolicyEntry)
 		// Convert from policymap.PolicyEntry to policy.MapStateEntry.
 		policyEntry := policy.MapStateEntry{
 			ProxyPort: policymapEntry.GetProxyPort(),
 			IsDeny:    policymapEntry.IsDeny(),
 			AuthType:  policy.AuthType(policymapEntry.AuthType),
 		}
+		// if policymapEntry has invalid prefix length, force update by storing as an
+		// invalid MapStateEntry
+		if !policymapEntry.IsValid(policymapKey) {
+			policyEntry.Invalid = true
+		}
 		currentMap[policyKey] = policyEntry
 	}
-	err := e.policyMap.DumpValid(cb)
+	err := e.policyMap.DumpWithCallback(cb)
 
 	return currentMap, err
 }

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -458,19 +458,8 @@ func (pm *PolicyMap) DumpToSlice() (PolicyEntriesDump, error) {
 	return entries, err
 }
 
-// DumpValid calls 'cb' for each key/value in the policy map where the prefix length fields
-// in the key and value agree. This should be used to filter out invalid entries so that
-// they will be rewritten with the valid values.
-func (pm *PolicyMap) DumpValid(cb func(key *PolicyKey, value *PolicyEntry)) error {
-	return pm.DumpWithCallback(func(key bpf.MapKey, value bpf.MapValue) {
-		k := key.(*PolicyKey)
-		v := value.(*PolicyEntry)
-
-		// Call 'cb' only for entries with valid prefix len
-		if v.GetPrefixLen() == uint8(k.Prefixlen-StaticPrefixBits) {
-			cb(k, v)
-		}
-	})
+func (v *PolicyEntry) IsValid(k *PolicyKey) bool {
+	return v.GetPrefixLen() == uint8(k.Prefixlen-StaticPrefixBits)
 }
 
 func newMap(path string) *PolicyMap {

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -404,6 +404,9 @@ type MapStateEntry struct {
 	// IsDeny is true when the policy should be denied.
 	IsDeny bool
 
+	// Invalid is only set to mark the current entry for update when syncing entries to datapath
+	Invalid bool
+
 	// AuthType is non-zero when authentication is required for the traffic to be allowed.
 	AuthType AuthType
 }


### PR DESCRIPTION
Mark policymap entries not valid explicitly when policy map entry is not valid so that map sync will update the entry, instead just ignoring the key, as in that case the key would remain in the map if it would have needed to be removed instead.

Fixes: #35534
