### PR TITLE
Silence error logs if pod is deleted during restoration

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"go4.org/netipx"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -1723,6 +1724,15 @@ func (e *Endpoint) metadataResolver(ctx context.Context,
 		return false, nil
 	}
 
+	filterResolveMetadataError := func(err error) error {
+		if restoredEndpoint && k8sErrors.IsNotFound(err) {
+			e.getLogger().WithError(err).Info("Unable to resolve metadata during endpoint restoration. Is the pod still running?")
+			return nil
+		}
+
+		return err
+	}
+
 	// copy the base labels into this local variable
 	// so that we don't override 'baseLabels'.
 	controllerBaseLabels := labels.NewFrom(baseLabels)
@@ -1732,6 +1742,10 @@ func (e *Endpoint) metadataResolver(ctx context.Context,
 	pod, k8sMetadata, err := resolveMetadata(ns, podName)
 	switch {
 	case err != nil:
+		if filterResolveMetadataError(err) == nil {
+			break
+		}
+
 		e.Logger(resolveLabels).WithError(err).Warning("Unable to fetch kubernetes labels")
 		fallthrough
 	case e.K8sUID != "" && e.K8sUID != string(pod.GetUID()):
@@ -1763,7 +1777,7 @@ func (e *Endpoint) metadataResolver(ctx context.Context,
 	e.UpdateNoTrackRules(func(_, _ string) (noTrackPort string, err error) {
 		po, _, err := resolveMetadata(ns, podName)
 		if err != nil {
-			return "", err
+			return "", filterResolveMetadataError(err)
 		}
 		value, _ := annotation.Get(po, annotation.NoTrack, annotation.NoTrackAlias)
 		return value, nil
@@ -1771,7 +1785,7 @@ func (e *Endpoint) metadataResolver(ctx context.Context,
 	e.UpdateBandwidthPolicy(bwm, func(ns, podName string) (bandwidthEgress string, err error) {
 		_, k8sMetadata, err := resolveMetadata(ns, podName)
 		if err != nil {
-			return "", err
+			return "", filterResolveMetadataError(err)
 		}
 		return k8sMetadata.Annotations[bandwidth.EgressBandwidth], nil
 	})


### PR DESCRIPTION
Please review commit by commit, and refer to the individual commit messages for additional details.

Overall, aims to fix the flakyness of the Cilium Cluster Mesh upgrade workflow (once backported to v1.16 as well) appeared after enabling the no-log-errors check in https://github.com/cilium/cilium/pull/35739.