### PR TITLE
bgpv2: add support for per-node LocalASN

### DIFF
--- a/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
@@ -33,7 +33,7 @@ the cluster based on its ``nodeSelector`` field. Each ``CiliumBGPClusterConfig``
 more BGP instances, which are uniquely identified by their ``name`` field.
 
 A BGP instance can have one or more peers. Each peer is uniquely identified by its ``name`` field. The Peer
-autonomous number and peer address are defined by the ``peerASN`` and ``peerAddress`` fields,
+autonomous system number and peer address are defined by the ``peerASN`` and ``peerAddress`` fields,
 respectively. The configuration of the peers is defined by the ``peerConfigRef`` field, which is a reference
 to a peer configuration resource. ``Group`` and ``kind`` in ``peerConfigRef`` are optional and default to
 ``cilium.io`` and ``CiliumBGPPeerConfig``, respectively.
@@ -744,8 +744,8 @@ BGP Configuration Override
 The ``CiliumBGPNodeConfigOverride`` resource can be used to override some of the auto-generated configuration
 on a per-node basis.
 
-Here is an example of the ``CiliumBGPNodeConfigOverride`` resource, that sets Router ID and local address
-used in each peer for the node with a name ``bgpv2-cplane-dev-multi-homing-worker``.
+Here is an example of the ``CiliumBGPNodeConfigOverride`` resource, that sets Router ID, local address and
+local autonomous system number used in each peer for the node with a name ``bgpv2-cplane-dev-multi-homing-worker``.
 
 .. code-block:: yaml
 
@@ -758,6 +758,7 @@ used in each peer for the node with a name ``bgpv2-cplane-dev-multi-homing-worke
         - name: "instance-65000"
           routerID: "192.168.10.1"
           localPort: 1790
+          localASN: 65010
           peers:
             - name: "peer-65000-tor1"
               localAddress: fd00:10:0:2::2
@@ -802,6 +803,14 @@ BGP peering should be setup.
 
 To configure the source address, the ``peers[*].localAddress`` field can be set. It should be an
 address configured on one of the links on the node.
+
+Local ASN
+---------
+
+It is possible to override the Autonomous System Number (ASN) of a node using the field ``LocalASN`` of the
+``CiliumBGPNodeConfigOverride`` resource. When this field is not defined, the ``LocalASN`` from the matching
+``CiliumBGPClusterConfig`` is used as local ASN for the node. This customization allows individual nodes to
+operate with a different ASN when required by the network design.
 
 Sample Configurations
 =====================

--- a/operator/pkg/bgpv2/cluster.go
+++ b/operator/pkg/bgpv2/cluster.go
@@ -301,6 +301,9 @@ func toNodeBGPInstance(clusterBGPInstances []v2alpha1.CiliumBGPInstance, overrid
 			if overrideBGPInstance.Name == clusterBGPInstance.Name {
 				nodeBGPInstance.RouterID = overrideBGPInstance.RouterID
 				nodeBGPInstance.LocalPort = overrideBGPInstance.LocalPort
+				if overrideBGPInstance.LocalASN != nil {
+					nodeBGPInstance.LocalASN = overrideBGPInstance.LocalASN
+				}
 				override = overrideBGPInstance
 				break
 			}

--- a/operator/pkg/bgpv2/cluster_test.go
+++ b/operator/pkg/bgpv2/cluster_test.go
@@ -64,6 +64,7 @@ var (
 				Name:      "cluster-1-instance-65001",
 				RouterID:  ptr.To[string]("10.10.10.10"),
 				LocalPort: ptr.To[int32](5400),
+				LocalASN:  ptr.To[int64](65010),
 				Peers: []cilium_api_v2alpha1.CiliumBGPNodeConfigPeerOverride{
 					{
 						Name:         "cluster-1-instance-65002-peer-10.0.0.2",
@@ -76,7 +77,7 @@ var (
 
 	expectedNodeWithOverride1 = cilium_api_v2alpha1.CiliumBGPNodeInstance{
 		Name:      "cluster-1-instance-65001",
-		LocalASN:  ptr.To[int64](65001),
+		LocalASN:  ptr.To[int64](65010),
 		RouterID:  ptr.To[string]("10.10.10.10"),
 		LocalPort: ptr.To[int32](5400),
 		Peers: []cilium_api_v2alpha1.CiliumBGPNodePeer{

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpnodeconfigoverrides.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpnodeconfigoverrides.yaml
@@ -59,6 +59,12 @@ spec:
                   description: CiliumBGPNodeConfigInstanceOverride defines configuration
                     options which can be overridden for a specific BGP instance.
                   properties:
+                    localASN:
+                      description: LocalASN is the ASN to use for this BGP instance.
+                      format: int64
+                      maximum: 4294967295
+                      minimum: 1
+                      type: integer
                     localPort:
                       description: LocalPort is port to use for this BGP instance.
                       format: int32

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_node_override_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_node_override_types.go
@@ -77,6 +77,13 @@ type CiliumBGPNodeConfigInstanceOverride struct {
 	// +listType=map
 	// +listMapKey=name
 	Peers []CiliumBGPNodeConfigPeerOverride `json:"peers,omitempty"`
+
+	// LocalASN is the ASN to use for this BGP instance.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=4294967295
+	LocalASN *int64 `json:"localASN,omitempty"`
 }
 
 // CiliumBGPNodeConfigPeerOverride defines configuration options which can be overridden for a specific peer.

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
@@ -545,6 +545,11 @@ func (in *CiliumBGPNodeConfigInstanceOverride) DeepCopyInto(out *CiliumBGPNodeCo
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.LocalASN != nil {
+		in, out := &in.LocalASN, &out.LocalASN
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
@@ -560,6 +560,14 @@ func (in *CiliumBGPNodeConfigInstanceOverride) DeepEqual(other *CiliumBGPNodeCon
 		}
 	}
 
+	if (in.LocalASN == nil) != (other.LocalASN == nil) {
+		return false
+	} else if in.LocalASN != nil {
+		if *in.LocalASN != *other.LocalASN {
+			return false
+		}
+	}
+
 	return true
 }
 


### PR DESCRIPTION
Introduce a `LocalASN` field in the `CiliumBGPNodeConfigOverride` CRD to allow configuration of per-node local ASNs. This simplifies BGP configuration by reducing the need for multiple `CiliumBGPClusterConfig` instances for each node, as discussed in issue [#35925](https://github.com/cilium/cilium/issues/35925).

- Update `CiliumBGPNodeConfigOverride` CRD to include `LocalASN`
- Adjust BGP logic to use node-specific `LocalASN` when specified
- Add `LocalASN` in tests to validate behavior of per-node `LocalASN`
- Update documentation to reflect this new feature
- Update a line in the documentation to reduce confusion about ASNs

Fixes: #35925

```release-note
bgpv2: add support for node-specific LocalASN in CiliumBGPNodeConfigOverride
```