### PR TITLE
[v1.16] Revert backport of #36466 (k8s: Debounce service events)

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -498,14 +498,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	option.BindEnv(vp, option.K8sServiceCacheSize)
 	flags.MarkHidden(option.K8sServiceCacheSize)
 
-	flags.Int(option.K8sServiceDebounceBufferSize, 128, "Number of distinct services to buffer for event debouncing")
-	option.BindEnv(vp, option.K8sServiceDebounceBufferSize)
-	flags.MarkHidden(option.K8sServiceDebounceBufferSize)
-
-	flags.Duration(option.K8sServiceDebounceWaitTime, 200*time.Millisecond, "The amount of time to wait to debounce service events")
-	option.BindEnv(vp, option.K8sServiceDebounceWaitTime)
-	flags.MarkHidden(option.K8sServiceDebounceWaitTime)
-
 	flags.String(option.K8sWatcherEndpointSelector, defaults.K8sWatcherEndpointSelector, "K8s endpoint watcher will watch for these k8s endpoints")
 	option.BindEnv(vp, option.K8sWatcherEndpointSelector)
 

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -31,12 +31,7 @@ func k8sServiceHandler(ctx context.Context, cinfo cmtypes.ClusterInfo, shared bo
 	serviceHandler := func(event k8s.ServiceEvent) {
 		defer event.SWG.Done()
 
-		var svc serviceStore.ClusterService
-		if event.Action == k8s.UpdateService {
-			svc = k8s.NewClusterService(event.ID, event.Service, event.Endpoints)
-		} else if event.Action == k8s.DeleteService {
-			svc = k8s.NewClusterService(event.ID, event.OldService, event.OldEndpoints)
-		}
+		svc := k8s.NewClusterService(event.ID, event.Service, event.Endpoints)
 		svc.Cluster = cinfo.Name
 		svc.ClusterID = cinfo.ID
 
@@ -46,8 +41,6 @@ func k8sServiceHandler(ctx context.Context, cinfo cmtypes.ClusterInfo, shared bo
 			"action":               event.Action.String(),
 			"service":              event.Service.String(),
 			"endpoints":            event.Endpoints.String(),
-			"old-service":          event.OldService.String(),
-			"old-endpoints":        event.OldEndpoints.String(),
 			"shared":               event.Service.Shared,
 		})
 		scopedLog.Debug("Kubernetes service definition changed")

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -48,11 +48,11 @@ func k8sServiceHandler(ctx context.Context, cinfo cmtypes.ClusterInfo, shared bo
 			"endpoints":            event.Endpoints.String(),
 			"old-service":          event.OldService.String(),
 			"old-endpoints":        event.OldEndpoints.String(),
-			"shared":               svc.Shared,
+			"shared":               event.Service.Shared,
 		})
 		scopedLog.Debug("Kubernetes service definition changed")
 
