### PR TITLE
bgpv2: Add a knob to disable CRD status reporting

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -107,6 +107,7 @@ cilium-agent [flags]
       --enable-bandwidth-manager                                  Enable BPF bandwidth manager
       --enable-bbr                                                Enable BBR for the bandwidth manager
       --enable-bgp-control-plane                                  Enable the BGP control plane.
+      --enable-bgp-control-plane-status-report                    Enable the BGP control plane status reporting (default true)
       --enable-bpf-clock-probe                                    Enable BPF clock source probing for more efficient tick retrieval
       --enable-bpf-masquerade                                     Masquerade packets from endpoints leaving the host with BPF instead of iptables
       --enable-bpf-tproxy                                         Enable BPF-based proxy redirection (beta), if support available

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -287,7 +287,7 @@
    * - :spelling:ignore:`bgpControlPlane`
      - This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs.
      - object
-     - ``{"enabled":false,"secretsNamespace":{"create":false,"name":"kube-system"}}``
+     - ``{"enabled":false,"secretsNamespace":{"create":false,"name":"kube-system"},"statusReport":{"enabled":true}}``
    * - :spelling:ignore:`bgpControlPlane.enabled`
      - Enables the BGP control plane.
      - bool
@@ -304,6 +304,14 @@
      - The name of the secret namespace to which Cilium agents are given read access
      - string
      - ``"kube-system"``
+   * - :spelling:ignore:`bgpControlPlane.statusReport`
+     - Status reporting settings (BGPv2 only)
+     - object
+     - ``{"enabled":true}``
+   * - :spelling:ignore:`bgpControlPlane.statusReport.enabled`
+     - Enable/Disable BGPv2 status reporting It is recommended to enable status reporting in general, but if you have any issue such as high API server load, you can disable it by setting this to false.
+     - bool
+     - ``true``
    * - :spelling:ignore:`bpf.authMapMax`
      - Configure the maximum number of entries in auth map.
      - int

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1012,6 +1012,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableBGPControlPlane, false, "Enable the BGP control plane.")
 	option.BindEnv(vp, option.EnableBGPControlPlane)
 
+	flags.Bool(option.EnableBGPControlPlaneStatusReport, true, "Enable the BGP control plane status reporting")
+	option.BindEnv(vp, option.EnableBGPControlPlaneStatusReport)
+
 	flags.Bool(option.EnablePMTUDiscovery, false, "Enable path MTU discovery to send ICMP fragmentation-needed replies to the client")
 	option.BindEnv(vp, option.EnablePMTUDiscovery)
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -121,11 +121,13 @@ contributors across the globe, there is almost always someone available to help.
 | bgp.announce.loadbalancerIP | bool | `false` | Enable allocation and announcement of service LoadBalancer IPs |
 | bgp.announce.podCIDR | bool | `false` | Enable announcement of node pod CIDR |
 | bgp.enabled | bool | `false` | Enable BGP support inside Cilium; embeds a new ConfigMap for BGP inside cilium-agent and cilium-operator |
-| bgpControlPlane | object | `{"enabled":false,"secretsNamespace":{"create":false,"name":"kube-system"}}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs. |
+| bgpControlPlane | object | `{"enabled":false,"secretsNamespace":{"create":false,"name":"kube-system"},"statusReport":{"enabled":true}}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs. |
 | bgpControlPlane.enabled | bool | `false` | Enables the BGP control plane. |
 | bgpControlPlane.secretsNamespace | object | `{"create":false,"name":"kube-system"}` | SecretsNamespace is the namespace which BGP support will retrieve secrets from. |
 | bgpControlPlane.secretsNamespace.create | bool | `false` | Create secrets namespace for BGP secrets. |
 | bgpControlPlane.secretsNamespace.name | string | `"kube-system"` | The name of the secret namespace to which Cilium agents are given read access |
