### PR TITLE
v1.16 Backports 2024-11-20

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -278,12 +278,6 @@ jobs:
         run: |
           cilium status --wait --wait-duration=10m
 
-      - name: Port forward Relay
-        run: |
-          cilium hubble port-forward&
-          sleep 10s
-          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
-
       - name: Make JUnit report directory
         run: |
           mkdir -p cilium-junits
@@ -296,7 +290,6 @@ jobs:
 
       - name: Clean up Cilium
         run: |
-          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" || test $? -eq 1
           cilium uninstall --wait
 
       - name: Create custom IPsec secret
@@ -316,12 +309,6 @@ jobs:
       - name: Wait for Cilium status to be ready
         run: |
           cilium status --wait --wait-duration=10m
-
-      - name: Port forward Relay
-        run: |
-          cilium hubble port-forward&
-          sleep 10s
-          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})
         run: |

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -296,12 +296,6 @@ jobs:
             fi
           done
 
-      - name: Port forward Relay
-        run: |
-          cilium hubble port-forward&
-          sleep 10s
-          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
-
       - name: Make JUnit report directory
         run: |
           mkdir -p cilium-junits

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -572,12 +572,6 @@ jobs:
           cilium --context ${{ env.contextName1 }} clustermesh status --wait
           cilium --context ${{ env.contextName2 }} clustermesh status --wait
 
-      - name: Port forward Relay
-        run: |
-          cilium --context ${{ env.contextName1 }} hubble port-forward &
-          sleep 10s
-          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
-
       - name: Make JUnit report directory
         run: |
           mkdir -p cilium-junits

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -333,12 +333,6 @@ jobs:
             fi
           done
 
-      - name: Port forward Relay
-        run: |
-          ./cilium-cli hubble port-forward&
-          sleep 10s
-          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
-
       - name: Make JUnit report directory
         run: |
           mkdir -p cilium-junits

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -309,12 +309,6 @@ jobs:
           cilium status --wait --wait-duration=10m
           kubectl get pods -n kube-system
 
-      - name: Port forward Relay
-        run: |
-          cilium hubble port-forward&
-          sleep 10s
-          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
-
       - name: Make JUnit report directory
         run: |
           mkdir -p cilium-junits

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -110,12 +110,6 @@ jobs:
           cilium status --wait
           kubectl -n kube-system get pods
 
-      - name: Port forward Relay
-        run: |
-          cilium hubble port-forward&
-          sleep 10s
-          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
-
       - name: Make JUnit report directory
         run: |
           mkdir -p cilium-junits

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -211,12 +211,6 @@ jobs:
           cilium status --wait
           kubectl -n kube-system get pods
 
-      - name: Port forward Relay
-        run: |
-          cilium hubble port-forward&
-          sleep 10s
-          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
-
       - name: Make JUnit report directory
         run: |
           mkdir -p cilium-junits

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -151,12 +151,6 @@ jobs:
           cilium status --wait
           kubectl -n kube-system get pods
 
-      - name: Port forward Relay
-        run: |
-          cilium hubble port-forward&
-          sleep 10s
-          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
-
       - name: Run conformance test (e.g. connectivity check without external 1.1.1.1 and www.google.com)
         run: |
           kubectl apply -f ${{ env.CONFORMANCE_TEMPLATE }}

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -166,12 +166,6 @@ jobs:
           cilium status --wait
           kubectl -n kube-system get pods
 
