### PR TITLE
[v1.17] agent: Deprecate lb-only mode

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -80,7 +80,7 @@ cilium-agent [flags]
       --container-ip-local-reserved-ports string                  Instructs the Cilium CNI plugin to reserve the provided comma-separated list of ports in the container network namespace. Prevents the container from using these ports as ephemeral source ports (see Linux ip_local_reserved_ports). Use this flag if you observe port conflicts between transparent DNS proxy requests and host network namespace services. Value "auto" reserves the WireGuard and VXLAN ports used by Cilium (default "auto")
       --controller-group-metrics strings                          List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --crd-wait-timeout duration                                 Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
-      --datapath-mode string                                      Datapath mode name (veth, netkit, netkit-l2, lb-only) (default "veth")
+      --datapath-mode string                                      Datapath mode name (veth, netkit, netkit-l2, lb-only (deprecated)) (default "veth")
   -D, --debug                                                     Enable debugging mode
       --debug-verbose strings                                     List of enabled verbose debug groups
       --devices strings                                           List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -380,6 +380,7 @@ Deprecated Options
   has been deprecated. It will be remove in v1.18.
 * The ``--enable-k8s-terminating-endpoint`` cilium-agent flag (``enableK8sTerminatingEndpoint`` in Helm) has been deprecated.
   The feature will be unconditionally enabled in v1.18.
+* The ``--datapath-mode=lb-only`` has been deprecated and will be removed in v1.18.
 
 Helm Options
 ~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -250,7 +250,7 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkDeprecated(option.EnableRuntimeDeviceDetection, "Runtime device detection and datapath reconfiguration is now the default and only mode of operation")
 
 	flags.String(option.DatapathMode, defaults.DatapathMode,
-		fmt.Sprintf("Datapath mode name (%s, %s, %s, %s)",
+		fmt.Sprintf("Datapath mode name (%s, %s, %s, %s (deprecated))",
 			datapathOption.DatapathModeVeth, datapathOption.DatapathModeNetkit,
 			datapathOption.DatapathModeNetkitL2, datapathOption.DatapathModeLBOnly))
 	option.BindEnv(vp, option.DatapathMode)
@@ -1288,6 +1288,7 @@ func initEnv(vp *viper.Viper) {
 		}
 	case datapathOption.DatapathModeLBOnly:
 		log.Info("Running in LB-only mode")
+		log.Warn("LB-only mode is deprecated and will be removed in v1.18")
 		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
 			option.Config.EnablePMTUDiscovery = true
 		}


### PR DESCRIPTION
The feature is no longer maintained.