### PR TITLE
Pr/add bgp health checks

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -233,7 +233,7 @@ func (d *Daemon) startAgentHealthHTTPService() {
 
 // GetPolicyRepository returns the policy repository of the daemon
 func (d *Daemon) GetPolicyRepository() policy.PolicyRepository {
-	return d.policy
+    return d.policy // Ensure no extra keywords are here
 }
 
 // GetCompilationLock returns the mutex responsible for synchronizing compilation
@@ -940,6 +940,5 @@ func (d *Daemon) SendNotification(notification monitorAPI.AgentNotifyMessage) er
 }
 
 type endpointMetadataFetcher interface {
-	Fetch(nsName, podName string) (*slim_corev1.Namespace, *slim_corev1.Pod, error)
-}
+    Fetch(nsName, podName string) (*slim_corev1.Namespace, *slim_corev1.Pod, error)
 }

--- a/pkg/bgp/manager/manager_test.go
+++ b/pkg/bgp/manager/manager_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/google/go-cmp/cmp"
 	metallbk8s "go.universe.tf/metallb/pkg/k8s"
 	"go.universe.tf/metallb/pkg/k8s/types"
@@ -29,6 +31,27 @@ var (
 		Type: metallbk8s.Eps,
 	}
 )
+
+type mockSessionManager struct{}
+
+func (m *mockSessionManager) ListPeers() []Peer {
+	return []Peer{
+		{PeerIP: "192.168.1.1", SessionState: "Established"},
+		{PeerIP: "192.168.1.2", SessionState: "Idle"},
+	}
+}
+
+func TestGetPeerStatuses(t *testing.T) {
+	mgr := &Manager{
+		sessionManager: &mockSessionManager{},
+	}
+
+	statuses, err := mgr.GetPeerStatuses()
+	assert.NoError(t, err)
+	assert.Len(t, statuses, 2)
+	assert.Equal(t, "Established", statuses[0].SessionState)
+	assert.Equal(t, "Idle", statuses[1].SessionState)
+}
 
 // TestManagerEventNoService confirms when the
 // manager is provided a service which does not exist

--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -220,38 +220,39 @@ func (n *linuxNodeHandler) enableIPSecIPv4DoSubnetEncryption(newNode *nodeTypes.
 		if err != nil {
 			statesUpdated = false
 		}
-
-		// insert fwd rule
-		params = ipsec.NewIPSecParamaters(template)
-		params.Dir = ipsec.IPSecDirFwd
-		params.SourceSubnet = wildcardCIDR
-		params.DestSubnet = wildcardCIDR
-		params.SourceTunnelIP = &net.IP{}
-		params.DestTunnelIP = &localIP
-		spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
-		errs = errors.Join(errs, upsertIPsecLog(n.log, err, "fwd IPv4", params.SourceSubnet, params.DestSubnet, spi, nodeID))
-
-		params = ipsec.NewIPSecParamaters(template)
-		params.Dir = ipsec.IPSecDirIn
-		params.SourceSubnet = wildcardCIDR
-		params.DestSubnet = wildcardCIDR
-		params.SourceTunnelIP = &remoteCiliumInternalIP
-		params.DestTunnelIP = &localCiliumInternalIP
-		spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
-		errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in CiliumInternalIPv4", params.SourceSubnet, params.DestSubnet, spi, nodeID))
-		if err != nil {
-			statesUpdated = false
-		}
-
-		// we just need to update the tunnel ips here...
-		params.SourceTunnelIP = &remoteNodeInternalIP
-		params.DestTunnelIP = &localNodeInternalIP
-		spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
-		errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in NodeInternalIPv4", params.SourceSubnet, params.DestSubnet, spi, nodeID))
-		if err != nil {
-			statesUpdated = false
-		}
 	}
