### PR TITLE
endpoint: enable tests run multiple times

### DIFF
--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -77,13 +77,15 @@ func (s *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdentit
 func TestReadEPsFromDirNames(t *testing.T) {
 	s := setupEndpointSuite(t)
 	epsWanted, _ := s.createEndpoints()
-	tmpDir, err := os.MkdirTemp("", "cilium-tests")
-	defer func() {
-		os.RemoveAll(tmpDir)
-	}()
+	tmpDir := t.TempDir()
 
 	const unsupportedTestOption = "unsupported-test-only-option-xyz"
 
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		os.Chdir(cwd)
+	}()
 	os.Chdir(tmpDir)
 	require.NoError(t, err)
 	epsNames := []string{}
@@ -151,11 +153,13 @@ func TestReadEPsFromDirNamesWithRestoreFailure(t *testing.T) {
 	eps, _ := s.createEndpoints()
 	ep := eps[0]
 	require.NotNil(t, ep)
-	tmpDir, err := os.MkdirTemp("", "cilium-tests")
-	defer func() {
-		os.RemoveAll(tmpDir)
-	}()
+	tmpDir := t.TempDir()
 
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		os.Chdir(cwd)
+	}()
 	os.Chdir(tmpDir)
 	require.NoError(t, err)
 
@@ -212,11 +216,13 @@ func BenchmarkReadEPsFromDirNames(b *testing.B) {
 	// serialize config files to disk and benchmark the restore.
 
 	epsWanted, _ := s.createEndpoints()
-	tmpDir, err := os.MkdirTemp("", "cilium-tests")
-	defer func() {
-		os.RemoveAll(tmpDir)
-	}()
+	tmpDir := b.TempDir()
 
+	cwd, err := os.Getwd()
+	require.NoError(b, err)
+	defer func() {
+		os.Chdir(cwd)
+	}()
 	os.Chdir(tmpDir)
 	require.NoError(b, err)
 	epsNames := []string{}


### PR DESCRIPTION
`go test` `-count` option can be used to run tests multiple times, which is useful in trying to reproduce test flakes. The endpoint package reliably fails if a count greater than `1` is given.

This happens because restore tests change the working directory to a temp one, then remove the temp directory without changing the working directory back to the old one. This leaves any file operations relative to current working directory fail with `ENOENT` (due to directory not existing).

Fix this by changing back to the original working directory in restore tests.

Secondly, recreate policy log file by creating a new Lumberjack logger each time policy logging is enabled. Otherwise, if the policy log file is deleted from the filesystem, it is newer created again. This is another reason why multiple runs of go test in `pkg/endpoint` never succeeded, as `TestPolicyLog` is deleting the log file from the file system at the end of the test.

After this fix the following succeeds:
```
  $ go test -v -count=2 ./pkg/endpoint
```