### PR TITLE
helm: fix cilium-config nullvalue multiPoolPreAllocation

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1040,7 +1040,7 @@ data:
 {{- else }}
   ipam: {{ $ipam | quote }}
 {{- end }}
-{{- if hasKey .Values.ipam "multiPoolPreAllocation" }}
+{{- if .Values.ipam.multiPoolPreAllocation }}
   ipam-multi-pool-pre-allocation: {{ .Values.ipam.multiPoolPreAllocation }}
 {{- end }}
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->
*Summary*
This change fixes the conditional for setting the  `ipam-multi-pool-pre-allocation` key/value pair in the cilium-config configmap.   


*Notes*
1.17.0 introduced a new field in the cilium-config configmap in https://github.com/cilium/cilium/pull/35812.  That field is only intended to be present when the setting `.ipam.multiPoolPreAllocation` is configured.  The current conditional is always true as it checks to see if the key for `ipam.multiPoolPreAllocation` exists instead of looking at a value.

This lead to `ipam-multi-pool-pre-allocation` being set to null value.  This can be tested by using helm/yq-go.  
```sh
helm template --repo https://helm.cilium.io/ cilium --version 1.17.0

apiVersion: v1
kind: ConfigMap
metadata:
  name: cilium-config
  namespace: demo
data:
  ipam: "cluster-pool"
  ipam-multi-pool-pre-allocation:
  ipam-cilium-node-update-rate: "15s"
  cluster-pool-ipv4-cidr: "10.0.0.0/8"
```
or alternative 1 liner
```sh
helm template --repo https://helm.cilium.io/ cilium --version 1.17.0 | yq eval-all '. | select(.metadata.name == "cilium-config")' - | grep -i ipam-multi
  ipam-multi-pool-pre-allocation:
```

At some point during the upgrade to 1.17.0, the `ipam-multi-pool-pre-allocation` caused a reconciliation loop with ArgoCD related to trying to set a null value.  Workaround of just recreating the configmap fixed the reconciliation loop.
![image](https://github.com/user-attachments/assets/e2d8fb0b-c911-48d1-8d8b-9a435372d133)




