### PR TITLE
cilium-cli: extend no-interrupted-connections to test NodePort from outside

### DIFF
--- a/.github/actions/conn-disrupt-test-check/action.yaml
+++ b/.github/actions/conn-disrupt-test-check/action.yaml
@@ -31,11 +31,11 @@ runs:
           TEST_ARG="${{ inputs.tests }}"
         else
           TEST_ARG="no-interrupted-connections"
-          EXTRA_ARG="--include-conn-disrupt-test"
+          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic"
         fi
         if [[ "${{ inputs.full-test }}" == "true" ]]; then
           TEST_ARG=""
-          EXTRA_ARG="--include-conn-disrupt-test"
+          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic"
         fi
         ${{ inputs.cilium-cli }} connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
           --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \

--- a/.github/actions/conn-disrupt-test-setup/action.yaml
+++ b/.github/actions/conn-disrupt-test-setup/action.yaml
@@ -16,7 +16,9 @@ runs:
         # Create pods which establish long lived connections. It will be used by
         # subsequent connectivity tests with --include-conn-disrupt-test to catch any
         # interruption in such flows.
-        ${{ inputs.cilium-cli }} connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup \
+        ${{ inputs.cilium-cli }} connectivity test --include-conn-disrupt-test \
+          --include-conn-disrupt-test-ns-traffic \
+          --conn-disrupt-test-setup \
           --conn-disrupt-dispatch-interval 0ms \
           --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
           --conn-disrupt-test-xfrm-errors-path "./cilium-conn-disrupt-xfrm-errors" \

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -450,7 +450,8 @@ jobs:
           # interruption in such flows.
           cilium --context ${{ env.contextName1 }} connectivity test \
             --multi-cluster=${{ env.contextName2 }} --hubble=false \
-            --include-conn-disrupt-test --conn-disrupt-test-setup \
+            --include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic \
+            --conn-disrupt-test-setup \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --conn-disrupt-dispatch-interval 0ms
 
@@ -590,7 +591,7 @@ jobs:
           cilium --context ${{ env.contextName1 }} connectivity test \
             --multi-cluster=${{ env.contextName2 }} \
             ${{ steps.vars.outputs.connectivity_test_defaults }} \
-            --include-conn-disrupt-test \
+            --include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --junit-file "cilium-junits/${{ env.job_name }} - post upgrade (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests post-upgrade (${{ join(matrix.*, ', ') }})"
@@ -600,7 +601,8 @@ jobs:
           # interruption in such flows.
           cilium --context ${{ env.contextName1 }} connectivity test \
             --multi-cluster=${{ env.contextName2 }} --hubble=false \
-            --include-conn-disrupt-test --conn-disrupt-test-setup \
+            --include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic \
+            --conn-disrupt-test-setup \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --conn-disrupt-dispatch-interval 0ms
 
@@ -672,6 +674,7 @@ jobs:
             --test='no-interrupted-connections' \
             --test='no-unexpected-packet-drops' \
             --include-conn-disrupt-test \
+            --include-conn-disrupt-test-ns-traffic \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --junit-file "cilium-junits/${{ env.job_name }} - stress test (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests stess-test (${{ join(matrix.*, ', ') }})"
@@ -681,7 +684,8 @@ jobs:
           # interruption in such flows.
           cilium --context ${{ env.contextName1 }} connectivity test \
             --multi-cluster=${{ env.contextName2 }} --hubble=false \
-            --include-conn-disrupt-test --conn-disrupt-test-setup \
+            --include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic \
+            --conn-disrupt-test-setup \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --conn-disrupt-dispatch-interval 0ms
 
@@ -730,7 +734,7 @@ jobs:
           cilium --context ${{ env.contextName1 }} connectivity test \
             --multi-cluster=${{ env.contextName2 }} \
             ${{ steps.vars.outputs.connectivity_test_defaults }} \
