### PR TITLE
proxy: Take proxy port reference for new redirects immediately

### DIFF
--- a/pkg/proxy/proxyports/proxyports.go
+++ b/pkg/proxy/proxyports/proxyports.go
@@ -69,6 +69,8 @@ type ProxyPort struct {
 	// is non-zero when a proxy has been successfully created and the
 	// (new, if after restart) datapath rules have been created.
 	rulesPort uint16
+	// cancel for delayed release. Call if non-nil when a new reference is taken to cancel out a pending delayed release
+	releaseCancel func()
 }
 
 type proxyPortsMap map[string]*ProxyPort
@@ -271,6 +273,14 @@ func (p *ProxyPorts) AllocateCRDProxyPort(name string) (uint16, error) {
 	return pp.ProxyPort, nil
 }
 
+func (pp *ProxyPort) addReference() {
+	pp.nRedirects++
+	if pp.releaseCancel != nil {
+		pp.releaseCancel()
+		pp.releaseCancel = nil
+	}
+}
+
 // AckProxyPortWithReference() marks the proxy of the given type as successfully
 // created and creates or updates the datapath rules accordingly.
 // Takes a reference on the proxy port.
@@ -283,7 +293,7 @@ func (p *ProxyPorts) AckProxyPortWithReference(ctx context.Context, name string)
 	}
 	err := p.ackProxyPort(ctx, name, pp) // creates datapath rules
 	if err == nil {
-		pp.nRedirects++
+		pp.addReference()
 	}
 	return err
 }
@@ -349,20 +359,26 @@ func (p *ProxyPorts) releaseProxyPort(name string, portReuseWait time.Duration) 
 
 	// Static proxy port is not released, dynamic proxy ports are released after a delay if
 	// still on last reference count
