### PR TITLE
renovate: Fix the typo in validator config file name

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -803,7 +803,7 @@
     },
     {
       "fileMatch": [
-        "^.github/workflows/enterprise-renovate-config-validator\\.yaml$"
+        "^.github/workflows/renovate-config-validator\\.yaml$"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?)\\s+RENOVATE_IMAGE=\"(?<depName>.*):(?<currentValue>.*)@(?<currentDigest>sha256:[a-f0-9]+)\""


### PR DESCRIPTION
Relates: 2fb022eb28ad7c0373ed0dab700e81ee8bb547fd
