### PR TITLE
Emit azure API rate limits metrics

### DIFF
--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -14,6 +14,7 @@ cilium-operator-azure [flags]
       --auto-create-cilium-pod-ip-pools map                  Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
       --azure-resource-group string                          Resource group to use for Azure IPAM
       --azure-subscription-id string                         Subscription ID to access Azure API
+      --azure-tenant-id string                               Tenant ID to access Azure API
       --azure-use-primary-address                            Use Azure IP address from interface's primary IPConfigurations
       --azure-user-assigned-identity-id string               ID of the user assigned identity used to auth with the Azure API
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -19,6 +19,7 @@ cilium-operator [flags]
       --aws-use-primary-address                              Allows for using primary address of the ENI for allocations on the node
       --azure-resource-group string                          Resource group to use for Azure IPAM
       --azure-subscription-id string                         Subscription ID to access Azure API
+      --azure-tenant-id string                               Tenant ID to access Azure API
       --azure-use-primary-address                            Use Azure IP address from interface's primary IPConfigurations
       --azure-user-assigned-identity-id string               ID of the user assigned identity used to auth with the Azure API
       --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)

--- a/operator/cmd/provider_azure_flags.go
+++ b/operator/cmd/provider_azure_flags.go
@@ -25,6 +25,9 @@ func (hook *azureFlagsHooks) RegisterProviderFlag(cmd *cobra.Command, vp *viper.
 	flags.String(operatorOption.AzureSubscriptionID, "", "Subscription ID to access Azure API")
 	option.BindEnvWithLegacyEnvFallback(vp, operatorOption.AzureSubscriptionID, "AZURE_SUBSCRIPTION_ID")
 
+	flags.String(operatorOption.AzureTenantID, "", "Tenant ID to access Azure API")
+	option.BindEnvWithLegacyEnvFallback(vp, operatorOption.AzureTenantID, "AZURE_TENANT_ID")
+
 	flags.String(operatorOption.AzureResourceGroup, "", "Resource group to use for Azure IPAM")
 	option.BindEnvWithLegacyEnvFallback(vp, operatorOption.AzureResourceGroup, "AZURE_RESOURCE_GROUP")
 

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -143,6 +143,9 @@ const (
 	// AzureSubscriptionID is the subscription ID to use when accessing the Azure API
 	AzureSubscriptionID = "azure-subscription-id"
 
+	// AzureTenantID is the tenant ID to use when accessing the Azure API
+	AzureTenantID = "azure-tenant-id"
+
 	// AzureResourceGroup is the resource group of the nodes used for the cluster
 	AzureResourceGroup = "azure-resource-group"
 
@@ -337,6 +340,9 @@ type OperatorConfig struct {
 	// AzureSubscriptionID is the subscription ID to use when accessing the Azure API
 	AzureSubscriptionID string
 
+	// AzureTenantID is the tenant ID to use when accessing the Azure API
+	AzureTenantID string
+
 	// AzureResourceGroup is the resource group of the nodes used for the cluster
 	AzureResourceGroup string
 
@@ -447,6 +453,7 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	// Azure options
 
 	c.AzureSubscriptionID = vp.GetString(AzureSubscriptionID)
+	c.AzureTenantID = vp.GetString(AzureTenantID)
 	c.AzureResourceGroup = vp.GetString(AzureResourceGroup)
 	c.AzureUsePrimaryAddress = vp.GetBool(AzureUsePrimaryAddress)
 	c.AzureUserAssignedIdentityID = vp.GetString(AzureUserAssignedIdentityID)

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -15,13 +15,16 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"k8s.io/apimachinery/pkg/util/rand"
 
+	operatorMetrics "github.com/cilium/cilium/operator/metrics"
 	"github.com/cilium/cilium/pkg/api/helpers"
+	azureMetrics "github.com/cilium/cilium/pkg/azure/metrics"
 	"github.com/cilium/cilium/pkg/azure/types"
 	"github.com/cilium/cilium/pkg/cidr"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
@@ -66,7 +69,7 @@ type MetricsAPI interface {
 // net/http Client with a custom cilium user agent
 type httpClient struct{}
 
-func (t *httpClient) Do(req *http.Request) (*http.Response, error) {
+func (_ *httpClient) Do(req *http.Request) (*http.Response, error) {
 	req.Header.Set("User-Agent", fmt.Sprintf("cilium/%s", version.Version))
 	return http.DefaultClient.Do(req)
 }
@@ -83,9 +86,12 @@ func newTokenCredential(clientOptions *azcore.ClientOptions, userAssignedIdentit
 	})
 }
 
-func newClientOptions(cloudName string) (*azcore.ClientOptions, error) {
+func newClientOptions(cloudName, subscriptionID, tenantID string, registry operatorMetrics.RegisterGatherer) (*azcore.ClientOptions, error) {
+	metricsExtractor := azureMetrics.NewMetricsExtractor(log, subscriptionID, tenantID, "Microsoft.Compute", registry)
+
 	clientOptions := &azcore.ClientOptions{
-		Transport: &httpClient{},
+		Transport:        &httpClient{},
+		PerRetryPolicies: []policy.Policy{metricsExtractor},
 	}
 
 	// See possible values here:
@@ -107,8 +113,8 @@ func newClientOptions(cloudName string) (*azcore.ClientOptions, error) {
 }
 
 // NewClient returns a new Azure client
-func NewClient(cloudName, subscriptionID, resourceGroup, userAssignedIdentityID string, metrics MetricsAPI, rateLimit float64, burst int, usePrimary bool) (*Client, error) {
-	clientOptions, err := newClientOptions(cloudName)
+func NewClient(cloudName, subscriptionID, tenantID, resourceGroup, userAssignedIdentityID string, metrics MetricsAPI, registry operatorMetrics.RegisterGatherer, rateLimit float64, burst int, usePrimary bool) (*Client, error) {
+	clientOptions, err := newClientOptions(cloudName, subscriptionID, tenantID, registry)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/azure/metrics/metrics.go
+++ b/pkg/azure/metrics/metrics.go
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	operatorMetrics "github.com/cilium/cilium/operator/metrics"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	// See https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/request-limits-and-throttling#remaining-requests
+	// tags are conditionally set based on description
+	metricAzureRateLimitRemaining = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "azure_ratelimit_remaining",
+		Help: "Rate limit metrics grouped by description, see https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/request-limits-and-throttling#remaining-requests for more information. Example description: Subscription-Reads",
+	}, []string{
+		rateLimitRemainingDescriptionTag,
+		rateLimitRemainingTenantIDTag,
+		rateLimitRemainingSubscriptionIDTag,
+		rateLimitRemainingResourceTypeTag,
+	})
+	rateLimitMetricHeaderPrefix         = "X-Ms-Ratelimit-Remaining-"
+	rateLimitRemainingDescriptionTag    = "description"
+	rateLimitRemainingTenantIDTag       = "tenant_id"
+	rateLimitRemainingSubscriptionIDTag = "subscription_id"
+	rateLimitRemainingResourceTypeTag   = "resource_type"
+
+	// See https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/request-limits-and-throttling#remaining-requests
+	metricAzureRateLimitRemainingResource = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "azure_ratelimit_remaining_resource",
+		Help: "Rate limit resource metrics grouped by policy, see https://docs.microsoft.com/en-us/azure/virtual-machines/troubleshooting/troubleshooting-throttling-errors#call-rate-informational-response-headers for more information. Example description: Microsoft.Compute/HighCostGet3Min",
+	}, []string{
+		rateLimitRemainingPolicyTag,
+		rateLimitRemainingTenantIDTag,
+		rateLimitRemainingSubscriptionIDTag,
+		rateLimitRemainingResourceTypeTag,
+	})
+	rateLimitRemainingResourceHeader = "X-Ms-Ratelimit-Remaining-Resource"
+	rateLimitRemainingPolicyTag      = "policy"
+
+	// See docs https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/request-limits-and-throttling#remaining-requests
+	rateLimitDescriptionToRequiredTags = map[string]map[string]struct{}{
+		// Subscription scoped reads remaining. This value is returned on read operations.
+		"subscription-reads": {
+			rateLimitRemainingDescriptionTag:    {},
+			rateLimitRemainingTenantIDTag:       {},
+			rateLimitRemainingSubscriptionIDTag: {},
+		},
+		// Subscription scoped writes remaining. This value is returned on write operations.
+		"subscription-writes": {
+			rateLimitRemainingDescriptionTag:    {},
+			rateLimitRemainingTenantIDTag:       {},
+			rateLimitRemainingSubscriptionIDTag: {},
+		},
+		// Subscription scoped writes remaining. This value is returned on delete operations.
+		"subscription-deletes": {
+			rateLimitRemainingDescriptionTag:    {},
+			rateLimitRemainingTenantIDTag:       {},
+			rateLimitRemainingSubscriptionIDTag: {},
+		},
+		// global limits should be 15x the individual limits
+		// Subscription scoped reads remaining. This value is returned on read operations.
+		"subscription-global-reads": {
+			rateLimitRemainingDescriptionTag:    {},
+			rateLimitRemainingTenantIDTag:       {},
+			rateLimitRemainingSubscriptionIDTag: {},
+		},
+		// Subscription scoped writes remaining. This value is returned on write operations.
+		"subscription-global-writes": {
+			rateLimitRemainingDescriptionTag:    {},
+			rateLimitRemainingTenantIDTag:       {},
+			rateLimitRemainingSubscriptionIDTag: {},
+		},
+		// Subscription scoped writes remaining. This value is returned on delete operations.
+		"subscription-global-deletes": {
+			rateLimitRemainingDescriptionTag:    {},
+			rateLimitRemainingTenantIDTag:       {},
+			rateLimitRemainingSubscriptionIDTag: {},
+		},
+
+		// Tenant scoped reads remaining
+		"tenant-reads": {
+			rateLimitRemainingDescriptionTag: {},
+			rateLimitRemainingTenantIDTag:    {},
+		},
+		// Tenant scoped writes remaining
+		"tenant-writes": {
+			rateLimitRemainingDescriptionTag: {},
+			rateLimitRemainingTenantIDTag:    {},
+		},
+		// Subscription scoped resource type requests remaining.
+		//
+		// This header value is only returned if a service has overridden the default limit. Resource Manager adds this value instead of the subscription reads or writes.
+		"subscription-resource-requests": {
+			rateLimitRemainingDescriptionTag:    {},
+			rateLimitRemainingTenantIDTag:       {},
+			rateLimitRemainingSubscriptionIDTag: {},
+			rateLimitRemainingResourceTypeTag:   {},
+		},
+		// Subscription scoped resource type collection requests remaining.
+		//
+		// This header value is only returned if a service has overridden the default limit. This value provides the number of remaining collection requests (list resources).
+		"subscription-resource-entities-read": {
+			rateLimitRemainingDescriptionTag:    {},
+			rateLimitRemainingTenantIDTag:       {},
+			rateLimitRemainingSubscriptionIDTag: {},
+			rateLimitRemainingResourceTypeTag:   {},
+		},
+		// Tenant scoped resource type requests remaining.
+		//
+		// This header is only added for requests at tenant level, and only if a service has overridden the default limit. Resource Manager adds this value instead of the tenant reads or writes.
+		"tenant-resource-requests": {
+			rateLimitRemainingDescriptionTag:  {},
+			rateLimitRemainingTenantIDTag:     {},
+			rateLimitRemainingResourceTypeTag: {},
+		},
+		// Tenant scoped resource type collection requests remaining.
+		//
+		// This header is only added for requests at tenant level, and only if a service has overridden the default limit.
+		"tenant-resource-entities-read": {
+			rateLimitRemainingDescriptionTag:  {},
+			rateLimitRemainingTenantIDTag:     {},
+			rateLimitRemainingResourceTypeTag: {},
+		},
+	}
+
+	metricAzureRateLimitHeaderParseError = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "azure_rate_limit_header_parse_error_count",
+		Help: "Count of the number of errors encountered while to parse rate limit headers.",
+	})
+)
+
+type MetricsExtractor struct {
+	logger         *logrus.Entry
+	tenantID       string
+	subscriptionID string
+	resourceType   string
+}
+
+// Ensure that MetricsExtractor implements the policy.Policy interface
+var _ policy.Policy = &MetricsExtractor{}
+
+func NewMetricsExtractor(logger *logrus.Entry, subscriptionID string, tenantID string, resourceType string, registry operatorMetrics.RegisterGatherer) *MetricsExtractor {
+	registry.MustRegister(
+		metricAzureRateLimitRemaining,
+		metricAzureRateLimitRemainingResource,
+		metricAzureRateLimitHeaderParseError,
+	)
+	return &MetricsExtractor{
+		logger:         logger,
+		tenantID:       tenantID,
+		subscriptionID: subscriptionID,
+		resourceType:   resourceType,
+	}
+}
+
+func (m *MetricsExtractor) extractMetrics(response *http.Response) error {
+	if response == nil || response.Request == nil || response.Request.URL == nil {
+		return nil
+	}
+	logger := m.logger.WithFields(logrus.Fields{"url": response.Request.URL.String(), "status": response.Status, "method": response.Request.Method})
+	metricResults, err := m.getRequestLimitMetrics(response)
+	if err != nil {
+		metricAzureRateLimitHeaderParseError.Inc()
+		logger.Error(err, "Failed to get metrics from response")
+	}
+	for _, metricResult := range metricResults {
+		gauge, err := metricAzureRateLimitRemaining.GetMetricWithLabelValues(metricResult.TagValues...)
+		if err != nil {
+			logger.Error(err, "Failed to get metric with tag values")
+		} else {
+			gauge.Set(metricResult.Value)
+		}
+	}
+	metricResults, err = m.getRequestLimitResourceMetrics(response)
+	if err != nil {
+		metricAzureRateLimitHeaderParseError.Inc()
+		logger.Error(err, "Failed to get resource metrics from response")
+	}
+	for _, metricResult := range metricResults {
+		gauge, err := metricAzureRateLimitRemainingResource.GetMetricWithLabelValues(metricResult.TagValues...)
+		if err != nil {
+			logger.Error(err, "Failed to get metric with tag values")
+		} else {
+			gauge.Set(metricResult.Value)
+		}
+	}
+	return nil
+}
+
+type metricResult struct {
+	TagValues []string
+	Value     float64
+}
+
+func (m *MetricsExtractor) getRequestLimitMetrics(response *http.Response) ([]metricResult, error) {
+	var ret []metricResult
+	var headerKeys []string
+	for headerKey := range response.Header {
+		headerKeys = append(headerKeys, headerKey)
+	}
+	sort.Strings(headerKeys)
+	for _, headerKey := range headerKeys {
+		headerValue := response.Header.Get(headerKey)
+		if strings.HasPrefix(headerKey, rateLimitMetricHeaderPrefix) && !strings.HasPrefix(headerKey, rateLimitRemainingResourceHeader) {
+			description := strings.ToLower(strings.TrimPrefix(headerKey, rateLimitMetricHeaderPrefix))
+			value, err := strconv.ParseInt(headerValue, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse int from header, header value:%s", headerValue)
+			}
+			var descriptionTagValue string
+			var tenantIDTagValue string
+			var subscriptionIDTagValue string
+			var resourceTypeTagValue string
+			requiredTags, ok := rateLimitDescriptionToRequiredTags[description]
+			if !ok {
+				return nil, fmt.Errorf("description not found in description to required tags map, description: %s, tags map: %v", description, rateLimitDescriptionToRequiredTags)
+
+			}
+			if _, ok := requiredTags[rateLimitRemainingDescriptionTag]; ok {
+				descriptionTagValue = description
+			}
+			if _, ok := requiredTags[rateLimitRemainingTenantIDTag]; ok {
+				tenantIDTagValue = m.tenantID
+			}
+			if _, ok := requiredTags[rateLimitRemainingSubscriptionIDTag]; ok {
+				subscriptionIDTagValue = m.subscriptionID
+			}
+			if _, ok := requiredTags[rateLimitRemainingResourceTypeTag]; ok {
+				resourceTypeTagValue = m.resourceType
+			}
+			ret = append(ret, metricResult{
+				TagValues: []string{
+					descriptionTagValue,
+					tenantIDTagValue,
+					subscriptionIDTagValue,
+					resourceTypeTagValue,
+				},
+				Value: float64(value),
+			})
+		}
+	}
+	return ret, nil
+}
+
+func (m *MetricsExtractor) getRequestLimitResourceMetrics(response *http.Response) ([]metricResult, error) {
+	var ret []metricResult
+	headerValue := response.Header.Get(rateLimitRemainingResourceHeader)
+	if headerValue == "" {
+		return nil, nil
+	}
+	headerValues := strings.Split(headerValue, ",")
+	for _, splitHeaderValue := range headerValues {
+		split := strings.Split(splitHeaderValue, ";")
+		if len(split) != 2 {
+			return nil, fmt.Errorf("header value split had unexpected length, expected 2, actual: %d, headerValue: %s", len(split), splitHeaderValue)
+		}
+		policy := split[0]
+		valueString := split[1]
+		value, err := strconv.ParseInt(valueString, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse int from header value, headerValue: %s: %w", splitHeaderValue, err)
+		}
+		ret = append(ret, metricResult{
+			TagValues: []string{policy, m.tenantID, m.subscriptionID, m.resourceType},
+			Value:     float64(value),
+		})
+	}
+	return ret, nil
+}
+
+// Do applies the policy to the specified Request.  When implementing a Policy, mutate the
+// request before calling req.Next() to move on to the next policy, and respond to the result
+// before returning to the caller.
+func (m *MetricsExtractor) Do(req *policy.Request) (*http.Response, error) {
+	resp, err := req.Next()
+	if extractErr := m.extractMetrics(resp); extractErr != nil {
+		m.logger.WithError(extractErr).Info("Failed to extract metric")
+	}
+	return resp, err
+}

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -55,6 +55,11 @@ func (*AllocatorAzure) Start(ctx context.Context, getterUpdater ipam.CiliumNodeG
 		log.WithField("subscriptionID", subscriptionID).Debug("Detected subscriptionID via Azure IMS")
 	}
 
