### PR TITLE
fix(helm): Missing $ prevents template to use root scope

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/dashboards-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/dashboards-configmap.yaml
@@ -12,7 +12,7 @@ metadata:
     k8s-app: cilium
     app.kubernetes.io/name: cilium-agent
     app.kubernetes.io/part-of: cilium
-    {{- with .Values.commonLabels }}
+    {{- with $.Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if $.Values.dashboards.label }}


### PR DESCRIPTION
Due to a missing $ the Helm template engine failes to use the root Values scope when templating `install/kubernetes/cilium/templates/cilium-agent/dashboards-configmap.yaml`

Fixes: #37371
