### PR TITLE
.github: quote arguments in bash string comparison

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -144,11 +144,11 @@ jobs:
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
 
           EXEMPT_FEATURES="HTTPRouteParentRefPort,MeshConsumerRoute"
-          if [ ${{ matrix.crd-channel }} == "standard" ]; then
+          if [ "${{ matrix.crd-channel }}" == "standard" ]; then
             EXEMPT_FEATURES+=",HTTPRouteDestinationPortMatching,HTTPRouteRequestTimeout,HTTPRouteBackendTimeout,GatewayInfrastructurePropagation"
           fi
 
-          if [ ${{ matrix.conformance-profile }} == "true" ]; then
+          if [ "${{ matrix.conformance-profile }}" == "true" ]; then
             SKIPPED_TESTS+="MeshConsumerRoute,HTTPRouteListenerPortMatching"
           fi
 
@@ -224,7 +224,7 @@ jobs:
         id: install-cilium
         run: |
           cilium_install_defaults="${{ steps.vars.outputs.cilium_install_defaults }}"
-          if [ ${{ matrix.encryption }} == "ipsec" ]; then
+          if [ "${{ matrix.encryption }}" == "ipsec" ]; then
             kubectl create -n kube-system secret generic cilium-ipsec-keys \
               --from-literal=keys="3 rfc4106(gcm(aes)) $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64) 128"
             cilium_install_defaults+=" --helm-set=encryption.enabled=true \
@@ -286,7 +286,7 @@ jobs:
           GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES=$(echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.216@")
           echo "GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES: $GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES"
           echo "GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES: $GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES"
-          if [ ${{ matrix.conformance-profile }} == "true" ]; then
+          if [ "${{ matrix.conformance-profile }}" == "true" ]; then
             GATEWAY_API_CONFORMANCE_TESTS=1 \
             GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES=$GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES  \
             GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES=$GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES \

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -271,7 +271,7 @@ jobs:
         timeout-minutes: 5
         run: |
           kubectl apply -n default -f https://raw.githubusercontent.com/istio/istio/release-1.11/samples/bookinfo/platform/kube/bookinfo.yaml
-          if [ ${{ matrix.default-ingress-controller }} = "true" ]; then
+          if [ "${{ matrix.default-ingress-controller }}" = "true" ]; then
             # remove ingressClassName line from basic-ingress.yaml
             sed -i '/ingressClassName/d' untrusted/examples/kubernetes/servicemesh/basic-ingress.yaml
             kubectl apply -n default -f untrusted/examples/kubernetes/servicemesh/basic-ingress.yaml
@@ -294,7 +294,7 @@ jobs:
         if: ${{ matrix.kube-proxy-replacement == true }}
         timeout-minutes: 5
         run: |
-          if [ ${{ matrix.loadbalancer-mode }} = "dedicated" ]; then
+          if [ "${{ matrix.loadbalancer-mode }}" = "dedicated" ]; then
             node_port=$(kubectl get svc cilium-ingress-basic-ingress -o jsonpath='{.spec.ports[?(@.port==80)].nodePort}')
           else
             node_port=$(kubectl get -n kube-system svc cilium-ingress -o jsonpath='{.spec.ports[?(@.port==80)].nodePort}')

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -603,7 +603,7 @@ jobs:
         if: ${{ !matrix.external-kvstore }}
         run: |
           kubectl --context ${{ env.contextName1 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
-          if [ ${{ matrix.kube-proxy }} != "none" ]; then
+          if [ "${{ matrix.kube-proxy }}" != "none" ]; then
             kubectl --context ${{ env.contextName2 }} scale -n kube-system deploy/clustermesh-apiserver --replicas 0
           fi
 


### PR DESCRIPTION
In the case where interpolated variables are not set or resolve to the empty string, an error can be thrown such as:
```
  line 2: [: ==: unary operator expected
```
