### PR TITLE
test: Move demo-httpd from Docker to Quay

### DIFF
--- a/examples/kubernetes-external-ips/demo.yaml
+++ b/examples/kubernetes-external-ips/demo.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: docker.io/cilium/demo-httpd:latest
+          image: quay.io/cilium/demo-httpd:1.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80

--- a/test/helpers/constants/images.go
+++ b/test/helpers/constants/images.go
@@ -10,7 +10,7 @@ const (
 	NetperfImage = "quay.io/cilium/net-test:v1.0.0"
 
 	// HttpdImage is the image used for starting an HTTP server.
-	HttpdImage = "docker.io/cilium/demo-httpd:1.0"
+	HttpdImage = "quay.io/cilium/demo-httpd:1.0"
 
 	// DNSSECContainerImage is the image used for starting a DNSSec client.
 	DNSSECContainerImage = "docker.io/cilium/dnssec-client:v0.2"

--- a/test/k8s/manifests/demo-named-port.yaml
+++ b/test/k8s/manifests/demo-named-port.yaml
@@ -43,7 +43,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: web
-        image: docker.io/cilium/demo-httpd:1.0
+        image: quay.io/cilium/demo-httpd:1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/test/k8s/manifests/demo.yaml
+++ b/test/k8s/manifests/demo.yaml
@@ -43,7 +43,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
       - name: web
-        image: docker.io/cilium/demo-httpd:1.0
+        image: quay.io/cilium/demo-httpd:1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80


### PR DESCRIPTION
Problems managing DockerHub credentials are widely documented especially
when using GitHub infrastructure for testing. Avoid ratelimit issues by
switching to Quay.io.

Fixes: https://github.com/cilium/cilium/issues/37148
