### PR TITLE
Push BGP Health Checks

### DIFF
--- a/pkg/bgp/manager/manager_test.go
+++ b/pkg/bgp/manager/manager_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/google/go-cmp/cmp"
 	metallbk8s "go.universe.tf/metallb/pkg/k8s"
 	"go.universe.tf/metallb/pkg/k8s/types"
@@ -29,6 +31,27 @@ var (
 		Type: metallbk8s.Eps,
 	}
 )
+
+type mockSessionManager struct{}
+
+func (m *mockSessionManager) ListPeers() []Peer {
+	return []Peer{
+		{PeerIP: "192.168.1.1", SessionState: "Established"},
+		{PeerIP: "192.168.1.2", SessionState: "Idle"},
+	}
+}
+
+func TestGetPeerStatuses(t *testing.T) {
+	mgr := &Manager{
+		sessionManager: &mockSessionManager{},
+	}
+
+	statuses, err := mgr.GetPeerStatuses()
+	assert.NoError(t, err)
+	assert.Len(t, statuses, 2)
+	assert.Equal(t, "Established", statuses[0].SessionState)
+	assert.Equal(t, "Idle", statuses[1].SessionState)
+}
 
 // TestManagerEventNoService confirms when the
 // manager is provided a service which does not exist


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #35934


# Release Notes: BGP Health Check Feature

## **New Feature: BGP Health Check Endpoint**

### **Description**
This release introduces a new health check endpoint, `/healthz/bgp`, in the Cilium agent. The endpoint allows users to monitor the status of BGP peer connections managed by Cilium's BGP control plane.

### **Key Highlights**
- **New Endpoint**: `/healthz/bgp`
  - Reports the health of BGP peer connections.
  - Returns HTTP `200 OK` if all BGP peers are in the "Established" state.
  - Returns HTTP `500 Internal Server Error` if one or more peers are not in the "Established" state.

- **Automatic Integration**:
  - The endpoint is enabled automatically if the BGP control plane is configured and enabled via `BGPControlPlaneEnabled`.

- **Enhanced Observability**:
  - Provides clear visibility into the status of BGP peers, helping operators detect and troubleshoot network issues more effectively.

### **Configuration**
- The BGP health check endpoint is enabled if the BGP control plane is active (`BGPControlPlaneEnabled` set to `true`).
- The endpoint is served on the same port as other health checks, configurable via the `AgentHealthPort` option.

### **Usage**
- To check the BGP peer statuses, use:
  ```bash
  curl http://<Cilium Agent Host>:<AgentHealthPort>/healthz/bgp
  ```
  - A `200 OK` response indicates that all BGP peers are established.
  - A `500 Internal Server Error` response indicates one or more peers are not established.

### **Implementation Details**
- The `/healthz/bgp` endpoint leverages the `bgpManager.GetPeerStatuses()` method to query peer connection states.
- Errors in retrieving peer statuses or issues with peer connections are logged for further analysis.

---

### **Example Scenarios**
1. **All Peers Established**:
   ```bash
   curl http://localhost:8080/healthz/bgp
   HTTP/1.1 200 OK
   All BGP peers are established
   ```

2. **Some Peers Not Established**:
   ```bash
   curl http://localhost:8080/healthz/bgp
   HTTP/1.1 500 Internal Server Error
   One or more BGP peers are not established
   ```

---

### **Benefits**
- Simplifies monitoring of BGP connections in environments where Cilium is used with the BGP control plane.
- Helps maintain cluster and network reliability by providing a clear and actionable health status.

### **Acknowledgments**
Thanks to the contributors and the community for their valuable input and testing to bring this feature to fruition.

