### PR TITLE
policy: Return labels of contributing rules from mapState.Lookup

### DIFF
--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -1880,7 +1880,7 @@ func Test_EnsureEntitiesSelectableByCIDR(t *testing.T) {
 
 // allowsKey returns returns true if 'ms' allows "traffic" with 'key'
 func (ms *mapState) allowsKey(key Key) bool {
-	entry, _ := ms.Lookup(key)
+	entry, _ := ms.lookup(key)
 	return !entry.IsDeny()
 }
 


### PR DESCRIPTION
Change `Lookup` to return the labels of the rules that contributed to the chosen policy verdict, `nil` for default deny. `Lookup` is only used for testing, but is exported so that it can be used from other packages as well. Returning the labels allows for validation that the expected rules were used in reaching the verdict.

