### PR TITLE
ci: more robust hubble relay service port-forwarding

### DIFF
--- a/.github/workflows/hubble-cli-integration-test.yaml
+++ b/.github/workflows/hubble-cli-integration-test.yaml
@@ -173,14 +173,10 @@ jobs:
           set -ex
           ./hubble/hubble --version
 
-          kubectl -n kube-system port-forward service/hubble-relay 4245:80 &
+          cilium hubble port-forward&
           echo "wait until the port-forward is running"
-          until [ $(pgrep --count --full "kubectl.*port-forward.*service\/hubble-relay.*4245:80") -eq 1 ]; do
-            sleep 1
-          done
-
-          # give relay a little bit more time to actually connect to agent before running commands.
-          sleep 5
+          sleep 10s
+          nc -nvz 127.0.0.1 4245
 
           ./hubble/hubble status
 


### PR DESCRIPTION
This is a follow-up to #35483 which added native port-forwarding the Hubble CLI. Similar to [#2850](https://github.com/cilium/cilium-cli/pull/2850), we use `nc` as a more robust method for checking if hubble port-forward is successful, which should improve CI's reliability (hence why I marked the PR for backport).