### PR TITLE
clustermesh: pass down targetPort to MCS-API derived service

### DIFF
--- a/pkg/clustermesh/endpointslicesync/service_informer.go
+++ b/pkg/clustermesh/endpointslicesync/service_informer.go
@@ -113,8 +113,10 @@ func newMeshServiceInformer(
 }
 
 // toKubeServicePort use the clusterSvc to get a list of ServicePort to build
-// the kubernetes (non slim) Service. Note that we cannot use the slim Service to get this
-// as the slim Service trims the TargetPort which we needs inside the EndpointSliceReconciler
+// the kubernetes (non slim) Service. Note that we intentionally not use the local
+// Service to build the port list so that we don't change the remote Cluster Service port
+// list. Also targetPort might be targeting a named port and we currently don't
+// sync the container ports names.
 func toKubeServicePort(clusterSvc *store.ClusterService) []v1.ServicePort {
 	// Merge all the port config into one to get all the possible ports
 	globalPortConfig := store.PortConfiguration{}
@@ -297,9 +299,11 @@ func (i *meshServiceInformer) Start(ctx context.Context) error {
 func (i *meshServiceInformer) Services(namespace string) listersv1.ServiceNamespaceLister {
 	return &meshServiceLister{informer: i, namespace: namespace}
 }
+
 func (i *meshServiceInformer) Informer() cache.SharedIndexInformer {
 	return i
 }
+
 func (i *meshServiceInformer) Lister() listersv1.ServiceLister {
 	return i
 }


### PR DESCRIPTION
This commit pass down the targetPort in a MCS-API derived Service from the local Service. We only need targetPort for local Endpoints so we do not need to globally sync this as ports are synced from endpoints on remote clusters that already account for targetPort. Thus we just take the ports merged globally from the ServiceImport and add the context of the targetPorts if we need to on the local cluster.

This also clarifies the EndpointSlice sync on target port as the targetPort field  is now available into the slim Service copy done by Cilium be we shouldn't actually use it as targetPort may be a string and we do not have this info from remote clusters.

Fixes: #36735

```release-note
clustermesh: add support for targetPort in MCS-API
```
