### PR TITLE
helm: configure cilium-operator managing identities

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2292,6 +2292,10 @@
      - Time to wait before using new identity on endpoint identity change.
      - string
      - ``"5s"``
+   * - :spelling:ignore:`identityManagementMode`
+     - Control whether CiliumIdentities are created by the agent ("agent"), the operator ("operator") or both ("both"). "Both" should be used only to migrate between "agent" and "operator". Operator-managed identities is a beta feature.
+     - string
+     - ``"agent"``
    * - :spelling:ignore:`image`
      - Agent container image.
      - object

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -623,6 +623,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | hubble-ui update strategy. |
 | identityAllocationMode | string | `"crd"` | Method to use for identity allocation (`crd`, `kvstore` or `doublewrite-readkvstore` / `doublewrite-readcrd` for migrating between identity backends). |
 | identityChangeGracePeriod | string | `"5s"` | Time to wait before using new identity on endpoint identity change. |
+| identityManagementMode | string | `"agent"` | Control whether CiliumIdentities are created by the agent ("agent"), the operator ("operator") or both ("both"). "Both" should be used only to migrate between "agent" and "operator". Operator-managed identities is a beta feature. |
 | image | object | `{"digest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-ci","tag":"latest","useDigest":false}` | Agent container image. |
 | imagePullSecrets | list | `[]` | Configure image pull secrets for pulling container images |
 | ingressController.default | bool | `false` | Set cilium ingress controller to be the default ingress controller This will let cilium ingress controller route entries without ingress class set |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1205,6 +1205,8 @@ data:
   {{- end }}
 {{- end }}
 
