### PR TITLE
Add feature tracking in Cilium Operator as prometheus metrics

### DIFF
--- a/cilium-cli/cli/features.go
+++ b/cilium-cli/cli/features.go
@@ -32,6 +32,7 @@ func newCmdFeaturesStatus() *cobra.Command {
 		Long:  "This command returns features enabled from all nodes in the cluster",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			params.CiliumNamespace = namespace
+			params.CiliumOperatorNamespace = namespace
 			s := features.NewFeatures(k8sClient, params)
 			if err := s.PrintFeatureStatus(context.Background()); err != nil {
 				fatalf("Unable to print features status: %s", err)
@@ -40,7 +41,10 @@ func newCmdFeaturesStatus() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&params.AgentPodSelector, "agent-pod-selector", defaults.AgentPodSelector, "Label on cilium-agent pods to select with")
+	cmd.Flags().StringVar(&params.OperatorPodSelector, "operator-pod-selector", defaults.OperatorPodSelector, "Label on cilium-operator pods to select with")
+	cmd.Flags().StringVar(&params.CiliumOperatorCommand, "operator-container-command", "", "Binary used to run Cilium Operator")
 	cmd.Flags().StringVar(&params.NodeName, "node", "", "Node from which features status will be fetched, omit to select all nodes")
+	cmd.Flags().StringVar(&params.OperatorNodeName, "operator-node", "", "Node from which features status will be fetched, omit to select all nodes")
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", 1*time.Minute, "Maximum time to wait for result, default 1 minute")
 	cmd.Flags().StringVarP(&params.Output, "output", "o", "tab", "Output format. One of: tab, markdown, json")
 	cmd.Flags().StringVarP(&params.Outputfile, "output-file", "", "-", "Outputs into a file. Defaults to stdout")

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -69,6 +69,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
+	features "github.com/cilium/cilium/pkg/metrics/features/operator"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pprof"
 	"github.com/cilium/cilium/pkg/version"
@@ -272,6 +273,11 @@ var (
 			// corresponding ClusterIP, without depending on CoreDNS. Leveraged by etcd
 			// and clustermesh.
 			dial.ServiceResolverCell,
+
+			// The feature Cell will retrieve information from all other cells /
+			// configuration to describe, in form of prometheus metrics, which
+			// features are enabled on the operator.
+			features.Cell,
 		),
 	)
 

--- a/operator/pkg/ciliumenvoyconfig/cell.go
+++ b/operator/pkg/ciliumenvoyconfig/cell.go
@@ -25,6 +25,7 @@ var Cell = cell.Module(
 		LoadBalancerL7Algorithm: "round_robin",
 	}),
 	cell.Invoke(registerL7LoadBalancingController),
