### PR TITLE
cilium-cli: Test TLS with serverNames

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -202,7 +202,7 @@ jobs:
             --helm-set=azure.resourceGroup=${{ env.name }} \
             --helm-set ipam.operator.clusterPoolIPv4PodCIDRList=192.168.0.0/16" # To avoid clashing with the default Service CIDR of AKS (10.0.0.0/16)
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled \
-            --hubble=false --collect-sysdump-on-failure --external-target bing.com. --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8"
+            --hubble=false --collect-sysdump-on-failure --external-target bing.com --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8"
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -218,7 +218,7 @@ jobs:
           # L7 policies are not supported in chaining mode.
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --test-concurrency=3 \
             --hubble=false --collect-sysdump-on-failure --test '!fqdn,!l7' \
-            --external-target amazon.com. --external-ip 1.0.0.1 --external-other-ip 1.1.1.1"
+            --external-target amazon.com --external-ip 1.0.0.1 --external-other-ip 1.1.1.1"
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -331,7 +331,7 @@ jobs:
             --flow-validation=disabled \
             --test-concurrency=5 \
             --multi-cluster=${{ env.contextName2 }} \
-            --external-target=google.com. \
+            --external-target=google.com \
             --include-unsafe-tests \
             --collect-sysdump-on-failure \
             --sysdump-output-filename 'cilium-sysdump-${{ matrix.name }}-<ts>'" \

--- a/.github/workflows/conformance-delegated-ipam.yaml
+++ b/.github/workflows/conformance-delegated-ipam.yaml
@@ -155,7 +155,7 @@ jobs:
 
           CONNECTIVITY_TEST_DEFAULTS="--test-concurrency=5 \
             --flow-validation=disabled --hubble=false --collect-sysdump-on-failure \
-            --external-target bing.com. --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8"
+            --external-target bing.com --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8"
 
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -213,7 +213,7 @@ jobs:
           fi
 
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --test-concurrency=3 \
-            --collect-sysdump-on-failure --external-target amazon.com."
+            --collect-sysdump-on-failure --external-target amazon.com"
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -225,7 +225,7 @@ jobs:
             --datapath-mode=tunnel \
             --helm-set kubeProxyReplacement=true"
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --collect-sysdump-on-failure \
-            --external-target google.com. --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8"
+            --external-target google.com --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8"
           # Explicitly specify LoadBalancer service type since the default type is NodePort in Helm mode.
           # Ref: https://github.com/cilium/cilium-cli/pull/1527#discussion_r1177244379
           #

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -228,7 +228,7 @@ jobs:
             --wait=false"
 
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --collect-sysdump-on-failure \
-            --external-target google.com. --external-cidr 8.0.0.0/8 --external-ip 8.8.8.8 --external-other-ip 8.8.4.4"
+            --external-target google.com --external-cidr 8.0.0.0/8 --external-ip 8.8.8.8 --external-other-ip 8.8.4.4"
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo hubble_enable_defaults=${HUBBLE_ENABLE_DEFAULTS} >> $GITHUB_OUTPUT
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -155,7 +155,7 @@ jobs:
 
           CONNECTIVITY_TEST_DEFAULTS="--test-concurrency=5 \
             --flow-validation=disabled --hubble=false --collect-sysdump-on-failure \
-            --external-target bing.com. --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8 \
+            --external-target bing.com --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8 \
             --namespace-annotations='{\"ipam.cilium.io/ip-pool\":\"cilium-test-pool\"}' \
             --deployment-pod-annotations='{ \
                 \"client\":{\"ipam.cilium.io/ip-pool\":\"client-pool\"}, \

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1287,7 +1287,7 @@
    * - :spelling:ignore:`envoy.image`
      - Envoy container image.
      - object
