### PR TITLE
Update the default identity label in the example

### DIFF
--- a/Documentation/operations/performance/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/performance/scalability/identity-relevant-labels.rst
@@ -137,6 +137,7 @@ evaluating Cilium identities:
 - reserved:.*
 - io\.kubernetes\.pod\.namespace
 - io\.cilium\.k8s.namespace\.labels
+- io\.cilium\.k8s\.policy\.cluster
 - app\.kubernetes\.io
 
 Note that ``io.kubernetes.pod.namespace`` is already included in default


### PR DESCRIPTION
Update the default identity label in the example

PR #31178 added "io.cilium.k8s.policy.cluster" label to default ones but didn't update the doc

PR #35422 added the label in the doc but didn't update the example

Fixes: #31178

```release-note
docs: Add missing default identity label in the description of identity-relevant labels' example
```