### PR TITLE
policy: Fix toRequires/fromRequires Bug

### DIFF
--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -326,13 +326,13 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 	require.False(t, eQABar.Allows(qaBarSecLblsCtx.ID))
 	require.False(t, eQABar.Allows(prodBarSecLblsCtx.ID))
 	require.True(t, eQABar.Allows(qaFooSecLblsCtx.ID))
-	require.False(t, eQABar.Allows(prodFooSecLblsCtx.ID))
+	require.True(t, eQABar.Allows(prodFooSecLblsCtx.ID))
 
 	eProdBar := ds.prepareEndpoint(t, prodBarSecLblsCtx, false)
 	require.False(t, eProdBar.Allows(0))
 	require.False(t, eProdBar.Allows(qaBarSecLblsCtx.ID))
 	require.False(t, eProdBar.Allows(prodBarSecLblsCtx.ID))
-	require.False(t, eProdBar.Allows(qaFooSecLblsCtx.ID))
+	require.True(t, eProdBar.Allows(qaFooSecLblsCtx.ID))
 	require.True(t, eProdBar.Allows(prodFooSecLblsCtx.ID))
 	require.True(t, eProdBar.Allows(prodFooJoeSecLblsCtx.ID))
 
@@ -345,10 +345,8 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 	require.NotNil(t, qaBarNetworkPolicy)
 	expectedRemotePolicies := []uint32{
 		uint32(qaFooSecLblsCtx.ID),
-		// The prodFoo* identities are allowed by FromEndpoints but rejected by
-		// FromRequires, so they are not included in the remote policies:
-		// uint32(prodFooSecLblsCtx.ID),
-		// uint32(prodFooJoeSecLblsCtx.ID),
+		uint32(prodFooSecLblsCtx.ID),
+		uint32(prodFooJoeSecLblsCtx.ID),
 	}
 	sort.Slice(expectedRemotePolicies, func(i, j int) bool {
 		return expectedRemotePolicies[i] < expectedRemotePolicies[j]
@@ -386,9 +384,7 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 	prodBarNetworkPolicy := networkPolicies[ProdIPv4Addr.String()]
 	require.NotNil(t, prodBarNetworkPolicy)
 	expectedRemotePolicies = []uint32{
-		// The qaFoo identity is allowed by FromEndpoints but rejected by
-		// FromRequires, so it is not included in the remote policies:
-		// uint64(qaFooSecLblsCtx.ID),
+		uint32(qaFooSecLblsCtx.ID),
 		uint32(prodFooSecLblsCtx.ID),
 		uint32(prodFooJoeSecLblsCtx.ID),
 	}

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -2008,7 +2008,7 @@ func TestEgressPortRangePrecedence(t *testing.T) {
 
 			require.NoError(t, tr.Sanitize())
 			state := traceState{}
-			res, err := tr.resolveEgressPolicy(td.testPolicyContext, &ctxFromA, &state, NewL4PolicyMap(), nil, nil)
+			res, err := tr.resolveEgressPolicy(td.testPolicyContext, &ctxFromA, &state, NewL4PolicyMap())
 			require.NoError(t, err)
 			require.NotNil(t, res)
 

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -36,7 +36,7 @@ func FuzzResolveEgressPolicy(f *testing.F) {
 		rule := &rule{Rule: r}
 		state := traceState{}
 		td := newTestData()
-		_, _ = rule.resolveEgressPolicy(td.testPolicyContext, fromBar, &state, NewL4PolicyMap(), nil, nil)
+		_, _ = rule.resolveEgressPolicy(td.testPolicyContext, fromBar, &state, NewL4PolicyMap())
 
 	})
 }

--- a/pkg/policy/l4_filter_deny_test.go
+++ b/pkg/policy/l4_filter_deny_test.go
@@ -203,7 +203,7 @@ func TestL3DenyRuleShadowedByL3DenyAll(t *testing.T) {
 	}})
 
 	state := traceState{}
-	resDeny, err := shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	resDeny, err := shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, resDeny)
 	require.EqualValues(t, expected, resDeny)
@@ -214,7 +214,7 @@ func TestL3DenyRuleShadowedByL3DenyAll(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, resDeny)
 	require.Equal(t, 0, state.selectedRules)
@@ -272,7 +272,7 @@ func TestL3DenyRuleShadowedByL3DenyAll(t *testing.T) {
 	}})
 
 	state = traceState{}
-	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, resDeny)
 	require.EqualValues(t, expected, resDeny)
@@ -283,7 +283,7 @@ func TestL3DenyRuleShadowedByL3DenyAll(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, resDeny)
 	require.Equal(t, 0, state.selectedRules)
