### PR TITLE
[v1.15] .github: Fix missing variable escaping in LVH command

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -529,7 +529,7 @@ jobs:
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
               --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
               --junit-property github_job_step="Run tests upgrade 2 (${{ join(matrix.*, ', ') }})" \
-              "${EXTRA[@]}"
+              "\${EXTRA[@]}"
 
             # --flush-ct interrupts the flows, so we need to set up again.
             ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup \
@@ -579,7 +579,7 @@ jobs:
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
               --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
               --junit-property github_job_step="Run tests upgrade 3 (${{ join(matrix.*, ', ') }})" \
-              "${EXTRA[@]}"
+              "\${EXTRA[@]}"
 
       - name: Fetch artifacts
         if: ${{ !success() }}


### PR DESCRIPTION
This fixes an issue with the tests-e2e-upgrade workflow where the `${EXTRA{@}}` arguments were actually empty, because commands are bash expanded on the host runner, i.e. before they are passed to the LVH VM. As a result, the additional arguments were ignored.

This fix is only applied to v1.15 because other branches use different methods for passing in `cilium connectivity check` command.
