### PR TITLE
bpf: egw: fix over-eager matching of EGW policy against reply traffic

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2115,7 +2115,6 @@ nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	__u32 dst_sec_identity __maybe_unused = 0;
 	__u32 src_sec_identity __maybe_unused = SECLABEL;
 	bool allow_neigh_map = true;
-	bool check_revdnat = true;
 	bool has_l4_header;
 	__u32 *vrf_id __maybe_unused = NULL;
 
@@ -2128,24 +2127,10 @@ nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	if (ret < 0) {
 		/* If it's not a SVC protocol, we don't need to check for RevDNAT: */
 		if (ret == DROP_UNSUPP_SERVICE_PROTO || ret == DROP_UNKNOWN_L4)
-			check_revdnat = false;
-		else
-			return ret;
-	}
+			goto skip_revdnat;
 
-#if defined(ENABLE_EGRESS_GATEWAY_COMMON) && !defined(IS_BPF_OVERLAY)
-	/* The gateway node needs to manually steer any reply traffic
-	 * for a remote pod into the tunnel (to avoid iptables potentially
-	 * dropping or accidentally SNATing the packets).
-	 */
-	if (egress_gw_reply_needs_redirect_hook(ip4, &tunnel_endpoint, &dst_sec_identity)) {
-		trace->reason = TRACE_REASON_CT_REPLY;
-		goto redirect;
+		return ret;
 	}
-#endif /* ENABLE_EGRESS_GATEWAY_COMMON */
-
-	if (!check_revdnat)
-		goto out;
 
 #if defined(ENABLE_SRV6) && defined(IS_BPF_LXC)
 	/* Determine if packet belongs to a VRF before we do NAT.
@@ -2194,7 +2179,19 @@ nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 
 		goto redirect;
 	}
-out:
+
+skip_revdnat:
+#if defined(ENABLE_EGRESS_GATEWAY_COMMON) && !defined(IS_BPF_OVERLAY)
+	/* The gateway node needs to manually steer any reply traffic
+	 * for a remote pod into the tunnel (to avoid iptables potentially
+	 * dropping or accidentally SNATing the packets).
+	 */
+	if (egress_gw_reply_needs_redirect_hook(ip4, &tunnel_endpoint, &dst_sec_identity)) {
+		trace->reason = TRACE_REASON_CT_REPLY;
+		goto redirect;
+	}
+#endif /* ENABLE_EGRESS_GATEWAY_COMMON */
+
 	return CTX_ACT_OK;
 
 redirect:

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -14,6 +14,8 @@
 #define EGRESS_IP2		IPV4(2, 3, 4, 5)
 #define EGRESS_IP3		IPV4(3, 3, 4, 5)
 
+#include "egressgw_policy.h"
+
 static volatile const __u8 *client_mac  = mac_one;
 static volatile const __u8 *gateway_mac = mac_two;
 static volatile const __u8 *ext_svc_mac = mac_three;
@@ -44,36 +46,6 @@ static __always_inline __be16 client_port(__u16 t)
 {
 	return CLIENT_PORT + bpf_htons(t);
 }
-
-#ifdef ENABLE_EGRESS_GATEWAY
-static __always_inline void add_egressgw_policy_entry(__be32 saddr, __be32 daddr, __u8 cidr,
-						      __be32 gateway_ip, __be32 egress_ip)
-{
-	struct egress_gw_policy_key in_key = {
-		.lpm_key = { EGRESS_PREFIX_LEN(cidr), {} },
-		.saddr   = saddr,
-		.daddr   = daddr,
-	};
-
-	struct egress_gw_policy_entry in_val = {
-		.egress_ip  = egress_ip,
-		.gateway_ip = gateway_ip,
-	};
-
-	map_update_elem(&EGRESS_POLICY_MAP, &in_key, &in_val, 0);
-}
-
-static __always_inline void del_egressgw_policy_entry(__be32 saddr, __be32 daddr, __u8 cidr)
-{
-	struct egress_gw_policy_key in_key = {
-		.lpm_key = { EGRESS_PREFIX_LEN(cidr), {} },
-		.saddr   = saddr,
-		.daddr   = daddr,
-	};
-
-	map_delete_elem(&EGRESS_POLICY_MAP, &in_key);
-}
-#endif /* ENABLE_EGRESS_GATEWAY */
 
 static __always_inline int egressgw_pktgen(struct __ctx_buff *ctx,
 					   struct egressgw_test_ctx test_ctx)

