### PR TITLE
node: remove refresh parameter from NodeNeighborRefresh

### DIFF
--- a/pkg/datapath/fake/types/node_handler.go
+++ b/pkg/datapath/fake/types/node_handler.go
@@ -68,7 +68,7 @@ func (n *FakeNodeHandler) NodeNeighDiscoveryEnabled() bool {
 	return false
 }
 
-func (n *FakeNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node, refresh bool) error {
+func (n *FakeNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) error {
 	return nil
 }
 

--- a/pkg/datapath/linux/fuzz_test.go
+++ b/pkg/datapath/linux/fuzz_test.go
@@ -32,9 +32,9 @@ func FuzzNodeHandler(f *testing.F) {
 		if err != nil {
 			t.Skip()
 		}
-		linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev1, true)
+		linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev1)
 		linuxNodeHandler.NodeDelete(nodev1)
-		linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev1, true)
+		linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev1)
 	})
 }
 
@@ -42,9 +42,9 @@ type mockEnqueuer struct {
 	nh *linuxNodeHandler
 }
 
-func (q *mockEnqueuer) Enqueue(n *nodeTypes.Node, refresh bool) {
+func (q *mockEnqueuer) Enqueue(n *nodeTypes.Node) {
 	if q.nh != nil {
-		if err := q.nh.insertNeighbor(context.Background(), n, refresh); err != nil {
+		if err := q.nh.insertNeighbor(context.Background(), n); err != nil {
 			q.nh.log.Error("MockQ NodeNeighborRefresh failed", logfields.Error, err)
 		}
 	}

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -262,7 +262,6 @@ func removeDevice(name string) {
 }
 
 func TestAll(t *testing.T) {
-
 	for _, tt := range []string{"IPv4", "IPv6", "dual"} {
 		t.Run(tt, func(t *testing.T) {
 			t.Run("TestUpdateNodeRoute", func(t *testing.T) {
@@ -1587,7 +1586,7 @@ func TestArpPingHandlingIPv6(t *testing.T) {
 	err = netlink.LinkSetHardwareAddr(veth0, veth1HwAddr)
 	require.NoError(t, err)
 
-	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1, true)
+	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1)
 	wait(nodev1.Identity(), "veth0", &now, false)
 
 	assertNeigh(ip1, func(neigh netlink.Neigh) bool {
@@ -1637,7 +1636,7 @@ func TestArpPingHandlingIPv6(t *testing.T) {
 			defer wg.Done()
 			ticker := time.NewTicker(100 * time.Millisecond)
 			for {
-				linuxNodeHandler.insertNeighbor(context.Background(), &nodev1, true)
+				linuxNodeHandler.insertNeighbor(context.Background(), &nodev1)
 				select {
 				case <-ticker.C:
 				case <-done:
@@ -1687,8 +1686,8 @@ func TestArpPingHandlingIPv6(t *testing.T) {
 
 	// Setup routine for the 2. test
 	setupRemoteNode := func(vethName, vethPeerName, netnsName, vethCIDR, vethIPAddr,
-		vethPeerIPAddr string) (cleanup func(), errRet error) {
-
+		vethPeerIPAddr string,
+	) (cleanup func(), errRet error) {
 		veth := &netlink.Veth{
 			LinkAttrs: netlink.LinkAttrs{Name: vethName},
 			PeerName:  vethPeerName,
@@ -1824,7 +1823,8 @@ func TestArpPingHandlingIPv6(t *testing.T) {
 		Name: "node2",
 		IPAddresses: []nodeTypes.Address{{
 			Type: nodeaddressing.NodeInternalIP,
-			IP:   node2IP}},
+			IP:   node2IP,
+		}},
 	}
 	now = time.Now()
 	require.NoError(t, linuxNodeHandler.NodeAdd(nodev2))
@@ -1937,8 +1937,8 @@ func TestArpPingHandlingIPv6(t *testing.T) {
 
 	// insertNeighbor is invoked async, so thus this wait based on last ping
 	now = time.Now()
-	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev2, true)
-	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev3, true)
+	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev2)
+	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev3)
 	waitGw("f00d::251", nodev2.Identity(), "veth0", &now)
 	waitGw("f00d::250", nodev3.Identity(), "veth0", &now)
 
@@ -1955,8 +1955,8 @@ func TestArpPingHandlingIPv6(t *testing.T) {
 
 	// insertNeighbor is invoked async, so thus this wait based on last ping
 	now = time.Now()
-	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev2, true)
-	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev3, true)
+	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev2)
+	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev3)
 	waitGw("f00d::251", nodev2.Identity(), "veth0", &now)
 	waitGw("f00d::251", nodev3.Identity(), "veth0", &now)
 
@@ -2173,7 +2173,8 @@ func TestArpPingHandlingForMultiDeviceIPv6(t *testing.T) {
 				LinkIndex: veth2.Attrs().Index,
 				Gw:        v2IP1,
 			},
-		}}
+		},
+	}
 
 	err = netlink.RouteAdd(r)
 	require.NoError(t, err)
@@ -2374,7 +2375,7 @@ func TestArpPingHandlingForMultiDeviceIPv6(t *testing.T) {
 	err = netlink.LinkSetHardwareAddr(veth2, veth3HwAddr)
 	require.NoError(t, err)
 
-	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1, true)
+	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1)
 	wait(nodev1.Identity(), "veth0", &now, false)
 	wait(nodev1.Identity(), "veth2", &now, false)
 
@@ -2613,7 +2614,7 @@ func TestArpPingHandlingIPv4(t *testing.T) {
 	err = netlink.LinkSetHardwareAddr(veth0, veth1HwAddr)
 	require.NoError(t, err)
 
-	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1, true)
+	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1)
 	wait(nodev1.Identity(), "veth0", &now, false)
 
 	assertNeigh(ip1,
@@ -2665,7 +2666,7 @@ func TestArpPingHandlingIPv4(t *testing.T) {
 			defer wg.Done()
 			ticker := time.NewTicker(100 * time.Millisecond)
 			for {
-				linuxNodeHandler.insertNeighbor(context.Background(), &nodev1, true)
+				linuxNodeHandler.insertNeighbor(context.Background(), &nodev1)
 				select {
 				case <-ticker.C:
 				case <-done:
@@ -2715,8 +2716,8 @@ func TestArpPingHandlingIPv4(t *testing.T) {
 
 	// Setup routine for the 2. test
 	setupRemoteNode := func(vethName, vethPeerName, netnsName, vethCIDR, vethIPAddr,
-		vethPeerIPAddr string) (cleanup func(), errRet error) {
-
+		vethPeerIPAddr string,
+	) (cleanup func(), errRet error) {
 		veth := &netlink.Veth{
 			LinkAttrs: netlink.LinkAttrs{Name: vethName},
 			PeerName:  vethPeerName,
@@ -2965,8 +2966,8 @@ func TestArpPingHandlingIPv4(t *testing.T) {
 
 	// insertNeighbor is invoked async, so thus this wait based on last ping
 	now = time.Now()
-	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev2, true)
-	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev3, true)
+	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev2)
+	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev3)
 	waitGw("9.9.9.251", nodev2.Identity(), "veth0", &now)
 	waitGw("9.9.9.250", nodev3.Identity(), "veth0", &now)
 
@@ -2983,8 +2984,8 @@ func TestArpPingHandlingIPv4(t *testing.T) {
 
 	// insertNeighbor is invoked async, so thus this wait based on last ping
 	now = time.Now()
-	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev2, true)
-	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev3, true)
+	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev2)
+	linuxNodeHandler.NodeNeighborRefresh(context.Background(), nodev3)
 	waitGw("9.9.9.251", nodev2.Identity(), "veth0", &now)
 	waitGw("9.9.9.251", nodev3.Identity(), "veth0", &now)
 
@@ -3196,7 +3197,8 @@ func TestArpPingHandlingForMultiDeviceIPv4(t *testing.T) {
 				LinkIndex: veth2.Attrs().Index,
 				Gw:        v2IP1,
 			},
-		}}
+		},
+	}
 	err = netlink.RouteAdd(r)
 	require.NoError(t, err)
 	defer netlink.RouteDel(r)
