### PR TITLE
watchers: demote "CEP deleted" log message to debug level

### DIFF
--- a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
+++ b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
@@ -157,13 +157,13 @@ func (cs *cesSubscriber) deleteCEPfromCES(CEPName, CESName string, c *types.Cili
 		log.WithFields(logrus.Fields{
 			"CESName": CESName,
 			"CEPName": CEPName,
-		}).Info("CEP deleted, calling endpointDeleted")
+		}).Debug("CEP deleted, calling endpointDeleted")
 		cs.epWatcher.endpointDeleted(c)
 	} else {
 		log.WithFields(logrus.Fields{
 			"CESName": CESName,
 			"CEPName": CEPName,
-		}).Info("CEP deleted, other CEP exists, calling endpointUpdated")
+		}).Debug("CEP deleted, other CEP exists, calling endpointUpdated")
 		cs.epWatcher.endpointUpdated(c, cep)
 	}
 }


### PR DESCRIPTION
Let's demote these log messages to debug level, for uniformity with other similar ones, and as they can be potentially triggered thousands of times in large and churny environments, flooding the logs and hiding other potentially relevant messages.
