### PR TITLE
bgpv2: Do not fail if PeerAddress is not configured for a peer

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/neighbor.go
+++ b/pkg/bgpv1/manager/reconcilerv2/neighbor.go
@@ -153,7 +153,8 @@ func (r *NeighborReconciler) Reconcile(ctx context.Context, p ReconcileParams) e
 		}
 
 		if n.PeerAddress == nil {
-			return fmt.Errorf("peer %s does not have a PeerAddress", n.Name)
+			l.WithField(types.PeerLogField, n.Name).Debug("Peer does not have PeerAddress configured, skipping")
+			continue
 		}
 
 		var (
@@ -344,21 +345,24 @@ func (r *NeighborReconciler) fetchSecret(name string) (map[string][]byte, bool, 
 	return result, true, nil
 }
 
-func GetPeerAddressFromConfig(conf *v2alpha1.CiliumBGPNodeInstance, peerName string) (netip.Addr, error) {
+// GetPeerAddressFromConfig returns peering address for the given peer from the provided BGPNodeInstance.
+// If no error is returned and "exists" is false, it means that PeerAddress is not present in peer configuration.
+func GetPeerAddressFromConfig(conf *v2alpha1.CiliumBGPNodeInstance, peerName string) (addr netip.Addr, exists bool, err error) {
 	if conf == nil {
-		return netip.Addr{}, fmt.Errorf("passed instance is nil")
+		return netip.Addr{}, false, fmt.Errorf("passed instance is nil")
 	}
 
 	for _, peer := range conf.Peers {
 		if peer.Name == peerName {
 			if peer.PeerAddress != nil {
-				return netip.ParseAddr(*peer.PeerAddress)
+				addr, err = netip.ParseAddr(*peer.PeerAddress)
+				return addr, true, err
 			} else {
-				return netip.Addr{}, fmt.Errorf("peer %s does not have a PeerAddress", peerName)
+				return netip.Addr{}, false, nil // PeerAddress not present in peer configuration
 			}
 		}
 	}
-	return netip.Addr{}, fmt.Errorf("peer %s not found in instance %s", peerName, conf.Name)
+	return netip.Addr{}, false, fmt.Errorf("peer %s not found in instance %s", peerName, conf.Name)
 }
 
 func (r *NeighborReconciler) neighborID(n *v2alpha1.CiliumBGPNodePeer) string {

--- a/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
@@ -202,9 +202,12 @@ func (r *PodCIDRReconciler) getDesiredRoutePolicies(p ReconcileParams, desiredPe
 	desiredPolicies := make(RoutePolicyMap)
 
 	for peer, afAdverts := range desiredPeerAdverts {
-		peerAddr, err := GetPeerAddressFromConfig(p.DesiredConfig, peer)
+		peerAddr, peerAddrExists, err := GetPeerAddressFromConfig(p.DesiredConfig, peer)
 		if err != nil {
 			return nil, err
+		}
+		if !peerAddrExists {
+			return nil, nil
 		}
 
 		for family, adverts := range afAdverts {

--- a/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_ip_pool.go
@@ -351,9 +351,12 @@ func (r *PodIPPoolReconciler) getDesiredAFPaths(pool *v2alpha1.CiliumPodIPPool, 
 
 func (r *PodIPPoolReconciler) getPodIPPoolPolicy(p ReconcileParams, peer string, family types.Family, pool *v2alpha1.CiliumPodIPPool, advert v2alpha1.BGPAdvertisement, lp map[string][]netip.Prefix) (*types.RoutePolicy, error) {
 	// get the peer address
-	peerAddr, err := GetPeerAddressFromConfig(p.DesiredConfig, peer)
+	peerAddr, peerAddrExists, err := GetPeerAddressFromConfig(p.DesiredConfig, peer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get peer address: %w", err)
+	}
+	if !peerAddrExists {
+		return nil, nil
 	}
 
 	// check if the pool selector matches the advertisement

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -662,9 +662,12 @@ func (r *ServiceReconciler) getLoadBalancerIPRoutePolicy(p ReconcileParams, peer
 	}
 
 	// get the peer address
-	peerAddr, err := GetPeerAddressFromConfig(p.DesiredConfig, peer)
+	peerAddr, peerAddrExists, err := GetPeerAddressFromConfig(p.DesiredConfig, peer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get peer address: %w", err)
+	}
+	if !peerAddrExists {
+		return nil, nil
 	}
 
 	valid, err := checkServiceAdvertisement(advert, v2alpha1.BGPLoadBalancerIPAddr)
@@ -706,9 +709,12 @@ func (r *ServiceReconciler) getLoadBalancerIPRoutePolicy(p ReconcileParams, peer
 
 func (r *ServiceReconciler) getExternalIPRoutePolicy(p ReconcileParams, peer string, family types.Family, svc *slim_corev1.Service, advert v2alpha1.BGPAdvertisement, ls sets.Set[resource.Key]) (*types.RoutePolicy, error) {
 	// get the peer address
-	peerAddr, err := GetPeerAddressFromConfig(p.DesiredConfig, peer)
+	peerAddr, peerAddrExists, err := GetPeerAddressFromConfig(p.DesiredConfig, peer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get peer address: %w", err)
+	}
+	if !peerAddrExists {
+		return nil, nil
 	}
 
 	valid, err := checkServiceAdvertisement(advert, v2alpha1.BGPExternalIPAddr)
@@ -760,9 +766,12 @@ func (r *ServiceReconciler) getExternalIPRoutePolicy(p ReconcileParams, peer str
 
 func (r *ServiceReconciler) getClusterIPRoutePolicy(p ReconcileParams, peer string, family types.Family, svc *slim_corev1.Service, advert v2alpha1.BGPAdvertisement, ls sets.Set[resource.Key]) (*types.RoutePolicy, error) {
 	// get the peer address
-	peerAddr, err := GetPeerAddressFromConfig(p.DesiredConfig, peer)
+	peerAddr, peerAddrExists, err := GetPeerAddressFromConfig(p.DesiredConfig, peer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get peer address: %w", err)
+	}
+	if !peerAddrExists {
+		return nil, nil
 	}
 
 	valid, err := checkServiceAdvertisement(advert, v2alpha1.BGPClusterIPAddr)


### PR DESCRIPTION
As `PeerAddress` is optional in `CiliumBGPPeer` struct used in `CiliumBGPClusterConfig` CRD, BGP Control Plane should not fail the reconciliation if it is not configured. Instead, it should skip processing of the peer until the `PeerAddress` is configured.
