### PR TITLE
Fix the Mutual Authentication Example to work under M macs

### DIFF
--- a/Documentation/network/servicemesh/mutual-authentication/mutual-authentication-example.rst
+++ b/Documentation/network/servicemesh/mutual-authentication/mutual-authentication-example.rst
@@ -29,7 +29,7 @@ Verify that the Pods have been successfully deployed:
 
     $ kubectl get svc echo
     NAME   TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)    AGE
-    echo   ClusterIP   10.96.16.90   <none>        8080/TCP   42m
+    echo   ClusterIP   10.96.16.90   <none>        3000/TCP   42m
     $ kubectl get pod pod-worker 
     NAME         READY   STATUS    RESTARTS   AGE
     pod-worker   1/1     Running   0          40m
@@ -40,9 +40,9 @@ Run the following commands:
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it pod-worker -- curl -s -o /dev/null -w "%{http_code}" http://echo:8080/headers
+    $ kubectl exec -it pod-worker -- curl -s -o /dev/null -w "%{http_code}" http://echo:3000/headers
     200
-    $ kubectl exec -it pod-worker -- curl http://echo:8080/headers-1
+    $ kubectl exec -it pod-worker -- curl http://echo:3000/headers-1
     Access denied
 
 The first request should be successful (the *pod-worker* Pod is able to connect to the *echo* Service over a specific HTTP path and the HTTP status code is ``200``).
@@ -212,9 +212,9 @@ Re-try your connectivity tests. They should give similar results as before:
 
 .. code-block:: shell-session
 
-    $ kubectl exec -it pod-worker -- curl -s -o /dev/null -w "%{http_code}" http://echo:8080/headers
+    $ kubectl exec -it pod-worker -- curl -s -o /dev/null -w "%{http_code}" http://echo:3000/headers
     200
-    $ kubectl exec -it pod-worker -- curl http://echo:8080/headers-1
+    $ kubectl exec -it pod-worker -- curl http://echo:3000/headers-1
     Access denied
 
 Verify that mutual authentication has happened by accessing the logs on the agent. 

--- a/examples/kubernetes/servicemesh/cnp-with-mutual-auth.yaml
+++ b/examples/kubernetes/servicemesh/cnp-with-mutual-auth.yaml
@@ -14,7 +14,7 @@ spec:
       mode: "required"
     toPorts:
     - ports:
-      - port: "8080"
+      - port: "3000"
         protocol: TCP
       rules:
         http:

--- a/examples/kubernetes/servicemesh/cnp-without-mutual-auth.yaml
+++ b/examples/kubernetes/servicemesh/cnp-without-mutual-auth.yaml
@@ -12,7 +12,7 @@ spec:
         app: pod-worker
     toPorts:
     - ports:
-      - port: "8080"
+      - port: "3000"
         protocol: TCP
       rules:
         http:

--- a/examples/kubernetes/servicemesh/mutual-auth-example.yaml
+++ b/examples/kubernetes/servicemesh/mutual-auth-example.yaml
@@ -7,10 +7,10 @@ metadata:
   name: echo
 spec:
   ports:
-  - port: 8080
+  - port: 3000
     name: high
     protocol: TCP
-    targetPort: 8080
+    targetPort: 3000
   selector:
     app: echo
 ---
@@ -31,10 +31,10 @@ spec:
         app: echo
     spec:
       containers:
-      - image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+      - image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
         name: echo
         ports:
-        - containerPort: 8080
+        - containerPort: 3000
         env:
           - name: NODE_NAME
             valueFrom:


### PR DESCRIPTION
The nginx in the `echoserver:2.2` image panics when run under docker in an M mac:

```
Generating self-signed cert
Generating a 2048 bit RSA private key
........+++
...............................................................................................................................................................................................................................+++
writing new private key to '/certs/privateKey.key'
-----
Starting nginx
PANIC: unprotected error in call to Lua API (bad light userdata pointer)
```

This change changes the manifest to use the echoserver from ingressconformance, which works fine. This entails having to change the port, as that echoserer uses 3000 and not 8080.

Fixes: https://github.com/cilium/cilium/issues/37185

```release-note
examples: Fix the Mutual Authentication example to work with Apple M series (arm64)
```
