### PR TITLE
cilium-cli: add IPv6 connectivity test for LocalRedirectPolicy

### DIFF
--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-cidr-lrp-frontend-deny.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-cidr-lrp-frontend-deny.yaml
@@ -13,3 +13,4 @@ spec:
   egressDeny:
   - toCIDRSet:
     - cidr: 169.254.169.255/32
+    - cidr: fd00::169:254:169:255/128


### PR DESCRIPTION
Modified LRP connectivity test for IPv6.

Fixes: #36960 
