### PR TITLE
Cleanup: make Endpoint.GetSecurityIdentity() lock-free

### DIFF
--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -117,13 +117,13 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 		endpoints[i] = &endpoint.Endpoint{
 			ID:   uint16(i),
 			IPv4: netip.MustParseAddr(fmt.Sprintf("10.96.%d.%d", i/256, i%256)),
-			SecurityIdentity: &identity.Identity{
-				ID: identity.NumericIdentity(i % int(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))),
-			},
 			DNSZombies: &fqdn.DNSZombieMappings{
 				Mutex: lock.Mutex{},
 			},
 		}
+		endpoints[i].SetSecurityIdentity(&identity.Identity{
+			ID: identity.NumericIdentity(i % int(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))),
+		})
 		ep := endpoints[i]
 		ep.UpdateLogger(nil)
 		ep.DNSHistory = fqdn.NewDNSCache(0)

--- a/pkg/auth/authmap_gc_test.go
+++ b/pkg/auth/authmap_gc_test.go
@@ -302,17 +302,15 @@ func Test_authMapGarbageCollector_cleanupEndpoints(t *testing.T) {
 	}
 	gc := newAuthMapGC(hivetest.Logger(t), authMap, nil, nil)
 	gc.endpointsCache = map[uint16]*endpoint.Endpoint{
-		1: {
-			SecurityIdentity: &identity.Identity{
-				ID: 2,
-			},
-		},
-		2: {
-			SecurityIdentity: &identity.Identity{
-				ID: 3,
-			},
-		},
+		1: {},
+		2: {},
 	}
+	gc.endpointsCache[1].SetSecurityIdentity(&identity.Identity{
+		ID: 2,
+	})
+	gc.endpointsCache[2].SetSecurityIdentity(&identity.Identity{
+		ID: 3,
+	})
 	gc.endpointsCacheSynced = true
 
 	assert.Len(t, authMap.entries, 3)
@@ -342,27 +340,23 @@ func Test_authMapGarbageCollector_cleanupEndpointsNoopCase(t *testing.T) {
 	}
 	gc := newAuthMapGC(hivetest.Logger(t), authMap, nil, nil)
 	gc.endpointsCache = map[uint16]*endpoint.Endpoint{
-		1: {
-			SecurityIdentity: &identity.Identity{
-				ID: 1,
-			},
-		},
-		2: {
-			SecurityIdentity: &identity.Identity{
-				ID: 2,
-			},
-		},
-		3: {
-			SecurityIdentity: &identity.Identity{
-				ID: 3,
-			},
-		},
-		4: {
-			SecurityIdentity: &identity.Identity{
-				ID: 3,
-			},
-		},
+		1: {},
+		2: {},
+		3: {},
+		4: {},
 	}
+	gc.endpointsCache[1].SetSecurityIdentity(&identity.Identity{
+		ID: 1,
+	})
+	gc.endpointsCache[2].SetSecurityIdentity(&identity.Identity{
+		ID: 2,
+	})
+	gc.endpointsCache[3].SetSecurityIdentity(&identity.Identity{
+		ID: 3,
+	})
+	gc.endpointsCache[4].SetSecurityIdentity(&identity.Identity{
+		ID: 3,
+	})
 	gc.endpointsCacheSynced = true
 
 	assert.Len(t, authMap.entries, 3)

