### PR TITLE
fix(hubble): use strconv.Itoa for kafka.ErrorCode + add unit tests

### DIFF
--- a/pkg/hubble/metrics/kafka/handler.go
+++ b/pkg/hubble/metrics/kafka/handler.go
@@ -5,6 +5,7 @@ package kafka
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -83,7 +84,7 @@ func (h *kafkaHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error
 		reporter = "server"
 	}
 
-	h.requests.WithLabelValues(append(labelValues, kafka.Topic, kafka.ApiKey, string(kafka.ErrorCode), reporter)...).Inc()
+	h.requests.WithLabelValues(append(labelValues, kafka.Topic, kafka.ApiKey, strconv.Itoa(int(kafka.ErrorCode)), reporter)...).Inc()
 	h.duration.WithLabelValues(append(labelValues, kafka.Topic, kafka.ApiKey, reporter)...).Observe(float64(l7.LatencyNs) / float64(time.Second))
 	return nil
 }

--- a/pkg/hubble/metrics/kafka/handler_test.go
+++ b/pkg/hubble/metrics/kafka/handler_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package kafka
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/metrics/api"
+)
+
+func Test_kafkaHandler_Status(t *testing.T) {
+	plugin := kafkaPlugin{}
+	handler := plugin.NewHandler()
+	assert.Equal(t, "", handler.Status())
+	options := []*api.ContextOptionConfig{
+		{
+			Name:   "sourceContext",
+			Values: []string{"namespace"},
+		},
+		{
+			Name:   "destinationContext",
+			Values: []string{"identity"},
+		},
+	}
+	require.NoError(t, handler.Init(prometheus.NewRegistry(), options))
+	assert.Equal(t, "destination=identity,source=namespace", handler.Status())
+}
+
+func Test_kafkaHandler_ProcessFlow(t *testing.T) {
+	ctx := context.Background()
+	plugin := kafkaPlugin{}
+	handler := plugin.NewHandler()
+	options := []*api.ContextOptionConfig{
+		{
+			Name:   "destinationContext",
+			Values: []string{"invalid"},
+		},
+	}
+	require.Error(t, handler.Init(prometheus.NewRegistry(), options))
+	options = []*api.ContextOptionConfig{
+		{
+			Name:   "sourceContext",
+			Values: []string{"pod"},
+		},
+		{
+			Name:   "destinationContext",
+			Values: []string{"pod"},
+		},
+		{
+			Name:   "labelsContext",
+			Values: []string{"source_pod", "destination_pod"},
+		},
+	}
+	require.NoError(t, handler.Init(prometheus.NewRegistry(), options))
+	fp, ok := handler.(api.FlowProcessor)
+	require.True(t, ok)
+	// shouldn't count
+	fp.ProcessFlow(ctx, &pb.Flow{})
+	// shouldn't count
+	fp.ProcessFlow(ctx, &pb.Flow{L7: &pb.Layer7{
+		Type:   pb.L7FlowType_RESPONSE,
+		Record: &pb.Layer7_Dns{},
+	}})
+	sourceEndpoint := &pb.Endpoint{
+		Namespace: "source-ns",
+		PodName:   "source-deploy-pod",
+		Workloads: []*pb.Workload{{
+			Name: "source-deploy",
+			Kind: "Deployment",
+		}},
+		Labels: []string{
+			"k8s:app=sourceapp",
+		},
+	}
+	destinationEndpoint := &pb.Endpoint{
+		Namespace: "destination-ns",
+		PodName:   "destination-deploy-pod",
+		Workloads: []*pb.Workload{{
+			Name: "destination-deploy",
+			Kind: "Deployment",
+		}},
+		Labels: []string{
+			"k8s:app=destinationapp",
+		},
+	}
+	// should count for request
+	fp.ProcessFlow(ctx, &pb.Flow{
+		TrafficDirection: pb.TrafficDirection_INGRESS,
+		Source:           sourceEndpoint,
+		Destination:      destinationEndpoint,
+		L7: &pb.Layer7{
+			Type:      pb.L7FlowType_REQUEST,
+			LatencyNs: 12345678,
+			Record: &pb.Layer7_Kafka{Kafka: &pb.Kafka{
+				Topic:     "test-topic",
+				ApiKey:    "test-api-key",
+				ErrorCode: 0,
+			}},
+		},
+	})
+	requestsExpected := `
+        # HELP hubble_kafka_requests_total Count of Kafka requests
+        # TYPE hubble_kafka_requests_total counter
+	      hubble_kafka_requests_total{api_key="test-api-key", destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",error_code="0",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic"} 1
+	`
+	assert.NoError(t, testutil.CollectAndCompare(handler.(*kafkaHandler).requests, strings.NewReader(requestsExpected)))
+	durationExpected := `
+        # HELP hubble_kafka_request_duration_seconds Quantiles of HTTP request duration in seconds
+        # TYPE hubble_kafka_request_duration_seconds histogram
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="0.005"} 0
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="0.01"} 0
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="0.025"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="0.05"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="0.1"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="0.25"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="0.5"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="1"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="2.5"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="5"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="10"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="+Inf"} 1
+        hubble_kafka_request_duration_seconds_sum{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic"} 0.012345678
+        hubble_kafka_request_duration_seconds_count{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic"} 1
+	`
+	require.NoError(t, testutil.CollectAndCompare(handler.(*kafkaHandler).duration, strings.NewReader(durationExpected)))
+}
+
+func Test_kafkaHandler_ListMetricVec(t *testing.T) {
+	plugin := kafkaPlugin{}
+	handler := plugin.NewHandler()
+	require.NoError(t, handler.Init(prometheus.NewRegistry(), nil))
+	assert.Len(t, handler.ListMetricVec(), 2, "expecting 2 metrics, requests and duration")
+	for _, vec := range handler.ListMetricVec() {
+		require.NotNil(t, vec, "ListMetricVec should not nil metrics vectors")
+	}
+}

