### PR TITLE
maps/ctmap: don't log if batch iteration is not supported

### DIFF
--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -417,12 +417,7 @@ func purgeCtEntry(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map, next func(
 }
 
 var batchAPISupported = sync.OnceValue(func() bool {
-	err := probes.HaveBatchAPI()
-	supported := !errors.Is(err, probes.ErrNotSupported)
-	if !supported {
-		log.WithError(err).Info("kernel does not support batch iteration for ctmap gc")
-	}
-	return supported
+	return !errors.Is(probes.HaveBatchAPI(), probes.ErrNotSupported)
 })
 
 func iterate[KT any, VT any, KP bpf.KeyPointer[KT], VP bpf.ValuePointer[VT]](m *Map, stats *gcStats, filterCallback func(key bpf.MapKey, value bpf.MapValue)) error {


### PR DESCRIPTION
Otherwise cilium-cli connectivity tests trip on the log line being emitted when running `cilium bpf ct flush global` and treating any stderr output as an error, see example failure at [^1].

[^1]: https://github.com/cilium/cilium/actions/runs/12885698983/job/35925057019