### PR TITLE
cilium-cli/connectivity: disable warning log checks before v1.17

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -81,7 +81,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string) check.Sc
 	if slices.Contains(checkLevels, defaults.LogLevelError) {
 		errorMsgsWithExceptions["level=error"] = errorLogExceptions
 	}
-	if slices.Contains(checkLevels, defaults.LogLevelWarning) {
+	if slices.Contains(checkLevels, defaults.LogLevelWarning) && ciliumVersion.GE(semver.MustParse("1.17.0")) {
 		errorMsgsWithExceptions["level=warn"] = warningLogExceptions
 	}
 	return &noErrorsInLogs{errorMsgsWithExceptions}

--- a/cilium-cli/connectivity/tests/errors_test.go
+++ b/cilium-cli/connectivity/tests/errors_test.go
@@ -26,11 +26,13 @@ level=error msg="bar"
 
 	for _, tt := range []struct {
 		levels        []string
+		version       semver.Version
 		wantLen       int
 		wantLogsCount map[string]int
 	}{
 		{
 			levels:  defaults.LogCheckLevels,
+			version: semver.MustParse("1.17.0"),
 			wantLen: 2,
 			wantLogsCount: map[string]int{
 				`level=error msg="bar"`:   2,
@@ -38,7 +40,16 @@ level=error msg="bar"
 			},
 		},
 		{
+			levels:  defaults.LogCheckLevels,
+			version: semver.MustParse("1.16.99"),
+			wantLen: 1,
+			wantLogsCount: map[string]int{
+				`level=error msg="bar"`: 2,
+			},
+		},
+		{
 			levels:  []string{defaults.LogLevelError},
+			version: semver.MustParse("1.17.0"),
 			wantLen: 1,
 			wantLogsCount: map[string]int{
 				`level=error msg="bar"`: 2,
@@ -46,11 +57,12 @@ level=error msg="bar"
 		},
 		{
 			levels:        []string{},
+			version:       semver.MustParse("1.17.0"),
 			wantLen:       0,
 			wantLogsCount: map[string]int{},
 		},
 	} {
-		s := NoErrorsInLogs(semver.MustParse("1.15.0"), tt.levels).(*noErrorsInLogs)
+		s := NoErrorsInLogs(tt.version, tt.levels).(*noErrorsInLogs)
 		fails := s.findUniqueFailures(errs)
 		assert.Len(t, fails, tt.wantLen)
 		for wantMsg, wantCount := range tt.wantLogsCount {


### PR DESCRIPTION
Since commit 5417a3fa37bc ("cli/connectivity: Check for unexpected warning logs") we check for unexpected warnings in logs as part of the connectivity checks. Given that the connectivity tests are potentially run against all Cilium stable branches, this opens for a significant number of issues that would need to be addressed before being able adopt the new CLI version, introducing delays and potential risks of regressions due to the extra churn in stable branches. Let's avoid this by enabling the warning checks only starting from Cilium v1.17 (current main), so that we can gradually stabilize it without having to backport any changes to the previous versions.

Note that the Cilium version used in this context is the minimum across all Cilium agents in the tested cluster(mesh), which means that the check will be disabled in a clustermesh upgrade/downgrade test where one cluster uses v1.16 and the other v1.17, which is reasonable.

Related: 66377ae13a6b ("cilium-cli/connectivity: allow to specify log levels to check")