### PR TITLE
v1.15 Backports 2024-11-12

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -140,6 +140,7 @@ jobs:
             key-two: 'gcm(aes)'
             key-type-one: ''
             key-type-two: '+'
+            kvstore: 'true'
 
           - name: '4'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -154,6 +155,7 @@ jobs:
             key-two: 'gcm(aes)'
             key-type-one: ''
             key-type-two: ''
+            kvstore: 'true'
 
           - name: '5'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -227,6 +229,8 @@ jobs:
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
           ingress-controller: ${{ matrix.ingress-controller }}
+          # Mutual auth doesn't currently work in kvstore mode.
+          mutual-auth: ${{ matrix.kvstore != 'true' }}
           misc: ${{ matrix.misc }}
 
       - name: Install Cilium CLI
@@ -256,6 +260,19 @@ jobs:
           kind-params: "${{ steps.kind-params.outputs.params }}"
           kind-image: ${{ env.KIND_K8S_IMAGE }}
 
+      - name: Start Cilium KVStore
+        id: kvstore
+        if: matrix.kvstore == 'true'
+        run: |
+          make kind-kvstore-start KVSTORE_POD_NAME=kvstore KVSTORE_POD_PORT=2378
+
+          IP=$(kubectl --namespace kube-system get pod kvstore -o jsonpath='{.status.hostIP}')
+          echo "config= \
+            --set=etcd.enabled=true \
+            --set=identityAllocationMode=kvstore \
+            --set=etcd.endpoints[0]=http://${IP}:2378 \
+          " >> $GITHUB_OUTPUT
+
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
@@ -283,9 +300,12 @@ jobs:
             --from-literal=keys="3${{ matrix.key-type-one }} ${key}"
 
           export CILIUM_CLI_MODE=helm
-          ./cilium-cli install ${{ steps.cilium-config.outputs.config }}
-          kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-server --timeout=300s
-          kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-agent --timeout=300s
+          ./cilium-cli install ${{ steps.cilium-config.outputs.config }} ${{ steps.kvstore.outputs.config }}
+
+          if [[ "${{ matrix.kvstore }}" != "true" ]]; then
+            kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-server --timeout=300s
+            kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-agent --timeout=300s
+          fi
 
           ./cilium-cli status --wait
           kubectl get pods --all-namespaces -o wide
@@ -381,6 +401,12 @@ jobs:
           ./cilium-cli status
           mkdir -p cilium-sysdumps
           ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
+
+          if [ "${{ matrix.kvstore }}" == "true" ]; then
+            echo
+            echo "# Retrieving Cilium etcd logs"
+            kubectl -n kube-system logs kvstore
+          fi
 
       - name: Upload artifacts
         if: ${{ !success() }}

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -124,6 +124,7 @@ jobs:
             kpr: 'false'
             tunnel: 'disabled'
             endpoint-routes: 'true'
+            kvstore: 'true'
 
           - name: '4'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -434,6 +435,22 @@ jobs:
 
             mkdir -p cilium-junits
 
+      - name: Start Cilium KVStore
+        if: matrix.kvstore == 'true'
+        uses: cilium/little-vm-helper@97c89f004bd0ab4caeacfe92ebc956e13e362e6b # v0.0.19
+        with:
+          provision: 'false'
+          cmd: |
+            cd /host/
+            make kind-kvstore-start KVSTORE_POD_NAME=kvstore KVSTORE_POD_PORT=2378
+
+            IP=\$(kubectl --namespace kube-system get pod kvstore -o jsonpath='{.status.hostIP}')
+            echo " \
+              --set=etcd.enabled=true \
+              --set=identityAllocationMode=kvstore \
+              --set=etcd.endpoints[0]=http://\${IP}:2378 \
+            " | tr -s ' ' > etcd.config
+
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
@@ -464,10 +481,12 @@ jobs:
 
             if ${{ matrix.skip-upgrade != 'true' }}; then
               CILIUM_CLI_MODE=helm ./cilium-cli install \