@@ -345,7 +345,7 @@ func TestMergingWithDifferentEndpointSelectedDenyAllL7(t *testing.T) {
 	}})
 
 	state := traceState{}
-	resDeny, err := selectDifferentEndpointsDenyAllL7.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	resDeny, err := selectDifferentEndpointsDenyAllL7.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, resDeny)
 	require.EqualValues(t, expected, resDeny)
@@ -361,7 +361,7 @@ func TestMergingWithDifferentEndpointSelectedDenyAllL7(t *testing.T) {
 	t.Log(buffer)
 
 	state = traceState{}
-	resDeny, err = selectDifferentEndpointsDenyAllL7.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	resDeny, err = selectDifferentEndpointsDenyAllL7.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, resDeny)
 	require.Equal(t, 0, state.selectedRules)
@@ -427,7 +427,7 @@ func TestL3AllowRuleShadowedByL3DenyAll(t *testing.T) {
 	}})
 
 	state := traceState{}
-	resDeny, err := shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	resDeny, err := shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, resDeny)
 	require.EqualValues(t, expectedDeny, resDeny)
@@ -438,7 +438,7 @@ func TestL3AllowRuleShadowedByL3DenyAll(t *testing.T) {
 	expectedDeny.Detach(td.sc)
 
 	state = traceState{}
-	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, resDeny)
 	require.Equal(t, 0, state.selectedRules)
@@ -498,7 +498,7 @@ func TestL3AllowRuleShadowedByL3DenyAll(t *testing.T) {
 	}})
 
 	state = traceState{}
-	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, resDeny)
 	require.EqualValues(t, expectedDeny, resDeny)
@@ -509,7 +509,7 @@ func TestL3AllowRuleShadowedByL3DenyAll(t *testing.T) {
 	expectedDeny.Detach(td.sc)
 
 	state = traceState{}
-	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, resDeny)
 	require.Equal(t, 0, state.selectedRules)
@@ -585,7 +585,7 @@ func TestL3L4AllowRuleWithByL3DenyAll(t *testing.T) {
 	}})
 
 	state := traceState{}
-	resDeny, err := shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	resDeny, err := shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, resDeny)
 	require.EqualValues(t, expected, resDeny)
@@ -596,7 +596,7 @@ func TestL3L4AllowRuleWithByL3DenyAll(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, resDeny)
 	require.Equal(t, 0, state.selectedRules)
@@ -666,7 +666,7 @@ func TestL3L4AllowRuleWithByL3DenyAll(t *testing.T) {
 	}})
 
 	state = traceState{}
-	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, resDeny)
 	require.EqualValues(t, expected, resDeny)
