### PR TITLE
helm: subnetTagsFilter/instanceTagsFilter should template to comma separated string

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -536,10 +536,10 @@ data:
   subnet-ids-filter: {{ .Values.eni.subnetIDsFilter | join " " | quote }}
 {{- end }}
 {{- if .Values.eni.subnetTagsFilter }}
-  subnet-tags-filter: {{ .Values.eni.subnetTagsFilter |  join " " | quote }}
+  subnet-tags-filter: {{ .Values.eni.subnetTagsFilter |  join "," | quote }}
 {{- end }}
 {{- if .Values.eni.instanceTagsFilter }}
-  instance-tags-filter: {{ .Values.eni.instanceTagsFilter | join " " | quote }}
+  instance-tags-filter: {{ .Values.eni.instanceTagsFilter | join "," | quote }}
 {{- end }}
 {{- end }}
 {{ if .Values.eni.gcInterval }}


### PR DESCRIPTION
Trying to use `subnetTagsFilter` and the generated output in the configmap was a space separated string.

In the logs of the cilium operator this message was logged:
```
time="2024-12-16T01:35:02Z" level=fatal msg="unable to parse subnet-tags-filter: 'key=value key=value' is not formatted as key=value,key1=value1" subsys=option
```

```release-note
eni.subnetTagsFilter and eni.instanceTagsFilter are now templated to comma separated string
```
