### PR TITLE
operator: Add more common metrics to operator (kvstore, rate-limiting, version)

### DIFF
--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -107,6 +107,21 @@ func registerMetricsManager(p params) {
 		Registry.MustRegister(metric.(prometheus.Collector))
 	}
 
+	// Constructing the legacy metrics and register them at the metrics global variable.
+	// This is a hack until we can unify this metrics manager with the metrics.Registry.
+	metrics.NewLegacyMetrics()
+	Registry.MustRegister(
+		metrics.VersionMetric,
+		metrics.KVStoreOperationsDuration,
+		metrics.KVStoreEventsQueueDuration,
+		metrics.KVStoreQuorumErrors,
+		metrics.APILimiterProcessingDuration,
+		metrics.APILimiterWaitDuration,
+		metrics.APILimiterRequestsInFlight,
+		metrics.APILimiterRateLimit,
+		metrics.APILimiterProcessedRequests,
+	)
+
 	metrics.InitOperatorMetrics()
 	Registry.MustRegister(metrics.ErrorsWarnings)
 	metrics.FlushLoggingMetrics()


### PR DESCRIPTION
Add a set of metrics that are used in the cilium-agent and the clustermesh-apiserver. These metrics are useful to debug how the operator interacts with the kvstore.

It adds the same metrics as the clustermesh-apiserver is using from the "legacy metrics", including kvstore metrics, api limiter metrics and a version metric.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
operator: Add more common metrics to operator (kvstore, rate-limiting, version)
```

---

```bash
# This PR
kubectl get --raw /api/v1/namespaces/kube-system/pods/http:$(kubectl get pods -n kube-system -l io.cilium/app=operator -ojsonpath='{.items[0].metadata.name}'):9963/proxy/metrics |egrep -a "(kvstore|etcd|version)" | awk 'BEGIN{FS="{| "} /^c/{ print $1}' | sort | uniq -c | sort -n
   1 cilium_operator_api_limiter_processed_requests_total
   1 cilium_operator_doublewrite_identity_kvstore_only_count
   1 cilium_operator_doublewrite_identity_kvstore_total_count
   1 cilium_operator_identity_gc_latency
   1 cilium_operator_identity_gc_runs
   1 cilium_operator_version
   2 cilium_operator_api_limiter_processing_duration_seconds
   2 cilium_operator_api_limiter_rate_limit
   2 cilium_operator_api_limiter_requests_in_flight
   2 cilium_operator_identity_gc_entries
   2 cilium_operator_kvstore_initial_sync_completed
   2 cilium_operator_kvstore_sync_errors_total
   2 cilium_operator_kvstore_sync_queue_size
   3 cilium_operator_api_limiter_wait_duration_seconds
   5 cilium_operator_kvstore_events_queue_seconds_count
   5 cilium_operator_kvstore_events_queue_seconds_sum
   6 cilium_operator_kvstore_operations_duration_seconds_count
   6 cilium_operator_kvstore_operations_duration_seconds_sum
  60 cilium_operator_kvstore_events_queue_seconds_bucket
  72 cilium_operator_kvstore_operations_duration_seconds_bucket

# v1.17.0-pre.2
$ kubectl get --raw /api/v1/namespaces/kube-system/pods/http:$(kubectl get pods -n kube-system -l io.cilium/app=operator -ojsonpath='{.items[0].metadata.name}'):9963/proxy/metrics |egrep -a "(kvstore|etcd|version)" | awk 'BEGIN{FS="{| "} /^c/{ print $1}' | sort | uniq -c | sort -n
   1 cilium_operator_doublewrite_identity_kvstore_only_count
   1 cilium_operator_doublewrite_identity_kvstore_total_count
   1 cilium_operator_identity_gc_latency
   1 cilium_operator_identity_gc_runs
   2 cilium_operator_identity_gc_entries
   2 cilium_operator_kvstore_initial_sync_completed
   2 cilium_operator_kvstore_sync_errors_total
   2 cilium_operator_kvstore_sync_queue_size