+  identity-management-mode: {{ .Values.identityManagementMode | quote }}
+
 {{- if hasKey .Values "enableK8sTerminatingEndpoint" }}
   enable-k8s-terminating-endpoint: {{ .Values.enableK8sTerminatingEndpoint | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -164,6 +164,9 @@ rules:
   verbs:
   # To synchronize garbage collection of such resources
   - update
+  {{- if (or (eq .Values.identityManagementMode "operator") (eq .Values.identityManagementMode "both")) }}
+  - create
+  {{- end }}
 - apiGroups:
   - cilium.io
   resources:

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -3600,6 +3600,13 @@
     "identityChangeGracePeriod": {
       "type": "string"
     },
+    "identityManagementMode": {
+      "enum": [
+        "agent",
+        "operator",
+        "both"
+      ]
+    },
     "image": {
       "properties": {
         "digest": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -823,6 +823,13 @@ ciliumEndpointSlice:
   # identity groups together CiliumEndpoints that share the same identity.
   # fcfs groups together CiliumEndpoints in a first-come-first-serve basis, filling in the largest non-full slice first.
   sliceMode: identity
+# @schema
+# enum: ["agent", "operator", "both"]
+# @schema
+# -- Control whether CiliumIdentities are created by the agent ("agent"), the operator ("operator") or both ("both").
+# "Both" should be used only to migrate between "agent" and "operator".
+# Operator-managed identities is a beta feature.
+identityManagementMode: "agent"
 envoyConfig:
   # -- Enable CiliumEnvoyConfig CRD
   # CiliumEnvoyConfig CRD can also be implicitly enabled by other options.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -829,6 +829,14 @@ ciliumEndpointSlice:
   # fcfs groups together CiliumEndpoints in a first-come-first-serve basis, filling in the largest non-full slice first.
   sliceMode: identity
 
+# @schema
+# enum: ["agent", "operator", "both"]
+# @schema
+# -- Control whether CiliumIdentities are created by the agent ("agent"), the operator ("operator") or both ("both").
+# "Both" should be used only to migrate between "agent" and "operator".
+# Operator-managed identities is a beta feature.
+identityManagementMode: "agent"
+
 envoyConfig:
   # -- Enable CiliumEnvoyConfig CRD
   # CiliumEnvoyConfig CRD can also be implicitly enabled by other options.

--- a/operator/pkg/ciliumidentity/cell.go
+++ b/operator/pkg/ciliumidentity/cell.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 // Cell implements the CID Controller. It subscribes to CID, CES, Pods
@@ -21,15 +22,23 @@ var Cell = cell.Module(
 )
 
 type config struct {
+	IdentityManagementMode string `mapstructure:"identity-management-mode"`
+
+	// Deprecated in favor of IdentityManagementMode.
 	EnableOperatorManageCIDs bool `mapstructure:"operator-manages-identities"`
 }
 
 func (c config) Flags(flags *pflag.FlagSet) {
+	flags.String(option.IdentityManagementMode, c.IdentityManagementMode, "Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both")
+	flags.MarkHidden(option.IdentityManagementMode) // See https://github.com/cilium/cilium/issues/34675
+
+	// Deprecated in favor of IdentityManagementMode
 	flags.Bool("operator-manages-identities", c.EnableOperatorManageCIDs, "Enables operator to manage Cilium Identities by running a Cilium Identity controller")
 	flags.MarkHidden("operator-manages-identities") // See https://github.com/cilium/cilium/issues/34675
 }
 
 var defaultConfig = config{
+	IdentityManagementMode:   option.IdentityManagementModeAgent,
 	EnableOperatorManageCIDs: false,
 }
 

--- a/operator/pkg/ciliumidentity/controller.go
+++ b/operator/pkg/ciliumidentity/controller.go
@@ -24,6 +24,7 @@ import (
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 const (
@@ -90,9 +91,15 @@ type Controller struct {
 }
 
 func registerController(p params) {
+	isOperatorManageCIDsEnabled := cmp.Or(
+		p.Config.IdentityManagementMode == option.IdentityManagementModeOperator,
+		p.Config.IdentityManagementMode == option.IdentityManagementModeBoth,
+		p.Config.EnableOperatorManageCIDs, // backwards-compatibility with deprecated operator-manages-identities flag.
+	)
+
 	if cmp.Or(
 		!p.Clientset.IsEnabled(),
-		!p.Config.EnableOperatorManageCIDs,
+		!isOperatorManageCIDsEnabled,
 		p.SharedCfg.DisableNetworkPolicy,
 	) {
 		return

--- a/operator/pkg/ciliumidentity/controller_test.go
+++ b/operator/pkg/ciliumidentity/controller_test.go
@@ -29,6 +29,7 @@ import (
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -114,8 +115,16 @@ func initHiveTest(operatorManagingCID bool) (*resource.Resource[*capi_v2.CiliumI
 		k8s.ResourcesCell,
 		metrics.Metric(NewMetrics),
 		cell.Provide(func() config {
-			return config{
-				EnableOperatorManageCIDs: operatorManagingCID,
+			if operatorManagingCID {
+				return config{
+					IdentityManagementMode:   option.IdentityManagementModeOperator,
+					EnableOperatorManageCIDs: true, // deprecated
+				}
+			} else {
+				return config{
+					IdentityManagementMode:   option.IdentityManagementModeAgent,
+					EnableOperatorManageCIDs: false, // deprecated
+				}
 			}
 		}),
 		cell.Provide(func() SharedConfig {

--- a/pkg/identity/cache/cell/cell.go
+++ b/pkg/identity/cache/cell/cell.go
@@ -4,6 +4,7 @@
 package identitycachecell
 
 import (
+	"cmp"
 	"context"
 	"log/slog"
 	"maps"
@@ -94,15 +95,23 @@ type identityAllocatorOut struct {
 }
 
 type config struct {
+	IdentityManagementMode string `mapstructure:"identity-management-mode"`
+
+	// Deprecated in favor of IdentityManagementMode.
 	EnableOperatorManageCIDs bool `mapstructure:"operator-manages-identities"`
 }
 
 func (c config) Flags(flags *pflag.FlagSet) {
+	flags.String(option.IdentityManagementMode, c.IdentityManagementMode, "Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both")
+	flags.MarkHidden(option.IdentityManagementMode) // See https://github.com/cilium/cilium/issues/34675
+
+	// Deprecated in favor of IdentityManagementMode
 	flags.Bool("operator-manages-identities", c.EnableOperatorManageCIDs, "Enables operator to manage Cilium Identities by running a Cilium Identity controller")
 	flags.MarkHidden("operator-manages-identities") // See https://github.com/cilium/cilium/issues/34675
 }
 
 var defaultConfig = config{
+	IdentityManagementMode:   option.IdentityManagementModeAgent,
 	EnableOperatorManageCIDs: false,
 }
 
@@ -119,8 +128,14 @@ func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
 	var idAlloc CachingIdentityAllocator
 
 	if option.NetworkPolicyEnabled(option.Config) {
+		isOperatorManageCIDsEnabled := cmp.Or(
+			params.Config.IdentityManagementMode == option.IdentityManagementModeOperator,
+			params.Config.IdentityManagementMode == option.IdentityManagementModeBoth,
+			params.Config.EnableOperatorManageCIDs, // backwards-compatibility with deprecated operator-manages-identities flag.
+		)
+
 		allocatorConfig := cache.AllocatorConfig{
-			EnableOperatorManageCIDs: params.Config.EnableOperatorManageCIDs,
+			EnableOperatorManageCIDs: isOperatorManageCIDsEnabled,
 		}
 
 		// Allocator: allocates local and cluster-wide security identities.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1201,6 +1201,9 @@ const (
 	// EnableCiliumEndpointSlice enables the cilium endpoint slicing feature.
 	EnableCiliumEndpointSlice = "enable-cilium-endpoint-slice"
 
+	// IdentityManagementMode controls whether CiliumIdentities are managed by cilium-agent, cilium-operator, or both.
+	IdentityManagementMode = "identity-management-mode"
+
 	// EnableExternalWorkloads enables the support for external workloads.
 	EnableExternalWorkloads = "enable-external-workloads"
 
@@ -1267,6 +1270,16 @@ const (
 
 	// PprofPortAgent is the default value for pprof in the agent
 	PprofPortAgent = 6060
+
+	// IdentityManagementModeAgent means cilium-agent is solely responsible for managing CiliumIdentity.
+	IdentityManagementModeAgent = "agent"
+
+	// IdentityManagementModeOperator means cilium-operator is solely responsible for managing CiliumIdentity.
+	IdentityManagementModeOperator = "operator"
+
+	// IdentityManagementModeBoth means cilium-agent and cilium-operator both manage identities
+	// (used only during migration between "agent" and "operator").
+	IdentityManagementModeBoth = "both"
 )
 
 // getEnvName returns the environment variable to be used for the given option name.


### PR DESCRIPTION
Add new helm value identityManagementMode that is an enum of:
* "agent": cilium-agent manages identities (current default).
* "operator": cilium-operator manages identities.
* "both": migration mode where both agent and operator manage identities.

When operator manages identities, its cluster role adds "create" permission for CiliumIdentity.

Per discussion on the PR, this also adds a new config option `identity-management-mode` shared between operator and agent.
The new config option deprecates the flag `operator-manages-identities`.

Related: https://github.com/cilium/design-cfps/pull/59

```release-note
helm: add identityManagementMode option to allow cilium-operator to manage identities.
```
