### PR TITLE
make: Update cilium-bugtool upon fast target

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -256,6 +256,11 @@ kind-image-fast-agent: kind-ready build-cli build-agent build-hubble-cli ## Buil
 			docker exec $${node_name} rm -f "${dst}/hubble"; \
 			docker cp "./hubble/hubble" $${node_name}:"${dst}"; \
 			docker exec $${node_name} chmod +x "${dst}/hubble"; \
+			\
+			docker exec $${node_name} rm -f "${dst}/cilium-bugtool"; \
+			docker cp "./bugtool/cilium-bugtool" $${node_name}:"${dst}"; \
+			docker exec $${node_name} chmod +x "${dst}/cilium-bugtool"; \
+
 		done; \
 		kubectl --context=kind-$${cluster_name} delete pods -n kube-system -l k8s-app=cilium --force; \
 	done

--- a/contrib/testing/kind-fast.yaml
+++ b/contrib/testing/kind-fast.yaml
@@ -15,6 +15,10 @@ extraVolumes:
   hostPath:
     path: /cilium-binaries/hubble
     type: File
+- name: cilium-bugtool-binary
+  hostPath:
+    path: /cilium-binaries/cilium-bugtool
+    type: File
 extraVolumeMounts:
 - name: cilium-dbg-binary
   mountPath: /usr/bin/cilium-dbg
@@ -26,6 +30,9 @@ extraVolumeMounts:
   mountPath: /var/lib/cilium/bpf
 - name: hubble-cli-binary
   mountPath: /usr/bin/hubble
+  readOnly: true
+- name: cilium-bugtool-binary
+  mountPath: /usr/bin/cilium-bugtool
   readOnly: true
 operator:
   extraVolumeMounts:


### PR DESCRIPTION
Otherwise, "make kind-image-fast-agent" will use an upstream cilium-bugtool.