### PR TITLE
cilium-cli: collect logs from crashing Cilium Agent pods

### DIFF
--- a/cilium-cli/sysdump/defaults.go
+++ b/cilium-cli/sysdump/defaults.go
@@ -19,6 +19,7 @@ const (
 	DefaultCiliumNodeInitLabelSelector       = "app=cilium-node-init"
 	DefaultCiliumSpireAgentLabelSelector     = "app=spire-agent"
 	DefaultCiliumSpireServerLabelSelector    = "app=spire-server"
+	DefaultCollectLogsFromNotReadyAgents     = true
 	DefaultDebug                             = false
 	DefaultProfiling                         = true
 	DefaultTracing                           = false


### PR DESCRIPTION
In case some of the agents in the cluster are crashing, are in not
ready state or with container restarts, let's collect their logs as well.
This works even if node filter doesn't select nodes running such agents.

```release-note
cilium-cli: collect Cilium Agent logs from crashing / not ready / restarted pods
```
