### PR TITLE
policy: optimize mapstate rule labels

### DIFF
--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -106,7 +106,7 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 	dscu := &testpolicy.DummySelectorCacheUser{}
 	selectorsToAdd := api.FQDNSelectorSlice{ciliumIOSel, ciliumIOSelMatchPattern, ebpfIOSel}
 	for _, sel := range selectorsToAdd {
-		ds.d.policy.GetSelectorCache().AddFQDNSelector(dscu, nil, sel)
+		ds.d.policy.GetSelectorCache().AddFQDNSelector(dscu, policy.EmptyStringLabels, sel)
 	}
 
 	const nEndpoints int = 1024

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1094,7 +1094,7 @@ func (e *Endpoint) UpdateBandwidthPolicy(bwm dptypes.BandwidthManager, bandwidth
 // This function explicitly exported to be accessed by code outside of the
 // Cilium source code tree and for testing.
 func (e *Endpoint) GetRealizedPolicyRuleLabelsForKey(key policyTypes.Key) (
-	derivedFrom labels.LabelArrayList,
+	derivedFrom string,
 	revision uint64,
 	ok bool,
 ) {

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -335,7 +335,8 @@ func (obtained LabelArrayListMap) Equals(expected LabelArrayListMap) bool {
 func (e *Endpoint) GetDesiredPolicyRuleLabels() LabelArrayListMap {
 	desiredLabels := make(LabelArrayListMap)
 	for k := range e.desiredPolicy.Entries() {
-		desiredLabels[k], _ = e.desiredPolicy.GetRuleLabels(k)
+		strLbls, _ := e.desiredPolicy.GetRuleLabels(k)
+		desiredLabels[k] = labels.LabelArrayListFromString(strLbls)
 	}
 	return desiredLabels
 }

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -196,24 +196,24 @@ var (
 	}
 	testSelectorCache = policy.NewSelectorCache(IdentityCache)
 
-	wildcardCachedSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, api.WildcardEndpointSelector)
+	wildcardCachedSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, policy.EmptyStringLabels, api.WildcardEndpointSelector)
 
 	EndpointSelector1 = api.NewESFromLabels(
 		labels.NewLabel("app", "etcd", labels.LabelSourceK8s),
 	)
-	cachedSelector1, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, EndpointSelector1)
+	cachedSelector1, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, policy.EmptyStringLabels, EndpointSelector1)
 
 	// EndpointSelector1 with FromRequires("k8s:version=v2") folded in
 	RequiresV2Selector1 = api.NewESFromLabels(
 		labels.NewLabel("app", "etcd", labels.LabelSourceK8s),
 		labels.NewLabel("version", "v2", labels.LabelSourceK8s),
 	)
-	cachedRequiresV2Selector1, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, RequiresV2Selector1)
+	cachedRequiresV2Selector1, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, policy.EmptyStringLabels, RequiresV2Selector1)
 
 	EndpointSelector2 = api.NewESFromLabels(
 		labels.NewLabel("version", "v1", labels.LabelSourceK8s),
 	)
-	cachedSelector2, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, EndpointSelector2)
+	cachedSelector2, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, policy.EmptyStringLabels, EndpointSelector2)
 )
 
 var L7Rules12 = &policy.PerSelectorPolicy{L7Rules: api.L7Rules{HTTP: []api.PortRuleHTTP{*PortRuleHTTP1, *PortRuleHTTP2}}}

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -249,15 +249,15 @@ var (
 	testSelectorCache       = policy.NewSelectorCache(cacheAllocator.GetIdentityCache())
 	dummySelectorCacheUser  = &testpolicy.DummySelectorCacheUser{}
 	DstID1Selector          = api.NewESFromLabels(labels.ParseSelectLabel("k8s:Dst1=test"))
-	cachedDstID1Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, DstID1Selector)
+	cachedDstID1Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, policy.EmptyStringLabels, DstID1Selector)
 	DstID2Selector          = api.NewESFromLabels(labels.ParseSelectLabel("k8s:Dst2=test"))
-	cachedDstID2Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, DstID2Selector)
+	cachedDstID2Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, policy.EmptyStringLabels, DstID2Selector)
 	DstID3Selector          = api.NewESFromLabels(labels.ParseSelectLabel("k8s:Dst3=test"))
-	cachedDstID3Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, DstID3Selector)
+	cachedDstID3Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, policy.EmptyStringLabels, DstID3Selector)
 	DstID4Selector          = api.NewESFromLabels(labels.ParseSelectLabel("k8s:Dst4=test"))
-	cachedDstID4Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, DstID4Selector)
+	cachedDstID4Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, policy.EmptyStringLabels, DstID4Selector)
 
-	cachedWildcardSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, api.WildcardEndpointSelector)
+	cachedWildcardSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, policy.EmptyStringLabels, api.WildcardEndpointSelector)
 
 	epID1            = uint64(111)
 	epID2            = uint64(222)

