### PR TITLE
dynamicconfig: Enables dynamic-config and drift-checker by default

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -114,8 +114,8 @@ cilium-agent [flags]
       --enable-cilium-endpoint-slice                              Enable the CiliumEndpointSlice watcher in place of the CiliumEndpoint watcher (beta)
       --enable-cilium-health-api-server-access strings            List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-custom-calls                                       Enable tail call hooks for custom eBPF programs
-      --enable-drift-checker                                      Enables support for config drift checker
-      --enable-dynamic-config                                     Enables support for dynamic agent config
+      --enable-drift-checker                                      Enables support for config drift checker (default true)
+      --enable-dynamic-config                                     Enables support for dynamic agent config (default true)
       --enable-dynamic-lifecycle-manager                          Enables support for dynamic lifecycle management
       --enable-encryption-strict-mode                             Enable encryption strict mode
       --enable-endpoint-health-checking                           Enable connectivity health checking between virtual endpoints (default true)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -39,8 +39,8 @@ cilium-agent hive [flags]
       --enable-bbr                                                Enable BBR for the bandwidth manager
       --enable-cilium-api-server-access strings                   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cilium-health-api-server-access strings            List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-drift-checker                                      Enables support for config drift checker
-      --enable-dynamic-config                                     Enables support for dynamic agent config
+      --enable-drift-checker                                      Enables support for config drift checker (default true)
+      --enable-dynamic-config                                     Enables support for dynamic agent config (default true)
       --enable-dynamic-lifecycle-manager                          Enables support for dynamic lifecycle management
       --enable-gateway-api                                        Enables Envoy secret sync for Gateway API related TLS secrets
       --enable-hubble                                             Enable hubble server (default true)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -45,8 +45,8 @@ cilium-agent hive dot-graph [flags]
       --enable-bbr                                                Enable BBR for the bandwidth manager
       --enable-cilium-api-server-access strings                   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cilium-health-api-server-access strings            List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-drift-checker                                      Enables support for config drift checker
-      --enable-dynamic-config                                     Enables support for dynamic agent config
+      --enable-drift-checker                                      Enables support for config drift checker (default true)
+      --enable-dynamic-config                                     Enables support for dynamic agent config (default true)
       --enable-dynamic-lifecycle-manager                          Enables support for dynamic lifecycle management
       --enable-gateway-api                                        Enables Envoy secret sync for Gateway API related TLS secrets
       --enable-hubble                                             Enable hubble server (default true)

--- a/pkg/driftchecker/cell.go
+++ b/pkg/driftchecker/cell.go
@@ -22,7 +22,7 @@ var Cell = cell.Module(
 )
 
 var defaultConfig = config{
-	EnableDriftChecker:      false,
+	EnableDriftChecker:      true,
 	IgnoreFlagsDriftChecker: []string{},
 }
 

--- a/pkg/driftchecker/checker.go
+++ b/pkg/driftchecker/checker.go
@@ -66,8 +66,12 @@ func (c checker) watchTableChanges(ctx context.Context) error {
 		tableKeys, channel := dynamicconfig.WatchAllKeys(c.db.ReadTxn(), c.dct)
 		// Wait for table initialization
 		if len(tableKeys) == 0 {
-			<-channel
-			continue
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-channel:
+				continue
+			}
 		}
 
 		deltas := c.computeDelta(tableKeys, c.cla)

--- a/pkg/dynamicconfig/cell.go
+++ b/pkg/dynamicconfig/cell.go
@@ -48,7 +48,7 @@ var Cell = cell.Module(
 )
 
 var defaultConfig = Config{
-	EnableDynamicConfig:    false,
+	EnableDynamicConfig:    true,
 	ConfigSources:          `[{"kind":"config-map","namespace":"kube-system","name":"cilium-config"}]`, // See pkg/option/resolver.go for the JSON definition
 	ConfigSourcesOverrides: `{"allowConfigKeys":null,"denyConfigKeys":null}`,
 }

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -469,6 +469,14 @@ func filterList(obj k8sRuntime.Object, restrictions k8sTesting.ListRestrictions)
 			}
 		}
 		obj.Items = items
+	case *corev1.ConfigMapList:
+		items := make([]corev1.ConfigMap, 0, len(obj.Items))
+		for i := range obj.Items {
+			if matchFieldSelector(&obj.Items[i], selector) {
+				items = append(items, obj.Items[i])
+			}
+		}
+		obj.Items = items
 	case *slim_corev1.NodeList:
 		items := make([]slim_corev1.Node, 0, len(obj.Items))
 		for i := range obj.Items {


### PR DESCRIPTION
tl;dr
The agent will monitor the designated ConfigMap and automatically synchronize any changes with its in-memory database, StateDB. Create a new cell in the Agent that watches the configured ConfigMap and creates a StateDB table to store the key-value pairs. The Agent cell will expose the read-only version of the StateDB table.
The monitored sources are configured by the initContainer at start-up, see https://github.com/cilium/cilium/blob/236bc2eac4c36cff60e0079f06d33816b3344ccc/pkg/option/resolver/resolver.go#L110

--
**Drift Checker** will compare the DynamicConfig Table content with the Agent config and compute the drift delta, logging the deltas and publish relevant metrics. This functionality allows the cluster administrators to easily track config drifts.
Publishes metrics counting the delta length and labeling by the checksum.

<details>

<summary> Grafana metrics</summary>
Agent start -> Drift appears -> delete all agent pods
<img width="1986" alt="image" src="https://github.com/user-attachments/assets/4ea2886a-5b62-4e1c-9a24-8828122b2784">

Start -> Drift -> kubectl rollout restart daemonset cilium -n kube-system

<img width="1984" alt="image" src="https://github.com/user-attachments/assets/b49a4d8f-52d5-4eda-8db9-bb86e4078a14">

</details>

Related: https://github.com/cilium/cilium/issues/27972, https://github.com/cilium/cilium/issues/34101

```release-note
Introduces cilium-config ConfigMap monitoring, allowing the agent to automatically synchronize changes in designated sources with its in-memory database. A new drift checker compares the ingested configurations with the agent's configuration, logging any differences and publishing metrics for easy tracking of configuration drifts. 
```