-		if shared && !svc.Shared {
+		if shared && !event.Service.Shared {
 			// The annotation may have been added, delete an eventual existing service
 			kvs.DeleteKey(ctx, &svc)
 			return

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -311,7 +311,7 @@ func TestClusterMeshServicesUpdate(t *testing.T) {
 
 	require.NoError(t, kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName+"2"))
 	s.expectEvent(t, k8s.DeleteService, svcID, func(c *assert.CollectT, event k8s.ServiceEvent) {
-		assert.Contains(c, event.OldEndpoints.Backends, cmtypes.MustParseAddrCluster("90.0.185.196"))
+		assert.Empty(c, event.OldEndpoints.Backends)
 	})
 
 	swgSvcs.Stop()

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -311,7 +311,7 @@ func TestClusterMeshServicesUpdate(t *testing.T) {
 
 	require.NoError(t, kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName+"2"))
 	s.expectEvent(t, k8s.DeleteService, svcID, func(c *assert.CollectT, event k8s.ServiceEvent) {
-		assert.Empty(c, event.OldEndpoints.Backends)
+		assert.Len(c, event.Endpoints.Backends, 0)
 	})
 
 	swgSvcs.Stop()

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -415,11 +415,11 @@ func (s *ServiceCache) DeleteService(k8sSvc *slim_corev1.Service, swg *lock.Stop
 		s.metrics.DelService(oldService)
 		swg.Add()
 		s.emitEvent(ServiceEvent{
-			Action:       DeleteService,
-			ID:           svcID,
-			OldService:   oldService,
-			OldEndpoints: endpoints,
-			SWG:          swg,
+			Action:    DeleteService,
+			ID:        svcID,
+			Service:   oldService,
+			Endpoints: endpoints,
+			SWG:       swg,
 		})
 	}
 }
@@ -813,7 +813,6 @@ func (s *ServiceCache) mergeExternalServiceDeleteLocked(service *serviceStore.Cl
 				Action:       UpdateService,
 				ID:           id,
 				Service:      svc,
-				OldService:   svc,
 				Endpoints:    endpoints,
 				OldEndpoints: oldEPs,
 				SWG:          swg,
@@ -822,8 +821,6 @@ func (s *ServiceCache) mergeExternalServiceDeleteLocked(service *serviceStore.Cl
 			if !serviceReady {
 				delete(s.services, id)
 				event.Action = DeleteService
-				event.Service = nil
-				event.Endpoints = nil
 			}
 
 			s.emitEvent(event)
@@ -880,11 +877,11 @@ func (s *ServiceCache) MergeClusterServiceDelete(service *serviceStore.ClusterSe
 	if ok {
 		swg.Add()
 		s.emitEvent(ServiceEvent{
-			Action:       DeleteService,
-			ID:           id,
-			OldService:   svc,
-			OldEndpoints: endpoints,
-			SWG:          swg,
+			Action:    DeleteService,
+			ID:        id,
+			Service:   svc,
+			Endpoints: endpoints,
+			SWG:       swg,
 		})
 	}
 }

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -183,7 +183,7 @@ func (k *K8sServiceWatcher) k8sServiceHandler() {
 		case k8s.UpdateService:
 			k.addK8sSVCs(event.ID, event.OldService, svc, event.Endpoints)
 		case k8s.DeleteService:
-			k.delK8sSVCs(event.ID, event.OldService)
+			k.delK8sSVCs(event.ID, event.Service)
 		}
 	}
 	for {

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -10,7 +10,6 @@ import (
 	"sync/atomic"
 
 	"github.com/cilium/hive/cell"
-	"github.com/cilium/stream"
 	"github.com/sirupsen/logrus"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
@@ -157,90 +156,45 @@ func (k *K8sServiceWatcher) deleteK8sServiceV1(svc *slim_corev1.Service, swg *lo
 }
 
 func (k *K8sServiceWatcher) k8sServiceHandler() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	eventHandler := func(event k8s.ServiceEvent) {
+		defer func(startTime time.Time) {
+			event.SWG.Done()
+			k.k8sServiceEventProcessed(event.Action.String(), startTime)
+		}(time.Now())
 
-	type event struct {
-		k8s.ServiceEvent
-		doneFuncs []func()
-	}
+		svc := event.Service
 
-	bufferEvent := func(buf map[k8s.ServiceID]event, ev k8s.ServiceEvent) map[k8s.ServiceID]event {
-		if buf == nil {
-			buf = map[k8s.ServiceID]event{}
+		scopedLog := log.WithFields(logrus.Fields{
+			logfields.K8sSvcName:   event.ID.Name,
+			logfields.K8sNamespace: event.ID.Namespace,
+		})
+
+		if logging.CanLogAt(scopedLog.Logger, logrus.DebugLevel) {
+			scopedLog.WithFields(logrus.Fields{
+				"action":        event.Action.String(),
+				"service":       event.Service.String(),
+				"old-service":   event.OldService.String(),
+				"endpoints":     event.Endpoints.String(),
+				"old-endpoints": event.OldEndpoints.String(),
+			}).Debug("Kubernetes service definition changed")
 		}
 
-		event := event{ServiceEvent: ev, doneFuncs: []func(){ev.SWG.Done}}
-		old, ok := buf[ev.ID]
-		if ok {
-			// Older event existed, reuse the "old" structures so that the event describes
-			// the full delta.
-			event.OldEndpoints = old.OldEndpoints
-			event.OldService = old.OldService
-			event.doneFuncs = append(old.doneFuncs, event.doneFuncs...)
+		switch event.Action {
+		case k8s.UpdateService:
+			k.addK8sSVCs(event.ID, event.OldService, svc, event.Endpoints)
+		case k8s.DeleteService:
+			k.delK8sSVCs(event.ID, event.OldService)
 		}
-		buf[ev.ID] = event
-		return buf
 	}
-
-	// Collect events into a buffer to debounce repeated events for the same service.
-	// This has a big impact when there are many EndpointSlices for a single service as
-	// we'll collapse those into a single event and avoid the repeated service upserts.
-	events :=
-		stream.ToChannel(ctx,
-			stream.Buffer(
-				stream.FromChannel(k.k8sSvcCache.Events),
-				option.Config.K8sServiceDebounceBufferSize,
-				option.Config.K8sServiceDebounceWaitTime,
-				bufferEvent,
-			),
-		)
 	for {
 		select {
 		case <-k.stop:
-			cancel()
-		case buf, ok := <-events:
+			return
+		case event, ok := <-k.k8sSvcCache.Events:
 			if !ok {
 				return
 			}
-			for _, ev := range buf {
-				k.processServiceEvent(ev.ServiceEvent)
-				for _, done := range ev.doneFuncs {
-					done()
-				}
-			}
-		}
-	}
-}
-
-func (k *K8sServiceWatcher) processServiceEvent(event k8s.ServiceEvent) {
-	defer func(startTime time.Time) {
-		k.k8sServiceEventProcessed(event.Action.String(), startTime)
-	}(time.Now())
-
-	scopedLog := log.WithFields(logrus.Fields{
-		logfields.K8sSvcName:   event.ID.Name,
-		logfields.K8sNamespace: event.ID.Namespace,
-	})
-
-	if logging.CanLogAt(scopedLog.Logger, logrus.DebugLevel) {
-		scopedLog.WithFields(logrus.Fields{
-			"action":        event.Action.String(),
-			"service":       event.Service.String(),
-			"old-service":   event.OldService.String(),
-			"endpoints":     event.Endpoints.String(),
-			"old-endpoints": event.OldEndpoints.String(),
-		}).Debug("Kubernetes service definition changed")
-	}
-
-	switch event.Action {
-	case k8s.UpdateService:
-		k.addK8sSVCs(event.ID, event.OldService, event.Service, event.Endpoints)
-	case k8s.DeleteService:
-		// If [event.OldService] is nil then no upsert event was ever processed
-		// and we have nothing to delete.
-		if event.OldService != nil {
-			k.delK8sSVCs(event.ID, event.OldService)
+			eventHandler(event)
 		}
 	}
 }

--- a/pkg/k8s/watchers/service_test.go
+++ b/pkg/k8s/watchers/service_test.go
@@ -4,14 +4,12 @@
 package watchers
 
 import (
-	"os"
 	"sort"
 	"testing"
 
 	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
@@ -22,16 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/time"
 )
-
-func TestMain(m *testing.M) {
-	// Reduce debouncing duration to speed up the tests.
-	option.Config.K8sServiceDebounceWaitTime = time.Millisecond
-	option.Config.K8sServiceDebounceBufferSize = 128
-
-	os.Exit(m.Run())
-}
 
 type fakeSvcManager struct {
 	OnDeleteService func(frontend loadbalancer.L3n4Addr) (bool, error)
@@ -347,27 +336,18 @@ func Test_addK8sSVCs_ClusterIP(t *testing.T) {
 	}
 
 	go svcWatcher.k8sServiceHandler()
-
 	swg := lock.NewStoppableWaitGroup()
+
 	k8sSvcCache.UpdateService(k8sSvc, swg)
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
-	swg.Stop()
-	swg.Wait()
-
-	// NOTE: Due to the service event debouncing of the service events we use a new [StoppableWaitGroup]
-	// for each group of changes we want to be processed without coalescing.
-
-	swg = lock.NewStoppableWaitGroup()
 	// Running a 2nd update should also trigger a new upsert service
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
 	// Running a 3rd update should also not trigger anything because the
 	// endpoints are the same
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
-	swg.Stop()
-	swg.Wait()
 
-	swg = lock.NewStoppableWaitGroup()
 	k8sSvcCache.DeleteService(k8sSvc, swg)
+
 	swg.Stop()
 	swg.Wait()
 	require.Equal(t, len(upsert1stWanted)+len(upsert2ndWanted), svcUpsertManagerCalls)
@@ -488,18 +468,14 @@ func TestChangeSVCPort(t *testing.T) {
 	}
 
 	go svcWatcher.k8sServiceHandler()
-
 	swg := lock.NewStoppableWaitGroup()
+
 	k8sSvcCache.UpdateService(k8sSvc, swg)
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
-	swg.Stop()
-	swg.Wait()
-
-	swg = lock.NewStoppableWaitGroup()
 	k8sSvcCache.UpdateService(k8sSvcChanged, swg)
+
 	swg.Stop()
 	swg.Wait()
-
 	require.Equal(t, 2, svcUpsertManagerCalls) // Add and Update events
 	require.EqualValues(t, upsertsWanted, upserts)
 }
@@ -957,30 +933,21 @@ func Test_addK8sSVCs_NodePort(t *testing.T) {
 
 	k8sSvcCache.UpdateService(k8sSvc, swg)
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
-
-	swg.Stop()
-	swg.Wait()
-
-	swg = lock.NewStoppableWaitGroup()
-
 	// Running a 2nd update should also trigger a new upsert service
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
 	// Running a 3rd update should also not trigger anything because the
 	// endpoints are the same
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
 
+	k8sSvcCache.DeleteService(k8sSvc, swg)
+
 	swg.Stop()
 	swg.Wait()
 	require.Equal(t, len(upsert1stWanted)+len(upsert2ndWanted), svcUpsertManagerCalls)
-	require.EqualValues(t, upsert1stWanted, upsert1st)
-	require.EqualValues(t, upsert2ndWanted, upsert2nd)
-
-	swg = lock.NewStoppableWaitGroup()
-	k8sSvcCache.DeleteService(k8sSvc, swg)
-	swg.Stop()
-	swg.Wait()
 	require.Equal(t, len(del1stWanted), svcDeleteManagerCalls)
 
+	require.EqualValues(t, upsert1stWanted, upsert1st)
+	require.EqualValues(t, upsert2ndWanted, upsert2nd)
 	require.EqualValues(t, del1stWanted, del1st)
 }
 
@@ -1257,18 +1224,15 @@ func Test_addK8sSVCs_GH9576_1(t *testing.T) {
 	}
 
 	go svcWatcher.k8sServiceHandler()
-
 	swg := lock.NewStoppableWaitGroup()
+
 	k8sSvcCache.UpdateService(k8sSvc1stApply, swg)
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
-	swg.Stop()
-	swg.Wait()
 
-	swg = lock.NewStoppableWaitGroup()
 	k8sSvcCache.UpdateService(k8sSvc2ndApply, swg)
+
 	swg.Stop()
 	swg.Wait()
-
 	require.Equal(t, wantSvcUpsertManagerCalls, svcUpsertManagerCalls)
 	require.Equal(t, wantSvcDeleteManagerCalls, svcDeleteManagerCalls)
 
@@ -1548,15 +1512,12 @@ func Test_addK8sSVCs_GH9576_2(t *testing.T) {
 	}
 
 	go svcWatcher.k8sServiceHandler()
-
 	swg := lock.NewStoppableWaitGroup()
+
 	k8sSvcCache.UpdateService(k8sSvc1stApply, swg)
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
-	swg.Stop()
-	swg.Wait()
-
-	swg = lock.NewStoppableWaitGroup()
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
+
 	swg.Stop()
 	swg.Wait()
 
@@ -2453,32 +2414,22 @@ func Test_addK8sSVCs_ExternalIPs(t *testing.T) {
 	}
 
 	go svcWatcher.k8sServiceHandler()
-
 	swg := lock.NewStoppableWaitGroup()
+
 	k8sSvcCache.UpdateService(svc1stApply, swg)
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
-	swg.Stop()
-	swg.Wait()
-
-	swg = lock.NewStoppableWaitGroup()
 	// Running a 2nd update should also trigger a new upsert service
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
 	// Running a 3rd update should also not trigger anything because the
 	// endpoints are the same
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
-	swg.Stop()
-	swg.Wait()
 
-	swg = lock.NewStoppableWaitGroup()
 	k8sSvcCache.UpdateService(svc2ndApply, swg)
-	swg.Stop()
-	swg.Wait()
 
-	swg = lock.NewStoppableWaitGroup()
 	k8sSvcCache.DeleteService(svc1stApply, swg)
+
 	swg.Stop()
 	swg.Wait()
-
 	require.Equal(t, len(upsert1stWanted)+len(upsert2ndWanted)+len(upsert3rdWanted), svcUpsertManagerCalls)
 	require.Equal(t, len(del1stWanted)+len(del2ndWanted), svcDeleteManagerCalls)
 
@@ -2588,188 +2539,16 @@ func TestHeadless(t *testing.T) {
 	}
 
 	go svcWatcher.k8sServiceHandler()
-
 	swg := lock.NewStoppableWaitGroup()
+
 	k8sSvcCache.UpdateService(k8sSvc, swg)
 	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
-	swg.Stop()
-	swg.Wait()
-
-	swg = lock.NewStoppableWaitGroup()
 	k8sSvcCache.UpdateService(k8sSvcChanged, swg)
+
 	swg.Stop()
 	swg.Wait()
-
 	require.Equal(t, len(upsertsWanted), svcUpsertManagerCalls)
 	require.Equal(t, len(delstWanted), svcDeleteManagerCalls)
 	require.EqualValues(t, upsertsWanted, upserts)
 	require.EqualValues(t, delstWanted, delst)
-}
-
-func TestServiceEventDebounce(t *testing.T) {
-	oldTime := option.Config.K8sServiceDebounceWaitTime
-	defer func() {
-		option.Config.K8sServiceDebounceWaitTime = oldTime
-	}()
-	// Use longer wait time to trigger coalescing. The asserts in this test must
-	// retry if needed and not rely on coalescing to always happen.
-	option.Config.K8sServiceDebounceWaitTime = 20 * time.Millisecond
-
-	ep := &slim_corev1.Endpoints{
-		ObjectMeta: slim_metav1.ObjectMeta{
-			Name:      "foo",
-			Namespace: "bar",
-		},
-		Subsets: []slim_corev1.EndpointSubset{
-			{
-				Addresses: []slim_corev1.EndpointAddress{{IP: "10.0.0.2"}},
-				Ports: []slim_corev1.EndpointPort{
-					{
-						Name:     "http",
-						Port:     8080,
-						Protocol: slim_corev1.ProtocolTCP,
-					},
-				},
-			},
-		},
-	}
-
-	upserts, deletes := 0, 0
-	fes := sets.New[loadbalancer.L3n4Addr]()
-	var lastDelete *loadbalancer.L3n4Addr
-
-	svcManager := &fakeSvcManager{
-		OnUpsertService: func(p *loadbalancer.SVC) (bool, loadbalancer.ID, error) {
-			upserts++
-			fes.Insert(p.Frontend.L3n4Addr)
-			return false, 0, nil
-		},
-		OnDeleteService: func(fe loadbalancer.L3n4Addr) (b bool, e error) {
-			deletes++
-			fes.Delete(fe)
-			lastDelete = &fe
-			return true, nil
-		},
-	}
-
-	db, nodeAddrs := newDB(t)
-	k8sSvcCache := k8s.NewServiceCache(db, nodeAddrs, k8s.NewSVCMetricsNoop())
-	svcWatcher := &K8sServiceWatcher{
-		k8sSvcCache: k8sSvcCache,
-		svcManager:  svcManager,
-	}
-
-	go svcWatcher.k8sServiceHandler()
-
-	k8sSvc := &slim_corev1.Service{
-		ObjectMeta: slim_metav1.ObjectMeta{
-			Name:      "foo",
-			Namespace: "bar",
-			Labels: map[string]string{
-				"foo": "bar",
-			},
-		},
-		Spec: slim_corev1.ServiceSpec{
-			ClusterIP:  "127.0.0.1",
-			ClusterIPs: []string{"127.0.0.1"},
-			Type:       slim_corev1.ServiceTypeClusterIP,
-			Ports: []slim_corev1.ServicePort{
-				{
-					Name:     "http",
-					Protocol: slim_corev1.ProtocolTCP,
-					Port:     80,
-				},
-			},
-		},
-	}
-	setClusterIP := func(ip string) {
-		k8sSvc.Spec.ClusterIP = ip
-		k8sSvc.Spec.ClusterIPs = []string{ip}
-	}
-
-	// Test that coalescing will mark multiple SWGs as done.
-	swg1, swg2, swg3 := lock.NewStoppableWaitGroup(),
-		lock.NewStoppableWaitGroup(),
-		lock.NewStoppableWaitGroup()
-
-	k8sSvcCache.UpdateService(k8sSvc, swg1)
-	k8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep), swg1)
-
-	swg1.Stop()
-	swg1.Wait()
-
-	setClusterIP("127.0.0.2")
-	k8sSvcCache.UpdateService(k8sSvc, swg2)
-	setClusterIP("127.0.0.3")
-	k8sSvcCache.UpdateService(k8sSvc, swg3)
-	k8sSvcCache.DeleteService(k8sSvc, swg3)
-	setClusterIP("127.0.0.4")
-	k8sSvcCache.UpdateService(k8sSvc, swg3)
-	k8sSvcCache.DeleteService(k8sSvc, swg3)
-
-	// All SWGs should be marked done even when they're collapsed.
-	for _, swg := range []*lock.StoppableWaitGroup{swg2, swg3} {
-		swg.Stop()
-		swg.Wait()
-	}
-
-	require.NotZero(t, upserts, "upserts")
-	require.NotZero(t, deletes, "deletes")
-	require.Empty(t, fes)
-
-	// Test coalescing of update and deletes within single buffer. Since
-	// this requires the coalescing to really happen, we try this multiple
-	// times to make this non-flaky. Looking forward to the testing/synctest
-	// package when we don't need this sort of thing anymore.
-	for range 20 {
-		upserts, deletes = 0, 0
-		swg := lock.NewStoppableWaitGroup()
-		k8sSvcCache.UpdateService(k8sSvc, swg)
-		k8sSvcCache.DeleteService(k8sSvc, swg)
-		swg.Stop()
-		swg.Wait()
-		if upserts == 0 && deletes == 0 {
-			break
-		}
-	}
-	// The update and delete cancelled each other out.
-	require.Zero(t, upserts, "upserts")
-	require.Zero(t, deletes, "deletes")
-	require.Empty(t, fes)
-
-	// Test that multiple updates followed by a delete will be coalesced into
-	// a single delete of the original service.
-	for range 20 {
-		// Start with a service with IP 127.0.0.5
-		swg := lock.NewStoppableWaitGroup()
-		setClusterIP("127.0.0.5")
-		k8sSvcCache.UpdateService(k8sSvc, swg)
-		swg.Stop()
-		swg.Wait()
-
-		// Update the service multiple times and finally delete it.
-		// These should get coalesced into a single delete.
-		upserts, deletes = 0, 0
-		swg = lock.NewStoppableWaitGroup()
-		k8sSvcCache.UpdateService(k8sSvc, swg)
-		setClusterIP("127.0.0.6")
-		k8sSvcCache.UpdateService(k8sSvc, swg)
-		setClusterIP("127.0.0.7")
-		k8sSvcCache.UpdateService(k8sSvc, swg)
-		setClusterIP("127.0.0.8")
-		k8sSvcCache.UpdateService(k8sSvc, swg)
-		k8sSvcCache.DeleteService(k8sSvc, swg)
-		swg.Stop()
-		swg.Wait()
-
-		if lastDelete != nil && lastDelete.AddrCluster.String() == "127.0.0.5" {
-			break
-		}
-	}
-	require.Zero(t, upserts, "upserts")
-	require.Equal(t, 1, deletes, "deletes")
-	require.Empty(t, fes)
-	require.NotNil(t, lastDelete)
-	require.Equal(t, "127.0.0.5", lastDelete.AddrCluster.String())
-
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -211,13 +211,6 @@ const (
 	// K8sServiceCacheSize is service cache size for cilium k8s package.
 	K8sServiceCacheSize = "k8s-service-cache-size"
 
-	// K8sServiceDebounceBufferSize is the maximum number of service events to buffer.
-	K8sServiceDebounceBufferSize = "k8s-service-debounce-buffer-size"
-
-	// K8sServiceDebounceBufferWaitTime is the amount of time to wait before emitting
-	// the service event buffer.
-	K8sServiceDebounceWaitTime = "k8s-service-debounce-wait-time"
-
 	// K8sSyncTimeout is the timeout since last event was received to synchronize all resources with k8s.
 	K8sSyncTimeoutName = "k8s-sync-timeout"
 
@@ -1498,13 +1491,6 @@ type DaemonConfig struct {
 
 	// K8sServiceCacheSize is the service cache size for cilium k8s package.
 	K8sServiceCacheSize uint
-
-	// Number of distinct services to buffer at most.
-	K8sServiceDebounceBufferSize int
-
-	// The amount of time to wait to debounce service events before
-	// emitting the buffer.
-	K8sServiceDebounceWaitTime time.Duration
 
 	// MTU is the maximum transmission unit of the underlying network
 	MTU int
@@ -3081,8 +3067,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.K8sRequireIPv4PodCIDR = vp.GetBool(K8sRequireIPv4PodCIDRName)
 	c.K8sRequireIPv6PodCIDR = vp.GetBool(K8sRequireIPv6PodCIDRName)
 	c.K8sServiceCacheSize = uint(vp.GetInt(K8sServiceCacheSize))
-	c.K8sServiceDebounceBufferSize = vp.GetInt(K8sServiceDebounceBufferSize)
-	c.K8sServiceDebounceWaitTime = vp.GetDuration(K8sServiceDebounceWaitTime)
 	c.K8sSyncTimeout = vp.GetDuration(K8sSyncTimeoutName)
 	c.AllocatorListTimeout = vp.GetDuration(AllocatorListTimeoutName)
 	c.K8sWatcherEndpointSelector = vp.GetString(K8sWatcherEndpointSelector)


### PR DESCRIPTION
This reverts the following commits:

commit dedde5d6dea390f96d0ef2ef3f4de143837f4dde ("k8s: Debounce service events") 
commit 10d3eb523c1a8181ce3a9079539ae4446d9b9681 ("k8s: Use Old{Service,Endpoints} in delete events")