### PR TITLE
docs, daemon: Deprecate high-scale ipcache mode

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -126,7 +126,6 @@ cilium-agent [flags]
       --enable-health-check-loadbalancer-ip                       Enable access of the healthcheck nodePort on the LoadBalancerIP. Needs --enable-health-check-nodeport to be enabled
       --enable-health-check-nodeport                              Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
       --enable-health-checking                                    Enable connectivity health checking (default true)
-      --enable-high-scale-ipcache                                 Enable the high scale mode for ipcache
       --enable-host-firewall                                      Enable host network policies
       --enable-host-legacy-routing                                Enable the legacy host forwarding model which does not bypass upper stack in host namespace
       --enable-host-port                                          Enable k8s hostPort mapping feature (requires enabling enable-node-port)

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -351,6 +351,7 @@ Removed Options
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~
 
+* The high-scale mode for ipcache has been deprecated and will be removed in v1.18.
 * The hubble-relay flag ``--dial-timeout`` has been deprecated (now a no-op)
   and will be removed in Cilium 1.18.
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -636,6 +636,7 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 
 	flags.Bool(option.EnableHighScaleIPcache, defaults.EnableHighScaleIPcache, "Enable the high scale mode for ipcache")
 	option.BindEnv(vp, option.EnableHighScaleIPcache)
+	flags.MarkDeprecated(option.EnableHighScaleIPcache, "The high-scale mode for ipcache is deprecated and will be removed in v1.18.")
 
 	flags.Bool(option.EnableHostFirewall, false, "Enable host network policies")
 	option.BindEnv(vp, option.EnableHostFirewall)


### PR DESCRIPTION
This feature never made it out of beta. It doesn't even have documentation and has zero known users to this day. It's however covered in CI and adding maintenance burden. Let's deprecate it and remove it in v1.18.