### PR TITLE
Proxy: Do not release acknowledged proxy ports when endpoint regeneration fails

### DIFF
--- a/pkg/envoy/embedded_envoy_test.go
+++ b/pkg/envoy/embedded_envoy_test.go
@@ -20,6 +20,15 @@ import (
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
 
+// To run the embedded_envoy_test, the following have to be met:
+// - Environment variable `CILIUM_ENABLE_ENVOY_UNIT_TEST` must be set
+// - `cilium-envoy-starter` and `cilium-envoy` must exist in the PATH
+//   - if these were left running from a previous test, these must be killed
+//     - `pkill -9 cilium-envoy`
+// - `proxylib.so` must exist in the library path (e.g., `/usr/lib`)
+// - `cilium-envoy-starter` must have capabilities CAP_NET_ADMIN and CAP_BPF
+//   - e.g., `sudo setcap 'cap_net_admin,cap_bpf+pe' cilium-envoy-starter`
+
 type EnvoySuite struct {
 	waitGroup *completion.WaitGroup
 }
@@ -59,7 +68,7 @@ func TestEnvoy(t *testing.T) {
 
 	xdsServer, err := newXDSServer(nil, testipcache.NewMockIPCache(), localEndpointStore,
 		xdsServerConfig{
-			envoySocketDir:    testRunDir,
+			envoySocketDir:    GetSocketDir(testRunDir),
 			proxyGID:          1337,
 			httpNormalizePath: true,
 		},
@@ -81,12 +90,14 @@ func TestEnvoy(t *testing.T) {
 	envoyProxy, err := startEmbeddedEnvoy(embeddedEnvoyConfig{
 		runDir:         testRunDir,
 		logPath:        filepath.Join(testRunDir, "cilium-envoy.log"),
-		baseID:         0,
+		baseID:         15,
 		connectTimeout: 1,
 	})
-	require.NotNil(t, envoyProxy)
 	require.NoError(t, err)
+	require.NotNil(t, envoyProxy)
 	log.Debug("started Envoy")
+
+	defer envoyProxy.admin.quit()
 
 	log.Debug("adding metrics listener")
 	xdsServer.AddMetricsListener(9964, s.waitGroup)
@@ -165,7 +176,7 @@ func TestEnvoyNACK(t *testing.T) {
 
 	xdsServer, err := newXDSServer(nil, testipcache.NewMockIPCache(), localEndpointStore,
 		xdsServerConfig{
-			envoySocketDir:    testRunDir,
+			envoySocketDir:    GetSocketDir(testRunDir),
 			proxyGID:          1337,
 			httpNormalizePath: true,
 		}, nil)
@@ -183,13 +194,16 @@ func TestEnvoyNACK(t *testing.T) {
 
 	// launch debug variant of the Envoy proxy
 	envoyProxy, err := startEmbeddedEnvoy(embeddedEnvoyConfig{
-		runDir:  testRunDir,
-		logPath: filepath.Join(testRunDir, "cilium-envoy.log"),
-		baseID:  42,
+		runDir:         testRunDir,
+		logPath:        filepath.Join(testRunDir, "cilium-envoy.log"),
+		baseID:         42,
+		connectTimeout: 1,
 	})
 	require.NotNil(t, envoyProxy)
 	require.NoError(t, err)
 	log.Debug("started Envoy")
+
+	defer envoyProxy.admin.quit()
 
 	rName := "listener:22"
 
@@ -198,7 +212,7 @@ func TestEnvoyNACK(t *testing.T) {
 
 	err = s.waitForProxyCompletion()
 	require.Error(t, err)
-	require.EqualValues(t, &xds.ProxyError{Err: xds.ErrNackReceived, Detail: "Error adding/updating listener(s) listener:22: cannot bind '[::]:22': Address already in use\n"}, err)
+	require.EqualValues(t, &xds.ProxyError{Err: xds.ErrNackReceived, Detail: "Error adding/updating listener(s) listener:22: cannot bind '127.0.0.1:22': Address already in use\n"}, err)
 
 	s.waitGroup = completion.NewWaitGroup(ctx)
 	// Remove listener1

--- a/pkg/envoy/embedded_envoy_test.go
+++ b/pkg/envoy/embedded_envoy_test.go
@@ -108,13 +108,13 @@ func TestEnvoy(t *testing.T) {
 	s.waitGroup = completion.NewWaitGroup(ctx)
 
 	log.Debug("adding listener1")
-	xdsServer.AddListener("listener1", policy.ParserTypeHTTP, 8081, true, false, s.waitGroup)
+	xdsServer.AddListener("listener1", policy.ParserTypeHTTP, 8081, true, false, s.waitGroup, nil)
 
 	log.Debug("adding listener2")
-	xdsServer.AddListener("listener2", policy.ParserTypeHTTP, 8082, true, false, s.waitGroup)
+	xdsServer.AddListener("listener2", policy.ParserTypeHTTP, 8082, true, false, s.waitGroup, nil)
 
 	log.Debug("adding listener3")
-	xdsServer.AddListener("listener3", policy.ParserTypeHTTP, 8083, false, false, s.waitGroup)
+	xdsServer.AddListener("listener3", policy.ParserTypeHTTP, 8083, false, false, s.waitGroup, nil)
 
 	err = s.waitForProxyCompletion()
 	require.NoError(t, err)
@@ -132,10 +132,18 @@ func TestEnvoy(t *testing.T) {
 
 	// Add listener3 again
 	log.Debug("adding listener 3")
-	xdsServer.AddListener("listener3", "test.headerparser", 8083, false, false, s.waitGroup)
+	var cbErr error
+	cbCalled := false
+	xdsServer.AddListener("listener3", "test.headerparser", 8083, false, false, s.waitGroup,
+		func(err error) {
+			cbCalled = true
+			cbErr = err
+		})
 
 	err = s.waitForProxyCompletion()
 	require.NoError(t, err)
+	require.True(t, cbCalled)
+	require.NoError(t, cbErr)
 	log.Debug("completed adding listener 3")
 	s.waitGroup = completion.NewWaitGroup(ctx)
 
@@ -208,10 +216,18 @@ func TestEnvoyNACK(t *testing.T) {
 	rName := "listener:22"
 
 	log.Debug("adding ", rName)
-	xdsServer.AddListener(rName, policy.ParserTypeHTTP, 22, true, false, s.waitGroup)
+	var cbErr error
+	cbCalled := false
+	xdsServer.AddListener(rName, policy.ParserTypeHTTP, 22, true, false, s.waitGroup,
+		func(err error) {
+			cbCalled = true
+			cbErr = err
+		})
 
 	err = s.waitForProxyCompletion()
 	require.Error(t, err)
+	require.True(t, cbCalled)
+	require.Equal(t, err, cbErr)
 	require.EqualValues(t, &xds.ProxyError{Err: xds.ErrNackReceived, Detail: "Error adding/updating listener(s) listener:22: cannot bind '127.0.0.1:22': Address already in use\n"}, err)
 
 	s.waitGroup = completion.NewWaitGroup(ctx)

--- a/pkg/envoy/secretsync_test.go
+++ b/pkg/envoy/secretsync_test.go
@@ -439,7 +439,7 @@ func (r *fakeXdsServer) UpsertEnvoyResources(ctx context.Context, resources Reso
 	return nil
 }
 
-func (*fakeXdsServer) AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup, cb func(err error)) {
+func (*fakeXdsServer) AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup, cb func(err error)) error {
 	panic("unimplemented")
 }
 

--- a/pkg/envoy/secretsync_test.go
+++ b/pkg/envoy/secretsync_test.go
@@ -439,7 +439,7 @@ func (r *fakeXdsServer) UpsertEnvoyResources(ctx context.Context, resources Reso
 	return nil
 }
 
-func (*fakeXdsServer) AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup) {
+func (*fakeXdsServer) AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup, cb func(err error)) {
 	panic("unimplemented")
 }
 

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -84,7 +84,7 @@ const (
 // XDSServer provides a high-lever interface to manage resources published using the xDS gRPC API.
 type XDSServer interface {
 	// AddListener adds a listener to a running Envoy proxy.
-	AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup)
+	AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup, cb func(err error))
 	// AddAdminListener adds an Admin API listener to Envoy.
 	AddAdminListener(port uint16, wg *completion.WaitGroup)
 	// AddMetricsListener adds a prometheus metrics listener to Envoy.
@@ -983,12 +983,12 @@ func (s *xdsServer) getListenerConf(name string, kind policy.L7ParserType, port 
 	return listenerConf
 }
 
-func (s *xdsServer) AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup) {
+func (s *xdsServer) AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup, cb func(err error)) {
 	log.Debugf("Envoy: %s AddListener %s (mayUseOriginalSourceAddr: %v)", kind, name, mayUseOriginalSourceAddr)
 
 	s.addListener(name, func() *envoy_config_listener.Listener {
 		return s.getListenerConf(name, kind, port, isIngress, mayUseOriginalSourceAddr)
-	}, wg, nil, true)
+	}, wg, cb, true)
 }
 
 func (s *xdsServer) RemoveListener(name string, wg *completion.WaitGroup) xds.AckingResourceMutatorRevertFunc {

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -84,7 +84,7 @@ const (
 // XDSServer provides a high-lever interface to manage resources published using the xDS gRPC API.
 type XDSServer interface {
 	// AddListener adds a listener to a running Envoy proxy.
-	AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup, cb func(err error))
+	AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup, cb func(err error)) error
 	// AddAdminListener adds an Admin API listener to Envoy.
 	AddAdminListener(port uint16, wg *completion.WaitGroup)
 	// AddMetricsListener adds a prometheus metrics listener to Envoy.
@@ -793,7 +793,7 @@ func (s *xdsServer) AddMetricsListener(port uint16, wg *completion.WaitGroup) {
 
 // addListener either reuses an existing listener with 'name', or creates a new one.
 // 'listenerConf()' is only called if a new listener is being created.
-func (s *xdsServer) addListener(name string, listenerConf func() *envoy_config_listener.Listener, wg *completion.WaitGroup, cb func(err error), isProxyListener bool) {
+func (s *xdsServer) addListener(name string, listenerConf func() *envoy_config_listener.Listener, wg *completion.WaitGroup, cb func(err error), isProxyListener bool) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -805,11 +805,7 @@ func (s *xdsServer) addListener(name string, listenerConf func() *envoy_config_l
 		listenerConfig.EnableReusePort = &wrapperspb.BoolValue{Value: false}
 	}
 	if err := listenerConfig.Validate(); err != nil {
-		log.Errorf("Envoy: Could not validate Listener (%s): %s", err, listenerConfig.String())
-		if cb != nil {
-			cb(err)
-		}
-		return
+		return fmt.Errorf("Envoy: Could not validate Listener %s: %w", listenerConfig.String(), err)
 	}
 
 	count := s.listenerCount[name]
@@ -828,6 +824,7 @@ func (s *xdsServer) addListener(name string, listenerConf func() *envoy_config_l
 				cb(err)
 			}
 		})
+	return nil
 }
 
 // upsertListener either updates an existing LDS listener with 'name', or creates a new one.
@@ -983,10 +980,10 @@ func (s *xdsServer) getListenerConf(name string, kind policy.L7ParserType, port 
 	return listenerConf
 }
 
-func (s *xdsServer) AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup, cb func(err error)) {
+func (s *xdsServer) AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup, cb func(err error)) error {
 	log.Debugf("Envoy: %s AddListener %s (mayUseOriginalSourceAddr: %v)", kind, name, mayUseOriginalSourceAddr)
 
-	s.addListener(name, func() *envoy_config_listener.Listener {
+	return s.addListener(name, func() *envoy_config_listener.Listener {
 		return s.getListenerConf(name, kind, port, isIngress, mayUseOriginalSourceAddr)
 	}, wg, cb, true)
 }

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -847,67 +847,67 @@ func (s *xdsServer) deleteListener(name string, wg *completion.WaitGroup, callba
 }
 
 // upsertRoute either updates an existing RDS route with 'name', or creates a new one.
-func (s *xdsServer) upsertRoute(name string, conf *envoy_config_route.RouteConfiguration, wg *completion.WaitGroup, callback func(error)) xds.AckingResourceMutatorRevertFunc {
+func (s *xdsServer) upsertRoute(name string, conf *envoy_config_route.RouteConfiguration, wg *completion.WaitGroup) xds.AckingResourceMutatorRevertFunc {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	// 'callback' is not called if there is no change and this configuration has already been acked.
-	return s.routeMutator.Upsert(RouteTypeURL, name, conf, []string{"127.0.0.1"}, wg, callback)
+	return s.routeMutator.Upsert(RouteTypeURL, name, conf, []string{"127.0.0.1"}, wg, nil)
 }
 
 // deleteRoute deletes an RDS Route.
-func (s *xdsServer) deleteRoute(name string, wg *completion.WaitGroup, callback func(error)) xds.AckingResourceMutatorRevertFunc {
+func (s *xdsServer) deleteRoute(name string, wg *completion.WaitGroup) xds.AckingResourceMutatorRevertFunc {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	// 'callback' is not called if there is no change and this configuration has already been acked.
-	return s.routeMutator.Delete(RouteTypeURL, name, []string{"127.0.0.1"}, wg, callback)
+	return s.routeMutator.Delete(RouteTypeURL, name, []string{"127.0.0.1"}, wg, nil)
 }
 
 // upsertCluster either updates an existing CDS cluster with 'name', or creates a new one.
-func (s *xdsServer) upsertCluster(name string, conf *envoy_config_cluster.Cluster, wg *completion.WaitGroup, callback func(error)) xds.AckingResourceMutatorRevertFunc {
+func (s *xdsServer) upsertCluster(name string, conf *envoy_config_cluster.Cluster, wg *completion.WaitGroup) xds.AckingResourceMutatorRevertFunc {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	// 'callback' is not called if there is no change and this configuration has already been acked.
-	return s.clusterMutator.Upsert(ClusterTypeURL, name, conf, []string{"127.0.0.1"}, wg, callback)
+	return s.clusterMutator.Upsert(ClusterTypeURL, name, conf, []string{"127.0.0.1"}, wg, nil)
 }
 
 // deleteCluster deletes an CDS cluster.
-func (s *xdsServer) deleteCluster(name string, wg *completion.WaitGroup, callback func(error)) xds.AckingResourceMutatorRevertFunc {
+func (s *xdsServer) deleteCluster(name string, wg *completion.WaitGroup) xds.AckingResourceMutatorRevertFunc {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	// 'callback' is not called if there is no change and this configuration has already been acked.
-	return s.clusterMutator.Delete(ClusterTypeURL, name, []string{"127.0.0.1"}, wg, callback)
+	return s.clusterMutator.Delete(ClusterTypeURL, name, []string{"127.0.0.1"}, wg, nil)
 }
 
 // upsertEndpoint either updates an existing EDS endpoint with 'name', or creates a new one.
-func (s *xdsServer) upsertEndpoint(name string, conf *envoy_config_endpoint.ClusterLoadAssignment, wg *completion.WaitGroup, callback func(error)) xds.AckingResourceMutatorRevertFunc {
+func (s *xdsServer) upsertEndpoint(name string, conf *envoy_config_endpoint.ClusterLoadAssignment, wg *completion.WaitGroup) xds.AckingResourceMutatorRevertFunc {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	// 'callback' is not called if there is no change and this configuration has already been acked.
-	return s.endpointMutator.Upsert(EndpointTypeURL, name, conf, []string{"127.0.0.1"}, wg, callback)
+	return s.endpointMutator.Upsert(EndpointTypeURL, name, conf, []string{"127.0.0.1"}, wg, nil)
 }
 
 // deleteEndpoint deletes an EDS endpoint.
-func (s *xdsServer) deleteEndpoint(name string, wg *completion.WaitGroup, callback func(error)) xds.AckingResourceMutatorRevertFunc {
+func (s *xdsServer) deleteEndpoint(name string, wg *completion.WaitGroup) xds.AckingResourceMutatorRevertFunc {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	// 'callback' is not called if there is no change and this configuration has already been acked.
-	return s.endpointMutator.Delete(EndpointTypeURL, name, []string{"127.0.0.1"}, wg, callback)
+	return s.endpointMutator.Delete(EndpointTypeURL, name, []string{"127.0.0.1"}, wg, nil)
 }
 
 // upsertSecret either updates an existing SDS secret with 'name', or creates a new one.
-func (s *xdsServer) upsertSecret(name string, conf *envoy_config_tls.Secret, wg *completion.WaitGroup, callback func(error)) xds.AckingResourceMutatorRevertFunc {
+func (s *xdsServer) upsertSecret(name string, conf *envoy_config_tls.Secret, wg *completion.WaitGroup) xds.AckingResourceMutatorRevertFunc {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	// 'callback' is not called if there is no change and this configuration has already been acked.
-	return s.secretMutator.Upsert(SecretTypeURL, name, conf, []string{"127.0.0.1"}, wg, callback)
+	return s.secretMutator.Upsert(SecretTypeURL, name, conf, []string{"127.0.0.1"}, wg, nil)
 }
 
 // deleteSecret deletes an SDS secret.
-func (s *xdsServer) deleteSecret(name string, wg *completion.WaitGroup, callback func(error)) xds.AckingResourceMutatorRevertFunc {
+func (s *xdsServer) deleteSecret(name string, wg *completion.WaitGroup) xds.AckingResourceMutatorRevertFunc {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	// 'callback' is not called if there is no change and this configuration has already been acked.
-	return s.secretMutator.Delete(SecretTypeURL, name, []string{"127.0.0.1"}, wg, callback)
+	return s.secretMutator.Delete(SecretTypeURL, name, []string{"127.0.0.1"}, wg, nil)
 }
 
 func getListenerFilter(isIngress bool, useOriginalSourceAddr bool, proxyPort uint16) *envoy_config_listener.ListenerFilter {
@@ -2044,19 +2044,19 @@ func (s *xdsServer) UpsertEnvoyResources(ctx context.Context, resources Resource
 	// If both listeners and clusters are added then wait for clusters.
 	for _, r := range resources.Secrets {
 		log.Debugf("Envoy upsertSecret %s", r.Name)
-		revertFuncs = append(revertFuncs, s.upsertSecret(r.Name, r, nil, nil))
+		revertFuncs = append(revertFuncs, s.upsertSecret(r.Name, r, nil))
 	}
 	for _, r := range resources.Endpoints {
 		log.Debugf("Envoy upsertEndpoint %s %v", r.ClusterName, r)
-		revertFuncs = append(revertFuncs, s.upsertEndpoint(r.ClusterName, r, nil, nil))
+		revertFuncs = append(revertFuncs, s.upsertEndpoint(r.ClusterName, r, nil))
 	}
 	for _, r := range resources.Clusters {
 		log.Debugf("Envoy upsertCluster %s %v", r.Name, r)
-		revertFuncs = append(revertFuncs, s.upsertCluster(r.Name, r, wg, nil))
+		revertFuncs = append(revertFuncs, s.upsertCluster(r.Name, r, wg))
 	}
 	for _, r := range resources.Routes {
 		log.Debugf("Envoy upsertRoute %s %v", r.Name, r)
-		revertFuncs = append(revertFuncs, s.upsertRoute(r.Name, r, nil, nil))
+		revertFuncs = append(revertFuncs, s.upsertRoute(r.Name, r, nil))
 	}
 	// Wait before new Listeners are added if clusters were also added above.
 	if wg != nil {
@@ -2177,7 +2177,7 @@ func (s *xdsServer) UpdateEnvoyResources(ctx context.Context, old, new Resources
 	}
 	log.Debugf("UpdateEnvoyResources: Deleting %d, Upserting %d routes...", len(deleteRoutes), len(new.Routes))
 	for _, route := range deleteRoutes {
-		revertFuncs = append(revertFuncs, s.deleteRoute(route.Name, nil, nil))
+		revertFuncs = append(revertFuncs, s.deleteRoute(route.Name, nil))
 	}
 
 	// Delete old clusters not added in 'new'
@@ -2195,7 +2195,7 @@ func (s *xdsServer) UpdateEnvoyResources(ctx context.Context, old, new Resources
 	}
 	log.Debugf("UpdateEnvoyResources: Deleting %d, Upserting %d clusters...", len(deleteClusters), len(new.Clusters))
 	for _, cluster := range deleteClusters {
-		revertFuncs = append(revertFuncs, s.deleteCluster(cluster.Name, nil, nil))
+		revertFuncs = append(revertFuncs, s.deleteCluster(cluster.Name, nil))
 	}
 
 	// Delete old endpoints not added in 'new'
@@ -2213,7 +2213,7 @@ func (s *xdsServer) UpdateEnvoyResources(ctx context.Context, old, new Resources
 	}
 	log.Debugf("UpdateEnvoyResources: Deleting %d, Upserting %d endpoints...", len(deleteEndpoints), len(new.Endpoints))
 	for _, endpoint := range deleteEndpoints {
-		revertFuncs = append(revertFuncs, s.deleteEndpoint(endpoint.ClusterName, nil, nil))
+		revertFuncs = append(revertFuncs, s.deleteEndpoint(endpoint.ClusterName, nil))
 	}
 
 	// Delete old secrets not added in 'new'
@@ -2231,7 +2231,7 @@ func (s *xdsServer) UpdateEnvoyResources(ctx context.Context, old, new Resources
 	}
 	log.Debugf("UpdateEnvoyResources: Deleting %d, Upserting %d secrets...", len(deleteSecrets), len(new.Secrets))
 	for _, secret := range deleteSecrets {
-		revertFuncs = append(revertFuncs, s.deleteSecret(secret.Name, nil, nil))
+		revertFuncs = append(revertFuncs, s.deleteSecret(secret.Name, nil))
 	}
 
 	// Have to wait for deletes to complete before adding new listeners if a listener's port number is changed.
@@ -2249,19 +2249,19 @@ func (s *xdsServer) UpdateEnvoyResources(ctx context.Context, old, new Resources
 
 	// Add new Secrets
 	for _, r := range new.Secrets {
-		revertFuncs = append(revertFuncs, s.upsertSecret(r.Name, r, nil, nil))
+		revertFuncs = append(revertFuncs, s.upsertSecret(r.Name, r, nil))
 	}
 	// Add new Endpoints
 	for _, r := range new.Endpoints {
-		revertFuncs = append(revertFuncs, s.upsertEndpoint(r.ClusterName, r, nil, nil))
+		revertFuncs = append(revertFuncs, s.upsertEndpoint(r.ClusterName, r, nil))
 	}
 	// Add new Clusters
 	for _, r := range new.Clusters {
-		revertFuncs = append(revertFuncs, s.upsertCluster(r.Name, r, wg, nil))
+		revertFuncs = append(revertFuncs, s.upsertCluster(r.Name, r, wg))
 	}
 	// Add new Routes
 	for _, r := range new.Routes {
-		revertFuncs = append(revertFuncs, s.upsertRoute(r.Name, r, nil, nil))
+		revertFuncs = append(revertFuncs, s.upsertRoute(r.Name, r, nil))
 	}
 	if wg != nil && len(new.Clusters) > 0 {
 		start := time.Now()
@@ -2334,16 +2334,16 @@ func (s *xdsServer) DeleteEnvoyResources(ctx context.Context, resources Resource
 	// there is no listener referring to other named resources to
 	// begin with.
 	for _, r := range resources.Routes {
-		revertFuncs = append(revertFuncs, s.deleteRoute(r.Name, nil, nil))
+		revertFuncs = append(revertFuncs, s.deleteRoute(r.Name, nil))
 	}
 	for _, r := range resources.Clusters {
-		revertFuncs = append(revertFuncs, s.deleteCluster(r.Name, nil, nil))
+		revertFuncs = append(revertFuncs, s.deleteCluster(r.Name, nil))
 	}
 	for _, r := range resources.Endpoints {
-		revertFuncs = append(revertFuncs, s.deleteEndpoint(r.ClusterName, nil, nil))
+		revertFuncs = append(revertFuncs, s.deleteEndpoint(r.ClusterName, nil))
 	}
 	for _, r := range resources.Secrets {
-		revertFuncs = append(revertFuncs, s.deleteSecret(r.Name, nil, nil))
+		revertFuncs = append(revertFuncs, s.deleteSecret(r.Name, nil))
 	}
 
 	if wg != nil {

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -311,6 +312,10 @@ func (s *xdsServer) initializeXdsConfigs() map[string]*xds.ResourceTypeConfigura
 }
 
 func (s *xdsServer) newSocketListener() (*net.UnixListener, error) {
+	// Make sure sockets dir exists
+	socketsDir, _ := filepath.Split(s.socketPath)
+	os.MkdirAll(GetSocketDir(socketsDir), 0777)
+
 	// Remove/Unlink the old unix domain socket, if any.
 	_ = os.Remove(s.socketPath)
 

--- a/pkg/envoy/xds_server_ondemand.go
+++ b/pkg/envoy/xds_server_ondemand.go
@@ -33,12 +33,12 @@ type onDemandXdsStarter struct {
 
 var _ XDSServer = &onDemandXdsStarter{}
 
-func (o *onDemandXdsStarter) AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup) {
+func (o *onDemandXdsStarter) AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup, cb func(err error)) {
 	if err := o.startEmbeddedEnvoy(nil); err != nil {
 		log.WithError(err).Error("Envoy: Failed to start embedded Envoy proxy on demand")
 	}
 
-	o.XDSServer.AddListener(name, kind, port, isIngress, mayUseOriginalSourceAddr, wg)
+	o.XDSServer.AddListener(name, kind, port, isIngress, mayUseOriginalSourceAddr, wg, cb)
 }
 
 func (o *onDemandXdsStarter) UpsertEnvoyResources(ctx context.Context, resources Resources) error {

--- a/pkg/envoy/xds_server_ondemand.go
+++ b/pkg/envoy/xds_server_ondemand.go
@@ -33,12 +33,12 @@ type onDemandXdsStarter struct {
 
 var _ XDSServer = &onDemandXdsStarter{}
 
-func (o *onDemandXdsStarter) AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup, cb func(err error)) {
+func (o *onDemandXdsStarter) AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup, cb func(err error)) error {
 	if err := o.startEmbeddedEnvoy(nil); err != nil {
 		log.WithError(err).Error("Envoy: Failed to start embedded Envoy proxy on demand")
 	}
 
-	o.XDSServer.AddListener(name, kind, port, isIngress, mayUseOriginalSourceAddr, wg, cb)
+	return o.XDSServer.AddListener(name, kind, port, isIngress, mayUseOriginalSourceAddr, wg, cb)
 }
 
 func (o *onDemandXdsStarter) UpsertEnvoyResources(ctx context.Context, resources Resources) error {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -371,6 +371,9 @@ const (
 	// ProxyName is the name of a proxy (e.g., "Envoy")
 	ProxyName = "proxyName"
 
+	// ProxyPort is the port number of an L7 proxy listener.
+	ProxyPort = "ProxyPort"
+
 	// L7LBProxyPort is the port number of the Envoy listener a L7 LB service redirects traffic to for load balancing.
 	L7LBProxyPort = "l7LBProxyPort"
 

--- a/pkg/proxy/cell.go
+++ b/pkg/proxy/cell.go
@@ -79,15 +79,15 @@ func newProxy(params proxyParams) *Proxy {
 		OnStart: func(cell.HookContext) (err error) {
 			// Restore all proxy ports before we create the trigger to overwrite the
 			// file below
-			p.RestoreProxyPorts(params.Config.RestoredProxyPortsAgeLimit)
+			p.proxyPorts.RestoreProxyPorts(params.Config.RestoredProxyPortsAgeLimit)
 
-			p.proxyPortsTrigger, err = trigger.NewTrigger(trigger.Parameters{
+			p.proxyPorts.Trigger, err = trigger.NewTrigger(trigger.Parameters{
 				MinInterval: 10 * time.Second,
 				TriggerFunc: func(reasons []string) {
 					controllerManager.UpdateController(controllerName, controller.ControllerParams{
 						Group:    controllerGroup,
-						DoFunc:   p.storeProxyPorts,
-						StopFunc: p.storeProxyPorts, // perform one last checkpoint when the controller is removed
+						DoFunc:   p.proxyPorts.StoreProxyPorts,
+						StopFunc: p.proxyPorts.StoreProxyPorts, // perform one last checkpoint when the controller is removed
 					})
 				},
 				ShutdownFunc: func() {
@@ -98,7 +98,7 @@ func newProxy(params proxyParams) *Proxy {
 			return err
 		},
 		OnStop: func(cell.HookContext) error {
-			p.proxyPortsTrigger.Shutdown()
+			p.proxyPorts.Trigger.Shutdown()
 			<-triggerDone
 			return nil
 		},

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -59,7 +59,7 @@ func (p *envoyProxyIntegration) handleEnvoyRedirect(r *Redirect, wg *completion.
 	if l.Ingress {
 		mayUseOriginalSourceAddr = false
 	}
-	p.xdsServer.AddListener(redirect.listenerName, policy.L7ParserType(l.ProxyType), l.ProxyPort, l.Ingress, mayUseOriginalSourceAddr, wg)
+	p.xdsServer.AddListener(redirect.listenerName, policy.L7ParserType(l.ProxyType), l.ProxyPort, l.Ingress, mayUseOriginalSourceAddr, wg, nil)
 
 	return redirect, nil
 }

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -32,21 +32,13 @@ type envoyProxyIntegration struct {
 }
 
 // createRedirect creates a redirect with corresponding proxy configuration. This will launch a proxy instance.
-func (p *envoyProxyIntegration) createRedirect(r *Redirect, wg *completion.WaitGroup) (RedirectImplementation, error) {
+func (p *envoyProxyIntegration) createRedirect(r *Redirect, wg *completion.WaitGroup, cb func(err error)) (RedirectImplementation, error) {
 	if r.listener.ProxyType == types.ProxyTypeCRD {
 		// CRD Listeners already exist, create a no-op implementation
 		return &CRDRedirect{}, nil
 	}
 
 	// create an Envoy Listener for Cilium policy enforcement
-	return p.handleEnvoyRedirect(r, wg)
-}
-
-func (p *envoyProxyIntegration) changeLogLevel(level logrus.Level) error {
-	return p.adminClient.ChangeLogLevel(level)
-}
-
-func (p *envoyProxyIntegration) handleEnvoyRedirect(r *Redirect, wg *completion.WaitGroup) (RedirectImplementation, error) {
 	l := r.listener
 	redirect := &envoyRedirect{
 		listenerName: net.JoinHostPort(r.name, fmt.Sprintf("%d", l.ProxyPort)),
@@ -59,9 +51,13 @@ func (p *envoyProxyIntegration) handleEnvoyRedirect(r *Redirect, wg *completion.
 	if l.Ingress {
 		mayUseOriginalSourceAddr = false
 	}
-	err := p.xdsServer.AddListener(redirect.listenerName, policy.L7ParserType(l.ProxyType), l.ProxyPort, l.Ingress, mayUseOriginalSourceAddr, wg, nil)
+	err := p.xdsServer.AddListener(redirect.listenerName, policy.L7ParserType(l.ProxyType), l.ProxyPort, l.Ingress, mayUseOriginalSourceAddr, wg, cb)
 
 	return redirect, err
+}
+
+func (p *envoyProxyIntegration) changeLogLevel(level logrus.Level) error {
+	return p.adminClient.ChangeLogLevel(level)
 }
 
 func (p *envoyProxyIntegration) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -59,9 +59,9 @@ func (p *envoyProxyIntegration) handleEnvoyRedirect(r *Redirect, wg *completion.
 	if l.Ingress {
 		mayUseOriginalSourceAddr = false
 	}
-	p.xdsServer.AddListener(redirect.listenerName, policy.L7ParserType(l.ProxyType), l.ProxyPort, l.Ingress, mayUseOriginalSourceAddr, wg, nil)
+	err := p.xdsServer.AddListener(redirect.listenerName, policy.L7ParserType(l.ProxyType), l.ProxyPort, l.Ingress, mayUseOriginalSourceAddr, wg, nil)
 
-	return redirect, nil
+	return redirect, err
 }
 
 func (p *envoyProxyIntegration) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -214,6 +214,32 @@ func (p *Proxy) createNewRedirect(
 	// try first with the previous port, if any
 	p.proxyPorts.Restore(pp)
 
+	// Callback for Envoy ACK/NACK handling for the redirect.
+	// If we get a non-nil 'err' Envoy has NACKed the listener update, and the whole (endpoint)
+	// regeneration will also be reverted. Revert can happen for other reasons as well (such as
+	// bpf datapath compilation failure), and we do not want to churn proxy ports in that case.
+	// Not called for DNS redirects.
+	// This callbck is called before the finalize or revert function is called.
+	proxyCallback := func(err error) {
+		if err == nil {
+			// Enable datapath redirection for the proxy port if proxy creation
+			// was successful, even if the overall (endpoint) regeneration
+			// fails. This way there is less churm on the procy port allocation
+			// and datapath. Endpoint policy will no redirect to the new proxy
+			// implementation if regeneration fails.
+			err = p.proxyPorts.AckProxyPort(ctx, ppName, pp)
+			if err != nil {
+				scopedLog.
+					WithError(err).
+					Error("Datapath proxy redirection cannot be enabled, L7 proxy may be bypassed")
+			}
+		} else {
+			// Release proxy port if NACK was received. Do not release a port that has
+			// already been successfully acknowledged or that it statically configured.
+			p.proxyPorts.Reset(pp)
+		}
+	}
+
 	var err error
 	for nRetry := 0; nRetry < redirectCreationAttempts; nRetry++ {
 		if err != nil {
@@ -230,7 +256,7 @@ func (p *Proxy) createNewRedirect(
 			break
 		}
 
-		err = p.createRedirectImpl(redirect, l4, wg)
+		err = p.createRedirectImpl(redirect, l4, wg, proxyCallback)
 		if err == nil {
 			break
 		}
@@ -258,10 +284,6 @@ func (p *Proxy) createNewRedirect(
 		// when reverting. Undo what we have done above.
 		p.mutex.Lock()
 		delete(p.redirects, id)
-
-		// Does not release static proxy ports
-		p.proxyPorts.Reset(pp)
-
 		p.updateRedirectMetrics()
 		p.mutex.Unlock()
 		redirect.implementation.Close()
@@ -270,14 +292,14 @@ func (p *Proxy) createNewRedirect(
 
 	// Increase the reference count only when ACK is received
 	finalizeFunc := func() {
-		p.proxyPorts.AckProxyPortWithReference(ctx, ppName)
+		p.proxyPorts.AddReference(pp)
 	}
 
 	// Must return the proxy port when successful
 	return pp.ProxyPort, nil, finalizeFunc, revertFunc
 }
 
-func (p *Proxy) createRedirectImpl(redir *Redirect, l4 policy.ProxyPolicy, wg *completion.WaitGroup) error {
+func (p *Proxy) createRedirectImpl(redir *Redirect, l4 policy.ProxyPolicy, wg *completion.WaitGroup, cb func(err error)) error {
 	var err error
 
 	switch l4.GetL7Parser() {
@@ -285,7 +307,7 @@ func (p *Proxy) createRedirectImpl(redir *Redirect, l4 policy.ProxyPolicy, wg *c
 		redir.implementation, err = p.dnsIntegration.createRedirect(redir, wg)
 		// 'cb' not called for DNS redirects, which have a static proxy port
 	default:
-		redir.implementation, err = p.envoyIntegration.createRedirect(redir, wg)
+		redir.implementation, err = p.envoyIntegration.createRedirect(redir, wg, cb)
 	}
 
 	return err

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -5,22 +5,12 @@ package proxy
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"math/rand/v2"
-	"net"
-	"os"
-	"path/filepath"
 
-	"github.com/google/renameio/v2"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/sirupsen/logrus"
-	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/completion"
-	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
-	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -29,10 +19,9 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
+	"github.com/cilium/cilium/pkg/proxy/proxyports"
 	"github.com/cilium/cilium/pkg/proxy/types"
 	"github.com/cilium/cilium/pkg/revert"
-	"github.com/cilium/cilium/pkg/time"
-	"github.com/cilium/cilium/pkg/trigger"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "proxy")
@@ -41,453 +30,47 @@ var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "proxy")
 const (
 	fieldProxyRedirectID = "id"
 
-	// portReuseDelay is the delay until a port is being reused
-	portReuseDelay = 5 * time.Minute
-
 	// redirectCreationAttempts is the number of attempts to create a redirect
 	redirectCreationAttempts = 5
-
-	// The filename for the allocated proxy ports. This is periodically
-	// written, and restored on restart.
-	// The full path is, by default, /run/cilium/state/proxy_ports_state.json
-	proxyPortsFile = "proxy_ports_state.json"
 )
-
-type DatapathUpdater interface {
-	InstallProxyRules(proxyPort uint16, name string)
-	GetProxyPorts() map[string]uint16
-}
-
-type ProxyPort struct {
-	// proxy type this port applies to (immutable)
-	ProxyType types.ProxyType `json:"type"`
-	// 'true' for Ingress, 'false' for egress (immutable)
-	// 'false' for CRD redirects, which are accessed by name only.
-	Ingress bool `json:"ingress"`
-	// ProxyPort is the desired proxy listening port number.
-	ProxyPort uint16 `json:"port"`
-	// isStatic is true when the listener on the proxy port is incapable
-	// of stopping and/or being reconfigured with a new proxy port once it has been
-	// first started. Set 'true' by SetProxyPort(), which is only called for
-	// static listeners (currently only DNS proxy).
-	isStatic bool
-	// nRedirects is the number of redirects using this proxy port
-	nRedirects int
-	// Configured is true when the proxy is (being) configured, but not necessarily
-	// acknowledged yet. This is reset to false when the underlying proxy listener
-	// is removed.
-	configured bool
-	// rulesPort contains the proxy port value configured to the datapath rules and
-	// is non-zero when a proxy has been successfully created and the
-	// (new, if after restart) datapath rules have been created.
-	rulesPort uint16
-}
-
-type proxyPortsMap map[string]*ProxyPort
 
 // Proxy maintains state about redirects
 type Proxy struct {
 	// mutex is the lock required when modifying any proxy datastructure
 	mutex lock.RWMutex
 
-	// rangeMin is the minimum port used for proxy port allocation
-	rangeMin uint16
-
-	// rangeMax is the maximum port used for proxy port allocation.
-	// If port is unspecified, the proxy will automatically allocate
-	// ports out of the rangeMin-rangeMax range.
-	rangeMax uint16
-
 	// redirects is the map of all redirect configurations indexed by
 	// the redirect identifier. Redirects may be implemented by different
 	// proxies.
 	redirects map[string]*Redirect
 
-	// Datapath updater for installing and removing proxy rules for a single
-	// proxy port
-	datapathUpdater DatapathUpdater
-
-	// allocatedPorts is the map of all allocated proxy ports
-	// 'true' - port is currently in use
-	// 'false' - port has been used the past, and can be reused if needed
-	allocatedPorts map[uint16]bool
-
-	// proxyPorts defaults to a map of all supported proxy ports.
-	// In addition, it also manages dynamically created proxy ports (e.g. CEC).
-	proxyPorts proxyPortsMap
-
-	// path where the set of proxyPorts is persisted on the filesystem for restoration on
-	// restart
-	proxyPortsPath string
-
-	proxyPortsTrigger *trigger.Trigger
-
 	envoyIntegration *envoyProxyIntegration
 	dnsIntegration   *dnsProxyIntegration
+
+	// proxyPorts manages proxy port allocation
+	proxyPorts *proxyports.ProxyPorts
 }
 
 func createProxy(
 	minPort uint16,
 	maxPort uint16,
-	datapathUpdater DatapathUpdater,
+	datapathUpdater proxyports.DatapathUpdater,
 	envoyIntegration *envoyProxyIntegration,
 	dnsIntegration *dnsProxyIntegration,
 ) *Proxy {
 	return &Proxy{
-		rangeMin:         minPort,
-		rangeMax:         maxPort,
 		redirects:        make(map[string]*Redirect),
-		datapathUpdater:  datapathUpdater,
-		allocatedPorts:   make(map[uint16]bool),
-		proxyPorts:       defaultProxyPortMap(),
-		proxyPortsPath:   filepath.Join(option.Config.StateDir, proxyPortsFile),
 		envoyIntegration: envoyIntegration,
 		dnsIntegration:   dnsIntegration,
+		proxyPorts:       proxyports.NewProxyPorts(minPort, maxPort, datapathUpdater),
 	}
-}
-
-func defaultProxyPortMap() proxyPortsMap {
-	return proxyPortsMap{
-		"cilium-http-egress": {
-			ProxyType: types.ProxyTypeHTTP,
-			Ingress:   false,
-		},
-		"cilium-http-ingress": {
-			ProxyType: types.ProxyTypeHTTP,
-			Ingress:   true,
-		},
-		types.DNSProxyName: {
-			ProxyType: types.ProxyTypeDNS,
-			Ingress:   false,
-		},
-		"cilium-proxylib-egress": {
-			ProxyType: types.ProxyTypeAny,
-			Ingress:   false,
-		},
-		"cilium-proxylib-ingress": {
-			ProxyType: types.ProxyTypeAny,
-			Ingress:   true,
-		},
-	}
-}
-
-// Called with mutex held!
-func (p *Proxy) isPortAvailable(openLocalPorts map[uint16]struct{}, port uint16, reuse bool) bool {
-	if port == 0 {
-		return false // zero port requested
-	}
-	if inuse, used := p.allocatedPorts[port]; used && (inuse || !reuse) {
-		return false // port already used
-	}
-	// Check that the port is not already open
-	if _, alreadyOpen := openLocalPorts[port]; alreadyOpen {
-		return false // port already open
-	}
-
-	return true
-}
-
-// Called with mutex held!
-func (p *Proxy) allocatePort(port, min, max uint16) (uint16, error) {
-	// Get a snapshot of the TCP and UDP ports already open locally.
-	openLocalPorts := readOpenLocalPorts(append(procNetTCPFiles, procNetUDPFiles...))
-
-	if p.isPortAvailable(openLocalPorts, port, false) {
-		return port, nil
-	}
-
-	// TODO: Maybe not create a large permutation each time?
-	portRange := rand.Perm(int(max - min + 1))
-
-	// Allow reuse of previously used ports only if no ports are otherwise availeble.
-	// This allows the same port to be used again by a listener being reconfigured
-	// after deletion.
-	for _, reuse := range []bool{false, true} {
-		for _, r := range portRange {
-			resPort := uint16(r) + min
-
-			if p.isPortAvailable(openLocalPorts, resPort, reuse) {
-				return resPort, nil
-			}
-		}
-	}
-
-	return 0, fmt.Errorf("no available proxy ports")
 }
 
 // AckProxyPort() marks the proxy of the given type as successfully
 // created and creates or updates the datapath rules accordingly.
+// Takes a reference on the proxy port.
 func (p *Proxy) AckProxyPort(ctx context.Context, name string) error {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-	pp := p.proxyPorts[name]
-	if pp == nil {
-		return proxyNotFoundError(name)
-	}
-	return p.ackProxyPort(ctx, name, pp) // creates datapath rules, increases the reference count
-}
-
-// ackProxyPort() increases proxy port reference count and creates or updates the datapath rules.
-// Each call must eventually be paired with a corresponding releaseProxyPort() call
-// to keep the use count up-to-date.
-// Must be called with mutex held!
-func (p *Proxy) ackProxyPort(ctx context.Context, name string, pp *ProxyPort) error {
-	scopedLog := log.WithField(fieldProxyRedirectID, name)
-
-	if pp.ProxyPort == 0 {
-		return fmt.Errorf("ackProxyPort: zero port on %s not allowed", name)
-	}
-
-	// Datapath rules are added only after we know the proxy configuration
-	// with the actual port number has succeeded. Deletion of the rules
-	// is delayed after the redirects have been removed to the point
-	// when we know the port number changes. This is to reduce the churn
-	// in the datapath, but means that the datapath rules may exist even
-	// if the proxy is not currently configured.
-
-	// Add new rules, if needed
-	if pp.rulesPort != pp.ProxyPort {
-		// Add rules for the new port
-		// This should always succeed if we have managed to start-up properly
-		scopedLog.Infof("Adding new proxy port rules for %s:%d", name, pp.ProxyPort)
-		p.datapathUpdater.InstallProxyRules(pp.ProxyPort, name)
-		pp.rulesPort = pp.ProxyPort
-
-		// trigger writing proxy ports to file
-		p.proxyPortsTrigger.Trigger()
-	}
-	pp.nRedirects++
-	scopedLog.Debugf("AckProxyPort: acked proxy port %d (%v)", pp.ProxyPort, *pp)
-	return nil
-}
-
-// releaseProxyPort() decreases the use count and frees the port if no users remain
-// Must be called with mutex held!
-func (p *Proxy) releaseProxyPort(name string, portReuseWait time.Duration) error {
-	pp := p.proxyPorts[name]
-	if pp == nil {
-		return fmt.Errorf("Can't find proxy port %s", name)
-	}
-
-	if pp.nRedirects <= 0 {
-		nRedirects := pp.nRedirects
-		pp.nRedirects = 0
-		return fmt.Errorf("Can't release proxy port with has non-positive reference count: %d", nRedirects)
-	}
-
-	pp.nRedirects--
-
-	// Static proxy port is not released, dynamic proxy ports are released after a delay if
-	// still on last reference count
-	if !pp.isStatic && pp.nRedirects == 0 {
-		pp.nRedirects = 1 // keep the last reference during the delay
-		go func() {
-			time.Sleep(portReuseWait)
-
-			p.mutex.Lock()
-			defer p.mutex.Unlock()
-
-			pp.nRedirects--
-			if pp.nRedirects == 0 {
-				log.WithField(fieldProxyRedirectID, name).Debugf("Delayed release of proxy port %d", pp.ProxyPort)
-
-				// Allow the port to be reallocated for other use if needed.
-				p.allocatedPorts[pp.ProxyPort] = false
-				pp.ProxyPort = 0
-				pp.configured = false
-
-				// Leave the datapath rules behind on the hope that they get reused
-				// later.  This becomes possible when we are able to keep the proxy
-				// listeners configured also when there are no redirects.
-			}
-		}()
-	}
-
-	return nil
-}
-
-// findProxyPortByType returns a ProxyPort matching the given type, listener name, and direction, if
-// found.  Must be called with mutex held!
-func (p *Proxy) findProxyPortByType(l7Type types.ProxyType, listener string, ingress bool) (string, *ProxyPort) {
-	portType := l7Type
-	switch l7Type {
-	case types.ProxyTypeCRD:
-		// CRD proxy ports are dynamically created, look up by name
-		// 'ingress' is always false for CRD type
-		if pp, ok := p.proxyPorts[listener]; ok && pp.ProxyType == types.ProxyTypeCRD && !pp.Ingress {
-			return listener, pp
-		}
-		log.Debugf("findProxyPortByType: can not find crd listener %s from %v", listener, p.proxyPorts)
-		return "", nil
-	case types.ProxyTypeDNS, types.ProxyTypeHTTP:
-		// Look up by the given type
-	default:
-		// "Unknown" parsers are assumed to be Proxylib (TCP) parsers, which
-		// is registered with an empty string.
-		// This works also for explicit TCP and TLS parser types, which are backed by the
-		// TCP Proxy filter chain.
-		portType = types.ProxyTypeAny
-	}
-	// proxyPorts is small enough to not bother indexing it.
-	for name, pp := range p.proxyPorts {
-		if pp.ProxyType == portType && pp.Ingress == ingress {
-			return name, pp
-		}
-	}
-	return "", nil
-}
-
-func proxyTypeNotFoundError(proxyType types.ProxyType, listener string, ingress bool) error {
-	dir := "egress"
-	if ingress {
-		dir = "ingress"
-	}
-	return fmt.Errorf("unrecognized %s proxy type for %s: %s", dir, listener, proxyType)
-}
-
-func proxyNotFoundError(name string) error {
-	return fmt.Errorf("unrecognized proxy: %s", name)
-}
-
-// must be called with mutex NOT held via p.proxyPortsTrigger
-func (p *Proxy) storeProxyPorts(ctx context.Context) error {
-	if p.proxyPortsPath == "" {
-		return nil // this is a unit test
-	}
-	log := log.WithField(logfields.Path, p.proxyPortsPath)
-
-	// use renameio to prevent partial writes
-	out, err := renameio.NewPendingFile(p.proxyPortsPath, renameio.WithExistingPermissions(), renameio.WithPermissions(0o600))
-	if err != nil {
-		log.WithError(err).Error("failed to prepare proxy ports file")
-		return err
-	}
-	defer out.Cleanup()
-
-	jw := jsoniter.ConfigFastest.NewEncoder(out)
-
-	portsMap := make(proxyPortsMap)
-	p.mutex.Lock()
-	// only retain acknowledged, non-zero ports
-	for name, pp := range p.proxyPorts {
-		if pp.configured && pp.ProxyPort > 0 {
-			portsMap[name] = pp
-		}
-	}
-	p.mutex.Unlock()
-
-	if err := jw.Encode(portsMap); err != nil {
-		log.WithError(err).Error("failed to marshal proxy ports state")
-		return err
-	}
-	if err := out.CloseAtomicallyReplace(); err != nil {
-		log.WithError(err).Error("failed to write proxy ports file")
-		return err
-	}
-	log.Debug("Wrote proxy ports state")
-	return nil
-}
-
-var (
-	staleProxyPortsFile = errors.New("proxy ports file is too old")
-)
-
-// restore proxy ports from file created earlier by stroreProxyPorts
-// must be called with mutex held
-func (p *Proxy) restoreProxyPortsFromFile(restoredProxyPortsStaleLimit uint) error {
-	log := log.WithField(logfields.Path, p.proxyPortsPath)
-
-	// Check that the file exists and is not too old
-	stat, err := os.Stat(p.proxyPortsPath)
-	if err != nil {
-		return err
-	}
-	if time.Since(stat.ModTime()) > time.Duration(restoredProxyPortsStaleLimit)*time.Minute {
-		return staleProxyPortsFile
-	}
-
-	// Read in checkpoint file
-	fp, err := os.Open(p.proxyPortsPath)
-	if err != nil {
-		return err
-	}
-	defer fp.Close()
-
-	jr := jsoniter.ConfigFastest.NewDecoder(fp)
-	var portsMap proxyPortsMap
-	if err := jr.Decode(&portsMap); err != nil {
-		return err
-	}
-
-	for name, pp := range portsMap {
-		if existing := p.proxyPorts[name]; existing != nil {
-			if existing.ProxyPort != 0 {
-				continue // do not overwrite explicitly set port
-			}
-		}
-		p.proxyPorts[name] = pp
-		p.allocatedPorts[pp.ProxyPort] = false
-		log.
-			WithField(fieldProxyRedirectID, name).
-			WithField("proxyPort", pp.ProxyPort).
-			Debugf("RestoreProxyPorts: preallocated proxy port")
-	}
-	return nil
-}
-
-// restoreProxyPortsFromIptables tries to find earlier port numbers from datapath and use them
-// as defaults for proxy ports
-// must be called with mutex held
-func (p *Proxy) restoreProxyPortsFromIptables() {
-	// restore proxy ports from the datapath iptables rules
-	portsMap := p.datapathUpdater.GetProxyPorts()
-	for name, port := range portsMap {
-		pp := p.proxyPorts[name]
-		if pp != nil {
-			if pp.ProxyPort != 0 {
-				continue // do not overwrite explicitly set port
-			}
-			pp.ProxyPort = port
-		} else {
-			// Only CRD type proxy ports can be dynamically allocated. Assume a port
-			// from datapath with an unknown name was for a dynamically allocated CRD
-			// proxy and pre-allocate a proxy port for it.
-			// CRD proxy ports always have 'ingress' as 'false'.
-			p.proxyPorts[name] = &ProxyPort{ProxyType: types.ProxyTypeCRD, Ingress: false, ProxyPort: port}
-		}
-		p.allocatedPorts[port] = false
-		log.
-			WithField(fieldProxyRedirectID, name).
-			WithField("proxyPort", port).
-			Debugf("RestoreProxyPorts: preallocated proxy port from iptables")
-	}
-}
-
-// Exported API
-
-// RestoreProxyPorts tries to find earlier port numbers from datapath and use them
-// as defaults for proxy ports
-func (p *Proxy) RestoreProxyPorts(restoredProxyPortsStaleLimit uint) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	err := p.restoreProxyPortsFromFile(restoredProxyPortsStaleLimit)
-	if err != nil {
-		log.WithError(err).WithField(logfields.Path, p.proxyPortsPath).Info("Resoring proxy ports from file failed, falling back to restoring from iptables rules")
-		p.restoreProxyPortsFromIptables()
-	}
-}
-
-// GetProxyPort() returns the fixed listen port for a proxy, if any.
-func (p *Proxy) GetProxyPort(name string) (port uint16, isStatic bool, err error) {
-	// Accessing pp.proxyPort requires the lock
-	p.mutex.RLock()
-	defer p.mutex.RUnlock()
-	pp := p.proxyPorts[name]
-	if pp != nil {
-		return pp.ProxyPort, pp.isStatic, nil
-	}
-	return 0, false, proxyNotFoundError(name)
+	return p.proxyPorts.AckProxyPortWithReference(ctx, name)
 }
 
 // AllocateCRDProxyPort() allocates a new port for listener 'name', or returns the current one if
@@ -495,154 +78,34 @@ func (p *Proxy) GetProxyPort(name string) (port uint16, isStatic bool, err error
 // Each call has to be paired with AckProxyPort(name) to update the datapath rules accordingly.
 // Each allocated port must be eventually freed with ReleaseProxyPort().
 func (p *Proxy) AllocateCRDProxyPort(name string) (uint16, error) {
-	// Accessing pp.proxyPort requires the lock
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-	pp := p.proxyPorts[name]
-	if pp == nil || pp.Ingress {
-		pp = &ProxyPort{ProxyType: types.ProxyTypeCRD, Ingress: false}
-	}
-
-	// Allocate a new port only if a port was never allocated before.
-	// This is required since Envoy may already be listening on the
-	// previously allocated port for this proxy listener.
-	if pp.ProxyPort == 0 {
-		var err error
-		// Try to allocate the same port that was previously used on the datapath
-		if pp.rulesPort != 0 && !p.allocatedPorts[pp.rulesPort] {
-			pp.ProxyPort = pp.rulesPort
-		} else {
-			pp.ProxyPort, err = p.allocatePort(pp.rulesPort, p.rangeMin, p.rangeMax)
-			if err != nil {
-				return 0, err
-			}
-		}
-	}
-	p.proxyPorts[name] = pp
-	// marks port as reserved
-	p.allocatedPorts[pp.ProxyPort] = true
-	// mark proxy port as configured
-	pp.configured = true
-
-	log.WithField(fieldProxyRedirectID, name).Debugf("AllocateProxyPort: allocated proxy port %d (%v)", pp.ProxyPort, *pp)
-
-	return pp.ProxyPort, nil
+	return p.proxyPorts.AllocateCRDProxyPort(name)
 }
 
 func (p *Proxy) ReleaseProxyPort(name string) error {
-	// Accessing pp.proxyPort requires the lock
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-	return p.releaseProxyPort(name, portReuseDelay)
+	return p.proxyPorts.ReleaseProxyPort(name)
+}
+
+func (p *Proxy) ReinstallRoutingRules(mtu int) error {
+	return ReinstallRoutingRules(mtu)
+}
+
+// GetProxyPort() returns the fixed listen port for a proxy, if any.
+func (p *Proxy) GetProxyPort(name string) (port uint16, isStatic bool, err error) {
+	return p.proxyPorts.GetProxyPort(name)
 }
 
 // SetProxyPort() marks the proxy 'name' as successfully created with proxy port 'port'.
 // Another call to AckProxyPort(name) is needed to update the datapath rules accordingly.
 // This should only be called for proxies that have a static listener that is already listening on
 // 'port'. May only be called once per proxy.
+
 func (p *Proxy) SetProxyPort(name string, proxyType types.ProxyType, port uint16, ingress bool) error {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	pp := p.proxyPorts[name]
-	if pp == nil {
-		pp = &ProxyPort{ProxyType: proxyType, Ingress: ingress}
-		p.proxyPorts[name] = pp
-	}
-	if pp.nRedirects > 0 {
-		return fmt.Errorf("Can't set proxy port to %d: proxy %s is already configured on %d", port, name, pp.ProxyPort)
-	}
-	pp.ProxyPort = port
-	pp.isStatic = true // prevents release of the proxy port
-	// marks port as reserved
-	p.allocatedPorts[pp.ProxyPort] = true
-	// mark proxy port as configured
-	pp.configured = true
-	return nil
+	return p.proxyPorts.SetProxyPort(name, proxyType, port, ingress)
 }
 
-// ReinstallRoutingRules ensures the presence of routing rules and tables needed
-// to route packets to and from the L7 proxy.
-func (p *Proxy) ReinstallRoutingRules(mtu int) error {
-	fromIngressProxy, fromEgressProxy := requireFromProxyRoutes()
-
-	// Use the provided mtu (RouteMTU) only with both ingress and egress proxy.
-	if !fromIngressProxy || !fromEgressProxy {
-		mtu = 0
-	}
-
-	if option.Config.EnableIPv4 {
-		if err := installToProxyRoutesIPv4(); err != nil {
-			return err
-		}
-
-		if fromIngressProxy || fromEgressProxy {
-			if err := installFromProxyRoutesIPv4(node.GetInternalIPv4Router(), defaults.HostDevice, fromIngressProxy, fromEgressProxy, mtu); err != nil {
-				return err
-			}
-		} else {
-			if err := removeFromProxyRoutesIPv4(); err != nil {
-				return err
-			}
-		}
-	} else {
-		if err := removeToProxyRoutesIPv4(); err != nil {
-			return err
-		}
-		if err := removeFromProxyRoutesIPv4(); err != nil {
-			return err
-		}
-	}
-
-	if option.Config.EnableIPv6 {
-		if err := installToProxyRoutesIPv6(); err != nil {
-			return err
-		}
-
-		if fromIngressProxy || fromEgressProxy {
-			ipv6, err := getCiliumNetIPv6()
-			if err != nil {
-				return err
-			}
-			if err := installFromProxyRoutesIPv6(ipv6, defaults.HostDevice, fromIngressProxy, fromEgressProxy, mtu); err != nil {
-				return err
-			}
-		} else {
-			if err := removeFromProxyRoutesIPv6(); err != nil {
-				return err
-			}
-		}
-	} else {
-		if err := removeToProxyRoutesIPv6(); err != nil {
-			return err
-		}
-		if err := removeFromProxyRoutesIPv6(); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func requireFromProxyRoutes() (fromIngressProxy, fromEgressProxy bool) {
-	fromIngressProxy = (option.Config.EnableEnvoyConfig || option.Config.EnableIPSec) && !option.Config.TunnelingEnabled()
-	fromEgressProxy = option.Config.EnableIPSec && !option.Config.TunnelingEnabled()
-	return
-}
-
-// getCiliumNetIPv6 retrieves the first IPv6 address from the cilium_net device.
-func getCiliumNetIPv6() (net.IP, error) {
-	link, err := safenetlink.LinkByName(defaults.SecondHostDevice)
-	if err != nil {
-		return nil, fmt.Errorf("cannot find link '%s': %w", defaults.SecondHostDevice, err)
-	}
-
-	addrList, err := safenetlink.AddrList(link, netlink.FAMILY_V6)
-	if err == nil && len(addrList) > 0 {
-		return addrList[0].IP, nil
-	}
-
-	return nil, fmt.Errorf("failed to find valid IPv6 address for cilium_net")
+// OpenLocalPorts returns the set of L4 ports currently open locally.
+func OpenLocalPorts() map[uint16]struct{} {
+	return proxyports.OpenLocalPorts()
 }
 
 // CreateOrUpdateRedirect creates or updates a L4 redirect with corresponding
@@ -677,7 +140,7 @@ func (p *Proxy) CreateOrUpdateRedirect(
 		existingRedirect.mutex.Lock()
 
 		// Only consider configured (but not necessarily acked) proxy ports for update
-		if existingRedirect.listener.configured && existingRedirect.listener.ProxyType == types.ProxyType(l4.GetL7Parser()) {
+		if p.proxyPorts.HasProxyType(existingRedirect.listener, types.ProxyType(l4.GetL7Parser())) {
 			updateRevertFunc := existingRedirect.updateRules(l4)
 			revertStack.Push(updateRevertFunc)
 			implUpdateRevertFunc, err := existingRedirect.implementation.UpdateRules(wg)
@@ -718,6 +181,14 @@ func (p *Proxy) CreateOrUpdateRedirect(
 	return port, nil, finalizeList.Finalize, revertStack.Revert
 }
 
+func proxyTypeNotFoundError(proxyType types.ProxyType, listener string, ingress bool) error {
+	dir := "egress"
+	if ingress {
+		dir = "ingress"
+	}
+	return fmt.Errorf("unrecognized %s proxy type for %s: %s", dir, listener, proxyType)
+}
+
 func (p *Proxy) createNewRedirect(
 	ctx context.Context, l4 policy.ProxyPolicy, id string, epID uint16, wg *completion.WaitGroup,
 ) (
@@ -728,7 +199,7 @@ func (p *Proxy) createNewRedirect(
 		WithField(logfields.Listener, l4.GetListener()).
 		WithField("l7parser", l4.GetL7Parser())
 
-	ppName, pp := p.findProxyPortByType(types.ProxyType(l4.GetL7Parser()), l4.GetListener(), l4.GetIngress())
+	ppName, pp := p.proxyPorts.FindByType(types.ProxyType(l4.GetL7Parser()), l4.GetListener(), l4.GetIngress())
 	if pp == nil {
 		return 0, proxyTypeNotFoundError(types.ProxyType(l4.GetL7Parser()), l4.GetListener(), l4.GetIngress()), nil, nil
 	}
@@ -740,65 +211,47 @@ func (p *Proxy) createNewRedirect(
 	scopedLog = scopedLog.
 		WithField("portName", ppName)
 
-	if pp.ProxyPort == 0 && pp.rulesPort != 0 {
-		// try first with the previous port
-		pp.ProxyPort = pp.rulesPort
+	// try first with the previous port, if any
+	p.proxyPorts.Restore(pp)
+
+	var err error
+	for nRetry := 0; nRetry < redirectCreationAttempts; nRetry++ {
+		if err != nil {
+			// an error occurred and we are retrying
+			scopedLog.
+				WithError(err).
+				WithField(logfields.ProxyPort, pp.ProxyPort).
+				Warning("Unable to create proxy, retrying")
+		}
+
+		err = p.proxyPorts.AllocatePort(pp, nRetry > 0)
+		if err != nil {
+			err = fmt.Errorf("failed to allocate port: %w", err)
+			break
+		}
+
+		err = p.createRedirectImpl(redirect, l4, wg)
+		if err == nil {
+			break
+		}
 	}
 
-	for nRetry := 0; nRetry < redirectCreationAttempts; nRetry++ {
-		// Reallocate port only if not yet configured and the first try failed, or the port
-		// has not been (pre)allocated yet.
-		// For example, on restart we may have preallocated port that is not configured
-		// yet. The port may already be listening, causing allocatePort() to select another
-		// one, as the port is not available. We should make the first try with the
-		// preallocated port, as in typical case the listener we are about to configure
-		// already exists (daemonset proxy), or can be created on a new proxy with the same
-		// port (embedded Envoy).
-		if !pp.configured && (nRetry > 0 || pp.ProxyPort == 0) {
-			// Clear the proxy port on retry so that a random new port will be tried.
-			pp.ProxyPort = 0
-
-			// Check if pp.proxyPort is available and find another available proxy port if not.
-			proxyPort, err := p.allocatePort(pp.ProxyPort, p.rangeMin, p.rangeMax)
-			if err != nil {
-				return 0, fmt.Errorf("failed to allocate port: %w", err), nil, nil
-			}
-			pp.ProxyPort = proxyPort
-		}
-
-		if err := p.createRedirectImpl(redirect, l4, wg); err != nil {
-			if nRetry < redirectCreationAttempts-1 {
-				// an error occurred and we are retrying
-				scopedLog.
-					WithError(err).
-					Warning("Unable to create proxy, retrying")
-				continue
-			} else {
-				// an error occurred, and we have no more retries
-				scopedLog.
-					WithError(err).
-					Error("Unable to create proxy")
-				return 0, fmt.Errorf("failed to create redirect implementation: %w", err), nil, nil
-			}
-		}
-
-		break
+	if err != nil {
+		// an error occurred, and we have no more retries
+		scopedLog.
+			WithError(err).
+			WithField(logfields.ProxyPort, pp.ProxyPort).
+			Error("Unable to create proxy")
+		return 0, fmt.Errorf("failed to create redirect implementation: %w", err), nil, nil
 	}
 
 	scopedLog.
 		WithField(logfields.Object, logfields.Repr(redirect)).
+		WithField(logfields.ProxyPort, pp.ProxyPort).
 		Info("Created new proxy instance")
 
 	p.redirects[id] = redirect
 	p.updateRedirectMetrics()
-
-	// must mark the proxyPort configured while we still hold the lock to prevent racing between
-	// two parallel runs
-
-	// marks port as reserved
-	p.allocatedPorts[pp.ProxyPort] = true
-	// mark proxy port as configured
-	pp.configured = true
 
 	revertFunc := func() error {
 		// Proxy port refcount has not been incremented yet, so it must not be decremented
@@ -806,16 +259,8 @@ func (p *Proxy) createNewRedirect(
 		p.mutex.Lock()
 		delete(p.redirects, id)
 
-		// Do not release static proxy port.
-		if !pp.isStatic {
-			// Mark the port for reuse only if no other ports are available
-			// Discourage the reuse of the same port in future as revert may have been
-			// due to port not being available for bind().
-			p.allocatedPorts[pp.ProxyPort] = false
-			// clear proxy port on failure so that a new one will be tried next time
-			pp.ProxyPort = 0
-			pp.configured = false
-		}
+		// Does not release static proxy ports
+		p.proxyPorts.Reset(pp)
 
 		p.updateRedirectMetrics()
 		p.mutex.Unlock()
@@ -823,16 +268,9 @@ func (p *Proxy) createNewRedirect(
 		return nil
 	}
 
-	// Set the proxy port only after an ACK is received.
+	// Increase the reference count only when ACK is received
 	finalizeFunc := func() {
-		p.mutex.Lock()
-		err := p.ackProxyPort(ctx, ppName, pp)
-		p.mutex.Unlock()
-		if err != nil {
-			scopedLog.
-				WithError(err).
-				Error("Datapath proxy redirection cannot be enabled, L7 proxy may be bypassed")
-		}
+		p.proxyPorts.AckProxyPortWithReference(ctx, ppName)
 	}
 
 	// Must return the proxy port when successful
@@ -845,6 +283,7 @@ func (p *Proxy) createRedirectImpl(redir *Redirect, l4 policy.ProxyPolicy, wg *c
 	switch l4.GetL7Parser() {
 	case policy.ParserTypeDNS:
 		redir.implementation, err = p.dnsIntegration.createRedirect(redir, wg)
+		// 'cb' not called for DNS redirects, which have a static proxy port
 	default:
 		redir.implementation, err = p.envoyIntegration.createRedirect(redir, wg)
 	}
@@ -874,8 +313,6 @@ func (p *Proxy) RemoveRedirect(id string) {
 }
 
 // removeRedirect removes an existing redirect. p.mutex must be held
-// p.mutex must NOT be held when the returned revert function is called!
-// proxyPortsMutex must NOT be held when the returned finalize function is called!
 func (p *Proxy) removeRedirect(id string) {
 	log.
 		WithField(fieldProxyRedirectID, id).
@@ -897,7 +334,7 @@ func (p *Proxy) removeRedirect(id string) {
 	// break GC loop (implementation may point back to 'r')
 	r.implementation = nil
 
-	err := p.releaseProxyPort(listenerName, portReuseDelay)
+	err := p.proxyPorts.ReleaseProxyPort(listenerName)
 	if err != nil {
 		log.
 			WithField(fieldProxyRedirectID, id).
@@ -935,21 +372,20 @@ func (p *Proxy) GetStatusModel() *models.ProxyStatus {
 	p.mutex.RLock()
 	defer p.mutex.RUnlock()
 
+	rangeMin, rangeMax, nPorts := p.proxyPorts.GetStatusInfo()
+
 	result := &models.ProxyStatus{
 		IP:             node.GetInternalIPv4Router().String(),
-		PortRange:      fmt.Sprintf("%d-%d", p.rangeMin, p.rangeMax),
+		PortRange:      fmt.Sprintf("%d-%d", rangeMin, rangeMax),
+		TotalPorts:     int64(nPorts),
 		TotalRedirects: int64(len(p.redirects)),
 	}
-	for _, pp := range p.proxyPorts {
-		if pp.nRedirects > 0 {
-			result.TotalPorts++
-		}
-	}
+
 	for name, redirect := range p.redirects {
 		result.Redirects = append(result.Redirects, &models.ProxyRedirect{
 			Name:      name,
 			Proxy:     redirect.name,
-			ProxyPort: int64(redirect.listener.rulesPort),
+			ProxyPort: int64(p.proxyPorts.GetRulesPort(redirect.listener)),
 		})
 	}
 	result.EnvoyDeploymentMode = "embedded"

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -13,193 +13,25 @@ import (
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/proxy/types"
+	"github.com/cilium/cilium/pkg/proxy/proxyports"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
-type MockDatapathUpdater struct{}
-
-func (m *MockDatapathUpdater) InstallProxyRules(proxyPort uint16, name string) {
-}
-
-func (m *MockDatapathUpdater) GetProxyPorts() map[string]uint16 {
-	return nil
-}
-
 func proxyForTest() (*Proxy, func()) {
-	mockDatapathUpdater := &MockDatapathUpdater{}
+	mockDatapathUpdater := &proxyports.MockDatapathUpdater{}
 	p := createProxy(10000, 20000, mockDatapathUpdater, nil, nil)
 	triggerDone := make(chan struct{})
-	p.proxyPortsTrigger, _ = trigger.NewTrigger(trigger.Parameters{
+	p.proxyPorts.Trigger, _ = trigger.NewTrigger(trigger.Parameters{
 		MinInterval:  10 * time.Second,
 		TriggerFunc:  func(reasons []string) {},
 		ShutdownFunc: func() { close(triggerDone) },
 	})
 	return p, func() {
-		p.proxyPortsTrigger.Shutdown()
+		p.proxyPorts.Trigger.Shutdown()
 		<-triggerDone
 	}
-}
-
-func TestPortAllocator(t *testing.T) {
-	testRunDir := t.TempDir()
-	socketDir := envoy.GetSocketDir(testRunDir)
-	err := os.MkdirAll(socketDir, 0700)
-	require.NoError(t, err)
-
-	p, cleaner := proxyForTest()
-	defer cleaner()
-
-	port, err := p.AllocateCRDProxyPort("listener1")
-	require.NoError(t, err)
-	require.NotEqual(t, 0, port)
-
-	port1, _, err := p.GetProxyPort("listener1")
-	require.NoError(t, err)
-	require.Equal(t, port, port1)
-
-	// Another allocation for the same name gets the same port
-	port1a, err := p.AllocateCRDProxyPort("listener1")
-	require.NoError(t, err)
-	require.Equal(t, port1, port1a)
-
-	name, pp := p.findProxyPortByType(types.ProxyTypeCRD, "listener1", false)
-	require.Equal(t, "listener1", name)
-	require.Equal(t, types.ProxyTypeCRD, pp.ProxyType)
-	require.Equal(t, port, pp.ProxyPort)
-	require.False(t, pp.Ingress)
-	require.True(t, pp.configured)
-	require.False(t, pp.isStatic)
-	require.Equal(t, 0, pp.nRedirects)
-	require.Equal(t, uint16(0), pp.rulesPort)
-
-	// Proxy port without references can not be released, so increment to simulate proxy
-	// redirect creation
-	pp.nRedirects++
-
-	err = p.releaseProxyPort("listener1", 10*time.Millisecond)
-	require.NoError(t, err)
-
-	// Proxy port is not released immediately
-	require.Equal(t, 1, pp.nRedirects)
-	require.Equal(t, port, pp.ProxyPort)
-	port1a, _, err = p.GetProxyPort("listener1")
-	require.NoError(t, err)
-	require.Equal(t, port, port1a)
-
-	// Wait past the time the proxy port is released
-	time.Sleep(15 * time.Millisecond)
-
-	// ProxyPort lingers and can still be found, but it's port is zeroed
-	port1b, _, err := p.GetProxyPort("listener1")
-	require.NoError(t, err)
-	require.Equal(t, uint16(0), port1b)
-	require.Equal(t, uint16(0), pp.ProxyPort)
-	require.False(t, pp.configured)
-	require.Equal(t, 0, pp.nRedirects)
-
-	// the port was never acked, so rulesPort is 0
-	require.Equal(t, uint16(0), pp.rulesPort)
-
-	// Allocates a different port (due to port was never acked)
-	port2, err := p.AllocateCRDProxyPort("listener1")
-	require.NoError(t, err)
-	require.NotEqual(t, port, port2)
-	name2, pp2 := p.findProxyPortByType(types.ProxyTypeCRD, "listener1", false)
-	require.Equal(t, name2, name)
-	require.Equal(t, pp2, pp)
-	require.Equal(t, types.ProxyTypeCRD, pp.ProxyType)
-	require.False(t, pp.Ingress)
-	require.Equal(t, port2, pp.ProxyPort)
-	require.True(t, pp.configured)
-	require.False(t, pp.isStatic)
-	require.Equal(t, 0, pp.nRedirects)
-	require.Equal(t, uint16(0), pp.rulesPort)
-
-	// Ack configures the port to the datapath
-	err = p.AckProxyPort(context.TODO(), "listener1")
-	require.NoError(t, err)
-	require.Equal(t, 1, pp.nRedirects)
-	require.Equal(t, port2, pp.rulesPort)
-
-	// Another Ack takes another reference
-	err = p.AckProxyPort(context.TODO(), "listener1")
-	require.NoError(t, err)
-	require.Equal(t, 2, pp.nRedirects)
-	require.Equal(t, port2, pp.rulesPort)
-
-	// 1st release decreases the count
-	err = p.ReleaseProxyPort("listener1")
-	require.NoError(t, err)
-	require.Equal(t, 1, pp.nRedirects)
-	require.True(t, pp.configured)
-	require.Equal(t, port2, pp.ProxyPort)
-
-	// 2nd release decreases the count to zero
-	err = p.releaseProxyPort("listener1", time.Microsecond)
-	require.NoError(t, err)
-	time.Sleep(time.Millisecond)
-	require.Equal(t, 0, pp.nRedirects)
-	require.False(t, pp.configured)
-	require.Equal(t, uint16(0), pp.ProxyPort)
-	require.Equal(t, port2, pp.rulesPort)
-
-	// extra releases return an error
-	err = p.ReleaseProxyPort("listener1")
-	require.Error(t, err)
-
-	// mimic some other process taking the port
-	p.allocatedPorts[port2] = true
-
-	// Allocate again, this time a different port is allocated
-	port3, err := p.AllocateCRDProxyPort("listener1")
-	require.NoError(t, err)
-	require.NotEqual(t, uint16(0), port3)
-	require.NotEqual(t, port2, port3)
-	require.NotEqual(t, port1, port3)
-	name2, pp2 = p.findProxyPortByType(types.ProxyTypeCRD, "listener1", false)
-	require.Equal(t, name2, name)
-	require.Equal(t, pp2, pp)
-	require.Equal(t, types.ProxyTypeCRD, pp.ProxyType)
-	require.False(t, pp.Ingress)
-	require.Equal(t, port3, pp.ProxyPort)
-	require.True(t, pp.configured)
-	require.False(t, pp.isStatic)
-	require.Equal(t, 0, pp.nRedirects)
-	require.Equal(t, port2, pp.rulesPort)
-
-	// Ack configures the port to the datapath
-	err = p.AckProxyPort(context.TODO(), "listener1")
-	require.NoError(t, err)
-	require.Equal(t, 1, pp.nRedirects)
-	require.Equal(t, port3, pp.rulesPort)
-
-	// Release marks the port as unallocated
-	err = p.releaseProxyPort("listener1", time.Microsecond)
-	require.NoError(t, err)
-	time.Sleep(time.Millisecond)
-	require.Equal(t, 0, pp.nRedirects)
-	require.False(t, pp.configured)
-	require.Equal(t, uint16(0), pp.ProxyPort)
-	require.Equal(t, port3, pp.rulesPort)
-
-	inuse, exists := p.allocatedPorts[port3]
-	require.True(t, exists)
-	require.False(t, inuse)
-
-	// No-one used the port so next allocation gets the same port again
-	port4, err := p.AllocateCRDProxyPort("listener1")
-	require.NoError(t, err)
-	require.Equal(t, port3, port4)
-	require.Equal(t, types.ProxyTypeCRD, pp.ProxyType)
-	require.False(t, pp.Ingress)
-	require.Equal(t, port4, pp.ProxyPort)
-	require.True(t, pp.configured)
-	require.False(t, pp.isStatic)
-	require.Equal(t, 0, pp.nRedirects)
-	require.Equal(t, port3, pp.rulesPort)
 }
 
 type fakeProxyPolicy struct{}

--- a/pkg/proxy/proxyports/netstat.go
+++ b/pkg/proxy/proxyports/netstat.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package proxy
+package proxyports
 
 import (
 	"bytes"

--- a/pkg/proxy/proxyports/proxyports.go
+++ b/pkg/proxy/proxyports/proxyports.go
@@ -1,0 +1,637 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package proxyports
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"path/filepath"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/proxy/types"
+	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/trigger"
+
+	"github.com/google/renameio/v2"
+	jsoniter "github.com/json-iterator/go"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "proxy")
+
+// field names used while logging
+const (
+	fieldProxyRedirectID = "id"
+
+	// portReuseDelay is the delay until a port is being reused
+	portReuseDelay = 5 * time.Minute
+
+	// The filename for the allocated proxy ports. This is periodically
+	// written, and restored on restart.
+	// The full path is, by default, /run/cilium/state/proxy_ports_state.json
+	proxyPortsFile = "proxy_ports_state.json"
+)
+
+type DatapathUpdater interface {
+	InstallProxyRules(proxyPort uint16, name string)
+	GetProxyPorts() map[string]uint16
+}
+
+type ProxyPort struct {
+	// proxy type this port applies to (immutable)
+	ProxyType types.ProxyType `json:"type"`
+	// 'true' for Ingress, 'false' for egress (immutable)
+	// 'false' for CRD redirects, which are accessed by name only.
+	Ingress bool `json:"ingress"`
+	// ProxyPort is the desired proxy listening port number.
+	ProxyPort uint16 `json:"port"`
+	// isStatic is true when the listener on the proxy port is incapable
+	// of stopping and/or being reconfigured with a new proxy port once it has been
+	// first started. Set 'true' by SetProxyPort(), which is only called for
+	// static listeners (currently only DNS proxy).
+	isStatic bool
+	// nRedirects is the number of redirects using this proxy port
+	nRedirects int
+	// Configured is true when the proxy is (being) configured, but not necessarily
+	// acknowledged yet. This is reset to false when the underlying proxy listener
+	// is removed.
+	configured bool
+	// rulesPort contains the proxy port value configured to the datapath rules and
+	// is non-zero when a proxy has been successfully created and the
+	// (new, if after restart) datapath rules have been created.
+	rulesPort uint16
+}
+
+type proxyPortsMap map[string]*ProxyPort
+
+type ProxyPorts struct {
+	// rangeMin is the minimum port used for proxy port allocation
+	rangeMin uint16
+
+	// rangeMax is the maximum port used for proxy port allocation.
+	// If port is unspecified, the proxy will automatically allocate
+	// ports out of the rangeMin-rangeMax range.
+	rangeMax uint16
+
+	// Datapath updater for installing and removing proxy rules for a single
+	// proxy port
+	datapathUpdater DatapathUpdater
+
+	// path where the set of proxyPorts is persisted on the filesystem for restoration on
+	// restart
+	proxyPortsPath string
+
+	// Trigger for stroring proxy ports on to file
+	Trigger *trigger.Trigger
+
+	// mutex is the lock required when accessing fields below or
+	// any of the mutable fields of a specific ProxyPort.
+	mutex lock.RWMutex
+
+	// allocatedPorts is the map of all allocated proxy ports
+	// 'true' - port is currently in use
+	// 'false' - port has been used the past, and can be reused if needed
+	allocatedPorts map[uint16]bool
+
+	// proxyPorts defaults to a map of all supported proxy ports.
+	// In addition, it also manages dynamically created proxy ports (e.g. CEC).
+	proxyPorts proxyPortsMap
+}
+
+func NewProxyPorts(
+	minPort uint16,
+	maxPort uint16,
+	datapathUpdater DatapathUpdater,
+) *ProxyPorts {
+	return &ProxyPorts{
+		rangeMin:        minPort,
+		rangeMax:        maxPort,
+		datapathUpdater: datapathUpdater,
+		proxyPortsPath:  filepath.Join(option.Config.StateDir, proxyPortsFile),
+		allocatedPorts:  make(map[uint16]bool),
+		proxyPorts:      defaultProxyPortMap(),
+	}
+}
+
+func (p *ProxyPorts) GetStatusInfo() (rangeMin, rangeMax, nPorts uint16) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	for _, pp := range p.proxyPorts {
+		if pp.nRedirects > 0 {
+			nPorts++
+		}
+	}
+	return p.rangeMin, p.rangeMax, nPorts
+}
+
+func defaultProxyPortMap() proxyPortsMap {
+	return proxyPortsMap{
+		"cilium-http-egress": {
+			ProxyType: types.ProxyTypeHTTP,
+			Ingress:   false,
+		},
+		"cilium-http-ingress": {
+			ProxyType: types.ProxyTypeHTTP,
+			Ingress:   true,
+		},
+		types.DNSProxyName: {
+			ProxyType: types.ProxyTypeDNS,
+			Ingress:   false,
+		},
+		"cilium-proxylib-egress": {
+			ProxyType: types.ProxyTypeAny,
+			Ingress:   false,
+		},
+		"cilium-proxylib-ingress": {
+			ProxyType: types.ProxyTypeAny,
+			Ingress:   true,
+		},
+	}
+}
+
+func (p *ProxyPorts) isPortAvailable(openLocalPorts map[uint16]struct{}, port uint16, reuse bool) bool {
+	if port == 0 {
+		return false // zero port requested
+	}
+	if inuse, used := p.allocatedPorts[port]; used && (inuse || !reuse) {
+		return false // port already used
+	}
+	// Check that the port is not already open
+	if _, alreadyOpen := openLocalPorts[port]; alreadyOpen {
+		return false // port already open
+	}
+
+	return true
+}
+
+func (p *ProxyPorts) allocatePort(port, min, max uint16) (uint16, error) {
+	// Get a snapshot of the TCP and UDP ports already open locally.
+	openLocalPorts := OpenLocalPorts()
+
+	if p.isPortAvailable(openLocalPorts, port, false) {
+		return port, nil
+	}
+
+	// TODO: Maybe not create a large permutation each time?
+	portRange := rand.Perm(int(max - min + 1))
+
+	// Allow reuse of previously used ports only if no ports are otherwise available.
+	// This allows the same port to be used again by a listener being reconfigured
+	// after deletion.
+	for _, reuse := range []bool{false, true} {
+		for _, r := range portRange {
+			resPort := uint16(r) + min
+
+			if p.isPortAvailable(openLocalPorts, resPort, reuse) {
+				return resPort, nil
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("no available proxy ports")
+}
+
+func (p *ProxyPorts) AllocatePort(pp *ProxyPort, retry bool) (err error) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	// Reallocate port only if not yet configured and the first try failed, or the port
+	// has not been (pre)allocated yet.
+
+	// For example, on restart we may have preallocated port that is not configured
+	// yet. The port may already be listening, causing allocatePort() to select another
+	// one, as the port is not available. We should make the first try with the
+	// preallocated port, as in typical case the listener we are about to configure
+	// already exists (daemonset proxy), or can be created on a new proxy with the same
+	// port (embedded Envoy).
+	if !pp.configured && (retry || pp.ProxyPort == 0) {
+		if pp.ProxyPort != 0 {
+			p.reset(pp)
+		}
+
+		// Check if pp.proxyPort is available and find another available proxy port
+		// if not.
+		pp.ProxyPort, err = p.allocatePort(pp.ProxyPort, p.rangeMin, p.rangeMax)
+		if err == nil {
+			// marks port as reserved
+			p.allocatedPorts[pp.ProxyPort] = true
+			// mark proxy port as configured
+			pp.configured = true
+		}
+	}
+	return err
+}
+
+// AllocateCRDProxyPort() allocates a new port for listener 'name', or returns the current one if
+// already allocated.
+// Each call has to be paired with AckProxyPort(name) to update the datapath rules accordingly.
+// Each allocated port must be eventually freed with ReleaseProxyPort().
+func (p *ProxyPorts) AllocateCRDProxyPort(name string) (uint16, error) {
+	// Accessing pp.proxyPort requires the lock
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	pp := p.proxyPorts[name]
+	if pp == nil || pp.Ingress {
+		pp = &ProxyPort{ProxyType: types.ProxyTypeCRD, Ingress: false}
+	}
+
+	// Allocate a new port only if a port was never allocated before.
+	// This is required since Envoy may already be listening on the
+	// previously allocated port for this proxy listener.
+	if pp.ProxyPort == 0 {
+		var err error
+		// Try to allocate the same port that was previously used on the datapath
+		if pp.rulesPort != 0 && !p.allocatedPorts[pp.rulesPort] {
+			pp.ProxyPort = pp.rulesPort
+		} else {
+			pp.ProxyPort, err = p.allocatePort(pp.rulesPort, p.rangeMin, p.rangeMax)
+			if err != nil {
+				return 0, err
+			}
+		}
+	}
+	p.proxyPorts[name] = pp
+	// marks port as reserved
+	p.allocatedPorts[pp.ProxyPort] = true
+	// mark proxy port as configured
+	pp.configured = true
+
+	log.WithField(fieldProxyRedirectID, name).Debugf("AllocateProxyPort: allocated proxy port %d (%v)", pp.ProxyPort, *pp)
+
+	return pp.ProxyPort, nil
+}
+
+// AckProxyPortWithReference() marks the proxy of the given type as successfully
+// created and creates or updates the datapath rules accordingly.
+// Takes a reference on the proxy port.
+func (p *ProxyPorts) AckProxyPortWithReference(ctx context.Context, name string) error {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	pp := p.proxyPorts[name]
+	if pp == nil {
+		return proxyNotFoundError(name)
+	}
+	err := p.ackProxyPort(ctx, name, pp) // creates datapath rules
+	if err == nil {
+		pp.nRedirects++
+	}
+	return err
+}
+
+// AckProxyPort() marks the proxy of the given type as successfully
+// created and creates or updates the datapath rules accordingly.
+// Does NOT take a reference on the proxy port.
+func (p *ProxyPorts) AckProxyPort(ctx context.Context, name string, pp *ProxyPort) error {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	return p.ackProxyPort(ctx, name, pp)
+}
+
+// AddReference takes a reference on a proxy port that was previously acknowledged
+func (p *ProxyPorts) AddReference(pp *ProxyPort) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	pp.nRedirects++
+}
+
+// ackProxyPort() increases proxy port reference count and creates or updates the datapath rules.
+// Each call must eventually be paired with a corresponding releaseProxyPort() call
+// to keep the use count up-to-date.
+// Must be called with mutex held!
+func (p *ProxyPorts) ackProxyPort(ctx context.Context, name string, pp *ProxyPort) error {
+	scopedLog := log.WithField(fieldProxyRedirectID, name)
+
+	if pp.ProxyPort == 0 {
+		return fmt.Errorf("ackProxyPort: zero port on %s not allowed", name)
+	}
+
+	// Datapath rules are added only after we know the proxy configuration
+	// with the actual port number has succeeded. Deletion of the rules
+	// is delayed after the redirects have been removed to the point
+	// when we know the port number changes. This is to reduce the churn
+	// in the datapath, but means that the datapath rules may exist even
+	// if the proxy is not currently configured.
+
+	// Add new rules, if needed
+	if pp.rulesPort != pp.ProxyPort {
+		// Add rules for the new port
+		// This should always succeed if we have managed to start-up properly
+		scopedLog.Infof("Adding new proxy port rules for %s:%d", name, pp.ProxyPort)
+		p.datapathUpdater.InstallProxyRules(pp.ProxyPort, name)
+		pp.rulesPort = pp.ProxyPort
+
+		// trigger writing proxy ports to file
+		p.Trigger.Trigger()
+	}
+	scopedLog.Debugf("AckProxyPort: acked proxy port %d (%v)", pp.ProxyPort, *pp)
+	return nil
+}
+
+// releaseProxyPort() decreases the use count and frees the port if no users remain
+// Must be called with mutex held!
+func (p *ProxyPorts) releaseProxyPort(name string, portReuseWait time.Duration) error {
+	pp := p.proxyPorts[name]
+	if pp == nil {
+		return fmt.Errorf("Can't find proxy port %s", name)
+	}
+
+	if pp.nRedirects <= 0 {
+		nRedirects := pp.nRedirects
+		pp.nRedirects = 0
+		return fmt.Errorf("Can't release proxy port with has non-positive reference count: %d", nRedirects)
+	}
+
+	pp.nRedirects--
+
+	// Static proxy port is not released, dynamic proxy ports are released after a delay if
+	// still on last reference count
+	if !pp.isStatic && pp.nRedirects == 0 {
+		pp.nRedirects = 1 // keep the last reference during the delay
+		go func() {
+			time.Sleep(portReuseWait)
+
+			p.mutex.Lock()
+			defer p.mutex.Unlock()
+
+			pp.nRedirects--
+			if pp.nRedirects == 0 {
+				log.WithField(fieldProxyRedirectID, name).Debugf("Delayed release of proxy port %d", pp.ProxyPort)
+				p.reset(pp)
+
+				// Leave the datapath rules behind on the hope that they get reused
+				// later.  This becomes possible when we are able to keep the proxy
+				// listeners configured also when there are no redirects.
+			}
+		}()
+	}
+
+	return nil
+}
+
+// HasProxyType returns 'true' if 'pp' is configured and has the given proxy type.
+func (p *ProxyPorts) HasProxyType(pp *ProxyPort, proxyType types.ProxyType) bool {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	return pp.configured && pp.ProxyType == proxyType
+}
+
+// reset() frees the port
+// Must be called with mutex held!
+func (p *ProxyPorts) Restore(pp *ProxyPort) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	if pp.ProxyPort == 0 && pp.rulesPort != 0 {
+		// try first with the previous port
+		pp.ProxyPort = pp.rulesPort
+	}
+}
+
+func (p *ProxyPorts) GetRulesPort(pp *ProxyPort) uint16 {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	return pp.rulesPort
+}
+
+// Reset() frees the port, if it's redirect count has reached zero.
+// A static port is not reset.
+func (p *ProxyPorts) Reset(pp *ProxyPort) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	if !pp.isStatic && pp.nRedirects == 0 {
+		p.reset(pp)
+	}
+}
+
+// reset() frees the port
+// Must be called with mutex held!
+func (p *ProxyPorts) reset(pp *ProxyPort) {
+	// Mark the port for reuse only if no other ports are
+	// available Discourage the reuse of the same port in future
+	// as revert may have been due to port not being available
+	// for bind().
+	p.allocatedPorts[pp.ProxyPort] = false
+	// clear proxy port on failure so that a new one will be
+	// tried next time
+	pp.ProxyPort = 0
+	pp.configured = false
+}
+
+// FindByType returns a ProxyPort matching the given type, listener name, and direction, if
+// found.
+// Must NOT be called with mutex held!
+func (p *ProxyPorts) FindByType(l7Type types.ProxyType, listener string, ingress bool) (string, *ProxyPort) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	portType := l7Type
+	switch l7Type {
+	case types.ProxyTypeCRD:
+		// CRD proxy ports are dynamically created, look up by name
+		// 'ingress' is always false for CRD type
+		if pp, ok := p.proxyPorts[listener]; ok && pp.ProxyType == types.ProxyTypeCRD && !pp.Ingress {
+			return listener, pp
+		}
+		log.Debugf("findProxyPortByType: can not find crd listener %s from %v", listener, p.proxyPorts)
+		return "", nil
+	case types.ProxyTypeDNS, types.ProxyTypeHTTP:
+		// Look up by the given type
+	default:
+		// "Unknown" parsers are assumed to be Proxylib (TCP) parsers, which
+		// is registered with an empty string.
+		// This works also for explicit TCP and TLS parser types, which are backed by the
+		// TCP Proxy filter chain.
+		portType = types.ProxyTypeAny
+	}
+	// proxyPorts is small enough to not bother indexing it.
+	for name, pp := range p.proxyPorts {
+		if pp.ProxyType == portType && pp.Ingress == ingress {
+			return name, pp
+		}
+	}
+	return "", nil
+}
+
+func proxyNotFoundError(name string) error {
+	return fmt.Errorf("unrecognized proxy: %s", name)
+}
+
+// must be called with mutex NOT held via p.proxyPortsTrigger
+func (p *ProxyPorts) StoreProxyPorts(ctx context.Context) error {
+	if p.proxyPortsPath == "" {
+		return nil // this is a unit test
+	}
+	log := log.WithField(logfields.Path, p.proxyPortsPath)
+
+	// use renameio to prevent partial writes
+	out, err := renameio.NewPendingFile(p.proxyPortsPath, renameio.WithExistingPermissions(), renameio.WithPermissions(0o600))
+	if err != nil {
+		log.WithError(err).Error("failed to prepare proxy ports file")
+		return err
+	}
+	defer out.Cleanup()
+
+	jw := jsoniter.ConfigFastest.NewEncoder(out)
+
+	portsMap := make(proxyPortsMap)
+	p.mutex.Lock()
+	// only retain acknowledged, non-zero ports
+	for name, pp := range p.proxyPorts {
+		if pp.configured && pp.ProxyPort > 0 {
+			portsMap[name] = pp
+		}
+	}
+	p.mutex.Unlock()
+
+	if err := jw.Encode(portsMap); err != nil {
+		log.WithError(err).Error("failed to marshal proxy ports state")
+		return err
+	}
+	if err := out.CloseAtomicallyReplace(); err != nil {
+		log.WithError(err).Error("failed to write proxy ports file")
+		return err
+	}
+	log.Debug("Wrote proxy ports state")
+	return nil
+}
+
+var (
+	staleProxyPortsFile = errors.New("proxy ports file is too old")
+)
+
+// restore proxy ports from file created earlier by stroreProxyPorts
+// must be called with mutex held
+func (p *ProxyPorts) restoreProxyPortsFromFile(restoredProxyPortsStaleLimit uint) error {
+	log := log.WithField(logfields.Path, p.proxyPortsPath)
+
+	// Check that the file exists and is not too old
+	stat, err := os.Stat(p.proxyPortsPath)
+	if err != nil {
+		return err
+	}
+	if time.Since(stat.ModTime()) > time.Duration(restoredProxyPortsStaleLimit)*time.Minute {
+		return staleProxyPortsFile
+	}
+
+	// Read in checkpoint file
+	fp, err := os.Open(p.proxyPortsPath)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	jr := jsoniter.ConfigFastest.NewDecoder(fp)
+	var portsMap proxyPortsMap
+	if err := jr.Decode(&portsMap); err != nil {
+		return err
+	}
+
+	for name, pp := range portsMap {
+		if existing := p.proxyPorts[name]; existing != nil {
+			if existing.ProxyPort != 0 {
+				continue // do not overwrite explicitly set port
+			}
+		}
+		p.proxyPorts[name] = pp
+		p.allocatedPorts[pp.ProxyPort] = false
+		log.
+			WithField(fieldProxyRedirectID, name).
+			WithField("proxyPort", pp.ProxyPort).
+			Debugf("RestoreProxyPorts: preallocated proxy port")
+	}
+	return nil
+}
+
+// restoreProxyPortsFromIptables tries to find earlier port numbers from datapath and use them
+// as defaults for proxy ports
+// must be called with mutex held
+func (p *ProxyPorts) restoreProxyPortsFromIptables() {
+	// restore proxy ports from the datapath iptables rules
+	portsMap := p.datapathUpdater.GetProxyPorts()
+	for name, port := range portsMap {
+		pp := p.proxyPorts[name]
+		if pp != nil {
+			if pp.ProxyPort != 0 {
+				continue // do not overwrite explicitly set port
+			}
+			pp.ProxyPort = port
+		} else {
+			// Only CRD type proxy ports can be dynamically allocated. Assume a port
+			// from datapath with an unknown name was for a dynamically allocated CRD
+			// proxy and pre-allocate a proxy port for it.
+			// CRD proxy ports always have 'ingress' as 'false'.
+			p.proxyPorts[name] = &ProxyPort{ProxyType: types.ProxyTypeCRD, Ingress: false, ProxyPort: port}
+		}
+		p.allocatedPorts[port] = false
+		log.
+			WithField(fieldProxyRedirectID, name).
+			WithField("proxyPort", port).
+			Debugf("RestoreProxyPorts: preallocated proxy port from iptables")
+	}
+}
+
+// Exported API
+
+// RestoreProxyPorts tries to find earlier port numbers from datapath and use them
+// as defaults for proxy ports
+func (p *ProxyPorts) RestoreProxyPorts(restoredProxyPortsStaleLimit uint) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	err := p.restoreProxyPortsFromFile(restoredProxyPortsStaleLimit)
+	if err != nil {
+		log.WithError(err).WithField(logfields.Path, p.proxyPortsPath).Info("Resoring proxy ports from file failed, falling back to restoring from iptables rules")
+		p.restoreProxyPortsFromIptables()
+	}
+}
+
+// GetProxyPort() returns the fixed listen port for a proxy, if any.
+func (p *ProxyPorts) GetProxyPort(name string) (port uint16, isStatic bool, err error) {
+	// Accessing pp.proxyPort requires the lock
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+
+	pp := p.proxyPorts[name]
+	if pp != nil {
+		return pp.ProxyPort, pp.isStatic, nil
+	}
+	return 0, false, proxyNotFoundError(name)
+}
+
+func (p *ProxyPorts) ReleaseProxyPort(name string) error {
+	// Accessing p.proxyPorts requires the lock
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	return p.releaseProxyPort(name, portReuseDelay)
+}
+
+// SetProxyPort() marks the proxy 'name' as successfully created with proxy port 'port'.
+// Another call to AckProxyPort(name) is needed to update the datapath rules accordingly.
+// This should only be called for proxies that have a static listener that is already listening on
+// 'port'. May only be called once per proxy.
+func (p *ProxyPorts) SetProxyPort(name string, proxyType types.ProxyType, port uint16, ingress bool) error {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	pp := p.proxyPorts[name]
+	if pp == nil {
+		pp = &ProxyPort{ProxyType: proxyType, Ingress: ingress}
+		p.proxyPorts[name] = pp
+	}
+	if pp.nRedirects > 0 {
+		return fmt.Errorf("Can't set proxy port to %d: proxy %s is already configured on %d", port, name, pp.ProxyPort)
+	}
+	pp.ProxyPort = port
+	pp.isStatic = true // prevents release of the proxy port
+	// marks port as reserved
+	p.allocatedPorts[pp.ProxyPort] = true
+	// mark proxy port as configured
+	pp.configured = true
+	return nil
+}

--- a/pkg/proxy/proxyports/proxyports_test.go
+++ b/pkg/proxy/proxyports/proxyports_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package proxyports
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/envoy"
+	"github.com/cilium/cilium/pkg/proxy/types"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func TestPortAllocator(t *testing.T) {
+	testRunDir := t.TempDir()
+	socketDir := envoy.GetSocketDir(testRunDir)
+	err := os.MkdirAll(socketDir, 0700)
+	require.NoError(t, err)
+
+	p, cleaner := proxyPortsForTest()
+	defer cleaner()
+
+	port, err := p.AllocateCRDProxyPort("listener1")
+	require.NoError(t, err)
+	require.NotEqual(t, 0, port)
+
+	port1, _, err := p.GetProxyPort("listener1")
+	require.NoError(t, err)
+	require.Equal(t, port, port1)
+
+	// Another allocation for the same name gets the same port
+	port1a, err := p.AllocateCRDProxyPort("listener1")
+	require.NoError(t, err)
+	require.Equal(t, port1, port1a)
+
+	name, pp := p.FindByType(types.ProxyTypeCRD, "listener1", false)
+	require.Equal(t, "listener1", name)
+	require.Equal(t, types.ProxyTypeCRD, pp.ProxyType)
+	require.Equal(t, port, pp.ProxyPort)
+	require.False(t, pp.Ingress)
+	require.True(t, pp.configured)
+	require.False(t, pp.isStatic)
+	require.Equal(t, 0, pp.nRedirects)
+	require.Equal(t, uint16(0), pp.rulesPort)
+
+	// Proxy port without references can not be released, so increment to simulate proxy
+	// redirect creation
+	pp.nRedirects++
+
+	err = p.releaseProxyPort("listener1", 10*time.Millisecond)
+	require.NoError(t, err)
+
+	// Proxy port is not released immediately
+	require.Equal(t, 1, pp.nRedirects)
+	require.Equal(t, port, pp.ProxyPort)
+	port1a, _, err = p.GetProxyPort("listener1")
+	require.NoError(t, err)
+	require.Equal(t, port, port1a)
+
+	// Wait past the time the proxy port is released
+	time.Sleep(15 * time.Millisecond)
+
+	// ProxyPort lingers and can still be found, but it's port is zeroed
+	port1b, _, err := p.GetProxyPort("listener1")
+	require.NoError(t, err)
+	require.Equal(t, uint16(0), port1b)
+	require.Equal(t, uint16(0), pp.ProxyPort)
+	require.False(t, pp.configured)
+	require.Equal(t, 0, pp.nRedirects)
+
+	// the port was never acked, so rulesPort is 0
+	require.Equal(t, uint16(0), pp.rulesPort)
+
+	// Allocates a different port (due to port was never acked)
+	port2, err := p.AllocateCRDProxyPort("listener1")
+	require.NoError(t, err)
+	require.NotEqual(t, port, port2)
+	name2, pp2 := p.FindByType(types.ProxyTypeCRD, "listener1", false)
+	require.Equal(t, name2, name)
+	require.Equal(t, pp2, pp)
+	require.Equal(t, types.ProxyTypeCRD, pp.ProxyType)
+	require.False(t, pp.Ingress)
+	require.Equal(t, port2, pp.ProxyPort)
+	require.True(t, pp.configured)
+	require.False(t, pp.isStatic)
+	require.Equal(t, 0, pp.nRedirects)
+	require.Equal(t, uint16(0), pp.rulesPort)
+
+	// Ack configures the port to the datapath
+	err = p.AckProxyPortWithReference(context.TODO(), "listener1")
+	require.NoError(t, err)
+	require.Equal(t, 1, pp.nRedirects)
+	require.Equal(t, port2, pp.rulesPort)
+
+	// Another Ack takes another reference
+	err = p.AckProxyPortWithReference(context.TODO(), "listener1")
+	require.NoError(t, err)
+	require.Equal(t, 2, pp.nRedirects)
+	require.Equal(t, port2, pp.rulesPort)
+
+	// 1st release decreases the count
+	err = p.ReleaseProxyPort("listener1")
+	require.NoError(t, err)
+	require.Equal(t, 1, pp.nRedirects)
+	require.True(t, pp.configured)
+	require.Equal(t, port2, pp.ProxyPort)
+
+	// 2nd release decreases the count to zero
+	err = p.releaseProxyPort("listener1", time.Microsecond)
+	require.NoError(t, err)
+	time.Sleep(time.Millisecond)
+	require.Equal(t, 0, pp.nRedirects)
+	require.False(t, pp.configured)
+	require.Equal(t, uint16(0), pp.ProxyPort)
+	require.Equal(t, port2, pp.rulesPort)
+
+	// extra releases return an error
+	err = p.ReleaseProxyPort("listener1")
+	require.Error(t, err)
+
+	// mimic some other process taking the port
+	p.allocatedPorts[port2] = true
+
+	// Allocate again, this time a different port is allocated
+	port3, err := p.AllocateCRDProxyPort("listener1")
+	require.NoError(t, err)
+	require.NotEqual(t, uint16(0), port3)
+	require.NotEqual(t, port2, port3)
+	require.NotEqual(t, port1, port3)
+	name2, pp2 = p.FindByType(types.ProxyTypeCRD, "listener1", false)
+	require.Equal(t, name2, name)
+	require.Equal(t, pp2, pp)
+	require.Equal(t, types.ProxyTypeCRD, pp.ProxyType)
+	require.False(t, pp.Ingress)
+	require.Equal(t, port3, pp.ProxyPort)
+	require.True(t, pp.configured)
+	require.False(t, pp.isStatic)
+	require.Equal(t, 0, pp.nRedirects)
+	require.Equal(t, port2, pp.rulesPort)
+
+	// Ack configures the port to the datapath
+	err = p.AckProxyPortWithReference(context.TODO(), "listener1")
+	require.NoError(t, err)
+	require.Equal(t, 1, pp.nRedirects)
+	require.Equal(t, port3, pp.rulesPort)
+
+	// Release marks the port as unallocated
+	err = p.releaseProxyPort("listener1", time.Microsecond)
+	require.NoError(t, err)
+	time.Sleep(time.Millisecond)
+	require.Equal(t, 0, pp.nRedirects)
+	require.False(t, pp.configured)
+	require.Equal(t, uint16(0), pp.ProxyPort)
+	require.Equal(t, port3, pp.rulesPort)
+
+	inuse, exists := p.allocatedPorts[port3]
+	require.True(t, exists)
+	require.False(t, inuse)
+
+	// No-one used the port so next allocation gets the same port again
+	port4, err := p.AllocateCRDProxyPort("listener1")
+	require.NoError(t, err)
+	require.Equal(t, port3, port4)
+	require.Equal(t, types.ProxyTypeCRD, pp.ProxyType)
+	require.False(t, pp.Ingress)
+	require.Equal(t, port4, pp.ProxyPort)
+	require.True(t, pp.configured)
+	require.False(t, pp.isStatic)
+	require.Equal(t, 0, pp.nRedirects)
+	require.Equal(t, port3, pp.rulesPort)
+}

--- a/pkg/proxy/proxyports/testutils.go
+++ b/pkg/proxy/proxyports/testutils.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package proxyports
+
+import (
+	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/trigger"
+)
+
+type MockDatapathUpdater struct{}
+
+func (m *MockDatapathUpdater) InstallProxyRules(proxyPort uint16, name string) {
+}
+
+func (m *MockDatapathUpdater) GetProxyPorts() map[string]uint16 {
+	return nil
+}
+
+func proxyPortsForTest() (*ProxyPorts, func()) {
+	mockDatapathUpdater := &MockDatapathUpdater{}
+	p := NewProxyPorts(10000, 20000, mockDatapathUpdater)
+	triggerDone := make(chan struct{})
+	p.Trigger, _ = trigger.NewTrigger(trigger.Parameters{
+		MinInterval:  10 * time.Second,
+		TriggerFunc:  func(reasons []string) {},
+		ShutdownFunc: func() { close(triggerDone) },
+	})
+	return p, func() {
+		p.Trigger.Shutdown()
+		<-triggerDone
+	}
+}

--- a/pkg/proxy/redirect.go
+++ b/pkg/proxy/redirect.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/proxy/proxyports"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -33,7 +34,7 @@ type Redirect struct {
 	// The following fields are only written to during initialization, it
 	// is safe to read these fields without locking the mutex
 	name           string
-	listener       *ProxyPort
+	listener       *proxyports.ProxyPort
 	dstPortProto   restore.PortProto
 	endpointID     uint16
 	implementation RedirectImplementation
@@ -44,7 +45,7 @@ type Redirect struct {
 	rules policy.L7DataMap
 }
 
-func newRedirect(epID uint16, name string, listener *ProxyPort, port uint16, proto u8proto.U8proto) *Redirect {
+func newRedirect(epID uint16, name string, listener *proxyports.ProxyPort, port uint16, proto u8proto.U8proto) *Redirect {
 	return &Redirect{
 		name:         name,
 		listener:     listener,


### PR DESCRIPTION
Endpoint regeneration can fail for many reasons, only one of which is Envoy NACKing the listener configuration. Previously it was possible for a proxy port (e.g., DNS proxy port) to be released (and subsequently reallocated) if endpoint regeneration adding a new redirect (such as endpoint restore on agent restart) happened to fail for any reason. Handle proxy port ACK/NACK directly with an AddListener callback and only reset the proxy port if there are no redirects on the port and a NACK was received. Since envoy.AddListener is not used for DNS proxy redirects, it follows that DNS proxy port is now never reset. The AddListener callback allows to keep even newly configured redirects if the regeneration failure reason is not a NACK from Envoy. This helps reduce churn on Envoy listener configuration and the associated datapath proxy port redirection when endpoint regeneration fails for other reasons than Envoy Listener NACK.

To make the AddListener callback work we had to add a separate mutex for the proxy ports, so that a proxy mutex can be held without holding the proxy ports mutex while calling AddListener with a callback that then needs to take the proxy ports mutex. This also happens to solve a latent deadlock bug in CEC parser that also needs to take the mutex for acknowledging a proxy port. In this case we had different locking order for the `Proxy.mutex` and `xdsServer.mutex` in two different code paths:

- CEC parser via `upsertListener()`
  1. takes `xdsServer.mutex`
  2. takes `Proxy.mutex` in the callback via `AckProxyPort()`
- Endpoint redirect creation:
  1. takes `Proxy.mutex` to create a new redirect
  2. calls `AddListener()` which locks `xdsServer.mutex`

With the new `Proxy.proxyPorts.mutex` the above is modified so that `AckProxyPort()` no longer needs to take `Proxy.mutex` (but `Proxy.proxyPorts.mutex` instead), and on the latter path `AddListener()` is called without holding the new `Proxy.proxyPorts.mutex` which can then be taken in the callback function as needed.

Fixes: #36063

```release-note
DNS proxy port is no longer released when endpoint with a DNS policy fails to regenerate successfully.
A potential deadlock between CEC/CCEC parser and endpoint policy update is removed.
```
