### PR TITLE
CLI: cilium upgrade preserve prev config

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2843,7 +2843,7 @@
    * - :spelling:ignore:`operator.prometheus`
      - Enable prometheus metrics for cilium-operator on the configured port at /metrics
      - object
-     - ``{"enabled":true,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","jobLabel":"","labels":{},"metricRelabelings":null,"relabelings":null}}``
+     - ``{"enabled":true,"metricsService":false,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","jobLabel":"","labels":{},"metricRelabelings":null,"relabelings":null}}``
    * - :spelling:ignore:`operator.prometheus.serviceMonitor.annotations`
      - Annotations to add to ServiceMonitor cilium-operator
      - object

--- a/cilium-cli/cli/install.go
+++ b/cilium-cli/cli/install.go
@@ -177,6 +177,10 @@ cilium upgrade --set cluster.id=1 --set cluster.name=cluster1
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			params.Namespace = namespace
 			params.HelmReleaseName = helmReleaseName
+			// Default behavior: reset-then-reuse-values
+			if !cmd.Flags().Changed("reset-values") && !cmd.Flags().Changed("reuse-values") {
+				params.HelmMergeStrategy = "reset-then-reuse-values"
+			}
 			// Don't log anything if it's a dry run so that the dry run output can easily be piped to other commands.
 			if params.IsDryRun() {
 				params.Writer = io.Discard
@@ -199,6 +203,8 @@ cilium upgrade --set cluster.id=1 --set cluster.name=cluster1
 		"When upgrading, reset the helm values to the ones built into the chart")
 	cmd.Flags().BoolVar(&params.HelmReuseValues, "reuse-values", false,
 		"When upgrading, reuse the helm values from the latest release unless any overrides from are set from other flags. This option takes precedence over HelmResetValues")
+	cmd.Flags().StringVar(&params.HelmMergeStrategy, "merge-strategy", "",
+		"Helm values merge strategy: reset-then-reuse-values (default), reset-values, or reuse-values")
 	cmd.Flags().BoolVar(&params.DryRun, "dry-run", false,
 		"Write resources to be installed to stdout without actually installing them")
 	cmd.Flags().BoolVar(&params.DryRunHelmValues, "dry-run-helm-values", false,

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -760,7 +760,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.pprof.enabled | bool | `false` | Enable pprof for cilium-operator |
 | operator.pprof.port | int | `6061` | Configure pprof listen port for cilium-operator |
 | operator.priorityClassName | string | `""` | The priority class to use for cilium-operator |
-| operator.prometheus | object | `{"enabled":true,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","jobLabel":"","labels":{},"metricRelabelings":null,"relabelings":null}}` | Enable prometheus metrics for cilium-operator on the configured port at /metrics |
+| operator.prometheus | object | `{"enabled":true,"metricsService":false,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","jobLabel":"","labels":{},"metricRelabelings":null,"relabelings":null}}` | Enable prometheus metrics for cilium-operator on the configured port at /metrics |
 | operator.prometheus.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor cilium-operator |
 | operator.prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | operator.prometheus.serviceMonitor.interval | string | `"10s"` | Interval for scrape metrics. |

--- a/install/kubernetes/cilium/templates/cilium-agent/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/service.yaml
@@ -1,6 +1,6 @@
 {{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
 {{- if and .Values.agent (not .Values.preflight.enabled) .Values.prometheus.enabled }}
-{{- if .Values.prometheus.serviceMonitor.enabled }}
+{{- if (or .Values.prometheus.serviceMonitor.enabled .Values.prometheus.metricsService) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/install/kubernetes/cilium/templates/cilium-operator/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.operator.enabled .Values.operator.prometheus.enabled .Values.operator.prometheus.serviceMonitor.enabled }}
+{{- if and .Values.operator.enabled .Values.operator.prometheus.enabled (or .Values.operator.prometheus.serviceMonitor.enabled .Values.operator.prometheus.metricsService) }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4430,6 +4430,9 @@
             "enabled": {
               "type": "boolean"
             },
+            "metricsService": {
+              "type": "boolean"
+            },
             "port": {
               "type": "integer"
             },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2758,6 +2758,7 @@ operator:
   # -- Enable prometheus metrics for cilium-operator on the configured port at
   # /metrics
   prometheus:
+    metricsService: false
     enabled: true
     port: 9963
     serviceMonitor:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2775,6 +2775,7 @@ operator:
   # -- Enable prometheus metrics for cilium-operator on the configured port at
   # /metrics
   prometheus:
+    metricsService: false
     enabled: true
     port: 9963
     serviceMonitor:


### PR DESCRIPTION
### Title: Add Helm Merge Strategy Support to Cilium Upgrade

Description

This PR introduces support for specifying Helm merge strategies during the Cilium upgrade process. Helm upgrade operations can now leverage the following merge strategies:

1. reset-then-reuse-values (default behavior)
2. reset-values
3. reuse-values

This change addresses the confusing behavior where Helm upgrade silently resets certain configuration values, potentially breaking existing installations.

Changes

Added HelmMergeStrategy to Parameters:

- Introduced a new parameter (HelmMergeStrategy) to the Parameters struct, allowing users to specify the desired Helm merge strategy for upgrades.

Updated UpgradeWithHelm to Use HelmMergeStrategy:

- The UpgradeWithHelm function now validates the merge strategy and applies it to the Helm upgrade parameters.
- Default behavior is reset-then-reuse-values if no strategy is specified.

CLI Flag for Merge Strategy:

- Added a new --merge-strategy flag in the Cilium CLI to let users choose the merge strategy when upgrading Cilium.

Validation of Helm Merge Strategy:

- Added validation to ensure that only valid merge strategies (reset-then-reuse-values, reset-values, reuse-values) are accepted.

Related Issue: #34464 

```release-note
The cilium upgrade command now supports the --merge-strategy flag with options: reset-then-reuse-values (default), reset-values, and reuse-values. This ensures better handling of Helm values during upgrades, preventing unintended resets of configurations.
```