### PR TITLE
creation of additional ccnp e2e tests & multipolicy tests

### DIFF
--- a/cilium-cli/connectivity/builder/all_egress_deny_ccnp.go
+++ b/cilium-cli/connectivity/builder/all_egress_deny_ccnp.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+)
+
+
+//go:embed manifests/deny-all-egress-ccnp.yaml
+var denyAllEgressCCNPPolicyYAML string
+
+type allEgressDenyCCNP struct{}
+
+func (t allEgressDenyCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	//Denying egresses 
+	newTest("all-egress-deny-ccnp", ct).
+		WithCiliumClusterwidePolicy(denyAllEgressCCNPPolicyYAML).
+		WithScenarios(
+			tests.PodToPod(),
+			tests.PodToPodWithEndpoints(),
+		).
+		WithExpectations(func(_ *check.Action) (egress, ingress check.Result) {
+			return check.ResultDefaultDenyEgressDrop, check.ResultNone
+		})
+}

--- a/cilium-cli/connectivity/builder/all_ingress_deny_ccnp.go
+++ b/cilium-cli/connectivity/builder/all_ingress_deny_ccnp.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+
+//go:embed manifests/deny-all-ingress-ccnp.yaml
+var denyAllIngressCCNPPolicyYAML string
+
+type allIngressDenyCCNP struct{}
+
+func (t allIngressDenyCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("all-ingress-deny-ccnp", ct).
+		WithCiliumClusterwidePolicy(denyAllIngressCCNPPolicyYAML).
+		WithScenarios(tests.PodToPod(), tests.PodToCIDR(tests.WithRetryAll())).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Destination().Address(features.GetIPFamily(ct.Params().ExternalOtherIP)) == ct.Params().ExternalOtherIP ||
+				a.Destination().Address(features.GetIPFamily(ct.Params().ExternalIP)) == ct.Params().ExternalIP {
+				return check.ResultOK, check.ResultNone
+			}
+			return check.ResultDrop, check.ResultDefaultDenyIngressDrop
+		})
+}

--- a/cilium-cli/connectivity/builder/allow_all_except_world_ccnp.go
+++ b/cilium-cli/connectivity/builder/allow_all_except_world_ccnp.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+)
+
+
+//go:embed manifests/allow-all-except-world-ccnp.yaml
+var allowAllExceptWorldCCNPYAML string
+
+type allowAllExceptWorldCCNP struct{}
+
+func (t allowAllExceptWorldCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("allow-all-except-world-ccnp", ct).
+		WithCiliumClusterwidePolicy(allowAllExceptWorldCCNPYAML).
+		WithScenarios(
+			tests.PodToPod(),
+			tests.ClientToClient(),
+			tests.PodToService(),
+			tests.PodToHost(),
+			tests.PodToExternalWorkload(),
+		)
+}

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -89,6 +89,20 @@ var (
 
 	//go:embed manifests/echo-ingress-from-cidr.yaml
 	echoIngressFromCIDRYAML string
+
+	//go:embed manifests/allow-all-egress-ccnp.yaml
+	allowAllEgressCCNPPolicyYAML string
+
+	//go:embed manifests/allow-all-ingress-ccnp.yaml
+	allowAllIngressCCNPPolicyYAML string
+
+	//go:embed manifests/client-egress-to-cidr-external-deny-ccnp.yaml
+	clientEgressToCIDRExternalDenyCCNPPolicyYAML string 
+
+	//go:embed manifests/client-egress-to-cidr-external-ccnp.yaml
+	clientEgressToCIDRExternalCCNPPolicyYAML string
+
+
 )
 
 var (
@@ -278,6 +292,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		bgpControlPlane{},
 		multicast{},
 		strictModeEncryption{},
+		
 	}
 	return injectTests(tests, connTests...)
 }
@@ -289,6 +304,32 @@ func sequentialTests(ct *check.ConnectivityTest) error {
 		hostFirewallEgress{},
 		clientEgressL7TlsDenyWithoutHeaders{},
 		clientEgressL7TlsHeaders{},
+		allowAllExceptWorldCCNP{},
+		clientIngressCCNP{},
+		allIngressDenyCCNP{},
+		allEgressDenyCCNP{},
+		clusterEntityCCNP{},
+		hostEntityEgressCCNP{},
+		hostEntityIngressCCNP{},
+		echoIngressCCNP{},
+		clientIngressIcmpCCNP{},
+		clientEgressCCNP{},
+		clientEgressExpressionCCNP{},
+		clientEgressToEchoServiceAccountCCNP{},
+		toCidrExternalCCNP{},
+		echoIngressFromOtherClientDenyCCNP{},
+		clientIngressFromOtherClientIcmpDenyCCNP{},
+		clientEgressToEchoDenyCCNP{},
+		clientEgressToEchoExpressionDenyCCNP{},
+		clientEgressToEchoServiceAccountDenyCCNP{},
+		clientWithServiceAccountEgressToEchoDenyCCNP{},
+		clientEgressToCidrDenyCCNP{},
+		clientEgressToCidrDenyDefaultCCNP{},
+		clientWithServiceAccountEgressToEchoCCNP{},
+		toEntitiesWorldCCNP{},
+		clientIngressToEchoNamedPortDenyCCNP{},
+		clientEgressToEchoAllAllow{},
+		clientEgressToEchoAllDeny{},
 	}
 	return injectTests(tests, ct)
 }
@@ -321,6 +362,11 @@ func renderTemplates(clusterName string, param check.Parameters) (map[string]str
 		"clientEgressOnlyDNSPolicyYAML":                      clientEgressOnlyDNSPolicyYAML,
 		"echoIngressFromCIDRYAML":                            echoIngressFromCIDRYAML,
 		"denyCIDRPolicyYAML":                                 denyCIDRPolicyYAML,
+		"allowAllEgressCCNPPolicyYAML":					   	  allowAllEgressCCNPPolicyYAML,
+		"allowAllIngressCCNPPolicyYAML":					  allowAllIngressCCNPPolicyYAML,
+		"clientEgressToCIDRExternalDenyCCNPPolicyYAML":		  clientEgressToCIDRExternalDenyCCNPPolicyYAML,
+		"clientEgressToCIDRExternalCCNPPolicyYAML":			  clientEgressToCIDRExternalCCNPPolicyYAML,
+
 	}
 	if param.K8sLocalHostTest {
 		templates["clientEgressToCIDRCPHostPolicyYAML"] = clientEgressToCIDRCPHostPolicyYAML

--- a/cilium-cli/connectivity/builder/client_egress_ccnp.go
+++ b/cilium-cli/connectivity/builder/client_egress_ccnp.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+)
+
+//go:embed manifests/client-egress-to-echo-ccnp.yaml
+var clientEgressToEchoCCNPPolicyYAML string
+
+type clientEgressCCNP struct{}
+
+func (t clientEgressCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("client-egress-ccnp", ct).
+		WithCiliumClusterwidePolicy(clientEgressToEchoCCNPPolicyYAML).
+		WithScenarios(tests.PodToPod())
+}

