### PR TITLE
fix: node ip allocation log level

### DIFF
--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -936,7 +936,7 @@ func (n *Node) handleIPAllocation(ctx context.Context, a *maintenanceAction) (in
 		scopedLog.WithFields(logrus.Fields{
 			"selectedInterface": a.allocation.InterfaceID,
 			"ipsToAllocate":     a.allocation.IPv4.AvailableForAllocation,
-		}).WithError(err).Warning("Unable to assign additional IPs to interface, will create new interface")
+		}).WithError(err).Info("Unable to assign additional IPs to interface, will create new interface")
 	}
 
 	return n.createInterface(ctx, a.allocation)


### PR DESCRIPTION
This PR changes the log level of IP allocation. 
The expected behavior is, once the maximum number of IP is hit on the interface, a new one will be created. 
Switching this log from warning to info would prevent workflow failures on intended behavior.

<!-- Description of change -->

Fixes: [#36428](https://github.com/cilium/cilium/issues/36428)

```release-note
Switch IP allocation log level of hitting max number of IPs on interface from warning to info
```
