### PR TITLE
bgp: fix race in bgp stores

### DIFF
--- a/pkg/bgpv1/manager/store/diffstore.go
+++ b/pkg/bgpv1/manager/store/diffstore.go
@@ -90,7 +90,9 @@ func NewDiffStore[T k8sRuntime.Object](params diffStoreParams[T]) DiffStore[T] {
 	params.JobGroup.Add(
 		job.OneShot("diffstore-events",
 			func(ctx context.Context, health cell.Health) (err error) {
+				ds.mu.Lock()
 				ds.store, err = ds.resource.Store(ctx)
+				ds.mu.Unlock()
 				if err != nil {
 					return fmt.Errorf("error creating resource store: %w", err)
 				}

--- a/pkg/bgpv1/manager/store/diffstore_test.go
+++ b/pkg/bgpv1/manager/store/diffstore_test.go
@@ -110,6 +110,15 @@ func TestDiffSignal(t *testing.T) {
 	fixture.diffStore.InitDiff(testCallerID1)
 	fixture.diffStore.InitDiff(testCallerID2)
 
+	// wait for initial sync signal
+	timer := time.NewTimer(5 * time.Second)
+	select {
+	case <-fixture.signaler.Sig:
+		timer.Stop()
+	case <-timer.C:
+		t.Fatal("No signal sent by diffstore")
+	}
+
 	// Add an initial object.
 	err = tracker.Add(&slimv1.Service{
 		ObjectMeta: v1.ObjectMeta{
@@ -120,7 +129,7 @@ func TestDiffSignal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	timer := time.NewTimer(5 * time.Second)
+	timer = time.NewTimer(5 * time.Second)
 	select {
 	case <-fixture.signaler.Sig:
 		timer.Stop()

--- a/pkg/bgpv1/manager/store/resource_store.go
+++ b/pkg/bgpv1/manager/store/resource_store.go
@@ -63,7 +63,9 @@ func NewBGPCPResourceStore[T k8sRuntime.Object](params bgpCPResourceStoreParams[
 	params.JobGroup.Add(
 		job.OneShot("bgpcp-resource-store-events",
 			func(ctx context.Context, health cell.Health) (err error) {
+				s.mu.Lock()
 				s.store, err = s.resource.Store(ctx)
+				s.mu.Unlock()
 				if err != nil {
 					return fmt.Errorf("error creating resource store: %w", err)
 				}


### PR DESCRIPTION
Resource store need to be protected by mutex, it is read and written by different go routines. Since resource.Store is blocking call, store is nil till this call is completed. In the meantime, reconciliation will fail because store is nil. Adding mutex around resource.Store will block reconciliation till store is initialized. This prevents the case where reconciliation is failed and never retried.

Fixes: #35607
Fixes: #35872