-      - name: Port forward Relay
-        run: |
-          cilium hubble port-forward&
-          sleep 10s
-          [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
-
       - name: Run conformance test (e.g. connectivity check)
         run: |
           kubectl apply -f ${{ env.CONFORMANCE_TEMPLATE }}

--- a/Documentation/installation/k0s.rst
+++ b/Documentation/installation/k0s.rst
@@ -28,7 +28,9 @@ After deploying the VMs, export their IP addresses to environment variables (see
 
 .. code-block:: shell-session
 
-   export node1-IP=192.168.2.1 node2-IP=192.168.2.2 node3-IP=192.168.2.3
+   export node1_IP=192.168.2.1
+   export node2_IP=192.168.2.2
+   export node3_IP=192.168.2.3
 
 
 Prepare the yaml configuration file k0sctl will use:
@@ -37,7 +39,7 @@ Prepare the yaml configuration file k0sctl will use:
 
    # The following command assumes the user has deployed 3 VMs
    # with the default user "k0s" using the default ssh-key (without passphrase)
-   k0sctl init --k0s -n "myk0scluster" -u "k0s" -i "~/.ssh/id_rsa" -C "1" "${node1-IP}" "${node2-IP}" "${node3-IP}" > k0s-myk0scluster-config.yaml
+   k0sctl init --k0s -n "myk0scluster" -u "k0s" -i "~/.ssh/id_rsa" -C "1" "${node1_IP}" "${node2_IP}" "${node3_IP}" > k0s-myk0scluster-config.yaml
    
 
 Next step is editing ``k0s-myk0scluster-config.yaml``::

--- a/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
@@ -16,7 +16,7 @@ The following resources are used to manage the BGP Control Plane:
 
 * ``CiliumBGPClusterConfig``: Defines BGP instances and peer configurations that are applied to multiple nodes.
 * ``CiliumBGPPeerConfig``: A common set of BGP peering setting. It can be used across multiple peers.
-* ``CiliumBGPAdvertisements``: Defines prefixes that are injected into the BGP routing table.
+* ``CiliumBGPAdvertisement``: Defines prefixes that are injected into the BGP routing table.
 * ``CiliumBGPNodeConfigOverride``: Defines node-specific BGP configuration to provide a finer control.
 
 The relationship between various resources is shown in the below diagram:

--- a/Documentation/network/kubernetes/local-redirect-policy.rst
+++ b/Documentation/network/kubernetes/local-redirect-policy.rst
@@ -578,7 +578,9 @@ When a local redirect policy is applied, cilium BPF datapath redirects traffic g
 However, for traffic originating from a node-local backend pod destined to the policy frontend, users may want to
 skip redirecting the traffic back to the node-local backend pod, and instead forward the traffic to the original frontend.
 This behavior can be enabled by setting the ``skipRedirectFromBackend`` flag to ``true`` in the local redirect policy spec.
-This configuration requires the ``SO_NETNS_COOKIE`` feature available in Linux kernel version >= 5.8.
+This configuration requires the use of ``getsockopt()`` with the ``SO_NETNS_COOKIE`` option, which is available in
+Linux kernel version >= 5.12. Note that ``SO_NETNS_COOKIE`` was introduced in 5.7 (available to BPF programs),
+and exposed to user space in versions >= 5.12.
 
 .. note::
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -73,8 +73,9 @@ export KUBECTL ?= kubectl
 # command locally for any version update.
 # make generate-api generate-health-api generate-hubble-api generate-operator-api generate-kvstoremesh-api
 # renovate: datasource=docker depName=quay.io/goswagger/swagger
-SWAGGER_VERSION := v0.30.5
-SWAGGER := $(CONTAINER_ENGINE) run -u $(shell id -u):$(shell id -g) --rm -v $(ROOT_DIR):$(ROOT_DIR) -w $(ROOT_DIR) --entrypoint swagger quay.io/goswagger/swagger:$(SWAGGER_VERSION)
+SWAGGER_VERSION = v0.30.5
+SWAGGER_IMAGE_SHA = sha256:46ae4e82784530fa6d57503b7293c64073b54f35fb8df5dd361efdd34f5eab11
+SWAGGER := $(CONTAINER_ENGINE) run -u $(shell id -u):$(shell id -g) --rm -v $(ROOT_DIR):$(ROOT_DIR) -w $(ROOT_DIR) --entrypoint swagger quay.io/goswagger/swagger:$(SWAGGER_VERSION)@$(SWAGGER_IMAGE_SHA)
 
 # go build/test/clean flags
 # these are declared here so they are treated explicitly

--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -4,14 +4,9 @@
 package k8s
 
 import (
-	"fmt"
-
 	"github.com/cilium/hive/cell"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -36,7 +31,6 @@ var (
 
 		cell.Config(k8s.DefaultConfig),
 		LocalNodeCell,
-		ServiceNonHeadlessCell,
 		cell.Provide(
 			k8s.ServiceResource,
 			k8s.EndpointsResource,
@@ -84,50 +78,6 @@ var (
 			},
 		),
 	)
-
-	ServiceNonHeadlessCell = cell.Module(
-		"k8s-service-non-headless",
-		"Agent Kubernetes non headless service resources",
-
-		cell.Provide(
-			func(lc cell.Lifecycle, cfg k8s.Config, cs client.Clientset) (ServiceNonHeadless, error) {
-				return k8s.ServiceResource(
-					lc, cfg, cs,
-					func(opts *metav1.ListOptions) {
-						nonHeadlessServiceSelector, err := labels.NewRequirement(v1.IsHeadlessService, selection.DoesNotExist, nil)
-						if err != nil {
-							panic(fmt.Sprintf("can't create headless service requirement: %s", err))
-						}
-
-						labelSelector, err := labels.Parse(opts.LabelSelector)
-						if err != nil {
-							panic(fmt.Sprintf("can't parse existing service label selector: %s", err))
-						}
-						labelSelector = labelSelector.Add(*nonHeadlessServiceSelector)
-						opts.LabelSelector = labelSelector.String()
-					},
-				)
-			},
-			func(lc cell.Lifecycle, cfg k8s.Config, cs client.Clientset) (EndpointsNonHeadless, error) {
-				return k8s.EndpointsResource(
-					lc, cfg, cs,
-					func(opts *metav1.ListOptions) {
-						nonHeadlessServiceSelector, err := labels.NewRequirement(v1.IsHeadlessService, selection.DoesNotExist, nil)
-						if err != nil {
-							panic(fmt.Sprintf("can't create headless service requirement: %s", err))
-						}
-
-						labelSelector, err := labels.Parse(opts.LabelSelector)
-						if err != nil {
-							panic(fmt.Sprintf("can't parse existing endpoints label selector: %s", err))
-						}
-						labelSelector = labelSelector.Add(*nonHeadlessServiceSelector)
-						opts.LabelSelector = labelSelector.String()
-					},
-				)
-			},
-		),
-	)
 )
 
 // LocalNodeResource is a resource.Resource[*slim_corev1.Node] but one which will only stream updates for the node object
@@ -142,20 +92,12 @@ type LocalCiliumNodeResource resource.Resource[*cilium_api_v2.CiliumNode]
 // objects scheduled on the node we are currently running on.
 type LocalPodResource resource.Resource[*slim_corev1.Pod]
 
-// ServiceNonHeadless is a resource.Resource[*slim_corev1.Service] but one which will only stream updates for
-// non headless Services.
-type ServiceNonHeadless resource.Resource[*slim_corev1.Service]
-
-// EndpointsNonHeadless is a resource.Resource[*slim_corev1.Service] but one which will only stream updates for
-// Endpoints from non headless Services.
-type EndpointsNonHeadless resource.Resource[*k8s.Endpoints]
-
 // Resources is a convenience struct to group all the agent k8s resources as cell constructor parameters.
 type Resources struct {
 	cell.In
 
-	Services                         ServiceNonHeadless
-	Endpoints                        EndpointsNonHeadless
+	Services                         resource.Resource[*slim_corev1.Service]
+	Endpoints                        resource.Resource[*k8s.Endpoints]
 	LocalNode                        LocalNodeResource
 	LocalCiliumNode                  LocalCiliumNodeResource
 	LocalPods                        LocalPodResource

--- a/hubble/Makefile
+++ b/hubble/Makefile
@@ -39,10 +39,10 @@ local-release: clean
 				ARCHS='amd64 arm64'; \
 				;; \
 			linux) \
-				ARCHS='386 amd64 arm arm64'; \
+				ARCHS='amd64 arm64'; \
 				;; \
 			windows) \
-				ARCHS='386 amd64 arm64'; \
+				ARCHS='amd64 arm64'; \
 				EXT=".exe"; \
 				;; \
 		esac; \

--- a/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml
@@ -16,7 +16,7 @@ metadata:
 data:
   config.yaml: |
     cluster-name: {{ .Values.cluster.name }}
-    peer-service: "hubble-peer.{{ .Release.Namespace }}.svc.{{ .Values.hubble.peerService.clusterDomain }}:{{ $peerSvcPort }}"
+    peer-service: "hubble-peer.{{ .Release.Namespace }}.svc.{{ .Values.hubble.peerService.clusterDomain }}.:{{ $peerSvcPort }}"
     listen-address: {{ include "hubble-relay.config.listenAddress" . }}
     gops: {{ .Values.hubble.relay.gops.enabled }}
     gops-port: {{ .Values.hubble.relay.gops.port | quote }}

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -874,21 +874,64 @@ func (a *Allocator) DeleteAllKeys() {
 func (a *Allocator) syncLocalKeys() error {
 	// Create a local copy of all local allocations to not require to hold
 	// any locks while performing kvstore operations. Local use can
-	// disappear while we perform the sync but that is fine as worst case,
-	// a master key is created for a slave key that no longer exists. The
-	// garbage collector will remove it again.
+	// disappear while we perform the sync. For master keys this is fine as
+	// the garbage collector will remove it again. However, for slave keys, they
+	// will continue to exist until the kvstore lease expires after the agent is restarted.
+	// To ensure slave keys are not leaked, we do an extra check after the upsert,
+	// to ensure the key is still in use. If it's not in use, we grab the slave key mutex
+	// and hold it until we have released the key knowing that no new usage has started during the operation.
 	ids := a.localKeys.getVerifiedIDs()
+	ctx := context.TODO()
 
-	for id, value := range ids {
-		if err := a.backend.UpdateKey(context.TODO(), id, value, false); err != nil {
-			log.WithError(err).WithFields(logrus.Fields{
-				fieldKey: value,
-				fieldID:  id,
-			}).Warning("Unable to sync key")
-		}
+	for id, key := range ids {
+		a.syncLocalKey(ctx, id, key)
 	}
 
 	return nil
+}
+
+func (a *Allocator) syncLocalKey(ctx context.Context, id idpool.ID, key AllocatorKey) {
+	encodedKey := key.GetKey()
+	if newId := a.localKeys.lookupKey(encodedKey); newId != id {
+		return
+	}
+	err := a.backend.UpdateKey(ctx, id, key, false)
+	if err != nil {
+		log.WithError(err).WithFields(logrus.Fields{
+			fieldKey: key,
+			fieldID:  id,
+		}).Warning("Error updating key")
+	}
+
+	// Check if the key is still in use locally. Given its expected it's still
+	// in use in most cases, we avoid grabbing the slaveKeysMutex here to reduce lock contention.
+	// If it is in use here, we know the slave key is not leaked, and we don't need to do any cleanup.
+	if newId := a.localKeys.lookupKey(encodedKey); newId != idpool.NoID {
+		return
+	}
+
+	a.slaveKeysMutex.Lock()
+	defer a.slaveKeysMutex.Unlock()
+
+	// Check once again that the slave key is unused locally before releasing it,
+	// all while holding the slaveKeysMutex to ensure there are no concurrent allocations or releases.
+	// If the key is still unused, it could mean that the slave key was upserted into the kvstore during "UpdateKey"
+	// after it was previously released. If that is the case, we release it while holding the slaveKeysMutex.
+	if newId := a.localKeys.lookupKey(encodedKey); newId == idpool.NoID {
+		ctx, cancel := context.WithTimeout(ctx, backendOpTimeout)
+		defer cancel()
+		log.WithFields(logrus.Fields{
+			fieldKey: key,
+			fieldID:  id,
+		}).Warning("Releasing now unused key that was re-recreated")
+		err = a.backend.Release(ctx, id, key)
+		if err != nil {
+			log.WithError(err).WithFields(logrus.Fields{
+				fieldKey: key,
+				fieldID:  id,
+			}).Warning("Error releasing unused key")
+		}
+	}
 }
 
 func (a *Allocator) startLocalKeySync() {

--- a/pkg/allocator/allocator_test.go
+++ b/pkg/allocator/allocator_test.go
@@ -27,17 +27,20 @@ import (
 
 type dummyBackend struct {
 	mutex      lock.RWMutex
-	identities map[idpool.ID]AllocatorKey
+	masterKeys map[idpool.ID]AllocatorKey
+	slaveKeys  map[idpool.ID]AllocatorKey
 	handler    CacheMutations
 
-	updateKey func(ctx context.Context, id idpool.ID, key AllocatorKey) error
+	updateMasterKeyHandler func(ctx context.Context, id idpool.ID, key AllocatorKey) error
+	updateSlaveKeyHandler  func(ctx context.Context, id idpool.ID, key AllocatorKey) error
 
 	disableListDone bool
 }
 
 func newDummyBackend() *dummyBackend {
 	return &dummyBackend{
-		identities: map[idpool.ID]AllocatorKey{},
+		slaveKeys:  map[idpool.ID]AllocatorKey{},
+		masterKeys: map[idpool.ID]AllocatorKey{},
 	}
 }
 
@@ -48,18 +51,26 @@ func (d *dummyBackend) Encode(v string) string {
 func (d *dummyBackend) DeleteAllKeys(ctx context.Context) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
-	d.identities = map[idpool.ID]AllocatorKey{}
+	d.slaveKeys = map[idpool.ID]AllocatorKey{}
+	d.masterKeys = map[idpool.ID]AllocatorKey{}
+}
+
+func (d *dummyBackend) DeleteID(ctx context.Context, id idpool.ID) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	delete(d.slaveKeys, id)
+	return nil
 }
 
 func (d *dummyBackend) AllocateID(ctx context.Context, id idpool.ID, key AllocatorKey) (AllocatorKey, error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	if _, ok := d.identities[id]; ok {
+	if _, ok := d.masterKeys[id]; ok {
 		return nil, fmt.Errorf("identity already exists")
 	}
 
-	d.identities[id] = key
+	d.masterKeys[id] = key
 
 	if d.handler != nil {
 		d.handler.OnUpsert(id, key)
@@ -76,9 +87,11 @@ func (d *dummyBackend) AcquireReference(ctx context.Context, id idpool.ID, key A
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	if _, ok := d.identities[id]; !ok {
+	if _, ok := d.masterKeys[id]; !ok {
 		return fmt.Errorf("identity does not exist")
 	}
+
+	d.slaveKeys[id] = key
 
 	if d.handler != nil {
 		d.handler.OnUpsert(id, key)
@@ -101,18 +114,41 @@ func (d *dummyBackend) Lock(ctx context.Context, key AllocatorKey) (kvstore.KVLo
 	return &dummyLock{}, nil
 }
 
-func (d *dummyBackend) setUpdateKeyMutator(mutator func(ctx context.Context, id idpool.ID, key AllocatorKey) error) {
+func (d *dummyBackend) setUpdateMasterKeyMutator(mutator func(ctx context.Context, id idpool.ID, key AllocatorKey) error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
-	d.updateKey = mutator
+	d.updateMasterKeyHandler = mutator
+}
+
+func (d *dummyBackend) setUpdateSlaveKeyMutator(mutator func(ctx context.Context, id idpool.ID, key AllocatorKey) error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.updateSlaveKeyHandler = mutator
 }
 
 func (d *dummyBackend) UpdateKey(ctx context.Context, id idpool.ID, key AllocatorKey, reliablyMissing bool) error {
+	if err := d.updateMasterKey(ctx, id, key, reliablyMissing); err != nil {
+		return err
+	}
+	return d.updateSlaveKey(ctx, id, key, reliablyMissing)
+}
+
+func (d *dummyBackend) updateMasterKey(ctx context.Context, id idpool.ID, key AllocatorKey, reliablyMissing bool) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
-	d.identities[id] = key
-	if d.updateKey != nil {
-		return d.updateKey(ctx, id, key)
+	d.masterKeys[id] = key
+	if d.updateMasterKeyHandler != nil {
+		return d.updateMasterKeyHandler(ctx, id, key)
+	}
+	return nil
+}
+
+func (d *dummyBackend) updateSlaveKey(ctx context.Context, id idpool.ID, key AllocatorKey, reliablyMissing bool) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.slaveKeys[id] = key
+	if d.updateSlaveKeyHandler != nil {
+		return d.updateSlaveKeyHandler(ctx, id, key)
 	}
 	return nil
 }
@@ -124,7 +160,8 @@ func (d *dummyBackend) UpdateKeyIfLocked(ctx context.Context, id idpool.ID, key 
 func (d *dummyBackend) Get(ctx context.Context, key AllocatorKey) (idpool.ID, error) {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
-	for id, k := range d.identities {
+	// This loops through slaveKeys to mimic the kvstore implementation
+	for id, k := range d.slaveKeys {
 		if key.GetKey() == k.GetKey() {
 			return id, nil
 		}
@@ -139,7 +176,7 @@ func (d *dummyBackend) GetIfLocked(ctx context.Context, key AllocatorKey, lock k
 func (d *dummyBackend) GetByID(ctx context.Context, id idpool.ID) (AllocatorKey, error) {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
-	if key, ok := d.identities[id]; ok {
+	if key, ok := d.masterKeys[id]; ok {
 		return key, nil
 	}
 	return nil, nil
@@ -148,10 +185,10 @@ func (d *dummyBackend) GetByID(ctx context.Context, id idpool.ID) (AllocatorKey,
 func (d *dummyBackend) Release(ctx context.Context, id idpool.ID, key AllocatorKey) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
-	for idtyID, k := range d.identities {
+	for idtyID, k := range d.slaveKeys {
 		if k.GetKey() == key.GetKey() &&
 			idtyID == id {
-			delete(d.identities, id)
+			delete(d.slaveKeys, id)
 			if d.handler != nil {
 				d.handler.OnDelete(id, k)
 			}
@@ -166,10 +203,10 @@ func (d *dummyBackend) ListAndWatch(ctx context.Context, handler CacheMutations,
 	d.handler = handler
 
 	// Sort by ID to ensure consistent ordering
-	ids := maps.Keys(d.identities)
+	ids := maps.Keys(d.masterKeys)
 	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 	for _, id := range ids {
-		d.handler.OnUpsert(id, d.identities[id])
+		d.handler.OnUpsert(id, d.masterKeys[id])
 	}
 	d.mutex.Unlock()
 
@@ -445,7 +482,7 @@ func TestHandleK8sDelete(t *testing.T) {
 	require.True(t, newlyAllocated)
 
 	var counter atomic.Uint32
-	backend.setUpdateKeyMutator(func(ctx context.Context, id idpool.ID, key AllocatorKey) error {
+	backend.setUpdateMasterKeyMutator(func(ctx context.Context, id idpool.ID, key AllocatorKey) error {
 		counter.Add(1)
 		if counter.Load() <= 2 {
 			return fmt.Errorf("updateKey failed: %d", counter.Load())
@@ -667,4 +704,128 @@ func TestCacheValidators(t *testing.T) {
 	require.Empty(t, events, "Invalid delete event should not be propagated")
 	require.Nil(t, allocator.mainCache.getByID(invalidID))
 	require.Equal(t, AllocatorChangeDelete, kind)
+}
+
+func TestSyncLocalKeys(t *testing.T) {
+	numIDs := idpool.ID(3)
+	backend := newDummyBackend()
+	allocator, err := NewAllocator(TestAllocatorKey(""), backend, WithMax(numIDs))
+	require.NoError(t, err)
+	require.NotNil(t, allocator)
+
+	var ids []idpool.ID
+
+	// allocate IDs
+	for i := idpool.ID(1); i <= numIDs; i++ {
+		key := TestAllocatorKey(fmt.Sprintf("key-%04d", i))
+		id, _, _, err := allocator.Allocate(context.Background(), key)
+		require.NoError(t, err)
+		require.NotEqual(t, idpool.NoID, id)
+		ids = append(ids, id)
+
+		// Ensure id stored in backend is the same
+		backendID, err := backend.Get(context.TODO(), key)
+		require.NoError(t, err)
+		require.Equal(t, backendID, id)
+	}
+
+	err = allocator.syncLocalKeys()
+	require.NoError(t, err)
+
+	/// Release the use one id/delete the slave key
+	key, err := backend.GetByID(context.TODO(), ids[0])
+	require.NoError(t, err)
+	err = backend.Release(context.TODO(), ids[0], key)
+	require.NoError(t, err)
+
+	// Delete the master key of one ID
+	err = backend.DeleteID(context.TODO(), ids[1])
+	require.NoError(t, err)
+
+	// Delete both master and slave key for another ID
+	key, err = backend.GetByID(context.TODO(), ids[2])
+	require.NoError(t, err)
+	err = backend.Release(context.TODO(), ids[2], key)
+	require.NoError(t, err)
+	err = backend.DeleteID(context.TODO(), ids[2])
+	require.NoError(t, err)
+
+	err = allocator.syncLocalKeys()
+	require.NoError(t, err)
+
+	// Ensure all IDs are present
+	for i := idpool.ID(1); i <= numIDs; i++ {
+		key := TestAllocatorKey(fmt.Sprintf("key-%04d", i))
+
+		// Ensure all slave keys are present via Get
+		backendID, err := backend.Get(context.TODO(), key)
+		require.NoError(t, err)
+		require.NotEqual(t, idpool.NoID, backendID)
+
+		// Ensure all master keys are present via GetById
+		backendKey, err := backend.GetByID(context.TODO(), backendID)
+		require.NoError(t, err)
+		require.Equal(t, key, backendKey)
+	}
+
+}
+
+func TestSyncLocalKeysWithIdentityAllocations(t *testing.T) {
+	numIDs := idpool.ID(500)
+	backend := newDummyBackend()
+	allocator, err := NewAllocator(TestAllocatorKey(""), backend, WithMax(100*numIDs))
+	require.NoError(t, err)
+	require.NotNil(t, allocator)
+
+	allocateKeys := func(prefix string) func() {
+		// allocate IDs
+		for i := idpool.ID(1); i <= numIDs; i++ {
+			key := TestAllocatorKey(fmt.Sprintf("%s-key-%04d", prefix, i))
+			id, _, _, err := allocator.Allocate(context.Background(), key)
+			require.NoError(t, err)
+			require.NotEqual(t, idpool.NoID, id)
+		}
+		return func() {
+			for i := idpool.ID(1); i <= numIDs; i++ {
+				key := TestAllocatorKey(fmt.Sprintf("%s-key-%04d", prefix, i))
+				_, err := allocator.Release(context.TODO(), key)
+				require.NoError(t, err)
+			}
+		}
+	}
+	releaseKeys := allocateKeys("initial")
+
+	backend.setUpdateSlaveKeyMutator(func(ctx context.Context, id idpool.ID, key AllocatorKey) error {
+		time.Sleep(time.Microsecond)
+		return nil
+	})
+	done := make(chan struct{})
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		for {
+			select {
+			case <-done:
+				wg.Done()
+				return
+			default:
+				err := allocator.syncLocalKeys()
+				require.NoError(t, err)
+			}
+		}
+	}()
+
+	// Release keys concurrently with syncLocalKeys
+	go func() {
+		releaseKeys()
+		releaseExtraKeys := allocateKeys("extra")
+		releaseExtraKeys()
+		close(done)
+	}()
+
+	wg.Wait()
+
+	// Ensure all slave keys are deleted, and non are leaked
+	assert.Empty(t, backend.slaveKeys)
 }

--- a/pkg/bgpv1/manager/store/diffstore.go
+++ b/pkg/bgpv1/manager/store/diffstore.go
@@ -90,7 +90,9 @@ func NewDiffStore[T k8sRuntime.Object](params diffStoreParams[T]) DiffStore[T] {
 	params.JobGroup.Add(
 		job.OneShot("diffstore-events",
 			func(ctx context.Context, health cell.Health) (err error) {
+				ds.mu.Lock()
 				ds.store, err = ds.resource.Store(ctx)
+				ds.mu.Unlock()
 				if err != nil {
 					return fmt.Errorf("error creating resource store: %w", err)
 				}

--- a/pkg/bgpv1/manager/store/diffstore_test.go
+++ b/pkg/bgpv1/manager/store/diffstore_test.go
@@ -110,6 +110,15 @@ func TestDiffSignal(t *testing.T) {
 	fixture.diffStore.InitDiff(testCallerID1)
 	fixture.diffStore.InitDiff(testCallerID2)
 
+	// wait for initial sync signal
+	timer := time.NewTimer(5 * time.Second)
+	select {
+	case <-fixture.signaler.Sig:
+		timer.Stop()
+	case <-timer.C:
+		t.Fatal("No signal sent by diffstore")
+	}
+
 	// Add an initial object.
 	err = tracker.Add(&slimv1.Service{
 		ObjectMeta: v1.ObjectMeta{
@@ -120,7 +129,7 @@ func TestDiffSignal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	timer := time.NewTimer(5 * time.Second)
+	timer = time.NewTimer(5 * time.Second)
 	select {
 	case <-fixture.signaler.Sig:
 		timer.Stop()

--- a/pkg/bgpv1/manager/store/resource_store.go
+++ b/pkg/bgpv1/manager/store/resource_store.go
@@ -63,7 +63,9 @@ func NewBGPCPResourceStore[T k8sRuntime.Object](params bgpCPResourceStoreParams[
 	params.JobGroup.Add(
 		job.OneShot("bgpcp-resource-store-events",
 			func(ctx context.Context, health cell.Health) (err error) {
+				s.mu.Lock()
 				s.store, err = s.resource.Store(ctx)
+				s.mu.Unlock()
 				if err != nil {
 					return fmt.Errorf("error creating resource store: %w", err)
 				}

--- a/pkg/hubble/metrics/kafka/handler.go
+++ b/pkg/hubble/metrics/kafka/handler.go
@@ -5,6 +5,7 @@ package kafka
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -83,7 +84,7 @@ func (h *kafkaHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error
 		reporter = "server"
 	}
 
-	h.requests.WithLabelValues(append(labelValues, kafka.Topic, kafka.ApiKey, string(kafka.ErrorCode), reporter)...).Inc()
+	h.requests.WithLabelValues(append(labelValues, kafka.Topic, kafka.ApiKey, strconv.Itoa(int(kafka.ErrorCode)), reporter)...).Inc()
 	h.duration.WithLabelValues(append(labelValues, kafka.Topic, kafka.ApiKey, reporter)...).Observe(float64(l7.LatencyNs) / float64(time.Second))
 	return nil
 }

--- a/pkg/hubble/metrics/kafka/handler_test.go
+++ b/pkg/hubble/metrics/kafka/handler_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package kafka
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/metrics/api"
+)
+
+func Test_kafkaHandler_Status(t *testing.T) {
+	plugin := kafkaPlugin{}
+	handler := plugin.NewHandler()
+	assert.Equal(t, "", handler.Status())
+	options := map[string]string{
+		"sourceContext":      "namespace",
+		"destinationContext": "identity",
+	}
+	require.NoError(t, handler.Init(prometheus.NewRegistry(), options))
+	assert.Equal(t, "destination=identity,source=namespace", handler.Status())
+}
+
+func Test_kafkaHandler_ProcessFlow(t *testing.T) {
+	ctx := context.Background()
+	plugin := kafkaPlugin{}
+	handler := plugin.NewHandler()
+	options := map[string]string{"destinationContext": "invalid"}
+	require.Error(t, handler.Init(prometheus.NewRegistry(), options))
+	options = map[string]string{
+		"sourceContext":      "pod",
+		"destinationContext": "pod",
+		"labelsContext":      "source_pod,destination_pod",
+	}
+	require.NoError(t, handler.Init(prometheus.NewRegistry(), options))
+	fp, ok := handler.(api.FlowProcessor)
+	require.True(t, ok)
+	// shouldn't count
+	fp.ProcessFlow(ctx, &pb.Flow{})
+	// shouldn't count
+	fp.ProcessFlow(ctx, &pb.Flow{L7: &pb.Layer7{
+		Type:   pb.L7FlowType_RESPONSE,
+		Record: &pb.Layer7_Dns{},
+	}})
+	sourceEndpoint := &pb.Endpoint{
+		Namespace: "source-ns",
+		PodName:   "source-deploy-pod",
+		Workloads: []*pb.Workload{{
+			Name: "source-deploy",
+			Kind: "Deployment",
+		}},
+		Labels: []string{
+			"k8s:app=sourceapp",
+		},
+	}
+	destinationEndpoint := &pb.Endpoint{
+		Namespace: "destination-ns",
+		PodName:   "destination-deploy-pod",
+		Workloads: []*pb.Workload{{
+			Name: "destination-deploy",
+			Kind: "Deployment",
+		}},
+		Labels: []string{
+			"k8s:app=destinationapp",
+		},
+	}
+	// should count for request
+	fp.ProcessFlow(ctx, &pb.Flow{
+		TrafficDirection: pb.TrafficDirection_INGRESS,
+		Source:           sourceEndpoint,
+		Destination:      destinationEndpoint,
+		L7: &pb.Layer7{
+			Type:      pb.L7FlowType_REQUEST,
+			LatencyNs: 12345678,
+			Record: &pb.Layer7_Kafka{Kafka: &pb.Kafka{
+				Topic:     "test-topic",
+				ApiKey:    "test-api-key",
+				ErrorCode: 0,
+			}},
+		},
+	})
+	requestsExpected := `
+        # HELP hubble_kafka_requests_total Count of Kafka requests
+        # TYPE hubble_kafka_requests_total counter
+	      hubble_kafka_requests_total{api_key="test-api-key", destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",error_code="0",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic"} 1
+	`
+	assert.NoError(t, testutil.CollectAndCompare(handler.(*kafkaHandler).requests, strings.NewReader(requestsExpected)))
+	durationExpected := `
+        # HELP hubble_kafka_request_duration_seconds Quantiles of HTTP request duration in seconds
+        # TYPE hubble_kafka_request_duration_seconds histogram
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="0.005"} 0
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="0.01"} 0
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="0.025"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="0.05"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="0.1"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="0.25"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="0.5"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="1"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="2.5"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="5"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="10"} 1
+        hubble_kafka_request_duration_seconds_bucket{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic",le="+Inf"} 1
+        hubble_kafka_request_duration_seconds_sum{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic"} 0.012345678
+        hubble_kafka_request_duration_seconds_count{api_key="test-api-key",destination="destination-ns/destination-deploy-pod",destination_pod="destination-deploy-pod",reporter="server",source="source-ns/source-deploy-pod",source_pod="source-deploy-pod",topic="test-topic"} 1
+	`
+	require.NoError(t, testutil.CollectAndCompare(handler.(*kafkaHandler).duration, strings.NewReader(durationExpected)))
+}
+
+func Test_kafkaHandler_ListMetricVec(t *testing.T) {
+	plugin := kafkaPlugin{}
+	handler := plugin.NewHandler()
+	require.NoError(t, handler.Init(prometheus.NewRegistry(), nil))
+	assert.Len(t, handler.ListMetricVec(), 2, "expecting 2 metrics, requests and duration")
+	for _, vec := range handler.ListMetricVec() {
+		require.NotNil(t, vec, "ListMetricVec should not nil metrics vectors")
+	}
+}

--- a/pkg/hubble/metrics/kafka/plugin_test.go
+++ b/pkg/hubble/metrics/kafka/plugin_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package kafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_kafkaPlugin_HelpText(t *testing.T) {
+	plugin := &kafkaPlugin{}
+	expected := `kafka - Kafka metrics
+Metrics related to the Kafka protocol
+
+Metrics:
+  kafka_requests_total           - Count of Kafka requests by topic and ApiKey.
+  kafka_request_duration_seconds - Histogram of Kafka request duration by topic and ApiKey.
+
+Options:
+ sourceContext             ::= identifier , { "|", identifier }
+ destinationContext        ::= identifier , { "|", identifier }
+ sourceEgressContext       ::= identifier , { "|", identifier }
+ sourceIngressContext      ::= identifier , { "|", identifier }
+ destinationEgressContext  ::= identifier , { "|", identifier }
+ destinationIngressContext ::= identifier , { "|", identifier }
+ labels                    ::= label , { ",", label }
+ identifier                ::= identity | namespace | pod | pod-name | dns | ip | reserved-identity | workload | workload-name | app
+ label                     ::= source_ip | source_pod | source_namespace | source_workload | source_workload_kind | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_workload_kind | destination_app | traffic_direction
+`
+	assert.Equal(t, expected, plugin.HelpText())
+}

--- a/pkg/hubble/observer/local_node_watcher_test.go
+++ b/pkg/hubble/observer/local_node_watcher_test.go
@@ -54,10 +54,11 @@ func Test_LocalNodeWatcher(t *testing.T) {
 	}
 
 	var watcher *LocalNodeWatcher
+	store := node.NewTestLocalNodeStore(localNode)
 
 	t.Run("NewLocalNodeWatcher", func(t *testing.T) {
 		var err error
-		watcher, err = NewLocalNodeWatcher(ctx, node.NewTestLocalNodeStore(localNode))
+		watcher, err = NewLocalNodeWatcher(ctx, store)
 		require.NoError(t, err)
 		require.NotNil(t, watcher)
 	})
@@ -71,7 +72,9 @@ func Test_LocalNodeWatcher(t *testing.T) {
 	})
 
 	t.Run("update", func(t *testing.T) {
-		watcher.update(updatedNode)
+		store.Update(func(ln *node.LocalNode) {
+			*ln = updatedNode
+		})
 		var flow flowpb.Flow
 		stop, err := watcher.OnDecodedFlow(ctx, &flow)
 		require.False(t, stop)

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -150,7 +150,7 @@ func ParseService(svc *slim_corev1.Service, nodePortAddrs []netip.Addr) (Service
 		}
 	}
 
-	headless := false
+	_, headless := svc.Labels[v1.IsHeadlessService]
 	if strings.ToLower(svc.Spec.ClusterIP) == "none" {
 		headless = true
 	}
@@ -227,7 +227,7 @@ func ParseService(svc *slim_corev1.Service, nodePortAddrs []netip.Addr) (Service
 				proto := loadbalancer.L4Type(port.Protocol)
 				port := uint16(port.NodePort)
 				// This can happen if the service type is NodePort/LoadBalancer but the upstream apiserver
-				// did not assign any NodePort to the serivce port field.
+				// did not assign any NodePort to the service port field.
 				// For example if `allocateLoadBalancerNodePorts` is set to false in the service
 				// spec. For more details see -
 				// https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1864-disable-lb-node-ports
@@ -486,8 +486,8 @@ func parseIPs(externalIPs []string) map[string]net.IP {
 func NewService(ips []net.IP, externalIPs, loadBalancerIPs, loadBalancerSourceRanges []string,
 	headless bool, extTrafficPolicy, intTrafficPolicy loadbalancer.SVCTrafficPolicy,
 	healthCheckNodePort uint16, labels, selector map[string]string,
-	namespace string, svcType loadbalancer.SVCType) *Service {
-
+	namespace string, svcType loadbalancer.SVCType,
+) *Service {
 	var (
 		k8sExternalIPs     map[string]net.IP
 		k8sLoadBalancerIPs map[string]net.IP


### PR DESCRIPTION
 * [x] #33523 (@michi-covalent)
 * [ ] #35923 (@yilas)
 * [x] #35921 (@ysksuzuki)
 * [ ] #35953 (@seadog007)
 * [x] #35945 (@tommyp1ckles)
 * [x] #35974 (@michi-covalent)
 * [x] #35971 (@harsimran-pabla)
 * [x] #35902 (@pippolo84)
 * [x] #35979 (@aanm) :warning: resolved conflicts
   - dropped changes in `.github/renovate.json5` (does not exist in v1.16)
 * [x] #34893 (@odinuge) :warning: resolved conflicts
   - manually resolved minor conflicts in few `dummyBackend` methods in `allocator_test.go`
 * [ ] #36005 (@devodev) :warning: resolved conflicts
   - manually added terminanting dot for peer-service as its content did not match with the version in the main branch
 * [x] #35838 (@MrFreezeex) :warning: resolved conflicts
   - resolved multiple conflicts and test incompatibilities, please see backporter's notes on individual commits
 * [ ] #35856 (@nddq)
 * [ ] #35936 (@jrajahalme)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 33523 35923 35921 35953 35945 35974 35971 35902 35979 34893 36005 35838 35856 35936
```
