### PR TITLE
bgpv2: Pass copy of BGPNodeConfig to reconcilers

### DIFF
--- a/pkg/bgpv1/agent/controller.go
+++ b/pkg/bgpv1/agent/controller.go
@@ -270,6 +270,9 @@ func (c *Controller) Reconcile(ctx context.Context) error {
 		log.WithError(err).Error("failed to get BGPNodeConfig")
 		return err
 	}
+	if bgpncExists {
+		bgpnc = bgpnc.DeepCopy() // reconcilers can mutate the NodeConfig, make a copy to not mutate the version in store
+	}
 
 	switch c.ConfigMode.Get() {
 	case mode.Disabled:


### PR DESCRIPTION
BGP reconcilers can mutate the passed NodeConfig, therefore pass a copy of it instead of the pointer to the version in the resource store.