--- a/cilium-cli/connectivity/builder/client_egress_expression_ccnp.go
+++ b/cilium-cli/connectivity/builder/client_egress_expression_ccnp.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/client-egress-to-echo-expression-ccnp.yaml
+var clientEgressToEchoExpressionCCNPPolicyYAML string
+
+//go:embed manifests/client-egress-to-echo-expression-port-range-ccnp.yaml
+var clientEgressToEchoExpressionCCNPPolicyPortRangeYAML string
+
+type clientEgressExpressionCCNP struct{}
+
+func (t clientEgressExpressionCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	clientEgressExpressionCCNPTest(ct, false)
+	if ct.Features[features.PortRanges].Enabled {
+		clientEgressExpressionCCNPTest(ct, true)
+	}
+}
+
+func clientEgressExpressionCCNPTest(ct *check.ConnectivityTest, portRanges bool) {
+	testName := "client-egress-expression-ccnp"
+	policyYAML := clientEgressToEchoExpressionCCNPPolicyYAML
+	if portRanges {
+		testName = "client-egress-expression-port-range-ccnp"
+		policyYAML = clientEgressToEchoExpressionCCNPPolicyPortRangeYAML
+	}
+	newTest(testName, ct).
+		WithCiliumClusterwidePolicy(policyYAML).
+		WithScenarios(tests.PodToPod())
+}

--- a/cilium-cli/connectivity/builder/client_egress_to_cidr_deny_ccnp.go
+++ b/cilium-cli/connectivity/builder/client_egress_to_cidr_deny_ccnp.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type clientEgressToCidrDenyCCNP struct{}
+
+func (t clientEgressToCidrDenyCCNP) build(ct *check.ConnectivityTest, templates map[string]string) {
+	newTest("client-egress-to-cidr-deny-ccnp", ct).
+		WithCiliumClusterwidePolicy(allowAllEgressPolicyYAML). 
+		WithCiliumClusterwidePolicy(templates["clientEgressToCIDRExternalDenyCCNPPolicyYAML"]).
+		WithScenarios(
+			tests.PodToCIDR(tests.WithRetryDestIP(ct.Params().ExternalIP)), 
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Destination().Address(features.GetIPFamily(ct.Params().ExternalOtherIP)) == ct.Params().ExternalOtherIP {
+				return check.ResultPolicyDenyEgressDrop, check.ResultNone
+			}
+			if a.Destination().Address(features.GetIPFamily(ct.Params().ExternalIP)) == ct.Params().ExternalIP {
+				return check.ResultOK, check.ResultNone
+			}
+			return check.ResultDrop, check.ResultDrop
+		})
+}

--- a/cilium-cli/connectivity/builder/client_egress_to_cidr_deny_default_ccnp.go
+++ b/cilium-cli/connectivity/builder/client_egress_to_cidr_deny_default_ccnp.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type clientEgressToCidrDenyDefaultCCNP struct{}
+
+func (t clientEgressToCidrDenyDefaultCCNP) build(ct *check.ConnectivityTest, templates map[string]string) {
+	newTest("client-egress-to-cidr-deny-default-ccnp", ct).
+		WithCiliumClusterwidePolicy(templates["clientEgressToCIDRExternalDenyCCNPPolicyYAML"]).
+		WithScenarios(tests.PodToCIDR()). 
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Destination().Address(features.GetIPFamily(ct.Params().ExternalOtherIP)) == ct.Params().ExternalOtherIP {
+				return check.ResultPolicyDenyEgressDrop, check.ResultNone
+			}
+			if a.Destination().Address(features.GetIPFamily(ct.Params().ExternalIP)) == ct.Params().ExternalIP {
+				return check.ResultDefaultDenyEgressDrop, check.ResultNone
+			}
+			return check.ResultDrop, check.ResultDrop
+		})
+}

--- a/cilium-cli/connectivity/builder/client_egress_to_echo_all_allow.go
+++ b/cilium-cli/connectivity/builder/client_egress_to_echo_all_allow.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+
+)
+
+//go:embed manifests/client-egress-to-echo-allow.yaml
+var clientEgressToEchoAllAllowPolicyYAML string
+
+
+type clientEgressToEchoAllAllow struct{}
+
+func (t clientEgressToEchoAllAllow) build(ct *check.ConnectivityTest, _ map[string]string) {
+
+	// This policy allows port 8080 from client to echo (using label match expression), but allows traffic from client2
+	newTest("client-egress-to-echo-multipolicy-allow", ct).
+		WithCiliumClusterwidePolicy(allowAllEgressCCNPPolicyYAML).  // Allow all egress traffic ccnp
+		WithCiliumPolicy(allowAllIngressPolicyYAML). // Allow all ingress traffic cnp
+		WithCiliumPolicy(clientEgressToEchoAllAllowPolicyYAML).
+		WithScenarios(
+			tests.PodToPod(tests.WithSourceLabelsOption(clientLabel)),  //client -> echo should be allowed
+			tests.PodToPod(tests.WithSourceLabelsOption(client2Label)), //client2 -> echo should be allowed
+			
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Destination().HasLabel("kind", "echo") &&
+				a.Source().HasLabel("name", "client") && a.Destination().Port() == 8080  {
+				return check.ResultOK, check.ResultNone
+			}
+			return check.ResultOK, check.ResultOK
+		})
+	
+
+}
+
+

