### PR TITLE
helm: fix comment mangling hubble export options

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1,5 +1,5 @@
 {{- if and ( or (.Values.agent) (.Values.operator.enabled) .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) (not .Values.preflight.enabled) }}
-{{- /*  Default values with backwards compatibility */ -}}
+{{- /*  Default values with backwards compatibility */}}
 {{- $defaultBpfMapDynamicSizeRatio := 0.0 -}}
 {{- $defaultBpfMasquerade := "false" -}}
 {{- $defaultBpfClockProbe := "false" -}}
@@ -19,7 +19,7 @@
 {{- $readSecretsOnlyFromSecretsNamespace := eq (include "readSecretsOnlyFromSecretsNamespace" .) "true" -}}
 {{- $secretSyncEnabled := eq (include "secretSyncEnabled" .) "true" -}}
 
-{{- /* Default values when 1.8 was initially deployed */ -}}
+{{- /* Default values when 1.8 was initially deployed */}}
 {{- if semverCompare ">=1.8" (default "1.8" .Values.upgradeCompatibility) -}}
   {{- $defaultBpfMapDynamicSizeRatio = 0.0025 -}}
   {{- $defaultBpfMasquerade = "true" -}}
@@ -35,18 +35,18 @@
   {{- $defaultKubeProxyReplacement = "probe" -}}
 {{- end -}}
 
-{{- /* Default values when 1.9 was initially deployed */ -}}
+{{- /* Default values when 1.9 was initially deployed */}}
 {{- if semverCompare ">=1.9" (default "1.9" .Values.upgradeCompatibility) -}}
   {{- $defaultKubeProxyReplacement = "probe" -}}
 {{- end -}}
 
-{{- /* Default values when 1.10 was initially deployed */ -}}
+{{- /* Default values when 1.10 was initially deployed */}}
 {{- if semverCompare ">=1.10" (default "1.10" .Values.upgradeCompatibility) -}}
-  {{- /* Needs to be explicitly disabled because it was enabled on all versions >=v1.8 above. */ -}}
+  {{- /* Needs to be explicitly disabled because it was enabled on all versions >=v1.8 above. */}}
   {{- $defaultBpfMasquerade = "false" -}}
 {{- end -}}
 
-{{- /* Default values when 1.12 was initially deployed */ -}}
+{{- /* Default values when 1.12 was initially deployed */}}
 {{- if semverCompare ">=1.12" (default "1.12" .Values.upgradeCompatibility) -}}
   {{- if .Values.azure.enabled }}
       {{- $azureUsePrimaryAddress = "false" -}}
@@ -55,9 +55,9 @@
   {{- $defaultDNSProxyEnableTransparentMode = "true" -}}
 {{- end -}}
 
-{{- /* Default values when 1.14 was initially deployed */ -}}
+{{- /* Default values when 1.14 was initially deployed */}}
 {{- if semverCompare ">=1.14" (default "1.14" .Values.upgradeCompatibility) -}}
-  {{- /* KPR default for 1.14 needed to override earlier version defaults set above when upgradeCompatibility is not specified */ -}}
+  {{- /* KPR default for 1.14 needed to override earlier version defaults set above when upgradeCompatibility is not specified */}}
   {{- $defaultKubeProxyReplacement = "false" -}}
 {{- end -}}
 
@@ -989,11 +989,11 @@ data:
 {{- end }}
 {{- if .Values.hubble.export }}
 {{- if .Values.hubble.export.static.enabled }}
