### PR TITLE
renovate: Allow go 1.23 for stable branches 1.14+

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -356,18 +356,9 @@
       "allowedVersions": "<1.24",
       "matchBaseBranches": [
         "v1.17",
-      ]
-    },
-    {
-      "matchPackageNames": [
-        "docker.io/library/golang",
-        "go"
-      ],
-      "allowedVersions": "<1.23",
-      "matchBaseBranches": [
         "v1.16",
         "v1.15",
-        "v1.14",
+        "v1.14"
       ]
     },
     {


### PR DESCRIPTION
Golang 1.22 will be EOL once 1.24 is released (currently planned for Feb 2025).

Relates: #37056

