### PR TITLE
feat: Standalone dns proxy - Cilium agent grpc server

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -177,6 +177,7 @@ cilium-agent [flags]
       --enable-route-mtu-for-cni-chaining                         Enable route MTU for pod netns when CNI chaining is used
       --enable-sctp                                               Enable SCTP support (beta)
       --enable-service-topology                                   Enable support for service topology aware hints
+      --enable-standalone-dns-proxy                               Enables standalone DNS proxy.
       --enable-svc-source-range-check                             Enable check of service source ranges (currently, only for LoadBalancer) (default true)
       --enable-tcx                                                Attach endpoint programs using tcx if supported by the kernel (default true)
       --enable-tracing                                            Enable tracing while determining policy (debugging)
@@ -386,6 +387,7 @@ cilium-agent [flags]
       --tofqdns-pre-cache string                                  DNS cache data at this path is preloaded on agent startup
       --tofqdns-proxy-port int                                    Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
       --tofqdns-proxy-response-max-delay duration                 The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
+      --tofqdns-server-port int                                   Global port on which the gRPC server for standalone DNS proxy should listen. (default 40045)
       --trace-payloadlen int                                      Length of payload to capture when tracing (default 128)
       --trace-sock                                                Enable tracing for socket-based LB (default true)
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -801,8 +801,18 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Int(option.ToFQDNsMinTTL, defaults.ToFQDNsMinTTL, "The minimum time, in seconds, to use DNS data for toFQDNs policies")
 	option.BindEnv(vp, option.ToFQDNsMinTTL)
 
+	flags.Bool(option.EnableStandaloneDNSProxy, false, "Enables standalone DNS proxy.")
+	option.BindEnv(vp, option.EnableStandaloneDNSProxy)
+
+	flags.Bool(option.EnableEmbeddedDNSProxy, true, "Enables embedded DNS proxy.")
+	flags.MarkHidden(option.EnableEmbeddedDNSProxy)
+	option.BindEnv(vp, option.EnableEmbeddedDNSProxy)
+
 	flags.Int(option.ToFQDNsProxyPort, 0, "Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.")
 	option.BindEnv(vp, option.ToFQDNsProxyPort)
+
+	flags.Int(option.ToFQDNsServerPort, 40045, "Global port on which the gRPC server for standalone DNS proxy should listen.")
+	option.BindEnv(vp, option.ToFQDNsServerPort)
 
 	flags.String(option.FQDNRejectResponseCode, option.FQDNProxyDenyWithRefused, fmt.Sprintf("DNS response code for rejecting DNS requests, available options are '%v'", option.FQDNRejectOptions))
 	option.BindEnv(vp, option.FQDNRejectResponseCode)

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/revert"
@@ -17,6 +18,7 @@ import (
 type EndpointProxy interface {
 	CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, epID uint16, wg *completion.WaitGroup) (proxyPort uint16, err error, revertFunc revert.RevertFunc)
 	RemoveRedirect(id string)
+	UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy)
 	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
 	UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
 	RemoveNetworkPolicy(ep endpoint.EndpointInfoSource)
@@ -63,3 +65,6 @@ func (f *FakeEndpointProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, pol
 
 // RemoveNetworkPolicy does nothing.
 func (f *FakeEndpointProxy) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {}
+
+func (f *FakeEndpointProxy) UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy) {
+}

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -122,6 +122,10 @@ func (r *RedirectSuiteProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, po
 // RemoveNetworkPolicy does nothing.
 func (r *RedirectSuiteProxy) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {}
 
+// UpdateSDP does nothing.
+func (r *RedirectSuiteProxy) UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy) {
+}
+
 // DummyIdentityAllocatorOwner implements
 // pkg/identity/cache/IdentityAllocatorOwner. It is used for unit testing.
 type DummyIdentityAllocatorOwner struct{}

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -644,6 +644,10 @@ func (mgr *endpointManager) GetPolicyEndpoints() map[policy.Endpoint]struct{} {
 	return eps
 }
 
