### PR TITLE
metrics/features: remove reporting metrics' defaults by default

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -87,6 +87,10 @@ runs:
             --helm-set-string=kubeProxyReplacement=${{ inputs.kpr }} \
             --set='${{ inputs.misc }}'"
 
+          if [ -f "${{ inputs.chart-dir }}/../../../.github/actions/helm-default/ci-required-values.yaml" ]; then
+            DEFAULTS+=" --values=${{ inputs.chart-dir }}/../../../.github/actions/helm-default/ci-required-values.yaml"
+          fi
+
           IMAGE=""
           if [ "${{ inputs.image-tag }}" != "" ]; then
             IMAGE="--helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \

--- a/.github/actions/helm-default/ci-required-values.yaml
+++ b/.github/actions/helm-default/ci-required-values.yaml
@@ -1,3 +1,5 @@
 extraEnv:
   - name: "KUBE_CACHE_MUTATION_DETECTOR"
     value: "true"
+  - name: "CILIUM_FEATURE_METRICS_WITH_DEFAULTS"
+    value: "true"

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -97,30 +97,36 @@ jobs:
       - name: Install cilium chart
         id: install-cilium
         run: |
-          helm install cilium ./install/kubernetes/cilium \
-             --wait \
-             --namespace kube-system \
-             --set nodeinit.enabled=true \
-             --set kubeProxyReplacement=false \
-             --set socketLB.enabled=false \
-             --set externalIPs.enabled=true \
-             --set nodePort.enabled=true \
-             --set hostPort.enabled=true \
-             --set bpf.masquerade=false \
-             --set ipam.mode=kubernetes \
-             --set image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
-             --set image.tag=${{ steps.vars.outputs.tag }} \
-             --set image.pullPolicy=IfNotPresent \
-             --set image.useDigest=false \
-             --set operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
-             --set operator.image.suffix=-ci \
-             --set operator.image.tag=${{ steps.vars.outputs.tag }} \
-             --set operator.image.pullPolicy=IfNotPresent \
-             --set operator.image.useDigest=false \
-             --set prometheus.enabled=true \
-             --set operator.prometheus.enabled=true \
-             --set hubble.enabled=true \
-             --set hubble.metrics.enabled="{dns,drop,tcp,flow,port-distribution,icmp,http}"
+          HELM_ARGS="\
+            --wait \
+            --namespace kube-system \
+            --set nodeinit.enabled=true \
+            --set kubeProxyReplacement=false \
+            --set socketLB.enabled=false \
+            --set externalIPs.enabled=true \
+            --set nodePort.enabled=true \
+            --set hostPort.enabled=true \
+            --set bpf.masquerade=false \
+            --set ipam.mode=kubernetes \
+            --set image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
+            --set image.tag=${{ steps.vars.outputs.tag }} \
+            --set image.pullPolicy=IfNotPresent \
+            --set image.useDigest=false \
+            --set operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
+            --set operator.image.suffix=-ci \
+            --set operator.image.tag=${{ steps.vars.outputs.tag }} \
+            --set operator.image.pullPolicy=IfNotPresent \
+            --set operator.image.useDigest=false \
+            --set prometheus.enabled=true \
+            --set operator.prometheus.enabled=true \
+            --set hubble.enabled=true \
+            --set hubble.metrics.enabled=\"{dns,drop,tcp,flow,port-distribution,icmp,http}\""
+
+          if [ -f ".github/actions/helm-default/ci-required-values.yaml" ]; then
+            HELM_ARGS+=" --values=.github/actions/helm-default/ci-required-values.yaml"
+          fi
+
+          helm install cilium ./install/kubernetes/cilium $HELM_ARGS
 
           kubectl wait -n kube-system --for=condition=Ready -l app.kubernetes.io/part-of=cilium pod --timeout=5m
           kubectl rollout -n kube-system status deploy/coredns --timeout=5m

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -46,6 +46,8 @@ jobs:
               - '!(test|Documentation)/**'
 
   conformance-test-ipv6:
+    env:
+      job_name: "Conformance Smoke Test with IPv6"
     needs: check_changes
     if: ${{ needs.check_changes.outputs.tested == 'true' }}
     runs-on: ubuntu-24.04

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -74,6 +74,8 @@ jobs:
           test -z "$(git status --porcelain)" || (echo "please run 'make -C install/kubernetes' and submit your changes"; exit 1)
 
   conformance-test:
