### PR TITLE
vendor: bump ebpf-go to 0.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/cilium/coverbee v0.3.3-0.20240723084546-664438750fce
 	github.com/cilium/deepequal-gen v0.0.0-20241016021505-f57df2fe2e62
 	github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a
-	github.com/cilium/ebpf v0.16.1-0.20241212130635-98ede8ac7aa8
+	github.com/cilium/ebpf v0.17.1
 	github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b
 	github.com/cilium/fake v0.6.1
 	github.com/cilium/hive v0.0.0-20241213121623-605c1412b9b3

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/cilium/deepequal-gen v0.0.0-20241016021505-f57df2fe2e62 h1:MOWY9eqnrr
 github.com/cilium/deepequal-gen v0.0.0-20241016021505-f57df2fe2e62/go.mod h1:9EU8oWNwEP6f98xJz/YjWw7yOLHK7p90MKmaPu1wBcE=
 github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a h1:PRGN7B+72mj3OtLL2DM3F/9jp+ItgqgNS7mecgCmwsQ=
 github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a/go.mod h1:/7LC2GOgyXJ7maupZlaVIumYQiGPIgllSf6mA9sg6RU=
-github.com/cilium/ebpf v0.16.1-0.20241212130635-98ede8ac7aa8 h1:8JEXgZ0pcBvp430GkpfD8uMMMAJWQiJFYajKJGajKLM=
-github.com/cilium/ebpf v0.16.1-0.20241212130635-98ede8ac7aa8/go.mod h1:vay2FaYSmIlv3r8dNACd4mW/OCaZLJKJOo+IHBvCIO8=
+github.com/cilium/ebpf v0.17.1 h1:G8mzU81R2JA1nE5/8SRubzqvBMmAmri2VL8BIZPWvV0=
+github.com/cilium/ebpf v0.17.1/go.mod h1:vay2FaYSmIlv3r8dNACd4mW/OCaZLJKJOo+IHBvCIO8=
 github.com/cilium/endpointslice v0.29.4-0.20240409195643-982ad68ab7ba h1:Ddc5e+pz0/nY0XiAEW/UcIlvnaHACSuF77ePyMNX510=
 github.com/cilium/endpointslice v0.29.4-0.20240409195643-982ad68ab7ba/go.mod h1:9MPoeojWVEBLFnioKXTvRoqGWTs9Dt252r1ACFsi8K8=
 github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b h1:JxoccA9UQVXoQlJaMI7dtCXhg5R1ZPLPW+py376p1SA=

