### PR TITLE
Fix for extraEnv in clustermesh-apiserver

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -224,6 +224,7 @@ spec:
           {{- toYaml . | trim | nindent 10 }}
           {{- end }}
         {{- with .Values.clustermesh.apiserver.extraEnv }}
+        env:
         {{- toYaml . | trim | nindent 8 }}
         {{- end }}
         ports:


### PR DESCRIPTION
This fixes a bug, which is triggered by setting the extraEnv variable for the clustermesh-apiserver in the cilium helm chart.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
