### PR TITLE
v1.16 Backports 2024-12-16

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -450,9 +450,9 @@ jobs:
 
           # Example of a feature that is being introduced, and we want to test
           # it without performing an upgrade, we use skip-upgrade: 'true'
-          # - name: '27'
-          #   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-          #   kernel: 'bpf-20241218.004849'
+          # - name: '23'
+          #   # <insert renovate dependency descriptor here>
+          #   kernel: 'bpf-20241206.013345'
           #   misc: 'bpf.datapathMode=netkit-l2,bpf.masquerade=true'
           #   skip-upgrade: 'true'
 

--- a/Documentation/observability/hubble/configuration/tls.rst
+++ b/Documentation/observability/hubble/configuration/tls.rst
@@ -362,11 +362,11 @@ Now try to query the Hubble server without providing any client certificate:
 .. code-block:: shell-session
 
     $ kubectl exec -it -n kube-system deployment/hubble-cli -- \
-    hubble observe --server ${IP?}:4244 \
+    hubble observe --server tls://${IP?}:4244 \
         --tls-server-name ${SERVERNAME?} \
         --tls-ca-cert-files /var/lib/hubble-relay/tls/hubble-server-ca.crt
 
-    failed to connect to '172.18.0.2:4244': context deadline exceeded: connection error: desc = "transport: authentication handshake failed: mTLS client certificate requested, but not provided"
+    failed to connect to '172.18.0.2:4244': context deadline exceeded: connection error: desc = "error reading server preface: remote error: tls: certificate requiredd"
     command terminated with exit code 1
 
 You can also try to connect without TLS:

--- a/Documentation/operations/performance/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/performance/scalability/identity-relevant-labels.rst
@@ -132,6 +132,7 @@ evaluating Cilium identities:
 - reserved:.*
 - io\.kubernetes\.pod\.namespace
 - io\.cilium\.k8s.namespace\.labels
+- io\.cilium\.k8s\.policy\.cluster
 - app\.kubernetes\.io
 
 Note that ``k8s:io\.kubernetes\.pod\.namespace`` is already included in default

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -545,8 +545,8 @@ toCIDR
   the respective destination endpoints.
 
 toCIDRSet
-  List of destination prefixes/CIDRs that are allowed to talk to all endpoints
-  selected by the ``endpointSelector``, along with an optional list of
+  List of destination prefixes/CIDRs that endpoints selected by
+  ``endpointSelector`` are allowed to talk to, along with an optional list of
   prefixes/CIDRs per source prefix/CIDR that are subnets of the destination
   prefix/CIDR to which communication is not allowed.
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -498,6 +498,14 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	option.BindEnv(vp, option.K8sServiceCacheSize)
 	flags.MarkHidden(option.K8sServiceCacheSize)
 
+	flags.Int(option.K8sServiceDebounceBufferSize, 128, "Number of distinct services to buffer for event debouncing")
+	option.BindEnv(vp, option.K8sServiceDebounceBufferSize)
+	flags.MarkHidden(option.K8sServiceDebounceBufferSize)
+
+	flags.Duration(option.K8sServiceDebounceWaitTime, 200*time.Millisecond, "The amount of time to wait to debounce service events")
+	option.BindEnv(vp, option.K8sServiceDebounceWaitTime)
+	flags.MarkHidden(option.K8sServiceDebounceWaitTime)
+
 	flags.String(option.K8sWatcherEndpointSelector, defaults.K8sWatcherEndpointSelector, "K8s endpoint watcher will watch for these k8s endpoints")
 	option.BindEnv(vp, option.K8sWatcherEndpointSelector)
 

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -34,10 +34,12 @@ ARG MODIFIERS
 # as that will mess with caching for incremental builds!
 #
 WORKDIR /go/src/github.com/cilium/cilium
+# We must override NOSTRIP=1 to ensure binaries include debug symbols for extraction. They will be stripped subsequently
+# in accordance with the supplied/default NOSTRIP setting. See "Extract debug symbols" below.
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
     --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/go/pkg \
