### PR TITLE
test: prefer dl.k8s.io over storage.googleapis.com/kubernetes-release

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4798,7 +4798,7 @@ func (kub *Kubectl) ensureKubectlVersion() error {
 		rcVersion = fmt.Sprintf("v%s.0", GetCurrentK8SEnv())
 	}
 	res = kub.Exec(
-		fmt.Sprintf("curl --output %s https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/amd64/kubectl && chmod +x %s",
+		fmt.Sprintf("curl --output %s https://dl.k8s.io/release/%s/bin/linux/amd64/kubectl && chmod +x %s",
 			path, rcVersion, path))
 	if !res.WasSuccessful() {
 		return fmt.Errorf("failed to download kubectl")

--- a/test/provision/helpers.bash
+++ b/test/provision/helpers.bash
@@ -60,7 +60,7 @@ function install_k8s_using_binary {
     	curl -sSL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins${OS}-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
     fi
 
-    wget -q https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubectl,kubeadm,kubelet}
+    wget -q https://dl.k8s.io/release/${RELEASE}/bin/linux/amd64/{kubectl,kubeadm,kubelet}
     chmod 777 ku*
     cp -fv ku* /usr/bin/
     rm -rf /etc/systemd/system/kubelet.service || true


### PR DESCRIPTION
The latter has been deprecated, and doesn't provide binaries for the latest releases.

Also see https://github.com/kubernetes/k8s.io/issues/2396.