### PR TITLE
bpf: clean up CB_IFINDEX

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1677,7 +1677,7 @@ static __always_inline
 int tail_ipv6_policy(struct __ctx_buff *ctx)
 {
 	struct ipv6_ct_tuple tuple = {};
-	int ret, ifindex = ctx_load_meta(ctx, CB_IFINDEX);
+	bool do_redirect = ctx_load_meta(ctx, CB_DELIVERY_REDIRECT);
 	__u32 src_label = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);
 	bool from_host = ctx_load_and_clear_meta(ctx, CB_FROM_HOST);
 	bool proxy_redirect __maybe_unused = false;
@@ -1686,6 +1686,7 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 	__u16 proxy_port = 0;
 	struct ipv6hdr *ip6;
 	__s8 ext_err = 0;
+	int ret;
 
 #ifdef HAVE_ENCAP
 	from_tunnel = ctx_load_and_clear_meta(ctx, CB_FROM_TUNNEL);
@@ -1715,7 +1716,7 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 		}
 #endif /* !ENABLE_ROUTING && !ENABLE_NODEPORT */
 
-		if (ifindex)
+		if (do_redirect)
 			ret = redirect_ep(ctx, THIS_INTERFACE_IFINDEX, from_host,
 					  from_tunnel);
 		break;
@@ -2025,7 +2026,7 @@ static __always_inline
 int tail_ipv4_policy(struct __ctx_buff *ctx)
 {
 	struct ipv4_ct_tuple tuple = {};
-	int ret, ifindex = ctx_load_meta(ctx, CB_IFINDEX);
+	bool do_redirect = ctx_load_meta(ctx, CB_DELIVERY_REDIRECT);
 	__u32 src_label = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);
 	bool from_host = ctx_load_and_clear_meta(ctx, CB_FROM_HOST);
 	bool proxy_redirect __maybe_unused = false;
@@ -2034,6 +2035,7 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 	__u16 proxy_port = 0;
 	struct iphdr *ip4;
 	__s8 ext_err = 0;
+	int ret;
 
 	ctx_store_meta(ctx, CB_CLUSTER_ID_INGRESS, 0);
 
@@ -2072,7 +2074,7 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 		}
 #endif /* !ENABLE_ROUTING && !ENABLE_NODEPORT */
 
-		if (ifindex)
+		if (do_redirect)
 			ret = redirect_ep(ctx, THIS_INTERFACE_IFINDEX, from_host,
 					  from_tunnel);
 		break;

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -835,15 +835,16 @@ enum {
 #define	CB_ENCRYPT_MAGIC	CB_SRC_LABEL	/* Alias, non-overlapping */
 #define	CB_DST_ENDPOINT_ID	CB_SRC_LABEL    /* Alias, non-overlapping */
 #define CB_SRV6_SID_1		CB_SRC_LABEL	/* Alias, non-overlapping */
-	CB_IFINDEX,
-#define	CB_NAT_46X64		CB_IFINDEX	/* Alias, non-overlapping */
-#define	CB_ADDR_V4		CB_IFINDEX	/* Alias, non-overlapping */
-#define	CB_ADDR_V6_1		CB_IFINDEX	/* Alias, non-overlapping */
-#define	CB_IPCACHE_SRC_LABEL	CB_IFINDEX	/* Alias, non-overlapping */
-#define CB_SRV6_SID_2		CB_IFINDEX	/* Alias, non-overlapping */
-#define CB_CLUSTER_ID_EGRESS	CB_IFINDEX	/* Alias, non-overlapping */
-#define CB_HSIPC_ADDR_V4	CB_IFINDEX	/* Alias, non-overlapping */
-#define CB_TRACED		CB_IFINDEX	/* Alias, non-overlapping */
+	CB_1,
+#define	CB_DELIVERY_REDIRECT	CB_1		/* Alias, non-overlapping */
+#define	CB_NAT_46X64		CB_1		/* Alias, non-overlapping */
+#define	CB_ADDR_V4		CB_1		/* Alias, non-overlapping */
+#define	CB_ADDR_V6_1		CB_1		/* Alias, non-overlapping */
+#define	CB_IPCACHE_SRC_LABEL	CB_1		/* Alias, non-overlapping */
+#define	CB_SRV6_SID_2		CB_1		/* Alias, non-overlapping */
+#define	CB_CLUSTER_ID_EGRESS	CB_1		/* Alias, non-overlapping */
+#define	CB_HSIPC_ADDR_V4	CB_1		/* Alias, non-overlapping */
+#define	CB_TRACED		CB_1		/* Alias, non-overlapping */
 	CB_2,
 #define	CB_ADDR_V6_2		CB_2		/* Alias, non-overlapping */
 #define CB_SRV6_SID_3		CB_2		/* Alias, non-overlapping */

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -103,10 +103,7 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 
 	/* Jumps to destination pod's BPF program to enforce ingress policies. */
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);
-	/* With v1.17+, the actual ifindex is unused and this can be just a
-	 * "needs redirect" boolean flag:
-	 */
-	ctx_store_meta(ctx, CB_IFINDEX, ep->ifindex);
+	ctx_store_meta(ctx, CB_DELIVERY_REDIRECT, 1);
 	ctx_store_meta(ctx, CB_FROM_HOST, from_host ? 1 : 0);
 	ctx_store_meta(ctx, CB_FROM_TUNNEL, from_tunnel ? 1 : 0);
 	ctx_store_meta(ctx, CB_CLUSTER_ID_INGRESS, cluster_id);

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
@@ -155,7 +155,7 @@ int overlay_to_lxc_syn_setup(struct __ctx_buff *ctx)
 
 	/* Emulate metadata filled by ipv4_local_delivery on bpf_overlay */
 	ctx_store_meta(ctx, CB_SRC_LABEL, CLIENT_IDENTITY);
