### PR TITLE
treewide: use {assert|require}.JSONEq to compare JSON strings in tests

### DIFF
--- a/cilium-dbg/cmd/helpers_test.go
+++ b/cilium-dbg/cmd/helpers_test.go
@@ -41,7 +41,7 @@ func TestExpandNestedJSON(t *testing.T) {
 	buf = bytes.NewBufferString(`{"foo": ["{\n  \"port\": 8080,\n  \"protocol\": \"TCP\"\n}"]}`)
 	res, err = expandNestedJSON(*buf)
 	require.NoError(t, err)
-	require.EqualValues(t, `{"foo": [{
+	require.JSONEq(t, `{"foo": [{
   "port": 8080,
   "protocol": "TCP"
 }]}`, res.String())
@@ -286,7 +286,7 @@ func TestExpandNestedJSON(t *testing.T) {
 ]`)
 	res, err = expandNestedJSON(*buf)
 	require.NoError(t, err)
-	require.EqualValues(t, `[
+	require.JSONEq(t, `[
   {
     "id": 2669,
     "spec": {

--- a/pkg/envoy/accesslog_server_test.go
+++ b/pkg/envoy/accesslog_server_test.go
@@ -66,7 +66,7 @@ func TestKafkaLogNoTopic(t *testing.T) {
 		})
 
 		require.Len(t, notifier.kafka, 1)
-		require.Equal(t, `{"ErrorCode":42,"APIVersion":3,"APIKey":"fetch","CorrelationID":76541,"Topic":{}}`, notifier.kafka[0])
+		require.JSONEq(t, `{"ErrorCode":42,"APIVersion":3,"APIKey":"fetch","CorrelationID":76541,"Topic":{}}`, notifier.kafka[0])
 	})
 }
 
@@ -85,7 +85,7 @@ func TestKafkaLogSingleTopic(t *testing.T) {
 		})
 
 		require.Len(t, notifier.kafka, 1)
-		require.Equal(t, `{"ErrorCode":42,"APIVersion":3,"APIKey":"fetch","CorrelationID":76541,"Topic":{"Topic":"topic 1"}}`, notifier.kafka[0])
+		require.JSONEq(t, `{"ErrorCode":42,"APIVersion":3,"APIKey":"fetch","CorrelationID":76541,"Topic":{"Topic":"topic 1"}}`, notifier.kafka[0])
 	})
 }
 
@@ -106,7 +106,7 @@ func TestKafkaLogMultipleTopics(t *testing.T) {
 		})
 
 		require.Len(t, notifier.kafka, 2)
-		require.Equal(t, `{"ErrorCode":42,"APIVersion":3,"APIKey":"fetch","CorrelationID":76541,"Topic":{"Topic":"topic 1"}}`, notifier.kafka[0])
-		require.Equal(t, `{"ErrorCode":42,"APIVersion":3,"APIKey":"fetch","CorrelationID":76541,"Topic":{"Topic":"topic 2"}}`, notifier.kafka[1])
+		require.JSONEq(t, `{"ErrorCode":42,"APIVersion":3,"APIKey":"fetch","CorrelationID":76541,"Topic":{"Topic":"topic 1"}}`, notifier.kafka[0])
+		require.JSONEq(t, `{"ErrorCode":42,"APIVersion":3,"APIKey":"fetch","CorrelationID":76541,"Topic":{"Topic":"topic 2"}}`, notifier.kafka[1])
 	})
 }

--- a/pkg/hubble/exporter/exporter_test.go
+++ b/pkg/hubble/exporter/exporter_test.go
@@ -65,7 +65,7 @@ func TestExporter(t *testing.T) {
 {"agent_event":{},"node_name":"my-node","time":"1970-01-01T00:00:02Z"}
 {"debug_event":{},"node_name":"my-node","time":"1970-01-01T00:00:03Z"}
 {"lost_events":{},"node_name":"my-node","time":"1970-01-01T00:00:04Z"}
-`, buf.String())
+`, buf.String()) //nolint: testifylint
 }
 
 func TestExporterWithFilters(t *testing.T) {
@@ -142,7 +142,7 @@ func TestExporterWithFilters(t *testing.T) {
 		assert.NoError(t, err)
 
 	}
-	assert.Equal(t,
+	assert.JSONEq(t,
 		`{"flow":{"time":"1970-01-01T00:00:13Z","source":{"namespace":"namespace-a","pod_name":"x"}},"time":"1970-01-01T00:00:13Z"}
 `, buf.String())
 }
@@ -260,7 +260,7 @@ func TestExporterWithFieldMask(t *testing.T) {
 
 	assert.Equal(t, `{"flow":{"source":{"namespace":"nsA","pod_name":"podA"}}}
 {"flow":{}}
-`, buf.String())
+`, buf.String()) //nolint: testifylint
 }
 
 func BenchmarkExporter(b *testing.B) {

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -28,13 +28,13 @@ func TestGetLogFormat(t *testing.T) {
 
 	// case doesn't matter with log options
 	opts[FormatOpt] = "JsOn"
-	require.Equal(t, LogFormatJSON, opts.GetLogFormat())
+	require.Equal(t, LogFormatJSON, opts.GetLogFormat()) //nolint: testifylint
 
 	opts[FormatOpt] = "Invalid"
 	require.Equal(t, DefaultLogFormatTimestamp, opts.GetLogFormat())
 
 	opts[FormatOpt] = "JSON-TS"
-	require.Equal(t, LogFormatJSONTimestamp, opts.GetLogFormat())
+	require.Equal(t, LogFormatJSONTimestamp, opts.GetLogFormat()) //nolint: testifylint
 }
 
 func TestSetLogLevel(t *testing.T) {

--- a/pkg/maps/api_test.go
+++ b/pkg/maps/api_test.go
@@ -78,7 +78,7 @@ func Test_getMapNameEvents(t *testing.T) {
 	resp.WriteResponse(mw, fp)
 	d, err := safeio.ReadAllLimit(w.Body, safeio.MB)
 	assert.NoError(err)
-	assert.Equal(`{"action":"update","desired-action":"sync","key":"\u003cnil\u003e","last-error":"\u003cnil\u003e","timestamp":"2006-01-02T15:04:05.000Z","value":"\u003cnil\u003e"}`+"\n", string(d))
+	assert.JSONEq(`{"action":"update","desired-action":"sync","key":"\u003cnil\u003e","last-error":"\u003cnil\u003e","timestamp":"2006-01-02T15:04:05.000Z","value":"\u003cnil\u003e"}`+"\n", string(d))
 }
 
 func Test_getMapNameEventsMapErrors(t *testing.T) {


### PR DESCRIPTION
PR #35956 updates golangci-lint to v1.62.0. This new version surfaces a new lint error, which this PR aims to address:
```
encoded-compare: use require.JSONEq (testifylint)
```