### PR TITLE
gha: fix retrieval of DNS server in conformance external workloads

### DIFF
--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -359,7 +359,7 @@ jobs:
         # Limit nslookup to the first (global) DNS server setting
         run: |
           gcloud compute ssh ${{ env.vmName }}-${{ matrix.vmIndex }} --zone ${{ matrix.zone }} \
-            --command "nslookup -d2 -retry=10 -timeout=5 -norecurse clustermesh-apiserver.kube-system.svc.cluster.local \$(systemd-resolve --status | grep -m 1 \"Current DNS Server:\" | cut -d':' -f2)"
+            --command "nslookup -d2 -retry=10 -timeout=5 -norecurse clustermesh-apiserver.kube-system.svc.cluster.local \$(resolvectl status | grep -m 1 \"Current DNS Server:\" | cut -d':' -f2)"
 
       - name: Ping clustermesh-apiserver from VM
         run: |


### PR DESCRIPTION
The "Verify cluster DNS on VM" step of Conformance External Workloads is currently flaky. Looking at the logs, one of the aspects that stand out is that the `systemd-resolve --status` command fails with ` bash: line 1: systemd-resolve: command not found`; in turn nslookup appears to be using both the orignal DNS server, and the one behind the coredns service:

    make_server(34.118.224.10)
    make_server(169.254.169.254)

My assumption is that the resolution then either succeeds or fails depending on which one gets picked, as only the latter is able to resolve `clustermesh-apiserver.kube-system.svc.cluster.local`.

Let's fix the retrieval of the target DNS server, and see whether this addresses the flakiness as well.