### PR TITLE
connectivity: Add L7 combined ingress and egress policy test

### DIFF
--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -241,6 +241,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		clusterMeshEndpointSliceSync{},
 		health{},
 		northSouthLoadbalancing{},
+		podToPodL7{},
 		podToPodEncryption{},
 		nodeToNodeEncryption{},
 		egressGateway{},

--- a/cilium-cli/connectivity/builder/pod_to_pod_l7.go
+++ b/cilium-cli/connectivity/builder/pod_to_pod_l7.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type podToPodL7 struct{}
+
+func (t podToPodL7) build(ct *check.ConnectivityTest, templates map[string]string) {
+	newTest("pod-to-pod-with-ingress-egress-l7", ct).
+		WithCondition(func() bool { return !ct.Params().SingleNode }).
+		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithCiliumPolicy(templates["clientEgressL7HTTPPolicyYAML"]).
+		WithCiliumPolicy(echoIngressL7HTTPPolicyYAML).
+		WithScenarios(tests.PodToPod()).
+		WithExpectations(expectation)
+}


### PR DESCRIPTION
Currently, we don't have any test to cover both egress and ingress L7 polices together without encryption.

Suggested-by: Simone Magnani <simone.magnani@isovalent.com>
Suggested-by: gray <greyschwinger@gmail.com>