-  {{- /* hubble export configurations moved, use default to make upgrades seemless */ -}}
-  {{- /* TODO: remove default once v1.18 is released, remove warning in warnings.txt and add failure validation in validate.yaml */ -}}
-  hubble-export-file-max-size-mb: {{ default .Values.hubble.export.fileMaxSizeMb .Values.hubble.export.static.fileMaxSizeMb | quote }}
-  hubble-export-file-max-backups: {{ default .Values.hubble.export.fileMaxBackups .Values.hubble.export.static.fileMaxBackups | quote }}
-  hubble-export-file-compress: {{ default .Values.hubble.export.fileCompress .Values.hubble.export.static.fileCompress | quote }}
+  {{- /* hubble export configurations moved, use default to make upgrades seemless */}}
+  {{- /* TODO: remove default once v1.18 is released, remove warning in warnings.txt and add failure validation in validate.yaml */}}
+  hubble-export-file-max-size-mb: {{ .Values.hubble.export.fileMaxSizeMb | default .Values.hubble.export.static.fileMaxSizeMb | quote }}
+  hubble-export-file-max-backups: {{ .Values.hubble.export.fileMaxBackups | default .Values.hubble.export.static.fileMaxBackups | quote }}
+  hubble-export-file-compress: {{ .Values.hubble.export.fileCompress | default .Values.hubble.export.static.fileCompress | quote }}
   hubble-export-file-path: {{ .Values.hubble.export.static.filePath | quote }}
   hubble-export-fieldmask: {{ .Values.hubble.export.static.fieldMask | join " " | quote }}
   hubble-export-allowlist: {{ .Values.hubble.export.static.allowList | join " " | quote }}
@@ -1051,7 +1051,7 @@ data:
 {{- if (eq $ipam "cluster-pool") }}
 {{- if .Values.ipv4.enabled }}
   {{- if hasKey .Values.ipam.operator "clusterPoolIPv4PodCIDR" }}
-    {{- /* ipam.operator.clusterPoolIPv4PodCIDR removed in v1.14, remove this failsafe around v1.17 */ -}}
+    {{- /* ipam.operator.clusterPoolIPv4PodCIDR removed in v1.14, remove this failsafe around v1.17 */}}
     {{- fail "Value ipam.operator.clusterPoolIPv4PodCIDR removed, use ipam.operator.clusterPoolIPv4PodCIDRList instead" }}
   {{- end }}
   cluster-pool-ipv4-cidr: {{ .Values.ipam.operator.clusterPoolIPv4PodCIDRList | join " " | quote }}
@@ -1059,7 +1059,7 @@ data:
 {{- end }}
 {{- if .Values.ipv6.enabled }}
   {{- if hasKey .Values.ipam.operator "clusterPoolIPv6PodCIDR" }}
-    {{- /* ipam.operator.clusterPoolIPv6PodCIDR removed in v1.14, remove this failsafe around v1.17 */ -}}
+    {{- /* ipam.operator.clusterPoolIPv6PodCIDR removed in v1.14, remove this failsafe around v1.17 */}}
     {{- fail "Value ipam.operator.clusterPoolIPv6PodCIDR removed, use ipam.operator.clusterPoolIPv6PodCIDRList instead" }}
   {{- end }}
   cluster-pool-ipv6-cidr: {{ .Values.ipam.operator.clusterPoolIPv6PodCIDRList | join " " | quote }}
@@ -1242,7 +1242,7 @@ data:
 {{- if .Values.operator.removeNodeTaints }}
   remove-cilium-node-taints: "true"
 {{- end }}
-{{- /* set node taints if setNodeTaints is explicitly enabled or removeNodeTaints is set */ -}}
+{{- /* set node taints if setNodeTaints is explicitly enabled or removeNodeTaints is set */}}
 {{- if or .Values.operator.setNodeTaints
           ( and (kindIs "invalid" .Values.operator.setNodeTaints)
                 .Values.operator.removeNodeTaints ) }}


### PR DESCRIPTION
In https://github.com/cilium/cilium/pull/36974 (d57500ec1bbc3acf8f626597e5589d81003f62c9) we added deprecation comments above hubble export options that moved in the values file. These comments are not real comments (or they are but don't behave like we would expect) and can cause yaml parsing issues, update trailing formatting from `*/ -}}` to `*/}}`.
See: https://helm.sh/docs/chart_best_practices/templates/#comments-yaml-comments-vs-template-comments

Also fix the default ordering as we got it wrong before, using the moved value as default instead of optional 🤦 .