--- a/pkg/hubble/metrics/kafka/plugin_test.go
+++ b/pkg/hubble/metrics/kafka/plugin_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package kafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_kafkaPlugin_HelpText(t *testing.T) {
+	plugin := &kafkaPlugin{}
+	expected := `kafka - Kafka metrics
+Metrics related to the Kafka protocol
+
+Metrics:
+  kafka_requests_total           - Count of Kafka requests by topic and ApiKey.
+  kafka_request_duration_seconds - Histogram of Kafka request duration by topic and ApiKey.
+
+Options:
+ sourceContext             ::= identifier , { "|", identifier }
+ destinationContext        ::= identifier , { "|", identifier }
+ sourceEgressContext       ::= identifier , { "|", identifier }
+ sourceIngressContext      ::= identifier , { "|", identifier }
+ destinationEgressContext  ::= identifier , { "|", identifier }
+ destinationIngressContext ::= identifier , { "|", identifier }
+ labels                    ::= label , { ",", label }
+ identifier                ::= identity | namespace | pod | pod-name | dns | ip | reserved-identity | workload | workload-name | app
+ label                     ::= source_ip | source_pod | source_namespace | source_workload | source_workload_kind | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_workload_kind | destination_app | traffic_direction
+`
+	assert.Equal(t, expected, plugin.HelpText())
+}


### PR DESCRIPTION
<!-- Description of change -->

Fixes: #35749
```release-note
Use `strconv.Itoa` instead of `string()` for the correct behavior when converting `kafka.ErrorCode` from `int32` to `string`. Add relevant unit tests for Kafka plugin and handler.
```

Verified that `hubble_kafka_requests_total` is working with the fix
![image](https://github.com/user-attachments/assets/519afb2d-c61f-484d-bb20-3a1e432cae61)
![image](https://github.com/user-attachments/assets/548d88fb-8fff-486a-86a3-8cb797e4da8b)


