### PR TITLE
Replace the deprecated workqueue with the generic TypedWorkqueue

### DIFF
--- a/operator/pkg/ciliumendpointslice/rate_limit.go
+++ b/operator/pkg/ciliumendpointslice/rate_limit.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"golang.org/x/time/rate"
-	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -27,7 +26,7 @@ type rateLimitConfig struct {
 	current          rateLimit
 	dynamicRateLimit dynamicRateLimit
 
-	rateLimiter *workqueue.BucketRateLimiter
+	rateLimiter *rate.Limiter
 
 	logger *slog.Logger
 }
@@ -44,7 +43,7 @@ func getRateLimitConfig(p params) (rateLimitConfig, error) {
 	}
 	rlc.dynamicRateLimit = parsed
 	rlc.updateRateLimitWithNodes(0, true)
-	rlc.rateLimiter = &workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(rlc.current.Limit), rlc.current.Burst)}
+	rlc.rateLimiter = rate.NewLimiter(rate.Limit(rlc.current.Limit), rlc.current.Burst)
 	return rlc, nil
 }
 

--- a/operator/pkg/ciliumidentity/controller.go
+++ b/operator/pkg/ciliumidentity/controller.go
@@ -79,7 +79,7 @@ type Controller struct {
 	// requests going to api-server. Ensures a single resource key will not be
 	// processed multiple times concurrently, and if a resource key is added
 	// multiple times before it can be processed, this will only be processed once.
-	resourceQueue workqueue.RateLimitingInterface
+	resourceQueue workqueue.TypedRateLimitingInterface[QueuedItem]
 
 	cesEnabled bool
 
@@ -167,9 +167,9 @@ func (c *Controller) initializeQueues() {
 		logfields.WorkQueueSyncBackOff, defaultSyncBackOff,
 		logfields.WorkQueueMaxSyncBackOff, maxSyncBackOff)
 
-	c.resourceQueue = workqueue.NewRateLimitingQueueWithConfig(
-		workqueue.NewItemExponentialFailureRateLimiter(defaultSyncBackOff, maxSyncBackOff),
-		workqueue.RateLimitingQueueConfig{Name: "ciliumidentity_resource"})
+	c.resourceQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.NewTypedItemExponentialFailureRateLimiter[QueuedItem](defaultSyncBackOff, maxSyncBackOff),
+		workqueue.TypedRateLimitingQueueConfig[QueuedItem]{Name: "ciliumidentity_resource"})
 }
 
 // startEventProcessing starts the event processing loop for the Controller.
