### PR TITLE
allocator: correctly propagate context to RunGC call

### DIFF
--- a/operator/identitygc/kvstore_gc.go
+++ b/operator/identitygc/kvstore_gc.go
@@ -42,7 +42,7 @@ func (igc *GC) runKVStoreModeGC(ctx context.Context) error {
 	for {
 		now := time.Now()
 
-		keysToDelete, gcStats, err := igc.allocator.RunGC(igc.rateLimiter, keysToDeletePrev)
+		keysToDelete, gcStats, err := igc.allocator.RunGC(ctx, igc.rateLimiter, keysToDeletePrev)
 		gcDuration := time.Since(now)
 		if err != nil {
 			igc.logger.Warn("Unable to run kvstore security identity garbage collector", logfields.Error, err)

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -931,8 +931,8 @@ func (a *Allocator) Release(ctx context.Context, key AllocatorKey) (lastUse bool
 }
 
 // RunGC scans the kvstore for unused master keys and removes them
-func (a *Allocator) RunGC(rateLimit *rate.Limiter, staleKeysPrevRound map[string]uint64) (map[string]uint64, *GCStats, error) {
-	return a.backend.RunGC(context.TODO(), rateLimit, staleKeysPrevRound, a.min, a.max)
+func (a *Allocator) RunGC(ctx context.Context, rateLimit *rate.Limiter, staleKeysPrevRound map[string]uint64) (map[string]uint64, *GCStats, error) {
+	return a.backend.RunGC(ctx, rateLimit, staleKeysPrevRound, a.min, a.max)
 }
 
 // RunLocksGC scans the kvstore for stale locks and removes them

--- a/pkg/allocator/allocator_test.go
+++ b/pkg/allocator/allocator_test.go
@@ -384,7 +384,7 @@ func testAllocator(t *testing.T, maxID idpool.ID) {
 	rateLimiter := rate.NewLimiter(10*time.Second, 100)
 
 	// running the GC should not evict any entries
-	allocator.RunGC(rateLimiter, nil)
+	allocator.RunGC(context.Background(), rateLimiter, nil)
 
 	// release final reference of all IDs
 	for i := idpool.ID(1); i <= maxID; i++ {
@@ -397,7 +397,7 @@ func testAllocator(t *testing.T, maxID idpool.ID) {
 	}
 
 	// running the GC should evict all entries
-	allocator.RunGC(rateLimiter, nil)
+	allocator.RunGC(context.Background(), rateLimiter, nil)
 
 	allocator.DeleteAllKeys()
 	allocator.Delete()

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -233,10 +233,10 @@ func benchmarkGC(b *testing.B) {
 	rateLimiter := rate.NewLimiter(10*time.Second, 100)
 
 	keysToDelete := map[string]uint64{}
-	keysToDelete, _, err = allocator.RunGC(rateLimiter, keysToDelete)
+	keysToDelete, _, err = allocator.RunGC(context.Background(), rateLimiter, keysToDelete)
 	require.NoError(b, err)
 	require.Len(b, keysToDelete, 1)
-	keysToDelete, _, err = allocator.RunGC(rateLimiter, keysToDelete)
+	keysToDelete, _, err = allocator.RunGC(context.Background(), rateLimiter, keysToDelete)
 	require.NoError(b, err)
 	require.Empty(b, keysToDelete)
 
@@ -305,11 +305,11 @@ func benchmarkGCShouldSkipOutOfRangeIdentities(b *testing.B) {
 	rateLimiter := rate.NewLimiter(10*time.Second, 100)
 
 	keysToDelete := map[string]uint64{}
-	keysToDelete, _, err = allocator1.RunGC(rateLimiter, keysToDelete)
+	keysToDelete, _, err = allocator1.RunGC(context.Background(), rateLimiter, keysToDelete)
 	require.NoError(b, err)
 	// But, only one will be filtered out and GC'ed
 	require.Len(b, keysToDelete, 1)
-	keysToDelete, _, err = allocator1.RunGC(rateLimiter, keysToDelete)
+	keysToDelete, _, err = allocator1.RunGC(context.Background(), rateLimiter, keysToDelete)
 	require.NoError(b, err)
 	require.Empty(b, keysToDelete)
 
@@ -397,7 +397,7 @@ func testAllocatorCached(t *testing.T, maxID idpool.ID, allocatorName string) {
 	staleKeysPreviousRound := map[string]uint64{}
 	rateLimiter := rate.NewLimiter(10*time.Second, 100)
 	// running the GC should not evict any entries
-	staleKeysPreviousRound, _, err = a.RunGC(rateLimiter, staleKeysPreviousRound)
+	staleKeysPreviousRound, _, err = a.RunGC(context.Background(), rateLimiter, staleKeysPreviousRound)
 	require.NoError(t, err)
 
 	v, err := kvstore.Client().ListPrefix(context.TODO(), path.Join(allocatorName, "id"))
@@ -411,9 +411,9 @@ func testAllocatorCached(t *testing.T, maxID idpool.ID, allocatorName string) {
 	}
 
 	// running the GC should evict all entries
-	staleKeysPreviousRound, _, err = a.RunGC(rateLimiter, staleKeysPreviousRound)
+	staleKeysPreviousRound, _, err = a.RunGC(context.Background(), rateLimiter, staleKeysPreviousRound)
 	require.NoError(t, err)
-	_, _, err = a.RunGC(rateLimiter, staleKeysPreviousRound)
+	_, _, err = a.RunGC(context.Background(), rateLimiter, staleKeysPreviousRound)
 	require.NoError(t, err)
 
 	v, err = kvstore.Client().ListPrefix(context.TODO(), path.Join(allocatorName, "id"))


### PR DESCRIPTION
This ensures that the underlying operations (e.g., kvstore calls) are correctly aborted when the context gets closed, most relevantly during shutdown. In turn, preventing blocking the shutdown of the operator until the grace period kicks in if the connection to the kvstore failed.