### PR TITLE
k8s/resource: NewTableEventStream to adapt from Resource to Tables

### DIFF
--- a/pkg/k8s/resource/statedb.go
+++ b/pkg/k8s/resource/statedb.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resource
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/stream"
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// NewTableEventStream constructs a stream of [Event] from a StateDB table of Kubernetes
+// objects. This is meant as a transitionary mechanism for converting from Resource[T] to Table[T]
+// and is not meant as a long term solution. Sub-systems should instead consider either moving to
+// the StateDB reconciler (expressing their desired state in a StateDB table) or using an internal
+// workqueue for processing.
+//
+// This should only be used when the workqueue retry handling is required. If it is not needed
+// you should use [statedb.Observable].
+//
+// Deprecated: This is a transitionary helper. Use only if converting from Resource[T] and need the
+// workqueue retry handling. If retrying is not needed use [statedb.Observable] instead or refactor
+// your code to use [statedb.Table.Changes].
+func NewTableEventStream[T k8sRuntime.Object](db *statedb.DB, table statedb.Table[T], getByKey func(Key) statedb.Query[T]) stream.Observable[Event[T]] {
+	return &tableWorkQueue[T]{
+		db:       db,
+		table:    table,
+		getByKey: getByKey,
+	}
+}
+
+type tableWorkQueueItem struct {
+	key          Key
+	initOccurred bool
+}
+
+type tableWorkQueue[T k8sRuntime.Object] struct {
+	db       *statedb.DB
+	table    statedb.Table[T]
+	getByKey func(Key) statedb.Query[T]
+}
+
+func (twq *tableWorkQueue[T]) Observe(ctx context.Context, next func(Event[T]), complete func(error)) {
+	var zero T
+	wq := workqueue.NewTypedRateLimitingQueueWithConfig[tableWorkQueueItem](
+		workqueue.DefaultTypedControllerRateLimiter[tableWorkQueueItem](),
+		workqueue.TypedRateLimitingQueueConfig[tableWorkQueueItem]{
+			Name: fmt.Sprintf("%T", zero),
+		},
+	)
+
+	var deletedObjects lastKnownObjects[T]
+
+	wtxn := twq.db.WriteTxn(twq.table)
+	changeIter, err := twq.table.Changes(wtxn)
+	_, initWatch := twq.table.Initialized(wtxn)
+	wtxn.Commit()
+	if err != nil {
+		complete(err)
+		return
+	}
+
+	_, callerFile, callerLine, _ := runtime.Caller(1)
+	debugInfo := fmt.Sprintf("%T.Observe() called from %s:%d", twq, callerFile, callerLine)
+	doneFinalizer := func(done *bool) {
+		// If you get here it is because an Event[T] was handed to a subscriber
+		// that forgot to call Event[T].Done().
+		//
+		// Calling Done() is needed to mark the event as handled. This allows
+		// the next event for the same key to be handled and is used to clear
+		// rate limiting and retry counts of prior failures.
+		panic(fmt.Sprintf(
+			"%s has a broken event handler that did not call Done() "+
+				"before event was garbage collected",
+			debugInfo))
+	}
+
+	// Start a goroutine to feed the workqueue.
+	go func() {
+		defer wq.ShutDown()
+
+		// Limit the read transaction rate to at most 10 per second to reduce
+		// overhead and coalesce changes.
+		limiter := rate.NewLimiter(time.Second/10, 1)
+		defer limiter.Stop()
+
+		for {
+			changes, watch := changeIter.Next(twq.db.ReadTxn())
+			for change := range changes {
+				if ctx.Err() != nil {
+					break
+				}
+				obj := change.Object
+				key := NewKey(obj)
+				wq.Add(tableWorkQueueItem{key: key})
+				if change.Deleted {
+					deletedObjects.Store(key, change.Object)
+				}
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-watch:
+			case <-initWatch:
+				initWatch = nil
+				wq.Add(tableWorkQueueItem{
+					initOccurred: true,
+				})
+			}
+			if err := limiter.Wait(ctx); err != nil {
+				return
+			}
+		}
+	}()
+
+	// And a goroutine to emit the events
+	go func() {
+		defer complete(nil)
+
+		for {
+			item, shutdown := wq.Get()
+			if shutdown {
+				return
+			}
+
+			var event Event[T]
+			var eventDoneSentinel = new(bool)
+			event.Done = func(err error) {
+				runtime.SetFinalizer(eventDoneSentinel, nil)
+				defer wq.Done(item)
+				if err == nil {
+					// Clear rate limiting.
+					wq.Forget(item)
+
+					if event.Kind == Delete {
+						// Deletion processed successfully, forget the deleted object.
+						deletedObjects.DeleteByUID(item.key, event.Object)
+					}
+				} else {
+					// Requeue for retry.
+					wq.AddRateLimited(item)
+				}
+			}
+			// Add a finalizer to catch forgotten calls to Done().
+			runtime.SetFinalizer(eventDoneSentinel, doneFinalizer)
+
+			if item.initOccurred {
+				event.Kind = Sync
+				next(event)
+				continue
+			}
+
+			obj, _, found := twq.table.Get(twq.db.ReadTxn(), twq.getByKey(item.key))
+			if found {
+				event.Kind = Upsert
+				event.Object = obj
+				next(event)
+			} else {
+				event.Kind = Delete
+				obj, found := deletedObjects.Load(item.key)
+				if found {
+					event.Object = obj
+					next(event)
+				}
+			}
+		}
+	}()
+}

