### PR TITLE
cilium-cli: Derive the default version from cilium/charts

### DIFF
--- a/cilium-cli/Makefile
+++ b/cilium-cli/Makefile
@@ -9,15 +9,13 @@ INSTALL = $(QUIET)install
 BINDIR ?= /usr/local/bin
 CLI_VERSION=$(shell git describe --tags --always)
 THIS_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-CILIUM_VERSION=$(shell cat $(THIS_DIR)/../stable.txt)
 CLI_MAIN_DIR?=./cmd/cilium
 STRIP_DEBUG=-w -s
 ifdef DEBUG
 	STRIP_DEBUG=
 endif
 GO_BUILD_LDFLAGS ?= $(STRIP_DEBUG) \
-	-X 'github.com/cilium/cilium/cilium-cli/defaults.CLIVersion=$(CLI_VERSION)' \
-	-X 'github.com/cilium/cilium/cilium-cli/defaults.Version=$(CILIUM_VERSION)'
+	-X 'github.com/cilium/cilium/cilium-cli/defaults.CLIVersion=$(CLI_VERSION)'
 
 TEST_TIMEOUT ?= 5s
 

--- a/cilium-cli/cli/install.go
+++ b/cilium-cli/cli/install.go
@@ -18,11 +18,12 @@ import (
 	"github.com/cilium/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium/cilium-cli/hubble"
 	"github.com/cilium/cilium/cilium-cli/install"
+	"github.com/cilium/cilium/cilium-cli/internal/helm"
 )
 
 // addCommonInstallFlags adds install command flags that are shared between install and upgrade commands.
 func addCommonInstallFlags(cmd *cobra.Command, params *install.Parameters) {
-	cmd.Flags().StringVar(&params.Version, "version", defaults.Version, "Cilium version to install")
+	cmd.Flags().StringVar(&params.Version, "version", helm.GetDefaultVersionString(), "Cilium version to install")
 	cmd.Flags().StringVar(&params.DatapathMode, "datapath-mode", "", "Datapath mode to use { tunnel | native | aws-eni | gke | azure | aks-byocni } (default: autodetected).")
 	cmd.Flags().BoolVar(&params.ListVersions, "list-versions", false, "List all the available versions without actually installing")
 	cmd.Flags().BoolVar(&params.NodesWithoutCilium, "nodes-without-cilium", false, "Configure the affinities to avoid scheduling Cilium components on nodes labeled with cilium.io/no-schedule. It is assumed that the infrastructure has set up routing on these nodes to provide connectivity within the Cilium cluster.")

--- a/cilium-cli/cli/version.go
+++ b/cilium-cli/cli/version.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium/cilium-cli/internal/helm"
 	"github.com/cilium/cilium/pkg/safeio"
 )
 
@@ -38,7 +39,7 @@ func newCmdVersion() *cobra.Command {
 		Long:  `Displays information about the version of this software.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			fmt.Printf("cilium-cli: %s compiled with %v on %v/%v\n", defaults.CLIVersion, runtime.Version(), runtime.GOOS, runtime.GOARCH)
-			fmt.Printf("cilium image (default): %s\n", defaults.Version)
+			fmt.Printf("cilium image (default): %s\n", helm.GetDefaultVersionString())
 			fmt.Printf("cilium image (stable): %s\n", getLatestStableVersion())
 			if clientOnly {
 				return nil

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium/cilium-cli/internal/helm"
 	"github.com/cilium/cilium/cilium-cli/k8s"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
 	"github.com/cilium/cilium/pkg/option"
@@ -291,8 +292,9 @@ func (ct *ConnectivityTest) detectCiliumVersion(ctx context.Context) error {
 			return err
 		}
 	} else if minVersion, err := ct.DetectMinimumCiliumVersion(ctx); err != nil {
-		ct.Warnf("Unable to detect Cilium version, assuming %v for connectivity tests: %s", defaults.Version, err)
-		ct.CiliumVersion, err = semver.ParseTolerant(defaults.Version)
+		defaultVersion := helm.GetDefaultVersionString()
+		ct.Warnf("Unable to detect Cilium version, assuming %v for connectivity tests: %s", defaultVersion, err)
+		ct.CiliumVersion, err = semver.ParseTolerant(defaultVersion)
 		if err != nil {
 			return err
 		}

--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -118,10 +118,6 @@ const (
 )
 
 var (
-	// Version is the default Cilium version to be installed. It is set during build based on
-	// the version in stable.txt.
-	Version string
-
 	// HelmRepository specifies Helm repository to download Cilium charts from.
 	HelmRepoIDLen    = 4
 	HelmRepository   = "https://helm.cilium.io"

--- a/cilium-cli/install/install.go
+++ b/cilium-cli/install/install.go
@@ -178,10 +178,11 @@ func (k *K8sInstaller) listVersions() error {
 	if err != nil {
 		return err
 	}
+	defaultVersion := helm.GetDefaultVersionString()
 	// Iterate backwards to print the newest version first.
 	for i := len(versions) - 1; i >= 0; i-- {
 		version := "v" + versions[i].String()
-		if version == defaults.Version {
+		if version == defaultVersion {
 			fmt.Println(version, "(default)")
 		} else {
 			fmt.Println(version)

--- a/cilium-cli/internal/helm/helm.go
+++ b/cilium-cli/internal/helm/helm.go
@@ -209,6 +209,24 @@ func ListVersions() ([]semver.Version, error) {
 	return versions, nil
 }
 
+// GetDefaultVersionString returns the default Cilium version to install.
+func GetDefaultVersionString() string {
+	versions, err := ListVersions()
+	if err != nil {
+		// Can't do much if cilium-cli can't find Cilium versions. Time to panic.
+		panic(err)
+	}
+	// Start from the latest version
+	for i := len(versions) - 1; i >= 0; i-- {
+		// Skip pre-releases
+		if versions[i].Pre != nil {
+			continue
+		}
+		return fmt.Sprintf("v%s", versions[i].String())
+	}
+	panic("there is no Cilium version to install")
+}
+
 // ResolveHelmChartVersion resolves Helm chart version based on --version, --chart-directory, and --repository flags.
 func ResolveHelmChartVersion(versionFlag, chartDirectoryFlag, repository string) (semver.Version, *chart.Chart, error) {
 	// If repository is empty, set it to the default Helm repository ("https://helm.cilium.io") for backward compatibility.

--- a/cilium-cli/internal/helm/helm_test.go
+++ b/cilium-cli/internal/helm/helm_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/cilium-cli/defaults"
 )
@@ -134,4 +135,11 @@ func TestParseVals(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetDefaultVersionString(t *testing.T) {
+	versionString := GetDefaultVersionString()
+	version, err := semver.ParseTolerant(versionString)
+	assert.NoError(t, err)
+	assert.Nil(t, version.Pre)
 }


### PR DESCRIPTION
Derive the default Cilium version from the source using vendored cilium/charts instead of injecting it at compile time. This helps ensure that the default version is consistent across all the downstream cilium-cli packages.

Fixes: cilium/cilium-cli#2870