### PR TITLE
cilium-cli/connectivity: fix IPv6 feature check for 2ndary node IPv6

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -1751,7 +1751,7 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 					}
 					ct.secondaryNetworkNodeIPv4[pod.Spec.NodeName] = strings.TrimSuffix(addr.String(), "\n")
 				}
-				if ct.Features[features.IPv4].Enabled {
+				if ct.Features[features.IPv6].Enabled {
 					cmd := []string{"/bin/sh", "-c", fmt.Sprintf("ip -family inet6 -oneline address show dev %s scope global | awk '{print $4}' | cut -d/ -f1", iface)}
 					addr, err := client.ExecInPod(ctx, pod.Namespace, pod.Name, "", cmd)
 					if err != nil {


### PR DESCRIPTION
Currently, the feature check is for IPv4 to be enabled, even though the secondary node IPv6 address is configured. This was likely copy-pasted from the section above which does the corresponding configuration of the secondary node IPv4 address. Fix the feature check accordingly to check for IPv6 to be enabled.

Fixes: #35125
Fixes: 849809274b8b ("connectivity: Add secondary network NodePort tests")