### PR TITLE
daemon: drop the non headless service/endpoint resources

### DIFF
--- a/.github/actions/cl2-modules/cilium-metrics.yaml
+++ b/.github/actions/cl2-modules/cilium-metrics.yaml
@@ -106,12 +106,10 @@ steps:
         queries:
         - name: Services
           query: sum(apiserver_longrunning_requests{scope="cluster", verb="WATCH", resource="services"})
-          # TODO: Should be 2x not 3x - https://github.com/cilium/cilium/issues/35797
-          threshold: {{AddInt (MultiplyInt $DEFAULT_WATCH_THRESHOLD 3) $DEFAULT_WATCH_THRESHOLD_INCREASE}}
+          threshold: {{AddInt (MultiplyInt $DEFAULT_WATCH_THRESHOLD 2) $DEFAULT_WATCH_THRESHOLD_INCREASE}}
         - name: EndpointSlices
           query: sum(apiserver_longrunning_requests{scope="cluster", verb="WATCH", resource="endpointslices"})
-          # TODO: Should be 1x not 2x - https://github.com/cilium/cilium/issues/35797
-          threshold: {{AddInt (MultiplyInt $DEFAULT_WATCH_THRESHOLD 2) $DEFAULT_WATCH_THRESHOLD_INCREASE}}
+          threshold: {{AddInt $DEFAULT_WATCH_THRESHOLD $DEFAULT_WATCH_THRESHOLD_INCREASE}}
         - name: Endpoints
           query: sum(apiserver_longrunning_requests{scope="cluster", verb="WATCH", resource="endpoints"})
           threshold: {{$DEFAULT_WATCH_THRESHOLD_INCREASE}}

--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -4,14 +4,9 @@
 package k8s
 
 import (
-	"fmt"
-
 	"github.com/cilium/hive/cell"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -36,7 +31,6 @@ var (
 
 		cell.Config(k8s.DefaultConfig),
 		LocalNodeCell,
-		ServiceNonHeadlessCell,
 		cell.Provide(
 			k8s.ServiceResource,
 			k8s.EndpointsResource,
@@ -84,50 +78,6 @@ var (
 			},
 		),
 	)
-
-	ServiceNonHeadlessCell = cell.Module(
-		"k8s-service-non-headless",
-		"Agent Kubernetes non headless service resources",
-
-		cell.Provide(
-			func(lc cell.Lifecycle, cfg k8s.Config, cs client.Clientset) (ServiceNonHeadless, error) {
-				return k8s.ServiceResource(
-					lc, cfg, cs,
-					func(opts *metav1.ListOptions) {
-						nonHeadlessServiceSelector, err := labels.NewRequirement(v1.IsHeadlessService, selection.DoesNotExist, nil)
-						if err != nil {
-							panic(fmt.Sprintf("can't create headless service requirement: %s", err))
-						}
-
-						labelSelector, err := labels.Parse(opts.LabelSelector)
-						if err != nil {
-							panic(fmt.Sprintf("can't parse existing service label selector: %s", err))
-						}
-						labelSelector = labelSelector.Add(*nonHeadlessServiceSelector)
-						opts.LabelSelector = labelSelector.String()
-					},
-				)
-			},
-			func(lc cell.Lifecycle, cfg k8s.Config, cs client.Clientset) (EndpointsNonHeadless, error) {
-				return k8s.EndpointsResource(
-					lc, cfg, cs,
-					func(opts *metav1.ListOptions) {
-						nonHeadlessServiceSelector, err := labels.NewRequirement(v1.IsHeadlessService, selection.DoesNotExist, nil)
-						if err != nil {
-							panic(fmt.Sprintf("can't create headless service requirement: %s", err))
-						}
-
-						labelSelector, err := labels.Parse(opts.LabelSelector)
-						if err != nil {
-							panic(fmt.Sprintf("can't parse existing endpoints label selector: %s", err))
-						}
-						labelSelector = labelSelector.Add(*nonHeadlessServiceSelector)
-						opts.LabelSelector = labelSelector.String()
-					},
-				)
-			},
-		),
-	)
 )
 
 // LocalNodeResource is a resource.Resource[*slim_corev1.Node] but one which will only stream updates for the node object
@@ -142,20 +92,12 @@ type LocalCiliumNodeResource resource.Resource[*cilium_api_v2.CiliumNode]
 // objects scheduled on the node we are currently running on.
 type LocalPodResource resource.Resource[*slim_corev1.Pod]
 
