### PR TITLE
policy: Use no-op ID allocator when policy is disabled

### DIFF
--- a/pkg/identity/cache/cell/utils.go
+++ b/pkg/identity/cache/cell/utils.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package identitycachecell
+
+import "github.com/cilium/cilium/pkg/option"
+
+func netPolicySystemIsEnabled(cfg *option.DaemonConfig) bool {
+	conditions := []bool{
+		cfg.EnablePolicy != option.NeverEnforce,
+		cfg.EnableK8sNetworkPolicy,
+		cfg.EnableCiliumNetworkPolicy,
+		cfg.EnableCiliumClusterwideNetworkPolicy,
+		!cfg.DisableCiliumEndpointCRD,
+		cfg.IdentityAllocationMode != option.IdentityAllocationModeCRD,
+	}
+
+	for _, condition := range conditions {
+		if condition {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/identity/cache/cell/utils_test.go
+++ b/pkg/identity/cache/cell/utils_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package identitycachecell
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/option"
+)
+
+func TestNetPolicySystemIsEnabled(t *testing.T) {
+	type testCase struct {
+		description string
+		want        bool
+
+		enablePolicy    string
+		enableK8sPolicy bool
+		enableCNP       bool
+		enableCCNP      bool
+		disableCEP      bool
+		idAllocMode     string
+	}
+
+	tcs := []testCase{
+		{
+			description: "disabled",
+			want:        false,
+
+			enablePolicy: option.NeverEnforce,
+			disableCEP:   true,
+			idAllocMode:  option.IdentityAllocationModeCRD,
+		},
+		{
+			description: "enabled_all",
+			want:        true,
+
+			enablePolicy:    option.AlwaysEnforce,
+			enableK8sPolicy: true,
+			enableCNP:       true,
+			enableCCNP:      true,
+			disableCEP:      false,
+		},
+		{
+			description: "enabled_only_policy_not_never",
+			want:        true,
+
+			enablePolicy: "test",
+			disableCEP:   true,
+		},
+		{
+			description: "enabled_only_k8s_np_on",
+			want:        true,
+
+			enablePolicy:    option.NeverEnforce,
+			enableK8sPolicy: true,
+			disableCEP:      true,
+		},
+		{
+			description: "enabled_only_cnp_on",
+			want:        true,
+
+			enablePolicy: option.NeverEnforce,
+			enableCNP:    true,
+			disableCEP:   true,
+		},
+		{
+			description: "enabled_only_ccnp_on",
+			want:        true,
+
+			enablePolicy: option.NeverEnforce,
+			enableCCNP:   true,
+			disableCEP:   true,
+		},
+		{
+			description: "enabled_only_cep_crd_on",
+			want:        true,
+
+			enablePolicy: option.NeverEnforce,
+			disableCEP:   false,
+		},
+		{
+			description: "enabled_only_id_alloc_not_crd",
+			want:        true,
+
+			idAllocMode: "test",
+			disableCEP:  false,
+		},
+	}
+
+	for _, tc := range tcs {
+		cfg := &option.DaemonConfig{
+			EnablePolicy:                         tc.enablePolicy,
+			EnableK8sNetworkPolicy:               tc.enableK8sPolicy,
+			EnableCiliumNetworkPolicy:            tc.enableCNP,
+			EnableCiliumClusterwideNetworkPolicy: tc.enableCCNP,
+			DisableCiliumEndpointCRD:             tc.disableCEP,
+			IdentityAllocationMode:               tc.idAllocMode,
+		}
+
+		t.Run(tc.description, func(t *testing.T) {
+			if got := netPolicySystemIsEnabled(cfg); got != tc.want {
+				t.Errorf("policy enabled = %t, want = %t", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/identity/cache/noop_allocator.go
+++ b/pkg/identity/cache/noop_allocator.go
@@ -131,3 +131,8 @@ func (n *NoopIdentityAllocator) ReleaseRestoredIdentities() {
 }
 
 func (n *NoopIdentityAllocator) Close() {}
+
+func (m *NoopIdentityAllocator) Observe(ctx context.Context, next func(IdentityChange), complete func(error)) {
+	// No-op, because identities are not managed.
+	complete(nil)
+}


### PR DESCRIPTION
Ref: https://github.com/cilium/cilium/issues/33360

Conditions for policy disabled:
- EnablePolicy=never
- DisableCiliumEndpointCRD=true
- EnableK8sNetworkPolicy=false
- EnableCiliumNetworkPolicy=false
- EnableCiliumClusterwideNetworkPolicy=false
- IdentityAllocationMode=crd

**Benefits**
Users will be able to improve scalability and performance and reduce resource consumption when network policies are not used. Other than that, users that upgrade will see no difference, because when their configuration already includes CRD ID allocation mode and disabled CEP CRD, features that could utilize these CRDs, like Hubble, already didn’t utilize them.

**Transitions**
When cilium-agent restarts to pick up the changed config, it will work the following way:
- Enabled -> Disabled: No-op allocator is no longer watching for Cilium Identities or allocating global and local identities. The rest is covered by the system, when the mentioned configuration is applied. eBPF maps will be emptied with CEPs, CESs and CIDs, because they are no longer used.
- Disabled -> Enabled: It’s just like starting the network policy enforcement system for the first time. Generation of global resources starts with cilium-agents coming up.


Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>