### PR TITLE
daemon: Create Snat4AllocRetries Map early on startup

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -221,6 +221,19 @@ func (d *Daemon) initMaps() error {
 		}
 	}
 
+	ipv4Retries, ipv6Retries := nat.RetriesMaps(option.Config.EnableIPv4,
+		option.Config.EnableIPv6, option.Config.EnableNodePort)
+	if ipv4Retries != nil {
+		if err := ipv4Retries.Create(); err != nil {
+			return fmt.Errorf("initializing ipv4Retries map: %w", err)
+		}
+	}
+	if ipv6Retries != nil {
+		if err := ipv6Retries.Create(); err != nil {
+			return fmt.Errorf("initializing ipv6Retries map: %w", err)
+		}
+	}
+
 	if option.Config.EnableNodePort {
 		if err := neighborsmap.InitMaps(option.Config.EnableIPv4,
 			option.Config.EnableIPv6); err != nil {

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -85,6 +85,7 @@ type NatMap interface {
 
 type RetriesMap interface {
 	commonMap
+	Create() error
 	DumpPerCPUWithCallback(bpf.DumpPerCPUCallback) error
 	ClearAll() error
 }


### PR DESCRIPTION
This PR initializes cilium_snat_v4_alloc_retries and cilium_snat_v6_alloc_retries maps early on the agent startup

Fixes: #37325

