### PR TITLE
cilium-cli: skip some IPv6 connectivity tests for Cilium<1.14 when IPsec is enabled

### DIFF
--- a/cilium-cli/connectivity/tests/service.go
+++ b/cilium-cli/connectivity/tests/service.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
+	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 // PodToService sends an HTTP request from all client Pods
@@ -225,6 +226,13 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 				if f, ok := t.Context().Feature(features.Flavor); ok && f.Enabled && f.Mode == "gke" {
 					continue
 				}
+			}
+
+			//  Skip IPv6 requests when running on <1.14.0 Cilium with CNPs
+			if features.GetIPFamily(addr.Address) == features.IPFamilyV6 &&
+				versioncheck.MustCompile("<1.14.0")(t.Context().CiliumVersion) &&
+				t.HasNetworkPolicies() {
+				continue
 			}
 
 			// Manually construct an HTTP endpoint to override the destination IP


### PR DESCRIPTION
It wasn't until https://github.com/cilium/cilium/issues/23445 was fixed in 1.14 when Cilium had robust IPv6 connectivity for IPsec[1]. Previously CI workflows didn't run IPv6 connectivity test for IPsec in 1.13, until https://github.com/cilium/cilium/pull/35314 recently enabled it. Subsequently, We noticed a number of CI failures in ci-ipsec-upgrade, caused by testing IPv6 connectivity in 1.13.

This patch reverts the deletion of `if <1.14 then skip` made by https://github.com/cilium/cilium/pull/35314 [2]

[1] https://github.com/cilium/cilium/issues/23461
[2] git diff aabda4bdbb578f8159627ca145ece7e66ad3df7a aabda4bdbb578f8159627ca145ece7e66ad3df7a~ | grep '<1.14.0' -C8

```diff
 func (t *Test) ForEachIPFamily(do func(features.IPFamily)) {
 	ipFams := []features.IPFamily{features.IPFamilyV4, features.IPFamilyV6}
 
+	// The per-endpoint routes feature is broken with IPv6 on < v1.14 when there
+	// are any netpols installed (https://github.com/cilium/cilium/issues/23852
+	// and https://github.com/cilium/cilium/issues/23910).
+	if f, ok := t.Context().Feature(features.EndpointRoutes); ok &&
+		f.Enabled && (len(t.cnps) > 0 || len(t.knps) > 0) &&
+		versioncheck.MustCompile("<1.14.0")(t.Context().CiliumVersion) {
+
+		ipFams = []features.IPFamily{features.IPFamilyV4}
+	}
+
 	for _, ipFam := range ipFams {
 		switch ipFam {
 		case features.IPFamilyV4:
@@ -853,6 +979,18 @@ func (t *Test) CertificateCAs() map[string][]byte {
--
+	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 // PodToService sends an HTTP request from all client Pods
@@ -227,6 +228,13 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 				}
 			}
 
+			//  Skip IPv6 requests when running on <1.14.0 Cilium with CNPs
+			if features.GetIPFamily(addr.Address) == features.IPFamilyV6 &&
+				versioncheck.MustCompile("<1.14.0")(t.Context().CiliumVersion) &&
+				(len(t.CiliumNetworkPolicies()) > 0 || len(t.KubernetesNetworkPolicies()) > 0) {
+				continue
+			}
+
 			// Manually construct an HTTP endpoint to override the destination IP
 			// and port of the request.
 			ep := check.HTTPEndpoint(name, fmt.Sprintf("%s://%s:%d%s", svc.Scheme(), addr.Address, np, svc.Path()))
diff --git a/cilium-cli/k8s/client.go b/cilium-cli/k8s/client.go
```

1.14 ci-ipsec-upgrade test: https://github.com/cilium/cilium/pull/36668