### PR TITLE
gha: Run client-egress-l7-tls-headers test repeatedly

### DIFF
--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -27,7 +27,7 @@ jobs:
   installation-and-connectivity:
     name: "Installation and Connectivity Test"
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 120
     env:
       job_name: "Installation and Connectivity Test"
     steps:
@@ -112,6 +112,21 @@ jobs:
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --curl-parallel 3 \
             --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
+
+      - name: Run one test repeatedly
+        run: |
+          for i in {1..100}
+          do
+            kubectl -n kube-system rollout restart ds/cilium
+            cilium status --wait
+
+            echo "Running Cilium connectivity test iteration $i"
+            cilium connectivity test --test "client-egress-l7-tls-headers" -v --force-deploy
+            if [ $? -ne 0 ]; then
+              echo "Cilium connectivity test failed on iteration $i"
+              exit 1
+            fi
+          done
 
       - name: Features tested
         uses: ./.github/actions/feature-status


### PR DESCRIPTION
This is to debug flake mentioned in #36458


```diff
diff --git a/.github/workflows/conformance-kind-proxy-embedded.yaml b/.github/workflows/conformance-kind-proxy-embedded.yaml
index 00f27866b3..d782b4f039 100644
--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -27,7 +27,7 @@ jobs:
   installation-and-connectivity:
     name: "Installation and Connectivity Test"
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 120
     env:
       job_name: "Installation and Connectivity Test"
     steps:
@@ -113,6 +113,21 @@ jobs:
             --curl-parallel 3 \
             --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
 
+      - name: Run one test repeatedly
+        run: |
+          for i in {1..100}
+          do
+            kubectl -n kube-system rollout restart ds/cilium
+            cilium status --wait
+
+            echo "Running Cilium connectivity test iteration $i"
+            cilium connectivity test --test "client-egress-l7-tls-headers" -v --force-deploy
+            if [ $? -ne 0 ]; then
+              echo "Cilium connectivity test failed on iteration $i"
+              exit 1
+            fi
+          done
+
       - name: Features tested
         uses: ./.github/actions/feature-status
         with:
```
