### PR TITLE
Add feature tracking in Cilium agent as prometheus metrics

### DIFF
--- a/.github/actions/feature-status/action.yaml
+++ b/.github/actions/feature-status/action.yaml
@@ -1,0 +1,37 @@
+name: Feature status report
+description: Reports all features enabled on the agent
+
+inputs:
+  cilium-cli:
+    required: false
+    default: "/usr/local/bin/cilium"
+    description: 'Path to the Cilium CLI binary'
+  title:
+    required: true
+    description: 'Title for the summary description'
+  json-filename:
+    required: true
+    description: 'Title for the JSON filename (without .json extension)'
+
+runs:
+  using: composite
+  steps:
+    - name: Report features enabled on the agent from host
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        ${{ inputs.cilium-cli }} features status -o markdown --output-file="feature-status.md"
+        ${{ inputs.cilium-cli }} features status -o json --output-file="${{ inputs.json-filename }}.json"
+
+    - name: Report summary for features enabled on the agent
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        echo ""                                        >> "$GITHUB_STEP_SUMMARY"
+        echo "## ${{ inputs.title }}"                  >> "$GITHUB_STEP_SUMMARY"
+        echo ""                                        >> "$GITHUB_STEP_SUMMARY"
+        echo "<details>"                               >> "$GITHUB_STEP_SUMMARY"
+        echo "  <summary>Click here to see</summary>"  >> "$GITHUB_STEP_SUMMARY"
+        echo ""                                        >> "$GITHUB_STEP_SUMMARY"
+        cat feature-status.md                          >> "$GITHUB_STEP_SUMMARY"
+        echo "</details>"                              >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -287,6 +287,12 @@ jobs:
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1.xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1"
+
       - name: Clean up Cilium
         run: |
           cilium uninstall --wait
@@ -314,6 +320,12 @@ jobs:
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 2.xml" \
           --junit-property github_job_step="Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})"
+
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 2"
 
       - name: Post-test information gathering
         if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
