### PR TITLE
gh: harmonize lvh kernel naming scheme

### DIFF
--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -6,25 +6,25 @@ include:
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.32.0@sha256:22cf2864f90cfab0d442fda2decf2eae107edd03483053a902614dec637eff76"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "bpf-next-20250110.013326@sha256:4f33de8f4deb6c5af3fdcdd8f57bc7567f7e0ea56e511c296b427a99d15c9c42"
+    kernel: "bpf-next-20250110.013326"
 
   - k8s-version: "1.31"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.31.0@sha256:d2b2a8cd6fa282b9a4126938341a4d2924dfa96f60b1f983d519498c9cde1a99"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "rhel8.6-20241218.004849@sha256:ba7d32e6291029f44422752b444a3f471155c5eb3c865a90d5e213c274796cb9"
+    kernel: "rhel8.6-20241218.004849"
 
   - k8s-version: "1.30"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.30.0@sha256:edcb457c0b2ecc69a0fa9b0878bdcfd4a0f1205340cf08bf36a03d3a94a16dd9"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "rhel8.6-20241218.004849@sha256:ba7d32e6291029f44422752b444a3f471155c5eb3c865a90d5e213c274796cb9"
+    kernel: "rhel8.6-20241218.004849"
 
   - k8s-version: "1.29"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.29.12@sha256:62c0672ba99a4afd7396512848d6fc382906b8f33349ae68fb1dbfe549f70dec"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "5.4-20241218.004849@sha256:7e3279228075a3b9d227c7b09298f79559d9bef236173ce0f8b58e159d4a0788"
+    kernel: "5.4-20241218.004849"

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -267,7 +267,7 @@ jobs:
           test-name: runtime-tests
           install-dependencies: true
           # renovate: datasource=docker depName=quay.io/lvh-images/kind
-          image-version: "bpf-next-20250110.013326@sha256:4f33de8f4deb6c5af3fdcdd8f57bc7567f7e0ea56e511c296b427a99d15c9c42"
+          image-version: "bpf-next-20250110.013326"
           host-mount: ./
           images-folder-parent: "/tmp"
           cpu: 4


### PR DESCRIPTION
Some workflows still specify the digest of the LVH kernel image. Remove it to have identical behavior across all workflows, and to simplify parsing in the LVH action.