### PR TITLE
test: Fix the flake for TestRestoredPort

### DIFF
--- a/pkg/proxy/proxyports/proxyports_test.go
+++ b/pkg/proxy/proxyports/proxyports_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/envoy"
@@ -278,8 +279,8 @@ func TestRestoredPort(t *testing.T) {
 	require.Zero(t, pp.nRedirects)
 
 	// wait for port reuse wait to pass
-	time.Sleep(time.Millisecond)
-	require.Zero(t, pp.ProxyPort)
+	// waiting time is set up to 1s (instead of exactly 1ms) to avoid potential flake in CI
+	require.Eventually(t, func() bool { return assert.Zero(t, pp.ProxyPort) }, time.Second, time.Millisecond)
 	require.False(t, pp.configured)
 	require.False(t, pp.acknowledged)
 


### PR DESCRIPTION
Testing was done locally as per below

```
➜  cilium git:(main) ✗ go test -count=1000 ./pkg/proxy/proxyports/... -test.run TestRestoredPort
ok      github.com/cilium/cilium/pkg/proxy/proxyports   4.666s
```

Fixes: #37091 