### PR TITLE
Centralize policy calculation in the PolicyRepository

### DIFF
--- a/pkg/endpoint/metrics.go
+++ b/pkg/endpoint/metrics.go
@@ -90,6 +90,16 @@ func (s *regenerationStatistics) GetMap() map[string]*spanstat.SpanStat {
 	return result
 }
 
+// used by PolicyRepository.GetSelectorPolicy
+func (s *regenerationStatistics) WaitingForPolicyRepository() *spanstat.SpanStat {
+	return &s.waitingForPolicyRepository
+}
+
+// used by PolicyRepository.GetSelectorPolicy
+func (s *regenerationStatistics) PolicyCalculation() *spanstat.SpanStat {
+	return &s.policyCalculation
+}
+
 // endpointPolicyStatusMap is a map to store the endpoint id and the policy
 // enforcement status. It is used only to send metrics to prometheus.
 type endpointPolicyStatusMap struct {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -263,8 +263,8 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 	}
 	e.runlock()
 
-	// Consume converts a SelectorPolicy in to an EndpointPolicy
-	result.endpointPolicy = selectorPolicy.Consume(e, desiredRedirects)
+	// DistillPolicy converts a SelectorPolicy in to an EndpointPolicy
+	result.endpointPolicy = selectorPolicy.DistillPolicy(e, desiredRedirects)
 
 	return result, nil
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -162,7 +162,7 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 	)
 
 	// lock the endpoint, read our values, then unlock
-	err = e.rlockAlive()
+	err = e.lockAlive()
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +170,7 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 	// No point in calculating policy if endpoint does not have an identity yet.
 	if e.SecurityIdentity == nil {
 		e.getLogger().Warn("Endpoint lacks identity, skipping policy calculation")
-		e.runlock()
+		e.unlock()
 		return nil, nil
 	}
 
@@ -189,7 +189,7 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 		endpointPolicy:   e.desiredPolicy,
 		identityRevision: e.identityRevision,
 	}
-	e.runlock()
+	e.unlock()
 
 	e.getLogger().Debug("Starting policy recalculation...")
 

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -74,7 +74,6 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 	}
 
 	podID := addIdentity("pod")
-	repo.GetPolicyCache().LocalEndpointIdentityAdded(podID)
 
 	ep := Endpoint{
 		SecurityIdentity: podID,

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -142,9 +142,9 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 	// Continuously compute policy for the pod and ensure we never missed an incremental update.
 	for {
 		t.Log("Calculating policy...")
+		ep.forcePolicyCompute = true
 		res, err := ep.regeneratePolicy(stats, datapathRegenCtxt)
 		assert.NoError(t, err)
-		res.endpointPolicy = res.selectorPolicy.Consume(&ep, nil)
 
 		// Sleep a random amount, so we accumulate some changes
 		// This does not slow down the test, since we always generate testFactor identities.

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -57,9 +57,6 @@ func (s *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdentit
 	}
 	identity.Sanitize()
 
-	repo := s.GetPolicyRepository()
-	repo.GetPolicyCache().LocalEndpointIdentityAdded(identity)
-
 	ep := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), id, StateReady)
 	// Random network ID and docker endpoint ID with 59 hex chars + 5 strID = 64 hex chars
 	ep.dockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -112,16 +112,6 @@ func (cache *PolicyCache) LocalEndpointIdentityRemoved(identity *identityPkg.Ide
 	cache.delete(identity)
 }
 
