### PR TITLE
chore: quarantine high-scale IPcache

### DIFF
--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -655,7 +655,8 @@ var _ = Describe("K8sDatapathConfig", func() {
 		})
 	})
 
-	SkipContextIf(helpers.DoesNotRunOnNetNextKernel, "High-scale IPcache", func() {
+	// Quarantine waiting for https://github.com/cilium/cilium/pull/36373 before deleting the test
+	SkipContextIf(func() bool { return helpers.DoesNotRunOnNetNextKernel() || helpers.SkipQuarantined() }, "High-scale IPcache", func() {
 		const hsIPcacheFile = "high-scale-ipcache.yaml"
 
 		AfterEach(func() {


### PR DESCRIPTION
Quarantine of high-scale IPCache test, fixing the flake documented in https://github.com/cilium/cilium/issues/36323
Once this PR https://github.com/cilium/cilium/pull/36373 deprecating the high-scale ipcache mode is merged, the test will be deleted

Fixes: [#36323](https://github.com/cilium/cilium/issues/36323)

```release-note
Quarantine of high-scale IPcache
```