--- a/pkg/hubble/parser/getters/getters.go
+++ b/pkg/hubble/parser/getters/getters.go
@@ -78,5 +78,5 @@ type EndpointInfo interface {
 	GetK8sNamespace() string
 	GetLabels() labels.Labels
 	GetPod() *slim_corev1.Pod
-	GetRealizedPolicyRuleLabelsForKey(key policyTypes.Key) (derivedFrom labels.LabelArrayList, revision uint64, ok bool)
+	GetRealizedPolicyRuleLabelsForKey(key policyTypes.Key) (derivedFrom string, revision uint64, ok bool)
 }

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -76,8 +76,8 @@ var (
 			if ip == localIP {
 				return &testutils.FakeEndpointInfo{
 					ID: uint64(localEP),
-					PolicyMap: map[policyTypes.Key]labels.LabelArrayList{
-						remotePolicyKey: fooBarLabel,
+					PolicyMap: map[policyTypes.Key]string{
+						remotePolicyKey: fooBarLabel.String(),
 					},
 					PolicyRevision: 1,
 				}, true
@@ -453,8 +453,8 @@ func TestDecodePolicyVerdictNotify(t *testing.T) {
 		PodName:      "xwing",
 		PodNamespace: "default",
 		Labels:       []string{"a", "b", "c"},
-		PolicyMap: map[policyTypes.Key]labels.LabelArrayList{
-			policyKey: {policyLabel},
+		PolicyMap: map[policyTypes.Key]string{
+			policyKey: labels.LabelArrayList{policyLabel}.String(),
 		},
 		PolicyRevision: 1,
 	}
@@ -708,8 +708,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 			if ip == localIP {
 				return &testutils.FakeEndpointInfo{
 					ID: uint64(localEP),
-					PolicyMap: map[policyTypes.Key]labels.LabelArrayList{
-						policyKey: policyLabel,
+					PolicyMap: map[policyTypes.Key]string{
+						policyKey: policyLabel.String(),
 					},
 					PolicyRevision: 1,
 				}, true
@@ -894,10 +894,11 @@ func TestDecodeTrafficDirection(t *testing.T) {
 
 	ep, ok := endpointGetter.GetEndpointInfo(localIP)
 	assert.True(t, ok)
-	lbls, rev, ok := ep.GetRealizedPolicyRuleLabelsForKey(
+	strLbls, rev, ok := ep.GetRealizedPolicyRuleLabelsForKey(
 		policy.KeyForDirection(directionFromProto(f.GetTrafficDirection())).
 			WithIdentity(identity.NumericIdentity(f.GetDestination().GetIdentity())))
 	assert.True(t, ok)
+	lbls := labels.LabelArrayListFromString(strLbls)
 	assert.Equal(t, lbls, policyLabel)
 	assert.Equal(t, uint64(1), rev)
 

--- a/pkg/hubble/testutils/fake.go
+++ b/pkg/hubble/testutils/fake.go
@@ -425,7 +425,7 @@ type FakeEndpointInfo struct {
 	Labels       []string
 	Pod          *slim_corev1.Pod
 
-	PolicyMap      map[policyTypes.Key]labels.LabelArrayList
+	PolicyMap      map[policyTypes.Key]string
 	PolicyRevision uint64
 }
 
@@ -460,7 +460,7 @@ func (e *FakeEndpointInfo) GetPod() *slim_corev1.Pod {
 }
 
 func (e *FakeEndpointInfo) GetRealizedPolicyRuleLabelsForKey(key policyTypes.Key) (
-	derivedFrom labels.LabelArrayList,
+	derivedFrom string,
 	revision uint64,
 	ok bool,
 ) {

--- a/pkg/labels/array.go
+++ b/pkg/labels/array.go
@@ -4,6 +4,7 @@
 package labels
 
 import (
+	"bytes"
 	"sort"
 	"strings"
 )
@@ -197,17 +198,48 @@ func (ls LabelArray) GetModel() []string {
 	return res
 }
 
-func (ls LabelArray) String() string {
-	var sb strings.Builder
+func LabelArrayFromString(str string) LabelArray {
+	// each LabelArray starts with '[' and ends with ']'
+	if len(str) > 2 && str[0] == '[' && str[len(str)-1] == ']' {
+		str = str[1 : len(str)-1] // remove brackets
+		labels := strings.Split(str, " ")
+		la := make(LabelArray, 0, len(labels))
+		for j := range labels {
+			la = append(la, ParseLabel(labels[j]))
+		}
+		if len(la) > 0 {
+			return la
+		}
+	}
+	return nil
+}
+
+func (ls LabelArray) BuildString(sb *strings.Builder) {
 	sb.WriteString("[")
 	for l := range ls {
 		if l > 0 {
 			sb.WriteString(" ")
 		}
-		sb.WriteString(ls[l].String())
+		ls[l].BuildString(sb)
 	}
 	sb.WriteString("]")
+}
+
+func (ls LabelArray) String() string {
+	var sb strings.Builder
+	ls.BuildString(&sb)
 	return sb.String()
+}
+
+func (ls LabelArray) BuildBytes(buf *bytes.Buffer) {
+	buf.WriteString("[")
+	for l := range ls {
+		if l > 0 {
+			buf.WriteString(" ")
+		}
+		ls[l].BuildBytes(buf)
+	}
+	buf.WriteString("]")
 }
 
 // StringMap converts LabelArray into map[string]string

--- a/pkg/labels/arraylist.go
+++ b/pkg/labels/arraylist.go
@@ -5,6 +5,7 @@ package labels
 
 import (
 	"bytes"
+	"iter"
 	"sort"
 	"strings"
 )
@@ -115,6 +116,27 @@ func LabelArrayListFromString(str string) (ls LabelArrayList) {
 		}
 	}
 	return ls
+}
+
+func ModelsFromLabelArrayListString(str string) iter.Seq[[]string] {
+	return func(yield func(labelArray []string) bool) {
+		// each LabelArray starts with '[' and ends with ']'
+		if len(str) > 2 && str[0] == '[' && str[len(str)-1] == ']' {
+			str = str[1 : len(str)-1] // remove first and last bracket
+			for {
+				i := strings.Index(str, "], [")
+				if i < 0 {
+					break
+				}
+				if !yield(strings.Split(str[:i], " ")) {
+					return
+				}
+				str = str[i+4:]
+			}
+			// last label array
+			yield(strings.Split(str, " "))
+		}
+	}
 }
 
 func (ls LabelArrayList) BuildBytes(buf *bytes.Buffer) {

--- a/pkg/labels/arraylist_test.go
+++ b/pkg/labels/arraylist_test.go
@@ -253,8 +253,15 @@ func TestLabelArrayListMergeSorted(t *testing.T) {
 
 		a = tc.a.DeepCopy().Sort()
 		b = tc.b.DeepCopy().Sort()
+		as := a.String()
+		bs := b.String()
+
 		a.MergeSorted(b)
 		require.EqualValues(t, tc.expected, a, tc.name+" MergeSorted")
 		require.EqualValues(t, a.Sort(), a, tc.name+" MergeSorted returned unsorted result")
+
+		as = MergeSortedLabelArrayListStrings(as, bs)
+		require.EqualValues(t, tc.expected.String(), as, tc.name+" MergeSortedLabelArrayListStrings")
+		require.EqualValues(t, a.Sort().String(), as, tc.name+" MergeSortedLabelArrayListStrings returned unsorted result")
 	}
 }

--- a/pkg/labels/arraylist_test.go
+++ b/pkg/labels/arraylist_test.go
@@ -163,6 +163,44 @@ func TestLabelArrayListSort(t *testing.T) {
 	require.EqualValues(t, expected2, list2.Sort())
 }
 
+func TestModelsFromLabelArrayListString(t *testing.T) {
+	arrayList := LabelArrayList{
+		nil,
+		{
+			NewLabel("aaa", "", LabelSourceReserved),
+		},
+		{
+			NewLabel("env", "devel", LabelSourceAny),
+		},
+		{
+			NewLabel("env", "devel", LabelSourceAny),
+			NewLabel("user", "bob", LabelSourceContainer),
+		},
+		{
+			NewLabel("env", "devel", LabelSourceAny),
+			NewLabel("user", "bob", LabelSourceContainer),
+			NewLabel("xyz", "", LabelSourceAny),
+		},
+		{
+			NewLabel("foo", "bar", LabelSourceAny),
+		},
+	}
+	expected := [][]string{
+		{""},
+		{"reserved:aaa"},
+		{"any:env=devel"},
+		{"any:env=devel", "container:user=bob"},
+		{"any:env=devel", "container:user=bob", "any:xyz"},
+		{"any:foo=bar"},
+	}
+
+	i := 0
+	for model := range ModelsFromLabelArrayListString(arrayList.String()) {
+		require.EqualValues(t, expected[i], model)
+		i++
+	}
+}
+
 func TestLabelArrayListMergeSorted(t *testing.T) {
 	list1 := LabelArrayList{
 		{

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -411,6 +411,26 @@ func (l *Label) String() string {
 	return l.Source + ":" + l.Key
 }
 
+func (l *Label) BuildString(sb *strings.Builder) {
+	sb.WriteString(l.Source)
+	sb.WriteString(":")
+	sb.WriteString(l.Key)
+	if len(l.Value) != 0 {
+		sb.WriteString("=")
+		sb.WriteString(l.Value)
+	}
+}
+
+func (l *Label) BuildBytes(buf *bytes.Buffer) {
+	buf.WriteString(l.Source)
+	buf.WriteString(":")
+	buf.WriteString(l.Key)
+	if len(l.Value) != 0 {
+		buf.WriteString("=")
+		buf.WriteString(l.Value)
+	}
+}
+
 // IsValid returns true if Key != "".
 func (l *Label) IsValid() bool {
 	return l.Key != ""

--- a/pkg/policy/correlation/correlation_test.go
+++ b/pkg/policy/correlation/correlation_test.go
@@ -68,8 +68,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		PodName:      "xwing",
 		PodNamespace: "default",
 		Labels:       []string{"a", "b", "c"},
-		PolicyMap: map[policy.Key]labels.LabelArrayList{
-			policyKey: {policyLabel},
+		PolicyMap: map[policy.Key]string{
+			policyKey: labels.LabelArrayList{policyLabel}.String(),
 		},
 		PolicyRevision: 1,
 	}
@@ -182,8 +182,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		PodName:      "xwing",
 		PodNamespace: "default",
 		Labels:       []string{"a", "b", "c"},
-		PolicyMap: map[policy.Key]labels.LabelArrayList{
-			policyKey: {policyLabel},
+		PolicyMap: map[policy.Key]string{
+			policyKey: labels.LabelArrayList{policyLabel}.String(),
 		},
 		PolicyRevision: 1,
 	}
@@ -205,8 +205,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		PodName:      "xwing",
 		PodNamespace: "default",
 		Labels:       []string{"a", "b", "c"},
-		PolicyMap: map[policy.Key]labels.LabelArrayList{
-			policyKey: {policyLabel},
+		PolicyMap: map[policy.Key]string{
+			policyKey: labels.LabelArrayList{policyLabel}.String(),
 		},
 		PolicyRevision: 1,
 	}
@@ -256,8 +256,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		PodName:      "xwing",
 		PodNamespace: "default",
 		Labels:       []string{"a", "b", "c"},
-		PolicyMap: map[policy.Key]labels.LabelArrayList{
-			policyKey: {policyLabel},
+		PolicyMap: map[policy.Key]string{
+			policyKey: labels.LabelArrayList{policyLabel}.String(),
 		},
 		PolicyRevision: 1,
 	}
@@ -307,8 +307,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		PodName:      "xwing",
 		PodNamespace: "default",
 		Labels:       []string{"a", "b", "c"},
-		PolicyMap: map[policy.Key]labels.LabelArrayList{
-			policyKey: {policyLabel},
+		PolicyMap: map[policy.Key]string{
+			policyKey: labels.LabelArrayList{policyLabel}.String(),
 		},
 		PolicyRevision: 1,
 	}
@@ -358,8 +358,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		PodName:      "xwing",
 		PodNamespace: "default",
 		Labels:       []string{"a", "b", "c"},
-		PolicyMap: map[policy.Key]labels.LabelArrayList{
-			policyKey: {policyLabel},
+		PolicyMap: map[policy.Key]string{
+			policyKey: labels.LabelArrayList{policyLabel}.String(),
 		},
 		PolicyRevision: 1,
 	}
@@ -410,8 +410,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		PodName:      "xwing",
 		PodNamespace: "default",
 		Labels:       []string{"a", "b", "c"},
-		PolicyMap: map[policy.Key]labels.LabelArrayList{
-			policyKey: {policyLabel},
+		PolicyMap: map[policy.Key]string{
+			policyKey: labels.LabelArrayList{policyLabel}.String(),
 		},
 		PolicyRevision: 1,
 	}
@@ -509,8 +509,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		PodName:      "xwing",
 		PodNamespace: "default",
 		Labels:       []string{"a", "b", "c"},
-		PolicyMap: map[policy.Key]labels.LabelArrayList{
-			policyKey: {policyLabel},
+		PolicyMap: map[policy.Key]string{
+			policyKey: labels.LabelArrayList{policyLabel}.String(),
 		},
 		PolicyRevision: 1,
 	}

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -1371,11 +1371,11 @@ var (
 
 	AllowEntry    = types.AllowEntry()
 	DenyEntry     = types.DenyEntry()
-	mapEntryDeny  = NewMapStateEntry(DenyEntry, labels.LabelArrayList{nil})
-	mapEntryAllow = NewMapStateEntry(AllowEntry, labels.LabelArrayList{nil})
+	mapEntryDeny  = NewMapStateEntry(DenyEntry).withLabels(labels.LabelArrayList{nil})
+	mapEntryAllow = NewMapStateEntry(AllowEntry).withLabels(labels.LabelArrayList{nil})
 
 	worldLabelArrayList         = labels.LabelArrayList{labels.LabelWorld.LabelArray()}
-	mapEntryWorldDenyWithLabels = NewMapStateEntry(DenyEntry, worldLabelArrayList)
+	mapEntryWorldDenyWithLabels = NewMapStateEntry(DenyEntry).withLabels(worldLabelArrayList)
 
 	worldIPIdentity = localIdentity(16324)
 	worldIPCIDR     = api.CIDR("192.0.2.3/32")

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -46,7 +46,7 @@ func FuzzDenyPreferredInsert(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		keys := emptyMapState()
 		key := Key{}
-		entry := NewMapStateEntry(types.AllowEntry(), nil)
+		entry := NewMapStateEntry(types.AllowEntry())
 		ff := fuzz.NewConsumer(data)
 		ff.GenerateStruct(&key)
 		ff.GenerateStruct(&entry)
@@ -84,7 +84,7 @@ func FuzzAccumulateMapChange(f *testing.F) {
 			proxyPort = 1
 		}
 		key := KeyForDirection(dir).WithPortProto(proto, port)
-		value := newMapStateEntry(nil, proxyPort, 0, deny, NoAuthRequirement)
+		value := newMapStateEntry(singleRuleOrigin(EmptyStringLabels), proxyPort, 0, deny, NoAuthRequirement)
 		policyMaps := MapChanges{}
 		policyMaps.AccumulateMapChanges(adds, deletes, []Key{key}, value)
 		policyMaps.SyncMapChanges(versioned.LatestTx)

--- a/pkg/policy/l4_filter_deny_test.go
+++ b/pkg/policy/l4_filter_deny_test.go
@@ -87,7 +87,7 @@ func TestMergeDenyAllL3(t *testing.T) {
 			td.wildcardCachedSelector: &PerSelectorPolicy{IsDeny: true},
 		},
 		Ingress:    true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	}})
 
 	require.EqualValues(t, expected, l4IngressDenyPolicy)
@@ -196,10 +196,10 @@ func TestL3DenyRuleShadowedByL3DenyAll(t *testing.T) {
 			td.wildcardCachedSelector: &PerSelectorPolicy{IsDeny: true},
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}})
 
 	state := traceState{}
@@ -265,10 +265,10 @@ func TestL3DenyRuleShadowedByL3DenyAll(t *testing.T) {
 			td.cachedSelectorA:        &PerSelectorPolicy{IsDeny: true},
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}})
 
 	state = traceState{}
@@ -338,10 +338,10 @@ func TestMergingWithDifferentEndpointSelectedDenyAllL7(t *testing.T) {
 			td.cachedSelectorC: &PerSelectorPolicy{IsDeny: true},
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA: {nil},
 			td.cachedSelectorC: {nil},
-		},
+		}),
 	}})
 
 	state := traceState{}
@@ -420,10 +420,10 @@ func TestL3AllowRuleShadowedByL3DenyAll(t *testing.T) {
 			td.wildcardCachedSelector: nil,
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}})
 
 	state := traceState{}
