### PR TITLE
Add more features tracking in Cilium agent as prometheus metrics

### DIFF
--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -36,7 +36,10 @@ var Cell = cell.Module(
 
 	// The auth manager is the main entry point which gets registered to signal map and receives auth requests.
 	// In addition, it handles re-authentication and auth map garbage collection.
-	cell.Provide(registerAuthManager),
+	cell.Provide(
+		registerAuthManager,
+		func(c config) MeshAuthConfig { return c },
+	),
 	cell.ProvidePrivate(
 		// Auth handler that performs a mutual auth handshake
 		newMutualAuthHandler,
@@ -65,6 +68,14 @@ func (r config) Flags(flags *pflag.FlagSet) {
 	flags.Duration("mesh-auth-gc-interval", r.MeshAuthGCInterval, "Interval in which auth entries are attempted to be garbage collected")
 	flags.Duration("mesh-auth-signal-backoff-duration", r.MeshAuthSignalBackoffDuration, "Time to wait betweeen two authentication required signals in case of a cache mismatch")
 	flags.MarkHidden("mesh-auth-signal-backoff-duration")
+}
+
+func (r config) IsEnabled() bool {
+	return r.MeshAuthEnabled
+}
+
+type MeshAuthConfig interface {
+	IsEnabled() bool
 }
 
 type authManagerParams struct {

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -77,6 +77,8 @@ var Cell = cell.Module(
 		tables.NewDeviceTable,
 		tables.NewL2AnnounceTable, statedb.RWTable[*tables.L2AnnounceEntry].ToTable,
 		tables.NewRouteTable, statedb.RWTable[*tables.Route].ToTable,
+
+		func() types.BigTCPConfig { return &fakeTypes.BigTCPUserConfig{} },
 	),
 
 	tables.NodeAddressCell,

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
+	"github.com/cilium/cilium/pkg/datapath/garp"
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
@@ -79,6 +80,8 @@ var Cell = cell.Module(
 		tables.NewRouteTable, statedb.RWTable[*tables.Route].ToTable,
 
 		func() types.BigTCPConfig { return &fakeTypes.BigTCPUserConfig{} },
+
+		func() garp.L2PodAnnouncementConfig { return &fakeTypes.GarpConfig{} },
 	),
 
 	tables.NodeAddressCell,

--- a/pkg/datapath/fake/types/bigtcp.go
+++ b/pkg/datapath/fake/types/bigtcp.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+// BigTCPUserConfig are the configuration flags that the user can modify.
+type BigTCPUserConfig struct {
+	// EnableIPv6BIGTCP enables IPv6 BIG TCP (larger GSO/GRO limits) for the node including pods.
+	EnableIPv6BIGTCP bool
+
+	// EnableIPv4BIGTCP enables IPv4 BIG TCP (larger GSO/GRO limits) for the node including pods.
+	EnableIPv4BIGTCP bool
+}
+
+func (def BigTCPUserConfig) IsIPv4Enabled() bool {
+	return def.EnableIPv4BIGTCP
+}
+
+func (def BigTCPUserConfig) IsIPv6Enabled() bool {
+	return def.EnableIPv6BIGTCP
+}

--- a/pkg/datapath/fake/types/garp.go
+++ b/pkg/datapath/fake/types/garp.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+// GarpConfig contains the configuration for the GARP cell.
+type GarpConfig struct {
+	EnableL2PodAnnouncements bool
+}
+
+func (def GarpConfig) Enabled() bool {
+	return def.EnableL2PodAnnouncements
+}
+
+type L2PodAnnouncementConfig interface {
+	Enabled() bool
+}

--- a/pkg/datapath/garp/cells.go
+++ b/pkg/datapath/garp/cells.go
@@ -21,6 +21,10 @@ type Config struct {
 	EnableL2PodAnnouncements    bool
 }
 
+func (def Config) Enabled() bool {
+	return def.EnableL2PodAnnouncements
+}
+
 func (def Config) Flags(flags *pflag.FlagSet) {
 	flags.String(L2PodAnnouncementsInterface, def.L2PodAnnouncementsInterface, "Interface used for sending gratuitous arp messages")
 	flags.Bool(EnableL2PodAnnouncements, def.EnableL2PodAnnouncements, "Enable announcing Pod IPs with Gratuitous ARP")
@@ -38,9 +42,17 @@ var Cell = cell.Module(
 	"l2-pod-announcements-garp",
 	"GARP processor sends gratuitous ARP packets for local pods",
 
-	cell.Provide(newGARPSender),
+	cell.Provide(
+		newGARPSender,
+		func(c Config) L2PodAnnouncementConfig {
+			return c
+		}),
 
 	cell.Config(defaultConfig),
 
 	cell.Invoke(newGARPProcessor),
 )
+
+type L2PodAnnouncementConfig interface {
+	Enabled() bool
+}

--- a/pkg/datapath/linux/bigtcp/bigtcp.go
+++ b/pkg/datapath/linux/bigtcp/bigtcp.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
-	"github.com/spf13/pflag"
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/math"
 	"github.com/cilium/cilium/pkg/option"
@@ -28,28 +28,11 @@ const (
 	bigTCPGSOMaxSize = 196608
 
 	probeDevice = "lo"
-
-	EnableIPv4BIGTCPFlag = "enable-ipv4-big-tcp"
-	EnableIPv6BIGTCPFlag = "enable-ipv6-big-tcp"
 )
 
-// UserConfig are the configuration flags that the user can modify.
-type UserConfig struct {
-	// EnableIPv6BIGTCP enables IPv6 BIG TCP (larger GSO/GRO limits) for the node including pods.
-	EnableIPv6BIGTCP bool
-
-	// EnableIPv4BIGTCP enables IPv4 BIG TCP (larger GSO/GRO limits) for the node including pods.
-	EnableIPv4BIGTCP bool
-}
-
-var defaultUserConfig = UserConfig{
+var defaultUserConfig = types.BigTCPUserConfig{
 	EnableIPv6BIGTCP: false,
 	EnableIPv4BIGTCP: false,
-}
-
-func (def UserConfig) Flags(flags *pflag.FlagSet) {
-	flags.Bool(EnableIPv4BIGTCPFlag, def.EnableIPv4BIGTCP, "Enable IPv4 BIG TCP option which increases device's maximum GRO/GSO limits for IPv4")
-	flags.Bool(EnableIPv6BIGTCPFlag, def.EnableIPv6BIGTCP, "Enable IPv6 BIG TCP option which increases device's maximum GRO/GSO limits for IPv6")
 }
 
 var Cell = cell.Module(
@@ -57,24 +40,25 @@ var Cell = cell.Module(
 	"BIG TCP support",
 
 	cell.Config(defaultUserConfig),
-	cell.Provide(newBIGTCP),
+	cell.Provide(newBIGTCP,
+		func(c types.BigTCPUserConfig) types.BigTCPConfig { return c }),
 	cell.Invoke(func(*Configuration) {}),
 )
 
-func newDefaultConfiguration(userConfig UserConfig) *Configuration {
+func newDefaultConfiguration(userConfig types.BigTCPUserConfig) *Configuration {
 	return &Configuration{
-		UserConfig:     userConfig,
-		groIPv4MaxSize: defaultGROMaxSize,
-		gsoIPv4MaxSize: defaultGSOMaxSize,
-		groIPv6MaxSize: defaultGROMaxSize,
-		gsoIPv6MaxSize: defaultGSOMaxSize,
+		BigTCPUserConfig: userConfig,
+		groIPv4MaxSize:   defaultGROMaxSize,
+		gsoIPv4MaxSize:   defaultGSOMaxSize,
+		groIPv6MaxSize:   defaultGROMaxSize,
+		gsoIPv6MaxSize:   defaultGSOMaxSize,
 	}
 }
 
 // Configuration is the BIG TCP configuration. The values are finalized after
 // BIG TCP has started and must not be read before that.
 type Configuration struct {
-	UserConfig
+	types.BigTCPUserConfig
 
 	// gsoIPv{4,6}MaxSize is the GSO maximum size used when configuring
 	// devices.
@@ -115,7 +99,7 @@ func (c *Configuration) GetGSOIPv4MaxSize() int {
 
 // If an error is returned the caller is responsible for rolling back
 // any partial changes.
-func setGROGSOIPv6MaxSize(log *slog.Logger, userConfig UserConfig, device string, GROMaxSize, GSOMaxSize int) error {
+func setGROGSOIPv6MaxSize(log *slog.Logger, userConfig types.BigTCPUserConfig, device string, GROMaxSize, GSOMaxSize int) error {
 	link, err := safenetlink.LinkByName(device)
 	if err != nil {
 		log.Warn("Link does not exist", logfields.Device, device, logfields.Error, err)
@@ -143,7 +127,7 @@ func setGROGSOIPv6MaxSize(log *slog.Logger, userConfig UserConfig, device string
 
 // If an error is returned the caller is responsible for rolling back
 // any partial changes.
-func setGROGSOIPv4MaxSize(log *slog.Logger, userConfig UserConfig, device string, GROMaxSize, GSOMaxSize int) error {
+func setGROGSOIPv4MaxSize(log *slog.Logger, userConfig types.BigTCPUserConfig, device string, GROMaxSize, GSOMaxSize int) error {
 	link, err := safenetlink.LinkByName(device)
 	if err != nil {
 		log.Warn("Link does not exist", logfields.Device, device, logfields.Error, err)
@@ -212,12 +196,12 @@ type params struct {
 
 	Log          *slog.Logger
 	DaemonConfig *option.DaemonConfig
-	UserConfig   UserConfig
+	UserConfig   types.BigTCPUserConfig
 	DB           *statedb.DB
 	Devices      statedb.Table[*tables.Device]
 }
 
-func validateConfig(cfg UserConfig, daemonCfg *option.DaemonConfig) error {
+func validateConfig(cfg types.BigTCPUserConfig, daemonCfg *option.DaemonConfig) error {
 	if cfg.EnableIPv6BIGTCP || cfg.EnableIPv4BIGTCP {
 		if daemonCfg.DatapathMode == datapathOption.DatapathModeLBOnly {
 			return errors.New("BIG TCP is supported only in veth & netkit datapath mode")
@@ -269,13 +253,13 @@ func startBIGTCP(p params, cfg *Configuration) error {
 
 	if !haveIPv4 {
 		if p.UserConfig.EnableIPv4BIGTCP {
-			p.Log.Warn("Cannot enable --" + EnableIPv4BIGTCPFlag + ", needs kernel 6.3 or newer")
+			p.Log.Warn("Cannot enable --" + types.EnableIPv4BIGTCPFlag + ", needs kernel 6.3 or newer")
 		}
 		p.UserConfig.EnableIPv4BIGTCP = false
 	}
 	if !haveIPv6 {
 		if p.UserConfig.EnableIPv6BIGTCP {
-			p.Log.Warn("Cannot enable --" + EnableIPv6BIGTCPFlag + ", needs kernel 5.19 or newer")
+			p.Log.Warn("Cannot enable --" + types.EnableIPv6BIGTCPFlag + ", needs kernel 5.19 or newer")
 		}
 		p.UserConfig.EnableIPv6BIGTCP = false
 	}

--- a/pkg/datapath/types/bigtcp.go
+++ b/pkg/datapath/types/bigtcp.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"github.com/spf13/pflag"
+)
+
+const (
+	EnableIPv4BIGTCPFlag = "enable-ipv4-big-tcp"
+	EnableIPv6BIGTCPFlag = "enable-ipv6-big-tcp"
+)
+
+// BigTCPUserConfig are the configuration flags that the user can modify.
+type BigTCPUserConfig struct {
+	// EnableIPv6BIGTCP enables IPv6 BIG TCP (larger GSO/GRO limits) for the node including pods.
+	EnableIPv6BIGTCP bool
+
+	// EnableIPv4BIGTCP enables IPv4 BIG TCP (larger GSO/GRO limits) for the node including pods.
+	EnableIPv4BIGTCP bool
+}
+
+func (def BigTCPUserConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool(EnableIPv4BIGTCPFlag, def.EnableIPv4BIGTCP, "Enable IPv4 BIG TCP option which increases device's maximum GRO/GSO limits for IPv4")
+	flags.Bool(EnableIPv6BIGTCPFlag, def.EnableIPv6BIGTCP, "Enable IPv6 BIG TCP option which increases device's maximum GRO/GSO limits for IPv6")
+}
+
+func (def BigTCPUserConfig) IsIPv4Enabled() bool {
+	return def.EnableIPv4BIGTCP
+}
+
+func (def BigTCPUserConfig) IsIPv6Enabled() bool {
+	return def.EnableIPv6BIGTCP
+}
+
+type BigTCPConfig interface {
+	IsIPv4Enabled() bool
+	IsIPv6Enabled() bool
+}

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/auth"
+	"github.com/cilium/cilium/pkg/datapath/garp"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -46,11 +47,12 @@ type featuresParams struct {
 	ConfigPromise promise.Promise[*option.DaemonConfig]
 	Metrics       featureMetrics
 
-	TunnelConfig     tunnel.Config
-	CNIConfigManager cni.CNIConfigManager
-	MutualAuth       auth.MeshAuthConfig
-	BandwidthManager types.BandwidthManager
-	BigTCP           types.BigTCPConfig
+	TunnelConfig      tunnel.Config
+	CNIConfigManager  cni.CNIConfigManager
+	MutualAuth        auth.MeshAuthConfig
+	BandwidthManager  types.BandwidthManager
+	BigTCP            types.BigTCPConfig
+	L2PodAnnouncement garp.L2PodAnnouncementConfig
 }
 
 func (fp *featuresParams) TunnelProtocol() tunnel.Protocol {
@@ -73,10 +75,15 @@ func (fp *featuresParams) BigTCPConfig() types.BigTCPConfig {
 	return fp.BigTCP
 }
 
+func (fp *featuresParams) IsL2PodAnnouncementEnabled() bool {
+	return fp.L2PodAnnouncement.Enabled()
+}
+
 type enabledFeatures interface {
 	TunnelProtocol() tunnel.Protocol
 	GetChainingMode() string
 	IsMutualAuthEnabled() bool
 	IsBandwidthManagerEnabled() bool
 	BigTCPConfig() types.BigTCPConfig
+	IsL2PodAnnouncementEnabled() bool
 }

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/garp"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/dynamicconfig"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
@@ -47,12 +48,13 @@ type featuresParams struct {
 	ConfigPromise promise.Promise[*option.DaemonConfig]
 	Metrics       featureMetrics
 
-	TunnelConfig      tunnel.Config
-	CNIConfigManager  cni.CNIConfigManager
-	MutualAuth        auth.MeshAuthConfig
-	BandwidthManager  types.BandwidthManager
-	BigTCP            types.BigTCPConfig
-	L2PodAnnouncement garp.L2PodAnnouncementConfig
+	TunnelConfig        tunnel.Config
+	CNIConfigManager    cni.CNIConfigManager
+	MutualAuth          auth.MeshAuthConfig
+	BandwidthManager    types.BandwidthManager
+	BigTCP              types.BigTCPConfig
+	L2PodAnnouncement   garp.L2PodAnnouncementConfig
+	DynamicConfigSource dynamicconfig.ConfigSource
 }
 
 func (fp *featuresParams) TunnelProtocol() tunnel.Protocol {
@@ -79,6 +81,10 @@ func (fp *featuresParams) IsL2PodAnnouncementEnabled() bool {
 	return fp.L2PodAnnouncement.Enabled()
 }
 
+func (fp *featuresParams) IsDynamicConfigSourceKindNodeConfig() bool {
+	return fp.DynamicConfigSource.IsKindNodeConfig()
+}
+
 type enabledFeatures interface {
 	TunnelProtocol() tunnel.Protocol
 	GetChainingMode() string
@@ -86,4 +92,5 @@ type enabledFeatures interface {
 	IsBandwidthManagerEnabled() bool
 	BigTCPConfig() types.BigTCPConfig
 	IsL2PodAnnouncementEnabled() bool
+	IsDynamicConfigSourceKindNodeConfig() bool
 }

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/auth"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
@@ -48,6 +49,7 @@ type featuresParams struct {
 	TunnelConfig     tunnel.Config
 	CNIConfigManager cni.CNIConfigManager
 	MutualAuth       auth.MeshAuthConfig
+	BandwidthManager types.BandwidthManager
 }
 
 func (fp *featuresParams) TunnelProtocol() tunnel.Protocol {
@@ -62,8 +64,13 @@ func (fp *featuresParams) IsMutualAuthEnabled() bool {
 	return fp.MutualAuth.IsEnabled()
 }
 
+func (fp *featuresParams) IsBandwidthManagerEnabled() bool {
+	return fp.BandwidthManager.Enabled()
+}
+
 type enabledFeatures interface {
 	TunnelProtocol() tunnel.Protocol
 	GetChainingMode() string
 	IsMutualAuthEnabled() bool
+	IsBandwidthManagerEnabled() bool
 }

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -50,6 +50,7 @@ type featuresParams struct {
 	CNIConfigManager cni.CNIConfigManager
 	MutualAuth       auth.MeshAuthConfig
 	BandwidthManager types.BandwidthManager
+	BigTCP           types.BigTCPConfig
 }
 
 func (fp *featuresParams) TunnelProtocol() tunnel.Protocol {
@@ -68,9 +69,14 @@ func (fp *featuresParams) IsBandwidthManagerEnabled() bool {
 	return fp.BandwidthManager.Enabled()
 }
 
+func (fp *featuresParams) BigTCPConfig() types.BigTCPConfig {
+	return fp.BigTCP
+}
+
 type enabledFeatures interface {
 	TunnelProtocol() tunnel.Protocol
 	GetChainingMode() string
 	IsMutualAuthEnabled() bool
 	IsBandwidthManagerEnabled() bool
+	BigTCPConfig() types.BigTCPConfig
 }

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/hive/job"
 
 	"github.com/cilium/cilium/daemon/cmd/cni"
+	"github.com/cilium/cilium/pkg/auth"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
@@ -46,6 +47,7 @@ type featuresParams struct {
 
 	TunnelConfig     tunnel.Config
 	CNIConfigManager cni.CNIConfigManager
+	MutualAuth       auth.MeshAuthConfig
 }
 
 func (fp *featuresParams) TunnelProtocol() tunnel.Protocol {
@@ -56,7 +58,12 @@ func (fp *featuresParams) GetChainingMode() string {
 	return fp.CNIConfigManager.GetChainingMode()
 }
 
+func (fp *featuresParams) IsMutualAuthEnabled() bool {
+	return fp.MutualAuth.IsEnabled()
+}
+
 type enabledFeatures interface {
 	TunnelProtocol() tunnel.Protocol
 	GetChainingMode() string
+	IsMutualAuthEnabled() bool
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -23,7 +23,8 @@ type Metrics struct {
 	DPCiliumEndpointSlicesEnabled metric.Gauge
 	DPDeviceMode                  metric.Vec[metric.Gauge]
 
-	NPHostFirewallEnabled metric.Gauge
+	NPHostFirewallEnabled        metric.Gauge
+	NPLocalRedirectPolicyEnabled metric.Gauge
 }
 
 const (
@@ -221,6 +222,13 @@ func NewMetrics(withDefaults bool) Metrics {
 			Subsystem: subsystemNP,
 			Name:      "host_firewall_enabled",
 		}),
+
+		NPLocalRedirectPolicyEnabled: metric.NewGauge(metric.GaugeOpts{
+			Help:      "Local Redirect Policy enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "local_redirect_policy_enabled",
+		}),
 	}
 }
 
@@ -269,5 +277,9 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 
 	if config.EnableHostFirewall {
 		m.NPHostFirewallEnabled.Add(1)
+	}
+
+	if config.EnableLocalRedirectPolicy {
+		m.NPLocalRedirectPolicyEnabled.Add(1)
 	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -22,10 +22,13 @@ type Metrics struct {
 	DPIdentityAllocation          metric.Vec[metric.Gauge]
 	DPCiliumEndpointSlicesEnabled metric.Gauge
 	DPDeviceMode                  metric.Vec[metric.Gauge]
+
+	NPHostFirewallEnabled metric.Gauge
 }
 
 const (
 	subsystemDP = "feature_datapath"
+	subsystemNP = "feature_network_policies"
 )
 
 const (
@@ -211,6 +214,13 @@ func NewMetrics(withDefaults bool) Metrics {
 				}(),
 			},
 		}),
+
+		NPHostFirewallEnabled: metric.NewGauge(metric.GaugeOpts{
+			Help:      "Host firewall enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "host_firewall_enabled",
+		}),
 	}
 }
 
@@ -256,4 +266,8 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 
 	deviceMode := config.DatapathMode
 	m.DPDeviceMode.WithLabelValues(deviceMode).Add(1)
+
+	if config.EnableHostFirewall {
+		m.NPHostFirewallEnabled.Add(1)
+	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy/api"
 )
 
 // Metrics represents a collection of metrics related to a specific feature.
@@ -27,6 +28,7 @@ type Metrics struct {
 	NPLocalRedirectPolicyEnabled metric.Gauge
 	NPMutualAuthEnabled          metric.Gauge
 	NPNonDefaultDenyEnabled      metric.Gauge
+	NPCIDRPoliciesToNodes        metric.Vec[metric.Gauge]
 }
 
 const (
@@ -96,6 +98,11 @@ var (
 		datapathOption.DatapathModeNetkit,
 		datapathOption.DatapathModeNetkitL2,
 		datapathOption.DatapathModeLBOnly,
+	}
+
+	defaultCIDRPolicies = []string{
+		string(api.EntityWorld),
+		string(api.EntityRemoteNode),
 	}
 )
 
@@ -245,6 +252,24 @@ func NewMetrics(withDefaults bool) Metrics {
 			Subsystem: subsystemNP,
 			Name:      "non_defaultdeny_policies_enabled",
 		}),
+
+		NPCIDRPoliciesToNodes: metric.NewGaugeVecWithLabels(metric.GaugeOpts{
+			Help:      "Mode to apply CIDR Policies to Nodes",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "cidr_policies",
+		}, metric.Labels{
+			{
+				Name: "mode", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultCIDRPolicies...,
+					)
+				}(),
+			},
+		}),
 	}
 }
 
@@ -305,5 +330,9 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 
 	if config.EnableNonDefaultDenyPolicies {
 		m.NPNonDefaultDenyEnabled.Add(1)
+	}
+
+	for _, mode := range config.PolicyCIDRMatchMode {
+		m.NPCIDRPoliciesToNodes.WithLabelValues(mode).Add(1)
 	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -34,6 +34,7 @@ type Metrics struct {
 	ACLBKubeProxyReplacementEnabled metric.Gauge
 	ACLBNodePortConfig              metric.Vec[metric.Gauge]
 	ACLBBGPEnabled                  metric.Gauge
+	ACLBEgressGatewayEnabled        metric.Gauge
 }
 
 const (
@@ -384,6 +385,13 @@ func NewMetrics(withDefaults bool) Metrics {
 			Subsystem: subsystemACLB,
 			Name:      "bgp_advertisement_enabled",
 		}),
+
+		ACLBEgressGatewayEnabled: metric.NewGauge(metric.GaugeOpts{
+			Help:      "Egress Gateway enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Name:      "egress_gateway_enabled",
+		}),
 	}
 }
 
@@ -473,5 +481,9 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 
 	if config.BGPAnnouncePodCIDR || config.BGPAnnounceLBIP || config.EnableBGPControlPlane {
 		m.ACLBBGPEnabled.Add(1)
+	}
+
+	if config.EnableIPv4EgressGateway {
+		m.ACLBEgressGatewayEnabled.Add(1)
 	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -30,13 +30,14 @@ type Metrics struct {
 	NPNonDefaultDenyEnabled      metric.Gauge
 	NPCIDRPoliciesToNodes        metric.Vec[metric.Gauge]
 
-	ACLBTransparentEncryption       metric.Vec[metric.Gauge]
-	ACLBKubeProxyReplacementEnabled metric.Gauge
-	ACLBNodePortConfig              metric.Vec[metric.Gauge]
-	ACLBBGPEnabled                  metric.Gauge
-	ACLBEgressGatewayEnabled        metric.Gauge
-	ACLBBandwidthManagerEnabled     metric.Gauge
-	ACLBSCTPEnabled                 metric.Gauge
+	ACLBTransparentEncryption        metric.Vec[metric.Gauge]
+	ACLBKubeProxyReplacementEnabled  metric.Gauge
+	ACLBNodePortConfig               metric.Vec[metric.Gauge]
+	ACLBBGPEnabled                   metric.Gauge
+	ACLBEgressGatewayEnabled         metric.Gauge
+	ACLBBandwidthManagerEnabled      metric.Gauge
+	ACLBSCTPEnabled                  metric.Gauge
+	ACLBInternalTrafficPolicyEnabled metric.Gauge
 }
 
 const (
@@ -408,6 +409,13 @@ func NewMetrics(withDefaults bool) Metrics {
 			Subsystem: subsystemACLB,
 			Name:      "sctp_enabled",
 		}),
+
+		ACLBInternalTrafficPolicyEnabled: metric.NewGauge(metric.GaugeOpts{
+			Help:      "K8s Internal Traffic Policy enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Name:      "k8s_internal_traffic_policy_enabled",
+		}),
 	}
 }
 
@@ -509,5 +517,9 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 
 	if config.EnableSCTP {
 		m.ACLBSCTPEnabled.Add(1)
+	}
+
+	if config.EnableInternalTrafficPolicy {
+		m.ACLBInternalTrafficPolicyEnabled.Add(1)
 	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -38,6 +38,7 @@ type Metrics struct {
 	ACLBBandwidthManagerEnabled      metric.Gauge
 	ACLBSCTPEnabled                  metric.Gauge
 	ACLBInternalTrafficPolicyEnabled metric.Gauge
+	ACLBVTEPEnabled                  metric.Gauge
 }
 
 const (
@@ -416,6 +417,13 @@ func NewMetrics(withDefaults bool) Metrics {
 			Subsystem: subsystemACLB,
 			Name:      "k8s_internal_traffic_policy_enabled",
 		}),
+
+		ACLBVTEPEnabled: metric.NewGauge(metric.GaugeOpts{
+			Help:      "VTEP enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Name:      "vtep_enabled",
+		}),
 	}
 }
 
@@ -521,5 +529,9 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 
 	if config.EnableInternalTrafficPolicy {
 		m.ACLBInternalTrafficPolicyEnabled.Add(1)
+	}
+
+	if config.EnableVTEP {
+		m.ACLBVTEPEnabled.Add(1)
 	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -33,6 +33,7 @@ type Metrics struct {
 	ACLBTransparentEncryption       metric.Vec[metric.Gauge]
 	ACLBKubeProxyReplacementEnabled metric.Gauge
 	ACLBNodePortConfig              metric.Vec[metric.Gauge]
+	ACLBBGPEnabled                  metric.Gauge
 }
 
 const (
@@ -376,6 +377,13 @@ func NewMetrics(withDefaults bool) Metrics {
 				}(),
 			},
 		}),
+
+		ACLBBGPEnabled: metric.NewGauge(metric.GaugeOpts{
+			Help:      "BGP Advertisement enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Name:      "bgp_advertisement_enabled",
+		}),
 	}
 }
 
@@ -462,4 +470,8 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 	}
 
 	m.ACLBNodePortConfig.WithLabelValues(config.NodePortMode, config.NodePortAlg, config.NodePortAcceleration).Add(1)
+
+	if config.BGPAnnouncePodCIDR || config.BGPAnnounceLBIP || config.EnableBGPControlPlane {
+		m.ACLBBGPEnabled.Add(1)
+	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -30,7 +30,8 @@ type Metrics struct {
 	NPNonDefaultDenyEnabled      metric.Gauge
 	NPCIDRPoliciesToNodes        metric.Vec[metric.Gauge]
 
-	ACLBTransparentEncryption metric.Vec[metric.Gauge]
+	ACLBTransparentEncryption       metric.Vec[metric.Gauge]
+	ACLBKubeProxyReplacementEnabled metric.Gauge
 }
 
 const (
@@ -310,6 +311,13 @@ func NewMetrics(withDefaults bool) Metrics {
 				}(),
 			},
 		}),
+
+		ACLBKubeProxyReplacementEnabled: metric.NewGauge(metric.GaugeOpts{
+			Help:      "KubeProxyReplacement enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Name:      "kube_proxy_replacement_enabled",
+		}),
 	}
 }
 
@@ -389,5 +397,9 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 		} else {
 			m.ACLBTransparentEncryption.WithLabelValues(advConnNetEncWireGuard, "false").Add(1)
 		}
+	}
+
+	if config.KubeProxyReplacement == option.KubeProxyReplacementTrue {
+		m.ACLBKubeProxyReplacementEnabled.Add(1)
 	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -26,6 +26,7 @@ type Metrics struct {
 	NPHostFirewallEnabled        metric.Gauge
 	NPLocalRedirectPolicyEnabled metric.Gauge
 	NPMutualAuthEnabled          metric.Gauge
+	NPNonDefaultDenyEnabled      metric.Gauge
 }
 
 const (
@@ -237,6 +238,13 @@ func NewMetrics(withDefaults bool) Metrics {
 			Subsystem: subsystemNP,
 			Name:      "mutual_auth_enabled",
 		}),
+
+		NPNonDefaultDenyEnabled: metric.NewGauge(metric.GaugeOpts{
+			Help:      "Non DefaultDeny Policies is enabled in the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "non_defaultdeny_policies_enabled",
+		}),
 	}
 }
 
@@ -293,5 +301,9 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 
 	if params.IsMutualAuthEnabled() {
 		m.NPMutualAuthEnabled.Add(1)
+	}
+
+	if config.EnableNonDefaultDenyPolicies {
+		m.NPNonDefaultDenyEnabled.Add(1)
 	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -43,6 +43,7 @@ type Metrics struct {
 	ACLBBigTCPEnabled                metric.Vec[metric.Gauge]
 	ACLBL2LBEnabled                  metric.Gauge
 	ACLBL2PodAnnouncementEnabled     metric.Gauge
+	ACLBExternalEnvoyProxyEnabled    metric.Vec[metric.Gauge]
 }
 
 const (
@@ -73,6 +74,9 @@ const (
 	advConnBigTCPIPv4      = "ipv4-only"
 	advConnBigTCPIPv6      = "ipv6-only"
 	advConnBigTCPDualStack = "ipv4-ipv6-dual-stack"
+
+	advConnExtEnvoyProxyStandalone = "standalone"
+	advConnExtEnvoyProxyEmbedded   = "embedded"
 )
 
 var (
@@ -155,6 +159,11 @@ var (
 		advConnBigTCPIPv4,
 		advConnBigTCPIPv6,
 		advConnBigTCPDualStack,
+	}
+
+	defaultExternalEnvoyProxyModes = []string{
+		advConnExtEnvoyProxyStandalone,
+		advConnExtEnvoyProxyEmbedded,
 	}
 )
 
@@ -477,6 +486,24 @@ func NewMetrics(withDefaults bool) Metrics {
 			Subsystem: subsystemACLB,
 			Name:      "l2_pod_announcement_enabled",
 		}),
+
+		ACLBExternalEnvoyProxyEnabled: metric.NewGaugeVecWithLabels(metric.GaugeOpts{
+			Help:      "Envoy Proxy mode enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Name:      "envoy_proxy_enabled",
+		}, metric.Labels{
+			{
+				Name: "mode", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultExternalEnvoyProxyModes...,
+					)
+				}(),
+			},
+		}),
 	}
 }
 
@@ -612,5 +639,11 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 
 	if params.IsL2PodAnnouncementEnabled() {
 		m.ACLBL2PodAnnouncementEnabled.Add(1)
+	}
+
+	if config.ExternalEnvoyProxy {
+		m.ACLBExternalEnvoyProxyEnabled.WithLabelValues(advConnExtEnvoyProxyStandalone).Add(1)
+	} else {
+		m.ACLBExternalEnvoyProxyEnabled.WithLabelValues(advConnExtEnvoyProxyEmbedded).Add(1)
 	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -35,6 +35,7 @@ type Metrics struct {
 	ACLBNodePortConfig              metric.Vec[metric.Gauge]
 	ACLBBGPEnabled                  metric.Gauge
 	ACLBEgressGatewayEnabled        metric.Gauge
+	ACLBBandwidthManagerEnabled     metric.Gauge
 }
 
 const (
@@ -392,6 +393,13 @@ func NewMetrics(withDefaults bool) Metrics {
 			Subsystem: subsystemACLB,
 			Name:      "egress_gateway_enabled",
 		}),
+
+		ACLBBandwidthManagerEnabled: metric.NewGauge(metric.GaugeOpts{
+			Help:      "Bandwidth Manager enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Name:      "bandwidth_manager_enabled",
+		}),
 	}
 }
 
