### PR TITLE
fix: Change CNI CHECK Error Code from 1 to 101

### DIFF
--- a/plugins/cilium-cni/types/types.go
+++ b/plugins/cilium-cni/types/types.go
@@ -110,6 +110,6 @@ type Args struct{}
 // CNI error codes
 // (error codes 100+ are allowed for plugin use)
 const (
-	CniErrHealthzGet uint = 100
-	CniErrUnhealthy       = iota
+	CniErrHealthzGet uint = 100 + iota
+	CniErrUnhealthy
 )


### PR DESCRIPTION
Currently the CniErrUnhealthy error code returned by the cilium-cni CHECK operation is set to 1 instead of 101. This collides with the CNI well-known error code 1 which means "Incompatible CNI version". (see https://github.com/containernetworking/cni/blob/main/SPEC.md#error)

This commit fixes the issue by setting the error code to 101 and ensuring all future error codes in the list will also be 100+, which are codes allowed for plugin use.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!


