### PR TITLE
datapath: move probe for `bpf_skb_adjust_room` with `BPF_ADJ_ROOM_MAC` mode

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1375,13 +1375,6 @@ func initEnv(vp *viper.Viper) {
 		}
 	}
 
-	if err := probes.HaveSKBAdjustRoomL2RoomMACSupport(); err != nil {
-		if option.Config.ServiceNoBackendResponse != option.ServiceNoBackendResponseDrop {
-			log.Warn("The kernel does not support --service-no-backend-response=reject, falling back to --service-no-backend-response=drop")
-			option.Config.ServiceNoBackendResponse = option.ServiceNoBackendResponseDrop
-		}
-	}
-
 	if option.Config.EnableIPv4FragmentsTracking {
 		if !option.Config.EnableIPv4 {
 			option.Config.EnableIPv4FragmentsTracking = false

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -56,6 +56,10 @@ func CheckRequirements(log *slog.Logger) error {
 			return errors.New("Require support for large programs (Linux 5.2.0 or newer)")
 		}
 
+		if probes.HaveSKBAdjustRoomL2RoomMACSupport() != nil {
+			return errors.New("Require support for bpf_skb_adjust_room with BPF_ADJ_ROOM_MAC mode (Linux 5.2 or newer)")
+		}
+
 		if err := probeManager.SystemConfigProbes(); err != nil {
 			// TODO(vincentmli): revisit log when GH#14314 has been resolved
 			// Warn missing required kernel config option


### PR DESCRIPTION
The `BPF_ADJ_ROOM_MAC` mode for `bpf_skb_adjust_room` is available since kernel v5.2 and the minimum required kernel version was lifted to v5.4/RHEL8.6 for Cilium ~1.17~1.16, see #30456.

Assume that Cilium is running on a supported kernel version and error out instead of adjusting --service-no-backend-response in case `bpf_skb_adjust_room` with `BPF_ADJ_ROOM_MAC` mode is not supported.
