### PR TITLE
[v1.14] author backport: lrp: update LRP services with stale backends on agent restart

### DIFF
--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -482,6 +482,9 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState, endpointsR
 								swg := lock.NewStoppableWaitGroup()
 								for _, svc := range stale {
 									d.k8sWatcher.K8sSvcCache.EnsureService(svc, swg)
+									if option.Config.EnableLocalRedirectPolicy {
+										d.redirectPolicyManager.EnsureService(svc)
+									}
 								}
 
 								swg.Stop()

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -167,6 +167,7 @@ type redirectPolicyManager interface {
 	AddRedirectPolicy(config redirectpolicy.LRPConfig) (bool, error)
 	DeleteRedirectPolicy(config redirectpolicy.LRPConfig) error
 	OnAddService(svcID k8s.ServiceID)
+	EnsureService(svcID k8s.ServiceID) (bool, error)
 	OnDeleteService(svcID k8s.ServiceID)
 	OnUpdatePod(pod *slim_corev1.Pod, needsReassign bool, ready bool)
 	OnDeletePod(pod *slim_corev1.Pod)

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 
 	"github.com/cilium/ebpf"
@@ -226,6 +227,33 @@ func (rpm *Manager) OnAddService(svcID k8s.ServiceID) {
 		}
 		rpm.getAndUpsertPolicySvcConfig(config)
 	}
+}
+
+// EnsureService ensures that the LRP service is updated to the latest state.
+// It is called after synchronization is complete during agent startup.
+func (rpm *Manager) EnsureService(svcID k8s.ServiceID) (bool, error) {
+	rpm.mutex.Lock()
+	defer rpm.mutex.Unlock()
+
+	if len(rpm.policyConfigs) == 0 {
+		return false, nil
+	}
+
+	if svcName, found := strings.CutSuffix(svcID.Name, localRedirectSvcStr); found {
+		id := k8s.ServiceID{
+			Name:      svcName,
+			Namespace: svcID.Namespace,
+		}
+
+		if config, ok := rpm.policyConfigs[id]; ok && config.lrpType == lrpConfigTypeSvc {
+			if err := rpm.getAndUpsertPolicySvcConfig(config); err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // OnDeleteService handles Kubernetes service deletes, and deletes the internal state

--- a/pkg/redirectpolicy/manager_test.go
+++ b/pkg/redirectpolicy/manager_test.go
@@ -559,3 +559,37 @@ func (m *ManagerSuite) TestManager_OnAddandUpdatePod(c *C) {
 	_, found = m.rpm.policyPods[podID]
 	c.Assert(found, Equals, false)
 }
+
+// Tests if EnsureService only processes the LRP type service
+func (m *ManagerSuite) TestManager_EnsureService(c *C) {
+	configSvc := configSvcType
+	configSvc.serviceID = &k8s.ServiceID{
+		Name:      "foo",
+		Namespace: "ns1",
+	}
+	m.rpm.policyConfigs[configSvc.id] = &configSvc
+
+	processed, err := m.rpm.EnsureService(k8s.ServiceID{
+		Name:      "test-foo" + localRedirectSvcStr,
+		Namespace: "ns1",
+	})
+
+	c.Assert(processed, Equals, true)
+	c.Assert(err, IsNil)
+
+	processed, err = m.rpm.EnsureService(k8s.ServiceID{
+		Name:      "test-foo",
+		Namespace: "ns1",
+	})
+
+	c.Assert(processed, Equals, false)
+	c.Assert(err, IsNil)
+
+	processed, err = m.rpm.EnsureService(k8s.ServiceID{
+		Name:      "test-foo" + localRedirectSvcStr,
+		Namespace: "ns2",
+	})
+
+	c.Assert(processed, Equals, false)
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
This PR is an author backport for https://github.com/cilium/cilium/pull/36036