### PR TITLE
node: avoid JSON unserializable log field

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -1051,9 +1051,17 @@ func (m *manager) pruneNodes(includeMeshed bool) {
 	}
 
 	if len(m.restoredNodes) > 0 {
-		log.WithFields(logrus.Fields{
-			"stale-nodes": m.restoredNodes,
-		}).Info("Deleting stale nodes")
+		if log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+			printableNodes := make([]string, 0, len(m.restoredNodes))
+			for ni := range m.restoredNodes {
+				printableNodes = append(printableNodes, ni.String())
+			}
+			log.WithFields(logrus.Fields{
+				"stale-nodes": printableNodes,
+			}).Debugf("Deleting %v stale nodes", len(m.restoredNodes))
+		} else {
+			log.Infof("Deleting %v stale nodes", len(m.restoredNodes))
+		}
 	}
 	m.mutex.Unlock()
 


### PR DESCRIPTION
When setting logging up in such a way that logrus would attempt to serialise entries to JSON, it could fail with errors such as:

    Failed to obtain reader, failed to marshal fields to JSON, json: unsupported type: map[types.Identity]*types.Node

Replace the broken Info log with logging just the number of deleted nodes and prepare a serializable slice of strings for the debug log with more detail.

Fixes: b855b2575f (node/manager: synthesize node deletion events)
