### PR TITLE
bgpv2: SortRouteStatementsByName to use cmp pkg for sorting

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/policies_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/policies_test.go
@@ -4,6 +4,7 @@
 package reconcilerv2
 
 import (
+	"cmp"
 	"slices"
 	"testing"
 
@@ -497,12 +498,6 @@ func Test_MergeRoutePolicies(t *testing.T) {
 
 func SortRouteStatementsByName(statements []*types.RoutePolicyStatement) {
 	slices.SortFunc(statements, func(i, j *types.RoutePolicyStatement) int {
-		if i.Conditions.String() < j.Conditions.String() {
-			return -1
-		} else if i.Conditions.String() > j.Conditions.String() {
-			return 1
-		} else {
-			return 0
-		}
+		return cmp.Compare(i.Conditions.String(), j.Conditions.String())
 	})
 }


### PR DESCRIPTION
Follow up on https://github.com/cilium/cilium/pull/36846#discussion_r1906647474