### PR TITLE
docs: remove some stale requirements

### DIFF
--- a/Documentation/network/concepts/masquerading.rst
+++ b/Documentation/network/concepts/masquerading.rst
@@ -48,8 +48,7 @@ eBPF-based
    file a GitHub issue if you experience any problems. IPv4 BPF masquerading is
    production-ready.
 
-The eBPF-based implementation is the most efficient
-implementation. It requires Linux kernel 4.19 and can be enabled with
+The eBPF-based implementation is the most efficient implementation. It can be enabled with
 the ``bpf.masquerade=true`` helm option.
 
 The current implementation depends on :ref:`the BPF NodePort feature <kubeproxy-free>`.

--- a/Documentation/network/vtep.rst
+++ b/Documentation/network/vtep.rst
@@ -33,7 +33,7 @@ endpoint IPs, CIDRs, and MAC addresses.
 Enable VXLAN Tunnel Endpoint (VTEP) integration
 ===============================================
 
-This feature requires a Linux 5.2 kernel or later, and is disabled by default. When enabling the
+This feature is disabled by default. When enabling the
 VTEP integration, you must also specify the IPs, CIDR ranges and MACs for each VTEP device
 as part of the configuration.
 

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -119,7 +119,6 @@ routing enabled - the reporting status under "Host Routing" must state "BPF".
 **Requirements:**
 
 * Kernel >= 6.8
-* Direct-routing configuration or tunneling
 * eBPF host-routing
 
 To enable netkit device mode with eBPF host-routing:
@@ -160,7 +159,6 @@ in any of the Cilium pods and look for the line reporting the status for
 **Requirements:**
 
 * Kernel >= 5.10
-* Direct-routing configuration or tunneling
 * eBPF-based kube-proxy replacement
 * eBPF-based masquerading
 
@@ -560,7 +558,6 @@ settings for the networking stack.
 
 **Requirements:**
 
-* Direct-routing configuration or tunneling
 * eBPF-based kube-proxy replacement
 
 To enable the Bandwidth Manager:


### PR DESCRIPTION
Remove a few redundant requirements. Mostly because they are satisfied by the minimum kernel version.