### PR TITLE
bpf: nat: skip snat when using iptables masquerade

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -475,17 +475,21 @@ snat_v4_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 }
 
 static __always_inline bool
-snat_v4_nat_can_skip(const struct ipv4_nat_target *target,
-		     const struct ipv4_ct_tuple *tuple)
+snat_v4_nat_can_skip(const struct ipv4_nat_target *target __maybe_unused,
+		     const struct ipv4_ct_tuple *tuple __maybe_unused)
 {
-	__u16 sport = bpf_ntohs(tuple->sport);
+	__u16 sport __maybe_unused = bpf_ntohs(tuple->sport);
 
 #if defined(ENABLE_EGRESS_GATEWAY_COMMON) && defined(IS_BPF_HOST)
 	if (target->egress_gateway)
 		return false;
 #endif
 
+#ifndef ENABLE_IPTABLES_MASQUERADE_IPV4
 	return (!target->from_local_endpoint && sport < NAT_MIN_EGRESS);
+#else
+    return true;
+#endif
 }
 
 static __always_inline bool
@@ -1380,12 +1384,16 @@ snat_v6_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off, int l4
 }
 
 static __always_inline bool
-snat_v6_nat_can_skip(const struct ipv6_nat_target *target,
-		     const struct ipv6_ct_tuple *tuple)
+snat_v6_nat_can_skip(const struct ipv6_nat_target *target __maybe_unused,
+		     const struct ipv6_ct_tuple *tuple __maybe_unused)
 {
-	__u16 sport = bpf_ntohs(tuple->sport);
+	__u16 sport __maybe_unused = bpf_ntohs(tuple->sport);
 
+#ifndef ENABLE_IPTABLES_MASQUERADE_IPV6
 	return (!target->from_local_endpoint && sport < NAT_MIN_EGRESS);
+#else
+	return true;
+#endif
 }
 
 static __always_inline bool

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -684,6 +684,13 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 					fw.WriteString(FmtDefineAddress("IPV6_SNAT_EXCLUSION_DST_CIDR_MASK", excludeCIDR.Mask))
 				}
 			}
+		} else {
+			if option.Config.EnableIPv4Masquerade {
+				cDefinesMap["ENABLE_IPTABLES_MASQUERADE_IPV4"] = "1"
+			}
+			if option.Config.EnableIPv6Masquerade {
+				cDefinesMap["ENABLE_IPTABLES_MASQUERADE_IPV6"] = "1"
+			}
 		}
 
 		ctmap.WriteBPFMacros(fw, nil)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

When using iptables masquerade, the source address is already nat-ed by iptables. So, we should skip snat when using iptables masquerade. If we don't skip snat, the source address is nat-ed twice. It also unnecessarily occupies entry in the SNAT_MAPPING map. And if it exceeds SNAT_COLLISION_RETRIES, it leads to connection failures.

Fixes: #36572 