### PR TITLE
gha: Disable envoy version check in upgrade/downgrade tests

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -687,6 +687,7 @@ jobs:
         shell: bash
         run: |
           cilium upgrade \
+            --helm-set=disableEnvoyVersionCheck=true \
             ${{ steps.cilium-newest-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}
 
@@ -761,6 +762,7 @@ jobs:
         shell: bash
         run: |
           cilium upgrade \
+            --helm-set=disableEnvoyVersionCheck=true \
             ${{ steps.cilium-stable-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}
 

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -351,6 +351,7 @@ jobs:
         shell: bash
         run: |
           cilium upgrade \
+            --helm-set=disableEnvoyVersionCheck=true \
             ${{ steps.cilium-newest-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}
 
@@ -395,6 +396,7 @@ jobs:
         shell: bash
         run: |
           cilium upgrade \
+            --helm-set=disableEnvoyVersionCheck=true \
             ${{ steps.cilium-stable-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}
 


### PR DESCRIPTION
Each stable releases might run with different cilium/proxy versions, which might cause below error logs during upgrade/downgrade tests. This commit is to disable such validation, as any incompatibility issue will trigger connectivity failure. Additionally, any error logs in cilium envoy pod will be checked after #36498 is merged.

```
 time=2024-12-19T15:02:09Z level=error msg="Timer job errored" module=agent.controlplane.envoy-proxy name=version-check func="envoy.registerEnvoyVersionCheck.func2 (pkg/envoy/cell.go:279)" error="envoy version 3a8ccd54545785689e677d785b69025d1d4b33de/1.31.4/Distribution/RELEASE/BoringSSL does not match with required version fff09f16c2c269b22509c86dfc1d3e8f52eb3857" (1 occurrences)
```
