### PR TITLE
Add the tls:// prefix in the Hubble TLS doc

### DIFF
--- a/Documentation/observability/hubble/configuration/tls.rst
+++ b/Documentation/observability/hubble/configuration/tls.rst
@@ -362,11 +362,11 @@ Now try to query the Hubble server without providing any client certificate:
 .. code-block:: shell-session
 
     $ kubectl exec -it -n kube-system deployment/hubble-cli -- \
-    hubble observe --server ${IP?}:4244 \
+    hubble observe --server tls://${IP?}:4244 \
         --tls-server-name ${SERVERNAME?} \
         --tls-ca-cert-files /var/lib/hubble-relay/tls/hubble-server-ca.crt
 
-    failed to connect to '172.18.0.2:4244': context deadline exceeded: connection error: desc = "transport: authentication handshake failed: mTLS client certificate requested, but not provided"
+    failed to connect to '172.18.0.2:4244': context deadline exceeded: connection error: desc = "error reading server preface: remote error: tls: certificate requiredd"
     command terminated with exit code 1
 
 You can also try to connect without TLS:


### PR DESCRIPTION
Just found I didn't update the prefix in the same doc in my previous PR https://github.com/cilium/cilium/pull/36118.

Double checked that page and there shouldn't any such mistake.