### PR TITLE
Helm: Increase Cilium Agent Startup Failure Threshold

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3281,9 +3281,9 @@
      - bool
      - ``false``
    * - :spelling:ignore:`startupProbe.failureThreshold`
-     - failure threshold of startup probe. 105 x 2s translates to the old behaviour of the readiness probe (120s delay + 30 x 3s)
+     - failure threshold of startup probe. Allow Cilium to take up to 600s to start up (300 attempts with 2s between attempts).
      - int
-     - ``105``
+     - ``300``
    * - :spelling:ignore:`startupProbe.periodSeconds`
      - interval between checks of the startup probe
      - int

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -870,7 +870,7 @@ contributors across the globe, there is almost always someone available to help.
 | sleepAfterInit | bool | `false` | Do not run Cilium agent when running with clean mode. Useful to completely uninstall Cilium as it will stop Cilium from starting and create artifacts in the node. |
 | socketLB | object | `{"enabled":false}` | Configure socket LB |
 | socketLB.enabled | bool | `false` | Enable socket LB |
-| startupProbe.failureThreshold | int | `105` | failure threshold of startup probe. 105 x 2s translates to the old behaviour of the readiness probe (120s delay + 30 x 3s) |
+| startupProbe.failureThreshold | int | `300` | failure threshold of startup probe. Allow Cilium to take up to 600s to start up (300 attempts with 2s between attempts). |
 | startupProbe.periodSeconds | int | `2` | interval between checks of the startup probe |
 | svcSourceRangeCheck | bool | `true` | Enable check of service source ranges (currently, only for LoadBalancer). |
 | synchronizeK8sNodes | bool | `true` | Synchronize Kubernetes nodes to kvstore and perform CNP GC. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2016,8 +2016,8 @@ keepDeprecatedLabels: false
 keepDeprecatedProbes: false
 startupProbe:
   # -- failure threshold of startup probe.
-  # 105 x 2s translates to the old behaviour of the readiness probe (120s delay + 30 x 3s)
-  failureThreshold: 105
+  # Allow Cilium to take up to 600s to start up (300 attempts with 2s between attempts).
+  failureThreshold: 300
   # -- interval between checks of the startup probe
   periodSeconds: 2
 livenessProbe:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2029,8 +2029,8 @@ keepDeprecatedLabels: false
 keepDeprecatedProbes: false
 startupProbe:
   # -- failure threshold of startup probe.
-  # 105 x 2s translates to the old behaviour of the readiness probe (120s delay + 30 x 3s)
-  failureThreshold: 105
+  # Allow Cilium to take up to 600s to start up (300 attempts with 2s between attempts).
+  failureThreshold: 300
   # -- interval between checks of the startup probe
   periodSeconds: 2
 livenessProbe:


### PR DESCRIPTION
This commit increases the startup failure threshold from 105 to 300. Given that the Cilium Agent startup behavior now includes waiting for Envoy configs to be properly updated we should increase the failure threshold for the startup probe to allow for more time for Cilium to startup correctly.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Helm: Cilium agent startup probe failure threshold increased to 300
```
