### PR TITLE
hubble: escape terminal special characters from observe output

### DIFF
--- a/hubble/pkg/printer/color.go
+++ b/hubble/pkg/printer/color.go
@@ -4,6 +4,8 @@
 package printer
 
 import (
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/fatih/color"
@@ -115,4 +117,20 @@ func (c colorer) authTestAlwaysFail(a interface{}) string {
 
 func (c colorer) authIsEnabled(a interface{}) string {
 	return c.green.Sprint(a)
+}
+
+// compute the list of unique ANSI escape sequences for this colorer.
+func (c *colorer) sequences() []string {
+	unique := make(map[string]struct{})
+	for _, v := range c.colors {
+		seq := v.Sprint("|")
+		split := strings.Split(seq, "|")
+		if len(split) != 2 {
+			// should never happen
+			continue
+		}
+		unique[split[0]] = struct{}{}
+		unique[split[1]] = struct{}{}
+	}
+	return slices.Collect(maps.Keys(unique))
 }

--- a/hubble/pkg/printer/terminal.go
+++ b/hubble/pkg/printer/terminal.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package printer
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type terminalEscaperBuilder struct {
+	replacer *strings.Replacer
+}
+
+// newTerminalEscaperBuilder creates a new terminalEscaperBuilder that allows a subset of control
+// sequences, such as a reserved set of colors and their reset sequences.
+func newTerminalEscaperBuilder(allowed []string) *terminalEscaperBuilder {
+	var oldnew []string
+	for _, a := range allowed {
+		oldnew = append(oldnew, a, a)
+	}
+	oldnew = append(oldnew, "\x1b", "^[", "\r", "\\r")
+	return &terminalEscaperBuilder{replacer: strings.NewReplacer(oldnew...)}
+}
+
+func (teb *terminalEscaperBuilder) NewWriter(w io.Writer) *terminalEscaperWriter {
+	return &terminalEscaperWriter{w: w, replacer: teb.replacer}
+}
+
+// terminalEscaperWriter replaces ANSI escape sequences and other terminal special
+// characters to avoid terminal escape character attacks. It stops on the first error
+// encountered and stores its value. The caller is responsible for checking Err()
+// when done writing.
+type terminalEscaperWriter struct {
+	w        io.Writer
+	replacer *strings.Replacer
+	err      error
+}
+
+func (tew *terminalEscaperWriter) print(a ...interface{}) {
+	if tew.err != nil {
+		return
+	}
+	_, tew.err = tew.replacer.WriteString(tew.w, fmt.Sprint(a...))
+}
+
+func (tew *terminalEscaperWriter) printf(format string, a ...interface{}) {
+	if tew.err != nil {
+		return
+	}
+	_, tew.err = tew.replacer.WriteString(tew.w, fmt.Sprintf(format, a...))
+}

--- a/hubble/pkg/printer/terminal_test.go
+++ b/hubble/pkg/printer/terminal_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package printer
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTerminalEscaperWriter(t *testing.T) {
+	colorer := newColorer("always")
+	allowedSequences := colorer.sequences()
+	builder := newTerminalEscaperBuilder(allowedSequences)
+
+	testCases := []struct {
+		name   string
+		format string
+		args   []any
+		want   string
+	}{
+		{name: "control", args: []any{"\x1b"}, want: "^["},
+		{name: "control", args: []any{"\033"}, want: "^["},
+		{name: "carriage return", args: []any{"\r"}, want: "\\r"},
+		{name: "both", args: []any{"\x1b \r"}, want: "^[ \\r"},
+		{name: "formatted args", format: "%d%s%d%s%d", args: []any{1, "\x1b", 3, "\r", 5}, want: "1^[3\\r5"},
+		{name: "formatted args split sequence", format: "%s%s", args: []any{"\\", "x1b"}, want: "\\x1b"},
+		{name: "formatted args split sequence", format: "%s%s", args: []any{"\\", "033"}, want: "\\033"},
+		{
+			name: "allowed colors",
+			args: []any{
+				colorer.red.Sprint("red"),
+				colorer.green.Sprint("green"),
+				colorer.blue.Sprint("blue"),
+				colorer.cyan.Sprint("cyan"),
+				colorer.magenta.Sprint("magenta"),
+				colorer.yellow.Sprint("yellow"),
+			},
+			want: "\x1b[31mred\x1b[0m\x1b[32mgreen\x1b[0m\x1b[34mblue\x1b[0m\x1b[36mcyan\x1b[0m\x1b[35mmagenta\x1b[0m\x1b[33myellow\x1b[0m",
+		},
+	}
+
+	for idx, tc := range testCases {
+		t.Run(fmt.Sprintf("%d.%s", idx, tc.name), func(t *testing.T) {
+			var buf bytes.Buffer
+			tew := builder.NewWriter(&buf)
+			if tc.format != "" {
+				tew.printf(tc.format, tc.args...)
+			} else {
+				tew.print(tc.args...)
+			}
+			got := buf.String()
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Escape special characters from `hubble observe` output when not using JSON formatting to protect against possible malicious character injection.

This approach escapes characters at the very end, before writing the output to its writer. It also takes care of allowing control characters used to colorize the output. I tried something smart, but we might want to simply escape manually all callsites that may return unsanitized strings before colorizing.

Similar to: https://github.com/kubernetes/kubernetes/issues/101695
Similar to: https://github.com/python/cpython/issues/100001