### PR TITLE
Bump StateDB to v0.3.4 and refactor db command usages

### DIFF
--- a/Documentation/contributing/development/statedb.rst
+++ b/Documentation/contributing/development/statedb.rst
@@ -169,7 +169,7 @@ The ``show`` command prints out the table using the *TableRow* and *TableHeader*
 
 .. code-block:: shell-session
 
-    root@kind-worker:/home/cilium# cilium-dbg shell -- db show mtu
+    root@kind-worker:/home/cilium# cilium-dbg shell -- db/show mtu
     Prefix      DeviceMTU   RouteMTU   RoutePostEncryptMTU
     ::/0        1500        1450       1450
     0.0.0.0/0   1500        1450       1450
@@ -204,13 +204,13 @@ The shell session can also be run interactively:
         Inspect and manipulate StateDB
         ...
     
-    cilium> db show mtu
+    cilium> db/show mtu
     [stdout]
     Prefix      DeviceMTU   RouteMTU   RoutePostEncryptMTU
     ::/0        1500        1450       1450
     0.0.0.0/0   1500        1450       1450
 
-    cilium> db show -o=/tmp/devices.json -format=json devices
+    cilium> db/show -o=/tmp/devices.json -format=json devices
     ...
 
 Kubernetes reflection

--- a/Documentation/network/egress-gateway/egress-gateway-troubleshooting.rst
+++ b/Documentation/network/egress-gateway/egress-gateway-troubleshooting.rst
@@ -39,7 +39,7 @@ Cilium agent stores stats about the top 30 such connection tuples, this can be a
 
 .. code-block:: shell-session
 
-    $ kubectl -n kube-system exec ds/cilium -- cilium-dbg shell -- db show nat-stats
+    $ kubectl -n kube-system exec ds/cilium -- cilium-dbg shell -- db/show nat-stats
     # IPFamily   Proto    EgressIP                RemoteAddr                   Count
     ipv4         TCP      10.244.1.160            10.244.3.174:4240            1
     ipv4         ICMP     172.18.0.2              172.18.0.3                   1

--- a/Documentation/network/l2-announcements.rst
+++ b/Documentation/network/l2-announcements.rst
@@ -487,7 +487,7 @@ Finally, take the name of the cilium agent pod and inspect the l2-announce state
     $ kubectl -n kube-system get pod -l 'app.kubernetes.io/name=cilium-agent' -o wide | grep <node-name>
     <agent-pod>   1/1     Running   0          35m   172.19.0.3   kind-worker          <none>           <none>
 
-    $ kubectl -n kube-system exec pod/<agent-pod> -- cilium-dbg shell -- db show l2-announce
+    $ kubectl -n kube-system exec pod/<agent-pod> -- cilium-dbg shell -- db/show l2-announce
     # IP        NetworkInterface
     10.0.10.0   eth0
 
@@ -498,7 +498,7 @@ If the filter seems correct or isn't specified, inspect the known devices:
 
 .. code-block:: shell-session
 
-    $ kubectl -n kube-system exec ds/cilium -- cilium-dbg shell -- db show devices
+    $ kubectl -n kube-system exec ds/cilium -- cilium-dbg shell -- db/show devices
     Name              Index   Selected   Type     MTU     HWAddr              Flags                    Addresses
     lxc5d23398605f6   10      false      veth     1500    b6:ed:d8:d2:dd:ec   up|broadcast|multicast   fe80::b4ed:d8ff:fed2:ddec
     lxc3bf03c00d6e3   12      false      veth     1500    8a:d1:0c:91:8a:d3   up|broadcast|multicast   fe80::88d1:cff:fe91:8ad3

--- a/cilium-dbg/cmd/statedb.go
+++ b/cilium-dbg/cmd/statedb.go
@@ -27,16 +27,16 @@ $ cilium-dbg shell
 cilium> help db
 (shows help for 'db' command)
 
-cilium> db tables
+cilium> db
 (shows all registered tables)
 
-cilium> db show health
+cilium> db/show health
 (shows contents of health table)
 
-$ cilium-dbg shell -- db show health
+$ cilium-dbg shell -- db/show health
 (shows contents of health table)
 
