### PR TITLE
pkg/endpoint: delete unused const backupDirectorySuffix in directory.go

### DIFF
--- a/pkg/endpoint/directory.go
+++ b/pkg/endpoint/directory.go
@@ -18,7 +18,6 @@ import (
 const (
 	nextDirectorySuffix       = "_next"
 	nextFailedDirectorySuffix = "_next_fail"
-	backupDirectorySuffix     = "_stale"
 )
 
 // DirectoryPath returns the directory name for this endpoint bpf program.


### PR DESCRIPTION
As the introduction of commit acf3141f3596, backupDirectorySuffix is no longer used, thus delete this const.
