### PR TITLE
[ci] isolate wireguard n2n tests

### DIFF
--- a/cilium-cli/connectivity/builder/node_to_node_encryption.go
+++ b/cilium-cli/connectivity/builder/node_to_node_encryption.go
@@ -21,5 +21,5 @@ func (t nodeToNodeEncryption) build(ct *check.ConnectivityTest, _ map[string]str
 				features.RequireEnabled(features.EncryptionPod),
 				features.RequireEnabled(features.EncryptionNode),
 			),
-		)
+		).WithFeatureRequirements(features.RequireModeIsNot(features.EncryptionPod, "ipsec"))
 }

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -143,6 +143,9 @@ func (fs Set) MatchRequirements(reqs ...Requirement) (bool, string) {
 		if req.requiresMode && (req.mode != status.Mode) {
 			return false, fmt.Sprintf("requires Feature %s mode %s, got %s", req.Feature, req.mode, status.Mode)
 		}
+		if req.requireModeIsNot && (req.mode == status.Mode) {
+			return false, fmt.Sprintf("requires Feature %s mode %s to not equal %s, req.Feature", req.Feature, status.Mode, req.mode)
+		}
 	}
 
 	return true, ""
@@ -184,8 +187,9 @@ type Requirement struct {
 	requiresEnabled bool
 	enabled         bool
 
-	requiresMode bool
-	mode         string
+	requiresMode     bool
+	requireModeIsNot bool
+	mode             string
 }
 
 // RequireEnabled constructs a Requirement which expects the
@@ -215,6 +219,20 @@ func RequireMode(feature Feature, mode string) Requirement {
 		Feature:      feature,
 		requiresMode: true,
 		mode:         mode,
+	}
+}
+
+// RequiredModeIsNot constructs a Requirement which expects the Feature to not
+// be in the given mode
+//
+// When evaluating a set of requirements with MatchRequirements,
+// having a RequireMode requirement of the same feature and mode will cause
+// conflicting results.
+func RequireModeIsNot(feature Feature, mode string) Requirement {
+	return Requirement{
+		Feature:          feature,
+		requireModeIsNot: true,
+		mode:             mode,
 	}
 }
 

--- a/cilium-cli/utils/features/features_test.go
+++ b/cilium-cli/utils/features/features_test.go
@@ -56,6 +56,17 @@ func TestFeatureSetMatchRequirements(t *testing.T) {
 	if matches {
 		t.Errorf("features %v unexpectedly matched feature %v with mode %v", features, CNIChaining, cniMode)
 	}
+
+	matches, _ = features.MatchRequirements(RequireEnabled(CNIChaining), RequireModeIsNot(CNIChaining, "kubernetes"))
+	if !matches {
+		t.Errorf("expected features %v to match feature %v with mode different from kubernetes", features, CNIChaining)
+	}
+
+	matches, _ = features.MatchRequirements(RequireEnabled(CNIChaining), RequireModeIsNot(CNIChaining, "aws-cni"))
+	if matches {
+		t.Errorf("expected features %v to not match feature %v with mode different from aws-cni", features, CNIChaining)
+	}
+
 }
 
 func TestFeatureSet_extractFromVersionedConfigMap(t *testing.T) {


### PR DESCRIPTION
The node-to-node encryption tests do not provide any benefits for IPsec since IPsec does not support this. 
Currently, the node-to-node encryption tests run for IPsec. 

I did some digging and chatting with folks and its a mixed bag one whether this was intentional or not. 
As we begin to move to VinE traffic with IPsec it simplifies things to no longer run node-to-node for IPsec, reducing the configuration matrix necessary to perform the correct tests.

The node-to-node tests still run when no encryption mode is set at all. 
This acts as a sanity check to ensure the TCPDump filters correctly capture expected traffic. 

```release-note
Isolate node-to-node encryption tests to wireguard
```