-// ServiceNonHeadless is a resource.Resource[*slim_corev1.Service] but one which will only stream updates for
-// non headless Services.
-type ServiceNonHeadless resource.Resource[*slim_corev1.Service]
-
-// EndpointsNonHeadless is a resource.Resource[*slim_corev1.Service] but one which will only stream updates for
-// Endpoints from non headless Services.
-type EndpointsNonHeadless resource.Resource[*k8s.Endpoints]
-
 // Resources is a convenience struct to group all the agent k8s resources as cell constructor parameters.
 type Resources struct {
 	cell.In
 
-	Services                         ServiceNonHeadless
-	Endpoints                        EndpointsNonHeadless
+	Services                         resource.Resource[*slim_corev1.Service]
+	Endpoints                        resource.Resource[*k8s.Endpoints]
 	LocalNode                        LocalNodeResource
 	LocalCiliumNode                  LocalCiliumNodeResource
 	LocalPods                        LocalPodResource

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -207,7 +207,7 @@ func ParseService(svc *slim_corev1.Service, nodePortAddrs []netip.Addr) (Service
 		}
 	}
 
-	headless := false
+	_, headless := svc.Labels[v1.IsHeadlessService]
 	if strings.ToLower(svc.Spec.ClusterIP) == "none" {
 		headless = true
 	}
