### PR TITLE
[v1.14] Unblock verifier test LVH image updates

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -85,22 +85,22 @@ jobs:
       matrix:
         include:
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '4.19-20240703.151759'
+          - kernel: '4.19-20241212.120648'
             ci-kernel: '419'
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '5.4-20240703.151759'
+          - kernel: '5.4-20241212.120648'
             ci-kernel: '54'
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '5.10-20240703.151759'
+          - kernel: '5.10-20241212.120648'
             ci-kernel: '510'
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '5.15-20240703.151759'
+          - kernel: '5.15-20241212.120648'
             ci-kernel: '510'
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '6.1-20240703.151759'
+          - kernel: '6.1-20241212.120648'
             ci-kernel: '61'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-          - kernel: '6.6-20241107.001101'
+          - kernel: '6.6-20241212.120648'
             ci-kernel: 'netnext'
     timeout-minutes: 60
     steps:

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -129,10 +129,18 @@ jobs:
 
             git config --global --add safe.directory /host
             uname -a
+
             # The LVH image might ship with an arbitrary Go toolchain version,
             # install the same Go toolchain version as current HEAD.
             CGO_ENABLED=0 GOPROXY=direct GOSUMDB= go install golang.org/dl/go${{ env.go-version }}@latest
             go${{ env.go-version }} download
+
+            # The LVH image ships with LLVM taken from a release Cilium version.
+            # Replace it with the one extracted from the cilium-builder image.
+            /bootstrap/deb-docker.sh # Install docker first.
+            /host/contrib/scripts/extract-llvm.sh /tmp/llvm
+            mv /tmp/llvm/usr/local/bin/{clang,llc} /bin/
+            rm -r /tmp/llvm
 
       - name: Run verifier tests
         uses: cilium/little-vm-helper@97c89f004bd0ab4caeacfe92ebc956e13e362e6b # v0.0.19

--- a/contrib/scripts/extract-llvm.sh
+++ b/contrib/scripts/extract-llvm.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eu
+
+OUT=${1:-"$PWD"}
+
+cd "$(dirname "$0")/../.."
+
+IMAGE=$(cat images/cilium/Dockerfile | grep '^ARG CILIUM_BUILDER_IMAGE=' | cut -d '=' -f 2)
+NAME=$(docker create "$IMAGE" /bin/true)
+trap 'docker rm "$NAME" > /dev/null' EXIT
+mkdir -p "$OUT"
+docker export "$NAME" | tar x -C "$OUT"


### PR DESCRIPTION
[ upstream commit 726a93b559f91d0dac11bd234437fb2005aadcb6 ]

Currently, the verifier test is using Clang from Cilium release images, and the integration tests use hardcoded Clang 10.0.0 releases. Convert the verifier test to extract Clang from the relevant cilium-builder image instead.

Unfortunately, the integration tests can't be converted that simply (because cilium-builder images don't contain an LLVM toolchain for the host, only for BPF), so leave it as is for now and keep in mind to upgrade the LLVM version there on upgrades.

Cherry-picked from https://github.com/cilium/cilium/pull/31754

---

The second commit manually updates the complexity-test images in the datapath verifier CI workflow to check whether they now work again. Once they prove to work, we can revert 6b198ce8a83d122b7e26692aa571ca5ff964c807 on `main` again to allow renovate to perform future image updates.

For #36184

/cc @julianwiedmann