### PR TITLE
bgpv2: populate locally available services after performing svc diff

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -127,14 +127,9 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, p ReconcileParams) er
 		return err
 	}
 
-	ls, err := r.populateLocalServices(p.CiliumNode.Name)
-	if err != nil {
-		return fmt.Errorf("failed to populate local services: %w", err)
-	}
-
 	reqFullReconcile := r.modifiedServiceAdvertisements(p, desiredPeerAdverts)
 
-	err = r.reconcileServices(ctx, p, desiredPeerAdverts, ls, reqFullReconcile)
+	err = r.reconcileServices(ctx, p, desiredPeerAdverts, reqFullReconcile)
 
 	if err == nil && reqFullReconcile {
 		// update svc advertisements in metadata only if the reconciliation was successful
@@ -143,7 +138,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, p ReconcileParams) er
 	return err
 }
 
-func (r *ServiceReconciler) reconcileServices(ctx context.Context, p ReconcileParams, desiredPeerAdverts PeerAdvertisements, ls sets.Set[resource.Key], fullReconcile bool) error {
+func (r *ServiceReconciler) reconcileServices(ctx context.Context, p ReconcileParams, desiredPeerAdverts PeerAdvertisements, fullReconcile bool) error {
 	var (
 		toReconcile []*slim_corev1.Service
 		toWithdraw  []resource.Key
@@ -171,6 +166,12 @@ func (r *ServiceReconciler) reconcileServices(ctx context.Context, p ReconcilePa
 		if err != nil {
 			return err
 		}
+	}
+
+	// populate locally available services
+	ls, err := r.populateLocalServices(p.CiliumNode.Name)
+	if err != nil {
+		return fmt.Errorf("failed to populate local services: %w", err)
 	}
 
 	// get desired service route policies


### PR DESCRIPTION
To prevent potential race during service reconcilation, move populating of locally available services (`epDiffStore.List()`) after performing service diff reconciliation (`epDiffStore.Diff`).

Related: https://github.com/cilium/cilium/issues/36055

```release-note
BGPv2: Fix race by reconciliation of services with externalTrafficPolicy=Local by populating locally available services after performing service diff
```