### PR TITLE
cilium-cli/sysdump: add tetragon helm information

### DIFF
--- a/cilium-cli/sysdump/constants.go
+++ b/cilium-cli/sysdump/constants.go
@@ -87,6 +87,8 @@ const (
 	eniconfigsFileName                       = "aws-eniconfigs-<ts>.yaml"
 	ciliumHelmMetadataFileName               = "cilium-helm-metadata-<ts>.yaml"
 	ciliumHelmValuesFileName                 = "cilium-helm-values-<ts>.yaml"
+	tetragonHelmMetadataFileName             = "tetragon-helm-metadata-<ts>.yaml"
+	tetragonHelmValuesFileName               = "tetragon-helm-values-<ts>.yaml"
 	gopsFileName                             = "gops-%s-%s-<ts>-%s.txt"
 	hubbleDaemonsetFileName                  = "hubble-daemonset-<ts>.yaml"
 	hubbleFlowsFileName                      = "hubble-flows-%s-<ts>.json"

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -39,7 +39,8 @@ import (
 )
 
 const sysdumpLogFile = "cilium-sysdump.log"
-const helmReleaseName = "cilium"
+const ciliumHelmReleaseName = "cilium"
+const tetragonHelmReleaseName = "tetragon"
 
 // Options groups together the set of options required to collect a sysdump.
 type Options struct {
@@ -57,6 +58,8 @@ type Options struct {
 	CiliumEnvoyLabelSelector string
 	// The release name of Cilium Helm chart.
 	CiliumHelmReleaseName string
+	// The release name of Tetragon Helm chart.
+	TetragonHelmReleaseName string
 	// The labels used to target Cilium Node Init daemon set. Usually, this label is same as CiliumNodeInitLabelSelector.
 	CiliumNodeInitDaemonSetSelector string
 	// The labels used to target Cilium Node Init pods.
@@ -225,10 +228,17 @@ func NewCollector(
 	}
 
 	if c.Options.CiliumHelmReleaseName == "" {
-		c.log("ℹ️ Using default Cilium Helm release name: %q", helmReleaseName)
-		c.Options.CiliumHelmReleaseName = helmReleaseName
+		c.log("ℹ️ Using default Cilium Helm release name: %q", ciliumHelmReleaseName)
+		c.Options.CiliumHelmReleaseName = ciliumHelmReleaseName
 	} else {
 		c.log("ℹ️ Cilium Helm release name: %q", c.Options.CiliumHelmReleaseName)
+	}
+
+	if c.Options.TetragonHelmReleaseName == "" {
+		c.log("ℹ️ Using default Tetragon Helm release name: %q", tetragonHelmReleaseName)
+		c.Options.TetragonHelmReleaseName = tetragonHelmReleaseName
+	} else {
+		c.log("ℹ️ Tetragon Helm release name: %q", c.Options.TetragonHelmReleaseName)
 	}
 
 	if c.Options.CiliumSPIRENamespace == "" {
@@ -1620,7 +1630,7 @@ func (c *Collector) Run() error {
 	helmTasks := []Task{
 		{
 			CreatesSubtasks: true,
-			Description:     "Collecting Helm metadata from the release",
+			Description:     "Collecting Helm metadata from the Cilium release",
 			Quick:           true,
 			Task: func(ctx context.Context) error {
 				v, err := c.Client.GetHelmMetadata(ctx, c.Options.CiliumHelmReleaseName, c.Options.CiliumNamespace)
@@ -1635,7 +1645,22 @@ func (c *Collector) Run() error {
 		},
 		{
 			CreatesSubtasks: true,
-			Description:     "Collecting Helm values from the release",
+			Description:     "Collecting Helm metadata from the Tetragon release",
+			Quick:           true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.GetHelmMetadata(ctx, c.Options.TetragonHelmReleaseName, c.Options.TetragonNamespace)
+				if err != nil {
+					return fmt.Errorf("failed to get the helm metadata from the release: %w", err)
+				}
+				if err := c.WriteString(tetragonHelmMetadataFileName, v); err != nil {
+					return fmt.Errorf("failed to write the helm metadata to the file: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			CreatesSubtasks: true,
+			Description:     "Collecting Helm values from the Cilium release",
 			Quick:           true,
 			Task: func(ctx context.Context) error {
 				v, err := c.Client.GetHelmValues(ctx, c.Options.CiliumHelmReleaseName, c.Options.CiliumNamespace)
@@ -1643,6 +1668,21 @@ func (c *Collector) Run() error {
 					return fmt.Errorf("failed to get the helm values from the release: %w", err)
 				}
 				if err := c.WriteString(ciliumHelmValuesFileName, v); err != nil {
+					return fmt.Errorf("failed to write the helm values to the file: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			CreatesSubtasks: true,
+			Description:     "Collecting Helm values from the Tetragon release",
+			Quick:           true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.GetHelmValues(ctx, c.Options.TetragonHelmReleaseName, c.Options.TetragonNamespace)
+				if err != nil {
+					return fmt.Errorf("failed to get the helm values from the release: %w", err)
+				}
+				if err := c.WriteString(tetragonHelmValuesFileName, v); err != nil {
 					return fmt.Errorf("failed to write the helm values to the file: %w", err)
 				}
 				return nil
@@ -3166,6 +3206,9 @@ func InitSysdumpFlags(cmd *cobra.Command, options *Options, optionPrefix string,
 	cmd.Flags().StringVar(&options.CiliumHelmReleaseName,
 		optionPrefix+"cilium-helm-release-name", "",
 		"The Cilium Helm release name for which to get values. If not provided then the --helm-release-name global flag is used (if provided)")
+	cmd.Flags().StringVar(&options.TetragonHelmReleaseName,
+		optionPrefix+"tetragon-helm-release-name", "",
+		"The Tetragon Helm release name for which to get values.")
 	cmd.Flags().StringVar(&options.CiliumOperatorLabelSelector,
 		optionPrefix+"cilium-operator-label-selector", DefaultCiliumOperatorLabelSelector,
 		"The labels used to target Cilium operator pods")


### PR DESCRIPTION
With this change `cilium sysdump` is going to create the following new files:
- `tetragon-helm-metadata-<ts>.yaml`
- `tetragon-helm-values-<ts>.yaml`

Creating a minimal cluster with Tetragon for testing purposes:
```
cat <<EOF > kind-config.yaml
apiVersion: kind.x-k8s.io/v1alpha4
kind: Cluster
name: cli
nodes:
  - role: control-plane
    extraMounts:
      - hostPath: /proc
        containerPath: /procHost
EOF
kind create cluster --config kind-config.yaml
EXTRA_HELM_FLAGS=(--set tetragon.hostProcPath=/procHost)

helm repo add cilium https://helm.cilium.io
helm repo update
helm install tetragon ${EXTRA_HELM_FLAGS[@]} cilium/tetragon -n kube-system
kubectl rollout status -n kube-system ds/tetragon -w
```

Release notes:
```release-note
Cilium CLI now captures Tetragon helm data when performing `cilium sysdump`.
```
