### PR TITLE
maglev: Cleanup implementation

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -44,7 +44,7 @@ cilium-agent [flags]
       --bpf-lb-dsr-dispatch string                                BPF load balancing DSR dispatch method ("opt", "ipip", "geneve") (default "opt")
       --bpf-lb-external-clusterip                                 Enable external access to ClusterIP services (default false)
       --bpf-lb-maglev-hash-seed string                            Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
-      --bpf-lb-maglev-table-size uint                             Maglev per service backend table size (parameter M) (default 16381)
+      --bpf-lb-maglev-table-size uint                             Maglev per service backend table size (parameter M, one of: [251 509 1021 2039 4093 8191 16381 32749 65521 131071]) (default 16381)
       --bpf-lb-map-max int                                        Maximum number of entries in Cilium BPF lbmap (default 65536)
       --bpf-lb-mode string                                        BPF load balancing mode ("snat", "dsr", "hybrid") (default "snat")
       --bpf-lb-mode-annotation                                    Enable service-level annotation for configuring BPF load balancing mode

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -13,6 +13,8 @@ cilium-agent hive [flags]
 ```
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
       --api-rate-limit string                                     API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
+      --bpf-lb-maglev-hash-seed string                            Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
+      --bpf-lb-maglev-table-size uint                             Maglev per service backend table size (parameter M, one of: [251 509 1021 2039 4093 8191 16381 32749 65521 131071]) (default 16381)
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --cluster-id uint32                                         Unique identifier of the cluster

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -19,6 +19,8 @@ cilium-agent hive dot-graph [flags]
 ```
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
       --api-rate-limit string                                     API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
+      --bpf-lb-maglev-hash-seed string                            Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
+      --bpf-lb-maglev-table-size uint                             Maglev per service backend table size (parameter M, one of: [251 509 1021 2039 4093 8191 16381 32749 65521 131071]) (default 16381)
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --cluster-id uint32                                         Unique identifier of the cluster

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cilium/cilium/pkg/l2announcer"
 	loadbalancer_experimental "github.com/cilium/cilium/pkg/loadbalancer/experimental"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
 	natStats "github.com/cilium/cilium/pkg/maps/nat/stats"
 	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
@@ -195,6 +196,9 @@ var (
 
 		// daemonCell wraps the legacy daemon initialization and provides Promise[*Daemon].
 		daemonCell,
+
+		// Maglev table computtations
+		maglev.Cell,
 
 		// Experimental control-plane for configuring service load-balancing.
 		loadbalancer_experimental.Cell,

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
@@ -184,9 +185,9 @@ type Daemon struct {
 	iptablesManager datapath.IptablesManager
 	hubble          hubblecell.HubbleIntegration
 
-	lrpManager *redirectpolicy.Manager
-
-	ctMapGC ctmap.GCRunner
+	lrpManager   *redirectpolicy.Manager
+	ctMapGC      ctmap.GCRunner
+	maglevConfig maglev.Config
 }
 
 // GetPolicyRepository returns the policy repository of the daemon
@@ -401,6 +402,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		hubble:            params.Hubble,
 		lrpManager:        params.LRPManager,
 		ctMapGC:           params.CTNATMapGC,
+		maglevConfig:      params.MaglevConfig,
 	}
 
 	// initialize endpointRestoreComplete channel as soon as possible so that subsystems

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -611,12 +611,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.LoadBalancerProtocolDifferentiation, true, "Enable support for service protocol differentiation (TCP, UDP, SCTP)")
 	option.BindEnv(vp, option.LoadBalancerProtocolDifferentiation)
 
-	flags.Uint(option.MaglevTableSize, maglev.DefaultTableSize, "Maglev per service backend table size (parameter M)")
-	option.BindEnv(vp, option.MaglevTableSize)
-
-	flags.String(option.MaglevHashSeed, maglev.DefaultHashSeed, "Maglev cluster-wide hash seed (base64 encoded)")
-	option.BindEnv(vp, option.MaglevHashSeed)
-
 	flags.Bool(option.EnableAutoProtectNodePortRange, true,
 		"Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps "+
 			"with ephemeral port range (net.ipv4.ip_local_port_range)")