-     - ``{"digest":"sha256:5738b0d3d9e570ef17b97b828bdf41332251073131f0ed4e19fac803910b07c1","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.30.7-1730965050-cd22d9ffa21eb4f214bf059bcc5d2f40f0c47882","useDigest":true}``
+     - ``{"digest":"sha256:ec303104d5ec6baea108ee69e0e1a1c74d1bd571b48ee215481c592632f27e09","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy-dev","tag":"56316c0a012b32e87926b35f7d621dc09cf1ea30","useDigest":true}``
    * - :spelling:ignore:`envoy.initialFetchTimeoutSeconds`
      - Time in seconds after which the initial fetch on an xDS stream is considered timed out
      - int

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -128,7 +128,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().BoolVarP(&params.Verbose, "verbose", "v", false, "Show informational messages and don't buffer any lines")
 	cmd.Flags().BoolVarP(&params.Timestamp, "timestamp", "t", false, "Show timestamp in messages")
 	cmd.Flags().BoolVarP(&params.PauseOnFail, "pause-on-fail", "p", false, "Pause execution on test failure")
-	cmd.Flags().StringVar(&params.ExternalTarget, "external-target", "one.one.one.one.", "Domain name to use as external target in connectivity tests")
+	cmd.Flags().StringVar(&params.ExternalTarget, "external-target", "one.one.one.one", "Domain name to use as external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalTargetCANamespace, "external-target-ca-namespace", "", "Namespace of the CA secret for the external target. Used by client-egress-l7-tls test cases.")
 	cmd.Flags().StringVar(&params.ExternalTargetCAName, "external-target-ca-name", "cabundle", "Name of the CA secret for the external target. Used by client-egress-l7-tls test cases.")
 	cmd.Flags().StringVar(&params.ExternalCIDR, "external-cidr", "1.0.0.0/8", "CIDR to use as external target in connectivity tests")

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -66,6 +66,12 @@ var (
 	//go:embed manifests/client-egress-l7-http-named-port.yaml
 	clientEgressL7HTTPNamedPortPolicyYAML string
 
+	//go:embed manifests/client-egress-tls-sni.yaml
+	clientEgressTLSSNIPolicyYAML string
+
+	//go:embed manifests/client-egress-l7-tls-sni.yaml
+	clientEgressL7TLSSNIPolicyYAML string
+
 	//go:embed manifests/client-egress-l7-tls.yaml
 	clientEgressL7TLSPolicyYAML string
 
@@ -232,6 +238,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		clientEgressL7NamedPort{},
 		clientEgressL7TlsDenyWithoutHeaders{},
 		clientEgressL7TlsHeaders{},
+		clientEgressTlsSni{},
 		clientEgressL7SetHeader{},
 		echoIngressAuthAlwaysFail{},
 		echoIngressMutualAuthSpiffe{},
@@ -285,6 +292,8 @@ func renderTemplates(param check.Parameters) (map[string]string, error) {
 		"clientEgressL7HTTPPolicyPortRangeYAML":            clientEgressL7HTTPPolicyPortRangeYAML,
 		"clientEgressL7HTTPNamedPortPolicyYAML":            clientEgressL7HTTPNamedPortPolicyYAML,
 		"clientEgressToFQDNsPolicyYAML":                    clientEgressToFQDNsPolicyYAML,
+		"clientEgressTLSSNIPolicyYAML":                     clientEgressTLSSNIPolicyYAML,
+		"clientEgressL7TLSSNIPolicyYAML":                   clientEgressL7TLSSNIPolicyYAML,
 		"clientEgressL7TLSPolicyYAML":                      clientEgressL7TLSPolicyYAML,
 		"clientEgressL7TLSPolicyPortRangeYAML":             clientEgressL7TLSPolicyPortRangeYAML,
 		"clientEgressL7HTTPMatchheaderSecretYAML":          clientEgressL7HTTPMatchheaderSecretYAML,

--- a/cilium-cli/connectivity/builder/client_egress_tls_sni.go
+++ b/cilium-cli/connectivity/builder/client_egress_tls_sni.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type clientEgressTlsSni struct{}
+
+func (t clientEgressTlsSni) build(ct *check.ConnectivityTest, templates map[string]string) {
+	clientEgressTlsSniTest(ct, templates)
+	clientEgressL7TlsSniTest(ct, templates)
+}
+
+func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]string) {
+	testName := "client-egress-tls-sni"
+	yamlFile := templates["clientEgressTLSSNIPolicyYAML"]
+	// Test TLS SNI enforcement using an egress policy on the clients.
+	newTest(testName, ct).
+		WithCiliumVersion("!1.14.15 !1.14.16 !1.15.9 !1.15.10 !1.16.2 !1.16.3").
+		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithCiliumPolicy(yamlFile). // L7 allow policy TLS SNI enforcement
+		WithScenarios(tests.PodToWorld()).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Destination().Port() == 443 {
+				return check.ResultOK, check.ResultNone
+			}
+			return check.ResultDefaultDenyEgressDrop, check.ResultNone
+		})
+}
+
+func clientEgressL7TlsSniTest(ct *check.ConnectivityTest, templates map[string]string) {
+	testName := "client-egress-l7-tls-headers-sni"
+	yamlFile := templates["clientEgressL7TLSSNIPolicyYAML"]
+	// Test TLS SNI enforcement using an egress policy on the clients.
+	newTest(testName, ct).
+		WithCiliumVersion("!1.14.15 !1.14.16 !1.15.9 !1.15.10 !1.16.2 !1.16.3").
+		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretBackendK8s)).
+		WithCABundleSecret().
+		WithCertificate("externaltarget-tls", ct.Params().ExternalTarget).
+		WithCiliumPolicy(yamlFile). // L7 allow policy TLS SNI enforcement
+		WithScenarios(tests.PodToWorldWithTLSIntercept("-H", "X-Very-Secret-Token: 42")).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			return check.ResultOK, check.ResultNone
+		})
+}

