### PR TITLE
cilium-cli: extend no-interrupted-connections to test NodePort from outside

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -175,6 +175,8 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.ConnDisruptTestRestartsPath, "conn-disrupt-test-restarts-path", "/tmp/cilium-conn-disrupt-restarts", "Conn disrupt test temporary result file (used internally)")
 	cmd.Flags().StringVar(&params.ConnDisruptTestXfrmErrorsPath, "conn-disrupt-test-xfrm-errors-path", "/tmp/cilium-conn-disrupt-xfrm-errors", "Conn disrupt test temporary result file (used internally)")
 	cmd.Flags().DurationVar(&params.ConnDisruptDispatchInterval, "conn-disrupt-dispatch-interval", 0, "TCP packet dispatch interval")
+	cmd.Flags().BoolVar(&params.SkipConnDisruptTestNSTraffic, "skip-conn-disrupt-test-ns-traffic", false, "Skip conn disrupt test for NS traffic")
+	cmd.Flags().MarkHidden("skip-conn-disrupt-test-ns-traffic")
 
 	cmd.Flags().StringSliceVar(&params.ExpectedDropReasons, "expected-drop-reasons", defaults.ExpectedDropReasons, "List of expected drop reasons")
 	cmd.Flags().MarkHidden("expected-drop-reasons")

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -94,6 +94,7 @@ type Parameters struct {
 
 	IncludeConnDisruptTest        bool
 	ConnDisruptTestSetup          bool
+	SkipConnDisruptTestNSTraffic  bool
 	ConnDisruptTestRestartsPath   string
 	ConnDisruptTestXfrmErrorsPath string
 	ConnDisruptDispatchInterval   time.Duration

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1297,5 +1297,7 @@ func (ct *ConnectivityTest) ForEachIPFamily(hasNetworkPolicies bool, do func(fea
 func (ct *ConnectivityTest) ShouldRunConnDisruptNSTraffic() bool {
 	return !ct.params.SkipConnDisruptTestNSTraffic &&
 		ct.Features[features.NodeWithoutCilium].Enabled &&
-		(ct.Params().MultiCluster == "" || ct.Features[features.KPRNodePort].Enabled)
+		(ct.Params().MultiCluster == "" || ct.Features[features.KPRNodePort].Enabled) &&
+		!ct.Features[features.KPRNodePortAcceleration].Enabled &&
+		(!ct.Features[features.IPsecEnabled].Enabled || !ct.Features[features.KPRNodePort].Enabled)
 }

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1295,6 +1295,7 @@ func (ct *ConnectivityTest) ForEachIPFamily(hasNetworkPolicies bool, do func(fea
 }
 
 func (ct *ConnectivityTest) ShouldRunConnDisruptNSTraffic() bool {
-	return ct.Features[features.NodeWithoutCilium].Enabled &&
+	return !ct.params.SkipConnDisruptTestNSTraffic &&
+		ct.Features[features.NodeWithoutCilium].Enabled &&
 		(ct.Params().MultiCluster == "" || ct.Features[features.KPRNodePort].Enabled)
 }

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -5,6 +5,7 @@ package check
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -70,11 +71,17 @@ const (
 	hostNetNSDeploymentNameNonCilium = "host-netns-non-cilium" // runs on non-Cilium test nodes
 	kindHostNetNS                    = "host-netns"
 
-	testConnDisruptClientDeploymentName = "test-conn-disrupt-client"
-	testConnDisruptServerDeploymentName = "test-conn-disrupt-server"
-	testConnDisruptServiceName          = "test-conn-disrupt"
-	testConnDisruptCNPName              = "test-conn-disrupt"
-	KindTestConnDisrupt                 = "test-conn-disrupt"
+	testConnDisruptClientDeploymentName          = "test-conn-disrupt-client"
+	testConnDisruptClientNSTrafficDeploymentName = "test-conn-disrupt-client"
+	testConnDisruptServerDeploymentName          = "test-conn-disrupt-server"
+	testConnDisruptServerNSTrafficDeploymentName = "test-conn-disrupt-server-ns-traffic"
+	testConnDisruptServiceName                   = "test-conn-disrupt"
+	testConnDisruptNSTrafficServiceName          = "test-conn-disrupt-ns-traffic"
+	testConnDisruptCNPName                       = "test-conn-disrupt"
+	testConnDisruptNSTrafficCNPName              = "test-conn-disrupt-ns-traffic"
+	testConnDisruptServerNSTrafficAppLabel       = "test-conn-disrupt-server-ns-traffic"
+	KindTestConnDisrupt                          = "test-conn-disrupt"
+	KindTestConnDisruptNSTraffic                 = "test-conn-disrupt-ns-traffic"
 
 	bwPrioAnnotationString = "bandwidth.cilium.io/priority"
 )
@@ -448,6 +455,41 @@ func newConnDisruptCNP(ns string) *ciliumv2.CiliumNetworkPolicy {
 	}
 }
 
+func newConnDisruptCNPForNSTraffic(ns string) *ciliumv2.CiliumNetworkPolicy {
+	selector := policyapi.EndpointSelector{
+		LabelSelector: &slimmetav1.LabelSelector{
+			MatchLabels: map[string]string{"kind": KindTestConnDisruptNSTraffic},
+		},
+	}
+
+	ports := []policyapi.PortRule{{
+		Ports: []policyapi.PortProtocol{{
+			Protocol: policyapi.ProtoTCP,
+			Port:     "8000",
+		}},
+	}}
+
+	return &ciliumv2.CiliumNetworkPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       ciliumv2.CNPKindDefinition,
+			APIVersion: ciliumv2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: testConnDisruptNSTrafficCNPName, Namespace: ns},
+		Spec: &policyapi.Rule{
+			EndpointSelector: selector,
+			Ingress: []policyapi.IngressRule{{
+				IngressCommonRule: policyapi.IngressCommonRule{
+					FromEntities: policyapi.EntitySlice{
+						policyapi.EntityWorld,
+						policyapi.EntityRemoteNode,
+					},
+				},
+				ToPorts: ports,
+			}},
+		},
+	}
+}
+
 func (ct *ConnectivityTest) ingresses() map[string]string {
 	ingresses := map[string]string{"same-node": echoSameNodeDeploymentName}
 	if !ct.Params().SingleNode || ct.Params().MultiCluster != "" {
@@ -520,113 +562,25 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	// Deploy test-conn-disrupt actors (only in the first
 	// test namespace in case of tests concurrent run)
 	if ct.params.ConnDisruptTestSetup && ct.params.TestNamespaceIndex == 0 {
-		_, err = ct.clients.src.GetDeployment(ctx, ct.params.TestNamespace, testConnDisruptServerDeploymentName, metav1.GetOptions{})
-		if err != nil {
-			ct.Logf("✨ [%s] Deploying %s deployment...", ct.clients.src.ClusterName(), testConnDisruptServerDeploymentName)
-			readinessProbe := &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					Exec: &corev1.ExecAction{
-						Command: []string{"cat", "/tmp/server-ready"},
-					},
-				},
-				PeriodSeconds:       int32(3),
-				InitialDelaySeconds: int32(1),
-				FailureThreshold:    int32(20),
-			}
-			testConnDisruptServerDeployment := newDeployment(deploymentParameters{
-				Name:           testConnDisruptServerDeploymentName,
-				Kind:           KindTestConnDisrupt,
-				Image:          ct.params.TestConnDisruptImage,
-				Replicas:       3,
-				Labels:         map[string]string{"app": "test-conn-disrupt-server"},
-				Command:        []string{"tcd-server", "8000"},
-				Port:           8000,
-				ReadinessProbe: readinessProbe,
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{corev1.ResourceCPU: *resource.NewMilliQuantity(100, resource.DecimalSI)},
-				},
-			})
-			_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(testConnDisruptServerDeploymentName), metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("unable to create service account %s: %w", testConnDisruptServerDeploymentName, err)
-			}
-			_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, testConnDisruptServerDeployment, metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("unable to create deployment %s: %w", testConnDisruptServerDeployment, err)
-			}
+		if err := ct.createTestConnDisruptServerDeployAndSvc(ctx, testConnDisruptServerDeploymentName, KindTestConnDisrupt, 3,
+			testConnDisruptServiceName, "test-conn-disrupt-server", newConnDisruptCNP); err != nil {
+			return err
 		}
 
