### PR TITLE
Fixing typos in fqdn and policy pkg

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -167,7 +167,7 @@ func (d *Daemon) getEndpointsDNSInfo(endpointID string) []fqdn.EndpointDNSInfo {
 }
 
 // updateDNSDatapathRules updates the DNS proxy iptables rules. Must be
-// called after iptables has been initailized, and only after
+// called after iptables has been initialized, and only after
 // successful bootstrapFQDN().
 func (d *Daemon) updateDNSDatapathRules(ctx context.Context) error {
 	if option.Config.DryMode || !option.Config.EnableL7Proxy {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -112,7 +112,7 @@ const (
 	// for each FQDN selector in endpoint's restored DNS rules.
 	DNSMaxIPsPerRestoredRule = 1000
 
-	// FFQDNRegexCompileLRUSize defines the maximum size for the FQDN regex
+	// FQDNRegexCompileLRUSize defines the maximum size for the FQDN regex
 	// compilation LRU used by the DNS proxy and policy validation.
 	FQDNRegexCompileLRUSize = 1024
 
@@ -464,7 +464,7 @@ const (
 	// specified in the L7 policies.
 	CertsDirectory = RuntimePath + "/certs"
 
-	// IPAMExpiration is the timeout after which an IP subject to expiratio
+	// IPAMExpiration is the timeout after which an IP subject to expiration
 	// is being released again if no endpoint is being created in time.
 	IPAMExpiration = 10 * time.Minute
 

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -38,7 +38,7 @@ type cacheEntry struct {
 	// LookupTime is when the data begins being valid
 	LookupTime time.Time `json:"lookup-time,omitempty"`
 
-	// ExpirationTime is a calcutated time when the DNS data stops being valid.
+	// ExpirationTime is a calculated time when the DNS data stops being valid.
 	// It is simply LookupTime + TTL
 	ExpirationTime time.Time `json:"expiration-time,omitempty"`
 
@@ -135,8 +135,8 @@ type DNSCache struct {
 	// perHostLimit is the number of maximum number of IP per host.
 	perHostLimit int
 
-	// minTTL is the minimun TTL value that a cache entry can have, if the TTL
-	// sent in the Update is lower, the TTL will be owerwritten to this value.
+	// minTTL is the minimum TTL value that a cache entry can have, if the TTL
+	// sent in the Update is lower, the TTL will be overwritten to this value.
 	// Due is only read-only is not protected by the mutex.
 	minTTL int
 }
@@ -457,7 +457,7 @@ func (c *DNSCache) lookupByRegexpByTime(now time.Time, re *regexp.Regexp) (match
 
 // LookupIP returns all DNS names in entries that include that IP. The cache
 // maintains the latest-expiring entry per-name per-IP. This means that multiple
-// names referrring to the same IP will expire from the cache at different times,
+// names referring to the same IP will expire from the cache at different times,
 // and only 1 entry for each name-IP pair is internally retained.
 func (c *DNSCache) LookupIP(ip netip.Addr) (names []string) {
 	c.RLock()
@@ -716,7 +716,7 @@ func (c *DNSCache) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON rebuilds a DNSCache from serialized JSON.
-// Note: This is destructive to any currect data. Use UpdateFromCache for bulk
+// Note: This is destructive to any correct data. Use UpdateFromCache for bulk
 // updates.
 func (c *DNSCache) UnmarshalJSON(raw []byte) error {
 	lookups := make([]*cacheEntry, 0)
@@ -963,7 +963,7 @@ func sortZombieMappingSlice(alive []*DNSZombieMapping) {
 }
 
 // GC returns alive and dead DNSZombieMapping entries. This removes dead
-// zombies interally, and repeated calls will return different data.
+// zombies internally, and repeated calls will return different data.
 // Zombies are alive if they have been marked alive (with MarkAlive). When
 // SetCTGCTime is called and an zombie not marked alive, it becomes dead.
 // Calling Upsert on a dead zombie will make it alive again.
@@ -1215,7 +1215,7 @@ func (zombies *DNSZombieMappings) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON rebuilds a DNSZombieMappings from serialized JSON. It resets
 // the AliveAt timestamps, requiring a CT GC cycle to occur before any zombies
 // are deleted (by not being marked alive).
-// Note: This is destructive to any currect data
+// Note: This is destructive to any correct data
 func (zombies *DNSZombieMappings) UnmarshalJSON(raw []byte) error {
 	zombies.Lock()
 	defer zombies.Unlock()

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -1144,7 +1144,7 @@ func TestOverlimitPreferNewerEntries(t *testing.T) {
 }
 
 // This test tests the over limit behaviour of DNS Mapping zombies for repeated
-// lookups to the same domain (e.g. an S3 bucket). It tries to mimick the "fun"
+// lookups to the same domain (e.g. an S3 bucket). It tries to mimic the "fun"
 // interactions between the CT GC, FQDN GC and per-host IP limits. It covers a
 // case which, prior to the commit introducing this test, zombies were reaped
 // erroneously, since their "AliveAt" field was zero (and they thus sorted to

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -129,7 +129,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 	require.NoError(tb, err, "error starting DNS Proxy")
 	s.proxy = proxy
 
-	// This is here because Listener or Listeer.Addr() was nil. The
+	// This is here because Listener or Listener.Addr() was nil. The
 	// lookupTargetDNSServer function doesn't need to change the target.
 	require.NotNil(tb, s.dnsServer.Listener, "DNS server missing a Listener")
 	DNSServerListenerAddr := (s.dnsServer.Listener.Addr()).(*net.TCPAddr)
@@ -1065,7 +1065,7 @@ func TestRestoredEndpoint(t *testing.T) {
 
 	// Respond with an actual answer for the query. This also tests that the
 	// connection was forwarded via the correct protocol (tcp/udp) because we
-	// connet with TCP, and the server only listens on TCP.
+	// connect with TCP, and the server only listens on TCP.
 
 	name := "cilium.io."
 	pattern := "*.cilium.com."

--- a/pkg/fqdn/dnsproxy/udp.go
+++ b/pkg/fqdn/dnsproxy/udp.go
@@ -73,7 +73,7 @@ type sessionUDP struct {
 	oob   []byte
 }
 
-// Set the socket options needed for tranparent proxying for the listening socket
+// Set the socket options needed for transparent proxying for the listening socket
 // IP(V6)_TRANSPARENT allows socket to receive packets with any destination address/port
 // IP(V6)_RECVORIGDSTADDR tells the kernel to pass the original destination address/port on recvmsg
 // By design, a socket of a DNS Server can only receive IPv4 or IPv6 traffic.

--- a/pkg/fqdn/matchpattern/matchpattern.go
+++ b/pkg/fqdn/matchpattern/matchpattern.go
@@ -23,7 +23,7 @@ const MatchAllAnchoredPattern = "(?:)"
 // it can be or-ed (joined with "|") with other rules, and still match all rules.
 const MatchAllUnAnchoredPattern = ".*"
 
-// Validate ensures that pattern is a parseable matchPattern. It returns the
+// Validate ensures that pattern is a parsable matchPattern. It returns the
 // regexp generated when validating.
 func Validate(pattern string) (matcher *regexp.Regexp, err error) {
 	if err := prevalidate(pattern); err != nil {

--- a/pkg/fqdn/name_manager_gc.go
+++ b/pkg/fqdn/name_manager_gc.go
@@ -155,7 +155,7 @@ func (n *NameManager) GC(ctx context.Context) error {
 	namesCount := len(namesToCleanSlice)
 	// Limit the amount of info level logging to some sane amount
 	if namesCount > 20 {
-		// namedsToClean is only used for logging after this so we can reslice it in place
+		// namesToClean is only used for logging after this so we can reslice it in place
 		namesToCleanSlice = namesToCleanSlice[:20]
 	}
 	log.WithField(logfields.Controller, dnsGCJobName).Infof(

--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -31,7 +31,7 @@ const PortProtoV2 = 1 << 24
 // bit positions 0-15.
 //
 // This works because Version 1 will naturally encode
-// no values at postions 16-31 as the original Version 1
+// no values at positions 16-31 as the original Version 1
 // was a uint16. Version 2 enforces a 1 value at the 24th
 // bit position, so it will always be legible.
 type PortProto uint32

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -435,7 +435,7 @@ spec:
                               A trailing "." is automatically added when missing.
 
                               Examples:
-                              `*.cilium.io` matches subomains of cilium at that level
+                              `*.cilium.io` matches subdomains of cilium at that level
                                 www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
                               `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                 except those containing "." separator, subcilium.io and sub-cilium.io match,
@@ -749,7 +749,7 @@ spec:
                                         A trailing "." is automatically added when missing.
 
                                         Examples:
-                                        `*.cilium.io` matches subomains of cilium at that level
+                                        `*.cilium.io` matches subdomains of cilium at that level
                                           www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
                                         `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                           except those containing "." separator, subcilium.io and sub-cilium.io match,
@@ -2587,7 +2587,7 @@ spec:
                                         A trailing "." is automatically added when missing.
 
                                         Examples:
-                                        `*.cilium.io` matches subomains of cilium at that level
+                                        `*.cilium.io` matches subdomains of cilium at that level
                                           www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
                                         `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                           except those containing "." separator, subcilium.io and sub-cilium.io match,
@@ -3879,7 +3879,7 @@ spec:
                                 A trailing "." is automatically added when missing.
 
                                 Examples:
-                                `*.cilium.io` matches subomains of cilium at that level
+                                `*.cilium.io` matches subdomains of cilium at that level
                                   www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
                                 `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                   except those containing "." separator, subcilium.io and sub-cilium.io match,
@@ -4193,7 +4193,7 @@ spec:
                                           A trailing "." is automatically added when missing.
 
                                           Examples:
-                                          `*.cilium.io` matches subomains of cilium at that level
+                                          `*.cilium.io` matches subdomains of cilium at that level
                                             www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
                                           `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                             except those containing "." separator, subcilium.io and sub-cilium.io match,
@@ -6033,7 +6033,7 @@ spec:
                                           A trailing "." is automatically added when missing.
 
                                           Examples:
-                                          `*.cilium.io` matches subomains of cilium at that level
+                                          `*.cilium.io` matches subdomains of cilium at that level
                                             www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
                                           `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                             except those containing "." separator, subcilium.io and sub-cilium.io match,

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -438,7 +438,7 @@ spec:
                               A trailing "." is automatically added when missing.
 
                               Examples:
-                              `*.cilium.io` matches subomains of cilium at that level
+                              `*.cilium.io` matches subdomains of cilium at that level
                                 www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
                               `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                 except those containing "." separator, subcilium.io and sub-cilium.io match,
@@ -752,7 +752,7 @@ spec:
                                         A trailing "." is automatically added when missing.
 
                                         Examples:
-                                        `*.cilium.io` matches subomains of cilium at that level
+                                        `*.cilium.io` matches subdomains of cilium at that level
                                           www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
                                         `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                           except those containing "." separator, subcilium.io and sub-cilium.io match,
@@ -2590,7 +2590,7 @@ spec:
                                         A trailing "." is automatically added when missing.
 
                                         Examples:
-                                        `*.cilium.io` matches subomains of cilium at that level
+                                        `*.cilium.io` matches subdomains of cilium at that level
                                           www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
                                         `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                           except those containing "." separator, subcilium.io and sub-cilium.io match,
@@ -3882,7 +3882,7 @@ spec:
                                 A trailing "." is automatically added when missing.
 
                                 Examples:
-                                `*.cilium.io` matches subomains of cilium at that level
+                                `*.cilium.io` matches subdomains of cilium at that level
                                   www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
                                 `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                   except those containing "." separator, subcilium.io and sub-cilium.io match,
@@ -4196,7 +4196,7 @@ spec:
                                           A trailing "." is automatically added when missing.
 
                                           Examples:
-                                          `*.cilium.io` matches subomains of cilium at that level
+                                          `*.cilium.io` matches subdomains of cilium at that level
                                             www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
                                           `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                             except those containing "." separator, subcilium.io and sub-cilium.io match,
@@ -6036,7 +6036,7 @@ spec:
                                           A trailing "." is automatically added when missing.
 
                                           Examples:
-                                          `*.cilium.io` matches subomains of cilium at that level
+                                          `*.cilium.io` matches subdomains of cilium at that level
                                             www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
                                           `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                             except those containing "." separator, subcilium.io and sub-cilium.io match,

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -83,7 +83,7 @@ const (
 	AllowLocalhostPolicy = "policy"
 
 	// AnnotateK8sNode enables annotating a kubernetes node while bootstrapping
-	// the daemon, which can also be disbled using this option.
+	// the daemon, which can also be disabled using this option.
 	AnnotateK8sNode = "annotate-k8s-node"
 
 	// ARPPingRefreshPeriod is the ARP entries refresher period

--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -18,7 +18,7 @@ var (
 	allowedMatchNameChars = regexp.MustCompile("^[-a-zA-Z0-9_.]+$")
 
 	// allowedPatternChars tests that the MatchPattern field contains only the
-	// characters we want in our wilcard scheme.
+	// characters we want in our wildcard scheme.
 	allowedPatternChars = regexp.MustCompile("^[-a-zA-Z0-9_.*]+$") // the * inside the [] is a literal *
 
 	// FQDNMatchNameRegexString is a regex string which matches what's expected
@@ -51,7 +51,7 @@ type FQDNSelector struct {
 	// A trailing "." is automatically added when missing.
 	//
 	// Examples:
-	// `*.cilium.io` matches subomains of cilium at that level
+	// `*.cilium.io` matches subdomains of cilium at that level
 	//   www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
 	// `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
 	//   except those containing "." separator, subcilium.io and sub-cilium.io match,

--- a/pkg/proxy/endpoint/test/updater_mock.go
+++ b/pkg/proxy/endpoint/test/updater_mock.go
@@ -29,7 +29,7 @@ func (m *ProxyUpdaterMock) ConntrackNameLocked() string { return "global" }
 
 func (m *ProxyUpdaterMock) OnProxyPolicyUpdate(policyRevision uint64) {}
 
-func (m *ProxyUpdaterMock) UpdateProxyStatistics(proxyTypet, l4Protocol string, port, proxyPort uint16, ingress, request bool,
+func (m *ProxyUpdaterMock) UpdateProxyStatistics(proxyType, l4Protocol string, port, proxyPort uint16, ingress, request bool,
 	verdict accesslog.FlowVerdict) {
 }
 

--- a/pkg/proxy/logger/logger.go
+++ b/pkg/proxy/logger/logger.go
@@ -107,7 +107,7 @@ var LogTags logTags
 
 type logTags struct{}
 
-// Verdict attachs verdict information to the log record
+// Verdict attach verdict information to the log record
 func (logTags) Verdict(v accesslog.FlowVerdict, info string) LogTag {
 	return func(lr *LogRecord) {
 		lr.Verdict = v
@@ -281,7 +281,7 @@ func SetMetadata(md []string) {
 // EndpointInfoRegistry provides endpoint information lookup by endpoint IP address.
 type EndpointInfoRegistry interface {
 	// FillEndpointInfo resolves the labels of the specified identity if known locally.
-	// ID and Labels should be provieded in 'info' if known.
+	// ID and Labels should be provided in 'info' if known.
 	// If 'id' is passed as zero, will locate the EP by 'addr', and also fill info.ID, if found.
 	// Fills in the following info member fields:
 	//  - info.IPv4           (if 'ip' is IPv4)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -196,12 +196,12 @@ func (p *Proxy) createNewRedirect(
 	// regeneration will also be reverted. Revert can happen for other reasons as well (such as
 	// bpf datapath compilation failure), and we do not want to churn proxy ports in that case.
 	// Not called for DNS redirects.
-	// This callbck is called before the finalize or revert function is called.
+	// This callback is called before the finalize or revert function is called.
 	proxyCallback := func(err error) {
 		if err == nil {
 			// Enable datapath redirection for the proxy port if proxy creation
 			// was successful, even if the overall (endpoint) regeneration
-			// fails. This way there is less churm on the procy port allocation
+			// fails. This way there is less churn on the proxy port allocation
 			// and datapath. Endpoint policy will no redirect to the new proxy
 			// implementation if regeneration fails.
 			err = p.proxyPorts.AckProxyPort(ctx, ppName, pp)

--- a/pkg/proxy/proxyports/proxyports.go
+++ b/pkg/proxy/proxyports/proxyports.go
@@ -92,7 +92,7 @@ type ProxyPorts struct {
 	// restart
 	proxyPortsPath string
 
-	// Trigger for stroring proxy ports on to file
+	// Trigger for storing proxy ports on to file
 	Trigger *trigger.Trigger
 
 	// mutex is the lock required when accessing fields below or
@@ -443,7 +443,7 @@ func (p *ProxyPorts) reset(pp *ProxyPort) {
 
 // FindByType returns a ProxyPort matching the given type, listener name, and direction, if
 // found.
-// Adds reference cound to the returned ProxyPort to prevent it being concurrently released.
+// Adds reference bound to the returned ProxyPort to prevent it being concurrently released.
 // Reference must be released with ReleaseProxyPort.
 // Must NOT be called with mutex held!
 func (p *ProxyPorts) FindByTypeWithReference(l7Type types.ProxyType, listener string, ingress bool) (string, *ProxyPort) {
@@ -527,7 +527,7 @@ var (
 	staleProxyPortsFile = errors.New("proxy ports file is too old")
 )
 
-// restore proxy ports from file created earlier by stroreProxyPorts
+// restore proxy ports from file created earlier by storeProxyPorts
 // must be called with mutex held
 func (p *ProxyPorts) restoreProxyPortsFromFile(restoredProxyPortsStaleLimit uint) error {
 	log := log.WithField(logfields.Path, p.proxyPortsPath)
@@ -608,7 +608,7 @@ func (p *ProxyPorts) RestoreProxyPorts(restoredProxyPortsStaleLimit uint) {
 
 	err := p.restoreProxyPortsFromFile(restoredProxyPortsStaleLimit)
 	if err != nil {
-		log.WithError(err).WithField(logfields.Path, p.proxyPortsPath).Info("Resoring proxy ports from file failed, falling back to restoring from iptables rules")
+		log.WithError(err).WithField(logfields.Path, p.proxyPortsPath).Info("Restoring proxy ports from file failed, falling back to restoring from iptables rules")
 		p.restoreProxyPortsFromIptables()
 	}
 }

--- a/pkg/proxy/types/types.go
+++ b/pkg/proxy/types/types.go
@@ -8,7 +8,7 @@ const (
 	ProxyTypeAny ProxyType = ""
 	// ProxyTypeHTTP specifies the Envoy HTTP proxy type
 	ProxyTypeHTTP ProxyType = "http"
-	// ProxyTypeDNS specifies the staticly configured DNS proxy type
+	// ProxyTypeDNS specifies the statically configured DNS proxy type
 	ProxyTypeDNS ProxyType = "dns"
 	// ProxyTypeCRD specifies a proxy configured via CiliumEnvoyConfig CRD
 	ProxyTypeCRD ProxyType = "crd"


### PR DESCRIPTION
Fixing few of the typos I encountered while working on the fqdn/policy package