### PR TITLE
CLI: Attribute tests to codeowners

### DIFF
--- a/.github/actions/conn-disrupt-test-check/action.yaml
+++ b/.github/actions/conn-disrupt-test-check/action.yaml
@@ -46,6 +46,7 @@ runs:
           --junit-file "cilium-junits/conn-disrupt-test-${{ inputs.job-name }}.xml" \
           ${{ inputs.extra-connectivity-test-flags }} \
           --junit-property github_job_step="Run conn disrupt tests (${{ inputs.job-name }})" \
+          --log-code-owners \
           --test "$TEST_ARG" \
           --expected-xfrm-errors "+inbound_no_state" \
           ${EXTRA_ARG}

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -284,6 +284,7 @@ jobs:
       - name: Run connectivity test (${{ join(matrix.*, ', ') }})
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --log-code-owners \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1.xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
@@ -318,6 +319,7 @@ jobs:
       - name: Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
+          --log-code-owners \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 2.xml" \
           --junit-property github_job_step="Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})"
 

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -326,6 +326,7 @@ jobs:
       - name: Run connectivity test (${{ join(matrix.*, ', ') }})
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --log-code-owners \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -573,6 +573,7 @@ jobs:
       - name: Run connectivity test (${{ join(matrix.*, ', ') }})
         run: |
           cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --log-code-owners \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 

--- a/.github/workflows/conformance-delegated-ipam.yaml
+++ b/.github/workflows/conformance-delegated-ipam.yaml
@@ -336,6 +336,7 @@ jobs:
       - name: Cilium connectivity test
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+            --log-code-owners \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Features tested

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -328,6 +328,7 @@ jobs:
       - name: Run connectivity test (${{ join(matrix.*, ', ') }})
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+            --log-code-owners \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1.xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -337,6 +337,7 @@ jobs:
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
+            --log-code-owners \
             --test 'allow-all-except-world,encryption,packet-drops'
 
       - name: Features tested

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -327,6 +327,7 @@ jobs:
       - name: Run connectivity test (${{ matrix.k8s.version }}, ${{ matrix.config.index }}, ${{ matrix.config.type }})
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+            --log-code-owners \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.k8s.*, ', ') }}, ${{ join(matrix.config.*, ', ') }}).xml" \
           --junit-property github_job_step="Run connectivity test (${{ matrix.k8s.version }}, ${{ matrix.config.index }}, ${{ matrix.config.type }})"
 

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -423,6 +423,7 @@ jobs:
         shell: bash
         run: |
           cilium connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+            --log-code-owners \
             --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --test 'packet-drops'

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -289,6 +289,7 @@ jobs:
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
+            --log-code-owners \
             --flush-ct
 
       - name: Features tested
@@ -347,6 +348,7 @@ jobs:
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
+            --log-code-owners \
             --flush-ct $TEST
 
       - name: Features tested

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -112,6 +112,7 @@ jobs:
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --curl-parallel 3 \
+            --log-code-owners \
             --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Features tested
@@ -137,6 +138,7 @@ jobs:
         run: |
           cilium connectivity test --test="l7|sni|check-log-errors" \
             --curl-parallel 3 \
+            --log-code-owners \
             --junit-file "cilium-junits/${{ env.job_name }}-without-secret-sync.xml" \
             --junit-property github_job_step="Run connectivity test with secret sync disabled"
 

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -219,6 +219,7 @@ jobs:
       - name: Run connectivity test
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+            --log-code-owners \
             --junit-file "cilium-junits/${{ env.job_name }} - 1.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Features tested

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -389,7 +389,7 @@ jobs:
             go install golang.org/dl/go${{ env.go-version }}@latest
             go${{ env.go-version }} download
             go${{ env.go-version}} install github.com/mfridman/tparse@baf229e8494613f134bc0e1f4cb9dc9b12f66442
