### PR TITLE
ces: Fix bug where stale endpoint information was injected into IPCache

### DIFF
--- a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
+++ b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
@@ -124,18 +124,13 @@ func (cs *cesSubscriber) OnDelete(ces *cilium_v2a1.CiliumEndpointSlice) {
 	}
 }
 
-// OnDelete calls endpointDeleted for CEPs from remote Nodes.
+// onDelete calls endpointDeleted for CEPs removed from a CES
 func (cs *cesSubscriber) onDelete(ces *cilium_v2a1.CiliumEndpointSlice, cep *types.CiliumEndpoint) {
 	CEPName := cep.Namespace + "/" + cep.Name
 	log.WithFields(logrus.Fields{
 		"CESName": ces.GetName(),
 		"CEPName": CEPName,
 	}).Debug("CES deleted, calling endpointDeleted")
-	// LocalNode already deleted the CEP.
-	// Hence, skip processing endpointDeleted for localNode CEPs.
-	if p := cs.epCache.LookupCEPName(k8sUtils.GetObjNamespaceName(cep)); p != nil {
-		return
-	}
 	// Delete CEP if and only if that CEP is owned by a CES, that was used during CES updated.
 	// Delete CEP only if there is match in CEPToCES map and also delete CEPName in CEPToCES map.
 	cs.deleteCEPfromCES(CEPName, ces.GetName(), cep)

--- a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber_test.go
+++ b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber_test.go
@@ -637,7 +637,6 @@ func TestCESSubscriber_OnAdd(t *testing.T) {
 func TestCESSubscriber_OnUpdate(t *testing.T) {
 	testCases := []struct {
 		name           string
-		local          []cacheEntry
 		newCES, oldCES *v2alpha1.CiliumEndpointSlice
 		expectUpdates  []endpointUpdate
 		expectDeleted  []*types.CiliumEndpoint
@@ -799,23 +798,6 @@ func TestCESSubscriber_OnUpdate(t *testing.T) {
 				"default/cep3": "ces",
 			},
 		},
-		{
-			name: "keep_local_cep2",
-			local: []cacheEntry{
-				{Key: "default/cep2"},
-			},
-			oldCES: newCES("ces", testNamespace,
-				v2alpha1.CoreCiliumEndpoint{Name: "cep1"},
-				v2alpha1.CoreCiliumEndpoint{Name: "cep2"},
-			),
-			newCES: newCES("ces", testNamespace,
-				v2alpha1.CoreCiliumEndpoint{Name: "cep1"},
-			),
-			expectedCurrentCES: map[string]string{
-				"default/cep1": "ces",
-				"default/cep2": "ces",
-			},
-		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -826,7 +808,7 @@ func TestCESSubscriber_OnUpdate(t *testing.T) {
 			}
 			subscriber := &cesSubscriber{
 				epWatcher: watcher,
-				epCache:   newFakeEndpointCache(tc.local...),
+				epCache:   newFakeEndpointCache(),
 				cepMap:    m,
 			}
 			// Initialize state, but do not record the events.
@@ -851,7 +833,6 @@ func TestCESSubscriber_OnUpdate(t *testing.T) {
 func TestCESSubscriber_OnDelete(t *testing.T) {
 	testCases := []struct {
 		name          string
-		local         []cacheEntry
 		ces           *v2alpha1.CiliumEndpointSlice
 		expectDeleted []*types.CiliumEndpoint
 		// Expected cepToCESmap.expectedCurrentCES
@@ -877,22 +858,6 @@ func TestCESSubscriber_OnDelete(t *testing.T) {
 			},
 			expectedCurrentCES: map[string]string{},
 		},
-		{
-			name: "keep_cep1",
-			local: []cacheEntry{
-				{Key: "default/cep1"},
-			},
-			ces: newCES("ces", testNamespace,
-				v2alpha1.CoreCiliumEndpoint{Name: "cep1"},
-				v2alpha1.CoreCiliumEndpoint{Name: "cep2"},
-			),
-			expectDeleted: []*types.CiliumEndpoint{
-				newEndpoint("cep2", testNamespace, 0),
-			},
-			expectedCurrentCES: map[string]string{
-				"default/cep1": "ces",
-			},
-		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -903,7 +868,7 @@ func TestCESSubscriber_OnDelete(t *testing.T) {
 			}
 			subscriber := &cesSubscriber{
 				epWatcher: watcher,
-				epCache:   newFakeEndpointCache(tc.local...),
+				epCache:   newFakeEndpointCache(),
 				cepMap:    m,
 			}
 			// Initialize state, but do not record the events.


### PR DESCRIPTION
This commit removes an if-statement which skipped the propagation of a CEP deletion if the endpoint still exists. The purpose of that statement was likely to deal with cases where a CEP update (e.g. due to an identity change) causes it to be removed from its old CES and then added to a new one. This would cause the endpoint to be temporarily absent from IPCache.

However, this if-statement has some unintended side effects: Since the guard skips the invocation of `deleteCEPfromCES`, the stale CEP is never removed from never removed from the local `cepMap`. Keeping this stale CEP in the map causes problems later: Once the endpoint is deleted for good (and the if-statement no longer skips the call to `deleteCEPfromCES`), the stale CEP (which we have not deleted from our map) becomes the new "current CEP". This in turn causes us to handle an actual endpoint deletion as an endpoint update, leading us to upsert the stale CEP into IPCache. This leaks IPCache entry, or worse, can in some cases even overwrite existing IPCache entries for other endpoints (such a sequence is shown below).

Therefore, this commit removes this if-statement, as it does more harm than good. By removing it, there is no longer a distinction on how CEP deletions are handled between the local node and remote nodes. In addition, FCFS slicing also has reduced the amount of delete-then-add sequences than can be observed.

Here is the sequence of events where this if-statement could overwrite IPCache entries of running pods in FCFS mode. I have successfully reproduced this sequence:

  1. cilium-agent comes up after node reboot. It has 0 restored pods but a stale pre-reboot CEPs owned by it, so it issues CEP removals
  2. cilium-operator observes the CEP removals and removes the stale pre-reboot CEPs from their CES
  3. kubelet re-creates the previously scheduled pods (with pre-reboot pod names) via CNI ADD. Cilium starts re-creating all the endpoints including re-creating the post-reboot CEPs
  4. cilium-agent observes the CES being updated from step 2, but hits the above if statement because the endpoint exists now (again), and skips the update to the internal mapping. The pre-reboot CEPs are kept in the `cesMap`.
  5. cilium-operator adds the new post-reboot CEP back into a different CES
  6. cilium-agent observes the new post-reboot CEP adds it to IPCache
  7. cilium-agent gets endpoint deletion requestion for one of its endpoints, deletes the post-reboot CEP
  8. cilium-operator removes the post-reboot CEP from the CES
  9. cilium-agent removes the post-reboot CEP from its mapping, but `deleteCEPfromCES` discovers the old pre-reboot CEP and uses it to update IPCache

If the pre-reboot CEP has an IP that is now in use by a different endpoint, then step 9 will overwrite the IPCache entry for that endpoint, causing the IPCache entry of a running endpoint to be wrong.
