### PR TITLE
nodeinit: move kubelet restart inside if/else in startup.bash

### DIFF
--- a/install/kubernetes/cilium/files/nodeinit/startup.bash
+++ b/install/kubernetes/cilium/files/nodeinit/startup.bash
@@ -116,6 +116,8 @@ else
   exec /home/kubernetes/bin/the-kubelet "${@}" --network-plugin=cni --cni-bin-dir={{ .Values.cni.binPath }}
 fi
 EOF
+    echo "Restarting the kubelet..."
+    systemctl restart kubelet
   else
     echo "Kubelet wrapper already exists, skipping..."
   fi
@@ -135,10 +137,10 @@ else
     echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir={{ .Values.cni.binPath }}"
     mkdir -p {{ .Values.cni.binPath }}
     sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir={{ .Values.cni.binPath }}:g" "${KUBELET_DEFAULTS_FILE}"
+    echo "Restarting the kubelet..."
+    systemctl restart kubelet
   fi
 fi
-echo "Restarting the kubelet..."
-systemctl restart kubelet
 {{- end }}
 
 {{- if (and .Values.gke.enabled (or .Values.enableIPv4Masquerade .Values.gke.disableDefaultSnat))}}


### PR DESCRIPTION
Moving the kubelet restart commands into specific conditional blocks, the kubelet won't be restarted unless it's necessary.
Restarting the kubelet may cause the Pod's Started and Ready statuses to be set to False for a short period of time, it can disrupt traffic for services for which the affected Pods act as backends. Therefore, we should avoid restarting the kubelet upon each start of the nodeinit pod, and only restart it in cases when the kubelet configuration or kubelet wrapper has changed.