-		// Make sure that the server deployment is ready to spread client connections
-		err := WaitForDeployment(ctx, ct, ct.clients.src, ct.params.TestNamespace, testConnDisruptServerDeploymentName)
-		if err != nil {
-			ct.Failf("%s deployment is not ready: %s", testConnDisruptServerDeploymentName, err)
+		if err := ct.createTestConnDisruptClientDeployment(ctx, testConnDisruptClientDeploymentName, KindTestConnDisrupt,
+			"test-conn-disrupt-client", fmt.Sprintf("test-conn-disrupt.%s.svc.cluster.local.:8000", ct.params.TestNamespace),
+			5, false); err != nil {
+			return err
 		}
 
-		for _, client := range ct.Clients() {
-			_, err = client.GetService(ctx, ct.params.TestNamespace, testConnDisruptServiceName, metav1.GetOptions{})
-			if err != nil {
-				ct.Logf("✨ [%s] Deploying %s service...", client.ClusterName(), testConnDisruptServiceName)
-				svc := newService(testConnDisruptServiceName, map[string]string{"app": "test-conn-disrupt-server"}, nil, "http", 8000, ct.Params().ServiceType)
-				svc.ObjectMeta.Annotations = map[string]string{"service.cilium.io/global": "true"}
-				_, err = client.CreateService(ctx, ct.params.TestNamespace, svc, metav1.CreateOptions{})
-				if err != nil {
-					return fmt.Errorf("unable to create service %s: %w", testConnDisruptServiceName, err)
-				}
+		if ct.ShouldRunConnDisruptNSTraffic() {
+			if err := ct.createTestConnDisruptServerDeployAndSvc(ctx, testConnDisruptServerNSTrafficDeploymentName, KindTestConnDisruptNSTraffic, 1,
+				testConnDisruptNSTrafficServiceName, testConnDisruptServerNSTrafficAppLabel, newConnDisruptCNPForNSTraffic); err != nil {
+				return err
 			}
 
-			if enabled, _ := ct.Features.MatchRequirements(features.RequireEnabled(features.CNP)); enabled {
-				ipsec, _ := ct.Features.MatchRequirements(features.RequireMode(features.EncryptionPod, "ipsec"))
-				if ipsec && versioncheck.MustCompile(">=1.14.0 <1.16.0")(ct.CiliumVersion) {
-					// https://github.com/cilium/cilium/issues/36681
-					continue
-				}
-				for _, client := range ct.Clients() {
-					ct.Logf("✨ [%s] Deploying %s CiliumNetworkPolicy...", client.ClusterName(), testConnDisruptCNPName)
-					_, err = client.ApplyGeneric(ctx, newConnDisruptCNP(ct.params.TestNamespace))
-					if err != nil {
-						return fmt.Errorf("unable to create CiliumNetworkPolicy %s: %w", testConnDisruptCNPName, err)
-					}
-				}
-			}
-		}
-
-		_, err = ct.clients.dst.GetDeployment(ctx, ct.params.TestNamespace, testConnDisruptClientDeploymentName, metav1.GetOptions{})
-		if err != nil {
-			ct.Logf("✨ [%s] Deploying %s deployment...", ct.clients.dst.ClusterName(), testConnDisruptClientDeploymentName)
-			readinessProbe := &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					Exec: &corev1.ExecAction{
-						Command: []string{"cat", "/tmp/client-ready"},
-					},
-				},
-				PeriodSeconds:       int32(3),
-				InitialDelaySeconds: int32(1),
-				FailureThreshold:    int32(20),
-			}
-			testConnDisruptClientDeployment := newDeployment(deploymentParameters{
-				Name:     testConnDisruptClientDeploymentName,
-				Kind:     KindTestConnDisrupt,
-				Image:    ct.params.TestConnDisruptImage,
-				Replicas: 5,
-				Labels:   map[string]string{"app": "test-conn-disrupt-client"},
-				Command: []string{
-					"tcd-client",
-					"--dispatch-interval", ct.params.ConnDisruptDispatchInterval.String(),
-					fmt.Sprintf("test-conn-disrupt.%s.svc.cluster.local.:8000", ct.params.TestNamespace),
-				},
-				ReadinessProbe: readinessProbe,
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{corev1.ResourceCPU: *resource.NewMilliQuantity(100, resource.DecimalSI)},
-				},
-			})
-
-			_, err = ct.clients.dst.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(testConnDisruptClientDeploymentName), metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("unable to create service account %s: %w", testConnDisruptClientDeploymentName, err)
-			}
-			_, err = ct.clients.dst.CreateDeployment(ctx, ct.params.TestNamespace, testConnDisruptClientDeployment, metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("unable to create deployment %s: %w", testConnDisruptClientDeployment, err)
+			if err := ct.createTestConnDisruptClientDeploymentForNSTraffic(ctx); err != nil {
+				return err
 			}
 		}
 	}
