### PR TITLE
Set available addresses when Azure returns nil IP configs

### DIFF
--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -433,7 +433,7 @@ func parseSubnet(subnet *armnetwork.Subnet) (s *ipamTypes.Subnet) {
 			// API / SDK is supposed to return a IpConfigurationsNextLink which can be used to make an additional
 			// call to get all IPConfigs. This field however seems to be missing from the API spec.
 			// Since we cannot fall back to other subnets anyway, assume all IPs are available.
-			// TODO: Update this once there's an official recommendation from Azure.
+			// TODO: Update this once azure-sdk-for-go supports ipConfigurationsNextLink
 			s.AvailableAddresses = c.AvailableIPs()
 		}
 	}

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -428,6 +428,13 @@ func parseSubnet(subnet *armnetwork.Subnet) (s *ipamTypes.Subnet) {
 		s.CIDR = c
 		if subnet.Properties.IPConfigurations != nil {
 			s.AvailableAddresses = c.AvailableIPs() - len(subnet.Properties.IPConfigurations)
+		} else {
+			// Azure currently returns nil for subnet IPConfigs if the subnet has a large number of existing IPConfigs.
+			// API / SDK is supposed to return a IpConfigurationsNextLink which can be used to make an additional
+			// call to get all IPConfigs. This field however seems to be missing from the API spec.
+			// Since we cannot fall back to other subnets anyway, assume all IPs are available.
+			// TODO: Update this once there's an official recommendation from Azure.
+			s.AvailableAddresses = c.AvailableIPs()
 		}
 	}
 


### PR DESCRIPTION
In some scenarios we noticed that in describe VPCs API call, Azure can return nil IP configs for some subnets, even when there are IP configs allocated.

This results in the operator initializing subnets with no available addresses. When this happens operator falls back to selecting other subnets to allocate IPs from, which is also not supported in Azure and results in `VMScaleSetIpConfigurationsOnSameNicCannotUseDifferentSubnets` error code, causing all IP allocations to fail in these subnets. Instead, when IP config is nil, initialize subnets with total IP capacity.

_We filed a support ticket with Azure for clarification on this behavior. Will update the description here once its resolved._
