### PR TITLE
pkg/maps/nat/stats: cleanup: remove unused nth index from nat-stats.

### DIFF
--- a/pkg/maps/nat/stats/stats.go
+++ b/pkg/maps/nat/stats/stats.go
@@ -80,7 +80,6 @@ type NatMapStats struct {
 	RemotePort uint16
 	Proto      string
 	Count      int
-	Nth        int
 }
 
 func (s NatMapStats) Key() index.Key {


### PR DESCRIPTION
Previous commits already removed setting the nth value. This value is not really necessary as it can easily be computed from the actual tuple port saturation value in the table.

It also wasn't being shown in `cilium-dbg shell -- db/show nat-stats` output.
