### PR TITLE
[fix] update hive to fix cilium shell help panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/cilium/ebpf v0.16.0
 	github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b
 	github.com/cilium/fake v0.6.1
-	github.com/cilium/hive v0.0.0-20241107100319-bedf51d6e63b
+	github.com/cilium/hive v0.0.0-20241122120553-e90d0875ae01
 	github.com/cilium/linters v0.1.0
 	github.com/cilium/lumberjack/v2 v2.4.0
 	github.com/cilium/proxy v0.0.0-20241115112946-fb67566cbd95

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b h1
 github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b/go.mod h1:izWO5C3waDVkh/nt++nNyozXyJAPL6tfFpJSMtzVnwQ=
 github.com/cilium/fake v0.6.1 h1:cLkNx1nkF0b0pPW79JaQxaI5oG2/rBzRKpp0YUg1fTA=
 github.com/cilium/fake v0.6.1/go.mod h1:V9lCbbcsnSf3vB6sdOP7Q0bsUUJ/jyHPZxnFAw5nPUc=
-github.com/cilium/hive v0.0.0-20241107100319-bedf51d6e63b h1:5GbUBPUprdhAB72CRs2+DSArFfFR8n5a4GYer+j1iB8=
-github.com/cilium/hive v0.0.0-20241107100319-bedf51d6e63b/go.mod h1:pI2GJ1n3SLKIQVFrKF7W6A6gb6BQkZ+3Hp4PAEo5SuI=
+github.com/cilium/hive v0.0.0-20241122120553-e90d0875ae01 h1:eNOjtUsqu2W/nTZlInLAj+zyIg/HIQ1K7norewaxsgM=
+github.com/cilium/hive v0.0.0-20241122120553-e90d0875ae01/go.mod h1:pI2GJ1n3SLKIQVFrKF7W6A6gb6BQkZ+3Hp4PAEo5SuI=
 github.com/cilium/linters v0.1.0 h1:ABdLyPBtF+X6oTlTE0AAJbkuo2s1OYaEsP2jb9+7BGY=
 github.com/cilium/linters v0.1.0/go.mod h1:mpr0RBmILRLQu2F7ek+gjBxxuacUB/IBmjDRC3RaFkI=
 github.com/cilium/lumberjack/v2 v2.4.0 h1:toQDgWpB9n2vBod79a5I7ZD/jTAVTrd+IW5ySdYQMmU=

--- a/vendor/github.com/cilium/hive/script.go
+++ b/vendor/github.com/cilium/hive/script.go
@@ -44,7 +44,9 @@ type ScriptCmds struct {
 func (sc ScriptCmds) Map() map[string]script.Cmd {
 	m := make(map[string]script.Cmd, len(sc.ScriptCmds))
 	for _, c := range sc.ScriptCmds {
-		m[c.Name] = c.Cmd
+		if c.Name != "" {
+			m[c.Name] = c.Cmd
+		}
 	}
 	return m
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -264,7 +264,7 @@ github.com/cilium/endpointslice-controller/util/endpointslice
 # github.com/cilium/fake v0.6.1
 ## explicit; go 1.20
 github.com/cilium/fake
-# github.com/cilium/hive v0.0.0-20241107100319-bedf51d6e63b
+# github.com/cilium/hive v0.0.0-20241122120553-e90d0875ae01
 ## explicit; go 1.21.3
 github.com/cilium/hive
 github.com/cilium/hive/cell


### PR DESCRIPTION
When newBPFReconciler is not enabled, it return an empty ScriptCmd. Which cause cilium shell help panic.

https://github.com/cilium/hive/pull/26

`
cilium shell help
`
```
PANIC: runtime error: invalid memory address or nil pointer dereference
goroutine 1947 [running]:
github.com/cilium/cilium/daemon/cmd.shell.handleConn.func2()
	/go/src/github.com/cilium/cilium/daemon/cmd/shell.go:117 +0x78
panic({0x36dd600?, 0x706ef80?})
	/usr/local/go/src/runtime/panic.go:785 +0x124
github.com/cilium/hive/script.(*Engine).ListCmds(0x40004f6b00, {0x4689a00, 0x400045ae00}, 0x0, {0x0?, 0x4c?, 0x4003a55768?})
	/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/script/engine.go:770 +0x104
github.com/cilium/hive/script.DefaultCmds.Help.func13(0x4002173340, {0x7675940?, 0x0, 0x732fec?})
	/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/script/cmds.go:760 +0x3c8
github.com/cilium/hive/script.(*funcCmd).Run(0x0?, 0x2aaaaaaaa?, {0x7675940?, 0x108888?, 0x394dca0?})
	/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/script/cmds.go:73 +0x38
github.com/cilium/hive/script.(*Engine).runCommand(0x4002173340?, 0x4002173340, 0x4003df6ab0, {0x46bd7f8, 0x4001e61860})
	/go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/script/engine.
```

```release-note
Fix `cilium shell help` panic
```
