### PR TITLE
test: drop no-op `-cilium.provision-k8s` flag

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -416,7 +416,6 @@ jobs:
              -cilium.hubble-relay-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
              -cilium.hubble-relay-tag=${{ needs.setup-vars.outputs.SHA }} \
              -cilium.kubeconfig=/root/.kube/config \
-             -cilium.provision-k8s=false \
              -cilium.operator-suffix=-ci ${{ env.CILIUM_GINKGO_EXTRA_ARGS }}"
 
               ./test.test \
@@ -432,7 +431,6 @@ jobs:
                -cilium.hubble-relay-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
                -cilium.hubble-relay-tag=${{ needs.setup-vars.outputs.SHA }} \
                -cilium.kubeconfig=/root/.kube/config \
-               -cilium.provision-k8s=false \
                -cilium.operator-suffix=-ci ${{ env.CILIUM_GINKGO_EXTRA_ARGS }}
 
       - name: Fetch artifacts

--- a/Documentation/contributing/testing/e2e_legacy.rst
+++ b/Documentation/contributing/testing/e2e_legacy.rst
@@ -246,7 +246,6 @@ usage information.
         -cilium.hubble-relay-image=quay.io/${quay_org}/hubble-relay-ci \
         -cilium.hubble-relay-tag=${commit_sha} \
         -cilium.kubeconfig=/root/.kube/config \
-        -cilium.provision-k8s=false \
         -cilium.operator-suffix=-ci \
         -cilium.holdEnvironment=true
       Using CNI_INTEGRATION="kind"
@@ -440,8 +439,6 @@ framework in the ``test/`` directory and interact with ginkgo directly:
             Pass the environment invoking ginkgo, including PATH, to subcommands
       -cilium.provision
             Provision Vagrant boxes and Cilium before running test (default true)
-      -cilium.provision-k8s
-            Specifies whether Kubernetes should be deployed and installed via kubeadm or not (default true)
       -cilium.runQuarantined
             Run tests that are under quarantine.
       -cilium.showCommands
@@ -734,7 +731,7 @@ To run tests with Kind, try
 
 .. code-block:: shell-session
 
-  K8S_VERSION=1.25 ginkgo --focus=K8s -- -cilium.provision=false --cilium.image=localhost:5000/cilium/cilium-dev -cilium.tag=local  --cilium.operator-image=localhost:5000/cilium/operator -cilium.operator-tag=local -cilium.kubeconfig=`echo ~/.kube/config` -cilium.provision-k8s=false  -cilium.testScope=K8s -cilium.operator-suffix=
+  K8S_VERSION=1.25 ginkgo --focus=K8s -- -cilium.provision=false --cilium.image=localhost:5000/cilium/cilium-dev -cilium.tag=local  --cilium.operator-image=localhost:5000/cilium/operator -cilium.operator-tag=local -cilium.kubeconfig=`echo ~/.kube/config` -cilium.testScope=K8s -cilium.operator-suffix=
 
 
 Running in GKE

--- a/contrib/scripts/run-gh-ginkgo-workflow.sh
+++ b/contrib/scripts/run-gh-ginkgo-workflow.sh
@@ -204,7 +204,6 @@ run_tests() {
             -cilium.hubble-relay-image=quay.io/${quay_org}/hubble-relay-ci \
             -cilium.hubble-relay-tag=${commit_sha} \
             -cilium.kubeconfig=/root/.kube/config \
-            -cilium.provision-k8s=false \
             -cilium.operator-suffix=-ci \
             -cilium.holdEnvironment=true"
 }

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -35,7 +35,6 @@ type CiliumTestConfigType struct {
 	CiliumOperatorSuffix string
 	HubbleRelayImage     string
 	HubbleRelayTag       string
-	ProvisionK8s         bool
 	Timeout              time.Duration
 	Kubeconfig           string
 	KubectlPath          string
@@ -85,8 +84,6 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Specifies which image of hubble-relay to use during tests")
 	flagset.StringVar(&c.HubbleRelayTag, "cilium.hubble-relay-tag", "",
 		"Specifies which tag of hubble-relay to use during tests")
-	flagset.BoolVar(&c.ProvisionK8s, "cilium.provision-k8s", true,
-		"Specifies whether Kubernetes should be deployed and installed via kubeadm or not")
 	flagset.DurationVar(&c.Timeout, "cilium.timeout", 24*time.Hour,
 		"Specifies timeout for test run")
 	flagset.StringVar(&c.Kubeconfig, "cilium.kubeconfig", "",

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -265,10 +265,6 @@ func Init() {
 		os.Setenv("HUBBLE_RELAY_TAG", config.CiliumTestConfig.HubbleRelayTag)
 	}
 
-	if !config.CiliumTestConfig.ProvisionK8s {
-		os.Setenv("SKIP_K8S_PROVISION", "true")
-	}
-
 	// Copy over envronment variables that are passed in.
 	for envVar, helmVar := range map[string]string{
 		"CILIUM_TAG":             "image.tag",


### PR DESCRIPTION
Setting the `SKIP_K8S_PROVISION` environment variable no longer has any effect since commit 306b022567bc ("drop vagrant and Jenkins references").