### PR TITLE
renovate: Run post upgrade tasks for protoc related files

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,8 @@
     "go.sum",
     "Makefile.defs",
     "test/packet/scripts/install.sh",
+    "images/builder/install-protoc.sh",
+    "images/builder/install-protoplugins.sh",
     "install/kubernetes/cilium/templates/spire/**",
     "install/kubernetes/cilium/values.yaml.tmpl",
     "install/kubernetes/Makefile.values",
@@ -587,8 +589,21 @@
       }
     },
     {
+      "matchFiles": [
+        "images/builder/install-protoc.sh",
+        "images/builder/install-protoplugins.sh"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "make GO='RUN_AS_NONROOT=1 contrib/scripts/builder.sh go' generate-apis"
+        ],
+        "executionMode": "update"
+      }
+    },
+    {
       matchPackageNames: [
         "protocolbuffers/protobuf",
+        "protocolbuffers/protobuf-go",
         "quay.io/goswagger/swagger"
       ],
       "postUpgradeTasks": {


### PR DESCRIPTION
This commit is to make sure the post upgrade tasks (e.g. make generate-apis) whenever there is a change in the files

- images/builder/install-protoc.sh
- images/builder/install-protoplugins.sh

The main goal is to avoid any manual update like the below PR

Relates: https://github.com/cilium/cilium/pull/36770

