### PR TITLE
[v1.15] fqdn: Skip "open ports" check for statically configured ports

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -164,10 +164,16 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 	port := uint16(option.Config.ToFQDNsProxyPort)
 	if port == 0 {
 		// Try reuse previous DNS proxy port number
-		if oldPort, err := d.l7Proxy.GetProxyPort(proxytypes.DNSProxyName); err == nil {
-			openLocalPorts := proxy.OpenLocalPorts()
-			if _, alreadyOpen := openLocalPorts[oldPort]; !alreadyOpen {
+		if oldPort, isStatic, err := d.l7Proxy.GetProxyPort(proxytypes.DNSProxyName); err == nil {
+			if isStatic {
 				port = oldPort
+			} else {
+				openLocalPorts := proxy.OpenLocalPorts()
+				if _, alreadyOpen := openLocalPorts[oldPort]; !alreadyOpen {
+					port = oldPort
+				} else {
+					log.WithField(logfields.Port, oldPort).Info("Unable re-use old DNS proxy port as it is already in use")
+				}
 			}
 		}
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -407,6 +407,11 @@ func (p *Proxy) restoreProxyPortsFromFile() error {
 	}
 
 	for name, pp := range portsMap {
+		if existing := p.proxyPorts[name]; existing != nil {
+			if existing.ProxyPort != 0 {
+				continue // do not overwrite explicitly set port
+			}
+		}
 		p.proxyPorts[name] = pp
 		p.allocatedPorts[pp.ProxyPort] = false
 		log.
@@ -426,6 +431,9 @@ func (p *Proxy) restoreProxyPortsFromIptables() {
 	for name, port := range portsMap {
 		pp := p.proxyPorts[name]
 		if pp != nil {
+			if pp.ProxyPort != 0 {
+				continue // do not overwrite explicitly set port
+			}
 			pp.ProxyPort = port
 		} else {
 			// Only CRD type proxy ports can be dynamically allocated. Assume a port
@@ -458,15 +466,15 @@ func (p *Proxy) RestoreProxyPorts() {
 }
 
 // GetProxyPort() returns the fixed listen port for a proxy, if any.
-func (p *Proxy) GetProxyPort(name string) (uint16, error) {
+func (p *Proxy) GetProxyPort(name string) (port uint16, isStatic bool, err error) {
 	// Accessing pp.proxyPort requires the lock
 	p.mutex.RLock()
 	defer p.mutex.RUnlock()
 	pp := p.proxyPorts[name]
 	if pp != nil {
-		return pp.ProxyPort, nil
+		return pp.ProxyPort, pp.isStatic, nil
 	}
-	return 0, proxyNotFoundError(name)
+	return 0, false, proxyNotFoundError(name)
 }
 
 // AllocateCRDProxyPort() allocates a new port for listener 'name', or returns the current one if

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -69,7 +69,7 @@ func (s *ProxySuite) TestPortAllocator(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(port, Not(Equals), 0)
 
-	port1, err := p.GetProxyPort("listener1")
+	port1, _, err := p.GetProxyPort("listener1")
 	c.Assert(err, IsNil)
 	c.Assert(port1, Equals, port)
 
@@ -92,7 +92,7 @@ func (s *ProxySuite) TestPortAllocator(c *C) {
 	c.Assert(err, IsNil)
 
 	// ProxyPort lingers and can still be found, but it's port is zeroed
-	port1b, err := p.GetProxyPort("listener1")
+	port1b, _, err := p.GetProxyPort("listener1")
 	c.Assert(err, IsNil)
 	c.Assert(port1b, Equals, uint16(0))
 	c.Assert(pp.ProxyPort, Equals, uint16(0))


### PR DESCRIPTION
 * [x] #33230 (@gandro) :warning: resolved conflicts

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 33230
```

This is a release blocker because the referenced commit has been backported to v1.15
