### PR TITLE
cilium-cli: Limit L7 port range tests to 1.17 and up

### DIFF
--- a/cilium-cli/connectivity/builder/client_egress_l7.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7.go
@@ -13,7 +13,7 @@ type clientEgressL7 struct{}
 
 func (t clientEgressL7) build(ct *check.ConnectivityTest, templates map[string]string) {
 	clientEgressL7Test(ct, templates, false)
-	if ct.Features[features.PortRanges].Enabled {
+	if ct.Features[features.L7PortRanges].Enabled {
 		clientEgressL7Test(ct, templates, true)
 	}
 }

--- a/cilium-cli/connectivity/builder/client_egress_l7_method.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_method.go
@@ -21,7 +21,7 @@ type clientEgressL7Method struct{}
 
 func (t clientEgressL7Method) build(ct *check.ConnectivityTest, templates map[string]string) {
 	clientEgressL7MethodTest(ct, templates, false)
-	if ct.Features[features.PortRanges].Enabled {
+	if ct.Features[features.L7PortRanges].Enabled {
 		clientEgressL7MethodTest(ct, templates, true)
 	}
 }

--- a/cilium-cli/connectivity/builder/client_egress_l7_set_header.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_set_header.go
@@ -16,7 +16,7 @@ type clientEgressL7SetHeader struct{}
 
 func (t clientEgressL7SetHeader) build(ct *check.ConnectivityTest, templates map[string]string) {
 	clientEgressL7SetHeaderTest(ct, templates, false)
-	if ct.Features[features.PortRanges].Enabled {
+	if ct.Features[features.L7PortRanges].Enabled {
 		clientEgressL7SetHeaderTest(ct, templates, true)
 	}
 }

--- a/cilium-cli/connectivity/builder/client_egress_l7_tls_headers.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_tls_headers.go
@@ -13,7 +13,7 @@ type clientEgressL7TlsHeaders struct{}
 
 func (t clientEgressL7TlsHeaders) build(ct *check.ConnectivityTest, templates map[string]string) {
 	clientEgressL7TlsHeadersTest(ct, templates, false)
-	if ct.Features[features.PortRanges].Enabled {
+	if ct.Features[features.L7PortRanges].Enabled {
 		clientEgressL7TlsHeadersTest(ct, templates, true)
 	}
 }

--- a/cilium-cli/connectivity/builder/north_south_loadbalancing_with_l7_policy.go
+++ b/cilium-cli/connectivity/builder/north_south_loadbalancing_with_l7_policy.go
@@ -21,7 +21,7 @@ type northSouthLoadbalancingWithL7Policy struct{}
 
 func (t northSouthLoadbalancingWithL7Policy) build(ct *check.ConnectivityTest, _ map[string]string) {
 	northSouthLoadbalancingWithL7PolicyTest(ct, false)
-	if ct.Features[features.PortRanges].Enabled {
+	if ct.Features[features.L7PortRanges].Enabled {
 		northSouthLoadbalancingWithL7PolicyTest(ct, true)
 	}
 }

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -22,6 +22,7 @@ const (
 	HostFirewall       Feature = "host-firewall"
 	ICMPPolicy         Feature = "icmp-policy"
 	PortRanges         Feature = "port-ranges"
+	L7PortRanges       Feature = "l7-port-ranges"
 	Tunnel             Feature = "tunnel"
 	EndpointRoutes     Feature = "endpoint-routes"
 
@@ -222,10 +223,18 @@ func RequireMode(feature Feature, mode string) Requirement {
 func (fs Set) ExtractFromVersionedConfigMap(ciliumVersion semver.Version, cm *v1.ConfigMap) {
 	fs[Tunnel] = ExtractTunnelFeatureFromVersionedConfigMap(ciliumVersion, cm)
 	fs[PortRanges] = ExtractPortRanges(ciliumVersion)
+	fs[L7PortRanges] = ExtractL7PortRanges(ciliumVersion)
 }
 
 func ExtractPortRanges(ciliumVersion semver.Version) Status {
 	enabled := versioncheck.MustCompile(">=1.16.0")(ciliumVersion)
+	return Status{
+		Enabled: enabled,
+	}
+}
+
+func ExtractL7PortRanges(ciliumVersion semver.Version) Status {
+	enabled := versioncheck.MustCompile(">=1.17.0")(ciliumVersion)
 	return Status{
 		Enabled: enabled,
 	}


### PR DESCRIPTION
HTTP port range policies are not supported on 1.16, skip them on unless running on 1.17+.

Related: #36050

```release-note
Connecticity tests with L7 policies and port ranges are skipped on Cilium releases prior to 1.17.
```
