### PR TITLE
refactor(ipcache): Allow IP/Service Cache to run as a standalone component 

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -245,6 +245,13 @@ func (ipc *IPCache) GetMetadataSourceByPrefix(prefix netip.Prefix) source.Source
 	return ipc.metadata.getLocked(prefix).Source()
 }
 
+// GetMetadataLabelsByPrefix returns the labels associated with the given prefix.
+func (ipc *IPCache) GetMetadataLabelsByPrefix(prefix netip.Prefix) labels.Labels {
+	ipc.metadata.RLock()
+	defer ipc.metadata.RUnlock()
+	return ipc.metadata.getLocked(prefix).ToLabels()
+}
+
 func (m *metadata) getLocked(prefix netip.Prefix) prefixInfo {
 	return m.m[canonicalPrefix(prefix)]
 }

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -140,6 +140,9 @@ type ServiceCache struct {
 	// externalEndpoints is a list of additional service backends derived from source other than the local cluster
 	externalEndpoints map[ServiceID]externalEndpoints
 
+	// map frontend and loadbalancer IP to service ID.
+	ipToServiceID map[string]ServiceID
+
 	selfNodeZoneLabel string
 
 	ServiceMutators []func(svc *slim_corev1.Service, svcInfo *Service)
@@ -161,6 +164,7 @@ func NewServiceCache(db *statedb.DB, nodeAddrs statedb.Table[datapathTables.Node
 		services:              map[ServiceID]*Service{},
 		endpoints:             map[ServiceID]*EndpointSlices{},
 		externalEndpoints:     map[ServiceID]externalEndpoints{},
+		ipToServiceID:         map[string]ServiceID{},
 		Events:                events,
 		sendEvents:            events,
 		notifications:         notifications,
@@ -320,6 +324,15 @@ func (s *ServiceCache) ForEachService(yield func(svcID ServiceID, svc *Service, 
 	}
 }
 
+// GetServiceIDByIP returns the ServiceID for the given IP address.
+// IP address can be either a frontend IP or a loadbalancer IP.
+func (s *ServiceCache) GetServiceIDByIP(ip net.IP) (ServiceID, bool) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	id, ok := s.ipToServiceID[ip.String()]
+	return id, ok
+}
+
 // UpdateService parses a Kubernetes service and adds or updates it in the
 // ServiceCache. Returns the ServiceID unless the Kubernetes service could not
 // be parsed and a bool to indicate whether the service was changed in the
@@ -360,6 +373,14 @@ func (s *ServiceCache) UpdateService(k8sSvc *slim_corev1.Service, swg *lock.Stop
 
 	s.metrics.AddService(newService)
 	s.services[svcID] = newService
+
+	for _, feIP := range newService.FrontendIPs {
+		s.ipToServiceID[feIP.String()] = svcID
+	}
+
+	for _, lbIP := range newService.LoadBalancerIPs {
+		s.ipToServiceID[lbIP.String()] = svcID
+	}
 
 	// Check if the corresponding Endpoints resource is already available
 	endpoints, serviceReady := s.correlateEndpoints(svcID)
@@ -409,6 +430,14 @@ func (s *ServiceCache) DeleteService(k8sSvc *slim_corev1.Service, swg *lock.Stop
 	oldService, serviceOK := s.services[svcID]
 	endpoints, _ := s.correlateEndpoints(svcID)
 	delete(s.services, svcID)
+
+	for _, feIP := range oldService.FrontendIPs {
+		delete(s.ipToServiceID, feIP.String())
+	}
+
+	for _, lbIP := range oldService.LoadBalancerIPs {
+		delete(s.ipToServiceID, lbIP.String())
+	}
 
 	if serviceOK {
 		s.metrics.DelService(oldService)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

## Summary

Two highly common design pattern for Kubernetes applications are 
- Watching for resources
- caching them 

Cilium repository includes modules that provide excellent support for the two above scenarios. Moreover, because both uses `cell` library, it is possible to simply import them as libraries and use in new projects. To help with that I want to introduce few refactors that will have no impact to existing use of `IPCache` and `Watcher` but will allow them to be used as standalone components.

Note: This will also facilitate running Hubble as a standalone component without the Cilium Dataplane. Hubble can be used as a library and IP/Service cache can be leveraged to enrich the `Flows`.

## Changes

- `ipcache.go` - Introduce `DisableLabelInjection` to disregard dataplane operation needed for labels added/deleted.
- `metadata.go` - Add `GetMetadataLabelsByPrefix` to return labels cached by IP.
- `service_cache.go` - Similar to IPCache, map service metadata information keyed to fronted or loadbalancer IP.
- `cilium_endpoint.go` - Add support caching endpoint labels.
- `watcher.go` - Allow starting the watcher to watch only specified resources.

## Testing Done

Ran the following commands successfully

```bash
$ make kind-image-fast
...
$ make kind-install-cilium-fast
...
$ make integration-tests
...
$ go test ./...
...
```

 
Fixes: N/A

