### PR TITLE
bpf: nodeport: forward L7 svc traffic straight to proxy

### DIFF
--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -8,6 +8,8 @@
 #include <netdev_config.h>
 #include <filter_config.h>
 
+#define IS_BPF_XDP 1
+
 #define SKIP_POLICY_MAP 1
 
 /* Controls the inclusion of the CILIUM_CALL_HANDLE_ICMP6_NS section in the
@@ -185,7 +187,7 @@ int tail_lb_ipv4(struct __ctx_buff *ctx)
 no_encap:
 #endif /* ENABLE_DSR && !ENABLE_DSR_HYBRID && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE */
 
-		ret = nodeport_lb4(ctx, ip4, l3_off, UNKNOWN_ID, &ext_err, &is_dsr);
+		ret = nodeport_lb4(ctx, ip4, l3_off, UNKNOWN_ID, NULL, &ext_err, &is_dsr);
 		if (ret == NAT_46X64_RECIRC)
 			ret = tail_call_internal(ctx, CILIUM_CALL_IPV6_FROM_NETDEV,
 						 &ext_err);
@@ -266,7 +268,7 @@ int tail_lb_ipv6(struct __ctx_buff *ctx)
 			goto drop_err;
 		}
 
-		ret = nodeport_lb6(ctx, ip6, UNKNOWN_ID, &ext_err, &is_dsr);
+		ret = nodeport_lb6(ctx, ip6, UNKNOWN_ID, NULL, &ext_err, &is_dsr);
 		if (IS_ERR(ret))
 			goto drop_err;
 	}


### PR DESCRIPTION
L7 svc requests are currently redirected to cilium_net / cilium_host, where they get marked with MARK_MAGIC_TO_PROXY and then get rerouted to the proxy.

Simplify this by marking the packet in from-netdev and from-overlay, and letting it pass up the stack. This avoids the dependency on skb->cb surviving the transfer from the native program to cilium_net.

The BPF TPROXY path needs further investigation, so only apply this change when BPF TPROXY is disabled.