### PR TITLE
ci: Fix fetching tested features and uploading artifacts

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -282,6 +282,7 @@ jobs:
           mv ./linux-amd64/helm ./helm
 
       - name: Provision LVH VMs
+        id: provision-vh-vms
         uses: cilium/little-vm-helper@97c89f004bd0ab4caeacfe92ebc956e13e362e6b # v0.0.19
         with:
           test-name: datapath-conformance


### PR DESCRIPTION
Seems like we were never fetching features tested and thus failing to upload artifacts due to lack of `provision-vh-vms` id on v1.14 branch

Fixes: #36519

Failing runs: https://github.com/cilium/cilium/actions/workflows/conformance-ginkgo.yaml?query=branch%3Av1.14
Error:
```
Error: No artifacts found matching pattern 'features-tested-*'
```
Both steps `Prepare script to run inside lvm` and `Fetch features tested` were always skipped due to lack of this id.