### PR TITLE
Cilium CLI IPsec fixes

### DIFF
--- a/cilium-cli/cli/encrypt.go
+++ b/cilium-cli/cli/encrypt.go
@@ -70,8 +70,6 @@ func newCmdIPsecRotateKey() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&params.IPsecKeyAuthAlgo, "auth-algo", "", "", "IPsec key authentication algorithm (optional parameter, if omitted the current settings will be used). One of: gcm-aes, hmac-sha256, hmac-sha512")
-	cmd.Flags().StringVarP(&params.IPsecKeyPerNode, "key-per-node", "", "", "IPsec key per cluster node (optional parameter, if omitted the current settings will be used). One of: true, false")
-	_ = cmd.Flags().MarkHidden("key-per-node")
 	cmd.Flags().DurationVar(&params.WaitDuration, "wait-duration", 1*time.Minute, "Maximum time to wait for result, default 1 minute")
 	return cmd
 }
@@ -98,11 +96,6 @@ func newCmdIPsecKeyStatus() *cobra.Command {
 }
 
 func checkParams(params encrypt.Parameters) error {
-	switch params.IPsecKeyPerNode {
-	case "", "true", "false":
-	default:
-		return fmt.Errorf("key-per-node has invalid value: %s", params.IPsecKeyPerNode)
-	}
 	if !encrypt.IsIPsecAlgoSupported(params.IPsecKeyAuthAlgo) {
 		return fmt.Errorf("auth-algo has invalid value: %s", params.IPsecKeyAuthAlgo)
 	}

--- a/cilium-cli/encrypt/encrypt.go
+++ b/cilium-cli/encrypt/encrypt.go
@@ -22,7 +22,6 @@ type Parameters struct {
 	NodeName         string
 	PerNodeDetails   bool
 	IPsecKeyAuthAlgo string
-	IPsecKeyPerNode  string
 	Writer           io.Writer
 	WaitDuration     time.Duration
 	Output           string

--- a/cilium-cli/encrypt/ipsec_key_rotator.go
+++ b/cilium-cli/encrypt/ipsec_key_rotator.go
@@ -25,11 +25,10 @@ func newGcmAesKey(key ipsecKey) (ipsecKey, error) {
 		return ipsecKey{}, err
 	}
 	newKey := ipsecKey{
-		spi:       key.nextSPI(),
-		spiSuffix: key.spiSuffix,
-		algo:      "rfc4106(gcm(aes))",
-		key:       authKey,
-		size:      128,
+		spi:  key.nextSPI(),
+		algo: "rfc4106(gcm(aes))",
+		key:  authKey,
+		size: 128,
 	}
 	return newKey, nil
 }
@@ -53,7 +52,6 @@ func newCbcAesKey(key ipsecKey, algo string, authKeylen int, cipherKeyLen int) (
 	}
 	newKey := ipsecKey{
 		spi:        key.nextSPI(),
-		spiSuffix:  key.spiSuffix,
 		algo:       algo,
 		key:        authKey,
 		cipherMode: "cbc(aes)",

--- a/cilium-cli/encrypt/ipsec_key_rotator_test.go
+++ b/cilium-cli/encrypt/ipsec_key_rotator_test.go
@@ -53,76 +53,37 @@ func Test_rotateIPsecKey(t *testing.T) {
 		{
 			haveAlgo: "",
 			haveKey: ipsecKey{
-				spi:       3,
-				spiSuffix: false,
-				algo:      "rfc4106(gcm(aes))",
-				key:       "41049390e1e2b5d6543901daab6435f4042155fe",
-				size:      128,
+				spi:  3,
+				algo: "rfc4106(gcm(aes))",
+				key:  "41049390e1e2b5d6543901daab6435f4042155fe",
+				size: 128,
 			},
 			expected: ipsecKey{
-				spi:       4,
-				spiSuffix: false,
-				algo:      "rfc4106(gcm(aes))",
-				key:       "41049390e1e2b5d6543901daab6435f4042155fe",
-				size:      128,
+				spi:  4,
+				algo: "rfc4106(gcm(aes))",
+				key:  "41049390e1e2b5d6543901daab6435f4042155fe",
+				size: 128,
 			},
 		},
 		{
 			haveAlgo: "",
 			haveKey: ipsecKey{
-				spi:       16,
-				spiSuffix: false,
-				algo:      "rfc4106(gcm(aes))",
-				key:       "41049390e1e2b5d6543901daab6435f4042155fe",
-				size:      128,
+				spi:  16,
+				algo: "rfc4106(gcm(aes))",
+				key:  "41049390e1e2b5d6543901daab6435f4042155fe",
+				size: 128,
 			},
 			expected: ipsecKey{
-				spi:       1,
-				spiSuffix: false,
-				algo:      "rfc4106(gcm(aes))",
-				key:       "41049390e1e2b5d6543901daab6435f4042155fe",
-				size:      128,
-			},
-		},
-		{
-			haveAlgo: "",
-			haveKey: ipsecKey{
-				spi:       3,
-				spiSuffix: true,
-				algo:      "rfc4106(gcm(aes))",
-				key:       "41049390e1e2b5d6543901daab6435f4042155fe",
-				size:      128,
-			},
-			expected: ipsecKey{
-				spi:       4,
-				spiSuffix: true,
-				algo:      "rfc4106(gcm(aes))",
-				key:       "41049390e1e2b5d6543901daab6435f4042155fe",
-				size:      128,
-			},
-		},
-		{
-			haveAlgo: "",
-			haveKey: ipsecKey{
-				spi:       16,
-				spiSuffix: true,
-				algo:      "rfc4106(gcm(aes))",
-				key:       "41049390e1e2b5d6543901daab6435f4042155fe",
-				size:      128,
-			},
-			expected: ipsecKey{
-				spi:       1,
-				spiSuffix: true,
-				algo:      "rfc4106(gcm(aes))",
-				key:       "41049390e1e2b5d6543901daab6435f4042155fe",
-				size:      128,
+				spi:  1,
+				algo: "rfc4106(gcm(aes))",
+				key:  "41049390e1e2b5d6543901daab6435f4042155fe",
+				size: 128,
 			},
 		},
 		{
 			haveAlgo: "",
 			haveKey: ipsecKey{
 				spi:        3,
-				spiSuffix:  false,
 				algo:       "hmac(sha256)",
 				key:        "e6b4bab427cd37bb64b39cd66a8476a62963174b78bc544fb525f4c2f548342b",
 				cipherMode: "cbc(aes)",
@@ -130,7 +91,6 @@ func Test_rotateIPsecKey(t *testing.T) {
 			},
 			expected: ipsecKey{
 				spi:        4,
-				spiSuffix:  false,
 				algo:       "hmac(sha256)",
 				key:        "e6b4bab427cd37bb64b39cd66a8476a62963174b78bc544fb525f4c2f548342b",
 				cipherMode: "cbc(aes)",
@@ -141,7 +101,6 @@ func Test_rotateIPsecKey(t *testing.T) {
 			haveAlgo: "",
 			haveKey: ipsecKey{
 				spi:        16,
-				spiSuffix:  false,
 				algo:       "hmac(sha256)",
 				key:        "e6b4bab427cd37bb64b39cd66a8476a62963174b78bc544fb525f4c2f548342b",
 				cipherMode: "cbc(aes)",
@@ -149,45 +108,6 @@ func Test_rotateIPsecKey(t *testing.T) {
 			},
 			expected: ipsecKey{
 				spi:        1,
-				spiSuffix:  false,
-				algo:       "hmac(sha256)",
-				key:        "e6b4bab427cd37bb64b39cd66a8476a62963174b78bc544fb525f4c2f548342b",
-				cipherMode: "cbc(aes)",
-				cipherKey:  "0f12337d9ee75095ff21402dc98476f5f9107261073b70bb37747237d2691d3e",
-			},
-		},
-		{
-			haveAlgo: "",
-			haveKey: ipsecKey{
-				spi:        3,
-				spiSuffix:  true,
-				algo:       "hmac(sha256)",
-				key:        "e6b4bab427cd37bb64b39cd66a8476a62963174b78bc544fb525f4c2f548342b",
-				cipherMode: "cbc(aes)",
-				cipherKey:  "0f12337d9ee75095ff21402dc98476f5f9107261073b70bb37747237d2691d3e",
-			},
-			expected: ipsecKey{
-				spi:        4,
-				spiSuffix:  true,
-				algo:       "hmac(sha256)",
-				key:        "e6b4bab427cd37bb64b39cd66a8476a62963174b78bc544fb525f4c2f548342b",
-				cipherMode: "cbc(aes)",
-				cipherKey:  "0f12337d9ee75095ff21402dc98476f5f9107261073b70bb37747237d2691d3e",
-			},
-		},
-		{
-			haveAlgo: "",
-			haveKey: ipsecKey{
-				spi:        16,
-				spiSuffix:  true,
-				algo:       "hmac(sha256)",
-				key:        "e6b4bab427cd37bb64b39cd66a8476a62963174b78bc544fb525f4c2f548342b",
-				cipherMode: "cbc(aes)",
-				cipherKey:  "0f12337d9ee75095ff21402dc98476f5f9107261073b70bb37747237d2691d3e",
-			},
-			expected: ipsecKey{
-				spi:        1,
-				spiSuffix:  true,
 				algo:       "hmac(sha256)",
 				key:        "e6b4bab427cd37bb64b39cd66a8476a62963174b78bc544fb525f4c2f548342b",
 				cipherMode: "cbc(aes)",
@@ -197,26 +117,22 @@ func Test_rotateIPsecKey(t *testing.T) {
 		{
 			haveAlgo: "gcm-aes",
 			haveKey: ipsecKey{
-				spi:       16,
-				spiSuffix: true,
+				spi: 16,
 			},
 			expected: ipsecKey{
-				spi:       1,
-				spiSuffix: true,
-				algo:      "rfc4106(gcm(aes))",
-				key:       "41049390e1e2b5d6543901daab6435f4042155fe",
-				size:      128,
+				spi:  1,
+				algo: "rfc4106(gcm(aes))",
+				key:  "41049390e1e2b5d6543901daab6435f4042155fe",
+				size: 128,
 			},
 		},
 		{
 			haveAlgo: "hmac-sha256",
 			haveKey: ipsecKey{
-				spi:       3,
-				spiSuffix: true,
+				spi: 3,
 			},
 			expected: ipsecKey{
 				spi:        4,
-				spiSuffix:  true,
 				algo:       "hmac(sha256)",
 				key:        "a9d204b6c2df6f0b707bbfdb71b4bd44",
 				cipherMode: "cbc(aes)",
@@ -226,12 +142,10 @@ func Test_rotateIPsecKey(t *testing.T) {
 		{
 			haveAlgo: "hmac-sha512",
 			haveKey: ipsecKey{
-				spi:       4,
-				spiSuffix: true,
+				spi: 4,
 			},
 			expected: ipsecKey{
 				spi:        5,
-				spiSuffix:  true,
 				algo:       "hmac(sha512)",
 				key:        "8b4d92bf9396e7febb4d51e87394bb158ebcc0d9d57e4da8e938b0e931223ec7",
 				cipherMode: "cbc(aes)",
@@ -246,7 +160,6 @@ func Test_rotateIPsecKey(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, tt.expected.spi, actual.spi)
-		require.Equal(t, tt.expected.spiSuffix, actual.spiSuffix)
 		require.Equal(t, tt.expected.algo, actual.algo)
 		require.Equal(t, len(tt.expected.key), len(actual.key))
 		require.Equal(t, len(tt.expected.cipherKey), len(actual.cipherKey))

--- a/cilium-cli/encrypt/ipsec_rotate_key_test.go
+++ b/cilium-cli/encrypt/ipsec_rotate_key_test.go
@@ -15,42 +15,18 @@ func Test_ipsecKeyFromString(t *testing.T) {
 		expected ipsecKey
 	}{
 		{
-			have: "3 rfc4106(gcm(aes)) 41049390e1e2b5d6543901daab6435f4042155fe 128",
-			expected: ipsecKey{
-				spi:       3,
-				spiSuffix: false,
-				algo:      "rfc4106(gcm(aes))",
-				key:       "41049390e1e2b5d6543901daab6435f4042155fe",
-				size:      128,
-			},
-		},
-		{
 			have: "3+ rfc4106(gcm(aes)) 41049390e1e2b5d6543901daab6435f4042155fe 128",
 			expected: ipsecKey{
-				spi:       3,
-				spiSuffix: true,
-				algo:      "rfc4106(gcm(aes))",
-				key:       "41049390e1e2b5d6543901daab6435f4042155fe",
-				size:      128,
-			},
-		},
-		{
-			have: "3 hmac(sha256) e6b4bab427cd37bb64b39cd66a8476a62963174b78bc544fb525f4c2f548342b cbc(aes) 0f12337d9ee75095ff21402dc98476f5f9107261073b70bb37747237d2691d3e",
-			expected: ipsecKey{
-				spi:        3,
-				spiSuffix:  false,
-				algo:       "hmac(sha256)",
-				key:        "e6b4bab427cd37bb64b39cd66a8476a62963174b78bc544fb525f4c2f548342b",
-				size:       0,
-				cipherMode: "cbc(aes)",
-				cipherKey:  "0f12337d9ee75095ff21402dc98476f5f9107261073b70bb37747237d2691d3e",
+				spi:  3,
+				algo: "rfc4106(gcm(aes))",
+				key:  "41049390e1e2b5d6543901daab6435f4042155fe",
+				size: 128,
 			},
 		},
 		{
 			have: "3+ hmac(sha256) e6b4bab427cd37bb64b39cd66a8476a62963174b78bc544fb525f4c2f548342b cbc(aes) 0f12337d9ee75095ff21402dc98476f5f9107261073b70bb37747237d2691d3e",
 			expected: ipsecKey{
 				spi:        3,
-				spiSuffix:  true,
 				algo:       "hmac(sha256)",
 				key:        "e6b4bab427cd37bb64b39cd66a8476a62963174b78bc544fb525f4c2f548342b",
 				size:       0,
@@ -76,40 +52,16 @@ func Test_ipsecKey_String(t *testing.T) {
 	}{
 		{
 			have: ipsecKey{
-				spi:       3,
-				spiSuffix: false,
-				algo:      "rfc4106(gcm(aes))",
-				key:       "41049390e1e2b5d6543901daab6435f4042155fe",
-				size:      128,
-			},
-			expected: "3 rfc4106(gcm(aes)) 41049390e1e2b5d6543901daab6435f4042155fe 128",
-		},
-		{
-			have: ipsecKey{
-				spi:       3,
-				spiSuffix: true,
-				algo:      "rfc4106(gcm(aes))",
-				key:       "41049390e1e2b5d6543901daab6435f4042155fe",
-				size:      128,
+				spi:  3,
+				algo: "rfc4106(gcm(aes))",
+				key:  "41049390e1e2b5d6543901daab6435f4042155fe",
+				size: 128,
 			},
 			expected: "3+ rfc4106(gcm(aes)) 41049390e1e2b5d6543901daab6435f4042155fe 128",
 		},
 		{
 			have: ipsecKey{
 				spi:        3,
-				spiSuffix:  false,
-				algo:       "hmac(sha256)",
-				key:        "e6b4bab427cd37bb64b39cd66a8476a62963174b78bc544fb525f4c2f548342b",
-				size:       0,
-				cipherMode: "cbc(aes)",
-				cipherKey:  "0f12337d9ee75095ff21402dc98476f5f9107261073b70bb37747237d2691d3e",
-			},
-			expected: "3 hmac(sha256) e6b4bab427cd37bb64b39cd66a8476a62963174b78bc544fb525f4c2f548342b cbc(aes) 0f12337d9ee75095ff21402dc98476f5f9107261073b70bb37747237d2691d3e",
-		},
-		{
-			have: ipsecKey{
-				spi:        3,
-				spiSuffix:  true,
 				algo:       "hmac(sha256)",
 				key:        "e6b4bab427cd37bb64b39cd66a8476a62963174b78bc544fb525f4c2f548342b",
 				size:       0,

--- a/cilium-cli/encrypt/model.go
+++ b/cilium-cli/encrypt/model.go
@@ -13,7 +13,6 @@ type clusterStatus struct {
 	IPsecKeysInUseNodeCount    map[int64]int64  `json:"ipsec-keys-in-use-node-count,omitempty"`
 	IPsecMaxSeqNum             string           `json:"ipsec-max-seq-num,omitempty"`
 	IPsecErrCount              int64            `json:"ipsec-err-count,omitempty"`
-	IPsecPerNodeKey            bool             `json:"ipsec-per-node-key,omitempty"`
 	IPsecKeyRotationInProgress bool             `json:"ipsec-key-rotation-in-progress,omitempty"`
 	IPsecExpectedKeyCount      int              `json:"ipsec-expected-key-count,omitempty"`
 	XfrmErrors                 map[string]int64 `json:"xfrm-errors,omitempty"`
@@ -22,7 +21,6 @@ type clusterStatus struct {
 
 type nodeStatus struct {
 	models.EncryptionStatus
-	IPsecPerNodeKey            bool `json:"ipsec-per-node-key,omitempty"`
 	IPsecKeyRotationInProgress bool `json:"ipsec-key-rotation-in-progress,omitempty"`
 	IPsecExpectedKeyCount      int  `json:"ipsec-expected-key-count,omitempty"`
 }


### PR DESCRIPTION
Cilium CLI IPsec fixes:
1. `expectedIPsecKeyCount` function fixed according to [the rules from CI](https://github.com/cilium/cilium/blob/main/.github/actions/ipsec-key-rotate/action.yaml#L41C9-L52C27).
2. Make `key-per-node` param visible to users