### PR TITLE
bpffs: Use defaults.BPFFSRoot to distinguish default/custom BPF FS mount location

### DIFF
--- a/pkg/bpf/bpffs_linux.go
+++ b/pkg/bpf/bpffs_linux.go
@@ -265,7 +265,7 @@ func checkOrMountDefaultLocations() error {
 }
 
 func checkOrMountFS(bpfRoot string) error {
-	if bpfRoot == "" {
+	if bpfRoot == "" || bpfRoot == defaults.BPFFSRoot {
 		if err := checkOrMountDefaultLocations(); err != nil {
 			return err
 		}


### PR DESCRIPTION
Apart from empty string, also use the value from `defaults.BPFFSRoot` to distinguish whether the default or a custom BPF FS mount location is being used. 

When Cilium is deployed via Helm, the `bpfRoot` value in `checkOrMountFS` is never empty, but set to `/sys/fs/bpf` [by default](https://github.com/cilium/cilium/blob/03f24942b18a10a89c067f9be5d6ccd9decfba6a/install/kubernetes/cilium/values.yaml.tmpl#L482). However, even if this is the default value, this was handled by the `checkOrMountCustomLocation()` path instead of the `checkOrMountDefaultLocations()`, which caused an unnecessary warning `BPF filesystem is not mounted`.

Fixes: https://github.com/cilium/cilium/issues/36148