### PR TITLE
Improve the CiliumNode to KVStore synchronization logic of the Cilium operator

### DIFF
--- a/operator/cmd/allocator_test.go
+++ b/operator/cmd/allocator_test.go
@@ -92,7 +92,7 @@ func podCIDRAllocatorOverlapTestRun(t *testing.T) {
 
 	// start synchronization.
 	cns := newCiliumNodeSynchronizer(fakeSet, podCidrManager, false)
-	if err := cns.Start(ctx, &wg); err != nil {
+	if err := cns.Start(ctx, &wg, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -271,6 +271,10 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.KVstoreLeaseTTL)
 	option.BindEnv(vp, option.KVstoreLeaseTTL)
 
+	flags.Bool(option.KVstorePodNetworkSupport, defaults.KVstorePodNetworkSupport, "Enable the support for running the Cilium KVstore in pod network")
+	flags.MarkHidden(option.KVstorePodNetworkSupport)
+	option.BindEnv(vp, option.KVstorePodNetworkSupport)
+
 	flags.Bool(option.EnableCiliumNetworkPolicy, defaults.EnableCiliumNetworkPolicy, "Enable support for Cilium Network Policy")
 	flags.MarkHidden(option.EnableCiliumNetworkPolicy)
 	option.BindEnv(vp, option.EnableCiliumNetworkPolicy)

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -700,7 +700,7 @@ func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 		}
 		operatorWatchers.PodStore = podStore.CacheStore()
 
-		if err := ciliumNodeSynchronizer.Start(legacy.ctx, &legacy.wg); err != nil {
+		if err := ciliumNodeSynchronizer.Start(legacy.ctx, &legacy.wg, podStore); err != nil {
 			log.WithError(err).Fatal("Unable to setup cilium node synchronizer")
 		}
 


### PR DESCRIPTION
Extend the operator logic in charge of synchronizing the CiliumNodes into the corresponding KVStore representation to:

* Skip updating node objects when the support for running the KVStore in pod network is disabled, given that it is not required in this case, and it causes unnecessary churn on both etcd and all watching agents;
* Make the deletion of node objects more robust, waiting until the agent running on that agent stops before removing it, to prevent the agent from recreating it right away.

Please review commit by commit, and refer to the individual commit messages for additional details.

<!-- Description of change -->

```release-note
Improve the CiliumNode to KVStore synchronization logic of the Cilium operator 
```
