### PR TITLE
cli: Don't ignore datapath bug packet drops

### DIFF
--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -159,7 +159,6 @@ var (
 		"Unsupported protocol for NAT masquerade",
 		"Invalid source ip",
 		"Unknown L3 target address",
-		"No tunnel/encapsulation endpoint (datapath BUG!)",
 		"Host datapath not ready",
 		"Unknown ICMPv4 code",
 		"Forbidden ICMPv6 message",


### PR DESCRIPTION
Packet drops with reason `No tunnel/encapsulation endpoint (datapath BUG!)` look highly suspicious. Yet, I allowlisted it in CI in commit 4d0d9bf15df9 ("defaults: Add expected drop reasons") and didn't explain where it was seen 😬

This pull request removes it from the list of packet drops that are expected in CI. It doesn't seem to be occurring anymore, so maybe it was just my mistake. And if it ever happens again in CI, it's definitely something we'll want to investigate.