### PR TITLE
renovate: pin renovate image version in config validator workflow

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -801,6 +801,14 @@
     },
     {
       "fileMatch": [
+        "^.github/workflows/enterprise-renovate-config-validator\\.yaml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?)\\s+RENOVATE_IMAGE=\"(?<depName>.*):(?<currentValue>.*)@(?<currentDigest>sha256:[a-f0-9]+)\""
+      ]
+    },
+    {
+      "fileMatch": [
         "^go\\.mod$"
       ],
       "matchStrings": [

--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -15,7 +15,9 @@ jobs:
 
       # this step uses latest renovate slim release
       - name: Validate configuration
-        run: >
-          docker run --rm --entrypoint "renovate-config-validator"
-          -v "${{ github.workspace }}/.github/renovate.json5":"/renovate.json5"
-          ghcr.io/renovatebot/renovate "/renovate.json5"
+        run: |
+          # renovate: datasource=docker
+          export RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:39.98.0@sha256:43e35242449741dab5e60510ba39704a720422f83fdaa495709bc1e0f141625d
+          docker run --rm --entrypoint "renovate-config-validator" \
+            -v "${{ github.workspace }}/.github/renovate.json5":"/renovate.json5" \
+            ${RENOVATE_IMAGE} "/renovate.json5"


### PR DESCRIPTION
Use a fixed tagged image version with digest to avoid upstream image updates silently breaking the workflow.

Also let renovate itselft keep the image version up-to-date.