-	ctx_store_meta(ctx, CB_IFINDEX, 1);
+	ctx_store_meta(ctx, CB_DELIVERY_REDIRECT, 1);
 	ctx_store_meta(ctx, CB_CLUSTER_ID_INGRESS, 0);
 	ctx_store_meta(ctx, CB_FROM_HOST, 0);
 	ctx_store_meta(ctx, CB_FROM_TUNNEL, 1);
@@ -351,7 +351,7 @@ int overlay_to_lxc_ack_setup(struct __ctx_buff *ctx)
 {
 	/* Emulate metadata filled by ipv4_local_delivery on bpf_overlay */
 	ctx_store_meta(ctx, CB_SRC_LABEL, CLIENT_IDENTITY);
-	ctx_store_meta(ctx, CB_IFINDEX, 1);
+	ctx_store_meta(ctx, CB_DELIVERY_REDIRECT, 1);
 	ctx_store_meta(ctx, CB_CLUSTER_ID_INGRESS, 0);
 	ctx_store_meta(ctx, CB_FROM_HOST, 0);
 	ctx_store_meta(ctx, CB_FROM_TUNNEL, 1);

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
@@ -261,9 +261,9 @@ int from_overlay_syn_check(struct __ctx_buff *ctx)
 	if (l4->check != bpf_htons(0x777f))
 		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
 
-	meta = ctx_load_meta(ctx, CB_IFINDEX);
-	if (meta != BACKEND_IFINDEX)
-		test_fatal("skb->cb[CB_IFINDEX] should be %d, got %d", BACKEND_IFINDEX, meta);
+	meta = ctx_load_meta(ctx, CB_DELIVERY_REDIRECT);
+	if (meta != 1)
+		test_fatal("skb->cb[CB_DELIVERY_REDIRECT] should be 1, got %d", meta);
 
 	meta = ctx_load_meta(ctx, CB_SRC_LABEL);
 	if (meta != CLIENT_IDENTITY)
@@ -430,9 +430,9 @@ int from_overlay_ack_check(struct __ctx_buff *ctx)
 	if (l4->check != bpf_htons(0x7771))
 		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
 
-	meta = ctx_load_meta(ctx, CB_IFINDEX);
-	if (meta != BACKEND_IFINDEX)
-		test_fatal("skb->cb[CB_IFINDEX] should be %d, got %d", BACKEND_IFINDEX, meta);
+	meta = ctx_load_meta(ctx, CB_DELIVERY_REDIRECT);
+	if (meta != 1)
+		test_fatal("skb->cb[CB_DELIVERY_REDIRECT] should be 1, got %d", meta);
 
 	meta = ctx_load_meta(ctx, CB_SRC_LABEL);
 	if (meta != CLIENT_IDENTITY)

--- a/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
@@ -264,7 +264,7 @@ int overlay_to_lxc_synack_setup(struct __ctx_buff *ctx)
 {
 	/* Emulate metadata filled by ipv4_local_delivery on bpf_overlay */
 	ctx_store_meta(ctx, CB_SRC_LABEL, BACKEND_IDENTITY);
-	ctx_store_meta(ctx, CB_IFINDEX, 1);
+	ctx_store_meta(ctx, CB_DELIVERY_REDIRECT, 1);
 	ctx_store_meta(ctx, CB_CLUSTER_ID_INGRESS, 2);
 	ctx_store_meta(ctx, CB_FROM_HOST, 0);
 	ctx_store_meta(ctx, CB_FROM_TUNNEL, 1);

--- a/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
@@ -361,9 +361,9 @@ int from_overlay_synack_check(struct __ctx_buff *ctx)
 	if (l4->check != bpf_htons(0x2fc5))
 		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
 
-	meta = ctx_load_meta(ctx, CB_IFINDEX);
-	if (meta != CLIENT_IFINDEX)
-		test_fatal("skb->cb[CB_IFINDEX] should be %d, got %d", CLIENT_IFINDEX, meta);
+	meta = ctx_load_meta(ctx, CB_DELIVERY_REDIRECT);
+	if (meta != 1)
+		test_fatal("skb->cb[CB_DELIVERY_REDIRECT] should be 1, got %d", meta);
 
 	meta = ctx_load_meta(ctx, CB_SRC_LABEL);
 	if (meta != BACKEND_IDENTITY)


### PR DESCRIPTION
As the comment in lib/l3.h states, we no longer need to transport the actual ifindex into bpf_lxc's ingress policy program. Replace it with a simple boolean flag.