@@ -485,5 +493,9 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 
 	if config.EnableIPv4EgressGateway {
 		m.ACLBEgressGatewayEnabled.Add(1)
+	}
+
+	if params.IsBandwidthManagerEnabled() {
+		m.ACLBBandwidthManagerEnabled.Add(1)
 	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -44,6 +44,7 @@ type Metrics struct {
 	ACLBL2LBEnabled                  metric.Gauge
 	ACLBL2PodAnnouncementEnabled     metric.Gauge
 	ACLBExternalEnvoyProxyEnabled    metric.Vec[metric.Gauge]
+	ACLBCiliumNodeConfigEnabled      metric.Gauge
 }
 
 const (
@@ -504,6 +505,13 @@ func NewMetrics(withDefaults bool) Metrics {
 				}(),
 			},
 		}),
+
+		ACLBCiliumNodeConfigEnabled: metric.NewGauge(metric.GaugeOpts{
+			Help:      "Cilium Node Config enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Name:      "cilium_node_config_enabled",
+		}),
 	}
 }
 
@@ -645,5 +653,9 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 		m.ACLBExternalEnvoyProxyEnabled.WithLabelValues(advConnExtEnvoyProxyStandalone).Add(1)
 	} else {
 		m.ACLBExternalEnvoyProxyEnabled.WithLabelValues(advConnExtEnvoyProxyEmbedded).Add(1)
+	}
+
+	if params.IsDynamicConfigSourceKindNodeConfig() {
+		m.ACLBCiliumNodeConfigEnabled.Add(1)
 	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -39,6 +39,7 @@ type Metrics struct {
 	ACLBSCTPEnabled                  metric.Gauge
 	ACLBInternalTrafficPolicyEnabled metric.Gauge
 	ACLBVTEPEnabled                  metric.Gauge
+	ACLBCiliumEnvoyConfigEnabled     metric.Gauge
 }
 
 const (
@@ -424,6 +425,13 @@ func NewMetrics(withDefaults bool) Metrics {
 			Subsystem: subsystemACLB,
 			Name:      "vtep_enabled",
 		}),
+
+		ACLBCiliumEnvoyConfigEnabled: metric.NewGauge(metric.GaugeOpts{
+			Help:      "Cilium Envoy Config enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Name:      "cilium_envoy_config_enabled",
+		}),
 	}
 }
 
