### PR TITLE
Improve cilium-dbg policy output

### DIFF
--- a/cilium-dbg/cmd/bpf_policy_get.go
+++ b/cilium-dbg/cmd/bpf_policy_get.go
@@ -199,6 +199,9 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 		} else if lbls := labelsID[id]; lbls != nil && len(lbls.Labels) > 0 {
 			first := true
 			for _, lbl := range lbls.Labels.GetPrintableModel() {
+				if lbl == "reserved:unknown" {
+					lbl = "ANY"
+				}
 				if first {
 					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t\n",
 						policyStr, trafficDirectionString, lbl, port, proxyPort, stat.AuthRequirement.AuthType(), stat.Bytes, stat.Packets, prefixLen)


### PR DESCRIPTION
Change the output of the identity 0 from reserved:unknown to ANY in clium-dbg so it's more clear in cilium-dbg policy output command.


Fixes: https://github.com/cilium/cilium/issues/35556


```release-note
Improve cilium-dbg policy output from reserved:unknown to ANY 
```
