### PR TITLE
gha: use /test to trigger tests in stable branches

### DIFF
--- a/.github/workflows/ariane-scheduled.yaml
+++ b/.github/workflows/ariane-scheduled.yaml
@@ -50,10 +50,10 @@ jobs:
             echo "Skipping scheduled workflows for branch ${{ matrix.branch }}"
             exit 0
           fi
-          BRANCH="${{ matrix.branch }}"
-          REF="v${BRANCH}"
+
+          REF="v${{ matrix.branch }}"
           SHA=$(git rev-parse ${REF})
-          readarray workflows < <(TRIGGER="/test-backport-${BRANCH}" yq '.triggers[env(TRIGGER)].workflows[]' .github/ariane-config.yaml)
+          readarray workflows < <(yq '.triggers["/test"].workflows[]' .github/ariane-config.yaml)
 
           for workflow in ${workflows[@]}; do
             echo triggering ${workflow}

--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -332,8 +332,8 @@ Running the CI Against the Pull Request
 
 To validate a cross-section of various tests against the PRs, backport PRs
 should be validated in the CI by running all CI targets. This can be triggered
-by adding a comment to the PR with exactly the text ``/test-backport-x.x``,
-where ``x.x`` is the target version as described in :ref:`trigger_phrases`.
+by adding a comment to the PR with exactly the text ``/test``, as described in
+:ref:`trigger_phrases`.
 The comment must not contain any other characters.
 
 After the Backports are Merged

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -44,22 +44,8 @@ of the Cilium organization.
 
 Depending on the PR target branch, a specific set of jobs is marked as required,
 as per the `Cilium CI matrix`_. They will be automatically featured in PR checks
-directly on the PR page. The following trigger phrases may be used to trigger
-them all at once:
-
-+------------------+--------------------------+
-| PR target branch | Trigger required PR jobs |
-+==================+==========================+
-| main             | /test                    |
-+------------------+--------------------------+
-| v1.17            | /test-backport-1.17      |
-+------------------+--------------------------+
-| v1.16            | /test-backport-1.16      |
-+------------------+--------------------------+
-| v1.15            | /test-backport-1.15      |
-+------------------+--------------------------+
-| v1.14            | /test-backport-1.14      |
-+------------------+--------------------------+
+directly on the PR page. The ``/test`` trigger phrase may be used to trigger
+them all at once.
 
 More triggers can be found in `ariane-config.yaml <https://github.com/cilium/cilium/blob/main/.github/ariane-config.yaml>`_
 


### PR DESCRIPTION
Historically, Jenkins required the usage of a different trigger phrase on different branches, to allow distinguishing the target branch. Yet, Jenkins has been sunset when Cilium v1.13 became EOL a few months ago, and Ariane does not impose that requirement anymore. Hence, let's uniform the trigger phrase to simply be `/test` in all branches, to ensure consistency and preventing possible confusion during backports.

Related: https://github.com/cilium/cilium/pull/36690, https://github.com/cilium/cilium/pull/36673, https://github.com/cilium/cilium/pull/36674, https://github.com/cilium/cilium/pull/36675