### PR TITLE
helm: kvstoremesh with external etcd

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -612,6 +612,10 @@
      - TCP port for the KVStoreMesh health API.
      - int
      - ``9881``
+   * - :spelling:ignore:`clustermesh.apiserver.kvstoremesh.kvstoreMode`
+     - Specify the KVStore mode when running KVStoreMesh Supported values: - "internal": remote cluster identities are cached in etcd that runs as a sidecar within ``clustermesh-apiserver`` pod. - "external": ``clustermesh-apiserver`` will sync remote cluster information to the etcd used as kvstore. This can't be enabled with crd identity allocation mode.
+     - string
+     - ``"internal"``
    * - :spelling:ignore:`clustermesh.apiserver.kvstoremesh.lifecycle`
      - lifecycle setting for the KVStoreMesh container
      - object

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -203,6 +203,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.kvstoremesh.extraEnv | list | `[]` | Additional KVStoreMesh environment variables. |
 | clustermesh.apiserver.kvstoremesh.extraVolumeMounts | list | `[]` | Additional KVStoreMesh volumeMounts. |
 | clustermesh.apiserver.kvstoremesh.healthPort | int | `9881` | TCP port for the KVStoreMesh health API. |
+| clustermesh.apiserver.kvstoremesh.kvstoreMode | string | `"internal"` | Specify the KVStore mode when running KVStoreMesh Supported values: - "internal": remote cluster identities are cached in etcd that runs as a sidecar within ``clustermesh-apiserver`` pod. - "external": ``clustermesh-apiserver`` will sync remote cluster information to the etcd used as kvstore. This can't be enabled with crd identity allocation mode. |
 | clustermesh.apiserver.kvstoremesh.lifecycle | object | `{}` | lifecycle setting for the KVStoreMesh container |
 | clustermesh.apiserver.kvstoremesh.readinessProbe | object | `{}` | Configuration for the KVStoreMesh readiness probe. |
 | clustermesh.apiserver.kvstoremesh.resources | object | `{}` | Resource requests and limits for the KVStoreMesh container |

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.serviceAccounts.clustermeshApiserver.create .Values.rbac.create (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -23,9 +23,16 @@ spec:
   selector:
     matchLabels:
       k8s-app: clustermesh-apiserver
-  {{- with .Values.clustermesh.apiserver.updateStrategy }}
+  {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external" }}
+  {{/* without proper locking in kvstoremesh we can't run multiple pods at once */}}
   strategy:
+      type: Recreate
+  {{- else }}
+    {{- with .Values.clustermesh.apiserver.updateStrategy }}
+  strategy:
+    # -- The priority class to use for clustermesh-apiserver
     {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
   template:
     metadata:
@@ -52,6 +59,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal" }}
       initContainers:
       - name: etcd-init
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
@@ -104,7 +112,9 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- end }}
       containers:
+      {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal" }}
       - name: etcd
         # The clustermesh-apiserver container image includes an etcd binary.
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
@@ -266,6 +276,7 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- end }}
       {{- if .Values.clustermesh.apiserver.kvstoremesh.enabled }}
       - name: kvstoremesh
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
@@ -281,7 +292,9 @@ spec:
         - --cluster-id=$(CLUSTER_ID)
         - --kvstore-opt=etcd.config=/var/lib/cilium/etcd-config.yaml
         - --kvstore-opt=etcd.qps=100