--- a/cilium-cli/connectivity/builder/client_egress_to_echo_all_deny.go
+++ b/cilium-cli/connectivity/builder/client_egress_to_echo_all_deny.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+
+)
+
+//go:embed manifests/client-egress-to-echo-deny.yaml
+var clientEgressToEchoAllDenyPolicyYAML string
+
+
+type clientEgressToEchoAllDeny struct{}
+
+func (t clientEgressToEchoAllDeny) build(ct *check.ConnectivityTest, _ map[string]string) {
+
+	newTest("client-egress-to-echo-multipolicy-deny", ct).
+		WithCiliumClusterwidePolicy(denyAllEgressCCNPPolicyYAML).  // Deny all egress traffic ccnp
+		WithCiliumClusterwidePolicy(denyAllIngressCCNPPolicyYAML). // Deny all ingress traffic ccnp
+		WithCiliumPolicy(denyAllIngressPolicyYAML). //Deny all ingress traffic cnp
+		WithCiliumPolicy(clientEgressToEchoAllDenyPolicyYAML). //Egress policy cnp 
+		WithScenarios(
+			tests.PodToPod(tests.WithSourceLabelsOption(clientLabel)),  //client -> echo should be denied
+			tests.PodToPod(tests.WithSourceLabelsOption(client2Label)), //client2 -> echo should be denied
+			
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+            if a.Destination().HasLabel("kind", "echo") {
+                return check.ResultPolicyDenyEgressDrop, check.ResultNone
+            }
+            return check.ResultOK, check.ResultNone
+		})
+	
+
+}
+
+

--- a/cilium-cli/connectivity/builder/client_egress_to_echo_deny_ccnp.go
+++ b/cilium-cli/connectivity/builder/client_egress_to_echo_deny_ccnp.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/client-egress-to-echo-deny-ccnp.yaml
+var clientEgressToEchoDenyCCNPPolicyYAML string
+
+//go:embed manifests/client-egress-to-echo-deny-port-range-ccnp.yaml
+var clientEgressToEchoDenyCCNPPolicyPortRangeYAML string
+
+type clientEgressToEchoDenyCCNP struct{}
+
+func (t clientEgressToEchoDenyCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	clientEgressToEchoDenyCCNPTest(ct, false)
+	if ct.Features[features.PortRanges].Enabled {
+		clientEgressToEchoDenyCCNPTest(ct, true)
+	}
+}
+
+func clientEgressToEchoDenyCCNPTest(ct *check.ConnectivityTest, portRanges bool) {
+	testName := "client-egress-to-echo-deny-ccnp"
+	policyYAML := clientEgressToEchoDenyCCNPPolicyYAML
+	if portRanges {
+		testName = "client-egress-to-echo-deny-port-range-ccnp"
+		policyYAML = clientEgressToEchoDenyCCNPPolicyPortRangeYAML
+	}
+	newTest(testName, ct).
+		WithCiliumClusterwidePolicy(allowAllEgressCCNPPolicyYAML).  
+		WithCiliumClusterwidePolicy(allowAllIngressCCNPPolicyYAML). 
+		WithCiliumClusterwidePolicy(policyYAML).                
+		WithScenarios(
+			tests.ClientToClient(), 
+			tests.PodToPod(),      
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Source().HasLabel("kind", "client") &&
+				a.Destination().HasLabel("kind", "echo") &&
+				a.Destination().Port() == 8080 {
+				return check.ResultPolicyDenyEgressDrop, check.ResultNone
+			}
+			return check.ResultOK, check.ResultNone
+		})
+}

--- a/cilium-cli/connectivity/builder/client_egress_to_echo_expression_deny_ccnp.go
+++ b/cilium-cli/connectivity/builder/client_egress_to_echo_expression_deny_ccnp.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/client-egress-to-echo-expression-deny-ccnp.yaml
+var clientEgressToEchoExpressionDenyCCNPPolicyYAML string
+
+//go:embed manifests/client-egress-to-echo-expression-deny-port-range-ccnp.yaml
+var clientEgressToEchoExpressionDenyCCNPPolicyPortRangeYAML string
+
+type clientEgressToEchoExpressionDenyCCNP struct{}
+
+func (t clientEgressToEchoExpressionDenyCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	clientEgressToEchoExpressionDenyCCNPTest(ct, false)
+	if ct.Features[features.PortRanges].Enabled {
+		clientEgressToEchoExpressionDenyCCNPTest(ct, true)
+	}
+}
+
+func clientEgressToEchoExpressionDenyCCNPTest(ct *check.ConnectivityTest, portRanges bool) {
+	testName := "client-egress-to-echo-expression-deny-ccnp"
+	policyYAML := clientEgressToEchoExpressionDenyCCNPPolicyYAML
+	if portRanges {
+		testName = "client-egress-to-echo-expression-deny-port-range-ccnp"
+		policyYAML = clientEgressToEchoExpressionDenyCCNPPolicyPortRangeYAML
+	}
+	newTest(testName, ct).
+		WithCiliumClusterwidePolicy(allowAllEgressCCNPPolicyYAML).  
+		WithCiliumClusterwidePolicy(allowAllIngressCCNPPolicyYAML). 
+		WithCiliumClusterwidePolicy(policyYAML).
+		WithScenarios(
+			tests.PodToPod(tests.WithSourceLabelsOption(clientLabel)), 
+			tests.PodToPod(tests.WithSourceLabelsOption(client2Label)), 
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Destination().HasLabel("kind", "echo") &&
+				a.Source().HasLabel("name", "client") {
+				return check.ResultPolicyDenyEgressDrop, check.ResultNone
+			}
+			return check.ResultOK, check.ResultOK
+		})
+}

--- a/cilium-cli/connectivity/builder/client_egress_to_echo_service_account_ccnp.go
+++ b/cilium-cli/connectivity/builder/client_egress_to_echo_service_account_ccnp.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/client-egress-to-echo-service-account-ccnp.yaml
+var clientEgressToEchoServiceAccountCCNPPolicyYAML string
+
+//go:embed manifests/client-egress-to-echo-service-account-port-range-ccnp.yaml
+var clientEgressToEchoServiceAccountCCNPPolicyPortRangeYAML string
+
+type clientEgressToEchoServiceAccountCCNP struct{}
+
+func (t clientEgressToEchoServiceAccountCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	clientEgressToEchoServiceAccountCCNPTest(ct, false)
+	if ct.Features[features.PortRanges].Enabled {
+		clientEgressToEchoServiceAccountCCNPTest(ct, true)
+	}
+}
+
+func clientEgressToEchoServiceAccountCCNPTest(ct *check.ConnectivityTest, portRanges bool) {
+	testName := "client-egress-to-echo-service-account-ccnp"
+	policyYAML := clientEgressToEchoServiceAccountCCNPPolicyYAML
+	if portRanges {
+		testName = "client-egress-to-echo-service-account-port-range-ccnp"
+		policyYAML = clientEgressToEchoServiceAccountCCNPPolicyPortRangeYAML
+	}
+	newTest(testName, ct).
+		WithCiliumClusterwidePolicy(policyYAML).
+		WithScenarios(
+			tests.PodToPod(tests.WithSourceLabelsOption(map[string]string{"kind": "client"})),
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Destination().HasLabel("name", "echo-same-node") {
+				return check.ResultOK, check.ResultOK
+			}
+			return check.ResultDefaultDenyEgressDrop, check.ResultNone
+		})
+}