+	cell.Provide(func(r l7LoadBalancerConfig) LoadBalancerConfig { return r }),
 )
 
 type l7LoadBalancerConfig struct {
@@ -37,6 +38,14 @@ func (r l7LoadBalancerConfig) Flags(flags *pflag.FlagSet) {
 	flags.String("loadbalancer-l7", r.LoadBalancerL7, "Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy")
 	flags.String("loadbalancer-l7-algorithm", r.LoadBalancerL7Algorithm, "Default LB algorithm for services that do not specify related annotation")
 	flags.StringSlice("loadbalancer-l7-ports", r.LoadBalancerL7Ports, "List of service ports that will be automatically redirected to backend.")
+}
+
+type LoadBalancerConfig interface {
+	GetLoadBalancerL7() string
+}
+
+func (r l7LoadBalancerConfig) GetLoadBalancerL7() string {
+	return r.LoadBalancerL7
 }
 
 type l7LoadbalancerParams struct {

--- a/operator/pkg/lbipam/cell.go
+++ b/operator/pkg/lbipam/cell.go
@@ -23,7 +23,10 @@ var Cell = cell.Module(
 	"lbipam",
 	"LB-IPAM",
 	// Provide LBIPAM so instances of it can be used while testing
-	cell.Provide(newLBIPAMCell),
+	cell.Provide(
+		newLBIPAMCell,
+		func(c lbipamConfig) Config { return c },
+	),
 	// Invoke an empty function which takes an LBIPAM to force its construction.
 	cell.Invoke(func(*LBIPAM) {}),
 	// Provide LB-IPAM related metrics
@@ -43,6 +46,14 @@ type lbipamConfig struct {
 
 func (lc lbipamConfig) Flags(flags *pflag.FlagSet) {
 	flags.BoolVar(&lc.EnableLBIPAM, "enable-lb-ipam", lc.EnableLBIPAM, "Enable LB IPAM")
+}
+
+func (lc lbipamConfig) IsEnabled() bool {
+	return lc.EnableLBIPAM
+}
+
+type Config interface {
+	IsEnabled() bool
 }
 
 type lbipamCellParams struct {

--- a/operator/pkg/nodeipam/cell.go
+++ b/operator/pkg/nodeipam/cell.go
@@ -19,6 +19,7 @@ var Cell = cell.Module(
 	"nodeipam",
 	"Node-IPAM",
 
+	cell.Provide(func(r nodeIpamConfig) NodeIPAMConfig { return r }),
 	cell.Config(nodeIpamConfig{}),
 	cell.Invoke(registerNodeSvcLBReconciler),
 )
@@ -35,6 +36,14 @@ type nodeipamCellParams struct {
 
 type nodeIpamConfig struct {
 	EnableNodeIPAM bool
+}
+
+func (r nodeIpamConfig) IsEnabled() bool {
+	return r.EnableNodeIPAM
+}
+
+type NodeIPAMConfig interface {
+	IsEnabled() bool
 }
 
 func (r nodeIpamConfig) Flags(flags *pflag.FlagSet) {

--- a/pkg/metrics/features/operator/cell.go
+++ b/pkg/metrics/features/operator/cell.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/hive/job"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/operator/pkg/ingress"
 	"github.com/cilium/cilium/pkg/metrics"
 )
 
@@ -41,7 +42,14 @@ type featuresParams struct {
 	Metrics   featureMetrics
 
 	OperatorConfig *operatorOption.OperatorConfig
+
+	IngressController ingress.IngressConfig
+}
+
+func (p featuresParams) IsIngressControllerEnabled() bool {
+	return p.IngressController.IsEnabled()
 }
 
 type enabledFeatures interface {
+	IsIngressControllerEnabled() bool
 }

--- a/pkg/metrics/features/operator/cell.go
+++ b/pkg/metrics/features/operator/cell.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+
+	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/pkg/metrics"
+)
+
+// Cell will retrieve information from all other cells /
+// configuration to describe, in form of prometheus metrics, which
+// features are enabled on the operator.
+var Cell = cell.Module(
+	"enabled-features",
+	"Exports prometheus metrics describing which features are enabled in operator",
+
+	cell.Invoke(updateOperatorConfigMetricOnStart),
+	cell.Provide(
+		func(m Metrics) featureMetrics {
+			return m
+		},
+	),
+	metrics.Metric(func() Metrics {
+		return NewMetrics(true)
+	}),
+)
+
+type featuresParams struct {
+	cell.In
+
+	Log       *slog.Logger
+	JobGroup  job.Group
+	Health    cell.Health
+	Lifecycle cell.Lifecycle
+	Metrics   featureMetrics
+
+	OperatorConfig *operatorOption.OperatorConfig
+}
+
+type enabledFeatures interface {
+}

--- a/pkg/metrics/features/operator/cell.go
+++ b/pkg/metrics/features/operator/cell.go
@@ -13,6 +13,7 @@ import (
 	ciliumenvoyconfig2 "github.com/cilium/cilium/operator/pkg/ciliumenvoyconfig"
 	"github.com/cilium/cilium/operator/pkg/ingress"
 	"github.com/cilium/cilium/operator/pkg/lbipam"
+	"github.com/cilium/cilium/operator/pkg/nodeipam"
 	"github.com/cilium/cilium/pkg/metrics"
 )
 
@@ -48,6 +49,7 @@ type featuresParams struct {
 	IngressController ingress.IngressConfig
 	LBIPAM            lbipam.Config
 	LBConfig          ciliumenvoyconfig2.LoadBalancerConfig
+	NodeIPAM          nodeipam.NodeIPAMConfig
 }
 
 func (p featuresParams) IsIngressControllerEnabled() bool {
@@ -62,8 +64,13 @@ func (p featuresParams) GetLoadBalancerL7() string {
 	return p.LBConfig.GetLoadBalancerL7()
 }
 
+func (p featuresParams) IsNodeIPAMEnabled() bool {
+	return p.NodeIPAM.IsEnabled()
+}
+
 type enabledFeatures interface {
 	IsIngressControllerEnabled() bool
 	IsLBIPAMEnabled() bool
 	GetLoadBalancerL7() string
+	IsNodeIPAMEnabled() bool
 }

--- a/pkg/metrics/features/operator/cell.go
+++ b/pkg/metrics/features/operator/cell.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/hive/job"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
+	ciliumenvoyconfig2 "github.com/cilium/cilium/operator/pkg/ciliumenvoyconfig"
 	"github.com/cilium/cilium/operator/pkg/ingress"
 	"github.com/cilium/cilium/operator/pkg/lbipam"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -46,6 +47,7 @@ type featuresParams struct {
 
 	IngressController ingress.IngressConfig
 	LBIPAM            lbipam.Config
+	LBConfig          ciliumenvoyconfig2.LoadBalancerConfig
 }
 
 func (p featuresParams) IsIngressControllerEnabled() bool {
@@ -56,7 +58,12 @@ func (p featuresParams) IsLBIPAMEnabled() bool {
 	return p.LBIPAM.IsEnabled()
 }
 
+func (p featuresParams) GetLoadBalancerL7() string {
+	return p.LBConfig.GetLoadBalancerL7()
+}
+
 type enabledFeatures interface {
 	IsIngressControllerEnabled() bool
 	IsLBIPAMEnabled() bool
+	GetLoadBalancerL7() string
 }

--- a/pkg/metrics/features/operator/cell.go
+++ b/pkg/metrics/features/operator/cell.go
@@ -11,6 +11,7 @@ import (
 
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/operator/pkg/ingress"
+	"github.com/cilium/cilium/operator/pkg/lbipam"
 	"github.com/cilium/cilium/pkg/metrics"
 )
 
@@ -44,12 +45,18 @@ type featuresParams struct {
 	OperatorConfig *operatorOption.OperatorConfig
 
 	IngressController ingress.IngressConfig
+	LBIPAM            lbipam.Config
 }
 
 func (p featuresParams) IsIngressControllerEnabled() bool {
 	return p.IngressController.IsEnabled()
 }
 
+func (p featuresParams) IsLBIPAMEnabled() bool {
+	return p.LBIPAM.IsEnabled()
+}
+
 type enabledFeatures interface {
 	IsIngressControllerEnabled() bool
+	IsLBIPAMEnabled() bool
 }

--- a/pkg/metrics/features/operator/features.go
+++ b/pkg/metrics/features/operator/features.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"context"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+)
+
+func updateOperatorConfigMetricOnStart(jg job.Group, params featuresParams, m featureMetrics) error {
+	jg.Add(job.OneShot("update-config-metric", func(ctx context.Context, health cell.Health) error {
+		health.OK("Updating metrics based on OperatorConfig")
+		m.update(&params, params.OperatorConfig)
+		return nil
+	}))
+
+	return nil
+}

--- a/pkg/metrics/features/operator/metrics.go
+++ b/pkg/metrics/features/operator/metrics.go
@@ -12,6 +12,7 @@ import (
 type Metrics struct {
 	ACLBGatewayAPIEnabled        metric.Gauge
 	ACLBIngressControllerEnabled metric.Gauge
+	ACLBIPAMEnabled              metric.Gauge
 }
 
 const (
@@ -35,6 +36,13 @@ func NewMetrics(withDefaults bool) Metrics {
 			Help:      "IngressController enabled on the operator",
 			Name:      "ingress_controller_enabled",
 		}),
+
+		ACLBIPAMEnabled: metric.NewGauge(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Help:      "LB IPAM enabled on the operator",
+			Name:      "lb_ipam_enabled",
+		}),
 	}
 }
 
@@ -48,5 +56,8 @@ func (m Metrics) update(params enabledFeatures, config *option.OperatorConfig) {
 	}
 	if params.IsIngressControllerEnabled() {
 		m.ACLBIngressControllerEnabled.Add(1)
+	}
+	if params.IsLBIPAMEnabled() {
+		m.ACLBIPAMEnabled.Add(1)
 	}
 }

--- a/pkg/metrics/features/operator/metrics.go
+++ b/pkg/metrics/features/operator/metrics.go
@@ -10,9 +10,10 @@ import (
 )
 
 type Metrics struct {
-	ACLBGatewayAPIEnabled        metric.Gauge
-	ACLBIngressControllerEnabled metric.Gauge
-	ACLBIPAMEnabled              metric.Gauge
+	ACLBGatewayAPIEnabled               metric.Gauge
+	ACLBIngressControllerEnabled        metric.Gauge
+	ACLBIPAMEnabled                     metric.Gauge
+	ACLBL7AwareTrafficManagementEnabled metric.Gauge
 }
 
 const (
@@ -43,6 +44,13 @@ func NewMetrics(withDefaults bool) Metrics {
 			Help:      "LB IPAM enabled on the operator",
 			Name:      "lb_ipam_enabled",
 		}),
+
+		ACLBL7AwareTrafficManagementEnabled: metric.NewGauge(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Help:      "L7 Aware Traffic Management enabled on the operator",
+			Name:      "l7_aware_traffic_management_enabled",
+		}),
 	}
 }
 