-// UpdatePolicy resolves the policy for the security identity of the specified
-// endpoint and caches it for future use.
-//
-// The caller must provide threadsafety for iteration over the policy
-// repository.
-func (cache *PolicyCache) UpdatePolicy(identity *identityPkg.Identity) (SelectorPolicy, error) {
-	sp, _, err := cache.updateSelectorPolicy(identity)
-	return sp, err
-}
-
 // GetAuthTypes returns the AuthTypes required by the policy between the localID and remoteID, if
 // any, otherwise returns nil.
 func (cache *PolicyCache) GetAuthTypes(localID, remoteID identityPkg.NumericIdentity) AuthTypes {

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -2076,7 +2076,7 @@ func TestDenyPreferredInsertLogic(t *testing.T) {
 	td.bootstrapRepo(GenerateCIDRDenyRules, 1000, t)
 	p, _ := td.repo.resolvePolicyLocked(fooIdentity)
 
-	epPolicy := p.DistillPolicy(DummyOwner{}, nil, false)
+	epPolicy := p.DistillPolicy(DummyOwner{}, nil)
 	epPolicy.Ready()
 
 	n := epPolicy.policyMapState.Len()

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -188,7 +188,7 @@ func BenchmarkRegenerateCIDRDenyPolicyRules(b *testing.B) {
 	b.ResetTimer()
 	n := 0
 	for i := 0; i < b.N; i++ {
-		epPolicy := ip.DistillPolicy(DummyOwner{}, nil, false)
+		epPolicy := ip.DistillPolicy(DummyOwner{}, nil)
 		n += epPolicy.policyMapState.Len()
 		epPolicy.Ready()
 	}
@@ -200,7 +200,7 @@ func TestRegenerateCIDRDenyPolicyRules(t *testing.T) {
 	td := newTestData()
 	td.bootstrapRepo(GenerateCIDRDenyRules, 10, t)
 	ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
-	epPolicy := ip.DistillPolicy(DummyOwner{}, nil, false)
+	epPolicy := ip.DistillPolicy(DummyOwner{}, nil)
 	n := epPolicy.policyMapState.Len()
 	epPolicy.Ready()
 	ip.Detach()
@@ -242,7 +242,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 	defer repo.mutex.RUnlock()
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
-	policy := selPolicy.DistillPolicy(DummyOwner{}, nil, false)
+	policy := selPolicy.DistillPolicy(DummyOwner{}, nil)
 	policy.Ready()
 
 	expectedEndpointPolicy := EndpointPolicy{
@@ -334,7 +334,7 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
-	policy := selPolicy.DistillPolicy(DummyOwner{}, nil, false)
+	policy := selPolicy.DistillPolicy(DummyOwner{}, nil)
 	policy.Ready()
 
 	cachedSelectorHost := td.sc.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameHost])
@@ -429,7 +429,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 
-	policy := selPolicy.DistillPolicy(DummyOwner{}, nil, false)
+	policy := selPolicy.DistillPolicy(DummyOwner{}, nil)
 	policy.Ready()
 
 	rule1MapStateEntry := newMapStateEntry(td.wildcardCachedSelector, labels.LabelArrayList{ruleLabel}, 0, 0, true, DefaultAuthType, AuthTypeDisabled)
@@ -555,7 +555,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 
-	policy := selPolicy.DistillPolicy(DummyOwner{}, nil, false)
+	policy := selPolicy.DistillPolicy(DummyOwner{}, nil)
 	policy.Ready()
 
 	// Add new identity to test accumulation of MapChanges

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -171,6 +171,10 @@ func (d DummyOwner) GetID() uint64 {
 	return 1234
 }
 
+func (d DummyOwner) IsHost() bool {
+	return false
+}
+
 func (d DummyOwner) PolicyDebug(fields logrus.Fields, msg string) {
 	log.WithFields(fields).Info(msg)
 }
@@ -216,7 +220,7 @@ func BenchmarkRegenerateCIDRPolicyRules(b *testing.B) {
 	b.ResetTimer()
 	n := 0
 	for i := 0; i < b.N; i++ {
-		epPolicy := ip.DistillPolicy(DummyOwner{}, nil, false)
+		epPolicy := ip.DistillPolicy(DummyOwner{}, nil)
 		epPolicy.Ready()
 		n += epPolicy.policyMapState.Len()
 	}
@@ -230,7 +234,7 @@ func BenchmarkRegenerateL3IngressPolicyRules(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
-		policy := ip.DistillPolicy(DummyOwner{}, nil, false)
+		policy := ip.DistillPolicy(DummyOwner{}, nil)
 		policy.Ready()
 		ip.Detach()
 	}
@@ -242,7 +246,7 @@ func BenchmarkRegenerateL3EgressPolicyRules(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
-		policy := ip.DistillPolicy(DummyOwner{}, nil, false)
+		policy := ip.DistillPolicy(DummyOwner{}, nil)
 		policy.Ready()
 		ip.Detach()
 	}
@@ -292,7 +296,7 @@ func TestL7WithIngressWildcard(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, redirectTypeEnvoy, selPolicy.L4Policy.redirectTypes)
 
-	policy := selPolicy.DistillPolicy(DummyOwner{}, testRedirects, false)
+	policy := selPolicy.DistillPolicy(DummyOwner{}, testRedirects)
 	policy.Ready()
 
 	expectedEndpointPolicy := EndpointPolicy{
@@ -399,7 +403,7 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 
-	policy := selPolicy.DistillPolicy(DummyOwner{}, testRedirects, false)
+	policy := selPolicy.DistillPolicy(DummyOwner{}, testRedirects)
 	policy.Ready()
 
 	cachedSelectorHost := td.sc.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameHost])
@@ -504,7 +508,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 
-	policy := selPolicy.DistillPolicy(DummyOwner{}, testRedirects, false)
+	policy := selPolicy.DistillPolicy(DummyOwner{}, testRedirects)
 	policy.Ready()
 
 	rule1MapStateEntry := newMapStateEntry(td.wildcardCachedSelector, labels.LabelArrayList{ruleLabel}, 0, 0, false, DefaultAuthType, AuthTypeDisabled)
@@ -632,7 +636,7 @@ func TestMapStateWithIngress(t *testing.T) {
 	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
 	require.NoError(t, err)
 
-	policy := selPolicy.DistillPolicy(DummyOwner{}, testRedirects, false)
+	policy := selPolicy.DistillPolicy(DummyOwner{}, testRedirects)
 	policy.Ready()
 
 	// Add new identity to test accumulation of MapChanges


### PR DESCRIPTION
Please review commit-by-commit.

This PR attempts to clean up the policy generation logic behind the PolicyRepository interface, reducing the coupling between the endpoint and policy packages. There are no functional changes, just a lot of small cleanups.

The basic outline:

1. remove unused `selectorPolicy` field from the endpoint
2. make the policyCache a simple read-through cache
3. move SelectorPolicy interface to the underlying type, off of the cache placeholder
4. move policy calculation to the PolicyRepository itself
5. unexport the now-internal PolicyCache