### PR TITLE
ci/ipsec: Cilium agents in ci-ipsec-e2e no longer share host's boot ID

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -200,6 +200,17 @@ jobs:
           kind-params: "${{ steps.kind-params.outputs.params }}"
           kind-image: ${{ env.KIND_K8S_IMAGE }}
 
+      - name: Setup bootid file
+        uses: cilium/little-vm-helper@97c89f004bd0ab4caeacfe92ebc956e13e362e6b # v0.0.19
+        with:
+          provision: 'false'
+          cmd: |
+            set -ex
+            for container in \$(docker ps -q); do
+              docker exec \$container mkdir -p /var/run/cilium/
+              docker exec \$container sh -c 'cat /proc/sys/kernel/random/uuid > /var/run/cilium/boot_id'
+            done
+
       - name: Start Cilium KVStore
         id: kvstore
         if: matrix.kvstore == 'true'
@@ -246,7 +257,7 @@ jobs:
           kubectl create -n kube-system secret generic cilium-ipsec-keys \
             --from-literal=keys="3+ ${key}"
 
-          cilium install ${{ steps.cilium-config.outputs.config }} ${{ steps.kvstore.outputs.config }}
+          cilium install ${{ steps.cilium-config.outputs.config }} ${{ steps.kvstore.outputs.config }} --set extraConfig.boot-id-file=/var/run/cilium/boot_id
 
           cilium status --wait
           kubectl get pods --all-namespaces -o wide

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1057,6 +1057,10 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableEndpointLockdownOnPolicyOverflow, false, "When an endpoint's policy map overflows, shutdown all (ingress and egress) network traffic for that endpoint.")
 	option.BindEnv(vp, option.EnableEndpointLockdownOnPolicyOverflow)
 
+	flags.String(option.BootIDFilename, "/proc/sys/kernel/random/boot_id", "Path to filename of the boot ID")
+	flags.MarkHidden(option.BootIDFilename)
+	option.BindEnv(vp, option.BootIDFilename)
+
 	if err := vp.BindPFlags(flags); err != nil {
 		log.Fatalf("BindPFlags failed: %s", err)
 	}

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -806,6 +806,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeChurnXFRMLeaks(t *testing.T) {
 	// Cover the XFRM configuration for IPAM modes cluster-pool, kubernetes, etc.
 	config := s.nodeConfigTemplate
 	config.EnableIPSec = true
+	option.Config.BootIDFile = "/proc/sys/kernel/random/boot_id"
 	s.testNodeChurnXFRMLeaksWithConfig(t, config)
 }
 
@@ -835,6 +836,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeChurnXFRMLeaksSubnetMode(t *testi
 	require.NoError(t, err)
 	require.NotNil(t, ipv6PodSubnets)
 	config.IPv6PodSubnets = []*cidr.CIDR{ipv6PodSubnets}
+	option.Config.BootIDFile = "/proc/sys/kernel/random/boot_id"
 	s.testNodeChurnXFRMLeaksWithConfig(t, config)
 }
 

--- a/pkg/node/bootid.go
+++ b/pkg/node/bootid.go
@@ -11,8 +11,6 @@ var (
 )
 
 func GetBootID() string {
-	logOnce.Do(func() {
-		log.Infof("Local boot ID is %q", localBootID)
-	})
+	logOnce.Do(initLocalBootID)
 	return localBootID
 }

--- a/pkg/node/bootid_linux.go
+++ b/pkg/node/bootid_linux.go
@@ -1,20 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
+//go:build linux
+
 package node
 
 import (
 	"os"
 	"strings"
+
+	"github.com/cilium/cilium/pkg/option"
 )
 
-var bootIDFilePath = "/proc/sys/kernel/random/boot_id"
-
-func init() {
-	bootID, err := os.ReadFile(bootIDFilePath)
+func initLocalBootID() {
+	bootID, err := os.ReadFile(option.Config.BootIDFile)
 	if err != nil {
-		log.WithError(err).Warnf("Could not read boot id from %s", bootIDFilePath)
+		log.WithError(err).Warnf("Could not read boot id from %s", option.Config.BootIDFile)
 		return
 	}
 	localBootID = strings.TrimSpace(string(bootID))
+	log.Infof("Local boot ID is %q", localBootID)
 }

--- a/pkg/node/bootid_other.go
+++ b/pkg/node/bootid_other.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !linux
+
+package node
+
+func initLocalBootID() {
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -776,6 +776,11 @@ const (
 	// This feature will encrypt overlay traffic before it leaves the cluster.
 	EnableIPSecEncryptedOverlay = "enable-ipsec-encrypted-overlay"
 
+	// BootIDFilename is a hidden flag that allows users to specify a
+	// filename other than /proc/sys/kernel/random/boot_id. This can be
+	// useful for testing purposes in local containerized cluster.
+	BootIDFilename = "boot-id-file"
+
 	// EnableWireguard is the name of the option to enable WireGuard
 	EnableWireguard = "enable-wireguard"
 
@@ -1572,6 +1577,9 @@ type DaemonConfig struct {
 
 	// EnableIPSecEncryptedOverlay enables IPSec encryption for overlay traffic.
 	EnableIPSecEncryptedOverlay bool
+
+	// BootIDFile is the file containing the boot ID of the node
+	BootIDFile string
 
 	// EnableWireguard enables Wireguard encryption
 	EnableWireguard bool
@@ -2967,6 +2975,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.BPFConntrackAccounting = vp.GetBool(BPFConntrackAccounting)
 	c.EnableIPSecEncryptedOverlay = vp.GetBool(EnableIPSecEncryptedOverlay)
 	c.LBSourceRangeAllTypes = vp.GetBool(LBSourceRangeAllTypes)
+	c.BootIDFile = vp.GetString(BootIDFilename)
 
 	c.ServiceNoBackendResponse = vp.GetString(ServiceNoBackendResponse)
 	switch c.ServiceNoBackendResponse {


### PR DESCRIPTION
Containers on the same host share boot id (/proc/sys/kernel/random/boot_id), previous IPsec kind-based e2e tests didn't fully cover the per-node-pair key feature.

This PR introduces a new hidden flag `boot-id-file` for specifying boot ID path, allows us to cover the missing scenario in CI.

ci-ipsec-upgrade can't be covered in this PR because 1.16 still shares boot ID. Upgrade from 1.16 to 1.17 in CI will break connectivity as new cilium suddenly uses a different boot ID.