### PR TITLE
cilium-cli: Test TLS with serverNames

### DIFF
--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -66,6 +66,12 @@ var (
 	//go:embed manifests/client-egress-l7-http-named-port.yaml
 	clientEgressL7HTTPNamedPortPolicyYAML string
 
+	//go:embed manifests/client-egress-tls-sni.yaml
+	clientEgressTLSSNIPolicyYAML string
+
+	//go:embed manifests/client-egress-l7-tls-sni.yaml
+	clientEgressL7TLSSNIPolicyYAML string
+
 	//go:embed manifests/client-egress-l7-tls.yaml
 	clientEgressL7TLSPolicyYAML string
 
@@ -232,6 +238,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		clientEgressL7NamedPort{},
 		clientEgressL7TlsDenyWithoutHeaders{},
 		clientEgressL7TlsHeaders{},
+		clientEgressTlsSni{},
 		clientEgressL7SetHeader{},
 		echoIngressAuthAlwaysFail{},
 		echoIngressMutualAuthSpiffe{},
@@ -285,6 +292,8 @@ func renderTemplates(param check.Parameters) (map[string]string, error) {
 		"clientEgressL7HTTPPolicyPortRangeYAML":            clientEgressL7HTTPPolicyPortRangeYAML,
 		"clientEgressL7HTTPNamedPortPolicyYAML":            clientEgressL7HTTPNamedPortPolicyYAML,
 		"clientEgressToFQDNsPolicyYAML":                    clientEgressToFQDNsPolicyYAML,
+		"clientEgressTLSSNIPolicyYAML":                     clientEgressTLSSNIPolicyYAML,
+		"clientEgressL7TLSSNIPolicyYAML":                   clientEgressL7TLSSNIPolicyYAML,
 		"clientEgressL7TLSPolicyYAML":                      clientEgressL7TLSPolicyYAML,
 		"clientEgressL7TLSPolicyPortRangeYAML":             clientEgressL7TLSPolicyPortRangeYAML,
 		"clientEgressL7HTTPMatchheaderSecretYAML":          clientEgressL7HTTPMatchheaderSecretYAML,

--- a/cilium-cli/connectivity/builder/client_egress_tls_sni.go
+++ b/cilium-cli/connectivity/builder/client_egress_tls_sni.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type clientEgressTlsSni struct{}
+
+func (t clientEgressTlsSni) build(ct *check.ConnectivityTest, templates map[string]string) {
+	clientEgressTlsSniTest(ct, templates)
+	clientEgressL7TlsSniTest(ct, templates)
+}
+
+func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]string) {
+	testName := "client-egress-tls-sni"
+	yamlFile := templates["clientEgressTLSSNIPolicyYAML"]
+	// Test TLS SNI enforcement using an egress policy on the clients.
+	newTest(testName, ct).
+		WithCiliumVersion("!1.14.15 !1.14.16 !1.15.9 !1.15.10 !1.16.2 !1.16.3").
+		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithCiliumPolicy(yamlFile). // L7 allow policy TLS SNI enforcement
+		WithScenarios(tests.PodToWorld()).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Destination().Port() == 443 {
+				return check.ResultOK, check.ResultNone
+			}
+			return check.ResultDefaultDenyEgressDrop, check.ResultNone
+		})
+}
+
+func clientEgressL7TlsSniTest(ct *check.ConnectivityTest, templates map[string]string) {
+	testName := "client-egress-l7-tls-headers-sni"
+	yamlFile := templates["clientEgressL7TLSSNIPolicyYAML"]
+	// Test TLS SNI enforcement using an egress policy on the clients.
+	newTest(testName, ct).
+		WithCiliumVersion("!1.14.15 !1.14.16 !1.15.9 !1.15.10 !1.16.2 !1.16.3").
+		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretBackendK8s)).
+		WithCABundleSecret().
+		WithCertificate("externaltarget-tls", ct.Params().ExternalTarget).
+		WithCiliumPolicy(yamlFile). // L7 allow policy TLS SNI enforcement
+		WithScenarios(tests.PodToWorldWithTLSIntercept("-H", "X-Very-Secret-Token: 42")).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			return check.ResultOK, check.ResultNone
+		})
+}

--- a/cilium-cli/connectivity/builder/manifests/client-egress-l7-tls-sni.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-l7-tls-sni.yaml
@@ -1,0 +1,43 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "l7-policy-tls"
+specs:
+- description: "L7 policy with TLS"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  # Allow DNS 
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+      rules:
+        dns:
+          - matchPattern: "*"
+  # Allow HTTPS when X-Very-Secret-Token is set
+  - toFQDNs:
+    - matchName: "{{.ExternalTarget}}"
+    toPorts:
+    - ports:
+      - port: "443"
+        protocol: "TCP"
+      serverNames:
+      - "{{trimSuffix .ExternalTarget "."}}"
+      terminatingTLS:
+        secret:
+          namespace: "{{.TestNamespace}}"
+          name: externaltarget-tls # internal certificate to terminate in cluster
+      originatingTLS:
+        secret:
+          namespace: "{{.ExternalTargetCANamespace}}"
+          name: "{{.ExternalTargetCAName}}" # public CA bundle to validate external target
+      rules:
+        http:
+        - method: "GET"
+          path: "/"
+          headers:
+          - "X-Very-Secret-Token: 42"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni.yaml
@@ -1,0 +1,29 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "l7-policy-tls-sni"
+specs:
+- description: "L7 policy with TLS SNI"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  # Allow DNS 
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+      rules:
+        dns:
+          - matchPattern: "*"
+  # Allow HTTPS when X-Very-Secret-Token is set
+  - toFQDNs:
+    - matchName: "{{.ExternalTarget}}"
+    toPorts:
+    - ports:
+      - port: "443"
+        protocol: "TCP"
+      serverNames:
+      - "{{trimSuffix .ExternalTarget "."}}"


### PR DESCRIPTION
Add new connectivity tests `client-egress-l7-tls-headers-sni` and `client-egress-tls-sni` to test SNI enforcement with and without TLS interception. Regressed patch releases are excluded from the new tests so that CI will not fail on downgrade tests.

```release-note
Add coverage for SNI enforcement in cilium-cli connectivity tests.
```
