### PR TITLE
gateway-api: Refator and cleanup codebase

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -129,8 +129,11 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		return err
 	}
 
-	cecTranslator := translation.NewCECTranslator(translation.Config{
+	cfg := translation.Config{
 		SecretsNamespace: params.GatewayApiConfig.GatewayAPISecretsNamespace,
+		ServiceConfig: translation.ServiceConfig{
+			ExternalTrafficPolicy: params.GatewayApiConfig.GatewayAPIServiceExternalTrafficPolicy,
+		},
 		HostNetworkConfig: translation.HostNetworkConfig{
 			Enabled:           params.GatewayApiConfig.GatewayAPIHostnetworkEnabled,
 			NodeLabelSelector: translation.ParseNodeLabelSelector(params.GatewayApiConfig.GatewayAPIHostnetworkNodelabelselector),
@@ -153,13 +156,10 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
 			XFFNumTrustedHops: params.GatewayApiConfig.GatewayAPIXffNumTrustedHops,
 		},
-	})
+	}
+	cecTranslator := translation.NewCECTranslator(cfg)
 
-	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(
-		cecTranslator,
-		params.GatewayApiConfig.GatewayAPIHostnetworkEnabled,
-		params.GatewayApiConfig.GatewayAPIServiceExternalTrafficPolicy,
-	)
+	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, cfg)
 
 	if err := registerReconcilers(
 		params.CtrlRuntimeManager,

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -317,7 +317,14 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 			IdleTimeoutSeconds: 60,
 		},
 	})
-	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, false, string(corev1.ServiceExternalTrafficPolicyCluster))
+	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
+		HostNetworkConfig: translation.HostNetworkConfig{
+			Enabled: false,
+		},
+		ServiceConfig: translation.ServiceConfig{
+			ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
+		},
+	})
 
 	r := &gatewayReconciler{
 		Client:     c,

--- a/operator/pkg/gateway-api/grpcroute.go
+++ b/operator/pkg/gateway-api/grpcroute.go
@@ -5,6 +5,7 @@ package gateway_api
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	corev1 "k8s.io/api/core/v1"
@@ -43,21 +44,14 @@ func newGRPCRouteReconciler(mgr ctrl.Manager, logger *slog.Logger) *grpcRouteRec
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *grpcRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.GRPCRoute{},
-		backendServiceIndex, r.getBackendServiceForGRPCRoute,
-	); err != nil {
-		return err
-	}
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.GRPCRoute{},
-		backendServiceImportIndex, r.getBackendServiceImportForGRPCRoute,
-	); err != nil {
-		return err
-	}
-
-	// Create field indexer for Gateway parents, this allows a faster lookup for event queueing
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.GRPCRoute{},
-		gatewayIndex, getParentGatewayForGRPCRoute); err != nil {
-		return err
+	for indexName, indexerFunc := range map[string]client.IndexerFunc{
+		backendServiceIndex:       r.referencedBackendService,
+		backendServiceImportIndex: r.referencedBackendServiceImport,
+		gatewayIndex:              r.referencedGateway,
+	} {
+		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.GRPCRoute{}, indexName, indexerFunc); err != nil {
+			return fmt.Errorf("failed to setup field indexer %q: %w", indexName, err)
+		}
 	}
 
 	builder := ctrl.NewControllerManagedBy(mgr).
@@ -80,7 +74,7 @@ func (r *grpcRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return builder.Complete(r)
 }
 
