### PR TITLE
k8s: Add support for 1.32.0

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -211,18 +211,36 @@ include:
 exclude:
   # The bandwidth test is disabled and hubble tests are not meant
   # to run on net-next.
-  - k8s-version: "1.31"
+  - k8s-version: "1.32"
     focus: "f10-agent-hubble-bandwidth"
 
   # These tests are meant to run with kube-proxy which is not available
   # with net-next
-  - k8s-version: "1.31"
+  - k8s-version: "1.32"
     focus: "f16-datapath-service-ew-2"
 
   # These tests are meant to run with kube-proxy which is not available
   # with net-next
-  - k8s-version: "1.31"
+  - k8s-version: "1.32"
     focus: "f17-datapath-service-ew-kube-proxy"
+
+  # These tests require an external node which is only available on 1.31
+  # / net-next so there's no point on running them
+  - k8s-version: "1.31"
+    focus: "f05-agent-policy-multi-node-2"
+
+  # These tests require kernel net-next so there's no point on running them
+  - k8s-version: "1.31"
+    focus: "f11-datapath-service-ns-tc"
+
+  - k8s-version: "1.31"
+    focus: "f12-datapath-service-ns-misc"
+
+  - k8s-version: "1.31"
+    focus: "f13-datapath-service-ns-xdp-1"
+
+  - k8s-version: "1.31"
+    focus: "f14-datapath-service-ns-xdp-2"
 
   # These tests require an external node which is only available on 1.30
   # / net-next so there's no point on running them
@@ -233,69 +251,51 @@ exclude:
   - k8s-version: "1.30"
     focus: "f11-datapath-service-ns-tc"
 
-  - k8s-version: "1.30"
+  - k8s-version: "1.28"
     focus: "f12-datapath-service-ns-misc"
 
   - k8s-version: "1.30"
     focus: "f13-datapath-service-ns-xdp-1"
 
   - k8s-version: "1.30"
-    focus: "f14-datapath-service-ns-xdp-2"
-
-  # These tests require an external node which is only available on 1.29
-  # / net-next so there's no point on running them
-  - k8s-version: "1.29"
-    focus: "f05-agent-policy-multi-node-2"
-
-  # These tests require kernel net-next so there's no point on running them
-  - k8s-version: "1.29"
-    focus: "f11-datapath-service-ns-tc"
-
-  - k8s-version: "1.29"
-    focus: "f12-datapath-service-ns-misc"
-
-  - k8s-version: "1.29"
-    focus: "f13-datapath-service-ns-xdp-1"
-
-  - k8s-version: "1.29"
     focus: "f14-datapath-service-ns-xdp-2"
 
   # These tests require are not intended to run on kernel 5.4, thus we can ignore them
-  - k8s-version: "1.28"
+  - k8s-version: "1.29"
     focus: "f01-agent-chaos"
 
-  - k8s-version: "1.28"
+  - k8s-version: "1.29"
     focus: "f03-agent-policy"
 
-  - k8s-version: "1.28"
+  - k8s-version: "1.29"
     focus: "f04-agent-policy-multi-node-1"
 
-  - k8s-version: "1.28"
+  - k8s-version: "1.29"
     focus: "f05-agent-policy-multi-node-2"
 
-  - k8s-version: "1.28"
+  - k8s-version: "1.29"
     focus: "f11-datapath-service-ns-tc"
 
-  - k8s-version: "1.28"
+  - k8s-version: "1.29"
     focus: "f12-datapath-service-ns-misc"
 
-  - k8s-version: "1.28"
+  - k8s-version: "1.29"
     focus: "f13-datapath-service-ns-xdp-1"
 
-  - k8s-version: "1.28"
+  - k8s-version: "1.29"
     focus: "f14-datapath-service-ns-xdp-2"
 
-  - k8s-version: "1.28"
+  - k8s-version: "1.29"
     focus: "f15-datapath-service-ew-1"
 
-  - k8s-version: "1.28"
+  - k8s-version: "1.29"
     focus: "f16-datapath-service-ew-2"
 
-  - k8s-version: "1.28"
+  - k8s-version: "1.29"
     focus: "f17-datapath-service-ew-kube-proxy"
 
-  - k8s-version: "1.28"
+  - k8s-version: "1.29"
     focus: "f18-datapath-lrp"
 
-  - k8s-version: "1.28"
+  - k8s-version: "1.29"
     focus: "f19-kafka"

--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -1,12 +1,19 @@
 # This file contains which kernel versions should be run with which k8s versions
 ---
 include:
