### PR TITLE
Cache for string and string map allocation deduplication

### DIFF
--- a/pkg/container/cache/cache.go
+++ b/pkg/container/cache/cache.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cache
+
+import (
+	"sync"
+)
+
+const (
+	cacheSize = 512
+	cacheMask = cacheSize - 1
+)
+
+func New[T any](hashfn func(T) uint64, skipfn func(x T) bool, eqfn func(a, b T) bool) *Cache[T] {
+	return &Cache[T]{
+		hashfn: hashfn,
+		eqfn:   eqfn,
+		skipfn: skipfn,
+		pool: sync.Pool{New: func() any {
+			var arr [cacheSize]T
+			return &arr
+		}},
+	}
+}
+
+// Cache is a simple fixed size cache for efficient deduplication of objects.
+type Cache[T any] struct {
+	// pool of cache arrays. Pool is used here as it provides a very efficient
+	// shared access to a set of "cache arrays", and under low memory scenarios
+	// allows the Go runtime to drop the caches.
+	pool sync.Pool
+
+	skipfn func(T) bool
+	hashfn func(T) uint64
+	eqfn   func(a, b T) bool
+}
+
+// Get a cached object if any. If Get() was called previously with an object equal to [x]
+// and it is found from the cache then it is returned, otherwise [x] is inserted into
+// cache.
+func (c *Cache[T]) Get(x T) T {
+	if c.skipfn != nil && c.skipfn(x) {
+		return x
+	}
+	x, _ = c.get(x)
+	return x
+}
+
+func (c *Cache[T]) get(x T) (T, uint64) {
+	hash := c.hashfn(x)
+	arr := c.pool.Get().(*[cacheSize]T)
+	idx := hash & cacheMask
+	v := (*arr)[idx]
+	if !c.eqfn(x, v) {
+		(*arr)[idx] = x
+		v = x
+	}
+	c.pool.Put(arr)
+	return v, hash
+}

--- a/pkg/container/cache/cache_test.go
+++ b/pkg/container/cache/cache_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cache
+
+import (
+	"maps"
+	"strings"
+	"testing"
+	"unique"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringsCache(t *testing.T) {
+	tests := []string{
+		"",
+		"foo",
+		"foobar",
+	}
+	for _, test := range tests {
+		x := Strings.Get(test)
+		assert.Equal(t, x, test)
+	}
+}
+
+func BenchmarkStringsCache(b *testing.B) {
+	s := "foobar"
+	for range b.N {
+		x := Strings.Get(s)
+		if x != s {
+			b.Fatalf("strings not equal, %q vs %q", s, x)
+		}
+	}
+}
+
+// BenchmarkStringCache_Large shows that lookups of long strings from the cache
+// are skipped.
+func BenchmarkStringsCache_Large(b *testing.B) {
+	s := strings.Repeat("ni", 500)
+	for range b.N {
+		x := Strings.Get(s)
+		if x != s {
+			b.Fatalf("strings not equal, %q vs %q", s, x)
+		}
+	}
+}
+
+func BenchmarkUniqueString(b *testing.B) {
+	s := "foobar"
+	for range b.N {
+		x := unique.Make(s)
+		if x.Value() != s {
+			b.Fatalf("strings not equal, %q vs %q", s, x.Value())
+		}
+	}
+}
+
+func TestStringMapsCache(t *testing.T) {
+	tests := []map[string]string{
+		nil,
+		{"": ""},
+		{"foo": "bar"},
+	}
+	for _, test := range tests {
+		x := StringMaps.Get(test)
+		assert.True(t, maps.Equal(x, test), "maps equal")
+	}
+}
+
+func BenchmarkStringMapsCache(b *testing.B) {
+	m := map[string]string{"foo": "bar"}
+	for range b.N {
+		x := StringMaps.Get(m)
+		if !maps.Equal(x, m) {
+			b.Fatalf("maps not equal, %q vs %q", m, x)
+		}
+	}
+}
+
+// BenchmarkStringMapsCache_Large shows that lookups of large maps from the cache
+// are skipped.
+func BenchmarkStringMapsCache_Large(b *testing.B) {
+	m := map[string]string{}
+	s := strings.Repeat("ni", 500)
+	for range 500 {
+		m[s] = s
+	}
+	b.ResetTimer()
+	for range b.N {
+		x := StringMaps.Get(m)
+		if !maps.Equal(x, m) {
+			b.Fatalf("maps not equal, %q vs %q", m, x)
+		}
+	}
+}

--- a/pkg/container/cache/caches.go
+++ b/pkg/container/cache/caches.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cache
+
+import (
+	"maps"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+var (
+	Strings = New(
+		xxhash.Sum64String,
+		func(s string) bool {
+			// Skip caching of long strings
+			return len(s) > 256
+		},
+		func(a, b string) bool { return a == b },
+	)
+
+	StringMaps = New(
+		func(m map[string]string) (hash uint64) {
+			for k, v := range m {
+				_, hashk := Strings.get(k)
+				_, hashv := Strings.get(v)
+				hash = hash ^ hashk ^ hashv
+			}
+			return
+		},
+		func(m map[string]string) bool {
+			// Skip caching of large maps
+			return len(m) > 32
+		},
+		maps.Equal,
+	)
+)

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/cilium/cilium/pkg/container/cache"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -315,9 +316,9 @@ func NewLabel(key string, value string, source string) Label {
 	}
 
 	l := Label{
-		Key:    key,
-		Value:  value,
-		Source: source,
+		Key:    cache.Strings.Get(key),
+		Value:  cache.Strings.Get(value),
+		Source: cache.Strings.Get(source),
 	}
 	if l.Source == LabelSourceCIDR {
 		c, err := LabelToPrefix(l.Key)


### PR DESCRIPTION
The label and annotation data coming from Kubernetes is highly repetitive and thus we can reduce the agent memory consumption if we can avoid allocating a new string or a string map for labels or annotations if we have seen it before.

This PR introduces a simple fixed-size cache from which to look up recently allocated strings and string maps. This cache is then used in `Resource[T]` to dedup annotations and labels, and in `pkg/labels` to dedup key/value/source in `NewLabel`.

An alternative for deduplicating the strings would have been to use the `unique` package. That however wasn't that suitable for `map[string]string` and here we get the benefit of deduplicating the string and reusing the hash we computed to deduplicate `map[string]string`. This is also a bit faster than `unique` (18ns vs 25ns).

Related issue: https://github.com/cilium/cilium/issues/36166

```release-note
The agent now tries to deduplicate the strings and maps holding Kubernetes labels and annotations to reduce overall memory consumption.
```
