### PR TITLE
hubble: Stop building 32-bit binaries

### DIFF
--- a/hubble/Makefile
+++ b/hubble/Makefile
@@ -37,10 +37,10 @@ local-release: clean
 				ARCHS='amd64 arm64'; \
 				;; \
 			linux) \
-				ARCHS='386 amd64 arm arm64'; \
+				ARCHS='amd64 arm64'; \
 				;; \
 			windows) \
-				ARCHS='386 amd64 arm64'; \
+				ARCHS='amd64 arm64'; \
 				EXT=".exe"; \
 				;; \
 		esac; \


### PR DESCRIPTION
Similar to cilium-cli [^1], it's time to move on and drop 32-bit binaries from release artifacts.

[^1]: https://github.com/cilium/cilium-cli/pull/2136/commits/dc9f2e2c08d7c9a0c3fd179c2ffa9bbbdeab0e50