### PR TITLE
doc: fix typo on kubeproxy-free (CEV -> CVE)

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -554,7 +554,7 @@ In some public cloud provider environments that implement source /
 destination IP address checking (e.g. AWS), the checking has to be disabled in
 order for the DSR mode to work.
 
-By default Cilium uses special ExternalIP mitigation for CEV-2020-8554 MITM vulnerability.
+By default Cilium uses special ExternalIP mitigation for CVE-2020-8554 MITM vulnerability.
 This may affect connectivity targeted to ExternalIP on the same cluster.
 This mitigation can be disabled by setting ``bpf.disableExternalIPMitigation`` to ``true``.
 


### PR DESCRIPTION
Fix a small typo found on kubeproxy-free(.rst) documentation