### PR TITLE
metrics: Use new style script flags

### DIFF
--- a/cilium-dbg/cmd/metrics_list.go
+++ b/cilium-dbg/cmd/metrics_list.go
@@ -23,7 +23,7 @@ var MetricsListCmd = &cobra.Command{
 		if command.OutputOption() {
 			format = strings.ToLower(command.OutputOptionString())
 		}
-		shellExchange(os.Stdout, "metrics -format=%s '%s'", format, matchPattern)
+		shellExchange(os.Stdout, "metrics --format=%s '%s'", format, matchPattern)
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/cilium/ebpf v0.17.1
 	github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b
 	github.com/cilium/fake v0.6.1
-	github.com/cilium/hive v0.0.0-20241213121623-605c1412b9b3
+	github.com/cilium/hive v0.0.0-20250121145729-e67f66eb0375
 	github.com/cilium/linters v0.1.0
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20241219105110-b2e1bb5839df

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b h1
 github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b/go.mod h1:izWO5C3waDVkh/nt++nNyozXyJAPL6tfFpJSMtzVnwQ=
 github.com/cilium/fake v0.6.1 h1:cLkNx1nkF0b0pPW79JaQxaI5oG2/rBzRKpp0YUg1fTA=
 github.com/cilium/fake v0.6.1/go.mod h1:V9lCbbcsnSf3vB6sdOP7Q0bsUUJ/jyHPZxnFAw5nPUc=
-github.com/cilium/hive v0.0.0-20241213121623-605c1412b9b3 h1:RfmUH1ouzj0LzORYJRhp43e1rlGpx6GNv4NIRUakU2w=
-github.com/cilium/hive v0.0.0-20241213121623-605c1412b9b3/go.mod h1:pI2GJ1n3SLKIQVFrKF7W6A6gb6BQkZ+3Hp4PAEo5SuI=
+github.com/cilium/hive v0.0.0-20250121145729-e67f66eb0375 h1:EhoCO0AI3qJavnhfAls4w7VpVVpAr12wIh293sNA0hQ=
+github.com/cilium/hive v0.0.0-20250121145729-e67f66eb0375/go.mod h1:pI2GJ1n3SLKIQVFrKF7W6A6gb6BQkZ+3Hp4PAEo5SuI=
 github.com/cilium/linters v0.1.0 h1:ABdLyPBtF+X6oTlTE0AAJbkuo2s1OYaEsP2jb9+7BGY=
 github.com/cilium/linters v0.1.0/go.mod h1:mpr0RBmILRLQu2F7ek+gjBxxuacUB/IBmjDRC3RaFkI=
 github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y2qDBs=

--- a/pkg/metrics/testdata/metrics.txtar
+++ b/pkg/metrics/testdata/metrics.txtar
@@ -17,19 +17,19 @@ metrics -s -o=actual ^test
 cmp sampled actual
 
 # Show in json format
-metrics -o=actual -format=json ^test
+metrics -o=actual --format=json ^test
 cmp all.json actual
 
 # Show in yaml format
-metrics -o=actual -format=yaml ^test
+metrics -o=actual --format=yaml ^test
 cmp all.yaml actual
 
-# Show samples in json format
-metrics -s -o=actual -format=json ^test
+# Show samples in json format. Test long-form args.
+metrics --sampled --out=actual --format=json ^test
 cmp sampled.json actual
 
 # Show samples in yaml format
-metrics -s -o=actual -format=yaml ^test
+metrics -s -o=actual --format=yaml ^test
 cmp sampled.yaml actual
 
 -- all --

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -296,7 +296,7 @@ github.com/cilium/endpointslice-controller/util/endpointslice
 # github.com/cilium/fake v0.6.1
 ## explicit; go 1.20
 github.com/cilium/fake
-# github.com/cilium/hive v0.0.0-20241213121623-605c1412b9b3
+# github.com/cilium/hive v0.0.0-20250121145729-e67f66eb0375
 ## explicit; go 1.21.3
 github.com/cilium/hive
 github.com/cilium/hive/cell


### PR DESCRIPTION
As preparation bump Hive to new version to fix flag parsing of retried script commands.
Refactor the metrics script commands to use the pflag-based flags for the metrics script commands.

Marking this as `needs-backport/1.17` to ship v1.17 with the correct style flags.