### PR TITLE
.github/workflows: do not fail ginkgo if unable to fetch features

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -463,6 +463,7 @@ jobs:
 
       - name: Fetch features tested
         if: ${{ always() && steps.provision-vh-vms.outcome == 'success' }}
+        continue-on-error: true
         uses: cilium/little-vm-helper@97c89f004bd0ab4caeacfe92ebc956e13e362e6b # v0.0.19
         with:
           provision: 'false'


### PR DESCRIPTION
Fetching the features tested on the GH workflow should not be a reason to fail the workflow. Thus, we can continue on error if this step fails.

Fixes: a23106d28619 (".github/workflows: report which features are being used in CI")