### PR TITLE
[1.16] Do not leak ipcache entries when apiserver entities are cluster external

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2088,7 +2088,7 @@ func (e *Endpoint) UpdateLabels(ctx context.Context, sourceFilter string, identi
 	// - the endpoint is in this init state.
 	if len(identityLabels) != 0 &&
 		sourceFilter != labels.LabelSourceAny &&
-		!identityLabels.Has(labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved)) &&
+		!identityLabels.HasInitLabel() &&
 		e.IsInit() {
 
 		idLabls := e.OpLabels.IdentityLabels()

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -203,7 +203,7 @@ func ScopeForLabels(lbls labels.Labels) NumericIdentity {
 	// Note that this is not reachable when policy-cidr-selects-nodes is false or
 	// when enable-node-selector-labels is false, since
 	// callers will already have gotten a value from LookupReservedIdentityByLabels.
-	if lbls.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode]) {
+	if lbls.HasRemoteNodeLabel() {
 		return IdentityScopeRemoteNode
 	}
 
@@ -268,9 +268,9 @@ func LookupReservedIdentityByLabels(lbls labels.Labels) *Identity {
 	}
 
 	var nid NumericIdentity
-	if lbls.Has(labels.LabelHost[labels.IDNameHost]) {
+	if lbls.HasHostLabel() {
 		nid = ReservedIdentityHost
-	} else if lbls.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode]) {
+	} else if lbls.HasRemoteNodeLabel() {
 		// If selecting remote-nodes via CIDR policies is allowed, then
 		// they no longer have a reserved identity.
 		if option.Config.PolicyCIDRMatchesNodes() {
@@ -283,7 +283,7 @@ func LookupReservedIdentityByLabels(lbls labels.Labels) *Identity {
 			return nil
 		}
 		nid = ReservedIdentityRemoteNode
-		if lbls.Has(labels.LabelKubeAPIServer[labels.IDNameKubeAPIServer]) {
+		if lbls.HasKubeAPIServerLabel() {
 			// If there's a kube-apiserver label, then we know this is
 			// kube-apiserver reserved ID, so change it as such.
 			// Only traffic from non-kube-apiserver nodes should be

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -663,13 +663,12 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 
 	// Ensure any prefix with a FQDN label also has the world label set
 	if lbls.HasSource(labels.LabelSourceFQDN) {
-		labels.AddWorldLabel(prefix.Addr(), lbls)
+		lbls.AddWorldLabel(prefix.Addr())
 	}
 
 	// If the prefix is associated with the host or remote-node, then
 	// force-remove the world label.
-	if lbls.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode]) ||
-		lbls.Has(labels.LabelHost[labels.IDNameHost]) {
+	if lbls.HasRemoteNodeLabel() || lbls.HasHostLabel() {
 		n := lbls.Remove(labels.LabelWorld)
 		n = n.Remove(labels.LabelWorldIPv4)
 		n = n.Remove(labels.LabelWorldIPv6)
@@ -686,7 +685,7 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 		lbls = n
 	}
 
-	if lbls.Has(labels.LabelHost[labels.IDNameHost]) {
+	if lbls.HasHostLabel() {
 		// Associate any new labels with the host identity.
 		//
 		// This case is a bit special, because other parts of Cilium
@@ -720,9 +719,7 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 	// other labels with such IPs, but this assumption will break if/when
 	// we allow more arbitrary labels to be associated with these IPs that
 	// correspond to remote nodes.
-	if !lbls.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode]) &&
-		!lbls.Has(labels.LabelHealth[labels.IDNameHealth]) &&
-		!lbls.Has(labels.LabelIngress[labels.IDNameIngress]) &&
+	if !lbls.HasRemoteNodeLabel() && !lbls.HasHealthLabel() && !lbls.HasIngressLabel() &&
 		!lbls.HasSource(labels.LabelSourceFQDN) &&
 		!lbls.HasSource(labels.LabelSourceCIDR) {
 		cidrLabels := labels.GetCIDRLabels(prefix)
@@ -740,9 +737,7 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 		}).Warning("Failed to allocate new identity for prefix's Labels.")
 		return nil, false, err
 	}
-	if lbls.Has(labels.LabelWorld[labels.IDNameWorld]) ||
-		lbls.Has(labels.LabelWorldIPv4[labels.IDNameWorldIPv4]) ||
-		lbls.Has(labels.LabelWorldIPv6[labels.IDNameWorldIPv6]) {
+	if lbls.HasWorldLabel() {
 		id.CIDRLabel = labels.NewLabelsFromModel([]string{labels.LabelSourceCIDR + ":" + prefix.String()})
 	}
 	return id, isNew, err

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -117,15 +117,15 @@ func TestInjectLabels(t *testing.T) {
 	// -- prefix2 should have remote-node and cidr
 	id1 := IPIdentityCache.IdentityAllocator.LookupIdentityByID(ctx, nid1)
 	assert.NotNil(t, id1)
-	assert.True(t, id1.Labels.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode]))
-	assert.True(t, id1.Labels.Has(labels.LabelKubeAPIServer[labels.IDNameKubeAPIServer]))
+	assert.True(t, id1.Labels.HasRemoteNodeLabel())
+	assert.True(t, id1.Labels.HasKubeAPIServerLabel())
 	assert.True(t, id1.Labels.Has(labels.ParseLabel("cidr:10.0.0.4/32")))
 	assert.False(t, id1.Labels.Has(labels.ParseLabel("cidr:10.0.0.5/32")))
 
 	id2 := IPIdentityCache.IdentityAllocator.LookupIdentityByID(ctx, nid2)
 	assert.NotNil(t, id2)
-	assert.True(t, id2.Labels.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode]))
-	assert.False(t, id2.Labels.Has(labels.LabelKubeAPIServer[labels.IDNameKubeAPIServer]))
+	assert.True(t, id2.Labels.HasRemoteNodeLabel())
+	assert.False(t, id2.Labels.HasKubeAPIServerLabel())
 	assert.False(t, id2.Labels.Has(labels.ParseLabel("cidr:10.0.0.4/32")))
 	assert.True(t, id2.Labels.Has(labels.ParseLabel("cidr:10.0.0.5/32")))
 
