### PR TITLE
bpf: egressgw: let gateway node identify reply traffic as WORLD_ID

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2188,6 +2188,7 @@ skip_revdnat:
 	 */
 	if (egress_gw_reply_needs_redirect_hook(ip4, &tunnel_endpoint, &dst_sec_identity)) {
 		trace->reason = TRACE_REASON_CT_REPLY;
+		src_sec_identity = WORLD_ID;
 		goto redirect;
 	}
 #endif /* ENABLE_EGRESS_GATEWAY_COMMON */


### PR DESCRIPTION
When a gateway node forwards reply traffic by the external endpoint to a client pod on a different node, it utilizes the overlay network. The redirection path in bpf_host's `from-netdev` program currently selects SECLABEL as the transported source identity (which is HOST_ID for bpf_host, and gets translated to LOCAL_NODE_ID by __encap_with_nodeid()), which is then visible to the network in the VNI field of the VXLAN / GENEVE header.

Use the more appropriate WORLD_ID. This matches what the worker node would resolve as identity for the packet's source IP (unless a CIDR-based identity is associated with the external endpoint). Given that the packet is a reply, we don't expect any network policy decision to be taken. But *if* policy was applied, then it should use WORLD_ID.

Fixes: https://github.com/cilium/cilium/issues/34243