### PR TITLE
helm: use absolute FQDN in hubble peer-service endpoint

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
@@ -16,7 +16,7 @@ metadata:
 data:
   config.yaml: |
     cluster-name: {{ .Values.cluster.name }}
-    peer-service: "hubble-peer.{{ include "cilium.namespace" . }}.svc.{{ .Values.hubble.peerService.clusterDomain }}:{{ $peerSvcPort }}"
+    peer-service: "hubble-peer.{{ include "cilium.namespace" . }}.svc.{{ .Values.hubble.peerService.clusterDomain }}.:{{ $peerSvcPort }}"
     listen-address: {{ include "hubble-relay.config.listenAddress" . }}
     gops: {{ .Values.hubble.relay.gops.enabled }}
     gops-port: {{ .Values.hubble.relay.gops.port | quote }}


### PR DESCRIPTION
Add a terminating dot to the templated peer-service host to prevent the DNS resolver from appending host-configured search domains which could result in out-of-cluster IPs from being resolved.

Fixes: https://github.com/cilium/cilium/issues/31898

```release-note
helm: Use an absolute FQDN for the Hubble peer-service endpoint to avoid incorrect DNS resolution outside the cluster
```
