### PR TITLE
ci: skip plain-text TCP RST packets in bpftrace

### DIFF
--- a/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
@@ -101,28 +101,31 @@ kprobe:br_forward
 
     if (($src_is_pod && $dst_is_pod) || ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))) {
       $tcph = (struct tcphdr*)$udph;
-      printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
-        strftime("%H:%M:%S:%f", nsecs),
-        ntop($ip4h->saddr), bswap($udph->source),
-        ntop($ip4h->daddr), bswap($udph->dest),
-        $ip4h->protocol,
-        $ip4h->protocol == PROTO_TCP && $tcph->syn ? CH_S : CH_DOT,
-        $ip4h->protocol == PROTO_TCP && $tcph->ack ? CH_A : CH_DOT,
-        $ip4h->protocol == PROTO_TCP && $tcph->fin ? CH_F : CH_DOT,
-        $ip4h->protocol == PROTO_TCP && $tcph->rst ? CH_R : CH_DOT,
-        $skb->encapsulation,
-        $skb->dev->ifindex,
-        $skb->dev->nd_net.net->ns.inum,
-        $pod_to_pod_via_proxy);
 
-      if ($ip4h->protocol == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
-        $dns = (struct dnshdr*)($udph + 1);
-        $query = (uint8 *)($dns + 1);
-        printf("[%s] Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
+      if (!$tcph->rst) {
+        printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
           strftime("%H:%M:%S:%f", nsecs),
-          bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
-          bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
-          str(kptr($query)));
+          ntop($ip4h->saddr), bswap($udph->source),
+          ntop($ip4h->daddr), bswap($udph->dest),
+          $ip4h->protocol,
+          $ip4h->protocol == PROTO_TCP && $tcph->syn ? CH_S : CH_DOT,
+          $ip4h->protocol == PROTO_TCP && $tcph->ack ? CH_A : CH_DOT,
+          $ip4h->protocol == PROTO_TCP && $tcph->fin ? CH_F : CH_DOT,
+          $ip4h->protocol == PROTO_TCP && $tcph->rst ? CH_R : CH_DOT,
+          $skb->encapsulation,
+          $skb->dev->ifindex,
+          $skb->dev->nd_net.net->ns.inum,
+          $pod_to_pod_via_proxy);
+
+        if ($ip4h->protocol == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
+          $dns = (struct dnshdr*)($udph + 1);
+          $query = (uint8 *)($dns + 1);
+          printf("[%s] Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
+            strftime("%H:%M:%S:%f", nsecs),
+            bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
+            bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
+            str(kptr($query)));
+        }
       }
     }
   }
@@ -137,28 +140,31 @@ kprobe:br_forward
 
     if (($src_is_pod && $dst_is_pod) || ($pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod))) {
       $tcph = (struct tcphdr*)$udph;
-      printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
-        strftime("%H:%M:%S:%f", nsecs),
-        ntop($ip6h->saddr.in6_u.u6_addr8), bswap($udph->source),
-        ntop($ip6h->daddr.in6_u.u6_addr8), bswap($udph->dest),
-        $ip6h->nexthdr,
-        $ip6h->nexthdr == PROTO_TCP && $tcph->syn ? CH_S : CH_DOT,
-        $ip6h->nexthdr == PROTO_TCP && $tcph->ack ? CH_A : CH_DOT,
-        $ip6h->nexthdr == PROTO_TCP && $tcph->fin ? CH_F : CH_DOT,
-        $ip6h->nexthdr == PROTO_TCP && $tcph->rst ? CH_R : CH_DOT,
-        $skb->encapsulation,
-        $skb->dev->ifindex,
-        $skb->dev->nd_net.net->ns.inum,
-        $pod_to_pod_via_proxy);
 
-      if ($ip6h->nexthdr == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
-        $dns = (struct dnshdr*)($udph + 1);
-        $query = (uint8 *)($dns + 1);
-        printf("[%s] Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
+      if (!$tcph->rst) {
+        printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
           strftime("%H:%M:%S:%f", nsecs),
-          bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
-          bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
-          str(kptr($query)));
+          ntop($ip6h->saddr.in6_u.u6_addr8), bswap($udph->source),
+          ntop($ip6h->daddr.in6_u.u6_addr8), bswap($udph->dest),
+          $ip6h->nexthdr,
+          $ip6h->nexthdr == PROTO_TCP && $tcph->syn ? CH_S : CH_DOT,
+          $ip6h->nexthdr == PROTO_TCP && $tcph->ack ? CH_A : CH_DOT,
+          $ip6h->nexthdr == PROTO_TCP && $tcph->fin ? CH_F : CH_DOT,
+          $ip6h->nexthdr == PROTO_TCP && $tcph->rst ? CH_R : CH_DOT,
+          $skb->encapsulation,
+          $skb->dev->ifindex,
+          $skb->dev->nd_net.net->ns.inum,
+          $pod_to_pod_via_proxy);
+
+        if ($ip6h->nexthdr == PROTO_UDP && (bswap($udph->source) == PORT_DNS || bswap($udph->dest) == PORT_DNS)) {
+          $dns = (struct dnshdr*)($udph + 1);
+          $query = (uint8 *)($dns + 1);
+          printf("[%s] Detected DNS message, ID: %04x, flags %04x, QD: %d, AN: %d, NS: %d, AR: %d, query %s\n",
+            strftime("%H:%M:%S:%f", nsecs),
+            bswap($dns->id), bswap($dns->flags), bswap($dns->qdcount),
+            bswap($dns->ancount), bswap($dns->nscount), bswap($dns->arcount),
+            str(kptr($query)));
+        }
       }
     }
   }


### PR DESCRIPTION
In #35485, we identified a leaked TCP RST packet generated from the kernel client in response to a FIN-ACK coming from the envoy proxy at the server-side. We noticed the behavior is due to a set of timers in the proxy that make it attempt closing (already closed) connections after specific intervals, causing the client to reply with a reset packet. The main issue is that such kernel-level packets don't contain the MARK we rely on to forward traffic from/to proxy, therefore letting the plain text packet through the default path.

Let's tolerate such RST packets with this patch in all the cases we'd trace it as plain-text. That means:

1. $src_is_pod && $dst_is_pod
2. $pod_to_pod_via_proxy && ($src_is_pod || $dst_is_pod)

Depending on the Cilium config, we observe leaked packets with source address either pod IP or ingress IP. The patch included both the two cases.

Fixes: #35485

```release-note
Skip tracking unmarked plain-text TCP RST packets generated from proxy timeouts in the CI bpftrace script.
```