### PR TITLE
Envoy: demote initial fetch timeout warning

### DIFF
--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -292,6 +292,11 @@ func newEnvoyLogPiper() io.WriteCloser {
 			case envoyLogLevelOff, envoyLogLevelCritical, envoyLogLevelError:
 				scopedLog.Error(msg)
 			case envoyLogLevelWarning:
+				// Demote expected warnings to info level
+				if strings.Contains(msg, "gRPC config: initial fetch timed out for") {
+					scopedLog.Info(msg)
+					continue
+				}
 				scopedLog.Warn(msg)
 			case envoyLogLevelInfo:
 				scopedLog.Info(msg)

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -30,7 +30,7 @@ var (
 // startXDSGRPCServer starts a gRPC server to serve xDS APIs using the given
 // resource watcher and network listener.
 // Returns a function that stops the GRPC server when called.
-func (s *xdsServer) startXDSGRPCServer(config map[string]*xds.ResourceTypeConfiguration) context.CancelFunc {
+func (s *xdsServer) startXDSGRPCServer(listener net.Listener, config map[string]*xds.ResourceTypeConfiguration) context.CancelFunc {
 	grpcServer := grpc.NewServer()
 
 	// xdsServer optionally pauses serving any resources until endpoints have been restored
@@ -62,13 +62,6 @@ func (s *xdsServer) startXDSGRPCServer(config map[string]*xds.ResourceTypeConfig
 				log.Debug("Envoy: xDS server stopped before started serving")
 				return
 			}
-		}
-
-		// Have to start listening after restoration has completed to avoid initial fetch
-		// timeouts on Envoy side.
-		listener, err := s.newSocketListener()
-		if err != nil {
-			log.WithError(err).Fatal("Envoy: Failed to create socket listener")
 		}
 
 		log.Infof("Envoy: Starting xDS gRPC server listening on %s", listener.Addr())

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -62,6 +62,8 @@ func (s *xdsServer) startXDSGRPCServer(listener net.Listener, config map[string]
 				log.Debug("Envoy: xDS server stopped before started serving")
 				return
 			}
+			// Tell xdsServer it's time to start waiting for acknowledgements
+			xdsServer.RestoreCompleted()
 		}
 
 		log.Infof("Envoy: Starting xDS gRPC server listening on %s", listener.Addr())

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -65,10 +65,6 @@ var (
 
 // Server implements the handling of xDS streams.
 type Server struct {
-	// restorerPromise is initialized only if xDS server should wait sending any xDS resources
-	// until all endpoints have been restored.
-	restorerPromise promise.Promise[endpointstate.Restorer]
-
 	// watchers maps each supported type URL to its corresponding resource
 	// watcher.
 	watchers map[string]*ResourceWatcher
@@ -115,7 +111,13 @@ func NewServer(resourceTypes map[string]*ResourceTypeConfiguration, restorerProm
 
 	// TODO: Unregister the watchers when stopping the server.
 
-	return &Server{restorerPromise: restorerPromise, watchers: watchers, ackObservers: ackObservers}
+	return &Server{watchers: watchers, ackObservers: ackObservers}
+}
+
+func (s *Server) RestoreCompleted() {
+	for _, ackObserver := range s.ackObservers {
+		ackObserver.MarkRestoreCompleted()
+	}
 }
 
 func getXDSRequestFields(req *envoy_service_discovery.DiscoveryRequest) logrus.Fields {
@@ -263,12 +265,6 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 
 	nodeIP := ""
 	firstRequest := true
-
-	// We get here only if endpoints have been restored, tells the ackObservers that
-	// it is time to wait for acknowledgements.
-	for _, ackObserver := range s.ackObservers {
-		ackObserver.MarkRestoreCompleted()
-	}
 
 	for {
 		// Process either a new request from the xDS stream or a response

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -229,12 +229,14 @@ func newXDSServer(restorerPromise promise.Promise[endpointstate.Restorer], ipCac
 
 // start configures and starts the xDS GRPC server.
 func (s *xdsServer) start() error {
-	// Remove/Unlink the old unix domain socket, if any.
-	_ = os.Remove(s.socketPath)
+	socketListener, err := s.newSocketListener()
+	if err != nil {
+		return fmt.Errorf("failed to create socket listener: %w", err)
+	}
 
 	resourceConfig := s.initializeXdsConfigs()
 
-	s.stopFunc = s.startXDSGRPCServer(resourceConfig)
+	s.stopFunc = s.startXDSGRPCServer(socketListener, resourceConfig)
 
 	return nil
 }


### PR DESCRIPTION
Revert #36032 as it did not resolve the issue with Envoy initial fetch timeout warnings. Demote those warnings in the inlined logs from the embedded cilium-envoy instead.

Start waiting for Envoy acknowledgements as soon as endpoints have regenerated, rather than only when the first request on the xDS stream has been received.

Note that any proxied DNS requests will not wait for acknowledgements if issued before endpoints have regenerated, and even if they did, the maximum delay for passing the DNS response to the source pod is shorter than the time span allowed for endpoint regeneration.

We could start serving xDS resources sooner if we computed policies for the regenerated endpoints first, after which we could start serving xDS resources to envoy. Then the endpoints could take the time to recompute their bpf programs etc.

Fixes: #36032
Fixes: #35984

```release-note
Envoy "initial fetch timeout" warnings are now demoted to info level, as they are expected to happen
during Cilium Agent restart.
```
