### PR TITLE
bpf: Makefile improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -513,10 +513,12 @@ help: ## Display help for the Makefile, from https://www.thapaliya.com/en/writin
 force :;
 
 BPF_TEST_FILE ?= ""
+BPF_TEST_DUMP_CTX ?= ""
+BPF_TEST_VERBOSE ?= 0
 
 run_bpf_tests: ## Build and run the BPF unit tests using the cilium-builder container image.
 	DOCKER_ARGS=--privileged contrib/scripts/builder.sh \
-		"make" "-j$(shell nproc)" "-C" "bpf/tests/" "run" "BPF_TEST_FILE=$(BPF_TEST_FILE)"
+		"make" "-j$(shell nproc)" "-C" "bpf/tests/" "run" "BPF_TEST_FILE=$(BPF_TEST_FILE)" "BPF_TEST_DUMP_CTX=$(BPF_TEST_DUMP_CTX)" "V=$(BPF_TEST_VERBOSE)"
 
 run-builder: ## Drop into a shell inside a container running the cilium-builder image.
 	DOCKER_ARGS=-it contrib/scripts/builder.sh bash

--- a/bpf/tests/Makefile
+++ b/bpf/tests/Makefile
@@ -75,7 +75,7 @@ endif
 ifdef RUN
     BPF_TEST_FLAGS += -run $(RUN)
 endif
-ifdef DUMPCTX
+ifdef BPF_TEST_DUMP_CTX
     BPF_TEST_FLAGS += -dump-ctx
 endif
 ifdef BPF_TEST_FILE


### PR DESCRIPTION
The commit allows populating debug context and verbosity level for the bpf test from root Makefile.
Usage example: `make run_bpf_tests BPF_TEST_DUMP_CTX=1 BPF_TEST_VERBOSE=1`