### PR TITLE
ci: use the VERSION file from the PR branch in push-charts-ci.yaml

### DIFF
--- a/.github/workflows/push-chart-ci.yaml
+++ b/.github/workflows/push-chart-ci.yaml
@@ -60,7 +60,6 @@ jobs:
         mkdir -p ../cilium-default-branch/contrib/scripts
         if [[ -f ./contrib/scripts/print-chart-version.sh ]]; then
           cp ./contrib/scripts/print-chart-version.sh ../cilium-default-branch/contrib/scripts
-          cp VERSION ../cilium-default-branch
         else
           echo "./contrib/scripts/print-chart-version.sh missing. Perhaps it needs to be backported to your target branch?"
           exit 1
@@ -100,6 +99,8 @@ jobs:
       run: |
         set -o pipefail
         set -e
+        # print-chart-version.sh expects the VERSION file in a specific location, so copy it there
+        cp VERSION ../cilium-default-branch
         echo "chart_version=$(../cilium-default-branch/contrib/scripts/print-chart-version.sh)" | tee -a $GITHUB_OUTPUT
 
   push-charts:


### PR DESCRIPTION
The Push Chart CI workflow uses the default branch when running `print-chart-version.sh`. Other workflows checkout the PR branch for the same script. The `print-chart-version.sh` script uses the VERSION file at the repo root to determine the tags of the Helm charts that are pushed, which means that we were seeing inconsistencies between the chart tag that was being pushed and the chart tags that other workflows were looking for when PRs are opened against version branches.

This change to the Push Chart CI workflow copies the VERSION file from the PR branch into the location that `print-chart-version.sh` expects, so that all workflows are now getting the VERSION from the same file.
