### PR TITLE
k8s: Convert from Resource[Pod] to Table[LocalPod]

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -167,6 +167,9 @@ var (
 		// read-only stores.
 		agentK8s.ResourcesCell,
 
+		// StateDB tables for Kubernetes objects.
+		agentK8s.TablesCell,
+
 		// Shared synchronization structures for waiting on K8s resources to
 		// be synced
 		k8sSynced.Cell,

--- a/daemon/k8s/pods.go
+++ b/daemon/k8s/pods.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/duration"
+
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// LocalPod is Cilium's internal model of the pods running on this node.
+type LocalPod struct {
+	*slim_corev1.Pod
+
+	// UpdatedAt is the time when [LocalPod] was last updated, e.g. it
+	// shows when the pod change was received from the api-server.
+	UpdatedAt time.Time `json:"updatedAt" yaml:"updatedAt"`
+}
+
+func (p LocalPod) TableHeader() []string {
+	return []string{
+		"Name",
+		"HostNetwork",
+		"PodIPs",
+		"Containers",
+		"Phase",
+		"Age",
+	}
+}
+
+func (p LocalPod) TableRow() []string {
+	podIPs := make([]string, len(p.Status.PodIPs))
+	for i := range p.Status.PodIPs {
+		podIPs[i] = p.Status.PodIPs[i].IP
+	}
+	containers := make([]string, len(p.Spec.Containers))
+	for i, cont := range p.Spec.Containers {
+		ports := make([]string, len(cont.Ports))
+		for i, port := range cont.Ports {
+			if port.Name != "" {
+				ports[i] = fmt.Sprintf("%d/%s (%s)", port.ContainerPort, string(port.Protocol), port.Name)
+			} else {
+				ports[i] = fmt.Sprintf("%d/%s", port.ContainerPort, string(port.Protocol))
+			}
+		}
+		contName := cont.Name
+		if len(ports) > 0 {
+			contName += " (" + strings.Join(ports, ",") + ")"
+		}
+		containers[i] = contName
+	}
+	return []string{
+		p.Namespace + "/" + p.Name,
+		strconv.FormatBool(p.Spec.HostNetwork),
+		strings.Join(podIPs, ", "),
+		strings.Join(containers, ", "),
+		string(p.Status.Phase),
+		duration.HumanDuration(time.Since(p.UpdatedAt)),
+	}
+}
+
+const (
+	PodTableName = "k8s-pods"
+)
+
+var (
+	PodNameIndex = newNameIndex[LocalPod]()
+
+	PodTableCell = cell.Group(
+		cell.ProvidePrivate(NewPodTable),
+		cell.Provide(statedb.RWTable[LocalPod].ToTable),
+		cell.Invoke(registerPodReflector),
+	)
+)
+
+func PodByName(namespace, name string) statedb.Query[LocalPod] {
+	return PodNameIndex.Query(namespace + "/" + name)
+}
+
+func NewPodTable(db *statedb.DB) (statedb.RWTable[LocalPod], error) {
+	tbl, err := statedb.NewTable(
+		PodTableName,
+		PodNameIndex,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return tbl, db.RegisterTable(tbl)
+}
+
+func registerPodReflector(jg job.Group, db *statedb.DB, cs client.Clientset, pods statedb.RWTable[LocalPod]) error {
+	if !cs.IsEnabled() {
+		return nil
+	}
+	cfg := podReflectorConfig(cs, pods)
+	return k8s.RegisterReflector(jg, db, cfg)
+}
+
+func podReflectorConfig(cs client.Clientset, pods statedb.RWTable[LocalPod]) k8s.ReflectorConfig[LocalPod] {
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped(cs.Slim().CoreV1().Pods("")),
+		func(opts *metav1.ListOptions) {
+			opts.FieldSelector = fields.ParseSelectorOrDie("spec.nodeName=" + nodeTypes.GetName()).String()
+		})
+	return k8s.ReflectorConfig[LocalPod]{
+		Name:          reflectorName,
+		Table:         pods,
+		ListerWatcher: lw,
+		Transform: func(_ statedb.ReadTxn, obj any) (LocalPod, bool) {
+			pod, ok := obj.(*slim_corev1.Pod)
+			if !ok {
+				return LocalPod{}, false
+			}
+			return LocalPod{
+				Pod:       pod,
+				UpdatedAt: time.Now(),
+			}, true
+		},
+	}
+}

--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -68,14 +68,6 @@ var (
 					},
 				)
 			},
-			func(lc cell.Lifecycle, cs client.Clientset) (LocalPodResource, error) {
-				return k8s.PodResource(
-					lc, cs,
-					func(opts *metav1.ListOptions) {
-						opts.FieldSelector = fields.ParseSelectorOrDie("spec.nodeName=" + nodeTypes.GetName()).String()
-					},
-				)
-			},
 		),
 	)
 )
@@ -88,10 +80,6 @@ type LocalNodeResource resource.Resource[*slim_corev1.Node]
 // CiliumNode object associated with the node we are currently running on.
 type LocalCiliumNodeResource resource.Resource[*cilium_api_v2.CiliumNode]
 
