### PR TITLE
proxy: Ensure proxy ports are written on shutdown

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -355,6 +355,7 @@ cilium-agent [flags]
       --proxy-xff-num-trusted-hops-ingress uint32                 Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --restore                                                   Restores state, if possible, from previous daemon (default true)
+      --restored-proxy-ports-age-limit uint                       Time after which a restored proxy ports file is considered stale (in minutes) (default 15)
       --route-metric int                                          Overwrite the metric used by cilium when adding routes to its 'cilium_host' device
       --routing-mode string                                       Routing mode ("native" or "tunnel") (default "tunnel")
       --service-no-backend-response string                        Response to traffic for a service without backends (default "reject")

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -157,6 +157,7 @@ cilium-agent hive [flags]
       --proxy-xff-num-trusted-hops-egress uint32                  Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
       --proxy-xff-num-trusted-hops-ingress uint32                 Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
+      --restored-proxy-ports-age-limit uint                       Time after which a restored proxy ports file is considered stale (in minutes) (default 15)
       --static-cnp-path string                                    Directory path to watch and load static cilium network policy yaml files.
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -162,6 +162,7 @@ cilium-agent hive dot-graph [flags]
       --proxy-xff-num-trusted-hops-egress uint32                  Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
       --proxy-xff-num-trusted-hops-ingress uint32                 Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
+      --restored-proxy-ports-age-limit uint                       Time after which a restored proxy ports file is considered stale (in minutes) (default 15)
       --static-cnp-path string                                    Directory path to watch and load static cilium network policy yaml files.
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -534,12 +534,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	if err != nil {
 		log.WithError(err).Error("Unable to read existing endpoints")
 	}
-	// Restore all proxy ports from datapath, if possible
-	// Must be run before d.bootstrapFQDN(), which depends
-	// on the ports having been restored.
-	if d.l7Proxy != nil {
-		d.l7Proxy.RestoreProxyPorts()
-	}
 	bootstrapStats.restore.End(true)
 
 	bootstrapStats.fqdn.Start()

--- a/pkg/proxy/cell.go
+++ b/pkg/proxy/cell.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/spf13/pflag"
 
+	"github.com/cilium/cilium/pkg/controller"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/envoy"
 	monitoragent "github.com/cilium/cilium/pkg/monitor/agent"
@@ -70,6 +71,10 @@ func newProxy(params proxyParams) *Proxy {
 
 	triggerDone := make(chan struct{})
 
+	controllerManager := controller.NewManager()
+	controllerGroup := controller.NewGroup("proxy-ports-allocator")
+	controllerName := "proxy-ports-checkpoint"
+
 	params.Lifecycle.Append(cell.Hook{
 		OnStart: func(cell.HookContext) (err error) {
 			// Restore all proxy ports before we create the trigger to overwrite the
@@ -77,9 +82,18 @@ func newProxy(params proxyParams) *Proxy {
 			p.RestoreProxyPorts(params.Config.RestoredProxyPortsAgeLimit)
 
 			p.proxyPortsTrigger, err = trigger.NewTrigger(trigger.Parameters{
-				MinInterval:  10 * time.Second,
-				TriggerFunc:  p.storeProxyPorts,
-				ShutdownFunc: func() { close(triggerDone) },
+				MinInterval: 10 * time.Second,
+				TriggerFunc: func(reasons []string) {
+					controllerManager.UpdateController(controllerName, controller.ControllerParams{
+						Group:    controllerGroup,
+						DoFunc:   p.storeProxyPorts,
+						StopFunc: p.storeProxyPorts, // perform one last checkpoint when the controller is removed
+					})
+				},
+				ShutdownFunc: func() {
+					controllerManager.RemoveControllerAndWait(controllerName) // waits for StopFunc
+					close(triggerDone)
+				},
 			})
 			return err
 		},

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -331,9 +331,9 @@ func proxyNotFoundError(name string) error {
 }
 
 // must be called with mutex NOT held via p.proxyPortsTrigger
-func (p *Proxy) storeProxyPorts(reasons []string) {
+func (p *Proxy) storeProxyPorts(ctx context.Context) error {
 	if p.proxyPortsPath == "" {
-		return // this is a unit test
+		return nil // this is a unit test
 	}
 	log := log.WithField(logfields.Path, p.proxyPortsPath)
 
@@ -341,7 +341,7 @@ func (p *Proxy) storeProxyPorts(reasons []string) {
 	out, err := renameio.NewPendingFile(p.proxyPortsPath, renameio.WithExistingPermissions(), renameio.WithPermissions(0o600))
 	if err != nil {
 		log.WithError(err).Error("failed to prepare proxy ports file")
-		return
+		return err
 	}
 	defer out.Cleanup()
 
@@ -359,13 +359,14 @@ func (p *Proxy) storeProxyPorts(reasons []string) {
 
 	if err := jw.Encode(portsMap); err != nil {
 		log.WithError(err).Error("failed to marshal proxy ports state")
-		return
+		return err
 	}
 	if err := out.CloseAtomicallyReplace(); err != nil {
 		log.WithError(err).Error("failed to write proxy ports file")
-		return
+		return err
 	}
 	log.Debug("Wrote proxy ports state")
+	return nil
 }
 
 var (


### PR DESCRIPTION
Use a controller to make sure the proxy port file is written on shutdown.

Move proxy port restoration to the cell just before the trigger for writing the proxy ports file is created. This removes the possibility that the trigger would run before the ports are restored.

Add a configurable time limit ('`--restored-proxy-ports-age-limit`', default `15` minutes) for the age of the restored proxy ports file to remove the chance that stale port numbers would be used e.g., on upgrade after a downgrade to Cilium 1.15 (which does not store the proxy ports to a file).
