### PR TITLE
CODEOWNERS: adjust ownership of the pkg/crypto subpackages

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -499,7 +499,8 @@ Makefile* @cilium/build
 /pkg/container/set/ @cilium/sig-policy
 /pkg/controller @cilium/sig-agent
 /pkg/counter @cilium/sig-datapath
-/pkg/crypto/ @cilium/sig-hubble @cilium/sig-policy
+/pkg/crypto/certificatemanager @cilium/envoy @cilium/sig-servicemesh
+/pkg/crypto/certloader @cilium/sig-hubble
 /pkg/datapath/ @cilium/sig-datapath
 /pkg/datapath/fake/ipsec.go @cilium/ipsec
 /pkg/datapath/linux/config/ @cilium/loader


### PR DESCRIPTION
The `pkg/crypto/certloader` was originally contributed by SIG Hubble and is still mostly used and maintained by the Hubble team today. However, the `pkg/crypto/certificatemanager` package was contributed by the SIG Envoy team and is mostly relevant to them.

In order to pull in the right people for code reviews, adjust the ownership of both packages with better granularity.

See also https://github.com/cilium/cilium/pull/37076#issuecomment-2609437742
