### PR TITLE
Remove always-nil error returns

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -352,9 +352,7 @@ func (ct *ConnectivityTest) SetupAndValidate(ctx context.Context, extra SetupHoo
 		}
 	}
 	if match, _ := ct.Features.MatchRequirements(features.RequireEnabled(features.NodeWithoutCilium)); match {
-		if err := ct.detectPodCIDRs(); err != nil {
-			return fmt.Errorf("unable to detect pod CIDRs: %w", err)
-		}
+		ct.detectPodCIDRs()
 
 		if err := ct.detectNodesWithoutCiliumIPs(); err != nil {
 			return fmt.Errorf("unable to detect nodes w/o Cilium IPs: %w", err)
@@ -606,7 +604,7 @@ func (ct *ConnectivityTest) enableHubbleClient(ctx context.Context) error {
 	return nil
 }
 
-func (ct *ConnectivityTest) detectPodCIDRs() error {
+func (ct *ConnectivityTest) detectPodCIDRs() {
 	for id, n := range ct.CiliumNodes() {
 		if _, ok := ct.nodesWithoutCilium[id.Name]; ok {
 			// Skip the nodes where Cilium is not installed.
@@ -634,8 +632,6 @@ func (ct *ConnectivityTest) detectPodCIDRs() error {
 			}
 		}
 	}
-
-	return nil
 }
 
 // detectNodeCIDRs produces one or more CIDRs that cover all nodes in the cluster.

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -272,10 +272,7 @@ func NewCollector(
 	}
 
 	// Build the list of node names in which the user is interested.
-	c.NodeList, err = buildNodeNameList(c.allNodes, c.Options.NodeList)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build node list: %w", err)
-	}
+	c.NodeList = buildNodeNameList(c.allNodes, c.Options.NodeList)
 	c.logDebug("Restricting bugtool and logs collection to pods in %v", c.NodeList)
 
 	if c.Options.CiliumNamespace != "" {
@@ -3008,7 +3005,7 @@ func podIsRunningAndHasContainer(pod *corev1.Pod, container string) bool {
 	return false
 }
 
-func buildNodeNameList(nodes *corev1.NodeList, filter string) ([]string, error) {
+func buildNodeNameList(nodes *corev1.NodeList, filter string) []string {
 	w := strings.Split(strings.TrimSpace(filter), ",")
 	r := make([]string, 0)
 	for _, node := range nodes.Items {
@@ -3021,7 +3018,7 @@ func buildNodeNameList(nodes *corev1.NodeList, filter string) ([]string, error) 
 			continue
 		}
 	}
-	return r, nil
+	return r
 }
 
 // AllPods converts a PodList into a slice of Pod objects.

--- a/operator/cmd/ccnp_event.go
+++ b/operator/cmd/ccnp_event.go
@@ -32,7 +32,7 @@ func k8sEventMetric(scope, action string) {
 // clusterwide policies. Since, internally Clusterwide policies are implemented
 // using CiliumNetworkPolicy itself, the entire implementation uses the methods
 // associcated with CiliumNetworkPolicy.
-func enableCCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sClient.Clientset) error {
+func enableCCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sClient.Clientset) {
 	log.Info("Starting CCNP derivative handler")
 
 	ccnpStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
@@ -104,6 +104,4 @@ func enableCCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sCli
 			},
 			RunInterval: 5 * time.Minute,
 		})
-
-	return nil
 }

--- a/operator/cmd/cnp_event.go
+++ b/operator/cmd/cnp_event.go
@@ -34,7 +34,7 @@ func init() {
 
 // enableCNPWatcher waits for the CiliumNetworkPolicy CRD availability and then
 // garbage collects stale CiliumNetworkPolicy status field entries.
-func enableCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sClient.Clientset) error {
+func enableCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sClient.Clientset) {
 	log.Info("Starting CNP derivative handler")
 	cnpStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 
@@ -105,6 +105,4 @@ func enableCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sClie
 			},
 			RunInterval: 5 * time.Minute,
 		})
