### PR TITLE
[v1.16] Reject CNPs with CIDRGroupRef used in combination with ExceptCIDRs

### DIFF
--- a/pkg/policy/k8s/cilium_cidr_group.go
+++ b/pkg/policy/k8s/cilium_cidr_group.go
@@ -283,3 +283,47 @@ func translateCIDRRuleSlice(cidrRules api.CIDRRuleSlice, cidrsSets map[string][]
 
 	return append(oldRules, newRules...)
 }
+
+func validateCIDRRules(cnp *types.SlimCNP) error {
+	for _, spec := range append(cnp.Specs, cnp.Spec) {
+		if spec == nil {
+			continue
+		}
+		for _, ingress := range spec.Ingress {
+			for _, rule := range ingress.FromCIDRSet {
+				if err := validateCIDRRule(rule); err != nil {
+					return err
+				}
+			}
+		}
+		for _, ingress := range spec.IngressDeny {
+			for _, rule := range ingress.FromCIDRSet {
+				if err := validateCIDRRule(rule); err != nil {
+					return err
+				}
+			}
+		}
+		for _, ingress := range spec.Egress {
+			for _, rule := range ingress.ToCIDRSet {
+				if err := validateCIDRRule(rule); err != nil {
+					return err
+				}
+			}
+		}
+		for _, ingress := range spec.EgressDeny {
+			for _, rule := range ingress.ToCIDRSet {
+				if err := validateCIDRRule(rule); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateCIDRRule(rule api.CIDRRule) error {
+	if rule.CIDRGroupRef != "" && len(rule.ExceptCIDRs) > 0 {
+		return errors.New("ExceptCIDRs cannot be used in combination with CIDRGroupRef")
+	}
+	return nil
+}

--- a/pkg/policy/k8s/cilium_network_policy.go
+++ b/pkg/policy/k8s/cilium_network_policy.go
@@ -53,6 +53,16 @@ func (p *policyWatcher) onUpsert(
 		return nil
 	}
 
+	// check that CIDRGroupRef is not used in combination with ExceptCIDRs in a CIDRRule
+	if err := validateCIDRRules(cnp); err != nil {
+		p.log.WithFields(logrus.Fields{
+			logfields.CiliumNetworkPolicyName: cnp.ObjectMeta.Name,
+			logfields.K8sAPIVersion:           cnp.TypeMeta.APIVersion,
+			logfields.K8sNamespace:            cnp.ObjectMeta.Namespace,
+		}).WithError(err).Warn("Error validating CiliumNetworkPolicy CIDR rules")
+		return err
+	}
+
 	// check if this cnp was referencing or is now referencing at least one non-empty
 	// CiliumCIDRGroup and update the relevant metric accordingly.
 	cidrGroupRefs := getCIDRGroupRefs(cnp)


### PR DESCRIPTION
In CNP CIDR rules, `ExceptCIDRs` is supported only in combination with a CIDR, but not with a CIDR group reference.

An example of a not supported CNP is the following:

```yaml
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  name: client-egress-to-cidrgroup-deny
spec:
  endpointSelector:
    matchLabels:
      kind: client
  egressDeny:
  - toCIDRSet:
    - cidrGroupRef: cilium-test-external-cidr
      except:
        - "1.1.1.1/32"
```

The PR adds a specific validation step to early reject this kind of policies before trying to parse it.

```release-note
Reject CNP/CCNP with CIDR rules where CIDRGroupRef is used in combination with ExceptCIDRs
```
