### PR TITLE
workflows/eks: Disable socket-level LB tracing

### DIFF
--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -207,6 +207,7 @@ jobs:
             --helm-set=ipam.mode=cluster-pool \
             --helm-set=routingMode=native \
             --helm-set=bandwidthManager.enabled=false \
+            --helm-set=socketLB.tracing=false \
             --wait=false"
 
           if [ "${{ matrix.wireguard }}" == "true" ]; then

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -204,6 +204,7 @@ jobs:
             --helm-set loadBalancer.l7.backend=envoy \
             --helm-set tls.secretsBackend=k8s \
             --helm-set=bpf.monitorAggregation=none \
+            --helm-set=socketLB.tracing=false \
             --wait=false"
           if [[ "${{ matrix.ipsec }}" == "true" ]]; then
             CILIUM_INSTALL_DEFAULTS+=" --helm-set encryption.enabled=true --helm-set encryption.type=ipsec"


### PR DESCRIPTION
Socket-level LB tracing doesn't work on EKS and results in a warning. We should therefore disable it in those workflows.