### PR TITLE
iptables: Fix data race in iptables manager

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -256,6 +256,8 @@ type Manager struct {
 	cfg       Config
 	sharedCfg SharedConfig
 
+	argsInit *lock.StoppableWaitGroup
+
 	// anything that can trigger a reconciliation
 	reconcilerParams reconcilerParams
 
@@ -302,6 +304,7 @@ func newIptablesManager(p params) datapath.IptablesManager {
 		sysctl:     p.Sysctl,
 		cfg:        p.Cfg,
 		sharedCfg:  p.SharedCfg,
+		argsInit:   lock.NewStoppableWaitGroup(),
 		reconcilerParams: reconcilerParams{
 			clock:          clock.RealClock{},
 			localNodeStore: p.LocalNodeStore,
@@ -315,12 +318,11 @@ func newIptablesManager(p params) datapath.IptablesManager {
 		cniConfigManager: p.CNIConfigManager,
 	}
 
-	argsInit := make(chan struct{})
-
 	// init iptables/ip6tables wait arguments before using them in the reconciler or in the manager (e.g: GetProxyPorts)
+	iptMgr.argsInit.Add()
 	p.Lifecycle.Append(cell.Hook{
 		OnStart: func(ctx cell.HookContext) error {
-			defer close(argsInit)
+			defer iptMgr.argsInit.Done()
 			ip4tables.initArgs(ctx, int(p.Cfg.IPTablesLockTimeout/time.Second))
 			if p.SharedCfg.EnableIPv6 {
 				ip6tables.initArgs(ctx, int(p.Cfg.IPTablesLockTimeout/time.Second))
@@ -329,13 +331,20 @@ func newIptablesManager(p params) datapath.IptablesManager {
 		},
 	})
 
+	// init haveIp6tables argument before using it in a reconciliation loop
+	iptMgr.argsInit.Add()
 	p.Lifecycle.Append(iptMgr)
 
 	p.JobGroup.Add(
 		job.OneShot("iptables-reconciliation-loop", func(ctx context.Context, health cell.Health) error {
-			// each job runs in an independent goroutine, so we need to explicitly wait for
-			// iptables arguments initialization before starting the reconciler.
-			<-argsInit
+			// each job runs in an independent goroutine, so we need to explicitly wait for both
+			// ip{4,6}tables and haveIp6tables initialization before starting the reconciler.
+			iptMgr.argsInit.Stop()
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-iptMgr.argsInit.WaitChannel():
+			}
 			return reconciliationLoop(
 				ctx, p.Logger, health,
 				iptMgr.sharedCfg.InstallIptRules, &iptMgr.reconcilerParams,
@@ -352,6 +361,8 @@ func newIptablesManager(p params) datapath.IptablesManager {
 
 // Start initializes the iptables manager and checks for iptables kernel modules availability.
 func (m *Manager) Start(ctx cell.HookContext) error {
+	defer m.argsInit.Done()
+
 	if os.Getenv("CILIUM_PREPEND_IPTABLES_CHAIN") != "" {
 		m.logger.Warning("CILIUM_PREPEND_IPTABLES_CHAIN env var has been deprecated. Please use 'CILIUM_PREPEND_IPTABLES_CHAINS' " +
 			"env var or '--prepend-iptables-chains' command line flag instead")


### PR DESCRIPTION
The haveIp6tables parameter is initially set to true, but its initializiation is completed in the manager Start hook.  That hook is executed in its onw goroutine, while another one runs the iptables reconciler oneshot job. Those two goroutines may run concurrently thus leading to a data race when accessing the haveIp6tables parameter.

Since that parameter enables or disable the support for IPv6 rules, we must enforce an ordering between the two goroutines, specifically we must force the reconciler to wait for the initialization to be completed.

Therefore, use a wait group to force the reconciler to wait for both the ip{4,6}tables wait arguments and haveIp6tables config parameter to be fully initialized.