### PR TITLE
endpoint: let regeneration failure handler work more than once

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -919,6 +919,7 @@ func (e *Endpoint) startRegenerationFailureHandler() {
 			}
 			return fmt.Errorf("regeneration recovery failed")
 		},
+		RunInterval:            1 * time.Second,
 		ErrorRetryBaseDuration: 2 * time.Second,
 		Context:                e.aliveCtx,
 	})

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -898,8 +898,6 @@ func (e *Endpoint) startRegenerationFailureHandler() {
 			}
 
 			regenMetadata := &regeneration.ExternalRegenerationMetadata{
-				// TODO (ianvernon) - is there a way we can plumb a parent
-				// context to a controller (e.g., endpoint.aliveCtx)?
 				ParentContext: ctx,
 				Reason:        reasonRegenRetry,
 				// Completely rewrite the endpoint - we don't know the nature


### PR DESCRIPTION
Every endpoint is associated with a controller that is responsible for retrying endpoint regeneration in case it previously failed; however this logic currently only works once, as upon regeneration success the controller is never executed again because RunInterval is 0. Let's get this fixed setting a non-zero RunInterval, so that the controller body gets executed again and it can react upon a subsequent error.

<!-- Description of change -->

```release-note
Fix bug causing the endpoint regeneration failure handler to be effective only once
```
