### PR TITLE
pkg/health: use configurable probing interval

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -76,6 +76,7 @@ cilium-agent [flags]
       --cni-log-file string                                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
       --config string                                             Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                                         Configuration directory that contains a file for each option
+      --connectivity-probe-frequency-ratio float                  Ratio of the connectivity probe frequency vs resource usage, a float in [0, 1]. 0 will give more frequent probing, 1 will give less frequent probing. Probing frequency is dynamically adjusted based on the cluster size. (default 0.5)
       --conntrack-gc-interval duration                            Overwrite the connection-tracking garbage collection interval
       --conntrack-gc-max-interval duration                        Set the maximum interval for the connection-tracking garbage collection
       --container-ip-local-reserved-ports string                  Instructs the Cilium CNI plugin to reserve the provided comma-separated list of ports in the container network namespace. Prevents the container from using these ports as ephemeral source ports (see Linux ip_local_reserved_ports). Use this flag if you observe port conflicts between transparent DNS proxy requests and host network namespace services. Value "auto" reserves the WireGuard and VXLAN ports used by Cilium (default "auto")

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -948,6 +948,10 @@
      - commonLabels allows users to add common labels for all Cilium resources.
      - object
      - ``{}``
+   * - :spelling:ignore:`connectivityProbeFrequencyRatio`
+     - Ratio of the connectivity probe frequency vs resource usage, a float in [0, 1]. 0 will give more frequent probing, 1 will give less frequent probing. Probing frequency is dynamically adjusted based on the cluster size.
+     - float64
+     - ``0.5``
    * - :spelling:ignore:`conntrackGCInterval`
      - Configure how frequently garbage collection should occur for the datapath connection tracking table.
      - string

