### PR TITLE
cilium-cli: retry exec-in-pod requests in case of transient errors

### DIFF
--- a/cilium-cli/connectivity/check/action.go
+++ b/cilium-cli/connectivity/check/action.go
@@ -302,6 +302,12 @@ func (a *Action) ExecInPod(ctx context.Context, cmd []string) {
 		if err == nil && strings.TrimSpace(pingHeaderPattern.ReplaceAllString(output.String(), "")) == "" {
 			a.Debugf("retrying command %s due to inconclusive results", cmdStr)
 			continue
+		} else if err != nil {
+			exitCode, _ := a.extractExitCode(err)
+			if exitCode == ExitInvalidCode {
+				a.Debugf("retrying command %s to to command execution error", cmdStr)
+				continue
+			}
 		}
 		break
 	}

--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -54,6 +54,8 @@ import (
 	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
+const getLogsRetries = 3
+
 func init() {
 	// Register the Cilium types in the default scheme.
 	_ = ciliumv2.AddToScheme(scheme.Scheme)
@@ -946,7 +948,17 @@ func (c *Client) ListCiliumPodIPPools(ctx context.Context, opts metav1.ListOptio
 func (c *Client) GetLogs(ctx context.Context, namespace, name, container string, opts corev1.PodLogOptions) (string, error) {
 	opts.Container = container
 	r := c.Clientset.CoreV1().Pods(namespace).GetLogs(name, &opts)
-	s, err := r.Stream(ctx)
+	var s io.ReadCloser
+	var err error
+	// rety request upon EOF to work around transient (?) failures on Azure, see
+	// https://github.com/cilium/cilium/issues/29845
+	for range getLogsRetries {
+		s, err = r.Stream(ctx)
+		if errors.Is(err, io.EOF) {
+			continue
+		}
+		break
+	}
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
In some cases, connectivity tests fail due to transient errors with the underlying SPDY stream during command execution in pods. This is especially prevalent on AKS. The source of these errors is unknown but according to https://github.com/cilium/cilium/issues/29845#issuecomment-1856143700 (and following discussion) there is not much that can be done to prevent them, except for treating the error as transient and retrying the respective request. Do that for the known cases documented in #29845.

Also see commit messages for details.

Fixes: #29845
