### PR TITLE
clustermesh: update mcs-api dependency

### DIFF
--- a/Documentation/network/clustermesh/mcsapi.rst
+++ b/Documentation/network/clustermesh/mcsapi.rst
@@ -20,8 +20,8 @@ You first need to install the required MCS-API CRDs:
 
    .. code-block:: shell-session
 
-      kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/fede3192824f8c9d44719a467528f9438ae6007b/config/crd/multicluster.x-k8s.io_serviceexports.yaml
-      kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/fede3192824f8c9d44719a467528f9438ae6007b/config/crd/multicluster.x-k8s.io_serviceimports.yaml
+      kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/62ede9a032dcfbc41b3418d7360678cb83092498/config/crd/multicluster.x-k8s.io_serviceexports.yaml
+      kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/mcs-api/62ede9a032dcfbc41b3418d7360678cb83092498/config/crd/multicluster.x-k8s.io_serviceimports.yaml
 
 
 To install Cilium with MCS-API support, run:

--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.19.4
 	sigs.k8s.io/controller-tools v0.16.5
 	sigs.k8s.io/gateway-api v1.2.1
-	sigs.k8s.io/mcs-api v0.1.1-0.20250109091032-a0594610c49f
+	sigs.k8s.io/mcs-api v0.1.1-0.20250116162235-62ede9a032dc
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1091,8 +1091,8 @@ sigs.k8s.io/kustomize/api v0.18.0 h1:hTzp67k+3NEVInwz5BHyzc9rGxIauoXferXyjv5lWPo
 sigs.k8s.io/kustomize/api v0.18.0/go.mod h1:f8isXnX+8b+SGLHQ6yO4JG1rdkZlvhaCf/uZbLVMb0U=
 sigs.k8s.io/kustomize/kyaml v0.18.1 h1:WvBo56Wzw3fjS+7vBjN6TeivvpbW9GmRaWZ9CIVmt4E=
 sigs.k8s.io/kustomize/kyaml v0.18.1/go.mod h1:C3L2BFVU1jgcddNBE1TxuVLgS46TjObMwW5FT9FcjYo=
-sigs.k8s.io/mcs-api v0.1.1-0.20250109091032-a0594610c49f h1:zDiSRnDMFAm1qu2uuP/JhPdY8h/WDAwwsNvAInRRRSU=
-sigs.k8s.io/mcs-api v0.1.1-0.20250109091032-a0594610c49f/go.mod h1:Uicqc5FnWP4dco2y7+AEg2mzNN20mVX1TDB3aDfmvhc=
+sigs.k8s.io/mcs-api v0.1.1-0.20250116162235-62ede9a032dc h1:oQrn1nrTacXiaXEYg+0TozPznSDIHFl2U/KZ5UFiYT8=
+sigs.k8s.io/mcs-api v0.1.1-0.20250116162235-62ede9a032dc/go.mod h1:Uicqc5FnWP4dco2y7+AEg2mzNN20mVX1TDB3aDfmvhc=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.2 h1:MdmvkGuXi/8io6ixD5wud3vOLwc1rj0aNqRlpuvjmwA=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.2/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2790,7 +2790,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/internal/k8sgen/pkg/util/validation/field
 sigs.k8s.io/kustomize/kyaml/yaml/merge2
 sigs.k8s.io/kustomize/kyaml/yaml/schema
 sigs.k8s.io/kustomize/kyaml/yaml/walk
-# sigs.k8s.io/mcs-api v0.1.1-0.20250109091032-a0594610c49f
+# sigs.k8s.io/mcs-api v0.1.1-0.20250116162235-62ede9a032dc
 ## explicit; go 1.23.0
 sigs.k8s.io/mcs-api/pkg/apis/v1alpha1
 sigs.k8s.io/mcs-api/pkg/client/clientset/versioned

--- a/vendor/sigs.k8s.io/mcs-api/pkg/apis/v1alpha1/serviceimport.go
+++ b/vendor/sigs.k8s.io/mcs-api/pkg/apis/v1alpha1/serviceimport.go
@@ -53,7 +53,7 @@ type ServiceImportSpec struct {
 	// +listType=atomic
 	Ports []ServicePort `json:"ports"`
 	// ip will be used as the VIP for this service when type is ClusterSetIP.
-	// +kubebuilder:validation:MaxItems:=1
+	// +kubebuilder:validation:MaxItems:=2
 	// +optional
 	IPs []string `json:"ips,omitempty"`
 	// type defines the type of this service.


### PR DESCRIPTION
This commit updates the mcs-api deps addressing two issues:
- An headless ServiceImport should have an empty IPs list and not a list containing the string "None"
- Add support for dual stack services by copying at most two ips from the derived Service instead of only one (requires a CRD change, hence also updating the install documentation).

```release-note
clustermesh: add dualstack support for MCS-API and fix a spec compliance issue with headless services
```
