### PR TITLE
.gitattributes: Syntax highlight bpftrace script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,4 @@ Documentation/_static/* -diff
 pkg/k8s/client/clientset/** linguist-generated
 pkg/k8s/client/informers/** linguist-generated
 pkg/k8s/client/listers/** linguist-generated
+*.bt linguist-language=D


### PR DESCRIPTION
These scripts are obviously not written in the D language, but Linguist doesn't support the bpftrace syntax [1]. The D language is the closest match and what the upstream bpftrace repository uses as well [2].

1 - https://github.com/github-linguist/linguist/blob/main/vendor/README.md
2 - https://github.com/bpftrace/bpftrace/blob/master/.gitattributes