### PR TITLE
renovate: do not pin digest for helm/kind-action

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -287,6 +287,17 @@
       ]
     },
     {
+      // Do not ping helm/kind since the last version (1.10.0) has a bug which
+      // prevents it from downloading kubectl in older versions.
+      "enabled": false,
+      "matchDepNames": [
+        "helm/kind-action"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ]
+    },
+    {
       "matchFiles": [
         "install/kubernetes/Makefile.values"
       ],


### PR DESCRIPTION
Versions lower than v1.10.0 have a problem downloading kubectl. Thus, we need to configure renovate to stop setting the right digest for the specific version. Once a new major, minor or patch version is released renovate will update this dependency again.