-    make GOARCH=${TARGETARCH} DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} PKG_BUILD=1 ${MODIFIERS} \
+    make GOARCH=${TARGETARCH} DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} PKG_BUILD=1 ${MODIFIERS} NOSTRIP=1 \
     build-container install-container-binary
 
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -48,11 +48,11 @@ func k8sServiceHandler(ctx context.Context, cinfo cmtypes.ClusterInfo, shared bo
 			"endpoints":            event.Endpoints.String(),
 			"old-service":          event.OldService.String(),
 			"old-endpoints":        event.OldEndpoints.String(),
-			"shared":               event.Service.Shared,
+			"shared":               svc.Shared,
 		})
 		scopedLog.Debug("Kubernetes service definition changed")
 
-		if shared && !event.Service.Shared {
+		if shared && !svc.Shared {
 			// The annotation may have been added, delete an eventual existing service
 			kvs.DeleteKey(ctx, &svc)
 			return

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -311,7 +311,7 @@ func TestClusterMeshServicesUpdate(t *testing.T) {
 
 	require.NoError(t, kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName+"2"))
 	s.expectEvent(t, k8s.DeleteService, svcID, func(c *assert.CollectT, event k8s.ServiceEvent) {
-		assert.Empty(c, event.OldEndpoints.Backends)
+		assert.Contains(c, event.OldEndpoints.Backends, cmtypes.MustParseAddrCluster("90.0.185.196"))
 	})
 
 	swgSvcs.Stop()

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -311,7 +311,7 @@ func TestClusterMeshServicesUpdate(t *testing.T) {
 
 	require.NoError(t, kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName+"2"))
 	s.expectEvent(t, k8s.DeleteService, svcID, func(c *assert.CollectT, event k8s.ServiceEvent) {
-		assert.Len(c, event.Endpoints.Backends, 0)
+		assert.Empty(c, event.OldEndpoints.Backends)
 	})
 
 	swgSvcs.Stop()

--- a/pkg/hubble/parser/agent/parser_test.go
+++ b/pkg/hubble/parser/agent/parser_test.go
@@ -284,6 +284,7 @@ func TestDecodeAgentEvent(t *testing.T) {
 						Port: 7077,
 					},
 				},
+				0, // backends omitted
 				"ClusterIP",
 				"myTrafficPolicyExt",
 				"myTrafficPolicyInt",

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -415,11 +415,11 @@ func (s *ServiceCache) DeleteService(k8sSvc *slim_corev1.Service, swg *lock.Stop
 		s.metrics.DelService(oldService)
 		swg.Add()
 		s.emitEvent(ServiceEvent{
-			Action:    DeleteService,
-			ID:        svcID,
-			Service:   oldService,
-			Endpoints: endpoints,
-			SWG:       swg,
+			Action:       DeleteService,
+			ID:           svcID,
+			OldService:   oldService,
+			OldEndpoints: endpoints,
+			SWG:          swg,
 		})
 	}
 }
