### PR TITLE
policy: Run namespace watcher only when policies are enabled

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -379,16 +379,19 @@ func allResourceGroups(cfg watchers.WatcherConfiguration) (resourceGroups, waitF
 		// To perform the service translation and have the BPF LB datapath
 		// with the right service -> backend (k8s endpoints) translation.
 		resources.K8sAPIGroupServiceV1Core,
-
-		// Namespaces can contain labels which are essential for
-		// endpoints being restored to have the right identity.
-		resources.K8sAPIGroupNamespaceV1Core,
 		// Pods can contain labels which are essential for endpoints
 		// being restored to have the right identity.
 		resources.K8sAPIGroupPodV1Core,
 		// To perform the service translation and have the BPF LB datapath
 		// with the right service -> backend (k8s endpoints) translation.
 		resources.K8sAPIGroupEndpointSliceOrEndpoint,
+	}
+
+	if option.NetworkPolicyEnabled(option.Config) {
+		// Namespaces can contain labels which are essential for
+		// endpoints being restored to have the right identity.
+		// Namespaces are only used when network policies are enabled.
+		k8sGroups = append(k8sGroups, resources.K8sAPIGroupNamespaceV1Core)
 	}
 
 	if cfg.K8sNetworkPolicyEnabled() {


### PR DESCRIPTION
Scalability improvement

Namespaces are only watched for their labels, which are used in policy enforcement. When policies are disabled, namespace watcher is not needed.

Ref: https://github.com/cilium/cilium/issues/33360

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>