### PR TITLE
operator: promote invalid policy from debug to error level

### DIFF
--- a/operator/pkg/networkpolicy/cell.go
+++ b/operator/pkg/networkpolicy/cell.go
@@ -130,7 +130,7 @@ func (pv *policyValidator) handleCNPEvent(ctx context.Context, event resource.Ev
 	}
 
 	if errs != nil {
-		log.Debug("Detected invalid CNP, setting condition", logfields.Error, errs)
+		log.Error("Detected invalid CNP, setting condition", logfields.Error, errs)
 	} else {
 		log.Debug("CNP now valid, setting condition")
 	}


### PR DESCRIPTION
```release-note
operator: log error for invalid network policies
```
