### PR TITLE
[v1.16] author backport: helm: avoid setting bpf-lb-sock-terminate-pod-connections

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -315,13 +315,9 @@ spec:
         {{- end}}
         - name: cilium-run
           mountPath: /var/run/cilium
-        {{- /* mount the directory if socketLB.enabled is true and socketLB.terminatePodConnections is not explicitly set to false */ -}}
-        {{- if or (and (kindIs "invalid" .Values.socketLB.terminatePodConnections) .Values.socketLB.enabled)
-                  (and .Values.socketLB.enabled .Values.socketLB.terminatePodConnections)  }}
         - name: cilium-netns
           mountPath: /var/run/cilium/netns
           mountPropagation: HostToContainer
-        {{- end}}
         - name: etc-cni-netd
           mountPath: {{ .Values.cni.hostConfDirMountPath }}
         {{- if .Values.etcd.enabled }}
@@ -797,14 +793,11 @@ spec:
         hostPath:
           path: {{ .Values.daemon.runPath }}
           type: DirectoryOrCreate
-      {{- if or (and (kindIs "invalid" .Values.socketLB.terminatePodConnections) .Values.socketLB.enabled)
-                (and .Values.socketLB.enabled .Values.socketLB.terminatePodConnections)  }}
         # To exec into pod network namespaces
       - name: cilium-netns
         hostPath:
           path: /var/run/netns
           type: DirectoryOrCreate
-      {{- end }}
       {{- if .Values.bpf.autoMount.enabled }}
         # To keep state between restarts / upgrades for bpf maps
       - name: bpf-maps

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -718,8 +718,6 @@ data:
 {{- end }}
 {{- if hasKey $socketLB "terminatePodConnections" }}
   bpf-lb-sock-terminate-pod-connections: {{ $socketLB.terminatePodConnections | quote }}
-{{- else if hasKey $socketLB "enabled" }}
-  bpf-lb-sock-terminate-pod-connections: {{ $socketLB.enabled | quote }}
 {{- end }}
 {{- if hasKey $socketLB "tracing" }}
   trace-sock: {{ $socketLB.tracing | quote }}


### PR DESCRIPTION
This PR is an author backport for https://github.com/cilium/cilium/pull/36508

Note that  cilium-netns volume will be unconditionally mounted with this PR so that  the agent can lookup sockets in the pod netns in the case of KRP auto enabling.