### PR TITLE
bandwidth: support ingress rate limiting using eBPF token bucket

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -343,14 +343,22 @@ struct endpoint_info {
 	__u32		pad[2];
 };
 
+#define DIRECTION_EGRESS 0
+#define DIRECTION_INGRESS 1
+
 struct edt_id {
-	__u64		id;
+	__u32		id;
+	__u8		direction;
+	__u8		pad[3];
 };
 
 struct edt_info {
 	__u64		bps;
 	__u64		t_last;
-	__u64		t_horizon_drop;
+	union {
+		__u64	t_horizon_drop;
+		__u64	tokens;
+	};
 	__u32		prio;
 	__u32		pad_32;
 	__u64		pad[3];

--- a/bpf/lib/edt.h
+++ b/bpf/lib/edt.h
@@ -44,7 +44,7 @@ static __always_inline int
 edt_sched_departure(struct __ctx_buff *ctx, __be16 proto)
 {
 	__u64 delay, now, t, t_next;
-	struct edt_id aggregate;
+	struct edt_id aggregate = {};
 	struct edt_info *info;
 
 	if (!eth_is_supported_ethertype(proto))
@@ -56,6 +56,8 @@ edt_sched_departure(struct __ctx_buff *ctx, __be16 proto)
 	aggregate.id = edt_get_aggregate(ctx);
 	if (!aggregate.id)
 		return CTX_ACT_OK;
+
+	aggregate.direction = DIRECTION_EGRESS;
 
 	info = map_lookup_elem(&THROTTLE_MAP, &aggregate);
 	if (!info)

--- a/bpf/lib/token_bucket.h
+++ b/bpf/lib/token_bucket.h
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+#include <bpf/ctx/ctx.h>
+#include <linux/bpf.h>
+
+#include "common.h"
+#include "time.h"
+#include "edt.h"
+
+/* For now the map is not thread safe, may add spin lock in the future */
+
+#if defined(ENABLE_BANDWIDTH_MANAGER) && __ctx_is == __ctx_skb
+static __always_inline int accept(struct __ctx_buff *ctx, __u32 ep_id)
+{
+	__u64 tokens, now, t_last, elapsed_time, bps;
+	struct edt_id aggregate = {};
+	struct edt_info *info;
+	__u32 ret = CTX_ACT_OK;
+
+	aggregate.id = ep_id;
+	if (!aggregate.id)
+		return CTX_ACT_OK;
+
+	aggregate.direction = DIRECTION_INGRESS;
+
+	info = map_lookup_elem(&THROTTLE_MAP, &aggregate);
+	if (!info)
+		return CTX_ACT_OK;
+	if (!info->bps)
+		return CTX_ACT_OK;
+
+	now = ktime_get_ns();
+
+	bps = READ_ONCE(info->bps);
+	t_last = READ_ONCE(info->t_last);
+	tokens = READ_ONCE(info->tokens);
+	elapsed_time = now - t_last;
+	if (elapsed_time > 0) {
+		tokens += (bps * elapsed_time / NSEC_PER_SEC);
+		if (tokens > bps)
+			tokens = bps;
+	}
+	if (tokens >= ctx_wire_len(ctx))
+		tokens -= ctx_wire_len(ctx);
+	else
+		ret = CTX_ACT_DROP;
+	WRITE_ONCE(info->t_last, now);
+	WRITE_ONCE(info->tokens, tokens);
+	return ret;
+}
+#else
+static __always_inline int
+accept(struct __ctx_buff *ctx __maybe_unused, __u32 ep_id __maybe_unused)
+{
+	return CTX_ACT_OK;
+}
+#endif /* ENABLE_BANDWIDTH_MANAGER */

--- a/cilium-dbg/cmd/bpf_bandwidth_list.go
+++ b/cilium-dbg/cmd/bpf_bandwidth_list.go
@@ -51,20 +51,36 @@ func listBandwidth(bpfBandwidthList map[string][]string) {
 
 	const (
 		labelsIDTitle   = "IDENTITY"
-		labelsBandwidth = "EGRESS BANDWIDTH (BitsPerSec)"
+		labelsBandwidth = "BANDWIDTH (BitsPerSec)"
 		labelsPrio      = "PRIO"
+		labelsDirection = "DIRECTION"
 	)
 
 	w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
-	fmt.Fprintf(w, "%s\t%s\t%s\n", labelsIDTitle, labelsPrio, labelsBandwidth)
+	fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", labelsIDTitle, labelsDirection, labelsPrio, labelsBandwidth)
 
-	const numColumns = 3
+	const numColumns = 4
 	rows := [][numColumns]string{}
 
 	for key, value := range bpfBandwidthList {
+		keys := strings.Split(key, ",")
+		id := ""
+		dirStr := "Egress"
+
+		if len(keys) > 0 {
+			id = keys[0]
+		}
+		if len(keys) > 1 {
+			dir, _ := strconv.Atoi(strings.TrimSpace(keys[1]))
+			if dir == 1 {
+				dirStr = "Ingress"
+			}
+		}
+
 		bps := 0
 		prio := ""
 		info := strings.Split(value[0], ",")
+
 		if len(info) > 0 {
 			bps, _ = strconv.Atoi(info[0])
 		}
@@ -73,7 +89,7 @@ func listBandwidth(bpfBandwidthList map[string][]string) {
 		}
 		bps *= 8
 		quantity := resource.NewQuantity(int64(bps), resource.DecimalSI)
-		rows = append(rows, [numColumns]string{key, prio, quantity.String()})
+		rows = append(rows, [numColumns]string{id, dirStr, prio, quantity.String()})
 	}
 
 	sort.Slice(rows, func(i, j int) bool {
@@ -89,7 +105,7 @@ func listBandwidth(bpfBandwidthList map[string][]string) {
 	})
 
 	for _, r := range rows {
-		fmt.Fprintf(w, "%s\t%s\t%s\n", r[0], r[1], r[2])
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", r[0], r[1], r[2], r[3])
 	}
 
 	w.Flush()

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -488,11 +488,11 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 			ep.SetK8sMetadata(k8sMetadata.ContainerPorts)
 			identityLbls.MergeLabels(k8sMetadata.IdentityLabels)
 			infoLabels.MergeLabels(k8sMetadata.InfoLabels)
-			if _, ok := pod.Annotations[bandwidth.IngressBandwidth]; ok {
+			if _, ok := pod.Annotations[bandwidth.IngressBandwidth]; ok && !d.bwManager.Enabled() {
 				log.WithFields(logrus.Fields{
 					logfields.K8sPodName:  epTemplate.K8sNamespace + "/" + epTemplate.K8sPodName,
 					logfields.Annotations: logfields.Repr(pod.Annotations),
-				}).Warningf("Endpoint has %s annotation which is unsupported. This annotation is ignored.",
+				}).Warningf("Endpoint has %s annotation, but BPF bandwidth manager is disabled. This annotation is ignored.",
 					bandwidth.IngressBandwidth)
 			}
 			if _, ok := pod.Annotations[bandwidth.EgressBandwidth]; ok && !d.bwManager.Enabled() {

--- a/pkg/datapath/fake/types/bandwidth.go
+++ b/pkg/datapath/fake/types/bandwidth.go
@@ -15,6 +15,10 @@ func (fbm *BandwidthManager) DeleteBandwidthLimit(endpointID uint16) {
 func (fbm *BandwidthManager) UpdateBandwidthLimit(endpointID uint16, bytesPerSecond uint64, prio uint32) {
 }
 
+func (fbm *BandwidthManager) UpdateIngressBandwidthLimit(endpointID uint16, bytesPerSecond uint64) {}
+
+func (fbm *BandwidthManager) DeleteIngressBandwidthLimit(endpointID uint16) {}
+
 func (fbm *BandwidthManager) BBREnabled() bool {
 	return false
 }

--- a/pkg/datapath/types/bandwidth.go
+++ b/pkg/datapath/types/bandwidth.go
@@ -34,4 +34,7 @@ type BandwidthManager interface {
 
 	UpdateBandwidthLimit(endpointID uint16, bytesPerSecond uint64, prio uint32)
 	DeleteBandwidthLimit(endpointID uint16)
+
+	UpdateIngressBandwidthLimit(endpointID uint16, bytesPerSecond uint64)
+	DeleteIngressBandwidthLimit(endpointID uint16)
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -830,6 +830,9 @@ func (e *Endpoint) deleteMaps() []error {
 	if e.bps != 0 {
 		e.owner.BandwidthManager().DeleteBandwidthLimit(e.ID)
 	}
+	if e.ingressBps != 0 {
+		e.owner.BandwidthManager().DeleteIngressBandwidthLimit(e.ID)
+	}
 
 	if e.ConntrackLocalLocked() {
 		// Remove endpoint-specific CT map pins.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -219,6 +219,9 @@ type Endpoint struct {
 	// bps is the egress rate of the endpoint
 	bps uint64
 
+	// ingressBps is the ingress rate of the endpoint
+	ingressBps uint64
+
 	// mac is the MAC address of the endpoint
 	// Constant after endpoint creation / restoration.
 	mac mac.MAC // Container MAC address.
@@ -1786,6 +1789,7 @@ func (e *Endpoint) metadataResolver(ctx context.Context,
 	}())
 	e.UpdateBandwidthPolicy(bwm,
 		pod.Annotations[bandwidth.EgressBandwidth],
+		pod.Annotations[bandwidth.IngressBandwidth],
 		pod.Annotations[bandwidth.Priority],
 	)
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1071,14 +1071,15 @@ func (e *Endpoint) UpdateNoTrackRules(noTrackPort string) {
 	}
 }
 
-// UpdateBandwidthPolicy updates the egress bandwidth of this endpoint to
+// UpdateBandwidthPolicy updates the egress/ingress bandwidth of this endpoint to
 // progagate the throttle rate to the BPF data path.
-func (e *Endpoint) UpdateBandwidthPolicy(bwm dptypes.BandwidthManager, bandwidthEgress, priority string) {
+func (e *Endpoint) UpdateBandwidthPolicy(bwm dptypes.BandwidthManager, bandwidthEgress, bandwidthIngress, priority string) {
 	ch, err := e.eventQueue.Enqueue(eventqueue.NewEvent(&EndpointPolicyBandwidthEvent{
-		bwm:             bwm,
-		ep:              e,
-		bandwidthEgress: bandwidthEgress,
-		priority:        priority,
+		bwm:              bwm,
+		ep:               e,
+		bandwidthEgress:  bandwidthEgress,
+		bandwidthIngress: bandwidthIngress,
+		priority:         priority,
 	}))
 	if err != nil {
 		e.getLogger().WithError(err).Error("Unable to enqueue endpoint policy bandwidth event")

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -435,7 +435,7 @@ func (k *K8sPodWatcher) updateK8sPodV1(oldK8sPod, newK8sPod *slim_corev1.Pod) er
 	// Check annotation updates.
 	oldAnno := oldK8sPod.ObjectMeta.Annotations
 	newAnno := newK8sPod.ObjectMeta.Annotations
-	annoChangedBandwidth := !k8s.AnnotationsEqual([]string{bandwidth.EgressBandwidth}, oldAnno, newAnno)
+	annoChangedBandwidth := !k8s.AnnotationsEqual([]string{bandwidth.EgressBandwidth}, oldAnno, newAnno) || !k8s.AnnotationsEqual([]string{bandwidth.IngressBandwidth}, oldAnno, newAnno)
 	annoChangedPriority := !k8s.AnnotationsEqual([]string{bandwidth.Priority}, oldAnno, newAnno)
 	annoChangedNoTrack := !k8s.AnnotationsEqual([]string{annotation.NoTrack, annotation.NoTrackAlias}, oldAnno, newAnno)
 	annotationsChanged := annoChangedBandwidth || annoChangedPriority || annoChangedNoTrack
@@ -511,6 +511,7 @@ func (k *K8sPodWatcher) updateK8sPodV1(oldK8sPod, newK8sPod *slim_corev1.Pod) er
 			if annoChangedBandwidth {
 				podEP.UpdateBandwidthPolicy(k.bandwidthManager,
 					newK8sPod.Annotations[bandwidth.EgressBandwidth],
+					newK8sPod.Annotations[bandwidth.IngressBandwidth],
 					newK8sPod.Annotations[bandwidth.Priority])
 			}
 			if annoChangedNoTrack {

--- a/pkg/maps/bwmap/bwmap.go
+++ b/pkg/maps/bwmap/bwmap.go
@@ -28,22 +28,30 @@ const (
 )
 
 type EdtId struct {
-	Id uint64 `align:"id"`
+	Id        uint32   `align:"id"`
+	Direction uint8    `align:"direction"`
+	Pad       [3]uint8 `align:"pad"`
 }
 
-func (k *EdtId) String() string  { return fmt.Sprintf("%d", int(k.Id)) }
+func (k *EdtId) String() string {
+	return fmt.Sprintf("%d, %d", int(k.Id), int(k.Direction))
+}
+
 func (k *EdtId) New() bpf.MapKey { return &EdtId{} }
 
 type EdtInfo struct {
-	Bps             uint64    `align:"bps"`
-	TimeLast        uint64    `align:"t_last"`
-	TimeHorizonDrop uint64    `align:"t_horizon_drop"`
-	Prio            uint32    `align:"prio"`
-	Pad32           uint32    `align:"pad_32"`
-	Pad             [3]uint64 `align:"pad"`
+	Bps                     uint64    `align:"bps"`
+	TimeLast                uint64    `align:"t_last"`
+	TimeHorizonDropOrTokens uint64    `align:"$union0"`
+	Prio                    uint32    `align:"prio"`
+	Pad32                   uint32    `align:"pad_32"`
+	Pad                     [3]uint64 `align:"pad"`
 }
 
-func (v *EdtInfo) String() string    { return fmt.Sprintf("%d, %d", int(v.Bps), int(v.Prio)) }
+func (v *EdtInfo) String() string {
+	return fmt.Sprintf("%d, %d", int(v.Bps), int(v.Prio))
+}
+
 func (v *EdtInfo) New() bpf.MapValue { return &EdtInfo{} }
 
 type throttleMap struct {

--- a/pkg/maps/bwmap/table.go
+++ b/pkg/maps/bwmap/table.go
@@ -6,6 +6,7 @@ package bwmap
 import (
 	"encoding"
 	"strconv"
+	"strings"
 
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/index"
@@ -23,8 +24,7 @@ const EdtTableName = "bandwidth-edts"
 //
 // Edt is stored by value as it's relatively tiny.
 type Edt struct {
-	// EndpointID is the identity of the endpoint being throttled.
-	EndpointID uint16
+	EdtIDKey
 
 	// BytesPerSecond is the bandwidth limit for the endpoint.
 	BytesPerSecond uint64
@@ -39,19 +39,44 @@ type Edt struct {
 	Status reconciler.Status
 }
 
-var EdtIDIndex = statedb.Index[Edt, uint16]{
-	Name: "endpoint-id",
-	FromObject: func(t Edt) index.KeySet {
-		return index.NewKeySet(index.Uint16(t.EndpointID))
-	},
-	FromKey:    index.Uint16,
-	FromString: index.Uint16String,
-	Unique:     true,
+type EdtIDKey struct {
+	EndpointID uint16
+	Direction  uint8
 }
 
-func NewEdt(endpointID uint16, bytesPerSecond uint64, prio uint32) Edt {
+func (k EdtIDKey) Key() index.Key {
+	key := append(index.Uint16(k.EndpointID), '+')
+	key = append(key, index.Uint16(uint16(k.Direction))...)
+	return key
+}
+
+var EdtIDIndex = statedb.Index[Edt, EdtIDKey]{
+	Name: "endpoint-id",
+	FromObject: func(t Edt) index.KeySet {
+		return index.NewKeySet(t.Key())
+	},
+	FromKey: EdtIDKey.Key,
+	FromString: func(key string) (index.Key, error) {
+		epS, directionS, _ := strings.Cut(key, "+")
+		ep, err := strconv.ParseUint(epS, 10, 16)
+		if err != nil {
+			return index.Key{}, err
+		}
+		direction, err := strconv.ParseUint(directionS, 10, 16)
+		if err != nil {
+			return index.Key{}, err
+		}
+		return EdtIDKey{EndpointID: uint16(ep), Direction: uint8(direction)}.Key(), nil
+	},
+	Unique: true,
+}
+
+func NewEdt(endpointID uint16, direction uint8, bytesPerSecond uint64, prio uint32) Edt {
 	return Edt{
-		EndpointID:      endpointID,
+		EdtIDKey: EdtIDKey{
+			EndpointID: endpointID,
+			Direction:  direction,
+		},
 		BytesPerSecond:  bytesPerSecond,
 		Prio:            prio,
 		TimeHorizonDrop: uint64(DefaultDropHorizon),
@@ -67,26 +92,39 @@ func NewEdtTable() (statedb.RWTable[Edt], error) {
 }
 
 func (e Edt) BinaryKey() encoding.BinaryMarshaler {
-	k := EdtId{Id: uint32(e.EndpointID)}
+	k := EdtId{Id: uint32(e.EndpointID), Direction: e.Direction}
 	return bpf.StructBinaryMarshaler{Target: &k}
 }
 
 func (e Edt) BinaryValue() encoding.BinaryMarshaler {
 	v := EdtInfo{
-		Bps:                     e.BytesPerSecond,
-		TimeLast:                0, // Used on the BPF-side
-		TimeHorizonDropOrTokens: e.TimeHorizonDrop,
-		Prio:                    e.Prio,
+		Bps:      e.BytesPerSecond,
+		TimeLast: 0, // Used on the BPF-side
 	}
+	if e.Direction == 0 {
+		// egress
+		v.TimeHorizonDropOrTokens = e.TimeHorizonDrop
+		v.Prio = e.Prio
+	} else {
+		v.TimeHorizonDropOrTokens = 0
+	}
+
 	return bpf.StructBinaryMarshaler{Target: &v}
 }
 
 func (e Edt) TableHeader() []string {
+	if e.Direction == 0 {
+		return []string{
+			"EndpointID",
+			"BitsPerSecond",
+			"Prio",
+			"TimeHorizonDrop",
+			"Status",
+		}
+	}
 	return []string{
 		"EndpointID",
 		"BitsPerSecond",
-		"Prio",
-		"TimeHorizonDrop",
 		"Status",
 	}
 }
@@ -95,11 +133,19 @@ func (e Edt) TableRow() []string {
 	// Show the limit as bits per second as that's how it is configured via
 	// the annotation.
 	quantity := resource.NewQuantity(int64(e.BytesPerSecond*8), resource.DecimalSI)
+
+	if e.Direction == 0 {
+		return []string{
+			strconv.FormatUint(uint64(e.EndpointID), 10),
+			quantity.String(),
+			strconv.FormatUint(uint64(e.Prio), 10),
+			strconv.FormatUint(e.TimeHorizonDrop, 10),
+			e.Status.String(),
+		}
+	}
 	return []string{
 		strconv.FormatUint(uint64(e.EndpointID), 10),
 		quantity.String(),
-		strconv.FormatUint(uint64(e.Prio), 10),
-		strconv.FormatUint(e.TimeHorizonDrop, 10),
 		e.Status.String(),
 	}
 }

--- a/pkg/maps/bwmap/table.go
+++ b/pkg/maps/bwmap/table.go
@@ -67,16 +67,16 @@ func NewEdtTable() (statedb.RWTable[Edt], error) {
 }
 
 func (e Edt) BinaryKey() encoding.BinaryMarshaler {
-	k := EdtId{uint64(e.EndpointID)}
+	k := EdtId{Id: uint32(e.EndpointID)}
 	return bpf.StructBinaryMarshaler{Target: &k}
 }
 
 func (e Edt) BinaryValue() encoding.BinaryMarshaler {
 	v := EdtInfo{
-		Bps:             e.BytesPerSecond,
-		TimeLast:        0, // Used on the BPF-side
-		TimeHorizonDrop: e.TimeHorizonDrop,
-		Prio:            e.Prio,
+		Bps:                     e.BytesPerSecond,
+		TimeLast:                0, // Used on the BPF-side
+		TimeHorizonDropOrTokens: e.TimeHorizonDrop,
+		Prio:                    e.Prio,
 	}
 	return bpf.StructBinaryMarshaler{Target: &v}
 }


### PR DESCRIPTION
This commit adds ingress bandwidth rate limiting support using an eBPF token bucket implementation. This complements the existing egress bandwidth management and allows for bidirectional traffic shaping of Cilium endpoints. The QoS works on native device, same as EDT does, so traffic in the same node, will not work.

Key changes:
- Implements a token bucket rate limiter in eBPF (bpf/lib/tb.h)
- Extend cilium_throttle map to store ingress rate limits
- Extends the bandwidth manager to handle ingress bandwidth annotations
- Updates the CLI to display both ingress and egress bandwidth limits

Limitations:
- For native routing, BPF Routing is required

<!-- Description of change -->

Fixes: #15636

```release-note
bandwidth: support ingress rate limiting using eBPF token bucket
```
