### PR TITLE
Replace hyphens with underscores in environment variable names

### DIFF
--- a/Documentation/installation/k0s.rst
+++ b/Documentation/installation/k0s.rst
@@ -28,7 +28,9 @@ After deploying the VMs, export their IP addresses to environment variables (see
 
 .. code-block:: shell-session
 
-   export node1-IP=192.168.2.1 node2-IP=192.168.2.2 node3-IP=192.168.2.3
+   export node1_IP=192.168.2.1
+   export node2_IP=192.168.2.2
+   export node3_IP=192.168.2.3
 
 
 Prepare the yaml configuration file k0sctl will use:
@@ -37,7 +39,7 @@ Prepare the yaml configuration file k0sctl will use:
 
    # The following command assumes the user has deployed 3 VMs
    # with the default user "k0s" using the default ssh-key (without passphrase)
-   k0sctl init --k0s -n "myk0scluster" -u "k0s" -i "~/.ssh/id_rsa" -C "1" "${node1-IP}" "${node2-IP}" "${node3-IP}" > k0s-myk0scluster-config.yaml
+   k0sctl init --k0s -n "myk0scluster" -u "k0s" -i "~/.ssh/id_rsa" -C "1" "${node1_IP}" "${node2_IP}" "${node3_IP}" > k0s-myk0scluster-config.yaml
    
 
 Next step is editing ``k0s-myk0scluster-config.yaml``::


### PR DESCRIPTION
In bash, hyphens are not permitted in variable names, as they can cause syntax errors. To avoid this issue, variable names have been updated to use underscores (_) instead of hyphens. This change ensures compatibility with bash syntax and avoids potential errors during script execution.

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

<!-- Description of change -->

```release-note
docs: In k0s guide, remove dashes to fix invalid Bash variable names.
```


Fixes: #35922 

