### PR TITLE
connectivity: Add retry all error for L7 header related test

### DIFF
--- a/cilium-cli/connectivity/builder/client_egress_l7_set_header.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_set_header.go
@@ -42,8 +42,18 @@ func clientEgressL7SetHeaderTest(ct *check.ConnectivityTest, templates map[strin
 		}).
 		WithCiliumPolicy(templates[templateName]). // L7 allow policy with HTTP introspection (POST only)
 		WithScenarios(
-			tests.PodToPodWithEndpoints(tests.WithMethod("POST"), tests.WithPath("auth-header-required"), tests.WithDestinationLabelsOption(map[string]string{"other": "echo"})),
-			tests.PodToPodWithEndpoints(tests.WithMethod("POST"), tests.WithPath("auth-header-required"), tests.WithDestinationLabelsOption(map[string]string{"first": "echo"})),
+			tests.PodToPodWithEndpoints(
+				tests.WithMethod("POST"),
+				tests.WithPath("auth-header-required"),
+				tests.WithDestinationLabelsOption(map[string]string{"other": "echo"}),
+				tests.WithRetryCondition(tests.WithRetryAll()),
+			),
+			tests.PodToPodWithEndpoints(
+				tests.WithMethod("POST"),
+				tests.WithPath("auth-header-required"),
+				tests.WithDestinationLabelsOption(map[string]string{"first": "echo"}),
+				tests.WithRetryCondition(tests.WithRetryAll()),
+			),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Source().HasLabel("other", "client") && // Only client2 has the header policy.

--- a/cilium-cli/connectivity/tests/common.go
+++ b/cilium-cli/connectivity/tests/common.go
@@ -21,6 +21,7 @@ type labelsOption struct {
 	destinationLabels map[string]string
 	method            string
 	path              string
+	retryCondition    []RetryOption
 }
 
 func WithMethod(method string) Option {
@@ -44,6 +45,12 @@ func WithDestinationLabelsOption(destinationLabels map[string]string) Option {
 func WithPath(path string) Option {
 	return func(option *labelsOption) {
 		option.path = path
+	}
+}
+
+func WithRetryCondition(retryCondition ...RetryOption) Option {
+	return func(option *labelsOption) {
+		option.retryCondition = retryCondition
 	}
 }
 


### PR DESCRIPTION
### Description

This is to cater for the case that SDS secret is ingested later when the
curl request is sent, applicable when secret-backend-k8s is enabled.

Fixes: #36998
Relates: #35513
Signed-off-by: Tam Mach <tam.mach@cilium.io>

### Testing

Testing is done via the temp commit as per below

https://github.com/cilium/cilium/actions/runs/12806785932/job/35705984212?pr=37010

```diff
Subject: [PATCH] gha: Run client-egress-l7-set-header-port-range repeatedly
---
Index: .github/workflows/conformance-kind-proxy-embedded.yaml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/.github/workflows/conformance-kind-proxy-embedded.yaml b/.github/workflows/conformance-kind-proxy-embedded.yaml
--- a/.github/workflows/conformance-kind-proxy-embedded.yaml	(revision e93f01819b8de2674ac969072c31b36ff9d369af)
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml	(revision 0c144d523be66c09081c215339d6f485b27d55cd)
@@ -27,7 +27,7 @@
   installation-and-connectivity:
     name: "Installation and Connectivity Test"
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 120
     env:
       job_name: "Installation and Connectivity Test"
     steps:
@@ -113,6 +113,21 @@
             --curl-parallel 3 \
             --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
 
+      - name: Run one test repeatedly
+        run: |
+          for i in {1..30}
+          do
+            kubectl -n kube-system rollout restart ds/cilium
+            cilium status --wait
+
+            echo "Running Cilium connectivity test iteration $i"
+            cilium connectivity test --test "client-egress-l7-set-header-port-range" -v --force-deploy
+            if [ $? -ne 0 ]; then
+              echo "Cilium connectivity test failed on iteration $i"
+              exit 1
+            fi
+          done
+
       - name: Features tested
         uses: ./.github/actions/feature-status
         with:
```