### PR TITLE
node/manager: Trigger node neighbor reconciliation after carrier down

### DIFF
--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -5,8 +5,11 @@ package manager
 
 import (
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
 
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -86,9 +89,12 @@ func newAllNodeManager(in struct {
 	IPSetFilter IPSetFilterFn `optional:"true"`
 	NodeMetrics *nodeMetrics
 	Health      cell.Health
+	JobGroup    job.Group
+	DB          *statedb.DB
+	Devices     statedb.Table[*tables.Device]
 },
 ) (NodeManager, error) {
-	mngr, err := New(option.Config, in.IPCache, in.IPSetMgr, in.IPSetFilter, in.NodeMetrics, in.Health)
+	mngr, err := New(option.Config, in.IPCache, in.IPSetMgr, in.IPSetFilter, in.NodeMetrics, in.Health, in.JobGroup, in.DB, in.Devices)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"iter"
 	"math/rand/v2"
 	"net"
 	"net/netip"
@@ -18,17 +19,21 @@ import (
 	"sync"
 
 	"github.com/cilium/hive/cell"
-	"github.com/cilium/workerpool"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
 	"github.com/google/renameio/v2"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"go4.org/netipx"
+	"golang.org/x/sys/unix"
 	"golang.org/x/time/rate"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ip"
@@ -64,10 +69,6 @@ var (
 
 	neighborTableRefreshControllerGroup = controller.NewGroup("neighbor-table-refresh")
 	neighborTableUpdateControllerGroup  = controller.NewGroup("neighbor-table-update")
-)
-
-const (
-	numBackgroundWorkers = 1
 )
 
 type nodeEntry struct {
@@ -134,8 +135,8 @@ type manager struct {
 	// events.
 	nodeHandlers map[datapath.NodeHandler]struct{}
 
-	// workerpool manages background workers
-	workerpool *workerpool.WorkerPool
+	// group of jobs, tied to the lifecycle of the manager
+	jobGroup job.Group
 
 	// metrics to track information about the node manager
 	metrics *nodeMetrics
@@ -168,6 +169,11 @@ type manager struct {
 
 	// Ensure the pruning is only attempted once.
 	nodePruneOnce sync.Once
+
+	// Reference to the StateDB
+	db *statedb.DB
+	// The devices table
+	devices statedb.Table[*tables.Device]
 }
 
 type nodeQueueEntry struct {
@@ -289,7 +295,17 @@ func NewNodeMetrics() *nodeMetrics {
 }
 
 // New returns a new node manager
-func New(c *option.DaemonConfig, ipCache IPCache, ipsetMgr ipset.Manager, ipsetFilter IPSetFilterFn, nodeMetrics *nodeMetrics, health cell.Health) (*manager, error) {
+func New(
+	c *option.DaemonConfig,
+	ipCache IPCache,
+	ipsetMgr ipset.Manager,
+	ipsetFilter IPSetFilterFn,
+	nodeMetrics *nodeMetrics,
+	health cell.Health,
+	jobGroup job.Group,
+	db *statedb.DB,
+	devices statedb.Table[*tables.Device],
+) (*manager, error) {
 	if ipsetFilter == nil {
 		ipsetFilter = func(*nodeTypes.Node) bool { return false }
 	}
@@ -306,31 +322,33 @@ func New(c *option.DaemonConfig, ipCache IPCache, ipsetMgr ipset.Manager, ipsetF
 		ipsetFilter:       ipsetFilter,
 		metrics:           nodeMetrics,
 		health:            health,
+		jobGroup:          jobGroup,
+		db:                db,
+		devices:           devices,
 	}
 
 	return m, nil
 }
 
 func (m *manager) Start(cell.HookContext) error {
-	m.workerpool = workerpool.New(numBackgroundWorkers)
-
 	// Ensure that we read a potential nodes file before we overwrite it.
 	m.restoreNodeCheckpoint()
 	if err := m.initNodeCheckpointer(nodeCheckpointMinInterval); err != nil {
 		return fmt.Errorf("failed to initialize node file writer: %w", err)
 	}
 
-	return m.workerpool.Submit("backgroundSync", m.backgroundSync)
+	m.jobGroup.Add(job.OneShot("backgroundSync", m.backgroundSync))
+
+	// In LB-only doing reconciliation of node neighbors should not happen
+	if !option.Config.LoadBalancerOnly {
+		m.jobGroup.Add(job.OneShot("carrierDownReconciler", m.carrierDownReconciler))
+	}
+
+	return nil
 }
 
 // Stop shuts down a node manager
 func (m *manager) Stop(cell.HookContext) error {
-	if m.workerpool != nil {
-		if err := m.workerpool.Close(); err != nil {
-			return err
-		}
-	}
-
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -385,9 +403,108 @@ func (m *manager) backgroundSyncInterval() time.Duration {
 	return m.ClusterSizeDependantInterval(baseBackgroundSyncInterval)
 }
 
+func (m *manager) carrierDownReconciler(ctx context.Context, health cell.Health) error {
+	runningDevices := make(sets.Set[int])
+
+	// Collect all up and running devices, and start watching for changes
+	txn := m.db.WriteTxn(m.devices)
+	devChanges, err := m.devices.Changes(txn)
+	if err != nil {
+		txn.Abort()
+		return fmt.Errorf("failed to watch device table: %w", err)
+	}
+
+	devices, watch := m.devices.AllWatch(txn)
+	for dev := range devices {
+		if !deviceIsUpAndRunning(dev) {
+			continue
+		}
+
+		runningDevices = runningDevices.Insert(dev.Index)
+	}
+	txn.Commit()
+
+	health.OK("Watching for device changes")
+
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			// If the context is done, we should stop the background sync.
+			return nil
+		case <-watch:
+			// On changes to the device table
+
+			revalidate := false
+
+		changesLoop:
+			for {
+				// Use change iterator instead of [statedb.Table.AllWatch] so we can catch when a device
+				// goes down for a short time. Something we would miss by looking at just the latest state.
+				var changes iter.Seq2[statedb.Change[*tables.Device], uint64]
+				changes, watch = devChanges.Next(m.db.ReadTxn())
+				for change := range changes {
+					isRunning := runningDevices.Has(change.Object.Index)
+
+					if change.Deleted {
+						// If a running device has been deleted, we just need to track that.
+						// No need for revalidation.
+						runningDevices = runningDevices.Delete(change.Object.Index)
+						continue
+					}
+
+					upAndRunning := deviceIsUpAndRunning(change.Object)
+					if !isRunning && upAndRunning {
+						// This device is new, or was not up and running before.
+						// We should revalidate the node implementations.
+						runningDevices = runningDevices.Insert(change.Object.Index)
+						revalidate = true
+					} else if isRunning && !upAndRunning {
+						// This device was up and running, but is no longer.
+						// Keep track so we know to revalidate when it comes back up.
+						runningDevices = runningDevices.Delete(change.Object.Index)
+					}
+				}
+
+				// The change iterator will return an already closed channel if there are more changes.
+				// So lets process all changes until we get a channel that will block for optimal batching.
+				select {
+				case <-watch:
+				default:
+					break changesLoop
+				}
+			}
+
+			if !revalidate {
+				health.OK("Processed device change, not revalidating")
+				continue loop
+			}
+
+			// A device went down, was removed, added, or went up. We need to
+			// trigger node neighbor system to reconcile neighbor entries
+
+			m.mutex.RLock()
+			for _, entry := range m.nodes {
+				entry.mutex.Lock()
+				entryNode := entry.node
+				entry.mutex.Unlock()
+
+				if entryNode.IsLocal() {
+					continue
+				}
+
+				m.Enqueue(&entryNode)
+			}
+			m.mutex.RUnlock()
+
+			health.OK("Processed device change, enqueued all nodes")
+		}
+	}
+}
+
 // backgroundSync ensures that local node has a valid datapath in-place for
 // each node in the cluster. See NodeValidateImplementation().
-func (m *manager) backgroundSync(ctx context.Context) error {
+func (m *manager) backgroundSync(ctx context.Context, health cell.Health) error {
 	for {
 		syncInterval := m.backgroundSyncInterval()
 		startWaiting := time.After(syncInterval)
@@ -404,13 +521,37 @@ func (m *manager) backgroundSync(ctx context.Context) error {
 		case <-startWaiting:
 		}
 
-		hr := m.health.NewScope("background-sync")
 		if err != nil {
-			hr.Degraded("Failed to apply node validation", err)
+			health.Degraded("Failed to apply node validation", err)
 		} else {
-			hr.OK("Node validation successful")
+			health.OK("Node validation successful")
 		}
 	}
+}
+
+const (
+	upAndRunningFlags = unix.IFF_UP | unix.IFF_RUNNING
+	LoopbackFlags     = unix.IFF_LOOPBACK
+)
+
+// Check if a given device is up and running (not down or carrier down).
+// Always returns false for non-physical devices so we never detect a
+// transition from down to up.
+func deviceIsUpAndRunning(dev *tables.Device) bool {
+	// We only care about physical devices. So we select for [netlink.Device].
+	// This technically also include loopback devices, but those are filtered
+	// in a later step.
+	if dev.Type != "device" {
+		return false
+	}
+
+	loopbackDevice := dev.RawFlags&LoopbackFlags != 0
+	if loopbackDevice {
+		return false
+	}
+
+	upAndRunning := dev.RawFlags&upAndRunningFlags == upAndRunningFlags
+	return upAndRunning
 }
 
 func (m *manager) singleBackgroundLoop(ctx context.Context, expectedLoopTime time.Duration) error {

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -21,9 +21,11 @@ import (
 	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/health"
@@ -240,7 +242,7 @@ func TestNodeLifecycle(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 
@@ -319,7 +321,7 @@ func TestMultipleSources(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -402,7 +404,7 @@ func BenchmarkUpdateAndDeleteCycle(b *testing.B) {
 	ipcacheMock := newIPcacheMock()
 	dp := fakeTypes.NewNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(b, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -426,7 +428,7 @@ func TestClusterSizeDependantInterval(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	dp := fakeTypes.NewNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -451,7 +453,7 @@ func TestBackgroundSync(t *testing.T) {
 	signalNodeHandler.EnableNodeValidateImplementationEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	mngr.Subscribe(signalNodeHandler)
 	require.NoError(t, err)
 	defer mngr.Stop(context.TODO())
@@ -498,7 +500,7 @@ func TestIpcache(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -575,7 +577,7 @@ func TestIpcacheHealthIP(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -657,7 +659,7 @@ func TestNodeEncryption(t *testing.T) {
 	mngr, err := New(&option.DaemonConfig{
 		EncryptNode: true,
 		EnableIPSec: true,
-	}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -750,7 +752,7 @@ func TestNode(t *testing.T) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	mngr, err := New(&option.DaemonConfig{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -911,6 +913,222 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 	assert.NoError(err)
 }
 
+// TestCarrierDownReconciler tests that we can detect carrier down events for physical devices
+// but ignore loopback devices.
+func TestCarrierDownReconciler(t *testing.T) {
+	// Declare values to use outside of hive later.
+	var (
+		m           *manager
+		deviceTable statedb.RWTable[*tables.Device]
+		db          *statedb.DB
+	)
+
+	// Use hive to create the manager and tables, mock the rest.
+	h := hive.New(
+		cell.Provide(tables.NewDeviceTable),                   // Provide statedb.RWTable[*tables.Device]
+		cell.Provide(statedb.RWTable[*tables.Device].ToTable), // Provide statedb.Table[*tables.Device] from RW table
+		cell.Invoke(statedb.RegisterTable[*tables.Device]),
+		cell.Provide(func() testParams {
+			return testParams{
+				Config:        &option.DaemonConfig{},
+				IPCache:       newIPcacheMock(),
+				IPSet:         newIPSetMock(),
+				NodeMetrics:   NewNodeMetrics(),
+				IPSetFilterFn: func(no *nodeTypes.Node) bool { return false },
+			}
+		}),
+		cell.Module("node_manager", "Node Manager",
+			cell.Provide(New),
+		),
+		cell.Invoke(func(manager *manager, dt statedb.RWTable[*tables.Device], database *statedb.DB) {
+			m = manager
+			deviceTable = dt
+			db = database
+		}),
+	)
+
+	// Just populate the hive, no need to start it.
+	h.Populate(hivetest.Logger(t))
+
+	// Add a node to the manager. When we decide to revalidate neighbors, we do so for all nodes
+	// so we need at least one to be present otherwise we will never enqueue anything.
+	m.nodes[nodeTypes.Identity{
+		Name: "node1",
+	}] = &nodeEntry{
+		node: nodeTypes.Node{
+			Name: "node1",
+		},
+	}
+
+	// Stop the reconciler if things take to long.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Create two devices, eth0 and lo. We will modify these devices to simulate carrier changes.
+	tx := db.WriteTxn(deviceTable)
+	_, _, err := deviceTable.Insert(tx, &tables.Device{
+		Index:    1,
+		Name:     "eth0",
+		RawFlags: unix.IFF_UP | unix.IFF_RUNNING,
+		Type:     "device",
+	})
+	if err != nil {
+		tx.Abort()
+		t.Fatal(err)
+	}
+
+	_, _, err = deviceTable.Insert(tx, &tables.Device{
+		Index:    2,
+		Name:     "lo",
+		RawFlags: unix.IFF_UP | unix.IFF_RUNNING | unix.IFF_LOOPBACK,
+		Type:     "device",
+	})
+	if err != nil {
+		tx.Abort()
+		t.Fatal(err)
+	}
+
+	tx.Commit()
+
+	// Create a mock health reporter. We will the health reporting as a signal for when reconciliation
+	// happened.
+	mh := &mockHealth{ok: make(chan struct{}, 10)}
+	// Wait for at least one OK signal, but consume more if there are any.
+	wait := func() {
+		<-mh.ok
+	loop:
+		for {
+			select {
+			case <-mh.ok:
+			default:
+				break loop
+			}
+		}
+	}
+
+	// Start the reconciler in the background.
+	go m.carrierDownReconciler(ctx, mh)
+
+	// Wait for the initial OK we get after initialization
+	wait()
+
+	// Modify eth0 so it is carrier down
+	tx = db.WriteTxn(deviceTable)
+	_, _, err = deviceTable.Insert(tx, &tables.Device{
+		Index:    1,
+		Name:     "eth0",
+		RawFlags: unix.IFF_UP,
+		Type:     "device",
+	})
+	if err != nil {
+		tx.Abort()
+		t.Fatal(err)
+	}
+	tx.Commit()
+
+	// Wait for reconciliation
+	wait()
+
+	if !m.nodeNeighborQueue.isEmpty() {
+		t.Fatal("Expected nodeNeighborQueue to be empty")
+	}
+
+	// Modify eth0 so its carrier is up again.
+	tx = db.WriteTxn(deviceTable)
+	_, _, err = deviceTable.Insert(tx, &tables.Device{
+		Index:    1,
+		Name:     "eth0",
+		RawFlags: unix.IFF_UP | unix.IFF_RUNNING,
+		Type:     "device",
+	})
+	if err != nil {
+		tx.Abort()
+		t.Fatal(err)
+	}
+	tx.Commit()
+
+	// Wait for reconciliation
+	wait()
+
+	if m.nodeNeighborQueue.isEmpty() {
+		t.Fatal("Expected nodeNeighborQueue to not be empty")
+	}
+	// Drain the queue
+	for _, more := m.nodeNeighborQueue.pop(); more; _, more = m.nodeNeighborQueue.pop() {
+	}
+
+	// Modify lo so its down
+	tx = db.WriteTxn(deviceTable)
+	_, _, err = deviceTable.Insert(tx, &tables.Device{
+		Index:    2,
+		Name:     "lo",
+		RawFlags: unix.IFF_LOOPBACK,
+		Type:     "device",
+	})
+	if err != nil {
+		tx.Abort()
+		t.Fatal(err)
+	}
+
+	tx.Commit()
+
+	// Wait for reconciliation
+	wait()
+
+	if !m.nodeNeighborQueue.isEmpty() {
+		t.Fatal("Expected nodeNeighborQueue to be empty")
+	}
+
+	// Modify lo so its carrier is up again.
+	tx = db.WriteTxn(deviceTable)
+	_, _, err = deviceTable.Insert(tx, &tables.Device{
+		Index:    2,
+		Name:     "lo",
+		RawFlags: unix.IFF_UP | unix.IFF_RUNNING | unix.IFF_LOOPBACK,
+		Type:     "device",
+	})
+
+	if err != nil {
+		tx.Abort()
+		t.Fatal(err)
+	}
+
+	tx.Commit()
+
+	// Wait for reconciliation
+	wait()
+
+	// We expect the queue to still be empty since we should be ignoring changes
+	// to loopback devices.
+	if !m.nodeNeighborQueue.isEmpty() {
+		t.Fatal("Expected nodeNeighborQueue to be empty")
+	}
+
+	cancel()
+}
+
+var _ cell.Health = (*mockHealth)(nil)
+
+type mockHealth struct {
+	ok chan struct{}
+}
+
+func (mh *mockHealth) OK(status string) {
+	mh.ok <- struct{}{}
+}
+
+func (mh *mockHealth) Degraded(reason string, err error) {
+}
+
+func (mh *mockHealth) Stopped(reason string) {
+}
+
+func (mh *mockHealth) NewScope(name string) cell.Health {
+	return mh
+}
+
+func (mh *mockHealth) Close() {}
+
 type testParams struct {
 	cell.Out
 	Config        *option.DaemonConfig
@@ -949,7 +1167,7 @@ func TestNodeWithSameInternalIP(t *testing.T) {
 	h, _ := cell.NewSimpleHealth()
 	mngr, err := New(&option.DaemonConfig{
 		LocalRouterIPv4: "169.254.4.6",
-	}, ipcache, newIPSetMock(), nil, NewNodeMetrics(), h)
+	}, ipcache, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -1049,7 +1267,7 @@ func TestNodeIpset(t *testing.T) {
 	mngr, err := New(&option.DaemonConfig{
 		RoutingMode:          option.RoutingModeNative,
 		EnableIPv4Masquerade: true,
-	}, newIPcacheMock(), newIPSetMock(), filter, NewNodeMetrics(), h)
+	}, newIPcacheMock(), newIPSetMock(), filter, NewNodeMetrics(), h, nil, nil, nil)
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 	defer mngr.Stop(context.TODO())
@@ -1230,7 +1448,7 @@ func TestNodesStartupPruning(t *testing.T) {
 	mngr, err := New(&option.DaemonConfig{
 		StateDir:    tmp,
 		ClusterName: "c1",
-	}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h)
+	}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		mngr.Stop(context.TODO())

--- a/pkg/node/manager/rest_api_test.go
+++ b/pkg/node/manager/rest_api_test.go
@@ -33,7 +33,7 @@ func setupGetNodesSuite(tb testing.TB) *GetNodesSuite {
 	option.Config.IPv6ServiceRange = "auto"
 
 	h, _ := cell.NewSimpleHealth()
-	nm, err := New(fakeConfig, nil, &fakeTypes.IPSet{}, nil, NewNodeMetrics(), h)
+	nm, err := New(fakeConfig, nil, &fakeTypes.IPSet{}, nil, NewNodeMetrics(), h, nil, nil, nil)
 	require.NoError(tb, err)
 
 	g := &GetNodesSuite{


### PR DESCRIPTION
When a carrier down event occurs on a physical device, the kernel will flush the neighbor table entries associated with that device. To ensure our datapath can always forward traffic to other nodes, we add managed neighbor entries for the next hops of these nodes.

This change uses the device table to detect when a device comes up after being down, including carrier down, and triggers reconciliation of neighbor entries for all nodes.

```release-note
Reconcile node neighbor table entries after recovering from carrier down events
```
