### PR TITLE
Fix specifying multiple interfaces for egress masquerade with enable-masquerade-to-route-source=false

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -100,7 +100,7 @@ cilium-agent [flags]
       --dynamic-lifecycle-config string                           List of dynamic lifecycle features and their configuration including the dependencies (default "[]")
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
-      --egress-masquerade-interfaces strings                      Limit iptables-based egress masquerading to interface selector
+      --egress-masquerade-interfaces string                       Limit iptables-based egress masquerading to interfaces selector
       --egress-multi-home-ip-rule-compat                          Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.
       --enable-active-connection-tracking                         Count open and active connections to services, grouped by zones defined in fixed-zone-mapping.
       --enable-auto-protect-node-port-range                       Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -333,7 +333,7 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.DisableCiliumEndpointCRDName, false, "Disable use of CiliumEndpoint CRD")
 	option.BindEnv(vp, option.DisableCiliumEndpointCRDName)
 
-	flags.StringSlice(option.MasqueradeInterfaces, []string{}, "Limit iptables-based egress masquerading to interface selector")
+	flags.String(option.MasqueradeInterfaces, "", "Limit iptables-based egress masquerading to interfaces selector")
 	option.BindEnv(vp, option.MasqueradeInterfaces)
 
 	flags.Bool(option.BPFSocketLBHostnsOnly, false, "Skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface. Socket LB is still used when in the host namespace. Required by service mesh (e.g., Istio, Linkerd).")

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1297,30 +1297,12 @@ func (m *Manager) installMasqueradeRules(
 		//     range
 		// * Non-tunnel mode:
 		//   * May not be targeted to an IP in the cluster range
-		progArgs := []string{
-			"-t", "nat",
-			"-A", ciliumPostNatChain,
-			"!", "-d", snatDstExclusionCIDR,
-		}
-		if len(m.sharedCfg.MasqueradeInterfaces) > 0 {
-			progArgs = append(
-				progArgs,
-				"-o", strings.Join(m.sharedCfg.MasqueradeInterfaces, ","))
-		} else {
-			progArgs = append(
-				progArgs,
-				"-s", allocRange,
-				"!", "-o", "cilium_+")
-		}
-		progArgs = append(
-			progArgs,
-			"-m", "comment", "--comment", "cilium masquerade non-cluster",
-			"-j", "MASQUERADE")
-		if m.cfg.IPTablesRandomFully {
-			progArgs = append(progArgs, "--random-fully")
-		}
-		if err := prog.runProg(progArgs); err != nil {
-			return err
+		cmds := allEgressMasqueradeCmds(allocRange, snatDstExclusionCIDR, m.sharedCfg.MasqueradeInterfaces,
+			m.cfg.IPTablesRandomFully)
+		for _, cmd := range cmds {
+			if err := prog.runProg(cmd); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -1819,3 +1801,39 @@ func nodeIpsetNATCmds(allocRange string, ipset string, masqueradeInterfaces []st
 	return cmds
 }
 
+func allEgressMasqueradeCmds(allocRange string, snatDstExclusionCIDR string,
+	masqueradeInterfaces []string, iptablesRandomFully bool) [][]string {
+	preArgs := []string{
+		"-t", "nat",
+		"-A", ciliumPostNatChain,
+		"!", "-d", snatDstExclusionCIDR,
+	}
+
+	postArgs := []string{
+		"-m", "comment", "--comment", "cilium masquerade non-cluster",
+		"-j", "MASQUERADE",
+	}
+
+	if len(masqueradeInterfaces) == 0 {
+		cmd := append(preArgs,
+			"-s", allocRange,
+			"!", "-o", "cilium_+",
+		)
+		cmd = append(cmd, postArgs...)
+		if iptablesRandomFully {
+			cmd = append(cmd, "--random-fully")
+		}
+		return [][]string{cmd}
+	}
+
+	cmds := make([][]string, 0, len(masqueradeInterfaces))
+	for _, inf := range masqueradeInterfaces {
+		cmd := append(preArgs, "-o", inf)
+		cmd = append(cmd, postArgs...)
+		if iptablesRandomFully {
+			cmd = append(cmd, "--random-fully")
+		}
+		cmds = append(cmds, cmd)
+	}
+	return cmds
+}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1179,28 +1179,11 @@ func (m *Manager) installMasqueradeRules(
 	devices := nativeDevices
 
 	if m.sharedCfg.NodeIpsetNeeded {
-		// Exclude traffic to nodes from masquerade.
-		progArgs := []string{
-			"-t", "nat",
-			"-A", ciliumPostNatChain,
-		}
-
-		// If MasqueradeInterfaces is set, we need to mirror base condition of the
-		// "cilium masquerade non-cluster" rule below, as the allocRange might not
-		// be valid in such setups (e.g. in ENI mode).
-		if len(m.sharedCfg.MasqueradeInterfaces) > 0 {
-			progArgs = append(progArgs, "-o", strings.Join(m.sharedCfg.MasqueradeInterfaces, ","))
-		} else {
-			progArgs = append(progArgs, "-s", allocRange)
-		}
-
-		progArgs = append(progArgs,
-			"-m", "set", "--match-set", prog.getIpset(), "dst",
-			"-m", "comment", "--comment", "exclude traffic to cluster nodes from masquerade",
-			"-j", "ACCEPT",
-		)
-		if err := prog.runProg(progArgs); err != nil {
-			return err
+		cmds := nodeIpsetNATCmds(allocRange, prog.getIpset(), m.sharedCfg.MasqueradeInterfaces)
+		for _, cmd := range cmds {
+			if err := prog.runProg(cmd); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -1806,3 +1789,33 @@ func (m *Manager) addCiliumENIRules() error {
 		"-m", "comment", "--comment", "cilium: primary ENI",
 		"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask})
 }
+
+func nodeIpsetNATCmds(allocRange string, ipset string, masqueradeInterfaces []string) [][]string {
+	// Exclude traffic to nodes from masquerade.
+	preArgs := []string{
+		"-t", "nat",
+		"-A", ciliumPostNatChain,
+	}
+
+	postArgs := []string{
+		"-m", "set", "--match-set", ipset, "dst",
+		"-m", "comment", "--comment", "exclude traffic to cluster nodes from masquerade",
+		"-j", "ACCEPT",
+	}
+
+	if len(masqueradeInterfaces) == 0 {
+		cmd := append(preArgs, "-s", allocRange)
+		return [][]string{append(cmd, postArgs...)}
+	}
+
+	// If MasqueradeInterfaces is set, we need to mirror base condition of the
+	// "cilium masquerade non-cluster" rule below, as the allocRange might not
+	// be valid in such setups (e.g. in ENI mode).
+	cmds := make([][]string, 0, len(masqueradeInterfaces))
+	for _, inf := range masqueradeInterfaces {
+		cmd := append(preArgs, "-o", inf)
+		cmds = append(cmds, append(cmd, postArgs...))
+	}
+	return cmds
+}
+

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type expectation struct {
@@ -609,5 +611,75 @@ func TestRemoveCiliumRulesv6(t *testing.T) {
 	err := mockIp6tables.checkExpectations()
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestNodeIpsetNATCmds(t *testing.T) {
+	allocRange := "10.0.0.0/16"
+	ipset := "1.1.1.1"
+	tests := []struct {
+		masqueradeInterfaces []string
+		expected             [][]string
+	}{
+		{
+			expected: [][]string{
+				{
+					"-t", "nat",
+					"-A", "CILIUM_POST_nat",
+					"-s", "10.0.0.0/16",
+					"-m", "set",
+					"--match-set", "1.1.1.1", "dst",
+					"-m", "comment",
+					"--comment", "exclude traffic to cluster nodes from masquerade",
+					"-j", "ACCEPT",
+				},
+			},
+		},
+		{
+			masqueradeInterfaces: []string{"eth+"},
+			expected: [][]string{
+				{
+					"-t", "nat",
+					"-A", "CILIUM_POST_nat",
+					"-o", "eth+",
+					"-m", "set",
+					"--match-set", "1.1.1.1", "dst",
+					"-m", "comment",
+					"--comment", "exclude traffic to cluster nodes from masquerade",
+					"-j", "ACCEPT",
+				},
+			},
+		},
+		{
+			masqueradeInterfaces: []string{"eth+", "ens+"},
+			expected: [][]string{
+				{
+					"-t", "nat",
+					"-A", "CILIUM_POST_nat",
+					"-o", "eth+",
+					"-m", "set",
+					"--match-set", "1.1.1.1", "dst",
+					"-m", "comment",
+					"--comment", "exclude traffic to cluster nodes from masquerade",
+					"-j", "ACCEPT",
+				},
+				{
+					"-t", "nat",
+					"-A", "CILIUM_POST_nat",
+					"-o", "ens+",
+					"-m", "set",
+					"--match-set", "1.1.1.1", "dst",
+					"-m", "comment",
+					"--comment", "exclude traffic to cluster nodes from masquerade",
+					"-j", "ACCEPT",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		actual := nodeIpsetNATCmds(allocRange, ipset, tt.masqueradeInterfaces)
+
+		assert.Equal(t, tt.expected, actual)
 	}
 }

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -683,3 +683,114 @@ func TestNodeIpsetNATCmds(t *testing.T) {
 		assert.Equal(t, tt.expected, actual)
 	}
 }
+
+func TestAllEgressMasqueradeCmds(t *testing.T) {
+	allocRange := "10.0.0.0/16"
+	snatDstExclusionCIDR := "192.168.0.0/16"
+	tests := []struct {
+		masqueradeInterfaces []string
+		iptablesRandomFull   bool
+		expected             [][]string
+	}{
+		{
+			expected: [][]string{
+				{
+					"-t", "nat",
+					"-A", "CILIUM_POST_nat", "!",
+					"-d", "192.168.0.0/16",
+					"-s", "10.0.0.0/16", "!",
+					"-o", "cilium_+",
+					"-m", "comment",
+					"--comment", "cilium masquerade non-cluster",
+					"-j", "MASQUERADE",
+				},
+			},
+		},
+		{
+			iptablesRandomFull: true,
+			expected: [][]string{
+				{
+					"-t", "nat",
+					"-A", "CILIUM_POST_nat", "!",
+					"-d", "192.168.0.0/16",
+					"-s", "10.0.0.0/16", "!",
+					"-o", "cilium_+",
+					"-m", "comment",
+					"--comment", "cilium masquerade non-cluster",
+					"-j", "MASQUERADE",
+					"--random-fully",
+				},
+			},
+		},
+		{
+			masqueradeInterfaces: []string{"eth+"},
+			expected: [][]string{
+				{
+					"-t", "nat",
+					"-A", "CILIUM_POST_nat", "!",
+					"-d", "192.168.0.0/16",
+					"-o", "eth+",
+					"-m", "comment",
+					"--comment", "cilium masquerade non-cluster",
+					"-j", "MASQUERADE",
+				},
+			},
+		},
+		{
+			masqueradeInterfaces: []string{"eth+", "ens+"},
+			expected: [][]string{
+				{
+					"-t", "nat",
+					"-A", "CILIUM_POST_nat", "!",
+					"-d", "192.168.0.0/16",
+					"-o", "eth+",
+					"-m", "comment",
+					"--comment", "cilium masquerade non-cluster",
+					"-j", "MASQUERADE",
+				},
+				{
+					"-t", "nat",
+					"-A", "CILIUM_POST_nat", "!",
+					"-d", "192.168.0.0/16",
+					"-o", "ens+",
+					"-m", "comment",
+					"--comment", "cilium masquerade non-cluster",
+					"-j", "MASQUERADE",
+				},
+			},
+		},
+		{
+			masqueradeInterfaces: []string{"eth+", "ens+"},
+			iptablesRandomFull:   true,
+			expected: [][]string{
+				{
+					"-t", "nat",
+					"-A", "CILIUM_POST_nat", "!",
+					"-d", "192.168.0.0/16",
+					"-o", "eth+",
+					"-m", "comment",
+					"--comment", "cilium masquerade non-cluster",
+					"-j", "MASQUERADE",
+					"--random-fully",
+				},
+				{
+					"-t", "nat",
+					"-A", "CILIUM_POST_nat", "!",
+					"-d", "192.168.0.0/16",
+					"-o", "ens+",
+					"-m", "comment",
+					"--comment", "cilium masquerade non-cluster",
+					"-j", "MASQUERADE",
+					"--random-fully",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		actual := allEgressMasqueradeCmds(allocRange, snatDstExclusionCIDR, tt.masqueradeInterfaces,
+			tt.iptablesRandomFull)
+
+		assert.Equal(t, tt.expected, actual)
+	}
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1997,11 +1997,8 @@ type DaemonConfig struct {
 	IPv6NativeRoutingCIDR *cidr.CIDR
 
 	// MasqueradeInterfaces is the selector used to select interfaces subject
-	// to egress masquerading. EgressMasqueradeInterfaces is the same but as
-	// a string representation. It's deprecated and can be removed once the GH
-	// issue https://github.com/cilium/cilium-cli/issues/1896 is fixed.
-	MasqueradeInterfaces       []string
-	EgressMasqueradeInterfaces string
+	// to egress masquerading.
+	MasqueradeInterfaces []string
 
 	// PolicyTriggerInterval is the amount of time between when policy updates
 	// are triggered.
@@ -2835,7 +2832,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableTCX = vp.GetBool(EnableTCX)
 	c.DisableCiliumEndpointCRD = vp.GetBool(DisableCiliumEndpointCRDName)
 	c.MasqueradeInterfaces = vp.GetStringSlice(MasqueradeInterfaces)
-	c.EgressMasqueradeInterfaces = strings.Join(c.MasqueradeInterfaces, ",")
 	c.BPFSocketLBHostnsOnly = vp.GetBool(BPFSocketLBHostnsOnly)
 	c.EnableSocketLB = vp.GetBool(EnableSocketLB)
 	c.EnableSocketLBTracing = vp.GetBool(EnableSocketLBTracing)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2831,7 +2831,9 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableXDPPrefilter = vp.GetBool(EnableXDPPrefilter)
 	c.EnableTCX = vp.GetBool(EnableTCX)
 	c.DisableCiliumEndpointCRD = vp.GetBool(DisableCiliumEndpointCRDName)
-	c.MasqueradeInterfaces = vp.GetStringSlice(MasqueradeInterfaces)
+	if masqInfs := vp.GetString(MasqueradeInterfaces); masqInfs != "" {
+		c.MasqueradeInterfaces = strings.Split(masqInfs, ",")
+	}
 	c.BPFSocketLBHostnsOnly = vp.GetBool(BPFSocketLBHostnsOnly)
 	c.EnableSocketLB = vp.GetBool(EnableSocketLB)
 	c.EnableSocketLBTracing = vp.GetBool(EnableSocketLBTracing)


### PR DESCRIPTION
This PR introduces fix for `egressMasqueradeInterfaces` multiple interfaces support.
Multi-interface support can be helpful when cluster contains nodes with different operation systems and network interfaces might have different names
E.g.: EKS cluster upgrade to Amazon Linux 2023 that uses `ens` instead of `eth`.

Usage example via Cilium CLI:
```
cilium install --helm-set=egressMasqueradeInterfaces=eth+\,ens+ ...
```

Please see per commit for full details.