### PR TITLE
build: Filter out --jobserver-auth from MAKEFLAGS

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -45,7 +45,8 @@ endif
 cilium-build:
 ifndef SKIP_BUILD
 	$(MAKE) builder-image
-	../contrib/scripts/builder.sh env MAKEFLAGS="$(MAKEFLAGS)" make build
+	echo $(MAKEFLAGS)
+	../contrib/scripts/builder.sh env MAKEFLAGS="$(filter-out --jobserver-auth=%,$(MAKEFLAGS))" make build
 else
 	echo "SKIP_BUILD set, assuming all build artifacts are already present."
 endif


### PR DESCRIPTION
GNU make on the host may use --jobserver-style=fifo (default on my machine). It also implies --jobserver-auth=fifo:/tmp/GMfifo$MAKE_PID, an undocumented flag, used internally by make and passed to the child instances of make. This flag appears in $(MAKEFLAGS).

The cilium-build target in Documentation/Makefile passes MAKEFLAGS to another make instance, called in a docker image. The problem is that --jobserver-auth passed to make inside docker points to a file that doesn't exist in the container filesystem namespace, and make fails with an error like this:

    make: *** internal error: invalid --jobserver-auth string 'fifo:/tmp/GMfifo361142'.  Stop.
    make: *** [Makefile:48: cilium-build] Error 2
    make: Leaving directory '/home/max/.opt/go/src/github.com/cilium/cilium-snat/Documentation'

Fix this by filtering out --jobserver-auth=... from MAKEFLAGS when passing it to make inside docker.

```release-note
Fix `make -C Documentation update-cmdref` when make uses `--jobserver-style=fifo`.
```
