### PR TITLE
make: Fix kind-image-fast-agent

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -260,7 +260,6 @@ kind-image-fast-agent: kind-ready build-cli build-agent build-hubble-cli ## Buil
 			docker exec $${node_name} rm -f "${dst}/cilium-bugtool"; \
 			docker cp "./bugtool/cilium-bugtool" $${node_name}:"${dst}"; \
 			docker exec $${node_name} chmod +x "${dst}/cilium-bugtool"; \
-
 		done; \
 		kubectl --context=kind-$${cluster_name} delete pods -n kube-system -l k8s-app=cilium --force; \
 	done


### PR DESCRIPTION
Fixes: c275fbe2 ("make: Update cilium-bugtool upon fast target")
Reported-by: André Martins <andre@cilium.io>