### PR TITLE
gh: Improve check-ipsec-leaks.bt

### DIFF
--- a/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
@@ -103,6 +103,16 @@ kprobe:br_forward
       $tcph = (struct tcphdr*)$udph;
 
       if (!$tcph->rst) {
+        $i = (uint64)0;
+        while ($i < 16) {
+            if ($i >= @skb_footprint_len[$skb]) {
+                break;
+            }
+            printf("%s%s ", @skb_footprints[$skb, $i].0, @skb_footprints[$skb, $i].4);
+            $i++;
+        }
+        printf("\n");
+
         printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
           strftime("%H:%M:%S:%f", nsecs),
           ntop($ip4h->saddr), bswap($udph->source),
@@ -142,6 +152,16 @@ kprobe:br_forward
       $tcph = (struct tcphdr*)$udph;
 
       if (!$tcph->rst) {
+        $i = (uint64)0;
+        while ($i < 16) {
+            if ($i >= @skb_footprint_len[$skb]) {
+                break;
+            }
+            printf("%s%s ", @skb_footprints[$skb, $i].0, @skb_footprints[$skb, $i].4);
+            $i++;
+        }
+        printf("\n");
+
         printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
           strftime("%H:%M:%S:%f", nsecs),
           ntop($ip6h->saddr.in6_u.u6_addr8), bswap($udph->source),
@@ -293,3 +313,64 @@ END
   clear(@trace_sk);
   clear(@sanity);
 }
+
+BEGIN
+{
+    @skb_footprint_len[(struct sk_buff *)0] = (uint8)0;
+    @skb_footprints[(struct sk_buff *)0, (uint8)0] = ("<>", (uint32)0, (int32)0, (uint32)0, "_______________", strftime("%H:%M:%S:%f", nsecs));
+}
+
+tracepoint:net:net_dev_queue
+{
+    $skb = (struct sk_buff *)args->skbaddr;
+    $fp_len = @skb_footprint_len[$skb];
+    @skb_footprints[$skb, $fp_len] = (
+        "<-",
+        $skb->mark,
+        $skb->dev->ifindex,
+        $skb->dev->nd_net.net->ns.inum,
+        $skb->dev->name,
+        strftime("%H:%M:%S:%f", nsecs)
+    );
+    @skb_footprint_len[$skb]++;
+}
+
+tracepoint:net:netif_receive_skb
+{
+    $skb = (struct sk_buff *)args->skbaddr;
+    $fp_len = @skb_footprint_len[$skb];
+    @skb_footprints[$skb, $fp_len] = (
+        "->",
+        $skb->mark,
+        $skb->dev->ifindex,
+        $skb->dev->nd_net.net->ns.inum,
+        $skb->dev->name,
+        strftime("%H:%M:%S:%f", nsecs)
+    );
+    @skb_footprint_len[$skb]++;
+}
+
+tracepoint:skb:kfree_skb,tracepoint:skb:consume_skb
+{
+    $skb = (struct sk_buff *)args->skbaddr;
+    $fp_len = @skb_footprint_len[$skb];
+    $i = (uint64)0;
+    while ($i < ($fp_len & 0xff)) {
+        delete(@skb_footprints[$skb, $i]);
+        $i++;
+    }
+    delete(@skb_footprint_len[$skb]);
+}
+
+kprobe:kfree_skbmem
+{
+    $skb = (struct sk_buff *)arg0;
+    $fp_len = @skb_footprint_len[$skb];
+    $i = (uint64)0;
+    while ($i < ($fp_len & 0xff)) {
+        delete(@skb_footprints[$skb, $i]);
+        $i++;
+    }
+    delete(@skb_footprint_len[$skb]);
+}
+

--- a/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-ipsec-leaks.bt
@@ -103,15 +103,17 @@ kprobe:br_forward
       $tcph = (struct tcphdr*)$udph;
 
       if (!$tcph->rst) {
+        printf("\n");
+
         $i = (uint64)0;
         while ($i < 16) {
             if ($i >= @skb_footprint_len[$skb]) {
                 break;
             }
-            printf("%s%s ", @skb_footprints[$skb, $i].0, @skb_footprints[$skb, $i].4);
+            $fp = @skb_footprints[$skb, $i];
+            printf("%s%s mark=%x %s=%d netns=%x\n", $fp.0, $fp.4, $fp.1, $fp.5, $fp.2, $fp.3);
             $i++;
         }
-        printf("\n");
 
         printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
           strftime("%H:%M:%S:%f", nsecs),
@@ -152,15 +154,17 @@ kprobe:br_forward
       $tcph = (struct tcphdr*)$udph;
 
       if (!$tcph->rst) {
+        printf("\n");
+
         $i = (uint64)0;
         while ($i < 16) {
             if ($i >= @skb_footprint_len[$skb]) {
                 break;
             }
-            printf("%s%s ", @skb_footprints[$skb, $i].0, @skb_footprints[$skb, $i].4);
+            $fp = @skb_footprints[$skb, $i];
+            printf("%s%s mark=%x %s=%d netns=%x\n", $fp.0, $fp.4, $fp.1, $fp.5, $fp.2, $fp.3);
             $i++;
         }
-        printf("\n");
 
         printf("[%s] %s:%d -> %s:%d (proto: %d, TCP flags: %c%c%c%c, encap: %d, ifindex: %d, netns: %x, override: %d)\n",
           strftime("%H:%M:%S:%f", nsecs),
@@ -317,7 +321,22 @@ END
 BEGIN
 {
     @skb_footprint_len[(struct sk_buff *)0] = (uint8)0;
-    @skb_footprints[(struct sk_buff *)0, (uint8)0] = ("<>", (uint32)0, (int32)0, (uint32)0, "_______________", strftime("%H:%M:%S:%f", nsecs));
+    @skb_footprints[(struct sk_buff *)0, (uint8)0] = ("<>", (uint32)0, (uint32)0, (uint32)0, "_______________", "ifindex");
+}
+
+kprobe:ip_output,kprobe:ip6_output
+{
+    $skb = (struct sk_buff *)arg2;
+    $fp_len = @skb_footprint_len[$skb];
+    @skb_footprints[$skb, $fp_len] = (
+        "<-",
+        $skb->mark,
+        (uint32)pid,
+        (uint32)0,
+        comm,
+        "process"
+    );
+    @skb_footprint_len[$skb]++;
 }
 
 tracepoint:net:net_dev_queue
@@ -327,10 +346,10 @@ tracepoint:net:net_dev_queue
     @skb_footprints[$skb, $fp_len] = (
         "<-",
         $skb->mark,
-        $skb->dev->ifindex,
+        (uint32)$skb->dev->ifindex,
         $skb->dev->nd_net.net->ns.inum,
         $skb->dev->name,
-        strftime("%H:%M:%S:%f", nsecs)
+        "ifindex"
     );
     @skb_footprint_len[$skb]++;
 }
@@ -342,10 +361,10 @@ tracepoint:net:netif_receive_skb
     @skb_footprints[$skb, $fp_len] = (
         "->",
         $skb->mark,
-        $skb->dev->ifindex,
+        (uint32)$skb->dev->ifindex,
         $skb->dev->nd_net.net->ns.inum,
         $skb->dev->name,
-        strftime("%H:%M:%S:%f", nsecs)
+        "ifindex"
     );
     @skb_footprint_len[$skb]++;
 }

--- a/.github/actions/bpftrace/start/action.yaml
+++ b/.github/actions/bpftrace/start/action.yaml
@@ -25,7 +25,7 @@ runs:
             # https://github.com/bpftrace/bpftrace/issues/3011
             # Let's buy us some time, and keep installing v0.19.1 for the moment.
 
-            curl -L https://github.com/bpftrace/bpftrace/releases/download/v0.19.1/bpftrace -o bpftrace
+            curl -L https://github.com/bpftrace/bpftrace/releases/download/v0.20.4/bpftrace -o bpftrace
             install -m 755 bpftrace /usr/local/bin/bpftrace
 
           fi
@@ -42,6 +42,8 @@ runs:
             export BPFTRACE_BTF="/boot/btf-\$(uname -r)"
           fi
 
+          export BPFTRACE_MAX_MAP_KEYS=8192
+          export BPFTRACE_LOG_SIZE=100000000
           bpftrace ${{ inputs.script }} -q \
             ${{ inputs.args }} \
             > ${{ inputs.output-path }}/bpftrace.out \


### PR DESCRIPTION
Now leak detection prints netdevs through which the plain-text skbs passed:
```
<-tcd-client mark=0 process=1410683 netns=0                                                                                                                                                                          
<-eth0 mark=0 ifindex=11 netns=f0000c75                                                                                                                                                                              
->lxce894844ba247 mark=0 ifindex=12 netns=f00009af                                                                                                                                                                   
<-cilium_vxlan mark=a70a0400 ifindex=4 netns=f00009af                                                                                                                                                                
<-tcd-client mark=a70a0400 process=1410683 netns=0                                                                                                                                                                   
<-eth0 mark=a70a0400 ifindex=31 netns=f00009af                                                                                                                                                                       
->vethead1a34 mark=0 ifindex=32 netns=f0000000                                                                                                                                                                       
[01:55:02:575756] 10.244.2.66:58680 -> 10.244.1.105:8000 (proto: 6, TCP flags: .A.., encap: 1, ifindex: 32, netns: f0000000, override: 0
```

This PR requires higher version of bpftrace (v0.22.1), which requires CONFIG_FUSE_FS for lvh kernel images. Otherwise bpftrace ends up with error:
```
# bpftrace --help
fuse: device not found, try 'modprobe fuse' first

Cannot mount AppImage, please check your FUSE setup.
You might still be able to extract the contents of this AppImage 
if you run it with the --appimage-extract option. 
See https://github.com/AppImage/AppImageKit/wiki/FUSE 
for more information
open dir error: No such file or directory
```

lvh PR: https://github.com/cilium/little-vm-helper-images/pull/850