### PR TITLE
experimental/lb: Add NodePort and HostPort addr refresher

### DIFF
--- a/pkg/loadbalancer/experimental/cell.go
+++ b/pkg/loadbalancer/experimental/cell.go
@@ -41,9 +41,12 @@ var Cell = cell.Module(
 	// Provide the 'lb/' script commands for debugging and testing.
 	cell.Provide(scriptCommands),
 
+	//
 	// Health server runs an HTTP server for each service on port [HealthCheckNodePort]
 	// (when non-zero) and responds with the number of healthy backends.
 	healthServerCell,
+
+	cell.Invoke(registerNodePortAddressReconciler),
 )
 
 // TablesCell provides the [Writer] API for configuring load-balancing and the

--- a/pkg/loadbalancer/experimental/frontend.go
+++ b/pkg/loadbalancer/experimental/frontend.go
@@ -5,7 +5,6 @@ package experimental
 
 import (
 	"iter"
-	"net/netip"
 	"strings"
 
 	"github.com/cilium/statedb"
@@ -52,11 +51,6 @@ type Frontend struct {
 
 	// Backends associated with the frontend.
 	Backends iter.Seq2[*Backend, statedb.Revision]
-
-	// nodePortAddrs are the IP addresses on which to serve NodePort and HostPort
-	// services. Not set if [Type] is not NodePort or HostPort. These are updated
-	// when the Table[NodeAddress] changes.
-	nodePortAddrs []netip.Addr
 
 	// service associated with the frontend. If service is updated
 	// this pointer to the service will update as well and the

--- a/pkg/loadbalancer/experimental/node_addr_reconciler.go
+++ b/pkg/loadbalancer/experimental/node_addr_reconciler.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package experimental
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+)
+
+type nodePortAddressReconcilerParams struct {
+	cell.In
+
+	Config   Config
+	JobGroup job.Group
+	Log      *slog.Logger
+
+	DB            *statedb.DB
+	NodeAddresses statedb.Table[tables.NodeAddress]
+	Frontends     statedb.Table[*Frontend]
+}
+
+func registerNodePortAddressReconciler(p nodePortAddressReconcilerParams) {
+	if !p.Config.EnableExperimentalLB {
+		return
+	}
+
+	r := nodePortAddrReconciler{
+		log:       p.Log,
+		db:        p.DB,
+		nodeAddrs: p.NodeAddresses,
+		frontends: p.Frontends.(statedb.RWTable[*Frontend]),
+	}
+
+	p.JobGroup.Add(job.OneShot("node-addr-reconciler", r.nodePortAddressReconcilerLoop))
+}
+
+type nodePortAddrReconciler struct {
+	log       *slog.Logger
+	db        *statedb.DB
+	nodeAddrs statedb.Table[tables.NodeAddress]
+	frontends statedb.RWTable[*Frontend]
+}
+
+func (r *nodePortAddrReconciler) nodePortAddressReconcilerLoop(ctx context.Context, health cell.Health) error {
+	for {
+		wtxn := r.db.WriteTxn(r.frontends)
+
+		_, watch := r.nodeAddrs.ListWatch(wtxn, tables.NodeAddressNodePortIndex.Query(true))
+
+		for fe := range r.frontends.All(wtxn) {
+			if fe.Type != loadbalancer.SVCTypeNodePort &&
+				!(fe.Type == loadbalancer.SVCTypeHostPort && fe.Address.AddrCluster.IsUnspecified()) {
+				continue
+			}
+
+			fe = fe.Clone()
+			// Set status to Pending, so that BPFOps reconciler gets invoked to update Frontend(s)' addrs accordingly
+			fe.setStatus(reconciler.StatusPending())
+			_, _, err := r.frontends.Insert(wtxn, fe)
+			if err != nil {
+				// Should not happen, but let's log it anyway
+				r.log.Warn("Could not set frontend status to pending", "frontend", fe, "error", err)
+			}
+		}
+
+		wtxn.Commit()
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-watch:
+		}
+	}
+}

--- a/pkg/loadbalancer/experimental/test_utils.go
+++ b/pkg/loadbalancer/experimental/test_utils.go
@@ -290,7 +290,7 @@ func FastCheckEmptyTablesAndState(db *statedb.DB, writer *Writer, bo *BPFOps) bo
 	if writer.Frontends().NumObjects(txn) > 0 || writer.Backends().NumObjects(txn) > 0 || writer.Services().NumObjects(txn) > 0 {
 		return false
 	}
