### PR TITLE
Export Map{Key,Value} fields to prevent `map {get,list}` handler panics.

### DIFF
--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -509,9 +509,9 @@ const SizeofSockRevNat6Key = int(unsafe.Sizeof(SockRevNat6Key{}))
 
 // SockRevNat6Value is an entry in the reverse NAT sock map.
 type SockRevNat6Value struct {
-	address     types.IPv6 `align:"address"`
-	port        int16      `align:"port"`
-	revNatIndex uint16     `align:"rev_nat_index"`
+	Address     types.IPv6 `align:"address"`
+	Port        int16      `align:"port"`
+	RevNatIndex uint16     `align:"rev_nat_index"`
 }
 
 // SizeofSockRevNat6Value is the size of type SockRevNat6Value.
@@ -539,7 +539,7 @@ func (k *SockRevNat6Key) New() bpf.MapKey { return &SockRevNat6Key{} }
 
 // String converts the value into a human readable string format.
 func (v *SockRevNat6Value) String() string {
-	return fmt.Sprintf("[%s]:%d, %d", v.address, v.port, v.revNatIndex)
+	return fmt.Sprintf("[%s]:%d, %d", v.Address, v.Port, v.RevNatIndex)
 }
 
 func (v *SockRevNat6Value) New() bpf.MapValue { return &SockRevNat6Value{} }

