### PR TITLE
feat: Standalone dns proxy - Client side w.r.t cilium

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -176,6 +176,7 @@ cilium-agent [flags]
       --enable-sctp                                               Enable SCTP support (beta)
       --enable-service-topology                                   Enable support for service topology aware hints
       --enable-session-affinity                                   Enable support for service session affinity
+      --enable-standalone-dns-proxy                               Enables standalone dns proxy.
       --enable-svc-source-range-check                             Enable check of service source ranges (currently, only for LoadBalancer) (default true)
       --enable-tcx                                                Attach endpoint programs using tcx if supported by the kernel (default true)
       --enable-tracing                                            Enable tracing while determining policy (debugging)
@@ -382,6 +383,7 @@ cilium-agent [flags]
       --tofqdns-pre-cache string                                  DNS cache data at this path is preloaded on agent startup
       --tofqdns-proxy-port int                                    Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
       --tofqdns-proxy-response-max-delay duration                 The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
+      --tofqdns-server-port int                                   Global port on which the grpc server for standalone dns proxy should listen. Default is 40045. (default 40045)
       --trace-payloadlen int                                      Length of payload to capture when tracing (default 128)
       --trace-sock                                                Enable tracing for socket-based LB (default true)
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -802,8 +802,14 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Int(option.ToFQDNsMinTTL, defaults.ToFQDNsMinTTL, "The minimum time, in seconds, to use DNS data for toFQDNs policies")
 	option.BindEnv(vp, option.ToFQDNsMinTTL)
 
+	flags.Bool(option.EnableStandaloneDNSProxy, false, "Enables standalone dns proxy.")
+	option.BindEnv(vp, option.EnableStandaloneDNSProxy)
+
 	flags.Int(option.ToFQDNsProxyPort, 0, "Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.")
 	option.BindEnv(vp, option.ToFQDNsProxyPort)
+
+	flags.Int(option.ToFqdnsServerPort, 40045, "Global port on which the grpc server for standalone dns proxy should listen. Default is 40045.")
+	option.BindEnv(vp, option.ToFqdnsServerPort)
 
 	flags.String(option.FQDNRejectResponseCode, option.FQDNProxyDenyWithRefused, fmt.Sprintf("DNS response code for rejecting DNS requests, available options are '%v'", option.FQDNRejectOptions))
 	option.BindEnv(vp, option.FQDNRejectResponseCode)

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -161,6 +162,9 @@ type DNSProxy struct {
 
 	// UnbindAddress unbinds dns servers from socket in order to stop serving DNS traffic before proxy shutdown
 	unbindAddress func()
+
+	// DNSProxyType is the type of DNS proxy - either in built DNS proxy or standalone DNS proxy
+	DNSProxyType DNSProxyType
 }
 
 // regexCacheEntry is a lookup entry used to cache a compiled regex
@@ -189,6 +193,55 @@ type CachedSelectorREEntry map[policy.CachedSelector]*regexp.Regexp
 
 // structure for restored rules that can be used while Cilium agent is restoring endpoints
 type perEPRestored map[uint64]map[restore.PortProto][]restoredIPRule
+
+// DNSServerIdentity contains the identities of the DNS servers and used to
+// determine if a DNS request is allowed or not from standalone DNS proxy.
+// It adheres the interface policy.CachedSelector and reuses the
+// embedded dns proxy filtering path.
+type DnsServerIdentity struct {
+	Identities []uint32
+}
+
+func (d DnsServerIdentity) Selects(_ *versioned.VersionHandle, identity identity.NumericIdentity) bool {
+	for _, id := range d.Identities {
+		if id == identity.Uint32() {
+			return true
+		}
+	}
+	return false
+}
+
+func (d DnsServerIdentity) String() string {
+	identityStrings := make([]string, len(d.Identities))
+	for i, id := range d.Identities {
+		identityStrings[i] = strconv.FormatUint(uint64(id), 10)
+	}
+	return strings.Join(identityStrings, ",")
+}
+
+// Not being used in the standalone dns proxy path
+func (d DnsServerIdentity) IsWildcard() bool {
+	return false
+}
+
+// Not being used in the standalone dns proxy path
+func (d DnsServerIdentity) IsNone() bool {
+	return false
+}
+
+// Not being used in the standalone dns proxy path
+func (d DnsServerIdentity) GetSelections(_ *versioned.VersionHandle) identity.NumericIdentitySlice {
+	s := make(identity.NumericIdentitySlice, len(d.Identities))
+	for i, id := range d.Identities {
+		s[i] = identity.NumericIdentity(id)
+	}
+	return s
+}
+
+// Not being used in the standalone dns proxy path
+func (d DnsServerIdentity) GetMetadataLabels() labels.LabelArray {
+	return nil
+}
 
 // restoredIPRule is the dnsproxy internal way of representing a restored IPRule
 // where we also store the actual compiled regular expression as a, as well
@@ -529,6 +582,11 @@ func (allow perEPAllow) setPortRulesForID(cache regexCache, endpointID uint64, d
 		}
 		return err
 	}
+	allow.updatePortRulesForID(cache, endpointID, destPortProto, cse)
+	return nil
+}
+
+func (allow perEPAllow) updatePortRulesForID(cache regexCache, endpointID uint64, destPortProto restore.PortProto, cse CachedSelectorREEntry) {
 	allow.removeAndReleasePortRulesForID(cache, endpointID, destPortProto)
 	epPortProtos, exist := allow[endpointID]
 	if !exist {
@@ -536,7 +594,6 @@ func (allow perEPAllow) setPortRulesForID(cache regexCache, endpointID uint64, d
 		allow[endpointID] = epPortProtos
 	}
 	epPortProtos[destPortProto] = cse
-	return nil
 }
 
 // setPortRulesForIDFromUnifiedFormat sets the matching rules for endpointID and destPort for
@@ -663,6 +720,11 @@ func (proxyStat *ProxyRequestContext) IsTimeout() bool {
 	return false
 }
 
+type DNSProxyType string
+
+const DefaultDNSProxy DNSProxyType = "default"
+const StandaloneDNSProxy DNSProxyType = "standalone"
+
 // DNSProxyConfig is the configuration for the DNS proxy.
 type DNSProxyConfig struct {
 	Address                string
@@ -673,6 +735,7 @@ type DNSProxyConfig struct {
 	MaxRestoreDNSIPs       int
 	ConcurrencyLimit       int
 	ConcurrencyGracePeriod time.Duration
+	DNSProxyType           DNSProxyType
 }
 
 // StartDNSProxy starts a proxy used for DNS L7 redirects that listens on
@@ -701,6 +764,10 @@ func StartDNSProxy(
 		return nil, errors.New("DNS proxy must have lookupEPFunc and notifyFunc provided")
 	}
 
+	if dnsProxyConfig.DNSProxyType == "" {
+		dnsProxyConfig.DNSProxyType = DefaultDNSProxy
+	}
+
 	p := &DNSProxy{
 		LookupRegisteredEndpoint: lookupEPFunc,
 		LookupSecIDByIP:          lookupSecIDFunc,
@@ -717,6 +784,7 @@ func StartDNSProxy(
 		EnableDNSCompression:     dnsProxyConfig.EnableDNSCompression,
 		maxIPsPerRestoredDNSRule: dnsProxyConfig.MaxRestoreDNSIPs,
 		DNSClients:               NewSharedClients(),
+		DNSProxyType:             dnsProxyConfig.DNSProxyType,
 	}
 	if dnsProxyConfig.ConcurrencyLimit > 0 {
 		p.ConcurrencyLimit = semaphore.NewWeighted(int64(dnsProxyConfig.ConcurrencyLimit))
@@ -835,6 +903,57 @@ func (p *DNSProxy) UpdateAllowedFromSelectorRegexes(endpointID uint64, destPortP
 	// Rules were updated based on policy, remove restored rules
 	p.removeRestoredRulesLocked(endpointID)
 	return nil
+}
+
+// Used for testing Standalone DNS Proxy
+func (p *DNSProxy) GetAllowedRulesForEndpoint(endpointID uint64) (map[restore.PortProto]CachedSelectorREEntry, error) {
+	p.RLock()
+	defer p.RUnlock()
+	return p.allowed[endpointID], nil
+}
+
+// UpdateAllowedStandaloneDnsProxy called by SDP to update per endpoint id DNS rules
+func (p *DNSProxy) UpdateAllowedStandaloneDnsProxy(epId uint64, portProto restore.PortProto, dnsRules map[policy.CachedSelector][]string) (revert.RevertFunc, error) {
+	p.Lock()
+	defer p.Unlock()
+
+	if dnsRules == nil {
+		p.allowed.removeAndReleasePortRulesForID(p.cache, epId, portProto)
+		return nil, nil
+	}
+
+	var err error
+	var regex *regexp.Regexp
+	cse := make(CachedSelectorREEntry, len(dnsRules))
+	for sel, dnsPattern := range dnsRules {
+		pattern := GeneratePatternForRules(dnsPattern)
+		regex, err = p.cache.lookupOrCompileRegex(pattern)
+		if err != nil {
+			break
+		}
+		cse[sel] = regex
+	}
+
+	if err != nil {
+		// Unregister the registered regexes before returning the error to avoid
+		// leaving unused references in the cache
+		for k, regex := range cse {
+			p.cache.releaseRegex(regex)
+			delete(cse, k)
+		}
+		return nil, err
+	}
+
+	p.allowed.updatePortRulesForID(p.cache, epId, portProto, cse)
+	revert := func() error {
+		p.Lock()
+		defer p.Unlock()
+		if _, exists := p.allowed[epId]; exists {
+			p.allowed.updatePortRulesForID(p.cache, epId, portProto, p.allowed[epId][portProto])
+		}
+		return nil
+	}
+	return revert, err
 }
 
 // CheckAllowed checks endpointID, destPortProto, destID, destIP, and name against the rules
@@ -1088,8 +1207,16 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	scopedLog.Debug("Forwarding DNS request for a name that is allowed")
 	if err := p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, request, protocol, true, &stat); err != nil {
 		scopedLog.WithError(err).Error("Failed to process DNS query")
-		p.sendRefused(scopedLog, w, request)
-		return
+		if p.DNSProxyType == StandaloneDNSProxy {
+			// In standalone mode, we don't want to send a refused response to the client
+			// because this can happen when cilium agent is down and the DNS proxy is still
+			// running. In this case, we want to allow the DNS query to be forwarded to the
+			// upstream DNS server.
+			scopedLog.Warn("Failed to process DNS query, allowing the DNS query to be forwarded to the upstream DNS server")
+		} else {
+			p.sendRefused(scopedLog, w, request)
+			return
+		}
 	}
 
 	// Keep the same L4 protocol. This handles DNS re-requests over TCP, for
@@ -1171,8 +1298,16 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	scopedLog.Debug("Notifying with DNS response to original DNS query")
 	if err := p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, response, protocol, true, &stat); err != nil {
 		scopedLog.WithField(logfields.Response, response).WithError(err).Error("Failed to process DNS response")
-		p.sendRefused(scopedLog, w, request)
-		return
+		if p.DNSProxyType == StandaloneDNSProxy {
+			// In standalone mode, we don't want to send a refused response to the client
+			// because this can happen when cilium agent is down and the DNS proxy is still
+			// running. In this case, we want to allow the DNS response to be forwarded to the
+			// client.
+			scopedLog.Warn("Failed to process DNS response, allowing the DNS response to be forwarded to the client")
+		} else {
+			p.sendRefused(scopedLog, w, request)
+			return
+		}
 	}
 
 	scopedLog.Debug("Responding to original DNS query")
@@ -1481,6 +1616,24 @@ func GeneratePattern(l7Rules *policy.PerSelectorPolicy) (pattern string) {
 			}
 			reStrings = append(reStrings, dnsPatternAsRE)
 		}
+	}
+	return "^(?:" + strings.Join(reStrings, "|") + ")$"
+}
+
+func GeneratePatternForRules(rules []string) (pattern string) {
+	if len(rules) == 0 {
+		return matchpattern.MatchAllAnchoredPattern
+	}
+
+	reStrings := make([]string, 0, len(rules))
+	for _, rule := range rules {
+		rulePattern := matchpattern.Sanitize(rule)
+		ruleAsRE := matchpattern.ToUnAnchoredRegexp(rulePattern)
+		if ruleAsRE == matchpattern.MatchAllUnAnchoredPattern {
+			return matchpattern.MatchAllAnchoredPattern
+		}
+		reStrings = append(reStrings, ruleAsRE)
+
 	}
 	return "^(?:" + strings.Join(reStrings, "|") + ")$"
 }

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -259,9 +259,13 @@ var (
 
 	cachedWildcardSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, policy.EmptyStringLabels, api.WildcardEndpointSelector)
 
