### PR TITLE
datapath: Add per-endpoint direct routing support

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -118,6 +118,7 @@ cilium-agent [flags]
       --enable-dynamic-config                                     Enables support for dynamic agent config
       --enable-dynamic-lifecycle-manager                          Enables support for dynamic lifecycle management
       --enable-encryption-strict-mode                             Enable encryption strict mode
+      --enable-endpoint-direct-routing                            Enable BPF to redirect traffic directly to the parent ENI of the endpoint
       --enable-endpoint-health-checking                           Enable connectivity health checking between virtual endpoints (default true)
       --enable-endpoint-lockdown-on-policy-overflow               When an endpoint's policy map overflows, shutdown all (ingress and egress) network traffic for that endpoint.
       --enable-endpoint-routes                                    Use per endpoint routes instead of routing via cilium_host

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -729,9 +729,18 @@ ct_recreate6:
 	}
 #endif
 	if (is_defined(ENABLE_HOST_ROUTING)) {
+#ifdef ENDPOINT_DIRECT_ROUTING_DEV_IFINDEX
+		int oif = ENDPOINT_DIRECT_ROUTING_DEV_IFINDEX;
+#else
 		int oif = 0;
-
-		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, false, ext_err, &oif);
+#endif
+		if (oif > 0) {
+			ret = ipv6_l3(ctx, ETH_HLEN, NULL, NULL, METRIC_EGRESS);
+			if (ret == CTX_ACT_OK)
+				ret = redirect_neigh(oif, NULL, 0, 0);
+		} else {
+			ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, false, ext_err, &oif);
+		}
 		if (fib_ok(ret))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV6,
 					  *dst_sec_identity, TRACE_EP_ID_UNKNOWN, oif,
@@ -1283,9 +1292,18 @@ skip_vtep:
 #endif /* TUNNEL_MODE || ENABLE_HIGH_SCALE_IPCACHE */
 
 	if (is_defined(ENABLE_HOST_ROUTING)) {
+#ifdef ENDPOINT_DIRECT_ROUTING_DEV_IFINDEX
+		int oif = ENDPOINT_DIRECT_ROUTING_DEV_IFINDEX;
+#else
 		int oif = 0;
-
-		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, false, ext_err, &oif);
+#endif
+		if (oif > 0) {
+			ret = ipv4_l3(ctx, ETH_HLEN, NULL, NULL, ip4);
+			if (ret == CTX_ACT_OK)
+				ret = redirect_neigh(oif, NULL, 0, 0);
+		} else {
+			ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, false, ext_err, &oif);
+		}
 		if (fib_ok(ret))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV4,
 					  *dst_sec_identity, TRACE_EP_ID_UNKNOWN, oif,

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -361,6 +361,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableHostLegacyRouting, defaults.EnableHostLegacyRouting, "Enable the legacy host forwarding model which does not bypass upper stack in host namespace")
 	option.BindEnv(vp, option.EnableHostLegacyRouting)
 
+	flags.Bool(option.EnableEndpointDirectRouting, defaults.EnableEndpointDirectRouting, "Enable BPF to redirect traffic directly to the parent ENI of the endpoint")
+	option.BindEnv(vp, option.EnableEndpointDirectRouting)
+
 	flags.String(option.EnablePolicy, option.DefaultEnforcement, "Enable policy enforcement")
 	option.BindEnv(vp, option.EnablePolicy)
 

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -1089,6 +1089,11 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, devices []strin
 		}
 	}
 
+	if option.Config.EnableEndpointDirectRouting &&
+		!e.IsHost() && e.GetParentIfIndex() > 0 {
+		fmt.Fprintf(fw, "#define ENDPOINT_DIRECT_ROUTING_DEV_IFINDEX %d\n", e.GetParentIfIndex())
+	}
+
 	if e.IsHost() {
 		// Only used to differentiate between host endpoint template and other templates.
 		fmt.Fprintf(fw, "#define HOST_ENDPOINT 1\n")

--- a/pkg/datapath/types/config.go
+++ b/pkg/datapath/types/config.go
@@ -84,6 +84,9 @@ type CompileTimeConfiguration interface {
 
 	// IsHost returns true if the endpoint is the host endpoint.
 	IsHost() bool
+
+	// GetParentIfIndex returns eni index related to the endpoint.
+	GetParentIfIndex() int
 }
 
 // EndpointConfiguration provides datapath implementations a clean interface

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -217,6 +217,9 @@ const (
 	// EnableHostLegacyRouting is the default value for using the old routing path via stack.
 	EnableHostLegacyRouting = false
 
+	// EnableEndpointDirectRouting is the default value for utilizes BPF redirect to route traffic directly to ENI.
+	EnableEndpointDirectRouting = false
+
 	// PreAllocateMaps is the default value for BPF map preallocation
 	PreAllocateMaps = true
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -236,6 +236,9 @@ const (
 	// EnableHostLegacyRouting enables the old routing path via stack.
 	EnableHostLegacyRouting = "enable-host-legacy-routing"
 
+	// EnableEndpointDirectRouting enables direct routing for each endpoint
+	EnableEndpointDirectRouting = "enable-endpoint-direct-routing"
+
 	// EnableNodePort enables NodePort services implemented by Cilium in BPF
 	EnableNodePort = "enable-node-port"
 
@@ -1851,6 +1854,9 @@ type DaemonConfig struct {
 	// EnableHostLegacyRouting enables the old routing path via stack.
 	EnableHostLegacyRouting bool
 
+	// EnableEndpointDirectRouting enables direct routing for each endpoint
+	EnableEndpointDirectRouting bool
+
 	// NodePortNat46X64 indicates whether NAT46 / NAT64 can be used.
 	NodePortNat46X64 bool
 
@@ -2851,6 +2857,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableSVCSourceRangeCheck = vp.GetBool(EnableSVCSourceRangeCheck)
 	c.EnableHostPort = vp.GetBool(EnableHostPort)
 	c.EnableHostLegacyRouting = vp.GetBool(EnableHostLegacyRouting)
+	c.EnableEndpointDirectRouting = vp.GetBool(EnableEndpointDirectRouting)
 	c.NodePortBindProtection = vp.GetBool(NodePortBindProtection)
 	c.EnableAutoProtectNodePortRange = vp.GetBool(EnableAutoProtectNodePortRange)
 	c.KubeProxyReplacement = vp.GetString(KubeProxyReplacement)

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -74,6 +74,7 @@ func (e *TestEndpoint) GetNodeMAC() mac.MAC                         { return e.M
 func (e *TestEndpoint) GetIfIndex() int                             { return e.IfIndex }
 func (e *TestEndpoint) GetOptions() *option.IntOptions              { return e.Opts }
 func (e *TestEndpoint) IsHost() bool                                { return e.isHost }
+func (e *TestEndpoint) GetParentIfIndex() int                       { return 0 }
 
 func (e *TestEndpoint) IPv4Address() netip.Addr {
 	return netip.MustParseAddr("192.0.2.3")


### PR DESCRIPTION
Introduce ENDPOINT_DIRECT_ROUTING_DEV_IFINDEX for container endpoints to enable direct packet redirection using bpf_redirect_neigh(). This optimization eliminates the overhead of BPF FIB lookup operations in the datapath.


<!-- Description of change -->

Fixes: #29619

