### PR TITLE
Ciliumidentity: newly allocated ciliumidentity may become dirty data and the amount of ciliumidentity increase forever

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2206,7 +2206,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context) (regenTriggered bo
 	// continue even if the parent has given up. Enforce a timeout of two
 	// minutes to avoid blocking forever but give plenty of time to release
 	// the identity.
-	releaseCtx, cancel := context.WithTimeout(ctx, option.Config.KVstoreConnectivityTimeout)
+	releaseCtx, cancel := context.WithTimeout(context.Background(), option.Config.KVstoreConnectivityTimeout)
 	defer cancel()
 
 	releaseNewlyAllocatedIdentity := func() {


### PR DESCRIPTION
When pod changes label and immediately is deleted, the newly allocated identity may become a dirty data in Allocator's localKeys for the race between "resolve-identity controller -> identityLabelsChanged" and "func (e *Endpoint) Stop()" . But in func (a *Allocator) syncLocalKeys, which is called periodically every five minites, for every data in Allocator's localKeys, especially for the dirty data, it will delete the ciliumidentity's annotation "io.cilium.heartbeat" which is attached by the cilium-operator ciliumidentity gc. Then the amount of ciliumidentity in apiserver and etcd will increase forever, it is a big threat to apiserver and etcd.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #35946 

```release-note
Fixes a bug where identities may be leaked if a pod changes labels and is immediately deleted.
```
