### PR TITLE
gha: merge artifacts in net-perf-gke workflow

### DIFF
--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -279,7 +279,7 @@ jobs:
         uses: ./.github/actions/feature-status
         with:
           title: "Summary of all features tested"
-          json-filename: "${{ env.job_name }}"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }})"
 
       - name: Get sysdump
         if: ${{ always() && steps.run-perf.outcome != 'skipped' && steps.run-perf.outcome != 'cancelled' }}
@@ -292,7 +292,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: features-tested
+          name: features-tested-${{ matrix.name }}
           path: ${{ env.job_name }}*.json
 
       - name: Clean up GKE
@@ -312,6 +312,25 @@ jobs:
           results_bucket: ${{ env.GCP_PERF_RESULTS_BUCKET }}
           artifacts: ./output/*
           other_files: cilium-sysdump-final.zip
+
+  merge-upload:
+    if: ${{ always() }}
+    name: Merge and Upload Artifacts
+    runs-on: ubuntu-latest
+    needs: installation-and-perf
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Merge Features tested
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: features-tested
+          pattern: features-tested-*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   commit-status-final:
     if: ${{ always() }}


### PR DESCRIPTION
The net-perf-gke workflow is currently broken because multiple matrix entries attempt to upload the same artifact. Let's fix this by using a different name for each of them, and adding a step which takes care of merging the artifacts at the end.

Fixes: a23106d28619 (".github/workflows: report which features are being used in CI")