### PR TITLE
ci: modify bpftrace script to ignore destinations outside pod CIDRs

### DIFF
--- a/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
@@ -165,6 +165,7 @@ kprobe:br_forward
 }
 
 // Trace TCP connections established by the L7 proxy, even if the source address belongs to the host.
+// Ignore connections with the destination address outside pod CIDRs.
 kprobe:tcp_connect
 {
   if (strncmp(comm, "wrk:", 4) != 0) {
@@ -173,6 +174,19 @@ kprobe:tcp_connect
 
   $sk = ((struct sock *) arg0);
   $inet_family = $sk->__sk_common.skc_family;
+  $dst_is_pod = false;
+
+  if ($inet_family == AF_INET) {
+    $dst_is_pod = (bswap($sk->__sk_common.skc_daddr) & MASK4) == CIDR4;
+  }
+
+  if ($inet_family == AF_INET6) {
+    $dst_is_pod = bswap($sk->__sk_common.skc_v6_daddr.in6_u.u6_addr16[0]) == CIDR6;
+  }
+
+  if (!$dst_is_pod) {
+    return
+  }
 
   if ($inet_family == AF_INET) {
     @trace_ip4[$sk->__sk_common.skc_rcv_saddr, bswap($sk->__sk_common.skc_num), PROTO_TCP] = true;

--- a/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
@@ -61,13 +61,13 @@ kprobe:br_forward
     $udph = ((struct udphdr*) ($skb->head + $skb->inner_transport_header));
 
     if ($proto == PROTO_IPV4) {
-      $trace_override =
+      $pod_to_pod_via_proxy =
         @trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] ||
         @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol];
 
       // Skip CiliumInternalIP addresses, as they belong to the PodCIDR,
       // unless the given flow is explicitly marked as traced (i.e., from proxy).
-      if (!$trace_override &&
+      if (!$pod_to_pod_via_proxy &&
            ($ip4h->saddr == (uint32)pton(str($1)) || $ip4h->daddr == (uint32)pton(str($1)) ||
             $ip4h->saddr == (uint32)pton(str($3)) || $ip4h->daddr == (uint32)pton(str($3)) ||
             $ip4h->saddr == (uint32)pton(str($5)) || $ip4h->daddr == (uint32)pton(str($5)))) {
@@ -76,13 +76,13 @@ kprobe:br_forward
     }
 
     if ($proto == PROTO_IPV6) {
-      $trace_override =
+      $pod_to_pod_via_proxy =
         @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] ||
         @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr];
 
       // Skip CiliumInternalIP addresses, as they belong to the PodCIDR
       // unless the given flow is explicitly marked as traced (i.e., from proxy).
-      if (!$trace_override &&
+      if (!$pod_to_pod_via_proxy &&
            ($ip6h->saddr.in6_u.u6_addr8 == pton(str($2)) || $ip6h->daddr.in6_u.u6_addr8 == pton(str($2)) ||
             $ip6h->saddr.in6_u.u6_addr8 == pton(str($4)) || $ip6h->daddr.in6_u.u6_addr8 == pton(str($4)) ||
             $ip6h->saddr.in6_u.u6_addr8 == pton(str($6)) || $ip6h->daddr.in6_u.u6_addr8 == pton(str($6)))) {
@@ -95,11 +95,11 @@ kprobe:br_forward
     $src_is_pod = (bswap($ip4h->saddr) & MASK4) == CIDR4;
     $dst_is_pod = (bswap($ip4h->daddr) & MASK4) == CIDR4;
 
-    $trace_override =
+    $pod_to_pod_via_proxy =
         @trace_ip4[$ip4h->saddr, $udph->source, $ip4h->protocol] ||
         @trace_ip4[$ip4h->daddr, $udph->dest, $ip4h->protocol];
 
-    if (($src_is_pod && $dst_is_pod) || ($trace_override && ($src_is_pod || $dst_is_pod))) {
+    if (($src_is_pod && $dst_is_pod) || ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))) {
       $tcph = (struct tcphdr*)$udph;
       printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
         strftime("%H:%M:%S:%f", nsecs),
@@ -113,7 +113,7 @@ kprobe:br_forward
         $skb->encapsulation,
         $skb->dev->ifindex,
         $skb->dev->nd_net.net->ns.inum,
-        $trace_override);
+        $pod_to_pod_via_proxy);
 
       if ($ip4h->protocol == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
         $dns = (struct dnshdr*)($udph + 1);
@@ -131,11 +131,11 @@ kprobe:br_forward
     $src_is_pod = bswap($ip6h->saddr.in6_u.u6_addr16[0]) == CIDR6;
     $dst_is_pod = bswap($ip6h->daddr.in6_u.u6_addr16[0]) == CIDR6;
 
-    $trace_override =
+    $pod_to_pod_via_proxy =
         @trace_ip6[$ip6h->saddr.in6_u.u6_addr8, $udph->source, $ip6h->nexthdr] ||
         @trace_ip6[$ip6h->daddr.in6_u.u6_addr8, $udph->dest, $ip6h->nexthdr];
 
-    if (($src_is_pod && $dst_is_pod) || ($trace_override && ($src_is_pod || $dst_is_pod))) {
+    if (($src_is_pod && $dst_is_pod) || ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))) {
       $tcph = (struct tcphdr*)$udph;
       printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
         strftime("%H:%M:%S:%f", nsecs),
@@ -149,7 +149,7 @@ kprobe:br_forward
         $skb->encapsulation,
         $skb->dev->ifindex,
         $skb->dev->nd_net.net->ns.inum,
-        $trace_override);
+        $pod_to_pod_via_proxy);
 
       if ($ip6h->nexthdr == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
         $dns = (struct dnshdr*)($udph + 1);

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -273,36 +273,13 @@ jobs:
 
           echo "params=$CILIUM_INTERNAL_IPS" >> $GITHUB_OUTPUT
 
-      # We need to run the egress gateway tests before checking for unencrypted
-      # packets because redirected pod->world traffic will otherwise be
-      # detected as wrongly unencrypted (when that's expected).
-      - name: Run egress gateway tests (${{ join(matrix.*, ', ') }})
-        if: ${{ matrix.egress-gateway == 'true' }}
-        shell: bash
-        run: |
-          mkdir -p cilium-junits
-
-          cilium connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
-            --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
-            --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-            --test egress-gateway \
-            --flush-ct
-
-      - name: Features tested after egress gateway tests
-        uses: ./.github/actions/feature-status
-        with:
-          title: "Summary of all features tested after egress gateway tests"
-          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - egress-gateway"
-
       - name: Start unencrypted packets check
         uses: ./.github/actions/bpftrace/start
         with:
           script: ./.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
           args: ${{ steps.bpftrace-params.outputs.params }} "true"
 
-      - name: Run all other tests (${{ join(matrix.*, ', ') }})
+      - name: Run tests (${{ join(matrix.*, ', ') }})
         shell: bash
         run: |
           mkdir -p cilium-junits
@@ -312,14 +289,13 @@ jobs:
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-            --test '!egress-gateway' \
             --flush-ct
 
-      - name: Features tested after running all other tests
+      - name: Features tested
         uses: ./.github/actions/feature-status
         with:
-          title: "Summary of all features tested after all other tests"
-          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - other tests"
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }})"
 
       - name: Assert that no unencrypted packets are leaked
         uses: ./.github/actions/bpftrace/check