+  - k8s-version: "1.32"
+    ip-family: "dual"
+    # renovate: datasource=docker
+    kube-image: "quay.io/cilium/kindest-node:v1.32.0-rc.0@sha256:88bf78209d8eda4fa76e8e4b3fd564ffcd0800742898ed4b0e0a081727a9fd4f"
+    # renovate: datasource=docker depName=quay.io/lvh-images/kind
+    kernel: "bpf-next-20241129.013349@sha256:3fa5e7f7215f75b00188ad2ffa1764ce33d8a946eeccb63fe60ec20503a084c4"
+
   - k8s-version: "1.31"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.31.0@sha256:d2b2a8cd6fa282b9a4126938341a4d2924dfa96f60b1f983d519498c9cde1a99"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "bpf-next-20241129.013349@sha256:3fa5e7f7215f75b00188ad2ffa1764ce33d8a946eeccb63fe60ec20503a084c4"
+    kernel: "rhel8.6-20241107.001101@sha256:019b7f1b600a35f3e788d4f10930268c0f19766ba38fac255bcfe3d943534c2f"
 
   - k8s-version: "1.30"
     ip-family: "dual"
@@ -19,12 +26,5 @@ include:
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.29.10@sha256:3b2d8c31753e6c8069d4fc4517264cd20e86fd36220671fb7d0a5855103aa84b"
-    # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "rhel8.6-20241107.001101@sha256:019b7f1b600a35f3e788d4f10930268c0f19766ba38fac255bcfe3d943534c2f"
-
-  - k8s-version: "1.28"
-    ip-family: "dual"
-    # renovate: datasource=docker
-    kube-image: "kindest/node:v1.28.15@sha256:a7c05c7ae043a0b8c818f5a06188bc2c4098f6cb59ca7d1856df00375d839251"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
     kernel: "5.4-20241107.001101@sha256:5ae09e46bf871787890d65d6b989d84bac6df81133c4d6e3883b428ac9c9de60"

--- a/.github/actions/ginkgo/main-prs.yaml
+++ b/.github/actions/ginkgo/main-prs.yaml
@@ -2,6 +2,7 @@
 # When upgrading k8s version, increment each minor version of each line by one.
 ---
 k8s-version:
+  - "1.32"
   - "1.31"
   - "1.30"
-  - "1.28"
+  - "1.29"

--- a/.github/actions/ginkgo/main-scheduled.yaml
+++ b/.github/actions/ginkgo/main-scheduled.yaml
@@ -1,7 +1,7 @@
 # This file contain which k8s-versions should be executed for on a regular basis
 ---
 k8s-version:
+  - "1.32"
   - "1.31"
   - "1.30"
   - "1.29"
-  - "1.28"

--- a/.github/actions/set-env-variables/action.yml
+++ b/.github/actions/set-env-variables/action.yml
@@ -23,7 +23,7 @@ runs:
         # renovate: datasource=github-releases depName=kubernetes-sigs/kind
         KIND_VERSION="v0.25.0"
         # renovate: datasource=docker
-        KIND_K8S_IMAGE="quay.io/cilium/kindest-node:v1.31.0@sha256:d2b2a8cd6fa282b9a4126938341a4d2924dfa96f60b1f983d519498c9cde1a99"
+        KIND_K8S_IMAGE="quay.io/cilium/kindest-node:v1.32.0-rc.0@sha256:88bf78209d8eda4fa76e8e4b3fd564ffcd0800742898ed4b0e0a081727a9fd4f"
         KIND_K8S_VERSION=$(echo "$KIND_K8S_IMAGE" | sed -r 's|.+:(v[0-9a-z.-]+)(@.+)?|\1|')
 
         echo "KIND_VERSION=$KIND_VERSION" >> $GITHUB_ENV

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -370,7 +370,7 @@ jobs:
             envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster2.yaml
 
       - name: Create Kind cluster 1
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        uses: helm/kind-action@9fdad0686e6f19fcd572f62516f5e0436f562ee7 # v1.10.0
         with:
           cluster_name: ${{ env.clusterName1 }}
           version: ${{ env.KIND_VERSION }}
@@ -380,7 +380,7 @@ jobs:
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Create Kind cluster 2
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        uses: helm/kind-action@9fdad0686e6f19fcd572f62516f5e0436f562ee7 # v1.10.0
         with:
           cluster_name: ${{ env.clusterName2 }}
           version: ${{ env.KIND_VERSION }}

