### PR TITLE
[v1.15] envoy: Demote expected initial fetch timeout warning to info level

### DIFF
--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -259,6 +259,11 @@ func newEnvoyLogPiper() io.WriteCloser {
 				if !tracing && strings.Contains(msg, "message 'envoy.extensions.bootstrap.internal_listener.v3.InternalListener' is contained in proto file 'envoy/extensions/bootstrap/internal_listener/v3/internal_listener.proto' marked as work-in-progress.") {
 					continue
 				}
+				// Demote expected warnings to info level
+				if strings.Contains(msg, "gRPC config: initial fetch timed out for") {
+					scopedLog.Info(msg)
+					continue
+				}
 				scopedLog.Warn(msg)
 			case "info":
 				scopedLog.Info(msg)


### PR DESCRIPTION
[upstream 8f6fe610623b4bbfd7d1ad73f2a339a40c9f0f7d]

Demote the expected initial fetch timeout warning due to Cilium Agent delaying serving resources until endpoints have regenerated.