### PR TITLE
pkg/service: Increase maximum set Service IDs

### DIFF
--- a/pkg/service/const.go
+++ b/pkg/service/const.go
@@ -9,7 +9,7 @@ const (
 
 	// MaxSetOfServiceID is maximum number of set of service IDs that can be stored
 	// in the kvstore or the local ID allocator.
-	MaxSetOfServiceID = uint32(0xFFFF)
+	MaxSetOfServiceID = uint32(0xFFFFFF)
 
 	// FirstFreeBackendID is the first ID for which the backend should be assigned.
 	// BPF datapath assumes that backend_id cannot be 0.


### PR DESCRIPTION
In some large clusters with 65,535+ service ids across all services and ports, new services will not get added to Cilium's LB map due to a hard limit set here: https://github.com/cilium/cilium/blob/70c42143ed2ef93f3de16b7c217bc84ee52f2952/pkg/service/const.go#L12

The error shown in agent logs:
```
level=error msg="Error while inserting service in LB map" error="Unable to allocate service ID 0 for {{xxx.xxx.xxx.xxx {TCP 20261} 0} 0}: no service ID available" k8sNamespace==****** k8sSvcName=****** subsys=k8s-watcher.
```

This PR increases the max service IDs from 65,535 to 16,777,215 which has resolved the issue in my environment.

It seems this limit was last changed when it was implemented ~7 years ago, I am unsure if this is a proper fix for my issue or if there is an underlying problem that will require a bigger revisit.