### PR TITLE
policy: clean up synthesised deny entries

### DIFF
--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -933,12 +933,14 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 					// must be added.
 					denyKeyCpy := k
 					denyKeyCpy.Identity = newKey.Identity
-					l3l4DenyEntry := NewMapStateEntry(k, v.DerivedFromRules, false, true, DefaultAuthType, AuthTypeDisabled)
+					// Note that we let the new key own this copy, since only
+					// the new key can be incrementally deleted.
+					l3l4DenyEntry := NewMapStateEntry(newKey, v.DerivedFromRules, false, true, DefaultAuthType, AuthTypeDisabled)
 					ms.addKeyWithChanges(denyKeyCpy, l3l4DenyEntry, changes)
 					// L3-only entries can be deleted incrementally so we need
 					// to track their effects on other entries so that those
 					// effects can be reverted when the identity is removed.
-					ms.addDependentOnEntry(k, v, denyKeyCpy, changes)
+					newEntry.AddDependent(denyKeyCpy)
 				}
 			}
 

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -825,9 +825,9 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 				// identity of the iterated allow key must be added.
 				denyKeyCpy := newKey
 				denyKeyCpy.Identity = k.Identity
-				l3l4DenyEntry := NewMapStateEntry(newKey, newEntry.DerivedFromRules, false, true, DefaultAuthType, AuthTypeDisabled)
+				l3l4DenyEntry := NewMapStateEntry(k, newEntry.DerivedFromRules, false, true, DefaultAuthType, AuthTypeDisabled)
 				ms.addKeyWithChanges(denyKeyCpy, l3l4DenyEntry, changes)
-				newEntry.AddDependent(denyKeyCpy)
+				ms.addDependentOnEntry(k, v, denyKeyCpy, changes)
 			}
 			return true
 		})

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -2407,9 +2407,9 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithSubnets(c *check.
 		}
 		if tt.outcome&insertBWithAProtoAsDeny > 0 {
 			bKeyWithAProto := Key{tt.bIdentity, tt.aPort, tt.aProto, 0}
-			bEntryAsDeny := bEntry.WithOwners(aKey).asDeny()
-			aEntryWithDep := aEntry.WithDependents(bKeyWithAProto)
-			expectedKeys.denies[aKey] = aEntryWithDep
+			bEntryAsDeny := bEntry.WithOwners(bKey).asDeny()
+			bEntryWithDep := bEntry.WithDependents(bKeyWithAProto)
+			expectedKeys.allows[bKey] = bEntryWithDep
 			expectedKeys.denies[bKeyWithAProto] = bEntryAsDeny
 		}
 		outcomeKeys := newMapState(nil)


### PR DESCRIPTION
When there is an overlap in policies a case can arise where cilium needs to synthesise map state entries for specific identities to avoid punching holes in broad deny policies. One such example is:

egressDeny toPorts TCP 123
toFQDN matchPattern: *

When cilium allocates a new (locally-scoped) identity for an IP learned via DNS interception and inserts it into the policy map of an EP, it avoids punching a hole into the deny by inserting "synthesised", more specific deny entries for the new identity and TCP port 123.

This works, but the implementation neglects to handle the case that, uniquely, FQDN selectors can stop selecting the identity _without policy changing_. The incremental deletion path only removes the newly added allow entry, without cleaning up the synthesised denies. It's possible to write policies which blow up the number of synthesised entries by a significant factor - combined with the identity churn of FQDN identities, policy map space is exhausted quickly. Any policy revision bump or other reasons for policy recalculation fix this, but aren't necessarily common.

The actual change is somewhat subtle: instead of the broad deny entry the new allow owns the more specific deny copy. The key insight is that a wildcarded identity selector can not incrementally deselect an identity like the FQDN selector can.[1] We can thus use the ownership/dependency infrastructure to have the deny copies be cleaned up when the allow is removed.

Since we're in the specific branch where we're inserting an allow which has a more specific identity, but a less specific port/proto, the new entry is always the right choice of owner.

[1] Note that this applies only to 1.15 and older - 1.16 has transformed the FQDN selectors to also not change selections dynamically.

```release-note
Cilium avoids running out of space in policy maps by cleaning up entries in specific cases previously missed.
```
