### PR TITLE
images: Add Hubble CLI image

### DIFF
--- a/.github/workflows/build-go-caches.yaml
+++ b/.github/workflows/build-go-caches.yaml
@@ -48,6 +48,9 @@ jobs:
           - name: operator-generic
             make-target: build-container-operator-generic
 
+          - name: hubble
+            make-target: -C hubble
+
           - name: hubble-relay
             make-target: build-container-hubble-relay
 

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -54,6 +54,10 @@ jobs:
             dockerfile: ./images/operator/Dockerfile
             platforms: linux/amd64,linux/arm64
 
+          - name: hubble
+            dockerfile: ./images/hubble/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
           - name: hubble-relay
             dockerfile: ./images/hubble-relay/Dockerfile
             platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -39,6 +39,9 @@ jobs:
           - name: operator-generic
             dockerfile: ./images/operator/Dockerfile
 
+          - name: hubble
+            dockerfile: ./images/hubble/Dockerfile
+
           - name: hubble-relay
             dockerfile: ./images/hubble-relay/Dockerfile
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -439,6 +439,7 @@ Makefile* @cilium/build
 /images/builder/install-protoc.sh @cilium/sig-hubble-api
 /images/builder/install-protoplugins.sh @cilium/sig-hubble-api
 /images/builder/update-cilium-builder-image.sh @cilium/github-sec
+/images/hubble @cilium/sig-hubble
 /images/hubble-relay @cilium/sig-hubble
 /images/runtime/update-cilium-runtime-image.sh @cilium/github-sec
 /install/kubernetes/ @cilium/sig-k8s @cilium/helm

--- a/images/Makefile
+++ b/images/Makefile
@@ -48,6 +48,9 @@ cilium-image: .buildx_builder
 operator-image: .buildx_builder
 	ROOT_CONTEXT=true scripts/build-image.sh operator-dev images/operator $(PLATFORMS) $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
 
+hubble-image: .buildx_builder
+	ROOT_CONTEXT=true scripts/build-image.sh hubble-dev images/hubble $(PLATFORMS) $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
+
 hubble-relay-image: .buildx_builder
 	ROOT_CONTEXT=true scripts/build-image.sh hubble-relay-dev images/hubble-relay $(PLATFORMS) $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
 

--- a/images/README.md
+++ b/images/README.md
@@ -38,6 +38,11 @@ For other operators such as: aws, aks, generic, a copy of the same Dockerfile is
 used on all of them. Ideally we will re-use the same Dockerfile to build all the
 different operators.
 
+### [`hubble`](hubble/Dockerfile)
+
+This image includes only `hubble` CLI binary (plus CA certificates), no other
+binaries or libraries are included.
+
 ### [`hubble-relay`](hubble-relay/Dockerfile)
 
 This image includes only `hubble-relay` binary (plus CA certificates), no other

--- a/images/hubble/Dockerfile
+++ b/images/hubble/Dockerfile
@@ -1,0 +1,53 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+# distroless images are signed by cosign. You should verify the image with the following public key:
+# $ cat cosign.pub
+# -----BEGIN PUBLIC KEY-----
+# MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWZzVzkb8A+DbgDpaJId/bOmV8n7Q
+# OqxYbK0Iro6GzSmOzxkn+N2AKawLyXi84WSwJQBK//psATakCgAQKkNTAA==
+# -----END PUBLIC KEY-----
+# $ cosign verify --key cosign.pub $BASE_IMAGE
+# The key may be found at the following address:
+# https://raw.githubusercontent.com/GoogleContainerTools/distroless/main/cosign.pub
+ARG BASE_IMAGE=gcr.io/distroless/static-debian11:nonroot@sha256:63ebe035fbdd056ed682e6a87b286d07d3f05f12cb46f26b2b44fc10fc4a59ed
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:ecb349059c88dc4ae4d0e63e3fabd161d1f6d277@sha256:9037b37e6ea6f9d1b009167f700c07208e2977a8580503a8aa7184579ca010cc
+
+# BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
+# Represents the plataform where the build is happening, do not mix with
+# TARGETARCH
+FROM --platform=${BUILDPLATFORM} ${CILIUM_BUILDER_IMAGE} AS builder
+
+# TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETOS
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETARCH
+# MODIFIERS are extra arguments to be passed to make at build time.
+ARG MODIFIERS
+
+WORKDIR /go/src/github.com/cilium/cilium
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
+    --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/go/pkg \
+    make GOARCH=${TARGETARCH} TARGET_DIR=/out/${TARGETOS}/${TARGETARCH} $(echo $MODIFIERS | tr -d '"') \
+    -C hubble hubble
+
+WORKDIR /go/src/github.com/cilium/cilium
+# licenses-all is a "script" that executes "go run" so its ARCH should be set
+# to the same ARCH specified in the base image of this Docker stage (BUILDARCH)
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
+    --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/go/pkg \
+    make GOARCH=${BUILDARCH} licenses-all && mv LICENSE.all /out/${TARGETOS}/${TARGETARCH}
+
+FROM ${BASE_IMAGE} AS release
+# TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETOS
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETARCH
+LABEL maintainer="maintainer@cilium.io"
+COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/hubble /usr/bin/hubble
+COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all
+# use uid:gid for the nonroot user for compatibility with runAsNonRoot
+USER 65532:65532
+ENTRYPOINT ["/usr/bin/hubble"]


### PR DESCRIPTION
Build and push Hubble CLI image directly from cilium/cilium repo instead of vendoring cilium/cilium repo and building it from cilium/hubble repo. This is a part of [CFP-31893] phase 2.

[CFP-31893]: https://github.com/cilium/design-cfps/blob/main/cilium/CFP-31893-move-hubble-into-cilium.md
