### PR TITLE
Improve Network Policy Validation

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -49,6 +49,23 @@ spec:
           metadata:
             type: object
           spec:
+            anyOf:
+            - properties:
+                ingress: {}
+              required:
+              - ingress
+            - properties:
+                ingressDeny: {}
+              required:
+              - ingressDeny
+            - properties:
+                egress: {}
+              required:
+              - egress
+            - properties:
+                egressDeny: {}
+              required:
+              - egressDeny
             description: Spec is the desired Cilium specific rule specification.
             oneOf:
             - properties:
@@ -3481,6 +3498,23 @@ spec:
           specs:
             description: Specs is a list of desired Cilium specific rule specification.
             items:
+              anyOf:
+              - properties:
+                  ingress: {}
+                required:
+                - ingress
+              - properties:
+                  ingressDeny: {}
+                required:
+                - ingressDeny
+              - properties:
+                  egress: {}
+                required:
+                - egress
+              - properties:
+                  egressDeny: {}
+                required:
+                - egressDeny
               description: |-
                 Rule is a policy rule which must be applied to all endpoints which match the
                 labels contained in the endpointSelector

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -52,6 +52,23 @@ spec:
           metadata:
             type: object
           spec:
+            anyOf:
+            - properties:
+                ingress: {}
+              required:
+              - ingress
+            - properties:
+                ingressDeny: {}
+              required:
+              - ingressDeny
+            - properties:
+                egress: {}
+              required:
+              - egress
+            - properties:
+                egressDeny: {}
+              required:
+              - egressDeny
             description: Spec is the desired Cilium specific rule specification.
             oneOf:
             - properties:
@@ -3484,6 +3501,23 @@ spec:
           specs:
             description: Specs is a list of desired Cilium specific rule specification.
             items:
+              anyOf:
+              - properties:
+                  ingress: {}
+                required:
+                - ingress
+              - properties:
+                  ingressDeny: {}
+                required:
+                - ingressDeny
+              - properties:
+                  egress: {}
+                required:
+                - egress
+              - properties:
+                  egressDeny: {}
+                required:
+                - egressDeny
               description: |-
                 Rule is a policy rule which must be applied to all endpoints which match the
                 labels contained in the endpointSelector

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
@@ -307,6 +307,8 @@ metadata:
   name: cnp-test-1
 spec:
   endpointSelector: {}
+  ingress: 
+    - {}
 `),
 			clusterwide: false,
 			err:         ErrTopLevelDescriptionFound,
@@ -320,6 +322,8 @@ metadata:
   name: cnp-test-1
 spec:
   endpointSelector: {}
+  ingress: 
+    - {}
 `),
 			clusterwide: false,
 			err:         nil,
@@ -334,6 +338,8 @@ metadata:
   name: ccnp-test-1
 spec:
   nodeSelector: {}
+  ingress: 
+    - {}
 `),
 			clusterwide: true,
 			err:         ErrTopLevelDescriptionFound,
@@ -347,6 +353,8 @@ metadata:
   name: ccnp-test-1
 spec:
   nodeSelector: {}
+  ingress: 
+    - {}
 `),
 			clusterwide: true,
 			err:         nil,
@@ -362,6 +370,8 @@ metadata:
   name: ccnp-test-1
 spec:
   endpointSelector: {}
+  ingress: 
+    - {}
   bar: baz
 `),
 			clusterwide: false,
@@ -379,6 +389,8 @@ metadata:
   name: ccnp-test-1
 spec:
   nodeSelector: {}
+  ingress: 
+    - {}
   bar: baz
 `),
 			clusterwide: true,

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -76,7 +76,7 @@ type Rule struct {
 	// Ingress is a list of IngressRule which are enforced at ingress.
 	// If omitted or empty, this rule does not apply at ingress.
 	//
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:AnyOf
 	Ingress []IngressRule `json:"ingress,omitempty"`
 
 	// IngressDeny is a list of IngressDenyRule which are enforced at ingress.
@@ -84,13 +84,13 @@ type Rule struct {
 	// rules in the 'ingress' field.
 	// If omitted or empty, this rule does not apply at ingress.
 	//
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:AnyOf
 	IngressDeny []IngressDenyRule `json:"ingressDeny,omitempty"`
 
 	// Egress is a list of EgressRule which are enforced at egress.
 	// If omitted or empty, this rule does not apply at egress.
 	//
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:AnyOf
 	Egress []EgressRule `json:"egress,omitempty"`
 
 	// EgressDeny is a list of EgressDenyRule which are enforced at egress.
@@ -98,7 +98,7 @@ type Rule struct {
 	// rules in the 'egress' field.
 	// If omitted or empty, this rule does not apply at egress.
 	//
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:AnyOf
 	EgressDeny []EgressDenyRule `json:"egressDeny,omitempty"`
 
 	// Labels is a list of optional strings which can be used to
@@ -229,6 +229,12 @@ func (r *Rule) WithEgressRules(rules []EgressRule) *Rule {
 // WithEgressDenyRules configures the Rule with the specified rules.
 func (r *Rule) WithEgressDenyRules(rules []EgressDenyRule) *Rule {
 	r.EgressDeny = rules
+	return r
+}
+
+// WithEnableDefaultDeny configures the Rule to enable default deny.
+func (r *Rule) WithEnableDefaultDeny(ingress, egress bool) *Rule {
+	r.EnableDefaultDeny = DefaultDenyConfig{&ingress, &egress}
 	return r
 }
 

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -36,6 +36,10 @@ var (
 // Note: this function is called from both the operator and the agent;
 // make sure any configuration flags are bound in **both** binaries.
 func (r *Rule) Sanitize() error {
+	if len(r.Ingress) == 0 && len(r.IngressDeny) == 0 && len(r.Egress) == 0 && len(r.EgressDeny) == 0 {
+		return fmt.Errorf("rule must have at least one of Ingress, IngressDeny, Egress, EgressDeny")
+	}
+
 	if option.Config.EnableNonDefaultDenyPolicies {
 		// Fill in the default traffic posture of this Rule.
 		// Default posture is per-direction (ingress or egress),
@@ -53,7 +57,6 @@ func (r *Rule) Sanitize() error {
 		// Since Non Default Deny Policies is disabled by flag, set EnableDefaultDeny to true
 		r.EnableDefaultDeny.Egress = &enableDefaultDenyDefault
 		r.EnableDefaultDeny.Ingress = &enableDefaultDenyDefault
-
 	}
 
 	if r.EndpointSelector.LabelSelector == nil && r.NodeSelector.LabelSelector == nil {

--- a/pkg/policy/cell/policy_importer_test.go
+++ b/pkg/policy/cell/policy_importer_test.go
@@ -237,6 +237,8 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 										},
 									},
 								},
+								Ingress: []policyapi.IngressRule{{}},
+								Egress:  nil,
 							},
 						},
 					},
@@ -255,7 +257,7 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 								},
 							},
 						}).
