### PR TITLE
deprecate cilium-docker-plugin

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -374,7 +374,8 @@ Deprecated Options
 * The high-scale mode for ipcache has been deprecated and will be removed in v1.18.
 * The hubble-relay flag ``--dial-timeout`` has been deprecated (now a no-op)
   and will be removed in Cilium 1.18.
-* The :ref:`External Workloads <external_workloads>` feature has been deprecated and will be removed in v1.18. 
+* The :ref:`External Workloads <external_workloads>` feature has been deprecated and will be removed in v1.18.
+* The ``cilium-docker-plugin`` has been deprecated and is planned to be removed in v1.18.
 
 Helm Options
 ~~~~~~~~~~~~


### PR DESCRIPTION
The only use cases we have for this is our runtime tests, it's time to mark this feature as deprecated so that we can remove it in v1.18.

Related to https://github.com/cilium/cilium/issues/27022