--- a/cilium-cli/connectivity/builder/manifests/client-egress-l7-tls-sni.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-l7-tls-sni.yaml
@@ -1,0 +1,43 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "l7-policy-tls"
+specs:
+- description: "L7 policy with TLS"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  # Allow DNS 
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+      rules:
+        dns:
+          - matchPattern: "*"
+  # Allow HTTPS when X-Very-Secret-Token is set
+  - toFQDNs:
+    - matchName: "{{.ExternalTarget}}"
+    toPorts:
+    - ports:
+      - port: "443"
+        protocol: "TCP"
+      serverNames:
+      - "{{.ExternalTarget}}"
+      terminatingTLS:
+        secret:
+          namespace: "{{.TestNamespace}}"
+          name: externaltarget-tls # internal certificate to terminate in cluster
+      originatingTLS:
+        secret:
+          namespace: "{{.ExternalTargetCANamespace}}"
+          name: "{{.ExternalTargetCAName}}" # public CA bundle to validate external target
+      rules:
+        http:
+        - method: "GET"
+          path: "/"
+          headers:
+          - "X-Very-Secret-Token: 42"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni.yaml
@@ -1,0 +1,29 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "l7-policy-tls-sni"
+specs:
+- description: "L7 policy with TLS SNI"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  # Allow DNS 
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+      rules:
+        dns:
+          - matchPattern: "*"
+  # Allow HTTPS when X-Very-Secret-Token is set
+  - toFQDNs:
+    - matchName: "{{.ExternalTarget}}"
+    toPorts:
+    - ports:
+      - port: "443"
+        protocol: "TCP"
+      serverNames:
+      - "{{.ExternalTarget}}"