@@ -491,10 +491,10 @@ func TestL3AllowRuleShadowedByL3DenyAll(t *testing.T) {
 			td.wildcardCachedSelector: nil,
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}})
 
 	state = traceState{}
@@ -578,10 +578,10 @@ func TestL3L4AllowRuleWithByL3DenyAll(t *testing.T) {
 			},
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}})
 
 	state := traceState{}
@@ -659,10 +659,10 @@ func TestL3L4AllowRuleWithByL3DenyAll(t *testing.T) {
 			},
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}})
 
 	state = traceState{}

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -65,18 +65,18 @@ func newTestData() *testData {
 	td.testPolicyContext.sc = td.sc
 	td.repo.selectorCache = td.sc
 
-	td.wildcardCachedSelector, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, api.WildcardEndpointSelector)
+	td.wildcardCachedSelector, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, api.WildcardEndpointSelector)
 
-	td.cachedSelectorA, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, endpointSelectorA)
-	td.cachedSelectorB, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, endpointSelectorB)
-	td.cachedSelectorC, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, endpointSelectorC)
-	td.cachedSelectorHost, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, hostSelector)
+	td.cachedSelectorA, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, endpointSelectorA)
+	td.cachedSelectorB, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, endpointSelectorB)
+	td.cachedSelectorC, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, endpointSelectorC)
+	td.cachedSelectorHost, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, hostSelector)
 
-	td.cachedFooSelector, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, fooSelector)
-	td.cachedBazSelector, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, bazSelector)
+	td.cachedFooSelector, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, fooSelector)
+	td.cachedBazSelector, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, bazSelector)
 
-	td.cachedSelectorBar1, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, selBar1)
-	td.cachedSelectorBar2, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, selBar2)
+	td.cachedSelectorBar1, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, selBar1)
+	td.cachedSelectorBar2, _ = td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, selBar2)
 
 	return td
 }
@@ -348,7 +348,7 @@ func TestMergeAllowAllL3AndShadowedL7(t *testing.T) {
 			},
 		},
 		Ingress:    true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	}})
 
 	require.EqualValues(t, expected, res)
@@ -469,7 +469,7 @@ func TestMergeIdenticalAllowAllL3AndRestrictedL7HTTP(t *testing.T) {
 			},
 		},
 		Ingress:    true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	}})
 
 	buffer := new(bytes.Buffer)
@@ -557,7 +557,7 @@ func TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(t *testing.T) {
 			},
 		},
 		Ingress:    true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	}})
 
 	state := traceState{}
@@ -873,10 +873,10 @@ func TestMergeTLSTCPPolicy(t *testing.T) {
 			},
 		},
 		Ingress: false,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA: {nil},
 			td.cachedSelectorC: {nil},
-		},
+		}),
 	}})
 
 	require.EqualValues(t, expected, res)
@@ -975,10 +975,10 @@ func TestMergeTLSHTTPPolicy(t *testing.T) {
 			},
 		},
 		Ingress: false,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA: {nil},
 			td.cachedSelectorC: {nil},
-		},
+		}),
 	}})
 
 	require.EqualValues(t, expected, res)
@@ -1093,10 +1093,10 @@ func TestMergeTLSSNIPolicy(t *testing.T) {
 			},
 		},
 		Ingress: false,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA: {nil},
 			td.cachedSelectorC: {nil},
-		},
+		}),
 	}})
 
 	require.EqualValues(t, expected, res)
@@ -1231,10 +1231,10 @@ func TestMergeListenerPolicy(t *testing.T) {
 			},
 		},
 		Ingress: false,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA: {nil},
 			td.cachedSelectorC: {nil},
-		},
+		}),
 	}})
 
 	require.EqualValues(t, expected, res)
@@ -1313,10 +1313,10 @@ func TestMergeListenerPolicy(t *testing.T) {
 			},
 		},
 		Ingress: false,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA: {nil},
 			td.cachedSelectorC: {nil},
-		},
+		}),
 	}})
 
 	require.EqualValues(t, expected, res)
@@ -1396,10 +1396,10 @@ func TestMergeListenerPolicy(t *testing.T) {
 			},
 		},
 		Ingress: false,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA: {nil},
 			td.cachedSelectorC: {nil},
-		},
+		}),
 	}})
 
 	require.EqualValues(t, expected, res)
@@ -1459,10 +1459,10 @@ func TestL3RuleShadowedByL3AllowAll(t *testing.T) {
 			td.wildcardCachedSelector: nil,
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}})
 
 	state := traceState{}
@@ -1527,10 +1527,10 @@ func TestL3RuleShadowedByL3AllowAll(t *testing.T) {
 			td.cachedSelectorA:        nil,
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}})
 
 	state = traceState{}
@@ -1614,10 +1614,10 @@ func TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(t *testing.T) {
 			},
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}})
 
 	state := traceState{}
@@ -1694,10 +1694,10 @@ func TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(t *testing.T) {
 			},
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.wildcardCachedSelector: {nil},
 			td.cachedSelectorA:        {nil},
-		},
+		}),
 	}})
 
 	state = traceState{}
@@ -1792,10 +1792,10 @@ func TestL3RuleWithL7RuleShadowedByL3AllowAll(t *testing.T) {
 			},
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}})
 
 	state := traceState{}
@@ -1882,10 +1882,10 @@ func TestL3RuleWithL7RuleShadowedByL3AllowAll(t *testing.T) {
 			},
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}})
 
 	state = traceState{}
@@ -2093,10 +2093,10 @@ func TestMergingWithDifferentEndpointsSelectedAllowSameL7(t *testing.T) {
 			},
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA: {nil},
 			td.cachedSelectorC: {nil},
-		},
+		}),
 	}})
 
 	state := traceState{}
@@ -2169,10 +2169,10 @@ func TestMergingWithDifferentEndpointSelectedAllowAllL7(t *testing.T) {
 			td.cachedSelectorC: nil,
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorA: {nil},
 			td.cachedSelectorC: {nil},
-		},
+		}),
 	}})
 
 	state := traceState{}
@@ -2255,7 +2255,7 @@ func TestAllowingLocalhostShadowsL7(t *testing.T) {
 			td.cachedSelectorHost: nil, // no proxy redirect
 		},
 		Ingress:    true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	}})
 
 	state := traceState{}
