### PR TITLE
hubble-relay: make MinTLSVersion a var

### DIFF
--- a/pkg/hubble/relay/server/option.go
+++ b/pkg/hubble/relay/server/option.go
@@ -20,7 +20,7 @@ import (
 
 // MinTLSVersion defines the minimum TLS version clients are expected to
 // support in order to establish a connection to the hubble-relay server.
-const MinTLSVersion = tls.VersionTLS13
+var MinTLSVersion uint16 = tls.VersionTLS13
 
 // options stores all the configuration values for the hubble-relay server.
 type options struct {


### PR DESCRIPTION
Allows updating the value from init func when needed.

For example, one might need to lower the MinTLSVersion for compliance/regulation/etc.

Follow-up to: https://github.com/cilium/cilium/pull/36164