### PR TITLE
Change client-egress-l7-tls tests to sequential because flaky

### DIFF
--- a/cilium-cli/connectivity/builder/client_egress_l7_tls_deny_without_headers.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_tls_deny_without_headers.go
@@ -14,7 +14,7 @@ type clientEgressL7TlsDenyWithoutHeaders struct{}
 func (t clientEgressL7TlsDenyWithoutHeaders) build(ct *check.ConnectivityTest, templates map[string]string) {
 	// Test L7 HTTPS interception using an egress policy on the clients.
 	// Fail to load site due to missing headers.
-	newTest("client-egress-l7-tls-deny-without-headers", ct).
+	newTest("seq-client-egress-l7-tls-deny-without-headers", ct).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretBackendK8s)).
 		WithCABundleSecret().

--- a/cilium-cli/connectivity/builder/client_egress_l7_tls_headers.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_tls_headers.go
@@ -19,7 +19,7 @@ func (t clientEgressL7TlsHeaders) build(ct *check.ConnectivityTest, templates ma
 }
 
 func clientEgressL7TlsHeadersTest(ct *check.ConnectivityTest, templates map[string]string, portRanges bool) {
-	testName := "client-egress-l7-tls-headers"
+	testName := "seq-client-egress-l7-tls-headers"
 	yamlFile := templates["clientEgressL7TLSPolicyYAML"]
 	if portRanges {
 		testName = "client-egress-l7-tls-headers-port-range"


### PR DESCRIPTION
Testing to see if I can reproduce flakes.
