### PR TITLE
bugtool: dump tail-call map for bpf_wireguard

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -129,6 +129,7 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"tc/globals/cilium_auth_map",
 		"tc/globals/cilium_call_policy",
 		"tc/globals/cilium_calls_overlay_2",
+		"tc/globals/cilium_calls_wireguard_2",
 		"tc/globals/cilium_calls_xdp",
 		"tc/globals/cilium_capture_cache",
 		"tc/globals/cilium_runtime_config",


### PR DESCRIPTION
This was added with https://github.com/cilium/cilium/pull/33426.