@@ -1616,6 +1610,7 @@ type daemonParams struct {
 	IPTablesManager     datapath.IptablesManager
 	Hubble              hubblecell.HubbleIntegration
 	LRPManager          *redirectpolicy.Manager
+	MaglevConfig        maglev.Config
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -297,7 +297,7 @@ func (d *Daemon) initMaps() error {
 
 	if option.Config.NodePortAlg == option.NodePortAlgMaglev ||
 		option.Config.LoadBalancerAlgorithmAnnotation {
-		if err := lbmap.InitMaglevMaps(option.Config.EnableIPv4, option.Config.EnableIPv6, uint32(option.Config.MaglevTableSize)); err != nil {
+		if err := lbmap.InitMaglevMaps(option.Config.EnableIPv4, option.Config.EnableIPv6, uint32(d.maglevConfig.MaglevTableSize)); err != nil {
 			return fmt.Errorf("initializing maglev maps: %w", err)
 		}
 	}

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -306,10 +306,10 @@ func (d *Daemon) getKubeProxyReplacementStatus() *models.KubeProxyReplacement {
 		features.NodePort.Algorithm = models.KubeProxyReplacementFeaturesNodePortAlgorithmRandom
 		if option.Config.NodePortAlg == option.NodePortAlgMaglev {
 			features.NodePort.Algorithm = models.KubeProxyReplacementFeaturesNodePortAlgorithmMaglev
-			features.NodePort.LutSize = int64(option.Config.MaglevTableSize)
+			features.NodePort.LutSize = int64(d.maglevConfig.MaglevTableSize)
 		}
 		if option.Config.LoadBalancerAlgorithmAnnotation {
-			features.NodePort.LutSize = int64(option.Config.MaglevTableSize)
+			features.NodePort.LutSize = int64(d.maglevConfig.MaglevTableSize)
 		}
 		if option.Config.NodePortAcceleration == option.NodePortAccelerationGeneric {
 			features.NodePort.Acceleration = models.KubeProxyReplacementFeaturesNodePortAccelerationGeneric

--- a/pkg/ciliumenvoyconfig/exp_test.go
+++ b/pkg/ciliumenvoyconfig/exp_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
+	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
@@ -49,6 +50,7 @@ func TestScript(t *testing.T) {
 			daemonk8s.ResourcesCell,
 			cell.Config(cecConfig{}),
 			experimental.Cell,
+			maglev.Cell,
 			cell.Provide(
 				tables.NewNodeAddressTable,
 				statedb.RWTable[tables.NodeAddress].ToTable,
@@ -59,7 +61,6 @@ func TestScript(t *testing.T) {
 						EnableIPv6:        true,
 						SockRevNatEntries: 1000,
 						LBMapEntries:      1000,
-						MaglevTableSize:   1021,
 					}
 				},
 				func() *experimental.TestConfig {

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/datapath/xdp"
 	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
+	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/maps"
 	"github.com/cilium/cilium/pkg/maps/eventsmap"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
@@ -82,14 +83,14 @@ var Cell = cell.Module(
 
 	cell.Provide(newWireguardAgent),
 
-	cell.Provide(func(expConfig experimental.Config) types.LBMap {
+	cell.Provide(func(expConfig experimental.Config, maglev *maglev.Maglev) types.LBMap {
 		if expConfig.EnableExperimentalLB {
 			// The experimental control-plane is enabled. Use a fake LBMap
 			// to effectively disable the other code paths writing to LBMaps.
 			return mockmaps.NewLBMockMap()
 		}
 
-		return lbmap.New()
+		return lbmap.New(maglev)
 	}),
 
 	// Provides the Table[NodeAddress] and the controller that populates it from Table[*Device]

--- a/pkg/datapath/linux/config/cell.go
+++ b/pkg/datapath/linux/config/cell.go
@@ -11,6 +11,7 @@ import (
 	dpdef "github.com/cilium/cilium/pkg/datapath/linux/config/defines"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
 )
 
@@ -23,6 +24,7 @@ type WriterParams struct {
 	NodeExtraDefines   []dpdef.Map `group:"header-node-defines"`
 	NodeExtraDefineFns []dpdef.Fn  `group:"header-node-define-fns"`
 	Sysctl             sysctl.Sysctl
+	Maglev             *maglev.Maglev
 }
 
 var Cell = cell.Module(

--- a/pkg/loadbalancer/experimental/bpf_reconciler.go
+++ b/pkg/loadbalancer/experimental/bpf_reconciler.go
@@ -73,6 +73,7 @@ type BPFOps struct {
 	LBMaps LBMaps
 	log    *slog.Logger
 	cfg    ExternalConfig
+	maglev *maglev.Maglev
 
 	serviceIDAlloc     idAllocator
 	restoredServiceIDs sets.Set[loadbalancer.ID]
@@ -104,12 +105,13 @@ type backendState struct {
 	id       loadbalancer.BackendID
 }
 
-func newBPFOps(lc cell.Lifecycle, log *slog.Logger, cfg Config, extCfg ExternalConfig, lbmaps LBMaps) *BPFOps {
+func newBPFOps(lc cell.Lifecycle, log *slog.Logger, cfg Config, extCfg ExternalConfig, lbmaps LBMaps, maglev *maglev.Maglev) *BPFOps {
 	if !cfg.EnableExperimentalLB {
 		return nil
 	}
 	ops := &BPFOps{
 		cfg:                extCfg,
+		maglev:             maglev,
 		serviceIDAlloc:     newIDAllocator(firstFreeServiceID, maxSetOfServiceID),
 		restoredServiceIDs: sets.New[loadbalancer.ID](),
 		backendIDAlloc:     newIDAllocator(firstFreeBackendID, maxSetOfBackendID),
@@ -930,28 +932,29 @@ func (ops *BPFOps) releaseBackend(id loadbalancer.BackendID, addr loadbalancer.L
 }
 
 func (ops *BPFOps) computeMaglevTable(svc *Service, bes []BackendWithRevision) ([]loadbalancer.BackendID, error) {
-	backendsMap := make(map[string]*loadbalancer.Backend, len(bes))
-	for _, be := range bes {
-		output := &loadbalancer.Backend{} // We only populate selected fields used in maglev.GetLookupTable().
-		output.L3n4Addr = be.L3n4Addr
-		id, err := ops.backendIDAlloc.lookupLocalID(output.L3n4Addr)
-		if err != nil {
-			return nil, fmt.Errorf("local id for address %s not found: %w", output.L3n4Addr.String(), err)
+	var errs []error
+	backendInfos := func(yield func(maglev.BackendInfo) bool) {
+		for _, be := range bes {
+			instance := be.GetInstance(svc.Name)
+			if instance == nil {
+				errs = append(errs, fmt.Errorf("instance of backend %q for service %q not found", be.String(), svc.Name.String()))
+				continue
+			}
+			id, err := ops.backendIDAlloc.lookupLocalID(be.L3n4Addr)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("local id for address %s not found: %w", be.L3n4Addr.String(), err))
+				continue
+			}
+			if !yield(maglev.BackendInfo{
+				ID:     loadbalancer.BackendID(id),
+				Addr:   be.L3n4Addr,
+				Weight: instance.Weight,
+			}) {
+				break
+			}
 		}
-		output.ID = loadbalancer.BackendID(id)
-		instance := be.GetInstance(svc.Name)
-		if instance == nil {
-			return nil, fmt.Errorf("instance of backend %q for service %q not found", be.String(), svc.Name.String())
-		}
-		output.Weight = instance.Weight
-		backendsMap[output.String()] = output
 	}
-	var maglevTable []int = maglev.GetLookupTable(backendsMap, uint64(ops.cfg.MaglevTableSize))
-	maglevTableTyped := make([]loadbalancer.BackendID, len(maglevTable))
-	for i, id := range maglevTable {
-		maglevTableTyped[i] = loadbalancer.BackendID(id)
-	}
-	return maglevTableTyped, nil
+	return ops.maglev.GetLookupTable(backendInfos), errors.Join(errs...)
 }
 
 // sortedBackends sorts the backends in-place with the following sort order:

--- a/pkg/loadbalancer/experimental/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/experimental/bpf_reconciler_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -815,7 +816,12 @@ func TestBPFOps(t *testing.T) {
 	lc := hivetest.Lifecycle(t)
 	log := hivetest.Logger(t)
 
-	maglevTableSize := 1021
+	maglevCfg := maglev.Config{
+		MaglevTableSize: 1021,
+		MaglevHashSeed:  maglev.DefaultHashSeed,
+	}
+	maglev, err := maglev.New(maglevCfg, lc)
+	require.NoError(t, err, "maglev.New")
 
 	var lbmaps LBMaps
 	if testutils.IsPrivileged() {
@@ -829,8 +835,8 @@ func TestBPFOps(t *testing.T) {
 				AffinityMapMaxEntries:    1000,
 				SourceRangeMapMaxEntries: 1000,
 				MaglevMapMaxEntries:      1000,
-				MaglevTableSize:          maglevTableSize,
 			},
+			MaglevCfg: maglevCfg,
 		}
 		lc.Append(r)
 		lbmaps = r
@@ -841,7 +847,6 @@ func TestBPFOps(t *testing.T) {
 	// Enable features.
 	extCfg := ExternalConfig{
 		EnableSessionAffinity: true,
-		MaglevTableSize:       maglevTableSize,
 	}
 
 	cfg := DefaultConfig
@@ -856,7 +861,7 @@ func TestBPFOps(t *testing.T) {
 				// fresh IDs.
 				external := extCfg
 				external.NodePortAlg = algo
-				ops := newBPFOps(lc, log, cfg, external, lbmaps)
+				ops := newBPFOps(lc, log, cfg, external, lbmaps, maglev)
 				for _, testCase := range testCaseSet {
 					t.Run(fmt.Sprintf("%s/%s/ipv6:%v", testCase.name, algo, addr.IsIPv6()), func(t *testing.T) {
 						frontend := testCase.frontend

--- a/pkg/loadbalancer/experimental/cell_test.go
+++ b/pkg/loadbalancer/experimental/cell_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 )
@@ -26,6 +27,7 @@ func TestCell(t *testing.T) {
 	h := hive.New(
 		client.FakeClientCell,
 		daemonk8s.ResourcesCell,
+		maglev.Cell,
 		Cell,
 		cell.Provide(source.NewSources),
 		cell.Provide(

--- a/pkg/loadbalancer/experimental/config.go
+++ b/pkg/loadbalancer/experimental/config.go
@@ -54,7 +54,6 @@ type ExternalConfig struct {
 	EnableSessionAffinity    bool
 	NodePortMin, NodePortMax uint16
 	NodePortAlg              string
-	MaglevTableSize          int
 }
 
 func newExternalConfig(cfg *option.DaemonConfig) ExternalConfig {
@@ -64,6 +63,5 @@ func newExternalConfig(cfg *option.DaemonConfig) ExternalConfig {
 		NodePortMin:           uint16(cfg.NodePortMin),
 		NodePortMax:           uint16(cfg.NodePortMax),
 		NodePortAlg:           cfg.NodePortAlg,
-		MaglevTableSize:       cfg.MaglevTableSize,
 	}
 }

--- a/pkg/maglev/maglev.go
+++ b/pkg/maglev/maglev.go
@@ -4,17 +4,31 @@
 package maglev
 
 import (
+	"cmp"
 	"context"
 	"encoding/base64"
 	"fmt"
+	"iter"
 	"runtime"
 	"slices"
+	"strconv"
+	"strings"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/workerpool"
-	"github.com/mackerelio/go-osstat/memory"
+	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/murmur3"
+)
+
+var Cell = cell.Module(
+	"maglev",
+	"Maglev table computations",
+
+	cell.Config(DefaultConfig),
+	cell.Provide(New),
 )
 
 const (
@@ -22,63 +36,116 @@ const (
 
 	// seed=$(head -c12 /dev/urandom | base64 -w0)
 	DefaultHashSeed = "JLfvgnHc2kaSUFaI"
+
+	MaglevTableSizeName = "bpf-lb-maglev-table-size"
+	MaglevHashSeedName  = "bpf-lb-maglev-hash-seed"
 )
 
 var (
-	seedMurmur uint32
-
-	SeedJhash0 uint32
-	SeedJhash1 uint32
-
-	// permutation is the slice containing the Maglev permutation calculations.
-	permutation []uint64
+	maglevSupportedTableSizes = []uint{251, 509, 1021, 2039, 4093, 8191, 16381, 32749, 65521, 131071}
 )
 
-// Init initializes the Maglev subsystem with the seed and the backend table
-// size (m).
-func Init(seed string, m uint64) error {
+type Config struct {
+	// Maglev backend table size (M) per service. Must be prime number.
+	// "Let N be the size of a VIP's backend pool." [...] "In practice, we choose M to be
+	// larger than 100 x N to ensure at most a 1% difference in hash space assigned to
+	// backends." (from Maglev paper, page 6)
+	MaglevTableSize uint `mapstructure:"bpf-lb-maglev-table-size"`
+
+	// MaglevHashSeed contains the cluster-wide seed for the hash(es).
+	MaglevHashSeed string `mapstructure:"bpf-lb-maglev-hash-seed"`
+}
+
+func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.Uint(MaglevTableSizeName, def.MaglevTableSize, fmt.Sprintf("Maglev per service backend table size (parameter M, one of: %v)", maglevSupportedTableSizes))
+	flags.String(MaglevHashSeedName, def.MaglevHashSeed, "Maglev cluster-wide hash seed (base64 encoded)")
+}
+
+var DefaultConfig = Config{
+	MaglevTableSize: DefaultTableSize,
+	MaglevHashSeed:  DefaultHashSeed,
+}
+
+type Maglev struct {
+	Config
+	SeedJhash0 uint32
+	SeedJhash1 uint32
+	seedMurmur uint32
+
+	// mu protects the fields below
+	mu lock.Mutex
+
+	wp *workerpool.WorkerPool
+
+	// backendInfosBuffer is a reusable buffer for holding the backend infos.
+	backendInfosBuffer []BackendInfo
+
+	// permutations is (re)used during each GetLookupTable call to compute the table.
+	permutations []uint64
+}
+
+// New constructs a new Maglev computation object.
+func New(cfg Config, lc cell.Lifecycle) (*Maglev, error) {
+	if !slices.Contains(maglevSupportedTableSizes, cfg.MaglevTableSize) {
+		return nil, fmt.Errorf("Invalid value for --%s: %d, supported values are: %v",
+			MaglevTableSizeName, cfg.MaglevTableSize, maglevSupportedTableSizes)
+	}
+
+	seed := cfg.MaglevHashSeed
 	d, err := base64.StdEncoding.DecodeString(seed)
 	if err != nil {
-		return fmt.Errorf("Cannot decode base64 Maglev hash seed %q: %w", seed, err)
+		return nil, fmt.Errorf("cannot decode base64 Maglev hash seed %q: %w", seed, err)
 	}
 	if len(d) != 12 {
-		return fmt.Errorf("Decoded hash seed is %d bytes (not 12 bytes)", len(d))
+		return nil, fmt.Errorf("decoded hash seed is %d bytes (not 12 bytes)", len(d))
 	}
 
-	seedMurmur = uint32(d[0])<<24 | uint32(d[1])<<16 | uint32(d[2])<<8 | uint32(d[3])
+	seedMurmur := uint32(d[0])<<24 | uint32(d[1])<<16 | uint32(d[2])<<8 | uint32(d[3])
+	SeedJhash0 := uint32(d[4])<<24 | uint32(d[5])<<16 | uint32(d[6])<<8 | uint32(d[7])
+	SeedJhash1 := uint32(d[8])<<24 | uint32(d[9])<<16 | uint32(d[10])<<8 | uint32(d[11])
 
-	SeedJhash0 = uint32(d[4])<<24 | uint32(d[5])<<16 | uint32(d[6])<<8 | uint32(d[7])
-	SeedJhash1 = uint32(d[8])<<24 | uint32(d[9])<<16 | uint32(d[10])<<8 | uint32(d[11])
+	ml := &Maglev{
+		Config:     cfg,
+		seedMurmur: seedMurmur,
+		SeedJhash0: SeedJhash0,
+		SeedJhash1: SeedJhash1,
+	}
+	lc.Append(ml)
+	return ml, nil
+}
 
-	// Allocate this ahead of time to avoid expensive allocations inside
-	// getPermutation().
-	permutation = make([]uint64, derivePermutationSliceLen(m))
-
+func (ml *Maglev) Start(cell.HookContext) error {
+	ml.wp = workerpool.New(runtime.NumCPU())
 	return nil
 }
 
-func getOffsetAndSkip(backend string, m uint64) (uint64, uint64) {
-	h1, h2 := murmur3.Hash128([]byte(backend), seedMurmur)
-	offset := h1 % m
-	skip := (h2 % (m - 1)) + 1
-
-	return offset, skip
+func (ml *Maglev) Stop(cell.HookContext) error {
+	err := ml.wp.Close()
+	*ml = Maglev{}
+	return err
 }
 
-func getPermutation(backends []string, m uint64, numCPU int) []uint64 {
+func (ml *Maglev) getPermutation(backends []BackendInfo, numCPU int) []uint64 {
+	if len(backends) == 0 {
+		return nil
+	}
+
+	m := int(ml.MaglevTableSize)
+
+	if size := len(backends) * int(m); size > len(ml.permutations) {
+		// As the permutations array is large and often used, we'll keep a single
+		// instance around and reuse it.
+		minSize := derivePermutationSliceLen(uint64(ml.Config.MaglevTableSize))
+		ml.permutations = make([]uint64, max(minSize, size))
+	}
+
 	// The idea is to split the calculation into batches so that they can be
 	// concurrently executed. We limit the number of concurrent goroutines to
 	// the number of available CPU cores. This is because the calculation does
 	// not block and is completely CPU-bound. Therefore, adding more goroutines
 	// would result into an overhead (allocation of stackframes, stress on
 	// scheduling, etc) instead of a performance gain.
-
 	bCount := len(backends)
-	if size := uint64(bCount) * m; size > uint64(len(permutation)) {
-		// Reallocate slice so we don't have to allocate again on the next
-		// call.
-		permutation = make([]uint64, size)
-	}
 
 	batchSize := bCount / numCPU
 	if batchSize == 0 {
@@ -89,35 +156,86 @@ func getPermutation(backends []string, m uint64, numCPU int) []uint64 {
 	// ignore the returned error from wp methods. Also as our task func never
 	// return any error, we have no use returned value from Drain() and don't
 	// need to provide an id to Submit().
-	wp := workerpool.New(numCPU)
-	defer wp.Close()
 	for g := 0; g < bCount; g += batchSize {
 		from, to := g, g+batchSize
 		if to > bCount {
 			to = bCount
 		}
-		wp.Submit("", func(_ context.Context) error {
+		ml.wp.Submit("", func(_ context.Context) error {
 			for i := from; i < to; i++ {
-				offset, skip := getOffsetAndSkip(backends[i], m)
-				permutation[i*int(m)] = offset % m
-				for j := uint64(1); j < m; j++ {
-					permutation[i*int(m)+int(j)] = (permutation[i*int(m)+int(j-1)] + skip) % m
+				offset, skip := getOffsetAndSkip([]byte(backends[i].hashString), uint64(m), ml.seedMurmur)
+				start := i * m
+				ml.permutations[start] = offset
+				for j := 1; j < m; j++ {
+					ml.permutations[start+j] = (ml.permutations[start+(j-1)] + skip) % uint64(m)
 				}
 			}
 			return nil
 		})
 	}
-	wp.Drain()
+	ml.wp.Drain()
 
-	return permutation[:bCount*int(m)]
+	return ml.permutations[:bCount*int(m)]
 }
 
-// GetLookupTable returns the Maglev lookup table of the size "m" for the given
-// backends. The lookup table contains the IDs of the given backends.
+func getOffsetAndSkip(addr []byte, m uint64, seed uint32) (uint64, uint64) {
+	h1, h2 := murmur3.Hash128(addr, seed)
+	offset := h1 % m
+	skip := (h2 % (m - 1)) + 1
+	return offset, skip
+}
+
+// BackendInfo describes the backend information relevant for the maglev
+// computation.
+type BackendInfo struct {
+	ID     loadbalancer.BackendID
+	Addr   loadbalancer.L3n4Addr
+	Weight uint16
+
+	hashString string
+}
+
+// hashString is the string representation of the backend used for both
+// sorting and for hashing. To make sure the representation stays stable,
+// this method is reproducing parts of Backend.String(), AddrCluster.String(),
+// etc.
+//
+// This MUST NOT be changed as otherwise we may end up with different maglev
+// lookup tables on different nodes during upgrades. To introduce a change to
+// this we would need to add a new flag to switch to new algorithm to migrate
+// new installs over.
+func (bi *BackendInfo) setHashString() {
+	if bi.hashString != "" {
+		return
+	}
+
+	var b strings.Builder
+	b.WriteByte('[')
+	a := bi.Addr
+	if a.IsIPv6() {
+		b.WriteByte('[')
+		b.WriteString(a.AddrCluster.String())
+		b.WriteString("]:")
+	} else {
+		b.WriteString(a.AddrCluster.String())
+		b.WriteByte(':')
+	}
+	b.WriteString(strconv.FormatUint(uint64(a.Port), 10))
+	b.WriteByte('/')
+	b.WriteString(a.Protocol)
+	if a.Scope == loadbalancer.ScopeInternal {
+		b.WriteString("/i")
+	}
+	b.WriteString(",State:active]")
+	bi.hashString = b.String()
+}
+
+// GetLookupTable returns the Maglev lookup table for the given backends.
+// The lookup table contains the IDs of the given backends.
 //
 // Maglev algorithm might produce different lookup table for the same
 // set of backends listed in a different order. To avoid that sort
-// backends by name, as the names are the same on all nodes (in opposite
+// backends by the hash, as these are the same on all nodes (in opposite
 // to backend IDs which are node-local).
 //
 // The weights implementation is inspired by https://github.com/envoyproxy/envoy/pull/2982.
@@ -125,54 +243,71 @@ func getPermutation(backends []string, m uint64, numCPU int) []uint64 {
 // A backend weight is honored by altering the frequency how often a backend's turn is
 // selected.
 // A backend weight is multiplied in each turn by (n + 1) and compared to
-// weightCntr[backendName] value which is an incrementation of weightSum (but starts at
+// weightCntr[index] value which is an incrementation of weightSum (but starts at
 // backend's weight / number of backends, so that each backend is selected at least once). If this is lower
-// than weightCntr[backendName], another backend has a turn (and weightCntr[backendName]
+// than weightCntr[index], another backend has a turn (and weightCntr[index]
 // is incremented). This way we honor the weights.
-func GetLookupTable(backendsMap map[string]*loadbalancer.Backend, m uint64) []int {
-	if len(backendsMap) == 0 {
-		return nil
+func (ml *Maglev) GetLookupTable(backends iter.Seq[BackendInfo]) []loadbalancer.BackendID {
+	ml.mu.Lock()
+	defer ml.mu.Unlock()
+
+	ml.backendInfosBuffer = ml.backendInfosBuffer[:0]
+	for b := range backends {
+		b.setHashString()
+		ml.backendInfosBuffer = append(ml.backendInfosBuffer, b)
 	}
 
-	backends := make([]string, 0, len(backendsMap))
-	weightCntr := make(map[string]float64, len(backendsMap))
+	// Sort the backends by 'hashString'
+	slices.SortFunc(
+		ml.backendInfosBuffer,
+		func(a, b BackendInfo) int {
+			return cmp.Compare(a.hashString, b.hashString)
+		})
+
+	return ml.computeLookupTable()
+}
+
+func (ml *Maglev) computeLookupTable() []loadbalancer.BackendID {
+	backends := ml.backendInfosBuffer
+	m := uint64(ml.MaglevTableSize)
+
+	l := len(backends)
 	weightSum := uint64(0)
-
-	l := len(backendsMap)
-
-	for name, b := range backendsMap {
-		backends = append(backends, name)
-		weightSum += uint64(b.Weight)
-		weightCntr[name] = float64(b.Weight) / float64(l)
+	weightCntr := make([]float64, l)
+	for i, info := range backends {
+		weightSum += uint64(info.Weight)
+		weightCntr[i] = float64(info.Weight) / float64(l)
 	}
+	weightsUsed := weightSum/uint64(l) > 1
 
-	slices.Sort(backends)
+	perm := ml.getPermutation(backends, runtime.NumCPU())
 
-	perm := getPermutation(backends, m, runtime.NumCPU())
 	next := make([]int, len(backends))
-	entry := make([]int, m)
+	entry := make([]loadbalancer.BackendID, m)
 
-	for j := uint64(0); j < m; j++ {
-		entry[j] = -1
+	const sentinel = 0xffff_ffff
+	for j := range m {
+		entry[j] = sentinel
 	}
 
-	for n := uint64(0); n < m; n++ {
+	for n := range m {
 		i := int(n) % l
 		for {
+			info := backends[i]
 			// change the default selection of backend turns only if weights are used
-			if weightSum/uint64(l) > 1 {
-				if ((n + 1) * uint64(backendsMap[backends[i]].Weight)) < uint64(weightCntr[backends[i]]) {
+			if weightsUsed {
+				if ((n + 1) * uint64(info.Weight)) < uint64(weightCntr[i]) {
 					i = (i + 1) % l
 					continue
 				}
-				weightCntr[backends[i]] += float64(weightSum)
+				weightCntr[i] += float64(weightSum)
 			}
 			c := perm[i*int(m)+next[i]]
-			for entry[c] >= 0 {
+			for entry[c] != sentinel {
 				next[i] += 1
 				c = perm[i*int(m)+next[i]]
 			}
-			entry[c] = int(backendsMap[backends[i]].ID)
+			entry[c] = info.ID
 			next[i] += 1
 			break
 		}
@@ -195,17 +330,9 @@ func GetLookupTable(backendsMap map[string]*loadbalancer.Backend, m uint64) []in
 //	65521:  327.5300171661377 MB
 //	131071: 1310.700000076294 MB
 //
-// The heuristic does not apply to nodes with less than or equal to 8GB, as to
-// avoid memory pressure on memory-tight systems.
-//
 // Note, this function does not return the MB, but rather returns the number of
 // uint64 elements in the slice that equal to the total MB (length). To get the
 // MB, multiply by sizeof(uint64).
-func derivePermutationSliceLen(m uint64) uint64 {
-	threshold := uint64(8 * 1024 * 1024 * 1024) // 8GB
-	if vm, err := memory.Get(); err != nil || vm == nil || vm.Total <= threshold {
-		return 0
-	}
-
-	return (m / uint64(100)) * m
+func derivePermutationSliceLen(m uint64) int {
+	return int((m / 100) * m)
 }

--- a/pkg/maglev/maglev_test.go
+++ b/pkg/maglev/maglev_test.go
@@ -6,33 +6,25 @@ package maglev
 import (
 	"encoding/binary"
 	"fmt"
-	"strconv"
+	"slices"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 )
 
-type MaglevTestSuite struct{}
-
-func setupMaglevTestSuite(tb testing.TB) *MaglevTestSuite {
-	s := &MaglevTestSuite{}
-
-	err := Init(DefaultHashSeed, DefaultTableSize)
-	require.NoError(tb, err)
-
-	return s
-}
-
 func TestPermutations(t *testing.T) {
-	setupMaglevTestSuite(t)
-
-	getExpectedPermutation := func(backends []string, m uint64) []uint64 {
+	lc := hivetest.Lifecycle(t)
+	getExpectedPermutation := func(backends []BackendInfo, m uint64, seedMurmur uint32) []uint64 {
+		if len(backends) == 0 {
+			return nil
+		}
 		perm := make([]uint64, len(backends)*int(m))
 		for i, backend := range backends {
-			offset, skip := getOffsetAndSkip(backend, m)
+			offset, skip := getOffsetAndSkip([]byte(backend.hashString), m, seedMurmur)
 			perm[i*int(m)] = offset % m
 			for j := uint64(1); j < m; j++ {
 				perm[i*int(m)+int(j)] = (perm[i*int(m)+int(j-1)] + skip) % m
@@ -41,14 +33,24 @@ func TestPermutations(t *testing.T) {
 		return perm
 	}
 	for _, bCount := range []int{0, 1, 2, 5, 111, 222, 333, 1001} {
-		backends := make([]string, bCount)
+		backends := make([]BackendInfo, bCount)
 		for i := 0; i < len(backends); i++ {
-			backends[i] = strconv.Itoa(i)
+			backends[i] = BackendInfo{
+				Addr:   mkAddr(int32(i)),
+				ID:     loadbalancer.BackendID(i),
+				Weight: 1,
+			}
+			backends[i].setHashString()
 		}
 		for _, m := range []uint64{251, 509, 1021} {
-			expectedPerm := getExpectedPermutation(backends, m)
+			ml, err := New(Config{
+				MaglevTableSize: uint(m),
+				MaglevHashSeed:  DefaultHashSeed,
+			}, lc)
+			require.NoError(t, err, "New")
+			expectedPerm := getExpectedPermutation(backends, m, ml.seedMurmur)
 			for _, numCPU := range []int{1, 2, 3, 4, 8, 100} {
-				testPerm := getPermutation(backends, m, numCPU)
+				testPerm := ml.getPermutation(backends, numCPU)
 				require.EqualValues(t, expectedPerm, testPerm)
 			}
 		}
@@ -70,7 +72,7 @@ func mkAddr(i int32) loadbalancer.L3n4Addr {
 	return a
 }
 
-func runLengthEncodeIDs(ids []int) string {
+func runLengthEncodeIDs(ids []loadbalancer.BackendID) string {
 	if len(ids) == 0 {
 		return ""
 	}
@@ -91,7 +93,16 @@ func runLengthEncodeIDs(ids []int) string {
 }
 
 func TestReproducible(t *testing.T) {
-	setupMaglevTestSuite(t)
+	// Use the smallest table size to keep the expected output
+	// small.
+	m := uint64(251)
+
+	ml, err := New(
+		Config{
+			MaglevTableSize: uint(m),
+			MaglevHashSeed:  DefaultHashSeed,
+		}, hivetest.Lifecycle(t))
+	require.NoError(t, err, "New")
 
 	// Run-length-encoded expected maglev table in format <id>(<count>),...
 	expected := "2(5),3(1),2(3),1(1),2(2),0(1),2(1),3(1),2(1),3(1),2(1),1(1),2(7),1(1),2(14),3(1),2(1)," +
@@ -100,49 +111,45 @@ func TestReproducible(t *testing.T) {
 		"3(1),1(1),2(8),1(1),2(4),0(1),2(1),1(1),2(5),3(1),2(3),1(1),2(4),3(1),2(3),1(1),2(12),0(1),3(1),2(3),3(1)," +
 		"2(4),3(1),2(2),1(1),2(7)"
 
-	// Use the smallest table size to keep the expected output
-	// small.
-	m := uint64(251)
-
-	backends := []*loadbalancer.Backend{
-		{L3n4Addr: mkAddr(1), Weight: 2, ID: 0},
-		{L3n4Addr: mkAddr(3), Weight: 13, ID: 1},
-		{L3n4Addr: mkAddr(4), Weight: 111, ID: 2},
-		{L3n4Addr: mkAddr(5), Weight: 10, ID: 3},
+	backends := []BackendInfo{
+		{Addr: mkAddr(1), Weight: 2, ID: 0},
+		{Addr: mkAddr(3), Weight: 13, ID: 1},
+		{Addr: mkAddr(4), Weight: 111, ID: 2},
+		{Addr: mkAddr(5), Weight: 10, ID: 3},
 	}
-	backendsMap := map[string]*loadbalancer.Backend{}
-	for _, be := range backends {
-		backendsMap[be.String()] = be
-	}
-
-	actual := runLengthEncodeIDs(GetLookupTable(backendsMap, m))
+	actual := runLengthEncodeIDs(ml.GetLookupTable(slices.Values(backends)))
 
 	require.Equal(t, expected, actual)
 }
 
 func TestBackendRemoval(t *testing.T) {
-	setupMaglevTestSuite(t)
-
-	m := uint64(1021) // 3 (backends) * 100 should be less than M
+	m := uint(1021) // 3 (backends) * 100 should be less than M
+	ml, err := New(
+		Config{
+			MaglevTableSize: uint(m),
+			MaglevHashSeed:  DefaultHashSeed,
+		}, hivetest.Lifecycle(t))
+	require.NoError(t, err, "New")
 	changesInExistingBackends := 0
 
-	backendsMap := map[string]*loadbalancer.Backend{
-		"one":   {Weight: 1, ID: 0},
-		"three": {Weight: 1, ID: 1},
-		"two":   {Weight: 1, ID: 2},
+	backends := []BackendInfo{
+		{ID: 1, Weight: 1, Addr: mkAddr(1)},
+		{ID: 2, Weight: 1, Addr: mkAddr(2)},
+		{ID: 3, Weight: 1, Addr: mkAddr(3)},
 	}
-	before := GetLookupTable(backendsMap, m)
+	before := ml.GetLookupTable(slices.Values(backends))
 
-	// Remove backend "two"
-	delete(backendsMap, "two")
-	after := GetLookupTable(backendsMap, m)
+	// Remove the last backend
+	backends = backends[:2]
+
+	after := ml.GetLookupTable(slices.Values(backends))
 
 	for pos, backend := range before {
-		if (backend == 0 || backend == 1) && after[pos] != before[pos] {
+		if (backend == 1 || backend == 2) && after[pos] != before[pos] {
 			changesInExistingBackends++
 		} else {
-			// Check that "three" placement was overridden by "one" or "two"
-			require.True(t, after[pos] == 0 || after[pos] == 1)
+			// Check that backend 3 was now replaced by either 1 or 2.
+			require.True(t, after[pos] == 1 || after[pos] == 2)
 		}
 	}
 
@@ -152,37 +159,40 @@ func TestBackendRemoval(t *testing.T) {
 }
 
 func TestWeightedBackendWithRemoval(t *testing.T) {
-	setupMaglevTestSuite(t)
+	m := uint(1021) // 4 (backends) * 100 is still less than M
+	ml, err := New(
+		Config{
+			MaglevTableSize: uint(m),
+			MaglevHashSeed:  DefaultHashSeed,
+		}, hivetest.Lifecycle(t))
+	require.NoError(t, err, "New")
 
-	m := uint64(1021) // 4 (backends) * 100 is still less than M
 	changesInExistingBackends := 0
-
 	// using following formula we can get the approximate number of times
 	// the backendID is found in the computed lut
 	// m / len(weightSum) * backend.Weight
-	backendsMap := map[string]*loadbalancer.Backend{
-		"one":   {Weight: 2, ID: 0},   // approx. 15x times
-		"three": {Weight: 13, ID: 1},  // approx. 97.5x times
-		"two":   {Weight: 111, ID: 2}, // approx. 833x times
-		"tzwe":  {Weight: 10, ID: 3},  // approx. 75x times
+	backends := []BackendInfo{
+		{ID: 1, Weight: 2, Addr: mkAddr(1)},
+		{ID: 2, Weight: 13, Addr: mkAddr(2)},
+		{ID: 3, Weight: 111, Addr: mkAddr(3)},
+		{ID: 4, Weight: 10, Addr: mkAddr(4)},
 	}
 
-	backendsCounter := make(map[int]uint64, len(backendsMap))
+	backendsCounter := make(map[loadbalancer.BackendID]uint64, len(backends))
 
-	before := GetLookupTable(backendsMap, m)
+	before := ml.GetLookupTable(slices.Values(backends))
 
-	// Remove the backend "one"
-	delete(backendsMap, "one")
-	after := GetLookupTable(backendsMap, m)
+	// Again without first backend. It's weight is
+	// 2 / (2+13+111+10) = 0.014 ~= 1.4% of total weight.
+	after := ml.GetLookupTable(slices.Values(backends[1:]))
 
 	for pos, backend := range before {
 		// count how many times backend position changed, take into consideration
 		// that IDs are decreased by 1 in the "after" lut
-		if (backend == 1 || backend == 2 || backend == 3) && after[pos] != before[pos] {
+		if (backend == 2 || backend == 3 || backend == 4) && after[pos] != before[pos] {
 			changesInExistingBackends++
 		} else {
-			// Check that there is no ID 0 as backend "one" with ID 0 has been removed
-			require.True(t, after[pos] == 1 || after[pos] == 2 || after[pos] == 3)
+			require.True(t, after[pos] == 2 || after[pos] == 3 || after[pos] == 4)
 		}
 		backendsCounter[backend]++
 	}
@@ -193,10 +203,10 @@ func TestWeightedBackendWithRemoval(t *testing.T) {
 
 	// Check that each backend is present x times using following formula:
 	// m / len(weightSum) * backend.Weight; e.g. 1021 / (2+13+111+10) * 13 = 97.6 => 98
-	require.EqualValues(t, 16, backendsCounter[0])
-	require.EqualValues(t, 98, backendsCounter[1])
-	require.EqualValues(t, 832, backendsCounter[2])
-	require.EqualValues(t, 75, backendsCounter[3])
+	require.EqualValues(t, 16, backendsCounter[1])
+	require.EqualValues(t, 98, backendsCounter[2])
+	require.EqualValues(t, 832, backendsCounter[3])
+	require.EqualValues(t, 75, backendsCounter[4])
 }
 
 func BenchmarkGetMaglevTable(b *testing.B) {
@@ -209,19 +219,27 @@ func BenchmarkGetMaglevTable(b *testing.B) {
 
 func benchmarkGetMaglevTable(b *testing.B, m uint64) {
 	backendCount := 1000
+	ml, err := New(
+		Config{
+			MaglevTableSize: uint(m),
+			MaglevHashSeed:  DefaultHashSeed,
+		}, hivetest.Lifecycle(b))
+	require.NoError(b, err, "New")
 
-	if err := Init(DefaultHashSeed, m); err != nil {
-		b.Fatal(err)
-	}
+	// Preallocate the info buffer to not skew the allocation count.
+	ml.backendInfosBuffer = make([]BackendInfo, 0, 1024)
 
-	backends := make(map[string]*loadbalancer.Backend, backendCount)
+	backends := make([]BackendInfo, backendCount)
 	for i := 0; i < backendCount; i++ {
-		backends[fmt.Sprintf("backend-%d", i)] = &loadbalancer.Backend{Weight: 1}
+		backends[i] = BackendInfo{ID: loadbalancer.BackendID(i), Weight: 1, Addr: mkAddr(int32(i))}
+		// Already compute hash string so we compare apples-to-apples to prev benchmarks. Previously
+		// the backends were passed in as map[string]*Backend so these strings precomputed.
+		backends[i].setHashString()
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		table := GetLookupTable(backends, m)
+		table := ml.GetLookupTable(slices.Values(backends))
 		require.Len(b, table, int(m))
 	}
 	b.StopTimer()

--- a/pkg/maglev/maglev_test.go
+++ b/pkg/maglev/maglev_test.go
@@ -133,8 +133,15 @@ func TestWeightedBackendWithRemoval(t *testing.T) {
 }
 
 func BenchmarkGetMaglevTable(b *testing.B) {
+	for _, m := range []uint64{2039, 4093, 16381, 131071} {
+		b.Run(fmt.Sprintf("%d", m), func(b *testing.B) {
+			benchmarkGetMaglevTable(b, m)
+		})
+	}
+}
+
+func benchmarkGetMaglevTable(b *testing.B, m uint64) {
 	backendCount := 1000
-	m := uint64(131071)
 
 	if err := Init(DefaultHashSeed, m); err != nil {
 		b.Fatal(err)

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -41,26 +41,11 @@ var (
 
 // LBBPFMap is an implementation of the LBMap interface.
 type LBBPFMap struct {
-	// Buffer used to avoid excessive allocations to temporarily store backend
-	// IDs. Concurrent access is protected by the
-	// pkg/service.go:(Service).UpsertService() lock.
-	maglevBackendIDsBuffer []loadbalancer.BackendID
-	maglevTableSize        uint64
+	maglev *maglev.Maglev
 }
 
-func New() *LBBPFMap {
-	maglev := option.Config.NodePortAlg == option.NodePortAlgMaglev ||
-		option.Config.LoadBalancerAlgorithmAnnotation
-	maglevTableSize := option.Config.MaglevTableSize
-
-	m := &LBBPFMap{}
-
-	if maglev {
-		m.maglevBackendIDsBuffer = make([]loadbalancer.BackendID, maglevTableSize)
-		m.maglevTableSize = uint64(maglevTableSize)
-	}
-
-	return m
+func New(maglev *maglev.Maglev) *LBBPFMap {
+	return &LBBPFMap{maglev}
 }
 
 func (lbmap *LBBPFMap) upsertServiceProto(p *datapathTypes.UpsertServiceParams, ipv6 bool) error {
@@ -191,14 +176,17 @@ func (lbmap *LBBPFMap) UpsertService(p *datapathTypes.UpsertServiceParams) error
 // UpsertMaglevLookupTable calculates Maglev lookup table for given backends, and
 // inserts into the Maglev BPF map.
 func (lbmap *LBBPFMap) UpsertMaglevLookupTable(svcID uint16, backends map[string]*loadbalancer.Backend, ipv6 bool) error {
-	table := maglev.GetLookupTable(backends, lbmap.maglevTableSize)
-	for i, id := range table {
-		lbmap.maglevBackendIDsBuffer[i] = loadbalancer.BackendID(id)
-	}
-	if err := updateMaglevTable(ipv6, svcID, lbmap.maglevBackendIDsBuffer); err != nil {
+	table := lbmap.maglev.GetLookupTable(
+		func(yield func(maglev.BackendInfo) bool) {
+			for _, be := range backends {
+				if !yield(maglev.BackendInfo{ID: be.ID, Weight: be.Weight, Addr: be.L3n4Addr}) {
+					break
+				}
+			}
+		})
+	if err := updateMaglevTable(ipv6, svcID, table); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -287,12 +287,6 @@ const (
 	// LoadBalancerProtocolDifferentiation enables support for service protocol differentiation (TCP, UDP, SCTP)
 	LoadBalancerProtocolDifferentiation = "bpf-lb-proto-diff"
 
-	// MaglevTableSize determines the size of the backend table per service
-	MaglevTableSize = "bpf-lb-maglev-table-size"
-
-	// MaglevHashSeed contains the cluster-wide seed for the hash
-	MaglevHashSeed = "bpf-lb-maglev-hash-seed"
-
 	// NodePortBindProtection rejects bind requests to NodePort service ports
 	NodePortBindProtection = "node-port-bind-protection"
 
@@ -1895,12 +1889,6 @@ type DaemonConfig struct {
 	// replies to the client (when needed).
 	EnablePMTUDiscovery bool
 
-	// Maglev backend table size (M) per service. Must be prime number.
-	MaglevTableSize int
-
-	// MaglevHashSeed contains the cluster-wide seed for the hash(es).
-	MaglevHashSeed string
-
 	// NodePortAcceleration indicates whether NodePort should be accelerated
 	// via XDP ("none", "generic", "native", or "best-effort")
 	NodePortAcceleration string
@@ -2855,8 +2843,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableSVCSourceRangeCheck = vp.GetBool(EnableSVCSourceRangeCheck)
 	c.EnableHostPort = vp.GetBool(EnableHostPort)
 	c.EnableHostLegacyRouting = vp.GetBool(EnableHostLegacyRouting)
-	c.MaglevTableSize = vp.GetInt(MaglevTableSize)
-	c.MaglevHashSeed = vp.GetString(MaglevHashSeed)
 	c.NodePortBindProtection = vp.GetBool(NodePortBindProtection)
 	c.EnableAutoProtectNodePortRange = vp.GetBool(EnableAutoProtectNodePortRange)
 	c.KubeProxyReplacement = vp.GetString(KubeProxyReplacement)


### PR DESCRIPTION
This makes the maglev implementation a bit more generic by not depending on the `loadbalancer.Backend` type directly, but instead just taking in the bare minimum. To avoid temporary data structures the backend infos are passed as a iter.Seq. This allows https://github.com/cilium/cilium/pull/35430 to avoid the sillyness of converting `experimental.Backend` into `loadbalancer.Backend` and having to build up [temporary hash maps](https://github.com/cilium/cilium/pull/35430/commits/10aadf5023372b0fee2e5ef1ee61ea476df7e7b3#diff-f337ba46ecf9c114a3e65c5717d5d79800693a36ed758542fbdc9f805f75f749R947).

To make sure the refactoring does not introduce any changes the `TestReproducible` hard-codes the expected maglev table to check against.

```
maglev: Add benchmarks for more values of 'm'

    Benchmark also the more realistic smaller sizes. Results from my machine:

    goos: linux goarch: amd64 pkg: github.com/cilium/cilium/pkg/maglev cpu: 13th Gen Intel(R) Core(TM) i9-13950HX
    BenchmarkGetMaglevTable/2039-32                      681           1746071 ns/op          130665 B/op        151 allocs/op
    BenchmarkGetMaglevTable/4093-32                      367           2793396 ns/op          212250 B/op        151 allocs/op
    BenchmarkGetMaglevTable/16381-32                     135           8171612 ns/op         1192045 B/op        151 allocs/op
    BenchmarkGetMaglevTable/131071-32                     22          52912588 ns/op         1138965 B/op        151 allocs/op

    Signed-off-by: Jussi Maki <jussi@isovalent.com>

maglev: Add reproducibility test

    Add a test to maglev to make sure the generated table is always the same with the default configuration. This ensures we
    don't accidentally change the algorithm and end up with differing maglev tables on nodes when upgrading.

    Signed-off-by: Jussi Maki <jussi@isovalent.com>

maglev: Refactor into cell to allow concurrent use in tests

    Parallel test cases in pkg/loadbalancer/experimental are causing racy access to the maglev permutations array.

    Refactor the maglev package into a cell with its own configuration to allow safely using it in parallel tests with
    potentially different configurations.

    To avoid needless copying and construction of temporary data structures, pass the backends as a sequence to GetLookupTable.

    Benchmark results: 
    goos: linux goarch: amd64 pkg: github.com/cilium/cilium/pkg/maglev cpu: 13th Gen Intel(R) Core(TM) i9-13950HX
    BenchmarkGetMaglevTable/2039-32                      724           1668577 ns/op           55210 B/op        146 allocs/op
    BenchmarkGetMaglevTable/4093-32                      456           2624453 ns/op          112473 B/op        146 allocs/op
    BenchmarkGetMaglevTable/16381-32                     135           8564586 ns/op         1060573 B/op        146 allocs/op
    BenchmarkGetMaglevTable/131071-32                     25          49359121 ns/op          548535 B/op        146 allocs/op

    Signed-off-by: Jussi Maki <jussi@isovalent.com>
```