### PR TITLE
Do not leak ipcache entries when apiserver entities are cluster external

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -804,6 +804,15 @@ func (ipc *IPCache) updateReservedHostLabels(prefix netip.Prefix, lbls labels.La
 	return identity.AddReservedIdentityWithLabels(identity.ReservedIdentityHost, newLabels)
 }
 
+// appendAPIServerLabelsForDeletion inspects labels and performs special handling for corner cases like API server entities
+// deployed external to the cluster.
+func appendAPIServerLabelsForDeletion(lbls labels.Labels, currentLabels labels.Labels) labels.Labels {
+	if currentLabels.HasKubeAPIServerLabel() && currentLabels.HasWorldLabel() && len(currentLabels) == 2 {
+		lbls.MergeLabels(labels.LabelWorld)
+	}
+	return lbls
+}
+
 // RemoveLabelsExcluded removes the given labels from all IPs inside the IDMD
 // except for the IPs / prefixes inside the given excluded set.
 //
@@ -821,7 +830,9 @@ func (ipc *IPCache) RemoveLabelsExcluded(
 	oldSet := ipc.metadata.filterByLabels(lbls)
 	for _, ip := range oldSet {
 		if _, ok := toExclude[ip]; !ok {
-			affectedPrefixes = append(affectedPrefixes, ipc.metadata.remove(ip, rid, lbls)...)
+			prefixLabels := ipc.metadata.getLocked(ip).ToLabels()
+			lblsToRemove := appendAPIServerLabelsForDeletion(lbls, prefixLabels)
+			affectedPrefixes = append(affectedPrefixes, ipc.metadata.remove(ip, rid, lblsToRemove)...)
 		}
 	}
 	ipc.metadata.enqueuePrefixUpdates(affectedPrefixes...)

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -475,6 +475,26 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	assert.Nil(t, id)
 }
 
+func TestRemoveAPIServerIdentityExternal(t *testing.T) {
+	cancel := setupTestExternalAPIServer(t)
+	defer cancel()
+	ctx := context.Background()
+
+	assert.Len(t, IPIdentityCache.metadata.m, 1)
+	remaining, err := IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	assert.NoError(t, err)
+	assert.Empty(t, remaining)
+	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
+
+	IPIdentityCache.RemoveLabelsExcluded(
+		labels.LabelKubeAPIServer, map[netip.Prefix]struct{}{},
+		"kube-uid")
+	remaining, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{worldPrefix})
+	assert.NoError(t, err)
+	assert.Empty(t, IPIdentityCache.metadata.m)
+	assert.Empty(t, remaining)
+}
+
 func TestOverrideIdentity(t *testing.T) {
 	allocator := testidentity.NewMockIdentityAllocator(nil)
 
@@ -1088,6 +1108,27 @@ func setupTest(t *testing.T) (cleanup func()) {
 
 	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.KubeAPIServer, "kube-uid", labels.LabelKubeAPIServer)
 	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.Local, "host-uid", labels.LabelHost)
+
+	return func() {
+		cancel()
+		IPIdentityCache.Shutdown()
+	}
+}
+
+func setupTestExternalAPIServer(t *testing.T) (cleanup func()) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	Allocator = testidentity.NewMockIdentityAllocator(nil)
+	PolicyHandler = newMockUpdater()
+	IPIdentityCache = NewIPCache(&Configuration{
+		Context:           ctx,
+		IdentityAllocator: Allocator,
+		PolicyHandler:     PolicyHandler,
+		DatapathHandler:   &mockTriggerer{},
+	})
+
+	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.KubeAPIServer, "kube-uid", labels.LabelKubeAPIServerExt)
 
 	return func() {
 		cancel()

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -104,6 +104,11 @@ var (
 	// on IDNameKubeAPIServer.
 	LabelKubeAPIServer = Labels{IDNameKubeAPIServer: NewLabel(IDNameKubeAPIServer, "", LabelSourceReserved)}
 
+	LabelKubeAPIServerExt = Labels{
+		IDNameKubeAPIServer: NewLabel(IDNameKubeAPIServer, "", LabelSourceReserved),
+		IDNameWorld:         NewLabel(IDNameWorld, "", LabelSourceReserved),
+	}
+
 	// LabelIngress is the label used for Ingress proxies. See comment
 	// on IDNameIngress.
 	LabelIngress = Labels{IDNameIngress: NewLabel(IDNameIngress, "", LabelSourceReserved)}


### PR DESCRIPTION
When apiserver endpoints are external to cluster, they are also considered as world identities. When an endpoint is deleted, apiserver label is removed, but the world label is not. Since the labels are not empty, the entry in ipcache is never removed.

This results in packet drops if the deleted endpoint's IP address is allocated to a different workload and workloads within the cluster try connecting to it. This scenario is likely to happen if the cluster's control plane is managed in a different kubernetes cluster.

_Note : The current patch takes a quick stab at fixing the issue, but it is in a super hot path though. Let me know if there's a better approach / if we can move this logic elsewhere._
