### PR TITLE
fqdn: fix zombie over-limit reaping

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -744,8 +744,8 @@ func (c *DNSCache) UnmarshalJSON(raw []byte) error {
 // Special handling exists when the count of zombies is large. Overlimit
 // zombies are deleted in GC with the following preferences (this is cumulative
 // and in order of precedence):
-//   - Zombies with zero AliveAt are evicted before those with a non-zero value
-//     (i.e. known connections marked by CT GC are evicted last)
+//   - Zombies with an earlier AliveAt are evicted before those with a later value
+//     (i.e. connections no longer marked as alive by CT GC are evicted first).
 //   - Zombies with an earlier DeletePendingAtTime are evicted first.
 //     Note: Upsert sets DeletePendingAt on every update, thus making GC prefer
 //     to evict IPs with less DNS churn on them.
@@ -760,7 +760,11 @@ type DNSZombieMapping struct {
 	IP netip.Addr `json:"ip,omitempty"`
 
 	// AliveAt is the last time this IP was marked alive via
-	// DNSZombieMappings.MarkAlive.
+	// DNSZombieMappings.MarkAlive. At zombie creation time we assume a zombie
+	// to be alive and initialize the field to the `lastCTGCUpdate` time. This
+	// avoids comparing a zero-valued time.Time as "earlier" than any other
+	// AliveAt values.
+	//
 	// When AliveAt is later than DNSZombieMappings.lastCTGCUpdate the zombie is
 	// considered alive.
 	AliveAt time.Time `json:"alive-at,omitempty"`
@@ -817,9 +821,10 @@ func NewDNSZombieMappings(max, perHostLimit int) *DNSZombieMappings {
 	}
 }
 
-// Upsert enqueues the ip -> qname as a possible deletion
-// updatedExisting is true when an earlier enqueue existed and was updated
-// If an existing entry is updated, the later expiryTime is applied to the existing entry.
+// Upsert enqueues the ip -> qname as a possible deletion. updatedExisting is
+// true when an earlier enqueue existed and was updated. If an entry already
+// exists and the expiry time is later, it is updated. The same also applies for
+// the AliveAt time.
 func (zombies *DNSZombieMappings) Upsert(expiryTime time.Time, addr netip.Addr, qname ...string) (updatedExisting bool) {
 	zombies.Lock()
 	defer zombies.Unlock()
@@ -829,6 +834,7 @@ func (zombies *DNSZombieMappings) Upsert(expiryTime time.Time, addr netip.Addr, 
 		zombie = &DNSZombieMapping{
 			Names:           ciliumslices.Unique(qname),
 			IP:              addr,
+			AliveAt:         zombies.lastCTGCUpdate,
 			DeletePendingAt: expiryTime,
 			revisionAddedAt: zombies.ctGCRevision,
 		}
@@ -838,6 +844,10 @@ func (zombies *DNSZombieMappings) Upsert(expiryTime time.Time, addr netip.Addr, 
 		// Keep the latest expiry time
 		if expiryTime.After(zombie.DeletePendingAt) {
 			zombie.DeletePendingAt = expiryTime
+		}
+		// and bump the aliveAt.
+		if zombies.lastCTGCUpdate.After(zombie.AliveAt) {
+			zombie.AliveAt = zombies.lastCTGCUpdate
 		}
 	}
 	return updatedExisting
@@ -1008,7 +1018,7 @@ func (zombies *DNSZombieMappings) GC() (alive, dead []*DNSZombieMapping) {
 			for _, z := range aliveIPsForName[overLimit:] {
 				possibleAlive[z] = struct{}{}
 			}
-			if dead[len(dead)-1].AliveAt.IsZero() {
+			if dead[len(dead)-1].AliveAt.After(zombies.lastCTGCUpdate) {
 				warnActiveDNSEntries = true
 			}
 		}
@@ -1034,7 +1044,7 @@ func (zombies *DNSZombieMappings) GC() (alive, dead []*DNSZombieMapping) {
 		sortZombieMappingSlice(alive)
 		dead = append(dead, alive[:overLimit]...)
 		alive = alive[overLimit:]
-		if dead[len(dead)-1].AliveAt.IsZero() {
+		if dead[len(dead)-1].AliveAt.After(zombies.lastCTGCUpdate) {
 			log.Warning("Evicting expired DNS cache entries that may be in-use. This may cause recently created connections to be disconnected. Raise --tofqdns-max-deferred-connection-deletes to mitigate this.")
 		}
 	}
@@ -1223,9 +1233,8 @@ func (zombies *DNSZombieMappings) UnmarshalJSON(raw []byte) error {
 	}
 	zombies.deletes = aux.Deletes
 
-	// Reset the alive time & conntrack revision to ensure no deletes happen until we run CT GC again
+	// Reset the conntrack revision to ensure no deletes happen until we run CT GC again
 	for _, zombie := range zombies.deletes {
-		zombie.AliveAt = time.Time{}
 		zombie.revisionAddedAt = zombies.ctGCRevision
 	}
 	return nil

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -1143,6 +1143,113 @@ func TestOverlimitPreferNewerEntries(t *testing.T) {
 	})
 }
 
+// This test tests the over limit behaviour of DNS Mapping zombies for repeated
+// lookups to the same domain (e.g. an S3 bucket). It tries to mimick the "fun"
+// interactions between the CT GC, FQDN GC and per-host IP limits. It covers a
+// case which, prior to the commit introducing this test, zombies were reaped
+// erroneously, since their "AliveAt" field was zero (and they thus sorted to
+// the front).
+func TestPerHostLimitBehaviourForS3(t *testing.T) {
+	someDomain := "s3.example.com"
+	maxIPs := 5
+	dnsTTL := 4 // seconds
+
+	tc := NewDNSCacheWithLimit(0, maxIPs)
+	z := NewDNSZombieMappings(10000, maxIPs)
+
+	// These are simulated lookup results for someDomain.
+	reallyOldLookup := []netip.Addr{
+		netip.MustParseAddr("1.0.0.1"),
+	}
+	recentLookup := []netip.Addr{
+		netip.MustParseAddr("1.1.0.1"),
+		netip.MustParseAddr("1.1.0.2"),
+		netip.MustParseAddr("1.1.0.3"),
+		netip.MustParseAddr("1.1.0.4"),
+		netip.MustParseAddr("1.1.0.5"),
+	}
+	keepaliveLookup := netip.MustParseAddr("1.2.0.1")
+
+	simulateFQDNGC := func(when time.Time) sets.Set[string] {
+		t.Helper()
+		names := tc.GC(when, z)
+		z.GC()
+		return names
+	}
+
+	simulateCTGC := func(when time.Time, alive []netip.Addr) {
+		t.Helper()
+		for _, ip := range alive {
+			z.MarkAlive(when, ip)
+		}
+		z.SetCTGCTime(when, when.Add(10*time.Second))
+	}
+
+	// Simulates a lookup and runs all GCs
+	tick := func(tock time.Time) {
+		t.Helper()
+		tc.Update(tock, someDomain, []netip.Addr{keepaliveLookup}, dnsTTL)
+		// Must be past TTL
+		simulateFQDNGC(tock.Add((2*time.Duration(dnsTTL)*time.Second + 1)))
+		simulateCTGC(tock.Add(2*time.Duration(dnsTTL)*time.Second+2), nil)
+	}
+
+	now := time.Now()
+	aLongTimeAgo := now.Add(-10 * time.Hour)
+	sevenSecondsAgo := now.Add(-7 * time.Second) // TTL expired by "now"
+
+	// A long time ago, we looked up example.com
+	tc.Update(aLongTimeAgo, someDomain, reallyOldLookup, dnsTTL)
+	// At some point past the lookup's TTL, a FQDN GC happens. The lookup now
+	// moves to the DNSMappingZombies. It's not yet dead, since the zombie
+	// tracking doesn't know whether its dead or alive (since CT GC hasn't run).
+	simulateFQDNGC(aLongTimeAgo.Add(8 * time.Second))
+	// Turns out it was a long-standing connection and hence CT GC marked it
+	// alive. The entry is still a zombie, but a live one.
+	simulateCTGC(aLongTimeAgo.Add(10*time.Second), reallyOldLookup)
+	if _, found := z.deletes[reallyOldLookup[0]]; !found {
+		t.Errorf("expected really old lookup to still be present")
+	}
+
+	// During these "ticks", we simulate lookups to someDomain. We call these
+	// keep-alive lookups because they keep the really old lookup alive. Any
+	// alive IP for a name keeps that name alive, and any name keeps
+	// corresponding zombies alive. Cilium wants to keep these alive to not
+	// break applications which resolve someDomain once, early, and then assume
+	// the resolved IPs to be alive for longer than TTL.
+	tick(aLongTimeAgo.Add(20 * time.Second))
+	tick(aLongTimeAgo.Add(30 * time.Second))
+	tick(aLongTimeAgo.Add(40 * time.Second))
+	tick(aLongTimeAgo.Add(50 * time.Second))
+	if _, found := z.deletes[reallyOldLookup[0]]; !found {
+		t.Errorf("expected really old lookup to still be present")
+	}
+
+	// Seven seconds ago, we looked example.com up again. To test the over-limit
+	// behaviour, this lookup gets multiple IPs back.
+	tc.Update(sevenSecondsAgo, someDomain, recentLookup, dnsTTL)
+	// FQDN GC should collect all but the newest five IPs due to the perHost limit.
+	affectedNames := simulateFQDNGC(now)
+	if len(affectedNames) != 1 || !affectedNames.Has(someDomain) {
+		t.Errorf("expected affected name to contain only %s but it is %+v", someDomain, affectedNames)
+	}
+
+	// Assert that the zombies respect the limit.
+	if len(z.deletes) != maxIPs {
+		t.Errorf("expected zombies to contain %v entries, but has %v", maxIPs, len(z.deletes))
+	}
+	// Assert that the old lookup was thrown out.
+	if _, found := z.deletes[reallyOldLookup[0]]; found {
+		t.Errorf("expected really old lookup not to be present")
+	}
+	// Asser that the new lookups are present.
+	for _, ip := range recentLookup {
+		if _, found := z.deletes[ip]; !found {
+			t.Errorf("expected recent lookup %v to be present", ip)
+		}
+	}
+}
+
 // Define a test-only string representation to make the output below more readable.
 func (z *DNSZombieMapping) String() string {
 	return fmt.Sprintf(


### PR DESCRIPTION
The purpose of DNS zombie tracking is to avoid deleting mappings which are still in use by long-running connections. To do so, it employs the help of the conntrack (CT) subsystem, to tell it which IPs are still the target of existing connections. CT does this periodically, updating the zombie's `AliveAt` field. The period of CT GC is variable at runtime, but can easily be on the order of minutes or hours, since it is relatively expensive.

As a circuit-breaker, the DNSZombieMapping is configured to limit the number of IPs per single FQDN. When this limit is exceeded, some zombies must be deleted. A heuristic is in place to choose the victim zombies: delete those which have not been marked alive the longest.

The bug we fix here is that the `AliveAt` field was not initialized when a mapping became a zombie. Since the zero value of `time.Time` sorts before any real moment in time, these new zombies were considered "older" than any other which had the field set by CT GC. New zombies hence had a chance of being killed as part of FQDN GC when enough zombies existed for a specific FQDN.

To make a concrete example: many applications use S3, and allow this traffic via toFQDN policy. S3 DNS records have a TTL of five seconds and contain 8 IPs. The IPs are selected from a very large set and hence the number of IPs quickly exceeds the per-fqdn IP limit. Each of those IPs first becomes an entry in the Endpoint DNS cache and, once past TTL, migrates to become a DNSZombie (with a zero valued `AliveAt` field).

Now, for a few (un)lucky zombies, CT GC will mark them alive (i.e. set `AliveAt`) before FQDN GC runs. Since we are a) over the limit of IPs per hostname, and b) a steady stream of zombies come in, the incoming zombies were considered "older" than the ones marked by CT GC. Therefore, when zombies were selected to be removed, cilium chose the newly added zombies, even though older ones would have been available.

A complicating factor we've so far glossed over is that this only occurs if the FQDN is being kept alive. That is, as long as there's _any_ IP that's alive which is pointed to by the FQDN, that FQDN is kept alive, as are all _other_ IPs pointed to by that name. (See the added test for an example.)

Another complicating factor is that this bug was previously masked by other issues, such as https://github.com/cilium/cilium/pull/31205 and https://github.com/cilium/cilium/pull/27572. With these fixes being in the tree, this issue became more prevalent - a beautiful example of how making things better can actually make it worse :sweat_smile: 

Related: #28427

```release-note
Cilium no longer keeps old DNS-IP mappings alive while reaping newer ones, leading to spurious drops in connections to domains with many IPs associated.
```
