### PR TITLE
envoy: update to latest version

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1303,7 +1303,7 @@
    * - :spelling:ignore:`envoy.image`
      - Envoy container image.
      - object
-     - ``{"digest":"sha256:4ca99b3a1c18b1e5c498e1d1fc55b0f90e2914567ffdb12bedd9b32970501c08","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.31.4-1734096493-fff09f16c2c269b22509c86dfc1d3e8f52eb3857","useDigest":true}``
+     - ``{"digest":"sha256:85adb1b3a66182de9a1d24cc5b5240a71dd742cdc846af19589227ecf0053cfe","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.31.4-1734310891-3a8ccd54545785689e677d785b69025d1d4b33de","useDigest":true}``
    * - :spelling:ignore:`envoy.initialFetchTimeoutSeconds`
      - Time in seconds after which the initial fetch on an xDS stream is considered timed out
      - int

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -410,6 +410,20 @@ Removed Metrics
 
 Changed Metrics
 ~~~~~~~~~~~~~~~
+The metrics prefix of all Envoy NPDS (NetworkPolicy discovery service) metrics 
+has been renamed from ``envoy_cilium_policymap_<node-ip>_<node-id>_`` to ``envoy_cilium_npds_``.
+
+* ``envoy_cilium_policymap_<node-ip>_<node-id>_control_plane_rate_limit_enforced`` -> ``envoy_cilium_npds_control_plane_rate_limit_enforced``
+* ``envoy_cilium_policymap_<node-ip>_<node-id>_control_plane_connected_state`` -> ``envoy_cilium_npds_control_plane_connected_state``
+* ``envoy_cilium_policymap_<node-ip>_<node-id>_control_plane_pending_requests`` -> ``envoy_cilium_npds_control_plane_pending_requests``
+* ``envoy_cilium_policymap_<node-ip>_<node-id>_init_fetch_timeout`` ->  ``envoy_cilium_npds_init_fetch_timeout``
+* ``envoy_cilium_policymap_<node-ip>_<node-id>_update_attempt`` -> ``envoy_cilium_npds_update_attempt``
+* ``envoy_cilium_policymap_<node-ip>_<node-id>_update_failure`` -> ``envoy_cilium_npds_update_failure``
+* ``envoy_cilium_policymap_<node-ip>_<node-id>_update_rejected`` -> ``envoy_cilium_npds_update_rejected``
+* ``envoy_cilium_policymap_<node-ip>_<node-id>_update_success`` -> ``envoy_cilium_npds_update_success``
+* ``envoy_cilium_policymap_<node-ip>_<node-id>_update_time`` -> ``envoy_cilium_npds_update_time``
+* ``envoy_cilium_policymap_<node-ip>_<node-id>_update_duration`` -> ``envoy_cilium_npds_update_duration``
+* ``envoy_cilium_policymap_<node-ip>_<node-id>_version`` -> ``envoy_cilium_npds_version``
 
 Deprecated Metrics
 ~~~~~~~~~~~~~~~~~~

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:ce95aa5782dcc3e841c09cc61
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-ARG CILIUM_ENVOY_IMAGE=quay.io/cilium/cilium-envoy:v1.31.4-1734096493-fff09f16c2c269b22509c86dfc1d3e8f52eb3857@sha256:4ca99b3a1c18b1e5c498e1d1fc55b0f90e2914567ffdb12bedd9b32970501c08
+ARG CILIUM_ENVOY_IMAGE=quay.io/cilium/cilium-envoy:v1.31.4-1734310891-3a8ccd54545785689e677d785b69025d1d4b33de@sha256:85adb1b3a66182de9a1d24cc5b5240a71dd742cdc846af19589227ecf0053cfe
 
 FROM ${CILIUM_ENVOY_IMAGE} AS cilium-envoy
 

--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -37,8 +37,8 @@ export CILIUM_NODEINIT_DIGEST:=sha256:8d7b41c4ca45860254b3c19e20210462ef89479bb6
 
 # renovate: datasource=docker
 export CILIUM_ENVOY_REPO:=quay.io/cilium/cilium-envoy
-export CILIUM_ENVOY_VERSION:=v1.31.4-1734096493-fff09f16c2c269b22509c86dfc1d3e8f52eb3857
-export CILIUM_ENVOY_DIGEST:=sha256:4ca99b3a1c18b1e5c498e1d1fc55b0f90e2914567ffdb12bedd9b32970501c08
+export CILIUM_ENVOY_VERSION:=v1.31.4-1734310891-3a8ccd54545785689e677d785b69025d1d4b33de
+export CILIUM_ENVOY_DIGEST:=sha256:85adb1b3a66182de9a1d24cc5b5240a71dd742cdc846af19589227ecf0053cfe
 
 # renovate: datasource=docker
 export HUBBLE_UI_BACKEND_REPO:=quay.io/cilium/hubble-ui-backend

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -375,7 +375,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.httpRetryCount | int | `3` | Maximum number of retries for each HTTP request |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:4ca99b3a1c18b1e5c498e1d1fc55b0f90e2914567ffdb12bedd9b32970501c08","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.31.4-1734096493-fff09f16c2c269b22509c86dfc1d3e8f52eb3857","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:85adb1b3a66182de9a1d24cc5b5240a71dd742cdc846af19589227ecf0053cfe","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.31.4-1734310891-3a8ccd54545785689e677d785b69025d1d4b33de","useDigest":true}` | Envoy container image. |
 | envoy.initialFetchTimeoutSeconds | int | `30` | Time in seconds after which the initial fetch on an xDS stream is considered timed out |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2336,9 +2336,9 @@ envoy:
     # @schema
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.31.4-1734096493-fff09f16c2c269b22509c86dfc1d3e8f52eb3857"
+    tag: "v1.31.4-1734310891-3a8ccd54545785689e677d785b69025d1d4b33de"
     pullPolicy: "Always"
-    digest: "sha256:4ca99b3a1c18b1e5c498e1d1fc55b0f90e2914567ffdb12bedd9b32970501c08"
+    digest: "sha256:85adb1b3a66182de9a1d24cc5b5240a71dd742cdc846af19589227ecf0053cfe"
     useDigest: true
   # -- Additional containers added to the cilium Envoy DaemonSet.
   extraContainers: []


### PR DESCRIPTION
update & document changed Envoy NPDS metrics in upgrade guide
This commit documents the changed Envoy NPDS related metrics
in the upgrade guide.

The reason for the change is that in v1.17 new metrics regarding
policy enforcement in the Cilium Proxy have been introduced
(`envoy_cilium_policy_`). They have similar metric names and would
have been difficult to separate from the NPDS related ones.

Related Cilium Proxy PR: https://github.com/cilium/proxy/pull/1058
