### PR TITLE
Clean up high scale ipcache leftovers

### DIFF
--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -515,69 +515,6 @@ var HaveNetkit = sync.OnceValue(func() error {
 	})
 })
 
-// HaveOuterSourceIPSupport tests whether the kernel support setting the outer
-// source IP address via the bpf_skb_set_tunnel_key BPF helper. We can't rely
-// on the verifier to reject a program using the new support because the
-// verifier just accepts any argument size for that helper; non-supported
-// fields will simply not be used. Instead, we set the outer source IP and
-// retrieve it with bpf_skb_get_tunnel_key right after. If the retrieved value
-// equals the value set, we have a confirmation the kernel supports it.
-func HaveOuterSourceIPSupport() (err error) {
-	defer func() {
-		if err != nil && !errors.Is(err, ebpf.ErrNotSupported) {
-			log.WithError(err).Fatal("failed to probe for outer source IP support")
-		}
-	}()
-
-	progSpec := &ebpf.ProgramSpec{
-		Name:    "set_tunnel_key_probe",
-		Type:    ebpf.SchedACT,
-		License: "GPL",
-	}
-	progSpec.Instructions = asm.Instructions{
-		asm.Mov.Reg(asm.R8, asm.R1),
-
-		asm.Mov.Imm(asm.R2, 0),
-		asm.StoreMem(asm.RFP, -8, asm.R2, asm.DWord),
-		asm.StoreMem(asm.RFP, -16, asm.R2, asm.DWord),
-		asm.StoreMem(asm.RFP, -24, asm.R2, asm.DWord),
-		asm.StoreMem(asm.RFP, -32, asm.R2, asm.DWord),
-		asm.StoreMem(asm.RFP, -40, asm.R2, asm.DWord),
-		asm.Mov.Imm(asm.R2, 42),
-		asm.StoreMem(asm.RFP, -44, asm.R2, asm.Word),
-		asm.Mov.Reg(asm.R2, asm.RFP),
-		asm.Add.Imm(asm.R2, -44),
-		asm.Mov.Imm(asm.R3, 44), // sizeof(struct bpf_tunnel_key) when setting the outer source IP is supported.
-		asm.Mov.Imm(asm.R4, 0),
-		asm.FnSkbSetTunnelKey.Call(),
-
-		asm.Mov.Reg(asm.R1, asm.R8),
-		asm.Mov.Reg(asm.R2, asm.RFP),
-		asm.Add.Imm(asm.R2, -44),
-		asm.Mov.Imm(asm.R3, 44),
-		asm.Mov.Imm(asm.R4, 0),
-		asm.FnSkbGetTunnelKey.Call(),
-
-		asm.LoadMem(asm.R0, asm.RFP, -44, asm.Word),
-		asm.Return(),
-	}
-	prog, err := ebpf.NewProgram(progSpec)
-	if err != nil {
-		return err
-	}
-	defer prog.Close()
-
-	pkt := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-	ret, _, err := prog.Test(pkt)
-	if err != nil {
-		return err
-	}
-	if ret != 42 {
-		return ebpf.ErrNotSupported
-	}
-	return nil
-}
-
 // HaveSKBAdjustRoomL2RoomMACSupport tests whether the kernel supports the `bpf_skb_adjust_room` helper
 // with the `BPF_ADJ_ROOM_MAC` mode. To do so, we create a program that requests the passed in SKB
 // to be expanded by 20 bytes. The helper checks the `mode` argument and will return -ENOSUPP if

--- a/pkg/datapath/linux/probes/probes_test.go
+++ b/pkg/datapath/linux/probes/probes_test.go
@@ -304,15 +304,6 @@ func TestExecuteHeaderProbes(t *testing.T) {
 	}
 }
 
-func TestOuterSourceIPProbe(t *testing.T) {
-	testutils.PrivilegedTest(t)
-	testutils.SkipOnOldKernel(t, "5.19", "source IP support in struct bpf_tunnel_key")
-
-	if err := HaveOuterSourceIPSupport(); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestSKBAdjustRoomL2RoomMACSupportProbe(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	testutils.SkipOnOldKernel(t, "5.2", "BPF_ADJ_ROOM_MAC mode support in bpf_skb_adjust_room")

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -141,12 +141,6 @@ func (id *Identity) IsWellKnown() bool {
 	return WellKnown.lookupByNumericIdentity(id.ID) != nil
 }
 
-// IsWellKnownIdentity returns true if the identity represents a well-known
-// identity, false otherwise.
-func IsWellKnownIdentity(id NumericIdentity) bool {
-	return WellKnown.lookupByNumericIdentity(id) != nil
-}
-
 // NewIdentityFromLabelArray creates a new identity
 func NewIdentityFromLabelArray(id NumericIdentity, lblArray labels.LabelArray) *Identity {
 	var lbls labels.Labels


### PR DESCRIPTION
Clean up some code left unused after the high-scale ipcache mode was removed in #36898. See commits for details.