@@ -533,5 +541,9 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 
 	if config.EnableVTEP {
 		m.ACLBVTEPEnabled.Add(1)
+	}
+
+	if config.EnableEnvoyConfig {
+		m.ACLBCiliumEnvoyConfigEnabled.Add(1)
 	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -40,6 +40,7 @@ type Metrics struct {
 	ACLBInternalTrafficPolicyEnabled metric.Gauge
 	ACLBVTEPEnabled                  metric.Gauge
 	ACLBCiliumEnvoyConfigEnabled     metric.Gauge
+	ACLBBigTCPEnabled                metric.Vec[metric.Gauge]
 }
 
 const (
@@ -66,6 +67,10 @@ const (
 
 	advConnNetEncIPSec     = "ipsec"
 	advConnNetEncWireGuard = "wireguard"
+
+	advConnBigTCPIPv4      = "ipv4-only"
+	advConnBigTCPIPv6      = "ipv6-only"
+	advConnBigTCPDualStack = "ipv4-ipv6-dual-stack"
 )
 
 var (
@@ -142,6 +147,12 @@ var (
 		option.NodePortAccelerationGeneric,
 		option.NodePortAccelerationBestEffort,
 		option.NodePortAccelerationNative,
+	}
+
+	defaultBigTCPAddressFamilies = []string{
+		advConnBigTCPIPv4,
+		advConnBigTCPIPv6,
+		advConnBigTCPDualStack,
 	}
 )
 
@@ -432,6 +443,24 @@ func NewMetrics(withDefaults bool) Metrics {
 			Subsystem: subsystemACLB,
 			Name:      "cilium_envoy_config_enabled",
 		}),
+
+		ACLBBigTCPEnabled: metric.NewGaugeVecWithLabels(metric.GaugeOpts{
+			Help:      "Big TCP enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Name:      "big_tcp_enabled",
+		}, metric.Labels{
+			{
+				Name: "address_family", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultBigTCPAddressFamilies...,
+					)
+				}(),
+			},
+		}),
 	}
 }
 