--- a/cilium-cli/connectivity/builder/client_egress_to_echo_service_account_deny_ccnp.go
+++ b/cilium-cli/connectivity/builder/client_egress_to_echo_service_account_deny_ccnp.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/client-egress-to-echo-service-account-deny-ccnp.yaml
+var clientEgressToEchoServiceAccountDenyCCNPPolicyYAML string
+
+//go:embed manifests/client-egress-to-echo-service-account-deny-port-range-ccnp.yaml
+var clientEgressToEchoServiceAccountDenyPolicyCCNPPortRangeYAML string
+
+type clientEgressToEchoServiceAccountDenyCCNP struct{}
+
+func (t clientEgressToEchoServiceAccountDenyCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	clientEgressToEchoServiceAccountDenyCCNPTest(ct, false)
+	if ct.Features[features.PortRanges].Enabled {
+		clientEgressToEchoServiceAccountDenyTest(ct, true)
+	}
+}
+
+func clientEgressToEchoServiceAccountDenyCCNPTest(ct *check.ConnectivityTest, portRanges bool) {
+	testName := "client-egress-to-echo-service-account-deny-ccnp"
+	policyYAML := clientEgressToEchoServiceAccountDenyCCNPPolicyYAML
+	if portRanges {
+		testName = "client-egress-to-echo-service-account-deny-port-range-ccnp"
+		policyYAML = clientEgressToEchoServiceAccountDenyPolicyCCNPPortRangeYAML
+	}
+	newTest(testName, ct).
+		WithCiliumClusterwidePolicy(allowAllEgressCCNPPolicyYAML).  
+		WithCiliumClusterwidePolicy(allowAllIngressCCNPPolicyYAML). 
+		WithCiliumClusterwidePolicy(policyYAML).
+		WithScenarios(
+			tests.PodToPod(tests.WithSourceLabelsOption(map[string]string{"name": "client"})),
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Destination().HasLabel("name", "echo-same-node") {
+				return check.ResultPolicyDenyEgressDrop, check.ResultNone
+			}
+			return check.ResultOK, check.ResultOK
+		})
+}

--- a/cilium-cli/connectivity/builder/client_ingress_ccnp.go
+++ b/cilium-cli/connectivity/builder/client_ingress_ccnp.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+)
+
+
+//go:embed manifests/client-ingress-from-client2-ccnp.yaml
+var clientIngressFromClient2CCNPPolicyYAML string
+type clientIngressCCNP struct{}
+
+func (t clientIngressCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+
+	newTest("client-ingress-ccnp", ct).
+		WithCiliumClusterwidePolicy(clientIngressFromClient2CCNPPolicyYAML).
+		WithScenarios(tests.ClientToClient()).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Source().HasLabel("other", "client") {
+				return check.ResultOK, check.ResultOK
+			}
+			return check.ResultOK, check.ResultDefaultDenyIngressDrop
+		})
+}

--- a/cilium-cli/connectivity/builder/client_ingress_from_other_client_icmp_deny_ccnp.go
+++ b/cilium-cli/connectivity/builder/client_ingress_from_other_client_icmp_deny_ccnp.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/echo-ingress-icmp-deny-ccnp.yaml
+var echoIngressICMPDenyCCNPPolicyYAML string
+
+type clientIngressFromOtherClientIcmpDenyCCNP struct{}
+
+func (t clientIngressFromOtherClientIcmpDenyCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("client-ingress-from-other-client-icmp-deny-ccnp", ct).
+		WithCiliumClusterwidePolicy(allowAllEgressCCNPPolicyYAML).      
+		WithCiliumClusterwidePolicy(allowAllIngressCCNPPolicyYAML).    
+		WithCiliumClusterwidePolicy(echoIngressICMPDenyCCNPPolicyYAML). 
+		WithFeatureRequirements(features.RequireEnabled(features.ICMPPolicy)).
+		WithScenarios(
+			tests.PodToPod(),      
+			tests.ClientToClient(), 
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Source().HasLabel("other", "client") &&
+				a.Destination().HasLabel("kind", "client") {
+				return check.ResultDrop, check.ResultPolicyDenyIngressDrop
+			}
+			return check.ResultOK, check.ResultNone
+		})
+}

--- a/cilium-cli/connectivity/builder/client_ingress_icmp_ccnp.go
+++ b/cilium-cli/connectivity/builder/client_ingress_icmp_ccnp.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/echo-ingress-icmp-ccnp.yaml
+var echoIngressICMPCCNPPolicyYAML string
+
+type clientIngressIcmpCCNP struct{}
+
+func (t clientIngressIcmpCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("client-ingress-icmp-ccnp", ct).
+		WithCiliumClusterwidePolicy(echoIngressICMPCCNPPolicyYAML).
+		WithFeatureRequirements(features.RequireEnabled(features.ICMPPolicy)).
+		WithScenarios(tests.ClientToClient()).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Source().HasLabel("other", "client") {
+				return check.ResultOK, check.ResultOK
+			}
+			return check.ResultOK, check.ResultDefaultDenyIngressDrop
+		})
+}

