### PR TITLE
operator: skip CES list if CES disabled with cilium-operator managed identities

### DIFF
--- a/operator/pkg/ciliumidentity/reconciler.go
+++ b/operator/pkg/ciliumidentity/reconciler.go
@@ -86,9 +86,13 @@ func newReconciler(
 	if err != nil {
 		return nil, err
 	}
-	cesStore, err := ciliumEndpointSlice.Store(ctx)
-	if err != nil {
-		return nil, err
+
+	var cesStore resource.Store[*v2alpha1.CiliumEndpointSlice]
+	if cesEnabled {
+		cesStore, err = ciliumEndpointSlice.Store(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	r := &reconciler{


### PR DESCRIPTION
When cilium-operator manages identities, it retrieve CiliumEndpointSlice
only when CES is enabled. Otherwise the LIST request fails since the CES CRD
isn't installed:

    failed to list *v2alpha1.CiliumEndpointSlice:
    the server could not find the requested resource (get ciliumendpointslices.cilium.io)

```release-note
When cilium-operator managing identities is enabled, cilium-operator LISTs CiliumEndpointSlice only if CES is enabled.
```
