### PR TITLE
ci: set --interactive=false for cilium status in delegated ipam e2e

### DIFF
--- a/.github/workflows/conformance-delegated-ipam.yaml
+++ b/.github/workflows/conformance-delegated-ipam.yaml
@@ -326,7 +326,7 @@ jobs:
 
       - name: Wait for Cilium status to be ready
         run: |
-          cilium status --wait
+          cilium status --wait --interactive=false --wait-duration=10m
           kubectl -n kube-system get pods -owide
 
       - name: Make JUnit report directory


### PR DESCRIPTION
Update delegated IPAM E2E test to use --interactive=false for `cilium status`.
This is the same change for other E2E tests made in commit a29ba1998d6ed8887e3639f6f59c7b7805c3f27a