### PR TITLE
gh: e2e-upgrade: enable HostFW in config 5

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -155,7 +155,7 @@ jobs:
             lb-mode: 'dsr'
             endpoint-routes: 'true'
             egress-gateway: 'true'
-            host-fw: 'false' # enabling breaks downgrading (missed tail calls)
+            host-fw: 'true'
             ingress-controller: 'true'
 
           - name: '6'


### PR DESCRIPTION
Assume that all remaining issues with missed tail calls are resolved, and enable the HostFW feature.