--- a/pkg/k8s/resource/statedb_test.go
+++ b/pkg/k8s/resource/statedb_test.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resource_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+	"github.com/cilium/stream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/pkg/k8s/resource"
+)
+
+var (
+	nodeNameIndex = statedb.Index[*corev1.Node, string]{
+		Name: "name",
+		FromObject: func(obj *corev1.Node) index.KeySet {
+			return index.NewKeySet(index.String(obj.Name))
+		},
+		FromKey: index.String,
+		Unique:  true,
+	}
+)
+
+func newNodesTable(db *statedb.DB) (statedb.RWTable[*corev1.Node], error) {
+	tbl, err := statedb.NewTable(
+		"nodes",
+		nodeNameIndex,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return tbl, db.RegisterTable(tbl)
+}
+
+func TestStateDBTableEventStream(t *testing.T) {
+	db := statedb.New()
+	nodes, err := newNodesTable(db)
+	require.NoError(t, err)
+
+	wtxn := db.WriteTxn(nodes)
+	initDone := nodes.RegisterInitializer(wtxn, "test")
+	wtxn.Commit()
+
+	tableStream := resource.NewTableEventStream(
+		db,
+		nodes,
+		func(k resource.Key) statedb.Query[*corev1.Node] {
+			return nodeNameIndex.Query(k.String())
+		},
+	)
+
+	// No sync event before initialized
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		ev, ok := <-stream.ToChannel(ctx, tableStream)
+		cancel()
+		require.False(t, ok) // Channel should be closed
+		require.Equal(t, resource.Event[*corev1.Node]{}, ev)
+	}
+
+	// Mark the table initialized, emitting the Sync event to observers.
+	wtxn = db.WriteTxn(nodes)
+	initDone(wtxn)
+	wtxn.Commit()
+
+	// Test that sync events are retried
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		t.Cleanup(cancel)
+		xs := stream.ToChannel(ctx, tableStream)
+
+		expectedErr := errors.New("sync")
+		expectedRetries := 3
+		numRetries := 0
+
+		for ev := range xs {
+			switch ev.Kind {
+			case resource.Sync:
+				numRetries++
+				if numRetries >= expectedRetries {
+					ev.Done(nil)
+					cancel()
+				} else {
+					ev.Done(expectedErr)
+				}
+			case resource.Upsert:
+				t.Fatalf("unexpected upsert of %s", ev.Key)
+			case resource.Delete:
+				t.Fatalf("unexpected delete of %s", ev.Key)
+			}
+		}
+		assert.Equal(t, expectedRetries, numRetries, "expected to see 3 retries for sync")
+	}
+
+	// Create the initial version of the node.
+	var node = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "some-node",
+			ResourceVersion: "0",
+		},
+		Status: corev1.NodeStatus{
+			Phase: "init",
+		},
+	}
+
+	wtxn = db.WriteTxn(nodes)
+	nodes.Insert(wtxn, node)
+	wtxn.Commit()
+
+	// Test that update events are retried
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		t.Cleanup(cancel)
+		xs := stream.ToChannel(ctx, tableStream)
+
+		expectedErr := errors.New("update")
+		expectedRetries := 3
+		numRetries := 0
+
+		for ev := range xs {
+			switch ev.Kind {
+			case resource.Sync:
+				ev.Done(nil)
+			case resource.Upsert:
+				numRetries++
+				if numRetries >= expectedRetries {
+					ev.Done(nil)
+					cancel()
+				} else {
+					ev.Done(expectedErr)
+				}
+			case resource.Delete:
+				t.Fatalf("unexpected delete of %s", ev.Key)
+			}
+		}
+
+		assert.Equal(t, expectedRetries, numRetries, "expected to see 3 retries for update")
+	}
+
+	// Test that delete events are retried
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		t.Cleanup(cancel)
+		xs := stream.ToChannel(ctx, tableStream)
+
+		expectedErr := errors.New("delete")
+		expectedRetries := 3
+		numRetries := 0
+
+		for ev := range xs {
+			switch ev.Kind {
+			case resource.Sync:
+				ev.Done(nil)
+			case resource.Upsert:
+				wtxn := db.WriteTxn(nodes)
+				nodes.Delete(wtxn, ev.Object)
+				wtxn.Commit()
+				ev.Done(nil)
+			case resource.Delete:
+				numRetries++
+				if numRetries >= expectedRetries {
+					ev.Done(nil)
+					cancel()
+				} else {
+					ev.Done(expectedErr)
+				}
+			}
+		}
+
+		assert.Equal(t, expectedRetries, numRetries, "expected to see 3 retries for delete")
+	}
+}


### PR DESCRIPTION
Add helper to construct a [resource.Event] stream from a table of k8s objects backed by a workqueue. This allows easy transitioning to StateDB tables of k8s objects from Resource[T] where the code is depending on retrying of the events.

This implementation is not very efficient as it is doing a read transaction and point-wise lookup for every object. It should be only used to transition away from Resource[T] and only when error retrying is needed (e.g. event.Done(err), err != nil).
