### PR TITLE
ci: add docker build wrapper action

### DIFF
--- a/.github/actions/docker-build-wrapper/action.yaml
+++ b/.github/actions/docker-build-wrapper/action.yaml
@@ -4,33 +4,33 @@ inputs:
   provenance:
     required: false
     default: false
-    description: ""
+    description: "Generate provenance attestation for the build"
   context:
     required: false
     default: "."
-    description: ""
+    description: "Build's context"
   file:
     required: true
-    description: ""
+    description: "Path to the Dockerfile"
   push:
     required: false
     default: true
-    description: ""
+    description: "Push the build result to registry"
   platforms:
     required: true
-    description: ""
+    description: "List of target platforms for build"
   tags:
     required: true
-    description: ""
+    description: "List of tags"
   target:
     required: true
-    description: ""
+    description: "Sets the target stage to build"
   build-args:
     required: false
-    description: ""
+    description: "List of build-time variables"
 outputs:
   digest:
-    description: ""
+    description: "Image digest"
     value: ${{ steps.build.outputs.digest }}
 runs:
   using: composite

--- a/.github/actions/docker-build-wrapper/action.yaml
+++ b/.github/actions/docker-build-wrapper/action.yaml
@@ -1,0 +1,49 @@
+name: Docker build and push wrapper
+description: Allows attaching custom options to all docker builds
+inputs:
+  provenance:
+    required: false
+    default: false
+    description: ""
+  context:
+    required: false
+    default: "."
+    description: ""
+  file:
+    required: true
+    description: ""
+  push:
+    required: false
+    default: true
+    description: ""
+  platforms:
+    required: true
+    description: ""
+  tags:
+    required: true
+    description: ""
+  target:
+    required: true
+    description: ""
+  build-args:
+    required: false
+    description: ""
+outputs:
+  digest:
+    description: ""
+    value: ${{ steps.build.outputs.digest }}
+runs:
+  using: composite
+  steps:
+    - name: Build
+      id: build
+      uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355
+      with:
+        provenance: ${{ inputs.provenance }}
+        context: ${{ inputs.context }}
+        file: ${{ inputs.file }}
+        push: ${{ inputs.push }}
+        platforms: ${{ inputs.platforms }}
+        tags: ${{ inputs.tags }}
+        target: ${{ inputs.target }}
+        build-args: ${{ inputs.build-args }}


### PR DESCRIPTION
This wrapper action can allow us to add global arguments or build-args to all docker builds using the wrapper.