+    env:
+      job_name: "Conformance Smoke Test"
     needs: check_changes
     if: ${{ needs.check_changes.outputs.tested == 'true' && github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -5,6 +5,7 @@ package features
 
 import (
 	"log/slog"
+	"os"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -18,6 +19,11 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
+)
+
+var (
+	// withDefaults will set enable all default metrics in the agent.
+	withDefaults = os.Getenv("CILIUM_FEATURE_METRICS_WITH_DEFAULTS")
 )
 
 // Cell will retrieve information from all other cells /
@@ -34,7 +40,10 @@ var Cell = cell.Module(
 		},
 	),
 	metrics.Metric(func() Metrics {
-		return NewMetrics(true)
+		if withDefaults != "" {
+			return NewMetrics(true)
+		}
+		return NewMetrics(false)
 	}),
 )
 

--- a/pkg/metrics/features/operator/cell.go
+++ b/pkg/metrics/features/operator/cell.go
@@ -5,6 +5,7 @@ package features
 
 import (
 	"log/slog"
+	"os"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -15,6 +16,11 @@ import (
 	"github.com/cilium/cilium/operator/pkg/lbipam"
 	"github.com/cilium/cilium/operator/pkg/nodeipam"
 	"github.com/cilium/cilium/pkg/metrics"
+)
+
+var (
+	// withDefaults will set enable all default metrics in the operator.
+	withDefaults = os.Getenv("CILIUM_FEATURE_METRICS_WITH_DEFAULTS")
 )
 
 // Cell will retrieve information from all other cells /
@@ -31,7 +37,10 @@ var Cell = cell.Module(
 		},
 	),
 	metrics.Metric(func() Metrics {
-		return NewMetrics(true)
+		if withDefaults != "" {
+			return NewMetrics(true)
+		}
+		return NewMetrics(false)
 	}),
 )
 

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -253,6 +253,7 @@ const (
 	cantRecreateMasterKey      = "unable to re-create missing master key"                                // cf. https://github.com/cilium/cilium/issues/29738
 	cantUpdateCRDIdentity      = "Unable update CRD identity information with a reference for this node" // cf. https://github.com/cilium/cilium/issues/29739
 	cantDeleteFromPolicyMap    = "cilium_call_policy: delete: key does not exist"                        // cf. https://github.com/cilium/cilium/issues/29754
+	mutationDetector           = "Mutation detector is enabled, this will result in memory leakage."     // cf. https://github.com/cilium/cilium/issues/35929
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
 
@@ -316,7 +317,7 @@ var badLogMessages = map[string][]string{
 		unableGetNode, sessionAffinitySocketLB, objectHasBeenModified, legacyBGPFeature,
 		etcdTimeout, endpointRestoreFailed, unableRestoreRouterIP, routerIPReallocated,
 		cantFindIdentityInCache, keyAllocFailedFoundMaster, cantRecreateMasterKey,
-		cantUpdateCRDIdentity, cantDeleteFromPolicyMap, failedToListCRDs},
+		cantUpdateCRDIdentity, cantDeleteFromPolicyMap, failedToListCRDs, mutationDetector},
 }
 
 var ciliumCLICommands = map[string]string{

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -119,8 +119,10 @@ var (
 		"etcd.leaseTTL":          "30s",
 		"ipv4.enabled":           "true",
 		"ipv6.enabled":           "true",
-		// "extraEnv[0].name":              "KUBE_CACHE_MUTATION_DETECTOR",
-		// "extraEnv[0].value":             "true",
+		"extraEnv[0].name":       "KUBE_CACHE_MUTATION_DETECTOR",
+		"extraEnv[0].value":      "'true'",
+		"extraEnv[1].name":       "CILIUM_FEATURE_METRICS_WITH_DEFAULTS",
+		"extraEnv[1].value":      "'true'",
 
 		// We need CNP node status to know when a policy is being enforced
 		"ipv4NativeRoutingCIDR": IPv4NativeRoutingCIDR,
@@ -4335,9 +4337,12 @@ func (kub *Kubectl) HelmTemplate(chartDir, namespace, filename string, options m
 	optionsString := ""
 
 	for k, v := range options {
-		if v == "true" || v == "false" {
+		switch {
+		case v == "true" || v == "false":
 			optionsString += fmt.Sprintf(" --set %s=%s ", k, v)
-		} else {
+		case v == "'true'" || v == "'false'":
+			optionsString += fmt.Sprintf(" --set-string %s=%s ", k, v)
+		default:
 			optionsString += fmt.Sprintf(" --set '%s=%s' ", k, v)
 		}
 	}


### PR DESCRIPTION
Having all metrics defaults can cause certain cardinality issue for
production clusters. Since the hive framework does not yet provides a
way to pass a flag to enable, at runtime, the metrics defaults, we need
to use a environment variable. Since, enabling defaults are not actually
intended to be used by users, it's safe to reasonable to have this
option to only be configurable by an environment variable.