@@ -1179,6 +1133,255 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	return nil
 }
 
+func (ct *ConnectivityTest) createTestConnDisruptServerDeployAndSvc(ctx context.Context, deployName, kind string, replicas int, svcName, appLabel string,
+	cnpFunc func(ns string) *ciliumv2.CiliumNetworkPolicy) error {
+	_, err := ct.clients.src.GetDeployment(ctx, ct.params.TestNamespace, deployName, metav1.GetOptions{})
+	if err != nil {
+		ct.Logf("✨ [%s] Deploying %s deployment...", ct.clients.src.ClusterName(), deployName)
+		readinessProbe := &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"cat", "/tmp/server-ready"},
+				},
+			},
+			PeriodSeconds:       int32(3),
+			InitialDelaySeconds: int32(1),
+			FailureThreshold:    int32(20),
+		}
+		testConnDisruptServerDeployment := newDeployment(deploymentParameters{
+			Name:           deployName,
+			Kind:           kind,
+			Image:          ct.params.TestConnDisruptImage,
+			Replicas:       replicas,
+			Labels:         map[string]string{"app": appLabel},
+			Command:        []string{"tcd-server", "8000"},
+			Port:           8000,
+			ReadinessProbe: readinessProbe,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceCPU: *resource.NewMilliQuantity(100, resource.DecimalSI)},
+			},
+		})
+		_, err = ct.clients.src.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(deployName), metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to create service account %s: %w", deployName, err)
+		}
+		_, err = ct.clients.src.CreateDeployment(ctx, ct.params.TestNamespace, testConnDisruptServerDeployment, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to create deployment %s: %w", testConnDisruptServerDeployment, err)
+		}
+	}
+
+	// Make sure that the server deployment is ready to spread client connections
+	err = WaitForDeployment(ctx, ct, ct.clients.src, ct.params.TestNamespace, deployName)
+	if err != nil {
+		ct.Failf("%s deployment is not ready: %s", deployName, err)
+	}
+
+	for _, client := range ct.Clients() {
+		_, err = client.GetService(ctx, ct.params.TestNamespace, svcName, metav1.GetOptions{})
+		if err != nil {
+			ct.Logf("✨ [%s] Deploying %s service...", client.ClusterName(), svcName)
+			svc := newService(svcName, map[string]string{"app": appLabel}, nil, "http", 8000, ct.Params().ServiceType)
+			svc.ObjectMeta.Annotations = map[string]string{"service.cilium.io/global": "true"}
+			_, err = client.CreateService(ctx, ct.params.TestNamespace, svc, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create service %s: %w", svcName, err)
+			}
+		}
+
+		if enabled, _ := ct.Features.MatchRequirements(features.RequireEnabled(features.CNP)); enabled {
+			ipsec, _ := ct.Features.MatchRequirements(features.RequireMode(features.EncryptionPod, "ipsec"))
+			if ipsec && versioncheck.MustCompile(">=1.14.0 <1.16.0")(ct.CiliumVersion) {
+				// https://github.com/cilium/cilium/issues/36681
+				continue
+			}
+			for _, client := range ct.Clients() {
+				cnp := cnpFunc(ct.params.TestNamespace)
+				ct.Logf("✨ [%s] Deploying %s CiliumNetworkPolicy...", client.ClusterName(), cnp.Name)
+				_, err = client.ApplyGeneric(ctx, cnp)
+				if err != nil {
+					return fmt.Errorf("unable to create CiliumNetworkPolicy %s: %w", cnp.Name, err)
+				}
+			}
+		}
+	}
+
+	return err
+}
+
+func (ct *ConnectivityTest) createTestConnDisruptClientDeployment(ctx context.Context, deployName, kind, appLabel, address string, replicas int, isExternal bool) error {
+	_, err := ct.clients.dst.GetDeployment(ctx, ct.params.TestNamespace, deployName, metav1.GetOptions{})
+	if err != nil {
+		ct.Logf("✨ [%s] Deploying %s deployment...", ct.clients.dst.ClusterName(), deployName)
+		readinessProbe := &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"cat", "/tmp/client-ready"},
+				},
+			},
+			PeriodSeconds:       int32(3),
+			InitialDelaySeconds: int32(1),
+			FailureThreshold:    int32(20),
+		}
+
+		param := deploymentParameters{
+			Name:     deployName,
+			Kind:     kind,
+			Image:    ct.params.TestConnDisruptImage,
+			Replicas: replicas,
+			Labels:   map[string]string{"app": appLabel},
+			Command: []string{
+				"tcd-client",
+				"--dispatch-interval", ct.params.ConnDisruptDispatchInterval.String(),
+				address,
+			},
+			ReadinessProbe: readinessProbe,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceCPU: *resource.NewMilliQuantity(100, resource.DecimalSI)},
+			},
+		}
+		if isExternal {
+			param.NodeSelector = map[string]string{"cilium.io/no-schedule": "true"}
+			param.HostNetwork = true
+			param.Tolerations = []corev1.Toleration{
+				{Operator: corev1.TolerationOpExists},
+			}
+		}
+		testConnDisruptClientDeployment := newDeployment(param)
+
+		_, err = ct.clients.dst.CreateServiceAccount(ctx, ct.params.TestNamespace, k8s.NewServiceAccount(deployName), metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to create service account %s: %w", deployName, err)
+		}
+		_, err = ct.clients.dst.CreateDeployment(ctx, ct.params.TestNamespace, testConnDisruptClientDeployment, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to create deployment %s: %w", testConnDisruptClientDeployment, err)
+		}
+	}
+
+	return err
+}
+
+func (ct *ConnectivityTest) createTestConnDisruptClientDeploymentForNSTraffic(ctx context.Context) error {
+	nodes, err := ct.getBackendNodeAndNonBackendNode(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, n := range nodes {
+		for _, client := range ct.Clients() {
+			svc, err := client.GetService(ctx, ct.params.TestNamespace, testConnDisruptNSTrafficServiceName, metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to get service %s: %w", testConnDisruptNSTrafficServiceName, err)
+			}
+
+			var errs error
+			np := uint32(svc.Spec.Ports[0].NodePort)
+			addrs := slices.Clone(n.node.Status.Addresses)
+			hasNetworkPolicies, err := ct.hasNetworkPolicies(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to check if any netpol exists: %w", err)
+			}
+			ct.ForEachIPFamily(hasNetworkPolicies, func(family features.IPFamily) {
+				for _, addr := range addrs {
+					if features.GetIPFamily(addr.Address) != family {
+						continue
+					}
+
+					// On GKE ExternalIP is not reachable from inside a cluster
+					if addr.Type == corev1.NodeExternalIP {
+						if f, ok := ct.Feature(features.Flavor); ok && f.Enabled && f.Mode == "gke" {
+							continue
+						}
+					}
+
+					addrFormat := "%s:%d"
+					if family == features.IPFamilyV6 {
+						addrFormat = "[%s]:%d"
+					}
+					deployName := fmt.Sprintf("%s-%s-%s-%s", testConnDisruptClientNSTrafficDeploymentName, n.nodeType, family, strings.ToLower(string(addr.Type)))
+					if err := ct.createTestConnDisruptClientDeployment(ctx,
+						deployName,
+						KindTestConnDisruptNSTraffic,
+						fmt.Sprintf("test-conn-disrupt-client-%s-%s-%s", n.nodeType, family, strings.ToLower(string(addr.Type))),
+						fmt.Sprintf(addrFormat, addr.Address, np),
+						1, true); err != nil {
+						errs = errors.Join(errs, err)
+					}
+					ct.testConnDisruptClientNSTrafficDeploymentNames = append(ct.testConnDisruptClientNSTrafficDeploymentNames, deployName)
+				}
+			})
+			if errs != nil {
+				return errs
+			}
+		}
+	}
+
+	return err
+}
+
+type nodeWithType struct {
+	nodeType string
+	node     *corev1.Node
+}
+
+func (ct *ConnectivityTest) getBackendNodeAndNonBackendNode(ctx context.Context) ([]nodeWithType, error) {
+	appLabel := fmt.Sprintf("app=%s", testConnDisruptServerNSTrafficAppLabel)
+	podList, err := ct.clients.src.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: appLabel})
+	if err != nil {
+		return nil, fmt.Errorf("unable to list pods with lable %s: %w", appLabel, err)
+	}
+
+	pod := podList.Items[0]
+
+	var nodes []nodeWithType
+	nodes = append(nodes, nodeWithType{
+		nodeType: "backend-node",
+		node:     ct.nodes[pod.Spec.NodeName],
+	})
+	for name, node := range ct.Nodes() {
+		if name != pod.Spec.NodeName {
+			nodes = append(nodes, nodeWithType{
+				nodeType: "non-backend-node",
+				node:     node,
+			})
+			break
+		}
+	}
+
+	return nodes, err
+}
+
+func (ct *ConnectivityTest) hasNetworkPolicies(ctx context.Context) (bool, error) {
+	for _, client := range ct.Clients() {
+		cnps, err := client.ListCiliumNetworkPolicies(ctx, ct.params.TestNamespace, metav1.ListOptions{Limit: 1})
+		if err != nil {
+			return false, err
+		}
+		if len(cnps.Items) > 0 {
+			return true, nil
+		}
+
+		ccnps, err := client.ListCiliumClusterwideNetworkPolicies(ctx, metav1.ListOptions{Limit: 1})
+		if err != nil {
+			return false, err
+		}
+		if len(ccnps.Items) > 0 {
+			return true, nil
+		}
+
+		nps, err := client.ListNetworkPolicies(ctx, metav1.ListOptions{Limit: 1})
+		if err != nil {
+			return false, err
+		}
+		if len(nps.Items) > 0 {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 func (ct *ConnectivityTest) createClientPerfDeployment(ctx context.Context, name string, nodeName string, hostNetwork bool) error {
 	ct.Logf("✨ [%s] Deploying %s deployment...", ct.clients.src.ClusterName(), name)
 	gracePeriod := int64(1)
@@ -1351,6 +1554,10 @@ func (ct *ConnectivityTest) deploymentList() (srcList []string, dstList []string
 		// not matter much, because the two clients are identical.
 		srcList = append(srcList, testConnDisruptServerDeploymentName)
 		dstList = append(dstList, testConnDisruptClientDeploymentName)
+		if ct.ShouldRunConnDisruptNSTraffic() {
+			srcList = append(srcList, testConnDisruptServerNSTrafficDeploymentName)
+			dstList = append(dstList, ct.testConnDisruptClientNSTrafficDeploymentNames...)
+		}
 	}
 
 	if ct.params.MultiCluster != "" || !ct.params.SingleNode {
@@ -1412,10 +1619,22 @@ func (ct *ConnectivityTest) DeleteConnDisruptTestDeployment(ctx context.Context,
 	ct.Debugf("🔥 [%s] Deleting test-conn-disrupt deployments...", client.ClusterName())
 	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, testConnDisruptClientDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, testConnDisruptServerDeploymentName, metav1.DeleteOptions{})
+	deployList, err := client.ListDeployment(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + KindTestConnDisruptNSTraffic})
+	if err != nil {
+		ct.Warnf("failed to list deployments: %s %v", KindTestConnDisruptNSTraffic, err)
+	}
+	for _, deploy := range deployList.Items {
+		_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, deploy.Name, metav1.DeleteOptions{})
+		_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, deploy.Name, metav1.DeleteOptions{})
+	}
+	_ = client.DeleteDeployment(ctx, ct.params.TestNamespace, testConnDisruptServerNSTrafficDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, testConnDisruptClientDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, testConnDisruptServerDeploymentName, metav1.DeleteOptions{})
+	_ = client.DeleteServiceAccount(ctx, ct.params.TestNamespace, testConnDisruptServerNSTrafficDeploymentName, metav1.DeleteOptions{})
 	_ = client.DeleteService(ctx, ct.params.TestNamespace, testConnDisruptServiceName, metav1.DeleteOptions{})
+	_ = client.DeleteService(ctx, ct.params.TestNamespace, testConnDisruptNSTrafficServiceName, metav1.DeleteOptions{})
 	_ = client.DeleteCiliumNetworkPolicy(ctx, ct.params.TestNamespace, testConnDisruptCNPName, metav1.DeleteOptions{})
+	_ = client.DeleteCiliumNetworkPolicy(ctx, ct.params.TestNamespace, testConnDisruptNSTrafficCNPName, metav1.DeleteOptions{})
 
 	return nil
 }

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -165,6 +165,11 @@ func (ct *ConnectivityTest) extractFeaturesFromCiliumStatus(ctx context.Context,
 			}
 			if f.NodePort != nil {
 				result[features.KPRNodePort] = features.Status{Enabled: f.NodePort.Enabled}
+				acceleration := strings.ToLower(f.NodePort.Acceleration)
+				result[features.KPRNodePortAcceleration] = features.Status{
+					Enabled: acceleration != "disabled",
+					Mode:    mode,
+				}
 			}
 			if f.SessionAffinity != nil {
 				result[features.KPRSessionAffinity] = features.Status{Enabled: f.SessionAffinity.Enabled}

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -837,31 +837,7 @@ func (t *Test) collectSysdump() {
 }
 
 func (t *Test) ForEachIPFamily(do func(features.IPFamily)) {
-	ipFams := features.GetIPFamilies(t.ctx.Params().IPFamilies)
-
-	// The per-endpoint routes feature is broken with IPv6 on < v1.14 when there
-	// are any netpols installed (https://github.com/cilium/cilium/issues/23852
-	// and https://github.com/cilium/cilium/issues/23910).
-	if f, ok := t.Context().Feature(features.EndpointRoutes); ok &&
-		f.Enabled && t.HasNetworkPolicies() &&
-		versioncheck.MustCompile("<1.14.0")(t.Context().CiliumVersion) {
-
-		ipFams = []features.IPFamily{features.IPFamilyV4}
-	}
-
-	for _, ipFam := range ipFams {
-		switch ipFam {
-		case features.IPFamilyV4:
-			if f, ok := t.ctx.Features[features.IPv4]; ok && f.Enabled {
-				do(ipFam)
-			}
-
-		case features.IPFamilyV6:
-			if f, ok := t.ctx.Features[features.IPv6]; ok && f.Enabled {
-				do(ipFam)
-			}
-		}
-	}
+	t.ctx.ForEachIPFamily(t.HasNetworkPolicies(), do)
 }
 
 // CertificateCAs returns the CAs used to sign the certificates within the test.

--- a/cilium-cli/connectivity/tests/upgrade.go
+++ b/cilium-cli/connectivity/tests/upgrade.go
@@ -56,6 +56,20 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 		for _, pod := range pods.Items {
 			restartCount[pod.GetObjectMeta().GetName()] = strconv.Itoa(int(pod.Status.ContainerStatuses[0].RestartCount))
 		}
+
+		if ct.ShouldRunConnDisruptNSTraffic() {
+			pods, err = client.ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + check.KindTestConnDisruptNSTraffic})
+			if err != nil {
+				t.Fatalf("Unable to list test-conn-disrupt-ns-traffic pods: %s", err)
+			}
+			if len(pods.Items) == 0 {
+				t.Fatal("No test-conn-disrupt-{client,server} for NS traffic pods found")
+			}
+
+			for _, pod := range pods.Items {
+				restartCount[pod.GetObjectMeta().GetName()] = strconv.Itoa(int(pod.Status.ContainerStatuses[0].RestartCount))
+			}
+		}
 	}
 
 	// Only store restart counters which will be used later when running the same

