### PR TITLE
endpoint: don't propagate health/ingress endpoints to kvstore

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -832,6 +832,14 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 		return
 	}
 
+	// Neither the health nor the ingress endpoints should be propagated into the
+	// kvstore, given that they are already listed inside the node representation,
+	// and to mimic the corresponding CiliumEndpoint which is not created as well.
+	// We don't use e.HasLabels because we are already holding the lock here.
+	if e.hasLabelsRLocked(labels.LabelHealth) || e.hasLabelsRLocked(labels.LabelIngress) {
+		return
+	}
+
 	addressFamily := "IPv4"
 	if endpointIP.Is6() {
 		addressFamily = "IPv6"


### PR DESCRIPTION
Health and ingress IPs are propagated to the other Cilium agents via CiliumNodes, and the equivalent kvstore representation. However, they are also additionally upserted into the kvstore as endpoints, leading to information duplication both in the kvstore and inside the user-space ipcache representation of all remote nodes (as observed via the `cilium ip list` command). Indeed, they get upserted both as single IPs (i.e., without netmask) when observed from the endpoint prefix, and as prefix (with /32 mask) when observed from the node prefix. The same does not happen when operating in CRD mode, because the corresponding CEPs do not get created in these cases.

Let's fix this divergence by avoiding to upsert these entries in the kvstore case as well. Considering an upgrade scenario, the stale health/ingress entries will be automatically deleted when the corresponding lease expires (by default after 15 minutes). Still, this does not create any problems, because all other agents would observe the deletion event, clean-up the duplicate internal entries, but not propagate the deletion event down to the datapath (and the other subsystems), given that another CIDR entry for the same IP is still present \[1], hence preserving correctness.

\[1]: https://github.com/cilium/cilium/blob/40dde8b83c9829ae8288b3be0e8d6bdba256da0c/pkg/ipcache/ipcache.go#L428-L431

<!-- Description of change -->

```release-note
Stop propagating duplicate health and ingress endpoint information to the kvstore
```
