### PR TITLE
cilium-cli: Use unique CNP names

### DIFF
--- a/cilium-cli/connectivity/builder/manifests/client-egress-l7-tls-port-range.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-l7-tls-port-range.yaml
@@ -1,7 +1,7 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: "l7-policy-tls-port-range"
+  name: "client-egress-l7-tls-port-range"
 specs:
 - description: "L7 policy with TLS port range"
   endpointSelector:

--- a/cilium-cli/connectivity/builder/manifests/client-egress-l7-tls-sni.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-l7-tls-sni.yaml
@@ -1,7 +1,7 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: "l7-policy-tls"
+  name: "client-egress-l7-tls-sni"
 specs:
 - description: "L7 policy with TLS"
   endpointSelector:

--- a/cilium-cli/connectivity/builder/manifests/client-egress-l7-tls.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-l7-tls.yaml
@@ -1,7 +1,7 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: "l7-policy-tls"
+  name: "client-egress-l7-tls"
 specs:
 - description: "L7 policy with TLS"
   endpointSelector:

--- a/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni.yaml
@@ -1,7 +1,7 @@
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
-  name: "l7-policy-tls-sni"
+  name: "client-egress-tls-sni"
 specs:
 - description: "L7 policy with TLS SNI"
   endpointSelector:


### PR DESCRIPTION
'client-egress-l7-tls.yaml' and 'client-egress-l7-tls-sni.yaml' had the same resource name "l7-policy-tls". Fix this by using the file name (minus the suffix) as the resource name.

Fixes: #35887
