### PR TITLE
make: Fix kind-image-fast-agent from scratch

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -233,8 +233,12 @@ build-clustermesh-apiserver: ## Build cilium clustermesh-apiserver binary
 build-hubble-cli: ## Build hubble cli binary
 	$(QUIET)$(MAKE) -C hubble GOOS=linux
 
+.PHONY: build-bugtool
+build-bugtool: ## Build bugtool binary
+	$(QUIET)$(MAKE) -C bugtool GOOS=linux
+
 .PHONY: kind-image-fast-agent
-kind-image-fast-agent: kind-ready build-cli build-agent build-hubble-cli ## Build cilium cli, daemon binaries, and hubble cli. Copy the bins and bpf files to kind nodes.
+kind-image-fast-agent: kind-ready build-cli build-agent build-hubble-cli build-bugtool ## Build cilium cli, daemon binaries, and hubble cli. Copy the bins and bpf files to kind nodes.
 	$(eval dst:=/cilium-binaries)
 	for cluster_name in $${KIND_CLUSTERS:-$(shell kind get clusters)}; do \
 		for node_name in $$(kind get nodes -n "$$cluster_name"); do \


### PR DESCRIPTION
When running this make target from a clean tree, it would fail with the
following error:

```
lstat /home/ubuntu/git/cilium/bugtool/cilium-bugtool: no such file or directory
make: *** [Makefile.kind:239: kind-image-fast-agent] Error 1
```

Fix it by making the bugtool a dependency for the make target.

Fixes: c275fbe29ad7 ("make: Update cilium-bugtool upon fast target")
Fixes: https://github.com/cilium/cilium/pull/36516
Fixes: #36562
Reported-by: @pmatulis
CC: @brb 