### PR TITLE
Updating the header file with DNS rules during policy update

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -190,6 +190,7 @@ cilium-agent [flags]
       --encryption-strict-mode-allow-remote-node-identities       Allows unencrypted traffic from pods to remote node identities within the strict mode CIDR. This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap.
       --encryption-strict-mode-cidr string                        In strict-mode encryption, all unencrypted traffic coming from this CIDR and going to this same CIDR will be dropped
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
+      --endpoint-header-file-sync-interval duration               Interval for syncing the endpoint header file (default 5m0s)
       --endpoint-queue-size int                                   Size of EventQueue per-endpoint (default 25)
       --endpoint-regen-interval duration                          Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable (default 2m0s)
       --envoy-access-log-buffer-size uint                         Envoy access log buffer size in bytes (default 4096)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -208,6 +208,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Duration(option.ARPPingRefreshPeriod, defaults.ARPBaseReachableTime, "Period for remote node ARP entry refresh (set 0 to disable)")
 	option.BindEnv(vp, option.ARPPingRefreshPeriod)
 
+	flags.Duration(option.EndpointHeaderFileSyncInterval, defaults.EndpointHeaderFileSyncInterval, "Interval for syncing the endpoint header file")
+	option.BindEnv(vp, option.EndpointHeaderFileSyncInterval)
+
 	flags.Bool(option.EnableL2NeighDiscovery, true, "Enables L2 neighbor discovery used by kube-proxy-replacement and IPsec")
 	option.BindEnv(vp, option.EnableL2NeighDiscovery)
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -521,6 +521,9 @@ const (
 	// ARPBaseReachableTime resembles the kernel's NEIGH_VAR_BASE_REACHABLE_TIME which defaults to 30 seconds.
 	ARPBaseReachableTime = 30 * time.Second
 
+	// EndpointHeaderFileSyncInterval
+	EndpointHeaderFileSyncInterval = 5 * time.Minute
+
 	// EnableVTEP enables VXLAN Tunnel Endpoint (VTEP) Integration
 	EnableVTEP     = false
 	MaxVTEPDevices = 8

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -530,10 +530,10 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 		datapathRegenCtxt.policyMapSyncDone = true
 	}
 
-	// Initialize (if not done yet) the DNS history trigger to allow DNS proxy to trigger
+	// Initialize (if not done yet) the EndpointSync Controller to allow DNS proxy to trigger
 	// updates to endpoint headers. The initialization happens here as at this point
 	// datapath is ready to process the trigger.
-	e.initDNSHistoryTrigger()
+	e.initEndpointSyncController(option.Config.EndpointHeaderFileSyncInterval)
 
 	return datapathRegenCtxt.epInfoCache.revision, err
 }

--- a/pkg/endpointmanager/endpointsynchronizer_test.go
+++ b/pkg/endpointmanager/endpointsynchronizer_test.go
@@ -16,7 +16,10 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/node"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
 
 func Test_updateCEPUID(t *testing.T) {
@@ -28,7 +31,8 @@ func Test_updateCEPUID(t *testing.T) {
 		}
 	}
 	epWithUID := func(uid string, pod *slim_corev1.Pod) *endpoint.Endpoint {
-		ep := &endpoint.Endpoint{}
+		s := setupEndpointManagerSuite(t)
+		ep := endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 2, endpoint.StateReady)
 		ep.SetPod(pod)
 		ep.SetCiliumEndpointUID(types.UID(uid))
 		return ep

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -87,6 +87,9 @@ const (
 	// ARPPingRefreshPeriod is the ARP entries refresher period
 	ARPPingRefreshPeriod = "arping-refresh-period"
 
+	// EndpointHeaderFileSyncInterval is the interval for syncing endpointHeader file
+	EndpointHeaderFileSyncInterval = "endpoint-header-file-sync-interval"
+
 	// EnableL2NeighDiscovery determines if cilium should perform L2 neighbor
 	// discovery.
 	EnableL2NeighDiscovery = "enable-l2-neigh-discovery"
@@ -1361,6 +1364,9 @@ type DaemonConfig struct {
 	// at runtime and reconfigure the datapath to load programs onto the new
 	// devices.
 	EnableRuntimeDeviceDetection bool
+
+	// EndpointHeaderFileSyncInterval is the interval for syncing the endpointHeader file
+	EndpointHeaderFileSyncInterval time.Duration
 
 	DatapathMode string // Datapath mode
 	RoutingMode  string // Routing mode
@@ -2839,6 +2845,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.AgentHealthPort = vp.GetInt(AgentHealthPort)
 	c.ClusterHealthPort = vp.GetInt(ClusterHealthPort)
 	c.ClusterMeshHealthPort = vp.GetInt(ClusterMeshHealthPort)
+	c.EndpointHeaderFileSyncInterval = vp.GetDuration(EndpointHeaderFileSyncInterval)
 	c.AllowICMPFragNeeded = vp.GetBool(AllowICMPFragNeeded)
 	c.AllowLocalhost = vp.GetString(AllowLocalhost)
 	c.AnnotateK8sNode = vp.GetBool(AnnotateK8sNode)


### PR DESCRIPTION
Writing the DNS rules to the endpoint header/json file as we apply the policy changes, This keeps the ep_config.json and ep_config.h in sync with the current rules being applied the policy.

The PR is based on the comments of the PR: #33412 (Got closed due to inactivity so had to reopen it)

```release-note
Add flag to configure how frequently DNS information is stored to disk, with a default of waiting at least 5s and a maximum of 5m between disk write operations per Endpoint.
```