### PR TITLE
bgpv2: Test_MergeRoutePolicies statements can be unordered

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/policies_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/policies_test.go
@@ -4,6 +4,7 @@
 package reconcilerv2
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -483,8 +484,25 @@ func Test_MergeRoutePolicies(t *testing.T) {
 				req.NoError(err)
 			}
 
+			if tt.expected != nil {
+				req.NotNil(result)
+				SortRouteStatementsByName(result.Statements)
+				SortRouteStatementsByName(tt.expected.Statements)
+			}
+
 			req.Equal(tt.expected, result)
 		})
 	}
+}
 
+func SortRouteStatementsByName(statements []*types.RoutePolicyStatement) {
+	slices.SortFunc(statements, func(i, j *types.RoutePolicyStatement) int {
+		if i.Conditions.String() < j.Conditions.String() {
+			return -1
+		} else if i.Conditions.String() > j.Conditions.String() {
+			return 1
+		} else {
+			return 0
+		}
+	})
 }


### PR DESCRIPTION
Merged policies may have statements in different order compared to what is expected in the test case. Currently, we do not need ordering of statements so test should check unordered statements.

Test run 

```
go test -c -race . &&  stress ./reconcilerv2.test -test.run=Test_MergeRoutePolicies
5s: 40 runs so far, 0 failures
10s: 90 runs so far, 0 failures
15s: 130 runs so far, 0 failures
20s: 180 runs so far, 0 failures
25s: 220 runs so far, 0 failures
30s: 270 runs so far, 0 failures
35s: 310 runs so far, 0 failures
40s: 360 runs so far, 0 failures
45s: 407 runs so far, 0 failures
50s: 450 runs so far, 0 failures
```

Fixes: #36867