### PR TITLE
[v1.16] backport of #35890 (endpoint: don't start DNS history trigger when parsing endpoint)

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -943,8 +943,6 @@ func parseEndpoint(ctx context.Context, owner regeneration.Owner, policyGetter p
 		return nil, fmt.Errorf("failed to parse restored endpoint: %w", err)
 	}
 
-	ep.initDNSHistoryTrigger()
-
 	// Validate the options that were parsed
 	ep.SetDefaultOpts(ep.Options)
 


### PR DESCRIPTION
 * [x] #35890 (@squeed)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 35890
```

Fixes: #35080 