### PR TITLE
docs: lrp: fix kernel version requirement for skipRedirectFromBackend

### DIFF
--- a/Documentation/network/kubernetes/local-redirect-policy.rst
+++ b/Documentation/network/kubernetes/local-redirect-policy.rst
@@ -578,7 +578,9 @@ When a local redirect policy is applied, cilium BPF datapath redirects traffic g
 However, for traffic originating from a node-local backend pod destined to the policy frontend, users may want to
 skip redirecting the traffic back to the node-local backend pod, and instead forward the traffic to the original frontend.
 This behavior can be enabled by setting the ``skipRedirectFromBackend`` flag to ``true`` in the local redirect policy spec.
-This configuration requires the ``SO_NETNS_COOKIE`` feature available in Linux kernel version >= 5.8.
+This configuration requires the use of ``getsockopt()`` with the ``SO_NETNS_COOKIE`` option, which is available in
+Linux kernel version >= 5.12. Note that ``SO_NETNS_COOKIE`` was introduced in 5.7 (available to BPF programs),
+and exposed to user space in versions >= 5.12.
 
 .. note::
 


### PR DESCRIPTION
The skipRedirectFromBackend requires getsockopt() with SO_NETNS_COOKIE option which available in the kernel >= 5.12. This commit fixes the LRP doc accordingly.

The kernel commit which exposes `SO_NETNS_COOKIE` to the userspace
https://github.com/torvalds/linux/commit/e8b9eab99232c4e62ada9d7976c80fd5e8118289
