### PR TITLE
bgpv1: Extend component test timeout

### DIFF
--- a/pkg/bgpv1/test/adverts_test.go
+++ b/pkg/bgpv1/test/adverts_test.go
@@ -26,10 +26,7 @@ import (
 
 var (
 	// maxTestDuration is allowed time for test execution
-	maxTestDuration = 25 * time.Second
-
-	// maxGracefulRestartTestDuration is max allowed time for graceful restart test
-	maxGracefulRestartTestDuration = 1 * time.Minute
+	maxTestDuration = 5 * time.Minute
 )
 
 // Test_PodCIDRAdvert validates pod IPv4/v6 subnet is advertised, withdrawn and modified on node addresses change.

--- a/pkg/bgpv1/test/neighbor_test.go
+++ b/pkg/bgpv1/test/neighbor_test.go
@@ -264,7 +264,7 @@ func Test_NeighborGracefulRestart(t *testing.T) {
 	}
 
 	// This test run can take upto a minute
-	testCtx, testDone := context.WithTimeout(context.Background(), maxGracefulRestartTestDuration)
+	testCtx, testDone := context.WithTimeout(context.Background(), maxTestDuration)
 	defer testDone()
 
 	// test setup, we configure single gobgp instance here.


### PR DESCRIPTION
Currently, we only let whole tests to run 25sec for regular tests and 1min for Graceful Restart tests. These are a bit tight and often causes timeout which makes CI flakiness. Extend the timeout for all tests to 5min.

Fixes: #28415
Fixes: #36254
Fixes: #37280 

```release-note
bgpv1: Extend component test timeout
```
