### PR TITLE
fix: SetBackends should always update frontends of the modified service

### DIFF
--- a/pkg/loadbalancer/experimental/writer.go
+++ b/pkg/loadbalancer/experimental/writer.go
@@ -334,6 +334,7 @@ func (w *Writer) SetBackends(txn WriteTxn, name loadbalancer.ServiceName, source
 	if err != nil {
 		return err
 	}
+	refs = refs.Insert(name) // Even for empty bes, we need to refresh this service.
 
 	// Release orphaned backends, e.g. all backends from this source referencing this
 	// service.


### PR DESCRIPTION
When `SetBackends(txn, name, source, bes)` received an empty slice `bes` of `BackendParams`, it failed to refresh frontends of the service specified by `name`. This omission is now fixed and a test for `SetBackends()` is added, which in particular covers this issue.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!