### PR TITLE
Cilium CLI fix for AWS ENI mode

### DIFF
--- a/cilium-cli/install/helm.go
+++ b/cilium-cli/install/helm.go
@@ -64,9 +64,13 @@ func (k *K8sInstaller) getHelmValues() (map[string]interface{}, error) {
 				// Can be removed once we drop support for <1.14.0
 				helmMapOpts["tunnel"] = tunnelDisabled
 			}
-			// AL2023 uses ens interfaces, but we default to eth interfaces for everything else for backwards compatibility,
-			// since the CLI was assuming eth interfaces before support for AL2023 was introduced
-			helmMapOpts["egressMasqueradeInterfaces"] = "eth+ ens+"
+			if versioncheck.MustCompile(">=1.17.0")(k.chartVersion) {
+				// AL2023 uses ens interfaces, but we default to eth interfaces for everything else for backwards compatibility,
+				// since the CLI was assuming eth interfaces before support for AL2023 was introduced
+				helmMapOpts["egressMasqueradeInterfaces"] = "eth+ ens+"
+			} else {
+				helmMapOpts["egressMasqueradeInterfaces"] = "eth+"
+			}
 
 		case DatapathGKE:
 			helmMapOpts["ipam.mode"] = ipamKubernetes


### PR DESCRIPTION
Use both `eth+` and `ens+` interfaces only with newer CLI versions due to a bug in iptables provisioning for the older Cilium versions.