+	tenantID := operatorOption.Config.AzureTenantID
+	if tenantID == "" {
+		log.Debug("TenantID was not specified via CLI, tenant scoped azure rate limit metrics will be unavailable")
+	}
+
 	resourceGroupName := operatorOption.Config.AzureResourceGroup
 	if resourceGroupName == "" {
 		log.Debug("ResourceGroupName was not specified via CLI, retrieving it via Azure IMS")
@@ -74,7 +79,7 @@ func (*AllocatorAzure) Start(ctx context.Context, getterUpdater ipam.CiliumNodeG
 		iMetrics = &ipamMetrics.NoOpMetrics{}
 	}
 
-	azureClient, err := azureAPI.NewClient(azureCloudName, subscriptionID, resourceGroupName, operatorOption.Config.AzureUserAssignedIdentityID, azMetrics, operatorOption.Config.IPAMAPIQPSLimit, operatorOption.Config.IPAMAPIBurst, operatorOption.Config.AzureUsePrimaryAddress)
+	azureClient, err := azureAPI.NewClient(azureCloudName, subscriptionID, tenantID, resourceGroupName, operatorOption.Config.AzureUserAssignedIdentityID, azMetrics, operatorMetrics.Registry, operatorOption.Config.IPAMAPIQPSLimit, operatorOption.Config.IPAMAPIBurst, operatorOption.Config.AzureUsePrimaryAddress)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Azure client: %w", err)
 	}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
Emit azure API rate limits metrics
```

---

Azure API responses include headers containing information on remaining rate limits budget. This PR updates the azure IPAM allocator to read those response headers and emit metrics based on those to gain visibility on the status of azure API rate limits budget.

See [azure documentation](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/request-limits-and-throttling#remaining-requests).

The new metrics are:
* `cilium.azure_ratelimit_remaining_resource` which is by `policy` (example policy: `microsoft.compute/vmscalesetvmviewssubscriptionmaximum`)
* `cilium.azure_ratelimit_remaining` which is by `description` (example description: `subscription-global-reads`)
* `cilium.azure_rate_limit_header_parse_error_count` which is emmitted when there is an error parsing the rate limits headers.

Example graph for the `cilium.azure_ratelimit_remaining_resource` metric scoped to the "Get scale set VMs" policy which has a subscription level limit of 6000 ([ref](https://learn.microsoft.com/en-us/azure/virtual-machines/compute-throttling-limits#throttling-limits-for-virtual-machine-scale-set-virtual-machines)):
<img width="2457" alt="image" src="https://github.com/user-attachments/assets/7fa91941-9102-413a-b544-cce2763d69ef" />