@@ -2313,7 +2313,7 @@ func TestEntitiesL3(t *testing.T) {
 			td.wildcardCachedSelector: nil,
 		},
 		Ingress:    false,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	}})
 
 	state := traceState{}

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -150,7 +150,7 @@ func TestCreateL4Filter(t *testing.T) {
 		// Regardless of ingress/egress, we should end up with
 		// a single L7 rule whether the selector is wildcarded
 		// or if it is based on specific labels.
-		filter, err := createL4IngressFilter(td.testPolicyContext, eps, nil, nil, portrule, tuple, tuple.Protocol, nil)
+		filter, err := createL4IngressFilter(td.testPolicyContext, eps, nil, nil, portrule, tuple, tuple.Protocol, EmptyStringLabels)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, r := range filter.PerSelectorPolicies {
@@ -160,7 +160,7 @@ func TestCreateL4Filter(t *testing.T) {
 		}
 		require.Equal(t, redirectTypeEnvoy, filter.redirectType())
 
-		filter, err = createL4EgressFilter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol, nil, nil)
+		filter, err = createL4EgressFilter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol, EmptyStringLabels, nil)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, r := range filter.PerSelectorPolicies {
@@ -194,7 +194,7 @@ func TestCreateL4FilterAuthRequired(t *testing.T) {
 		// Regardless of ingress/egress, we should end up with
 		// a single L7 rule whether the selector is wildcarded
 		// or if it is based on specific labels.
-		filter, err := createL4IngressFilter(td.testPolicyContext, eps, auth, nil, portrule, tuple, tuple.Protocol, nil)
+		filter, err := createL4IngressFilter(td.testPolicyContext, eps, auth, nil, portrule, tuple, tuple.Protocol, EmptyStringLabels)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, r := range filter.PerSelectorPolicies {
@@ -204,7 +204,7 @@ func TestCreateL4FilterAuthRequired(t *testing.T) {
 		}
 		require.Equal(t, redirectTypeEnvoy, filter.redirectType())
 
-		filter, err = createL4EgressFilter(td.testPolicyContext, eps, auth, portrule, tuple, tuple.Protocol, nil, nil)
+		filter, err = createL4EgressFilter(td.testPolicyContext, eps, auth, portrule, tuple, tuple.Protocol, EmptyStringLabels, nil)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
 		for _, r := range filter.PerSelectorPolicies {
@@ -247,10 +247,10 @@ func TestCreateL4FilterMissingSecret(t *testing.T) {
 		// Regardless of ingress/egress, we should end up with
 		// a single L7 rule whether the selector is wildcarded
 		// or if it is based on specific labels.
-		_, err := createL4IngressFilter(td.testPolicyContext, eps, nil, nil, portrule, tuple, tuple.Protocol, nil)
+		_, err := createL4IngressFilter(td.testPolicyContext, eps, nil, nil, portrule, tuple, tuple.Protocol, EmptyStringLabels)
 		require.Error(t, err)
 
-		_, err = createL4EgressFilter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol, nil, nil)
+		_, err = createL4EgressFilter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol, EmptyStringLabels, nil)
 		require.Error(t, err)
 	}
 }

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -421,10 +421,6 @@ func NewMapStateEntry(e MapStateEntry) mapStateEntry {
 	}
 }
 
-func (e *mapStateEntry) GetRuleLabels() labels.LabelArrayList {
-	return labels.LabelArrayListFromString(e.derivedFromRules.Value())
-}
-
 func emptyMapState() mapState {
 	return newMapState(0)
 }

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -383,7 +383,7 @@ func (ms *mapState) lookup(key Key) (mapStateEntry, bool) {
 	}
 
 	// Deny by default if no matches are found
-	return mapStateEntry{MapStateEntry: types.DenyEntry()}, false
+	return mapStateEntry{MapStateEntry: types.DenyEntry(), derivedFromRules: NilRuleOrigin}, false
 }
 
 func (ms *mapState) Len() int {
@@ -396,6 +396,7 @@ type mapStateEntry struct {
 	MapStateEntry
 
 	// derivedFromRules tracks the policy rules this entry derives from.
+	// Must be initialized explicitly, zero-intialization does not work with unique.Handle[].
 	derivedFromRules ruleOrigin
 }
 
@@ -415,7 +416,8 @@ func newAllowEntryWithLabels(lbls labels.LabelArray) mapStateEntry {
 
 func NewMapStateEntry(e MapStateEntry) mapStateEntry {
 	return mapStateEntry{
-		MapStateEntry: e,
+		MapStateEntry:    e,
+		derivedFromRules: NilRuleOrigin,
 	}
 }
 

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -464,7 +464,7 @@ func (p *Repository) newRule(apiRule api.Rule, key ruleKey) *rule {
 		Rule: apiRule,
 		key:  key,
 	}
-	r.subjectSelector, _ = p.selectorCache.AddIdentitySelector(r, r.Labels, *r.getSelector())
+	r.subjectSelector, _ = p.selectorCache.AddIdentitySelector(r, makeStringLabels(r.Labels), *r.getSelector())
 	return r
 }
 

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -506,7 +506,7 @@ func TestWildcardL3RulesIngressDeny(t *testing.T) {
 				td.cachedSelectorBar1: &PerSelectorPolicy{IsDeny: true},
 			},
 			Ingress:    true,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL3}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL3}}),
 		},
 	})
 	require.EqualValues(t, expectedPolicy, policyDeny)
@@ -583,7 +583,7 @@ func TestWildcardL4RulesIngressDeny(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar1: &PerSelectorPolicy{IsDeny: true},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL4HTTP}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL4HTTP}}),
 		},
 		"9092/TCP": {
 			Port:     9092,
@@ -594,7 +594,7 @@ func TestWildcardL4RulesIngressDeny(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar1: &PerSelectorPolicy{IsDeny: true},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL4Kafka}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL4Kafka}}),
 		},
 	})
 	require.True(t, policyDeny.TestingOnlyEquals(expectedDenyPolicy), policyDeny.TestingOnlyDiff(expectedDenyPolicy))
@@ -652,7 +652,7 @@ func TestL3DependentL4IngressDenyFromRequires(t *testing.T) {
 			Values:   []string{"bar2"},
 		},
 	})
-	expectedCachedSelector, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, expectedSelector)
+	expectedCachedSelector, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, expectedSelector)
 
 	expectedDenyPolicy := NewL4PolicyMapWithValues(map[string]*L4Filter{
 		"80/TCP": {
@@ -663,7 +663,7 @@ func TestL3DependentL4IngressDenyFromRequires(t *testing.T) {
 				expectedCachedSelector: &PerSelectorPolicy{IsDeny: true},
 			},
 			Ingress:    true,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{expectedCachedSelector: {nil}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{expectedCachedSelector: {nil}}),
 		},
 	})
 	require.EqualValues(t, expectedDenyPolicy, policyDeny)
@@ -732,8 +732,8 @@ func TestL3DependentL4EgressDenyFromRequires(t *testing.T) {
 			Values:   []string{"bar2"},
 		},
 	})
-	expectedCachedSelector, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, expectedSelector)
-	expectedCachedSelector2, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, expectedSelector2)
+	expectedCachedSelector, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, makeStringLabels(nil), expectedSelector)
+	expectedCachedSelector2, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, makeStringLabels(nil), expectedSelector2)
 
 	expectedDenyPolicy := NewL4PolicyMapWithValues(map[string]*L4Filter{
 		"0/ANY": {
@@ -743,7 +743,7 @@ func TestL3DependentL4EgressDenyFromRequires(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				expectedCachedSelector2: &PerSelectorPolicy{IsDeny: true},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{expectedCachedSelector2: {nil}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{expectedCachedSelector2: {nil}}),
 		},
 		"80/TCP": {
 			Port:     80,
@@ -752,7 +752,7 @@ func TestL3DependentL4EgressDenyFromRequires(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				expectedCachedSelector: &PerSelectorPolicy{IsDeny: true},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{expectedCachedSelector: {nil}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{expectedCachedSelector: {nil}}),
 		},
 	})
 	if !assert.True(t, policyDeny.TestingOnlyEquals(expectedDenyPolicy), policyDeny.TestingOnlyDiff(expectedDenyPolicy)) {
@@ -858,7 +858,7 @@ func TestWildcardL3RulesEgressDeny(t *testing.T) {
 				td.cachedSelectorBar1: &PerSelectorPolicy{IsDeny: true},
 			},
 			Ingress:    false,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL4}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL4}}),
 		},
 		"8/ICMP": {
 			Port:     8,
@@ -869,7 +869,7 @@ func TestWildcardL3RulesEgressDeny(t *testing.T) {
 				td.cachedSelectorBar1: &PerSelectorPolicy{IsDeny: true},
 			},
 			Ingress:    false,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsICMP}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsICMP}}),
 		},
 		"128/ICMPV6": {
 			Port:     128,
@@ -880,7 +880,7 @@ func TestWildcardL3RulesEgressDeny(t *testing.T) {
 				td.cachedSelectorBar1: &PerSelectorPolicy{IsDeny: true},
 			},
 			Ingress:    false,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsICMPv6}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsICMPv6}}),
 		},
 	})
 	require.Truef(t, policyDeny.TestingOnlyEquals(expectedDenyPolicy),
@@ -961,7 +961,7 @@ func TestWildcardL4RulesEgressDeny(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar1: &PerSelectorPolicy{IsDeny: true},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL3HTTP}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL3HTTP}}),
 		},
 		"53/UDP": {
 			Port:     53,
@@ -972,7 +972,7 @@ func TestWildcardL4RulesEgressDeny(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar1: &PerSelectorPolicy{IsDeny: true},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL3DNS}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL3DNS}}),
 		},
 	})
 	if !assert.True(t, policyDeny.TestingOnlyEquals(expectedDenyPolicy), policyDeny.TestingOnlyDiff(expectedDenyPolicy)) {
@@ -993,7 +993,7 @@ func TestWildcardCIDRRulesEgressDeny(t *testing.T) {
 	cidrSelectors := cidrSlice.GetAsEndpointSelectors()
 	var cachedSelectors CachedSelectorSlice
 	for i := range cidrSelectors {
-		c, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, cidrSelectors[i])
+		c, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, cidrSelectors[i])
 		cachedSelectors = append(cachedSelectors, c)
 		defer td.sc.RemoveSelector(c, dummySelectorCacheUser)
 	}
