### PR TITLE
Add support for pod level Networking QoS classes with BW Manager and FQ

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -184,6 +184,7 @@ battlestation
 bcc
 behaviour
 benchmarking
+besteffort
 bgp
 blackholing
 blockedConfigOverrides

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -350,7 +350,9 @@ struct edt_info {
 	__u64		bps;
 	__u64		t_last;
 	__u64		t_horizon_drop;
-	__u64		pad[4];
+	__u32		prio;
+	__u32		pad_32;
+	__u64		pad[3];
 };
 
 struct remote_endpoint_info {

--- a/bpf/lib/edt.h
+++ b/bpf/lib/edt.h
@@ -60,6 +60,8 @@ edt_sched_departure(struct __ctx_buff *ctx, __be16 proto)
 	info = map_lookup_elem(&THROTTLE_MAP, &aggregate);
 	if (!info)
 		return CTX_ACT_OK;
+	if (!info->bps)
+		goto out;
 
 	now = ktime_get_ns();
 	t = ctx->tstamp;
@@ -80,6 +82,12 @@ edt_sched_departure(struct __ctx_buff *ctx, __be16 proto)
 		return CTX_ACT_DROP;
 	WRITE_ONCE(info->t_last, t_next);
 	ctx->tstamp = t_next;
+out:
+	/* TODO: Hack to avoid defaulting prio 0 when user doesn't specify anything.
+	 * Priority set by user will always be 1 greater than what scheduler expects.
+	 */
+	if (info->prio)
+		ctx->priority = info->prio - 1;
 	return CTX_ACT_OK;
 }
 #else

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -222,6 +222,7 @@ func newCmdConnectivityPerf(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().IntVar(&params.PerfParameters.Samples, "samples", 1, "Number of Performance samples to capture (how many times to run each test)")
 	cmd.Flags().BoolVar(&params.PerfParameters.HostNet, "host-net", true, "Test host network")
 	cmd.Flags().BoolVar(&params.PerfParameters.PodNet, "pod-net", true, "Test pod network")
+	cmd.Flags().BoolVar(&params.PerfParameters.NetQos, "net-qos", false, "Test pod network Quality of Service")
 
 	cmd.Flags().StringVar(&params.PerfParameters.Image, "performance-image", defaults.ConnectivityPerformanceImage, "Image path to use for performance")
 	cmd.Flags().StringVar(&params.PerfParameters.ReportDir, "report-dir", "", "Directory to save perf results in json format")

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -103,6 +103,13 @@ type testBuilder interface {
 func GetTestSuites(params check.Parameters) ([]func(connTests []*check.ConnectivityTest, extraTests func(cts ...*check.ConnectivityTest) error) error, error) {
 	switch {
 	case params.Perf:
+		if params.PerfParameters.NetQos {
+			return []func(connTests []*check.ConnectivityTest, extraTests func(cts ...*check.ConnectivityTest) error) error{
+				func(connTests []*check.ConnectivityTest, _ func(cts ...*check.ConnectivityTest) error) error {
+					return networkQosTests(connTests[0])
+				},
+			}, nil
+		}
 		return []func(connTests []*check.ConnectivityTest, extraTests func(cts ...*check.ConnectivityTest) error) error{
 			func(connTests []*check.ConnectivityTest, _ func(cts ...*check.ConnectivityTest) error) error {
 				return networkPerformanceTests(connTests[0])
@@ -163,6 +170,12 @@ func GetTestSuites(params check.Parameters) ([]func(connTests []*check.Connectiv
 // networkPerformanceTests injects the network performance connectivity tests.
 func networkPerformanceTests(ct *check.ConnectivityTest) error {
 	tests := []testBuilder{networkPerf{}}
+	return injectTests(tests, ct)
+}
+
+// networkQosTests injects the network performance connectivity tests.
+func networkQosTests(ct *check.ConnectivityTest) error {
+	tests := []testBuilder{networkQos{}}
 	return injectTests(tests, ct)
 }
 

--- a/cilium-cli/connectivity/builder/network_qos.go
+++ b/cilium-cli/connectivity/builder/network_qos.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/perf/benchmarks/netperf"
+)
+
+type networkQos struct{}
+
+func (t networkQos) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("network-qos", ct).
+		WithCondition(func() bool { return ct.Params().Perf }).
+		WithScenarios(netperf.NetQos(""))
+}

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -31,6 +31,7 @@ type PerfParameters struct {
 	RR          bool
 	UDP         bool
 	Image       string
+	NetQos      bool
 }
 
 type Parameters struct {

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -511,7 +511,7 @@ func (ct *ConnectivityTest) report() error {
 		return fmt.Errorf("[%s] %d tests failed", ct.params.TestNamespace, nf)
 	}
 
-	if ct.params.Perf {
+	if ct.params.Perf && !ct.params.PerfParameters.NetQos {
 		ct.Header(fmt.Sprintf("🔥 Network Performance Test Summary [%s]:", ct.params.TestNamespace))
 		ct.Logf("%s", strings.Repeat("-", 200))
 		ct.Logf("📋 %-15s | %-10s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s | %-15s", "Scenario", "Node", "Test", "Duration", "Min", "Mean", "Max", "P50", "P90", "P99", "Transaction rate OP/s")

--- a/cilium-cli/connectivity/perf/benchmarks/netperf/bandwidth.go
+++ b/cilium-cli/connectivity/perf/benchmarks/netperf/bandwidth.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package netperf
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/perf/common"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+const (
+	netQosToolName = "netQos"
+)
+
+// NetQos : Test Network QoS Enforcement
+func NetQos(n string) check.Scenario {
+	return &netQos{
+		name: n,
+	}
+}
+
+type netQos struct {
+	lock.Mutex
+	name string
+}
+
+func (s *netQos) Name() string {
+	if s.name == "" {
+		return netQosToolName
+	}
+	return fmt.Sprintf("%s:%s", netQosToolName, s.name)
+}
+
+func (s *netQos) Run(ctx context.Context, t *check.Test) {
+	perfParameters := t.Context().Params().PerfParameters
+	tests := []string{"TCP_STREAM"}
+	tputSum := map[string]uint64{}
+	var wg sync.WaitGroup
+
+	for sample := 1; sample <= perfParameters.Samples; sample++ {
+		for _, c := range t.Context().PerfClientPods() {
+			c := c
+			for _, server := range t.Context().PerfServerPod() {
+				scenarioName := "pod-to-pod"
+
+				sameNode := false
+				for _, test := range tests {
+					testName := netQosToolName + "_" + test + "_" + scenarioName
+					action := t.NewAction(s, testName, &c, server, features.IPFamilyV4)
+					action.CollectFlows = false
+					wg.Add(1)
+					go action.Run(func(a *check.Action) {
+						k := common.PerfTests{
+							Test:     test,
+							Tool:     netQosToolName,
+							SameNode: sameNode,
+							Sample:   sample,
+							Duration: 30 * time.Second,
+							Scenario: scenarioName,
+							MsgSize:  1500000,
+							NetQos:   true,
+						}
+						perfResult := NetperfCmd(ctx, server.Pod.Status.PodIP, k, a)
+						s.Lock()
+						tputSum[c.Name()] += uint64(perfResult.ThroughputMetric.Throughput / 1000000)
+						s.Unlock()
+						wg.Done()
+					})
+				}
+			}
+		}
+	}
+	wg.Wait()
+	var lowPrio, highPrio uint64
+	t.Context().Log("\n")
+	for k, v := range tputSum {
+		t.Context().Infof("%s : %v", k, uint64(v))
+		if strings.Contains(k, "low") {
+			lowPrio = uint64(v)
+		}
+		if strings.Contains(k, "high") {
+			highPrio = uint64(v)
+		}
+	}
+	if lowPrio == 0 || highPrio == 0 {
+		t.Failf("QoS ratio not enforced between high and low priority traffic; High : %v, Low: %v",
+			highPrio, lowPrio)
+		return
+	}
+	ratio := highPrio / lowPrio
+	if !(ratio >= 8 && ratio <= 9) {
+		t.Failf("QoS ratio not enforced between high and low priority traffic; High : %v, Low: %v, ratio: %v",
+			highPrio, lowPrio, ratio)
+	}
+}

--- a/cilium-cli/connectivity/perf/benchmarks/netperf/perfpod.go
+++ b/cilium-cli/connectivity/perf/benchmarks/netperf/perfpod.go
@@ -99,8 +99,9 @@ func (s *netPerf) Run(ctx context.Context, t *check.Test) {
 							Duration: perfParameters.Duration,
 							Scenario: scenarioName,
 							MsgSize:  perfParameters.MessageSize,
+							NetQos:   false,
 						}
-						perfResult := netperf(ctx, server.Pod.Status.PodIP, k, a)
+						perfResult := NetperfCmd(ctx, server.Pod.Status.PodIP, k, a)
 						t.Context().PerfResults = append(t.Context().PerfResults, common.PerfSummary{PerfTest: k, Result: perfResult})
 					})
 				}
@@ -132,9 +133,9 @@ func parseFloat(a *check.Action, value string) float64 {
 	return res
 }
 
-func netperf(ctx context.Context, sip string, perfTest common.PerfTests, a *check.Action) common.PerfResult {
+func NetperfCmd(ctx context.Context, sip string, perfTest common.PerfTests, a *check.Action) common.PerfResult {
 	args := []string{"-o", "MIN_LATENCY,MEAN_LATENCY,MAX_LATENCY,P50_LATENCY,P90_LATENCY,P99_LATENCY,TRANSACTION_RATE,THROUGHPUT,THROUGHPUT_UNITS"}
-	if perfTest.Test == "UDP_STREAM" {
+	if perfTest.Test == "UDP_STREAM" || perfTest.NetQos {
 		args = append(args, "-m", fmt.Sprintf("%d", perfTest.MsgSize))
 	}
 	exec := buildExecCommand(perfTest.Test, sip, perfTest.Duration, args)

--- a/cilium-cli/connectivity/perf/common/metrics.go
+++ b/cilium-cli/connectivity/perf/common/metrics.go
@@ -101,6 +101,7 @@ type PerfTests struct {
 	Sample   int
 	MsgSize  int
 	Duration time.Duration
+	NetQos   bool
 }
 
 // PerfSummary stores combined metadata information and results of test

--- a/pkg/datapath/fake/types/bandwidth.go
+++ b/pkg/datapath/fake/types/bandwidth.go
@@ -12,7 +12,7 @@ type BandwidthManager struct{}
 func (fbm *BandwidthManager) DeleteBandwidthLimit(endpointID uint16) {
 }
 
-func (fbm *BandwidthManager) UpdateBandwidthLimit(endpointID uint16, bytesPerSecond uint64) {
+func (fbm *BandwidthManager) UpdateBandwidthLimit(endpointID uint16, bytesPerSecond uint64, prio uint32) {
 }
 
 func (fbm *BandwidthManager) BBREnabled() bool {

--- a/pkg/datapath/linux/bandwidth/bandwidth.go
+++ b/pkg/datapath/linux/bandwidth/bandwidth.go
@@ -29,6 +29,8 @@ const (
 	EgressBandwidth = "kubernetes.io/egress-bandwidth"
 	// IngressBandwidth is the K8s Pod annotation.
 	IngressBandwidth = "kubernetes.io/ingress-bandwidth"
+	// Priority is the Cilium Pod priority annotation.
+	Priority = "bandwidth.cilium.io/priority"
 
 	// FqDefaultHorizon represents maximum allowed departure
 	// time delta in future. Given applications can set SO_TXTIME
@@ -66,12 +68,12 @@ func (m *manager) defines() (defines.Map, error) {
 	return cDefinesMap, nil
 }
 
-func (m *manager) UpdateBandwidthLimit(epID uint16, bytesPerSecond uint64) {
+func (m *manager) UpdateBandwidthLimit(epID uint16, bytesPerSecond uint64, prio uint32) {
 	if m.enabled {
 		txn := m.params.DB.WriteTxn(m.params.EdtTable)
 		m.params.EdtTable.Insert(
 			txn,
-			bwmap.NewEdt(epID, bytesPerSecond),
+			bwmap.NewEdt(epID, bytesPerSecond, prio),
 		)
 		txn.Commit()
 	}

--- a/pkg/datapath/linux/bandwidth/bandwidth.go
+++ b/pkg/datapath/linux/bandwidth/bandwidth.go
@@ -40,6 +40,19 @@ const (
 	// FqDefaultBuckets is the default 32k (2^15) bucket limit for bwm.
 	// Too low bucket limit can cause scalability issue.
 	FqDefaultBuckets = 15
+
+	// FQ priomap starting from index 0 is 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
+	// Constants below map priority levels to bands high, medium and low.
+	// TODO: These are picked arbitrarily for each QoS class amongst different possible
+	// values. Revisit to see if picking these values would have any unintended side effects.
+	// HACK: Increment prio values by 1 to allow for distinguishing between 0 prio and no prio set.
+
+	// GuaranteedQoSDefaultPriority prio value to classify packets to high prio band
+	GuaranteedQoSDefaultPriority = 6 + 1
+	// BurstableQoSDefaultPriority prio value to classify packets to medium prio band
+	BurstableQoSDefaultPriority = 8 + 1
+	// BestEffortQoSDefaultPriority prio value to classify packets to medium prio band
+	BestEffortQoSDefaultPriority = 5 + 1
 )
 
 type manager struct {

--- a/pkg/datapath/types/bandwidth.go
+++ b/pkg/datapath/types/bandwidth.go
@@ -32,6 +32,6 @@ type BandwidthManager interface {
 	BBREnabled() bool
 	Enabled() bool
 
-	UpdateBandwidthLimit(endpointID uint16, bytesPerSecond uint64)
+	UpdateBandwidthLimit(endpointID uint16, bytesPerSecond uint64, prio uint32)
 	DeleteBandwidthLimit(endpointID uint16)
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1792,12 +1792,12 @@ func (e *Endpoint) metadataResolver(ctx context.Context,
 		value, _ := annotation.Get(po, annotation.NoTrack, annotation.NoTrackAlias)
 		return value, nil
 	})
-	e.UpdateBandwidthPolicy(bwm, func(ns, podName string) (bandwidthEgress string, err error) {
+	e.UpdateBandwidthPolicy(bwm, func(ns, podName string) (bandwidthEgress string, prio string, err error) {
 		_, k8sMetadata, err := resolveMetadata(ns, podName)
 		if err != nil {
-			return "", filterResolveMetadataError(err)
+			return "", "", filterResolveMetadataError(err)
 		}
-		return k8sMetadata.Annotations[bandwidth.EgressBandwidth], nil
+		return k8sMetadata.Annotations[bandwidth.EgressBandwidth], k8sMetadata.Annotations[bandwidth.Priority], nil
 	})
 
 	// If 'baseLabels' are not set then 'controllerBaseLabels' only contains

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -895,7 +895,8 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity, newEndpoint bool)
 
 // AnnotationsResolverCB provides an implementation for resolving the pod
 // annotations.
-type AnnotationsResolverCB func(ns, podName string) (value string, err error)
+type AnnotationsResolverCB func(ns, podName string) (proxyVisibility string, err error)
+type AnnotationsResolverCBBW func(ns, podName string) (bw string, prio string, err error)
 
 // UpdateNoTrackRules updates the NOTRACK iptable rules for this endpoint. If anno
 // is empty, then any existing NOTRACK rules will be removed. If anno cannot be parsed,
@@ -919,7 +920,7 @@ func (e *Endpoint) UpdateNoTrackRules(annoCB AnnotationsResolverCB) {
 
 // UpdateBandwidthPolicy updates the egress bandwidth of this endpoint to
 // progagate the throttle rate to the BPF data path.
-func (e *Endpoint) UpdateBandwidthPolicy(bwm dptypes.BandwidthManager, annoCB AnnotationsResolverCB) {
+func (e *Endpoint) UpdateBandwidthPolicy(bwm dptypes.BandwidthManager, annoCB AnnotationsResolverCBBW) {
 	ch, err := e.eventQueue.Enqueue(eventqueue.NewEvent(&EndpointPolicyBandwidthEvent{
 		bwm:    bwm,
 		ep:     e,

--- a/pkg/maps/bwmap/bwmap.go
+++ b/pkg/maps/bwmap/bwmap.go
@@ -38,10 +38,12 @@ type EdtInfo struct {
 	Bps             uint64    `align:"bps"`
 	TimeLast        uint64    `align:"t_last"`
 	TimeHorizonDrop uint64    `align:"t_horizon_drop"`
-	Pad             [4]uint64 `align:"pad"`
+	Prio            uint32    `align:"prio"`
+	Pad32           uint32    `align:"pad_32"`
+	Pad             [3]uint64 `align:"pad"`
 }
 
-func (v *EdtInfo) String() string    { return fmt.Sprintf("%d", int(v.Bps)) }
+func (v *EdtInfo) String() string    { return fmt.Sprintf("%d, %d", int(v.Bps), int(v.Prio)) }
 func (v *EdtInfo) New() bpf.MapValue { return &EdtInfo{} }
 
 type throttleMap struct {

--- a/pkg/maps/bwmap/table.go
+++ b/pkg/maps/bwmap/table.go
@@ -29,6 +29,8 @@ type Edt struct {
 	// BytesPerSecond is the bandwidth limit for the endpoint.
 	BytesPerSecond uint64
 
+	Prio uint32
+
 	// TimeHorizonDrop is the maximum allowed departure time nanoseconds
 	// delta in future.
 	TimeHorizonDrop uint64
@@ -47,10 +49,11 @@ var EdtIDIndex = statedb.Index[Edt, uint16]{
 	Unique:     true,
 }
 
-func NewEdt(endpointID uint16, bytesPerSecond uint64) Edt {
+func NewEdt(endpointID uint16, bytesPerSecond uint64, prio uint32) Edt {
 	return Edt{
 		EndpointID:      endpointID,
 		BytesPerSecond:  bytesPerSecond,
+		Prio:            prio,
 		TimeHorizonDrop: uint64(DefaultDropHorizon),
 		Status:          reconciler.StatusPending(),
 	}
@@ -73,6 +76,7 @@ func (e Edt) BinaryValue() encoding.BinaryMarshaler {
 		Bps:             e.BytesPerSecond,
 		TimeLast:        0, // Used on the BPF-side
 		TimeHorizonDrop: e.TimeHorizonDrop,
+		Prio:            e.Prio,
 	}
 	return bpf.StructBinaryMarshaler{Target: &v}
 }
@@ -81,6 +85,7 @@ func (e Edt) TableHeader() []string {
 	return []string{
 		"EndpointID",
 		"BitsPerSecond",
+		"Prio",
 		"TimeHorizonDrop",
 		"Status",
 	}
@@ -93,6 +98,7 @@ func (e Edt) TableRow() []string {
 	return []string{
 		strconv.FormatUint(uint64(e.EndpointID), 10),
 		quantity.String(),
+		strconv.FormatUint(uint64(e.Prio), 10),
 		strconv.FormatUint(e.TimeHorizonDrop, 10),
 		e.Status.String(),
 	}


### PR DESCRIPTION
Adds support for setting networking QoS classes for pods via an annotation `bandwidth.cilium.io/priority`. Annotation currently supports two kinds of values : 
* QoS class strings `Guaranteed`, `Burstable`, and `BestEffort` similar to [Kubernetes pod QoS](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/) 
* Priority level integers supported by the FQ scheduler (based on priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1 )

BW manager currently uses FQ packet scheduler which recently got support for priority bands in `6.7`.

This allows users to pick between three FQ priority bands low, medium and high. FQ uses a weighted round robin algorithm to avoid starvation. These weights are customizable and we can consider supporting custom weights in the future.

Default weights are as follows :
- high prio (band=0) packets get 90% of the bandwidth if they compete with low prio (band=2) packets.
- high prio packets get 75% of the bandwidth if they compete with medium prio (band=1) packets.

See https://github.com/torvalds/linux/commit/29f834aa326e659ed354c406056e94ea3d29706a for more details.

This PR also sets `Guaranteed` QoS class (FQ high priority band) for the host endpoint.

Tested this on an instance with 1 Gb/s max throughput, under contention notice the ~ 1:9 throughput split.

```
// On pod configured to use Band 0
bash-5.1# super_netperf 100 -t TCP_STREAM -H 10.42.1.83 -l 120 -P 8 -- -m 1500000 -R 1
912.94

// On pod configured to use Band 2
bash-5.1# super_netperf 100 -t TCP_STREAM -H 10.42.1.83 -l 120 -P 8 -- -m 1500000 -R 1
103.83
```

Based on @borkmann 's PoC https://github.com/cilium/cilium/pull/25618 

ToDo : 
- [x] Trigger connectivity perf --net-qos from CI (will be addressed in a different PR)
- [x]  Disable ginkgo test

This PR also extends Cilium CLI's connectivity perf command to test for network QoS enforcement

```
➜  cilium git:(hmalla/bw_prio) ✗ go run cilium-cli/cmd/cilium/main.go connectivity perf --net-qos
ℹ️   Monitor aggregation detected, will skip some flow validation steps
🔥 [default] Deleting connectivity check deployments...
⌛ [default] Waiting for namespace cilium-test-1 to disappear
✨ [default] Creating namespace cilium-test-1 for connectivity check...
ℹ️   Nodes used for performance testing:
ℹ️   Node name: ip-10-0-12-161, zone:
ℹ️   Node name: ip-10-0-12-237, zone:
✨ [default] Deploying perf-server deployment...
✨ [default] Deploying perf-client-low-priority deployment...
✨ [default] Deploying perf-client-high-priority deployment...
⌛ [default] Waiting for deployment cilium-test-1/perf-client-low-priority to become ready...
⌛ [default] Waiting for deployment cilium-test-1/perf-client-high-priority to become ready...
⌛ [default] Waiting for deployment cilium-test-1/perf-server to become ready...
ℹ️   Expose Relay locally with:
   cilium hubble enable
   cilium hubble port-forward&
ℹ️   Cilium version: 1.17.0
🏃[cilium-test-1] Running 1 tests ...
[=] [cilium-test-1] Test [network-qos] [1/1]
........................................................................................................................................................................................................

ℹ️   cilium-test-1/perf-client-high-priority-5c76d95c76-fbdv7 : 928840000
ℹ️   cilium-test-1/perf-client-low-priority-6b6c59647-qvgpl : 111660000

✅ [cilium-test-1] All 1 tests (200 actions) successful, 0 tests skipped, 0 scenarios skipped.
```

Closes: #24194