-// LocalPodResource is a resource.Resource[*slim_corev1.Pod] but one which will only stream updates for pod
-// objects scheduled on the node we are currently running on.
-type LocalPodResource resource.Resource[*slim_corev1.Pod]
-
 // Resources is a convenience struct to group all the agent k8s resources as cell constructor parameters.
 type Resources struct {
 	cell.In
@@ -100,7 +88,6 @@ type Resources struct {
 	Endpoints                        resource.Resource[*k8s.Endpoints]
 	LocalNode                        LocalNodeResource
 	LocalCiliumNode                  LocalCiliumNodeResource
-	LocalPods                        LocalPodResource
 	Namespaces                       resource.Resource[*slim_corev1.Namespace]
 	NetworkPolicies                  resource.Resource[*slim_networkingv1.NetworkPolicy]
 	CiliumNetworkPolicies            resource.Resource[*cilium_api_v2.CiliumNetworkPolicy]

--- a/daemon/k8s/script_test.go
+++ b/daemon/k8s/script_test.go
@@ -9,9 +9,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/hive/script"
 	"github.com/cilium/hive/script/scripttest"
+	"github.com/cilium/statedb"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,6 +39,13 @@ func TestScript(t *testing.T) {
 			h := hive.New(
 				client.FakeClientCell,
 				TablesCell,
+
+				// Instantiate the tables we're testing. Without this the
+				// tables and reflectors would not be created (as nothing
+				// would depend on them).
+				cell.Invoke(
+					func(statedb.Table[LocalPod]) {},
+				),
 			)
 
 			flags := pflag.NewFlagSet("", pflag.ContinueOnError)

--- a/daemon/k8s/script_test.go
+++ b/daemon/k8s/script_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"context"
+	"maps"
+	"os"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// TestScript runs all the testdata/*.txtar script tests. The tests are
+// run in parallel. If you need to update the expected files inside the txtar
+// files you can run 'go test . -scripttest.update' to update the files.
+func TestScript(t *testing.T) {
+	time.Now = func() time.Time {
+		return time.Date(2000, 1, 1, 10, 30, 0, 0, time.UTC)
+	}
+	os.Setenv("TZ", "")
+
+	log := hivetest.Logger(t)
+	scripttest.Test(t,
+		context.Background(),
+		func(t testing.TB, args []string) *script.Engine {
+			h := hive.New(
+				client.FakeClientCell,
+				TablesCell,
+			)
+
+			flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+			h.RegisterFlags(flags)
+
+			t.Cleanup(func() {
+				assert.NoError(t, h.Stop(log, context.TODO()))
+			})
+			cmds, err := h.ScriptCommands(log)
+			require.NoError(t, err, "ScriptCommands")
+			maps.Insert(cmds, maps.All(script.DefaultCmds()))
+			return &script.Engine{
+				Cmds: cmds,
+			}
+		}, []string{}, "testdata/*.txtar")
+}

--- a/daemon/k8s/tables.go
+++ b/daemon/k8s/tables.go
@@ -10,15 +10,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ResourcesCell provides a set of handles to Kubernetes resources used throughout the
-// agent. Each of the resources share a client-go informer and backing store so we only
-// have one watch API call for each resource kind and that we maintain only one copy of each object.
-//
-// See pkg/k8s/resource/resource.go for documentation on the Resource[T] type.
-
 // TablesCell provides a set of StateDB tables for common Kubernetes objects.
 // The tables are populated with the StateDB k8s reflector (pkg/k8s/statedb.go).
-// Some tables are provided as OnDemand[Table[T]]
+//
+// NOTE: When adding new k8s tables make sure to provide and register from a
+// single provider to ensure reflector starts before anyone depending on the table.
+// See [NewPodTableAndReflector] for example.
 var TablesCell = cell.Module(
 	"k8s-tables",
 	"StateDB tables of Kubernetes objects",

--- a/daemon/k8s/tables.go
+++ b/daemon/k8s/tables.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ResourcesCell provides a set of handles to Kubernetes resources used throughout the
+// agent. Each of the resources share a client-go informer and backing store so we only
+// have one watch API call for each resource kind and that we maintain only one copy of each object.
+//
+// See pkg/k8s/resource/resource.go for documentation on the Resource[T] type.
+
+// TablesCell provides a set of StateDB tables for common Kubernetes objects.
+// The tables are populated with the StateDB k8s reflector (pkg/k8s/statedb.go).
+// Some tables are provided as OnDemand[Table[T]]
+var TablesCell = cell.Module(
+	"k8s-tables",
+	"StateDB tables of Kubernetes objects",
+
+	PodTableCell,
+)
+
+// reflectorName to use in [k8s.ReflectorConfig]. This is the name that appears
+// for these tables in the table initializers and is visible in "db" command output
+// when the tables are initializing. If a table has multiple reflectors into it
+// in this package, append a suffix to [reflectorName].
+const reflectorName = "daemon-k8s"
+
+func newNameIndex[Obj metav1.Object]() statedb.Index[Obj, string] {
+	return statedb.Index[Obj, string]{
+		Name: "name",
+		FromObject: func(obj Obj) index.KeySet {
+			return index.NewKeySet(index.String(obj.GetNamespace() + "/" + obj.GetName()))
+		},
+		FromKey: index.String,
+		FromString: func(key string) (index.Key, error) {
+			return index.String(key), nil
+		},
+		Unique: true,
+	}
+}

--- a/daemon/k8s/testdata/pod.txtar
+++ b/daemon/k8s/testdata/pod.txtar
@@ -1,0 +1,271 @@
+#
+# This test case validates that when using the k8s.TablesCell, we will have
+# a Table[LocalPod] that is correctly populated from the Pod objects received
+# from api-server. The test uses the client-go fake client instead of a real
+# api-server.
+#
+
+# Start and wait for reflector to sync up (List & Watch). This is needed
+# as the fake k8s client is dumb and would miss events between the List
+# and Watch calls.
+hive start
+db/initialized
+
+# At the start the table is empty
+db/cmp k8s-pods empty.table 
+
+# Add a pod
+k8s add pod.yaml
+
+# TIP: Since this is the first test of its kind, it's worth mentioning
+# here that you can add a 'break' command to drop into an interactive
+# debug shell to explore. E.g. if you would have 'break' here, you could
+# run 'help', 'db show k8s-pods', 'db show health', etc. to explore what
+# state the 'k8s add' above left us in.
+
+# Validate that it gets reflected and health is reported
+db/cmp k8s-pods pods.table
+db/cmp --grep=reflector-k8s-pods health health.table
+
+# Check the JSON export of the pod. 
+# The yaml annotations are missing from slimv1.Pod which is why all
+# the keys are lower-case.
+db/show --format=json --out=actual.json k8s-pods
+cmp expected.json actual.json
+
+# TIP2: When using 'cmp' and your expected file is big, you might want
+# to use the '-scripttest.update' flag to automatically update it.
+
+# Check that the pod name index works (FromString is implemented).
+db/get --index=name --columns=Name --out=actual.table k8s-pods default/nginx
+cmp pods_name.table actual.table
+
+# We can also prefix search by namespace. Only taking the 'Name' column
+# so we don't end up comparing the 'Age'.
+db/prefix --index=name --columns=Name -o actual.table k8s-pods default/
+cmp pods_name.table actual.table
+
+# Remove the pod
+k8s delete pod.yaml
+
+# Table should be empty
+db/cmp k8s-pods empty.table
+
+-- health.table --
+Module        Component                              Level      Message
+k8s-tables    job-k8s-reflector-k8s-pods-daemon-k8s  OK         1 upserted, 0 deleted, 1 total objects
+
+-- empty.table --
+Name   HostNetwork   PodIPs   Phase   Age
+
+-- pods.table --
+Name           HostNetwork   PodIPs       Containers      Phase 
+default/nginx  false         10.244.1.178 nginx (80/TCP)  Running
+
+-- pods_name.table --
+Name
+default/nginx
+-- expected.json --
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "nginx",
+    "namespace": "default",
+    "uid": "d96be1eb-51df-4383-87ab-bc29d5b42933",
+    "resourceVersion": "482057",
+    "labels": {
+      "run": "nginx"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "nginx",
+        "image": "nginx",
+        "ports": [
+          {
+            "containerPort": 80,
+            "protocol": "TCP"
+          }
+        ],
+        "volumeMounts": [
+          {
+            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+          }
+        ]
+      }
+    ],
+    "serviceAccountName": "default",
+    "nodeName": "kind-worker"
+  },
+  "status": {
+    "phase": "Running",
+    "conditions": [
+      {
+        "type": "PodReadyToStartContainers",
+        "status": "True",
+        "lastProbeTime": null,
+        "lastTransitionTime": "2024-11-21T14:52:24Z"
+      },
+      {
+        "type": "Initialized",
+        "status": "True",
+        "lastProbeTime": null,
+        "lastTransitionTime": "2024-11-21T14:52:23Z"
+      },
+      {
+        "type": "Ready",
+        "status": "True",
+        "lastProbeTime": null,
+        "lastTransitionTime": "2024-11-21T14:52:24Z"
+      },
+      {
+        "type": "ContainersReady",
+        "status": "True",
+        "lastProbeTime": null,
+        "lastTransitionTime": "2024-11-21T14:52:24Z"
+      },
+      {
+        "type": "PodScheduled",
+        "status": "True",
+        "lastProbeTime": null,
+        "lastTransitionTime": "2024-11-21T14:52:23Z"
+      }
+    ],
+    "hostIP": "172.19.0.3",
+    "podIP": "10.244.1.178",
+    "podIPs": [
+      {
+        "ip": "10.244.1.178"
+      }
+    ],
+    "startTime": "2024-11-21T14:52:23Z",
+    "containerStatuses": [
+      {
+        "state": {
+          "running": {
+            "startedAt": "2024-11-21T14:52:24Z"
+          }
+        },
+        "containerID": "containerd://8e707b9ac927f5c25b6be87ee483845993063b540f9465cbe14dc5ea113fc636"
+      }
+    ],
+    "qosClass": "BestEffort"
+  },
+  "updatedAt": "2000-01-01T10:30:00Z"
+}
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2024-11-21T14:52:23Z"
+  labels:
+    run: nginx
+  name: nginx
+  namespace: default
+  resourceVersion: "482057"
+  uid: d96be1eb-51df-4383-87ab-bc29d5b42933
+spec:
+  containers:
+  - image: nginx
+    imagePullPolicy: Always
+    name: nginx
+    ports:
+    - containerPort: 80
+      protocol: TCP
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: kube-api-access-fsxsw
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: kind-worker
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - name: kube-api-access-fsxsw
+    projected:
+      defaultMode: 420
+      sources:
+      - serviceAccountToken:
+          expirationSeconds: 3607
+          path: token
+      - configMap:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          name: kube-root-ca.crt
+      - downwardAPI:
+          items:
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+            path: namespace
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2024-11-21T14:52:24Z"
+    status: "True"
+    type: PodReadyToStartContainers
+  - lastProbeTime: null
+    lastTransitionTime: "2024-11-21T14:52:23Z"
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2024-11-21T14:52:24Z"
+    status: "True"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2024-11-21T14:52:24Z"
+    status: "True"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2024-11-21T14:52:23Z"
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: containerd://8e707b9ac927f5c25b6be87ee483845993063b540f9465cbe14dc5ea113fc636
+    image: docker.io/library/nginx:latest
+    imageID: docker.io/library/nginx@sha256:bc5eac5eafc581aeda3008b4b1f07ebba230de2f27d47767129a6a905c84f470
+    lastState: {}
+    name: nginx
+    ready: true
+    restartCount: 0
+    started: true
+    state:
+      running:
+        startedAt: "2024-11-21T14:52:24Z"
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: kube-api-access-fsxsw
+      readOnly: true
+      recursiveReadOnly: Disabled
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  - ip: fc00:c111::3
+  phase: Running
+  podIP: 10.244.1.178
+  podIPs:
+  - ip: 10.244.1.178
+  qosClass: BestEffort
+  startTime: "2024-11-21T14:52:23Z"

--- a/pkg/ciliumenvoyconfig/exp_test.go
+++ b/pkg/ciliumenvoyconfig/exp_test.go
@@ -48,6 +48,7 @@ func TestScript(t *testing.T) {
 		h := hive.New(
 			client.FakeClientCell,
 			daemonk8s.ResourcesCell,
+			daemonk8s.TablesCell,
 			cell.Config(cecConfig{}),
 			cell.Config(envoy.ProxyConfig{}),
 			experimental.Cell,

--- a/pkg/ipam/metadata/cell.go
+++ b/pkg/ipam/metadata/cell.go
@@ -5,6 +5,7 @@ package metadata
 
 import (
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
 
 	"github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/ipam"
@@ -28,7 +29,8 @@ type managerParams struct {
 	DaemonConfig *option.DaemonConfig
 
 	NamespaceResource resource.Resource[*slim_core_v1.Namespace]
-	PodResource       k8s.LocalPodResource
+	DB                *statedb.DB
+	Pods              statedb.Table[k8s.LocalPod]
 }
 
 func newIPAMMetadataManager(params managerParams) Manager {
@@ -37,8 +39,9 @@ func newIPAMMetadataManager(params managerParams) Manager {
 	}
 
 	manager := &manager{
+		db:                params.DB,
 		namespaceResource: params.NamespaceResource,
-		podResource:       params.PodResource,
+		pods:              params.Pods,
 	}
 	params.Lifecycle.Append(manager)
 

--- a/pkg/ipam/metadata/manager_test.go
+++ b/pkg/ipam/metadata/manager_test.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -52,13 +54,6 @@ func (m mockStore[T]) Release() {
 	panic("not implemented")
 }
 
-func podKey(ns, name string) resource.Key {
-	return resource.Key{
-		Namespace: ns,
-		Name:      name,
-	}
-}
-
 func namespaceKey(name string) resource.Key {
 	return resource.Key{
 		Name: name,
@@ -66,7 +61,11 @@ func namespaceKey(name string) resource.Key {
 }
 
 func TestManager_GetIPPoolForPod(t *testing.T) {
+	db := statedb.New()
+	pods, err := k8s.NewPodTable(db)
+	require.NoError(t, err, "NewPodTable")
 	m := &manager{
+		db: db,
 		namespaceStore: mockStore[*slim_core_v1.Namespace]{
 			namespaceKey("default"): &slim_core_v1.Namespace{},
 			namespaceKey("special"): &slim_core_v1.Namespace{
@@ -77,60 +76,52 @@ func TestManager_GetIPPoolForPod(t *testing.T) {
 				},
 			},
 		},
-		podStore: mockStore[*slim_core_v1.Pod]{
-			podKey("default", "client"): &slim_core_v1.Pod{},
-			podKey("default", "custom-workload"): &slim_core_v1.Pod{
-				ObjectMeta: slim_meta_v1.ObjectMeta{
-					Annotations: map[string]string{
-						annotation.IPAMPoolKey: "custom-pool",
-					},
-				},
-			},
-			podKey("default", "custom-workload2"): &slim_core_v1.Pod{
-				ObjectMeta: slim_meta_v1.ObjectMeta{
-					Annotations: map[string]string{
-						annotation.IPAMIPv4PoolKey: "ipv4-pool",
-					},
-				},
-			},
-			podKey("default", "custom-workload3"): &slim_core_v1.Pod{
-				ObjectMeta: slim_meta_v1.ObjectMeta{
-					Annotations: map[string]string{
-						annotation.IPAMIPv4PoolKey: "ipv4-pool",
-						annotation.IPAMPoolKey:     "custom-pool",
-					},
-				},
-			},
-			podKey("default", "custom-workload4"): &slim_core_v1.Pod{
-				ObjectMeta: slim_meta_v1.ObjectMeta{
-					Annotations: map[string]string{
-						annotation.IPAMIPv4PoolKey: "ipv4-pool",
-						annotation.IPAMIPv6PoolKey: "ipv6-pool",
-					},
-				},
-			},
-			podKey("default", "custom-workload5"): &slim_core_v1.Pod{
-				ObjectMeta: slim_meta_v1.ObjectMeta{
-					Annotations: map[string]string{
-						annotation.IPAMIPv4PoolKey: "ipv4-pool",
-						annotation.IPAMIPv6PoolKey: "ipv6-pool",
-						annotation.IPAMPoolKey:     "custom-pool",
-					},
-				},
-			},
-
-			podKey("special", "server"): &slim_core_v1.Pod{},
-			podKey("special", "server2"): &slim_core_v1.Pod{
-				ObjectMeta: slim_meta_v1.ObjectMeta{
-					Annotations: map[string]string{
-						annotation.IPAMPoolKey: "pod-pool",
-					},
-				},
-			},
-
-			podKey("missing-ns", "pod"): &slim_core_v1.Pod{},
-		},
+		pods: pods,
 	}
+
+	txn := db.WriteTxn(pods)
+	newPod := func(namespace, name string, annotations map[string]string) k8s.LocalPod {
+		return k8s.LocalPod{Pod: &slim_core_v1.Pod{
+			ObjectMeta: slim_meta_v1.ObjectMeta{
+				Namespace:   namespace,
+				Name:        name,
+				Annotations: annotations,
+			},
+		}}
+	}
+	pods.Insert(txn, newPod("default", "client", nil))
+	pods.Insert(txn, newPod("default", "custom-workload",
+		map[string]string{
+			annotation.IPAMPoolKey: "custom-pool",
+		}))
+	pods.Insert(txn, newPod("default", "custom-workload2",
+		map[string]string{
+			annotation.IPAMIPv4PoolKey: "ipv4-pool",
+		}))
+	pods.Insert(txn, newPod("default", "custom-workload3",
+		map[string]string{
+			annotation.IPAMIPv4PoolKey: "ipv4-pool",
+			annotation.IPAMPoolKey:     "custom-pool",
+		}))
+	pods.Insert(txn, newPod("default", "custom-workload4",
+		map[string]string{
+			annotation.IPAMIPv4PoolKey: "ipv4-pool",
+			annotation.IPAMIPv6PoolKey: "ipv6-pool",
+		}))
+	pods.Insert(txn, newPod("default", "custom-workload5",
+		map[string]string{
+			annotation.IPAMIPv4PoolKey: "ipv4-pool",
+			annotation.IPAMIPv6PoolKey: "ipv6-pool",
+			annotation.IPAMPoolKey:     "custom-pool",
+		}))
+
+	pods.Insert(txn, newPod("special", "server", nil))
+	pods.Insert(txn, newPod("special", "server2",
+		map[string]string{
+			annotation.IPAMPoolKey: "pod-pool",
+		}))
+	pods.Insert(txn, newPod("missing-ns", "pod", nil))
+	txn.Commit()
 
 	tests := []struct {
 		name     string

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -30,7 +30,7 @@ func Test_No_Resources_InitK8sSubsystem(t *testing.T) {
 		fakeClientSet,
 		&K8sPodWatcher{
 			controllersStarted: make(chan struct{}),
-			podStoreSet:        make(chan struct{}),
+			allPodsStoreSet:    make(chan struct{}),
 		},
 		nil,
 		nil,

--- a/pkg/loadbalancer/experimental/benchmark/benchmark.go
+++ b/pkg/loadbalancer/experimental/benchmark/benchmark.go
@@ -22,9 +22,11 @@ import (
 	"github.com/cilium/stream"
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 
+	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_discovery_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
@@ -85,11 +87,6 @@ func RunBenchmark(testSize int, iterations int, loglevel slog.Level, validate bo
 		Kind: resource.Sync,
 		Done: func(error) {},
 	}
-	pods := make(chan resource.Event[*slim_corev1.Pod], 1)
-	pods <- resource.Event[*slim_corev1.Pod]{
-		Kind: resource.Sync,
-		Done: func(error) {},
-	}
 	endpoints := make(chan resource.Event[*k8s.Endpoints], 1000)
 	endpoints <- resource.Event[*k8s.Endpoints]{
 		Kind: resource.Sync,
@@ -101,7 +98,7 @@ func RunBenchmark(testSize int, iterations int, loglevel slog.Level, validate bo
 		db     *statedb.DB
 		bo     *experimental.BPFOps
 	)
-	h := testHive(maps, services, pods, endpoints, &writer, &db, &bo)
+	h := testHive(maps, services, endpoints, &writer, &db, &bo)
 
 	if err := h.Start(log, context.TODO()); err != nil {
 		panic(err)
@@ -505,7 +502,6 @@ var (
 
 func testHive(maps experimental.LBMaps,
 	services chan resource.Event[*slim_corev1.Service],
-	pods chan resource.Event[*slim_corev1.Pod],
 	endpoints chan resource.Event[*k8s.Endpoints],
 	writer **experimental.Writer,
 	db **statedb.DB,
@@ -523,6 +519,8 @@ func testHive(maps experimental.LBMaps,
 			"loadbalancer-test",
 			"Test module",
 
+			client.FakeClientCell,
+
 			cell.Provide(
 				func() experimental.Config {
 					return experimental.Config{
@@ -537,7 +535,6 @@ func testHive(maps experimental.LBMaps,
 					return experimental.StreamsOut{
 						ServicesStream:  stream.FromChannel(services),
 						EndpointsStream: stream.FromChannel(endpoints),
-						PodsStream:      stream.FromChannel(pods),
 					}
 				},
 
@@ -552,6 +549,8 @@ func testHive(maps experimental.LBMaps,
 					return maglev.New(maglevConfig, lc)
 				},
 			),
+
+			daemonk8s.PodTableCell,
 
 			cell.Invoke(func(db_ *statedb.DB, w *experimental.Writer, bo_ *experimental.BPFOps) {
 				*db = db_

--- a/pkg/loadbalancer/experimental/cell.go
+++ b/pkg/loadbalancer/experimental/cell.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cilium/statedb"
 	"github.com/cilium/stream"
 
-	daemonK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -86,14 +85,12 @@ type resourceIn struct {
 	cell.In
 	ServicesResource  resource.Resource[*slim_corev1.Service]
 	EndpointsResource resource.Resource[*k8s.Endpoints]
-	PodsResource      daemonK8s.LocalPodResource
 }
 
 type StreamsOut struct {
 	cell.Out
 	ServicesStream  stream.Observable[resource.Event[*slim_corev1.Service]]
 	EndpointsStream stream.Observable[resource.Event[*k8s.Endpoints]]
-	PodsStream      stream.Observable[resource.Event[*slim_corev1.Pod]]
 }
 
 // resourcesToStreams extracts the stream.Observable from resource.Resource.
@@ -102,6 +99,5 @@ func resourcesToStreams(in resourceIn) StreamsOut {
 	return StreamsOut{
 		ServicesStream:  in.ServicesResource,
 		EndpointsStream: in.EndpointsResource,
-		PodsStream:      in.PodsResource,
 	}
 }

--- a/pkg/loadbalancer/experimental/cell_test.go
+++ b/pkg/loadbalancer/experimental/cell_test.go
@@ -27,6 +27,7 @@ func TestCell(t *testing.T) {
 	h := hive.New(
 		client.FakeClientCell,
 		daemonk8s.ResourcesCell,
+		daemonk8s.TablesCell,
 		maglev.Cell,
 		Cell,
 		cell.Provide(source.NewSources),

--- a/pkg/loadbalancer/experimental/script_test.go
+++ b/pkg/loadbalancer/experimental/script_test.go
@@ -56,12 +56,14 @@ func TestScript(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
+
 	scripttest.Test(t,
 		ctx,
 		func(t testing.TB, args []string) *script.Engine {
 			h := hive.New(
 				client.FakeClientCell,
 				daemonk8s.ResourcesCell,
+				daemonk8s.TablesCell,
 				Cell,
 				cell.Config(TestConfig{
 					// By default 10% of the time the LBMap operations fail

--- a/pkg/redirectpolicy/cell.go
+++ b/pkg/redirectpolicy/cell.go
@@ -5,6 +5,7 @@ package redirectpolicy
 
 import (
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
 
 	serviceapi "github.com/cilium/cilium/api/v1/server/restapi/service"
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
@@ -25,15 +26,16 @@ var Cell = cell.Module(
 type lrpManagerParams struct {
 	cell.In
 
+	DB             *statedb.DB
 	Svc            service.ServiceManager
 	SvcCache       *k8s.ServiceCache
-	Lpr            agentK8s.LocalPodResource
+	Pods           statedb.Table[agentK8s.LocalPod]
 	Ep             endpointmanager.EndpointManager
 	MetricsManager LRPMetrics
 }
 
 func newLRPManager(params lrpManagerParams) *Manager {
-	return NewRedirectPolicyManager(params.Svc, params.SvcCache, params.Lpr, params.Ep, params.MetricsManager)
+	return NewRedirectPolicyManager(params.DB, params.Svc, params.SvcCache, params.Pods, params.Ep, params.MetricsManager)
 }
 
 func newLRPApiHandler(lrpManager *Manager) serviceapi.GetLrpHandler {

--- a/pkg/redirectpolicy/manager_test.go
+++ b/pkg/redirectpolicy/manager_test.go
@@ -4,17 +4,17 @@
 package redirectpolicy
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"net/netip"
 	"sync"
 	"testing"
 
+	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/tools/cache"
 
+	agentk8s "github.com/cilium/cilium/daemon/k8s"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -30,9 +30,11 @@ import (
 )
 
 type ManagerSuite struct {
-	rpm *Manager
-	svc svcManager
-	epM endpointManager
+	db   *statedb.DB
+	pods statedb.RWTable[agentk8s.LocalPod]
+	rpm  *Manager
+	svc  svcManager
+	epM  endpointManager
 }
 
 func setupManagerSuite(tb testing.TB) *ManagerSuite {
@@ -40,11 +42,13 @@ func setupManagerSuite(tb testing.TB) *ManagerSuite {
 
 	m := &ManagerSuite{}
 	m.svc = &fakeSvcManager{}
-	fpr := &fakePodResource{
-		fakePodStore{},
-	}
 	m.epM = &fakeEpManager{}
-	m.rpm = NewRedirectPolicyManager(m.svc, nil, fpr, m.epM, NewLRPMetricsNoop())
+	var err error
+	m.db = statedb.New()
+	m.pods, err = agentk8s.NewPodTable(m.db)
+	require.NoError(tb, err, "NewPodTable")
+	m.rpm = NewRedirectPolicyManager(m.db, m.svc, nil, m.pods, m.epM, NewLRPMetricsNoop())
+
 	configAddrType = LRPConfig{
 		id: k8s.ServiceID{
 			Name:      "test-foo",
@@ -104,52 +108,6 @@ func (f *fakeSvcManager) TerminateUDPConnectionsToBackend(l3n4Addr *lb.L3n4Addr)
 	if f.destroyConnectionEvents != nil {
 		f.destroyConnectionEvents <- *l3n4Addr
 	}
-}
-
-type fakePodResource struct {
-	store fakePodStore
-}
-
-func (fpr *fakePodResource) Observe(ctx context.Context, next func(resource.Event[*slimcorev1.Pod]), complete func(error)) {
-	panic("unimplemented")
-}
-func (fpr *fakePodResource) Events(ctx context.Context, opts ...resource.EventsOpt) <-chan resource.Event[*slimcorev1.Pod] {
-	panic("unimplemented")
-}
-func (fpr *fakePodResource) Store(context.Context) (resource.Store[*slimcorev1.Pod], error) {
-	return &fpr.store, nil
-}
-
-type fakePodStore struct {
-	OnList func() []*slimcorev1.Pod
-	Pods   map[resource.Key]*slimcorev1.Pod
-}
-
-func (ps *fakePodStore) List() []*slimcorev1.Pod {
-	if ps.OnList != nil {
-		return ps.OnList()
-	}
-	pods := []*slimcorev1.Pod{pod1, pod2}
-	return pods
-}
-
-func (ps *fakePodStore) IterKeys() resource.KeyIter { return nil }
-func (ps *fakePodStore) Get(obj *slimcorev1.Pod) (item *slimcorev1.Pod, exists bool, err error) {
-	return nil, false, nil
-}
-func (ps *fakePodStore) GetByKey(key resource.Key) (item *slimcorev1.Pod, exists bool, err error) {
-	if len(ps.Pods) != 0 {
-		return ps.Pods[key], true, nil
-	}
-	return nil, false, nil
-}
-func (ps *fakePodStore) CacheStore() cache.Store { return nil }
-
-func (ps *fakePodStore) IndexKeys(indexName, indexedValue string) ([]string, error) { return nil, nil }
-func (ps *fakePodStore) ByIndex(indexName, indexedValue string) ([]*slimcorev1.Pod, error) {
-	return nil, nil
-}
-func (ps *fakePodStore) Release() {
 }
 
 type fakeEpManager struct {
@@ -393,6 +351,11 @@ func TestManager_AddRedirectPolicy_SvcMatcherDuplicateConfig(t *testing.T) {
 func TestManager_AddrMatcherConfigSinglePort(t *testing.T) {
 	m := setupManagerSuite(t)
 
+	txn := m.db.WriteTxn(m.pods)
+	m.pods.Insert(txn, agentk8s.LocalPod{Pod: pod1})
+	m.pods.Insert(txn, agentk8s.LocalPod{Pod: pod2})
+	txn.Commit()
+
 	// Add an addressMatcher type LRP with single port. The policy config
 	// frontend should have 2 pod backends with each of the podIPs.
 	podIPs := utils.ValidIPs(pod1.Status)
@@ -497,14 +460,10 @@ func TestManager_AddrMatcherConfigSinglePortMulPods(t *testing.T) {
 	newPod2 := pod2.DeepCopy()
 	newPod2.Labels["test"] = "foo"
 
-	psg := &fakePodResource{
-		fakePodStore{
-			OnList: func() []*slimcorev1.Pod {
-				return []*slimcorev1.Pod{pod1, newPod2}
-			},
-		},
-	}
-	m.rpm.localPods = psg
+	txn := m.db.WriteTxn(m.pods)
+	m.pods.Insert(txn, agentk8s.LocalPod{Pod: pod1})
+	m.pods.Insert(txn, agentk8s.LocalPod{Pod: newPod2})
+	txn.Commit()
 
 	// Add an addressMatcher type LRP with single port. The policy config
 	// frontend should have 4 pod backends with each of the podIPs.
@@ -556,6 +515,10 @@ func TestManager_AddrMatcherConfigSinglePortMulPods(t *testing.T) {
 // for an addressMatcher config with a frontend having multiple named ports.
 func TestManager_AddrMatcherConfigMultiplePorts(t *testing.T) {
 	m := setupManagerSuite(t)
+	txn := m.db.WriteTxn(m.pods)
+	m.pods.Insert(txn, agentk8s.LocalPod{Pod: pod1})
+	m.pods.Insert(txn, agentk8s.LocalPod{Pod: pod2})
+	txn.Commit()
 
 	// Add an addressMatcher type LRP with multiple named ports.
 	configAddrType.frontendType = addrFrontendNamedPorts
@@ -641,14 +604,10 @@ func TestManager_AddrMatcherConfigMultiplePortsMulPods(t *testing.T) {
 	newPod2 := pod2.DeepCopy()
 	newPod2.Labels["test"] = "foo"
 
-	psg := &fakePodResource{
-		fakePodStore{
-			OnList: func() []*slimcorev1.Pod {
-				return []*slimcorev1.Pod{pod1, newPod2}
-			},
-		},
-	}
-	m.rpm.localPods = psg
+	txn := m.db.WriteTxn(m.pods)
+	m.pods.Insert(txn, agentk8s.LocalPod{Pod: pod1})
+	m.pods.Insert(txn, agentk8s.LocalPod{Pod: newPod2})
+	txn.Commit()
 
 	// Add an addressMatcher type LRP with multiple named ports.
 	configAddrType.frontendType = addrFrontendNamedPorts
@@ -758,14 +717,9 @@ func TestManager_AddrMatcherConfigDualStack(t *testing.T) {
 		podID:    pod3ID,
 	}}
 	pod3.Status.PodIPs = append(pod3.Status.PodIPs, pod3v6)
-	psg := &fakePodResource{
-		fakePodStore{
-			OnList: func() []*slimcorev1.Pod {
-				return []*slimcorev1.Pod{pod3}
-			},
-		},
-	}
-	m.rpm.localPods = psg
+	txn := m.db.WriteTxn(m.pods)
+	m.pods.Insert(txn, agentk8s.LocalPod{Pod: pod3})
+	txn.Commit()
 
 	added, err := m.rpm.AddRedirectPolicy(configAddrType)
 
@@ -844,18 +798,18 @@ func TestManager_OnAddRedirectPolicy(t *testing.T) {
 	pod := pod1.DeepCopy()
 	pod.Status.PodIPs = []slimcorev1.PodIP{pod1IP1}
 	pods[pk1] = pod
-	fps := &fakePodResource{
-		fakePodStore{
-			Pods: pods,
-		},
+
+	txn := m.db.WriteTxn(m.pods)
+	for _, pod := range pods {
+		m.pods.Insert(txn, agentk8s.LocalPod{Pod: pod})
 	}
-	m.rpm.localPods = fps
+	txn.Commit()
 	ep := &endpoint.Endpoint{
 		K8sPodName:   pod.Name,
 		K8sNamespace: pod.Namespace,
 		NetNsCookie:  1234,
 	}
-	m.rpm = NewRedirectPolicyManager(m.svc, nil, fps, m.epM, NewLRPMetricsNoop())
+	m.rpm = NewRedirectPolicyManager(m.db, m.svc, nil, m.pods, m.epM, NewLRPMetricsNoop())
 	m.rpm.skipLBMap = &fakeSkipLBMap{lb4Events: lbEvents}
 
 	added, err := m.rpm.AddRedirectPolicy(pc)
@@ -913,14 +867,12 @@ func TestManager_OnAddRedirectPolicy(t *testing.T) {
 	addr, _ := netip.ParseAddr(pod.Status.PodIP)
 	cookies[addr] = cookie
 	m.epM = &fakeEpManager{cookies: cookies}
-	fps = &fakePodResource{
-		fakePodStore{
-			OnList: func() []*slimcorev1.Pod {
-				return []*slimcorev1.Pod{pod}
-			},
-		},
-	}
-	m.rpm = NewRedirectPolicyManager(m.svc, nil, fps, m.epM, NewLRPMetricsNoop())
+
+	txn = m.db.WriteTxn(m.pods)
+	m.pods.DeleteAll(txn)
+	m.pods.Insert(txn, agentk8s.LocalPod{Pod: pod})
+	txn.Commit()
+	m.rpm = NewRedirectPolicyManager(m.db, m.svc, nil, m.pods, m.epM, NewLRPMetricsNoop())
 	lbEvents = make(chan skipLBParams)
 	m.rpm.skipLBMap = &fakeSkipLBMap{lb4Events: lbEvents}
 
@@ -979,12 +931,14 @@ func TestManager_OnAddRedirectPolicy(t *testing.T) {
 		Namespace: pod1.Namespace,
 	}
 	pods[pk1] = pod
-	fps = &fakePodResource{
-		fakePodStore{
-			Pods: pods,
-		},
+
+	txn = m.db.WriteTxn(m.pods)
+	m.pods.DeleteAll(txn)
+	for _, pod := range pods {
+		m.pods.Insert(txn, agentk8s.LocalPod{Pod: pod})
 	}
-	m.rpm = NewRedirectPolicyManager(m.svc, nil, fps, m.epM, NewLRPMetricsNoop())
+	txn.Commit()
+	m.rpm = NewRedirectPolicyManager(m.db, m.svc, nil, m.pods, m.epM, NewLRPMetricsNoop())
 	lbEvents = make(chan skipLBParams)
 	m.rpm.skipLBMap = &fakeSkipLBMap{lb4Events: lbEvents}
 


### PR DESCRIPTION
This kicks off the transition away from `Resource[T]` to `Table[T]` by switching `Resource[*Pod]` into `Table[LocalPod]`. I've talked about the benefits in https://github.com/cilium/cilium/pull/34060. The `daemon/k8s/testdata/pod.txtar` somewhat show-cases the benefits to inspection, testing and indexing. By storing the K8s objects in StateDB tables we get all the machinery for querying, watching for changes, testing (with 'db' script commands) and inspecting with cilium-dbg.

I'm starting with pods as that's needed for https://github.com/cilium/cilium/pull/35652.

I'm not making `Table[LocalPod]` a `OnDemand[Table[LocalPod]]`, e.g. we'll start reflecting pods regardless of whether there's users for it or not, since it's one of the fundamental core k8s objects that we always pull regardless of configuration.

For other conversions we'll need to consider carefully whether or not to start the reflection, or whether to expose the table as the reference counted `OnDemand` resource.