@@ -545,5 +574,19 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 
 	if config.EnableEnvoyConfig {
 		m.ACLBCiliumEnvoyConfigEnabled.Add(1)
+	}
+
+	var bigTCPProto string
+	switch {
+	case params.BigTCPConfig().IsIPv4Enabled() && params.BigTCPConfig().IsIPv6Enabled():
+		bigTCPProto = advConnBigTCPDualStack
+	case params.BigTCPConfig().IsIPv4Enabled():
+		bigTCPProto = advConnBigTCPIPv4
+	case params.BigTCPConfig().IsIPv6Enabled():
+		bigTCPProto = advConnBigTCPIPv6
+	}
+
+	if bigTCPProto != "" {
+		m.ACLBBigTCPEnabled.WithLabelValues(bigTCPProto).Add(1)
 	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -32,6 +32,7 @@ type Metrics struct {
 
 	ACLBTransparentEncryption       metric.Vec[metric.Gauge]
 	ACLBKubeProxyReplacementEnabled metric.Gauge
+	ACLBNodePortConfig              metric.Vec[metric.Gauge]
 }
 
 const (
@@ -115,6 +116,25 @@ var (
 	defaultEncryptionModes = []string{
 		advConnNetEncIPSec,
 		advConnNetEncWireGuard,
+	}
+
+	defaultNodePortModes = []string{
+		option.NodePortModeSNAT,
+		option.NodePortModeDSR,
+		option.NodePortModeAnnotation,
+		option.NodePortModeHybrid,
+	}
+
+	defaultNodePortModeAlgorithms = []string{
+		option.NodePortAlgMaglev,
+		option.NodePortAlgRandom,
+	}
+
+	defaultNodePortModeAccelerations = []string{
+		option.NodePortAccelerationDisabled,
+		option.NodePortAccelerationGeneric,
+		option.NodePortAccelerationBestEffort,
+		option.NodePortAccelerationNative,
 	}
 )
 
@@ -318,6 +338,44 @@ func NewMetrics(withDefaults bool) Metrics {
 			Subsystem: subsystemACLB,
 			Name:      "kube_proxy_replacement_enabled",
 		}),
+
+		ACLBNodePortConfig: metric.NewGaugeVecWithLabels(metric.GaugeOpts{
+			Help:      "Node Port configuration enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Name:      "node_port_configuration",
+		}, metric.Labels{
+			{
+				Name: "mode", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultNodePortModes...,
+					)
+				}(),
+			},
+			{
+				Name: "algorithm", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultNodePortModeAlgorithms...,
+					)
+				}(),
+			},
+			{
+				Name: "acceleration", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultNodePortModeAccelerations...,
+					)
+				}(),
+			},
+		}),
 	}
 }
 
