### PR TITLE
v1.14 Backports 2024-11-12

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -125,6 +125,7 @@ jobs:
             kpr: 'false'
             tunnel: 'disabled'
             endpoint-routes: 'true'
+            kvstore: 'true'
 
           - name: '4'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -280,6 +281,7 @@ jobs:
             encryption: 'wireguard'
             encryption-node: 'false'
             host-fw: 'true'
+            kvstore: 'true'
 
     timeout-minutes: 60
     steps:
@@ -324,6 +326,8 @@ jobs:
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
           ingress-controller: ${{ matrix.ingress-controller }}
+          # Mutual auth doesn't currently work in kvstore mode.
+          mutual-auth: ${{ matrix.kvstore != 'true' }}
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@6977c4a640ad45da3a95eb12054497f2bdd22c48 # v0.16.19
@@ -351,6 +355,19 @@ jobs:
           kind-params: "${{ steps.kind-params.outputs.params }}"
           kind-image: ${{ env.KIND_K8S_IMAGE }}
 
+      - name: Start Cilium KVStore
+        id: kvstore
+        if: matrix.kvstore == 'true'
+        run: |
+          make kind-kvstore-start KVSTORE_POD_NAME=kvstore KVSTORE_POD_PORT=2378
+
+          IP=$(kubectl --namespace kube-system get pod kvstore -o jsonpath='{.status.hostIP}')
+          echo "config= \
+            --set=etcd.enabled=true \
+            --set=identityAllocationMode=kvstore \
+            --set=etcd.endpoints[0]=http://${IP}:2378 \
+          " >> $GITHUB_OUTPUT
+
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
@@ -368,9 +385,12 @@ jobs:
           kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
 
           export CILIUM_CLI_MODE=helm
-          ./cilium-cli install ${{ steps.cilium-config.outputs.config }}
-          kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-server --timeout=300s
-          kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-agent --timeout=300s
+          ./cilium-cli install ${{ steps.cilium-config.outputs.config }} ${{ steps.kvstore.outputs.config }}
+
+          if [[ "${{ matrix.kvstore }}" != "true" ]]; then
+            kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-server --timeout=300s
+            kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-agent --timeout=300s
+          fi
 
           ./cilium-cli status --wait
           kubectl get pods --all-namespaces -o wide
@@ -415,6 +435,12 @@ jobs:
           ./cilium-cli status
           mkdir -p cilium-sysdumps
           ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
+
+          if [ "${{ matrix.kvstore }}" == "true" ]; then
+            echo
+            echo "# Retrieving Cilium etcd logs"
+            kubectl -n kube-system logs kvstore
+          fi
 
       - name: Upload artifacts
         if: ${{ !success() }}

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -143,6 +143,7 @@ jobs:
             key-two: 'gcm(aes)'
             key-type-one: ''
             key-type-two: '+'
+            kvstore: 'true'
 
           - name: '4'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -157,6 +158,7 @@ jobs:
             key-two: 'gcm(aes)'
             key-type-one: ''
             key-type-two: ''
+            kvstore: 'true'
 
     timeout-minutes: 75
     steps:
@@ -201,6 +203,8 @@ jobs:
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
           ingress-controller: ${{ matrix.ingress-controller }}
+          # Mutual auth doesn't currently work in kvstore mode.
+          mutual-auth: ${{ matrix.kvstore != 'true' }}
           misc: ${{ matrix.misc }}
 
       - name: Install Cilium CLI
@@ -229,6 +233,19 @@ jobs:
           kind-params: "${{ steps.kind-params.outputs.params }}"
           kind-image: ${{ env.KIND_K8S_IMAGE }}
 
