### PR TITLE
bgpv2: decouple instance registration and reconcile errors

### DIFF
--- a/pkg/bgpv1/manager/manager.go
+++ b/pkg/bgpv1/manager/manager.go
@@ -816,17 +816,13 @@ func (m *BGPRouterManager) ReconcileInstances(ctx context.Context,
 		m.withdrawV2(ctx, rd)
 	}
 	if len(rd.register) > 0 {
-		if err := m.registerV2(ctx, rd); err != nil {
-			return err
-		}
+		err = errors.Join(err, m.registerV2(ctx, rd))
 	}
 	if len(rd.reconcile) > 0 {
-		if err := m.reconcileV2(ctx, rd); err != nil {
-			return err
-		}
+		err = errors.Join(err, m.reconcileV2(ctx, rd))
 	}
 
-	return nil
+	return err
 }
 
 // registerV2 instantiates and configures BGP Instance(s) as instructed by the provided


### PR DESCRIPTION
BGP instances are independent of each other, if there is failure to register or reconcile one instance, we should not abort registering or reconciling remaining instances. We calculate diff for registering and reconciling on each trigger, so failed instances will be retried again when next trigger is received.

