### PR TITLE
operator/pkg/lbipam: Remove `_total` suffix from non-counter metrics

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -757,11 +757,11 @@ LB-IPAM
 ======================================== ================================================================= ========== ========================================================
 Name                                     Labels                                                            Default    Description
 ======================================== ================================================================= ========== ========================================================
-``lbipam_conflicting_pools_total``                                                                         Enabled    Number of conflicting pools
-``lbipam_ips_available_total``           ``pool``                                                          Enabled    Number of available IPs per pool
-``lbipam_ips_used_total``                ``pool``                                                          Enabled    Number of used IPs per pool
-``lbipam_services_matching_total``                                                                         Enabled    Number of matching services
-``lbipam_services_unsatisfied_total``                                                                      Enabled    Number of services which did not get requested IPs
+``lbipam_conflicting_pools``                                                                               Enabled    Number of conflicting pools
+``lbipam_ips_available``                 ``pool``                                                          Enabled    Number of available IPs per pool
+``lbipam_ips_used``                      ``pool``                                                          Enabled    Number of used IPs per pool
+``lbipam_services_matching``                                                                               Enabled    Number of matching services
+``lbipam_services_unsatisfied``                                                                            Enabled    Number of services which did not get requested IPs
 ======================================== ================================================================= ========== ========================================================
 
 Controllers

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -439,6 +439,11 @@ has been renamed from ``envoy_cilium_policymap_<node-ip>_<node-id>_`` to ``envoy
 * ``doublewrite_identity_kvstore_total_count`` has been renamed to ``doublewrite_identity_kvstore_total``
 * ``doublewrite_identity_crd_only_count`` has been renamed to ``doublewrite_identity_crd_only_total``
 * ``doublewrite_identity_kvstore_only_count`` has been renamed to ``doublewrite_identity_kvstore_only_total``
+* ``lbipam_conflicting_pools_total`` has been renamed to ``lbipam_conflicting_pools``
+* ``lbipam_ips_available_total`` has been renamed to ``lbipam_ips_available``
+* ``lbipam_ips_used_total`` has been renamed to ``lbipam_ips_used``
+* ``lbipam_services_matching_total`` has been renamed to ``lbipam_services_matching``
+* ``lbipam_services_unsatisfied_total`` has been renamed to ``lbipam_services_unsatisfied``
 
 Deprecated Metrics
 ~~~~~~~~~~~~~~~~~~

--- a/operator/pkg/lbipam/metrics.go
+++ b/operator/pkg/lbipam/metrics.go
@@ -19,38 +19,38 @@ type ipamMetrics struct {
 func newMetrics() *ipamMetrics {
 	return &ipamMetrics{
 		ConflictingPools: metric.NewGauge(metric.GaugeOpts{
-			ConfigName: metrics.Namespace + "_lbipam_conflicting_pools_total",
+			ConfigName: metrics.Namespace + "_lbipam_conflicting_pools",
 			Namespace:  metrics.Namespace,
 			Subsystem:  "lbipam",
-			Name:       "conflicting_pools_total",
+			Name:       "conflicting_pools",
 			Help:       "The number of conflicting pools",
 		}),
 		AvailableIPs: metric.NewGaugeVec(metric.GaugeOpts{
-			ConfigName: metrics.Namespace + "_lbipam_ips_available_total",
+			ConfigName: metrics.Namespace + "_lbipam_ips_available",
 			Namespace:  metrics.Namespace,
 			Subsystem:  "lbipam",
-			Name:       "ips_available_total",
+			Name:       "ips_available",
 			Help:       "The number of IP addresses available in a given pool",
 		}, []string{"pool"}),
 		UsedIPs: metric.NewGaugeVec(metric.GaugeOpts{
-			ConfigName: metrics.Namespace + "_lbipam_ips_used_total",
+			ConfigName: metrics.Namespace + "_lbipam_ips_used",
 			Namespace:  metrics.Namespace,
 			Subsystem:  "lbipam",
-			Name:       "ips_used_total",
+			Name:       "ips_used",
 			Help:       "The number of IP addresses used in a given pool",
 		}, []string{"pool"}),
 		MatchingServices: metric.NewGauge(metric.GaugeOpts{
-			ConfigName: metrics.Namespace + "_lbipam_services_matching_total",
+			ConfigName: metrics.Namespace + "_lbipam_services_matching",
 			Namespace:  metrics.Namespace,
 			Subsystem:  "lbipam",
-			Name:       "services_matching_total",
+			Name:       "services_matching",
 			Help:       "The number of services matching pools",
 		}),
 		UnsatisfiedServices: metric.NewGauge(metric.GaugeOpts{
-			ConfigName: metrics.Namespace + "_lbipam_services_unsatisfied_total",
+			ConfigName: metrics.Namespace + "_lbipam_services_unsatisfied",
 			Namespace:  metrics.Namespace,
 			Subsystem:  "lbipam",
-			Name:       "services_unsatisfied_total",
+			Name:       "services_unsatisfied",
 			Help:       "The number of services which did not receive all requested IPs",
 		}),
 	}


### PR DESCRIPTION
This PR removes the `_total` suffix from non-counter metrics of LB-IPAM.

Fixes: #36581

```release-note
Remove `_total` suffix from non-counter LB-IPAM metrics
```