+
+	// insert fwd rule
+	params := ipsec.NewIPSecParamaters(template)
+	params.Dir = ipsec.IPSecDirFwd
+	params.SourceSubnet = wildcardCIDR
+	params.DestSubnet = wildcardCIDR
+	params.SourceTunnelIP = &net.IP{}
+	params.DestTunnelIP = &localIP
+	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
+	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "fwd IPv4", params.SourceSubnet, params.DestSubnet, spi, nodeID))
+
+	params = ipsec.NewIPSecParamaters(template)
+	params.Dir = ipsec.IPSecDirIn
+	params.SourceSubnet = wildcardCIDR
+	params.DestSubnet = wildcardCIDR
+	params.SourceTunnelIP = &remoteCiliumInternalIP
+	params.DestTunnelIP = &localCiliumInternalIP
+	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
+	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in CiliumInternalIPv4", params.SourceSubnet, params.DestSubnet, spi, nodeID))
+	if err != nil {
+		statesUpdated = false
+	}
+
+	// we just need to update the tunnel ips here...
+	params.SourceTunnelIP = &remoteNodeInternalIP
+	params.DestTunnelIP = &localNodeInternalIP
+	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
+	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in NodeInternalIPv4", params.SourceSubnet, params.DestSubnet, spi, nodeID))
+	if err != nil {
+		statesUpdated = false
+	}
+
 	return statesUpdated, errs
 }
 
@@ -467,39 +468,39 @@ func (n *linuxNodeHandler) enableIPSecIPv6DoSubnetEncryption(newNode *nodeTypes.
 		if err != nil {
 			statesUpdated = false
 		}
+	}
 
