### PR TITLE
Cilium CLI: Trim EKS cluster ARN to extract valid cluster name

### DIFF
--- a/cilium-cli/install/autodetect_test.go
+++ b/cilium-cli/install/autodetect_test.go
@@ -31,3 +31,20 @@ func Test_getClusterName(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "my-cluster", getClusterName(vals))
 }
+
+func Test_trimEKSClusterARN(t *testing.T) {
+	vals := ""
+	assert.Equal(t, "", trimEKSClusterARN(vals))
+
+	vals = "arn:aws:eks:eu-west-1:111111111111:cluster/my-cluster"
+	assert.Equal(t, "my-cluster", trimEKSClusterARN(vals))
+
+	vals = "cluster/my-cluster"
+	assert.Equal(t, "my-cluster", trimEKSClusterARN(vals))
+
+	vals = "arn:aws:eks:region:account-id:cluster/"
+	assert.Equal(t, "", trimEKSClusterARN(vals))
+
+	vals = "invalid-arn-format"
+	assert.Equal(t, "invalid-arn-format", trimEKSClusterARN(vals))
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

<!-- Description of change -->

This pull request resolves the issue of interpreting the EKS Cluster ARN in the comments in issue #34006. It introduces the `trimEKSClusterARN` function to extract the actual cluster name, ensures the cluster name does not exceed 32 characters. This prevents validation errors during installation.

### Before
```bash
 jaehan 🚀  ~
 cilium install --version 1.16.5 
🔮 Auto-detected Kubernetes kind: EKS
ℹ️  Using Cilium version 1.16.5
🔮 Auto-detected cluster name: arn:aws:eks:ap-northeast-2:730904690368:cluster/test-cluster
🔮 Auto-detected kube-proxy has been installed
🔥 Patching the "aws-node" DaemonSet to evict its pods...

Error: Unable to install Cilium: execution error at (cilium/templates/validate.yaml:144:5): The cluster name is invalid: must not be more than 32 characters. Configure 'upgradeCompatibility' to 1.15 or earlier to temporarily skip this check at your own risk
```

### After
```bash
jaehan 🚀  ~/projects/cilium/cilium-cli/release   main ±
 cilium install --version 1.16.5 
🔮 Auto-detected Kubernetes kind: EKS
ℹ️  Using Cilium version 1.16.5
🔮 Auto-detected cluster name: test-cluster
🔮 Auto-detected kube-proxy has been installed
🔥 Patching the "aws-node" DaemonSet to evict its pods...
```