-	epID1            = uint64(111)
-	epID2            = uint64(222)
-	epID3            = uint64(333)
+	epID1 = uint64(111)
+	epID2 = uint64(222)
+	epID3 = uint64(333)
+	// Endpoints id used by sdp
+	epSdpID1         = uint64(1111)
+	epSdpID2         = uint64(2222)
+	epSdpID3         = uint64(3333)
 	dstID1           = identity.NumericIdentity(1001)
 	dstID2           = identity.NumericIdentity(2002)
 	dstID3           = identity.NumericIdentity(3003)
@@ -271,6 +275,15 @@ var (
 	udpProtoPort54   = restore.MakeV2PortProto(54, u8proto.UDP)
 	udpProtoPort8053 = restore.MakeV2PortProto(8053, u8proto.UDP)
 	tcpProtoPort53   = restore.MakeV2PortProto(53, u8proto.TCP)
+
+	// StandaloneDNSProxy dns server ids
+	dnsServerId1 = &DnsServerIdentity{Identities: []uint32{dstID1.Uint32()}}
+	dnsServerId2 = &DnsServerIdentity{Identities: []uint32{dstID2.Uint32()}}
+	dnsServerId3 = &DnsServerIdentity{Identities: []uint32{dstID3.Uint32()}}
+	dnsServerId4 = &DnsServerIdentity{Identities: []uint32{dstID4.Uint32()}}
+	dnsRules     = map[policy.CachedSelector][]string{
+		dnsServerId1: {"cilium.io"},
+	}
 )
 
 func TestRejectFromDifferentEndpoint(t *testing.T) {
@@ -292,6 +305,13 @@ func TestRejectFromDifferentEndpoint(t *testing.T) {
 	allowed, err := s.proxy.CheckAllowed(epID2, dstPortProto, dstID1, netip.Addr{}, query)
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was not rejected when it should be blocked")
+
+	// Reject a query from not endpoint 2
+	_, err = s.proxy.UpdateAllowedStandaloneDnsProxy(epID2, dstPortProto, dnsRules)
+	require.NoError(t, err, "Could not update with rules")
+	allowed, err = s.proxy.CheckAllowed(epID3, dstPortProto, dstID1, netip.Addr{}, query)
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was not rejected when it should be blocked")
 }
 
 func TestAcceptFromMatchingEndpoint(t *testing.T) {
@@ -311,6 +331,13 @@ func TestAcceptFromMatchingEndpoint(t *testing.T) {
 	_, err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	require.NoError(t, err, "Could not update with rules")
 	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, netip.Addr{}, query)
+	require.NoError(t, err, "Error when checking allowed")
+	require.True(t, allowed, "request was rejected when it should be allowed")
+
+	// StandaloneDNSProxy should accept the request
+	_, err = s.proxy.UpdateAllowedStandaloneDnsProxy(epID2, dstPortProto, dnsRules)
+	require.NoError(t, err, "Could not update with rules")
+	allowed, err = s.proxy.CheckAllowed(epID2, dstPortProto, dstID1, netip.Addr{}, query)
 	require.NoError(t, err, "Error when checking allowed")
 	require.True(t, allowed, "request was rejected when it should be allowed")
 }
@@ -353,6 +380,13 @@ func TestRejectNonRegex(t *testing.T) {
 	_, err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	require.NoError(t, err, "Could not update with rules")
 	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, netip.Addr{}, query)
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was not rejected when it should be blocked")
+
+	// StandaloneDNSProxy should reject the query
+	_, err = s.proxy.UpdateAllowedStandaloneDnsProxy(epID2, dstPortProto, dnsRules)
+	require.NoError(t, err, "Could not update with rules")
+	allowed, err = s.proxy.CheckAllowed(epID2, dstPortProto, dstID1, netip.Addr{}, query)
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was not rejected when it should be blocked")
 }
