### PR TITLE
gha: correctly downgrade to patch release in ipsec workflows

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -350,7 +350,7 @@ jobs:
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
         shell: bash
         run: |
-          cilium upgrade \
+          cilium upgrade --reset-values=true \
             --helm-set=disableEnvoyVersionCheck=true \
             ${{ steps.cilium-newest-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}
@@ -395,7 +395,7 @@ jobs:
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
         shell: bash
         run: |
-          cilium upgrade \
+          cilium upgrade --reset-values=true \
             --helm-set=disableEnvoyVersionCheck=true \
             ${{ steps.cilium-stable-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}


### PR DESCRIPTION
439f5584cbb9 ("CLI: cilium upgrade preserver previous configurations") changed the default behavior of `cilium upgrade` to preserve the previous configuration upon upgrade. While this is the expected behavior in most situations, it turned out being problematic in the ipsec upgrade downgrade tests (specifically in case of patch matrix entries). Indeed, the images are not overwritten for the stable configuration, leading in turn to not actually performing the downgrade. Let's fix this by explicitly resetting the values when performing the upgrade and downgrade operations.

Reported-by: Jarno Rajahalme <jarno@isovalent.com>