### PR TITLE
bpf:hubble: update trace/drop notify for L2-less packets

### DIFF
--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -21,6 +21,8 @@
 #include "metrics.h"
 #include "ratelimit.h"
 
+#define NOTIFY_DROP_VER 2
+
 struct drop_notify {
 	NOTIFY_CAPTURE_HDR
 	__u32		src_label;
@@ -30,6 +32,10 @@ struct drop_notify {
 	__u8		file;
 	__s8		ext_error;
 	__u32		ifindex;
+	__u8		ipv6:1;
+	__u8		l3_dev:1;
+	__u8		pad1:6;
+	__u8		pad2[3];
 };
 
 #ifdef DROP_NOTIFY
@@ -53,6 +59,7 @@ struct drop_notify {
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_DROP_NOTIFY)
 int __send_drop_notify(struct __ctx_buff *ctx)
 {
+	bool l3_dev = false, ipv6 = false;
 	/* Mask needed to calm verifier. */
 	__u32 error = ctx_load_meta(ctx, 2) & 0xFFFFFFFF;
 	__u64 ctx_len = ctx_full_len(ctx);
@@ -76,9 +83,16 @@ int __send_drop_notify(struct __ctx_buff *ctx)
 			return exitcode;
 	}
 
+#if defined(ENABLE_WIREGUARD) && (defined(IS_BPF_HOST) || defined(IS_BPF_WIREGUARD))
+	if (THIS_INTERFACE_IFINDEX == WG_IFINDEX) {
+		l3_dev = true;
+		ipv6 = ctx->protocol == bpf_htons(ETH_P_IPV6);
+	}
+#endif
+
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_DROP, (__u8)error),
-		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_CAPTURE_VER),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_DROP_VER),
 		.src_label	= ctx_load_meta(ctx, 0),
 		.dst_label	= ctx_load_meta(ctx, 1),
 		.dst_id		= ctx_load_meta(ctx, 3),
@@ -86,6 +100,8 @@ int __send_drop_notify(struct __ctx_buff *ctx)
 		.file           = file,
 		.ext_error      = (__s8)(__u8)(error >> 8),
 		.ifindex        = ctx_get_ifindex(ctx),
+		.ipv6           = ipv6,
+		.l3_dev         = l3_dev,
 	};
 
 	ctx_event_output(ctx, &cilium_events,

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -171,7 +171,8 @@ struct trace_notify {
 	__u16		dst_id;
 	__u8		reason;
 	__u8		ipv6:1;
-	__u8		pad:7;
+	__u8		l3_dev:1;
+	__u8		pad:6;
 	__u32		ifindex;
 	union {
 		struct {
@@ -224,6 +225,7 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 		   __u32 src, __u32 dst, __u16 dst_id, __u32 ifindex,
 		   enum trace_reason reason, __u32 monitor, __u16 line, __u8 file)
 {
+	bool l3_dev = false, ipv6 = false;
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, monitor ? : TRACE_PAYLOAD_LEN,
 			      ctx_len);
@@ -247,6 +249,13 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 			return;
 	}
 
+#if defined(ENABLE_WIREGUARD) && (defined(IS_BPF_HOST) || defined(IS_BPF_WIREGUARD))
+	if (THIS_INTERFACE_IFINDEX == WG_IFINDEX) {
+		l3_dev = true;
+		ipv6 = ctx->protocol == bpf_htons(ETH_P_IPV6);
+	}
+#endif
+
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
 		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_CAPTURE_VER),
@@ -254,6 +263,8 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 		.dst_label	= dst,
 		.dst_id		= dst_id,
 		.reason		= reason,
+		.ipv6		= ipv6,
+		.l3_dev		= l3_dev,
 		.ifindex	= ifindex,
 	};
 	memset(&msg.orig_ip6, 0, sizeof(union v6addr));
@@ -268,6 +279,7 @@ send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 		   __u32 src, __u32 dst, __be32 orig_addr, __u16 dst_id,
 		   __u32 ifindex, enum trace_reason reason, __u32 monitor)
 {
+	bool l3_dev = false;
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, monitor ? : TRACE_PAYLOAD_LEN,
 			      ctx_len);
@@ -291,6 +303,11 @@ send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 			return;
 	}
 
+#if defined(ENABLE_WIREGUARD) && (defined(IS_BPF_HOST) || defined(IS_BPF_WIREGUARD))
+	if (THIS_INTERFACE_IFINDEX == WG_IFINDEX)
+		l3_dev = true;
+#endif
+
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
 		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_CAPTURE_VER),
@@ -299,7 +316,8 @@ send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 		.dst_id		= dst_id,
 		.reason		= reason,
 		.ifindex	= ifindex,
-		.ipv6		= 0,
+		.ipv6		= false,
+		.l3_dev		= l3_dev,
 		.orig_ip4	= orig_addr,
 	};
 
@@ -314,6 +332,7 @@ send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 		   __u16 dst_id, __u32 ifindex, enum trace_reason reason,
 		   __u32 monitor)
 {
+	bool l3_dev = false;
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, monitor ? : TRACE_PAYLOAD_LEN,
 			      ctx_len);
@@ -337,6 +356,11 @@ send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 			return;
 	}
 
+#if defined(ENABLE_WIREGUARD) && (defined(IS_BPF_HOST) || defined(IS_BPF_WIREGUARD))
+	if (THIS_INTERFACE_IFINDEX == WG_IFINDEX)
+		l3_dev = true;
+#endif
+
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
 		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_CAPTURE_VER),
@@ -345,7 +369,8 @@ send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 		.dst_id		= dst_id,
 		.reason		= reason,
 		.ifindex	= ifindex,
