### PR TITLE
gh: e2e-upgrade: add coverage for 6.6 kernel

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -101,7 +101,7 @@ jobs:
       job_name: 'Setup & Test'
     strategy:
       fail-fast: false
-      max-parallel: 25
+      max-parallel: 28
       matrix:
         include:
           - name: '1'
@@ -420,6 +420,43 @@ jobs:
             endpoint-routes: 'true'
             ingress-controller: 'true'
             skip-upgrade: 'true'
+
+          - name: '26'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: '6.6-20241212.120648'
+            kube-proxy: 'none'
+            kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
+            tunnel: 'vxlan'
+            lb-mode: 'snat'
+            egress-gateway: 'true'
+            ingress-controller: 'true'
+
+          - name: '27'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: '6.6-20241212.120648'
+            kube-proxy: 'none'
+            kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
+            tunnel: 'disabled'
+            lb-mode: 'snat'
+            egress-gateway: 'true'
+            ingress-controller: 'true'
+
+          - name: '28'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: '6.6-20241212.120648'
+            kube-proxy: 'none'
+            kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
+            tunnel: 'disabled'
+            lb-mode: 'snat'
+            endpoint-routes: 'true'
+            egress-gateway: 'true'
+            ingress-controller: 'true'
 
           # Example of a feature that is being introduced, and we want to test
           # it without performing an upgrade, we use skip-upgrade: 'true'


### PR DESCRIPTION
Introduce a number of configs to run e2e tests on the 6.6 LTS kernel.

I tried to cover the most relevant datapath configs (overlay routing, and native routing with/without endpoint routes), along with some optional features that increase test coverage (EGW, Ingress). We can add other optional features as we identify them.