### PR TITLE
ci: datapath-verifier: also run on 6.12 kernel

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -105,6 +105,9 @@ jobs:
           - kernel: '6.6-20241212.120648'
             ci-kernel: '61'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
+          - kernel: '6.12-20241214.023514'
+            ci-kernel: '61'
+          # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
           - kernel: 'bpf-next-20241213.013358'
             ci-kernel: 'netnext'
     timeout-minutes: 60


### PR DESCRIPTION
6.12 is the latest longterm-stable kernel, give it the usual coverage in CI.

Use the 6.1 complexity configs for now, until we depend on any 6.12-specific kernel capabilities.