-            --include-conn-disrupt-test \
+            --include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --junit-file "cilium-junits/${{ env.job_name }} - post downgrade (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests post-downgrade (${{ join(matrix.*, ', ') }})"

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -676,7 +676,8 @@ jobs:
           # Create pods which establish long lived connections. It will be used by
           # subsequent connectivity tests with --include-conn-disrupt-test to catch any
           # interruption in such flows.
-          cilium connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup \
+          cilium connectivity test --include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic \
+            --conn-disrupt-test-setup \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --conn-disrupt-dispatch-interval 0ms
 
@@ -721,6 +722,7 @@ jobs:
         run: |
           cilium connectivity test \
             --include-conn-disrupt-test \
+            --include-conn-disrupt-test-ns-traffic \
             --test "no-interrupted-connections" \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             ${{ steps.cli-flags.outputs.flags }}

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -171,6 +171,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	sysdump.InitSysdumpFlags(cmd, &params.SysdumpOptions, "sysdump-", hooks)
 
 	cmd.Flags().BoolVar(&params.IncludeConnDisruptTest, "include-conn-disrupt-test", false, "Include conn disrupt test")
+	cmd.Flags().BoolVar(&params.IncludeConnDisruptTestNSTraffic, "include-conn-disrupt-test-ns-traffic", false, "Include conn disrupt test for NS traffic")
 	cmd.Flags().BoolVar(&params.ConnDisruptTestSetup, "conn-disrupt-test-setup", false, "Set up conn disrupt test dependencies")
 	cmd.Flags().StringVar(&params.ConnDisruptTestRestartsPath, "conn-disrupt-test-restarts-path", "/tmp/cilium-conn-disrupt-restarts", "Conn disrupt test temporary result file (used internally)")
 	cmd.Flags().StringVar(&params.ConnDisruptTestXfrmErrorsPath, "conn-disrupt-test-xfrm-errors-path", "/tmp/cilium-conn-disrupt-xfrm-errors", "Conn disrupt test temporary result file (used internally)")

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -92,11 +92,12 @@ type Parameters struct {
 	ImpersonateGroups      []string
 	IPFamilies             []string
 
-	IncludeConnDisruptTest        bool
-	ConnDisruptTestSetup          bool
-	ConnDisruptTestRestartsPath   string
-	ConnDisruptTestXfrmErrorsPath string
-	ConnDisruptDispatchInterval   time.Duration
+	IncludeConnDisruptTest          bool
+	IncludeConnDisruptTestNSTraffic bool
+	ConnDisruptTestSetup            bool
+	ConnDisruptTestRestartsPath     string
+	ConnDisruptTestXfrmErrorsPath   string
+	ConnDisruptDispatchInterval     time.Duration
 
 	ExpectedDropReasons []string
 	ExpectedXFRMErrors  []string

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1295,6 +1295,7 @@ func (ct *ConnectivityTest) ForEachIPFamily(hasNetworkPolicies bool, do func(fea
 }
 
 func (ct *ConnectivityTest) ShouldRunConnDisruptNSTraffic() bool {
-	return ct.Features[features.NodeWithoutCilium].Enabled &&
+	return ct.params.IncludeConnDisruptTestNSTraffic &&
+		ct.Features[features.NodeWithoutCilium].Enabled &&
 		(ct.Params().MultiCluster == "" || ct.Features[features.KPRNodePort].Enabled)
 }

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1297,5 +1297,7 @@ func (ct *ConnectivityTest) ForEachIPFamily(hasNetworkPolicies bool, do func(fea
 func (ct *ConnectivityTest) ShouldRunConnDisruptNSTraffic() bool {
 	return ct.params.IncludeConnDisruptTestNSTraffic &&
 		ct.Features[features.NodeWithoutCilium].Enabled &&
-		(ct.Params().MultiCluster == "" || ct.Features[features.KPRNodePort].Enabled)
+		(ct.Params().MultiCluster == "" || ct.Features[features.KPRNodePort].Enabled) &&
+		!ct.Features[features.KPRNodePortAcceleration].Enabled &&
+		(!ct.Features[features.IPsecEnabled].Enabled || !ct.Features[features.KPRNodePort].Enabled)
 }

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -165,6 +165,11 @@ func (ct *ConnectivityTest) extractFeaturesFromCiliumStatus(ctx context.Context,
 			}
 			if f.NodePort != nil {
 				result[features.KPRNodePort] = features.Status{Enabled: f.NodePort.Enabled}
+				acceleration := strings.ToLower(f.NodePort.Acceleration)
+				result[features.KPRNodePortAcceleration] = features.Status{
+					Enabled: mode != "false" && acceleration != "disabled",
+					Mode:    mode,
+				}
 			}
 			if f.SessionAffinity != nil {
 				result[features.KPRSessionAffinity] = features.Status{Enabled: f.SessionAffinity.Enabled}

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -837,31 +837,7 @@ func (t *Test) collectSysdump() {
 }
 
 func (t *Test) ForEachIPFamily(do func(features.IPFamily)) {
-	ipFams := features.GetIPFamilies(t.ctx.Params().IPFamilies)
-
-	// The per-endpoint routes feature is broken with IPv6 on < v1.14 when there
-	// are any netpols installed (https://github.com/cilium/cilium/issues/23852
-	// and https://github.com/cilium/cilium/issues/23910).
-	if f, ok := t.Context().Feature(features.EndpointRoutes); ok &&
-		f.Enabled && t.HasNetworkPolicies() &&
-		versioncheck.MustCompile("<1.14.0")(t.Context().CiliumVersion) {
-
-		ipFams = []features.IPFamily{features.IPFamilyV4}
-	}
-
-	for _, ipFam := range ipFams {
-		switch ipFam {
-		case features.IPFamilyV4:
-			if f, ok := t.ctx.Features[features.IPv4]; ok && f.Enabled {
-				do(ipFam)
-			}
-
-		case features.IPFamilyV6:
-			if f, ok := t.ctx.Features[features.IPv6]; ok && f.Enabled {
-				do(ipFam)
-			}
-		}
-	}
+	t.ctx.ForEachIPFamily(t.HasNetworkPolicies(), do)
 }
 
 // CertificateCAs returns the CAs used to sign the certificates within the test.

--- a/cilium-cli/connectivity/tests/upgrade.go
+++ b/cilium-cli/connectivity/tests/upgrade.go
@@ -56,6 +56,22 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 		for _, pod := range pods.Items {
 			restartCount[pod.GetObjectMeta().GetName()] = strconv.Itoa(int(pod.Status.ContainerStatuses[0].RestartCount))
 		}
+
+		if ct.ShouldRunConnDisruptNSTraffic() {
+			pods, err = client.ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + check.KindTestConnDisruptNSTraffic})
+			if err != nil {
+				t.Fatalf("Unable to list test-conn-disrupt-ns-traffic pods: %s", err)
+			}
+			if len(pods.Items) == 0 {
+				t.Fatal("No test-conn-disrupt-{client,server} for NS traffic pods found")
+			}
+
+			for _, pod := range pods.Items {
+				restartCount[pod.GetObjectMeta().GetName()] = strconv.Itoa(int(pod.Status.ContainerStatuses[0].RestartCount))
+			}
+		} else {
+			ct.Info("Skipping conn-disrupt-test for NS traffic")
+		}
 	}
 
 	// Only store restart counters which will be used later when running the same

--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -239,6 +239,10 @@ func (c *Client) GetDeployment(ctx context.Context, namespace, name string, opts
 	return c.Clientset.AppsV1().Deployments(namespace).Get(ctx, name, opts)
 }
 
+func (c *Client) ListDeployment(ctx context.Context, namespace string, options metav1.ListOptions) (*appsv1.DeploymentList, error) {
+	return c.Clientset.AppsV1().Deployments(namespace).List(ctx, options)
+}
+
 func (c *Client) DeleteDeployment(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
 	return c.Clientset.AppsV1().Deployments(namespace).Delete(ctx, name, opts)
 }

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -26,14 +26,15 @@ const (
 	Tunnel             Feature = "tunnel"
 	EndpointRoutes     Feature = "endpoint-routes"
 
-	KPRMode                Feature = "kpr-mode"
-	KPRExternalIPs         Feature = "kpr-external-ips"
-	KPRGracefulTermination Feature = "kpr-graceful-termination"
-	KPRHostPort            Feature = "kpr-hostport"
-	KPRSocketLB            Feature = "kpr-socket-lb"
-	KPRSocketLBHostnsOnly  Feature = "kpr-socket-lb-hostns-only"
-	KPRNodePort            Feature = "kpr-nodeport"
-	KPRSessionAffinity     Feature = "kpr-session-affinity"
+	KPRMode                 Feature = "kpr-mode"
+	KPRExternalIPs          Feature = "kpr-external-ips"
+	KPRGracefulTermination  Feature = "kpr-graceful-termination"
+	KPRHostPort             Feature = "kpr-hostport"
+	KPRSocketLB             Feature = "kpr-socket-lb"
+	KPRSocketLBHostnsOnly   Feature = "kpr-socket-lb-hostns-only"
+	KPRNodePort             Feature = "kpr-nodeport"
+	KPRNodePortAcceleration Feature = "kpr-nodeport-acceleration"
+	KPRSessionAffinity      Feature = "kpr-session-affinity"
 
 	BPFLBExternalClusterIP Feature = "bpf-lb-external-clusterip"
 


### PR DESCRIPTION
This PR extends the conn-disrupt-test to ensure that external connections through a NodePort are not disrupted.

The test deploys a conn-disrupt-test server with a single replica in the cluster and multiple clients on an external node.
Clients establish long-lived TCP connections with the server using a NodePort. Each client selects a node where the backend is running, and one where the backend is not running. The clients send requests to both nodes using IPv4 and IPv6 addresses.

After upgrade, the test checks the restart counters, and compares them with the counters stored before the upgrade.  A mismatch indicates that a connection was interrupted.

Example output from `kubectl -n cilium-test-1 get po -o wide`:

```
NAME                                                              READY   STATUS    RESTARTS   AGE     IP             NODE
test-conn-disrupt-client-backend-node-ipv4-internalip-7fc97pbp9   1/1     Running   0          34s     172.18.0.2     kind-worker3
test-conn-disrupt-client-backend-node-ipv6-internalip-66bdtmg2z   1/1     Running   0          34s     172.18.0.2     kind-worker3
test-conn-disrupt-client-non-backend-node-ipv4-internalip-d6bns   1/1     Running   0          34s     172.18.0.2     kind-worker3
test-conn-disrupt-client-non-backend-node-ipv6-internalip-4x77p   1/1     Running   0          34s     172.18.0.2     kind-worker3
test-conn-disrupt-server-ns-traffic-5cc46556fb-bm9lz              1/1     Running   0          37s     10.244.2.173   kind-worker2
```


The conn-disrupt-test for NS traffic runs in the following workflows

- ci-e2e-upgrade
- ci-ipsec-upgrade
- ci-ipsec-e2

It will be skipped in the following because the feature node-without-cilium is disabled (The one for EW traffic will run)

- conformance-eks
- ci-clustermesh upgrade
- ci-ces-migrate

Note that ci-e2e-upgrade and ci-ipsec-upgrade become unstable if we enable no-interrupted-connections for NS traffic test. Will skip these conditions (lb-acceleration and ipsec + KPR + ipv6) for now, and investigate the cause as follow-up.

ci-e2e-upgrade (lb-acceleration enabled)
https://github.com/cilium/cilium/actions/runs/12984833400/job/36208601353

```
  ❌ Found unexpected packet drops:
{
  "labels": {
    "direction": "EGRESS",
    "reason": "FIB lookup failed"
  },
  "name": "cilium_drop_count_total",
  "value": 1
}
```

ci-ipsec-upgrade (ipsec + KPR + ipv6)
https://github.com/cilium/cilium/actions/runs/12982469981/job/36203776562
```
  [-] Scenario [no-interrupted-connections/no-interrupted-connections]
  🟥 Pod test-conn-disrupt-client-non-backend-node-ipv6-internalip-9rp69 flow was interrupted (restart count does not match 0 != 1)
```


Fixes: #13530
