### PR TITLE
Fix MapOptions validation logic

### DIFF
--- a/pkg/option/map_options_test.go
+++ b/pkg/option/map_options_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package option
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMapOptions(t *testing.T) {
+	for _, tc := range []struct {
+		desc      string
+		input     string
+		validator Validator
+		wantErr   string
+		want      map[string]string
+	}{
+		{
+			desc:  "no validator",
+			input: "k1= v1,k2=",
+			want: map[string]string{
+				"k1": " v1",
+				"k2": "",
+			},
+		},
+		{
+			desc:  "validator that returns error",
+			input: "k1=v1,k2=v2",
+			validator: func(val string) (string, error) {
+				return "", fmt.Errorf("invalid value %s", val)
+			},
+			wantErr: "invalid value k1=v1",
+		},
+		{
+			desc:  "validator that modifies entries",
+			input: "k8s:k1 =v1,k8s:k2= v2",
+			validator: func(val string) (string, error) {
+				val = strings.TrimPrefix(val, "k8s:")
+				vals := strings.SplitN(val, "=", 2)
+				kv := []string{strings.TrimSpace(vals[0]), strings.TrimSpace(vals[1])}
+				return strings.Join(kv, "="), nil
+			},
+			want: map[string]string{
+				"k1": "v1",
+				"k2": "v2",
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			opts := NewNamedMapOptions("flag-1", &map[string]string{}, tc.validator)
+			err := opts.Set(tc.input)
+			if err != nil {
+				if len(tc.wantErr) == 0 {
+					t.Fatalf("NewNamedMapOptions()=%v, want nil", err)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("NewNamedMapOptions()=%v, want error with substring %q", err, tc.wantErr)
+				}
+				return
+			} else if len(tc.wantErr) != 0 {
+				t.Fatalf("NewNamedMapOptions()=nil, want error with substring %q", tc.wantErr)
+			}
+			if diff := cmp.Diff(tc.want, opts.vals); diff != "" {
+				t.Errorf("Unexpected result map (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Current validation runs into the following error with multiple entries ("200=pod1,201=pod2")

```
level=fatal msg="Incorrect config-map flag value" error="option fixed-identity-mapping: invalid fixed identity: expecting \"<numeric-identity>=<identity-name>\" got \"200=pod1,201=pod2\"" subsys=config
```

The flag supports multiple entries as well so this needs to be addressed.

https://github.com/cilium/cilium/blob/5674e8fdf29d4d88d4e8ded993d940e666e0ea15/daemon/cmd/daemon_main.go#L439-L441

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
Fix the options parsing logic for options with a map argument to allow multiple fields to be configured in a configmap, separated by commas
```