--- a/cilium-cli/connectivity/builder/to_fqdns.go
+++ b/cilium-cli/connectivity/builder/to_fqdns.go
@@ -15,7 +15,7 @@ import (
 type toFqdns struct{}
 
 func (t toFqdns) build(ct *check.ConnectivityTest, templates map[string]string) {
-	// This policy only allows port 80 to domain-name, default one.one.one.one., DNS proxy enabled.
+	// This policy only allows port 80 to domain-name, default one.one.one.one, DNS proxy enabled.
 	newTest("to-fqdns", ct).
 		WithCiliumPolicy(templates["clientEgressToFQDNsPolicyYAML"]).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).

--- a/examples/kubernetes/servicemesh/envoy/client-egress-l7-http.yaml
+++ b/examples/kubernetes/servicemesh/envoy/client-egress-l7-http.yaml
@@ -25,7 +25,7 @@ spec:
             http:
               - method: "GET"
                 path: "/"
-    # Allow GET / requests, only towards one.one.one.one.
+    # Allow GET / requests, only towards one.one.one.one
     - toFQDNs:
         - matchName: "one.one.one.one"
       toPorts:

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:ea50ccacdf85fc48eeb61947e
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-ARG CILIUM_ENVOY_IMAGE=quay.io/cilium/cilium-envoy:v1.30.7-1730965050-cd22d9ffa21eb4f214bf059bcc5d2f40f0c47882@sha256:5738b0d3d9e570ef17b97b828bdf41332251073131f0ed4e19fac803910b07c1
+ARG CILIUM_ENVOY_IMAGE=quay.io/cilium/cilium-envoy-dev:56316c0a012b32e87926b35f7d621dc09cf1ea30@sha256:ec303104d5ec6baea108ee69e0e1a1c74d1bd571b48ee215481c592632f27e09
 
 FROM ${CILIUM_ENVOY_IMAGE} AS cilium-envoy
 

--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -36,9 +36,9 @@ export CILIUM_NODEINIT_VERSION:=c54c7edeab7fde4da68e59acd319ab24af242c3f
 export CILIUM_NODEINIT_DIGEST:=sha256:8d7b41c4ca45860254b3c19e20210462ef89479bb6331d6760c4e609d651b29c
 
 # renovate: datasource=docker
-export CILIUM_ENVOY_REPO:=quay.io/cilium/cilium-envoy
-export CILIUM_ENVOY_VERSION:=v1.30.7-1730965050-cd22d9ffa21eb4f214bf059bcc5d2f40f0c47882
-export CILIUM_ENVOY_DIGEST:=sha256:5738b0d3d9e570ef17b97b828bdf41332251073131f0ed4e19fac803910b07c1
+export CILIUM_ENVOY_REPO:=quay.io/cilium/cilium-envoy-dev
+export CILIUM_ENVOY_VERSION:=56316c0a012b32e87926b35f7d621dc09cf1ea30
+export CILIUM_ENVOY_DIGEST:=sha256:ec303104d5ec6baea108ee69e0e1a1c74d1bd571b48ee215481c592632f27e09
 
 # renovate: datasource=docker
 export HUBBLE_UI_BACKEND_REPO:=quay.io/cilium/hubble-ui-backend

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -371,7 +371,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:5738b0d3d9e570ef17b97b828bdf41332251073131f0ed4e19fac803910b07c1","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.30.7-1730965050-cd22d9ffa21eb4f214bf059bcc5d2f40f0c47882","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:ec303104d5ec6baea108ee69e0e1a1c74d1bd571b48ee215481c592632f27e09","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy-dev","tag":"56316c0a012b32e87926b35f7d621dc09cf1ea30","useDigest":true}` | Envoy container image. |
 | envoy.initialFetchTimeoutSeconds | int | `30` | Time in seconds after which the initial fetch on an xDS stream is considered timed out |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2296,10 +2296,10 @@ envoy:
     # type: [null, string]
     # @schema
     override: ~
-    repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.30.7-1730965050-cd22d9ffa21eb4f214bf059bcc5d2f40f0c47882"
+    repository: "quay.io/cilium/cilium-envoy-dev"
+    tag: "56316c0a012b32e87926b35f7d621dc09cf1ea30"
     pullPolicy: "Always"
-    digest: "sha256:5738b0d3d9e570ef17b97b828bdf41332251073131f0ed4e19fac803910b07c1"
+    digest: "sha256:ec303104d5ec6baea108ee69e0e1a1c74d1bd571b48ee215481c592632f27e09"
     useDigest: true
   # -- Additional containers added to the cilium Envoy DaemonSet.
   extraContainers: []


### PR DESCRIPTION
Change the client-egress-l7-tls policy to also require SNI match on the configured external target. Add a new `client-egress-tls-sni` test case to test SNI enforcement without TLS interception. Remove the trailing dot from the external target default value to make this easier.

```release-note
Add coverage for SNI enforcement in cilium-cli connectivity tests.
```
