### PR TITLE
docs: add documentation for operator managing identities

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -253,6 +253,7 @@ cilium-agent [flags]
       --hubble-tls-key-file string                                Path to the private key file for the Hubble server. The file must contain PEM encoded data.
       --identity-allocation-mode string                           Method to use for identity allocation (default "kvstore")
       --identity-change-grace-period duration                     Time to wait before using new identity on endpoint identity change (default 5s)
+      --identity-management-mode string                           Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --identity-restore-grace-period duration                    Time to wait before releasing unused restored CIDR identities during agent restart (default 30s)
       --ignore-flags-drift-checker strings                        Ignores specified flags during drift checking
       --ingress-secrets-namespace string                          IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -117,6 +117,7 @@ cilium-agent hive [flags]
       --hubble-tls-cert-file string                               Path to the public key file for the Hubble server. The file must contain PEM encoded data.
       --hubble-tls-client-ca-files strings                        Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
       --hubble-tls-key-file string                                Path to the private key file for the Hubble server. The file must contain PEM encoded data.
+      --identity-management-mode string                           Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ignore-flags-drift-checker strings                        Ignores specified flags during drift checking
       --ingress-secrets-namespace string                          IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -122,6 +122,7 @@ cilium-agent hive dot-graph [flags]
       --hubble-tls-cert-file string                               Path to the public key file for the Hubble server. The file must contain PEM encoded data.
       --hubble-tls-client-ca-files strings                        Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
       --hubble-tls-key-file string                                Path to the private key file for the Hubble server. The file must contain PEM encoded data.
