### PR TITLE
cilium-cli: Add envoy log pattern in error check

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -64,19 +64,21 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string) check.Sc
 		failedCreategRPCClient, unableReallocateIngressIP, fqdnMaxIPPerHostname, failedGetMetricsAPI}
 	// The list is adopted from cilium/cilium/test/helper/utils.go
 	var errorMsgsWithExceptions = map[string][]logMatcher{
-		panicMessage:        nil,
-		deadLockHeader:      nil,
-		RunInitFailed:       nil,
-		emptyBPFInitArg:     nil,
-		RemovingMapMsg:      {stringMatcher("globals/cilium_policy")},
-		symbolSubstitution:  nil,
-		uninitializedRegen:  nil,
-		unstableStat:        nil,
-		missingIptablesWait: nil,
-		localIDRestoreFail:  nil,
-		routerIPMismatch:    nil,
-		emptyIPNodeIDAlloc:  nil,
-		"DATA RACE":         nil,
+		panicMessage:         nil,
+		deadLockHeader:       nil,
+		RunInitFailed:        nil,
+		emptyBPFInitArg:      nil,
+		RemovingMapMsg:       {stringMatcher("globals/cilium_policy")},
+		symbolSubstitution:   nil,
+		uninitializedRegen:   nil,
+		unstableStat:         nil,
+		missingIptablesWait:  nil,
+		localIDRestoreFail:   nil,
+		routerIPMismatch:     nil,
+		emptyIPNodeIDAlloc:   nil,
+		"DATA RACE":          nil,
+		envoyErrorMessage:    nil,
+		envoyCriticalMessage: nil,
 	}
 	if slices.Contains(checkLevels, defaults.LogLevelError) {
 		errorMsgsWithExceptions["level=error"] = errorLogExceptions
@@ -309,6 +311,10 @@ const (
 	unableReallocateIngressIP stringMatcher = "unable to re-allocate ingress IPv6"                                    // cf. https://github.com/cilium/cilium/issues/36072
 	fqdnMaxIPPerHostname      stringMatcher = "Raise tofqdns-endpoint-max-ip-per-hostname to mitigate this"           // cf. https://github.com/cilium/cilium/issues/36073
 	failedGetMetricsAPI       stringMatcher = "retrieve the complete list of server APIs: metrics.k8s.io/v1beta1"     // cf. https://github.com/cilium/cilium/issues/36085
+
+	// Logs messages that should not be in the cilium-envoy DS logs
+	envoyErrorMessage    = "[error]"
+	envoyCriticalMessage = "[critical]"
 )
 
 var (

--- a/cilium-cli/connectivity/tests/errors_test.go
+++ b/cilium-cli/connectivity/tests/errors_test.go
@@ -22,6 +22,9 @@ level=error msg="bar"
 level=error error="Failed to update lock:..."
 level=warning msg="baz"
 level=error msg="bar"
+[debug][admin] request complete: path: /server_info
+[error][envoy_bug] envoy bug failure: !Thread::MainThread::isMainOrTestThread()
+[critical][backtrace] Caught Aborted, suspect faulting address 0xd
 `
 
 	for _, tt := range []struct {
@@ -33,33 +36,42 @@ level=error msg="bar"
 		{
 			levels:  defaults.LogCheckLevels,
 			version: semver.MustParse("1.17.0"),
-			wantLen: 2,
+			wantLen: 4,
 			wantLogsCount: map[string]int{
 				`level=error msg="bar"`:   2,
 				`level=warning msg="baz"`: 1,
+				`[error][envoy_bug] envoy bug failure: !Thread::MainThread::isMainOrTestThread()`: 1,
+				`[critical][backtrace] Caught Aborted, suspect faulting address 0xd`:              1,
 			},
 		},
 		{
 			levels:  defaults.LogCheckLevels,
 			version: semver.MustParse("1.16.99"),
-			wantLen: 1,
+			wantLen: 3,
 			wantLogsCount: map[string]int{
 				`level=error msg="bar"`: 2,
+				`[error][envoy_bug] envoy bug failure: !Thread::MainThread::isMainOrTestThread()`: 1,
+				`[critical][backtrace] Caught Aborted, suspect faulting address 0xd`:              1,
 			},
 		},
 		{
 			levels:  []string{defaults.LogLevelError},
 			version: semver.MustParse("1.17.0"),
-			wantLen: 1,
+			wantLen: 3,
 			wantLogsCount: map[string]int{
 				`level=error msg="bar"`: 2,
+				`[error][envoy_bug] envoy bug failure: !Thread::MainThread::isMainOrTestThread()`: 1,
+				`[critical][backtrace] Caught Aborted, suspect faulting address 0xd`:              1,
 			},
 		},
 		{
-			levels:        []string{},
-			version:       semver.MustParse("1.17.0"),
-			wantLen:       0,
-			wantLogsCount: map[string]int{},
+			levels:  []string{},
+			version: semver.MustParse("1.17.0"),
+			wantLen: 2,
+			wantLogsCount: map[string]int{
+				`[error][envoy_bug] envoy bug failure: !Thread::MainThread::isMainOrTestThread()`: 1,
+				`[critical][backtrace] Caught Aborted, suspect faulting address 0xd`:              1,
+			},
 		},
 	} {
 		s := NoErrorsInLogs(tt.version, tt.levels).(*noErrorsInLogs)


### PR DESCRIPTION
Cilium Envoy might be running as Daemonset mode, which will have its own log format. Just a note that cilium-envoy logs are already retrieved as part of label selector app.kubernetes.io/part-of=cilium.

Relates: #36259
