### PR TITLE
xds: Add ack and nack metrics

### DIFF
--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -17,11 +17,13 @@ import (
 
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/endpointstate"
+	"github.com/cilium/cilium/pkg/envoy/xds"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
@@ -34,6 +36,8 @@ import (
 var Cell = cell.Module(
 	"envoy-proxy",
 	"Envoy proxy and control-plane",
+
+	metrics.Metric(xds.NewXDSMetric),
 
 	cell.Config(ProxyConfig{}),
 	cell.Config(secretSyncConfig{}),
@@ -139,6 +143,7 @@ type xdsServerParams struct {
 	ArtifactCopier *ArtifactCopier
 
 	SecretManager certificatemanager.SecretManager
+	Metrics       *xds.XDSMetrics
 }
 
 func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
@@ -163,6 +168,7 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 			useSDS:                        params.SecretManager.PolicySecretSyncEnabled(),
 			proxyXffNumTrustedHopsIngress: params.EnvoyProxyConfig.ProxyXffNumTrustedHopsIngress,
 			proxyXffNumTrustedHopsEgress:  params.EnvoyProxyConfig.ProxyXffNumTrustedHopsEgress,
+			metrics:                       params.Metrics,
 		},
 		params.SecretManager)
 

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -34,7 +34,7 @@ func (s *xdsServer) startXDSGRPCServer(listener net.Listener, config map[string]
 	grpcServer := grpc.NewServer()
 
 	// xdsServer optionally pauses serving any resources until endpoints have been restored
-	xdsServer := xds.NewServer(config, s.restorerPromise)
+	xdsServer := xds.NewServer(config, s.restorerPromise, s.config.metrics)
 	dsServer := (*xdsGRPCServer)(xdsServer)
 
 	// TODO: https://github.com/cilium/cilium/issues/5051

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -116,6 +116,8 @@ type AckingResourceMutatorWrapper struct {
 	// restoring controls waiting for acks. When 'true' updates do not wait for acks from the xDS client,
 	// as xDS caches are pre-populated before passing any resources to xDS clients.
 	restoring bool
+
+	metrics Metrics
 }
 
 // pendingCompletion is an update that is pending completion.
@@ -133,11 +135,12 @@ type pendingCompletion struct {
 
 // NewAckingResourceMutatorWrapper creates a new AckingResourceMutatorWrapper
 // to wrap the given ResourceMutator.
-func NewAckingResourceMutatorWrapper(mutator ResourceMutator) *AckingResourceMutatorWrapper {
+func NewAckingResourceMutatorWrapper(mutator ResourceMutator, metrics Metrics) *AckingResourceMutatorWrapper {
 	return &AckingResourceMutatorWrapper{
 		mutator:            mutator,
 		ackedVersions:      make(map[string]uint64),
 		pendingCompletions: make(map[*completion.Completion]*pendingCompletion),
+		metrics:            metrics,
 	}
 }
 
@@ -408,9 +411,11 @@ func (m *AckingResourceMutatorWrapper) HandleResourceVersionAck(ackVersion uint6
 					if len(pending.remainingNodesResources) == 0 {
 						// completedComparision. Notify and remove from pending list.
 						if pending.version <= ackVersion {
+							m.metrics.IncreaseACK(typeURL)
 							ackLog.Debugf("completing ACK: %v", pending)
 							comp.Complete(nil)
 						} else {
+							m.metrics.IncreaseNACK(typeURL)
 							ackLog.Warningf("completing NACK: %v", pending)
 							comp.Complete(&ProxyError{Err: ErrNackReceived, Detail: detail})
 						}

--- a/pkg/envoy/xds/metrics.go
+++ b/pkg/envoy/xds/metrics.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xds
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+const (
+	subsystem       = "xds"
+	typeURLLabel    = "type_url"
+	statusLabel     = "status"
+	statusACKValue  = "ack"
+	statusNACKValue = "nack"
+)
+
+type Metrics interface {
+	IncreaseNACK(string)
+	IncreaseACK(string)
+}
+
+var _ Metrics = (*XDSMetrics)(nil)
+
+type XDSMetrics struct {
+	// EventCount is the number of ACK and NACK responses from envoy.
+	EventCount metric.Vec[metric.Counter]
+}
+
+func NewXDSMetric() *XDSMetrics {
+	return &XDSMetrics{
+		EventCount: metric.NewCounterVec(metric.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "events_count",
+			Help:      "The number of ACK/NACK event responses from Envoy",
+		}, []string{typeURLLabel, statusLabel}),
+	}
+}
+
+func (x *XDSMetrics) IncreaseNACK(typeURL string) {
+	x.EventCount.WithLabelValues(typeURL, statusNACKValue).Inc()
+}
+
+func (x *XDSMetrics) IncreaseACK(typeURL string) {
+	x.EventCount.WithLabelValues(typeURL, statusACKValue).Inc()
+}

--- a/pkg/envoy/xds/metrics_mock_test.go
+++ b/pkg/envoy/xds/metrics_mock_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xds
+
+type mockMetrics struct {
+	ack  map[string]int
+	nack map[string]int
+}
+
+func (m *mockMetrics) IncreaseNACK(typeURL string) {
+	m.ack[typeURL]++
+}
+
+func (m *mockMetrics) IncreaseACK(typeURL string) {
+	m.nack[typeURL]++
+}
+
+func newMockMetrics() *mockMetrics {
+	return &mockMetrics{
+		ack:  map[string]int{},
+		nack: map[string]int{},
+	}
+}

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -76,6 +76,7 @@ func responseCheck(response *envoy_service_discovery.DiscoveryResponse,
 
 func TestRequestAllResources(t *testing.T) {
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
+	metrics := newMockMetrics()
 
 	var err error
 	var req *envoy_service_discovery.DiscoveryRequest
@@ -87,13 +88,13 @@ func TestRequestAllResources(t *testing.T) {
 	defer cancel()
 
 	cache := NewCache()
-	mutator := NewAckingResourceMutatorWrapper(cache)
+	mutator := NewAckingResourceMutatorWrapper(cache, metrics)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
 
 	streamDone := make(chan struct{})
 
@@ -120,6 +121,8 @@ func TestRequestAllResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -142,12 +145,16 @@ func TestRequestAllResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Create version 3 with resources 0 and 1.
 	// This time, update the cache before sending the request.
 	v, mod, _ = cache.Upsert(typeURL, resources[1].Name, resources[1])
 	require.Equal(t, uint64(3), v)
 	require.True(t, mod)
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -165,6 +172,8 @@ func TestRequestAllResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0], resources[1]}, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -187,6 +196,8 @@ func TestRequestAllResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "4", []proto.Message{resources[1]}, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -200,6 +211,7 @@ func TestRequestAllResources(t *testing.T) {
 
 func TestAck(t *testing.T) {
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
+	metrics := newMockMetrics()
 
 	var err error
 	var req *envoy_service_discovery.DiscoveryRequest
@@ -210,13 +222,13 @@ func TestAck(t *testing.T) {
 	wg := completion.NewWaitGroup(ctx)
 
 	cache := NewCache()
-	mutator := NewAckingResourceMutatorWrapper(cache)
+	mutator := NewAckingResourceMutatorWrapper(cache, metrics)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
 
 	streamDone := make(chan struct{})
 
@@ -320,6 +332,7 @@ func TestAck(t *testing.T) {
 
 func TestRequestSomeResources(t *testing.T) {
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
+	metrics := newMockMetrics()
 
 	var err error
 	var req *envoy_service_discovery.DiscoveryRequest
@@ -331,13 +344,13 @@ func TestRequestSomeResources(t *testing.T) {
 	defer cancel()
 
 	cache := NewCache()
-	mutator := NewAckingResourceMutatorWrapper(cache)
+	mutator := NewAckingResourceMutatorWrapper(cache, metrics)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
 
 	streamDone := make(chan struct{})
 
@@ -364,6 +377,8 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -386,6 +401,8 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", nil, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Create version 3 with resource 0 and 1.
 	// This time, update the cache before sending the request.
@@ -409,6 +426,8 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[1]}, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -431,6 +450,8 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "4", []proto.Message{resources[1], resources[2]}, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -467,6 +488,8 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "6", []proto.Message{resources[2]}, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Resource 1 has been deleted; Resource 2 exists. Confirm using Lookup().
 	rsrc, err := cache.Lookup(typeURL, resources[1].Name)
@@ -477,6 +500,8 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, rsrc)
 	require.EqualValues(t, resources[2], rsrc.(*envoy_config_route.RouteConfiguration))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -490,6 +515,7 @@ func TestRequestSomeResources(t *testing.T) {
 
 func TestUpdateRequestResources(t *testing.T) {
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
+	metrics := newMockMetrics()
 
 	var err error
 	var req *envoy_service_discovery.DiscoveryRequest
@@ -501,13 +527,13 @@ func TestUpdateRequestResources(t *testing.T) {
 	defer cancel()
 
 	cache := NewCache()
-	mutator := NewAckingResourceMutatorWrapper(cache)
+	mutator := NewAckingResourceMutatorWrapper(cache, metrics)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
 
 	streamDone := make(chan struct{})
 
@@ -542,6 +568,8 @@ func TestUpdateRequestResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[1]}, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Request the next version of resource 1.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -577,6 +605,8 @@ func TestUpdateRequestResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[1], resources[2]}, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -590,6 +620,7 @@ func TestUpdateRequestResources(t *testing.T) {
 
 func TestRequestStaleNonce(t *testing.T) {
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
+	metrics := newMockMetrics()
 
 	var err error
 	var req *envoy_service_discovery.DiscoveryRequest
@@ -601,13 +632,13 @@ func TestRequestStaleNonce(t *testing.T) {
 	defer cancel()
 
 	cache := NewCache()
-	mutator := NewAckingResourceMutatorWrapper(cache)
+	mutator := NewAckingResourceMutatorWrapper(cache, metrics)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
 
 	streamDone := make(chan struct{})
 
@@ -634,6 +665,8 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -656,6 +689,8 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Create version 3 with resources 0 and 1.
 	// This time, update the cache before sending the request.
@@ -682,6 +717,8 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0], resources[1]}, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -704,6 +741,8 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "4", []proto.Message{resources[1]}, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -717,6 +756,7 @@ func TestRequestStaleNonce(t *testing.T) {
 
 func TestNAck(t *testing.T) {
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
+	metrics := newMockMetrics()
 
 	var err error
 	var req *envoy_service_discovery.DiscoveryRequest
@@ -727,13 +767,13 @@ func TestNAck(t *testing.T) {
 	wg := completion.NewWaitGroup(ctx)
 
 	cache := NewCache()
-	mutator := NewAckingResourceMutatorWrapper(cache)
+	mutator := NewAckingResourceMutatorWrapper(cache, metrics)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
 
 	streamDone := make(chan struct{})
 
@@ -760,6 +800,8 @@ func TestNAck(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -783,6 +825,8 @@ func TestNAck(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// NACK the received version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -816,6 +860,8 @@ func TestNAck(t *testing.T) {
 
 	require.Condition(t, isNotCompletedComparison(comp1))
 	require.Condition(t, isNotCompletedComparison(comp2))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 2, metrics.ack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -830,6 +876,8 @@ func TestNAck(t *testing.T) {
 
 	require.Condition(t, isNotCompletedComparison(comp1))
 	require.Condition(t, completedComparison(comp2))
+	require.Equal(t, 1, metrics.nack[typeURL])
+	require.Equal(t, 2, metrics.ack[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -843,6 +891,7 @@ func TestNAck(t *testing.T) {
 
 func TestNAckFromTheStart(t *testing.T) {
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
+	metrics := newMockMetrics()
 
 	var err error
 	var req *envoy_service_discovery.DiscoveryRequest
@@ -853,13 +902,13 @@ func TestNAckFromTheStart(t *testing.T) {
 	wg := completion.NewWaitGroup(ctx)
 
 	cache := NewCache()
-	mutator := NewAckingResourceMutatorWrapper(cache)
+	mutator := NewAckingResourceMutatorWrapper(cache, metrics)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
 
 	streamDone := make(chan struct{})
 
@@ -886,6 +935,8 @@ func TestNAckFromTheStart(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Create version 2 with resource 0.
 	callback1, comp1 := newCompCallback()
@@ -908,6 +959,8 @@ func TestNAckFromTheStart(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
 
 	// NACK the received version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -943,6 +996,8 @@ func TestNAckFromTheStart(t *testing.T) {
 	require.NotEqual(t, "", resp.Nonce)
 
 	require.Condition(t, isNotCompletedComparison(comp2))
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 3, metrics.ack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -957,6 +1012,8 @@ func TestNAckFromTheStart(t *testing.T) {
 
 	// Version 3 was ACKed by the last request.
 	require.Condition(t, completedComparison(comp2))
+	require.Equal(t, 1, metrics.nack[typeURL])
+	require.Equal(t, 3, metrics.ack[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -970,6 +1027,7 @@ func TestNAckFromTheStart(t *testing.T) {
 
 func TestRequestHighVersionFromTheStart(t *testing.T) {
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
+	metrics := newMockMetrics()
 
 	var err error
 	var req *envoy_service_discovery.DiscoveryRequest
@@ -980,13 +1038,13 @@ func TestRequestHighVersionFromTheStart(t *testing.T) {
 	wg := completion.NewWaitGroup(ctx)
 
 	cache := NewCache()
-	mutator := NewAckingResourceMutatorWrapper(cache)
+	mutator := NewAckingResourceMutatorWrapper(cache, metrics)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil)
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
 
 	streamDone := make(chan struct{})
 
@@ -1020,6 +1078,8 @@ func TestRequestHighVersionFromTheStart(t *testing.T) {
 	require.NoError(t, err)
 	require.Condition(t, responseCheck(resp, "65", []proto.Message{resources[0]}, false, typeURL))
 	require.NotEqual(t, "", resp.Nonce)
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
 
 	// Close the stream.
 	closeStream()

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -214,6 +214,7 @@ type xdsServerConfig struct {
 	useSDS                        bool
 	proxyXffNumTrustedHopsIngress uint32
 	proxyXffNumTrustedHopsEgress  uint32
+	metrics                       xds.Metrics
 }
 
 // newXDSServer creates a new xDS GRPC server.
@@ -248,42 +249,42 @@ func (s *xdsServer) start() error {
 
 func (s *xdsServer) initializeXdsConfigs() {
 	ldsCache := xds.NewCache()
-	ldsMutator := xds.NewAckingResourceMutatorWrapper(ldsCache)
+	ldsMutator := xds.NewAckingResourceMutatorWrapper(ldsCache, s.config.metrics)
 	ldsConfig := &xds.ResourceTypeConfiguration{
 		Source:      ldsCache,
 		AckObserver: ldsMutator,
 	}
 
 	rdsCache := xds.NewCache()
-	rdsMutator := xds.NewAckingResourceMutatorWrapper(rdsCache)
+	rdsMutator := xds.NewAckingResourceMutatorWrapper(rdsCache, s.config.metrics)
 	rdsConfig := &xds.ResourceTypeConfiguration{
 		Source:      rdsCache,
 		AckObserver: rdsMutator,
 	}
 
 	cdsCache := xds.NewCache()
-	cdsMutator := xds.NewAckingResourceMutatorWrapper(cdsCache)
+	cdsMutator := xds.NewAckingResourceMutatorWrapper(cdsCache, s.config.metrics)
 	cdsConfig := &xds.ResourceTypeConfiguration{
 		Source:      cdsCache,
 		AckObserver: cdsMutator,
 	}
 
 	edsCache := xds.NewCache()
-	edsMutator := xds.NewAckingResourceMutatorWrapper(edsCache)
+	edsMutator := xds.NewAckingResourceMutatorWrapper(edsCache, s.config.metrics)
 	edsConfig := &xds.ResourceTypeConfiguration{
 		Source:      edsCache,
 		AckObserver: edsMutator,
 	}
 
 	sdsCache := xds.NewCache()
-	sdsMutator := xds.NewAckingResourceMutatorWrapper(sdsCache)
+	sdsMutator := xds.NewAckingResourceMutatorWrapper(sdsCache, s.config.metrics)
 	sdsConfig := &xds.ResourceTypeConfiguration{
 		Source:      sdsCache,
 		AckObserver: sdsMutator,
 	}
 
 	npdsCache := xds.NewCache()
-	npdsMutator := xds.NewAckingResourceMutatorWrapper(npdsCache)
+	npdsMutator := xds.NewAckingResourceMutatorWrapper(npdsCache, s.config.metrics)
 	npdsConfig := &xds.ResourceTypeConfiguration{
 		Source:      npdsCache,
 		AckObserver: npdsMutator,


### PR DESCRIPTION
### Description

This is to improve the observability for xds subsystem, one high level
metric with typeURL and status={ack,nack} as labels could be used
to check and alert if there is any mis-configuration rejected by Envoy.

Relates: #36691

### Testing

Testing was done locally with metric enabled (e.g. prometheus.enabled=true, operator.prometheus.enabled=true), and some hacky malformed config for NACK.

```
root@kind-worker:/home/cilium# cilium metrics list | grep xds
cilium_errors_warnings_total                                             level=warning subsystem=xds                                                                                                                                                                                                                    8.000000
cilium_xds_events_count                                                  type_url=type.googleapis.com/envoy.config.listener.v3.Listener status=ack                                                                                                                                                                      4.000000
cilium_xds_events_count                                                  type_url=type.googleapis.com/envoy.config.listener.v3.Listener status=nack                                                                                                                                                                     4.000000
```