### PR TITLE
Fix configuration of proxy-max-concurrent-retries

### DIFF
--- a/pkg/ciliumenvoyconfig/cec_resource_parser.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser.go
@@ -69,14 +69,15 @@ type parserParams struct {
 	PortAllocator  PortAllocator
 	LocalNodeStore *node.LocalNodeStore
 
-	CecConfig cecConfig
+	CecConfig   cecConfig
+	EnvoyConfig envoy.ProxyConfig
 }
 
 func newCECResourceParser(params parserParams) *cecResourceParser {
 	parser := &cecResourceParser{
 		logger:                      params.Logger,
 		portAllocator:               params.PortAllocator,
-		defaultMaxConcurrentRetries: params.CecConfig.ProxyMaxConcurrentRetries,
+		defaultMaxConcurrentRetries: params.EnvoyConfig.ProxyMaxConcurrentRetries,
 	}
 
 	// Retrieve Ingress IPs from local Node.

--- a/pkg/ciliumenvoyconfig/cell.go
+++ b/pkg/ciliumenvoyconfig/cell.go
@@ -60,15 +60,13 @@ var Cell = cell.Module(
 )
 
 type cecConfig struct {
-	EnvoyConfigRetryInterval  time.Duration
-	EnvoyConfigTimeout        time.Duration
-	ProxyMaxConcurrentRetries uint32
+	EnvoyConfigRetryInterval time.Duration
+	EnvoyConfigTimeout       time.Duration
 }
 
 func (r cecConfig) Flags(flags *pflag.FlagSet) {
 	flags.Duration("envoy-config-retry-interval", 15*time.Second, "Interval in which an attempt is made to reconcile failed EnvoyConfigs. If the duration is zero, the retry is deactivated.")
 	flags.Duration("envoy-config-timeout", 2*time.Minute, "Timeout that determines how long to wait for Envoy to N/ACK CiliumEnvoyConfig resources")
-	flags.Uint32("proxy-max-concurrent-retries", 128, "Maximum number of concurrent retries on Envoy clusters")
 }
 
 type reconcilerParams struct {
@@ -161,7 +159,8 @@ type managerParams struct {
 
 	Logger logrus.FieldLogger
 
-	Config cecConfig
+	Config      cecConfig
+	EnvoyConfig envoy.ProxyConfig
 
 	PolicyUpdater  *policy.Updater
 	ServiceManager service.ServiceManager
@@ -178,7 +177,7 @@ type managerParams struct {
 
 func newCECManager(params managerParams) ciliumEnvoyConfigManager {
 	return newCiliumEnvoyConfigManager(params.Logger, params.PolicyUpdater, params.ServiceManager, params.XdsServer,
-		params.BackendSyncer, params.ResourceParser, params.Config.EnvoyConfigTimeout, params.Config.ProxyMaxConcurrentRetries, params.Services, params.Endpoints, params.MetricsManager)
+		params.BackendSyncer, params.ResourceParser, params.Config.EnvoyConfigTimeout, params.EnvoyConfig.ProxyMaxConcurrentRetries, params.Services, params.Endpoints, params.MetricsManager)
 }
 
 func newPortAllocator(proxy *proxy.Proxy) PortAllocator {

--- a/pkg/ciliumenvoyconfig/exp_test.go
+++ b/pkg/ciliumenvoyconfig/exp_test.go
@@ -49,6 +49,7 @@ func TestScript(t *testing.T) {
 			client.FakeClientCell,
 			daemonk8s.ResourcesCell,
 			cell.Config(cecConfig{}),
+			cell.Config(envoy.ProxyConfig{}),
 			experimental.Cell,
 			maglev.Cell,
 			cell.Provide(

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -35,7 +35,7 @@ var Cell = cell.Module(
 	"envoy-proxy",
 	"Envoy proxy and control-plane",
 
-	cell.Config(envoyProxyConfig{}),
+	cell.Config(ProxyConfig{}),
 	cell.Config(secretSyncConfig{}),
 	cell.Provide(newEnvoyXDSServer),
 	cell.Provide(newEnvoyAdminClient),
@@ -46,7 +46,7 @@ var Cell = cell.Module(
 	cell.Invoke(registerSecretSyncer),
 )
 
-type envoyProxyConfig struct {
+type ProxyConfig struct {
 	DisableEnvoyVersionCheck          bool
 	ProxyPrometheusPort               int
 	ProxyAdminPort                    int
@@ -73,7 +73,7 @@ type envoyProxyConfig struct {
 	ProxyXffNumTrustedHopsEgress      uint32
 }
 
-func (r envoyProxyConfig) Flags(flags *pflag.FlagSet) {
+func (r ProxyConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool("disable-envoy-version-check", false, "Do not perform Envoy version check")
 	flags.Int("proxy-prometheus-port", 0, "Port to serve Envoy metrics on. Default 0 (disabled).")
 	flags.Int("proxy-admin-port", 0, "Port to serve Envoy admin interface on.")
@@ -127,7 +127,7 @@ type xdsServerParams struct {
 	RestorerPromise    promise.Promise[endpointstate.Restorer]
 	LocalEndpointStore *LocalEndpointStore
 
-	EnvoyProxyConfig envoyProxyConfig
+	EnvoyProxyConfig ProxyConfig
 
 	// Depend on access log server to enforce init order.
 	// This ensures that the access log server is ready before it gets used by the
@@ -207,7 +207,7 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 	return xdsServer, nil
 }
 
-func newEnvoyAdminClient(envoyProxyConfig envoyProxyConfig) *EnvoyAdminClient {
+func newEnvoyAdminClient(envoyProxyConfig ProxyConfig) *EnvoyAdminClient {
 	return NewEnvoyAdminClientForSocket(GetSocketDir(option.Config.RunDir), envoyProxyConfig.EnvoyDefaultLogLevel)
 }
 
@@ -216,7 +216,7 @@ type accessLogServerParams struct {
 
 	Lifecycle          cell.Lifecycle
 	LocalEndpointStore *LocalEndpointStore
-	EnvoyProxyConfig   envoyProxyConfig
+	EnvoyProxyConfig   ProxyConfig
 }
 
 func newEnvoyAccessLogServer(params accessLogServerParams) *AccessLogServer {
@@ -251,7 +251,7 @@ type versionCheckParams struct {
 	Logger           logrus.FieldLogger
 	JobRegistry      job.Registry
 	Health           cell.Health
-	EnvoyProxyConfig envoyProxyConfig
+	EnvoyProxyConfig ProxyConfig
 	EnvoyAdminClient *EnvoyAdminClient
 }
 


### PR DESCRIPTION
Hive/Cell does not have defined behavior when the same flag is
registered twice. Avoid registering the flag twice by depending on the
envoy package configuration that has the flag, and remove the second
declaration.

Fixes: 70a4979ebb59 ("envoy: Increase per-cluster concurrent retry limit")
Related: https://github.com/cilium/hive/pull/31