### PR TITLE
gha: Fix feature test artifact upload

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -563,11 +563,7 @@ jobs:
           cat <<EOF > run-in-lvm.sh
           #!/usr/bin/env bash
           ./cilium-cli features status -o markdown --output-file="feature-status.md"
-          ./cilium-cli features status -o json --output-file="${1}.json"
-          cd /host
-          if ! find /host/test/test_results -type f -iname 'feature-status-*.json' | grep -q .; then
-            exit 0
-          fi
+          ./cilium-cli features status -o json --output-file="feature-status-${1}.json"
           find . -type f -iname 'feature-status-*.json' | while IFS= read -r file; do
             mv "\$file" "./${{ env.job_name }}-\${file##*/feature-status-}"
           done


### PR DESCRIPTION
### Description 

This is to fix make sure the features tested file artifact is upload,
two changes are done in this commit:

- Remove `find /host/test/test_results` block, as this is mainly for
  ginkgo tests but not connectivity tests.
- Add prefix `feature-status-` for json output.

Sample failure: https://github.com/cilium/cilium/actions/runs/12941992870

Signed-off-by: Tam Mach <tam.mach@cilium.io>

----

Testing was done in https://github.com/cilium/cilium/actions/runs/12948198313