### PR TITLE
maps/nat/stats: Use Start context when waiting for maps

### DIFF
--- a/pkg/maps/nat/stats/stats.go
+++ b/pkg/maps/nat/stats/stats.go
@@ -162,7 +162,7 @@ func newStats(params params) (*Stats, error) {
 
 	params.Lifecycle.Append(cell.Hook{
 		OnStart: func(hc cell.HookContext) error {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*120)
+			ctx, cancel := context.WithTimeout(hc, time.Second*120)
 			defer cancel()
 			nmap4, err := params.NatMap4.Await(ctx)
 			if err != nil {
@@ -192,7 +192,7 @@ func newStats(params params) (*Stats, error) {
 				<-time.After(5 * time.Second)
 				tr.Trigger()
 			}()
-			return params.Jobs.Start(hc)
+			return nil
 		},
 		OnStop: func(hc cell.HookContext) error {
 			m.complete4(nil)


### PR DESCRIPTION
The parent context of the Start hook was not used which made it impossible to stop the cilium-agent before the 2 minute timeout for the nat maps had expired. Use the parent context to allow stopping early.

Also remove the unnecessary job group start. It has already been started, so need to call Start() again.

```release-notes
Fix issue where Cilium agent with nat-stats enabled can hang for up to 2 minutes while terminating
```