### PR TITLE
k8s/epslices: ensure that all fields are always DeepCopied

### DIFF
--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -475,11 +475,9 @@ func (es *EndpointSlices) GetEndpoints() *Endpoints {
 			if !ok {
 				allEps.Backends[backend] = ep.DeepCopy()
 			} else {
-				clone := b.DeepCopy()
 				for k, v := range ep.Ports {
-					clone.Ports[k] = v
+					b.Ports[k] = v.DeepCopy()
 				}
-				allEps.Backends[backend] = clone
 			}
 		}
 	}


### PR DESCRIPTION
The GetEndpoints() method already returns a complete DeepCopy of the underlying structures, except when two separate epslices contain information about the same address. In this case, the additional ports are not DeepCopied, but plainly assigned. While I wouldn't expect this to create problems at the moment, let's get it fixed, especially considering that the result is not DeepCopied a second time anymore \[1].

While being there, let's also get rid of the unnecessary DeepCopy of the mutated object, as already guaranteed to be a DeepCopy.

\[1]: 3b59c2631e92 ("service-cache: improve performance of correlateEndpoints")