### PR TITLE
endpoint: write header file on shutdown

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1264,6 +1264,11 @@ func (e *Endpoint) leaveLocked(conf DeleteConfig) []error {
 	return errs
 }
 
+// OnShutdown is called when the daemon is shutting down, but the endpoint itself will be preserved
+func (e *Endpoint) OnShutdown() {
+	e.syncEndpointHeaderFile([]string{"agent shutting down"})
+}
+
 // GetK8sNamespace returns the name of the pod if the endpoint represents a
 // Kubernetes pod
 func (e *Endpoint) GetK8sNamespace() string {

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -221,6 +221,7 @@ func newDefaultEndpointManager(p endpointManagerParams) endpointManagerOut {
 			},
 			OnStop: func(cell.HookContext) error {
 				cancel()
+				mgr.OnShutdown()
 				mgr.controllers.RemoveAllAndWait()
 				return nil
 			},

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -802,3 +802,10 @@ func (mgr *endpointManager) GetEndpointNetnsCookieByIP(ip netip.Addr) (uint64, e
 
 	return ep.NetNsCookie, nil
 }
+
+func (mgr *endpointManager) OnShutdown() {
+	eps := mgr.GetEndpoints()
+	for _, ep := range eps {
+		ep.OnShutdown()
+	}
+}

--- a/test/k8s/fqdn.go
+++ b/test/k8s/fqdn.go
@@ -63,7 +63,10 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sAgentFQDNTest", func() {
 		demoManifest = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
 
 		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
-		DeployCiliumAndDNS(kubectl, ciliumFilename)
+		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+			"dnsProxy.idleConnectionGracePeriod": "5m",  // do not GC connections while we are restarting
+			"dnsProxy.minTtl":                    "300", // force long TTLs for names
+		})
 
 		By("Applying demo manifest")
 		res := kubectl.ApplyDefault(demoManifest)


### PR DESCRIPTION
The endpoint's DNS history is preserved in the header file; we need it on restoration so IPs are preserved. This adds a shutdown hook in the EndpointManager to force dumping the header file to disk.