### PR TITLE
gha: configure environment in build-images-base/image-digests job

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -348,6 +348,7 @@ jobs:
   image-digests:
     name: Display Digests
     runs-on: ubuntu-24.04
+    environment: ${{ inputs.environment || 'release-base-images' }}
     needs: build-and-push
     steps:
       - name: Downloading Image Digests


### PR DESCRIPTION
Currently, the Display Digests job of the build-images-base workflow is always failing when called from renovate branches, as lacking access to the required secrets, even if not actually used. Let's configure the environment to mimic the one of the other jobs, to hopefully fix this.

If this change works correctly without unintended consequences, then we should backport this PR to all stable branches.