### PR TITLE
datapath: require FnGetSocketCookie

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -17,6 +17,7 @@
 #include "lib/identity.h"
 #include "lib/metrics.h"
 #include "lib/nat_46x64.h"
+#include "lib/sock.h"
 #include "lib/trace_sock.h"
 
 #define SYS_REJECT	0

--- a/bpf/lib/sock.h
+++ b/bpf/lib/sock.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+static __always_inline __maybe_unused
+__sock_cookie sock_local_cookie(struct bpf_sock_addr *ctx)
+{
+#ifdef TEST_BPF_SOCK
+	/* Some BPF tests run bpf_sock.c code in XDP context.
+	 * Allow them to pass the verifier.
+	 */
+	return ctx->protocol == IPPROTO_TCP ? get_prandom_u32() : 0;
+#else
+	return get_socket_cookie(ctx);
+#endif
+}
+

--- a/bpf/lib/trace_sock.h
+++ b/bpf/lib/trace_sock.h
@@ -21,6 +21,7 @@
 #include "common.h"
 #include "events.h"
 #include "ratelimit.h"
+#include "sock.h"
 
 /* L4 protocol for the trace event */
 enum l4_protocol {

--- a/bpf/tests/host_only_socket_lb_test.c
+++ b/bpf/tests/host_only_socket_lb_test.c
@@ -6,6 +6,8 @@
 #include <bpf/api.h>
 #include "pktgen.h"
 
+#define TEST_BPF_SOCK 1
+
 #define ENABLE_IPV4 1
 #undef ENABLE_HEALTH_CHECK
 #define ENABLE_SOCKET_LB_HOST_ONLY 1

--- a/bpf/tests/skip_lb_xlate_socket_lb.c
+++ b/bpf/tests/skip_lb_xlate_socket_lb.c
@@ -6,6 +6,8 @@
 #include <bpf/api.h>
 #include "pktgen.h"
 
+#define TEST_BPF_SOCK 1
+
 #define ENABLE_IPV4 1
 #define ENABLE_IPV6 1
 #undef ENABLE_HEALTH_CHECK

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -745,7 +745,6 @@ func ExecuteHeaderProbes() *FeatureProbes {
 		// common probes
 		{ebpf.CGroupSock, asm.FnGetNetnsCookie},
 		{ebpf.CGroupSockAddr, asm.FnGetNetnsCookie},
-		{ebpf.CGroupSockAddr, asm.FnGetSocketCookie},
 		{ebpf.CGroupSock, asm.FnJiffies64},
 		{ebpf.CGroupSockAddr, asm.FnJiffies64},
 		{ebpf.SchedCLS, asm.FnJiffies64},
@@ -778,7 +777,6 @@ func writeCommonHeader(writer io.Writer, probes *FeatureProbes) error {
 	features := map[string]bool{
 		"HAVE_NETNS_COOKIE": probes.ProgramHelpers[ProgramHelper{ebpf.CGroupSock, asm.FnGetNetnsCookie}] &&
 			probes.ProgramHelpers[ProgramHelper{ebpf.CGroupSockAddr, asm.FnGetNetnsCookie}],
-		"HAVE_SOCKET_COOKIE": probes.ProgramHelpers[ProgramHelper{ebpf.CGroupSockAddr, asm.FnGetSocketCookie}],
 		"HAVE_JIFFIES": probes.ProgramHelpers[ProgramHelper{ebpf.CGroupSock, asm.FnJiffies64}] &&
 			probes.ProgramHelpers[ProgramHelper{ebpf.CGroupSockAddr, asm.FnJiffies64}] &&
 			probes.ProgramHelpers[ProgramHelper{ebpf.SchedCLS, asm.FnJiffies64}] &&

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
@@ -37,6 +39,10 @@ func CheckRequirements(log *slog.Logger) error {
 	// bpftool checks
 	if !option.Config.DryMode {
 		probeManager := probes.NewProbeManager()
+
+		if probes.HaveProgramHelper(ebpf.CGroupSockAddr, asm.FnGetSocketCookie) != nil {
+			return errors.New("Require support for bpf_get_socket_cookie() (Linux 4.12 or newer)")
+		}
 
 		if probes.HaveDeadCodeElim() != nil {
 			return errors.New("Require support for dead code elimination (Linux 5.1 or newer)")


### PR DESCRIPTION
This helper was added with kernel 4.12, while we already have 5.4 as minimum version. Just require that it's available, and remove the fallback logic.