### PR TITLE
Don't mark the agent as ready until successfully connecting to the kvstore (if enabled)

### DIFF
--- a/Documentation/network/concepts/ipam/gke.rst
+++ b/Documentation/network/concepts/ipam/gke.rst
@@ -66,7 +66,7 @@ for IPAM matches the PodCIDR announced in the Kubernetes node:
     cilium-lv4xd                       1/1     Running   0          3h8m   10.164.0.112   gke-cluster4-default-pool-b195a3f3-k431   <none>           <none>
 
     $ kubectl -n kube-system exec -ti cilium-lv4xd -- cilium-dbg status
-    KVStore:                Ok   Disabled
+    KVStore:                Disabled
     Kubernetes:             Ok   1.14+ (v1.14.10-gke.27) [linux/amd64]
     Kubernetes APIs:        ["CustomResourceDefinition", "cilium/v2::CiliumClusterwideNetworkPolicy", "cilium/v2::CiliumEndpoint", "cilium/v2::CiliumNetworkPolicy", "cilium/v2::CiliumNode", "core/v1::Endpoint", "core/v1::Namespace", "core/v1::Pods", "core/v1::Service", "networking.k8s.io/v1::NetworkPolicy"]
     KubeProxyReplacement:   Probe   []

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -332,6 +332,8 @@ communicating via the proxy must reconnect to re-establish connections.
 * The option to run a synchronous probe using ``cilium-health status --probe`` is no longer supported,
   and is now a hidden option that returns the results of the most recent cached probe. It will be 
   removed in a future release.
+* The Cilium status API now reports the KVStore subsystem with ``Disabled`` state when disabled,
+  instead of ``OK`` state and ``Disabled`` message.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1864,7 +1864,9 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 	}
 	bootstrapStats.healthCheck.End(true)
 
