### PR TITLE
gha: fix merging of features-related artifacts

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -392,10 +392,12 @@ jobs:
           retention-days: 5
           delete-merged: true
       - name: Merge Features tested
-        uses: ./.github/actions/merge-artifacts
+        uses: actions/upload-artifact/merge@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: features-tested
           pattern: features-tested-*
+          retention-days: 5
+          delete-merged: true
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -371,10 +371,12 @@ jobs:
           retention-days: 5
           delete-merged: true
       - name: Merge Features tested
-        uses: ./.github/actions/merge-artifacts
+        uses: actions/upload-artifact/merge@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: features-tested
           pattern: features-tested-*
+          retention-days: 5
+          delete-merged: true
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -667,10 +667,12 @@ jobs:
           retention-days: 5
           delete-merged: true
       - name: Merge Features tested
-        uses: ./.github/actions/merge-artifacts
+        uses: actions/upload-artifact/merge@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: features-tested
           pattern: features-tested-*
+          retention-days: 5
+          delete-merged: true
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -427,10 +427,12 @@ jobs:
           retention-days: 5
           delete-merged: true
       - name: Merge Features tested
-        uses: ./.github/actions/merge-artifacts
+        uses: actions/upload-artifact/merge@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: features-tested
           pattern: features-tested-*
+          retention-days: 5
+          delete-merged: true
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -442,10 +442,12 @@ jobs:
           retention-days: 5
           delete-merged: true
       - name: Merge Features tested
-        uses: ./.github/actions/merge-artifacts
+        uses: actions/upload-artifact/merge@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: features-tested
           pattern: features-tested-*
+          retention-days: 5
+          delete-merged: true
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -528,10 +528,12 @@ jobs:
           retention-days: 5
           delete-merged: true
       - name: Merge Features tested
-        uses: ./.github/actions/merge-artifacts
+        uses: actions/upload-artifact/merge@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: features-tested
           pattern: features-tested-*
+          retention-days: 5
+          delete-merged: true
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -392,10 +392,12 @@ jobs:
           retention-days: 5
           delete-merged: true
       - name: Merge Features tested
-        uses: ./.github/actions/merge-artifacts
+        uses: actions/upload-artifact/merge@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: features-tested
           pattern: features-tested-*
+          retention-days: 5
+          delete-merged: true
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -472,10 +472,12 @@ jobs:
           retention-days: 5
           delete-merged: true
       - name: Merge Features tested
-        uses: ./.github/actions/merge-artifacts
+        uses: actions/upload-artifact/merge@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: features-tested
           pattern: features-tested-*
+          retention-days: 5
+          delete-merged: true
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -495,10 +495,12 @@ jobs:
           retention-days: 5
           delete-merged: true
       - name: Merge Features tested
-        uses: ./.github/actions/merge-artifacts
+        uses: actions/upload-artifact/merge@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: features-tested
           pattern: features-tested-*
+          retention-days: 5
+          delete-merged: true
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -367,10 +367,12 @@ jobs:
           persist-credentials: false
 
       - name: Merge Features tested
-        uses: ./.github/actions/merge-artifacts
+        uses: actions/upload-artifact/merge@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: features-tested
           pattern: features-tested-*
+          retention-days: 5
+          delete-merged: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
   commit-status-final:

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -823,10 +823,12 @@ jobs:
           retention-days: 5
           delete-merged: true
       - name: Merge Features tested
-        uses: ./.github/actions/merge-artifacts
+        uses: actions/upload-artifact/merge@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: features-tested
           pattern: features-tested-*
+          retention-days: 5
+          delete-merged: true
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -804,10 +804,12 @@ jobs:
           retention-days: 5
           delete-merged: true
       - name: Merge Features tested
-        uses: ./.github/actions/merge-artifacts
+        uses: actions/upload-artifact/merge@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: features-tested
           pattern: features-tested-*
+          retention-days: 5
+          delete-merged: true
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -470,10 +470,12 @@ jobs:
           retention-days: 5
           delete-merged: true
       - name: Merge Features tested
-        uses: ./.github/actions/merge-artifacts
+        uses: actions/upload-artifact/merge@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: features-tested
           pattern: features-tested-*
+          retention-days: 5
+          delete-merged: true
 
   commit-status-final:
     if: ${{ always() }}


### PR DESCRIPTION
The blamed commit backported the usage of the merge-artifacts reusable action which is not available yet in v1.16. Hence, let's fix this by directly using the upstream action instead.

Fixes: f7cb161c3f43 (".github/workflows: report which features are being used in CI")
