### PR TITLE
doc: eks cluster restriction removed

### DIFF
--- a/Documentation/installation/k8s-install-helm.rst
+++ b/Documentation/installation/k8s-install-helm.rst
@@ -166,7 +166,7 @@ Install Cilium
          If you use masquerading with the option ``egressMasqueradeInterfaces=eth+``,
          remember to replace ``eth+`` with the proper interface name. For
          reference, Amazon Linux 2 uses ``eth+``, whereas Amazon Linux 2023 uses
-         ``ens+``. Mixed node clusters are not supported currently.
+         ``ens+``.
 
     .. group-tab:: OpenShift
 


### PR DESCRIPTION
The commit removes EKS cluster mixed node support restriction since egress masquerade supports multiple interfaces (see fix: #36103).
