### PR TITLE
helm: fix commonLabels parsing in hubble dashboard configmap

### DIFF
--- a/install/kubernetes/cilium/templates/hubble/dashboards-configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble/dashboards-configmap.yaml
@@ -12,8 +12,8 @@ metadata:
     k8s-app: hubble
     app.kubernetes.io/name: hubble
     app.kubernetes.io/part-of: cilium
-    
-    {{- with .Values.commonLabels }}
+
+    {{- with $.Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 


### PR DESCRIPTION
This PR (https://github.com/cilium/cilium/pull/35628) added commonLabels to most cilium resources, and that caused an issue with the hubble dashboards configmap where we needed to use `$.Values` .

Fixes:
```
Error: template: cilium/templates/hubble/dashboards-configmap.yaml:16:20: executing "cilium/templates/hubble/dashboards-configmap.yaml" at <.Values.commonLabels>: can't evaluate field Values in type []uint8
```