### PR TITLE
cilium-dbg/troubleshoot: do not import cilium-dbg from operator

### DIFF
--- a/Documentation/cmdref/cilium-dbg_troubleshoot_clustermesh.md
+++ b/Documentation/cmdref/cilium-dbg_troubleshoot_clustermesh.md
@@ -11,6 +11,7 @@ cilium-dbg troubleshoot clustermesh [clusters...] [flags]
 ### Options
 
 ```
+      --H string                     URI to server-side API
       --clustermesh-config string    Path to the ClusterMesh configuration directory (default "/var/lib/cilium/clustermesh/")
   -h, --help                         help for clustermesh
       --timeout duration             Timeout when checking connectivity to a given cluster (default 5s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_troubleshoot_clustermesh.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_troubleshoot_clustermesh.md
@@ -11,6 +11,7 @@ cilium-operator-alibabacloud troubleshoot clustermesh [clusters...] [flags]
 ### Options
 
 ```
+      --H string                     URI to server-side API
       --clustermesh-config string    Path to the ClusterMesh configuration directory (default "/var/lib/cilium/clustermesh/")
   -h, --help                         help for clustermesh
       --timeout duration             Timeout when checking connectivity to a given cluster (default 5s)

--- a/Documentation/cmdref/cilium-operator-aws_troubleshoot_clustermesh.md
+++ b/Documentation/cmdref/cilium-operator-aws_troubleshoot_clustermesh.md
@@ -11,6 +11,7 @@ cilium-operator-aws troubleshoot clustermesh [clusters...] [flags]
 ### Options
 
 ```
+      --H string                     URI to server-side API
       --clustermesh-config string    Path to the ClusterMesh configuration directory (default "/var/lib/cilium/clustermesh/")
   -h, --help                         help for clustermesh
       --timeout duration             Timeout when checking connectivity to a given cluster (default 5s)

--- a/Documentation/cmdref/cilium-operator-azure_troubleshoot_clustermesh.md
+++ b/Documentation/cmdref/cilium-operator-azure_troubleshoot_clustermesh.md
@@ -11,6 +11,7 @@ cilium-operator-azure troubleshoot clustermesh [clusters...] [flags]
 ### Options
 
 ```
+      --H string                     URI to server-side API
       --clustermesh-config string    Path to the ClusterMesh configuration directory (default "/var/lib/cilium/clustermesh/")
   -h, --help                         help for clustermesh
       --timeout duration             Timeout when checking connectivity to a given cluster (default 5s)

--- a/Documentation/cmdref/cilium-operator-generic_troubleshoot_clustermesh.md
+++ b/Documentation/cmdref/cilium-operator-generic_troubleshoot_clustermesh.md
@@ -11,6 +11,7 @@ cilium-operator-generic troubleshoot clustermesh [clusters...] [flags]
 ### Options
 
 ```
+      --H string                     URI to server-side API
       --clustermesh-config string    Path to the ClusterMesh configuration directory (default "/var/lib/cilium/clustermesh/")
   -h, --help                         help for clustermesh
       --timeout duration             Timeout when checking connectivity to a given cluster (default 5s)

--- a/Documentation/cmdref/cilium-operator_troubleshoot_clustermesh.md
+++ b/Documentation/cmdref/cilium-operator_troubleshoot_clustermesh.md
@@ -11,6 +11,7 @@ cilium-operator troubleshoot clustermesh [clusters...] [flags]
 ### Options
 
 ```
+      --H string                     URI to server-side API
       --clustermesh-config string    Path to the ClusterMesh configuration directory (default "/var/lib/cilium/clustermesh/")
   -h, --help                         help for clustermesh
       --timeout duration             Timeout when checking connectivity to a given cluster (default 5s)

--- a/cilium-dbg/cmd/root.go
+++ b/cilium-dbg/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/cilium/cilium/cilium-dbg/cmd/troubleshoot"
 	clientPkg "github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/cmdref"
 	"github.com/cilium/cilium/pkg/components"
@@ -55,6 +56,7 @@ func init() {
 	vp.BindPFlags(flags)
 	RootCmd.AddCommand(cmdref.NewCmd(RootCmd))
 	RootCmd.AddCommand(newCmdCompletion(os.Stdout))
+	RootCmd.AddCommand(troubleshoot.Cmd)
 	RootCmd.SetOut(os.Stdout)
 	RootCmd.SetErr(os.Stderr)
 }

--- a/cilium-dbg/cmd/troubleshoot/troubleshoot.go
+++ b/cilium-dbg/cmd/troubleshoot/troubleshoot.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package cmd
+package troubleshoot
 
 import (
 	"context"
@@ -21,15 +21,11 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 )
 
-// TroubleshootCmd represents the troubleshoot command. Note that this command
+// Cmd represents the troubleshoot command. Note that this command
 // is additionally registered as a subcommand of the Cilium operator.
-var TroubleshootCmd = &cobra.Command{
+var Cmd = &cobra.Command{
 	Use:   "troubleshoot",
 	Short: "Run troubleshooting utilities to check control-plane connectivity",
-}
-
-func init() {
-	RootCmd.AddCommand(TroubleshootCmd)
 }
 
 var _ kvstore.EtcdDbgDialer = (*troubleshootDialer)(nil)

--- a/cilium-dbg/cmd/troubleshoot/troubleshoot_kvstore.go
+++ b/cilium-dbg/cmd/troubleshoot/troubleshoot_kvstore.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package cmd
+package troubleshoot
 
 import (
 	"context"
@@ -51,5 +51,5 @@ var troubleshootKVStoreCmd = func() *cobra.Command {
 }()
 
 func init() {
-	TroubleshootCmd.AddCommand(troubleshootKVStoreCmd)
+	Cmd.AddCommand(troubleshootKVStoreCmd)
 }

--- a/clustermesh-apiserver/kvstoremesh-dbg/troubleshoot.go
+++ b/clustermesh-apiserver/kvstoremesh-dbg/troubleshoot.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	ciliumdbg "github.com/cilium/cilium/cilium-dbg/cmd"
+	ciliumdbg "github.com/cilium/cilium/cilium-dbg/cmd/troubleshoot"
 	"github.com/cilium/cilium/pkg/kvstore"
 )
 

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	operatorApi "github.com/cilium/cilium/api/v1/operator/server"
-	ciliumdbg "github.com/cilium/cilium/cilium-dbg/cmd"
+	troubleshoot "github.com/cilium/cilium/cilium-dbg/cmd/troubleshoot"
 	"github.com/cilium/cilium/operator/api"
 	"github.com/cilium/cilium/operator/auth"
 	"github.com/cilium/cilium/operator/doublewrite"
@@ -324,7 +324,7 @@ func NewOperatorCmd(h *hive.Hive) *cobra.Command {
 		cmdref.NewCmd(cmd),
 		MetricsCmd,
 		StatusCmd,
-		ciliumdbg.TroubleshootCmd,
+		troubleshoot.Cmd,
 		h.Command(),
 	)
 


### PR DESCRIPTION
Since we are importing cilium-dbg from the operator, this is causing all of its init() functions to be initialized causing some potential concurrency issues as cilium-dbg is initializing functions assuming it's the only binary using them, same as with the operator. To avoid this problem, we will move the troubleshoot as an independent package that can be imported by the operator, the clustermesh-apiserver and the cilium-dbg tool.

Fixes: 5f0e3e21ae40 ("operator: add troubleshoot subcommands")