### PR TITLE
cilium-dbg: output parentIfIndex in bpf endpoint list

### DIFF
--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -163,13 +163,14 @@ func (v *EndpointInfo) String() string {
 		return "(localhost)"
 	}
 
-	return fmt.Sprintf("id=%-5d sec_id=%-5d flags=0x%04X ifindex=%-3d mac=%s nodemac=%s",
+	return fmt.Sprintf("id=%-5d sec_id=%-5d flags=0x%04X ifindex=%-3d mac=%s nodemac=%s parent_ifindex=%-3d",
 		v.LxcID,
 		v.SecID,
 		v.Flags,
 		v.IfIndex,
 		v.MAC,
 		v.NodeMAC,
+		v.ParentIfIndex,
 	)
 }
 


### PR DESCRIPTION
Fixes: #37378

After adding `parentIfIndex` to the `Endpoint` Struct by this PR https://github.com/cilium/cilium/pull/35298. I changed the output of the command `cilium-dbg bpf endpoint list` to include the new added parameter.

<img width="961" alt="Screenshot 2025-01-31 at 19 31 37" src="https://github.com/user-attachments/assets/c3201e1d-d191-490c-86d3-c8a8cae4f853" />
