### PR TITLE
hubble: consistenly prefix version string with 'v'

### DIFF
--- a/hubble/Makefile
+++ b/hubble/Makefile
@@ -20,7 +20,7 @@ include ../Makefile.defs
 all: hubble
 
 hubble:
-	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/cilium/hubble/pkg.GitHash=$(GIT_HASH)' -X 'github.com/cilium/cilium/hubble/pkg.Version=${VERSION}'" -o $(TARGET_DIR)/$(TARGET)$(EXT) $(SUBDIRS_HUBBLE_CLI)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/cilium/hubble/pkg.GitHash=$(GIT_HASH)' -X 'github.com/cilium/cilium/hubble/pkg.Version=v${VERSION}'" -o $(TARGET_DIR)/$(TARGET)$(EXT) $(SUBDIRS_HUBBLE_CLI)
 
 release:
 	cd ../ && \

--- a/hubble/cmd/root.go
+++ b/hubble/cmd/root.go
@@ -90,7 +90,7 @@ func NewWithViper(vp *viper.Viper) *cobra.Command {
 	rootCmd.SetUsageTemplate(template.Usage)
 
 	rootCmd.SetErr(os.Stderr)
-	rootCmd.SetVersionTemplate("{{with .Name}}{{printf \"%s \" .}}{{end}}{{printf \"v%s\" .Version}}\r\n")
+	rootCmd.SetVersionTemplate("{{with .Name}}{{printf \"%s \" .}}{{end}}{{printf \"%s\" .Version}}\r\n")
 
 	rootCmd.AddCommand(
 		cmdConfig.New(vp),


### PR DESCRIPTION
Prior to this change, using `hubble --version` and `hubble version` would produce different results:

    hubble --version # v1.16.3
    hubble version   # 1.16.3

Ref: https://github.com/cilium/hubble/issues/1613

```release-note
hubble: consistently use v as prefix for the Hubble version
```
