### PR TITLE
vendor: Bump gateway-api version to v1.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,7 @@ require (
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 	sigs.k8s.io/controller-runtime v0.19.3
 	sigs.k8s.io/controller-tools v0.16.5
-	sigs.k8s.io/gateway-api v1.2.0
+	sigs.k8s.io/gateway-api v1.2.1
 	sigs.k8s.io/mcs-api v0.1.1-0.20241217092652-fede3192824f
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1099,8 +1099,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcp
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.19.3 h1:XO2GvC9OPftRst6xWCpTgBZO04S2cbp0Qqkj8bX1sPw=
 sigs.k8s.io/controller-runtime v0.19.3/go.mod h1:j4j87DqtsThvwTv5/Tc5NFRyyF/RF0ip4+62tbTSIUM=
-sigs.k8s.io/gateway-api v1.2.0 h1:LrToiFwtqKTKZcZtoQPTuo3FxhrrhTgzQG0Te+YGSo8=
-sigs.k8s.io/gateway-api v1.2.0/go.mod h1:EpNfEXNjiYfUJypf0eZ0P5iXA9ekSGWaS1WgPaM42X0=
+sigs.k8s.io/gateway-api v1.2.1 h1:fZZ/+RyRb+Y5tGkwxFKuYuSRQHu9dZtbjenblleOLHM=
+sigs.k8s.io/gateway-api v1.2.1/go.mod h1:EpNfEXNjiYfUJypf0eZ0P5iXA9ekSGWaS1WgPaM42X0=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8i4DhaJ65T6EruyzmoQqI2BVDo=
 sigs.k8s.io/kind v0.23.0 h1:8fyDGWbWTeCcCTwA04v4Nfr45KKxbSPH1WO9K+jVrBg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2645,7 +2645,7 @@ sigs.k8s.io/controller-tools/pkg/schemapatcher
 sigs.k8s.io/controller-tools/pkg/schemapatcher/internal/yaml
 sigs.k8s.io/controller-tools/pkg/version
 sigs.k8s.io/controller-tools/pkg/webhook
-# sigs.k8s.io/gateway-api v1.2.0
+# sigs.k8s.io/gateway-api v1.2.1
 ## explicit; go 1.22.0
 sigs.k8s.io/gateway-api/apis/v1
 sigs.k8s.io/gateway-api/apis/v1alpha2

--- a/vendor/sigs.k8s.io/gateway-api/apis/v1/gatewayclass_types_overrides.go
+++ b/vendor/sigs.k8s.io/gateway-api/apis/v1/gatewayclass_types_overrides.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// Below code handles the experimental field breaking change introduced in
+// https://github.com/kubernetes-sigs/gateway-api/pull/3200/.
+// We are overriding the UnmarshalJSON function to be able to handle cases where
+// users had the old version of the GatewayClass CRD applied with SupportedFeatures
+// as a list of strings and not list of objects.
+// See https://github.com/kubernetes-sigs/gateway-api/issues/3464
+// for more information.
+
+func (s *SupportedFeature) UnmarshalJSON(data []byte) error {
+	var oldSupportedFeature oldSupportedFeature
+	var unmarshalTypeErr *json.UnmarshalTypeError
+	if err := json.Unmarshal(data, &oldSupportedFeature); err == nil {
+		s.Name = FeatureName(oldSupportedFeature)
+		return nil
+	} else if !errors.As(err, &unmarshalTypeErr) {
+		// If the error is not a type error, return it
+		return err
+	}
+
+	var si supportedFeatureInternal
+	if err := json.Unmarshal(data, &si); err != nil {
+		return err
+	}
+	s.Name = si.Name
+	return nil
+}
+
+// This is solely for the purpose of ensuring backward compatibility and
+// SHOULD NOT be used elsewhere.
+type supportedFeatureInternal struct {
+	Name FeatureName `json:"name"`
+}
+
+// This is solely for the purpose of ensuring backward compatibility and
+// SHOULD NOT be used elsewhere.
+type oldSupportedFeature string

--- a/vendor/sigs.k8s.io/gateway-api/pkg/consts/consts.go
+++ b/vendor/sigs.k8s.io/gateway-api/pkg/consts/consts.go
@@ -27,7 +27,7 @@ const (
 
 	// BundleVersion is the value used for the "gateway.networking.k8s.io/bundle-version" annotation.
 	// These value must be updated during the release process.
-	BundleVersion = "v1.2.0"
+	BundleVersion = "v1.2.1"
 
 	// ApprovalLink is the value used for the "api-approved.kubernetes.io" annotation.
 	// These value must be updated during the release process.


### PR DESCRIPTION
This is to pick up the backward compatibility fix.

Relates: https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.2.1


