### PR TITLE
lock: Remove StoppableWaitGroup.Done(), return done function from Add()

### DIFF
--- a/clustermesh-apiserver/syncstate/syncstate.go
+++ b/clustermesh-apiserver/syncstate/syncstate.go
@@ -53,9 +53,9 @@ func (ss SyncState) Complete() bool {
 // WaitForResource adds a resource to the SyncState and returns a callback function that should be
 // called when the resource has been synchronized.
 func (ss SyncState) WaitForResource() func(context.Context) {
-	ss.Add()
+	done := ss.Add()
 	return func(_ context.Context) {
-		ss.Done()
+		done()
 	}
 }
 

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -30,7 +30,7 @@ var (
 
 func k8sServiceHandler(ctx context.Context, cinfo cmtypes.ClusterInfo, shared bool, logger *slog.Logger) {
 	serviceHandler := func(event k8s.ServiceEvent) {
-		defer event.SWG.Done()
+		defer event.SWGDone()
 
 		svc := k8s.NewClusterService(event.ID, event.Service, event.Endpoints)
 		svc.Cluster = cinfo.Name

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
@@ -755,7 +755,7 @@ func TestRemoteClusterSync(t *testing.T) {
 				readyTimeout: tt.config.PerClusterReadyTimeout,
 				logger:       km.logger.WithField(logfields.ClusterName, "foo"),
 			}
-			rc.synced.resources.Add()
+			swgDone := rc.synced.resources.Add()
 			rc.synced.resources.Stop()
 
 			mockClusterMesh.clusters[rc.name] = rc
@@ -778,7 +778,7 @@ func TestRemoteClusterSync(t *testing.T) {
 
 			if tt.connect {
 				require.False(t, clusterSyncComplete(), "Cluster sync should not be complete until all resources are done")
-				rc.synced.resources.Done()
+				swgDone()
 			}
 
 			require.NoError(t, rc.synced.Resources(ctx), "Still waiting for remote cluster resources")

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -225,12 +225,10 @@ func (o *fakeObserver) NodeDeleted(_ nodeTypes.Node) { o.deletes.Add(1) }
 
 func (o *fakeObserver) MergeExternalServiceUpdate(_ *serviceStore.ClusterService, swg *lock.StoppableWaitGroup) {
 	o.updates.Add(1)
-	swg.Done()
 }
 
 func (o *fakeObserver) MergeExternalServiceDelete(_ *serviceStore.ClusterService, swg *lock.StoppableWaitGroup) {
 	o.deletes.Add(1)
-	swg.Done()
 }
 
 func (o *fakeObserver) Upsert(string, net.IP, uint8, *ipcache.K8sMetadata, ipcache.Identity) (bool, error) {

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -154,7 +154,7 @@ func (s *ClusterMeshServicesTestSuite) expectEvent(t *testing.T, action k8s.Cach
 		case <-time.After(defaults.NodeDeleteDelay + timeout):
 			c.Errorf("Timeout while waiting for event to be received")
 		}
-		defer event.SWG.Done()
+		defer event.SWGDone()
 
 		require.Equal(t, action, event.Action)
 		require.Equal(t, id, event.ID)

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -95,9 +95,10 @@ type ServiceEvent struct {
 	// OldEndpoints is old endpoints structure.
 	OldEndpoints *Endpoints
 
-	// SWG provides a mechanism to detect if a service was synchronized with
+	// SWGDone marks the event as processed. The underlying StoppableWaitGroup
+	// provides a mechanism to detect if a service was synchronized with
 	// the datapath.
-	SWG *lock.StoppableWaitGroup
+	SWGDone lock.DoneFunc
 }
 
 // ServiceNotification is a slimmed down version of a ServiceEvent. In particular
@@ -363,7 +364,6 @@ func (s *ServiceCache) UpdateService(k8sSvc *slim_corev1.Service, swg *lock.Stop
 	// Check if the corresponding Endpoints resource is already available
 	endpoints, serviceReady := s.correlateEndpoints(svcID)
 	if serviceReady {
-		swg.Add()
 		s.emitEvent(ServiceEvent{
 			Action:       UpdateService,
 			ID:           svcID,
@@ -371,7 +371,7 @@ func (s *ServiceCache) UpdateService(k8sSvc *slim_corev1.Service, swg *lock.Stop
 			OldService:   oldService,
 			Endpoints:    endpoints,
 			OldEndpoints: endpoints,
-			SWG:          swg,
+			SWGDone:      swg.Add(),
 		})
 	}
 
@@ -383,7 +383,6 @@ func (s *ServiceCache) EnsureService(svcID ServiceID, swg *lock.StoppableWaitGro
 	defer s.mutex.RUnlock()
 	if svc, found := s.services[svcID]; found {
 		if endpoints, serviceReady := s.correlateEndpoints(svcID); serviceReady {
-			swg.Add()
 			s.emitEvent(ServiceEvent{
 				Action:       UpdateService,
 				ID:           svcID,
@@ -391,7 +390,7 @@ func (s *ServiceCache) EnsureService(svcID ServiceID, swg *lock.StoppableWaitGro
 				OldService:   svc,
 				Endpoints:    endpoints,
 				OldEndpoints: endpoints,
-				SWG:          swg,
+				SWGDone:      swg.Add(),
 			})
 			return true
 		}
@@ -413,13 +412,12 @@ func (s *ServiceCache) DeleteService(k8sSvc *slim_corev1.Service, swg *lock.Stop
 
 	if serviceOK {
 		s.metrics.DelService(oldService)
-		swg.Add()
 		s.emitEvent(ServiceEvent{
 			Action:    DeleteService,
 			ID:        svcID,
 			Service:   oldService,
 			Endpoints: endpoints,
-			SWG:       swg,
+			SWGDone:   swg.Add(),
 		})
 	}
 }
@@ -469,14 +467,13 @@ func (s *ServiceCache) UpdateEndpoints(newEndpoints *Endpoints, swg *lock.Stoppa
 	svc, ok := s.services[esID.ServiceID]
 	endpoints, serviceReady := s.correlateEndpoints(esID.ServiceID)
 	if ok && serviceReady {
-		swg.Add()
 		s.emitEvent(ServiceEvent{
 			Action:       UpdateService,
 			ID:           esID.ServiceID,
 			Service:      svc,
 			Endpoints:    endpoints,
 			OldEndpoints: oldEPs,
-			SWG:          swg,
+			SWGDone:      swg.Add(),
 		})
 	}
 
@@ -502,14 +499,13 @@ func (s *ServiceCache) DeleteEndpoints(svcID EndpointSliceID, swg *lock.Stoppabl
 	endpoints, _ := s.correlateEndpoints(svcID.ServiceID)
 
 	if serviceOK {
-		swg.Add()
 		event := ServiceEvent{
 			Action:       UpdateService,
 			ID:           svcID.ServiceID,
 			Service:      svc,
 			Endpoints:    endpoints,
 			OldEndpoints: oldEPs,
-			SWG:          swg,
+			SWGDone:      swg.Add(),
 		}
 
 		s.emitEvent(event)
@@ -749,7 +745,6 @@ func (s *ServiceCache) mergeServiceUpdateLocked(service *serviceStore.ClusterSer
 
 	// Only send event notification if service is ready.
 	if ok && serviceReady {
-		swg.Add()
 		s.emitEvent(ServiceEvent{
 			Action:       UpdateService,
 			ID:           id,
@@ -757,7 +752,7 @@ func (s *ServiceCache) mergeServiceUpdateLocked(service *serviceStore.ClusterSer
 			OldService:   oldService,
 			Endpoints:    endpoints,
 			OldEndpoints: oldEPs,
-			SWG:          swg,
+			SWGDone:      swg.Add(),
 		})
 	}
 }
@@ -809,14 +804,13 @@ func (s *ServiceCache) mergeExternalServiceDeleteLocked(service *serviceStore.Cl
 
 		// Only send event notification if service is shared.
 		if ok && svc.Shared {
-			swg.Add()
 			event := ServiceEvent{
 				Action:       UpdateService,
 				ID:           id,
 				Service:      svc,
 				Endpoints:    endpoints,
 				OldEndpoints: oldEPs,
-				SWG:          swg,
+				SWGDone:      swg.Add(),
 			}
 
 			if !serviceReady {
@@ -876,13 +870,12 @@ func (s *ServiceCache) MergeClusterServiceDelete(service *serviceStore.ClusterSe
 	delete(s.services, id)
 
 	if ok {
-		swg.Add()
 		s.emitEvent(ServiceEvent{
 			Action:    DeleteService,
 			ID:        id,
 			Service:   svc,
 			Endpoints: endpoints,
-			SWG:       swg,
+			SWGDone:   swg.Add(),
 		})
 	}
 }
@@ -915,7 +908,6 @@ func (s *ServiceCache) updateSelfNodeLabels(labels map[string]string) {
 
 		if endpoints, ready := s.correlateEndpoints(id); ready {
 			swg := lock.NewStoppableWaitGroup()
-			swg.Add()
 			s.emitEvent(ServiceEvent{
 				Action:       UpdateService,
 				ID:           id,
@@ -923,7 +915,7 @@ func (s *ServiceCache) updateSelfNodeLabels(labels map[string]string) {
 				OldService:   svc,
 				Endpoints:    endpoints,
 				OldEndpoints: endpoints,
-				SWG:          swg,
+				SWGDone:      swg.Add(),
 			})
 		}
 	}

--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -249,7 +249,7 @@ func testServiceCache(t *testing.T,
 	// imported
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -276,7 +276,7 @@ func testServiceCache(t *testing.T,
 	svcCache.DeleteService(k8sSvc, swgSvcs)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, DeleteService, event.Action)
 		require.Equal(t, svcID, event.ID)
 
@@ -291,7 +291,7 @@ func testServiceCache(t *testing.T,
 	svcCache.UpdateService(k8sSvc, swgSvcs)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 
@@ -306,7 +306,7 @@ func testServiceCache(t *testing.T,
 	deleteEndpointsCB(svcCache, swgEps)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 
@@ -332,7 +332,7 @@ func testServiceCache(t *testing.T,
 	updateEndpointsCB(svcCache, swgEps)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -346,7 +346,7 @@ func testServiceCache(t *testing.T,
 	svcCache.DeleteService(k8sSvc, swgSvcs)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, DeleteService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -450,7 +450,7 @@ func TestForEachService(t *testing.T) {
 	svcID1, eps1 := svcCache.UpdateEndpoints(k8sEndpoints1, swg)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID1, event.ID)
 		require.Equal(t, eps1, event.Endpoints)
@@ -461,7 +461,7 @@ func TestForEachService(t *testing.T) {
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		println("waiting for events2")
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID2, event.ID)
 		require.Equal(t, eps2, event.Endpoints)
@@ -563,7 +563,7 @@ func TestExternalServiceMerging(t *testing.T) {
 	// imported
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -616,7 +616,7 @@ func TestExternalServiceMerging(t *testing.T) {
 	// IncludeExternal is set (i.e., the service is marked as a global one in the remote cluster).
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 
@@ -652,7 +652,7 @@ func TestExternalServiceMerging(t *testing.T) {
 	// IncludeExternal is set (i.e., the service is marked as a global one in the remote cluster).
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 
@@ -692,7 +692,7 @@ func TestExternalServiceMerging(t *testing.T) {
 	// is set (i.e., the service is marked as a global one in the remote cluster).
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		require.EqualValues(t, &Backend{
@@ -763,7 +763,7 @@ func TestExternalServiceMerging(t *testing.T) {
 
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID2, event.ID)
 		return true
@@ -789,7 +789,7 @@ func TestExternalServiceMerging(t *testing.T) {
 	svcCache.MergeExternalServiceUpdate(cluster2svc, swgSvcs)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.EqualValues(t, &Backend{
 			Ports: serviceStore.PortConfiguration{
@@ -803,7 +803,7 @@ func TestExternalServiceMerging(t *testing.T) {
 	svcCache.MergeExternalServiceDelete(cluster2svc, swgSvcs)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Nil(t, event.Endpoints.Backends[cmtypes.MustParseAddrCluster("4.4.4.4")])
 		return true
@@ -813,7 +813,7 @@ func TestExternalServiceMerging(t *testing.T) {
 	svcCache.DeleteService(k8sSvc, swgSvcs)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, DeleteService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -823,7 +823,7 @@ func TestExternalServiceMerging(t *testing.T) {
 	svcCache.UpdateService(k8sSvc, swgSvcs)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		require.EqualValues(t, &Backend{
@@ -886,7 +886,7 @@ func TestExternalServiceDeletion(t *testing.T) {
 
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, DeleteService, event.Action)
 		require.Equal(t, id1, event.ID)
 		return true
@@ -906,7 +906,7 @@ func TestExternalServiceDeletion(t *testing.T) {
 
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, id1, event.ID)
 		return true
@@ -924,7 +924,7 @@ func TestExternalServiceDeletion(t *testing.T) {
 
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, DeleteService, event.Action)
 		require.Equal(t, id2, event.ID)
 		return true
@@ -980,7 +980,7 @@ func TestClusterServiceMerging(t *testing.T) {
 	// regardless of whether it is marked as global or shared (since the cluster name matches).
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		require.EqualValues(t, &Backend{
@@ -1165,7 +1165,7 @@ func TestServiceCacheWith2EndpointSlice(t *testing.T) {
 	// imported for k8sEndpointSlice1
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -1175,7 +1175,7 @@ func TestServiceCacheWith2EndpointSlice(t *testing.T) {
 	// imported for k8sEndpointSlice2
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -1203,7 +1203,7 @@ func TestServiceCacheWith2EndpointSlice(t *testing.T) {
 	svcCache.DeleteService(k8sSvc, swgSvcs)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, DeleteService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -1213,7 +1213,7 @@ func TestServiceCacheWith2EndpointSlice(t *testing.T) {
 	svcCache.UpdateService(k8sSvc, swgSvcs)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -1223,7 +1223,7 @@ func TestServiceCacheWith2EndpointSlice(t *testing.T) {
 	svcCache.DeleteEndpoints(k8sEndpointSlice2.EndpointSliceID, swgEps)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -1236,7 +1236,7 @@ func TestServiceCacheWith2EndpointSlice(t *testing.T) {
 	svcCache.DeleteEndpoints(k8sEndpointSlice1.EndpointSliceID, swgEps)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -1250,7 +1250,7 @@ func TestServiceCacheWith2EndpointSlice(t *testing.T) {
 	svcCache.UpdateEndpoints(k8sEndpointSlice1, swgEps)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -1264,7 +1264,7 @@ func TestServiceCacheWith2EndpointSlice(t *testing.T) {
 	svcCache.DeleteService(k8sSvc, swgSvcs)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, DeleteService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -1383,7 +1383,7 @@ func TestServiceCacheWith2EndpointSliceSameAddress(t *testing.T) {
 	// imported for k8sEndpointSlice1
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -1393,7 +1393,7 @@ func TestServiceCacheWith2EndpointSliceSameAddress(t *testing.T) {
 	// imported for k8sEndpointSlice2
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -1421,7 +1421,7 @@ func TestServiceCacheWith2EndpointSliceSameAddress(t *testing.T) {
 	svcCache.DeleteService(k8sSvc, swgSvcs)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, DeleteService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -1431,7 +1431,7 @@ func TestServiceCacheWith2EndpointSliceSameAddress(t *testing.T) {
 	svcCache.UpdateService(k8sSvc, swgSvcs)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -1441,7 +1441,7 @@ func TestServiceCacheWith2EndpointSliceSameAddress(t *testing.T) {
 	svcCache.DeleteEndpoints(k8sEndpointSlice2.EndpointSliceID, swgEps)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -1454,7 +1454,7 @@ func TestServiceCacheWith2EndpointSliceSameAddress(t *testing.T) {
 	svcCache.DeleteEndpoints(k8sEndpointSlice1.EndpointSliceID, swgEps)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -1468,7 +1468,7 @@ func TestServiceCacheWith2EndpointSliceSameAddress(t *testing.T) {
 	svcCache.UpdateEndpoints(k8sEndpointSlice1, swgEps)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, UpdateService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true
@@ -1482,7 +1482,7 @@ func TestServiceCacheWith2EndpointSliceSameAddress(t *testing.T) {
 	svcCache.DeleteService(k8sSvc, swgSvcs)
 	require.NoError(t, testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
-		defer event.SWG.Done()
+		defer event.SWGDone()
 		require.Equal(t, DeleteService, event.Action)
 		require.Equal(t, svcID, event.ID)
 		return true

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -158,7 +158,7 @@ func (k *K8sServiceWatcher) deleteK8sServiceV1(svc *slim_corev1.Service, swg *lo
 func (k *K8sServiceWatcher) k8sServiceHandler() {
 	eventHandler := func(event k8s.ServiceEvent) {
 		defer func(startTime time.Time) {
-			event.SWG.Done()
+			event.SWGDone()
 			k.k8sServiceEventProcessed(event.Action.String(), startTime)
 		}(time.Now())
 

--- a/pkg/lock/stoppable_waitgroup.go
+++ b/pkg/lock/stoppable_waitgroup.go
@@ -36,11 +36,11 @@ func (l *StoppableWaitGroup) Stop() {
 	l.stopOnce.Do(func() {
 		// We will do an Add here so we can perform a Done after we close
 		// the l.noopAdd channel.
-		l.Add()
+		done := l.Add()
 		close(l.noopAdd)
-		// Calling Done() here so we know that in case 'l.i' will become zero
+		// Calling done() here so we know that in case 'l.i' will become zero
 		// it will trigger a close of l.noopDone channel.
-		l.Done()
+		done()
 	})
 }
 
@@ -57,22 +57,38 @@ func (l *StoppableWaitGroup) WaitChannel() <-chan struct{} {
 	return l.noopDone
 }
 
+// DoneFunc returned by Add() marks the goroutine as completed.
+type DoneFunc func()
+
 // Add adds the goroutine to the list of routines to that Wait() will have
 // to wait before it returns.
 // If the StoppableWaitGroup was stopped this will be a no-op.
-func (l *StoppableWaitGroup) Add() {
+// Returns a "done" function to mark the goroutine as completed. Wait() is
+// unblocked once all done functions obtained before Stop() have been called.
+func (l *StoppableWaitGroup) Add() DoneFunc {
 	select {
 	case <-l.noopAdd:
+		return func() {}
 	default:
 		l.i.Add(1)
+		var once sync.Once
+		return func() {
+			once.Do(l.done)
+		}
 	}
 }
 
-// Done will decrement the number of goroutines the Wait() will have to wait
+// TEMP: For cleaner git commits, this keeps done() exported until the next commit that
+// removes this and reworks the tree to not use it.
+func (l *StoppableWaitGroup) Done() {
+	l.done()
+}
+
+// done will decrement the number of goroutines the Wait() will have to wait
 // before it returns.
 // This function is a no-op once all goroutines that have called 'Add()' have
 // also called 'Done()' and the StoppableWaitGroup was stopped.
-func (l *StoppableWaitGroup) Done() {
+func (l *StoppableWaitGroup) done() {
 	select {
 	case <-l.noopDone:
 		return

--- a/pkg/lock/stoppable_waitgroup.go
+++ b/pkg/lock/stoppable_waitgroup.go
@@ -78,12 +78,6 @@ func (l *StoppableWaitGroup) Add() DoneFunc {
 	}
 }
 
-// TEMP: For cleaner git commits, this keeps done() exported until the next commit that
-// removes this and reworks the tree to not use it.
-func (l *StoppableWaitGroup) Done() {
-	l.done()
-}
-
 // done will decrement the number of goroutines the Wait() will have to wait
 // before it returns.
 // This function is a no-op once all goroutines that have called 'Add()' have

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -118,8 +118,7 @@ func NewCollector(probes []Probe, config Config) *Collector {
 	}
 
 	for i := range probes {
-		c.firstRunSwg.Add()
-		c.spawnProbe(&probes[i], c.firstRunSwg.Done)
+		c.spawnProbe(&probes[i], c.firstRunSwg.Add())
 	}
 	c.firstRunSwg.Stop()
 


### PR DESCRIPTION
```
lock: StoppableWaitGroup.Add() returns done function

    StoppableWaitGroup wasn't well suited for use-cases where the Add() and
    Done() calls did not happen in strict order. E.g. consider:

    1. Add() "event x" 
    2. Add() "event y" 
    3. Stop() 
    4. Add() "event z" (no-op)
    5. Done() "event z" 
    6. Done() "event x"

    Now the StoppableWaitGroup.Wait() returns even though the "event y" for
    which Add() was called has not been processed.

    To make StoppableWaitGroups safer in these situations, unexport the Done()
    function and return it from Add(). If the SWG has been stopped return a
    no-op function from Add(). To further increase safety, wrap the returned
    function with a sync.Once.

    Signed-off-by: Jussi Maki <jussi@isovalent.com>

treewise: Refactor uses of StoppableWaitGroup

    Remove StoppableWaitGroup.Done() and refactor all uses of Add() to use the
    returned done function.

    Signed-off-by: Jussi Maki <jussi@isovalent.com>
```