### PR TITLE
Cleanup leaked GCE kops clusters

### DIFF
--- a/.github/workflows/scale-cleanup-kops.yaml
+++ b/.github/workflows/scale-cleanup-kops.yaml
@@ -1,0 +1,78 @@
+name: Cleanup GCE kops clusters
+
+on:
+  # Run every 3 hours
+  # In case we leak kops cluster, we want to cleanup
+  # 100 node cluster pretty fast
+  schedule:
+    - cron: '0 */3 * * *'
+
+permissions:
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To be able to request the JWT from GitHub's OIDC provider
+  id-token: write
+  # To allow retrieving information from the PR API
+  pull-requests: read
+
+concurrency:
+  # Structure:
+  # - Workflow name
+  group: |
+    ${{ github.workflow }}
+  cancel-in-progress: true
+
+env:
+  # renovate: datasource=golang-version depName=go
+  go_version: 1.23.1
+  # renovate: datasource=docker depName=google/cloud-sdk
+  gcloud_version: 492.0.0
+
+jobs:
+  cleanup-kops-clusters:
+    runs-on: ubuntu-latest
+    name: Cleanup kops clusters
+    timeout-minutes: 30
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Install Kops
+        uses: cilium/scale-tests-action/install-kops@746605acaf51e628ba5b8941d547c7cf32655358 # main
+
+      - name: Setup gcloud credentials
+        uses: google-github-actions/auth@62cf5bd3e4211a0a0b51f2c6d6a37129d828611d # v2.1.5
+        with:
+          workload_identity_provider: ${{ secrets.GCP_PERF_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_PERF_SA }}
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
+        with:
+          project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
+          version: ${{ env.gcloud_version }}
+
+      - name: Cleanup stale clusters
+        shell: bash
+        timeout-minutes: 25
+        run: |
+          if ./kops get clusters --state ${{ secrets.GCP_PERF_KOPS_STATE_STORE }} -o json > /tmp/clusters.json
+          then
+            echo "Clusters list fetched successfully"
+            date=`date -u +%Y-%m-%d'T'%H:%M'Z' -d "3 hour ago"`
+            cat /tmp/clusters.json | jq -r --arg date "$date" '.[] | select([.metadata.creationTimestamp < $date]) | .metadata.name' > /tmp/stale-clusters.txt
+            # iterate through list of cluster names in /tmp/stale-clusters.txt
+            while IFS= read -r cluster; do
+              ./kops delete cluster --state ${{ secrets.GCP_PERF_KOPS_STATE_STORE }} $cluster --yes
+            done < /tmp/stale-clusters.txt
+          else
+            echo "Failed to fetch clusters list, probably no clusters present"
+          fi


### PR DESCRIPTION
Add CI job to cleanup leaked clusters.

Example run: https://github.com/cilium/cilium/actions/runs/11796421412/job/32858237616?pr=35915