--- a/cilium-cli/connectivity/builder/client_ingress_to_echo_named_port_deny_ccnp.go
+++ b/cilium-cli/connectivity/builder/client_ingress_to_echo_named_port_deny_ccnp.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+)
+
+//go:embed manifests/client-egress-to-echo-named-port-deny-ccnp.yaml
+var clientEgressToEchoDenyNamedCCNPPortPolicyYAML string
+
+type clientIngressToEchoNamedPortDenyCCNP struct{}
+
+func (t clientIngressToEchoNamedPortDenyCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("client-ingress-to-echo-named-port-deny-ccnp", ct).
+		WithCiliumClusterwidePolicy(allowAllEgressCCNPPolicyYAML).  
+		WithCiliumClusterwidePolicy(allowAllIngressCCNPPolicyYAML). 
+		WithCiliumClusterwidePolicy(clientEgressToEchoDenyNamedCCNPPortPolicyYAML).
+		WithScenarios(
+			tests.PodToPod(tests.WithSourceLabelsOption(clientLabel)),  //client -> echo should be denied
+			tests.PodToPod(tests.WithSourceLabelsOption(client2Label)), //client2 -> echo should be allowed
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Destination().HasLabel("kind", "echo") && a.Source().HasLabel("name", "client") {
+				return check.ResultDropCurlTimeout, check.ResultPolicyDenyIngressDrop
+			}
+			return check.ResultOK, check.ResultOK
+		})
+}

--- a/cilium-cli/connectivity/builder/client_with_service_account_egress_to_echo_ccnp.go
+++ b/cilium-cli/connectivity/builder/client_with_service_account_egress_to_echo_ccnp.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/client-with-service-account-egress-to-echo-ccnp.yaml
+var clientWithServiceAccountEgressToEchoCCNPPolicyYAML string
+
+//go:embed manifests/client-with-service-account-egress-to-echo-port-range-ccnp.yaml
+var clientWithServiceAccountEgressToEchoCCNPPolicyPortRangeYAML string
+
+type clientWithServiceAccountEgressToEchoCCNP struct{}
+
+func (t clientWithServiceAccountEgressToEchoCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	clientWithServiceAccountEgressToEchoCCNPTest(ct, false)
+	if ct.Features[features.PortRanges].Enabled {
+		clientWithServiceAccountEgressToEchoCCNPTest(ct, true)
+	}
+}
+
+func clientWithServiceAccountEgressToEchoCCNPTest(ct *check.ConnectivityTest, portRanges bool) {
+	testName := "client-with-service-account-egress-to-echo-ccnp"
+	policyYAML := clientWithServiceAccountEgressToEchoCCNPPolicyYAML
+	if portRanges {
+		testName = "client-with-service-account-egress-to-echo-port-range-ccnp"
+		policyYAML = clientWithServiceAccountEgressToEchoCCNPPolicyPortRangeYAML
+	}
+	newTest(testName, ct).
+		WithCiliumClusterwidePolicy(policyYAML).
+		WithScenarios(
+			tests.PodToPod(tests.WithSourceLabelsOption(map[string]string{"kind": "client"})),
+		)
+}

--- a/cilium-cli/connectivity/builder/client_with_service_account_egress_to_echo_deny_ccnp.go
+++ b/cilium-cli/connectivity/builder/client_with_service_account_egress_to_echo_deny_ccnp.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/client-with-service-account-egress-to-echo-deny-ccnp.yaml
+var clientWithServiceAccountEgressToEchoDenyCCNPPolicyYAML string
+
+//go:embed manifests/client-with-service-account-egress-to-echo-deny-port-range-ccnp.yaml
+var clientWithServiceAccountEgressToEchoDenyPolicyCCNPPortRangeYAML string
+
+type clientWithServiceAccountEgressToEchoDenyCCNP struct{}
+
+func (t clientWithServiceAccountEgressToEchoDenyCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	clientWithServiceAccountEgressToEchoDenyCCNPTest(ct, false)
+	if ct.Features[features.PortRanges].Enabled {
+		clientWithServiceAccountEgressToEchoDenyCCNPTest(ct, true)
+	}
+}
+
+func clientWithServiceAccountEgressToEchoDenyCCNPTest(ct *check.ConnectivityTest, portRanges bool) {
+	testName := "client-with-service-account-egress-to-echo-deny-ccnp"
+	policyYAML := clientWithServiceAccountEgressToEchoDenyCCNPPolicyYAML
+	if portRanges {
+		testName = "client-with-service-account-egress-to-echo-deny-port-range-ccnp"
+		policyYAML = clientWithServiceAccountEgressToEchoDenyPolicyCCNPPortRangeYAML
+	}
+	newTest(testName, ct).
+		WithCiliumClusterwidePolicy(allowAllEgressCCNPPolicyYAML).  
+		WithCiliumClusterwidePolicy(allowAllIngressCCNPPolicyYAML). 
+		WithCiliumClusterwidePolicy(policyYAML).
+		WithScenarios(
+			tests.PodToPod(tests.WithSourceLabelsOption(map[string]string{"name": "client"})),  //client -> echo should be denied
+			tests.PodToPod(tests.WithSourceLabelsOption(map[string]string{"name": "client2"})), //client2 -> echo should be allowed
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Destination().HasLabel("kind", "echo") && a.Source().HasLabel("name", "client") {
+				return check.ResultPolicyDenyEgressDrop, check.ResultNone
+			}
+			return check.ResultOK, check.ResultOK
+		})
+}

--- a/cilium-cli/connectivity/builder/cluster_entity_ccnp.go
+++ b/cilium-cli/connectivity/builder/cluster_entity_ccnp.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+)
+
+//go:embed manifests/allow-cluster-entity-ccnp.yaml
+var allowClusterEntityCCNPPolicyYAML string
+type clusterEntityCCNP struct{}
+
+func (t clusterEntityCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("cluster-entity-ccnp", ct).
+		WithCiliumClusterwidePolicy(allowClusterEntityCCNPPolicyYAML).
+		WithScenarios(
+			tests.PodToPod(tests.WithDestinationLabelsOption(map[string]string{"name": "echo-same-node"})),
+		).
+		WithExpectations(func(_ *check.Action) (egress, ingress check.Result) {
+			return check.ResultOK, check.ResultOK
+		})
+}

--- a/cilium-cli/connectivity/builder/echo_ingress_ccnp.go
+++ b/cilium-cli/connectivity/builder/echo_ingress_ccnp.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+)
+
+//go:embed manifests/echo-ingress-from-other-client-ccnp.yaml
+var echoIngressFromOtherClientCCNPPolicyYAML string
+
+type echoIngressCCNP struct{}
+
+func (t echoIngressCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("echo-ingress-ccnp", ct).
+		WithCiliumClusterwidePolicy(echoIngressFromOtherClientCCNPPolicyYAML).
+		WithScenarios(tests.PodToPod()).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Destination().HasLabel("kind", "echo") && !a.Source().HasLabel("other", "client") {
+				return check.ResultDropCurlTimeout, check.ResultDropCurlTimeout
+			}
+			return check.ResultOK, check.ResultOK
+		})
+}

