### PR TITLE
Acknowledge different types of error from NotifyOnDNSMsg

### DIFF
--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -151,7 +151,7 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 					Answer: []ciliumdns.RR{&ciliumdns.A{
 						Hdr: ciliumdns.RR_Header{Name: dns.FQDN("cilium.io")},
 						A:   net.ParseIP("192.0.2.3"),
-					}}}, "udp", true, &dnsproxy.ProxyRequestContext{}))
+					}}}, "udp", true, &dnsproxy.ProxyRequestContext{}, &dnsproxy.NotifyOnDNSMsgContext{}))
 
 				require.NoError(b, ds.d.notifyOnDNSMsg(time.Now(), ep, "10.96.64.4:54321", 0, "10.96.64.1:53", &ciliumdns.Msg{
 					MsgHdr: ciliumdns.MsgHdr{
@@ -164,7 +164,7 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 					Answer: []ciliumdns.RR{&ciliumdns.A{
 						Hdr: ciliumdns.RR_Header{Name: dns.FQDN("ebpf.io")},
 						A:   net.ParseIP("192.0.2.4"),
-					}}}, "udp", true, &dnsproxy.ProxyRequestContext{}))
+					}}}, "udp", true, &dnsproxy.ProxyRequestContext{}, &dnsproxy.NotifyOnDNSMsgContext{}))
 			}()
 		}
 		wg.Wait()

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -122,7 +122,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 			}
 		},
 		// NotifyOnDNSMsg
-		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext) error {
+		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext, notifyOnDNSMsgContext *NotifyOnDNSMsgContext) error {
 			return nil
 		},
 	)


### PR DESCRIPTION
NotifyOnDNSMsg can send three types of error for each call from DNS proxy, i.e. `ErrTimeout`, `ErrNoEndpoint` and `ErrDNSMsgDetails`. This [commit](https://github.com/cilium/cilium/commit/b4542af78abaa13e439a9469f07389bb00ea8a16) introduced the acknowledgment of these error while processing the req/response in DNS prxoy and send refused if there is an error. This may not be true always. For example, during the timeout error in case of request, it be returned without forwarding the req further. The PR enhances the ability to either refuse the processing of msg further based on the type of dns msg and the response from the callback. Types of error:
- `ErrTimeout`: Proxy context timeout
- `ErrNoEndpoint`: Endpoint is nil
- `ErrDNSMsgDetails`: Error processing DNS Msg

| Type Of Msg |  ErrTimeout |  ErrNoEndpoint | ErrDNSMsgDetails  |
|---|---|---|---|
| Request  |  Return with warning log |  send refused | send refused  |
| Response  | Forward the response with warning log  |  send refused | send refused  |

Note: Planning to clean up the code as well by using the `NotifyOnDNSMsgContext` for encompassing all the other parameters sent to the callback. But will create a separate PR for that.