### PR TITLE
ci: fix curl call for metrics in smoke tests

### DIFF
--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -176,9 +176,8 @@ jobs:
         if: ${{ success() }}
         run: |
           cd $HOME
-          cilium_pod=$(kubectl -n kube-system get po -o name --field-selector=status.phase==Running -l 'k8s-app=cilium' -o jsonpath='{.items[0].metadata.name}' )
-          kubectl -n kube-system exec $cilium_pod -- sh -c "apt update && apt install curl -y"
-          kubectl -n kube-system exec $cilium_pod -- curl http://localhost:9962/metrics > metrics-agent.prom
+          cilium_pod_ip=$(kubectl -n kube-system get po -o name --field-selector=status.phase==Running -l 'k8s-app=cilium' -o jsonpath='{.items[0].status.podIP}' )
+          curl http://${cilium_pod_ip}:9962/metrics > metrics-agent.prom
 
           operator_ip=$(kubectl get pods -n kube-system -l io.cilium/app=operator -o jsonpath='{range .items[*]}{.status.podIP}{"\n"}{end}')
           curl http://${operator_ip}:9963/metrics > metrics-operator.prom


### PR DESCRIPTION
This commit remove the usage of installing apt and curl inside the container by calling the metric endpoint from the runner instead.

```release-note
call for metrics in smoke tests from runner instead of installing apt/curl on cilium pod
```
