### PR TITLE
make: Don't hide install errors

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -210,7 +210,7 @@ kind-install-cilium-fast: check_deps kind-ready ## "Fast" Install a local Cilium
 		$(CILIUM_CLI) install --context=kind-$$cluster_name \
 			--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
 			$(KIND_VALUES_FAST_FILES) \
-			--version= >/dev/null 2>&1 & \
+			--version= >/dev/null ; \
 	done
 
 .PHONY: build-cli


### PR DESCRIPTION
The make "kind-install-cilium-fast" target was previously hiding all
errors and running installs in the background. As soon as any sort of
error is introduced into the install process, this means that developers
attempting to make those changes will get weird failing behavior without
any sort of feedback about why this part of the process is working.

Ensure that stderr is printed to the shell and avoid running multiple
clustermeshes in parallel.
