### PR TITLE
Add policy-related features tracking in Cilium agent as prometheus metrics

### DIFF
--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -64,7 +64,7 @@ func setupDaemonFQDNSuite(tb testing.TB) *DaemonFQDNSuite {
 	ds := &DaemonFQDNSuite{}
 	d := &Daemon{}
 	d.ctx = context.Background()
-	d.policy = policy.NewPolicyRepository(nil, nil, nil, nil)
+	d.policy = policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())
 	d.endpointManager = endpointmanager.New(&dummyEpSyncher{}, nil, nil)
 	d.ipcache = ipcache.NewIPCache(&ipcache.Configuration{
 		Context:           context.TODO(),

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -1067,11 +1067,11 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 							},
 						},
 					},
-					repo: policy.NewPolicyRepository(nil, nil, nil, nil),
+					repo: policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop()),
 				}
 			},
 			setupWanted: func() wanted {
-				r := policy.NewPolicyRepository(nil, nil, nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())
 				r.MustAddList(api.Rules{
 					api.NewRule().
 						WithEndpointSelector(api.EndpointSelector{
@@ -1100,7 +1100,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 		{
 			name: "have a rule with user labels and update it without user labels, all other rules should be deleted",
 			setupArgs: func() args {
-				r := policy.NewPolicyRepository(nil, nil, nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())
 				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...).Sort()
 				r.MustAddList(api.Rules{
@@ -1143,7 +1143,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 				}
 			},
 			setupWanted: func() wanted {
-				r := policy.NewPolicyRepository(nil, nil, nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())
 				r.MustAddList(api.Rules{
 					api.NewRule().
 						WithEndpointSelector(api.EndpointSelector{
@@ -1172,7 +1172,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 		{
 			name: "have a rule without user labels and update it with user labels, all other rules should be deleted",
 			setupArgs: func() args {
-				r := policy.NewPolicyRepository(nil, nil, nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())
 				r.MustAddList(api.Rules{
 					{
 						EndpointSelector: api.EndpointSelector{
@@ -1214,7 +1214,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 				}
 			},
 			setupWanted: func() wanted {
-				r := policy.NewPolicyRepository(nil, nil, nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())
 				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...).Sort()
 				r.MustAddList(api.Rules{
@@ -1240,7 +1240,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 		{
 			name: "have a rule policy installed with multiple rules and apply an empty spec should delete all rules installed",
 			setupArgs: func() args {
-				r := policy.NewPolicyRepository(nil, nil, nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())
 				r.MustAddList(api.Rules{
 					{
 						EndpointSelector: api.EndpointSelector{
@@ -1287,7 +1287,7 @@ func (ds *DaemonSuite) testAddCiliumNetworkPolicyV2(t *testing.T) {
 				}
 			},
 			setupWanted: func() wanted {
-				r := policy.NewPolicyRepository(nil, nil, nil, nil)
+				r := policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())
 				r.MustAddList(api.Rules{
 					{
 						EndpointSelector: api.EndpointSelector{

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	K8sSvcCache = k8s.NewServiceCache(nil, nil)
+	K8sSvcCache = k8s.NewServiceCache(nil, nil, k8s.NewSVCMetricsNoop())
 
 	kvs store.SyncStore
 )

--- a/pkg/ciliumenvoyconfig/cell.go
+++ b/pkg/ciliumenvoyconfig/cell.go
@@ -147,6 +147,13 @@ func registerCECK8sReconciler(params reconcilerParams) {
 	}
 }
 
+type CECMetrics interface {
+	AddCEC(cec *ciliumv2.CiliumEnvoyConfigSpec)
+	DelCEC(cec *ciliumv2.CiliumEnvoyConfigSpec)
+	AddCCEC(spec *ciliumv2.CiliumEnvoyConfigSpec)
+	DelCCEC(spec *ciliumv2.CiliumEnvoyConfigSpec)
+}
+
 type managerParams struct {
 	cell.In
 
@@ -163,11 +170,13 @@ type managerParams struct {
 
 	Services  allService
 	Endpoints allEndpoint
+
+	MetricsManager CECMetrics
 }
 
 func newCECManager(params managerParams) ciliumEnvoyConfigManager {
 	return newCiliumEnvoyConfigManager(params.Logger, params.PolicyUpdater, params.ServiceManager, params.XdsServer,
-		params.BackendSyncer, params.ResourceParser, params.Config.EnvoyConfigTimeout, params.Services, params.Endpoints)
+		params.BackendSyncer, params.ResourceParser, params.Config.EnvoyConfigTimeout, params.Services, params.Endpoints, params.MetricsManager)
 }
 
 func newPortAllocator(proxy *proxy.Proxy) PortAllocator {

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -90,7 +90,7 @@ func setup(tb testing.TB) *ClusterMeshServicesTestSuite {
 	err = db.RegisterTable(nodeAddrs)
 	require.NoError(tb, err)
 
-	s.svcCache = k8s.NewServiceCache(db, nodeAddrs)
+	s.svcCache = k8s.NewServiceCache(db, nodeAddrs, k8s.NewSVCMetricsNoop())
 
 	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{}, cache.AllocatorConfig{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -63,7 +63,7 @@ func setupEndpointSuite(tb testing.TB) *EndpointSuite {
 
 	s := &EndpointSuite{
 		orchestrator: &fakeTypes.FakeOrchestrator{},
-		repo:         policy.NewPolicyRepository(nil, nil, nil, nil),
+		repo:         policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop()),
 		mgr:          cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{}, cache.AllocatorConfig{}),
 	}
 

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
@@ -24,7 +25,7 @@ func TestEndpointLogFormat(t *testing.T) {
 	setupEndpointSuite(t)
 
 	// Default log format is text
-	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
+	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())}
 	ep := NewTestEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 12345, StateReady)
 
 	_, ok := ep.getLogger().Logger.Formatter.(*logrus.TextFormatter)
@@ -35,7 +36,7 @@ func TestEndpointLogFormat(t *testing.T) {
 	defer func() {
 		logging.SetLogFormat(logging.LogFormatText)
 	}()
-	do = &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
+	do = &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())}
 	ep = NewTestEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 12345, StateReady)
 
 	_, ok = ep.getLogger().Logger.Formatter.(*logrus.JSONFormatter)
@@ -45,7 +46,7 @@ func TestEndpointLogFormat(t *testing.T) {
 func TestPolicyLog(t *testing.T) {
 	setupEndpointSuite(t)
 
-	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
+	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())}
 	ep := NewTestEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 12345, StateReady)
 
 	// Initially nil

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -42,7 +42,7 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 
 	idcache := make(identity.IdentityMap, testfactor)
 	fakeAllocator := testidentity.NewMockIdentityAllocator(idcache)
-	repo := policy.NewPolicyRepository(fakeAllocator.GetIdentityCache(), nil, nil, nil)
+	repo := policy.NewPolicyRepository(fakeAllocator.GetIdentityCache(), nil, nil, nil, api.NewPolicyMetricsNoop())
 
 	defer func() {
 		repoChangeQueue := repo.GetRepositoryChangeQueue()

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -60,7 +60,7 @@ func setupRedirectSuite(tb testing.TB) *RedirectSuite {
 	}
 
 	s.do.idmgr = identitymanager.NewIDManager()
-	s.do.repo = policy.NewPolicyRepository(identityCache, nil, nil, s.do.idmgr)
+	s.do.repo = policy.NewPolicyRepository(identityCache, nil, nil, s.do.idmgr, api.NewPolicyMetricsNoop())
 	s.do.repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 
 	s.rsp = &RedirectSuiteProxy{

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
@@ -60,7 +61,7 @@ type EndpointManagerSuite struct {
 
 func setupEndpointManagerSuite(tb testing.TB) *EndpointManagerSuite {
 	s := &EndpointManagerSuite{}
-	s.repo = policy.NewPolicyRepository(nil, nil, nil, nil)
+	s.repo = policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())
 
 	return s
 }

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -69,7 +69,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 	}, nil, wg)
 	wg.Wait()
 
-	s.repo = policy.NewPolicyRepository(nil, nil, nil, nil)
+	s.repo = policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())
 	s.dnsTCPClient = &dns.Client{Net: "tcp", Timeout: time.Second, SingleInflight: true}
 	s.dnsServer = setupServer(tb)
 	require.NotNil(tb, s.dnsServer, "unable to setup DNS server")

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -86,7 +86,7 @@ var (
 )
 
 func testNewPolicyRepository() *policy.Repository {
-	repo := policy.NewPolicyRepository(nil, nil, nil, nil)
+	repo := policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())
 	repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 	return repo
 }

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -145,10 +145,12 @@ type ServiceCache struct {
 
 	db        *statedb.DB
 	nodeAddrs statedb.Table[datapathTables.NodeAddress]
+
+	metrics SVCMetrics
 }
 
 // NewServiceCache returns a new ServiceCache
-func NewServiceCache(db *statedb.DB, nodeAddrs statedb.Table[datapathTables.NodeAddress]) *ServiceCache {
+func NewServiceCache(db *statedb.DB, nodeAddrs statedb.Table[datapathTables.NodeAddress], svcMetrics SVCMetrics) *ServiceCache {
 	events := make(chan ServiceEvent, option.Config.K8sServiceCacheSize)
 	notifications, emitNotifications, completeNotifications := stream.Multicast[ServiceNotification]()
 
@@ -163,11 +165,12 @@ func NewServiceCache(db *statedb.DB, nodeAddrs statedb.Table[datapathTables.Node
 		notifications:         notifications,
 		emitNotifications:     emitNotifications,
 		completeNotifications: completeNotifications,
+		metrics:               svcMetrics,
 	}
 }
 
-func newServiceCache(lc cell.Lifecycle, cfg ServiceCacheConfig, lns *node.LocalNodeStore, db *statedb.DB, nodeAddrs statedb.Table[datapathTables.NodeAddress]) *ServiceCache {
-	sc := NewServiceCache(db, nodeAddrs)
+func newServiceCache(lc cell.Lifecycle, cfg ServiceCacheConfig, lns *node.LocalNodeStore, db *statedb.DB, nodeAddrs statedb.Table[datapathTables.NodeAddress], metrics SVCMetrics) *ServiceCache {
+	sc := NewServiceCache(db, nodeAddrs, metrics)
 	sc.config = cfg
 
 	var wg sync.WaitGroup
@@ -351,8 +354,10 @@ func (s *ServiceCache) UpdateService(k8sSvc *slim_corev1.Service, swg *lock.Stop
 		if oldService.DeepEqual(newService) {
 			return svcID
 		}
+		s.metrics.DelService(oldService)
 	}
 
+	s.metrics.AddService(newService)
 	s.services[svcID] = newService
 
 	// Check if the corresponding Endpoints resource is already available
@@ -407,6 +412,7 @@ func (s *ServiceCache) DeleteService(k8sSvc *slim_corev1.Service, swg *lock.Stop
 	delete(s.services, svcID)
 
 	if serviceOK {
+		s.metrics.DelService(oldService)
 		swg.Add()
 		s.emitEvent(ServiceEvent{
 			Action:    DeleteService,
@@ -921,4 +927,22 @@ func (s *ServiceCache) updateSelfNodeLabels(labels map[string]string) {
 			})
 		}
 	}
+}
+
+type SVCMetrics interface {
+	AddService(svc *Service)
+	DelService(svc *Service)
+}
+
+type svcMetricsNoop struct {
+}
+
+func (s svcMetricsNoop) AddService(svc *Service) {
+}
+
+func (s svcMetricsNoop) DelService(svc *Service) {
+}
+
+func NewSVCMetricsNoop() SVCMetrics {
+	return &svcMetricsNoop{}
 }

--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -67,7 +67,7 @@ func TestGetUniqueServiceFrontends(t *testing.T) {
 	}
 
 	db, nodeAddrs := newDB(t)
-	cache := NewServiceCache(db, nodeAddrs)
+	cache := NewServiceCache(db, nodeAddrs, NewSVCMetricsNoop())
 
 	cache.services = map[ServiceID]*Service{
 		svcID1: {
@@ -142,7 +142,6 @@ func TestGetUniqueServiceFrontends(t *testing.T) {
 		require.Equal(t, wild_match_ok, frontends.LooseMatch(*frontend))
 	}
 }
-
 func TestServiceCacheEndpoints(t *testing.T) {
 	endpoints := ParseEndpoints(&slim_corev1.Endpoints{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -213,7 +212,7 @@ func testServiceCache(t *testing.T,
 	updateEndpointsCB, deleteEndpointsCB func(svcCache *ServiceCache, swgEps *lock.StoppableWaitGroup)) {
 
 	db, nodeAddrs := newDB(t)
-	svcCache := NewServiceCache(db, nodeAddrs)
+	svcCache := NewServiceCache(db, nodeAddrs, NewSVCMetricsNoop())
 
 	k8sSvc := &slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -378,7 +377,7 @@ func testServiceCache(t *testing.T,
 
 func TestForEachService(t *testing.T) {
 	db, nodeAddrs := newDB(t)
-	svcCache := NewServiceCache(db, nodeAddrs)
+	svcCache := NewServiceCache(db, nodeAddrs, NewSVCMetricsNoop())
 
 	k8sSvc1 := &slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -489,7 +488,7 @@ func TestServiceMutators(t *testing.T) {
 	var m1, m2 int
 
 	db, nodeAddrs := newDB(t)
-	svcCache := NewServiceCache(db, nodeAddrs)
+	svcCache := NewServiceCache(db, nodeAddrs, NewSVCMetricsNoop())
 
 	svcCache.ServiceMutators = append(svcCache.ServiceMutators,
 		func(svc *slim_corev1.Service, svcInfo *Service) { m1++ },
@@ -512,7 +511,7 @@ func TestServiceMutators(t *testing.T) {
 
 func TestExternalServiceMerging(t *testing.T) {
 	db, nodeAddrs := newDB(t)
-	svcCache := NewServiceCache(db, nodeAddrs)
+	svcCache := NewServiceCache(db, nodeAddrs, NewSVCMetricsNoop())
 
 	k8sSvc := &slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -873,7 +872,7 @@ func TestExternalServiceDeletion(t *testing.T) {
 
 	swg := lock.NewStoppableWaitGroup()
 	db, nodeAddrs := newDB(t)
-	svcCache := NewServiceCache(db, nodeAddrs)
+	svcCache := NewServiceCache(db, nodeAddrs, NewSVCMetricsNoop())
 
 	// Store the service with the non-cluster-aware ID
 	svcCache.services[id1] = &svc
@@ -934,7 +933,7 @@ func TestExternalServiceDeletion(t *testing.T) {
 
 func TestClusterServiceMerging(t *testing.T) {
 	db, nodeAddrs := newDB(t)
-	svcCache := NewServiceCache(db, nodeAddrs)
+	svcCache := NewServiceCache(db, nodeAddrs, NewSVCMetricsNoop())
 	swgSvcs := lock.NewStoppableWaitGroup()
 	swgEps := lock.NewStoppableWaitGroup()
 
@@ -1002,7 +1001,7 @@ func TestClusterServiceMerging(t *testing.T) {
 
 func TestNonSharedService(t *testing.T) {
 	db, nodeAddrs := newDB(t)
-	svcCache := NewServiceCache(db, nodeAddrs)
+	svcCache := NewServiceCache(db, nodeAddrs, NewSVCMetricsNoop())
 
 	k8sSvc := &slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -1127,7 +1126,7 @@ func TestServiceCacheWith2EndpointSlice(t *testing.T) {
 	})
 
 	db, nodeAddrs := newDB(t)
-	svcCache := NewServiceCache(db, nodeAddrs)
+	svcCache := NewServiceCache(db, nodeAddrs, NewSVCMetricsNoop())
 
 	k8sSvc := &slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -1346,7 +1345,7 @@ func TestServiceCacheWith2EndpointSliceSameAddress(t *testing.T) {
 	})
 
 	db, nodeAddrs := newDB(t)
-	svcCache := NewServiceCache(db, nodeAddrs)
+	svcCache := NewServiceCache(db, nodeAddrs, NewSVCMetricsNoop())
 
 	k8sSvc := &slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -1562,7 +1561,7 @@ func TestServiceEndpointFiltering(t *testing.T) {
 	db, nodeAddrs := newDB(t)
 	svcCache := newServiceCache(hivetest.Lifecycle(t),
 		ServiceCacheConfig{EnableServiceTopology: true}, store,
-		db, nodeAddrs)
+		db, nodeAddrs, NewSVCMetricsNoop())
 
 	swg := lock.NewStoppableWaitGroup()
 
@@ -1636,7 +1635,7 @@ func BenchmarkCorrelateEndpoints(b *testing.B) {
 	const epsPerSlice = 100
 
 	db, nodeAddrs := newDB(b)
-	cache := NewServiceCache(db, nodeAddrs)
+	cache := NewServiceCache(db, nodeAddrs, NewSVCMetricsNoop())
 
 	var swg lock.StoppableWaitGroup
 	id := ServiceID{Name: "foo", Namespace: "bar"}

--- a/pkg/k8s/watchers/service_test.go
+++ b/pkg/k8s/watchers/service_test.go
@@ -331,7 +331,7 @@ func Test_addK8sSVCs_ClusterIP(t *testing.T) {
 	}
 
 	db, nodeAddrs := newDB(t)
-	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs)
+	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs, k8s.NewSVCMetricsNoop())
 	svcWatcher := &K8sServiceWatcher{
 		k8sSvcCache: k8sSvcCache,
 		svcManager:  svcManager,
@@ -466,7 +466,7 @@ func TestChangeSVCPort(t *testing.T) {
 	}
 
 	db, nodeAddrs := newDB(t)
-	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs)
+	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs, k8s.NewSVCMetricsNoop())
 	svcWatcher := &K8sServiceWatcher{
 		k8sSvcCache: k8sSvcCache,
 		svcManager:  svcManager,
@@ -933,7 +933,7 @@ func Test_addK8sSVCs_NodePort(t *testing.T) {
 	}
 
 	db, nodeAddrs := newDB(t)
-	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs)
+	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs, k8s.NewSVCMetricsNoop())
 	svcWatcher := &K8sServiceWatcher{
 		k8sSvcCache: k8sSvcCache,
 		svcManager:  svcManager,
@@ -1229,7 +1229,7 @@ func Test_addK8sSVCs_GH9576_1(t *testing.T) {
 	}
 
 	db, nodeAddrs := newDB(t)
-	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs)
+	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs, k8s.NewSVCMetricsNoop())
 	svcWatcher := &K8sServiceWatcher{
 		k8sSvcCache: k8sSvcCache,
 		svcManager:  svcManager,
@@ -1518,7 +1518,7 @@ func Test_addK8sSVCs_GH9576_2(t *testing.T) {
 	}
 
 	db, nodeAddrs := newDB(t)
-	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs)
+	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs, k8s.NewSVCMetricsNoop())
 	svcWatcher := &K8sServiceWatcher{
 		k8sSvcCache: k8sSvcCache,
 		svcManager:  svcManager,
@@ -2441,7 +2441,7 @@ func Test_addK8sSVCs_ExternalIPs(t *testing.T) {
 	}
 
 	db, nodeAddrs := newDB(t)
-	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs)
+	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs, k8s.NewSVCMetricsNoop())
 	svcWatcher := &K8sServiceWatcher{
 		k8sSvcCache: k8sSvcCache,
 		svcManager:  svcManager,
@@ -2572,7 +2572,7 @@ func TestHeadless(t *testing.T) {
 	}
 
 	db, nodeAddrs := newDB(t)
-	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs)
+	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs, k8s.NewSVCMetricsNoop())
 	svcWatcher := &K8sServiceWatcher{
 		k8sSvcCache: k8sSvcCache,
 		svcManager:  svcManager,

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/auth"
+	"github.com/cilium/cilium/pkg/ciliumenvoyconfig"
 	"github.com/cilium/cilium/pkg/datapath/garp"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/datapath/types"
@@ -42,6 +43,9 @@ var Cell = cell.Module(
 			return m
 		},
 		func(m Metrics) k8s.SVCMetrics {
+			return m
+		},
+		func(m Metrics) ciliumenvoyconfig.CECMetrics {
 			return m
 		},
 	),

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
+	k8s2 "github.com/cilium/cilium/pkg/policy/k8s"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 )
@@ -46,6 +47,9 @@ var Cell = cell.Module(
 			return m
 		},
 		func(m Metrics) ciliumenvoyconfig.CECMetrics {
+			return m
+		},
+		func(m Metrics) k8s2.CNPMetrics {
 			return m
 		},
 	),

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/dynamicconfig"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/promise"
 )
 
@@ -30,6 +31,9 @@ var Cell = cell.Module(
 	cell.Invoke(updateAgentConfigMetricOnStart),
 	cell.Provide(
 		func(m Metrics) featureMetrics {
+			return m
+		},
+		func(m Metrics) api.PolicyMetrics {
 			return m
 		},
 	),

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/dynamicconfig"
+	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -38,6 +39,9 @@ var Cell = cell.Module(
 			return m
 		},
 		func(m Metrics) redirectpolicy.LRPMetrics {
+			return m
+		},
+		func(m Metrics) k8s.SVCMetrics {
 			return m
 		},
 	),

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/redirectpolicy"
 )
 
 // Cell will retrieve information from all other cells /
@@ -34,6 +35,9 @@ var Cell = cell.Module(
 			return m
 		},
 		func(m Metrics) api.PolicyMetrics {
+			return m
+		},
+		func(m Metrics) redirectpolicy.LRPMetrics {
 			return m
 		},
 	),

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -52,6 +52,7 @@ type Metrics struct {
 	NPDNSIngested               metric.Vec[metric.Counter]
 	NPHTTPIngested              metric.Vec[metric.Counter]
 	NPHTTPHeaderMatchesIngested metric.Vec[metric.Counter]
+	NPOtherL7Ingested           metric.Vec[metric.Counter]
 }
 
 const (
@@ -604,6 +605,24 @@ func NewMetrics(withDefaults bool) Metrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystemNP,
 			Name:      "http_header_matches_policies_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		NPOtherL7Ingested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "Other L7 Policies have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "other_l7_policies_total",
 		}, metric.Labels{
 			{
 				Name: "action", Values: func() metric.Values {

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -60,6 +60,8 @@ type Metrics struct {
 	NPSNIAllowListIngested      metric.Vec[metric.Counter]
 	NPNonDefaultDenyIngested    metric.Vec[metric.Counter]
 	NPLRPIngested               metric.Vec[metric.Counter]
+	NPCNPIngested               metric.Vec[metric.Counter]
+	NPCCNPIngested              metric.Vec[metric.Counter]
 
 	ACLBInternalTrafficPolicyIngested        metric.Vec[metric.Counter]
 	ACLBCiliumEnvoyConfigIngested            metric.Vec[metric.Counter]
@@ -778,6 +780,42 @@ func NewMetrics(withDefaults bool) Metrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystemNP,
 			Name:      "internal_traffic_policy_services_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		NPCNPIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "Cilium Network Policies have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "cilium_network_policies_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		NPCCNPIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "Cilium Clusterwide Network Policies have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "cilium_clusterwide_network_policies_total",
 		}, metric.Labels{
 			{
 				Name: "action", Values: func() metric.Values {

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -60,6 +60,8 @@ type Metrics struct {
 	NPSNIAllowListIngested      metric.Vec[metric.Counter]
 	NPNonDefaultDenyIngested    metric.Vec[metric.Counter]
 	NPLRPIngested               metric.Vec[metric.Counter]
+
+	ACLBInternalTrafficPolicyIngested metric.Vec[metric.Counter]
 }
 
 const (
@@ -756,6 +758,24 @@ func NewMetrics(withDefaults bool) Metrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystemNP,
 			Name:      "local_redirect_policies_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		ACLBInternalTrafficPolicyIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "K8s Services with Internal Traffic Policy have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "internal_traffic_policy_services_total",
 		}, metric.Labels{
 			{
 				Name: "action", Values: func() metric.Values {

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -58,6 +58,7 @@ type Metrics struct {
 	NPMutualAuthIngested        metric.Vec[metric.Counter]
 	NPTLSInspectionIngested     metric.Vec[metric.Counter]
 	NPSNIAllowListIngested      metric.Vec[metric.Counter]
+	NPNonDefaultDenyIngested    metric.Vec[metric.Counter]
 }
 
 const (
@@ -718,6 +719,24 @@ func NewMetrics(withDefaults bool) Metrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystemNP,
 			Name:      "sni_allow_list_policies_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		NPNonDefaultDenyIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "Non DefaultDeny Policies have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "non_defaultdeny_policies_total",
 		}, metric.Labels{
 			{
 				Name: "action", Values: func() metric.Values {

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -47,7 +47,8 @@ type Metrics struct {
 	ACLBExternalEnvoyProxyEnabled    metric.Vec[metric.Gauge]
 	ACLBCiliumNodeConfigEnabled      metric.Gauge
 
-	NPL3Ingested metric.Vec[metric.Counter]
+	NPL3Ingested     metric.Vec[metric.Counter]
+	NPHostNPIngested metric.Vec[metric.Counter]
 }
 
 const (
@@ -528,6 +529,24 @@ func NewMetrics(withDefaults bool) Metrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystemNP,
 			Name:      "l3_policies_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		NPHostNPIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "Host Network Policies have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "host_network_policies_total",
 		}, metric.Labels{
 			{
 				Name: "action", Values: func() metric.Values {

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -59,6 +59,7 @@ type Metrics struct {
 	NPTLSInspectionIngested     metric.Vec[metric.Counter]
 	NPSNIAllowListIngested      metric.Vec[metric.Counter]
 	NPNonDefaultDenyIngested    metric.Vec[metric.Counter]
+	NPLRPIngested               metric.Vec[metric.Counter]
 }
 
 const (
@@ -737,6 +738,24 @@ func NewMetrics(withDefaults bool) Metrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystemNP,
 			Name:      "non_defaultdeny_policies_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		NPLRPIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "Local Redirect Policies have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "local_redirect_policies_total",
 		}, metric.Labels{
 			{
 				Name: "action", Values: func() metric.Values {

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -46,6 +46,8 @@ type Metrics struct {
 	ACLBL2PodAnnouncementEnabled     metric.Gauge
 	ACLBExternalEnvoyProxyEnabled    metric.Vec[metric.Gauge]
 	ACLBCiliumNodeConfigEnabled      metric.Gauge
+
+	NPL3Ingested metric.Vec[metric.Counter]
 }
 
 const (
@@ -80,6 +82,8 @@ const (
 
 	advConnExtEnvoyProxyStandalone = "standalone"
 	advConnExtEnvoyProxyEmbedded   = "embedded"
+	actionAdd                      = "add"
+	actionDel                      = "delete"
 )
 
 var (
@@ -167,6 +171,10 @@ var (
 	defaultExternalEnvoyProxyModes = []string{
 		advConnExtEnvoyProxyStandalone,
 		advConnExtEnvoyProxyEmbedded,
+	}
+	defaultActions = []string{
+		actionAdd,
+		actionDel,
 	}
 )
 
@@ -513,6 +521,24 @@ func NewMetrics(withDefaults bool) Metrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystemACLB,
 			Name:      "cilium_node_config_enabled",
+		}),
+
+		NPL3Ingested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "Layer 3 and Layer 4 policies have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "l3_policies_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
 		}),
 	}
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -54,6 +54,7 @@ type Metrics struct {
 	NPHTTPHeaderMatchesIngested metric.Vec[metric.Counter]
 	NPOtherL7Ingested           metric.Vec[metric.Counter]
 	NPDenyPoliciesIngested      metric.Vec[metric.Counter]
+	NPIngressCIDRGroupIngested  metric.Vec[metric.Counter]
 }
 
 const (
@@ -642,6 +643,24 @@ func NewMetrics(withDefaults bool) Metrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystemNP,
 			Name:      "deny_policies_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		NPIngressCIDRGroupIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "Ingress CIDR Group Policies have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "ingress_cidr_group_policies_total",
 		}, metric.Labels{
 			{
 				Name: "action", Values: func() metric.Values {

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -50,6 +50,7 @@ type Metrics struct {
 	NPL3Ingested                metric.Vec[metric.Counter]
 	NPHostNPIngested            metric.Vec[metric.Counter]
 	NPDNSIngested               metric.Vec[metric.Counter]
+	NPToFQDNsIngested           metric.Vec[metric.Counter]
 	NPHTTPIngested              metric.Vec[metric.Counter]
 	NPHTTPHeaderMatchesIngested metric.Vec[metric.Counter]
 	NPOtherL7Ingested           metric.Vec[metric.Counter]
@@ -582,6 +583,24 @@ func NewMetrics(withDefaults bool) Metrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystemNP,
 			Name:      "dns_policies_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		NPToFQDNsIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "ToFQDNs Policies have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "fqdn_policies_total",
 		}, metric.Labels{
 			{
 				Name: "action", Values: func() metric.Values {

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -47,9 +47,11 @@ type Metrics struct {
 	ACLBExternalEnvoyProxyEnabled    metric.Vec[metric.Gauge]
 	ACLBCiliumNodeConfigEnabled      metric.Gauge
 
-	NPL3Ingested     metric.Vec[metric.Counter]
-	NPHostNPIngested metric.Vec[metric.Counter]
-	NPDNSIngested    metric.Vec[metric.Counter]
+	NPL3Ingested                metric.Vec[metric.Counter]
+	NPHostNPIngested            metric.Vec[metric.Counter]
+	NPDNSIngested               metric.Vec[metric.Counter]
+	NPHTTPIngested              metric.Vec[metric.Counter]
+	NPHTTPHeaderMatchesIngested metric.Vec[metric.Counter]
 }
 
 const (
@@ -566,6 +568,42 @@ func NewMetrics(withDefaults bool) Metrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystemNP,
 			Name:      "dns_policies_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		NPHTTPIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "HTTP/GRPC Policies have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "http_policies_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		NPHTTPHeaderMatchesIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "HTTP HeaderMatches Policies have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "http_header_matches_policies_total",
 		}, metric.Labels{
 			{
 				Name: "action", Values: func() metric.Values {

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -61,7 +61,9 @@ type Metrics struct {
 	NPNonDefaultDenyIngested    metric.Vec[metric.Counter]
 	NPLRPIngested               metric.Vec[metric.Counter]
 
-	ACLBInternalTrafficPolicyIngested metric.Vec[metric.Counter]
+	ACLBInternalTrafficPolicyIngested        metric.Vec[metric.Counter]
+	ACLBCiliumEnvoyConfigIngested            metric.Vec[metric.Counter]
+	ACLBCiliumClusterwideEnvoyConfigIngested metric.Vec[metric.Counter]
 }
 
 const (
@@ -776,6 +778,42 @@ func NewMetrics(withDefaults bool) Metrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystemNP,
 			Name:      "internal_traffic_policy_services_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		ACLBCiliumEnvoyConfigIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "Cilium Envoy Config have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "cilium_envoy_config_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		ACLBCiliumClusterwideEnvoyConfigIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "Cilium Clusterwide Envoy Config have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "cilium_clusterwide_envoy_config_total",
 		}, metric.Labels{
 			{
 				Name: "action", Values: func() metric.Values {

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -56,6 +56,8 @@ type Metrics struct {
 	NPDenyPoliciesIngested      metric.Vec[metric.Counter]
 	NPIngressCIDRGroupIngested  metric.Vec[metric.Counter]
 	NPMutualAuthIngested        metric.Vec[metric.Counter]
+	NPTLSInspectionIngested     metric.Vec[metric.Counter]
+	NPSNIAllowListIngested      metric.Vec[metric.Counter]
 }
 
 const (
@@ -680,6 +682,42 @@ func NewMetrics(withDefaults bool) Metrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystemNP,
 			Name:      "mutual_auth_policies_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		NPTLSInspectionIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "TLS Inspection Policies have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "tls_inspection_policies_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		NPSNIAllowListIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "SNI Allow List Policies have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "sni_allow_list_policies_total",
 		}, metric.Labels{
 			{
 				Name: "action", Values: func() metric.Values {

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -55,6 +55,7 @@ type Metrics struct {
 	NPOtherL7Ingested           metric.Vec[metric.Counter]
 	NPDenyPoliciesIngested      metric.Vec[metric.Counter]
 	NPIngressCIDRGroupIngested  metric.Vec[metric.Counter]
+	NPMutualAuthIngested        metric.Vec[metric.Counter]
 }
 
 const (
@@ -661,6 +662,24 @@ func NewMetrics(withDefaults bool) Metrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystemNP,
 			Name:      "ingress_cidr_group_policies_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		NPMutualAuthIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "Mutual Auth Policies have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "mutual_auth_policies_total",
 		}, metric.Labels{
 			{
 				Name: "action", Values: func() metric.Values {

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -49,6 +49,7 @@ type Metrics struct {
 
 	NPL3Ingested     metric.Vec[metric.Counter]
 	NPHostNPIngested metric.Vec[metric.Counter]
+	NPDNSIngested    metric.Vec[metric.Counter]
 }
 
 const (
@@ -547,6 +548,24 @@ func NewMetrics(withDefaults bool) Metrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystemNP,
 			Name:      "host_network_policies_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		NPDNSIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "DNS Policies have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "dns_policies_total",
 		}, metric.Labels{
 			{
 				Name: "action", Values: func() metric.Values {

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -53,6 +53,7 @@ type Metrics struct {
 	NPHTTPIngested              metric.Vec[metric.Counter]
 	NPHTTPHeaderMatchesIngested metric.Vec[metric.Counter]
 	NPOtherL7Ingested           metric.Vec[metric.Counter]
+	NPDenyPoliciesIngested      metric.Vec[metric.Counter]
 }
 
 const (
@@ -623,6 +624,24 @@ func NewMetrics(withDefaults bool) Metrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystemNP,
 			Name:      "other_l7_policies_total",
+		}, metric.Labels{
+			{
+				Name: "action", Values: func() metric.Values {
+					if !withDefaults {
+						return nil
+					}
+					return metric.NewValues(
+						defaultActions...,
+					)
+				}(),
+			},
+		}),
+
+		NPDenyPoliciesIngested: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Help:      "Deny Policies have been ingested since the agent started",
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemNP,
+			Name:      "deny_policies_total",
 		}, metric.Labels{
 			{
 				Name: "action", Values: func() metric.Values {

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -789,7 +789,7 @@ func TestUpdateKubeProxyReplacement(t *testing.T) {
 	}
 }
 
-func TestUpdateStandaloneNSLB(t *testing.T) {
+func TestUpdateNodePortConfig(t *testing.T) {
 	type testCase struct {
 		name             string
 		portMode         string
@@ -805,7 +805,7 @@ func TestUpdateStandaloneNSLB(t *testing.T) {
 		for _, algoMode := range defaultNodePortModeAlgorithms {
 			for _, aclMode := range defaultNodePortModeAccelerations {
 				tests = append(tests, testCase{
-					name:             fmt.Sprintf("NSLB %s - %s - %s", portMode, algoMode, aclMode),
+					name:             fmt.Sprintf("NodePortConfig %s - %s - %s", portMode, algoMode, aclMode),
 					portMode:         portMode,
 					algoMode:         algoMode,
 					accelerationMode: aclMode,
@@ -817,10 +817,6 @@ func TestUpdateStandaloneNSLB(t *testing.T) {
 			}
 		}
 	}
-	tests = append(tests, testCase{
-		name:             "NSLB disabled",
-		accelerationMode: option.NodePortAccelerationDisabled,
-	})
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/metrics/features/misc.go
+++ b/pkg/metrics/features/misc.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"github.com/cilium/cilium/pkg/redirectpolicy"
+)
+
+func (m Metrics) AddLRPConfig(_ *redirectpolicy.LRPConfig) {
+	m.NPLRPIngested.WithLabelValues(actionAdd).Inc()
+}
+
+func (m Metrics) DelLRPConfig(_ *redirectpolicy.LRPConfig) {
+	m.NPLRPIngested.WithLabelValues(actionDel).Inc()
+}

--- a/pkg/metrics/features/misc.go
+++ b/pkg/metrics/features/misc.go
@@ -45,3 +45,19 @@ func (m Metrics) AddCCEC(_ *v2.CiliumEnvoyConfigSpec) {
 func (m Metrics) DelCCEC(_ *v2.CiliumEnvoyConfigSpec) {
 	m.ACLBCiliumClusterwideEnvoyConfigIngested.WithLabelValues(actionDel).Inc()
 }
+
+func (m Metrics) AddCNP(_ *v2.CiliumNetworkPolicy) {
+	m.NPCNPIngested.WithLabelValues(actionAdd).Inc()
+}
+
+func (m Metrics) DelCNP(_ *v2.CiliumNetworkPolicy) {
+	m.NPCNPIngested.WithLabelValues(actionDel).Inc()
+}
+
+func (m Metrics) AddCCNP(_ *v2.CiliumNetworkPolicy) {
+	m.NPCCNPIngested.WithLabelValues(actionAdd).Inc()
+}
+
+func (m Metrics) DelCCNP(_ *v2.CiliumNetworkPolicy) {
+	m.NPCCNPIngested.WithLabelValues(actionDel).Inc()
+}

--- a/pkg/metrics/features/misc.go
+++ b/pkg/metrics/features/misc.go
@@ -4,6 +4,8 @@
 package features
 
 import (
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 )
 
@@ -13,4 +15,16 @@ func (m Metrics) AddLRPConfig(_ *redirectpolicy.LRPConfig) {
 
 func (m Metrics) DelLRPConfig(_ *redirectpolicy.LRPConfig) {
 	m.NPLRPIngested.WithLabelValues(actionDel).Inc()
+}
+
+func (m Metrics) AddService(svc *k8s.Service) {
+	if svc.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal {
+		m.ACLBInternalTrafficPolicyIngested.WithLabelValues(actionAdd).Inc()
+	}
+}
+
+func (m Metrics) DelService(svc *k8s.Service) {
+	if svc.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal {
+		m.ACLBInternalTrafficPolicyIngested.WithLabelValues(actionDel).Inc()
+	}
 }

--- a/pkg/metrics/features/misc.go
+++ b/pkg/metrics/features/misc.go
@@ -5,6 +5,7 @@ package features
 
 import (
 	"github.com/cilium/cilium/pkg/k8s"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 )
@@ -27,4 +28,20 @@ func (m Metrics) DelService(svc *k8s.Service) {
 	if svc.IntTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal {
 		m.ACLBInternalTrafficPolicyIngested.WithLabelValues(actionDel).Inc()
 	}
+}
+
+func (m Metrics) AddCEC(_ *v2.CiliumEnvoyConfigSpec) {
+	m.ACLBCiliumEnvoyConfigIngested.WithLabelValues(actionAdd).Inc()
+}
+
+func (m Metrics) DelCEC(_ *v2.CiliumEnvoyConfigSpec) {
+	m.ACLBCiliumEnvoyConfigIngested.WithLabelValues(actionDel).Inc()
+}
+
+func (m Metrics) AddCCEC(_ *v2.CiliumEnvoyConfigSpec) {
+	m.ACLBCiliumClusterwideEnvoyConfigIngested.WithLabelValues(actionAdd).Inc()
+}
+
+func (m Metrics) DelCCEC(_ *v2.CiliumEnvoyConfigSpec) {
+	m.ACLBCiliumClusterwideEnvoyConfigIngested.WithLabelValues(actionDel).Inc()
 }

--- a/pkg/metrics/features/misc_test.go
+++ b/pkg/metrics/features/misc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/pkg/k8s"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 )
@@ -100,6 +101,96 @@ func TestInternalTrafficPolicy(t *testing.T) {
 
 			assert.Equalf(t, tt.want.wantMetrics.aclbInternalTrafficPolicyIngested, metrics.ACLBInternalTrafficPolicyIngested.WithLabelValues(actionAdd).Get(), "ACLBInternalTrafficPolicyIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.aclbInternalTrafficPolicyIngested, metrics.ACLBInternalTrafficPolicyIngested.WithLabelValues(actionDel).Get(), "ACLBInternalTrafficPolicyIngested different")
+
+		})
+	}
+}
+
+func TestCiliumEnvoyConfig(t *testing.T) {
+	type args struct {
+		cec ciliumv2.CiliumEnvoyConfigSpec
+	}
+	type metrics struct {
+		aclbCiliumEnvoyConfigIngested float64
+	}
+	type wanted struct {
+		wantMetrics metrics
+	}
+	tests := []struct {
+		name string
+		args args
+		want wanted
+	}{
+		{
+			name: "CiliumEnvoyConfig",
+			args: args{
+				cec: ciliumv2.CiliumEnvoyConfigSpec{},
+			},
+			want: wanted{
+				wantMetrics: metrics{
+					aclbCiliumEnvoyConfigIngested: 1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			metrics := NewMetrics(true)
+			metrics.AddCEC(&tt.args.cec)
+
+			assert.Equalf(t, tt.want.wantMetrics.aclbCiliumEnvoyConfigIngested, metrics.ACLBCiliumEnvoyConfigIngested.WithLabelValues(actionAdd).Get(), "ACLBCiliumEnvoyConfigIngested different")
+			assert.Equalf(t, float64(0), metrics.ACLBCiliumEnvoyConfigIngested.WithLabelValues(actionDel).Get(), "ACLBCiliumEnvoyConfigIngested different")
+
+			metrics.DelCEC(&tt.args.cec)
+
+			assert.Equalf(t, tt.want.wantMetrics.aclbCiliumEnvoyConfigIngested, metrics.ACLBCiliumEnvoyConfigIngested.WithLabelValues(actionAdd).Get(), "ACLBCiliumEnvoyConfigIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.aclbCiliumEnvoyConfigIngested, metrics.ACLBCiliumEnvoyConfigIngested.WithLabelValues(actionDel).Get(), "ACLBCiliumEnvoyConfigIngested different")
+
+		})
+	}
+}
+
+func TestCiliumClusterwideEnvoyConfig(t *testing.T) {
+	type args struct {
+		cec ciliumv2.CiliumEnvoyConfigSpec
+	}
+	type metrics struct {
+		aclbCiliumClusterwideEnvoyConfigIngested float64
+	}
+	type wanted struct {
+		wantMetrics metrics
+	}
+	tests := []struct {
+		name string
+		args args
+		want wanted
+	}{
+		{
+			name: "CiliumClusterwideEnvoyConfig",
+			args: args{
+				cec: ciliumv2.CiliumEnvoyConfigSpec{},
+			},
+			want: wanted{
+				wantMetrics: metrics{
+					aclbCiliumClusterwideEnvoyConfigIngested: 1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			metrics := NewMetrics(true)
+			metrics.AddCCEC(&tt.args.cec)
+
+			assert.Equalf(t, tt.want.wantMetrics.aclbCiliumClusterwideEnvoyConfigIngested, metrics.ACLBCiliumClusterwideEnvoyConfigIngested.WithLabelValues(actionAdd).Get(), "ACLBCiliumClusterwideEnvoyConfigIngested different")
+			assert.Equalf(t, float64(0), metrics.ACLBCiliumClusterwideEnvoyConfigIngested.WithLabelValues(actionDel).Get(), "ACLBCiliumClusterwideEnvoyConfigIngested different")
+
+			metrics.DelCCEC(&tt.args.cec)
+
+			assert.Equalf(t, tt.want.wantMetrics.aclbCiliumClusterwideEnvoyConfigIngested, metrics.ACLBCiliumClusterwideEnvoyConfigIngested.WithLabelValues(actionAdd).Get(), "ACLBCiliumClusterwideEnvoyConfigIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.aclbCiliumClusterwideEnvoyConfigIngested, metrics.ACLBCiliumClusterwideEnvoyConfigIngested.WithLabelValues(actionDel).Get(), "ACLBCiliumClusterwideEnvoyConfigIngested different")
 
 		})
 	}

--- a/pkg/metrics/features/misc_test.go
+++ b/pkg/metrics/features/misc_test.go
@@ -195,3 +195,93 @@ func TestCiliumClusterwideEnvoyConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestCNP(t *testing.T) {
+	type args struct {
+		cnp ciliumv2.CiliumNetworkPolicy
+	}
+	type metrics struct {
+		npCNPIngested float64
+	}
+	type wanted struct {
+		wantMetrics metrics
+	}
+	tests := []struct {
+		name string
+		args args
+		want wanted
+	}{
+		{
+			name: "CNP",
+			args: args{
+				cnp: ciliumv2.CiliumNetworkPolicy{},
+			},
+			want: wanted{
+				wantMetrics: metrics{
+					npCNPIngested: 1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			metrics := NewMetrics(true)
+			metrics.AddCNP(&tt.args.cnp)
+
+			assert.Equalf(t, tt.want.wantMetrics.npCNPIngested, metrics.NPCNPIngested.WithLabelValues(actionAdd).Get(), "NPCNPIngested different")
+			assert.Equalf(t, float64(0), metrics.NPCNPIngested.WithLabelValues(actionDel).Get(), "NPCNPIngested different")
+
+			metrics.DelCNP(&tt.args.cnp)
+
+			assert.Equalf(t, tt.want.wantMetrics.npCNPIngested, metrics.NPCNPIngested.WithLabelValues(actionAdd).Get(), "NPCNPIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npCNPIngested, metrics.NPCNPIngested.WithLabelValues(actionDel).Get(), "NPCNPIngested different")
+
+		})
+	}
+}
+
+func TestCCNP(t *testing.T) {
+	type args struct {
+		cnp ciliumv2.CiliumNetworkPolicy
+	}
+	type metrics struct {
+		npCCNPIngested float64
+	}
+	type wanted struct {
+		wantMetrics metrics
+	}
+	tests := []struct {
+		name string
+		args args
+		want wanted
+	}{
+		{
+			name: "CCNP",
+			args: args{
+				cnp: ciliumv2.CiliumNetworkPolicy{},
+			},
+			want: wanted{
+				wantMetrics: metrics{
+					npCCNPIngested: 1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			metrics := NewMetrics(true)
+			metrics.AddCCNP(&tt.args.cnp)
+
+			assert.Equalf(t, tt.want.wantMetrics.npCCNPIngested, metrics.NPCCNPIngested.WithLabelValues(actionAdd).Get(), "NPCCNPIngested different")
+			assert.Equalf(t, float64(0), metrics.NPCCNPIngested.WithLabelValues(actionDel).Get(), "NPCCNPIngested different")
+
+			metrics.DelCCNP(&tt.args.cnp)
+
+			assert.Equalf(t, tt.want.wantMetrics.npCCNPIngested, metrics.NPCCNPIngested.WithLabelValues(actionAdd).Get(), "NPCCNPIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npCCNPIngested, metrics.NPCCNPIngested.WithLabelValues(actionDel).Get(), "NPCCNPIngested different")
+
+		})
+	}
+}

--- a/pkg/metrics/features/misc_test.go
+++ b/pkg/metrics/features/misc_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/redirectpolicy"
+)
+
+func TestLRPConfig(t *testing.T) {
+	type args struct {
+		lrpConfig redirectpolicy.LRPConfig
+	}
+	type metrics struct {
+		npLRPConfigIngested float64
+	}
+	type wanted struct {
+		wantMetrics metrics
+	}
+	tests := []struct {
+		name string
+		args args
+		want wanted
+	}{
+		{
+			name: "LRP Config",
+			args: args{
+				lrpConfig: redirectpolicy.LRPConfig{},
+			},
+			want: wanted{
+				wantMetrics: metrics{
+					npLRPConfigIngested: 1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			metrics := NewMetrics(true)
+			metrics.AddLRPConfig(&tt.args.lrpConfig)
+
+			assert.Equalf(t, tt.want.wantMetrics.npLRPConfigIngested, metrics.NPLRPIngested.WithLabelValues(actionAdd).Get(), "NPLRPIngested different")
+			assert.Equalf(t, float64(0), metrics.NPLRPIngested.WithLabelValues(actionDel).Get(), "NPLRPIngested different")
+
+			metrics.DelLRPConfig(&tt.args.lrpConfig)
+
+			assert.Equalf(t, tt.want.wantMetrics.npLRPConfigIngested, metrics.NPLRPIngested.WithLabelValues(actionAdd).Get(), "NPLRPIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npLRPConfigIngested, metrics.NPLRPIngested.WithLabelValues(actionDel).Get(), "NPLRPIngested different")
+
+		})
+	}
+}

--- a/pkg/metrics/features/policy.go
+++ b/pkg/metrics/features/policy.go
@@ -17,6 +17,8 @@ type RuleFeatures struct {
 	Deny              bool
 	IngressCIDRGroup  bool
 	MutualAuth        bool
+	TLSInspection     bool
+	SNIAllowList      bool
 }
 
 func (m Metrics) AddRule(r api.Rule) {
@@ -48,6 +50,12 @@ func (m Metrics) AddRule(r api.Rule) {
 	}
 	if rf.MutualAuth {
 		m.NPMutualAuthIngested.WithLabelValues(actionAdd).Inc()
+	}
+	if rf.TLSInspection {
+		m.NPTLSInspectionIngested.WithLabelValues(actionAdd).Inc()
+	}
+	if rf.SNIAllowList {
+		m.NPSNIAllowListIngested.WithLabelValues(actionAdd).Inc()
 	}
 }
 
@@ -81,6 +89,12 @@ func (m Metrics) DelRule(r api.Rule) {
 	if rf.MutualAuth {
 		m.NPMutualAuthIngested.WithLabelValues(actionDel).Inc()
 	}
+	if rf.TLSInspection {
+		m.NPTLSInspectionIngested.WithLabelValues(actionDel).Inc()
+	}
+	if rf.SNIAllowList {
+		m.NPSNIAllowListIngested.WithLabelValues(actionDel).Inc()
+	}
 }
 
 func (rf *RuleFeatures) allFeaturesIngressCommon() bool {
@@ -92,7 +106,7 @@ func (rf *RuleFeatures) allFeaturesEgressCommon() bool {
 }
 
 func (rf *RuleFeatures) allFeaturesPortRules() bool {
-	return rf.DNS && rf.HTTP && rf.HTTPHeaderMatches && rf.OtherL7
+	return rf.DNS && rf.HTTP && rf.HTTPHeaderMatches && rf.OtherL7 && rf.TLSInspection && rf.SNIAllowList
 }
 
 func ruleTypeIngressCommon(rf *RuleFeatures, i api.IngressCommonRule) {
@@ -139,6 +153,12 @@ func ruleTypePortRules(rf *RuleFeatures, portRules api.PortRules) {
 		}
 		if p.Rules != nil && (len(p.Rules.L7) > 0 || len(p.Rules.Kafka) > 0) {
 			rf.OtherL7 = true
+		}
+		if !rf.TLSInspection && (p.OriginatingTLS != nil || p.TerminatingTLS != nil) {
+			rf.TLSInspection = true
+		}
+		if !rf.SNIAllowList && len(p.ServerNames) != 0 {
+			rf.SNIAllowList = true
 		}
 		if rf.allFeaturesPortRules() {
 			break

--- a/pkg/metrics/features/policy.go
+++ b/pkg/metrics/features/policy.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+type RuleFeatures struct {
+	L3 bool
+}
+
+func (m Metrics) AddRule(r api.Rule) {
+	rf := ruleType(r)
+
+	if rf.L3 {
+		m.NPL3Ingested.WithLabelValues(actionAdd).Inc()
+	}
+}
+
+func (m Metrics) DelRule(r api.Rule) {
+	rf := ruleType(r)
+
+	if rf.L3 {
+		m.NPL3Ingested.WithLabelValues(actionDel).Inc()
+	}
+}
+
+func (rf *RuleFeatures) allFeaturesIngressCommon() bool {
+	return rf.L3
+}
+
+func (rf *RuleFeatures) allFeaturesEgressCommon() bool {
+	return rf.L3
+}
+
+func ruleTypeIngressCommon(rf *RuleFeatures, i api.IngressCommonRule) {
+	if len(i.FromNodes) > 0 {
+		rf.L3 = true
+	}
+	for _, cidrRuleSet := range i.FromCIDRSet {
+		if cidrRuleSet.CIDRGroupRef != "" {
+			rf.L3 = true
+		}
+	}
+	if !rf.L3 && i.IsL3() {
+		rf.L3 = true
+	}
+}
+
+func ruleTypeEgressCommon(rf *RuleFeatures, e api.EgressCommonRule) {
+	if len(e.ToNodes) > 0 {
+		rf.L3 = true
+	}
+
+	if !rf.L3 && e.IsL3() {
+		rf.L3 = true
+	}
+}
+
+func ruleType(r api.Rule) RuleFeatures {
+
+	var rf RuleFeatures
+
+	for _, i := range r.Ingress {
+		ruleTypeIngressCommon(&rf, i.IngressCommonRule)
+		if rf.allFeaturesIngressCommon() {
+			break
+		}
+	}
+
+	if !(rf.allFeaturesIngressCommon()) {
+		for _, i := range r.IngressDeny {
+			ruleTypeIngressCommon(&rf, i.IngressCommonRule)
+			if rf.allFeaturesIngressCommon() {
+				break
+			}
+		}
+	}
+
+	if !(rf.allFeaturesEgressCommon()) {
+		for _, e := range r.Egress {
+			ruleTypeEgressCommon(&rf, e.EgressCommonRule)
+			if rf.allFeaturesEgressCommon() {
+				break
+			}
+		}
+	}
+
+	if !(rf.allFeaturesEgressCommon()) {
+		for _, e := range r.EgressDeny {
+			ruleTypeEgressCommon(&rf, e.EgressCommonRule)
+			if rf.allFeaturesEgressCommon() {
+				break
+			}
+		}
+	}
+	return rf
+}

--- a/pkg/metrics/features/policy.go
+++ b/pkg/metrics/features/policy.go
@@ -19,6 +19,7 @@ type RuleFeatures struct {
 	MutualAuth        bool
 	TLSInspection     bool
 	SNIAllowList      bool
+	NonDefaultDeny    bool
 }
 
 func (m Metrics) AddRule(r api.Rule) {
@@ -57,6 +58,9 @@ func (m Metrics) AddRule(r api.Rule) {
 	if rf.SNIAllowList {
 		m.NPSNIAllowListIngested.WithLabelValues(actionAdd).Inc()
 	}
+	if rf.NonDefaultDeny {
+		m.NPNonDefaultDenyIngested.WithLabelValues(actionAdd).Inc()
+	}
 }
 
 func (m Metrics) DelRule(r api.Rule) {
@@ -94,6 +98,9 @@ func (m Metrics) DelRule(r api.Rule) {
 	}
 	if rf.SNIAllowList {
 		m.NPSNIAllowListIngested.WithLabelValues(actionDel).Inc()
+	}
+	if rf.NonDefaultDeny {
+		m.NPNonDefaultDenyIngested.WithLabelValues(actionDel).Inc()
 	}
 }
 
@@ -169,6 +176,10 @@ func ruleTypePortRules(rf *RuleFeatures, portRules api.PortRules) {
 func ruleType(r api.Rule) RuleFeatures {
 
 	var rf RuleFeatures
+
+	rf.NonDefaultDeny =
+		r.EnableDefaultDeny.Ingress != nil && *r.EnableDefaultDeny.Ingress ||
+			r.EnableDefaultDeny.Egress != nil && *r.EnableDefaultDeny.Egress
 
 	for _, i := range r.Ingress {
 		ruleTypeIngressCommon(&rf, i.IngressCommonRule)

--- a/pkg/metrics/features/policy.go
+++ b/pkg/metrics/features/policy.go
@@ -15,6 +15,7 @@ type RuleFeatures struct {
 	HTTPHeaderMatches bool
 	OtherL7           bool
 	Deny              bool
+	IngressCIDRGroup  bool
 }
 
 func (m Metrics) AddRule(r api.Rule) {
@@ -40,6 +41,9 @@ func (m Metrics) AddRule(r api.Rule) {
 	}
 	if rf.Deny {
 		m.NPDenyPoliciesIngested.WithLabelValues(actionAdd).Inc()
+	}
+	if rf.IngressCIDRGroup {
+		m.NPIngressCIDRGroupIngested.WithLabelValues(actionAdd).Inc()
 	}
 }
 
@@ -67,10 +71,13 @@ func (m Metrics) DelRule(r api.Rule) {
 	if rf.Deny {
 		m.NPDenyPoliciesIngested.WithLabelValues(actionDel).Inc()
 	}
+	if rf.IngressCIDRGroup {
+		m.NPIngressCIDRGroupIngested.WithLabelValues(actionDel).Inc()
+	}
 }
 
 func (rf *RuleFeatures) allFeaturesIngressCommon() bool {
-	return rf.L3 && rf.Host
+	return rf.L3 && rf.Host && rf.IngressCIDRGroup
 }
 
 func (rf *RuleFeatures) allFeaturesEgressCommon() bool {
@@ -88,6 +95,7 @@ func ruleTypeIngressCommon(rf *RuleFeatures, i api.IngressCommonRule) {
 	}
 	for _, cidrRuleSet := range i.FromCIDRSet {
 		if cidrRuleSet.CIDRGroupRef != "" {
+			rf.IngressCIDRGroup = true
 			rf.L3 = true
 		}
 	}

--- a/pkg/metrics/features/policy_test.go
+++ b/pkg/metrics/features/policy_test.go
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package features
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+func Test_ruleType(t *testing.T) {
+	type args struct {
+		r api.Rule
+	}
+	type metrics struct {
+		npL3Ingested float64
+	}
+	type wanted struct {
+		wantRF      RuleFeatures
+		wantMetrics metrics
+	}
+	tests := []struct {
+		name string
+		args args
+		want wanted
+	}{
+		{
+			name: "L3 from FromEndpoints",
+			args: args{
+				r: api.Rule{
+					Ingress: []api.IngressRule{
+						{
+							IngressCommonRule: api.IngressCommonRule{
+								FromEndpoints: []api.EndpointSelector{
+									{},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: wanted{
+				wantRF: RuleFeatures{
+					L3: true,
+				},
+				wantMetrics: metrics{
+					npL3Ingested: 1,
+				},
+			},
+		},
+		{
+			name: "L3 from FromCIDRSet with CIDRGroupRef",
+			args: args{
+				r: api.Rule{
+					Ingress: []api.IngressRule{
+						{
+							IngressCommonRule: api.IngressCommonRule{
+								FromCIDRSet: []api.CIDRRule{
+									{CIDRGroupRef: "some-group-ref"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: wanted{
+				wantRF: RuleFeatures{
+					L3: true,
+				},
+				wantMetrics: metrics{
+					npL3Ingested: 1,
+				},
+			},
+		},
+		{
+			name: "L3 IngressDeny from FromCIDRSet with CIDRGroupRef",
+			args: args{
+				r: api.Rule{
+					IngressDeny: []api.IngressDenyRule{
+						{
+							IngressCommonRule: api.IngressCommonRule{
+								FromCIDRSet: []api.CIDRRule{
+									{CIDRGroupRef: "some-group-ref"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: wanted{
+				wantRF: RuleFeatures{
+					L3: true,
+				},
+				wantMetrics: metrics{
+					npL3Ingested: 1,
+				},
+			},
+		},
+		{
+			name: "L3 from Ingress ToNodes",
+			args: args{
+				r: api.Rule{
+					Ingress: []api.IngressRule{
+						{
+							IngressCommonRule: api.IngressCommonRule{
+								FromNodes: []api.EndpointSelector{
+									{},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: wanted{
+				wantRF: RuleFeatures{
+					L3: true,
+				},
+				wantMetrics: metrics{
+					npL3Ingested: 1,
+				},
+			},
+		},
+		{
+			name: "L3 from Egress ToNodes",
+			args: args{
+				r: api.Rule{
+					Egress: []api.EgressRule{
+						{
+							EgressCommonRule: api.EgressCommonRule{
+								ToNodes: []api.EndpointSelector{
+									{},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: wanted{
+				wantRF: RuleFeatures{
+					L3: true,
+				},
+				wantMetrics: metrics{
+					npL3Ingested: 1,
+				},
+			},
+		},
+		{
+			name: "No L3 rule present",
+			args: args{
+				r: api.Rule{
+					Ingress: []api.IngressRule{
+						{
+							IngressCommonRule: api.IngressCommonRule{},
+						},
+					},
+					Egress: []api.EgressRule{
+						{
+							EgressCommonRule: api.EgressCommonRule{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "L3 from IngressDeny FromNodes",
+			args: args{
+				r: api.Rule{
+					IngressDeny: []api.IngressDenyRule{
+						{
+							IngressCommonRule: api.IngressCommonRule{
+								FromNodes: []api.EndpointSelector{
+									{},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: wanted{
+				wantRF: RuleFeatures{
+					L3: true,
+				},
+				wantMetrics: metrics{
+					npL3Ingested: 1,
+				},
+			},
+		},
+		{
+			name: "L3 from IngressDeny IsL3",
+			args: args{
+				r: api.Rule{
+					IngressDeny: []api.IngressDenyRule{
+						{
+							IngressCommonRule: api.IngressCommonRule{
+								FromCIDR: []api.CIDR{"192.168.0.0/24"},
+							},
+						},
+					},
+				},
+			},
+			want: wanted{
+				wantRF: RuleFeatures{
+					L3: true,
+				},
+				wantMetrics: metrics{
+					npL3Ingested: 1,
+				},
+			},
+		},
+		{
+			name: "L3 from EgressDeny IsL3",
+			args: args{
+				r: api.Rule{
+					EgressDeny: []api.EgressDenyRule{
+						{
+							EgressCommonRule: api.EgressCommonRule{
+								ToCIDR: []api.CIDR{"192.168.0.0/24"},
+							},
+						},
+					},
+				},
+			},
+			want: wanted{
+				wantRF: RuleFeatures{
+					L3: true,
+				},
+				wantMetrics: metrics{
+					npL3Ingested: 1,
+				},
+			},
+		},
+		{
+			name: "L3 from EgressDeny ToNodes",
+			args: args{
+				r: api.Rule{
+					EgressDeny: []api.EgressDenyRule{
+						{
+							EgressCommonRule: api.EgressCommonRule{
+								ToNodes: []api.EndpointSelector{
+									{},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: wanted{
+				wantRF: RuleFeatures{
+					L3: true,
+				},
+				wantMetrics: metrics{
+					npL3Ingested: 1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := ruleType(tt.args.r)
+			assert.Equalf(t, tt.want.wantRF, rt, "ruleType(%v)", tt.args.r)
+
+			metrics := NewMetrics(true)
+			metrics.AddRule(tt.args.r)
+
+			assert.Equalf(t, tt.want.wantMetrics.npL3Ingested, metrics.NPL3Ingested.WithLabelValues(actionAdd).Get(), "NPL3Ingested different")
+			assert.Equalf(t, float64(0), metrics.NPL3Ingested.WithLabelValues(actionDel).Get(), "NPL3Ingested different")
+
+			metrics.DelRule(tt.args.r)
+
+			assert.Equalf(t, tt.want.wantMetrics.npL3Ingested, metrics.NPL3Ingested.WithLabelValues(actionAdd).Get(), "NPL3Ingested different")
+			assert.Equalf(t, tt.want.wantMetrics.npL3Ingested, metrics.NPL3Ingested.WithLabelValues(actionDel).Get(), "NPL3Ingested different")
+		})
+	}
+}

--- a/pkg/metrics/features/policy_test.go
+++ b/pkg/metrics/features/policy_test.go
@@ -28,6 +28,7 @@ func Test_ruleType(t *testing.T) {
 		npMutualAuthIngested        float64
 		npTLSInspectionIngested     float64
 		npSNIAllowListIngested      float64
+		npNonDefaultDenyIngested    float64
 	}
 	type wanted struct {
 		wantRF      RuleFeatures
@@ -384,9 +385,10 @@ func Test_ruleType(t *testing.T) {
 			},
 		},
 		{
-			name: "FQDN rules",
+			name: "FQDN rules w/ default deny config",
 			args: args{
 				r: api.Rule{
+					EnableDefaultDeny: api.DefaultDenyConfig{Ingress: func() *bool { a := true; return &a }()},
 					Egress: []api.EgressRule{
 						{
 							ToFQDNs: api.FQDNSelectorSlice{
@@ -401,10 +403,12 @@ func Test_ruleType(t *testing.T) {
 			},
 			want: wanted{
 				wantRF: RuleFeatures{
-					DNS: true,
+					DNS:            true,
+					NonDefaultDeny: true,
 				},
 				wantMetrics: metrics{
-					npDNSIngested: 1,
+					npDNSIngested:            1,
+					npNonDefaultDenyIngested: 1,
 				},
 			},
 		},
@@ -595,6 +599,8 @@ func Test_ruleType(t *testing.T) {
 			assert.Equalf(t, float64(0), metrics.NPTLSInspectionIngested.WithLabelValues(actionDel).Get(), "TLSInspectionIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npSNIAllowListIngested, metrics.NPSNIAllowListIngested.WithLabelValues(actionAdd).Get(), "SNIAllowListIngested different")
 			assert.Equalf(t, float64(0), metrics.NPSNIAllowListIngested.WithLabelValues(actionDel).Get(), "SNIAllowListIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npNonDefaultDenyIngested, metrics.NPNonDefaultDenyIngested.WithLabelValues(actionAdd).Get(), "NPNonDefaultDenyIngested different")
+			assert.Equalf(t, float64(0), metrics.NPNonDefaultDenyIngested.WithLabelValues(actionDel).Get(), "NPNonDefaultDenyIngested different")
 
 			metrics.DelRule(tt.args.r)
 
@@ -620,6 +626,8 @@ func Test_ruleType(t *testing.T) {
 			assert.Equalf(t, tt.want.wantMetrics.npTLSInspectionIngested, metrics.NPTLSInspectionIngested.WithLabelValues(actionDel).Get(), "NPTLSInspectionIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npSNIAllowListIngested, metrics.NPSNIAllowListIngested.WithLabelValues(actionAdd).Get(), "NPSNIAllowListIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npSNIAllowListIngested, metrics.NPSNIAllowListIngested.WithLabelValues(actionDel).Get(), "NPSNIAllowListIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npNonDefaultDenyIngested, metrics.NPNonDefaultDenyIngested.WithLabelValues(actionAdd).Get(), "NPNonDefaultDenyIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npNonDefaultDenyIngested, metrics.NPNonDefaultDenyIngested.WithLabelValues(actionDel).Get(), "NPNonDefaultDenyIngested different")
 
 		})
 	}

--- a/pkg/metrics/features/policy_test.go
+++ b/pkg/metrics/features/policy_test.go
@@ -20,6 +20,7 @@ func Test_ruleType(t *testing.T) {
 		npL3Ingested                float64
 		npHostNPIngested            float64
 		npDNSIngested               float64
+		npToFQDNsIngested           float64
 		npHTTPIngested              float64
 		npHTTPHeaderMatchesIngested float64
 		npOtherL7Ingested           float64
@@ -403,11 +404,11 @@ func Test_ruleType(t *testing.T) {
 			},
 			want: wanted{
 				wantRF: RuleFeatures{
-					DNS:            true,
+					ToFQDNs:        true,
 					NonDefaultDeny: true,
 				},
 				wantMetrics: metrics{
-					npDNSIngested:            1,
+					npToFQDNsIngested:        1,
 					npNonDefaultDenyIngested: 1,
 				},
 			},
@@ -583,6 +584,8 @@ func Test_ruleType(t *testing.T) {
 			assert.Equalf(t, float64(0), metrics.NPHostNPIngested.WithLabelValues(actionDel).Get(), "NPHostNPIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npDNSIngested, metrics.NPDNSIngested.WithLabelValues(actionAdd).Get(), "NPDNSIngested different")
 			assert.Equalf(t, float64(0), metrics.NPDNSIngested.WithLabelValues(actionDel).Get(), "NPDNSIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npToFQDNsIngested, metrics.NPToFQDNsIngested.WithLabelValues(actionAdd).Get(), "NPToFQDNsIngested different")
+			assert.Equalf(t, float64(0), metrics.NPToFQDNsIngested.WithLabelValues(actionDel).Get(), "NPToFQDNsIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npHTTPIngested, metrics.NPHTTPIngested.WithLabelValues(actionAdd).Get(), "NPHTTPIngested different")
 			assert.Equalf(t, float64(0), metrics.NPHTTPIngested.WithLabelValues(actionDel).Get(), "NPHTTPIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npHTTPHeaderMatchesIngested, metrics.NPHTTPHeaderMatchesIngested.WithLabelValues(actionAdd).Get(), "NPHTTPHeaderMatchesIngested different")
@@ -610,6 +613,8 @@ func Test_ruleType(t *testing.T) {
 			assert.Equalf(t, tt.want.wantMetrics.npHostNPIngested, metrics.NPHostNPIngested.WithLabelValues(actionDel).Get(), "NPL3Ingested different")
 			assert.Equalf(t, tt.want.wantMetrics.npDNSIngested, metrics.NPDNSIngested.WithLabelValues(actionAdd).Get(), "NPDNSIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npDNSIngested, metrics.NPDNSIngested.WithLabelValues(actionDel).Get(), "NPDNSIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npToFQDNsIngested, metrics.NPToFQDNsIngested.WithLabelValues(actionAdd).Get(), "NPToFQDNsIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npToFQDNsIngested, metrics.NPToFQDNsIngested.WithLabelValues(actionDel).Get(), "NPToFQDNsIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npHTTPIngested, metrics.NPHTTPIngested.WithLabelValues(actionAdd).Get(), "NPHTTPIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npHTTPIngested, metrics.NPHTTPIngested.WithLabelValues(actionDel).Get(), "NPHTTPIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npHTTPHeaderMatchesIngested, metrics.NPHTTPHeaderMatchesIngested.WithLabelValues(actionAdd).Get(), "NPHTTPHeaderMatchesIngested different")

--- a/pkg/metrics/features/policy_test.go
+++ b/pkg/metrics/features/policy_test.go
@@ -24,6 +24,7 @@ func Test_ruleType(t *testing.T) {
 		npHTTPHeaderMatchesIngested float64
 		npOtherL7Ingested           float64
 		npDenyPoliciesIngested      float64
+		npIngressCIDRGroupIngested  float64
 	}
 	type wanted struct {
 		wantRF      RuleFeatures
@@ -75,10 +76,12 @@ func Test_ruleType(t *testing.T) {
 			},
 			want: wanted{
 				wantRF: RuleFeatures{
-					L3: true,
+					L3:               true,
+					IngressCIDRGroup: true,
 				},
 				wantMetrics: metrics{
-					npL3Ingested: 1,
+					npL3Ingested:               1,
+					npIngressCIDRGroupIngested: 1,
 				},
 			},
 		},
@@ -99,12 +102,14 @@ func Test_ruleType(t *testing.T) {
 			},
 			want: wanted{
 				wantRF: RuleFeatures{
-					L3:   true,
-					Deny: true,
+					L3:               true,
+					Deny:             true,
+					IngressCIDRGroup: true,
 				},
 				wantMetrics: metrics{
-					npL3Ingested:           1,
-					npDenyPoliciesIngested: 1,
+					npL3Ingested:               1,
+					npDenyPoliciesIngested:     1,
+					npIngressCIDRGroupIngested: 1,
 				},
 			},
 		},
@@ -547,6 +552,8 @@ func Test_ruleType(t *testing.T) {
 			assert.Equalf(t, float64(0), metrics.NPOtherL7Ingested.WithLabelValues(actionDel).Get(), "NPOtherL7Ingested different")
 			assert.Equalf(t, tt.want.wantMetrics.npDenyPoliciesIngested, metrics.NPDenyPoliciesIngested.WithLabelValues(actionAdd).Get(), "NPDenyPoliciesIngested different")
 			assert.Equalf(t, float64(0), metrics.NPDenyPoliciesIngested.WithLabelValues(actionDel).Get(), "NPDenyPoliciesIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npIngressCIDRGroupIngested, metrics.NPIngressCIDRGroupIngested.WithLabelValues(actionAdd).Get(), "IngressCIDRGroupIngested different")
+			assert.Equalf(t, float64(0), metrics.NPIngressCIDRGroupIngested.WithLabelValues(actionDel).Get(), "IngressCIDRGroupIngested different")
 
 			metrics.DelRule(tt.args.r)
 
@@ -564,6 +571,8 @@ func Test_ruleType(t *testing.T) {
 			assert.Equalf(t, tt.want.wantMetrics.npOtherL7Ingested, metrics.NPOtherL7Ingested.WithLabelValues(actionDel).Get(), "NPOtherL7Ingested different")
 			assert.Equalf(t, tt.want.wantMetrics.npDenyPoliciesIngested, metrics.NPDenyPoliciesIngested.WithLabelValues(actionAdd).Get(), "NPDenyPoliciesIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npDenyPoliciesIngested, metrics.NPDenyPoliciesIngested.WithLabelValues(actionDel).Get(), "NPDenyPoliciesIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npIngressCIDRGroupIngested, metrics.NPIngressCIDRGroupIngested.WithLabelValues(actionAdd).Get(), "NPIngressCIDRGroupIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npIngressCIDRGroupIngested, metrics.NPIngressCIDRGroupIngested.WithLabelValues(actionDel).Get(), "NPIngressCIDRGroupIngested different")
 
 		})
 	}

--- a/pkg/metrics/features/policy_test.go
+++ b/pkg/metrics/features/policy_test.go
@@ -6,6 +6,7 @@ package features
 import (
 	"testing"
 
+	"github.com/cilium/proxy/pkg/policy/api/kafka"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -21,6 +22,7 @@ func Test_ruleType(t *testing.T) {
 		npDNSIngested               float64
 		npHTTPIngested              float64
 		npHTTPHeaderMatchesIngested float64
+		npOtherL7Ingested           float64
 	}
 	type wanted struct {
 		wantRF      RuleFeatures
@@ -321,7 +323,7 @@ func Test_ruleType(t *testing.T) {
 			},
 		},
 		{
-			name: "DNS rules",
+			name: "DNS rules and other L7",
 			args: args{
 				r: api.Rule{
 					Egress: []api.EgressRule{
@@ -334,6 +336,9 @@ func Test_ruleType(t *testing.T) {
 												MatchName: "cilium.io",
 											},
 										},
+										Kafka: []kafka.PortRule{
+											{},
+										},
 									},
 								},
 							},
@@ -343,10 +348,12 @@ func Test_ruleType(t *testing.T) {
 			},
 			want: wanted{
 				wantRF: RuleFeatures{
-					DNS: true,
+					DNS:     true,
+					OtherL7: true,
 				},
 				wantMetrics: metrics{
-					npDNSIngested: 1,
+					npDNSIngested:     1,
+					npOtherL7Ingested: 1,
 				},
 			},
 		},
@@ -466,7 +473,7 @@ func Test_ruleType(t *testing.T) {
 			},
 		},
 		{
-			name: "HTTP matches egress rules",
+			name: "HTTP matches egress rules and other L7",
 			args: args{
 				r: api.Rule{
 					Egress: []api.EgressRule{
@@ -481,6 +488,9 @@ func Test_ruleType(t *testing.T) {
 												},
 											},
 										},
+										L7: []api.PortRuleL7{
+											{},
+										},
 									},
 								},
 							},
@@ -492,10 +502,12 @@ func Test_ruleType(t *testing.T) {
 				wantRF: RuleFeatures{
 					HTTP:              true,
 					HTTPHeaderMatches: true,
+					OtherL7:           true,
 				},
 				wantMetrics: metrics{
 					npHTTPIngested:              1,
 					npHTTPHeaderMatchesIngested: 1,
+					npOtherL7Ingested:           1,
 				},
 			},
 		},
@@ -518,6 +530,8 @@ func Test_ruleType(t *testing.T) {
 			assert.Equalf(t, float64(0), metrics.NPHTTPIngested.WithLabelValues(actionDel).Get(), "NPHTTPIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npHTTPHeaderMatchesIngested, metrics.NPHTTPHeaderMatchesIngested.WithLabelValues(actionAdd).Get(), "NPHTTPHeaderMatchesIngested different")
 			assert.Equalf(t, float64(0), metrics.NPHTTPHeaderMatchesIngested.WithLabelValues(actionDel).Get(), "NPHTTPHeaderMatchesIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npOtherL7Ingested, metrics.NPOtherL7Ingested.WithLabelValues(actionAdd).Get(), "NPOtherL7Ingested different")
+			assert.Equalf(t, float64(0), metrics.NPOtherL7Ingested.WithLabelValues(actionDel).Get(), "NPOtherL7Ingested different")
 
 			metrics.DelRule(tt.args.r)
 
@@ -531,6 +545,8 @@ func Test_ruleType(t *testing.T) {
 			assert.Equalf(t, tt.want.wantMetrics.npHTTPIngested, metrics.NPHTTPIngested.WithLabelValues(actionDel).Get(), "NPHTTPIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npHTTPHeaderMatchesIngested, metrics.NPHTTPHeaderMatchesIngested.WithLabelValues(actionAdd).Get(), "NPHTTPHeaderMatchesIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npHTTPHeaderMatchesIngested, metrics.NPHTTPHeaderMatchesIngested.WithLabelValues(actionDel).Get(), "NPHTTPHeaderMatchesIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npOtherL7Ingested, metrics.NPOtherL7Ingested.WithLabelValues(actionAdd).Get(), "NPOtherL7Ingested different")
+			assert.Equalf(t, tt.want.wantMetrics.npOtherL7Ingested, metrics.NPOtherL7Ingested.WithLabelValues(actionDel).Get(), "NPOtherL7Ingested different")
 
 		})
 	}

--- a/pkg/metrics/features/policy_test.go
+++ b/pkg/metrics/features/policy_test.go
@@ -16,7 +16,8 @@ func Test_ruleType(t *testing.T) {
 		r api.Rule
 	}
 	type metrics struct {
-		npL3Ingested float64
+		npL3Ingested     float64
+		npHostNPIngested float64
 	}
 	type wanted struct {
 		wantRF      RuleFeatures
@@ -116,10 +117,12 @@ func Test_ruleType(t *testing.T) {
 			},
 			want: wanted{
 				wantRF: RuleFeatures{
-					L3: true,
+					L3:   true,
+					Host: true,
 				},
 				wantMetrics: metrics{
-					npL3Ingested: 1,
+					npL3Ingested:     1,
+					npHostNPIngested: 1,
 				},
 			},
 		},
@@ -140,10 +143,12 @@ func Test_ruleType(t *testing.T) {
 			},
 			want: wanted{
 				wantRF: RuleFeatures{
-					L3: true,
+					L3:   true,
+					Host: true,
 				},
 				wantMetrics: metrics{
-					npL3Ingested: 1,
+					npL3Ingested:     1,
+					npHostNPIngested: 1,
 				},
 			},
 		},
@@ -181,10 +186,12 @@ func Test_ruleType(t *testing.T) {
 			},
 			want: wanted{
 				wantRF: RuleFeatures{
-					L3: true,
+					L3:   true,
+					Host: true,
 				},
 				wantMetrics: metrics{
-					npL3Ingested: 1,
+					npL3Ingested:     1,
+					npHostNPIngested: 1,
 				},
 			},
 		},
@@ -249,10 +256,64 @@ func Test_ruleType(t *testing.T) {
 			},
 			want: wanted{
 				wantRF: RuleFeatures{
-					L3: true,
+					L3:   true,
+					Host: true,
 				},
 				wantMetrics: metrics{
-					npL3Ingested: 1,
+					npL3Ingested:     1,
+					npHostNPIngested: 1,
+				},
+			},
+		},
+		{
+			name: "Host from EgressDeny ToNodes",
+			args: args{
+				r: api.Rule{
+					EgressDeny: []api.EgressDenyRule{
+						{
+							EgressCommonRule: api.EgressCommonRule{
+								ToNodes: []api.EndpointSelector{
+									{},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: wanted{
+				wantRF: RuleFeatures{
+					L3:   true,
+					Host: true,
+				},
+				wantMetrics: metrics{
+					npL3Ingested:     1,
+					npHostNPIngested: 1,
+				},
+			},
+		},
+		{
+			name: "Host from Egress ToNodes",
+			args: args{
+				r: api.Rule{
+					Egress: []api.EgressRule{
+						{
+							EgressCommonRule: api.EgressCommonRule{
+								ToNodes: []api.EndpointSelector{
+									{},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: wanted{
+				wantRF: RuleFeatures{
+					L3:   true,
+					Host: true,
+				},
+				wantMetrics: metrics{
+					npL3Ingested:     1,
+					npHostNPIngested: 1,
 				},
 			},
 		},
@@ -267,11 +328,15 @@ func Test_ruleType(t *testing.T) {
 
 			assert.Equalf(t, tt.want.wantMetrics.npL3Ingested, metrics.NPL3Ingested.WithLabelValues(actionAdd).Get(), "NPL3Ingested different")
 			assert.Equalf(t, float64(0), metrics.NPL3Ingested.WithLabelValues(actionDel).Get(), "NPL3Ingested different")
+			assert.Equalf(t, tt.want.wantMetrics.npHostNPIngested, metrics.NPHostNPIngested.WithLabelValues(actionAdd).Get(), "NPHostNPIngested different")
+			assert.Equalf(t, float64(0), metrics.NPHostNPIngested.WithLabelValues(actionDel).Get(), "NPHostNPIngested different")
 
 			metrics.DelRule(tt.args.r)
 
 			assert.Equalf(t, tt.want.wantMetrics.npL3Ingested, metrics.NPL3Ingested.WithLabelValues(actionAdd).Get(), "NPL3Ingested different")
 			assert.Equalf(t, tt.want.wantMetrics.npL3Ingested, metrics.NPL3Ingested.WithLabelValues(actionDel).Get(), "NPL3Ingested different")
+			assert.Equalf(t, tt.want.wantMetrics.npHostNPIngested, metrics.NPHostNPIngested.WithLabelValues(actionAdd).Get(), "NPL3Ingested different")
+			assert.Equalf(t, tt.want.wantMetrics.npHostNPIngested, metrics.NPHostNPIngested.WithLabelValues(actionDel).Get(), "NPL3Ingested different")
 		})
 	}
 }

--- a/pkg/metrics/features/policy_test.go
+++ b/pkg/metrics/features/policy_test.go
@@ -23,6 +23,7 @@ func Test_ruleType(t *testing.T) {
 		npHTTPIngested              float64
 		npHTTPHeaderMatchesIngested float64
 		npOtherL7Ingested           float64
+		npDenyPoliciesIngested      float64
 	}
 	type wanted struct {
 		wantRF      RuleFeatures
@@ -98,10 +99,12 @@ func Test_ruleType(t *testing.T) {
 			},
 			want: wanted{
 				wantRF: RuleFeatures{
-					L3: true,
+					L3:   true,
+					Deny: true,
 				},
 				wantMetrics: metrics{
-					npL3Ingested: 1,
+					npL3Ingested:           1,
+					npDenyPoliciesIngested: 1,
 				},
 			},
 		},
@@ -193,10 +196,12 @@ func Test_ruleType(t *testing.T) {
 				wantRF: RuleFeatures{
 					L3:   true,
 					Host: true,
+					Deny: true,
 				},
 				wantMetrics: metrics{
-					npL3Ingested:     1,
-					npHostNPIngested: 1,
+					npL3Ingested:           1,
+					npHostNPIngested:       1,
+					npDenyPoliciesIngested: 1,
 				},
 			},
 		},
@@ -215,10 +220,12 @@ func Test_ruleType(t *testing.T) {
 			},
 			want: wanted{
 				wantRF: RuleFeatures{
-					L3: true,
+					L3:   true,
+					Deny: true,
 				},
 				wantMetrics: metrics{
-					npL3Ingested: 1,
+					npL3Ingested:           1,
+					npDenyPoliciesIngested: 1,
 				},
 			},
 		},
@@ -237,10 +244,12 @@ func Test_ruleType(t *testing.T) {
 			},
 			want: wanted{
 				wantRF: RuleFeatures{
-					L3: true,
+					L3:   true,
+					Deny: true,
 				},
 				wantMetrics: metrics{
-					npL3Ingested: 1,
+					npL3Ingested:           1,
+					npDenyPoliciesIngested: 1,
 				},
 			},
 		},
@@ -263,10 +272,12 @@ func Test_ruleType(t *testing.T) {
 				wantRF: RuleFeatures{
 					L3:   true,
 					Host: true,
+					Deny: true,
 				},
 				wantMetrics: metrics{
-					npL3Ingested:     1,
-					npHostNPIngested: 1,
+					npL3Ingested:           1,
+					npHostNPIngested:       1,
+					npDenyPoliciesIngested: 1,
 				},
 			},
 		},
@@ -289,10 +300,12 @@ func Test_ruleType(t *testing.T) {
 				wantRF: RuleFeatures{
 					L3:   true,
 					Host: true,
+					Deny: true,
 				},
 				wantMetrics: metrics{
-					npL3Ingested:     1,
-					npHostNPIngested: 1,
+					npL3Ingested:           1,
+					npHostNPIngested:       1,
+					npDenyPoliciesIngested: 1,
 				},
 			},
 		},
@@ -532,6 +545,8 @@ func Test_ruleType(t *testing.T) {
 			assert.Equalf(t, float64(0), metrics.NPHTTPHeaderMatchesIngested.WithLabelValues(actionDel).Get(), "NPHTTPHeaderMatchesIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npOtherL7Ingested, metrics.NPOtherL7Ingested.WithLabelValues(actionAdd).Get(), "NPOtherL7Ingested different")
 			assert.Equalf(t, float64(0), metrics.NPOtherL7Ingested.WithLabelValues(actionDel).Get(), "NPOtherL7Ingested different")
+			assert.Equalf(t, tt.want.wantMetrics.npDenyPoliciesIngested, metrics.NPDenyPoliciesIngested.WithLabelValues(actionAdd).Get(), "NPDenyPoliciesIngested different")
+			assert.Equalf(t, float64(0), metrics.NPDenyPoliciesIngested.WithLabelValues(actionDel).Get(), "NPDenyPoliciesIngested different")
 
 			metrics.DelRule(tt.args.r)
 
@@ -547,6 +562,8 @@ func Test_ruleType(t *testing.T) {
 			assert.Equalf(t, tt.want.wantMetrics.npHTTPHeaderMatchesIngested, metrics.NPHTTPHeaderMatchesIngested.WithLabelValues(actionDel).Get(), "NPHTTPHeaderMatchesIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npOtherL7Ingested, metrics.NPOtherL7Ingested.WithLabelValues(actionAdd).Get(), "NPOtherL7Ingested different")
 			assert.Equalf(t, tt.want.wantMetrics.npOtherL7Ingested, metrics.NPOtherL7Ingested.WithLabelValues(actionDel).Get(), "NPOtherL7Ingested different")
+			assert.Equalf(t, tt.want.wantMetrics.npDenyPoliciesIngested, metrics.NPDenyPoliciesIngested.WithLabelValues(actionAdd).Get(), "NPDenyPoliciesIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npDenyPoliciesIngested, metrics.NPDenyPoliciesIngested.WithLabelValues(actionDel).Get(), "NPDenyPoliciesIngested different")
 
 		})
 	}

--- a/pkg/metrics/features/policy_test.go
+++ b/pkg/metrics/features/policy_test.go
@@ -25,6 +25,7 @@ func Test_ruleType(t *testing.T) {
 		npOtherL7Ingested           float64
 		npDenyPoliciesIngested      float64
 		npIngressCIDRGroupIngested  float64
+		npMutualAuthIngested        float64
 	}
 	type wanted struct {
 		wantRF      RuleFeatures
@@ -124,18 +125,23 @@ func Test_ruleType(t *testing.T) {
 									{},
 								},
 							},
+							Authentication: &api.Authentication{
+								Mode: api.AuthenticationModeRequired,
+							},
 						},
 					},
 				},
 			},
 			want: wanted{
 				wantRF: RuleFeatures{
-					L3:   true,
-					Host: true,
+					L3:         true,
+					Host:       true,
+					MutualAuth: true,
 				},
 				wantMetrics: metrics{
-					npL3Ingested:     1,
-					npHostNPIngested: 1,
+					npL3Ingested:         1,
+					npHostNPIngested:     1,
+					npMutualAuthIngested: 1,
 				},
 			},
 		},
@@ -554,6 +560,8 @@ func Test_ruleType(t *testing.T) {
 			assert.Equalf(t, float64(0), metrics.NPDenyPoliciesIngested.WithLabelValues(actionDel).Get(), "NPDenyPoliciesIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npIngressCIDRGroupIngested, metrics.NPIngressCIDRGroupIngested.WithLabelValues(actionAdd).Get(), "IngressCIDRGroupIngested different")
 			assert.Equalf(t, float64(0), metrics.NPIngressCIDRGroupIngested.WithLabelValues(actionDel).Get(), "IngressCIDRGroupIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npMutualAuthIngested, metrics.NPMutualAuthIngested.WithLabelValues(actionAdd).Get(), "MutualAuthIngested different")
+			assert.Equalf(t, float64(0), metrics.NPMutualAuthIngested.WithLabelValues(actionDel).Get(), "MutualAuthIngested different")
 
 			metrics.DelRule(tt.args.r)
 
@@ -573,6 +581,8 @@ func Test_ruleType(t *testing.T) {
 			assert.Equalf(t, tt.want.wantMetrics.npDenyPoliciesIngested, metrics.NPDenyPoliciesIngested.WithLabelValues(actionDel).Get(), "NPDenyPoliciesIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npIngressCIDRGroupIngested, metrics.NPIngressCIDRGroupIngested.WithLabelValues(actionAdd).Get(), "NPIngressCIDRGroupIngested different")
 			assert.Equalf(t, tt.want.wantMetrics.npIngressCIDRGroupIngested, metrics.NPIngressCIDRGroupIngested.WithLabelValues(actionDel).Get(), "NPIngressCIDRGroupIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npMutualAuthIngested, metrics.NPMutualAuthIngested.WithLabelValues(actionAdd).Get(), "NPMutualAuthIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npMutualAuthIngested, metrics.NPMutualAuthIngested.WithLabelValues(actionDel).Get(), "NPMutualAuthIngested different")
 
 		})
 	}

--- a/pkg/metrics/features/policy_test.go
+++ b/pkg/metrics/features/policy_test.go
@@ -18,6 +18,7 @@ func Test_ruleType(t *testing.T) {
 	type metrics struct {
 		npL3Ingested     float64
 		npHostNPIngested float64
+		npDNSIngested    float64
 	}
 	type wanted struct {
 		wantRF      RuleFeatures
@@ -317,6 +318,61 @@ func Test_ruleType(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "DNS rules",
+			args: args{
+				r: api.Rule{
+					Egress: []api.EgressRule{
+						{
+							ToPorts: api.PortRules{
+								{
+									Rules: &api.L7Rules{
+										DNS: []api.PortRuleDNS{
+											{
+												MatchName: "cilium.io",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: wanted{
+				wantRF: RuleFeatures{
+					DNS: true,
+				},
+				wantMetrics: metrics{
+					npDNSIngested: 1,
+				},
+			},
+		},
+		{
+			name: "FQDN rules",
+			args: args{
+				r: api.Rule{
+					Egress: []api.EgressRule{
+						{
+							ToFQDNs: api.FQDNSelectorSlice{
+								{
+									MatchName:    "cilium.io",
+									MatchPattern: "",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: wanted{
+				wantRF: RuleFeatures{
+					DNS: true,
+				},
+				wantMetrics: metrics{
+					npDNSIngested: 1,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -330,6 +386,8 @@ func Test_ruleType(t *testing.T) {
 			assert.Equalf(t, float64(0), metrics.NPL3Ingested.WithLabelValues(actionDel).Get(), "NPL3Ingested different")
 			assert.Equalf(t, tt.want.wantMetrics.npHostNPIngested, metrics.NPHostNPIngested.WithLabelValues(actionAdd).Get(), "NPHostNPIngested different")
 			assert.Equalf(t, float64(0), metrics.NPHostNPIngested.WithLabelValues(actionDel).Get(), "NPHostNPIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npDNSIngested, metrics.NPDNSIngested.WithLabelValues(actionAdd).Get(), "NPDNSIngested different")
+			assert.Equalf(t, float64(0), metrics.NPDNSIngested.WithLabelValues(actionDel).Get(), "NPDNSIngested different")
 
 			metrics.DelRule(tt.args.r)
 
@@ -337,6 +395,8 @@ func Test_ruleType(t *testing.T) {
 			assert.Equalf(t, tt.want.wantMetrics.npL3Ingested, metrics.NPL3Ingested.WithLabelValues(actionDel).Get(), "NPL3Ingested different")
 			assert.Equalf(t, tt.want.wantMetrics.npHostNPIngested, metrics.NPHostNPIngested.WithLabelValues(actionAdd).Get(), "NPL3Ingested different")
 			assert.Equalf(t, tt.want.wantMetrics.npHostNPIngested, metrics.NPHostNPIngested.WithLabelValues(actionDel).Get(), "NPL3Ingested different")
+			assert.Equalf(t, tt.want.wantMetrics.npDNSIngested, metrics.NPDNSIngested.WithLabelValues(actionAdd).Get(), "NPDNSIngested different")
+			assert.Equalf(t, tt.want.wantMetrics.npDNSIngested, metrics.NPDNSIngested.WithLabelValues(actionDel).Get(), "NPDNSIngested different")
 		})
 	}
 }

--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -363,6 +363,19 @@ func (e *EgressCommonRule) RequiresDerivative() bool {
 	return len(e.ToGroups) > 0
 }
 
+func (e *EgressCommonRule) IsL3() bool {
+	if e == nil {
+		return false
+	}
+	return len(e.ToEndpoints) > 0 ||
+		len(e.ToRequires) > 0 ||
+		len(e.ToCIDR) > 0 ||
+		len(e.ToCIDRSet) > 0 ||
+		len(e.ToEntities) > 0 ||
+		len(e.ToGroups) > 0 ||
+		len(e.ToNodes) > 0
+}
+
 // CreateDerivative will return a new rule based on the data gathered by the
 // rules that creates a new derivative policy.
 // In the case of ToGroups will call outside using the groups callback and this

--- a/pkg/policy/api/ingress.go
+++ b/pkg/policy/api/ingress.go
@@ -284,6 +284,21 @@ func (e *IngressCommonRule) RequiresDerivative() bool {
 	return len(e.FromGroups) > 0
 }
 
+// IsL3 returns true if the IngressCommonRule contains at least a rule that
+// affects L3 policy enforcement.
+func (in *IngressCommonRule) IsL3() bool {
+	if in == nil {
+		return false
+	}
+	return len(in.FromEndpoints) > 0 ||
+		len(in.FromRequires) > 0 ||
+		len(in.FromCIDR) > 0 ||
+		len(in.FromCIDRSet) > 0 ||
+		len(in.FromEntities) > 0 ||
+		len(in.FromGroups) > 0 ||
+		len(in.FromNodes) > 0
+}
+
 // CreateDerivative will return a new rule based on the data gathered by the
 // rules that creates a new derivative policy.
 // In the case of FromGroups will call outside using the groups callback and this

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -311,3 +311,21 @@ func (r *Rule) CreateDerivative(ctx context.Context) (*Rule, error) {
 	}
 	return newRule, nil
 }
+
+type PolicyMetrics interface {
+	AddRule(r Rule)
+	DelRule(r Rule)
+}
+
+type policyMetricsNoop struct {
+}
+
+func (p *policyMetricsNoop) AddRule(Rule) {
+}
+
+func (p *policyMetricsNoop) DelRule(Rule) {
+}
+
+func NewPolicyMetricsNoop() PolicyMetrics {
+	return &policyMetricsNoop{}
+}

--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
 )
 
 // Cell provides the PolicyRepository and PolicyUpdater.
@@ -34,6 +35,7 @@ type policyRepoParams struct {
 	SecretManager   certificatemanager.SecretManager
 	IdentityManager identitymanager.IDManager
 	ClusterInfo     cmtypes.ClusterInfo
+	MetricsManager  api.PolicyMetrics
 }
 
 func newPolicyRepo(params policyRepoParams) policy.PolicyRepository {
@@ -56,6 +58,7 @@ func newPolicyRepo(params policyRepoParams) policy.PolicyRepository {
 		params.CertManager,
 		params.SecretManager,
 		params.IdentityManager,
+		params.MetricsManager,
 	)
 	policyRepo.SetEnvoyRulesFunc(envoy.GetEnvoyHTTPRules)
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -44,7 +44,7 @@ func localIdentity(n uint32) identity.NumericIdentity {
 }
 
 func TestCacheManagement(t *testing.T) {
-	repo := NewStoppedPolicyRepository(nil, nil, nil, nil)
+	repo := NewStoppedPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())
 	cache := repo.policyCache
 	identity := ep1.GetSecurityIdentity()
 	require.Equal(t, identity, ep2.GetSecurityIdentity())
@@ -87,7 +87,7 @@ func TestCacheManagement(t *testing.T) {
 }
 
 func TestCachePopulation(t *testing.T) {
-	repo := NewStoppedPolicyRepository(nil, nil, nil, nil)
+	repo := NewStoppedPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())
 	repo.revision.Store(42)
 	cache := repo.policyCache
 
@@ -385,7 +385,7 @@ type policyDistillery struct {
 
 func newPolicyDistillery(selectorCache *SelectorCache) *policyDistillery {
 	ret := &policyDistillery{
-		Repository: NewStoppedPolicyRepository(nil, nil, nil, nil),
+		Repository: NewStoppedPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop()),
 	}
 	ret.selectorCache = selectorCache
 	return ret

--- a/pkg/policy/k8s/cell.go
+++ b/pkg/policy/k8s/cell.go
@@ -82,6 +82,8 @@ type PolicyWatcherParams struct {
 	CiliumClusterwideNetworkPolicies resource.Resource[*cilium_v2.CiliumClusterwideNetworkPolicy]
 	CiliumCIDRGroups                 resource.Resource[*cilium_v2_alpha1.CiliumCIDRGroup]
 	NetworkPolicies                  resource.Resource[*slim_networking_v1.NetworkPolicy]
+
+	MetricsManager CNPMetrics
 }
 
 func startK8sPolicyWatcher(params PolicyWatcherParams) {
@@ -114,6 +116,7 @@ func startK8sPolicyWatcher(params PolicyWatcherParams) {
 
 		toServicesPolicies: make(map[resource.Key]struct{}),
 		cnpByServiceID:     make(map[k8s.ServiceID]map[resource.Key]struct{}),
+		metricsManager:     params.MetricsManager,
 	}
 
 	params.Lifecycle.Append(cell.Hook{

--- a/pkg/policy/k8s/cilium_network_policy.go
+++ b/pkg/policy/k8s/cilium_network_policy.go
@@ -11,6 +11,7 @@ import (
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/k8s/types"
+	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/policy"
@@ -161,6 +162,12 @@ func (p *policyWatcher) upsertCiliumNetworkPolicyV2(cnp *types.SlimCNP, initialR
 	})
 
 	scopedLog.Debug("Adding CiliumNetworkPolicy")
+	namespace := k8sUtils.ExtractNamespace(&cnp.ObjectMeta)
+	if namespace == "" {
+		p.metricsManager.AddCCNP(cnp.CiliumNetworkPolicy)
+	} else {
+		p.metricsManager.AddCNP(cnp.CiliumNetworkPolicy)
+	}
 
 	rules, policyImportErr := cnp.Parse()
 	if policyImportErr == nil {
@@ -189,6 +196,12 @@ func (p *policyWatcher) deleteCiliumNetworkPolicyV2(cnp *types.SlimCNP, resource
 	})
 
 	scopedLog.Debug("Deleting CiliumNetworkPolicy")
+	namespace := k8sUtils.ExtractNamespace(&cnp.ObjectMeta)
+	if namespace == "" {
+		p.metricsManager.DelCCNP(cnp.CiliumNetworkPolicy)
+	} else {
+		p.metricsManager.DelCNP(cnp.CiliumNetworkPolicy)
+	}
 
 	_, err := p.policyManager.PolicyDelete(nil, &policy.DeleteOptions{
 		Source:           source.CustomResource,

--- a/pkg/policy/k8s/cilium_network_policy_test.go
+++ b/pkg/policy/k8s/cilium_network_policy_test.go
@@ -73,6 +73,7 @@ func Test_GH33432(t *testing.T) {
 		cnpCache:           map[resource.Key]*types.SlimCNP{},
 		toServicesPolicies: map[resource.Key]struct{}{},
 		cnpByServiceID:     map[k8s.ServiceID]map[resource.Key]struct{}{},
+		metricsManager:     NewCNPMetricsNoop(),
 	}
 
 	err := p.onUpsert(cnp, cnpKey, k8sAPIGroupCiliumNetworkPolicyV2, cnpResourceID)

--- a/pkg/policy/k8s/service_test.go
+++ b/pkg/policy/k8s/service_test.go
@@ -267,6 +267,7 @@ func TestPolicyWatcher_updateToServicesPolicies(t *testing.T) {
 		cnpCache:           map[resource.Key]*types.SlimCNP{},
 		toServicesPolicies: map[resource.Key]struct{}{},
 		cnpByServiceID:     map[k8s.ServiceID]map[resource.Key]struct{}{},
+		metricsManager:     NewCNPMetricsNoop(),
 	}
 
 	// Upsert policies. No services are known, so generated ToCIDRSet should be empty
@@ -547,6 +548,7 @@ func TestPolicyWatcher_updateToServicesPoliciesTransformToEndpoint(t *testing.T)
 		cnpCache:           map[resource.Key]*types.SlimCNP{},
 		toServicesPolicies: map[resource.Key]struct{}{},
 		cnpByServiceID:     map[k8s.ServiceID]map[resource.Key]struct{}{},
+		metricsManager:     NewCNPMetricsNoop(),
 	}
 
 	// Upsert policies. No services are known, so generated ToEndpoints should be empty

--- a/pkg/policy/k8s/watcher.go
+++ b/pkg/policy/k8s/watcher.go
@@ -63,6 +63,8 @@ type policyWatcher struct {
 	// toServicesPolicies is the set of policies that contain ToServices references
 	toServicesPolicies map[resource.Key]struct{}
 	cnpByServiceID     map[k8s.ServiceID]map[resource.Key]struct{}
+
+	metricsManager CNPMetrics
 }
 
 func (p *policyWatcher) watchResources(ctx context.Context) {
@@ -218,4 +220,30 @@ func (p *policyWatcher) watchResources(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+type CNPMetrics interface {
+	AddCNP(cec *cilium_v2.CiliumNetworkPolicy)
+	DelCNP(cec *cilium_v2.CiliumNetworkPolicy)
+	AddCCNP(spec *cilium_v2.CiliumNetworkPolicy)
+	DelCCNP(spec *cilium_v2.CiliumNetworkPolicy)
+}
+
+type cnpMetricsNoop struct {
+}
+
+func (c cnpMetricsNoop) AddCNP(cec *cilium_v2.CiliumNetworkPolicy) {
+}
+
+func (c cnpMetricsNoop) DelCNP(cec *cilium_v2.CiliumNetworkPolicy) {
+}
+
+func (c cnpMetricsNoop) AddCCNP(spec *cilium_v2.CiliumNetworkPolicy) {
+}
+
+func (c cnpMetricsNoop) DelCCNP(spec *cilium_v2.CiliumNetworkPolicy) {
+}
+
+func NewCNPMetricsNoop() CNPMetrics {
+	return &cnpMetricsNoop{}
 }

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -58,7 +58,7 @@ type testData struct {
 func newTestData() *testData {
 	td := &testData{
 		sc:                testNewSelectorCache(nil),
-		repo:              NewStoppedPolicyRepository(nil, nil, nil, nil),
+		repo:              NewStoppedPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop()),
 		testPolicyContext: &testPolicyContextType{},
 	}
 	td.testPolicyContext.sc = td.sc
@@ -82,7 +82,7 @@ func newTestData() *testData {
 // resetRepo clears only the policy repository.
 // Some tests rely on the accumulated state, but a clean repo.
 func (td *testData) resetRepo() *Repository {
-	td.repo = NewStoppedPolicyRepository(nil, nil, nil, nil)
+	td.repo = NewStoppedPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())
 	td.repo.selectorCache = td.sc
 	return td.repo
 }

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -2509,7 +2509,7 @@ func TestDefaultAllow(t *testing.T) {
 func TestReplaceByResource(t *testing.T) {
 	// don't use the full testdata() here, since we want to watch
 	// selectorcache changes carefully
-	repo := NewStoppedPolicyRepository(nil, nil, nil, nil)
+	repo := NewStoppedPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())
 	sc := testNewSelectorCache(nil)
 	repo.selectorCache = sc
 	assert.Empty(t, sc.selectors)

--- a/pkg/redirectpolicy/cell.go
+++ b/pkg/redirectpolicy/cell.go
@@ -25,14 +25,15 @@ var Cell = cell.Module(
 type lrpManagerParams struct {
 	cell.In
 
-	Svc      service.ServiceManager
-	SvcCache *k8s.ServiceCache
-	Lpr      agentK8s.LocalPodResource
-	Ep       endpointmanager.EndpointManager
+	Svc            service.ServiceManager
+	SvcCache       *k8s.ServiceCache
+	Lpr            agentK8s.LocalPodResource
+	Ep             endpointmanager.EndpointManager
+	MetricsManager LRPMetrics
 }
 
 func newLRPManager(params lrpManagerParams) *Manager {
-	return NewRedirectPolicyManager(params.Svc, params.SvcCache, params.Lpr, params.Ep)
+	return NewRedirectPolicyManager(params.Svc, params.SvcCache, params.Lpr, params.Ep, params.MetricsManager)
 }
 
 func newLRPApiHandler(lrpManager *Manager) serviceapi.GetLrpHandler {

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -97,9 +97,11 @@ type Manager struct {
 	policyEndpoints map[podID]sets.Set[policyID]
 
 	noNetnsCookieSupport bool
+
+	metricsManager LRPMetrics
 }
 
-func NewRedirectPolicyManager(svc svcManager, svcCache *k8s.ServiceCache, lpr agentK8s.LocalPodResource, epM endpointManager) *Manager {
+func NewRedirectPolicyManager(svc svcManager, svcCache *k8s.ServiceCache, lpr agentK8s.LocalPodResource, epM endpointManager, metricsManager LRPMetrics) *Manager {
 	return &Manager{
 		svcManager:            svc,
 		svcCache:              svcCache,
@@ -110,6 +112,7 @@ func NewRedirectPolicyManager(svc svcManager, svcCache *k8s.ServiceCache, lpr ag
 		policyPods:            make(map[podID][]policyID),
 		policyConfigs:         make(map[policyID]*LRPConfig),
 		policyEndpoints:       make(map[podID]sets.Set[policyID]),
+		metricsManager:        metricsManager,
 	}
 }
 
@@ -552,6 +555,7 @@ func (rpm *Manager) getAndUpsertPolicySvcConfig(config *LRPConfig) error {
 // storePolicyConfig stores various state for the given policy config.
 func (rpm *Manager) storePolicyConfig(config LRPConfig) {
 	rpm.policyConfigs[config.id] = &config
+	rpm.metricsManager.AddLRPConfig(&config)
 
 	switch config.lrpType {
 	case lrpConfigTypeAddr:
@@ -565,6 +569,7 @@ func (rpm *Manager) storePolicyConfig(config LRPConfig) {
 
 // deletePolicyConfig cleans up stored state for the given policy config.
 func (rpm *Manager) deletePolicyConfig(config *LRPConfig) {
+	rpm.metricsManager.DelLRPConfig(config)
 	switch config.lrpType {
 	case lrpConfigTypeAddr:
 		for _, feM := range config.frontendMappings {

--- a/pkg/redirectpolicy/manager_test.go
+++ b/pkg/redirectpolicy/manager_test.go
@@ -44,7 +44,7 @@ func setupManagerSuite(tb testing.TB) *ManagerSuite {
 		fakePodStore{},
 	}
 	m.epM = &fakeEpManager{}
-	m.rpm = NewRedirectPolicyManager(m.svc, nil, fpr, m.epM)
+	m.rpm = NewRedirectPolicyManager(m.svc, nil, fpr, m.epM, NewLRPMetricsNoop())
 	configAddrType = LRPConfig{
 		id: k8s.ServiceID{
 			Name:      "test-foo",
@@ -855,7 +855,7 @@ func TestManager_OnAddRedirectPolicy(t *testing.T) {
 		K8sNamespace: pod.Namespace,
 		NetNsCookie:  1234,
 	}
-	m.rpm = NewRedirectPolicyManager(m.svc, nil, fps, m.epM)
+	m.rpm = NewRedirectPolicyManager(m.svc, nil, fps, m.epM, NewLRPMetricsNoop())
 	m.rpm.skipLBMap = &fakeSkipLBMap{lb4Events: lbEvents}
 
 	added, err := m.rpm.AddRedirectPolicy(pc)
@@ -920,7 +920,7 @@ func TestManager_OnAddRedirectPolicy(t *testing.T) {
 			},
 		},
 	}
-	m.rpm = NewRedirectPolicyManager(m.svc, nil, fps, m.epM)
+	m.rpm = NewRedirectPolicyManager(m.svc, nil, fps, m.epM, NewLRPMetricsNoop())
 	lbEvents = make(chan skipLBParams)
 	m.rpm.skipLBMap = &fakeSkipLBMap{lb4Events: lbEvents}
 
@@ -984,7 +984,7 @@ func TestManager_OnAddRedirectPolicy(t *testing.T) {
 			Pods: pods,
 		},
 	}
-	m.rpm = NewRedirectPolicyManager(m.svc, nil, fps, m.epM)
+	m.rpm = NewRedirectPolicyManager(m.svc, nil, fps, m.epM, NewLRPMetricsNoop())
 	lbEvents = make(chan skipLBParams)
 	m.rpm.skipLBMap = &fakeSkipLBMap{lb4Events: lbEvents}
 

--- a/pkg/redirectpolicy/redirectpolicy.go
+++ b/pkg/redirectpolicy/redirectpolicy.go
@@ -373,3 +373,21 @@ func (config *LRPConfig) GetModel() *models.LRPSpec {
 		FrontendMappings: feMappingModelArray,
 	}
 }
+
+type LRPMetrics interface {
+	AddLRPConfig(cfg *LRPConfig)
+	DelLRPConfig(cfg *LRPConfig)
+}
+
+type lrpMetricsNoop struct {
+}
+
+func (p *lrpMetricsNoop) AddLRPConfig(cfg *LRPConfig) {
+}
+
+func (p *lrpMetricsNoop) DelLRPConfig(cfg *LRPConfig) {
+}
+
+func NewLRPMetricsNoop() LRPMetrics {
+	return &lrpMetricsNoop{}
+}


### PR DESCRIPTION
Follow up of https://github.com/cilium/cilium/pull/35852 for more features. I've split in multiple commits so it's easier for each sig to review their section.

**Note for reviewers**: Review on a per-commit basis to make sure the feature of your sig is being detected correctly.

### Features Checklist
- [ ] Enable L3 policy (@cilium/sig-policy)
- [ ] Enable Host Network Policies (@cilium/sig-policy)
- [ ] Enable DNS rules (@cilium/sig-policy)
- [ ] Enable HTTP and HTTPHeaderMatches Network Policies (@cilium/sig-policy)
- [ ] Enable other L7 Network Policies (@cilium/sig-policy)
- [ ] Enable Deny Network Policies (@cilium/sig-policy)
- [ ] Enable IngressCIDR Network Policies (@cilium/sig-policy)
- [x] Enable Mutual Auth Network Policies (@cilium/sig-servicemesh)
- [x] Enable TLS and SNI Network Policies (@cilium/sig-servicemesh)
- [ ] Enable Default Deny Network Policies (@cilium/sig-policy)
- [ ] Enable Local Redirect Policies (@cilium/sig-datapath)
- [ ] Enable Service Internal Traffic Policy (@cilium/sig-datapath)
- [x] Enable CiliumEnvoyConfig (@cilium/sig-servicemesh)
- [ ] Enable CiliumNetworkPolicy (@cilium/sig-policy)
- [ ] Enable Host Network Policies (@cilium/sig-policy)
- [ ] Enable ToFQDNs (@cilium/sig-policy)
