### PR TITLE
identity: fix bug where fromNodes could be used to allow custom endpoint

### DIFF
--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -120,7 +120,9 @@ func parseToCiliumIngressCommonRule(namespace string, es api.EndpointSelector, i
 	if ing.FromNodes != nil {
 		retRule.FromNodes = make([]api.EndpointSelector, len(ing.FromNodes))
 		for j, node := range ing.FromNodes {
-			retRule.FromNodes[j] = api.NewESFromK8sLabelSelector("", node.LabelSelector)
+			es = api.NewESFromK8sLabelSelector("", node.LabelSelector)
+			es.AddMatchExpression(labels.LabelSourceReservedKeyPrefix+labels.IDNameRemoteNode, slim_metav1.LabelSelectorOpExists, []string{})
+			retRule.FromNodes[j] = es
 		}
 	}
 
@@ -239,7 +241,9 @@ func parseToCiliumEgressCommonRule(namespace string, es api.EndpointSelector, eg
 	if egr.ToNodes != nil {
 		retRule.ToNodes = make([]api.EndpointSelector, len(egr.ToNodes))
 		for j, node := range egr.ToNodes {
-			retRule.ToNodes[j] = api.NewESFromK8sLabelSelector("", node.LabelSelector)
+			es = api.NewESFromK8sLabelSelector("", node.LabelSelector)
+			es.AddMatchExpression(labels.LabelSourceReservedKeyPrefix+labels.IDNameRemoteNode, slim_metav1.LabelSelectorOpExists, []string{})
+			retRule.ToNodes[j] = es
 		}
 	}
 


### PR DESCRIPTION
Currently when `--enable-node-selector-labels` flag is set to true user can use (from/to)Nodes sections in CNPs/CCNPs to allow/block access to/from nodes based on custom node label. The node identity contains not only labels filtered out by `--node-labels` flag, but also contains `reserved:remote-node` label as seen in this example:

```
33554556   node:scif.cz/node=worker
           reserved:remote-node
```

The problematic part is in fromNodes/toNodes sections as those use the same `matchLabels` selector as classic fromEndpoints/toEndpoints. In case user specifies labels owned not only by node, but also by endpoint he/she might end up in a situation where unexpected endpoints might get access to users deployment.

It is necessary to be either specific or better - prevent this situation.

This commit fixes this by adding a matchExpression with `reserved:remote-node` key to the policy engine as all nodes have this label.

```
"fromNodes": [
          {
            "matchLabels": {
              "any:scif.cz/node": "worker"
            },
            "matchExpressions": [
              {
                "key": "reserved:remote-node",
                "operator": "Exists"
              }
            ]
          }
        ]
```

```release-note
identity: fix bug where fromNodes/toNodes could be used to allow custom endpoint
```

