### PR TITLE
.github: Set --interactive=false for cilium status

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -275,7 +275,7 @@ jobs:
 
       - name: Wait for Cilium status to be ready
         run: |
-          cilium status --wait --wait-duration=10m
+          cilium status --wait --interactive=false --wait-duration=10m
 
       - name: Make JUnit report directory
         run: |
@@ -313,7 +313,7 @@ jobs:
 
       - name: Wait for Cilium status to be ready
         run: |
-          cilium status --wait --wait-duration=10m
+          cilium status --wait --interactive=false --wait-duration=10m
 
       - name: Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})
         run: |

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -303,7 +303,7 @@ jobs:
 
       - name: Wait for Cilium to be ready
         run: |
-          cilium status --wait --wait-duration=10m
+          cilium status --wait --interactive=false --wait-duration=10m
           kubectl get pods -n kube-system
 
       - name: Check that AWS iptables chains have not been removed

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -304,7 +304,7 @@ jobs:
 
       - name: Wait for Cilium to be ready
         run: |
-          cilium status --wait --wait-duration=10m
+          cilium status --wait --interactive=false --wait-duration=10m
           kubectl get pods -n kube-system
 
       - name: Check that AWS leftover iptables chains have been removed

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -317,7 +317,7 @@ jobs:
 
       - name: Wait for Cilium to be ready
         run: |
-          cilium status --wait --wait-duration=10m
+          cilium status --wait --interactive=false --wait-duration=10m
           kubectl get pods -n kube-system
 
       - name: Make JUnit report directory

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -128,7 +128,7 @@ jobs:
             --set=tls.secretSync.enabled=false
 
           kubectl -n kube-system rollout restart ds/cilium deployment/cilium-operator
-          cilium status --wait --wait-duration=10m
+          cilium status --wait --interactive=false --wait-duration=10m
           kubectl -n kube-system get pods
 
       - name: Run L7 related connectivity test

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -264,7 +264,7 @@ jobs:
 
       - name: Wait for Cilium to be ready
         run: |
-          cilium status --wait --wait-duration=10m
+          cilium status --wait --interactive=false --wait-duration=10m
           kubectl get pods -n kube-system
           kubectl -n kube-system exec daemonset/cilium -- cilium-dbg status
 

--- a/.github/workflows/scale-test-clustermesh.yaml
+++ b/.github/workflows/scale-test-clustermesh.yaml
@@ -344,7 +344,7 @@ jobs:
             --values values-clustermesh-config.yaml
 
           cilium status --wait
-          cilium clustermesh status --wait --wait-duration=5m
+          cilium clustermesh status --wait --interactive=false --wait-duration=5m
 
       - name: Run CL2
         id: run-cl2

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -428,8 +428,8 @@ jobs:
 
       - name: Wait for cluster mesh status to be ready
         run: |
-          cilium --context ${{ env.contextName1 }} status --wait --wait-duration=10m
-          cilium --context ${{ env.contextName2 }} status --wait --wait-duration=10m
+          cilium --context ${{ env.contextName1 }} status --wait --interactive=false --wait-duration=10m
+          cilium --context ${{ env.contextName2 }} status --wait --interactive=false --wait-duration=10m
           cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
           cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
 
@@ -481,8 +481,8 @@ jobs:
 
       - name: Wait for cluster mesh status to be ready
         run: |
-          cilium --context ${{ env.contextName1 }} status --wait --wait-duration=10m
-          cilium --context ${{ env.contextName2 }} status --wait --wait-duration=10m
+          cilium --context ${{ env.contextName1 }} status --wait --interactive=false --wait-duration=10m
+          cilium --context ${{ env.contextName2 }} status --wait --interactive=false --wait-duration=10m
           cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
           cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
 
@@ -554,8 +554,8 @@ jobs:
       - name: Wait for cluster mesh status to be ready
         if: ${{ !matrix.external-kvstore }}
         run: |
-          cilium --context ${{ env.contextName1 }} status --wait --wait-duration=10m
-          cilium --context ${{ env.contextName2 }} status --wait --wait-duration=10m
+          cilium --context ${{ env.contextName1 }} status --wait --interactive=false --wait-duration=10m
+          cilium --context ${{ env.contextName2 }} status --wait --interactive=false --wait-duration=10m
           cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
           cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
 
@@ -649,8 +649,8 @@ jobs:
 
       - name: Wait for cluster mesh status to be ready
         run: |
-          cilium --context ${{ env.contextName1 }} status --wait --wait-duration=10m
-          cilium --context ${{ env.contextName2 }} status --wait --wait-duration=10m
+          cilium --context ${{ env.contextName1 }} status --wait --interactive=false --wait-duration=10m
+          cilium --context ${{ env.contextName2 }} status --wait --interactive=false --wait-duration=10m
           cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
           cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
 
@@ -712,8 +712,8 @@ jobs:
 
       - name: Wait for cluster mesh status to be ready
         run: |
-          cilium --context ${{ env.contextName1 }} status --wait --wait-duration=10m
-          cilium --context ${{ env.contextName2 }} status --wait --wait-duration=10m
+          cilium --context ${{ env.contextName1 }} status --wait --interactive=false --wait-duration=10m
+          cilium --context ${{ env.contextName2 }} status --wait --interactive=false --wait-duration=10m
           cilium --context ${{ env.contextName1 }} clustermesh status --wait --wait-duration=5m
           cilium --context ${{ env.contextName2 }} clustermesh status --wait --wait-duration=5m
 

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -689,7 +689,7 @@ jobs:
             ${{ steps.cilium-newest-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}
 
-          cilium status --wait --wait-duration=10m
+          cilium status --wait --interactive=false --wait-duration=10m
           kubectl get pods --all-namespaces -o wide
           kubectl -n kube-system exec daemonset/cilium -- cilium status
 
@@ -764,7 +764,7 @@ jobs:
             ${{ steps.cilium-stable-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}
 
-          cilium status --wait --wait-duration=10m
+          cilium status --wait --interactive=false --wait-duration=10m
           kubectl get pods --all-namespaces -o wide
           kubectl -n kube-system exec daemonset/cilium -- cilium status
 

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -337,7 +337,7 @@ jobs:
             ${{ steps.cilium-stable-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}
 
-          cilium status --wait --wait-duration=10m
+          cilium status --wait --interactive=false --wait-duration=10m
           kubectl get pods --all-namespaces -o wide
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 
@@ -371,7 +371,7 @@ jobs:
             ${{ steps.cilium-newest-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}
 
-          cilium status --wait --wait-duration=10m
+          cilium status --wait --interactive=false --wait-duration=10m
           kubectl get pods --all-namespaces -o wide
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 
@@ -427,7 +427,7 @@ jobs:
             ${{ steps.cilium-stable-config.outputs.config }} \
             ${{ steps.kvstore.outputs.config }}
 
-          cilium status --wait --wait-duration=10m
+          cilium status --wait --interactive=false --wait-duration=10m
           kubectl get pods --all-namespaces -o wide
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 


### PR DESCRIPTION
CI is a non-interactive forum for invoking cilium wait commands, so pass
the interactive=false flag. This helps by reducing the amount of
unnecessary repetition in status output in CI jobs, thereby improving
the signal to noise ratio when trying to debug a CI failure.

The side-effect of this is that there is no terminal output until either
success or timeout. We can likely further tune the timeouts to more
quickly highlight scenarios where Cilium is clearly not getting ready
fast enough, but that's a subject for a future commit.
