### PR TITLE
github: Fix branch name in build-go-caches.yaml

### DIFF
--- a/.github/workflows/build-go-caches.yaml
+++ b/.github/workflows/build-go-caches.yaml
@@ -4,15 +4,15 @@ name: Build Golang caches
 on:
   push:
     branches:
-      - v1.16
+      - v1.17
 
   # If the cache was cleaned we should re-build the cache with the latest commit
   workflow_run:
     workflows:
      - "Image CI Cache Cleaner"
     branches:
-     - v1.16
-     - ft/v1.16/**
+     - v1.17
+     - ft/v1.17/**
     types:
      - completed
 


### PR DESCRIPTION
I'm guessing the branch name is meant to be v1.17 in v1.17 branch.

Fixes: e2f92c4bc271 ("Prepare v1.17 stable branch")