### PR TITLE
test: FQDN: prevent names from being GCd when restarting

### DIFF
--- a/test/k8s/fqdn.go
+++ b/test/k8s/fqdn.go
@@ -63,7 +63,10 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sAgentFQDNTest", func() {
 		demoManifest = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
 
 		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
-		DeployCiliumAndDNS(kubectl, ciliumFilename)
+		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
+			"dnsProxy.idleConnectionGracePeriod": "5m",  // do not GC connections while we are restarting
+			"dnsProxy.minTtl":                    "300", // force long TTLs for names
+		})
 
 		By("Applying demo manifest")
 		res := kubectl.ApplyDefault(demoManifest)


### PR DESCRIPTION
We rely on names not being eligible for garbage collection when restarting. However, if the DNS name being tested has a low TTL, this can trigger this accidentally.

So, we bump the idle grace period as well as the min TTL, so that IPs won't be prematurely GCd even if they are no longer present in the conntrack map.

(this should get `main` green again)