### PR TITLE
docs: Add the tls:// prefix before the IP address

### DIFF
--- a/Documentation/observability/hubble/configuration/tls.rst
+++ b/Documentation/observability/hubble/configuration/tls.rst
@@ -345,7 +345,7 @@ correct certificate:
 .. code-block:: shell-session
 
     $ kubectl exec -it -n kube-system deployment/hubble-cli -- \
-    hubble observe --server ${IP?}:4244 \
+    hubble observe --server tls://${IP?}:4244 \
         --tls-server-name ${SERVERNAME?} \
         --tls-ca-cert-files /var/lib/hubble-relay/tls/hubble-server-ca.crt \
         --tls-client-cert-file /var/lib/hubble-relay/tls/client.crt \


### PR DESCRIPTION
Add the tls:// prefix before the IP address since Hubble CLI requires that in the newer version.

Here is the Hubble's complain without using the tls://
```

(⎈|kind-kind:default)~/repo/cilium/cilium (pr/liyihuang/add_tls_prefix_for_newer_hubble_cli ✔) kubectl exec -it -n kube-system deployment/hubble-cli -- \
hubble observe --server ${IP?}:4244 \
    --tls-server-name ${SERVERNAME?} \
    --tls-ca-cert-files /var/lib/hubble-relay/tls/hubble-server-ca.crt \
    --tls-client-cert-file /var/lib/hubble-relay/tls/client.crt \
    --tls-client-key-file /var/lib/hubble-relay/tls/client.key

invalid flag(s): transport layer security required
command terminated with exit code 1

----
(⎈|kind-kind:default)~/repo/cilium/cilium (pr/liyihuang/add_tls_prefix_for_newer_hubble_cli ✔) kubectl exec -it -n kube-system deployment/hubble-cli -- \
hubble observe --server tls://${IP?}:4244 \
    --tls-server-name ${SERVERNAME?} \
    --tls-ca-cert-files /var/lib/hubble-relay/tls/hubble-server-ca.crt \
    --tls-client-cert-file /var/lib/hubble-relay/tls/client.crt \
    --tls-client-key-file /var/lib/hubble-relay/tls/client.key

Nov 22 17:08:13.799: 10.1.0.23:40590 (host) <- 10.1.0.143:4240 (health) to-stack FORWARDED (TCP Flags: ACK, PSH)




```