### PR TITLE
Update isFqdn fn based on the source github.com/miekg/dns

### DIFF
--- a/pkg/fqdn/dns/dns.go
+++ b/pkg/fqdn/dns/dns.go
@@ -15,18 +15,27 @@ import "strings"
 
 // isFQDN reports whether the domain name s is fully qualified.
 func isFQDN(s string) bool {
-	s2 := strings.TrimSuffix(s, ".")
-	if s == s2 {
+	// Check for (and remove) a trailing dot, returning if there isn't one.
+	if s == "" || s[len(s)-1] != '.' {
 		return false
 	}
+	s = s[:len(s)-1]
 
-	i := strings.LastIndexFunc(s2, func(r rune) bool {
+	// If we don't have an escape sequence before the final dot, we know it's
+	// fully qualified and can return here.
+	if s == "" || s[len(s)-1] != '\\' {
+		return true
+	}
+
+	// Otherwise we have to check if the dot is escaped or not by checking if
+	// there are an odd or even number of escape sequences before the dot.
+	i := strings.LastIndexFunc(s, func(r rune) bool {
 		return r != '\\'
 	})
 
 	// Test whether we have an even number of escape sequences before
 	// the dot or none.
-	return (len(s2)-i)%2 != 0
+	return (len(s)-i)%2 != 0
 }
 
 // FQDN returns the fully qualified domain name from s.


### PR DESCRIPTION
The function `IsFQDN` is adapted from github.com/miekg/dns. The function in source got update to improve the performance in this PR: https://github.com/miekg/dns/pull/1453, reflecting the same update here as well.