--- a/cilium-cli/connectivity/builder/echo_ingress_from_other_client_deny_ccnp.go
+++ b/cilium-cli/connectivity/builder/echo_ingress_from_other_client_deny_ccnp.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+)
+
+//go:embed manifests/echo-ingress-from-other-client-deny-ccnp.yaml
+var echoIngressFromOtherClientDenyCCNPPolicyYAML string
+
+type echoIngressFromOtherClientDenyCCNP struct{}
+
+func (t echoIngressFromOtherClientDenyCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	// Tests with deny policy
+	newTest("echo-ingress-from-other-client-deny-ccnp", ct).
+		WithCiliumClusterwidePolicy(allowAllEgressCCNPPolicyYAML).              
+		WithCiliumClusterwidePolicy(allowAllIngressCCNPPolicyYAML).              
+		WithCiliumClusterwidePolicy(echoIngressFromOtherClientDenyCCNPPolicyYAML). 
+		WithScenarios(
+			tests.PodToPod(tests.WithSourceLabelsOption(clientLabel)),  //client -> echo should be allowed
+			tests.PodToPod(tests.WithSourceLabelsOption(client2Label)), //client2 -> echo should be denied
+			tests.ClientToClient(), //client -> client should be allowed
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Source().HasLabel("other", "client") && a.Destination().HasLabel("kind", "echo") {
+				return check.ResultDrop, check.ResultPolicyDenyIngressDrop
+			}
+			return check.ResultOK, check.ResultOK
+		})
+}

--- a/cilium-cli/connectivity/builder/host_entity_egress_ccnp.go
+++ b/cilium-cli/connectivity/builder/host_entity_egress_ccnp.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+)
+
+//go:embed manifests/allow-host-entity-egress-ccnp.yaml
+var allowHostEntityEgressCCNPPolicyYAML string
+
+type hostEntityEgressCCNP struct{}
+
+func (t hostEntityEgressCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("host-entity-egress-ccnp", ct).
+		WithCiliumClusterwidePolicy(allowHostEntityEgressCCNPPolicyYAML).
+		WithScenarios(tests.PodToHost()).
+		WithExpectations(func(_ *check.Action) (egress, ingress check.Result) {
+			return check.ResultOK, check.ResultNone
+		})
+}

--- a/cilium-cli/connectivity/builder/host_entity_ingress_ccnp.go
+++ b/cilium-cli/connectivity/builder/host_entity_ingress_ccnp.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+)
+
+//go:embed manifests/allow-host-entity-ingress-ccnp.yaml
+var allowHostEntityIngressCCNPPolicyYAML string
+
+type hostEntityIngressCCNP struct{}
+
+func (t hostEntityIngressCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	
+	newTest("host-entity-ingress-ccnp", ct).
+		WithCiliumClusterwidePolicy(allowHostEntityIngressCCNPPolicyYAML).
+		WithScenarios(tests.HostToPod())
+}

--- a/cilium-cli/connectivity/builder/manifests/allow-all-egress-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/allow-all-egress-ccnp.yaml
@@ -1,0 +1,12 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-all-egress-ccnp
+spec:
+  endpointSelector: {}
+  egress:
+  - toEndpoints:
+    - {}
+  - toCIDR:
+    - 0.0.0.0/0
+    - ::/0

--- a/cilium-cli/connectivity/builder/manifests/allow-all-except-world-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/allow-all-except-world-ccnp.yaml
@@ -1,0 +1,34 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-all-except-world-ccnp
+spec:
+  endpointSelector: {}
+  egress:
+  - toEntities:
+    - host
+    - remote-node
+    - cluster
+    - init
+    - health
+    - kube-apiserver
+  - toEndpoints:
+      - {}
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+    toEntities:
+      - world
+  ingress:
+  - fromEntities:
+    - host
+    - remote-node
+    - cluster
+    - init
+    - health
+    - kube-apiserver
+  - fromEndpoints:
+    - {}

--- a/cilium-cli/connectivity/builder/manifests/allow-all-ingress-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/allow-all-ingress-ccnp.yaml
@@ -1,0 +1,9 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-all-ingress-ccnp
+spec:
+  endpointSelector: {}
+  ingress:
+  - fromEndpoints:
+    - {}

--- a/cilium-cli/connectivity/builder/manifests/allow-cluster-entity-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/allow-cluster-entity-ccnp.yaml
@@ -1,0 +1,11 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "entity-cluster-ccnp"
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+    - toEntities:
+        - cluster

--- a/cilium-cli/connectivity/builder/manifests/allow-host-entity-egress-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/allow-host-entity-egress-ccnp.yaml
@@ -1,0 +1,11 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "host-cluster-egress-ccnp"
+spec:
+  endpointSelector:
+    matchLabels: {}
+  egress:
+    - toEntities:
+        - host
+        - remote-node