@@ -289,7 +289,7 @@ func ParseService(svc *slim_corev1.Service, nodePortAddrs []netip.Addr) (Service
 				proto := loadbalancer.L4Type(port.Protocol)
 				port := uint16(port.NodePort)
 				// This can happen if the service type is NodePort/LoadBalancer but the upstream apiserver
-				// did not assign any NodePort to the serivce port field.
+				// did not assign any NodePort to the service port field.
 				// For example if `allocateLoadBalancerNodePorts` is set to false in the service
 				// spec. For more details see -
 				// https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1864-disable-lb-node-ports
@@ -553,7 +553,8 @@ func parseIPs(externalIPs []string) map[string]net.IP {
 func NewService(ips []net.IP, externalIPs, loadBalancerIPs, loadBalancerSourceRanges []string,
 	headless bool, extTrafficPolicy, intTrafficPolicy loadbalancer.SVCTrafficPolicy,
 	healthCheckNodePort uint16, annotations, labels, selector map[string]string,
-	namespace string, svcType loadbalancer.SVCType) *Service {
+	namespace string, svcType loadbalancer.SVCType,
+) *Service {
 	var (
 		k8sExternalIPs     map[string]net.IP
 		k8sLoadBalancerIPs map[string]net.IP

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -406,6 +406,30 @@ func TestParseService(t *testing.T) {
 		ForwardingMode:           loadbalancer.SVCForwardingModeSNAT,
 	}, svc)
 
+	k8sSvc = &slim_corev1.Service{
+		ObjectMeta: *objMeta.DeepCopy(),
+		Spec: slim_corev1.ServiceSpec{
+			Type:      slim_corev1.ServiceTypeClusterIP,
+			ClusterIP: "127.0.0.1",
+		},
+	}
+	k8sSvc.ObjectMeta.Labels[corev1.IsHeadlessService] = ""
+
+	id, svc = ParseService(k8sSvc, nil)
+	require.EqualValues(t, ServiceID{Namespace: "bar", Name: "foo"}, id)
+	require.EqualValues(t, &Service{
+		IsHeadless:               true,
+		ExtTrafficPolicy:         loadbalancer.SVCTrafficPolicyCluster,
+		IntTrafficPolicy:         loadbalancer.SVCTrafficPolicyCluster,
+		FrontendIPs:              []net.IP{net.ParseIP("127.0.0.1")},
+		Labels:                   map[string]string{"foo": "bar", corev1.IsHeadlessService: ""},
+		Ports:                    map[loadbalancer.FEPortName]*loadbalancer.L4Addr{},
+		NodePorts:                map[loadbalancer.FEPortName]NodePortToFrontend{},
+		LoadBalancerSourceRanges: map[string]*cidr.CIDR{},
+		Type:                     loadbalancer.SVCTypeClusterIP,
+		ForwardingMode:           loadbalancer.SVCForwardingModeSNAT,
+	}, svc)
+
 	serviceInternalTrafficPolicyLocal := slim_corev1.ServiceInternalTrafficPolicyLocal
 	k8sSvc = &slim_corev1.Service{
 		ObjectMeta: objMeta,

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -210,11 +210,11 @@ func (k *K8sServiceWatcher) RunK8sServiceHandler() {
 }
 
 func (k *K8sServiceWatcher) delK8sSVCs(svc k8s.ServiceID, svcInfo *k8s.Service) {
-	// Headless services do not need any datapath implementation
-	if svcInfo.IsHeadless {
+	// Cleanup any headless services with a frontend IP as services may still be
+	// marked as headless if labeled with `service.kubernetes.io/headless`.
+	if svcInfo.IsHeadless && len(svcInfo.FrontendIPs) == 0 {
 		return
 	}
-
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.K8sSvcName:   svc.Name,
 		logfields.K8sNamespace: svc.Namespace,
@@ -507,6 +507,7 @@ func stripEndpointsProtocol(endpoints *k8s.Endpoints) *k8s.Endpoints {
 func (k *K8sServiceWatcher) addK8sSVCs(svcID k8s.ServiceID, oldSvc, svc *k8s.Service, endpoints *k8s.Endpoints) {
 	// Headless services do not need any datapath implementation
 	if svc.IsHeadless {
+		k.delK8sSVCs(svcID, svc)
 		return
 	}
 

--- a/pkg/k8s/watchers/service_test.go
+++ b/pkg/k8s/watchers/service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
@@ -361,6 +362,8 @@ func Test_addK8sSVCs_ClusterIP(t *testing.T) {
 }
 
 func TestChangeSVCPort(t *testing.T) {
+	option.Config.LoadBalancerProtocolDifferentiation = true
+
 	k8sSvc := &slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
 			Name:      "foo",
@@ -2469,4 +2472,123 @@ func Test_addK8sSVCs_ExternalIPs(t *testing.T) {
 	require.EqualValues(t, upsert3rdWanted, upsert3rd)
 	require.EqualValues(t, del1stWanted, del1st)
 	require.EqualValues(t, del2ndWanted, del2nd)
+}
+
+func TestHeadless(t *testing.T) {
+	option.Config.LoadBalancerProtocolDifferentiation = true
+
+	k8sSvc := &slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		Spec: slim_corev1.ServiceSpec{
+			Ports: []slim_corev1.ServicePort{
+				{
+					Name:     "port-udp-80",
+					Protocol: slim_corev1.ProtocolUDP,
+					Port:     80,
+				},
+			},
+			ClusterIP: "172.0.20.1",
+			Type:      slim_corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	ep1stApply := &slim_corev1.Endpoints{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+		},
+		Subsets: []slim_corev1.EndpointSubset{
+			{
+				Addresses: []slim_corev1.EndpointAddress{{IP: "10.0.0.2"}},
+				Ports: []slim_corev1.EndpointPort{
+					{
+						Name:     "port-udp-80",
+						Port:     8080,
+						Protocol: slim_corev1.ProtocolUDP,
+					},
+				},
+			},
+		},
+	}
+
+	lb1 := loadbalancer.NewL3n4AddrID(loadbalancer.UDP, cmtypes.MustParseAddrCluster("172.0.20.1"), 80, loadbalancer.ScopeExternal, 0)
+	upsertsWanted := []loadbalancer.SVC{
+		{
+			Type:     loadbalancer.SVCTypeClusterIP,
+			Frontend: *lb1,
+			Backends: []*loadbalancer.Backend{
+				{
+					FEPortName: "port-udp-80",
+					L3n4Addr: loadbalancer.L3n4Addr{
+						AddrCluster: cmtypes.MustParseAddrCluster("10.0.0.2"),
+						L4Addr: loadbalancer.L4Addr{
+							Protocol: loadbalancer.UDP,
+							Port:     8080,
+						},
+					},
+					Weight: loadbalancer.DefaultBackendWeight,
+				},
+			},
+		},
+	}
+
+	delstWanted := map[string]struct{}{
+		lb1.Hash(): {},
+	}
+
+	k8sSvcChanged := k8sSvc.DeepCopy()
+	k8sSvcChanged.Labels[corev1.IsHeadlessService] = ""
+
+	upserts := []loadbalancer.SVC{}
+	delst := map[string]struct{}{}
+
+	svcUpsertManagerCalls, svcDeleteManagerCalls := 0, 0
+
+	svcManager := &fakeSvcManager{
+		OnUpsertService: func(p *loadbalancer.SVC) (bool, loadbalancer.ID, error) {
+			upserts = append(upserts, loadbalancer.SVC{
+				Frontend: p.Frontend,
+				Backends: p.Backends,
+				Type:     p.Type,
+			})
+			svcUpsertManagerCalls++
+			return false, 0, nil
+		},
+		OnDeleteService: func(fe loadbalancer.L3n4Addr) (b bool, e error) {
+			if fe.Protocol == loadbalancer.ANY {
+				return true, nil
+			}
+
+			delst[fe.Hash()] = struct{}{}
+			svcDeleteManagerCalls++
+			return true, nil
+		},
+	}
+
+	db, nodeAddrs := newDB(t)
+	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs)
+	svcWatcher := &K8sServiceWatcher{
+		k8sSvcCache: k8sSvcCache,
+		svcManager:  svcManager,
+	}
+
+	go svcWatcher.k8sServiceHandler()
+	swg := lock.NewStoppableWaitGroup()
+
+	k8sSvcCache.UpdateService(k8sSvc, swg)
+	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
+	k8sSvcCache.UpdateService(k8sSvcChanged, swg)
+
+	swg.Stop()
+	swg.Wait()
+	require.Equal(t, len(upsertsWanted), svcUpsertManagerCalls)
+	require.Equal(t, len(delstWanted), svcDeleteManagerCalls)
+	require.EqualValues(t, upsertsWanted, upserts)
+	require.EqualValues(t, delstWanted, delst)
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

Before this PR two types of resources were exposed for services and endpoints: one excluding headless services/endpoints and one including them. This PR drop the non headless resource (and make the necessary changes to accommodate that) to make sure we only start one informer for services and endpoints and lower the load the apiserver.

Fixes: #35797

```release-note
Remove duplicated watch on services and endpoint in the cilium-agent
```
