### PR TITLE
policy: No-op Identity Allocator

### DIFF
--- a/pkg/allocator/allocator_test.go
+++ b/pkg/allocator/allocator_test.go
@@ -532,7 +532,7 @@ func TestWatchRemoteKVStore(t *testing.T) {
 	var wg sync.WaitGroup
 	var synced atomic.Bool
 
-	run := func(ctx context.Context, rc *RemoteCache) context.CancelFunc {
+	run := func(ctx context.Context, rc RemoteIDCache) context.CancelFunc {
 		ctx, cancel := context.WithCancel(ctx)
 		wg.Add(1)
 		go func() {
@@ -548,7 +548,7 @@ func TestWatchRemoteKVStore(t *testing.T) {
 		synced.Store(false)
 	}
 
-	global := Allocator{remoteCaches: make(map[string]*RemoteCache)}
+	global := Allocator{remoteCaches: make(map[string]*remoteCache)}
 	events := make(AllocatorEventChan, 10)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -91,7 +91,7 @@ type RemoteIdentityWatcher interface {
 	// identity cache. remoteName should be unique unless replacing an existing
 	// remote's backend. When cachedPrefix is set, identities are assumed to be
 	// stored under the "cilium/cache" prefix, and the watcher is adapted accordingly.
-	WatchRemoteIdentities(remoteName string, remoteID uint32, backend kvstore.BackendOperations, cachedPrefix bool) (*allocator.RemoteCache, error)
+	WatchRemoteIdentities(remoteName string, remoteID uint32, backend kvstore.BackendOperations, cachedPrefix bool) (allocator.RemoteIDCache, error)
 
 	// RemoveRemoteIdentities removes any reference to a remote identity source,
 	// emitting a deletion event for all previously known identities.

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -62,7 +62,7 @@ type remoteCluster struct {
 
 	// remoteIdentityCache is a locally cached copy of the identity
 	// allocations in the remote cluster
-	remoteIdentityCache *allocator.RemoteCache
+	remoteIdentityCache allocator.RemoteIDCache
 
 	// status is the function which fills the common part of the status.
 	status common.StatusFunc
@@ -156,14 +156,17 @@ func (rc *remoteCluster) Status() *models.RemoteCluster {
 
 	status.NumNodes = int64(rc.remoteNodes.NumEntries())
 	status.NumSharedServices = int64(rc.remoteServices.NumEntries())
-	status.NumIdentities = int64(rc.remoteIdentityCache.NumEntries())
 	status.NumEndpoints = int64(rc.ipCacheWatcher.NumEntries())
 
 	status.Synced = &models.RemoteClusterSynced{
-		Nodes:      rc.remoteNodes.Synced(),
-		Services:   rc.remoteServices.Synced(),
-		Identities: rc.remoteIdentityCache.Synced(),
-		Endpoints:  rc.ipCacheWatcher.Synced(),
+		Nodes:     rc.remoteNodes.Synced(),
+		Services:  rc.remoteServices.Synced(),
+		Endpoints: rc.ipCacheWatcher.Synced(),
+	}
+
+	if rc.remoteIdentityCache != nil {
+		status.NumIdentities = int64(rc.remoteIdentityCache.NumEntries())
+		status.Synced.Identities = rc.remoteIdentityCache.Synced()
 	}
 
 	status.Ready = status.Ready &&

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -789,7 +789,7 @@ func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Ide
 // identity cache. remoteName should be unique unless replacing an existing
 // remote's backend. When cachedPrefix is set, identities are assumed to be
 // stored under the "cilium/cache" prefix, and the watcher is adapted accordingly.
-func (m *CachingIdentityAllocator) WatchRemoteIdentities(remoteName string, remoteID uint32, backend kvstore.BackendOperations, cachedPrefix bool) (*allocator.RemoteCache, error) {
+func (m *CachingIdentityAllocator) WatchRemoteIdentities(remoteName string, remoteID uint32, backend kvstore.BackendOperations, cachedPrefix bool) (allocator.RemoteIDCache, error) {
 	<-m.globalIdentityAllocatorInitialized
 
 	prefix := m.identitiesPath

--- a/pkg/identity/cache/noop_allocator.go
+++ b/pkg/identity/cache/noop_allocator.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cache
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/allocator"
+	"github.com/cilium/cilium/pkg/identity"
+	identitymodel "github.com/cilium/cilium/pkg/identity/model"
+	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+type NoopIdentityAllocator struct {
+	// allocatorInitialized is closed when the allocator is initialized.
+	allocatorInitialized chan struct{}
+}
+
+func NewNoopIdentityAllocator() *NoopIdentityAllocator {
+	return &NoopIdentityAllocator{
+		allocatorInitialized: make(chan struct{}),
+	}
+}
+
+func (n *NoopIdentityAllocator) WaitForInitialGlobalIdentities(context.Context) error {
+	return nil
+}
+
+func (n *NoopIdentityAllocator) AllocateIdentity(ctx context.Context, lbls labels.Labels, notifyOwner bool, oldNID identity.NumericIdentity) (*identity.Identity, bool, error) {
+	if option.Config.Debug {
+		log.WithFields(logrus.Fields{
+			logfields.IdentityLabels: lbls.String(),
+			logfields.Identity:       identity.ReservedIdentityInit,
+		}).Debug("Assigning a fixed identity that is not based on labels, because network policies are disabled")
+	}
+
+	initID := identity.LookupReservedIdentity(identity.ReservedIdentityInit)
+	return initID, false, nil
+}
+
+func (n *NoopIdentityAllocator) Release(context.Context, *identity.Identity, bool) (released bool, err error) {
+	// No need to release identities. All endpoints will have the same identity.
+	// The existing global identities will be cleaned up.
+	return false, nil
+}
+
+func (n *NoopIdentityAllocator) LookupIdentity(ctx context.Context, lbls labels.Labels) *identity.Identity {
+	// Lookup only reserved identities.
+	return identity.LookupReservedIdentityByLabels(lbls)
+}
+
+func (n *NoopIdentityAllocator) LookupIdentityByID(ctx context.Context, id identity.NumericIdentity) *identity.Identity {
+	// Lookup only reserved identities.
+	return identity.LookupReservedIdentity(id)
+}
+
+func (n *NoopIdentityAllocator) GetIdentityCache() identity.IdentityMap {
+	// Return only reserved identities, because reserved identities are
+	// statically initialized and are not managed by identity allocator.
+	cache := identity.IdentityMap{}
+
+	identity.IterateReservedIdentities(func(ni identity.NumericIdentity, id *identity.Identity) {
+		cache[ni] = id.Labels.LabelArray()
+	})
+
+	return cache
+}
+
+func (n *NoopIdentityAllocator) GetIdentities() IdentitiesModel {
+	// Return only reserved identities, because reserved identities are
+	// statically initialized and are not managed by identity allocator.
+	identities := IdentitiesModel{}
+
+	identity.IterateReservedIdentities(func(ni identity.NumericIdentity, id *identity.Identity) {
+		identities = append(identities, identitymodel.CreateModel(id))
+	})
+
+	return identities
+}
+
+func (n *NoopIdentityAllocator) WithholdLocalIdentities(nids []identity.NumericIdentity) {
+	// No-op, because local identities are not used when network policies are disabled.
+}
+
+func (n *NoopIdentityAllocator) UnwithholdLocalIdentities(nids []identity.NumericIdentity) {
+	// No-op, because local identities are not used when network policies are disabled.
+}
+
+type NoopRemoteIDCache struct{}
+
+func (n *NoopRemoteIDCache) NumEntries() int {
+	return 0
+}
+
+func (n *NoopRemoteIDCache) Synced() bool {
+	return true
+}
+
+func (n *NoopRemoteIDCache) Watch(ctx context.Context, onSync func(context.Context)) {
+	onSync(ctx)
+}
+
+func (n *NoopIdentityAllocator) WatchRemoteIdentities(remoteName string, remoteID uint32, backend kvstore.BackendOperations, cachedPrefix bool) (allocator.RemoteIDCache, error) {
+	// Remote watchers are not used when the cluster has network policies disabled.
+	return &NoopRemoteIDCache{}, nil
+}
+
+func (n *NoopIdentityAllocator) RemoveRemoteIdentities(name string) {
+	// No-op, because remote identities are not used when network policies are disabled.
+}
+
+func (n *NoopIdentityAllocator) InitIdentityAllocator(versioned.Interface) <-chan struct{} {
+	close(n.allocatorInitialized)
+	return n.allocatorInitialized
+}
+
+func (n *NoopIdentityAllocator) RestoreLocalIdentities() (map[identity.NumericIdentity]*identity.Identity, error) {
+	// No-op, because local identities are not used when network policies are disabled.
+	return make(map[identity.NumericIdentity]*identity.Identity), nil
+}
+
+func (n *NoopIdentityAllocator) ReleaseRestoredIdentities() {
+	// No-op, because restored identities are not used when network policies are disabled.
+}
+
+func (n *NoopIdentityAllocator) Close() {}

--- a/pkg/identity/cache/noop_allocator_test.go
+++ b/pkg/identity/cache/noop_allocator_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestNoopAllocateIdentity(t *testing.T) {
+	testutils.IntegrationTest(t)
+	kvstore.SetupDummy(t, "etcd")
+
+	// Init labels are always assigned with NoopAllocator.
+	initID := identity.LookupReservedIdentity(identity.ReservedIdentityInit)
+
+	lbls1 := labels.NewLabelsFromSortedList("blah=%%//!!;id=foo;user=anna")
+	lbls2 := labels.NewLabelsFromSortedList("id=bar;user=anna")
+	lbls3 := labels.NewLabelsFromSortedList("id=bar;user=susan")
+
+	mgr := NewNoopIdentityAllocator()
+	<-mgr.InitIdentityAllocator(nil)
+	defer mgr.Close()
+
+	// Noop AllocateIdentity always returns id=init, isNew=false, error=nil,
+	// regardless of the provided labels.
+	id1a, isNew, err := mgr.AllocateIdentity(context.Background(), lbls1, false, identity.InvalidIdentity)
+	require.NotNil(t, id1a)
+	require.NoError(t, err)
+	require.False(t, isNew)
+	require.EqualValues(t, initID.LabelArray, id1a.LabelArray)
+
+	id1b, isNew, err := mgr.AllocateIdentity(context.Background(), lbls1, false, identity.InvalidIdentity)
+	require.NotNil(t, id1b)
+	require.NoError(t, err)
+	require.False(t, isNew)
+	require.EqualValues(t, initID.LabelArray, id1b.LabelArray)
+
+	id2, isNew, err := mgr.AllocateIdentity(context.Background(), lbls2, false, identity.InvalidIdentity)
+	require.NotNil(t, id2)
+	require.NoError(t, err)
+	require.False(t, isNew)
+	require.EqualValues(t, initID.LabelArray, id2.LabelArray)
+
+	id3, isNew, err := mgr.AllocateIdentity(context.Background(), lbls3, false, identity.InvalidIdentity)
+	require.NotNil(t, id3)
+	require.NoError(t, err)
+	require.False(t, isNew)
+	require.EqualValues(t, initID.LabelArray, id3.LabelArray)
+
+	reservedID := identity.LookupReservedIdentity(identity.ReservedIdentityHost)
+	id4, isNew, err := mgr.AllocateIdentity(context.Background(), reservedID.Labels, false, identity.InvalidIdentity)
+	require.NotNil(t, id4)
+	require.NoError(t, err)
+	require.False(t, isNew)
+	require.EqualValues(t, initID.LabelArray, id4.LabelArray)
+}


### PR DESCRIPTION
Ref: https://github.com/cilium/cilium/issues/33360

**Description**
As part of the network policy modularization and decoupling of the network policy enforcement system from the endpoint, the no-op allocator aims to provide a possibility of disabling the identity allocation system when network policies are disabled.

**Motivation**
The scalability of network policy feature is limited when the scalability dimensions, # of nodes and pod churn rate, are stretched. Cilium has many networking features that scale better, or are unaffected by these scalability dimensions. Currently, disabling network policies to reach higher scale for other features is the only feasible solution.

Note: The plan is to improve scalability of network policies, so that it can reach higher scales that are required.

**Follow-up**
Subsequently, the plan is to agree on a configuration set that would determine if the identity allocation system should be disabled, and put the no-op allocator to use.

Proposed config:
- EnablePolicy=never
- DisableCiliumEndpointCRD=true
- EnableK8sNetworkPolicy=false
- EnableCiliumNetworkPolicy=false
- EnableCiliumClusterwideNetworkPolicy=false

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>
