### PR TITLE
workflow: add cilium-runtime image as env variable

### DIFF
--- a/.github/actions/set-env-variables/action.yml
+++ b/.github/actions/set-env-variables/action.yml
@@ -25,7 +25,9 @@ runs:
         # renovate: datasource=docker
         KIND_K8S_IMAGE="quay.io/cilium/kindest-node:v1.32.0@sha256:22cf2864f90cfab0d442fda2decf2eae107edd03483053a902614dec637eff76"
         KIND_K8S_VERSION=$(echo "$KIND_K8S_IMAGE" | sed -r 's|.+:(v[0-9a-z.-]+)(@.+)?|\1|')
+        CILIUM_RUNTIME_IMAGE="quay.io/cilium/cilium-runtime:38f4286a000b2326b614bf880d29f153585b9ebf@sha256:1deea3508c08fe23b5ff686f84902558c0cef80ec213404aa94702589d3c2da4"
 
+        echo "CILIUM_RUNTIME_IMAGE=$CILIUM_RUNTIME_IMAGE" >> $GITHUB_ENV
         echo "KIND_VERSION=$KIND_VERSION" >> $GITHUB_ENV
         echo "KIND_K8S_IMAGE=$KIND_K8S_IMAGE" >> $GITHUB_ENV
         echo "KIND_K8S_VERSION=$KIND_K8S_VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
This commit adds cilium-runtime as environment variable in the $GITHUB_ENV context.

This will help us investigate https://github.com/cilium/cilium/issues/37155 and find out a way to move forward with the whole feature. With this merged we'll be able to test properly the workflow and carry on the feature without breaking hubble-relay image again.

```release-note
adds cilium-runtime as environment variable
```
