### PR TITLE
gha: Enable promtool check again

### DIFF
--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -190,8 +190,7 @@ jobs:
           rm -f prometheus-${PROM_VERSION}.linux-amd64.tar.gz
           sudo mv prometheus-${PROM_VERSION}.linux-amd64/promtool /usr/bin
           cat metrics-agent.prom | promtool check metrics
-          # Uncomment this line once https://github.com/cilium/cilium/issues/36581 is fixed
-          #cat metrics-operator.prom | promtool check metrics
+          cat metrics-operator.prom | promtool check metrics
 
       - name: Check prometheus feature metrics documentation
         if: ${{ success() }}

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -327,6 +327,11 @@ Removed Metrics
 Changed Metrics
 ~~~~~~~~~~~~~~~
 
+* ``doublewrite_identity_crd_total_count`` has been renamed to ``doublewrite_crd_identities``
+* ``doublewrite_identity_kvstore_total_count`` has been renamed to ``doublewrite_kvstore_identities``
+* ``doublewrite_identity_crd_only_count`` has been renamed to ``doublewrite_crd_only_identities``
+* ``doublewrite_identity_kvstore_only_count`` has been renamed to ``doublewrite_kvstore_only_identities``
+
 Deprecated Metrics
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The underlying issue #36581 is fixed, so we should validate the metric convention again in GHA.


