### PR TITLE
devices controller: spell out list of required netlink families

### DIFF
--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -714,7 +714,7 @@ type netlinkFuncs struct {
 // makeNetlinkFuncs returns a *netlinkFuncs containing netlink accessors to the
 // network namespace of the calling goroutine's OS thread.
 func makeNetlinkFuncs() (*netlinkFuncs, error) {
-	netlinkHandle, err := netlink.NewHandle()
+	netlinkHandle, err := netlink.NewHandle(unix.NETLINK_ROUTE, unix.NETLINK_NETFILTER)
 	if err != nil {
 		return nil, fmt.Errorf("creating netlink handle: %w", err)
 	}


### PR DESCRIPTION
Spell out the list of netlink families that we use. Otherwise the netlink library will pull in a default list (`SupportedNlFamilies`) which includes NETLINK_XFRM. This might not be available on the host kernel.

See https://github.com/cilium/cilium/issues/36600#issuecomment-2546387246.

```release-note
Allow cilium agent to start on linux kernels that don't have CONFIG_XFRM.
```
