### PR TITLE
envoy: Start listening on xDS socket only after endpoint restoration

### DIFF
--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -229,14 +229,12 @@ func newXDSServer(restorerPromise promise.Promise[endpointstate.Restorer], ipCac
 
 // start configures and starts the xDS GRPC server.
 func (s *xdsServer) start() error {
-	socketListener, err := s.newSocketListener()
-	if err != nil {
-		return fmt.Errorf("failed to create socket listener: %w", err)
-	}
+	// Remove/Unlink the old unix domain socket, if any.
+	_ = os.Remove(s.socketPath)
 
 	resourceConfig := s.initializeXdsConfigs()
 
-	s.stopFunc = s.startXDSGRPCServer(socketListener, resourceConfig)
+	s.stopFunc = s.startXDSGRPCServer(resourceConfig)
 
 	return nil
 }


### PR DESCRIPTION
NOTE: This has been reverted on `main`, see #36060.

Envoy can successfully connect to a socket as soon as the socket is listening, regardless when the accept calls on the new connections are made.

Delay listening on the xDS socket until endpoints have regenerated so that the time gap between the successful xDS connection and the initial fetch of the xDS resources is less likely to hit the initial fetch timeout. This silences related warnings in the logs. Hopefully there will not be a flood of warning logs due to the increased time to successful xDS connections now.
