### PR TITLE
Add cli connectivity test for NodePort traffic to host netns pods

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -40,13 +40,14 @@ func newCmdConnectivity(hooks api.Hooks) *cobra.Command {
 }
 
 var params = check.Parameters{
-	ExternalDeploymentPort: 8080,
-	EchoServerHostPort:     4000,
-	JunitProperties:        make(map[string]string),
-	NamespaceLabels:        make(map[string]string),
-	NamespaceAnnotations:   make(map[string]string),
-	NodeSelector:           make(map[string]string),
-	Writer:                 os.Stdout,
+	ExternalDeploymentPort:  8080,
+	EchoServerHostPort:      4000,
+	EchoServerHostNetNsPort: 5000,
+	JunitProperties:         make(map[string]string),
+	NamespaceLabels:         make(map[string]string),
+	NamespaceAnnotations:    make(map[string]string),
+	NodeSelector:            make(map[string]string),
+	Writer:                  os.Stdout,
 	SysdumpOptions: sysdump.Options{
 		LargeSysdumpAbortTimeout: sysdump.DefaultLargeSysdumpAbortTimeout,
 		LargeSysdumpThreshold:    sysdump.DefaultLargeSysdumpThreshold,
@@ -338,6 +339,7 @@ func newConnectivityTests(
 		}
 		params.ExternalDeploymentPort += i
 		params.EchoServerHostPort += i
+		params.EchoServerHostNetNsPort += i
 		cc, err := check.NewConnectivityTest(k8sClient, params, hooks, logger, owners)
 		if err != nil {
 			return nil, err

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -275,6 +275,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		clusterMeshEndpointSliceSync{},
 		health{},
 		northSouthLoadbalancing{},
+		northSouthLoadbalancingWithHostNetNs{},
 		podToPodEncryption{},
 		podToPodEncryptionV2{},
 		nodeToNodeEncryption{},

--- a/cilium-cli/connectivity/builder/north_south_loadbalancing_with_host_netns.go
+++ b/cilium-cli/connectivity/builder/north_south_loadbalancing_with_host_netns.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+	"github.com/cilium/cilium/pkg/versioncheck"
+)
+
+type northSouthLoadbalancingWithHostNetNs struct{}
+
+func (t northSouthLoadbalancingWithHostNetNs) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("north-south-loadbalancing-with-host-netns", ct).
+		WithCondition(func() bool {
+			return versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion)
+		}).
+		WithFeatureRequirements(
+			withKPRReqForMultiCluster(ct, features.RequireEnabled(features.NodeWithoutCilium))...,
+		).
+		WithScenarios(tests.OutsideToNodePortForHostNetNs())
+}

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -111,6 +111,7 @@ type Parameters struct {
 	ExternalOtherIPv6         string
 	ServiceType               string
 	EchoServerHostPort        int
+	EchoServerHostNetNsPort   int
 	PodCIDRs                  []podCIDRs
 	NodeCIDRs                 []string
 	ControlPlaneCIDRs         []string

--- a/cilium-cli/connectivity/tests/service.go
+++ b/cilium-cli/connectivity/tests/service.go
@@ -298,6 +298,40 @@ func (s *outsideToNodePort) Run(ctx context.Context, t *check.Test) {
 	}
 }
 
+// OutsideToNodePortForHostNetNs sends an HTTP request from client pod running on a node w/o
+// Cilium to NodePort services in front of a hostnetwork pod.
+func OutsideToNodePortForHostNetNs() check.Scenario {
+	return &outsideToNodePortForHostNetNs{
+		ScenarioBase: check.NewScenarioBase(),
+	}
+}
+
+type outsideToNodePortForHostNetNs struct {
+	check.ScenarioBase
+}
+
+func (s *outsideToNodePortForHostNetNs) Name() string {
+	return "outside-to-nodeport-for-host-netns"
+}
+
+func (s *outsideToNodePortForHostNetNs) Run(ctx context.Context, t *check.Test) {
+	clientPod := t.Context().HostNetNSPodsByNode()[t.NodesWithoutCilium()[0]]
+	i := 0
+
+	// With kube-proxy doing N/S LB it is not possible to see the original client
+	// IP, as iptables rules do the LB SNAT/DNAT before the packet hits any
+	// of Cilium's datapath BPF progs. So, skip the flow validation in that case.
+	status, ok := t.Context().Feature(features.KPRNodePort)
+	validateFlows := ok && status.Enabled
+
+	for _, svc := range t.Context().EchoHostNetNsServices() {
+		for _, node := range t.Context().Nodes() {
+			curlNodePort(ctx, s, t, fmt.Sprintf("curl-%d", i), &clientPod, svc, node, validateFlows, t.Context().Params().SecondaryNetworkIface != "")
+			i++
+		}
+	}
+}
+
 // OutsideToIngressService sends an HTTP request from client pod running on a node w/o
 // Cilium to NodePort services.
 func OutsideToIngressService() check.Scenario {


### PR DESCRIPTION
Add necessary context scaffolding and extend the north-south lb connectivity test to validate traffic to services backed by hostNetwork pods.

Ensures no future regressions from #36901