-
-	return nil
 }

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -575,7 +575,6 @@ func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 
 	var (
 		nodeManager allocator.NodeEventHandler
-		err         error
 		withKVStore bool
 	)
 
@@ -737,19 +736,11 @@ func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 	}
 
 	if legacy.clientset.IsEnabled() && option.Config.EnableCiliumNetworkPolicy {
-		err = enableCNPWatcher(legacy.ctx, &legacy.wg, legacy.clientset)
-		if err != nil {
-			log.WithError(err).WithField(logfields.LogSubsys, "CNPWatcher").Fatal(
-				"Cannot connect to Kubernetes apiserver ")
-		}
+		enableCNPWatcher(legacy.ctx, &legacy.wg, legacy.clientset)
 	}
 
 	if legacy.clientset.IsEnabled() && option.Config.EnableCiliumClusterwideNetworkPolicy {
-		err = enableCCNPWatcher(legacy.ctx, &legacy.wg, legacy.clientset)
-		if err != nil {
-			log.WithError(err).WithField(logfields.LogSubsys, "CCNPWatcher").Fatal(
-				"Cannot connect to Kubernetes apiserver ")
-		}
+		enableCCNPWatcher(legacy.ctx, &legacy.wg, legacy.clientset)
 	}
 
 	if legacy.clientset.IsEnabled() {

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -221,11 +221,7 @@ func (i *cecTranslator) filterChains(name string, m *model.Model) []*envoy_confi
 	}
 	filterChains = append(filterChains, httpsFilterChains...)
 
-	tlsPassthroughFilterChains, err := tlsPassthroughFilterChains(tlsPassthroughBackendsToHostnames(m))
-	if err != nil {
-		return nil
-	}
-	filterChains = append(filterChains, tlsPassthroughFilterChains...)
+	filterChains = append(filterChains, tlsPassthroughFilterChains(tlsPassthroughBackendsToHostnames(m))...)
 
 	return filterChains
 }
@@ -391,9 +387,9 @@ func tlsSecretsToHostnames(m *model.Model) map[model.TLSSecret][]string {
 	return res
 }
 
-func tlsPassthroughFilterChains(ptBackendsToHostnames map[string][]string) ([]*envoy_config_listener.FilterChain, error) {
+func tlsPassthroughFilterChains(ptBackendsToHostnames map[string][]string) []*envoy_config_listener.FilterChain {
 	if len(ptBackendsToHostnames) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	var filterChains []*envoy_config_listener.FilterChain
@@ -420,7 +416,7 @@ func tlsPassthroughFilterChains(ptBackendsToHostnames map[string][]string) ([]*e
 		})
 	}
 