-	if len(bo.backendReferences) > 0 || len(bo.backendStates) > 0 || len(bo.nodePortAddrs) > 0 || len(bo.serviceIDAlloc.entities) > 0 || len(bo.backendIDAlloc.entities) > 0 {
+	if len(bo.backendReferences) > 0 || len(bo.backendStates) > 0 || len(bo.nodePortAddrByService) > 0 || len(bo.serviceIDAlloc.entities) > 0 || len(bo.backendIDAlloc.entities) > 0 {
 		return false
 	}
 	return true

--- a/pkg/loadbalancer/experimental/testdata/healthserver.txtar
+++ b/pkg/loadbalancer/experimental/testdata/healthserver.txtar
@@ -88,6 +88,7 @@ devicename: test
 -- health_no_service.table --
 Module                                   Component                   Level   Message                    Error   
 loadbalancer-experimental.healthserver   job-control-loop            OK      0 health servers running   
+loadbalancer-experimental                job-node-addr-reconciler    OK      Running
 loadbalancer-experimental.reconciler     job-reconcile               OK      OK, 0 object(s)            
 loadbalancer-experimental.reconciler     job-refresh                 OK      Next refresh in 30m0s      
 loadbalancer-experimental.reflector      job-reflector               OK      Running                    
@@ -96,6 +97,7 @@ loadbalancer-experimental.reflector      job-reflector               OK      Run
 Module                                   Component                   Level   Message                    Error   
 loadbalancer-experimental.healthserver   job-control-loop            OK      1 health servers running   
 loadbalancer-experimental.healthserver   job-listener-$PORT1          OK      Running
+loadbalancer-experimental                job-node-addr-reconciler    OK      Running
 loadbalancer-experimental.reconciler     job-reconcile               OK      OK, 3 object(s)            
 loadbalancer-experimental.reconciler     job-refresh                 OK      Next refresh in 30m0s      
 loadbalancer-experimental.reflector      job-reflector               OK      Running                    

--- a/pkg/loadbalancer/experimental/testdata/nodeport-addr.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport-addr.txtar
@@ -1,0 +1,349 @@
+#! --enable-experimental-lb --lb-test-fault-probability=0.0
+# NOTE: Fault injection disabled as it leads to non-deterministic id allocation with multiple
+# frontends from single service.
+
+# Add some node addresses
+db/insert node-addresses addrv4-1.yaml
+db/cmp node-addresses nodeaddrs.table
+
+# Add the first service before starting (List() path)
+k8s add service.yaml endpointslice.yaml
+
+# Start the test application
+hive start
+
+# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
+# (otherwise might miss events due to List() vs Watch() race in fake client).
+# NOTE: The 100ms delay you might see is from WaitForCacheSync polling at 100ms.
+db/initialized
+
+# First frontends should exist and be reconciled. Need to wait for reconciliation to
+# have the ID assigned.
+db/cmp frontends frontends1.table
+
+k8s add service2.yaml endpointslice2.yaml
+
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table 
+
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
+
+# Insert new node addresses
+db/insert node-addresses addrv4-2.yaml
+db/insert node-addresses addrv4-3.yaml
+db/delete node-addresses addrv4-1.yaml
+db/cmp node-addresses nodeaddrs-updated.table
+
+db/cmp frontends frontends.table
+
+# Check BPF maps
+lb/maps-dump lbmaps-updated.actual
+* cmp lbmaps-updated.expected lbmaps-updated.actual
+
+# Cleanup. Backends first in this test.
+k8s delete endpointslice.yaml endpointslice2.yaml
+db/cmp backends backends_empty.table
+db/cmp frontends frontends_nobackends.table
+
+k8s delete service.yaml service2.yaml
+db/cmp frontends frontends_empty.table
+db/cmp services services_empty.table
+
+#####
+
+-- addrv4-1.yaml --
+addr: 1.1.1.1
+nodeport: true
+primary: true
+devicename: test
+
+-- addrv4-2.yaml --
+addr: 2.2.2.2
+nodeport: true
+primary: true
+devicename: test2
+
+-- addrv4-3.yaml --
+addr: 3.3.3.3
+nodeport: false
+primary: true
+devicename: test3
+
+-- nodeaddrs.table --
+Address NodePort Primary DeviceName
+1.1.1.1 true     true    test
+
+-- nodeaddrs-updated.table --
+Address NodePort Primary DeviceName
+2.2.2.2 true     true    test2
+3.3.3.3 false    true    test3
+
+-- services.table --
+Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+test/echo    k8s                  Cluster            Cluster                              0                     false              
+test/echo2   k8s                  Cluster            Cluster                              0                     false              
+
+-- services_empty.table --
+Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+
+
+-- frontends1.table --
+Address               Type        ServiceName   PortName   Status  Backends
+0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
+
+-- frontends.table --
+Address               Type        ServiceName   PortName   Status  Backends
+0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
+0.0.0.0:30782/TCP     NodePort    test/echo2    http2      Done    10.244.2.1:80/TCP (active), 10.244.2.2:80/TCP (active), 10.244.2.3:80/TCP (active), 10.244.2.4:80/TCP (active)
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
+10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done    10.244.2.1:80/TCP (active), 10.244.2.2:80/TCP (active), 10.244.2.3:80/TCP (active), 10.244.2.4:80/TCP (active)
+
+-- frontends_nobackends.table --
+Address               Type        ServiceName   PortName   Status  Backends
+0.0.0.0:30781/TCP     NodePort    test/echo     http       Done        
+0.0.0.0:30782/TCP     NodePort    test/echo2    http2      Done        
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done        
+10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done        
+
+-- frontends_empty.table --
+Address               Type        ServiceName   PortName   Status  Backends
+
+-- backends.table --
+Address             State    Instances            NodeName           ZoneID
+10.244.1.1:80/TCP   active   test/echo (http)     nodeport-worker    0
+10.244.1.2:80/TCP   active   test/echo (http)     nodeport-worker    0
+10.244.1.3:80/TCP   active   test/echo (http)     nodeport-worker2   0
+10.244.1.4:80/TCP   active   test/echo (http)     nodeport-worker2   0
+10.244.2.1:80/TCP   active   test/echo2 (http2)   nodeport-worker    0
+10.244.2.2:80/TCP   active   test/echo2 (http2)   nodeport-worker    0
+10.244.2.3:80/TCP   active   test/echo2 (http2)   nodeport-worker2   0
+10.244.2.4:80/TCP   active   test/echo2 (http2)   nodeport-worker2   0
+
+-- backends_empty.table --
+Address             State    Instances            NodeName           ZoneID
+
+-- lbmaps.expected --
+BE: ID=1 ADDR=10.244.1.1:80 STATE=active
+BE: ID=2 ADDR=10.244.1.2:80 STATE=active
+BE: ID=3 ADDR=10.244.1.3:80 STATE=active
+BE: ID=4 ADDR=10.244.1.4:80 STATE=active
+BE: ID=5 ADDR=10.244.2.1:80 STATE=active
+BE: ID=6 ADDR=10.244.2.2:80 STATE=active
+BE: ID=7 ADDR=10.244.2.3:80 STATE=active
+BE: ID=8 ADDR=10.244.2.4:80 STATE=active
+REV: ID=1 ADDR=10.96.50.104:80
+REV: ID=2 ADDR=<zero>
+REV: ID=3 ADDR=1.1.1.1:30781
+REV: ID=4 ADDR=10.96.50.105:80
+REV: ID=5 ADDR=<zero>
+REV: ID=6 ADDR=1.1.1.1:30782
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=0 BEID=0 COUNT=4 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=3 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=4 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=<zero> SLOT=0 BEID=0 COUNT=4 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=2 ADDR=<zero> SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=2 ADDR=<zero> SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=2 ADDR=<zero> SLOT=3 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=2 ADDR=<zero> SLOT=4 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=1.1.1.1:30781 SLOT=0 BEID=0 COUNT=4 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=1.1.1.1:30781 SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=1.1.1.1:30781 SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=1.1.1.1:30781 SLOT=3 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=1.1.1.1:30781 SLOT=4 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=10.96.50.105:80 SLOT=0 BEID=0 COUNT=4 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=10.96.50.105:80 SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=10.96.50.105:80 SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=10.96.50.105:80 SLOT=3 BEID=7 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=10.96.50.105:80 SLOT=4 BEID=8 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=<zero> SLOT=0 BEID=0 COUNT=4 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=<zero> SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=<zero> SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=<zero> SLOT=3 BEID=7 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=<zero> SLOT=4 BEID=8 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=6 ADDR=1.1.1.1:30782 SLOT=0 BEID=0 COUNT=4 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30782 SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30782 SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30782 SLOT=3 BEID=7 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30782 SLOT=4 BEID=8 COUNT=0 QCOUNT=0 FLAGS=NodePort
+-- lbmaps-updated.expected --
+BE: ID=1 ADDR=10.244.1.1:80 STATE=active
+BE: ID=2 ADDR=10.244.1.2:80 STATE=active
+BE: ID=3 ADDR=10.244.1.3:80 STATE=active
+BE: ID=4 ADDR=10.244.1.4:80 STATE=active
+BE: ID=5 ADDR=10.244.2.1:80 STATE=active
+BE: ID=6 ADDR=10.244.2.2:80 STATE=active
+BE: ID=7 ADDR=10.244.2.3:80 STATE=active
+BE: ID=8 ADDR=10.244.2.4:80 STATE=active
+REV: ID=1 ADDR=10.96.50.104:80
+REV: ID=2 ADDR=<zero>
+REV: ID=4 ADDR=10.96.50.105:80
+REV: ID=5 ADDR=<zero>
+REV: ID=7 ADDR=2.2.2.2:30781
+REV: ID=8 ADDR=2.2.2.2:30782
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=0 BEID=0 COUNT=4 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=3 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80 SLOT=4 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=<zero> SLOT=0 BEID=0 COUNT=4 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=2 ADDR=<zero> SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=2 ADDR=<zero> SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=2 ADDR=<zero> SLOT=3 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=2 ADDR=<zero> SLOT=4 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=4 ADDR=10.96.50.105:80 SLOT=0 BEID=0 COUNT=4 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=10.96.50.105:80 SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=10.96.50.105:80 SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=10.96.50.105:80 SLOT=3 BEID=7 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=10.96.50.105:80 SLOT=4 BEID=8 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=<zero> SLOT=0 BEID=0 COUNT=4 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=<zero> SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=<zero> SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=<zero> SLOT=3 BEID=7 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=<zero> SLOT=4 BEID=8 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=7 ADDR=2.2.2.2:30781 SLOT=0 BEID=0 COUNT=4 QCOUNT=0 FLAGS=NodePort
+SVC: ID=7 ADDR=2.2.2.2:30781 SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=7 ADDR=2.2.2.2:30781 SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=7 ADDR=2.2.2.2:30781 SLOT=3 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=7 ADDR=2.2.2.2:30781 SLOT=4 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=8 ADDR=2.2.2.2:30782 SLOT=0 BEID=0 COUNT=4 QCOUNT=0 FLAGS=NodePort
+SVC: ID=8 ADDR=2.2.2.2:30782 SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=8 ADDR=2.2.2.2:30782 SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=8 ADDR=2.2.2.2:30782 SLOT=3 BEID=7 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=8 ADDR=2.2.2.2:30782 SLOT=4 BEID=8 COUNT=0 QCOUNT=0 FLAGS=NodePort
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: echo
+  namespace: test
+  resourceVersion: "741"
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: NodePort
+status:
+  loadBalancer: {}
+
+-- service2.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: echo2
+  namespace: test
+  resourceVersion: "741"
+  uid: b49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.105
+  clusterIPs:
+  - 10.96.50.105
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http2
+    nodePort: 30782
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: NodePort
+status:
+  loadBalancer: {}
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  annotations:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  generateName: echo-
+  generation: 3
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+  resourceVersion: "797"
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  nodeName: nodeport-worker
+- addresses:
+  - 10.244.1.2
+  nodeName: nodeport-worker
+- addresses:
+  - 10.244.1.3
+  nodeName: nodeport-worker2
+- addresses:
+  - 10.244.1.4
+  nodeName: nodeport-worker2
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- endpointslice2.yaml --
+# This is similar to endpointslice.yaml but references
+# a different service (echo2) and port (http2).
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  annotations:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  generateName: echo-
+  generation: 3
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: echo2
+  name: echo-another
+  namespace: test
+  resourceVersion: "797"
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.2.1
+  nodeName: nodeport-worker
+- addresses:
+  - 10.244.2.2
+  nodeName: nodeport-worker
+- addresses:
+  - 10.244.2.3
+  nodeName: nodeport-worker2
+- addresses:
+  - 10.244.2.4
+  nodeName: nodeport-worker2
+ports:
+- name: http2
+  port: 80
+  protocol: TCP


### PR DESCRIPTION
```
    This commit adds a new reconciler which watches for node address
    changes. Once an addr changes, it sets NodePort/HostPort Frontends
    reconcilation status to Pending. This triggers the BPFOps reconciler to
    update the affected services in the LBMaps.

    In addition, this commit removes all detail about NodePort addrs from
    Frontend. Thus, only the lower level (i.e., BPFOps) is aware of this LB
    BPF implementation specific detail.
```