### PR TITLE
docs: Deprecate Requires Fields

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -198,6 +198,11 @@ egress.
 Additional Label Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. warning::
+
+   The ``fromRequires`` and ``toRequires`` fields are deprecated as of Cilium
+   1.17.x. They will be dropped from support in Cilium 1.18.
+
 It is often required to apply the principle of *separation of concern* when defining
 policies. For this reason, an additional construct exists which allows to establish
 base requirements for any connectivity to happen.


### PR DESCRIPTION
The toRequires and fromRequires fields cause confusion.
The requires fields also
can accumulate across policy as a global union. This
needs to be more intuitive and can cause problems as cluster
operators need to know what all extant requires labels
are to know the overall effect they will have.

Fixes: #issue-number

```release-note
policy: Deprecating the `toRequires` and `fromRequires` fields in network policies.
```
