### PR TITLE
fix: Hubble metrics not deleted for deleted pods

### DIFF
--- a/pkg/hubble/metrics/metrics.go
+++ b/pkg/hubble/metrics/metrics.go
@@ -86,7 +86,7 @@ func initEndpointDeletionHandler() {
 			if quit {
 				return
 			}
-			ProcessCiliumEndpointDeletion(endpoint.(*types.CiliumEndpoint))
+			api.ProcessCiliumEndpointDeletion(endpoint.(*types.CiliumEndpoint), EnabledMetrics)
 			endpointDeletionHandler.queue.Done(endpoint)
 		}
 	}()


### PR DESCRIPTION
The function that deletes metrics for deleted pods isn't getting called due to a mistake in previous refactoring.
Instead, the code that posts the deletion in a queue calls itself in a loop.
 
Fixes #36195
