### PR TITLE
cilium-cli: do not print checkmarks for non-binary values

### DIFF
--- a/cilium-cli/features/markdown.go
+++ b/cilium-cli/features/markdown.go
@@ -35,10 +35,14 @@ func (mw *markdownWriter) printHeader(nodesSorted []string) error {
 }
 
 func (mw *markdownWriter) printNode(metricName, labels string, isBinary bool, values map[float64]struct{}, key string, nodesSorted []string, metricsPerNode map[string]map[string]float64) {
-	if isBinary && len(values) <= 1 {
-		mw.builder.WriteString("| :heavy_check_mark: ")
+	if isBinary {
+		if len(values) <= 1 {
+			mw.builder.WriteString("| :heavy_check_mark: ")
+		} else {
+			mw.builder.WriteString("| :warning: ")
+		}
 	} else {
-		mw.builder.WriteString("| :warning: ")
+		mw.builder.WriteString("| ")
 	}
 
 	mw.builder.WriteString(fmt.Sprintf("| %s | %s |", metricName, labels))

--- a/cilium-cli/features/tab_writer.go
+++ b/cilium-cli/features/tab_writer.go
@@ -32,10 +32,14 @@ func (t *tabWriter) printNode(metricName, labels string, isBinary bool, values m
 	// Determine if "Yes" should be placed in "Uniform" column
 	// if len(values) <= 1 then it means that all nodes have a value of
 	// either 0 or 1.
-	if isBinary && len(values) <= 1 {
-		fmt.Fprintf(t.tb, "Yes\t")
+	if isBinary {
+		if len(values) <= 1 {
+			fmt.Fprintf(t.tb, "Yes\t")
+		} else {
+			fmt.Fprintf(t.tb, "No\t")
+		}
 	} else {
-		fmt.Fprintf(t.tb, "No\t")
+		fmt.Fprintf(t.tb, " \t")
 	}
 
 	fmt.Fprintf(t.tb, "%s\t%s\t", metricName, labels)


### PR DESCRIPTION
When feature metrics have non-binary values, we don't need to print the uniformity checkmarks for them as having different values across nodes can be expected.