### PR TITLE
connectivity: Add test for update TLS secret

### DIFF
--- a/cilium-cli/connectivity/builder/client_egress_l7_tls_headers.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_tls_headers.go
@@ -13,6 +13,7 @@ type clientEgressL7TlsHeaders struct{}
 
 func (t clientEgressL7TlsHeaders) build(ct *check.ConnectivityTest, templates map[string]string) {
 	clientEgressL7TlsHeadersTest(ct, templates, false)
+	clientEgressL7ExtraTlsHeadersTest(ct, templates)
 	if ct.Features[features.L7PortRanges].Enabled {
 		clientEgressL7TlsHeadersTest(ct, templates, true)
 	}
@@ -33,7 +34,34 @@ func clientEgressL7TlsHeadersTest(ct *check.ConnectivityTest, templates map[stri
 		WithCertificate("externaltarget-tls", ct.Params().ExternalTarget).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy with TLS interception
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-		WithScenarios(tests.PodToWorldWithTLSIntercept("-H", "X-Very-Secret-Token: 42")).
+		WithScenarios(tests.PodToWorldWithTLSIntercept(
+			"-H", "X-Very-Secret-Token: 42",
+			"--retry", "5",
+			"--retry-delay", "0",
+			"--retry-all-errors")).
+		WithExpectations(func(_ *check.Action) (egress, ingress check.Result) {
+			return check.ResultOK, check.ResultNone
+		})
+}
+
+func clientEgressL7ExtraTlsHeadersTest(ct *check.ConnectivityTest, templates map[string]string) {
+	testName := "seq-client-egress-l7-extra-tls-headers"
+	yamlFile := templates["clientEgressL7TLSPolicyYAML"]
+	// Test L7 HTTPS interception using an egress policy on the clients.
+	newTest(testName, ct).
+		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretBackendK8s)).
+		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretSync)).
+		WithCABundleSecret().
+		WithCertificate("externaltarget-tls", ct.Params().ExternalTarget). // Only one certificate for ExternalTarget
+		WithCiliumPolicy(yamlFile).                                        // L7 allow policy with TLS interception
+		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]).      // DNS resolution only
+		WithScenarios(tests.PodToWorldWithExtraTLSIntercept(
+			"externaltarget-tls",
+			"-H", "X-Very-Secret-Token: 42",
+			"--retry", "5",
+			"--retry-delay", "0",
+			"--retry-all-errors")).
 		WithExpectations(func(_ *check.Action) (egress, ingress check.Result) {
 			return check.ResultOK, check.ResultNone
 		})

--- a/cilium-cli/connectivity/builder/manifests/client-egress-l7-tls.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-l7-tls.yaml
@@ -31,3 +31,23 @@ specs:
           path: "/"
           headers:
           - "X-Very-Secret-Token: 42"
+  - toFQDNs:
+    - matchName: "{{.ExternalOtherTarget}}"
+    toPorts:
+    - ports:
+      - port: "443"
+        protocol: "TCP"
+      terminatingTLS:
+        secret:
+          namespace: "{{.TestNamespace}}"
+          name: externaltarget-tls # internal certificate to terminate in cluster
+      originatingTLS:
+        secret:
+          namespace: "{{.ExternalTargetCANamespace}}"
+          name: "{{.ExternalTargetCAName}}" # public CA bundle to validate external target
+      rules:
+        http:
+        - method: "GET"
+          path: "/"
+          headers:
+          - "X-Very-Secret-Token: 42"

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -121,7 +121,8 @@ type Test struct {
 	secrets map[string]*corev1.Secret
 
 	// CA certificates of the certificates that have to be present during the test.
-	certificateCAs map[string][]byte
+	certificateCAs  map[string][]byte
+	certificateKeys map[string][]byte
 
 	// A custom sysdump policy for the given test.
 	sysdumpPolicy SysdumpPolicy
@@ -707,6 +708,11 @@ func (t *Test) WithCertificate(name, hostname string) *Test {
 	}
 	t.certificateCAs[name] = caCert
 
+	if t.certificateKeys == nil {
+		t.certificateKeys = make(map[string][]byte)
+	}
+	t.certificateKeys[name] = caKey
+
 	return t.WithSecret(&corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -861,6 +867,11 @@ func (t *Test) ForEachIPFamily(do func(features.IPFamily)) {
 // CertificateCAs returns the CAs used to sign the certificates within the test.
 func (t *Test) CertificateCAs() map[string][]byte {
 	return t.certificateCAs
+}
+
+// CertificateKeys returns the CA keys used to sign the certificates within the test.
+func (t *Test) CertificateKeys() map[string][]byte {
+	return t.certificateKeys
 }
 
 func (t *Test) CiliumLocalRedirectPolicies() map[string]*ciliumv2.CiliumLocalRedirectPolicy {


### PR DESCRIPTION
This test is same as the existing seq-client-egress-l7-tls-headers test,
but the secret is updated with one additional host (e.g. cilium.io), so
that we can verify the update path is still working as expected.

Signed-off-by: Tam Mach <tam.mach@cilium.io>