@@ -402,4 +460,6 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 	if config.KubeProxyReplacement == option.KubeProxyReplacementTrue {
 		m.ACLBKubeProxyReplacementEnabled.Add(1)
 	}
+
+	m.ACLBNodePortConfig.WithLabelValues(config.NodePortMode, config.NodePortAlg, config.NodePortAcceleration).Add(1)
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -41,6 +41,8 @@ type Metrics struct {
 	ACLBVTEPEnabled                  metric.Gauge
 	ACLBCiliumEnvoyConfigEnabled     metric.Gauge
 	ACLBBigTCPEnabled                metric.Vec[metric.Gauge]
+	ACLBL2LBEnabled                  metric.Gauge
+	ACLBL2PodAnnouncementEnabled     metric.Gauge
 }
 
 const (
@@ -461,6 +463,20 @@ func NewMetrics(withDefaults bool) Metrics {
 				}(),
 			},
 		}),
+
+		ACLBL2LBEnabled: metric.NewGauge(metric.GaugeOpts{
+			Help:      "L2 LB announcement enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Name:      "l2_lb_enabled",
+		}),
+
+		ACLBL2PodAnnouncementEnabled: metric.NewGauge(metric.GaugeOpts{
+			Help:      "L2 pod announcement enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Name:      "l2_pod_announcement_enabled",
+		}),
 	}
 }
 
@@ -588,5 +604,13 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 
 	if bigTCPProto != "" {
 		m.ACLBBigTCPEnabled.WithLabelValues(bigTCPProto).Add(1)
+	}
+
+	if config.EnableL2Announcements {
+		m.ACLBL2LBEnabled.Add(1)
+	}
+
+	if params.IsL2PodAnnouncementEnabled() {
+		m.ACLBL2PodAnnouncementEnabled.Add(1)
 	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -25,6 +25,7 @@ type Metrics struct {
 
 	NPHostFirewallEnabled        metric.Gauge
 	NPLocalRedirectPolicyEnabled metric.Gauge
+	NPMutualAuthEnabled          metric.Gauge
 }
 
 const (
@@ -229,6 +230,13 @@ func NewMetrics(withDefaults bool) Metrics {
 			Subsystem: subsystemNP,
 			Name:      "local_redirect_policy_enabled",
 		}),
+
+		NPMutualAuthEnabled: metric.NewGauge(metric.GaugeOpts{
+			Help:      "Mutual Auth enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "mutual_auth_enabled",
+		}),
 	}
 }
 
@@ -281,5 +289,9 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 
 	if config.EnableLocalRedirectPolicy {
 		m.NPLocalRedirectPolicyEnabled.Add(1)
+	}
+
+	if params.IsMutualAuthEnabled() {
+		m.NPMutualAuthEnabled.Add(1)
 	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -36,6 +36,7 @@ type Metrics struct {
 	ACLBBGPEnabled                  metric.Gauge
 	ACLBEgressGatewayEnabled        metric.Gauge
 	ACLBBandwidthManagerEnabled     metric.Gauge
+	ACLBSCTPEnabled                 metric.Gauge
 }
 
 const (
@@ -400,6 +401,13 @@ func NewMetrics(withDefaults bool) Metrics {
 			Subsystem: subsystemACLB,
 			Name:      "bandwidth_manager_enabled",
 		}),
+
+		ACLBSCTPEnabled: metric.NewGauge(metric.GaugeOpts{
+			Help:      "SCTP enabled on the agent",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemACLB,
+			Name:      "sctp_enabled",
+		}),
 	}
 }
 
