### PR TITLE
gha: drop leftover token parameter in net-perf-gke workflow

### DIFF
--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -373,7 +373,6 @@ jobs:
           pattern: features-tested-*
           retention-days: 5
           delete-merged: true
-          token: ${{ secrets.GITHUB_TOKEN }}
 
   commit-status-final:
     if: ${{ always() }}


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/36665/files#r1889355471