### PR TITLE
bpf: minor clean-ups for the ENI symmetric routing feature

### DIFF
--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -339,6 +339,9 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 				if (eth_store_saddr_aligned(ctx, smac.addr, 0) < 0)
 					return DROP_WRITE_ERROR;
 
+				/* For EKS we don't have to rewrite the dmac. Once we require a 5.10
+				 * kernel, this can turn into bpf_redirect_neigh() for robustness.
+				 */
 				return ctx_redirect(ctx, ep->parent_ifindex, 0);
 			}
 		}

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -306,7 +306,6 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 	void *data, *data_end;
 	struct iphdr *ip4;
 	int l4_off, ret;
-	struct endpoint_info *ep;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
@@ -314,7 +313,9 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 	snat_v4_init_tuple(ip4, NAT_DIR_EGRESS, &tuple);
 	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
 
-	if (is_defined(IS_BPF_HOST)) {
+	if (is_defined(IS_BPF_HOST) && is_defined(ENABLE_MASQUERADE_IPV4)) {
+		struct endpoint_info *ep;
+
 		ep = __lookup_ip4_endpoint(ip4->saddr);
 		if (ep && ep->parent_ifindex && ep->parent_ifindex != THIS_INTERFACE_IFINDEX) {
 			/* This packet came from an endpoint with a parent interface and

--- a/bpf/tests/eni_nlb_symetric_routing_host.c
+++ b/bpf/tests/eni_nlb_symetric_routing_host.c
@@ -14,6 +14,7 @@
 /* Enable code paths under test*/
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT
+#define ENABLE_MASQUERADE_IPV4	1
 #define ENABLE_ROUTING
 
 #define PRIMARY_IFACE 1


### PR DESCRIPTION
Apply some polish we had discussed in https://github.com/cilium/cilium/pull/35298, but didn't make the initial PR.