### PR TITLE
Remove "_total" suffix from doublewrite metrics

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -813,10 +813,10 @@ enabled, the following metrics are available:
 ============================================ ======= ========== ============================================================
 Name                                         Labels  Default    Description
 ============================================ ======= ========== ============================================================
-``doublewrite_identity_crd_total``                   Enabled    The total number of CRD identities
-``doublewrite_identity_kvstore_total``               Enabled    The total number of identities in the KVStore
-``doublewrite_identity_crd_only_total``              Enabled    The number of CRD identities not present in the KVStore
-``doublewrite_identity_kvstore_only_total``          Enabled    The number of identities in the KVStore not present as a CRD
+``doublewrite_crd_identities``                       Enabled    The total number of CRD identities
+``doublewrite_kvstore_identities``                   Enabled    The total number of identities in the KVStore
+``doublewrite_crd_only_identities``                  Enabled    The number of CRD identities not present in the KVStore
+``doublewrite_kvstore_only_identities``              Enabled    The number of identities in the KVStore not present as a CRD
 ============================================ ======= ========== ============================================================
 
 

--- a/operator/doublewrite/metricreporter.go
+++ b/operator/doublewrite/metricreporter.go
@@ -161,10 +161,10 @@ func (g *DoubleWriteMetricReporter) compareCRDAndKVStoreIdentities(ctx context.C
 	onlyInCrdSample := onlyInCrd[:min(onlyInCrdCount, maxPrintedDiffIDs)]
 	onlyInKVStoreSample := onlyInKVStore[:min(onlyInKVStoreCount, maxPrintedDiffIDs)]
 
-	g.metrics.IdentityCRDTotal.Set(float64(len(crdIdentityIds)))
-	g.metrics.IdentityKVStoreTotal.Set(float64(len(kvstoreIdentityIds)))
-	g.metrics.IdentityCRDOnlyTotal.Set(float64(onlyInCrdCount))
-	g.metrics.IdentityKVStoreOnlyTotal.Set(float64(onlyInKVStoreCount))
+	g.metrics.CRDIdentities.Set(float64(len(crdIdentityIds)))
+	g.metrics.KVStoreIdentities.Set(float64(len(kvstoreIdentityIds)))
+	g.metrics.CRDOnlyIdentities.Set(float64(onlyInCrdCount))
+	g.metrics.KVStoreOnlyIdentities.Set(float64(onlyInKVStoreCount))
 
 	if onlyInCrdCount == 0 && onlyInKVStoreCount == 0 {
 		g.logger.Info("CRD and KVStore identities are in sync")

--- a/operator/doublewrite/metrics.go
+++ b/operator/doublewrite/metrics.go
@@ -10,46 +10,46 @@ import (
 
 func NewMetrics() *Metrics {
 	return &Metrics{
-		IdentityCRDTotal: metric.NewGauge(metric.GaugeOpts{
+		CRDIdentities: metric.NewGauge(metric.GaugeOpts{
 			Namespace: metrics.CiliumOperatorNamespace,
-			Name:      "doublewrite_identity_crd_total",
+			Name:      "doublewrite_crd_identities",
 			Help:      "The total number of CRD identities (Requires the Double-Write Identity allocation mode to be enabled)",
 		}),
 
-		IdentityKVStoreTotal: metric.NewGauge(metric.GaugeOpts{
+		KVStoreIdentities: metric.NewGauge(metric.GaugeOpts{
 			Namespace: metrics.CiliumOperatorNamespace,
-			Name:      "doublewrite_identity_kvstore_total",
+			Name:      "doublewrite_kvstore_identities",
 			Help:      "The total number of identities in the KVStore (Requires the Double-Write Identity allocation mode to be enabled)",
 		}),
 
-		IdentityCRDOnlyTotal: metric.NewGauge(metric.GaugeOpts{
+		CRDOnlyIdentities: metric.NewGauge(metric.GaugeOpts{
 			Namespace: metrics.CiliumOperatorNamespace,
-			Name:      "doublewrite_identity_crd_only_total",
+			Name:      "doublewrite_crd_only_identities",
 			Help:      "The number of CRD identities not present in the KVStore (Requires the Double-Write Identity allocation mode to be enabled)",
 		}),
 
-		IdentityKVStoreOnlyTotal: metric.NewGauge(metric.GaugeOpts{
+		KVStoreOnlyIdentities: metric.NewGauge(metric.GaugeOpts{
 			Namespace: metrics.CiliumOperatorNamespace,
-			Name:      "doublewrite_identity_kvstore_only_total",
+			Name:      "doublewrite_kvstore_only_identities",
 			Help:      "The number of identities in the KVStore not present as a CRD (Requires the Double-Write Identity allocation mode to be enabled)",
 		}),
 	}
 }
 
 type Metrics struct {
-	// IdentityCRDTotal records the total number of CRD identities
+	// CRDIdentities records the total number of CRD identities
 	// Requires the Double-Write Identity allocation mode to be enabled
-	IdentityCRDTotal metric.Gauge
+	CRDIdentities metric.Gauge
 
-	// IdentityKVStoreTotal records the total number of identities in the KVStore
+	// KVStoreIdentities records the total number of identities in the KVStore
 	// Requires the Double-Write Identity allocation mode to be enabled
-	IdentityKVStoreTotal metric.Gauge
+	KVStoreIdentities metric.Gauge
 
-	// IdentityCRDOnlyTotal records the number of CRD identities not present in the KVStore
+	// CRDOnlyIdentities records the number of CRD identities not present in the KVStore
 	// Requires the Double-Write Identity allocation mode to be enabled
-	IdentityCRDOnlyTotal metric.Gauge
+	CRDOnlyIdentities metric.Gauge
 
-	// IdentityKVStoreOnlyTotal records the number of identities in the KVStore not present as a CRD
+	// KVStoreOnlyIdentities records the number of identities in the KVStore not present as a CRD
 	// Requires the Double-Write Identity allocation mode to be enabled
-	IdentityKVStoreOnlyTotal metric.Gauge
+	KVStoreOnlyIdentities metric.Gauge
 }


### PR DESCRIPTION
Follow-up to https://github.com/cilium/cilium/pull/36585

Unfortunately the `_total` suffix gets flagged by `promtool` as well: https://github.com/cilium/cilium/pull/37079#issuecomment-2601773770
More context: https://github.com/cilium/cilium/pull/37079#discussion_r1926097631