@@ -59,5 +67,8 @@ func (m Metrics) update(params enabledFeatures, config *option.OperatorConfig) {
 	}
 	if params.IsLBIPAMEnabled() {
 		m.ACLBIPAMEnabled.Add(1)
+	}
+	if params.GetLoadBalancerL7() != "" {
+		m.ACLBL7AwareTrafficManagementEnabled.Add(1)
 	}
 }

--- a/pkg/metrics/features/operator/metrics.go
+++ b/pkg/metrics/features/operator/metrics.go
@@ -10,7 +10,8 @@ import (
 )
 
 type Metrics struct {
-	ACLBGatewayAPIEnabled metric.Gauge
+	ACLBGatewayAPIEnabled        metric.Gauge
+	ACLBIngressControllerEnabled metric.Gauge
 }
 
 const (
@@ -27,6 +28,13 @@ func NewMetrics(withDefaults bool) Metrics {
 			Help:      "GatewayAPI enabled on the operator",
 			Name:      "gateway_api_enabled",
 		}),
+
+		ACLBIngressControllerEnabled: metric.NewGauge(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Help:      "IngressController enabled on the operator",
+			Name:      "ingress_controller_enabled",
+		}),
 	}
 }
 
@@ -37,5 +45,8 @@ type featureMetrics interface {
 func (m Metrics) update(params enabledFeatures, config *option.OperatorConfig) {
 	if config.EnableGatewayAPI {
 		m.ACLBGatewayAPIEnabled.Add(1)
+	}
+	if params.IsIngressControllerEnabled() {
+		m.ACLBIngressControllerEnabled.Add(1)
 	}
 }

--- a/pkg/metrics/features/operator/metrics.go
+++ b/pkg/metrics/features/operator/metrics.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+type Metrics struct {
+	ACLBGatewayAPIEnabled metric.Gauge
+}
+
+const (
+	subsystemACLB = "feature_adv_connect_and_lb"
+)
+
+// NewMetrics returns all feature metrics. If 'withDefaults' is set, then
+// all metrics will have defined all of their possible values.
+func NewMetrics(withDefaults bool) Metrics {
+	return Metrics{
+		ACLBGatewayAPIEnabled: metric.NewGauge(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Help:      "GatewayAPI enabled on the operator",
+			Name:      "gateway_api_enabled",
+		}),
+	}
+}
+
+type featureMetrics interface {
+	update(params enabledFeatures, config *option.OperatorConfig)
+}
+
+func (m Metrics) update(params enabledFeatures, config *option.OperatorConfig) {
+	if config.EnableGatewayAPI {
+		m.ACLBGatewayAPIEnabled.Add(1)
+	}
+}

