### PR TITLE
socket-lb: Fix null pointer dereference in socketlb/cgroup.go

### DIFF
--- a/pkg/socketlb/cgroup.go
+++ b/pkg/socketlb/cgroup.go
@@ -183,7 +183,7 @@ func detachCgroup(name, cgroupRoot, pinPath string) error {
 func detachAll(attach ebpf.AttachType, cgroupRoot string) error {
 	cg, err := os.Open(cgroupRoot)
 	if err != nil {
-		return fmt.Errorf("open cgroup %s: %w", cg.Name(), err)
+		return fmt.Errorf("open cgroup %s: %w", cgroupRoot, err)
 	}
 	defer cg.Close()
 


### PR DESCRIPTION
If the `os.Open` fails, `cg` will be nil, accessing its `Name()` in the error path thus causes a panic.