### PR TITLE
docs: pass current_version to html_context

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -199,7 +199,8 @@ googleanalytics_id = 'G-V9SYWYG92Y'
 html_theme = "sphinx_rtd_theme_cilium"
 
 html_context = {
-    'release': release
+    'release': release,
+    'current_version': os.environ.get('READTHEDOCS_VERSION')
 }
 
 # Set canonical URL from the Read the Docs Domain


### PR DESCRIPTION
This explicitly sets the current_version in conf.py. 

The current_version is used in the Algolia search filter to search only within the displayed documentation version, rather than across all versions. 

Here is the link to the specific line in the layout.html file of the sphinx_rtd_theme: repository: https://github.com/cilium/sphinx_rtd_theme/blob/cilium/rebase-2023-09/sphinx_rtd_theme/layout.html#L361

However, it seems that the readthedocs build no longer passes the current_version into the sphinx html_context. This is likely due to changes in the builder, as described here: https://github.com/readthedocs/sphinx-build-compatibility

As a result, the search functionality is currently broken.

<img width="1385" alt="Screenshot 2025-01-16 at 10 19 46" src="https://github.com/user-attachments/assets/a570a2ee-4dbb-4bec-b063-61b46491e952" />