### PR TITLE
Endpoint policy before restoration

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -136,7 +136,8 @@ type Daemon struct {
 
 	endpointManager endpointmanager.EndpointManager
 
-	endpointRestoreComplete chan struct{}
+	endpointRestoreComplete       chan struct{}
+	endpointInitialPolicyComplete chan struct{}
 
 	identityAllocator identitycell.CachingIdentityAllocator
 
@@ -410,6 +411,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	// waiting when it is not yet initialized (which causes them to block forever).
 	if option.Config.RestoreState {
 		d.endpointRestoreComplete = make(chan struct{})
+		d.endpointInitialPolicyComplete = make(chan struct{})
 	}
 
 	// Collect CIDR identities from the "old" bpf ipcache and restore them

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -381,7 +381,8 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 			{Protocol: envoy_config_core.SocketAddress_TCP},
 		},
 	}
-	require.Equal(t, expectedNetworkPolicy, qaBarNetworkPolicy)
+
+	require.EqualExportedValues(t, expectedNetworkPolicy, qaBarNetworkPolicy)
 
 	prodBarNetworkPolicy := networkPolicies[ProdIPv4Addr.String()]
 	require.NotNil(t, prodBarNetworkPolicy)
@@ -424,7 +425,7 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 			{Protocol: envoy_config_core.SocketAddress_TCP},
 		},
 	}
-	require.Equal(t, expectedNetworkPolicy, prodBarNetworkPolicy)
+	require.EqualExportedValues(t, expectedNetworkPolicy, prodBarNetworkPolicy)
 }
 
 func TestL4L7ShadowingEtcd(t *testing.T) {
@@ -511,7 +512,7 @@ func (ds *DaemonSuite) testL4L7Shadowing(t *testing.T) {
 			{Protocol: envoy_config_core.SocketAddress_TCP},
 		},
 	}
-	require.Equal(t, expectedNetworkPolicy, qaBarNetworkPolicy)
+	require.EqualExportedValues(t, expectedNetworkPolicy, qaBarNetworkPolicy)
 }
 
 func TestL4L7ShadowingShortCircuitEtcd(t *testing.T) {
@@ -595,7 +596,7 @@ func (ds *DaemonSuite) testL4L7ShadowingShortCircuit(t *testing.T) {
 			{Protocol: envoy_config_core.SocketAddress_TCP},
 		},
 	}
-	require.Equal(t, expectedNetworkPolicy, qaBarNetworkPolicy)
+	require.EqualExportedValues(t, expectedNetworkPolicy, qaBarNetworkPolicy)
 }
 
 func TestL3DependentL7Etcd(t *testing.T) {
@@ -700,7 +701,7 @@ func (ds *DaemonSuite) testL3DependentL7(t *testing.T) {
 			{Protocol: envoy_config_core.SocketAddress_TCP},
 		},
 	}
-	require.Equal(t, expectedNetworkPolicy, qaBarNetworkPolicy)
+	require.EqualExportedValues(t, expectedNetworkPolicy, qaBarNetworkPolicy)
 }
 
 func TestReplacePolicyEtcd(t *testing.T) {
@@ -942,7 +943,7 @@ func (ds *DaemonSuite) testIncrementalPolicy(t *testing.T) {
 			},
 		},
 	}
-	require.Equal(t, expectedIngressPolicy, qaBarNetworkPolicy.IngressPerPortPolicies[0])
+	require.EqualExportedValues(t, expectedIngressPolicy, qaBarNetworkPolicy.IngressPerPortPolicies[0])
 
 	// Allocate identities needed for this test
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}

