### PR TITLE
[v1.17] daemon: deprecate no-op `--k8s-watcher-endpoint-selector` flag

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -290,7 +290,6 @@ cilium-agent [flags]
       --k8s-require-ipv4-pod-cidr                                 Require IPv4 PodCIDR to be specified in node resource
       --k8s-require-ipv6-pod-cidr                                 Require IPv6 PodCIDR to be specified in node resource
       --k8s-service-proxy-name string                             Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --k8s-watcher-endpoint-selector string                      K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
       --keep-config                                               When restoring state, keeps containers' configuration in place
       --kube-proxy-replacement string                             Enable only selected features (will panic if any selected feature cannot be enabled) ("false"), or enable all features (will panic if any feature cannot be enabled) ("true") (default "false")
       --kube-proxy-replacement-healthz-bind-address string        The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -376,6 +376,8 @@ Deprecated Options
   and will be removed in Cilium 1.18.
 * The :ref:`External Workloads <external_workloads>` feature has been deprecated and will be removed in v1.18.
 * The ``cilium-docker-plugin`` has been deprecated and is planned to be removed in v1.18.
+* The ``--k8s-watcher-endpoint-selector`` cilium-agent flag didn't have any effect since v1.14 and
+  has been deprecated. It will be remove in v1.18.
 
 Helm Options
 ~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -500,6 +500,7 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 
 	flags.String(option.K8sWatcherEndpointSelector, defaults.K8sWatcherEndpointSelector, "K8s endpoint watcher will watch for these k8s endpoints")
 	option.BindEnv(vp, option.K8sWatcherEndpointSelector)
+	flags.MarkDeprecated(option.K8sWatcherEndpointSelector, "This option is deprecated and no longer has any effect. It will be removed in v1.18")
 
 	flags.Bool(option.KeepConfig, false, "When restoring state, keeps containers' configuration in place")
 	option.BindEnv(vp, option.KeepConfig)


### PR DESCRIPTION
The `--k8s-watcher-endpoint-selector` flag no longer has any effect since Cilium v1.14. Namely, in #23977 endpoint watchers were replaced by `Resource[*Endpoint]` and thus this configuration is no longer applicable.

```release-note
daemon: deprecate no-op --k8s-watcher-endpoint-selector flag
```