### PR TITLE
Silence spurious clustermesh-related warnings

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -279,6 +279,7 @@ jobs:
             --helm-set=clustermesh.apiserver.tls.auto.certManagerIssuerRef.kind=Issuer \
             --helm-set=clustermesh.apiserver.tls.auto.certManagerIssuerRef.name=cilium \
             --helm-set=ciliumEndpointSlice.enabled=${{ matrix.ciliumEndpointSlice == 'enabled'}} \
+            --helm-set=extraConfig.clustermesh-sync-timeout=5m \
             "
 
           CILIUM_INSTALL_TUNNEL="--helm-set=tunnelProtocol=${{ matrix.tunnel }}"

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -140,6 +140,11 @@ func (b *Exponential) Reset() {
 	b.attempt = 0
 }
 
+// Attempt returns the number of attempts since the last reset.
+func (b *Exponential) Attempt() int {
+	return b.attempt
+}
+
 // Wait waits for the required time using an exponential backoff
 func (b *Exponential) Wait(ctx context.Context) error {
 	if resetDuration := b.ResetAfter; resetDuration != time.Duration(0) && resetDuration > b.Max {

--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -158,7 +158,12 @@ func (rc *remoteCluster) restartRemoteConnection() {
 					if backend != nil {
 						backend.Close()
 					}
-					rc.logger.WithError(err).Warning("Unable to establish etcd connection to remote cluster")
+
+					select {
+					case <-ctx.Done():
+					default:
+						rc.logger.WithError(err).Warning("Unable to establish etcd connection to remote cluster")
+					}
 					return err
 				}
 
@@ -181,6 +186,16 @@ func (rc *remoteCluster) restartRemoteConnection() {
 
 				config, err := rc.getClusterConfig(ctx, backend)
 				if err != nil {
+					// Return immediately if the context has been canceled, to
+					// avoid emitting a spurious warning in case the failure is
+					// expected, and has already been logged elsewhere (or we
+					// are terminating).
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					default:
+					}
+
 					lgr := rc.logger
 					if errors.Is(err, cmutils.ErrClusterConfigNotFound) {
 						lgr = lgr.WithField(logfields.Hint,
@@ -208,7 +223,13 @@ func (rc *remoteCluster) restartRemoteConnection() {
 				}()
 
 				if err := <-ready; err != nil {
-					rc.logger.WithError(err).Warning("Connection to remote cluster failed")
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					default:
+						rc.logger.WithError(err).Warning("Connection to remote cluster failed")
+					}
+
 					return err
 				}
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -809,7 +809,13 @@ reList:
 		kvs, revision, err := e.paginatedList(ctx, scopedLog, w.Prefix)
 		if err != nil {
 			lr.Error(err, -1)
-			scopedLog.WithError(Hint(err)).Warn("Unable to list keys before starting watcher")
+
+			if attempt := errLimiter.Attempt(); attempt < 10 {
+				scopedLog.WithError(Hint(err)).WithField(logfields.Attempt, attempt).Info("Unable to list keys before starting watcher, will retry")
+			} else {
+				scopedLog.WithError(Hint(err)).WithField(logfields.Attempt, attempt).Warn("Unable to list keys before starting watcher, will retry")
+			}
+
 			errLimiter.Wait(ctx)
 			continue
 		}


### PR DESCRIPTION
Please refer to the individual commits for additional details.

Fixes: https://github.com/cilium/cilium/issues/35865
Marked for backport to v1.16 to prevent issues on downgrade when warning logs start being flagged in CI.