--- a/vendor/github.com/cilium/ebpf/README.md
+++ b/vendor/github.com/cilium/ebpf/README.md
@@ -53,6 +53,7 @@ This library includes the following packages:
 * [rlimit](https://pkg.go.dev/github.com/cilium/ebpf/rlimit) provides a convenient API to lift
   the `RLIMIT_MEMLOCK` constraint on kernels before 5.11.
 * [btf](https://pkg.go.dev/github.com/cilium/ebpf/btf) allows reading the BPF Type Format.
+* [pin](https://pkg.go.dev/github.com/cilium/ebpf/pin) provides APIs for working with pinned objects on bpffs.
 
 ## Requirements
 

--- a/vendor/github.com/cilium/ebpf/btf/format.go
+++ b/vendor/github.com/cilium/ebpf/btf/format.go
@@ -161,6 +161,9 @@ func (gf *GoFormatter) writeTypeLit(typ Type, depth int) error {
 	case *Datasec:
 		err = gf.writeDatasecLit(v, depth)
 
+	case *Var:
+		err = gf.writeTypeLit(v.Type, depth)
+
 	default:
 		return fmt.Errorf("type %T: %w", v, ErrNotSupported)
 	}

--- a/vendor/github.com/cilium/ebpf/btf/types.go
+++ b/vendor/github.com/cilium/ebpf/btf/types.go
@@ -1291,6 +1291,20 @@ func UnderlyingType(typ Type) Type {
 	return &cycle{typ}
 }
 
+// QualifiedType returns the type with all qualifiers removed.
+func QualifiedType(typ Type) Type {
+	result := typ
+	for depth := 0; depth <= maxResolveDepth; depth++ {
+		switch v := (result).(type) {
+		case qualifier:
+			result = v.qualify()
+		default:
+			return result
+		}
+	}
+	return &cycle{typ}
+}
+
 // As returns typ if is of type T. Otherwise it peels qualifiers and Typedefs
 // until it finds a T.
 //

--- a/vendor/github.com/cilium/ebpf/elf_reader.go
+++ b/vendor/github.com/cilium/ebpf/elf_reader.go
@@ -1013,6 +1013,13 @@ func mapSpecFromBTF(es *elfSection, vs *btf.VarSecinfo, def *btf.Struct, spec *b
 		}
 	}
 
+	// Some maps don't support value sizes, but annotating their map definitions
+	// with __type macros can still be useful, especially to let bpf2go generate
+	// type definitions for them.
+	if value != nil && !mapType.canHaveValueSize() {
+		valueSize = 0
+	}
+
 	return &MapSpec{
 		Name:       SanitizeName(name, -1),
 		Type:       MapType(mapType),

--- a/vendor/github.com/cilium/ebpf/internal/epoll/poller.go
+++ b/vendor/github.com/cilium/ebpf/internal/epoll/poller.go
@@ -168,13 +168,8 @@ func (p *Poller) Wait(events []unix.EpollEvent, deadline time.Time) (int, error)
 	for {
 		timeout := int(-1)
 		if !deadline.IsZero() {
-			msec := time.Until(deadline).Milliseconds()
-			// Deadline is in the past, don't block.
-			msec = max(msec, 0)
-			// Deadline is too far in the future.
-			msec = min(msec, math.MaxInt)
-
-			timeout = int(msec)
+			// Ensure deadline is not in the past and not too far into the future.
+			timeout = int(internal.Between(time.Until(deadline).Milliseconds(), 0, math.MaxInt))
 		}
 
 		n, err := unix.EpollWait(p.epollFd, events, timeout)

--- a/vendor/github.com/cilium/ebpf/internal/math.go
+++ b/vendor/github.com/cilium/ebpf/internal/math.go
@@ -10,6 +10,17 @@ func IsPow[I Integer](n I) bool {
 	return n != 0 && (n&(n-1)) == 0
 }
 
+// Between returns the value clamped between a and b.
+func Between[I Integer](val, a, b I) I {
+	lower, upper := a, b
+	if lower > upper {
+		upper, lower = a, b
+	}
+
+	val = min(val, upper)
+	return max(val, lower)
+}
+
 // Integer represents all possible integer types.
 // Remove when x/exp/constraints is moved to the standard library.
 type Integer interface {

--- a/vendor/github.com/cilium/ebpf/internal/sys/fd.go
+++ b/vendor/github.com/cilium/ebpf/internal/sys/fd.go
@@ -81,10 +81,13 @@ func (fd *FD) Close() error {
 		return nil
 	}
 
-	return unix.Close(fd.disown())
+	return unix.Close(fd.Disown())
 }
 
-func (fd *FD) disown() int {
+// Disown destroys the FD and returns its raw file descriptor without closing
+// it. After this call, the underlying fd is no longer tied to the FD's
+// lifecycle.
+func (fd *FD) Disown() int {
 	value := fd.raw
 	fdtrace.ForgetFD(value)
 	fd.raw = -1
@@ -118,7 +121,7 @@ func (fd *FD) File(name string) *os.File {
 		return nil
 	}
 
-	return os.NewFile(uintptr(fd.disown()), name)
+	return os.NewFile(uintptr(fd.Disown()), name)
 }
 
 // ObjGetTyped wraps [ObjGet] with a readlink call to extract the type of the

--- a/vendor/github.com/cilium/ebpf/map.go
+++ b/vendor/github.com/cilium/ebpf/map.go
@@ -158,6 +158,17 @@ func (spec *MapSpec) fixupMagicFields() (*MapSpec, error) {
 			// behaviour in the past.
 			spec.MaxEntries = n
 		}
+
+	case CPUMap:
+		n, err := PossibleCPU()
+		if err != nil {
+			return nil, fmt.Errorf("fixup cpu map: %w", err)
+		}
+
+		if n := uint32(n); spec.MaxEntries == 0 || spec.MaxEntries > n {
+			// Perform clamping similar to PerfEventArray.
+			spec.MaxEntries = n
+		}
 	}
 
 	return spec, nil

--- a/vendor/github.com/cilium/ebpf/types.go
+++ b/vendor/github.com/cilium/ebpf/types.go
@@ -127,6 +127,21 @@ func (mt MapType) canStoreProgram() bool {
 	return mt == ProgramArray
 }
 
+// canHaveValueSize returns true if the map type supports setting a value size.
+func (mt MapType) canHaveValueSize() bool {
+	switch mt {
+	case RingBuf, Arena:
+		return false
+
+	// Special-case perf events since they require a value size of either 0 or 4
+	// for historical reasons. Let the library fix this up later.
+	case PerfEventArray:
+		return false
+	}
+
+	return true
+}
+
 // ProgramType of the eBPF program
 type ProgramType uint32
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -235,7 +235,7 @@ github.com/cilium/deepequal-gen/generators
 # github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a
 ## explicit; go 1.18
 github.com/cilium/dns
-# github.com/cilium/ebpf v0.16.1-0.20241212130635-98ede8ac7aa8
+# github.com/cilium/ebpf v0.17.1
 ## explicit; go 1.22
 github.com/cilium/ebpf
 github.com/cilium/ebpf/asm


### PR DESCRIPTION
Does what it says on the tin, this bumps ebpf-go from an unreleased 0.16.x to 0.17.