-              ${{ steps.cilium-stable-config.outputs.config }}
+              ${{ steps.cilium-stable-config.outputs.config }} \
+              \$(cat etcd.config)
             else
               CILIUM_CLI_MODE=helm ./cilium-cli install \
-              ${{ steps.cilium-newest-config.outputs.config }}
+              ${{ steps.cilium-newest-config.outputs.config }} \
+              \$(cat etcd.config)
             fi
 
             ./cilium-cli status --wait
@@ -496,7 +515,8 @@ jobs:
             cd /host/
 
             CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
-              ${{ steps.cilium-newest-config.outputs.config }}
+              ${{ steps.cilium-newest-config.outputs.config }} \
+              \$(cat etcd.config)
 
             ./cilium-cli status --wait --wait-duration=10m
             kubectl get pods --all-namespaces -o wide
@@ -544,7 +564,8 @@ jobs:
             cd /host/
 
             CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
-              ${{ steps.cilium-stable-config.outputs.config }}
+              ${{ steps.cilium-stable-config.outputs.config }} \
+              \$(cat etcd.config)
 
             ./cilium-cli status --wait --wait-duration=10m
             kubectl get pods --all-namespaces -o wide
@@ -595,6 +616,12 @@ jobs:
             ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
             # To debug https://github.com/cilium/cilium/issues/26062
             head -n -0 /proc/buddyinfo /proc/pagetypeinfo
+
+            if [ "${{ matrix.kvstore }}" == "true" ]; then
+              echo
+              echo "# Retrieving Cilium etcd logs"
+              kubectl -n kube-system logs kvstore
+            fi
 
       - name: Upload artifacts
         if: ${{ !success() }}

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -118,6 +118,7 @@ jobs:
             tunnel: 'disabled'
             encryption: 'ipsec'
             endpoint-routes: 'true'
+            kvstore: 'true'
 
           - config: '6.1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -127,6 +128,7 @@ jobs:
             tunnel: 'vxlan'
             encryption: 'ipsec'
             endpoint-routes: 'false'
+            kvstore: 'true'
 
           - config: '6.6'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -320,6 +322,19 @@ jobs:
           kind-params: "${{ steps.kind-params.outputs.params }}"
           kind-image: ${{ env.KIND_K8S_IMAGE }}
 
+      - name: Start Cilium KVStore
+        id: kvstore
+        if: ${{ steps.vars.outputs.downgrade_version != '' && matrix.kvstore == 'true' }}
+        run: |
+          make kind-kvstore-start KVSTORE_POD_NAME=kvstore KVSTORE_POD_PORT=2378
+
+          IP=$(kubectl --namespace kube-system get pod kvstore -o jsonpath='{.status.hostIP}')
+          echo "config= \
+            --set=etcd.enabled=true \
+            --set=identityAllocationMode=kvstore \
+            --set=etcd.endpoints[0]=http://${IP}:2378 \
+          " >> $GITHUB_OUTPUT
+
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
@@ -353,7 +368,8 @@ jobs:
           mkdir -p cilium-junits
 
           CILIUM_CLI_MODE=helm ./cilium-cli install \
-            ${{ steps.cilium-stable-config.outputs.config }}
+            ${{ steps.cilium-stable-config.outputs.config }} \
+            ${{ steps.kvstore.outputs.config }}
 
           ./cilium-cli status --wait
           kubectl get pods --all-namespaces -o wide
@@ -369,7 +385,8 @@ jobs:
         shell: bash
         run: |
           CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
-            ${{ steps.cilium-newest-config.outputs.config }}
+            ${{ steps.cilium-newest-config.outputs.config }} \
+            ${{ steps.kvstore.outputs.config }}
 
           ./cilium-cli status --wait
           kubectl get pods --all-namespaces -o wide