+| bgpControlPlane.statusReport | object | `{"enabled":true}` | Status reporting settings (BGPv2 only) |
+| bgpControlPlane.statusReport.enabled | bool | `true` | Enable/Disable BGPv2 status reporting It is recommended to enable status reporting in general, but if you have any issue such as high API server load, you can disable it by setting this to false. |
 | bpf.authMapMax | int | `524288` | Configure the maximum number of entries in auth map. |
 | bpf.autoMount.enabled | bool | `true` | Enable automatic mount of BPF filesystem When `autoMount` is enabled, the BPF filesystem is mounted at `bpf.root` path on the underlying host and inside the cilium agent pod. If users disable `autoMount`, it's expected that users have mounted bpffs filesystem at the specified `bpf.root` volume, and then the volume will be mounted inside the cilium agent pod at the same path. |
 | bpf.ctAccounting | bool | `false` | Enable CT accounting for packets and bytes |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1161,6 +1161,7 @@ data:
 {{- if .Values.bgpControlPlane.enabled }}
   enable-bgp-control-plane: "true"
   bgp-secrets-namespace: {{ .Values.bgpControlPlane.secretsNamespace.name | quote }}
+  enable-bgp-control-plane-status-report: {{ .Values.bgpControlPlane.statusReport.enabled | quote }}
 {{- end }}
 
 {{- if .Values.pmtuDiscovery.enabled }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -489,6 +489,14 @@
             }
           },
           "type": "object"
+        },
+        "statusReport": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
         }
       },
       "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -458,6 +458,12 @@ bgpControlPlane:
     create: false
     # -- The name of the secret namespace to which Cilium agents are given read access
     name: kube-system
+  # -- Status reporting settings (BGPv2 only)
+  statusReport:
+    # -- Enable/Disable BGPv2 status reporting
+    # It is recommended to enable status reporting in general, but if you have any issue
+    # such as high API server load, you can disable it by setting this to false.
+    enabled: true
 pmtuDiscovery:
   # -- Enable path MTU discovery to send ICMP fragmentation-needed replies to
   # the client.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -459,6 +459,12 @@ bgpControlPlane:
     create: false
     # -- The name of the secret namespace to which Cilium agents are given read access
     name: kube-system
+  # -- Status reporting settings (BGPv2 only)
+  statusReport:
+    # -- Enable/Disable BGPv2 status reporting
+    # It is recommended to enable status reporting in general, but if you have any issue
+    # such as high API server load, you can disable it by setting this to false.
+    enabled: true
 pmtuDiscovery:
   # -- Enable path MTU discovery to send ICMP fragmentation-needed replies to
   # the client.

