### PR TITLE
[v1.16] envoy: Bump envoy version to v1.31.x

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1215,7 +1215,7 @@
    * - :spelling:ignore:`envoy.image`
      - Envoy container image.
      - object
-     - ``{"digest":"sha256:a69dfe0e54b24b0ff747385c8feeae0612cfbcae97bfcc8ee42a773bb3f69c88","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5","useDigest":true}``
+     - ``{"digest":"sha256:c0e3dace196ec1eb9aa92423998c35fc9789328383b16f052bfb9e58ab116bf9","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.31.5-1737469659-9905ed1230bcdd57b2522c4b7b76373c80f54bcb","useDigest":true}``
    * - :spelling:ignore:`envoy.initialFetchTimeoutSeconds`
      - Time in seconds after which the initial fetch on an xDS stream is considered timed out
      - int

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:5877b512320f80ef65b4973d8
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-ARG CILIUM_ENVOY_IMAGE=quay.io/cilium/cilium-envoy:v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5@sha256:a69dfe0e54b24b0ff747385c8feeae0612cfbcae97bfcc8ee42a773bb3f69c88
+ARG CILIUM_ENVOY_IMAGE=quay.io/cilium/cilium-envoy:v1.31.5-1737469659-9905ed1230bcdd57b2522c4b7b76373c80f54bcb@sha256:c0e3dace196ec1eb9aa92423998c35fc9789328383b16f052bfb9e58ab116bf9
 
 FROM ${CILIUM_ENVOY_IMAGE} AS cilium-envoy
 

--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -38,8 +38,8 @@ export CILIUM_NODEINIT_DIGEST:=sha256:8d7b41c4ca45860254b3c19e20210462ef89479bb6
 
 # renovate: datasource=docker
 export CILIUM_ENVOY_REPO:=quay.io/cilium/cilium-envoy
-export CILIUM_ENVOY_VERSION:=v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5
-export CILIUM_ENVOY_DIGEST:=sha256:a69dfe0e54b24b0ff747385c8feeae0612cfbcae97bfcc8ee42a773bb3f69c88
+export CILIUM_ENVOY_VERSION:=v1.31.5-1737469659-9905ed1230bcdd57b2522c4b7b76373c80f54bcb
+export CILIUM_ENVOY_DIGEST:=sha256:c0e3dace196ec1eb9aa92423998c35fc9789328383b16f052bfb9e58ab116bf9
 
 # renovate: datasource=docker
 export HUBBLE_UI_BACKEND_REPO:=quay.io/cilium/hubble-ui-backend

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -353,7 +353,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:a69dfe0e54b24b0ff747385c8feeae0612cfbcae97bfcc8ee42a773bb3f69c88","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:c0e3dace196ec1eb9aa92423998c35fc9789328383b16f052bfb9e58ab116bf9","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.31.5-1737469659-9905ed1230bcdd57b2522c4b7b76373c80f54bcb","useDigest":true}` | Envoy container image. |
 | envoy.initialFetchTimeoutSeconds | int | `30` | Time in seconds after which the initial fetch on an xDS stream is considered timed out |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2169,9 +2169,9 @@ envoy:
     # @schema
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5"
+    tag: "v1.31.5-1737469659-9905ed1230bcdd57b2522c4b7b76373c80f54bcb"
     pullPolicy: "IfNotPresent"
-    digest: "sha256:a69dfe0e54b24b0ff747385c8feeae0612cfbcae97bfcc8ee42a773bb3f69c88"
+    digest: "sha256:c0e3dace196ec1eb9aa92423998c35fc9789328383b16f052bfb9e58ab116bf9"
     useDigest: true
   # -- Additional containers added to the cilium Envoy DaemonSet.
   extraContainers: []


### PR DESCRIPTION
This is as part of regular maintenance as Envoy v1.30 will be EOL in 3 months.

https://github.com/envoyproxy/envoy/blob/main/RELEASES.md#major-release-schedule
