### PR TITLE
Revert "renovate: exclude complexity-test image on v1.14 / v1.15"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -483,20 +483,6 @@
       "versioning": "regex:^((?<compatibility>[a-z0-9-.]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
     },
     {
-      "groupName": "old stable lvh-images",
-      "groupSlug": "old stable-lvh-images",
-      "matchPackageNames": [
-        "cilium/little-vm-helper",
-	// complexity-test needs https://github.com/cilium/little-vm-helper-images/issues/674.
-        "quay.io/lvh-images/kind"
-      ],
-      "allowedVersions": "!/bpf-next-.*/",
-      "matchBaseBranches": [
-        "v1.14",
-        "v1.15",
-      ],
-    },
-    {
       "groupName": "stable lvh-images",
       "groupSlug": "stable-lvh-images",
       "matchPackageNames": [
@@ -508,6 +494,8 @@
       "matchBaseBranches": [
         "v1.17",
         "v1.16",
+        "v1.15",
+        "v1.14",
       ],
     },
     {


### PR DESCRIPTION
This reverts commit 6b198ce8a83d122b7e26692aa571ca5ff964c807.

The workflow was changed to use the LLVM version from the cilium-builder image like it is already the case on main and v1.16. Hence, we can enable renovate updates for the complexity-test image on v1.14 and v1.15 again.

Ref. https://github.com/cilium/cilium/pull/36688
Ref. https://github.com/cilium/cilium/pull/36689

Fixes #36184