### PR TITLE
hubble-export: fix allowlist and denylist flow-filters parsing

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -221,8 +221,8 @@ cilium-agent [flags]
       --hubble-dynamic-metrics-config-path string                 Filepath with dynamic configuration of hubble metrics
       --hubble-event-buffer-capacity int                          Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)
       --hubble-event-queue-size int                               Buffer size of the channel to receive monitor events.
-      --hubble-export-allowlist strings                           Specify allowlist as JSON encoded FlowFilters to Hubble exporter.
-      --hubble-export-denylist strings                            Specify denylist as JSON encoded FlowFilters to Hubble exporter.
+      --hubble-export-allowlist string                            Specify allowlist as JSON encoded FlowFilters to Hubble exporter.
+      --hubble-export-denylist string                             Specify denylist as JSON encoded FlowFilters to Hubble exporter.
       --hubble-export-fieldmask strings                           Specify list of fields to use for field mask in Hubble exporter.
       --hubble-export-file-compress                               Compress rotated Hubble export files.
       --hubble-export-file-max-backups int                        Number of rotated Hubble export files to keep. (default 5)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -87,8 +87,8 @@ cilium-agent hive [flags]
       --hubble-dynamic-metrics-config-path string                 Filepath with dynamic configuration of hubble metrics
       --hubble-event-buffer-capacity int                          Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)
       --hubble-event-queue-size int                               Buffer size of the channel to receive monitor events.
-      --hubble-export-allowlist strings                           Specify allowlist as JSON encoded FlowFilters to Hubble exporter.
-      --hubble-export-denylist strings                            Specify denylist as JSON encoded FlowFilters to Hubble exporter.
+      --hubble-export-allowlist string                            Specify allowlist as JSON encoded FlowFilters to Hubble exporter.
+      --hubble-export-denylist string                             Specify denylist as JSON encoded FlowFilters to Hubble exporter.
       --hubble-export-fieldmask strings                           Specify list of fields to use for field mask in Hubble exporter.
       --hubble-export-file-compress                               Compress rotated Hubble export files.
       --hubble-export-file-max-backups int                        Number of rotated Hubble export files to keep. (default 5)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -92,8 +92,8 @@ cilium-agent hive dot-graph [flags]
       --hubble-dynamic-metrics-config-path string                 Filepath with dynamic configuration of hubble metrics
       --hubble-event-buffer-capacity int                          Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)
       --hubble-event-queue-size int                               Buffer size of the channel to receive monitor events.
-      --hubble-export-allowlist strings                           Specify allowlist as JSON encoded FlowFilters to Hubble exporter.
-      --hubble-export-denylist strings                            Specify denylist as JSON encoded FlowFilters to Hubble exporter.
+      --hubble-export-allowlist string                            Specify allowlist as JSON encoded FlowFilters to Hubble exporter.
+      --hubble-export-denylist string                             Specify denylist as JSON encoded FlowFilters to Hubble exporter.
       --hubble-export-fieldmask strings                           Specify list of fields to use for field mask in Hubble exporter.
       --hubble-export-file-compress                               Compress rotated Hubble export files.
       --hubble-export-file-max-backups int                        Number of rotated Hubble export files to keep. (default 5)

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -988,12 +988,12 @@ data:
 {{- end }}
 {{- end }}
 {{- if .Values.hubble.export }}
+{{- /* hubble export configurations moved, use default to make upgrades seemless */ -}}
+{{- /* TODO: remove default once v1.18 is released, remove warning in warnings.txt and add failure validation in validate.yaml */ -}}
 {{- if .Values.hubble.export.static.enabled }}