--- a/.github/workflows/conformance-delegated-ipam.yaml
+++ b/.github/workflows/conformance-delegated-ipam.yaml
@@ -255,7 +255,7 @@ jobs:
             install/kubernetes/cilium
 
       - name: Create kind cluster
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        uses: helm/kind-action@9fdad0686e6f19fcd572f62516f5e0436f562ee7 # v1.10.0
         with:
           version: ${{ env.KIND_VERSION }}
           node_image: ${{ env.KIND_K8S_IMAGE }}

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -176,7 +176,7 @@ jobs:
             examples
 
       - name: Create kind cluster
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        uses: helm/kind-action@9fdad0686e6f19fcd572f62516f5e0436f562ee7 # v1.10.0
         with:
           version: ${{ env.KIND_VERSION }}
           node_image: ${{ env.KIND_K8S_IMAGE }}

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -190,7 +190,7 @@ jobs:
             examples
 
       - name: Create kind cluster
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        uses: helm/kind-action@9fdad0686e6f19fcd572f62516f5e0436f562ee7 # v1.10.0
         with:
           version: ${{ env.KIND_VERSION }}
           node_image: ${{ env.KIND_K8S_IMAGE }}

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -86,7 +86,7 @@ jobs:
           until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator-generic-ci:${{ steps.vars.outputs.tag }} &> /dev/null; do sleep 45s; done
 
       - name: Create kind cluster
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        uses: helm/kind-action@9fdad0686e6f19fcd572f62516f5e0436f562ee7 # v1.10.0
         with:
           version: ${{ env.KIND_VERSION }}
           node_image: ${{ env.KIND_K8S_IMAGE }}

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -69,7 +69,7 @@ jobs:
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
 
       - name: Create kind cluster
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        uses: helm/kind-action@9fdad0686e6f19fcd572f62516f5e0436f562ee7 # v1.10.0
         with:
           version: ${{ env.KIND_VERSION }}
           node_image: ${{ env.KIND_K8S_IMAGE }}

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -179,7 +179,7 @@ jobs:
             install/kubernetes/cilium
 
       - name: Create kind cluster
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        uses: helm/kind-action@9fdad0686e6f19fcd572f62516f5e0436f562ee7 # v1.10.0
         with:
           version: ${{ env.KIND_VERSION }}
           node_image: ${{ env.KIND_K8S_IMAGE }}

--- a/.github/workflows/hubble-cli-integration-test.yaml
+++ b/.github/workflows/hubble-cli-integration-test.yaml
@@ -130,7 +130,7 @@ jobs:
 
       # Setup the cluster
       - name: Create kind cluster
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0 -C hubble
+        uses: helm/kind-action@9fdad0686e6f19fcd572f62516f5e0436f562ee7 # v1.10.0 -C hubble
         with:
           version: ${{ env.KIND_VERSION }}
           node_image: ${{ env.KIND_K8S_IMAGE }}

--- a/.github/workflows/tests-ces-migrate.yaml
+++ b/.github/workflows/tests-ces-migrate.yaml
@@ -121,7 +121,7 @@ jobs:
           echo sha=${SHA} >> $GITHUB_OUTPUT
 
       - name: Create kind cluster
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        uses: helm/kind-action@9fdad0686e6f19fcd572f62516f5e0436f562ee7 # v1.10.0
         with:
           version: ${{ env.KIND_VERSION }}
           node_image: ${{ env.KIND_K8S_IMAGE }}

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -235,7 +235,7 @@ jobs:
             envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster2.yaml
 
       - name: Create Kind cluster 1
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        uses: helm/kind-action@9fdad0686e6f19fcd572f62516f5e0436f562ee7 # v1.10.0
         with:
           cluster_name: ${{ env.clusterName1 }}
           version: ${{ env.KIND_VERSION }}
@@ -245,7 +245,7 @@ jobs:
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Create Kind cluster 2
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        uses: helm/kind-action@9fdad0686e6f19fcd572f62516f5e0436f562ee7 # v1.10.0
         with:
           cluster_name: ${{ env.clusterName2 }}
           version: ${{ env.KIND_VERSION }}

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -93,7 +93,7 @@ jobs:
           sudo systemctl restart docker
 
       - name: Create kind cluster
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        uses: helm/kind-action@9fdad0686e6f19fcd572f62516f5e0436f562ee7 # v1.10.0
         with:
           version: ${{ env.KIND_VERSION }}
           node_image: ${{ env.KIND_K8S_IMAGE }}

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -110,7 +110,7 @@ jobs:
           test -z "$(git status --porcelain)" || (echo "please run 'make -C examples/kubernetes/connectivity-check fmt all' and submit your changes"; exit 1)
 
       - name: Create kind cluster
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        uses: helm/kind-action@9fdad0686e6f19fcd572f62516f5e0436f562ee7 # v1.10.0
         with:
           version: ${{ env.KIND_VERSION }}
           node_image: ${{ env.KIND_K8S_IMAGE }}

