### PR TITLE
datapath/linux: Refactor device controller tests to use scripttest

### DIFF
--- a/pkg/datapath/linux/devices_controller_test.go
+++ b/pkg/datapath/linux/devices_controller_test.go
@@ -7,32 +7,33 @@ package linux
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
+	"maps"
 	"net"
-	"net/netip"
 	"os"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
 	"github.com/cilium/statedb"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
+	"github.com/vishvananda/netns"
 	"go.uber.org/goleak"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/testutils"
-	"github.com/cilium/cilium/pkg/testutils/netns"
 )
 
 func devicesControllerTestSetup(t *testing.T) {
@@ -50,480 +51,67 @@ func devicesControllerTestSetup(t *testing.T) {
 	})
 }
 
-const (
-	secondaryAddress = true
-	primaryAddress   = false
-)
-
-func containsAddress(dev *tables.Device, addrStr string, secondary bool) bool {
-	addr := netip.MustParseAddr(addrStr)
-	for _, a := range dev.Addrs {
-		if a.Addr == addr && a.Secondary == secondary {
-			return true
-		}
-	}
-	return false
-}
-
-func TestDevicesController(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
+func TestDevicesControllerScript(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	devicesControllerTestSetup(t)
 
-	logging.SetLogLevelToDebug()
+	setup := func(t testing.TB, args []string) *script.Engine {
+		var err error
 
-	addrToString := func(addr netip.Addr) string {
-		if !addr.IsValid() {
-			return ""
-		}
-		return addr.String()
-	}
-
-	routeExists := func(routes []*tables.Route, linkIndex int, dst, src, gw string) bool {
-		for _, r := range routes {
-			// undefined IP will stringify as "invalid IP", turn them into "".
-			actualDst, actualSrc, actualGw := r.Dst.String(), addrToString(r.Src), addrToString(r.Gw)
-			if r.LinkIndex == linkIndex && actualDst == dst && actualSrc == src &&
-				actualGw == gw {
-				return true
+		// Run the test in a new network namespace.
+		origNS := netns.None()
+		newNS := netns.None()
+		runtime.LockOSThread()
+		t.Cleanup(func() {
+			if origNS.IsOpen() {
+				netns.Set(origNS)
+				origNS.Close()
 			}
-		}
-		return false
-	}
-
-	neighborExists := func(neighbors []*tables.Neighbor, linkIndex int, ip, mac string, flags tables.NeighborFlags) bool {
-		for _, n := range neighbors {
-			if n.LinkIndex == linkIndex && n.IPAddr.String() == ip && n.HardwareAddr.String() == mac && n.Flags == flags {
-				return true
+			if newNS.IsOpen() {
+				newNS.Close()
 			}
-		}
-		return false
-	}
+			runtime.UnlockOSThread()
+		})
+		origNS, err = netns.Get()
+		assert.NoError(t, err)
+		newNS, err = netns.New()
+		assert.NoError(t, err)
 
-	v4Routes := func(routes []*tables.Route) (out []*tables.Route) {
-		for _, r := range routes {
-			if r.Dst.Addr().Is4() {
-				out = append(out, r)
-			}
-		}
-		return
-	}
-
-	orphanRoutes := func(devs []*tables.Device, routes []*tables.Route) bool {
-		indexes := map[int]bool{}
-		for _, dev := range devs {
-			indexes[dev.Index] = true
-		}
-		for _, r := range routes {
-			if !indexes[r.LinkIndex] {
-				// A route exists without a device.
-				t.Logf("Orphan route found: %+v", r)
-				return true
-			}
-		}
-		return false
-	}
-
-	orphanNeighbors := func(devs []*tables.Device, neighbors []*tables.Neighbor) bool {
-		indexes := map[int]bool{}
-		for _, dev := range devs {
-			indexes[dev.Index] = true
-		}
-		for _, n := range neighbors {
-			if !indexes[n.LinkIndex] {
-				// A neighbor exists without a device.
-				t.Logf("Orphan neighbor found: %+v", n)
-				return true
-			}
-		}
-		return false
-	}
-
-	// The test steps perform an action, wait for devices table to change
-	// and then validate the change. Since we may see intermediate states
-	// in the devices table (as there's multiple netlink updates that may
-	// be processed at different times) the check function is repeated
-	// until the desired state is reached or [ctx] times out.
-	testSteps := []struct {
-		name    string
-		prepare func(*testing.T)
-		check   func(*testing.T, []*tables.Device, []*tables.Route, []*tables.Neighbor) bool
-	}{
-		{
-			"initial",
-			func(*testing.T) {},
-			func(t *testing.T, devs []*tables.Device, routes []*tables.Route, neighbors []*tables.Neighbor) bool {
-				return len(devs) == 1 &&
-					devs[0].Name == "dummy0" &&
-					devs[0].Index > 0 &&
-					devs[0].Selected &&
-					routeExists(routes, devs[0].Index, "192.168.0.0/24", "192.168.0.1", "")
-			},
-		},
-		{
-			"add dummy1",
-			func(t *testing.T) {
-				// Create another dummy to check that the table updates.
-				require.NoError(t, createDummy("dummy1", "192.168.1.1/24", false))
-
-				// Add a default route
-				assert.NoError(t,
-					addRoute(addRouteParams{iface: "dummy1", gw: "192.168.1.254", table: unix.RT_TABLE_MAIN}))
-
-				// Add a static neighbor entry for the GW:
-				assert.NoError(t,
-					addNeighbor(addNeighborParams{iface: "dummy1", ip: "192.168.1.254", mac: "00:00:5e:00:53:01", flags: netlink.NTF_EXT_LEARNED}))
-			},
-			func(t *testing.T, devs []*tables.Device, routes []*tables.Route, neighbors []*tables.Neighbor) bool {
-				// Since we're indexing by ifindex, we expect these to be in the order
-				// they were added.
-				return len(devs) == 2 &&
-					"dummy0" == devs[0].Name &&
-					routeExists(routes, devs[0].Index, "192.168.0.0/24", "192.168.0.1", "") &&
-					devs[0].Selected &&
-					"dummy1" == devs[1].Name &&
-					devs[1].Selected &&
-					routeExists(routes, devs[1].Index, "192.168.1.0/24", "192.168.1.1", "") &&
-					neighborExists(neighbors, devs[1].Index, "192.168.1.254", "00:00:5e:00:53:01", tables.NTF_EXT_LEARNED)
-			},
-		},
-
-		{
-			"secondary address",
-			func(t *testing.T) {
-				require.NoError(t, addAddrScoped("dummy1", "192.168.1.2/24", netlink.SCOPE_SITE, unix.IFA_F_SECONDARY))
-			},
-			func(t *testing.T, devs []*tables.Device, routes []*tables.Route, neighbors []*tables.Neighbor) bool {
-				// Since we're indexing by ifindex, we expect these to be in the order
-				// they were added.
-				return len(devs) == 2 &&
-					"dummy1" == devs[1].Name &&
-					devs[1].Selected &&
-					containsAddress(devs[1], "192.168.1.1", primaryAddress) &&
-					containsAddress(devs[1], "192.168.1.2", secondaryAddress)
-			},
-		},
-
-		{ // Only consider veth devices when they have a default route.
-			"veth-without-default-gw",
-			func(t *testing.T) {
-				require.NoError(t, createVeth("veth0", "192.168.4.1/24", false))
-			},
-			func(t *testing.T, devs []*tables.Device, routes []*tables.Route, neighbors []*tables.Neighbor) bool {
-				// No changes expected to previous step.
-				return len(devs) == 2 &&
-					"dummy0" == devs[0].Name &&
-					"dummy1" == devs[1].Name
-			},
-		},
-
-		{
-			"veth-with-default-gw",
-			func(t *testing.T) {
-				// Remove default route + neighbor from dummy1
-				assert.NoError(t,
-					delRoute(addRouteParams{iface: "dummy1", gw: "192.168.1.254", table: unix.RT_TABLE_MAIN}))
-				assert.NoError(t,
-					delNeighbor(addNeighborParams{iface: "dummy1", ip: "192.168.1.254", mac: "00:00:5e:00:53:01", flags: netlink.NTF_EXT_LEARNED}))
-
-				// And add default route + neighbor for veth0.
-				assert.NoError(t,
-					addRoute(addRouteParams{iface: "veth0", gw: "192.168.4.254", table: unix.RT_TABLE_MAIN}))
-				assert.NoError(t,
-					addNeighbor(addNeighborParams{iface: "veth0", ip: "192.168.1.254", mac: "00:00:5e:00:53:01", flags: netlink.NTF_EXT_LEARNED}))
-			},
-			func(t *testing.T, devs []*tables.Device, routes []*tables.Route, neighbors []*tables.Neighbor) bool {
-				return len(devs) == 3 &&
-					devs[0].Name == "dummy0" &&
-					devs[1].Name == "dummy1" &&
-					devs[2].Name == "veth0" &&
-					containsAddress(devs[2], "192.168.4.1", primaryAddress) &&
-					routeExists(routes, devs[2].Index, "0.0.0.0/0", "", "192.168.4.254") &&
-					neighborExists(neighbors, devs[2].Index, "192.168.1.254", "00:00:5e:00:53:01", tables.NTF_EXT_LEARNED)
-			},
-		},
-
-		{
-			"check-all-v4-routes",
-			func(t *testing.T) {},
-			func(t *testing.T, devs []*tables.Device, routes []*tables.Route, neighbors []*tables.Neighbor) bool {
-				routes = v4Routes(routes)
-				json, _ := json.Marshal(routes)
-				os.WriteFile("/tmp/routes.json", json, 0644)
-				return routeExists(routes, devs[0].Index, "192.168.0.0/24", "192.168.0.1", "") &&
-					routeExists(routes, devs[0].Index, "192.168.0.1/32", "192.168.0.1", "") &&
-					routeExists(routes, devs[0].Index, "192.168.0.255/32", "192.168.0.1", "") &&
-
-					routeExists(routes, devs[1].Index, "192.168.1.0/24", "192.168.1.1", "") &&
-					routeExists(routes, devs[1].Index, "192.168.1.1/32", "192.168.1.1", "") &&
-					routeExists(routes, devs[1].Index, "192.168.1.2/32", "192.168.1.1", "") &&
-					routeExists(routes, devs[1].Index, "192.168.1.255/32", "192.168.1.1", "") &&
-
-					routeExists(routes, devs[2].Index, "192.168.4.0/24", "192.168.4.1", "") &&
-					routeExists(routes, devs[2].Index, "192.168.4.1/32", "192.168.4.1", "") &&
-					routeExists(routes, devs[2].Index, "192.168.4.255/32", "192.168.4.1", "") &&
-					routeExists(routes, devs[2].Index, "0.0.0.0/0", "", "192.168.4.254") &&
-					len(routes) == 11
-			},
-		},
-
-		{
-			"delete-dummy0",
-			func(t *testing.T) {
-				require.NoError(t, deleteLink("dummy0"))
-			},
-			func(t *testing.T, devs []*tables.Device, routes []*tables.Route, neighbors []*tables.Neighbor) bool {
-				return len(devs) == 2 &&
-					"dummy1" == devs[0].Name &&
-					"veth0" == devs[1].Name
-			},
-		},
-
-		{
-			"bond-is-selected",
-			func(t *testing.T) {
-				require.NoError(t, deleteLink("veth0"))
-				require.NoError(t, createBond("bond0", "192.168.6.1/24", false))
-				require.NoError(t, setBondMaster("dummy1", "bond0"))
-			},
-			func(t *testing.T, devs []*tables.Device, routes []*tables.Route, neighbors []*tables.Neighbor) bool {
-				// Slaved devices are ignored, so we should only see bond0.
-				return len(devs) == 1 &&
-					devs[0].Name == "bond0" &&
-					devs[0].Selected
-			},
-		},
-		{
-			"dummy1-restored",
-			func(t *testing.T) {
-				// Deleting the bond device restores dummy1 as a selected device
-				// as it is no longer a slave device.
-				assert.NoError(t, deleteLink("bond0"))
-				assert.NoError(t, setLinkUp("dummy1"))
-			},
-			func(t *testing.T, devs []*tables.Device, routes []*tables.Route, neighbors []*tables.Neighbor) bool {
-				return len(devs) == 1 &&
-					devs[0].Name == "dummy1" &&
-					devs[0].Selected
-			},
-		},
-		{
-			"skip-bridge-devices",
-			func(t *testing.T) {
-				require.NoError(t, createBridge("br0", "192.168.5.1/24", false))
-				require.NoError(t, setMaster("dummy1", "br0"))
-			},
-			func(t *testing.T, devs []*tables.Device, routes []*tables.Route, neighbors []*tables.Neighbor) bool {
-				return len(devs) == 0
-			},
-		},
-	}
-
-	tlog := hivetest.Logger(t)
-	ns := netns.NewNetNS(t)
-	ns.Do(func() error {
-		var (
-			db             *statedb.DB
-			devicesTable   statedb.Table[*tables.Device]
-			routesTable    statedb.Table[*tables.Route]
-			neighborsTable statedb.Table[*tables.Neighbor]
-		)
 		h := hive.New(
 			DevicesControllerCell,
 			cell.Provide(func() (*netlinkFuncs, error) {
-				// Provide the normal netlink interface, but restrict it to the test network
-				// namespace.
+				// Provide the normal netlink interface, restricted to the test network namespace.
 				return makeNetlinkFuncs()
 			}),
-
-			cell.Invoke(func(db_ *statedb.DB, devicesTable_ statedb.Table[*tables.Device], routesTable_ statedb.Table[*tables.Route], neighborsTable_ statedb.Table[*tables.Neighbor]) {
-				db = db_
-				devicesTable = devicesTable_
-				routesTable = routesTable_
-				neighborsTable = neighborsTable_
-			}))
-		hive.AddConfigOverride(h, func(c *DevicesConfig) {
-			c.EnableStateDBNeighborSync = true
-		})
-
-		// Create a dummy device before starting to exercise initialize()
-		require.NoError(t, createDummy("dummy0", "192.168.0.1/24", false))
-
-		err := h.Start(tlog, ctx)
-		require.NoError(t, err)
-
-		for _, step := range testSteps {
-			step.prepare(t)
-
-			// Get the new set of devices
-			for {
-				txn := db.ReadTxn()
-				allDevs := statedb.Collect(devicesTable.All(txn))
-				devs, devsInvalidated := tables.SelectedDevices(devicesTable, txn)
-
-				routesIter, routesIterInvalidated := routesTable.AllWatch(txn)
-				routes := statedb.Collect(routesIter)
-
-				neighborsIter, neighborsIterInvalidated := neighborsTable.AllWatch(txn)
-				neighbors := statedb.Collect(neighborsIter)
-
-				// Stop if the test case passes and there are no orphan routes left in the
-				// route / neighbor table.
-				if step.check(t, devs, routes, neighbors) &&
-					!orphanRoutes(allDevs, routes) && !orphanNeighbors(allDevs, neighbors) {
-					break
-				}
-
-				// Wait for a changes and try again.
-				select {
-				case <-routesIterInvalidated:
-				case <-devsInvalidated:
-				case <-neighborsIterInvalidated:
-				case <-ctx.Done():
-					txn.WriteJSON(os.Stdout)
-					t.Fatalf("Test case %q timed out while waiting for devices", step.name)
-				}
-			}
-
-			if t.Failed() {
-				break
-			}
-		}
-
-		err = h.Stop(tlog, ctx)
-		require.NoError(t, err)
-		return nil
-	})
-}
-
-// Test that if the user specifies a device wildcard, then all devices not matching the wildcard
-// will be marked as non-selected.
-func TestDevicesController_Wildcards(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	testutils.PrivilegedTest(t)
-	devicesControllerTestSetup(t)
-
-	tlog := hivetest.Logger(t)
-	ns := netns.NewNetNS(t)
-	ns.Do(func() error {
-		var (
-			db           *statedb.DB
-			devicesTable statedb.Table[*tables.Device]
-		)
-		h := hive.New(
-			DevicesControllerCell,
-			cell.Provide(func() (*netlinkFuncs, error) { return makeNetlinkFuncs() }),
-			cell.Invoke(func(db_ *statedb.DB, devicesTable_ statedb.Table[*tables.Device]) {
-				db = db_
-				devicesTable = devicesTable_
-			}))
-		hive.AddConfigOverride(h, func(c *DevicesConfig) {
-			c.Devices = []string{"dummy+"}
-		})
-
-		err := h.Start(tlog, ctx)
-		require.NoError(t, err)
-		require.NoError(t, createDummy("dummy0", "192.168.0.1/24", false))
-		require.NoError(t, createDummy("nonviable", "192.168.1.1/24", false))
-
-		// This device satisfies the autodetection rule, but should not be included
-		// because the ForceDeviceDetection option is not enabled
-		require.NoError(t, createDummy("eth0", "1.2.3.4/24", false))
-
-		for {
-			rxn := db.ReadTxn()
-			devs, invalidated := tables.SelectedDevices(devicesTable, rxn)
-
-			if len(devs) == 1 && devs[0].Name == "dummy0" {
-				break
-			}
-
-			// Not yet what we expected, wait for changes and try again.
-			select {
-			case <-ctx.Done():
-				t.Fatalf("Test timed out while waiting for devices, last seen: %v", devs)
-			case <-invalidated:
-			}
-		}
-
-		err = h.Stop(tlog, context.TODO())
-		assert.NoError(t, err)
-		return nil
-	})
-}
-
-// TestDevicesController_with_ForcedDetection tests the behavior of device detection when forced detection is enabled.
-// It expects all devices matching a specific pattern to be detected will append to detected devices and marked as selected.
-func TestDevicesController_with_ForcedDetection(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	testutils.PrivilegedTest(t)
-	devicesControllerTestSetup(t)
-
-	tlog := hivetest.Logger(t)
-	ns := netns.NewNetNS(t)
-	ns.Do(func() error {
-		var (
-			db           *statedb.DB
-			devicesTable statedb.Table[*tables.Device]
-			h            *hive.Hive
 		)
 
-		// Function to set up the hive and run device detection
-		runDeviceDetection := func(devicePattern string, forceDetection bool) error {
-			h = hive.New(
-				DevicesControllerCell,
-				cell.Provide(func() (*netlinkFuncs, error) { return makeNetlinkFuncs() }),
-				cell.Invoke(func(db_ *statedb.DB, devicesTable_ statedb.Table[*tables.Device]) {
-					db = db_
-					devicesTable = devicesTable_
-				}),
-			)
-			hive.AddConfigOverride(h, func(c *DevicesConfig) {
-				c.Devices = []string{devicePattern}
-				c.ForceDeviceDetection = forceDetection
-			})
+		log := hivetest.Logger(t)
+		t.Cleanup(func() {
+			assert.NoError(t, h.Stop(log, context.TODO()))
+		})
 
-			return h.Start(tlog, ctx)
+		// Parse the shebang arguments in the script.
+		flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+		h.RegisterFlags(flags)
+		require.NoError(t, flags.Parse(args), "flags.Parse")
+
+		cmds, err := h.ScriptCommands(log)
+		require.NoError(t, err, "ScriptCommands")
+		maps.Insert(cmds, maps.All(script.DefaultCmds()))
+
+		return &script.Engine{
+			Cmds: cmds,
 		}
+	}
 
-		// Function to check the expected number of devices
-		testDevices := func(expectedCount int) bool {
-			rxn := db.ReadTxn()
-			devs, invalidated := tables.SelectedDevices(devicesTable, rxn)
-			if len(devs) == expectedCount {
-				return true
-			}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
 
-			select {
-			case <-ctx.Done():
-				t.Fatalf("Test timed out while waiting for devices, last seen: %v", devs)
-				return false
-			case <-invalidated:
-				return false
-			}
-		}
-
-		// Create dummy interfaces as per test requirements
-		require.NoError(t, createDummy("dummy0", "192.168.0.1/24", false))
-		require.NoError(t, createDummy("dummy1", "192.168.1.1/24", false))
-
-		// This device does not match the "dummy+" pattern, but should be included
-		// because the ForceDeviceDetection option is enabled
-		require.NoError(t, createDummy("eth0", "1.2.3.4/24", false))
-
-		// Test with forced detection enabled
-		require.NoError(t, runDeviceDetection("dummy+", true))
-		require.True(t, testDevices(3), "Expecting all three devices to be detected")
-		require.NoError(t, h.Stop(tlog, ctx))
-
-		return nil
-	})
+	scripttest.Test(t,
+		ctx,
+		setup,
+		[]string{"PATH=" + os.Getenv("PATH")},
+		"testdata/device-*.txtar")
 }
 
 func TestDevicesController_Restarts(t *testing.T) {
@@ -690,260 +278,4 @@ func TestDevicesController_Restarts(t *testing.T) {
 	err = h.Stop(tlog, ctx)
 	assert.NoError(t, err)
 
-}
-
-func createLink(linkTemplate netlink.Link, iface, ipAddr string, flagMulticast bool) error {
-	var flags net.Flags
-	if flagMulticast {
-		flags = net.FlagMulticast
-	}
-	*linkTemplate.Attrs() = netlink.LinkAttrs{
-		Name:  iface,
-		Flags: flags,
-	}
-
-	if err := netlink.LinkAdd(linkTemplate); err != nil {
-		return err
-	}
-
-	if ipAddr != "" {
-		if err := addAddr(iface, ipAddr); err != nil {
-			return err
-		}
-	}
-
-	link, err := netlink.LinkByName(iface)
-	if err != nil {
-		return err
-	}
-
-	if err := netlink.LinkSetUp(link); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func deleteLink(name string) error {
-	link, err := netlink.LinkByName(name)
-	if err != nil {
-		return err
-	}
-	return netlink.LinkDel(link)
-}
-
-func createDummy(iface, ipAddr string, flagMulticast bool) error {
-	return createLink(&netlink.Dummy{}, iface, ipAddr, flagMulticast)
-}
-
-func createVeth(iface, ipAddr string, flagMulticast bool) error {
-	return createLink(&netlink.Veth{PeerName: iface + "_"}, iface, ipAddr, flagMulticast)
-}
-
-func createBridge(iface, ipAddr string, flagMulticast bool) error {
-	return createLink(&netlink.Bridge{}, iface, ipAddr, flagMulticast)
-}
-
-func createBond(iface, ipAddr string, flagMulticast bool) error {
-	bond := netlink.NewLinkBond(netlink.LinkAttrs{})
-	bond.Mode = netlink.BOND_MODE_BALANCE_RR
-	return createLink(bond, iface, ipAddr, flagMulticast)
-}
-
-func setLinkUp(iface string) error {
-	link, err := netlink.LinkByName(iface)
-	if err != nil {
-		return err
-	}
-	return netlink.LinkSetUp(link)
-}
-
-func setMaster(iface string, master string) error {
-	masterLink, err := netlink.LinkByName(master)
-	if err != nil {
-		return err
-	}
-	link, err := netlink.LinkByName(iface)
-	if err != nil {
-		return err
-	}
-	return netlink.LinkSetMaster(link, masterLink)
-}
-
-func setBondMaster(iface string, master string) error {
-	masterLink, err := netlink.LinkByName(master)
-	if err != nil {
-		return err
-	}
-	link, err := netlink.LinkByName(iface)
-	if err != nil {
-		return err
-	}
-	netlink.LinkSetDown(link)
-	defer netlink.LinkSetUp(link)
-	return netlink.LinkSetBondSlave(link, masterLink.(*netlink.Bond))
-}
-func addAddr(iface string, cidr string) error {
-	return addAddrScoped(iface, cidr, netlink.SCOPE_SITE, 0)
-}
-
-func addAddrScoped(iface string, cidr string, scope netlink.Scope, flags int) error {
-	ip, ipnet, err := net.ParseCIDR(cidr)
-	if err != nil {
-		return fmt.Errorf("ParseCIDR: %w", err)
-	}
-	ipnet.IP = ip
-	link, err := netlink.LinkByName(iface)
-	if err != nil {
-		return fmt.Errorf("LinkByName: %w", err)
-	}
-
-	if err := netlink.AddrAdd(link, &netlink.Addr{IPNet: ipnet, Scope: int(scope), Flags: flags}); err != nil {
-		return fmt.Errorf("AddrAdd: %w", err)
-	}
-	return nil
-}
-
-type addRouteParams struct {
-	iface string
-	gw    string
-	src   string
-	dst   string
-	table int
-	scope netlink.Scope
-}
-
-func addRoute(p addRouteParams) error {
-	link, err := netlink.LinkByName(p.iface)
-	if err != nil {
-		return err
-	}
-
-	var dst *net.IPNet
-	if p.dst != "" {
-		_, dst, err = net.ParseCIDR(p.dst)
-		if err != nil {
-			return err
-		}
-	}
-
-	var src net.IP
-	if p.src != "" {
-		src = net.ParseIP(p.src)
-	}
-
-	if p.table == 0 {
-		p.table = unix.RT_TABLE_MAIN
-	}
-
-	route := &netlink.Route{
-		LinkIndex: link.Attrs().Index,
-		Dst:       dst,
-		Src:       src,
-		Gw:        net.ParseIP(p.gw),
-		Table:     p.table,
-		Scope:     p.scope,
-	}
-	if err := netlink.RouteAdd(route); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func delRoute(p addRouteParams) error {
-	link, err := netlink.LinkByName(p.iface)
-	if err != nil {
-		return err
-	}
-
-	var dst *net.IPNet
-	if p.dst != "" {
-		_, dst, err = net.ParseCIDR(p.dst)
-		if err != nil {
-			return err
-		}
-	}
-
-	var src net.IP
-	if p.src != "" {
-		src = net.ParseIP(p.src)
-	}
-
-	if p.table == 0 {
-		p.table = unix.RT_TABLE_MAIN
-	}
-
-	route := &netlink.Route{
-		LinkIndex: link.Attrs().Index,
-		Dst:       dst,
-		Src:       src,
-		Gw:        net.ParseIP(p.gw),
-		Table:     p.table,
-		Scope:     p.scope,
-	}
-	if err := netlink.RouteDel(route); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-type addNeighborParams struct {
-	iface string
-	ip    string
-	mac   string
-	flags int
-}
-
-func addNeighbor(p addNeighborParams) error {
-	link, err := netlink.LinkByName(p.iface)
-	if err != nil {
-		return err
-	}
-
-	hwAddr, err := net.ParseMAC(p.mac)
-	if err != nil {
-		return err
-	}
-
-	neigh := &netlink.Neigh{
-		LinkIndex:    link.Attrs().Index,
-		Type:         netlink.NDA_DST,
-		State:        netlink.NUD_PERMANENT,
-		IP:           net.ParseIP(p.ip),
-		HardwareAddr: hwAddr,
-		Flags:        p.flags,
-	}
-	if err := netlink.NeighAdd(neigh); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func delNeighbor(p addNeighborParams) error {
-	link, err := netlink.LinkByName(p.iface)
-	if err != nil {
-		return err
-	}
-
-	hwAddr, err := net.ParseMAC(p.mac)
-	if err != nil {
-		return err
-	}
-
-	neigh := &netlink.Neigh{
-		LinkIndex:    link.Attrs().Index,
-		Type:         netlink.NDA_DST,
-		State:        netlink.NUD_PERMANENT,
-		IP:           net.ParseIP(p.ip),
-		HardwareAddr: hwAddr,
-		Flags:        p.flags,
-	}
-	if err := netlink.NeighDel(neigh); err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/pkg/datapath/linux/testdata/device-controller-tables.txtar
+++ b/pkg/datapath/linux/testdata/device-controller-tables.txtar
@@ -1,0 +1,183 @@
+#! --enable-statedb-neighbor-sync
+
+# Tests interactions with all statedb tables managed by the device controller.
+
+# Start the hive and wait for tables to be synchronized.
+hive start
+db/initialized
+
+# Start with clean state.
+db/cmp devices devices_lo.table
+db/cmp routes routes_empty.table
+db/cmp neighbors neighbors_empty.table
+
+# Add dummy0 interface (keep it down).
+exec ip link add dummy0 type dummy
+exec ip addr add 192.168.0.1/24 dev dummy0
+
+# Verify lo + dummy0 interface.
+db/cmp devices devices_lo_dummy0.table
+db/cmp routes routes_dummy0.table
+db/cmp neighbors neighbors_empty.table
+
+# Add dummy1 interface with multiple addresses, routes and neighbor entries.
+exec ip link add dummy1 type dummy
+exec ip link set dummy1 addrgenmode none
+exec ip link set dummy1 up
+exec ip addr add 192.168.1.1/24 dev dummy1
+exec ip addr add 192.168.1.2/24 dev dummy1
+exec ip route add 192.168.1.253/32 dev dummy1
+exec ip route add 192.168.1.254/32 dev dummy1
+exec ip route add default via 192.168.1.254 dev dummy1
+exec ip neighbor add 192.168.1.253 lladdr 00:00:5e:00:53:01 nud permanent extern_learn dev dummy1
+exec ip neighbor add 192.168.1.254 lladdr 00:00:5e:00:53:02 nud permanent extern_learn dev dummy1
+exec ip neighbor add ::ffff:192.168.1.254 lladdr 00:00:5e:00:53:02 nud permanent extern_learn dev dummy1
+
+# Verify dummy0 + dummy1 interfaces routes and neighbors.
+db/cmp devices devices_lo_dummy01.table
+db/cmp routes routes_dummy01.table
+db/cmp neighbors neighbors_dummy1.table
+
+# Exercise device table primary index.
+db/get --columns=Name,Index,Selected,Type,Flags,Addresses -o devices.actual devices 3
+* cmp devices_dummy1.table devices.actual
+
+# Exercise device table "selected" index.
+db/prefix --index=selected --columns=Name,Index,Selected,Type,Flags,Addresses -o devices.actual devices true
+* cmp devices_dummy1.table devices.actual
+
+# Exercise device table "name" index.
+db/prefix --index=name --columns=Name,Index,Selected,Type,Flags,Addresses -o devices.actual devices dummy
+* cmp devices_dummy01.table devices.actual
+
+# Exercise route table primary index - get.
+db/get -o routes.actual routes 254:3:192.168.1.254/32
+* cmp routes_table254_link3_254.table routes.actual
+
+# Exercise route table primary index - prefix.
+db/prefix -o routes.actual routes 254:3
+* cmp routes_table254_link3_all.table routes.actual
+
+# Exercise route table "LinkIndex" index.
+db/prefix --index=LinkIndex -o routes.actual routes 3
+* cmp routes_link3.table routes.actual
+
+# Exercise neighbor table primary index - get.
+db/get -o neighbors.actual neighbors 3:192.168.1.254
+* cmp neighbors_dummy1_254.table neighbors.actual
+
+# Exercise neighbor table primary index - prefix.
+db/prefix -o neighbors.actual neighbors 3
+* cmp neighbors_dummy1.table neighbors.actual
+
+# Exercise neighbor table "LinkIndex" index.
+db/prefix --index=LinkIndex -o neighbors.actual neighbors 3
+* cmp neighbors_dummy1_link.table neighbors.actual
+
+# Exercise neighbor table "IPAddr" index.
+db/prefix --index=IPAddr -o neighbors.actual neighbors 192.168.1.253
+* cmp neighbors_dummy1_253.table neighbors.actual
+
+# Delete dummy1
+exec ip link del dummy1
+
+# Verify only lo + dummy0 interface and their routes left
+db/cmp devices devices_lo_dummy0.table
+db/cmp routes routes_dummy0.table
+db/cmp neighbors neighbors_empty.table
+
+# Delete dummy0
+exec ip link del dummy0
+
+# Verify clean state.
+db/cmp devices devices_lo.table
+db/cmp routes routes_empty.table
+db/cmp neighbors neighbors_empty.table
+
+# ---------------------------------------------
+
+-- devices_lo.table --
+Name   Index   Selected   Type     Flags      Addresses
+lo     1       false      device   loopback
+
+-- devices_lo_dummy0.table --
+Name     Index   Selected   Type     Flags       Addresses
+lo       1       false      device   loopback
+dummy0   2       false      dummy    broadcast   192.168.0.1
+
+-- devices_lo_dummy01.table --
+Name     Index   Selected   Type     Flags          Addresses
+lo       1       false      device   loopback
+dummy0   2       false      dummy    broadcast      192.168.0.1
+dummy1   3       true       dummy    up|broadcast   192.168.1.1, 192.168.1.2
+
+-- devices_dummy01.table --
+Name     Index   Selected   Type    Flags          Addresses
+dummy0   2       false      dummy   broadcast      192.168.0.1
+dummy1   3       true       dummy   up|broadcast   192.168.1.1, 192.168.1.2
+-- devices_dummy1.table --
+Name     Index   Selected   Type    Flags          Addresses
+dummy1   3       true       dummy   up|broadcast   192.168.1.1, 192.168.1.2
+-- devices_placeholder --
+
+
+-- routes_empty.table --
+Destination   Source   Gateway   LinkIndex   Table   Scope
+
+-- routes_dummy0.table --
+Destination      Source        Gateway   LinkIndex   Table   Scope
+192.168.0.1/32   192.168.0.1             2           255     254
+
+-- routes_dummy01.table --
+Destination        Source        Gateway         LinkIndex   Table   Scope
+0.0.0.0/0                        192.168.1.254   3           254     0
+192.168.1.0/24     192.168.1.1                   3           254     253
+192.168.1.253/32                                 3           254     253
+192.168.1.254/32                                 3           254     253
+192.168.0.1/32     192.168.0.1                   2           255     254
+192.168.1.1/32     192.168.1.1                   3           255     254
+192.168.1.2/32     192.168.1.1                   3           255     254
+192.168.1.255/32   192.168.1.1                   3           255     253
+ff00::/8                                         3           255     0
+
+-- routes_table254_link3_254.table --
+Destination        Source   Gateway   LinkIndex   Table   Scope
+192.168.1.254/32                      3           254     253
+-- routes_table254_link3_all.table --
+Destination        Source        Gateway         LinkIndex   Table   Scope
+0.0.0.0/0                        192.168.1.254   3           254     0
+192.168.1.0/24     192.168.1.1                   3           254     253
+192.168.1.253/32                                 3           254     253
+192.168.1.254/32                                 3           254     253
+-- routes_link3.table --
+Destination        Source        Gateway         LinkIndex   Table   Scope
+192.168.1.254/32                                 3           254     253
+192.168.1.253/32                                 3           254     253
+192.168.1.0/24     192.168.1.1                   3           254     253
+0.0.0.0/0                        192.168.1.254   3           254     0
+192.168.1.1/32     192.168.1.1                   3           255     254
+192.168.1.2/32     192.168.1.1                   3           255     254
+192.168.1.255/32   192.168.1.1                   3           255     253
+ff00::/8                                         3           255     0
+-- routes_placeholder --
+
+
+-- neighbors_empty.table --
+LinkIndex   IPAddr   HardwareAddr   Type   State   Flags   FlagsExt
+
+-- neighbors_dummy1.table --
+LinkIndex   IPAddr                 HardwareAddr        Type   State   Flags   FlagsExt
+3           192.168.1.253          00:00:5e:00:53:01   1      0x80    0x10    0x0
+3           192.168.1.254          00:00:5e:00:53:02   1      0x80    0x10    0x0
+3           ::ffff:192.168.1.254   00:00:5e:00:53:02   1      0x80    0x10    0x0
+-- neighbors_dummy1_link.table --
+LinkIndex   IPAddr                 HardwareAddr        Type   State   Flags   FlagsExt
+3           192.168.1.254          00:00:5e:00:53:02   1      0x80    0x10    0x0
+3           ::ffff:192.168.1.254   00:00:5e:00:53:02   1      0x80    0x10    0x0
+3           192.168.1.253          00:00:5e:00:53:01   1      0x80    0x10    0x0
+-- neighbors_dummy1_254.table --
+LinkIndex   IPAddr          HardwareAddr        Type   State   Flags   FlagsExt
+3           192.168.1.254   00:00:5e:00:53:02   1      0x80    0x10    0x0
+-- neighbors_dummy1_253.table --
+LinkIndex   IPAddr          HardwareAddr        Type   State   Flags   FlagsExt
+3           192.168.1.253   00:00:5e:00:53:01   1      0x80    0x10    0x0

--- a/pkg/datapath/linux/testdata/device-controller-tables.txtar
+++ b/pkg/datapath/linux/testdata/device-controller-tables.txtar
@@ -1,13 +1,18 @@
 #! --enable-statedb-neighbor-sync
 
 # Tests interactions with all statedb tables managed by the device controller.
+# NOTES:
+# - We can not rely on presence of particular interfaces upon ns creation (e.g. sit0 interface may or may not
+#   be present based on whether or not the sit kernel module is loaded). Therefore we always filter devices by name.
+# - Because of the above, we can not rely on assignment of particular interface indexes to the newly created interfaces.
+#   Therefore we always omit the Index / DeviceIndex columns in all tables.
 
 # Start the hive and wait for tables to be synchronized.
 hive start
 db/initialized
 
 # Start with clean state.
-db/cmp devices devices_lo.table
+db/cmp devices --grep dummy devices_empty.table
 db/cmp routes routes_empty.table
 db/cmp neighbors neighbors_empty.table
 
@@ -16,7 +21,7 @@ exec ip link add dummy0 type dummy
 exec ip addr add 192.168.0.1/24 dev dummy0
 
 # Verify lo + dummy0 interface.
-db/cmp devices devices_lo_dummy0.table
+db/cmp devices --grep dummy devices_dummy0.table
 db/cmp routes routes_dummy0.table
 db/cmp neighbors neighbors_empty.table
 
@@ -34,55 +39,51 @@ exec ip neighbor add 192.168.1.254 lladdr 00:00:5e:00:53:02 nud permanent extern
 exec ip neighbor add ::ffff:192.168.1.254 lladdr 00:00:5e:00:53:02 nud permanent extern_learn dev dummy1
 
 # Verify dummy0 + dummy1 interfaces routes and neighbors.
-db/cmp devices devices_lo_dummy01.table
+db/cmp devices --grep dummy devices_dummy01.table
 db/cmp routes routes_dummy01.table
 db/cmp neighbors neighbors_dummy1.table
 
-# Exercise device table primary index.
-db/get --columns=Name,Index,Selected,Type,Flags,Addresses -o devices.actual devices 3
-* cmp devices_dummy1.table devices.actual
-
 # Exercise device table "selected" index.
-db/prefix --index=selected --columns=Name,Index,Selected,Type,Flags,Addresses -o devices.actual devices true
+db/prefix --index=selected --columns=Name,Selected,Type,Flags,Addresses -o devices.actual devices true
 * cmp devices_dummy1.table devices.actual
 
 # Exercise device table "name" index.
-db/prefix --index=name --columns=Name,Index,Selected,Type,Flags,Addresses -o devices.actual devices dummy
+db/prefix --index=name --columns=Name,Selected,Type,Flags,Addresses -o devices.actual devices dummy
 * cmp devices_dummy01.table devices.actual
 
 # Exercise route table primary index - get.
-db/get -o routes.actual routes 254:3:192.168.1.254/32
-* cmp routes_table254_link3_254.table routes.actual
+# db/get -o routes.actual routes 254:3:192.168.1.254/32
+# * cmp routes_table254_link3_254.table routes.actual
 
 # Exercise route table primary index - prefix.
-db/prefix -o routes.actual routes 254:3
-* cmp routes_table254_link3_all.table routes.actual
+# db/prefix -o routes.actual routes 254:3
+# * cmp routes_table254_link3_all.table routes.actual
 
 # Exercise route table "LinkIndex" index.
-db/prefix --index=LinkIndex -o routes.actual routes 3
-* cmp routes_link3.table routes.actual
+# db/prefix --index=LinkIndex -o routes.actual routes 3
+# * cmp routes_link3.table routes.actual
 
 # Exercise neighbor table primary index - get.
-db/get -o neighbors.actual neighbors 3:192.168.1.254
-* cmp neighbors_dummy1_254.table neighbors.actual
+# db/get -o neighbors.actual neighbors 3:192.168.1.254
+# * cmp neighbors_dummy1_254.table neighbors.actual
 
 # Exercise neighbor table primary index - prefix.
-db/prefix -o neighbors.actual neighbors 3
-* cmp neighbors_dummy1.table neighbors.actual
+# db/prefix -o neighbors.actual neighbors 3
+# * cmp neighbors_dummy1.table neighbors.actual
 
 # Exercise neighbor table "LinkIndex" index.
-db/prefix --index=LinkIndex -o neighbors.actual neighbors 3
-* cmp neighbors_dummy1_link.table neighbors.actual
+# db/prefix --index=LinkIndex -o neighbors.actual neighbors 3
+# * cmp neighbors_dummy1_link.table neighbors.actual
 
 # Exercise neighbor table "IPAddr" index.
-db/prefix --index=IPAddr -o neighbors.actual neighbors 192.168.1.253
+db/prefix --index=IPAddr --columns=IPAddr,HardwareAddr,Type,State,Flags,FlagsExt -o neighbors.actual neighbors 192.168.1.253
 * cmp neighbors_dummy1_253.table neighbors.actual
 
 # Delete dummy1
 exec ip link del dummy1
 
-# Verify only lo + dummy0 interface and their routes left
-db/cmp devices devices_lo_dummy0.table
+# Verify only dummy0 interface and their routes left
+db/cmp devices --grep dummy devices_dummy0.table
 db/cmp routes routes_dummy0.table
 db/cmp neighbors neighbors_empty.table
 
@@ -90,34 +91,31 @@ db/cmp neighbors neighbors_empty.table
 exec ip link del dummy0
 
 # Verify clean state.
-db/cmp devices devices_lo.table
+db/cmp devices --grep dummy devices_empty.table
 db/cmp routes routes_empty.table
 db/cmp neighbors neighbors_empty.table
 
 # ---------------------------------------------
 
--- devices_lo.table --
-Name   Index   Selected   Type     Flags      Addresses
-lo     1       false      device   loopback
+-- devices_empty.table --
+Name   Selected   Type     Flags      Addresses
 
--- devices_lo_dummy0.table --
-Name     Index   Selected   Type     Flags       Addresses
-lo       1       false      device   loopback
-dummy0   2       false      dummy    broadcast   192.168.0.1
-
--- devices_lo_dummy01.table --
-Name     Index   Selected   Type     Flags          Addresses
-lo       1       false      device   loopback
-dummy0   2       false      dummy    broadcast      192.168.0.1
-dummy1   3       true       dummy    up|broadcast   192.168.1.1, 192.168.1.2
+-- devices_dummy0.table --
+Name     Selected   Type     Flags       Addresses
+dummy0   false      dummy    broadcast   192.168.0.1
 
 -- devices_dummy01.table --
-Name     Index   Selected   Type    Flags          Addresses
-dummy0   2       false      dummy   broadcast      192.168.0.1
-dummy1   3       true       dummy   up|broadcast   192.168.1.1, 192.168.1.2
+Name     Selected   Type     Flags          Addresses
+dummy0   false      dummy    broadcast      192.168.0.1
+dummy1   true       dummy    up|broadcast   192.168.1.1, 192.168.1.2
+
+-- devices_dummy01.table --
+Name     Selected   Type    Flags          Addresses
+dummy0   false      dummy   broadcast      192.168.0.1
+dummy1   true       dummy   up|broadcast   192.168.1.1, 192.168.1.2
 -- devices_dummy1.table --
-Name     Index   Selected   Type    Flags          Addresses
-dummy1   3       true       dummy   up|broadcast   192.168.1.1, 192.168.1.2
+Name     Selected   Type    Flags          Addresses
+dummy1   true       dummy   up|broadcast   192.168.1.1, 192.168.1.2
 -- devices_placeholder --
 
 
@@ -125,59 +123,59 @@ dummy1   3       true       dummy   up|broadcast   192.168.1.1, 192.168.1.2
 Destination   Source   Gateway   LinkIndex   Table   Scope
 
 -- routes_dummy0.table --
-Destination      Source        Gateway   LinkIndex   Table   Scope
-192.168.0.1/32   192.168.0.1             2           255     254
+Destination      Source        Gateway   Table   Scope
+192.168.0.1/32   192.168.0.1             255     254
 
 -- routes_dummy01.table --
-Destination        Source        Gateway         LinkIndex   Table   Scope
-0.0.0.0/0                        192.168.1.254   3           254     0
-192.168.1.0/24     192.168.1.1                   3           254     253
-192.168.1.253/32                                 3           254     253
-192.168.1.254/32                                 3           254     253
-192.168.0.1/32     192.168.0.1                   2           255     254
-192.168.1.1/32     192.168.1.1                   3           255     254
-192.168.1.2/32     192.168.1.1                   3           255     254
-192.168.1.255/32   192.168.1.1                   3           255     253
-ff00::/8                                         3           255     0
+Destination        Source        Gateway         Table   Scope
+0.0.0.0/0                        192.168.1.254   254     0
+192.168.1.0/24     192.168.1.1                   254     253
+192.168.1.253/32                                 254     253
+192.168.1.254/32                                 254     253
+192.168.0.1/32     192.168.0.1                   255     254
+192.168.1.1/32     192.168.1.1                   255     254
+192.168.1.2/32     192.168.1.1                   255     254
+192.168.1.255/32   192.168.1.1                   255     253
+ff00::/8                                         255     0
 
 -- routes_table254_link3_254.table --
-Destination        Source   Gateway   LinkIndex   Table   Scope
-192.168.1.254/32                      3           254     253
+Destination        Source   Gateway   Table   Scope
+192.168.1.254/32                      254     253
 -- routes_table254_link3_all.table --
-Destination        Source        Gateway         LinkIndex   Table   Scope
-0.0.0.0/0                        192.168.1.254   3           254     0
-192.168.1.0/24     192.168.1.1                   3           254     253
-192.168.1.253/32                                 3           254     253
-192.168.1.254/32                                 3           254     253
+Destination        Source        Gateway         Table   Scope
+0.0.0.0/0                        192.168.1.254   254     0
+192.168.1.0/24     192.168.1.1                   254     253
+192.168.1.253/32                                 254     253
+192.168.1.254/32                                 254     253
 -- routes_link3.table --
-Destination        Source        Gateway         LinkIndex   Table   Scope
-192.168.1.254/32                                 3           254     253
-192.168.1.253/32                                 3           254     253
-192.168.1.0/24     192.168.1.1                   3           254     253
-0.0.0.0/0                        192.168.1.254   3           254     0
-192.168.1.1/32     192.168.1.1                   3           255     254
-192.168.1.2/32     192.168.1.1                   3           255     254
-192.168.1.255/32   192.168.1.1                   3           255     253
-ff00::/8                                         3           255     0
+Destination        Source        Gateway         Table   Scope
+192.168.1.254/32                                 254     253
+192.168.1.253/32                                 254     253
+192.168.1.0/24     192.168.1.1                   254     253
+0.0.0.0/0                        192.168.1.254   254     0
+192.168.1.1/32     192.168.1.1                   255     254
+192.168.1.2/32     192.168.1.1                   255     254
+192.168.1.255/32   192.168.1.1                   255     253
+ff00::/8                                         255     0
 -- routes_placeholder --
 
 
 -- neighbors_empty.table --
-LinkIndex   IPAddr   HardwareAddr   Type   State   Flags   FlagsExt
+IPAddr   HardwareAddr   Type   State   Flags   FlagsExt
 
 -- neighbors_dummy1.table --
-LinkIndex   IPAddr                 HardwareAddr        Type   State   Flags   FlagsExt
-3           192.168.1.253          00:00:5e:00:53:01   1      0x80    0x10    0x0
-3           192.168.1.254          00:00:5e:00:53:02   1      0x80    0x10    0x0
-3           ::ffff:192.168.1.254   00:00:5e:00:53:02   1      0x80    0x10    0x0
+IPAddr                 HardwareAddr        Type   State   Flags   FlagsExt
+192.168.1.253          00:00:5e:00:53:01   1      0x80    0x10    0x0
+192.168.1.254          00:00:5e:00:53:02   1      0x80    0x10    0x0
+::ffff:192.168.1.254   00:00:5e:00:53:02   1      0x80    0x10    0x0
 -- neighbors_dummy1_link.table --
-LinkIndex   IPAddr                 HardwareAddr        Type   State   Flags   FlagsExt
-3           192.168.1.254          00:00:5e:00:53:02   1      0x80    0x10    0x0
-3           ::ffff:192.168.1.254   00:00:5e:00:53:02   1      0x80    0x10    0x0
-3           192.168.1.253          00:00:5e:00:53:01   1      0x80    0x10    0x0
+IPAddr                 HardwareAddr        Type   State   Flags   FlagsExt
+192.168.1.254          00:00:5e:00:53:02   1      0x80    0x10    0x0
+::ffff:192.168.1.254   00:00:5e:00:53:02   1      0x80    0x10    0x0
+192.168.1.253          00:00:5e:00:53:01   1      0x80    0x10    0x0
 -- neighbors_dummy1_254.table --
-LinkIndex   IPAddr          HardwareAddr        Type   State   Flags   FlagsExt
-3           192.168.1.254   00:00:5e:00:53:02   1      0x80    0x10    0x0
+IPAddr          HardwareAddr        Type   State   Flags   FlagsExt
+192.168.1.254   00:00:5e:00:53:02   1      0x80    0x10    0x0
 -- neighbors_dummy1_253.table --
-LinkIndex   IPAddr          HardwareAddr        Type   State   Flags   FlagsExt
-3           192.168.1.253   00:00:5e:00:53:01   1      0x80    0x10    0x0
+IPAddr          HardwareAddr        Type   State   Flags   FlagsExt
+192.168.1.253   00:00:5e:00:53:01   1      0x80    0x10    0x0

--- a/pkg/datapath/linux/testdata/device-detection-force.txtar
+++ b/pkg/datapath/linux/testdata/device-detection-force.txtar
@@ -1,0 +1,35 @@
+#! --devices=dummy+ --force-device-detection
+
+# Tests the behavior of device detection when forced detection is enabled.
+
+# Start the hive and wait for tables to be synchronized.
+hive start
+db/initialized
+
+# Add dummy0 interface - matches devices wildcard, should be selected.
+exec ip link add dummy0 type dummy
+exec ip addr add 192.168.0.1/24 dev dummy0
+exec ip link set dummy0 up
+
+# Add dummy1 interface - matches devices wildcard, should be selected.
+exec ip link add dummy1 type dummy
+exec ip addr add 192.168.1.1/24 dev dummy1
+exec ip link set dummy1 up
+
+# Add eth0 interface - does not match devices wildcard, but still should be selected
+# because the force-device-detection option is enabled.
+exec ip link add eth0 type dummy
+exec ip addr add 1.2.3.4/24 dev eth0
+exec ip link set eth0 up
+
+# Verify selected devices. All 3 of them should be selected.
+db/cmp devices devices.table
+
+# ---------------------------------------------
+
+-- devices.table --
+Name        Index   Selected   Type
+lo          1       false      device
+dummy0      2       true       dummy
+dummy1      3       true       dummy
+eth0        4       true       dummy

--- a/pkg/datapath/linux/testdata/device-detection-wildcard.txtar
+++ b/pkg/datapath/linux/testdata/device-detection-wildcard.txtar
@@ -1,0 +1,37 @@
+#! --devices=dummy+
+
+# Test that if the user specifies a device wildcard, then all devices not matching the wildcard
+# will be marked as non-selected.
+
+# Start the hive and wait for tables to be synchronized.
+hive start
+db/initialized
+
+# Add dummy0 interface - matches devices wildcard.
+exec ip link add dummy0 type dummy
+exec ip addr add 192.168.0.1/24 dev dummy0
+exec ip link set dummy0 up
+
+# Add dummy1 interface - does not match devices wildcard.
+exec ip link add nonviable type dummy
+exec ip addr add 192.168.1.1/24 dev nonviable
+exec ip link set nonviable up
+
+# Add eth0 interface - does not match devices wildcard.
+# This device satisfies the autodetection rule, but should not be included
+# because the force-device-detection option is not enabled.
+exec ip link add eth0 type dummy
+exec ip addr add 1.2.3.4/24 dev eth0
+exec ip link set eth0 up
+
+# Verify selected devices. Only the one matching the wildcard is expected to be selected.
+db/cmp devices devices.table
+
+# ---------------------------------------------
+
+-- devices.table --
+Name        Index   Selected   Type
+lo          1       false      device
+dummy0      2       true       dummy
+nonviable   3       false      dummy
+eth0        4       false      dummy

--- a/pkg/datapath/linux/testdata/device-detection.txtar
+++ b/pkg/datapath/linux/testdata/device-detection.txtar
@@ -1,0 +1,74 @@
+# Tests the behavior of device detection without providing explicit --devices option.
+
+# Start the hive and wait for tables to be synchronized.
+hive start
+db/initialized
+
+# Create veth0 + veth1 interfaces without default route - should not be selected.
+exec ip link add veth0 type veth peer name veth1
+exec ip addr add 192.168.0.1/24 dev veth0
+exec ip link set veth0 up
+
+# Verify selected devices - none should be selected.
+db/cmp devices devices_veth_unselected.table
+
+# Add default route for veth0.
+exec ip route add default via 192.168.0.254 dev veth0
+
+# Verify selected devices - veth0 now should be selected.
+db/cmp devices devices_veth_selected.table
+
+# Add bond device and add veth0 into it.
+exec ip link add bond0 type bond
+exec ip addr add 192.168.2.1/24 dev bond0
+exec ip link set veth0 down
+exec ip link set veth0 master bond0
+exec ip link set bond0 up
+
+# Verify selected devices - only bond should be selected now.
+db/cmp devices devices_bond.table
+
+# Delete the bond interface.
+exec ip link del bond0
+exec ip link set veth0 up
+
+# Verify selected devices - veth0 now should be selected again.
+db/cmp devices devices_veth_selected.table
+
+# Add bridge interface and add veth0 into it.
+exec ip link add br0 type bridge
+exec ip addr add 192.168.3.1/24 dev br0
+exec ip link set veth0 down
+exec ip link set veth0 master br0
+exec ip link set br0 up
+
+# Verify selected devices - none should be selected as bridge devices are skipped.
+db/cmp devices devices_bridge.table
+
+# ---------------------------------------------
+
+-- devices_veth_unselected.table --
+Name     Index   Selected   Type
+lo       1       false      device
+veth1    2       false      veth
+veth0    3       false      veth
+
+-- devices_veth_selected.table --
+Name     Index   Selected   Type
+lo       1       false      device
+veth1    2       false      veth
+veth0    3       true       veth
+
+-- devices_bond.table --
+Name     Index   Selected   Type
+lo       1       false      device
+veth1    2       false      veth
+veth0    3       false      veth
+bond0    4       true       bond
+
+-- devices_bridge.table --
+Name     Index   Selected   Type
+lo       1       false      device
+veth1    2       false      veth
+veth0    3       false      device
+br0      5       false      bridge


### PR DESCRIPTION
This moves test logic previously written in Golang into script language provided by `github.com/cilium/hive/script`.
Covers all cases tested by the Go tests and additionally exercises all indexes provided by the statedb tables managed by the device controller (devices, routes and neighbors tables).

Stress-tested:
```
stress -p 30 ./dc.test -test.run=TestDevicesController
5s: 60 runs so far, 0 failures, 30 active
10s: 120 runs so far, 0 failures, 30 active
15s: 180 runs so far, 0 failures, 30 active
...
5m0s: 3790 runs so far, 0 failures, 30 active
```