@@ -244,32 +244,31 @@ func (c *Controller) processNextItem() bool {
 	if quit {
 		return false
 	}
-	qItem := item.(QueuedItem)
 	defer c.resourceQueue.Done(item)
 	processingStartTime := time.Now()
-	enqueueTime, exists := c.enqueueTimeTracker.GetAndReset(qItem.Key().String())
+	enqueueTime, exists := c.enqueueTimeTracker.GetAndReset(item.Key().String())
 
-	err := qItem.Reconcile(c.reconciler)
+	err := item.Reconcile(c.reconciler)
 	if err != nil {
 		retries := c.resourceQueue.NumRequeues(item)
-		c.logger.Warn("Failed to process resource item", logfields.Key, qItem.Key().String(), "retries", retries, "maxRetries", maxProcessRetries, logfields.Error, err)
+		c.logger.Warn("Failed to process resource item", logfields.Key, item.Key().String(), "retries", retries, "maxRetries", maxProcessRetries, logfields.Error, err)
 
 		if retries < maxProcessRetries {
-			c.enqueueTimeTracker.Track(qItem.Key().String())
+			c.enqueueTimeTracker.Track(item.Key().String())
 			c.resourceQueue.AddRateLimited(item)
 			return true
 		}
 
 		// Drop the pod from queue, exceeded max retries
-		c.logger.Error("Dropping item from resource queue, exceeded maxRetries", logfields.Key, qItem.Key().String(), "maxRetries", maxProcessRetries, logfields.Error, err)
+		c.logger.Error("Dropping item from resource queue, exceeded maxRetries", logfields.Key, item.Key().String(), "maxRetries", maxProcessRetries, logfields.Error, err)
 	}
 
 	if exists {
 		enqueuedLatency := processingStartTime.Sub(enqueueTime).Seconds()
 		processingLatency := time.Since(processingStartTime).Seconds()
-		qItem.Meter(enqueuedLatency, processingLatency, err != nil, c.metrics)
+		item.Meter(enqueuedLatency, processingLatency, err != nil, c.metrics)
 	} else {
-		c.logger.Warn("Enqueue time not found for queue item", logfields.Key, qItem.Key().String())
+		c.logger.Warn("Enqueue time not found for queue item", logfields.Key, item.Key().String())
 	}
 
 	c.resourceQueue.Forget(item)

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -59,7 +59,7 @@ var (
 	eventsOpts = resource.WithRateLimiter(
 		// This rate limiter will retry in the following pattern
 		// 250ms, 500ms, 1s, 2s, 4s, 8s, 16s, 32s, .... max 5m
-		workqueue.NewItemExponentialFailureRateLimiter(250*time.Millisecond, 5*time.Minute),
+		workqueue.NewTypedItemExponentialFailureRateLimiter[resource.WorkItem](250*time.Millisecond, 5*time.Minute),
 	)
 )
 

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -319,7 +319,10 @@ func (manager *Manager) processEvents(ctx context.Context) {
 	// the identity allocator, where the minimum retry timeout is set to 20
 	// milliseconds and the max number of attempts is 16 (so 20ms * 2^16 ==
 	// ~20 minutes)
-	endpointsRateLimit := workqueue.NewItemExponentialFailureRateLimiter(time.Millisecond*20, time.Minute*20)
+	endpointsRateLimit := workqueue.NewTypedItemExponentialFailureRateLimiter[resource.WorkItem](
+		time.Millisecond*20,
+		time.Minute*20,
+	)
 
 	policyEvents := manager.policies.Events(ctx)
 	nodeEvents := manager.ciliumNodes.Events(ctx)

--- a/pkg/hubble/metrics/metrics.go
+++ b/pkg/hubble/metrics/metrics.go
@@ -33,7 +33,7 @@ import (
 
 type CiliumEndpointDeletionHandler struct {
 	gracefulPeriod time.Duration
-	queue          workqueue.DelayingInterface
+	queue          workqueue.TypedDelayingInterface[*types.CiliumEndpoint]
 }
 
 var (
@@ -77,7 +77,7 @@ func ProcessCiliumEndpointDeletion(pod *types.CiliumEndpoint) error {
 func initEndpointDeletionHandler() {
 	endpointDeletionHandler = &CiliumEndpointDeletionHandler{
 		gracefulPeriod: time.Minute,
-		queue:          workqueue.NewDelayingQueue(),
+		queue:          workqueue.NewTypedDelayingQueue[*types.CiliumEndpoint](),
 	}
 
 	go func() {
@@ -86,7 +86,7 @@ func initEndpointDeletionHandler() {
 			if quit {
 				return
 			}
-			api.ProcessCiliumEndpointDeletion(endpoint.(*types.CiliumEndpoint), EnabledMetrics)
+			api.ProcessCiliumEndpointDeletion(endpoint, EnabledMetrics)
 			endpointDeletionHandler.queue.Done(endpoint)
 		}
 	}()

--- a/pkg/hubble/metrics/metrics_test.go
+++ b/pkg/hubble/metrics/metrics_test.go
@@ -42,7 +42,7 @@ func TestInitializedMetrics(t *testing.T) {
 		EnabledMetrics = []api.NamedHandler{}
 		endpointDeletionHandler = &CiliumEndpointDeletionHandler{
 			gracefulPeriod: 10 * time.Millisecond,
-			queue:          workqueue.NewDelayingQueue(),
+			queue:          workqueue.NewTypedDelayingQueue[*types.CiliumEndpoint](),
 		}
 
 		ProcessCiliumEndpointDeletion(deletedEndpoint)

--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -407,14 +407,14 @@ func (r *resource[T]) Stop(stopCtx cell.HookContext) error {
 }
 
 type eventsOpts struct {
-	rateLimiter  workqueue.RateLimiter
+	rateLimiter  workqueue.TypedRateLimiter[WorkItem]
 	errorHandler ErrorHandler
 }
 
 type EventsOpt func(*eventsOpts)
 
 // WithRateLimiter sets the rate limiting algorithm to be used when requeueing failed events.
-func WithRateLimiter(r workqueue.RateLimiter) EventsOpt {
+func WithRateLimiter(r workqueue.TypedRateLimiter[WorkItem]) EventsOpt {
 	return func(o *eventsOpts) {
 		o.rateLimiter = r
 	}
@@ -453,7 +453,7 @@ func (r *resource[T]) Events(ctx context.Context, opts ...EventsOpt) <-chan Even
 
 	options := eventsOpts{
 		errorHandler: AlwaysRetry, // Default error handling is to always retry.
-		rateLimiter:  workqueue.DefaultControllerRateLimiter(),
+		rateLimiter:  workqueue.DefaultTypedControllerRateLimiter[WorkItem](),
 	}
 	for _, apply := range opts {
 		apply(&options)
@@ -469,8 +469,8 @@ func (r *resource[T]) Events(ctx context.Context, opts ...EventsOpt) <-chan Even
 		r:         r,
 		options:   options,
 		debugInfo: debugInfo,
-		wq: workqueue.NewRateLimitingQueueWithConfig(options.rateLimiter,
-			workqueue.RateLimitingQueueConfig{Name: r.resourceName()}),
+		wq: workqueue.NewTypedRateLimitingQueueWithConfig[WorkItem](options.rateLimiter,
+			workqueue.TypedRateLimitingQueueConfig[WorkItem]{Name: r.resourceName()}),
 	}
 
 	// Fork a goroutine to process the queued keys and pass them to the subscriber.
@@ -588,7 +588,7 @@ func (r *resource[T]) resourceName() string {
 type subscriber[T k8sRuntime.Object] struct {
 	r         *resource[T]
 	debugInfo string
-	wq        workqueue.RateLimitingInterface
+	wq        workqueue.TypedRateLimitingInterface[WorkItem]
 	options   eventsOpts
 }
 
@@ -694,13 +694,12 @@ loop:
 	}
 }
 
-func (s *subscriber[T]) getWorkItem() (e workItem, shutdown bool) {
-	var raw any
-	raw, shutdown = s.wq.Get()
+func (s *subscriber[T]) getWorkItem() (e WorkItem, shutdown bool) {
+	raw, shutdown := s.wq.Get()
 	if shutdown {
 		return
 	}
-	return raw.(workItem), false
+	return raw, false
 }
 
 func (s *subscriber[T]) enqueueSync() {
@@ -711,7 +710,7 @@ func (s *subscriber[T]) enqueueKey(key Key) {
 	s.wq.Add(keyWorkItem{key})
 }
 
-func (s *subscriber[T]) eventDone(entry workItem, err error) {
+func (s *subscriber[T]) eventDone(entry WorkItem, err error) {
 	// This is based on the example found in k8s.io/client-go/examples/worsueue/main.go.
 
 	// Mark the object as done being processed. If it was marked dirty
@@ -788,13 +787,13 @@ func (l *lastKnownObjects[T]) DeleteByUID(key Key, objToDelete T) {
 	}
 }
 
-// workItem restricts the set of types we use when type-switching over the
+// WorkItem restricts the set of types we use when type-switching over the
 // queue entries, so that we'll get a compiler error on impossible types.
 //
 // The queue entries must be kept comparable and not be pointers as we want
 // to be able to coalesce multiple keyEntry's into a single element in the
 // queue.
-type workItem interface {
+type WorkItem interface {
 	isWorkItem()
 }
 

--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -743,9 +743,9 @@ func TestResource_Retries(t *testing.T) {
 	)
 
 	var rateLimiterUsed atomic.Int64
-	rateLimiter := func() workqueue.RateLimiter {
+	rateLimiter := func() workqueue.TypedRateLimiter[resource.WorkItem] {
 		rateLimiterUsed.Add(1)
-		return workqueue.DefaultControllerRateLimiter()
+		return workqueue.DefaultTypedControllerRateLimiter[resource.WorkItem]()
 	}
 
 	hive := hive.New(

--- a/pkg/kvstore/store/syncstore_test.go
+++ b/pkg/kvstore/store/syncstore_test.go
@@ -100,14 +100,14 @@ func NewFakeRateLimiter() *fakeRateLimiter {
 	return &fakeRateLimiter{whenCalled: make(chan *KVPair), forgetCalled: make(chan *KVPair)}
 }
 
-func (frl *fakeRateLimiter) When(item interface{}) time.Duration {
-	frl.whenCalled <- NewKVPair(item.(string), "")
+func (frl *fakeRateLimiter) When(item workqueueKey) time.Duration {
+	frl.whenCalled <- NewKVPair(item.value, "")
 	return time.Duration(0)
 }
-func (frl *fakeRateLimiter) Forget(item interface{}) {
-	frl.forgetCalled <- NewKVPair(item.(string), "")
+func (frl *fakeRateLimiter) Forget(item workqueueKey) {
+	frl.forgetCalled <- NewKVPair(item.value, "")
 }
-func (frl *fakeRateLimiter) NumRequeues(item interface{}) int { return 0 }
+func (frl *fakeRateLimiter) NumRequeues(item workqueueKey) int { return 0 }
 
 func eventually(in <-chan *KVPair) *KVPair {
 	select {


### PR DESCRIPTION
The workqueue got deprecated in favor of a generic one, this change makes cilium use the generic workqueue throughout.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!