### PR TITLE
docs: tuning: add config snippet for BPF Host Routing

### DIFF
--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -162,6 +162,19 @@ in any of the Cilium pods and look for the line reporting the status for
 * eBPF-based kube-proxy replacement
 * eBPF-based masquerading
 
+To enable eBPF Host-Routing:
+
+.. tabs::
+
+    .. group-tab:: Helm
+
+       .. parsed-literal::
+
+           helm install cilium |CHART_RELEASE| \\
+             --namespace kube-system \\
+             --set bpf.masquerade=true \\
+             --set kubeProxyReplacement=true
+
 .. _ipv6_big_tcp:
 
 IPv6 BIG TCP


### PR DESCRIPTION
Be consistent with the other features that are described on this page, and provide a snippet with the needed cilium config.