### PR TITLE
gha: Disable reset-then-result-values in cilium upgrade

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -686,7 +686,7 @@ jobs:
         if: ${{ matrix.skip-upgrade != 'true' }}
         shell: bash
         run: |
-          cilium upgrade \
+          cilium upgrade --reset-then-reuse-values=false \
             ${{ steps.cilium-newest-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}
 
@@ -760,7 +760,7 @@ jobs:
         if: ${{ matrix.skip-upgrade != 'true' }}
         shell: bash
         run: |
-          cilium upgrade \
+          cilium upgrade --reset-then-reuse-values=false \
             ${{ steps.cilium-stable-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}
 

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -350,7 +350,7 @@ jobs:
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
         shell: bash
         run: |
-          cilium upgrade \
+          cilium upgrade --reset-then-reuse-values=false \
             ${{ steps.cilium-newest-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}
 
@@ -394,7 +394,7 @@ jobs:
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
         shell: bash
         run: |
-          cilium upgrade \
+          cilium upgrade --reset-then-reuse-values=false \
             ${{ steps.cilium-stable-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}
 


### PR DESCRIPTION
This commit is to retain cilium upgrade behavior by adding the --reset-then-reuse-values=false command line option.

Relates: https://github.com/cilium/cilium/pull/36347/files#r1872951933
Relates: https://github.com/cilium/cilium/pull/36541
