### PR TITLE
[1.15] ci-ipsec-upgrade: use cilium-cli-ci built from #36682

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -293,9 +293,8 @@ jobs:
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: cilium/cilium-cli@c52e8c38e6d6235bd8e6e961199a984275547d6f # v0.16.22
         with:
-          repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
-          release-version: ${{ env.CILIUM_CLI_VERSION }}
-          ci-version: ${{ env.cilium_cli_ci_version }}
+          repository: quay.io/cilium/cilium-cli-ci
+          ci-version: 0ac7ebab1fb60835d3368e2a19584b1324778888
           binary-name: cilium-cli
           binary-dir: ./
 


### PR DESCRIPTION
#36682

ci-ipsec-upgrade result: green https://github.com/cilium/cilium/actions/runs/12389318760