### PR TITLE
clustermesh: Add hidden flag --allow-unsafe-policy-skb-usage

### DIFF
--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -149,6 +149,7 @@
   {{ fail "The cluster name is invalid: cannot use default value with cluster.id != 0" }}
 {{- end }}
 {{ if and
+    (ne (index .Values.extraConfig "allow-unsafe-policy-skb-usage") "true")
     (or (and (ge (int .Values.cluster.id) 128) (le (int .Values.cluster.id) 255)) (and (ge (int .Values.cluster.id) 384) (le (int .Values.cluster.id) 511)))
     (or .Values.eni.enabled .Values.alibabacloud.enabled (eq .Values.cni.chainingMode "aws-cni")) -}}
   {{ fail "Cilium is currently affected by a bug that causes traffic matched by network policies to be incorrectly dropped when running in either ENI mode (both AWS and AlibabaCloud) or AWS VPC CNI chaining mode, if the cluster ID is 128-255 (and 384-511 when maxConnectedClusters=511). Please refer to https://github.com/cilium/cilium/issues/21330 for additional details." }}

--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -5,6 +5,7 @@ package clustermesh
 
 import (
 	"github.com/cilium/hive/cell"
+	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
@@ -40,10 +41,10 @@ var Cell = cell.Module(
 	metrics.Metric(common.MetricsProvider(subsystem)),
 
 	cell.Config(types.DefaultQuirks),
-	cell.Invoke(func(info types.ClusterInfo, dcfg *option.DaemonConfig, cnimgr cni.CNIConfigManager, cfg Configuration, quirks types.QuirksConfig) error {
+	cell.Invoke(func(info types.ClusterInfo, dcfg *option.DaemonConfig, cnimgr cni.CNIConfigManager, log logrus.FieldLogger, quirks types.QuirksConfig) error {
 		err := info.ValidateBuggyClusterID(dcfg.IPAM, cnimgr.GetChainingMode())
 		if err != nil && quirks.AllowUnsafePolicySKBUsage {
-			cfg.Logger.WithError(err).Error("Detected clustermesh ID configuration that may cause connection impact")
+			log.WithError(err).Error("Detected clustermesh ID configuration that may cause connection impact")
 			return nil
 		}
 		return err

--- a/pkg/clustermesh/types/option.go
+++ b/pkg/clustermesh/types/option.go
@@ -112,3 +112,26 @@ func (c ClusterInfo) ValidateRemoteConfig(config CiliumClusterConfig) error {
 
 	return nil
 }
+
+// QuirksConfig allows the user to configure how Cilium behaves when a set
+// of incompatible options are configured together into the agent.
+type QuirksConfig struct {
+	// AllowUnsafePolicySKBUsage determines whether to hard-fail startup
+	// due to detection of a configuration combination that may trigger
+	// connection impact in the dataplane due to clustermesh IDs
+	// conflicting with other usage of skb->mark field. See GH-21330.
+	AllowUnsafePolicySKBUsage bool
+}
+
+var DefaultQuirks = QuirksConfig{
+	AllowUnsafePolicySKBUsage: false,
+}
+
+func (_ QuirksConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool("allow-unsafe-policy-skb-usage", false,
+		"Allow the daemon to continue to operate even if conflicting "+
+			"clustermesh ID configuration is detected which may "+
+			"impact the ability for Cilium to enforce network "+
+			"policy both within and across clusters")
+	flags.MarkHidden("allow-unsafe-policy-skb-usage")
+}


### PR DESCRIPTION
This hidden flag can allow existing users who are using a high
clustermesh ID in ENI environments to continue using it at their own
risk. Recently we added a check to startup to detect this potentially
problematic configuration and warn users, however it's now no longer
possible to run Cilium in the risky configuration. This puts users in a
tough spot of whether to run an outdated release or manually patch out
this newly introduced guardrail.

In the long term we should be able to lift the restriction around
usage of clustermesh ID in the datapath, but for now we should try to
encourage users not to configure Cilium this way while still ultimately
leaving the decision up to them about how to manage their environments.

Related: #35349
Related: #36309

To use this feature, you need the `extraConfig.allow-unsafe-policy-skb-usage` flag to be set:

```
...
cluster:
  id: 166
extraConfig:
  allow-unsafe-policy-skb-usage: "true"
```

I tested this feature using this diff:

```
diff --git a/contrib/testing/kind-common.yaml b/contrib/testing/kind-common.yaml
index 1be34fdebdde..e866a213dfbb 100644
--- a/contrib/testing/kind-common.yaml
+++ b/contrib/testing/kind-common.yaml
@@ -18,3 +18,7 @@ readinessProbe:
   failureThreshold: 9999
 startupProbe:
   failureThreshold: 9999
+cluster:
+  id: 166
+extraConfig:
+  allow-unsafe-policy-skb-usage: "true"
diff --git a/install/kubernetes/cilium/templates/validate.yaml b/install/kubernetes/cilium/templates/validate.yaml
index 37da6cd651f7..d8ce7ed1b0be 100644
--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -151,7 +151,7 @@
 {{ if and
     (ne (index .Values.extraConfig "allow-unsafe-policy-skb-usage") "true")
     (or (and (ge (int .Values.cluster.id) 128) (le (int .Values.cluster.id) 255)) (and (ge (int .Values.cluster.id) 384) (le (int .Values.cluster.id) 511)))
-    (or .Values.eni.enabled .Values.alibabacloud.enabled (eq .Values.cni.chainingMode "aws-cni")) -}}
+    (or .Values.eni.enabled .Values.alibabacloud.enabled (eq .Values.cni.chainingMode "aws-cni") true) -}}
   {{ fail "Cilium is currently affected by a bug that causes traffic matched by network policies to be incorrectly dropped when running in either ENI mode (both AWS and AlibabaCloud) or AWS VPC CNI chaining mode, if the cluster ID is 128-255 (and 384-511 when maxConnectedClusters=511). Please refer to https://github.com/cilium/cilium/issues/21330 for additional details." }}
 {{- end }}
 
diff --git a/pkg/clustermesh/types/option.go b/pkg/clustermesh/types/option.go
index fe746e82b85f..77372776eb91 100644
--- a/pkg/clustermesh/types/option.go
+++ b/pkg/clustermesh/types/option.go
@@ -69,7 +69,7 @@ func (c ClusterInfo) ValidateStrict() error {
 // ValidateBuggyClusterID returns an error if a buggy cluster ID (i.e., with the
 // 7th bit set) is used in combination with ENI IPAM mode or AWS CNI chaining.
 func (c ClusterInfo) ValidateBuggyClusterID(ipamMode, chainingMode string) error {
-       if (c.ID&0x80) != 0 && (ipamMode == ipamOption.IPAMENI || ipamMode == ipamOption.IPAMAlibabaCloud || chainingMode == "aws-cni") {
+       if (c.ID&0x80) != 0 && (ipamMode == ipamOption.IPAMENI || ipamMode == ipamOption.IPAMAlibabaCloud || chainingMode == "aws-cni" || true) {
                return errors.New("Cilium is currently affected by a bug that causes traffic matched " +
                        "by network policies to be incorrectly dropped when running in either ENI mode (both " +
                        "AWS and AlibabaCloud) or AWS VPC CNI chaining mode, if 
the cluster ID is 128-255 (and " +
```