### PR TITLE
[v1.17] agent: Deprecate --enable-k8s-terminating-endpoint flag

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -153,7 +153,6 @@ cilium-agent [flags]
       --enable-k8s                                                Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                                  Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                                 Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-k8s-terminating-endpoint                           Enable auto-detect of terminating endpoint condition (default true)
       --enable-l2-announcements                                   Enable L2 announcements
       --enable-l2-neigh-discovery                                 Enables L2 neighbor discovery used by kube-proxy-replacement and IPsec (default true)
       --enable-l2-pod-announcements                               Enable announcing Pod IPs with Gratuitous ARP

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -378,6 +378,8 @@ Deprecated Options
 * The ``cilium-docker-plugin`` has been deprecated and is planned to be removed in v1.18.
 * The ``--k8s-watcher-endpoint-selector`` cilium-agent flag didn't have any effect since v1.14 and
   has been deprecated. It will be remove in v1.18.
+* The ``--enable-k8s-terminating-endpoint`` cilium-agent flag (``enableK8sTerminatingEndpoint`` in Helm) has been deprecated.
+  The feature will be unconditionally enabled in v1.18.
 
 Helm Options
 ~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -988,6 +988,7 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 
 	flags.Bool(option.EnableK8sTerminatingEndpoint, true, "Enable auto-detect of terminating endpoint condition")
 	option.BindEnv(vp, option.EnableK8sTerminatingEndpoint)
+	flags.MarkDeprecated(option.EnableK8sTerminatingEndpoint, "Feature will be unconditionally enabled in v1.18")
 
 	flags.Bool(option.EnableVTEP, defaults.EnableVTEP, "Enable  VXLAN Tunnel Endpoint (VTEP) Integration (beta)")
 	option.BindEnv(vp, option.EnableVTEP)


### PR DESCRIPTION
The ProxyTerminatingEndpoint feature was made GA since K8s v1.28, and thus we can enable it unconditionally [1].

https://github.com/kubernetes/kubernetes/pull/122134/


```release-note
agent: Deprecate --enable-k8s-terminating-endpoint flag
```