### PR TITLE
Add CNP IngressDeny and EgressDeny rules validation

### DIFF
--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -280,13 +280,10 @@ func (e *EgressRule) sanitize(hostPolicy bool) error {
 		"HTTP":  !hostPolicy,
 	}
 
-	for m1 := range l3Members {
-		for m2 := range l3Members {
-			if m2 != m1 && l3Members[m1] > 0 && l3Members[m2] > 0 {
-				return fmt.Errorf("combining %s and %s is not supported yet", m1, m2)
-			}
-		}
+	if err := e.EgressCommonRule.sanitize(l3Members); err != nil {
+		return err
 	}
+
 	for member := range l3Members {
 		if l3Members[member] > 0 && len(e.ToPorts) > 0 && !l3DependentL4Support[member] {
 			return fmt.Errorf("combining %s and ToPorts is not supported yet", member)
@@ -314,6 +311,39 @@ func (e *EgressRule) sanitize(hostPolicy bool) error {
 		return errUnsupportedICMPWithToPorts
 	}
 
+	for i := range e.ToPorts {
+		if err := e.ToPorts[i].sanitize(false); err != nil {
+			return err
+		}
+	}
+
+	for n := range e.ICMPs {
+		if err := e.ICMPs[n].verify(); err != nil {
+			return err
+		}
+	}
+
+	for i := range e.ToFQDNs {
+		err := e.ToFQDNs[i].sanitize()
+		if err != nil {
+			return err
+		}
+	}
+
+	e.SetAggregatedSelectors()
+
+	return nil
+}
+
+func (e *EgressCommonRule) sanitize(l3Members map[string]int) error {
+	for m1 := range l3Members {
+		for m2 := range l3Members {
+			if m2 != m1 && l3Members[m1] > 0 && l3Members[m2] > 0 {
+				return fmt.Errorf("combining %s and %s is not supported yet", m1, m2)
+			}
+		}
+	}
+
 	var retErr error
 
 	if len(e.ToNodes) > 0 && !option.Config.EnableNodeSelectorLabels {
@@ -328,18 +358,6 @@ func (e *EgressRule) sanitize(hostPolicy bool) error {
 
 	for _, es := range e.ToRequires {
 		if err := es.sanitize(); err != nil {
-			return errors.Join(err, retErr)
-		}
-	}
-
-	for i := range e.ToPorts {
-		if err := e.ToPorts[i].sanitize(false); err != nil {
-			return errors.Join(err, retErr)
-		}
-	}
-
-	for n := range e.ICMPs {
-		if err := e.ICMPs[n].verify(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
@@ -367,15 +385,6 @@ func (e *EgressRule) sanitize(hostPolicy bool) error {
 			return errors.Join(fmt.Errorf("unsupported entity: %s", toEntity), retErr)
 		}
 	}
-
-	for i := range e.ToFQDNs {
-		err := e.ToFQDNs[i].sanitize()
-		if err != nil {
-			return errors.Join(err, retErr)
-		}
-	}
-
-	e.SetAggregatedSelectors()
 
 	return retErr
 }

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -284,8 +284,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 		},
 	}
 	err = invalidPortRule.Sanitize()
-	require.Error(t, err)
-	require.Equal(t, "Empty server name is not allowed", err.Error())
+	require.ErrorIs(t, err, errEmptyServerName)
 
 	//  Rule is invalid because ServerNames with L7 rules are not allowed without TLS termination.
 	invalidPortRule = Rule{
@@ -1093,11 +1092,10 @@ func TestICMPRuleWithOtherRuleFailed(t *testing.T) {
 	}
 
 	option.Config.EnableICMPRules = true
-	errStr := "The ICMPs block may only be present without ToPorts. Define a separate rule to use ToPorts."
 	err := ingressICMPWithPort.Sanitize()
-	require.ErrorContains(t, err, errStr)
+	require.ErrorIs(t, err, errUnsupportedICMPWithToPorts)
 	err = egressICMPWithPort.Sanitize()
-	require.ErrorContains(t, err, errStr)
+	require.ErrorIs(t, err, errUnsupportedICMPWithToPorts)
 }
 
 // This test ensures that PortRules aren't configured in the wrong direction,

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -1470,7 +1470,7 @@ Resolving ingress policy for [any:bar]
     Denies from labels {"matchLabels":{"reserved:host":""}}
     Denies from labels {"matchLabels":{"any:baz":""}}
       Found all required labels
-      Denies port [{80 0 }]
+      Denies port [{80 0 ANY}]
 2/2 rules selected
 Found no allow rule
 Found deny rule
@@ -1547,7 +1547,7 @@ Resolving ingress policy for [any:bar]
     Denies from labels {"matchLabels":{"reserved:host":""},"matchExpressions":[{"key":"any:baz","operator":"In","values":[""]}]}
     Denies from labels {"matchLabels":{"any:baz":""},"matchExpressions":[{"key":"any:baz","operator":"In","values":[""]}]}
       Found all required labels
-      Denies port [{80 0 }]
+      Denies port [{80 0 ANY}]
         No port match found
 * Rule {"matchLabels":{"any:bar":""}}: selected
 3/3 rules selected


### PR DESCRIPTION
Add sanitization for IngressDeny and EgressDeny rules in CNP/CCNP.

The sanitization logic follows the same rules already applied for Ingress and Egress rules, except for the parts that are not supported in their "Deny" counterparts (e.g: no L7 rules support in IngressDeny/EgressDeny, hence no L7 rules validation).

**Note to reviewers**: please review commit by commit

```release-note
Add IngressDeny and EgressDeny rules validation for CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy
```
