### PR TITLE
docs: add "devices" to helm reference guide

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1004,6 +1004,10 @@
      - defaultLBServiceIPAM indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set. Applicable values: lbipam, nodeipam, none @schema type: [string] @schema
      - string
      - ``"lbipam"``
+   * - :spelling:ignore:`devices`
+     - List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'. Note that setting this option disables auto-detection of devices, a feature that selects only those network devices with an IP address configured. Refer to ``forceDeviceDetection``.
+     - string
+     - ``nil`` 
    * - :spelling:ignore:`directRoutingSkipUnreachable`
      - Enable skipping of PodCIDR routes between worker nodes if the worker nodes are in a different L2 network segment.
      - bool


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

# Overview

Cilium's Helm Reference guide is missing the `devices` flag, though the same is in the `cilium-agent` [command reference guide](https://docs.cilium.io/en/stable/cmdref/cilium-agent/).  This adds it to the Helm guide.

## Description

The original help text shown in the `cilium-agent` code was first copied as written and then further expanded in the Helm documentation.  

A note was added regarding the interactions between `devices` and `forceDeviceDetection`, as the potential need for setting `forceDeviceDetection` when setting `devices` is not currently documented.  While there is a mention to `forceDeviceDetection` in the `cilium-agent` docs, I only discovered the potential need for that flag after coming across it in https://github.com/cilium/cilium/blob/main/pkg/datapath/linux/devices_controller.go.

## Testing

Locally, I ran `make render-docs` and then opened a browser to `http://localhost:9081`.  I observed:

<img width="1293" alt="Screenshot 2025-01-27 at 6 16 11 PM" src="https://github.com/user-attachments/assets/8c00088e-92e1-4714-805d-7586ed152389" />
