### PR TITLE
policy: Make CES config compatible with disabled policies

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -166,6 +166,7 @@ var (
 		) ciliumendpointslice.SharedConfig {
 			return ciliumendpointslice.SharedConfig{
 				EnableCiliumEndpointSlice: daemonCfg.EnableCiliumEndpointSlice,
+				DisableNetworkPolicy:      !option.NetworkPolicyEnabled(daemonCfg),
 			}
 		}),
 

--- a/operator/pkg/ciliumendpointslice/cell.go
+++ b/operator/pkg/ciliumendpointslice/cell.go
@@ -107,4 +107,7 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 type SharedConfig struct {
 	// EnableCiliumEndpointSlice enables the cilium endpoint slicing feature and the CES Controller.
 	EnableCiliumEndpointSlice bool
+	// DisableNetworkPolicy indicates if the network policy enforcement system is
+	// disabled for K8s, Cilium and Cilium Clusterwide network policies.
+	DisableNetworkPolicy bool
 }

--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -4,6 +4,7 @@
 package ciliumendpointslice
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
@@ -103,7 +104,11 @@ func registerController(p params) error {
 	if err != nil {
 		return err
 	}
-	if !clientset.IsEnabled() || !p.SharedCfg.EnableCiliumEndpointSlice {
+	if cmp.Or(
+		!clientset.IsEnabled(),
+		!p.SharedCfg.EnableCiliumEndpointSlice,
+		p.SharedCfg.DisableNetworkPolicy,
+	) {
 		return nil
 	}
 

--- a/operator/pkg/ciliumendpointslice/controller_test.go
+++ b/operator/pkg/ciliumendpointslice/controller_test.go
@@ -48,6 +48,7 @@ func TestRegisterController(t *testing.T) {
 		cell.Provide(func() SharedConfig {
 			return SharedConfig{
 				EnableCiliumEndpointSlice: true,
+				DisableNetworkPolicy:      false,
 			}
 		}),
 		cell.Provide(func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
@@ -107,6 +108,7 @@ func TestNotRegisterControllerWithCESDisabled(t *testing.T) {
 		cell.Provide(func() SharedConfig {
 			return SharedConfig{
 				EnableCiliumEndpointSlice: false,
+				DisableNetworkPolicy:      false,
 			}
 		}),
 		cell.Provide(func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3229,8 +3229,10 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	// Ensure CiliumEndpointSlice is enabled only if CiliumEndpointCRD is enabled too.
 	c.EnableCiliumEndpointSlice = vp.GetBool(EnableCiliumEndpointSlice)
 	if c.EnableCiliumEndpointSlice && c.DisableCiliumEndpointCRD {
-		log.Fatalf("Running Cilium with %s=%t requires %s set to false to enable CiliumEndpoint CRDs.",
-			EnableCiliumEndpointSlice, c.EnableCiliumEndpointSlice, DisableCiliumEndpointCRDName)
+		log.Warningf("Running Cilium with %s=%t requires %s set to false to enable CiliumEndpoint CRDs. Changing %s to %t",
+			EnableCiliumEndpointSlice, c.EnableCiliumEndpointSlice, DisableCiliumEndpointCRDName, EnableCiliumEndpointSlice, false)
+
+		c.EnableCiliumEndpointSlice = false
 	}
 
 	// To support K8s NetworkPolicy


### PR DESCRIPTION
CESs depend on CEP CRD. Before this change, If CEP CRD is disabled to disable the network policy enforcement system (and all its background processes), but CESs remain enabled, cilium-agent cannot start.

Changes:
- Disable CESs and log a warning when CEP CRD is disabled, rather than crashing cilium-agent.
- CES controller in cilium-operator will be disabled if network policies are disabled, but it can still run even if CEP CRD is disabled, the same way CID controller does.

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>