### PR TITLE
ipsec: Fix XFRM clean up

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -890,6 +890,13 @@ func isXfrmPolicyCilium(policy netlink.XfrmPolicy) bool {
 			policy.Priority == linux_defaults.IPsecFwdPriority {
 			return true
 		}
+		// Check if its our catch-all IN policy.
+		if policy.Dir == netlink.XFRM_DIR_IN && len(policy.Tmpls) == 1 {
+			tmpl := policy.Tmpls[0]
+			if tmpl.Spi == 0 && tmpl.Reqid == 0 && tmpl.Optional == 1 {
+				return true
+			}
+		}
 		return false
 	}
 


### PR DESCRIPTION
When deleting old XFRM policies (ex. when disabling IPsec), we try to skip policies not installed by Cilium, just in case someone else has the good idea of using XFRM. We do so in function `isXfrmPolicyCilium` with various rules.

Unfortunately, our XFRM IN policies changed in https://github.com/cilium/cilium/commit/f108c0cebcc86b888a6c0b6248c9f10eb31fa77b ("ipsec: Simplify XFRM IN policies") and `isXfrmPolicyCilium` doesn't work anymore. So we need to adapt it to recognize the new XFRM IN policy.

This bug resulted in Cilium never cleaning up the XFRM IN policy, which would cause one of our IPsec integration tests to always pass.

Ran it against the old `main` to show that it now fails as it should: https://github.com/cilium/cilium/actions/runs/11914957041/job/33204378536. And then rebased to catch the fix for the test.

Fixes: https://github.com/cilium/cilium/pull/35831.