### PR TITLE
docs: Fix broken link in BGP control plane docs

### DIFF
--- a/Documentation/network/bgp-control-plane/bgp-control-plane-operation.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane-operation.rst
@@ -380,7 +380,7 @@ Service's ``externalTrafficPolicy`` is set to ``Local``, it is inevitable that
 all ongoing connections with the endpoints on the failed node, and connections
 forwarded to a different node than before, will be reset.
 
-.. _Resilient Hashing: https://www.juniper.net/documentation/us/en/software/junos/interfaces-ethernet-switches/topics/topic-map/switches-interface-resilient-hashing.html
+.. _Resilient Hashing: https://www.juniper.net/documentation/us/en/software/junos/interfaces-ethernet-switches/topics/topic-map/resillient-hashing-lag-ecmp.html
 
 Node Down
 ~~~~~~~~~


### PR DESCRIPTION
Fixes a broken link in the control-plane docs.