@@ -1059,7 +1059,7 @@ func TestWildcardCIDRRulesEgressDeny(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				cachedSelectors[0]: &PerSelectorPolicy{IsDeny: true},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectors[0]: {labelsHTTP}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{cachedSelectors[0]: {labelsHTTP}}),
 		},
 		"0/ANY": {
 			Port:     0,
@@ -1070,7 +1070,7 @@ func TestWildcardCIDRRulesEgressDeny(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				cachedSelectors[0]: &PerSelectorPolicy{IsDeny: true},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectors[0]: {labelsL3}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{cachedSelectors[0]: {labelsL3}}),
 		},
 	})
 	if !assert.True(t, policyDeny.TestingOnlyEquals(expectedDenyPolicy), policyDeny.TestingOnlyDiff(expectedDenyPolicy)) {
@@ -1135,11 +1135,11 @@ func TestWildcardL3RulesIngressDenyFromEntities(t *testing.T) {
 				cachedSelectorWorldV6: &PerSelectorPolicy{IsDeny: true},
 			},
 			Ingress: true,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 				cachedSelectorWorld:   {labelsL3},
 				cachedSelectorWorldV4: {labelsL3},
 				cachedSelectorWorldV6: {labelsL3},
-			},
+			}),
 		},
 	})
 
@@ -1204,11 +1204,11 @@ func TestWildcardL3RulesEgressDenyToEntities(t *testing.T) {
 				cachedSelectorWorldV6: &PerSelectorPolicy{IsDeny: true},
 			},
 			Ingress: false,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 				cachedSelectorWorld:   {labelsL3},
 				cachedSelectorWorldV4: {labelsL3},
 				cachedSelectorWorldV6: {labelsL3},
-			},
+			}),
 		},
 	})
 
@@ -1300,7 +1300,7 @@ func TestMinikubeGettingStartedDeny(t *testing.T) {
 			cachedSelectorApp2: &PerSelectorPolicy{IsDeny: true},
 		},
 		Ingress:    true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectorApp2: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{cachedSelectorApp2: {nil}}),
 	})
 
 	if !assert.EqualValues(t, expectedDeny.Ingress.PortRules, l4IngressDenyPolicy) {

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -670,7 +670,7 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 				td.cachedSelectorBar1: nil,
 			},
 			Ingress:    true,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL3}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL3}}),
 		},
 		"8/ICMP": {
 			Port:     8,
@@ -680,7 +680,7 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 				td.cachedSelectorBar2: nil,
 			},
 			Ingress:    true,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsICMP}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsICMP}}),
 		},
 		"128/ICMPV6": {
 			Port:     128,
@@ -690,7 +690,7 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 				td.cachedSelectorBar2: nil,
 			},
 			Ingress:    true,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsICMPv6}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsICMPv6}}),
 		},
 		"9092/TCP": {
 			Port:     9092,
@@ -706,7 +706,7 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 					isRedirect: true,
 				},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsKafka}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsKafka}}),
 		},
 		"80/TCP": {
 			Port:     80,
@@ -722,7 +722,7 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 					isRedirect: true,
 				},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsHTTP}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsHTTP}}),
 		},
 		"9090/TCP": {
 			Port:     9090,
@@ -739,7 +739,7 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 					isRedirect: true,
 				},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsL7}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsL7}}),
 		},
 	})
 	require.True(t, policy.TestingOnlyEquals(expectedPolicy), policy.TestingOnlyDiff(expectedPolicy))
@@ -874,10 +874,10 @@ func TestWildcardL4RulesIngress(t *testing.T) {
 					isRedirect: true,
 				},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 				td.cachedSelectorBar1: {labelsL4HTTP},
 				td.cachedSelectorBar2: {labelsL7HTTP},
-			},
+			}),
 		},
 		"9092/TCP": {
 			Port:     9092,
@@ -894,10 +894,10 @@ func TestWildcardL4RulesIngress(t *testing.T) {
 					isRedirect: true,
 				},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 				td.cachedSelectorBar1: {labelsL4Kafka},
 				td.cachedSelectorBar2: {labelsL7Kafka},
-			},
+			}),
 		},
 	})
 	require.True(t, policy.TestingOnlyEquals(expectedPolicy), policy.TestingOnlyDiff(expectedPolicy))
@@ -955,7 +955,7 @@ func TestL3DependentL4IngressFromRequires(t *testing.T) {
 			Values:   []string{"bar2"},
 		},
 	})
-	expectedCachedSelector, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, expectedSelector)
+	expectedCachedSelector, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, expectedSelector)
 
 	expectedPolicy := NewL4PolicyMapWithValues(map[string]*L4Filter{
 		"80/TCP": {
@@ -966,9 +966,9 @@ func TestL3DependentL4IngressFromRequires(t *testing.T) {
 				expectedCachedSelector: nil,
 			},
 			Ingress: true,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 				expectedCachedSelector: {nil},
-			},
+			}),
 		},
 	})
 	require.Equal(t, expectedPolicy, policy)
@@ -1037,8 +1037,8 @@ func TestL3DependentL4EgressFromRequires(t *testing.T) {
 			Values:   []string{"bar2"},
 		},
 	})
-	expectedCachedSelector, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, expectedSelector)
-	expectedCachedSelector2, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, expectedSelector2)
+	expectedCachedSelector, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, expectedSelector)
+	expectedCachedSelector2, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, expectedSelector2)
 
 	expectedPolicy := NewL4PolicyMapWithValues(map[string]*L4Filter{
 		"0/ANY": {
@@ -1048,9 +1048,9 @@ func TestL3DependentL4EgressFromRequires(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				expectedCachedSelector2: nil,
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 				expectedCachedSelector2: {nil},
-			},
+			}),
 		},
 		"80/TCP": {
 			Port:     80,
@@ -1059,9 +1059,9 @@ func TestL3DependentL4EgressFromRequires(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				expectedCachedSelector: nil,
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 				expectedCachedSelector: {nil},
-			},
+			}),
 		},
 	})
 	if !assert.True(t, policy.TestingOnlyEquals(expectedPolicy), policy.TestingOnlyDiff(expectedPolicy)) {
@@ -1218,7 +1218,7 @@ func TestWildcardL3RulesEgress(t *testing.T) {
 					isRedirect: true,
 				},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsDNS}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsDNS}}),
 		},
 		"80/TCP": {
 			Port:     80,
@@ -1234,7 +1234,7 @@ func TestWildcardL3RulesEgress(t *testing.T) {
 					isRedirect: true,
 				},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsHTTP}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsHTTP}}),
 		},
 		"8/ICMP": {
 			Port:     8,
@@ -1244,7 +1244,7 @@ func TestWildcardL3RulesEgress(t *testing.T) {
 				td.cachedSelectorBar2: nil,
 			},
 			Ingress:    false,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsICMP}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsICMP}}),
 		},
 		"128/ICMPV6": {
 			Port:     128,
@@ -1254,7 +1254,7 @@ func TestWildcardL3RulesEgress(t *testing.T) {
 				td.cachedSelectorBar2: nil,
 			},
 			Ingress:    false,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsICMPv6}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsICMPv6}}),
 		},
 		"0/ANY": {
 			Port:     0,
@@ -1265,7 +1265,7 @@ func TestWildcardL3RulesEgress(t *testing.T) {
 				td.cachedSelectorBar1: nil,
 			},
 			Ingress:    false,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL4}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL4}}),
 		},
 	})
 	if !assert.True(t, policy.TestingOnlyEquals(expectedPolicy), policy.TestingOnlyDiff(expectedPolicy)) {
@@ -1406,10 +1406,10 @@ func TestWildcardL4RulesEgress(t *testing.T) {
 					isRedirect: true,
 				},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 				td.cachedSelectorBar1: {labelsL3HTTP},
 				td.cachedSelectorBar2: {labelsL7HTTP},
-			},
+			}),
 		},
 		"53/UDP": {
 			Port:     53,
@@ -1426,10 +1426,10 @@ func TestWildcardL4RulesEgress(t *testing.T) {
 					isRedirect: true,
 				},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 				td.cachedSelectorBar1: {labelsL3DNS},
 				td.cachedSelectorBar2: {labelsL7DNS},
-			},
+			}),
 		},
 	})
 	if !assert.True(t, policy.TestingOnlyEquals(expectedPolicy), policy.TestingOnlyDiff(expectedPolicy)) {
@@ -1450,7 +1450,7 @@ func TestWildcardCIDRRulesEgress(t *testing.T) {
 	cidrSelectors := cidrSlice.GetAsEndpointSelectors()
 	var cachedSelectors CachedSelectorSlice
 	for i := range cidrSelectors {
-		c, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, nil, cidrSelectors[i])
+		c, _ := td.sc.AddIdentitySelector(dummySelectorCacheUser, EmptyStringLabels, cidrSelectors[i])
 		cachedSelectors = append(cachedSelectors, c)
 		defer td.sc.RemoveSelector(c, dummySelectorCacheUser)
 	}
@@ -1535,7 +1535,7 @@ func TestWildcardCIDRRulesEgress(t *testing.T) {
 					isRedirect: true,
 				},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectors[0]: {labelsHTTP}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{cachedSelectors[0]: {labelsHTTP}}),
 		},
 		"0/ANY": {
 			Port:     0,
@@ -1546,7 +1546,7 @@ func TestWildcardCIDRRulesEgress(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				cachedSelectors[0]: nil,
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectors[0]: {labelsL3}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{cachedSelectors[0]: {labelsL3}}),
 		},
 	})
 	if !assert.True(t, policy.TestingOnlyEquals(expectedPolicy), policy.TestingOnlyDiff(expectedPolicy)) {
@@ -1664,11 +1664,11 @@ func TestWildcardL3RulesIngressFromEntities(t *testing.T) {
 				cachedSelectorWorldV6: nil,
 			},
 			Ingress: true,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 				cachedSelectorWorld:   {labelsL3},
 				cachedSelectorWorldV4: {labelsL3},
 				cachedSelectorWorldV6: {labelsL3},
-			},
+			}),
 		},
 		"9092/TCP": {
 			Port:     9092,
@@ -1684,7 +1684,7 @@ func TestWildcardL3RulesIngressFromEntities(t *testing.T) {
 					isRedirect: true,
 				},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsKafka}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsKafka}}),
 		},
 		"80/TCP": {
 			Port:     80,
@@ -1700,7 +1700,7 @@ func TestWildcardL3RulesIngressFromEntities(t *testing.T) {
 					isRedirect: true,
 				},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsHTTP}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsHTTP}}),
 		},
 	})
 
