### PR TITLE
[v1.16] bpf: prefer skb->mark over skb->cb to transport metadata across interface boundary

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1638,6 +1638,13 @@ int cil_to_host(struct __ctx_buff *ctx)
 	__u32 src_id = 0;
 	__s8 ext_err = 0;
 
+	/* Prefer ctx->mark when it is set to one of the expected values.
+	 * Also see https://github.com/cilium/cilium/issues/36329.
+	 */
+	if (((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT) ||
+	    ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_TO_PROXY))
+		magic = ctx->mark;
+
 	if ((magic & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT) {
 		ctx->mark = magic; /* CB_ENCRYPT_MAGIC */
 		src_id = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1765,6 +1765,7 @@ int tail_ipv6_to_endpoint(struct __ctx_buff *ctx)
 	switch (ret) {
 	case POLICY_ACT_PROXY_REDIRECT:
 		ret = ctx_redirect_to_proxy_hairpin_ipv6(ctx, proxy_port);
+		ctx->mark = ctx_load_meta(ctx, CB_PROXY_MAGIC);
 		proxy_redirect = true;
 		break;
 	case CTX_ACT_OK:
@@ -2123,6 +2124,7 @@ int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 		}
 
 		ret = ctx_redirect_to_proxy_hairpin_ipv4(ctx, ip4, proxy_port);
+		ctx->mark = ctx_load_meta(ctx, CB_PROXY_MAGIC);
 		proxy_redirect = true;
 		break;
 	case CTX_ACT_OK:

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -10,6 +10,8 @@
 
 #define SKIP_POLICY_MAP 1
 
+#define IS_BPF_XDP 1
+
 /* Controls the inclusion of the CILIUM_CALL_HANDLE_ICMP6_NS section in the
  * bpf_lxc object file.
  */

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -128,8 +128,8 @@ set_ipsec_encrypt(struct __ctx_buff *ctx, __u8 spi, __u32 tunnel_endpoint,
 	set_identity_meta(ctx, seclabel);
 	if (use_meta)
 		set_encrypt_key_meta(ctx, spi, node_value->id);
-	else
-		set_encrypt_key_mark(ctx, spi, node_value->id);
+	set_encrypt_key_mark(ctx, spi, node_value->id);
+
 	return CTX_ACT_OK;
 }
 


### PR DESCRIPTION
Manual backport PR to add the fix for the nodeport path.

* [ ] #36484

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 36484
```