-		.ipv6		= 1,
+		.ipv6		= true,
+		.l3_dev		= l3_dev,
 	};
 
 	ipv6_addr_copy(&msg.orig_ip6, orig_addr);

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -173,10 +173,10 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	// TODO: reconsider this check if the issue is fixed upstream
 	if len(data[packetOffset:]) > 0 {
 		var isL3Device, isIPv6 bool
-		if tn != nil && tn.IsL3Device() {
+		if (tn != nil && tn.IsL3Device()) || (dn != nil && dn.IsL3Device()) {
 			isL3Device = true
 		}
-		if tn != nil && tn.IsIPv6() {
+		if tn != nil && tn.IsIPv6() || (dn != nil && dn.IsIPv6()) {
 			isIPv6 = true
 		}
 

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -44,8 +44,14 @@ type Parser struct {
 // re-usable packet to avoid reallocating gopacket datastructures
 type packet struct {
 	lock.Mutex
-	decLayer *gopacket.DecodingLayerParser
-	Layers   []gopacket.LayerType
+
+	decLayerL2Dev *gopacket.DecodingLayerParser
+	decLayerL3Dev struct {
+		IPv4 *gopacket.DecodingLayerParser
+		IPv6 *gopacket.DecodingLayerParser
+	}
+
+	Layers []gopacket.LayerType
 	layers.Ethernet
 	layers.IPv4
 	layers.IPv6
@@ -67,15 +73,21 @@ func New(
 	linkGetter getters.LinkGetter,
 ) (*Parser, error) {
 	packet := &packet{}
-	packet.decLayer = gopacket.NewDecodingLayerParser(
-		layers.LayerTypeEthernet, &packet.Ethernet,
+	decoders := []gopacket.DecodingLayer{
+		&packet.Ethernet,
 		&packet.IPv4, &packet.IPv6,
 		&packet.ICMPv4, &packet.ICMPv6,
-		&packet.TCP, &packet.UDP, &packet.SCTP)
+		&packet.TCP, &packet.UDP, &packet.SCTP,
+	}
+	packet.decLayerL2Dev = gopacket.NewDecodingLayerParser(layers.LayerTypeEthernet, decoders...)
+	packet.decLayerL3Dev.IPv4 = gopacket.NewDecodingLayerParser(layers.LayerTypeIPv4, decoders...)
+	packet.decLayerL3Dev.IPv6 = gopacket.NewDecodingLayerParser(layers.LayerTypeIPv6, decoders...)
 	// Let packet.decLayer.DecodeLayers return a nil error when it
 	// encounters a layer it doesn't have a parser for, instead of returning
 	// an UnsupportedLayerType error.
-	packet.decLayer.IgnoreUnsupported = true
+	packet.decLayerL2Dev.IgnoreUnsupported = true
+	packet.decLayerL3Dev.IPv4.IgnoreUnsupported = true
+	packet.decLayerL3Dev.IPv6.IgnoreUnsupported = true
 
 	return &Parser{
 		log:            log,
@@ -160,7 +172,24 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	// https://github.com/google/gopacket/issues/846
 	// TODO: reconsider this check if the issue is fixed upstream
 	if len(data[packetOffset:]) > 0 {
-		err := p.packet.decLayer.DecodeLayers(data[packetOffset:], &p.packet.Layers)
+		var isL3Device, isIPv6 bool
+		if tn != nil && tn.IsL3Device() {
+			isL3Device = true
+		}
+		if tn != nil && tn.IsIPv6() {
+			isIPv6 = true
+		}
+
+		var err error
+		switch {
+		case !isL3Device:
+			err = p.packet.decLayerL2Dev.DecodeLayers(data[packetOffset:], &p.packet.Layers)
+		case isIPv6:
+			err = p.packet.decLayerL3Dev.IPv6.DecodeLayers(data[packetOffset:], &p.packet.Layers)
+		default:
+			err = p.packet.decLayerL3Dev.IPv4.DecodeLayers(data[packetOffset:], &p.packet.Layers)
+		}
+
 		if err != nil {
 			return err
 		}

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -325,48 +325,77 @@ func BenchmarkL34Decode(b *testing.B) {
 }
 
 func TestDecodeTraceNotify(t *testing.T) {
-	buf := &bytes.Buffer{}
-	tn := monitor.TraceNotifyV0{
-		Type:     byte(monitorAPI.MessageTypeTrace),
-		SrcLabel: 123,
-		DstLabel: 456,
+	for _, c := range []struct {
+		Name       string
+		IsL3Device bool
+	}{{"L3Device", true}, {"L2Device", false}} {
+		t.Run(c.Name, func(t *testing.T) {
+			tn := monitor.TraceNotify{
+				TraceNotifyV0: monitor.TraceNotifyV0{
+					Type:     byte(monitorAPI.MessageTypeTrace),
+					SrcLabel: 123,
+					DstLabel: 456,
+					Version:  monitor.TraceNotifyVersion1,
+				},
+			}
+			lay := []gopacket.SerializableLayer{
+				&layers.Ethernet{
+					SrcMAC:       net.HardwareAddr{1, 2, 3, 4, 5, 6},
+					DstMAC:       net.HardwareAddr{1, 2, 3, 4, 5, 6},
+					EthernetType: layers.EthernetTypeIPv4,
+				},
+				&layers.IPv4{
+					Version:  4,
+					IHL:      5,
+					Length:   49,
+					Id:       0xCECB,
+					TTL:      64,
+					Protocol: layers.IPProtocolUDP,
+					SrcIP:    net.IPv4(1, 2, 3, 4),
+					DstIP:    net.IPv4(1, 2, 3, 4),
+				},
+				&layers.UDP{
+					SrcPort: 23939,
+					DstPort: 32412,
+				},
+			}
+
+			if c.IsL3Device {
+				tn.Flags = monitor.TraceNotifyFlagIsL3Device
+				lay = lay[1:]
+			}
+
+			buf := &bytes.Buffer{}
+			err := binary.Write(buf, byteorder.Native, &tn)
+			require.NoError(t, err)
+			buffer := gopacket.NewSerializeBuffer()
+			err = gopacket.SerializeLayers(buffer, gopacket.SerializeOptions{}, lay...)
+			require.NoError(t, err)
+			buf.Write(buffer.Bytes())
+			require.NoError(t, err)
+			identityGetter := &testutils.FakeIdentityGetter{OnGetIdentity: func(securityIdentity uint32) (*identity.Identity, error) {
+				if securityIdentity == uint32(tn.SrcLabel) {
+					return &identity.Identity{Labels: labels.NewLabelsFromModel([]string{"k8s:src=label", "k8s:io.cilium.k8s.policy.cluster=cluster-name"})}, nil
+				} else if securityIdentity == uint32(tn.DstLabel) {
+					return &identity.Identity{Labels: labels.NewLabelsFromModel([]string{"k8s:dst=label", "k8s:io.cilium.k8s.policy.cluster=cluster-name"})}, nil
+				}
+				return nil, fmt.Errorf("identity not found for %d", securityIdentity)
+			}}
+
+			parser, err := New(hivetest.Logger(t), &testutils.NoopEndpointGetter, identityGetter, &testutils.NoopDNSGetter, &testutils.NoopIPGetter, &testutils.NoopServiceGetter, &testutils.NoopLinkGetter)
+			require.NoError(t, err)
+
+			f := &flowpb.Flow{}
+			err = parser.Decode(buf.Bytes(), f)
+			require.NoError(t, err)
+			assert.Equal(t, []string{"k8s:io.cilium.k8s.policy.cluster=cluster-name", "k8s:src=label"}, f.GetSource().GetLabels())
+			assert.Equal(t, []string{"k8s:dst=label", "k8s:io.cilium.k8s.policy.cluster=cluster-name"}, f.GetDestination().GetLabels())
+			assert.Equal(t, "cluster-name", f.GetSource().GetClusterName())
+			assert.Equal(t, "cluster-name", f.GetDestination().GetClusterName())
+			assert.Equal(t, uint32(23939), f.GetL4().GetUDP().GetSourcePort())
+			assert.Equal(t, uint32(32412), f.GetL4().GetUDP().GetDestinationPort())
+		})
 	}
-	err := binary.Write(buf, byteorder.Native, &tn)
-	require.NoError(t, err)
-	buffer := gopacket.NewSerializeBuffer()
-	err = gopacket.SerializeLayers(buffer,
-		gopacket.SerializeOptions{},
-		&layers.Ethernet{
-			SrcMAC: net.HardwareAddr{1, 2, 3, 4, 5, 6},
-			DstMAC: net.HardwareAddr{1, 2, 3, 4, 5, 6},
-		},
-		&layers.IPv4{
-			SrcIP: net.IPv4(1, 2, 3, 4),
-			DstIP: net.IPv4(1, 2, 3, 4),
-		},
-	)
-	require.NoError(t, err)
-	buf.Write(buffer.Bytes())
-	require.NoError(t, err)
-	identityGetter := &testutils.FakeIdentityGetter{OnGetIdentity: func(securityIdentity uint32) (*identity.Identity, error) {
-		if securityIdentity == uint32(tn.SrcLabel) {
-			return &identity.Identity{Labels: labels.NewLabelsFromModel([]string{"k8s:src=label", "k8s:io.cilium.k8s.policy.cluster=cluster-name"})}, nil
-		} else if securityIdentity == uint32(tn.DstLabel) {
-			return &identity.Identity{Labels: labels.NewLabelsFromModel([]string{"k8s:dst=label", "k8s:io.cilium.k8s.policy.cluster=cluster-name"})}, nil
-		}
-		return nil, fmt.Errorf("identity not found for %d", securityIdentity)
-	}}
-
-	parser, err := New(hivetest.Logger(t), &testutils.NoopEndpointGetter, identityGetter, &testutils.NoopDNSGetter, &testutils.NoopIPGetter, &testutils.NoopServiceGetter, &testutils.NoopLinkGetter)
-	require.NoError(t, err)
-
-	f := &flowpb.Flow{}
-	err = parser.Decode(buf.Bytes(), f)
-	require.NoError(t, err)
-	assert.Equal(t, []string{"k8s:io.cilium.k8s.policy.cluster=cluster-name", "k8s:src=label"}, f.GetSource().GetLabels())
-	assert.Equal(t, []string{"k8s:dst=label", "k8s:io.cilium.k8s.policy.cluster=cluster-name"}, f.GetDestination().GetLabels())
-	assert.Equal(t, "cluster-name", f.GetSource().GetClusterName())
-	assert.Equal(t, "cluster-name", f.GetDestination().GetClusterName())
 }
 
 func TestDecodeDropNotify(t *testing.T) {
@@ -1523,23 +1552,29 @@ func TestDecode_TraceNotify(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), defaultEndpointGetter, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	template := &flowpb.Flow{
-		EventType:   &flowpb.CiliumEventType{Type: 4},
-		Summary:     flowpb.IPVersion_IPv4.String(),
-		Type:        flowpb.FlowType_L3_L4,
-		Verdict:     flowpb.Verdict_FORWARDED,
-		Source:      &flowpb.Endpoint{},
-		Destination: &flowpb.Endpoint{},
-		Ethernet: &flowpb.Ethernet{
-			Source:      srcMAC.String(),
-			Destination: dstMAC.String(),
-		},
-		IP: &flowpb.IP{
-			IpVersion:   flowpb.IPVersion_IPv4,
-			Source:      localIP.String(),
-			Destination: remoteIP.String(),
-		},
-		TraceObservationPoint: flowpb.TraceObservationPoint_TO_ENDPOINT,
+	getTemplate := func(isL3Device bool) *flowpb.Flow {
+		template := &flowpb.Flow{
+			EventType:   &flowpb.CiliumEventType{Type: 4},
+			Summary:     flowpb.IPVersion_IPv4.String(),
+			Type:        flowpb.FlowType_L3_L4,
+			Verdict:     flowpb.Verdict_FORWARDED,
+			Source:      &flowpb.Endpoint{},
+			Destination: &flowpb.Endpoint{},
+			Ethernet: &flowpb.Ethernet{
+				Source:      srcMAC.String(),
+				Destination: dstMAC.String(),
+			},
+			IP: &flowpb.IP{
+				IpVersion:   flowpb.IPVersion_IPv4,
+				Source:      localIP.String(),
+				Destination: remoteIP.String(),
+			},
+			TraceObservationPoint: flowpb.TraceObservationPoint_TO_ENDPOINT,
+		}
+		if isL3Device {
+			template.Ethernet = nil
+		}
+		return template
 	}
 
 	testCases := []struct {
@@ -1611,6 +1646,7 @@ func TestDecode_TraceNotify(t *testing.T) {
 					ObsPoint: monitorAPI.TraceToCrypto,
 					Version:  monitor.TraceNotifyVersion1,
 					Reason:   monitor.TraceReasonUnknown,
+					Flags:    monitor.TraceNotifyFlagIsL3Device,
 				},
 				OrigIP: types.IPv6{1, 2, 3, 4},
 			},
@@ -1636,6 +1672,7 @@ func TestDecode_TraceNotify(t *testing.T) {
 					ObsPoint: monitorAPI.TraceFromCrypto,
 					Version:  monitor.TraceNotifyVersion1,
 					Reason:   monitor.TraceReasonUnknown,
+					Flags:    monitor.TraceNotifyFlagIsL3Device,
 				},
 				OrigIP: types.IPv6{1, 2, 3, 4},
 			},
@@ -1849,17 +1886,25 @@ func TestDecode_TraceNotify(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			want := proto.Clone(template)
-			proto.Merge(want, tc.want)
+			isL3Device := false
+			if ev, ok := tc.event.(monitor.TraceNotifyV1); ok {
+				isL3Device = (*monitor.TraceNotify)(&ev).IsL3Device()
+			}
 
-			data, err := testutils.CreateL3L4Payload(tc.event,
-				&layers.Ethernet{
+			var l []gopacket.SerializableLayer
+			if !isL3Device {
+				l = append(l, &layers.Ethernet{
 					SrcMAC:       srcMAC,
 					DstMAC:       dstMAC,
 					EthernetType: layers.EthernetTypeIPv4,
-				},
-				&layers.IPv4{SrcIP: tc.ipTuple.src.AsSlice(), DstIP: tc.ipTuple.dst.AsSlice()},
-			)
+				})
+			}
+			l = append(l, &layers.IPv4{SrcIP: tc.ipTuple.src.AsSlice(), DstIP: tc.ipTuple.dst.AsSlice()})
+
+			want := proto.Clone(getTemplate(isL3Device))
+			proto.Merge(want, tc.want)
+
+			data, err := testutils.CreateL3L4Payload(tc.event, l...)
 			if err != nil {
 				t.Fatalf("Unexpected error from CreateL3L4Payload(%T, ...): %v", tc.event, err)
 			}

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -399,53 +399,80 @@ func TestDecodeTraceNotify(t *testing.T) {
 }
 
 func TestDecodeDropNotify(t *testing.T) {
-	buf := &bytes.Buffer{}
-	dn := monitor.DropNotify{
-		Type:     byte(monitorAPI.MessageTypeDrop),
-		File:     1, // bpf_host.c
-		Line:     42,
-		SrcLabel: 123,
-		DstLabel: 456,
-	}
-	err := binary.Write(buf, byteorder.Native, &dn)
-	require.NoError(t, err)
-	buffer := gopacket.NewSerializeBuffer()
-	err = gopacket.SerializeLayers(buffer,
-		gopacket.SerializeOptions{},
-		&layers.Ethernet{
-			SrcMAC: net.HardwareAddr{1, 2, 3, 4, 5, 6},
-			DstMAC: net.HardwareAddr{1, 2, 3, 4, 5, 6},
-		},
-		&layers.IPv4{
-			SrcIP: net.IPv4(1, 2, 3, 4),
-			DstIP: net.IPv4(1, 2, 3, 4),
-		},
-	)
-	require.NoError(t, err)
-	buf.Write(buffer.Bytes())
-	require.NoError(t, err)
-	identityGetter := &testutils.FakeIdentityGetter{
-		OnGetIdentity: func(securityIdentity uint32) (*identity.Identity, error) {
-			if securityIdentity == uint32(dn.SrcLabel) {
-				return &identity.Identity{Labels: labels.NewLabelsFromModel([]string{"k8s:src=label"})}, nil
-			} else if securityIdentity == uint32(dn.DstLabel) {
-				return &identity.Identity{Labels: labels.NewLabelsFromModel([]string{"k8s:dst=label"})}, nil
+	for _, c := range []struct {
+		Name       string
+		IsL3Device bool
+	}{{"L3Device", true}, {"L2Device", false}} {
+		t.Run(c.Name, func(t *testing.T) {
+			dn := monitor.DropNotify{
+				Type:     byte(monitorAPI.MessageTypeDrop),
+				File:     1, // bpf_host.c
+				Line:     42,
+				SrcLabel: 123,
+				DstLabel: 456,
+				Version:  monitor.DropNotifyVersion2,
 			}
-			return nil, fmt.Errorf("identity not found for %d", securityIdentity)
-		},
+			lay := []gopacket.SerializableLayer{
+				&layers.Ethernet{
+					SrcMAC:       net.HardwareAddr{1, 2, 3, 4, 5, 6},
+					DstMAC:       net.HardwareAddr{1, 2, 3, 4, 5, 6},
+					EthernetType: layers.EthernetTypeIPv4,
+				},
+				&layers.IPv4{
+					Version:  4,
+					IHL:      5,
+					Length:   49,
+					Id:       0xCECB,
+					TTL:      64,
+					Protocol: layers.IPProtocolUDP,
+					SrcIP:    net.IPv4(1, 2, 3, 4),
+					DstIP:    net.IPv4(1, 2, 3, 4),
+				},
+				&layers.UDP{
+					SrcPort: 23939,
+					DstPort: 32412,
+				},
+			}
+
+			if c.IsL3Device {
+				dn.Flags = monitor.TraceNotifyFlagIsL3Device
+				lay = lay[1:]
+			}
+
+			buf := &bytes.Buffer{}
+			err := binary.Write(buf, byteorder.Native, &dn)
+			require.NoError(t, err)
+			buffer := gopacket.NewSerializeBuffer()
+			err = gopacket.SerializeLayers(buffer, gopacket.SerializeOptions{}, lay...)
+			require.NoError(t, err)
+			buf.Write(buffer.Bytes())
+			require.NoError(t, err)
+			identityGetter := &testutils.FakeIdentityGetter{
+				OnGetIdentity: func(securityIdentity uint32) (*identity.Identity, error) {
+					if securityIdentity == uint32(dn.SrcLabel) {
+						return &identity.Identity{Labels: labels.NewLabelsFromModel([]string{"k8s:src=label"})}, nil
+					} else if securityIdentity == uint32(dn.DstLabel) {
+						return &identity.Identity{Labels: labels.NewLabelsFromModel([]string{"k8s:dst=label"})}, nil
+					}
+					return nil, fmt.Errorf("identity not found for %d", securityIdentity)
+				},
+			}
+
+			parser, err := New(hivetest.Logger(t), &testutils.NoopEndpointGetter, identityGetter, &testutils.NoopDNSGetter, &testutils.NoopIPGetter, &testutils.NoopServiceGetter, &testutils.NoopLinkGetter)
+			require.NoError(t, err)
+
+			f := &flowpb.Flow{}
+			err = parser.Decode(buf.Bytes(), f)
+			require.NoError(t, err)
+			assert.Equal(t, []string{"k8s:src=label"}, f.GetSource().GetLabels())
+			assert.Equal(t, []string{"k8s:dst=label"}, f.GetDestination().GetLabels())
+			assert.NotNil(t, f.GetFile())
+			assert.Equal(t, "bpf_host.c", f.GetFile().GetName())
+			assert.Equal(t, uint32(42), f.GetFile().GetLine())
+			assert.Equal(t, uint32(23939), f.GetL4().GetUDP().GetSourcePort())
+			assert.Equal(t, uint32(32412), f.GetL4().GetUDP().GetDestinationPort())
+		})
 	}
-
-	parser, err := New(hivetest.Logger(t), &testutils.NoopEndpointGetter, identityGetter, &testutils.NoopDNSGetter, &testutils.NoopIPGetter, &testutils.NoopServiceGetter, &testutils.NoopLinkGetter)
-	require.NoError(t, err)
-
-	f := &flowpb.Flow{}
-	err = parser.Decode(buf.Bytes(), f)
-	require.NoError(t, err)
-	assert.Equal(t, []string{"k8s:src=label"}, f.GetSource().GetLabels())
-	assert.Equal(t, []string{"k8s:dst=label"}, f.GetDestination().GetLabels())
-	assert.NotNil(t, f.GetFile())
-	assert.Equal(t, "bpf_host.c", f.GetFile().GetName())
-	assert.Equal(t, uint32(42), f.GetFile().GetLine())
 }
 
 func TestDecodePolicyVerdictNotify(t *testing.T) {
@@ -582,6 +609,7 @@ func TestDecodeDropReason(t *testing.T) {
 	dn := monitor.DropNotify{
 		Type:    byte(monitorAPI.MessageTypeDrop),
 		SubType: reason,
+		Version: monitor.DropNotifyVersion2,
 	}
 	data, err := testutils.CreateL3L4Payload(dn)
 	require.NoError(t, err)
@@ -758,7 +786,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 
 	// DROP at unknown endpoint
 	dn := monitor.DropNotify{
-		Type: byte(monitorAPI.MessageTypeDrop),
+		Type:    byte(monitorAPI.MessageTypeDrop),
+		Version: monitor.DropNotifyVersion2,
 	}
 	f := parseFlow(dn, localIP, remoteIP)
 	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.GetTrafficDirection())
@@ -766,8 +795,9 @@ func TestDecodeTrafficDirection(t *testing.T) {
 
 	// DROP Egress
 	dn = monitor.DropNotify{
-		Type:   byte(monitorAPI.MessageTypeDrop),
-		Source: localEP,
+		Type:    byte(monitorAPI.MessageTypeDrop),
+		Source:  localEP,
+		Version: monitor.DropNotifyVersion2,
 	}
 	f = parseFlow(dn, localIP, remoteIP)
 	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
@@ -775,8 +805,9 @@ func TestDecodeTrafficDirection(t *testing.T) {
 
 	// DROP Ingress
 	dn = monitor.DropNotify{
-		Type:   byte(monitorAPI.MessageTypeDrop),
-		Source: localEP,
+		Type:    byte(monitorAPI.MessageTypeDrop),
+		Source:  localEP,
+		Version: monitor.DropNotifyVersion2,
 	}
 	f = parseFlow(dn, remoteIP, localIP)
 	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.GetTrafficDirection())
@@ -1459,9 +1490,10 @@ func TestDecode_DropNotify(t *testing.T) {
 		{
 			name: "drop_unknown",
 			event: monitor.DropNotify{
-				Type: byte(monitorAPI.MessageTypeDrop),
-				File: 2,
-				Line: 42,
+				Type:    byte(monitorAPI.MessageTypeDrop),
+				File:    2,
+				Line:    42,
+				Version: monitor.DropNotifyVersion2,
 			},
 			ipTuple: egressTuple,
 			want: &flowpb.Flow{
@@ -1475,10 +1507,11 @@ func TestDecode_DropNotify(t *testing.T) {
 		{
 			name: "drop_egress",
 			event: monitor.DropNotify{
-				Type:   byte(monitorAPI.MessageTypeDrop),
-				Source: localEP,
-				File:   6,
-				Line:   12,
+				Type:    byte(monitorAPI.MessageTypeDrop),
+				Source:  localEP,
+				File:    6,
+				Line:    12,
+				Version: monitor.DropNotifyVersion2,
 			},
 			ipTuple: egressTuple,
 			want: &flowpb.Flow{
@@ -1493,10 +1526,11 @@ func TestDecode_DropNotify(t *testing.T) {
 		{
 			name: "drop_ingress",
 			event: monitor.DropNotify{
-				Type:   byte(monitorAPI.MessageTypeDrop),
-				Source: localEP,
-				File:   4,
-				Line:   44,
+				Type:    byte(monitorAPI.MessageTypeDrop),
+				Source:  localEP,
+				File:    4,
+				Line:    44,
+				Version: monitor.DropNotifyVersion2,
 			},
 			ipTuple: ingressTuple,
 			want: &flowpb.Flow{

--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -466,7 +466,7 @@ func (n *DebugCapture) DumpInfo(data []byte, linkMonitor getters.LinkGetter) {
 	prefix := n.infoPrefix(linkMonitor)
 
 	if len(prefix) > 0 {
-		fmt.Printf("%s: %s\n", prefix, GetConnectionSummary(data[DebugCaptureLen:]))
+		fmt.Printf("%s: %s\n", prefix, GetConnectionSummary(data[DebugCaptureLen:], nil))
 	}
 }
 
@@ -530,7 +530,7 @@ func (n *DebugCapture) getJSON(data []byte, cpuPrefix string, linkMonitor getter
 
 	v := DebugCaptureToVerbose(n, linkMonitor)
 	v.CPUPrefix = cpuPrefix
-	v.Summary = GetConnectionSummary(data[DebugCaptureLen:])
+	v.Summary = GetConnectionSummary(data[DebugCaptureLen:], nil)
 
 	ret, err := json.Marshal(v)
 	return string(ret), err

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -15,17 +15,30 @@ import (
 )
 
 const (
-	DropNotifyVersion0 = 0
-	DropNotifyVersion1 = 1
+	DropNotifyVersion0 = iota
+	DropNotifyVersion1
+	DropNotifyVersion2
+)
 
-	// DropNotifyV1Len is the amount of packet data provided in a v1 drop notification.
-	DropNotifyV1Len = 36
+const (
+	// dropNotifyV1Len is the amount of packet data provided in a v0/v1 drop notification.
+	dropNotifyV1Len = 36
+	// dropNotifyV2Len is the amount of packet data provided in a v2 drop notification.
+	dropNotifyV2Len = 40
+)
+
+const (
+	// DropNotifyFlagIsIPv6 is set in DropNotify.Flags when it refers to an IPv6 flow.
+	DropNotifyFlagIsIPv6 uint8 = 1 << iota
+	// DropNotifyFlagIsL3Device is set in DropNotify.Flags when it refers to a L3 device.
+	DropNotifyFlagIsL3Device
 )
 
 var (
 	dropNotifyLengthFromVersion = map[uint16]uint{
-		DropNotifyVersion0: DropNotifyV1Len, // retain backwards compatibility for testing.
-		DropNotifyVersion1: DropNotifyV1Len,
+		DropNotifyVersion0: dropNotifyV1Len, // retain backwards compatibility for testing.
+		DropNotifyVersion1: dropNotifyV1Len,
+		DropNotifyVersion2: dropNotifyV2Len,
 	}
 )
 
@@ -45,6 +58,8 @@ type DropNotify struct {
 	File     uint8
 	ExtError int8
 	Ifindex  uint32
+	Flags    uint8
+	_        [3]uint8
 	// data
 }
 
@@ -64,8 +79,8 @@ func DecodeDropNotify(data []byte, dn *DropNotify) error {
 }
 
 func (n *DropNotify) decodeDropNotify(data []byte) error {
-	if l := len(data); l < DropNotifyV1Len {
-		return fmt.Errorf("unexpected DropNotify data length, expected %d but got %d", DropNotifyV1Len, l)
+	if l := len(data); l < dropNotifyV1Len {
+		return fmt.Errorf("unexpected DropNotify data length, expected %d but got %d", dropNotifyV1Len, l)
 	}
 
 	n.Type = data[0]
@@ -83,7 +98,25 @@ func (n *DropNotify) decodeDropNotify(data []byte) error {
 	n.ExtError = int8(data[31])
 	n.Ifindex = byteorder.Native.Uint32(data[32:36])
 
+	switch n.Version {
+	case DropNotifyVersion2:
+		if l := len(data); l < dropNotifyV2Len {
+			return fmt.Errorf("unexpected DropNotify data length, expected %d but got %d", dropNotifyV2Len, l)
+		}
+		n.Flags = data[36]
+	}
+
 	return nil
+}
+
+// IsL3Device returns true if the trace comes from an L3 device.
+func (n *DropNotify) IsL3Device() bool {
+	return n.Flags&DropNotifyFlagIsL3Device != 0
+}
+
+// IsIPv6 returns true if the trace refers to an IPv6 packet.
+func (n *DropNotify) IsIPv6() bool {
+	return n.Flags&DropNotifyFlagIsIPv6 != 0
 }
 
 // DataOffset returns the offset from the beginning of DropNotify where the
@@ -100,7 +133,7 @@ func (n *DropNotify) DumpInfo(data []byte, numeric DisplayFormat) {
 	fmt.Fprintf(buf, "xx drop (%s) flow %#x to endpoint %d, ifindex %d, file %s:%d, ",
 		api.DropReasonExt(n.SubType, n.ExtError), n.Hash, n.DstID, n.Ifindex, api.BPFFileName(n.File), int(n.Line))
 	n.dumpIdentity(buf, numeric)
-	fmt.Fprintf(buf, ": %s\n", GetConnectionSummary(data[n.DataOffset():], nil))
+	fmt.Fprintf(buf, ": %s\n", GetConnectionSummary(data[n.DataOffset():], &decodeOpts{n.IsL3Device(), n.IsIPv6()}))
 	buf.Flush()
 }
 

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -100,7 +100,7 @@ func (n *DropNotify) DumpInfo(data []byte, numeric DisplayFormat) {
 	fmt.Fprintf(buf, "xx drop (%s) flow %#x to endpoint %d, ifindex %d, file %s:%d, ",
 		api.DropReasonExt(n.SubType, n.ExtError), n.Hash, n.DstID, n.Ifindex, api.BPFFileName(n.File), int(n.Line))
 	n.dumpIdentity(buf, numeric)
-	fmt.Fprintf(buf, ": %s\n", GetConnectionSummary(data[n.DataOffset():]))
+	fmt.Fprintf(buf, ": %s\n", GetConnectionSummary(data[n.DataOffset():], nil))
 	buf.Flush()
 }
 

--- a/pkg/monitor/datapath_drop_test.go
+++ b/pkg/monitor/datapath_drop_test.go
@@ -16,7 +16,7 @@ import (
 func TestDecodeDropNotify(t *testing.T) {
 	// This check on the struct length constant is there to ensure that this
 	// test is updated when the struct changes.
-	require.Equal(t, 36, DropNotifyV1Len)
+	require.Equal(t, 40, dropNotifyV2Len)
 
 	input := DropNotify{
 		Type:     0x00,
@@ -25,7 +25,7 @@ func TestDecodeDropNotify(t *testing.T) {
 		Hash:     0x04_05_06_07,
 		OrigLen:  0x08_09_0a_0b,
 		CapLen:   0x0c_0d,
-		Version:  0x01,
+		Version:  0x02,
 		SrcLabel: 0x11_12_13_14,
 		DstLabel: 0x15_16_17_18,
 		DstID:    0x19_1a_1b_1c,
@@ -33,6 +33,7 @@ func TestDecodeDropNotify(t *testing.T) {
 		File:     0x20,
 		ExtError: 0x21,
 		Ifindex:  0x22_23_24_25,
+		Flags:    DropNotifyFlagIsIPv6 | DropNotifyFlagIsL3Device,
 	}
 	buf := bytes.NewBuffer(nil)
 	err := binary.Write(buf, byteorder.Native, input)
@@ -55,6 +56,9 @@ func TestDecodeDropNotify(t *testing.T) {
 	require.Equal(t, input.File, output.File)
 	require.Equal(t, input.ExtError, output.ExtError)
 	require.Equal(t, input.Ifindex, output.Ifindex)
+	require.Equal(t, input.Flags, output.Flags)
+	require.True(t, output.IsL3Device())
+	require.True(t, output.IsIPv6())
 }
 
 func BenchmarkNewDecodeDropNotify(b *testing.B) {

--- a/pkg/monitor/datapath_policy.go
+++ b/pkg/monitor/datapath_policy.go
@@ -149,6 +149,6 @@ func (n *PolicyVerdictNotify) DumpInfo(data []byte, numeric DisplayFormat) {
 	fmt.Fprintf(buf, ", proto %d, %s, action %s, auth: %s, match %s, %s\n", n.Proto, dir,
 		GetPolicyActionString(n.Verdict, n.IsTrafficAudited()),
 		n.GetAuthType(), n.GetPolicyMatchType(),
-		GetConnectionSummary(data[PolicyVerdictNotifyLen:]))
+		GetConnectionSummary(data[PolicyVerdictNotifyLen:], nil))
 	buf.Flush()
 }

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -30,7 +30,10 @@ const (
 const (
 	// TraceNotifyFlagIsIPv6 is set in TraceNotify.Flags when the
 	// notification refers to an IPv6 flow
-	TraceNotifyFlagIsIPv6 uint8 = 1
+	TraceNotifyFlagIsIPv6 uint8 = 1 << iota
+	// TraceNotifyFlagIsL3Device is set in TraceNotify.Flags when the
+	// notification refers to a L3 device.
+	TraceNotifyFlagIsL3Device
 )
 
 const (
@@ -274,10 +277,20 @@ func (n *TraceNotify) traceSummary() string {
 	}
 }
 
+// IsL3Device returns true if the trace comes from an L3 device.
+func (n *TraceNotify) IsL3Device() bool {
+	return n.Flags&TraceNotifyFlagIsL3Device != 0
+}
+
+// IsIPv6 returns true if the trace refers to an IPv6 packet.
+func (n *TraceNotify) IsIPv6() bool {
+	return n.Flags&TraceNotifyFlagIsIPv6 != 0
+}
+
 // OriginalIP returns the original source IP if reverse NAT was performed on
 // the flow
 func (n *TraceNotify) OriginalIP() net.IP {
-	if (n.Flags & TraceNotifyFlagIsIPv6) != 0 {
+	if n.IsIPv6() {
 		return n.OrigIP[:]
 	}
 	return n.OrigIP[:4]
@@ -304,7 +317,7 @@ func (n *TraceNotify) DumpInfo(data []byte, numeric DisplayFormat, linkMonitor g
 	n.dumpIdentity(buf, numeric)
 	ifname := linkMonitor.Name(n.Ifindex)
 	fmt.Fprintf(buf, " state %s ifindex %s orig-ip %s: %s\n", n.traceReasonString(),
-		ifname, n.OriginalIP().String(), GetConnectionSummary(data[hdrLen:]))
+		ifname, n.OriginalIP().String(), GetConnectionSummary(data[hdrLen:], &decodeOpts{n.IsL3Device(), n.IsIPv6()}))
 	buf.Flush()
 }
 

--- a/pkg/monitor/dissect.go
+++ b/pkg/monitor/dissect.go
@@ -137,18 +137,6 @@ func getConnectionInfoFromCache() (c *ConnectionInfo, hasIP, hasEth bool) {
 	return c, hasIP, hasEth
 }
 
-// GetConnectionInfo returns the ConnectionInfo structure from data
-func GetConnectionInfo(data []byte) *ConnectionInfo {
-	dissectLock.Lock()
-	defer dissectLock.Unlock()
-
-	initParser()
-	parser.DecodeLayers(data, &cache.decoded)
-
-	c, _, _ := getConnectionInfoFromCache()
-	return c
-}
-
 // GetConnectionSummary decodes the data into layers and returns a connection
 // summary in the format:
 //

--- a/pkg/monitor/dissect_test.go
+++ b/pkg/monitor/dissect_test.go
@@ -6,6 +6,7 @@ package monitor
 import (
 	"fmt"
 	"net"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -51,15 +52,29 @@ func TestConnectionSummaryTcp(t *testing.T) {
 
 	// Generated in scapy:
 	// Ether(src="01:23:45:67:89:ab", dst="02:33:45:67:89:ab")/IP(src="1.2.3.4",dst="5.6.7.8")/TCP(sport=80,dport=443)
-	packetData := []byte{2, 51, 69, 103, 137, 171, 1, 35, 69, 103, 137, 171, 8, 0, 69, 0, 0, 40, 0, 1, 0, 0, 64, 6, 106, 188, 1, 2, 3, 4, 5, 6, 7, 8, 0, 80, 1, 187, 0, 0, 0, 0, 0, 0, 0, 0, 80, 2, 32, 0, 125, 196, 0, 0}
+	l2Data := []byte{2, 51, 69, 103, 137, 171, 1, 35, 69, 103, 137, 171, 8, 0}
+	l3Data := []byte{69, 0, 0, 40, 0, 1, 0, 0, 64, 6, 106, 188, 1, 2, 3, 4, 5, 6, 7, 8, 0, 80, 1, 187, 0, 0, 0, 0, 0, 0, 0, 0, 80, 2, 32, 0, 125, 196, 0, 0}
 
-	summary := GetConnectionSummary(packetData)
+	for _, c := range []struct {
+		Name       string
+		IsL3Device bool
+	}{{"L3Device", true}, {"L2Device", false}} {
+		t.Run(c.Name, func(t *testing.T) {
+			var data []byte
+			if c.IsL3Device {
+				data = l3Data
+			} else {
+				data = slices.Concat(l2Data, l3Data)
+			}
+			summary := GetConnectionSummary(data, &decodeOpts{c.IsL3Device, false})
 
-	expect := fmt.Sprintf("%s -> %s %s",
-		net.JoinHostPort(srcIP, sport),
-		net.JoinHostPort(dstIP, dport),
-		"tcp SYN")
-	require.Equal(t, expect, summary)
+			expect := fmt.Sprintf("%s -> %s %s",
+				net.JoinHostPort(srcIP, sport),
+				net.JoinHostPort(dstIP, dport),
+				"tcp SYN")
+			require.Equal(t, expect, summary)
+		})
+	}
 }
 
 func TestConnectionSummaryIcmp(t *testing.T) {
@@ -70,7 +85,7 @@ func TestConnectionSummaryIcmp(t *testing.T) {
 	// Ether(src="01:23:45:67:89:ab", dst="02:33:45:67:89:ab")/IP(src="1.2.3.4",dst="5.6.7.8")/ICMP(type=3, code=1)
 	packetData := []byte{2, 51, 69, 103, 137, 171, 1, 35, 69, 103, 137, 171, 8, 0, 69, 0, 0, 28, 0, 1, 0, 0, 64, 1, 106, 205, 1, 2, 3, 4, 5, 6, 7, 8, 3, 1, 252, 254, 0, 0, 0, 0}
 
-	summary := GetConnectionSummary(packetData)
+	summary := GetConnectionSummary(packetData, nil)
 
 	expect := fmt.Sprintf("%s -> %s %s",
 		srcIP,


### PR DESCRIPTION
Currently we're mistakenly parsing packets sent from an L3 device, as our decoders in Hubble/Monitors assume Ethernet as the first layers of the packet. Therefore, the output looks something like:

```bash
-> crypto flow 0x0 , identity 53498->unknown state unknown ifindex cilium_wg0 orig-ip 0.0.0.0: 40:00:3f:01:53:89 -> 45:00:00:54:cd:c8 UnknownEthernetType
```

Let's fix that by borrowing a bit in the trace/drop notify event to tell whether the packet comes from an L3 device or not:
1. if from L3 device (ex wireguard), then look at `ctx->protocol` to additionally tell whether IPv4/6 (we need these info to know which parser to use)
2. if from L2 device, then use the default parser (starting from Ethernet layer).

The output after this patch should look as follows:

```bash
# IPv4
## Cilium Monitor
<- crypto flow 0x0 , identity 37044->unknown state unknown ifindex cilium_wg0 orig-ip 0.0.0.0: 10.244.1.88 -> 10.244.2.35 EchoRequest
-> crypto flow 0x0 , identity 54684->unknown state unknown ifindex cilium_wg0 orig-ip 0.0.0.0: 10.244.2.35 -> 10.244.1.88 EchoReply
## Hubble Observe
Jan 31 14:34:38.876: cilium-test-1/client-7d44dd948b-cjh5k (ID:37044) <> cilium-test-1/echo-other-node-79787668d5-xwg9k (ID:54684) from-crypto FORWARDED (ICMPv4 EchoRequest)
Jan 31 14:34:38.877: cilium-test-1/echo-other-node-79787668d5-xwg9k (ID:54684) <> cilium-test-1/client-7d44dd948b-cjh5k (ID:37044) to-crypto FORWARDED (ICMPv4 EchoReply)

# IPv6
## Cilium Monitor
<- crypto flow 0x0 , identity 37044->unknown state unknown ifindex cilium_wg0 orig-ip ::: fd00:10:244:1::3c72 -> fd00:10:244:2::ca3f EchoRequest
-> crypto flow 0xc0318447 , identity 54684->unknown state unknown ifindex cilium_wg0 orig-ip ::: fd00:10:244:2::ca3f -> fd00:10:244:1::3c72 EchoReply
## Hubble Observe
Jan 31 14:26:26.430: cilium-test-1/client-7d44dd948b-cjh5k (ID:37044) <> cilium-test-1/echo-other-node-79787668d5-xwg9k (ID:54684) from-crypto FORWARDED (ICMPv6 EchoRequest)
Jan 31 14:26:26.430: cilium-test-1/echo-other-node-79787668d5-xwg9k (ID:54684) <> cilium-test-1/client-7d44dd948b-cjh5k (ID:37044) to-crypto FORWARDED (ICMPv6 EchoReply)
```

Fixes: #37095