### PR TITLE
Update RTD theme commit hash to fix slack url

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -64,7 +64,7 @@ jobs:
           # Needed to detect missing redirects
           fetch-depth: 0
       - name: Build HTML
-        uses: docker://quay.io/cilium/docs-builder:550ca417f5dc0b13fa7f117cc117443b23120f5e@sha256:febb1339085d9bcabcfd547ab2125e67e1c6468f0bc33f62f9326e790efb938a
+        uses: docker://quay.io/cilium/docs-builder:5f497e3f4c73f217a780c8038f9174ceabfabe57@sha256:37105a84068e427116bad64f8812ef5f4239812fd4f085252901b4c7cddb48af
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -3,7 +3,7 @@ Sphinx==7.1.2
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@84a34e7f301e9bfed5330da9acdb65d62020af4d
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@3047cc4ad7aca4ed6184b6b40658910af2130f4d
 # We use semver to parse Cilium's version in the config file
 semver==3.0.1
 # Sphinx extensions


### PR DESCRIPTION
This commit updates the commit hash for the read the docs theme to use a newer commit pointing the slack URL in the docs to current slack.cilium.io.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)

