### PR TITLE
gha: Override cilium envoy image in common config

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -75,6 +75,7 @@ runs:
     - shell: bash
       id: derive-config
       run: |
+        CILIUM_ENVOY_REF=$(sed -E -e 's/^ARG CILIUM_ENVOY_IMAGE=([^ ]*)/\1/p;d' < ./images/cilium/Dockerfile)
         DEFAULTS="--wait \
             --chart-directory=${{ inputs.chart-dir }} \
             --helm-set=debug.enabled=true \
@@ -85,6 +86,7 @@ runs:
             --helm-set=authentication.mutual.spire.enabled=${{ inputs.mutual-auth }} \
             --nodes-without-cilium \
             --helm-set-string=kubeProxyReplacement=${{ inputs.kpr }} \
+            --helm-set=envoy.image.override=$CILIUM_ENVOY_REF \
             --set='${{ inputs.misc }}'"
 
           if [ -f "${{ inputs.chart-dir }}/../../../.github/actions/helm-default/ci-required-values.yaml" ]; then


### PR DESCRIPTION
This is to make sure that there is no mismatch between upgrades and downgrade. The ref is same as default value in Dockerfile/values.yaml from the same version.
