### PR TITLE
lrp: update LRP services with stale backends on agent restart

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -71,6 +71,7 @@ import (
 	policyAPI "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/redirectpolicy"
 	"github.com/cilium/cilium/pkg/resiliency"
 	"github.com/cilium/cilium/pkg/service"
 	serviceStore "github.com/cilium/cilium/pkg/service/store"
@@ -182,6 +183,8 @@ type Daemon struct {
 	orchestrator    datapath.Orchestrator
 	iptablesManager datapath.IptablesManager
 	hubble          hubblecell.HubbleIntegration
+
+	lrpManager *redirectpolicy.Manager
 }
 
 // GetPolicyRepository returns the policy repository of the daemon
@@ -394,6 +397,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		orchestrator:      params.Orchestrator,
 		iptablesManager:   params.IPTablesManager,
 		hubble:            params.Hubble,
+		lrpManager:        params.LRPManager,
 	}
 
 	// initialize endpointRestoreComplete channel as soon as possible so that subsystems

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -100,6 +100,7 @@ import (
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/redirectpolicy"
 	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/version"
@@ -1626,6 +1627,7 @@ type daemonParams struct {
 	Orchestrator        datapath.Orchestrator
 	IPTablesManager     datapath.IptablesManager
 	Hubble              hubblecell.HubbleIntegration
+	LRPManager          *redirectpolicy.Manager
 }
 
 func newDaemonPromise(params daemonParams) (promise.Promise[*Daemon], promise.Promise[policyK8s.PolicyManager]) {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -442,6 +442,9 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState, endpointsR
 								swg := lock.NewStoppableWaitGroup()
 								for _, svc := range stale {
 									d.k8sSvcCache.EnsureService(svc, swg)
+									if option.Config.EnableLocalRedirectPolicy {
+										d.lrpManager.EnsureService(svc)
+									}
 								}
 
 								swg.Stop()

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -88,6 +88,7 @@ type redirectPolicyManager interface {
 	AddRedirectPolicy(config redirectpolicy.LRPConfig) (bool, error)
 	DeleteRedirectPolicy(config redirectpolicy.LRPConfig) error
 	OnAddService(svcID k8s.ServiceID)
+	EnsureService(svcID k8s.ServiceID) (bool, error)
 	OnDeleteService(svcID k8s.ServiceID)
 	OnUpdatePod(pod *slim_corev1.Pod, needsReassign bool, ready bool)
 	OnDeletePod(pod *slim_corev1.Pod)

--- a/pkg/redirectpolicy/manager_test.go
+++ b/pkg/redirectpolicy/manager_test.go
@@ -1145,3 +1145,39 @@ func TestManager_OnDeletePod(t *testing.T) {
 
 	wg.Wait()
 }
+
+// Tests if EnsureService only processes the LRP type service
+func TestManager_EnsureService(t *testing.T) {
+	m := setupManagerSuite(t)
+
+	configSvc := configSvcType
+	configSvc.serviceID = &k8s.ServiceID{
+		Name:      "foo",
+		Namespace: "ns1",
+	}
+	m.rpm.policyConfigs[configSvc.id] = &configSvc
+
+	processed, err := m.rpm.EnsureService(k8s.ServiceID{
+		Name:      "test-foo" + localRedirectSvcStr,
+		Namespace: "ns1",
+	})
+
+	require.True(t, processed)
+	require.NoError(t, err)
+
+	processed, err = m.rpm.EnsureService(k8s.ServiceID{
+		Name:      "test-foo",
+		Namespace: "ns1",
+	})
+
+	require.False(t, processed)
+	require.NoError(t, err)
+
+	processed, err = m.rpm.EnsureService(k8s.ServiceID{
+		Name:      "test-foo" + localRedirectSvcStr,
+		Namespace: "ns2",
+	})
+
+	require.False(t, processed)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This PR fixes the issue where stale backends are associated with the LRP service after the agent restarts.

Cilium restores the service and backend cache from the BPF map and synchronizes it with the Kubernetes API server, assuming that UpsertService is called for each active service. During the sync period, Cilium keeps a list of restored backends that haven't been observed for each service to prevent temporary connectivity loss during agent restarts. (See commit 920976a.)

After synchronization, an update is triggered for each service still associated with stale backends, allowing them to be removed. However, LRP services are not updated and remain associated with stale backends because the ServiceCache cannot update LRP services. Instead, the LRP manager is responsible for updating them.

This issue arises if a CLRP is created during an agent restart. For example, consider a scenario where the following nodelocaldns CLRP is applied during agent startup:

1) Cilium restores the kube-dns ClusterIP service and its backends (coredns) from the BPF map and synchronizes them with Kubernetes.
2) If the LRP manager calls UpsertService first, it retains coredns, adds node-local-dns as a backend, and updates the kube-dns service to an LRP-type service.
3) After synchronization, updates are triggered for all services. However, the LRP service is not updated, leaving stale backends associated with it. (node-local-dns + coredns)

To address this issue, this commit ensures that the LRP manager calls EnsureService to remove stale backends.

```yaml
apiVersion: "cilium.io/v2"
kind: CiliumLocalRedirectPolicy
metadata:
  name: "nodelocaldns"
  namespace: kube-system
spec:
  redirectFrontend:
    serviceMatcher:
      serviceName: kube-dns
      namespace: kube-system
  redirectBackend:
    localEndpointSelector:
      matchLabels:
        k8s-app: node-local-dns
    toPorts:
      - port: "53"
        name: dns
        protocol: UDP
      - port: "53"
        name: dns-tcp
        protocol: TCP
```

### How can we reproduce the issue?

Note that adding time.Sleep before calling UpsertService makes it easier to reproduce. so that the LRP manager can call UpsertService first.
https://github.com/cilium/cilium/blob/0648731a571cdd1356ce4c0cdc3d449e5720711e/pkg/k8s/watchers/service.go#L575

```
# Set up kind cluster and install Cilium
$ contrib/scripts/kind.sh --xdp "" 3 "" "" "none" "dual"
$ make kind-image
$ cilium install --wait \
    --chart-directory=$(pwd)/install/kubernetes/cilium \
    --disable-check=minimum-version \
    --helm-set=debug.enabled=false \
    --helm-set=debug.verbose=envoy \
    --helm-set=hubble.eventBufferCapacity=65535 \
    --helm-set=bpf.monitorAggregation=none \
    --helm-set=cluster.name=default \
    --helm-set=authentication.mutual.spire.enabled=false \
    --nodes-without-cilium \
    --helm-set-string=kubeProxyReplacement=true \
    --set='bpfClockProbe=false,cni.uninstall=false' \
    --helm-set=image.repository=localhost:5000/cilium/cilium-dev \
    --helm-set=image.useDigest=false \
    --helm-set=image.tag=local \
    --helm-set=image.pullPolicy=Never \
    --helm-set=operator.image.repository=localhost:5000/cilium/operator \
    --helm-set=operator.image.suffix= \
    --helm-set=operator.image.tag=local \
    --helm-set=operator.image.useDigest=false \
    --helm-set=operator.image.pullPolicy=Never \
    --helm-set-string=tunnelProtocol=vxlan \
    --helm-set=devices='eth0' \
    --helm-set-string=loadBalancer.mode=snat \
    --helm-set-string=endpointRoutes.enabled=false \
    --helm-set=ipv6.enabled=true \
    --helm-set=bpf.masquerade=true \
    --helm-set=localRedirectPolicy=true

# Set up node-localdns with LRP
kubedns=$(kubectl get svc kube-dns -n kube-system -o jsonpath={.spec.clusterIP}) && sed -i "s/__PILLAR__DNS__SERVER__/$kubedns/g;" ./examples/kubernetes-local-redirect/node-local-dns.yaml
sed -i "s/__PILLAR__UPSTREAM__SERVERS__/1.1.1.1/g;" ./examples/kubernetes-local-redirect/node-local-dns.yaml
kubectl apply -k ./examples/kubernetes-local-redirect
kubectl rollout status -n kube-system ds/node-local-dns

$ kubectl -n kube-system get po -o wide -l k8s-app=kube-dns
NAME                       READY   STATUS    RESTARTS   AGE   IP             NODE                 NOMINATED NODE   READINESS GATES
coredns-7db6d8ff4d-tmbgr   1/1     Running   0          12m   10.244.0.125   kind-control-plane   <none>           <none>
coredns-7db6d8ff4d-xpgz6   1/1     Running   0          19s   10.244.1.136   kind-worker          <none>           <none>

$ kubectl -n kube-system get po -o wide -l k8s-app=node-local-dns
NAME                   READY   STATUS    RESTARTS   AGE   IP             NODE                 NOMINATED NODE   READINESS GATES
node-local-dns-2ckd7   1/1     Running   0          87s   10.244.0.102   kind-control-plane   <none>           <none>
node-local-dns-2tb99   1/1     Running   0          87s   10.244.2.162   kind-worker2         <none>           <none>
node-local-dns-p2f77   1/1     Running   0          87s   10.244.1.124   kind-worker          <none>           <none>

# Remove clrp and recreate it during the agent restart
kubectl -n kube-system delete clrp nodelocaldns
kubectl -n kube-system delete po $(kubectl -n kube-system get pods -l k8s-app=cilium --field-selector spec.nodeName=kind-worker -o jsonpath='{.items[0].metadata.name}') && kubectl apply -k ./examples/kubernetes-local-redirect

$ kubectl -n kube-system exec $(kubectl -n kube-system get pods -l k8s-app=cilium --field-selector spec.nodeName=kind-worker -o jsonpath='{.items[0].metadata.name}') -- cilium service list
ID   Frontend               Service Type    Backend                               
1    10.96.0.1:443/TCP      ClusterIP       1 => 172.19.0.5:6443/TCP (active)     
2    10.96.69.121:443/TCP   ClusterIP       1 => 172.19.0.2:4244/TCP (active)     
6    10.96.1.90:53/UDP      ClusterIP       1 => 10.244.0.125:53/UDP (active)     
                                            2 => 10.244.1.136:53/UDP (active)     
7    10.96.1.90:53/TCP      ClusterIP       1 => 10.244.0.125:53/TCP (active)     
                                            2 => 10.244.1.136:53/TCP (active)     
11   10.96.0.10:53/UDP      LocalRedirect   1 => 10.244.0.125:53/UDP (active)     
                                            2 => 10.244.1.136:53/UDP (active)     
                                            3 => 10.244.1.124:53/UDP (active)     
12   10.96.0.10:53/TCP      LocalRedirect   1 => 10.244.0.125:53/TCP (active)     
                                            2 => 10.244.1.136:53/TCP (active)     
                                            3 => 10.244.1.124:53/TCP (active)     
13   10.96.0.10:9153/TCP    ClusterIP       1 => 10.244.0.125:9153/TCP (active)   
                                            2 => 10.244.1.136:9153/TCP (active) 
```