### PR TITLE
hubble: fix metrics configuration parsing

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -229,7 +229,7 @@ cilium-agent [flags]
       --hubble-export-file-path stdout                            Filepath to write Hubble events to. By specifying stdout the flows are logged instead of written to a rotated file.
       --hubble-flowlogs-config-path string                        Filepath with configuration of hubble flowlogs
       --hubble-listen-address string                              An additional address for Hubble server to listen to, e.g. ":4244"
-      --hubble-metrics strings                                    List of Hubble metrics to enable.
+      --hubble-metrics string                                     List of Hubble metrics to enable.
       --hubble-metrics-server string                              Address to serve Hubble metrics on.
       --hubble-metrics-server-enable-tls                          Run the Hubble metrics server on the given listen address with TLS.
       --hubble-metrics-server-tls-cert-file string                Path to the public key file for the Hubble metrics server. The file must contain PEM encoded data.

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -94,7 +94,7 @@ cilium-agent hive [flags]
       --hubble-export-file-path stdout                            Filepath to write Hubble events to. By specifying stdout the flows are logged instead of written to a rotated file.
       --hubble-flowlogs-config-path string                        Filepath with configuration of hubble flowlogs
       --hubble-listen-address string                              An additional address for Hubble server to listen to, e.g. ":4244"
-      --hubble-metrics strings                                    List of Hubble metrics to enable.
+      --hubble-metrics string                                     List of Hubble metrics to enable.
       --hubble-metrics-server string                              Address to serve Hubble metrics on.
       --hubble-metrics-server-enable-tls                          Run the Hubble metrics server on the given listen address with TLS.
       --hubble-metrics-server-tls-cert-file string                Path to the public key file for the Hubble metrics server. The file must contain PEM encoded data.

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -99,7 +99,7 @@ cilium-agent hive dot-graph [flags]
       --hubble-export-file-path stdout                            Filepath to write Hubble events to. By specifying stdout the flows are logged instead of written to a rotated file.
       --hubble-flowlogs-config-path string                        Filepath with configuration of hubble flowlogs
       --hubble-listen-address string                              An additional address for Hubble server to listen to, e.g. ":4244"
-      --hubble-metrics strings                                    List of Hubble metrics to enable.
+      --hubble-metrics string                                     List of Hubble metrics to enable.
       --hubble-metrics-server string                              Address to serve Hubble metrics on.
       --hubble-metrics-server-enable-tls                          Run the Hubble metrics server on the given listen address with TLS.
       --hubble-metrics-server-tls-cert-file string                Path to the public key file for the Hubble metrics server. The file must contain PEM encoded data.

--- a/pkg/hubble/cell/config.go
+++ b/pkg/hubble/cell/config.go
@@ -57,7 +57,7 @@ type config struct {
 	ServerTLSClientCAFiles []string `mapstructure:"hubble-tls-client-ca-files"`
 
 	// Metrics specifies enabled metrics and their configuration options.
-	Metrics []string `mapstructure:"hubble-metrics"`
+	Metrics string `mapstructure:"hubble-metrics"`
 	// EnableOpenMetrics enables exporting hubble metrics in OpenMetrics
 	// format.
 	EnableOpenMetrics bool `mapstructure:"enable-hubble-open-metrics"`
@@ -132,7 +132,7 @@ var defaultConfig = config{
 	ServerTLSKeyFile:       "",
 	ServerTLSClientCAFiles: []string{},
 	// Hubble metrics configuration
-	Metrics:           []string{},
+	Metrics:           "",
 	EnableOpenMetrics: false,
 	// Hubble metrics server configuration
 	MetricsServer:                 "",
@@ -180,7 +180,7 @@ func (def config) Flags(flags *pflag.FlagSet) {
 	flags.String("hubble-tls-cert-file", def.ServerTLSCertFile, "Path to the public key file for the Hubble server. The file must contain PEM encoded data.")
 	flags.String("hubble-tls-key-file", def.ServerTLSKeyFile, "Path to the private key file for the Hubble server. The file must contain PEM encoded data.")
 	flags.StringSlice("hubble-tls-client-ca-files", def.ServerTLSClientCAFiles, "Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.")
-	flags.StringSlice("hubble-metrics", def.Metrics, "List of Hubble metrics to enable.")
+	flags.String("hubble-metrics", def.Metrics, "List of Hubble metrics to enable.")
 	flags.Bool("enable-hubble-open-metrics", def.EnableOpenMetrics, "Enable exporting hubble metrics in OpenMetrics format")
 	// Hubble metrics server configuration
 	flags.String("hubble-metrics-server", def.MetricsServer, "Address to serve Hubble metrics on.")

--- a/pkg/hubble/cell/hubbleintegration.go
+++ b/pkg/hubble/cell/hubbleintegration.go
@@ -367,9 +367,10 @@ func (h *hubbleIntegration) launch(ctx context.Context) {
 					"tls":     h.config.EnableMetricsServerTLS,
 				}).Info("Starting Hubble Metrics server")
 
-				err := metrics.InitMetrics(metrics.Registry, api.ParseStaticMetricsConfig(h.config.Metrics), grpcMetrics)
+				metricConfigs := api.ParseStaticMetricsConfig(strings.Fields(h.config.Metrics))
+				err := metrics.InitMetrics(metrics.Registry, metricConfigs, grpcMetrics)
 				if err != nil {
-					h.log.WithError(err).Error("Unable to setup metrics: %w", err)
+					h.log.WithError(err).Error("Unable to setup metrics")
 					return
 				}
 


### PR DESCRIPTION
Before this patch, the --hubble-metrics flag was declared as a StringSlice which caused split on comma. Since the Hubble Metrics configuration are whitespace separared values that can contain comma, the StringSlice split caused parsing issue for valid configuration.

This patch fix the issue by declaring the flag as a String, and handling the whitespace split manually.

Fix #35619