### PR TITLE
pkg/ciliumidentity: skip CID creation for unmanaged pods

### DIFF
--- a/operator/pkg/ciliumidentity/pod.go
+++ b/operator/pkg/ciliumidentity/pod.go
@@ -39,9 +39,12 @@ func (c *Controller) processPodEvents(ctx context.Context, wg *sync.WaitGroup) e
 		}
 
 		if event.Kind == resource.Upsert || event.Kind == resource.Delete {
-			c.logger.Debug("Got Pod event", logfields.Type, event.Kind, logfields.K8sPodName, event.Key.String())
-			c.enqueueReconciliation(PodItem{podResourceKey(event.Object.Name, event.Object.Namespace)}, 0)
+			if !event.Object.Spec.HostNetwork {
+				c.logger.Debug("Got Pod event", logfields.Type, event.Kind, logfields.K8sPodName, event.Key.String())
+				c.enqueueReconciliation(PodItem{podResourceKey(event.Object.Name, event.Object.Namespace)}, 0)
+			}
 		}
+
 		event.Done(nil)
 	}
 	return nil

--- a/operator/pkg/ciliumidentity/reconciler.go
+++ b/operator/pkg/ciliumidentity/reconciler.go
@@ -401,7 +401,10 @@ func (r *reconciler) updateAllPodsInNamespace(namespace string) error {
 	var lastErr error
 
 	for _, pod := range podList {
-		r.queueOps.enqueueReconciliation(PodItem{podResourceKey(pod.Name, pod.Namespace)}, 0)
+		if !pod.Spec.HostNetwork {
+			r.logger.Debug("Reconcile Pod in namespace", logfields.K8sPodName, pod.Name)
+			r.queueOps.enqueueReconciliation(PodItem{podResourceKey(pod.Name, pod.Namespace)}, 0)
+		}
 	}
 
 	return lastErr


### PR DESCRIPTION
Operator should only create CiliumIdentities for pods managed by Cilium, specifically here, skip creating CIDs for pods using host networking.

Fixes: #35402
