### PR TITLE
option: remove unused DaemonConfig.KVstoreKeepAliveInterval field

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -370,10 +370,6 @@ const (
 	// kvstore consecutive quorum errors before the agent assumes permanent failure
 	KVstoreMaxConsecutiveQuorumErrors = 2
 
-	// KVstoreKeepAliveIntervalFactor is the factor to calculate the interval
-	// from KVstoreLeaseTTL in which KVstore lease is being renewed.
-	KVstoreKeepAliveIntervalFactor = 3
-
 	// LockLeaseTTL is the time-to-live of the lease dedicated for locks of Kvstore.
 	LockLeaseTTL = 25 * time.Second
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1793,11 +1793,6 @@ type DaemonConfig struct {
 	// is marked as healthy.
 	HealthCheckICMPFailureThreshold int
 
-	// KVstoreKeepAliveInterval is the interval in which the lease is being
-	// renewed. This must be set to a value lesser than the LeaseTTL ideally
-	// by a factor of 3.
-	KVstoreKeepAliveInterval time.Duration
-
 	// KVstoreLeaseTTL is the time-to-live for kvstore lease.
 	KVstoreLeaseTTL time.Duration
 
@@ -2911,7 +2906,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.KeepConfig = vp.GetBool(KeepConfig)
 	c.KVStore = vp.GetString(KVStore)
 	c.KVstoreLeaseTTL = vp.GetDuration(KVstoreLeaseTTL)
-	c.KVstoreKeepAliveInterval = c.KVstoreLeaseTTL / defaults.KVstoreKeepAliveIntervalFactor
 	c.KVstorePeriodicSync = vp.GetDuration(KVstorePeriodicSync)
 	c.KVstoreConnectivityTimeout = vp.GetDuration(KVstoreConnectivityTimeout)
 	c.KVstorePodNetworkSupport = vp.GetBool(KVstorePodNetworkSupport)


### PR DESCRIPTION
The field is only ever set but no longer read since commit f323ffc16d79 ("kvstore: Remove Consul support").