-	return filterChains, nil
+	return filterChains
 }
 
 func newTransportSocket(ciliumSecretNamespace string, tls []model.TLSSecret) (*envoy_config_core_v3.TransportSocket, error) {

--- a/operator/pkg/model/translation/envoy_route_configuration.go
+++ b/operator/pkg/model/translation/envoy_route_configuration.go
@@ -75,7 +75,7 @@ func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) []cil
 		if port == insecureHost {
 			for _, h := range slices.Unique(portHostNameRedirect[secureHost]) {
 				if h.redirect {
-					vhs, _ := i.desiredVirtualHost(hostNamePortRoutes[h.hostname][secureHost], VirtualHostParameter{
+					vhs := i.desiredVirtualHost(hostNamePortRoutes[h.hostname][secureHost], VirtualHostParameter{
 						HostNames:     []string{h.hostname},
 						HTTPSRedirect: true,
 						ListenerPort:  m.HTTP[0].Port,
@@ -95,7 +95,7 @@ func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) []cil
 			if !exists {
 				continue
 			}
-			vhs, _ := i.desiredVirtualHost(routes, VirtualHostParameter{
+			vhs := i.desiredVirtualHost(routes, VirtualHostParameter{
 				HostNames:     []string{h.hostname},
 				HTTPSRedirect: false,
 				ListenerPort:  m.HTTP[0].Port,

--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -127,7 +127,7 @@ type VirtualHostParameter struct {
 
 // desiredVirtualHost creates a new VirtualHost with the given HTTP routes, set of pre-defined params as well mutator
 // based on global configuration.
-func (i *cecTranslator) desiredVirtualHost(httpRoutes []model.HTTPRoute, param VirtualHostParameter, mutators ...VirtualHostMutator) (*envoy_config_route_v3.VirtualHost, error) {
+func (i *cecTranslator) desiredVirtualHost(httpRoutes []model.HTTPRoute, param VirtualHostParameter, mutators ...VirtualHostMutator) *envoy_config_route_v3.VirtualHost {
 	var routes SortableRoute
 	if param.HTTPSRedirect {
 		routes = envoyHTTPSRoutes(httpRoutes, param.HostNames, i.Config.RouteConfig.HostNameSuffixMatch)
@@ -164,7 +164,7 @@ func (i *cecTranslator) desiredVirtualHost(httpRoutes []model.HTTPRoute, param V
 		res = fn(res)
 	}
 
-	return res, nil
+	return res
 }
 
 func envoyHTTPSRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameSuffixMatch bool) []*envoy_config_route_v3.Route {

--- a/pkg/alibabacloud/api/api.go
+++ b/pkg/alibabacloud/api/api.go
@@ -83,10 +83,7 @@ func (c *Client) GetInstance(ctx context.Context, vpcs ipamTypes.VirtualNetworkM
 
 	for _, iface := range networkInterfaceSets {
 		ifId := iface.NetworkInterfaceId
-		_, eni, err := parseENI(&iface, vpcs, subnets)
-		if err != nil {
-			return nil, err
-		}
+		_, eni := parseENI(&iface, vpcs, subnets)
 
 		instance.Interfaces[ifId] = ipamTypes.InterfaceRevision{
 			Resource: eni,
@@ -112,10 +109,7 @@ func (c *Client) GetInstances(ctx context.Context, vpcs ipamTypes.VirtualNetwork
 	}
 
 	for _, iface := range networkInterfaceSets {
-		id, eni, err := parseENI(&iface, vpcs, subnets)
-		if err != nil {
-			return nil, err
-		}
+		id, eni := parseENI(&iface, vpcs, subnets)
 
 		instances.Update(id, ipamTypes.InterfaceRevision{
 			Resource: eni,
@@ -631,7 +625,7 @@ func deriveStatus(err error) string {
 
 // parseENI parses a ecs.NetworkInterface as returned by the ecs service API,
 // converts it into a eniTypes.ENI object
-func parseENI(iface *ecs.NetworkInterfaceSet, vpcs ipamTypes.VirtualNetworkMap, subnets ipamTypes.SubnetMap) (instanceID string, eni *eniTypes.ENI, err error) {
+func parseENI(iface *ecs.NetworkInterfaceSet, vpcs ipamTypes.VirtualNetworkMap, subnets ipamTypes.SubnetMap) (instanceID string, eni *eniTypes.ENI) {
 	var privateIPSets []eniTypes.PrivateIPSet
 	for _, p := range iface.PrivateIpSets.PrivateIpSet {
 		privateIPSets = append(privateIPSets, eniTypes.PrivateIPSet{
@@ -667,7 +661,7 @@ func parseENI(iface *ecs.NetworkInterfaceSet, vpcs ipamTypes.VirtualNetworkMap, 
 	if ok && subnet.CIDR != nil {
 		eni.VSwitch.CIDRBlock = subnet.CIDR.String()
 	}
-	return iface.InstanceId, eni, nil
+	return iface.InstanceId, eni
 }
 
 // parseECSTags convert ECS Tags to ipam Tags

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -945,7 +945,7 @@ func (a *Allocator) DeleteAllKeys() {
 // syncLocalKeys checks the kvstore and verifies that a master key exists for
 // all locally used allocations. This will restore master keys if deleted for
 // some reason.
-func (a *Allocator) syncLocalKeys() error {
+func (a *Allocator) syncLocalKeys() {
 	// Create a local copy of all local allocations to not require to hold
 	// any locks while performing kvstore operations. Local use can
 	// disappear while we perform the sync. For master keys this is fine as
@@ -960,8 +960,6 @@ func (a *Allocator) syncLocalKeys() error {
 	for id, key := range ids {
 		a.syncLocalKey(ctx, id, key)
 	}
-
-	return nil
 }
 
 func (a *Allocator) syncLocalKey(ctx context.Context, id idpool.ID, key AllocatorKey) {
@@ -1011,9 +1009,7 @@ func (a *Allocator) syncLocalKey(ctx context.Context, id idpool.ID, key Allocato
 func (a *Allocator) startLocalKeySync() {
 	go func(a *Allocator) {
 		for {
-			if err := a.syncLocalKeys(); err != nil {
-				log.WithError(err).Warning("Unable to run local key sync routine")
-			}
+			a.syncLocalKeys()
 
 			select {
 			case <-a.stopGC:

--- a/pkg/allocator/allocator_test.go
+++ b/pkg/allocator/allocator_test.go
@@ -727,8 +727,7 @@ func TestSyncLocalKeys(t *testing.T) {
 		require.Equal(t, backendID, id)
 	}
 
-	err = allocator.syncLocalKeys()
-	require.NoError(t, err)
+	allocator.syncLocalKeys()
 
 	/// Release the use one id/delete the slave key
 	key, err := backend.GetByID(context.TODO(), ids[0])
@@ -748,8 +747,7 @@ func TestSyncLocalKeys(t *testing.T) {
 	err = backend.DeleteID(context.TODO(), ids[2])
 	require.NoError(t, err)
 
-	err = allocator.syncLocalKeys()
-	require.NoError(t, err)
+	allocator.syncLocalKeys()
 
 	// Ensure all IDs are present
 	for i := idpool.ID(1); i <= numIDs; i++ {
@@ -808,8 +806,7 @@ func TestSyncLocalKeysWithIdentityAllocations(t *testing.T) {
 				wg.Done()
 				return
 			default:
-				err := allocator.syncLocalKeys()
-				require.NoError(t, err)
+				allocator.syncLocalKeys()
 			}
 		}
 	}()

--- a/pkg/bgpv1/manager/manager.go
+++ b/pkg/bgpv1/manager/manager.go
@@ -271,9 +271,7 @@ func (m *BGPRouterManager) ConfigurePeers(ctx context.Context,
 	l.WithField("diff", rd.String()).Debug("Reconciling new CiliumBGPPeeringPolicy")
 
 	if len(rd.register) > 0 {
-		if err := m.register(ctx, rd); err != nil {
-			return fmt.Errorf("encountered error adding new BGP Servers: %w", err)
-		}
+		m.register(ctx, rd)
 	}
 	if len(rd.withdraw) > 0 {
 		if err := m.withdraw(ctx, rd); err != nil {
@@ -281,16 +279,14 @@ func (m *BGPRouterManager) ConfigurePeers(ctx context.Context,
 		}
 	}
 	if len(rd.reconcile) > 0 {
-		if err := m.reconcile(ctx, rd); err != nil {
-			return fmt.Errorf("encountered error reconciling existing BGP Servers: %w", err)
-		}
+		m.reconcile(ctx, rd)
 	}
 	return nil
 }
 
 // register instantiates and configures BgpServer(s) as instructed by the provided
 // work diff.
-func (m *BGPRouterManager) register(ctx context.Context, rd *reconcileDiff) error {
+func (m *BGPRouterManager) register(ctx context.Context, rd *reconcileDiff) {
 	l := log.WithFields(
 		logrus.Fields{
 			"component": "manager.add",
@@ -308,7 +304,6 @@ func (m *BGPRouterManager) register(ctx context.Context, rd *reconcileDiff) erro
 			l.WithError(err).Errorf("Error while registering new BGP server for local ASN %v.", config.LocalASN)
 		}
 	}
-	return nil
 }
 
 // registerBGPServer encapsulates the logic for instantiating a
@@ -433,7 +428,7 @@ func (m *BGPRouterManager) withdrawAll(ctx context.Context, rd *reconcileDiff) e
 
 // reconcile evaluates existing BgpServer(s), making changes if necessary, as
 // instructed by the provided reoncileDiff.
-func (m *BGPRouterManager) reconcile(ctx context.Context, rd *reconcileDiff) error {
+func (m *BGPRouterManager) reconcile(ctx context.Context, rd *reconcileDiff) {
 	l := log.WithFields(
 		logrus.Fields{
 			"component": "manager.reconcile",
@@ -456,7 +451,6 @@ func (m *BGPRouterManager) reconcile(ctx context.Context, rd *reconcileDiff) err
 			l.WithError(err).Errorf("Encountered error reconciling virtual router with local ASN %v", newc.LocalASN)
 		}
 	}
-	return nil
 }
 
 // reconcileBGPConfig will utilize the current set of ConfigReconciler(s)

--- a/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
@@ -120,10 +120,7 @@ func (r *PodCIDRReconciler) reconcilePaths(ctx context.Context, p ReconcileParam
 	metadata := r.getMetadata(p.BGPInstance)
 
 	// get desired paths per address family
-	desiredFamilyAdverts, err := r.getDesiredPathsPerFamily(desiredPeerAdverts, podPrefixes)
-	if err != nil {
-		return err
-	}
+	desiredFamilyAdverts := r.getDesiredPathsPerFamily(desiredPeerAdverts, podPrefixes)
 
 	// reconcile family advertisements
 	updatedAFPaths, err := ReconcileAFPaths(&ReconcileAFPathsParams{
@@ -165,7 +162,7 @@ func (r *PodCIDRReconciler) reconcileRoutePolicies(ctx context.Context, p Reconc
 // getDesiredPathsPerFamily returns a map of desired paths per address family.
 // Note: This returns prefixes per address family. Global routing table will contain prefix per family not per neighbor.
 // Per neighbor advertisement will be controlled by BGP Policy.
-func (r *PodCIDRReconciler) getDesiredPathsPerFamily(desiredPeerAdverts PeerAdvertisements, desiredPrefixes []netip.Prefix) (AFPathsMap, error) {
+func (r *PodCIDRReconciler) getDesiredPathsPerFamily(desiredPeerAdverts PeerAdvertisements, desiredPrefixes []netip.Prefix) AFPathsMap {
 	// Calculate desired paths per address family, collapsing per-peer advertisements into per-family advertisements.
 	desiredFamilyAdverts := make(AFPathsMap)
 	for _, peerFamilyAdverts := range desiredPeerAdverts {
@@ -195,7 +192,7 @@ func (r *PodCIDRReconciler) getDesiredPathsPerFamily(desiredPeerAdverts PeerAdve
 			}
 		}
 	}
-	return desiredFamilyAdverts, nil
+	return desiredFamilyAdverts
 }
 
 func (r *PodCIDRReconciler) getDesiredRoutePolicies(p ReconcileParams, desiredPeerAdverts PeerAdvertisements, desiredPrefixes []netip.Prefix) (RoutePolicyMap, error) {

--- a/pkg/bgpv1/manager/workdiff.go
+++ b/pkg/bgpv1/manager/workdiff.go
@@ -53,9 +53,7 @@ func (wd *reconcileDiff) diff(m LocalASNMap, policy *v2alpha1api.CiliumBGPPeerin
 	if err := wd.registerOrReconcileDiff(m, policy); err != nil {
 		return fmt.Errorf("encountered error creating register or reconcile diff: %w", err)
 	}
-	if err := wd.withdrawDiff(m); err != nil {
-		return fmt.Errorf("encountered error creating withdraw diff: %w", err)
-	}
+	wd.withdrawDiff(m)
 	return nil
 }
 
@@ -105,13 +103,12 @@ func (wd *reconcileDiff) registerOrReconcileDiff(m LocalASNMap, policy *v2alpha1
 
 // withdrawDiff will populate the `withdraw` field of a reconcileDiff, indicating which
 // existing BgpServers must disconnected and removed from the Manager.
-func (wd *reconcileDiff) withdrawDiff(m LocalASNMap) error {
+func (wd *reconcileDiff) withdrawDiff(m LocalASNMap) {
 	for k := range m {
 		if _, ok := wd.seen[k]; !ok {
 			wd.withdraw = append(wd.withdraw, k)
 		}
 	}
-	return nil
 }
 
 type reconcileDiffV2 struct {
@@ -140,9 +137,7 @@ func (wd *reconcileDiffV2) diff(existingInstances map[string]*instance.BGPInstan
 	if err := wd.registerOrReconcileDiff(existingInstances, desiredConfig); err != nil {
 		return fmt.Errorf("encountered error creating register or reconcile diff: %w", err)
 	}
-	if err := wd.withdrawDiff(existingInstances); err != nil {
-		return fmt.Errorf("encountered error creating withdraw diff: %w", err)
-	}
+	wd.withdrawDiff(existingInstances)
 	return nil
 }
 
@@ -223,11 +218,10 @@ func (wd *reconcileDiffV2) requiresRecreate(existing *instance.BGPInstance, desi
 
 // withdrawDiff will populate the `withdraw` field of a reconcileDiff, indicating which
 // existing BgpInstances must be disconnected and removed from the Manager.
-func (wd *reconcileDiffV2) withdrawDiff(existingInstances map[string]*instance.BGPInstance) error {
+func (wd *reconcileDiffV2) withdrawDiff(existingInstances map[string]*instance.BGPInstance) {
 	for k := range existingInstances {
 		if _, ok := wd.seen[k]; !ok {
 			wd.withdraw = append(wd.withdraw, k)
 		}
 	}
-	return nil
 }

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -92,32 +92,26 @@ func TestSetPortRulesForIDFromUnifiedFormat(t *testing.T) {
 	rules[new(MockCachedSelector)] = regexp.MustCompile("^.*[.]cilium[.]io$")
 	rules[new(MockCachedSelector)] = regexp.MustCompile("^.*[.]cilium[.]io$")
 
-	err := pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, rules)
-	require.NoError(t, err)
+	pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, rules)
 	require.Len(t, cache, 1)
 
 	selector2 := new(MockCachedSelector)
 	rules[selector2] = regexp.MustCompile("^sub[.]cilium[.]io")
-	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, rules)
-	require.NoError(t, err)
+	pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, rules)
 	require.Len(t, cache, 2)
 
 	delete(rules, selector2)
-	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, rules)
-	require.NoError(t, err)
+	pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, rules)
 	require.Len(t, cache, 1)
 
-	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, nil)
-	require.NoError(t, err)
+	pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, nil)
 	require.Empty(t, cache)
 
 	delete(rules, selector2)
-	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, rules)
-	require.NoError(t, err)
+	pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, rules)
 	require.Len(t, cache, 1)
 
-	err = pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, nil)
-	require.NoError(t, err)
+	pea.setPortRulesForIDFromUnifiedFormat(cache, epID, udpProtoPort8053, nil)
 	require.Empty(t, cache)
 }
 

--- a/pkg/hubble/filters/http.go
+++ b/pkg/hubble/filters/http.go
@@ -63,7 +63,7 @@ func filterByHTTPStatusCode(statusCodePrefixes []string) (FilterFunc, error) {
 	}, nil
 }
 
-func filterByHTTPMethods(methods []string) (FilterFunc, error) {
+func filterByHTTPMethods(methods []string) FilterFunc {
 	return func(ev *v1.Event) bool {
 		http := ev.GetFlow().GetL7().GetHttp()
 
@@ -75,7 +75,7 @@ func filterByHTTPMethods(methods []string) (FilterFunc, error) {
 		return slices.ContainsFunc(methods, func(method string) bool {
 			return strings.EqualFold(http.Method, method)
 		})
-	}, nil
+	}
 }
 
 func filterByHTTPUrls(urlRegexpStrs []string) (FilterFunc, error) {
@@ -101,7 +101,7 @@ func filterByHTTPUrls(urlRegexpStrs []string) (FilterFunc, error) {
 	}, nil
 }
 
-func filterByHTTPHeaders(headers []*flowpb.HTTPHeader) (FilterFunc, error) {
+func filterByHTTPHeaders(headers []*flowpb.HTTPHeader) FilterFunc {
 	return func(ev *v1.Event) bool {
 		http := ev.GetFlow().GetL7().GetHttp()
 
@@ -119,7 +119,7 @@ func filterByHTTPHeaders(headers []*flowpb.HTTPHeader) (FilterFunc, error) {
 		}
 
 		return false
-	}, nil
+	}
 }
 
 func filterByHTTPPaths(pathRegexpStrs []string) (FilterFunc, error) {
@@ -177,11 +177,7 @@ func (h *HTTPFilter) OnBuildFilter(ctx context.Context, ff *flowpb.FlowFilter) (
 				"the event type filter to only match 'l7' events")
 		}
 
-		methodf, err := filterByHTTPMethods(ff.GetHttpMethod())
-		if err != nil {
-			return nil, fmt.Errorf("invalid http method filter: %w", err)
-		}
-		fs = append(fs, methodf)
+		fs = append(fs, filterByHTTPMethods(ff.GetHttpMethod()))
 	}
 
 	if ff.GetHttpPath() != nil {
@@ -216,11 +212,7 @@ func (h *HTTPFilter) OnBuildFilter(ctx context.Context, ff *flowpb.FlowFilter) (
 				"the event type filter to only match 'l7' events")
 		}
 
-		headerf, err := filterByHTTPHeaders(ff.GetHttpHeader())
-		if err != nil {
-			return nil, fmt.Errorf("invalid http header filter: %w", err)
-		}
-		fs = append(fs, headerf)
+		fs = append(fs, filterByHTTPHeaders(ff.GetHttpHeader()))
 	}
 
 	return fs, nil

--- a/pkg/hubble/filters/tcp.go
+++ b/pkg/hubble/filters/tcp.go
@@ -5,13 +5,12 @@ package filters
 
 import (
 	"context"
-	"fmt"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 )
 
-func filterByTCPFlags(flags []*flowpb.TCPFlags) (FilterFunc, error) {
+func filterByTCPFlags(flags []*flowpb.TCPFlags) FilterFunc {
 	return func(ev *v1.Event) bool {
 		flowFlags := ev.GetFlow().GetL4().GetTCP().GetFlags()
 		if flowFlags == nil {
@@ -36,7 +35,7 @@ func filterByTCPFlags(flags []*flowpb.TCPFlags) (FilterFunc, error) {
 			return true
 		}
 		return false
-	}, nil
+	}
 }
 
 // TCPFilter implements filtering based on TCP protocol header
@@ -47,11 +46,7 @@ func (p *TCPFilter) OnBuildFilter(ctx context.Context, ff *flowpb.FlowFilter) ([
 	var fs []FilterFunc
 
 	if ff.GetTcpFlags() != nil {
-		pf, err := filterByTCPFlags(ff.GetTcpFlags())
-		if err != nil {
-			return nil, fmt.Errorf("invalid tcp flags filter: %w", err)
-		}
-		fs = append(fs, pf)
+		fs = append(fs, filterByTCPFlags(ff.GetTcpFlags()))
 	}
 
 	return fs, nil

--- a/pkg/hubble/server/server.go
+++ b/pkg/hubble/server/server.go
@@ -48,13 +48,11 @@ func NewServer(log logrus.FieldLogger, options ...serveroption.Option) (*Server,
 	}
 
 	s := &Server{log: log, opts: opts}
-	if err := s.initGRPCServer(); err != nil {
-		return nil, err
-	}
+	s.initGRPCServer()
 	return s, nil
 }
 
-func (s *Server) newGRPCServer() (*grpc.Server, error) {
+func (s *Server) newGRPCServer() *grpc.Server {
 	var opts []grpc.ServerOption
 	for _, interceptor := range s.opts.GRPCUnaryInterceptors {
 		opts = append(opts, grpc.UnaryInterceptor(interceptor))
@@ -70,14 +68,11 @@ func (s *Server) newGRPCServer() (*grpc.Server, error) {
 		})
 		opts = append(opts, grpc.Creds(credentials.NewTLS(tlsConfig)))
 	}
-	return grpc.NewServer(opts...), nil
+	return grpc.NewServer(opts...)
 }
 
-func (s *Server) initGRPCServer() error {
-	srv, err := s.newGRPCServer()
-	if err != nil {
-		return err
-	}
+func (s *Server) initGRPCServer() {
+	srv := s.newGRPCServer()
 	if s.opts.HealthService != nil {
 		healthpb.RegisterHealthServer(srv, s.opts.HealthService)
 	}
@@ -95,7 +90,6 @@ func (s *Server) initGRPCServer() error {
 		s.opts.GRPCMetrics.InitializeMetrics(srv)
 	}
 	s.srv = srv
-	return nil
 }
 
 // Serve starts the hubble server and accepts new connections on the configured

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -401,9 +401,7 @@ func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 			return
 		}
 
-		if err := configureENIDevices(n.ownNode, node, n.mtuConfig, n.sysctl); err != nil {
-			log.WithError(err).Errorf("Failed to update routes and rules for ENIs")
-		}
+		configureENIDevices(n.ownNode, node, n.mtuConfig, n.sysctl)
 	}
 
 	n.ownNode = node

--- a/pkg/ipam/crd_eni.go
+++ b/pkg/ipam/crd_eni.go
@@ -33,7 +33,7 @@ type eniDeviceConfig struct {
 type configMap map[string]eniDeviceConfig // by MAC addr
 type linkMap map[string]netlink.Link      // by MAC addr
 
-func configureENIDevices(oldNode, newNode *ciliumv2.CiliumNode, mtuConfig MtuConfiguration, sysctl sysctl.Sysctl) error {
+func configureENIDevices(oldNode, newNode *ciliumv2.CiliumNode, mtuConfig MtuConfiguration, sysctl sysctl.Sysctl) {
 	var (
 		existingENIByName map[string]eniTypes.ENI
 		addedENIByMac     = configMap{}
@@ -66,8 +66,6 @@ func configureENIDevices(oldNode, newNode *ciliumv2.CiliumNode, mtuConfig MtuCon
 	}
 
 	go setupENIDevices(addedENIByMac, sysctl)
-
-	return nil
 }
 
 func setupENIDevices(eniConfigByMac configMap, sysctl sysctl.Sysctl) {

--- a/pkg/maps/l2respondermap/l2_responder_map4.go
+++ b/pkg/maps/l2respondermap/l2_responder_map4.go
@@ -30,7 +30,7 @@ type Map interface {
 	IterateWithCallback(cb IterateCallback) error
 }
 
-func NewMap(lifecycle cell.Lifecycle) (Map, error) {
+func NewMap(lifecycle cell.Lifecycle) Map {
 	return newMap(lifecycle, DefaultMaxEntries)
 }
 
@@ -38,7 +38,7 @@ type l2ResponderMap struct {
 	*ebpf.Map
 }
 
-func newMap(lifecycle cell.Lifecycle, maxEntries int) (*l2ResponderMap, error) {
+func newMap(lifecycle cell.Lifecycle, maxEntries int) *l2ResponderMap {
 	outerMap := &l2ResponderMap{}
 
 	lifecycle.Append(cell.Hook{
@@ -69,7 +69,7 @@ func newMap(lifecycle cell.Lifecycle, maxEntries int) (*l2ResponderMap, error) {
 		},
 	})
 
-	return outerMap, nil
+	return outerMap
 }
 
 // Create creates a new entry for the given IP and IfIndex tuple.


### PR DESCRIPTION
These errors are always nil, so they can be omitted and get rid of the respective error checking code. Found using [`unparam`](https://github.com/mvdan/unparam). Note that we cannot enable the `unparam` linter yet in `golangci-lint` because there are some false positives.
