### PR TITLE
daemon: disable dependent bpf-sock-lb options if bpf-sock-lb=false

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -234,6 +234,11 @@ func initKubeProxyReplacementOptions(sysctl sysctl.Sysctl, tunnelConfig tunnel.C
 		option.Config.EnableSocketLBTracing = false
 	}
 
+	if !option.Config.EnableSocketLB {
+		option.Config.EnableSocketLBTracing = false
+		option.Config.EnableSocketLBPeer = false
+	}
+
 	if option.Config.DryMode {
 		return nil
 	}

--- a/daemon/cmd/kube_proxy_replacement_test.go
+++ b/daemon/cmd/kube_proxy_replacement_test.go
@@ -215,7 +215,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			},
 		},
 
-		// KPR false: all options disabled exception socket LB tracing
+		// KPR false: all options disabled
 		{
 			"kpr-disabled",
 			func(cfg *kprConfig) {
@@ -229,7 +229,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 				enableSessionAffinity:   false,
 				enableIPSec:             false,
 				enableHostLegacyRouting: false,
-				enableSocketLBTracing:   true,
+				enableSocketLBTracing:   false,
 				expectedErrorRegex:      "",
 			},
 		},


### PR DESCRIPTION
Socket LB tracing and support for getpeername are only supported if bpf-sock-lb is true.

Because the default value for option.Config.EnableSocketLBTracing is true[^1], e.g. the cgroup manager cell is still coming up in these cases[^2], leading to unnecessary work and log messages (previously warnings) being emitted. Avoid this by disabling these two options in case bpf-sock-lb=false

[^1]: https://github.com/cilium/cilium/blob/429b2a0afcc806b4d6b3162de843f107eec1d8fd/daemon/cmd/daemon_main.go#L349
[^2]: https://github.com/cilium/cilium/blob/429b2a0afcc806b4d6b3162de843f107eec1d8fd/pkg/cgroups/manager/cell.go#L32-L43