### PR TITLE
renovate: various smaller updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -462,6 +462,20 @@
       "versioning": "regex:^((?<compatibility>[a-z0-9-.]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
     },
     {
+      "groupName": "old stable lvh-images",
+      "groupSlug": "old stable-lvh-images",
+      "matchPackageNames": [
+        "cilium/little-vm-helper",
+	// complexity-test needs https://github.com/cilium/little-vm-helper-images/issues/674.
+        "quay.io/lvh-images/kind"
+      ],
+      "allowedVersions": "!/bpf-next-.*/",
+      "matchBaseBranches": [
+        "v1.14",
+        "v1.15",
+      ],
+    },
+    {
       "groupName": "stable lvh-images",
       "groupSlug": "stable-lvh-images",
       "matchPackageNames": [
@@ -472,8 +486,6 @@
       "allowedVersions": "!/bpf-next-.*/",
       "matchBaseBranches": [
         "v1.16",
-        "v1.15",
-        "v1.14",
       ],
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -459,7 +459,7 @@
         "quay.io/lvh-images/complexity-test",
         "quay.io/lvh-images/kind"
       ],
-      "versioning": "regex:^((?<compatibility>[a-z0-9-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
+      "versioning": "regex:^((?<compatibility>[a-z0-9-.]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
     },
     {
       "groupName": "stable lvh-images",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,7 @@
   // This ensures that the gitAuthor and gitSignOff fields match
   "gitAuthor": "cilium-renovate[bot] <134692979+cilium-renovate[bot]@users.noreply.github.com>",
   "includePaths": [
+    ".github/actions/bpftrace/**",
     ".github/actions/kvstore/**",
     ".github/actions/ginkgo/**",
     ".github/actions/lvh-kind/**",


### PR DESCRIPTION
* Apply updates for RHEL 8.6 LVH images
* exclude updates for the complexity-test LVH image on branches where it currently doesn't work
* Apply updates for `actions/bpftrace`