@@ -677,7 +677,7 @@ func TestL3L4AllowRuleWithByL3DenyAll(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	resDeny, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, resDeny)
 	require.Equal(t, 0, state.selectedRules)

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -310,7 +310,7 @@ func TestMergeAllowAllL3AndShadowedL7(t *testing.T) {
 	ctx.Logging = stdlog.New(buffer, "", 0)
 
 	ingressState := traceState{}
-	res, err := rule1.resolveIngressPolicy(td.testPolicyContext, &ctx, &ingressState, NewL4PolicyMap(), nil, nil)
+	res, err := rule1.resolveIngressPolicy(td.testPolicyContext, &ctx, &ingressState, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
@@ -461,7 +461,7 @@ func TestMergeIdenticalAllowAllL3AndRestrictedL7HTTP(t *testing.T) {
 	t.Log(buffer)
 
 	state := traceState{}
-	res, err := identicalHTTPRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	res, err := identicalHTTPRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.EqualValues(t, expected, res)
@@ -471,7 +471,7 @@ func TestMergeIdenticalAllowAllL3AndRestrictedL7HTTP(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	res, err = identicalHTTPRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = identicalHTTPRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)
@@ -544,7 +544,7 @@ func TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(t *testing.T) {
 	}})
 
 	state := traceState{}
-	res, err := identicalKafkaRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	res, err := identicalKafkaRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.EqualValues(t, expected, res)
@@ -554,7 +554,7 @@ func TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	res, err = identicalKafkaRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = identicalKafkaRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)
@@ -611,7 +611,7 @@ func TestMergeIdenticalAllowAllL3AndMismatchingParsers(t *testing.T) {
 	t.Log(buffer)
 
 	state := traceState{}
-	res, err := conflictingParsersRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	res, err := conflictingParsersRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.Error(t, err)
 	require.Nil(t, res)
 
@@ -660,7 +660,7 @@ func TestMergeIdenticalAllowAllL3AndMismatchingParsers(t *testing.T) {
 	t.Log(buffer)
 
 	state = traceState{}
-	res, err = conflictingParsersRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	res, err = conflictingParsersRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.Error(t, err)
 	require.Nil(t, res)
 
@@ -713,7 +713,7 @@ func TestMergeIdenticalAllowAllL3AndMismatchingParsers(t *testing.T) {
 	require.NoError(t, err)
 
 	state = traceState{}
-	res, err = conflictingParsersIngressRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	res, err = conflictingParsersIngressRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.Error(t, err)
 	require.Nil(t, res)
 
@@ -763,7 +763,7 @@ func TestMergeIdenticalAllowAllL3AndMismatchingParsers(t *testing.T) {
 	require.NoError(t, err)
 
 	state = traceState{}
-	res, err = conflictingParsersEgressRule.resolveEgressPolicy(td.testPolicyContext, &ctxAToC, &state, NewL4PolicyMap(), nil, nil)
+	res, err = conflictingParsersEgressRule.resolveEgressPolicy(td.testPolicyContext, &ctxAToC, &state, NewL4PolicyMap())
 	t.Log(buffer)
 	require.Error(t, err)
 	require.Nil(t, res)
@@ -821,7 +821,7 @@ func TestMergeTLSTCPPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	state := traceState{}
-	res, err := egressRule.resolveEgressPolicy(td.testPolicyContext, &ctxFromFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err := egressRule.resolveEgressPolicy(td.testPolicyContext, &ctxFromFoo, &state, NewL4PolicyMap())
 	t.Log(buffer)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -921,7 +921,7 @@ func TestMergeTLSHTTPPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	state := traceState{}
-	res, err := egressRule.resolveEgressPolicy(td.testPolicyContext, &ctxFromFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err := egressRule.resolveEgressPolicy(td.testPolicyContext, &ctxFromFoo, &state, NewL4PolicyMap())
 	t.Log(buffer)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -1038,7 +1038,7 @@ func TestMergeTLSSNIPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	state := traceState{}
-	res, err := egressRule.resolveEgressPolicy(td.testPolicyContext, &ctxFromFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err := egressRule.resolveEgressPolicy(td.testPolicyContext, &ctxFromFoo, &state, NewL4PolicyMap())
 	t.Log(buffer)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -1140,7 +1140,7 @@ func TestMergeListenerPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	state := traceState{}
-	res, err := egressRule.resolveEgressPolicy(td.testPolicyContext, &ctxFromFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err := egressRule.resolveEgressPolicy(td.testPolicyContext, &ctxFromFoo, &state, NewL4PolicyMap())
 	t.Log(buffer)
 	require.ErrorContains(t, err, "Listener \"test\" in CCNP can not use Kind CiliumEnvoyConfig")
 	require.Nil(t, res)
@@ -1192,7 +1192,7 @@ func TestMergeListenerPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	state = traceState{}
-	res, err = egressRule.resolveEgressPolicy(td.testPolicyContext, &ctxFromFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = egressRule.resolveEgressPolicy(td.testPolicyContext, &ctxFromFoo, &state, NewL4PolicyMap())
 	t.Log(buffer)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -1274,7 +1274,7 @@ func TestMergeListenerPolicy(t *testing.T) {
 
 	state = traceState{}
 	td.testPolicyContext.ns = "default"
-	res, err = egressRule.resolveEgressPolicy(td.testPolicyContext, &ctxFromFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = egressRule.resolveEgressPolicy(td.testPolicyContext, &ctxFromFoo, &state, NewL4PolicyMap())
 	t.Log(buffer)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -1357,7 +1357,7 @@ func TestMergeListenerPolicy(t *testing.T) {
 
 	state = traceState{}
 	td.testPolicyContext.ns = "default"
-	res, err = egressRule.resolveEgressPolicy(td.testPolicyContext, &ctxFromFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = egressRule.resolveEgressPolicy(td.testPolicyContext, &ctxFromFoo, &state, NewL4PolicyMap())
 	t.Log(buffer)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -1449,7 +1449,7 @@ func TestL3RuleShadowedByL3AllowAll(t *testing.T) {
 	}})
 
 	state := traceState{}
-	res, err := shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	res, err := shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Equal(t, expected, res)
@@ -1459,7 +1459,7 @@ func TestL3RuleShadowedByL3AllowAll(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	res, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)
@@ -1517,7 +1517,7 @@ func TestL3RuleShadowedByL3AllowAll(t *testing.T) {
 	}})
 
 	state = traceState{}
-	res, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	res, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Equal(t, expected, res)
@@ -1527,7 +1527,7 @@ func TestL3RuleShadowedByL3AllowAll(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	res, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)
@@ -1604,7 +1604,7 @@ func TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(t *testing.T) {
 	}})
 
 	state := traceState{}
-	res, err := shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	res, err := shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.EqualValues(t, expected, res)
@@ -1614,7 +1614,7 @@ func TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	res, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)
@@ -1684,7 +1684,7 @@ func TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(t *testing.T) {
 	}})
 
 	state = traceState{}
-	res, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	res, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.EqualValues(t, expected, res)
@@ -1694,7 +1694,7 @@ func TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	res, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = shadowRule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)
@@ -1782,7 +1782,7 @@ func TestL3RuleWithL7RuleShadowedByL3AllowAll(t *testing.T) {
 	}})
 
 	state := traceState{}
-	res, err := case8Rule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	res, err := case8Rule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.EqualValues(t, expected, res)
@@ -1792,7 +1792,7 @@ func TestL3RuleWithL7RuleShadowedByL3AllowAll(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	res, err = case8Rule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = case8Rule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)
@@ -1872,7 +1872,7 @@ func TestL3RuleWithL7RuleShadowedByL3AllowAll(t *testing.T) {
 	}})
 
 	state = traceState{}
