### PR TITLE
bpf: host: exit early when to-host handles to-proxy traffic

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1662,15 +1662,14 @@ int cil_to_host(struct __ctx_buff *ctx)
 	} else if ((magic & 0xFFFF) == MARK_MAGIC_TO_PROXY) {
 		/* Upper 16 bits may carry proxy port number */
 		__be16 port = magic >> 16;
-
-		ctx_store_meta(ctx, CB_PROXY_MAGIC, 0);
-		ret = ctx_redirect_to_proxy_first(ctx, port);
-		if (IS_ERR(ret))
-			goto out;
 		/* We already traced this in the previous prog with more
 		 * background context, skip trace here.
 		 */
 		traced = true;
+
+		ctx_store_meta(ctx, CB_PROXY_MAGIC, 0);
+		ret = ctx_redirect_to_proxy_first(ctx, port);
+		goto out;
 	}
 
 #ifdef ENABLE_IPSEC


### PR DESCRIPTION
When the to-host program handles traffic marked as MARK_MAGIC_TO_PROXY, it currently continues through the remaining datapath flow before returning.

That's rather unexpected, and we certainly don't want to apply HostFW or RevDNAT logic to our own proxy-destined traffic. Let's skip to the end straight away.

Fixes: #36324