### PR TITLE
doc: Removed nodeinit from aks byocni install

### DIFF
--- a/Documentation/installation/k8s-install-helm.rst
+++ b/Documentation/installation/k8s-install-helm.rst
@@ -93,8 +93,7 @@ Install Cilium
 
           helm install cilium |CHART_RELEASE| \\
             --namespace kube-system \\
-            --set aksbyocni.enabled=true \\
-            --set nodeinit.enabled=true
+            --set aksbyocni.enabled=true
 
        .. note::
 


### PR DESCRIPTION
Nodeinit is actually not required when running Cilium on AKS BYOCNI. Hence, let's remove it from the AKS BYOCNI-specific Helm installation guide.

Nodeinit’s [startup.bash](https://github.com/cilium/cilium/blob/v1.15.6/install/kubernetes/cilium/files/nodeinit/startup.bash) or [prestop.bash](https://github.com/cilium/cilium/blob/v1.15.6/install/kubernetes/cilium/files/nodeinit/prestop.bash) don't to anything specific to AKS BYOCNI (1.15.6 versions). Everything seems to be GKE-specific except [one section](https://github.com/cilium/cilium/blob/a09e05e6b63d82dbc3a1b0de1721a3407c340e7c/install/kubernetes/cilium/files/nodeinit/startup.bash#L162-L198) in the startup.bash, which is for Azure **chaining** mode (`.Values.azure.enabled`) and even that part is removed in later Cilium versions (see https://github.com/cilium/cilium/pull/34870).

```release-note
doc: Removed nodeinit from aks byocni install
```

It needs a backport to all maintained Cilium minor versions.
