### PR TITLE
bgp: adding internal reconciliation metrics

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -636,6 +636,19 @@ Exported Metrics
 
 All metrics are exported under the ``cilium_operator_`` Prometheus namespace.
 
+.. _metrics_bgp_control_plane_operator:
+
+BGP Control Plane Operator
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+================================== ======================= ======== ======================================================================
+Name                               Labels                  Default  Description
+================================== ======================= ======== ======================================================================
+``cluster_config_error_count``     ``bgp_cluster_config``  Enabled  Number of errors returned per BGP cluster configuration reconciliation
+================================== ======================= ======== ======================================================================
+
+All metrics are enabled only when the BGP Control Plane is enabled.
+
 .. _ipam_metrics:
 
 IPAM

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -608,13 +608,15 @@ Name                                           Labels                           
 BGP Control Plane
 ~~~~~~~~~~~~~~~~~
 
-====================== =============================================================== ======== ===================================================================
-Name                   Labels                                                          Default  Description
-====================== =============================================================== ======== ===================================================================
-``session_state``      ``vrouter``, ``neighbor``, ``neighbor_asn``                     Enabled  Current state of the BGP session with the peer, Up = 1 or Down = 0
-``advertised_routes``  ``vrouter``, ``neighbor``, ``neighbor_asn``, ``afi``, ``safi``  Enabled  Number of routes advertised to the peer
-``received_routes``    ``vrouter``, ``neighbor``, ``neighbor_asn``, ``afi``, ``safi``  Enabled  Number of routes received from the peer
-====================== =============================================================== ======== ===================================================================
+================================== =============================================================== ======== ===================================================================
+Name                               Labels                                                          Default  Description
+================================== =============================================================== ======== ===================================================================
+``session_state``                  ``vrouter``, ``neighbor``, ``neighbor_asn``                     Enabled  Current state of the BGP session with the peer, Up = 1 or Down = 0
+``advertised_routes``              ``vrouter``, ``neighbor``, ``neighbor_asn``, ``afi``, ``safi``  Enabled  Number of routes advertised to the peer
+``received_routes``                ``vrouter``, ``neighbor``, ``neighbor_asn``, ``afi``, ``safi``  Enabled  Number of routes received from the peer
+``reconcile_error_count``          ``vrouter``                                                     Enabled  Number of reconciliation runs that returned an error
+``reconcile_run_duration_seconds`` ``vrouter``                                                     Enabled  Histogram of reconciliation run duration
+================================== =============================================================== ======== ===================================================================
 
 All metrics are enabled only when the BGP Control Plane is enabled.
 

