### PR TITLE
v1.14 Backports 2025-01-15

### DIFF
--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -274,7 +274,7 @@ jobs:
               --boot-disk-type pd-standard \
               --boot-disk-size 10GB \
               --image-project ubuntu-os-cloud \
-              --image-family ubuntu-2004-lts \
+              --image-family ubuntu-2404-lts-amd64 \
               --metadata hostname=${{ env.vmName }}-${{ matrix.vmIndex }} \
               --metadata-from-file startup-script=${{ env.vmStartupScript}}
 

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -388,7 +388,7 @@ jobs:
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
         shell: bash
         run: |
-          CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
+          CILIUM_CLI_MODE=helm ./cilium-cli upgrade --reset-values=true \
             ${{ steps.cilium-newest-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}
 
@@ -419,7 +419,7 @@ jobs:
         if: ${{ steps.vars.outputs.downgrade_version != '' }}
         shell: bash
         run: |
-          CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
+          CILIUM_CLI_MODE=helm ./cilium-cli upgrade --reset-values=true \
             ${{ steps.cilium-stable-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}
 


### PR DESCRIPTION
 * [x] #36858 (@giorio94) :warning: resolved conflicts
 * [x] #36859 (@giorio94)
 * [x] #36917 (@gentoo-root) (empty commit, nothing to backport)
 
PRs skipped due to conflicts:

 * #31754 (@gentoo-root) (this was already backported, for some reason the needs-backport label was still in PR)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 36858 36859 36917
```