@@ -391,7 +408,8 @@ jobs:
         shell: bash
         run: |
           CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
-            ${{ steps.cilium-stable-config.outputs.config }}
+            ${{ steps.cilium-stable-config.outputs.config }} \
+            ${{ steps.kvstore.outputs.config }}
 
           ./cilium-cli status --wait
           kubectl get pods --all-namespaces -o wide
@@ -413,6 +431,12 @@ jobs:
           ./cilium-cli status
           mkdir -p cilium-sysdumps
           ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
+
+          if [ "${{ matrix.kvstore }}" == "true" ]; then
+            echo
+            echo "# Retrieving Cilium etcd logs"
+            kubectl -n kube-system logs kvstore
+          fi
 
       - name: Upload artifacts
         if: ${{ steps.vars.outputs.downgrade_version != '' && !success() }}

--- a/Makefile
+++ b/Makefile
@@ -763,6 +763,32 @@ kind-egressgw-install-cilium: kind-ready ## Install a local Cilium version into 
 		--version= \
 		>/dev/null 2>&1 &
 
+KVSTORE_POD_NAME ?= "kvstore"
+KVSTORE_POD_PORT ?= "2378"
+
+.PHONY: kind-kvstore-install-cilium
+kind-kvstore-install-cilium: kind-ready kind-kvstore-start ## Install a local Cilium version into the cluster, configured in kvstore mode.
+	$(MAKE) kind-install-cilium KIND_VALUES_FILES="\
+		$(KIND_VALUES_FILES) \
+		--set etcd.enabled=true \
+		--set etcd.endpoints[0]=http://$(shell kubectl --namespace kube-system get pod $(KVSTORE_POD_NAME) -o jsonpath='{.status.hostIP}'):$(KVSTORE_POD_PORT) \
+		--set identityAllocationMode=kvstore \
+	"
+
+.PHONY: kind-kvstore-start
+kind-kvstore-start: ## Start an etcd pod serving as Cilium's kvstore
+	kubectl --namespace kube-system get pod $(KVSTORE_POD_NAME) >/dev/null 2>/dev/null || \
+		kubectl --namespace kube-system run $(KVSTORE_POD_NAME) --image $(ETCD_IMAGE) \
+			--overrides='{ "apiVersion": "v1", "spec": { "hostNetwork": true, "nodeSelector": {"node-role.kubernetes.io/control-plane": ""},  "tolerations": [{ "operator": "Exists" }] }}' \
+			-- etcd --listen-client-urls=http://0.0.0.0:$(KVSTORE_POD_PORT) --advertise-client-urls=http://0.0.0.0:$(KVSTORE_POD_PORT)
+
+	kubectl --namespace kube-system wait --for=condition=Ready pod/$(KVSTORE_POD_NAME)
+
+.PHONY: kind-kvstore-stop
+kind-kvstore-stop: ## Stop the etcd pod serving as Cilium's kvstore
+	kubectl --namespace kube-system delete pod $(KVSTORE_POD_NAME) --ignore-not-found
+	kubectl --namespace kube-system wait --for=delete pod/$(KVSTORE_POD_NAME)
+
 .PHONY: kind-uninstall-cilium
 kind-uninstall-cilium: ## Uninstall Cilium from the cluster.
 	@echo "  UNINSTALL cilium"


### PR DESCRIPTION
 * [x] #35646 (@giorio94) :warning: resolved conflicts
    * :information_source: Applied the changes to the main Makefile, rather than Makefile.kind that did not exist in the v1.15 tree.
 * [x] #35679 (@giorio94) :warning: resolved conflicts
    * :information_source: Hit multiple conflicts due to different surrounding context. Adapted the etcd setup logic to be run within the LVH context. Additionally skipped testing kvstore in combination with WireGuard, as v1.15 and earlier are affected by bugs potentially causing connection disruption upon agent restart in this combination (cilium/cilium#31985, cilium/cilium#31979).

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 35646 35679
```