@@ -489,6 +523,16 @@ func TestCheckNoRules(t *testing.T) {
 
 	require.True(t, allowed, "request was rejected when it should be allowed")
 
+	dnsRules := map[policy.CachedSelector][]string{
+		dnsServerId1: nil,
+	}
+	_, err = s.proxy.UpdateAllowedStandaloneDnsProxy(epID2, dstPortProto, dnsRules)
+	require.NoError(t, err, "Error when inserting rules")
+	allowed, err = s.proxy.CheckAllowed(epID2, dstPortProto, dstID1, netip.Addr{}, query)
+	require.NoError(t, err, "Error when checking allowed")
+
+	require.True(t, allowed, "request was rejected when it should be allowed")
+
 	l7map = policy.L7DataMap{
 		cachedDstID1Selector: &policy.PerSelectorPolicy{
 			L7Rules: api.L7Rules{
@@ -502,6 +546,16 @@ func TestCheckNoRules(t *testing.T) {
 	allowed, err = s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, netip.Addr{}, query)
 	require.NoError(t, err, "Error when checking allowed")
 	require.True(t, allowed, "request was rejected when it should be allowed")
+
+	dnsRules = map[policy.CachedSelector][]string{
+		dnsServerId1: {},
+	}
+	_, err = s.proxy.UpdateAllowedStandaloneDnsProxy(epID2, dstPortProto, dnsRules)
+	require.NoError(t, err, "Error when inserting rules")
+
+	allowed, err = s.proxy.CheckAllowed(epID2, dstPortProto, dstID1, netip.Addr{}, query)
+	require.NoError(t, err, "Error when checking allowed")
+	require.True(t, allowed, "request was rejected when it should be blocked")
 }
 
 func TestCheckAllowedTwiceRemovedOnce(t *testing.T) {
@@ -537,6 +591,30 @@ func TestCheckAllowedTwiceRemovedOnce(t *testing.T) {
 	_, err = s.proxy.UpdateAllowed(epID1, dstPortProto, nil)
 	require.NoError(t, err, "Could not update with rules")
 	allowed, err = s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, netip.Addr{}, query)
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
+
+	// StandaloneDNSProxy
+	// Add the rule twice
+	_, err = s.proxy.UpdateAllowedStandaloneDnsProxy(epID2, dstPortProto, dnsRules)
+	require.NoError(t, err, "Could not update with rules")
+	_, err = s.proxy.UpdateAllowedStandaloneDnsProxy(epID2, dstPortProto, dnsRules)
+	require.NoError(t, err, "Could not update with rules")
+	allowed, err = s.proxy.CheckAllowed(epID2, dstPortProto, dstID1, netip.Addr{}, query)
+	require.NoError(t, err, "Error when checking allowed")
+	require.True(t, allowed, "request was rejected when it should be allowed")
+
+	// Delete once, it should reject
+	_, err = s.proxy.UpdateAllowedStandaloneDnsProxy(epID2, dstPortProto, nil)
+	require.NoError(t, err, "Could not update with rules")
+	allowed, err = s.proxy.CheckAllowed(epID2, dstPortProto, dstID1, netip.Addr{}, query)
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
+
+	// Delete once, it should reject and not crash
+	_, err = s.proxy.UpdateAllowedStandaloneDnsProxy(epID2, dstPortProto, nil)
+	require.NoError(t, err, "Could not update with rules")
+	allowed, err = s.proxy.CheckAllowed(epID2, dstPortProto, dstID1, netip.Addr{}, query)
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was allowed when it should be rejected")
 }
@@ -618,6 +696,16 @@ func TestFullPathDependence(t *testing.T) {
 		},
 	})
 	require.NoError(t, err, "Could not update with port 53 rules")
+	// SDP
+	//	| SDPEP1  | DstID1 |      53 |  UDP  | *.ubuntu.com   |
+	//	| SDPEP1  | DstID1 |      53 |  UDP  | aws.amazon.com |
+	//	| SDPEP1  | DstID2 |      53 |  UDP  | cilium.io      |
+	dnsRules = map[policy.CachedSelector][]string{
+		dnsServerId1: {"*.ubuntu.com.", "aws.amazon.com."},
+		dnsServerId2: {"cilium.io."},
+	}
+	_, err = s.proxy.UpdateAllowedStandaloneDnsProxy(epSdpID1, udpProtoPort53, dnsRules)
+	require.NoError(t, err, "Could not update with port 53 rules")
 
 	//      | EP1  | DstID1 |      53 |  TCP  | sub.ubuntu.com |
 	_, err = s.proxy.UpdateAllowed(epID1, tcpProtoPort53, policy.L7DataMap{
@@ -631,6 +719,14 @@ func TestFullPathDependence(t *testing.T) {
 	})
 	require.NoError(t, err, "Could not update with rules")
 
+	// SDP
+	//  | SDPEP1  | DstID1 |      53 |  TCP  | sub.ubuntu.com |
+	dnsRules = map[policy.CachedSelector][]string{
+		dnsServerId1: {"sub.ubuntu.com."},
+	}
+	_, err = s.proxy.UpdateAllowedStandaloneDnsProxy(epSdpID1, tcpProtoPort53, dnsRules)
+	require.NoError(t, err, "Could not update with rules")
+
 	//	| EP1  | DstID1 |      54 |  UDP  | example.com    |
 	_, err = s.proxy.UpdateAllowed(epID1, udpProtoPort54, policy.L7DataMap{
 		cachedWildcardSelector: &policy.PerSelectorPolicy{
@@ -641,6 +737,14 @@ func TestFullPathDependence(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(t, err, "Could not update with rules")
+
+	// SDP
+	//	| SDPEP1  | DstID1 |      54 |  UDP  | example.com    |
+	dnsRules = map[policy.CachedSelector][]string{
+		dnsServerId1: {"example.com."},
+	}
+	_, err = s.proxy.UpdateAllowedStandaloneDnsProxy(epSdpID1, udpProtoPort54, dnsRules)
 	require.NoError(t, err, "Could not update with rules")
 
 	// | EP3  | DstID1 |      53 |  UDP  | example.com    |
@@ -665,6 +769,19 @@ func TestFullPathDependence(t *testing.T) {
 	})
 	require.NoError(t, err, "Could not update with rules")
 
+	// SDP
+	// | SDPEP3  | DstID1 |      53 |  UDP  | example.com    |
+	// | SDPEP3  | DstID3 |      53 |  UDP  | *              |
+	// | SDPEP3  | DstID4 |      53 |  UDP  | nil            |
+	dnsRules = map[policy.CachedSelector][]string{
+		dnsServerId1: {"example.com."},
+		dnsServerId3: {"*"},
+		dnsServerId4: nil,
+	}
+
+	_, err = s.proxy.UpdateAllowedStandaloneDnsProxy(epSdpID3, udpProtoPort53, dnsRules)
+	require.NoError(t, err, "Could not update with rules")
+
 	// | EP3  | DstID3 |      53 |  TCP  | example.com    |
 	_, err = s.proxy.UpdateAllowed(epID3, tcpProtoPort53, policy.L7DataMap{
 		cachedDstID3Selector: &policy.PerSelectorPolicy{
@@ -677,44 +794,76 @@ func TestFullPathDependence(t *testing.T) {
 	})
 	require.NoError(t, err, "Could not update with rules")
 
+	// SDP
+	// | SDPEP3  | DstID3 |      53 |  TCP  | example.com    |
+	dnsRules = map[policy.CachedSelector][]string{
+		dnsServerId3: {"example.com"},
+	}
+	_, err = s.proxy.UpdateAllowedStandaloneDnsProxy(epSdpID3, tcpProtoPort53, dnsRules)
+	require.NoError(t, err, "Could not update with rules")
+
 	// Test cases
-	// Case 1 | EPID1 | DstID1 |   53 |  UDP  | www.ubuntu.com | Allowed
+	// Case 1 | EPID1 or EPSDPE1 | DstID1 |   53 |  UDP  | www.ubuntu.com | Allowed
 	allowed, err := s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID1, netip.Addr{}, "www.ubuntu.com")
 	require.NoError(t, err, "Error when checking allowed")
 	require.True(t, allowed, "request was rejected when it should be allowed")
+	allowed, err = s.proxy.CheckAllowed(epSdpID1, udpProtoPort53, dstID1, netip.Addr{}, "www.ubuntu.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.True(t, allowed, "request was rejected when it should be allowed")
 
-	// Case 2 | EPID1 | DstID1 |   53 |    TCP   | www.ubuntu.com | Rejected | Protocol TCP only allows "sub.ubuntu.com"
+	// Case 2 | EPID1  or EPSDPE1 | DstID1 |   53 |    TCP   | www.ubuntu.com | Rejected | Protocol TCP only allows "sub.ubuntu.com"
 	allowed, err = s.proxy.CheckAllowed(epID1, tcpProtoPort53, dstID1, netip.Addr{}, "www.ubuntu.com")
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was allowed when it should be rejected")
+	allowed, err = s.proxy.CheckAllowed(epSdpID1, tcpProtoPort53, dstID1, netip.Addr{}, "www.ubuntu.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
 
-	// Case 3 | EPID1 | DstID1 |   53 |    TCP   | sub.ubuntu.com | Allowed
+	// Case 3 | EPID1 or EPSDPE1 | DstID1 |   53 |    TCP   | sub.ubuntu.com | Allowed
 	allowed, err = s.proxy.CheckAllowed(epID1, tcpProtoPort53, dstID1, netip.Addr{}, "sub.ubuntu.com")
 	require.NoError(t, err, "Error when checking allowed")
 	require.True(t, allowed, "request was rejected when it should be allowed")
+	allowed, err = s.proxy.CheckAllowed(epSdpID1, tcpProtoPort53, dstID1, netip.Addr{}, "sub.ubuntu.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.True(t, allowed, "request was rejected when it should be allowed")
 
-	// Case 4 | EPID1 | DstID1 |   53 |    UDP   | sub.ubuntu.com | Allowed
+	// Case 4 | EPID1 or EPSDPE1 | DstID1 |   53 |    UDP   | sub.ubuntu.com | Allowed
 	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID1, netip.Addr{}, "sub.ubuntu.com")
 	require.NoError(t, err, "Error when checking allowed")
 	require.True(t, allowed, "request was rejected when it should be allowed")
-
-	// Case 5 | EPID1 | DstID1 |   54 |  UDP  | cilium.io      | Rejected | Port 54 only allows example.com
-	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, dstID1, netip.Addr{}, "cilium.io")
-	require.NoError(t, err, "Error when checking allowed")
-	require.False(t, allowed, "request was allowed when it should be rejected")
-
-	// Case 6 | EPID1 | DstID2 |   53 |  UDP  | cilium.io      | Allowed
-	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID2, netip.Addr{}, "cilium.io")
+	allowed, err = s.proxy.CheckAllowed(epSdpID1, udpProtoPort53, dstID1, netip.Addr{}, "sub.ubuntu.com")
 	require.NoError(t, err, "Error when checking allowed")
 	require.True(t, allowed, "request was rejected when it should be allowed")
 
-	// Case 7 | EPID1 | DstID2 |   53 |  UDP  | aws.amazon.com | Rejected | Only cilium.io is allowed with DstID2
-	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID2, netip.Addr{}, "aws.amazon.com")
+	// Case 5 | EPID1 or EPSDPE1 | DstID1 |   54 |  UDP  | cilium.io      | Rejected | Port 54 only allows example.com
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, dstID1, netip.Addr{}, "cilium.io")
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
+	allowed, err = s.proxy.CheckAllowed(epSdpID1, udpProtoPort54, dstID1, netip.Addr{}, "cilium.io")
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was allowed when it should be rejected")
 
-	// Case 8 | EPID1 | DstID1 |   54 |  UDP  | example.com    | Allowed
+	// Case 6 | EPID1 or EPSDPE1 | DstID2 |   53 |  UDP  | cilium.io      | Allowed
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID2, netip.Addr{}, "cilium.io")
+	require.NoError(t, err, "Error when checking allowed")
+	require.True(t, allowed, "request was rejected when it should be allowed")
+	allowed, err = s.proxy.CheckAllowed(epSdpID1, udpProtoPort53, dstID2, netip.Addr{}, "cilium.io")
+	require.NoError(t, err, "Error when checking allowed")
+	require.True(t, allowed, "request was rejected when it should be allowed")
+
+	// Case 7 | EPID1 or EPSDPE1 | DstID2 |   53 |  UDP  | aws.amazon.com | Rejected | Only cilium.io is allowed with DstID2
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID2, netip.Addr{}, "aws.amazon.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
+	allowed, err = s.proxy.CheckAllowed(epSdpID1, udpProtoPort53, dstID2, netip.Addr{}, "aws.amazon.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
+
+	// Case 8 | EPID1 or EPSDPE1 | DstID1 |   54 |  UDP  | example.com    | Allowed
 	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, dstID1, netip.Addr{}, "example.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.True(t, allowed, "request was rejected when it should be allowed")
+	allowed, err = s.proxy.CheckAllowed(epSdpID1, udpProtoPort54, dstID1, netip.Addr{}, "example.com")
 	require.NoError(t, err, "Error when checking allowed")
 	require.True(t, allowed, "request was rejected when it should be allowed")
 
@@ -722,9 +871,15 @@ func TestFullPathDependence(t *testing.T) {
 	allowed, err = s.proxy.CheckAllowed(epID2, udpProtoPort53, dstID1, netip.Addr{}, "cilium.io")
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was allowed when it should be rejected")
+	allowed, err = s.proxy.CheckAllowed(epSdpID2, udpProtoPort53, dstID1, netip.Addr{}, "cilium.io")
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
 
 	// Case 10 | EPID3 | DstID1 |   53 |  UDP  | example.com    | Allowed
 	allowed, err = s.proxy.CheckAllowed(epID3, udpProtoPort53, dstID1, netip.Addr{}, "example.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.True(t, allowed, "request was rejected when it should be allowed")
+	allowed, err = s.proxy.CheckAllowed(epSdpID3, udpProtoPort53, dstID1, netip.Addr{}, "example.com")
 	require.NoError(t, err, "Error when checking allowed")
 	require.True(t, allowed, "request was rejected when it should be allowed")
 
@@ -732,9 +887,15 @@ func TestFullPathDependence(t *testing.T) {
 	allowed, err = s.proxy.CheckAllowed(epID3, udpProtoPort53, dstID1, netip.Addr{}, "aws.amazon.io")
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was allowed when it should be rejected")
+	allowed, err = s.proxy.CheckAllowed(epSdpID3, udpProtoPort53, dstID1, netip.Addr{}, "aws.amazon.io")
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
 
 	// Case 12 | EPID3 | DstID1 |   54 |  UDP  | example.com    | Rejected | EPID3 is only allowed to ask DstID1 on Port 53 for example.com
 	allowed, err = s.proxy.CheckAllowed(epID3, udpProtoPort54, dstID1, netip.Addr{}, "example.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
+	allowed, err = s.proxy.CheckAllowed(epSdpID3, udpProtoPort54, dstID1, netip.Addr{}, "example.com")
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was allowed when it should be rejected")
 
@@ -742,9 +903,15 @@ func TestFullPathDependence(t *testing.T) {
 	allowed, err = s.proxy.CheckAllowed(epID3, udpProtoPort53, dstID2, netip.Addr{}, "example.com")
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was allowed when it should be rejected")
+	allowed, err = s.proxy.CheckAllowed(epSdpID3, udpProtoPort53, dstID2, netip.Addr{}, "example.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
 
 	// Case 14 | EPID3 | DstID3 |   53 |  UDP  | example.com    | Allowed due to wildcard match pattern
 	allowed, err = s.proxy.CheckAllowed(epID3, udpProtoPort53, dstID3, netip.Addr{}, "example.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.True(t, allowed, "request was rejected when it should be allowed")
+	allowed, err = s.proxy.CheckAllowed(epSdpID3, udpProtoPort53, dstID3, netip.Addr{}, "example.com")
 	require.NoError(t, err, "Error when checking allowed")
 	require.True(t, allowed, "request was rejected when it should be allowed")
 
@@ -752,9 +919,15 @@ func TestFullPathDependence(t *testing.T) {
 	allowed, err = s.proxy.CheckAllowed(epID3, tcpProtoPort53, dstID3, netip.Addr{}, "example.com")
 	require.NoError(t, err, "Error when checking allowed")
 	require.True(t, allowed, "request was rejected when it should be allowed")
+	allowed, err = s.proxy.CheckAllowed(epSdpID3, tcpProtoPort53, dstID3, netip.Addr{}, "example.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.True(t, allowed, "request was rejected when it should be allowed")
 
 	// Case 16 | EPID3 | DstID3 |   53 |    TCP   | amazon.com     | Rejected | TCP protocol only allows "example.com"
 	allowed, err = s.proxy.CheckAllowed(epID3, tcpProtoPort53, dstID3, netip.Addr{}, "amazon.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
+	allowed, err = s.proxy.CheckAllowed(epSdpID3, tcpProtoPort53, dstID3, netip.Addr{}, "amazon.com")
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was allowed when it should be rejected")
 
@@ -762,9 +935,15 @@ func TestFullPathDependence(t *testing.T) {
 	allowed, err = s.proxy.CheckAllowed(epID3, tcpProtoPort53, dstID4, netip.Addr{}, "example.com")
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was allowed when it should be rejected")
+	allowed, err = s.proxy.CheckAllowed(epSdpID3, tcpProtoPort53, dstID4, netip.Addr{}, "example.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
 
 	// Case 18 | EPID3 | DstID4 |   53 |  UDP  | example.com    | Allowed due to a nil rule
 	allowed, err = s.proxy.CheckAllowed(epID3, udpProtoPort53, dstID4, netip.Addr{}, "example.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.True(t, allowed, "request was rejected when it should be allowed")
+	allowed, err = s.proxy.CheckAllowed(epSdpID3, udpProtoPort53, dstID4, netip.Addr{}, "example.com")
 	require.NoError(t, err, "Error when checking allowed")
 	require.True(t, allowed, "request was rejected when it should be allowed")
 
@@ -836,9 +1015,20 @@ func TestFullPathDependence(t *testing.T) {
 	_, exists = s.proxy.allowed[epID2]
 	require.False(t, exists)
 
+	s.proxy.UpdateAllowed(epSdpID1, udpProtoPort53, nil)
+	s.proxy.UpdateAllowed(epSdpID1, udpProtoPort54, nil)
+	s.proxy.UpdateAllowed(epSdpID1, tcpProtoPort53, nil)
+	_, exists = s.proxy.allowed[epSdpID1]
+	require.False(t, exists)
+
 	s.proxy.UpdateAllowed(epID3, udpProtoPort53, nil)
 	s.proxy.UpdateAllowed(epID3, tcpProtoPort53, nil)
 	_, exists = s.proxy.allowed[epID3]
+	require.False(t, exists)
+
+	s.proxy.UpdateAllowed(epSdpID3, udpProtoPort53, nil)
+	s.proxy.UpdateAllowed(epSdpID3, tcpProtoPort53, nil)
+	_, exists = s.proxy.allowed[epSdpID3]
 	require.False(t, exists)
 
 	dstIP1 := (s.dnsServer.Listener.Addr()).(*net.TCPAddr).AddrPort().Addr()
@@ -847,28 +1037,43 @@ func TestFullPathDependence(t *testing.T) {
 	dstIPrandom := netip.MustParseAddr("127.0.0.42")
 
 	// Before restore: all rules removed above, everything is dropped
-	// Case 1 | EPID1 | DstID1 |   53 |  UDP  | www.ubuntu.com | Rejected | No rules
+	// Case 1 | EPID1 or epSdpID1 | DstID1 |   53 |  UDP  | www.ubuntu.com | Rejected | No rules
 	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID1, dstIP1, "www.ubuntu.com")
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was allowed when it should be rejected")
+	allowed, err = s.proxy.CheckAllowed(epSdpID1, udpProtoPort53, dstID1, dstIP1, "www.ubuntu.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
 
-	// Case 2 | EPID1 | DstID1 |   54 |  UDP  | cilium.io      | Rejected | No rules
+	// Case 2 | EPID1 or epSdpID1 | DstID1 |   54 |  UDP  | cilium.io      | Rejected | No rules
 	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, dstID1, dstIP1, "cilium.io")
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was allowed when it should be rejected")
+	allowed, err = s.proxy.CheckAllowed(epSdpID1, udpProtoPort54, dstID1, dstIP1, "cilium.io")
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
 
-	// Case 3 | EPID1 | DstID2 |   53 |  UDP  | cilium.io      | Rejected | No rules
+	// Case 3 | EPID1 or epSdpID1 | DstID2 |   53 |  UDP  | cilium.io      | Rejected | No rules
 	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID2, dstIP2a, "cilium.io")
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was allowed when it should be rejected")
-
-	// Case 4 | EPID1 | DstID2 |   53 |  UDP  | aws.amazon.com | Rejected | No rules
-	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID2, dstIP2b, "aws.amazon.com")
+	allowed, err = s.proxy.CheckAllowed(epSdpID1, udpProtoPort53, dstID2, dstIP2a, "cilium.io")
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was allowed when it should be rejected")
 
-	// Case 5 | EPID1 | DstID1 |   54 |  UDP  | example.com    | Rejected | No rules
+	// Case 4 | EPID1or epSdpID1 | DstID2 |   53 |  UDP  | aws.amazon.com | Rejected | No rules
+	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort53, dstID2, dstIP2b, "aws.amazon.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
+	allowed, err = s.proxy.CheckAllowed(epSdpID1, udpProtoPort53, dstID2, dstIP2b, "aws.amazon.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
+
+	// Case 5 | EPID1 or epSdpID1 | DstID1 |   54 |  UDP  | example.com    | Rejected | No rules
 	allowed, err = s.proxy.CheckAllowed(epID1, udpProtoPort54, dstID1, dstIP1, "example.com")
+	require.NoError(t, err, "Error when checking allowed")
+	require.False(t, allowed, "request was allowed when it should be rejected")
+	allowed, err = s.proxy.CheckAllowed(epSdpID1, udpProtoPort54, dstID1, dstIP1, "example.com")
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was allowed when it should be rejected")
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -429,6 +429,12 @@ const (
 	// ToFQDNsProxyPort is the global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
 	ToFQDNsProxyPort = "tofqdns-proxy-port"
 
+	// EnableStandaloneDNSProxy is the name of the option to enable standalone dns proxy
+	EnableStandaloneDNSProxy = "enable-standalone-dns-proxy"
+
+	// ToFQDNsServerAddr is the port on which the standalone grpc server should listen.
+	ToFqdnsServerPort = "tofqdns-server-port"
+
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost = "tofqdns-endpoint-max-ip-per-hostname"
@@ -1533,6 +1539,9 @@ type DaemonConfig struct {
 	// EnableNat46X64Gateway is true when L3 based NAT46 and NAT64 translation is enabled
 	EnableNat46X64Gateway bool
 
+	// EnableStandaloneDNSProxy is the option to enable standalone DNS proxy
+	EnableStandaloneDNSProxy bool
+
 	// EnableIPv6NDP is true when NDP is enabled for IPv6
 	EnableIPv6NDP bool
 
@@ -1687,6 +1696,9 @@ type DaemonConfig struct {
 	// is 0 a random port will be assigned, and can be obtained from
 	// DefaultDNSProxy below.
 	ToFQDNsProxyPort int
+
+	// ToFqdnsServerPort is the user-configured global, Standalone dns proxy grpc server port
+	ToFqdnsServerPort int
 
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
 	// for each FQDN name in an endpoint's FQDN cache
@@ -2925,6 +2937,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableIPMasqAgent = vp.GetBool(EnableIPMasqAgent)
 	c.EnableIPv4EgressGateway = vp.GetBool(EnableIPv4EgressGateway)
 	c.EnableEnvoyConfig = vp.GetBool(EnableEnvoyConfig)
+	c.EnableStandaloneDNSProxy = vp.GetBool(EnableStandaloneDNSProxy)
 	c.IPMasqAgentConfigPath = vp.GetString(IPMasqAgentConfigPath)
 	c.InstallIptRules = vp.GetBool(InstallIptRules)
 	c.IPSecKeyFile = vp.GetString(IPSecKeyFileName)
@@ -3088,6 +3101,12 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.ClockSource = ClockSourceKtime
 	c.EnableIdentityMark = vp.GetBool(EnableIdentityMark)
 
+	if c.EnableStandaloneDNSProxy {
+		if !c.EnableL7Proxy {
+			log.Fatalf("Standalone DNS proxy requires L7 proxy to be enabled")
+		}
+	}
+
 	// toFQDNs options
 	c.DNSMaxIPsPerRestoredRule = vp.GetInt(DNSMaxIPsPerRestoredRule)
 	c.DNSPolicyUnloadOnShutdown = vp.GetBool(DNSPolicyUnloadOnShutdown)
@@ -3106,6 +3125,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 		c.ToFQDNsMinTTL = defaults.ToFQDNsMinTTL
 	}
 	c.ToFQDNsProxyPort = vp.GetInt(ToFQDNsProxyPort)
+	c.ToFqdnsServerPort = vp.GetInt(ToFqdnsServerPort)
 	c.ToFQDNsPreCache = vp.GetString(ToFQDNsPreCache)
 	c.ToFQDNsEnableDNSCompression = vp.GetBool(ToFQDNsEnableDNSCompression)
 	c.ToFQDNsIdleConnectionGracePeriod = vp.GetDuration(ToFQDNsIdleConnectionGracePeriod)

--- a/standalone-dns-proxy/cmd/flags.go
+++ b/standalone-dns-proxy/cmd/flags.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"github.com/cilium/cilium/pkg/option"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
+	flags := cmd.Flags()
+
+	flags.String(option.ConfigDir, "", `Configuration directory that contains a file for each option`)
+	option.BindEnv(vp, option.ConfigDir)
+	vp.BindPFlags(flags)
+}

--- a/standalone-dns-proxy/cmd/root.go
+++ b/standalone-dns-proxy/cmd/root.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+var (
+	DNSProxy = cell.Module(
+		"standalone-dns-proxy",
+		"Standalone DNS Proxy",
+
+		cell.Provide(func() *option.DaemonConfig { return option.Config }),
+		cell.Invoke(registerDNSProxyHooks),
+	)
+
+	binaryName = "standalone-dns-proxy"
+
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, binaryName)
+)
+
+func NewDNSProxyCmd(h *hive.Hive) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   binaryName,
+		Short: "Run " + binaryName,
+		Run: func(cobraCmd *cobra.Command, args []string) {
+			initEnv(h.Viper())
+
+			if err := h.Run(logging.DefaultSlogLogger); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+	h.RegisterFlags(cmd.Flags())
+
+	InitGlobalFlags(cmd, h.Viper())
+	cmd.AddCommand(
+		h.Command(),
+	)
+	cobra.OnInitialize(option.InitConfig(cmd, "Standalone-DNS-Proxy", "standalone-dns-proxy", h.Viper()))
+
+	return cmd
+}
+
+func initEnv(vp *viper.Viper) {
+	option.Config.Populate(vp)
+	option.LogRegisteredOptions(vp, log)
+}
+
+func Execute(cmd *cobra.Command) {
+	if err := cmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func registerDNSProxyHooks(lc cell.Lifecycle) {
+	args := &StandaloneDNSProxyArgs{
+		DNSProxyConfig: dnsproxy.DNSProxyConfig{
+			Address:                "",
+			Port:                   uint16(option.Config.ToFQDNsProxyPort),
+			IPv4:                   option.Config.EnableIPv4,
+			IPv6:                   option.Config.EnableIPv6,
+			EnableDNSCompression:   option.Config.ToFQDNsEnableDNSCompression,
+			MaxRestoreDNSIPs:       option.Config.DNSMaxIPsPerRestoredRule,
+			ConcurrencyLimit:       option.Config.DNSProxyConcurrencyLimit,
+			ConcurrencyGracePeriod: option.Config.DNSProxyConcurrencyProcessingGracePeriod,
+			DNSProxyType:           dnsproxy.StandaloneDNSProxy,
+		},
+		toFqdnServerPort:         uint16(option.Config.ToFqdnsServerPort),
+		enableL7Proxy:            option.Config.EnableL7Proxy,
+		enableStandaloneDNsProxy: option.Config.EnableStandaloneDNSProxy,
+	}
+
+	sdp, err := NewStandaloneDNSProxy(args)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to create Standalone DNS Proxy")
+	}
+
+	// Todo: add the log with individual fields
+	log.WithField("Standalone Args", args).Info("Starting Standalone DNS Proxy")
+
+	lc.Append(cell.Hook{
+		OnStart: func(cell.HookContext) error {
+			return sdp.StartStandaloneDNSProxy()
+		},
+		OnStop: func(cell.HookContext) error {
+			return sdp.StopStandaloneDNSProxy()
+		},
+	})
+}

--- a/standalone-dns-proxy/cmd/standalonednsproxy.go
+++ b/standalone-dns-proxy/cmd/standalonednsproxy.go
@@ -1,0 +1,578 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+
+	ciliumdns "github.com/cilium/dns"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/status"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/revert"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/trigger"
+	"github.com/cilium/cilium/pkg/u8proto"
+
+	standalonednsproxy "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
+)
+
+var kacp = keepalive.ClientParameters{
+	Time:                10 * time.Second, // send pings every 10 seconds if there is no activity
+	Timeout:             5 * time.Second,  // wait 1 second for ping ack before considering the connection dead
+	PermitWithoutStream: true,             // send pings even without active streams
+}
+
+type StandaloneDNSProxyArgs struct {
+	dnsproxy.DNSProxyConfig
+
+	toFqdnServerPort         uint16
+	enableL7Proxy            bool
+	enableStandaloneDNsProxy bool
+}
+
+type StandaloneDNSProxy struct {
+	// DNSProxy is the standalone DNS proxy
+	DNSProxy *dnsproxy.DNSProxy
+
+	// Client is the client for the standalone DNS proxy to connect to the cilium agent
+	Client standalonednsproxy.FQDNDataClient
+
+	// connection stores the grpc connection to the cilium agent
+	connection *grpc.ClientConn
+
+	// ciliumAgentConnectionTrigger is the trigger to connect to the cilium agent
+	ciliumAgentConnectionTrigger *trigger.Trigger
+
+	// mu is the mutex to protect creation of multiple policy state stream in case of multiple triggers
+	mu lock.Mutex
+
+	// policyStateStream is the stream to subscribe to the policy state
+	policyStateStream standalonednsproxy.FQDNData_StreamPolicyStateClient
+
+	// cancelStreamPolicyStateStream is the cancel function for the PolicyState stream
+	cancelStreamPolicyStateStream context.CancelFunc
+
+	// args are the arguments for the standalone DNS proxy
+	args *StandaloneDNSProxyArgs
+
+	ipToIdentityCache map[string]uint32
+
+	ipToEndpointIdCache map[string]uint64
+}
+
+// NewStandaloneDNSProxy creates a new standalone DNS proxy
+func NewStandaloneDNSProxy(args *StandaloneDNSProxyArgs) (*StandaloneDNSProxy, error) {
+	if args.toFqdnServerPort == 0 {
+		log.Error("toFqdnServerPort is 0")
+		return nil, errors.New("toFqdnServerPort is 0")
+	}
+
+	return &StandaloneDNSProxy{
+		args:                args,
+		ipToIdentityCache:   make(map[string]uint32),
+		ipToEndpointIdCache: make(map[string]uint64),
+	}, nil
+}
+
+func (sdp *StandaloneDNSProxy) StopStandaloneDNSProxy() error {
+	if sdp.DNSProxy != nil {
+		sdp.DNSProxy.Cleanup()
+	}
+
+	err := sdp.closeConnection()
+	if err != nil {
+		log.WithError(err).Error("Failed to close connection")
+		return err
+	}
+	return nil
+}
+
+// CreateClient creates a client for the cilium agent connection
+// 1. It checks if connection is created, if not it returns an error and triggers the cilium agent connection trigger
+// 2. Else it creates the client
+// 3. If the policy state stream is not created, it creates the stream
+// Note: This function is called with a mutex lock in the caller function because there can be multiple triggers trying to
+// create the stream at the same time
+func (sdp *StandaloneDNSProxy) CreateClient(ctx context.Context) error {
+	var err error
+	defer func() {
+		if err != nil {
+			log.WithError(err).Error("Failed to start cilium agent connection")
+			sdp.closeConnection()
+			sdp.ciliumAgentConnectionTrigger.TriggerWithReason("Failed to start cilium agent connection")
+		}
+	}()
+
+	if sdp.connection == nil {
+		log.Error("Connection is nil")
+		return fmt.Errorf("connection is nil")
+	}
+
+	// Create the client
+	sdp.Client = standalonednsproxy.NewFQDNDataClient(sdp.connection)
+
+	if sdp.policyStateStream == nil {
+		err = sdp.createStreamPolicyStateStream(ctx)
+		if err != nil {
+			log.WithError(err).Error("Failed to create subscription stream")
+			return err
+		}
+	}
+	log.Debugf("Successfully created client for Cilium agent")
+
+	return nil
+}
+
+// ConnectToCiliumAgent creates a connection to the cilium agent
+// It returns an error if the connection is not successful and triggers the cilium agent connection trigger
+func (sdp *StandaloneDNSProxy) ConnectToCiliumAgent() error {
+	var err error
+	defer func() {
+		if err != nil {
+			log.Errorf("Failed to connect to cilium agent: %v", err)
+			sdp.ciliumAgentConnectionTrigger.TriggerWithReason("Failed to connect to cilium agent")
+		}
+	}()
+
+	if sdp.connection != nil {
+		return nil
+	}
+
+	var opts []grpc.DialOption
+	opts = append(opts, grpc.WithInsecure())
+	opts = append(opts, grpc.WithBlock())
+	opts = append(opts, grpc.WithKeepaliveParams(kacp))
+
+	address := fmt.Sprintf("localhost:%d", sdp.args.toFqdnServerPort)
+
+	log.Infof("Connecting to server %v", address)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5) // 5 seconds timeout
+	defer cancel()
+
+	conn, err := grpc.DialContext(ctx, address, opts...)
+	if err != nil {
+		log.Errorf("Failed to connect to server %v at address %s", err, address)
+		return err
+	}
+	log.Infof("Connected to server %v", address)
+	sdp.connection = conn
+
+	return nil // Successfully connected
+}
+
+// StartStandaloneDNSProxy starts the standalone DNS proxy and creates the cilium agent connection trigger
+// The flow is as follows:
+// 1. It starts the DNS Proxy
+// 2. It creates the cilium agent connection trigger
+// 3. It triggers the cilium agent connection trigger
+func (sdp *StandaloneDNSProxy) StartStandaloneDNSProxy() error {
+	var err error
+
+	if !sdp.args.enableL7Proxy {
+		log.Info("L7 Proxy is disabled")
+		return nil
+	}
+
+	if !sdp.args.enableStandaloneDNsProxy {
+		log.Info("Standalone DNS Proxy is disabled")
+		return nil
+	}
+
+	// Initialize the DNS Proxy
+	sdp.DNSProxy, err = dnsproxy.StartDNSProxy(sdp.args.DNSProxyConfig, sdp.LookupEPByIP, sdp.LookupSecIDByIP, sdp.LookupIPsBySecID, sdp.NotifyOnDNSMsg)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to start DNS Proxy")
+		return err
+	}
+	log.Infof("DNS Proxy started on %s:%d", sdp.args.Address, sdp.args.Port)
+
+	// Create the cilium agent connection trigger
+	err = sdp.createciliumAgentConnectionTriggerTrigger()
+	if err != nil {
+		log.WithError(err).Error("Failed to create the trigger for connecting to Cilium agent")
+		return err
+	}
+
+	// trigger the cilium agent connection
+	sdp.ciliumAgentConnectionTrigger.TriggerWithReason("Start standalone DNS proxy")
+	return nil
+}
+
+// createciliumAgentConnectionTriggerTrigger creates a trigger to connect to the cilium agent
+// 1. It tries to connect to the cilium agent
+// 2. If the connection is successful, it tries to start the grpc streams
+// 3. If the streams are started, it tries to subscribe to the policy state as go routine
+func (sdp *StandaloneDNSProxy) createciliumAgentConnectionTriggerTrigger() error {
+	var err error
+	sdp.ciliumAgentConnectionTrigger, err = trigger.NewTrigger(trigger.Parameters{
+		Name:        "start-cilium-agent-connection",
+		MinInterval: 5 * time.Second,
+		TriggerFunc: func(reasons []string) {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Errorf("Recovered from panic in trigger function: %v", r)
+				}
+			}()
+			log.Infof("Triggering cilium agent connection: %v", reasons)
+			// 1. Try creating the connection to the cilium agent
+			err := sdp.ConnectToCiliumAgent()
+			if err != nil {
+				log.WithError(err).Error("Failed to connect to cilium agent")
+				return
+			}
+
+			sdp.mu.Lock()
+			defer sdp.mu.Unlock()
+			// 2. Try starting the cilium agent connection
+			// only create the client if no stream is already open
+			// Imagine a scenarios where two triggers are fired at the same time
+			// and both try to create the client at the same time
+			// Due to the mutex, only one of them will create the client and start the stream
+			// The other one will just return
+			if sdp.policyStateStream == nil {
+				ctx, cancel := context.WithCancel(context.Background())
+
+				err = sdp.CreateClient(ctx)
+				if err != nil {
+					log.WithError(err).Error("Failed to create client")
+					cancel()
+					return
+				}
+
+				// 3. Try to subscribe to the policy state
+				sdp.cancelStreamPolicyStateStream = cancel // Store the cancel function for later use
+				go sdp.streamPolicyState(ctx)
+			}
+		},
+	})
+	if err != nil {
+		log.Errorf("Failed to create trigger: %v", err)
+		return err // Return the error after logging
+	}
+	return nil
+}
+
+// Note: isHost is always false as it is not used in the current implementation
+// TODO: Remove isHost from the function signature
+func (sdp *StandaloneDNSProxy) LookupEPByIP(ip netip.Addr) (ep *endpoint.Endpoint, isHost bool, err error) {
+	log.Debugf("LookupEPByIP: %s", ip.String())
+
+	// find the identity from the cache
+	secId, ok := sdp.ipToIdentityCache[ip.String()]
+	if !ok {
+		log.Errorf("Failed to get identity for IP %s", ip.String())
+		return nil, false, fmt.Errorf("failed to get identity for IP %s", ip.String())
+	}
+
+	id, ok := sdp.ipToEndpointIdCache[ip.String()]
+	if !ok {
+		log.Errorf("Endpoint ID not found for IP %s", ip.String())
+		return nil, false, fmt.Errorf("endpoint ID not found for IP %s", ip.String())
+	}
+
+	endpt := &endpoint.Endpoint{
+		ID: uint16(id),
+		SecurityIdentity: &identity.Identity{
+			ID: identity.NumericIdentity(secId),
+		},
+	}
+	log.Debugf("Endpoint Identity found: %v", endpt)
+
+	return endpt, false, nil
+}
+
+func (sdp *StandaloneDNSProxy) LookupIPsBySecID(nid identity.NumericIdentity) []string {
+	return nil
+}
+
+func (sdp *StandaloneDNSProxy) LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool) {
+	log.Debugf("LookupSecIDByIP: %s", ip.String())
+
+	id, ok := sdp.ipToIdentityCache[ip.String()]
+	if !ok {
+		log.Errorf("Failed to get identity for IP %s", ip.String())
+		return ipcache.Identity{}, false
+	}
+
+	log.Debugf("Identity found: %v", id)
+	return ipcache.Identity{
+		ID:     identity.NumericIdentity(id),
+		Source: source.Local, // Local source means the identity is from the local agent
+	}, true
+}
+
+func (sdp *StandaloneDNSProxy) NotifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, serverAddr netip.AddrPort, msg *ciliumdns.Msg, protocol string, allowed bool, stat *dnsproxy.ProxyRequestContext) error {
+	log.Debugf("Received DNS message: %v", msg)
+	qname, responseIPs, TTL, _, rcode, _, _, err := dnsproxy.ExtractMsgDetails(msg)
+	if err != nil {
+		log.WithError(err).Error("cannot extract DNS message details")
+		return err
+	}
+
+	var ips [][]byte
+	for _, i := range responseIPs {
+		log.Debugf("%s is mapped to %s", qname, i.String())
+		ips = append(ips, []byte(i.String()))
+	}
+
+	sourceIp, _, err := net.SplitHostPort(epIPPort)
+	if err != nil {
+		log.WithError(err).Error("Failed to split IP:Port")
+		return err
+	}
+
+	sourceIdentity, err := ep.GetSecurityIdentity()
+	if err != nil {
+		log.WithError(err).Error("Failed to get security identity")
+	}
+	message := &standalonednsproxy.FQDNMapping{
+		Fqdn:           qname,
+		RecordIp:       ips,
+		Ttl:            TTL,
+		SourceIp:       []byte(sourceIp),
+		SourceIdentity: uint32(sourceIdentity.ID),
+		ResponseCode:   uint32(rcode),
+	}
+	log.Debugf("Sending FQDN Mapping message: %v", message)
+	if sdp.Client == nil {
+		log.Error("Client is nil")
+		return fmt.Errorf("client is nil")
+	}
+	result, err := sdp.Client.UpdateMappingRequest(context.Background(), message)
+	log.Debugf("Received result from FQDN mapping stream %v", result)
+	if err != nil {
+		log.WithError(err).Error("Failed to send FQDN Mapping message")
+		return err
+	}
+
+	return nil
+}
+
+// streamPolicyState subscribes to the policy state
+// 1. Tries to get the stream connected
+// 2. If the stream is connected, it waits for the policy state to be received
+func (sdp *StandaloneDNSProxy) streamPolicyState(ctx context.Context) error {
+	var err error
+	defer func() {
+		if err != nil {
+			sdp.closePolicyStateStream()
+			reason := "Failed to subscribe to policy state"
+			switch status.Code(err) {
+			case codes.Unavailable:
+				sdp.closeConnection()
+				reason = "DNS server unavailable"
+			default:
+				if errors.Is(err, io.EOF) {
+					sdp.closeConnection()
+					reason = "Received EOF from policy state stream"
+					log.Error("Received EOF from policy state stream")
+				} else {
+					log.WithError(err).Error("Failed to subscribe to policy state")
+				}
+			}
+			sdp.ciliumAgentConnectionTrigger.TriggerWithReason(reason)
+		}
+		sdp.cancelStreamPolicyStateStream()
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Context was cancelled, exit goroutine
+			log.Info("Stopping subscription to policy state")
+			return nil
+		default:
+			log.Debugf("Waiting for policy state")
+			policyState, recvErr := sdp.policyStateStream.Recv()
+			if recvErr != nil {
+				if errors.Is(recvErr, io.EOF) || status.Code(recvErr) == codes.Unavailable {
+					log.WithError(recvErr).Error("Policy state stream closed")
+					err = recvErr
+					return err
+				}
+				log.WithError(recvErr).Error("Failed to receive policy state")
+				err = recvErr // Set the outer err for the deferred function to handle.
+				return err
+			}
+			log.WithField("policyState", policyState).Debug("Received policy state")
+
+			response := &standalonednsproxy.PolicyStateResponse{
+				RequestId: policyState.GetRequestId(),
+			}
+			revertStack, err := sdp.UpdatePolicyState(policyState)
+			if err != nil {
+				log.WithError(err).Error("Failed to update policy state")
+				revertStack.Revert()
+				err = sdp.policyStateStream.Send(response)
+				if err != nil {
+					log.WithError(err).Error("Failed to send policy state response")
+					return err
+				}
+				return err
+			}
+			response.Response = standalonednsproxy.ResponseCode_RESPONSE_CODE_NO_ERROR
+			err = sdp.policyStateStream.Send(response)
+			if err != nil {
+				log.WithError(err).Error("Failed to send policy state response")
+				return err
+			}
+		}
+	}
+}
+
+func (sdp *StandaloneDNSProxy) closePolicyStateStream() {
+	if sdp.policyStateStream != nil {
+		err := sdp.policyStateStream.CloseSend()
+		if err != nil {
+			log.Errorf("Failed to close policy state stream: %v", err)
+		}
+		sdp.policyStateStream = nil
+	}
+}
+
+func (sdp *StandaloneDNSProxy) closeConnection() error {
+	if sdp.connection != nil {
+		err := sdp.connection.Close()
+		if err != nil {
+			log.Errorf("Failed to close connection: %v", err)
+			return err
+		}
+		sdp.connection = nil
+	}
+	return nil
+}
+
+// createStreamPolicyStateStream creates a subscription stream to the policy state
+func (sdp *StandaloneDNSProxy) createStreamPolicyStateStream(ctx context.Context) error {
+	if sdp.Client == nil {
+		log.Error("Client is nil")
+		return fmt.Errorf("client is nil")
+	}
+
+	if sdp.policyStateStream != nil {
+		log.Error("Policy state stream is not nil")
+		sdp.closePolicyStateStream()
+	}
+
+	stream, err := sdp.Client.StreamPolicyState(ctx)
+	if err != nil {
+		log.WithError(err).Error("Failed to subscribe to policy state")
+		return err
+	}
+	sdp.policyStateStream = stream
+	return nil
+}
+
+// UpdatePolicyState updates the DNS rules in the standalone DNS proxy
+// 1. It updates the ip to identity cache and ip to endpoint id cache
+// 2. It updates the DNS rules in the standalone DNS proxy
+// The input is the policy state received from the cilium agent as :
+//
+//	PolicyState : {
+//	  EgressL7DnsPolicy : [
+//	    {
+//	    SourceEndpointId : 1
+//	    DnsServers : [{
+//	      DnsServerIdentity : 2
+//	      DnsServerPort : 53
+//	      DnsServerProto : 17
+//	    	},
+//	    	{
+//	      DnsServerIdentity : 3
+//	      DnsServerPort : 53
+//	      DnsServerProto : 17
+//	    	}]
+//	    DnsPattern : ["www.example.com"]
+//	    },
+//	    {
+//	    SourceEndpointId : 1
+//	    DnsServers : [{
+//	      DnsServerIdentity : 2
+//	      DnsServerPort : 54
+//	      DnsServerProto : 17
+//	    	}]
+//	    DnsPattern : ["www.test.com"]
+//	    }
+//	  ]
+//	  IdentityToEndpointMapping : []
+//	}
+func (sdp *StandaloneDNSProxy) UpdatePolicyState(rules *standalonednsproxy.PolicyState) (revert.RevertStack, error) {
+	log.Debugf("Received policy state: %v", rules)
+
+	var revertStack revert.RevertStack
+	identityToEndpointMapping := rules.GetIdentityToEndpointMapping()
+
+	// Update the ip to identity cache and ip to endpoint id cache
+	for _, mapping := range identityToEndpointMapping {
+		for _, epInfo := range mapping.GetEndpointInfo() {
+			for _, ip := range epInfo.GetIp() {
+				sdp.ipToIdentityCache[string(ip)] = mapping.GetIdentity()
+				if epInfo.GetId() != 0 {
+					sdp.ipToEndpointIdCache[string(ip)] = epInfo.GetId()
+				}
+			}
+		}
+	}
+
+	endpointIdToRule := make(map[uint32]map[restore.PortProto]map[policy.CachedSelector][]string)
+	for _, rule := range rules.GetEgressL7DnsPolicy() {
+
+		portProtoToServerIdentity := make(map[restore.PortProto][]uint32)
+		for _, dnsServer := range rule.GetDnsServers() {
+			portProto := restore.MakeV2PortProto(uint16(dnsServer.GetDnsServerPort()), u8proto.U8proto(dnsServer.GetDnsServerProto()))
+			portProtoToServerIdentity[portProto] = append(portProtoToServerIdentity[portProto], dnsServer.GetDnsServerIdentity())
+		}
+
+		portProtoToDNSrules := make(map[restore.PortProto]map[policy.CachedSelector][]string)
+		for portProto, identities := range portProtoToServerIdentity {
+			cs := make(map[policy.CachedSelector][]string)
+			cs[&dnsproxy.DnsServerIdentity{Identities: identities}] = rule.GetDnsPattern()
+			portProtoToDNSrules[portProto] = cs
+		}
+
+		epId := rule.GetSourceEndpointId()
+		if _, ok := endpointIdToRule[epId]; !ok {
+			endpointIdToRule[epId] = make(map[restore.PortProto]map[policy.CachedSelector][]string)
+		}
+
+		for portProto, cs := range portProtoToDNSrules {
+			if _, ok := endpointIdToRule[epId][portProto]; !ok {
+				endpointIdToRule[epId][portProto] = make(map[policy.CachedSelector][]string)
+			}
+
+			for k, v := range cs {
+				endpointIdToRule[epId][portProto][k] = v
+			}
+		}
+	}
+
+	for epId, rules := range endpointIdToRule {
+		for portProto, cs := range rules {
+			revertFunc, err := sdp.DNSProxy.UpdateAllowedStandaloneDnsProxy(uint64(epId), portProto, cs)
+			if err != nil {
+				log.WithError(err).Error("Failed to update DNS rules")
+				return revertStack, err
+			}
+			revertStack.Push(revertFunc)
+		}
+	}
+
+	return revertStack, nil
+}

--- a/standalone-dns-proxy/cmd/standalonednsproxy_test.go
+++ b/standalone-dns-proxy/cmd/standalonednsproxy_test.go
@@ -1,0 +1,668 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/cilium/dns"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/trigger"
+	"github.com/cilium/cilium/pkg/u8proto"
+
+	standalonednsproxy "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
+)
+
+func TestNewStandaloneDNSProxy(t *testing.T) {
+	tests := []struct {
+		name string
+		args *StandaloneDNSProxyArgs
+		err  error
+	}{
+		{
+			name: "Valid grpc server port",
+			args: &StandaloneDNSProxyArgs{
+				toFqdnServerPort: 1234,
+				enableL7Proxy:    true,
+			},
+			err: nil,
+		},
+		{
+			name: "Invalid grpc server port",
+			args: &StandaloneDNSProxyArgs{
+				toFqdnServerPort: 0,
+				enableL7Proxy:    true,
+			},
+			err: errors.New("toFqdnServerPort is 0"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sdp, err := NewStandaloneDNSProxy(tt.args)
+			if err != nil {
+				require.Equal(t, tt.err, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, sdp)
+		})
+	}
+}
+
+func TestStandaloneDNSProxyWhenDisabled(t *testing.T) {
+	test := map[string]struct {
+		args *StandaloneDNSProxyArgs
+		err  error
+	}{
+		"L7ProxyDisbaled": {
+			args: &StandaloneDNSProxyArgs{
+				toFqdnServerPort:         4321,
+				enableStandaloneDNsProxy: false,
+				enableL7Proxy:            false,
+			},
+			err: nil,
+		},
+		"StandaloneDNSProxyDisabled": {
+			args: &StandaloneDNSProxyArgs{
+				toFqdnServerPort:         4321,
+				enableStandaloneDNsProxy: false,
+				enableL7Proxy:            true,
+			},
+			err: nil,
+		},
+	}
+
+	for name, tt := range test {
+		t.Run(name, func(t *testing.T) {
+			sdp, err := NewStandaloneDNSProxy(tt.args)
+			require.NoError(t, err)
+			require.Nil(t, sdp.DNSProxy)
+		})
+	}
+}
+
+func TestStandaloneDNSProxyWhenEnabled(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	sdp, err := NewStandaloneDNSProxy(&StandaloneDNSProxyArgs{
+		DNSProxyConfig: dnsproxy.DNSProxyConfig{
+			Address:                "",
+			Port:                   1234,
+			IPv4:                   true,
+			IPv6:                   true,
+			EnableDNSCompression:   true,
+			MaxRestoreDNSIPs:       10,
+			ConcurrencyLimit:       10,
+			ConcurrencyGracePeriod: 10,
+			DNSProxyType:           dnsproxy.StandaloneDNSProxy,
+		},
+		toFqdnServerPort:         4321,
+		enableStandaloneDNsProxy: true,
+		enableL7Proxy:            true,
+	})
+	require.NoError(t, err)
+
+	sdp.StartStandaloneDNSProxy()
+	defer sdp.StopStandaloneDNSProxy()
+
+	// check if the server is running
+	require.Equal(t, dnsproxy.StandaloneDNSProxy, sdp.DNSProxy.DNSProxyType)
+	require.NotNil(t, sdp.ciliumAgentConnectionTrigger)
+}
+
+type MockFQDNDataServer struct {
+	standalonednsproxy.UnimplementedFQDNDataServer
+}
+
+func (m *MockFQDNDataServer) UpdateMappingRequest(ctx context.Context, in *standalonednsproxy.FQDNMapping) (*standalonednsproxy.UpdateMappingResponse, error) {
+	return &standalonednsproxy.UpdateMappingResponse{
+		Response: standalonednsproxy.ResponseCode_RESPONSE_CODE_NO_ERROR,
+	}, nil
+}
+
+// create a channel to receive the policy state
+var dnsPoliciesResult = make(chan *standalonednsproxy.PolicyStateResponse)
+
+func (m *MockFQDNDataServer) StreamPolicyState(stream standalonednsproxy.FQDNData_StreamPolicyStateServer) error {
+	//Receive the success message from the SDP
+	go func() {
+		res, err := stream.Recv()
+		if err != nil {
+			log.Errorf("Error receiving policy state response: %v", err)
+		}
+		dnsPoliciesResult <- res
+		// Send the close message
+		stream.Context().Done()
+	}()
+	go func() {
+		// Send the current state of the policy state
+		err := stream.Send(&standalonednsproxy.PolicyState{
+			EgressL7DnsPolicy: []*standalonednsproxy.DNSPolicy{
+				{
+					SourceEndpointId: 1,
+					DnsPattern:       []string{"*.cilium.io", "example.com"},
+					DnsServers: []*standalonednsproxy.DNSServer{
+						{
+							DnsServerIdentity: 2,
+							DnsServerPort:     53,
+							DnsServerProto:    17,
+						},
+					},
+				},
+			},
+			RequestId: "1",
+			IdentityToEndpointMapping: []*standalonednsproxy.IdentityToEndpointMapping{
+				{
+					Identity: 1,
+					EndpointInfo: []*standalonednsproxy.EndpointInfo{
+						{
+							Ip: [][]byte{[]byte(net.ParseIP("1.1.1.0").String())},
+							Id: 100,
+						},
+					},
+				},
+				{
+					Identity: 2,
+					EndpointInfo: []*standalonednsproxy.EndpointInfo{
+						{
+							Ip: [][]byte{[]byte(net.ParseIP("1.1.1.1").String())},
+							Id: 101,
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			log.Errorf("Error sending policy state: %v", err)
+		}
+	}()
+
+	log.Debugf("StreamPolicyState waiting for context to be done")
+	<-stream.Context().Done()
+	log.Info("Closing the stream")
+	return stream.Context().Err()
+}
+
+func setupStandaloneDNSProxy(t *testing.T, ctx context.Context) (*StandaloneDNSProxy, func()) {
+	buffer := 1024
+	lis := bufconn.Listen(buffer)
+
+	baseServer := grpc.NewServer()
+
+	server := &MockFQDNDataServer{}
+	standalonednsproxy.RegisterFQDNDataServer(baseServer, server)
+	go func() {
+		if err := baseServer.Serve(lis); err != nil {
+			log.Fatalf("Server exited with error: %v", err)
+		}
+	}()
+
+	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	if err != nil {
+		log.Fatalf("Failed to dial bufnet: %v", err)
+	}
+
+	sdp, err := NewStandaloneDNSProxy(&StandaloneDNSProxyArgs{
+		DNSProxyConfig: dnsproxy.DNSProxyConfig{
+			Address: "",
+			Port:    1234,
+			IPv4:    true,
+			IPv6:    false,
+		},
+		toFqdnServerPort:         4321,
+		enableStandaloneDNsProxy: true,
+		enableL7Proxy:            true,
+	})
+	require.NoError(t, err)
+
+	sdp.connection = conn
+
+	closer := func() {
+		if sdp.Client != nil {
+			sdp.connection.Close()
+		}
+		err := lis.Close()
+		if err != nil {
+			log.Printf("error closing listener: %v", err)
+		}
+		baseServer.Stop()
+	}
+
+	return sdp, closer
+}
+
+func TestSubscribeToPolicyState(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	sdp, closer := setupStandaloneDNSProxy(t, context.Background())
+	defer closer()
+
+	// Create the client
+	err := sdp.CreateClient(context.Background())
+	require.NoError(t, err)
+	tr, err := trigger.NewTrigger(trigger.Parameters{
+		TriggerFunc: func(reasons []string) {
+			time.Sleep(time.Second)
+		},
+	})
+	require.NoError(t, err)
+	sdp.ciliumAgentConnectionTrigger = tr
+	// Add a dummy dns proxy server
+	sdp.DNSProxy, err = dnsproxy.StartDNSProxy(sdp.args.DNSProxyConfig, // any address, any port, enable ipv4, enable ipv6, enable compression, max 1000 restore IPs
+		// LookupEPByIP
+		func(ip netip.Addr) (*endpoint.Endpoint, bool, error) {
+			return &endpoint.Endpoint{}, false, nil
+		},
+		// LookupSecIDByIP
+		func(ip netip.Addr) (ipcache.Identity, bool) {
+			return ipcache.Identity{}, false
+		},
+		// LookupIPsBySecID
+		func(nid identity.NumericIdentity) []string {
+			return []string{}
+		},
+		// NotifyOnDNSMsg
+		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, dstAddr netip.AddrPort, msg *dns.Msg, protocol string, allowed bool, stat *dnsproxy.ProxyRequestContext) error {
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	// StreamPolicyState is called successfully
+	go func() {
+		context, cancel := context.WithCancel(context.Background())
+		sdp.cancelStreamPolicyStateStream = cancel
+		err = sdp.streamPolicyState(context)
+		require.Contains(t, err.Error(), "rpc error: code = Canceled desc = grpc: the client connection is closing")
+	}()
+
+	// check if the server received the success or not
+	result := <-dnsPoliciesResult
+	require.Equal(t, standalonednsproxy.ResponseCode_RESPONSE_CODE_NO_ERROR, result.GetResponse())
+	// Check the data sent from the server is added
+	require.Equal(t, map[string]uint64{"1.1.1.1": 101, "1.1.1.0": 100}, sdp.ipToEndpointIdCache)
+	require.Equal(t, map[string]uint32{"1.1.1.1": 2, "1.1.1.0": 1}, sdp.ipToIdentityCache)
+
+	// // check the dnsResult channel is empty
+	select {
+	case <-dnsPoliciesResult:
+		for _, s := range sdp.DNSProxy.DNSServers {
+			s.Shutdown()
+		}
+		t.Fatalf("dnsPoliciesResult channel is not empty")
+	default:
+		log.Info("dnsPoliciesResult channel is empty")
+	}
+}
+
+func TestCreateClientIsCreatedSuccessfully(t *testing.T) {
+	ctx := context.Background()
+	sdp, closer := setupStandaloneDNSProxy(t, ctx)
+	defer closer()
+
+	err := sdp.CreateClient(ctx)
+	require.NoError(t, err)
+
+	// check if the client is created
+	require.NotNil(t, sdp.Client)
+	// Check if dns rules stream is created
+	require.NotNil(t, sdp.policyStateStream)
+}
+
+func TestCreateClientFails(t *testing.T) {
+	ctx := context.Background()
+	sdp, closer := setupStandaloneDNSProxy(t, ctx)
+	defer closer()
+
+	sdp.connection = nil
+	err := sdp.CreateClient(ctx)
+	require.Error(t, err)
+}
+
+func TestNotifyOnDNSMsg(t *testing.T) {
+	ctx := context.Background()
+	sdp, closer := setupStandaloneDNSProxy(t, ctx)
+	defer closer()
+
+	err := sdp.CreateClient(ctx)
+	require.NoError(t, err)
+
+	ep := &endpoint.Endpoint{
+		SecurityIdentity: &identity.Identity{
+			ID: 1,
+		},
+	}
+	serverId := identity.NumericIdentity(2)
+	msg := new(dns.Msg)
+	msg.SetQuestion("test.com.", dns.TypeA)
+	retARR, err := dns.NewRR(msg.Question[0].Name + " 60 IN A 1.1.1.1")
+	if err != nil {
+		panic(err)
+	}
+	msg.Answer = append(msg.Answer, retARR)
+
+	// Case 1: NotifyOnDNSMsg is called successfully
+	err = sdp.NotifyOnDNSMsg(time.Now(), ep, "1.1.1.1:80", serverId, netip.AddrPortFrom(netip.MustParseAddr("10.0.0.1"), 53), msg, "udp", true, nil)
+	require.NoError(t, err)
+
+	// Case 2: NotifyOnDNSMsg is called with invalid epIpPort
+	err = sdp.NotifyOnDNSMsg(time.Now(), ep, "1.1.1.1", serverId, netip.AddrPortFrom(netip.MustParseAddr("10.0.0.1"), 53), msg, "udp", true, nil)
+	require.Error(t, err)
+
+	// Case 3: NotifyOnDNSMsg is called with nil client
+	sdp.Client = nil
+	err = sdp.NotifyOnDNSMsg(time.Now(), ep, "1.1.1.1:80", serverId, netip.AddrPortFrom(netip.MustParseAddr("10.0.0.1"), 53), msg, "udp", true, nil)
+	require.Error(t, err)
+
+	// Case 4: NotifyOnDNSMsg is called with invalid msg
+	err = sdp.CreateClient(ctx)
+	require.NoError(t, err)
+	msg = new(dns.Msg)
+	err = sdp.NotifyOnDNSMsg(time.Now(), ep, "1.1.1.1:80", serverId, netip.AddrPortFrom(netip.MustParseAddr("10.0.0.1"), 53), msg, "udp", true, nil)
+	require.Equal(t, errors.New("Invalid DNS message"), err)
+
+}
+
+func TestCreateSubscriptionStream(t *testing.T) {
+	ctx := context.Background()
+	sdp, closer := setupStandaloneDNSProxy(t, ctx)
+	defer closer()
+
+	// First check if the subscription stream is created successfully
+	err := sdp.CreateClient(ctx)
+	require.NoError(t, err)
+
+	err = sdp.createStreamPolicyStateStream(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, sdp.policyStateStream)
+
+	// Now check if the subscription stream is created again if the dnsRulesStream is not nil
+	current := sdp.policyStateStream
+	err = sdp.createStreamPolicyStateStream(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, sdp.policyStateStream)
+	require.NotEqual(t, current, sdp.policyStateStream)
+
+	// Now check if the subscription stream is not created if the client is nil
+	sdp.Client = nil
+	err = sdp.createStreamPolicyStateStream(ctx)
+	require.Error(t, err)
+}
+
+var (
+	ipToEndpointIdCache = map[string]uint64{"1.1.1.10": 1}
+	ipToIdentityCache   = map[string]uint32{"1.1.1.10": 100}
+)
+
+func TestLookupSecIDByIP(t *testing.T) {
+	ctx := context.Background()
+	sdp, closer := setupStandaloneDNSProxy(t, ctx)
+	defer closer()
+
+	sdp.ipToIdentityCache = ipToIdentityCache
+	// Case 1: LookupSecIDByIP is called successfully
+	secID, found := sdp.LookupSecIDByIP(netip.MustParseAddr("1.1.1.10"))
+	require.True(t, found)
+	require.Equal(t, ipcache.Identity{
+		ID:     identity.NumericIdentity(100),
+		Source: source.Local,
+	}, secID)
+
+	// Case 2: LookupSecIDByIP is called with invalid ip
+	secID, found = sdp.LookupSecIDByIP(netip.MustParseAddr("2.2.2.2"))
+	require.False(t, found)
+	require.Equal(t, ipcache.Identity{}, secID)
+}
+
+func TestLookEPByIP(t *testing.T) {
+	ctx := context.Background()
+	sdp, closer := setupStandaloneDNSProxy(t, ctx)
+	defer closer()
+
+	sdp.ipToEndpointIdCache = ipToEndpointIdCache
+	sdp.ipToIdentityCache = ipToIdentityCache
+	// Case 1: LookupEPByIP is called successfully
+	ep, _, err := sdp.LookupEPByIP(netip.MustParseAddr("1.1.1.10"))
+	require.NoError(t, err)
+	require.NotNil(t, ep)
+	require.Equal(t, uint64(1), ep.GetID())
+	require.Equal(t, identity.NumericIdentity(100), ep.SecurityIdentity.ID)
+
+	// Case 2: LookupEPByIP is called with invalid ip
+	ep, _, err = sdp.LookupEPByIP(netip.MustParseAddr("2.2.2.2"))
+	require.Error(t, err)
+	require.Nil(t, ep)
+}
+
+func TestUpdatePolicyState(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ctx := context.Background()
+	sdp, closer := setupStandaloneDNSProxy(t, ctx)
+	defer closer()
+
+	dnsProxyConfig := dnsproxy.DNSProxyConfig{
+		Address:                "",
+		Port:                   1234,
+		IPv4:                   true,
+		IPv6:                   true,
+		EnableDNSCompression:   true,
+		MaxRestoreDNSIPs:       10,
+		ConcurrencyLimit:       10,
+		ConcurrencyGracePeriod: 10,
+		DNSProxyType:           dnsproxy.StandaloneDNSProxy,
+	}
+	epId := uint32(1)
+	dnsServerIps := []net.IP{
+		net.ParseIP("2.2.2.2"),
+	}
+	var dnsIps [][]byte
+	for _, i := range dnsServerIps {
+		dnsIps = append(dnsIps, []byte(i.String()))
+	}
+
+	epIps := []net.IP{
+		net.ParseIP("1.1.1.1"),
+	}
+	var ips [][]byte
+	for _, i := range epIps {
+		ips = append(ips, []byte(i.String()))
+	}
+
+	dstPortProto := restore.MakeV2PortProto(53, u8proto.UDP) // Set below when we setup the server!
+	IdentityToEndpointMapping := []*standalonednsproxy.IdentityToEndpointMapping{
+		{
+			Identity: 2,
+			EndpointInfo: []*standalonednsproxy.EndpointInfo{
+				{
+					Ip: dnsIps,
+					Id: 101,
+				},
+			},
+		},
+		{
+			Identity: 3,
+			EndpointInfo: []*standalonednsproxy.EndpointInfo{
+				{
+					Ip: dnsIps,
+					Id: 102,
+				},
+			},
+		},
+		{
+			Identity: 1,
+			EndpointInfo: []*standalonednsproxy.EndpointInfo{
+				{
+					Ip: ips,
+					Id: 100,
+				},
+			},
+		},
+	}
+	var test = []struct {
+		name string
+		args *standalonednsproxy.PolicyState
+		err  error
+		out  map[restore.PortProto][]identity.NumericIdentitySlice
+	}{
+		{
+			name: "Single DNS Policy with single DNS server",
+			args: &standalonednsproxy.PolicyState{
+				EgressL7DnsPolicy: []*standalonednsproxy.DNSPolicy{
+					{
+						SourceEndpointId: epId,
+						DnsPattern:       []string{"*.cilium.io", "example.com"},
+						DnsServers: []*standalonednsproxy.DNSServer{
+							{
+								DnsServerIdentity: 2,
+								DnsServerPort:     53,
+								DnsServerProto:    17,
+							},
+						},
+					},
+				},
+				IdentityToEndpointMapping: IdentityToEndpointMapping,
+			},
+			err: nil,
+			out: map[restore.PortProto][]identity.NumericIdentitySlice{
+				dstPortProto: {
+					{identity.NumericIdentity(2)},
+				},
+			},
+		},
+		{
+			name: "Single DNS Policy with multiple port and protocol DNS servers",
+			args: &standalonednsproxy.PolicyState{
+				EgressL7DnsPolicy: []*standalonednsproxy.DNSPolicy{
+					{
+						SourceEndpointId: epId,
+						DnsPattern:       []string{"*.cilium.io", "example.com"},
+						DnsServers: []*standalonednsproxy.DNSServer{
+							{
+								DnsServerIdentity: 2,
+								DnsServerPort:     53,
+								DnsServerProto:    17,
+							},
+							{
+								DnsServerIdentity: 3,
+								DnsServerPort:     53,
+								DnsServerProto:    17,
+							},
+						},
+					},
+				},
+				IdentityToEndpointMapping: IdentityToEndpointMapping,
+			},
+			err: nil,
+			out: map[restore.PortProto][]identity.NumericIdentitySlice{
+				dstPortProto: {
+					{identity.NumericIdentity(2), identity.NumericIdentity(3)},
+				},
+			},
+		},
+		{
+			name: "Multiple DNS Policies with same identity",
+			args: &standalonednsproxy.PolicyState{
+				EgressL7DnsPolicy: []*standalonednsproxy.DNSPolicy{
+					{
+						SourceEndpointId: epId,
+						DnsPattern:       []string{"*.aws.io"},
+						DnsServers: []*standalonednsproxy.DNSServer{
+							{
+								DnsServerIdentity: 2,
+								DnsServerPort:     53,
+								DnsServerProto:    17,
+							},
+						},
+					},
+					{
+						SourceEndpointId: epId,
+						DnsPattern:       []string{"*.cilium.io", "example.com"},
+						DnsServers: []*standalonednsproxy.DNSServer{
+							{
+								DnsServerIdentity: 3,
+								DnsServerPort:     53,
+								DnsServerProto:    17,
+							},
+						},
+					},
+				},
+				IdentityToEndpointMapping: IdentityToEndpointMapping,
+			},
+			err: nil,
+			out: map[restore.PortProto][]identity.NumericIdentitySlice{
+				dstPortProto: {
+					{identity.NumericIdentity(2)},
+					{identity.NumericIdentity(3)},
+				},
+			},
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy, err := dnsproxy.StartDNSProxy(dnsProxyConfig, // any address, any port, enable ipv4, enable ipv6, enable compression, max 1000 restore IPs
+				// LookupEPByIP
+				func(ip netip.Addr) (*endpoint.Endpoint, bool, error) {
+					return &endpoint.Endpoint{}, false, nil
+				},
+				// LookupSecIDByIP
+				func(ip netip.Addr) (ipcache.Identity, bool) {
+					return ipcache.Identity{}, false
+				},
+				// LookupIPsBySecID
+				func(nid identity.NumericIdentity) []string {
+					return []string{}
+				},
+				// NotifyOnDNSMsg
+				func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, dstAddr netip.AddrPort, msg *dns.Msg, protocol string, allowed bool, stat *dnsproxy.ProxyRequestContext) error {
+					return nil
+				},
+			)
+			require.NoError(t, err, "error starting DNS Proxy")
+			sdp.DNSProxy = proxy
+
+			_, err = sdp.UpdatePolicyState(tt.args)
+			if err != nil {
+				require.Equal(t, tt.err, err)
+				return
+			}
+			require.NoError(t, err)
+
+			allowedRules, err := sdp.DNSProxy.GetAllowedRulesForEndpoint(uint64(epId))
+			require.NoError(t, err)
+			// Compare the allowed rules with the expected output
+			for portProto, expectedSelectors := range tt.out {
+				actualSelectors, ok := allowedRules[portProto]
+				require.True(t, ok)
+				require.Equal(t, len(expectedSelectors), len(actualSelectors))
+			}
+
+			// Shutdown the DNS Proxy
+			for _, s := range sdp.DNSProxy.DNSServers {
+				s.Shutdown()
+			}
+		})
+	}
+}

--- a/standalone-dns-proxy/main.go
+++ b/standalone-dns-proxy/main.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/standalone-dns-proxy/cmd"
+)
+
+func main() {
+	dnsProxyHive := hive.New(cmd.DNSProxy)
+
+	cmd.Execute(cmd.NewDNSProxyCmd(dnsProxyHive))
+}

--- a/vendor/google.golang.org/grpc/test/bufconn/bufconn.go
+++ b/vendor/google.golang.org/grpc/test/bufconn/bufconn.go
@@ -1,0 +1,318 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package bufconn provides a net.Conn implemented by a buffer and related
+// dialing and listening functionality.
+package bufconn
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+// Listener implements a net.Listener that creates local, buffered net.Conns
+// via its Accept and Dial method.
+type Listener struct {
+	mu   sync.Mutex
+	sz   int
+	ch   chan net.Conn
+	done chan struct{}
+}
+
+// Implementation of net.Error providing timeout
+type netErrorTimeout struct {
+	error
+}
+
+func (e netErrorTimeout) Timeout() bool   { return true }
+func (e netErrorTimeout) Temporary() bool { return false }
+
+var errClosed = fmt.Errorf("closed")
+var errTimeout net.Error = netErrorTimeout{error: fmt.Errorf("i/o timeout")}
+
+// Listen returns a Listener that can only be contacted by its own Dialers and
+// creates buffered connections between the two.
+func Listen(sz int) *Listener {
+	return &Listener{sz: sz, ch: make(chan net.Conn), done: make(chan struct{})}
+}
+
+// Accept blocks until Dial is called, then returns a net.Conn for the server
+// half of the connection.
+func (l *Listener) Accept() (net.Conn, error) {
+	select {
+	case <-l.done:
+		return nil, errClosed
+	case c := <-l.ch:
+		return c, nil
+	}
+}
+
+// Close stops the listener.
+func (l *Listener) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	select {
+	case <-l.done:
+		// Already closed.
+		break
+	default:
+		close(l.done)
+	}
+	return nil
+}
+
+// Addr reports the address of the listener.
+func (l *Listener) Addr() net.Addr { return addr{} }
+
+// Dial creates an in-memory full-duplex network connection, unblocks Accept by
+// providing it the server half of the connection, and returns the client half
+// of the connection.
+func (l *Listener) Dial() (net.Conn, error) {
+	return l.DialContext(context.Background())
+}
+
+// DialContext creates an in-memory full-duplex network connection, unblocks Accept by
+// providing it the server half of the connection, and returns the client half
+// of the connection.  If ctx is Done, returns ctx.Err()
+func (l *Listener) DialContext(ctx context.Context) (net.Conn, error) {
+	p1, p2 := newPipe(l.sz), newPipe(l.sz)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-l.done:
+		return nil, errClosed
+	case l.ch <- &conn{p1, p2}:
+		return &conn{p2, p1}, nil
+	}
+}
+
+type pipe struct {
+	mu sync.Mutex
+
+	// buf contains the data in the pipe.  It is a ring buffer of fixed capacity,
+	// with r and w pointing to the offset to read and write, respectively.
+	//
+	// Data is read between [r, w) and written to [w, r), wrapping around the end
+	// of the slice if necessary.
+	//
+	// The buffer is empty if r == len(buf), otherwise if r == w, it is full.
+	//
+	// w and r are always in the range [0, cap(buf)) and [0, len(buf)].
+	buf  []byte
+	w, r int
+
+	wwait sync.Cond
+	rwait sync.Cond
+
+	// Indicate that a write/read timeout has occurred
+	wtimedout bool
+	rtimedout bool
+
+	wtimer *time.Timer
+	rtimer *time.Timer
+
+	closed      bool
+	writeClosed bool
+}
+
+func newPipe(sz int) *pipe {
+	p := &pipe{buf: make([]byte, 0, sz)}
+	p.wwait.L = &p.mu
+	p.rwait.L = &p.mu
+
+	p.wtimer = time.AfterFunc(0, func() {})
+	p.rtimer = time.AfterFunc(0, func() {})
+	return p
+}
+
+func (p *pipe) empty() bool {
+	return p.r == len(p.buf)
+}
+
+func (p *pipe) full() bool {
+	return p.r < len(p.buf) && p.r == p.w
+}
+
+func (p *pipe) Read(b []byte) (n int, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Block until p has data.
+	for {
+		if p.closed {
+			return 0, io.ErrClosedPipe
+		}
+		if !p.empty() {
+			break
+		}
+		if p.writeClosed {
+			return 0, io.EOF
+		}
+		if p.rtimedout {
+			return 0, errTimeout
+		}
+
+		p.rwait.Wait()
+	}
+	wasFull := p.full()
+
+	n = copy(b, p.buf[p.r:len(p.buf)])
+	p.r += n
+	if p.r == cap(p.buf) {
+		p.r = 0
+		p.buf = p.buf[:p.w]
+	}
+
+	// Signal a blocked writer, if any
+	if wasFull {
+		p.wwait.Signal()
+	}
+
+	return n, nil
+}
+
+func (p *pipe) Write(b []byte) (n int, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return 0, io.ErrClosedPipe
+	}
+	for len(b) > 0 {
+		// Block until p is not full.
+		for {
+			if p.closed || p.writeClosed {
+				return 0, io.ErrClosedPipe
+			}
+			if !p.full() {
+				break
+			}
+			if p.wtimedout {
+				return 0, errTimeout
+			}
+
+			p.wwait.Wait()
+		}
+		wasEmpty := p.empty()
+
+		end := cap(p.buf)
+		if p.w < p.r {
+			end = p.r
+		}
+		x := copy(p.buf[p.w:end], b)
+		b = b[x:]
+		n += x
+		p.w += x
+		if p.w > len(p.buf) {
+			p.buf = p.buf[:p.w]
+		}
+		if p.w == cap(p.buf) {
+			p.w = 0
+		}
+
+		// Signal a blocked reader, if any.
+		if wasEmpty {
+			p.rwait.Signal()
+		}
+	}
+	return n, nil
+}
+
+func (p *pipe) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closed = true
+	// Signal all blocked readers and writers to return an error.
+	p.rwait.Broadcast()
+	p.wwait.Broadcast()
+	return nil
+}
+
+func (p *pipe) closeWrite() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.writeClosed = true
+	// Signal all blocked readers and writers to return an error.
+	p.rwait.Broadcast()
+	p.wwait.Broadcast()
+	return nil
+}
+
+type conn struct {
+	io.Reader
+	io.Writer
+}
+
+func (c *conn) Close() error {
+	err1 := c.Reader.(*pipe).Close()
+	err2 := c.Writer.(*pipe).closeWrite()
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+func (c *conn) SetDeadline(t time.Time) error {
+	c.SetReadDeadline(t)
+	c.SetWriteDeadline(t)
+	return nil
+}
+
+func (c *conn) SetReadDeadline(t time.Time) error {
+	p := c.Reader.(*pipe)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.rtimer.Stop()
+	p.rtimedout = false
+	if !t.IsZero() {
+		p.rtimer = time.AfterFunc(time.Until(t), func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.rtimedout = true
+			p.rwait.Broadcast()
+		})
+	}
+	return nil
+}
+
+func (c *conn) SetWriteDeadline(t time.Time) error {
+	p := c.Writer.(*pipe)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.wtimer.Stop()
+	p.wtimedout = false
+	if !t.IsZero() {
+		p.wtimer = time.AfterFunc(time.Until(t), func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.wtimedout = true
+			p.wwait.Broadcast()
+		})
+	}
+	return nil
+}
+
+func (*conn) LocalAddr() net.Addr  { return addr{} }
+func (*conn) RemoteAddr() net.Addr { return addr{} }
+
+type addr struct{}
+
+func (addr) Network() string { return "bufconn" }
+func (addr) String() string  { return "bufconn" }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1875,6 +1875,7 @@ google.golang.org/grpc/serviceconfig
 google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
+google.golang.org/grpc/test/bufconn
 # google.golang.org/protobuf v1.36.5
 ## explicit; go 1.21
 google.golang.org/protobuf/encoding/protodelim


### PR DESCRIPTION
The PR adds the standalone dns proxy and handling the client side of the grpc created in #36121. For overall flow, please go through the https://github.com/cilium/cilium/issues/30984#issuecomment-2505035738 and overall SDP PR: https://github.com/cilium/cilium/pull/37836
- Standalone DNS Proxy will start by starting the DNS Proxy with a type `StandaloneDNSProxy` and creating a trigger that handles the connection to cilium agent.
- The controller tries to connect to the cilium agent and create the stream using the `streamPolicyState`(For receiving the DNS policies) and then start a go routine to listen on the created stream. It retries to use the connection/stream if there are multiple triggers.
- `streamPolicyState` is called as a part of trigger to create a stream to listen for DNS policy rules from cilium agent.
- `UpdateMappingRequest` is used during the callback with the DNS mappings in the `NotifyDNSMsg` in the DNS proxy. This is used to send the data to cilium agent to configure the policy.

Fixes: https://github.com/cilium/cilium/issues/30984
Related PRs: https://github.com/cilium/cilium/pull/36213, https://github.com/cilium/cilium/pull/36215
CFP: https://github.com/cilium/design-cfps/pull/54