-func getParentGatewayForGRPCRoute(rawObj client.Object) []string {
+func (r *grpcRouteReconciler) referencedGateway(rawObj client.Object) []string {
 	route, ok := rawObj.(*gatewayv1.GRPCRoute)
 	if !ok {
 		return nil
@@ -100,7 +94,7 @@ func getParentGatewayForGRPCRoute(rawObj client.Object) []string {
 	return gateways
 }
 
-func (r *grpcRouteReconciler) getBackendServiceForGRPCRoute(rawObj client.Object) []string {
+func (r *grpcRouteReconciler) referencedBackendService(rawObj client.Object) []string {
 	route, ok := rawObj.(*gatewayv1.GRPCRoute)
 	if !ok {
 		return nil
@@ -129,7 +123,7 @@ func (r *grpcRouteReconciler) getBackendServiceForGRPCRoute(rawObj client.Object
 	return backendServices
 }
 
-func (r *grpcRouteReconciler) getBackendServiceImportForGRPCRoute(rawObj client.Object) []string {
+func (r *grpcRouteReconciler) referencedBackendServiceImport(rawObj client.Object) []string {
 	route, ok := rawObj.(*gatewayv1.GRPCRoute)
 	if !ok {
 		return nil

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -4,10 +4,13 @@
 package model
 
 import (
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/cilium/cilium/pkg/slices"
 )
 
 // Model holds an abstracted data model representing the translation
@@ -466,4 +469,82 @@ type HTTPRetry struct {
 	// Backoff specifies the minimum duration a Gateway should wait between
 	// retry attempts
 	Backoff *time.Duration `json:"backoff,omitempty"`
+}
+
+// IsEmpty returns true if the model has no HTTP or TLS Passthrough listeners.
+func (m *Model) IsEmpty() bool {
+	return len(m.HTTP) == 0 && len(m.TLSPassthrough) == 0
+}
+
+// IsHTTPListenerConfigured returns true if the model has any HTTP listeners.
+func (m *Model) IsHTTPListenerConfigured() bool {
+	return len(m.HTTP) > 0
+}
+
+// IsHTTPSListenerConfigured returns true if the model has any HTTPS listeners.
+func (m *Model) IsHTTPSListenerConfigured() bool {
+	for _, l := range m.HTTP {
+		if len(l.TLS) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTLSPassthroughListenerConfigured returns true if the model has any TLS Passthrough listeners.
+func (m *Model) IsTLSPassthroughListenerConfigured() bool {
+	return len(m.TLSPassthrough) > 0
+}
+
+// HTTPPorts returns a list of unique ports for all HTTP listeners.
+func (m *Model) HTTPPorts() []uint32 {
+	var ports []uint32
+	for _, l := range m.HTTP {
+		ports = append(ports, l.Port)
+	}
+	return slices.SortedUnique(ports)
+}
+
+// TLSPassthroughPorts returns a list of unique ports for all TLS Passthrough listeners.
+func (m *Model) TLSPassthroughPorts() []uint32 {
+	var ports []uint32
+	for _, l := range m.TLSPassthrough {
+		ports = append(ports, l.Port)
+	}
+	return slices.SortedUnique(ports)
+}
+
+// AllPorts returns a list of unique ports for all listeners.
+func (m *Model) AllPorts() []uint32 {
+	var ports []uint32
+	ports = append(ports, m.HTTPPorts()...)
+	ports = append(ports, m.TLSPassthroughPorts()...)
+	return slices.SortedUnique(ports)
+}
+
+// TLSBackendsToHostnames returns a map of TLS backends to hostnames.
+// This is only for TLS Passthrough listeners.
+func (m *Model) TLSBackendsToHostnames() map[string][]string {
+	res := make(map[string][]string)
+	for _, h := range m.TLSPassthrough {
+		for _, route := range h.Routes {
+			for _, backend := range route.Backends {
+				key := fmt.Sprintf("%s:%s:%s", backend.Namespace, backend.Name, backend.Port.GetPort())
+				res[key] = append(res[key], route.Hostnames...)
+			}
+		}
+	}
+	return res
+}
+
+// TLSSecretsToHostnames returns a map of TLS secrets to hostnames.
+// This is only for HTTP listeners.
+func (m *Model) TLSSecretsToHostnames() map[TLSSecret][]string {
+	res := make(map[TLSSecret][]string)
+	for _, h := range m.HTTP {
+		for _, s := range h.TLS {
+			res[s] = append(res[s], h.Hostname)
+		}
+	}
+	return res
 }

--- a/operator/pkg/model/translation/cec_translator.go
+++ b/operator/pkg/model/translation/cec_translator.go
@@ -29,6 +29,10 @@ const (
 
 var _ CECTranslator = (*cecTranslator)(nil)
 
+type ServiceConfig struct {
+	ExternalTrafficPolicy string `json:"external_traffic_policy,omitempty"`
+}
+
 type HostNetworkConfig struct {
 	Enabled           bool                       `json:"enabled,omitempty"`
 	NodeLabelSelector *slim_metav1.LabelSelector `json:"node_label_selector,omitempty"`
@@ -65,6 +69,7 @@ type OriginalIPDetectionConfig struct {
 type Config struct {
 	SecretsNamespace string `json:"secrets_namespace,omitempty"`
 
+	ServiceConfig             ServiceConfig             `json:"service_config"`
 	HostNetworkConfig         HostNetworkConfig         `json:"host_network_config"`
 	IPConfig                  IPConfig                  `json:"ip_config"`
 	ListenerConfig            ListenerConfig            `json:"listener_config"`

--- a/operator/pkg/model/translation/cec_translator_test.go
+++ b/operator/pkg/model/translation/cec_translator_test.go
@@ -148,7 +148,8 @@ func TestSharedIngressTranslator_getBackendServices(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			i := &cecTranslator{}
-			res := i.desiredBackendServices(tt.args.m)
+			res, err := i.desiredBackendServices(tt.args.m)
+			require.NoError(t, err)
 			require.Equal(t, tt.want, res)
 		})
 	}
@@ -249,7 +250,8 @@ func TestSharedIngressTranslator_getServices(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			i := &cecTranslator{}
-			got := i.desiredServicesWithPorts(tt.fields.namespace, tt.fields.name, tt.model)
+			got, err := i.desiredServicesWithPorts(tt.fields.namespace, tt.fields.name, tt.model)
+			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})
 	}
@@ -264,7 +266,7 @@ func TestSharedIngressTranslator_getListenerProxy(t *testing.T) {
 			},
 		},
 	}
-	res := i.desiredEnvoyListener(&model.Model{
+	res, err := i.desiredEnvoyListener(&model.Model{
 		HTTP: []model.HTTPListener{
 			{
 				TLS: []model.TLSSecret{
@@ -276,10 +278,11 @@ func TestSharedIngressTranslator_getListenerProxy(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(t, err)
 	require.Len(t, res, 1)
 
 	listener := &envoy_config_listener.Listener{}
-	err := proto.Unmarshal(res[0].GetValue(), listener)
+	err = proto.Unmarshal(res[0].GetValue(), listener)
 	require.NoError(t, err)
 
 	listenerNames := []string{}
@@ -297,7 +300,7 @@ func TestSharedIngressTranslator_getListener(t *testing.T) {
 		},
 	}
 
-	res := i.desiredEnvoyListener(&model.Model{
+	res, err := i.desiredEnvoyListener(&model.Model{
 		HTTP: []model.HTTPListener{
 			{
 				TLS: []model.TLSSecret{
@@ -309,10 +312,11 @@ func TestSharedIngressTranslator_getListener(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(t, err)
 	require.Len(t, res, 1)
 
 	listener := &envoy_config_listener.Listener{}
-	err := proto.Unmarshal(res[0].GetValue(), listener)
+	err = proto.Unmarshal(res[0].GetValue(), listener)
 	require.NoError(t, err)
 
 	require.Len(t, listener.ListenerFilters, 1)
@@ -408,7 +412,8 @@ func TestSharedIngressTranslator_getClusters(t *testing.T) {
 		i := &cecTranslator{}
 
 		t.Run(tt.name, func(t *testing.T) {
-			res := i.desiredEnvoyCluster(tt.args.m)
+			res, err := i.desiredEnvoyCluster(tt.args.m)
+			require.NoError(t, err)
 			require.Len(t, res, len(tt.expected))
 
 			for i := 0; i < len(tt.expected); i++ {
@@ -468,8 +473,10 @@ func TestGetEnvoyHTTPRouteConfiguration_VirtualHostSorted(t *testing.T) {
 		},
 	}
 
-	res1 := defT.desiredEnvoyHTTPRouteConfiguration(&model.Model{HTTP: l1})
-	res2 := defT.desiredEnvoyHTTPRouteConfiguration(&model.Model{HTTP: l2})
+	res1, err1 := defT.desiredEnvoyHTTPRouteConfiguration(&model.Model{HTTP: l1})
+	res2, err2 := defT.desiredEnvoyHTTPRouteConfiguration(&model.Model{HTTP: l2})
+	require.NoError(t, err1)
+	require.NoError(t, err2)
 
 	diffOutput := cmp.Diff(res1, res2, protocmp.Transform())
 	if len(diffOutput) != 0 {
@@ -551,7 +558,8 @@ func TestSharedIngressTranslator_getEnvoyHTTPRouteConfiguration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res := defT.desiredEnvoyHTTPRouteConfiguration(tt.args.m)
+			res, err := defT.desiredEnvoyHTTPRouteConfiguration(tt.args.m)
+			require.NoError(t, err)
 			require.Len(t, res, len(tt.expectedRouteConfigs), "Number of Listeners did not match")
 
 			for i, rawRoute := range res {
@@ -735,7 +743,8 @@ func TestSharedIngressTranslator_getResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			i := &cecTranslator{}
-			got := i.desiredResources(tt.args.m)
+			got, err := i.desiredResources(tt.args.m)
+			require.NoError(t, err)
 			require.Lenf(t, got, tt.expected, "expected %d resources, got %d", tt.expected, len(got))
 
 			// Log for debugging purpose

--- a/operator/pkg/model/translation/envoy_cluster.go
+++ b/operator/pkg/model/translation/envoy_cluster.go
@@ -60,7 +60,7 @@ func (i *cecTranslator) tcpClusterMutators(mutationFunc ...ClusterMutator) []Clu
 	)
 }
 
-func (i *cecTranslator) desiredEnvoyCluster(m *model.Model) []ciliumv2.XDSResource {
+func (i *cecTranslator) desiredEnvoyCluster(m *model.Model) ([]ciliumv2.XDSResource, error) {
 	envoyClusters := map[string]ciliumv2.XDSResource{}
 	var sortedClusterNames []string
 
@@ -94,7 +94,7 @@ func (i *cecTranslator) desiredEnvoyCluster(m *model.Model) []ciliumv2.XDSResour
 		res[i] = envoyClusters[name]
 	}
 
-	return res
+	return res, nil
 }
 
 // httpCluster creates a new Envoy cluster.

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -178,9 +178,9 @@ func withSocketOption(tcpKeepAlive, tcpKeepIdleInSeconds, tcpKeepAliveProbeInter
 }
 
 // desiredEnvoyListener returns the desired Envoy listener for the given model.
-func (i *cecTranslator) desiredEnvoyListener(m *model.Model) []ciliumv2.XDSResource {
+func (i *cecTranslator) desiredEnvoyListener(m *model.Model) ([]ciliumv2.XDSResource, error) {
 	if len(m.HTTP) == 0 && len(m.TLSPassthrough) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	listener := &envoy_config_listener.Listener{
@@ -200,8 +200,11 @@ func (i *cecTranslator) desiredEnvoyListener(m *model.Model) []ciliumv2.XDSResou
 		listener = fn(listener)
 	}
 
-	res, _ := toXdsResource(listener, envoy.ListenerTypeURL)
-	return []ciliumv2.XDSResource{res}
+	res, err := toXdsResource(listener, envoy.ListenerTypeURL)
+	if err != nil {
+		return nil, err
+	}
+	return []ciliumv2.XDSResource{res}, nil
 }
 
 func (i *cecTranslator) filterChains(name string, m *model.Model) []*envoy_config_listener.FilterChain {

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -118,17 +118,8 @@ func withXffNumTrustedHops(xff uint32) ListenerMutator {
 }
 
 func withHostNetworkPort(m *model.Model, ipv4Enabled bool, ipv6Enabled bool) ListenerMutator {
-	ports := []uint32{}
-	for _, hl := range m.HTTP {
-		ports = append(ports, hl.GetPort())
-	}
-	for _, hl := range m.TLSPassthrough {
-		ports = append(ports, hl.GetPort())
-	}
-
 	return func(listener *envoy_config_listener.Listener) *envoy_config_listener.Listener {
-		listener.Address, listener.AdditionalAddresses = getHostNetworkListenerAddresses(slices.SortedUnique(ports), ipv4Enabled, ipv6Enabled)
-
+		listener.Address, listener.AdditionalAddresses = getHostNetworkListenerAddresses(m.AllPorts(), ipv4Enabled, ipv6Enabled)
 		return listener
 	}
 }
@@ -179,13 +170,18 @@ func withSocketOption(tcpKeepAlive, tcpKeepIdleInSeconds, tcpKeepAliveProbeInter
 
 // desiredEnvoyListener returns the desired Envoy listener for the given model.
 func (i *cecTranslator) desiredEnvoyListener(m *model.Model) ([]ciliumv2.XDSResource, error) {
-	if len(m.HTTP) == 0 && len(m.TLSPassthrough) == 0 {
+	if m.IsEmpty() {
 		return nil, nil
+	}
+
+	filterChains, err := i.filterChains(listenerName, m)
+	if err != nil {
+		return nil, err
 	}
 
 	listener := &envoy_config_listener.Listener{
 		Name:         listenerName,
-		FilterChains: i.filterChains(listenerName, m),
+		FilterChains: filterChains,
 		ListenerFilters: []*envoy_config_listener.ListenerFilter{
 			{
 				Name: tlsInspectorType,
@@ -207,26 +203,31 @@ func (i *cecTranslator) desiredEnvoyListener(m *model.Model) ([]ciliumv2.XDSReso
 	return []ciliumv2.XDSResource{res}, nil
 }
 
-func (i *cecTranslator) filterChains(name string, m *model.Model) []*envoy_config_listener.FilterChain {
+func (i *cecTranslator) filterChains(name string, m *model.Model) ([]*envoy_config_listener.FilterChain, error) {
 	var filterChains []*envoy_config_listener.FilterChain
 
-	if len(m.HTTP) > 0 {
-		httpFilterChain, err := i.httpFilterChain(name, i.Config.IPConfig.IPv4Enabled, i.Config.IPConfig.IPv6Enabled)
+	if m.IsHTTPListenerConfigured() {
+		httpFilterChain, err := i.httpFilterChain(name)
 		if err != nil {
-			return nil
+			return nil, err
 		}
 		filterChains = append(filterChains, httpFilterChain)
 	}
 
-	httpsFilterChains, err := i.httpsFilterChains(name, i.Config.SecretsNamespace, tlsSecretsToHostnames(m), i.Config.IPConfig.IPv4Enabled, i.Config.IPConfig.IPv6Enabled)
-	if err != nil {
-		return nil
+	if m.IsHTTPSListenerConfigured() {
+		httpsFilterChains, err := i.httpsFilterChains(name, m)
+		if err != nil {
+			return nil, err
+		}
+		filterChains = append(filterChains, httpsFilterChains...)
 	}
-	filterChains = append(filterChains, httpsFilterChains...)
 
-	filterChains = append(filterChains, tlsPassthroughFilterChains(tlsPassthroughBackendsToHostnames(m))...)
+	if m.IsTLSPassthroughListenerConfigured() {
+		tlsPTFilterChains := tlsPassthroughFilterChains(m)
+		filterChains = append(filterChains, tlsPTFilterChains...)
+	}
 
-	return filterChains
+	return filterChains, nil
 }
 
 // listenerMutators returns a list of listener mutators to apply to the listener.
@@ -256,7 +257,7 @@ func (i *cecTranslator) listenerMutators(m *model.Model) []ListenerMutator {
 	return res
 }
 
-func (i *cecTranslator) httpFilterChain(name string, enableIpv4 bool, enableIpv6 bool) (*envoy_config_listener.FilterChain, error) {
+func (i *cecTranslator) httpFilterChain(name string) (*envoy_config_listener.FilterChain, error) {
 	insecureHttpConnectionManagerName := fmt.Sprintf("%s-insecure", name)
 	insecureHttpConnectionManager, err := i.desiredHTTPConnectionManager(
 		insecureHttpConnectionManagerName,
@@ -279,32 +280,26 @@ func (i *cecTranslator) httpFilterChain(name string, enableIpv4 bool, enableIpv6
 	}, nil
 }
 
-func (i *cecTranslator) httpsFilterChains(name string, ciliumSecretNamespace string, tlsSecretsToHostnames map[model.TLSSecret][]string,
-	enableIpv4 bool, enableIpv6 bool) ([]*envoy_config_listener.FilterChain, error) {
-	if len(tlsSecretsToHostnames) == 0 {
+func (i *cecTranslator) httpsFilterChains(name string, m *model.Model) ([]*envoy_config_listener.FilterChain, error) {
+	tlsToHostnames := m.TLSSecretsToHostnames()
+	if len(tlsToHostnames) == 0 {
 		return nil, nil
 	}
 
 	var filterChains []*envoy_config_listener.FilterChain
 
-	orderedSecrets := goslices.SortedStableFunc(maps.Keys(tlsSecretsToHostnames), func(a, b model.TLSSecret) int {
+	orderedSecrets := goslices.SortedStableFunc(maps.Keys(tlsToHostnames), func(a, b model.TLSSecret) int {
 		return cmp.Compare(a.Namespace+"/"+a.Name, b.Namespace+"/"+b.Name)
 	})
 
 	for _, secret := range orderedSecrets {
-		hostNames := tlsSecretsToHostnames[secret]
+		hostNames := tlsToHostnames[secret]
 
 		secureHttpConnectionManagerName := fmt.Sprintf("%s-secure", name)
 		secureHttpConnectionManager, err := i.desiredHTTPConnectionManager(secureHttpConnectionManagerName, secureHttpConnectionManagerName)
 		if err != nil {
 			return nil, err
 		}
-
-		transportSocket, err := newTransportSocket(ciliumSecretNamespace, []model.TLSSecret{secret})
-		if err != nil {
-			return nil, err
-		}
-
 		filterChains = append(filterChains, &envoy_config_listener.FilterChain{
 			FilterChainMatch: toFilterChainMatch(hostNames),
 			Filters: []*envoy_config_listener.Filter{
@@ -315,24 +310,11 @@ func (i *cecTranslator) httpsFilterChains(name string, ciliumSecretNamespace str
 					},
 				},
 			},
-			TransportSocket: transportSocket,
+			TransportSocket: toTransportSocket(i.Config.SecretsNamespace, []model.TLSSecret{secret}),
 		})
 	}
 
 	return filterChains, nil
-}
-
-func tlsPassthroughBackendsToHostnames(m *model.Model) map[string][]string {
-	res := make(map[string][]string)
-	for _, h := range m.TLSPassthrough {
-		for _, route := range h.Routes {
-			for _, backend := range route.Backends {
-				key := fmt.Sprintf("%s:%s:%s", backend.Namespace, backend.Name, backend.Port.GetPort())
-				res[key] = append(res[key], route.Hostnames...)
-			}
-		}
-	}
-	return res
 }
 
 func getHostNetworkListenerAddresses(ports []uint32, ipv4Enabled, ipv6Enabled bool) (*envoy_config_core_v3.Address, []*envoy_config_listener.AdditionalAddress) {
@@ -379,18 +361,8 @@ func getHostNetworkListenerAddresses(ports []uint32, ipv4Enabled, ipv6Enabled bo
 	}, additionalAddress
 }
 
-func tlsSecretsToHostnames(m *model.Model) map[model.TLSSecret][]string {
-	res := make(map[model.TLSSecret][]string)
-	for _, h := range m.HTTP {
-		for _, s := range h.TLS {
-			res[s] = append(res[s], h.Hostname)
-		}
-	}
-
-	return res
-}
-
-func tlsPassthroughFilterChains(ptBackendsToHostnames map[string][]string) []*envoy_config_listener.FilterChain {
+func tlsPassthroughFilterChains(m *model.Model) []*envoy_config_listener.FilterChain {
+	ptBackendsToHostnames := m.TLSBackendsToHostnames()
 	if len(ptBackendsToHostnames) == 0 {
 		return nil
 	}
@@ -422,7 +394,7 @@ func tlsPassthroughFilterChains(ptBackendsToHostnames map[string][]string) []*en
 	return filterChains
 }
 
-func newTransportSocket(ciliumSecretNamespace string, tls []model.TLSSecret) (*envoy_config_core_v3.TransportSocket, error) {
+func toTransportSocket(ciliumSecretNamespace string, tls []model.TLSSecret) *envoy_config_core_v3.TransportSocket {
 	var tlsSdsConfig []*envoy_extensions_transport_sockets_tls_v3.SdsSecretConfig
 	tlsMap := map[string]struct{}{}
 	for _, t := range tls {
@@ -440,11 +412,7 @@ func newTransportSocket(ciliumSecretNamespace string, tls []model.TLSSecret) (*e
 			TlsCertificateSdsSecretConfigs: tlsSdsConfig,
 		},
 	}
-
-	downstreamBytes, err := proto.Marshal(&downStreamContext)
-	if err != nil {
-		return nil, err
-	}
+	downstreamBytes, _ := proto.Marshal(&downStreamContext)
 
 	return &envoy_config_core_v3.TransportSocket{
 		Name: tlsTransportSocketType,
@@ -454,7 +422,7 @@ func newTransportSocket(ciliumSecretNamespace string, tls []model.TLSSecret) (*e
 				Value:   downstreamBytes,
 			},
 		},
-	}, nil
+	}
 }
 
 func toFilterChainMatch(hostNames []string) *envoy_config_listener.FilterChainMatch {

--- a/operator/pkg/model/translation/envoy_route_configuration.go
+++ b/operator/pkg/model/translation/envoy_route_configuration.go
@@ -19,7 +19,7 @@ import (
 type RouteConfigurationMutator func(*envoy_config_route_v3.RouteConfiguration) *envoy_config_route_v3.RouteConfiguration
 
 // desiredEnvoyHTTPRouteConfiguration returns the route configuration for the given model.
-func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) []ciliumv2.XDSResource {
+func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) ([]ciliumv2.XDSResource, error) {
 	var res []ciliumv2.XDSResource
 
 	type hostnameRedirect struct {
@@ -107,11 +107,14 @@ func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) []cil
 		// otherwise the request will be dropped by envoy
 		routeName := fmt.Sprintf("listener-%s", port)
 		goslices.SortStableFunc(virtualhosts, func(a, b *envoy_config_route_v3.VirtualHost) int { return cmp.Compare(a.Name, b.Name) })
-		rc, _ := routeConfiguration(routeName, virtualhosts)
+		rc, err := routeConfiguration(routeName, virtualhosts)
+		if err != nil {
+			return nil, err
+		}
 		res = append(res, rc)
 	}
 
-	return res
+	return res, nil
 }
 
 // routeConfiguration returns a new route configuration for a given list of http routes.

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_with_xff_num_trusted_hops/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_with_xff_num_trusted_hops/cec-output.yaml
@@ -19,6 +19,15 @@ spec:
     - "8080"
   resources:
   - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    additionalAddresses:
+    - address:
+        socketAddress:
+          address: '::'
+          portValue: 80
+    address:
+      socketAddress:
+        address: 0.0.0.0
+        portValue: 80
     filterChains:
     - filterChainMatch:
         transportProtocol: raw_buffer

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_with_xff_num_trusted_hops/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_with_xff_num_trusted_hops/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_tls_sni_listener/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_tls_sni_listener/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  ports:
+  - name: port-443
+    port: 443
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httpexact_path_matching/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httpexact_path_matching/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_protocol_h_2_c/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_protocol_h_2_c/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_protocol_h_2_c_app_protocol/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_protocol_h_2_c_app_protocol/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_refs_request_header_modifier/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_refs_request_header_modifier/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_refs_response_header_modifier/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_refs_response_header_modifier/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_cross_namespace/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_cross_namespace/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: backend-namespaces
+    io.cilium.gateway/owning-gateway: backend-namespaces
+  name: cilium-gateway-backend-namespaces
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: backend-namespaces
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_header_matching/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_header_matching/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_hostname_intersection/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_hostname_intersection/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: httproute-hostname-intersection
+    io.cilium.gateway/owning-gateway: httproute-hostname-intersection
+  name: cilium-gateway-httproute-hostname-intersection
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: httproute-hostname-intersection
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_listener_hostname_matching/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_listener_hostname_matching/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: httproute-listener-hostname-matching
+    io.cilium.gateway/owning-gateway: httproute-listener-hostname-matching
+  name: cilium-gateway-httproute-listener-hostname-matching
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: httproute-listener-hostname-matching
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_matching/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_matching/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_matching_across_routes/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_matching_across_routes/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_method_matching/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_method_matching/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_query_param_matching/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_query_param_matching/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_header_modifier/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_header_modifier/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_mirror/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_mirror/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect_with_multi_httplisteners/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect_with_multi_httplisteners/service-output.yaml
@@ -1,0 +1,26 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  - name: port-443
+    port: 443
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_response_header_modifier/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_response_header_modifier/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_rewrite_host/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_rewrite_host/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_rewrite_path/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_rewrite_path/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_simple_same_namespace/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_simple_same_namespace/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/with_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/with_external_traffic_policy/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/without_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/without_external_traffic_policy/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/with_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/with_external_traffic_policy/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  ports:
+  - name: port-55555
+    port: 55555
+    protocol: TCP
+    targetPort: 0
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/without_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/without_external_traffic_policy/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  ports:
+  - name: port-55555
+    port: 55555
+    protocol: TCP
+    targetPort: 0
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/with_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/with_external_traffic_policy/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  ports:
+  - name: port-55555
+    port: 55555
+    protocol: TCP
+    targetPort: 0
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/without_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/without_external_traffic_policy/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  ports:
+  - name: port-55555
+    port: 55555
+    protocol: TCP
+    targetPort: 0
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/with_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/with_external_traffic_policy/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  ports:
+  - name: port-55555
+    port: 55555
+    protocol: TCP
+    targetPort: 0
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/without_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/without_external_traffic_policy/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  ports:
+  - name: port-55555
+    port: 55555
+    protocol: TCP
+    targetPort: 0
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -5,6 +5,7 @@ package gateway_api
 
 import (
 	"fmt"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -125,6 +126,9 @@ func getService(resource *model.FullyQualifiedResource, allPorts []uint32, label
 			Protocol: corev1.ProtocolTCP,
 		})
 	}
+	slices.SortFunc(ports, func(a, b corev1.ServicePort) int {
+		return int(a.Port) - int(b.Port)
+	})
 
 	shortenName := shortener.ShortenK8sResourceName(resource.Name)
 

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -30,16 +30,13 @@ const (
 
 type gatewayAPITranslator struct {
 	cecTranslator translation.CECTranslator
-
-	hostNetworkEnabled    bool
-	externalTrafficPolicy string
+	cfg           translation.Config
 }
 
-func NewTranslator(cecTranslator translation.CECTranslator, hostNetworkEnabled bool, externalTrafficPolicy string) translation.Translator {
+func NewTranslator(cecTranslator translation.CECTranslator, cfg translation.Config) translation.Translator {
 	return &gatewayAPITranslator{
-		cecTranslator:         cecTranslator,
-		hostNetworkEnabled:    hostNetworkEnabled,
-		externalTrafficPolicy: externalTrafficPolicy,
+		cecTranslator: cecTranslator,
+		cfg:           cfg,
 	}
 }
 
@@ -152,12 +149,12 @@ func (t *gatewayAPITranslator) desiredService(owner *model.FullyQualifiedResourc
 		},
 		Spec: corev1.ServiceSpec{
 			Type:                  corev1.ServiceTypeLoadBalancer,
-			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicy(t.externalTrafficPolicy),
+			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicy(t.cfg.ServiceConfig.ExternalTrafficPolicy),
 			Ports:                 servicePorts,
 		},
 	}
 
-	if t.hostNetworkEnabled {
+	if t.cfg.HostNetworkConfig.Enabled {
 		res.Spec.Type = corev1.ServiceTypeClusterIP
 		res.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicy("")
 	}

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -53,6 +53,7 @@ func Test_translator_Translate(t *testing.T) {
 		{name: "conformance/httproute_rewrite_path"},
 		{name: "conformance/httproute_request_mirror"},
 		{name: "conformance/httproute_request_redirect_with_multi_httplisteners"},
+		{name: "conformance/httproute_backend_protocol_h_2_c_app_protocol"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -75,41 +76,6 @@ func Test_translator_Translate(t *testing.T) {
 			require.Equal(t, expectedService, svc, "Service mismatch")
 
 			diffOutput := cmp.Diff(expectedCEC, cec, protocmp.Transform())
-			if len(diffOutput) != 0 {
-				t.Errorf("CiliumEnvoyConfigs did not match:\n%s\n", diffOutput)
-			}
-		})
-	}
-}
-
-func Test_translator_Translate_AppProtocol(t *testing.T) {
-	tests := []struct {
-		name    string
-		wantErr bool
-	}{
-		{name: "conformance/httproute_backend_protocol_h_2_c_app_protocol"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := translation.Config{}
-			readInput(t, fmt.Sprintf("testdata/%s/config-input.yaml", tt.name), &cfg)
-
-			trans := &gatewayAPITranslator{
-				cecTranslator: translation.NewCECTranslator(cfg),
-			}
-
-			input := &model.Model{}
-			readInput(t, fmt.Sprintf("testdata/%s/input.yaml", tt.name), input)
-			output := &ciliumv2.CiliumEnvoyConfig{}
-			readOutput(t, fmt.Sprintf("testdata/%s/cec-output.yaml", tt.name), output)
-			expectedService := &corev1.Service{}
-			readOutput(t, fmt.Sprintf("testdata/%s/service-output.yaml", tt.name), expectedService)
-
-			cec, svc, _, err := trans.Translate(input)
-
-			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
-			require.Equal(t, expectedService, svc, "Service mismatch")
-			diffOutput := cmp.Diff(output, cec, protocmp.Transform())
 			if len(diffOutput) != 0 {
 				t.Errorf("CiliumEnvoyConfigs did not match:\n%s\n", diffOutput)
 			}

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -345,8 +345,9 @@ func Test_getService(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getService(tt.args.resource, tt.args.allPorts, tt.args.labels, tt.args.annotations, tt.args.externalTrafficPolicy)
-			assert.Equalf(t, tt.want, got, "getService(%v, %v, %v, %v)", tt.args.resource, tt.args.allPorts, tt.args.labels, tt.args.annotations)
+			trans := &gatewayAPITranslator{externalTrafficPolicy: tt.args.externalTrafficPolicy}
+			got := trans.desiredService(tt.args.resource, tt.args.allPorts, tt.args.labels, tt.args.annotations)
+			assert.Equalf(t, tt.want, got, "desiredService(%v, %v, %v, %v)", tt.args.resource, tt.args.allPorts, tt.args.labels, tt.args.annotations)
 			assert.LessOrEqual(t, len(got.Name), 63, "Service name is too long")
 		})
 	}


### PR DESCRIPTION
Please refer to individual commit for more details. This is to pave the way for coming features (e.g. ParameterRef in GatewayClass), there is no logic change at all.