### PR TITLE
gha: test disabled kvstoremesh clustermesh upgrade/downgrade tests

### DIFF
--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -493,7 +493,6 @@ jobs:
         run: |
           NAMESPACE=$(kubectl get namespace -l "app.kubernetes.io/name=cilium-cli" -o name | sort | cut -d / -f 2 | head -1)
           echo namespace="$NAMESPACE" >> $GITHUB_OUTPUT
-          ${{ steps.cilium-cli.outputs.namespace }}
 
       - name: Write the Service manifest for testing failover
         if: ${{ !matrix.external-kvstore }}

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -542,7 +542,7 @@ jobs:
           kubectl --context ${{ env.contextName1 }} delete -f echo-failover.yaml
           kubectl --context ${{ env.contextName2 }} delete -f echo-failover.yaml
 
-      - name: Enable kvstoremesh on cluster1
+      - name: Disable kvstoremesh on cluster1
         if: ${{ !matrix.external-kvstore }}
         env:
           KVSTORE_ID: 1
@@ -551,7 +551,7 @@ jobs:
             ${{ steps.newest-vars.outputs.cilium_install_defaults }} \
             ${{ steps.vars.outputs.cilium_install_defaults }} \
             ${{ steps.clustermesh-vars.outputs.cilium_install_cluster1 }} \
-            --set clustermesh.apiserver.kvstoremesh.enabled=true
+            --set clustermesh.apiserver.kvstoremesh.enabled=false
 
       - name: Wait for cluster mesh status to be ready
         if: ${{ !matrix.external-kvstore }}
@@ -702,7 +702,7 @@ jobs:
           json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - cluster 2 - stress-test"
 
 
-      - name: Downgrade Cilium in cluster1 and disable kvstoremesh
+      - name: Downgrade Cilium in cluster1 and enable kvstoremesh again
         env:
           KVSTORE_ID: 1
         run: |


### PR DESCRIPTION
KVStoreMesh is enabled by default since https://github.com/cilium/cilium/commit/511f077a6d5514e7697d1ea3add5a7451dc01fdb ("clustermesh:
enable  kvstoremesh by default"), part of v1.16. However, we forgot
to subsequently update the clustermesh upgrade/downgrade tests to
keep testing both kvstoremesh enabled and disabled once v1.16 got
officially released. Let's fix that now.
