### PR TITLE
CODEOWNERS: Add feature owners for masquerade

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -393,6 +393,7 @@ Makefile* @cilium/build
 /Documentation/network/concepts/ipam/ @cilium/sig-ipam @cilium/docs-structure
 /Documentation/network/concepts/ipam/azure* @cilium/sig-ipam @cilium/azure @cilium/docs-structure
 /Documentation/network/concepts/ipam/eni* @cilium/sig-ipam @cilium/aws @cilium/docs-structure
+/Documentation/network/concepts/masquerading.rst @cilium/sig-datapath @cilium/docs-structure
 /Documentation/network/ebpf/ @cilium/sig-datapath @cilium/docs-structure
 /Documentation/network/egress-gateway-toc.rst @cilium/egress-gateway @cilium/docs-structure
 /Documentation/network/egress-gateway/ @cilium/egress-gateway @cilium/docs-structure


### PR DESCRIPTION
It's useful to have a codeowner for the feature content of pages like this, in addition to the wording/formatting feedback from the @cilium/docs-structure team.