### PR TITLE
vendor: Bump StateDB to v0.3.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/cilium/linters v0.1.0
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20241115112946-fb67566cbd95
-	github.com/cilium/statedb v0.3.4
+	github.com/cilium/statedb v0.3.5
 	github.com/cilium/stream v0.0.0-20241203114243-53c3e5d79744
 	github.com/cilium/workerpool v1.2.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y
 github.com/cilium/lumberjack/v2 v2.4.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20241115112946-fb67566cbd95 h1:iMn0++U3CDqoDINY5JLOhlPcjj3kW/xCmse+d+EZkOM=
 github.com/cilium/proxy v0.0.0-20241115112946-fb67566cbd95/go.mod h1:/UoCz3gByKwF5gCHFMUhwmIN5/Pgmb8LTIrfBlmjGCo=
-github.com/cilium/statedb v0.3.4 h1:nb5qNntmtaNljJD1r2s5zGOs62LP87AqLhFKIZH2rRE=
-github.com/cilium/statedb v0.3.4/go.mod h1:hpcYZXvrOhmdBd02/N/WqxSjbeO2HYG8l3Z2fGq6Ioo=
+github.com/cilium/statedb v0.3.5 h1:/lN7noYjC+JP6+fII7dhUNRS2FuLrlE0CtNOtuBtI9c=
+github.com/cilium/statedb v0.3.5/go.mod h1:n2lNVxi8vz5Up1Y1rRD++aQP2izQA932fUwTkedKSV0=
 github.com/cilium/stream v0.0.0-20241203114243-53c3e5d79744 h1:f+CgYUy2YyZ2EX31QSqf3vwFiJJQSAMIQLn4d3QQYno=
 github.com/cilium/stream v0.0.0-20241203114243-53c3e5d79744/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.2.0 h1:Wc2iOPTvCgWKQXeq4L5tnx4QFEI+z5q1+bSpSS0cnAY=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -558,7 +558,7 @@ github.com/cilium/proxy/go/envoy/type/tracing/v3
 github.com/cilium/proxy/go/envoy/type/v3
 github.com/cilium/proxy/go/envoy/watchdog/v3
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.3.4
+# github.com/cilium/statedb v0.3.5
 ## explicit; go 1.23
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
This brings in the refactored db/... commands that use the new way of defining flags that significantly improves the produced 'help' output. The list of flags is no longer maintained by hand and the verbose help now lists details of the flags (before this was only available with "<cmd> -h"). The pflag package is also now used instead of flag which gives us a more usual GNU-style arguments in the same style as cilium-agent/ cilium-dbg etc.

Before:
```
> help db/prefix
[stdout]
db/prefix [-o=<file>] [-columns=col1,...] [-format={table*,yaml,json}] [-index=<index>] table key
        Query table by prefix

        Show all objects that start with the given key.
```

After:
```
> help db/prefix
[stdout]
db/prefix [-fio] [--columns=stringSlice] [--delete] [--format=string] [--index=string] [--out=string] table key
        Query table by prefix

        Show all objects that start with the given key.

        Flags:
              --columns strings   Columns to write
              --delete            Delete all matching objects
          -f, --format string     Format to write in (table, yaml or json) (default "table")
          -i, --index string      Index to query
          -o, --out string        File to write to instead of stdout
```
