### PR TITLE
[v1.15] gha: Retrieve eks supported version via aws cli

### DIFF
--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -119,15 +119,9 @@ jobs:
       - name: Set up AWS CLI credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          role-to-assume: ${{ secrets.AWS_PR_ASSUME_ROLE }}
+          aws-access-key-id: ${{ secrets.AWS_PR_SA_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_PR_SA_KEY }}
           aws-region: us-west-1
-
-      - name: Run aws configure
-        run: |
-          aws configure set aws_access_key_id ${{ env.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ env.AWS_SECRET_ACCESS_KEY }}
-          aws configure set aws_session_token ${{ env.AWS_SESSION_TOKEN }}
-          aws configure set default.region ${{ env.AWS_REGION }}
 
       - name: Filter Matrix
         id: set-matrix

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -119,15 +119,9 @@ jobs:
       - name: Set up AWS CLI credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          role-to-assume: ${{ secrets.AWS_PR_ASSUME_ROLE }}
+          aws-access-key-id: ${{ secrets.AWS_PR_SA_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_PR_SA_KEY }}
           aws-region: us-west-1
-
-      - name: Run aws configure
-        run: |
-          aws configure set aws_access_key_id ${{ env.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ env.AWS_SECRET_ACCESS_KEY }}
-          aws configure set aws_session_token ${{ env.AWS_SESSION_TOKEN }}
-          aws configure set default.region ${{ env.AWS_REGION }}
 
       - name: Filter Matrix
         id: set-matrix


### PR DESCRIPTION
 * [x] #37210 (@sayboras)
    * Note: This is to align the way we are doing aws login for 1.15 branch 

Testing was done with below runs

ci-eks: https://github.com/cilium/cilium/actions/runs/12939643144/job/36092353938
aws-cni: https://github.com/cilium/cilium/actions/runs/12939642894

