### PR TITLE
connectivity: run client-egress-to-cidrgroup-deny conditionally

### DIFF
--- a/cilium-cli/connectivity/builder/client_egress_to_cidrgroup_deny.go
+++ b/cilium-cli/connectivity/builder/client_egress_to_cidrgroup_deny.go
@@ -15,6 +15,7 @@ func (t clientEgressToCidrgroupDeny) build(ct *check.ConnectivityTest, templates
 	// This policy denies L3 traffic to ExternalCIDR except ExternalIP/32
 	// It does so using a CiliumCIDRGroup
 	newTest("client-egress-to-cidrgroup-deny", ct).
+		WithCiliumVersion(">=1.17.0").
 		WithCiliumPolicy(allowAllEgressPolicyYAML). // Allow all egress traffic
 		WithCiliumPolicy(templates["clientEgressToCIDRGroupExternalDenyPolicyYAML"]).
 		WithScenarios(


### PR DESCRIPTION
This test breaks all Cilium versions lower than v1.17.0. Thus, until the bug is fixed on those versions we should only run this test on Cilium >= v1.17.0.