-  {{- /* hubble export configurations moved, use default to make upgrades seemless */ -}}
-  {{- /* TODO: remove default once v1.18 is released, remove warning in warnings.txt and add failure validation in validate.yaml */ -}}
-  hubble-export-file-max-size-mb: {{ default .Values.hubble.export.fileMaxSizeMb .Values.hubble.export.static.fileMaxSizeMb | quote }}
-  hubble-export-file-max-backups: {{ default .Values.hubble.export.fileMaxBackups .Values.hubble.export.static.fileMaxBackups | quote }}
-  hubble-export-file-compress: {{ default .Values.hubble.export.fileCompress .Values.hubble.export.static.fileCompress | quote }}
+  hubble-export-file-max-size-mb: {{ .Values.hubble.export.fileMaxSizeMb | default .Values.hubble.export.static.fileMaxSizeMb | quote }}
+  hubble-export-file-max-backups: {{ .Values.hubble.export.fileMaxBackups | default .Values.hubble.export.static.fileMaxBackups | quote }}
+  hubble-export-file-compress: {{ .Values.hubble.export.fileCompress | default .Values.hubble.export.static.fileCompress | quote }}
   hubble-export-file-path: {{ .Values.hubble.export.static.filePath | quote }}
   hubble-export-fieldmask: {{ .Values.hubble.export.static.fieldMask | join " " | quote }}
   hubble-export-allowlist: {{ .Values.hubble.export.static.allowList | join " " | quote }}

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -16,11 +16,9 @@ import (
 	"github.com/cilium/statedb"
 	"github.com/sirupsen/logrus"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/hive/health"
 	"github.com/cilium/cilium/pkg/hive/health/types"
-	"github.com/cilium/cilium/pkg/hubble"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -113,20 +111,6 @@ var decodeHooks = cell.DecodeHooks{
 			return data, nil
 		}
 		return cidr.ParseCIDR(s)
-	},
-	// Decode JSON encoded *flowpb.FlowFilter fields
-	func(from reflect.Type, to reflect.Type, data interface{}) (interface{}, error) {
-		if from.Kind() != reflect.Slice {
-			return data, nil
-		}
-		xs, ok := data.([]string)
-		if !ok {
-			return data, nil
-		}
-		if to != reflect.TypeOf(([]*flowpb.FlowFilter)(nil)) {
-			return data, nil
-		}
-		return hubble.ParseFlowFilters(xs...)
 	},
 }
 

--- a/pkg/hubble/exporter/cell/cell.go
+++ b/pkg/hubble/exporter/cell/cell.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble"
 	"github.com/cilium/cilium/pkg/hubble/exporter"
 )
 
@@ -32,9 +33,9 @@ type config struct {
 	// ExportFileCompress specifies whether rotated files are compressed.
 	ExportFileCompress bool `mapstructure:"hubble-export-file-compress"`
 	// ExportAllowlist specifies allow list filter use by exporter.
-	ExportAllowlist []*flowpb.FlowFilter `mapstructure:"hubble-export-allowlist"`
+	ExportAllowlist string `mapstructure:"hubble-export-allowlist"`
 	// ExportDenylist specifies deny list filter use by exporter.
-	ExportDenylist []*flowpb.FlowFilter `mapstructure:"hubble-export-denylist"`
+	ExportDenylist string `mapstructure:"hubble-export-denylist"`
 	// ExportFieldmask specifies list of fields to log in exporter.
 	ExportFieldmask []string `mapstructure:"hubble-export-fieldmask"`
 }
@@ -45,8 +46,8 @@ var DefaultConfig = config{
 	ExportFileMaxSizeMB:    exporter.DefaultFileMaxSizeMB,
 	ExportFileMaxBackups:   exporter.DefaultFileMaxBackups,
 	ExportFileCompress:     false,
-	ExportAllowlist:        []*flowpb.FlowFilter{},
-	ExportDenylist:         []*flowpb.FlowFilter{},
+	ExportAllowlist:        "",
+	ExportDenylist:         "",
 	ExportFieldmask:        []string{},
 }
 
@@ -56,8 +57,8 @@ func (def config) Flags(flags *pflag.FlagSet) {
 	flags.Int("hubble-export-file-max-size-mb", def.ExportFileMaxSizeMB, "Size in MB at which to rotate Hubble export file.")
 	flags.Int("hubble-export-file-max-backups", def.ExportFileMaxBackups, "Number of rotated Hubble export files to keep.")
 	flags.Bool("hubble-export-file-compress", def.ExportFileCompress, "Compress rotated Hubble export files.")
-	flags.StringSlice("hubble-export-allowlist", []string{}, "Specify allowlist as JSON encoded FlowFilters to Hubble exporter.")
-	flags.StringSlice("hubble-export-denylist", []string{}, "Specify denylist as JSON encoded FlowFilters to Hubble exporter.")
+	flags.String("hubble-export-allowlist", "", "Specify allowlist as JSON encoded FlowFilters to Hubble exporter.")
+	flags.String("hubble-export-denylist", "", "Specify denylist as JSON encoded FlowFilters to Hubble exporter.")
 	flags.StringSlice("hubble-export-fieldmask", def.ExportFieldmask, "Specify list of fields to use for field mask in Hubble exporter.")
 }
 