@@ -813,6 +813,7 @@ func (s *ServiceCache) mergeExternalServiceDeleteLocked(service *serviceStore.Cl
 				Action:       UpdateService,
 				ID:           id,
 				Service:      svc,
+				OldService:   svc,
 				Endpoints:    endpoints,
 				OldEndpoints: oldEPs,
 				SWG:          swg,
@@ -821,6 +822,8 @@ func (s *ServiceCache) mergeExternalServiceDeleteLocked(service *serviceStore.Cl
 			if !serviceReady {
 				delete(s.services, id)
 				event.Action = DeleteService
+				event.Service = nil
+				event.Endpoints = nil
 			}
 
 			s.emitEvent(event)
@@ -877,11 +880,11 @@ func (s *ServiceCache) MergeClusterServiceDelete(service *serviceStore.ClusterSe
 	if ok {
 		swg.Add()
 		s.emitEvent(ServiceEvent{
-			Action:    DeleteService,
-			ID:        id,
-			Service:   svc,
-			Endpoints: endpoints,
-			SWG:       swg,
+			Action:       DeleteService,
+			ID:           id,
+			OldService:   svc,
+			OldEndpoints: endpoints,
+			SWG:          swg,
 		})
 	}
 }

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -183,7 +183,7 @@ func (k *K8sServiceWatcher) k8sServiceHandler() {
 		case k8s.UpdateService:
 			k.addK8sSVCs(event.ID, event.OldService, svc, event.Endpoints)
 		case k8s.DeleteService:
-			k.delK8sSVCs(event.ID, event.Service)
+			k.delK8sSVCs(event.ID, event.OldService)
 		}
 	}
 	for {

--- a/pkg/k8s/watchers/service_test.go
+++ b/pkg/k8s/watchers/service_test.go
@@ -4,12 +4,14 @@
 package watchers
 
 import (
+	"os"
 	"sort"
 	"testing"
 
 	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
@@ -20,7 +22,16 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
+
+func TestMain(m *testing.M) {
+	// Reduce debouncing duration to speed up the tests.
+	option.Config.K8sServiceDebounceWaitTime = time.Millisecond
+	option.Config.K8sServiceDebounceBufferSize = 128
+
+	os.Exit(m.Run())
+}
 
 type fakeSvcManager struct {
 	OnDeleteService func(frontend loadbalancer.L3n4Addr) (bool, error)
@@ -336,18 +347,27 @@ func Test_addK8sSVCs_ClusterIP(t *testing.T) {
 	}
 
 	go svcWatcher.k8sServiceHandler()
-	swg := lock.NewStoppableWaitGroup()
 
+	swg := lock.NewStoppableWaitGroup()
 	k8sSvcCache.UpdateService(k8sSvc, swg)
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
+	swg.Stop()
+	swg.Wait()
+
+	// NOTE: Due to the service event debouncing of the service events we use a new [StoppableWaitGroup]
+	// for each group of changes we want to be processed without coalescing.
+
+	swg = lock.NewStoppableWaitGroup()
 	// Running a 2nd update should also trigger a new upsert service
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
 	// Running a 3rd update should also not trigger anything because the
 	// endpoints are the same
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
+	swg.Stop()
+	swg.Wait()
 
+	swg = lock.NewStoppableWaitGroup()
 	k8sSvcCache.DeleteService(k8sSvc, swg)
-
 	swg.Stop()
 	swg.Wait()
 	require.Equal(t, len(upsert1stWanted)+len(upsert2ndWanted), svcUpsertManagerCalls)
@@ -468,14 +488,18 @@ func TestChangeSVCPort(t *testing.T) {
 	}
 
 	go svcWatcher.k8sServiceHandler()
-	swg := lock.NewStoppableWaitGroup()
 
+	swg := lock.NewStoppableWaitGroup()
 	k8sSvcCache.UpdateService(k8sSvc, swg)
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
-	k8sSvcCache.UpdateService(k8sSvcChanged, swg)
-
 	swg.Stop()
 	swg.Wait()
+
+	swg = lock.NewStoppableWaitGroup()
+	k8sSvcCache.UpdateService(k8sSvcChanged, swg)
+	swg.Stop()
+	swg.Wait()
+
 	require.Equal(t, 2, svcUpsertManagerCalls) // Add and Update events
 	require.EqualValues(t, upsertsWanted, upserts)
 }
@@ -933,21 +957,30 @@ func Test_addK8sSVCs_NodePort(t *testing.T) {
 
 	k8sSvcCache.UpdateService(k8sSvc, swg)
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
+
+	swg.Stop()
+	swg.Wait()
+
+	swg = lock.NewStoppableWaitGroup()
+
 	// Running a 2nd update should also trigger a new upsert service
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
 	// Running a 3rd update should also not trigger anything because the
 	// endpoints are the same
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
 
-	k8sSvcCache.DeleteService(k8sSvc, swg)
-
 	swg.Stop()
 	swg.Wait()
 	require.Equal(t, len(upsert1stWanted)+len(upsert2ndWanted), svcUpsertManagerCalls)
-	require.Equal(t, len(del1stWanted), svcDeleteManagerCalls)
-
 	require.EqualValues(t, upsert1stWanted, upsert1st)
 	require.EqualValues(t, upsert2ndWanted, upsert2nd)
+
+	swg = lock.NewStoppableWaitGroup()
+	k8sSvcCache.DeleteService(k8sSvc, swg)
+	swg.Stop()
+	swg.Wait()
+	require.Equal(t, len(del1stWanted), svcDeleteManagerCalls)
+
 	require.EqualValues(t, del1stWanted, del1st)
 }
 
@@ -1224,15 +1257,18 @@ func Test_addK8sSVCs_GH9576_1(t *testing.T) {
 	}
 
 	go svcWatcher.k8sServiceHandler()
-	swg := lock.NewStoppableWaitGroup()
 
+	swg := lock.NewStoppableWaitGroup()
 	k8sSvcCache.UpdateService(k8sSvc1stApply, swg)
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
-
-	k8sSvcCache.UpdateService(k8sSvc2ndApply, swg)
-
 	swg.Stop()
 	swg.Wait()
+
+	swg = lock.NewStoppableWaitGroup()
+	k8sSvcCache.UpdateService(k8sSvc2ndApply, swg)
+	swg.Stop()
+	swg.Wait()
+
 	require.Equal(t, wantSvcUpsertManagerCalls, svcUpsertManagerCalls)
 	require.Equal(t, wantSvcDeleteManagerCalls, svcDeleteManagerCalls)
 
@@ -1512,12 +1548,15 @@ func Test_addK8sSVCs_GH9576_2(t *testing.T) {
 	}
 
 	go svcWatcher.k8sServiceHandler()
-	swg := lock.NewStoppableWaitGroup()
 
+	swg := lock.NewStoppableWaitGroup()
 	k8sSvcCache.UpdateService(k8sSvc1stApply, swg)
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
-	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
+	swg.Stop()
+	swg.Wait()
 
+	swg = lock.NewStoppableWaitGroup()
+	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
 	swg.Stop()
 	swg.Wait()
 
@@ -2414,22 +2453,32 @@ func Test_addK8sSVCs_ExternalIPs(t *testing.T) {
 	}
 
 	go svcWatcher.k8sServiceHandler()
-	swg := lock.NewStoppableWaitGroup()
 
+	swg := lock.NewStoppableWaitGroup()
 	k8sSvcCache.UpdateService(svc1stApply, swg)
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
+	swg.Stop()
+	swg.Wait()
+
+	swg = lock.NewStoppableWaitGroup()
 	// Running a 2nd update should also trigger a new upsert service
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
 	// Running a 3rd update should also not trigger anything because the
 	// endpoints are the same
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
-
-	k8sSvcCache.UpdateService(svc2ndApply, swg)
-
-	k8sSvcCache.DeleteService(svc1stApply, swg)
-
 	swg.Stop()
 	swg.Wait()
+
+	swg = lock.NewStoppableWaitGroup()
+	k8sSvcCache.UpdateService(svc2ndApply, swg)
+	swg.Stop()
+	swg.Wait()
+
+	swg = lock.NewStoppableWaitGroup()
+	k8sSvcCache.DeleteService(svc1stApply, swg)
+	swg.Stop()
+	swg.Wait()
+
 	require.Equal(t, len(upsert1stWanted)+len(upsert2ndWanted)+len(upsert3rdWanted), svcUpsertManagerCalls)
 	require.Equal(t, len(del1stWanted)+len(del2ndWanted), svcDeleteManagerCalls)
 
@@ -2539,16 +2588,188 @@ func TestHeadless(t *testing.T) {
 	}
 
 	go svcWatcher.k8sServiceHandler()
-	swg := lock.NewStoppableWaitGroup()
 
+	swg := lock.NewStoppableWaitGroup()
 	k8sSvcCache.UpdateService(k8sSvc, swg)
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
-	k8sSvcCache.UpdateService(k8sSvcChanged, swg)
-
 	swg.Stop()
 	swg.Wait()
+
+	swg = lock.NewStoppableWaitGroup()
+	k8sSvcCache.UpdateService(k8sSvcChanged, swg)
+	swg.Stop()
+	swg.Wait()
+
 	require.Equal(t, len(upsertsWanted), svcUpsertManagerCalls)
 	require.Equal(t, len(delstWanted), svcDeleteManagerCalls)
 	require.EqualValues(t, upsertsWanted, upserts)
 	require.EqualValues(t, delstWanted, delst)
+}
+
+func TestServiceEventDebounce(t *testing.T) {
+	oldTime := option.Config.K8sServiceDebounceWaitTime
+	defer func() {
+		option.Config.K8sServiceDebounceWaitTime = oldTime
+	}()
+	// Use longer wait time to trigger coalescing. The asserts in this test must
+	// retry if needed and not rely on coalescing to always happen.
+	option.Config.K8sServiceDebounceWaitTime = 20 * time.Millisecond
+
+	ep := &slim_corev1.Endpoints{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+		},
+		Subsets: []slim_corev1.EndpointSubset{
+			{
+				Addresses: []slim_corev1.EndpointAddress{{IP: "10.0.0.2"}},
+				Ports: []slim_corev1.EndpointPort{
+					{
+						Name:     "http",
+						Port:     8080,
+						Protocol: slim_corev1.ProtocolTCP,
+					},
+				},
+			},
+		},
+	}
+
+	upserts, deletes := 0, 0
+	fes := sets.New[loadbalancer.L3n4Addr]()
+	var lastDelete *loadbalancer.L3n4Addr
+
+	svcManager := &fakeSvcManager{
+		OnUpsertService: func(p *loadbalancer.SVC) (bool, loadbalancer.ID, error) {
+			upserts++
+			fes.Insert(p.Frontend.L3n4Addr)
+			return false, 0, nil
+		},
+		OnDeleteService: func(fe loadbalancer.L3n4Addr) (b bool, e error) {
+			deletes++
+			fes.Delete(fe)
+			lastDelete = &fe
+			return true, nil
+		},
+	}
+
+	db, nodeAddrs := newDB(t)
+	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs, k8s.NewSVCMetricsNoop())
+	svcWatcher := &K8sServiceWatcher{
+		k8sSvcCache: k8sSvcCache,
+		svcManager:  svcManager,
+	}
+
+	go svcWatcher.k8sServiceHandler()
+
+	k8sSvc := &slim_corev1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		Spec: slim_corev1.ServiceSpec{
+			ClusterIP:  "127.0.0.1",
+			ClusterIPs: []string{"127.0.0.1"},
+			Type:       slim_corev1.ServiceTypeClusterIP,
+			Ports: []slim_corev1.ServicePort{
+				{
+					Name:     "http",
+					Protocol: slim_corev1.ProtocolTCP,
+					Port:     80,
+				},
+			},
+		},
+	}
+	setClusterIP := func(ip string) {
+		k8sSvc.Spec.ClusterIP = ip
+		k8sSvc.Spec.ClusterIPs = []string{ip}
+	}
+
+	// Test that coalescing will mark multiple SWGs as done.
+	swg1, swg2, swg3 := lock.NewStoppableWaitGroup(),
+		lock.NewStoppableWaitGroup(),
+		lock.NewStoppableWaitGroup()
+
+	k8sSvcCache.UpdateService(k8sSvc, swg1)
+	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep), swg1)
+
+	swg1.Stop()
+	swg1.Wait()
+
+	setClusterIP("127.0.0.2")
+	k8sSvcCache.UpdateService(k8sSvc, swg2)
+	setClusterIP("127.0.0.3")
+	k8sSvcCache.UpdateService(k8sSvc, swg3)
+	k8sSvcCache.DeleteService(k8sSvc, swg3)
+	setClusterIP("127.0.0.4")
+	k8sSvcCache.UpdateService(k8sSvc, swg3)
+	k8sSvcCache.DeleteService(k8sSvc, swg3)
+
+	// All SWGs should be marked done even when they're collapsed.
+	for _, swg := range []*lock.StoppableWaitGroup{swg2, swg3} {
+		swg.Stop()
+		swg.Wait()
+	}
+
+	require.NotZero(t, upserts, "upserts")
+	require.NotZero(t, deletes, "deletes")
+	require.Empty(t, fes)
+
+	// Test coalescing of update and deletes within single buffer. Since
+	// this requires the coalescing to really happen, we try this multiple
+	// times to make this non-flaky. Looking forward to the testing/synctest
+	// package when we don't need this sort of thing anymore.
+	for range 20 {
+		upserts, deletes = 0, 0
+		swg := lock.NewStoppableWaitGroup()
+		k8sSvcCache.UpdateService(k8sSvc, swg)
+		k8sSvcCache.DeleteService(k8sSvc, swg)
+		swg.Stop()
+		swg.Wait()
+		if upserts == 0 && deletes == 0 {
+			break
+		}
+	}
+	// The update and delete cancelled each other out.
+	require.Zero(t, upserts, "upserts")
+	require.Zero(t, deletes, "deletes")
+	require.Empty(t, fes)
+
+	// Test that multiple updates followed by a delete will be coalesced into
+	// a single delete of the original service.
+	for range 20 {
+		// Start with a service with IP 127.0.0.5
+		swg := lock.NewStoppableWaitGroup()
+		setClusterIP("127.0.0.5")
+		k8sSvcCache.UpdateService(k8sSvc, swg)
+		swg.Stop()
+		swg.Wait()
+
+		// Update the service multiple times and finally delete it.
+		// These should get coalesced into a single delete.
+		upserts, deletes = 0, 0
+		swg = lock.NewStoppableWaitGroup()
+		k8sSvcCache.UpdateService(k8sSvc, swg)
+		setClusterIP("127.0.0.6")
+		k8sSvcCache.UpdateService(k8sSvc, swg)
+		setClusterIP("127.0.0.7")
+		k8sSvcCache.UpdateService(k8sSvc, swg)
+		setClusterIP("127.0.0.8")
+		k8sSvcCache.UpdateService(k8sSvc, swg)
+		k8sSvcCache.DeleteService(k8sSvc, swg)
+		swg.Stop()
+		swg.Wait()
+
+		if lastDelete != nil && lastDelete.AddrCluster.String() == "127.0.0.5" {
+			break
+		}
+	}
+	require.Zero(t, upserts, "upserts")
+	require.Equal(t, 1, deletes, "deletes")
+	require.Empty(t, fes)
+	require.NotNil(t, lastDelete)
+	require.Equal(t, "127.0.0.5", lastDelete.AddrCluster.String())
+
 }

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -413,6 +413,9 @@ func (*LBBPFMap) UpdateSourceRanges(revNATID uint16, prevSourceRanges []*cidr.CI
 	}
 
 	for _, prevCIDR := range prevSourceRanges {
+		if ip.IsIPv6(prevCIDR.IP) == !ipv6 {
+			continue
+		}
 		if _, found := srcRangeMap[prevCIDR.String()]; !found {
 			if err := m.Delete(srcRangeKey(prevCIDR, revNATID, ipv6)); err != nil {
 				return err

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -417,9 +417,7 @@ func (*LBBPFMap) UpdateSourceRanges(revNATID uint16, prevSourceRanges []*cidr.CI
 			continue
 		}
 		if _, found := srcRangeMap[prevCIDR.String()]; !found {
-			if err := m.Delete(srcRangeKey(prevCIDR, revNATID, ipv6)); err != nil {
-				return err
-			}
+			m.Delete(srcRangeKey(prevCIDR, revNATID, ipv6))
 		} else {
 			delete(srcRangeMap, prevCIDR.String())
 		}

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -401,12 +401,9 @@ func (*LBBPFMap) UpdateSourceRanges(revNATID uint16, prevSourceRanges []*cidr.CI
 
 	srcRangeMap := map[string]*cidr.CIDR{}
 	for _, cidr := range sourceRanges {
-		// k8s api server does not catch the IP family mismatch, so we need to catch it here
+		// k8s api server does not catch the IP family mismatch, so we need
+		// to catch it here and below.
 		if ip.IsIPv6(cidr.IP) == !ipv6 {
-			log.WithFields(logrus.Fields{
-				logfields.ServiceID: revNATID,
-				logfields.CIDR:      cidr,
-			}).Warn("Source range's IP family does not match with the LB's. Ignoring the source range CIDR")
 			continue
 		}
 		srcRangeMap[cidr.String()] = cidr

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -455,8 +455,9 @@ type ServiceUpsertNotificationAddr struct {
 type ServiceUpsertNotification struct {
 	ID uint32 `json:"id"`
 
-	Frontend ServiceUpsertNotificationAddr   `json:"frontend-address"`
-	Backends []ServiceUpsertNotificationAddr `json:"backend-addresses"`
+	Frontend           ServiceUpsertNotificationAddr   `json:"frontend-address"`
+	Backends           []ServiceUpsertNotificationAddr `json:"backend-addresses"`
+	NumBackendsOmitted int                             `json:"num-backends-omitted,omitempty"`
 
 	Type string `json:"type,omitempty"`
 	// Deprecated: superseded by ExtTrafficPolicy.
@@ -473,18 +474,20 @@ func ServiceUpsertMessage(
 	id uint32,
 	frontend ServiceUpsertNotificationAddr,
 	backends []ServiceUpsertNotificationAddr,
+	numBackendsOmitted int,
 	svcType, svcExtTrafficPolicy, svcIntTrafficPolicy, svcName, svcNamespace string,
 ) AgentNotifyMessage {
 	notification := ServiceUpsertNotification{
-		ID:               id,
-		Frontend:         frontend,
-		Backends:         backends,
-		Type:             svcType,
-		TrafficPolicy:    svcExtTrafficPolicy,
-		ExtTrafficPolicy: svcExtTrafficPolicy,
-		IntTrafficPolicy: svcIntTrafficPolicy,
-		Name:             svcName,
-		Namespace:        svcNamespace,
+		ID:                 id,
+		Frontend:           frontend,
+		Backends:           backends,
+		NumBackendsOmitted: numBackendsOmitted,
+		Type:               svcType,
+		TrafficPolicy:      svcExtTrafficPolicy,
+		ExtTrafficPolicy:   svcExtTrafficPolicy,
+		IntTrafficPolicy:   svcIntTrafficPolicy,
+		Name:               svcName,
+		Namespace:          svcNamespace,
 	}
 
 	return AgentNotifyMessage{

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -211,6 +211,13 @@ const (
 	// K8sServiceCacheSize is service cache size for cilium k8s package.
 	K8sServiceCacheSize = "k8s-service-cache-size"
 
+	// K8sServiceDebounceBufferSize is the maximum number of service events to buffer.
+	K8sServiceDebounceBufferSize = "k8s-service-debounce-buffer-size"
+
+	// K8sServiceDebounceBufferWaitTime is the amount of time to wait before emitting
+	// the service event buffer.
+	K8sServiceDebounceWaitTime = "k8s-service-debounce-wait-time"
+
 	// K8sSyncTimeout is the timeout since last event was received to synchronize all resources with k8s.
 	K8sSyncTimeoutName = "k8s-sync-timeout"
 
@@ -1491,6 +1498,13 @@ type DaemonConfig struct {
 
 	// K8sServiceCacheSize is the service cache size for cilium k8s package.
 	K8sServiceCacheSize uint
+
+	// Number of distinct services to buffer at most.
+	K8sServiceDebounceBufferSize int
+
+	// The amount of time to wait to debounce service events before
+	// emitting the buffer.
+	K8sServiceDebounceWaitTime time.Duration
 
 	// MTU is the maximum transmission unit of the underlying network
 	MTU int
@@ -3067,6 +3081,8 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.K8sRequireIPv4PodCIDR = vp.GetBool(K8sRequireIPv4PodCIDRName)
 	c.K8sRequireIPv6PodCIDR = vp.GetBool(K8sRequireIPv6PodCIDRName)
 	c.K8sServiceCacheSize = uint(vp.GetInt(K8sServiceCacheSize))
+	c.K8sServiceDebounceBufferSize = vp.GetInt(K8sServiceDebounceBufferSize)
+	c.K8sServiceDebounceWaitTime = vp.GetDuration(K8sServiceDebounceWaitTime)
 	c.K8sSyncTimeout = vp.GetDuration(K8sSyncTimeoutName)
 	c.AllocatorListTimeout = vp.GetDuration(AllocatorListTimeoutName)
 	c.K8sWatcherEndpointSelector = vp.GetString(K8sWatcherEndpointSelector)


### PR DESCRIPTION
 * [x] #36176 (@tamilmani1989)
 * [x] #36463 (@julianwiedmann) :warning: resolved conflicts
  - fixed minor conflict accepting incoming changes
 * [x] #36410 (@liyihuang)
 * [x] #36417 (@EricMountain) :warning: resolved conflicts
  - Fixed minor conflict due to a different handling of the `MODIFIERS` var in main, kept v1.16 approach.
 * [x] #36517 (@borkmann)
 * [x] #36549 (@verysonglaa)
 * [x] #36394 (@joamaki) :warning: resolved conflicts
  - Fixed minor conflicts due to `TrafficPolicy` field in `ServiceUpsertNotification` removed in main.
 * [x] #36558 (@liyihuang)
 * [x] #36466 (@joamaki) :warning: resolved conflicts
  - Minor conflicts due to different package for logging
  - Decreased number of expected deletes in `TestServiceEventDebounce`, as https://github.com/cilium/cilium/pull/33434 has not been backported and `ANY` protocol is not expected.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 36176 36463 36410 36417 36517 36549 36394 36558 36466
```
