### PR TITLE
bpf: egressgw: support policy entry with egress ifindex

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -421,10 +421,12 @@ not_esp:
 
 #if defined(ENABLE_EGRESS_GATEWAY_COMMON)
 	{
+		__u32 egress_ifindex = 0;
 		__be32 snat_addr, daddr;
 
 		daddr = ip4->daddr;
-		if (egress_gw_snat_needed_hook(ip4->saddr, daddr, &snat_addr)) {
+		if (egress_gw_snat_needed_hook(ip4->saddr, daddr, &snat_addr,
+					       &egress_ifindex)) {
 			if (snat_addr == EGRESS_GATEWAY_NO_EGRESS_IP)
 				return DROP_NO_EGRESS_IP;
 
@@ -436,7 +438,8 @@ not_esp:
 
 			/* to-netdev@bpf_host handles SNAT, so no need to do it here. */
 			ret = egress_gw_fib_lookup_and_redirect(ctx, snat_addr,
-								daddr, ext_err);
+								daddr, egress_ifindex,
+								ext_err);
 			if (ret != CTX_ACT_OK)
 				return ret;
 

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -31,11 +31,17 @@
 
 static __always_inline
 int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, __be32 daddr,
-				      __s8 *ext_err)
+				      __u32 egress_ifindex, __s8 *ext_err)
 {
 	struct bpf_fib_lookup_padded fib_params = {};
 	int oif = 0;
 	int ret;
+
+	/* Immediate redirect to egress_ifindex requires L2 resolution.
+	 * Fall back to FIB lookup on older kernels.
+	 */
+	if (egress_ifindex && neigh_resolver_available())
+		return redirect_neigh(egress_ifindex, NULL, 0, 0);
 
 	ret = (__s8)fib_lookup_v4(ctx, &fib_params, egress_ip, daddr, 0);
 
@@ -115,7 +121,8 @@ egress_gw_request_needs_redirect(struct ipv4_ct_tuple *rtuple __maybe_unused,
 static __always_inline
 bool egress_gw_snat_needed(__be32 saddr __maybe_unused,
 			   __be32 daddr __maybe_unused,
-			   __be32 *snat_addr __maybe_unused)
+			   __be32 *snat_addr __maybe_unused,
+			   __u32 *egress_ifindex __maybe_unused)
 {
 #if defined(ENABLE_EGRESS_GATEWAY)
 	struct egress_gw_policy_entry *egress_gw_policy;
@@ -129,6 +136,10 @@ bool egress_gw_snat_needed(__be32 saddr __maybe_unused,
 		return false;
 
 	*snat_addr = egress_gw_policy->egress_ip;
+#ifdef EGRESS_IFINDEX
+	*egress_ifindex = EGRESS_IFINDEX;
+#endif
+
 	return true;
 #else
 	return false;
@@ -173,7 +184,8 @@ egress_gw_request_needs_redirect_hook(struct ipv4_ct_tuple *rtuple,
 }
 
 static __always_inline
-bool egress_gw_snat_needed_hook(__be32 saddr, __be32 daddr, __be32 *snat_addr)
+bool egress_gw_snat_needed_hook(__be32 saddr, __be32 daddr, __be32 *snat_addr,
+				__u32 *egress_ifindex)
 {
 	struct remote_endpoint_info *remote_ep;
 
@@ -186,7 +198,7 @@ bool egress_gw_snat_needed_hook(__be32 saddr, __be32 daddr, __be32 *snat_addr)
 	    identity_is_cluster(remote_ep->sec_identity))
 		return false;
 
-	return egress_gw_snat_needed(saddr, daddr, snat_addr);
+	return egress_gw_snat_needed(saddr, daddr, snat_addr, egress_ifindex);
 }
 
 static __always_inline

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -108,6 +108,7 @@ struct ipv4_nat_target {
 	bool egress_gateway; /* NAT is needed because of an egress gateway policy */
 	__u32 cluster_id;
 	bool needs_ct;
+	__u32 ifindex; /* Obtained from EGW policy */
 };
 
 #if defined(ENABLE_IPV4) && defined(ENABLE_NODEPORT)
@@ -615,7 +616,8 @@ snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 	if (is_reply)
 		goto skip_egress_gateway;
 
-	if (egress_gw_snat_needed_hook(tuple->saddr, tuple->daddr, &target->addr)) {
+	if (egress_gw_snat_needed_hook(tuple->saddr, tuple->daddr, &target->addr,
+				       &target->ifindex)) {
 		if (target->addr == EGRESS_GATEWAY_NO_EGRESS_IP)
 			return DROP_NO_EGRESS_IP;
 

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -323,9 +323,14 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 
 #if defined(ENABLE_EGRESS_GATEWAY_COMMON) && defined(IS_BPF_HOST)
 	if (target.egress_gateway) {
+		/* Stay on the desired egress interface: */
+		if (target.ifindex && target.ifindex == NATIVE_DEV_IFINDEX)
+			goto apply_snat;
+
 		/* Send packet to the correct egress interface, and SNAT it there. */
 		ret = egress_gw_fib_lookup_and_redirect(ctx, target.addr,
-							tuple.daddr, ext_err);
+							tuple.daddr, target.ifindex,
+							ext_err);
 		if (ret != CTX_ACT_OK)
 			return ret;
 

--- a/bpf/tests/tc_egressgw_redirect_from_overlay_with_egress_interface.c
+++ b/bpf/tests/tc_egressgw_redirect_from_overlay_with_egress_interface.c
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+#define SECLABEL
+#define SECLABEL_IPV4
+#define SECLABEL_IPV6
+#undef SECLABEL
+#undef SECLABEL_IPV4
+#undef SECLABEL_IPV6
+
+/* Enable code paths under test */
+#define HAVE_FIB_NEIGH	1
+
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define ENABLE_EGRESS_GATEWAY
+#define ENABLE_MASQUERADE_IPV4
+#define ENCAP_IFINDEX	42
+#define IFACE_IFINDEX	44
+
+/* Provide the desired egress interface to the datapath */
+#define EGRESS_IFINDEX	IFACE_IFINDEX
+
+#define SECCTX_FROM_IPCACHE 1
+
+#define fib_lookup mock_fib_lookup
+static __always_inline __maybe_unused long
+mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_unused,
+		int plen __maybe_unused, __u32 flags __maybe_unused);
+
+#define skb_get_tunnel_key mock_skb_get_tunnel_key
+static int mock_skb_get_tunnel_key(__maybe_unused struct __sk_buff *skb,
+				   struct bpf_tunnel_key *to,
+				   __maybe_unused __u32 size,
+				   __maybe_unused __u32 flags)
+{
+	to->remote_ipv4 = v4_node_one;
+	/* 0xfffff is the default SECLABEL */
+	to->tunnel_id = 0xfffff;
+	return 0;
+}
+
+#include "bpf_overlay.c"
+
+#include "lib/egressgw.h"
+#include "lib/ipcache.h"
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
+{
+	if (ifindex == IFACE_IFINDEX)
+		return CTX_ACT_REDIRECT;
+
+	return CTX_ACT_OK;
+}
+
+static __always_inline __maybe_unused long
+mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_unused,
+		int plen __maybe_unused, __u32 flags __maybe_unused)
+{
+	/* Should not need a FIB lookup, we provide the EGRESS_IFINDEX */
+	return -1;
+}
+
+#define FROM_OVERLAY 0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 2);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_OVERLAY] = &cil_from_overlay,
+	},
+};
+
+/* Test that a packet matching an egress gateway policy on the from-overlay program
+ * gets correctly redirected to the target netdev.
+ */
+PKTGEN("tc", "tc_egressgw_redirect_from_overlay_with_egress_interface")
+int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_REDIRECT,
+			.redirect = true,
+		});
+}
+
+SETUP("tc", "tc_egressgw_redirect_from_overlay_with_egress_interface")
+int egressgw_redirect_setup(struct __ctx_buff *ctx)
+{
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP,
+				  EGRESS_IP);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_redirect_from_overlay_with_egress_interface")
+int egressgw_redirect_check(const struct __ctx_buff *ctx)
+{
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = TC_ACT_REDIRECT,
+	});
+
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24);
+
+	return ret;
+}


### PR DESCRIPTION
When the EGW policy lookup returns the ifindex of the egress interface, skip the FIB-lookup based selection and redirect straight to the desired interface.

This currently only covers the minimal datapath part. To make full use of this enhancement we'll also need CEGP control plane improvements (and migrate to an EGW policy entry with space to store the ifindex).