-$ cilium-dbg shell -- db show -format=json health
+$ cilium-dbg shell -- db/show -format=json health
 (shows contents as JSON)
 `)
 	},

--- a/contrib/examples/statedb/example.go
+++ b/contrib/examples/statedb/example.go
@@ -117,7 +117,7 @@ func (e *exampleController) loop(ctx context.Context, health cell.Health) error 
 		wtxn.Commit()
 
 		// Report the health of the job. This can be inspected with
-		// "cilium-dbg status --all-health" or with "cilium-dbg shell -- db show health".
+		// "cilium-dbg status --all-health" or with "cilium-dbg shell -- db/show health".
 		health.OK(fmt.Sprintf("%d examples inserted", id))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/cilium/linters v0.1.0
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20241115112946-fb67566cbd95
-	github.com/cilium/statedb v0.3.3
+	github.com/cilium/statedb v0.3.4
 	github.com/cilium/stream v0.0.0-20241203114243-53c3e5d79744
 	github.com/cilium/workerpool v1.2.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y
 github.com/cilium/lumberjack/v2 v2.4.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20241115112946-fb67566cbd95 h1:iMn0++U3CDqoDINY5JLOhlPcjj3kW/xCmse+d+EZkOM=
 github.com/cilium/proxy v0.0.0-20241115112946-fb67566cbd95/go.mod h1:/UoCz3gByKwF5gCHFMUhwmIN5/Pgmb8LTIrfBlmjGCo=
-github.com/cilium/statedb v0.3.3 h1:hB1J28yE6KMrwLSxFfus1QjwYK1PEhibKADckxVHNyk=
-github.com/cilium/statedb v0.3.3/go.mod h1:hpcYZXvrOhmdBd02/N/WqxSjbeO2HYG8l3Z2fGq6Ioo=
+github.com/cilium/statedb v0.3.4 h1:nb5qNntmtaNljJD1r2s5zGOs62LP87AqLhFKIZH2rRE=
+github.com/cilium/statedb v0.3.4/go.mod h1:hpcYZXvrOhmdBd02/N/WqxSjbeO2HYG8l3Z2fGq6Ioo=
 github.com/cilium/stream v0.0.0-20241203114243-53c3e5d79744 h1:f+CgYUy2YyZ2EX31QSqf3vwFiJJQSAMIQLn4d3QQYno=
 github.com/cilium/stream v0.0.0-20241203114243-53c3e5d79744/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.2.0 h1:Wc2iOPTvCgWKQXeq4L5tnx4QFEI+z5q1+bSpSS0cnAY=

--- a/pkg/ciliumenvoyconfig/testdata/anyport.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/anyport.txtar
@@ -2,25 +2,25 @@
 
 # Start the hive and wait for tables to be synchronized before adding k8s objects.
 hive start
-db initialized
+db/initialized
 
 # Start with clean state.
-db cmp services services_empty.table
-db cmp ciliumenvoyconfigs cec_empty.table
+db/cmp services services_empty.table
+db/cmp ciliumenvoyconfigs cec_empty.table
 
 # Set up the services and endpoints
 k8s add service.yaml endpointslice.yaml
-db cmp services services.table
+db/cmp services services.table
 
 # Add the CiliumEnvoyConfig and wait for it to be ingested.
 k8s add cec.yaml
-db cmp ciliumenvoyconfigs cec.table
+db/cmp ciliumenvoyconfigs cec.table
 
 # Check that both services are now redirected to proxy.
-db cmp services services_redirected.table
+db/cmp services services_redirected.table
 
 # Check BPF maps. The service should have L7 redirect set.
-lb-maps dump lbmaps.out
+lbmaps/dump lbmaps.out
 * cmp lbmaps.out lbmaps.expected
 
 # Check that right updates towards Envoy happened.
@@ -37,11 +37,11 @@ envoy envoy.out
 
 # Drop the service
 k8s delete service.yaml
-db cmp services services_empty.table
+db/cmp services services_empty.table
 
 # Add back the service and endpoints
 k8s add service.yaml endpointslice.yaml
-db cmp services services_redirected.table
+db/cmp services services_redirected.table
 
 # Check again that updates happened.
 envoy envoy.out
@@ -49,8 +49,8 @@ envoy envoy.out
 
 # Cleanup. Remove CEC and check that proxy redirect is gone.
 k8s delete cec.yaml
-db cmp services services.table
-db cmp ciliumenvoyconfigs cec_empty.table
+db/cmp services services.table
+db/cmp ciliumenvoyconfigs cec_empty.table
 
 # The listener should now be deleted.
 envoy envoy.out

--- a/pkg/ciliumenvoyconfig/testdata/anyport.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/anyport.txtar
@@ -20,7 +20,7 @@ db/cmp ciliumenvoyconfigs cec.table
 db/cmp services services_redirected.table
 
 # Check BPF maps. The service should have L7 redirect set.
-lbmaps/dump lbmaps.out
+lb/maps-dump lbmaps.out
 * cmp lbmaps.out lbmaps.expected
 
 # Check that right updates towards Envoy happened.

--- a/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
@@ -2,22 +2,22 @@
 
 # Start the hive and wait for tables to be synchronized before adding k8s objects.
 hive start
-db initialized
+db/initialized
 
 # Start with clean state.
-db cmp services services_empty.table
-db cmp ciliumenvoyconfigs cec_empty.table
+db/cmp services services_empty.table
+db/cmp ciliumenvoyconfigs cec_empty.table
 
 # Set up the services and endpoints
 k8s add service.yaml endpointslice.yaml
-db cmp services services.table
+db/cmp services services.table
 
 # Add the CiliumClusterwideEnvoyConfig and wait for it to be ingested.
 k8s add ccec.yaml
-db cmp ciliumenvoyconfigs cec.table
+db/cmp ciliumenvoyconfigs cec.table
 
 # Check that both services are now redirected to proxy.
-db cmp services services_redirected.table
+db/cmp services services_redirected.table
 
 # Check that right updates towards Envoy happened.
 envoy envoy.out
@@ -26,7 +26,7 @@ envoy envoy.out
 # Test the processing other way around, e.g. CEC exists before
 # the service.
 k8s delete service.yaml endpointslice.yaml
-db cmp services services_empty.table
+db/cmp services services_empty.table
 
 # Backends towards Envoy should be updated.
 envoy envoy.out
@@ -34,7 +34,7 @@ envoy envoy.out
 
 # Add back the service and endpoints
 k8s add service.yaml endpointslice.yaml
-db cmp services services_redirected.table
+db/cmp services services_redirected.table
 
 # Check again that updates happened.
 envoy envoy.out
@@ -42,8 +42,8 @@ envoy envoy.out
 
 # Cleanup. Remove CEC and check that proxy redirect is gone.
 k8s delete ccec.yaml
-db cmp services services.table
-db cmp ciliumenvoyconfigs cec_empty.table
+db/cmp services services.table
+db/cmp ciliumenvoyconfigs cec_empty.table
 
 # The listener should now be deleted.
 envoy envoy.out

--- a/pkg/ciliumenvoyconfig/testdata/labels.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/labels.txtar
@@ -2,7 +2,7 @@
 
 # Start the hive and wait for tables to be synchronized before adding k8s objects.
 hive start
-db initialized
+db/initialized
 
 set-node-labels foo=a
 
@@ -10,7 +10,7 @@ set-node-labels foo=a
 k8s add cec_a.yaml cec_b.yaml
 
 # CEC with foo=a should be selected.
-db cmp ciliumenvoyconfigs cec_a.table
+db/cmp ciliumenvoyconfigs cec_a.table
 envoy envoy.out
 * cmp envoy.out envoy_a.expected
 
@@ -18,7 +18,7 @@ envoy envoy.out
 set-node-labels foo=b
 
 # CEC with foo=b should be selected.
-db cmp ciliumenvoyconfigs cec_b.table
+db/cmp ciliumenvoyconfigs cec_b.table
 envoy envoy.out
 * cmp envoy.out envoy_b.expected
 

--- a/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
@@ -2,25 +2,25 @@
 
 # Start the hive and wait for tables to be synchronized before adding k8s objects.
 hive start
-db initialized
+db/initialized
 
 # Start with clean state.
-db cmp services services_empty.table
-db cmp ciliumenvoyconfigs cec_empty.table
+db/cmp services services_empty.table
+db/cmp ciliumenvoyconfigs cec_empty.table
 
 # Set up the services and endpoints
 k8s add service.yaml endpointslice.yaml
-db cmp services services.table
+db/cmp services services.table
 
 # Add the CiliumEnvoyConfig and wait for it to be ingested.
 k8s add cec.yaml
-db cmp ciliumenvoyconfigs cec.table
+db/cmp ciliumenvoyconfigs cec.table
 
 # Check that both services are now redirected to proxy.
-db cmp services services_redirected.table
+db/cmp services services_redirected.table
 
 # Check BPF maps. The service should have L7 redirect set.
-lb-maps dump lbmaps.out
+lbmaps/dump lbmaps.out
 * cmp lbmaps.out lbmaps.expected
 
 # Check that right updates towards Envoy happened.
@@ -37,11 +37,11 @@ envoy envoy.out
 
 # Drop the service
 k8s delete service.yaml
-db cmp services services_empty.table
+db/cmp services services_empty.table
 
 # Add back the service and endpoints
 k8s add service.yaml endpointslice.yaml
-db cmp services services_redirected.table
+db/cmp services services_redirected.table
 
 # Check again that updates happened.
 envoy envoy.out
@@ -49,8 +49,8 @@ envoy envoy.out
 
 # Cleanup. Remove CEC and check that proxy redirect is gone.
 k8s delete cec.yaml
-db cmp services services.table
-db cmp ciliumenvoyconfigs cec_empty.table
+db/cmp services services.table
+db/cmp ciliumenvoyconfigs cec_empty.table
 
 # The listener should now be deleted.
 envoy envoy.out

--- a/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
@@ -20,7 +20,7 @@ db/cmp ciliumenvoyconfigs cec.table
 db/cmp services services_redirected.table
 
 # Check BPF maps. The service should have L7 redirect set.
-lbmaps/dump lbmaps.out
+lb/maps-dump lbmaps.out
 * cmp lbmaps.out lbmaps.expected
 
 # Check that right updates towards Envoy happened.

--- a/pkg/k8s/statedb.go
+++ b/pkg/k8s/statedb.go
@@ -106,7 +106,7 @@ type ReflectorConfig[Obj any] struct {
 
 	// Optional function to transform the objects given by the ListerWatcher. This can
 	// be used to convert into an internal model on the fly to save space and add additional
-	// fields or to for example implement TableRow/TableHeader for the "db show" command.
+	// fields or to for example implement TableRow/TableHeader for the "db/show" command.
 	Transform TransformFunc[Obj]
 
 	// Optional function to transform the object to a set of objects to insert into the table.

--- a/pkg/loadbalancer/experimental/README.md
+++ b/pkg/loadbalancer/experimental/README.md
@@ -62,7 +62,7 @@ Once running the state can be inspected with:
   > db/show backends
   > db/show services
   > db/prefix health agent.controlplane.loadbalancer-experimental
-  > lb-maps dump
+  > lbmaps/dump
 ```
 ## Integration testing
 

