### PR TITLE
bgp: improve reconciler error handling

### DIFF
--- a/pkg/bgpv1/manager/reconcilerv2/neighbor_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/neighbor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/store"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
+	v2api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -253,6 +254,11 @@ func TestNeighborReconciler(t *testing.T) {
 			reconcileParams := ReconcileParams{
 				BGPInstance:   testInstance,
 				DesiredConfig: nodeConfig,
+				CiliumNode: &v2api.CiliumNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-node",
+					},
+				},
 			}
 			err = neighborReconciler.Reconcile(context.Background(), reconcileParams)
 			req.NoError(err)
@@ -268,6 +274,11 @@ func TestNeighborReconciler(t *testing.T) {
 			reconcileParams = ReconcileParams{
 				BGPInstance:   testInstance,
 				DesiredConfig: nodeConfig,
+				CiliumNode: &v2api.CiliumNode{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bgp-node",
+					},
+				},
 			}
 			err = neighborReconciler.Reconcile(context.Background(), reconcileParams)
 			req.NoError(err)

--- a/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
+++ b/pkg/bgpv1/manager/reconcilerv2/pod_cidr.go
@@ -84,12 +84,8 @@ func (r *PodCIDRReconciler) Cleanup(i *instance.BGPInstance) {
 }
 
 func (r *PodCIDRReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
-	if p.DesiredConfig == nil {
-		return fmt.Errorf("BUG: PodCIDR reconciler called with nil CiliumBGPNodeConfig")
-	}
-
-	if p.CiliumNode == nil {
-		return fmt.Errorf("BUG: PodCIDR reconciler called with nil CiliumNode")
+	if err := p.ValidateParams(); err != nil {
+		return err
 	}
 
 	// get pod CIDR prefixes

--- a/pkg/bgpv1/manager/reconcilerv2/reconcilers.go
+++ b/pkg/bgpv1/manager/reconcilerv2/reconcilers.go
@@ -5,6 +5,7 @@ package reconcilerv2
 
 import (
 	"context"
+	"errors"
 	"sort"
 
 	"github.com/cilium/hive/cell"
@@ -30,6 +31,12 @@ const (
 	PodIPPoolReconcilerPriority = 50
 	ServiceReconcilerPriority   = 40
 	PodCIDRReconcilerPriority   = 30
+)
+
+var (
+	// ErrAbortReconcile is used to indicate that the current reconcile loop should
+	// be aborted.
+	ErrAbortReconcile = errors.New("abort reconcile error")
 )
 
 type ReconcileParams struct {
@@ -94,4 +101,14 @@ func GetActiveReconcilers(log logrus.FieldLogger, reconcilers []ConfigReconciler
 	})
 
 	return activeReconcilers
+}
+
+func (p ReconcileParams) ValidateParams() error {
+	if p.DesiredConfig == nil {
+		return errors.Join(errors.New("BUG: reconciler called with nil CiliumBGPNodeConfig"), ErrAbortReconcile)
+	}
+	if p.CiliumNode == nil {
+		return errors.Join(errors.New("BUG: reconciler called with nil CiliumNode"), ErrAbortReconcile)
+	}
+	return nil
 }

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -114,12 +114,8 @@ func (r *ServiceReconciler) Cleanup(i *instance.BGPInstance) {
 }
 
 func (r *ServiceReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
-	if p.DesiredConfig == nil {
-		return fmt.Errorf("BUG: attempted service reconciliation with nil CiliumBGPNodeConfig")
-	}
-
-	if p.CiliumNode == nil {
-		return fmt.Errorf("BUG: attempted service reconciliation with nil local CiliumNode")
+	if err := p.ValidateParams(); err != nil {
+		return err
 	}
 
 	desiredPeerAdverts, err := r.peerAdvert.GetConfiguredAdvertisements(p.DesiredConfig, v2alpha1.BGPServiceAdvert)


### PR DESCRIPTION
Introducing error condition ErrAbortReconcile, which can be used to abort BGP reconcile loop in some case. Most of the error conditions will fall into non-abort type of errors, as such we will try to reconcile as much as possible in those cases.

