### PR TITLE
[dockerfile] Add debug symbol test + gdb support

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -70,6 +70,10 @@ RUN set -xe && \
          mv -v ${0}.debug ${D}/${filename}.debug' \
       {} \;
 
+# Check debug symbols are present
+RUN for f in $(find /tmp/debug -type f -name '*.debug') ; do readelf -S ${f} | grep -q \\.symtab || \
+    (echo Debug symbols are missing in ${f} - possibly due to incorrect build parameters && false); done
+
 COPY images/cilium/init-container.sh \
      plugins/cilium-cni/install-plugin.sh \
      plugins/cilium-cni/cni-uninstall.sh \

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -59,7 +59,6 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
 # Extract debug symbols to /tmp/debug and strip the binaries if NOSTRIP is not set.
 RUN set -xe && \
     export D=/tmp/debug/${TARGETOS}/${TARGETARCH} && \
-    mkdir -p $D && \
     cd /tmp/install/${TARGETOS}/${TARGETARCH} && \
     find . -type f \
       -executable \
@@ -67,7 +66,8 @@ RUN set -xe && \
         'filename=$(basename ${0}) && \
          objcopy --only-keep-debug ${0} ${0}.debug && \
          if ! echo "$MODIFIERS" | grep "NOSTRIP=1" ; then objcopy --strip-all ${0} && (cd $(dirname ${0}) && objcopy --add-gnu-debuglink=${filename}.debug ${filename}) ; fi && \
-         mv -v ${0}.debug ${D}/${filename}.debug' \
+         mkdir -p $(dirname ${D}/${0}) && \
+         mv -v ${0}.debug ${D}/${0}.debug' \
       {} \;
 
 # Check debug symbols are present
@@ -128,11 +128,10 @@ COPY --from=builder /tmp/install/${TARGETOS}/${TARGETARCH}/usr/bin/cilium-agent 
 COPY --from=builder /go/bin/dlv /usr/bin/dlv
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/bin/debug-wrapper /usr/bin/cilium-agent
 
-# Copy in the debug symbols in case the binaries were stripped
-COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH} /usr/lib/debug
+# Copy the debug symbols across in case the binaries were stripped
+COPY --from=builder /tmp/debug/${TARGETOS}/${TARGETARCH}/ /usr/lib/debug/
 
 # Ensure dlv finds the debug symbols. Due to CGO_ENABLED=0, we have no GNU build-id, so Delve's default search path
 # is insufficient.
 RUN mkdir -p ${HOME}/.config/dlv && \
-    echo 'debug-info-directories: ["/usr/lib/debug/.build-id","/usr/lib/debug"]' > ${HOME}/.config/dlv/config.yml && \
-    ln -s /usr/lib/debug/cilium-agent.debug /usr/lib/debug/cilium-agent-bin.debug
+    echo 'debug-info-directories: ["/usr/lib/debug/.build-id","/usr/lib/debug"]' > ${HOME}/.config/dlv/config.yml


### PR DESCRIPTION
Adds a test to check debug symbols are always generated and extracted.

Places debug symbols in a hierarchy under `/usr/lib/debug` that matches the
expected location embedded in the binaries. That way `gdb` can find the symbol
files and we can eliminate  a symlink that dlv will no longer require.

Without this change:

```
root@f62055ef662f:/home/cilium# gdb /usr/bin/cilium-agent-bin
…
Reading symbols from /usr/bin/cilium-agent-bin...
(No debugging symbols found in /usr/bin/cilium-agent-bin)
…
```

With this change:

```
root@0a1bedcaf638:/home/cilium# gdb /usr/bin/cilium-agent-bin
…
Reading symbols from /usr/bin/cilium-agent-bin...
Reading symbols from /usr/lib/debug//usr/bin/cilium-agent.debug...
warning: Missing auto-load script at offset 0 in section .debug_gdb_scripts
of file /usr/lib/debug/usr/bin/cilium-agent.debug.
Use `info auto-load python-scripts [REGEXP]' to list them.
…
```

And dlv still works: (no "symbols not found" error)

```
root@244fcaf145a1:/home/cilium# dlv exec /usr/bin/cilium-agent-bin
Type 'help' for list of commands.
(dlv)
```

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
Add test for generation and extraction of debug symbols.
Add debug symbol support for gdb.
```
