### PR TITLE
ci: fix cleanup of stale kops clusters.

### DIFF
--- a/.github/workflows/scale-cleanup-kops.yaml
+++ b/.github/workflows/scale-cleanup-kops.yaml
@@ -68,7 +68,7 @@ jobs:
           then
             echo "Clusters list fetched successfully"
             date=`date -u +%Y-%m-%d'T'%H:%M'Z' -d "3 hour ago"`
-            cat /tmp/clusters.json | jq -r --arg date "$date" '.[] | select([.metadata.creationTimestamp < $date]) | .metadata.name' > /tmp/stale-clusters.txt
+            cat /tmp/clusters.json | jq -r --arg date "$date" '.[] | select(.metadata.creationTimestamp < $date) | .metadata.name' > /tmp/stale-clusters.txt
             # iterate through list of cluster names in /tmp/stale-clusters.txt
             while IFS= read -r cluster; do
               ./kops delete cluster --state ${{ secrets.GCP_PERF_KOPS_STATE_STORE }} $cluster --yes


### PR DESCRIPTION
Select should not be performed on the list but boolean value.

Fixes: #35915

Apparently, I am not good at writing jq queries. 
Before I've tested positive case only, and now I've tested both positive and negative cases manually.