### PR TITLE
cli: Improve fetching of Cilium component logs in failure scenarios

### DIFF
--- a/cilium-cli/cli/status.go
+++ b/cilium-cli/cli/status.go
@@ -68,6 +68,7 @@ func newCmdStatus() *cobra.Command {
 		"The number of workers to use")
 	cmd.Flags().StringVarP(&params.Output, "output", "o", status.OutputSummary, "Output format. One of: json, summary")
 	cmd.Flags().BoolVar(&params.Interactive, "interactive", true, "Refresh the status summary output after each retry when --wait flag is specified")
+	cmd.Flags().BoolVar(&params.Verbose, "verbose", false, "Print more verbose error / log messages")
 
 	return cmd
 }

--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -80,7 +80,7 @@ type k8sClusterMeshImplementation interface {
 	CreateCiliumExternalWorkload(ctx context.Context, cew *ciliumv2.CiliumExternalWorkload, opts metav1.CreateOptions) (*ciliumv2.CiliumExternalWorkload, error)
 	DeleteCiliumExternalWorkload(ctx context.Context, name string, opts metav1.DeleteOptions) error
 	ListCiliumEndpoints(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error)
-	CiliumLogs(ctx context.Context, namespace, pod string, since time.Time, previous bool) (string, error)
+	CiliumLogs(ctx context.Context, namespace, pod, containerName string, since time.Time, previous bool) (string, error)
 }
 
 type K8sClusterMesh struct {

--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -80,7 +80,7 @@ type k8sClusterMeshImplementation interface {
 	CreateCiliumExternalWorkload(ctx context.Context, cew *ciliumv2.CiliumExternalWorkload, opts metav1.CreateOptions) (*ciliumv2.CiliumExternalWorkload, error)
 	DeleteCiliumExternalWorkload(ctx context.Context, name string, opts metav1.DeleteOptions) error
 	ListCiliumEndpoints(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error)
-	CiliumLogs(ctx context.Context, namespace, pod, containerName string, since time.Time, previous bool) (string, error)
+	ContainerLogs(ctx context.Context, namespace, pod, containerName string, since time.Time, previous bool) (string, error)
 }
 
 type K8sClusterMesh struct {

--- a/cilium-cli/connectivity/check/policy.go
+++ b/cilium-cli/connectivity/check/policy.go
@@ -374,7 +374,7 @@ func (t *Test) deleteResources(ctx context.Context) error {
 // filter is applied on each line of output.
 func (t *Test) CiliumLogs(ctx context.Context) {
 	for _, pod := range t.Context().ciliumPods {
-		log, err := pod.K8sClient.CiliumLogs(ctx, pod.Pod.Namespace, pod.Pod.Name, t.startTime, false)
+		log, err := pod.K8sClient.CiliumLogs(ctx, pod.Pod.Namespace, pod.Pod.Name, defaults.AgentContainerName, t.startTime, false)
 		if err != nil {
 			t.Fatalf("Error reading Cilium logs: %s", err)
 		}

--- a/cilium-cli/connectivity/check/policy.go
+++ b/cilium-cli/connectivity/check/policy.go
@@ -294,7 +294,7 @@ func (t *Test) applyResources(ctx context.Context) error {
 	// performed if the user cancels during the policy revision wait time.
 	t.finalizers = append(t.finalizers, func(ctx context.Context) error {
 		if err := t.deleteResources(ctx); err != nil {
-			t.CiliumLogs(ctx)
+			t.ContainerLogs(ctx)
 			return err
 		}
 
@@ -370,11 +370,11 @@ func (t *Test) deleteResources(ctx context.Context) error {
 	return nil
 }
 
-// CiliumLogs dumps the logs of all Cilium agents since the start of the Test.
+// ContainerLogs dumps the logs of all Cilium agents since the start of the Test.
 // filter is applied on each line of output.
-func (t *Test) CiliumLogs(ctx context.Context) {
+func (t *Test) ContainerLogs(ctx context.Context) {
 	for _, pod := range t.Context().ciliumPods {
-		log, err := pod.K8sClient.CiliumLogs(ctx, pod.Pod.Namespace, pod.Pod.Name, defaults.AgentContainerName, t.startTime, false)
+		log, err := pod.K8sClient.ContainerLogs(ctx, pod.Pod.Namespace, pod.Pod.Name, defaults.AgentContainerName, t.startTime, false)
 		if err != nil {
 			t.Fatalf("Error reading Cilium logs: %s", err)
 		}

--- a/cilium-cli/connectivity/check/secrets.go
+++ b/cilium-cli/connectivity/check/secrets.go
@@ -56,7 +56,7 @@ func (t *Test) applySecrets(ctx context.Context) error {
 	// Register a finalizer with the Test immediately to enable cleanup.
 	t.finalizers = append(t.finalizers, func(ctx context.Context) error {
 		if err := t.deleteSecrets(ctx); err != nil {
-			t.CiliumLogs(ctx)
+			t.ContainerLogs(ctx)
 			return err
 		}
 

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -199,13 +199,13 @@ func (t *Test) setup(ctx context.Context) error {
 
 	// Apply Secrets to the cluster.
 	if err := t.applySecrets(ctx); err != nil {
-		t.CiliumLogs(ctx)
+		t.ContainerLogs(ctx)
 		return fmt.Errorf("applying Secrets: %w", err)
 	}
 
 	// Apply CNPs & KNPs to the cluster.
 	if err := t.applyResources(ctx); err != nil {
-		t.CiliumLogs(ctx)
+		t.ContainerLogs(ctx)
 		return fmt.Errorf("applying network policies: %w", err)
 	}
 

--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -32,6 +32,7 @@ const (
 	RelayContainerName  = "hubble-relay"
 	RelayDeploymentName = "hubble-relay"
 	RelayConfigMapName  = "hubble-relay-config"
+	RelayPodSelector    = "app.kubernetes.io/name=hubble-relay"
 
 	HubbleUIDeploymentName = "hubble-ui"
 

--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -323,7 +323,7 @@ func (c *Client) PodLogs(namespace, name string, opts *corev1.PodLogOptions) *re
 	return c.Clientset.CoreV1().Pods(namespace).GetLogs(name, opts)
 }
 
-func (c *Client) CiliumLogs(ctx context.Context, namespace, pod, containerName string, since time.Time, previous bool) (string, error) {
+func (c *Client) ContainerLogs(ctx context.Context, namespace, pod, containerName string, since time.Time, previous bool) (string, error) {
 	opts := &corev1.PodLogOptions{
 		Container:  containerName,
 		Timestamps: true,

--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -323,9 +323,9 @@ func (c *Client) PodLogs(namespace, name string, opts *corev1.PodLogOptions) *re
 	return c.Clientset.CoreV1().Pods(namespace).GetLogs(name, opts)
 }
 
-func (c *Client) CiliumLogs(ctx context.Context, namespace, pod string, since time.Time, previous bool) (string, error) {
+func (c *Client) CiliumLogs(ctx context.Context, namespace, pod, containerName string, since time.Time, previous bool) (string, error) {
 	opts := &corev1.PodLogOptions{
-		Container:  defaults.AgentContainerName,
+		Container:  containerName,
 		Timestamps: true,
 		SinceTime:  &metav1.Time{Time: since},
 		Previous:   previous,

--- a/cilium-cli/status/k8s.go
+++ b/cilium-cli/status/k8s.go
@@ -80,7 +80,7 @@ type k8sImplementation interface {
 	GetDeployment(ctx context.Context, namespace, name string, options metav1.GetOptions) (*appsv1.Deployment, error)
 	ListPods(ctx context.Context, namespace string, options metav1.ListOptions) (*corev1.PodList, error)
 	ListCiliumEndpoints(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error)
-	CiliumLogs(ctx context.Context, namespace, pod, container string, since time.Time, previous bool) (string, error)
+	ContainerLogs(ctx context.Context, namespace, pod, container string, since time.Time, previous bool) (string, error)
 }
 
 func NewK8sStatusCollector(client k8sImplementation, params K8sStatusParameters) (*K8sStatusCollector, error) {
@@ -447,7 +447,7 @@ func (k *K8sStatusCollector) logComponentTask(status *Status, namespace, deploym
 						if containerStatus.RestartCount > 0 {
 							getPrevious = true
 						}
-						logs, errLogCollection := k.client.CiliumLogs(ctx, namespace, podName, containerName, terminated.FinishedAt.Time.Add(-2*time.Minute), getPrevious)
+						logs, errLogCollection := k.client.ContainerLogs(ctx, namespace, podName, containerName, terminated.FinishedAt.Time.Add(-2*time.Minute), getPrevious)
 						if errLogCollection != nil {
 							status.CollectionError(fmt.Errorf("failed to gather logs from %s:%s:%s: %w", namespace, podName, containerName, err))
 						} else if logs != "" {

--- a/cilium-cli/status/k8s.go
+++ b/cilium-cli/status/k8s.go
@@ -660,18 +660,17 @@ func (k *K8sStatusCollector) status(ctx context.Context, cancel context.CancelFu
 								dyingGasp := ""
 								if terminated.Message != "" {
 									lastLog = strings.TrimSpace(terminated.Message)
-								} else {
-									agentLogsOnce.Do(func() { // in a sync.Once so we don't waste time retrieving lots of logs
-										var getPrevious bool
-										if containerStatus.RestartCount > 0 {
-											getPrevious = true
-										}
-										logs, err := k.client.CiliumLogs(ctx, pod.Namespace, pod.Name, terminated.FinishedAt.Time.Add(-2*time.Minute), getPrevious)
-										if err == nil && logs != "" {
-											dyingGasp = strings.TrimSpace(logs)
-										}
-									})
 								}
+								agentLogsOnce.Do(func() { // in a sync.Once so we don't waste time retrieving lots of logs
+									var getPrevious bool
+									if containerStatus.RestartCount > 0 {
+										getPrevious = true
+									}
+									logs, err := k.client.CiliumLogs(ctx, pod.Namespace, pod.Name, terminated.FinishedAt.Time.Add(-2*time.Minute), getPrevious)
+									if err == nil && logs != "" {
+										dyingGasp = strings.TrimSpace(logs)
+									}
+								})
 
 								// output the last few log lines if available
 								if dyingGasp != "" {

--- a/cilium-cli/status/k8s.go
+++ b/cilium-cli/status/k8s.go
@@ -805,6 +805,23 @@ func (k *K8sStatusCollector) status(ctx context.Context, cancel context.CancelFu
 		status.CollectionError(err)
 	}
 
+	err = k.podStatus(ctx, status, defaults.RelayDeploymentName, defaults.RelayPodSelector, func(_ context.Context, status *Status, name string, pod *corev1.Pod) {
+		if pod.Status.Phase == corev1.PodRunning {
+			// extract container status
+			var containerStatus *corev1.ContainerStatus
+			for i, cStatus := range pod.Status.ContainerStatuses {
+				if cStatus.Name == defaults.RelayContainerName {
+					containerStatus = &pod.Status.ContainerStatuses[i]
+					break
+				}
+			}
+			tasks = append(tasks, k.logComponentTask(status, pod.Namespace, defaults.RelayDeploymentName, pod.Name, defaults.RelayContainerName, containerStatus))
+		}
+	})
+	if err != nil {
+		status.CollectionError(err)
+	}
+
 	wc := k.params.WorkerCount
 	if wc < 1 {
 		wc = DefaultWorkerCount

--- a/cilium-cli/status/k8s_test.go
+++ b/cilium-cli/status/k8s_test.go
@@ -140,7 +140,7 @@ func (c *k8sStatusMockClient) ListCiliumEndpoints(_ context.Context, _ string, o
 	return c.ciliumEndpointList[options.LabelSelector], nil
 }
 
-func (c *k8sStatusMockClient) CiliumLogs(_ context.Context, _, _, _ string, _ time.Time, _ bool) (string, error) {
+func (c *k8sStatusMockClient) ContainerLogs(_ context.Context, _, _, _ string, _ time.Time, _ bool) (string, error) {
 	return "[error] a sample cilium-agent error message", nil
 }
 

--- a/cilium-cli/status/k8s_test.go
+++ b/cilium-cli/status/k8s_test.go
@@ -140,7 +140,7 @@ func (c *k8sStatusMockClient) ListCiliumEndpoints(_ context.Context, _ string, o
 	return c.ciliumEndpointList[options.LabelSelector], nil
 }
 
-func (c *k8sStatusMockClient) CiliumLogs(_ context.Context, _, _ string, _ time.Time, _ bool) (string, error) {
+func (c *k8sStatusMockClient) CiliumLogs(_ context.Context, _, _, _ string, _ time.Time, _ bool) (string, error) {
 	return "[error] a sample cilium-agent error message", nil
 }
 


### PR DESCRIPTION
Previously, the Cilium CLI would print the first 50 messages printed
up to 2 minutes before the last termination of the Cilium agent, in
order to provide some context about why a failure may have occurred.

This PR comes up with a slightly different strategy: Let's say that
the 5 oldest lines, 5 newest lines and any errors/warnings within that
2 minute window are the most important. Make sure to print those. Omit
all other logs to minimize noise to the user (but print a hint that some
logs are missing, `<...>`).

Furthermore this extends the log gathering capabilities to not only
gather logs from the cilium-agent when it encounters errors, but also
from other components like cilium-operator, hubble-relay and
clustermesh-apiserver.

Some sample output when I simulated a bunch of errors in the cilium-agent,
operator and hubble-relay components:

```
$ ./cilium-cli/cilium status --wait-duration=1s --wait --interactive=false          
    /¯¯\
 /¯¯\__/¯¯\    Cilium:             4 errors
 \__/¯¯\__/    Operator:           2 errors
 /¯¯\__/¯¯\    Envoy DaemonSet:    OK
 \__/¯¯\__/    Hubble Relay:       2 errors
    \__/       ClusterMesh:        disabled

DaemonSet              cilium             Desired: 2, Unavailable: 2/2
DaemonSet              cilium-envoy       Desired: 2, Ready: 2/2, Available: 2/2
Deployment             cilium-operator    Desired: 1, Unavailable: 1/1
Deployment             hubble-relay       Desired: 1, Unavailable: 1/1
Containers:            cilium             Running: 2
                       cilium-envoy       Running: 2
                       cilium-operator    Running: 1
                       hubble-relay       Running: 1
Cluster Pods:          0/4 managed by Cilium
Helm chart version:    1.18.0-dev
Image versions         cilium             quay.io/cilium/cilium-ci:latest: 2
                       cilium-envoy       quay.io/cilium/cilium-envoy:v1.32.3-1737449866-585ba14700a2c729f024d9f0b2c694bc83a908a2@sha256:a3bbf5d8acc652f91e83c59890c61da5ee84c552be331fe9ad5389ad1a299562: 2
                       cilium-operator    quay.io/cilium/operator-generic-ci:latest: 1
                       hubble-relay       quay.io/cilium/hubble-relay-ci@sha256:063c07e2b465988fb25210f7ea94ed0dc1b2d1d529a4bd5a3f108a4e32634388: 1
Errors:                cilium             cilium          2 pods of DaemonSet cilium are not ready
                       cilium             cilium-dth9h    unable to retrieve cilium status: container cilium-agent is in CrashLoopBackOff, exited with code 1: ermesh.nodeManagerNotifier (pkg/clustermesh/notifier.go:38)"
time=2025-01-24T00:43:02Z level=debug msg=Invoked duration=6.86µs function="clustermesh.nodeManagerNotifier (pkg/clustermesh/notifier.go:38)"
time=2025-01-24T00:43:02Z level=debug msg=Invoking function="stats.init.func3 (.../nat/stats/cell.go:61)"
time=2025-01-24T00:43:02Z level=debug msg=Invoked duration=551.756µs function="stats.init.func3 (.../nat/stats/cell.go:61)"
time=2025-01-24T00:43:02Z level=debug msg=Invoking function="dynamicconfig.RegisterConfigMapReflector (pkg/dynamicconfig/table.go:90)"
time=2025-01-24T00:43:02Z level=debug msg=Invoked duration=487.35µs function="dynamicconfig.RegisterConfigMapReflector (pkg/dynamicconfig/table.go:90)"
time=2025-01-24T00:43:02Z level=debug msg=Invoking function="dynamiclifecycle.registerWatcher (pkg/dynamiclifecycle/watcher.go:125)"
time=2025-01-24T00:43:02Z level=debug msg=Invoked duration=492.1µs function="dynamiclifecycle.registerWatcher (pkg/dynamiclifecycle/watcher.go:125)"
time=2025-01-24T00:43:02Z level=debug msg=Invoking function="dynamiclifecycle.registerReconciler (pkg/dynamiclifecycle/reconciler.go:120)"
time=2025-01-24T00:43:02Z level=debug msg=Invoked duration=29.343µs function="dynamiclifecycle.registerReconciler (pkg/dynamiclifecycle/reconciler.go:120)"
time=2025-01-24T00:43:02Z level=debug msg=Invoking function="driftchecker.Register (pkg/driftchecker/checker.go:45)"
time=2025-01-24T00:43:02Z level=debug msg=Invoked duration=459.917µs function="driftchecker.Register (pkg/driftchecker/checker.go:45)"
time=2025-01-24T00:43:02Z level=debug msg=Invoking function="features.updateAgentConfigMetricOnStart (.../metrics/features/features.go:14)"
time=2025-01-24T00:43:02Z level=debug msg=Invoked duration=5
    cilium    cilium-dth9h    container cilium-agent is in CrashLoopBackOff, pulling previous Pod logs for further investigation:
2025-01-24T00:43:02.601425337Z time="2025-01-24T00:43:02.601305767Z" level=debug msg="Skipped reading configuration file" error="Config File \"cilium\" Not Found in \"[/root]\"" subsys=config
2025-01-24T00:43:02.601606875Z time="2025-01-24T00:43:02.601571414Z" level=info msg="Memory available for map entries (0.250% of 33283883008B): 83209707B" subsys=config
2025-01-24T00:43:02.601613454Z time="2025-01-24T00:43:02.601579129Z" level=debug msg="Total memory for default map entries: 149422080" subsys=config
2025-01-24T00:43:02.601615701Z time="2025-01-24T00:43:02.601583651Z" level=info msg="option bpf-ct-global-tcp-max set by dynamic sizing to 291963" subsys=config
2025-01-24T00:43:02.601618004Z time="2025-01-24T00:43:02.601586582Z" level=info msg="option bpf-ct-global-any-max set by dynamic sizing to 145981" subsys=config
<...>
2025-01-24T00:43:02.827153296Z time=2025-01-24T00:43:02Z level=debug msg=Invoked duration=459.917µs function="driftchecker.Register (pkg/driftchecker/checker.go:45)"
2025-01-24T00:43:02.827163834Z time=2025-01-24T00:43:02Z level=debug msg=Invoking function="features.updateAgentConfigMetricOnStart (.../metrics/features/features.go:14)"
2025-01-24T00:43:02.827624091Z time=2025-01-24T00:43:02Z level=debug msg=Invoked duration=502.504µs function="features.updateAgentConfigMetricOnStart (.../metrics/features/features.go:14)"
2025-01-24T00:43:02.827638509Z time=2025-01-24T00:43:02Z level=debug msg=Invoking function="cmd.init.func4 (cmd/cells.go:318)"
2025-01-24T00:43:02.828002710Z time="2025-01-24T00:43:02.827962574Z" level=fatal msg="joe is BREAKING cilium 😱" subsys=daemon
    cilium    cilium-k46l9    unable to retrieve cilium status: container cilium-agent is in CrashLoopBackOff, exited with code 1: esh.nodeManagerNotifier (pkg/clustermesh/notifier.go:38)"
time=2025-01-24T00:43:23Z level=debug msg=Invoked duration=9.986µs function="clustermesh.nodeManagerNotifier (pkg/clustermesh/notifier.go:38)"
time=2025-01-24T00:43:23Z level=debug msg=Invoking function="stats.init.func3 (.../nat/stats/cell.go:61)"
time=2025-01-24T00:43:23Z level=debug msg=Invoked duration=560.968µs function="stats.init.func3 (.../nat/stats/cell.go:61)"
time=2025-01-24T00:43:23Z level=debug msg=Invoking function="dynamicconfig.RegisterConfigMapReflector (pkg/dynamicconfig/table.go:90)"
time=2025-01-24T00:43:23Z level=debug msg=Invoked duration=508.107µs function="dynamicconfig.RegisterConfigMapReflector (pkg/dynamicconfig/table.go:90)"
time=2025-01-24T00:43:23Z level=debug msg=Invoking function="dynamiclifecycle.registerWatcher (pkg/dynamiclifecycle/watcher.go:125)"
time=2025-01-24T00:43:23Z level=debug msg=Invoked duration=506.31µs function="dynamiclifecycle.registerWatcher (pkg/dynamiclifecycle/watcher.go:125)"
time=2025-01-24T00:43:23Z level=debug msg=Invoking function="dynamiclifecycle.registerReconciler (pkg/dynamiclifecycle/reconciler.go:120)"
time=2025-01-24T00:43:23Z level=debug msg=Invoked duration=35.509µs function="dynamiclifecycle.registerReconciler (pkg/dynamiclifecycle/reconciler.go:120)"
time=2025-01-24T00:43:23Z level=debug msg=Invoking function="driftchecker.Register (pkg/driftchecker/checker.go:45)"
time=2025-01-24T00:43:23Z level=debug msg=Invoked duration=477.289µs function="driftchecker.Register (pkg/driftchecker/checker.go:45)"
time=2025-01-24T00:43:23Z level=debug msg=Invoking function="features.updateAgentConfigMetricOnStart (.../metrics/features/features.go:14)"
time=2025-01-24T00:43:23Z level=debug msg=Invoked duration=5
    cilium-operator    cilium-operator                    1 pods of Deployment cilium-operator are not ready
    cilium-operator    cilium-operator-658fbf65c-bs78c    container cilium-operator is in CrashLoopBackOff, pulling previous Pod logs for further investigation:
2025-01-24T00:44:22.646874302Z Error: unknown flag: --bad-arg-yo
2025-01-24T00:44:22.647348762Z Usage:
2025-01-24T00:44:22.647367160Z   cilium-operator-generic [flags]
2025-01-24T00:44:22.647372538Z   cilium-operator-generic [command]
2025-01-24T00:44:22.647375700Z 
<...>
2025-01-24T00:44:22.647792729Z       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
2025-01-24T00:44:22.647795371Z       --version                                              Print version information
2025-01-24T00:44:22.647797851Z 
2025-01-24T00:44:22.647800608Z Use "cilium-operator-generic [command] --help" for more information about a command.
2025-01-24T00:44:22.647803181Z
    hubble-relay    hubble-relay                     1 pods of Deployment hubble-relay are not ready
    hubble-relay    hubble-relay-6cbf9894c4-lj5kc    container hubble-relay is in CrashLoopBackOff, pulling previous Pod logs for further investigation:
2025-01-24T00:45:25.063779760Z Error: failed to start gops agent: mkdir /.config: permission denied

Error: Unable to determine status:  wait canceled, cilium agent container has crashed or was terminated: context canceled
```