@@ -104,9 +105,18 @@ func NewHubbleStaticExporter(params hubbleExportersParams) (hubbleExportersOut, 
 		return hubbleExportersOut{}, nil
 	}
 
+	allowList, err := hubble.ParseFlowFilters(params.Config.ExportAllowlist)
+	if err != nil {
+		return hubbleExportersOut{}, fmt.Errorf("failed to parse allowlist: %w", err)
+	}
+	denyList, err := hubble.ParseFlowFilters(params.Config.ExportDenylist)
+	if err != nil {
+		return hubbleExportersOut{}, fmt.Errorf("failed to parse denylist: %w", err)
+	}
+
 	exporterOpts := []exporter.Option{
-		exporter.WithAllowList(params.Logger, params.Config.ExportAllowlist),
-		exporter.WithDenyList(params.Logger, params.Config.ExportDenylist),
+		exporter.WithAllowList(params.Logger, allowList),
+		exporter.WithDenyList(params.Logger, denyList),
 		exporter.WithFieldMask(params.Config.ExportFieldmask),
 	}
 	if params.Config.ExportFilePath != "stdout" {

--- a/pkg/hubble/helpers_test.go
+++ b/pkg/hubble/helpers_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package hubble
+
+import (
+	"fmt"
+	"testing"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/test/helpers"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseFlowFilters(t *testing.T) {
+	testCases := []struct {
+		name    string
+		arg     string
+		want    []*flowpb.FlowFilter
+		wantErr bool
+	}{
+		// valid
+		{name: "empty"},
+		{name: "whitespaces", arg: "   "},
+		{name: "one json", arg: "{}", want: []*flowpb.FlowFilter{{}}},
+		{name: "one json whitespaces", arg: "{}  ", want: []*flowpb.FlowFilter{{}}},
+		{
+			name: "one json whitespaces",
+			arg:  ` { "source_ip": ["1.2.3.4",  "2.3.4.5"]  } `,
+			want: []*flowpb.FlowFilter{{
+				SourceIp: []string{"1.2.3.4", "2.3.4.5"},
+			}},
+		},
+		{name: "two jsons", arg: "{}{}", want: []*flowpb.FlowFilter{{}, {}}},
+		{name: "two jsons whitespaces", arg: "{}  {}", want: []*flowpb.FlowFilter{{}, {}}},
+		{name: "two jsons whitespaces", arg: "{}  {}   ", want: []*flowpb.FlowFilter{{}, {}}},
+		{
+			name: "two json whitespaces",
+			arg: `
+                { "source_ip": ["1.2.3.4",  "2.3.4.5"],
+                  "destination_ip": ["2.3.4.5", "1.2.3.4"] }
+                { "destination_pod": ["mypod1",  "mypod2"]  }
+            `,
+			want: []*flowpb.FlowFilter{
+				{SourceIp: []string{"1.2.3.4", "2.3.4.5"}, DestinationIp: []string{"2.3.4.5", "1.2.3.4"}},
+				{DestinationPod: []string{"mypod1", "mypod2"}},
+			},
+		},
+		// invalid
+		{name: "quoted json", arg: "'{}'", wantErr: true},
+		{name: "quoted jsons", arg: "'{}''{}'", wantErr: true},
+		{name: "comma delimited", arg: "{},{}", wantErr: true},
+		{name: "json array", arg: "[]", wantErr: true},
+		{name: "json array", arg: "[{}]", wantErr: true},
+		{name: "json array", arg: "[{},{}]", wantErr: true},
+		{name: "invalid json", arg: "{", wantErr: true},
+		{name: "invalid json", arg: "{}}", wantErr: true},
+		{name: "invalid json", arg: "}}", wantErr: true},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
+			got, err := ParseFlowFilters(tc.arg)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			helpers.AssertProtoEqual(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Hubble export allow/deny list parsing regressed in https://github.com/cilium/cilium/pull/35596 when moving export to a hive cell due to how hive cells handle flags.StringSlices. Similar to https://github.com/cilium/cilium/issues/35619.

Redefine the flag as a string and parse it ourselves to avoid going through the implicit hive decoder hooks that convert strings to slices by splitting on comma.

Also added tests for the hubble.ParseFlowFilters helper to make it clear which formats we support and which we don't.

NOTE: This also needs to be backported to 1.17.

Fixes: #37233

Depends on: https://github.com/cilium/cilium/pull/37255