### PR TITLE
cli: restrict conn test to ip families

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium/cilium-cli/sysdump"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -190,6 +191,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().DurationVar(&params.Timeout, "timeout", defaults.ConnectivityTestSuiteTimeout, "Maximum time to allow the connectivity test suite to take")
 
 	cmd.Flags().IntVar(&params.TestConcurrency, "test-concurrency", 1, "Count of namespaces to perform the connectivity tests in parallel (value <= 0 will be treated as 1)")
+	cmd.Flags().StringSliceVar(&params.IPFamilies, "ip-families", []string{features.IPFamilyV4.String(), features.IPFamilyV6.String()}, "Restrict test actions to specific IP families")
 
 	hooks.AddConnectivityTestFlags(cmd.Flags())
 

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -90,6 +90,7 @@ type Parameters struct {
 	JunitProperties        map[string]string
 	ImpersonateAs          string
 	ImpersonateGroups      []string
+	IPFamilies             []string
 
 	IncludeConnDisruptTest        bool
 	ConnDisruptTestSetup          bool

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -837,7 +837,7 @@ func (t *Test) collectSysdump() {
 }
 
 func (t *Test) ForEachIPFamily(do func(features.IPFamily)) {
-	ipFams := []features.IPFamily{features.IPFamilyV4, features.IPFamilyV6}
+	ipFams := features.GetIPFamilies(t.ctx.Params().IPFamilies)
 
 	// The per-endpoint routes feature is broken with IPv6 on < v1.14 when there
 	// are any netpols installed (https://github.com/cilium/cilium/issues/23852

--- a/cilium-cli/utils/features/utils.go
+++ b/cilium-cli/utils/features/utils.go
@@ -27,6 +27,27 @@ func (f IPFamily) String() string {
 	return "undefined"
 }
 
+// GetIPFamilies function converts string slice to IPFamily slice.
+func GetIPFamilies(families []string) []IPFamily {
+	ipFams := make([]IPFamily, 0, len(families))
+	for i := range families {
+		ipFams = append(ipFams, NewIPFamily(families[i]))
+	}
+	return ipFams
+}
+
+// NewIPFamily is a factory function that consumes string and returns IPFamily.
+func NewIPFamily(s string) IPFamily {
+	switch s {
+	case "ipv4":
+		return IPFamilyV4
+	case "ipv6":
+		return IPFamilyV6
+	default:
+		return IPFamilyAny
+	}
+}
+
 func GetIPFamily(addr string) IPFamily {
 	ip := net.ParseIP(addr)
 


### PR DESCRIPTION
The PR introduces a new input param for connectivity tests to restrict test actions to specific IP families.