### PR TITLE
cli: Added parameter to print used images

### DIFF
--- a/cilium-cli/cli/connectivity_test.go
+++ b/cilium-cli/cli/connectivity_test.go
@@ -14,6 +14,7 @@ import (
 	assets "github.com/cilium/cilium"
 	"github.com/cilium/cilium/cilium-cli/api"
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/defaults"
 )
 
 func TestNewConnectivityTests(t *testing.T) {
@@ -111,4 +112,46 @@ func TestConnectivityTestFlags(t *testing.T) {
 	require.Equal(t, map[string]string{"a": "b"}, params.NodeSelector)
 	require.NoError(t, ct.Flags().Set("node-selector", "c=d"))
 	require.Equal(t, map[string]string{"a": "b", "c": "d"}, params.NodeSelector)
+}
+
+func TestPrintImageArtifacts(t *testing.T) {
+	ct := newCmdConnectivityTest(&api.NopHooks{})
+	var buf bytes.Buffer
+
+	params.Writer = &buf
+
+	// Test print-image-artifacts flag for connectivity test subcommand
+	buf.Reset()
+	require.NoError(t, ct.Flags().Set("print-image-artifacts", "true"))
+	require.NoError(t, ct.Execute())
+	for _, img := range defaults.ConnectivityCheckImagesTest {
+		require.Contains(t, buf.String(), img)
+	}
+
+	// Test print-image-artifacts flag for connectivity test subcommand with overridden image
+	buf.Reset()
+	var alpineImage = "alpine/curl:latest"
+	require.NoError(t, ct.Flags().Set("print-image-artifacts", "true"))
+	require.NoError(t, ct.Flags().Set("curl-image", alpineImage))
+	require.NoError(t, ct.Execute())
+	require.Contains(t, buf.String(), alpineImage)
+	require.NotContains(t, buf.String(), defaults.ConnectivityCheckImagesTest["ConnectivityCheckAlpineCurlImage"])
+
+	// Test print-image-artifacts flag for connectivity perf subcommand
+	cp := newCmdConnectivityPerf(&api.NopHooks{})
+	buf.Reset()
+	require.NoError(t, cp.Flags().Set("print-image-artifacts", "true"))
+	require.NoError(t, cp.Execute())
+	for _, img := range defaults.ConnectivityCheckImagesPerf {
+		require.Contains(t, buf.String(), img)
+	}
+
+	// Test print-image-artifacts flag for connectivity perf subcommand with overridden image
+	buf.Reset()
+	var perfImage = "alpine:latest"
+	require.NoError(t, cp.Flags().Set("print-image-artifacts", "true"))
+	require.NoError(t, cp.Flags().Set("performance-image", perfImage))
+	require.NoError(t, cp.Execute())
+	require.Contains(t, buf.String(), perfImage)
+	require.NotContains(t, buf.String(), defaults.ConnectivityCheckImagesPerf["ConnectivityPerformanceImage"])
 }

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -67,6 +67,7 @@ type Parameters struct {
 	SocatImage             string
 	AgentDaemonSetName     string
 	DNSTestServerImage     string
+	PrintImageArtifacts    bool
 	IncludeUnsafeTests     bool
 	AgentPodSelector       string
 	CiliumPodSelector      string

--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -65,21 +65,6 @@ const (
 
 	ConnectivityCheckNamespace = "cilium-test"
 
-	// renovate: datasource=docker
-	ConnectivityCheckAlpineCurlImage = "quay.io/cilium/alpine-curl:v1.10.0@sha256:913e8c9f3d960dde03882defa0edd3a919d529c2eb167caa7f54194528bde364"
-	// renovate: datasource=docker
-	ConnectivityPerformanceImage = "quay.io/cilium/network-perf:a816f935930cb2b40ba43230643da4d5751a5711@sha256:679d3a370c696f63884da4557a4466f3b5569b4719bb4f86e8aac02fbe390eea"
-	// renovate: datasource=docker
-	ConnectivityCheckJSONMockImage = "quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603"
-	// renovate: datasource=docker
-	ConnectivityDNSTestServerImage = "docker.io/coredns/coredns:1.12.0@sha256:40384aa1f5ea6bfdc77997d243aec73da05f27aed0c5e9d65bfa98933c519d97"
-	// renovate: datasource=docker
-	ConnectivityTestConnDisruptImage = "quay.io/cilium/test-connection-disruption:v0.0.16@sha256:8f47eb03545097f65ac3863720e6f5691feadcd02341a1ad3da7ca4097c0c656"
-	// renovate: datasource=docker
-	ConnectivityTestFRRImage = "quay.io/frrouting/frr:10.2.1@sha256:c8543d3e0a1348cc0f2b19154fd8b0300e237773dbec65d9d6d6570c1d088deb"
-	// renovate: datasource=docker
-	ConnectivityTestSocatImage = "docker.io/alpine/socat:1.8.0.1@sha256:2fe7c6362c14c85898763664f3c1327157075d88650c8e9bee71008b7d01a344"
-
 	ConfigMapName = "cilium-config"
 
 	StatusWaitDuration = 5 * time.Minute
@@ -177,6 +162,26 @@ var (
 	LogCheckLevels = []string{
 		LogLevelError,
 		LogLevelWarning,
+	}
+
+	ConnectivityCheckImagesTest = map[string]string{
+		// renovate: datasource=docker
+		"ConnectivityCheckAlpineCurlImage": "quay.io/cilium/alpine-curl:v1.10.0@sha256:913e8c9f3d960dde03882defa0edd3a919d529c2eb167caa7f54194528bde364",
+		// renovate: datasource=docker
+		"ConnectivityCheckJSONMockImage": "quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603",
+		// renovate: datasource=docker
+		"ConnectivityDNSTestServerImage": "docker.io/coredns/coredns:1.12.0@sha256:40384aa1f5ea6bfdc77997d243aec73da05f27aed0c5e9d65bfa98933c519d97",
+		// renovate: datasource=docker
+		"ConnectivityTestConnDisruptImage": "quay.io/cilium/test-connection-disruption:v0.0.14@sha256:c3fd56e326ae16f6cb63dbb2e26b4e47ec07a123040623e11399a7fe1196baa0",
+		// renovate: datasource=docker
+		"ConnectivityTestFRRImage": "quay.io/frrouting/frr:10.2.1@sha256:c8543d3e0a1348cc0f2b19154fd8b0300e237773dbec65d9d6d6570c1d088deb",
+		// renovate: datasource=docker
+		"ConnectivityTestSocatImage": "docker.io/alpine/socat:1.8.0.1@sha256:e899028c84c1a1e65bb14821b0802a683a2cffbff96c9ac02ff1d9cbb03f64e6",
+	}
+
+	ConnectivityCheckImagesPerf = map[string]string{
+		// renovate: datasource=docker
+		"ConnectivityPerformanceImage": "quay.io/cilium/network-perf:a816f935930cb2b40ba43230643da4d5751a5711@sha256:679d3a370c696f63884da4557a4466f3b5569b4719bb4f86e8aac02fbe390eea",
 	}
 
 	// The following variables are set at compile time via LDFLAGS.


### PR DESCRIPTION
Added `--print-image-artifacts` for the cilium connectivity test|perf subcommands so it's easier to know which image dependencies there are. This is especially helpful when running the CLI tests in an air-happed environment.

ToDos:
- [x] The go tests do not yet work. `buf.String()` always seems empty.
- [x] Does anyone see a nicer solution than iterating over the images individually? The default images are defined [here](https://github.com/cilium/cilium/blob/25c82e7ad55c1043d85a3c067c6a4069e2aab561/cilium-cli/defaults/defaults.go#L69-L82) as const string values (so not in an array/map or something).

Manual testing:
```bash
$ ./cilium connectivity test --print-image-artifacts
quay.io/cilium/alpine-curl:v1.10.0@sha256:913e8c9f3d960dde03882defa0edd3a919d529c2eb167caa7f54194528bde364
quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
docker.io/coredns/coredns:1.12.0@sha256:40384aa1f5ea6bfdc77997d243aec73da05f27aed0c5e9d65bfa98933c519d97
quay.io/cilium/test-connection-disruption:v0.0.14@sha256:c3fd56e326ae16f6cb63dbb2e26b4e47ec07a123040623e11399a7fe1196baa0
quay.io/frrouting/frr:10.2.1@sha256:c8543d3e0a1348cc0f2b19154fd8b0300e237773dbec65d9d6d6570c1d088deb
docker.io/alpine/socat:1.8.0.1@sha256:d95d6a210a87164533d444e8d7ebd586231b3387a27ee7c0732ade3d6c3b0f4d

$ ./cilium connectivity perf --print-image-artifacts
quay.io/cilium/network-perf:a816f935930cb2b40ba43230643da4d5751a5711@sha256:679d3a370c696f63884da4557a4466f3b5569b4719bb4f86e8aac02fbe390eea

$ ./cilium connectivity test --print-image-artifacts --curl-image "alpine/curl:latest"
alpine/curl:latest
quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
docker.io/coredns/coredns:1.12.0@sha256:40384aa1f5ea6bfdc77997d243aec73da05f27aed0c5e9d65bfa98933c519d97
quay.io/cilium/test-connection-disruption:v0.0.14@sha256:c3fd56e326ae16f6cb63dbb2e26b4e47ec07a123040623e11399a7fe1196baa0
quay.io/frrouting/frr:10.2.1@sha256:c8543d3e0a1348cc0f2b19154fd8b0300e237773dbec65d9d6d6570c1d088deb
docker.io/alpine/socat:1.8.0.1@sha256:d95d6a210a87164533d444e8d7ebd586231b3387a27ee7c0732ade3d6c3b0f4d

$ ./cilium connectivity perf --print-image-artifacts --performance-image "alpine:latest"
alpine:latest
```

```release-note
cli: Added parameter to print used images
```

cc @tklauser 