@@ -1816,11 +1816,11 @@ func TestWildcardL3RulesEgressToEntities(t *testing.T) {
 				cachedSelectorWorldV6: nil,
 			},
 			Ingress: false,
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 				cachedSelectorWorld:   {labelsL3},
 				cachedSelectorWorldV4: {labelsL3},
 				cachedSelectorWorldV6: {labelsL3},
-			},
+			}),
 		},
 		"53/UDP": {
 			Port:     53,
@@ -1836,7 +1836,7 @@ func TestWildcardL3RulesEgressToEntities(t *testing.T) {
 					isRedirect: true,
 				},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsDNS}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsDNS}}),
 		},
 		"80/TCP": {
 			Port:     80,
@@ -1852,7 +1852,7 @@ func TestWildcardL3RulesEgressToEntities(t *testing.T) {
 					isRedirect: true,
 				},
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsHTTP}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsHTTP}}),
 		},
 	})
 
@@ -1976,7 +1976,7 @@ func TestMinikubeGettingStarted(t *testing.T) {
 			},
 		},
 		Ingress:    true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{cachedSelectorApp2: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{cachedSelectorApp2: {nil}}),
 	})
 
 	if !assert.EqualValues(t, expected.Ingress.PortRules, l4IngressPolicy) {

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -113,7 +113,7 @@ func (p *EndpointPolicy) LookupRedirectPort(ingress bool, protocol string, port 
 // 'key' must not have a wildcard identity or port.
 func (p *EndpointPolicy) Lookup(key Key) (MapStateEntry, labels.LabelArrayList, bool) {
 	entry, found := p.policyMapState.lookup(key)
-	return entry.MapStateEntry, entry.derivedFromRules, found
+	return entry.MapStateEntry, entry.GetRuleLabels(), found
 }
 
 // PolicyOwner is anything which consumes a EndpointPolicy.

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -113,7 +113,8 @@ func (p *EndpointPolicy) LookupRedirectPort(ingress bool, protocol string, port 
 // 'key' must not have a wildcard identity or port.
 func (p *EndpointPolicy) Lookup(key Key) (MapStateEntry, labels.LabelArrayList, bool) {
 	entry, found := p.policyMapState.lookup(key)
-	return entry.MapStateEntry, entry.GetRuleLabels(), found
+	lbls := labels.LabelArrayListFromString(entry.derivedFromRules.Value())
+	return entry.MapStateEntry, lbls, found
 }
 
 // PolicyOwner is anything which consumes a EndpointPolicy.
@@ -245,13 +246,13 @@ var errMissingKey = errors.New("Key not found")
 
 // GetRuleLabels returns the list of labels of the rules that contributed
 // to the entry at this key.
-// The returned LabelArrayList is shallow-copied and therefore must not be mutated.
-func (p *EndpointPolicy) GetRuleLabels(k Key) (labels.LabelArrayList, error) {
+// The returned string is the string representation of a LabelArrayList.
+func (p *EndpointPolicy) GetRuleLabels(k Key) (string, error) {
 	entry, ok := p.policyMapState.get(k)
 	if !ok {
-		return nil, errMissingKey
+		return "", errMissingKey
 	}
-	return entry.GetRuleLabels(), nil
+	return entry.derivedFromRules.Value(), nil
 }
 
 func (p *EndpointPolicy) Entries() iter.Seq2[Key, MapStateEntry] {

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -262,7 +262,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 						PerSelectorPolicies: L7DataMap{
 							td.wildcardCachedSelector: &PerSelectorPolicy{IsDeny: true},
 						},
-						RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 					},
 				}),
 					features: denyRules,
@@ -357,7 +357,7 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 						PerSelectorPolicies: L7DataMap{
 							td.wildcardCachedSelector: &PerSelectorPolicy{IsDeny: true},
 						},
-						RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 					},
 				}),
 					features: denyRules,
@@ -452,7 +452,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 						PerSelectorPolicies: L7DataMap{
 							td.wildcardCachedSelector: &PerSelectorPolicy{IsDeny: true},
 						},
-						RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {ruleLabel}},
+						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {ruleLabel}}),
 					},
 				}),
 					features: denyRules,
@@ -611,12 +611,12 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 							cachedSelectorWorldV6: &PerSelectorPolicy{IsDeny: true},
 							cachedSelectorTest:    &PerSelectorPolicy{IsDeny: true},
 						},
-						RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 							cachedSelectorWorld:   {ruleLabel},
 							cachedSelectorWorldV4: {ruleLabel},
 							cachedSelectorWorldV6: {ruleLabel},
 							cachedSelectorTest:    {ruleLabel},
-						},
+						}),
 					},
 				}),
 					features: denyRules,

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -296,7 +296,7 @@ func TestL7WithIngressWildcard(t *testing.T) {
 								isRedirect:      true,
 							},
 						},
-						RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 					},
 				}),
 					features: redirectRules,
@@ -409,7 +409,7 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 							},
 							cachedSelectorHost: nil,
 						},
-						RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 					},
 				}),
 					features: redirectRules,
@@ -509,7 +509,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 						PerSelectorPolicies: L7DataMap{
 							td.wildcardCachedSelector: nil,
 						},
-						RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {ruleLabel}},
+						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {ruleLabel}}),
 					},
 				})},
 				Egress: newL4DirectionPolicy(),
@@ -675,12 +675,12 @@ func TestMapStateWithIngress(t *testing.T) {
 								CanShortCircuit: true,
 							},
 						},
-						RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 							cachedSelectorWorld:   {ruleLabel},
 							cachedSelectorWorldV4: {ruleLabel},
 							cachedSelectorWorldV6: {ruleLabel},
 							cachedSelectorTest:    {ruleLabel},
-						},
+						}),
 					},
 				}),
 					features: authRules,
