### PR TITLE
refactor: move WithUnixSocketListener to a linux specific file

### DIFF
--- a/pkg/hubble/server/serveroption/option_linux.go
+++ b/pkg/hubble/server/serveroption/option_linux.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+// Copyright Authors of Cilium
+
+package serveroption
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/api"
+)
+
+// WithUnixSocketListener configures a unix domain socket listener with the
+// given file path. When the process runs in privileged mode, the file group
+// owner is set to socketGroup.
+func WithUnixSocketListener(path string) Option {
+	return func(o *Options) error {
+		if o.Listener != nil {
+			return fmt.Errorf("listener already configured")
+		}
+		socketPath := strings.TrimPrefix(path, "unix://")
+		unix.Unlink(socketPath)
+		socket, err := net.Listen("unix", socketPath)
+		if err != nil {
+			return err
+		}
+		if os.Getuid() == 0 {
+			if err := api.SetDefaultPermissions(socketPath); err != nil {
+				socket.Close()
+				return err
+			}
+		}
+		o.Listener = socket
+		return nil
+	}
+}


### PR DESCRIPTION
### Overview

This pull request includes changes to refactor the handling of Unix socket listeners in the Hubble server options. The primary changes involve moving the Unix socket listener configuration to a new file specifically for Linux. 

#### Why?

Retina uses hubble as it's dataplane. However we build the retina agent with windows as well, having the unix import is causing failure as we move towards using the newer release of cilium. To address this I have moved the option to use Unix import just for linux builds. 

Refactoring Unix socket listener configuration:

* [`pkg/hubble/server/serveroption/option.go`](diffhunk://#diff-0820e1fd9d953c06c1d44322bb224907d7deff4a77a32910670d38144b74c5d1L12-L24): Removed the `WithUnixSocketListener` function and its associated imports. [[1]](diffhunk://#diff-0820e1fd9d953c06c1d44322bb224907d7deff4a77a32910670d38144b74c5d1L12-L24) [[2]](diffhunk://#diff-0820e1fd9d953c06c1d44322bb224907d7deff4a77a32910670d38144b74c5d1L66-L90)
* [`pkg/hubble/server/serveroption/option_linux.go`](diffhunk://#diff-b3a514b21543342b04ea58b809a3c2d2d3fc5bd3b3307682d8da30cd26bd9702R1-R41): Added a new file containing the `WithUnixSocketListener` function and necessary imports, ensuring the Unix socket listener configuration is specific to Linux.


Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

```release-note
Moves Unix socket listener configuration to a new file specifically for Linux builds.
```
