### PR TITLE
docs: use latest for rtd theme commit with fixed version selector

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -3,7 +3,7 @@ Sphinx==7.1.2
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@3047cc4ad7aca4ed6184b6b40658910af2130f4d
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@0d7703280a1287e97f37124c1d9689e2efe03923
 # We use semver to parse Cilium's version in the config file
 semver==3.0.1
 # Sphinx extensions


### PR DESCRIPTION
Updates the commit hash for the read the docs theme to get version selector fix

https://github.com/cilium/sphinx_rtd_theme/commit/0d7703280a1287e97f37124c1d9689e2efe03923