### PR TITLE
ipsec: Fix XFRM leak test for encrypted overlay

### DIFF
--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -17,9 +17,7 @@ import (
 	"time"
 
 	"github.com/cilium/ebpf/rlimit"
-	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
-	"github.com/cilium/statedb"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
@@ -32,7 +30,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
-	"github.com/cilium/cilium/pkg/hive"
 	nodemapfake "github.com/cilium/cilium/pkg/maps/nodemap/fake"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
 	"github.com/cilium/cilium/pkg/mtu"
@@ -838,74 +835,6 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeChurnXFRMLeaksSubnetMode(t *testi
 	config.IPv6PodSubnets = []*cidr.CIDR{ipv6PodSubnets}
 	option.Config.BootIDFile = "/proc/sys/kernel/random/boot_id"
 	s.testNodeChurnXFRMLeaksWithConfig(t, config)
-}
-
-func (s *linuxPrivilegedIPv4OnlyTestSuite) TestEncryptedOverlayXFRMLeaks(t *testing.T) {
-	// Cover the XFRM configuration for IPAM modes cluster-pool, kubernetes, etc.
-	config := datapath.LocalNodeConfiguration{
-		EnableIPv4:  s.enableIPv4,
-		EnableIPv6:  s.enableIPv6,
-		EnableIPSec: true,
-	}
-	s.testEncryptedOverlayXFRMLeaks(t, config)
-}
-
-// TestEncryptedOverlayXFRMLeaks tests that the XFRM policies and states are accurate when the encrypted overlay
-// feature is enabled and disabled.
-func (s *linuxPrivilegedIPv4OnlyTestSuite) testEncryptedOverlayXFRMLeaks(t *testing.T, config datapath.LocalNodeConfiguration) {
-	tlog := hivetest.Logger(t)
-	keys := bytes.NewReader([]byte("6+ rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n"))
-	_, _, err := ipsec.LoadIPSecKeys(tlog, keys)
-	require.NoError(t, err)
-
-	var linuxNodeHandler *linuxNodeHandler
-	h := hive.New(
-		DevicesControllerCell,
-		cell.Invoke(func(db *statedb.DB, devices statedb.Table[*tables.Device]) {
-			dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-			linuxNodeHandler = newNodeHandler(tlog, dpConfig, nodemapfake.NewFakeNodeMapV2(), new(mockEnqueuer))
-		}),
-	)
-
-	require.NoError(t, h.Start(tlog, context.TODO()))
-	defer func() { require.NoError(t, h.Stop(tlog, context.TODO())) }()
-	require.NotNil(t, linuxNodeHandler)
-
-	err = linuxNodeHandler.NodeConfigurationChanged(config)
-	require.NoError(t, err)
-
-	// Adding a node adds some XFRM states and policies.
-	node := nodeTypes.Node{
-		Name: "node",
-		IPAddresses: []nodeTypes.Address{
-			{IP: net.ParseIP("3.3.3.3"), Type: nodeaddressing.NodeInternalIP},
-			{IP: net.ParseIP("4.4.4.4"), Type: nodeaddressing.NodeCiliumInternalIP},
-		},
-		IPv4AllocCIDR: cidr.MustParseCIDR("4.4.4.0/24"),
-		BootID:        "b892866c-26cb-4018-8a55-c0330551a2be",
-	}
-	err = linuxNodeHandler.NodeAdd(node)
-	require.NoError(t, err)
-
-	states, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
-	require.NoError(t, err)
-	require.Len(t, states, 4)
-	policies, err := netlink.XfrmPolicyList(netlink.FAMILY_ALL)
-	require.NoError(t, err)
-	require.Equal(t, 2, countXFRMPolicies(policies))
-
-	// disable encrypted overlay feature
-	config.EnableIPSecEncryptedOverlay = false
-
-	err = linuxNodeHandler.NodeConfigurationChanged(config)
-	require.NoError(t, err)
-
-	states, err = netlink.XfrmStateList(netlink.FAMILY_ALL)
-	require.NoError(t, err)
-	require.Len(t, states, 2)
-	policies, err = netlink.XfrmPolicyList(netlink.FAMILY_ALL)
-	require.NoError(t, err)
-	require.Equal(t, 1, countXFRMPolicies(policies))
 }
 
 func (s *linuxPrivilegedBaseTestSuite) testNodeChurnXFRMLeaksWithConfig(t *testing.T, config datapath.LocalNodeConfiguration) {

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -807,6 +807,17 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeChurnXFRMLeaks(t *testing.T) {
 	s.testNodeChurnXFRMLeaksWithConfig(t, config)
 }
 
+// Tests the same as TestNodeChurnXFRMLeaks, but in tunneling mode. As a
+// consequence, encrypted overlay will kick in.
+func TestNodeChurnXFRMLeaksEncryptedOverlay(t *testing.T) {
+	s := setupLinuxPrivilegedIPv4OnlyTestSuite(t)
+	config := s.nodeConfigTemplate
+	config.EnableIPSec = true
+	config.EnableEncapsulation = true
+	option.Config.BootIDFile = "/proc/sys/kernel/random/boot_id"
+	s.testNodeChurnXFRMLeaksWithConfig(t, config)
+}
+
 // Tests the same as linuxPrivilegedBaseTestSuite.TestNodeChurnXFRMLeaks just
 // for the subnet encryption.
 func (s *linuxPrivilegedBaseTestSuite) TestNodeChurnXFRMLeaksSubnetMode(t *testing.T) {


### PR DESCRIPTION
This pull request reimplements the XFRM leak test for encrypted overlay. That test wasn't actually working or executed before.