### PR TITLE
policy: Remove unneeded error return in GetSelectorPolicy()

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -198,12 +198,7 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 	}
 
 	var selectorPolicy policy.SelectorPolicy
-	selectorPolicy, result.policyRevision, err = e.policyGetter.GetPolicyRepository().GetSelectorPolicy(securityIdentity, skipPolicyRevision, stats)
-	if err != nil {
-		e.getLogger().WithError(err).Warning("Failed to calculate SelectorPolicy")
-		return nil, err
-	}
-
+	selectorPolicy, result.policyRevision = e.policyGetter.GetPolicyRepository().GetSelectorPolicy(securityIdentity, skipPolicyRevision, stats)
 	// selectorPolicy is nil if skipRevision was matched.
 	if selectorPolicy == nil {
 		e.getLogger().WithFields(logrus.Fields{
@@ -211,7 +206,7 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 			"policyRevision.repo": result.policyRevision,
 			"policyChanged":       e.nextPolicyRevision > e.policyRevision,
 		}).Debug("Skipping unnecessary endpoint policy recalculation")
-		return result, err
+		return result, nil
 	}
 
 	// Add new redirects before Consume() so that all required proxy ports are available for it.

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -401,9 +401,9 @@ func (d *policyDistillery) WithLogBuffer(w io.Writer) *policyDistillery {
 // distillPolicy distills the policy repository into a set of bpf map state
 // entries for an endpoint with the specified labels.
 func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.LabelArray, identity *identity.Identity) (mapState, error) {
-	sp, _, err := d.Repository.GetSelectorPolicy(identity, 0, &dummyPolicyStats{})
-	if err != nil {
-		return newMapState(), fmt.Errorf("failed to calculate policy: %w", err)
+	sp, _ := d.Repository.GetSelectorPolicy(identity, 0, &dummyPolicyStats{})
+	if sp == nil {
+		return newMapState(), fmt.Errorf("policy distillation skipped, rev: %v", d.Repository.GetRevision())
 	}
 	epp := sp.DistillPolicy(owner, testRedirects)
 	if epp == nil {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -119,7 +119,7 @@ type PolicyRepository interface {
 	// This is used to skip policy calculation when a certain revision delta is
 	// known to not affect the given identity. Pass a skipRevision of 0 to force
 	// calculation.
-	GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics) (SelectorPolicy, uint64, error)
+	GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics) (SelectorPolicy, uint64)
 
 	GetRevision() uint64
 	GetRulesList() *models.Policy
@@ -826,7 +826,7 @@ func wildcardRule(lbls labels.LabelArray, ingress bool) *rule {
 // This is used to skip policy calculation when a certain revision delta is
 // known to not affect the given identity. Pass a skipRevision of 0 to force
 // calculation.
-func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics) (SelectorPolicy, uint64, error) {
+func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics) (SelectorPolicy, uint64) {
 	stats.WaitingForPolicyRepository().Start()
 	r.RLock()
 	defer r.RUnlock()
@@ -837,7 +837,7 @@ func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint6
 	// Do we already have a given revision?
 	// If so, skip calculation.
 	if skipRevision >= rev {
-		return nil, rev, nil
+		return nil, rev
 	}
 
 	stats.PolicyCalculation().Start()
@@ -851,7 +851,7 @@ func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint6
 		stats.PolicyCalculation().Reset()
 	}
 
-	return sp, rev, nil
+	return sp, rev
 }
 
 // ReplaceByResource replaces all rules by resource, returning the complete set of affected endpoints.


### PR DESCRIPTION
GetSelectorPolicy() always returns nil so no need to have it return an
error. Simplify the calling code accordingly as well.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
