### PR TITLE
CLI: cilium upgrade preserve prev config

### DIFF
--- a/cilium-cli/cli/install.go
+++ b/cilium-cli/cli/install.go
@@ -194,6 +194,8 @@ cilium upgrade --set cluster.id=1 --set cluster.name=cluster1
 
 	addCommonInstallFlags(cmd, &params)
 	addCommonHelmFlags(cmd, &params)
+	cmd.Flags().BoolVar(&params.HelmResetThenReuseValues, "reset-then-reuse-values", true,
+		"When upgrading, reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --set and -f. If '--reset-values' or '--reuse-values' is specified, this is ignored")
 	cmd.Flags().BoolVar(&params.HelmResetValues, "reset-values", false,
 		"When upgrading, reset the helm values to the ones built into the chart")
 	cmd.Flags().BoolVar(&params.HelmReuseValues, "reuse-values", false,

--- a/cilium-cli/install/install.go
+++ b/cilium-cli/install/install.go
@@ -131,6 +131,10 @@ type Parameters struct {
 	// specified by other flags. This options take precedence over the HelmResetValues option.
 	HelmReuseValues bool
 
+	// HelmResetThenReuseValues if true, will reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --set and -f.
+	// If '--reset-values' or '--reuse-values' is specified, this is ignored
+	HelmResetThenReuseValues bool
+
 	// DryRun writes resources to be installed to stdout without actually installing them. For Helm
 	// installation mode only.
 	DryRun bool

--- a/cilium-cli/install/upgrade.go
+++ b/cilium-cli/install/upgrade.go
@@ -29,14 +29,15 @@ func (k *K8sInstaller) UpgradeWithHelm(ctx context.Context, k8sClient *k8s.Clien
 	}
 
 	upgradeParams := helm.UpgradeParameters{
-		Namespace:    k.params.Namespace,
-		Name:         k.params.HelmReleaseName,
-		Chart:        k.chart, // k.chart was initialized in NewK8sInstaller, based on Version and HelmChartDirectory
-		Values:       vals,
-		ResetValues:  k.params.HelmResetValues,
-		ReuseValues:  k.params.HelmReuseValues,
-		Wait:         k.params.Wait,
-		WaitDuration: k.params.WaitDuration,
+		Namespace:            k.params.Namespace,
+		Name:                 k.params.HelmReleaseName,
+		Chart:                k.chart, // k.chart was initialized in NewK8sInstaller, based on Version and HelmChartDirectory
+		Values:               vals,
+		ResetValues:          k.params.HelmResetValues,
+		ReuseValues:          k.params.HelmReuseValues,
+		ResetThenReuseValues: k.params.HelmResetThenReuseValues,
+		Wait:                 k.params.Wait,
+		WaitDuration:         k.params.WaitDuration,
 
 		// In addition to the DryRun i/o, we need to tell Helm not to execute the upgrade
 		DryRun:           k.params.DryRun,

--- a/cilium-cli/internal/helm/helm.go
+++ b/cilium-cli/internal/helm/helm.go
@@ -285,6 +285,8 @@ type UpgradeParameters struct {
 	ResetValues bool
 	// --reuse-values flag from Helm upgrade. See https://helm.sh/docs/helm/helm_upgrade/ for details.
 	ReuseValues bool
+	// --reset-then-reuse-values flag from Helm upgrade. See https://helm.sh/docs/helm/helm_upgrade/ for details.
+	ResetThenReuseValues bool
 	// Wait determines if Helm actions will wait for completion
 	Wait bool
 	// WaitDuration is the timeout for helm operations
@@ -317,6 +319,7 @@ func Upgrade(
 
 	helmClient := action.NewUpgrade(actionConfig)
 	helmClient.Namespace = params.Namespace
+	helmClient.ResetThenReuseValues = params.ResetThenReuseValues
 	helmClient.ResetValues = params.ResetValues
 	helmClient.ReuseValues = params.ReuseValues
 	helmClient.Wait = params.Wait


### PR DESCRIPTION
## Title:
Add ResetThenReuseValues Parameter to Helm Upgrade Process

### Description:
This PR enhances the cilium upgrade command by introducing a new ResetThenReuseValues parameter to the Helm upgrade process. The motivation is to mitigate issues arising from Helm's default behavior, which could cause unintended resets of values during upgrades, potentially breaking configurations.

### Key Changes:

1. Added ResetThenReuseValues to the UpgradeParameters struct.
2. Modified the Upgrade function to apply ResetThenReuseValues logic:
3. If ResetThenReuseValues is true, both ResetValues and ReuseValues are enabled.
4. Otherwise, the values of ResetValues and ReuseValues are used independently.
5. Integrated the new parameter into UpgradeWithHelm to propagate the CLI flag.

Resolve issues: #34464 