### PR TITLE
Fix service id exceeds max limit

### DIFF
--- a/cilium-dbg/cmd/service_update.go
+++ b/cilium-dbg/cmd/service_update.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/service"
 )
 
 var (
@@ -119,6 +120,11 @@ func updateService(cmd *cobra.Command, args []string) {
 	warnIdTypeDeprecation()
 
 	id := int64(idU)
+	maxID := int64(service.MaxSetOfServiceID)
+	if id > maxID {
+		Fatalf("Service ID %d exceeds the maximum limit of %d", id, maxID)
+	}
+
 	fa := parseFrontendAddress(protocol, frontend)
 	skipFrontendCheck := false
 

--- a/pkg/service/service_api_handler.go
+++ b/pkg/service/service_api_handler.go
@@ -68,6 +68,7 @@ func (h *putServiceIDHandler) Handle(params serviceapi.PutServiceIDParams) middl
 
 	h.logger.WithField(logfields.Params, logfields.Repr(params)).Debug("PUT /service/{id} request")
 
+	maxID := int64(MaxSetOfServiceID)
 	if params.Config.ID == 0 {
 		if !params.Config.UpdateServices {
 			return api.Error(serviceapi.PutServiceIDFailureCode, fmt.Errorf("invalid service ID 0"))
@@ -84,6 +85,9 @@ func (h *putServiceIDHandler) Handle(params serviceapi.PutServiceIDParams) middl
 			return api.Error(serviceapi.PutServiceIDUpdateBackendFailureCode, err)
 		}
 		return serviceapi.NewPutServiceIDOK()
+	} else if params.Config.ID > maxID {
+		return api.Error(serviceapi.PutServiceIDFailureCode, fmt.Errorf("service ID %d exceeds the maximum limit of %d",
+			params.Config.ID, maxID))
 	}
 
 	f, err := loadbalancer.NewL3n4AddrFromModel(params.Config.FrontendAddress)


### PR DESCRIPTION
The maximum service id is 65535 due to the limit of __u16 rev_nat_index. the service command line and service api handler do not check the maximum id. this patch checks the maximum service id.

Fixes: #32758