### PR TITLE
KVStoreMesh: only sync identities ID

### DIFF
--- a/pkg/clustermesh/kvstoremesh/kvstoremesh.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh.go
@@ -150,17 +150,19 @@ func (km *KVStoreMesh) newRemoteCluster(name string, status common.StatusFunc) c
 	synced := newSynced()
 	defer synced.resources.Stop()
 
+	identityCacheSuffix := "id"
+
 	rc := &remoteCluster{
 		name:         name,
 		localBackend: km.backend,
 
 		cancel: cancel,
 
-		nodes:          newReflector(km.backend, name, nodeStore.NodeStorePrefix, km.storeFactory, synced.resources),
-		services:       newReflector(km.backend, name, serviceStore.ServiceStorePrefix, km.storeFactory, synced.resources),
-		serviceExports: newReflector(km.backend, name, mcsapitypes.ServiceExportStorePrefix, km.storeFactory, synced.resources),
-		identities:     newReflector(km.backend, name, identityCache.IdentitiesPath, km.storeFactory, synced.resources),
-		ipcache:        newReflector(km.backend, name, ipcache.IPIdentitiesPath, km.storeFactory, synced.resources),
+		nodes:          newReflector(km.backend, name, nodeStore.NodeStorePrefix, "", km.storeFactory, synced.resources),
+		services:       newReflector(km.backend, name, serviceStore.ServiceStorePrefix, "", km.storeFactory, synced.resources),
+		serviceExports: newReflector(km.backend, name, mcsapitypes.ServiceExportStorePrefix, "", km.storeFactory, synced.resources),
+		identities:     newReflector(km.backend, name, identityCache.IdentitiesPath, identityCacheSuffix, km.storeFactory, synced.resources),
+		ipcache:        newReflector(km.backend, name, ipcache.IPIdentitiesPath, "", km.storeFactory, synced.resources),
 		status:         status,
 		storeFactory:   km.storeFactory,
 		synced:         synced,

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
@@ -139,8 +139,9 @@ func TestRemoteClusterRun(t *testing.T) {
 				"cilium/state/nodes/v1/foo/bar":          "qux1",
 				"cilium/state/services/v1/foo/bar":       "qux2",
 				"cilium/state/serviceexports/v1/foo/bar": "qux3",
-				"cilium/state/identities/v1/bar":         "qux4",
-				"cilium/state/ip/v1/default/bar":         "qux5",
+				"cilium/state/identities/v1/id/bar":      "qux4",
+				"cilium/state/identities/v1/value/bar":   "qux5",
+				"cilium/state/ip/v1/default/bar":         "qux6",
 			},
 		},
 		{
@@ -162,8 +163,9 @@ func TestRemoteClusterRun(t *testing.T) {
 				"cilium/state/nodes/v1/foo/bar":          "qux1",
 				"cilium/state/services/v1/foo/bar":       "qux2",
 				"cilium/state/serviceexports/v1/foo/bar": "qux3",
-				"cilium/state/identities/v1/bar":         "qux4",
-				"cilium/state/ip/v1/default/bar":         "qux5",
+				"cilium/state/identities/v1/id/bar":      "qux4",
+				"cilium/state/identities/v1/value/bar":   "qux5",
+				"cilium/state/ip/v1/default/bar":         "qux6",
 			},
 		},
 		{
@@ -184,11 +186,12 @@ func TestRemoteClusterRun(t *testing.T) {
 				},
 			},
 			kvs: map[string]string{
-				"cilium/cache/nodes/v1/foo/bar":          "qux1",
-				"cilium/cache/services/v1/foo/bar":       "qux2",
-				"cilium/cache/serviceexports/v1/foo/bar": "qux3",
-				"cilium/cache/identities/v1/foo/bar":     "qux4",
-				"cilium/cache/ip/v1/foo/bar":             "qux5",
+				"cilium/cache/nodes/v1/foo/bar":            "qux1",
+				"cilium/cache/services/v1/foo/bar":         "qux2",
+				"cilium/cache/serviceexports/v1/foo/bar":   "qux3",
+				"cilium/cache/identities/v1/foo/id/bar":    "qux4",
+				"cilium/cache/identities/v1/foo/value/bar": "qux5",
+				"cilium/cache/ip/v1/foo/bar":               "qux6",
 			},
 		},
 		{
@@ -210,11 +213,12 @@ func TestRemoteClusterRun(t *testing.T) {
 				},
 			},
 			kvs: map[string]string{
-				"cilium/cache/nodes/v1/foo/bar":          "qux1",
-				"cilium/cache/services/v1/foo/bar":       "qux2",
-				"cilium/cache/serviceexports/v1/foo/bar": "qux3",
-				"cilium/cache/identities/v1/foo/bar":     "qux4",
-				"cilium/cache/ip/v1/foo/bar":             "qux5",
+				"cilium/cache/nodes/v1/foo/bar":            "qux1",
+				"cilium/cache/services/v1/foo/bar":         "qux2",
+				"cilium/cache/serviceexports/v1/foo/bar":   "qux3",
+				"cilium/cache/identities/v1/foo/id/bar":    "qux4",
+				"cilium/cache/identities/v1/foo/value/bar": "qux5",
+				"cilium/cache/ip/v1/foo/bar":               "qux6",
 			},
 		},
 	}