-		params = ipsec.NewIPSecParamaters(template)
-		params.Dir = ipsec.IPSecDirFwd
-		params.SourceSubnet = wildcardCIDR6
-		params.DestSubnet = wildcardCIDR6
-		params.SourceTunnelIP = &net.IP{}
-		params.DestTunnelIP = &localIP
-		spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
-		errs = errors.Join(errs, upsertIPsecLog(n.log, err, "fwd IPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
-		if err != nil {
-			statesUpdated = false
-		}
+	params := ipsec.NewIPSecParamaters(template)
+	params.Dir = ipsec.IPSecDirFwd
+	params.SourceSubnet = wildcardCIDR6
+	params.DestSubnet = wildcardCIDR6
+	params.SourceTunnelIP = &net.IP{}
+	params.DestTunnelIP = &localIP
+	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
+	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "fwd IPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
+	if err != nil {
+		statesUpdated = false
+	}
 
-		params = ipsec.NewIPSecParamaters(template)
-		params.Dir = ipsec.IPSecDirIn
-		params.SourceSubnet = wildcardCIDR6
-		params.DestSubnet = wildcardCIDR6
-		params.SourceTunnelIP = &remoteCiliumInternalIP
-		params.DestTunnelIP = &localCiliumInternalIP
-		spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
-		errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in CiliumInternalIPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
-		if err != nil {
-			statesUpdated = false
-		}
+	params = ipsec.NewIPSecParamaters(template)
+	params.Dir = ipsec.IPSecDirIn
+	params.SourceSubnet = wildcardCIDR6
+	params.DestSubnet = wildcardCIDR6
+	params.SourceTunnelIP = &remoteCiliumInternalIP
+	params.DestTunnelIP = &localCiliumInternalIP
+	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
+	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in CiliumInternalIPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
+	if err != nil {
+		statesUpdated = false
+	}
 
-		// we just need to update the tunnel ips here...
-		params.SourceTunnelIP = &remoteNodeInternalIP
-		params.DestTunnelIP = &localNodeInternalIP
-		spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
-		errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in NodeInternalIPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
-		if err != nil {
-			statesUpdated = false
-		}
+	// we just need to update the tunnel ips here...
+	params.SourceTunnelIP = &remoteNodeInternalIP
+	params.DestTunnelIP = &localNodeInternalIP
+	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
+	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in NodeInternalIPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
+	if err != nil {
+		statesUpdated = false
 	}
 
 	return statesUpdated, errs

--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -233,7 +233,7 @@ func (n *linuxNodeHandler) enableIPSecIPv4DoSubnetEncryption(newNode *nodeTypes.
 
 		params = ipsec.NewIPSecParamaters(template)
 		params.Dir = ipsec.IPSecDirIn
-		params.SourceSubnet = cidr
+		params.SourceSubnet = wildcardCIDR
 		params.DestSubnet = wildcardCIDR
 		params.SourceTunnelIP = &remoteCiliumInternalIP
 		params.DestTunnelIP = &localCiliumInternalIP
@@ -271,7 +271,6 @@ func (n *linuxNodeHandler) enableIPSecIPv4Do(newNode *nodeTypes.Node, nodeID uin
 	localCiliumInternalIP := n.nodeConfig.CiliumInternalIPv4
 	localIP := localCiliumInternalIP
 
-	localCIDR := n.nodeConfig.AllocCIDRIPv4.IPNet
 	remoteCIDR := newNode.IPv4AllocCIDR.IPNet
 	if err := n.replaceNodeIPSecOutRoute(remoteCIDR); err != nil {
 		errs = errors.Join(errs, fmt.Errorf("failed to replace ipsec OUT (%q): %w", remoteCIDR.IP, err))
@@ -312,7 +311,7 @@ func (n *linuxNodeHandler) enableIPSecIPv4Do(newNode *nodeTypes.Node, nodeID uin
 	params = ipsec.NewIPSecParamaters(template)
 	params.Dir = ipsec.IPSecDirIn
 	params.SourceSubnet = wildcardCIDR
-	params.DestSubnet = localCIDR
+	params.DestSubnet = wildcardCIDR
 	params.SourceTunnelIP = &remoteIP
 	params.DestTunnelIP = &localIP
 	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
@@ -483,7 +482,7 @@ func (n *linuxNodeHandler) enableIPSecIPv6DoSubnetEncryption(newNode *nodeTypes.
 
 		params = ipsec.NewIPSecParamaters(template)
 		params.Dir = ipsec.IPSecDirIn
-		params.SourceSubnet = cidr
+		params.SourceSubnet = wildcardCIDR6
 		params.DestSubnet = wildcardCIDR6
 		params.SourceTunnelIP = &remoteCiliumInternalIP
 		params.DestTunnelIP = &localCiliumInternalIP
@@ -520,7 +519,6 @@ func (n *linuxNodeHandler) enableIPSecIPv6Do(newNode *nodeTypes.Node, nodeID uin
 	localCiliumInternalIP := n.nodeConfig.CiliumInternalIPv6
 	localIP := localCiliumInternalIP
 
-	localCIDR := n.nodeConfig.AllocCIDRIPv6.IPNet
 	remoteCIDR := newNode.IPv6AllocCIDR.IPNet
 	if err := n.replaceNodeIPSecOutRoute(remoteCIDR); err != nil {
 		errs = errors.Join(errs, fmt.Errorf("failed to replace ipsec OUT (%q): %w", remoteCIDR.IP, err))
@@ -564,7 +562,7 @@ func (n *linuxNodeHandler) enableIPSecIPv6Do(newNode *nodeTypes.Node, nodeID uin
 	params = ipsec.NewIPSecParamaters(template)
 	params.Dir = ipsec.IPSecDirIn
 	params.SourceSubnet = wildcardCIDR6
-	params.DestSubnet = localCIDR
+	params.DestSubnet = wildcardCIDR6
 	params.SourceTunnelIP = &remoteIP
 	params.DestTunnelIP = &localIP
 	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -324,14 +324,23 @@ func ipSecNewPolicy() *netlink.XfrmPolicy {
 	return &policy
 }
 
-func ipSecAttachPolicyTempl(policy *netlink.XfrmPolicy, keys *ipSecKey, srcIP, dstIP net.IP, spi bool, optional int) {
+func ipSecAttachPolicyTempl(policy *netlink.XfrmPolicy, keys *ipSecKey, srcIP, dstIP net.IP, spi bool, optional bool) {
 	tmpl := netlink.XfrmPolicyTmpl{
-		Proto:    netlink.XFRM_PROTO_ESP,
-		Mode:     netlink.XFRM_MODE_TUNNEL,
-		Reqid:    keys.ReqID,
-		Dst:      dstIP,
-		Src:      srcIP,
-		Optional: optional,
+		Proto: netlink.XFRM_PROTO_ESP,
+		Mode:  netlink.XFRM_MODE_TUNNEL,
+		Dst:   dstIP,
+		Src:   srcIP,
+		Reqid: keys.ReqID,
+	}
+
+	if optional {
+		tmpl.Optional = 1
+		// If the template is optional, we might as well make it accept
+		// everything it can.
+		tmpl.Reqid = 0
+		tmpl.Src = nil
+		tmpl.Dst = nil
+		spi = false
 	}
 
 	if spi {
@@ -547,7 +556,7 @@ func ipSecReplaceStateOut(log *slog.Logger, params *IPSecParameters) (uint8, err
 }
 
 func _ipSecReplacePolicyIn(params *IPSecParameters, proxyMark bool, dir netlink.Dir) error {
-	optional := int(0)
+	optional := false
 	// We can use the global IPsec key here because we are not going to
 	// actually use the secret itself.
 	key := getGlobalIPsecKey(params.DestSubnet.IP)
@@ -556,13 +565,6 @@ func _ipSecReplacePolicyIn(params *IPSecParameters, proxyMark bool, dir netlink.
 	}
 	key.ReqID = params.ReqID
 
-	wildcardIP := wildcardIPv4
-	if params.SourceTunnelIP.To4() == nil {
-		wildcardIP = wildcardIPv6
-	}
-
-	tmplSrc := params.SourceTunnelIP
-	tmplDst := params.DestTunnelIP
 	policy := ipSecNewPolicy()
 	policy.Dir = dir
 	if dir == netlink.XFRM_DIR_IN {
@@ -579,15 +581,12 @@ func _ipSecReplacePolicyIn(params *IPSecParameters, proxyMark bool, dir netlink.
 			policy.Mark.Value = linux_defaults.RouteMarkToProxy
 			// We must mark the IN policy for the proxy optional simply because it
 			// is lacking a corresponding state.
-			optional = 1
-			// We set the source tmpl address to 0/0 to explicit that it
-			// doesn't matter.
-			tmplSrc = &wildcardIP
+			optional = true
 		} else {
 			policy.Mark.Value = linux_defaults.RouteMarkDecrypt
 		}
 	}
-	ipSecAttachPolicyTempl(policy, key, *tmplSrc, *tmplDst, false, optional)
+	ipSecAttachPolicyTempl(policy, key, *params.SourceTunnelIP, *params.DestTunnelIP, false, optional)
 	return netlink.XfrmPolicyUpdate(policy)
 }
 
@@ -616,7 +615,7 @@ func IpSecReplacePolicyFwd(params *IPSecParameters) error {
 	policy.Src = params.SourceSubnet
 	policy.Dst = params.DestSubnet
 
-	ipSecAttachPolicyTempl(policy, key, *params.SourceTunnelIP, *params.DestTunnelIP, false, 1)
+	ipSecAttachPolicyTempl(policy, key, *params.SourceTunnelIP, *params.DestTunnelIP, false, true)
 	return netlink.XfrmPolicyUpdate(policy)
 }
 
@@ -695,7 +694,7 @@ func ipSecReplacePolicyOut(params *IPSecParameters) error {
 	policy.Dst = params.DestSubnet
 	policy.Dir = netlink.XFRM_DIR_OUT
 	policy.Mark = generateEncryptMark(key.Spi, params.RemoteNodeID)
-	ipSecAttachPolicyTempl(policy, key, *params.SourceTunnelIP, *params.DestTunnelIP, true, 0)
+	ipSecAttachPolicyTempl(policy, key, *params.SourceTunnelIP, *params.DestTunnelIP, true, false)
 	return netlink.XfrmPolicyUpdate(policy)
 }
 

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -421,11 +421,11 @@ func TestUpsertIPSecEndpointFwd(t *testing.T) {
 	if !policyTmpl.Src.Equal(wildcardIPv4) {
 		t.Fatalf("Expected Src to be %s, but got %s", wildcardIPv4.String(), policyTmpl.Src.String())
 	}
-	if !policyTmpl.Dst.Equal(local.IP) {
-		t.Fatalf("Expected Dst to be %s, but got %s", local.IP.String(), policyTmpl.Dst.String())
+	if !policyTmpl.Dst.Equal(wildcardIPv4) {
+		t.Fatalf("Expected Dst to be %s, but got %s", wildcardIPv4.String(), policyTmpl.Dst.String())
 	}
 	require.Equal(t, netlink.XFRM_PROTO_ESP, policyTmpl.Proto)
-	require.Equal(t, params.ReqID, policyTmpl.Reqid)
+	require.Equal(t, 0, policyTmpl.Reqid)
 	require.Equal(t, netlink.XFRM_MODE_TUNNEL, policyTmpl.Mode)
 	require.Equal(t, 1, policyTmpl.Optional)
 }
@@ -511,10 +511,10 @@ func TestUpsertIPSecEndpointIn(t *testing.T) {
 
 	tmpls := []netlink.XfrmPolicyTmpl{
 		{
-			Src:   remote.IP,
-			Dst:   local.IP,
+			Src:   wildcardIPv4,
+			Dst:   wildcardIPv4,
 			Proto: netlink.XFRM_PROTO_ESP,
-			Reqid: params.ReqID,
+			Reqid: 0,
 			Mode:  netlink.XFRM_MODE_TUNNEL,
 		},
 	}
@@ -594,13 +594,13 @@ func TestUpsertIPSecEndpointIn(t *testing.T) {
 	policyTmpl = policy.Tmpls[0]
 	// l7 proxy policy has a wildcard source
 	if !policyTmpl.Src.Equal(wildcardIPv4) {
-		t.Fatalf("Expected Src to be %s, but got %s", remote.IP.String(), policyTmpl.Src.String())
+		t.Fatalf("Expected Src to be %s, but got %s", wildcardIPv4.String(), policyTmpl.Src.String())
 	}
-	if !policyTmpl.Dst.Equal(local.IP) {
-		t.Fatalf("Expected Dst to be %s, but got %s", local.IP.String(), policyTmpl.Dst.String())
+	if !policyTmpl.Dst.Equal(wildcardIPv4) {
+		t.Fatalf("Expected Dst to be %s, but got %s", wildcardIPv4.String(), policyTmpl.Dst.String())
 	}
 	require.Equal(t, netlink.XFRM_PROTO_ESP, policyTmpl.Proto)
-	require.Equal(t, params.ReqID, policyTmpl.Reqid)
+	require.Equal(t, 0, policyTmpl.Reqid)
 	require.Equal(t, netlink.XFRM_MODE_TUNNEL, policyTmpl.Mode)
 }
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #35934 


# Release Notes: BGP Health Check Feature

## **New Feature: BGP Health Check Endpoint**

### **Description**
This release introduces a new health check endpoint, `/healthz/bgp`, in the Cilium agent. The endpoint allows users to monitor the status of BGP peer connections managed by Cilium's BGP control plane.

### **Key Highlights**
- **New Endpoint**: `/healthz/bgp`
  - Reports the health of BGP peer connections.
  - Returns HTTP `200 OK` if all BGP peers are in the "Established" state.
  - Returns HTTP `500 Internal Server Error` if one or more peers are not in the "Established" state.

- **Automatic Integration**:
  - The endpoint is enabled automatically if the BGP control plane is configured and enabled via `BGPControlPlaneEnabled`.

- **Enhanced Observability**:
  - Provides clear visibility into the status of BGP peers, helping operators detect and troubleshoot network issues more effectively.

### **Configuration**
- The BGP health check endpoint is enabled if the BGP control plane is active (`BGPControlPlaneEnabled` set to `true`).
- The endpoint is served on the same port as other health checks, configurable via the `AgentHealthPort` option.

### **Usage**
- To check the BGP peer statuses, use:
  ```bash
  curl http://<Cilium Agent Host>:<AgentHealthPort>/healthz/bgp
  ```
  - A `200 OK` response indicates that all BGP peers are established.
  - A `500 Internal Server Error` response indicates one or more peers are not established.

### **Implementation Details**
- The `/healthz/bgp` endpoint leverages the `bgpManager.GetPeerStatuses()` method to query peer connection states.
- Errors in retrieving peer statuses or issues with peer connections are logged for further analysis.

---

### **Example Scenarios**
1. **All Peers Established**:
   ```bash
   curl http://localhost:8080/healthz/bgp
   HTTP/1.1 200 OK
   All BGP peers are established
   ```

2. **Some Peers Not Established**:
   ```bash
   curl http://localhost:8080/healthz/bgp
   HTTP/1.1 500 Internal Server Error
   One or more BGP peers are not established
   ```

---

### **Benefits**
- Simplifies monitoring of BGP connections in environments where Cilium is used with the BGP control plane.
- Helps maintain cluster and network reliability by providing a clear and actionable health status.

### **Acknowledgments**
Thanks to the contributors and the community for their valuable input and testing to bring this feature to fruition.

