### PR TITLE
cilium-cli: add external-other-target arg to connectivity tests

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -129,6 +129,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().BoolVarP(&params.Timestamp, "timestamp", "t", false, "Show timestamp in messages")
 	cmd.Flags().BoolVarP(&params.PauseOnFail, "pause-on-fail", "p", false, "Pause execution on test failure")
 	cmd.Flags().StringVar(&params.ExternalTarget, "external-target", "one.one.one.one.", "Domain name to use as external target in connectivity tests")
+	cmd.Flags().StringVar(&params.ExternalOtherTarget, "external-other-target", "cilium.io.", "Domain name to use as a second external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalTargetCANamespace, "external-target-ca-namespace", "", "Namespace of the CA secret for the external target. Used by client-egress-l7-tls test cases.")
 	cmd.Flags().StringVar(&params.ExternalTargetCAName, "external-target-ca-name", "cabundle", "Name of the CA secret for the external target. Used by client-egress-l7-tls test cases.")
 	cmd.Flags().StringVar(&params.ExternalCIDR, "external-cidr", "1.0.0.0/8", "CIDR to use as external target in connectivity tests")

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -74,6 +74,7 @@ type Parameters struct {
 	DeploymentAnnotations  annotationsMap
 	NamespaceAnnotations   annotations
 	ExternalTarget         string
+	ExternalOtherTarget    string
 	ExternalCIDR           string
 	ExternalIP             string
 	ExternalDeploymentPort int

--- a/cilium-cli/connectivity/tests/world.go
+++ b/cilium-cli/connectivity/tests/world.go
@@ -70,7 +70,7 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 	}
 }
 
-// PodToWorld2 sends an HTTPS request to cilium.io from from random client
+// PodToWorld2 sends an HTTPS request to ExternalOtherTarget from random client
 // Pods.
 func PodToWorld2() check.Scenario {
 	return &podToWorld2{}
@@ -84,7 +84,8 @@ func (s *podToWorld2) Name() string {
 }
 
 func (s *podToWorld2) Run(ctx context.Context, t *check.Test) {
-	https := check.HTTPEndpoint("cilium-io-https", "https://cilium.io.")
+	extTarget := t.Context().Params().ExternalOtherTarget
+	https := check.HTTPEndpoint(extTarget+"-https", "https://"+extTarget)
 
 	fp := check.FlowParameters{
 		DNSRequired: true,
@@ -96,7 +97,7 @@ func (s *podToWorld2) Run(ctx context.Context, t *check.Test) {
 
 	for _, client := range ct.ClientPods() {
 		// With https, over port 443.
-		t.NewAction(s, fmt.Sprintf("https-cilium-io-%d", i), &client, https, features.IPFamilyAny).Run(func(a *check.Action) {
+		t.NewAction(s, fmt.Sprintf("https-%s-%d", extTarget, i), &client, https, features.IPFamilyAny).Run(func(a *check.Action) {
 			a.ExecInPod(ctx, ct.CurlCommand(https, features.IPFamilyAny))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 			a.ValidateMetrics(ctx, client, a.GetEgressMetricsRequirements())


### PR DESCRIPTION
Allow overriding the "blocked" domain in the test using `--external-other-target` instead of hard-coding cilium.io

This is a workaround for failing `to-fqdn` tests in IPv6-only cluster. These fail because "cilium.io" doesn't have an AAAA record, so `curl` tries to connect to the IPv4 address and fails with a different error code than the one expected by the test (network unreachable instead of timeout).

Fixes: #35553

```release-note
Add --external-other-target parameter to cilium CLI connectivity tests.
```
