### PR TITLE
pkg/byteorder: add loong64 platform support

### DIFF
--- a/pkg/byteorder/byteorder_littleendian.go
+++ b/pkg/byteorder/byteorder_littleendian.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-//go:build 386 || amd64 || arm || arm64 || mips64le || ppc64le || riscv64 || wasm
+//go:build 386 || amd64 || arm || arm64 || mips64le || ppc64le || riscv64 || wasm || loong64
 
 package byteorder
 


### PR DESCRIPTION
[LoongArch](https://docs.kernel.org/arch/loongarch/introduction.html) is a new RISC ISA developed by loongson. There are already a lot of [community support and testing](https://www.phoronix.com/search/LoongArch) about it. `go` also supported loong64 platform since 1.21.

This pr adds loong64 support in `pkg/byteorder` and enables cilium to be built on loong64 platform. I've tested it on Arch Linux port for loong64 and succeeded. Here is the [log](https://github.com/user-attachments/files/18217631/all.log).
