### PR TITLE
[v1.14] envoy: Demote expected initial fetch timeout warning to info level

### DIFF
--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -256,6 +256,11 @@ func newEnvoyLogPiper() io.WriteCloser {
 				if !flowdebug.Enabled() && strings.Contains(msg, "Unable to use runtime singleton for feature envoy.http.headermap.lazy_map_min_size") {
 					continue
 				}
+				// Demote expected warnings to info level
+				if strings.Contains(msg, "gRPC config: initial fetch timed out for") {
+					scopedLog.Info(msg)
+					continue
+				}
 				scopedLog.Warn(msg)
 			case "info":
 				scopedLog.Info(msg)


### PR DESCRIPTION
[upstream 8f6fe610623b4bbfd7d1ad73f2a339a40c9f0f7d]

Demote the expected initial fetch timeout warning due to Cilium Agent delaying serving resources until endpoints have regenerated.
