### PR TITLE
node_local_store: prevent racey tests while using mock node store.

### DIFF
--- a/pkg/hubble/observer/local_node_watcher_test.go
+++ b/pkg/hubble/observer/local_node_watcher_test.go
@@ -54,10 +54,11 @@ func Test_LocalNodeWatcher(t *testing.T) {
 	}
 
 	var watcher *LocalNodeWatcher
+	store := node.NewTestLocalNodeStore(localNode)
 
 	t.Run("NewLocalNodeWatcher", func(t *testing.T) {
 		var err error
-		watcher, err = NewLocalNodeWatcher(ctx, node.NewTestLocalNodeStore(localNode))
+		watcher, err = NewLocalNodeWatcher(ctx, store)
 		require.NoError(t, err)
 		require.NotNil(t, watcher)
 	})
@@ -71,7 +72,9 @@ func Test_LocalNodeWatcher(t *testing.T) {
 	})
 
 	t.Run("update", func(t *testing.T) {
-		watcher.update(updatedNode)
+		store.Update(func(ln *node.LocalNode) {
+			*ln = updatedNode
+		})
 		var flow flowpb.Flow
 		stop, err := watcher.OnDecodedFlow(ctx, &flow)
 		require.False(t, stop)


### PR DESCRIPTION
When creating the test node store, the node is stored and is immediately
ready via Get.
However, a observable event is also emitted at the same time.
In the hubble node observer tests, the node was updated directly the
update function - however in some cases this would be overwritten
by the initial node event if the observable emit call was scheduled
late.

Instead, we update the store directly by mutating the node which
forces the updates to be serialized in the order they are called.

Fixes: https://github.com/cilium/cilium/issues/34092