--- a/pkg/maps/neighborsmap/neighborsmap.go
+++ b/pkg/maps/neighborsmap/neighborsmap.go
@@ -50,12 +50,12 @@ func neighMapsGet() (*bpf.Map, *bpf.Map) {
 
 // Key4 is the IPv4 for the IP-to-MAC address mappings.
 type Key4 struct {
-	ipv4 types.IPv4
+	Ipv4 types.IPv4
 }
 
 // Key6 is the IPv6 for the IP-to-MAC address mappings.
 type Key6 struct {
-	ipv6 types.IPv6
+	Ipv6 types.IPv6
 }
 
 // SizeofNeighKey6 is the size of type NeighKey6.
@@ -63,7 +63,7 @@ const SizeofNeighKey6 = int(unsafe.Sizeof(Key6{}))
 
 // Value is the MAC address for the IP-to-MAC address mappings.
 type Value struct {
-	macaddr types.MACAddr
+	Macaddr types.MACAddr
 	_       uint16
 }
 
@@ -71,15 +71,15 @@ type Value struct {
 const SizeOfNeighValue = int(unsafe.Sizeof(Value{}))
 
 // String converts the key into a human readable string format.
-func (k *Key4) String() string  { return k.ipv4.String() }
+func (k *Key4) String() string  { return k.Ipv4.String() }
 func (k *Key4) New() bpf.MapKey { return &Key4{} }
 
 // String converts the key into a human readable string format.
-func (k *Key6) String() string  { return k.ipv6.String() }
+func (k *Key6) String() string  { return k.Ipv6.String() }
 func (k *Key6) New() bpf.MapKey { return &Key6{} }
 
 // String converts the value into a human readable string format.
-func (v *Value) String() string    { return v.macaddr.String() }
+func (v *Value) String() string    { return v.Macaddr.String() }
 func (k *Value) New() bpf.MapValue { return &Value{} }
 
 // InitMaps creates the nodeport neighbors maps in the kernel.
@@ -112,11 +112,11 @@ func NeighRetire(ip net.IP) {
 	defer neighMap.Close()
 	if len(ip) == net.IPv4len {
 		key := &Key4{}
-		copy(key.ipv4[:], ip.To4())
+		copy(key.Ipv4[:], ip.To4())
 		neighMap.Delete(key)
 	} else {
 		key := &Key6{}
-		copy(key.ipv6[:], ip.To16())
+		copy(key.Ipv6[:], ip.To16())
 		neighMap.Delete(key)
 	}
 }

--- a/pkg/maps/policymap/callmap.go
+++ b/pkg/maps/policymap/callmap.go
@@ -16,20 +16,20 @@ type PolicyPlumbingMap struct {
 }
 
 type PlumbingKey struct {
-	key uint32
+	Key uint32
 }
 
 type PlumbingValue struct {
-	fd uint32
+	Fd uint32
 }
 
 func (k *PlumbingKey) String() string {
-	return fmt.Sprintf("Endpoint: %d", k.key)
+	return fmt.Sprintf("Endpoint: %d", k.Key)
 }
 func (k *PlumbingKey) New() bpf.MapKey { return &PlumbingKey{} }
 
 func (v *PlumbingValue) String() string {
-	return fmt.Sprintf("fd: %d", v.fd)
+	return fmt.Sprintf("fd: %d", v.Fd)
 }
 
 func (k *PlumbingValue) New() bpf.MapValue { return &PlumbingValue{} }
@@ -40,7 +40,7 @@ func RemoveGlobalMapping(id uint32, haveEgressCallMap bool) error {
 	gpm, err := OpenCallMap(PolicyCallMapName)
 	if err == nil {
 		k := PlumbingKey{
-			key: id,
+			Key: id,
 		}
 		err = gpm.Map.Delete(&k)
 		gpm.Close()
@@ -49,7 +49,7 @@ func RemoveGlobalMapping(id uint32, haveEgressCallMap bool) error {
 		gpm, err2 := OpenCallMap(PolicyEgressCallMapName)
 		if err2 == nil {
 			k := PlumbingKey{
-				key: id,
+				Key: id,
 			}
 			err2 = gpm.Map.Delete(&k)
 			gpm.Close()

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -204,20 +204,20 @@ func getPolicyEntryFlags(p policyEntryFlagParams) policyEntryFlags {
 
 // CallKey is the index into the prog array map.
 type CallKey struct {
-	index uint32
+	Index uint32
 }
 
 // CallValue is the program ID in the prog array map.
 type CallValue struct {
-	progID uint32
+	ProgID uint32
 }
 
 // String converts the key into a human readable string format.
-func (k *CallKey) String() string  { return strconv.FormatUint(uint64(k.index), 10) }
+func (k *CallKey) String() string  { return strconv.FormatUint(uint64(k.Index), 10) }
 func (k *CallKey) New() bpf.MapKey { return &CallKey{} }
 
 // String converts the value into a human readable string format.
-func (v *CallValue) String() string    { return strconv.FormatUint(uint64(v.progID), 10) }
+func (v *CallValue) String() string    { return strconv.FormatUint(uint64(v.ProgID), 10) }
 func (v *CallValue) New() bpf.MapValue { return &CallValue{} }
 
 func (pe *PolicyEntry) Add(oPe PolicyEntry) {

--- a/pkg/maps/signalmap/signalmap.go
+++ b/pkg/maps/signalmap/signalmap.go
@@ -20,20 +20,20 @@ const (
 
 // Key is the index into the prog array map.
 type Key struct {
-	index uint32
+	Index uint32
 }
 
 // Value is the program ID in the prog array map.
 type Value struct {
-	progID uint32
+	ProgID uint32
 }
 
 // String converts the key into a human readable string format.
-func (k *Key) String() string  { return fmt.Sprintf("%d", k.index) }
+func (k *Key) String() string  { return fmt.Sprintf("%d", k.Index) }
 func (k *Key) New() bpf.MapKey { return &Key{} }
 
 // String converts the value into a human readable string format.
-func (v *Value) String() string    { return fmt.Sprintf("%d", v.progID) }
+func (v *Value) String() string    { return fmt.Sprintf("%d", v.ProgID) }
 func (v *Value) New() bpf.MapValue { return &Value{} }
 
 type signalMap struct {


### PR DESCRIPTION
pkg/maps/*: export Map{Key,Value} fields to fix cilium-dbg panics.

The `cilium-dbg map {get,list}` open-api handler will generically try to
unpack bpf map data into their respective key/value pairs.
However, if the Map{Key,Value} structs have unexported fields this will
panic causing the following errors:

level=warning msg="Cilium API handler panicked" client=@ method=GET panic_message="reflect: reflect.Value.SetUint using value obtained using unexported field" subsys=api url=/v1/map

This can be reproduced by enabling a feature that uses such a map, such
as `socketLB.enabled=true`, followed by doing a map list:

```
root@kind-worker:/home/cilium# cilium map list
Error: Get "http://localhost/v1/map": EOF
```

This commit exports any unexported fields in types used as key/values in
pkg/maps to avoid such errors.

Fixes: https://github.com/cilium/cilium/issues/33766