-	res, err = case8Rule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	res, err = case8Rule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	t.Log(buffer)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -1883,7 +1883,7 @@ func TestL3RuleWithL7RuleShadowedByL3AllowAll(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	res, err = case8Rule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = case8Rule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)
@@ -1940,12 +1940,12 @@ func TestL3SelectingEndpointAndL3AllowAllMergeConflictingL7(t *testing.T) {
 	t.Log(buffer)
 
 	state := traceState{}
-	res, err := conflictingL7Rule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	res, err := conflictingL7Rule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.Error(t, err)
 	require.Nil(t, res)
 
 	state = traceState{}
-	res, err = conflictingL7Rule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = conflictingL7Rule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)
@@ -1996,12 +1996,12 @@ func TestL3SelectingEndpointAndL3AllowAllMergeConflictingL7(t *testing.T) {
 	t.Log(buffer)
 
 	state = traceState{}
-	res, err = conflictingL7Rule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	res, err = conflictingL7Rule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.Error(t, err)
 	require.Nil(t, res)
 
 	state = traceState{}
-	res, err = conflictingL7Rule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = conflictingL7Rule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)
@@ -2083,7 +2083,7 @@ func TestMergingWithDifferentEndpointsSelectedAllowSameL7(t *testing.T) {
 	}})
 
 	state := traceState{}
-	res, err := selectDifferentEndpointsRestrictL7.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	res, err := selectDifferentEndpointsRestrictL7.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.EqualValues(t, expected, res)
@@ -2098,7 +2098,7 @@ func TestMergingWithDifferentEndpointsSelectedAllowSameL7(t *testing.T) {
 	t.Log(buffer)
 
 	state = traceState{}
-	res, err = selectDifferentEndpointsRestrictL7.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = selectDifferentEndpointsRestrictL7.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)
@@ -2159,7 +2159,7 @@ func TestMergingWithDifferentEndpointSelectedAllowAllL7(t *testing.T) {
 	}})
 
 	state := traceState{}
-	res, err := selectDifferentEndpointsAllowAllL7.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	res, err := selectDifferentEndpointsAllowAllL7.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Equal(t, expected, res)
@@ -2174,7 +2174,7 @@ func TestMergingWithDifferentEndpointSelectedAllowAllL7(t *testing.T) {
 	t.Log(buffer)
 
 	state = traceState{}
-	res, err = selectDifferentEndpointsAllowAllL7.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = selectDifferentEndpointsAllowAllL7.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)
@@ -2242,7 +2242,7 @@ func TestAllowingLocalhostShadowsL7(t *testing.T) {
 	}})
 
 	state := traceState{}
-	res, err := rule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap(), nil, nil)
+	res, err := rule.resolveIngressPolicy(td.testPolicyContext, &ctxToA, &state, NewL4PolicyMap())
 	t.Log(buffer)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -2258,7 +2258,7 @@ func TestAllowingLocalhostShadowsL7(t *testing.T) {
 	ctxToC.Logging = stdlog.New(buffer, "", 0)
 
 	state = traceState{}
-	res, err = rule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = rule.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	t.Log(buffer)
 	require.NoError(t, err)
 	require.Nil(t, res)
@@ -2300,7 +2300,7 @@ func TestEntitiesL3(t *testing.T) {
 	}})
 
 	state := traceState{}
