### PR TITLE
Fix GetResources function in xds.Cache

### DIFF
--- a/pkg/envoy/xds/cache.go
+++ b/pkg/envoy/xds/cache.go
@@ -208,16 +208,19 @@ func (c *Cache) GetResources(typeURL string, lastVersion uint64, nodeIP string, 
 		Canary:  false,
 	}
 
-	// Return all resources.
+	// Return all resources of given typeURL.
 	// TODO: return nil if no changes since the last version?
 	if len(resourceNames) == 0 {
 		res.ResourceNames = make([]string, 0, len(c.resources))
 		res.Resources = make([]proto.Message, 0, len(c.resources))
-		cacheLog.Debugf("no resource names requested, returning all %d resources", len(c.resources))
 		for k, v := range c.resources {
+			if k.typeURL != typeURL {
+				continue
+			}
 			res.ResourceNames = append(res.ResourceNames, k.resourceName)
 			res.Resources = append(res.Resources, v.resource)
 		}
+		cacheLog.Debugf("no resource names requested, returning %d resources of type %s", len(res.Resources), typeURL)
 		return res, nil
 	}
 

--- a/pkg/envoy/xds/cache_test.go
+++ b/pkg/envoy/xds/cache_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xds
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetResource(t *testing.T) {
+	c := NewCache()
+	c.resources[cacheKey{typeURL: "a", resourceName: "a1"}] = cacheValue{}
+	c.resources[cacheKey{typeURL: "a", resourceName: "a2"}] = cacheValue{}
+	c.resources[cacheKey{typeURL: "b", resourceName: "a1"}] = cacheValue{}
+	c.resources[cacheKey{typeURL: "b", resourceName: "b2"}] = cacheValue{lastModifiedVersion: 1}
+
+	for _, tc := range []struct {
+		desc            string
+		typeURL         string
+		version         uint64
+		getNames        []string
+		wantNames       []string
+		wantNilResponse bool
+	}{
+		{
+			desc:      "return resource by name",
+			typeURL:   "a",
+			getNames:  []string{"a1"},
+			wantNames: []string{"a1"},
+		},
+		{
+			desc:      "return all resources for given url",
+			typeURL:   "a",
+			wantNames: []string{"a1", "a2"},
+		},
+		{
+			desc:      "no resources found for given url",
+			typeURL:   "c",
+			wantNames: []string{},
+		},
+		{
+			desc:      "no resources found for given name and url",
+			typeURL:   "b",
+			getNames:  []string{"c1"},
+			wantNames: []string{},
+		},
+		{
+			desc:            "resource has no updates",
+			typeURL:         "b",
+			version:         1,
+			getNames:        []string{"b2"},
+			wantNilResponse: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Ignore version and nodeID they does not impact GetResource logic.
+			// Ignore error since it always returns nil.
+			got, _ := c.GetResources(tc.typeURL, tc.version, "", tc.getNames)
+			gotNilResponse := got == nil
+			if gotNilResponse != tc.wantNilResponse {
+				t.Fatalf("Returned response mismatch want: gotNilResponse != tc.wantNilResponse  %v != %v", gotNilResponse, tc.wantNilResponse)
+			}
+			if got == nil {
+				return
+			}
+			slices.Sort(got.ResourceNames)
+			if diff := cmp.Diff(got.ResourceNames, tc.wantNames); diff != "" {
+				t.Fatalf("returned resources mismatch (-got/+want): %v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
xds cache has method GetResources takes urlType, and resourceNames as an input. 
When resourcesNames list is empty the function returns all resources in the cache 
ignoring input urlType. The function should return all resources with given urlType instead.

Fixes: #36553
