### PR TITLE
wireguard: tracking only nodeIPs as AllowedIPs in tunneling mode

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1050,6 +1050,10 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.EnableNonDefaultDenyPolicies)
 	option.BindEnv(vp, option.EnableNonDefaultDenyPolicies)
 
+	flags.Bool(option.WireguardTrackAllIPsFallback, defaults.WireguardTrackAllIPsFallback, "Force WireGuard to track all IPs")
+	flags.MarkHidden(option.WireguardTrackAllIPsFallback)
+	option.BindEnv(vp, option.WireguardTrackAllIPsFallback)
+
 	flags.Bool(option.LBSourceRangeAllTypes, false, "Propagate loadbalancerSourceRanges to all corresponding service types")
 	option.BindEnv(vp, option.LBSourceRangeAllTypes)
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -582,6 +582,9 @@ const (
 
 	// BGPRouterIDAllocationMode is default BGP router-id allocation mode
 	BGPRouterIDAllocationMode = "default"
+
+	// WireguardTrackAllIPsFallback forces the WireGuard agent to track all IPs.
+	WireguardTrackAllIPsFallback = false
 )
 
 var (

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -782,6 +782,9 @@ const (
 	// EnableWireguard is the name of the option to enable WireGuard
 	EnableWireguard = "enable-wireguard"
 
+	// WireguardTrackAllIPsFallback forces the WireGuard agent to track all IPs.
+	WireguardTrackAllIPsFallback = "wireguard-track-all-ips-fallback"
+
 	// EnableL2Announcements is the name of the option to enable l2 announcements
 	EnableL2Announcements = "enable-l2-announcements"
 
@@ -1587,6 +1590,9 @@ type DaemonConfig struct {
 
 	// EnableEncryptionStrictMode enables strict mode for encryption
 	EnableEncryptionStrictMode bool
+
+	// WireguardTrackAllIPsFallback forces the WireGuard agent to track all IPs.
+	WireguardTrackAllIPsFallback bool
 
 	// EncryptionStrictModeCIDR is the CIDR to use for strict mode
 	EncryptionStrictModeCIDR netip.Prefix
@@ -2830,6 +2836,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.IPv6MCastDevice = vp.GetString(IPv6MCastDevice)
 	c.EnableIPSec = vp.GetBool(EnableIPSecName)
 	c.EnableWireguard = vp.GetBool(EnableWireguard)
+	c.WireguardTrackAllIPsFallback = vp.GetBool(WireguardTrackAllIPsFallback)
 	c.EnableL2Announcements = vp.GetBool(EnableL2Announcements)
 	c.L2AnnouncerLeaseDuration = vp.GetDuration(L2AnnouncerLeaseDuration)
 	c.L2AnnouncerRenewDeadline = vp.GetDuration(L2AnnouncerRenewDeadline)

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -318,30 +318,6 @@ func TestAgent_PeerConfig(t *testing.T) {
 	require.Empty(t, wgAgent.nodeNameByPubKey)
 }
 
-func TestAgent_PeerConfig_WithEncryptNode(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	wgAgent, ipCache := newTestAgent(ctx, newFakeWgClient())
-	defer ipCache.Shutdown()
-
-	ipCache.Upsert(pod1IPv4Str, k8s1NodeIPv4, 0, nil, ipcache.Identity{ID: 1, Source: source.Kubernetes})
-	ipCache.Upsert(pod2IPv4Str, k8s1NodeIPv4, 0, nil, ipcache.Identity{ID: 2, Source: source.Kubernetes})
-
-	err := wgAgent.UpdatePeer(k8s1NodeName, k8s1PubKey, k8s1NodeIPv4, k8s1NodeIPv6)
-	require.NoError(t, err)
-
-	k8s1 := wgAgent.peerByNodeName[k8s1NodeName]
-	require.NotNil(t, k8s1)
-	require.EqualValues(t, k8s1NodeIPv4, k8s1.nodeIPv4)
-	require.EqualValues(t, k8s1NodeIPv6, k8s1.nodeIPv6)
-	require.Equal(t, k8s1PubKey, k8s1.pubKey.String())
-	require.Len(t, k8s1.allowedIPs, 4)
-	require.True(t, containsIP(maps.Values(k8s1.allowedIPs), pod1IPv4))
-	require.True(t, containsIP(maps.Values(k8s1.allowedIPs), pod2IPv4))
-	require.True(t, containsIP(maps.Values(k8s1.allowedIPs), iputil.IPToPrefix(k8s1NodeIPv4)))
-	require.True(t, containsIP(maps.Values(k8s1.allowedIPs), iputil.IPToPrefix(k8s1NodeIPv6)))
-}
-
 func TestAgent_AllowedIPsRestoration(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
I tried to grasp all the details in the commit messages.

1. `wireguard: test: remove unneeded nodeEncryption test`: while preparing unit tests for subsequent commits, I noticed that `TestAgent_PeerConfig_WithEncryptNode` can be removed, as we always expect node IPs to be in allowedIPs regardless of node encryption being enabled or not. This behavior should already be covered in the other tests.
2. `wireguard: test: rework agent tests`: this is the commit that unfortunately does contribute a lot to LOCs, despite not modifying the testing logic. With this commit, I'd like to reuse the logic we have in `TestAgent_PeerConfig` and `TestAgent_AllowedIPsRestoration` for the subsequent introduced agent behaviors in different routing modes.
3. `wireguard: reduce syscall ConfigureDevice when not needed`: as described in the commit message, there are a few cases in which we still configure the device even when not necessarily needed (no ep changes, no key changes, no IPs to add). This could result in unneeded syscalls being executed anyways.
4. `daemon: wireguard: add WireguardTrackAllIPsFallback flag`: this is a precaution flag, used in case the new agent logic after the next commit is breaking connectivity. In tunneling mode, we will only track nodeIPs as all the pod-to-pod connections should go through the overlay. In case we're missing something, enabling this flag would allow the agent to track pod IPs even in tunnel mode.
5. `wireguard: track only nodeIPs with tunneling enabled`: pretty self-explanatory. Since in tunneling we'd track only node IPs provided in `UpdatePeer()` , we don't need to register to IPCache events.

Fixes: #35331 

```release-note
Tracking only nodeIPs in WireGuard AllowedIPs with overlay routing, while preserve native routing behavior of tracking both node and pods IPs from IPCache events.
```