### PR TITLE
[v1.14] Reject CNPs with CIDRGroupRef used in combination with ExceptCIDRs

### DIFF
--- a/pkg/k8s/watchers/cilium_cidr_group.go
+++ b/pkg/k8s/watchers/cilium_cidr_group.go
@@ -253,3 +253,47 @@ func translateSpec(spec *api.Rule, cidrsSets map[string][]api.CIDR) {
 		spec.Ingress[i].FromCIDRSet = append(oldRules, newRules...)
 	}
 }
+
+func validateCIDRRules(cnp *types.SlimCNP) error {
+	for _, spec := range append(cnp.Specs, cnp.Spec) {
+		if spec == nil {
+			continue
+		}
+		for _, ingress := range spec.Ingress {
+			for _, rule := range ingress.FromCIDRSet {
+				if err := validateCIDRRule(rule); err != nil {
+					return err
+				}
+			}
+		}
+		for _, ingress := range spec.IngressDeny {
+			for _, rule := range ingress.FromCIDRSet {
+				if err := validateCIDRRule(rule); err != nil {
+					return err
+				}
+			}
+		}
+		for _, ingress := range spec.Egress {
+			for _, rule := range ingress.ToCIDRSet {
+				if err := validateCIDRRule(rule); err != nil {
+					return err
+				}
+			}
+		}
+		for _, ingress := range spec.EgressDeny {
+			for _, rule := range ingress.ToCIDRSet {
+				if err := validateCIDRRule(rule); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateCIDRRule(rule api.CIDRRule) error {
+	if rule.CIDRGroupRef != "" && len(rule.ExceptCIDRs) > 0 {
+		return errors.New("ExceptCIDRs cannot be used in combination with CIDRGroupRef")
+	}
+	return nil
+}

--- a/pkg/k8s/watchers/cilium_cidr_group_test.go
+++ b/pkg/k8s/watchers/cilium_cidr_group_test.go
@@ -986,64 +986,6 @@ func TestCIDRGroupRefsTranslate(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "with CIDRGroupRef and ExceptCIDRs rules",
-			cnp: &types.SlimCNP{
-				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "cilium.io/v2",
-						Kind:       "CiliumNetworkPolicy",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-policy",
-						Namespace: "test-namespace",
-					},
-					Spec: &api.Rule{
-						Ingress: []api.IngressRule{
-							{
-								IngressCommonRule: api.IngressCommonRule{
-									FromCIDRSet: api.CIDRRuleSlice{
-										{
-											CIDRGroupRef: "cidr-group-1",
-											ExceptCIDRs:  []api.CIDR{"10.96.0.0/12", "10.112.0.0/12"},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			cidrsSets: map[string][]api.CIDR{
-				"cidr-group-1": {"10.0.0.0/8"},
-			},
-			expected: &types.SlimCNP{
-				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "cilium.io/v2",
-						Kind:       "CiliumNetworkPolicy",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-policy",
-						Namespace: "test-namespace",
-					},
-					Spec: &api.Rule{
-						Ingress: []api.IngressRule{
-							{
-								IngressCommonRule: api.IngressCommonRule{
-									FromCIDRSet: api.CIDRRuleSlice{
-										{
-											Cidr:        "10.0.0.0/8",
-											ExceptCIDRs: []api.CIDR{"10.96.0.0/12", "10.112.0.0/12"},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
 	}
 
 	for _, tc := range testCases {
@@ -1051,6 +993,327 @@ func TestCIDRGroupRefsTranslate(t *testing.T) {
 			got := translateCIDRGroupRefs(tc.cnp, tc.cidrsSets)
 			if !reflect.DeepEqual(got, tc.expected) {
 				t.Fatalf("expected translated cnp to be\n%v\n, got\n%v\n", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestValidateCIDRRules(t *testing.T) {
+	testCases := [...]struct {
+		name        string
+		cnp         *types.SlimCNP
+		shouldError bool
+	}{
+		{
+			name: "nil Spec and Specs",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{},
+			},
+			shouldError: false,
+		},
+		{
+			name: "Valid CIDR rules",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					Spec: &api.Rule{
+						Ingress: []api.IngressRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											Cidr:        api.CIDR("10.0.0.0/8"),
+											ExceptCIDRs: []api.CIDR{"10.96.0.0/12"},
+										},
+									},
+								},
+							},
+						},
+						IngressDeny: []api.IngressDenyRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											Cidr:        api.CIDR("10.0.0.0/8"),
+											ExceptCIDRs: []api.CIDR{"10.96.0.0/12"},
+										},
+									},
+								},
+							},
+						},
+						Egress: []api.EgressRule{
+							{
+								EgressCommonRule: api.EgressCommonRule{
+									ToCIDRSet: api.CIDRRuleSlice{
+										{
+											Cidr:        api.CIDR("10.0.0.0/8"),
+											ExceptCIDRs: []api.CIDR{"10.96.0.0/12"},
+										},
+									},
+								},
+							},
+						},
+						EgressDeny: []api.EgressDenyRule{
+							{
+								EgressCommonRule: api.EgressCommonRule{
+									ToCIDRSet: api.CIDRRuleSlice{
+										{
+											Cidr:        api.CIDR("10.0.0.0/8"),
+											ExceptCIDRs: []api.CIDR{"10.96.0.0/12"},
+										},
+									},
+								},
+							},
+						},
+					},
+					Specs: api.Rules{
+						&api.Rule{
+							Ingress: []api.IngressRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												Cidr:        api.CIDR("10.0.0.0/8"),
+												ExceptCIDRs: []api.CIDR{"10.96.0.0/12"},
+											},
+										},
+									},
+								},
+							},
+							IngressDeny: []api.IngressDenyRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												Cidr:        api.CIDR("10.0.0.0/8"),
+												ExceptCIDRs: []api.CIDR{"10.96.0.0/12"},
+											},
+										},
+									},
+								},
+							},
+							Egress: []api.EgressRule{
+								{
+									EgressCommonRule: api.EgressCommonRule{
+										ToCIDRSet: api.CIDRRuleSlice{
+											{
+												Cidr:        api.CIDR("10.0.0.0/8"),
+												ExceptCIDRs: []api.CIDR{"10.96.0.0/12"},
+											},
+										},
+									},
+								},
+							},
+							EgressDeny: []api.EgressDenyRule{
+								{
+									EgressCommonRule: api.EgressCommonRule{
+										ToCIDRSet: api.CIDRRuleSlice{
+											{
+												Cidr:        api.CIDR("10.0.0.0/8"),
+												ExceptCIDRs: []api.CIDR{"10.96.0.0/12"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldError: false,
+		},
+		{
+			name: "Invalid rule in Ingress Spec",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					Spec: &api.Rule{
+						Ingress: []api.IngressRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-test",
+											ExceptCIDRs:  []api.CIDR{"10.96.0.0/12"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldError: true,
+		},
+		{
+			name: "Invalid rule in Ingress Specs",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					Specs: api.Rules{
+						&api.Rule{
+							Ingress: []api.IngressRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-test",
+												ExceptCIDRs:  []api.CIDR{"10.96.0.0/12"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldError: true,
+		},
+		{
+			name: "Invalid rule in IngressDeny Spec",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					Spec: &api.Rule{
+						IngressDeny: []api.IngressDenyRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-test",
+											ExceptCIDRs:  []api.CIDR{"10.96.0.0/12"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldError: true,
+		},
+		{
+			name: "Invalid rule in IngressDeny Specs",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					Specs: api.Rules{
+						&api.Rule{
+							IngressDeny: []api.IngressDenyRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-test",
+												ExceptCIDRs:  []api.CIDR{"10.96.0.0/12"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldError: true,
+		},
+		{
+			name: "Invalid rule in Egress Spec",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					Spec: &api.Rule{
+						Egress: []api.EgressRule{
+							{
+								EgressCommonRule: api.EgressCommonRule{
+									ToCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-test",
+											ExceptCIDRs:  []api.CIDR{"10.96.0.0/12"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldError: true,
+		},
+		{
+			name: "Invalid rule in Egress Specs",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					Specs: api.Rules{
+						&api.Rule{
+							Egress: []api.EgressRule{
+								{
+									EgressCommonRule: api.EgressCommonRule{
+										ToCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-test",
+												ExceptCIDRs:  []api.CIDR{"10.96.0.0/12"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldError: true,
+		},
+		{
+			name: "Invalid rule in EgressDeny Spec",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					Spec: &api.Rule{
+						EgressDeny: []api.EgressDenyRule{
+							{
+								EgressCommonRule: api.EgressCommonRule{
+									ToCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-test",
+											ExceptCIDRs:  []api.CIDR{"10.96.0.0/12"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldError: true,
+		},
+		{
+			name: "Invalid rule in EgressDeny Specs",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					Specs: api.Rules{
+						&api.Rule{
+							EgressDeny: []api.EgressDenyRule{
+								{
+									EgressCommonRule: api.EgressCommonRule{
+										ToCIDRSet: api.CIDRRuleSlice{
+											{
+												CIDRGroupRef: "cidr-group-test",
+												ExceptCIDRs:  []api.CIDR{"10.96.0.0/12"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldError: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCIDRRules(tc.cnp)
+			if err != nil && !tc.shouldError {
+				t.Fatalf("unexpected error while checking CIDRRules in CNP: %s", err)
+			}
+			if err == nil && tc.shouldError {
+				t.Fatal("expected error while checking CIDRRules in CNP, got nil")
 			}
 		})
 	}

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -5,7 +5,6 @@ package watchers
 
 import (
 	"context"
-	"errors"
 	"sync/atomic"
 	"time"
 
@@ -395,27 +394,7 @@ func (k *K8sWatcher) deleteCiliumNetworkPolicyV2(cnp *types.SlimCNP, resourceID 
 func (k *K8sWatcher) updateCiliumNetworkPolicyV2(ciliumNPClient clientset.Interface,
 	oldRuleCpy, newRuleCpy *types.SlimCNP, initialRecvTime time.Time, resourceID ipcacheTypes.ResourceID) error {
 
-	_, err := oldRuleCpy.Parse()
-	if err != nil {
-		ns := oldRuleCpy.GetNamespace() // Disambiguates CNP & CCNP
-
-		// We want to ignore parsing errors for empty policies, otherwise the
-		// update to the new policy will be skipped.
-		switch {
-		case ns != "" && !errors.Is(err, cilium_v2.ErrEmptyCNP):
-			metrics.PolicyImportErrorsTotal.Inc() // Deprecated in Cilium 1.14, to be removed in 1.15.
-			log.WithError(err).WithField(logfields.Object, logfields.Repr(oldRuleCpy)).
-				Warn("Error parsing old CiliumNetworkPolicy rule")
-			return err
-		case ns == "" && !errors.Is(err, cilium_v2.ErrEmptyCCNP):
-			metrics.PolicyImportErrorsTotal.Inc() // Deprecated in Cilium 1.14, to be removed in 1.15.
-			log.WithError(err).WithField(logfields.Object, logfields.Repr(oldRuleCpy)).
-				Warn("Error parsing old CiliumClusterwideNetworkPolicy rule")
-			return err
-		}
-	}
-
-	_, err = newRuleCpy.Parse()
+	_, err := newRuleCpy.Parse()
 	if err != nil {
 		metrics.PolicyImportErrorsTotal.Inc() // Deprecated in Cilium 1.14, to be removed in 1.15.
 		log.WithError(err).WithField(logfields.Object, logfields.Repr(newRuleCpy)).

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -242,6 +242,13 @@ func (k *K8sWatcher) onUpsert(
 		return nil
 	}
 
+	// check that CIDRGroupRef is not used in combination with ExceptCIDRs in a CIDRRule
+	if err := validateCIDRRules(cnp); err != nil {
+		log.WithError(err).WithField(logfields.Object, logfields.Repr(cnp)).
+			Warn("Error validating CiliumNetworkPolicy CIDR rules")
+		return err
+	}
+
 	// check if this cnp was referencing or is now referencing at least one non-empty
 	// CiliumCIDRGroup and update the relevant metric accordingly.
 	cidrGroupRefs := getCIDRGroupRefs(cnp)


### PR DESCRIPTION
In CNP CIDR rules, `ExceptCIDRs` is supported only in combination with a CIDR, but not with a CIDR group reference.
Using `ExceptCIDRs` with `CIDRGroupRef` leads to a panic while computing the resultant CIDR set.

An example of a CNP that crashes the agent is the following:

```yaml
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  name: client-egress-to-cidrgroup-deny
spec:
  endpointSelector:
    matchLabels:
      kind: client
  egressDeny:
  - toCIDRSet:
    - cidrGroupRef: cilium-test-external-cidr
      except:
        - "1.1.1.1/32"
```

The PR adds a specific validation step to early reject this kind of policies before trying to parse it.

Moreover, the parsing of old CNP/CCNP versions, stored in the local cache and used to discard policy events that do not carry actual rules changes, is removed as it is already done in the previous add or update event.

Fixes: https://github.com/cilium/cilium/issues/36494

```release-note
Reject CNP/CCNP with CIDR rules where CIDRGroupRef is used in combination with ExceptCIDRs
```