@@ -143,15 +143,15 @@ func TestInjectLabels(t *testing.T) {
 
 	id1 = IPIdentityCache.IdentityAllocator.LookupIdentityByID(ctx, nid1)
 	assert.NotNil(t, id1)
-	assert.False(t, id1.Labels.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode]))
-	assert.True(t, id1.Labels.Has(labels.LabelKubeAPIServer[labels.IDNameKubeAPIServer]))
+	assert.False(t, id1.Labels.HasRemoteNodeLabel())
+	assert.True(t, id1.Labels.HasKubeAPIServerLabel())
 	assert.True(t, id1.Labels.Has(labels.ParseLabel("cidr:10.0.0.4/32")))
 	assert.False(t, id1.Labels.Has(labels.ParseLabel("cidr:10.0.0.5/32")))
 
 	id2 = IPIdentityCache.IdentityAllocator.LookupIdentityByID(ctx, nid2)
 	assert.NotNil(t, id2)
-	assert.False(t, id2.Labels.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode]))
-	assert.False(t, id2.Labels.Has(labels.LabelKubeAPIServer[labels.IDNameKubeAPIServer]))
+	assert.False(t, id2.Labels.HasRemoteNodeLabel())
+	assert.False(t, id2.Labels.HasKubeAPIServerLabel())
 	assert.False(t, id2.Labels.Has(labels.ParseLabel("cidr:10.0.0.4/32")))
 	assert.True(t, id2.Labels.Has(labels.ParseLabel("cidr:10.0.0.5/32")))
 

--- a/pkg/labels/cidr.go
+++ b/pkg/labels/cidr.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	worldLabelNonDualStack = Label{Key: IDNameWorld, Source: LabelSourceReserved}
+	worldLabelNonDualStack = Label{Source: LabelSourceReserved, Key: IDNameWorld}
 	worldLabelV4           = Label{Source: LabelSourceReserved, Key: IDNameWorldIPv4}
 	worldLabelV6           = Label{Source: LabelSourceReserved, Key: IDNameWorldIPv6}
 )
@@ -93,12 +93,12 @@ func GetCIDRLabels(prefix netip.Prefix) Labels {
 		l.cidr = &prefix
 		lbls[l.Key] = l
 	}
-	AddWorldLabel(prefix.Addr(), lbls)
+	lbls.AddWorldLabel(prefix.Addr())
 
 	return lbls
 }
 
