### PR TITLE
wireguard: track allowedIPs with a bitlpm.CIDRTrie and use pod CIDRs when available

### DIFF
--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/backoff"
+	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/clustermesh"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/container/bitlpm"
@@ -358,7 +359,7 @@ func (a *Agent) RestoreFinished(cm *clustermesh.ClusterMesh) error {
 	return nil
 }
 
-func (a *Agent) UpdatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP) error {
+func (a *Agent) UpdatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP, podAllocCIDRs []*cidr.CIDR) error {
 	// To avoid running into a deadlock, we need to lock the IPCache before
 	// calling a.Lock(), because IPCache might try to call into
 	// OnIPIdentityCacheChange concurrently
@@ -405,6 +406,15 @@ func (a *Agent) UpdatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP
 			for _, ip := range a.ipCache.LookupByHostRLocked(nodeIPv4, nodeIPv6) {
 				peer.queueAllowedIPInsert(ip)
 			}
+		}
+	}
+
+	// We always sync CIDRs when subscribed to IPCache events.
+	// This ensures that in case they're somehow removed through IPCache but the node
+	// still uses them (passed to this method), then the peer config is still aligned.
+	if a.needIPCacheEvents {
+		for _, c := range podAllocCIDRs {
+			peer.queueAllowedIPInsert(*c.IPNet)
 		}
 	}
 

--- a/pkg/wireguard/agent/node_handler.go
+++ b/pkg/wireguard/agent/node_handler.go
@@ -49,8 +49,9 @@ func (a *Agent) nodeUpsert(node nodeTypes.Node) error {
 
 	newIP4 := node.GetNodeIP(false)
 	newIP6 := node.GetNodeIP(true)
+	newPodAllocCIDRs := append(node.GetIPv4AllocCIDRs(), node.GetIPv6AllocCIDRs()...)
 
-	if err := a.UpdatePeer(node.Fullname(), node.WireguardPubKey, newIP4, newIP6); err != nil {
+	if err := a.UpdatePeer(node.Fullname(), node.WireguardPubKey, newIP4, newIP6, newPodAllocCIDRs); err != nil {
 		log.WithError(err).
 			WithField(logfields.NodeName, node.Fullname()).
 			Warning("Failed to update WireGuard configuration for peer")

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -993,6 +993,17 @@ func (kub *Kubectl) GetPodOnNodeLabeledWithOffset(label string, podFilter string
 	return podName, podIP
 }
 
+// GetPodCIDRsOnNodeByName retrieves the list of pod alloc CIDRs on a given node.
+func (kub *Kubectl) GetPodCIDRsOnNodeByName(node string) ([]string, error) {
+	jsonFilter := "{.spec.ipam.podCIDRs}"
+	res := kub.Exec(fmt.Sprintf("%s -n %s get cn %s -o jsonpath='%s'", KubectlCmd, KubeSystemNamespace, node, jsonFilter))
+	if !res.WasSuccessful() {
+		return nil, res.GetError()
+	}
+	podCIDRsList := []string{}
+	return podCIDRsList, res.Unmarshal(&podCIDRsList)
+}
+
 // GetSvcIP returns the cluster IP for the given service. If the service
 // does not contain a cluster IP, the function keeps retrying until it has or
 // the context timesout.


### PR DESCRIPTION
In #35895, we skip tracking individual IPs in overlay mode. This patch, instead, focuses on the native routing.
With this patch, we track all IPs and CIDRs, but configure the wireguard device with the minimum IPs needed.
More details in commit messages.

1. `wireguard: change allowedIPs implementation to bitlpm.CIDRTrie`: this commit changes our current agent implementation of AllowedIPs from hash map to bitlpm.CIDRTrie. We now track all IPs/CIDRs, in the agent state, but configure peers with the minimal needed IPs/CIDRs. This also enables support for when CIDRs will be upserted/deleted through IPCache.
2. `wireguard: track podAllocCIDRs when available`: this commit adds to `UpdatePeer` pod alloc CIDRs when available.
3. `tests: ginkgo: wireguard: ensure CIDRs in f20-datapath-misc-3`: could be squashed in (2), adjusts ginkgo test to look for the CIDR rather than podIP in the allowedIPs.

Fixes: #35331 

```release-note
Change WireGuard agent allowedIPs implementation to bitlpm.CIDRTrie and support pod allocation CIDRs when available.
```