### PR TITLE
bpf: host: misc improvements for cil_from_netdev() / cil_from_host()

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1316,13 +1316,8 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 
 	if (!validate_ethertype(ctx, &proto)) {
 #ifdef ENABLE_HOST_FIREWALL
-		__u32 id = WORLD_ID;
-		__u32 sec_label = SECLABEL;
-
 		ret = DROP_UNSUPPORTED_L2;
-
-		return send_drop_notify(ctx, sec_label, id, TRACE_EP_ID_UNKNOWN, ret,
-					CTX_ACT_DROP, METRIC_EGRESS);
+		goto drop_err;
 #else
 		send_trace_notify(ctx, TRACE_TO_STACK, HOST_ID, UNKNOWN_ID,
 				  TRACE_EP_ID_UNKNOWN,

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1270,7 +1270,7 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 __section_entry
 int cil_from_netdev(struct __ctx_buff *ctx)
 {
-	__u32 src_id = 0;
+	__u32 src_id = UNKNOWN_ID;
 	__be16 proto = 0;
 
 #ifdef ENABLE_NODEPORT_ACCELERATION
@@ -1319,7 +1319,7 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 		ret = DROP_UNSUPPORTED_L2;
 		goto drop_err;
 #else
-		send_trace_notify(ctx, TRACE_TO_STACK, HOST_ID, UNKNOWN_ID,
+		send_trace_notify(ctx, TRACE_TO_STACK, src_id, UNKNOWN_ID,
 				  TRACE_EP_ID_UNKNOWN,
 				  TRACE_IFINDEX_UNKNOWN, TRACE_REASON_UNKNOWN, 0);
 		/* Pass unknown traffic to the stack */

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1348,15 +1348,17 @@ int cil_from_host(struct __ctx_buff *ctx)
 	edt_set_aggregate(ctx, 0);
 
 	if (!validate_ethertype(ctx, &proto)) {
+		__u32 dst_sec_identity = UNKNOWN_ID;
+		__u32 src_sec_identity = HOST_ID;
+
 #ifdef ENABLE_HOST_FIREWALL
 		int ret = DROP_UNSUPPORTED_L2;
-		__u32 id = WORLD_ID;
-		__u32 sec_label = SECLABEL;
 
-		return send_drop_notify(ctx, sec_label, id, TRACE_EP_ID_UNKNOWN, ret,
+		return send_drop_notify(ctx, src_sec_identity, dst_sec_identity,
+					TRACE_EP_ID_UNKNOWN, ret,
 					CTX_ACT_DROP, METRIC_EGRESS);
 #else
-		send_trace_notify(ctx, TRACE_TO_STACK, HOST_ID, UNKNOWN_ID,
+		send_trace_notify(ctx, TRACE_TO_STACK, src_sec_identity, dst_sec_identity,
 				  TRACE_EP_ID_UNKNOWN,
 				  TRACE_IFINDEX_UNKNOWN, TRACE_REASON_UNKNOWN, 0);
 		/* Pass unknown traffic to the stack */


### PR DESCRIPTION
Regroup the code a bit, so that it becomes easier to report the correct identities in drop / trace notifications. This also removes one usage of SECLABEL.