### PR TITLE
bgpv1: Extend adverts tests duration timeout

### DIFF
--- a/pkg/bgpv1/test/adverts_test.go
+++ b/pkg/bgpv1/test/adverts_test.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	// maxTestDuration is allowed time for test execution
-	maxTestDuration = 15 * time.Second
+	maxTestDuration = 25 * time.Second
 
 	// maxGracefulRestartTestDuration is max allowed time for graceful restart test
 	maxGracefulRestartTestDuration = 1 * time.Minute


### PR DESCRIPTION
GoBGP uses [hard-coded 5s IdleHoldTimer](https://github.com/osrg/gobgp/blob/master/pkg/server/fsm.go#L145), which delays further connection attempts if a connection attempt fails.
This can delay the test session setup in some cases and the 15s test timeout may not be sufficient.

Related to: https://github.com/cilium/cilium/issues/37280
