### PR TITLE
ipam/aws: correct the address caculation

### DIFF
--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -289,6 +289,11 @@ func (n *Node) AllocateIPs(ctx context.Context, a *ipam.AllocationAction) error 
 			logfields.Node: n.k8sObj.Name,
 		}).Warning("Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore")
 	}
+	n.loggerLocked().WithFields(logrus.Fields{
+		logfields.Node:           n.k8sObj.Name,
+		"interfaceID":            a.InterfaceID,
+		"availableForAllocation": a.IPv4.AvailableForAllocation,
+	}).Warning("debug-36428 allocating IPs")
 	return n.manager.api.AssignPrivateIpAddresses(ctx, a.InterfaceID, int32(a.IPv4.AvailableForAllocation))
 }
 

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -385,6 +385,7 @@ func (n *NodeManager) Upsert(resource *v2.CiliumNode) {
 	}
 	// Update the resource in the node while holding the lock, otherwise resyncs can be
 	// triggered prior to the update being applied.
+	log.WithField(fieldName, resource.Name).Warning("debug-36428, it's about to update the resource")
 	node.UpdatedResource(resource)
 }
 


### PR DESCRIPTION
don't review. this commit is to add logs to track the issue
- add the logs to track the issue





Fixes: https://github.com/cilium/cilium/issues/36428
```release-note
Enhace the ENI address caculation to resolve the race condition in issue 36428
```
