### PR TITLE
bgpv1/manager/reconcilerv2: deflake Test_MergeRoutePolicies

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/policies_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/policies_test.go
@@ -477,13 +477,18 @@ func Test_MergeRoutePolicies(t *testing.T) {
 			req := require.New(t)
 
 			result, err := MergeRoutePolicies(tt.policyA, tt.policyB)
-			if tt.errorExpected == true {
+			if tt.errorExpected {
 				req.Error(err)
 			} else {
 				req.NoError(err)
 			}
 
-			req.Equal(tt.expected, result)
+			if tt.expected != nil {
+				req.Equal(tt.expected.Name, result.Name)
+				req.ElementsMatch(tt.expected.Statements, result.Statements)
+			} else {
+				req.Equal(tt.expected, result)
+			}
 		})
 	}
 


### PR DESCRIPTION
Test_MergeRoutePolicies compares the expected RoutePolicy objects for equality but the order of the elements in the RoutePolicy.Statements field might differ. Use `require.ElementsMatch` to compare those lists, ignoring the order of the elements.

Fixes: f520d9ed7b1b ("bgpv2: Support overlapping selector matches on CiliumBGPAdvertisement")
Fixes: #36867
