### PR TITLE
Remove "_count" suffix from doublewrite metrics

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -453,6 +453,7 @@ Makefile* @cilium/build
 /MAINTAINERS.md @cilium/contributing
 /netlify.toml @cilium/ci-structure
 /operator/ @cilium/operator
+/operator/doublewrite @cilium/metrics
 /operator/pkg/bgpv2 @cilium/sig-bgp
 /operator/pkg/ciliumendpointslice @cilium/sig-scalability
 /operator/pkg/ciliumenvoyconfig @cilium/sig-servicemesh

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -813,10 +813,10 @@ enabled, the following metrics are available:
 ============================================ ======= ========== ============================================================
 Name                                         Labels  Default    Description
 ============================================ ======= ========== ============================================================
-``doublewrite_identity_crd_total_count``             Enabled    The total number of CRD identities
-``doublewrite_identity_kvstore_total_count``         Enabled    The total number of identities in the KVStore
-``doublewrite_identity_crd_only_count``              Enabled    The number of CRD identities not present in the KVStore
-``doublewrite_identity_kvstore_only_count``          Enabled    The number of identities in the KVStore not present as a CRD
+``doublewrite_identity_crd_total``                   Enabled    The total number of CRD identities
+``doublewrite_identity_kvstore_total``               Enabled    The total number of identities in the KVStore
+``doublewrite_identity_crd_only_total``              Enabled    The number of CRD identities not present in the KVStore
+``doublewrite_identity_kvstore_only_total``          Enabled    The number of identities in the KVStore not present as a CRD
 ============================================ ======= ========== ============================================================
 
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -330,7 +330,7 @@ communicating via the proxy must reconnect to re-establish connections.
 * For IPsec, support for a single key has been removed. Per-tunnel keys will
   now be used regardless of the presence of the ``+`` sign in the secret.
 * The option to run a synchronous probe using ``cilium-health status --probe`` is no longer supported,
-  and is now a hidden option that returns the results of the most recent cached probe. It will be 
+  and is now a hidden option that returns the results of the most recent cached probe. It will be
   removed in a future release.
 * The Cilium status API now reports the KVStore subsystem with ``Disabled`` state when disabled,
   instead of ``OK`` state and ``Disabled`` message.
@@ -411,7 +411,7 @@ Removed Metrics
 
 Changed Metrics
 ~~~~~~~~~~~~~~~
-The metrics prefix of all Envoy NPDS (NetworkPolicy discovery service) metrics 
+The metrics prefix of all Envoy NPDS (NetworkPolicy discovery service) metrics
 has been renamed from ``envoy_cilium_policymap_<node-ip>_<node-id>_`` to ``envoy_cilium_npds_``.
 
 * ``envoy_cilium_policymap_<node-ip>_<node-id>_control_plane_rate_limit_enforced`` -> ``envoy_cilium_npds_control_plane_rate_limit_enforced``
@@ -425,6 +425,10 @@ has been renamed from ``envoy_cilium_policymap_<node-ip>_<node-id>_`` to ``envoy
 * ``envoy_cilium_policymap_<node-ip>_<node-id>_update_time`` -> ``envoy_cilium_npds_update_time``
 * ``envoy_cilium_policymap_<node-ip>_<node-id>_update_duration`` -> ``envoy_cilium_npds_update_duration``
 * ``envoy_cilium_policymap_<node-ip>_<node-id>_version`` -> ``envoy_cilium_npds_version``
+* ``doublewrite_identity_crd_total_count`` has been renamed to ``doublewrite_identity_crd_total``
+* ``doublewrite_identity_kvstore_total_count`` has been renamed to ``doublewrite_identity_kvstore_total``
+* ``doublewrite_identity_crd_only_count`` has been renamed to ``doublewrite_identity_crd_only_total``
+* ``doublewrite_identity_kvstore_only_count`` has been renamed to ``doublewrite_identity_kvstore_only_total``
 
 Deprecated Metrics
 ~~~~~~~~~~~~~~~~~~

