### PR TITLE
Helm: Preserve root context for .Values access

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/dashboards-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/dashboards-configmap.yaml
@@ -12,7 +12,7 @@ metadata:
     k8s-app: cilium
     app.kubernetes.io/name: cilium-agent
     app.kubernetes.io/part-of: cilium
-    {{- with .Values.commonLabels }}
+    {{- with $.Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if $.Values.dashboards.label }}

--- a/install/kubernetes/cilium/templates/cilium-operator/dashboards-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/dashboards-configmap.yaml
@@ -12,7 +12,7 @@ metadata:
     k8s-app: cilium
     app.kubernetes.io/name: cilium-operator
     app.kubernetes.io/part-of: cilium
-    {{- with .Values.commonLabels }}
+    {{- with $.Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if $.Values.operator.dashboards.label }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Creating a new PR because the [old one](https://github.com/cilium/cilium/pull/36874) had annoying unsigned merge commits.

As of now, enabling the Grafana Dashboard in the Helm Chart values results in the following error:

```
Error: Error: template: cilium/templates/cilium-agent/dashboards-configmap.yaml:15:20: executing "cilium/templates/cilium-agent/dashboards-configmap.yaml" at <.Values.commonLabels>: can't evaluate field Values in type []uint8
```
The with syntax scopes the context to the specified value (.Values.commonLabels), but inside range, .Values is inaccessible because the context is already shifted to $fileContents. Adding $ ensures that we’re referencing the root context (.Values) consistently, no matter how the context has shifted. It's also used in all other `with` blocks in this template.


```release-note
Fixes a type error that occurred when enabling the Grafana dashboards in the Helm chart.
```

This is my very first contribution. If you want me to fix or improve something, please tell me.

Fixes https://github.com/cilium/cilium/issues/37371