### PR TITLE
fix: ignore encrypt interface field

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3815,6 +3815,7 @@ func (c *DaemonConfig) checksum() [32]byte {
 	sumConfig := *c
 	// Ignore variable parts
 	sumConfig.Opts = nil
+	sumConfig.EncryptInterface = nil
 	cBytes, err := json.Marshal(&sumConfig)
 	if err != nil {
 		return [32]byte{}
@@ -3870,7 +3871,8 @@ func (c *DaemonConfig) diffFromFile() error {
 
 		diff = cmp.Diff(&config, c, opts,
 			cmpopts.IgnoreTypes(&IntOptions{}),
-			cmpopts.IgnoreTypes(&OptionLibrary{}))
+			cmpopts.IgnoreTypes(&OptionLibrary{}),
+			cmpopts.IgnoreFields(DaemonConfig{}, "EncryptInterface"))
 	}
 	return fmt.Errorf("Config differs:\n%s", diff)
 }

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -1324,6 +1324,12 @@ func TestDaemonConfig_StoreInFile(t *testing.T) {
 	assert.ErrorContains(t, err, "Config differs:", "Should return a validation error")
 	Config.DryMode = false
 
+	// minor change
+	Config.EncryptInterface = append(Config.EncryptInterface, "yolo")
+	err = Config.ValidateUnchanged()
+	assert.NoError(t, err)
+	Config.EncryptInterface = nil
+
 	// IntOptions changes are ignored
 	Config.Opts.SetBool("unit-test-key-only", false)
 	err = Config.ValidateUnchanged()


### PR DESCRIPTION
This commit ignores the field EncryptInterface when verifying if there's any mutation of option.Config after its initialization. 
With this commit, triggering reinitializeIPSec path causing mutation when using it without kube-proxy replacement on EKS clusters won't fail Cilium startup. 
This is a temporary fix, once bpf_network will be removed for IPsec, EncryptInterface won't be used anymore.

Fixes: [#34794](https://github.com/cilium/cilium/issues/34794)

```release-note
Ignore encrypt interface field when validating option.Config after initialization
```
