### PR TITLE
proxy: Only set/update L7 rules for DNS proxy

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -157,7 +157,6 @@ type policyGenerateResult struct {
 func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegenCtxt *datapathRegenerationContext) (*policyGenerateResult, error) {
 	var (
 		err error
-		ff  revert.FinalizeFunc
 		rf  revert.RevertFunc
 	)
 
@@ -223,9 +222,8 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 	// Ingress endpoint needs no redirects
 	if !e.isProperty(PropertySkipBPFPolicy) {
 		stats.proxyConfiguration.Start()
-		desiredRedirects, ff, rf = e.addNewRedirects(selectorPolicy, datapathRegenCtxt.proxyWaitGroup)
+		desiredRedirects, rf = e.addNewRedirects(selectorPolicy, datapathRegenCtxt.proxyWaitGroup)
 		stats.proxyConfiguration.End(true)
-		datapathRegenCtxt.finalizeList.Append(ff)
 		datapathRegenCtxt.revertStack.Push(rf)
 
 		// Add a finalize function to clear out stale redirects. This will be called after

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -15,7 +15,7 @@ import (
 
 // EndpointProxy defines any L7 proxy with which an Endpoint must interact.
 type EndpointProxy interface {
-	CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, epID uint16, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc)
+	CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, epID uint16, wg *completion.WaitGroup) (proxyPort uint16, err error, revertFunc revert.RevertFunc)
 	RemoveRedirect(id string)
 	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
 	UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
@@ -44,7 +44,7 @@ func (e *Endpoint) IsProxyDisabled() bool {
 type FakeEndpointProxy struct{}
 
 // CreateOrUpdateRedirect does nothing.
-func (f *FakeEndpointProxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, epid uint16, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
+func (f *FakeEndpointProxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, epid uint16, wg *completion.WaitGroup) (proxyPort uint16, err error, revertFunc revert.RevertFunc) {
 	return
 }
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -96,9 +96,10 @@ type RedirectSuiteProxy struct {
 
 // CreateOrUpdateRedirect returns the proxy port for the given L7Parser from the
 // ProxyPolicy parameter.
-func (r *RedirectSuiteProxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, epID uint16, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
+func (r *RedirectSuiteProxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, epID uint16, wg *completion.WaitGroup) (proxyPort uint16, err error, revertFunc revert.RevertFunc) {
 	pp := r.parserProxyPortMap[l4.GetL7Parser().String()+l4.GetListener()]
-	return pp, nil, func() { r.redirects[id] = pp }, nil
+	r.redirects[id] = pp
+	return pp, nil, nil
 }
 
 // RemoveRedirect removes a redirect from the map

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/spanstat"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -135,6 +136,9 @@ type DNSProxy struct {
 	// Note: Simple DNS names, e.g. bar.foo.com, will treat the "." as a literal.
 	allowed perEPAllow
 
+	// Current rules enforced by 'allowed', used for reverting
+	currentRules perEPPolicy
+
 	// restored is a set of rules restored from a previous instance that can be
 	// used until 'allowed' rules for an endpoint are first initialized after
 	// a restart
@@ -172,6 +176,9 @@ type regexCache map[string]*regexCacheEntry
 
 // perEPAllow maps EndpointIDs to protocols + ports + selectors + rules
 type perEPAllow map[uint64]portProtoToSelectorAllow
+
+// perEPPolicy stores the policy rules.
+type perEPPolicy map[uint64]policy.L7DataMap
 
 // portProtoToSelectorAllow maps protocol-port numbers to selectors + rules
 type portProtoToSelectorAllow map[restore.PortProto]CachedSelectorREEntry
@@ -704,6 +711,7 @@ func StartDNSProxy(
 		lookupTargetDNSServer:    lookupTargetDNSServer,
 		usedServers:              make(map[string]struct{}),
 		allowed:                  make(perEPAllow),
+		currentRules:             make(perEPPolicy),
 		restored:                 make(perEPRestored),
 		restoredEPs:              make(restoredEPs),
 		cache:                    make(regexCache),
@@ -795,16 +803,28 @@ func (p *DNSProxy) LookupEndpointByIP(ip netip.Addr) (endpoint *endpoint.Endpoin
 
 // UpdateAllowed sets newRules for endpointID and destPort. It compiles the DNS
 // rules into regexes that are then used in CheckAllowed.
-func (p *DNSProxy) UpdateAllowed(endpointID uint64, destPortProto restore.PortProto, newRules policy.L7DataMap) error {
+func (p *DNSProxy) UpdateAllowed(endpointID uint64, destPortProto restore.PortProto, newRules policy.L7DataMap) (revert.RevertFunc, error) {
 	p.Lock()
 	defer p.Unlock()
 
 	err := p.allowed.setPortRulesForID(p.cache, endpointID, destPortProto, newRules)
-	if err == nil {
-		// Rules were updated based on policy, remove restored rules
-		p.removeRestoredRulesLocked(endpointID)
+	if err != nil {
+		return nil, err
 	}
-	return err
+
+	// Rules were updated based on policy, remove restored rules
+	p.removeRestoredRulesLocked(endpointID)
+
+	// Get current rules for reverting
+	oldRules := p.currentRules[endpointID]
+	p.currentRules[endpointID] = newRules
+
+	revert := func() error {
+		p.Lock()
+		defer p.Unlock()
+		return p.allowed.setPortRulesForID(p.cache, endpointID, destPortProto, oldRules)
+	}
+	return revert, nil
 }
 
 // UpdateAllowedFromSelectorRegexes sets newRules for endpointID and destPort.

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -287,7 +287,7 @@ func TestRejectFromDifferentEndpoint(t *testing.T) {
 	query := name
 
 	// Reject a query from not endpoint 1
-	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
+	_, err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	require.NoError(t, err, "Could not update with rules")
 	allowed, err := s.proxy.CheckAllowed(epID2, dstPortProto, dstID1, netip.Addr{}, query)
 	require.NoError(t, err, "Error when checking allowed")
@@ -308,7 +308,7 @@ func TestAcceptFromMatchingEndpoint(t *testing.T) {
 	query := name
 
 	// accept a query that matches from endpoint1
-	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
+	_, err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	require.NoError(t, err, "Could not update with rules")
 	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, netip.Addr{}, query)
 	require.NoError(t, err, "Error when checking allowed")
@@ -329,7 +329,7 @@ func TestAcceptNonRegex(t *testing.T) {
 	query := name
 
 	// accept a query that matches from endpoint1
-	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
+	_, err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	require.NoError(t, err, "Could not update with rules")
 	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, netip.Addr{}, query)
 	require.NoError(t, err, "Error when checking allowed")
@@ -350,7 +350,7 @@ func TestRejectNonRegex(t *testing.T) {
 	query := "ciliumXio."
 
 	// reject a query for a non-regex where a . is different (i.e. ensure simple FQDNs treat . as .)
-	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
+	_, err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	require.NoError(t, err, "Could not update with rules")
 	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, netip.Addr{}, query)
 	require.NoError(t, err, "Error when checking allowed")
@@ -368,7 +368,7 @@ func (s *DNSProxyTestSuite) requestRejectNonMatchingRefusedResponse(t *testing.T
 	}
 	query := "notcilium.io."
 
-	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
+	_, err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	require.NoError(t, err, "Could not update with rules")
 	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, netip.Addr{}, query)
 	require.NoError(t, err, "Error when checking allowed")
@@ -420,7 +420,7 @@ func TestRespondViaCorrectProtocol(t *testing.T) {
 	}
 	query := name
 
-	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
+	_, err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	require.NoError(t, err, "Could not update with rules")
 	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, netip.Addr{}, query)
 	require.NoError(t, err, "Error when checking allowed")
@@ -450,7 +450,7 @@ func TestRespondMixedCaseInRequestResponse(t *testing.T) {
 	}
 	query := "CILIUM.io."
 
-	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
+	_, err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	require.NoError(t, err, "Could not update with rules")
 	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, netip.Addr{}, query)
 	require.NoError(t, err, "Error when checking allowed")
@@ -481,7 +481,7 @@ func TestCheckNoRules(t *testing.T) {
 	}
 	query := name
 
-	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
+	_, err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	require.NoError(t, err, "Error when inserting rules")
 
 	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, netip.Addr{}, query)
@@ -496,7 +496,7 @@ func TestCheckNoRules(t *testing.T) {
 			},
 		},
 	}
-	err = s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
+	_, err = s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	require.NoError(t, err, "Error when inserting rules")
 
 	allowed, err = s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, netip.Addr{}, query)
@@ -518,23 +518,23 @@ func TestCheckAllowedTwiceRemovedOnce(t *testing.T) {
 	query := name
 
 	// Add the rule twice
-	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
+	_, err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	require.NoError(t, err, "Could not update with rules")
-	err = s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
+	_, err = s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	require.NoError(t, err, "Could not update with rules")
 	allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, netip.Addr{}, query)
 	require.NoError(t, err, "Error when checking allowed")
 	require.True(t, allowed, "request was rejected when it should be allowed")
 
 	// Delete once, it should reject
-	err = s.proxy.UpdateAllowed(epID1, dstPortProto, nil)
+	_, err = s.proxy.UpdateAllowed(epID1, dstPortProto, nil)
 	require.NoError(t, err, "Could not update with rules")
 	allowed, err = s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, netip.Addr{}, query)
 	require.NoError(t, err, "Error when checking allowed")
 	require.False(t, allowed, "request was allowed when it should be rejected")
 
 	// Delete once, it should reject and not crash
-	err = s.proxy.UpdateAllowed(epID1, dstPortProto, nil)
+	_, err = s.proxy.UpdateAllowed(epID1, dstPortProto, nil)
 	require.NoError(t, err, "Could not update with rules")
 	allowed, err = s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, netip.Addr{}, query)
 	require.NoError(t, err, "Error when checking allowed")
@@ -600,7 +600,7 @@ func TestFullPathDependence(t *testing.T) {
 	//	| EP1  | DstID1 |      53 |  UDP  | *.ubuntu.com   |
 	//	| EP1  | DstID1 |      53 |  UDP  | aws.amazon.com |
 	//	| EP1  | DstID2 |      53 |  UDP  | cilium.io      |
-	err := s.proxy.UpdateAllowed(epID1, udpProtoPort53, policy.L7DataMap{
+	_, err := s.proxy.UpdateAllowed(epID1, udpProtoPort53, policy.L7DataMap{
 		cachedDstID1Selector: &policy.PerSelectorPolicy{
 			L7Rules: api.L7Rules{
 				DNS: []api.PortRuleDNS{
@@ -620,7 +620,7 @@ func TestFullPathDependence(t *testing.T) {
 	require.NoError(t, err, "Could not update with port 53 rules")
 
 	//      | EP1  | DstID1 |      53 |  TCP  | sub.ubuntu.com |
-	err = s.proxy.UpdateAllowed(epID1, tcpProtoPort53, policy.L7DataMap{
+	_, err = s.proxy.UpdateAllowed(epID1, tcpProtoPort53, policy.L7DataMap{
 		cachedDstID1Selector: &policy.PerSelectorPolicy{
 			L7Rules: api.L7Rules{
 				DNS: []api.PortRuleDNS{
@@ -632,7 +632,7 @@ func TestFullPathDependence(t *testing.T) {
 	require.NoError(t, err, "Could not update with rules")
 
 	//	| EP1  | DstID1 |      54 |  UDP  | example.com    |
-	err = s.proxy.UpdateAllowed(epID1, udpProtoPort54, policy.L7DataMap{
+	_, err = s.proxy.UpdateAllowed(epID1, udpProtoPort54, policy.L7DataMap{
 		cachedWildcardSelector: &policy.PerSelectorPolicy{
 			L7Rules: api.L7Rules{
 				DNS: []api.PortRuleDNS{
@@ -646,7 +646,7 @@ func TestFullPathDependence(t *testing.T) {
 	// | EP3  | DstID1 |      53 |  UDP  | example.com    |
 	// | EP3  | DstID3 |      53 |  UDP  | *              |
 	// | EP3  | DstID4 |      53 |  UDP  | nil            |
-	err = s.proxy.UpdateAllowed(epID3, udpProtoPort53, policy.L7DataMap{
+	_, err = s.proxy.UpdateAllowed(epID3, udpProtoPort53, policy.L7DataMap{
 		cachedDstID1Selector: &policy.PerSelectorPolicy{
 			L7Rules: api.L7Rules{
 				DNS: []api.PortRuleDNS{
@@ -666,7 +666,7 @@ func TestFullPathDependence(t *testing.T) {
 	require.NoError(t, err, "Could not update with rules")
 
 	// | EP3  | DstID3 |      53 |  TCP  | example.com    |
-	err = s.proxy.UpdateAllowed(epID3, tcpProtoPort53, policy.L7DataMap{
+	_, err = s.proxy.UpdateAllowed(epID3, tcpProtoPort53, policy.L7DataMap{
 		cachedDstID3Selector: &policy.PerSelectorPolicy{
 			L7Rules: api.L7Rules{
 				DNS: []api.PortRuleDNS{
@@ -926,7 +926,7 @@ func TestFullPathDependence(t *testing.T) {
 	require.True(t, exists)
 
 	// Set empty ruleset, check that restored rules were deleted in epID3
-	err = s.proxy.UpdateAllowed(epID3, udpProtoPort53, nil)
+	_, err = s.proxy.UpdateAllowed(epID3, udpProtoPort53, nil)
 	require.NoError(t, err, "Could not update with rules")
 
 	_, exists = s.proxy.restored[epID3]
@@ -1078,7 +1078,7 @@ func TestRestoredEndpoint(t *testing.T) {
 	}
 	queries := []string{name, strings.ReplaceAll(pattern, "*", "sub")}
 
-	err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
+	_, err := s.proxy.UpdateAllowed(epID1, dstPortProto, l7map)
 	require.NoError(t, err, "Could not update with rules")
 	for _, query := range queries {
 		allowed, err := s.proxy.CheckAllowed(epID1, dstPortProto, dstID1, netip.Addr{}, query)
@@ -1110,7 +1110,7 @@ func TestRestoredEndpoint(t *testing.T) {
 	restored.Sort(nil)
 
 	// remove rules
-	err = s.proxy.UpdateAllowed(epID1, dstPortProto, nil)
+	_, err = s.proxy.UpdateAllowed(epID1, dstPortProto, nil)
 	require.NoError(t, err, "Could not remove rules")
 
 	// 2nd request, refused due to no rules

--- a/pkg/fqdn/proxy/proxy.go
+++ b/pkg/fqdn/proxy/proxy.go
@@ -8,12 +8,13 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/revert"
 )
 
 type DNSProxier interface {
 	GetRules(*versioned.VersionHandle, uint16) (restore.DNSRules, error)
 	RemoveRestoredRules(uint16)
-	UpdateAllowed(endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) error
+	UpdateAllowed(endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) (revert.RevertFunc, error)
 	GetBindPort() uint16
 	SetRejectReply(string)
 	RestoreRules(op *endpoint.Endpoint)
@@ -29,8 +30,8 @@ func (m MockFQDNProxy) GetRules(*versioned.VersionHandle, uint16) (restore.DNSRu
 func (m MockFQDNProxy) RemoveRestoredRules(u uint16) {
 }
 
-func (m MockFQDNProxy) UpdateAllowed(endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) error {
-	return nil
+func (m MockFQDNProxy) UpdateAllowed(endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) (revert.RevertFunc, error) {
+	return nil, nil
 }
 
 func (m MockFQDNProxy) GetBindPort() uint16 {

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -321,15 +321,6 @@ func (l7 L7DataMap) MarshalJSON() ([]byte, error) {
 	return buffer.Bytes(), err
 }
 
-// ShallowCopy returns a shallow copy of the L7DataMap.
-func (l7 L7DataMap) ShallowCopy() L7DataMap {
-	m := make(L7DataMap, len(l7))
-	for k, v := range l7 {
-		m[k] = v
-	}
-	return m
-}
-
 // L7ParserType is the type used to indicate what L7 parser to use.
 // Consts are defined for all well known L7 parsers.
 // Unknown string values are created for key-value pair policies, which
@@ -459,8 +450,8 @@ func (l4 *L4Filter) SelectsAllEndpoints() bool {
 
 // CopyL7RulesPerEndpoint returns a shallow copy of the PerSelectorPolicies of the
 // L4Filter.
-func (l4 *L4Filter) CopyL7RulesPerEndpoint() L7DataMap {
-	return l4.PerSelectorPolicies.ShallowCopy()
+func (l4 *L4Filter) GetPerSelectorPolicies() L7DataMap {
+	return l4.PerSelectorPolicies
 }
 
 // GetL7Parser returns the L7ParserType of the L4Filter.
@@ -1785,7 +1776,7 @@ func (l4 *L4Policy) GetModel() *models.L4Policy {
 // ProxyPolicy is any type which encodes state needed to redirect to an L7
 // proxy.
 type ProxyPolicy interface {
-	CopyL7RulesPerEndpoint() L7DataMap
+	GetPerSelectorPolicies() L7DataMap
 	GetL7Parser() L7ParserType
 	GetIngress() bool
 	GetPort() uint16

--- a/pkg/proxy/crd.go
+++ b/pkg/proxy/crd.go
@@ -9,7 +9,13 @@ import (
 )
 
 // Redirect type for custom Listeners, which are managed externally.
-type CRDRedirect struct{}
+type CRDRedirect struct {
+	Redirect
+}
+
+func (dr *CRDRedirect) GetRedirect() *Redirect {
+	return &dr.Redirect
+}
 
 func (r *CRDRedirect) UpdateRules(rules policy.L7DataMap) (revert.RevertFunc, error) {
 	return nil, nil

--- a/pkg/proxy/crd.go
+++ b/pkg/proxy/crd.go
@@ -4,15 +4,15 @@
 package proxy
 
 import (
-	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/revert"
 )
 
 // Redirect type for custom Listeners, which are managed externally.
 type CRDRedirect struct{}
 
-func (r *CRDRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc, error) {
-	return func() error { return nil }, nil
+func (r *CRDRedirect) UpdateRules(rules policy.L7DataMap) (revert.RevertFunc, error) {
+	return nil, nil
 }
 
 func (r *CRDRedirect) Close() {

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -6,7 +6,6 @@ package proxy
 import (
 	"github.com/sirupsen/logrus"
 
-	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/fqdn/proxy"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -22,7 +21,6 @@ var (
 // dnsRedirect implements the Redirect interface for an l7 proxy
 type dnsRedirect struct {
 	redirect         *Redirect
-	currentRules     policy.L7DataMap
 	proxyRuleUpdater proxyRuleUpdater
 }
 
@@ -33,40 +31,28 @@ type dnsRedirect struct {
 type proxyRuleUpdater interface {
 	// UpdateAllowed updates the rules in the DNS proxy with newRules for the
 	// endpointID and destPort.
-	UpdateAllowed(endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) error
+	UpdateAllowed(endpointID uint64, destPort restore.PortProto, newRules policy.L7DataMap) (revert.RevertFunc, error)
 }
 
 // setRules replaces old l7 rules of a redirect with new ones.
-// TODO: Get rid of the duplication between 'currentRules' and 'r.rules'
-func (dr *dnsRedirect) setRules(_ *completion.WaitGroup, newRules policy.L7DataMap) error {
+func (dr *dnsRedirect) setRules(newRules policy.L7DataMap) (revert.RevertFunc, error) {
 	log.WithFields(logrus.Fields{
 		"newRules":           newRules,
 		logfields.EndpointID: dr.redirect.endpointID,
 	}).Debug("DNS Proxy updating matchNames in allowed list during UpdateRules")
-	if err := dr.proxyRuleUpdater.UpdateAllowed(uint64(dr.redirect.endpointID), dr.redirect.dstPortProto, newRules); err != nil {
-		return err
-	}
-	dr.currentRules = copyRules(dr.redirect.rules)
-
-	return nil
+	return dr.proxyRuleUpdater.UpdateAllowed(uint64(dr.redirect.endpointID), dr.redirect.dstPortProto, newRules)
 }
 
 // UpdateRules atomically replaces the proxy rules in effect for this redirect.
 // It is not aware of revision number and doesn't account for out-of-order
 // calls to UpdateRules or the returned RevertFunc.
-func (dr *dnsRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc, error) {
-	oldRules := dr.currentRules
-	err := dr.setRules(wg, dr.redirect.rules)
-	revertFunc := func() error {
-		return dr.setRules(nil, oldRules)
-	}
-	return revertFunc, err
+func (dr *dnsRedirect) UpdateRules(rules policy.L7DataMap) (revert.RevertFunc, error) {
+	return dr.setRules(rules)
 }
 
 // Close the redirect.
 func (dr *dnsRedirect) Close() {
-	dr.proxyRuleUpdater.UpdateAllowed(uint64(dr.redirect.endpointID), dr.redirect.dstPortProto, nil)
-	dr.currentRules = nil
+	dr.setRules(nil)
 }
 
 type dnsProxyIntegration struct {
@@ -74,7 +60,7 @@ type dnsProxyIntegration struct {
 
 // createRedirect creates a redirect to the dns proxy. The redirect structure passed
 // in is safe to access for reading and writing.
-func (p *dnsProxyIntegration) createRedirect(r *Redirect, _ *completion.WaitGroup) (RedirectImplementation, error) {
+func (p *dnsProxyIntegration) createRedirect(r *Redirect) (RedirectImplementation, error) {
 	dr := &dnsRedirect{
 		redirect:         r,
 		proxyRuleUpdater: DefaultDNSProxy,
@@ -84,17 +70,9 @@ func (p *dnsProxyIntegration) createRedirect(r *Redirect, _ *completion.WaitGrou
 		"dnsRedirect": dr,
 	}).Debug("Creating DNS Proxy redirect")
 
-	return dr, dr.setRules(nil, r.rules)
+	return dr, nil
 }
 
 func (p *dnsProxyIntegration) changeLogLevel(level logrus.Level) error {
 	return nil
-}
-
-func copyRules(rules policy.L7DataMap) policy.L7DataMap {
-	currentRules := policy.L7DataMap{}
-	for key, val := range rules {
-		currentRules[key] = val
-	}
-	return currentRules
 }

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -20,8 +20,12 @@ var (
 
 // dnsRedirect implements the Redirect interface for an l7 proxy
 type dnsRedirect struct {
-	redirect         *Redirect
+	Redirect
 	proxyRuleUpdater proxyRuleUpdater
+}
+
+func (dr *dnsRedirect) GetRedirect() *Redirect {
+	return &dr.Redirect
 }
 
 // proxyRuleUpdater updates L7 proxy rules per endpoint.
@@ -38,9 +42,9 @@ type proxyRuleUpdater interface {
 func (dr *dnsRedirect) setRules(newRules policy.L7DataMap) (revert.RevertFunc, error) {
 	log.WithFields(logrus.Fields{
 		"newRules":           newRules,
-		logfields.EndpointID: dr.redirect.endpointID,
+		logfields.EndpointID: dr.endpointID,
 	}).Debug("DNS Proxy updating matchNames in allowed list during UpdateRules")
-	return dr.proxyRuleUpdater.UpdateAllowed(uint64(dr.redirect.endpointID), dr.redirect.dstPortProto, newRules)
+	return dr.proxyRuleUpdater.UpdateAllowed(uint64(dr.endpointID), dr.dstPortProto, newRules)
 }
 
 // UpdateRules atomically replaces the proxy rules in effect for this redirect.
@@ -60,9 +64,9 @@ type dnsProxyIntegration struct {
 
 // createRedirect creates a redirect to the dns proxy. The redirect structure passed
 // in is safe to access for reading and writing.
-func (p *dnsProxyIntegration) createRedirect(r *Redirect) (RedirectImplementation, error) {
+func (p *dnsProxyIntegration) createRedirect(redirect Redirect) (RedirectImplementation, error) {
 	dr := &dnsRedirect{
-		redirect:         r,
+		Redirect:         redirect,
 		proxyRuleUpdater: DefaultDNSProxy,
 	}
 

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -20,9 +20,14 @@ import (
 
 // envoyRedirect implements the RedirectImplementation interface for an l7 proxy.
 type envoyRedirect struct {
+	Redirect
 	listenerName string
 	xdsServer    envoy.XDSServer
 	adminClient  *envoy.EnvoyAdminClient
+}
+
+func (dr *envoyRedirect) GetRedirect() *Redirect {
+	return &dr.Redirect
 }
 
 type envoyProxyIntegration struct {
@@ -32,15 +37,16 @@ type envoyProxyIntegration struct {
 }
 
 // createRedirect creates a redirect with corresponding proxy configuration. This will launch a proxy instance.
-func (p *envoyProxyIntegration) createRedirect(r *Redirect, wg *completion.WaitGroup, cb func(err error)) (RedirectImplementation, error) {
+func (p *envoyProxyIntegration) createRedirect(r Redirect, wg *completion.WaitGroup, cb func(err error)) (RedirectImplementation, error) {
 	if r.proxyPort.ProxyType == types.ProxyTypeCRD {
 		// CRD Listeners already exist, create a no-op implementation
-		return &CRDRedirect{}, nil
+		return &CRDRedirect{Redirect: r}, nil
 	}
 
 	// create an Envoy Listener for Cilium policy enforcement
 	l := r.proxyPort
 	redirect := &envoyRedirect{
+		Redirect:     r,
 		listenerName: net.JoinHostPort(r.name, fmt.Sprintf("%d", l.ProxyPort)),
 		xdsServer:    p.xdsServer,
 		adminClient:  p.adminClient,

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -33,13 +33,13 @@ type envoyProxyIntegration struct {
 
 // createRedirect creates a redirect with corresponding proxy configuration. This will launch a proxy instance.
 func (p *envoyProxyIntegration) createRedirect(r *Redirect, wg *completion.WaitGroup, cb func(err error)) (RedirectImplementation, error) {
-	if r.listener.ProxyType == types.ProxyTypeCRD {
+	if r.proxyPort.ProxyType == types.ProxyTypeCRD {
 		// CRD Listeners already exist, create a no-op implementation
 		return &CRDRedirect{}, nil
 	}
 
 	// create an Envoy Listener for Cilium policy enforcement
-	l := r.listener
+	l := r.proxyPort
 	redirect := &envoyRedirect{
 		listenerName: net.JoinHostPort(r.name, fmt.Sprintf("%d", l.ProxyPort)),
 		xdsServer:    p.xdsServer,
@@ -73,8 +73,8 @@ func (p *envoyProxyIntegration) RemoveNetworkPolicy(ep endpoint.EndpointInfoSour
 }
 
 // UpdateRules is a no-op for envoy, as redirect data is synchronized via the xDS cache.
-func (k *envoyRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc, error) {
-	return func() error { return nil }, nil
+func (k *envoyRedirect) UpdateRules(rules policy.L7DataMap) (revert.RevertFunc, error) {
+	return nil, nil
 }
 
 // Close the redirect.

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -42,7 +42,7 @@ type Proxy struct {
 	// redirects is the map of all redirect configurations indexed by
 	// the redirect identifier. Redirects may be implemented by different
 	// proxies.
-	redirects map[string]*Redirect
+	redirects map[string]RedirectImplementation
 
 	envoyIntegration *envoyProxyIntegration
 	dnsIntegration   *dnsProxyIntegration
@@ -59,7 +59,7 @@ func createProxy(
 	dnsIntegration *dnsProxyIntegration,
 ) *Proxy {
 	return &Proxy{
-		redirects:        make(map[string]*Redirect),
+		redirects:        make(map[string]RedirectImplementation),
 		envoyIntegration: envoyIntegration,
 		dnsIntegration:   dnsIntegration,
 		proxyPorts:       proxyports.NewProxyPorts(minPort, maxPort, datapathUpdater),
@@ -122,7 +122,7 @@ func OpenLocalPorts() map[uint16]struct{} {
 func (p *Proxy) CreateOrUpdateRedirect(
 	ctx context.Context, l4 policy.ProxyPolicy, id string, epID uint16, wg *completion.WaitGroup,
 ) (
-	uint16, error, revert.FinalizeFunc, revert.RevertFunc,
+	uint16, error, revert.RevertFunc,
 ) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
@@ -132,17 +132,15 @@ func (p *Proxy) CreateOrUpdateRedirect(
 		WithField(logfields.Listener, l4.GetListener()).
 		WithField("l7parser", l4.GetL7Parser())
 
-	var finalizeList revert.FinalizeList
-	var revertStack revert.RevertStack
-
 	// Check for existing redirect and try to update it if possible. Otherwise, it gets removed before re-creation.
-	if existingRedirect, ok := p.redirects[id]; ok {
+	if existingImpl, ok := p.redirects[id]; ok {
+		existingRedirect := existingImpl.GetRedirect()
 		// Only consider configured (but not necessarily acked) proxy ports for update
 		if p.proxyPorts.HasProxyType(existingRedirect.proxyPort, types.ProxyType(l4.GetL7Parser())) {
 			// (DNS) proxy policy is updated in finalize function
-			revert, err := existingRedirect.implementation.UpdateRules(l4.GetPerSelectorPolicies())
+			revert, err := existingImpl.UpdateRules(l4.GetPerSelectorPolicies())
 			if err != nil {
-				return 0, fmt.Errorf("unable to update existing redirect: %w", err), nil, nil
+				return 0, fmt.Errorf("unable to update existing redirect: %w", err), nil
 			}
 			scopedLog.
 				WithField(logfields.Object, logfields.Repr(existingRedirect)).
@@ -150,7 +148,7 @@ func (p *Proxy) CreateOrUpdateRedirect(
 				Debug("updated existing proxy instance")
 
 			// Must return the proxy port when successful
-			return existingRedirect.proxyPort.ProxyPort, nil, nil, revert
+			return existingRedirect.proxyPort.ProxyPort, nil, revert
 		}
 
 		// Stale or incompatible redirects get removed before a new one is created below
@@ -158,15 +156,7 @@ func (p *Proxy) CreateOrUpdateRedirect(
 	}
 
 	// Create a new redirect
-	port, err, newRedirectRevertFunc := p.createNewRedirect(ctx, l4, id, epID, wg)
-	if err != nil {
-		p.revertStackUnlocked(revertStack)
-		return 0, fmt.Errorf("failed to create new redirect: %w", err), nil, nil
-	}
-
-	revertStack.Push(newRedirectRevertFunc)
-
-	return port, nil, finalizeList.Finalize, revertStack.Revert
+	return p.createNewRedirect(ctx, l4, id, epID, wg)
 }
 
 func proxyTypeNotFoundError(proxyType types.ProxyType, listener string, ingress bool) error {
@@ -193,7 +183,7 @@ func (p *Proxy) createNewRedirect(
 		return 0, proxyTypeNotFoundError(types.ProxyType(l4.GetL7Parser()), l4.GetListener(), l4.GetIngress()), nil
 	}
 
-	redirect := newRedirect(epID, ppName, pp, l4.GetPort(), l4.GetProtocol())
+	redirect := initRedirect(epID, ppName, pp, l4.GetPort(), l4.GetProtocol())
 
 	scopedLog = scopedLog.
 		WithField("portName", ppName)
@@ -227,6 +217,7 @@ func (p *Proxy) createNewRedirect(
 		}
 	}
 
+	var impl RedirectImplementation
 	var err error
 	for nRetry := 0; nRetry < redirectCreationAttempts; nRetry++ {
 		if err != nil {
@@ -243,7 +234,7 @@ func (p *Proxy) createNewRedirect(
 			break
 		}
 
-		err = p.createRedirectImpl(redirect, l4, wg, proxyCallback)
+		impl, err = p.createRedirectImpl(redirect, l4, wg, proxyCallback)
 		if err == nil {
 			break
 		}
@@ -261,7 +252,7 @@ func (p *Proxy) createNewRedirect(
 
 	// Set the rules on the new redirect. Returned revert function not used, removing the rules
 	// is explicitly handled by the revertFunc below by calling redirect.implementation.Close()
-	_, err = redirect.implementation.UpdateRules(l4.GetPerSelectorPolicies())
+	_, err = impl.UpdateRules(l4.GetPerSelectorPolicies())
 	if err != nil {
 		return 0, fmt.Errorf("unable to set rules on redirect: %w", err), nil
 	}
@@ -271,7 +262,7 @@ func (p *Proxy) createNewRedirect(
 		WithField(logfields.ProxyPort, pp.ProxyPort).
 		Info("Created new proxy instance")
 
-	p.redirects[id] = redirect
+	p.redirects[id] = impl
 	p.updateRedirectMetrics()
 
 	revertFunc := func() error {
@@ -281,7 +272,7 @@ func (p *Proxy) createNewRedirect(
 		p.updateRedirectMetrics()
 		p.proxyPorts.ReleaseProxyPort(ppName)
 		p.mutex.Unlock()
-		redirect.implementation.Close()
+		impl.Close()
 		return nil
 	}
 
@@ -289,28 +280,14 @@ func (p *Proxy) createNewRedirect(
 	return pp.ProxyPort, nil, revertFunc
 }
 
-func (p *Proxy) createRedirectImpl(redir *Redirect, l4 policy.ProxyPolicy, wg *completion.WaitGroup, cb func(err error)) error {
-	var err error
-
+func (p *Proxy) createRedirectImpl(redir Redirect, l4 policy.ProxyPolicy, wg *completion.WaitGroup, cb func(err error)) (impl RedirectImplementation, err error) {
 	switch l4.GetL7Parser() {
 	case policy.ParserTypeDNS:
-		redir.implementation, err = p.dnsIntegration.createRedirect(redir)
 		// 'cb' not called for DNS redirects, which have a static proxy port
+		return p.dnsIntegration.createRedirect(redir)
 	default:
-		redir.implementation, err = p.envoyIntegration.createRedirect(redir, wg, cb)
+		return p.envoyIntegration.createRedirect(redir, wg, cb)
 	}
-
-	return err
-}
-
-func (p *Proxy) revertStackUnlocked(revertStack revert.RevertStack) {
-	// We ignore errors while reverting. This is best-effort.
-	// revertFunc must be called after p.mutex is unlocked, because
-	// some functions in the revert stack (like removeRevertFunc)
-	// require it
-	p.mutex.Unlock()
-	revertStack.Revert()
-	p.mutex.Lock()
 }
 
 // RemoveRedirect removes an existing redirect that has been successfully created earlier.
@@ -330,21 +307,19 @@ func (p *Proxy) removeRedirect(id string) {
 		WithField(fieldProxyRedirectID, id).
 		Debug("Removing proxy redirect")
 
-	r, ok := p.redirects[id]
+	impl, ok := p.redirects[id]
 	if !ok {
 		return
 	}
+	r := impl.GetRedirect()
 	delete(p.redirects, id)
 
-	r.implementation.Close()
+	impl.Close()
 
 	// Delay the release and reuse of the port number so it is guaranteed to be
 	// safe to listen on the port again.
 	proxyPort := r.proxyPort.ProxyPort
 	listenerName := r.name
-
-	// break GC loop (implementation may point back to 'r')
-	r.implementation = nil
 
 	err := p.proxyPorts.ReleaseProxyPort(listenerName)
 	if err != nil {
@@ -393,7 +368,8 @@ func (p *Proxy) GetStatusModel() *models.ProxyStatus {
 		TotalRedirects: int64(len(p.redirects)),
 	}
 
-	for name, redirect := range p.redirects {
+	for name, impl := range p.redirects {
+		redirect := impl.GetRedirect()
 		result.Redirects = append(result.Redirects, &models.ProxyRedirect{
 			Name:      name,
 			Proxy:     redirect.name,
@@ -411,7 +387,8 @@ func (p *Proxy) GetStatusModel() *models.ProxyStatus {
 // in Prometheus. Lock needs to be held to call this function.
 func (p *Proxy) updateRedirectMetrics() {
 	result := map[string]int{}
-	for _, redirect := range p.redirects {
+	for _, impl := range p.redirects {
+		redirect := impl.GetRedirect()
 		result[string(redirect.proxyPort.ProxyType)]++
 	}
 	for proto, count := range result {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -74,9 +74,8 @@ func TestCreateOrUpdateRedirectMissingListener(t *testing.T) {
 	ctx := context.TODO()
 	wg := completion.NewWaitGroup(ctx)
 
-	proxyPort, err, finalizeFunc, revertFunc := p.CreateOrUpdateRedirect(ctx, l4, "dummy-proxy-id", 1000, wg)
+	proxyPort, err, revertFunc := p.CreateOrUpdateRedirect(ctx, l4, "dummy-proxy-id", 1000, wg)
 	require.Equal(t, uint16(0), proxyPort)
 	require.Error(t, err)
-	require.Nil(t, finalizeFunc)
 	require.Nil(t, revertFunc)
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -36,7 +36,7 @@ func proxyForTest() (*Proxy, func()) {
 
 type fakeProxyPolicy struct{}
 
-func (p *fakeProxyPolicy) CopyL7RulesPerEndpoint() policy.L7DataMap {
+func (p *fakeProxyPolicy) GetPerSelectorPolicies() policy.L7DataMap {
 	return policy.L7DataMap{}
 }
 

--- a/pkg/proxy/redirect.go
+++ b/pkg/proxy/redirect.go
@@ -59,7 +59,7 @@ func newRedirect(epID uint16, name string, listener *proxyports.ProxyPort, port 
 // TODO: Replace this with RedirectImplementation UpdateRules method!
 func (r *Redirect) updateRules(p policy.ProxyPolicy) revert.RevertFunc {
 	oldRules := r.rules
-	r.rules = p.CopyL7RulesPerEndpoint()
+	r.rules = p.GetPerSelectorPolicies()
 	return func() error {
 		r.mutex.Lock()
 		r.rules = oldRules

--- a/pkg/proxy/redirect.go
+++ b/pkg/proxy/redirect.go
@@ -14,6 +14,9 @@ import (
 // RedirectImplementation is the generic proxy redirect interface that each
 // proxy redirect type must implement
 type RedirectImplementation interface {
+	// GetRedirect returns the static config of the redirect
+	GetRedirect() *Redirect
+
 	// UpdateRules synchronously updates the rules for the given proxy redirect.
 	// Note: UpdateRules is not called when a redirect is created.
 	UpdateRules(rules policy.L7DataMap) (revert.RevertFunc, error)
@@ -25,18 +28,16 @@ type RedirectImplementation interface {
 	Close()
 }
 
+// Redirect is the common static config for each RedirectImplementation
 type Redirect struct {
-	// The following fields are only written to during initialization, it
-	// is safe to read these fields without locking the mutex
-	name           string
-	proxyPort      *proxyports.ProxyPort
-	dstPortProto   restore.PortProto
-	endpointID     uint16
-	implementation RedirectImplementation
+	name         string
+	proxyPort    *proxyports.ProxyPort
+	dstPortProto restore.PortProto
+	endpointID   uint16
 }
 
-func newRedirect(epID uint16, name string, listener *proxyports.ProxyPort, port uint16, proto u8proto.U8proto) *Redirect {
-	return &Redirect{
+func initRedirect(epID uint16, name string, listener *proxyports.ProxyPort, port uint16, proto u8proto.U8proto) Redirect {
+	return Redirect{
 		name:         name,
 		proxyPort:    listener,
 		dstPortProto: restore.MakeV2PortProto(port, proto),

--- a/pkg/proxy/redirect.go
+++ b/pkg/proxy/redirect.go
@@ -4,9 +4,7 @@
 package proxy
 
 import (
-	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/proxyports"
 	"github.com/cilium/cilium/pkg/revert"
@@ -16,12 +14,9 @@ import (
 // RedirectImplementation is the generic proxy redirect interface that each
 // proxy redirect type must implement
 type RedirectImplementation interface {
-	// UpdateRules updates the rules for the given proxy redirect.
-	// The implementation should .Add to the WaitGroup if the update is
-	// asynchronous and the update should not return until it is complete.
-	// The returned RevertFunc must be non-nil.
+	// UpdateRules synchronously updates the rules for the given proxy redirect.
 	// Note: UpdateRules is not called when a redirect is created.
-	UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc, error)
+	UpdateRules(rules policy.L7DataMap) (revert.RevertFunc, error)
 
 	// Close closes and cleans up resources associated with the redirect
 	// implementation. The implementation should .Add to the WaitGroup if the
@@ -34,36 +29,17 @@ type Redirect struct {
 	// The following fields are only written to during initialization, it
 	// is safe to read these fields without locking the mutex
 	name           string
-	listener       *proxyports.ProxyPort
+	proxyPort      *proxyports.ProxyPort
 	dstPortProto   restore.PortProto
 	endpointID     uint16
 	implementation RedirectImplementation
-
-	// The following fields are updated while the redirect is alive, the
-	// mutex must be held to read and write these fields
-	mutex lock.RWMutex
-	rules policy.L7DataMap
 }
 
 func newRedirect(epID uint16, name string, listener *proxyports.ProxyPort, port uint16, proto u8proto.U8proto) *Redirect {
 	return &Redirect{
 		name:         name,
-		listener:     listener,
+		proxyPort:    listener,
 		dstPortProto: restore.MakeV2PortProto(port, proto),
 		endpointID:   epID,
-	}
-}
-
-// updateRules updates the rules of the redirect, Redirect.mutex must be held
-// 'implementation' is not initialized when this is called the first time.
-// TODO: Replace this with RedirectImplementation UpdateRules method!
-func (r *Redirect) updateRules(p policy.ProxyPolicy) revert.RevertFunc {
-	oldRules := r.rules
-	r.rules = p.GetPerSelectorPolicies()
-	return func() error {
-		r.mutex.Lock()
-		r.rules = oldRules
-		r.mutex.Unlock()
-		return nil
 	}
 }


### PR DESCRIPTION
Simplify proxy redirect implementations by:

- Remove (shallow) copies of L7DataMap to  proxy `Redirect`. `L7DataMap` is not mutated after a selector policy has been computed, so there is no need to take a copy.

- Remove the storage of L7 rules from `Redirect` by returning revert function from the `UpdateAllowed`. This requires rules to be set on a new redirect via `UpdateRules()`. Make `UpdateRules` explicitly handle only the synchronous rule update as needed for the DNS proxy.

- Remove circular reference from `RedirectImplementation` to `Redirect` by making each redirect implementation an extension of `Redirect`.