### PR TITLE
helm: Support extending certgen configuration templates

### DIFF
--- a/install/kubernetes/cilium/templates/_extensions.tpl
+++ b/install/kubernetes/cilium/templates/_extensions.tpl
@@ -48,3 +48,9 @@ disable-server-tls: true
 {{- define "hubble-relay.service.targetPort" -}}
 grpc
 {{- end }}
+
+{{/*
+Allow packagers to add extra configuration to certgen.
+*/}}
+{{- define "certgen.config.extra" -}}
+{{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
@@ -116,6 +116,7 @@ spec:
                   - client auth
                   validity: {{ $certValidityStr }}
                 {{- end }}
+                {{- include "certgen.config.extra" . | nindent 12 }}
           {{- with .Values.certgen.extraVolumeMounts }}
           volumeMounts:
           {{- toYaml . | nindent 10 }}


### PR DESCRIPTION
Similar to 2e18a24c0d0f203df51401ed9cbd914d91795bde, this enables packagers to package the helm chart with addiitonal templates for configuring certgen.