### PR TITLE
envoy: skip secret sync registration if l7-proxy is disabled

### DIFF
--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -330,7 +330,7 @@ type syncerParams struct {
 }
 
 func registerSecretSyncer(params syncerParams) error {
-	if !params.K8sClientset.IsEnabled() {
+	if !params.K8sClientset.IsEnabled() || !option.Config.EnableL7Proxy {
 		return nil
 	}
 


### PR DESCRIPTION
Currently, having L7 proxy functionality disabled (`--enable-l7-proxy=false`) might lead to issues / panics when syncing secrets to Envoy fails due to the xdsServer (its mutators) not being fully initialized.

Therefore, this commit is adding an additionl config that checks that L7 proxy is enabled before registering the secret syncs.