-            make SKIP_COVERAGE=1 tests-privileged GO=go${{ env.go-version }}
+            make SKIP_COVERAGE=1 LOG_CODEOWNERS=1 tests-privileged GO=go${{ env.go-version }}
 
       - name: Copy tested features
         if: ${{ matrix.focus == 'agent' || matrix.focus == 'datapath' }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -173,7 +173,7 @@ jobs:
           export V=0
           export DOCKER_BUILD_FLAGS=--quiet
           export CFLAGS="-Werror"
-          make integration-tests
+          make integration-tests LOG_CODEOWNERS=1
 
   commit-status-final:
     if: ${{ always() }}

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -197,6 +197,7 @@ jobs:
           CONNECTIVITY_TEST_DEFAULTS=" \
             --hubble=false \
             --flow-validation=disabled \
+            --log-code-owners \
             --test='no-interrupted-connections' \
             --test='no-unexpected-packet-drops' \
             --test='check-log-errors' \
@@ -670,6 +671,7 @@ jobs:
           cilium --context ${{ env.contextName1 }} connectivity test \
             --multi-cluster=${{ env.contextName2 }} \
             --hubble=false \
+            --log-code-owners \
             --flow-validation=disabled \
             --test='no-interrupted-connections' \
             --test='no-unexpected-packet-drops' \

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -721,6 +721,7 @@ jobs:
         shell: bash
         run: |
           cilium connectivity test \
+            --log-code-owners \
             --include-conn-disrupt-test \
             --include-conn-disrupt-test-ns-traffic \
             --test "no-interrupted-connections" \
@@ -731,6 +732,7 @@ jobs:
         shell: bash
         run: |
           cilium connectivity test \
+            --log-code-owners \
             --test "seq-.*" \
             ${{ steps.cli-flags.outputs.flags }}
 
@@ -738,6 +740,7 @@ jobs:
         shell: bash
         run: |
           cilium connectivity test \
+            --log-code-owners \
             --test-concurrency=${{ env.test_concurrency }} \
             --test "!seq-.*" \
             ${{ steps.cli-flags.outputs.flags }}
@@ -775,6 +778,7 @@ jobs:
         shell: bash
         run: |
           cilium connectivity test \
+            --log-code-owners \
             --include-conn-disrupt-test \
             --test "no-interrupted-connections" \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
@@ -785,6 +789,7 @@ jobs:
         shell: bash
         run: |
           cilium connectivity test \
+            --log-code-owners \
             --test "seq-.*" \
             ${{ steps.cli-flags.outputs.flags }}
 
@@ -793,6 +798,7 @@ jobs:
         shell: bash
         run: |
           cilium connectivity test \
+            --log-code-owners \
             --test-concurrency=${{ env.test_concurrency }} \
             --test "!seq-.*" \
             ${{ steps.cli-flags.outputs.flags }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -268,6 +268,7 @@
 /api/v1/peer/ @cilium/sig-hubble-api
 /api/v1/recorder/ @cilium/sig-hubble-api
 /api/v1/relay/ @cilium/sig-hubble-api
+/assets.go @cilium/sig-agent
 /bpf/ @cilium/sig-datapath
 /bpf/lib/egress_gateway.h @cilium/egress-gateway
 Makefile* @cilium/build

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -95,9 +95,14 @@ GOTEST_COVER_OPTS =
 GOTEST_FORMATTER ?= cat
 ifneq ($(shell command -v tparse),)
 	GOTEST_COVER_OPTS += -json
-	GOTEST_FORMATTER = tparse
+	GOTEST_FORMATTER_FLAGS :=
 ifneq ($(V),0)
-	GOTEST_FORMATTER += -follow
+	GOTEST_FORMATTER_FLAGS += -follow
+endif
+ifneq ($(LOG_CODEOWNERS),)
+	GOTEST_FORMATTER = tee >($(GO) run ./tools/testowners) >(tparse $(GOTEST_FORMATTER_FLAGS)) >/dev/null
+else
+	GOTEST_FORMATTER = tparse $(GOTEST_FORMATTER_FLAGS)
 endif
 endif
 

--- a/assets.go
+++ b/assets.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Cilium provides access to top-level files in the tree for Cilium development.
+package cilium
+
+import (
+	_ "embed"
+)
+
+//go:embed CODEOWNERS
+var CodeOwnersRaw string

--- a/cilium-cli/cli/connectivity_test.go
+++ b/cilium-cli/cli/connectivity_test.go
@@ -5,10 +5,13 @@ package cli
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
+	"github.com/hmarr/codeowners"
 	"github.com/stretchr/testify/require"
 
+	assets "github.com/cilium/cilium"
 	"github.com/cilium/cilium/cilium-cli/api"
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 )
@@ -75,8 +78,13 @@ func TestNewConnectivityTests(t *testing.T) {
 		},
 	}
 	for _, tt := range testCases {
+		owners, err := codeowners.ParseFile(strings.NewReader(assets.CodeOwnersRaw))
+		if err != nil {
+			t.Fatalf("🐛 Failed to parse CODEOWNERS. Developer BUG? %s", err)
+		}
+
 		// function to test
-		actual, err := newConnectivityTests(tt.params, &api.NopHooks{}, check.NewConcurrentLogger(&bytes.Buffer{}, 1))
+		actual, err := newConnectivityTests(tt.params, &api.NopHooks{}, check.NewConcurrentLogger(&bytes.Buffer{}, 1), owners)
 
 		require.NoError(t, err)
 		require.Len(t, actual, tt.expectedCount)

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -102,6 +102,7 @@ type Parameters struct {
 	ExpectedDropReasons []string
 	ExpectedXFRMErrors  []string
 
+	LogCodeOwners  bool
 	LogCheckLevels []string
 
 	FlushCT               bool

--- a/cilium-cli/connectivity/check/scenario.go
+++ b/cilium-cli/connectivity/check/scenario.go
@@ -14,6 +14,9 @@ type Scenario interface {
 	// Name returns the name of the Scenario.
 	Name() string
 
+	// Filepath returns the source code filename for the Scenario.
+	FilePath() string
+
 	// Run is invoked by the testing framework to execute the Scenario.
 	Run(ctx context.Context, t *Test)
 }
@@ -24,4 +27,10 @@ type Scenario interface {
 type ConditionalScenario interface {
 	Scenario
 	Requirements() []features.Requirement
+}
+
+type ScenarioBase struct {
+}
+
+func NewScenarioBase() ScenarioBase {
 }

--- a/cilium-cli/connectivity/check/scenario.go
+++ b/cilium-cli/connectivity/check/scenario.go
@@ -5,6 +5,9 @@ package check
 
 import (
 	"context"
+	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/cilium/cilium/cilium-cli/utils/features"
 )
@@ -30,7 +33,34 @@ type ConditionalScenario interface {
 }
 
 type ScenarioBase struct {
+	filepath string
 }
 
 func NewScenarioBase() ScenarioBase {
+	return ScenarioBase{
+		filepath: getSourceFile(),
+	}
+}
+
+func (s ScenarioBase) FilePath() string {
+	return s.filepath
+}
+
+// getSourceFile returns the file path for test scenario relative to the root
+// of this repository.
+func getSourceFile() string {
+	// 2 steps up go to NewScenarioBase() => actual scenario constructor.
+	_, path, _, ok := runtime.Caller(2)
+	if ok {
+		// 'path' is an absolute path on disk. Trim back to a relative
+		// path from the root directory of the repository, calculated
+		// using this filepath's relationship with the root directory.
+		// If you move this logic, ensure that this calculation directs
+		// back up to the root of the tree where CODEOWNERS exists!
+		_, thisPath, _, _ := runtime.Caller(0)
+		repoDir, _ := filepath.Abs(filepath.Join(thisPath, "..", "..", "..", ".."))
+		return strings.TrimPrefix(path, repoDir+string(filepath.Separator))
+	}
+	// Fall back to the general owner of connectivity infrastructure.
+	return "cilium-cli/connectivity/"
 }

--- a/cilium-cli/connectivity/perf/benchmarks/netperf/bandwidth.go
+++ b/cilium-cli/connectivity/perf/benchmarks/netperf/bandwidth.go
@@ -23,11 +23,14 @@ const (
 // NetQos : Test Network QoS Enforcement
 func NetQos(n string) check.Scenario {
 	return &netQos{
-		name: n,
+		name:         n,
+		ScenarioBase: check.NewScenarioBase(),
 	}
 }
 
 type netQos struct {
+	check.ScenarioBase
+
 	lock.Mutex
 	name string
 }

--- a/cilium-cli/connectivity/perf/benchmarks/netperf/perfpod.go
+++ b/cilium-cli/connectivity/perf/benchmarks/netperf/perfpod.go
@@ -22,11 +22,14 @@ const (
 // Network Performance
 func Netperf(n string) check.Scenario {
 	return &netPerf{
-		name: n,
+		name:         n,
+		ScenarioBase: check.NewScenarioBase(),
 	}
 }
 
 type netPerf struct {
+	check.ScenarioBase
+
 	name string
 }
 

--- a/cilium-cli/connectivity/tests/bgp.go
+++ b/cilium-cli/connectivity/tests/bgp.go
@@ -36,10 +36,13 @@ const (
 func BGPAdvertisements(bgpAPIVersion uint8) check.Scenario {
 	return &bgpAdvertisements{
 		bgpAPIVersion: bgpAPIVersion,
+		ScenarioBase:  check.NewScenarioBase(),
 	}
 }
 
 type bgpAdvertisements struct {
+	check.ScenarioBase
+
 	bgpAPIVersion uint8
 }
 

--- a/cilium-cli/connectivity/tests/client.go
+++ b/cilium-cli/connectivity/tests/client.go
@@ -14,11 +14,15 @@ import (
 // ClientToClient sends an ICMP packet from each client Pod
 // to each client Pod in the test context.
 func ClientToClient() check.Scenario {
-	return &clientToClient{}
+	return &clientToClient{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
 // clientToClient implements a Scenario.
-type clientToClient struct{}
+type clientToClient struct {
+	check.ScenarioBase
+}
 
 func (s *clientToClient) Name() string {
 	return "client-to-client"

--- a/cilium-cli/connectivity/tests/clustermesh-endpointslice-sync.go
+++ b/cilium-cli/connectivity/tests/clustermesh-endpointslice-sync.go
@@ -12,10 +12,14 @@ import (
 )
 
 func ClusterMeshEndpointSliceSync() check.Scenario {
-	return &clusterMeshEndpointSliceSync{}
+	return &clusterMeshEndpointSliceSync{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
-type clusterMeshEndpointSliceSync struct{}
+type clusterMeshEndpointSliceSync struct {
+	check.ScenarioBase
+}
 
 func (s *clusterMeshEndpointSliceSync) Name() string {
 	return "clustermesh-endpointslice-sync"

--- a/cilium-cli/connectivity/tests/dummy.go
+++ b/cilium-cli/connectivity/tests/dummy.go
@@ -13,12 +13,14 @@ import (
 
 // dummy implements a Scenario.
 type dummy struct {
+	check.ScenarioBase
 	name string
 }
 
 func Dummy(name string) check.Scenario {
 	return &dummy{
-		name: name,
+		name:         name,
+		ScenarioBase: check.NewScenarioBase(),
 	}
 }
 

--- a/cilium-cli/connectivity/tests/egressgateway.go
+++ b/cilium-cli/connectivity/tests/egressgateway.go
@@ -150,10 +150,14 @@ func extractClientIPFromResponse(res string) net.IP {
 // - reply traffic for services
 // - reply traffic for pods
 func EgressGateway() check.Scenario {
-	return &egressGateway{}
+	return &egressGateway{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
-type egressGateway struct{}
+type egressGateway struct {
+	check.ScenarioBase
+}
 
 func (s *egressGateway) Name() string {
 	return "egress-gateway"
@@ -311,10 +315,14 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 //
 // This suite tests the excludedCIDRs property and ensure traffic matching an excluded CIDR does not get masqueraded with the egress IP
 func EgressGatewayExcludedCIDRs() check.Scenario {
-	return &egressGatewayExcludedCIDRs{}
+	return &egressGatewayExcludedCIDRs{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
-type egressGatewayExcludedCIDRs struct{}
+type egressGatewayExcludedCIDRs struct {
+	check.ScenarioBase
+}
 
 func (s *egressGatewayExcludedCIDRs) Name() string {
 	return "egress-gateway-excluded-cidrs"

--- a/cilium-cli/connectivity/tests/encryption.go
+++ b/cilium-cli/connectivity/tests/encryption.go
@@ -213,10 +213,17 @@ func isWgEncap(t *check.Test) bool {
 // The checks are implemented by curl'ing a server pod from a client pod, and
 // then inspecting tcpdump captures from the client pod's node.
 func PodToPodEncryption(reqs ...features.Requirement) check.Scenario {
-	return &podToPodEncryption{reqs}
+	return &podToPodEncryption{
+		reqs:         reqs,
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
-type podToPodEncryption struct{ reqs []features.Requirement }
+type podToPodEncryption struct {
+	check.ScenarioBase
+
+	reqs []features.Requirement
+}
 
 func (s *podToPodEncryption) Name() string {
 	return "pod-to-pod-encryption"
@@ -373,10 +380,17 @@ func nodeToNodeEncTestPods(nodes map[check.NodeIdentity]*ciliumv2.CiliumNode, ex
 }
 
 func NodeToNodeEncryption(reqs ...features.Requirement) check.Scenario {
-	return &nodeToNodeEncryption{reqs}
+	return &nodeToNodeEncryption{
+		reqs:         reqs,
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
-type nodeToNodeEncryption struct{ reqs []features.Requirement }
+type nodeToNodeEncryption struct {
+	check.ScenarioBase
+
+	reqs []features.Requirement
+}
 
 func (s *nodeToNodeEncryption) Name() string {
 	return "node-to-node-encryption"

--- a/cilium-cli/connectivity/tests/encryption_v2.go
+++ b/cilium-cli/connectivity/tests/encryption_v2.go
@@ -56,10 +56,14 @@ var _ check.Scenario = (*podToPodEncryptionV2)(nil)
 // TCPDUMP filter, this is a sanity check to ensure we match plain-text packets
 // appropriately and have confidence that aforementioned leak detection works.
 func PodToPodEncryptionV2() check.Scenario {
-	return &podToPodEncryptionV2{}
+	return &podToPodEncryptionV2{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
 type podToPodEncryptionV2 struct {
+	check.ScenarioBase
+
 	ct *check.ConnectivityTest
 	// client pod used to generate traffic
 	client *check.Pod

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -90,10 +90,15 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 	if slices.Contains(checkLevels, defaults.LogLevelWarning) && ciliumVersion.GE(semver.MustParse("1.17.0")) {
 		errorMsgsWithExceptions["level=warn"] = warningLogExceptions
 	}
-	return &noErrorsInLogs{errorMsgsWithExceptions}
+	return &noErrorsInLogs{
+		errorMsgsWithExceptions: errorMsgsWithExceptions,
+		ScenarioBase:            check.NewScenarioBase(),
+	}
 }
 
 type noErrorsInLogs struct {
+	check.ScenarioBase
+
 	errorMsgsWithExceptions map[string][]logMatcher
 }
 
@@ -134,10 +139,15 @@ func (n *noErrorsInLogs) Run(ctx context.Context, t *check.Test) {
 // NoUnexpectedPacketDrops checks whether there were no drops due to expected
 // packet drops.
 func NoUnexpectedPacketDrops(expectedDrops []string) check.Scenario {
-	return &noUnexpectedPacketDrops{expectedDrops}
+	return &noUnexpectedPacketDrops{
+		expectedDrops: expectedDrops,
+		ScenarioBase:  check.NewScenarioBase(),
+	}
 }
 
 type noUnexpectedPacketDrops struct {
+	check.ScenarioBase
+
 	expectedDrops []string
 }
 

--- a/cilium-cli/connectivity/tests/externalworkload.go
+++ b/cilium-cli/connectivity/tests/externalworkload.go
@@ -12,10 +12,14 @@ import (
 )
 
 func PodToExternalWorkload() check.Scenario {
-	return &podToExternalWorkload{}
+	return &podToExternalWorkload{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
-type podToExternalWorkload struct{}
+type podToExternalWorkload struct {
+	check.ScenarioBase
+}
 
 func (s *podToExternalWorkload) Name() string {
 	return "pod-to-external-workload"

--- a/cilium-cli/connectivity/tests/from-cidr.go
+++ b/cilium-cli/connectivity/tests/from-cidr.go
@@ -15,11 +15,15 @@ import (
 // FromCIDRToPod generates HTTP request from each node without Cilium to the
 // echo pods within the Cilium / K8s cluster.
 func FromCIDRToPod() check.Scenario {
-	return &fromCIDRToPod{}
+	return &fromCIDRToPod{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
 // fromCIDRToPod implements a Scenario.
-type fromCIDRToPod struct{}
+type fromCIDRToPod struct {
+	check.ScenarioBase
+}
 
 func (f *fromCIDRToPod) Name() string {
 	return "from-cidr-to-pod"

--- a/cilium-cli/connectivity/tests/health.go
+++ b/cilium-cli/connectivity/tests/health.go
@@ -20,10 +20,14 @@ import (
 )
 
 func CiliumHealth() check.Scenario {
-	return &ciliumHealth{}
+	return &ciliumHealth{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
-type ciliumHealth struct{}
+type ciliumHealth struct {
+	check.ScenarioBase
+}
 
 func (s *ciliumHealth) Name() string {
 	return "cilium-health"

--- a/cilium-cli/connectivity/tests/host.go
+++ b/cilium-cli/connectivity/tests/host.go
@@ -16,11 +16,15 @@ import (
 // PodToHost sends an ICMP ping from all client Pods to all nodes
 // in the test context.
 func PodToHost() check.Scenario {
-	return &podToHost{}
+	return &podToHost{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
 // podToHost implements a Scenario.
-type podToHost struct{}
+type podToHost struct {
+	check.ScenarioBase
+}
 
 func (s *podToHost) Name() string {
 	return "pod-to-host"
@@ -70,11 +74,15 @@ func (s *podToHost) Run(ctx context.Context, t *check.Test) {
 // PodToControlPlaneHost sends an ICMP ping from the controlPlaneclient Pod to all nodes
 // in the test context.
 func PodToControlPlaneHost() check.Scenario {
-	return &podToControlPlaneHost{}
+	return &podToControlPlaneHost{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
 // podToHost implements a Scenario.
-type podToControlPlaneHost struct{}
+type podToControlPlaneHost struct {
+	check.ScenarioBase
+}
 
 func (s *podToControlPlaneHost) Name() string {
 	return "pod-to-controlplane-host"
@@ -110,11 +118,15 @@ func (s *podToControlPlaneHost) Run(ctx context.Context, t *check.Test) {
 // PodToHostPort sends an HTTP request from all client Pods
 // to all echo Services' HostPorts.
 func PodToHostPort() check.Scenario {
-	return &podToHostPort{}
+	return &podToHostPort{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
 // podToHostPort implements a ConditionalScenario.
-type podToHostPort struct{}
+type podToHostPort struct {
+	check.ScenarioBase
+}
 
 func (s *podToHostPort) Name() string {
 	return "pod-to-hostport"
@@ -154,10 +166,14 @@ func (s *podToHostPort) Run(ctx context.Context, t *check.Test) {
 // HostToPod generates one HTTP request from each node inside the cluster to
 // each echo (server) pod in the test context.
 func HostToPod() check.Scenario {
-	return &hostToPod{}
+	return &hostToPod{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
-type hostToPod struct{}
+type hostToPod struct {
+	check.ScenarioBase
+}
 
 func (s *hostToPod) Name() string {
 	return "host-to-pod"

--- a/cilium-cli/connectivity/tests/ipsec_xfrm.go
+++ b/cilium-cli/connectivity/tests/ipsec_xfrm.go
@@ -31,11 +31,14 @@ type ciliumMetricsXfrmError struct {
 
 func NoIPsecXfrmErrors(expectedErrors []string) check.Scenario {
 	return &noIPsecXfrmErrors{
-		features.ComputeFailureExceptions(defaults.ExpectedXFRMErrors, expectedErrors),
+		expectedErrors: features.ComputeFailureExceptions(defaults.ExpectedXFRMErrors, expectedErrors),
+		ScenarioBase:   check.NewScenarioBase(),
 	}
 }
 
 type noIPsecXfrmErrors struct {
+	check.ScenarioBase
+
 	expectedErrors []string
 }
 

--- a/cilium-cli/connectivity/tests/k8s.go
+++ b/cilium-cli/connectivity/tests/k8s.go
@@ -14,11 +14,15 @@ import (
 // PodToK8sLocal sends a curl from all control plane client Pods
 // to all control-plane nodes.
 func PodToK8sLocal() check.Scenario {
-	return &podToK8sLocal{}
+	return &podToK8sLocal{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
 // podToK8sLocal implements a Scenario.
-type podToK8sLocal struct{}
+type podToK8sLocal struct {
+	check.ScenarioBase
+}
 
 func (s *podToK8sLocal) Name() string {
 	return "pod-to-k8s-local"

--- a/cilium-cli/connectivity/tests/lrp.go
+++ b/cilium-cli/connectivity/tests/lrp.go
@@ -26,10 +26,14 @@ import (
 // - client pods to LRP frontend
 // - LRP backend pods to LRP frontend
 func LRP(skipRedirectFromBackend bool) check.Scenario {
-	return lrp{skipRedirectFromBackend: skipRedirectFromBackend}
+	return lrp{
+		ScenarioBase:            check.NewScenarioBase(),
+		skipRedirectFromBackend: skipRedirectFromBackend,
+	}
 }
 
 type lrp struct {
+	check.ScenarioBase
 	skipRedirectFromBackend bool
 }
 
@@ -191,10 +195,14 @@ func WaitForLocalRedirectBPFEntries(ctx context.Context, t *check.Test, frontend
 // The network policy allows the clients to access node-local-dns
 // and the externalEcho service.
 func LRPWithNodeDNS() check.Scenario {
-	return lrpWithNodeDNS{}
+	return lrpWithNodeDNS{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
-type lrpWithNodeDNS struct{}
+type lrpWithNodeDNS struct {
+	check.ScenarioBase
+}
 
 func (s lrpWithNodeDNS) Name() string {
 	return "local-redirect-policy-with-node-dns"

--- a/cilium-cli/connectivity/tests/multicast.go
+++ b/cilium-cli/connectivity/tests/multicast.go
@@ -38,10 +38,13 @@ var NodeWithoutGroupMu lock.RWMutex
 var NotSubscribePodAddressMu lock.RWMutex
 
 type socatMulticast struct {
+	check.ScenarioBase
 }
 
 func SocatMulticast() check.Scenario {
-	return &socatMulticast{}
+	return &socatMulticast{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
 func (s *socatMulticast) Name() string {

--- a/cilium-cli/connectivity/tests/pod.go
+++ b/cilium-cli/connectivity/tests/pod.go
@@ -30,6 +30,7 @@ func PodToPod(opts ...Option) check.Scenario {
 		opt(options)
 	}
 	return &podToPod{
+		ScenarioBase:      check.NewScenarioBase(),
 		sourceLabels:      options.sourceLabels,
 		destinationLabels: options.destinationLabels,
 		method:            options.method,
@@ -38,6 +39,8 @@ func PodToPod(opts ...Option) check.Scenario {
 
 // podToPod implements a Scenario.
 type podToPod struct {
+	check.ScenarioBase
+
 	sourceLabels      map[string]string
 	destinationLabels map[string]string
 	method            string
@@ -91,6 +94,7 @@ func PodToPodWithEndpoints(opts ...Option) check.Scenario {
 		opt(rc)
 	}
 	return &podToPodWithEndpoints{
+		ScenarioBase:      check.NewScenarioBase(),
 		sourceLabels:      options.sourceLabels,
 		destinationLabels: options.destinationLabels,
 		method:            options.method,
@@ -101,6 +105,8 @@ func PodToPodWithEndpoints(opts ...Option) check.Scenario {
 
 // podToPodWithEndpoints implements a Scenario.
 type podToPodWithEndpoints struct {
+	check.ScenarioBase
+
 	sourceLabels      map[string]string
 	destinationLabels map[string]string
 	method            string
@@ -189,10 +195,14 @@ func (s *podToPodWithEndpoints) curlEndpoints(ctx context.Context, t *check.Test
 // - For IPv4: $POD_MTU - 20 (IPv4 hdr) - 8 (ICMP Echo hdr)
 // - For IPv6: $POD_MTU - 40 (IPv6 hdr) - 8 (ICMP Echo hdr)
 func PodToPodNoFrag() check.Scenario {
-	return &podToPodNoFrag{}
+	return &podToPodNoFrag{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
-type podToPodNoFrag struct{}
+type podToPodNoFrag struct {
+	check.ScenarioBase
+}
 
 func (s *podToPodNoFrag) Name() string {
 	return "pod-to-pod-no-frag"
@@ -270,6 +280,7 @@ func PodToPodMissingIPCache(opts ...Option) check.Scenario {
 		opt(options)
 	}
 	return &podToPodMissingIPCache{
+		ScenarioBase:      check.NewScenarioBase(),
 		sourceLabels:      options.sourceLabels,
 		destinationLabels: options.destinationLabels,
 		method:            options.method,
@@ -277,6 +288,8 @@ func PodToPodMissingIPCache(opts ...Option) check.Scenario {
 }
 
 type podToPodMissingIPCache struct {
+	check.ScenarioBase
+
 	sourceLabels      map[string]string
 	destinationLabels map[string]string
 	method            string

--- a/cilium-cli/connectivity/tests/service.go
+++ b/cilium-cli/connectivity/tests/service.go
@@ -23,6 +23,7 @@ func PodToService(opts ...Option) check.Scenario {
 		opt(options)
 	}
 	return &podToService{
+		ScenarioBase:      check.NewScenarioBase(),
 		sourceLabels:      options.sourceLabels,
 		destinationLabels: options.destinationLabels,
 	}
@@ -30,6 +31,8 @@ func PodToService(opts ...Option) check.Scenario {
 
 // podToService implements a Scenario.
 type podToService struct {
+	check.ScenarioBase
+
 	sourceLabels      map[string]string
 	destinationLabels map[string]string
 }
@@ -75,6 +78,7 @@ func PodToIngress(opts ...Option) check.Scenario {
 		opt(options)
 	}
 	return &podToIngress{
+		ScenarioBase:      check.NewScenarioBase(),
 		sourceLabels:      options.sourceLabels,
 		destinationLabels: options.destinationLabels,
 	}
@@ -82,6 +86,8 @@ func PodToIngress(opts ...Option) check.Scenario {
 
 // podToIngress implements a Scenario.
 type podToIngress struct {
+	check.ScenarioBase
+
 	sourceLabels      map[string]string
 	destinationLabels map[string]string
 }
@@ -119,11 +125,15 @@ func (s *podToIngress) Run(ctx context.Context, t *check.Test) {
 // PodToRemoteNodePort sends an HTTP request from all client Pods
 // to all echo Services' NodePorts, but only to other nodes.
 func PodToRemoteNodePort() check.Scenario {
-	return &podToRemoteNodePort{}
+	return &podToRemoteNodePort{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
 // podToRemoteNodePort implements a Scenario.
-type podToRemoteNodePort struct{}
+type podToRemoteNodePort struct {
+	check.ScenarioBase
+}
 
 func (s *podToRemoteNodePort) Name() string {
 	return "pod-to-remote-nodeport"
@@ -160,11 +170,15 @@ func (s *podToRemoteNodePort) Run(ctx context.Context, t *check.Test) {
 // to all echo Services' NodePorts, but only on the same node as
 // the client Pods.
 func PodToLocalNodePort() check.Scenario {
-	return &podToLocalNodePort{}
+	return &podToLocalNodePort{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
 // podToLocalNodePort implements a Scenario.
-type podToLocalNodePort struct{}
+type podToLocalNodePort struct {
+	check.ScenarioBase
+}
 
 func (s *podToLocalNodePort) Name() string {
 	return "pod-to-local-nodeport"
@@ -260,10 +274,14 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 // OutsideToNodePort sends an HTTP request from client pod running on a node w/o
 // Cilium to NodePort services.
 func OutsideToNodePort() check.Scenario {
-	return &outsideToNodePort{}
+	return &outsideToNodePort{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
-type outsideToNodePort struct{}
+type outsideToNodePort struct {
+	check.ScenarioBase
+}
 
 func (s *outsideToNodePort) Name() string {
 	return "outside-to-nodeport"
@@ -290,10 +308,14 @@ func (s *outsideToNodePort) Run(ctx context.Context, t *check.Test) {
 // OutsideToIngressService sends an HTTP request from client pod running on a node w/o
 // Cilium to NodePort services.
 func OutsideToIngressService() check.Scenario {
-	return &outsideToIngressService{}
+	return &outsideToIngressService{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
-type outsideToIngressService struct{}
+type outsideToIngressService struct {
+	check.ScenarioBase
+}
 
 func (s *outsideToIngressService) Name() string {
 	return "outside-to-ingress-service"

--- a/cilium-cli/connectivity/tests/to-cidr.go
+++ b/cilium-cli/connectivity/tests/to-cidr.go
@@ -20,11 +20,16 @@ func PodToCIDR(opts ...RetryOption) check.Scenario {
 	for _, op := range opts {
 		op(cond)
 	}
-	return &podToCIDR{rc: cond}
+	return &podToCIDR{
+		ScenarioBase: check.NewScenarioBase(),
+		rc:           cond,
+	}
 }
 
 // podToCIDR implements a Scenario.
 type podToCIDR struct {
+	check.ScenarioBase
+
 	rc *retryCondition
 }
 

--- a/cilium-cli/connectivity/tests/upgrade.go
+++ b/cilium-cli/connectivity/tests/upgrade.go
@@ -31,10 +31,14 @@ import (
 // counters, and compares them against the previously stored ones. A mismatch
 // indicates that a connection was interrupted.
 func NoInterruptedConnections() check.Scenario {
-	return &noInterruptedConnections{}
+	return &noInterruptedConnections{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
-type noInterruptedConnections struct{}
+type noInterruptedConnections struct {
+	check.ScenarioBase
+}
 
 func (n *noInterruptedConnections) Name() string {
 	return "no-interrupted-connections"

--- a/cilium-cli/connectivity/tests/world.go
+++ b/cilium-cli/connectivity/tests/world.go
@@ -30,11 +30,16 @@ func PodToWorld(opts ...RetryOption) check.Scenario {
 	for _, op := range opts {
 		op(cond)
 	}
-	return &podToWorld{rc: cond}
+	return &podToWorld{
+		ScenarioBase: check.NewScenarioBase(),
+		rc:           cond,
+	}
 }
 
 // podToWorld implements a Scenario.
 type podToWorld struct {
+	check.ScenarioBase
+
 	rc *retryCondition
 }
 
@@ -85,11 +90,15 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 // PodToWorld2 sends an HTTPS request to ExternalOtherTarget from random client
 // Pods.
 func PodToWorld2() check.Scenario {
-	return &podToWorld2{}
+	return &podToWorld2{
+		ScenarioBase: check.NewScenarioBase(),
+	}
 }
 
 // podToWorld2 implements a Scenario.
-type podToWorld2 struct{}
+type podToWorld2 struct {
+	check.ScenarioBase
+}
 
 func (s *podToWorld2) Name() string {
 	return "pod-to-world-2"
@@ -122,7 +131,8 @@ func (s *podToWorld2) Run(ctx context.Context, t *check.Test) {
 // PodToWorldWithTLSIntercept sends an HTTPS request to one.one.one.one (default value of ExternalTarget) from from random client
 func PodToWorldWithTLSIntercept(curlOpts ...string) check.Scenario {
 	s := &podToWorldWithTLSIntercept{
-		curlOpts: []string{"--cacert", "/tmp/test-ca.crt"}, // skip TLS verification as it will be our internal cert
+		curlOpts:     []string{"--cacert", "/tmp/test-ca.crt"}, // skip TLS verification as it will be our internal cert
+		ScenarioBase: check.NewScenarioBase(),
 	}
 
 	s.curlOpts = append(s.curlOpts, curlOpts...)
@@ -132,6 +142,8 @@ func PodToWorldWithTLSIntercept(curlOpts ...string) check.Scenario {
 
 // podToWorldWithTLSIntercept implements a Scenario.
 type podToWorldWithTLSIntercept struct {
+	check.ScenarioBase
+
 	curlOpts []string
 }
 
@@ -175,8 +187,9 @@ func (s *podToWorldWithTLSIntercept) Run(ctx context.Context, t *check.Test) {
 // The goal is to make sure the secret update path is verified.
 func PodToWorldWithExtraTLSIntercept(caName string, curlOpts ...string) check.Scenario {
 	s := &podToWorldWithExtraTLSIntercept{
-		caName:   caName,
-		curlOpts: []string{"--cacert", "/tmp/test-ca.crt"}, // skip TLS verification as it will be our internal cert
+		caName:       caName,
+		curlOpts:     []string{"--cacert", "/tmp/test-ca.crt"}, // skip TLS verification as it will be our internal cert
+		ScenarioBase: check.NewScenarioBase(),
 	}
 
 	s.curlOpts = append(s.curlOpts, curlOpts...)
@@ -185,6 +198,8 @@ func PodToWorldWithExtraTLSIntercept(caName string, curlOpts ...string) check.Sc
 }
 
 type podToWorldWithExtraTLSIntercept struct {
+	check.ScenarioBase
+
 	caName   string
 	curlOpts []string
 }

--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -174,6 +174,7 @@ var (
 		"inbound_state_invalid",  // XfrmInStateInvalid
 	}
 
+	LogCodeOwners  = false
 	LogCheckLevels = []string{
 		LogLevelError,
 		LogLevelWarning,

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/hmarr/codeowners v1.2.1
 	github.com/jeremywohl/flatten v1.0.1
 	github.com/json-iterator/go v1.1.12
 	github.com/kevinburke/ssh_config v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -441,6 +441,8 @@ github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/hmarr/codeowners v1.2.1 h1:+9yndrwG0UVP1GkLBEQMSbSUNeLpbrbL924SRthA/9k=
+github.com/hmarr/codeowners v1.2.1/go.mod h1:KPlR1p/B4owPjwfNIBueWlOP4CmqlQFX9b6nANG6j40=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/tools/testowners/main.go
+++ b/tools/testowners/main.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/hmarr/codeowners"
+
+	assets "github.com/cilium/cilium"
+)
+
+func fatal(fmt string, msg ...any) {
+	slog.Error(fmt, msg...)
+	os.Exit(1)
+}
+
+// TestEvent corresponds to the same structure from stdlib test2json.
+type TestEvent struct {
+	Time    time.Time // encodes as an RFC3339-format string
+	Action  string
+	Package string
+	Test    string
+	Elapsed float64 // seconds
+	Output  string
+}
+
+func main() {
+	owners, err := codeowners.ParseFile(strings.NewReader(assets.CodeOwnersRaw))
+	if err != nil {
+		fatal("🐛 Failed to parse CODEOWNERS. Developer BUG? %s\n", err)
+	}
+
+	// Example JSON for failed test:
+	// {"Time":"2025-01-31T07:35:57.837543016+01:00","Action":"start","Package":"github.com/cilium/cilium/test/fail"}
+	// {"Time":"2025-01-31T07:35:57.840861715+01:00","Action":"run","Package":"github.com/cilium/cilium/test/fail","Test":"TestFailure"}
+	// {"Time":"2025-01-31T07:35:57.840923716+01:00","Action":"output","Package":"github.com/cilium/cilium/test/fail","Test":"TestFailure","Output":"=== RUN   TestFailure\n"}
+	// {"Time":"2025-01-31T07:35:57.841037505+01:00","Action":"output","Package":"github.com/cilium/cilium/test/fail","Test":"TestFailure","Output":"--- FAIL: TestFailure (0.00s)\n"}
+	// {"Time":"2025-01-31T07:35:57.841053472+01:00","Action":"fail","Package":"github.com/cilium/cilium/test/fail","Test":"TestFailure","Elapsed":0}
+	// {"Time":"2025-01-31T07:35:57.841070189+01:00","Action":"output","Package":"github.com/cilium/cilium/test/fail","Output":"FAIL\n"}
+	// {"Time":"2025-01-31T07:35:57.841542486+01:00","Action":"output","Package":"github.com/cilium/cilium/test/fail","Output":"FAIL\tgithub.com/cilium/cilium/test/fail\t0.004s\n"}
+	// {"Time":"2025-01-31T07:35:57.841580354+01:00","Action":"fail","Package":"github.com/cilium/cilium/test/fail","Elapsed":0.004}
+
+	failedPackages := make(map[string]struct{})
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		var event TestEvent
+
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			fatal(" Failed to unmarshal test results. Is the input malformed?\n")
+		}
+
+		if event.Action == "fail" {
+			failedPackages[event.Package] = struct{}{}
+		}
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
+	if len(failedPackages) > 0 {
+		fmt.Fprintln(w, "⛑️ The following owners are responsible for reliability of the failing test(s): ")
+		fmt.Fprintln(w, "Package\tOwner")
+	}
+	exitCode := 0
+	for pkg := range failedPackages {
+		relPath := strings.TrimPrefix(pkg, "github.com/cilium/cilium/") + "/"
+		rule, err := owners.Match(relPath)
+		if err != nil || rule == nil || rule.Owners == nil {
+			exitCode = 1
+			line := "Failed to locate owner for package " + relPath
+			if err != nil {
+				line = line + ":" + err.Error()
+			}
+			slog.Error(line)
+			continue
+		}
+		owners := make([]string, 0, len(rule.Owners))
+		for _, o := range rule.Owners {
+			owners = append(owners, o.String())
+		}
+		fmt.Fprintln(w, pkg+"\t"+strings.Join(owners, ", "))
+	}
+	w.Flush()
+
+	os.Exit(exitCode)
+}

--- a/vendor/github.com/hmarr/codeowners/.gitignore
+++ b/vendor/github.com/hmarr/codeowners/.gitignore
@@ -1,0 +1,1 @@
+/codeowners

--- a/vendor/github.com/hmarr/codeowners/.goreleaser.yml
+++ b/vendor/github.com/hmarr/codeowners/.goreleaser.yml
@@ -1,0 +1,47 @@
+version: 2
+
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - main: ./cmd/codeowners
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+brews:
+  - homepage: "https://github.com/hmarr/codeowners"
+    description: "Determine who owns what according CODEOWNERS files"
+
+    repository:
+      owner: hmarr
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_RELEASE_TOKEN }}"
+
+    commit_author:
+      name: release-bot
+      email: release-bot@hmarr.com
+
+    directory: Formula
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^build:'
+      - '^deps:'
+      - '(?i)typo'

--- a/vendor/github.com/hmarr/codeowners/LICENSE
+++ b/vendor/github.com/hmarr/codeowners/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Harry Marr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/hmarr/codeowners/Makefile
+++ b/vendor/github.com/hmarr/codeowners/Makefile
@@ -1,0 +1,3 @@
+.PHONY: build
+build:
+	go build ./cmd/codeowners

--- a/vendor/github.com/hmarr/codeowners/README.md
+++ b/vendor/github.com/hmarr/codeowners/README.md
@@ -1,0 +1,123 @@
+# codeowners
+
+![build](https://github.com/hmarr/codeowners/workflows/build/badge.svg)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/hmarr/codeowners)](https://pkg.go.dev/github.com/hmarr/codeowners)
+
+A CLI and Go library for GitHub's [CODEOWNERS file](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax).
+
+## Command line tool
+
+The `codeowners` CLI identifies the owners for files in a local repository or directory.
+
+### Installation
+
+If you're on macOS, you can install the CLI from the [homebrew tap](https://github.com/hmarr/homebrew-tap#codeowners).
+
+```console
+$ brew tap hmarr/tap
+$ brew install codeowners
+```
+
+Otherwise, grab a binary from the [releases page](https://github.com/hmarr/codeowners/releases) or install from source with `go install`:
+
+```console
+$ go install github.com/hmarr/codeowners/cmd/codeowners@latest
+```
+
+### Usage
+
+By default, the command line tool will walk the directory tree, printing the code owners of any files that are found.
+
+```console
+$ codeowners --help
+usage: codeowners <path>...
+  -f, --file string     CODEOWNERS file path
+  -h, --help            show this help message
+  -o, --owner strings   filter results by owner
+  -u, --unowned         only show unowned files (can be combined with -o)
+
+$ ls
+CODEOWNERS       DOCUMENTATION.md README.md        example.go       example_test.go
+
+$ cat CODEOWNERS
+*.go       @example/go-engineers
+*.md       @example/docs-writers
+README.md  product-manager@example.com
+
+$ codeowners
+CODEOWNERS                           (unowned)
+README.md                            product-manager@example.com
+example_test.go                      @example/go-engineers
+example.go                           @example/go-engineers
+DOCUMENTATION.md                     @example/docs-writers
+```
+
+To limit the files the tool looks at, provide one or more paths as arguments.
+
+```console
+$ codeowners *.md
+README.md                            product-manager@example.com
+DOCUMENTATION.md                     @example/docs-writers
+```
+
+Pass the `--owner` flag to filter results by a specific owner.
+
+```console
+$ codeowners -o @example/go-engineers
+example_test.go                      @example/go-engineers
+example.go                           @example/go-engineers
+```
+
+Pass the `--unowned` flag to only show unowned files.
+
+```console
+$ codeowners -u
+CODEOWNERS                           (unowned)
+```
+
+## Go library
+
+A package for parsing CODEOWNERS files and matching files to owners.
+
+### Installation
+
+```console
+$ go get github.com/hmarr/codeowners
+```
+
+### Usage
+
+Full documentation is available at [pkg.go.dev](https://pkg.go.dev/github.com/hmarr/codeowners).
+
+Here's a quick example to get you started:
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/hmarr/codeowners"
+)
+
+func main() {
+	file, err := os.Open("CODEOWNERS")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ruleset, err := codeowners.ParseFile(file)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rule, err := ruleset.Match("path/to/file")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Owners: %v\n", rule.Owners)
+}
+```

--- a/vendor/github.com/hmarr/codeowners/codeowners.go
+++ b/vendor/github.com/hmarr/codeowners/codeowners.go
@@ -1,0 +1,160 @@
+// Package codeowners is a library for working with CODEOWNERS files.
+//
+// CODEOWNERS files map gitignore-style path patterns to sets of owners, which
+// may be GitHub users, GitHub teams, or email addresses. This library parses
+// the CODEOWNERS file format into rulesets, which may then be used to determine
+// the ownership of files.
+//
+// Usage
+//
+// To find the owner of a given file, parse a CODEOWNERS file and call Match()
+// on the resulting ruleset.
+//  ruleset, err := codeowners.ParseFile(file)
+//  if err != nil {
+//  	log.Fatal(err)
+//  }
+//
+//  rule, err := ruleset.Match("path/to/file")
+//  if err != nil {
+//  	log.Fatal(err)
+//  }
+//
+// Command line interface
+//
+// A command line interface is also available in the cmd/codeowners package.
+// When run, it will walk the directory tree showing the code owners for each
+// file encountered. The help flag lists available options.
+//
+//  $ codeowners --help
+package codeowners
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// LoadFileFromStandardLocation loads and parses a CODEOWNERS file at one of the
+// standard locations for CODEOWNERS files (./, .github/, docs/). If run from a
+// git repository, all paths are relative to the repository root.
+func LoadFileFromStandardLocation() (Ruleset, error) {
+	path := findFileAtStandardLocation()
+	if path == "" {
+		return nil, fmt.Errorf("could not find CODEOWNERS file at any of the standard locations")
+	}
+	return LoadFile(path)
+}
+
+// LoadFile loads and parses a CODEOWNERS file at the path specified.
+func LoadFile(path string) (Ruleset, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return ParseFile(f)
+}
+
+// findFileAtStandardLocation loops through the standard locations for
+// CODEOWNERS files (./, .github/, docs/), and returns the first place a
+// CODEOWNERS file is found. If run from a git repository, all paths are
+// relative to the repository root.
+func findFileAtStandardLocation() string {
+	pathPrefix := ""
+	repoRoot, inRepo := findRepositoryRoot()
+	if inRepo {
+		pathPrefix = repoRoot
+	}
+
+	for _, path := range []string{"CODEOWNERS", ".github/CODEOWNERS", ".gitlab/CODEOWNERS", "docs/CODEOWNERS"} {
+		fullPath := filepath.Join(pathPrefix, path)
+		if fileExists(fullPath) {
+			return fullPath
+		}
+	}
+	return ""
+}
+
+// fileExist checks if a normal file exists at the path specified.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
+// findRepositoryRoot returns the path to the root of the git repository, if
+// we're currently in one. If we're not in a git repository, the boolean return
+// value is false.
+func findRepositoryRoot() (string, bool) {
+	output, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(output)), true
+}
+
+// Ruleset is a collection of CODEOWNERS rules.
+type Ruleset []Rule
+
+// Match finds the last rule in the ruleset that matches the path provided. When
+// determining the ownership of a file using CODEOWNERS, order matters, and the
+// last matching rule takes precedence.
+func (r Ruleset) Match(path string) (*Rule, error) {
+	for i := len(r) - 1; i >= 0; i-- {
+		rule := &r[i]
+		match, err := rule.Match(path)
+		if match || err != nil {
+			return rule, err
+		}
+	}
+	return nil, nil
+}
+
+// Rule is a CODEOWNERS rule that maps a gitignore-style path pattern to a set
+// of owners.
+type Rule struct {
+	Owners     []Owner
+	Comment    string
+	LineNumber int
+	pattern    pattern
+}
+
+// RawPattern returns the rule's gitignore-style path pattern.
+func (r Rule) RawPattern() string {
+	return r.pattern.pattern
+}
+
+// Match tests whether the provided matches the rule's pattern.
+func (r Rule) Match(path string) (bool, error) {
+	return r.pattern.match(path)
+}
+
+const (
+	// EmailOwner is the owner type for email addresses.
+	EmailOwner string = "email"
+	// TeamOwner is the owner type for GitHub teams.
+	TeamOwner string = "team"
+	// UsernameOwner is the owner type for GitHub usernames.
+	UsernameOwner string = "username"
+)
+
+// Owner represents an owner found in a rule.
+type Owner struct {
+	// Value is the name of the owner: the email addres, team name, or username.
+	Value string
+	// Type will be one of 'email', 'team', or 'username'.
+	Type string
+}
+
+// String returns a string representation of the owner. For email owners, it
+// simply returns the email address. For user and team owners it prepends an '@'
+// to the owner.
+func (o Owner) String() string {
+	if o.Type == EmailOwner {
+		return o.Value
+	}
+	return "@" + o.Value
+}

--- a/vendor/github.com/hmarr/codeowners/match.go
+++ b/vendor/github.com/hmarr/codeowners/match.go
@@ -1,0 +1,177 @@
+package codeowners
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type pattern struct {
+	pattern             string
+	regex               *regexp.Regexp
+	leftAnchoredLiteral bool
+}
+
+// newPattern creates a new pattern struct from a gitignore-style pattern string
+func newPattern(patternStr string) (pattern, error) {
+	pat := pattern{pattern: patternStr}
+
+	if !strings.ContainsAny(patternStr, "*?\\") && patternStr[0] == '/' {
+		pat.leftAnchoredLiteral = true
+	} else {
+		patternRegex, err := buildPatternRegex(patternStr)
+		if err != nil {
+			return pattern{}, err
+		}
+		pat.regex = patternRegex
+	}
+
+	return pat, nil
+}
+
+// match tests if the path provided matches the pattern
+func (p pattern) match(testPath string) (bool, error) {
+	// Normalize Windows-style path separators to forward slashes
+	testPath = filepath.ToSlash(testPath)
+
+	if p.leftAnchoredLiteral {
+		prefix := p.pattern
+
+		// Strip the leading slash as we're anchored to the root already
+		if prefix[0] == '/' {
+			prefix = prefix[1:]
+		}
+
+		// If the pattern ends with a slash we can do a simple prefix match
+		if prefix[len(prefix)-1] == '/' {
+			return strings.HasPrefix(testPath, prefix), nil
+		}
+
+		// If the strings are the same length, check for an exact match
+		if len(testPath) == len(prefix) {
+			return testPath == prefix, nil
+		}
+
+		// Otherwise check if the test path is a subdirectory of the pattern
+		if len(testPath) > len(prefix) && testPath[len(prefix)] == '/' {
+			return testPath[:len(prefix)] == prefix, nil
+		}
+
+		// Otherwise the test path must be shorter than the pattern, so it can't match
+		return false, nil
+	}
+
+	return p.regex.MatchString(testPath), nil
+}
+
+// buildPatternRegex compiles a new regexp object from a gitignore-style pattern string
+func buildPatternRegex(pattern string) (*regexp.Regexp, error) {
+	// Handle specific edge cases first
+	switch {
+	case strings.Contains(pattern, "***"):
+		return nil, fmt.Errorf("pattern cannot contain three consecutive asterisks")
+	case pattern == "":
+		return nil, fmt.Errorf("empty pattern")
+	case pattern == "/":
+		// "/" doesn't match anything
+		return regexp.Compile(`\A\z`)
+	}
+
+	segs := strings.Split(pattern, "/")
+
+	if segs[0] == "" {
+		// Leading slash: match is relative to root
+		segs = segs[1:]
+	} else {
+		// No leading slash - check for a single segment pattern, which matches
+		// relative to any descendent path (equivalent to a leading **/)
+		if len(segs) == 1 || (len(segs) == 2 && segs[1] == "") {
+			if segs[0] != "**" {
+				segs = append([]string{"**"}, segs...)
+			}
+		}
+	}
+
+	if len(segs) > 1 && segs[len(segs)-1] == "" {
+		// Trailing slash is equivalent to "/**"
+		segs[len(segs)-1] = "**"
+	}
+
+	sep := "/"
+
+	lastSegIndex := len(segs) - 1
+	needSlash := false
+	var re strings.Builder
+	re.WriteString(`\A`)
+	for i, seg := range segs {
+		switch seg {
+		case "**":
+			switch {
+			case i == 0 && i == lastSegIndex:
+				// If the pattern is just "**" we match everything
+				re.WriteString(`.+`)
+			case i == 0:
+				// If the pattern starts with "**" we match any leading path segment
+				re.WriteString(`(?:.+` + sep + `)?`)
+				needSlash = false
+			case i == lastSegIndex:
+				// If the pattern ends with "**" we match any trailing path segment
+				re.WriteString(sep + `.*`)
+			default:
+				// If the pattern contains "**" we match zero or more path segments
+				re.WriteString(`(?:` + sep + `.+)?`)
+				needSlash = true
+			}
+
+		case "*":
+			if needSlash {
+				re.WriteString(sep)
+			}
+
+			// Regular wildcard - match any characters except the separator
+			re.WriteString(`[^` + sep + `]+`)
+			needSlash = true
+
+		default:
+			if needSlash {
+				re.WriteString(sep)
+			}
+
+			escape := false
+			for _, ch := range seg {
+				if escape {
+					escape = false
+					re.WriteString(regexp.QuoteMeta(string(ch)))
+					continue
+				}
+
+				// Other pathspec implementations handle character classes here (e.g.
+				// [AaBb]), but CODEOWNERS doesn't support that so we don't need to
+				switch ch {
+				case '\\':
+					escape = true
+				case '*':
+					// Multi-character wildcard
+					re.WriteString(`[^` + sep + `]*`)
+				case '?':
+					// Single-character wildcard
+					re.WriteString(`[^` + sep + `]`)
+				default:
+					// Regular character
+					re.WriteString(regexp.QuoteMeta(string(ch)))
+				}
+			}
+
+			if i == lastSegIndex {
+				// As there's no trailing slash (that'd hit the '**' case), we
+				// need to match descendent paths
+				re.WriteString(`(?:` + sep + `.*)?`)
+			}
+
+			needSlash = true
+		}
+	}
+	re.WriteString(`\z`)
+	return regexp.Compile(re.String())
+}

--- a/vendor/github.com/hmarr/codeowners/parse.go
+++ b/vendor/github.com/hmarr/codeowners/parse.go
@@ -1,0 +1,273 @@
+package codeowners
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+type parseOption func(*parseOptions)
+
+type parseOptions struct {
+	ownerMatchers []OwnerMatcher
+}
+
+func WithOwnerMatchers(mm []OwnerMatcher) parseOption {
+	return func(opts *parseOptions) {
+		opts.ownerMatchers = mm
+	}
+}
+
+type OwnerMatcher interface {
+	// Matches give string agains a pattern e.g. a regexp.
+	// Should return ErrNoMatch if the pattern doesn't match.
+	Match(s string) (Owner, error)
+}
+
+type ErrInvalidOwnerFormat struct {
+	Owner string
+}
+
+func (err ErrInvalidOwnerFormat) Error() string {
+	return fmt.Sprintf("invalid owner format '%s'", err.Owner)
+}
+
+var ErrNoMatch = errors.New("no match")
+
+var (
+	emailRegexp    = regexp.MustCompile(`\A[A-Z0-9a-z\._%\+\-]+@[A-Za-z0-9\.\-]+\.[A-Za-z]{2,6}\z`)
+	teamRegexp     = regexp.MustCompile(`\A@([a-zA-Z0-9\-]+\/[a-zA-Z0-9_\-]+)\z`)
+	usernameRegexp = regexp.MustCompile(`\A@([a-zA-Z0-9\-_]+)\z`)
+)
+
+// DefaultOwnerMatchers is the default set of owner matchers, which includes the
+// GitHub-flavored email, team, and username matchers.
+var DefaultOwnerMatchers = []OwnerMatcher{
+	OwnerMatchFunc(MatchEmailOwner),
+	OwnerMatchFunc(MatchTeamOwner),
+	OwnerMatchFunc(MatchUsernameOwner),
+}
+
+// OwnerMatchFunc is a function that matches a string against a pattern and
+// returns an Owner, or ErrNoMatch if no match was found. It implements the
+// OwnerMatcher interface and may be provided to WithOwnerMatchers to customize
+// owner matching behavior (e.g. to support GitLab-style team names).
+type OwnerMatchFunc func(s string) (Owner, error)
+
+func (f OwnerMatchFunc) Match(s string) (Owner, error) {
+	return f(s)
+}
+
+// MatchEmailOwner matches an email address owner. May be provided to
+// WithOwnerMatchers.
+func MatchEmailOwner(s string) (Owner, error) {
+	match := emailRegexp.FindStringSubmatch(s)
+	if match == nil {
+		return Owner{}, ErrNoMatch
+	}
+
+	return Owner{Value: match[0], Type: EmailOwner}, nil
+}
+
+// MatchTeamOwner matches a GitHub team owner. May be provided to
+// WithOwnerMatchers.
+func MatchTeamOwner(s string) (Owner, error) {
+	match := teamRegexp.FindStringSubmatch(s)
+	if match == nil {
+		return Owner{}, ErrNoMatch
+	}
+
+	return Owner{Value: match[1], Type: TeamOwner}, nil
+}
+
+// MatchUsernameOwner matches a GitHub username owner. May be provided to
+// WithOwnerMatchers.
+func MatchUsernameOwner(s string) (Owner, error) {
+	match := usernameRegexp.FindStringSubmatch(s)
+	if match == nil {
+		return Owner{}, ErrNoMatch
+	}
+
+	return Owner{Value: match[1], Type: UsernameOwner}, nil
+}
+
+// ParseFile parses a CODEOWNERS file, returning a set of rules.
+// To override the default owner matchers, pass WithOwnerMatchers() as an option.
+func ParseFile(f io.Reader, options ...parseOption) (Ruleset, error) {
+	opts := parseOptions{ownerMatchers: DefaultOwnerMatchers}
+	for _, opt := range options {
+		opt(&opts)
+	}
+
+	rules := Ruleset{}
+	scanner := bufio.NewScanner(f)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+
+		// Ignore blank lines and comments
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+
+		rule, err := parseRule(line, opts)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", lineNo, err)
+		}
+		rule.LineNumber = lineNo
+		rules = append(rules, rule)
+	}
+	return rules, nil
+}
+
+const (
+	statePattern = iota + 1
+	stateOwners
+)
+
+// parseRule parses a single line of a CODEOWNERS file, returning a Rule struct
+func parseRule(ruleStr string, opts parseOptions) (Rule, error) {
+	r := Rule{}
+
+	state := statePattern
+	escaped := false
+	buf := bytes.Buffer{}
+	for i, ch := range strings.TrimSpace(ruleStr) {
+		// Comments consume the rest of the line and stop further parsing
+		if ch == '#' {
+			r.Comment = strings.TrimSpace(ruleStr[i+1:])
+			break
+		}
+
+		switch state {
+		case statePattern:
+			switch {
+			case ch == '\\':
+				// Escape the next character (important for whitespace while parsing), but
+				// don't lose the backslash as it's part of the pattern
+				escaped = true
+				buf.WriteRune(ch)
+				continue
+
+			case isWhitespace(ch) && !escaped:
+				// Unescaped whitespace means this is the end of the pattern
+				pattern, err := newPattern(buf.String())
+				if err != nil {
+					return r, err
+				}
+				r.pattern = pattern
+				buf.Reset()
+				state = stateOwners
+
+			case isPatternChar(ch) || (isWhitespace(ch) && escaped):
+				// Keep any valid pattern characters and escaped whitespace
+				buf.WriteRune(ch)
+
+			default:
+				return r, fmt.Errorf("unexpected character '%c' at position %d", ch, i+1)
+			}
+			// Escaping only applies to one character
+			escaped = false
+
+		case stateOwners:
+			switch {
+			case isWhitespace(ch):
+				// Whitespace means we've reached the end of the owner or we're just chomping
+				// through whitespace before or after owner declarations
+				if buf.Len() > 0 {
+					ownerStr := buf.String()
+					owner, err := newOwner(ownerStr, opts.ownerMatchers)
+					if err != nil {
+						return r, fmt.Errorf("%w at position %d", err, i+1-len(ownerStr))
+					}
+					r.Owners = append(r.Owners, owner)
+					buf.Reset()
+				}
+
+			case isOwnersChar(ch):
+				// Write valid owner characters to the buffer
+				buf.WriteRune(ch)
+
+			default:
+				return r, fmt.Errorf("unexpected character '%c' at position %d", ch, i+1)
+			}
+		}
+	}
+
+	// We've finished consuming the line, but we might still have content in the buffer
+	// if the line didn't end with a separator (whitespace)
+	switch state {
+	case statePattern:
+		if buf.Len() == 0 { // We should have non-empty pattern
+			return r, fmt.Errorf("unexpected end of rule")
+		}
+
+		pattern, err := newPattern(buf.String())
+		if err != nil {
+			return r, err
+		}
+		r.pattern = pattern
+
+	case stateOwners:
+		// If there's an owner left in the buffer, don't leave it behind
+		if buf.Len() > 0 {
+			ownerStr := buf.String()
+			owner, err := newOwner(ownerStr, opts.ownerMatchers)
+			if err != nil {
+				return r, fmt.Errorf("%s at position %d", err.Error(), len(ruleStr)+1-len(ownerStr))
+			}
+			r.Owners = append(r.Owners, owner)
+		}
+	}
+
+	return r, nil
+}
+
+// newOwner figures out which kind of owner this is and returns an Owner struct
+func newOwner(s string, mm []OwnerMatcher) (Owner, error) {
+	for _, m := range mm {
+		o, err := m.Match(s)
+		if errors.Is(err, ErrNoMatch) {
+			continue
+		} else if err != nil {
+			return Owner{}, err
+		}
+
+		return o, nil
+	}
+
+	return Owner{}, ErrInvalidOwnerFormat{
+		Owner: s,
+	}
+}
+
+func isWhitespace(ch rune) bool {
+	return ch == ' ' || ch == '\t' || ch == '\n'
+}
+
+func isAlphanumeric(ch rune) bool {
+	return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')
+}
+
+// isPatternChar matches characters that are allowed in patterns
+func isPatternChar(ch rune) bool {
+	switch ch {
+	case '*', '?', '.', '/', '@', '_', '+', '-', '\\', '(', ')':
+		return true
+	}
+	return isAlphanumeric(ch)
+}
+
+// isOwnersChar matches characters that are allowed in owner definitions
+func isOwnersChar(ch rune) bool {
+	switch ch {
+	case '.', '@', '/', '_', '%', '+', '-':
+		return true
+	}
+	return isAlphanumeric(ch)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1069,6 +1069,9 @@ github.com/hashicorp/hcl/hcl/token
 github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
+# github.com/hmarr/codeowners v1.2.1
+## explicit; go 1.18
+github.com/hmarr/codeowners
 # github.com/huandu/xstrings v1.5.0
 ## explicit; go 1.12
 github.com/huandu/xstrings


### PR DESCRIPTION
Review commit-by-commit. Don't be scared of the size, the majority is the new vendor dependency.

This PR introduces a link between CLI and/or unit test failures to the underlying CODEOWNERS for the corresponding test files, and pretty-prints a message after the test failure to indicate who can assist with understanding the test and stabilizing the results. See the lines with the ⛑️:

CLI Example:

![image](https://github.com/user-attachments/assets/87ed1c88-d577-44ab-a36f-fe92f69e017d)

Unit test example:

![image](https://github.com/user-attachments/assets/10d34705-2135-4c0b-ac38-dbe528ff9248)

Related: https://github.com/cilium/cilium-cli/pull/2936 will allow this logic to also pick up owners from the github workflow where the CLI is run.

Tested here: https://github.com/cilium/cilium/pull/37593#issuecomment-2656891762 .

Note that for CLI test failures, tests that properly use `a.Fail()`, `a.Fatal()` and similar functions to trigger a failure in an individual test action correctly, the attribution will go correctly to the test owner. Tests that fail directly with the top-level test fail functions (ie not `t.Fail()`, `t.Fatal()`, ...) will be attributed to @cilium/ci-structure.