### PR TITLE
endpoint: don't start DNS history trigger when parsing endpoint

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -916,8 +916,6 @@ func parseEndpoint(ctx context.Context, owner regeneration.Owner, policyGetter p
 		return nil, fmt.Errorf("failed to parse restored endpoint: %w", err)
 	}
 
-	ep.initDNSHistoryTrigger()
-
 	// Set default options, unsupported options were already dropped by
 	// ep.Options.UnmarshalJSON
 	ep.SetDefaultOpts(nil)


### PR DESCRIPTION
This trigger may be, well, triggered when reacting to a DNS request -- even when the agent is starting up. This could lead to a deadlock, as the datapath is not able to write the endpoint header file until the agent is started, but the agent cannot finish starting as the endpoint is locked.

The fix for this is to remove the unnecessary trigger initialization on endpoint parsing; we will always start it on first regeneration.

This catches a case missed in #34059, which only fixed the new-endpoint case. That change moved trigger initialization in to endpoint regeneration and out of endpoint initialization. But it missed this line.

```release-note
Fixes a potential deadlock when restarting cilium agent with pods with DNS interception configured
```