### PR TITLE
lbmap: skip expensive debug log operations when disabled

### DIFF
--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -712,11 +712,13 @@ func updateServiceEndpoint(key ServiceKey, value ServiceValue) error {
 		return err
 	}
 
-	log.WithFields(logrus.Fields{
-		logfields.ServiceKey:   key,
-		logfields.ServiceValue: value,
-		logfields.BackendSlot:  key.GetBackendSlot(),
-	}).Debug("Upserted service entry")
+	if logging.CanLogAt(log.Logger, logrus.DebugLevel) {
+		log.WithFields(logrus.Fields{
+			logfields.ServiceKey:   key,
+			logfields.ServiceValue: value,
+			logfields.BackendSlot:  key.GetBackendSlot(),
+		}).Debug("Upserted service entry")
+	}
 
 	return nil
 }


### PR DESCRIPTION
Modify the `updateServiceEndpoint` function to avoid attempting to log debug messages when debug logs are disabled, given that this is potentially an hot-path in case of high service/endpoint churn, and that causes unnecessary allocations.
