### PR TITLE
Decouple orchestrator from the local node store multicast stream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20241115112946-fb67566cbd95
 	github.com/cilium/statedb v0.3.3
-	github.com/cilium/stream v0.0.0-20240816054136-71321e385273
+	github.com/cilium/stream v0.0.0-20241203114243-53c3e5d79744
 	github.com/cilium/workerpool v1.2.0
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/containernetworking/cni v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/cilium/proxy v0.0.0-20241115112946-fb67566cbd95 h1:iMn0++U3CDqoDINY5J
 github.com/cilium/proxy v0.0.0-20241115112946-fb67566cbd95/go.mod h1:/UoCz3gByKwF5gCHFMUhwmIN5/Pgmb8LTIrfBlmjGCo=
 github.com/cilium/statedb v0.3.3 h1:hB1J28yE6KMrwLSxFfus1QjwYK1PEhibKADckxVHNyk=
 github.com/cilium/statedb v0.3.3/go.mod h1:hpcYZXvrOhmdBd02/N/WqxSjbeO2HYG8l3Z2fGq6Ioo=
-github.com/cilium/stream v0.0.0-20240816054136-71321e385273 h1:lyP0p5AW9fnNWmUcQ/BKaOmBEyZ+VWY1mGT1CFWv2b0=
-github.com/cilium/stream v0.0.0-20240816054136-71321e385273/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
+github.com/cilium/stream v0.0.0-20241203114243-53c3e5d79744 h1:f+CgYUy2YyZ2EX31QSqf3vwFiJJQSAMIQLn4d3QQYno=
+github.com/cilium/stream v0.0.0-20241203114243-53c3e5d79744/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.2.0 h1:Wc2iOPTvCgWKQXeq4L5tnx4QFEI+z5q1+bSpSS0cnAY=
 github.com/cilium/workerpool v1.2.0/go.mod h1:GOYJhwlnIjR+jWSDNBb5kw47G1H/XA9X4WOBpgr4pQU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -156,7 +156,7 @@ func (o *orchestrator) reconciler(ctx context.Context, health cell.Health) error
 	// Wait until the local node has the loopback IP and internal IP (cilium_host) allocated before
 	// proceeding. These are needed by the config file writer and we cannot proceed without them.
 	health.OK("Waiting for Cilium internal IP")
-	localNodes := stream.ToChannel(ctx,
+	localNodes := stream.ToTruncatingChannel(ctx,
 		stream.Filter(o.params.LocalNodeStore,
 			func(n node.LocalNode) bool {
 				if agentConfig.EnableIPv4 {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -565,7 +565,7 @@ github.com/cilium/statedb/index
 github.com/cilium/statedb/internal
 github.com/cilium/statedb/part
 github.com/cilium/statedb/reconciler
-# github.com/cilium/stream v0.0.0-20240816054136-71321e385273
+# github.com/cilium/stream v0.0.0-20241203114243-53c3e5d79744
 ## explicit; go 1.21.0
 github.com/cilium/stream
 # github.com/cilium/workerpool v1.2.0


### PR DESCRIPTION
The orchestrator is in charge of reinitializing the datapath after a
change to the local node configuration. To do so, like many other agent
components, it observes the updates from the local node store. Each
local node update is propagated to all the store subscribers thanks to
the stream.Multicast used in its implementation.

When an update is emitted from the multicasted stream, it needs to be
consumed by each subscriber before emitting the next one. This means
that all local node subscribers consume the updates at a rate equal to
the one of the slowest subscriber.  In other words, all the subscribers
are tightly coupled in terms of performance, and one single slow
consumer will slow down all the others, possibly introducing
unpredictable latencies in many areas of the agent.

Since the orchestrator is one of the possibly slow local node updates
consumer, and since it cares only of the latest status of the local
node, we change the way it subscribes to the store with a truncating
channel. As a result, while the orchestrator is busy reinitializing the
datapath, that is, handling the last received event, other subscribers
can receive newer local node updates independently.