### PR TITLE
v1.17: Deprecate External Workloads

### DIFF
--- a/Documentation/cmdref/clustermesh-apiserver_clustermesh.md
+++ b/Documentation/cmdref/clustermesh-apiserver_clustermesh.md
@@ -19,7 +19,6 @@ clustermesh-apiserver clustermesh [flags]
       --controller-group-metrics strings             List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --crd-wait-timeout duration                    Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
   -D, --debug                                        Enable debugging mode
-      --enable-external-workloads                    Enable support for external workloads (default true)
       --enable-k8s                                   Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                     Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                    Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)

--- a/Documentation/cmdref/clustermesh-apiserver_clustermesh_hive.md
+++ b/Documentation/cmdref/clustermesh-apiserver_clustermesh_hive.md
@@ -19,7 +19,6 @@ clustermesh-apiserver clustermesh hive [flags]
       --controller-group-metrics strings             List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --crd-wait-timeout duration                    Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
   -D, --debug                                        Enable debugging mode
-      --enable-external-workloads                    Enable support for external workloads (default true)
       --enable-k8s                                   Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                     Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                    Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)

--- a/Documentation/cmdref/clustermesh-apiserver_clustermesh_hive_dot-graph.md
+++ b/Documentation/cmdref/clustermesh-apiserver_clustermesh_hive_dot-graph.md
@@ -25,7 +25,6 @@ clustermesh-apiserver clustermesh hive dot-graph [flags]
       --controller-group-metrics strings             List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --crd-wait-timeout duration                    Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
   -D, --debug                                        Enable debugging mode
-      --enable-external-workloads                    Enable support for external workloads (default true)
       --enable-k8s                                   Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                     Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                    Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)

--- a/Documentation/network/external-workloads.rst
+++ b/Documentation/network/external-workloads.rst
@@ -16,7 +16,9 @@ This is a step-by-step guide on how to add external workloads (such as
 VMs) in to your Kubernetes cluster and to enforce security policies to
 restrict access.
 
-.. include:: ../beta.rst
+.. warning:: 
+
+	This feature has been deprecated and will be removed in v1.18.
 
 Prerequisites
 #############

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -374,6 +374,7 @@ Deprecated Options
 * The high-scale mode for ipcache has been deprecated and will be removed in v1.18.
 * The hubble-relay flag ``--dial-timeout`` has been deprecated (now a no-op)
   and will be removed in Cilium 1.18.
+* The :ref:`External Workloads <external_workloads>` feature has been deprecated and will be removed in v1.18. 
 
 Helm Options
 ~~~~~~~~~~~~

--- a/clustermesh-apiserver/clustermesh/vmmanager.go
+++ b/clustermesh-apiserver/clustermesh/vmmanager.go
@@ -60,6 +60,7 @@ type ExternalWorkloadsConfig struct {
 
 func (def ExternalWorkloadsConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool("enable-external-workloads", def.EnableExternalWorkloads, "Enable support for external workloads")
+	flags.MarkDeprecated("enable-external-workloads", "The feature has been deprecated and it will be removed in v1.18")
 }
 
 func externalWorkloadsProvider(


### PR DESCRIPTION
The feature is no longer maintained, and thus it will be removed in v1.18.