@@ -497,5 +505,9 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig) {
 
 	if params.IsBandwidthManagerEnabled() {
 		m.ACLBBandwidthManagerEnabled.Add(1)
+	}
+
+	if config.EnableSCTP {
+		m.ACLBSCTPEnabled.Add(1)
 	}
 }

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -414,3 +414,44 @@ func TestUpdateHostFirewall(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateLocalRedirectPolicies(t *testing.T) {
+	tests := []struct {
+		name      string
+		enableLRP bool
+		expected  float64
+	}{
+		{
+			name:      "LRP enabled",
+			enableLRP: true,
+			expected:  1,
+		},
+		{
+			name:      "LRP disabled",
+			enableLRP: false,
+			expected:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				IPAM:                      defaultIPAMModes[0],
+				EnableIPv4:                true,
+				IdentityAllocationMode:    defaultIdentityAllocationModes[0],
+				DatapathMode:              defaultDeviceModes[0],
+				EnableLocalRedirectPolicy: tt.enableLRP,
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.NPLocalRedirectPolicyEnabled.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableLRP, counterValue)
+		})
+	}
+}

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -671,3 +671,44 @@ func TestUpdateEncryptionMode(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateKubeProxyReplacement(t *testing.T) {
+	tests := []struct {
+		name                       string
+		enableKubeProxyReplacement string
+		expected                   float64
+	}{
+		{
+			name:                       "KubeProxyReplacement enabled",
+			enableKubeProxyReplacement: "true",
+			expected:                   1,
+		},
+		{
+			name:                       "KubeProxyReplacement disabled",
+			enableKubeProxyReplacement: "false",
+			expected:                   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
+				DatapathMode:           defaultDeviceModes[0],
+				KubeProxyReplacement:   tt.enableKubeProxyReplacement,
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.ACLBKubeProxyReplacementEnabled.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableKubeProxyReplacement, counterValue)
+		})
+	}
+}

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -590,3 +590,84 @@ func TestUpdateCIDRPolicyModeToNode(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateEncryptionMode(t *testing.T) {
+	tests := []struct {
+		name                      string
+		enableIPSec               bool
+		enableWireguard           bool
+		enableNode2NodeEncryption bool
+
+		expectEncryptionMode      string
+		expectNode2NodeEncryption string
+	}{
+		{
+			name:                      "IPSec enabled",
+			enableIPSec:               true,
+			expectEncryptionMode:      advConnNetEncIPSec,
+			expectNode2NodeEncryption: "false",
+		},
+		{
+			name:                      "IPSec disabled",
+			enableIPSec:               false,
+			expectEncryptionMode:      "",
+			expectNode2NodeEncryption: "",
+		},
+		{
+			name:                      "IPSec enabled w/ node2node",
+			enableIPSec:               true,
+			enableNode2NodeEncryption: true,
+			expectEncryptionMode:      advConnNetEncIPSec,
+			expectNode2NodeEncryption: "true",
+		},
+		{
+			name:                      "Wireguard enabled",
+			enableWireguard:           true,
+			expectEncryptionMode:      advConnNetEncWireGuard,
+			expectNode2NodeEncryption: "false",
+		},
+		{
+			name:                      "Wireguard enabled w/ node2node",
+			enableWireguard:           true,
+			enableNode2NodeEncryption: true,
+			expectEncryptionMode:      advConnNetEncWireGuard,
+			expectNode2NodeEncryption: "true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
+				DatapathMode:           defaultDeviceModes[0],
+				EnableIPSec:            tt.enableIPSec,
+				EnableWireguard:        tt.enableWireguard,
+				EncryptNode:            tt.enableNode2NodeEncryption,
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
+
+			metrics.update(params, config)
+
+			// Check that only the expected mode's counter is incremented
+			for _, encMode := range defaultEncryptionModes {
+				for _, node2node := range []string{"true", "false"} {
+					counter, err := metrics.ACLBTransparentEncryption.GetMetricWithLabelValues(encMode, node2node)
+					assert.NoError(t, err)
+
+					counterValue := counter.Get()
+					if encMode == tt.expectEncryptionMode && node2node == tt.expectNode2NodeEncryption {
+						assert.Equal(t, float64(1), counterValue, "Expected mode %s to be incremented", encMode)
+					} else {
+						assert.Equal(t, float64(0), counterValue, "Expected mode %s to remain at 0", encMode)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -373,3 +373,44 @@ func TestUpdateDeviceMode(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateHostFirewall(t *testing.T) {
+	tests := []struct {
+		name               string
+		enableHostFirewall bool
+		expected           float64
+	}{
+		{
+			name:               "Host firewall enabled",
+			enableHostFirewall: true,
+			expected:           1,
+		},
+		{
+			name:               "Host firewall disabled",
+			enableHostFirewall: false,
+			expected:           0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
+				DatapathMode:           defaultDeviceModes[0],
+				EnableHostFirewall:     tt.enableHostFirewall,
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.NPHostFirewallEnabled.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableHostFirewall, counterValue)
+		})
+	}
+}

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -1072,3 +1072,47 @@ func TestUpdateInternalTrafficPolicy(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateVTEP(t *testing.T) {
+	tests := []struct {
+		name       string
+		enableVTEP bool
+		expected   float64
+	}{
+		{
+			name:       "VTEP enabled",
+			enableVTEP: true,
+			expected:   1,
+		},
+		{
+			name:       "VTEP disabled",
+			enableVTEP: false,
+			expected:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				EnableVTEP:             tt.enableVTEP,
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
+				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.ACLBVTEPEnabled.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableVTEP, counterValue)
+		})
+	}
+}

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -890,3 +890,48 @@ func TestUpdateBGPAvertisment(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateIPv4EgressGateway(t *testing.T) {
+	tests := []struct {
+		name      string
+		enableEGW bool
+		expected  float64
+	}{
+		{
+			name:      "Enable EGW",
+			enableEGW: true,
+			expected:  1,
+		},
+		{
+			name:      "Disable EGW",
+			enableEGW: false,
+			expected:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				IPAM:                    defaultIPAMModes[0],
+				EnableIPv4:              true,
+				IdentityAllocationMode:  defaultIdentityAllocationModes[0],
+				DatapathMode:            defaultDeviceModes[0],
+				NodePortMode:            defaultNodePortModes[0],
+				NodePortAlg:             defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:    defaultNodePortModeAccelerations[0],
+				EnableIPv4EgressGateway: tt.enableEGW,
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.ACLBEgressGatewayEnabled.Get()
+
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableEGW, counterValue)
+		})
+	}
+}

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -16,6 +16,7 @@ import (
 type mockFeaturesParams struct {
 	TunnelConfig    tunnel.Protocol
 	CNIChainingMode string
+	MutualAuth      bool
 }
 
 func (m mockFeaturesParams) TunnelProtocol() tunnel.Protocol {
@@ -24,6 +25,10 @@ func (m mockFeaturesParams) TunnelProtocol() tunnel.Protocol {
 
 func (m mockFeaturesParams) GetChainingMode() string {
 	return m.CNIChainingMode
+}
+
+func (m mockFeaturesParams) IsMutualAuthEnabled() bool {
+	return m.MutualAuth
 }
 
 func TestUpdateNetworkMode(t *testing.T) {
@@ -452,6 +457,47 @@ func TestUpdateLocalRedirectPolicies(t *testing.T) {
 
 			counterValue := metrics.NPLocalRedirectPolicyEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableLRP, counterValue)
+		})
+	}
+}
+
+func TestUpdateMutualAuth(t *testing.T) {
+	tests := []struct {
+		name             string
+		enableMutualAuth bool
+		expected         float64
+	}{
+		{
+			name:             "MutualAuth enabled",
+			enableMutualAuth: true,
+			expected:         1,
+		},
+		{
+			name:             "MutualAuth disabled",
+			enableMutualAuth: false,
+			expected:         0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
+				DatapathMode:           defaultDeviceModes[0],
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+				MutualAuth:      tt.enableMutualAuth,
+			}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.NPMutualAuthEnabled.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableMutualAuth, counterValue)
 		})
 	}
 }

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -14,9 +14,10 @@ import (
 )
 
 type mockFeaturesParams struct {
-	TunnelConfig    tunnel.Protocol
-	CNIChainingMode string
-	MutualAuth      bool
+	TunnelConfig     tunnel.Protocol
+	CNIChainingMode  string
+	MutualAuth       bool
+	BandwidthManager bool
 }
 
 func (m mockFeaturesParams) TunnelProtocol() tunnel.Protocol {
@@ -29,6 +30,10 @@ func (m mockFeaturesParams) GetChainingMode() string {
 
 func (m mockFeaturesParams) IsMutualAuthEnabled() bool {
 	return m.MutualAuth
+}
+
+func (m mockFeaturesParams) IsBandwidthManagerEnabled() bool {
+	return m.BandwidthManager
 }
 
 func TestUpdateNetworkMode(t *testing.T) {
@@ -932,6 +937,50 @@ func TestUpdateIPv4EgressGateway(t *testing.T) {
 			counterValue := metrics.ACLBEgressGatewayEnabled.Get()
 
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableEGW, counterValue)
+		})
+	}
+}
+
+func TestUpdateBandwidthManager(t *testing.T) {
+	tests := []struct {
+		name                   string
+		enableBandwidthManager bool
+		expected               float64
+	}{
+		{
+			name:                   "BandwidthManager enabled",
+			enableBandwidthManager: true,
+			expected:               1,
+		},
+		{
+			name:                   "BandwidthManager disabled",
+			enableBandwidthManager: false,
+			expected:               0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
+				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode:  defaultChainingModes[0],
+				BandwidthManager: tt.enableBandwidthManager,
+			}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.ACLBBandwidthManagerEnabled.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableBandwidthManager, counterValue)
 		})
 	}
 }

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -1116,3 +1116,47 @@ func TestUpdateVTEP(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateEnvoyConfig(t *testing.T) {
+	tests := []struct {
+		name              string
+		enableEnvoyConfig bool
+		expected          float64
+	}{
+		{
+			name:              "EnvoyConfig enabled",
+			enableEnvoyConfig: true,
+			expected:          1,
+		},
+		{
+			name:              "EnvoyConfig disabled",
+			enableEnvoyConfig: false,
+			expected:          0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				EnableEnvoyConfig:      tt.enableEnvoyConfig,
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
+				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.ACLBCiliumEnvoyConfigEnabled.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableEnvoyConfig, counterValue)
+		})
+	}
+}

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -828,3 +828,65 @@ func TestUpdateStandaloneNSLB(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateBGPAvertisment(t *testing.T) {
+	tests := []struct {
+		name               string
+		bgpAnnouncePodCIDR bool
+		bgpAnnounceLBIP    bool
+		bgpControlPlane    bool
+		expected           float64
+	}{
+		{
+			name:               "Announce PodCIDR enabled",
+			bgpAnnouncePodCIDR: true,
+			expected:           1,
+		},
+		{
+			name:               "Announce LBIP enabled",
+			bgpAnnouncePodCIDR: true,
+			expected:           1,
+		},
+		{
+			name:               "Announce PodCIDR and LBIP enabled",
+			bgpAnnouncePodCIDR: true,
+			expected:           1,
+		},
+		{
+			name:            "Enable BGP Control Plane",
+			bgpControlPlane: true,
+			expected:        1,
+		},
+		{
+			name:     "Announce none",
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
+				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
+				BGPAnnouncePodCIDR:     tt.bgpAnnouncePodCIDR,
+				BGPAnnounceLBIP:        tt.bgpAnnounceLBIP,
+				EnableBGPControlPlane:  tt.bgpControlPlane,
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.ACLBBGPEnabled.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for bgpAnnouncePodCIDR: %t and bgpAnnounceLBIP: %t and bgpControlPlane: %t, got %.f", tt.expected, tt.bgpAnnouncePodCIDR, tt.bgpAnnounceLBIP, tt.bgpControlPlane, counterValue)
+		})
+	}
+}

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -501,3 +501,44 @@ func TestUpdateMutualAuth(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateNonDefaultDeny(t *testing.T) {
+	tests := []struct {
+		name                 string
+		enableNonDefaultDeny bool
+		expected             float64
+	}{
+		{
+			name:                 "NonDefaultDeny enabled",
+			enableNonDefaultDeny: true,
+			expected:             1,
+		},
+		{
+			name:                 "NonDefaultDeny disabled",
+			enableNonDefaultDeny: false,
+			expected:             0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				IPAM:                         defaultIPAMModes[0],
+				EnableIPv4:                   true,
+				IdentityAllocationMode:       defaultIdentityAllocationModes[0],
+				DatapathMode:                 defaultDeviceModes[0],
+				EnableNonDefaultDenyPolicies: tt.enableNonDefaultDeny,
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.NPNonDefaultDenyEnabled.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableNonDefaultDeny, counterValue)
+		})
+	}
+}

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -542,3 +542,51 @@ func TestUpdateNonDefaultDeny(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateCIDRPolicyModeToNode(t *testing.T) {
+	type testCase struct {
+		name         string
+		policyMode   string
+		expectedMode string
+	}
+	var tests []testCase
+	for _, mode := range defaultCIDRPolicies {
+		tests = append(tests, testCase{
+			name:         fmt.Sprintf("CIDR policy %s mode", mode),
+			policyMode:   mode,
+			expectedMode: mode,
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
+				DatapathMode:           defaultDeviceModes[0],
+				PolicyCIDRMatchMode:    []string{tt.policyMode},
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
+
+			metrics.update(params, config)
+
+			// Check that only the expected mode's counter is incremented
+			for _, mode := range defaultCIDRPolicies {
+				counter, err := metrics.NPCIDRPoliciesToNodes.GetMetricWithLabelValues(mode)
+				assert.NoError(t, err)
+
+				counterValue := counter.Get()
+				if mode == tt.expectedMode {
+					assert.Equal(t, float64(1), counterValue, "Expected mode %s to be incremented", mode)
+				} else {
+					assert.Equal(t, float64(0), counterValue, "Expected mode %s to remain at 0", mode)
+				}
+			}
+		})
+	}
+}

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -15,11 +15,12 @@ import (
 )
 
 type mockFeaturesParams struct {
-	TunnelConfig     tunnel.Protocol
-	CNIChainingMode  string
-	MutualAuth       bool
-	BandwidthManager bool
-	bigTCPMock       bigTCPMock
+	TunnelConfig      tunnel.Protocol
+	CNIChainingMode   string
+	MutualAuth        bool
+	BandwidthManager  bool
+	bigTCPMock        bigTCPMock
+	L2PodAnnouncement bool
 }
 
 func (m mockFeaturesParams) TunnelProtocol() tunnel.Protocol {
@@ -40,6 +41,10 @@ func (m mockFeaturesParams) IsBandwidthManagerEnabled() bool {
 
 func (m mockFeaturesParams) BigTCPConfig() types.BigTCPConfig {
 	return m.bigTCPMock
+}
+
+func (m mockFeaturesParams) IsL2PodAnnouncementEnabled() bool {
+	return m.L2PodAnnouncement
 }
 
 type bigTCPMock struct {
@@ -1240,6 +1245,94 @@ func TestUpdateBigTCPProtocol(t *testing.T) {
 					assert.Equal(t, float64(0), counterValue, "Expected mode %s to remain at 0", mode)
 				}
 			}
+		})
+	}
+}
+
+func TestUpdateL2Announcements(t *testing.T) {
+	tests := []struct {
+		name                  string
+		enableL2Announcements bool
+		expected              float64
+	}{
+		{
+			name:                  "L2Announcements enabled",
+			enableL2Announcements: true,
+			expected:              1,
+		},
+		{
+			name:                  "L2Announcements disabled",
+			enableL2Announcements: false,
+			expected:              0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				EnableL2Announcements:  tt.enableL2Announcements,
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
+				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.ACLBL2LBEnabled.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableL2Announcements, counterValue)
+		})
+	}
+}
+
+func TestUpdateL2PodAnnouncements(t *testing.T) {
+	tests := []struct {
+		name                     string
+		enableL2PodAnnouncements bool
+		expected                 float64
+	}{
+		{
+			name:                     "L2Announcements enabled",
+			enableL2PodAnnouncements: true,
+			expected:                 1,
+		},
+		{
+			name:                     "L2Announcements disabled",
+			enableL2PodAnnouncements: false,
+			expected:                 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
+				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode:   defaultChainingModes[0],
+				L2PodAnnouncement: tt.enableL2PodAnnouncements,
+			}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.ACLBL2PodAnnouncementEnabled.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableL2PodAnnouncements, counterValue)
 		})
 	}
 }

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -62,10 +62,13 @@ func TestUpdateNetworkMode(t *testing.T) {
 			metrics := NewMetrics(true)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
-				RoutingMode:            tt.tunnelMode,
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
+				RoutingMode:            tt.tunnelMode,
 			}
 
 			params := mockFeaturesParams{
@@ -110,10 +113,13 @@ func TestUpdateIPAMMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			metrics := NewMetrics(true)
 			config := &option.DaemonConfig{
-				IPAM:                   tt.IPAMMode,
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
+				IPAM:                   tt.IPAMMode,
 			}
 
 			params := mockFeaturesParams{
@@ -161,6 +167,9 @@ func TestUpdateCNIChainingMode(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 			}
 
 			params := mockFeaturesParams{
@@ -215,10 +224,13 @@ func TestUpdateInternetProtocol(t *testing.T) {
 			metrics := NewMetrics(true)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
-				EnableIPv4:             tt.enableIPv4,
-				EnableIPv6:             tt.enableIPv6,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
+				EnableIPv4:             tt.enableIPv4,
+				EnableIPv6:             tt.enableIPv6,
 			}
 
 			params := mockFeaturesParams{
@@ -264,8 +276,11 @@ func TestUpdateIdentityAllocationMode(t *testing.T) {
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
-				IdentityAllocationMode: tt.identityAllocationMode,
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				DatapathMode:           defaultDeviceModes[0],
+				IdentityAllocationMode: tt.identityAllocationMode,
 			}
 
 			params := mockFeaturesParams{
@@ -315,8 +330,11 @@ func TestUpdateCiliumEndpointSlices(t *testing.T) {
 				IPAM:                      defaultIPAMModes[0],
 				EnableIPv4:                true,
 				IdentityAllocationMode:    defaultIdentityAllocationModes[0],
-				EnableCiliumEndpointSlice: tt.enableCES,
 				DatapathMode:              defaultDeviceModes[0],
+				NodePortMode:              defaultNodePortModes[0],
+				NodePortAlg:               defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:      defaultNodePortModeAccelerations[0],
+				EnableCiliumEndpointSlice: tt.enableCES,
 			}
 
 			params := mockFeaturesParams{
@@ -354,6 +372,9 @@ func TestUpdateDeviceMode(t *testing.T) {
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				DatapathMode:           tt.deviceMode,
 			}
 
@@ -405,6 +426,9 @@ func TestUpdateHostFirewall(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				EnableHostFirewall:     tt.enableHostFirewall,
 			}
 
@@ -446,6 +470,9 @@ func TestUpdateLocalRedirectPolicies(t *testing.T) {
 				EnableIPv4:                true,
 				IdentityAllocationMode:    defaultIdentityAllocationModes[0],
 				DatapathMode:              defaultDeviceModes[0],
+				NodePortMode:              defaultNodePortModes[0],
+				NodePortAlg:               defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:      defaultNodePortModeAccelerations[0],
 				EnableLocalRedirectPolicy: tt.enableLRP,
 			}
 
@@ -487,6 +514,9 @@ func TestUpdateMutualAuth(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 			}
 
 			params := mockFeaturesParams{
@@ -528,6 +558,9 @@ func TestUpdateNonDefaultDeny(t *testing.T) {
 				EnableIPv4:                   true,
 				IdentityAllocationMode:       defaultIdentityAllocationModes[0],
 				DatapathMode:                 defaultDeviceModes[0],
+				NodePortMode:                 defaultNodePortModes[0],
+				NodePortAlg:                  defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:         defaultNodePortModeAccelerations[0],
 				EnableNonDefaultDenyPolicies: tt.enableNonDefaultDeny,
 			}
 
@@ -566,6 +599,9 @@ func TestUpdateCIDRPolicyModeToNode(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				PolicyCIDRMatchMode:    []string{tt.policyMode},
 			}
 
@@ -643,6 +679,9 @@ func TestUpdateEncryptionMode(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				EnableIPSec:            tt.enableIPSec,
 				EnableWireguard:        tt.enableWireguard,
 				EncryptNode:            tt.enableNode2NodeEncryption,
@@ -698,6 +737,9 @@ func TestUpdateKubeProxyReplacement(t *testing.T) {
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
 				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
 				KubeProxyReplacement:   tt.enableKubeProxyReplacement,
 			}
 
@@ -709,6 +751,80 @@ func TestUpdateKubeProxyReplacement(t *testing.T) {
 
 			counterValue := metrics.ACLBKubeProxyReplacementEnabled.Get()
 			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableKubeProxyReplacement, counterValue)
+		})
+	}
+}
+
+func TestUpdateStandaloneNSLB(t *testing.T) {
+	type testCase struct {
+		name             string
+		portMode         string
+		algoMode         string
+		accelerationMode string
+
+		expectedPortMode         string
+		expectedAlgoMode         string
+		expectedAccelerationMode string
+	}
+	var tests []testCase
+	for _, portMode := range defaultNodePortModes {
+		for _, algoMode := range defaultNodePortModeAlgorithms {
+			for _, aclMode := range defaultNodePortModeAccelerations {
+				tests = append(tests, testCase{
+					name:             fmt.Sprintf("NSLB %s - %s - %s", portMode, algoMode, aclMode),
+					portMode:         portMode,
+					algoMode:         algoMode,
+					accelerationMode: aclMode,
+
+					expectedPortMode:         portMode,
+					expectedAlgoMode:         algoMode,
+					expectedAccelerationMode: aclMode,
+				})
+			}
+		}
+	}
+	tests = append(tests, testCase{
+		name:             "NSLB disabled",
+		accelerationMode: option.NodePortAccelerationDisabled,
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
+				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           tt.portMode,
+				NodePortAlg:            tt.algoMode,
+				NodePortAcceleration:   tt.accelerationMode,
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
+
+			metrics.update(params, config)
+
+			// Check that only the expected mode's counter is incremented
+			for _, portMode := range defaultNodePortModes {
+				for _, algoMode := range defaultNodePortModeAlgorithms {
+					for _, aclMode := range defaultNodePortModeAccelerations {
+						counter, err := metrics.ACLBNodePortConfig.GetMetricWithLabelValues(portMode, algoMode, aclMode)
+						assert.NoError(t, err)
+
+						counterValue := counter.Get()
+						if portMode == tt.expectedPortMode &&
+							algoMode == tt.expectedAlgoMode &&
+							aclMode == tt.expectedAccelerationMode {
+							assert.Equal(t, float64(1), counterValue, "Expected mode %s - %s - %s to be incremented", portMode, algoMode, aclMode)
+						} else {
+							assert.Equal(t, float64(0), counterValue, "Expected mode %s - %s - %s to remain at 0", portMode, algoMode, aclMode)
+						}
+					}
+				}
+			}
 		})
 	}
 }

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -984,3 +984,47 @@ func TestUpdateBandwidthManager(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateSCTP(t *testing.T) {
+	tests := []struct {
+		name       string
+		enableSCTP bool
+		expected   float64
+	}{
+		{
+			name:       "SCTP enabled",
+			enableSCTP: true,
+			expected:   1,
+		},
+		{
+			name:       "SCTP disabled",
+			enableSCTP: false,
+			expected:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				EnableSCTP:             tt.enableSCTP,
+				IPAM:                   defaultIPAMModes[0],
+				EnableIPv4:             true,
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
+				DatapathMode:           defaultDeviceModes[0],
+				NodePortMode:           defaultNodePortModes[0],
+				NodePortAlg:            defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.ACLBSCTPEnabled.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableSCTP, counterValue)
+		})
+	}
+}

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -1028,3 +1028,47 @@ func TestUpdateSCTP(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateInternalTrafficPolicy(t *testing.T) {
+	tests := []struct {
+		name                        string
+		enableInternalTrafficPolicy bool
+		expected                    float64
+	}{
+		{
+			name:                        "InternalTrafficPolicy enabled",
+			enableInternalTrafficPolicy: true,
+			expected:                    1,
+		},
+		{
+			name:                        "InternalTrafficPolicy disabled",
+			enableInternalTrafficPolicy: false,
+			expected:                    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true)
+			config := &option.DaemonConfig{
+				EnableInternalTrafficPolicy: tt.enableInternalTrafficPolicy,
+				IPAM:                        defaultIPAMModes[0],
+				EnableIPv4:                  true,
+				IdentityAllocationMode:      defaultIdentityAllocationModes[0],
+				DatapathMode:                defaultDeviceModes[0],
+				NodePortMode:                defaultNodePortModes[0],
+				NodePortAlg:                 defaultNodePortModeAlgorithms[0],
+				NodePortAcceleration:        defaultNodePortModeAccelerations[0],
+			}
+
+			params := mockFeaturesParams{
+				CNIChainingMode: defaultChainingModes[0],
+			}
+
+			metrics.update(params, config)
+
+			counterValue := metrics.ACLBInternalTrafficPolicyEnabled.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected value to be %.f for enabled: %t, got %.f", tt.expected, tt.enableInternalTrafficPolicy, counterValue)
+		})
+	}
+}


### PR DESCRIPTION
Follow up of https://github.com/cilium/cilium/pull/35852 for more features. I've split in multiple commits so it's easier for each sig to review their section.

**Note for reviewers**: Review on a per-commit basis to make sure the feature of your sig is being detected correctly.

### Features Checklist
- [x] Enable HostFirewall (@cilium/sig-datapath)
- [x] Enable LocalRedirectPolicy (@cilium/sig-datapath)
- [x] Enable Mutual Auth (@cilium/sig-servicemesh)
- [x] Enable Non DefaultDeny policy enforcement (@cilium/sig-policy)
- [x] Enable CIDRPoliciesToNodes (@cilium/sig-policy)
- [x] Enable encryption modes (@cilium/sig-datapath)
- [x] Enable KubeProxyReplacement (@cilium/sig-datapath)
- [x] Enable standalone north-south LB (@cilium/sig-datapath)
- [x] Enable BGP advertisement (@cilium/sig-bgp)
- [x] Enable Egress Gateway (@cilium/egress-gateway)
- [x] Enable bandwidth manager (@cilium/sig-datapath)
- [x] Enable SRv6 (@cilium/sig-datapath)
- [x] Enable SCTP (@cilium/sig-datapath)
- [x] Enable internal traffic policy (@cilium/sig-datapath)
- [x] Enable VTEP (@cilium/sig-datapath)
- [x] Enable Cilium Envoy Config (@cilium/sig-servicemesh)
- [x] Enable BigTCP (@cilium/sig-datapath)
- [x] Enable L2 announcement (@cilium/sig-datapath)
- [x] Enable external EnvoyProxy (@cilium/sig-servicemesh)
- [x] Enable dynamic node config (@cilium/sig-policy)