### PR TITLE
Use batched iterator for CTMap GC

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -906,6 +906,14 @@ func startingChunkSize(maxEntries int) int {
 //
 // If the iteration fails, then the Err() function will return the error that caused the failure.
 func (bi *BatchIterator[KT, VT, KP, VP]) IterateAll(ctx context.Context, opts ...BatchIteratorOpt[KT, VT, KP, VP]) iter.Seq2[KP, VP] {
+	switch bi.m.Type() {
+	case ebpf.Hash, ebpf.LRUHash:
+		break
+	default:
+		bi.err = fmt.Errorf("unsupported map type %s, must be one either hash or lru-hash types", bi.m.Type())
+		return nil
+	}
+
 	bi.chunkSize = startingChunkSize(int(bi.m.MaxEntries()))
 
 	for _, opt := range opts {

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -908,7 +908,7 @@ func TestErrorResolver(t *testing.T) {
 			require.NoError(t, m.CreateUnpinned(), "Failed to create map")
 			require.NoError(t, m.Update(&key1, &val1), "Failed to insert element in map")
 
-			// Let's attempt to insert a second element in the map, which will fail because the map can only hoVld one
+			// Let's attempt to insert a second element in the map, which will fail because the map can only hold one.
 			require.Error(t, m.Update(&key2, &val2), "Map insertion should have failed")
 
 			// Let's now remove one of the two elements (the actual assertion depends on which element is to be removed)
@@ -940,16 +940,26 @@ func TestErrorResolver(t *testing.T) {
 	}
 }
 
+func TestBatchIteratorTypes(t *testing.T) {
+	m := NewMap("cilium_test",
+		ebpf.Array,
+		&TestKey{},
+		&TestValue{}, 1, 0)
+	iter := NewBatchIterator[TestKey, TestValue](m)
+	iter.IterateAll(context.TODO())
+	assert.Error(t, iter.Err())
+}
+
 func TestBatchIterator(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
-	runTest := func(size, mapSize int, t *testing.T, opts ...BatchIteratorOpt[TestKey, TestValue, *TestKey, *TestValue]) {
+	runTest := func(mapType ebpf.MapType, size, mapSize int, t *testing.T, opts ...BatchIteratorOpt[TestKey, TestValue, *TestKey, *TestValue]) {
 		m := NewMap("cilium_test",
-			ebpf.Hash,
+			mapType,
 			&TestKey{},
 			&TestValue{},
 			mapSize,
-			BPF_F_NO_PREALLOC,
+			0,
 		)
 		assert.NoError(t, m.OpenOrCreate())
 		defer assert.NoError(t, m.UnpinIfExists())
@@ -969,11 +979,12 @@ func TestBatchIterator(t *testing.T) {
 			ks.Insert(int(k.Key))
 			vs.Insert(int(v.Value))
 		}
-		assert.NoError(t, iter.Err())
+		require.NoError(t, iter.Err())
+		assert.Equal(t, size, count)
 
 		for i := range int(size) {
-			assert.Contains(t, ks, i)
-			assert.Contains(t, vs, i)
+			require.Contains(t, ks, i, "expect iterate to return key="+strconv.Itoa(i))
+			require.Contains(t, vs, i, "expect iterate to return val="+strconv.Itoa(i))
 		}
 		assert.Len(t, ks, int(size))
 		assert.Len(t, vs, int(size))
@@ -1011,7 +1022,10 @@ func TestBatchIterator(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("size=%d mapSize=%d", test.size, test.mapSize), func(t *testing.T) {
-			runTest(test.size, test.mapSize, t, test.opts...)
+			runTest(ebpf.Hash, test.size, test.mapSize, t, test.opts...)
+		})
+		t.Run(fmt.Sprintf("size=%d mapSize=%d", test.size, test.mapSize), func(t *testing.T) {
+			runTest(ebpf.LRUHash, test.size, test.mapSize, t, test.opts...)
 		})
 	}
 }

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -908,7 +908,7 @@ func TestErrorResolver(t *testing.T) {
 			require.NoError(t, m.CreateUnpinned(), "Failed to create map")
 			require.NoError(t, m.Update(&key1, &val1), "Failed to insert element in map")
 
-			// Let's attempt to insert a second element in the map, which will fail because the map can only hold one
+			// Let's attempt to insert a second element in the map, which will fail because the map can only hoVld one
 			require.Error(t, m.Update(&key2, &val2), "Map insertion should have failed")
 
 			// Let's now remove one of the two elements (the actual assertion depends on which element is to be removed)
@@ -943,7 +943,7 @@ func TestErrorResolver(t *testing.T) {
 func TestBatchIterator(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
-	runTest := func(size, mapSize int, t *testing.T, opts ...BatchIteratorOpt[TestKey, TestValue]) {
+	runTest := func(size, mapSize int, t *testing.T, opts ...BatchIteratorOpt[TestKey, TestValue, *TestKey, *TestValue]) {
 		m := NewMap("cilium_test",
 			ebpf.Hash,
 			&TestKey{},
@@ -962,9 +962,7 @@ func TestBatchIterator(t *testing.T) {
 		ks := sets.New[int]()
 		vs := sets.New[int]()
 
-		iter := BatchIterator[TestKey, TestValue]{
-			m: m,
-		}
+		iter := NewBatchIterator[TestKey, TestValue](m)
 		count := 0
 		for k, v := range iter.IterateAll(context.TODO(), opts...) {
 			count++
@@ -985,7 +983,7 @@ func TestBatchIterator(t *testing.T) {
 	for _, test := range []struct {
 		mapSize int
 		size    int
-		opts    []BatchIteratorOpt[TestKey, TestValue]
+		opts    []BatchIteratorOpt[TestKey, TestValue, *TestKey, *TestValue]
 	}{
 		{10, 10, nil},
 		{1024, 1024, nil},
@@ -994,7 +992,7 @@ func TestBatchIterator(t *testing.T) {
 		{
 			size:    1 << 12,
 			mapSize: 1 << 13,
-			opts: []BatchIteratorOpt[TestKey, TestValue]{
+			opts: []BatchIteratorOpt[TestKey, TestValue, *TestKey, *TestValue]{
 				WithMaxRetries[TestKey, TestValue](13), WithStartingChunkSize[TestKey, TestValue](1)},
 		},
 		{
@@ -1008,7 +1006,7 @@ func TestBatchIterator(t *testing.T) {
 		{
 			size:    1 << 12,
 			mapSize: 1 << 12,
-			opts: []BatchIteratorOpt[TestKey, TestValue]{
+			opts: []BatchIteratorOpt[TestKey, TestValue, *TestKey, *TestValue]{
 				WithMaxRetries[TestKey, TestValue](1), WithStartingChunkSize[TestKey, TestValue](1 << 13)},
 		},
 	} {

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -47,7 +47,7 @@ func BenchmarkMapBatchLookup(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		count, err := m.Count()
+		count, err := m.Count(context.TODO())
 		assert.NoError(b, err)
 		assert.Greater(b, count, option.CTMapEntriesGlobalAnyDefault)
 	}
@@ -761,7 +761,7 @@ func TestCount(t *testing.T) {
 	cache := populateFakeDataCTMap4(t, m, size)
 	initial := len(cache)
 
-	batchCount, err := m.Count()
+	batchCount, err := m.Count(context.TODO())
 	assert.Equal(t, initial, batchCount)
 	assert.NoError(t, err)
 
@@ -772,7 +772,7 @@ func TestCount(t *testing.T) {
 		}
 		delete(cache, k)
 
-		batchCount, err := m.Count()
+		batchCount, err := m.Count(context.TODO())
 		assert.Equal(t, len(cache), batchCount)
 		assert.NoError(t, err)
 
@@ -782,7 +782,7 @@ func TestCount(t *testing.T) {
 		}
 	}
 
-	batchCount, err = m.Count()
+	batchCount, err = m.Count(context.TODO())
 	assert.Equal(t, len(cache), batchCount)
 	assert.NoError(t, err)
 

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -222,7 +222,7 @@ func TestCtGcIcmp(t *testing.T) {
 	}
 	mcast, next, complete := stream.Multicast[GCEvent]()
 	mcast.Observe(context.Background(), NatMapNext4, func(err error) {})
-	stats := doGC4(ctMap, filter, next)
+	stats := doGCForFamily(ctMap, filter, next, nil, false)
 	complete(nil)
 	require.Equal(t, uint32(0), stats.aliveEntries)
 	require.Equal(t, uint32(1), stats.deleted)
@@ -336,7 +336,7 @@ func TestCtGcTcp(t *testing.T) {
 	}
 	mcast, next, complete := stream.Multicast[GCEvent]()
 	mcast.Observe(context.Background(), NatMapNext4, func(err error) {})
-	stats := doGC4(ctMap, filter, next)
+	stats := doGCForFamily(ctMap, filter, next, nil, false)
 	complete(nil)
 	require.Equal(t, uint32(0), stats.aliveEntries)
 	require.Equal(t, uint32(1), stats.deleted)
@@ -430,7 +430,7 @@ func TestCtGcDsr(t *testing.T) {
 	}
 	mcast, next, complete := stream.Multicast[GCEvent]()
 	mcast.Observe(context.Background(), NatMapNext4, func(err error) {})
-	stats := doGC4(ctMap, filter, next)
+	stats := doGCForFamily(ctMap, filter, next, nil, false)
 	complete(nil)
 	require.Equal(t, uint32(0), stats.aliveEntries)
 	require.Equal(t, uint32(1), stats.deleted)

--- a/pkg/maps/nat/cell.go
+++ b/pkg/maps/nat/cell.go
@@ -109,12 +109,12 @@ var Cell = cell.Module(
 // to hive.
 type NatMap4 interface {
 	NatMap
-	DumpBatch4(func(tuple.TupleKey4, NatEntry4)) (count int, err error)
+	DumpBatch4(func(*tuple.TupleKey4, *NatEntry4)) (count int, err error)
 }
 
 // NatMap6 describes ipv6 nat map behaviors, used for providing map
 // to hive.
 type NatMap6 interface {
 	NatMap
-	DumpBatch6(func(tuple.TupleKey6, NatEntry6)) (count int, err error)
+	DumpBatch6(func(*tuple.TupleKey6, *NatEntry6)) (count int, err error)
 }

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -100,7 +100,7 @@ func NewMap(name string, family IPFamily, entries int) *Map {
 }
 
 // DumpBatch4 uses batch iteration to walk the map and applies fn for each batch of entries.
-func (m *Map) DumpBatch4(fn func(tuple.TupleKey4, NatEntry4)) (count int, err error) {
+func (m *Map) DumpBatch4(fn func(*tuple.TupleKey4, *NatEntry4)) (count int, err error) {
 	if m.family != IPv4 {
 		return 0, fmt.Errorf("not implemented: wrong ip family: %s", m.family)
 	}
@@ -114,7 +114,7 @@ func (m *Map) DumpBatch4(fn func(tuple.TupleKey4, NatEntry4)) (count int, err er
 }
 
 // DumpBatch6 uses batch iteration to walk the map and applies fn for each batch of entries.
-func (m *Map) DumpBatch6(fn func(tuple.TupleKey6, NatEntry6)) (count int, err error) {
+func (m *Map) DumpBatch6(fn func(*tuple.TupleKey6, *NatEntry6)) (count int, err error) {
 	if m.family != IPv6 {
 		return 0, fmt.Errorf("not implemented: wrong ip family: %s", m.family)
 	}

--- a/pkg/maps/nat/nat_batch_test.go
+++ b/pkg/maps/nat/nat_batch_test.go
@@ -35,7 +35,7 @@ func TestDumpBatch4(t *testing.T) {
 		err := m.Update(mapKey, mapValue)
 		assert.NoError(t, err)
 	}
-	count, err := m.DumpBatch4(func(tk tuple.TupleKey4, ne NatEntry4) {})
+	count, err := m.DumpBatch4(func(tk *tuple.TupleKey4, ne *NatEntry4) {})
 	assert.NoError(t, err)
 	assert.Equal(t, 1024+1, count)
 }

--- a/pkg/maps/nat/stats/stats.go
+++ b/pkg/maps/nat/stats/stats.go
@@ -250,7 +250,7 @@ func (m *Stats) countNat(ctx context.Context) error {
 	var errs error
 	if m.natMap4 != nil {
 		tupleToPortCount := make(map[SNATTuple4]uint16, 128)
-		_, err := m.natMap4.DumpBatch4(func(k tuple.TupleKey4, _ nat.NatEntry4) {
+		_, err := m.natMap4.DumpBatch4(func(k *tuple.TupleKey4, _ *nat.NatEntry4) {
 			key := *k.ToHost().(*tuple.TupleKey4)
 			if flagsIsIn(key.Flags) &&
 				(key.NextHeader == u8proto.TCP || key.NextHeader == u8proto.ICMP ||
@@ -279,7 +279,7 @@ func (m *Stats) countNat(ctx context.Context) error {
 	}
 	if m.natMap6 != nil {
 		tupleToPortCount := make(map[SNATTuple6]uint16, 128)
-		_, err := m.natMap6.DumpBatch6(func(k tuple.TupleKey6, _ nat.NatEntry6) {
+		_, err := m.natMap6.DumpBatch6(func(k *tuple.TupleKey6, _ *nat.NatEntry6) {
 			key := *k.ToHost().(*tuple.TupleKey6)
 			if flagsIsIn(key.Flags) &&
 				(key.NextHeader == u8proto.TCP || key.NextHeader == u8proto.ICMPv6 ||

--- a/pkg/testutils/mockmaps/ctmap.go
+++ b/pkg/testutils/mockmaps/ctmap.go
@@ -4,6 +4,8 @@
 package mockmaps
 
 import (
+	"context"
+
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 )
@@ -53,7 +55,7 @@ func (m *CtMockMap) DumpWithCallback(cb bpf.DumpCallback) error {
 }
 
 // Count returns the length of the map entries.
-func (m *CtMockMap) Count() (int, error) {
+func (m *CtMockMap) Count(_ context.Context) (int, error) {
 	return len(m.Entries), nil
 }
 

--- a/pkg/tuple/ipv6.go
+++ b/pkg/tuple/ipv6.go
@@ -5,6 +5,7 @@ package tuple
 
 import (
 	"fmt"
+	"net/netip"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -16,13 +17,25 @@ import (
 // TupleKey6 represents the key for IPv6 entries in the local BPF conntrack map.
 // Address field names are correct for return traffic, i.e., they are reversed
 // compared to the original direction traffic.
-type TupleKey6 struct {
-	DestAddr   types.IPv6      `align:"daddr"`
-	SourceAddr types.IPv6      `align:"saddr"`
-	DestPort   uint16          `align:"dport"`
-	SourcePort uint16          `align:"sport"`
-	NextHeader u8proto.U8proto `align:"nexthdr"`
-	Flags      uint8           `align:"flags"`
+type TupleKey6 tupleKey[types.IPv6]
+
+func (t *TupleKey6) GetDestAddr() netip.Addr {
+	return t.DestAddr.Addr()
+}
+
+func (t *TupleKey6) GetDestPort() uint16 {
+	return t.DestPort
+}
+
+func (t *TupleKey6) GetSourceAddr() netip.Addr {
+	return t.SourceAddr.Addr()
+}
+func (t *TupleKey6) GetSourcePort() uint16 {
+	return t.SourcePort
+}
+
+func (t *TupleKey6) GetNextHeader() u8proto.U8proto {
+	return t.NextHeader
 }
 
 // ToNetwork converts TupleKey6 ports to network byte order.

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/types"
 )
 
 const (
@@ -31,4 +32,8 @@ type TupleKey interface {
 
 	// Returns flags containing the direction of the tuple key.
 	GetFlags() uint8
+}
+
+type ipFamily interface {
+	types.IPv4 | types.IPv6
 }


### PR DESCRIPTION
Please see commit messages for detailed explanation.

This changes `BatchIterator[...]` to yield map key/value pointer values: f98c0ef5feb3e7ff2a3a7af127f58823d6aabe8b
Following this, ctmap GC is refactored to DRY up code that is duplicated 4x for {ipv4,ipv6} x {global,nonGlobal} maps.
Finally, we probe for Kernel batch APIs and use `bpf.BatchIterator[...]` to perform ctmap GC.