### PR TITLE
fix concurrency issue related with allocator cache

### DIFF
--- a/cilium-dbg/cmd/preflight_identity_crd_migrate.go
+++ b/cilium-dbg/cmd/preflight_identity_crd_migrate.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"path"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cilium/hive/cell"
@@ -212,9 +213,10 @@ func initK8s(ctx context.Context, clientset k8sClient.Clientset) (crdBackend all
 
 	// Create a CRD Backend
 	crdBackend, err := identitybackend.NewCRDBackend(identitybackend.CRDBackendConfiguration{
-		Store:   nil,
-		Client:  clientset,
-		KeyFunc: (&cacheKey.GlobalIdentity{}).PutKeyFromMap,
+		Store:    nil,
+		StoreSet: &atomic.Bool{},
+		Client:   clientset,
+		KeyFunc:  (&cacheKey.GlobalIdentity{}).PutKeyFromMap,
 	})
 	if err != nil {
 		log.WithError(err).Fatal("Cannot create CRD identity backend")

--- a/operator/doublewrite/metricreporter.go
+++ b/operator/doublewrite/metricreporter.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cilium/hive/cell"
@@ -90,7 +91,7 @@ func (g *DoubleWriteMetricReporter) Start(ctx cell.HookContext) error {
 	}
 	g.kvStoreBackend = kvStoreBackend
 
-	crdBackend, err := identitybackend.NewCRDBackend(identitybackend.CRDBackendConfiguration{Store: nil, Client: g.clientset, KeyFunc: (&key.GlobalIdentity{}).PutKeyFromMap})
+	crdBackend, err := identitybackend.NewCRDBackend(identitybackend.CRDBackendConfiguration{Store: nil, StoreSet: &atomic.Bool{}, Client: g.clientset, KeyFunc: (&key.GlobalIdentity{}).PutKeyFromMap})
 	if err != nil {
 		g.logger.Error("Unable to initialize CRD backend for the Double Write Metric Reporter", logfields.Error, err)
 		return err

--- a/pkg/kvstore/allocator/doublewrite/backend_test.go
+++ b/pkg/kvstore/allocator/doublewrite/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"path"
 	"strconv"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -37,9 +38,10 @@ func setup(tb testing.TB) (string, *k8sClient.FakeClientset, allocator.Backend) 
 	backend, err := NewDoubleWriteBackend(
 		DoubleWriteBackendConfiguration{
 			CRDBackendConfiguration: identitybackend.CRDBackendConfiguration{
-				Store:   nil,
-				Client:  kubeClient,
-				KeyFunc: (&key.GlobalIdentity{}).PutKeyFromMap,
+				Store:    nil,
+				StoreSet: &atomic.Bool{},
+				Client:   kubeClient,
+				KeyFunc:  (&key.GlobalIdentity{}).PutKeyFromMap,
 			},
 			KVStoreBackendConfiguration: kvstoreallocator.KVStoreBackendConfiguration{
 				BasePath: kvstorePrefix,


### PR DESCRIPTION
Add an atomic.Bool to control if the store has been set or not instead of reading the variable directly. The concurrent was detected by golang's race detector:
```
Read at 0x00c000eab638 by goroutine 844:
  k8s.io/client-go/tools/cache.(*threadSafeMap).Get()
      /go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/thread_safe_store.go:256 +0xcd
  k8s.io/client-go/tools/cache.(*cache).GetByKey()
      /go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/store.go:256 +0xf9
  k8s.io/client-go/tools/cache.(*cache).Get()
      /go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/store.go:250 +0x108
  github.com/cilium/cilium/pkg/k8s/identitybackend.(*crdBackend).getById()
      /go/src/github.com/cilium/cilium/pkg/k8s/identitybackend/identity.go:308 +0x14c
  github.com/cilium/cilium/pkg/k8s/identitybackend.(*crdBackend).GetByID()
      /go/src/github.com/cilium/cilium/pkg/k8s/identitybackend/identity.go:327 +0x48
  github.com/cilium/cilium/pkg/allocator.(*Allocator).GetByIDIncludeRemoteCaches()
      /go/src/github.com/cilium/cilium/pkg/allocator/allocator.go:880 +0x2c5
  github.com/cilium/cilium/pkg/identity/cache.(*CachingIdentityAllocator).LookupIdentityByID()
      /go/src/github.com/cilium/cilium/pkg/identity/cache/cache.go:262 +0x124
  github.com/cilium/cilium/pkg/hubble/cell.(*hubbleIntegration).GetIdentity()
      /go/src/github.com/cilium/cilium/pkg/hubble/cell/hubbleintegration.go:184 +0x61
  github.com/cilium/cilium/pkg/hubble/parser/common.(*EndpointResolver).ResolveEndpoint()
      /go/src/github.com/cilium/cilium/pkg/hubble/parser/common/endpoint.go:175 +0x477
  github.com/cilium/cilium/pkg/hubble/parser/threefour.(*Parser).Decode()
      /go/src/github.com/cilium/cilium/pkg/hubble/parser/threefour/parser.go:199 +0x1211
  github.com/cilium/cilium/pkg/hubble/parser.(*Parser).Decode()
      /go/src/github.com/cilium/cilium/pkg/hubble/parser/parser.go:134 +0xd5c
  github.com/cilium/cilium/pkg/hubble/observer.(*LocalObserverServer).Start()
      /go/src/github.com/cilium/cilium/pkg/hubble/observer/local_observer.go:133 +0x143
  github.com/cilium/cilium/pkg/hubble/cell.(*hubbleIntegration).launch.gowrap2()
      /go/src/github.com/cilium/cilium/pkg/hubble/cell/hubbleintegration.go:470 +0x33

Previous write at 0x00c000eab638 by goroutine 2855:
  k8s.io/client-go/tools/cache.NewThreadSafeStore()
      /go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/thread_safe_store.go:378 +0x18e
  k8s.io/client-go/tools/cache.NewIndexer()
      /go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/cache/store.go:292 +0x164
  github.com/cilium/cilium/pkg/k8s/identitybackend.(*crdBackend).ListAndWatch()
      /go/src/github.com/cilium/cilium/pkg/k8s/identitybackend/identity.go:374 +0x3b7
  github.com/cilium/cilium/pkg/allocator.(*cache).start.func1()
      /go/src/github.com/cilium/cilium/pkg/allocator/cache.go:251 +0xb6

Goroutine 844 (running) created at:
  github.com/cilium/cilium/pkg/hubble/cell.(*hubbleIntegration).launch()
      /go/src/github.com/cilium/cilium/pkg/hubble/cell/hubbleintegration.go:470 +0x358b
  github.com/cilium/cilium/pkg/hubble/cell.newHubbleIntegration.func1()
      /go/src/github.com/cilium/cilium/pkg/hubble/cell/cell.go:107 +0x44
  github.com/cilium/hive/job.(*jobOneShot).start()
      /go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/oneshot.go:138 +0x847
  github.com/cilium/hive/job.(*group).Start.func1.gowrap1()
      /go/src/github.com/cilium/cilium/vendor/github.com/cilium/hive/job/job.go:161 +0x131

Goroutine 2855 (running) created at:
  github.com/cilium/cilium/pkg/allocator.(*cache).start()
      /go/src/github.com/cilium/cilium/pkg/allocator/cache.go:250 +0x1bc
  github.com/cilium/cilium/pkg/allocator.(*Allocator).start()
      /go/src/github.com/cilium/cilium/pkg/allocator/allocator.go:352 +0x46
  github.com/cilium/cilium/pkg/allocator.NewAllocator()
      /go/src/github.com/cilium/cilium/pkg/allocator/allocator.go:345 +0xcb0
  github.com/cilium/cilium/pkg/identity/cache.(*CachingIdentityAllocator).InitIdentityAllocator.func1()
      /go/src/github.com/cilium/cilium/pkg/identity/cache/allocator.go:276 +0x14fc
  github.com/cilium/cilium/pkg/identity/cache.(*CachingIdentityAllocator).InitIdentityAllocator.gowrap2()
      /go/src/github.com/cilium/cilium/pkg/identity/cache/allocator.go:283 +0x82
```