### PR TITLE
cilium-cli/connectivity: allow to specify log levels to check

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -178,6 +178,9 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().StringSliceVar(&params.ExpectedXFRMErrors, "expected-xfrm-errors", defaults.ExpectedXFRMErrors, "List of expected XFRM errors")
 	cmd.Flags().MarkHidden("expected-xfrm-errors")
 
+	cmd.Flags().StringSliceVar(&params.LogCheckLevels, "log-check-levels", defaults.LogCheckLevels, "Log levels to check for in log messages")
+	cmd.Flags().MarkHidden("log-check-levels")
+
 	cmd.Flags().BoolVar(&params.FlushCT, "flush-ct", false, "Flush conntrack of Cilium on each node")
 	cmd.Flags().MarkHidden("flush-ct")
 	cmd.Flags().StringVar(&params.SecondaryNetworkIface, "secondary-network-iface", "", "Secondary network iface name (e.g., to test NodePort BPF on multiple networks)")

--- a/cilium-cli/connectivity/builder/check_log_errors.go
+++ b/cilium-cli/connectivity/builder/check_log_errors.go
@@ -17,5 +17,5 @@ func (t checkLogErrors) build(ct *check.ConnectivityTest, _ map[string]string) {
 			return versioncheck.MustCompile(">=1.14.0")(ct.CiliumVersion) || ct.Params().IncludeUnsafeTests
 		}).
 		WithSysdumpPolicy(check.SysdumpPolicyOnce).
-		WithScenarios(tests.NoErrorsInLogs(ct.CiliumVersion))
+		WithScenarios(tests.NoErrorsInLogs(ct.CiliumVersion, ct.Params().LogCheckLevels))
 }

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -98,6 +98,8 @@ type Parameters struct {
 	ExpectedDropReasons []string
 	ExpectedXFRMErrors  []string
 
+	LogCheckLevels []string
+
 	FlushCT               bool
 	SecondaryNetworkIface string
 

--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -112,6 +112,9 @@ const (
 
 	// Default timeout for Connectivity Test Suite (disabled by default)
 	ConnectivityTestSuiteTimeout = 0 * time.Minute
+
+	LogLevelError   = "error"
+	LogLevelWarning = "warning"
 )
 
 var (
@@ -170,6 +173,11 @@ var (
 		"inbound_forward_header", // XfrmFwdHdrError
 		"inbound_other",          // XfrmInError
 		"inbound_state_invalid",  // XfrmInStateInvalid
+	}
+
+	LogCheckLevels = []string{
+		LogLevelError,
+		LogLevelWarning,
 	}
 
 	// The following variables are set at compile time via LDFLAGS.


### PR DESCRIPTION
Since commit 5417a3fa37bc ("cli/connectivity: Check for unexpected warning logs") we check for unexpected warnings in logs as part of the connectivity checks. This leads to some fallout in cilium/cilium-cli when pulling in that change[^1] for the upcoming cilium-cli v0.16.21 release, mainly due to the fact that Hubble and Hubble UI are enabled in the cilium/cilium-cli workflows.

To work around that and don't block the next release of cilium-cli for too long, allow to specify log levels to check by means of a hidden flag (by default, errors and warnings are both still checked). This allows to skip checking of warnings logs temporarily. In the long term all these warning logs should be addressed by either fixing their root cause, demoting their level or adding them to the ignore list.

[^1]: https://github.com/cilium/cilium-cli/pull/2869

/cc @pchaigno