@@ -349,29 +325,6 @@ jobs:
       - name: Check conn-disrupt-test after rotating (${{ join(matrix.*, ', ') }})
         uses: ./.github/actions/conn-disrupt-test-check
 
-      # We need to run the egress gateway tests before checking for unencrypted
-      # packets because redirected pod->world traffic will otherwise be
-      # detected as wrongly unencrypted (when that's expected).
-      - name: Run egress gateway tests (${{ join(matrix.*, ', ') }})
-        if: ${{ matrix.egress-gateway == 'true' }}
-        shell: bash
-        run: |
-          mkdir -p cilium-junits
-
-          cilium connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
-            --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
-            --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-            --test egress-gateway \
-            --flush-ct
-
-      - name: Features tested after egress gateway tests after rotating ipsec keys
-        uses: ./.github/actions/feature-status
-        with:
-          title: "Summary of all features tested after egress gateway tests after rotating ipsec keys"
-          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - egress-gateway after rotating keys"
-
       - name: Start unencrypted packets check for tests
         uses: ./.github/actions/bpftrace/start
         with:
@@ -394,14 +347,13 @@ jobs:
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-            --test '!egress-gateway' \
             --flush-ct $TEST
 
-      - name: Features tested after running all other tests after rotating ipsec keys
+      - name: Features tested
         uses: ./.github/actions/feature-status
         with:
           title: "Summary of all features tested after all other tests after rotating ipsec keys"
-          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - other tests after rotating keys"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - after rotating keys"
 
       - name: Assert that no unencrypted packets are leaked during tests
         uses: ./.github/actions/bpftrace/check


### PR DESCRIPTION
With this PR, the bpftrace script that we run in CI is now able to ignore TCP traffic with destionation address outside pod CIDRs. This is particularly useful in egress-gateway tests, for which pod-to-world and pod-to-node traffic is sent.
Prior to this, in conformance-ipsec-e2e we used to keep tests separate, and run bpftrace only on non egress-gateway tests.
This PR (re)unifies tests while also running bpftrace in background for all of them.

```release-note
Modify bpftrace script in CI to ignore proxy traffic if destination is outside pod CIDRs.
```