### PR TITLE
wireguard: attach Ingress program for native routing mode configurations

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2385,14 +2385,33 @@ func (c *DaemonConfig) AreDevicesRequired() bool {
 		c.EnableL2Announcements || c.ForceDeviceRequired || c.EnableIPSecEncryptedOverlay
 }
 
-// When WG & encrypt-node are on, a NodePort BPF to-be forwarded request
-// to a remote node running a selected service endpoint must be encrypted.
-// To make the NodePort's rev-{S,D}NAT translations to happen for a reply
-// from the remote node, we need to attach bpf_host to the Cilium's WG
-// netdev (otherwise, the WG netdev after decrypting the reply will pass
-// it to the stack which drops the packet).
+// NeedBPFHostOnWireGuardDevice returns true if the agent needs to attach
+// a BPF program on the Ingress of Cilium's WireGuard device
 func (c *DaemonConfig) NeedBPFHostOnWireGuardDevice() bool {
-	return c.EnableNodePort && c.EnableWireguard && c.EncryptNode
+	if !c.EnableWireguard {
+		return false
+	}
+
+	// In native routing mode we want to deliver packets to local endpoints
+	// straight from BPF, without passing through the stack.
+	// This matches overlay mode (where bpf_overlay would handle the delivery)
+	// and native routing mode without encryption (where bpf_host at the native
+	// device would handle the delivery).
+	if !c.TunnelingEnabled() {
+		return true
+	}
+
+	// When WG & encrypt-node are on, a NodePort BPF to-be forwarded request
+	// to a remote node running a selected service endpoint must be encrypted.
+	// To make the NodePort's rev-{S,D}NAT translations to happen for a reply
+	// from the remote node, we need to attach bpf_host to the Cilium's WG
+	// netdev (otherwise, the WG netdev after decrypting the reply will pass
+	// it to the stack which drops the packet).
+	if c.EnableNodePort && c.EncryptNode {
+		return true
+	}
+
+	return false
 }
 
 // MasqueradingEnabled returns true if either IPv4 or IPv6 masquerading is enabled.


### PR DESCRIPTION
Without the `from-netdev` program at cilium_wg0's Ingress hook, received packets drop into the host network stack and are then delivered via cilium_host / cilium_net.

This impacts configurations with BPF Host Routing, as packets are unexpectedly observed by the host stack. It is also different from overlay routing mode (where such packets are subsequently handled by `from-overlay` and delivered to local endpoints using BPF), or a configuration without encryption (where such packets are delivered to local endpoints by `from-netdev` at the native device).

Therefore change the condition in NeedBPFHostOnWireGuardDevice() to also consider native routing mode.