### PR TITLE
renovate: Update cilium-envoy for v1.17

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -329,6 +329,7 @@
       ],
       "allowedVersions": "24.04",
       "matchBaseBranches": [
+        "v1.17",
         "main",
       ],
     },
@@ -338,7 +339,6 @@
       ],
       "allowedVersions": "22.04",
       "matchBaseBranches": [
-        "v1.17",
         "v1.16",
         "v1.15",
         "v1.14",
@@ -617,7 +617,6 @@
       "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<revision>.*)$",
       "allowedVersions": "/^v1\\.30\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
-        "v1.17",
         "v1.16",
         "v1.15",
         "v1.14",
@@ -630,6 +629,7 @@
       "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<revision>.*)$",
       "allowedVersions": "/^v1\\.31\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
+        "v1.17",
         "main",
       ]
     },


### PR DESCRIPTION
Cilium v1.17 is currently running with envoy v1.31.x. Similar for ubuntu 24.04 as well.

Relates: b833f3e00baa4e1deb5d47127c2bb6f149504f73
