### PR TITLE
clustermesh: add annotations and labels sync to MCS-API

### DIFF
--- a/Documentation/network/clustermesh/mcsapi.rst
+++ b/Documentation/network/clustermesh/mcsapi.rst
@@ -138,6 +138,7 @@ The ServiceImport has also a logic to merge different Service properties:
 - SessionAffinity
 - Ports (Union of the different ServiceExports)
 - Type (ClusterSetIP/Headless)
+- Annotations & Labels (via the ServiceExport ``exportedLabels`` and ``exportedAnnotations`` fields)
 
 If any conflict arises on any of these properties, the oldest ServiceExport will
 have precedence to resolve the conflict. This means that you should get a

--- a/Documentation/network/clustermesh/mcsapi.rst
+++ b/Documentation/network/clustermesh/mcsapi.rst
@@ -20,8 +20,8 @@ You first need to install the required MCS-API CRDs:
 
    .. code-block:: shell-session
 
-      kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/4690877cc89bcfd9302d516ae43515f446d0aecf/config/crd/multicluster.x-k8s.io_serviceexports.yaml
-      kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/4690877cc89bcfd9302d516ae43515f446d0aecf/config/crd/multicluster.x-k8s.io_serviceimports.yaml
+      kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/fede3192824f8c9d44719a467528f9438ae6007b/config/crd/multicluster.x-k8s.io_serviceexports.yaml
+      kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/fede3192824f8c9d44719a467528f9438ae6007b/config/crd/multicluster.x-k8s.io_serviceimports.yaml
 
 
 To install Cilium with MCS-API support, run:

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -328,6 +328,8 @@ ethernet
 ethtool
 existingSecret
 expirations
+exportedAnnotations
+exportedLabels
 extTrafficPolicy
 extern
 externalIPs

--- a/pkg/clustermesh/mcsapi/serviceexportsync_test.go
+++ b/pkg/clustermesh/mcsapi/serviceexportsync_test.go
@@ -38,6 +38,14 @@ var (
 				Namespace:         "default",
 				CreationTimestamp: exportTime,
 			},
+			Spec: mcsapiv1alpha1.ServiceExportSpec{
+				ExportedAnnotations: map[string]string{
+					"my-annotation": "test",
+				},
+				ExportedLabels: map[string]string{
+					"my-label": "test",
+				},
+			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -182,6 +190,8 @@ func Test_mcsServiceExportSync_Reconcile(t *testing.T) {
 			if len(mcsAPISvcSpec.Ports) == 1 {
 				assert.Equal(c, "my-port-1", mcsAPISvcSpec.Ports[0].Name)
 			}
+			assert.Equal(c, map[string]string{"my-annotation": "test"}, mcsAPISvcSpec.Annotations)
+			assert.Equal(c, map[string]string{"my-label": "test"}, mcsAPISvcSpec.Labels)
 			assert.True(c, exportTime.Equal(&mcsAPISvcSpec.ExportCreationTimestamp), "Export time should be equal")
 			assert.Equal(c, mcsapiv1alpha1.ClusterSetIP, mcsAPISvcSpec.Type)
 		}, timeout, tick, "MCSAPIServiceSpec is not correctly synced")

--- a/pkg/clustermesh/mcsapi/types/mcsapiservicespec.go
+++ b/pkg/clustermesh/mcsapi/types/mcsapiservicespec.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"path"
 
 	corev1 "k8s.io/api/core/v1"
@@ -36,6 +37,12 @@ type MCSAPIServiceSpec struct {
 
 	// Namespace is the cluster namespace the service is configured in
 	Namespace string `json:"namespace"`
+
+	// Annotations contains the exported annotations
+	Annotations map[string]string
+
+	// Labels contains the exported labels
+	Labels map[string]string
 
 	// ExportCreationTimestamp is the timestamp representing when the
 	// ServiceExport object was created. It is used for conflict resolution.
@@ -188,6 +195,8 @@ func FromCiliumServiceToMCSAPIServiceSpec(clusterName string, svc *slim_corev1.S
 		Ports:           ports,
 		Type:            mcsAPISvcType,
 		SessionAffinity: corev1.ServiceAffinity(svc.Spec.SessionAffinity),
+		Annotations:     maps.Clone(svcExport.Spec.ExportedAnnotations),
+		Labels:          maps.Clone(svcExport.Spec.ExportedLabels),
 	}
 	if svc.Spec.SessionAffinityConfig != nil &&
 		svc.Spec.SessionAffinityConfig.ClientIP != nil &&


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

Add annotations sync to MCS-API with the newly added fields in ServiceExport, this would help synchronizing specific annotations such as topology aware annotation or many Cilium annotations modifying services (endpointslicesync, l7 proxy, clustermesh service affinity, etc.). And it helps with anything with a label selector matching a ServiceImport or its derived Service.

~~Currently with un-merged change from https://github.com/kubernetes-sigs/mcs-api/pull/84 / https://github.com/kubernetes/enhancements/pull/4922~~

```release-note
clustermesh: add annotations and labels sync to MCS-API
```
