### PR TITLE
Fix batched LRU flakes

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -957,7 +957,7 @@ func (bi *BatchIterator[KT, VT, KP, VP]) IterateAll(ctx context.Context, opts ..
 				// If we receive ENOSPC failures, we will try to recover by growing the batch buffer
 				// size (up to some max number of retries - default: 3) and retrying the iteration.
 				//
-				// [1] https://elixir.bootlin.com/linux/latest/source/kernel/bpf/hashtab.c#L1776
+				// [1] https://elixir.bootlin.com/linux/v6.12.6/source/kernel/bpf/hashtab.c#L1807-L1809
 				//
 				// Note: If this failure happens during the bpf syscall, it is expected that the underlying
 				// cursor will not have been swapped - meaning that we can retry the iteration at the same cursor.


### PR DESCRIPTION
Tests on LRU maps where unreliable due to evictions, we can mitigate this by only running such tests on cases where the map max size is far above the number of elements.

Fixes: https://github.com/cilium/cilium/issues/36999 