### PR TITLE
policy: fix missing error in GetSelectorPolicy()

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -198,7 +198,12 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 	}
 
 	var selectorPolicy policy.SelectorPolicy
-	selectorPolicy, result.policyRevision = e.policyGetter.GetPolicyRepository().GetSelectorPolicy(securityIdentity, skipPolicyRevision, stats)
+	selectorPolicy, result.policyRevision, err = e.policyGetter.GetPolicyRepository().GetSelectorPolicy(securityIdentity, skipPolicyRevision, stats)
+	if err != nil {
+		e.getLogger().WithError(err).Warning("Failed to calculate SelectorPolicy")
+		return nil, err
+	}
+
 	// selectorPolicy is nil if skipRevision was matched.
 	if selectorPolicy == nil {
 		e.getLogger().WithFields(logrus.Fields{
@@ -206,7 +211,7 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 			"policyRevision.repo": result.policyRevision,
 			"policyChanged":       e.nextPolicyRevision > e.policyRevision,
 		}).Debug("Skipping unnecessary endpoint policy recalculation")
-		return result, nil
+		return result, err
 	}
 
 	// Add new redirects before Consume() so that all required proxy ports are available for it.

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -401,9 +401,9 @@ func (d *policyDistillery) WithLogBuffer(w io.Writer) *policyDistillery {
 // distillPolicy distills the policy repository into a set of bpf map state
 // entries for an endpoint with the specified labels.
 func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.LabelArray, identity *identity.Identity) (mapState, error) {
-	sp, _ := d.Repository.GetSelectorPolicy(identity, 0, &dummyPolicyStats{})
-	if sp == nil {
-		return newMapState(), fmt.Errorf("policy distillation skipped, rev: %v", d.Repository.GetRevision())
+	sp, _, err := d.Repository.GetSelectorPolicy(identity, 0, &dummyPolicyStats{})
+	if err != nil {
+		return newMapState(), fmt.Errorf("failed to calculate policy: %w", err)
 	}
 	epp := sp.DistillPolicy(owner, testRedirects)
 	if epp == nil {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -119,7 +119,7 @@ type PolicyRepository interface {
 	// This is used to skip policy calculation when a certain revision delta is
 	// known to not affect the given identity. Pass a skipRevision of 0 to force
 	// calculation.
-	GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics) (SelectorPolicy, uint64)
+	GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics) (SelectorPolicy, uint64, error)
 
 	GetRevision() uint64
 	GetRulesList() *models.Policy
@@ -826,7 +826,7 @@ func wildcardRule(lbls labels.LabelArray, ingress bool) *rule {
 // This is used to skip policy calculation when a certain revision delta is
 // known to not affect the given identity. Pass a skipRevision of 0 to force
 // calculation.
-func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics) (SelectorPolicy, uint64) {
+func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics) (SelectorPolicy, uint64, error) {
 	stats.WaitingForPolicyRepository().Start()
 	r.RLock()
 	defer r.RUnlock()
@@ -837,7 +837,7 @@ func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint6
 	// Do we already have a given revision?
 	// If so, skip calculation.
 	if skipRevision >= rev {
-		return nil, rev
+		return nil, rev, nil
 	}
 
 	stats.SelectorPolicyCalculation().Start()
@@ -851,7 +851,7 @@ func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint6
 		stats.SelectorPolicyCalculation().Reset()
 	}
 
-	return sp, rev
+	return sp, rev, nil
 }
 
 // ReplaceByResource replaces all rules by resource, returning the complete set of affected endpoints.

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -851,7 +851,7 @@ func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint6
 		stats.SelectorPolicyCalculation().Reset()
 	}
 
-	return sp, rev, nil
+	return sp, rev, err
 }
 
 // ReplaceByResource replaces all rules by resource, returning the complete set of affected endpoints.


### PR DESCRIPTION
If policy calculation failed, we didn't return the error when we should.

Reverts: https://github.com/cilium/cilium/pull/36704
Fixes: 52d61cb1 ("policy: gather policy calculation in the repository")