### PR TITLE
gh: e2e-upgrade: don't explicitly enable BPF masquerading with KPR=true

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -315,7 +315,7 @@ jobs:
           - name: '17'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: 'bpf-20250105.013256'
-            misc: 'bpf.datapathMode=netkit,bpf.masquerade=true,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
+            misc: 'bpf.datapathMode=netkit,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
             kube-proxy: 'none'
             kpr: 'true'
             ipv6: 'true'
@@ -327,7 +327,7 @@ jobs:
           - name: '18'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: 'bpf-20250105.013256'
-            misc: 'bpf.datapathMode=netkit-l2,bpf.masquerade=true,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
+            misc: 'bpf.datapathMode=netkit-l2,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
             kube-proxy: 'none'
             kpr: 'true'
             ipv6: 'true'
@@ -339,7 +339,7 @@ jobs:
           - name: '19'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: 'bpf-20250105.013256'
-            misc: 'bpf.datapathMode=netkit,bpf.masquerade=true'
+            misc: 'bpf.datapathMode=netkit'
             kube-proxy: 'none'
             kpr: 'true'
             tunnel: 'vxlan'
@@ -351,7 +351,7 @@ jobs:
           - name: '20'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: 'bpf-20250105.013256'
-            misc: 'bpf.datapathMode=netkit-l2,bpf.masquerade=true'
+            misc: 'bpf.datapathMode=netkit-l2'
             kube-proxy: 'none'
             kpr: 'true'
             tunnel: 'vxlan'
@@ -362,7 +362,7 @@ jobs:
           - name: '21'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: 'bpf-20250105.013256'
-            misc: 'bpf.datapathMode=netkit,bpf.masquerade=true'
+            misc: 'bpf.datapathMode=netkit'
             kube-proxy: 'none'
             kpr: 'true'
             tunnel: 'geneve'
@@ -373,7 +373,7 @@ jobs:
           - name: '22'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: 'bpf-20250105.013256'
-            misc: 'bpf.datapathMode=netkit-l2,bpf.masquerade=true'
+            misc: 'bpf.datapathMode=netkit-l2'
             kube-proxy: 'none'
             kpr: 'true'
             tunnel: 'geneve'
@@ -384,7 +384,7 @@ jobs:
           - name: '23'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: 'bpf-20250105.013256'
-            misc: 'bpf.datapathMode=netkit,bpf.masquerade=true'
+            misc: 'bpf.datapathMode=netkit'
             kube-proxy: 'none'
             kpr: 'true'
             ipv6: 'true'
@@ -397,7 +397,7 @@ jobs:
           - name: '24'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: 'bpf-net-20250105.013256'
-            misc: 'bpf.datapathMode=netkit,bpf.masquerade=true,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
+            misc: 'bpf.datapathMode=netkit,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
             kube-proxy: 'none'
             kpr: 'true'
             ipv6: 'true'
@@ -409,7 +409,7 @@ jobs:
           - name: '25'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: 'bpf-net-20250105.013256'
-            misc: 'bpf.datapathMode=netkit-l2,bpf.masquerade=true,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
+            misc: 'bpf.datapathMode=netkit-l2,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
             kube-proxy: 'none'
             kpr: 'true'
             ipv6: 'true'
@@ -497,7 +497,7 @@ jobs:
           # - name: '23'
           #   # <insert renovate dependency descriptor here>
           #   kernel: 'bpf-20241206.013345'
-          #   misc: 'bpf.datapathMode=netkit-l2,bpf.masquerade=true'
+          #   misc: 'bpf.datapathMode=netkit-l2'
           #   skip-upgrade: 'true'
 
     timeout-minutes: 55


### PR DESCRIPTION
The `cilium-config` action already enables BPF masquerading whenever `kpr` is set to true.