### PR TITLE
bpf: Remove unnecessary `__maybe_unused`

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -482,7 +482,7 @@ tail_handle_ipv6(struct __ctx_buff *ctx, __u32 ipcache_srcid, const bool from_ho
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_FROM_HOST)
-int tail_handle_ipv6_from_host(struct __ctx_buff *ctx __maybe_unused)
+int tail_handle_ipv6_from_host(struct __ctx_buff *ctx)
 {
 	__u32 ipcache_srcid = 0;
 
@@ -622,7 +622,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 #ifdef ENABLE_NODEPORT
 	if (!from_host) {
 		if (!ctx_skip_nodeport(ctx)) {
-			bool __maybe_unused is_dsr = false;
+			bool is_dsr = false;
 
 			int ret = nodeport_lb4(ctx, ip4, ETH_HLEN, secctx, punt_to_stack,
 					       ext_err, &is_dsr);
@@ -1388,7 +1388,7 @@ int cil_from_host(struct __ctx_buff *ctx)
  * managed by Cilium (e.g., eth0).
  */
 __section_entry
-int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
+int cil_to_netdev(struct __ctx_buff *ctx)
 {
 	__u32 magic = ctx->mark & MARK_MAGIC_HOST_MASK;
 	__u32 dst_sec_identity = UNKNOWN_ID;
@@ -1398,7 +1398,7 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 		.monitor = 0,
 	};
 	__be16 __maybe_unused proto = 0;
-	__u32 __maybe_unused vlan_id;
+	__u32 vlan_id;
 	int ret = CTX_ACT_OK;
 	__s8 ext_err = 0;
 
@@ -1774,7 +1774,7 @@ __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_TO_HOST_POLICY_ONLY)
 static __always_inline
 int tail_ipv6_host_policy_ingress(struct __ctx_buff *ctx)
 {
-	struct trace_ctx __maybe_unused trace = {
+	struct trace_ctx trace = {
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = 0,
 	};
@@ -1802,7 +1802,7 @@ __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_TO_HOST_POLICY_ONLY)
 static __always_inline
 int tail_ipv4_host_policy_ingress(struct __ctx_buff *ctx)
 {
-	struct trace_ctx __maybe_unused trace = {
+	struct trace_ctx trace = {
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = TRACE_PAYLOAD_LEN,
 	};
@@ -1829,7 +1829,7 @@ static __always_inline int
 /* Handles packet from a local endpoint entering the host namespace. Applies
  * ingress host policies.
  */
-to_host_from_lxc(struct __ctx_buff *ctx __maybe_unused)
+to_host_from_lxc(struct __ctx_buff *ctx)
 {
 	int ret = CTX_ACT_OK;
 	__s8 ext_err = 0;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -446,7 +446,7 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = 0,
 	};
-	__u32 __maybe_unused tunnel_endpoint = 0;
+	__u32 tunnel_endpoint = 0;
 	__u8 __maybe_unused encrypt_key = 0;
 	bool __maybe_unused skip_tunnel = false;
 	enum ct_status ct_status;
@@ -823,7 +823,7 @@ TAIL_CT_LOOKUP6(CILIUM_CALL_IPV6_CT_EGRESS, tail_ipv6_ct_egress, CT_EGRESS,
 		CILIUM_CALL_IPV6_FROM_LXC_CONT, tail_handle_ipv6_cont)
 
 static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx,
-					      __s8 *ext_err __maybe_unused)
+					      __s8 *ext_err)
 {
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
@@ -890,7 +890,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = 0,
 	};
-	__u32 __maybe_unused tunnel_endpoint = 0, zero = 0;
+	__u32 tunnel_endpoint = 0, zero = 0;
 	__u8 __maybe_unused encrypt_key = 0;
 	bool __maybe_unused skip_tunnel = false;
 	bool hairpin_flow = false; /* endpoint wants to access itself via service IP */

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -27,7 +27,7 @@ struct {
 static __always_inline int
 __encap_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 		    __be32 tunnel_endpoint,
-		    __u32 seclabel, __u32 dstid, __u32 vni __maybe_unused,
+		    __u32 seclabel, __u32 dstid, __u32 vni,
 		    enum trace_reason ct_reason, __u32 monitor, int *ifindex)
 {
 	/* When encapsulating, a packet originating from the local host is
@@ -53,7 +53,7 @@ __encap_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 }
 
 static __always_inline int
-__encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip __maybe_unused,
+__encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip,
 				 __be32 tunnel_endpoint,
 				 __u32 seclabel, __u32 dstid, __u32 vni,
 				 const struct trace_ctx *trace)
@@ -100,9 +100,6 @@ __encap_and_redirect_lxc(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 			 __u8 encrypt_key, __u32 seclabel, __u32 dstid,
 			 const struct trace_ctx *trace)
 {
-	int ifindex __maybe_unused;
-	int ret __maybe_unused;
-
 	return encap_and_redirect_with_nodeid(ctx, tunnel_endpoint,
 					      encrypt_key, seclabel, dstid,
 					      trace);


### PR DESCRIPTION
Over time, some of the `__maybe_unused` have become unnecessary because the variable they mark is used in all datapath configurations.