### PR TITLE
clustermesh: update coredns version in mcs-api docs

### DIFF
--- a/Documentation/network/clustermesh/mcsapi.rst
+++ b/Documentation/network/clustermesh/mcsapi.rst
@@ -58,7 +58,7 @@ To rebuild the CoreDNS image you need to first clone the `CoreDNS repo`_:
    .. code-block:: shell-session
 
       git clone https://github.com/coredns/coredns.git
-      git checkout v1.11.3
+      git checkout v1.11.4
 
 
 Then you need add the multicluster plugin to the ``plugins.cfg`` file. The


### PR DESCRIPTION
The new version of the multicluster plugins needs coredns 1.11.4, so this is updating the corresponding MCS-API docs on how to recompile CoreDNS to reflect that.

```release-note
clustermesh: update coredns version in mcs-api docs
```