-func AddWorldLabel(addr netip.Addr, lbls Labels) {
+func (lbls Labels) AddWorldLabel(addr netip.Addr) {
 	switch {
 	case !option.Config.IsDualStack():
 		lbls[worldLabelNonDualStack.Key] = worldLabelNonDualStack

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -108,6 +108,10 @@ var (
 	// LabelIngress is the label used for Ingress proxies. See comment
 	// on IDNameIngress.
 	LabelIngress = Labels{IDNameIngress: NewLabel(IDNameIngress, "", LabelSourceReserved)}
+
+	// LabelKeyFixedIdentity is the label that can be used to define a fixed
+	// identity.
+	LabelKeyFixedIdentity = "io.cilium.fixed-identity"
 )
 
 const (
@@ -149,10 +153,6 @@ const (
 
 	// LabelSourceDirectory is the label source for policies read from files
 	LabelSourceDirectory = "directory"
-
-	// LabelKeyFixedIdentity is the label that can be used to define a fixed
-	// identity.
-	LabelKeyFixedIdentity = "io.cilium.fixed-identity"
 )
 
 // Label is the Cilium's representation of a container label.
@@ -171,6 +171,60 @@ type Label struct {
 
 // Labels is a map of labels where the map's key is the same as the label's key.
 type Labels map[string]Label
+
+//
+// Convenience functions to use instead of Has(), which iterates through the labels
+//
+
+// HasLabelWithKey returns true if lbls has a label with 'key'
+func (l Labels) HasLabelWithKey(key string) bool {
+	_, ok := l[key]
+	return ok
+}
+
+func (l Labels) HasFixedIdentityLabel() bool {
+	return l.HasLabelWithKey(LabelKeyFixedIdentity)
+}
+
+func (l Labels) HasInitLabel() bool {
+	return l.HasLabelWithKey(IDNameInit)
+}
+
+func (l Labels) HasHealthLabel() bool {
+	return l.HasLabelWithKey(IDNameHealth)
+}
+
+func (l Labels) HasIngressLabel() bool {
+	return l.HasLabelWithKey(IDNameIngress)
+}
+
+func (l Labels) HasHostLabel() bool {
+	return l.HasLabelWithKey(IDNameHost)
+}
+
+func (l Labels) HasKubeAPIServerLabel() bool {
+	return l.HasLabelWithKey(IDNameKubeAPIServer)
+}
+
+func (l Labels) HasRemoteNodeLabel() bool {
+	return l.HasLabelWithKey(IDNameRemoteNode)
+}
+
+func (l Labels) HasWorldIPv6Label() bool {
+	return l.HasLabelWithKey(IDNameWorldIPv6)
+}
+
+func (l Labels) HasWorldIPv4Label() bool {
+	return l.HasLabelWithKey(IDNameWorldIPv4)
+}
+
+func (l Labels) HasNonDualstackWorldLabel() bool {
+	return l.HasLabelWithKey(IDNameWorld)
+}
+
+func (l Labels) HasWorldLabel() bool {
+	return l.HasNonDualstackWorldLabel() || l.HasWorldIPv4Label() || l.HasWorldIPv6Label()
+}
 
 // GetPrintableModel turns the Labels into a sorted list of strings
 // representing the labels.

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -105,6 +105,11 @@ var (
 	// on IDNameKubeAPIServer.
 	LabelKubeAPIServer = Labels{IDNameKubeAPIServer: NewLabel(IDNameKubeAPIServer, "", LabelSourceReserved)}
 
+	LabelKubeAPIServerExt = Labels{
+		IDNameKubeAPIServer: NewLabel(IDNameKubeAPIServer, "", LabelSourceReserved),
+		IDNameWorld:         NewLabel(IDNameWorld, "", LabelSourceReserved),
+	}
+
 	// LabelIngress is the label used for Ingress proxies. See comment
 	// on IDNameIngress.
 	LabelIngress = Labels{IDNameIngress: NewLabel(IDNameIngress, "", LabelSourceReserved)}


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/35868 to 1.16.

There was a small issue with the regular backport in https://github.com/cilium/cilium/pull/36462 because the PR depended on functions introduced in https://github.com/cilium/cilium/pull/34347. I simply added https://github.com/cilium/cilium/pull/34347 to the backport because it seems low-risk.

There were no conflicts.

Fixes: #33772 

```release-note
Do not leak ipcache entries when apiserver entities are cluster external
```
