### PR TITLE
localnodeconfig: dedup cluster routing mode

### DIFF
--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -321,7 +321,7 @@ func (n *linuxNodeHandler) enableIPSecIPv4Do(newNode *nodeTypes.Node, nodeID uin
 		statesUpdated = false
 	}
 
-	if n.nodeConfig.RoutingMode != option.RoutingModeTunnel {
+	if !n.nodeConfig.EnableEncapsulation {
 		return statesUpdated, errs
 	}
 

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -101,6 +101,5 @@ func newLocalNodeConfig(
 		IPv4PodSubnets:               cidr.NewCIDRSlice(config.IPv4PodSubnets),
 		IPv6PodSubnets:               cidr.NewCIDRSlice(config.IPv6PodSubnets),
 		XDPConfig:                    xdpConfig,
-		RoutingMode:                  config.RoutingMode,
 	}, common.MergeChannels(devsWatch, addrsWatch, directRoutingDevWatch, mtuWatch), nil
 }

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -180,10 +180,6 @@ type LocalNodeConfiguration struct {
 	// XDPConfig holds configuration options to determine how the node should
 	// handle XDP programs.
 	XDPConfig xdp.Config
-
-	// RoutingMode is the current routing mode of the local node.
-	// Can be 'native' or 'tunnel'.
-	RoutingMode string
 }
 
 func (cfg *LocalNodeConfiguration) DeviceNames() []string {

--- a/pkg/datapath/types/zz_generated.deepequal.go
+++ b/pkg/datapath/types/zz_generated.deepequal.go
@@ -271,9 +271,5 @@ func (in *LocalNodeConfiguration) DeepEqual(other *LocalNodeConfiguration) bool 
 		return false
 	}
 
-	if in.RoutingMode != other.RoutingMode {
-		return false
-	}
-
 	return true
 }


### PR DESCRIPTION
`RoutingMode` and `EnableEncapsulation` have the same semantics. Slim it down to a single config variable.