@@ -343,6 +355,13 @@ jobs:
           name: cilium-junits-${{ matrix.index }}
           path: cilium-junits/*.xml
 
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ matrix.index }}
+          path: ${{ env.job_name }}*.json
+
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}
         uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
@@ -371,6 +390,12 @@ jobs:
         with:
           name: cilium-junits
           pattern: cilium-junits-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge Features tested
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: features-tested
+          pattern: features-tested-*
           token: ${{ secrets.GITHUB_TOKEN }}
 
   commit-status-final:

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -316,6 +316,12 @@ jobs:
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }})"
+
       - name: Post-test information gathering
         if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
@@ -338,6 +344,13 @@ jobs:
         with:
           name: cilium-junits-${{ matrix.version }}
           path: cilium-junits/*.xml
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ matrix.version }}
+          path: ${{ env.job_name }}*.json
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}
@@ -367,6 +380,12 @@ jobs:
         with:
           name: cilium-junits
           pattern: cilium-junits-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge Features tested
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: features-tested
+          pattern: features-tested-*
           token: ${{ secrets.GITHUB_TOKEN }}
 
   commit-status-final:

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -579,6 +579,20 @@ jobs:
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
+      - name: Features tested on cluster 1
+        uses: ./.github/actions/feature-status
+        with:
+          cilium-cli: "cilium --context ${{ env.contextName1 }}"
+          title: "Summary of all features tested on cluster 1"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - cluster 1"
+
+      - name: Features tested on cluster 2
+        uses: ./.github/actions/feature-status
+        with:
+          cilium-cli: "cilium --context ${{ env.contextName2 }}"
+          title: "Summary of all features tested on cluster 2"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - cluster 2"
+
       - name: Post-test information gathering
         if: ${{ !success() && steps.install-cilium-cluster1.outcome != 'skipped' }}
         run: |
@@ -621,6 +635,13 @@ jobs:
           name: cilium-junits-${{ matrix.name }}
           path: cilium-junits/*.xml
 
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ matrix.name }}
+          path: ${{ env.job_name }}*.json
+
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}
         uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
@@ -649,6 +670,12 @@ jobs:
         with:
           name: cilium-junits
           pattern: cilium-junits-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge Features tested
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: features-tested
+          pattern: features-tested-*
           token: ${{ secrets.GITHUB_TOKEN }}
 
   commit-status-final:

--- a/.github/workflows/conformance-delegated-ipam.yaml
+++ b/.github/workflows/conformance-delegated-ipam.yaml
@@ -81,6 +81,8 @@ jobs:
 
   delegated-ipam-conformance-test:
     name: Install and Connectivity Test
+    env:
+      job_name: "Install and Connectivity Test"
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
@@ -335,6 +337,12 @@ jobs:
         run: |
           cilium connectivity test
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }})"
+
       - name: Post-test information gathering
         if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
@@ -358,6 +366,13 @@ jobs:
           name: cilium-junits
           path: cilium-junits/*.xml
           retention-days: 5
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ join(matrix.*, '-') }}
+          path: ${{ env.job_name }}*.json
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -350,6 +350,12 @@ jobs:
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1.xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1"
+
       - name: Setup conn-disrupt-test before rotating (${{ join(matrix.*, ', ') }})
         if: ${{ matrix.ipsec == true }}
         uses: ./.github/actions/conn-disrupt-test-setup
@@ -391,6 +397,13 @@ jobs:
           name: cilium-junits-${{ matrix.version }}
           path: cilium-junits/*.xml
 
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ matrix.version }}
+          path: ${{ env.job_name }}*.json
+
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}
         uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
@@ -419,6 +432,12 @@ jobs:
         with:
           name: cilium-junits
           pattern: cilium-junits-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge Features tested
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: features-tested
+          pattern: features-tested-*
           token: ${{ secrets.GITHUB_TOKEN }}
 
   commit-status-final:

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -376,6 +376,12 @@ jobs:
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }})"
+
       - name: Post-test information gathering
         if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
@@ -414,6 +420,13 @@ jobs:
           name: cilium-junits-${{ matrix.vmIndex }}
           path: cilium-junits/*.xml
 
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ matrix.vmIndex }}
+          path: ${{ env.job_name }}*.json
+
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}
         uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
@@ -442,6 +455,12 @@ jobs:
         with:
           name: cilium-junits
           pattern: cilium-junits-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge Features tested
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: features-tested
+          pattern: features-tested-*
           token: ${{ secrets.GITHUB_TOKEN }}
 
   commit-status-final:

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -100,6 +100,8 @@ jobs:
 
   gateway-api-conformance-test:
     name: Gateway API Conformance Test
+    env:
+      job_name: "Gateway API Conformance Test"
     needs: [wait-for-images]
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -337,6 +339,12 @@ jobs:
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
             --test 'allow-all-except-world,encryption,packet-drops'
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }})"
+
       - name: Upload report artifacts
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
@@ -360,6 +368,13 @@ jobs:
           name: cilium-sysdump-out-${{ join(matrix.*, '-') }}
           path: cilium-sysdump-out-*.zip
           retention-days: 5
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ join(matrix.*, '-') }}
+          path: ${{ env.job_name }}*.json
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -276,8 +276,13 @@ jobs:
         uses: cilium/cilium-cli@3286926bbf80fdd0103a372256459e577224f9f6 # v0.16.20
         with:
           skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
-          ci-version: ${{ env.CILIUM_CLI_VERSION }}
-          binary-dir: '.'
+          image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
+          image-tag: ${{ needs.setup-vars.outputs.SHA }}
+
+      - name: Copy cilium-cli
+        shell: bash
+        run: |
+          cp -f /usr/local/bin/cilium ./cilium-cli-bin
 
       - name: Install helm
         shell: bash
@@ -304,7 +309,7 @@ jobs:
           cmd: |
             git config --global --add safe.directory /host
             mv /host/helm /usr/bin
-            mv /host/cilium /usr/bin/cilium-cli
+            cp /host/cilium-cli-bin /usr/bin/cilium-cli
 
       - name: Provision kind
         timeout-minutes: 5
@@ -440,6 +445,31 @@ jobs:
             kubectl get pods --all-namespaces -o wide
             tar -zcf "test_results-${{ env.job_name }}.tar.gz" /host/test/test_results
 
+      - name: Prepare script to run inside lvm
+        if: ${{ always() && steps.provision-vh-vms.outcome == 'success' }}
+        shell: bash
+        run: |
+          cat <<EOF > run-in-lvm.sh
+          #!/usr/bin/env bash
+          cd /host
+          if ! find /host/test/test_results -type f -iname 'feature-status-*.json' | grep -q .; then
+            exit 0
+          fi
+          find . -type f -iname 'feature-status-*.json' | while IFS= read -r file; do
+            mv "\$file" "./${{ env.job_name }}-\${file##*/feature-status-}"
+          done
+          EOF
+          chmod +x run-in-lvm.sh
+
+      - name: Fetch features tested
+        if: ${{ always() && steps.provision-vh-vms.outcome == 'success' }}
+        uses: cilium/little-vm-helper@97c89f004bd0ab4caeacfe92ebc956e13e362e6b # v0.0.19
+        with:
+          provision: 'false'
+          cmd: |
+            cd /host
+            ./run-in-lvm.sh
+
       - name: Upload artifacts
         if: ${{ !success() }}
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -465,6 +495,13 @@ jobs:
         with:
           name: cilium-junits-${{ matrix.k8s-version }}-${{matrix.focus}}
           path: cilium-junits/*.xml
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ matrix.k8s-version }}-${{matrix.focus}}
+          path: ${{ env.job_name }}*.json
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}
@@ -494,6 +531,12 @@ jobs:
         with:
           name: cilium-junits
           pattern: cilium-junits-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge Features tested
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: features-tested
+          pattern: features-tested-*
           token: ${{ secrets.GITHUB_TOKEN }}
 
   commit-status-final:

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -330,6 +330,12 @@ jobs:
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.k8s.*, ', ') }}, ${{ join(matrix.config.*, ', ') }}).xml" \
           --junit-property github_job_step="Run connectivity test (${{ matrix.k8s.version }}, ${{ matrix.config.index }}, ${{ matrix.config.type }})"
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.k8s.*, ', ') }}, ${{ join(matrix.config.*, ', ') }})"
+
       - name: Post-test information gathering
         if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
@@ -361,6 +367,13 @@ jobs:
           name: cilium-junits-${{ matrix.config.index }}-${{ matrix.k8s.vmIndex }}
           path: cilium-junits/*.xml
 
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ matrix.config.index }}-${{ matrix.k8s.vmIndex }}
+          path: ${{ env.job_name }}*.json
+
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}
         uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
@@ -389,6 +402,12 @@ jobs:
         with:
           name: cilium-junits
           pattern: cilium-junits-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge Features tested
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: features-tested
+          pattern: features-tested-*
           token: ${{ secrets.GITHUB_TOKEN }}
 
   commit-status-final:

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -99,6 +99,8 @@ jobs:
 
   ingress-conformance-test:
     name: Ingress Conformance Test
+    env:
+      job_name: "Ingress Conformance Test"
     needs: [wait-for-images]
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -425,6 +427,12 @@ jobs:
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --test 'packet-drops'
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }} ${{ matrix.name }}"
+
       - name: Post-test information gathering
         if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
@@ -440,6 +448,13 @@ jobs:
           name: cilium-sysdump-out-${{ matrix.name }}
           path: cilium-sysdump-out-*.zip
           retention-days: 5
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ matrix.name }}
+          path: ${{ env.job_name }}*.json
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -279,6 +279,12 @@ jobs:
             --test egress-gateway \
             --flush-ct
 
+      - name: Features tested after egress gateway tests
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested after egress gateway tests"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - egress-gateway"
+
       - name: Start unencrypted packets check
         uses: ./.github/actions/bpftrace/start
         with:
@@ -297,6 +303,12 @@ jobs:
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
             --test '!egress-gateway' \
             --flush-ct
+
+      - name: Features tested after running all other tests
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested after all other tests"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - other tests"
 
       - name: Assert that no unencrypted packets are leaked
         uses: ./.github/actions/bpftrace/check
@@ -343,6 +355,12 @@ jobs:
             --test egress-gateway \
             --flush-ct
 
+      - name: Features tested after egress gateway tests after rotating ipsec keys
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested after egress gateway tests after rotating ipsec keys"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - egress-gateway after rotating keys"
+
       - name: Start unencrypted packets check for tests
         uses: ./.github/actions/bpftrace/start
         with:
@@ -367,6 +385,12 @@ jobs:
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
             --test '!egress-gateway' \
             --flush-ct $TEST
+
+      - name: Features tested after running all other tests after rotating ipsec keys
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested after all other tests after rotating ipsec keys"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - other tests after rotating keys"
 
       - name: Assert that no unencrypted packets are leaked during tests
         uses: ./.github/actions/bpftrace/check
@@ -400,6 +424,13 @@ jobs:
           name: cilium-junits-${{ matrix.name }}
           path: cilium-junits/*.xml
 
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ matrix.name }}
+          path: ${{ env.job_name }}*.json
+
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}
         uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
@@ -428,6 +459,12 @@ jobs:
         with:
           name: cilium-junits
           pattern: cilium-junits-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge Features tested
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: features-tested
+          pattern: features-tested-*
           token: ${{ secrets.GITHUB_TOKEN }}
 
   commit-status-final:

--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -35,6 +35,7 @@ jobs:
         ipFamily: ["ipv4"]
     env:
       IP_FAMILY: ${{ matrix.ipFamily }}
+      job_name: "Installation and Conformance Test"
 
     steps:
       - name: Collect Workflow Telemetry
@@ -204,6 +205,12 @@ jobs:
             --report-dir=${E2E_REPORT_DIR}                \
             --disable-log-dump=true
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }}"
+
       - name: Post-test information gathering
         if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
@@ -220,6 +227,13 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested
+          path: ${{ env.job_name }}*.json
 
       - name: Upload cluster logs
         if: ${{ !success() }}

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -35,6 +35,7 @@ jobs:
         ipFamily: ["ipv4"]
     env:
       IP_FAMILY: ${{ matrix.ipFamily }}
+      job_name: "Installation and Conformance Test"
 
     steps:
       - name: Collect Workflow Telemetry
@@ -202,6 +203,12 @@ jobs:
             --report-dir=${E2E_REPORT_DIR}                \
             --disable-log-dump=true
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }} ${{ matrix.ipFamily }}"
+
       - name: Post-test information gathering
         if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
@@ -218,6 +225,13 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: "features-tested-${{ matrix.ipFamily }}"
+          path: ${{ env.job_name }}*.json
 
       - name: Upload cluster logs
         if: ${{ !success() }}

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -40,6 +40,8 @@ jobs:
 
   cyclonus-test:
     name: Cyclonus Test
+    env:
+      job_name: "Cyclonus Test"
     runs-on: ubuntu-latest
     steps:
       - name: Collect Workflow Telemetry
@@ -139,6 +141,12 @@ jobs:
           image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
           image-tag: ${{ steps.vars.outputs.tag }}
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }}"
+
       - name: Report cluster failure status and capture cilium-sysdump
         if: ${{ failure() && steps.install-cilium.outcome != 'skipped' }}
         run: |
@@ -153,3 +161,10 @@ jobs:
         with:
           name: cilium-sysdump-out.zip
           path: cilium-sysdump-out.zip
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested
+          path: ${{ env.job_name }}*.json

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -118,6 +118,12 @@ jobs:
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
           --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }}"
+
       - name: Post-test information gathering
         if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
@@ -141,6 +147,13 @@ jobs:
           name: cilium-junits
           path: cilium-junits/*.xml
           retention-days: 5
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested
+          path: ${{ env.job_name }}*.json
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -82,6 +82,8 @@ jobs:
 
   multi-pool-ipam-conformance-test:
     name: Install and Connectivity Test
+    env:
+      job_name: "Install and Connectivity Test"
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -219,6 +221,12 @@ jobs:
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --junit-file "cilium-junits/${{ env.job_name }} - 1.xml" --junit-property github_job_step="Run connectivity test"
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }} - 1"
+
       - name: Collect Pod and Pool IPs
         id: ips
         run: |
@@ -270,6 +278,13 @@ jobs:
           name: cilium-junits
           path: cilium-junits/*.xml
           retention-days: 5
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested
+          path: ${{ env.job_name }}*.json
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -391,6 +391,17 @@ jobs:
             go${{ env.go-version}} install github.com/mfridman/tparse@baf229e8494613f134bc0e1f4cb9dc9b12f66442
             make SKIP_COVERAGE=1 tests-privileged GO=go${{ env.go-version }}
 
+      - name: Copy tested features
+        if: ${{ matrix.focus == 'agent' || matrix.focus == 'datapath' }}
+        uses: cilium/little-vm-helper@97c89f004bd0ab4caeacfe92ebc956e13e362e6b # v0.0.19
+        with:
+          provision: 'false'
+          cmd: |
+            docker create --name cilium-dbg quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci:${{ steps.vars.outputs.sha }}
+            docker cp cilium-dbg:/usr/bin/cilium-dbg /usr/local/bin/cilium-dbg
+            docker rm cilium-dbg
+            cilium-dbg metrics list -p cilium_feature -o json > '/host/${{ env.job_name }} (${{ matrix.focus }}).json'
+
       - name: Debug failure on VM
         # Only debug the failure on the LVH that have Cilium running as a service,
         # which is 'agent' and 'datapath' focus.
@@ -441,6 +452,13 @@ jobs:
           name: cilium-junits-${{ matrix.focus }}
           path: cilium-junits/*.xml
 
+      - name: Upload features tested
+        if: ${{ always() && (matrix.focus == 'agent' || matrix.focus == 'datapath') }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ matrix.focus }}
+          path: ${{ env.job_name }}*.json
+
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() && (matrix.focus == 'agent' || matrix.focus == 'datapath') }}
         uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
@@ -469,6 +487,12 @@ jobs:
         with:
           name: cilium-junits
           pattern: cilium-junits-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge Features tested
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: features-tested
+          pattern: features-tested-*
           token: ${{ secrets.GITHUB_TOKEN }}
 
   commit-status-final:

--- a/.github/workflows/fqdn-perf.yaml
+++ b/.github/workflows/fqdn-perf.yaml
@@ -259,11 +259,24 @@ jobs:
             --testoverrides=./testing/prometheus/not-scrape-kube-proxy.yaml \
             2>&1 | tee cl2-output.txt
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }}"
+
       - name: Get sysdump
         if: ${{ always() && steps.run-cl2.outcome != 'skipped' && steps.run-cl2.outcome != 'cancelled' }}
         run: |
           cilium status
           cilium sysdump --output-filename cilium-sysdump-final
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested
+          path: ${{ env.job_name }}*.json
 
       - name: Cleanup cluster
         if: ${{ always() && steps.deploy-cluster.outcome != 'skipped' }}

--- a/.github/workflows/hubble-cli-integration-test.yaml
+++ b/.github/workflows/hubble-cli-integration-test.yaml
@@ -68,6 +68,8 @@ jobs:
 
   integration-test:
     runs-on: ubuntu-latest
+    env:
+      job_name: "Integration Test"
     name: Hubble CLI Integration Test
     timeout-minutes: 20
     steps:
@@ -195,6 +197,12 @@ jobs:
           echo "test piping flows into the CLI"
           test $(./hubble/hubble observe --input-file flows.json -o json | jq -r --slurp 'length') -eq $(jq -r --slurp 'length' flows.json)
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }}"
+
       - name: Post-test information gathering
         if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
@@ -210,6 +218,13 @@ jobs:
           name: cilium-sysdump-out-${{ matrix.conformance-profile }}-${{ matrix.crd-channel }}
           path: cilium-sysdump-out-*.zip
           retention-days: 5
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ matrix.conformance-profile }}-${{ matrix.crd-channel }}
+          path: ${{ env.job_name }}*.json
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -275,12 +275,25 @@ jobs:
           cilium connectivity perf --duration=30s --host-net=true --pod-net=true --report-dir=./output
           sudo chmod -R +r ./output
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }}"
+
       - name: Get sysdump
         if: ${{ always() && steps.run-perf.outcome != 'skipped' && steps.run-perf.outcome != 'cancelled' }}
         run: |
           cilium status
           cilium sysdump --output-filename cilium-sysdump-final
           sudo chmod +r cilium-sysdump-final.zip
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested
+          path: ${{ env.job_name }}*.json
 
       - name: Clean up GKE
         if: ${{ always() }}

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -336,12 +336,25 @@ jobs:
             --testoverrides=./modules.yaml \
             2>&1 | tee cl2-output.txt
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }}"
+
       - name: Get sysdump
         if: ${{ always() && steps.run-cl2.outcome != 'skipped' && steps.run-cl2.outcome != 'cancelled' }}
         run: |
           cilium status
           cilium sysdump --output-filename cilium-sysdump-final
           sudo chmod +r cilium-sysdump-final.zip
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested
+          path: ${{ env.job_name }}*.json
 
       - name: Cleanup cluster
         if: ${{ always() && steps.deploy-cluster.outcome != 'skipped' }}

--- a/.github/workflows/scale-test-clustermesh.yaml
+++ b/.github/workflows/scale-test-clustermesh.yaml
@@ -368,11 +368,25 @@ jobs:
             --kubeconfig=$HOME/.kube/config \
             2>&1 | tee cl2-output.txt
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }}"
+
       - name: Get sysdump
         if: ${{ always() && steps.install-cilium.outcome != 'skipped' && steps.install-cilium.outcome != 'cancelled' }}
         run: |
           cilium status
           cilium sysdump --output-filename cilium-sysdump-final
+          sudo chmod +r cilium-sysdump-final.zip
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested
+          path: ${{ env.job_name }}*.json
 
       - name: Upload sysdump
         if: ${{ !success() && steps.install-cilium.outcome != 'skipped' && steps.install-cilium.outcome != 'cancelled' }}

--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -204,11 +204,25 @@ jobs:
             --kubeconfig=$HOME/.kube/config \
             2>&1 | tee cl2-output.txt
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }}"
+
       - name: Get sysdump
         if: ${{ always() && steps.run-cl2.outcome != 'skipped' }}
         run: |
           cilium status
           cilium sysdump --output-filename cilium-sysdump-final
+          sudo chmod +r cilium-sysdump-final.zip
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested
+          path: ${{ env.job_name }}*.json
 
       - name: Cleanup cluster
         if: ${{ always() && steps.deploy-cluster.outcome != 'skipped' }}

--- a/.github/workflows/tests-ces-migrate.yaml
+++ b/.github/workflows/tests-ces-migrate.yaml
@@ -190,6 +190,12 @@ jobs:
           job-name: ces-enable
           full-test: 'true'
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }}"
+
       - name: Fetch artifacts
         if: ${{ failure() && steps.install-cilium.outcome != 'skipped' }}
         # The following is needed to prevent hubble from receiving an empty
@@ -216,6 +222,13 @@ jobs:
         with:
           name: cilium-junits
           path: cilium-junits/*.xml
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested
+          path: ${{ env.job_name }}*.json
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -456,6 +456,20 @@ jobs:
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --conn-disrupt-dispatch-interval 0ms
 
+      - name: Features tested on cluster 1
+        uses: ./.github/actions/feature-status
+        with:
+          cilium-cli: "cilium --context ${{ env.contextName1 }}"
+          title: "Summary of all features tested on cluster 1"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - cluster 1"
+
+      - name: Features tested on cluster 2
+        uses: ./.github/actions/feature-status
+        with:
+          cilium-cli: "cilium --context ${{ env.contextName2 }}"
+          title: "Summary of all features tested on cluster 2"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - cluster 2"
+
 
       - name: Upgrade Cilium in cluster1
         env:
@@ -593,6 +607,20 @@ jobs:
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --conn-disrupt-dispatch-interval 0ms
 
+      - name: Features tested on cluster 1 - post upgrade
+        uses: ./.github/actions/feature-status
+        with:
+          cilium-cli: "cilium --context ${{ env.contextName1 }}"
+          title: "Summary of all features tested on cluster 1 - post upgrade"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - cluster 1 - post upgrade"
+
+      - name: Features tested on cluster 2 - post upgrade
+        uses: ./.github/actions/feature-status
+        with:
+          cilium-cli: "cilium --context ${{ env.contextName2 }}"
+          title: "Summary of all features tested on cluster 2 - post upgrade"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - cluster 2 - post upgrade"
+
 
       # Perform an additional "stress" test, scaling the clustermesh-apiservers in both clusters
       # to zero replicas, and restarting all agents. Existing connections should not be disrupted.
@@ -660,6 +688,20 @@ jobs:
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --conn-disrupt-dispatch-interval 0ms
 
+      - name: Features tested on cluster 1 - stress-test
+        uses: ./.github/actions/feature-status
+        with:
+          cilium-cli: "cilium --context ${{ env.contextName1 }}"
+          title: "Summary of all features tested on cluster 1 - stress-test"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - cluster 1 - stress-test"
+
+      - name: Features tested on cluster 2 - stress-test
+        uses: ./.github/actions/feature-status
+        with:
+          cilium-cli: "cilium --context ${{ env.contextName2 }}"
+          title: "Summary of all features tested on cluster 2 - stress-test"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - cluster 2 - stress-test"
+
 
       - name: Downgrade Cilium in cluster1 and disable kvstoremesh
         env:
@@ -695,6 +737,20 @@ jobs:
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --junit-file "cilium-junits/${{ env.job_name }} - post downgrade (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests post-downgrade (${{ join(matrix.*, ', ') }})"
+
+      - name: Features tested on cluster 1 - post-downgrade
+        uses: ./.github/actions/feature-status
+        with:
+          cilium-cli: "cilium --context ${{ env.contextName1 }}"
+          title: "Summary of all features tested on cluster 1 - post-downgrade"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - cluster 1 - post-downgrade"
+
+      - name: Features tested on cluster 2 - post-downgrade
+        uses: ./.github/actions/feature-status
+        with:
+          cilium-cli: "cilium --context ${{ env.contextName2 }}"
+          title: "Summary of all features tested on cluster 2 - post-downgrade"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - cluster 2 - post-downgrade"
 
 
       - name: Post-test information gathering
@@ -736,6 +792,13 @@ jobs:
           name: cilium-junits-${{ matrix.name }}
           path: cilium-junits/*.xml
 
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ matrix.name }}
+          path: ${{ env.job_name }}*.json
+
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}
         uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
@@ -764,6 +827,12 @@ jobs:
         with:
           name: cilium-junits
           pattern: cilium-junits-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge Features tested
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: features-tested
+          pattern: features-tested-*
           token: ${{ secrets.GITHUB_TOKEN }}
 
   commit-status-final:

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -675,6 +675,12 @@ jobs:
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --conn-disrupt-dispatch-interval 0ms
 
+      - name: Features tested before downgrade
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested before downgrade"
+          json-filename: "${{ env.job_name }} (${{ matrix.name }}) - before downgrade"
+
       - name: Downgrade Cilium ${{ steps.vars.outputs.downgrade_version }}
         if: ${{ matrix.skip-upgrade != 'true' }}
         shell: bash
@@ -714,6 +720,12 @@ jobs:
             --test "!seq-.*" \
             ${{ steps.cli-flags.outputs.flags }}
 
+      - name: Features tested after downgrade
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested after downgrade"
+          json-filename: "${{ env.job_name }} (${{ matrix.name }}) - after downgrade"
+
       - name: Fetch artifacts
         if: ${{ !success() }}
         shell: bash
@@ -743,6 +755,13 @@ jobs:
           name: cilium-junits-${{ matrix.name }}
           path: cilium-junits/*.xml
 
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ matrix.name }}
+          path: ${{ env.job_name }}*.json
+
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}
         uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
@@ -771,6 +790,12 @@ jobs:
         with:
           name: cilium-junits
           pattern: cilium-junits-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge Features tested
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: features-tested
+          pattern: features-tested-*
           token: ${{ secrets.GITHUB_TOKEN }}
 
   commit-status-final:

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -383,6 +383,13 @@ jobs:
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: ./.github/actions/conn-disrupt-test-setup
 
+      - name: Features tested before downgrade
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested before downgrade"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - before downgrade"
+
       - name: Downgrade Cilium to ${{ steps.vars.outputs.downgrade_version }} (${{ join(matrix.*, ', ') }})
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
         shell: bash
@@ -416,6 +423,13 @@ jobs:
           tests: '!seq-.*'
           extra-connectivity-test-flags: "--test-concurrency=${{ env.test_concurrency }}"
 
+      - name: Features tested after downgrade
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested after downgrade"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - after downgrade"
+
       - name: Fetch artifacts
         if: ${{ steps.vars.outputs.downgrade_version != '' && !success() }}
         shell: bash
@@ -445,6 +459,13 @@ jobs:
           name: cilium-junits-${{ matrix.name }}-${{ matrix.mode }}
           path: cilium-junits/*.xml
 
+      - name: Upload features tested
+        if: ${{ steps.vars.outputs.downgrade_version != '' && always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested-${{ matrix.name }}-${{ matrix.mode }}
+          path: ${{ env.job_name }}*.json
+
       - name: Publish Test Results As GitHub Summary
         if: ${{ steps.vars.outputs.downgrade_version != '' && always() }}
         uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
@@ -473,6 +494,12 @@ jobs:
         with:
           name: cilium-junits
           pattern: cilium-junits-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge Features tested
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: features-tested
+          pattern: features-tested-*
           token: ${{ secrets.GITHUB_TOKEN }}
 
   commit-status-final:

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -155,6 +155,12 @@ jobs:
           kubectl apply -f ${{ env.CONFORMANCE_TEMPLATE }}
           kubectl wait --for=condition=Available --all deployment --timeout=${{ env.TIMEOUT }}
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }}"
+
       - name: Report cluster failure status and capture cilium-sysdump
         if: ${{ failure() && steps.install-cilium.outcome != 'skipped' }}
         # The following is needed to prevent hubble from receiving an empty
@@ -172,3 +178,10 @@ jobs:
         with:
           name: cilium-sysdump-out.zip
           path: cilium-sysdump-out.zip
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested
+          path: ${{ env.job_name }}*.json

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -170,6 +170,12 @@ jobs:
           kubectl apply -f ${{ env.CONFORMANCE_TEMPLATE }}
           kubectl wait --for=condition=Available --all deployment --timeout=${{ env.TIMEOUT }}
 
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }}"
+
       - name: Check prometheus metrics
         if: ${{ success() }}
         run: |
@@ -203,3 +209,10 @@ jobs:
         with:
           name: cilium-sysdump-out.zip
           path: cilium-sysdump-out.zip
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: features-tested
+          path: ${{ env.job_name }}*.json

--- a/cilium-cli/cli/cmd.go
+++ b/cilium-cli/cli/cmd.go
@@ -106,6 +106,7 @@ cilium connectivity test`,
 		newCmdInstallWithHelm(),
 		newCmdUninstallWithHelm(),
 		newCmdUpgradeWithHelm(),
+		newCmdFeatures(),
 	)
 
 	cmd.SetOut(os.Stdout)

--- a/cilium-cli/cli/features.go
+++ b/cilium-cli/cli/features.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cli
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cilium/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium/cilium-cli/features"
+)
+
+func newCmdFeatures() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "features",
+		Short:   "Report which features are enabled in Cilium agents",
+		Long:    ``,
+		Aliases: []string{"fs"},
+	}
+	cmd.AddCommand(newCmdFeaturesStatus())
+	return cmd
+}
+
+func newCmdFeaturesStatus() *cobra.Command {
+	params := features.Parameters{}
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Display features status",
+		Long:  "This command returns features enabled from all nodes in the cluster",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			params.CiliumNamespace = namespace
+			s := features.NewFeatures(k8sClient, params)
+			if err := s.PrintFeatureStatus(context.Background()); err != nil {
+				fatalf("Unable to print features status: %s", err)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&params.AgentPodSelector, "agent-pod-selector", defaults.AgentPodSelector, "Label on cilium-agent pods to select with")
+	cmd.Flags().StringVar(&params.NodeName, "node", "", "Node from which features status will be fetched, omit to select all nodes")
+	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", 1*time.Minute, "Maximum time to wait for result, default 1 minute")
+	cmd.Flags().StringVarP(&params.Output, "output", "o", "tab", "Output format. One of: tab, markdown, json")
+	cmd.Flags().StringVarP(&params.Outputfile, "output-file", "", "-", "Outputs into a file. Defaults to stdout")
+	return cmd
+}

--- a/cilium-cli/features/features.go
+++ b/cilium-cli/features/features.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cilium/cilium/cilium-cli/k8s"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Parameters contains options for CLI
+type Parameters struct {
+	CiliumNamespace  string
+	AgentPodSelector string
+	NodeName         string
+	WaitDuration     time.Duration
+	Output           string
+	Outputfile       string
+}
+
+type Feature struct {
+	client *k8s.Client
+	params Parameters
+}
+
+func NewFeatures(client *k8s.Client, p Parameters) *Feature {
+	return &Feature{
+		client: client,
+		params: p,
+	}
+}
+
+// fetchCiliumPods returns slice of cilium agent pods.
+// If option NodeName is specified then only that nodes' cilium-agent
+// pod is returned else all cilium-agents in the cluster are returned.
+func (s *Feature) fetchCiliumPods(ctx context.Context) ([]corev1.Pod, error) {
+	opts := metav1.ListOptions{LabelSelector: s.params.AgentPodSelector}
+	if s.params.NodeName != "" {
+		opts.FieldSelector = fmt.Sprintf("spec.nodeName=%s", s.params.NodeName)
+	}
+
+	pods, err := s.client.ListPods(ctx, s.params.CiliumNamespace, opts)
+	if err != nil {
+		return nil, fmt.Errorf("unable to list Cilium pods: %w", err)
+	}
+	return pods.Items, nil
+}

--- a/cilium-cli/features/markdown.go
+++ b/cilium-cli/features/markdown.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type markdownWriter struct {
+	builder *strings.Builder
+	writer  io.Writer
+}
+
+func newMarkdownWriter(w io.Writer) statusPrinter {
+	return &markdownWriter{
+		builder: &strings.Builder{},
+		writer:  w,
+	}
+}
+
+func (mw *markdownWriter) printHeader(nodesSorted []string) error {
+	mw.builder.WriteString("| Uniform | Name | Labels |")
+	for _, node := range nodesSorted {
+		mw.builder.WriteString(fmt.Sprintf(" %s |", node))
+	}
+	mw.builder.WriteString("\n|-|-|")
+	for range nodesSorted {
+		mw.builder.WriteString("-|")
+	}
+	mw.builder.WriteString("-|\n")
+	return nil
+}
+
+func (mw *markdownWriter) printNode(metricName, labels string, isBinary bool, values map[float64]struct{}, key string, nodesSorted []string, metricsPerNode map[string]map[string]float64) {
+	if isBinary && len(values) <= 1 {
+		mw.builder.WriteString("| :heavy_check_mark: ")
+	} else {
+		mw.builder.WriteString("| :warning: ")
+	}
+
+	mw.builder.WriteString(fmt.Sprintf("| %s | %s |", metricName, labels))
+
+	for _, node := range nodesSorted {
+		value := metricsPerNode[key][node]
+		mw.builder.WriteString(fmt.Sprintf(" %.0f |", value))
+	}
+	mw.builder.WriteString(fmt.Sprintln())
+}
+
+func (mw *markdownWriter) end() error {
+	_, err := fmt.Fprint(mw.writer, mw.builder.String())
+	return err
+}

--- a/cilium-cli/features/status.go
+++ b/cilium-cli/features/status.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/cilium-cli/defaults"
+)
+
+var (
+	cmdMetricsList = []string{"cilium", "metrics", "list", "-p", "cilium_feature", "-o", "json"}
+)
+
+// perNodeMetrics maps a node name to their metrics
+type perNodeMetrics map[string][]*models.Metric
+
+// PrintFeatureStatus prints encryption status from all/specific cilium agent pods.
+func (s *Feature) PrintFeatureStatus(ctx context.Context) error {
+	ctx, cancelFn := context.WithTimeout(ctx, s.params.WaitDuration)
+	defer cancelFn()
+
+	pods, err := s.fetchCiliumPods(ctx)
+	if err != nil {
+		return err
+	}
+
+	nodeMap, err := s.fetchStatusConcurrently(ctx, pods)
+	if err != nil {
+		return err
+	}
+
+	w := os.Stdout
+	if s.params.Outputfile != "-" {
+		w, err = os.Create(s.params.Outputfile)
+		if err != nil {
+			return err
+		}
+		defer w.Close()
+	}
+
+	switch s.params.Output {
+	case "tab":
+		return printPerNodeFeatureStatus(nodeMap, newTabWriter(w))
+	case "markdown":
+		return printPerNodeFeatureStatus(nodeMap, newMarkdownWriter(w))
+	case "json":
+		return json.NewEncoder(w).Encode(nodeMap)
+	default:
+		return fmt.Errorf("output %s not recognized", s.params.Output)
+	}
+}
+
+func (s *Feature) fetchStatusConcurrently(ctx context.Context, pods []corev1.Pod) (perNodeMetrics, error) {
+	// res contains data returned from cilium pod
+	type res struct {
+		nodeName string
+		status   []*models.Metric
+		err      error
+	}
+	resCh := make(chan res)
+	defer close(resCh)
+
+	// concurrently fetch state from each cilium pod
+	for _, pod := range pods {
+		go func(ctx context.Context, pod corev1.Pod) {
+			st, err := s.fetchCiliumFeatureMetricsFromPod(ctx, pod)
+			resCh <- res{
+				nodeName: pod.Spec.NodeName,
+				status:   st,
+				err:      err,
+			}
+		}(ctx, pod)
+	}
+
+	// read from the channel, on error, store error and continue to next node
+	var err error
+	data := make(perNodeMetrics)
+	for range pods {
+		r := <-resCh
+		if r.err != nil {
+			err = errors.Join(err, r.err)
+			continue
+		}
+		data[r.nodeName] = r.status
+	}
+	return data, err
+}
+
+func (s *Feature) fetchCiliumFeatureMetricsFromPod(ctx context.Context, pod corev1.Pod) ([]*models.Metric, error) {
+	output, err := s.client.ExecInPod(ctx, pod.Namespace, pod.Name, defaults.AgentContainerName, cmdMetricsList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to features status from %s: %w", pod.Name, err)
+	}
+	encStatus, err := nodeStatusFromOutput(output.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to features status from %s: %w", pod.Name, err)
+	}
+	return encStatus, nil
+}
+
+func nodeStatusFromOutput(output string) ([]*models.Metric, error) {
+	var encStatus []*models.Metric
+	if err := json.Unmarshal([]byte(output), &encStatus); err != nil {
+		return []*models.Metric{}, fmt.Errorf("failed to unmarshal json: %w", err)
+	}
+	return encStatus, nil
+}
+
+type statusPrinter interface {
+	printHeader(sorted []string) error
+	printNode(metricName, labels string, isBinary bool, values map[float64]struct{}, key string, nodesSorted []string, metricsPerNode map[string]map[string]float64)
+	end() error
+}
+
+// parseNameAndLabels splits the key into name and labels based on the first ";" separator
+func parseNameAndLabels(key string) (string, string) {
+	if idx := strings.Index(key, ";"); idx != -1 {
+		return key[:idx], key[idx+1:]
+	}
+	return key, ""
+}
+
+func printPerNodeFeatureStatus(nodeMap perNodeMetrics, sp statusPrinter) error {
+	var nodesSorted []string
+	for node := range nodeMap {
+		nodesSorted = append(nodesSorted, node)
+	}
+	slices.Sort(nodesSorted)
+
+	// Create header with all the nodes' names
+	err := sp.printHeader(nodesSorted)
+	if err != nil {
+		return err
+	}
+
+	// map a metric name + labels to a node value
+	//   map[name+labels][node-name]value
+	metrics := make(map[string]map[string]float64)
+	metricNamesLabels := map[string]struct{}{}
+	for nodeName, nodeMetrics := range nodeMap {
+		for _, metric := range nodeMetrics {
+			var orderedLabels []string
+			for k, v := range metric.Labels {
+				orderedLabels = append(orderedLabels, fmt.Sprintf("%s=%s", k, v))
+			}
+			slices.Sort(orderedLabels)
+
+			// Generate a unique key based on metric name and labels for each entry
+			key := metric.Name
+			if len(orderedLabels) != 0 {
+				key += ";"
+			}
+			key += strings.Join(orderedLabels, ";")
+
+			if _, ok := metrics[key]; !ok {
+				metrics[key] = make(map[string]float64)
+			}
+			metrics[key][nodeName] = metric.Value
+			metricNamesLabels[key] = struct{}{}
+		}
+	}
+
+	var metricNamesLabelsSorted []string
+	for key := range metricNamesLabels {
+		metricNamesLabelsSorted = append(metricNamesLabelsSorted, key)
+	}
+	slices.Sort(metricNamesLabelsSorted)
+
+	var previousMetricName string
+	var firstMetric bool
+	for _, key := range metricNamesLabelsSorted {
+
+		values := make(map[float64]struct{})
+		isBinary := true
+		for _, node := range nodesSorted {
+			value := metrics[key][node]
+			values[value] = struct{}{}
+			if value != 0 && value != 1 {
+				isBinary = false
+			}
+		}
+
+		metricName, labels := parseNameAndLabels(key)
+
+		if firstMetric || (previousMetricName != metricName) {
+			firstMetric = false
+			previousMetricName = metricName
+		} else {
+			previousMetricName = ""
+		}
+		sp.printNode(previousMetricName, labels, isBinary, values, key, nodesSorted, metrics)
+
+		previousMetricName = metricName
+	}
+
+	return sp.end()
+}

--- a/cilium-cli/features/status_test.go
+++ b/cilium-cli/features/status_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/models"
+)
+
+func Test_printPerNodeFeatureStatus(t *testing.T) {
+	type args struct {
+		nodeMap        perNodeMetrics
+		sp             func(w io.Writer) statusPrinter
+		buffer         bytes.Buffer
+		expectedResult string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Test tab writter output",
+			args: args{
+				nodeMap: perNodeMetrics{
+					"node-1": {
+						&models.Metric{
+							Labels: map[string]string{
+								"protocol": "ipv4-only",
+							},
+							Name:  "cilium_feature_adv_connect_and_lb_big_tcp_enabled",
+							Value: 1,
+						},
+						&models.Metric{
+							Name:  "cilium_feature_adv_connect_and_lb_envoy_proxy_enabled",
+							Value: 1,
+						},
+						&models.Metric{
+							Labels: map[string]string{
+								"protocol": "ipv6-only",
+							},
+							Name:  "cilium_feature_adv_connect_and_lb_big_tcp_enabled",
+							Value: 0,
+						},
+					},
+					"node-2": {
+						&models.Metric{
+							Labels: map[string]string{
+								"protocol": "ipv4-only",
+							},
+							Name:  "cilium_feature_adv_connect_and_lb_big_tcp_enabled",
+							Value: 1,
+						},
+						&models.Metric{
+							Name:  "cilium_feature_adv_connect_and_lb_envoy_proxy_enabled",
+							Value: 0,
+						},
+						&models.Metric{
+							Labels: map[string]string{
+								"protocol": "ipv6-only",
+							},
+							Name:  "cilium_feature_adv_connect_and_lb_big_tcp_enabled",
+							Value: 0,
+						},
+					},
+					"node-3": {
+						&models.Metric{
+							Labels: map[string]string{
+								"protocol": "ipv4-only",
+							},
+							Name:  "cilium_feature_adv_connect_and_lb_big_tcp_enabled",
+							Value: 1,
+						},
+						&models.Metric{
+							Name:  "cilium_feature_adv_connect_and_lb_envoy_proxy_enabled",
+							Value: 0,
+						},
+						&models.Metric{
+							Labels: map[string]string{
+								"protocol": "ipv6-only",
+							},
+							Name:  "cilium_feature_adv_connect_and_lb_big_tcp_enabled",
+							Value: 0,
+						},
+					},
+				},
+				sp:     func(w io.Writer) statusPrinter { return newTabWriter(w) },
+				buffer: bytes.Buffer{},
+				expectedResult: `Uniform  Name                                                   Labels              node-1  node-2  node-3  
+Yes      cilium_feature_adv_connect_and_lb_big_tcp_enabled      protocol=ipv4-only  1       1       1       
+Yes                                                             protocol=ipv6-only  0       0       0       
+No       cilium_feature_adv_connect_and_lb_envoy_proxy_enabled                      1       0       0       
+`,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test markdown writer output",
+			args: args{
+				nodeMap: perNodeMetrics{
+					"node-1": {
+						&models.Metric{
+							Labels: map[string]string{
+								"protocol": "ipv4-only",
+							},
+							Name:  "cilium_feature_adv_connect_and_lb_big_tcp_enabled",
+							Value: 1,
+						},
+						&models.Metric{
+							Name:  "cilium_feature_adv_connect_and_lb_envoy_proxy_enabled",
+							Value: 1,
+						},
+						&models.Metric{
+							Labels: map[string]string{
+								"protocol": "ipv6-only",
+							},
+							Name:  "cilium_feature_adv_connect_and_lb_big_tcp_enabled",
+							Value: 0,
+						},
+					},
+					"node-2": {
+						&models.Metric{
+							Labels: map[string]string{
+								"protocol": "ipv4-only",
+							},
+							Name:  "cilium_feature_adv_connect_and_lb_big_tcp_enabled",
+							Value: 1,
+						},
+						&models.Metric{
+							Name:  "cilium_feature_adv_connect_and_lb_envoy_proxy_enabled",
+							Value: 0,
+						},
+						&models.Metric{
+							Labels: map[string]string{
+								"protocol": "ipv6-only",
+							},
+							Name:  "cilium_feature_adv_connect_and_lb_big_tcp_enabled",
+							Value: 0,
+						},
+					},
+					"node-3": {
+						&models.Metric{
+							Labels: map[string]string{
+								"protocol": "ipv4-only",
+							},
+							Name:  "cilium_feature_adv_connect_and_lb_big_tcp_enabled",
+							Value: 1,
+						},
+						&models.Metric{
+							Name:  "cilium_feature_adv_connect_and_lb_envoy_proxy_enabled",
+							Value: 0,
+						},
+						&models.Metric{
+							Labels: map[string]string{
+								"protocol": "ipv6-only",
+							},
+							Name:  "cilium_feature_adv_connect_and_lb_big_tcp_enabled",
+							Value: 0,
+						},
+					},
+				},
+				sp:     func(w io.Writer) statusPrinter { return newMarkdownWriter(w) },
+				buffer: bytes.Buffer{},
+				expectedResult: `| Uniform | Name | Labels | node-1 | node-2 | node-3 |
+|-|-|-|-|-|-|
+| :heavy_check_mark: | cilium_feature_adv_connect_and_lb_big_tcp_enabled | protocol=ipv4-only | 1 | 1 | 1 |
+| :heavy_check_mark: |  | protocol=ipv6-only | 0 | 0 | 0 |
+| :warning: | cilium_feature_adv_connect_and_lb_envoy_proxy_enabled |  | 1 | 0 | 0 |
+`,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := printPerNodeFeatureStatus(tt.args.nodeMap, tt.args.sp(&tt.args.buffer)); (err != nil) != tt.wantErr {
+				t.Errorf("printPerNodeFeatureStatus() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, tt.args.expectedResult, tt.args.buffer.String())
+		})
+	}
+}

--- a/cilium-cli/features/tab_writer.go
+++ b/cilium-cli/features/tab_writer.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+)
+
+type tabWriter struct {
+	tb *tabwriter.Writer
+}
+
+func newTabWriter(w io.Writer) statusPrinter {
+	return &tabWriter{
+		tb: tabwriter.NewWriter(w, 0, 0, 2, ' ', 0),
+	}
+}
+
+func (t *tabWriter) printHeader(nodesSorted []string) error {
+	fmt.Fprintf(t.tb, "Uniform\tName\tLabels\t")
+	for _, node := range nodesSorted {
+		fmt.Fprintf(t.tb, "%s\t", node)
+	}
+	fmt.Fprintf(t.tb, "\n")
+	return nil
+}
+
+func (t *tabWriter) printNode(metricName, labels string, isBinary bool, values map[float64]struct{}, key string, nodesSorted []string, metricsPerNode map[string]map[string]float64) {
+	// Determine if "Yes" should be placed in "Uniform" column
+	// if len(values) <= 1 then it means that all nodes have a value of
+	// either 0 or 1.
+	if isBinary && len(values) <= 1 {
+		fmt.Fprintf(t.tb, "Yes\t")
+	} else {
+		fmt.Fprintf(t.tb, "No\t")
+	}
+
+	fmt.Fprintf(t.tb, "%s\t%s\t", metricName, labels)
+	for _, node := range nodesSorted {
+		value := metricsPerNode[key][node]
+		fmt.Fprintf(t.tb, "%.0f\t", value)
+	}
+	fmt.Fprintln(t.tb)
+}
+
+func (t *tabWriter) end() error {
+	return t.tb.Flush()
+}

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -54,6 +54,7 @@ import (
 	natStats "github.com/cilium/cilium/pkg/maps/nat/stats"
 	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/features"
 	"github.com/cilium/cilium/pkg/node"
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/nodediscovery"
@@ -304,6 +305,11 @@ var (
 
 		// Runs the Hubble servers and Hubble metrics.
 		hubble.Cell,
+
+		// The feature Cell will retrieve information from all other cells /
+		// configuration to describe, in form of prometheus metrics, which
+		// features are enabled on the agent.
+		features.Cell,
 	)
 )
 

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 
+	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
@@ -43,13 +44,19 @@ type featuresParams struct {
 	ConfigPromise promise.Promise[*option.DaemonConfig]
 	Metrics       featureMetrics
 
-	TunnelConfig tunnel.Config
+	TunnelConfig     tunnel.Config
+	CNIConfigManager cni.CNIConfigManager
 }
 
 func (fp *featuresParams) TunnelProtocol() tunnel.Protocol {
 	return fp.TunnelConfig.Protocol()
 }
 
+func (fp *featuresParams) GetChainingMode() string {
+	return fp.CNIConfigManager.GetChainingMode()
+}
+
 type enabledFeatures interface {
 	TunnelProtocol() tunnel.Protocol
+	GetChainingMode() string
 }

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/promise"
+)
+
+// Cell will retrieve information from all other cells /
+// configuration to describe, in form of prometheus metrics, which
+// features are enabled on the agent.
+var Cell = cell.Module(
+	"enabled-features",
+	"Exports prometheus metrics describing which features are enabled in cilium-agent",
+
+	cell.Invoke(updateAgentConfigMetricOnStart),
+	cell.Provide(
+		func(m Metrics) featureMetrics {
+			return m
+		},
+	),
+	metrics.Metric(func() Metrics {
+		return NewMetrics(true)
+	}),
+)
+
+type featuresParams struct {
+	cell.In
+
+	Log           *slog.Logger
+	JobGroup      job.Group
+	Health        cell.Health
+	Lifecycle     cell.Lifecycle
+	ConfigPromise promise.Promise[*option.DaemonConfig]
+	Metrics       featureMetrics
+
+	TunnelConfig tunnel.Config
+}
+
+func (fp *featuresParams) TunnelProtocol() tunnel.Protocol {
+	return fp.TunnelConfig.Protocol()
+}
+
+type enabledFeatures interface {
+	TunnelProtocol() tunnel.Protocol
+}

--- a/pkg/metrics/features/features.go
+++ b/pkg/metrics/features/features.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+)
+
+func updateAgentConfigMetricOnStart(jg job.Group, params featuresParams, m featureMetrics) error {
+	jg.Add(job.OneShot("update-config-metric", func(ctx context.Context, health cell.Health) error {
+		// We depend on settings modified by the Daemon startup.
+		// Once the Deamon is initialized this promise
+		// is resolved and we are guaranteed to have the correct settings.
+		health.OK("Waiting for agent config")
+		agentConfig, err := params.ConfigPromise.Await(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get agent config: %w", err)
+		}
+		m.update(&params, agentConfig)
+		return nil
+	}))
+
+	return nil
+}

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -14,11 +14,12 @@ import (
 // Metrics represents a collection of metrics related to a specific feature.
 // Each field is named according to the specific feature that it tracks.
 type Metrics struct {
-	DPMode               metric.Vec[metric.Gauge]
-	DPIPAM               metric.Vec[metric.Gauge]
-	DPChaining           metric.Vec[metric.Gauge]
-	DPIP                 metric.Vec[metric.Gauge]
-	DPIdentityAllocation metric.Vec[metric.Gauge]
+	DPMode                        metric.Vec[metric.Gauge]
+	DPIPAM                        metric.Vec[metric.Gauge]
+	DPChaining                    metric.Vec[metric.Gauge]
+	DPIP                          metric.Vec[metric.Gauge]
+	DPIdentityAllocation          metric.Vec[metric.Gauge]
+	DPCiliumEndpointSlicesEnabled metric.Gauge
 }
 
 const (
@@ -176,6 +177,13 @@ func NewMetrics(withDefaults bool) Metrics {
 				}(),
 			},
 		}),
+
+		DPCiliumEndpointSlicesEnabled: metric.NewGauge(metric.GaugeOpts{
+			Help:      "Cilium Endpoint Slices enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemDP,
+			Name:      "cilium_endpoint_slices_enabled",
+		}),
 	}
 }
 
@@ -214,4 +222,8 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 
 	identityAllocationMode := config.IdentityAllocationMode
 	m.DPIdentityAllocation.WithLabelValues(identityAllocationMode).Add(1)
+
+	if config.EnableCiliumEndpointSlice {
+		m.DPCiliumEndpointSlicesEnabled.Add(1)
+	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -14,8 +14,9 @@ import (
 // Metrics represents a collection of metrics related to a specific feature.
 // Each field is named according to the specific feature that it tracks.
 type Metrics struct {
-	DPMode metric.Vec[metric.Gauge]
-	DPIPAM metric.Vec[metric.Gauge]
+	DPMode     metric.Vec[metric.Gauge]
+	DPIPAM     metric.Vec[metric.Gauge]
+	DPChaining metric.Vec[metric.Gauge]
 }
 
 const (
@@ -26,6 +27,13 @@ const (
 	networkModeOverlayVXLAN  = "overlay-vxlan"
 	networkModeOverlayGENEVE = "overlay-geneve"
 	networkModeDirectRouting = "direct-routing"
+
+	networkChainingModeNone        = "none"
+	networkChainingModeAWSCNI      = "aws-cni"
+	networkChainingModeAWSVPCCNI   = "aws-vpc-cni"
+	networkChainingModeCalico      = "calico"
+	networkChainingModeFlannel     = "flannel"
+	networkChainingModeGenericVeth = "generic-veth"
 )
 
 var (
@@ -44,6 +52,15 @@ var (
 		ipamOption.IPAMMultiPool,
 		ipamOption.IPAMAlibabaCloud,
 		ipamOption.IPAMDelegatedPlugin,
+	}
+
+	defaultChainingModes = []string{
+		networkChainingModeNone,
+		networkChainingModeAWSCNI,
+		networkChainingModeAWSVPCCNI,
+		networkChainingModeCalico,
+		networkChainingModeFlannel,
+		networkChainingModeGenericVeth,
 	}
 )
 
@@ -86,6 +103,24 @@ func NewMetrics(withDefaults bool) Metrics {
 				}(),
 			},
 		}),
+
+		DPChaining: metric.NewGaugeVecWithLabels(metric.GaugeOpts{
+			Help:      "Chaining mode enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemDP,
+			Name:      "chaining_enabled",
+		}, metric.Labels{
+			{
+				Name: "mode", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultChainingModes...,
+					)
+				}(),
+			},
+		}),
 	}
 }
 
@@ -109,4 +144,7 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 	ipamMode := config.IPAMMode()
 
 	m.DPIPAM.WithLabelValues(ipamMode).Add(1)
+
+	chainingMode := params.GetChainingMode()
+	m.DPChaining.WithLabelValues(chainingMode).Add(1)
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// Metrics represents a collection of metrics related to a specific feature.
+// Each field is named according to the specific feature that it tracks.
+type Metrics struct {
+	DPMode metric.Vec[metric.Gauge]
+}
+
+const (
+	subsystemDP = "feature_datapath"
+)
+
+const (
+	networkModeOverlayVXLAN  = "overlay-vxlan"
+	networkModeOverlayGENEVE = "overlay-geneve"
+	networkModeDirectRouting = "direct-routing"
+)
+
+var (
+	defaultNetworkModes = []string{
+		networkModeOverlayVXLAN,
+		networkModeOverlayGENEVE,
+		networkModeDirectRouting,
+	}
+)
+
+// NewMetrics returns all feature metrics. If 'withDefaults' is set, then
+// all metrics will have defined all of their possible values.
+func NewMetrics(withDefaults bool) Metrics {
+	return Metrics{
+		DPMode: metric.NewGaugeVecWithLabels(metric.GaugeOpts{
+			Help:      "Network mode enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemDP,
+			Name:      "network",
+		}, metric.Labels{
+			{
+				Name: "mode", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultNetworkModes...,
+					)
+				}(),
+			},
+		}),
+	}
+}
+
+type featureMetrics interface {
+	update(params enabledFeatures, config *option.DaemonConfig)
+}
+
+func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
+	networkMode := networkModeDirectRouting
+	if config.TunnelingEnabled() {
+		switch params.TunnelProtocol() {
+		case tunnel.VXLAN:
+			networkMode = networkModeOverlayVXLAN
+		case tunnel.Geneve:
+			networkMode = networkModeOverlayGENEVE
+		}
+	}
+
+	m.DPMode.WithLabelValues(networkMode).Add(1)
+}

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -4,6 +4,7 @@
 package features
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
@@ -49,8 +50,10 @@ func TestUpdateNetworkMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			metrics := NewMetrics(true)
-			config := &option.DaemonConfig{}
-			config.RoutingMode = tt.tunnelMode
+			config := &option.DaemonConfig{
+				IPAM:        defaultIPAMModes[0],
+				RoutingMode: tt.tunnelMode,
+			}
 
 			params := mockFeaturesParams{
 				TunnelConfig: tt.tunnelProto,
@@ -61,6 +64,48 @@ func TestUpdateNetworkMode(t *testing.T) {
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultNetworkModes {
 				counter, err := metrics.DPMode.GetMetricWithLabelValues(mode)
+				assert.NoError(t, err)
+
+				counterValue := counter.Get()
+				if mode == tt.expectedMode {
+					assert.Equal(t, float64(1), counterValue, "Expected mode %s to be incremented", mode)
+				} else {
+					assert.Equal(t, float64(0), counterValue, "Expected mode %s to remain at 0", mode)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateIPAMMode(t *testing.T) {
+	type testCase struct {
+		name         string
+		IPAMMode     string
+		expectedMode string
+	}
+	var tests []testCase
+	for _, mode := range defaultIPAMModes {
+		tests = append(tests, testCase{
+			name:         fmt.Sprintf("IPAM %s mode", mode),
+			IPAMMode:     mode,
+			expectedMode: mode,
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				IPAM: tt.IPAMMode,
+			}
+
+			params := mockFeaturesParams{}
+
+			metrics.update(params, config)
+
+			// Check that only the expected mode's counter is incremented
+			for _, mode := range defaultIPAMModes {
+				counter, err := metrics.DPIPAM.GetMetricWithLabelValues(mode)
 				assert.NoError(t, err)
 
 				counterValue := counter.Get()

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -56,9 +56,10 @@ func TestUpdateNetworkMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			metrics := NewMetrics(true)
 			config := &option.DaemonConfig{
-				IPAM:        defaultIPAMModes[0],
-				RoutingMode: tt.tunnelMode,
-				EnableIPv4:  true,
+				IPAM:                   defaultIPAMModes[0],
+				RoutingMode:            tt.tunnelMode,
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 			}
 
 			params := mockFeaturesParams{
@@ -103,8 +104,9 @@ func TestUpdateIPAMMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			metrics := NewMetrics(true)
 			config := &option.DaemonConfig{
-				IPAM:       tt.IPAMMode,
-				EnableIPv4: true,
+				IPAM:                   tt.IPAMMode,
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 			}
 
 			params := mockFeaturesParams{
@@ -148,8 +150,9 @@ func TestUpdateCNIChainingMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			metrics := NewMetrics(true)
 			config := &option.DaemonConfig{
-				IPAM:       defaultIPAMModes[0],
-				EnableIPv4: true,
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 			}
 
 			params := mockFeaturesParams{
@@ -203,9 +206,10 @@ func TestUpdateInternetProtocol(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			metrics := NewMetrics(true)
 			config := &option.DaemonConfig{
-				IPAM:       defaultIPAMModes[0],
-				EnableIPv4: tt.enableIPv4,
-				EnableIPv6: tt.enableIPv6,
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             tt.enableIPv4,
+				EnableIPv6:             tt.enableIPv6,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 			}
 
 			params := mockFeaturesParams{
@@ -221,6 +225,52 @@ func TestUpdateInternetProtocol(t *testing.T) {
 
 				counterValue := counter.Get()
 				if mode == tt.expectedProtocol {
+					assert.Equal(t, float64(1), counterValue, "Expected mode %s to be incremented", mode)
+				} else {
+					assert.Equal(t, float64(0), counterValue, "Expected mode %s to remain at 0", mode)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateIdentityAllocationMode(t *testing.T) {
+	type testCase struct {
+		name                   string
+		identityAllocationMode string
+		expectedMode           string
+	}
+	var tests []testCase
+	for _, mode := range defaultIdentityAllocationModes {
+		tests = append(tests, testCase{
+			name:                   fmt.Sprintf("Identity Allocation mode %s", mode),
+			identityAllocationMode: mode,
+			expectedMode:           mode,
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             true,
+				IdentityAllocationMode: tt.identityAllocationMode,
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
+
+			metrics.update(params, config)
+
+			// Check that only the expected mode's counter is incremented
+			for _, mode := range defaultIdentityAllocationModes {
+				counter, err := metrics.DPIdentityAllocation.GetMetricWithLabelValues(mode)
+				assert.NoError(t, err)
+
+				counterValue := counter.Get()
+				if mode == tt.expectedMode {
 					assert.Equal(t, float64(1), counterValue, "Expected mode %s to be incremented", mode)
 				} else {
 					assert.Equal(t, float64(0), counterValue, "Expected mode %s to remain at 0", mode)

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -58,6 +58,7 @@ func TestUpdateNetworkMode(t *testing.T) {
 			config := &option.DaemonConfig{
 				IPAM:        defaultIPAMModes[0],
 				RoutingMode: tt.tunnelMode,
+				EnableIPv4:  true,
 			}
 
 			params := mockFeaturesParams{
@@ -102,7 +103,8 @@ func TestUpdateIPAMMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			metrics := NewMetrics(true)
 			config := &option.DaemonConfig{
-				IPAM: tt.IPAMMode,
+				IPAM:       tt.IPAMMode,
+				EnableIPv4: true,
 			}
 
 			params := mockFeaturesParams{
@@ -146,7 +148,8 @@ func TestUpdateCNIChainingMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			metrics := NewMetrics(true)
 			config := &option.DaemonConfig{
-				IPAM: defaultIPAMModes[0],
+				IPAM:       defaultIPAMModes[0],
+				EnableIPv4: true,
 			}
 
 			params := mockFeaturesParams{
@@ -162,6 +165,62 @@ func TestUpdateCNIChainingMode(t *testing.T) {
 
 				counterValue := counter.Get()
 				if mode == tt.expectedMode {
+					assert.Equal(t, float64(1), counterValue, "Expected mode %s to be incremented", mode)
+				} else {
+					assert.Equal(t, float64(0), counterValue, "Expected mode %s to remain at 0", mode)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateInternetProtocol(t *testing.T) {
+	tests := []struct {
+		name             string
+		enableIPv4       bool
+		enableIPv6       bool
+		expectedProtocol string
+	}{
+		{
+			name:             "IPv4-only",
+			enableIPv4:       true,
+			expectedProtocol: networkIPv4,
+		},
+		{
+			name:             "IPv6-only",
+			enableIPv6:       true,
+			expectedProtocol: networkIPv6,
+		},
+		{
+			name:             "IPv4-IPv6-dual-stack",
+			enableIPv4:       true,
+			enableIPv6:       true,
+			expectedProtocol: networkDualStack,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				IPAM:       defaultIPAMModes[0],
+				EnableIPv4: tt.enableIPv4,
+				EnableIPv6: tt.enableIPv6,
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
+
+			metrics.update(params, config)
+
+			// Check that only the expected mode's counter is incremented
+			for _, mode := range defaultChainingModes {
+				counter, err := metrics.DPIP.GetMetricWithLabelValues(mode)
+				assert.NoError(t, err)
+
+				counterValue := counter.Get()
+				if mode == tt.expectedProtocol {
 					assert.Equal(t, float64(1), counterValue, "Expected mode %s to be incremented", mode)
 				} else {
 					assert.Equal(t, float64(0), counterValue, "Expected mode %s to remain at 0", mode)

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/option"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockFeaturesParams struct {
+	TunnelConfig tunnel.Protocol
+}
+
+func (m mockFeaturesParams) TunnelProtocol() tunnel.Protocol {
+	return m.TunnelConfig
+}
+
+func TestUpdateNetworkMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		tunnelMode   string
+		tunnelProto  tunnel.Protocol
+		expectedMode string
+	}{
+		{
+			name:         "Direct routing mode",
+			tunnelMode:   option.RoutingModeNative,
+			expectedMode: networkModeDirectRouting,
+		},
+		{
+			name:         "Overlay VXLAN mode",
+			tunnelMode:   option.RoutingModeTunnel,
+			tunnelProto:  tunnel.VXLAN,
+			expectedMode: networkModeOverlayVXLAN,
+		},
+		{
+			name:         "Overlay Geneve mode",
+			tunnelMode:   option.RoutingModeTunnel,
+			tunnelProto:  tunnel.Geneve,
+			expectedMode: networkModeOverlayGENEVE,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{}
+			config.RoutingMode = tt.tunnelMode
+
+			params := mockFeaturesParams{
+				TunnelConfig: tt.tunnelProto,
+			}
+
+			metrics.update(params, config)
+
+			// Check that only the expected mode's counter is incremented
+			for _, mode := range defaultNetworkModes {
+				counter, err := metrics.DPMode.GetMetricWithLabelValues(mode)
+				assert.NoError(t, err)
+
+				counterValue := counter.Get()
+				if mode == tt.expectedMode {
+					assert.Equal(t, float64(1), counterValue, "Expected mode %s to be incremented", mode)
+				} else {
+					assert.Equal(t, float64(0), counterValue, "Expected mode %s to remain at 0", mode)
+				}
+			}
+		})
+	}
+}

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -14,11 +14,16 @@ import (
 )
 
 type mockFeaturesParams struct {
-	TunnelConfig tunnel.Protocol
+	TunnelConfig    tunnel.Protocol
+	CNIChainingMode string
 }
 
 func (m mockFeaturesParams) TunnelProtocol() tunnel.Protocol {
 	return m.TunnelConfig
+}
+
+func (m mockFeaturesParams) GetChainingMode() string {
+	return m.CNIChainingMode
 }
 
 func TestUpdateNetworkMode(t *testing.T) {
@@ -56,7 +61,8 @@ func TestUpdateNetworkMode(t *testing.T) {
 			}
 
 			params := mockFeaturesParams{
-				TunnelConfig: tt.tunnelProto,
+				TunnelConfig:    tt.tunnelProto,
+				CNIChainingMode: defaultChainingModes[0],
 			}
 
 			metrics.update(params, config)
@@ -99,13 +105,59 @@ func TestUpdateIPAMMode(t *testing.T) {
 				IPAM: tt.IPAMMode,
 			}
 
-			params := mockFeaturesParams{}
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
 
 			metrics.update(params, config)
 
 			// Check that only the expected mode's counter is incremented
 			for _, mode := range defaultIPAMModes {
 				counter, err := metrics.DPIPAM.GetMetricWithLabelValues(mode)
+				assert.NoError(t, err)
+
+				counterValue := counter.Get()
+				if mode == tt.expectedMode {
+					assert.Equal(t, float64(1), counterValue, "Expected mode %s to be incremented", mode)
+				} else {
+					assert.Equal(t, float64(0), counterValue, "Expected mode %s to remain at 0", mode)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateCNIChainingMode(t *testing.T) {
+	type testCase struct {
+		name         string
+		chainingMode string
+		expectedMode string
+	}
+	var tests []testCase
+	for _, mode := range defaultChainingModes {
+		tests = append(tests, testCase{
+			name:         fmt.Sprintf("CNI mode %s", mode),
+			chainingMode: mode,
+			expectedMode: mode,
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				IPAM: defaultIPAMModes[0],
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: tt.chainingMode,
+			}
+
+			metrics.update(params, config)
+
+			// Check that only the expected mode's counter is incremented
+			for _, mode := range defaultChainingModes {
+				counter, err := metrics.DPChaining.GetMetricWithLabelValues(mode)
 				assert.NoError(t, err)
 
 				counterValue := counter.Get()

--- a/test/k8s/bandwidth.go
+++ b/test/k8s/bandwidth.go
@@ -63,6 +63,7 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOnNetNextKernel, "K8sDatapathBandwidthT
 
 		JustAfterEach(func() {
 			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+			kubectl.CollectFeatures()
 		})
 
 		waitForTestPods := func() {

--- a/test/k8s/bgp.go
+++ b/test/k8s/bgp.go
@@ -42,6 +42,7 @@ var _ = SkipDescribeIf(
 
 		JustAfterEach(func() {
 			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+			kubectl.CollectFeatures()
 		})
 
 		AfterAll(func() {

--- a/test/k8s/chaos.go
+++ b/test/k8s/chaos.go
@@ -40,6 +40,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sAgentChaosTest", func() {
 
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		kubectl.CollectFeatures()
 	})
 
 	AfterAll(func() {

--- a/test/k8s/config.go
+++ b/test/k8s/config.go
@@ -49,6 +49,10 @@ var _ = SkipDescribeIf(func() bool {
 		kubectl.CloseSSHClient()
 	})
 
+	JustAfterEach(func() {
+		kubectl.CollectFeatures()
+	})
+
 	It("Correctly computes config overrides with CNC v2alpha1", func() {
 		pods, err := kubectl.GetPodsNodes(helpers.CiliumNamespace, helpers.CiliumSelector)
 		Expect(err).To(BeNil(), "error finding cilium pods")

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -55,6 +55,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		kubectl.CollectFeatures()
 	})
 
 	Context("MonitorAggregation", func() {

--- a/test/k8s/fqdn.go
+++ b/test/k8s/fqdn.go
@@ -98,6 +98,10 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sAgentFQDNTest", func() {
 		_ = kubectl.Exec(fmt.Sprintf("%s delete --all cnp", helpers.KubectlCmd))
 	})
 
+	JustAfterEach(func() {
+		kubectl.CollectFeatures()
+	})
+
 	It("Restart Cilium validate that FQDN is still working", func() {
 		// Test functionality:
 		// - When Cilium is running) Connectivity from App2 application can

--- a/test/k8s/hubble.go
+++ b/test/k8s/hubble.go
@@ -141,6 +141,7 @@ var _ = Describe("K8sAgentHubbleTest", func() {
 
 		JustAfterEach(func() {
 			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+			kubectl.CollectFeatures()
 		})
 
 		AfterAll(func() {

--- a/test/k8s/kafka_policies.go
+++ b/test/k8s/kafka_policies.go
@@ -88,6 +88,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sKafkaPolicyTest", func() {
 
 		JustAfterEach(func() {
 			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+			kubectl.CollectFeatures()
 		})
 
 		AfterEach(func() {

--- a/test/k8s/lrp.go
+++ b/test/k8s/lrp.go
@@ -31,6 +31,7 @@ var _ = SkipDescribeIf(func() bool { return helpers.RunsOn54Kernel() && helpers.
 
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		kubectl.CollectFeatures()
 	})
 
 	AfterAll(func() {

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -75,6 +75,7 @@ var _ = SkipDescribeIf(func() bool {
 
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		kubectl.CollectFeatures()
 	})
 
 	Context("Basic Test", func() {
@@ -1432,6 +1433,7 @@ var _ = SkipDescribeIf(helpers.DoesNotRunOn54OrLaterKernel,
 
 		JustAfterEach(func() {
 			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+			kubectl.CollectFeatures()
 		})
 
 		// Test must run with KPR enabled, see below comments.

--- a/test/k8s/pod_mac_address.go
+++ b/test/k8s/pod_mac_address.go
@@ -29,6 +29,7 @@ var _ = SkipDescribeIf(func() bool { return helpers.RunsOn54Kernel() && helpers.
 
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		kubectl.CollectFeatures()
 	})
 
 	AfterAll(func() {

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -55,6 +55,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		kubectl.CollectFeatures()
 	})
 
 	AfterAll(func() {


### PR DESCRIPTION
This PR lays the groundwork for tracking which features are being used in Cilium by representing them as metrics. After this PR is merged, additional PRs will follow to track more features.

Once all relevant features are being tracked, we'll gain insight into which features are being tested or left untested globally across our CI. In this initial phase, the PR will introduce summary tables (like the one below) to show which features are tested in each GitHub workflow.

<details>
<summary>Click here to summary example</summary>

| Uniform | Name | Labels | kind-control-plane | kind-worker |
|-|-|-|-|-|
| :heavy_check_mark: | cilium_feature_datapath_chaining_enabled | mode=aws-cni | 0 | 0 |
| :heavy_check_mark: |  | mode=aws-vpc-cni | 0 | 0 |
| :heavy_check_mark: |  | mode=calico | 0 | 0 |
| :heavy_check_mark: |  | mode=flannel | 0 | 0 |
| :heavy_check_mark: |  | mode=generic-veth | 0 | 0 |
| :heavy_check_mark: |  | mode=none | 1 | 1 |
| :heavy_check_mark: | cilium_feature_datapath_cilium_endpoint_slices_enabled |  | 0 | 0 |
| :heavy_check_mark: | cilium_feature_datapath_device | mode=lb-only | 0 | 0 |
| :heavy_check_mark: |  | mode=netkit | 0 | 0 |
| :heavy_check_mark: |  | mode=netkit-l2 | 0 | 0 |
| :heavy_check_mark: |  | mode=veth | 1 | 1 |
| :heavy_check_mark: | cilium_feature_datapath_identity_allocation | mode=crd | 1 | 1 |
| :heavy_check_mark: |  | mode=doublewrite-readcrd | 0 | 0 |
| :heavy_check_mark: |  | mode=doublewrite-readkvstore | 0 | 0 |
| :heavy_check_mark: |  | mode=kvstore | 0 | 0 |
| :heavy_check_mark: | cilium_feature_datapath_internet_protocol | protocol=ipv4-ipv6-dual-stack | 1 | 1 |
| :heavy_check_mark: |  | protocol=ipv4-only | 0 | 0 |
| :heavy_check_mark: |  | protocol=ipv6-only | 0 | 0 |
| :heavy_check_mark: | cilium_feature_datapath_ipam | mode=alibabacloud | 0 | 0 |
| :heavy_check_mark: |  | mode=azure | 0 | 0 |
| :heavy_check_mark: |  | mode=cluster-pool | 0 | 0 |
| :heavy_check_mark: |  | mode=crd | 0 | 0 |
| :heavy_check_mark: |  | mode=delegated-plugin | 0 | 0 |
| :heavy_check_mark: |  | mode=eni | 0 | 0 |
| :heavy_check_mark: |  | mode=kubernetes | 1 | 1 |
| :heavy_check_mark: |  | mode=multi-pool | 0 | 0 |
| :heavy_check_mark: | cilium_feature_datapath_network | mode=direct-routing | 0 | 0 |
| :heavy_check_mark: |  | mode=overlay-geneve | 0 | 0 |
| :heavy_check_mark: |  | mode=overlay-vxlan | 1 | 1 |

</details>

**F.A.Q.**:

**Why a single package with metrics?**
As this provides a great value in our CI and since the `pkg/metrics/features` is contained on its own package I'm planing to backport this to all branches.

**Why a gauges instead of counters?**
With gauges promtool doesn't complain that some metrics don't end with `_total` which is the norm for counters.

**Where are the docs?**
Oh that's right, I'll add them all on the last PR with the rest of the metrics. Thanks for asking, it's nice to know that people care about docs.

edit: the documentation was added in https://github.com/cilium/cilium/pull/36579

**This is a huge PR! Do I need to review everything?**
It could be worse but it's up to you. The first commit is the foundation, the commits in the middle is for each individual feature added so it's easier to reviewed per commit.