### PR TITLE
Test IPv4 and IPv6 explicitly in PodToWorld connectivity tests

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -160,7 +160,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().BoolVarP(&params.Timestamp, "timestamp", "t", false, "Show timestamp in messages")
 	cmd.Flags().BoolVarP(&params.PauseOnFail, "pause-on-fail", "p", false, "Pause execution on test failure")
 	cmd.Flags().StringVar(&params.ExternalTarget, "external-target", "one.one.one.one.", "Domain name to use as external target in connectivity tests")
-	cmd.Flags().StringVar(&params.ExternalOtherTarget, "external-other-target", "cilium.io.", "Domain name to use as a second external target in connectivity tests")
+	cmd.Flags().StringVar(&params.ExternalOtherTarget, "external-other-target", "k8s.io.", "Domain name to use as a second external target in connectivity tests")
 	cmd.Flags().StringVar(&params.ExternalTargetCANamespace, "external-target-ca-namespace", "", "Namespace of the CA secret for the external target. Used by client-egress-l7-tls test cases.")
 	cmd.Flags().StringVar(&params.ExternalTargetCAName, "external-target-ca-name", "cabundle", "Name of the CA secret for the external target. Used by client-egress-l7-tls test cases.")
 	cmd.Flags().StringVar(&params.ExternalCIDR, "external-cidr", "1.0.0.0/8", "CIDR to use as external target in connectivity tests")

--- a/cilium-cli/connectivity/tests/world.go
+++ b/cilium-cli/connectivity/tests/world.go
@@ -63,6 +63,13 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 
 	for _, client := range ct.ClientPods() {
 		t.ForEachIPFamily(func(ipFam features.IPFamily) {
+			// TODO: Reenable the test once the kernel with the bugfix is released:
+			// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
+			// and when IPv6 external connectivity starts working in the CI.
+			if ipFam == features.IPFamilyV6 {
+				return
+			}
+
 			// With http, over port 80.
 			httpOpts := s.rc.CurlOptions(http, ipFam, client, ct.Params())
 			t.NewAction(s, fmt.Sprintf("http-to-%s-%s-%d", extTarget, ipFam, i), &client, http, ipFam).Run(func(a *check.Action) {
@@ -120,6 +127,13 @@ func (s *podToWorld2) Run(ctx context.Context, t *check.Test) {
 
 	for _, client := range ct.ClientPods() {
 		t.ForEachIPFamily(func(ipFam features.IPFamily) {
+			// TODO: Reenable the test once the kernel with the bugfix is released:
+			// https://patchwork.kernel.org/project/netdevbpf/patch/20250318161516.3791383-1-maxim@isovalent.com/
+			// and when IPv6 external connectivity starts working in the CI.
+			if ipFam == features.IPFamilyV6 {
+				return
+			}
+
 			// With https, over port 443.
 			t.NewAction(s, fmt.Sprintf("https-%s-%s-%d", extTarget, ipFam, i), &client, https, ipFam).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, a.CurlCommand(https))

--- a/cilium-cli/connectivity/tests/world.go
+++ b/cilium-cli/connectivity/tests/world.go
@@ -62,25 +62,27 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 	ct := t.Context()
 
 	for _, client := range ct.ClientPods() {
-		// With http, over port 80.
-		httpOpts := s.rc.CurlOptions(http, features.IPFamilyAny, client, ct.Params())
-		t.NewAction(s, fmt.Sprintf("http-to-%s-%d", extTarget, i), &client, http, features.IPFamilyAny).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, a.CurlCommand(http, httpOpts...))
-			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
-		})
+		t.ForEachIPFamily(func(ipFam features.IPFamily) {
+			// With http, over port 80.
+			httpOpts := s.rc.CurlOptions(http, ipFam, client, ct.Params())
+			t.NewAction(s, fmt.Sprintf("http-to-%s-%s-%d", extTarget, ipFam, i), &client, http, ipFam).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, a.CurlCommand(http, httpOpts...))
+				a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
+			})
 
-		// With https, over port 443.
-		httpsOpts := s.rc.CurlOptions(https, features.IPFamilyAny, client, ct.Params())
-		t.NewAction(s, fmt.Sprintf("https-to-%s-%d", extTarget, i), &client, https, features.IPFamilyAny).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, a.CurlCommand(https, httpsOpts...))
-			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
-		})
+			// With https, over port 443.
+			httpsOpts := s.rc.CurlOptions(https, ipFam, client, ct.Params())
+			t.NewAction(s, fmt.Sprintf("https-to-%s-%s-%d", extTarget, ipFam, i), &client, https, ipFam).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, a.CurlCommand(https, httpsOpts...))
+				a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
+			})
 
-		// With https, over port 443, index.html.
-		httpsindexOpts := s.rc.CurlOptions(httpsindex, features.IPFamilyAny, client, ct.Params())
-		t.NewAction(s, fmt.Sprintf("https-to-%s-index-%d", extTarget, i), &client, httpsindex, features.IPFamilyAny).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, a.CurlCommand(httpsindex, httpsindexOpts...))
-			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
+			// With https, over port 443, index.html.
+			httpsindexOpts := s.rc.CurlOptions(httpsindex, ipFam, client, ct.Params())
+			t.NewAction(s, fmt.Sprintf("https-to-%s-index-%s-%d", extTarget, ipFam, i), &client, httpsindex, ipFam).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, a.CurlCommand(httpsindex, httpsindexOpts...))
+				a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
+			})
 		})
 
 		i++
@@ -117,11 +119,13 @@ func (s *podToWorld2) Run(ctx context.Context, t *check.Test) {
 	ct := t.Context()
 
 	for _, client := range ct.ClientPods() {
-		// With https, over port 443.
-		t.NewAction(s, fmt.Sprintf("https-%s-%d", extTarget, i), &client, https, features.IPFamilyAny).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, a.CurlCommand(https))
-			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
-			a.ValidateMetrics(ctx, client, a.GetEgressMetricsRequirements())
+		t.ForEachIPFamily(func(ipFam features.IPFamily) {
+			// With https, over port 443.
+			t.NewAction(s, fmt.Sprintf("https-%s-%s-%d", extTarget, ipFam, i), &client, https, ipFam).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, a.CurlCommand(https))
+				a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
+				a.ValidateMetrics(ctx, client, a.GetEgressMetricsRequirements())
+			})
 		})
 
 		i++


### PR DESCRIPTION
Fixes: https://github.com/cilium/cilium/issues/37139

```release-note
Test IPv4 and IPv6 explicitly in PodToWorld and PodToWorld2 connectivity tests
```