@@ -3398,7 +3400,7 @@ func TestArpPingHandlingForMultiDeviceIPv4(t *testing.T) {
 	err = netlink.LinkSetHardwareAddr(veth2, veth3HwAddr)
 	require.NoError(t, err)
 
-	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1, true)
+	linuxNodeHandler.NodeNeighborRefresh(context.TODO(), nodev1)
 	wait(nodev1.Identity(), "veth0", &now, false)
 	wait(nodev1.Identity(), "veth2", &now, false)
 

--- a/pkg/datapath/types/config.go
+++ b/pkg/datapath/types/config.go
@@ -19,7 +19,7 @@ import (
 // for further processing.
 type NodeNeighborEnqueuer interface {
 	// Enqueue enqueues a node for processing node neighbors updates.
-	Enqueue(*nodeTypes.Node, bool)
+	Enqueue(*nodeTypes.Node)
 }
 
 // DeviceConfiguration is an interface for injecting configuration of datapath

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -239,7 +239,7 @@ type NodeNeighbors interface {
 	NodeNeighDiscoveryEnabled() bool
 
 	// NodeNeighborRefresh is called to refresh node neighbor table
-	NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node, refresh bool) error
+	NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) error
 
 	// NodeCleanNeighbors cleans all neighbor entries for the direct routing device
 	// and the encrypt interface.
@@ -250,7 +250,7 @@ type NodeNeighbors interface {
 	// be added, for example, for external service backends.
 	InsertMiscNeighbor(newNode *nodeTypes.Node)
 
-	// DeleteMiscNeighbor delets a eighbor entry for the address passed via oldNode.
+	// DeleteMiscNeighbor deletes a neighbor entry for the address passed via oldNode.
 	// This is needed to delete the entries which have been inserted at an earlier
 	// point in time through InsertMiscNeighbor.
 	DeleteMiscNeighbor(oldNode *nodeTypes.Node)


### PR DESCRIPTION
This commit removes the unused parameter `refresh` and logic from the method `NodeNeighborRefresh`. Except for tests, it's always passed as `false`.