--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -239,6 +239,10 @@ func (c *Client) GetDeployment(ctx context.Context, namespace, name string, opts
 	return c.Clientset.AppsV1().Deployments(namespace).Get(ctx, name, opts)
 }
 
+func (c *Client) ListDeployment(ctx context.Context, namespace string, options metav1.ListOptions) (*appsv1.DeploymentList, error) {
+	return c.Clientset.AppsV1().Deployments(namespace).List(ctx, options)
+}
+
 func (c *Client) DeleteDeployment(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
 	return c.Clientset.AppsV1().Deployments(namespace).Delete(ctx, name, opts)
 }

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -26,14 +26,15 @@ const (
 	Tunnel             Feature = "tunnel"
 	EndpointRoutes     Feature = "endpoint-routes"
 
-	KPRMode                Feature = "kpr-mode"
-	KPRExternalIPs         Feature = "kpr-external-ips"
-	KPRGracefulTermination Feature = "kpr-graceful-termination"
-	KPRHostPort            Feature = "kpr-hostport"
-	KPRSocketLB            Feature = "kpr-socket-lb"
-	KPRSocketLBHostnsOnly  Feature = "kpr-socket-lb-hostns-only"
-	KPRNodePort            Feature = "kpr-nodeport"
-	KPRSessionAffinity     Feature = "kpr-session-affinity"
+	KPRMode                 Feature = "kpr-mode"
+	KPRExternalIPs          Feature = "kpr-external-ips"
+	KPRGracefulTermination  Feature = "kpr-graceful-termination"
+	KPRHostPort             Feature = "kpr-hostport"
+	KPRSocketLB             Feature = "kpr-socket-lb"
+	KPRSocketLBHostnsOnly   Feature = "kpr-socket-lb-hostns-only"
+	KPRNodePort             Feature = "kpr-nodeport"
+	KPRNodePortAcceleration Feature = "kpr-nodeport-acceleration"
+	KPRSessionAffinity      Feature = "kpr-session-affinity"
 
 	BPFLBExternalClusterIP Feature = "bpf-lb-external-clusterip"
 


### PR DESCRIPTION
This PR extends no-interrupted-connections to test NodePort from outside.

Fixes: #13530
