### PR TITLE
policy: Do not fuzz mapState receiver

### DIFF
--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -47,7 +47,6 @@ func FuzzDenyPreferredInsert(f *testing.F) {
 		key := Key{}
 		entry := mapStateEntry{}
 		ff := fuzz.NewConsumer(data)
-		ff.GenerateStruct(keys)
 		ff.GenerateStruct(&key)
 		ff.GenerateStruct(&entry)
 		keys.insertWithChanges(key, entry, allFeatures, ChangeState{})


### PR DESCRIPTION
Ever since we dropped the separate allow/deny maps the fuzz test has been failing on trying to fuzz the mapState receiver. With the new flatter mapState definition this no longer works, and the value of trying to fuzz the empty map is in itself questionable, so drop it. This allows the fuzz test to proceed with insertions of fuzzed keys and values.
