### PR TITLE
pkg/endpoint: reduce missed-policy-update severity when safe

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -664,7 +664,14 @@ func (e *Endpoint) UpdatePolicy(idsToRegen *set.Set[identityPkg.NumericIdentity]
 	// bump the policy revision directly (as long as we didn't miss an update somehow).
 	if !idsToRegen.Has(secID) {
 		if e.policyRevision < fromRev {
-			e.getLogger().WithField(logfields.PolicyRevision, fromRev).Warn("Endpoint missed a policy revision; triggering regeneration")
+			if e.state == StateWaitingToRegenerate {
+				// We can log this at less severity since a regeneration was already queued.
+				// This can happen if two policy updates come in quick succession, with the first
+				// affecting this endpoint and the second not.
+				e.getLogger().WithField(logfields.PolicyRevision, fromRev).Info("Endpoint missed a policy revision; triggering regeneration")
+			} else {
+				e.getLogger().WithField(logfields.PolicyRevision, fromRev).Warn("Endpoint missed a policy revision; triggering regeneration")
+			}
 		} else {
 			e.getLogger().WithField(logfields.PolicyRevision, toRev).Debug("Policy update is a no-op, bumping policyRevision")
 			e.setPolicyRevision(toRev)


### PR DESCRIPTION
Normally we warn if, somehow, the policy state machine encountered an unexpected transition. This could indicate a bug in revision tracking, which would obviously be bad.

However, since regenerations are coalesced, there is a specific sequence of events that can hit this case without indicating a bug:

1. Endpoint regen is queued for some other reasion
2. Policy is updated, and endpoint is affected. No regen queued
3. Policy is updated, but endpoint is not affected

When we hit step 3, we are trying to bump the EP from policy revision 2 to 3, but it's still at revision 1. Thus we warn. However, since a regeneration is already queued, we haven't actually missed anything and it's safe not to warn.

Fixes: #36493

(FYI, cleaning up regenerations as described in https://github.com/cilium/cilium/issues/37209 will also help this general confusion, since coalesced regenerations are non blocking)