### PR TITLE
docs: WireGuard doesn't require overlay port in Network Firewalls

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -346,10 +346,7 @@ For IPsec enabled Cilium deployments, you need to ensure that the firewall
 allows ESP traffic through. For example, AWS Security Groups doesn't allow ESP
 traffic by default.
 
-If you are using WireGuard, you must allow UDP port 51871. Furthermore, if you
-have disabled node-to-node encryption and configured an overlay network mode
-(such as VXLAN or Geneve) in addition to WireGuard, then the overlay ports must
-also be allowed.
+If you are using WireGuard, you must allow UDP port 51871.
 
 If you are using VXLAN overlay network mode, Cilium uses Linux's default VXLAN
 port 8472 over UDP, unless Linux has been configured otherwise. In this case,


### PR DESCRIPTION
When using WireGuard, all of Cilium's overlay network traffic is encrypted and not visible to the network. Therefore the overlay port doesn't need to be allowed in Network Firewalls.

Also see f604ce2cbd6d ("docs: update note on WireGuard with tunnel routing").