### PR TITLE
[v1.15] gha: bump ubuntu version in conformance-externalworkloads

### DIFF
--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -263,7 +263,7 @@ jobs:
               --boot-disk-type pd-standard \
               --boot-disk-size 10GB \
               --image-project ubuntu-os-cloud \
-              --image-family ubuntu-2004-lts \
+              --image-family ubuntu-2404-lts-amd64 \
               --metadata hostname=${{ env.vmName }}-${{ matrix.vmIndex }} \
               --metadata-from-file startup-script=${{ env.vmStartupScript}}
 


### PR DESCRIPTION
The conformance external workloads workflow recently started failing consistently on the v1.15 branch with the following error:

> msg="Failed to install iptables rules" error="cannot install static proxy rules: unable to run 'ip6tables -t mangle -A CILIUM_PRE_mangle -m socket --transparent -m mark ! --mark 0x00000e00/0x00000f00 -m mark ! --mark 0x00000800/0x00000f00 -m comment --comment cilium: any->pod redirect proxied traffic to host proxy -j MARK --set-mark 0x00000200' iptables command: exit status 1 stderr=\"Warning: Extension MARK revision 0 not supported, missing kernel module?\\nip6tables: No chain/target/match by that name.\\n\"" subsys=iptables

This seems to be the consequence of a regression backported by Canonical into linux-image-5.15.0-127-generic. Let's circumvent this problem by upgrading the selected image family, which was now largely out of date.

Related: https://bugs.launchpad.net/ubuntu/+source/linux-meta-oracle-5.15/+bug/2091960