### PR TITLE
docs: Update L7 Port Range Information

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -785,6 +785,9 @@ only be able to emit packets using TCP on ports 80-444, to any layer 3 destinati
         .. literalinclude:: ../../../examples/policies/l4/l4_port_range.json
 
 
+
+.. note:: Layer 7 rules support port ranges, except for DNS rules.
+
 Labels-dependent Layer 4 rule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -961,11 +964,7 @@ latter rule will have no effect.
           an *HTTP 403 access denied* is sent back for HTTP requests which
           violate the policy, or a *DNS REFUSED* response for DNS requests.
 
-.. note:: Layer 7 rules do not currently support port ranges.
-
-.. note:: There is currently a max limit of 40 ports with layer 7 policies per
-          endpoint. This might change in the future when support for ranges is
-          added.
+.. note:: Layer 7 rules support port ranges, except for DNS rules.
 
 .. note:: In `HostPolicies`, i.e. policies that use :ref:`NodeSelector`,
           only DNS layer 7 rules are currently supported.
@@ -1221,6 +1220,8 @@ allowed but connections to the returned IPs are not, as there is no L3
           ``servicename.namespace.svc.cluster.local.`` must have the latter
           allowed with ``matchName`` or ``matchPattern``. See `Alpine/musl deployments and DNS Refused`_.
 
+.. note:: DNS policies do not support port ranges.
+
 .. _DNS Obtaining Data:
 
 Obtaining DNS Data for use by ``toFQDNs``
@@ -1264,6 +1265,9 @@ DNS Proxy
 .. only:: epub or latex
 
         .. literalinclude:: ../../../examples/policies/l7/dns/dns-visibility.json
+
+.. note:: DNS policies do not support port ranges.
+
 
 Alpine/musl deployments and DNS Refused
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
L7 Rules now support port ranges, except for DNS rules.