--- a/pkg/metrics/features/operator/metrics.go
+++ b/pkg/metrics/features/operator/metrics.go
@@ -14,6 +14,7 @@ type Metrics struct {
 	ACLBIngressControllerEnabled        metric.Gauge
 	ACLBIPAMEnabled                     metric.Gauge
 	ACLBL7AwareTrafficManagementEnabled metric.Gauge
+	ACLBNodeIPAMEnabled                 metric.Gauge
 }
 
 const (
@@ -51,6 +52,13 @@ func NewMetrics(withDefaults bool) Metrics {
 			Help:      "L7 Aware Traffic Management enabled on the operator",
 			Name:      "l7_aware_traffic_management_enabled",
 		}),
+
+		ACLBNodeIPAMEnabled: metric.NewGauge(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Help:      "Node IPAM enabled on the operator",
+			Name:      "node_ipam_enabled",
+		}),
 	}
 }
 
@@ -70,5 +78,8 @@ func (m Metrics) update(params enabledFeatures, config *option.OperatorConfig) {
 	}
 	if params.GetLoadBalancerL7() != "" {
 		m.ACLBL7AwareTrafficManagementEnabled.Add(1)
+	}
+	if params.IsNodeIPAMEnabled() {
+		m.ACLBNodeIPAMEnabled.Add(1)
 	}
 }

