### PR TITLE
policy: Add datapath proxy port priority

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -403,13 +403,15 @@ struct policy_entry {
 			lpm_prefix_length:5; /* map key protocol and dport prefix length */
 	__u8		auth_type:7,
 			has_explicit_auth_type:1;
-	__u32		pad1;
+	__u8		proxy_port_priority;
+	__u8		pad1;
+	__u16	        pad2;
 	__u64		packets;
 	__u64		bytes;
 };
 
 /*
- * LPM_FULL_PREFIX_BITS is the maximum length in 'lpm_prefix_bits' when none of the protocol or
+ * LPM_FULL_PREFIX_BITS is the maximum length in 'lpm_prefix_length' when none of the protocol or
  * dport bits in the key are wildcarded.
  */
 #define LPM_PROTO_PREFIX_BITS 8                             /* protocol specified */

--- a/cilium-dbg/cmd/helpers.go
+++ b/cilium-dbg/cmd/helpers.go
@@ -342,14 +342,15 @@ func updatePolicyKey(pa *PolicyUpdateArgs, add bool) {
 		entry := fmt.Sprintf("%d %d/%s", pa.label, pa.port, u8p.String())
 		if add {
 			var (
-				authReq   policyTypes.AuthRequirement // never set
-				proxyPort uint16                      // never set
-				err       error
+				proxyPortPriority policyTypes.ProxyPortPriority // never set
+				authReq           policyTypes.AuthRequirement   // never set
+				proxyPort         uint16                        // never set
+				err               error
 			)
 			if pa.isDeny {
 				err = policyMap.Deny(pa.trafficDirection, pa.label, u8p, pa.port, policymap.SinglePortPrefixLen)
 			} else {
-				err = policyMap.Allow(pa.trafficDirection, pa.label, u8p, pa.port, policymap.SinglePortPrefixLen, authReq, proxyPort)
+				err = policyMap.Allow(pa.trafficDirection, pa.label, u8p, pa.port, policymap.SinglePortPrefixLen, proxyPortPriority, authReq, proxyPort)
 			}
 			if err != nil {
 				Fatalf("Cannot add policy key '%s': %s\n", entry, err)

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -392,13 +392,13 @@ func getIdentities(ep *policy.EndpointPolicy) (ingIdentities, ingDenyIdentities,
 			continue
 		}
 		if key.TrafficDirection() == trafficdirection.Ingress {
-			if entry.IsDeny {
+			if entry.IsDeny() {
 				ingDenyIdentities = append(ingDenyIdentities, int64(key.Identity))
 			} else {
 				ingIdentities = append(ingIdentities, int64(key.Identity))
 			}
 		} else {
-			if entry.IsDeny {
+			if entry.IsDeny() {
 				egDenyIdentities = append(egDenyIdentities, int64(key.Identity))
 			} else {
 				egIdentities = append(egIdentities, int64(key.Identity))

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -936,10 +936,10 @@ func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry)
 	policymapKey := policymap.NewKey(keyToAdd.TrafficDirection(), keyToAdd.Identity, keyToAdd.Nexthdr, keyToAdd.DestPort, keyToAdd.PortPrefixLen())
 
 	var err error
-	if entry.IsDeny {
+	if entry.IsDeny() {
 		err = e.policyMap.DenyKey(policymapKey)
 	} else {
-		err = e.policyMap.AllowKey(policymapKey, entry.AuthRequirement, entry.ProxyPort)
+		err = e.policyMap.AllowKey(policymapKey, entry.ProxyPortPriority, entry.AuthRequirement, entry.ProxyPort)
 	}
 	if err != nil {
 		e.getLogger().WithError(err).WithFields(logrus.Fields{
@@ -1231,10 +1231,10 @@ func (e *Endpoint) dumpPolicyMapToMapStateMap() (policy.MapStateMap, error) {
 		policymapEntry := value.(*policymap.PolicyEntry)
 		// Convert from policymap.PolicyEntry to policy.MapStateEntry.
 		policyEntry := policy.MapStateEntry{
-			ProxyPort:       policymapEntry.GetProxyPort(),
-			IsDeny:          policymapEntry.IsDeny(),
-			AuthRequirement: policymapEntry.AuthRequirement,
-		}
+			ProxyPortPriority: policymapEntry.ProxyPortPriority,
+			ProxyPort:         policymapEntry.GetProxyPort(),
+			AuthRequirement:   policymapEntry.AuthRequirement,
+		}.WithDeny(policymapEntry.IsDeny())
 		// if policymapEntry has invalid prefix length, force update by storing as an
 		// invalid MapStateEntry
 		if !policymapEntry.IsValid(policymapKey) {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -807,7 +807,7 @@ func (e *Endpoint) Allows(id identity.NumericIdentity) bool {
 	keyToLookup := policy.IngressKey().WithIdentity(id)
 
 	v, ok := e.desiredPolicy.Get(keyToLookup)
-	return ok && !v.IsDeny
+	return ok && !v.IsDeny()
 }
 
 // String returns endpoint on a JSON format.

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	policyTypes "github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -391,13 +392,9 @@ func TestRedirectWithDeny(t *testing.T) {
 	require.Len(t, ep.desiredPolicy.Redirects, 1)
 
 	expected := policy.MapStateMap{
-		mapKeyAllowAllE: {},
-		mapKeyAllL7: {
-			ProxyPort: httpPort,
-		},
-		mapKeyFoo: {
-			IsDeny: true,
-		},
+		mapKeyAllowAllE: policyTypes.AllowEntry(),
+		mapKeyAllL7:     policyTypes.AllowEntry().WithProxyPort(httpPort),
+		mapKeyFoo:       policyTypes.DenyEntry(),
 	}
 
 	ep.ValidateRuleLabels(t, LabelArrayListMap{
@@ -526,14 +523,14 @@ func TestRedirectWithPriority(t *testing.T) {
 	require.Len(t, ep.desiredPolicy.Redirects, 2)
 
 	expected := policy.MapStateMap{
-		mapKeyAllowAllE: {},
-		mapKeyFooL7:     {ProxyPort: crd2Port},
-		mapKeyAllL7:     {},
+		mapKeyAllowAllE: policyTypes.AllowEntry(),
+		mapKeyFooL7:     policyTypes.AllowEntry().WithProxyPort(crd2Port).WithProxyPriority(1),
+		mapKeyAllL7:     policyTypes.AllowEntry(),
 	}
 	ep.ValidateRuleLabels(t, LabelArrayListMap{
 		mapKeyAllowAllE: labels.LabelArrayList{AllowAnyEgressLabels},
-		mapKeyFooL7:     labels.LabelArrayList{lblsL4AllowListener1, lblsL4L7AllowListener2Priority1}, // lblsL4AllowPort80
-		mapKeyAllL7:     labels.LabelArrayList{lblsL4AllowPort80},                                     // lblsL4AllowListener1, lblsL4L7AllowListener2Priority1
+		mapKeyFooL7:     labels.LabelArrayList{lblsL4L7AllowListener2Priority1},
+		mapKeyAllL7:     labels.LabelArrayList{lblsL4AllowPort80},
 	})
 	if !ep.desiredPolicy.Equals(expected) {
 		t.Fatal("desired policy map does not equal expected map:\n",
@@ -581,9 +578,9 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 	require.Len(t, ep.desiredPolicy.Redirects, 2)
 
 	expected := policy.MapStateMap{
-		mapKeyAllowAllE: {},
-		mapKeyFooL7:     {ProxyPort: crd1Port},
-		mapKeyAllL7:     {},
+		mapKeyAllowAllE: policyTypes.AllowEntry(),
+		mapKeyFooL7:     policyTypes.AllowEntry().WithProxyPort(crd1Port).WithProxyPriority(1),
+		mapKeyAllL7:     policyTypes.AllowEntry(),
 	}
 	ep.ValidateRuleLabels(t, LabelArrayListMap{
 		mapKeyAllowAllE: labels.LabelArrayList{AllowAnyEgressLabels},

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -166,12 +166,14 @@ const (
 // PolicyEntry represents an entry in the BPF policy map for an endpoint. It must
 // match the layout of policy_entry in bpf/lib/common.h.
 type PolicyEntry struct {
-	ProxyPortNetwork uint16                      `align:"proxy_port"` // In network byte-order
-	Flags            policyEntryFlags            `align:"deny"`
-	AuthRequirement  policyTypes.AuthRequirement `align:"auth_type"`
-	Pad1             uint32                      `align:"pad1"`
-	Packets          uint64                      `align:"packets"`
-	Bytes            uint64                      `align:"bytes"`
+	ProxyPortNetwork  uint16                        `align:"proxy_port"` // In network byte-order
+	Flags             policyEntryFlags              `align:"deny"`
+	AuthRequirement   policyTypes.AuthRequirement   `align:"auth_type"`
+	ProxyPortPriority policyTypes.ProxyPortPriority `align:"proxy_port_priority"`
+	Pad1              uint8                         `align:"pad1"`
+	Pad2              uint16                        `align:"pad2"`
+	Packets           uint64                        `align:"packets"`
+	Bytes             uint64                        `align:"bytes"`
 }
 
 // GetProxyPort returns the ProxyPortNetwork in host byte order
@@ -337,22 +339,23 @@ func NewKey(trafficDirection trafficdirection.TrafficDirection, id identity.Nume
 
 // newEntry returns a PolicyEntry representing the specified parameters in
 // network byte-order.
-func newEntry(authReq policyTypes.AuthRequirement, proxyPort uint16, flags policyEntryFlags) PolicyEntry {
+func newEntry(proxyPortPriority policyTypes.ProxyPortPriority, authReq policyTypes.AuthRequirement, proxyPort uint16, flags policyEntryFlags) PolicyEntry {
 	return PolicyEntry{
-		ProxyPortNetwork: byteorder.HostToNetwork16(proxyPort),
-		Flags:            flags,
-		AuthRequirement:  authReq,
+		ProxyPortNetwork:  byteorder.HostToNetwork16(proxyPort),
+		Flags:             flags,
+		AuthRequirement:   authReq,
+		ProxyPortPriority: proxyPortPriority,
 	}
 }
 
 // newAllowEntry returns an allow PolicyEntry for the specified parameters in
 // network byte-order.
 // This is separated out to be used in unit testing.
-func newAllowEntry(key PolicyKey, authReq policyTypes.AuthRequirement, proxyPort uint16) PolicyEntry {
+func newAllowEntry(key PolicyKey, proxyPortPriority policyTypes.ProxyPortPriority, authReq policyTypes.AuthRequirement, proxyPort uint16) PolicyEntry {
 	pef := getPolicyEntryFlags(policyEntryFlagParams{
 		PrefixLen: uint8(key.Prefixlen - StaticPrefixBits),
 	})
-	return newEntry(authReq, proxyPort, pef)
+	return newEntry(proxyPortPriority, authReq, proxyPort, pef)
 }
 
 // newDenyEntry returns a deny PolicyEntry for the specified parameters in
@@ -363,22 +366,22 @@ func newDenyEntry(key PolicyKey) PolicyEntry {
 		IsDeny:    true,
 		PrefixLen: uint8(key.Prefixlen - StaticPrefixBits),
 	})
-	return newEntry(0, 0, pef)
+	return newEntry(0, 0, 0, pef)
 }
 
 // AllowKey pushes an entry into the PolicyMap for the given PolicyKey k.
 // Returns an error if the update of the PolicyMap fails.
-func (pm *PolicyMap) AllowKey(key PolicyKey, authReq policyTypes.AuthRequirement, proxyPort uint16) error {
-	entry := newAllowEntry(key, authReq, proxyPort)
+func (pm *PolicyMap) AllowKey(key PolicyKey, proxyPortPriority policyTypes.ProxyPortPriority, authReq policyTypes.AuthRequirement, proxyPort uint16) error {
+	entry := newAllowEntry(key, proxyPortPriority, authReq, proxyPort)
 	return pm.Update(&key, &entry)
 }
 
 // Allow pushes an entry into the PolicyMap to allow traffic in the given
 // `trafficDirection` for identity `id` with destination port `dport` over
 // protocol `proto`. It is assumed that `dport` and `proxyPort` are in host byte-order.
-func (pm *PolicyMap) Allow(trafficDirection trafficdirection.TrafficDirection, id identity.NumericIdentity, proto u8proto.U8proto, dport uint16, portPrefixLen uint8, authReq policyTypes.AuthRequirement, proxyPort uint16) error {
+func (pm *PolicyMap) Allow(trafficDirection trafficdirection.TrafficDirection, id identity.NumericIdentity, proto u8proto.U8proto, dport uint16, portPrefixLen uint8, proxyPortPriority policyTypes.ProxyPortPriority, authReq policyTypes.AuthRequirement, proxyPort uint16) error {
 	key := NewKey(trafficDirection, id, proto, dport, portPrefixLen)
-	return pm.AllowKey(key, authReq, proxyPort)
+	return pm.AllowKey(key, proxyPortPriority, authReq, proxyPort)
 }
 
 // DenyKey pushes an entry into the PolicyMap for the given PolicyKey k.

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -46,7 +46,7 @@ func TestPolicyMapDumpToSlice(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 
 	fooKey := NewKey(1, 1, 1, 1, SinglePortPrefixLen)
-	err := testMap.AllowKey(fooKey, policyTypes.AuthTypeSpire.AsDerivedRequirement(), 0)
+	err := testMap.AllowKey(fooKey, 42, policyTypes.AuthTypeSpire.AsDerivedRequirement(), 0)
 	require.NoError(t, err)
 
 	dump, err := testMap.DumpToSlice()
@@ -57,10 +57,11 @@ func TestPolicyMapDumpToSlice(t *testing.T) {
 
 	require.False(t, dump[0].PolicyEntry.AuthRequirement.IsExplicit())
 	require.Equal(t, policyTypes.AuthType(1), dump[0].PolicyEntry.AuthRequirement.AuthType())
+	require.Equal(t, policyTypes.ProxyPortPriority(42), dump[0].PolicyEntry.ProxyPortPriority)
 
 	// Special case: allow-all entry
 	barEntry := NewKey(0, 0, 0, 0, 0)
-	err = testMap.AllowKey(barEntry, policyTypes.AuthRequirement(0), 0)
+	err = testMap.AllowKey(barEntry, 0, policyTypes.AuthRequirement(0), 0)
 	require.NoError(t, err)
 
 	dump, err = testMap.DumpToSlice()

--- a/pkg/maps/policymap/policymap_test.go
+++ b/pkg/maps/policymap/policymap_test.go
@@ -172,14 +172,15 @@ const (
 
 func TestPolicyMapWildcarding(t *testing.T) {
 	type args struct {
-		op               opType
-		id               identity.NumericIdentity
-		dport            uint16
-		dportPrefixLen   uint8
-		proto            u8proto.U8proto
-		trafficDirection trafficdirection.TrafficDirection
-		authReq          policyTypes.AuthRequirement
-		proxyPort        uint16
+		op                opType
+		id                identity.NumericIdentity
+		dport             uint16
+		dportPrefixLen    uint8
+		proto             u8proto.U8proto
+		trafficDirection  trafficdirection.TrafficDirection
+		proxyPortPriority policyTypes.ProxyPortPriority
+		authReq           policyTypes.AuthRequirement
+		proxyPort         uint16
 	}
 	tests := []struct {
 		name string
@@ -187,83 +188,83 @@ func TestPolicyMapWildcarding(t *testing.T) {
 	}{
 		{
 			name: "Allow, no wildcarding, no redirection",
-			args: args{allow, 42, 80, 16, 6, ingress, 0, 0},
+			args: args{allow, 42, 80, 16, 6, ingress, 99, 0, 0},
 		},
 		{
 			name: "Allow, no wildcarding, with redirection and defaulted auth",
-			args: args{allow, 42, 80, 16, 6, ingress, policyTypes.AuthTypeSpire.AsDerivedRequirement(), 23767},
+			args: args{allow, 42, 80, 16, 6, ingress, 92, policyTypes.AuthTypeSpire.AsDerivedRequirement(), 23767},
 		},
 		{
 			name: "Allow, no wildcarding, with redirection and explicit auth",
-			args: args{allow, 42, 80, 16, 6, ingress, policyTypes.AuthTypeSpire.AsExplicitRequirement(), 23767},
+			args: args{allow, 42, 80, 16, 6, ingress, 91, policyTypes.AuthTypeSpire.AsExplicitRequirement(), 23767},
 		},
 		{
 			name: "Allow, wildcarded port, no redirection",
-			args: args{allow, 42, 0, 0, 6, ingress, 0, 0},
+			args: args{allow, 42, 0, 0, 6, ingress, 1 << 7, 0, 0},
 		},
 		{
 			name: "Allow, wildcarded protocol, no redirection",
-			args: args{allow, 42, 0, 0, 0, ingress, 0, 0},
+			args: args{allow, 42, 0, 0, 0, ingress, 90, 0, 0},
 		},
 		{
 			name: "Deny, no wildcarding, no redirection",
-			args: args{deny, 42, 80, 16, 6, ingress, 0, 0},
+			args: args{deny, 42, 80, 16, 6, ingress, 89, 0, 0},
 		},
 		{
 			name: "Deny, partially wildcarded port, no redirection",
-			args: args{deny, 42, 80, 15, 6, ingress, 0, 0},
+			args: args{deny, 42, 80, 15, 6, ingress, 88, 0, 0},
 		},
 		{
 			name: "Deny, no wildcarding, no redirection",
-			args: args{deny, 42, 80, 16, 6, ingress, 0, 0},
+			args: args{deny, 42, 80, 16, 6, ingress, 87, 0, 0},
 		},
 		{
 			name: "Deny, wildcarded port, no redirection",
-			args: args{deny, 42, 0, 0, 6, ingress, 0, 0},
+			args: args{deny, 42, 0, 0, 6, ingress, 0, 0, 0},
 		},
 		{
 			name: "Deny, wildcarded protocol, no redirection",
-			args: args{deny, 42, 0, 0, 0, ingress, 0, 0},
+			args: args{deny, 42, 0, 0, 0, ingress, 86, 0, 0},
 		},
 		{
 			name: "Allow, wildcarded id, no port wildcarding, no redirection",
-			args: args{allow, 0, 80, 16, 6, ingress, 0, 0},
+			args: args{allow, 0, 80, 16, 6, ingress, 85, 0, 0},
 		},
 		{
 			name: "Allow, wildcarded id, no port wildcarding, with redirection and defaulted auth",
-			args: args{allow, 0, 80, 16, 6, ingress, policyTypes.AuthTypeSpire.AsDerivedRequirement(), 23767},
+			args: args{allow, 0, 80, 16, 6, ingress, 84, policyTypes.AuthTypeSpire.AsDerivedRequirement(), 23767},
 		},
 		{
 			name: "Allow, wildcarded id, no port wildcarding, with redirection and explicit auth",
-			args: args{allow, 0, 80, 16, 6, ingress, policyTypes.AuthTypeSpire.AsExplicitRequirement(), 23767},
+			args: args{allow, 0, 80, 16, 6, ingress, 83, policyTypes.AuthTypeSpire.AsExplicitRequirement(), 23767},
 		},
 		{
 			name: "Allow, wildcarded id, wildcarded port, no redirection",
-			args: args{allow, 0, 0, 0, 6, ingress, 0, 0},
+			args: args{allow, 0, 0, 0, 6, ingress, 82, 0, 0},
 		},
 		{
 			name: "Allow, wildcarded id, partially wildcarded port, no redirection",
-			args: args{allow, 0, 80, 10, 6, ingress, 0, 0},
+			args: args{allow, 0, 80, 10, 6, ingress, 81, 0, 0},
 		},
 		{
 			name: "Allow, wildcarded id, wildcarded protocol, no redirection",
-			args: args{allow, 0, 0, 0, 0, ingress, 0, 0},
+			args: args{allow, 0, 0, 0, 0, ingress, 42, 0, 0},
 		},
 		{
 			name: "Deny, wildcarded id, no port wildcarding, no redirection",
-			args: args{deny, 0, 80, 16, 6, ingress, 0, 0},
+			args: args{deny, 0, 80, 16, 6, ingress, 42, 0, 0},
 		},
 		{
 			name: "Deny, wildcarded id, no port wildcarding, no redirection",
-			args: args{deny, 0, 80, 16, 6, ingress, 0, 0},
+			args: args{deny, 0, 80, 16, 6, ingress, 42, 0, 0},
 		},
 		{
 			name: "Deny, wildcarded id, wildcarded port, no redirection",
-			args: args{deny, 0, 0, 0, 6, ingress, 0, 0},
+			args: args{deny, 0, 0, 0, 6, ingress, 42, 0, 0},
 		},
 		{
 			name: "Deny, wildcarded id, wildcarded protocol, no redirection",
-			args: args{deny, 0, 0, 0, 0, ingress, 0, 0},
+			args: args{deny, 0, 0, 0, 0, ingress, 42, 0, 0},
 		},
 	}
 	for _, tt := range tests {
@@ -288,9 +289,10 @@ func TestPolicyMapWildcarding(t *testing.T) {
 		var entry PolicyEntry
 		switch tt.args.op {
 		case allow:
-			entry = newAllowEntry(key, tt.args.authReq, uint16(tt.args.proxyPort))
+			entry = newAllowEntry(key, tt.args.proxyPortPriority, tt.args.authReq, uint16(tt.args.proxyPort))
 
 			require.Equal(t, policyEntryFlags(0), entry.Flags&policyFlagDeny)
+			require.Equal(t, tt.args.proxyPortPriority, entry.ProxyPortPriority)
 			require.Equal(t, tt.args.authReq, entry.AuthRequirement)
 			require.Equal(t, uint16(tt.args.proxyPort), byteorder.NetworkToHost16(entry.ProxyPortNetwork))
 		case deny:

--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -160,7 +160,7 @@ type Listener struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=100
 	// +kubebuilder:validation:Optional
-	Priority uint16 `json:"priority"`
+	Priority uint8 `json:"priority"`
 }
 
 // PortRule is a list of ports/protocol combinations with optional Layer 7

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -454,7 +454,7 @@ func Test_Perm(t *testing.T) {
 	assert.Equal(t, expected, res, "invalid permutations")
 }
 
-func testMapState(initMap map[Key]mapStateEntry) mapState {
+func testMapState(initMap mapStateMap) mapState {
 	return newMapState().withState(initMap)
 }
 
@@ -482,7 +482,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			0,
 			api.Rules{ruleL3__AllowFoo, ruleL3__AllowBar},
-			testMapState(map[Key]mapStateEntry{
+			testMapState(mapStateMap{
 				mapKeyAllowFoo__: mapEntryL7None_(lblsL3__AllowFoo),
 				mapKeyAllowBar__: mapEntryL7None_(lblsL3__AllowBar),
 			}),
@@ -494,7 +494,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			1,
 			api.Rules{ruleL3__AllowFoo, ruleL3L4__Allow},
-			testMapState(map[Key]mapStateEntry{
+			testMapState(mapStateMap{
 				mapKeyAllowFoo__: mapEntryL7None_(lblsL3__AllowFoo),
 				mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow),
 			}),
@@ -506,7 +506,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			2,
 			api.Rules{ruleL3__AllowFoo, ruleL3__AllowBarAuth},
-			testMapState(map[Key]mapStateEntry{
+			testMapState(mapStateMap{
 				mapKeyAllowFoo__: mapEntryL7None_(lblsL3__AllowFoo),
 				mapKeyAllowBar__: mapEntryL7ExplicitAuth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
 			}),
@@ -518,7 +518,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			3,
 			api.Rules{ruleL3__AllowFoo, ruleL3__AllowBarAuth, rule__L4__AllowAuth},
-			testMapState(map[Key]mapStateEntry{
+			testMapState(mapStateMap{
 				mapKeyAllow___L4: mapEntryL7ExplicitAuth_(AuthTypeSpire, lbls__L4__Allow),
 				mapKeyAllowFoo__: mapEntryL7None_(lblsL3__AllowFoo),
 				mapKeyAllowBar__: mapEntryL7ExplicitAuth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
@@ -531,7 +531,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			4,
 			api.Rules{rule____AllowAll, ruleL3__AllowBarAuth},
-			testMapState(map[Key]mapStateEntry{
+			testMapState(mapStateMap{
 				mapKeyAllowAll__: mapEntryL7None_(lbls____AllowAll),
 				mapKeyAllowBar__: mapEntryL7ExplicitAuth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
 			}),
@@ -543,7 +543,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			5,
 			api.Rules{rule____AllowAllAuth, ruleL3__AllowBar},
-			testMapState(map[Key]mapStateEntry{
+			testMapState(mapStateMap{
 				mapKeyAllowAll__: mapEntryL7ExplicitAuth_(AuthTypeSpire, lbls____AllowAll),
 				mapKeyAllowBar__: mapEntryL7None_(lblsL3__AllowBar),
 			}),
@@ -555,7 +555,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			6,
 			api.Rules{rule____AllowAllAuth, rule__L4__Allow},
-			testMapState(map[Key]mapStateEntry{
+			testMapState(mapStateMap{
 				mapKeyAllowAll__: mapEntryL7ExplicitAuth_(AuthTypeSpire, lbls____AllowAll),
 				mapKeyAllow___L4: mapEntryL7DerivedAuth_(AuthTypeSpire, lbls__L4__Allow),
 			}),
@@ -567,7 +567,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			7,
 			api.Rules{rule____AllowAllAuth, ruleL3__AllowBar, rule__L4__Allow},
-			testMapState(map[Key]mapStateEntry{
+			testMapState(mapStateMap{
 				mapKeyAllowAll__: mapEntryL7ExplicitAuth_(AuthTypeSpire, lbls____AllowAll),
 				mapKeyAllow___L4: mapEntryL7DerivedAuth_(AuthTypeSpire, lbls__L4__Allow),
 				mapKeyAllowBar__: mapEntryL7DerivedAuth_(AuthTypeDisabled, lblsL3__AllowBar),
@@ -580,7 +580,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			8,
 			api.Rules{rule____AllowAll, ruleL3__AllowBar, rule__L4__Allow},
-			testMapState(map[Key]mapStateEntry{
+			testMapState(mapStateMap{
 				mapKeyAllowAll__: mapEntryL7None_(lbls____AllowAll),
 				mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow),
 				mapKeyAllowBar__: mapEntryL7None_(lblsL3__AllowBar),
@@ -593,7 +593,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			9,
 			api.Rules{rule____AllowAll, rule__L4__Allow, ruleL3__AllowBarAuth},
-			testMapState(map[Key]mapStateEntry{
+			testMapState(mapStateMap{
 				mapKeyAllowAll__: mapEntryL7None_(lbls____AllowAll),
 				mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow),
 				mapKeyAllowBar__: mapEntryL7ExplicitAuth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
@@ -606,7 +606,7 @@ func Test_MergeL3(t *testing.T) {
 		{
 			10, // Same as 9, but the L3L4 entry is created by an explicit rule.
 			api.Rules{rule____AllowAll, rule__L4__Allow, ruleL3__AllowBarAuth, ruleL3L4AllowBarAuth},
-			testMapState(map[Key]mapStateEntry{
+			testMapState(mapStateMap{
 				mapKeyAllowAll__: mapEntryL7None_(lbls____AllowAll),
 				mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow),
 				mapKeyAllowBar__: mapEntryL7ExplicitAuth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
@@ -1115,37 +1115,37 @@ func Test_MergeRules(t *testing.T) {
 		//
 		//  Rule 0                   | Rule 1         | Rule 2         | Rule 3         | Rule 4         | Rule 5         | Rule 6         | Rule 7         | Desired BPF map state
 		{0, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(nil)},
-		{1, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{2, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
-		{3, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{4, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow)})},
-		{5, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{6, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
-		{7, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
-		{8, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},
-		{9, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{10, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow)})},
-		{11, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{12, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                      // L3L4 entry suppressed to allow L4-only entry to redirect
-		{13, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                  // L3L4 entry suppressed to allow L4-only entry to redirect
-		{14, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow)})},                                                     // L3L4 entry suppressed to allow L4-only entry to redirect
-		{15, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // L3L4 entry suppressed to allow L4-only entry to redirect
-		{16, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow)})},
-		{17, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{18, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
-		{19, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{20, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4__Allow, lblsL3L4L7Allow)})},
-		{21, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4__Allow, lblsL3L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{22, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4__Allow, lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
-		{23, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4__Allow, lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{24, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                      // identical L3L4 entry suppressed
-		{25, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                  // identical L3L4 entry suppressed
-		{26, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow)})},                                                     // identical L3L4 entry suppressed
-		{27, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
-		{28, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                      // identical L3L4 entry suppressed
-		{29, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                  // identical L3L4 entry suppressed
-		{30, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow)})},                                                     // identical L3L4 entry suppressed
-		{31, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
+		{1, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{2, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{3, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{4, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow)})},
+		{5, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{6, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
+		{7, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
+		{8, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},
+		{9, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{10, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow)})},
+		{11, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{12, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                      // L3L4 entry suppressed to allow L4-only entry to redirect
+		{13, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                  // L3L4 entry suppressed to allow L4-only entry to redirect
+		{14, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow)})},                                                     // L3L4 entry suppressed to allow L4-only entry to redirect
+		{15, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // L3L4 entry suppressed to allow L4-only entry to redirect
+		{16, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow)})},
+		{17, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{18, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{19, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{20, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4__Allow, lblsL3L4L7Allow)})},
+		{21, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4__Allow, lblsL3L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{22, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4__Allow, lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{23, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4__Allow, lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{24, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                      // identical L3L4 entry suppressed
+		{25, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                  // identical L3L4 entry suppressed
+		{26, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow)})},                                                     // identical L3L4 entry suppressed
+		{27, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
+		{28, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                      // identical L3L4 entry suppressed
+		{29, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                  // identical L3L4 entry suppressed
+		{30, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow)})},                                                     // identical L3L4 entry suppressed
+		{31, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
 	}
 
 	expectedMapState := generateMapStates()
@@ -1228,37 +1228,37 @@ func Test_MergeRulesWithNamedPorts(t *testing.T) {
 		//
 		//  Rule 0                   | Rule 1         | Rule 2         | Rule 3         | Rule 4         | Rule 5         | Rule 6         | Rule 7         | Desired BPF map state
 		{0, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(nil)},
-		{1, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{2, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
-		{3, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{4, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow)})},
-		{5, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{6, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
-		{7, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
-		{8, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},
-		{9, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{10, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow)})},
-		{11, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{12, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                        // L3L4 entry suppressed to allow L4-only entry to redirect
-		{13, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                    // L3L4 entry suppressed to allow L4-only entry to redirect
-		{14, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow)})},                                                     // L3L4 entry suppressed to allow L4-only entry to redirect
-		{15, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // L3L4 entry suppressed to allow L4-only entry to redirect
-		{16, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow)})},
-		{17, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{18, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
-		{19, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{20, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4__Allow, lblsL3L4L7Allow)})},
-		{21, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4__Allow, lblsL3L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{22, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4__Allow, lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
-		{23, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4__Allow, lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
-		{24, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                          // identical L3L4 entry suppressed
-		{25, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                      // identical L3L4 entry suppressed
-		{26, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow)})},                                                       // identical L3L4 entry suppressed
-		{27, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},   // identical L3L4 entry suppressed
-		{28, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                        // identical L3L4 entry suppressed
-		{29, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                    // identical L3L4 entry suppressed
-		{30, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow)})},                                                     // identical L3L4 entry suppressed
-		{31, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, testMapState(map[Key]mapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
+		{1, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{2, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{3, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{4, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow)})},
+		{5, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{6, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
+		{7, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
+		{8, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},
+		{9, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{10, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow)})},
+		{11, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{12, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                        // L3L4 entry suppressed to allow L4-only entry to redirect
+		{13, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                    // L3L4 entry suppressed to allow L4-only entry to redirect
+		{14, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow)})},                                                     // L3L4 entry suppressed to allow L4-only entry to redirect
+		{15, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // L3L4 entry suppressed to allow L4-only entry to redirect
+		{16, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow)})},
+		{17, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{18, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{19, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{20, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4__Allow, lblsL3L4L7Allow)})},
+		{21, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4__Allow, lblsL3L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{22, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4__Allow, lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{23, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4__Allow, lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{24, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                          // identical L3L4 entry suppressed
+		{25, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                      // identical L3L4 entry suppressed
+		{26, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow)})},                                                       // identical L3L4 entry suppressed
+		{27, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},   // identical L3L4 entry suppressed
+		{28, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                        // identical L3L4 entry suppressed
+		{29, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                    // identical L3L4 entry suppressed
+		{30, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow)})},                                                     // identical L3L4 entry suppressed
+		{31, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, testMapState(mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
 	}
 	for _, tt := range tests {
 		repo := newPolicyDistillery(selectorCache)
@@ -1302,8 +1302,8 @@ func Test_AllowAll(t *testing.T) {
 		rules    api.Rules
 		expected mapState
 	}{
-		{0, api.EndpointSelectorNone, api.Rules{rule____AllowAll}, testMapState(map[Key]mapStateEntry{mapKeyAllowAll__: mapEntryL7None_(lblsAllowAllIngress)})},
-		{1, api.WildcardEndpointSelector, api.Rules{rule____AllowAll}, testMapState(map[Key]mapStateEntry{mapKeyAllowAll__: mapEntryL7None_(lbls____AllowAll)})},
+		{0, api.EndpointSelectorNone, api.Rules{rule____AllowAll}, testMapState(mapStateMap{mapKeyAllowAll__: mapEntryL7None_(lblsAllowAllIngress)})},
+		{1, api.WildcardEndpointSelector, api.Rules{rule____AllowAll}, testMapState(mapStateMap{mapKeyAllowAll__: mapEntryL7None_(lbls____AllowAll)})},
 	}
 
 	for _, tt := range tests {
@@ -1635,7 +1635,7 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 		rules    api.Rules
 		expected mapState
 	}{
-		{"deny_world_no_labels", api.Rules{ruleAllowAllIngress, ruleL3DenyWorld, ruleL3AllowWorldIP}, testMapState(map[Key]mapStateEntry{
+		{"deny_world_no_labels", api.Rules{ruleAllowAllIngress, ruleL3DenyWorld, ruleL3AllowWorldIP}, testMapState(mapStateMap{
 			mapKeyAnyIngress:             mapEntryAllow,
 			mapKeyL3WorldIngress:         mapEntryDeny,
 			mapKeyL3WorldIngressIPv4:     mapEntryDeny,
@@ -1647,7 +1647,7 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 			mapKeyL3SubnetEgress:         mapEntryDeny,
 			mapKeyL3SmallerSubnetIngress: mapEntryDeny,
 			mapKeyL3SmallerSubnetEgress:  mapEntryDeny,
-		})}, {"deny_world_with_labels", api.Rules{ruleAllowAllIngress, ruleL3DenyWorldWithLabels, ruleL3AllowWorldIP}, testMapState(map[Key]mapStateEntry{
+		})}, {"deny_world_with_labels", api.Rules{ruleAllowAllIngress, ruleL3DenyWorldWithLabels, ruleL3AllowWorldIP}, testMapState(mapStateMap{
 			mapKeyAnyIngress:             mapEntryAllow,
 			mapKeyL3WorldIngress:         mapEntryWorldDenyWithLabels,
 			mapKeyL3WorldIngressIPv4:     mapEntryWorldDenyWithLabels,
@@ -1659,19 +1659,19 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 			mapKeyL3SubnetEgress:         mapEntryWorldDenyWithLabels,
 			mapKeyL3SmallerSubnetIngress: mapEntryWorldDenyWithLabels,
 			mapKeyL3SmallerSubnetEgress:  mapEntryWorldDenyWithLabels,
-		})}, {"deny_one_ip_with_a_larger_subnet", api.Rules{ruleAllowAllIngress, ruleL3DenySubnet, ruleL3AllowWorldIP}, testMapState(map[Key]mapStateEntry{
+		})}, {"deny_one_ip_with_a_larger_subnet", api.Rules{ruleAllowAllIngress, ruleL3DenySubnet, ruleL3AllowWorldIP}, testMapState(mapStateMap{
 			mapKeyAnyIngress:             mapEntryAllow,
 			mapKeyL3SubnetIngress:        mapEntryDeny,
 			mapKeyL3SubnetEgress:         mapEntryDeny,
 			mapKeyL3SmallerSubnetIngress: mapEntryDeny,
 			mapKeyL3SmallerSubnetEgress:  mapEntryDeny,
-		})}, {"deny_part_of_a_subnet_with_an_ip", api.Rules{ruleAllowAllIngress, ruleL3DenySmallerSubnet, ruleL3AllowLargerSubnet}, testMapState(map[Key]mapStateEntry{
+		})}, {"deny_part_of_a_subnet_with_an_ip", api.Rules{ruleAllowAllIngress, ruleL3DenySmallerSubnet, ruleL3AllowLargerSubnet}, testMapState(mapStateMap{
 			mapKeyAnyIngress:             mapEntryAllow,
 			mapKeyL3SmallerSubnetIngress: mapEntryDeny,
 			mapKeyL3SmallerSubnetEgress:  mapEntryDeny,
 			mapKeyL3SubnetIngress:        mapEntryAllow,
 			mapKeyL3SubnetEgress:         mapEntryAllow,
-		})}, {"broad_cidr_deny_is_a_portproto_subset_of_a_specific_cidr_allow", api.Rules{ruleAllowAllIngress, ruleL3L4Port8080ProtoAnyDenyWorld, ruleL3AllowWorldIP}, testMapState(map[Key]mapStateEntry{
+		})}, {"broad_cidr_deny_is_a_portproto_subset_of_a_specific_cidr_allow", api.Rules{ruleAllowAllIngress, ruleL3L4Port8080ProtoAnyDenyWorld, ruleL3AllowWorldIP}, testMapState(mapStateMap{
 			mapKeyAnyIngress:                            mapEntryAllow,
 			mapKeyL3L4Port8080ProtoTCPWorldIngress:      mapEntryDeny,
 			mapKeyL3L4Port8080ProtoTCPWorldEgress:       mapEntryDeny,
@@ -1705,7 +1705,7 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 			mapKeyL3L4Port8080ProtoSCTPWorldIPEgress:    mapEntryDeny,
 			mapKeyL3SmallerSubnetIngress:                mapEntryAllow,
 			mapKeyL3SmallerSubnetEgress:                 mapEntryAllow,
-		})}, {"broad_cidr_allow_is_a_portproto_subset_of_a_specific_cidr_deny", api.Rules{ruleAllowAllIngress, ruleL3AllowWorldSubnet, ruleL3DenyWorldIP}, testMapState(map[Key]mapStateEntry{
+		})}, {"broad_cidr_allow_is_a_portproto_subset_of_a_specific_cidr_deny", api.Rules{ruleAllowAllIngress, ruleL3AllowWorldSubnet, ruleL3DenyWorldIP}, testMapState(mapStateMap{
 			mapKeyAnyIngress:                          mapEntryAllow,
 			mapKeyL3L4Port8080ProtoTCPWorldSNIngress:  mapEntryAllow,
 			mapKeyL3L4Port8080ProtoTCPWorldSNEgress:   mapEntryAllow,
@@ -1715,11 +1715,11 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 			mapKeyL3L4Port8080ProtoSCTPWorldSNEgress:  mapEntryAllow,
 			mapKeyL4AnyPortProtoWorldIPIngress:        mapEntryDeny,
 			mapKeyL4AnyPortProtoWorldIPEgress:         mapEntryDeny,
-		})}, {"named_port_world_subnet", api.Rules{ruleAllowAllIngress, ruleL3AllowWorldSubnetNamedPort}, testMapState(map[Key]mapStateEntry{
+		})}, {"named_port_world_subnet", api.Rules{ruleAllowAllIngress, ruleL3AllowWorldSubnetNamedPort}, testMapState(mapStateMap{
 			mapKeyAnyIngress: mapEntryAllow,
 			mapKeyL3L4NamedPortHTTPProtoTCPWorldSubNetIngress: mapEntryAllow,
 			mapKeyL3L4NamedPortHTTPProtoTCPWorldIPIngress:     mapEntryAllow,
-		})}, {"port_range_world_subnet", api.Rules{ruleAllowAllIngress, ruleL3AllowWorldSubnetPortRange}, testMapState(map[Key]mapStateEntry{
+		})}, {"port_range_world_subnet", api.Rules{ruleAllowAllIngress, ruleL3AllowWorldSubnetPortRange}, testMapState(mapStateMap{
 			mapKeyAnyIngress: mapEntryAllow,
 			mapKeyL3L4Port64To127ProtoTCPWorldSubNetIngress: mapEntryAllow,
 			mapKeyL3L4Port5ProtoTCPWorldSubNetIngress:       mapEntryAllow,
@@ -1805,7 +1805,7 @@ func Test_Allowception(t *testing.T) {
 	}
 	selectorCache := testNewSelectorCache(identityCache)
 
-	computedMapStateForAllowCeption := newMapState().withState(map[Key]mapStateEntry{
+	computedMapStateForAllowCeption := newMapState().withState(mapStateMap{
 		ingressKey(0, 0, 0, 0):                             mapEntryL7None_(lblsAllowAllIngress),
 		egressKey(identity.ReservedIdentityWorld, 0, 0, 0): mapEntryAllow,
 		egressKey(one3Z8Identity, 0, 0, 0):                 mapEntryDeny,
@@ -1863,7 +1863,7 @@ func Test_EnsureEntitiesSelectableByCIDR(t *testing.T) {
 		rules    api.Rules
 		expected mapState
 	}{
-		{"host_cidr_select", api.Rules{ruleL3AllowHostEgress}, newMapState().withState(map[Key]mapStateEntry{
+		{"host_cidr_select", api.Rules{ruleL3AllowHostEgress}, newMapState().withState(mapStateMap{
 			mapKeyL3UnknownIngress: mapEntryL3UnknownIngress,
 			mapKeyL3HostEgress:     mapEntryAllow,
 		})},

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -45,7 +45,7 @@ func FuzzDenyPreferredInsert(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		keys := newMapState()
 		key := Key{}
-		entry := mapStateEntry{}
+		entry := NewMapStateEntry(AllowEntry, nil)
 		ff := fuzz.NewConsumer(data)
 		ff.GenerateStruct(&key)
 		ff.GenerateStruct(&entry)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -509,9 +509,9 @@ func (l4 *L4Filter) Equals(bL4 *L4Filter) bool {
 // ChangeState allows caller to revert changes made by (multiple) toMapState call(s)
 // All fields are maps so we can pass this by value.
 type ChangeState struct {
-	Adds    Keys                  // Added or modified keys, if not nil
-	Deletes Keys                  // deleted keys, if not nil
-	old     map[Key]mapStateEntry // Old values of all modified or deleted keys, if not nil
+	Adds    Keys        // Added or modified keys, if not nil
+	Deletes Keys        // deleted keys, if not nil
+	old     mapStateMap // Old values of all modified or deleted keys, if not nil
 }
 
 // NewRevertState returns an empty ChangeState suitable for reverting MapState changes.
@@ -519,7 +519,7 @@ type ChangeState struct {
 func NewRevertState() ChangeState {
 	return ChangeState{
 		Adds: make(Keys),
-		old:  make(map[Key]mapStateEntry),
+		old:  make(mapStateMap),
 	}
 }
 

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -40,6 +40,8 @@ const NoAuthRequirement = types.NoAuthRequirement
 // as well as more extensive indexing via tries.
 type MapStateMap map[Key]MapStateEntry
 
+type mapStateMap map[Key]mapStateEntry
+
 func EgressKey() types.Key {
 	return types.EgressKey()
 }
@@ -97,7 +99,7 @@ var (
 // deletion, and insertion times.
 type mapState struct {
 	// entries is the map containing the MapStateEntries
-	entries map[Key]mapStateEntry
+	entries mapStateMap
 	// trie is a Trie that indexes policy Keys without their identity
 	// and stores the identities in an associated builtin map.
 	trie bitlpm.Trie[bitlpm.Key[types.LPMKey], IDSet]
@@ -469,7 +471,7 @@ func (e *mapStateEntry) GetRuleLabels() labels.LabelArrayList {
 
 func newMapState() mapState {
 	return mapState{
-		entries: make(map[Key]mapStateEntry),
+		entries: make(mapStateMap),
 		trie:    bitlpm.NewTrie[types.LPMKey, IDSet](types.MapStatePrefixLen),
 	}
 }
@@ -1083,7 +1085,7 @@ func (mc *MapChanges) consumeMapChanges(p *EndpointPolicy, features policyFeatur
 	changes := ChangeState{
 		Adds:    make(Keys, len(mc.synced)),
 		Deletes: make(Keys, len(mc.synced)),
-		old:     make(map[Key]mapStateEntry, len(mc.synced)),
+		old:     make(mapStateMap, len(mc.synced)),
 	}
 
 	for i := range mc.synced {

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"iter"
 	"slices"
-	"strconv"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/sirupsen/logrus"
@@ -32,6 +31,7 @@ import (
 // lest ye find yourself with hundreds of unnecessary imports.
 type Key = types.Key
 type Keys = types.Keys
+type MapStateEntry = types.MapStateEntry
 type MapStateOwner = types.CachedSelector
 
 const NoAuthRequirement = types.NoAuthRequirement
@@ -304,7 +304,7 @@ func (ms *mapState) LPMAncestors(key Key) iter.Seq2[Key, mapStateEntry] {
 }
 
 // Lookup finds the policy verdict applicable to the given 'key' using the same precedence logic
-// between L3 and L4-only policies when both match the given 'key'.
+// between L3 and L4-only policies as the bpf datapath  when both match the given 'key'.
 // To be used in testing in place of the bpf datapath when full integration testing is not desired.
 // Returns the closest matching covering policy entry and 'true' if found.
 // 'key' must not have a wildcard identity or port.
@@ -331,6 +331,9 @@ func (ms *mapState) Lookup(key Key) (MapStateEntry, bool) {
 	}
 
 	authOverride := func(entry, other MapStateEntry) MapStateEntry {
+		// This logic needs to be the same as in authPreferredInsert() where the newEntry's
+		// auth type may be overridden by a covering key.
+		// This also needs to reflect the logic in bpf/lib/policy.h __account_and_check().
 		if !entry.AuthRequirement.IsExplicit() &&
 			other.AuthRequirement.AuthType() > entry.AuthRequirement.AuthType() {
 			entry.AuthRequirement = other.AuthRequirement.AsDerived()
@@ -349,68 +352,56 @@ func (ms *mapState) Lookup(key Key) (MapStateEntry, bool) {
 	// both L3 and L4 matches found
 	if haveL3 && haveL4 {
 		// Precedence rules of the bpf datapath between two policy entries:
-		// 1. deny wins
-		// 2. if both entries are allows, the one with more specific L4 is selected
-		// 3. If the two allows have equal port/proto, the policy for a specific L3 is
-		//    selected (rather than the L4-only entry)
+		// 1. Deny is selected, if any
+		// 2. Higher proxy port priority wins
+		// 3. If both entries are allows at the same proxy port priority, the one with more
+		//    specific L4 is selected
+		// 4. If the two allows on the same proxy port priority have equal port/proto, then
+		//    the policy for a specific L3 is selected (rather than the L4-only entry)
 		//
 		// If the selected entry has non-explicit auth type, it gets the auth type from the
 		// other entry, if the other entry's auth type is numerically higher.
 
-		// 1. Deny wins, check for the broader deny first
-		if l4entry.IsDeny {
-			return l4entry, true
-		}
-		if l3entry.IsDeny {
+		// 1. Deny wins
+		// Check for the L3 deny first to match the datapath behavior
+		if l3entry.IsDeny() {
 			return l3entry, true
 		}
+		if l4entry.IsDeny() {
+			return l4entry, true
+		}
 
-		// 2. Two allow entries, select the one with more specific L4
+		// 2. Entry with higher proxy port priority is selected.
+		//    Auth requirement does not propagate from a lower proxy port priority rule to a
+		//    higher proxy port priority rule!
+		if l3entry.ProxyPortPriority > l4entry.ProxyPortPriority {
+			return l3entry, true
+		}
+		if l4entry.ProxyPortPriority > l3entry.ProxyPortPriority {
+			return l4entry, true
+		}
+
+		// 3. Two allow entries, select the one with more specific L4
 		// L3-entry must be selected if prefix lengths are the same!
 		if l4key.PrefixLength() > l3key.PrefixLength() {
 			return authOverride(l4entry, l3entry), true
 		}
-
-		// 3. Two allow entries with equally specific L4 or L3-entry is more specific
+		// 4. Two allow entries are equally specific port/proto or L3-entry is more specific
 		return authOverride(l3entry, l4entry), true
 	}
 
 	// Deny by default if no matches are found
-	return MapStateEntry{IsDeny: true}, false
+	return types.DenyEntry(), false
 }
 
 func (ms *mapState) Len() int {
 	return len(ms.entries)
 }
 
-// MapStateEntry is the configuration associated with a Key in a
-// MapState. This is a minimized version of policymap.PolicyEntry.
-type MapStateEntry struct {
-	// The proxy port, in host byte order.
-	// If 0 (default), there is no proxy redirection for the corresponding
-	// Key. Any other value signifies proxy redirection.
-	ProxyPort uint16
-
-	// IsDeny is true when the policy should be denied.
-	IsDeny bool
-
-	// Invalid is only set to mark the current entry for update when syncing entries to datapath
-	Invalid bool
-
-	// AuthRequirement is non-zero when authentication is required for the traffic to be
-	// allowed, except for when it explicitly defines authentication is not required.
-	AuthRequirement AuthRequirement
-}
-
 // mapSteteEntry is the entry type with additional internal bookkeping of the relation between
 // explicitly and implicitly added entries.
 type mapStateEntry struct {
 	MapStateEntry
-
-	// priority is used to select the proxy port if multiple rules would apply different proxy
-	// ports to a policy map entry. Lower numbers indicate higher priority. If left out, the
-	// proxy port number (10000-20000) is used.
-	priority uint16
 
 	// derivedFromRules tracks the policy rules this entry derives from.
 	// In sorted order.
@@ -427,41 +418,21 @@ type mapStateEntry struct {
 // 'cs' is used to keep track of which policy selectors need this entry. If it is 'nil' this entry
 // will become sticky and cannot be completely removed via incremental updates. Even in this case
 // the entry may be overridden or removed by a deny entry.
-func newMapStateEntry(cs MapStateOwner, derivedFrom labels.LabelArrayList, proxyPort uint16, priority uint16, deny bool, authReq AuthRequirement) mapStateEntry {
-	if proxyPort == 0 {
-		priority = 0
-	} else if priority == 0 {
-		priority = proxyPort // default for tie-breaking
-	}
-	return mapStateEntry{
-		MapStateEntry: MapStateEntry{
-			ProxyPort:       proxyPort,
-			IsDeny:          deny,
-			AuthRequirement: authReq,
-		},
-		priority:         priority,
-		derivedFromRules: derivedFrom,
-		owners:           set.NewSet(cs),
-	}
+func newMapStateEntry(cs MapStateOwner, derivedFrom labels.LabelArrayList, proxyPort uint16, priority uint8, deny bool, authReq AuthRequirement) mapStateEntry {
+	return NewMapStateEntry(types.NewMapStateEntry(deny, proxyPort, priority, authReq), derivedFrom, cs)
 }
 
 // newAllowEntryWithLabels creates an allow entry with the specified labels and a 'nil' owner.
-// Used for adding allow-all entries when policy ewnforcement is not wanted.
+// Used for adding allow-all entries when policy enforcement is not wanted.
 func newAllowEntryWithLabels(lbls labels.LabelArray) mapStateEntry {
 	return newMapStateEntry(nil, labels.LabelArrayList{lbls}, 0, 0, false, NoAuthRequirement)
 }
 
-func (e MapStateEntry) toMapStateEntry(priority uint16, cs MapStateOwner, derivedFrom labels.LabelArrayList) mapStateEntry {
-	if e.ProxyPort == 0 {
-		priority = 0
-	} else if priority == 0 {
-		priority = e.ProxyPort // default for tie-breaking
-	}
+func NewMapStateEntry(e MapStateEntry, derivedFrom labels.LabelArrayList, owners ...MapStateOwner) mapStateEntry {
 	return mapStateEntry{
 		MapStateEntry:    e,
-		priority:         priority,
 		derivedFromRules: derivedFrom,
-		owners:           set.NewSet(cs),
+		owners:           set.NewSet(owners...),
 	}
 }
 
@@ -610,57 +581,6 @@ func (ms mapState) String() (res string) {
 	return res
 }
 
-// merge adds owners, and DerivedFromRules from a new 'entry' to an existing
-// entry 'e'. 'entry' is not modified.
-// Merge is only called if both entries are allow or deny entries, so deny precedence is not
-// considered here.
-// ProxyPort, and AuthType are merged by giving precedence to proxy redirection over no proxy
-// redirection, and explicit auth type over default auth type.
-func (e *mapStateEntry) merge(entry *mapStateEntry) {
-	// Bail out loudly if both entries are not denies or allows
-	if e.IsDeny != entry.IsDeny {
-		log.WithField(logfields.Stacktrace, hclog.Stacktrace()).
-			Errorf("MapStateEntry.merge: both entries must be allows or denies")
-		return
-	}
-	// Only allow entries have proxy redirection or auth requirement
-	if !e.IsDeny {
-		// Proxy port takes precedence, but may be updated due to priority
-		if entry.IsRedirectEntry() {
-			// Lower number has higher priority, but non-redirects have 0 priority
-			// value.
-			// Proxy port value is the tie-breaker when priorities have the same value.
-			if !e.IsRedirectEntry() || entry.priority < e.priority || entry.priority == e.priority && entry.ProxyPort < e.ProxyPort {
-				e.ProxyPort = entry.ProxyPort
-				e.priority = entry.priority
-			}
-		}
-
-		// Numerically higher AuthType takes precedence when both are
-		// either explicitly defined or derived
-		if entry.AuthRequirement.IsExplicit() == e.AuthRequirement.IsExplicit() {
-			if entry.AuthRequirement > e.AuthRequirement {
-				e.AuthRequirement = entry.AuthRequirement
-			}
-		} else if entry.AuthRequirement.IsExplicit() {
-			// Explicit auth takes precedence over defaulted one.
-			e.AuthRequirement = entry.AuthRequirement
-		}
-	}
-
-	e.owners.Merge(entry.owners)
-
-	// merge DerivedFromRules
-	if len(entry.derivedFromRules) > 0 {
-		e.derivedFromRules.MergeSorted(entry.derivedFromRules)
-	}
-}
-
-// IsRedirectEntry returns true if the entry redirects to a proxy port
-func (e *MapStateEntry) IsRedirectEntry() bool {
-	return e.ProxyPort != 0
-}
-
 // DatapathAndDerivedFromEqual returns true of two entries are equal in the datapath's PoV,
 // i.e., IsDeny, ProxyPort and AuthType are the same for both entries, and the DerivedFromRules
 // fields are also equal.
@@ -681,10 +601,6 @@ func (e *mapStateEntry) deepEqual(o *mapStateEntry) bool {
 		return false
 	}
 
-	if e.priority != o.priority {
-		return false
-	}
-
 	if !e.owners.Equal(o.owners) {
 		return false
 	}
@@ -693,26 +609,9 @@ func (e *mapStateEntry) deepEqual(o *mapStateEntry) bool {
 }
 
 // String returns a string representation of the MapStateEntry
-func (e MapStateEntry) String() string {
-	var authText string
-	if e.AuthRequirement != 0 {
-		var authNote string
-		if !e.AuthRequirement.IsExplicit() {
-			authNote = " (derived)"
-		}
-		authText = ",AuthType=" + e.AuthRequirement.AuthType().String() + authNote
-	}
-
-	return "ProxyPort=" + strconv.FormatUint(uint64(e.ProxyPort), 10) +
-		",IsDeny=" + strconv.FormatBool(e.IsDeny) +
-		authText
-}
-
-// String returns a string representation of the MapStateEntry
 func (e mapStateEntry) String() string {
 	return e.MapStateEntry.String() +
 		",derivedFromRules=" + fmt.Sprintf("%v", e.derivedFromRules) +
-		",priority=" + strconv.FormatUint(uint64(e.priority), 10) +
 		",owners=" + e.owners.String()
 }
 
@@ -722,7 +621,7 @@ func (ms *mapState) addKeyWithChanges(key Key, entry mapStateEntry, changes Chan
 	var datapathEqual bool
 	oldEntry, exists := ms.get(key)
 	// Only merge if both old and new are allows or denies
-	if exists && (oldEntry.IsDeny == entry.IsDeny) {
+	if exists && oldEntry.IsDeny() == entry.IsDeny() {
 		// Do nothing if entries are equal
 		if entry.deepEqual(&oldEntry) {
 			return false // nothing to do
@@ -734,11 +633,17 @@ func (ms *mapState) addKeyWithChanges(key Key, entry mapStateEntry, changes Chan
 		// Compare for datapath equalness before merging, as the old entry is updated in
 		// place!
 		datapathEqual = oldEntry.MapStateEntry == entry.MapStateEntry
-		oldEntry.merge(&entry)
+
+		oldEntry.MapStateEntry.Merge(entry.MapStateEntry)
+		oldEntry.owners.Merge(entry.owners)
+		if len(entry.derivedFromRules) > 0 {
+			oldEntry.derivedFromRules.MergeSorted(entry.derivedFromRules)
+		}
+
 		ms.updateExisting(key, oldEntry)
-	} else if !exists || entry.IsDeny {
+	} else if !exists || entry.IsDeny() {
 		// Insert a new entry if one did not exist or a deny entry is overwriting an allow
-		// entry.
+		// entry
 
 		// Save old value before any changes, if any
 		if exists {
@@ -768,7 +673,7 @@ func (ms *mapState) addKeyWithChanges(key Key, entry mapStateEntry, changes Chan
 // and 'deletes'.
 // The key is unconditionally deleted if 'owner' is nil, otherwise only the contribution of this
 // 'owner' is removed.
-func (ms *mapState) deleteKeyWithChanges(key Key, owner MapStateOwner, changes ChangeState) {
+func (ms *mapState) deleteKeyWithChanges(owner MapStateOwner, key Key, changes ChangeState) {
 	if entry, exists := ms.get(key); exists {
 		// Save old value before any changes, if desired
 		oldAdded := changes.insertOldIfNotExists(key, entry)
@@ -805,8 +710,8 @@ func (ms *mapState) deleteKeyWithChanges(key Key, owner MapStateOwner, changes C
 	}
 }
 
-// RevertChanges undoes changes to 'keys' as indicated by 'changes.adds' and 'changes.old' collected via
-// denyPreferredInsertWithChanges().
+// RevertChanges undoes changes to 'keys' as indicated by 'changes.adds' and 'changes.old' collected
+// via insertWithChanges().
 func (ms *mapState) revertChanges(changes ChangeState) {
 	for k := range changes.Adds {
 		ms.delete(k)
@@ -817,37 +722,30 @@ func (ms *mapState) revertChanges(changes ChangeState) {
 	}
 }
 
-func (ms *mapState) insertWithChanges(key Key, entry mapStateEntry, features policyFeatures, changes ChangeState) {
-	ms.denyPreferredInsertWithChanges(key, entry, features, changes)
-}
-
-// denyPreferredInsertWithChanges contains the most important business logic for policy
-// insertions. It inserts a key and entry into the map by giving preference to deny entries, and
-// L3-only deny entries over L3-L4 allows.
-//
-// Since bpf datapath denies by default, we only need to add deny entries to carve out more specific
-// holes to less specific allow rules. But since we don't if allow entries will be added later
-// (e.g., incrementally due to FQDN rules), we must generally add deny entries even if there are no
-// allow entries yet.
+// insertWithChanges contains the most important business logic for policy insertions. It inserts a
+// key and entry into the map only if not covered by a deny entry.
 //
 // Whenever the bpf datapath finds both L4-only and L3/L4 matching policy entries for a given
 // packet, it uses the following logic to choose the policy entry:
-// - L4-only entry is chosen if it is a deny or has more specific port/proto than the L3/L4 entry
-// - otherwise the L3/L4 entry is chosen
+//  1. Deny is selected, if any
+//  2. Among two allows the one with higher proxy port priority is selected
+//  3. Otherwise, the L4-only entry is chosen if it has more specific port/proto than
+//     the L3/L4 entry
+//  4. Otherwise the L3/L4 entry is chosen
 //
-// This gives precedence for deny entry, or if none is present, then the one with the more specific
-// L4 is chosen. This means that it suffices to manage deny precedence among the keys with the same
-// ID here, the datapath take care of the precedence between different IDs (that is, between a
-// specific ID and the wildcard ID (==0)
+// This selects the higher precedence rule either by the deny status, or by the more
+// specific L4, and for the L3/L4 entry overwise. This means that it suffices to manage
+// deny precedence among the keys with the same ID here, the datapath take care of the precedence
+// between different IDs (that is, between a specific ID and the wildcard ID (==0)
 //
 // Note on bailed or deleted entries:
 //
-// It would seem like that when we bail out due to being covered by an existing
-// entry, or delete an entry due to being covered by the new one, we would want this action reversed
-// if the existing entry or this new one is incremantally removed, respectively.
+// It would seem like that when we bail out due to being covered by an existing entry, or delete an
+// entry due to being covered by the new one, we would want this action reversed if the existing
+// entry or this new one is incremantally removed, respectively.
 //
 // Consider these facts:
-//  1. Whenever a deny entry covers an allow entry, the covering key has broader or equal
+//  1. Whenever a key covers an another, the covering key has broader or equal
 //     protocol/port, and the keys have the same identity, or the covering key has wildcard identity
 //     (ID == 0).
 //  2. Only keys with a specific identity (ID != 0) can be incrementally added or deleted.
@@ -860,28 +758,43 @@ func (ms *mapState) insertWithChanges(key Key, entry mapStateEntry, features pol
 // deleted.
 //
 // Incremental changes performed are recorded in 'changes'.
-func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry mapStateEntry, features policyFeatures, changes ChangeState) {
-	// Bail if covered by a deny key
-	if features.contains(denyRules) {
+func (ms *mapState) insertWithChanges(newKey Key, newEntry mapStateEntry, features policyFeatures, changes ChangeState) {
+	if newEntry.IsDeny() {
+		// Bail if covered by another (different) deny key
 		for k, v := range ms.BroaderOrEqualKeys(newKey) {
-			// Identical deny key needs to be added to merge their entries.
-			if v.IsDeny && !(newEntry.IsDeny && k == newKey) {
+			if v.IsDeny() && k != newKey {
 				return
 			}
 		}
-	}
 
-	if newEntry.IsDeny {
-		// Delete covered entries
+		// Delete covered allows and denies with a different key
 		for k, v := range ms.NarrowerOrEqualKeys(newKey) {
-			// Except for identical deny keys that need to be merged.
-			if !(v.IsDeny && k == newKey) {
-				ms.deleteKeyWithChanges(k, nil, changes)
+			if !v.IsDeny() || k != newKey {
+				ms.deleteKeyWithChanges(nil, k, changes)
 			}
 		}
 	} else {
-		// newEntry is an allow entry.
-		// NOTE: We do not delete redundant allow entries.
+		// Bail if covered by a deny key or a key with a higher proxy port priority.
+		//
+		// This can be skipped if no rules have denies or proxy redirects
+		if features.contains(denyRules | redirectRules) {
+			for _, v := range ms.BroaderOrEqualKeys(newKey) {
+				if v.IsDeny() || v.ProxyPortPriority > newEntry.ProxyPortPriority {
+					return
+				}
+			}
+		}
+
+		// Delete covered allow entries with lower proxy port priority.
+		//
+		// This can be skipped if no rules have proxy redirects
+		if features.contains(redirectRules) {
+			for k, v := range ms.NarrowerOrEqualKeys(newKey) {
+				if !v.IsDeny() && v.ProxyPortPriority < newEntry.ProxyPortPriority {
+					ms.deleteKeyWithChanges(nil, k, changes)
+				}
+			}
+		}
 
 		// Checking for auth feature here is faster than calling 'authPreferredInsert' and
 		// checking for it there.
@@ -890,7 +803,6 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry mapState
 			return
 		}
 	}
-
 	ms.addKeyWithChanges(newKey, newEntry, changes)
 }
 
@@ -918,12 +830,12 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry mapStateEntry, chan
 	if !newEntry.AuthRequirement.IsExplicit() {
 		// New entry has a default auth type.
 
-		// Fill in the AuthRequirement from the most specific covering key with the same ID
-		// and an explicit auth type
+		// Fill in the AuthType from the most specific covering key with the same ID and an
+		// explicit auth type
 		for _, v := range ms.CoveringKeysWithSameID(newKey) {
 			if v.AuthRequirement.IsExplicit() {
-				// AuthRequirement from the most specific covering key is applied to
-				// 'newEntry'
+				// AuthType from the most specific covering key is applied
+				// to 'newEntry'
 				newEntry.AuthRequirement = v.AuthRequirement.AsDerived()
 				break
 			}
@@ -933,7 +845,7 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry mapStateEntry, chan
 		// with the same ID and default auth type, and propagate the auth type from the new
 		// entry to such entries.
 		for k, v := range ms.SubsetKeysWithSameID(newKey) {
-			if v.IsDeny || v.AuthRequirement.IsExplicit() {
+			if v.IsDeny() || v.AuthRequirement.IsExplicit() {
 				// Stop if a subset entry is deny or has an explicit auth type, as
 				// that is the more specific covering key for all remaining subset
 				// keys
@@ -1100,7 +1012,7 @@ func (mc *MapChanges) consumeMapChanges(p *EndpointPolicy, features policyFeatur
 			// Delete the contribution of this cs to the key and collect incremental
 			// changes
 			cs, _ := entry.owners.Get() // get the sole selector
-			p.policyMapState.deleteKeyWithChanges(key, cs, changes)
+			p.policyMapState.deleteKeyWithChanges(cs, key, changes)
 		}
 	}
 

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -733,6 +733,22 @@ func TestMapState_denyPreferredInsertWithChanges(t *testing.T) {
 			},
 		},
 		{
+			name: "test-14c - L3-L4 ingress allow should not overwrite a L3-L4-L7 port-range ingress allow on overlapping port",
+			ms: testMapState(mapStateMap{
+				ingressKey(1, 3, 64, 10): allowEntry.withProxyPort(8080),
+			}),
+			args: args{
+				key:   ingressKey(1, 3, 80, 16),
+				entry: MapStateEntry{},
+			},
+			want: testMapState(mapStateMap{
+				ingressKey(1, 3, 64, 10): allowEntry.withProxyPort(8080),
+			}),
+			wantAdds:    Keys{},
+			wantDeletes: Keys{},
+			wantOld:     mapStateMap{},
+		},
+		{
 			name: "test-15a - L3 port-range allow KV should not overwrite a wildcard deny entry",
 			ms: testMapState(mapStateMap{
 				ingressKey(0, 3, 80, 0): denyEntry,

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -432,7 +432,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	policy := selPolicy.DistillPolicy(DummyOwner{}, nil)
 	policy.Ready()
 
-	rule1MapStateEntry := newDenyEntry().withLabels(labels.LabelArrayList{ruleLabel}).withOwners(td.wildcardCachedSelector)
+	rule1MapStateEntry := denyEntry().withLabels(labels.LabelArrayList{ruleLabel}).withOwners(td.wildcardCachedSelector)
 	allowEgressMapStateEntry := newAllowEntryWithLabels(ruleLabelAllowAnyEgress)
 
 	expectedEndpointPolicy := EndpointPolicy{
@@ -589,7 +589,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	cachedSelectorTest := td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
 	require.NotNil(t, cachedSelectorTest)
 
-	rule1MapStateEntry := newDenyEntry().withLabels(labels.LabelArrayList{ruleLabel}).withOwners(cachedSelectorTest)
+	rule1MapStateEntry := denyEntry().withLabels(labels.LabelArrayList{ruleLabel}).withOwners(cachedSelectorTest)
 	allowEgressMapStateEntry := newAllowEntryWithLabels(ruleLabelAllowAnyEgress)
 
 	expectedEndpointPolicy := EndpointPolicy{

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -462,7 +462,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 			IngressPolicyEnabled: true,
 		},
 		PolicyOwner: DummyOwner{},
-		policyMapState: newMapState().withState(map[Key]mapStateEntry{
+		policyMapState: newMapState().withState(mapStateMap{
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
 			EgressKey():                  allowEgressMapStateEntry,
@@ -626,7 +626,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 			IngressPolicyEnabled: true,
 		},
 		PolicyOwner: DummyOwner{},
-		policyMapState: newMapState().withState(map[Key]mapStateEntry{
+		policyMapState: newMapState().withState(mapStateMap{
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
 			EgressKey(): allowEgressMapStateEntry,

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -508,7 +508,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 			EgressPolicyEnabled:  false,
 		},
 		PolicyOwner: DummyOwner{},
-		policyMapState: newMapState().withState(map[Key]mapStateEntry{
+		policyMapState: newMapState().withState(mapStateMap{
 			EgressKey():                  allowEgressMapStateEntry,
 			IngressKey().WithTCPPort(80): rule1MapStateEntry,
 		}),
@@ -681,7 +681,7 @@ func TestMapStateWithIngress(t *testing.T) {
 			EgressPolicyEnabled:  false,
 		},
 		PolicyOwner: DummyOwner{},
-		policyMapState: newMapState().withState(map[Key]mapStateEntry{
+		policyMapState: newMapState().withState(mapStateMap{
 			EgressKey(): allowEgressMapStateEntry,
 			IngressKey().WithIdentity(identity.ReservedIdentityWorld).WithTCPPort(80):     rule1MapStateEntry.withOwners(cachedSelectorWorld),
 			IngressKey().WithIdentity(identity.ReservedIdentityWorldIPv4).WithTCPPort(80): rule1MapStateEntry.withOwners(cachedSelectorWorld, cachedSelectorWorldV4),
@@ -801,7 +801,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: newMapState().withState(map[Key]mapStateEntry{
+				PolicyMapState: newMapState().withState(mapStateMap{
 					IngressKey(): {},
 				}),
 			},
@@ -818,7 +818,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: newMapState().withState(map[Key]mapStateEntry{
+				PolicyMapState: newMapState().withState(mapStateMap{
 					EgressKey(): {},
 				}),
 			},
@@ -835,7 +835,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: newMapState().withState(map[Key]mapStateEntry{
+				PolicyMapState: newMapState().withState(mapStateMap{
 					IngressKey(): {MapStateEntry: MapStateEntry{IsDeny: true}},
 				}),
 			},
@@ -852,7 +852,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: false,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: newMapState().withState(map[Key]mapStateEntry{
+				PolicyMapState: newMapState().withState(mapStateMap{
 					IngressKey(): {MapStateEntry: MapStateEntry{IsDeny: true}},
 				}),
 			},
@@ -869,7 +869,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: newMapState().withState(map[Key]mapStateEntry{
+				PolicyMapState: newMapState().withState(mapStateMap{
 					EgressKey(): {MapStateEntry: MapStateEntry{IsDeny: true}},
 				}),
 			},
@@ -886,7 +886,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  false,
 				},
-				PolicyMapState: newMapState().withState(map[Key]mapStateEntry{
+				PolicyMapState: newMapState().withState(mapStateMap{
 					EgressKey(): {MapStateEntry: MapStateEntry{IsDeny: true}},
 				}),
 			},

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -292,7 +292,9 @@ func TestL7WithIngressWildcard(t *testing.T) {
 						},
 						RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
 					},
-				})},
+				}),
+					features: redirectRules,
+				},
 				Egress:        newL4DirectionPolicy(),
 				redirectTypes: redirectTypeEnvoy,
 			},
@@ -403,7 +405,9 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 						},
 						RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
 					},
-				})},
+				}),
+					features: redirectRules,
+				},
 				Egress:        newL4DirectionPolicy(),
 				redirectTypes: redirectTypeEnvoy,
 			},
@@ -732,7 +736,7 @@ func (p *EndpointPolicy) allowsIdentity(identity identity.NumericIdentity) (ingr
 		ingress = true
 	} else {
 		key := IngressKey().WithIdentity(identity)
-		if v, exists := p.policyMapState.Get(key); exists && !v.IsDeny {
+		if v, exists := p.policyMapState.Get(key); exists && !v.IsDeny() {
 			ingress = true
 		}
 	}
@@ -741,7 +745,7 @@ func (p *EndpointPolicy) allowsIdentity(identity identity.NumericIdentity) (ingr
 		egress = true
 	} else {
 		key := EgressKey().WithIdentity(identity)
-		if v, exists := p.policyMapState.Get(key); exists && !v.IsDeny {
+		if v, exists := p.policyMapState.Get(key); exists && !v.IsDeny() {
 			egress = true
 		}
 	}
@@ -836,7 +840,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					EgressPolicyEnabled:  true,
 				},
 				PolicyMapState: newMapState().withState(mapStateMap{
-					IngressKey(): {MapStateEntry: MapStateEntry{IsDeny: true}},
+					IngressKey(): NewMapStateEntry(DenyEntry, nil),
 				}),
 			},
 			args: args{
@@ -853,7 +857,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					EgressPolicyEnabled:  true,
 				},
 				PolicyMapState: newMapState().withState(mapStateMap{
-					IngressKey(): {MapStateEntry: MapStateEntry{IsDeny: true}},
+					IngressKey(): NewMapStateEntry(DenyEntry, nil),
 				}),
 			},
 			args: args{
@@ -870,7 +874,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					EgressPolicyEnabled:  true,
 				},
 				PolicyMapState: newMapState().withState(mapStateMap{
-					EgressKey(): {MapStateEntry: MapStateEntry{IsDeny: true}},
+					EgressKey(): NewMapStateEntry(DenyEntry, nil),
 				}),
 			},
 			args: args{
@@ -887,7 +891,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					EgressPolicyEnabled:  false,
 				},
 				PolicyMapState: newMapState().withState(mapStateMap{
-					EgressKey(): {MapStateEntry: MapStateEntry{IsDeny: true}},
+					EgressKey(): NewMapStateEntry(DenyEntry, nil),
 				}),
 			},
 			args: args{

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -107,7 +107,7 @@ func (epd *PerSelectorPolicy) appendL7WildcardRule(ctx *SearchContext) api.L7Rul
 // takesListenerPrecedenceOver returns true if the listener reference in 'l7Rules' takes precedence
 // over the listener reference in 'other'.
 func (l7Rules *PerSelectorPolicy) takesListenerPrecedenceOver(other *PerSelectorPolicy) bool {
-	var priority, otherPriority uint16
+	var priority, otherPriority uint8
 
 	// decrement by one to wrap the undefined value (0) to be the highest numerical
 	// value of the uint16, which is the lowest possible priority

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -2815,26 +2815,26 @@ func TestMergeListenerReference(t *testing.T) {
 	err := ps.mergeListenerReference(ps)
 	require.NoError(t, err)
 	require.Equal(t, "", ps.Listener)
-	require.Equal(t, uint16(0), ps.Priority)
+	require.Equal(t, uint8(0), ps.Priority)
 
 	// Listener reference remains when the other has none
 	ps0 := &PerSelectorPolicy{Listener: "listener0"}
 	err = ps0.mergeListenerReference(ps)
 	require.NoError(t, err)
 	require.Equal(t, "listener0", ps0.Listener)
-	require.Equal(t, uint16(0), ps0.Priority)
+	require.Equal(t, uint8(0), ps0.Priority)
 
 	// Listener reference is propagated when there is none to begin with
 	err = ps.mergeListenerReference(ps0)
 	require.NoError(t, err)
 	require.Equal(t, "listener0", ps.Listener)
-	require.Equal(t, uint16(0), ps.Priority)
+	require.Equal(t, uint8(0), ps.Priority)
 
 	// A listener is not changed when there is no change
 	err = ps0.mergeListenerReference(ps0)
 	require.NoError(t, err)
 	require.Equal(t, "listener0", ps0.Listener)
-	require.Equal(t, uint16(0), ps0.Priority)
+	require.Equal(t, uint8(0), ps0.Priority)
 
 	// Cannot merge two different listeners with the default (zero) priority
 	ps0a := &PerSelectorPolicy{Listener: "listener0a"}
@@ -2850,24 +2850,24 @@ func TestMergeListenerReference(t *testing.T) {
 	err = ps1.mergeListenerReference(ps0)
 	require.NoError(t, err)
 	require.Equal(t, "listener1", ps1.Listener)
-	require.Equal(t, uint16(1), ps1.Priority)
+	require.Equal(t, uint8(1), ps1.Priority)
 
 	err = ps0.mergeListenerReference(ps1)
 	require.NoError(t, err)
 	require.Equal(t, "listener1", ps0.Listener)
-	require.Equal(t, uint16(1), ps0.Priority)
+	require.Equal(t, uint8(1), ps0.Priority)
 
 	// Listener with the lower priority value takes precedence
 	ps2 := &PerSelectorPolicy{Listener: "listener2", Priority: 2}
 	err = ps1.mergeListenerReference(ps2)
 	require.NoError(t, err)
 	require.Equal(t, "listener1", ps1.Listener)
-	require.Equal(t, uint16(1), ps1.Priority)
+	require.Equal(t, uint8(1), ps1.Priority)
 
 	err = ps2.mergeListenerReference(ps1)
 	require.NoError(t, err)
 	require.Equal(t, "listener1", ps2.Listener)
-	require.Equal(t, uint16(1), ps2.Priority)
+	require.Equal(t, uint8(1), ps2.Priority)
 
 	// Cannot merge two different listeners with the same priority
 	ps12 := &PerSelectorPolicy{Listener: "listener1", Priority: 2}
@@ -2882,10 +2882,10 @@ func TestMergeListenerReference(t *testing.T) {
 	err = ps2.mergeListenerReference(ps23)
 	require.NoError(t, err)
 	require.Equal(t, "listener2", ps2.Listener)
-	require.Equal(t, uint16(2), ps2.Priority)
+	require.Equal(t, uint8(2), ps2.Priority)
 
 	err = ps23.mergeListenerReference(ps2)
 	require.NoError(t, err)
 	require.Equal(t, "listener2", ps23.Listener)
-	require.Equal(t, uint16(2), ps23.Priority)
+	require.Equal(t, uint8(2), ps23.Priority)
 }

--- a/pkg/policy/types/entry.go
+++ b/pkg/policy/types/entry.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import "strconv"
+
+type ProxyPortPriority uint8
+
+const (
+	MaxProxyPortPriority = 255
+	MaxListenerPriority  = 100
+)
+
+// MapStateEntry is the configuration associated with a Key in a
+// MapState. This is a minimized version of policymap.PolicyEntry.
+type MapStateEntry struct {
+	// isDeny is true when the policy should be denied.
+	isDeny bool
+
+	// ProxyPortPriority encodes the listener priority.
+	ProxyPortPriority ProxyPortPriority
+
+	// The proxy port, in host byte order.
+	// If 0 (default), there is no proxy redirection for the corresponding
+	// Key. Any other value signifies proxy redirection.
+	ProxyPort uint16
+
+	// Invalid is only set to mark the current entry for update when syncing entries to datapath
+	Invalid bool
+
+	// AuthRequirement is non-zero when authentication is required for the traffic to be
+	// allowed, except for when it explicitly defines authentication is not required.
+	AuthRequirement AuthRequirement
+}
+
+// String returns a string representation of the MapStateEntry
+func (e MapStateEntry) String() string {
+	var authText string
+	if e.AuthRequirement != 0 {
+		var authNote string
+		if !e.AuthRequirement.IsExplicit() {
+			authNote = " (derived)"
+		}
+		authText = ",AuthType=" + e.AuthRequirement.AuthType().String() + authNote
+	}
+
+	return "IsDeny=" + strconv.FormatBool(e.IsDeny()) +
+		",ProxyPort=" + strconv.FormatUint(uint64(e.ProxyPort), 10) +
+		",Priority=" + strconv.FormatUint(uint64(e.ProxyPortPriority), 10) +
+		authText
+}
+
+// NewMapStateEntry creeates a new MapStateEntry
+// Listener 'priority' is encoded in ProxyPortPriority, inverted
+func NewMapStateEntry(deny bool, proxyPort uint16, priority uint8, authReq AuthRequirement) MapStateEntry {
+	// Normalize inputs
+	if deny {
+		proxyPort = 0
+		priority = 0
+		authReq = 0
+	}
+	return MapStateEntry{
+		isDeny:          deny,
+		ProxyPort:       proxyPort,
+		AuthRequirement: authReq,
+	}.WithProxyPriority(priority)
+}
+
+func (e MapStateEntry) IsDeny() bool {
+	return e.isDeny
+}
+
+// IsRedirectEntry returns true if the entry redirects to a proxy port
+func (e MapStateEntry) IsRedirectEntry() bool {
+	return e.ProxyPort != 0
+}
+
+// AllowEntry returns a MapStateEntry for an allow policy without a proxy redirect
+func AllowEntry() MapStateEntry {
+	return MapStateEntry{}
+}
+
+// DenyEntry returns a MapStateEntry for a deny policy
+func DenyEntry() MapStateEntry {
+	return MapStateEntry{isDeny: true}
+}
+
+// WithDeny returns the entry 'e' with 'isDeny' set as indicated
+func (e MapStateEntry) WithDeny(isDeny bool) MapStateEntry {
+	e.isDeny = isDeny
+	return e
+}
+
+// WithProxyPriority returns a MapStateEntry with the given listener priority:
+// 0 - default (low) priority for all proxy redirects
+// 1 - highest listener priority
+// ..
+// 100 - lowest (non-default) listener priority
+func (e MapStateEntry) WithProxyPriority(priority uint8) MapStateEntry {
+	if e.ProxyPort != 0 {
+		if priority > 0 {
+			priority = min(priority, MaxListenerPriority)
+
+			// invert the priority so that higher number has the
+			// precedence, priority 1 becomes 254, 100 -> 155
+			e.ProxyPortPriority = MaxProxyPortPriority - ProxyPortPriority(priority)
+		} else {
+			e.ProxyPortPriority = 1 // proxy port without explicit priority
+		}
+	}
+	return e
+}
+
+// WithProxyPort return the MapStateEntry with proxy port set at the default precedence
+func (e MapStateEntry) WithProxyPort(proxyPort uint16) MapStateEntry {
+	e.ProxyPort = proxyPort
+	e.ProxyPortPriority = 1 // proxy port without explicit priority
+	return e
+}
+
+// Merge is only called if both entries are denies or allows
+func (e *MapStateEntry) Merge(entry MapStateEntry) {
+	// Only allow entries have proxy redirection or auth requirement
+	if !e.IsDeny() {
+		// Proxy port takes precedence, but may be updated due to priority
+		if entry.IsRedirectEntry() {
+			// Higher number has higher priority, but non-redirects have 0 priority
+			// value.
+			// Proxy port value is the tie-breaker when priorities have the same value.
+			if entry.ProxyPortPriority > e.ProxyPortPriority || entry.ProxyPortPriority == e.ProxyPortPriority && entry.ProxyPort < e.ProxyPort {
+				e.ProxyPort = entry.ProxyPort
+				e.ProxyPortPriority = entry.ProxyPortPriority
+			}
+		}
+
+		// Numerically higher AuthType takes precedence when both are
+		// either explicitly defined or derived
+		if entry.AuthRequirement.IsExplicit() == e.AuthRequirement.IsExplicit() {
+			if entry.AuthRequirement > e.AuthRequirement {
+				e.AuthRequirement = entry.AuthRequirement
+			}
+		} else if entry.AuthRequirement.IsExplicit() {
+			// Explicit auth takes precedence over defaulted one.
+			e.AuthRequirement = entry.AuthRequirement
+		}
+	}
+}


### PR DESCRIPTION
Add support for listener priority by adding a datapath policymap `ProxyPortPriority` field.

Add a new test for HTTP policy on a port range and use the precedence field to make sure it is not overridden by a more-specific allow rule, e.g., on a single intersecting port.


```release-note
HTTP policies are now supported on port ranges.
```