### PR TITLE
sysdump: respect worker count and collect Cilium profiling data as first task

### DIFF
--- a/cilium-cli/sysdump/defaults.go
+++ b/cilium-cli/sysdump/defaults.go
@@ -4,7 +4,6 @@
 package sysdump
 
 import (
-	"runtime"
 	"time"
 )
 
@@ -52,8 +51,8 @@ const (
 )
 
 var (
-	// DefaultWorkerCount is initialized to the machine's available CPUs.
-	DefaultWorkerCount = runtime.NumCPU()
+	// DefaultWorkerCount is the default number of parallel workers for sysdump collection.
+	DefaultWorkerCount = 20
 
 	// DefaultCopyRetryLimit limits retries done while copying files from pods
 	DefaultCopyRetryLimit = 100

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -1683,7 +1683,7 @@ func (c *Collector) Run() error {
 
 		// Adjust the worker count to make enough headroom for tasks that submit sub-tasks.
 		// This is necessary because 'Submit' is blocking.
-		wc := 1
+		wc := max(1, c.Options.WorkerCount)
 		if t.CreatesSubtasks {
 			wc++
 		}

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -1227,20 +1227,6 @@ func (c *Collector) Run() error {
 		},
 		{
 			CreatesSubtasks: true,
-			Description:     "Collecting profiling data from Cilium pods",
-			Quick:           false,
-			Task: func(_ context.Context) error {
-				if !c.Options.Profiling {
-					return nil
-				}
-				if err := c.SubmitProfilingGopsSubtasks(c.CiliumPods, ciliumAgentContainerName); err != nil {
-					return fmt.Errorf("failed to collect profiling data from Cilium pods: %w", err)
-				}
-				return nil
-			},
-		},
-		{
-			CreatesSubtasks: true,
 			Description:     "Collecting profiling data from Cilium Operator pods",
 			Quick:           false,
 			Task: func(_ context.Context) error {
@@ -1456,6 +1442,19 @@ func (c *Collector) Run() error {
 		tasks = append(tasks, ciliumTasks...)
 
 		serialTasks = append(serialTasks, Task{
+			CreatesSubtasks: true,
+			Description:     "Collecting profiling data from Cilium pods",
+			Quick:           false,
+			Task: func(_ context.Context) error {
+				if !c.Options.Profiling {
+					return nil
+				}
+				if err := c.SubmitProfilingGopsSubtasks(c.CiliumPods, ciliumAgentContainerName); err != nil {
+					return fmt.Errorf("failed to collect profiling data from Cilium pods: %w", err)
+				}
+				return nil
+			},
+		}, Task{
 			CreatesSubtasks: true,
 			Description:     "Collecting tracing data from Cilium pods",
 			Quick:           false,


### PR DESCRIPTION
The first two commits modify the sysdump collection logic to actually respect the configured worker count, while the third moves again the collection of Cilium profiling data as first task to prevent it from being impacted by the other sysdump collection tasks. Refer to the individual commit messages for additional details.
