### PR TITLE
bpf: remove unused world_cidrs_key4

### DIFF
--- a/bpf/bpf_alignchecker.c
+++ b/bpf/bpf_alignchecker.c
@@ -87,7 +87,6 @@ add_type(struct tunnel_value);
 add_type(struct auth_key);
 add_type(struct auth_info);
 add_type(struct encrypt_config);
-add_type(struct world_cidrs_key4);
 add_type(struct mcast_subscriber_v4);
 add_type(struct node_key);
 add_type(struct node_value);

--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -257,11 +257,6 @@ struct {
 } VTEP_MAP __section_maps_btf;
 #endif /* ENABLE_VTEP */
 
-struct world_cidrs_key4 {
-	struct bpf_lpm_trie_key lpm_key;
-	__u32 ip;
-} __packed;
-
 #ifndef SKIP_CALLS_MAP
 static __always_inline __must_check int
 tail_call_internal(struct __ctx_buff *ctx, const __u32 index, __s8 *ext_err)


### PR DESCRIPTION
The users were removed in https://github.com/cilium/cilium/pull/36898.