### PR TITLE
bpf:nat: avoid SNAT from tracking wireguard

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1540,7 +1540,7 @@ skip_host_firewall:
 	 * encrypted WireGuard UDP packets), we check whether the mark
 	 * is set before the redirect.
 	 */
-	if ((ctx->mark & MARK_MAGIC_WG_ENCRYPTED) != MARK_MAGIC_WG_ENCRYPTED) {
+	if (!ctx_mark_is_wireguard(ctx)) {
 		ret = wg_maybe_redirect_to_encrypt(ctx, proto);
 		if (ret == CTX_ACT_REDIRECT)
 			return ret;

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1630,7 +1630,7 @@ skip_egress_gateway:
 #endif
 
 #ifdef ENABLE_NODEPORT
-	if (!ctx_snat_done(ctx) && !ctx_is_overlay(ctx)) {
+	if (!ctx_snat_done(ctx) && !ctx_is_overlay(ctx) && !ctx_mark_is_wireguard(ctx)) {
 		/*
 		 * handle_nat_fwd tail calls in the majority of cases,
 		 * so control might never return to this program.

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -262,6 +262,14 @@ static __always_inline bool ctx_is_overlay(const struct __sk_buff *ctx)
 	return (ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_OVERLAY;
 }
 
+static __always_inline bool ctx_mark_is_wireguard(const struct __sk_buff *ctx)
+{
+	if (!is_defined(ENABLE_WIREGUARD))
+		return false;
+
+	return (ctx->mark & MARK_MAGIC_WG_ENCRYPTED) == MARK_MAGIC_WG_ENCRYPTED;
+}
+
 #ifdef ENABLE_EGRESS_GATEWAY_COMMON
 static __always_inline void ctx_egw_done_set(struct __sk_buff *ctx)
 {


### PR DESCRIPTION
Commits:

* `moving MARK_MAGIC_WG_ENCRYPTED check into a separate function`: simple refactors of the check to reuse the function later;
* `bpf:nat: skip SNAT in to-netdev for WireGuard traffic`: similarly as we did in #31082 for Overlay traffic, here we don't want our SNAT engine to track our wireguard-related traffic. This can happen when the node-to-node IPv4 address is equal to [IPV4_MASQUERADE](https://github.com/cilium/cilium/blob/44ec948479bb7e4511ec39f1e0d19d794ca1fba3/bpf/lib/nat.h#L565) (example below), or equal to IPV4_DIRECT_ROUTING. The advantage is that in this case wg-encrypted traffic has already been marked, so we don't need additional logic.

```c
#if defined(ENABLE_MASQUERADE_IPV4) && defined(IS_BPF_HOST)
	if (tuple->saddr == IPV4_MASQUERADE) {
		target->addr = IPV4_MASQUERADE;
		target->needs_ct = true;
		return NAT_NEEDED;
	}
...
```

This has minor impact on the nat map, as prior to the patch we just noticed the two additional entries for Wireguard:

```bash
UDP OUT 172.18.0.4:51871 -> 172.18.0.3:51871 XLATE_SRC 172.18.0.4:51871 Created=13606sec ago NeedsCT=1
UDP IN 172.18.0.3:51871 -> 172.18.0.4:51871 XLATE_DST 172.18.0.4:51871 Created=13606sec ago NeedsCT=1
```

Differently than for the overlay, right now we're using the same well-known 51871 source and destination port, thus only `2 * node-to-node-combination` could potentially be inserted in the map. Still, this helps preventing this. 

Part of: #34089

```release-note
Skip WireGuard traffic in the BPF SNAT processing, slightly reducing pressure on the BPF Connection tracking and NAT maps.
```