### PR TITLE
v1.16 Backports 2024-11-08

### DIFF
--- a/operator/pkg/bgpv2/manager.go
+++ b/operator/pkg/bgpv2/manager.go
@@ -135,6 +135,14 @@ func (b *BGPResourceManager) initializeJobs() {
 			return nil
 		}),
 
+		job.OneShot("bgpv2-operator-node-config-tracker", func(ctx context.Context, health cell.Health) error {
+			for e := range b.nodeConfig.Events(ctx) {
+				b.triggerReconcile()
+				e.Done(nil)
+			}
+			return nil
+		}),
+
 		job.OneShot("bgpv2-operator-node-config-override-tracker", func(ctx context.Context, health cell.Health) error {
 			for e := range b.nodeConfigOverride.Events(ctx) {
 				b.triggerReconcile()


### PR DESCRIPTION
Author backport

 * [ ] #35690 (@YutaroHayakawa) Only one of the commit was backported. Another one is more like a feature. Thus, unnecessary.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 35690
```