+      - name: Start Cilium KVStore
+        id: kvstore
+        if: matrix.kvstore == 'true'
+        run: |
+          make kind-kvstore-start KVSTORE_POD_NAME=kvstore KVSTORE_POD_PORT=2378
+
+          IP=$(kubectl --namespace kube-system get pod kvstore -o jsonpath='{.status.hostIP}')
+          echo "config= \
+            --set=etcd.enabled=true \
+            --set=identityAllocationMode=kvstore \
+            --set=etcd.endpoints[0]=http://${IP}:2378 \
+          " >> $GITHUB_OUTPUT
+
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
@@ -256,9 +273,12 @@ jobs:
             --from-literal=keys="3${{ matrix.key-type-one }} ${key}"
 
           export CILIUM_CLI_MODE=helm
-          ./cilium-cli install ${{ steps.cilium-config.outputs.config }}
-          kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-server --timeout=300s
-          kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-agent --timeout=300s
+          ./cilium-cli install ${{ steps.cilium-config.outputs.config }} ${{ steps.kvstore.outputs.config }}
+
+          if [[ "${{ matrix.kvstore }}" != "true" ]]; then
+            kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-server --timeout=300s
+            kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-agent --timeout=300s
+          fi
 
           ./cilium-cli status --wait
           kubectl get pods --all-namespaces -o wide
@@ -354,6 +374,12 @@ jobs:
           ./cilium-cli status
           mkdir -p cilium-sysdumps
           ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
+
+          if [ "${{ matrix.kvstore }}" == "true" ]; then
+            echo
+            echo "# Retrieving Cilium etcd logs"
+            kubectl -n kube-system logs kvstore
+          fi
 
       - name: Upload artifacts
         if: ${{ !success() }}

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -121,6 +121,7 @@ jobs:
             tunnel: 'disabled'
             encryption: 'ipsec'
             endpoint-routes: 'true'
+            kvstore: 'true'
 
           - config: '6.1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -132,6 +133,7 @@ jobs:
             endpoint-routes: 'false'
             # https://github.com/cilium/cilium/issues/29805#issuecomment-1855600171
             ipv6: 'false'
+            kvstore: 'true'
 
           - config: '6.6'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -325,6 +327,19 @@ jobs:
           kind-params: "${{ steps.kind-params.outputs.params }}"
           kind-image: ${{ env.KIND_K8S_IMAGE }}
 
+      - name: Start Cilium KVStore
+        id: kvstore
+        if: ${{ steps.vars.outputs.downgrade_version != '' && matrix.kvstore == 'true' }}
+        run: |
+          make kind-kvstore-start KVSTORE_POD_NAME=kvstore KVSTORE_POD_PORT=2378
+
+          IP=$(kubectl --namespace kube-system get pod kvstore -o jsonpath='{.status.hostIP}')
+          echo "config= \
+            --set=etcd.enabled=true \
+            --set=identityAllocationMode=kvstore \
+            --set=etcd.endpoints[0]=http://${IP}:2378 \
+          " >> $GITHUB_OUTPUT
+
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
@@ -358,7 +373,8 @@ jobs:
           mkdir -p cilium-junits
 
           CILIUM_CLI_MODE=helm ./cilium-cli install \
-            ${{ steps.cilium-stable-config.outputs.config }}
+            ${{ steps.cilium-stable-config.outputs.config }} \
+            ${{ steps.kvstore.outputs.config }}
 
           ./cilium-cli status --wait
           kubectl get pods --all-namespaces -o wide
@@ -373,7 +389,8 @@ jobs:
         shell: bash
         run: |
           CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
-            ${{ steps.cilium-newest-config.outputs.config }}
+            ${{ steps.cilium-newest-config.outputs.config }} \
+            ${{ steps.kvstore.outputs.config }}
 
           ./cilium-cli status --wait
           kubectl get pods --all-namespaces -o wide
@@ -395,7 +412,8 @@ jobs:
         shell: bash
         run: |
           CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
-            ${{ steps.cilium-stable-config.outputs.config }}
+            ${{ steps.cilium-stable-config.outputs.config }} \
+            ${{ steps.kvstore.outputs.config }}
 
           ./cilium-cli status --wait
           kubectl get pods --all-namespaces -o wide
