### PR TITLE
operator: always use controller-runtime metric registry as base

### DIFF
--- a/operator/api/metrics_test.go
+++ b/operator/api/metrics_test.go
@@ -39,8 +39,7 @@ func TestMetricsHandlerWithoutMetrics(t *testing.T) {
 		operatorMetrics.Cell,
 		cell.Provide(func() operatorMetrics.SharedConfig {
 			return operatorMetrics.SharedConfig{
-				EnableMetrics:    false,
-				EnableGatewayAPI: false,
+				EnableMetrics: false,
 			}
 		}),
 
@@ -103,8 +102,7 @@ func TestMetricsHandlerWithMetrics(t *testing.T) {
 		operatorMetrics.Cell,
 		cell.Provide(func() operatorMetrics.SharedConfig {
 			return operatorMetrics.SharedConfig{
-				EnableMetrics:    true,
-				EnableGatewayAPI: false,
+				EnableMetrics: true,
 			}
 		}),
 		cellMetric.Metric(newTestMetrics),

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -15,9 +15,6 @@ import (
 	"time"
 
 	"github.com/cilium/hive/cell"
-
-	"github.com/cilium/cilium/operator/doublewrite"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -31,6 +28,7 @@ import (
 	ciliumdbg "github.com/cilium/cilium/cilium-dbg/cmd"
 	"github.com/cilium/cilium/operator/api"
 	"github.com/cilium/cilium/operator/auth"
+	"github.com/cilium/cilium/operator/doublewrite"
 	"github.com/cilium/cilium/operator/endpointgc"
 	"github.com/cilium/cilium/operator/identitygc"
 	operatorK8s "github.com/cilium/cilium/operator/k8s"
@@ -128,8 +126,7 @@ var (
 				// to add their metrics when it's set to true. Therefore, we leave the flag as global
 				// instead of declaring it as part of the metrics cell.
 				// This should be changed once the IPAM allocator is modularized.
-				EnableMetrics:    operatorCfg.EnableMetrics,
-				EnableGatewayAPI: operatorCfg.EnableGatewayAPI,
+				EnableMetrics: operatorCfg.EnableMetrics,
 			}
 		}),
 	)

--- a/operator/metrics/cell.go
+++ b/operator/metrics/cell.go
@@ -40,13 +40,7 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 
 // SharedConfig contains the configuration that is shared between
 // this module and others.
-// Metrics cell needs to know if GatewayAPI is enabled in order to use
-// the same Registry as controller-runtime and avoid to expose
-// multiple metrics endpoints or servers.
 type SharedConfig struct {
 	// EnableMetrics is set to true if operator metrics are enabled
 	EnableMetrics bool
-
-	// EnableGatewayAPI enables support of Gateway API
-	EnableGatewayAPI bool
 }


### PR DESCRIPTION
Currently, the Cilium Operator only uses the metrics registry of the `controller-runtime` as base registry if Gateway API functionality is enabled. This has historic reasons as Gateway API functionality was the first module that used `controller-runtime` for its controllers.

In the meantime, other modules (Ingress Controller, Secret Sync, ...) are using the `controller-runtime` too - but the metrics registry of the library is still only used if Gateway API is enabled. In these cases, the metrics of the `controller-runtime` library (https://book.kubebuilder.io/reference/metrics-reference) aren't exposed.

Therefore, this commit changes the behaviour, that the metrics registry of the `controller-runtime` library is always used as the base registry.

Note: Unfortunately, the `controller-runtime` library configures the base registry to have Go runtime metrics included by default (https://github.com/cilium/cilium/blob/main/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/metrics/metrics.go#L91-L92). Therefore, this Go metrics collector has to be removed from the metrics registry before registering a new Go metrics collector with custom Go runtime metrics enabled. Otherwise the registration fails because some Go runtime metrics are registered twice.

Related PRs:
- #28931 (extract `controller-runtime` integration into its own Hive Cell)
- #29245 (export go runtime sched latency metrics) cc @derailed 