@@ -262,10 +266,10 @@ func TestRemoteClusterRun(t *testing.T) {
 			}, timeout, tick, "Failed to retrieve the cluster config")
 
 			expectedReflected := map[string]string{
-				"cilium/cache/nodes/v1/foo/bar":      "qux1",
-				"cilium/cache/services/v1/foo/bar":   "qux2",
-				"cilium/cache/identities/v1/foo/bar": "qux4",
-				"cilium/cache/ip/v1/foo/bar":         "qux5",
+				"cilium/cache/nodes/v1/foo/bar":         "qux1",
+				"cilium/cache/services/v1/foo/bar":      "qux2",
+				"cilium/cache/identities/v1/foo/id/bar": "qux4",
+				"cilium/cache/ip/v1/foo/bar":            "qux6",
 			}
 			if tt.srccfg.Capabilities.ServiceExportsEnabled != nil {
 				expectedReflected["cilium/cache/serviceexports/v1/foo/bar"] = "qux3"
@@ -278,6 +282,11 @@ func TestRemoteClusterRun(t *testing.T) {
 					assert.Equal(c, value, string(v))
 				}, timeout, tick, "Expected key %q does not seem to have the correct value %q", key, value)
 			}
+
+			// Assert that other keys have not been reflected
+			values, err := kvstore.Client().ListPrefix(ctx, "cilium/cache/identities/v1/")
+			require.NoError(t, err)
+			require.Len(t, values, 1)
 
 			expectedSyncedCanaries := []string{
 				"cilium/synced/foo/cilium/cache/nodes/v1",
@@ -604,7 +613,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 			"cilium/state/services/v1/foo/baz":       "qux3",
 			"cilium/state/services/v1/foo/qux":       "qux4",
 			"cilium/state/serviceexports/v1/foo/qux": "qux5",
-			"cilium/state/identities/v1/bar":         "qux6",
+			"cilium/state/identities/v1/id/bar":      "qux6",
 			"cilium/state/ip/v1/default/fred":        "qux7",
 			"cilium/state/ip/v1/default/bar":         "qux8",
 			"cilium/state/ip/v1/default/baz":         "qux9",

--- a/pkg/clustermesh/kvstoremesh/remote_cluster.go
+++ b/pkg/clustermesh/kvstoremesh/remote_cluster.go
@@ -141,6 +141,7 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 		if srccfg.Capabilities.Cached {
 			suffix = rc.name
 		}
+		suffix = path.Join(suffix, "id")
 
 		rc.identities.watcher.Watch(ctx, backend, path.Join(adapter(identityCache.IdentitiesPath), suffix))
 	})
@@ -312,10 +313,12 @@ func (o *syncer) OnSync(ctx context.Context) {
 	}
 }
 
-func newReflector(local kvstore.BackendOperations, cluster, prefix string, factory store.Factory, synced *resources) reflector {
+func newReflector(local kvstore.BackendOperations, cluster, prefix, suffix string, factory store.Factory, synced *resources) reflector {
 	prefix = kvstore.StateToCachePrefix(prefix)
+	syncStorePrefix := path.Join(prefix, cluster, suffix)
+
 	syncer := syncer{
-		SyncStore: factory.NewSyncStore(cluster, local, path.Join(prefix, cluster),
+		SyncStore: factory.NewSyncStore(cluster, local, syncStorePrefix,
 			store.WSSWithSyncedKeyOverride(prefix)),
 		syncedDone: synced.Add(),
 		isSynced:   &atomic.Bool{},


### PR DESCRIPTION
This PR implements the patch described in #36425

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #36425

```release-note
KVStoreMesh: Optimize cross-cluster state distribution by only synchronizing identities keyed by ID, not by value
```
