### PR TITLE
v1.14 Backports 2025-01-24

### DIFF
--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -118,15 +118,12 @@ jobs:
           echo "Generated matrix:"
           cat /tmp/matrix.json
 
-      # We use latest eksctl just to fetch recent supported versions.
-      # We don't use that eksctl to create cluster.
-      # Eksctl has hardcoded list of supported versions in the binary.
-      # This is hack until https://github.com/aws/containers-roadmap/issues/982 is resolved.
-      - name: Install eksctl CLI
-        run: |
-          curl -LO "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz"
-          sudo tar xzvfC eksctl_$(uname -s)_amd64.tar.gz /usr/bin
-          rm eksctl_$(uname -s)_amd64.tar.gz
+      - name: Set up AWS CLI credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_PR_SA_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_PR_SA_KEY }}
+          aws-region: us-west-1
 
       - name: Filter Matrix
         id: set-matrix
@@ -134,7 +131,7 @@ jobs:
           cp /tmp/matrix.json /tmp/result.json
           jq -c '.include[]' /tmp/matrix.json | while read i; do
             VERSION=$(echo $i | jq -r '.version')
-            eksctl version -o json | jq -r '.EKSServerSupportedVersions[]' > /tmp/output
+            aws eks describe-cluster-versions | jq -r '.clusterVersions[].clusterVersion' > /tmp/output
             if grep -q -F $VERSION /tmp/output; then
               echo "Version $VERSION is supported"
             else

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -118,15 +118,12 @@ jobs:
           echo "Generated matrix:"
           cat /tmp/matrix.json
 
-      # We use latest eksctl just to fetch recent supported versions.
-      # We don't use that eksctl to create cluster.
-      # Eksctl has hardcoded list of supported versions in the binary.
-      # This is hack until https://github.com/aws/containers-roadmap/issues/982 is resolved.
-      - name: Install eksctl CLI
-        run: |
-          curl -LO "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz"
-          sudo tar xzvfC eksctl_$(uname -s)_amd64.tar.gz /usr/bin
-          rm eksctl_$(uname -s)_amd64.tar.gz
+      - name: Set up AWS CLI credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_PR_SA_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_PR_SA_KEY }}
+          aws-region: us-west-1
 
       - name: Filter Matrix
         id: set-matrix
@@ -134,7 +131,7 @@ jobs:
           cp /tmp/matrix.json /tmp/result.json
           jq -c '.include[]' /tmp/matrix.json | while read i; do
             VERSION=$(echo $i | jq -r '.version')
-            eksctl version -o json | jq -r '.EKSServerSupportedVersions[]' > /tmp/output
+            aws eks describe-cluster-versions | jq -r '.clusterVersions[].clusterVersion' > /tmp/output
             if grep -q -F $VERSION /tmp/output; then
               echo "Version $VERSION is supported"
             else


### PR DESCRIPTION
 * [x] #37210 (@sayboras)
 
 Test runs are as per below
 
aws-cni: https://github.com/cilium/cilium/actions/runs/12939637966
ci-eks: https://github.com/cilium/cilium/actions/runs/12939638525

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 37210
```
