### PR TITLE
proxyports: Use require.Eventually in tests

### DIFF
--- a/pkg/proxy/proxyports/proxyports_test.go
+++ b/pkg/proxy/proxyports/proxyports_test.go
@@ -61,8 +61,9 @@ func TestPortAllocator(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, port, port1a)
 
-	// Wait past the time the proxy port is released
-	time.Sleep(15 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return pp.nRedirects == 0
+	}, 100*time.Millisecond, time.Millisecond)
 
 	// ProxyPort lingers and can still be found, but it's port is zeroed
 	port1b, _, err := p.GetProxyPort("listener1")
@@ -112,7 +113,11 @@ func TestPortAllocator(t *testing.T) {
 	// 2nd release decreases the count to zero
 	err = p.releaseProxyPort("listener1", time.Microsecond)
 	require.NoError(t, err)
-	time.Sleep(time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		return pp.nRedirects == 0
+	}, 100*time.Millisecond, time.Millisecond)
+
 	require.Equal(t, 0, pp.nRedirects)
 	require.False(t, pp.configured)
 	require.Equal(t, uint16(0), pp.ProxyPort)
@@ -151,7 +156,11 @@ func TestPortAllocator(t *testing.T) {
 	// Release marks the port as unallocated
 	err = p.releaseProxyPort("listener1", time.Microsecond)
 	require.NoError(t, err)
-	time.Sleep(time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		return pp.nRedirects == 0
+	}, 100*time.Millisecond, time.Millisecond)
+
 	require.Equal(t, 0, pp.nRedirects)
 	require.False(t, pp.configured)
 	require.Equal(t, uint16(0), pp.ProxyPort)


### PR DESCRIPTION
Use require.Eventually to wait for the proxy port to be released for up to 100 ms in order to avoid test flakes like:

time="2024-12-05T10:03:53.750539537Z" level=info msg="Adding new proxy port rules for listener1:14623" id=listener1 subsys=proxy
    proxyports_test.go:155:
        	Error Trace:	/host/pkg/proxy/proxyports/proxyports_test.go:155
        	Error:      	Not equal:
        	            	expected: 0
        	            	actual  : 1
        	Test:       	TestPortAllocator
