### PR TITLE
bpf: Remove misnamed `node_id` variable

### DIFF
--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -30,8 +30,6 @@ __encap_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 		    __u32 seclabel, __u32 dstid, __u32 vni __maybe_unused,
 		    enum trace_reason ct_reason, __u32 monitor, int *ifindex)
 {
-	__u32 node_id;
-
 	/* When encapsulating, a packet originating from the local host is
 	 * being considered as a packet from a remote node as it is being
 	 * received.
@@ -39,9 +37,7 @@ __encap_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 	if (seclabel == HOST_ID)
 		seclabel = LOCAL_NODE_ID;
 
-	node_id = bpf_ntohl(tunnel_endpoint);
-
-	cilium_dbg(ctx, DBG_ENCAP, node_id, seclabel);
+	cilium_dbg(ctx, DBG_ENCAP, tunnel_endpoint, seclabel);
 
 #if __ctx_is == __ctx_skb
 	*ifindex = ENCAP_IFINDEX;
@@ -52,7 +48,7 @@ __encap_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 	send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, dstid, TRACE_EP_ID_UNKNOWN,
 			  *ifindex, ct_reason, monitor);
 
-	return ctx_set_encap_info(ctx, src_ip, src_port, node_id, seclabel, vni,
+	return ctx_set_encap_info(ctx, src_ip, src_port, tunnel_endpoint, seclabel, vni,
 				  NULL, 0);
 }
 
@@ -223,8 +219,6 @@ __encap_with_nodeid_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 			enum trace_reason ct_reason,
 			__u32 monitor, int *ifindex)
 {
-	__u32 node_id;
-
 	/* When encapsulating, a packet originating from the local host is
 	 * being considered as a packet from a remote node as it is being
 	 * received.
@@ -232,9 +226,7 @@ __encap_with_nodeid_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 	if (seclabel == HOST_ID)
 		seclabel = LOCAL_NODE_ID;
 
-	node_id = bpf_ntohl(tunnel_endpoint);
-
-	cilium_dbg(ctx, DBG_ENCAP, node_id, seclabel);
+	cilium_dbg(ctx, DBG_ENCAP, tunnel_endpoint, seclabel);
 
 #if __ctx_is == __ctx_skb
 	*ifindex = ENCAP_IFINDEX;
@@ -245,7 +237,7 @@ __encap_with_nodeid_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 	send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, dstid, TRACE_EP_ID_UNKNOWN,
 			  *ifindex, ct_reason, monitor);
 
-	return ctx_set_encap_info(ctx, src_ip, src_port, node_id, seclabel, vni, opt,
+	return ctx_set_encap_info(ctx, src_ip, src_port, tunnel_endpoint, seclabel, vni, opt,
 				  opt_len);
 }
 

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -286,7 +286,7 @@ static __always_inline bool ctx_egw_done(const struct __sk_buff *ctx)
 #ifdef HAVE_ENCAP
 static __always_inline __maybe_unused int
 ctx_set_encap_info(struct __sk_buff *ctx, __u32 src_ip,
-		   __be16 src_port __maybe_unused, __u32 node_id,
+		   __be16 src_port __maybe_unused, __u32 tunnel_endpoint,
 		   __u32 seclabel, __u32 vni __maybe_unused,
 		   void *opt, __u32 opt_len)
 {
@@ -305,7 +305,7 @@ ctx_set_encap_info(struct __sk_buff *ctx, __u32 src_ip,
 		key.local_ipv4 = bpf_ntohl(src_ip);
 		key_size = sizeof(key);
 	}
-	key.remote_ipv4 = node_id;
+	key.remote_ipv4 = bpf_ntohl(tunnel_endpoint);
 	key.tunnel_ttl = IPDEFTTL;
 
 	ret = ctx_set_tunnel_key(ctx, &key, key_size, BPF_F_ZERO_CSUM_TX);

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -254,7 +254,7 @@ ctx_set_encap_info(struct xdp_md *ctx, __u32 src_ip, __be16 src_port,
 	ip4->ttl = IPDEFTTL;
 	ip4->protocol = IPPROTO_UDP;
 	ip4->saddr = src_ip;
-	ip4->daddr = bpf_htonl(daddr);
+	ip4->daddr = daddr;
 	ip4->check = csum_fold(csum_diff(NULL, 0, ip4, sizeof(*ip4), 0));
 
 	eth->h_proto = bpf_htons(ETH_P_IP);


### PR DESCRIPTION
This variable doesn't actually hold the node ID but the tunnel endpoint IP. We can avoid this variable anyway because the `ctx_set_encap_info` function is better placed to convert the tunnel endpoint IP to host byte order.