@@ -846,7 +846,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					EgressPolicyEnabled:  true,
 				},
 				PolicyMapState: emptyMapState().withState(mapStateMap{
-					IngressKey(): NewMapStateEntry(DenyEntry, nil),
+					IngressKey(): NewMapStateEntry(DenyEntry),
 				}),
 			},
 			args: args{
@@ -863,7 +863,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					EgressPolicyEnabled:  true,
 				},
 				PolicyMapState: emptyMapState().withState(mapStateMap{
-					IngressKey(): NewMapStateEntry(DenyEntry, nil),
+					IngressKey(): NewMapStateEntry(DenyEntry),
 				}),
 			},
 			args: args{
@@ -880,7 +880,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					EgressPolicyEnabled:  true,
 				},
 				PolicyMapState: emptyMapState().withState(mapStateMap{
-					EgressKey(): NewMapStateEntry(DenyEntry, nil),
+					EgressKey(): NewMapStateEntry(DenyEntry),
 				}),
 			},
 			args: args{
@@ -897,7 +897,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					EgressPolicyEnabled:  false,
 				},
 				PolicyMapState: emptyMapState().withState(mapStateMap{
-					EgressKey(): NewMapStateEntry(DenyEntry, nil),
+					EgressKey(): NewMapStateEntry(DenyEntry),
 				}),
 			},
 			args: args{

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -333,7 +333,7 @@ func mergePortProto(ctx *SearchContext, existingFilter, filterToMerge *L4Filter,
 // forwarded to the proxy for endpoints matching those labels, but the proxy
 // will allow all such traffic.
 func mergeIngressPortProto(policyCtx PolicyContext, ctx *SearchContext, endpoints api.EndpointSelectorSlice, auth *api.Authentication, hostWildcardL7 []string,
-	r api.Ports, p api.PortProtocol, proto api.L4Proto, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
+	r api.Ports, p api.PortProtocol, proto api.L4Proto, ruleLabels stringLabels, resMap L4PolicyMap) (int, error) {
 	// Create a new L4Filter
 	filterToMerge, err := createL4IngressFilter(policyCtx, endpoints, auth, hostWildcardL7, r, p, proto, ruleLabels)
 	if err != nil {
@@ -400,7 +400,7 @@ func rulePortsCoverSearchContext(ports []api.PortProtocol, ctx *SearchContext) b
 	return false
 }
 
-func mergeIngress(policyCtx PolicyContext, ctx *SearchContext, fromEndpoints api.EndpointSelectorSlice, auth *api.Authentication, toPorts, icmp api.PortsIterator, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
+func mergeIngress(policyCtx PolicyContext, ctx *SearchContext, fromEndpoints api.EndpointSelectorSlice, auth *api.Authentication, toPorts, icmp api.PortsIterator, ruleLabels stringLabels, resMap L4PolicyMap) (int, error) {
 	found := 0
 
 	// short-circuit if no endpoint is selected
@@ -578,7 +578,7 @@ func (r *rule) resolveIngressPolicy(
 	}
 	for _, ingressRule := range r.Ingress {
 		fromEndpoints := ingressRule.GetSourceEndpointSelectorsWithRequirements(requirements)
-		cnt, err := mergeIngress(policyCtx, ctx, fromEndpoints, ingressRule.Authentication, ingressRule.ToPorts, ingressRule.ICMPs, r.Rule.Labels.DeepCopy(), result)
+		cnt, err := mergeIngress(policyCtx, ctx, fromEndpoints, ingressRule.Authentication, ingressRule.ToPorts, ingressRule.ICMPs, makeStringLabels(r.Rule.Labels), result)
 		if err != nil {
 			return nil, err
 		}
@@ -593,7 +593,7 @@ func (r *rule) resolveIngressPolicy(
 	}()
 	for _, ingressRule := range r.IngressDeny {
 		fromEndpoints := ingressRule.GetSourceEndpointSelectorsWithRequirements(requirementsDeny)
-		cnt, err := mergeIngress(policyCtx, ctx, fromEndpoints, nil, ingressRule.ToPorts, ingressRule.ICMPs, r.Rule.Labels.DeepCopy(), result)
+		cnt, err := mergeIngress(policyCtx, ctx, fromEndpoints, nil, ingressRule.ToPorts, ingressRule.ICMPs, makeStringLabels(r.Rule.Labels), result)
 		if err != nil {
 			return nil, err
 		}
@@ -643,7 +643,7 @@ func (r *rule) getSubjects() []identity.NumericIdentity {
 
 // ****************** EGRESS POLICY ******************
 
-func mergeEgress(policyCtx PolicyContext, ctx *SearchContext, toEndpoints api.EndpointSelectorSlice, auth *api.Authentication, toPorts, icmp api.PortsIterator, ruleLabels labels.LabelArray, resMap L4PolicyMap, fqdns api.FQDNSelectorSlice) (int, error) {
+func mergeEgress(policyCtx PolicyContext, ctx *SearchContext, toEndpoints api.EndpointSelectorSlice, auth *api.Authentication, toPorts, icmp api.PortsIterator, ruleLabels stringLabels, resMap L4PolicyMap, fqdns api.FQDNSelectorSlice) (int, error) {
 	found := 0
 
 	// short-circuit if no endpoint is selected
@@ -768,7 +768,7 @@ func mergeEgress(policyCtx PolicyContext, ctx *SearchContext, toEndpoints api.En
 // being merged has conflicting L7 rules with those already in the provided
 // L4PolicyMap for the specified port-protocol tuple, it returns an error.
 func mergeEgressPortProto(policyCtx PolicyContext, ctx *SearchContext, endpoints api.EndpointSelectorSlice, auth *api.Authentication, r api.Ports, p api.PortProtocol,
-	proto api.L4Proto, ruleLabels labels.LabelArray, resMap L4PolicyMap, fqdns api.FQDNSelectorSlice) (int, error) {
+	proto api.L4Proto, ruleLabels stringLabels, resMap L4PolicyMap, fqdns api.FQDNSelectorSlice) (int, error) {
 	// Create a new L4Filter
 	filterToMerge, err := createL4EgressFilter(policyCtx, endpoints, auth, r, p, proto, ruleLabels, fqdns)
 	if err != nil {
@@ -806,7 +806,7 @@ func (r *rule) resolveEgressPolicy(
 	}
 	for _, egressRule := range r.Egress {
 		toEndpoints := egressRule.GetDestinationEndpointSelectorsWithRequirements(requirements)
-		cnt, err := mergeEgress(policyCtx, ctx, toEndpoints, egressRule.Authentication, egressRule.ToPorts, egressRule.ICMPs, r.Rule.Labels.DeepCopy(), result, egressRule.ToFQDNs)
+		cnt, err := mergeEgress(policyCtx, ctx, toEndpoints, egressRule.Authentication, egressRule.ToPorts, egressRule.ICMPs, makeStringLabels(r.Rule.Labels), result, egressRule.ToFQDNs)
 		if err != nil {
 			return nil, err
 		}
@@ -821,7 +821,7 @@ func (r *rule) resolveEgressPolicy(
 	}()
 	for _, egressRule := range r.EgressDeny {
 		toEndpoints := egressRule.GetDestinationEndpointSelectorsWithRequirements(requirementsDeny)
-		cnt, err := mergeEgress(policyCtx, ctx, toEndpoints, nil, egressRule.ToPorts, egressRule.ICMPs, r.Rule.Labels.DeepCopy(), result, nil)
+		cnt, err := mergeEgress(policyCtx, ctx, toEndpoints, nil, egressRule.ToPorts, egressRule.ICMPs, makeStringLabels(r.Rule.Labels), result, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -71,13 +71,13 @@ func TestL4Policy(t *testing.T) {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		wildcard: td.wildcardCachedSelector,
 		L7Parser: "http", PerSelectorPolicies: l7map, Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
 	expected.Ingress.PortRules.Upsert("8080", 0, "TCP", &L4Filter{
 		Port: 8080, Protocol: api.ProtoTCP, U8Proto: 6,
 		wildcard: td.wildcardCachedSelector,
 		L7Parser: "http", PerSelectorPolicies: l7map, Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
 
 	expected.Egress.PortRules.Upsert("3000", 0, "TCP", &L4Filter{
@@ -86,7 +86,7 @@ func TestL4Policy(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: nil,
 		},
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
 	expected.Egress.PortRules.Upsert("3000", 0, "UDP", &L4Filter{
 		Port: 3000, Protocol: api.ProtoUDP, U8Proto: 17, Ingress: false,
@@ -94,7 +94,7 @@ func TestL4Policy(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: nil,
 		},
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
 	expected.Egress.PortRules.Upsert("3000", 0, "SCTP", &L4Filter{
 		Port: 3000, Protocol: api.ProtoSCTP, U8Proto: 132, Ingress: false,
@@ -102,7 +102,7 @@ func TestL4Policy(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: nil,
 		},
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
 
 	pol1, err := td.repo.resolvePolicyLocked(idA)
@@ -166,7 +166,7 @@ func TestL4Policy(t *testing.T) {
 			},
 		},
 		Ingress:    true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
 	expected.Egress.PortRules.Upsert("3000", 0, "TCP", &L4Filter{
 		Port: 3000, Protocol: api.ProtoTCP, U8Proto: 6, Ingress: false,
@@ -174,7 +174,7 @@ func TestL4Policy(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: nil,
 		},
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
 	expected.Egress.PortRules.Upsert("3000", 0, "UDP", &L4Filter{
 		Port: 3000, Protocol: api.ProtoUDP, U8Proto: 17, Ingress: false,
@@ -182,7 +182,7 @@ func TestL4Policy(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: nil,
 		},
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
 	expected.Egress.PortRules.Upsert("3000", 0, "SCTP", &L4Filter{
 		Port: 3000, Protocol: api.ProtoSCTP, U8Proto: 132, Ingress: false,
@@ -190,7 +190,7 @@ func TestL4Policy(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: nil,
 		},
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
 	pol2, err := td.repo.resolvePolicyLocked(idA)
 	require.NoError(t, err)
@@ -236,10 +236,10 @@ func TestMergeL4PolicyIngress(t *testing.T) {
 	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		L7Parser: ParserTypeNone, PerSelectorPolicies: mergedES, Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedFooSelector: {nil},
 			td.cachedBazSelector: {nil},
-		},
+		}),
 	}})
 
 	pol, err := td.repo.resolvePolicyLocked(idA)
@@ -287,10 +287,10 @@ func TestMergeL4PolicyEgress(t *testing.T) {
 	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		L7Parser: ParserTypeNone, PerSelectorPolicies: mergedES, Ingress: false,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorB: {nil},
 			td.cachedSelectorC: {nil},
-		},
+		}),
 	}})
 
 	pol, err := td.repo.resolvePolicyLocked(idA)
@@ -365,10 +365,10 @@ func TestMergeL7PolicyIngress(t *testing.T) {
 			},
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorB:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}})
 
 	sp, err := td.repo.resolvePolicyLocked(idA)
@@ -426,10 +426,10 @@ func TestMergeL7PolicyIngress(t *testing.T) {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		wildcard: td.wildcardCachedSelector,
 		L7Parser: "kafka", PerSelectorPolicies: l7map, Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorB:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}})
 
 	td.resetRepo()
@@ -509,10 +509,10 @@ func TestMergeL7PolicyIngress(t *testing.T) {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		wildcard: td.wildcardCachedSelector,
 		L7Parser: "kafka", PerSelectorPolicies: l7map, Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorB:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}})
 
 	sp, err = td.repo.resolvePolicyLocked(idA)
@@ -584,10 +584,10 @@ func TestMergeL7PolicyEgress(t *testing.T) {
 			},
 		},
 		Ingress: false,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.wildcardCachedSelector: {nil},
 			td.cachedSelectorB:        {nil},
-		},
+		}),
 	}})
 
 	sp, err := td.repo.resolvePolicyLocked(idA)
@@ -657,10 +657,10 @@ func TestMergeL7PolicyEgress(t *testing.T) {
 			},
 		},
 		Ingress: false,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorB:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}})
 
 	sp, err = td.repo.resolvePolicyLocked(idA)
@@ -730,10 +730,10 @@ func TestMergeL7PolicyEgress(t *testing.T) {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		wildcard: td.wildcardCachedSelector,
 		L7Parser: "kafka", PerSelectorPolicies: l7map, Ingress: false,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorB:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}})
 
 	sp, err = td.repo.resolvePolicyLocked(idA)
