### PR TITLE
Docs: update SIGs section

### DIFF
--- a/Documentation/community/community.rst
+++ b/Documentation/community/community.rst
@@ -68,6 +68,7 @@ Name                     Purpose
 ``#ebpf-go-dev``         Development discussion for the `eBPF Go library`_
 ``#git``                 GitHub notifications
 ``#sig-``\*              SIG-specific discussions (see below)
+``#area-``               Discussing a specific area of the project
 ``#testing``             Testing and CI discussions
 ``#cilium-website``      Development discussions around cilium.io
 ======================== ======================================================
@@ -112,35 +113,11 @@ How to create a Slack channel
 Special Interest Groups
 =======================
 
-All SIGs
---------
+The Cilium project has Special Interest Groups, or SIGs, with a common purpose
+of advancing the project with respect to a specific topic, such as network policy
+or documentation. Their goal is to enable a distributed decision structure and
+code ownership, as well as providing focused forums for getting work done, making
+decisions, and on boarding new contributors.
 
-The following is a list of special interest groups (SIGs) that are meeting on a
-regular interval. See the respective slack channel for exact meeting cadence
-and meeting links.
-
-====================== =============================================== ======================= ============================================================================
-SIG                    Meeting                                         Slack                   Description
-====================== =============================================== ======================= ============================================================================
-BGP                    None                                            ``#sig-bgp``            Border Gateway Protocol (BGP) discussions.
-Cluster Mesh           None                                            ``#sig-clustermesh``    Cluster Mesh discussions.
-Datapath               On demand                                       ``#sig-datapath``       Development discussions for Linux and eBPF code used in Cilium.
-Documentation          None                                            ``#sig-docs``           Documentation, Helm references, and translations.
-Envoy                  On demand                                       ``#sig-envoy``          Envoy, Istio and maintenance of all L7 protocol parsers.
-Hubble                 During community meeting                        ``#sig-hubble``         All Hubble-related code: Server, UI, CLI and Relay.
-Modularization         None                                            ``#sig-modularization`` Discussions around further modularizing the cilium/cilium codebase.
-Policy                 `Second Tuesday <https://isogo.to/sig-policy>`_ ``#sig-policy``         Network policy and enforcement.
-Release Management     None                                            ``#launchpad``          Release management and backport coordination.
-Scalability            Fourth Thursday of the month                    ``#sig-scalability``    Cilium scalability discussions.
-====================== =============================================== ======================= ============================================================================
-
-How to create a SIG
--------------------
-
-1. Open a new `GitHub issue in the cilium/cilium repo <https://github.com/cilium/cilium/issues>`_
-2. Specify the title "SIG-Request: <Name>"
-3. Provide a description
-4. Find two Cilium committers to support the SIG
-5. Ask on ``#development`` to get the Slack channel and Zoom meeting created
-6. Submit a PR to update the documentation to get your new SIG listed
-
+To learn more about what they are, how to get involved, or which ones are currently
+active, please check out the `SIG.md in the community repo <https://github.com/cilium/community/blob/main/SIG.md>`_


### PR DESCRIPTION
With the merge of https://github.com/cilium/community/pull/168, SIG documentation has been moved to the community repo. This PR removes outdated information and links to the new location.
