### PR TITLE
bpf: egressgw: skip reply handling for in-cluster traffic

### DIFF
--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -205,9 +205,13 @@ static __always_inline
 bool egress_gw_reply_needs_redirect_hook(struct iphdr *ip4, __u32 *tunnel_endpoint,
 					 __u32 *dst_sec_identity)
 {
-	if (egress_gw_reply_matches_policy(ip4)) {
-		struct remote_endpoint_info *info;
+	struct remote_endpoint_info *info;
 
+	info = lookup_ip4_remote_endpoint(ip4->saddr, 0);
+	if (!info || identity_is_cluster(info->sec_identity))
+		return false;
+
+	if (egress_gw_reply_matches_policy(ip4)) {
 		info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 		if (!info || info->tunnel_endpoint == 0)
 			return false;


### PR DESCRIPTION
On the outbound path, EGW only matches traffic towards cluster-external endpoints. Apply the same check in the reply path.

TODO: this might be needed for in-cluster access to nodeports:

0. EGW policy selects 'clientA -> 0.0.0.0/0' traffic, uses nodeB as potential gateway
1. clientA on nodeA accesses nodeport on nodeB, gets LBed to a backendC on nodeC. Request is DNATed and SNATed.
2. Reply `backendC -> nodeB` reaches nodeB.
3. Reply is RevSNATed (now it's `backendC -> clientA`), and has EGW policy applied. The policy matches the packet. As clientA is remote, the packet gets immediately forwarded to the tunnel, without RevDNAT.