### PR TITLE
Documentation typo: endponit -> endpoint

### DIFF
--- a/Documentation/configuration/api-rate-limiting.rst
+++ b/Documentation/configuration/api-rate-limiting.rst
@@ -54,7 +54,7 @@ API Call                   Config Name
 ``PUT /endpoint/{id}``     ``endpoint-create``
 ``DELETE /endpoint/{id}``  ``endpoint-delete``
 ``GET /endpoint/{id}/*``   ``endpoint-get``
-``PATCH /endpoint/{id}*``  ``endponit-patch``
+``PATCH /endpoint/{id}*``  ``endpoint-patch``
 ``GET /endpoint``          ``endpoint-list``
 ========================== ====================
 


### PR DESCRIPTION
**Extraordinarily trivial issue** noticed reviewing rate limit documentation. 

No impact out of documentation and trivial review shows this typo was unintented.

```release-note
docs: Fix a typo in API rate-limiting documentation
```