### PR TITLE
daemon: Catch panics in shell handler

### DIFF
--- a/daemon/cmd/shell.go
+++ b/daemon/cmd/shell.go
@@ -27,10 +27,18 @@ var shellCell = cell.Module(
 	cell.Invoke(registerShell),
 )
 
+// defaultCmdsToInclude specify which default script commands to include.
+// Most of them are for testing, so no need to clutter the shell
+// with them.
+var defaultCmdsToInclude = []string{
+	"cat", "exec", "help",
+}
+
 func registerShell(in upstreamHive.ScriptCmds, log *slog.Logger, jg job.Group) {
 	cmds := in.Map()
-	for k, cmd := range script.DefaultCmds() {
-		cmds[k] = cmd
+	defCmds := script.DefaultCmds()
+	for _, name := range defaultCmdsToInclude {
+		cmds[name] = defCmds[name]
 	}
 	e := script.Engine{
 		Cmds:  cmds,


### PR DESCRIPTION
To make sure that the shell commands cannot bring down the agent, catch the panics in the handler. On panic log it and also send it over the connection:
```
cilium> help tiuheot
PANIC: runtime error: invalid memory address or nil pointer dereference 
goroutine 1684 [running]:
github.com/cilium/cilium/daemon/cmd.shell.handleConn.func2()
        .../cilium/cilium/daemon/cmd/shell.go:109 +0x85
panic({0x3cba7e0?, 0x75d9af0?})
        .../share/go/src/runtime/panic.go:785 +0x132
github.com/cilium/hive/script.(*Engine).ListCmds(0xc000d68a38, ...
        .../cilium/cilium/vendor/github.com/cilium/hive/script/engine.go:731 +0x14c
        ...
```
