### PR TITLE
[v1.15] gha: use /test to trigger tests in stable branches

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -2,7 +2,7 @@ allowed-teams:
   - organization-members
 
 triggers:
-  /test-backport-1.15:
+  /test:
     workflows:
     - conformance-aks.yaml
     - conformance-aws-cni.yaml

--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -332,8 +332,8 @@ Running the CI Against the Pull Request
 
 To validate a cross-section of various tests against the PRs, backport PRs
 should be validated in the CI by running all CI targets. This can be triggered
-by adding a comment to the PR with exactly the text ``/test-backport-x.x``,
-where ``x.x`` is the target version as described in :ref:`trigger_phrases`.
+by adding a comment to the PR with exactly the text ``/test``, as described in
+:ref:`trigger_phrases`.
 The comment must not contain any other characters.
 
 After the Backports are Merged

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -44,20 +44,8 @@ of the Cilium organization.
 
 Depending on the PR target branch, a specific set of jobs is marked as required,
 as per the `Cilium CI matrix`_. They will be automatically featured in PR checks
-directly on the PR page. The following trigger phrases may be used to trigger
-them all at once:
-
-+------------------+--------------------------+
-| PR target branch | Trigger required PR jobs |
-+==================+==========================+
-| main             | /test                    |
-+------------------+--------------------------+
-| v1.14            | /test-backport-1.14      |
-+------------------+--------------------------+
-| v1.13            | /test-backport-1.13      |
-+------------------+--------------------------+
-| v1.12            | /test-backport-1.12      |
-+------------------+--------------------------+
+directly on the PR page. The ``/test`` trigger phrase may be used to trigger
+them all at once.
 
 Pull requests submitted against older stable branches such as v1.13 may also be
 subject to Jenkins CI jobs. For more information, see


### PR DESCRIPTION
Historically, Jenkins required the usage of a different trigger phrase on different branches, to allow distinguishing the target branch. Yet, Jenkins has been sunset when Cilium v1.13 became EOL a few months ago, and Ariane does not impose that requirement anymore. Hence, let's uniform the trigger phrase to simply be `/test` in all branches, to ensure consistency and preventing possible confusion during backports.