### PR TITLE
bpf: host: clean up redundant check for ipcache match

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -408,8 +408,7 @@ skip_tunnel:
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
 					 info->sec_identity, true, false);
 
-	if (from_proxy &&
-	    (!info || !identity_is_cluster(info->sec_identity)))
+	if (from_proxy && !identity_is_cluster(info->sec_identity))
 		ctx->mark = MARK_MAGIC_PROXY_TO_WORLD;
 #endif /* ENABLE_IPSEC && !TUNNEL_MODE */
 
@@ -887,8 +886,7 @@ skip_tunnel:
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
 					 info->sec_identity, true, false);
 
-	if (from_proxy &&
-	    (!info || !identity_is_cluster(info->sec_identity)))
+	if (from_proxy && !identity_is_cluster(info->sec_identity))
 		ctx->mark = MARK_MAGIC_PROXY_TO_WORLD;
 #endif /* ENABLE_IPSEC && !TUNNEL_MODE */
 


### PR DESCRIPTION
There is a preceding check a few lines earlier for `!info`, which would have already dropped the packet if the ipcache lookup didn't return a result. Therefore we don't need to guard this subsequent access to `info`.