### PR TITLE
.github/workflows: always install cilium-cli

### DIFF
--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -134,7 +134,6 @@ jobs:
         run: ./test-cyclonus.sh
 
       - name: Install Cilium CLI
-        if: ${{ failure() }}
         uses: cilium/cilium-cli@3286926bbf80fdd0103a372256459e577224f9f6 # v0.16.20
         with:
           skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}


### PR DESCRIPTION
As we need cilium-cli to retrieve the list of features from the agent, we need to always install it regardless if the workflow failed or not. This should fixed the test failures happening on the Cyclonus test suite.