--- a/cilium-cli/connectivity/builder/manifests/allow-host-entity-ingress-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/allow-host-entity-ingress-ccnp.yaml
@@ -1,0 +1,11 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "host-cluster-ingress-ccnp"
+spec:
+  endpointSelector:
+    matchLabels: {}
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-cidr-external-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-cidr-external-ccnp.yaml
@@ -1,0 +1,14 @@
+# This policy allows packets towards {{.ExternalIP}}, but not {{.ExternalOtherIP}}.
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-egress-to-cidr-ccnp
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toCIDRSet:
+    - cidr: "{{.ExternalCIDR}}"
+      except:
+      - "{{ .ExternalOtherIP | ipToCIDR }}"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-cidr-external-deny-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-cidr-external-deny-ccnp.yaml
@@ -1,0 +1,13 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-egress-to-cidr-deny-ccnp
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egressDeny:
+  - toCIDRSet:
+    - cidr: "{{.ExternalCIDR}}"
+      except:
+        - "{{.ExternalIP | ipToCIDR }}"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-allow.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-allow.yaml
@@ -1,0 +1,17 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-to-echo-allow
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        kind: echo

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-ccnp.yaml
@@ -1,0 +1,35 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-egress-to-echo-ccnp
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        kind: echo
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+    toEndpoints:
+    - matchExpressions:
+      - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
+      - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+    toEntities:
+    - world

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-deny-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-deny-ccnp.yaml
@@ -1,0 +1,17 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-egress-to-echo-deny-ccnp
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egressDeny:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        kind: echo

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-deny-port-range-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-deny-port-range-ccnp.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-egress-to-echo-deny-port-range-ccnp
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egressDeny:
+  - toPorts:
+    - ports:
+      - port: "4096"
+        endPort: 8191
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        kind: echo

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-ccnp.yaml
@@ -1,0 +1,17 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-egress-to-echo-expression-ccnp
+spec:
+  endpointSelector:
+    matchExpressions:
+    - { key: 'other', operator: Exists }
+  egress:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        kind: echo

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-deny-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-deny-ccnp.yaml
@@ -1,0 +1,16 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-egress-to-echo-expression-deny-ccnp
+spec:
+  endpointSelector:
+    matchExpressions:
+    - { key: 'name', operator: In, values: [ 'client' ] }
+  egressDeny:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchExpressions:
+      - { key: 'kind', operator: In, values: [ "echo" ] }

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-deny-port-range-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-deny-port-range-ccnp.yaml
@@ -1,0 +1,17 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-egress-to-echo-expression-deny-port-range-ccnp
+spec:
+  endpointSelector:
+    matchExpressions:
+    - { key: 'name', operator: In, values: [ 'client' ] }
+  egressDeny:
+  - toPorts:
+    - ports:
+      - port: "4096"
+        endPort: 8191
+        protocol: TCP
+    toEndpoints:
+    - matchExpressions:
+      - { key: 'kind', operator: In, values: [ "echo" ] }

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-port-range-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-expression-port-range-ccnp.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-egress-to-echo-expression-port-range-ccnp
+spec:
+  endpointSelector:
+    matchExpressions:
+    - { key: 'other', operator: Exists }
+  egress:
+  - toPorts:
+    - ports:
+      - port: "4196"
+        endPort: 8191
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        kind: echo

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-named-port-deny-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-named-port-deny-ccnp.yaml
@@ -1,0 +1,17 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-ingress-to-echo-named-port-deny-ccnp
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: echo
+  ingressDeny:
+  - toPorts:
+    - ports:
+      - port: "http-8080"
+        protocol: TCP
+    fromEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        name: client

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-service-account-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-service-account-ccnp.yaml
@@ -1,0 +1,17 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-egress-to-echo-service-account-ccnp
+spec:
+  description: "Allow client to endpoint with service account label"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.cilium.k8s.policy.serviceaccount: echo-same-node

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-service-account-deny-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-service-account-deny-ccnp.yaml
@@ -1,0 +1,17 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-egress-to-echo-service-account-deny-ccnp
+spec:
+  description: "Deny client to echo endpoint with service account label"
+  endpointSelector:
+    matchLabels:
+      io.cilium.k8s.policy.serviceaccount: client
+  egressDeny:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.cilium.k8s.policy.serviceaccount: echo-same-node

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-service-account-deny-port-range-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-service-account-deny-port-range-ccnp.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-egress-to-echo-service-account-deny-port-range-ccnp
+spec:
+  description: "Deny client port range to echo endpoint with service account label"
+  endpointSelector:
+    matchLabels:
+      io.cilium.k8s.policy.serviceaccount: client
+  egressDeny:
+  - toPorts:
+    - ports:
+      - port: "4096"
+        endPort: 8191
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.cilium.k8s.policy.serviceaccount: echo-same-node

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-service-account-port-range-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-service-account-port-range-ccnp.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-egress-to-echo-service-account-port-range-ccnp
+spec:
+  description: "Allow client to port range endpoint with service account label"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "4096"
+        endPort: 8191
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.cilium.k8s.policy.serviceaccount: echo-same-node

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-entities-world-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-entities-world-ccnp.yaml
@@ -1,0 +1,43 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-egress-to-entities-world-ccnp
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+  - toEndpoints:
+    - matchExpressions:
+      - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
+      - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+  - toEndpoints:
+    - matchExpressions:
+      - { key: 'dns.operator.openshift.io/daemonset-dns', operator: Exists }
+      - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "openshift-dns" ] }
+    toPorts:
+    - ports:
+      - port: "5353"
+        protocol: UDP
+      - port: "5353"
+        protocol: TCP
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+    toEntities:
+    - world

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-entities-world-port-range-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-entities-world-port-range-ccnp.yaml
@@ -1,0 +1,44 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-egress-to-entities-world-port-range-ccnp
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: "64"
+        endPort: 127
+        protocol: TCP
+  - toEndpoints:
+    - matchExpressions:
+      - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
+      - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+  - toEndpoints:
+    - matchExpressions:
+      - { key: 'dns.operator.openshift.io/daemonset-dns', operator: Exists }
+      - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "openshift-dns" ] }
+    toPorts:
+    - ports:
+      - port: "5353"
+        protocol: UDP
+      - port: "5353"
+        protocol: TCP
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+    toEntities:
+    - world

--- a/cilium-cli/connectivity/builder/manifests/client-ingress-from-client2-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-ingress-from-client2-ccnp.yaml
@@ -1,0 +1,12 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-ingress-from-client2-ccnp
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        other: client

--- a/cilium-cli/connectivity/builder/manifests/client-with-service-account-egress-to-echo-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-with-service-account-egress-to-echo-ccnp.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-with-service-account-egress-to-echo-ccnp
+spec:
+  description: "Allow client with service account endpoint selector to echo service"
+  endpointSelector:
+    matchLabels:
+      io.cilium.k8s.policy.serviceaccount: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        kind: echo

--- a/cilium-cli/connectivity/builder/manifests/client-with-service-account-egress-to-echo-deny-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-with-service-account-egress-to-echo-deny-ccnp.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-with-service-account-egress-to-echo-deny-ccnp
+spec:
+  description: "Deny client with service account endpoint selector to echo service"
+  endpointSelector:
+    matchLabels:
+      io.cilium.k8s.policy.serviceaccount: client
+  egressDeny:
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        kind: echo