--- a/pkg/container/versioned/value.go
+++ b/pkg/container/versioned/value.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 type version uint64
@@ -53,6 +54,8 @@ type VersionHandle struct {
 	// Coordinator of this versionHandle, if any. Used for closing if non-nil.
 	// Atomic due to nilling and for copy prevention.
 	coordinator atomic.Pointer[Coordinator]
+	// Optional stack trace of the caller for debugging purposes
+	stacktrace hclog.CapturedStacktrace
 }
 
 func (h *VersionHandle) IsValid() bool {
@@ -98,7 +101,11 @@ func (h *VersionHandle) Close() error {
 func versionHandleFinalizer(h *VersionHandle) {
 	coordinator := h.coordinator.Load()
 	if coordinator != nil && coordinator.Logger != nil {
-		coordinator.Logger.WithField(logfields.Version, h.version).Error("Handle for version not closed.")
+		logger := coordinator.Logger
+		if h.stacktrace != "" {
+			logger = logger.WithField(logfields.Stacktrace, h.stacktrace)
+		}
+		logger.WithField(logfields.Version, h.version).Error("Handle for version not closed.")
 	}
 	h.Close()
 }
@@ -114,6 +121,11 @@ func newVersionHandle(version version, coordinator *Coordinator) *VersionHandle 
 		// Set a finalizer to catch unclosed handles. The finalizer function complains
 		// loudly, so that we do not rely the finalizer for closing.
 		runtime.SetFinalizer(h, versionHandleFinalizer)
+
+		if option.Config.Debug {
+			// capture a stacktrace for debugging
+			h.stacktrace = hclog.Stacktrace()
+		}
 	}
 	return h
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -690,6 +690,9 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 		if err != nil && !errors.Is(err, ErrPolicyEntryMaxExceeded) {
 			return err
 		}
+
+		// Signal computation of the initial Envoy policy if not done yet
+		e.InitialPolicyComputedLocked()
 	}
 
 	currentDir := datapathRegenCtxt.currentDir
