### PR TITLE
v1.14 Backports 2024-12-16

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -484,8 +484,8 @@ toCIDR
   the respective destination endpoints.
 
 toCIDRSet
-  List of destination prefixes/CIDRs that are allowed to talk to all endpoints
-  selected by the ``endpointSelector``, along with an optional list of
+  List of destination prefixes/CIDRs that endpoints selected by
+  ``endpointSelector`` are allowed to talk to, along with an optional list of
   prefixes/CIDRs per source prefix/CIDR that are subnets of the destination
   prefix/CIDR to which communication is not allowed.
 


### PR DESCRIPTION
 * [x] #36549 (@verysonglaa) :warning: resolved conflicts
  - Dropped changes to "Host Policies known issues" section since it is missing in this branch.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 36549
```