@@ -939,7 +939,7 @@ func TestICMPPolicy(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: nil,
 		},
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	}})
 
 	expectedOut := NewL4PolicyMapWithValues(map[string]*L4Filter{"ICMP/9": {
@@ -951,7 +951,7 @@ func TestICMPPolicy(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: nil,
 		},
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	}})
 
 	pol, err := td.repo.resolvePolicyLocked(idA)
@@ -993,7 +993,7 @@ func TestICMPPolicy(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				td.wildcardCachedSelector: nil,
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 		},
 		"TCP/80": {
 			Port:     80,
@@ -1004,7 +1004,7 @@ func TestICMPPolicy(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				td.wildcardCachedSelector: nil,
 			},
-			RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 		},
 	})
 
@@ -1041,7 +1041,7 @@ func TestICMPPolicy(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: nil,
 		},
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	}})
 	pol, err = td.repo.resolvePolicyLocked(idA)
 	require.NoError(t, err)
@@ -1247,7 +1247,8 @@ func TestL3RuleLabels(t *testing.T) {
 					for cidr, rule := range exp {
 						matches := false
 						for _, origin := range filter.RuleOrigin {
-							if origin.Equals(rule) {
+							lbls := origin.GetLabelArrayList()
+							if lbls.Equals(rule) {
 								matches = true
 								break
 							}
@@ -1370,7 +1371,8 @@ func TestL4RuleLabels(t *testing.T) {
 				out := finalPolicy.L4Policy.Ingress.PortRules.ExactLookup(portProtoSlice[0], 0, portProtoSlice[1])
 				require.NotNil(t, out, test.description)
 				require.Len(t, out.RuleOrigin, 1, test.description)
-				require.EqualValues(t, test.expectedIngressLabels[portProto], out.RuleOrigin[out.wildcard], test.description)
+				lbls := out.RuleOrigin[out.wildcard].GetLabelArrayList()
+				require.EqualValues(t, test.expectedIngressLabels[portProto], lbls, test.description)
 			}
 
 			require.Equal(t, len(test.expectedEgressLabels), finalPolicy.L4Policy.Egress.PortRules.Len(), test.description)
@@ -1378,9 +1380,9 @@ func TestL4RuleLabels(t *testing.T) {
 				portProtoSlice := strings.Split(portProto, "/")
 				out := finalPolicy.L4Policy.Egress.PortRules.ExactLookup(portProtoSlice[0], 0, portProtoSlice[1])
 				require.NotNil(t, out, test.description)
-
 				require.Len(t, out.RuleOrigin, 1, test.description)
-				require.EqualValues(t, test.expectedEgressLabels[portProto], out.RuleOrigin[out.wildcard], test.description)
+				lbls := out.RuleOrigin[out.wildcard].GetLabelArrayList()
+				require.EqualValues(t, test.expectedEgressLabels[portProto], lbls, test.description)
 			}
 		})
 	}
@@ -1905,10 +1907,10 @@ func TestL4WildcardMerge(t *testing.T) {
 			},
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorC:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}
 	pol1, err := repo.resolvePolicyLocked(idA)
 	require.NoError(t, err)
@@ -1939,7 +1941,7 @@ func TestL4WildcardMerge(t *testing.T) {
 			},
 		},
 		Ingress:    true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{td.cachedSelectorC: {nil}},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorC: {nil}}),
 	}
 
 	filterL7 := l4IngressPolicy.ExactLookup("7000", 0, "TCP")
@@ -2208,10 +2210,10 @@ func TestL3L4L7Merge(t *testing.T) {
 			},
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorC:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}
 	require.True(t, expected.Equals(filter))
 
@@ -2272,10 +2274,10 @@ func TestL3L4L7Merge(t *testing.T) {
 			},
 		},
 		Ingress: true,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorC:        {nil},
 			td.wildcardCachedSelector: {nil},
-		},
+		}),
 	}
 
 	require.True(t, expected.Equals(filter))
@@ -2466,10 +2468,10 @@ func TestMergeL7PolicyEgressWithMultipleSelectors(t *testing.T) {
 			},
 		},
 		Ingress: false,
-		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorB: {nil},
 			td.cachedSelectorC: {nil},
-		},
+		}),
 	}
 
 	pol, err := td.repo.resolvePolicyLocked(idA)

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -322,7 +322,7 @@ type identityNotifier interface {
 // AddFQDNSelector adds the given api.FQDNSelector in to the selector cache. If
 // an identical EndpointSelector has already been cached, the corresponding
 // types.CachedSelector is returned, otherwise one is created and added to the cache.
-func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, lbls labels.LabelArray, fqdnSelec api.FQDNSelector) (cachedSelector types.CachedSelector, added bool) {
+func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, lbls stringLabels, fqdnSelec api.FQDNSelector) (cachedSelector types.CachedSelector, added bool) {
 	key := fqdnSelec.String()
 
 	sc.mutex.Lock()
@@ -345,7 +345,7 @@ func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, lbls labels.L
 }
 
 // must hold lock for writing
-func (sc *SelectorCache) addSelectorLocked(user CachedSelectionUser, lbls labels.LabelArray, key string, source selectorSource) (types.CachedSelector, bool) {
+func (sc *SelectorCache) addSelectorLocked(user CachedSelectionUser, lbls stringLabels, key string, source selectorSource) (types.CachedSelector, bool) {
 	idSel := &identitySelector{
 		key:              key,
 		users:            make(map[CachedSelectionUser]struct{}),
@@ -393,7 +393,7 @@ func (sc *SelectorCache) FindCachedIdentitySelector(selector api.EndpointSelecto
 // selector cache. If an identical EndpointSelector has already been
 // cached, the corresponding types.CachedSelector is returned, otherwise one
 // is created and added to the cache.
-func (sc *SelectorCache) AddIdentitySelector(user types.CachedSelectionUser, lbls labels.LabelArray, selector api.EndpointSelector) (cachedSelector types.CachedSelector, added bool) {
+func (sc *SelectorCache) AddIdentitySelector(user types.CachedSelectionUser, lbls stringLabels, selector api.EndpointSelector) (cachedSelector types.CachedSelector, added bool) {
 	// The key returned here may be different for equivalent
 	// labelselectors, if the selector's requirements are stored
 	// in different orders. When this happens we'll be tracking

--- a/pkg/policy/selectorcache_selector.go
+++ b/pkg/policy/selectorcache_selector.go
@@ -63,7 +63,7 @@ type identitySelector struct {
 	selections       versioned.Value[identity.NumericIdentitySlice]
 	users            map[CachedSelectionUser]struct{}
 	cachedSelections map[identity.NumericIdentity]struct{}
-	metadataLbls     labels.LabelArray
+	metadataLbls     stringLabels
 }
 
 func (i *identitySelector) MaySelectPeers() bool {
@@ -198,7 +198,7 @@ func (i *identitySelector) GetSelections(version *versioned.VersionHandle) ident
 }
 
 func (i *identitySelector) GetMetadataLabels() labels.LabelArray {
-	return i.metadataLbls
+	return labels.LabelArrayFromString(string(i.metadataLbls.Value()))
 }
 
 // Selects return 'true' if the CachedSelector selects the given

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -63,7 +63,7 @@ func (csu *cachedSelectionUser) AddIdentitySelector(sel api.EndpointSelector) Ca
 	csu.updateMutex.Lock()
 	defer csu.updateMutex.Unlock()
 
-	cached, added := csu.sc.AddIdentitySelector(csu, nil, sel)
+	cached, added := csu.sc.AddIdentitySelector(csu, EmptyStringLabels, sel)
 	require.NotNil(csu.t, cached)
 
 	_, exists := csu.selections[cached]
@@ -81,7 +81,7 @@ func (csu *cachedSelectionUser) AddFQDNSelector(sel api.FQDNSelector) CachedSele
 	csu.updateMutex.Lock()
 	defer csu.updateMutex.Unlock()
 
-	cached, added := csu.sc.AddFQDNSelector(csu, nil, sel)
+	cached, added := csu.sc.AddFQDNSelector(csu, EmptyStringLabels, sel)
 	require.NotNil(csu.t, cached)
 
 	_, exists := csu.selections[cached]


### PR DESCRIPTION
Origin rule labels are ingested and processed to the selector policy, cached selectors, and mapstate without any datapath impact. These labels are metadata that is only used when policy verdicts are inspected, e.g., when exporting hubble flows. As such it would be reasonable to optimize the processing and storage cost of these labels, possibly with somewhat higher cost when extracting them.

To this end we change the origin rule label storage from the Go "slice of slices of labels" (each label consisting of three strings) to a single string. This compacts the storage of the labels, removing the need for multiple levels of slice headers and the associated heap allocated storage. The algorithm for merging sorted label arrays in string form is implemented, operating directly in string domain.

This step alone is already beneficial, but this gets a bit better by interning the string (in the 2nd commit).

Third commit changes policy rule correlation to also function in string domain, eliminating the overhead introduced by the string representation.

This PR improves the BenchmarkRegenerateCIDRDenyPolicyRules (which generates unique labels for each rule) execution time by ~5%, reduces memory consumption by ~17%, and increases the number of heap allocations by ~3%.