@@ -416,6 +434,12 @@ jobs:
           ./cilium-cli status
           mkdir -p cilium-sysdumps
           ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
+
+          if [ "${{ matrix.kvstore }}" == "true" ]; then
+            echo
+            echo "# Retrieving Cilium etcd logs"
+            kubectl -n kube-system logs kvstore
+          fi
 
       - name: Upload artifacts
         if: ${{ steps.vars.outputs.downgrade_version != '' && !success() }}

--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -119,7 +119,7 @@ makefile targets:
 For Linux and Mac OS
 ^^^^^^^^^^^^^^^^^^^^
 
-Makefile targets automate building Cilium images:
+Makefile targets automate building and installing Cilium images:
 
 * ``make kind-image``: Builds all Cilium images and loads them into the
   cluster.
@@ -149,6 +149,18 @@ code, in an pre-existing running Cilium container.
 
 * ``make kind-image-fast``: Builds all Cilium binaries and loads them into all
   kind clusters available in the host.
+
+Configuration for Cilium
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Makefile targets that install Cilium pass the following list of Helm
+values (YAML files) to the Cilium CLI.
+
+* ``contrib/testing/kind-common.yaml``: Shared between normal and fast installation modes.
+* ``contrib/testing/kind-values.yaml``: Used by normal installation mode.
+* ``contrib/testing/kind-fast.yaml``: Used by fast installation mode.
+* ``contrib/testing/kind-custom.yaml``: User defined custom values that are applied if
+  the file is present. The file is ignored by Git as specified in ``contrib/testing/.gitignore``.
 
 .. _configurations_for_clusters:
 

--- a/Makefile
+++ b/Makefile
@@ -680,6 +680,32 @@ kind-install-cilium: kind-ready ## Install a local Cilium version into the clust
 		--version= \
 		>/dev/null 2>&1 &
 
+KVSTORE_POD_NAME ?= "kvstore"
+KVSTORE_POD_PORT ?= "2378"
+
+.PHONY: kind-kvstore-install-cilium
+kind-kvstore-install-cilium: kind-ready kind-kvstore-start ## Install a local Cilium version into the cluster, configured in kvstore mode.
+	$(MAKE) kind-install-cilium KIND_VALUES_FILES="\
+		$(KIND_VALUES_FILES) \
+		--set etcd.enabled=true \
+		--set etcd.endpoints[0]=http://$(shell kubectl --namespace kube-system get pod $(KVSTORE_POD_NAME) -o jsonpath='{.status.hostIP}'):$(KVSTORE_POD_PORT) \
+		--set identityAllocationMode=kvstore \
+	"
+
+.PHONY: kind-kvstore-start
+kind-kvstore-start: ## Start an etcd pod serving as Cilium's kvstore
+	kubectl --namespace kube-system get pod $(KVSTORE_POD_NAME) >/dev/null 2>/dev/null || \
+		kubectl --namespace kube-system run $(KVSTORE_POD_NAME) --image $(ETCD_IMAGE) \
+			--overrides='{ "apiVersion": "v1", "spec": { "hostNetwork": true, "nodeSelector": {"node-role.kubernetes.io/control-plane": ""},  "tolerations": [{ "operator": "Exists" }] }}' \
+			-- etcd --listen-client-urls=http://0.0.0.0:$(KVSTORE_POD_PORT) --advertise-client-urls=http://0.0.0.0:$(KVSTORE_POD_PORT)
+
+	kubectl --namespace kube-system wait --for=condition=Ready pod/$(KVSTORE_POD_NAME)
+
+.PHONY: kind-kvstore-stop
+kind-kvstore-stop: ## Stop the etcd pod serving as Cilium's kvstore
+	kubectl --namespace kube-system delete pod $(KVSTORE_POD_NAME) --ignore-not-found
+	kubectl --namespace kube-system wait --for=delete pod/$(KVSTORE_POD_NAME)
+
 .PHONY: kind-uninstall-cilium
 kind-uninstall-cilium: ## Uninstall Cilium from the cluster.
 	@echo "  UNINSTALL cilium"

