### PR TITLE
.github/workflows: Enable DualStack for conformance-kind-proxy-embedded

### DIFF
--- a/.github/kind-config-dual.yaml
+++ b/.github/kind-config-dual.yaml
@@ -1,0 +1,18 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      # To make sure that there is no taint for master node.
+      # Otherwise additional worker node might be required for conformance testing.
+      - |
+        apiVersion: kubeadm.k8s.io/v1beta3
+        kind: InitConfiguration
+        nodeRegistration:
+          taints: []
+  - role: worker
+networking:
+  ipFamily: dual
+  disableDefaultCNI: true
+  podSubnet: "10.244.0.0/16,fd00:10:244::/48"
+  serviceSubnet: "10.245.0.0/16,fd00:10:96::/112"

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  kind_config: .github/kind-config.yaml
+  kind_config: .github/kind-config-dual.yaml
 
 jobs:
   installation-and-connectivity:
@@ -62,6 +62,7 @@ jobs:
             --helm-set=loadBalancer.l7.backend=envoy \
             --helm-set=tls.secretsBackend=k8s \
             --helm-set=envoy.enabled=false \
+            --helm-set=ipv6.enabled=true \
             --wait=false"
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --test-concurrency=5 --hubble=false --collect-sysdump-on-failure"
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR changes the conformance-kind-proxy-embedded workflow to enable DualStack for the kind cluster and Cilium to enable more tests.