+      --identity-management-mode string                           Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ignore-flags-drift-checker strings                        Ignores specified flags during drift checking
       --ingress-secrets-namespace string                          IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -72,6 +72,7 @@ cilium-operator-alibabacloud [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -52,6 +52,7 @@ cilium-operator-alibabacloud hive [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -57,6 +57,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -80,6 +80,7 @@ cilium-operator-aws [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -52,6 +52,7 @@ cilium-operator-aws hive [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -57,6 +57,7 @@ cilium-operator-aws hive dot-graph [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -75,6 +75,7 @@ cilium-operator-azure [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -52,6 +52,7 @@ cilium-operator-azure hive [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -57,6 +57,7 @@ cilium-operator-azure hive dot-graph [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -71,6 +71,7 @@ cilium-operator-generic [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -52,6 +52,7 @@ cilium-operator-generic hive [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -57,6 +57,7 @@ cilium-operator-generic hive dot-graph [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -85,6 +85,7 @@ cilium-operator [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -52,6 +52,7 @@ cilium-operator hive [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -57,6 +57,7 @@ cilium-operator hive dot-graph [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
       --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
       --ingress-default-request-timeout duration             Default request timeout for Ingress.
       --ingress-default-secret-name string                   Default secret name for Ingress.

--- a/Documentation/network/kubernetes/identity-management-mode.rst
+++ b/Documentation/network/kubernetes/identity-management-mode.rst
@@ -1,0 +1,66 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _IdentityManagementMode:
+
+***************************
+Identity Management Mode
+***************************
+
+Cilium supports Cilium Identity (CID) management by either the Cilium Agents (default) or the
+Cilium Operator.
+
+When the Operator manages identities, identity creation is centralized. This provides benefits
+such as reduced CID duplication, which can occur when multiple Agents simultaneously create identities for
+the same set of labels. Given that there is a limitation on the maximum number of identities in a cluster
+and eBPF Policy Map size (see :ref:`bpf_map_limitations`), when the operator manages identities, we can improve the
+reliability of network policies and cluster scalability.
+
+.. note::
+
+    Labels relevant to identity management may be configured in the Cilium ConfigMap (see: :ref:`identity-relevant-labels`).
+    If the Cilium Operator is managing identities, both the Operator and Agents must be restarted to pick up the new label
+    pattern setting.
+
+Enable Identity Management by the Cilium Operator (Beta)
+=========================================================
+
+.. include:: ../../beta.rst
+
+The Cilium Agents manage CIDs by default. This section describes the steps necessary for enabling CID management by the Cilium Operator.
+
+Enable Operator Managing Identities on a New Cluster
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To enable the Cilium Operator to manage identities on a new cluster, set the ``identityManagementMode`` value to ``operator`` in your Helm chart
+or set the ``identity-management-mode`` flag to ``operator`` in the ``cilium-config`` configmap.
+
+How to Migrate from Cilium Agent to Cilium Operator Managing Identities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In order to minimize disruptions to connections or workload management, the following procedure should be followed. Note that in order
+to prevent disruptions to the cluster, there is an intermediate state where both the Cilium Agents and the Operator manage identities.
+As long as the Cilium Agents are creating identities, the CID duplication issue may occur. The transitional state is intended to
+only be used temporarily for the purpose of migrating identity management modes.
+
+#. Allow the Operator to also manage identities by setting the ``identityManagementMode`` value to ``both`` in your Helm chart or
+   by setting the ``identity-management-mode`` flag to ``both`` in the ``cilium-config`` configmap. Restart the Operator.
+
+#. Once the operator is running, upgrade the Cilium Agents by setting the ``identityManagementMode`` value to ``operator``
+   or by setting the ``identity-management-mode`` flag to ``operator`` and restarting the Cilium Agent DaemonSet.
+
+How to Downgrade from Cilium Operator to Cilium Agent Managing Identities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For a safe downgrade, the following procedure should be followed.
+
+#. First, downgrade the Cilium Agents by setting the ``identityManagementMode`` value to ``both`` in your Helm chart or
+   by setting the ``identity-management-mode`` flag to ``both`` in the ``cilium-config`` configmap. Restart the Cilium Agent DaemonSet.
+
+#. Once the Cilium Agents are running, downgrade the Operator by setting the ``identityManagementMode`` value to ``agent`` and restarting
+   the Operator.
+
+Metrics
+========
+Metrics for identity management by the operator are documented in the :ref:`identity_management_metrics` section of the metric documentation.

--- a/Documentation/network/kubernetes/index.rst
+++ b/Documentation/network/kubernetes/index.rst
@@ -27,3 +27,4 @@ Kubernetes Networking
    kata
    ipam
    local-redirect-policy
+   identity-management-mode

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -819,6 +819,17 @@ Name                                         Labels  Default    Description
 ``doublewrite_kvstore_only_identities``              Enabled    The number of identities in the KVStore not present as a CRD
 ============================================ ======= ========== ============================================================
 
+.. _identity_management_metrics:
+
+Identity Management Mode
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+=========================================== =========================== =====================================================================================
+Name                                        Labels                      Description
+=========================================== =========================== =====================================================================================
+``cid_controller_work_queue_event_count``   ``resource``, ``outcome``   Counts processed events by CID controller work queues
+``cid_controller_work_queue_latency``       ``resource``, ``phase``     Duration of CID controller work queues enqueuing and processing latencies in seconds
+=========================================== =========================== =====================================================================================
 
 Hubble
 ------

--- a/Documentation/operations/performance/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/performance/scalability/identity-relevant-labels.rst
@@ -92,13 +92,14 @@ with ``example.com``, whereas ``.*example\.com`` will match labels that contain
 the pattern matching too broadly and therefore including or excluding too many
 labels.
 
-The label patterns are using regular expressions. Therefore, using  ``kind$`` 
+The label patterns are using regular expressions. Therefore, using  ``kind$``
 or ``^kind$`` can exactly match the label key ``kind``, not just the prefix.
 
 Upon defining a custom list of label patterns in the ConfigMap, Cilium adds the
 provided list of label patterns to the default list of label patterns. After
-saving the ConfigMap, restart the Cilium Agents to pickup the new label pattern
-setting.
+saving the ConfigMap, if the Operator is managing identities (:ref:`IdentityManagementMode`),
+restart both the Cilium Operators and Agents to pickup the new label pattern setting. If the Agent
+is managing identities, restart the Cilium Agents to pickup the new label pattern.
 
 .. code-block:: shell-session
 
@@ -160,7 +161,7 @@ for Cilium identities:
 - name-defined
 
 Because we have ``$`` in label key ``kind$`` and ``other$``. Only label keys using
-exactly ``kind`` and ``other`` will be evaluated for Cilium. 
+exactly ``kind`` and ``other`` will be evaluated for Cilium.
 
 When a single inclusive label is added to the filter, all labels not defined
 in the default list will be excluded. For example, pods running with the

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -322,6 +322,7 @@ endpointSelector
 endpointmanager
 enet
 enetc
+enqueuing
 etcd
 etcdinit
 eth

--- a/operator/pkg/ciliumidentity/cell.go
+++ b/operator/pkg/ciliumidentity/cell.go
@@ -23,23 +23,14 @@ var Cell = cell.Module(
 
 type config struct {
 	IdentityManagementMode string `mapstructure:"identity-management-mode"`
-
-	// Deprecated in favor of IdentityManagementMode.
-	EnableOperatorManageCIDs bool `mapstructure:"operator-manages-identities"`
 }
 
 func (c config) Flags(flags *pflag.FlagSet) {
 	flags.String(option.IdentityManagementMode, c.IdentityManagementMode, "Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both")
-	flags.MarkHidden(option.IdentityManagementMode) // See https://github.com/cilium/cilium/issues/34675
-
-	// Deprecated in favor of IdentityManagementMode
-	flags.Bool("operator-manages-identities", c.EnableOperatorManageCIDs, "Enables operator to manage Cilium Identities by running a Cilium Identity controller")
-	flags.MarkHidden("operator-manages-identities") // See https://github.com/cilium/cilium/issues/34675
 }
 
 var defaultConfig = config{
-	IdentityManagementMode:   option.IdentityManagementModeAgent,
-	EnableOperatorManageCIDs: false,
+	IdentityManagementMode: option.IdentityManagementModeAgent,
 }
 
 // SharedConfig contains the configuration that is shared between

--- a/operator/pkg/ciliumidentity/controller.go
+++ b/operator/pkg/ciliumidentity/controller.go
@@ -94,7 +94,6 @@ func registerController(p params) {
 	isOperatorManageCIDsEnabled := cmp.Or(
 		p.Config.IdentityManagementMode == option.IdentityManagementModeOperator,
 		p.Config.IdentityManagementMode == option.IdentityManagementModeBoth,
-		p.Config.EnableOperatorManageCIDs, // backwards-compatibility with deprecated operator-manages-identities flag.
 	)
 
 	if cmp.Or(

--- a/operator/pkg/ciliumidentity/controller_test.go
+++ b/operator/pkg/ciliumidentity/controller_test.go
@@ -117,13 +117,11 @@ func initHiveTest(operatorManagingCID bool) (*resource.Resource[*capi_v2.CiliumI
 		cell.Provide(func() config {
 			if operatorManagingCID {
 				return config{
-					IdentityManagementMode:   option.IdentityManagementModeOperator,
-					EnableOperatorManageCIDs: true, // deprecated
+					IdentityManagementMode: option.IdentityManagementModeOperator,
 				}
 			} else {
 				return config{
-					IdentityManagementMode:   option.IdentityManagementModeAgent,
-					EnableOperatorManageCIDs: false, // deprecated
+					IdentityManagementMode: option.IdentityManagementModeAgent,
 				}
 			}
 		}),

--- a/pkg/identity/cache/cell/cell.go
+++ b/pkg/identity/cache/cell/cell.go
@@ -96,23 +96,14 @@ type identityAllocatorOut struct {
 
 type config struct {
 	IdentityManagementMode string `mapstructure:"identity-management-mode"`
-
-	// Deprecated in favor of IdentityManagementMode.
-	EnableOperatorManageCIDs bool `mapstructure:"operator-manages-identities"`
 }
 
 func (c config) Flags(flags *pflag.FlagSet) {
 	flags.String(option.IdentityManagementMode, c.IdentityManagementMode, "Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both")
-	flags.MarkHidden(option.IdentityManagementMode) // See https://github.com/cilium/cilium/issues/34675
-
-	// Deprecated in favor of IdentityManagementMode
-	flags.Bool("operator-manages-identities", c.EnableOperatorManageCIDs, "Enables operator to manage Cilium Identities by running a Cilium Identity controller")
-	flags.MarkHidden("operator-manages-identities") // See https://github.com/cilium/cilium/issues/34675
 }
 
 var defaultConfig = config{
-	IdentityManagementMode:   option.IdentityManagementModeAgent,
-	EnableOperatorManageCIDs: false,
+	IdentityManagementMode: option.IdentityManagementModeAgent,
 }
 
 func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
@@ -131,7 +122,6 @@ func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
 		isOperatorManageCIDsEnabled := cmp.Or(
 			params.Config.IdentityManagementMode == option.IdentityManagementModeOperator,
 			params.Config.IdentityManagementMode == option.IdentityManagementModeBoth,
-			params.Config.EnableOperatorManageCIDs, // backwards-compatibility with deprecated operator-manages-identities flag.
 		)
 
 		allocatorConfig := cache.AllocatorConfig{


### PR DESCRIPTION
Remove deprecated flag `operator-manages-identities` and unhide flag `identity-management-mode`. Add/update public documentation on operator managing identities.

Fixes: #34675
