### PR TITLE
envoy: Pass tofqdns-proxy-response-max-delay to Envoy

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -303,7 +303,7 @@ const (
 	mutationDetectorKlog      stringMatcher = "Mutation detector is enabled, this will result in memory leakage."     // cf. https://github.com/cilium/cilium/issues/35929
 	hubbleFailedCreatePeer    stringMatcher = "Failed to create peer client for peers synchronization"                // cf. https://github.com/cilium/cilium/issues/35930
 	fqdnDpUpdatesTimeout      stringMatcher = "Timed out waiting for datapath updates of FQDN IP information"         // cf. https://github.com/cilium/cilium/issues/35931
-	longNetpolUpdate          stringMatcher = "took longer than 100ms to update network policy"                       // cf. https://github.com/cilium/cilium/issues/36067
+	longNetpolUpdate          stringMatcher = "onConfigUpdate(): Worker threads took longer than"                     // cf. https://github.com/cilium/cilium/issues/36067
 	failedToGetEpLabels       stringMatcher = "Failed to get identity labels for endpoint"                            // cf. https://github.com/cilium/cilium/issues/36068
 	failedCreategRPCClient    stringMatcher = "Failed to create gRPC client"                                          // cf. https://github.com/cilium/cilium/issues/36070
 	unableReallocateIngressIP stringMatcher = "unable to re-allocate ingress IPv6"                                    // cf. https://github.com/cilium/cilium/issues/36072

--- a/pkg/ciliumenvoyconfig/cec_resource_parser.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -526,6 +527,7 @@ func (r *cecResourceParser) getBPFMetadataListenerFilter(useOriginalSourceAddr b
 		BpfRoot:                  bpf.BPFFSRoot(),
 		IsL7Lb:                   l7lb,
 		ProxyId:                  uint32(proxyPort),
+		PolicyUpdateWarningLimit: durationpb.New(option.Config.FQDNProxyResponseMaxDelay),
 	}
 
 	// Set Ingress source addresses if configuring for L7 LB.  One of these will be used when

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -906,6 +906,7 @@ func getListenerFilter(isIngress bool, useOriginalSourceAddr bool, proxyPort uin
 		BpfRoot:                  bpf.BPFFSRoot(),
 		IsL7Lb:                   false,
 		ProxyId:                  uint32(proxyPort),
+		PolicyUpdateWarningLimit: durationpb.New(option.Config.FQDNProxyResponseMaxDelay),
 	}
 
 	return &envoy_config_listener.ListenerFilter{


### PR DESCRIPTION
Pass Cilium Agent command line option `--tofqdns-proxy-response-max-delay` to Envoy so that when set to higher than the default 100ms, `cilium-envoy` will not issue warning logs too soon.

Adjust Cilium-CLI exception string to not include the exact delay duration.

Note: the helm value `dnsProxy.proxyResponseMaxDelay` gets used as the value for `--tofqdns-proxy-response-max-delay`.

Related: #36067
