### PR TITLE
policy: don't subscribe to service events if CNPs/CCNPs are disabled

### DIFF
--- a/pkg/policy/k8s/cell.go
+++ b/pkg/policy/k8s/cell.go
@@ -93,7 +93,6 @@ func startK8sPolicyWatcher(params PolicyWatcherParams) {
 	// We want to subscribe before the start hook is invoked in order to not miss
 	// any events
 	ctx, cancel := context.WithCancel(context.Background())
-	svcCacheNotifications := serviceNotificationsQueue(ctx, params.ServiceCache.Notifications())
 
 	p := &policyWatcher{
 		log:                              params.Logger,
@@ -102,7 +101,6 @@ func startK8sPolicyWatcher(params PolicyWatcherParams) {
 		k8sResourceSynced:                params.K8sResourceSynced,
 		k8sAPIGroups:                     params.K8sAPIGroups,
 		svcCache:                         params.ServiceCache,
-		svcCacheNotifications:            svcCacheNotifications,
 		ipCache:                          params.IPCache,
 		ciliumNetworkPolicies:            params.CiliumNetworkPolicies,
 		ciliumClusterwideNetworkPolicies: params.CiliumClusterwideNetworkPolicies,
@@ -116,6 +114,11 @@ func startK8sPolicyWatcher(params PolicyWatcherParams) {
 		toServicesPolicies: make(map[resource.Key]struct{}),
 		cnpByServiceID:     make(map[k8s.ServiceID]map[resource.Key]struct{}),
 		metricsManager:     params.MetricsManager,
+	}
+
+	// Service notifications are not used if CNPs/CCNPs are disabled.
+	if params.Config.EnableCiliumNetworkPolicy || params.Config.EnableCiliumClusterwideNetworkPolicy {
+		p.svcCacheNotifications = serviceNotificationsQueue(ctx, params.ServiceCache.Notifications())
 	}
 
 	params.Lifecycle.Append(cell.Hook{


### PR DESCRIPTION
Service events are not used when CNPs and CCNPs are disabled. However, we currently subscribe to the service cache, and enqueue all events in a local cache, in turn causing a memory leak in that case given that the events would never be dequeued. Let's get this fixed.

Fixes: 253a05bef383 ("policy: Add config for enabling Cilium NetworkPolicy")

```release-note
Fix memory leak caused by service events when when CNPs/CCNPs are disabled 
```
