### PR TITLE
bgpv2: Support overlapping selector matches on CiliumBGPAdvertisement

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/policies_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/policies_test.go
@@ -1,0 +1,490 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconcilerv2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/bgpv1/types"
+)
+
+func Test_MergeRoutePolicies(t *testing.T) {
+
+	localPrefDefault := int64(100)
+	localPrefLow := int64(50)
+	localPrefHigh := int64(200)
+
+	var nilPointerInt64 *int64
+
+	conditionsNeighborOne := types.RoutePolicyConditions{
+		MatchNeighbors: []string{"fd00::1"},
+		MatchFamilies:  []types.Family{{Afi: types.AfiIPv6}},
+	}
+
+	conditionsNeighborThree := types.RoutePolicyConditions{
+		MatchNeighbors: []string{"fd00::3"},
+		MatchFamilies:  []types.Family{{Afi: types.AfiIPv6}},
+	}
+
+	tests := []struct {
+		name          string
+		policyA       *types.RoutePolicy
+		policyB       *types.RoutePolicy
+		errorExpected bool
+		expected      *types.RoutePolicy
+	}{
+		{
+			name:          "nil policy",
+			policyA:       nil,
+			policyB:       nil,
+			errorExpected: true,
+			expected:      nil,
+		},
+		{
+			name:    "nil policyA",
+			policyA: nil,
+			policyB: &types.RoutePolicy{
+				Name: "policy",
+			},
+			errorExpected: true,
+			expected:      nil,
+		},
+		{
+			name: "nil policyB",
+			policyA: &types.RoutePolicy{
+				Name: "policy",
+			},
+			policyB:       nil,
+			errorExpected: true,
+			expected:      nil,
+		},
+		{
+			name: "policy names mismatched",
+			policyA: &types.RoutePolicy{
+				Name: "policy",
+			},
+			policyB: &types.RoutePolicy{
+				Name: "notpolicy",
+			},
+			errorExpected: true,
+			expected:      nil,
+		},
+		{
+			name: "policy types mismatched",
+			policyA: &types.RoutePolicy{
+				Name: "policy",
+				Type: types.RoutePolicyTypeExport,
+			},
+			policyB: &types.RoutePolicy{
+				Name: "policy",
+				Type: types.RoutePolicyTypeImport,
+			},
+			errorExpected: true,
+			expected:      nil,
+		},
+		{
+			name: "empty statements",
+			policyA: &types.RoutePolicy{
+				Name:       "policy",
+				Statements: []*types.RoutePolicyStatement{},
+			},
+			policyB: &types.RoutePolicy{
+				Name:       "policy",
+				Statements: []*types.RoutePolicyStatement{},
+			},
+			errorExpected: false,
+			expected: &types.RoutePolicy{
+				Name:       "policy",
+				Statements: []*types.RoutePolicyStatement{},
+			},
+		},
+		{
+			name: "nil statement.Action.SetLocalPref",
+			policyA: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:        types.RoutePolicyActionAccept,
+							SetLocalPreference: nil,
+						},
+					},
+				},
+			},
+			policyB: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:        types.RoutePolicyActionAccept,
+							SetLocalPreference: nil,
+						},
+					},
+				},
+			},
+			errorExpected: false,
+			expected: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:        types.RoutePolicyActionAccept,
+							SetLocalPreference: nil,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "nil dereferenced statement.Action.SetLocalPref",
+			policyA: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:        types.RoutePolicyActionAccept,
+							SetLocalPreference: nilPointerInt64, // can be nil or a nil pointer
+						},
+					},
+				},
+			},
+			policyB: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:        types.RoutePolicyActionAccept,
+							SetLocalPreference: &localPrefDefault, // In policy B, local pref is set
+						},
+					},
+				},
+			},
+			errorExpected: false,
+			expected: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction: types.RoutePolicyActionAccept,
+							// Ensures that nil is properly handled by selecting the non-nil value
+							SetLocalPreference: &localPrefDefault,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "both set standard communities",
+			policyA: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:    types.RoutePolicyActionAccept,
+							AddCommunities: []string{"100:100", "101:101"},
+						},
+					},
+				},
+			},
+			policyB: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:    types.RoutePolicyActionAccept,
+							AddCommunities: []string{"200:200", "202:202"},
+						},
+					},
+				},
+			},
+			errorExpected: false,
+			expected: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:    types.RoutePolicyActionAccept,
+							AddCommunities: []string{"100:100", "101:101", "200:200", "202:202"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "both set large communities",
+			policyA: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:         types.RoutePolicyActionAccept,
+							AddLargeCommunities: []string{"1000:1000:1000", "1111:1111:1111"},
+						},
+					},
+				},
+			},
+			policyB: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:         types.RoutePolicyActionAccept,
+							AddLargeCommunities: []string{"2000:2000:2000", "2222:2222:2222"},
+						},
+					},
+				},
+			},
+			errorExpected: false,
+			expected: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction: types.RoutePolicyActionAccept,
+							AddLargeCommunities: []string{
+								"1000:1000:1000",
+								"1111:1111:1111",
+								"2000:2000:2000",
+								"2222:2222:2222",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "both set standard and large communities",
+			policyA: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:    types.RoutePolicyActionAccept,
+							AddCommunities: []string{"100:100", "101:101"},
+						},
+					},
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:         types.RoutePolicyActionAccept,
+							AddLargeCommunities: []string{"1000:1000:1000", "1111:1111:1111"},
+						},
+					},
+				},
+			},
+			policyB: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:    types.RoutePolicyActionAccept,
+							AddCommunities: []string{"200:200", "202:202"},
+						},
+					},
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:         types.RoutePolicyActionAccept,
+							AddLargeCommunities: []string{"2000:2000:2000", "2222:2222:2222"},
+						},
+					},
+					{
+						Conditions: conditionsNeighborThree,
+						Actions: types.RoutePolicyActions{
+							RouteAction:         types.RoutePolicyActionAccept,
+							AddLargeCommunities: []string{"3333:3333:3333"},
+						},
+					},
+				},
+			},
+			errorExpected: false,
+			expected: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:    types.RoutePolicyActionAccept,
+							AddCommunities: []string{"100:100", "101:101", "200:200", "202:202"},
+							AddLargeCommunities: []string{
+								"1000:1000:1000",
+								"1111:1111:1111",
+								"2000:2000:2000",
+								"2222:2222:2222",
+							},
+						},
+					},
+					{
+						Conditions: conditionsNeighborThree,
+						Actions: types.RoutePolicyActions{
+							RouteAction:         types.RoutePolicyActionAccept,
+							AddLargeCommunities: []string{"3333:3333:3333"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "deduplicates standard and large communities",
+			policyA: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:         types.RoutePolicyActionAccept,
+							AddCommunities:      []string{"100:100", "101:101"},
+							AddLargeCommunities: []string{"1000:1000:1000", "1111:1111:1111"},
+						},
+					},
+				},
+			},
+			policyB: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:         types.RoutePolicyActionAccept,
+							AddCommunities:      []string{"100:100", "101:101", "200:200"},
+							AddLargeCommunities: []string{"1000:1000:1000", "2000:2000:2000", "2222:2222:2222"},
+						},
+					},
+				},
+			},
+			errorExpected: false,
+			expected: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:    types.RoutePolicyActionAccept,
+							AddCommunities: []string{"100:100", "101:101", "200:200"},
+							AddLargeCommunities: []string{
+								"1000:1000:1000",
+								"1111:1111:1111",
+								"2000:2000:2000",
+								"2222:2222:2222",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "both set standard and large communities with differing local preference",
+			policyA: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:        types.RoutePolicyActionAccept,
+							AddCommunities:     []string{"100:100", "101:101"},
+							SetLocalPreference: &localPrefLow,
+						},
+					},
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:         types.RoutePolicyActionAccept,
+							AddLargeCommunities: []string{"1000:1000:1000", "1111:1111:1111"},
+							SetLocalPreference:  &localPrefLow,
+						},
+					},
+				},
+			},
+			policyB: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:        types.RoutePolicyActionAccept,
+							AddCommunities:     []string{"200:200", "202:202"},
+							SetLocalPreference: &localPrefHigh,
+						},
+					},
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:         types.RoutePolicyActionAccept,
+							AddLargeCommunities: []string{"2000:2000:2000", "2222:2222:2222"},
+							SetLocalPreference:  &localPrefHigh,
+						},
+					},
+					{
+						Conditions: conditionsNeighborThree,
+						Actions: types.RoutePolicyActions{
+							RouteAction:         types.RoutePolicyActionAccept,
+							AddLargeCommunities: []string{"3333:3333:3333"},
+							SetLocalPreference:  &localPrefDefault,
+						},
+					},
+				},
+			},
+			errorExpected: false,
+			expected: &types.RoutePolicy{
+				Name: "policy",
+				Statements: []*types.RoutePolicyStatement{
+					{
+						Conditions: conditionsNeighborOne,
+						Actions: types.RoutePolicyActions{
+							RouteAction:    types.RoutePolicyActionAccept,
+							AddCommunities: []string{"100:100", "101:101", "200:200", "202:202"},
+							AddLargeCommunities: []string{
+								"1000:1000:1000",
+								"1111:1111:1111",
+								"2000:2000:2000",
+								"2222:2222:2222",
+							},
+							SetLocalPreference: &localPrefHigh,
+						},
+					},
+					{
+						Conditions: conditionsNeighborThree,
+						Actions: types.RoutePolicyActions{
+							RouteAction:         types.RoutePolicyActionAccept,
+							AddLargeCommunities: []string{"3333:3333:3333"},
+							SetLocalPreference:  &localPrefDefault,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			result, err := MergeRoutePolicies(tt.policyA, tt.policyB)
+			if tt.errorExpected == true {
+				req.Error(err)
+			} else {
+				req.NoError(err)
+			}
+
+			req.Equal(tt.expected, result)
+		})
+	}
+
+}

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -271,28 +271,49 @@ func (r *ServiceReconciler) getDesiredSvcRoutePolicies(p ReconcileParams, desire
 				if !labelSelector.Matches(serviceLabelSet(svc)) {
 					continue
 				}
+
 				// LoadBalancerIP
 				lbPolicy, err := r.getLoadBalancerIPRoutePolicy(p, peer, agentFamily, svc, advert, ls)
 				if err != nil {
 					return nil, fmt.Errorf("failed to get desired LoadBalancerIP route policy: %w", err)
 				}
 				if lbPolicy != nil {
+					currentLbPolicy := desiredSvcRoutePolicies[lbPolicy.Name]
+					if currentLbPolicy != nil {
+						if lbPolicy, err = MergeRoutePolicies(currentLbPolicy, lbPolicy); err != nil {
+							return nil, err
+						}
+					}
 					desiredSvcRoutePolicies[lbPolicy.Name] = lbPolicy
 				}
+
 				// ExternalIP
 				extPolicy, err := r.getExternalIPRoutePolicy(p, peer, agentFamily, svc, advert, ls)
 				if err != nil {
 					return nil, fmt.Errorf("failed to get desired ExternalIP route policy: %w", err)
 				}
 				if extPolicy != nil {
+					currentExtPolicy := desiredSvcRoutePolicies[extPolicy.Name]
+					if currentExtPolicy != nil {
+						if extPolicy, err = MergeRoutePolicies(currentExtPolicy, extPolicy); err != nil {
+							return nil, err
+						}
+					}
 					desiredSvcRoutePolicies[extPolicy.Name] = extPolicy
 				}
+
 				// ClusterIP
 				clusterPolicy, err := r.getClusterIPRoutePolicy(p, peer, agentFamily, svc, advert, ls)
 				if err != nil {
 					return nil, fmt.Errorf("failed to get desired ClusterIP route policy: %w", err)
 				}
 				if clusterPolicy != nil {
+					currentClusterPolicy := desiredSvcRoutePolicies[clusterPolicy.Name]
+					if currentClusterPolicy != nil {
+						if clusterPolicy, err = MergeRoutePolicies(currentClusterPolicy, clusterPolicy); err != nil {
+							return nil, err
+						}
+					}
 					desiredSvcRoutePolicies[clusterPolicy.Name] = clusterPolicy
 				}
 			}

