### PR TITLE
Fix dropped NodePort traffic to hostNetwork backends with Geneve+DSR

### DIFF
--- a/daemon/cmd/ipcache.go
+++ b/daemon/cmd/ipcache.go
@@ -77,7 +77,7 @@ func (ipc *ipCacheDumpListener) getIdentity(securityIdentity uint32) (*identity.
 // OnIPIdentityCacheChange is called by DumpToListenerLocked
 func (ipc *ipCacheDumpListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 	cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP, oldID *ipcache.Identity,
-	newID ipcache.Identity, encryptKey uint8, k8sMeta *ipcache.K8sMetadata) {
+	newID ipcache.Identity, encryptKey uint8, k8sMeta *ipcache.K8sMetadata, endpointFlags uint8) {
 	cidr := cidrCluster.AsIPNet()
 
 	// only capture entries which are a subnet of cidrFilter

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -97,7 +97,7 @@ func (l *BPFListener) notifyMonitor(modType ipcache.CacheModification,
 // is not required to upsert the new pair.
 func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrCluster cmtypes.PrefixCluster,
 	oldHostIP, newHostIP net.IP, oldID *ipcache.Identity, newID ipcache.Identity,
-	encryptKey uint8, k8sMeta *ipcache.K8sMetadata) {
+	encryptKey uint8, k8sMeta *ipcache.K8sMetadata, endpointFlags uint8) {
 	cidr := cidrCluster.AsIPNet()
 
 	scopedLog := log
@@ -126,6 +126,7 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 		value := ipcacheMap.RemoteEndpointInfo{
 			SecurityIdentity: uint32(newID.ID),
 			Key:              encryptKey,
+			Flags:            ipcacheMap.RemoteEndpointInfoFlags(endpointFlags),
 		}
 
 		if newHostIP != nil {

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -99,7 +99,7 @@ func (cache *NPHDSCache) HandleResourceVersionAck(ackVersion uint64, nackVersion
 // IP/ID mappings.
 func (cache *NPHDSCache) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrCluster cmtypes.PrefixCluster,
 	oldHostIP, newHostIP net.IP, oldID *ipcache.Identity, newID ipcache.Identity,
-	encryptKey uint8, k8sMeta *ipcache.K8sMetadata,
+	encryptKey uint8, k8sMeta *ipcache.K8sMetadata, endpointFlags uint8,
 ) {
 	cidr := cidrCluster.AsIPNet()
 
@@ -130,7 +130,7 @@ func (cache *NPHDSCache) OnIPIdentityCacheChange(modType ipcache.CacheModificati
 		// but only if the old ID is different.
 		if oldID != nil && oldID.ID != newID.ID {
 			// Recursive call to delete the 'cidr' from the 'oldID'
-			cache.OnIPIdentityCacheChange(ipcache.Delete, cidrCluster, nil, nil, nil, *oldID, encryptKey, k8sMeta)
+			cache.OnIPIdentityCacheChange(ipcache.Delete, cidrCluster, nil, nil, nil, *oldID, encryptKey, k8sMeta, endpointFlags)
 		}
 		err := cache.handleIPUpsert(npHost, resourceName, cidrStr, newID.ID)
 		if err != nil {

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -585,7 +585,7 @@ func newDummyListener(ipc *IPCache) *dummyListener {
 
 func (dl *dummyListener) OnIPIdentityCacheChange(modType CacheModification,
 	cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP, oldID *Identity,
-	newID Identity, encryptKey uint8, k8sMeta *K8sMetadata) {
+	newID Identity, encryptKey uint8, k8sMeta *K8sMetadata, endpointFlags uint8) {
 
 	switch modType {
 	case Upsert:

--- a/pkg/ipcache/listener.go
+++ b/pkg/ipcache/listener.go
@@ -30,6 +30,7 @@ type IPIdentityMappingListener interface {
 	// hostIP is optional and may only be non-nil for an Upsert modification.
 	// k8sMeta contains the Kubernetes pod namespace and name behind the IP
 	// and may be nil.
+	// endpointFlags contains optional flags to be attached to the endpoint
 	OnIPIdentityCacheChange(modType CacheModification, cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP,
-		oldID *Identity, newID Identity, encryptKey uint8, k8sMeta *K8sMetadata)
+		oldID *Identity, newID Identity, encryptKey uint8, k8sMeta *K8sMetadata, endpointFlags uint8)
 }

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -326,9 +326,10 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 	}
 
 	type ipcacheEntry struct {
-		identity   Identity
-		tunnelPeer net.IP
-		encryptKey uint8
+		identity      Identity
+		tunnelPeer    net.IP
+		encryptKey    uint8
+		endpointFlags uint8
 
 		force bool
 	}
@@ -355,6 +356,7 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 		pstr := prefix.String()
 		oldID, entryExists := ipc.LookupByIP(pstr)
 		oldTunnelIP, oldEncryptionKey := ipc.GetHostIPCache(pstr)
+		oldEndpointFlags := ipc.GetEndpointFlags(pstr)
 		prefixInfo := ipc.metadata.getLocked(prefix)
 		var newID *identity.Identity
 		var isNew bool
@@ -406,7 +408,8 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 				if oldID.ID == newID.ID && prefixInfo.Source() == oldID.Source &&
 					oldID.overwrittenLegacySource == newOverwrittenLegacySource &&
 					oldTunnelIP.Equal(prefixInfo.TunnelPeer().IP()) &&
-					oldEncryptionKey == prefixInfo.EncryptKey().Uint8() {
+					oldEncryptionKey == prefixInfo.EncryptKey().Uint8() &&
+					oldEndpointFlags == prefixInfo.EndpointFlags().Uint8() {
 					goto releaseIdentity
 				}
 			}
@@ -423,8 +426,9 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 					// Note: `modifiedByLegacyAPI` and `shadowed` will be
 					// set by the upsert call itself
 				},
-				tunnelPeer: prefixInfo.TunnelPeer().IP(),
-				encryptKey: prefixInfo.EncryptKey().Uint8(),
+				tunnelPeer:    prefixInfo.TunnelPeer().IP(),
+				encryptKey:    prefixInfo.EncryptKey().Uint8(),
+				endpointFlags: prefixInfo.EndpointFlags().Uint8(),
 				// IPCache.Upsert() and friends currently require a
 				// Source to be provided during upsert. If the old
 				// Source was higher precedence due to labels that
@@ -484,9 +488,10 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 							Source:              oldID.overwrittenLegacySource,
 							modifiedByLegacyAPI: true,
 						},
-						tunnelPeer: oldTunnelIP,
-						encryptKey: oldEncryptionKey,
-						force:      true, /* overwrittenLegacySource is lower precedence */
+						tunnelPeer:    oldTunnelIP,
+						encryptKey:    oldEncryptionKey,
+						endpointFlags: oldEndpointFlags,
+						force:         true, /* overwrittenLegacySource is lower precedence */
 					}
 					entriesToReplace[prefix] = unmanagedEntry
 
@@ -548,6 +553,7 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 			entry.encryptKey,
 			meta,
 			entry.identity,
+			entry.endpointFlags,
 			entry.force,
 			/* fromLegacyAPI */ false,
 		); err2 != nil {

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -48,6 +48,7 @@ type resourceInfo struct {
 	tunnelPeer        ipcachetypes.TunnelPeer
 	encryptKey        ipcachetypes.EncryptKey
 	requestedIdentity ipcachetypes.RequestedIdentity
+	endpointFlags     ipcachetypes.EndpointFlags
 }
 
 // IPMetadata is an empty interface intended to inform developers using the
@@ -90,6 +91,9 @@ func (m *resourceInfo) merge(info IPMetadata, src source.Source) bool {
 	case ipcachetypes.RequestedIdentity:
 		changed = m.requestedIdentity != info
 		m.requestedIdentity = info
+	case ipcachetypes.EndpointFlags:
+		changed = m.endpointFlags != info
+		m.endpointFlags = info
 	default:
 		log.Errorf("BUG: Invalid IPMetadata passed to ipinfo.merge(): %+v", info)
 		return false
@@ -113,6 +117,8 @@ func (m *resourceInfo) unmerge(info IPMetadata) {
 		m.encryptKey = ipcachetypes.EncryptKeyEmpty
 	case ipcachetypes.RequestedIdentity:
 		m.requestedIdentity = ipcachetypes.RequestedIdentity(identity.IdentityUnknown)
+	case ipcachetypes.EndpointFlags:
+		m.endpointFlags = ipcachetypes.EndpointFlags{}
 	default:
 		log.Errorf("BUG: Invalid IPMetadata passed to ipinfo.unmerge(): %+v", info)
 		return
@@ -135,6 +141,9 @@ func (m *resourceInfo) isValid() bool {
 	if m.requestedIdentity.IsValid() {
 		return true
 	}
+	if m.endpointFlags.IsValid() {
+		return true
+	}
 	return false
 }
 
@@ -146,6 +155,7 @@ func (m *resourceInfo) DeepCopy() *resourceInfo {
 	n.tunnelPeer = m.tunnelPeer
 	n.encryptKey = m.encryptKey
 	n.requestedIdentity = m.requestedIdentity
+	n.endpointFlags = m.endpointFlags
 	return n
 }
 
@@ -216,6 +226,15 @@ func (s prefixInfo) RequestedIdentity() ipcachetypes.RequestedIdentity {
 	return ipcachetypes.RequestedIdentity(identity.InvalidIdentity)
 }
 
+func (s prefixInfo) EndpointFlags() ipcachetypes.EndpointFlags {
+	for _, rid := range s.sortedBySourceThenResourceID() {
+		if flags := s[rid].endpointFlags; flags.IsValid() {
+			return flags
+		}
+	}
+	return ipcachetypes.EndpointFlags{}
+}
+
 // identityOverride extracts the labels of the pre-determined identity from
 // the prefix info. If no override identity is present, this returns nil.
 // This pre-determined identity will overwrite any other identity which may
@@ -250,7 +269,7 @@ func (s prefixInfo) identityOverride() (lbls labels.Labels, hasOverride bool) {
 }
 
 func (ri resourceInfo) shouldLogConflicts() bool {
-	return bool(ri.identityOverride) || ri.tunnelPeer.IsValid() || ri.encryptKey.IsValid() || ri.requestedIdentity.IsValid()
+	return bool(ri.identityOverride) || ri.tunnelPeer.IsValid() || ri.encryptKey.IsValid() || ri.requestedIdentity.IsValid() || ri.endpointFlags.IsValid()
 }
 
 func (s prefixInfo) logConflicts(scopedLog *logrus.Entry) {
@@ -266,6 +285,9 @@ func (s prefixInfo) logConflicts(scopedLog *logrus.Entry) {
 
 		requestedID           ipcachetypes.RequestedIdentity
 		requestedIDResourceID ipcachetypes.ResourceID
+
+		endpointFlags           ipcachetypes.EndpointFlags
+		endpointFlagsResourceID ipcachetypes.ResourceID
 	)
 
 	for _, resourceID := range s.sortedBySourceThenResourceID() {
@@ -339,6 +361,21 @@ func (s prefixInfo) logConflicts(scopedLog *logrus.Entry) {
 			} else {
 				requestedID = info.requestedIdentity
 				requestedIDResourceID = resourceID
+			}
+		}
+
+		if info.endpointFlags.IsValid() {
+			if endpointFlags.IsValid() {
+				scopedLog.WithFields(logrus.Fields{
+					logfields.EndpointFlags:            endpointFlags,
+					logfields.Resource:                 endpointFlagsResourceID,
+					logfields.ConflictingEndpointFlags: info.endpointFlags,
+					logfields.ConflictingResource:      resourceID,
+				}).Warning("Detected conflicting endpoint flags for prefix. " +
+					"This may cause connectivity issues for this address.")
+			} else {
+				endpointFlags = info.endpointFlags
+				endpointFlagsResourceID = resourceID
 			}
 		}
 	}

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -122,3 +122,40 @@ func (id RequestedIdentity) IsValid() bool {
 func (id RequestedIdentity) ID() identity.NumericIdentity {
 	return identity.NumericIdentity(id)
 }
+
+// EndpointFlags represents various flags that can be attached to endpoints in the IPCache
+// This type implements ipcache.IPMetadata
+type EndpointFlags struct {
+	// isInit gets flipped to true on the first intentional flag set
+	// it is a sentinel to distinguish an uninitialized EndpointFlags
+	// from one with all flags set to false
+	isInit bool
+
+	// flagSkipTunnel can be applied to a remote endpoint to signal that
+	// packets destined for said endpoint shall not be forwarded through
+	// an overlay tunnel, regardless of Cilium's configuration.
+	flagSkipTunnel bool
+}
+
+func (e *EndpointFlags) SetSkipTunnel(skip bool) {
+	e.isInit = true
+	e.flagSkipTunnel = skip
+}
+
+func (e EndpointFlags) IsValid() bool {
+	return e.isInit
+}
+
+// Uint8 encoding MUST mimic the one in pkg/maps/ipcache
+// since it will eventually get recast to it
+const (
+	FlagSkipTunnel uint8 = 1 << iota
+)
+
+func (e EndpointFlags) Uint8() uint8 {
+	var flags uint8 = 0
+	if e.flagSkipTunnel {
+		flags = flags | FlagSkipTunnel
+	}
+	return flags
+}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -444,6 +444,13 @@ const (
 	// with TunnelPeer
 	ConflictingTunnelPeer = "conflictingTunnelPeer"
 
+	// EndpointFlags is the encoded set of flags for an endpoint
+	EndpointFlags = "endpointFlags"
+
+	// ConflictingEndpointFlags is the encoded set of flags that conflicts
+	// with 'EndpointFlags'
+	ConflictingEndpointFlags = "conflictingEndpointFlags"
+
 	// Type is the address type
 	Type = "type"
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -564,7 +564,7 @@ func (m *manager) checkpoint() error {
 	return f.CloseAtomicallyReplace()
 }
 
-func (m *manager) nodeAddressHasTunnelIP(address nodeTypes.Address) bool {
+func (m *manager) nodeAddressShouldUseTunnel(address nodeTypes.Address) bool {
 	// If the host firewall is enabled, all traffic to remote nodes must go
 	// through the tunnel to preserve the source identity as part of the
 	// encapsulation. In encryption case we also want to use vxlan device
@@ -674,9 +674,13 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 			ipsetEntries = append(ipsetEntries, prefix)
 		}
 
-		var tunnelIP netip.Addr
-		if m.nodeAddressHasTunnelIP(address) {
-			tunnelIP = nodeIP
+		// Always set the tunnelIP so it can be used for metadata like DSR info
+		var tunnelIP netip.Addr = nodeIP
+
+		// Inform datapath not to use tunnelling for directly reachable endpoints
+		endpointFlags := ipcacheTypes.EndpointFlags{}
+		if !m.nodeAddressShouldUseTunnel(address) {
+			endpointFlags.SetSkipTunnel(true)
 		}
 
 		var key uint8
@@ -715,7 +719,8 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		m.ipcache.UpsertMetadata(prefix, n.Source, resource,
 			lbls,
 			ipcacheTypes.TunnelPeer{Addr: tunnelIP},
-			ipcacheTypes.EncryptKey(key))
+			ipcacheTypes.EncryptKey(key),
+			endpointFlags)
 		if nodeIdentityOverride {
 			m.ipcache.OverrideIdentity(prefix, nodeLabels, n.Source, resource)
 		}
@@ -880,9 +885,11 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 			}
 		}
 
-		var oldTunnelIP netip.Addr
-		if m.nodeAddressHasTunnelIP(address) {
-			oldTunnelIP = oldNodeIP
+		var oldTunnelIP netip.Addr = oldNodeIP
+
+		oldEndpointFlags := ipcacheTypes.EndpointFlags{}
+		if !m.nodeAddressShouldUseTunnel(address) {
+			oldEndpointFlags.SetSkipTunnel(true)
 		}
 
 		var oldKey uint8
@@ -893,7 +900,8 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 		m.ipcache.RemoveMetadata(oldPrefix, resource,
 			oldNodeLabels,
 			ipcacheTypes.TunnelPeer{Addr: oldTunnelIP},
-			ipcacheTypes.EncryptKey(oldKey))
+			ipcacheTypes.EncryptKey(oldKey),
+			oldEndpointFlags)
 		if oldNodeIdentityOverride {
 			m.ipcache.RemoveIdentityOverride(oldPrefix, oldNodeLabels, resource)
 		}

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -638,7 +638,7 @@ func loadOrGeneratePrivKey(filePath string) (key wgtypes.Key, err error) {
 
 // OnIPIdentityCacheChange implements ipcache.IPIdentityMappingListener
 func (a *Agent) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP,
-	_ *ipcache.Identity, _ ipcache.Identity, _ uint8, _ *ipcache.K8sMetadata) {
+	_ *ipcache.Identity, _ ipcache.Identity, _ uint8, _ *ipcache.K8sMetadata, _ uint8) {
 	ipnet := cidrCluster.AsIPNet()
 
 	// This function is invoked from the IPCache with the


### PR DESCRIPTION
This PR fixes DSR dispatch with Geneve to hostNetworked pods by ensuring tunnel_endpoint is always populated in ipcache, even for directly reachable endpoints. Unneeded encapsulation is avoided by passing the skiptunnel flag for such endpoints.

Fixes: #36901