### PR TITLE
ci: use docker build wrapper

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -67,6 +67,13 @@ jobs:
             platforms: linux/amd64,linux/arm64
 
     steps:
+      - name: Checkout default branch into trusted directory (trusted)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          path: ../trusted-cilium
+
       - name: Checkout default branch (trusted)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -192,7 +199,7 @@ jobs:
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
       - name: CI Build ${{ matrix.name }}
-        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        uses: ../trusted-cilium/.github/actions/docker-build-wrapper
         id: docker_build_ci
         with:
           provenance: false
@@ -206,7 +213,7 @@ jobs:
             OPERATOR_VARIANT=${{ matrix.name }}
 
       - name: CI race detection Build ${{ matrix.name }}
-        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        uses: ../trusted-cilium/.github/actions/docker-build-wrapper
         id: docker_build_ci_detect_race_condition
         with:
           provenance: false
@@ -222,7 +229,7 @@ jobs:
             OPERATOR_VARIANT=${{ matrix.name }}
 
       - name: CI Unstripped Binaries Build ${{ matrix.name }}
-        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        uses: ../trusted-cilium/.github/actions/docker-build-wrapper
         id: docker_build_ci_unstripped
         with:
           provenance: false


### PR DESCRIPTION
This change relies on merging https://github.com/cilium/cilium/pull/36592 to pass CI