### PR TITLE
test/fuzzing: Fix fuzzing test failure

### DIFF
--- a/.github/workflows/tests-cifuzz.yaml
+++ b/.github/workflows/tests-cifuzz.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - '.github/workflows/tests-cifuzz.yaml'
       - '**/fuzz_test.go'
+      - 'test/fuzzing/*'
 permissions: read-all
 jobs:
   Fuzzing:

--- a/test/fuzzing/oss-fuzz-build.sh
+++ b/test/fuzzing/oss-fuzz-build.sh
@@ -13,8 +13,13 @@ set -eu
 printf "package policy\nimport _ \"github.com/AdamKorcz/go-118-fuzz-build/testing\"\n" > $SRC/cilium/pkg/policy/registerfuzzdep.go
 
 go mod tidy && go mod vendor
+mv $SRC/cilium/pkg/policy/distillery_test.go $SRC/cilium/pkg/policy/distillery_test_fuzz.go
 mv $SRC/cilium/pkg/policy/l4_filter_test.go $SRC/cilium/pkg/policy/l4_filter_test_fuzz.go
 mv $SRC/cilium/pkg/policy/policy_test.go $SRC/cilium/pkg/policy/policy_test_fuzz.go
+mv $SRC/cilium/pkg/policy/mapstate_test.go $SRC/cilium/pkg/policy/mapstate_test_fuzz.go
+mv $SRC/cilium/pkg/policy/repository_test.go $SRC/cilium/pkg/policy/repository_test_fuzz.go
+mv $SRC/cilium/pkg/policy/resolve_test.go $SRC/cilium/pkg/policy/resolve_test_fuzz.go
+mv $SRC/cilium/pkg/policy/resolve_deny_test.go $SRC/cilium/pkg/policy/resolve_deny_test_fuzz.go
 mv $SRC/cilium/pkg/policy/rule_test.go $SRC/cilium/pkg/policy/rule_test_fuzz.go
 mv $SRC/cilium/pkg/policy/selectorcache_test.go $SRC/cilium/pkg/policy/selectorcache_test_fuzz.go
 


### PR DESCRIPTION
```
pkg/policy/rule_test_fuzz.go:57:10: td.repo.mustAdd undefined (type *Repository has no field or method mustAdd)
```

Fix by including the path with the policy repository `mustAdd()`
function in the fuzzing script, so that it's in scope when the fuzzer is
run.

Ref: https://github.com/cilium/cilium/actions/runs/12862705459/workflow
Fixes: d036ef2021 ("pkg/policy: convert rule_test.go to use Lookup")

Signed-off-by: Chris Tarazi <chris@isovalent.com>
