### PR TITLE
cli: Add support to exclude certain nodes on EKS clusters from the OS check

### DIFF
--- a/cilium-cli/cli/install.go
+++ b/cilium-cli/cli/install.go
@@ -205,6 +205,7 @@ cilium upgrade --set cluster.id=1 --set cluster.name=cluster1
 	cmd.Flags().BoolVar(&params.DryRunHelmValues, "dry-run-helm-values", false,
 		"Write non-default Helm values to stdout; without performing the actual upgrade")
 	cmd.Flags().StringVar(&params.HelmRepository, "repository", defaults.HelmRepository, "Helm chart repository to download Cilium charts from")
+	cmd.Flags().StringVar(&params.AWS.NodeLabelSelector, "eks-node-label-selector", defaults.AWSNodeLabelSelector, "Node selector to use for EKS nodes")
 	return cmd
 }
 

--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -117,6 +117,8 @@ const (
 
 	LogLevelError   = "error"
 	LogLevelWarning = "warning"
+
+	AWSNodeLabelSelector = "eks.amazonaws.com/compute-type notin (fargate)"
 )
 
 var (

--- a/cilium-cli/install/aws.go
+++ b/cilium-cli/install/aws.go
@@ -35,7 +35,9 @@ func (k *K8sInstaller) awsRetrieveNodeImageFamily() error {
 	// setting default fallback value
 	k.params.AWS.AwsNodeImageFamily = AwsNodeImageFamilyCustom
 
-	nodes, err := k.client.ListNodes(context.Background(), metav1.ListOptions{})
+	nodes, err := k.client.ListNodes(context.Background(), metav1.ListOptions{
+		LabelSelector: k.params.AWS.NodeLabelSelector,
+	})
 	if err != nil {
 		k.Log("❌ Could not list cluster nodes, defaulted to fallback node image family value: %s", k.params.AWS.AwsNodeImageFamily)
 		return err

--- a/cilium-cli/install/install.go
+++ b/cilium-cli/install/install.go
@@ -94,6 +94,7 @@ type AzureParameters struct {
 
 type AWSParameters struct {
 	AwsNodeImageFamily string
+	NodeLabelSelector  string
 }
 
 type Parameters struct {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #36320

```release-note
Excludes Fargate nodes from EKS cluster node checks. Overridable from the cli.
```