--- a/pkg/bgpv1/types/bgp.go
+++ b/pkg/bgpv1/types/bgp.go
@@ -6,6 +6,7 @@ package types
 import (
 	"context"
 	"net/netip"
+	"strings"
 
 	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
 
@@ -124,6 +125,19 @@ type RoutePolicyConditions struct {
 	MatchPrefixes []*RoutePolicyPrefixMatch
 	// MatchFamilies matches ANY of the provided address families. If empty matches all address families.
 	MatchFamilies []Family
+}
+
+// String() constructs a string identifier
+func (r RoutePolicyConditions) String() string {
+	values := []string{}
+	values = append(values, r.MatchNeighbors...)
+	for _, family := range r.MatchFamilies {
+		values = append(values, family.String())
+	}
+	for _, prefix := range r.MatchPrefixes {
+		values = append(values, prefix.CIDR.String())
+	}
+	return strings.Join(values, "-")
 }
 
 // RoutePolicyAction defines the action taken on a route matched by a routing policy.

--- a/pkg/bgpv1/types/bgp_test.go
+++ b/pkg/bgpv1/types/bgp_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_RoutePolicyConditionsString(t *testing.T) {
+	testPrefix, err := netip.ParsePrefix("192.2.0.1/24")
+	if err != nil {
+		t.Error(err)
+	}
+
+	tests := []struct {
+		name       string
+		conditions RoutePolicyConditions
+		expected   string
+	}{
+		{
+			name:       "empty",
+			conditions: RoutePolicyConditions{},
+			expected:   "",
+		},
+		{
+			name: "sets only neighbors",
+			conditions: RoutePolicyConditions{
+				MatchNeighbors: []string{"192.2.0.1", "192.2.0.2"},
+				MatchPrefixes:  []*RoutePolicyPrefixMatch{},
+				MatchFamilies:  []Family{},
+			},
+			expected: "192.2.0.1-192.2.0.2",
+		},
+		{
+			name: "sets only prefixes",
+			conditions: RoutePolicyConditions{
+				MatchNeighbors: []string{},
+				MatchPrefixes: []*RoutePolicyPrefixMatch{
+					{
+						CIDR: testPrefix,
+					}},
+				MatchFamilies: []Family{},
+			},
+			expected: "192.2.0.1/24",
+		},
+		{
+			name: "sets only families",
+			conditions: RoutePolicyConditions{
+				MatchNeighbors: []string{},
+				MatchPrefixes:  []*RoutePolicyPrefixMatch{},
+				MatchFamilies: []Family{
+					{
+						Afi:  AfiIPv6,
+						Safi: SafiUnicast,
+					},
+				},
+			},
+			expected: "ipv6-unicast",
+		},
+		{
+			name: "sets families and prefixes",
+			conditions: RoutePolicyConditions{
+				MatchNeighbors: []string{},
+				MatchPrefixes: []*RoutePolicyPrefixMatch{
+					{
+						CIDR: testPrefix,
+					},
+				},
+				MatchFamilies: []Family{
+					{
+						Afi:  AfiIPv6,
+						Safi: SafiUnicast,
+					},
+				},
+			},
+			expected: "ipv6-unicast-192.2.0.1/24",
+		},
+		{
+			name: "sets families prefixes neighbors",
+			conditions: RoutePolicyConditions{
+				MatchNeighbors: []string{"192.2.0.1", "192.2.0.2"},
+				MatchPrefixes: []*RoutePolicyPrefixMatch{
+					{
+						CIDR: testPrefix,
+					},
+				},
+				MatchFamilies: []Family{
+					{
+						Afi:  AfiIPv6,
+						Safi: SafiUnicast,
+					},
+				},
+			},
+			expected: "192.2.0.1-192.2.0.2-ipv6-unicast-192.2.0.1/24",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+			result := tt.conditions.String()
+			req.Equal(tt.expected, result)
+		})
+	}
+}