+        {{- if ne .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external" }}
         - --kvstore-opt=etcd.bootstrapQps=10000
+        {{- end }}
         - --kvstore-opt=etcd.maxInflight=10
         - --clustermesh-config=/var/lib/cilium/clustermesh
         {{- if hasKey .Values.clustermesh "maxConnectedClusters" }}
@@ -330,12 +343,19 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
+        {{- if (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") }}
         - name: etcd-admin-client
           mountPath: /var/lib/cilium/etcd-secrets
           readOnly: true
+        {{- end }}
         - name: kvstoremesh-secrets
           mountPath: /var/lib/cilium/clustermesh
           readOnly: true
+        {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external"}}
+        - name: etcd-config
+          mountPath: /var/lib/cilium
+          readOnly: true
+        {{- end }}
         {{- with .Values.clustermesh.apiserver.kvstoremesh.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -350,6 +370,7 @@ spec:
         {{- end }}
       {{- end }}
       volumes:
+      {{- if (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") }}
       - name: etcd-server-secrets
         projected:
           # note: the leading zero means this number is in octal representation: do not remove it
@@ -404,6 +425,7 @@ spec:
       - name: etcd-data-dir
         emptyDir:
           medium: {{ ternary "Memory" "" (eq .Values.clustermesh.apiserver.etcd.storageMedium "Memory") | quote }}
+      {{- end }}
       {{- if .Values.clustermesh.apiserver.kvstoremesh.enabled }}
       - name: kvstoremesh-secrets
         projected:
@@ -427,6 +449,15 @@ spec:
                 path: common-etcd-client.crt
               - key: ca.crt
                 path: common-etcd-client-ca.crt
+      {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external"}}
+      - configMap:
+          defaultMode: 0400
+          items:
+          - key: etcd-config
+            path: etcd-config.yaml
+          name: cilium-config
+        name: etcd-config
+      {{- end }}
       {{- end }}
       {{- with .Values.clustermesh.apiserver.extraVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/metrics-service.yaml
@@ -24,11 +24,13 @@ spec:
   clusterIP: None
   type: ClusterIP
   ports:
-  {{- if .Values.clustermesh.apiserver.metrics.enabled }}
+  {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal" }}
+    {{- if .Values.clustermesh.apiserver.metrics.enabled }}
   - name: apiserv-metrics
     port: {{ .Values.clustermesh.apiserver.metrics.port }}
     protocol: TCP
     targetPort: apiserv-metrics
+    {{- end }}
   {{- end }}
   {{- if $kvstoreMetricsEnabled }}
   - name: kvmesh-metrics
@@ -36,11 +38,13 @@ spec:
     protocol: TCP
     targetPort: kvmesh-metrics
   {{- end }}
-  {{- if .Values.clustermesh.apiserver.metrics.etcd.enabled }}
+  {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal" }}
+    {{- if .Values.clustermesh.apiserver.metrics.etcd.enabled }}
   - name: etcd-metrics
     port: {{ .Values.clustermesh.apiserver.metrics.etcd.port }}
     protocol: TCP
     targetPort: etcd-metrics
+    {{- end }}
   {{- end }}
   selector:
     k8s-app: clustermesh-apiserver

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
@@ -1,4 +1,4 @@
-{{- if (or .Values.externalWorkloads.enabled  .Values.clustermesh.useAPIServer) }}
+{{- if and (or .Values.externalWorkloads.enabled  .Values.clustermesh.useAPIServer) (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
@@ -35,7 +35,7 @@ spec:
     matchNames:
     - {{ include "cilium.namespace" . }}
   endpoints:
-  {{- if .Values.clustermesh.apiserver.metrics.enabled }}
+  {{- if and .Values.clustermesh.apiserver.metrics.enabled (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") }}
   - port: apiserv-metrics
     interval: {{ .Values.clustermesh.apiserver.metrics.serviceMonitor.interval | quote }}
     honorLabels: true
@@ -63,7 +63,7 @@ spec:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
-  {{- if .Values.clustermesh.apiserver.metrics.etcd.enabled }}
+  {{- if and .Values.clustermesh.apiserver.metrics.etcd.enabled (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") }}
   - port: etcd-metrics
     interval: {{ .Values.clustermesh.apiserver.metrics.serviceMonitor.etcd.interval | quote }}
     honorLabels: true

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/admin-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
+{{- if and (or .Values.externalWorkloads.enabled (and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal"))) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/local-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/local-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
+{{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/remote-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
+{{- if and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
+{{- if and (or .Values.externalWorkloads.enabled (and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal"))) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "certmanager") }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/job.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/job.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") }}
+{{- if and (or .Values.externalWorkloads.enabled (and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal"))) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "cronJob") }}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/admin-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "helm") }}
+{{- if and (or .Values.externalWorkloads.enabled ( and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal"))) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "helm") }}
 {{- $_ := include "cilium.ca.setup" . -}}
 {{- $cn := include "clustermesh-apiserver-generate-certs.admin-common-name" . -}}
 {{- $cert := genSignedCert $cn nil nil (.Values.clustermesh.apiserver.tls.auto.certValidityDuration | int) .commonCA -}}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/local-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/local-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "helm") }}
+{{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "helm") }}
 {{- $_ := include "cilium.ca.setup" . -}}
 {{- $cn := include "clustermesh-apiserver-generate-certs.local-common-name" . -}}
 {{- $cert := genSignedCert $cn nil nil (.Values.clustermesh.apiserver.tls.auto.certValidityDuration | int) .commonCA -}}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/remote-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "helm") }}
+{{- if and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "helm") }}
 {{- $_ := include "cilium.ca.setup" . -}}
 {{- $cn := include "clustermesh-apiserver-generate-certs.remote-common-name" . -}}
 {{- $cert := genSignedCert $cn nil nil (.Values.clustermesh.apiserver.tls.auto.certValidityDuration | int) .commonCA -}}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "helm") }}
+{{- if and (or .Values.externalWorkloads.enabled (and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal"))) .Values.clustermesh.apiserver.tls.auto.enabled (eq .Values.clustermesh.apiserver.tls.auto.method "helm") }}
 {{- $_ := include "cilium.ca.setup" . -}}
 {{- $cn := "clustermesh-apiserver.cilium.io" }}
 {{- $ip := concat (list "127.0.0.1" "::1") .Values.clustermesh.apiserver.tls.server.extraIpAddresses }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/admin-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) (not .Values.clustermesh.apiserver.tls.auto.enabled) }}
+{{- if and (or .Values.externalWorkloads.enabled (and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal"))) (not .Values.clustermesh.apiserver.tls.auto.enabled) }}
 {{- if .Values.clustermesh.apiserver.tls.enableSecrets }}
 apiVersion: v1
 kind: Secret

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/remote-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clustermesh.useAPIServer (not .Values.clustermesh.apiserver.tls.auto.enabled) }}
+{{- if and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") (not .Values.clustermesh.apiserver.tls.auto.enabled) }}
 {{- if .Values.clustermesh.apiserver.tls.enableSecrets }}
 apiVersion: v1
 kind: Secret

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/server-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) (not .Values.clustermesh.apiserver.tls.auto.enabled) }}
+{{- if and (or .Values.externalWorkloads.enabled (and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal"))) (not .Values.clustermesh.apiserver.tls.auto.enabled) }}
 {{- if .Values.clustermesh.apiserver.tls.enableSecrets }}
 apiVersion: v1
 kind: Secret

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
@@ -1,5 +1,5 @@
 {{- if and
-  (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer)
+  (or .Values.externalWorkloads.enabled (and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal")))
   (ne .Values.clustermesh.apiserver.tls.authMode "legacy")
 }}
 ---

--- a/install/kubernetes/cilium/templates/clustermesh-config/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-config/_helpers.tpl
@@ -2,6 +2,8 @@
 {{- $cluster := index . 0 -}}
 {{- $domain := index . 1 -}}
 {{- $override := index . 2 -}}
+{{- $local_etcd := index . 3 -}}
+{{- $etcd_config := index . 4 -}}
 {{- /* The parenthesis around $cluster.tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}
 {{- $prefix := ternary "common-" (printf "%s." $cluster.name) (or (empty ($cluster.tls).cert) (empty ($cluster.tls).key)) -}}
 {{- /* KVStoreMesh is enabled, and we are generating the secret used by Cilium agents. */}}
@@ -12,15 +14,24 @@
 {{- end -}}
 
 endpoints:
-{{- if ne $override "" }}
+{{- if $local_etcd }}
+{{ $etcd_config.endpoints | toYaml }}
+{{- else if ne $override "" }}
 - {{ $override }}
 {{- else if $cluster.ips }}
 - https://{{ $cluster.name }}.{{ $domain }}:{{ $cluster.port }}
 {{- else }}
 - https://{{ $cluster.address | required "missing clustermesh.apiserver.config.clusters.address" }}:{{ $cluster.port }}
 {{- end }}
+{{- if $local_etcd }}
+  {{- if $etcd_config.ssl }}
+trusted-ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
+key-file: '/var/lib/etcd-secrets/etcd-client.key'
+cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
+  {{- end }}
+{{- else }}
 {{- if or (ne $override "") (not (empty ($cluster.tls).caCert)) }}
-{{- /* The custom CA configuration takes effect only if a custom certificate and key are also set, */}}
+{{- /* The custom CA configuration takes effect only if a custom certificate and key are also set */}}
 {{- /* otherwise we may enter this branch, but the prefix is still set to common-.                 */}}
 {{- /* Additionally, when KVStoreMesh is enabled, and we are generating the secret for the agents, */}}
 {{- /* we want to always use the corresponding CA certificate, that is the one with local- prefix. */}}
@@ -30,4 +41,5 @@ trusted-ca-file: /var/lib/cilium/clustermesh/common-etcd-client-ca.crt
 {{- end }}
 key-file: /var/lib/cilium/clustermesh/{{ $prefix }}etcd-client.key
 cert-file: /var/lib/cilium/clustermesh/{{ $prefix }}etcd-client.crt
+{{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
@@ -17,8 +17,9 @@ metadata:
 data:
   {{- $kvstoremesh := and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled }}
   {{- $override := ternary (printf "https://clustermesh-apiserver.%s.svc:2379" (include "cilium.namespace" .)) "" $kvstoremesh }}
+  {{- $local_etcd := and $kvstoremesh (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external") }}
   {{- range .Values.clustermesh.config.clusters }}
-  {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain $override) | b64enc }}
+  {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain $override $local_etcd $.Values.etcd ) | b64enc }}
   {{- /* The parenthesis around .tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}
   {{- if and (eq $override "") (.tls).cert (.tls).key }}
   {{- if .tls.caCert }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/kvstoremesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/kvstoremesh-secret.yaml
@@ -16,7 +16,7 @@ metadata:
   {{- end }}
 data:
   {{- range .Values.clustermesh.config.clusters }}
-  {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain "") | b64enc }}
+  {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain "" false $.Values.etcd ) | b64enc }}
   {{- /* The parenthesis around .tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}
   {{- if and (.tls).cert (.tls).key }}
   {{- if .tls.caCert }}

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -156,7 +156,12 @@
 {{- end }}
 
 {{/* validate clustermesh-apiserver */}}
-{{- if .Values.clustermesh.useAPIServer }}
+
+{{- if not (list "internal" "external" | has .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode) -}}
+{{- fail ".Values.clustermesh.apiserver.kvstoremesh.kvstoreMode must have the value of external or internal" -}}
+{{- end -}}
+
+{{- if and .Values.clustermesh.useAPIServer (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") }}
   {{- if and (ne .Values.identityAllocationMode "crd") (ne .Values.identityAllocationMode "doublewrite-readkvstore") (ne .Values.identityAllocationMode "doublewrite-readcrd") }}
     {{ fail (printf "The clustermesh-apiserver cannot be enabled in combination with .Values.identityAllocationMode=%s. To establish a Cluster Mesh, directly configure the parameters to access the remote kvstore through .Values.clustermesh.config" .Values.identityAllocationMode ) }}
   {{- end }}
@@ -170,6 +175,23 @@
   {{- end }}
   {{- if .Values.disableEndpointCRD }}
     {{ fail "External workloads support cannot be enabled in combination with .Values.disableEndpointCRD=true" }}
+  {{- end }}
+{{- end }}
+{{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external"}}
+  {{- if not .Values.clustermesh.useAPIServer }}
+    {{- fail "kvstoremesh.kvstoreMode=external can only be used with clustermesh.useAPIServer=true" }}
+  {{- end }}
+  {{- if not .Values.clustermesh.apiserver.kvstoremesh.enabled }}
+    {{- fail "kvstoremesh.kvstoreMode=external can only be used with kvstoremesh.enabled=true" }}
+  {{- end }}
+  {{- if ne (toString .Values.clustermesh.apiserver.replicas) "1"  }}
+    {{- fail "Only single clustermesh-apiserver replica is allowed when kvstoreMode=external" }}
+  {{- end }}
+  {{- if .Values.externalWorkloads.enabled }}
+    {{- fail (printf "KVStoreMesh with %s etcd cannot be enabled in combination with .Values.externalWorkloads.enabled=true" .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode) }}
+  {{- end }}
+  {{- if and (ne .Values.identityAllocationMode "kvstore") (ne .Values.identityAllocationMode "doublewrite-readkvstore") (ne .Values.identityAllocationMode "doublewrite-readcrd") }}
+    {{- fail (printf "KVStoreMesh with %s etcd cannot be enabled in combination with .Values.identityAllocationMode=%s" .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode .Values.identityAllocationMode) }}
   {{- end }}
 {{- end }}
 

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -991,6 +991,9 @@
                 "healthPort": {
                   "type": "integer"
                 },
+                "kvstoreMode": {
+                  "type": "string"
+                },
                 "lifecycle": {
                   "type": "object"
                 },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3229,6 +3229,11 @@ clustermesh:
             - ALL
       # -- lifecycle setting for the KVStoreMesh container
       lifecycle: {}
+      # -- Specify the KVStore mode when running KVStoreMesh
+      # Supported values:
+      # - "internal": remote cluster identities are cached in etcd that runs as a sidecar within ``clustermesh-apiserver`` pod.
+      # - "external": ``clustermesh-apiserver`` will sync remote cluster information to the etcd used as kvstore. This can't be enabled with crd identity allocation mode.
+      kvstoreMode: "internal"
     service:
       # -- The type of service used for apiserver access.
       type: NodePort

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3254,6 +3254,11 @@ clustermesh:
             - ALL
       # -- lifecycle setting for the KVStoreMesh container
       lifecycle: {}
+      # -- Specify the KVStore mode when running KVStoreMesh
+      # Supported values:
+      # - "internal": remote cluster identities are cached in etcd that runs as a sidecar within ``clustermesh-apiserver`` pod.
+      # - "external": ``clustermesh-apiserver`` will sync remote cluster information to the etcd used as kvstore. This can't be enabled with crd identity allocation mode.
+      kvstoreMode: "internal"
     service:
       # -- The type of service used for apiserver access.
       type: NodePort


### PR DESCRIPTION
When running clustermesh-apiserver, there should be an option to enable and disable containers that are not needed.
For example the etcd and apiserver containers are not necessary when running kvstoremesh with an external kvstore.

This commit adds the options to disable these containers.

This PR is revival of https://github.com/cilium/cilium/pull/34174, its comments were adressed and some fixes were made.

<!-- Description of change -->

```release-note
Added possibility to run kvstoremesh with external etcd.
```