--- a/pkg/loadbalancer/experimental/README.md
+++ b/pkg/loadbalancer/experimental/README.md
@@ -58,10 +58,10 @@ BPF maps which are instead done by the experimental control-plane.
 Once running the state can be inspected with:
 ```
   $ cilium-dbg shell 
-  > db show frontends
-  > db show backends
-  > db show services
-  > db prefix health agent.controlplane.loadbalancer-experimental
+  > db/show frontends
+  > db/show backends
+  > db/show services
+  > db/prefix health agent.controlplane.loadbalancer-experimental
   > lb-maps dump
 ```
 ## Integration testing

--- a/pkg/loadbalancer/experimental/backend.go
+++ b/pkg/loadbalancer/experimental/backend.go
@@ -287,7 +287,10 @@ var (
 	BackendByServiceName = backendServiceIndex.Query
 )
 
-func NewBackendsTable(db *statedb.DB) (statedb.RWTable[*Backend], error) {
+func NewBackendsTable(cfg Config, db *statedb.DB) (statedb.RWTable[*Backend], error) {
+	if !cfg.EnableExperimentalLB {
+		return nil, nil
+	}
 	tbl, err := statedb.NewTable(
 		BackendTableName,
 		backendAddrIndex,

--- a/pkg/loadbalancer/experimental/bpf_reconciler.go
+++ b/pkg/loadbalancer/experimental/bpf_reconciler.go
@@ -12,9 +12,7 @@ import (
 	"net/netip"
 	"sort"
 
-	"github.com/cilium/hive"
 	"github.com/cilium/hive/cell"
-	"github.com/cilium/hive/script"
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/reconciler"
 	"golang.org/x/sys/unix"
@@ -46,11 +44,11 @@ var ReconcilerCell = cell.Module(
 	),
 )
 
-func newBPFReconciler(p reconciler.Params, cfg Config, ops *BPFOps, w *Writer) (reconciler.Reconciler[*Frontend], hive.ScriptCmdOut, error) {
+func newBPFReconciler(p reconciler.Params, cfg Config, ops *BPFOps, w *Writer) (reconciler.Reconciler[*Frontend], error) {
 	if !w.IsEnabled() {
-		return nil, hive.ScriptCmdOut{}, nil
+		return nil, nil
 	}
-	r, err := reconciler.Register(
+	return reconciler.Register(
 		p,
 		w.fes,
 
@@ -69,20 +67,6 @@ func newBPFReconciler(p reconciler.Params, cfg Config, ops *BPFOps, w *Writer) (
 			30*time.Minute,
 		),
 	)
-	if err != nil {
-		return nil, hive.ScriptCmdOut{}, err
-	}
-	cmd := hive.NewScriptCmd(
-		"lb-prune",
-		script.Command(
-			script.CmdUsage{Summary: "Force pruning of LB maps"},
-			func(s *script.State, args ...string) (script.WaitFunc, error) {
-				r.Prune()
-				return nil, nil
-			},
-		),
-	)
-	return r, cmd, err
 }
 
 type BPFOps struct {

--- a/pkg/loadbalancer/experimental/cell.go
+++ b/pkg/loadbalancer/experimental/cell.go
@@ -37,7 +37,9 @@ var Cell = cell.Module(
 
 	// Provide [lbmaps], abstraction for the load-balancing BPF map access.
 	cell.ProvidePrivate(newLBMaps, newLBMapsConfig),
-	cell.Provide(newLBMapsCommand),
+
+	// Provide the 'lb/' script commands for debugging and testing.
+	cell.Provide(scriptCommands),
 )
 
 // TablesCell provides the [Writer] API for configuring load-balancing and the

--- a/pkg/loadbalancer/experimental/cell.go
+++ b/pkg/loadbalancer/experimental/cell.go
@@ -60,11 +60,18 @@ var TablesCell = cell.Module(
 		NewWriter,
 
 		// Provide direct read-only access to the tables.
-		statedb.RWTable[*Service].ToTable,
-		statedb.RWTable[*Frontend].ToTable,
-		statedb.RWTable[*Backend].ToTable,
+		toReadOnlyTable[*Service],
+		toReadOnlyTable[*Frontend],
+		toReadOnlyTable[*Backend],
 	),
 )
+
+func toReadOnlyTable[T any](tbl statedb.RWTable[T]) statedb.Table[T] {
+	if tbl == nil {
+		return nil
+	}
+	return tbl
+}
 
 type resourceIn struct {
 	cell.In

--- a/pkg/loadbalancer/experimental/cell_test.go
+++ b/pkg/loadbalancer/experimental/cell_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/source"
 )
 
 // TestCell checks that 'Cell' can be instantiated with the defaults and it
@@ -26,6 +27,7 @@ func TestCell(t *testing.T) {
 		client.FakeClientCell,
 		daemonk8s.ResourcesCell,
 		Cell,
+		cell.Provide(source.NewSources),
 		cell.Provide(
 			tables.NewNodeAddressTable,
 			statedb.RWTable[tables.NodeAddress].ToTable,

--- a/pkg/loadbalancer/experimental/cell_test.go
+++ b/pkg/loadbalancer/experimental/cell_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package experimental
+
+import (
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/require"
+
+	daemonk8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// TestCell checks that 'Cell' can be instantiated with the defaults and it
+// also shows what are the minimal dependencies to it for testing.
+func TestCell(t *testing.T) {
+
+	h := hive.New(
+		client.FakeClientCell,
+		daemonk8s.ResourcesCell,
+		Cell,
+		cell.Provide(
+			tables.NewNodeAddressTable,
+			statedb.RWTable[tables.NodeAddress].ToTable,
+			func() *option.DaemonConfig {
+				return &option.DaemonConfig{}
+			},
+		),
+		cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
+	)
+	require.NoError(t, h.Populate(hivetest.Logger(t)))
+}

--- a/pkg/loadbalancer/experimental/cmds.go
+++ b/pkg/loadbalancer/experimental/cmds.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package experimental
+
+import (
+	"os"
+	"strings"
+
+	"github.com/cilium/hive"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/statedb/reconciler"
+
+	"github.com/cilium/cilium/pkg/loadbalancer"
+)
+
+func scriptCommands(cfg Config, m LBMaps, r reconciler.Reconciler[*Frontend]) hive.ScriptCmdsOut {
+	if !cfg.EnableExperimentalLB {
+		return hive.ScriptCmdsOut{}
+	}
+
+	var snapshot mapSnapshots
+	return hive.NewScriptCmds(map[string]script.Cmd{
+		"lb/prune": script.Command(
+			script.CmdUsage{Summary: "Trigger pruning of load-balancing BPF maps"},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				r.Prune()
+				return nil, nil
+			},
+		),
+		"lb/maps-dump":     lbmapDumpCommand(m),
+		"lb/maps-snapshot": lbmapSnapshotCommand(m, &snapshot),
+		"lb/maps-restore":  lbmapRestoreCommand(m, &snapshot),
+	})
+}
+
+func lbmapDumpCommand(m LBMaps) script.Cmd {
+	if f, ok := m.(*FaultyLBMaps); ok {
+		m = f.impl
+	}
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Dump the load-balancing BPF maps",
+			Args:    "(output file)",
+			Detail: []string{
+				"This dumps the load-balancer BPF maps either to stdout or to a file.",
+				"Each BPF map key-value is shown as one line, e.g. backend would be:",
+				"BE: ID=1 ADDR=10.244.1.1:80 STATE=active",
+				"",
+				"Format is not guaranteed to be stable as this command is only",
+				"for testing and debugging purposes.",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			return func(s *script.State) (stdout string, stderr string, err error) {
+				out := DumpLBMaps(
+					m,
+					loadbalancer.L3n4Addr{},
+					false,
+					nil,
+				)
+				data := strings.Join(out, "\n") + "\n"
+				if len(args) == 1 {
+					err = os.WriteFile(s.Path(args[0]), []byte(data), 0644)
+				} else {
+					stdout = data
+				}
+				return
+			}, nil
+		},
+	)
+}
+
+func lbmapSnapshotCommand(m LBMaps, snapshot *mapSnapshots) script.Cmd {
+	if f, ok := m.(*FaultyLBMaps); ok {
+		m = f.impl
+	}
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Snapshot the load-balancing BPF maps",
+			Args:    "",
+			Detail: []string{
+				"Dump the load-balancing BPF maps into an in-memory snapshot",
+				"which can be restored with lbmaps/restore. This is meant only",
+				"for testing.",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			return nil, snapshot.snapshot(m)
+		},
+	)
+}
+
+func lbmapRestoreCommand(m LBMaps, snapshot *mapSnapshots) script.Cmd {
+	if f, ok := m.(*FaultyLBMaps); ok {
+		m = f.impl
+	}
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Restore the load-balancing BPF maps from snapshot",
+			Args:    "",
+			Detail: []string{
+				"Restore the load-balancing BPF map contents from a snapshot",
+				"created with lbmaps/snapshot.",
+				"The BPF maps are not cleared before restoring, so any existing",
+				"values will not be removed.",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			return nil, snapshot.restore(m)
+		},
+	)
+}

--- a/pkg/loadbalancer/experimental/frontend.go
+++ b/pkg/loadbalancer/experimental/frontend.go
@@ -168,7 +168,10 @@ const (
 	FrontendTableName = "frontends"
 )
 
-func NewFrontendsTable(db *statedb.DB) (statedb.RWTable[*Frontend], error) {
+func NewFrontendsTable(cfg Config, db *statedb.DB) (statedb.RWTable[*Frontend], error) {
+	if !cfg.EnableExperimentalLB {
+		return nil, nil
+	}
 	tbl, err := statedb.NewTable(
 		FrontendTableName,
 		frontendAddressIndex,

--- a/pkg/loadbalancer/experimental/service.go
+++ b/pkg/loadbalancer/experimental/service.go
@@ -187,7 +187,10 @@ const (
 	ServiceTableName = "services"
 )
 
-func NewServicesTable(db *statedb.DB) (statedb.RWTable[*Service], error) {
+func NewServicesTable(cfg Config, db *statedb.DB) (statedb.RWTable[*Service], error) {
+	if !cfg.EnableExperimentalLB {
+		return nil, nil
+	}
 	tbl, err := statedb.NewTable(
 		ServiceTableName,
 		serviceNameIndex,

--- a/pkg/loadbalancer/experimental/testdata/clusterip.txtar
+++ b/pkg/loadbalancer/experimental/testdata/clusterip.txtar
@@ -4,20 +4,20 @@
 hive start
 
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db initialized
+db/initialized
 
 k8s add service.yaml endpointslice.yaml
-db cmp services services.table
-db cmp frontends frontends.table
-db cmp backends backends.table 
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table 
 
 lb-maps cmp lbmaps.dump
 
 # Cleanup
 k8s delete service.yaml endpointslice.yaml 
-db cmp services services_empty.table
-db cmp frontends frontends_empty.table
-db cmp backends backends_empty.table
+db/cmp services services_empty.table
+db/cmp frontends frontends_empty.table
+db/cmp backends backends_empty.table
 
 #####
 

--- a/pkg/loadbalancer/experimental/testdata/clusterip.txtar
+++ b/pkg/loadbalancer/experimental/testdata/clusterip.txtar
@@ -11,7 +11,9 @@ db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table 
 
-lb-maps cmp lbmaps.dump
+# Check the BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
 
 # Cleanup
 k8s delete service.yaml endpointslice.yaml 
@@ -98,7 +100,7 @@ ports:
   port: 80
   protocol: TCP
 
--- lbmaps.dump --
+-- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80 STATE=active
 REV: ID=1 ADDR=10.96.50.104:80
 SVC: ID=1 ADDR=10.96.50.104:80 SLOT=0 BEID=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable

--- a/pkg/loadbalancer/experimental/testdata/dualstack-maglev.txtar
+++ b/pkg/loadbalancer/experimental/testdata/dualstack-maglev.txtar
@@ -4,31 +4,31 @@
 # frontends from single service.
 
 # Add some node addresses
-db insert node-addresses addrv4.yaml addrv6.yaml
-db cmp node-addresses nodeaddrs.table
+db/insert node-addresses addrv4.yaml addrv6.yaml
+db/cmp node-addresses nodeaddrs.table
 
 # Start the test application
 hive start
 
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db initialized
+db/initialized
 
 # For determinism, add the IPv4 endpoints first and wait for reconciliation (for ID alloc)
 # and then do IPv6.
 k8s add service.yaml endpointslice-ipv4.yaml
-db cmp frontends frontends-ipv4.table
+db/cmp frontends frontends-ipv4.table
 k8s add endpointslice-ipv6.yaml
-db cmp services services.table
-db cmp frontends frontends.table
-db cmp backends backends.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table
 
 lb-maps cmp lbmaps.dump
 
 # Cleanup
 k8s delete service.yaml endpointslice-ipv4.yaml endpointslice-ipv6.yaml
-db cmp services services_empty.table
-db cmp frontends frontends_empty.table
-db cmp backends backends_empty.table
+db/cmp services services_empty.table
+db/cmp frontends frontends_empty.table
+db/cmp backends backends_empty.table
 
 #####
 

--- a/pkg/loadbalancer/experimental/testdata/dualstack-maglev.txtar
+++ b/pkg/loadbalancer/experimental/testdata/dualstack-maglev.txtar
@@ -22,7 +22,9 @@ db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table
 
-lb-maps cmp lbmaps.dump
+# Check the BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
 
 # Cleanup
 k8s delete service.yaml endpointslice-ipv4.yaml endpointslice-ipv6.yaml
@@ -248,7 +250,7 @@ ports:
   port: 69
   protocol: UDP
 
--- lbmaps.dump --
+-- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.54:80 STATE=active
 BE: ID=2 ADDR=10.244.2.9:80 STATE=active
 BE: ID=3 ADDR=10.244.1.54:69 STATE=active

--- a/pkg/loadbalancer/experimental/testdata/dualstack.txtar
+++ b/pkg/loadbalancer/experimental/testdata/dualstack.txtar
@@ -21,7 +21,9 @@ db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table 
 
-lb-maps cmp lbmaps.dump
+# Check the BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
 
 # Cleanup
 k8s delete service.yaml endpointslice-ipv4.yaml endpointslice-ipv6.yaml
@@ -247,7 +249,7 @@ ports:
   port: 69
   protocol: UDP
 
--- lbmaps.dump --
+-- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.54:80 STATE=active
 BE: ID=2 ADDR=10.244.2.9:80 STATE=active
 BE: ID=3 ADDR=10.244.1.54:69 STATE=active

--- a/pkg/loadbalancer/experimental/testdata/dualstack.txtar
+++ b/pkg/loadbalancer/experimental/testdata/dualstack.txtar
@@ -3,31 +3,31 @@
 # frontends from single service.
 
 # Add some node addresses
-db insert node-addresses addrv4.yaml addrv6.yaml
-db cmp node-addresses nodeaddrs.table
+db/insert node-addresses addrv4.yaml addrv6.yaml
+db/cmp node-addresses nodeaddrs.table
 
 # Start the test application
 hive start
 
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db initialized
+db/initialized
 
 # For determinism, add the IPv4 endpoints first and wait for reconciliation (for ID alloc)
 # and then do IPv6.
 k8s add service.yaml endpointslice-ipv4.yaml
-db cmp frontends frontends-ipv4.table
+db/cmp frontends frontends-ipv4.table
 k8s add endpointslice-ipv6.yaml
-db cmp services services.table
-db cmp frontends frontends.table
-db cmp backends backends.table 
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table 
 
 lb-maps cmp lbmaps.dump
 
 # Cleanup
 k8s delete service.yaml endpointslice-ipv4.yaml endpointslice-ipv6.yaml
-db cmp services services_empty.table
-db cmp frontends frontends_empty.table
-db cmp backends backends_empty.table
+db/cmp services services_empty.table
+db/cmp frontends frontends_empty.table
+db/cmp backends backends_empty.table
 
 #####
 

--- a/pkg/loadbalancer/experimental/testdata/graceful-termination.txtar
+++ b/pkg/loadbalancer/experimental/testdata/graceful-termination.txtar
@@ -11,14 +11,18 @@ db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table
 
-lb-maps cmp lbmaps-active.dump
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps-active.expected lbmaps.actual
 
 # Set the backend as terminating
 k8s update endpointslice-terminating.yaml
 db/cmp frontends frontends-terminating.table
 db/cmp backends backends-terminating.table
 
-lb-maps cmp lbmaps-terminating.dump
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps-terminating.expected lbmaps.actual
 
 # Cleanup
 k8s delete service.yaml endpointslice.yaml 
@@ -168,12 +172,12 @@ ports:
   port: 8081
   protocol: TCP
 
--- lbmaps-active.dump --
+-- lbmaps-active.expected --
 BE: ID=1 ADDR=10.244.0.112:8081 STATE=active
 REV: ID=1 ADDR=10.96.116.33:8081
 SVC: ID=1 ADDR=10.96.116.33:8081 SLOT=0 BEID=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=1 ADDR=10.96.116.33:8081 SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
--- lbmaps-terminating.dump --
+-- lbmaps-terminating.expected --
 BE: ID=1 ADDR=10.244.0.112:8081 STATE=terminating
 REV: ID=1 ADDR=10.96.116.33:8081
 SVC: ID=1 ADDR=10.96.116.33:8081 SLOT=0 BEID=0 COUNT=0 QCOUNT=1 FLAGS=ClusterIP+non-routable

--- a/pkg/loadbalancer/experimental/testdata/graceful-termination.txtar
+++ b/pkg/loadbalancer/experimental/testdata/graceful-termination.txtar
@@ -4,27 +4,27 @@
 hive start
 
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db initialized
+db/initialized
 
 k8s add service.yaml endpointslice.yaml
-db cmp services services.table
-db cmp frontends frontends.table
-db cmp backends backends.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table
 
 lb-maps cmp lbmaps-active.dump
 
 # Set the backend as terminating
 k8s update endpointslice-terminating.yaml
-db cmp frontends frontends-terminating.table
-db cmp backends backends-terminating.table
+db/cmp frontends frontends-terminating.table
+db/cmp backends backends-terminating.table
 
 lb-maps cmp lbmaps-terminating.dump
 
 # Cleanup
 k8s delete service.yaml endpointslice.yaml 
-db cmp services services_empty.table
-db cmp frontends frontends_empty.table
-db cmp backends backends_empty.table
+db/cmp services services_empty.table
+db/cmp frontends frontends_empty.table
+db/cmp backends backends_empty.table
 
 #####
 

--- a/pkg/loadbalancer/experimental/testdata/hostport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/hostport.txtar
@@ -14,7 +14,9 @@ db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table 
 
-lb-maps cmp lbmaps.dump
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
 
 # Cleanup
 k8s delete pod.yaml
@@ -102,7 +104,7 @@ status:
   qosClass: BestEffort
   startTime: "2024-07-10T16:20:42Z"
 
--- lbmaps.dump --
+-- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.113:80 STATE=active
 REV: ID=1 ADDR=<zero>
 REV: ID=2 ADDR=1.1.1.1:4444

--- a/pkg/loadbalancer/experimental/testdata/hostport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/hostport.txtar
@@ -1,26 +1,26 @@
 #! --enable-experimental-lb
 
-db insert node-addresses addrv4.yaml
-db cmp node-addresses nodeaddrs.table
+db/insert node-addresses addrv4.yaml
+db/cmp node-addresses nodeaddrs.table
 
 # Start the test application
 hive start
 
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db initialized
+db/initialized
 
 k8s add pod.yaml 
-db cmp services services.table
-db cmp frontends frontends.table
-db cmp backends backends.table 
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table 
 
 lb-maps cmp lbmaps.dump
 
 # Cleanup
 k8s delete pod.yaml
-db cmp services services_empty.table
-db cmp frontends frontends_empty.table
-db cmp backends backends_empty.table
+db/cmp services services_empty.table
+db/cmp frontends frontends_empty.table
+db/cmp backends backends_empty.table
 
 #####
 

--- a/pkg/loadbalancer/experimental/testdata/multiport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/multiport.txtar
@@ -11,7 +11,9 @@ db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table 
 
-lb-maps cmp lbmaps.dump
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
 
 # Cleanup
 k8s delete service.yaml endpointslice.yaml 
@@ -108,7 +110,7 @@ ports:
   port: 443
   protocol: TCP
 
--- lbmaps.dump --
+-- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80 STATE=active
 BE: ID=2 ADDR=10.244.1.1:443 STATE=active
 REV: ID=1 ADDR=10.96.50.104:80

--- a/pkg/loadbalancer/experimental/testdata/multiport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/multiport.txtar
@@ -4,20 +4,20 @@
 hive start
 
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db initialized
+db/initialized
 
 k8s add service.yaml endpointslice.yaml
-db cmp services services.table
-db cmp frontends frontends.table
-db cmp backends backends.table 
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table 
 
 lb-maps cmp lbmaps.dump
 
 # Cleanup
 k8s delete service.yaml endpointslice.yaml 
-db cmp services services_empty.table
-db cmp frontends frontends_empty.table
-db cmp backends backends_empty.table
+db/cmp services services_empty.table
+db/cmp frontends frontends_empty.table
+db/cmp backends backends_empty.table
 
 #####
 

--- a/pkg/loadbalancer/experimental/testdata/nodeport-maglev.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport-maglev.txtar
@@ -25,7 +25,9 @@ db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table
 
-lb-maps cmp lbmaps.dump
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
 
 # Cleanup. Backends first in this test.
 k8s delete endpointslice.yaml endpointslice2.yaml
@@ -35,6 +37,10 @@ db/cmp frontends frontends_nobackends.table
 k8s delete service.yaml service2.yaml
 db/cmp frontends frontends_empty.table
 db/cmp services services_empty.table
+
+# Check that BPF maps are empty
+lb/maps-dump lbmaps.actual
+* cmp lbmaps-empty.expected lbmaps.actual
 
 #####
 
@@ -93,7 +99,7 @@ Address             State    Instances            NodeName           ZoneID
 -- backends_empty.table --
 Address             State    Instances            NodeName           ZoneID
 
--- lbmaps.dump --
+-- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80 STATE=active
 BE: ID=2 ADDR=10.244.1.2:80 STATE=active
 BE: ID=3 ADDR=10.244.1.3:80 STATE=active
@@ -144,6 +150,8 @@ SVC: ID=6 ADDR=1.1.1.1:30782 SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=NodePort
 SVC: ID=6 ADDR=1.1.1.1:30782 SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=NodePort
 SVC: ID=6 ADDR=1.1.1.1:30782 SLOT=3 BEID=7 COUNT=0 QCOUNT=0 FLAGS=NodePort
 SVC: ID=6 ADDR=1.1.1.1:30782 SLOT=4 BEID=8 COUNT=0 QCOUNT=0 FLAGS=NodePort
+-- lbmaps-empty.expected --
+
 -- service.yaml --
 apiVersion: v1
 kind: Service

--- a/pkg/loadbalancer/experimental/testdata/nodeport-maglev.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport-maglev.txtar
@@ -1,8 +1,8 @@
 #! --enable-experimental-lb --node-port-algorithm=maglev
 
 # Add some node addresses
-db insert node-addresses addrv4.yaml
-db cmp node-addresses nodeaddrs.table
+db/insert node-addresses addrv4.yaml
+db/cmp node-addresses nodeaddrs.table
 
 # Add the first service before starting (List() path)
 k8s add service.yaml endpointslice.yaml
@@ -13,28 +13,28 @@ hive start
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
 # (otherwise might miss events due to List() vs Watch() race in fake client).
 # NOTE: The 100ms delay you might see is from WaitForCacheSync polling at 100ms.
-db initialized
+db/initialized
 
 # First frontends should exist and be reconciled. Need to wait for reconciliation to
 # have the ID assigned.
-db cmp frontends frontends1.table
+db/cmp frontends frontends1.table
 
 k8s add service2.yaml endpointslice2.yaml
 
-db cmp services services.table
-db cmp frontends frontends.table
-db cmp backends backends.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table
 
 lb-maps cmp lbmaps.dump
 
 # Cleanup. Backends first in this test.
 k8s delete endpointslice.yaml endpointslice2.yaml
-db cmp backends backends_empty.table
-db cmp frontends frontends_nobackends.table
+db/cmp backends backends_empty.table
+db/cmp frontends frontends_nobackends.table
 
 k8s delete service.yaml service2.yaml
-db cmp frontends frontends_empty.table
-db cmp services services_empty.table
+db/cmp frontends frontends_empty.table
+db/cmp services services_empty.table
 
 #####
 

--- a/pkg/loadbalancer/experimental/testdata/nodeport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport.txtar
@@ -1,8 +1,8 @@
 #! --enable-experimental-lb
 
 # Add some node addresses
-db insert node-addresses addrv4.yaml
-db cmp node-addresses nodeaddrs.table
+db/insert node-addresses addrv4.yaml
+db/cmp node-addresses nodeaddrs.table
 
 # Add the first service before starting (List() path)
 k8s add service.yaml endpointslice.yaml
@@ -13,28 +13,28 @@ hive start
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
 # (otherwise might miss events due to List() vs Watch() race in fake client).
 # NOTE: The 100ms delay you might see is from WaitForCacheSync polling at 100ms.
-db initialized
+db/initialized
 
 # First frontends should exist and be reconciled. Need to wait for reconciliation to
 # have the ID assigned.
-db cmp frontends frontends1.table
+db/cmp frontends frontends1.table
 
 k8s add service2.yaml endpointslice2.yaml
 
-db cmp services services.table
-db cmp frontends frontends.table
-db cmp backends backends.table 
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table 
 
 lb-maps cmp  lbmaps.dump
 
 # Cleanup. Backends first in this test.
 k8s delete endpointslice.yaml endpointslice2.yaml
-db cmp backends backends_empty.table
-db cmp frontends frontends_nobackends.table
+db/cmp backends backends_empty.table
+db/cmp frontends frontends_nobackends.table
 
 k8s delete service.yaml service2.yaml
-db cmp frontends frontends_empty.table
-db cmp services services_empty.table
+db/cmp frontends frontends_empty.table
+db/cmp services services_empty.table
 
 #####
 

--- a/pkg/loadbalancer/experimental/testdata/nodeport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport.txtar
@@ -25,7 +25,9 @@ db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table 
 
-lb-maps cmp  lbmaps.dump
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
 
 # Cleanup. Backends first in this test.
 k8s delete endpointslice.yaml endpointslice2.yaml
@@ -93,7 +95,7 @@ Address             State    Instances            NodeName           ZoneID
 -- backends_empty.table --
 Address             State    Instances            NodeName           ZoneID
 
--- lbmaps.dump --
+-- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80 STATE=active
 BE: ID=2 ADDR=10.244.1.2:80 STATE=active
 BE: ID=3 ADDR=10.244.1.3:80 STATE=active

--- a/pkg/loadbalancer/experimental/testdata/pruning.txtar
+++ b/pkg/loadbalancer/experimental/testdata/pruning.txtar
@@ -4,12 +4,12 @@
 hive start
 
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db initialized
+db/initialized
 
 k8s add service.yaml endpointslice.yaml
-db cmp services services.table
-db cmp frontends frontends.table
-db cmp backends backends.table 
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table 
 
 lb-maps cmp lbmaps.dump
 
@@ -23,9 +23,9 @@ lb-maps snapshot
 
 # Cleanup
 k8s delete service.yaml endpointslice.yaml 
-db cmp services services_empty.table
-db cmp frontends frontends_empty.table
-db cmp backends backends_empty.table
+db/cmp services services_empty.table
+db/cmp frontends frontends_empty.table
+db/cmp backends backends_empty.table
 
 # Maps should be empty now.
 lb-maps cmp lbmaps-empty.dump

--- a/pkg/loadbalancer/experimental/testdata/pruning.txtar
+++ b/pkg/loadbalancer/experimental/testdata/pruning.txtar
@@ -11,15 +11,18 @@ db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table 
 
-lb-maps cmp lbmaps.dump
+# Check that BPF maps are reconciled
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
 
 # Run prune. Nothing should change.
-lb-prune
+lb/prune
 sleep 0.1s
-lb-maps cmp lbmaps.dump
+lb/maps-dump lbmaps.actual
+cmp lbmaps.expected lbmaps.actual
 
 # Snapshot the contents of the maps so we have something to prune.
-lb-maps snapshot
+lb/maps-snapshot
 
 # Cleanup
 k8s delete service.yaml endpointslice.yaml 
@@ -28,15 +31,20 @@ db/cmp frontends frontends_empty.table
 db/cmp backends backends_empty.table
 
 # Maps should be empty now.
-lb-maps cmp lbmaps-empty.dump
+lb/maps-dump lbmaps.actual
+* cmp lbmaps-empty.expected lbmaps.actual
 
 # Restore the contents from the earlier snapshot.
-lb-maps restore
-lb-maps cmp lbmaps.dump
+lb/maps-restore
+lb/maps-dump lbmaps.actual
+cmp lbmaps.expected lbmaps.actual
 
 # Force pruning. This should clean up everything.
-lb-prune
-lb-maps cmp lbmaps-empty.dump
+lb/prune
+
+# Check that everything gets cleaned up
+lb/maps-dump lbmaps.actual
+* cmp lbmaps-empty.expected lbmaps.actual
 
 #####
 
@@ -117,10 +125,10 @@ ports:
   port: 80
   protocol: TCP
 
--- lbmaps.dump --
+-- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80 STATE=active
 REV: ID=1 ADDR=10.96.50.104:80
 SVC: ID=1 ADDR=10.96.50.104:80 SLOT=0 BEID=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=1 ADDR=10.96.50.104:80 SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
--- lbmaps-empty.dump --
+-- lbmaps-empty.expected --
 

--- a/pkg/loadbalancer/experimental/testdata/source-ranges.txtar
+++ b/pkg/loadbalancer/experimental/testdata/source-ranges.txtar
@@ -4,20 +4,20 @@
 hive start
 
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
-db initialized
+db/initialized
 
 k8s add service.yaml endpointslice.yaml
-db cmp services services.table
-db cmp frontends frontends.table
-db cmp backends backends.table 
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table 
 
 lb-maps cmp lbmaps.dump
 
 # Cleanup
 k8s delete service.yaml endpointslice.yaml 
-db cmp services services_empty.table
-db cmp frontends frontends_empty.table
-db cmp backends backends_empty.table
+db/cmp services services_empty.table
+db/cmp frontends frontends_empty.table
+db/cmp backends backends_empty.table
 
 #####
 

--- a/pkg/loadbalancer/experimental/testdata/source-ranges.txtar
+++ b/pkg/loadbalancer/experimental/testdata/source-ranges.txtar
@@ -11,7 +11,8 @@ db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table 
 
-lb-maps cmp lbmaps.dump
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
 
 # Cleanup
 k8s delete service.yaml endpointslice.yaml 
@@ -110,7 +111,7 @@ ports:
   port: 80
   protocol: TCP
 
--- lbmaps.dump --
+-- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80 STATE=active
 REV: ID=1 ADDR=10.0.0.1:80
 REV: ID=2 ADDR=10.0.0.2:80

--- a/pkg/maps/bwmap/cell.go
+++ b/pkg/maps/bwmap/cell.go
@@ -15,7 +15,7 @@ import (
 // Cell manages the cilium_throttle BPF map for implementing per-endpoint
 // bandwidth management. The cell provides RWTable[Edt] to which per
 // endpoint bandwidth limits can be inserted. Use [NewEdt] to create the
-// object. The table can be inspected with "cilium-dbg shell -- db show bandwidth-edts".
+// object. The table can be inspected with "cilium-dbg shell -- db/show bandwidth-edts".
 // A reconciler is registered that reconciles the table with the cilium_throttle
 // map.
 var Cell = cell.Module(

--- a/vendor/github.com/cilium/statedb/part/map.go
+++ b/vendor/github.com/cilium/statedb/part/map.go
@@ -243,9 +243,11 @@ func (m *Map[K, V]) UnmarshalJSON(data []byte) error {
 
 func (m Map[K, V]) MarshalYAML() (any, error) {
 	kvs := make([]mapKVPair[K, V], 0, m.Len())
-	iter := m.tree.Iterator()
-	for _, kv, ok := iter.Next(); ok; _, kv, ok = iter.Next() {
-		kvs = append(kvs, kv)
+	if m.tree != nil {
+		iter := m.tree.Iterator()
+		for _, kv, ok := iter.Next(); ok; _, kv, ok = iter.Next() {
+			kvs = append(kvs, kv)
+		}
 	}
 	return kvs, nil
 }

--- a/vendor/github.com/cilium/statedb/reconciler/incremental.go
+++ b/vendor/github.com/cilium/statedb/reconciler/incremental.go
@@ -174,7 +174,7 @@ func (round *incrementalRound[Obj]) batch(changes iter.Seq2[statedb.Change[Obj],
 			if entry.Result == nil {
 				round.retries.Clear(entry.Object)
 			}
-			round.results[entry.Object] = opResult{rev: entry.Revision, id: status.id, err: entry.Result, original: entry.original}
+			round.results[entry.Object] = opResult{rev: entry.Revision, id: status.ID, err: entry.Result, original: entry.original}
 		}
 	}
 }
@@ -213,7 +213,7 @@ func (round *incrementalRound[Obj]) processSingle(obj Obj, rev statedb.Revision,
 		op = OpUpdate
 		err = round.config.Operations.Update(round.ctx, round.txn, obj)
 		status := round.config.GetObjectStatus(obj)
-		round.results[obj] = opResult{original: orig, id: status.id, rev: rev, err: err}
+		round.results[obj] = opResult{original: orig, id: status.ID, rev: rev, err: err}
 	}
 	round.metrics.ReconciliationDuration(round.moduleID, op, time.Since(start))
 
@@ -256,7 +256,7 @@ func (round *incrementalRound[Obj]) commitStatus() (numErrors int) {
 			// modifying the object during reconciliation as the following will forget
 			// the changes.
 			currentStatus := round.config.GetObjectStatus(current)
-			if currentStatus.Kind == StatusKindPending && currentStatus.id == result.id {
+			if currentStatus.Kind == StatusKindPending && currentStatus.ID == result.id {
 				current = round.config.CloneObject(current)
 				current = round.config.SetObjectStatus(current, status)
 				round.table.Insert(wtxn, current)

--- a/vendor/github.com/cilium/statedb/reconciler/types.go
+++ b/vendor/github.com/cilium/statedb/reconciler/types.go
@@ -140,7 +140,7 @@ type Status struct {
 	// has really changed when committing the resulting status.
 	// This allows multiple reconcilers to exist for a single
 	// object without repeating work when status is updated.
-	id uint64
+	ID uint64 `json:"id,omitempty" yaml:"id,omitempty"`
 }
 
 func (s Status) IsPendingOrRefreshing() bool {
@@ -169,7 +169,7 @@ func StatusPending() Status {
 		Kind:      StatusKindPending,
 		UpdatedAt: time.Now(),
 		Error:     "",
-		id:        nextID(),
+		ID:        nextID(),
 	}
 }
 
@@ -186,7 +186,7 @@ func StatusRefreshing() Status {
 		Kind:      StatusKindRefreshing,
 		UpdatedAt: time.Now(),
 		Error:     "",
-		id:        nextID(),
+		ID:        nextID(),
 	}
 }
 
@@ -197,7 +197,7 @@ func StatusDone() Status {
 		Kind:      StatusKindDone,
 		UpdatedAt: time.Now(),
 		Error:     "",
-		id:        nextID(),
+		ID:        nextID(),
 	}
 }
 
@@ -208,7 +208,7 @@ func StatusError(err error) Status {
 		Kind:      StatusKindError,
 		UpdatedAt: time.Now(),
 		Error:     err.Error(),
-		id:        nextID(),
+		ID:        nextID(),
 	}
 }
 
@@ -249,7 +249,7 @@ func (s StatusSet) Pending() StatusSet {
 	s.statuses = slices.Clone(s.statuses)
 	for i := range s.statuses {
 		s.statuses[i].Kind = StatusKindPending
-		s.statuses[i].id = s.id
+		s.statuses[i].ID = s.id
 	}
 	return s
 }
@@ -331,7 +331,7 @@ func (s StatusSet) Get(name string) Status {
 		return Status{
 			Kind:      StatusKindPending,
 			UpdatedAt: s.createdAt,
-			id:        s.id,
+			ID:        s.id,
 		}
 	}
 	return s.statuses[idx].Status

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -558,7 +558,7 @@ github.com/cilium/proxy/go/envoy/type/tracing/v3
 github.com/cilium/proxy/go/envoy/type/v3
 github.com/cilium/proxy/go/envoy/watchdog/v3
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.3.3
+# github.com/cilium/statedb v0.3.4
 ## explicit; go 1.23
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
To improve the ergonomics of the 'help' command in cilium shell I've decided to avoid nested
sub-commands (e.g. "db show") and instead go for Plan 9 style flat "db/show" commands.
This way the 'help' command can list all the commands and 'help -v' can give extended help
for the commands.

This PR bumps StateDB to v0.3.4 which comes with the new style and refactors the usages
of the commands in tests and mentions in docs. 

While at it, I changed also the experimental LB to use the same style and to modify it so it won't 
register its tables or commands unless enabled to avoid confusion.

Help now looks like this:
```
cilium> help
[stdout]

commands:

cat files...
        concatenate files and print to the script's stdout buffer
db
        Describe StateDB configuration
db/cmp [-timeout=<dur>] [-grep=<pattern>] table file
        Compare table
db/delete table path...
        Delete an object from the table
db/get [-o=<file>] [-columns=col1,...] [-format={table*,yaml,json}] [-index=<index>] table key
        Get the first matching object
db/initialized [-timeout=<duration>] table...
        Wait until all or specific tables have been initialized
db/insert table path...
        Insert object into a table
db/list [-o=<file>] [-columns=col1,...] [-format={table*,yaml,json}] [-index=<index>] table key
        List objects in the table
db/lowerbound [-o=<file>] [-columns=col1,...] [-format={table*,yaml,json}] [-index=<index>] table key
        Query table by lower bound search
db/prefix [-o=<file>] [-columns=col1,...] [-format={table*,yaml,json}] [-index=<index>] table key
        Query table by prefix
db/show [-o=<file>] [-columns=col1,...] [-format={table,yaml,json}] table
        Show the contents of a table
db/watch table
        Watch a table for changes
exec program [args...] [&]
        run an executable program with arguments
help [-v] name...
        log help text for commands and conditions
lb/prune
        Trigger pruning of LB maps
lb/maps-dump (output file)
        Dump the load-balancing BPF maps
lb/maps-restore
        Restore the load-balancing BPF maps from snapshot
lb/maps-snapshot
        Snapshot the load-balancing BPF maps
```

And we now can get verbose help for the commands:
```
cilium> help db/show
[stdout]
db/show [-o=<file>] [-columns=col1,...] [-format={table,yaml,json}] table
        Show the contents of a table

        Show the contents of a table.

        The contents are written to stdout, but can be written to
        a file instead with the -o flag.

        By default the table is shown in the table format.
        For YAML use '-format=yaml' and for JSON use '-format=json'

        To only show specific columns use the '-columns' flag. The
        columns are as specified by 'TableHeader()' method.
        This flag is only supported with 'table' formatting.
```
