### PR TITLE
[v1.16] cilium, service: Fix checkLBSrcRange propagation to LB map

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1475,7 +1475,6 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, isExtLocal, isIntLocal b
 
 	var (
 		toDeleteAffinity, toAddAffinity []lb.BackendID
-		checkLBSrcRange                 bool
 	)
 
 	// Update sessionAffinity
@@ -1509,7 +1508,8 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, isExtLocal, isIntLocal b
 	}
 
 	// Update LB source range check cidrs
-	if checkLBSrcRange = svc.checkLBSourceRange() || len(prevLoadBalancerSourceRanges) != 0; checkLBSrcRange {
+	checkLBSrcRange := svc.checkLBSourceRange()
+	if checkLBSrcRange || len(prevLoadBalancerSourceRanges) != 0 {
 		if err := s.lbmap.UpdateSourceRanges(uint16(svc.frontend.ID),
 			prevLoadBalancerSourceRanges, svc.loadBalancerSourceRanges,
 			v6FE); err != nil {


### PR DESCRIPTION
[ upstream commit 52951cb42871090bf10772b73b927b6923b86d68 ]

partial backport of https://github.com/cilium/cilium/pull/35512

see also https://github.com/cilium/cilium/issues/36473