### PR TITLE
docs: Add Warning to Requires Policy Language

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -214,6 +214,21 @@ The purpose of this rule is to allow establishing base requirements such as, any
 endpoint in ``env=prod`` can only be accessed if the source endpoint also carries
 the label ``env=prod``.
 
+.. warning::
+
+   ``toRequires`` and ``fromRequires`` apply to all rules that share the same
+   endpoint selector and are not limited by other egress or ingress rules.
+   As a result ``toRequires`` and ``fromRequires`` limits all ingress and egress traffic
+   that applies to its endpoint selector. An important implication of the fact
+   that ``toRequires`` and ``fromRequires`` limit all ingress and egress traffic
+   that applies to an endpoint selector is that the other egress and ingress rules
+   (such as ``fromEndpoints``, ``fromPorts``, ``toEntities``, ``toServices``, and the rest)
+   do not limit the scope of the ``toRequires`` of ``fromRequires`` fields. Pairing other
+   ingress and egress rules with a ``toRequires`` or ``fromRequires`` will result in valid
+   policy, but the requirements set in ``toRequires`` and ``fromRequires`` stay in effect
+   no matter what would otherwise be allowed by the other rules.
+
+
 This example shows how to require every endpoint with the label ``env=prod`` to
 be only accessible if the source endpoint also has the label ``env=prod``.
 


### PR DESCRIPTION
FromRequires and ToRequires are not limited
by other ingress/egress rules. In theory
we should not have allowed its combination with
other rules, but we cannot introduce a sanitization rule that we forgot to add, as it could
easily break extant bodies of policy in the community.

This commit updates the requires labels policy
language documentation to warn explicitly on the
impotence of combining other rules with it.
