### PR TITLE
helm: Define a variable for common label validation exclusion

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -41,7 +41,12 @@ echo -e "# This file is based on $(RELATIVE_DIR)/cilium/$(VALUES_TMPL_FILE_NAME)
 $(YQ) ea '. as $$item ireduce ({}; . * $$item )' $(1) | envsubst >> $(2)
 endef
 
+COMMON_LABELS_EXCLUSIONS := --exclude validate.yaml
+
 all: update-versions check-values-yaml docs lint
+
+# Add the ability to override variables and add more targets.
+-include Makefile.override
 
 update-chart: $(ROOT_DIR)/VERSION # Update chart versions to point to the current version.
 	$(ECHO_GEN)cilium/Chart.yaml
@@ -73,7 +78,7 @@ CRD_FILES := $(shell find $(ROOT_DIR)/examples/crds/*/ -type f)
 CRDS := $(foreach path,$(patsubst %.yaml,%,$(CRD_FILES)),$(shell basename $(path)))
 lint:
 	$(ECHO_CHECK)
-	$(QUIET)grep -RL --exclude validate.yaml .Values.commonLabels $(ROOT_DIR)/$(RELATIVE_DIR)/cilium/templates/*.yaml $(ROOT_DIR)/$(RELATIVE_DIR)/cilium/templates/**/*.yaml >> missing_label
+	$(QUIET)grep -RL $(COMMON_LABELS_EXCLUSIONS) .Values.commonLabels $(ROOT_DIR)/$(RELATIVE_DIR)/cilium/templates/*.yaml $(ROOT_DIR)/$(RELATIVE_DIR)/cilium/templates/**/*.yaml >> missing_label
 	$(QUIET)if [ -s missing_label ]; then \
 		echo "These files are missing the .Values.commonLabels, please add them and submit your changes" ; \
 		cat missing_label ; \


### PR DESCRIPTION
Define COMMON_LABELS_EXCLUSIONS variable, and include an optional Makefile.override so that downstream projects can override the variable as needed.

cc @strongjz 