-	res, err := allowWorldRule.resolveEgressPolicy(td.testPolicyContext, &ctxFromA, &state, NewL4PolicyMap(), nil, nil)
+	res, err := allowWorldRule.resolveEgressPolicy(td.testPolicyContext, &ctxFromA, &state, NewL4PolicyMap())
 
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -2338,7 +2338,7 @@ func TestEgressEmptyToEndpoints(t *testing.T) {
 	t.Log(buffer)
 
 	state := traceState{}
-	res, err := rule.resolveEgressPolicy(td.testPolicyContext, &ctxFromA, &state, NewL4PolicyMap(), nil, nil)
+	res, err := rule.resolveEgressPolicy(td.testPolicyContext, &ctxFromA, &state, NewL4PolicyMap())
 
 	require.NoError(t, err)
 	require.Nil(t, res)

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -559,7 +559,6 @@ func (r *rule) resolveIngressPolicy(
 	ctx *SearchContext,
 	state *traceState,
 	result L4PolicyMap,
-	requirements, requirementsDeny []slim_metav1.LabelSelectorRequirement,
 ) (
 	L4PolicyMap, error,
 ) {
@@ -577,6 +576,10 @@ func (r *rule) resolveIngressPolicy(
 		ctx.PolicyTrace("    No ingress rules\n")
 	}
 	for _, ingressRule := range r.Ingress {
+		var requirements []slim_metav1.LabelSelectorRequirement
+		for _, requirement := range ingressRule.FromRequires {
+			requirements = append(requirements, requirement.ConvertToLabelSelectorRequirementSlice()...)
+		}
 		fromEndpoints := ingressRule.GetSourceEndpointSelectorsWithRequirements(requirements)
 		cnt, err := mergeIngress(policyCtx, ctx, fromEndpoints, ingressRule.Authentication, ingressRule.ToPorts, ingressRule.ICMPs, r.Rule.Labels.DeepCopy(), result)
 		if err != nil {
@@ -592,6 +595,10 @@ func (r *rule) resolveIngressPolicy(
 		policyCtx.SetDeny(oldDeny)
 	}()
 	for _, ingressRule := range r.IngressDeny {
+		var requirementsDeny []slim_metav1.LabelSelectorRequirement
+		for _, requirement := range ingressRule.FromRequires {
+			requirementsDeny = append(requirementsDeny, requirement.ConvertToLabelSelectorRequirementSlice()...)
+		}
 		fromEndpoints := ingressRule.GetSourceEndpointSelectorsWithRequirements(requirementsDeny)
 		cnt, err := mergeIngress(policyCtx, ctx, fromEndpoints, nil, ingressRule.ToPorts, ingressRule.ICMPs, r.Rule.Labels.DeepCopy(), result)
 		if err != nil {
@@ -787,7 +794,6 @@ func (r *rule) resolveEgressPolicy(
 	ctx *SearchContext,
 	state *traceState,
 	result L4PolicyMap,
-	requirements, requirementsDeny []slim_metav1.LabelSelectorRequirement,
 ) (
 	L4PolicyMap, error,
 ) {
@@ -805,6 +811,10 @@ func (r *rule) resolveEgressPolicy(
 		ctx.PolicyTrace("    No egress rules\n")
 	}
 	for _, egressRule := range r.Egress {
+		var requirements []slim_metav1.LabelSelectorRequirement
+		for _, requirement := range egressRule.ToRequires {
+			requirements = append(requirements, requirement.ConvertToLabelSelectorRequirementSlice()...)
+		}
 		toEndpoints := egressRule.GetDestinationEndpointSelectorsWithRequirements(requirements)
 		cnt, err := mergeEgress(policyCtx, ctx, toEndpoints, egressRule.Authentication, egressRule.ToPorts, egressRule.ICMPs, r.Rule.Labels.DeepCopy(), result, egressRule.ToFQDNs)
 		if err != nil {
@@ -820,6 +830,10 @@ func (r *rule) resolveEgressPolicy(
 		policyCtx.SetDeny(oldDeny)
 	}()
 	for _, egressRule := range r.EgressDeny {
+		var requirementsDeny []slim_metav1.LabelSelectorRequirement
+		for _, requirement := range egressRule.ToRequires {
+			requirementsDeny = append(requirementsDeny, requirement.ConvertToLabelSelectorRequirementSlice()...)
+		}
 		toEndpoints := egressRule.GetDestinationEndpointSelectorsWithRequirements(requirementsDeny)
 		cnt, err := mergeEgress(policyCtx, ctx, toEndpoints, nil, egressRule.ToPorts, egressRule.ICMPs, r.Rule.Labels.DeepCopy(), result, nil)
 		if err != nil {

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -113,12 +113,12 @@ func TestL4Policy(t *testing.T) {
 	res := NewL4Policy(0)
 	var err error
 	res.Ingress.PortRules, err =
-		rule1.resolveIngressPolicy(td.testPolicyContext, toBar, &ingressState, NewL4PolicyMap(), nil, nil)
+		rule1.resolveIngressPolicy(td.testPolicyContext, toBar, &ingressState, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res.Ingress)
 
 	res.Egress.PortRules, err =
-		rule1.resolveEgressPolicy(td.testPolicyContext, fromBar, &egressState, NewL4PolicyMap(), nil, nil)
+		rule1.resolveEgressPolicy(td.testPolicyContext, fromBar, &egressState, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res.Egress)
 
@@ -135,9 +135,9 @@ func TestL4Policy(t *testing.T) {
 	ingressState = traceState{}
 	egressState = traceState{}
 
-	res1, err := rule1.resolveIngressPolicy(td.testPolicyContext, toFoo, &ingressState, NewL4PolicyMap(), nil, nil)
+	res1, err := rule1.resolveIngressPolicy(td.testPolicyContext, toFoo, &ingressState, NewL4PolicyMap())
 	require.NoError(t, err)
-	res2, err := rule1.resolveEgressPolicy(td.testPolicyContext, fromFoo, &ingressState, NewL4PolicyMap(), nil, nil)
+	res2, err := rule1.resolveEgressPolicy(td.testPolicyContext, fromFoo, &ingressState, NewL4PolicyMap())
 	require.NoError(t, err)
 
 	require.Nil(t, res1)
@@ -237,13 +237,13 @@ func TestL4Policy(t *testing.T) {
 	ctx := SearchContext{To: labels.ParseSelectLabelArray("bar"), Trace: TRACE_VERBOSE}
 	ctx.Logging = stdlog.New(buffer, "", 0)
 
-	res.Ingress.PortRules, err = rule2.resolveIngressPolicy(td.testPolicyContext, &ctx, &ingressState, NewL4PolicyMap(), nil, nil)
+	res.Ingress.PortRules, err = rule2.resolveIngressPolicy(td.testPolicyContext, &ctx, &ingressState, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res.Ingress)
 
 	t.Log(buffer)
 
-	res.Egress.PortRules, err = rule2.resolveEgressPolicy(td.testPolicyContext, fromBar, &egressState, NewL4PolicyMap(), nil, nil)
+	res.Egress.PortRules, err = rule2.resolveEgressPolicy(td.testPolicyContext, fromBar, &egressState, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res.Egress)
 
@@ -260,11 +260,11 @@ func TestL4Policy(t *testing.T) {
 	ingressState = traceState{}
 	egressState = traceState{}
 
-	res1, err = rule2.resolveIngressPolicy(td.testPolicyContext, toFoo, &ingressState, NewL4PolicyMap(), nil, nil)
+	res1, err = rule2.resolveIngressPolicy(td.testPolicyContext, toFoo, &ingressState, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res1)
 
-	res2, err = rule2.resolveEgressPolicy(td.testPolicyContext, fromFoo, &egressState, NewL4PolicyMap(), nil, nil)
+	res2, err = rule2.resolveEgressPolicy(td.testPolicyContext, fromFoo, &egressState, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res2)
 
@@ -322,7 +322,7 @@ func TestMergeL4PolicyIngress(t *testing.T) {
 	}})
 
 	state := traceState{}
-	res, err := rule1.resolveIngressPolicy(td.testPolicyContext, toBar, &state, NewL4PolicyMap(), nil, nil)
+	res, err := rule1.resolveIngressPolicy(td.testPolicyContext, toBar, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Equal(t, expected, res)
@@ -385,7 +385,7 @@ func TestMergeL4PolicyEgress(t *testing.T) {
 	}})
 
 	state := traceState{}
-	res, err := rule1.resolveEgressPolicy(td.testPolicyContext, fromBar, &state, NewL4PolicyMap(), nil, nil)
+	res, err := rule1.resolveEgressPolicy(td.testPolicyContext, fromBar, &state, NewL4PolicyMap())
 
 	t.Log(buffer)
 
@@ -477,7 +477,7 @@ func TestMergeL7PolicyIngress(t *testing.T) {
 	}})
 
 	state := traceState{}
-	res, err := rule1.resolveIngressPolicy(td.testPolicyContext, toBar, &state, NewL4PolicyMap(), nil, nil)
+	res, err := rule1.resolveIngressPolicy(td.testPolicyContext, toBar, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.EqualValues(t, expected, res)
@@ -487,7 +487,7 @@ func TestMergeL7PolicyIngress(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	res, err = rule1.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = rule1.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)
@@ -553,7 +553,7 @@ func TestMergeL7PolicyIngress(t *testing.T) {
 	}})
 
 	state = traceState{}
-	res, err = rule2.resolveIngressPolicy(td.testPolicyContext, toBar, &state, NewL4PolicyMap(), nil, nil)
+	res, err = rule2.resolveIngressPolicy(td.testPolicyContext, toBar, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.EqualValues(t, expected, res)
@@ -563,19 +563,19 @@ func TestMergeL7PolicyIngress(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	res, err = rule2.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = rule2.resolveIngressPolicy(td.testPolicyContext, toFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)
 	require.Equal(t, 0, state.matchedRules)
 
 	// Resolve rule1's policy, then try to add rule2.
-	res, err = rule1.resolveIngressPolicy(td.testPolicyContext, toBar, &state, NewL4PolicyMap(), nil, nil)
+	res, err = rule1.resolveIngressPolicy(td.testPolicyContext, toBar, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
 	state = traceState{}
-	_, err = rule2.resolveIngressPolicy(td.testPolicyContext, toBar, &state, res, nil, nil)
+	_, err = rule2.resolveIngressPolicy(td.testPolicyContext, toBar, &state, res)
 
 	require.Error(t, err)
 	res.Detach(td.sc)
@@ -650,7 +650,7 @@ func TestMergeL7PolicyIngress(t *testing.T) {
 	}})
 
 	state = traceState{}
-	res, err = rule3.resolveIngressPolicy(td.testPolicyContext, toBar, &state, NewL4PolicyMap(), nil, nil)
+	res, err = rule3.resolveIngressPolicy(td.testPolicyContext, toBar, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.EqualValues(t, expected, res)
@@ -738,7 +738,7 @@ func TestMergeL7PolicyEgress(t *testing.T) {
 	}})
 
 	state := traceState{}
-	res, err := rule1.resolveEgressPolicy(td.testPolicyContext, fromBar, &state, NewL4PolicyMap(), nil, nil)
+	res, err := rule1.resolveEgressPolicy(td.testPolicyContext, fromBar, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.EqualValues(t, expected, res)
@@ -748,7 +748,7 @@ func TestMergeL7PolicyEgress(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	res, err = rule1.resolveEgressPolicy(td.testPolicyContext, fromFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = rule1.resolveEgressPolicy(td.testPolicyContext, fromFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)
@@ -823,7 +823,7 @@ func TestMergeL7PolicyEgress(t *testing.T) {
 	}})
 
 	state = traceState{}
-	res, err = rule2.resolveEgressPolicy(td.testPolicyContext, fromBar, &state, NewL4PolicyMap(), nil, nil)
+	res, err = rule2.resolveEgressPolicy(td.testPolicyContext, fromBar, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.EqualValues(t, expected, res)
@@ -833,14 +833,14 @@ func TestMergeL7PolicyEgress(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	res, err = rule2.resolveEgressPolicy(td.testPolicyContext, fromFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = rule2.resolveEgressPolicy(td.testPolicyContext, fromFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)
 	require.Equal(t, 0, state.matchedRules)
 
 	// Resolve rule1's policy, then try to add rule2.
-	res, err = rule1.resolveEgressPolicy(td.testPolicyContext, fromBar, &state, NewL4PolicyMap(), nil, nil)
+	res, err = rule1.resolveEgressPolicy(td.testPolicyContext, fromBar, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	res.Detach(td.sc)
@@ -911,7 +911,7 @@ func TestMergeL7PolicyEgress(t *testing.T) {
 	}})
 
 	state = traceState{}
-	res, err = rule3.resolveEgressPolicy(td.testPolicyContext, fromBar, &state, NewL4PolicyMap(), nil, nil)
+	res, err = rule3.resolveEgressPolicy(td.testPolicyContext, fromBar, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.EqualValues(t, expected, res)
@@ -1138,12 +1138,12 @@ func TestICMPPolicy(t *testing.T) {
 	egressState := traceState{}
 	res := NewL4Policy(0)
 	res.Ingress.PortRules, err =
-		rule1.resolveIngressPolicy(td.testPolicyContext, toBar, &ingressState, NewL4PolicyMap(), nil, nil)
+		rule1.resolveIngressPolicy(td.testPolicyContext, toBar, &ingressState, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res.Ingress)
 
 	res.Egress.PortRules, err =
-		rule1.resolveEgressPolicy(td.testPolicyContext, fromBar, &egressState, NewL4PolicyMap(), nil, nil)
+		rule1.resolveEgressPolicy(td.testPolicyContext, fromBar, &egressState, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res.Egress)
 
@@ -1204,7 +1204,7 @@ func TestICMPPolicy(t *testing.T) {
 	ingressState = traceState{}
 	res = NewL4Policy(0)
 	res.Ingress.PortRules, err =
-		rule2.resolveIngressPolicy(td.testPolicyContext, toBar, &ingressState, NewL4PolicyMap(), nil, nil)
+		rule2.resolveIngressPolicy(td.testPolicyContext, toBar, &ingressState, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res.Ingress)
 
@@ -1249,7 +1249,7 @@ func TestICMPPolicy(t *testing.T) {
 	ingressState = traceState{}
 	res = NewL4Policy(0)
 	res.Ingress.PortRules, err =
-		rule3.resolveIngressPolicy(td.testPolicyContext, toBar, &ingressState, NewL4PolicyMap(), nil, nil)
+		rule3.resolveIngressPolicy(td.testPolicyContext, toBar, &ingressState, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res.Ingress)
 
@@ -1447,9 +1447,9 @@ func TestL3RuleLabels(t *testing.T) {
 
 			rule := &rule{Rule: apiRule}
 
-			_, err = rule.resolveIngressPolicy(td.testPolicyContext, toBar, &traceState{}, finalPolicy.Ingress.PortRules, nil, nil)
+			_, err = rule.resolveIngressPolicy(td.testPolicyContext, toBar, &traceState{}, finalPolicy.Ingress.PortRules)
 			require.NoError(t, err)
-			_, err = rule.resolveEgressPolicy(td.testPolicyContext, fromBar, &traceState{}, finalPolicy.Egress.PortRules, nil, nil)
+			_, err = rule.resolveEgressPolicy(td.testPolicyContext, fromBar, &traceState{}, finalPolicy.Egress.PortRules)
 			require.NoError(t, err)
 		}
 		// For debugging the test:
@@ -1583,8 +1583,8 @@ func TestL4RuleLabels(t *testing.T) {
 
 			rule := &rule{Rule: apiRule}
 
-			rule.resolveIngressPolicy(td.testPolicyContext, toBar, &traceState{}, finalPolicy.Ingress.PortRules, nil, nil)
-			rule.resolveEgressPolicy(td.testPolicyContext, fromBar, &traceState{}, finalPolicy.Egress.PortRules, nil, nil)
+			rule.resolveIngressPolicy(td.testPolicyContext, toBar, &traceState{}, finalPolicy.Ingress.PortRules)
+			rule.resolveEgressPolicy(td.testPolicyContext, fromBar, &traceState{}, finalPolicy.Egress.PortRules)
 		}
 
 		require.Equal(t, len(test.expectedIngressLabels), finalPolicy.Ingress.PortRules.Len(), test.description)
@@ -2792,7 +2792,7 @@ func TestMergeL7PolicyEgressWithMultipleSelectors(t *testing.T) {
 	}})
 
 	state := traceState{}
-	res, err := rule1.resolveEgressPolicy(td.testPolicyContext, fromBar, &state, NewL4PolicyMap(), nil, nil)
+	res, err := rule1.resolveEgressPolicy(td.testPolicyContext, fromBar, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.EqualValues(t, expected, res)
@@ -2802,7 +2802,7 @@ func TestMergeL7PolicyEgressWithMultipleSelectors(t *testing.T) {
 	expected.Detach(td.sc)
 
 	state = traceState{}
-	res, err = rule1.resolveEgressPolicy(td.testPolicyContext, fromFoo, &state, NewL4PolicyMap(), nil, nil)
+	res, err = rule1.resolveEgressPolicy(td.testPolicyContext, fromFoo, &state, NewL4PolicyMap())
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 0, state.selectedRules)


### PR DESCRIPTION
This commit changes how we calculate requirement
constraints for ingress and egress rules. Previously,
we calculated requirement constraints before all
rules were merged, but neither the docs nor common
sense support that understanding. A requirements
constraint exists on the api level of a single
ingress or egress rule that selects endpoints, having
the requirements constraints "bubble" up as a constraint
to all other ingress or egress rules violates the basic
intuition of where the API field is.

This commit calculates the requirements constraints
only for the ingress or egress rule it is a part of
on the API level. Many integration tests assumed
this "bubbling" up of the requirements constraint to work, 
and some did not. The tests have been refactored to test for
requirement constraint selection to "operate" only on
its own ingress/egress rule.

Fixes: #34390
Fixes: #36431

```release-note
policy: Fixed a bug in which `toRequires` or `fromRequires` field of an ingress or egress rule could overly constrain the selection of unrelated ingress or egress rules.
```
