### PR TITLE
certloader: prevent panic when Watcher.Stop is called multiple times

### DIFF
--- a/pkg/crypto/certloader/watcher.go
+++ b/pkg/crypto/certloader/watcher.go
@@ -197,7 +197,11 @@ func (w *Watcher) Watch() <-chan struct{} {
 
 // Stop watching the files.
 func (w *Watcher) Stop() {
-	close(w.stop)
+	select {
+	case <-w.stop:
+	default:
+		close(w.stop)
+	}
 }
 
 // newFsWatcher returns a fswatcher.Watcher watching over the given files.


### PR DESCRIPTION
### Problem

Panic in Hubble when context is cancelled too quickly
```
 time="2024-12-04T08:02:03.359947688Z" level=error msg="Error while serving from Hubble server" address=":4244" error="grpc: the server has been stopped" subsys=hubble
panic: close of closed channel

goroutine 400 [running]:
github.com/cilium/cilium/pkg/crypto/certloader.(*Watcher).Stop(...)
    /go/src/github.com/cilium/cilium/pkg/crypto/certloader/watcher.go:200
github.com/cilium/cilium/pkg/hubble/cell.(*hu
```

### Explanation

In `pkg/hubble/cell/hubbleintegration.go`, we have a racy stop behaviour:
```go
h.log.WithFields(logrus.Fields{
	"address": address,
	"tls":     !h.config.DisableServerTLS,
}).Info("Starting Hubble server")

// (4)
go func() {
	// (5)
	if err := srv.Serve(); err != nil {
		// (6) err: grpc: the server has been stopped
		// NOTE: error only happens if serve is called AFTER Stop() is called.
		h.log.WithError(err).WithField("address", address).Error("Error while serving from Hubble server")
		// (7) close(tlsServerConfig.stop == nil) -> panic
		if tlsServerConfig != nil {
			tlsServerConfig.Stop()
		}
	}
}()

// (1)
go func() {
	<-ctx.Done()
	// (2)
	srv.Stop()
	if tlsServerConfig != nil {
		// (3)
		tlsServerConfig.Stop()
		// tlsServerConfig.stop == nil
	}
}()
```

### Fix

Since we plan on further updating the hubble cell integration and incorporate more components into the hive ecosystem, therefore modifying this behaviour in the near future, I apply a quick fix at the source by preventing the close call on the stop channel to happen twice.