### PR TITLE
identity: make locally-scoped identities observable

### DIFF
--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -834,7 +834,7 @@ type IdentityChange struct {
 	Labels labels.Labels
 }
 
-// Observe the identity changes. Conforms to stream.Observable.
+// Observe identity changes. Doesn't include local identities. Conforms to stream.Observable.
 // Replays the current state of the cache when subscribing.
 func (m *CachingIdentityAllocator) Observe(ctx context.Context, next func(IdentityChange), complete func(error)) {
 	// This short-lived go routine serves the purpose of waiting for the global identity allocator becoming ready
@@ -881,6 +881,12 @@ func mapLabels(allocatorKey allocator.AllocatorKey) labels.Labels {
 	}
 
 	return idLabels
+}
+
+// LocalIdentityChanges returns an observable for (only) node-local identities.
+// Replays current state on subscription followed by a Sync event.
+func (m *CachingIdentityAllocator) LocalIdentityChanges() stream.Observable[IdentityChange] {
+	return m.localIdentities
 }
 
 // clusterIDValidator returns a validator ensuring that the identity ID belongs

--- a/pkg/identity/cache/cell/cell.go
+++ b/pkg/identity/cache/cell/cell.go
@@ -67,6 +67,8 @@ type CachingIdentityAllocator interface {
 	ReleaseRestoredIdentities()
 
 	Close()
+
+	LocalIdentityChanges() stream.Observable[cache.IdentityChange]
 }
 
 type identityAllocatorParams struct {

--- a/pkg/identity/cache/noop_allocator.go
+++ b/pkg/identity/cache/noop_allocator.go
@@ -6,6 +6,7 @@ package cache
 import (
 	"context"
 
+	"github.com/cilium/stream"
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/allocator"
@@ -135,4 +136,9 @@ func (n *NoopIdentityAllocator) Close() {}
 func (m *NoopIdentityAllocator) Observe(ctx context.Context, next func(IdentityChange), complete func(error)) {
 	// No-op, because identities are not managed.
 	complete(nil)
+}
+
+// Noop identity allocator is itself a noop observable, just return itself as the local identity observable.
+func (m *NoopIdentityAllocator) LocalIdentityChanges() stream.Observable[IdentityChange] {
+	return m
 }


### PR DESCRIPTION
Introduces an implementation of Observable for locally-scoped identities. There's not a consumer at this point, but this will benefit the standalone DNS proxy work.