### PR TITLE
bpf: nat: support more embedded ICMP types for DEST_UNREACH packet

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -728,13 +728,17 @@ snat_v4_nat_handle_icmp_dest_unreach(struct __ctx_buff *ctx, __u64 off,
 		port_off = TCP_DPORT_OFF;
 		break;
 	case IPPROTO_ICMP:
-		/* No reasons to see a packet different than ICMP_ECHOREPLY. */
-		if (ctx_load_bytes(ctx, icmpoff, &type,
-				   sizeof(type)) < 0 ||
-		    type != ICMP_ECHOREPLY)
+		if (ctx_load_bytes(ctx, icmpoff, &type, sizeof(type)) < 0)
 			return DROP_INVALID;
 
-		port_off = offsetof(struct icmphdr, un.echo.id);
+		switch (type) {
+		case ICMP_ECHOREPLY:
+			port_off = offsetof(struct icmphdr, un.echo.id);
+			break;
+		default:
+			/* No reasons to see a packet different than ICMP_ECHOREPLY. */
+			return DROP_UNKNOWN_ICMP_CODE;
+		}
 
 		if (ctx_load_bytes(ctx, icmpoff + port_off,
 				   &tuple.sport, sizeof(tuple.sport)) < 0)
@@ -899,12 +903,17 @@ snat_v4_rev_nat_handle_icmp_dest_unreach(struct __ctx_buff *ctx,
 		port_off = TCP_SPORT_OFF;
 		break;
 	case IPPROTO_ICMP:
-		/* No reasons to see a packet different than ICMP_ECHO. */
-		if (ctx_load_bytes(ctx, icmpoff, &type, sizeof(type)) < 0 ||
-		    type != ICMP_ECHO)
+		if (ctx_load_bytes(ctx, icmpoff, &type, sizeof(type)) < 0)
 			return DROP_INVALID;
 
-		port_off = offsetof(struct icmphdr, un.echo.id);
+		switch (type) {
+		case ICMP_ECHO:
+			port_off = offsetof(struct icmphdr, un.echo.id);
+			break;
+		default:
+			/* No reasons to see a packet different than ICMP_ECHO. */
+			return DROP_UNKNOWN_ICMP_CODE;
+		}
 
 		if (ctx_load_bytes(ctx, icmpoff + port_off,
 				   &tuple.dport, sizeof(tuple.dport)) < 0)

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -732,11 +732,12 @@ snat_v4_nat_handle_icmp_dest_unreach(struct __ctx_buff *ctx, __u64 off,
 			return DROP_INVALID;
 
 		switch (type) {
+		case ICMP_ECHO:
+			return NAT_PUNT_TO_STACK;
 		case ICMP_ECHOREPLY:
 			port_off = offsetof(struct icmphdr, un.echo.id);
 			break;
 		default:
-			/* No reasons to see a packet different than ICMP_ECHOREPLY. */
 			return DROP_UNKNOWN_ICMP_CODE;
 		}
 
@@ -910,8 +911,9 @@ snat_v4_rev_nat_handle_icmp_dest_unreach(struct __ctx_buff *ctx,
 		case ICMP_ECHO:
 			port_off = offsetof(struct icmphdr, un.echo.id);
 			break;
+		case ICMP_ECHOREPLY:
+			return NAT_PUNT_TO_STACK;
 		default:
-			/* No reasons to see a packet different than ICMP_ECHO. */
 			return DROP_UNKNOWN_ICMP_CODE;
 		}
 


### PR DESCRIPTION
As follow-on to https://github.com/cilium/cilium/pull/35636, add support for additional types of  ICMP messages that potentially get reflected back by an `DEST_UNREACH` packet.