### PR TITLE
[v1.16] ctmap/gc: don't clamp conntrack scan timeout in CI

### DIFF
--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/netip"
 	"os"
+	stdtime "time"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
@@ -223,7 +224,7 @@ func (gc *GC) Enable() {
 	select {
 	case <-initialScanComplete:
 		gc.logger.Info("Initial scan of connection tracking completed")
-	case <-time.After(30 * time.Second):
+	case <-stdtime.After(30 * time.Second):
 		gc.logger.Fatal("Timeout while waiting for initial conntrack scan")
 	}
 


### PR DESCRIPTION
Currently, the agent panics if the initial ctmap/nat GC scan does not complete within an hard-coded timeout of 30 seconds. Additionally, this timeout is further reduced to 5 seconds in the Ginkgo tests. There, we are observing quite often failures in the datapath-misc matrix entry, due to agents crashes caused by this timeout being hit (most likely due to resource contention in the CI environment). Let's try avoiding clamping this value in CI, and see if flakiness decreases or there's a more serious issue under the hood.

Note that this issue does not affect v1.17 and later, as refactored by fea19ec9c730 ("ctmap/gc: do not terminate agent fatal on ctmap gc init after timeout"). Nor it affects v1.14, as the time wrapper had not been introduced yet there.