### PR TITLE
loader: attach datapath to IPIP tunnel devices

### DIFF
--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -474,6 +474,15 @@ func attachNetworkDevices(cfg *datapath.LocalNodeConfiguration, ep datapath.Endp
 		devices = append(devices, wgTypes.IfaceName)
 	}
 
+	if option.Config.EnableIPIPTermination {
+		if option.Config.IPv4Enabled() {
+			devices = append(devices, defaults.IPIPv4Device)
+		}
+		if option.Config.IPv6Enabled() {
+			devices = append(devices, defaults.IPIPv6Device)
+		}
+	}
+
 	// Replace programs on physical devices, ignoring devices that don't exist.
 	for _, device := range devices {
 		iface, err := safenetlink.LinkByName(device)


### PR DESCRIPTION
# User-facing issues

- This issue occurs when using Cilium's kube-proxy replacement. When creating a load balancer service in Kubernetes, if this load balancer establishes a connection with the node by the method of an L3 IPIP tunnel(L3 DSR), the load balancer service does not work.
- In the case of 'No kube-proxy replacement', there are no issues. because kube-proxy operates after the decapsulation of tunl0, so there are no problems. However, in the case of kube-proxy replacement, issues arise. This is because the bpf_host.o of the eth0 ingress tc filter runs before the tunnel device of eth0. from-netdev considers only the Outer IP Header to determine if a packet belongs to a service or not. Therefore, the service does not work.
- For more details, refer to #33020 

# Main idea

![image](https://github.com/user-attachments/assets/dba4be88-2ad7-46cc-9b5c-e069fabdc4ff)

- The IPIP packet is decapsulated using the tunnel device, and the kube-proxy service is applied at the ingress hook of that device.

----

This PR is intended to piggy-back on #31213. With this change, the `cil_from_netdev` and `cil_to_netdev` eBPF programs can be injected into the `cilium_ipip4` and `cilium_ipip6` devices. This type of termination has been demonstrated in the PoC linked [here](https://github.com/cilium/cilium/pull/33026#issuecomment-2489169476).

The major consideration for this code is as follows.
- IPIP tunnel devices are not classified as native devices. Because they are created by the Cilium agent. Therefore, they are still filtered by `isSelectedDevices()`. Instead, they are handled in `AttachNetworkDevices()`

There are still issues that prevent #31213 from working perfectly, even after merging this PR. Since IPIP tunnel devices operate at L3, they do not have an ethernet header. This means that the `ctx` in datapath like `cil_from_netdev()` does not contain an ethernet header. As a result, due to the offset mismatch, the existing datapath code, such as `cil_from_netdev()` does not function as expected. To address this, we either need to modify the cilium tunnel device to include an ethernet header or adjust the datapath to account for the absence of the L2 header.

In summary, the goal of this PR is to enable the injection of the datapath program into cilium tunnel devices, first phase of piggy-back #31213. How the injected code will work, including how it handles the Layer 2 header, can be addressed in a separate PR.

@borkmann and @joestringer, could you please review this code with @ti-mo ?