### PR TITLE
Documentation: Fix configuration CNI override example

### DIFF
--- a/Documentation/network/concepts/ipam/eni.rst
+++ b/Documentation/network/concepts/ipam/eni.rst
@@ -114,7 +114,6 @@ to them:
          "name":"cilium",
          "plugins": [
            {
-             "cniVersion":"0.3.1",
              "type":"cilium-cni",
              "eni": {
                "subnet-tags":{


### PR DESCRIPTION
The current example cannot be used and prevent the CNI to be launched. The consequence of this is that all nodes in the cluster go to status `NotReady`.

It looks like the `"cniVersion":"0.3.1",` in the `plugins` array is misplaced.

Fixes #36228

```release-note
Documentation: Fix example of configuration for AWS ENI leading nodes to be `NotReady`
```
