### PR TITLE
envoy: cleanup xds server initialization

### DIFF
--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -146,7 +146,7 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 	// the xDS ConfigSource is used for CEC/CCEC.
 	CiliumXDSConfigSource.InitialFetchTimeout.Seconds = int64(params.EnvoyProxyConfig.ProxyInitialFetchTimeout)
 
-	xdsServer, err := newXDSServer(
+	xdsServer := newXDSServer(
 		params.RestorerPromise,
 		params.IPCache,
 		params.LocalEndpointStore,
@@ -165,9 +165,6 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 			proxyXffNumTrustedHopsEgress:  params.EnvoyProxyConfig.ProxyXffNumTrustedHopsEgress,
 		},
 		params.SecretManager)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Envoy xDS server: %w", err)
-	}
 
 	if !option.Config.EnableL7Proxy {
 		log.Debug("L7 proxies are disabled - not starting Envoy xDS server")

--- a/pkg/envoy/embedded_envoy_test.go
+++ b/pkg/envoy/embedded_envoy_test.go
@@ -66,7 +66,7 @@ func TestEnvoy(t *testing.T) {
 
 	localEndpointStore := newLocalEndpointStore()
 
-	xdsServer, err := newXDSServer(nil, testipcache.NewMockIPCache(), localEndpointStore,
+	xdsServer := newXDSServer(nil, testipcache.NewMockIPCache(), localEndpointStore,
 		xdsServerConfig{
 			envoySocketDir:    GetSocketDir(testRunDir),
 			proxyGID:          1337,
@@ -74,7 +74,6 @@ func TestEnvoy(t *testing.T) {
 		},
 		nil)
 	require.NotNil(t, xdsServer)
-	require.NoError(t, err)
 
 	err = xdsServer.start()
 	require.NoError(t, err)
@@ -182,14 +181,14 @@ func TestEnvoyNACK(t *testing.T) {
 
 	localEndpointStore := newLocalEndpointStore()
 
-	xdsServer, err := newXDSServer(nil, testipcache.NewMockIPCache(), localEndpointStore,
+	xdsServer := newXDSServer(nil, testipcache.NewMockIPCache(), localEndpointStore,
 		xdsServerConfig{
 			envoySocketDir:    GetSocketDir(testRunDir),
 			proxyGID:          1337,
 			httpNormalizePath: true,
 		}, nil)
 	require.NotNil(t, xdsServer)
-	require.NoError(t, err)
+
 	err = xdsServer.start()
 	require.NoError(t, err)
 	defer xdsServer.stop()

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -177,6 +177,8 @@ type xdsServer struct {
 	// Exported for testing only!
 	NetworkPolicyMutator xds.AckingResourceMutator
 
+	resourceConfig map[string]*xds.ResourceTypeConfiguration
+
 	// stopFunc contains the function which stops the xDS gRPC server.
 	stopFunc context.CancelFunc
 
@@ -216,7 +218,7 @@ type xdsServerConfig struct {
 
 // newXDSServer creates a new xDS GRPC server.
 func newXDSServer(restorerPromise promise.Promise[endpointstate.Restorer], ipCache IPCacheEventSource, localEndpointStore *LocalEndpointStore, config xdsServerConfig, secretManager certificatemanager.SecretManager) *xdsServer {
-	return &xdsServer{
+	xdsServer := &xdsServer{
 		restorerPromise:    restorerPromise,
 		listenerCount:      make(map[string]uint),
 		ipCache:            ipCache,
@@ -227,23 +229,24 @@ func newXDSServer(restorerPromise promise.Promise[endpointstate.Restorer], ipCac
 		config:        config,
 		secretManager: secretManager,
 	}
+
+	xdsServer.initializeXdsConfigs()
+
+	return xdsServer
 }
 
-// start configures and starts the xDS GRPC server.
 func (s *xdsServer) start() error {
 	socketListener, err := s.newSocketListener()
 	if err != nil {
 		return fmt.Errorf("failed to create socket listener: %w", err)
 	}
 
-	resourceConfig := s.initializeXdsConfigs()
-
-	s.stopFunc = s.startXDSGRPCServer(socketListener, resourceConfig)
+	s.stopFunc = s.startXDSGRPCServer(socketListener, s.resourceConfig)
 
 	return nil
 }
 
-func (s *xdsServer) initializeXdsConfigs() map[string]*xds.ResourceTypeConfiguration {
+func (s *xdsServer) initializeXdsConfigs() {
 	ldsCache := xds.NewCache()
 	ldsMutator := xds.NewAckingResourceMutatorWrapper(ldsCache)
 	ldsConfig := &xds.ResourceTypeConfiguration{
@@ -300,7 +303,7 @@ func (s *xdsServer) initializeXdsConfigs() map[string]*xds.ResourceTypeConfigura
 	s.networkPolicyCache = npdsCache
 	s.NetworkPolicyMutator = npdsMutator
 
-	resourceConfig := map[string]*xds.ResourceTypeConfiguration{
+	s.resourceConfig = map[string]*xds.ResourceTypeConfiguration{
 		ListenerTypeURL:           ldsConfig,
 		RouteTypeURL:              rdsConfig,
 		ClusterTypeURL:            cdsConfig,
@@ -309,7 +312,6 @@ func (s *xdsServer) initializeXdsConfigs() map[string]*xds.ResourceTypeConfigura
 		NetworkPolicyTypeURL:      npdsConfig,
 		NetworkPolicyHostsTypeURL: nphdsConfig,
 	}
-	return resourceConfig
 }
 
 func (s *xdsServer) newSocketListener() (*net.UnixListener, error) {

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -215,7 +215,7 @@ type xdsServerConfig struct {
 }
 
 // newXDSServer creates a new xDS GRPC server.
-func newXDSServer(restorerPromise promise.Promise[endpointstate.Restorer], ipCache IPCacheEventSource, localEndpointStore *LocalEndpointStore, config xdsServerConfig, secretManager certificatemanager.SecretManager) (*xdsServer, error) {
+func newXDSServer(restorerPromise promise.Promise[endpointstate.Restorer], ipCache IPCacheEventSource, localEndpointStore *LocalEndpointStore, config xdsServerConfig, secretManager certificatemanager.SecretManager) *xdsServer {
 	return &xdsServer{
 		restorerPromise:    restorerPromise,
 		listenerCount:      make(map[string]uint),
@@ -226,7 +226,7 @@ func newXDSServer(restorerPromise promise.Promise[endpointstate.Restorer], ipCac
 		accessLogPath: getAccessLogSocketPath(config.envoySocketDir),
 		config:        config,
 		secretManager: secretManager,
-	}, nil
+	}
 }
 
 // start configures and starts the xDS GRPC server.


### PR DESCRIPTION
```
envoy: remove error from newXDSServer signature

This commit removes the unnecessary error from the function
`newXDSServer`.
```

```
envoy: initialize resourceconfig in newXSServer

Currently, most of the Envoy xDSServer is initialized in its
contructor function. But the xDS resource mutators and caches
are initialized when starting the xds server.

If L7 proxy functionality isn't enabled, the xds server isn't
started. In this scenario, the xDSServer is not fully initialized
and there's a risk of panics when accessing it.

Even though all current use-cases should check that l7 functionality
is enabled before calling the xds server, this commit is moving the
initialization of the xds resources from the method `start` into
the constructor `newXDSServer`. This way, a fully initialized (but
not started) xDSServer is returned in all cases.
```

Follow up of https://github.com/cilium/cilium/pull/37348