### PR TITLE
Change client-egress-l7-tls tests to sequential because flaky

### DIFF
--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -253,8 +253,6 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		clientEgressL7Method{},
 		clientEgressL7{},
 		clientEgressL7NamedPort{},
-		clientEgressL7TlsDenyWithoutHeaders{},
-		clientEgressL7TlsHeaders{},
 		clientEgressTlsSni{},
 		clientEgressL7SetHeader{},
 		echoIngressAuthAlwaysFail{},
@@ -289,6 +287,8 @@ func sequentialTests(ct *check.ConnectivityTest) error {
 	tests := []testBuilder{
 		hostFirewallIngress{},
 		hostFirewallEgress{},
+		clientEgressL7TlsDenyWithoutHeaders{},
+		clientEgressL7TlsHeaders{},
 	}
 	return injectTests(tests, ct)
 }

--- a/cilium-cli/connectivity/builder/client_egress_l7_tls_deny_without_headers.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_tls_deny_without_headers.go
@@ -14,7 +14,7 @@ type clientEgressL7TlsDenyWithoutHeaders struct{}
 func (t clientEgressL7TlsDenyWithoutHeaders) build(ct *check.ConnectivityTest, templates map[string]string) {
 	// Test L7 HTTPS interception using an egress policy on the clients.
 	// Fail to load site due to missing headers.
-	newTest("client-egress-l7-tls-deny-without-headers", ct).
+	newTest("seq-client-egress-l7-tls-deny-without-headers", ct).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretBackendK8s)).
 		WithCABundleSecret().

--- a/cilium-cli/connectivity/builder/client_egress_l7_tls_headers.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_tls_headers.go
@@ -19,10 +19,10 @@ func (t clientEgressL7TlsHeaders) build(ct *check.ConnectivityTest, templates ma
 }
 
 func clientEgressL7TlsHeadersTest(ct *check.ConnectivityTest, templates map[string]string, portRanges bool) {
-	testName := "client-egress-l7-tls-headers"
+	testName := "seq-client-egress-l7-tls-headers"
 	yamlFile := templates["clientEgressL7TLSPolicyYAML"]
 	if portRanges {
-		testName = "client-egress-l7-tls-headers-port-range"
+		testName = "seq-client-egress-l7-tls-headers-port-range"
 		yamlFile = templates["clientEgressL7TLSPolicyPortRangeYAML"]
 	}
 	// Test L7 HTTPS interception using an egress policy on the clients.


### PR DESCRIPTION
Testing for flakes, not from a fork this time.