### PR TITLE
clustermesh: fix MCS-API service export cache not properly deleted

### DIFF
--- a/pkg/clustermesh/operator/service_exports.go
+++ b/pkg/clustermesh/operator/service_exports.go
@@ -155,5 +155,6 @@ func (r *remoteServiceExportObserver) OnUpdate(key store.Key) {
 // OnDelete is called when a service export in a remote cluster is deleted
 func (r *remoteServiceExportObserver) OnDelete(key store.NamedKey) {
 	svcExport := &(key.(*mcsapitypes.ValidatingMCSAPIServiceSpec).MCSAPIServiceSpec)
+	r.cache.OnDelete(svcExport)
 	r.onDelete(svcExport)
 }


### PR DESCRIPTION
This fixes a bug  where we where not properly deleting the service export cache on a delete event from remote cluster which for instance prevents ServiceImport to be properly deleted in some/most cases.

```release-note
clustermesh:  fix MCS-API service export cache not properly deleted
```