--- a/Documentation/network/kubernetes/compatibility.rst
+++ b/Documentation/network/kubernetes/compatibility.rst
@@ -21,7 +21,7 @@ on the forward / backward compatibility offered by Kubernetes.
 | k8s Version            | k8s NetworkPolicy API     | CiliumNetworkPolicy              |
 +------------------------+---------------------------+----------------------------------+
 |                        |                           | ``cilium.io/v2`` has a           |
-| 1.28, 1.29, 1.30, 1.31 | * `networking.k8s.io/v1`_ | :term:`CustomResourceDefinition` |
+| 1.29, 1.30, 1.31, 1.32 | * `networking.k8s.io/v1`_ | :term:`CustomResourceDefinition` |
 +------------------------+---------------------------+----------------------------------+
 
 As a general rule, Cilium aims to run e2e tests using the latest build from the

--- a/Documentation/network/kubernetes/requirements.rst
+++ b/Documentation/network/kubernetes/requirements.rst
@@ -18,10 +18,10 @@ with this Cilium version. Older Kubernetes versions not listed here do not have
 Cilium support. Newer Kubernetes versions, while not listed, will depend on the
 backward compatibility offered by Kubernetes.
 
-* 1.28
 * 1.29
 * 1.30
 * 1.31
+* 1.32
 
 Additionally, Cilium runs e2e tests against various cloud providers' managed
 Kubernetes offerings using multiple Kubernetes versions. See the following links

--- a/contrib/scripts/devcontainer-setup.sh
+++ b/contrib/scripts/devcontainer-setup.sh
@@ -6,8 +6,8 @@ set -e
 
 ### User Setting
 
-KUBERNETES_VERSION=v1.31
-KIND_VERSION=v0.19.0
+KUBERNETES_VERSION=v1.32
+KIND_VERSION=v0.25.0
 CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt)
 CLI_ARCH=amd64
 if [ "$(uname -m)" = "aarch64" ]; then CLI_ARCH=arm64; fi

--- a/pkg/k8s/slim/README.md
+++ b/pkg/k8s/slim/README.md
@@ -17,7 +17,7 @@ generated diff is what needs to be committed; all other changes are
 unnecessary.
 
 ```bash
-tag=v1.31.0
+tag=v1.32.0
 url="https://raw.githubusercontent.com/kubernetes/kubernetes/${tag}"
 
 curl "${url}/staging/src/k8s.io/api/core/v1/doc.go" > pkg/k8s/slim/k8s/api/core/v1/doc.go

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4798,7 +4798,7 @@ func (kub *Kubectl) ensureKubectlVersion() error {
 		rcVersion = fmt.Sprintf("v%s.0", GetCurrentK8SEnv())
 	}
 	res = kub.Exec(
-		fmt.Sprintf("curl --output %s https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/amd64/kubectl && chmod +x %s",
+		fmt.Sprintf("curl -sSLo %s https://dl.k8s.io/release/%s/bin/linux/amd64/kubectl && chmod +x %s",
 			path, rcVersion, path))
 	if !res.WasSuccessful() {
 		return fmt.Errorf("failed to download kubectl")

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -447,7 +447,7 @@ func getK8sSupportedConstraints(ciliumVersion string) (semver.Range, error) {
 	}
 	switch {
 	case IsCiliumV1_17(cst):
-		return versioncheck.MustCompile(">=1.16.0 <1.32.0"), nil
+		return versioncheck.MustCompile(">=1.16.0 <1.33.0"), nil
 	case IsCiliumV1_16(cst):
 		return versioncheck.MustCompile(">=1.16.0 <1.31.0"), nil
 	case IsCiliumV1_15(cst):

--- a/test/provision/helpers.bash
+++ b/test/provision/helpers.bash
@@ -60,7 +60,7 @@ function install_k8s_using_binary {
     	curl -sSL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins${OS}-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
     fi
 
-    wget -q https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubectl,kubeadm,kubelet}
+    wget -q https://dl.k8s.io/release/${RELEASE}/bin/linux/amd64/{kubectl,kubeadm,kubelet}
     chmod 777 ku*
     cp -fv ku* /usr/bin/
     rm -rf /etc/systemd/system/kubelet.service || true

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -34,7 +34,7 @@ import (
 var (
 	log             = logging.DefaultLogger
 	DefaultSettings = map[string]string{
-		"K8S_VERSION": "1.31",
+		"K8S_VERSION": "1.32",
 	}
 	k8sNodesEnv         = "K8S_NODES"
 	commandsLogFileName = "cmds.log"


### PR DESCRIPTION
Most of the dependencies are updated as part of the below PR. This PR is to cover the rest to support k8s 1.32.

Relates: https://github.com/cilium/cilium/pull/35406