--- a/operator/pkg/bgpv2/cell.go
+++ b/operator/pkg/bgpv2/cell.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -19,6 +20,7 @@ var Cell = cell.Module(
 	cell.ProvidePrivate(newSecretResource),
 	cell.Invoke(registerBGPResourceManager),
 	cell.Invoke(registerPeerConfigStatusReconciler),
+	metrics.Metric(NewBGPOperatorMetrics),
 )
 
 func newSecretResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig) resource.Resource[*slim_core_v1.Secret] {

--- a/operator/pkg/bgpv2/cluster.go
+++ b/operator/pkg/bgpv2/cluster.go
@@ -27,6 +27,7 @@ func (b *BGPResourceManager) reconcileBGPClusterConfigs(ctx context.Context) err
 	for _, config := range b.clusterConfigStore.List() {
 		rcErr := b.reconcileBGPClusterConfig(ctx, config)
 		if rcErr != nil {
+			b.metrics.BGPClusterConfigErrorCount.WithLabelValues(config.Name).Inc()
 			err = errors.Join(err, rcErr)
 		}
 	}

--- a/operator/pkg/bgpv2/manager.go
+++ b/operator/pkg/bgpv2/manager.go
@@ -38,6 +38,7 @@ type BGPParams struct {
 	DaemonConfig *option.DaemonConfig
 	JobGroup     job.Group
 	Health       cell.Health
+	Metrics      *BGPOperatorMetrics
 
 	// resource tracking
 	ClusterConfigResource      resource.Resource[*cilium_api_v2alpha1.CiliumBGPClusterConfig]
@@ -53,6 +54,7 @@ type BGPResourceManager struct {
 	lc        cell.Lifecycle
 	jobs      job.Group
 	health    cell.Health
+	metrics   *BGPOperatorMetrics
 
 	// For BGP Cluster Config
 	clusterConfig           resource.Resource[*cilium_api_v2alpha1.CiliumBGPClusterConfig]
@@ -88,6 +90,7 @@ func registerBGPResourceManager(p BGPParams) *BGPResourceManager {
 		jobs:      p.JobGroup,
 		lc:        p.LC,
 		health:    p.Health,
+		metrics:   p.Metrics,
 
 		reconcileCh:        make(chan struct{}, 1),
 		bgpClusterSyncCh:   make(chan struct{}, 1),

--- a/operator/pkg/bgpv2/metrics.go
+++ b/operator/pkg/bgpv2/metrics.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bgpv2
+
+import (
+	"github.com/cilium/cilium/pkg/bgpv1/types"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+// BGPOperatorMetrics contains all metrics for the BGP control plane operator.
+type BGPOperatorMetrics struct {
+	// BGPClusterConfigErrorCount is the number of errors during reconciliation of the cluster
+	// configuration.
+	BGPClusterConfigErrorCount metric.Vec[metric.Counter]
+}
+
+// NewBGPOperatorMetrics returns a new BGPOperatorMetrics with all metrics initialized.
+func NewBGPOperatorMetrics() *BGPOperatorMetrics {
+	return &BGPOperatorMetrics{
+		BGPClusterConfigErrorCount: metric.NewCounterVec(metric.CounterOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Subsystem: types.MetricsSubsystem,
+			Name:      "cluster_config_error_count",
+			Help:      "The number of errors during reconciliation of the cluster configuration.",
+		}, []string{types.LabelClusterConfig}),
+	}
+}

--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/manager/reconciler"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/reconcilerv2"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/store"
-	"github.com/cilium/cilium/pkg/bgpv1/metrics"
+	bgp_metrics "github.com/cilium/cilium/pkg/bgpv1/metrics"
 	ipam_option "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -95,9 +96,11 @@ var Cell = cell.Module(
 	cell.Invoke(
 		// Invoke bgp controller to trigger the constructor.
 		func(*agent.Controller) {},
-		// Register the metrics collector
-		metrics.RegisterCollector,
+		// Register the bgp_metrics collector
+		bgp_metrics.RegisterCollector,
 	),
+
+	metrics.Metric(manager.NewBGPManagerMetrics),
 )
 
 func newBGPPeeringPolicyResource(lc cell.Lifecycle, c client.Clientset, dc *option.DaemonConfig) resource.Resource[*v2alpha1api.CiliumBGPPeeringPolicy] {

--- a/pkg/bgpv1/manager/metrics.go
+++ b/pkg/bgpv1/manager/metrics.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package manager
+
+import (
+	"github.com/cilium/cilium/pkg/bgpv1/types"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+type BGPManagerMetrics struct {
+	// ReconcileErrorCount is the number of errors during reconciliation of the BGP manager.
+	ReconcileErrorCount metric.Vec[metric.Counter]
+
+	// ReconcileRunDuration measures the duration of the reconciliation run. Histogram can
+	// be used to observe the total number of reconciliation runs and distribution of the run
+	// duration.
+	ReconcileRunDuration metric.Vec[metric.Observer]
+}
+
+func NewBGPManagerMetrics() *BGPManagerMetrics {
+	return &BGPManagerMetrics{
+		ReconcileErrorCount: metric.NewCounterVec(metric.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: types.MetricsSubsystem,
+			Name:      "reconcile_error_count",
+			Help:      "The number of errors during reconciliation of the BGP manager",
+		}, []string{types.LabelVRouter}),
+		ReconcileRunDuration: metric.NewHistogramVec(metric.HistogramOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: types.MetricsSubsystem,
+			Name:      "reconcile_run_duration_seconds",
+			Help:      "The duration of the BGP manager reconciliation run",
+		}, []string{types.LabelVRouter}),
+	}
+}

--- a/pkg/bgpv1/metrics/metrics.go
+++ b/pkg/bgpv1/metrics/metrics.go
@@ -19,16 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-const (
-	LabelVRouter     = "vrouter"
-	LabelNeighbor    = "neighbor"
-	LabelNeighborAsn = "neighbor_asn"
-	LabelAfi         = "afi"
-	LabelSafi        = "safi"
-
-	metricsSubsystem = "bgp_control_plane"
-)
-
 type collector struct {
 	SessionState          *prometheus.Desc
 	TotalAdvertisedRoutes *prometheus.Desc
@@ -61,19 +51,19 @@ func RegisterCollector(in collectorIn) {
 	}
 	in.Registry.MustRegister(&collector{
 		SessionState: prometheus.NewDesc(
-			prometheus.BuildFQName(metrics.Namespace, metricsSubsystem, "session_state"),
+			prometheus.BuildFQName(metrics.Namespace, types.MetricsSubsystem, "session_state"),
 			"Current state of the BGP session with the peer, Up = 1 or Down = 0",
-			[]string{LabelVRouter, LabelNeighbor, LabelNeighborAsn}, nil,
+			[]string{types.LabelVRouter, types.LabelNeighbor, types.LabelNeighborAsn}, nil,
 		),
 		TotalAdvertisedRoutes: prometheus.NewDesc(
-			prometheus.BuildFQName(metrics.Namespace, metricsSubsystem, "advertised_routes"),
+			prometheus.BuildFQName(metrics.Namespace, types.MetricsSubsystem, "advertised_routes"),
 			"Number of routes advertised to the peer",
-			[]string{LabelVRouter, LabelNeighbor, LabelNeighborAsn, LabelAfi, LabelSafi}, nil,
+			[]string{types.LabelVRouter, types.LabelNeighbor, types.LabelNeighborAsn, types.LabelAfi, types.LabelSafi}, nil,
 		),
 		TotalReceivedRoutes: prometheus.NewDesc(
-			prometheus.BuildFQName(metrics.Namespace, metricsSubsystem, "received_routes"),
+			prometheus.BuildFQName(metrics.Namespace, types.MetricsSubsystem, "received_routes"),
 			"Number of routes received from the peer",
-			[]string{LabelVRouter, LabelNeighbor, LabelNeighborAsn, LabelAfi, LabelSafi}, nil,
+			[]string{types.LabelVRouter, types.LabelNeighbor, types.LabelNeighborAsn, types.LabelAfi, types.LabelSafi}, nil,
 		),
 		in: in,
 	})

--- a/pkg/bgpv1/types/bgp.go
+++ b/pkg/bgpv1/types/bgp.go
@@ -13,6 +13,17 @@ import (
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
 
+// BGP metric labels
+const (
+	LabelVRouter     = "vrouter"
+	LabelNeighbor    = "neighbor"
+	LabelNeighborAsn = "neighbor_asn"
+	LabelAfi         = "afi"
+	LabelSafi        = "safi"
+
+	MetricsSubsystem = "bgp_control_plane"
+)
+
 // BGPGlobal contains high level BGP configuration for given instance.
 type BGPGlobal struct {
 	ASN                   uint32

--- a/pkg/bgpv1/types/bgp.go
+++ b/pkg/bgpv1/types/bgp.go
@@ -15,11 +15,12 @@ import (
 
 // BGP metric labels
 const (
-	LabelVRouter     = "vrouter"
-	LabelNeighbor    = "neighbor"
-	LabelNeighborAsn = "neighbor_asn"
-	LabelAfi         = "afi"
-	LabelSafi        = "safi"
+	LabelClusterConfig = "bgp_cluster_config"
+	LabelVRouter       = "vrouter"
+	LabelNeighbor      = "neighbor"
+	LabelNeighborAsn   = "neighbor_asn"
+	LabelAfi           = "afi"
+	LabelSafi          = "safi"
 
 	MetricsSubsystem = "bgp_control_plane"
 )


### PR DESCRIPTION
Introducing internal reconciliation metrics which can be used to raise alarms when BGP subsystem is reporting errors or taking longer than usual time to reconcile.

New metrics
- reconcile_error_count ( counter )
- reconcile_run_duration_seconds ( histogram )

reconcile_run_duration_seconds_count metric can be used to track number of reconciliation events in BGP sub-system.

<img width="3189" alt="bgp_reconcile_prom" src="https://github.com/user-attachments/assets/24763781-c9f6-4f47-b8d0-31c027cb26de">


```release-note
BGP: Introducing metrics for tracking health of BGP subsystem reconcile loop
```
