### PR TITLE
proxy: Check if acknowledged proxy port is listening

### DIFF
--- a/pkg/proxy/proxyports/proxyports.go
+++ b/pkg/proxy/proxyports/proxyports.go
@@ -304,6 +304,19 @@ func (p *ProxyPorts) AckProxyPortWithReference(ctx context.Context, name string)
 func (p *ProxyPorts) AckProxyPort(ctx context.Context, name string, pp *ProxyPort) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
+
+	if !pp.acknowledged {
+		scopedLog := log.WithField(fieldProxyRedirectID, name)
+
+		// check if the proxy port is listening
+		openLocalPorts := OpenLocalPorts()
+		if _, isListening := openLocalPorts[pp.ProxyPort]; !isListening {
+			scopedLog.Warningf("Proxy port not listening (%d)", pp.ProxyPort)
+		} else {
+			scopedLog.Debugf("Proxy port appears to be listening (%d)", pp.ProxyPort)
+		}
+	}
+
 	return p.ackProxyPort(ctx, name, pp)
 }
 


### PR DESCRIPTION
Add a warning log if a proxy port is not listening at the time it is first acknowledged.