--- a/Makefile
+++ b/Makefile
@@ -574,6 +574,15 @@ kind-image: ## Build cilium and operator images and import them into kind.
 	$(MAKE) kind-image-agent
 	$(MAKE) kind-image-operator
 
+define KIND_VALUES_FAST_FILES
+--helm-values=$(ROOT_DIR)/contrib/testing/kind-common.yaml \
+--helm-values=$(ROOT_DIR)/contrib/testing/kind-fast.yaml
+endef
+
+ifneq ("$(wildcard $(ROOT_DIR)/contrib/testing/kind-custom.yaml)","")
+	KIND_VALUES_FAST_FILES := $(KIND_VALUES_FAST_FILES) --helm-values=$(ROOT_DIR)/contrib/testing/kind-custom.yaml
+endif
+
 .PHONY: kind-install-cilium-fast
 kind-install-cilium-fast: kind-ready ## Install a local Cilium version into the cluster.
 	@echo "  INSTALL cilium"
@@ -646,19 +655,28 @@ kind-image-fast-clustermesh-apiserver: kind-ready build-clustermesh-apiserver ##
 		done; \
 	done
 
+define KIND_VALUES_FILES
+--helm-values=$(ROOT_DIR)/contrib/testing/kind-common.yaml \
+--helm-values=$(ROOT_DIR)/contrib/testing/kind-values.yaml
+endef
+
+ifneq ("$(wildcard $(ROOT_DIR)/contrib/testing/kind-custom.yaml)","")
+	KIND_VALUES_FILES := $(KIND_VALUES_FILES) --helm-values=$(ROOT_DIR)/contrib/testing/kind-custom.yaml
+endif
+
 .PHONY: kind-install-cilium
 kind-install-cilium: kind-ready ## Install a local Cilium version into the cluster.
 	@echo "  INSTALL cilium"
 	# cilium-cli doesn't support idempotent installs, so we uninstall and
 	# reinstall here. https://github.com/cilium/cilium-cli/issues/205
 	-$(CILIUM_CLI) uninstall >/dev/null
+
 	# cilium-cli's --wait flag doesn't work, so we just force it to run
 	# in the background instead and wait for the resources to be available.
 	# https://github.com/cilium/cilium-cli/issues/1070
 	$(CILIUM_CLI) install \
 		--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
-		--helm-values=$(ROOT_DIR)/contrib/testing/kind-common.yaml \
-		--helm-values=$(ROOT_DIR)/contrib/testing/kind-values.yaml \
+		$(KIND_VALUES_FILES) \
 		--version= \
 		>/dev/null 2>&1 &
 

--- a/contrib/testing/.gitignore
+++ b/contrib/testing/.gitignore
@@ -1,0 +1,4 @@
+# May contain additional custom Helm values that are taken into account when
+# installing cilium via Make target `kind-install-cilium`.
+kind-custom.yaml
+


### PR DESCRIPTION
 * [x] #28155 (@mhofstetter) :warning: resolved conflicts
    * :information_source: Hit minor conflict due to the presence of 8cf3df45cda1 ("Makefile fix kind-install-cilium-fast target"), resolved ignoring the associated hunk, as already up-to-date.
 * [x] #35646 (@giorio94) :warning: resolved conflicts
    * :information_source: Applied the changes to the main Makefile, rather than Makefile.kind that did not exist in the v1.14 tree.
 * [x] #35679 (@giorio94) :warning: resolved conflicts
    * Applied equivalent changes to the Conformance E2E workflow, as the upgrade/downgrade one does not exist in v1.14. Additionally configured the IPSec matrix entries in the individual workflow files, as ipsec/configs.yaml did not exist in the v1.14 tree.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 28155 35646 35679
```
