### PR TITLE
ipsec: Prepare XFRM rules for Encrypted Overlay with IPv6

### DIFF
--- a/.github/actions/ipsec-key-rotate/action.yaml
+++ b/.github/actions/ipsec-key-rotate/action.yaml
@@ -39,8 +39,8 @@ runs:
         kubectl patch secret -n kube-system cilium-ipsec-keys -p="$data" -v=1
 
         # We have two keys per node, per direction, per IP family. So a two-nodes IPv4-only cluster
-        # will have four keys. If tunnel mode is enabled, we have 4 more IPv4 keys for the
-        # overlay. During the key rotation, the number of keys doubles.
+        # will have four keys. If tunnel mode is enabled, we have 4 more IPv4 keys and 4 more IPv6
+        # keys for the overlay. During the key rotation, the number of keys doubles.
         exp_nb_keys=${{ inputs.nb-nodes }}
         ((exp_nb_keys*=2))
         if [[ "${{ inputs.ipv6 }}" == "true" ]]; then
@@ -48,6 +48,9 @@ runs:
         fi
         if [[ "${{ inputs.tunnel }}" != "disabled" ]]; then
           ((exp_nb_keys+=4))
+          if [[ "${{ inputs.ipv6 }}" == "true" ]]; then
+           ((exp_nb_keys+=4))
+          fi
         fi
         ((exp_nb_keys*=2))
 

--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -25,11 +25,12 @@ import (
 )
 
 var (
-	exactMatchMask = net.IPv4Mask(255, 255, 255, 255)
-	wildcardIP     = net.ParseIP(wildcardIPv4)
-	wildcardCIDR   = &net.IPNet{IP: wildcardIP, Mask: net.IPv4Mask(0, 0, 0, 0)}
-	wildcardIP6    = net.ParseIP(wildcardIPv6)
-	wildcardCIDR6  = &net.IPNet{IP: wildcardIP6, Mask: net.CIDRMask(0, 128)}
+	exactMatchMaskIPv4 = net.IPv4Mask(255, 255, 255, 255)
+	exactMatchMaskIPv6 = net.CIDRMask(0, 128)
+	wildcardIP         = net.ParseIP(wildcardIPv4)
+	wildcardCIDR       = &net.IPNet{IP: wildcardIP, Mask: net.IPv4Mask(0, 0, 0, 0)}
+	wildcardIP6        = net.ParseIP(wildcardIPv6)
+	wildcardCIDR6      = &net.IPNet{IP: wildcardIP6, Mask: net.CIDRMask(0, 128)}
 )
 
 // getDefaultEncryptionInterface() is needed to find the interface used when
@@ -336,8 +337,8 @@ func (n *linuxNodeHandler) enableIPSecIPv4Do(newNode *nodeTypes.Node, nodeID uin
 		return false, errs
 	}
 
-	localOverlayIPExactMatch := &net.IPNet{IP: localUnderlayIP, Mask: exactMatchMask}
-	remoteOverlayIPExactMatch := &net.IPNet{IP: remoteUnderlayIP, Mask: exactMatchMask}
+	localOverlayIPExactMatch := &net.IPNet{IP: localUnderlayIP, Mask: exactMatchMaskIPv4}
+	remoteOverlayIPExactMatch := &net.IPNet{IP: remoteUnderlayIP, Mask: exactMatchMaskIPv4}
 
 	params = ipsec.NewIPSecParamaters(template)
 	params.Dir = ipsec.IPSecDirOut
@@ -552,6 +553,48 @@ func (n *linuxNodeHandler) enableIPSecIPv6Do(newNode *nodeTypes.Node, nodeID uin
 	params.DestTunnelIP = &localIP
 	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
 	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "in IPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
+	if err != nil {
+		statesUpdated = false
+	}
+
+	if !n.nodeConfig.EnableEncapsulation {
+		return statesUpdated, errs
+	}
+
+	localUnderlayIP := n.nodeConfig.NodeIPv6
+	if localUnderlayIP == nil {
+		n.log.Warn("unable to enable encrypted overlay IPsec, nil local internal IP")
+		return false, errs
+	}
+	remoteUnderlayIP := newNode.GetNodeIP(true)
+	if remoteUnderlayIP == nil {
+		n.log.Warn("unable to enable encrypted overlay IPsec, nil remote internal IP for node", logfields.Node, newNode.Name)
+		return false, errs
+	}
+
+	localOverlayIPExactMatch := &net.IPNet{IP: localUnderlayIP, Mask: exactMatchMaskIPv6}
+	remoteOverlayIPExactMatch := &net.IPNet{IP: remoteUnderlayIP, Mask: exactMatchMaskIPv6}
+
+	params = ipsec.NewIPSecParamaters(template)
+	params.Dir = ipsec.IPSecDirOut
+	params.SourceSubnet = localOverlayIPExactMatch
+	params.DestSubnet = remoteOverlayIPExactMatch
+	params.SourceTunnelIP = &localUnderlayIP
+	params.DestTunnelIP = &remoteUnderlayIP
+	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
+	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "overlay out IPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
+	if err != nil {
+		statesUpdated = false
+	}
+
+	params = ipsec.NewIPSecParamaters(template)
+	params.Dir = ipsec.IPSecDirIn
+	params.SourceSubnet = wildcardCIDR
+	params.DestSubnet = wildcardCIDR
+	params.SourceTunnelIP = &remoteUnderlayIP
+	params.DestTunnelIP = &localUnderlayIP
+	spi, err = ipsec.UpsertIPsecEndpoint(n.log, params)
+	errs = errors.Join(errs, upsertIPsecLog(n.log, err, "overlay in IPv6", params.SourceSubnet, params.DestSubnet, spi, nodeID))
 	if err != nil {
 		statesUpdated = false
 	}


### PR DESCRIPTION
We're planning to support Encrypted Overlay with IPsec and IPv6 in the next release. This pull request prepares the agent code to install the necessary XFRM states and policies for IPv6.

This code won't be used before we have tunneling over IPv6.