### PR TITLE
Docs: CiliumCIDRGroup updates & cleanups

### DIFF
--- a/Documentation/network/kubernetes/ciliumcidrgroup.rst
+++ b/Documentation/network/kubernetes/ciliumcidrgroup.rst
@@ -21,7 +21,10 @@ CiliumCIDRGroup (CCG) is a feature that allows administrators to reference a gro
 CIDR blocks in a :ref:`CiliumNetworkPolicy`. Unlike :ref:`CiliumEndpoint` resources,
 which are managed by the Cilium agent, CiliumCIDRGroup resources are intended
 to be managed directly by administrators.
-It is particularly useful for enforcing policies on groups of external CIDR blocks.
+It is particularly useful for enforcing policies on groups of external CIDR blocks. 
+Additionally, any traffic to CIDRs referenced in the CiliumCIDRGroup will have their 
+:ref:`Hubble <hubble_intro>` flows annotated with the CCG's name and labels.
+
 
 The following is an example of a ``CiliumCIDRGroup`` object:
 
@@ -31,15 +34,18 @@ The following is an example of a ``CiliumCIDRGroup`` object:
   apiVersion: cilium.io/v2alpha1
   kind: CiliumCIDRGroup
   metadata:
-    name: vpn
+    name: vpn-example-1
+    labels:
+      role: vpn 
   spec:
     externalCIDRs:
       - "10.48.0.0/24"
       - "10.16.0.0/24"
 
 
-The ``vpn`` CCG can be referenced in a ``CiliumNetworkPolicy``
-by using the ``fromCIDRSet`` directive:
+The CCG can be referenced in a ``CiliumNetworkPolicy``
+by using the ``fromCIDRSet`` directive. CCGs may be selected
+by names or labels.
 
 
 .. code-block:: yaml
@@ -51,10 +57,16 @@ by using the ``fromCIDRSet`` directive:
   spec:
     endpointSelector: {}
     ingress:
+    ## select by name
     - fromCIDRSet:
-      - cidrGroupRef: vpn
+      - cidrGroupRef: vpn-example-1
+    ## alternatively, select by label:
+    - fromCIDRSet:
+      - cidrGroupSelector:
+          matchLabels:
+            role: vpn
 
 
 In this example, the ``fromCIDRSet`` directive in the CNP references the
-``vpn`` group defined in the ``CiliumCIDRGroup``. This allows the CNP to
-apply ingress rules based on the CIDRs grouped under the ``vpn`` name.
+``vpn-example-1`` group defined in the ``CiliumCIDRGroup``. This allows the CNP to
+apply ingress rules based on the CIDRs grouped under the ``vpn-example-1`` name.

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -543,6 +543,8 @@ fromCIDRSet
   prefixes/CIDRs per source prefix/CIDR that are subnets of the source
   prefix/CIDR from which communication is not allowed.
 
+  ``fromCIDRSet`` may also reference prefixes/CIDRs indirectly via a :ref:`CiliumCIDRGroup`.
+
 Egress
 ~~~~~~
 
@@ -557,6 +559,8 @@ toCIDRSet
   ``endpointSelector`` are allowed to talk to, along with an optional list of
   prefixes/CIDRs per source prefix/CIDR that are subnets of the destination
   prefix/CIDR to which communication is not allowed.
+
+  ``toCIDRSet`` may also reference prefixes/CIDRs indirectly via a :ref:`CiliumCIDRGroup`.
 
 Allow to external CIDR block
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Cleans up a few things:
- Documents the ability to select CCG by labels
- Mentions that hubble flows are now labeled
- Links from main policy page.

Ref: #36301
