### PR TITLE
cilium-dbg: add logging options

### DIFF
--- a/Documentation/cmdref/cilium-dbg.md
+++ b/Documentation/cmdref/cilium-dbg.md
@@ -11,10 +11,12 @@ CLI for interacting with the local Cilium Agent
 ### Options
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -h, --help            help for cilium-dbg
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -h, --help                 help for cilium-dbg
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bgp.md
+++ b/Documentation/cmdref/cilium-dbg_bgp.md
@@ -13,9 +13,11 @@ Access to BGP control plane
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bgp_peers.md
+++ b/Documentation/cmdref/cilium-dbg_bgp_peers.md
@@ -22,9 +22,11 @@ cilium-dbg bgp peers [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bgp_route-policies.md
+++ b/Documentation/cmdref/cilium-dbg_bgp_route-policies.md
@@ -22,9 +22,11 @@ cilium-dbg bgp route-policies [vrouter <asn>] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bgp_routes.md
+++ b/Documentation/cmdref/cilium-dbg_bgp_routes.md
@@ -35,9 +35,11 @@ cilium-dbg bgp routes <available | advertised> <afi> <safi> [vrouter <asn>] [pee
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf.md
+++ b/Documentation/cmdref/cilium-dbg_bpf.md
@@ -13,9 +13,11 @@ Direct access to local BPF maps
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_auth.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_auth.md
@@ -13,9 +13,11 @@ Manage authenticated connections between identities
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_auth_flush.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_auth_flush.md
@@ -22,9 +22,11 @@ cilium-dbg bpf auth flush [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_auth_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_auth_list.md
@@ -22,9 +22,11 @@ cilium-dbg bpf auth list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_bandwidth.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_bandwidth.md
@@ -13,9 +13,11 @@ BPF datapath bandwidth settings
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_bandwidth_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_bandwidth_list.md
@@ -18,9 +18,11 @@ cilium-dbg bpf bandwidth list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_config.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_config.md
@@ -13,9 +13,11 @@ Manage runtime config
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_config_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_config_list.md
@@ -22,9 +22,11 @@ cilium-dbg bpf config list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_ct.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_ct.md
@@ -13,9 +13,11 @@ Connection tracking tables
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_ct_flush.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_ct_flush.md
@@ -17,9 +17,11 @@ cilium-dbg bpf ct flush ( <endpoint identifier> | global ) [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_ct_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_ct_list.md
@@ -21,9 +21,11 @@ cilium-dbg bpf ct list ( global | endpoint | cluster ) [identifier] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_egress.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_egress.md
@@ -13,9 +13,11 @@ Manage the egress routing rules
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_egress_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_egress_list.md
@@ -22,9 +22,11 @@ cilium-dbg bpf egress list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_endpoint.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_endpoint.md
@@ -13,9 +13,11 @@ Local endpoint map
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_endpoint_delete.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_endpoint_delete.md
@@ -17,9 +17,11 @@ cilium-dbg bpf endpoint delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_endpoint_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_endpoint_list.md
@@ -18,9 +18,11 @@ cilium-dbg bpf endpoint list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_frag.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_frag.md
@@ -13,9 +13,11 @@ Manage the IPv4 datagram fragments
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_frag_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_frag_list.md
@@ -18,9 +18,11 @@ cilium-dbg bpf frag list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_fs.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_fs.md
@@ -13,9 +13,11 @@ BPF filesystem mount
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_fs_show.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_fs_show.md
@@ -24,9 +24,11 @@ cilium bpf fs show
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_ipcache.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_ipcache.md
@@ -13,9 +13,11 @@ Manage the IPCache mappings for IP/CIDR <-> Identity
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_ipcache_delete.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_ipcache_delete.md
@@ -24,9 +24,11 @@ cilium bpf ipcache delete 10.244.3.110/32 --clusterid 1
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_ipcache_get.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_ipcache_get.md
@@ -17,9 +17,11 @@ cilium-dbg bpf ipcache get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_ipcache_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_ipcache_list.md
@@ -22,9 +22,11 @@ cilium-dbg bpf ipcache list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_ipcache_update.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_ipcache_update.md
@@ -28,9 +28,11 @@ cilium bpf ipcache update 10.244.3.110/32 --tunnelendpoint 172.21.0.2 --identity
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_ipmasq.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_ipmasq.md
@@ -13,9 +13,11 @@ ip-masq-agent CIDRs
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_ipmasq_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_ipmasq_list.md
@@ -22,9 +22,11 @@ cilium-dbg bpf ipmasq list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_lb.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_lb.md
@@ -13,9 +13,11 @@ Load-balancing configuration
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_lb_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_lb_list.md
@@ -22,9 +22,11 @@ cilium-dbg bpf lb list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_lb_maglev.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_lb_maglev.md
@@ -13,9 +13,11 @@ Maglev lookup table
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_lb_maglev_get.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_lb_maglev_get.md
@@ -18,9 +18,11 @@ cilium-dbg bpf lb maglev get <service id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_lb_maglev_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_lb_maglev_list.md
@@ -18,9 +18,11 @@ cilium-dbg bpf lb maglev list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_metrics.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_metrics.md
@@ -13,9 +13,11 @@ BPF datapath traffic metrics
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_metrics_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_metrics_list.md
@@ -18,9 +18,11 @@ cilium-dbg bpf metrics list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_multicast.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_multicast.md
@@ -13,9 +13,11 @@ Manage multicast BPF programs
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_multicast_group.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_multicast_group.md
@@ -13,9 +13,11 @@ Manage the multicast groups.
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_multicast_group_add.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_multicast_group_add.md
@@ -28,9 +28,11 @@ cilium-dbg bpf multicast group add 229.0.0.1
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_multicast_group_delete.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_multicast_group_delete.md
@@ -28,9 +28,11 @@ cilium-dbg bpf multicast group delete 229.0.0.1
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_multicast_group_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_multicast_group_list.md
@@ -22,9 +22,11 @@ cilium-dbg bpf multicast group list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_multicast_subscriber.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_multicast_subscriber.md
@@ -13,9 +13,11 @@ Manage the multicast subscribers.
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_multicast_subscriber_add.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_multicast_subscriber_add.md
@@ -35,9 +35,11 @@ cilium-dbg bpf multicast subscriber add 229.0.0.1 10.100.0.1
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_multicast_subscriber_delete.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_multicast_subscriber_delete.md
@@ -33,9 +33,11 @@ cilium-dbg bpf multicast subscriber delete 229.0.0.1 10.100.0.1
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_multicast_subscriber_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_multicast_subscriber_list.md
@@ -23,9 +23,11 @@ cilium-dbg bpf multicast subscriber list < group | all > [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_nat.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_nat.md
@@ -13,9 +13,11 @@ NAT mapping tables
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_nat_flush.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_nat_flush.md
@@ -17,9 +17,11 @@ cilium-dbg bpf nat flush [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_nat_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_nat_list.md
@@ -18,9 +18,11 @@ cilium-dbg bpf nat list [cluster <cluster id>] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_nodeid.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_nodeid.md
@@ -13,9 +13,11 @@ Manage the node IDs
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_nodeid_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_nodeid_list.md
@@ -23,9 +23,11 @@ cilium-dbg bpf nodeid list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_policy.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_policy.md
@@ -13,9 +13,11 @@ Manage policy related BPF maps
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_policy_add.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_policy_add.md
@@ -18,9 +18,11 @@ cilium-dbg bpf policy add <endpoint id> <traffic-direction> <identity> [port/pro
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_policy_delete.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_policy_delete.md
@@ -18,9 +18,11 @@ cilium-dbg bpf policy delete <endpoint id> <identity> [port/proto] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_policy_get.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_policy_get.md
@@ -20,9 +20,11 @@ cilium-dbg bpf policy get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_policy_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_policy_list.md
@@ -18,9 +18,11 @@ cilium-dbg bpf policy list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_recorder.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_recorder.md
@@ -13,9 +13,11 @@ PCAP recorder
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_recorder_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_recorder_list.md
@@ -18,9 +18,11 @@ cilium-dbg bpf recorder list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_sha.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_sha.md
@@ -13,9 +13,11 @@ Manage compiled BPF template objects
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_sha_get.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_sha_get.md
@@ -18,9 +18,11 @@ cilium-dbg bpf sha get <sha> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_sha_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_sha_list.md
@@ -18,9 +18,11 @@ cilium-dbg bpf sha list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_srv6.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_srv6.md
@@ -13,9 +13,11 @@ Manage the SRv6 routing rules
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_srv6_policy.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_srv6_policy.md
@@ -22,9 +22,11 @@ cilium-dbg bpf srv6 policy [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_srv6_sid.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_srv6_sid.md
@@ -22,9 +22,11 @@ cilium-dbg bpf srv6 sid [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_srv6_vrf.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_srv6_vrf.md
@@ -22,9 +22,11 @@ cilium-dbg bpf srv6 vrf [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_tunnel.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_tunnel.md
@@ -13,9 +13,11 @@ Tunnel endpoint map
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_tunnel_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_tunnel_list.md
@@ -18,9 +18,11 @@ cilium-dbg bpf tunnel list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_vtep.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_vtep.md
@@ -13,9 +13,11 @@ Manage the VTEP mappings for IP/CIDR <-> VTEP MAC/IP
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_vtep_delete.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_vtep_delete.md
@@ -22,9 +22,11 @@ cilium-dbg bpf vtep delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_vtep_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_vtep_list.md
@@ -23,9 +23,11 @@ cilium-dbg bpf vtep list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_vtep_update.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_vtep_update.md
@@ -22,9 +22,11 @@ cilium-dbg bpf vtep update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_build-config.md
+++ b/Documentation/cmdref/cilium-dbg_build-config.md
@@ -31,9 +31,11 @@ cilium-dbg build-config --node-name $K8S_NODE_NAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_cgroups.md
+++ b/Documentation/cmdref/cilium-dbg_cgroups.md
@@ -13,9 +13,11 @@ Cgroup metadata
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_cgroups_list.md
+++ b/Documentation/cmdref/cilium-dbg_cgroups_list.md
@@ -19,9 +19,11 @@ cilium-dbg cgroups list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_completion.md
+++ b/Documentation/cmdref/cilium-dbg_completion.md
@@ -50,9 +50,11 @@ cilium-dbg completion [shell] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_config.md
+++ b/Documentation/cmdref/cilium-dbg_config.md
@@ -22,9 +22,11 @@ cilium-dbg config [<option>=(enable|disable) ...] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_config_get.md
+++ b/Documentation/cmdref/cilium-dbg_config_get.md
@@ -18,9 +18,11 @@ cilium-dbg config get <config name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_debuginfo.md
+++ b/Documentation/cmdref/cilium-dbg_debuginfo.md
@@ -21,9 +21,11 @@ cilium-dbg debuginfo [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_encrypt.md
+++ b/Documentation/cmdref/cilium-dbg_encrypt.md
@@ -13,9 +13,11 @@ Manage transparent encryption
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_encrypt_flush.md
+++ b/Documentation/cmdref/cilium-dbg_encrypt_flush.md
@@ -26,9 +26,11 @@ cilium-dbg encrypt flush [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_encrypt_status.md
+++ b/Documentation/cmdref/cilium-dbg_encrypt_status.md
@@ -18,9 +18,11 @@ cilium-dbg encrypt status [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_endpoint.md
+++ b/Documentation/cmdref/cilium-dbg_endpoint.md
@@ -13,9 +13,11 @@ Manage endpoints
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_endpoint_config.md
+++ b/Documentation/cmdref/cilium-dbg_endpoint_config.md
@@ -25,9 +25,11 @@ endpoint config 5421 DropNotification=false TraceNotification=false PolicyVerdic
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_endpoint_disconnect.md
+++ b/Documentation/cmdref/cilium-dbg_endpoint_disconnect.md
@@ -17,9 +17,11 @@ cilium-dbg endpoint disconnect <endpoint-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_endpoint_get.md
+++ b/Documentation/cmdref/cilium-dbg_endpoint_get.md
@@ -27,9 +27,11 @@ cilium-dbg endpoint get ( <endpoint identifier> | -l <endpoint labels> )  [flags
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_endpoint_health.md
+++ b/Documentation/cmdref/cilium-dbg_endpoint_health.md
@@ -24,9 +24,11 @@ cilium endpoint health 5421
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_endpoint_labels.md
+++ b/Documentation/cmdref/cilium-dbg_endpoint_labels.md
@@ -19,9 +19,11 @@ cilium-dbg endpoint labels [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_endpoint_list.md
+++ b/Documentation/cmdref/cilium-dbg_endpoint_list.md
@@ -19,9 +19,11 @@ cilium-dbg endpoint list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_endpoint_log.md
+++ b/Documentation/cmdref/cilium-dbg_endpoint_log.md
@@ -24,9 +24,11 @@ cilium endpoint log 5421
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_envoy.md
+++ b/Documentation/cmdref/cilium-dbg_envoy.md
@@ -13,9 +13,11 @@ Manage Envoy Proxy
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_envoy_admin.md
+++ b/Documentation/cmdref/cilium-dbg_envoy_admin.md
@@ -13,9 +13,11 @@ Access Envoy Admin Interface
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_envoy_admin_certs.md
+++ b/Documentation/cmdref/cilium-dbg_envoy_admin_certs.md
@@ -17,9 +17,11 @@ cilium-dbg envoy admin certs [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_envoy_admin_clusters.md
+++ b/Documentation/cmdref/cilium-dbg_envoy_admin_clusters.md
@@ -18,9 +18,11 @@ cilium-dbg envoy admin clusters [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_envoy_admin_config.md
+++ b/Documentation/cmdref/cilium-dbg_envoy_admin_config.md
@@ -18,9 +18,11 @@ cilium-dbg envoy admin config [ all | clusters | endpoints | listeners | network
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_envoy_admin_listeners.md
+++ b/Documentation/cmdref/cilium-dbg_envoy_admin_listeners.md
@@ -18,9 +18,11 @@ cilium-dbg envoy admin listeners [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_envoy_admin_logging.md
+++ b/Documentation/cmdref/cilium-dbg_envoy_admin_logging.md
@@ -13,9 +13,11 @@ List and change logging levels of Envoy Proxy
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_envoy_admin_logging_list.md
+++ b/Documentation/cmdref/cilium-dbg_envoy_admin_logging_list.md
@@ -17,9 +17,11 @@ cilium-dbg envoy admin logging list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_envoy_admin_logging_set.md
+++ b/Documentation/cmdref/cilium-dbg_envoy_admin_logging_set.md
@@ -13,9 +13,11 @@ Change logging levels of Envoy Proxy
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_envoy_admin_logging_set_global.md
+++ b/Documentation/cmdref/cilium-dbg_envoy_admin_logging_set_global.md
@@ -17,9 +17,11 @@ cilium-dbg envoy admin logging set global <level> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_envoy_admin_logging_set_loggers.md
+++ b/Documentation/cmdref/cilium-dbg_envoy_admin_logging_set_loggers.md
@@ -17,9 +17,11 @@ cilium-dbg envoy admin logging set loggers <logger_name>=<level>... [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_envoy_admin_metrics.md
+++ b/Documentation/cmdref/cilium-dbg_envoy_admin_metrics.md
@@ -18,9 +18,11 @@ cilium-dbg envoy admin metrics [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_envoy_admin_serverinfo.md
+++ b/Documentation/cmdref/cilium-dbg_envoy_admin_serverinfo.md
@@ -17,9 +17,11 @@ cilium-dbg envoy admin serverinfo [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_fqdn.md
+++ b/Documentation/cmdref/cilium-dbg_fqdn.md
@@ -17,9 +17,11 @@ cilium-dbg fqdn [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_fqdn_cache.md
+++ b/Documentation/cmdref/cilium-dbg_fqdn_cache.md
@@ -17,9 +17,11 @@ cilium-dbg fqdn cache [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_fqdn_cache_clean.md
+++ b/Documentation/cmdref/cilium-dbg_fqdn_cache_clean.md
@@ -19,9 +19,11 @@ cilium-dbg fqdn cache clean [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_fqdn_cache_list.md
+++ b/Documentation/cmdref/cilium-dbg_fqdn_cache_list.md
@@ -21,9 +21,11 @@ cilium-dbg fqdn cache list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_fqdn_names.md
+++ b/Documentation/cmdref/cilium-dbg_fqdn_names.md
@@ -17,9 +17,11 @@ cilium-dbg fqdn names [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_identity.md
+++ b/Documentation/cmdref/cilium-dbg_identity.md
@@ -13,9 +13,11 @@ Manage security identities
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_identity_get.md
+++ b/Documentation/cmdref/cilium-dbg_identity_get.md
@@ -19,9 +19,11 @@ cilium-dbg identity get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_identity_list.md
+++ b/Documentation/cmdref/cilium-dbg_identity_list.md
@@ -19,9 +19,11 @@ cilium-dbg identity list [LABELS] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_ip.md
+++ b/Documentation/cmdref/cilium-dbg_ip.md
@@ -13,9 +13,11 @@ Manage IP addresses and associated information
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_ip_get.md
+++ b/Documentation/cmdref/cilium-dbg_ip_get.md
@@ -20,9 +20,11 @@ cilium-dbg ip get ( <cidr> |-l <identity labels> ) [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_ip_list.md
+++ b/Documentation/cmdref/cilium-dbg_ip_list.md
@@ -20,9 +20,11 @@ cilium-dbg ip list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_kvstore.md
+++ b/Documentation/cmdref/cilium-dbg_kvstore.md
@@ -15,9 +15,11 @@ Direct access to the kvstore
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_kvstore_delete.md
+++ b/Documentation/cmdref/cilium-dbg_kvstore_delete.md
@@ -24,11 +24,13 @@ cilium kvstore delete --recursive foo
 ### Options inherited from parent commands
 
 ```
-      --config string     Config file (default is $HOME/.cilium.yaml)
-  -D, --debug             Enable debug messages
-  -H, --host string       URI to server-side API
-      --kvstore string    Key-Value Store type
-      --kvstore-opt map   Key-Value Store options
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --kvstore string       Key-Value Store type
+      --kvstore-opt map      Key-Value Store options
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_kvstore_get.md
+++ b/Documentation/cmdref/cilium-dbg_kvstore_get.md
@@ -25,11 +25,13 @@ cilium kvstore get --recursive foo
 ### Options inherited from parent commands
 
 ```
-      --config string     Config file (default is $HOME/.cilium.yaml)
-  -D, --debug             Enable debug messages
-  -H, --host string       URI to server-side API
-      --kvstore string    Key-Value Store type
-      --kvstore-opt map   Key-Value Store options
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --kvstore string       Key-Value Store type
+      --kvstore-opt map      Key-Value Store options
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_kvstore_set.md
+++ b/Documentation/cmdref/cilium-dbg_kvstore_set.md
@@ -25,11 +25,13 @@ cilium kvstore set foo=bar
 ### Options inherited from parent commands
 
 ```
-      --config string     Config file (default is $HOME/.cilium.yaml)
-  -D, --debug             Enable debug messages
-  -H, --host string       URI to server-side API
-      --kvstore string    Key-Value Store type
-      --kvstore-opt map   Key-Value Store options
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --kvstore string       Key-Value Store type
+      --kvstore-opt map      Key-Value Store options
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_loadinfo.md
+++ b/Documentation/cmdref/cilium-dbg_loadinfo.md
@@ -17,9 +17,11 @@ cilium-dbg loadinfo [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_lrp.md
+++ b/Documentation/cmdref/cilium-dbg_lrp.md
@@ -13,9 +13,11 @@ Manage local redirect policies
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_lrp_list.md
+++ b/Documentation/cmdref/cilium-dbg_lrp_list.md
@@ -18,9 +18,11 @@ cilium-dbg lrp list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_map.md
+++ b/Documentation/cmdref/cilium-dbg_map.md
@@ -13,9 +13,11 @@ Access userspace cached content of BPF maps
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_map_events.md
+++ b/Documentation/cmdref/cilium-dbg_map_events.md
@@ -25,9 +25,11 @@ cilium map events cilium_ipcache
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_map_get.md
+++ b/Documentation/cmdref/cilium-dbg_map_get.md
@@ -24,9 +24,11 @@ cilium map get cilium_ipcache
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_map_list.md
+++ b/Documentation/cmdref/cilium-dbg_map_list.md
@@ -25,9 +25,11 @@ cilium map list
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_metrics.md
+++ b/Documentation/cmdref/cilium-dbg_metrics.md
@@ -13,9 +13,11 @@ Access metric status
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_metrics_list.md
+++ b/Documentation/cmdref/cilium-dbg_metrics_list.md
@@ -19,9 +19,11 @@ cilium-dbg metrics list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_monitor.md
+++ b/Documentation/cmdref/cilium-dbg_monitor.md
@@ -35,9 +35,11 @@ cilium-dbg monitor [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_node.md
+++ b/Documentation/cmdref/cilium-dbg_node.md
@@ -13,9 +13,11 @@ Manage cluster nodes
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_node_list.md
+++ b/Documentation/cmdref/cilium-dbg_node_list.md
@@ -18,9 +18,11 @@ cilium-dbg node list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_nodeid.md
+++ b/Documentation/cmdref/cilium-dbg_nodeid.md
@@ -13,9 +13,11 @@ List node IDs and associated information
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_nodeid_list.md
+++ b/Documentation/cmdref/cilium-dbg_nodeid_list.md
@@ -18,9 +18,11 @@ cilium-dbg nodeid list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_policy.md
+++ b/Documentation/cmdref/cilium-dbg_policy.md
@@ -13,9 +13,11 @@ Manage security policies
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_policy_delete.md
+++ b/Documentation/cmdref/cilium-dbg_policy_delete.md
@@ -19,9 +19,11 @@ cilium-dbg policy delete [<labels>] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_policy_get.md
+++ b/Documentation/cmdref/cilium-dbg_policy_get.md
@@ -18,9 +18,11 @@ cilium-dbg policy get [<labels>] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_policy_import.md
+++ b/Documentation/cmdref/cilium-dbg_policy_import.md
@@ -28,9 +28,11 @@ cilium-dbg policy import <path> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_policy_selectors.md
+++ b/Documentation/cmdref/cilium-dbg_policy_selectors.md
@@ -19,9 +19,11 @@ cilium-dbg policy selectors [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_policy_validate.md
+++ b/Documentation/cmdref/cilium-dbg_policy_validate.md
@@ -19,9 +19,11 @@ cilium-dbg policy validate <path> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_policy_wait.md
+++ b/Documentation/cmdref/cilium-dbg_policy_wait.md
@@ -20,9 +20,11 @@ cilium-dbg policy wait <revision> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_post-uninstall-cleanup.md
+++ b/Documentation/cmdref/cilium-dbg_post-uninstall-cleanup.md
@@ -28,9 +28,11 @@ cilium-dbg post-uninstall-cleanup [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_prefilter.md
+++ b/Documentation/cmdref/cilium-dbg_prefilter.md
@@ -13,9 +13,11 @@ Manage XDP CIDR filters
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_prefilter_delete.md
+++ b/Documentation/cmdref/cilium-dbg_prefilter_delete.md
@@ -19,9 +19,11 @@ cilium-dbg prefilter delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_prefilter_list.md
+++ b/Documentation/cmdref/cilium-dbg_prefilter_list.md
@@ -18,9 +18,11 @@ cilium-dbg prefilter list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_prefilter_update.md
+++ b/Documentation/cmdref/cilium-dbg_prefilter_update.md
@@ -19,9 +19,11 @@ cilium-dbg prefilter update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_preflight.md
+++ b/Documentation/cmdref/cilium-dbg_preflight.md
@@ -17,9 +17,11 @@ CLI to help upgrade cilium
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_preflight_fqdn-poller.md
+++ b/Documentation/cmdref/cilium-dbg_preflight_fqdn-poller.md
@@ -29,9 +29,11 @@ cilium-dbg preflight fqdn-poller [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_preflight_migrate-identity.md
+++ b/Documentation/cmdref/cilium-dbg_preflight_migrate-identity.md
@@ -39,9 +39,11 @@ cilium-dbg preflight migrate-identity [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_preflight_validate-cnp.md
+++ b/Documentation/cmdref/cilium-dbg_preflight_validate-cnp.md
@@ -33,9 +33,11 @@ cilium-dbg preflight validate-cnp [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_recorder.md
+++ b/Documentation/cmdref/cilium-dbg_recorder.md
@@ -13,9 +13,11 @@ Introspect or mangle pcap recorder
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_recorder_delete.md
+++ b/Documentation/cmdref/cilium-dbg_recorder_delete.md
@@ -17,9 +17,11 @@ cilium-dbg recorder delete <recorder id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_recorder_get.md
+++ b/Documentation/cmdref/cilium-dbg_recorder_get.md
@@ -18,9 +18,11 @@ cilium-dbg recorder get <recorder id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_recorder_list.md
+++ b/Documentation/cmdref/cilium-dbg_recorder_list.md
@@ -18,9 +18,11 @@ cilium-dbg recorder list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_recorder_update.md
+++ b/Documentation/cmdref/cilium-dbg_recorder_update.md
@@ -20,9 +20,11 @@ cilium-dbg recorder update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_service.md
+++ b/Documentation/cmdref/cilium-dbg_service.md
@@ -13,9 +13,11 @@ Manage services & loadbalancers
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_service_delete.md
+++ b/Documentation/cmdref/cilium-dbg_service_delete.md
@@ -18,9 +18,11 @@ cilium-dbg service delete { <service id> | --all } [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_service_get.md
+++ b/Documentation/cmdref/cilium-dbg_service_get.md
@@ -18,9 +18,11 @@ cilium-dbg service get <service id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_service_list.md
+++ b/Documentation/cmdref/cilium-dbg_service_list.md
@@ -19,9 +19,11 @@ cilium-dbg service list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_service_update.md
+++ b/Documentation/cmdref/cilium-dbg_service_update.md
@@ -31,9 +31,11 @@ cilium-dbg service update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_shell.md
+++ b/Documentation/cmdref/cilium-dbg_shell.md
@@ -17,9 +17,11 @@ cilium-dbg shell [command] [args]... [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_statedb.md
+++ b/Documentation/cmdref/cilium-dbg_statedb.md
@@ -17,9 +17,11 @@ cilium-dbg statedb [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_statedb_dump.md
+++ b/Documentation/cmdref/cilium-dbg_statedb_dump.md
@@ -17,9 +17,11 @@ cilium-dbg statedb dump [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_status.md
+++ b/Documentation/cmdref/cilium-dbg_status.md
@@ -28,9 +28,11 @@ cilium-dbg status [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_sysdump.md
+++ b/Documentation/cmdref/cilium-dbg_sysdump.md
@@ -17,9 +17,11 @@ cilium-dbg sysdump [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_troubleshoot.md
+++ b/Documentation/cmdref/cilium-dbg_troubleshoot.md
@@ -13,9 +13,11 @@ Run troubleshooting utilities to check control-plane connectivity
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_troubleshoot_clustermesh.md
+++ b/Documentation/cmdref/cilium-dbg_troubleshoot_clustermesh.md
@@ -20,9 +20,11 @@ cilium-dbg troubleshoot clustermesh [clusters...] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_troubleshoot_kvstore.md
+++ b/Documentation/cmdref/cilium-dbg_troubleshoot_kvstore.md
@@ -20,9 +20,11 @@ cilium-dbg troubleshoot kvstore [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_version.md
+++ b/Documentation/cmdref/cilium-dbg_version.md
@@ -18,9 +18,11 @@ cilium-dbg version [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -62,7 +62,8 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string) check.Sc
 		hubbleQueueFull, reflectPanic, svcNotFound, unableTranslateCIDRgroups, gobgpWarnings,
 		endpointMapDeleteFailed, etcdReconnection, epRestoreMissingState, mutationDetectorKlog,
 		hubbleFailedCreatePeer, fqdnDpUpdatesTimeout, longNetpolUpdate, failedToGetEpLabels,
-		failedCreategRPCClient, unableReallocateIngressIP, fqdnMaxIPPerHostname, failedGetMetricsAPI, envoyTLSWarning}
+		failedCreategRPCClient, unableReallocateIngressIP, fqdnMaxIPPerHostname, failedGetMetricsAPI, envoyTLSWarning,
+		ciliumNodeConfigDeprecation}
 	// The list is adopted from cilium/cilium/test/helper/utils.go
 	var errorMsgsWithExceptions = map[string][]logMatcher{
 		panicMessage:         nil,
@@ -281,39 +282,40 @@ const (
 	klogLeaderElectionFail stringMatcher = "error retrieving resource lock kube-system/cilium-operator-resource-lock:" // from: https://github.com/cilium/cilium/issues/31050
 	nilDetailsForService   stringMatcher = "retrieved nil details for Service"                                         // from: https://github.com/cilium/cilium/issues/35595
 
-	cantEnableJIT             stringMatcher = "bpf_jit_enable: no such file or directory"                             // Because we run tests in Kind.
-	delMissingService         stringMatcher = "Deleting no longer present service"                                    // cf. https://github.com/cilium/cilium/issues/29679
-	podCIDRUnavailable        stringMatcher = " PodCIDR not available"                                                // cf. https://github.com/cilium/cilium/issues/29680
-	unableGetNode             stringMatcher = "Unable to get node resource"                                           // cf. https://github.com/cilium/cilium/issues/29710
-	sessionAffinitySocketLB   stringMatcher = "Session affinity for host reachable services needs kernel"             // cf. https://github.com/cilium/cilium/issues/29736
-	objectHasBeenModified     stringMatcher = "the object has been modified; please apply your changes"               // cf. https://github.com/cilium/cilium/issues/29712
-	noBackendResponse         stringMatcher = "The kernel does not support --service-no-backend-response=reject"      // cf. https://github.com/cilium/cilium/issues/29733
-	legacyBGPFeature          stringMatcher = "You are using the legacy BGP feature"                                  // Expected when testing the legacy BGP feature.
-	etcdTimeout               stringMatcher = "etcd client timeout exceeded"                                          // cf. https://github.com/cilium/cilium/issues/29714
-	endpointRestoreFailed     stringMatcher = "Unable to restore endpoint, ignoring"                                  // cf. https://github.com/cilium/cilium/issues/29716
-	unableRestoreRouterIP     stringMatcher = "Unable to restore router IP from filesystem"                           // cf. https://github.com/cilium/cilium/issues/29715
-	routerIPReallocated       stringMatcher = "Router IP could not be re-allocated"                                   // cf. https://github.com/cilium/cilium/issues/29715
-	cantFindIdentityInCache   stringMatcher = "unable to release identity: unable to find key in local cache"         // cf. https://github.com/cilium/cilium/issues/29732
-	keyAllocFailedFoundMaster stringMatcher = "Found master key after proceeding with new allocation"                 // cf. https://github.com/cilium/cilium/issues/29738
-	cantRecreateMasterKey     stringMatcher = "unable to re-create missing master key"                                // cf. https://github.com/cilium/cilium/issues/29738
-	cantUpdateCRDIdentity     stringMatcher = "Unable update CRD identity information with a reference for this node" // cf. https://github.com/cilium/cilium/issues/29739
-	cantDeleteFromPolicyMap   stringMatcher = "cilium_call_policy: delete: key does not exist"                        // cf. https://github.com/cilium/cilium/issues/29754
-	hubbleQueueFull           stringMatcher = "hubble events queue is full"                                           // Because we run without monitor aggregation
-	reflectPanic              stringMatcher = "reflect.Value.SetUint using value obtained using unexported field"     // cf. https://github.com/cilium/cilium/issues/33766
-	svcNotFound               stringMatcher = "service not found"                                                     // cf. https://github.com/cilium/cilium/issues/35768
-	unableTranslateCIDRgroups stringMatcher = "Unable to translate all CIDR groups to CIDRs"                          // Can be removed once v1.17 is released.
-	gobgpWarnings             stringMatcher = "component=gobgp.BgpServerInstance"                                     // cf. https://github.com/cilium/cilium/issues/35799
-	etcdReconnection          stringMatcher = "Error observed on etcd connection, reconnecting etcd"                  // cf. https://github.com/cilium/cilium/issues/35865
-	epRestoreMissingState     stringMatcher = "Couldn't find state, ignoring endpoint"                                // cf. https://github.com/cilium/cilium/issues/35869
-	mutationDetectorKlog      stringMatcher = "Mutation detector is enabled, this will result in memory leakage."     // cf. https://github.com/cilium/cilium/issues/35929
-	hubbleFailedCreatePeer    stringMatcher = "Failed to create peer client for peers synchronization"                // cf. https://github.com/cilium/cilium/issues/35930
-	fqdnDpUpdatesTimeout      stringMatcher = "Timed out waiting for datapath updates of FQDN IP information"         // cf. https://github.com/cilium/cilium/issues/35931
-	longNetpolUpdate          stringMatcher = "onConfigUpdate(): Worker threads took longer than"                     // cf. https://github.com/cilium/cilium/issues/36067
-	failedToGetEpLabels       stringMatcher = "Failed to get identity labels for endpoint"                            // cf. https://github.com/cilium/cilium/issues/36068
-	failedCreategRPCClient    stringMatcher = "Failed to create gRPC client"                                          // cf. https://github.com/cilium/cilium/issues/36070
-	unableReallocateIngressIP stringMatcher = "unable to re-allocate ingress IPv6"                                    // cf. https://github.com/cilium/cilium/issues/36072
-	fqdnMaxIPPerHostname      stringMatcher = "Raise tofqdns-endpoint-max-ip-per-hostname to mitigate this"           // cf. https://github.com/cilium/cilium/issues/36073
-	failedGetMetricsAPI       stringMatcher = "retrieve the complete list of server APIs: metrics.k8s.io/v1beta1"     // cf. https://github.com/cilium/cilium/issues/36085
+	cantEnableJIT               stringMatcher = "bpf_jit_enable: no such file or directory"                              // Because we run tests in Kind.
+	delMissingService           stringMatcher = "Deleting no longer present service"                                     // cf. https://github.com/cilium/cilium/issues/29679
+	podCIDRUnavailable          stringMatcher = " PodCIDR not available"                                                 // cf. https://github.com/cilium/cilium/issues/29680
+	unableGetNode               stringMatcher = "Unable to get node resource"                                            // cf. https://github.com/cilium/cilium/issues/29710
+	sessionAffinitySocketLB     stringMatcher = "Session affinity for host reachable services needs kernel"              // cf. https://github.com/cilium/cilium/issues/29736
+	objectHasBeenModified       stringMatcher = "the object has been modified; please apply your changes"                // cf. https://github.com/cilium/cilium/issues/29712
+	noBackendResponse           stringMatcher = "The kernel does not support --service-no-backend-response=reject"       // cf. https://github.com/cilium/cilium/issues/29733
+	legacyBGPFeature            stringMatcher = "You are using the legacy BGP feature"                                   // Expected when testing the legacy BGP feature.
+	etcdTimeout                 stringMatcher = "etcd client timeout exceeded"                                           // cf. https://github.com/cilium/cilium/issues/29714
+	endpointRestoreFailed       stringMatcher = "Unable to restore endpoint, ignoring"                                   // cf. https://github.com/cilium/cilium/issues/29716
+	unableRestoreRouterIP       stringMatcher = "Unable to restore router IP from filesystem"                            // cf. https://github.com/cilium/cilium/issues/29715
+	routerIPReallocated         stringMatcher = "Router IP could not be re-allocated"                                    // cf. https://github.com/cilium/cilium/issues/29715
+	cantFindIdentityInCache     stringMatcher = "unable to release identity: unable to find key in local cache"          // cf. https://github.com/cilium/cilium/issues/29732
+	keyAllocFailedFoundMaster   stringMatcher = "Found master key after proceeding with new allocation"                  // cf. https://github.com/cilium/cilium/issues/29738
+	cantRecreateMasterKey       stringMatcher = "unable to re-create missing master key"                                 // cf. https://github.com/cilium/cilium/issues/29738
+	cantUpdateCRDIdentity       stringMatcher = "Unable update CRD identity information with a reference for this node"  // cf. https://github.com/cilium/cilium/issues/29739
+	cantDeleteFromPolicyMap     stringMatcher = "cilium_call_policy: delete: key does not exist"                         // cf. https://github.com/cilium/cilium/issues/29754
+	hubbleQueueFull             stringMatcher = "hubble events queue is full"                                            // Because we run without monitor aggregation
+	reflectPanic                stringMatcher = "reflect.Value.SetUint using value obtained using unexported field"      // cf. https://github.com/cilium/cilium/issues/33766
+	svcNotFound                 stringMatcher = "service not found"                                                      // cf. https://github.com/cilium/cilium/issues/35768
+	unableTranslateCIDRgroups   stringMatcher = "Unable to translate all CIDR groups to CIDRs"                           // Can be removed once v1.17 is released.
+	gobgpWarnings               stringMatcher = "component=gobgp.BgpServerInstance"                                      // cf. https://github.com/cilium/cilium/issues/35799
+	etcdReconnection            stringMatcher = "Error observed on etcd connection, reconnecting etcd"                   // cf. https://github.com/cilium/cilium/issues/35865
+	epRestoreMissingState       stringMatcher = "Couldn't find state, ignoring endpoint"                                 // cf. https://github.com/cilium/cilium/issues/35869
+	mutationDetectorKlog        stringMatcher = "Mutation detector is enabled, this will result in memory leakage."      // cf. https://github.com/cilium/cilium/issues/35929
+	hubbleFailedCreatePeer      stringMatcher = "Failed to create peer client for peers synchronization"                 // cf. https://github.com/cilium/cilium/issues/35930
+	fqdnDpUpdatesTimeout        stringMatcher = "Timed out waiting for datapath updates of FQDN IP information"          // cf. https://github.com/cilium/cilium/issues/35931
+	longNetpolUpdate            stringMatcher = "onConfigUpdate(): Worker threads took longer than"                      // cf. https://github.com/cilium/cilium/issues/36067
+	failedToGetEpLabels         stringMatcher = "Failed to get identity labels for endpoint"                             // cf. https://github.com/cilium/cilium/issues/36068
+	failedCreategRPCClient      stringMatcher = "Failed to create gRPC client"                                           // cf. https://github.com/cilium/cilium/issues/36070
+	unableReallocateIngressIP   stringMatcher = "unable to re-allocate ingress IPv6"                                     // cf. https://github.com/cilium/cilium/issues/36072
+	fqdnMaxIPPerHostname        stringMatcher = "Raise tofqdns-endpoint-max-ip-per-hostname to mitigate this"            // cf. https://github.com/cilium/cilium/issues/36073
+	failedGetMetricsAPI         stringMatcher = "retrieve the complete list of server APIs: metrics.k8s.io/v1beta1"      // cf. https://github.com/cilium/cilium/issues/36085
+	ciliumNodeConfigDeprecation stringMatcher = "cilium.io/v2alpha1 CiliumNodeConfig will be deprecated in cilium v1.16" // cf. https://github.com/cilium/cilium/issues/37249
 
 	// Logs messages that should not be in the cilium-envoy DS logs
 	envoyErrorMessage    = "[error]"

--- a/cilium-dbg/cmd/build-config.go
+++ b/cilium-dbg/cmd/build-config.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
 	"strings"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	k8sConsts "github.com/cilium/cilium/pkg/k8s/constants"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/option/resolver"
 )
 
@@ -38,8 +38,8 @@ var buildConfigCmd = &cobra.Command{
 	Use:   "build-config --node-name $K8S_NODE_NAME",
 	Short: "Resolve all of the configuration sources that apply to this node",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Running")
-		if err := buildConfigHive.Run(slog.Default()); err != nil {
+		log.Info("Running")
+		if err := buildConfigHive.Run(logging.DefaultSlogLogger); err != nil {
 			Fatalf("Build config failed: %v\n", err)
 		}
 	},

--- a/cilium-dbg/cmd/preflight_identity_crd_migrate.go
+++ b/cilium-dbg/cmd/preflight_identity_crd_migrate.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"path"
 	"sync"
 	"time"
@@ -64,11 +63,7 @@ func migrateIdentityCmd() *cobra.Command {
 	hive.RegisterFlags(cmd.Flags())
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		// The internal packages log things. Make sure they follow the setup of
-		// the CLI tool.
-		logging.DefaultLogger.SetFormatter(log.Formatter)
-
-		if err := hive.Run(slog.Default()); err != nil {
+		if err := hive.Run(logging.DefaultSlogLogger); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/cilium-dbg/cmd/preflight_k8s_valid_cnp.go
+++ b/cilium-dbg/cmd/preflight_k8s_valid_cnp.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/cilium/hive/cell"
@@ -45,11 +44,7 @@ has an exit code 1 is returned.`,
 	hive.RegisterFlags(cmd.Flags())
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		// The internal packages log things. Make sure they follow the setup of of
-		// the CLI tool.
-		logging.DefaultLogger.SetFormatter(log.Formatter)
-
-		if err := hive.Run(slog.Default()); err != nil {
+		if err := hive.Run(logging.DefaultSlogLogger); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/cilium-dbg/cmd/root.go
+++ b/cilium-dbg/cmd/root.go
@@ -8,13 +8,15 @@ import (
 	"io"
 	"os"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	clientPkg "github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/cmdref"
 	"github.com/cilium/cilium/pkg/components"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
@@ -22,7 +24,7 @@ var (
 
 	cfgFile string
 	client  *clientPkg.Client
-	log     = logrus.New()
+	log     = logging.DefaultLogger.WithField(logfields.LogSubsys, "cilium-dbg")
 	verbose = false
 )
 
@@ -51,6 +53,8 @@ func init() {
 	flags := RootCmd.PersistentFlags()
 	flags.StringVar(&cfgFile, "config", "", "Config file (default is $HOME/.cilium.yaml)")
 	flags.BoolP("debug", "D", false, "Enable debug messages")
+	flags.StringSlice(option.LogDriver, []string{}, "Logging endpoints to use (example: syslog)")
+	flags.Var(option.NewNamedMapOptions(option.LogOpt, &option.Config.LogOpt, nil), option.LogOpt, "Log driver options (example: format=json)")
 	flags.StringP("host", "H", "", "URI to server-side API")
 	vp.BindPFlags(flags)
 	RootCmd.AddCommand(cmdref.NewCmd(RootCmd))
@@ -75,10 +79,8 @@ func initConfig() {
 		fmt.Println("Using config file:", vp.ConfigFileUsed())
 	}
 
-	if vp.GetBool("debug") {
-		log.Level = logrus.DebugLevel
-	} else {
-		log.Level = logrus.InfoLevel
+	if err := logging.SetupLogging(option.Config.LogDriver, option.Config.LogOpt, "cilium-dbg", vp.GetBool("debug")); err != nil {
+		Fatalf("Error while setting up logging: %s\n", err)
 	}
 
 	if cl, err := clientPkg.NewClient(vp.GetString("host")); err != nil {


### PR DESCRIPTION
# Description
This PR adds two new options for `cilium-dbg` commands: `--log-driver` and `--log-opt`, which is consistent with what we have for all other Cilium binaries (agent, operator, kvstoremesh, ...)

This should also help with preparing the migration from `logrus` to `slog` (described in https://github.com/cilium/cilium/pull/32020#discussion_r1579451969) by standardizing the way we initialize loggers.

# Testing
Before this change, logs from a command like `cilium-dbg build-config` ([used](https://github.com/cilium/cilium/blob/e645d1fdfb30d8d8090dbe4b35235d08e742afcd/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml#L437-L438) in the agent in order to allow for supporting [`CiliumNodeConfigs`](https://docs.cilium.io/en/latest/configuration/per-node-config/)) would be all over the place:
```
Running
2024/12/20 09:06:35 INFO Starting
time="2024-12-20T09:06:35Z" level=info msg="Establishing connection to apiserver" host="https://example.com" subsys=k8s-client
time="2024-12-20T09:06:35Z" level=info msg="Connected to apiserver" subsys=k8s-client
time="2024-12-20T09:06:35Z" level=info msg="Reading configuration from cilium-node-config:cluster-cni/" configSource="cilium-node-config:cluster-cni/" subsys=option-resolver
W1220 09:06:35.062395       1 warnings.go:70] cilium.io/v2alpha1 CiliumNodeConfig will be deprecated in cilium v1.16; use cilium.io/v2 CiliumNodeConfig
time="2024-12-20T09:06:35Z" level=info msg="Got 0 config pairs from source" configSource="cilium-node-config:cluster-cni/" subsys=option-resolver
2024/12/20 09:06:35 INFO Started duration=36.867725ms
2024/12/20 09:06:35 INFO Stopping
2024/12/20 09:06:35 INFO health.job-module-status-metrics (rev=2) module=health
```

Notice that there are **four** different log formats:
- No formatting at all from `fmt.Println`
- Formatting from the plain `logrus` logger
- Formatting from the plain `slog` logger
- Formatting from the plain `k8s.io/klog` logger

After this change, running the same command now shows:
```
time="2024-12-27T13:36:25Z" level=info msg=Running subsys=cilium-dbg
time=2024-12-27T13:36:25Z level=info msg=Starting
time="2024-12-27T13:36:25Z" level=info msg="Establishing connection to apiserver" host="https://example.com" subsys=k8s-client
time="2024-12-27T13:36:25Z" level=info msg="Connected to apiserver" subsys=k8s-client
time="2024-12-27T13:36:25Z" level=info msg="Reading configuration from cilium-node-config:cluster-cni/" configSource="cilium-node-config:cluster-cni/" subsys=option-resolver
time="2024-12-27T13:36:25Z" level=warning msg="cilium.io/v2alpha1 CiliumNodeConfig will be deprecated in cilium v1.16; use cilium.io/v2 CiliumNodeConfig" subsys=klog
time="2024-12-27T13:36:25Z" level=info msg="Got 0 config pairs from source" configSource="cilium-node-config:cluster-cni/" subsys=option-resolver
time=2024-12-27T13:36:25Z level=info msg=Started duration=31.967423ms
time=2024-12-27T13:36:25Z level=info msg=Stopping
time=2024-12-27T13:36:25Z level=info msg="health.job-module-status-metrics (rev=2)" module=health
```
The formatting is much more uniform now.

It is also possible to log in JSON as well (`cilium-dbg build-config --log-opt=format=json-ts`):
```
{"level":"info","msg":"Running","subsys":"cilium-dbg","time":"2024-12-27T13:39:05.191604359Z"}
{"time":"2024-12-27T13:39:05Z","level":"info","msg":"Starting"}
{"host":"https://example.com","level":"info","msg":"Establishing connection to apiserver","subsys":"k8s-client","time":"2024-12-27T13:39:05.193767383Z"}
{"level":"info","msg":"Connected to apiserver","subsys":"k8s-client","time":"2024-12-27T13:39:05.208540238Z"}
{"configSource":"cilium-node-config:cluster-cni/","level":"info","msg":"Reading configuration from cilium-node-config:cluster-cni/","subsys":"option-resolver","time":"2024-12-27T13:39:05.210553378Z"}
{"level":"warning","msg":"cilium.io/v2alpha1 CiliumNodeConfig will be deprecated in cilium v1.16; use cilium.io/v2 CiliumNodeConfig","subsys":"klog","time":"2024-12-27T13:39:05.229064937Z"}
{"configSource":"cilium-node-config:cluster-cni/","level":"info","msg":"Got 0 config pairs from source","subsys":"option-resolver","time":"2024-12-27T13:39:05.233927754Z"}
{"time":"2024-12-27T13:39:05Z","level":"info","msg":"Started","duration":40607555}
{"time":"2024-12-27T13:39:05Z","level":"info","msg":"Stopping"}
{"time":"2024-12-27T13:39:05Z","level":"info","msg":"health.job-module-status-metrics (rev=2)","module":"health"}
```

The new options are correctly shown to users:
```
# cilium-dbg --help
CLI for interacting with the local Cilium Agent

Usage:
  cilium-dbg [command]
[...]

Flags:
      --config string        Config file (default is $HOME/.cilium.yaml)
  -D, --debug                Enable debug messages
  -h, --help                 help for cilium-dbg
  -H, --host string          URI to server-side API
      --log-driver strings   Logging endpoints to use (example: syslog)
      --log-opt map          Log driver options (example: format=json)

Use "cilium-dbg [command] --help" for more information about a command.
```

```release-note
cilium-dbg: add logging options
```