+func (mgr *endpointManager) ExposeTestEndpoint(ep *endpoint.Endpoint) error {
+	return mgr.expose(ep)
+}
+
 func (mgr *endpointManager) expose(ep *endpoint.Endpoint) error {
 	newID, err := mgr.allocateID(ep.ID)
 	if err != nil {

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -673,6 +673,7 @@ type DNSProxyConfig struct {
 	MaxRestoreDNSIPs       int
 	ConcurrencyLimit       int
 	ConcurrencyGracePeriod time.Duration
+	DisableDNSProxy        bool
 }
 
 // StartDNSProxy starts a proxy used for DNS L7 redirects that listens on
@@ -723,6 +724,14 @@ func StartDNSProxy(
 		p.ConcurrencyGracePeriod = dnsProxyConfig.ConcurrencyGracePeriod
 	}
 	p.rejectReply.Store(dns.RcodeRefused)
+
+	// Disable the DNS proxy if configured. This is needed when only standalone dns proxy is present.
+	// Since the DNS Proxy is in the restoration path for endpoints, we don't start
+	// the DNS proxy if it is disabled. But we still need to return a DNSProxy that
+	// can be used to restoring endpoints.
+	if dnsProxyConfig.DisableDNSProxy {
+		return p, nil
+	}
 
 	// Start the DNS listeners on UDP and TCP for IPv4 and/or IPv6
 	var (

--- a/pkg/fqdn/service/service.go
+++ b/pkg/fqdn/service/service.go
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/netip"
+
+	"github.com/cilium/dns"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/container/versioned"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/time"
+
+	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
+)
+
+type updateOnDNSMsgFunc func(lookupTime time.Time, ep *endpoint.Endpoint, qname string, responseIPs []netip.Addr, TTL int, stat *dnsproxy.ProxyRequestContext) error
+
+type FQDNDataServer struct {
+	pb.UnimplementedFQDNDataServer
+
+	ctx             context.Context
+	closeServer     func()
+	endpointManager endpointmanager.EndpointManager
+
+	// streams is a map of the active streams and their cancel functions
+	// Streams are added when a client(standalone dns proxy) subscribes to DNS policies and removed when the client closes the connection
+	streams lock.Map[pb.FQDNData_StreamPolicyStateServer, context.CancelFunc]
+
+	// updateOnDNSMsg is a function to update the DNS message in the cilium agent on receiving the FQDN mapping
+	updateOnDNSMsg updateOnDNSMsgFunc
+
+	// dnsMappingResult is a map of the dns request id and bool value for success/failure
+	dnsMappingResult lock.Map[string, bool]
+
+	// snapshotMutex is a mutex to protect the current state of the DNS rules
+	snapshotMutex lock.Mutex
+
+	// currentSnapshot is the current state of the DNS rules
+	currentSnapshot map[identity.NumericIdentity]policy.SelectorPolicy
+
+	// identityToIpMutex is a mutex to protect the current state of the identity to Ip mapping
+	identityToIpMutex lock.Mutex
+
+	// currentIdentityToIp is a map of the identity to list of Ips
+	currentIdentityToIp map[identity.NumericIdentity][]net.IP
+
+	// log is the logger for the FQDNDataServer
+	log *slog.Logger
+}
+
+var (
+	kaep = keepalive.EnforcementPolicy{
+		PermitWithoutStream: true, // Allow pings even when there are no active streams
+	}
+	kasp = keepalive.ServerParameters{
+		Time:    5 * time.Second, // Ping the client if it is idle for 5 seconds to ensure the connection is still active
+		Timeout: 1 * time.Second, // Wait 1 second for the ping ack before assuming the connection is dead
+	}
+)
+
+// StreamPolicyState is a bidirectional streaming RPC to subscribe to DNS policies
+// SDP calls this method to subscribe to DNS policies
+// For each stream, we start a goroutine to receive the DNS policies ACKs
+// The flow of the method is as follows:
+// 1. Add the stream to the map( called by the client i.e SDP)
+// 2. Start a goroutine to receive the DNS policies ACKs for that particular client.
+// 3. Send the current state of the DNS rules to the client (We store the current state fo DNS rules during the endpoint regeneration see UpdatePolicyRulesLocked)
+// 4. Wait for the context to be done
+func (s *FQDNDataServer) StreamPolicyState(stream pb.FQDNData_StreamPolicyStateServer) error {
+	streamCtx, cancel := context.WithCancel(stream.Context())
+	s.streams.Store(stream, cancel)
+
+	// Start a goroutine to receive the DNS policies ACKs
+	go func() {
+		if err := s.receiveDNSPolicyACKs(stream); err != nil {
+			s.log.Error("Error receiving DNS policies ACK: ", logfields.Error, err)
+			cancel() // Cancel the context to close the stream
+		}
+	}()
+
+	//Send the current state of the DNS rules
+	go func() {
+		s.log.Debug("Sending current state of DNS rules")
+
+		// Send the current state of the DNS rules
+		if err := s.UpdatePolicyRulesLocked(nil, false); err != nil {
+			s.log.Error("Error sending current state of DNS rules: ", logfields.Error, err)
+			cancel() // Cancel the context to close the stream
+		}
+	}()
+
+	s.log.Debug("StreamPolicyState waiting for context to be done")
+	<-streamCtx.Done()
+	err := streamCtx.Err()
+	s.log.Error("StreamPolicyState context done: ", logfields.Error, err)
+	s.DeleteStream(stream)
+	return err
+}
+
+// receiveDNSPolicyACKs receives the DNS policies ACKs from the client
+// If the success is false, we can send cancel signal to the channel
+// in that case SDP will recreate the stream.
+func (s *FQDNDataServer) receiveDNSPolicyACKs(stream pb.FQDNData_StreamPolicyStateServer) error {
+	for {
+		select {
+		case <-stream.Context().Done():
+			s.log.Info("Stream context is finished, closing the stream")
+			return stream.Context().Err()
+		default:
+			// Continue receiving the DNS policies ACKs
+		}
+		update, err := stream.Recv()
+		if err != nil {
+			s.log.Error("Error receiving DNS policies ACK: ", logfields.Error, err)
+			return err
+		}
+		s.log.Debug("Received DNS policies ACK: ", logfields.Response, update)
+		requestId := update.GetRequestId()
+		_, ok := s.dnsMappingResult.Load(requestId)
+		if !ok {
+			s.log.Error("Received Message id not found: ", logfields.ID, requestId)
+		} else {
+			s.log.Debug("Received response for dns message id: ", logfields.ID, requestId)
+
+			// We can send cancel signal to the channel if the response code is not NO_ERROR,
+			// in that case SDP will recreate the stream.
+			responseCode := update.GetResponse()
+			if responseCode != pb.ResponseCode_RESPONSE_CODE_NO_ERROR {
+				s.log.Error("Received error response for dns message id: ", logfields.ID, requestId)
+				cancel, ok := s.streams.Load(stream)
+				if ok {
+					cancel()
+				}
+			}
+		}
+		// Delete the request from the map
+		s.dnsMappingResult.Delete(requestId)
+		s.log.Debug("Deleted request id from the map: ", logfields.ID, requestId)
+
+	}
+}
+
+// NewServer creates a new FQDNDataServer which is used to handle the Standalone DNS Proxy grpc service
+func NewServer(endpointManager endpointmanager.EndpointManager, updateOnDNSMsg updateOnDNSMsgFunc, logger *slog.Logger) *FQDNDataServer {
+	ctx := context.Background()
+
+	s := &FQDNDataServer{
+		endpointManager:     endpointManager,
+		updateOnDNSMsg:      updateOnDNSMsg,
+		ctx:                 ctx,
+		streams:             lock.Map[pb.FQDNData_StreamPolicyStateServer, context.CancelFunc]{},
+		currentSnapshot:     make(map[identity.NumericIdentity]policy.SelectorPolicy),
+		currentIdentityToIp: make(map[identity.NumericIdentity][]net.IP),
+		log:                 logger.With(logfields.LogSubsys, "fqdn/server"),
+	}
+
+	go func() {
+		<-s.ctx.Done()
+		s.log.Info("FQDN service context done, cleaning up resources")
+		if s.ctx.Err() != nil {
+			s.log.Error("FQDN service context error: ", logfields.Error, s.ctx.Err())
+		}
+		// Cleanup the streams
+		s.cleanupStreams()
+		s.closeServer()
+	}()
+
+	return s
+}
+
+func convertToBytes(ips []net.IP) [][]byte {
+	var byteIps [][]byte
+	for _, ip := range ips {
+		byteIps = append(byteIps, ip)
+	}
+	return byteIps
+}
+
+// convertEndpointInfo converts the endpoint info to the format required by the standalone dns proxy
+func (s *FQDNDataServer) convertEndpointInfo(ips []net.IP) []*pb.EndpointInfo {
+	var endpointInfo = make(map[uint64][]net.IP)
+	for _, ip := range ips {
+		var epId uint64
+		ep := s.endpointManager.LookupIP(netip.MustParseAddr(ip.String()))
+		if ep == nil {
+			// If the endpoint is not found, log a warning
+			// This can happen for the endpoints that are not managed by this cilium agent
+			s.log.Warn("Endpoint not found for IP: ", logfields.IPAddr, ip)
+		} else {
+			epId = ep.GetID()
+		}
+		endpointInfo[epId] = append(endpointInfo[epId], ip)
+	}
+
+	var convertedEndpointInfo []*pb.EndpointInfo
+	for epId, ips := range endpointInfo {
+		convertedEndpointInfo = append(convertedEndpointInfo, &pb.EndpointInfo{
+			Id: epId,
+			Ip: convertToBytes(ips),
+		})
+	}
+
+	return convertedEndpointInfo
+}
+
+// OnIPIdentityCacheChange is a method to receive the IP identity cache change events
+func (s *FQDNDataServer) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidr types.PrefixCluster, oldHostIP, newHostIP net.IP, oldID *ipcache.Identity, newID ipcache.Identity, encryptKey uint8, k8sMeta *ipcache.K8sMetadata, endpointFlags uint8) {
+	s.identityToIpMutex.Lock()
+	switch modType {
+	case ipcache.Upsert:
+		ip := cidr.AsIPNet().IP
+		s.currentIdentityToIp[newID.ID] = append(s.currentIdentityToIp[newID.ID], ip)
+	case ipcache.Delete:
+		if oldID != nil {
+			delete(s.currentIdentityToIp, oldID.ID)
+		}
+	}
+	s.identityToIpMutex.Unlock()
+	err := s.UpdatePolicyRulesLocked(nil, false)
+	if err != nil {
+		s.log.Error("Error updating policy rules: ", logfields.Error, err)
+	}
+}
+
+// UpdatePolicyRulesLocked updates the current state of the DNS rules with the given policies and sends the current state of the DNS rules to the client
+// This method is called:
+// 1. when the DNS rules are updated during the endpoint regeneration, we store the state of the DNS rules with flag rulesUpdate as true
+// 2. when the client subscribes to DNS policies, we send the current state of the DNS rules to the client(flag rulesUpdate as false)
+// 3. when the IP identity cache changes, we update the current state of the identity to IP mapping and send the current state of the DNS rules to
+// the client(flag rulesUpdate as false)
+func (s *FQDNDataServer) UpdatePolicyRulesLocked(policies map[identity.NumericIdentity]policy.SelectorPolicy, rulesUpdate bool) error {
+	s.snapshotMutex.Lock()
+	defer s.snapshotMutex.Unlock()
+
+	// We only update the rules if the rules are updated during the endpoint regeneration
+	if rulesUpdate {
+		s.currentSnapshot = policies
+	}
+
+	egressL7DnsPolicy := make([]*pb.DNSPolicy, 0, len(s.currentSnapshot))
+	identityToEndpointMapping := make([]*pb.IdentityToEndpointMapping, 0, len(s.currentSnapshot))
+	for identity, pol := range s.currentSnapshot {
+		for l4, polSelTuple := range pol.RedirectFilters() {
+			switch polSelTuple.Policy.L7Parser {
+			case policy.ParserTypeDNS:
+				selectorPolicy := polSelTuple.Policy
+				cacheSelector := polSelTuple.Selector
+
+				// Acquire the lock to read the current state of the identity to IP mapping
+				s.identityToIpMutex.Lock()
+				var dnsServersIdentity []uint32
+				var dnsServers []*pb.DNSServer
+				if cacheSelector != nil {
+					for _, sel := range cacheSelector.GetSelections(versioned.Latest()) {
+						dnsServersIdentity = append(dnsServersIdentity, sel.Uint32())
+						identityToEndpointMapping = append(identityToEndpointMapping, &pb.IdentityToEndpointMapping{
+							Identity:     sel.Uint32(),
+							EndpointInfo: s.convertEndpointInfo(s.currentIdentityToIp[sel]),
+						})
+					}
+					dnsServers = make([]*pb.DNSServer, 0, len(cacheSelector.GetSelections(versioned.Latest())))
+					for _, dnsServerIdentity := range dnsServersIdentity {
+						dnsServers = append(dnsServers, &pb.DNSServer{
+							DnsServerIdentity: dnsServerIdentity,
+							DnsServerPort:     uint32(l4.GetPort()),
+							DnsServerProto:    uint32(l4.U8Proto),
+						})
+					}
+				} else {
+					dnsServers = make([]*pb.DNSServer, 0, 1)
+					dnsServers = append(dnsServers, &pb.DNSServer{
+						DnsServerPort:  uint32(l4.GetPort()),
+						DnsServerProto: uint32(l4.U8Proto),
+					})
+				}
+				var dnsPattern []string
+				if selectorPolicy != nil && selectorPolicy.DNS != nil {
+					dnsPattern = make([]string, 0, len(selectorPolicy.DNS))
+					for _, dns := range selectorPolicy.DNS {
+						if dns.MatchPattern != "" {
+							dnsPattern = append(dnsPattern, dns.MatchPattern)
+						}
+						if dns.MatchName != "" {
+							dnsPattern = append(dnsPattern, dns.MatchName)
+						}
+					}
+				}
+				epIPs := s.currentIdentityToIp[identity]
+				for _, epIP := range epIPs {
+					ep := s.endpointManager.LookupIP(netip.MustParseAddr(epIP.String()))
+					if ep == nil {
+						// If the endpoint is not found, log a warning
+						// This can happen for the endpoints that are not managed by this cilium agent
+						s.log.Debug("Endpoint not found for IP: ", logfields.IPAddr, epIP)
+						continue
+					}
+					egressL7DnsPolicy = append(egressL7DnsPolicy, &pb.DNSPolicy{
+						SourceEndpointId: uint32(ep.GetID()),
+						DnsServers:       dnsServers,
+						DnsPattern:       dnsPattern,
+					})
+				}
+
+				identityToEndpointMapping = append(identityToEndpointMapping, &pb.IdentityToEndpointMapping{
+					Identity:     identity.Uint32(),
+					EndpointInfo: s.convertEndpointInfo(s.currentIdentityToIp[identity]),
+				})
+				s.identityToIpMutex.Unlock()
+			}
+		}
+	}
+
+	requestId := uuid.New().String()
+	s.log.Debug("Current EgressL7DnsPolicy: ",
+		logfields.Rule, egressL7DnsPolicy,
+		logfields.ID, requestId)
+	dnsPolices := &pb.PolicyState{
+		IdentityToEndpointMapping: identityToEndpointMapping,
+		RequestId:                 requestId,
+		EgressL7DnsPolicy:         egressL7DnsPolicy,
+	}
+
+	s.streams.Range(func(stream pb.FQDNData_StreamPolicyStateServer, cancel context.CancelFunc) bool {
+		s.log.Debug("Sending DNS policies to client: ", logfields.ID, requestId)
+		s.dnsMappingResult.Store(requestId, false)
+		if err := stream.Send(dnsPolices); err != nil {
+			s.log.Error("Error sending DNS policies to client: ", logfields.Error, err)
+			// Cancel the goroutine and remove the stream from the map
+			cancel()
+		}
+		return true
+	})
+	return nil
+}
+
+// DeleteStream deletes the stream from the map
+func (s *FQDNDataServer) DeleteStream(stream pb.FQDNData_StreamPolicyStateServer) {
+	_, ok := s.streams.Load(stream)
+	if ok {
+		s.log.Info("Deleting stream: ", logfields.ID, stream)
+		s.streams.Delete(stream)
+	} else {
+		s.log.Warn("Stream not found: ", logfields.ID, stream)
+	}
+
+}
+
+// cleanupStreams handles the cleanup of streams when the server's context is cancelled.
+func (s *FQDNDataServer) cleanupStreams() {
+	s.streams.Range(func(key pb.FQDNData_StreamPolicyStateServer, cancelFunc context.CancelFunc) bool {
+		cancelFunc() // Ensure we cancel the context of each stream
+		s.streams.Delete(key)
+		return true
+	})
+	s.log.Info("All streams have been cleaned up")
+}
+
+// UpdateMappingRequest updates the FQDN mapping with the given data
+// SDP sends the fqdn mapping to cilium agent
+// Steps to update the mapping:
+// 1. Get the endpoint from the IP
+// 2. If the endpoint is not found, return an error
+// 3. If the IPs are not empty, update the cilium agent with the mapping
+func (s *FQDNDataServer) UpdateMappingRequest(ctx context.Context, mappings *pb.FQDNMapping) (*pb.UpdateMappingResponse, error) {
+	now := time.Now()
+	var ips []netip.Addr
+
+	endpointAddr := netip.MustParseAddr(string(mappings.SourceIp))
+
+	ep := s.endpointManager.LookupIP(endpointAddr)
+	if ep == nil {
+		s.log.Error("Endpoint not found for IP: ", logfields.IPAddr, endpointAddr)
+		return &pb.UpdateMappingResponse{}, fmt.Errorf("endpoint not found for IP: %s", mappings.SourceIp)
+	}
+
+	recordIps := mappings.GetRecordIp()
+	if len(recordIps) == 0 {
+		// We don't have any IPs to update the mappings with
+		return &pb.UpdateMappingResponse{
+			Response: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
+		}, nil
+	}
+
+	for _, ip := range recordIps {
+		ips = append(ips, netip.MustParseAddr(string(ip)))
+	}
+
+	if mappings.GetResponseCode() == dns.RcodeSuccess {
+		err := s.updateOnDNSMsg(now, ep, mappings.GetFqdn(), ips, int(mappings.GetTtl()), nil)
+		if err != nil {
+			return &pb.UpdateMappingResponse{}, fmt.Errorf("cannot update DNS cache: %w", err)
+		}
+	}
+
+	return &pb.UpdateMappingResponse{
+		Response: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
+	}, nil
+}
+
+// RunServer starts the Standalone DNS Proxy grpc server on the given port
+func RunServer(port int, server *FQDNDataServer) error {
+	address := fmt.Sprintf("localhost:%d", port)
+	server.log.Info("Starting Standalone DNS Proxy server on: ", logfields.Address, address)
+	lis, err := net.Listen("tcp", address)
+	if err != nil {
+		server.log.Error("Failed to listen: ", logfields.Error, err)
+		return err
+	}
+	grpcServer := grpc.NewServer(grpc.KeepaliveEnforcementPolicy(kaep), grpc.KeepaliveParams(kasp))
+	pb.RegisterFQDNDataServer(grpcServer, server)
+
+	closer := func() {
+		grpcServer.GracefulStop()
+	}
+	server.closeServer = closer
+
+	if err := grpcServer.Serve(lis); err != nil {
+		server.log.Error("Failed to serve: ", logfields.Error, err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/fqdn/service/service_test.go
+++ b/pkg/fqdn/service/service_test.go
@@ -1,0 +1,559 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"log/slog"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/testutils"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
+	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
+	"github.com/cilium/cilium/pkg/time"
+
+	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
+)
+
+const (
+	dnsServerIdentity = identity.NumericIdentity(2)
+	endpointIdentity  = identity.NumericIdentity(1)
+)
+
+type dummyEpSyncher struct{}
+
+func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, h cell.Health) {
+}
+
+func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
+}
+
+type Dummy struct {
+	repo policy.PolicyRepository
+}
+
+func (s *Dummy) GetPolicyRepository() policy.PolicyRepository {
+	return s.repo
+}
+
+func (s *Dummy) GetProxyPort(string) (uint16, error) {
+	return 0, nil
+}
+
+func (s *Dummy) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), error) {
+	return nil, nil
+}
+
+func (s *Dummy) GetCompilationLock() types.CompilationLock {
+	return nil
+}
+
+func (s *Dummy) GetCIDRPrefixLengths() (s6, s4 []int) {
+	return nil, nil
+}
+
+func (s *Dummy) SendNotification(msg monitorAPI.AgentNotifyMessage) error {
+	return nil
+}
+
+func (s *Dummy) Loader() types.Loader {
+	return nil
+}
+
+func (s *Dummy) Orchestrator() types.Orchestrator {
+	return nil
+}
+
+func (s *Dummy) BandwidthManager() types.BandwidthManager {
+	return nil
+}
+
+func (s *Dummy) IPTablesManager() types.IptablesManager {
+	return nil
+}
+
+func (s *Dummy) GetDNSRules(epID uint16) restore.DNSRules {
+	return nil
+}
+
+func (s *Dummy) RemoveRestoredDNSRules(epID uint16) {}
+
+func (s *Dummy) AddIdentity(id *identity.Identity) {}
+
+func (s *Dummy) RemoveIdentity(id *identity.Identity) {}
+
+func (s *Dummy) RemoveOldAddNewIdentity(old, new *identity.Identity) {}
+
+func server(ctx context.Context, t *testing.T) (*FQDNDataServer, pb.FQDNDataClient, func()) {
+	buffer := 1024
+	lis := bufconn.Listen(buffer)
+
+	baseServer := grpc.NewServer()
+	endptMgr := endpointmanager.New(&dummyEpSyncher{}, nil, nil)
+	repo := policy.NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, api.NewPolicyMetricsNoop())
+	do := &Dummy{
+		repo: repo,
+	}
+	// Add a test endpoint
+	ep := endpoint.NewTestEndpointWithState(do, nil, do, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
+	ep.IPv4 = netip.MustParseAddr("1.1.1.1")
+	err := endptMgr.ExposeTestEndpoint(ep)
+	if err != nil {
+		panic(err)
+	}
+
+	server := NewServer(endptMgr,
+		func(lookupTime time.Time, ep *endpoint.Endpoint, qname string, responseIPs []netip.Addr, TTL int, stat *dnsproxy.ProxyRequestContext) error {
+			// Mocking the response for the test
+			if qname == "example.com" {
+				return nil
+			}
+			return errors.New("Failed to update fqdn mapping")
+		},
+		logging.DefaultSlogLogger,
+	)
+	// Add the identity to ip mapping
+	server.currentIdentityToIp = map[identity.NumericIdentity][]net.IP{
+		endpointIdentity:  {net.ParseIP("1.1.1.1")},
+		dnsServerIdentity: {net.ParseIP("1.1.1.0")},
+	}
+
+	pb.RegisterFQDNDataServer(baseServer, server)
+	go func() {
+		if err := baseServer.Serve(lis); err != nil {
+			server.log.Error("Failed to serve bufnet listener", logfields.Error, err)
+		}
+	}()
+
+	conn, err := grpc.NewClient("passthrough://bufnet", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	if err != nil {
+		server.log.Error("Failed to dial bufnet", logfields.Error, err)
+	}
+	closer := func() {
+		server.ctx.Done()
+
+		err := lis.Close()
+		if err != nil {
+			server.log.Error("Failed to close bufnet listener", logfields.Error, err)
+		}
+		baseServer.Stop()
+	}
+
+	client := pb.NewFQDNDataClient(conn)
+
+	return server, client, closer
+}
+
+func TestUpdateMappingRequest(t *testing.T) {
+	ctx := context.Background()
+
+	_, client, closer := server(ctx, t)
+	defer closer()
+
+	type expected struct {
+		out *pb.UpdateMappingResponse
+		err error
+	}
+
+	responseIps := []string{
+		"2.2.2.2",
+	}
+	var ips [][]byte
+	for _, i := range responseIps {
+		ips = append(ips, []byte(i))
+	}
+
+	tests := map[string]struct {
+		in       *pb.FQDNMapping
+		expected expected
+	}{
+		"Success on updating the fqdn ips": {
+			in: &pb.FQDNMapping{
+				Fqdn:           "example.com",
+				RecordIp:       ips,
+				Ttl:            60,
+				SourceIdentity: 1,
+				SourceIp:       []byte("1.1.1.1"),
+				ResponseCode:   0,
+			},
+			expected: expected{
+				out: &pb.UpdateMappingResponse{
+					Response: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
+				},
+				err: nil,
+			},
+		},
+		"Failure due to update of fqdn ips": {
+			in: &pb.FQDNMapping{
+				Fqdn:           "failure.com",
+				RecordIp:       ips,
+				Ttl:            60,
+				SourceIdentity: 1,
+				SourceIp:       []byte("1.1.1.1"),
+				ResponseCode:   0,
+			},
+			expected: expected{
+				out: &pb.UpdateMappingResponse{},
+				err: errors.New("rpc error: code = Unknown desc = cannot update DNS cache: Failed to update fqdn mapping"),
+			},
+		},
+		"Success on response code non zero": {
+			in: &pb.FQDNMapping{
+				Fqdn:           "example.com",
+				RecordIp:       ips,
+				Ttl:            60,
+				SourceIdentity: 1,
+				SourceIp:       []byte("1.1.1.1"),
+				ResponseCode:   1,
+			},
+			expected: expected{
+				out: &pb.UpdateMappingResponse{
+					Response: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
+				},
+				err: nil,
+			},
+		},
+		"Failure due to endpoint not found": {
+			in: &pb.FQDNMapping{
+				Fqdn:           "example.com",
+				RecordIp:       ips,
+				Ttl:            60,
+				SourceIdentity: 1,
+				SourceIp:       []byte("1.1.1.0"),
+				ResponseCode:   0,
+			},
+			expected: expected{
+				out: &pb.UpdateMappingResponse{},
+				err: errors.New("rpc error: code = Unknown desc = endpoint not found for IP: 1.1.1.0"),
+			},
+		},
+		"Success if length of response ips is 0": {
+			in: &pb.FQDNMapping{
+				Fqdn:           "example.com",
+				RecordIp:       [][]byte{},
+				Ttl:            60,
+				SourceIdentity: 1,
+				SourceIp:       []byte("1.1.1.1"),
+				ResponseCode:   0,
+			},
+			expected: expected{
+				out: &pb.UpdateMappingResponse{
+					Response: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
+				},
+				err: nil,
+			},
+		},
+	}
+
+	for scenario, tt := range tests {
+		t.Run(scenario, func(t *testing.T) {
+			out, err := client.UpdateMappingRequest(ctx, tt.in)
+			require.Equal(t, tt.expected.out.GetResponse(), out.GetResponse())
+			if err != nil {
+				require.Equal(t, tt.expected.err.Error(), err.Error())
+			} else {
+				require.Equal(t, tt.expected.err, err)
+			}
+		})
+	}
+}
+
+type dummySelectorPolicy struct{}
+
+func (sp *dummySelectorPolicy) DistillPolicy(logger *slog.Logger, owner policy.PolicyOwner, redirects map[string]uint16) *policy.EndpointPolicy {
+	return nil
+}
+
+func (sp *dummySelectorPolicy) RedirectFilters() iter.Seq2[*policy.L4Filter, policy.PerSelectorPolicyTuple] {
+	sc := policy.NewSelectorCache(
+		logging.DefaultSlogLogger,
+		identity.IdentityMap{
+			dnsServerIdentity: labels.LabelArray{
+				labels.Label{
+					Key:   "app",
+					Value: "test",
+				},
+			},
+		},
+	)
+	sc.SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
+	dummySelectorCacheUser := &testpolicy.DummySelectorCacheUser{}
+	endpointSelector := api.NewESFromLabels(labels.ParseSelectLabel("app=test"))
+	cachedSelector, _ := sc.AddIdentitySelector(dummySelectorCacheUser, policy.EmptyStringLabels, endpointSelector)
+	expectedPolicy := policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
+		"53/UDP": {
+			Port:     53,
+			Protocol: api.ProtoUDP,
+			U8Proto:  0x11,
+			Ingress:  false,
+			PerSelectorPolicies: policy.L7DataMap{
+				cachedSelector: &policy.PerSelectorPolicy{
+					L7Parser: policy.ParserTypeDNS,
+					L7Rules: api.L7Rules{
+						DNS: []api.PortRuleDNS{
+							{
+								MatchName:    "example.com",
+								MatchPattern: "*.cilium.io",
+							},
+						},
+					},
+				},
+			},
+		},
+		"ANY/ANY": {
+			Port:     0,
+			Protocol: api.ProtoAny,
+			U8Proto:  0x00,
+			Ingress:  false,
+		},
+	})
+
+	// return the expected policy
+	return func(yield func(*policy.L4Filter, policy.PerSelectorPolicyTuple) bool) {
+		expectedPolicy.ForEach(func(l4 *policy.L4Filter) bool {
+			for cs, perSelectorPolicy := range l4.PerSelectorPolicies {
+				return yield(l4, policy.PerSelectorPolicyTuple{
+					Policy:   perSelectorPolicy,
+					Selector: cs,
+				})
+			}
+			return true
+		})
+	}
+}
+
+func TestSuccessfullyStreamPolicyState(t *testing.T) {
+	ctx := context.Background()
+	server, client, closer := server(ctx, t)
+	defer closer()
+
+	type in struct {
+		snaptshot   map[identity.NumericIdentity]policy.SelectorPolicy
+		policyRules *pb.PolicyState
+	}
+
+	tests := map[string]struct {
+		in in
+	}{
+		"Success on sending the rules to the client": {
+			in: in{
+				snaptshot: map[identity.NumericIdentity]policy.SelectorPolicy{
+					endpointIdentity: &dummySelectorPolicy{},
+				},
+				policyRules: &pb.PolicyState{
+					EgressL7DnsPolicy: []*pb.DNSPolicy{
+						{
+							SourceEndpointId: 1,
+							DnsPattern:       []string{"*.cilium.io", "example.com"},
+							DnsServers: []*pb.DNSServer{
+								{
+									DnsServerIdentity: 2,
+									DnsServerPort:     53,
+									DnsServerProto:    17,
+								},
+							},
+						},
+					},
+					RequestId: "1",
+					IdentityToEndpointMapping: []*pb.IdentityToEndpointMapping{
+						{
+							Identity: 2,
+							EndpointInfo: []*pb.EndpointInfo{
+								{
+									Ip: [][]byte{[]byte("1.1.1.0")},
+								},
+							},
+						},
+						{
+							Identity: 1,
+							EndpointInfo: []*pb.EndpointInfo{
+								{
+									Ip: [][]byte{[]byte("1.1.1.1")},
+									Id: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"Success on sending empty rules to the client": {
+			in: in{
+				snaptshot:   map[identity.NumericIdentity]policy.SelectorPolicy{},
+				policyRules: &pb.PolicyState{},
+			},
+		},
+	}
+
+	for scenario, test := range tests {
+		t.Run(scenario, func(t *testing.T) {
+			// set the server snapshot
+			server.currentSnapshot = test.in.snaptshot
+
+			// Client subscribes to the DNS rules
+			outClient, err := client.StreamPolicyState(ctx)
+			require.NoError(t, err)
+
+			// Server sends the DNS rules
+			actualOut, err := outClient.Recv()
+			require.NoError(t, err)
+			require.Equal(t, len(test.in.policyRules.GetEgressL7DnsPolicy()), len(actualOut.GetEgressL7DnsPolicy()))
+
+			for i, expectedPolicy := range test.in.policyRules.GetEgressL7DnsPolicy() {
+				actualPolicy := actualOut.GetEgressL7DnsPolicy()[i]
+				require.Equal(t, expectedPolicy.GetSourceEndpointId(), actualPolicy.GetSourceEndpointId())
+				require.Equal(t, expectedPolicy.GetDnsPattern(), actualPolicy.GetDnsPattern())
+				require.Equal(t, len(expectedPolicy.GetDnsServers()), len(actualPolicy.GetDnsServers()))
+				for j, expectedServer := range expectedPolicy.GetDnsServers() {
+					actualServer := actualPolicy.GetDnsServers()[j]
+					require.Equal(t, expectedServer.GetDnsServerPort(), actualServer.GetDnsServerPort())
+					require.Equal(t, expectedServer.GetDnsServerProto(), actualServer.GetDnsServerProto())
+				}
+			}
+
+			for i, expectedMapping := range test.in.policyRules.GetIdentityToEndpointMapping() {
+				actualMapping := actualOut.GetIdentityToEndpointMapping()[i]
+				require.Equal(t, expectedMapping.GetIdentity(), actualMapping.GetIdentity())
+				require.Equal(t, len(expectedMapping.GetEndpointInfo()), len(actualMapping.GetEndpointInfo()))
+				for j, expectedInfo := range expectedMapping.GetEndpointInfo() {
+					actualInfo := actualMapping.GetEndpointInfo()[j]
+					for _, ip := range expectedInfo.GetIp() {
+						require.Equal(t, string(ip), net.IP(actualInfo.GetIp()[j]).String())
+					}
+					require.Equal(t, expectedInfo.GetId(), actualInfo.GetId())
+				}
+			}
+
+			err = outClient.Send(&pb.PolicyStateResponse{
+				Response:  pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
+				RequestId: actualOut.RequestId,
+			})
+			require.NoError(t, err)
+
+			_, val := server.dnsMappingResult.Load(actualOut.RequestId)
+			require.True(t, val)
+
+			// Client closes the connection
+			err = outClient.CloseSend()
+			require.NoError(t, err)
+
+			// Wait for a second before checking if the server has received the close signal
+			sleepTime := time.NewTimer(1 * time.Second)
+			<-sleepTime.C
+			// Server receives the close signal and deletes the mapping
+			_, val = server.dnsMappingResult.Load(actualOut.RequestId)
+			require.False(t, val)
+		})
+	}
+}
+
+func TestFailureToStreamPolicyState(t *testing.T) {
+	ctx := context.Background()
+	server, client, closer := server(ctx, t)
+	defer closer()
+
+	// Client subscribes to the DNS rules
+	outClient, err := client.StreamPolicyState(ctx)
+	require.NoError(t, err)
+
+	for {
+		actualOut, err := outClient.Recv()
+		if err != nil {
+			// This is expected as the server has received the success as false
+			// So the client should receive an error and reestablish the stream
+			require.Equal(t, "rpc error: code = Canceled desc = context canceled", err.Error())
+			break
+		}
+		require.NoError(t, err)
+
+		// Client sends a failure response
+		err = outClient.Send(&pb.PolicyStateResponse{
+			Response:  pb.ResponseCode_RESPONSE_CODE_SERVER_FAILURE,
+			RequestId: actualOut.RequestId,
+		})
+		require.NoError(t, err)
+
+		mapValue, _ := server.dnsMappingResult.Load(actualOut.RequestId)
+		require.False(t, mapValue)
+	}
+}
+
+func TestRunServer(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	test := map[string]struct {
+		port   int
+		server *FQDNDataServer
+		err    error
+	}{
+		"Success on running the server": {
+			port: 1234,
+			server: &FQDNDataServer{
+				log: logging.DefaultSlogLogger,
+			},
+			err: nil,
+		},
+		"Failure on running the server": {
+			port: -1,
+			server: &FQDNDataServer{
+				log: logging.DefaultSlogLogger,
+			},
+			err: errors.New("listen tcp: address -1: invalid port"),
+		},
+	}
+
+	for scenario, tt := range test {
+		t.Run(scenario, func(t *testing.T) {
+
+			go func() {
+				err := RunServer(tt.port, tt.server)
+				if err != nil {
+					require.Equal(t, tt.err.Error(), err.Error())
+					// If the error is not nil, then terminate the test
+					return
+				} else {
+					require.Equal(t, tt.err, err)
+				}
+			}()
+
+			// Give the server some time to start
+			time.Sleep(1 * time.Second)
+
+			// Try to connect to the server
+			conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", tt.port), grpc.WithTransportCredentials(insecure.NewCredentials()))
+			require.NoError(t, err)
+			defer conn.Close()
+
+		})
+	}
+}

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -49,6 +49,17 @@ func (cache *policyCache) lookupOrCreate(identity *identityPkg.Identity) *cached
 	return cip
 }
 
+// GetPolicySnapshot returns a snapshot of the current policy cache.
+func (cache *policyCache) GetPolicySnapshot() map[identityPkg.NumericIdentity]SelectorPolicy {
+	cache.Lock()
+	defer cache.Unlock()
+	snapshot := make(map[identityPkg.NumericIdentity]SelectorPolicy, len(cache.policies))
+	for k, v := range cache.policies {
+		snapshot[k] = v.getPolicy()
+	}
+	return snapshot
+}
+
 // delete forgets about any cached SelectorPolicy that this endpoint uses.
 //
 // Returns true if the SelectorPolicy was removed from the cache.

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -122,6 +122,8 @@ type PolicyRepository interface {
 	// calculation.
 	GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics, endpointID uint64) (SelectorPolicy, uint64, error)
 
+	// GetPolicySnapshot returns a map of all the SelectorPolicies in the repository.
+	GetPolicySnapshot() map[identity.NumericIdentity]SelectorPolicy
 	GetRevision() uint64
 	GetRulesList() *models.Policy
 	GetSelectorCache() *SelectorCache
@@ -719,4 +721,12 @@ func (p *Repository) ReplaceByLabels(rules api.Rules, searchLabelsList []labels.
 	}
 
 	return affectedIDs, p.BumpRevision(), len(oldRules)
+}
+
+// GetPolicySnapshot returns a map of all the SelectorPolicies in the repository.
+func (p *Repository) GetPolicySnapshot() map[identity.NumericIdentity]SelectorPolicy {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+
+	return p.policyCache.GetPolicySnapshot()
 }

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -25,7 +25,7 @@ import (
 type SelectorPolicy interface {
 	// CreateRedirects is used to ensure the endpoint has created all the needed redirects
 	// before a new EndpointPolicy is created.
-	RedirectFilters() iter.Seq2[*L4Filter, *PerSelectorPolicy]
+	RedirectFilters() iter.Seq2[*L4Filter, PerSelectorPolicyTuple]
 
 	// DistillPolicy returns the policy in terms of connectivity to peer
 	// Identities.
@@ -380,21 +380,26 @@ func (l4policy L4DirectionPolicy) toMapState(logger *slog.Logger, p *EndpointPol
 	})
 }
 
+type PerSelectorPolicyTuple struct {
+	Policy   *PerSelectorPolicy
+	Selector CachedSelector
+}
+
 // RedirectFilters returns an iterator for each L4Filter with a redirect in the policy.
-func (p *selectorPolicy) RedirectFilters() iter.Seq2[*L4Filter, *PerSelectorPolicy] {
-	return func(yield func(*L4Filter, *PerSelectorPolicy) bool) {
+func (p *selectorPolicy) RedirectFilters() iter.Seq2[*L4Filter, PerSelectorPolicyTuple] {
+	return func(yield func(*L4Filter, PerSelectorPolicyTuple) bool) {
 		if p.L4Policy.Ingress.forEachRedirectFilter(yield) {
 			p.L4Policy.Egress.forEachRedirectFilter(yield)
 		}
 	}
 }
 
-func (l4policy L4DirectionPolicy) forEachRedirectFilter(yield func(*L4Filter, *PerSelectorPolicy) bool) bool {
+func (l4policy L4DirectionPolicy) forEachRedirectFilter(yield func(*L4Filter, PerSelectorPolicyTuple) bool) bool {
 	ok := true
 	l4policy.PortRules.ForEach(func(l4 *L4Filter) bool {
-		for _, ps := range l4.PerSelectorPolicies {
+		for cs, ps := range l4.PerSelectorPolicies {
 			if ps != nil && ps.IsRedirect() {
-				ok = yield(l4, ps)
+				ok = yield(l4, PerSelectorPolicyTuple{ps, cs})
 			}
 		}
 		return ok

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -9,9 +9,15 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/fqdn/defaultdns"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/revert"
+)
+
+var (
+	// GlobalStandaloneDNSProxy is the global, shared, standalone DNS Proxy singleton.
+	GlobalStandaloneDNSProxy sdpPolicyUpdater
 )
 
 // dnsRedirect implements the Redirect interface for an l7 proxy
@@ -22,6 +28,10 @@ type dnsRedirect struct {
 
 func (dr *dnsRedirect) GetRedirect() *Redirect {
 	return &dr.Redirect
+}
+
+type sdpPolicyUpdater interface {
+	UpdatePolicyRulesLocked(map[identity.NumericIdentity]policy.SelectorPolicy, bool) error
 }
 
 // setRules replaces old l7 rules of a redirect with new ones.

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -163,6 +164,16 @@ func proxyTypeNotFoundError(proxyType types.ProxyType, listener string, ingress 
 		dir = "ingress"
 	}
 	return fmt.Errorf("unrecognized %s proxy type for %s: %s", dir, listener, proxyType)
+}
+
+func (p *Proxy) UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy) {
+	if GlobalStandaloneDNSProxy == nil {
+		return
+	}
+
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	GlobalStandaloneDNSProxy.UpdatePolicyRulesLocked(rules, true)
 }
 
 func (p *Proxy) createNewRedirect(

--- a/vendor/google.golang.org/grpc/test/bufconn/bufconn.go
+++ b/vendor/google.golang.org/grpc/test/bufconn/bufconn.go
@@ -1,0 +1,318 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package bufconn provides a net.Conn implemented by a buffer and related
+// dialing and listening functionality.
+package bufconn
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+// Listener implements a net.Listener that creates local, buffered net.Conns
+// via its Accept and Dial method.
+type Listener struct {
+	mu   sync.Mutex
+	sz   int
+	ch   chan net.Conn
+	done chan struct{}
+}
+
+// Implementation of net.Error providing timeout
+type netErrorTimeout struct {
+	error
+}
+
+func (e netErrorTimeout) Timeout() bool   { return true }
+func (e netErrorTimeout) Temporary() bool { return false }
+
+var errClosed = fmt.Errorf("closed")
+var errTimeout net.Error = netErrorTimeout{error: fmt.Errorf("i/o timeout")}
+
+// Listen returns a Listener that can only be contacted by its own Dialers and
+// creates buffered connections between the two.
+func Listen(sz int) *Listener {
+	return &Listener{sz: sz, ch: make(chan net.Conn), done: make(chan struct{})}
+}
+
+// Accept blocks until Dial is called, then returns a net.Conn for the server
+// half of the connection.
+func (l *Listener) Accept() (net.Conn, error) {
+	select {
+	case <-l.done:
+		return nil, errClosed
+	case c := <-l.ch:
+		return c, nil
+	}
+}
+
+// Close stops the listener.
+func (l *Listener) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	select {
+	case <-l.done:
+		// Already closed.
+		break
+	default:
+		close(l.done)
+	}
+	return nil
+}
+
+// Addr reports the address of the listener.
+func (l *Listener) Addr() net.Addr { return addr{} }
+
+// Dial creates an in-memory full-duplex network connection, unblocks Accept by
+// providing it the server half of the connection, and returns the client half
+// of the connection.
+func (l *Listener) Dial() (net.Conn, error) {
+	return l.DialContext(context.Background())
+}
+
+// DialContext creates an in-memory full-duplex network connection, unblocks Accept by
+// providing it the server half of the connection, and returns the client half
+// of the connection.  If ctx is Done, returns ctx.Err()
+func (l *Listener) DialContext(ctx context.Context) (net.Conn, error) {
+	p1, p2 := newPipe(l.sz), newPipe(l.sz)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-l.done:
+		return nil, errClosed
+	case l.ch <- &conn{p1, p2}:
+		return &conn{p2, p1}, nil
+	}
+}
+
+type pipe struct {
+	mu sync.Mutex
+
+	// buf contains the data in the pipe.  It is a ring buffer of fixed capacity,
+	// with r and w pointing to the offset to read and write, respectively.
+	//
+	// Data is read between [r, w) and written to [w, r), wrapping around the end
+	// of the slice if necessary.
+	//
+	// The buffer is empty if r == len(buf), otherwise if r == w, it is full.
+	//
+	// w and r are always in the range [0, cap(buf)) and [0, len(buf)].
+	buf  []byte
+	w, r int
+
+	wwait sync.Cond
+	rwait sync.Cond
+
+	// Indicate that a write/read timeout has occurred
+	wtimedout bool
+	rtimedout bool
+
+	wtimer *time.Timer
+	rtimer *time.Timer
+
+	closed      bool
+	writeClosed bool
+}
+
+func newPipe(sz int) *pipe {
+	p := &pipe{buf: make([]byte, 0, sz)}
+	p.wwait.L = &p.mu
+	p.rwait.L = &p.mu
+
+	p.wtimer = time.AfterFunc(0, func() {})
+	p.rtimer = time.AfterFunc(0, func() {})
+	return p
+}
+
+func (p *pipe) empty() bool {
+	return p.r == len(p.buf)
+}
+
+func (p *pipe) full() bool {
+	return p.r < len(p.buf) && p.r == p.w
+}
+
+func (p *pipe) Read(b []byte) (n int, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Block until p has data.
+	for {
+		if p.closed {
+			return 0, io.ErrClosedPipe
+		}
+		if !p.empty() {
+			break
+		}
+		if p.writeClosed {
+			return 0, io.EOF
+		}
+		if p.rtimedout {
+			return 0, errTimeout
+		}
+
+		p.rwait.Wait()
+	}
+	wasFull := p.full()
+
+	n = copy(b, p.buf[p.r:len(p.buf)])
+	p.r += n
+	if p.r == cap(p.buf) {
+		p.r = 0
+		p.buf = p.buf[:p.w]
+	}
+
+	// Signal a blocked writer, if any
+	if wasFull {
+		p.wwait.Signal()
+	}
+
+	return n, nil
+}
+
+func (p *pipe) Write(b []byte) (n int, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return 0, io.ErrClosedPipe
+	}
+	for len(b) > 0 {
+		// Block until p is not full.
+		for {
+			if p.closed || p.writeClosed {
+				return 0, io.ErrClosedPipe
+			}
+			if !p.full() {
+				break
+			}
+			if p.wtimedout {
+				return 0, errTimeout
+			}
+
+			p.wwait.Wait()
+		}
+		wasEmpty := p.empty()
+
+		end := cap(p.buf)
+		if p.w < p.r {
+			end = p.r
+		}
+		x := copy(p.buf[p.w:end], b)
+		b = b[x:]
+		n += x
+		p.w += x
+		if p.w > len(p.buf) {
+			p.buf = p.buf[:p.w]
+		}
+		if p.w == cap(p.buf) {
+			p.w = 0
+		}
+
+		// Signal a blocked reader, if any.
+		if wasEmpty {
+			p.rwait.Signal()
+		}
+	}
+	return n, nil
+}
+
+func (p *pipe) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closed = true
+	// Signal all blocked readers and writers to return an error.
+	p.rwait.Broadcast()
+	p.wwait.Broadcast()
+	return nil
+}
+
+func (p *pipe) closeWrite() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.writeClosed = true
+	// Signal all blocked readers and writers to return an error.
+	p.rwait.Broadcast()
+	p.wwait.Broadcast()
+	return nil
+}
+
+type conn struct {
+	io.Reader
+	io.Writer
+}
+
+func (c *conn) Close() error {
+	err1 := c.Reader.(*pipe).Close()
+	err2 := c.Writer.(*pipe).closeWrite()
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+func (c *conn) SetDeadline(t time.Time) error {
+	c.SetReadDeadline(t)
+	c.SetWriteDeadline(t)
+	return nil
+}
+
+func (c *conn) SetReadDeadline(t time.Time) error {
+	p := c.Reader.(*pipe)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.rtimer.Stop()
+	p.rtimedout = false
+	if !t.IsZero() {
+		p.rtimer = time.AfterFunc(time.Until(t), func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.rtimedout = true
+			p.rwait.Broadcast()
+		})
+	}
+	return nil
+}
+
+func (c *conn) SetWriteDeadline(t time.Time) error {
+	p := c.Writer.(*pipe)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.wtimer.Stop()
+	p.wtimedout = false
+	if !t.IsZero() {
+		p.wtimer = time.AfterFunc(time.Until(t), func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.wtimedout = true
+			p.wwait.Broadcast()
+		})
+	}
+	return nil
+}
+
+func (*conn) LocalAddr() net.Addr  { return addr{} }
+func (*conn) RemoteAddr() net.Addr { return addr{} }
+
+type addr struct{}
+
+func (addr) Network() string { return "bufconn" }
+func (addr) String() string  { return "bufconn" }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1866,6 +1866,7 @@ google.golang.org/grpc/serviceconfig
 google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
+google.golang.org/grpc/test/bufconn
 # google.golang.org/protobuf v1.36.5
 ## explicit; go 1.21
 google.golang.org/protobuf/encoding/protodelim


### PR DESCRIPTION
The PR adds the cilium agent grpc server to send the policy rules to SDP. For overall flow, please go through the https://github.com/cilium/cilium/issues/30984#issuecomment-2505035738 and overall SDP PR: https://github.com/cilium/cilium/pull/37836
- The grpc server starts running on a default port if `l7proxy` and `enable-standalone-dns-proxy` is true
- Cilium agent sends the data to SDP(standalone dns proxy) during endpoint regeneration specifically after the policy cache is updated. There is lock mechanism in the `policyCache` as well as the `FqdnDataServer` to make sure that the updates are a snapshot of the current policy state.(and in serialized manner)
- `StreamPolicyState` is called by the client(SDP) on start and cilium agent sents it the current policy rules it has. Otherwise, it stores the stream and write the rules on the same stream for the client to receive.
- `UpdateMappingRequest` is used by the client to send the data(DNS Response mappings) to cilium agent.
 
Fixes: https://github.com/cilium/cilium/issues/30984
Related PRs: https://github.com/cilium/cilium/pull/36214, https://github.com/cilium/cilium/pull/36215
CFP: https://github.com/cilium/design-cfps/pull/54