### PR TITLE
[1.14] xdp: make cilium_calls_xdp map per-endpoint

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -137,7 +137,6 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_auth_map", bpffsMountpoint),
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_call_policy", bpffsMountpoint),
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_calls_overlay_2", bpffsMountpoint),
-			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_calls_xdp", bpffsMountpoint),
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_capture_cache", bpffsMountpoint),
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_runtime_config", bpffsMountpoint),
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_lxc", bpffsMountpoint),

--- a/pkg/bpf/bpffs_migrate.go
+++ b/pkg/bpf/bpffs_migrate.go
@@ -99,11 +99,6 @@ func RepinMap(bpffsPath string, name string, spec *ebpf.MapSpec) error {
 		pinned.ValueSize() == spec.ValueSize &&
 		pinned.Flags() == spec.Flags &&
 		pinned.MaxEntries() == spec.MaxEntries {
-		// cilium_calls_xdp is shared between XDP interfaces and should only be
-		// migrated if the existing map is incompatible.
-		if spec.Name == "cilium_calls_xdp" {
-			return nil
-		}
 		// Maps prefixed with cilium_calls_ should never be reused by subsequent ELF
 		// loads and should be migrated unconditionally.
 		if !strings.HasPrefix(spec.Name, "cilium_calls_") {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/backoff"
+	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/datapath/alignchecker"
 	"github.com/cilium/cilium/pkg/datapath/connector"
@@ -297,6 +298,10 @@ func (l *Loader) reinitializeXDPLocked(ctx context.Context, extraCArgs []string)
 			return err
 		}
 	}
+
+	// Clean up the legacy cilium_calls_xdp path.
+	os.Remove(filepath.Join(bpf.TCGlobalsPath(), "cilium_calls_xdp"))
+
 	return nil
 }
 

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -118,7 +118,7 @@ func xdpCompileArgs(xdpDev string, extraCArgs []string) ([]string, error) {
 	args := []string{
 		fmt.Sprintf("-DSECLABEL=%d", identity.ReservedIdentityWorld),
 		fmt.Sprintf("-DNODE_MAC={.addr=%s}", mac.CArrayString(link.Attrs().HardwareAddr)),
-		"-DCALLS_MAP=cilium_calls_xdp",
+		fmt.Sprintf("-DCALLS_MAP=cilium_calls_xdp_%d", link.Attrs().Index),
 	}
 	args = append(args, extraCArgs...)
 	if option.Config.EnableNodePort {


### PR DESCRIPTION
Partial backport of https://github.com/cilium/cilium/pull/33067

This is a partial backport of an upstream commit that made cilium_calls_xdp
a per-endpoint map with an ifindex suffix. This is affecting 1.14 and 1.15
release branches, so backport only the specific behaviour.