--- a/cilium-cli/connectivity/builder/manifests/client-with-service-account-egress-to-echo-deny-port-range-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-with-service-account-egress-to-echo-deny-port-range-ccnp.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-with-service-account-egress-to-echo-deny-port-range-ccnp
+spec:
+  description: "Deny client port range with service account endpoint selector to echo service"
+  endpointSelector:
+    matchLabels:
+      io.cilium.k8s.policy.serviceaccount: client
+  egressDeny:
+  - toPorts:
+    - ports:
+      - port: "4096"
+        endPort: 8191
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        kind: echo

--- a/cilium-cli/connectivity/builder/manifests/client-with-service-account-egress-to-echo-port-range-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-with-service-account-egress-to-echo-port-range-ccnp.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-with-service-account-egress-to-echo-port-range-ccnp
+spec:
+  description: "Allow client port range with service account endpoint selector to echo service"
+  endpointSelector:
+    matchLabels:
+      io.cilium.k8s.policy.serviceaccount: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "4096"
+        endPort: 8191
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: cilium-test
+        kind: echo

--- a/cilium-cli/connectivity/builder/manifests/deny-all-egress-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/deny-all-egress-ccnp.yaml
@@ -1,0 +1,8 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "all-egress-deny-ccnp"
+spec:
+  endpointSelector: {}
+  egress:
+    - {}

--- a/cilium-cli/connectivity/builder/manifests/deny-all-ingress-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/deny-all-ingress-ccnp.yaml
@@ -1,0 +1,8 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "all-ingress-deny-ccnp"
+spec:
+  endpointSelector: {}
+  ingress:
+    - {}

--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-from-other-client-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-from-other-client-ccnp.yaml
@@ -1,0 +1,13 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: echo-ingress-from-other-client-ccnp
+spec:
+  description: "Allow other client to contact echo"
+  endpointSelector:
+    matchLabels:
+      kind: echo
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        other: client

--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-from-other-client-deny-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-from-other-client-deny-ccnp.yaml
@@ -1,0 +1,13 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: echo-ingress-from-other-client-deny-ccnp
+spec:
+  description: "Deny other client to contact echo"
+  endpointSelector:
+    matchLabels:
+      kind: echo
+  ingressDeny:
+  - fromEndpoints:
+    - matchLabels:
+        other: client

--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-icmp-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-icmp-ccnp.yaml
@@ -1,0 +1,19 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-ingress-from-client2-icmp-ccnp
+spec:
+  description: "Allow other client to contact another client via ICMP"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        other: client
+    icmps:
+    - fields:
+      - family: IPv4
+        type: 8
+      - family: IPv6
+        type: 128

--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-icmp-deny-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-icmp-deny-ccnp.yaml
@@ -1,0 +1,19 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: client-ingress-from-other-client-icmp-deny-ccnp
+spec:
+  description: "Deny other client to contact another client via ICMP"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  ingressDeny:
+  - fromEndpoints:
+    - matchLabels:
+        other: client
+    icmps:
+    - fields:
+      - family: IPv4
+        type: 8
+      - family: IPv6
+        type: 128

--- a/cilium-cli/connectivity/builder/to_cidr_external_ccnp.go
+++ b/cilium-cli/connectivity/builder/to_cidr_external_ccnp.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+
+type toCidrExternalCCNP struct{}
+
+func (t toCidrExternalCCNP) build(ct *check.ConnectivityTest, templates map[string]string) {
+	newTest("to-cidr-external-ccnp", ct).
+		WithCiliumClusterwidePolicy(templates["clientEgressToCIDRExternalCCNPPolicyYAML"]).
+		WithScenarios(
+			tests.PodToCIDR(tests.WithRetryDestIP(ct.Params().ExternalIP)),
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Destination().Address(features.IPFamilyV4) == ct.Params().ExternalOtherIP {
+				return check.ResultDropCurlTimeout, check.ResultNone
+			}
+			return check.ResultOK, check.ResultNone
+		})
+}

--- a/cilium-cli/connectivity/builder/to_entities_world_ccnp.go
+++ b/cilium-cli/connectivity/builder/to_entities_world_ccnp.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/client-egress-to-entities-world-ccnp.yaml
+var clientEgressToEntitiesWorldCCNPPolicyYAML string
+
+//go:embed manifests/client-egress-to-entities-world-port-range-ccnp.yaml
+var clientEgressToEntitiesWorldCCNPPolicyPortRangeYAML string
+
+type toEntitiesWorldCCNP struct{}
+
+func (t toEntitiesWorldCCNP) build(ct *check.ConnectivityTest, _ map[string]string) {
+	toEntitiesWorldCCNPTest(ct, false)
+	if ct.Features[features.PortRanges].Enabled {
+		toEntitiesWorldCCNPTest(ct, true)
+	}
+}
+
+func toEntitiesWorldCCNPTest(ct *check.ConnectivityTest, portRanges bool) {
+	testName := "to-entities-world-ccnp"
+	policyYAML := clientEgressToEntitiesWorldCCNPPolicyYAML
+	if portRanges {
+		testName = "to-entities-world-port-range-ccnp"
+		policyYAML = clientEgressToEntitiesWorldCCNPPolicyPortRangeYAML
+	}
+	newTest(testName, ct).
+		WithCiliumClusterwidePolicy(policyYAML).
+		WithScenarios(tests.PodToWorld(tests.WithRetryDestPort(80))).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Destination().Port() == 80 {
+				return check.ResultOK, check.ResultNone
+			}
+			return check.ResultDropCurlTimeout, check.ResultNone
+		})
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

 This PR adds a set of Cilium Cluster wide network policy end to end connectivity tests that are the same tests as the ones that were previously added for Cilium Network Policies but with the difference of Cilium Cluster wide Network Policies. This is to test the coverage of CCNPS on cilium enabled clusters. An additional 2 tests were added to test both Cilium Cluster wide Network Policies and Cilium Network Policies working additively. Tested these on a kind cilium version v1.16.5 cluster singlestack, dualstack and various aks clusters

Fixes: 37036 in https://github.com/cilium/cilium/issues/37036 & #2900 in cilium/cilium-cli https://github.com/cilium/cilium-cli/issues/2900 (these were issues created by me previously to inform that I will be working on this)

```release-note
Addition of Cilium Clusterwide Network Policy Tests that are the same test cases as Cilium Network Policy Tests for CCNP coverage, and two tests that have both CCNPS and CNPS for multipolicy coverage
```
