### PR TITLE
datapath/sockets: Rework serialization and deserialization of netlink requests/responses

### DIFF
--- a/pkg/datapath/sockets/sockets.go
+++ b/pkg/datapath/sockets/sockets.go
@@ -4,6 +4,7 @@
 package sockets
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -28,7 +29,7 @@ const (
 
 var (
 	log          = logging.DefaultLogger.WithField(logfields.LogSubsys, "datapath-sockets")
-	native       = nl.NativeEndian()
+	native       = binary.NativeEndian
 	networkOrder = binary.BigEndian
 )
 
@@ -125,8 +126,6 @@ func filterAndDestroyUDPSockets(family uint8, socketCB func(socket netlink.Socke
 	return nil
 }
 
-// Below handlers are adapted from netlink/socket_linux.go to avoid memory allocations.
-
 type socketRequest struct {
 	Family   uint8
 	Protocol uint8
@@ -136,95 +135,82 @@ type socketRequest struct {
 	ID       netlink.SocketID
 }
 
-type writeBuffer struct {
-	Bytes []byte
-	pos   int
-}
+func (r socketRequest) Serialize() []byte {
+	var bb bytes.Buffer
 
-func (b *writeBuffer) write(c byte) {
-	b.Bytes[b.pos] = c
-	b.pos++
-}
+	bb.Grow(sizeofSocketRequest)
 
-func (b *writeBuffer) next(n int) []byte {
-	s := b.Bytes[b.pos : b.pos+n]
-	b.pos += n
-	return s
-}
+	bb.WriteByte(r.Family)
+	bb.WriteByte(r.Protocol)
+	bb.WriteByte(r.Ext)
+	bb.WriteByte(r.pad)
+	b := bb.AvailableBuffer()
+	b = native.AppendUint32(b, r.States)
+	b = networkOrder.AppendUint16(b, r.ID.SourcePort)
+	b = networkOrder.AppendUint16(b, r.ID.DestinationPort)
+	bb.Write(b)
+	serializeAddr(&bb, r.Family, r.ID.Source)
+	serializeAddr(&bb, r.Family, r.ID.Destination)
+	b = bb.AvailableBuffer()
+	b = native.AppendUint32(b, r.ID.Interface)
+	b = native.AppendUint32(b, r.ID.Cookie[0])
+	b = native.AppendUint32(b, r.ID.Cookie[1])
+	bb.Write(b)
 
-func (r *socketRequest) Serialize() []byte {
-	b := writeBuffer{Bytes: make([]byte, sizeofSocketRequest)}
-	b.write(r.Family)
-	b.write(r.Protocol)
-	b.write(r.Ext)
-	b.write(r.pad)
-	native.PutUint32(b.next(4), r.States)
-	networkOrder.PutUint16(b.next(2), r.ID.SourcePort)
-	networkOrder.PutUint16(b.next(2), r.ID.DestinationPort)
-	if r.Family == unix.AF_INET6 {
-		copy(b.next(16), r.ID.Source)
-		copy(b.next(16), r.ID.Destination)
-	} else {
-		copy(b.next(4), r.ID.Source.To4())
-		b.next(12)
-		copy(b.next(4), r.ID.Destination.To4())
-		b.next(12)
-	}
-	native.PutUint32(b.next(4), r.ID.Interface)
-	native.PutUint32(b.next(4), r.ID.Cookie[0])
-	native.PutUint32(b.next(4), r.ID.Cookie[1])
-	return b.Bytes
+	return bb.Bytes()
 }
 
 func (r *socketRequest) Len() int { return sizeofSocketRequest }
 
-type readBuffer struct {
-	Bytes []byte
-	pos   int
-}
-
-func (b *readBuffer) Read() byte {
-	c := b.Bytes[b.pos]
-	b.pos++
-	return c
-}
-
-func (b *readBuffer) Next(n int) []byte {
-	s := b.Bytes[b.pos : b.pos+n]
-	b.pos += n
-	return s
+func serializeAddr(bb *bytes.Buffer, family uint8, addr net.IP) {
+	if addr == nil {
+		for range net.IPv6len {
+			bb.WriteByte(0)
+		}
+		return
+	}
+	if family == unix.AF_INET6 {
+		bb.Write(addr)
+	} else {
+		bb.Write(addr.To4())
+		for range net.IPv6len - net.IPv4len {
+			bb.WriteByte(0)
+		}
+	}
 }
 
 type socket netlink.Socket
 
 func (s *socket) deserialize(b []byte) error {
+	// early size check to guarantee safety of reads below
 	if len(b) < sizeofSocket {
 		return fmt.Errorf("socket data short read (%d); want %d", len(b), sizeofSocket)
 	}
-	rb := readBuffer{Bytes: b}
-	s.Family = rb.Read()
-	s.State = rb.Read()
-	s.Timer = rb.Read()
-	s.Retrans = rb.Read()
-	s.ID.SourcePort = networkOrder.Uint16(rb.Next(2))
-	s.ID.DestinationPort = networkOrder.Uint16(rb.Next(2))
+
+	bb := bytes.NewBuffer(b)
+	s.Family, _ = bb.ReadByte()
+	s.State, _ = bb.ReadByte()
+	s.Timer, _ = bb.ReadByte()
+	s.Retrans, _ = bb.ReadByte()
+	s.ID.SourcePort = networkOrder.Uint16(bb.Next(2))
+	s.ID.DestinationPort = networkOrder.Uint16(bb.Next(2))
 	if s.Family == unix.AF_INET6 {
-		s.ID.Source = net.IP(rb.Next(16))
-		s.ID.Destination = net.IP(rb.Next(16))
+		s.ID.Source = net.IP(bb.Next(net.IPv6len))
+		s.ID.Destination = net.IP(bb.Next(net.IPv6len))
 	} else {
-		s.ID.Source = net.IPv4(rb.Read(), rb.Read(), rb.Read(), rb.Read())
-		rb.Next(12)
-		s.ID.Destination = net.IPv4(rb.Read(), rb.Read(), rb.Read(), rb.Read())
-		rb.Next(12)
+		src := bb.Next(net.IPv6len)
+		s.ID.Source = net.IPv4(src[0], src[1], src[2], src[3])
+		dst := bb.Next(net.IPv6len)
+		s.ID.Destination = net.IPv4(dst[0], dst[1], dst[2], dst[3])
 	}
-	s.ID.Interface = native.Uint32(rb.Next(4))
-	s.ID.Cookie[0] = native.Uint32(rb.Next(4))
-	s.ID.Cookie[1] = native.Uint32(rb.Next(4))
-	s.Expires = native.Uint32(rb.Next(4))
-	s.RQueue = native.Uint32(rb.Next(4))
-	s.WQueue = native.Uint32(rb.Next(4))
-	s.UID = native.Uint32(rb.Next(4))
-	s.INode = native.Uint32(rb.Next(4))
+	s.ID.Interface = native.Uint32(bb.Next(4))
+	s.ID.Cookie[0] = native.Uint32(bb.Next(4))
+	s.ID.Cookie[1] = native.Uint32(bb.Next(4))
+	s.Expires = native.Uint32(bb.Next(4))
+	s.RQueue = native.Uint32(bb.Next(4))
+	s.WQueue = native.Uint32(bb.Next(4))
+	s.UID = native.Uint32(bb.Next(4))
+	s.INode = native.Uint32(bb.Next(4))
 	return nil
 }
 

--- a/pkg/datapath/sockets/sockets_test.go
+++ b/pkg/datapath/sockets/sockets_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func TestSerialize(t *testing.T) {
+func TestSocketReqSerialize(t *testing.T) {
 	testCases := []struct {
 		name     string
 		req      socketRequest
@@ -63,7 +63,70 @@ func TestSerialize(t *testing.T) {
 	}
 }
 
-func BenchmarkSerialize(b *testing.B) {
+func TestSocketDeserialize(t *testing.T) {
+	testCases := []struct {
+		name     string
+		buf      []byte
+		expected socket
+	}{
+		{
+			name: "default route addresses",
+			buf:  []byte{2, 7, 0, 0, 170, 213, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 108, 0, 0, 0, 89, 101, 0, 0, 5, 0, 8, 0, 0, 0, 0, 0, 8, 0, 15, 0, 0, 0, 0, 0, 12, 0, 21, 0, 157, 14, 0, 0, 0, 0, 0, 0, 6, 0, 22, 0, 80, 0, 0, 0},
+			expected: socket{
+				Family:  2,
+				State:   7,
+				Timer:   0,
+				Retrans: 0,
+				ID: netlink.SocketID{
+					SourcePort:      43733,
+					DestinationPort: 0,
+					Source:          net.ParseIP("0.0.0.0"),
+					Destination:     net.ParseIP("0.0.0.0"),
+					Interface:       0,
+					Cookie:          [2]uint32{8201, 0},
+				},
+				Expires: 0,
+				RQueue:  0,
+				WQueue:  0,
+				UID:     108,
+				INode:   25945,
+			},
+		},
+		{
+			name: "non default route addresses",
+			buf:  []byte{2, 1, 0, 0, 189, 137, 1, 187, 192, 168, 50, 194, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 151, 99, 52, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 232, 3, 0, 0, 146, 138, 10, 0, 5, 0, 8, 0, 0, 0, 0, 0, 8, 0, 15, 0, 0, 0, 0, 0, 12, 0, 21, 0, 1, 42, 0, 0, 0, 0, 0, 0, 6, 0, 22, 0, 80, 0, 0, 0},
+			expected: socket{
+				Family:  2,
+				State:   1,
+				Timer:   0,
+				Retrans: 0,
+				ID: netlink.SocketID{
+					SourcePort:      48521,
+					DestinationPort: 443,
+					Source:          net.ParseIP("192.168.50.194"),
+					Destination:     net.ParseIP("151.99.52.13"),
+					Interface:       0,
+					Cookie:          [2]uint32{8211, 0},
+				},
+				Expires: 0,
+				RQueue:  0,
+				WQueue:  0,
+				UID:     1000,
+				INode:   690834,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var sock socket
+			err := sock.deserialize(tc.buf)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, sock)
+		})
+	}
+}
+
+func BenchmarkSocketReqSerialize(b *testing.B) {
 	requests := [...]socketRequest{
 		{
 			Family:   2,
@@ -100,6 +163,20 @@ func BenchmarkSerialize(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, req := range requests {
 			req.Serialize()
+		}
+	}
+}
+
+func BenchmarkSocketDeserialize(b *testing.B) {
+	buffers := [...][]byte{
+		{2, 7, 0, 0, 170, 213, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 108, 0, 0, 0, 89, 101, 0, 0, 5, 0, 8, 0, 0, 0, 0, 0, 8, 0, 15, 0, 0, 0, 0, 0, 12, 0, 21, 0, 157, 14, 0, 0, 0, 0, 0, 0, 6, 0, 22, 0, 80, 0, 0, 0},
+		{2, 1, 0, 0, 189, 137, 1, 187, 192, 168, 50, 194, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 151, 99, 52, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 232, 3, 0, 0, 146, 138, 10, 0, 5, 0, 8, 0, 0, 0, 0, 0, 8, 0, 15, 0, 0, 0, 0, 0, 12, 0, 21, 0, 1, 42, 0, 0, 0, 0, 0, 0, 6, 0, 22, 0, 80, 0, 0, 0},
+	}
+
+	for i := 0; i < b.N; i++ {
+		for _, buf := range buffers {
+			var sock socket
+			sock.deserialize(buf)
 		}
 	}
 }

--- a/pkg/datapath/sockets/sockets_test.go
+++ b/pkg/datapath/sockets/sockets_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package sockets
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
+)
+
+func TestSerialize(t *testing.T) {
+	testCases := []struct {
+		name     string
+		req      socketRequest
+		expected []byte
+	}{
+		{
+			name: "nil addresses",
+			req: socketRequest{
+				Family:   2,
+				Protocol: 6,
+				Ext:      0,
+				pad:      0,
+				States:   4095,
+				ID: netlink.SocketID{
+					SourcePort:      0,
+					DestinationPort: 0,
+					Source:          nil,
+					Destination:     nil,
+					Interface:       0,
+					Cookie:          [2]uint32{0, 0},
+				},
+			},
+			expected: []byte{2, 6, 0, 0, 255, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "non-nil addresses",
+			req: socketRequest{
+				Family:   2,
+				Protocol: 6,
+				Ext:      0,
+				pad:      0,
+				States:   4095,
+				ID: netlink.SocketID{
+					SourcePort:      59212,
+					DestinationPort: 30000,
+					Source:          net.ParseIP("127.0.0.1"),
+					Destination:     net.ParseIP("127.0.0.1"),
+					Interface:       0,
+					Cookie:          [2]uint32{4144, 0},
+				},
+			},
+			expected: []byte{2, 6, 0, 0, 255, 15, 0, 0, 231, 76, 117, 48, 127, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 127, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 48, 16, 0, 0, 0, 0, 0, 0},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.req.Serialize())
+		})
+	}
+}
+
+func BenchmarkSerialize(b *testing.B) {
+	requests := [...]socketRequest{
+		{
+			Family:   2,
+			Protocol: 6,
+			Ext:      0,
+			pad:      0,
+			States:   4095,
+			ID: netlink.SocketID{
+				SourcePort:      0,
+				DestinationPort: 0,
+				Source:          nil,
+				Destination:     nil,
+				Interface:       0,
+				Cookie:          [2]uint32{0, 0},
+			},
+		},
+		{
+			Family:   2,
+			Protocol: 6,
+			Ext:      0,
+			pad:      0,
+			States:   4095,
+			ID: netlink.SocketID{
+				SourcePort:      59212,
+				DestinationPort: 30000,
+				Source:          net.ParseIP("127.0.0.1"),
+				Destination:     net.ParseIP("127.0.0.1"),
+				Interface:       0,
+				Cookie:          [2]uint32{4144, 0},
+			},
+		},
+	}
+
+	for i := 0; i < b.N; i++ {
+		for _, req := range requests {
+			req.Serialize()
+		}
+	}
+}


### PR DESCRIPTION
Drive-by PR to rework the serialization and deserialization of netlink messages removing manual buffer management. The same (limited) amount of memory allocations can now be obtained with standard library facilities only, thanks to [binary.NativeOrder](https://pkg.go.dev/encoding/binary#pkg-variables) and [Buffer.AvailableBuffer](https://pkg.go.dev/encoding/binary#pkg-variables). Specifically, the pattern used on the serialization side is the one explained in https://github.com/golang/go/issues/53685#issuecomment-1175365841

Refer to individual commit messages for further details.
