### PR TITLE
hubble-relay: refactor deprecated call to grpc.DialContext

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1805,7 +1805,7 @@
      - object
      - ``{}``
    * - :spelling:ignore:`hubble.relay.dialTimeout`
-     - Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").
+     - Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").  This option has been deprecated and is a no-op.
      - string
      - ``nil``
    * - :spelling:ignore:`hubble.relay.enabled`

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -347,6 +347,9 @@ Removed Options
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~
 
+* The hubble-relay flag ``--dial-timeout`` has been deprecated (now a no-op)
+  and will be removed in Cilium 1.18.
+
 Helm Options
 ~~~~~~~~~~~~
 
@@ -359,6 +362,8 @@ Helm Options
 * The default value of ``hubble.tls.auto.certValidityDuration`` has been
   lowered from 1095 days to 365 days because recent versions of MacOS will fail
   to validate certificates with expirations longer than 825 days.
+* The Helm option ``hubble.relay.dialTimeout`` has been deprecated (now a no-op)
+  and will be removed in Cilium 1.18.
 
 Agent Options
 ~~~~~~~~~~~~~

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -60,8 +60,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version) check.Scenario {
 		hubbleQueueFull, reflectPanic, svcNotFound, unableTranslateCIDRgroups, gobgpWarnings,
 		endpointMapDeleteFailed, etcdReconnection, epRestoreMissingState, mutationDetectorKlog,
 		hubbleFailedCreatePeer, fqdnDpUpdatesTimeout, longNetpolUpdate, failedToGetEpLabels,
-		errPeerChangeNotif, failedCreategRPCClient, unableReallocateIngressIP,
-		fqdnMaxIPPerHostname, failedGetMetricsAPI}
+		failedCreategRPCClient, unableReallocateIngressIP, fqdnMaxIPPerHostname, failedGetMetricsAPI}
 	// The list is adopted from cilium/cilium/test/helper/utils.go
 	var errorMsgsWithExceptions = map[string][]logMatcher{
 		panicMessage:        nil,
@@ -301,7 +300,6 @@ const (
 	fqdnDpUpdatesTimeout      stringMatcher = "Timed out waiting for datapath updates of FQDN IP information"         // cf. https://github.com/cilium/cilium/issues/35931
 	longNetpolUpdate          stringMatcher = "took longer than 100ms to update network policy"                       // cf. https://github.com/cilium/cilium/issues/36067
 	failedToGetEpLabels       stringMatcher = "Failed to get identity labels for endpoint"                            // cf. https://github.com/cilium/cilium/issues/36068
-	errPeerChangeNotif        stringMatcher = "Error while receiving peer change notification;"                       // cf. https://github.com/cilium/cilium/issues/36070
 	failedCreategRPCClient    stringMatcher = "Failed to create gRPC client"                                          // cf. https://github.com/cilium/cilium/issues/36070
 	unableReallocateIngressIP stringMatcher = "unable to re-allocate ingress IPv6"                                    // cf. https://github.com/cilium/cilium/issues/36072
 	fqdnMaxIPPerHostname      stringMatcher = "Raise tofqdns-endpoint-max-ip-per-hostname to mitigate this"           // cf. https://github.com/cilium/cilium/issues/36073

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -31,7 +31,7 @@ const (
 	keyPprofPort               = "pprof-port"
 	keyGops                    = "gops"
 	keyGopsPort                = "gops-port"
-	keyDialTimeout             = "dial-timeout"
+	keyDialTimeout             = "dial-timeout" // Deprecated: now a no-op
 	keyRetryTimeout            = "retry-timeout"
 	keyListenAddress           = "listen-address"
 	keyHealthListenAddress     = "health-listen-address"
@@ -88,6 +88,7 @@ func New(vp *viper.Viper) *cobra.Command {
 		keyDialTimeout,
 		defaults.DialTimeout,
 		"Dial timeout when connecting to hubble peers")
+	flags.MarkDeprecated(keyDialTimeout, "This option is deprecated, and will be removed in v1.18")
 	flags.Duration(
 		keyRetryTimeout,
 		defaults.RetryTimeout,
@@ -193,7 +194,6 @@ func runServe(vp *viper.Viper) error {
 
 	opts := []server.Option{
 		server.WithLocalClusterName(vp.GetString(keyClusterName)),
-		server.WithDialTimeout(vp.GetDuration(keyDialTimeout)),
 		server.WithPeerTarget(vp.GetString(keyPeerService)),
 		server.WithListenAddress(vp.GetString(keyListenAddress)),
 		server.WithHealthListenAddress(vp.GetString(keyHealthListenAddress)),

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -501,7 +501,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.redact.kafka.apiKey | bool | `false` | Enables redacting Kafka's API key. Example:    redact:     enabled: true     kafka:       apiKey: true  You can specify the options from the helm CLI:    --set hubble.redact.enabled="true"   --set hubble.redact.kafka.apiKey="true" |
 | hubble.relay.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for hubble-replay |
 | hubble.relay.annotations | object | `{}` | Annotations to be added to all top-level hubble-relay objects (resources under templates/hubble-relay) |
-| hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
+| hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").  This option has been deprecated and is a no-op. |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |
 | hubble.relay.extraEnv | list | `[]` | Additional hubble-relay environment variables. |
 | hubble.relay.extraVolumeMounts | list | `[]` | Additional hubble-relay volumeMounts. |

--- a/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
@@ -33,7 +33,6 @@ data:
     {{- if .Values.hubble.relay.prometheus.enabled }}
     metrics-listen-address: ":{{ .Values.hubble.relay.prometheus.port }}"
     {{- end }}
-    dial-timeout: {{ .Values.hubble.relay.dialTimeout }}
     retry-timeout: {{ .Values.hubble.relay.retryTimeout }}
     sort-buffer-len-max: {{ .Values.hubble.relay.sortBufferLenMax }}
     sort-buffer-drain-timeout: {{ .Values.hubble.relay.sortBufferDrainTimeout }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1560,6 +1560,8 @@ hubble:
     # type: [null, string]
     # @schema
     # -- Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").
+    #
+    # This option has been deprecated and is a no-op.
     dialTimeout: ~
     # @schema
     # type: [null, string]

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1569,6 +1569,8 @@ hubble:
     # type: [null, string]
     # @schema
     # -- Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").
+    #
+    # This option has been deprecated and is a no-op.
     dialTimeout: ~
     # @schema
     # type: [null, string]

--- a/pkg/hubble/peer/types/client.go
+++ b/pkg/hubble/peer/types/client.go
@@ -4,7 +4,6 @@
 package types
 
 import (
-	"context"
 	"crypto/tls"
 	"io"
 
@@ -15,7 +14,6 @@ import (
 	peerpb "github.com/cilium/cilium/api/v1/peer"
 	"github.com/cilium/cilium/pkg/crypto/certloader"
 	hubbleopts "github.com/cilium/cilium/pkg/hubble/server/serveroption"
-	"github.com/cilium/cilium/pkg/time"
 )
 
 // Client defines an interface that Peer service client should implement.
@@ -26,7 +24,7 @@ type Client interface {
 
 // ClientBuilder creates a new Client.
 type ClientBuilder interface {
-	// Client builds a new Client that connects to the given target.
+	// Client builds a new Client.
 	Client(target string) (Client, error)
 }
 
@@ -42,23 +40,18 @@ func (c *client) Close() error {
 	return c.conn.Close()
 }
 
+var _ ClientBuilder = (*LocalClientBuilder)(nil)
+
 // LocalClientBuilder is a ClientBuilder that is suitable when the gRPC
 // connection to the Peer service is local (typically a Unix Domain Socket).
-type LocalClientBuilder struct {
-	DialTimeout time.Duration
-}
+type LocalClientBuilder struct{}
 
 // Client implements ClientBuilder.Client.
 func (b LocalClientBuilder) Client(target string) (Client, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), b.DialTimeout)
-	defer cancel()
 	// The connection is local, so we assume using insecure connection is safe in
 	// this context.
-	conn, err := grpc.DialContext(ctx, target,
+	conn, err := grpc.NewClient(target,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
-		grpc.WithReturnConnectionError(),
-		grpc.FailOnNonTempDialError(true),
 	)
 	if err != nil {
 		return nil, err
@@ -66,21 +59,18 @@ func (b LocalClientBuilder) Client(target string) (Client, error) {
 	return &client{conn, peerpb.NewPeerClient(conn)}, nil
 }
 
+var _ ClientBuilder = (*RemoteClientBuilder)(nil)
+
 // RemoteClientBuilder is a ClientBuilder that is suitable when the gRPC
 // connection to the Peer service is remote (typically a K8s Service).
 type RemoteClientBuilder struct {
-	DialTimeout   time.Duration
 	TLSConfig     certloader.ClientConfigBuilder
 	TLSServerName string
 }
 
-// Client implements ClientBuilder.Client.
+// Client implements the ClientBuilder interface.
 func (b RemoteClientBuilder) Client(target string) (Client, error) {
-	opts := []grpc.DialOption{
-		grpc.WithBlock(),
-		grpc.WithReturnConnectionError(),
-		grpc.FailOnNonTempDialError(true),
-	}
+	var opts []grpc.DialOption
 	if b.TLSConfig == nil {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
@@ -92,9 +82,7 @@ func (b RemoteClientBuilder) Client(target string) (Client, error) {
 		})
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), b.DialTimeout)
-	defer cancel()
-	conn, err := grpc.DialContext(ctx, target, opts...)
+	conn, err := grpc.NewClient(target, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hubble/relay/pool/client_test.go
+++ b/pkg/hubble/relay/pool/client_test.go
@@ -39,15 +39,13 @@ func TestGRPCClientConnBuilder_CertificateChange(t *testing.T) {
 		ca:   ca,
 	}
 	cb := GRPCClientConnBuilder{
-		DialTimeout: 5 * time.Second,
-		Options: []grpc.DialOption{
-			grpc.WithBlock(),
-			grpc.FailOnNonTempDialError(true),
-			grpc.WithReturnConnectionError(),
-		},
 		TLSConfig: fTLSb,
 	}
-	dir, err := os.MkdirTemp("", t.Name())
+	// on mac, the max length of a unix socket path is 104
+	// when using the test name as-is, we can hit:
+	//   listen unix /var/folders/3c/l4cz8jlx17s0fz5z5vcj26500000gn/T/TestGRPCClientConnBuilder_CertificateChange1112872806/relay.sock: bind: invalid argument
+	// therefore hardcode a smaller name to avoid issues
+	dir, err := os.MkdirTemp("", "testCertificateChange**")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 

--- a/pkg/hubble/relay/pool/manager.go
+++ b/pkg/hubble/relay/pool/manager.go
@@ -97,7 +97,7 @@ connect:
 			m.opts.log.WithFields(logrus.Fields{
 				"error":  err,
 				"target": m.opts.peerServiceAddress,
-			}).Warning("Failed to create peer client for peers synchronization; will try again after the timeout has expired")
+			}).Info("Failed to create peer client for peers synchronization; will try again after the timeout has expired")
 			select {
 			case <-m.stop:
 				return
@@ -111,7 +111,7 @@ connect:
 			m.opts.log.WithFields(logrus.Fields{
 				"error":              err,
 				"connection timeout": m.opts.retryTimeout,
-			}).Warning("Failed to create peer notify client for peers change notification; will try again after the timeout has expired")
+			}).Info("Failed to create peer notify client for peers change notification; will try again after the timeout has expired")
 			select {
 			case <-m.stop:
 				return
@@ -133,7 +133,7 @@ connect:
 				m.opts.log.WithFields(logrus.Fields{
 					"error":              err,
 					"connection timeout": m.opts.retryTimeout,
-				}).Warning("Error while receiving peer change notification; will try again after the timeout has expired")
+				}).Info("Error while receiving peer change notification; will try again after the timeout has expired")
 				m.peerServiceConnected.Store(false)
 				select {
 				case <-m.stop:

--- a/pkg/hubble/relay/pool/manager_test.go
+++ b/pkg/hubble/relay/pool/manager_test.go
@@ -561,7 +561,7 @@ func TestPeerManager(t *testing.T) {
 			},
 			want: want{
 				log: []string{
-					`level=warning msg="Failed to create peer client for peers synchronization; will try again after the timeout has expired" error="I'm on PTO" target="unix:///var/run/cilium/hubble.sock"`,
+					`level=info msg="Failed to create peer client for peers synchronization; will try again after the timeout has expired" error="I'm on PTO" target="unix:///var/run/cilium/hubble.sock"`,
 				},
 			},
 		}, {
@@ -633,7 +633,7 @@ func TestPeerManager(t *testing.T) {
 			},
 			want: want{
 				log: []string{
-					`level=warning msg="Failed to create peer notify client for peers change notification; will try again after the timeout has expired" connection timeout=30s error="Don't feel like workin' today"`,
+					`level=info msg="Failed to create peer notify client for peers change notification; will try again after the timeout has expired" connection timeout=30s error="Don't feel like workin' today"`,
 				},
 			},
 		}, {
@@ -656,7 +656,7 @@ func TestPeerManager(t *testing.T) {
 				},
 			},
 			want: want{
-				log: []string{`level=warning msg="Error while receiving peer change notification; will try again after the timeout has expired" connection timeout=30s error="Nope, ain't doin' nothin'`},
+				log: []string{`level=info msg="Error while receiving peer change notification; will try again after the timeout has expired" connection timeout=30s error="Nope, ain't doin' nothin'`},
 			},
 		},
 	}

--- a/pkg/hubble/relay/pool/option.go
+++ b/pkg/hubble/relay/pool/option.go
@@ -5,8 +5,6 @@ package pool
 
 import (
 	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/cilium/cilium/pkg/backoff"
 	peerTypes "github.com/cilium/cilium/pkg/hubble/peer/types"
@@ -20,18 +18,8 @@ import (
 // defaultOptions is the reference point for default values.
 var defaultOptions = options{
 	peerServiceAddress: defaults.PeerTarget,
-	peerClientBuilder: peerTypes.LocalClientBuilder{
-		DialTimeout: defaults.DialTimeout,
-	},
-	clientConnBuilder: GRPCClientConnBuilder{
-		DialTimeout: defaults.DialTimeout,
-		Options: []grpc.DialOption{
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithBlock(),
-			grpc.FailOnNonTempDialError(true),
-			grpc.WithReturnConnectionError(),
-		},
-	},
+	peerClientBuilder:  peerTypes.LocalClientBuilder{},
+	clientConnBuilder:  GRPCClientConnBuilder{},
 	backoff: &backoff.Exponential{
 		Min:    time.Second,
 		Max:    time.Minute,

--- a/pkg/hubble/relay/server/option.go
+++ b/pkg/hubble/relay/server/option.go
@@ -25,7 +25,6 @@ const MinTLSVersion = tls.VersionTLS13
 // options stores all the configuration values for the hubble-relay server.
 type options struct {
 	peerTarget             string
-	dialTimeout            time.Duration
 	retryTimeout           time.Duration
 	listenAddress          string
 	healthListenAddress    string
@@ -45,7 +44,6 @@ type options struct {
 // defaultOptions is the reference point for default values.
 var defaultOptions = options{
 	peerTarget:          defaults.PeerTarget,
-	dialTimeout:         defaults.DialTimeout,
 	retryTimeout:        defaults.RetryTimeout,
 	listenAddress:       defaults.ListenAddress,
 	healthListenAddress: defaults.HealthListenAddress,
@@ -63,15 +61,6 @@ type Option func(o *options) error
 func WithPeerTarget(t string) Option {
 	return func(o *options) error {
 		o.peerTarget = t
-		return nil
-	}
-}
-
-// WithDialTimeout sets the dial timeout that is used when establishing a
-// connection to a hubble peer.
-func WithDialTimeout(t time.Duration) Option {
-	return func(o *options) error {
-		o.dialTimeout = t
 		return nil
 	}
 }

--- a/pkg/hubble/relay/server/server.go
+++ b/pkg/hubble/relay/server/server.go
@@ -73,12 +73,9 @@ func New(options ...Option) (*Server, error) {
 		return nil, ErrNoServerTLSConfig
 	}
 
-	var peerClientBuilder peerTypes.ClientBuilder = &peerTypes.LocalClientBuilder{
-		DialTimeout: opts.dialTimeout,
-	}
+	var peerClientBuilder peerTypes.ClientBuilder = &peerTypes.LocalClientBuilder{}
 	if !strings.HasPrefix(opts.peerTarget, "unix://") {
 		peerClientBuilder = &peerTypes.RemoteClientBuilder{
-			DialTimeout:   opts.dialTimeout,
 			TLSConfig:     opts.clientTLSConfig,
 			TLSServerName: peer.TLSServerName(defaults.PeerServiceName, opts.clusterName),
 		}
@@ -89,12 +86,6 @@ func New(options ...Option) (*Server, error) {
 		pool.WithPeerServiceAddress(opts.peerTarget),
 		pool.WithPeerClientBuilder(peerClientBuilder),
 		pool.WithClientConnBuilder(pool.GRPCClientConnBuilder{
-			DialTimeout: opts.dialTimeout,
-			Options: []grpc.DialOption{
-				grpc.WithBlock(),
-				grpc.FailOnNonTempDialError(true),
-				grpc.WithReturnConnectionError(),
-			},
 			TLSConfig: opts.clientTLSConfig,
 		}),
 		pool.WithRetryTimeout(opts.retryTimeout),

--- a/pkg/hubble/relay/server/server_test.go
+++ b/pkg/hubble/relay/server/server_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
@@ -33,7 +32,6 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/parser"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	peerTypes "github.com/cilium/cilium/pkg/hubble/peer/types"
-	"github.com/cilium/cilium/pkg/hubble/relay/defaults"
 	relayObserver "github.com/cilium/cilium/pkg/hubble/relay/observer"
 	"github.com/cilium/cilium/pkg/hubble/relay/pool"
 	poolTypes "github.com/cilium/cilium/pkg/hubble/relay/pool/types"
@@ -209,15 +207,7 @@ func benchmarkRelayGetFlows(b *testing.B, withFieldMask bool) {
 	}
 
 	// Create hubble relay server and connect to all peers from previous step.
-	ccb := pool.GRPCClientConnBuilder{
-		DialTimeout: defaults.DialTimeout,
-		Options: []grpc.DialOption{
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithBlock(),
-			grpc.FailOnNonTempDialError(true),
-			grpc.WithReturnConnectionError(),
-		},
-	}
+	ccb := pool.GRPCClientConnBuilder{}
 	plr := &testutils.FakePeerLister{
 		OnList: func() []poolTypes.Peer {
 			ret := make([]poolTypes.Peer, len(peers))


### PR DESCRIPTION
This PR replaces deprecated calls to `grpc.DialContext` with `grpc.NewClient`. It also removes the `--dial-timeout` flag from the CLI and deprecates the `hubble.relay.dialTimeout` in the Helm chart.

Rework of: https://github.com/cilium/cilium/pull/34261
Fixes: https://github.com/cilium/cilium/issues/33065
Fixes: https://github.com/cilium/cilium/issues/36070

```release-note
Refactor deprecated call to grpc.DialContext in Hubble Relay
```
