### PR TITLE
test: Move the dind image to Quay to avoid rate-limiting

### DIFF
--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -37,7 +37,7 @@ clang -O2 -Wall --target=bpf -c test_tc_tunnel.c -o test_tc_tunnel.o
 docker network create cilium-l4lb
 docker run --privileged --name lb-node -d --restart=on-failure:10 \
     --network cilium-l4lb -v /lib/modules:/lib/modules \
-    docker:dind
+    quay.io/cilium/docker:27.5.1-dind
 docker run --name nginx -d --network cilium-l4lb nginx
 
 # Create additional veth pair which is going to be used to test XDP_REDIRECT.

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -107,7 +107,7 @@ function initialize_docker_env {
     docker network create --subnet="172.12.42.0/24,2001:db8:1::/64" --ipv6 cilium-l4lb
     docker run --privileged --name lb-node -d --restart=on-failure:10 \
         --network cilium-l4lb -v /lib/modules:/lib/modules \
-        docker:dind
+        quay.io/cilium/docker:27.5.1-dind
     docker exec -t lb-node mount bpffs /sys/fs/bpf -t bpf
     docker run --name nginx -d --network cilium-l4lb nginx
 


### PR DESCRIPTION
Our CI sometimes fail with:

    +[02:21:02] docker run --privileged --name lb-node -d --restart=on-failure:10 --network cilium-l4lb -v /lib/modules:/lib/modules docker:dind
    Unable to find image 'docker:dind' locally
    docker: Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit.

This commit therefore switches those tests to start using our copy of the dind image, on our Quay account.