### PR TITLE
renovate: use proper image repository for config check

### DIFF
--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -18,4 +18,4 @@ jobs:
         run: >
           docker run --rm --entrypoint "renovate-config-validator"
           -v "${{ github.workspace }}/.github/renovate.json5":"/renovate.json5"
-          renovate/renovate:slim "/renovate.json5"
+          ghcr.io/renovatebot/renovate "/renovate.json5"


### PR DESCRIPTION
It seems that renovate migrated from their Docker repositories and it was no longer getting updated, let's use the image from the GHCR repo.

Follows https://github.com/cilium/tetragon/pull/3132