### PR TITLE
gha: extra Cilium agents CPU and Mem metrics in clustermesh scale test

### DIFF
--- a/.github/actions/cl2-modules/clustermesh/modules/metrics.yaml
+++ b/.github/actions/cl2-modules/clustermesh/modules/metrics.yaml
@@ -183,3 +183,27 @@ steps:
       - name: Max
         query: max_over_time(count({__name__=~"cilium_.+"})[%v:])
       enableViolations: true
+
+  - Identifier: CiliumCPUUsage
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: Average CPU Usage
+      metricVersion: v1
+      unit: cpu
+      enableViolations: true
+      queries:
+      - name: Max
+        query: max(avg_over_time(rate(cilium_process_cpu_seconds_total[1m])[%v:]))
+
+  - Identifier: CiliumMemUsage
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: Max Memory Usage
+      metricVersion: v1
+      unit: MB
+      enableViolations: true
+      queries:
+      - name: Max
+        query: max(max_over_time(cilium_process_resident_memory_bytes[%v:]) / 1e6)


### PR DESCRIPTION
Extend the CL2 configuration used by the clustermesh scale test to additionally gather extra metrics about Cilium agents CPU and memory usage. In particular, there are computed starting from the golang metrics, rather than retrieved from the kubelet.
