### PR TITLE
helm: Fix duplicate tunnel-protocol configuration in cilium-config configmap

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -488,25 +488,18 @@ data:
   {{- if ne (.Values.routingMode | default "native") "native" }}
     {{- fail (printf "RoutingMode must be set to native when gke.enabled=true" )}}
   {{- end }}
-  routing-mode: "native"
   enable-endpoint-routes: "true"
 {{- else if .Values.aksbyocni.enabled }}
   {{- if ne (.Values.routingMode | default "tunnel") "tunnel" }}
     {{- fail (printf "RoutingMode must be set to tunnel when aksbyocni.enabled=true" )}}
   {{- end }}
-  routing-mode: "tunnel"
-  tunnel-protocol: "vxlan"
-{{- else if .Values.routingMode }}
-  routing-mode: {{ .Values.routingMode | quote }}
-{{- else }}
-  # Default case
-  routing-mode: "tunnel"
-  tunnel-protocol: "vxlan"
+  {{- if ne (.Values.tunnelProtocol | default "vxlan" ) "vxlan" }}
+    {{- fail (printf "TunnelProtocol must be set to vxlan when aksbyocni.enabled=true" )}}
+  {{- end }}
 {{- end }}
 
-{{- if .Values.tunnelProtocol }}
-  tunnel-protocol: {{ .Values.tunnelProtocol | quote }}
-{{- end }}
+  routing-mode: {{ .Values.routingMode | default (ternary "native" "tunnel" .Values.gke.enabled) | quote }}
+  tunnel-protocol: {{ .Values.tunnelProtocol | default "vxlan" | quote }}
 
 {{- if .Values.tunnelPort }}
   tunnel-port: {{ .Values.tunnelPort | quote }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -493,9 +493,6 @@ data:
   {{- if ne (.Values.routingMode | default "tunnel") "tunnel" }}
     {{- fail (printf "RoutingMode must be set to tunnel when aksbyocni.enabled=true" )}}
   {{- end }}
-  {{- if ne (.Values.tunnelProtocol | default "vxlan" ) "vxlan" }}
-    {{- fail (printf "TunnelProtocol must be set to vxlan when aksbyocni.enabled=true" )}}
-  {{- end }}
 {{- end }}
 
   routing-mode: {{ .Values.routingMode | default (ternary "native" "tunnel" .Values.gke.enabled) | quote }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

---

We had trouble setting this up too, and as @haribhusal2025 stated in https://github.com/cilium/cilium/issues/33456#issuecomment-2233697293, setting the routingMode and tunnelProtocol explicitly works around the helm templating issues.

I am aware of #34315 attempting to fix this issue, but I think the approach of using a variable and overwriting it, is not the best for user experience.

As a heavy user of helm, having to look at the helm template itself to know what is happening or where values come from is more frustrating than simply being shown an error.
So I propose a solution to the problem that gives an early error message, without introducing more edge cases to check for with nested if-statements.

Fixes: #33456 
Closes: #34315

```release-note
Adjust verification for tunnel-protocol and routing-mode in helm templates to remove occurrence of duplicate entries in rendered configmap.
Remove constraint on tunnelProtocol for aksbyocni.
```