### PR TITLE
datapath: Add eni parent interface to short-cut the FIB lookup

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -727,6 +727,10 @@ ct_recreate6:
 #endif
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif = 0;
+#ifdef THIS_INTERFACE_PARENT_IFINDEX
+		if (ct_status == CT_REPLY)
+			oif = THIS_INTERFACE_PARENT_IFINDEX;
+#endif
 
 		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, false, ext_err, &oif);
 		if (fib_ok(ret))
@@ -1278,6 +1282,10 @@ skip_vtep:
 
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif = 0;
+#ifdef THIS_INTERFACE_PARENT_IFINDEX
+		if (ct_status == CT_REPLY)
+			oif = THIS_INTERFACE_PARENT_IFINDEX;
+#endif
 
 		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, false, ext_err, &oif);
 		if (fib_ok(ret))

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -233,10 +233,11 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 	int ret;
 
 #ifdef ENABLE_SKIP_FIB
-	*oif = DIRECT_ROUTING_DEV_IFINDEX;
+	if (*oif <= 0)
+		*oif = DIRECT_ROUTING_DEV_IFINDEX;
 #endif
 
-	if (!is_defined(ENABLE_SKIP_FIB) || !neigh_resolver_available()) {
+	if (*oif <= 0 || !neigh_resolver_available()) {
 		int fib_result;
 
 		fib_result = fib_lookup_v6(ctx, &fib_params, &ip6->saddr, &ip6->daddr, 0);
@@ -293,10 +294,11 @@ fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
 	int ret;
 
 #ifdef ENABLE_SKIP_FIB
-	*oif = DIRECT_ROUTING_DEV_IFINDEX;
+	if (*oif <= 0)
+		*oif = DIRECT_ROUTING_DEV_IFINDEX;
 #endif
 
-	if (!is_defined(ENABLE_SKIP_FIB) || !neigh_resolver_available()) {
+	if (*oif <= 0 || !neigh_resolver_available()) {
 		int fib_result;
 
 		fib_result = fib_lookup_v4(ctx, &fib_params, ip4->saddr, ip4->daddr, 0);


### PR DESCRIPTION
Introduce THIS_INTERFACE_PARENT_IFINDEX for container endpoints to enable direct packet redirection using bpf_redirect_neigh(). This optimization eliminates the overhead of BPF FIB lookup operations in the datapath.

Flow up #36310