### PR TITLE
[v1.15]  tests-e2e-upgrade: No longer use secondary network for test 14 

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -255,7 +255,7 @@ jobs:
             kube-proxy: 'iptables'
             kpr: 'true'
             devices: '{eth0,eth1}'
-            secondary-network: 'true'
+            secondary-network: 'false'
             tunnel: 'vxlan'
             lb-mode: 'snat'
             egress-gateway: 'true'


### PR DESCRIPTION
PR https://github.com/cilium/cilium/pull/35893 fixed an escaping issue in that workflow but it seems like the correct escaping (which made `--secondary-network` work again) seem to have exposed an underlying issue with that configuration where it started failing in `north-south-loadbalancing-with-l7-policy` (https://github.com/cilium/cilium/issues/35967).

In v1.16, we seemed to have fixed that problem in commit https://github.com/cilium/cilium/commit/1c42d6fc4068674302c91d630e9ad2dff8376d48, but in v1.15 running a different kernel version breaks the workflow to the point where it cannot even install Cilium anymore.

Therefore, this commit reverts the test back to not using a secondary network which is what it was effectively running previously.