### PR TITLE
cilium-cli/install: remove deprecated no-op --disable-check flag

### DIFF
--- a/cilium-cli/cli/install.go
+++ b/cilium-cli/cli/install.go
@@ -26,8 +26,6 @@ func addCommonInstallFlags(cmd *cobra.Command, params *install.Parameters) {
 	cmd.Flags().StringVar(&params.DatapathMode, "datapath-mode", "", "Datapath mode to use { tunnel | native | aws-eni | gke | azure | aks-byocni } (default: autodetected).")
 	cmd.Flags().BoolVar(&params.ListVersions, "list-versions", false, "List all the available versions without actually installing")
 	cmd.Flags().BoolVar(&params.NodesWithoutCilium, "nodes-without-cilium", false, "Configure the affinities to avoid scheduling Cilium components on nodes labeled with cilium.io/no-schedule. It is assumed that the infrastructure has set up routing on these nodes to provide connectivity within the Cilium cluster.")
-	cmd.Flags().StringSliceVar(&params.DisableChecks, "disable-check", []string{}, "Disable a particular validation check")
-	cmd.Flags().MarkDeprecated("disable-check", "cilium-cli no longer performs any validation checks.")
 }
 
 // addCommonUninstallFlags adds uninstall command flags that are shared between classic and helm mode.

--- a/cilium-cli/install/install.go
+++ b/cilium-cli/install/install.go
@@ -95,7 +95,6 @@ type Parameters struct {
 	Namespace             string
 	Writer                io.Writer
 	ClusterName           string
-	DisableChecks         []string
 	Version               string
 	Wait                  bool
 	WaitDuration          time.Duration


### PR DESCRIPTION
Deprecated for CLI release v0.16.20 in commit 16b91de9e121 ("cilium-cli: Deprecate --disable-check flag"). Remove it for the upcoming CLI v0.16.21 release.