### PR TITLE
[v1.14] fqdn: Skip "open ports" check for statically configured ports 

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -359,10 +359,16 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 	port := uint16(option.Config.ToFQDNsProxyPort)
 	if port == 0 {
 		// Try reuse previous DNS proxy port number
-		if oldPort, err := proxy.GetProxyPort(proxytypes.DNSProxyName); err == nil {
-			openLocalPorts := proxy.OpenLocalPorts()
-			if _, alreadyOpen := openLocalPorts[oldPort]; !alreadyOpen {
+		if oldPort, isStatic, err := proxy.GetProxyPort(proxytypes.DNSProxyName); err == nil {
+			if isStatic {
 				port = oldPort
+			} else {
+				openLocalPorts := proxy.OpenLocalPorts()
+				if _, alreadyOpen := openLocalPorts[oldPort]; !alreadyOpen {
+					port = oldPort
+				} else {
+					log.WithField(logfields.Port, oldPort).Info("Unable re-use old DNS proxy port as it is already in use")
+				}
 			}
 		}
 	}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -70,7 +70,7 @@ func (s *ProxySuite) TestPortAllocator(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(port, Not(Equals), 0)
 
-	port1, err := GetProxyPort("listener1")
+	port1, _, err := GetProxyPort("listener1")
 	c.Assert(err, IsNil)
 	c.Assert(port1, Equals, port)
 
@@ -93,7 +93,7 @@ func (s *ProxySuite) TestPortAllocator(c *C) {
 	c.Assert(err, IsNil)
 
 	// ProxyPort lingers and can still be found, but it's port is zeroed
-	port1b, err := GetProxyPort("listener1")
+	port1b, _, err := GetProxyPort("listener1")
 	c.Assert(err, IsNil)
 	c.Assert(port1b, Equals, uint16(0))
 	c.Assert(pp.ProxyPort, Equals, uint16(0))


### PR DESCRIPTION
 * [ ] #33230 (@gandro) :warning: resolved conflicts

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 33230
```
