### PR TITLE
Lower interval for icmp probes and stop on first success

### DIFF
--- a/pkg/health/server/prober.go
+++ b/pkg/health/server/prober.go
@@ -296,6 +296,7 @@ func icmpPing(node string, ip string, ctx context.Context, resChan chan<- connec
 
 	pinger.Timeout = probeDeadline
 	pinger.Count = nReqs
+	pinger.Interval = 100 * time.Millisecond
 	pinger.OnFinish = func(stats *probing.Statistics) {
 		if stats.PacketsRecv > 0 && len(stats.Rtts) > 0 {
 			if debugLogsEnabled {


### PR DESCRIPTION
Related: https://github.com/cilium/cilium/pull/36023
Commit messages:
```
pro-bing seems to be performing reads from connections with expBackoff
from 50 microseconds ... 100 ms:
https://github.com/cilium/cilium/blob/282b0a96f388a90894b95023d6a48f02410d86c6/vendor/github.com/prometheus-community/pro-bing/ping.go#L727
As we increased number of probes from 1 to 3, with default interval of
1s, it was unnecessarily looping there, causing additional overhead on
golang scheduler.
Let's decrease probing interval so we don't do unnecessary loops there.
```
```
As we are only reporting latency of first probe and are mostly
interested if probe was successful, let's stop probing once we receive
first response.
```

I've decided to skip release notes for this PR, as it is just improvement of related PR.

CPU usage is back to normal with this change:
```
metric: Average CPU Usage: Perc50, value: 0.06689166666666668, threshold: 0.1 (upper bound)
```
from https://github.com/cilium/cilium/actions/runs/12197202693/job/34026354456
before:
![image](https://github.com/user-attachments/assets/6eb3acf7-bf0f-48b1-a0a7-85a7eaaea1bb)