-	if !pp.isStatic && pp.nRedirects == 0 {
+	if !pp.isStatic && pp.nRedirects == 0 && pp.releaseCancel == nil {
+		ctx, cancel := context.WithCancel(context.Background())
+		pp.releaseCancel = cancel
+
 		go func() {
-			time.Sleep(portReuseWait)
+			select {
+			case <-time.After(portReuseWait):
+				p.mutex.Lock()
+				defer p.mutex.Unlock()
 
-			p.mutex.Lock()
-			defer p.mutex.Unlock()
+				if pp.nRedirects == 0 {
+					pp.releaseCancel = nil
+					log.WithField(fieldProxyRedirectID, name).Debugf("Delayed release of proxy port %d", pp.ProxyPort)
+					p.reset(pp)
 
-			if pp.nRedirects == 0 {
-				log.WithField(fieldProxyRedirectID, name).Debugf("Delayed release of proxy port %d", pp.ProxyPort)
-				p.reset(pp)
-
-				// Leave the datapath rules behind on the hope that they get reused
-				// later.  This becomes possible when we are able to keep the proxy
-				// listeners configured also when there are no redirects.
+					// Leave the datapath rules behind on the hope that they get reused
+					// later.  This becomes possible when we are able to keep the proxy
+					// listeners configured also when there are no redirects.
+				}
+			case <-ctx.Done():
 			}
 		}()
 	}
@@ -434,7 +450,7 @@ func (p *ProxyPorts) FindByTypeWithReference(l7Type types.ProxyType, listener st
 		// CRD proxy ports are dynamically created, look up by name
 		// 'ingress' is always false for CRD type
 		if pp, ok := p.proxyPorts[listener]; ok && pp.ProxyType == types.ProxyTypeCRD && !pp.Ingress {
-			pp.nRedirects++
+			pp.addReference()
 			return listener, pp
 		}
 		log.Debugf("findProxyPortByType: can not find crd listener %s from %v", listener, p.proxyPorts)
@@ -451,7 +467,7 @@ func (p *ProxyPorts) FindByTypeWithReference(l7Type types.ProxyType, listener st
 	// proxyPorts is small enough to not bother indexing it.
 	for name, pp := range p.proxyPorts {
 		if pp.ProxyType == portType && pp.Ingress == ingress {
-			pp.nRedirects++
+			pp.addReference()
 			return name, pp
 		}
 	}

--- a/pkg/proxy/proxyports/proxyports_test.go
+++ b/pkg/proxy/proxyports/proxyports_test.go
@@ -44,29 +44,32 @@ func TestPortAllocator(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, port1, port1a)
 
-	name, pp := p.FindByType(types.ProxyTypeCRD, "listener1", false)
+	name, pp := p.FindByTypeWithReference(types.ProxyTypeCRD, "listener1", false)
 	require.Equal(t, "listener1", name)
 	require.Equal(t, types.ProxyTypeCRD, pp.ProxyType)
 	require.Equal(t, port, pp.ProxyPort)
 	require.False(t, pp.Ingress)
 	require.True(t, pp.configured)
+	require.False(t, pp.acknowledged)
 	require.False(t, pp.isStatic)
-	require.Equal(t, 0, pp.nRedirects)
+	require.Equal(t, 1, pp.nRedirects)
 	require.Equal(t, uint16(0), pp.rulesPort)
 
-	// Proxy port without references can not be released, so increment to simulate proxy
-	// redirect creation
-	pp.nRedirects++
+	// Unacknowledged proxy port is released due to a NACK
+	p.ResetUnacknowledged(pp)
+	require.False(t, pp.configured)
+	require.False(t, pp.acknowledged)
+	require.Equal(t, uint16(0), pp.ProxyPort)
 
 	err = p.releaseProxyPort("listener1", 10*time.Millisecond)
 	require.NoError(t, err)
 
-	// Proxy port is not released immediately
+	// Last reference is not released immediately
 	require.Equal(t, 1, pp.nRedirects)
-	require.Equal(t, port, pp.ProxyPort)
+	require.Equal(t, uint16(0), pp.ProxyPort)
 	port1a, _, err = p.GetProxyPort("listener1")
 	require.NoError(t, err)
-	require.Equal(t, port, port1a)
+	require.Equal(t, uint16(0), port1a)
 
 	require.Eventually(t, func() bool {
 		return p.noRedirects(pp)
@@ -78,6 +81,7 @@ func TestPortAllocator(t *testing.T) {
 	require.Equal(t, uint16(0), port1b)
 	require.Equal(t, uint16(0), pp.ProxyPort)
 	require.False(t, pp.configured)
+	require.False(t, pp.acknowledged)
 	require.Equal(t, 0, pp.nRedirects)
 
 	// the port was never acked, so rulesPort is 0
@@ -87,27 +91,30 @@ func TestPortAllocator(t *testing.T) {
 	port2, err := p.AllocateCRDProxyPort("listener1")
 	require.NoError(t, err)
 	require.NotEqual(t, port, port2)
-	name2, pp2 := p.FindByType(types.ProxyTypeCRD, "listener1", false)
+	name2, pp2 := p.FindByTypeWithReference(types.ProxyTypeCRD, "listener1", false)
 	require.Equal(t, name2, name)
 	require.Equal(t, pp2, pp)
 	require.Equal(t, types.ProxyTypeCRD, pp.ProxyType)
 	require.False(t, pp.Ingress)
 	require.Equal(t, port2, pp.ProxyPort)
 	require.True(t, pp.configured)
+	require.False(t, pp.acknowledged)
 	require.False(t, pp.isStatic)
-	require.Equal(t, 0, pp.nRedirects)
+	require.Equal(t, 1, pp.nRedirects)
 	require.Equal(t, uint16(0), pp.rulesPort)
 
 	// Ack configures the port to the datapath
-	err = p.AckProxyPortWithReference(context.TODO(), "listener1")
+	err = p.AckProxyPort(context.TODO(), "listener1", pp)
 	require.NoError(t, err)
 	require.Equal(t, 1, pp.nRedirects)
+	require.True(t, pp.acknowledged)
 	require.Equal(t, port2, pp.rulesPort)
 
 	// Another Ack takes another reference
 	err = p.AckProxyPortWithReference(context.TODO(), "listener1")
 	require.NoError(t, err)
 	require.Equal(t, 2, pp.nRedirects)
+	require.True(t, pp.acknowledged)
 	require.Equal(t, port2, pp.rulesPort)
 
 	// 1st release decreases the count
@@ -115,6 +122,14 @@ func TestPortAllocator(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, pp.nRedirects)
 	require.True(t, pp.configured)
+	require.True(t, pp.acknowledged)
+	require.Equal(t, port2, pp.ProxyPort)
+
+	// Acknowledged proxy port is not released due to a NACK
+	p.ResetUnacknowledged(pp)
+	require.Equal(t, 1, pp.nRedirects)
+	require.True(t, pp.configured)
+	require.True(t, pp.acknowledged)
 	require.Equal(t, port2, pp.ProxyPort)
 
 	// 2nd release decreases the count to zero
@@ -127,6 +142,7 @@ func TestPortAllocator(t *testing.T) {
 
 	require.Equal(t, 0, pp.nRedirects)
 	require.False(t, pp.configured)
+	require.False(t, pp.acknowledged)
 	require.Equal(t, uint16(0), pp.ProxyPort)
 	require.Equal(t, port2, pp.rulesPort)
 
@@ -143,21 +159,23 @@ func TestPortAllocator(t *testing.T) {
 	require.NotEqual(t, uint16(0), port3)
 	require.NotEqual(t, port2, port3)
 	require.NotEqual(t, port1, port3)
-	name2, pp2 = p.FindByType(types.ProxyTypeCRD, "listener1", false)
+	name2, pp2 = p.FindByTypeWithReference(types.ProxyTypeCRD, "listener1", false)
 	require.Equal(t, name2, name)
 	require.Equal(t, pp2, pp)
 	require.Equal(t, types.ProxyTypeCRD, pp.ProxyType)
 	require.False(t, pp.Ingress)
 	require.Equal(t, port3, pp.ProxyPort)
 	require.True(t, pp.configured)
+	require.False(t, pp.acknowledged)
 	require.False(t, pp.isStatic)
-	require.Equal(t, 0, pp.nRedirects)
+	require.Equal(t, 1, pp.nRedirects)
 	require.Equal(t, port2, pp.rulesPort)
 
 	// Ack configures the port to the datapath
-	err = p.AckProxyPortWithReference(context.TODO(), "listener1")
+	err = p.AckProxyPort(context.TODO(), "listener1", pp)
 	require.NoError(t, err)
 	require.Equal(t, 1, pp.nRedirects)
+	require.True(t, pp.acknowledged)
 	require.Equal(t, port3, pp.rulesPort)
 
 	// Release marks the port as unallocated
@@ -170,6 +188,7 @@ func TestPortAllocator(t *testing.T) {
 
 	require.Equal(t, 0, pp.nRedirects)
 	require.False(t, pp.configured)
+	require.False(t, pp.acknowledged)
 	require.Equal(t, uint16(0), pp.ProxyPort)
 	require.Equal(t, port3, pp.rulesPort)
 
@@ -185,6 +204,7 @@ func TestPortAllocator(t *testing.T) {
 	require.False(t, pp.Ingress)
 	require.Equal(t, port4, pp.ProxyPort)
 	require.True(t, pp.configured)
+	require.False(t, pp.acknowledged)
 	require.False(t, pp.isStatic)
 	require.Equal(t, 0, pp.nRedirects)
 	require.Equal(t, port3, pp.rulesPort)

--- a/pkg/proxy/proxyports/testutils.go
+++ b/pkg/proxy/proxyports/testutils.go
@@ -22,7 +22,7 @@ func proxyPortsForTest() (*ProxyPorts, func()) {
 	p := NewProxyPorts(10000, 20000, mockDatapathUpdater)
 	triggerDone := make(chan struct{})
 	p.Trigger, _ = trigger.NewTrigger(trigger.Parameters{
-		MinInterval:  10 * time.Second,
+		MinInterval:  10 * time.Millisecond,
 		TriggerFunc:  func(reasons []string) {},
 		ShutdownFunc: func() { close(triggerDone) },
 	})


### PR DESCRIPTION
Take a proxy port reference for new redirects as soon as they are created, rather than when an acknowledgement is received. This fixes the case where a delayed release of the proxy port takes effect after a proxy redirect has been created but not acknowledged yet, signified by these error logs seen in the CI:
```
  msg="Created new proxy instance" ProxyPort=19659 id="2424:egress:TCP:64:" l7parser=http ...
  msg="Delayed release of proxy port 19659" id=cilium-http-egress ...
  msg="Datapath proxy redirection cannot be enabled, L7 proxy may be bypassed" error="ackProxyPort: zero port on cilium-http-egress not allowed" id="2424:egress:TCP:4096:" l7parser=http ...
```
This change makes it necessary to manage the acknowledgement status of a proxy port separately from the 'nRedirects' field. Add a new 'acknowledged' field for this purpose.

Cancel pending delayed release of the proxy port if a new reference is taken. This fixes the scenario where the last reference is released and a delayed release of the proxy port is scheduled, but the proxy port is reused and released before the scheduled release time. In this case the proxy port would have been released sooner than intended due to the original pending release had not been canceled when the new reference was taken.

Fixes: #36142