@@ -915,7 +918,7 @@ func (e *Endpoint) scrubIPsInConntrackTable() {
 // SkipStateClean can be called on a endpoint before its first build to skip
 // the cleaning of state such as the conntrack table. This is useful when an
 // endpoint is being restored from state and the datapath state should not be
-// claned.
+// cleaned.
 //
 // The endpoint lock must NOT be held.
 func (e *Endpoint) SkipStateClean() {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -587,14 +587,30 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 	stats := &regenContext.Stats
 	datapathRegenCtxt := regenContext.datapathRegenerationContext
 
+	// lock the endpoint, read our values, then unlock
+	err := e.lockAlive()
+	if err != nil {
+		return err
+	}
+	identityRevision := e.identityRevision
+	e.unlock()
+	policyRevision := e.policyGetter.GetPolicyRepository().GetRevision()
+
 	// regenerate policy without holding the lock.
 	// This is because policy generation needs the ipcache to make progress, and the ipcache
 	// needs to call endpoint.ApplyPolicyMapChanges()
-	stats.policyCalculation.Start()
-	policyResult, err := e.regeneratePolicy(stats, datapathRegenCtxt)
-	stats.policyCalculation.End(err == nil)
-	if err != nil {
-		return fmt.Errorf("unable to regenerate policy for '%s': %w", e.StringID(), err)
+	// Computed only if not already done earlier, or if policy has updated since the policy was
+	// computed.
+	if datapathRegenCtxt.policyResult == nil ||
+		datapathRegenCtxt.policyResult.endpointPolicy == nil ||
+		datapathRegenCtxt.policyResult.identityRevision < identityRevision ||
+		datapathRegenCtxt.policyResult.policyRevision < policyRevision {
+		stats.policyCalculation.Start()
+		err := e.regeneratePolicy(stats, datapathRegenCtxt)
+		stats.policyCalculation.End(err == nil)
+		if err != nil {
+			return fmt.Errorf("unable to regenerate policy for '%s': %w", e.StringID(), err)
+		}
 	}
 
 	// Any possible DNS redirects had their rules updated by 'e.regeneratePolicy' above, so we
@@ -640,11 +656,13 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 	// Note that the incoming policy can be the same as the previous policy in cases
 	// where an unnecessary policy computation was skipped. In that case
 	// e.desiredPolicy == e.realizedPolicy also after this call.
-	if err := e.setDesiredPolicy(policyResult, datapathRegenCtxt); err != nil {
+	if err := e.setDesiredPolicy(datapathRegenCtxt); err != nil {
 		return err
 	}
-	// Mark the desired policy as ready when done before the lock is released
-	defer e.desiredPolicy.Ready()
+	// Mark the new desired policy as ready when done before the lock is released
+	if e.desiredPolicy != e.realizedPolicy {
+		defer e.desiredPolicy.Ready()
+	}
 
 	// Apply pending policy map changes so that desired map is up-to-date before
 	// syncing the maps below.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1219,6 +1219,9 @@ func (e *Endpoint) leaveLocked(conf DeleteConfig) []error {
 	errs := []error{}
 
 	// Remove policy references from shared policy structures
+	// Endpoint with desiredPolicy computed can get deleted while queueing for regeneration,
+	// must mark the policy as 'Ready' so that Detach does not complain about it.
+	e.desiredPolicy.Ready()
 	e.desiredPolicy.Detach()
 	// Passing a new map of nil will purge all redirects
 	e.removeOldRedirects(nil, e.desiredPolicy.Redirects)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -160,6 +160,8 @@ type Endpoint struct {
 	// recalculated on endpoint restore.
 	createdAt time.Time
 
+	InitialEnvoyPolicyComputed chan struct{}
+
 	// mutex protects write operations to this endpoint structure
 	mutex lock.RWMutex
 
@@ -597,6 +599,8 @@ func createEndpoint(owner regeneration.Owner, policyGetter policyRepoGetter, nam
 
 		forcePolicyCompute: true,
 	}
+
+	ep.InitialEnvoyPolicyComputed = make(chan struct{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	ep.aliveCancel = cancel

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -30,7 +30,23 @@ func (ev *EndpointRegenerationEvent) Handle(res chan interface{}) {
 	e := ev.ep
 	regenContext := ev.regenContext
 
-	err := e.rlockAlive()
+	// Compute policy before acquiring the build permit in
+	// QueueEndpointBuild below
+	err, release := e.ComputeInitialPolicy(regenContext)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) {
+			e.getLogger().WithError(err).Error("Initial policy compute failed")
+		}
+
+		res <- &EndpointRegenerationResult{
+			err: err,
+		}
+		return
+	}
+	// release policy results when done
+	defer release()
+
+	err = e.rlockAlive()
 	if err != nil {
 		e.logDisconnectedMutexAction(err, "before regeneration")
 		res <- &EndpointRegenerationResult{

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -30,29 +30,33 @@ func (ev *EndpointRegenerationEvent) Handle(res chan interface{}) {
 	e := ev.ep
 	regenContext := ev.regenContext
 
-	// Compute policy before acquiring the build permit in
+	// Compute policy on the first regeneration before acquiring the build permit in
 	// QueueEndpointBuild below
-	err, release := e.ComputeInitialPolicy(regenContext)
-	if err != nil {
-		if !errors.Is(err, context.Canceled) {
-			e.getLogger().WithError(err).Error("Initial policy compute failed")
-		}
+	select {
+	case <-e.InitialEnvoyPolicyComputed:
+		// Already done
+	default:
+		err, release := e.ComputeInitialPolicy(regenContext)
+		if err != nil {
+			if !errors.Is(err, context.Canceled) {
+				e.getLogger().WithError(err).Error("Initial policy compute failed")
+			}
 
-		res <- &EndpointRegenerationResult{
-			err: err,
+			res <- &EndpointRegenerationResult{
+				err: err,
+			}
+			return
 		}
-		return
+		// release policy results when done
+		defer release()
 	}
-	// release policy results when done
-	defer release()
 
-	err = e.rlockAlive()
+	err := e.rlockAlive()
 	if err != nil {
 		e.logDisconnectedMutexAction(err, "before regeneration")
 		res <- &EndpointRegenerationResult{
 			err: err,
 		}
-
 		return
 	}
 	e.runlock()

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -122,6 +122,21 @@ type policyGenerateResult struct {
 	identityRevision int
 }
 
+// Release resources held for the new policy
+// Must be called with buildMutex held
+func (res *policyGenerateResult) release() {
+	// Detach the rejected endpoint policy.
+	// This is needed to release resources held for the EndpointPolicy
+	if res != nil && res.endpointPolicy != nil {
+		// Mark as "ready" so that Detach will not complain about it
+		res.endpointPolicy.Ready()
+		// Detach the EndpointPolicy from the SelectorPolicy it was
+		// instantiated from
+		res.endpointPolicy.Detach()
+		res.endpointPolicy = nil
+	}
+}
+
 // regeneratePolicy computes the policy for the given endpoint based off of the
 // rules in regeneration.Owner's policy repository.
 //
@@ -152,9 +167,9 @@ type policyGenerateResult struct {
 //     so ep.mutex must not be required to read this. Instead, both ep.mutex and ep.buildMutex
 //     must be held to write to this (i.e. we are deep in regeneration)
 //
-// Returns a result that should be passed to setDesiredPolicy after the endpoint's
-// write lock has been acquired, or err if recomputing policy failed.
-func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegenCtxt *datapathRegenerationContext) (*policyGenerateResult, error) {
+// Stores the result in 'datapathRegenCtxt.policyResult' that should be passed to setDesiredPolicy
+// after the endpoint's write lock has been acquired, returns err if recomputing policy failed.
+func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegenCtxt *datapathRegenerationContext) error {
 	var (
 		err error
 		ff  revert.FinalizeFunc
@@ -164,14 +179,14 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 	// lock the endpoint, read our values, then unlock
 	err = e.lockAlive()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// No point in calculating policy if endpoint does not have an identity yet.
 	if e.SecurityIdentity == nil {
 		e.getLogger().Warn("Endpoint lacks identity, skipping policy calculation")
 		e.unlock()
-		return nil, nil
+		return nil
 	}
 
 	// Copy out some values we care about, then unlock
@@ -201,7 +216,7 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 	selectorPolicy, result.policyRevision, err = e.policyGetter.GetPolicyRepository().GetSelectorPolicy(securityIdentity, skipPolicyRevision, stats)
 	if err != nil {
 		e.getLogger().WithError(err).Warning("Failed to calculate SelectorPolicy")
-		return nil, err
+		return err
 	}
 
 	// selectorPolicy is nil if skipRevision was matched.
@@ -211,14 +226,15 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 			"policyRevision.repo": result.policyRevision,
 			"policyChanged":       e.nextPolicyRevision > e.policyRevision,
 		}).Debug("Skipping unnecessary endpoint policy recalculation")
-		return result, err
+		datapathRegenCtxt.policyResult = result
+		return nil
 	}
 
 	// Add new redirects before Consume() so that all required proxy ports are available for it.
 	var desiredRedirects map[string]uint16
 	err = e.rlockAlive()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	// Ingress endpoint needs no redirects
 	if !e.isProperty(PropertySkipBPFPolicy) {
@@ -249,7 +265,8 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 	result.endpointPolicy = selectorPolicy.DistillPolicy(e, desiredRedirects)
 	stats.endpointPolicyCalculation.End(true)
 
-	return result, nil
+	datapathRegenCtxt.policyResult = result
+	return nil
 }
 
 // setDesiredPolicy updates the endpoint with the results of a policy calculation.
@@ -267,7 +284,8 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 // successfully performed a full sync with the endpoints PolicyMap. Otherwise,
 // the ipcache may remove an identity from the ipcache that the bpf PolicyMap is still
 // relying on.
-func (e *Endpoint) setDesiredPolicy(res *policyGenerateResult, datapathRegenCtxt *datapathRegenerationContext) error {
+func (e *Endpoint) setDesiredPolicy(datapathRegenCtxt *datapathRegenerationContext) error {
+	res := datapathRegenCtxt.policyResult
 	// nil result means endpoint had no identity while policy was calculated
 	if res == nil {
 		if e.SecurityIdentity != nil {
@@ -281,14 +299,7 @@ func (e *Endpoint) setDesiredPolicy(res *policyGenerateResult, datapathRegenCtxt
 	if e.identityRevision != res.identityRevision {
 		// Detach the rejected endpoint policy.
 		// This is needed to release resources held for the EndpointPolicy
-		if res.endpointPolicy != nil {
-			// Mark as "ready" so that Detach will not complain about it
-			res.endpointPolicy.Ready()
-			// Detach the EndpointPolicy from the SelectorPolicy it was
-			// instantiated from
-			res.endpointPolicy.Detach()
-			res.endpointPolicy = nil
-		}
+		res.release()
 
 		e.getLogger().Info("Endpoint SecurityIdentity changed during policy regeneration")
 		return fmt.Errorf("endpoint %d SecurityIdentity changed during policy regeneration", e.ID)
@@ -298,7 +309,7 @@ func (e *Endpoint) setDesiredPolicy(res *policyGenerateResult, datapathRegenCtxt
 	// repository.
 	e.setNextPolicyRevision(res.policyRevision)
 
-	if res.endpointPolicy != e.desiredPolicy {
+	if res.endpointPolicy != nil && res.endpointPolicy != e.desiredPolicy {
 		if e.desiredPolicy != e.realizedPolicy {
 			// Not sure if this can happen, but Detach e.desiredPolicy before we loose
 			// the only reference to it.
@@ -650,7 +661,7 @@ func (e *Endpoint) UpdatePolicy(idsToRegen *set.Set[identityPkg.NumericIdentity]
 	// bump the policy revision directly (as long as we didn't miss an update somehow).
 	if !idsToRegen.Has(secID) {
 		if e.policyRevision < fromRev {
-			e.getLogger().Warn("Endpoint missed a policy revision; triggering regeneration")
+			e.getLogger().WithField(logfields.PolicyRevision, fromRev).Warn("Endpoint missed a policy revision; triggering regeneration")
 		} else {
 			e.getLogger().WithField(logfields.PolicyRevision, toRev).Debug("Policy update is a no-op, bumping policyRevision")
 			e.setPolicyRevision(toRev)
@@ -724,8 +735,8 @@ func (e *Endpoint) Regenerate(regenMetadata *regeneration.ExternalRegenerationMe
 	// synchronously enqueued.
 	resChan, err := e.eventQueue.Enqueue(epEvent)
 	if err != nil {
+		cFunc()
 		e.getLogger().WithError(err).Error("Enqueue of EndpointRegenerationEvent failed")
-		done <- false
 		close(done)
 		return done
 	}
@@ -775,6 +786,79 @@ func (e *Endpoint) Regenerate(regenMetadata *regeneration.ExternalRegenerationMe
 	}()
 
 	return done
+}
+
+// Compute initial policy for the endpoint. This computes the selector policy and Envoy policy for
+// the endpoint. This is called on the first endpoint regeneration before the build permit is
+// requested and before bpf compilation is performed. When the initial (Envoy) policy is computed,
+// we can start serving xDS resources to Envoy without waiting for all the endpoints having been
+// regenerated first.
+// Must be called with both endpoint mutex and buildMutex not held.
+// The returned 'release' function must also be called with both mutexed not held.
+func (e *Endpoint) ComputeInitialPolicy(regenContext *regenerationContext) (error, func()) {
+	stats := &regenContext.Stats
+	datapathRegenCtxt := regenContext.datapathRegenerationContext
+
+	// buildMutex needed for all policy computation functions below.
+	e.buildMutex.Lock()
+	defer e.buildMutex.Unlock()
+
+	// Compute Endpoint's policy
+	stats.policyCalculation.Start()
+	err := e.regeneratePolicy(stats, datapathRegenCtxt)
+	stats.policyCalculation.End(err == nil)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) {
+			e.getLogger().WithError(err).Warning("unable to regenerate initial policy")
+		}
+		// Do not error out so that the policy regeneration is tried again.
+		return nil, func() {}
+	}
+
+	err = e.lockAlive()
+	if err != nil {
+		datapathRegenCtxt.policyResult.release()
+		return err, func() {}
+	}
+	defer e.unlock()
+
+	// 'release' is returned to the caller to be called after the policy result is not needed
+	// any more.
+	// Must be called without holding endpoint lock or the endpoint buildMutex.
+	release := func() {
+		e.buildMutex.Lock()
+		defer e.buildMutex.Unlock()
+		datapathRegenCtxt.policyResult.release()
+	}
+
+	err = e.setDesiredPolicy(datapathRegenCtxt)
+	if err != nil {
+		e.getLogger().
+			WithError(err).
+			Warning("Setting initial desired policy failed")
+		// Do not error out so that the policy regeneration is tried again.
+		return nil, release
+	}
+
+	if !e.IsProxyDisabled() {
+		e.getLogger().
+			WithField(logfields.SelectorCacheVersion, e.desiredPolicy.VersionHandle).
+			Debug("Regenerate: Initial Envoy NetworkPolicy")
+
+		stats.proxyPolicyCalculation.Start()
+		// Initial NetworkPolicy is not reverted
+		err, _ = e.proxy.UpdateNetworkPolicy(e, &e.desiredPolicy.L4Policy, e.desiredPolicy.IngressPolicyEnabled, e.desiredPolicy.EgressPolicyEnabled, nil)
+		stats.proxyPolicyCalculation.End(err == nil)
+		if err != nil {
+			e.getLogger().
+				WithError(err).
+				Warning("Initial Envoy NetworkPolicy failed")
+			// Do not error out so that the policy regeneration is tried again.
+			return nil, release
+		}
+	}
+
+	return nil, release
 }
 
 var reasonRegenRetry = "retrying regeneration"

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -788,6 +788,16 @@ func (e *Endpoint) Regenerate(regenMetadata *regeneration.ExternalRegenerationMe
 	return done
 }
 
+// InitialPolicyComputedLocked marks computation of the initial Envoy policy done.
+// Endpoint lock must be held so that the channel is never closed twice.
+func (e *Endpoint) InitialPolicyComputedLocked() {
+	select {
+	case <-e.InitialEnvoyPolicyComputed:
+	default:
+		close(e.InitialEnvoyPolicyComputed)
+	}
+}
+
 // Compute initial policy for the endpoint. This computes the selector policy and Envoy policy for
 // the endpoint. This is called on the first endpoint regeneration before the build permit is
 // requested and before bpf compilation is performed. When the initial (Envoy) policy is computed,
@@ -857,6 +867,9 @@ func (e *Endpoint) ComputeInitialPolicy(regenContext *regenerationContext) (erro
 			return nil, release
 		}
 	}
+
+	// Signal computation of the initial Envoy policy if not done yet
+	e.InitialPolicyComputedLocked()
 
 	return nil, release
 }

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -133,8 +133,9 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 	for {
 		t.Log("Calculating policy...")
 		ep.forcePolicyCompute = true
-		res, err := ep.regeneratePolicy(stats, datapathRegenCtxt)
+		err := ep.regeneratePolicy(stats, datapathRegenCtxt)
 		assert.NoError(t, err)
+		res := datapathRegenCtxt.policyResult
 
 		// Sleep a random amount, so we accumulate some changes
 		// This does not slow down the test, since we always generate testFactor identities.

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -301,15 +301,17 @@ func combineL4L7(l4 []api.PortRule, l7 *api.L7Rules) []api.PortRule {
 }
 
 func (s *RedirectSuite) computePolicyForTest(t *testing.T, ep *Endpoint, cmp *completion.WaitGroup) {
-	res, err := ep.regeneratePolicy(s.stats, s.datapathRegenCtxt)
+	err := ep.regeneratePolicy(s.stats, s.datapathRegenCtxt)
 	require.NoError(t, err)
+	res := s.datapathRegenCtxt.policyResult
 
 	oldDesiredPolicy := ep.desiredPolicy
 	s.datapathRegenCtxt.revertStack.Push(func() error {
 		ep.desiredPolicy = oldDesiredPolicy
 		return nil
 	})
-	ep.setDesiredPolicy(res, s.datapathRegenCtxt)
+	s.datapathRegenCtxt.policyResult = res
+	ep.setDesiredPolicy(s.datapathRegenCtxt)
 
 	// This will also remove old redirects
 	s.datapathRegenCtxt.finalizeList.Finalize()

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -55,6 +55,7 @@ func ParseExternalRegenerationMetadata(ctx context.Context, c context.CancelFunc
 // datapathRegenerationContext contains information related to regenerating the
 // datapath (BPF, proxy, etc.).
 type datapathRegenerationContext struct {
+	policyResult       *policyGenerateResult
 	bpfHeaderfilesHash string
 	epInfoCache        *epInfoCache
 	proxyWaitGroup     *completion.WaitGroup

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -560,6 +560,7 @@ func (ep *Endpoint) MarshalJSON() ([]byte, error) {
 func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.ID = r.ID
 	ep.createdAt = time.Now()
+	ep.InitialEnvoyPolicyComputed = make(chan struct{})
 	ep.containerName.Store(&r.ContainerName)
 	ep.containerID.Store(&r.ContainerID)
 	ep.dockerNetworkID = r.DockerNetworkID

--- a/pkg/endpointcleanup/cleanup_test.go
+++ b/pkg/endpointcleanup/cleanup_test.go
@@ -280,3 +280,7 @@ func (r *fakeRestorer) Await(context.Context) (endpointstate.Restorer, error) {
 func (r *fakeRestorer) WaitForEndpointRestore(_ context.Context) error {
 	return nil
 }
+
+func (r *fakeRestorer) WaitForInitialEnvoyPolicy(_ context.Context) error {
+	return nil
+}

--- a/pkg/endpointstate/restorer.go
+++ b/pkg/endpointstate/restorer.go
@@ -10,4 +10,8 @@ type Restorer interface {
 	// WaitForEndpointRestore blocks the caller until either the context is
 	// cancelled or all the endpoints have been restored from a previous run.
 	WaitForEndpointRestore(ctx context.Context) error
+
+	// WaitForInitialEnvoyPolicy blocks the caller until either the context is
+	// cancelled or policies of all the endpoints have been computed.
+	WaitForInitialEnvoyPolicy(ctx context.Context) error
 }

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -53,10 +53,11 @@ func (s *xdsServer) startXDSGRPCServer(listener net.Listener, config map[string]
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		if s.restorerPromise != nil {
+			log.Infof("Envoy: Waiting for endpoint restorer before serving xDS resources...")
 			restorer, err := s.restorerPromise.Await(ctx)
 			if err == nil && restorer != nil {
 				log.Infof("Envoy: Waiting for endpoint restoration before serving xDS resources...")
-				err = restorer.WaitForEndpointRestore(ctx)
+				err = restorer.WaitForInitialEnvoyPolicy(ctx)
 			}
 			if errors.Is(err, context.Canceled) {
 				log.Debug("Envoy: xDS server stopped before started serving")

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"runtime"
 
 	"github.com/sirupsen/logrus"
 
@@ -222,7 +223,8 @@ func (p *EndpointPolicy) Detach() {
 	// in case the call was missed previouly
 	if p.Ready() == nil {
 		// succeeded, so it was missed previously
-		log.Warningf("Detach: EndpointPolicy was not marked as Ready")
+		_, file, line, _ := runtime.Caller(1)
+		log.Warningf("Detach: EndpointPolicy was not marked as Ready (%s:%d)", file, line)
 	}
 	// Also release the version handle held for incremental updates, if any.
 	// This must be done after the removeUser() call above, so that we do not get a new version


### PR DESCRIPTION
Start serving xDS resources to Envoy as soon as policies for all restored endpoints have been computed, rather than waiting for them to be fully restored.