### PR TITLE
Egress masquerade interfaces: type change reverted

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -99,7 +99,7 @@ cilium-agent [flags]
       --dynamic-lifecycle-config string                           List of dynamic lifecycle features and their configuration including the dependencies (default "[]")
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
-      --egress-masquerade-interfaces string                       Limit iptables-based egress masquerading to interfaces selector
+      --egress-masquerade-interfaces strings                      Limit iptables-based egress masquerading to interfaces selector
       --egress-multi-home-ip-rule-compat                          Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.
       --enable-active-connection-tracking                         Count open and active connections to services, grouped by zones defined in fixed-zone-mapping.
       --enable-auto-protect-node-port-range                       Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)

--- a/cilium-cli/install/helm.go
+++ b/cilium-cli/install/helm.go
@@ -66,10 +66,7 @@ func (k *K8sInstaller) getHelmValues() (map[string]interface{}, error) {
 			}
 			// AL2023 uses ens interfaces, but we default to eth interfaces for everything else for backwards compatibility,
 			// since the CLI was assuming eth interfaces before support for AL2023 was introduced
-			helmMapOpts["egressMasqueradeInterfaces"] = "eth+"
-			if k.params.AWS.AwsNodeImageFamily == AwsNodeImageFamilyAmazonLinux2023 {
-				helmMapOpts["egressMasqueradeInterfaces"] = "ens+"
-			}
+			helmMapOpts["egressMasqueradeInterfaces"] = "eth+ ens+"
 
 		case DatapathGKE:
 			helmMapOpts["ipam.mode"] = ipamKubernetes

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -333,7 +333,7 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.DisableCiliumEndpointCRDName, false, "Disable use of CiliumEndpoint CRD")
 	option.BindEnv(vp, option.DisableCiliumEndpointCRDName)
 
-	flags.String(option.MasqueradeInterfaces, "", "Limit iptables-based egress masquerading to interfaces selector")
+	flags.StringSlice(option.MasqueradeInterfaces, []string{}, "Limit iptables-based egress masquerading to interfaces selector")
 	option.BindEnv(vp, option.MasqueradeInterfaces)
 
 	flags.Bool(option.BPFSocketLBHostnsOnly, false, "Skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface. Socket LB is still used when in the host namespace. Required by service mesh (e.g., Istio, Linkerd).")

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2824,9 +2824,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableXDPPrefilter = vp.GetBool(EnableXDPPrefilter)
 	c.EnableTCX = vp.GetBool(EnableTCX)
 	c.DisableCiliumEndpointCRD = vp.GetBool(DisableCiliumEndpointCRDName)
-	if masqInfs := vp.GetString(MasqueradeInterfaces); masqInfs != "" {
-		c.MasqueradeInterfaces = strings.Split(masqInfs, ",")
-	}
+	c.MasqueradeInterfaces = vp.GetStringSlice(MasqueradeInterfaces)
 	c.BPFSocketLBHostnsOnly = vp.GetBool(BPFSocketLBHostnsOnly)
 	c.EnableSocketLB = vp.GetBool(EnableSocketLB)
 	c.EnableSocketLBTracing = vp.GetBool(EnableSocketLBTracing)


### PR DESCRIPTION
`MasqueradeInterfaces` type reverted to string slice [to not break existing users](https://github.com/cilium/cilium/pull/36103#issuecomment-2518674416).
Also, Viper can do this out of the box.

```release-note
Restore the original flag semantics for --egress-masquerade-interfaces to the same as v1.17.0-pre.2 or earlier
```