-	d.startStatusCollector(cleaner)
+	if err := d.startStatusCollector(d.ctx, cleaner); err != nil {
+		return fmt.Errorf("failed to start status collector: %w", err)
+	}
 
 	d.startAgentHealthHTTPService()
 	if option.Config.KubeProxyReplacementHealthzBindAddr != "" {

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -573,18 +573,6 @@ func (d *Daemon) getIdentityRange() *models.IdentityRange {
 func (d *Daemon) startStatusCollector(cleaner *daemonCleanup) {
 	probes := []status.Probe{
 		{
-			Name: "check-locks",
-			Probe: func(ctx context.Context) (interface{}, error) {
-				// nothing to do any more.
-				return nil, nil
-			},
-			OnStatusUpdate: func(status status.Status) {
-				d.statusCollectMutex.Lock()
-				defer d.statusCollectMutex.Unlock()
-				// FIXME we have no field for the lock status
-			},
-		},
-		{
 			Name: "kvstore",
 			Probe: func(ctx context.Context) (interface{}, error) {
 				if option.Config.KVStore == "" {

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -596,6 +596,14 @@ func (d *Daemon) startStatusCollector(cleaner *daemonCleanup) {
 				}
 
 				if kvstore, ok := status.Data.(*models.Status); ok {
+					if kvstore.State == models.StatusStateWarning && option.Config.KVstorePodNetworkSupport {
+						// Don't treat warnings as errors when the support for running
+						// etcd in pod network is enabled. This is necessary to allow
+						// Cilium turning ready even before connecting to the kvstore,
+						// and break the chicken-and-egg dependency during startup.
+						kvstore.State = models.StatusStateOk
+					}
+
 					d.statusResponse.Kvstore = kvstore
 				}
 			},

--- a/operator/api/health.go
+++ b/operator/api/health.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"k8s.io/client-go/discovery"
 
+	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/api/v1/operator/server/restapi/operator"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -83,8 +84,10 @@ func (h *healthHandler) checkStatus() error {
 		if client == nil {
 			return errors.New("kvstore client not configured")
 		}
-		if _, err := client.Status(); err != nil {
-			return err
+
+		status := client.Status()
+		if status.State != models.StatusStateOk {
+			return errors.New(status.Msg)
 		}
 	}
 	_, err := h.discovery.ServerVersion()

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -289,9 +289,6 @@ type Backend interface {
 	// Note: not all Backend implementations rely on this, such as the kvstore
 	// backends, and may use leases to expire keys.
 	RunLocksGC(ctx context.Context, staleKeysPrevRound map[string]kvstore.Value) (map[string]kvstore.Value, error)
-
-	// Status returns a human-readable status of the Backend.
-	Status() (string, error)
 }
 
 // NewAllocator creates a new Allocator. Any type can be used as key as long as

--- a/pkg/allocator/allocator_test.go
+++ b/pkg/allocator/allocator_test.go
@@ -227,10 +227,6 @@ func (d *dummyBackend) RunGC(context.Context, *rate.Limiter, map[string]uint64, 
 	return nil, nil, nil
 }
 
-func (d *dummyBackend) Status() (string, error) {
-	return "", nil
-}
-
 type TestAllocatorKey string
 
 func (t TestAllocatorKey) GetKey() string { return string(t) }

--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -412,12 +412,7 @@ func (rc *remoteCluster) status() *models.RemoteCluster {
 	// for the first connection to succeed.
 	var backendStatus = "Waiting for initial connection to be established"
 	if rc.backend != nil {
-		var backendError error
-		backendStatus, backendError = rc.backend.Status()
-		if backendError != nil {
-			backendStatus = backendError.Error()
-		}
-
+		backendStatus = rc.backend.Status().Msg
 		if rc.etcdClusterID != "" {
 			backendStatus += ", ID: " + rc.etcdClusterID
 		}

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -426,7 +426,3 @@ func (c *crdBackend) ListAndWatch(ctx context.Context, handler allocator.CacheMu
 
 	identityInformer.Run(stopChan)
 }
-
-func (c *crdBackend) Status() (string, error) {
-	return "OK", nil
-}

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -624,7 +624,3 @@ abort:
 	cancel()
 	watcher.Stop()
 }
-
-func (k *kvstoreBackend) Status() (string, error) {
-	return k.backend.Status()
-}

--- a/pkg/kvstore/allocator/doublewrite/backend.go
+++ b/pkg/kvstore/allocator/doublewrite/backend.go
@@ -252,10 +252,3 @@ func (d *doubleWriteBackend) ListAndWatch(ctx context.Context, handler allocator
 	}
 	d.crdBackend.ListAndWatch(ctx, handler, stopChan)
 }
-
-func (d *doubleWriteBackend) Status() (string, error) {
-	if d.readFromKVStore {
-		return d.kvstoreBackend.Status()
-	}
-	return d.crdBackend.Status()
-}

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -8,6 +8,7 @@ import (
 
 	"google.golang.org/grpc"
 
+	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -141,9 +142,8 @@ type BackendOperations interface {
 	// client is not connected to the kvstore server. (Only implemented for etcd)
 	Disconnected() <-chan struct{}
 
-	// Status returns the status of the kvstore client including an
-	// eventual error
-	Status() (string, error)
+	// Status returns the status of the kvstore client
+	Status() *models.Status
 
 	// StatusCheckErrors returns a channel which receives status check
 	// errors

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -540,7 +540,7 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 		configPath:   cfgPath,
 		firstSession: make(chan struct{}),
 		status: models.Status{
-			State: models.StatusStateOk,
+			State: models.StatusStateWarning,
 			Msg:   "Waiting for initial connection to be established",
 		},
 		stopStatusChecker: make(chan struct{}),

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/time/rate"
 	"sigs.k8s.io/yaml"
 
+	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
@@ -351,15 +352,11 @@ type etcdClient struct {
 	// purposes, associated with a shorter TTL
 	lockLeaseManager *etcdLeaseManager
 
-	// statusLock protects latestStatusSnapshot and latestErrorStatus for
-	// read/write access
+	// statusLock protects status for read/write access
 	statusLock lock.RWMutex
 
-	// latestStatusSnapshot is a snapshot of the latest etcd cluster status
-	latestStatusSnapshot string
-
-	// latestErrorStatus is the latest error condition of the etcd connection
-	latestErrorStatus error
+	// status is a snapshot of the latest etcd cluster status
+	status models.Status
 
 	extraOptions *ExtraOptions
 
@@ -538,15 +535,18 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 	}
 
 	ec := &etcdClient{
-		client:               c,
-		config:               config,
-		configPath:           cfgPath,
-		firstSession:         make(chan struct{}),
-		latestStatusSnapshot: "Waiting for initial connection to be established",
-		stopStatusChecker:    make(chan struct{}),
-		extraOptions:         opts,
-		listBatchSize:        clientOptions.ListBatchSize,
-		statusCheckErrors:    make(chan error, 128),
+		client:       c,
+		config:       config,
+		configPath:   cfgPath,
+		firstSession: make(chan struct{}),
+		status: models.Status{
+			State: models.StatusStateOk,
+			Msg:   "Waiting for initial connection to be established",
+		},
+		stopStatusChecker: make(chan struct{}),
+		extraOptions:      opts,
+		listBatchSize:     clientOptions.ListBatchSize,
+		statusCheckErrors: make(chan error, 128),
 		logger: log.WithFields(logrus.Fields{
 			"endpoints": config.Endpoints,
 			"config":    cfgPath,
@@ -599,8 +599,8 @@ func (e *etcdClient) asyncConnectEtcdClient(errChan chan<- error) {
 
 	propagateError := func(err error) {
 		e.statusLock.Lock()
-		e.latestStatusSnapshot = "Failed to establish initial connection"
-		e.latestErrorStatus = err
+		e.status.State = models.StatusStateFailure
+		e.status.Msg = fmt.Sprintf("Failed to establish initial connection: %s", err.Error())
 		e.statusLock.Unlock()
 
 		errChan <- err
@@ -1022,6 +1022,7 @@ func (e *etcdClient) statusChecker() {
 	ctx := context.Background()
 
 	var consecutiveQuorumErrors uint
+	var err error
 
 	e.RWMutex.Lock()
 	// Ensure that lastHearbeat is always set to a non-zero value when starting
@@ -1081,25 +1082,27 @@ func (e *etcdClient) statusChecker() {
 
 		switch {
 		case consecutiveQuorumErrors > option.Config.KVstoreMaxConsecutiveQuorumErrors:
-			e.latestErrorStatus = fmt.Errorf("quorum check failed %d times in a row: %w",
-				consecutiveQuorumErrors, quorumError)
-			e.latestStatusSnapshot = e.latestErrorStatus.Error()
+			err = fmt.Errorf("quorum check failed %d times in a row: %w", consecutiveQuorumErrors, quorumError)
+			e.status.State = models.StatusStateFailure
+			e.status.Msg = fmt.Sprintf("Err: %s", err.Error())
 		case len(endpoints) > 0 && ok == 0:
-			e.latestErrorStatus = fmt.Errorf("not able to connect to any etcd endpoints")
-			e.latestStatusSnapshot = e.latestErrorStatus.Error()
+			err = fmt.Errorf("not able to connect to any etcd endpoints")
+			e.status.State = models.StatusStateFailure
+			e.status.Msg = fmt.Sprintf("Err: %s", err.Error())
 		default:
-			e.latestErrorStatus = nil
-			e.latestStatusSnapshot = fmt.Sprintf("etcd: %d/%d connected, leases=%d, lock leases=%d, has-quorum=%s: %s",
+			err = nil
+			e.status.State = models.StatusStateOk
+			e.status.Msg = fmt.Sprintf("etcd: %d/%d connected, leases=%d, lock leases=%d, has-quorum=%s: %s",
 				ok, len(endpoints), e.leaseManager.TotalLeases(), e.lockLeaseManager.TotalLeases(), quorumString, strings.Join(newStatus, "; "))
 		}
 
 		e.statusLock.Unlock()
-		if e.latestErrorStatus != nil {
+		if err != nil {
 			select {
-			case e.statusCheckErrors <- e.latestErrorStatus:
+			case e.statusCheckErrors <- err:
 			default:
 				// Channel's buffer is full, skip sending errors to the channel but log warnings instead
-				log.WithError(e.latestErrorStatus).
+				log.WithError(err).
 					Warning("Status check error channel is full, dropping this error")
 			}
 		}
@@ -1113,11 +1116,14 @@ func (e *etcdClient) statusChecker() {
 	}
 }
 
-func (e *etcdClient) Status() (string, error) {
+func (e *etcdClient) Status() *models.Status {
 	e.statusLock.RLock()
 	defer e.statusLock.RUnlock()
 
-	return e.latestStatusSnapshot, Hint(e.latestErrorStatus)
+	return &models.Status{
+		State: e.status.State,
+		Msg:   e.status.Msg,
+	}
 }
 
 // GetIfLocked returns value of key if the client is still holding the given lock.


### PR DESCRIPTION
Currently, the kvstore status is considered ready even during the initialization phase, when the connection has not been established yet. This behavior is potentially confusing, as the agents/operator eventually turn ready, breaking out of the startup probe phase, even if an essential subsystem is not ready at all, only to start crashing a few minutes later due to other timeouts kicking in.

Let's modify this behavior so that the kvstore subsystem, and in turn the Cilium agents, are marked ready only after successfully establishing the connection to etcd. Yet, we enable this behavior only if the support for running etcd in pod network is disabled. Differently, we need to preserve the previous behavior, to break the chicken-and-egg dependency during startup.

Even with these changes, the healthiness probe of the Cilium operator is still affected by issues causing it to initially turn ready, even if the connection to the kvstore has not completed yet. The reason being that, currently, only the leader connects to the kvstore \[1], which means that the status is reported as healthy until then \[2]. This could be fixed by letting all replicas to connect to the kvstore, which should be possible (it historically depended on other subsystems to be started as well, but it is no longer the case since https://github.com/cilium/cilium/pull/32916). However, let's leave that for another PR.

\[1]: https://github.com/cilium/cilium/blob/mio%2Fkvstore-status/operator/cmd/root.go#L666-L668
\[2]: https://github.com/cilium/cilium/blob/mio%2Fkvstore-status/operator/api/health.go#L78-L82

Please review commit by commit, and refer to the individual commit messages for additional details.

Related: https://github.com/cilium/cilium/issues/25288