--- a/pkg/auth/mutual_authhandler.go
+++ b/pkg/auth/mutual_authhandler.go
@@ -233,7 +233,8 @@ func (m *mutualAuthHandler) GetCertificateForIncomingConnection(info *tls.Client
 	localEPs := m.endpointManager.GetEndpoints()
 	matched := false
 	for _, ep := range localEPs {
-		if ep.SecurityIdentity != nil && ep.SecurityIdentity.ID == id {
+		securityIdentity, _ := ep.GetSecurityIdentity()
+		if securityIdentity != nil && securityIdentity.ID == id {
 			matched = true
 			break
 		}

--- a/pkg/auth/mutual_authhandler_test.go
+++ b/pkg/auth/mutual_authhandler_test.go
@@ -40,11 +40,11 @@ func (f *fakeEndpointGetter) GetEndpoints() []*endpoint.Endpoint {
 	ep := []*endpoint.Endpoint{}
 
 	for _, id := range []identity.NumericIdentity{id1000, id1001, idbad1} {
-		ep = append(ep, &endpoint.Endpoint{
-			SecurityIdentity: &identity.Identity{
-				ID: id,
-			},
+		e := &endpoint.Endpoint{}
+		e.SetSecurityIdentity(&identity.Identity{
+			ID: id,
 		})
+		ep = append(ep, e)
 	}
 
 	return ep

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -155,11 +155,12 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 
 	fw.WriteString("/*\n")
 	fw.WriteString(" * Labels:\n")
-	if e.SecurityIdentity != nil {
-		if len(e.SecurityIdentity.Labels) == 0 {
+	securityIdentity, _ := e.GetSecurityIdentity()
+	if securityIdentity != nil {
+		if len(securityIdentity.Labels) == 0 {
 			fmt.Fprintf(fw, " * - %s\n", "(no labels)")
 		} else {
-			for _, v := range e.SecurityIdentity.Labels {
+			for _, v := range securityIdentity.Labels {
 				fmt.Fprintf(fw, " * - %s\n", v.String())
 			}
 		}
@@ -648,7 +649,8 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 
 	// Apply pending policy map changes so that desired map is up-to-date before
 	// syncing the maps below.
-	if e.SecurityIdentity != nil {
+	securityIdentity, _ := e.GetSecurityIdentity()
+	if securityIdentity != nil {
 		_ = e.updateAndOverrideEndpointOptions(nil)
 
 		// Apply incremental changes to desiredPolicy and Configure the new network policy

--- a/pkg/endpoint/endpoint_status.go
+++ b/pkg/endpoint/endpoint_status.go
@@ -64,10 +64,11 @@ func (e *Endpoint) GetCiliumEndpointStatus() *cilium_v2.EndpointStatus {
 	e.mutex.RLock()
 	defer e.mutex.RUnlock()
 
+	securityIdentity, _ := e.GetSecurityIdentity()
 	status := &cilium_v2.EndpointStatus{
 		ID:                  int64(e.ID),
 		ExternalIdentifiers: e.getModelEndpointIdentitiersRLocked(),
-		Identity:            getEndpointIdentity(identitymodel.CreateModel(e.SecurityIdentity)),
+		Identity:            getEndpointIdentity(identitymodel.CreateModel(securityIdentity)),
 		Networking:          getEndpointNetworking(e.getModelNetworkingRLocked()),
 		State:               compressEndpointState(e.getModelCurrentStateRLocked()),
 		Encryption:          cilium_v2.EncryptionSpec{Key: int(node.GetEndpointEncryptKeyIndex())},

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -857,3 +857,32 @@ func TestMetadataResolver(t *testing.T) {
 		}
 	}
 }
+
+func TestGetSecurityIdentity(t *testing.T) {
+	s := setupEndpointSuite(t)
+
+	t.Run("Endpoint with SecurityIdentity set", func(t *testing.T) {
+		e := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{},
+			testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 123, StateWaitingForIdentity)
+		newIdentity := &identity.Identity{
+			ID:     1001,
+			Labels: labels.NewLabelsFromSortedList("k8s:foo=bar;k8s:qux=fred;"),
+		}
+
+		e.SetSecurityIdentity(newIdentity)
+
+		secIdentity, err := e.GetSecurityIdentity()
+		require.NoError(t, err)
+		require.Equal(t, newIdentity, secIdentity)
+	})
+
+	t.Run("Endpoint with SecurityIdentity nil", func(t *testing.T) {
+		e := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{},
+			testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 123, StateWaitingForIdentity)
+		e.SetSecurityIdentity(nil)
+
+		secIdentity, err := e.GetSecurityIdentity()
+		require.NoError(t, err)
+		require.Nil(t, secIdentity)
+	})
+}

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -110,8 +110,9 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 		logfields.CEPName:                e.GetK8sNamespaceAndCEPName(),
 	}
 
-	if e.SecurityIdentity != nil {
-		f[logfields.Identity] = e.SecurityIdentity.ID.StringID()
+	securityIdentity, _ := e.GetSecurityIdentity()
+	if securityIdentity != nil {
+		f[logfields.Identity] = securityIdentity.ID.StringID()
 	}
 
 	// Inherit properties from default logger.
@@ -179,8 +180,9 @@ func (e *Endpoint) updatePolicyLogger(fields map[string]interface{}) {
 			logfields.K8sPodName:             e.GetK8sNamespaceAndPodName(),
 		}
 
-		if e.SecurityIdentity != nil {
-			f[logfields.Identity] = e.SecurityIdentity.ID
+		securityIdentity, _ := e.GetSecurityIdentity()
+		if securityIdentity != nil {
+			f[logfields.Identity] = securityIdentity.ID
 		}
 
 		policyLogger = policyLogger.WithFields(f)

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -67,9 +67,9 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 	podID := addIdentity("pod")
 
 	ep := Endpoint{
-		SecurityIdentity: podID,
-		policyGetter:     &mockPolicyGetter{repo},
+		policyGetter: &mockPolicyGetter{repo},
 	}
+	ep.SetSecurityIdentity(podID)
 	ep.UpdateLogger(nil)
 
 	podSelectLabel := labels.ParseSelectLabel("pod")

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
@@ -322,8 +323,9 @@ func (e *Endpoint) restoreIdentity(regenerator *Regenerator) error {
 
 	e.setState(StateRestoring, "Synchronizing endpoint labels with KVStore")
 
-	if e.SecurityIdentity != nil {
-		if oldSecID := e.SecurityIdentity.ID; id.ID != oldSecID {
+	securityIdentity, _ := e.GetSecurityIdentity()
+	if securityIdentity != nil {
+		if oldSecID := securityIdentity.ID; id.ID != oldSecID {
 			log.WithFields(logrus.Fields{
 				logfields.EndpointID:              e.ID,
 				logfields.IdentityLabels + ".old": oldSecID,
@@ -383,7 +385,7 @@ func (e *Endpoint) restoreIdentity(regenerator *Regenerator) error {
 // restoring an Endpoint after cilium-agent restarts.
 func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 
-	return &serializableEndpoint{
+	endpoint := serializableEndpoint{
 		ID:                       e.ID,
 		ContainerName:            e.GetContainerName(),
 		ContainerID:              e.GetContainerID(),
@@ -400,7 +402,6 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		IPv4:                     e.IPv4,
 		IPv4IPAMPool:             e.IPv4IPAMPool,
 		NodeMAC:                  e.nodeMAC,
-		SecurityIdentity:         e.SecurityIdentity,
 		Options:                  e.Options,
 		DNSRules:                 e.DNSRules,
 		DNSRulesV2:               e.DNSRulesV2,
@@ -414,6 +415,9 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		Properties:               e.properties,
 		NetnsCookie:              e.NetNsCookie,
 	}
+	securityIdentity, _ := e.GetSecurityIdentity()
+	endpoint.SecurityIdentity.Store(securityIdentity)
+	return &endpoint
 }
 
 // serializableEndpoint contains the fields from an Endpoint which are needed to be
@@ -485,7 +489,7 @@ type serializableEndpoint struct {
 
 	// SecurityIdentity is the security identity of this endpoint. This is computed from
 	// the endpoint's labels.
-	SecurityIdentity *identity.Identity `json:"SecLabel"`
+	SecurityIdentity atomic.Pointer[identity.Identity]
 
 	// Options determine the datapath configuration of the endpoint.
 	Options *option.IntOptions
@@ -575,7 +579,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.IPv4 = r.IPv4
 	ep.IPv4IPAMPool = r.IPv4IPAMPool
 	ep.nodeMAC = r.NodeMAC
-	ep.SecurityIdentity = r.SecurityIdentity
+	ep.SetSecurityIdentity(r.SecurityIdentity.Load())
 	ep.DNSRules = r.DNSRules
 	ep.DNSRulesV2 = r.DNSRulesV2
 	ep.DNSHistory = r.DNSHistory

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -68,7 +68,7 @@ func (s *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdentit
 	ep.IPv6 = netip.AddrFrom16([16]byte{0xbe, 0xef, 0xbe, 0xef, 0xbe, 0xef, 0xbe, 0xef, 0xaa, 0xaa, 0xaa, 0xaa, 0x00, 0x00, b[0], b[1]})
 	ep.ifIndex = 1
 	ep.nodeMAC = []byte{0x02, 0xff, 0xf2, 0x12, 0x0, 0x0}
-	ep.SecurityIdentity = identity
+	ep.SetSecurityIdentity(identity)
 	ep.OpLabels = labels.NewOpLabels()
 	ep.NetNsCookie = 1234
 	return ep

--- a/pkg/endpoint/test_utils.go
+++ b/pkg/endpoint/test_utils.go
@@ -22,7 +22,7 @@ func (e *Endpoint) WaitForIdentity(timeoutDuration time.Duration) *identity.Iden
 			return nil
 		case <-tick.C:
 			e.unconditionalRLock()
-			secID = e.SecurityIdentity
+			secID, _ = e.GetSecurityIdentity()
 			e.runlock()
 			if secID != nil {
 				return secID


### PR DESCRIPTION
Make Endpoint.GetSecurityIdentity() lock-free

Fixes: #35907 

```release-note
Cleanup: make Endpoint.GetSecurityIdentity() lock-free
```
