### PR TITLE
cilium-cli: connectivity: clean up any leftover egw routes.

### DIFF
--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -213,6 +213,9 @@ func (t *Test) setup(ctx context.Context) error {
 	}
 
 	if t.installIPRoutesFromOutsideToPodCIDRs {
+		// Attempt to cleanup any leftover routes in case tests previously
+		// didn't cleanup correctly.
+		t.Context().modifyStaticRoutesForNodesWithoutCilium(ctx, "del")
 		if err := t.Context().modifyStaticRoutesForNodesWithoutCilium(ctx, "add"); err != nil {
 			return fmt.Errorf("installing static routes: %w", err)
 		}


### PR DESCRIPTION
If the CLI crashes or is stopped before running cleanup hooks, the egw routes installed on some nodes will cause other tests to fail. To prevent this, automatically try to clean these up on startup to avoid any confusing issues from leftover routes.
