### PR TITLE
test: Update negative test case for TLS SNI

### DIFF
--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -72,6 +72,9 @@ var (
 	//go:embed manifests/client-egress-tls-sni.yaml
 	clientEgressTLSSNIPolicyYAML string
 
+	//go:embed manifests/client-egress-tls-sni-other.yaml
+	clientEgressTLSSNIOtherPolicyYAML string
+
 	//go:embed manifests/client-egress-l7-tls-sni.yaml
 	clientEgressL7TLSSNIPolicyYAML string
 
@@ -311,6 +314,7 @@ func renderTemplates(clusterName string, param check.Parameters) (map[string]str
 		"clientEgressL7HTTPNamedPortPolicyYAML":              clientEgressL7HTTPNamedPortPolicyYAML,
 		"clientEgressToFQDNsPolicyYAML":                      clientEgressToFQDNsPolicyYAML,
 		"clientEgressTLSSNIPolicyYAML":                       clientEgressTLSSNIPolicyYAML,
+		"clientEgressTLSSNIOtherPolicyYAML":                  clientEgressTLSSNIOtherPolicyYAML,
 		"clientEgressL7TLSSNIPolicyYAML":                     clientEgressL7TLSSNIPolicyYAML,
 		"clientEgressL7TLSPolicyYAML":                        clientEgressL7TLSPolicyYAML,
 		"clientEgressL7TLSPolicyPortRangeYAML":               clientEgressL7TLSPolicyPortRangeYAML,

--- a/cilium-cli/connectivity/builder/client_egress_tls_sni.go
+++ b/cilium-cli/connectivity/builder/client_egress_tls_sni.go
@@ -35,12 +35,13 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 			return check.ResultDefaultDenyEgressDrop, check.ResultNone
 		})
 
+	yamlFile = templates["clientEgressTLSSNIOtherPolicyYAML"]
 	newTest(fmt.Sprintf("%s-denied", testName), ct).
 		WithCiliumVersion("!1.14.15 !1.14.16 !1.15.9 !1.15.10 !1.16.2 !1.16.3").
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
-		WithScenarios(tests.PodToWorld2()).                           // Another External Target is not allowed
+		WithScenarios(tests.PodToWorld()).                            // External Target is not allowed
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Destination().Port() == 443 {
 				// SSL error as another external target (e.g. cilium.io) SNI is not allowed

--- a/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni-other.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-tls-sni-other.yaml
@@ -1,0 +1,17 @@
+# Same as client-egress-tls-sni.yaml but with external other target server name
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "client-egress-tls-sni-other"
+specs:
+- description: "TLS SNI policy with ExternalOtherTarget"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "443"
+        protocol: "TCP"
+      serverNames:
+      - "{{trimSuffix .ExternalOtherTarget "."}}"

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -329,5 +329,5 @@ var (
 	// Cf. https://github.com/cilium/cilium/issues/35803
 	endpointMapDeleteFailed = regexMatcher{regexp.MustCompile(`Ignoring error while deleting endpoint.*from map cilium_\w+: delete: key does not exist`)}
 	// envoyTLSWarning is the legitimate warning log for negative TLS SNI test case
-	envoyTLSWarning = regexMatcher{regexp.MustCompile("cilium.tls_wrapper: Could not get server TLS context for pod.*on destination IP.*port 443 sni.*cilium.io.*and raw socket is not allowed")}
+	envoyTLSWarning = regexMatcher{regexp.MustCompile("cilium.tls_wrapper: Could not get server TLS context for pod.*on destination IP.*port 443 sni.*one.one.one.one.*and raw socket is not allowed")}
 )


### PR DESCRIPTION
The current SNI denied test sends request to cilium.io with serverNames as one.one.one.one, and expects TLS error. However, cilium.io might not be as reliable compared to one.one.one.one, hence causes timeout issue (e.g. 28) instead of expected SSL error code (e.g. 35) as observed in #37381.

This commit is to reverse the test to use one.one.one.one as external target, however, new CNP client-egress-tls-sni-other will only allow serverNames with ExternalOtherTarget (defaults to cilium.io).

Relates: #37122, #37381

