### PR TITLE
bpf: Avoid implicit shorten-64-to-32 in clang 19

### DIFF
--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -386,7 +386,7 @@ ctx_full_len(const struct xdp_md *ctx)
 static __always_inline __maybe_unused __u32
 ctx_wire_len(const struct xdp_md *ctx)
 {
-	return ctx_full_len(ctx);
+	return (__u32)ctx_full_len(ctx);
 }
 
 struct {

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -198,7 +198,7 @@ ____revalidate_data_pull(struct __ctx_buff *ctx, void **data_, void **data_end_,
 
 	/* Verifier workaround, do this unconditionally: invalid size of register spill. */
 	if (pull)
-		ctx_pull_data(ctx, tot_len);
+		ctx_pull_data(ctx, (__u32)tot_len);
 	data_end = ctx_data_end(ctx);
 	data = ctx_data(ctx);
 	if (data + tot_len > data_end)
@@ -1252,7 +1252,7 @@ static __always_inline int redirect_ep(struct __ctx_buff *ctx __maybe_unused,
 	 */
 	if (needs_backlog || !is_defined(ENABLE_HOST_ROUTING) ||
 	    ctx_get_ingress_ifindex(ctx) == 0) {
-		return ctx_redirect(ctx, ifindex, 0);
+		return (int)ctx_redirect(ctx, ifindex, 0);
 	}
 
 	/* When coming from overlay, we need to set packet type

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -96,7 +96,7 @@ static __always_inline __u32 __ct_update_timeout(struct ct_entry *entry,
 						 union tcp_flags flags,
 						 __u8 report_mask)
 {
-	__u32 now = bpf_mono_now();
+	__u32 now = (__u32)bpf_mono_now();
 	__u8 accumulated_flags;
 	__u8 seen_flags = flags.lower_bits & report_mask;
 	__u32 last_report;
@@ -193,7 +193,7 @@ ct_lookup_fill_state(struct ct_state *state, const struct ct_entry *entry,
 {
 	state->rev_nat_index = entry->rev_nat_index;
 	if (dir == CT_SERVICE) {
-		state->backend_id = entry->backend_id;
+		state->backend_id = (__u32)entry->backend_id;
 		state->syn = syn;
 	} else if (dir == CT_INGRESS || dir == CT_EGRESS) {
 #ifndef DISABLE_LOOPBACK_LB

--- a/bpf/lib/csum.h
+++ b/bpf/lib/csum.h
@@ -74,5 +74,5 @@ static __always_inline int csum_l4_replace(struct __ctx_buff *ctx, __u64 l4_off,
 					   const struct csum_offset *csum,
 					   __be32 from, __be32 to, int flags)
 {
-	return l4_csum_replace(ctx, l4_off + csum->offset, from, to, flags | csum->flags);
+	return l4_csum_replace(ctx, (__u32)(l4_off + csum->offset), from, to, flags | csum->flags);
 }

--- a/bpf/lib/dbg.h
+++ b/bpf/lib/dbg.h
@@ -220,7 +220,7 @@ static __always_inline void cilium_dbg_capture2(struct __ctx_buff *ctx, __u8 typ
 	__u64 cap_len = min_t(__u64, TRACE_PAYLOAD_LEN, ctx_len);
 	struct debug_capture_msg msg = {
 		__notify_common_hdr(CILIUM_NOTIFY_DBG_CAPTURE, type),
-		__notify_pktcap_hdr(ctx_len, (__u16)cap_len),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len),
 		.arg1	= arg1,
 		.arg2	= arg2,
 	};

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -77,7 +77,7 @@ int __send_drop_notify(struct __ctx_buff *ctx)
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_DROP, (__u8)error),
-		__notify_pktcap_hdr(ctx_len, (__u16)cap_len),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len),
 		.src_label	= ctx_load_meta(ctx, 0),
 		.dst_label	= ctx_load_meta(ctx, 1),
 		.dst_id		= ctx_load_meta(ctx, 3),

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -138,11 +138,11 @@ fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 						     &fib_params->l.ipv6_dst,
 						     sizeof(nh_params.ipv6_nh));
 
-				return redirect_neigh(*oif, &nh_params,
-						sizeof(nh_params), 0);
+				return (int)redirect_neigh(*oif, &nh_params,
+							   sizeof(nh_params), 0);
 			}
 
-			return redirect_neigh(*oif, NULL, 0, 0);
+			return (int)redirect_neigh(*oif, NULL, 0, 0);
 		} else {
 			union macaddr smac = NATIVE_DEV_MAC_BY_IFINDEX(*oif);
 			union macaddr *dmac = NULL;
@@ -168,7 +168,7 @@ fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 		}
 	};
 out_send:
-	return ctx_redirect(ctx, *oif, 0);
+	return (int)ctx_redirect(ctx, *oif, 0);
 }
 
 static __always_inline int
@@ -183,7 +183,7 @@ fib_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 	if (!is_defined(ENABLE_SKIP_FIB) || !neigh_resolver_available()) {
 		int ret;
 
-		ret = fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), 0);
+		ret = (int)fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), 0);
 		switch (ret) {
 		case BPF_FIB_LKUP_RET_SUCCESS:
 		case BPF_FIB_LKUP_RET_NO_NEIGH:
@@ -221,7 +221,7 @@ fib_lookup_v6(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
 	ipv6_addr_copy((union v6addr *)&fib_params->l.ipv6_dst,
 		       (union v6addr *)ipv6_dst);
 
-	return fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), flags);
+	return (int)fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), flags);
 };
 
 static __always_inline int
@@ -281,7 +281,7 @@ fib_lookup_v4(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
 	fib_params->l.ipv4_src	= ipv4_src;
 	fib_params->l.ipv4_dst	= ipv4_dst;
 
-	return fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), flags);
+	return (int)fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), flags);
 }
 
 static __always_inline int

--- a/bpf/lib/high_scale_ipcache.h
+++ b/bpf/lib/high_scale_ipcache.h
@@ -73,8 +73,8 @@ decapsulate_overlay(struct __ctx_buff *ctx, __u32 *src_id)
 	if (ip4->protocol != IPPROTO_UDP)
 		return CTX_ACT_OK;
 
-	off = ((void *)ip4 - data) + ipv4_hdrlen(ip4) +
-	      offsetof(struct udphdr, dest);
+	off = (__u32)(((void *)ip4 - data) + ipv4_hdrlen(ip4) +
+	      offsetof(struct udphdr, dest));
 	if (l4_load_port(ctx, off, &dport) < 0)
 		return DROP_INVALID;
 
@@ -113,9 +113,9 @@ decapsulate_overlay(struct __ctx_buff *ctx, __u32 *src_id)
 	case TUNNEL_PROTOCOL_VXLAN:
 		shrink = ipv4_hdrlen(ip4) + sizeof(struct udphdr) +
 			 sizeof(struct vxlanhdr) + sizeof(struct ethhdr);
-		off = ((void *)ip4 - data) + ipv4_hdrlen(ip4) +
+		off = (__u32)(((void *)ip4 - data) + ipv4_hdrlen(ip4) +
 		      sizeof(struct udphdr) +
-		      offsetof(struct vxlanhdr, vx_vni);
+		      offsetof(struct vxlanhdr, vx_vni));
 
 		if (ctx_load_bytes(ctx, off, src_id, sizeof(__u32)) < 0)
 			return DROP_INVALID;

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -219,7 +219,7 @@ static __always_inline int __icmp6_send_time_exceeded(struct __ctx_buff *ctx,
 		sum = compute_icmp6_csum(data, 56, ipv6hdr);
 		payload_len = bpf_htons(56);
 		trimlen = 56 - bpf_ntohs(ipv6hdr->payload_len);
-		if (ctx_change_tail(ctx, ctx_full_len(ctx) + trimlen, 0) < 0)
+		if (ctx_change_tail(ctx, (__u32)(ctx_full_len(ctx) + trimlen), 0) < 0)
 			return DROP_WRITE_ERROR;
 		/* trim or expand buffer and copy data buffer after ipv6 header */
 		if (ctx_store_bytes(ctx, nh_off + sizeof(struct ipv6hdr),
@@ -238,7 +238,7 @@ static __always_inline int __icmp6_send_time_exceeded(struct __ctx_buff *ctx,
 		payload_len = bpf_htons(68);
 		/* trim or expand buffer and copy data buffer after ipv6 header */
 		trimlen = 68 - bpf_ntohs(ipv6hdr->payload_len);
-		if (ctx_change_tail(ctx, ctx_full_len(ctx) + trimlen, 0) < 0)
+		if (ctx_change_tail(ctx, (__u32)(ctx_full_len(ctx) + trimlen), 0) < 0)
 			return DROP_WRITE_ERROR;
 		if (ctx_store_bytes(ctx, nh_off + sizeof(struct ipv6hdr),
 				    data, 68, 0) < 0)

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -40,14 +40,14 @@ ipv4_csum_update_by_value(struct __ctx_buff *ctx, int l3_off, __u64 old_val,
 			  __u64 new_val, __u32 len)
 {
 	return l3_csum_replace(ctx, l3_off + offsetof(struct iphdr, check),
-			       old_val, new_val, len);
+			       (__u32)old_val, (__u32)new_val, len);
 }
 
 static __always_inline int
 ipv4_csum_update_by_diff(struct __ctx_buff *ctx, int l3_off, __u64 diff)
 {
 	return l3_csum_replace(ctx, l3_off + offsetof(struct iphdr, check),
-			       0, diff, 0);
+			       0, (__u32)diff, 0);
 }
 
 static __always_inline int ipv4_load_daddr(struct __ctx_buff *ctx, int off,

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -819,7 +819,7 @@ __lb6_affinity_backend_id(const struct lb6_service *svc, bool netns_cookie,
 
 	val = map_lookup_elem(&LB6_AFFINITY_MAP, &key);
 	if (val != NULL) {
-		__u32 now = bpf_mono_now();
+		__u32 now = (__u32)bpf_mono_now();
 		struct lb_affinity_match match = {
 			.rev_nat_id	= svc->rev_nat_index,
 			.backend_id	= val->backend_id,
@@ -854,7 +854,7 @@ static __always_inline void
 __lb6_update_affinity(const struct lb6_service *svc, bool netns_cookie,
 		      union lb6_affinity_client_id *id, __u32 backend_id)
 {
-	__u32 now = bpf_mono_now();
+	__u32 now = (__u32)bpf_mono_now();
 	struct lb6_affinity_key key = {
 		.rev_nat_id	= svc->rev_nat_index,
 		.netns_cookie	= netns_cookie,
@@ -1552,7 +1552,7 @@ __lb4_affinity_backend_id(const struct lb4_service *svc, bool netns_cookie,
 
 	val = map_lookup_elem(&LB4_AFFINITY_MAP, &key);
 	if (val != NULL) {
-		__u32 now = bpf_mono_now();
+		__u32 now = (__u32)bpf_mono_now();
 		struct lb_affinity_match match = {
 			.rev_nat_id	= svc->rev_nat_index,
 			.backend_id	= val->backend_id,
@@ -1593,7 +1593,7 @@ __lb4_update_affinity(const struct lb4_service *svc, bool netns_cookie,
 		      const union lb4_affinity_client_id *id,
 		      __u32 backend_id)
 {
-	__u32 now = bpf_mono_now();
+	__u32 now = (__u32)bpf_mono_now();
 	struct lb4_affinity_key key = {
 		.rev_nat_id	= svc->rev_nat_index,
 		.netns_cookie	= netns_cookie,
@@ -1950,10 +1950,10 @@ int __tail_no_service_ipv4(struct __ctx_buff *ctx)
 	tos = ip4->tos;
 
 	/* Resize to ethernet header + 64 bytes or less */
-	sample_len = ctx_full_len(ctx);
+	sample_len = (int)ctx_full_len(ctx);
 	if (sample_len > ICMP_PACKET_MAX_SAMPLE_SIZE)
 		sample_len = ICMP_PACKET_MAX_SAMPLE_SIZE;
-	ctx_adjust_troom(ctx, sample_len + sizeof(struct ethhdr) - ctx_full_len(ctx));
+	ctx_adjust_troom(ctx, (__s32)(sample_len + sizeof(struct ethhdr) - ctx_full_len(ctx)));
 
 	data = ctx_data(ctx);
 	data_end = ctx_data_end(ctx);
@@ -2117,13 +2117,13 @@ int __tail_no_service_ipv6(struct __ctx_buff *ctx)
 	sample_len = ctx_full_len(ctx);
 	if (sample_len > (__u64)ICMPV6_PACKET_MAX_SAMPLE_SIZE)
 		sample_len = ICMPV6_PACKET_MAX_SAMPLE_SIZE;
-	ctx_adjust_troom(ctx, sample_len + sizeof(struct ethhdr) - ctx_full_len(ctx));
+	ctx_adjust_troom(ctx, (__s32)(sample_len + sizeof(struct ethhdr) - ctx_full_len(ctx)));
 
 	data = ctx_data(ctx);
 	data_end = ctx_data_end(ctx);
 
 	/* Calculate the unfolded checksum of the ICMPv6 sample */
-	csum = icmp_wsum_accumulate(data + sizeof(struct ethhdr), data_end, sample_len);
+	csum = icmp_wsum_accumulate(data + sizeof(struct ethhdr), data_end, (int)sample_len);
 
 	/* We need to insert a IPv6 and ICMPv6 header before the original packet.
 	 * Make that room.

--- a/bpf/lib/nat_46x64.h
+++ b/bpf/lib/nat_46x64.h
@@ -308,7 +308,7 @@ static __always_inline int ipv4_to_ipv6(struct __ctx_buff *ctx, int nh_off,
 	if (csum_off < 0)
 		return csum_off;
 	csum_off += sizeof(struct ipv6hdr);
-	if (l4_csum_replace(ctx, nh_off + csum_off, 0, csum, csum_flags) < 0)
+	if (l4_csum_replace(ctx, nh_off + csum_off, 0, csum, (__u32)csum_flags) < 0)
 		return DROP_CSUM_L4;
 	return 0;
 }
@@ -365,7 +365,7 @@ static __always_inline int ipv6_to_ipv4(struct __ctx_buff *ctx,
 	if (csum_off < 0)
 		return csum_off;
 	csum_off += sizeof(struct iphdr);
-	if (l4_csum_replace(ctx, nh_off + csum_off, 0, csum, csum_flags) < 0)
+	if (l4_csum_replace(ctx, nh_off + csum_off, 0, csum, (__u32)csum_flags) < 0)
 		return DROP_CSUM_L4;
 	return 0;
 }

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -162,7 +162,7 @@ redirect_self(const struct __sk_buff *ctx)
 	/* Looping back the packet into the originating netns. We xmit into the
 	 * hosts' veth device such that we end up on ingress in the peer.
 	 */
-	return ctx_redirect(ctx, ctx->ifindex, 0);
+	return (int)ctx_redirect(ctx, ctx->ifindex, 0);
 }
 
 static __always_inline __maybe_unused bool

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -184,7 +184,7 @@ ctx_set_encap_info(struct xdp_md *ctx, __u32 src_ip, __be16 src_port,
 		   __u32 daddr, __u32 seclabel __maybe_unused,
 		   __u32 vni __maybe_unused, void *opt, __u32 opt_len)
 {
-	__u32 inner_len = ctx_full_len(ctx);
+	__u32 inner_len = (__u32)ctx_full_len(ctx);
 	__u32 tunnel_hdr_len = 8; /* geneve / vxlan */
 	void *data, *data_end;
 	struct ethhdr *eth;

--- a/bpf/lib/pcap.h
+++ b/bpf/lib/pcap.h
@@ -64,8 +64,8 @@ static __always_inline void cilium_capture(struct __ctx_buff *ctx,
 			.to	= {
 				.tv_boot = tstamp,
 			},
-			.caplen	= cap_len,
-			.len	= ctx_len,
+			.caplen	= (__u32)cap_len,
+			.len	= (__u32)ctx_len,
 		},
 	};
 

--- a/bpf/lib/policy_log.h
+++ b/bpf/lib/policy_log.h
@@ -94,7 +94,7 @@ send_policy_verdict_notify(struct __ctx_buff *ctx, __u32 remote_label, __u16 dst
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_POLICY_VERDICT, 0),
-		__notify_pktcap_hdr(ctx_len, (__u16)cap_len),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len),
 		.remote_label	= remote_label,
 		.verdict	= verdict,
 		.dst_port	= bpf_ntohs(dst_port),

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -222,7 +222,7 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr(ctx_len, (__u16)cap_len),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len),
 		.src_label	= src,
 		.dst_label	= dst,
 		.dst_id		= dst_id,
@@ -266,7 +266,7 @@ send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr(ctx_len, (__u16)cap_len),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len),
 		.src_label	= src,
 		.dst_label	= dst,
 		.dst_id		= dst_id,
@@ -312,7 +312,7 @@ send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr(ctx_len, (__u16)cap_len),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len),
 		.src_label	= src,
 		.dst_label	= dst,
 		.dst_id		= dst_id,

--- a/bpf/tests/bpf_ct_tests.c
+++ b/bpf/tests/bpf_ct_tests.c
@@ -77,7 +77,7 @@ __always_inline int mkpkt(void *dst, bool first)
 	memcpy(dst, tcp_data, sizeof(tcp_data));
 	dst += sizeof(tcp_data);
 
-	return dst - orig;
+	return (int)(dst - orig);
 }
 
 static char pkt[100];
@@ -206,7 +206,7 @@ int test_ct4_rst1_check(__maybe_unused struct __ctx_buff *ctx)
 		assert(entry);
 		assert(entry->rx_flags_seen == tcp_flags_to_u8(TCP_FLAG_SYN | TCP_FLAG_RST));
 
-		__u32 expires = entry->lifetime - bpf_ktime_get_sec();
+		__u32 expires = (__u32)(entry->lifetime - bpf_ktime_get_sec());
 
 		if (expires > 10)
 			test_fatal("Expiration is %ds even if RST flag was set", expires);

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -138,7 +138,7 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr, bool egress)
 	}
 		break;
 	}
-	return dst - orig;
+	return (int)(dst - orig);
 }
 
 CHECK("tc", "nat4_icmp_error_tcp")

--- a/bpf/tests/conntrack_test.c
+++ b/bpf/tests/conntrack_test.c
@@ -62,7 +62,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		assert(entry.last_tx_report == 0);
 		assert(entry.rx_flags_seen == 0);
 		/* If <= a full report interval passes, don't report. */
-		then = __now;
+		then = (__u32)__now;
 		__now += CT_REPORT_INTERVAL;
 		monitor = __ct_update_timeout(&entry, 1000, CT_INGRESS, flags, REPORT_ALL_FLAGS);
 		assert(!monitor);

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -216,7 +216,7 @@ void *pktgen__push_rawhdr(struct pktgen *builder, __u32 hdrsize, enum pkt_layer 
 	int layer_idx;
 
 	/* Request additional tailroom, and check that we got it. */
-	ctx_adjust_troom(ctx, builder->cur_off + hdrsize - ctx_full_len(ctx));
+	ctx_adjust_troom(ctx, (__s32)(builder->cur_off + hdrsize - ctx_full_len(ctx)));
 	if (ctx_data(ctx) + builder->cur_off + hdrsize > ctx_data_end(ctx))
 		return NULL;
 
@@ -560,7 +560,7 @@ void *pktgen__push_data_room(struct pktgen *builder, int len)
 	int layer_idx;
 
 	/* Request additional tailroom, and check that we got it. */
-	ctx_adjust_troom(ctx, builder->cur_off + len - ctx_full_len(ctx));
+	ctx_adjust_troom(ctx, (__s32)(builder->cur_off + len - ctx_full_len(ctx)));
 	if (ctx_data(ctx) + builder->cur_off + len > ctx_data_end(ctx))
 		return 0;
 

--- a/bpf/tests/xdp_nodeport_lb4_test.c
+++ b/bpf/tests/xdp_nodeport_lb4_test.c
@@ -108,7 +108,7 @@ static __always_inline int build_packet(struct __ctx_buff *ctx)
 	data += sizeof(struct tcphdr) + sizeof(tcp_data);
 
 	/* Shrink ctx to the exact size we used */
-	offset = (long)data - (long)ctx->data_end;
+	offset = (int)((long)data - (long)ctx->data_end);
 	bpf_xdp_adjust_tail(ctx, offset);
 
 	return 0;


### PR DESCRIPTION
As per the below PR, clang 19.1.x is having -Wshorten-64-to32 under the -Wimplicit-int-conversion, which is already forbidden in Makefile.bpf. This commit is to avoid the conversion error as per below sample

```
./lib/nodeport.h:1825:18: error: implicit conversion loses integer precision: '__u64' (aka 'unsigned long long') to '__s32' (aka 'int') [-Werror,-Wshorten-64-to-32]
 1825 |         __s32 len_old = ctx_full_len(ctx);
```

Relates: https://github.com/llvm/llvm-project/pull/80814
Fixes: #35162 35162
