### PR TITLE
helm: avoid setting bpf-lb-sock-terminate-pod-connections

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -738,8 +738,6 @@ data:
 {{- end }}
 {{- if hasKey $socketLB "terminatePodConnections" }}
   bpf-lb-sock-terminate-pod-connections: {{ $socketLB.terminatePodConnections | quote }}
-{{- else if hasKey $socketLB "enabled" }}
-  bpf-lb-sock-terminate-pod-connections: {{ $socketLB.enabled | quote }}
 {{- end }}
 {{- if hasKey $socketLB "tracing" }}
   trace-sock: {{ $socketLB.tracing | quote }}


### PR DESCRIPTION
This PR avoids setting `bpf-lb-sock-terminate-pod-connections` to cilium-configmap unless specified.

The agent's [`bpf-lb-sock-terminate-pod-connections` flag defaults to true](https://github.com/cilium/cilium/blob/68ce93fa6bae920f647cbc30a3224303417949c0/daemon/cmd/daemon_main.go#L345), but the Helm chart currently adds false
to cilium-configmap by default (as socketLB.enabled=false is set in [values.yaml](https://github.com/cilium/cilium/blob/68ce93fa6bae920f647cbc30a3224303417949c0/install/kubernetes/cilium/values.yaml.tmpl#L1104)).

This behavior disables `bpf-lb-sock-terminate-pod-connections` when KPR is true, and the agent automatically enables socketLB. The change ensures `bpf-lb-sock-terminate-pod-connections` is not set unless explicitly specified.

Note:
The cilium-netns volume has been unconditionally mounted since commit https://github.com/cilium/cilium/commit/0c4d6d60e53a0f99e866071cea69fb546f7b545a.