### PR TITLE
plugins/cilium-cni: implement CNI STATUS support

### DIFF
--- a/plugins/cilium-cni/chaining/api/api.go
+++ b/plugins/cilium-cni/chaining/api/api.go
@@ -51,6 +51,10 @@ type ChainingPlugin interface {
 	// Check is called on CNI CHECK. The plugin should verify (to the best of its
 	// ability) that everything is reasonably configured, else return error.
 	Check(ctx context.Context, pluginContext PluginContext, client *client.Client) error
+
+	// Status is called on CNI STATUS. The plugin should return an error
+	// with exit code 50 if the plugin is not ready to service ADD requests.
+	Status(ctx context.Context, pluginContext PluginContext, client *client.Client) error
 }
 
 // Register is called by chaining plugins to register themselves. After

--- a/plugins/cilium-cni/chaining/api/api_test.go
+++ b/plugins/cilium-cni/chaining/api/api_test.go
@@ -28,6 +28,10 @@ func (p *pluginTest) Check(ctx context.Context, pluginContext PluginContext, cli
 	return nil
 }
 
+func (p *pluginTest) Status(ctx context.Context, pluginContext PluginContext, cli *client.Client) error {
+	return nil
+}
+
 func TestRegistration(t *testing.T) {
 	err := Register("foo", &pluginTest{})
 	require.NoError(t, err)

--- a/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
+++ b/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
@@ -279,6 +279,14 @@ func (f *GenericVethChainer) Check(ctx context.Context, pluginCtx chainingapi.Pl
 	return nil
 }
 
+func (f *GenericVethChainer) Status(ctx context.Context, pluginCtx chainingapi.PluginContext, cli *client.Client) error {
+	if _, err := cli.Daemon.GetHealthz(nil); err != nil {
+		return cniTypes.NewError(types.CniErrPluginNotAvailable, "DaemonHealthzFailed",
+			fmt.Sprintf("Cilium agent healthz check failed: %s", client.Hint(err)))
+	}
+	return nil
+}
+
 func init() {
 	chainingapi.Register("generic-veth", &GenericVethChainer{})
 }

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -94,9 +94,10 @@ func NewCmd(opts ...Option) *Cmd {
 // CNIFuncs returns the CNI functions supported by Cilium that can be passed to skel.PluginMainFuncs
 func (cmd *Cmd) CNIFuncs() skel.CNIFuncs {
 	return skel.CNIFuncs{
-		Add:   cmd.Add,
-		Del:   cmd.Del,
-		Check: cmd.Check,
+		Add:    cmd.Add,
+		Del:    cmd.Del,
+		Check:  cmd.Check,
+		Status: cmd.Status,
 	}
 }
 
@@ -947,6 +948,92 @@ func (cmd *Cmd) Check(args *skel.CmdArgs) error {
 	// we can get the IP from the CNI previous result.
 	if err := verifyInterface(args.Netns, args.IfName, prevResult); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// Status implements the cni STATUS verb.
+// Currently, it
+//   - checks cilium-cni connectivity with cilium-agent using healthz endpoint
+//   - If cilium-cni depends on delegated plugins (host-local, azure etc) for IPAM,
+//     cilium-cni invokes the STATUS API of the delegated plugins and passes the result back.
+func (cmd *Cmd) Status(args *skel.CmdArgs) error {
+	n, err := types.LoadNetConf(args.StdinData)
+	if err != nil {
+		return cniTypes.NewError(cniTypes.ErrInvalidNetworkConfig, "InvalidNetworkConfig",
+			fmt.Sprintf("unable to parse CNI configuration \"%s\": %v", string(args.StdinData), err))
+	}
+
+	if err := setupLogging(n); err != nil {
+		return cniTypes.NewError(cniTypes.ErrInvalidNetworkConfig, "InvalidLoggingConfig",
+			fmt.Sprintf("unable to setup logging: %s", err))
+	}
+
+	logger := loggerWithArguments(log.WithField(logfields.EventUUID, uuid.New()), args)
+
+	if n.EnableDebug {
+		if err := gops.Listen(gops.Options{}); err != nil {
+			log.WithError(err).Warn("Unable to start gops")
+		} else {
+			defer gops.Close()
+		}
+	}
+	logger.WithField("netconf", logfields.Repr(n)).Debugf("Processing CNI STATUS request")
+
+	if n.PrevResult != nil {
+		logger.WithField("previousResult", logfields.Repr(n.PrevResult)).Debugf("CNI Previous result")
+	}
+
+	cniArgs := &types.ArgsSpec{}
+	if err = cniTypes.LoadArgs(args.Args, cniArgs); err != nil {
+		return cniTypes.NewError(cniTypes.ErrInvalidNetworkConfig, "InvalidArgs",
+			fmt.Sprintf("unable to extract CNI arguments: %s", err))
+	}
+	logger = loggerWithCNIArgs(logger, cniArgs)
+
+	c, err := client.NewDefaultClientWithTimeout(defaults.ClientConnectTimeout)
+	if err != nil {
+		// use ErrTryAgainLater to tell the runtime that this is not a check failure
+		return cniTypes.NewError(cniTypes.ErrTryAgainLater, "DaemonDown",
+			fmt.Sprintf("unable to connect to Cilium agent: %s", client.Hint(err)))
+	}
+
+	if _, err := c.Daemon.GetHealthz(nil); err != nil {
+		return cniTypes.NewError(types.CniErrPluginNotAvailable, "DaemonHealthzFailed",
+			fmt.Sprintf("Cilium agent healthz check failed: %s", client.Hint(err)))
+	}
+	logger.Debugf("Cilium agent is healthy")
+
+	// If this is a chained plugin, then "delegate" to the special chaining mode and be done
+	if chainAction, err := getChainedAction(n, logger); chainAction != nil {
+		var (
+			ctx = chainingapi.PluginContext{
+				Logger:  logger,
+				Args:    args,
+				CniArgs: cniArgs,
+				NetConf: n,
+			}
+		)
+
+		// err is nil on success
+		err := chainAction.Status(context.TODO(), ctx, c)
+		logger.WithError(err).Debugf("Chained STATUS %s returned", n.Name)
+
+		return err
+	} else if err != nil {
+		logger.WithError(err).Error("Invalid chaining mode")
+		return err
+	}
+	fmt.Fprintln(os.Stderr, "No chained plugin")
+
+	if n.IPAM.Type != "" {
+		// If using a delegated plugin for IPAM, invoke the STATUS API of the delegated
+		// plugins and pass the result back.
+		err = cniInvoke.DelegateStatus(context.TODO(), n.IPAM.Type, args.StdinData, nil)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -995,15 +995,9 @@ func (cmd *Cmd) Status(args *skel.CmdArgs) error {
 	c, err := client.NewDefaultClientWithTimeout(defaults.ClientConnectTimeout)
 	if err != nil {
 		// use ErrTryAgainLater to tell the runtime that this is not a check failure
-		return cniTypes.NewError(cniTypes.ErrTryAgainLater, "DaemonDown",
+		return cniTypes.NewError(types.CniErrPluginNotAvailable, "DaemonDown",
 			fmt.Sprintf("unable to connect to Cilium agent: %s", client.Hint(err)))
 	}
-
-	if _, err := c.Daemon.GetHealthz(nil); err != nil {
-		return cniTypes.NewError(types.CniErrPluginNotAvailable, "DaemonHealthzFailed",
-			fmt.Sprintf("Cilium agent healthz check failed: %s", client.Hint(err)))
-	}
-	logger.Debugf("Cilium agent is healthy")
 
 	// If this is a chained plugin, then "delegate" to the special chaining mode and be done
 	if chainAction, err := getChainedAction(n, logger); chainAction != nil {
@@ -1025,7 +1019,12 @@ func (cmd *Cmd) Status(args *skel.CmdArgs) error {
 		logger.WithError(err).Error("Invalid chaining mode")
 		return err
 	}
-	fmt.Fprintln(os.Stderr, "No chained plugin")
+
+	if _, err := c.Daemon.GetHealthz(nil); err != nil {
+		return cniTypes.NewError(types.CniErrPluginNotAvailable, "DaemonHealthzFailed",
+			fmt.Sprintf("Cilium agent healthz check failed: %s", client.Hint(err)))
+	}
+	logger.Debugf("Cilium agent is healthy")
 
 	if n.IPAM.Type != "" {
 		// If using a delegated plugin for IPAM, invoke the STATUS API of the delegated

--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -20,6 +20,6 @@ func init() {
 func main() {
 	c := cmd.NewCmd()
 	skel.PluginMainFuncs(c.CNIFuncs(),
-		cniVersion.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0"),
+		cniVersion.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0", "1.1.0"),
 		"Cilium CNI plugin "+version.Version)
 }

--- a/plugins/cilium-cni/types/types.go
+++ b/plugins/cilium-cni/types/types.go
@@ -113,3 +113,4 @@ const (
 	CniErrHealthzGet uint = 100
 	CniErrUnhealthy       = iota
 )
+const CniErrPluginNotAvailable uint = 50


### PR DESCRIPTION
This PR replaces https://github.com/cilium/cilium/pull/36995.

CFP: https://github.com/cilium/design-cfps/blob/main/cilium/CFP-35631-support-cni-status-operation.md

This commit adds support for the STATUS verb in the CNI v1.1.0 spec. STATUS is currently called by containerd's CRI Status(), which is called periodically by the kubelet. When STATUS is called, Cilium CNI will check that it has connectivity to the agent and return an error otherwise.  See the linked CFP for more details.

Manually tested with `kind` and `containerd 2.0.1`, which is the version that adds support for calling STATUS on CNI plugins.  The kubelet calls CRI STATUS every 5 seconds to determine whether the NetworkReady=true for the node, and conatinerd in turn calls Cilium's STATUS as expected:

```
$ docker exec -it kind-worker journalctl -u containerd | grep STATUS
Jan 15 19:41:12 kind-worker containerd[111]: time="2025-01-15T19:41:12.715064312Z" level=debug msg="Processing CNI STATUS request" args= containerID= eventID=8d6e5d93-0d30-4f12-8038-e6684aaa95a3 file-path=/opt/cni/bin ifName= netconf="&{NetConf:{CNIVersion:1.1.0 Name:cilium Type:cilium-cni Capabilities:map[] IPAM:{Type:} DNS:{Nameservers:[] Domain: Search:[] Options:[]} RawPrevResult:map[] PrevResult:<nil> ValidAttachments:[]} MTU:0 Args:{} EnableRouteMTU:false ENI:{InstanceID: InstanceType: MinAllocate:0 PreAllocate:0 MaxAboveWatermark:0 FirstInterfaceIndex:<nil> SecurityGroups:[] SecurityGroupTags:map[] SubnetIDs:[] SubnetTags:map[] NodeSubnetID: VpcID: AvailabilityZone: ExcludeInterfaceTags:map[] DeleteOnTermination:<nil> UsePrimaryAddress:<nil> DisablePrefixDelegation:<nil>} Azure:{InterfaceName:} IPAM:{IPAM:{Type:} IPAMSpec:{Pool:map[] IPv6Pool:map[] Pools:{Requested:[] Allocated:[]} PodCIDRs:[] MinAllocate:0 MaxAllocate:0 PreAllocate:0 MaxAboveWatermark:0 StaticIPTags:map[]}} AlibabaCloud:{InstanceType: AvailabilityZone: VPCID: CIDRBlock: VSwitches:[] VSwitchTags:map[] SecurityGroups:[] SecurityGroupTags:map[]} EnableDebug:true LogFormat: LogFile:/var/run/cilium/cilium-cni.log ChainingMode:}" netns= subsys=cilium-cni
Jan 15 19:41:17 kind-worker containerd[111]: time="2025-01-15T19:41:17.749578649Z" level=debug msg="Processing CNI STATUS request" [ ... ]
[...]
```

```
$ docker exec -it kind-worker journalctl -u kubelet | grep "Container runtime" | tail -3
Jan 15 19:51:52 kind-worker kubelet[237]: I0115 19:51:52.336167     237 kubelet.go:3001] "Container runtime status" status="Runtime Conditions: RuntimeReady=true reason: message:, NetworkReady=true reason: message:, ContainerdHasNoDeprecationWarnings=true reason: message:; Handlers: Name=runc SupportsRecursiveReadOnlyMounts: true SupportsUserNamespaces: true, Name= SupportsRecursiveReadOnlyMounts: true SupportsUserNamespaces: true, Name=test-handler SupportsRecursiveReadOnlyMounts: true SupportsUserNamespaces: true, Features: SupplementalGroupsPolicy: true"
Jan 15 19:51:57 kind-worker kubelet[237]: I0115 19:51:57.371872     237 kubelet.go:3001] "Container runtime status" status="Runtime Conditions: RuntimeReady=true reason: message:, NetworkReady=true reason: message:, ContainerdHasNoDeprecationWarnings=true reason: message:; Handlers: Name=runc SupportsRecursiveReadOnlyMounts: true SupportsUserNamespaces: true, Name= SupportsRecursiveReadOnlyMounts: true SupportsUserNamespaces: true, Name=test-handler SupportsRecursiveReadOnlyMounts: true SupportsUserNamespaces: true, Features: SupplementalGroupsPolicy: true"
Jan 15 19:52:02 kind-worker kubelet[237]: I0115 19:52:02.409194     237 kubelet.go:3001] "Container runtime status" status="Runtime Conditions: RuntimeReady=true reason: message:, NetworkReady=true reason: message:, ContainerdHasNoDeprecationWarnings=true reason: message:; Handlers: Name=runc SupportsRecursiveReadOnlyMounts: true SupportsUserNamespaces: true, Name= SupportsRecursiveReadOnlyMounts: true SupportsUserNamespaces: true, Name=test-handler SupportsRecursiveReadOnlyMounts: true SupportsUserNamespaces: true, Features: SupplementalGroupsPolicy: true"
```

Note: I had to update this line https://github.com/cilium/cilium/blob/70c42143ed2ef93f3de16b7c217bc84ee52f2952/daemon/cmd/cni/config.go#L97 to v1.1.0 to get it to work, but I'm guessing we don't want to update it in this PR because all of the other requirements for v1.1.0 are not met (e.g. the verb "GC" is missing.)

I have not yet tested the "chained plugin" case and the case of delegated plugins for IPAM.


Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Adds support for the CNI STATUS operation (https://github.com/containernetworking/cni/blob/main/SPEC.md#status-check-plugin-status)
```
