### PR TITLE
[v1.17] ces: Fix bug where stale endpoint information was injected into IPCache

### DIFF
--- a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
+++ b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
@@ -124,18 +124,13 @@ func (cs *cesSubscriber) OnDelete(ces *cilium_v2a1.CiliumEndpointSlice) {
 	}
 }
 
-// OnDelete calls endpointDeleted for CEPs from remote Nodes.
+// onDelete calls endpointDeleted for CEPs removed from a CES
 func (cs *cesSubscriber) onDelete(ces *cilium_v2a1.CiliumEndpointSlice, cep *types.CiliumEndpoint) {
 	CEPName := cep.Namespace + "/" + cep.Name
 	log.WithFields(logrus.Fields{
 		"CESName": ces.GetName(),
 		"CEPName": CEPName,
 	}).Debug("CES deleted, calling endpointDeleted")
-	// LocalNode already deleted the CEP.
-	// Hence, skip processing endpointDeleted for localNode CEPs.
-	if p := cs.epCache.LookupCEPName(k8sUtils.GetObjNamespaceName(cep)); p != nil {
-		return
-	}
 	// Delete CEP if and only if that CEP is owned by a CES, that was used during CES updated.
 	// Delete CEP only if there is match in CEPToCES map and also delete CEPName in CEPToCES map.
 	cs.deleteCEPfromCES(CEPName, ces.GetName(), cep)

--- a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber_test.go
+++ b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber_test.go
@@ -637,7 +637,6 @@ func TestCESSubscriber_OnAdd(t *testing.T) {
 func TestCESSubscriber_OnUpdate(t *testing.T) {
 	testCases := []struct {
 		name           string
-		local          []cacheEntry
 		newCES, oldCES *v2alpha1.CiliumEndpointSlice
 		expectUpdates  []endpointUpdate
 		expectDeleted  []*types.CiliumEndpoint
@@ -799,23 +798,6 @@ func TestCESSubscriber_OnUpdate(t *testing.T) {
 				"default/cep3": "ces",
 			},
 		},
-		{
-			name: "keep_local_cep2",
-			local: []cacheEntry{
-				{Key: "default/cep2"},
-			},
-			oldCES: newCES("ces", testNamespace,
-				v2alpha1.CoreCiliumEndpoint{Name: "cep1"},
-				v2alpha1.CoreCiliumEndpoint{Name: "cep2"},
-			),
-			newCES: newCES("ces", testNamespace,
-				v2alpha1.CoreCiliumEndpoint{Name: "cep1"},
-			),
-			expectedCurrentCES: map[string]string{
-				"default/cep1": "ces",
-				"default/cep2": "ces",
-			},
-		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -826,7 +808,7 @@ func TestCESSubscriber_OnUpdate(t *testing.T) {
 			}
 			subscriber := &cesSubscriber{
 				epWatcher: watcher,
-				epCache:   newFakeEndpointCache(tc.local...),
+				epCache:   newFakeEndpointCache(),
 				cepMap:    m,
 			}
 			// Initialize state, but do not record the events.
@@ -851,7 +833,6 @@ func TestCESSubscriber_OnUpdate(t *testing.T) {
 func TestCESSubscriber_OnDelete(t *testing.T) {
 	testCases := []struct {
 		name          string
-		local         []cacheEntry
 		ces           *v2alpha1.CiliumEndpointSlice
 		expectDeleted []*types.CiliumEndpoint
 		// Expected cepToCESmap.expectedCurrentCES
@@ -877,22 +858,6 @@ func TestCESSubscriber_OnDelete(t *testing.T) {
 			},
 			expectedCurrentCES: map[string]string{},
 		},
-		{
-			name: "keep_cep1",
-			local: []cacheEntry{
-				{Key: "default/cep1"},
-			},
-			ces: newCES("ces", testNamespace,
-				v2alpha1.CoreCiliumEndpoint{Name: "cep1"},
-				v2alpha1.CoreCiliumEndpoint{Name: "cep2"},
-			),
-			expectDeleted: []*types.CiliumEndpoint{
-				newEndpoint("cep2", testNamespace, 0),
-			},
-			expectedCurrentCES: map[string]string{
-				"default/cep1": "ces",
-			},
-		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -903,7 +868,7 @@ func TestCESSubscriber_OnDelete(t *testing.T) {
 			}
 			subscriber := &cesSubscriber{
 				epWatcher: watcher,
-				epCache:   newFakeEndpointCache(tc.local...),
+				epCache:   newFakeEndpointCache(),
 				cepMap:    m,
 			}
 			// Initialize state, but do not record the events.


### PR DESCRIPTION
 * [x] #37347 (@gandro)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 37347
```
