### PR TITLE
mtu: Catch expected error in endpoint MTU updater 

### DIFF
--- a/pkg/mtu/endpoint_updater.go
+++ b/pkg/mtu/endpoint_updater.go
@@ -178,8 +178,6 @@ func (emu *endpointUpdater) updateHostNSDevices(rx statedb.ReadTxn, routeMtus []
 		return err
 	}
 
-	var errs []error
-
 	// Update the MTU of all endpoint interfaces in the host network namespace
 	deviceIter := emu.deviceTable.All(rx)
 	for dev := range deviceIter {
@@ -197,27 +195,19 @@ func (emu *endpointUpdater) updateHostNSDevices(rx statedb.ReadTxn, routeMtus []
 
 		link, err := netlink.LinkByIndex(dev.Index)
 		if err != nil {
-			emu.logger.Error("Error getting link by index",
-				logfields.Index, dev.Index,
-				logfields.Error, err,
-			)
-			errs = append(errs, err)
+			// Ignore any errors. It is possible that the device has been removed between the time
+			// we read the device table and now.
 			continue
 		}
 
 		if err := netlink.LinkSetMTU(link, defaultRouteMTU.DeviceMTU); err != nil {
-			emu.logger.Error("Error setting MTU for link",
-				logfields.Link, link.Attrs().Name,
-				logfields.Index, link.Attrs().Index,
-				logfields.MTU, defaultRouteMTU.DeviceMTU,
-				logfields.Error, err,
-			)
-			errs = append(errs, err)
+			// Ignore any errors. It is possible that the device has been removed between the time
+			// we got the link and now.
 			continue
 		}
 	}
 
-	return errors.Join(errs...)
+	return nil
 }
 
 // RegisterHook registers a hook to be called when updating the MTU of endpoints.
@@ -230,12 +220,11 @@ func (emu *endpointUpdater) RegisterHook(hook EndpointMTUUpdateHook) {
 func (emu *endpointUpdater) updateEndpoints(routeMTUs []RouteMTU) error {
 	files, err := os.ReadDir(defaults.NetNsPath)
 	if err != nil {
-		emu.logger.Error("Error opening the netns dir while "+
-			"updating MTU for endpoints",
-			logfields.NetNSDir, defaults.NetNsPath,
-			logfields.Error, err,
+		return fmt.Errorf(
+			"Error opening the netns dir (%q) while updating MTU for endpoints: %w",
+			defaults.NetNsPath,
+			err,
 		)
-		return err
 	}
 
 	var errs []error
@@ -243,6 +232,12 @@ func (emu *endpointUpdater) updateEndpoints(routeMTUs []RouteMTU) error {
 	for _, file := range files {
 		ns, err := netns.OpenPinned(filepath.Join(defaults.NetNsPath, file.Name()))
 		if err != nil {
+			// If the netns disappeared between the time we read the directory and now, ignore it,
+			// it likely means the endpoint was deleted.
+			if os.IsNotExist(err) {
+				continue
+			}
+
 			emu.logger.Error("Error opening netns",
 				logfields.NetNSName, file.Name(),
 				logfields.Error, err,
@@ -267,6 +262,14 @@ func (emu *endpointUpdater) updateEndpoints(routeMTUs []RouteMTU) error {
 		ns.Close()
 		// Even though we never return an error from ns.Do, it can still fail internally
 		if err != nil {
+			// When we open a netns, we get a file descriptor to the netns, which ns.Do uses internally
+			// to do syscalls for the switching. If the netns is deleted between the time we open it and
+			// the time of calling ns.Do, we get an -EINVAL error, since the file descriptor is no longer valid.
+			// We ignore this error, since it means the netns and thus the endpoint was deleted.
+			if errors.Is(err, os.ErrInvalid) {
+				continue
+			}
+
 			errs = append(errs, err)
 			emu.logger.Error("error while updating MTU for endpoint",
 				logfields.NetNSName, file.Name(),


### PR DESCRIPTION
There are a number of errors which we expect to occur when updating the
MTU of an endpoint while its being deleted. This commit adds checks to
catch and ignore these errors.

Fixes: #36590