### PR TITLE
envoy: Wait for endpoint restoration before listening on xDS socket

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -396,6 +396,13 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		hubble:            params.Hubble,
 	}
 
+	// initialize endpointRestoreComplete channel as soon as possible so that subsystems
+	// can wait on it to get closed and not block forever if they happen so start
+	// waiting when it is not yet initialized (which causes them to block forever).
+	if option.Config.RestoreState {
+		d.endpointRestoreComplete = make(chan struct{})
+	}
+
 	// Collect CIDR identities from the "old" bpf ipcache and restore them
 	// in to the metadata layer.
 	if option.Config.RestoreState && !option.Config.DryMode {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -33,15 +33,17 @@ import (
 
 var syncLBMapsControllerGroup = controller.NewGroup("sync-lb-maps-with-k8s-services")
 
-func (d *Daemon) WaitForEndpointRestore(ctx context.Context) {
+func (d *Daemon) WaitForEndpointRestore(ctx context.Context) error {
 	if !option.Config.RestoreState {
-		return
+		return nil
 	}
 
 	select {
 	case <-ctx.Done():
+		return ctx.Err()
 	case <-d.endpointRestoreComplete:
 	}
+	return nil
 }
 
 type endpointRestoreState struct {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -268,8 +268,6 @@ func (d *Daemon) restoreOldEndpoints(state *endpointRestoreState) {
 }
 
 func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState, endpointsRegenerator *endpoint.Regenerator) {
-	d.endpointRestoreComplete = make(chan struct{})
-
 	log.WithField("numRestored", len(state.restored)).Info("Regenerating restored endpoints")
 
 	// Before regenerating, check whether the CT map has properties that

--- a/pkg/endpointcleanup/cleanup_test.go
+++ b/pkg/endpointcleanup/cleanup_test.go
@@ -277,5 +277,6 @@ func (r *fakeRestorer) Await(context.Context) (endpointstate.Restorer, error) {
 	return r, nil
 }
 
-func (r *fakeRestorer) WaitForEndpointRestore(_ context.Context) {
+func (r *fakeRestorer) WaitForEndpointRestore(_ context.Context) error {
+	return nil
 }

--- a/pkg/endpointstate/restorer.go
+++ b/pkg/endpointstate/restorer.go
@@ -9,5 +9,5 @@ import "context"
 type Restorer interface {
 	// WaitForEndpointRestore blocks the caller until either the context is
 	// cancelled or all the endpoints have been restored from a previous run.
-	WaitForEndpointRestore(ctx context.Context)
+	WaitForEndpointRestore(ctx context.Context) error
 }

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -50,14 +50,30 @@ func (s *xdsServer) startXDSGRPCServer(listener net.Listener, config map[string]
 
 	reflection.Register(grpcServer)
 
+	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
+		if s.restorerPromise != nil {
+			restorer, err := s.restorerPromise.Await(ctx)
+			if err == nil && restorer != nil {
+				log.Infof("Envoy: Waiting for endpoint restoration before serving xDS resources...")
+				err = restorer.WaitForEndpointRestore(ctx)
+			}
+			if errors.Is(err, context.Canceled) {
+				log.Debug("Envoy: xDS server stopped before started serving")
+				return
+			}
+		}
+
 		log.Infof("Envoy: Starting xDS gRPC server listening on %s", listener.Addr())
 		if err := grpcServer.Serve(listener); err != nil && !errors.Is(err, net.ErrClosed) {
 			log.WithError(err).Fatal("Envoy: Failed to serve xDS gRPC API")
 		}
 	}()
 
-	return grpcServer.Stop
+	return func() {
+		cancel()
+		grpcServer.Stop()
+	}
 }
 
 // xdsGRPCServer handles gRPC streaming discovery requests for the


### PR DESCRIPTION
Delay listening on the Cilium xDS socket until endpoints have been restored. This eliminates the problem where Envoy times out on the initial fetch on the xDS streams.

```release-note
Cilium agent now waits until endpoints have restored before starting accepting new xDS streams.
```
