### PR TITLE
docs: Regenerate docs for cmdref

### DIFF
--- a/Documentation/cmdref/cilium-dbg_bpf_nat_retries.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_nat_retries.md
@@ -13,9 +13,11 @@ Histogram of retries
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_nat_retries_flush.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_nat_retries_flush.md
@@ -17,9 +17,11 @@ cilium-dbg bpf nat retries flush [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-dbg_bpf_nat_retries_list.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_nat_retries_list.md
@@ -18,9 +18,11 @@ cilium-dbg bpf nat retries list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string   Config file (default is $HOME/.cilium.yaml)
-  -D, --debug           Enable debug messages
-  -H, --host string     URI to server-side API
+      --config string        Config file (default is $HOME/.cilium.yaml)
+  -D, --debug                Enable debug messages
+  -H, --host string          URI to server-side API
+      --log-driver strings   Logging endpoints to use (example: syslog)
+      --log-opt map          Log driver options (example: format=json)
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
This is to fix failure due to diff while running the command `make -C Documentation check`.

Relates: #36802
Relates: 60f074d63f9f8b3e6cfccf62d99f7c58b4d6c11d
