### PR TITLE
hubble: make MinTLSVersion a var

### DIFF
--- a/pkg/hubble/server/serveroption/option.go
+++ b/pkg/hubble/server/serveroption/option.go
@@ -28,7 +28,7 @@ import (
 
 // MinTLSVersion defines the minimum TLS version clients are expected to
 // support in order to establish a connection to the hubble server.
-const MinTLSVersion = tls.VersionTLS13
+var MinTLSVersion uint16 = tls.VersionTLS13
 
 // Options stores all the configuration values for the hubble server.
 type Options struct {


### PR DESCRIPTION
Allows updating the value from init func when needed.

For example, one might need to lower the MinTLSVersion for compliance/regulation/etc.