### PR TITLE
service: Cap number of backends included in monitor message

### DIFF
--- a/pkg/hubble/parser/agent/parser_test.go
+++ b/pkg/hubble/parser/agent/parser_test.go
@@ -284,6 +284,7 @@ func TestDecodeAgentEvent(t *testing.T) {
 						Port: 7077,
 					},
 				},
+				0, // backends omitted
 				"ClusterIP",
 				"myTrafficPolicyExt",
 				"myTrafficPolicyInt",

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -455,8 +455,9 @@ type ServiceUpsertNotificationAddr struct {
 type ServiceUpsertNotification struct {
 	ID uint32 `json:"id"`
 
-	Frontend ServiceUpsertNotificationAddr   `json:"frontend-address"`
-	Backends []ServiceUpsertNotificationAddr `json:"backend-addresses"`
+	Frontend           ServiceUpsertNotificationAddr   `json:"frontend-address"`
+	Backends           []ServiceUpsertNotificationAddr `json:"backend-addresses"`
+	NumBackendsOmitted int                             `json:"num-backends-omitted,omitempty"`
 
 	Type             string `json:"type,omitempty"`
 	ExtTrafficPolicy string `json:"ext-traffic-policy,omitempty"`
@@ -471,17 +472,19 @@ func ServiceUpsertMessage(
 	id uint32,
 	frontend ServiceUpsertNotificationAddr,
 	backends []ServiceUpsertNotificationAddr,
+	numBackendsOmitted int,
 	svcType, svcExtTrafficPolicy, svcIntTrafficPolicy, svcName, svcNamespace string,
 ) AgentNotifyMessage {
 	notification := ServiceUpsertNotification{
-		ID:               id,
-		Frontend:         frontend,
-		Backends:         backends,
-		Type:             svcType,
-		ExtTrafficPolicy: svcExtTrafficPolicy,
-		IntTrafficPolicy: svcIntTrafficPolicy,
-		Name:             svcName,
-		Namespace:        svcNamespace,
+		ID:                 id,
+		Frontend:           frontend,
+		Backends:           backends,
+		NumBackendsOmitted: numBackendsOmitted,
+		Type:               svcType,
+		ExtTrafficPolicy:   svcExtTrafficPolicy,
+		IntTrafficPolicy:   svcIntTrafficPolicy,
+		Name:               svcName,
+		Namespace:          svcNamespace,
 	}
 
 	return AgentNotifyMessage{

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -2132,6 +2132,10 @@ func (s *Service) deleteBackendsFromCacheLocked(svc *svcInfo) ([]lb.BackendID, [
 	return obsoleteBackendIDs, obsoleteBackends
 }
 
+// maxBackendsInMonitorNotifyEvent caps the number of backends to include in the monitor notify event.
+// This avoids constructing large events when service has lots of backends and churn.
+const maxBackendsInMonitorNotifyEvent = 20
+
 func (s *Service) notifyMonitorServiceUpsert(frontend lb.L3n4AddrID, backends []*lb.Backend,
 	svcType lb.SVCType, svcExtTrafficPolicy, svcIntTrafficPolicy lb.SVCTrafficPolicy, svcName, svcNamespace string,
 ) {
@@ -2141,8 +2145,11 @@ func (s *Service) notifyMonitorServiceUpsert(frontend lb.L3n4AddrID, backends []
 		Port: frontend.Port,
 	}
 
-	be := make([]monitorAPI.ServiceUpsertNotificationAddr, 0, len(backends))
-	for _, backend := range backends {
+	numBackendsToInclude := min(maxBackendsInMonitorNotifyEvent, len(backends))
+	numBackendsOmitted := len(backends) - numBackendsToInclude
+
+	be := make([]monitorAPI.ServiceUpsertNotificationAddr, 0, numBackendsToInclude)
+	for _, backend := range backends[:numBackendsToInclude] {
 		b := monitorAPI.ServiceUpsertNotificationAddr{
 			IP:   backend.AddrCluster.AsNetIP(),
 			Port: backend.Port,
@@ -2153,7 +2160,7 @@ func (s *Service) notifyMonitorServiceUpsert(frontend lb.L3n4AddrID, backends []
 	if !option.Config.EnableInternalTrafficPolicy {
 		svcIntTrafficPolicy = lb.SVCTrafficPolicyCluster
 	}
-	msg := monitorAPI.ServiceUpsertMessage(id, fe, be, string(svcType), string(svcExtTrafficPolicy), string(svcIntTrafficPolicy), svcName, svcNamespace)
+	msg := monitorAPI.ServiceUpsertMessage(id, fe, be, numBackendsOmitted, string(svcType), string(svcExtTrafficPolicy), string(svcIntTrafficPolicy), svcName, svcNamespace)
 	s.monitorAgent.SendEvent(monitorAPI.MessageTypeAgent, msg)
 }
 


### PR DESCRIPTION
Limit the number of backends included in the ServiceUpsertMessage to avoid performing significant amount of allocations for services with lots of backends and churn. The number of omitted backends is included in the monitor message.

This is the second part of addressing a significant memory "leak" issue with services that have lots of backends. The root problem was the Hubble ring buffer holding onto lots of ServiceUpsertNotifications, which is fixed in https://github.com/cilium/cilium/pull/36391. After 36391 the remaining use-case for the service messages is just `cilium-dbg monitor`, so there isn't too much of a point to doing lots of work to generate the message.