--- a/api/v1/health/models/connectivity_status.go
+++ b/api/v1/health/models/connectivity_status.go
@@ -20,6 +20,9 @@ import (
 // swagger:model ConnectivityStatus
 type ConnectivityStatus struct {
 
+	// Timestamp of last probe completion
+	LastProbed string `json:"lastProbed,omitempty"`
+
 	// Round trip time to node in nanoseconds
 	Latency int64 `json:"latency,omitempty"`
 

--- a/api/v1/health/models/health_status_response.go
+++ b/api/v1/health/models/health_status_response.go
@@ -28,6 +28,9 @@ type HealthStatusResponse struct {
 	// Connectivity status to each other node
 	Nodes []*NodeStatus `json:"nodes"`
 
+	// Interval in seconds between probes
+	ProbeInterval string `json:"probeInterval,omitempty"`
+
 	// timestamp
 	Timestamp string `json:"timestamp,omitempty"`
 }

--- a/api/v1/health/openapi.yaml
+++ b/api/v1/health/openapi.yaml
@@ -188,3 +188,6 @@ definitions:
       status:
         type: string
         description: Human readable status/error/warning message
+      lastProbed:
+        description: Timestamp of last probe completion
+        type: string

--- a/api/v1/health/openapi.yaml
+++ b/api/v1/health/openapi.yaml
@@ -106,6 +106,9 @@ definitions:
     properties:
       timestamp:
         type: string
+      probeInterval:
+        description: Interval in seconds between probes
+        type: string
       local:
         description: Description of the local node
         "$ref": "#/definitions/SelfStatus"

--- a/api/v1/health/server/embedded_spec.go
+++ b/api/v1/health/server/embedded_spec.go
@@ -163,6 +163,10 @@ func init() {
             "$ref": "#/definitions/NodeStatus"
           }
         },
+        "probeInterval": {
+          "description": "Interval in seconds between probes",
+          "type": "string"
+        },
         "timestamp": {
           "type": "string"
         }
@@ -412,6 +416,10 @@ func init() {
           "items": {
             "$ref": "#/definitions/NodeStatus"
           }
+        },
+        "probeInterval": {
+          "description": "Interval in seconds between probes",
+          "type": "string"
         },
         "timestamp": {
           "type": "string"

--- a/api/v1/health/server/embedded_spec.go
+++ b/api/v1/health/server/embedded_spec.go
@@ -106,6 +106,10 @@ func init() {
       "description": "Connectivity status of a path",
       "type": "object",
       "properties": {
+        "lastProbed": {
+          "description": "Timestamp of last probe completion",
+          "type": "string"
+        },
         "latency": {
           "description": "Round trip time to node in nanoseconds",
           "type": "integer"
@@ -360,6 +364,10 @@ func init() {
       "description": "Connectivity status of a path",
       "type": "object",
       "properties": {
+        "lastProbed": {
+          "description": "Timestamp of last probe completion",
+          "type": "string"
+        },
         "latency": {
           "description": "Round trip time to node in nanoseconds",
           "type": "integer"

--- a/cilium-health/launch/launcher.go
+++ b/cilium-health/launch/launcher.go
@@ -34,7 +34,6 @@ type CiliumHealth struct {
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "cilium-health-launcher")
 
 const (
-	serverProbeInterval  = 60 * time.Second
 	serverProbeDeadline  = 10 * time.Second
 	connectRetryInterval = 1 * time.Second
 	statusProbeInterval  = 5 * time.Second
@@ -50,7 +49,6 @@ func Launch(spec *healthApi.Spec, initialized <-chan struct{}) (*CiliumHealth, e
 	config := server.Config{
 		CiliumURI:     ciliumPkg.DefaultSockPath(),
 		Debug:         option.Config.Opts.IsEnabled(option.Debug),
-		ProbeInterval: serverProbeInterval,
 		ICMPReqsCount: option.Config.HealthCheckICMPFailureThreshold,
 		ProbeDeadline: serverProbeDeadline,
 		HTTPPathPort:  option.Config.ClusterHealthPort,

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1053,6 +1053,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.BootIDFilename)
 	option.BindEnv(vp, option.BootIDFilename)
 
+	flags.Float64(option.ConnectivityProbeFrequencyRatio, defaults.ConnectivityProbeFrequencyRatio, "Ratio of the connectivity probe frequency vs resource usage, a float in [0, 1]. 0 will give more frequent probing, 1 will give less frequent probing. Probing frequency is dynamically adjusted based on the cluster size.")
+	option.BindEnv(vp, option.ConnectivityProbeFrequencyRatio)
+
 	if err := vp.BindPFlags(flags); err != nil {
 		log.Fatalf("BindPFlags failed: %s", err)
 	}

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -287,6 +287,7 @@ contributors across the globe, there is almost always someone available to help.
 | cni.resources | object | `{"requests":{"cpu":"100m","memory":"10Mi"}}` | Specifies the resources for the cni initContainer |
 | cni.uninstall | bool | `false` | Remove the CNI configuration and binary files on agent shutdown. Enable this if you're removing Cilium from the cluster. Disable this to prevent the CNI configuration file from being removed during agent upgrade, which can cause nodes to go unmanageable. |
 | commonLabels | object | `{}` | commonLabels allows users to add common labels for all Cilium resources. |
+| connectivityProbeFrequencyRatio | float64 | `0.5` | Ratio of the connectivity probe frequency vs resource usage, a float in [0, 1]. 0 will give more frequent probing, 1 will give less frequent probing. Probing frequency is dynamically adjusted based on the cluster size. |
 | conntrackGCInterval | string | `"0s"` | Configure how frequently garbage collection should occur for the datapath connection tracking table. |
 | conntrackGCMaxInterval | string | `""` | Configure the maximum frequency for the garbage collection of the connection tracking table. Only affects the automatic computation for the frequency and has no effect when 'conntrackGCInterval' is set. This can be set to more frequently clean up unused identities created from ToFQDN policies. |
 | crdWaitTimeout | string | `"5m"` | Configure timeout in which Cilium will exit if CRDs are not available |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1361,6 +1361,10 @@ data:
   enable-source-ip-verification: {{ .Values.daemon.enableSourceIPVerification | quote }}
 {{- end }}
 
+{{- if has (kindOf .Values.connectivityProbeFrequencyRatio) (list "int64" "float64") }}
+  connectivity-probe-frequency-ratio: {{ .Values.connectivityProbeFrequencyRatio | quote }}
+{{- end }}
+
 # Extra config allows adding arbitrary properties to the cilium config.
 # By putting it at the end of the ConfigMap, it's also possible to override existing properties.
 {{- if .Values.extraConfig }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1492,6 +1492,12 @@
         "object"
       ]
     },
+    "connectivityProbeFrequencyRatio": {
+      "type": [
+        "null",
+        "number"
+      ]
+    },
     "conntrackGCInterval": {
       "type": "string"
     },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -713,6 +713,14 @@ cni:
       memory: 10Mi
   # -- Enable route MTU for pod netns when CNI chaining is used
   enableRouteMTUForCNIChaining: false
+# @schema
+# type: [null, number]
+# @schema
+# -- (float64) Ratio of the connectivity probe frequency vs resource usage, a float in
+# [0, 1]. 0 will give more frequent probing, 1 will give less frequent probing. Probing
+# frequency is dynamically adjusted based on the cluster size.
+# @default -- `0.5`
+connectivityProbeFrequencyRatio: ~
 # -- (string) Configure how frequently garbage collection should occur for the datapath
 # connection tracking table.
 # @default -- `"0s"`
@@ -2601,7 +2609,7 @@ tls:
   secretsBackend: ~
   # @schema
   # type: [null, boolean]
-  # @schema  
+  # @schema
   # -- Configure if the Cilium Agent will only look in `tls.secretsNamespace` for
   #    CiliumNetworkPolicy relevant Secrets.
   #    If false, the Cilium Agent will be granted READ (GET/LIST/WATCH) access

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -714,6 +714,14 @@ cni:
       memory: 10Mi
   # -- Enable route MTU for pod netns when CNI chaining is used
   enableRouteMTUForCNIChaining: false
+# @schema
+# type: [null, number]
+# @schema
+# -- (float64) Ratio of the connectivity probe frequency vs resource usage, a float in
+# [0, 1]. 0 will give more frequent probing, 1 will give less frequent probing. Probing
+# frequency is dynamically adjusted based on the cluster size.
+# @default -- `0.5`
+connectivityProbeFrequencyRatio: ~
 # -- (string) Configure how frequently garbage collection should occur for the datapath
 # connection tracking table.
 # @default -- `"0s"`
@@ -2619,7 +2627,7 @@ tls:
   secretsBackend: ~
   # @schema
   # type: [null, boolean]
-  # @schema  
+  # @schema
   # -- Configure if the Cilium Agent will only look in `tls.secretsNamespace` for
   #    CiliumNetworkPolicy relevant Secrets.
   #    If false, the Cilium Agent will be granted READ (GET/LIST/WATCH) access
@@ -3833,3 +3841,4 @@ authentication:
 enableInternalTrafficPolicy: true
 # -- Enable LoadBalancer IP Address Management
 enableLBIPAM: true
+

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -577,6 +577,9 @@ const (
 
 	// WireguardTrackAllIPsFallback forces the WireGuard agent to track all IPs.
 	WireguardTrackAllIPsFallback = false
+
+	// ConnectivityProbeFrequencyRatio is the default connectivity probe frequency
+	ConnectivityProbeFrequencyRatio = 0.5
 )
 
 var (

--- a/pkg/health/client/client.go
+++ b/pkg/health/client/client.go
@@ -412,8 +412,8 @@ func FormatHealthStatusResponse(w io.Writer, sr *models.HealthStatusResponse, al
 		}
 	}
 
-	fmt.Fprintf(w, "Cluster health:\t%d/%d reachable\t(%s)\n",
-		healthy, len(sr.Nodes), sr.Timestamp)
+	fmt.Fprintf(w, "Cluster health:\t%d/%d reachable\t(%s)\t(Probe interval: %s)\n",
+		healthy, len(sr.Nodes), sr.Timestamp, sr.ProbeInterval)
 
 	fmt.Fprintf(w, "Name\tIP\tNode\tEndpoints\n")
 

--- a/pkg/health/client/client.go
+++ b/pkg/health/client/client.go
@@ -193,12 +193,13 @@ func SummarizePathConnectivityStatusType(cps []*models.PathStatus) map[Connectiv
 
 func formatConnectivityStatus(w io.Writer, cs *models.ConnectivityStatus, path, indent string) {
 	status := cs.Status
+	lastProbed := cs.LastProbed
 	switch GetConnectivityStatusType(cs) {
 	case ConnStatusReachable:
 		latency := time.Duration(cs.Latency)
 		status = fmt.Sprintf("OK, RTT=%s", latency)
 	}
-	fmt.Fprintf(w, "%s%s:\t%s\n", indent, path, status)
+	fmt.Fprintf(w, "%s%s:\t%s\t(Last probed: %s)\n", indent, path, status, lastProbed)
 }
 
 func formatPathStatus(w io.Writer, name string, cp *models.PathStatus, indent string, verbose bool) {

--- a/pkg/health/client/client_test.go
+++ b/pkg/health/client/client_test.go
@@ -343,12 +343,14 @@ func createNodes(healthy int, unhealthy int, unknown int) []*models.NodeStatus {
 				PrimaryAddress: &models.PathStatus{
 					IP: fmt.Sprintf("192.168.1.%d", i),
 					HTTP: &models.ConnectivityStatus{
-						Status:  "",
-						Latency: 10000000,
+						Status:     "",
+						Latency:    10000000,
+						LastProbed: "2023-04-01T12:30:00Z",
 					},
 					Icmp: &models.ConnectivityStatus{
-						Status:  "",
-						Latency: 10000000,
+						Status:     "",
+						Latency:    10000000,
+						LastProbed: "2023-04-01T12:35:00Z",
 					},
 				},
 			},
@@ -356,12 +358,14 @@ func createNodes(healthy int, unhealthy int, unknown int) []*models.NodeStatus {
 				PrimaryAddress: &models.PathStatus{
 					IP: fmt.Sprintf("192.168.1.%d", i),
 					HTTP: &models.ConnectivityStatus{
-						Status:  "",
-						Latency: 10000000,
+						Status:     "",
+						Latency:    10000000,
+						LastProbed: "2023-04-01T12:40:00Z",
 					},
 					Icmp: &models.ConnectivityStatus{
-						Status:  "",
-						Latency: 10000000,
+						Status:     "",
+						Latency:    10000000,
+						LastProbed: "2023-04-01T12:45:00Z",
 					},
 				},
 			},
@@ -375,10 +379,12 @@ func createNodes(healthy int, unhealthy int, unknown int) []*models.NodeStatus {
 				PrimaryAddress: &models.PathStatus{
 					IP: fmt.Sprintf("192.168.1.%d", i),
 					HTTP: &models.ConnectivityStatus{
-						Status: "failed",
+						Status:     "failed",
+						LastProbed: "2023-04-01T12:30:00Z",
 					},
 					Icmp: &models.ConnectivityStatus{
-						Status: "failed",
+						Status:     "failed",
+						LastProbed: "2023-04-01T12:35:00Z",
 					},
 				},
 			},
@@ -386,10 +392,12 @@ func createNodes(healthy int, unhealthy int, unknown int) []*models.NodeStatus {
 				PrimaryAddress: &models.PathStatus{
 					IP: fmt.Sprintf("192.168.1.%d", i),
 					HTTP: &models.ConnectivityStatus{
-						Status: "failed",
+						Status:     "failed",
+						LastProbed: "2023-04-01T12:40:00Z",
 					},
 					Icmp: &models.ConnectivityStatus{
-						Status: "failed",
+						Status:     "failed",
+						LastProbed: "2023-04-01T12:45:00Z",
 					},
 				},
 			},

--- a/pkg/health/client/client_test.go
+++ b/pkg/health/client/client_test.go
@@ -432,9 +432,10 @@ func TestFormatHealthStatusResponse(t *testing.T) {
 		{
 			name: "all healthy",
 			sr: &models.HealthStatusResponse{
-				Nodes:     createNodes(4, 0, 0),
-				Local:     localNode,
-				Timestamp: "2023-04-01T12:00:00Z",
+				Nodes:         createNodes(4, 0, 0),
+				Local:         localNode,
+				Timestamp:     "2023-04-01T12:00:00Z",
+				ProbeInterval: "1m14s",
 			},
 			allNodes:   false,
 			verbose:    false,
@@ -444,9 +445,10 @@ func TestFormatHealthStatusResponse(t *testing.T) {
 		{
 			name: "all healthy verbose",
 			sr: &models.HealthStatusResponse{
-				Nodes:     createNodes(4, 0, 0),
-				Local:     localNode,
-				Timestamp: "2023-04-01T12:00:00Z",
+				Nodes:         createNodes(4, 0, 0),
+				Local:         localNode,
+				Timestamp:     "2023-04-01T12:00:00Z",
+				ProbeInterval: "1m14s",
 			},
 			allNodes:   false,
 			verbose:    true,
@@ -456,9 +458,10 @@ func TestFormatHealthStatusResponse(t *testing.T) {
 		{
 			name: "all healthy all nodes",
 			sr: &models.HealthStatusResponse{
-				Nodes:     createNodes(4, 0, 0),
-				Local:     localNode,
-				Timestamp: "2023-04-01T12:00:00Z",
+				Nodes:         createNodes(4, 0, 0),
+				Local:         localNode,
+				Timestamp:     "2023-04-01T12:00:00Z",
+				ProbeInterval: "1m14s",
 			},
 			allNodes:   true,
 			verbose:    false,
@@ -468,9 +471,10 @@ func TestFormatHealthStatusResponse(t *testing.T) {
 		{
 			name: "one unhealthy",
 			sr: &models.HealthStatusResponse{
-				Nodes:     createNodes(3, 1, 0),
-				Local:     localNode,
-				Timestamp: "2023-04-01T12:00:00Z",
+				Nodes:         createNodes(3, 1, 0),
+				Local:         localNode,
+				Timestamp:     "2023-04-01T12:00:00Z",
+				ProbeInterval: "8m5s",
 			},
 			allNodes:   false,
 			verbose:    false,
@@ -480,9 +484,10 @@ func TestFormatHealthStatusResponse(t *testing.T) {
 		{
 			name: "one unhealthy verbose",
 			sr: &models.HealthStatusResponse{
-				Nodes:     createNodes(3, 1, 0),
-				Local:     localNode,
-				Timestamp: "2023-04-01T12:00:00Z",
+				Nodes:         createNodes(3, 1, 0),
+				Local:         localNode,
+				Timestamp:     "2023-04-01T12:00:00Z",
+				ProbeInterval: "8m5s",
 			},
 			allNodes:   false,
 			verbose:    true,
@@ -492,9 +497,10 @@ func TestFormatHealthStatusResponse(t *testing.T) {
 		{
 			name: "one unhealthy all nodes",
 			sr: &models.HealthStatusResponse{
-				Nodes:     createNodes(3, 1, 0),
-				Local:     localNode,
-				Timestamp: "2023-04-01T12:00:00Z",
+				Nodes:         createNodes(3, 1, 0),
+				Local:         localNode,
+				Timestamp:     "2023-04-01T12:00:00Z",
+				ProbeInterval: "8m5s",
 			},
 			allNodes:   true,
 			verbose:    false,
@@ -504,9 +510,10 @@ func TestFormatHealthStatusResponse(t *testing.T) {
 		{
 			name: "11 unhealthy",
 			sr: &models.HealthStatusResponse{
-				Nodes:     createNodes(0, 11, 0),
-				Local:     localNode,
-				Timestamp: "2023-04-01T12:00:00Z",
+				Nodes:         createNodes(0, 11, 0),
+				Local:         localNode,
+				Timestamp:     "2023-04-01T12:00:00Z",
+				ProbeInterval: "4m15s",
 			},
 			allNodes:   false,
 			verbose:    false,
@@ -516,9 +523,10 @@ func TestFormatHealthStatusResponse(t *testing.T) {
 		{
 			name: "11 healthy all nodes",
 			sr: &models.HealthStatusResponse{
-				Nodes:     createNodes(11, 0, 0),
-				Local:     localNode,
-				Timestamp: "2023-04-01T12:00:00Z",
+				Nodes:         createNodes(11, 0, 0),
+				Local:         localNode,
+				Timestamp:     "2023-04-01T12:00:00Z",
+				ProbeInterval: "4m15s",
 			},
 			allNodes:   true,
 			verbose:    false,

--- a/pkg/health/client/testdata/allHealthy.golden
+++ b/pkg/health/client/testdata/allHealthy.golden
@@ -1,2 +1,2 @@
-Cluster health:	4/4 reachable	(2023-04-01T12:00:00Z)
+Cluster health:	4/4 reachable	(2023-04-01T12:00:00Z)	(Probe interval: 1m14s)
 Name	IP	Node	Endpoints

--- a/pkg/health/client/testdata/allHealthyAllNodes.golden
+++ b/pkg/health/client/testdata/allHealthyAllNodes.golden
@@ -1,4 +1,4 @@
-Cluster health:	4/4 reachable	(2023-04-01T12:00:00Z)
+Cluster health:	4/4 reachable	(2023-04-01T12:00:00Z)	(Probe interval: 1m14s)
 Name	IP	Node	Endpoints
   node0	192.168.1.0	1/1	1/1
   node1	192.168.1.1	1/1	1/1

--- a/pkg/health/client/testdata/allHealthyVerbose.golden
+++ b/pkg/health/client/testdata/allHealthyVerbose.golden
@@ -1,4 +1,4 @@
-Cluster health:	4/4 reachable	(2023-04-01T12:00:00Z)
+Cluster health:	4/4 reachable	(2023-04-01T12:00:00Z)	(Probe interval: 1m14s)
 Name	IP	Node	Endpoints
   node0:
     Host connectivity to 192.168.1.0:

--- a/pkg/health/client/testdata/allHealthyVerbose.golden
+++ b/pkg/health/client/testdata/allHealthyVerbose.golden
@@ -2,29 +2,29 @@ Cluster health:	4/4 reachable	(2023-04-01T12:00:00Z)	(Probe interval: 1m14s)
 Name	IP	Node	Endpoints
   node0:
     Host connectivity to 192.168.1.0:
-      ICMP to stack:	OK, RTT=10ms
-      HTTP to agent:	OK, RTT=10ms
+      ICMP to stack:	OK, RTT=10ms	(Last probed: 2023-04-01T12:35:00Z)
+      HTTP to agent:	OK, RTT=10ms	(Last probed: 2023-04-01T12:30:00Z)
     Endpoint connectivity to 192.168.1.0:
-      ICMP to stack:	OK, RTT=10ms
-      HTTP to agent:	OK, RTT=10ms
+      ICMP to stack:	OK, RTT=10ms	(Last probed: 2023-04-01T12:45:00Z)
+      HTTP to agent:	OK, RTT=10ms	(Last probed: 2023-04-01T12:40:00Z)
   node1:
     Host connectivity to 192.168.1.1:
-      ICMP to stack:	OK, RTT=10ms
-      HTTP to agent:	OK, RTT=10ms
+      ICMP to stack:	OK, RTT=10ms	(Last probed: 2023-04-01T12:35:00Z)
+      HTTP to agent:	OK, RTT=10ms	(Last probed: 2023-04-01T12:30:00Z)
     Endpoint connectivity to 192.168.1.1:
-      ICMP to stack:	OK, RTT=10ms
-      HTTP to agent:	OK, RTT=10ms
+      ICMP to stack:	OK, RTT=10ms	(Last probed: 2023-04-01T12:45:00Z)
+      HTTP to agent:	OK, RTT=10ms	(Last probed: 2023-04-01T12:40:00Z)
   node2:
     Host connectivity to 192.168.1.2:
-      ICMP to stack:	OK, RTT=10ms
-      HTTP to agent:	OK, RTT=10ms
+      ICMP to stack:	OK, RTT=10ms	(Last probed: 2023-04-01T12:35:00Z)
+      HTTP to agent:	OK, RTT=10ms	(Last probed: 2023-04-01T12:30:00Z)
     Endpoint connectivity to 192.168.1.2:
-      ICMP to stack:	OK, RTT=10ms
-      HTTP to agent:	OK, RTT=10ms
+      ICMP to stack:	OK, RTT=10ms	(Last probed: 2023-04-01T12:45:00Z)
+      HTTP to agent:	OK, RTT=10ms	(Last probed: 2023-04-01T12:40:00Z)
   node3:
     Host connectivity to 192.168.1.3:
-      ICMP to stack:	OK, RTT=10ms
-      HTTP to agent:	OK, RTT=10ms
+      ICMP to stack:	OK, RTT=10ms	(Last probed: 2023-04-01T12:35:00Z)
+      HTTP to agent:	OK, RTT=10ms	(Last probed: 2023-04-01T12:30:00Z)
     Endpoint connectivity to 192.168.1.3:
-      ICMP to stack:	OK, RTT=10ms
-      HTTP to agent:	OK, RTT=10ms
+      ICMP to stack:	OK, RTT=10ms	(Last probed: 2023-04-01T12:45:00Z)
+      HTTP to agent:	OK, RTT=10ms	(Last probed: 2023-04-01T12:40:00Z)

--- a/pkg/health/client/testdata/elevenHealthyAllNodes.golden
+++ b/pkg/health/client/testdata/elevenHealthyAllNodes.golden
@@ -1,4 +1,4 @@
-Cluster health:	11/11 reachable	(2023-04-01T12:00:00Z)
+Cluster health:	11/11 reachable	(2023-04-01T12:00:00Z)	(Probe interval: 4m15s)
 Name	IP	Node	Endpoints
   node0	192.168.1.0	1/1	1/1
   node1	192.168.1.1	1/1	1/1

--- a/pkg/health/client/testdata/elevenUnhealthy.golden
+++ b/pkg/health/client/testdata/elevenUnhealthy.golden
@@ -1,4 +1,4 @@
-Cluster health:	0/11 reachable	(2023-04-01T12:00:00Z)
+Cluster health:	0/11 reachable	(2023-04-01T12:00:00Z)	(Probe interval: 4m15s)
 Name	IP	Node	Endpoints
   node0	192.168.1.0	0/1	0/1
   node1	192.168.1.1	0/1	0/1

--- a/pkg/health/client/testdata/oneUnhealthy.golden
+++ b/pkg/health/client/testdata/oneUnhealthy.golden
@@ -1,3 +1,3 @@
-Cluster health:	3/4 reachable	(2023-04-01T12:00:00Z)
+Cluster health:	3/4 reachable	(2023-04-01T12:00:00Z)	(Probe interval: 8m5s)
 Name	IP	Node	Endpoints
   node3	192.168.1.3	0/1	0/1

--- a/pkg/health/client/testdata/oneUnhealthyAllNodes.golden
+++ b/pkg/health/client/testdata/oneUnhealthyAllNodes.golden
@@ -1,4 +1,4 @@
-Cluster health:	3/4 reachable	(2023-04-01T12:00:00Z)
+Cluster health:	3/4 reachable	(2023-04-01T12:00:00Z)	(Probe interval: 8m5s)
 Name	IP	Node	Endpoints
   node0	192.168.1.0	1/1	1/1
   node1	192.168.1.1	1/1	1/1

--- a/pkg/health/client/testdata/oneUnhealthyVerbose.golden
+++ b/pkg/health/client/testdata/oneUnhealthyVerbose.golden
@@ -1,4 +1,4 @@
-Cluster health:	3/4 reachable	(2023-04-01T12:00:00Z)
+Cluster health:	3/4 reachable	(2023-04-01T12:00:00Z)	(Probe interval: 8m5s)
 Name	IP	Node	Endpoints
   node0:
     Host connectivity to 192.168.1.0:

--- a/pkg/health/client/testdata/oneUnhealthyVerbose.golden
+++ b/pkg/health/client/testdata/oneUnhealthyVerbose.golden
@@ -2,29 +2,29 @@ Cluster health:	3/4 reachable	(2023-04-01T12:00:00Z)	(Probe interval: 8m5s)
 Name	IP	Node	Endpoints
   node0:
     Host connectivity to 192.168.1.0:
-      ICMP to stack:	OK, RTT=10ms
-      HTTP to agent:	OK, RTT=10ms
+      ICMP to stack:	OK, RTT=10ms	(Last probed: 2023-04-01T12:35:00Z)
+      HTTP to agent:	OK, RTT=10ms	(Last probed: 2023-04-01T12:30:00Z)
     Endpoint connectivity to 192.168.1.0:
-      ICMP to stack:	OK, RTT=10ms
-      HTTP to agent:	OK, RTT=10ms
+      ICMP to stack:	OK, RTT=10ms	(Last probed: 2023-04-01T12:45:00Z)
+      HTTP to agent:	OK, RTT=10ms	(Last probed: 2023-04-01T12:40:00Z)
   node1:
     Host connectivity to 192.168.1.1:
-      ICMP to stack:	OK, RTT=10ms
-      HTTP to agent:	OK, RTT=10ms
+      ICMP to stack:	OK, RTT=10ms	(Last probed: 2023-04-01T12:35:00Z)
+      HTTP to agent:	OK, RTT=10ms	(Last probed: 2023-04-01T12:30:00Z)
     Endpoint connectivity to 192.168.1.1:
-      ICMP to stack:	OK, RTT=10ms
-      HTTP to agent:	OK, RTT=10ms
+      ICMP to stack:	OK, RTT=10ms	(Last probed: 2023-04-01T12:45:00Z)
+      HTTP to agent:	OK, RTT=10ms	(Last probed: 2023-04-01T12:40:00Z)
   node2:
     Host connectivity to 192.168.1.2:
-      ICMP to stack:	OK, RTT=10ms
-      HTTP to agent:	OK, RTT=10ms
+      ICMP to stack:	OK, RTT=10ms	(Last probed: 2023-04-01T12:35:00Z)
+      HTTP to agent:	OK, RTT=10ms	(Last probed: 2023-04-01T12:30:00Z)
     Endpoint connectivity to 192.168.1.2:
-      ICMP to stack:	OK, RTT=10ms
-      HTTP to agent:	OK, RTT=10ms
+      ICMP to stack:	OK, RTT=10ms	(Last probed: 2023-04-01T12:45:00Z)
+      HTTP to agent:	OK, RTT=10ms	(Last probed: 2023-04-01T12:40:00Z)
   node3:
     Host connectivity to 192.168.1.3:
-      ICMP to stack:	failed
-      HTTP to agent:	failed
+      ICMP to stack:	failed	(Last probed: 2023-04-01T12:35:00Z)
+      HTTP to agent:	failed	(Last probed: 2023-04-01T12:30:00Z)
     Endpoint connectivity to 192.168.1.3:
-      ICMP to stack:	failed
-      HTTP to agent:	failed
+      ICMP to stack:	failed	(Last probed: 2023-04-01T12:45:00Z)
+      HTTP to agent:	failed	(Last probed: 2023-04-01T12:40:00Z)

--- a/pkg/health/server/prober.go
+++ b/pkg/health/server/prober.go
@@ -17,16 +17,19 @@ import (
 
 	"github.com/cilium/cilium/api/v1/health/models"
 	ciliumModels "github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/health/probe"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 // healthReport is a snapshot of the health of the cluster.
 type healthReport struct {
-	startTime time.Time
-	nodes     []*models.NodeStatus
+	startTime     time.Time
+	nodes         []*models.NodeStatus
+	probeInterval time.Duration
 }
 
 type connectivityResult struct {
@@ -54,6 +57,8 @@ type prober struct {
 	nodes   nodeMap
 
 	probeRateLimiter *rate.Limiter
+	probeInterval    time.Duration
+	probeIpCount     int
 }
 
 // copyResultRLocked makes a copy of the path status for the specified IP.
@@ -127,7 +132,7 @@ func (p *prober) getResults() *healthReport {
 		resultMap[node.Name] = status
 	}
 
-	result := &healthReport{startTime: p.start}
+	result := &healthReport{startTime: p.start, probeInterval: p.probeInterval}
 	for _, res := range resultMap {
 		result.nodes = append(result.nodes, res)
 	}
@@ -322,7 +327,7 @@ func icmpPing(node string, ip string, ctx context.Context, resChan chan<- connec
 	resChan <- connectivityResult{ip: ip, status: result}
 }
 
-func Per(nodes int, duration time.Duration) rate.Limit {
+func per(nodes int, duration time.Duration) rate.Limit {
 	return rate.Every(duration / time.Duration(nodes))
 }
 
@@ -363,7 +368,7 @@ func httpProbe(node string, ip string, ctx context.Context, resChan chan<- conne
 	resChan <- connectivityResult{ip: ip, status: result}
 }
 
-func (p *prober) runProbe() {
+func (p *prober) runProbe(nodeIps map[string][]*net.IPAddr) {
 	httpResChan := make(chan connectivityResult)
 	icmpResChan := make(chan connectivityResult)
 	wg := sync.WaitGroup{}
@@ -379,13 +384,7 @@ func (p *prober) runProbe() {
 	debugLogsEnabled := logging.CanLogAt(log.Logger, logrus.DebugLevel)
 	scopedLog := log
 
-	nodeIps := p.getIPsByNode()
-	// Spread probes evenly across probing interval.
-	ipCount := 0
-	for _, ips := range nodeIps {
-		ipCount += len(ips)
-	}
-	p.probeRateLimiter = rate.NewLimiter(Per(ipCount, p.server.Config.ProbeInterval), 1)
+	p.probeRateLimiter = rate.NewLimiter(per(p.probeIpCount, p.probeInterval), 1)
 
 	// update results as probes complete
 	resultsWg.Add(2)
@@ -463,14 +462,17 @@ func (p *prober) Stop() {
 }
 
 // RunLoop periodically sends probes out to all of the other cilium nodes to
-// gather connectivity status for the cluster.
+// gather connectivity status for the cluster once the current probing interval
+// has elapsed.
 //
 // This is a non-blocking method so it immediately returns. If you want to
 // stop sending packets, call Stop().
 func (p *prober) RunLoop() {
 	go func() {
-		tick := time.NewTicker(p.server.ProbeInterval)
-		p.runProbe()
+		nodeIps := p.getIPsByNode()
+		p.setProbeInterval(nodeIps)
+		tick := time.NewTicker(p.probeInterval)
+		p.runProbe(nodeIps)
 	loop:
 		for {
 			select {
@@ -492,7 +494,13 @@ func (p *prober) RunLoop() {
 					// (2) Update results without stale nodes
 					p.server.updateCluster(p.getResults())
 				}
-				p.runProbe()
+				// Reset probe interval based on cluster size.
+				nodeIps := p.getIPsByNode()
+				changedInterval := p.setProbeInterval(nodeIps)
+				if changedInterval {
+					tick.Reset(p.probeInterval)
+				}
+				p.runProbe(nodeIps)
 				continue
 			}
 		}
@@ -516,4 +524,23 @@ func newProber(s *Server, nodes nodeMap) *prober {
 	}
 	prober.setNodes(nodes, nil)
 	return prober
+}
+
+// Given user-provided ConnectivityProbeFrequencyRatio, uses base interval
+// in [10, 110] to set the probe interval, where base interval is 10 + ratio * 100.
+// Returns true if the interval has changed.
+func (p *prober) setProbeInterval(nodeIps map[string][]*net.IPAddr) bool {
+	scopedLog := log
+	baseInterval := (10 + option.Config.ConnectivityProbeFrequencyRatio*100) * 1e9
+	ipCount := 0
+	for _, ips := range nodeIps {
+		ipCount += len(ips)
+	}
+	p.Lock()
+	defer p.Unlock()
+	oldInterval := p.probeInterval
+	p.probeInterval = backoff.ClusterSizeDependantInterval(time.Duration(baseInterval), ipCount)
+	p.probeIpCount = ipCount
+	scopedLog.Debugf("Setting probe interval %s for %d IPs", p.probeInterval, p.probeIpCount)
+	return oldInterval != p.probeInterval
 }

--- a/pkg/health/server/prober.go
+++ b/pkg/health/server/prober.go
@@ -317,6 +317,7 @@ func icmpPing(node string, ip string, ctx context.Context, resChan chan<- connec
 			scopedLog.Debug("Ping failed")
 			result.Status = "Connection timed out"
 		}
+		result.LastProbed = time.Now().Format(time.RFC3339)
 	}
 	pinger.SetPrivileged(true)
 	err = pinger.RunWithContext(ctx)
@@ -364,6 +365,7 @@ func httpProbe(node string, ip string, ctx context.Context, resChan chan<- conne
 		}
 		result.Status = err.Error()
 	}
+	result.LastProbed = time.Now().Format(time.RFC3339)
 
 	resChan <- connectivityResult{ip: ip, status: result}
 }

--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -36,7 +36,6 @@ var (
 type Config struct {
 	Debug         bool
 	CiliumURI     string
-	ProbeInterval time.Duration
 	ICMPReqsCount int
 	ProbeDeadline time.Duration
 	HTTPPathPort  int
@@ -70,6 +69,8 @@ type Server struct {
 	lock.RWMutex
 	connectivity *healthReport
 	localStatus  *healthModels.SelfStatus
+
+	nodesSeen map[string]struct{}
 }
 
 // DumpUptime returns the time that this server has been running.
@@ -148,19 +149,25 @@ func nodeElementSliceToNodeMap(nodeElements []*models.NodeElement) nodeMap {
 // updateCluster makes the specified health report visible to the API.
 //
 // It only updates the server's API-visible health report if the provided
-// report started after the current report.
+// report started at the same time as or after the current report.
 func (s *Server) updateCluster(report *healthReport) {
 	s.Lock()
 	defer s.Unlock()
 
-	if s.connectivity.startTime.Before(report.startTime) {
+	if s.connectivity.startTime.Compare(report.startTime) <= 0 {
+		if s.connectivity.startTime.Compare(report.startTime) < 0 {
+			// New probe, clear nodesSeen
+			s.nodesSeen = make(map[string]struct{})
+		}
+		s.collectNodeConnectivityMetrics(report)
 		s.connectivity = report
-		s.collectNodeConnectivityMetrics()
 	}
 }
 
-func (s *Server) collectNodeConnectivityMetrics() {
-	if s.localStatus == nil || s.connectivity == nil {
+// collectNodeConnectivityMetrics updates the metrics based on the provided
+// health report.
+func (s *Server) collectNodeConnectivityMetrics(report *healthReport) {
+	if s.localStatus == nil || report == nil {
 		return
 	}
 	localClusterName, localNodeName := getClusterNodeName(s.localStatus.Name)
@@ -168,7 +175,7 @@ func (s *Server) collectNodeConnectivityMetrics() {
 	endpointStatuses := make(map[healthClientPkg.ConnectivityStatusType]int)
 	nodeStatuses := make(map[healthClientPkg.ConnectivityStatusType]int)
 
-	for _, n := range s.connectivity.nodes {
+	for _, n := range report.nodes {
 		if n == nil || n.Host == nil || n.Host.PrimaryAddress == nil || n.HealthEndpoint == nil || n.HealthEndpoint.PrimaryAddress == nil {
 			continue
 		}
@@ -192,6 +199,7 @@ func (s *Server) collectNodeConnectivityMetrics() {
 			location = metrics.LabelLocationRemoteIntraCluster
 		}
 
+		// Update idempotent metrics here (to prevent overwriting with nil values).
 		// Aggregated status for endpoint connectivity
 		metrics.NodeConnectivityStatus.WithLabelValues(
 			localClusterName, localNodeName, targetClusterName, targetNodeName, location, metrics.LabelPeerEndpoint).
@@ -209,6 +217,21 @@ func (s *Server) collectNodeConnectivityMetrics() {
 		for connectivityStatusType, value := range isHealthNodeReachable {
 			nodeStatuses[connectivityStatusType] += value
 		}
+
+		// In order to avoid updating non-idempotent metrics, considers the possible cases.
+		// Case 1: If the report is newer than the current one, update the connectivity status report and all metrics.
+		// Case 2: If the report is from the same interval as the current one, update the report and only the new metrics.
+		if s.connectivity != nil && s.connectivity.startTime.Compare(report.startTime) == 0 {
+			if s.nodesSeen == nil {
+				continue
+			}
+			if _, ok := s.nodesSeen[n.Name]; ok {
+				// Skip updating non-idempotent latency metrics for nodes already seen.
+				continue
+			}
+		}
+
+		s.nodesSeen[n.Name] = struct{}{}
 
 		// HTTP endpoint primary
 		collectConnectivityMetric(endpointPathStatus.PrimaryAddress.HTTP, localClusterName, localNodeName,
@@ -339,8 +362,9 @@ func (s *Server) GetStatusResponse() *healthModels.HealthStatusResponse {
 		Local: &healthModels.SelfStatus{
 			Name: name,
 		},
-		Nodes:     s.connectivity.nodes,
-		Timestamp: s.connectivity.startTime.Format(time.RFC3339),
+		Nodes:         s.connectivity.nodes,
+		Timestamp:     s.connectivity.startTime.Format(time.RFC3339),
+		ProbeInterval: s.connectivity.probeInterval.String(),
 	}
 }
 
@@ -363,6 +387,35 @@ func (s *Server) runActiveServices() error {
 	prober := newProber(s, nodesAdded)
 	prober.RunLoop()
 	defer prober.Stop()
+
+	// Periodically update the cluster status, without waiting for the
+	// probing interval to pass.
+	go func() {
+		tick := time.NewTicker(60 * time.Second)
+	loop:
+		for {
+			select {
+			case <-prober.stop:
+				break loop
+			case <-tick.C:
+				// We don't want to report stale nodes in metrics.
+				// We don't update added nodes in the middle of a probing interval.
+				if nodesAdded, nodesRemoved, err := prober.server.getNodes(); err != nil {
+					// reset the cache by setting clientID to 0 and removing all current nodes
+					prober.server.clientID = 0
+					prober.setNodes(nil, prober.nodes)
+					log.WithError(err).Error("unable to get cluster nodes")
+				} else {
+					// (1) setNodes implementation doesn't override results for existing nodes.
+					// (2) Remove stale nodes so we don't report them in metrics before updating results
+					prober.setNodes(nodesAdded, nodesRemoved)
+					// (2) Update results without stale nodes
+					prober.server.updateCluster(prober.getResults())
+				}
+			}
+		}
+		tick.Stop()
+	}()
 
 	return s.Server.Serve()
 }
@@ -423,6 +476,7 @@ func NewServer(config Config) (*Server, error) {
 		startTime:    time.Now(),
 		Config:       config,
 		connectivity: &healthReport{},
+		nodesSeen:    make(map[string]struct{}),
 	}
 
 	cl, err := ciliumPkg.NewClient(config.CiliumURI)

--- a/pkg/health/server/server_old_test.go
+++ b/pkg/health/server/server_old_test.go
@@ -316,8 +316,9 @@ func Test_server_collectNodeConnectivityMetricsOld(t *testing.T) {
 			s := &Server{
 				connectivity: tt.connectivity,
 				localStatus:  tt.localStatus,
+				nodesSeen:    make(map[string]struct{}),
 			}
-			s.collectNodeConnectivityMetrics()
+			s.collectNodeConnectivityMetrics(tt.connectivity)
 
 			// perform static checks such as prometheus naming convention, number of labels matching, etc
 			lintProblems, err := testutil.CollectAndLint(collector)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1145,6 +1145,9 @@ const (
 	// EnableEndpointLockdownOnPolicyOverflow enables endpoint lockdown when an endpoint's
 	// policy map overflows.
 	EnableEndpointLockdownOnPolicyOverflow = "enable-endpoint-lockdown-on-policy-overflow"
+
+	// ConnectivityProbeFrequencyRatio is the name of the option to specify the connectivity probe frequency
+	ConnectivityProbeFrequencyRatio = "connectivity-probe-frequency-ratio"
 )
 
 // Default string arguments
@@ -2254,6 +2257,9 @@ type DaemonConfig struct {
 	// EnableEndpointLockdownOnPolicyOverflow enables endpoint lockdown when an endpoint's
 	// policy map overflows.
 	EnableEndpointLockdownOnPolicyOverflow bool
+
+	// ConnectivityProbeFrequencyRatio is the ratio of the connectivity probe frequency vs resource consumption
+	ConnectivityProbeFrequencyRatio float64
 }
 
 var (
@@ -2317,6 +2323,8 @@ var (
 		EnableNonDefaultDenyPolicies: defaults.EnableNonDefaultDenyPolicies,
 
 		EnableSourceIPVerification: defaults.EnableSourceIPVerification,
+
+		ConnectivityProbeFrequencyRatio: defaults.ConnectivityProbeFrequencyRatio,
 	}
 )
 
@@ -3327,6 +3335,15 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.LoadBalancerOnly = vp.GetBool(LoadBalancerOnly)
 	c.EnableInternalTrafficPolicy = vp.GetBool(EnableInternalTrafficPolicy)
 	c.EnableSourceIPVerification = vp.GetBool(EnableSourceIPVerification)
+
+	// Allow the range [0.0, 1.0].
+	connectivityFreqRatio := vp.GetFloat64(ConnectivityProbeFrequencyRatio)
+	if 0.0 <= connectivityFreqRatio && connectivityFreqRatio <= 1.0 {
+		c.ConnectivityProbeFrequencyRatio = connectivityFreqRatio
+	} else {
+		log.Warningf("specified connectivity probe frequency ratio %f must be in the range [0.0, 1.0], using default", connectivityFreqRatio)
+		c.ConnectivityProbeFrequencyRatio = defaults.ConnectivityProbeFrequencyRatio
+	}
 }
 
 func (c *DaemonConfig) populateLoadBalancerSettings(vp *viper.Viper) {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -131,6 +131,8 @@ var (
 		"ipam.operator.clusterPoolIPv6PodCIDRList": "fd02::/112",
 
 		"extraConfig.max-internal-timer-delay": "5s",
+
+		"connectivityProbeFrequencyRatio": "0",
 	}
 
 	eksChainingHelmOverrides = map[string]string{


### PR DESCRIPTION
PR with core changes for #32820 / [CFP](https://github.com/cilium/design-cfps/blob/main/cilium/CFP-32820-improve-scalability-of-health-probing.md), to improve scalability of health checking.

Summary of changes:
- Update health API so healthstatusresponse contains field for probing interval.
- Make probing interval configurable via agent flag `connectivity-probe-frequency-ratio` (for preference between frequent probing vs resource use) and dynamic based on cluster size.
- Update known results/metrics at intervals of 60s, even within a longer probing interval.

```release-note
connectivity health checking: introduce dynamic probing interval based on cluster size and configurable probing frequency for improved performance at scale
```