--- a/operator/doublewrite/metricreporter.go
+++ b/operator/doublewrite/metricreporter.go
@@ -161,10 +161,10 @@ func (g *DoubleWriteMetricReporter) compareCRDAndKVStoreIdentities(ctx context.C
 	onlyInCrdSample := onlyInCrd[:min(onlyInCrdCount, maxPrintedDiffIDs)]
 	onlyInKVStoreSample := onlyInKVStore[:min(onlyInKVStoreCount, maxPrintedDiffIDs)]
 
-	g.metrics.IdentityCRDTotalCount.Set(float64(len(crdIdentityIds)))
-	g.metrics.IdentityKVStoreTotalCount.Set(float64(len(kvstoreIdentityIds)))
-	g.metrics.IdentityCRDOnlyCount.Set(float64(onlyInCrdCount))
-	g.metrics.IdentityKVStoreOnlyCount.Set(float64(onlyInKVStoreCount))
+	g.metrics.IdentityCRDTotal.Set(float64(len(crdIdentityIds)))
+	g.metrics.IdentityKVStoreTotal.Set(float64(len(kvstoreIdentityIds)))
+	g.metrics.IdentityCRDOnlyTotal.Set(float64(onlyInCrdCount))
+	g.metrics.IdentityKVStoreOnlyTotal.Set(float64(onlyInKVStoreCount))
 
 	if onlyInCrdCount == 0 && onlyInKVStoreCount == 0 {
 		g.logger.Info("CRD and KVStore identities are in sync")

--- a/operator/doublewrite/metrics.go
+++ b/operator/doublewrite/metrics.go
@@ -10,46 +10,46 @@ import (
 
 func NewMetrics() *Metrics {
 	return &Metrics{
-		IdentityCRDTotalCount: metric.NewGauge(metric.GaugeOpts{
+		IdentityCRDTotal: metric.NewGauge(metric.GaugeOpts{
 			Namespace: metrics.CiliumOperatorNamespace,
-			Name:      "doublewrite_identity_crd_total_count",
+			Name:      "doublewrite_identity_crd_total",
 			Help:      "The total number of CRD identities (Requires the Double-Write Identity allocation mode to be enabled)",
 		}),
 
-		IdentityKVStoreTotalCount: metric.NewGauge(metric.GaugeOpts{
+		IdentityKVStoreTotal: metric.NewGauge(metric.GaugeOpts{
 			Namespace: metrics.CiliumOperatorNamespace,
-			Name:      "doublewrite_identity_kvstore_total_count",
+			Name:      "doublewrite_identity_kvstore_total",
 			Help:      "The total number of identities in the KVStore (Requires the Double-Write Identity allocation mode to be enabled)",
 		}),
 
-		IdentityCRDOnlyCount: metric.NewGauge(metric.GaugeOpts{
+		IdentityCRDOnlyTotal: metric.NewGauge(metric.GaugeOpts{
 			Namespace: metrics.CiliumOperatorNamespace,
-			Name:      "doublewrite_identity_crd_only_count",
+			Name:      "doublewrite_identity_crd_only_total",
 			Help:      "The number of CRD identities not present in the KVStore (Requires the Double-Write Identity allocation mode to be enabled)",
 		}),
 
-		IdentityKVStoreOnlyCount: metric.NewGauge(metric.GaugeOpts{
+		IdentityKVStoreOnlyTotal: metric.NewGauge(metric.GaugeOpts{
 			Namespace: metrics.CiliumOperatorNamespace,
-			Name:      "doublewrite_identity_kvstore_only_count",
+			Name:      "doublewrite_identity_kvstore_only_total",
 			Help:      "The number of identities in the KVStore not present as a CRD (Requires the Double-Write Identity allocation mode to be enabled)",
 		}),
 	}
 }
 
 type Metrics struct {
-	// IdentityCRDTotalCount records the total number of CRD identities
+	// IdentityCRDTotal records the total number of CRD identities
 	// Requires the Double-Write Identity allocation mode to be enabled
-	IdentityCRDTotalCount metric.Gauge
+	IdentityCRDTotal metric.Gauge
 
-	// IdentityKVStoreTotalCount records the total number of identities in the KVStore
+	// IdentityKVStoreTotal records the total number of identities in the KVStore
 	// Requires the Double-Write Identity allocation mode to be enabled
-	IdentityKVStoreTotalCount metric.Gauge
+	IdentityKVStoreTotal metric.Gauge
 
-	// IdentityCRDOnlyCount records the number of CRD identities not present in the KVStore
+	// IdentityCRDOnlyTotal records the number of CRD identities not present in the KVStore
 	// Requires the Double-Write Identity allocation mode to be enabled
-	IdentityCRDOnlyCount metric.Gauge
+	IdentityCRDOnlyTotal metric.Gauge
 
-	// IdentityKVStoreOnlyCount records the number of identities in the KVStore not present as a CRD
+	// IdentityKVStoreOnlyTotal records the number of identities in the KVStore not present as a CRD
 	// Requires the Double-Write Identity allocation mode to be enabled
-	IdentityKVStoreOnlyCount metric.Gauge
+	IdentityKVStoreOnlyTotal metric.Gauge
 }


### PR DESCRIPTION
Fixes: #36580
Follow-up to https://github.com/cilium/cilium/pull/31920

```release-note
Remove "_count" suffix from doublewrite metrics
```