-						WithIngressRules(nil).
+						WithIngressRules([]policyapi.IngressRule{{}}).
 						WithEgressRules(nil).
 						WithLabels(utils.GetPolicyLabels(
 							"production",
@@ -286,8 +288,8 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 								},
 							},
 						},
-						Ingress:     nil,
-						Egress:      nil,
+						Ingress:     []policyapi.IngressRule{{}},
+						Egress:      []policyapi.EgressRule{{}},
 						Labels:      lbls,
 						Description: "",
 					},
@@ -308,6 +310,8 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 										},
 									},
 								},
+								Ingress: []policyapi.IngressRule{{}},
+								Egress:  nil,
 							},
 						},
 					},
@@ -326,7 +330,7 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 								},
 							},
 						}).
-						WithIngressRules(nil).
+						WithIngressRules([]policyapi.IngressRule{{}}).
 						WithEgressRules(nil).
 						WithLabels(utils.GetPolicyLabels(
 							"production",
@@ -355,8 +359,8 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 								},
 							},
 						},
-						Ingress:     nil,
-						Egress:      nil,
+						Ingress:     []policyapi.IngressRule{{}},
+						Egress:      []policyapi.EgressRule{{}},
 						Labels:      utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy),
 						Description: "",
 					},
@@ -377,7 +381,8 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 										},
 									},
 								},
-								Labels: labels.ParseLabelArray("foo=bar"),
+								Labels:  labels.ParseLabelArray("foo=bar"),
+								Ingress: []policyapi.IngressRule{{}},
 							},
 						},
 					},
@@ -398,7 +403,7 @@ func TestAddCiliumNetworkPolicyByLabels(t *testing.T) {
 								},
 							},
 						}).
-						WithIngressRules(nil).
+						WithIngressRules([]policyapi.IngressRule{{}}).
 						WithEgressRules(nil).
 						WithLabels(lbls),
 				})

--- a/pkg/policy/groups/helpers_test.go
+++ b/pkg/policy/groups/helpers_test.go
@@ -31,6 +31,8 @@ func getSamplePolicy(name, ns string) *cilium_v2.CiliumNetworkPolicy {
 				},
 			},
 		},
+		Ingress: []api.IngressRule{{}},
+		Egress:  []api.EgressRule{{}},
 	}
 	return cnp
 }

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1156,8 +1156,8 @@ func TestL3RuleLabels(t *testing.T) {
 		"rule0": {
 			EndpointSelector: endpointSelectorA,
 			Labels:           ruleLabels["rule0"],
-			Ingress:          []api.IngressRule{},
-			Egress:           []api.EgressRule{},
+			Ingress:          []api.IngressRule{{}},
+			Egress:           []api.EgressRule{{}},
 		},
 		"rule1": {
 			EndpointSelector: endpointSelectorA,
@@ -1282,8 +1282,8 @@ func TestL4RuleLabels(t *testing.T) {
 		"rule0": {
 			EndpointSelector: endpointSelectorA,
 			Labels:           ruleLabels["rule0"],
-			Ingress:          []api.IngressRule{},
-			Egress:           []api.EgressRule{},
+			Ingress:          []api.IngressRule{{}},
+			Egress:           []api.EgressRule{{}},
 		},
 
 		"rule1": {


### PR DESCRIPTION
Description:  https://github.com/cilium/cilium/issues/35558#issuecomment-2513354154

Fixes: https://github.com/cilium/cilium/issues/35558

```release-note
Improves Network Policy validation and default deny behavior. Policies now require at least one of Ingress, IngressDeny, Egress, or EgressDeny to be defined.
```

