### PR TITLE
Update oss-fuzz CI workflow

### DIFF
--- a/.github/workflows/tests-cifuzz.yaml
+++ b/.github/workflows/tests-cifuzz.yaml
@@ -16,13 +16,13 @@ jobs:
     steps:
     - name: Build Fuzzers
       id: build
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@723bdbc7a8ee1e95af24284583b25d41efc0bd41
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@aa0dba641cb81070221554e0d2ed4f97aa46db35
       with:
         oss-fuzz-project-name: 'cilium'
         dry-run: false
         language: go
     - name: Run Fuzzers
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@723bdbc7a8ee1e95af24284583b25d41efc0bd41
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@aa0dba641cb81070221554e0d2ed4f97aa46db35
       with:
         oss-fuzz-project-name: 'cilium'
         fuzz-seconds: 600

--- a/.github/workflows/tests-cifuzz.yaml
+++ b/.github/workflows/tests-cifuzz.yaml
@@ -1,8 +1,13 @@
 name: CIFuzz
 on:
+  schedule:
+    # Run the Fuzzers every Monday at 7am
+    - cron: '0 7 * * 1'
+  workflow_dispatch: {}
   pull_request:
-    paths-ignore:
-      - 'Documentation/**'
+    paths:
+      - '.github/workflows/tests-cifuzz.yaml'
+      - '**/fuzz_test.go'
 permissions: read-all
 jobs:
   Fuzzing:

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -45,7 +46,7 @@ func FuzzDenyPreferredInsert(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		keys := newMapState()
 		key := Key{}
-		entry := NewMapStateEntry(AllowEntry, nil)
+		entry := NewMapStateEntry(types.AllowEntry(), nil)
 		ff := fuzz.NewConsumer(data)
 		ff.GenerateStruct(&key)
 		ff.GenerateStruct(&entry)


### PR DESCRIPTION
Previously ci-fuzz was triggered on almost any changes to the tree, but
the signal to noise ratio did not make it helpful for most developers.
It also takes longer than 15m to run, which is our goal for smoke tests.
So it's been disabled for a while. However, this has allowed breakage to
be introduced into the tree.

Reduce the filter for pull requests to only run on changes to the fuzz
tests themselves. While this won't catch all regressions, it will at
least allow developers to make changes to the fuzzers and validate that
the new changes may build and not detect new issues.

In order to make these results more accessible, run them once a week and
allow developers to manually trigger the workflow through the GitHub UI.

This PR also fixes the fuzzer build after a breakage in https://github.com/cilium/cilium/pull/36056 .