--- a/operator/pkg/bgpv2/cell.go
+++ b/operator/pkg/bgpv2/cell.go
@@ -22,7 +22,8 @@ var Cell = cell.Module(
 )
 
 func newSecretResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig) resource.Resource[*slim_core_v1.Secret] {
-	if !c.IsEnabled() || !dc.BGPControlPlaneEnabled() {
+	// Secret is only used for status reporting (MissingAuthSecret condition)
+	if !c.IsEnabled() || !dc.BGPControlPlaneEnabled() || !dc.EnableBGPControlPlaneStatusReport {
 		return nil
 	}
 	if dc.BGPSecretsNamespace == "" {

--- a/operator/pkg/bgpv2/cluster.go
+++ b/operator/pkg/bgpv2/cluster.go
@@ -45,12 +45,12 @@ func (b *BGPResourceManager) reconcileBGPClusterConfig(ctx context.Context, conf
 		errs = errors.Join(err)
 	}
 
+	updateStatus := false
 	if b.enableStatusReporting {
 		// Collect the missing peerConfig references
 		missingPCs := b.missingPeerConfigs(config)
 
 		// Update ClusterConfig conditions
-		updateStatus := false
 		if changed := b.updateNoMatchingNodeCondition(config, len(matchingNodes) == 0); changed {
 			updateStatus = true
 		}
@@ -60,18 +60,27 @@ func (b *BGPResourceManager) reconcileBGPClusterConfig(ctx context.Context, conf
 		if changed := b.updateConflictingClusterConfigsCondition(config, conflictingClusterConfigs); changed {
 			updateStatus = true
 		}
+	} else {
+		// If the status reporting is disabled, we need to ensure all
+		// conditions managed by this controller are removed.
+		// Otherwise, users may see the stale conditions which were
+		// reported previously.
+		for _, cond := range v2alpha1.AllBGPClusterConfigConditions {
+			if removed := meta.RemoveStatusCondition(&config.Status.Conditions, cond); removed {
+				updateStatus = true
+			}
+		}
+	}
 
+	// Call API only when there's a condition change
+	if updateStatus {
 		// Sort conditions to the stable order
 		slices.SortStableFunc(config.Status.Conditions, func(a, b meta_v1.Condition) int {
 			return strings.Compare(a.Type, b.Type)
 		})
-
-		// Call API only when there's a condition change
-		if updateStatus {
-			_, err := b.clientset.CiliumV2alpha1().CiliumBGPClusterConfigs().UpdateStatus(ctx, config, meta_v1.UpdateOptions{})
-			if err != nil {
-				errs = errors.Join(errs, err)
-			}
+		_, err := b.clientset.CiliumV2alpha1().CiliumBGPClusterConfigs().UpdateStatus(ctx, config, meta_v1.UpdateOptions{})
+		if err != nil {
+			errs = errors.Join(errs, err)
 		}
 	}
 

--- a/operator/pkg/bgpv2/fixture_test.go
+++ b/operator/pkg/bgpv2/fixture_test.go
@@ -133,9 +133,10 @@ func newFixture(ctx context.Context, req *require.Assertions) (*fixture, func())
 
 		cell.Provide(func() *option.DaemonConfig {
 			return &option.DaemonConfig{
-				EnableBGPControlPlane: true,
-				Debug:                 true,
-				BGPSecretsNamespace:   "kube-system",
+				EnableBGPControlPlane:             true,
+				Debug:                             true,
+				BGPSecretsNamespace:               "kube-system",
+				EnableBGPControlPlaneStatusReport: true,
 			}
 		}),
 

--- a/operator/pkg/bgpv2/fixture_test.go
+++ b/operator/pkg/bgpv2/fixture_test.go
@@ -41,7 +41,7 @@ type fixture struct {
 	bgpnClient cilium_client_v2alpha1.CiliumBGPNodeConfigInterface
 }
 
-func newFixture(ctx context.Context, req *require.Assertions) (*fixture, func()) {
+func newFixture(ctx context.Context, req *require.Assertions, enableStatusReport bool) (*fixture, func()) {
 	rws := map[string]*struct {
 		once    sync.Once
 		watchCh chan any
@@ -136,7 +136,7 @@ func newFixture(ctx context.Context, req *require.Assertions) (*fixture, func())
 				EnableBGPControlPlane:             true,
 				Debug:                             true,
 				BGPSecretsNamespace:               "kube-system",
-				EnableBGPControlPlaneStatusReport: true,
+				EnableBGPControlPlaneStatusReport: enableStatusReport,
 			}
 		}),
 

--- a/operator/pkg/bgpv2/manager.go
+++ b/operator/pkg/bgpv2/manager.go
@@ -78,6 +78,9 @@ type BGPResourceManager struct {
 	// internal state
 	reconcileCh      chan struct{}
 	bgpClusterSyncCh chan struct{}
+
+	// enable/disable status reporting
+	enableStatusReporting bool
 }
 
 // registerBGPResourceManager creates a new BGPResourceManager operator instance.
@@ -101,6 +104,8 @@ func registerBGPResourceManager(p BGPParams) *BGPResourceManager {
 		nodeConfig:         p.NodeConfigResource,
 		peerConfig:         p.PeerConfigResource,
 		ciliumNode:         p.NodeResource,
+
+		enableStatusReporting: p.DaemonConfig.EnableBGPControlPlaneStatusReport,
 	}
 
 	b.nodeConfigClient = b.clientset.CiliumV2alpha1().CiliumBGPNodeConfigs()

--- a/operator/pkg/bgpv2/peer.go
+++ b/operator/pkg/bgpv2/peer.go
@@ -40,7 +40,7 @@ type peerConfigStatusReconcilerIn struct {
 }
 
 func registerPeerConfigStatusReconciler(in peerConfigStatusReconcilerIn) {
-	if !in.DaemonConfig.BGPControlPlaneEnabled() {
+	if !in.DaemonConfig.BGPControlPlaneEnabled() || !in.DaemonConfig.EnableBGPControlPlaneStatusReport {
 		return
 	}
 

--- a/operator/pkg/bgpv2/peer.go
+++ b/operator/pkg/bgpv2/peer.go
@@ -8,24 +8,31 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	"k8s.io/apimachinery/pkg/api/meta"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8s_client "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/resiliency"
 )
 
 type peerConfigStatusReconciler struct {
-	cs              k8s_client.Clientset
+	cs k8s_client.Clientset
+
 	secretNamespace string
+	secretResource  resource.Resource[*slim_core_v1.Secret]
 	secretStore     resource.Store[*slim_core_v1.Secret]
-	peerConfigStore resource.Store[*cilium_api_v2alpha1.CiliumBGPPeerConfig]
+
+	peerConfigResource resource.Resource[*cilium_api_v2alpha1.CiliumBGPPeerConfig]
+	peerConfigStore    resource.Store[*cilium_api_v2alpha1.CiliumBGPPeerConfig]
 }
 
 type peerConfigStatusReconcilerIn struct {
@@ -40,59 +47,143 @@ type peerConfigStatusReconcilerIn struct {
 }
 
 func registerPeerConfigStatusReconciler(in peerConfigStatusReconcilerIn) {
-	if !in.DaemonConfig.BGPControlPlaneEnabled() || !in.DaemonConfig.EnableBGPControlPlaneStatusReport {
+	if !in.DaemonConfig.BGPControlPlaneEnabled() {
 		return
 	}
 
 	u := &peerConfigStatusReconciler{
-		cs:              in.Clientset,
-		secretNamespace: in.DaemonConfig.BGPSecretsNamespace,
+		cs:                 in.Clientset,
+		secretNamespace:    in.DaemonConfig.BGPSecretsNamespace,
+		secretResource:     in.SecretResource,
+		peerConfigResource: in.PeerConfigResource,
+	}
+
+	if !in.DaemonConfig.EnableBGPControlPlaneStatusReport {
+		// Register a job to cleanup the conditions from the existing
+		// PeerConfig resources. This is needed for the case that the
+		// status report was enabled previously and some conditions
+		// are already reported. Since we don't update the condition
+		// anymore, remove all previously reported conditions to avoid
+		// confusion.
+		in.JobGroup.Add(job.OneShot(
+			"cleanup-peer-config-status",
+			u.cleanupStatus,
+		))
+
+		// When the status reporting is disabled, don't register the
+		// status reconciler job.
+		return
 	}
 
 	in.JobGroup.Add(job.OneShot(
 		"peer-config-status-reconciler",
-		func(ctx context.Context, health cell.Health) error {
-			ss, err := in.SecretResource.Store(ctx)
-			if err != nil {
-				return err
+		u.reconcileStatus,
+	))
+}
+
+func (u *peerConfigStatusReconciler) reconcileStatus(ctx context.Context, health cell.Health) error {
+	ss, err := u.secretResource.Store(ctx)
+	if err != nil {
+		return err
+	}
+	u.secretStore = ss
+
+	ps, err := u.peerConfigResource.Store(ctx)
+	if err != nil {
+		return err
+	}
+	u.peerConfigStore = ps
+
+	se := u.secretResource.Events(ctx)
+	pe := u.peerConfigResource.Events(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case e, ok := <-se:
+			if !ok {
+				continue
 			}
-			u.secretStore = ss
-
-			ps, err := in.PeerConfigResource.Store(ctx)
-			if err != nil {
-				return err
+			if e.Kind == resource.Sync {
+				e.Done(nil)
+				continue
 			}
-			u.peerConfigStore = ps
+			e.Done(u.handleSecret(ctx, e))
+		case e, ok := <-pe:
+			if !ok {
+				continue
+			}
+			if e.Kind != resource.Upsert {
+				e.Done(nil)
+				continue
+			}
+			e.Done(u.reconcilePeerConfig(ctx, e.Object))
+		}
+	}
+}
 
-			se := in.SecretResource.Events(ctx)
-			pe := in.PeerConfigResource.Events(ctx)
+func (u *peerConfigStatusReconciler) cleanupStatus(ctx context.Context, _ cell.Health) error {
+	pcs, err := u.peerConfigResource.Store(ctx)
+	if err != nil {
+		return err
+	}
 
-			for {
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case e, ok := <-se:
-					if !ok {
-						continue
-					}
-					if e.Kind == resource.Sync {
-						e.Done(nil)
-						continue
-					}
-					e.Done(u.handleSecret(ctx, e))
-				case e, ok := <-pe:
-					if !ok {
-						continue
-					}
-					if e.Kind != resource.Upsert {
-						e.Done(nil)
-						continue
-					}
-					e.Done(u.reconcilePeerConfig(ctx, e.Object))
+	remaining := sets.New[resource.Key]()
+
+	iter := pcs.IterKeys()
+	for iter.Next() {
+		remaining.Insert(iter.Key())
+	}
+
+	// Ensure all conditions managed by this
+	// controller are removed from all resources.
+	// Retry until we remove conditions from all
+	// existing resources.
+	err = resiliency.Retry(ctx, 3*time.Second, 20, func(ctx context.Context, _ int) (bool, error) {
+		removed := sets.New[resource.Key]()
+
+		for k := range remaining {
+			pc, exists, err := pcs.GetByKey(k)
+			if err != nil {
+				// Failed to get the resource. Skip and retry.
+				continue
+			}
+
+			// The resource doesn't exist anymore which is fine.
+			if !exists {
+				continue
+			}
+
+			updateStatus := false
+			for _, cond := range cilium_api_v2alpha1.AllBGPPeerConfigConditions {
+				if removed := meta.RemoveStatusCondition(&pc.Status.Conditions, cond); removed {
+					updateStatus = true
 				}
 			}
-		},
-	))
+
+			if updateStatus {
+				if _, err := u.cs.CiliumV2alpha1().CiliumBGPPeerConfigs().UpdateStatus(ctx, pc, meta_v1.UpdateOptions{}); err != nil {
+					// Failed to update status. Skip and retry.
+					continue
+				} else {
+					removed.Insert(k)
+				}
+			}
+		}
+
+		remaining = remaining.Difference(removed)
+
+		if len(remaining) == 0 {
+			return false, nil
+		}
+
+		return true, nil
+	})
+
+	pcs.Release()
+
+	return err
 }
 
 func (u *peerConfigStatusReconciler) reconcilePeerConfig(ctx context.Context, config *cilium_api_v2alpha1.CiliumBGPPeerConfig) error {

--- a/operator/pkg/bgpv2/peer_test.go
+++ b/operator/pkg/bgpv2/peer_test.go
@@ -84,8 +84,9 @@ func newPeerConfigTestFixture(t *testing.T, ctx context.Context) (*peerConfigTes
 				k8s.CiliumBGPPeerConfigResource,
 				func() *option.DaemonConfig {
 					return &option.DaemonConfig{
-						EnableBGPControlPlane: true,
-						BGPSecretsNamespace:   "kube-system",
+						EnableBGPControlPlane:             true,
+						BGPSecretsNamespace:               "kube-system",
+						EnableBGPControlPlaneStatusReport: true,
 					}
 				},
 			),

--- a/pkg/bgpv1/manager/reconcilerv2/crd_status.go
+++ b/pkg/bgpv1/manager/reconcilerv2/crd_status.go
@@ -68,7 +68,7 @@ func NewStatusReconciler(in StatusReconcilerIn) StatusReconcilerOut {
 		return StatusReconcilerOut{}
 	}
 	// CRD Status reconciler is disabled if there is no kubernetes support
-	if !in.ClientSet.IsEnabled() {
+	if !in.ClientSet.IsEnabled() || !in.DaemonConfig.EnableBGPControlPlaneStatusReport {
 		return StatusReconcilerOut{}
 	}
 

--- a/pkg/bgpv1/manager/reconcilerv2/crd_status.go
+++ b/pkg/bgpv1/manager/reconcilerv2/crd_status.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/resiliency"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -68,7 +69,7 @@ func NewStatusReconciler(in StatusReconcilerIn) StatusReconcilerOut {
 		return StatusReconcilerOut{}
 	}
 	// CRD Status reconciler is disabled if there is no kubernetes support
-	if !in.ClientSet.IsEnabled() || !in.DaemonConfig.EnableBGPControlPlaneStatusReport {
+	if !in.ClientSet.IsEnabled() {
 		return StatusReconcilerOut{}
 	}
 
@@ -78,6 +79,17 @@ func NewStatusReconciler(in StatusReconcilerIn) StatusReconcilerOut {
 		ClientSet:         in.ClientSet,
 		desiredStatus:     &v2alpha1.CiliumBGPNodeStatus{},
 		runningStatus:     &v2alpha1.CiliumBGPNodeStatus{},
+	}
+
+	// If the status reporting is disabled, schedule a job to cleanup
+	// status field. Otherwise, users may see the stale status that
+	// previously reported.
+	if !in.DaemonConfig.EnableBGPControlPlaneStatusReport {
+		in.Job.Add(job.OneShot(
+			"bgp-crd-status-cleanup",
+			r.cleanupStatus,
+		))
+		return StatusReconcilerOut{}
 	}
 
 	in.Job.Add(job.OneShot("bgp-crd-status-initialize", func(ctx context.Context, health cell.Health) error {
@@ -194,6 +206,58 @@ func (r *StatusReconciler) Reconcile(ctx context.Context, params StateReconcileP
 
 	r.desiredStatus = current
 	return nil
+}
+
+func (r *StatusReconciler) cleanupStatus(ctx context.Context, health cell.Health) error {
+	var nodeName string
+
+	// Wait for the local node name
+	for event := range r.LocalNodeResource.Events(ctx) {
+		switch event.Kind {
+		case resource.Upsert:
+			nodeName = event.Key.Name
+		}
+
+		event.Done(nil)
+
+		if nodeName != "" {
+			break
+		}
+	}
+
+	return resiliency.Retry(ctx, 3*time.Second, 20, func(ctx context.Context, _ int) (bool, error) {
+		// Patch with an empty status
+		emptyStatus := []k8s.JSONPatch{
+			{
+				OP:    "replace",
+				Path:  "/status",
+				Value: &v2alpha1.CiliumBGPNodeStatus{},
+			},
+		}
+
+		patch, err := json.Marshal(emptyStatus)
+		if err != nil {
+			return false, fmt.Errorf("BUG: cannot marshal empty status: %w", err)
+		}
+
+		if _, err := r.ClientSet.CiliumV2alpha1().CiliumBGPNodeConfigs().Patch(
+			ctx,
+			nodeName,
+			k8s_types.JSONPatchType,
+			patch,
+			metav1.PatchOptions{FieldManager: r.Name()},
+			"status",
+		); err != nil {
+			// NodeConfig for this node doesn't exist yet. Then,
+			// there's no status to cleanup.
+			if k8sErrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, nil
+		}
+
+		return true, nil
+	})
 }
 
 func (r *StatusReconciler) getInstanceStatus(ctx context.Context, instance *instance.BGPInstance) (*v2alpha1.CiliumBGPNodeInstanceStatus, error) {

--- a/pkg/bgpv1/manager/reconcilerv2/crd_status_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/crd_status_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconcilerv2
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/job"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	daemon_k8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/hive"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8s_client "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+func TestDisableStatusReport(t *testing.T) {
+	ctx := context.TODO()
+	logger := hivetest.Logger(t)
+
+	var cs k8s_client.Clientset
+	hive := hive.New(cell.Module("test", "test",
+		daemon_k8s.LocalNodeCell,
+		cell.Provide(
+			func() *option.DaemonConfig {
+				return &option.DaemonConfig{
+					EnableBGPControlPlane:             true,
+					EnableBGPControlPlaneStatusReport: false,
+				}
+			},
+			k8s_client.NewFakeClientset,
+		),
+		cell.Invoke(func(jg job.Group, ln daemon_k8s.LocalCiliumNodeResource, _cs k8s_client.Clientset) {
+			cs = _cs
+
+			// Create a LocalNode to obtain local node name
+			_, err := cs.CiliumV2().CiliumNodes().Create(
+				ctx,
+				&v2.CiliumNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node0",
+					},
+				},
+				metav1.CreateOptions{},
+			)
+			require.NoError(t, err)
+
+			// Create a NodeConfig for this node
+			_, err = cs.CiliumV2alpha1().CiliumBGPNodeConfigs().Create(
+				ctx,
+				&v2alpha1.CiliumBGPNodeConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node0",
+					},
+					// Spec can be empty for this test
+					Spec: v2alpha1.CiliumBGPNodeSpec{},
+					// Fill with some dummy status
+					Status: v2alpha1.CiliumBGPNodeStatus{
+						BGPInstances: []v2alpha1.CiliumBGPNodeInstanceStatus{
+							{
+								Name: "foo",
+							},
+						},
+					},
+				},
+
+				metav1.CreateOptions{},
+			)
+			require.NoError(t, err)
+
+			// Ensure the status is not empty at this point
+			nc, err := cs.CiliumV2alpha1().CiliumBGPNodeConfigs().Get(ctx, "node0", metav1.GetOptions{})
+			require.NoError(t, err)
+			require.False(t, nc.Status.DeepEqual(&v2alpha1.CiliumBGPNodeStatus{}), "Status is already empty before cleanup job")
+
+			// Register cleanup job. This should cleanup the status of the NodeConfig above.
+			r := &StatusReconciler{
+				LocalNodeResource: ln,
+				ClientSet:         cs,
+			}
+			jg.Add(job.OneShot("cleanup-status", r.cleanupStatus))
+		}),
+	))
+
+	require.NoError(t, hive.Start(logger, ctx))
+	t.Cleanup(func() {
+		hive.Stop(logger, ctx)
+	})
+
+	// Wait for status to be cleared
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		nc, err := cs.CiliumV2alpha1().CiliumBGPNodeConfigs().Get(ctx, "node0", metav1.GetOptions{})
+		if !assert.NoError(ct, err) {
+			return
+		}
+		// The status should be cleared to empty
+		assert.True(ct, nc.Status.DeepEqual(&v2alpha1.CiliumBGPNodeStatus{}), "Status is not empty")
+	}, time.Second*5, time.Millisecond*100)
+}

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_cluster_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_cluster_types.go
@@ -157,7 +157,8 @@ type CiliumBGPClusterConfigStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// Conditions for CiliumBGPClusterConfig
+// Conditions for CiliumBGPClusterConfig. When you add a new condition, don't
+// forget to update the AllBGPClusterConfigConditions list as well.
 const (
 	// Node selector selects nothing
 	BGPClusterConfigConditionNoMatchingNode = "cilium.io/NoMatchingNode"
@@ -166,3 +167,9 @@ const (
 	// ClusterConfig with conflicting nodeSelector present
 	BGPClusterConfigConditionConflictingClusterConfigs = "cilium.io/ConflictingClusterConfig"
 )
+
+var AllBGPClusterConfigConditions = []string{
+	BGPClusterConfigConditionNoMatchingNode,
+	BGPClusterConfigConditionMissingPeerConfigs,
+	BGPClusterConfigConditionConflictingClusterConfigs,
+}

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_peer_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_peer_types.go
@@ -108,11 +108,16 @@ type CiliumBGPPeerConfigStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// Conditions for CiliumBGPPeerConfig
+// Conditions for CiliumBGPPeerConfig. When you add a new condition, don't
+// forget to to update the below AllBGPPeerConfigConditions list as well.
 const (
 	// Referenced auth secret is missing
 	BGPPeerConfigConditionMissingAuthSecret = "cilium.io/MissingAuthSecret"
 )
+
+var AllBGPPeerConfigConditions = []string{
+	BGPPeerConfigConditionMissingAuthSecret,
+}
 
 // CiliumBGPFamily represents a AFI/SAFI address family pair.
 type CiliumBGPFamily struct {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1087,6 +1087,9 @@ const (
 	// Flag to enable BGP control plane features
 	EnableBGPControlPlane = "enable-bgp-control-plane"
 
+	// EnableBGPControlPlaneStatusReport enables BGP Control Plane CRD status reporting
+	EnableBGPControlPlaneStatusReport = "enable-bgp-control-plane-status-report"
+
 	// EnableRuntimeDeviceDetection is the name of the option to enable detection
 	// of new and removed datapath devices during the agent runtime.
 	EnableRuntimeDeviceDetection = "enable-runtime-device-detection"
@@ -2176,6 +2179,9 @@ type DaemonConfig struct {
 
 	// Enables BGP control plane features.
 	EnableBGPControlPlane bool
+
+	// Enables BGP control plane status reporting.
+	EnableBGPControlPlaneStatusReport bool
 
 	// BPFMapEventBuffers has configuration on what BPF map event buffers to enabled
 	// and configuration options for those.
@@ -3272,6 +3278,9 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 
 	// Enable BGP control plane features
 	c.EnableBGPControlPlane = vp.GetBool(EnableBGPControlPlane)
+
+	// Enable BGP control plane status reporting
+	c.EnableBGPControlPlaneStatusReport = vp.GetBool(EnableBGPControlPlaneStatusReport)
 
 	// To support K8s NetworkPolicy
 	c.EnableK8sNetworkPolicy = vp.GetBool(EnableK8sNetworkPolicy)


### PR DESCRIPTION
We recently introduced several CRD status reporting features (https://github.com/cilium/cilium/pull/33411, https://github.com/cilium/cilium/pull/35517, https://github.com/cilium/cilium/pull/35527, https://github.com/cilium/cilium/pull/35650). They are useful for troubleshooting, but there's a trade-off between API server load. For the large cluster with many nodes or many BGP resources may experience a high API server load. In this PR, we introduce a knob to disable BGPv2 CRD status reporting for such an environment.

```release-note
bgpv2: Add a knob to disable CRD status reporting
```