--- a/bpf/tests/lib/egressgw_policy.h
+++ b/bpf/tests/lib/egressgw_policy.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#ifdef ENABLE_EGRESS_GATEWAY
+static __always_inline void add_egressgw_policy_entry(__be32 saddr, __be32 daddr, __u8 cidr,
+						      __be32 gateway_ip, __be32 egress_ip)
+{
+	struct egress_gw_policy_key in_key = {
+		.lpm_key = { EGRESS_PREFIX_LEN(cidr), {} },
+		.saddr   = saddr,
+		.daddr   = daddr,
+	};
+
+	struct egress_gw_policy_entry in_val = {
+		.egress_ip  = egress_ip,
+		.gateway_ip = gateway_ip,
+	};
+
+	map_update_elem(&EGRESS_POLICY_MAP, &in_key, &in_val, 0);
+}
+
+static __always_inline void del_egressgw_policy_entry(__be32 saddr, __be32 daddr, __u8 cidr)
+{
+	struct egress_gw_policy_key in_key = {
+		.lpm_key = { EGRESS_PREFIX_LEN(cidr), {} },
+		.saddr   = saddr,
+		.daddr   = daddr,
+	};
+
+	map_delete_elem(&EGRESS_POLICY_MAP, &in_key);
+}
+#endif /* ENABLE_EGRESS_GATEWAY */


### PR DESCRIPTION
The code to handle EGW reply traffic lives in the nodeport ingress path, after a packet has been RevSNATed. In contrast to the outbound path, it doesn't consider whether the packet's source is an in-cluster entity.

This becomes problematic when the EGW policy specifies a broad-range `destinationCIDR`, such as 0.0.0.0/0, and accidentally matches in-cluster service traffic. More precisely:
* a client pod matches an EGW policy of the form "from $client_pod to 0.0.0.0/0, exit via gateway nodeB"
* client_pod accesses a nodeport service on gateway nodeB, where the request is DNATed to a remote backend, and SNATed to nodeB's IP.
* once the backend's reply reaches nodeB, it is revSNATed to client_pod. At this point the packet matches the EGW policy entry, and is thus redirected into the overlay network and forwarded to client_pod.
* As the RevDNAT step has been skipped, client_pod rejects this packet from an unknown source.

Fix this by applying the RevDNAT logic *prior* to looking for EGW policy matches. Double-checking whether the packet's origin is an in-cluster entity might still make sense, but no longer strictly necessary.


From a tcpdump on a kind cluster (with EGW, KPR without SocketLB and native routing):

```
# client accesses nodeport 31936 on remote LB node
IP 10.244.1.236.35556 > 172.18.0.2.31936: Flags [S]
# request is DNATed + SNATed, and forwarded to remote backend
IP 172.18.0.2.35556 > 10.244.3.121.80: Flags [S]
# backend's reply reaches the LB node
IP 10.244.3.121.80 > 172.18.0.2.35556: Flags [S.]
# LB node applies revSNAT, adds VXLAN encapsulation and forwards to client
IP 172.18.0.2.54624 > 172.18.0.4.8472: OTV, flags [I] (0x08), overlay 0, instance 6
IP 10.244.3.121.80 > 10.244.1.236.35556: Flags [S.]
# client's RST to the backend
IP 10.244.1.236.35556 > 10.244.3.121.80: Flags [R]
```

```release-note
Fix a bug that prevents a pod from accessing Nodeport services when the pod is also in scope of a broad-range Egress Gateway policy.
```
