### PR TITLE
bpf: remove guards around CILIUM_NET_IFINDEX / CILIUM_HOST_MAC

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -669,12 +669,9 @@ ct_recreate6:
 		if (ep) {
 #if defined(ENABLE_HOST_ROUTING) || defined(ENABLE_ROUTING)
 			if (ep->flags & ENDPOINT_MASK_HOST_DELIVERY) {
-				if (is_defined(ENABLE_ROUTING)) {
-# ifdef CILIUM_NET_IFINDEX
+				if (is_defined(ENABLE_ROUTING))
 					goto to_host;
-# endif
-					return DROP_HOST_UNREACHABLE;
-				}
+
 				goto pass_to_stack;
 			}
 #endif /* ENABLE_HOST_ROUTING || ENABLE_ROUTING */
@@ -1179,12 +1176,9 @@ ct_recreate4:
 		if (ep) {
 #if defined(ENABLE_HOST_ROUTING) || defined(ENABLE_ROUTING)
 			if (ep->flags & ENDPOINT_MASK_HOST_DELIVERY) {
-				if (is_defined(ENABLE_ROUTING)) {
-# ifdef CILIUM_NET_IFINDEX
+				if (is_defined(ENABLE_ROUTING))
 					goto to_host;
-# endif
-					return DROP_HOST_UNREACHABLE;
-				}
+
 				goto pass_to_stack;
 			}
 #endif /* ENABLE_HOST_ROUTING || ENABLE_ROUTING */

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -158,7 +158,6 @@ not_esp:
 	/* A packet entering the node from the tunnel and not going to a local
 	 * endpoint has to be going to the local host.
 	 */
-#ifdef CILIUM_NET_IFINDEX
 	if (1) {
 		union macaddr host_mac = CILIUM_HOST_MAC;
 		union macaddr router_mac = THIS_INTERFACE_MAC;
@@ -171,9 +170,6 @@ not_esp:
 		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, CILIUM_NET_IFINDEX);
 		return ctx_redirect(ctx, CILIUM_NET_IFINDEX, 0);
 	}
-#else
-	return CTX_ACT_OK;
-#endif
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_FROM_OVERLAY)
@@ -195,7 +191,6 @@ int tail_handle_ipv6(struct __ctx_buff *ctx)
 #ifdef ENABLE_IPV4
 static __always_inline int ipv4_host_delivery(struct __ctx_buff *ctx, struct iphdr *ip4)
 {
-#ifdef CILIUM_NET_IFINDEX
 	if (1) {
 		union macaddr host_mac = CILIUM_HOST_MAC;
 		union macaddr router_mac = THIS_INTERFACE_MAC;
@@ -209,9 +204,6 @@ static __always_inline int ipv4_host_delivery(struct __ctx_buff *ctx, struct iph
 		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, CILIUM_NET_IFINDEX);
 		return ctx_redirect(ctx, CILIUM_NET_IFINDEX, 0);
 	}
-#else
-	return CTX_ACT_OK;
-#endif
 }
 
 #if defined(ENABLE_CLUSTER_AWARE_ADDRESSING) && defined(ENABLE_INTER_CLUSTER_SNAT)

--- a/bpf/lib/proxy_hairpin.h
+++ b/bpf/lib/proxy_hairpin.h
@@ -13,8 +13,6 @@
 #include "csum.h"
 #include "l4.h"
 
-#if defined(CILIUM_HOST_MAC) && defined(CILIUM_NET_IFINDEX)
-
 /** Redirect to the proxy by hairpinning the packet out the incoming
  *  interface.
  *
@@ -76,5 +74,3 @@ ctx_redirect_to_proxy_hairpin_ipv6(struct __ctx_buff *ctx, __be16 proxy_port)
 	return ctx_redirect_to_proxy_hairpin(ctx, NULL, proxy_port);
 }
 #endif
-
-#endif /* CILIUM_HOST_MAC && CILIUM_NET_IFINDEX */


### PR DESCRIPTION
These devices are created regardless of the specific cilium config, and the stubs for compile testing are also defined unconditionally. Therefore at this stage it's no longer necessary to guard these code paths.

In particular for the parts in bpf_lxc this is a nice simplification.