### PR TITLE
daemon: Create NAT retries maps early on startup

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -226,6 +226,10 @@ func (d *Daemon) initMaps() error {
 			option.Config.EnableIPv6); err != nil {
 			return fmt.Errorf("initializing neighbors map: %w", err)
 		}
+		if err := nat.CreateRetriesMaps(option.Config.EnableIPv4,
+			option.Config.EnableIPv6); err != nil {
+			return fmt.Errorf("initializing NAT retries map: %w", err)
+		}
 	}
 
 	if option.Config.EnableIPv4FragmentsTracking {

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -436,3 +436,19 @@ func RetriesMaps(ipv4, ipv6, nodeport bool) (ipv4RetriesMap, ipv6RetriesMap Retr
 	}
 	return
 }
+
+func CreateRetriesMaps(ipv4, ipv6 bool) error {
+	if ipv4 {
+		ipv4Map := NewRetriesMap(MapNameSnat4AllocRetries)
+		if err := ipv4Map.OpenOrCreate(); err != nil {
+			return err
+		}
+	}
+	if ipv6 {
+		ipv6Map := NewRetriesMap(MapNameSnat6AllocRetries)
+		if err := ipv6Map.OpenOrCreate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
We have some sort of race popping up in CI from time to time around the loading of some BPF maps:

    loading eBPF collection into the kernel: map
      cilium_snat_v4_alloc_retries: pin map to
      /sys/fs/bpf/tc/globals/cilium_snat_v4_alloc_retries: file exists

Example: https://github.com/cilium/cilium/actions/runs/13069908162/job/36469367172

One approach to avoid this is to ensure such maps are always created early on agent startup instead of being created during endpoint creation (where concurrent program loadings can run into this race).

This commit therefore adds the two maps concerned by this issue to the `initMaps` method.

Fixes: https://github.com/cilium/cilium/pull/36730.
cc @gentoo-root 