### PR TITLE
Improve Makefile help: add debug image commands for agent and operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -500,11 +500,13 @@ help: ## Display help for the Makefile, from https://www.thapaliya.com/en/writin
 	@# These are templated targets.
 	$(call print_help_line,"docker-cilium-image","Build cilium-agent docker image")
 	$(call print_help_line,"dev-docker-image","Build cilium-agent development docker image")
+	$(call print_help_line,"dev-docker-image-debug","Build cilium-agent development docker debug image")
 	$(call print_help_line,"docker-plugin-image","Build cilium-docker plugin image")
 	$(call print_help_line,"docker-hubble-relay-image","Build hubble-relay docker image")
 	$(call print_help_line,"docker-clustermesh-apiserver-image","Build docker image for Cilium clustermesh APIServer")
 	$(call print_help_line,"docker-operator-image","Build cilium-operator docker image")
 	$(call print_help_line,"docker-operator-*-image","Build platform specific cilium-operator images(alibabacloud, aws, azure, generic)")
+	$(call print_help_line,"docker-operator-*-image-debug","Build platform specific cilium-operator debug images(alibabacloud, aws, azure, generic)")
 	$(call print_help_line,"docker-*-image-unstripped","Build unstripped version of above docker images(cilium, hubble-relay, operator etc.)")
 
 .PHONY: help clean clean-container dev-doctor force generate-api generate-health-api generate-operator-api generate-kvstoremesh-api generate-hubble-api install licenses-all veryclean run_bpf_tests run-builder


### PR DESCRIPTION
From 
https://github.com/cilium/cilium/blob/main/Makefile.docker#L125  

https://github.com/cilium/cilium/blob/main/Makefile.docker#L142

We can see there are the targets to build up the debug image both for agent and operator but we don't have those info in the make help.



