### PR TITLE
envoy: Configure internal_address_config to avoid warning log

### DIFF
--- a/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.json
+++ b/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.json
@@ -52,6 +52,30 @@
                       }
                     }
                   ],
+                  "internal_address_config": {
+                    "cidr_ranges": [
+                      {
+                        "address_prefix": "10.0.0.0",
+                        "prefix_len": 8
+                      },
+                      {
+                        "address_prefix": "172.16.0.0",
+                        "prefix_len": 12
+                      },
+                      {
+                        "address_prefix": "192.168.0.0",
+                        "prefix_len": 16
+                      },
+                      {
+                        "address_prefix": "127.0.0.1",
+                        "prefix_len": 32
+                      },
+                      {
+                        "address_prefix": "::1",
+                        "prefix_len": 128
+                      }
+                    ]
+                  },
                   "stream_idle_timeout": "0s"
                 }
               }
@@ -119,6 +143,30 @@
                       }
                     }
                   ],
+                  "internal_address_config": {
+                    "cidr_ranges": [
+                      {
+                        "address_prefix": "10.0.0.0",
+                        "prefix_len": 8
+                      },
+                      {
+                        "address_prefix": "172.16.0.0",
+                        "prefix_len": 12
+                      },
+                      {
+                        "address_prefix": "192.168.0.0",
+                        "prefix_len": 16
+                      },
+                      {
+                        "address_prefix": "127.0.0.1",
+                        "prefix_len": 32
+                      },
+                      {
+                        "address_prefix": "::1",
+                        "prefix_len": 128
+                      }
+                    ]
+                  },
                   "stream_idle_timeout": "0s"
                 }
               }
@@ -185,6 +233,30 @@
                       }
                     }
                   ],
+                  "internal_address_config": {
+                    "cidr_ranges": [
+                      {
+                        "address_prefix": "10.0.0.0",
+                        "prefix_len": 8
+                      },
+                      {
+                        "address_prefix": "172.16.0.0",
+                        "prefix_len": 12
+                      },
+                      {
+                        "address_prefix": "192.168.0.0",
+                        "prefix_len": 16
+                      },
+                      {
+                        "address_prefix": "127.0.0.1",
+                        "prefix_len": 32
+                      },
+                      {
+                        "address_prefix": "::1",
+                        "prefix_len": 128
+                      }
+                    ]
+                  },
                   "stream_idle_timeout": "0s"
                 }
               }

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -646,6 +646,18 @@ func (s *xdsServer) AddAdminListener(port uint16, wg *completion.WaitGroup) {
 					TypedConfig: toAny(&envoy_extensions_filters_http_router_v3.Router{}),
 				},
 			}},
+			InternalAddressConfig: &envoy_config_http.HttpConnectionManager_InternalAddressConfig{
+				UnixSockets: false,
+				// only RFC1918 IP addresses will be considered internal
+				// https://datatracker.ietf.org/doc/html/rfc1918
+				CidrRanges: []*envoy_config_core.CidrRange{
+					{AddressPrefix: "10.0.0.0", PrefixLen: &wrapperspb.UInt32Value{Value: 8}},
+					{AddressPrefix: "172.16.0.0", PrefixLen: &wrapperspb.UInt32Value{Value: 12}},
+					{AddressPrefix: "192.168.0.0", PrefixLen: &wrapperspb.UInt32Value{Value: 16}},
+					{AddressPrefix: "127.0.0.1", PrefixLen: &wrapperspb.UInt32Value{Value: 32}},
+					{AddressPrefix: "::1", PrefixLen: &wrapperspb.UInt32Value{Value: 128}},
+				},
+			},
 			StreamIdleTimeout: &durationpb.Duration{}, // 0 == disabled
 			RouteSpecifier: &envoy_config_http.HttpConnectionManager_RouteConfig{
 				RouteConfig: &envoy_config_route.RouteConfiguration{
@@ -713,6 +725,18 @@ func (s *xdsServer) AddMetricsListener(port uint16, wg *completion.WaitGroup) {
 					TypedConfig: toAny(&envoy_extensions_filters_http_router_v3.Router{}),
 				},
 			}},
+			InternalAddressConfig: &envoy_config_http.HttpConnectionManager_InternalAddressConfig{
+				UnixSockets: false,
+				// only RFC1918 IP addresses will be considered internal
+				// https://datatracker.ietf.org/doc/html/rfc1918
+				CidrRanges: []*envoy_config_core.CidrRange{
+					{AddressPrefix: "10.0.0.0", PrefixLen: &wrapperspb.UInt32Value{Value: 8}},
+					{AddressPrefix: "172.16.0.0", PrefixLen: &wrapperspb.UInt32Value{Value: 12}},
+					{AddressPrefix: "192.168.0.0", PrefixLen: &wrapperspb.UInt32Value{Value: 16}},
+					{AddressPrefix: "127.0.0.1", PrefixLen: &wrapperspb.UInt32Value{Value: 32}},
+					{AddressPrefix: "::1", PrefixLen: &wrapperspb.UInt32Value{Value: 128}},
+				},
+			},
 			StreamIdleTimeout: &durationpb.Duration{}, // 0 == disabled
 			RouteSpecifier: &envoy_config_http.HttpConnectionManager_RouteConfig{
 				RouteConfig: &envoy_config_route.RouteConfiguration{


### PR DESCRIPTION
This was missed in the previous PR #35090

Relates: #34968, #35090