--- a/pkg/bgpv1/types/fake_router.go
+++ b/pkg/bgpv1/types/fake_router.go
@@ -6,12 +6,14 @@ package types
 import "context"
 
 type FakeRouter struct {
-	paths map[string]*Path
+	paths    map[string]*Path
+	policies map[string]*RoutePolicy
 }
 
 func NewFakeRouter() Router {
 	return &FakeRouter{
-		paths: make(map[string]*Path),
+		paths:    make(map[string]*Path),
+		policies: make(map[string]*RoutePolicy),
 	}
 }
 
@@ -46,10 +48,12 @@ func (f *FakeRouter) WithdrawPath(ctx context.Context, p PathRequest) error {
 }
 
 func (f *FakeRouter) AddRoutePolicy(ctx context.Context, p RoutePolicyRequest) error {
+	f.policies[p.Policy.Name] = p.Policy
 	return nil
 }
 
 func (f *FakeRouter) RemoveRoutePolicy(ctx context.Context, p RoutePolicyRequest) error {
+	delete(f.policies, p.Policy.Name)
 	return nil
 }
 
@@ -69,7 +73,11 @@ func (f *FakeRouter) GetRoutes(ctx context.Context, r *GetRoutesRequest) (*GetRo
 }
 
 func (f *FakeRouter) GetRoutePolicies(ctx context.Context) (*GetRoutePoliciesResponse, error) {
-	return nil, nil
+	var policies []*RoutePolicy
+	for _, policy := range f.policies {
+		policies = append(policies, policy)
+	}
+	return &GetRoutePoliciesResponse{Policies: policies}, nil
 }
 
 func (f *FakeRouter) GetBGP(ctx context.Context) (GetBGPResponse, error) {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

# bgpv2: Support overlapping selector matches on CiliumBGPAdvertisement

## Overview

**When configuring CiliumBGPAdvertisement with overlapping selector matches prior to this PR, the last sequential match was used, and previous matches were ignored.**

This PR modifies Cilium to support overlapping matches. Overlaps are handled as additive operations for attributes that can be unioned (standard and large communities).  When differing Local Preference values are set, the higher value is selected.  This is in line with [RFC 4271](https://datatracker.ietf.org/doc/html/rfc4271) which states "The higher degree of preference MUST be preferred."

The purpose of this change is to offer more flexibility for administrators of Cilium using the BGP Control Plane.  The flexibility added allows the administrator to configure any combination of BGP communities for Service announcements without explicitly defining every possible combination in advance on their `CiliumBGPAdvertisement`.

Prior to this change, an administrator would have been required to define a Kubernetes label for every possible combination of BGP communities and then define on their  `CiliumBGPAdvertisement` in the `advertisements` section a label selector-based match for each unique combination of communities.  In more complex networks, this poses a significant administrative burden and introduces the risk of configuration drift.

Instead, the administrator now needs to define one label per BGP community that they wish to set.  On their  `CiliumBGPAdvertisement`, the `advertisements` section simply needs a label selector match for each individual community.  If two `advertisements` match, the BGP communities defined on each entry will be applied to the corresponding advertisement.  The `CiliumBGPAdvertisement` no longer needs to be aware of the various combinations of communities that could be desired.  Instead, combinations of communities are set by simply labeling the respective Kubernetes Service with the respective labels.

The use-case above is further described in this [GitHub Issue](https://github.com/cilium/cilium/issues/35721).

Fixes: https://github.com/cilium/cilium/issues/35721

## Description

**`service.go`**:

The focus of this PR are the changes made to `pkg/bgpv1/manager/reconcilerv2/service.go` on ` getDesiredSvcRoutePolicies()`.  Prior to this change, each iteration simply updated the map named `desiredSvcRoutePolicies` without checking for an existing value.

**`policies.go`**:

This PR adds the function `MergeRoutePolicies()` to `policies.go`, which implements the merge operation.  The reconciliation process sequentially passes each overlapping match through that.  The final policy applied represents the merge of all which matched.

The merge operation is defined as:
```
// MergeRoutePolicies evaluates two instances of RoutePolicy{} and returns a single RoutePolicy{} representing
// the merger of the two.  The merge operation focuses on each policy's Statements.  Statements define one or more
// Actions, and these actions may include setting BGP Communities, Local Preference, and others.  Statements are
// keyed by their Conditions, which define the BGP Neighbor, AF, and Prefixes it applies to.
//
// The merge operation evaluates Actions across only those statements with the same key. For these Statements,
// the merge takes the union of all BGP Communities set.  When differing Local Preference values are set, the
// higher value is selected.
```

**`types/bgp.go`**:

In this file, a change was made to add a `String()` method for the type `RoutePolicyConditions`.  As the merge operation uses a map to track each unique set of `RoutePolicyConditions`, the new `String()` method provides a simple hashable key.

## Docs

This PR updates the BGPv2 Control Plane Docs to describe the change in behavior, shown below:

<img width="967" alt="Screenshot 2024-12-20 at 11 21 21 AM" src="https://github.com/user-attachments/assets/b7305d9c-f765-4eed-b2da-af8dbcaf9893" />

<img width="987" alt="Screenshot 2024-12-20 at 11 21 27 AM" src="https://github.com/user-attachments/assets/24c29fe7-d4d4-4ac2-8ae0-b5722c17f28c" />



## Testing

### Unit Tests

**`service_test.go`:**

Unit tests for `ClusterIP`,`External`, and `LoadBalancer` Service advertisements were updated to each add a new test that configures overlapping advertisements.  The overlapping advertisement tests each configure three advertisements, compared to all other tests which configure one.  The advertisements configured set the following sets of attributes:

```
	localPrefHigh             = int64(200)
	redPeer65001BgpAttributes = &v2alpha1.BGPAttributes{
		Communities: &v2alpha1.BGPCommunities{
			Standard:  []v2alpha1.BGPStandardCommunity{"101:101"},
			Large:     []v2alpha1.BGPLargeCommunity{"1111:1111:1111"},
			WellKnown: []v2alpha1.BGPWellKnownCommunity{"no-export"},
		},
		LocalPreference: &localPrefHigh,
	}

	localPrefLow               = int64(50)
	redPeer65001BgpAttributes2 = &v2alpha1.BGPAttributes{
		Communities: &v2alpha1.BGPCommunities{
			Standard:  []v2alpha1.BGPStandardCommunity{"202:202"},
			Large:     []v2alpha1.BGPLargeCommunity{"2222:2222:2222"},
			WellKnown: []v2alpha1.BGPWellKnownCommunity{"no-export"},
		},
		LocalPreference: &localPrefLow,
	}

	redPeer65001BgpAttributes3 = &v2alpha1.BGPAttributes{
		Communities: &v2alpha1.BGPCommunities{
			Standard: []v2alpha1.BGPStandardCommunity{"202:202", "303:303"},
			Large:    []v2alpha1.BGPLargeCommunity{"2222:2222:2222", "3333:3333:3333"},
		},
		LocalPreference: &localPrefLow,
	}
```

The first and second each set unique communities for `Standard` and `Large`.  The third first sets the same communities as the second, then adds a unique `Standard` and `Large` community.  The first and latter two set different `LocalPreference` values.

**`policies_test.go`:**
Tests were added here to cover expected and edge cases for `MergeRoutePolicies()`.

### Manual Testing

The lab from https://github.com/cilium/cilium/tree/main/contrib/containerlab/bgpv2/service was used to manually test this change.  Using the `Makefile` from that directory, I brought up a Kind cluster running Cilium with an instance of FRR.  I commented out the lines that applied configuration to Cilium.

Instead, I applied the following `yaml` file using `kubectl`:
 
```
apiVersion: cilium.io/v2alpha1
kind: CiliumBGPClusterConfig
metadata:
  name: cilium-bgp
spec:
  nodeSelector:
    matchLabels:
      bgp: "65001"
  bgpInstances:
  - name: "65001"
    localASN: 65001
    peers:
    - name: "65000"
      peerASN: 65000
      peerAddress: fd00:10::1
      peerConfigRef:
        name: "cilium-peer"

---
apiVersion: cilium.io/v2alpha1
kind: CiliumBGPPeerConfig
metadata:
  name: cilium-peer
spec:
  authSecretRef: bgp-auth-secret
  gracefulRestart:
    enabled: true
    restartTimeSeconds: 15
  families:
    - afi: ipv4
      safi: unicast
      advertisements:
        matchLabels:
          advertise: "bgp"
    - afi: ipv6
      safi: unicast
      advertisements:
        matchLabels:
          advertise: "bgp"
---
apiVersion: cilium.io/v2alpha1
kind: CiliumBGPAdvertisement
metadata:
  name: "bgp-advertisements"
  labels:
    advertise: "bgp"
spec:
  advertisements:
    - advertisementType: "Service"
      service:
        addresses:
        - ClusterIP
      selector:
        matchExpressions:
        - {key: somekey, operator: NotIn, values: ['never-used-value']}
      attributes:
        communities:
          standard: [ "202:202" ]
          large: [ "2222:2222:2222" ]
    - advertisementType: "Service"
      service:
        addresses:
        - ClusterIP
      selector:
        matchExpressions:
        - {key: somekey, operator: NotIn, values: ['never-used-value']}
      attributes:
        communities:
          standard: [ "303:303" ]
          large: [ "3333:3333:3333" ]
          wellKnown: [ "no-export" ]
    - advertisementType: "Service"
      service:
        addresses:
        - ClusterIP
      selector:
        matchExpressions:
        - {key: somekey, operator: NotIn, values: ['never-used-value']}
      attributes:
        communities:
          standard: [ "444:4444" ]
          large: [ "4444:4444:4444" ]
          wellKnown: [ "no-advertise" ]
```

**Inspecting FRR**

On FRR, shown below, I saw the superset of all communities defined above set on the Service announcement:
```
router0# show ip bgp  10.2.86.210
BGP routing table entry for 10.2.86.210/32, version 29
Paths: (2 available, best #2, table default, not advertised to EBGP peer)
  Not advertised to any peer
  65001
    fd00:10:0:1::2 from fd00:10:0:1::2 (10.0.1.2)
      Origin IGP, valid, external, multipath
      Community: 202:202 303:303 444:4444 no-export no-advertise
      Large Community: 2222:2222:2222 3333:3333:3333 4444:4444:4444
      Last update: Thu Dec  5 15:36:06 2024
  65001
    fd00:10:0:2::2 from fd00:10:0:2::2 (10.0.2.2)
      Origin IGP, valid, external, multipath, best (Older Path)
      Community: 202:202 303:303 444:4444 no-export no-advertise
      Large Community: 2222:2222:2222 3333:3333:3333 4444:4444:4444
      Last update: Thu Dec  5 15:36:06 2024
```

### Coverage

Using the [`uncover`](https://github.com/gregoryv/uncover) command line, coverage for `pkg/bgpv1/manager/reconcilerv2` under this PR is now:
```
total:    (statements)    71.1%
```

On `main` as of writing, it was:
```
total:    (statements)    69.6%
```


Fixes: #35721 


```release-note
BGPv2:  Support overlapping selector matches on CiliumBGPAdvertisement
```
