### PR TITLE
agent: defend against null pointer refs in cecManager.getEndpoint()

### DIFF
--- a/pkg/ciliumenvoyconfig/cec_manager.go
+++ b/pkg/ciliumenvoyconfig/cec_manager.go
@@ -272,7 +272,7 @@ func (r *cecManager) getEndpoint(serviceName string, serviceNamespace string) (*
 	iter := store.IterKeys()
 	for iter.Next() {
 		e, _, _ := store.GetByKey(iter.Key())
-		if e.EndpointSliceID.ServiceID.Name == serviceName &&
+		if e != nil && e.EndpointSliceID.ServiceID.Name == serviceName &&
 			e.EndpointSliceID.ServiceID.Namespace == serviceNamespace {
 			if res == nil {
 				res = e.DeepCopy()


### PR DESCRIPTION
Currently, if another thread deletes an entry from the Endpoint store while getEndpoint is iterating over the keys, it can result in a segfault+panic. This change adds some light bounds-checking to eliminate that possibility.

Fixes: #37187

```release-note
agent: defend against null pointer refs in cecManager.getEndpoint()
```
