### PR TITLE
cli: Fix empty egress bandwidth and priority config display

### DIFF
--- a/cilium-dbg/cmd/bpf_bandwidth_list.go
+++ b/cilium-dbg/cmd/bpf_bandwidth_list.go
@@ -52,19 +52,28 @@ func listBandwidth(bpfBandwidthList map[string][]string) {
 	const (
 		labelsIDTitle   = "IDENTITY"
 		labelsBandwidth = "EGRESS BANDWIDTH (BitsPerSec)"
+		labelsPrio      = "PRIO"
 	)
 
 	w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
-	fmt.Fprintf(w, "%s\t%s\n", labelsIDTitle, labelsBandwidth)
+	fmt.Fprintf(w, "%s\t%s\t%s\n", labelsIDTitle, labelsPrio, labelsBandwidth)
 
-	const numColumns = 2
+	const numColumns = 3
 	rows := [][numColumns]string{}
 
 	for key, value := range bpfBandwidthList {
-		bps, _ := strconv.Atoi(value[0])
+		bps := 0
+		prio := ""
+		info := strings.Split(value[0], ",")
+		if len(info) > 0 {
+			bps, _ = strconv.Atoi(info[0])
+		}
+		if len(info) > 1 {
+			prio = strings.TrimSpace(info[1])
+		}
 		bps *= 8
 		quantity := resource.NewQuantity(int64(bps), resource.DecimalSI)
-		rows = append(rows, [numColumns]string{key, quantity.String()})
+		rows = append(rows, [numColumns]string{key, prio, quantity.String()})
 	}
 
 	sort.Slice(rows, func(i, j int) bool {
@@ -80,7 +89,7 @@ func listBandwidth(bpfBandwidthList map[string][]string) {
 	})
 
 	for _, r := range rows {
-		fmt.Fprintf(w, "%s\t%s\n", r[0], r[1])
+		fmt.Fprintf(w, "%s\t%s\t%s\n", r[0], r[1], r[2])
 	}
 
 	w.Flush()


### PR DESCRIPTION
Resolved issue where the egress bandwidth configuration were displayed as empty values.

```
IDENTITY   PRIO   EGRESS BANDWIDTH (BitsPerSec)
1426       0      0
1763       0      5G
3571       7      0
...
```

Fixes: #37107