--- a/pkg/metrics/features/operator/metrics_test.go
+++ b/pkg/metrics/features/operator/metrics_test.go
@@ -12,6 +12,11 @@ import (
 )
 
 type mockFeaturesParams struct {
+	IngressControllerEnabled bool
+}
+
+func (p mockFeaturesParams) IsIngressControllerEnabled() bool {
+	return p.IngressControllerEnabled
 }
 
 func TestUpdateGatewayAPI(t *testing.T) {
@@ -45,6 +50,41 @@ func TestUpdateGatewayAPI(t *testing.T) {
 
 			counterValue := metrics.ACLBGatewayAPIEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableGatewayAPI, counterValue)
+		})
+	}
+}
+
+func TestUpdateIngressControllerEnabled(t *testing.T) {
+	tests := []struct {
+		name                           string
+		enableIngressControllerEnabled bool
+		expected                       float64
+	}{
+		{
+			name:                           "IngressController enabled",
+			enableIngressControllerEnabled: true,
+			expected:                       1,
+		},
+		{
+			name:                           "IngressController disabled",
+			enableIngressControllerEnabled: false,
+			expected:                       0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.OperatorConfig{}
+
+			params := mockFeaturesParams{
+				IngressControllerEnabled: tt.enableIngressControllerEnabled,
+			}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.ACLBIngressControllerEnabled.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableIngressControllerEnabled, counterValue)
 		})
 	}
 }

--- a/pkg/metrics/features/operator/metrics_test.go
+++ b/pkg/metrics/features/operator/metrics_test.go
@@ -13,10 +13,15 @@ import (
 
 type mockFeaturesParams struct {
 	IngressControllerEnabled bool
+	LBIPAMEnabled            bool
 }
 
 func (p mockFeaturesParams) IsIngressControllerEnabled() bool {
 	return p.IngressControllerEnabled
+}
+
+func (p mockFeaturesParams) IsLBIPAMEnabled() bool {
+	return p.LBIPAMEnabled
 }
 
 func TestUpdateGatewayAPI(t *testing.T) {
@@ -85,6 +90,41 @@ func TestUpdateIngressControllerEnabled(t *testing.T) {
 
 			counterValue := metrics.ACLBIngressControllerEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableIngressControllerEnabled, counterValue)
+		})
+	}
+}
+
+func TestUpdateLBIPAMEnabled(t *testing.T) {
+	tests := []struct {
+		name                string
+		enableLBIPAMEnabled bool
+		expected            float64
+	}{
+		{
+			name:                "LBIPAM enabled",
+			enableLBIPAMEnabled: true,
+			expected:            1,
+		},
+		{
+			name:                "LBIPAM disabled",
+			enableLBIPAMEnabled: false,
+			expected:            0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.OperatorConfig{}
+
+			params := mockFeaturesParams{
+				LBIPAMEnabled: tt.enableLBIPAMEnabled,
+			}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.ACLBIPAMEnabled.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableLBIPAMEnabled, counterValue)
 		})
 	}
 }

--- a/pkg/metrics/features/operator/metrics_test.go
+++ b/pkg/metrics/features/operator/metrics_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/operator/option"
+)
+
+type mockFeaturesParams struct {
+}
+
+func TestUpdateGatewayAPI(t *testing.T) {
+	tests := []struct {
+		name             string
+		enableGatewayAPI bool
+		expected         float64
+	}{
+		{
+			name:             "Gateway API enabled",
+			enableGatewayAPI: true,
+			expected:         1,
+		},
+		{
+			name:             "Gateway API disabled",
+			enableGatewayAPI: false,
+			expected:         0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.OperatorConfig{
+				EnableGatewayAPI: tt.enableGatewayAPI,
+			}
+
+			params := mockFeaturesParams{}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.ACLBGatewayAPIEnabled.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableGatewayAPI, counterValue)
+		})
+	}
+}


### PR DESCRIPTION
Follow up of https://github.com/cilium/cilium/pull/35852 but this time for Cilium Operator. I've split in multiple commits so it's easier for each sig to review their section.

**Note for reviewers**: Review on a per-commit basis to make sure the feature of your sig is being detected correctly.

### Features Checklist
- [x] Enable Gateway API (@cilium/sig-servicemesh)
- [x] Enable Ingress Controller (@cilium/sig-servicemesh)
- [x] Enable LBIPAM (@cilium/sig-ipam)
- [x] Enable L7AwareTrafficManagement (@cilium/sig-servicemesh)
- [x] Enable NodeIPAM (@cilium/sig-ipam)