### PR TITLE
dashboard: add egress, l7 to policy drop dashboard

### DIFF
--- a/install/kubernetes/cilium/files/cilium-agent/dashboards/cilium-dashboard.json
+++ b/install/kubernetes/cilium/files/cilium-agent/dashboards/cilium-dashboard.json
@@ -6908,14 +6908,10 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "bps"
+          "unit": "pps"
         },
         "overrides": []
       },
@@ -6945,14 +6941,15 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(cilium_drop_bytes_total{direction=\"INGRESS\", k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (reason) * 8",
+          "expr": "sum(rate(cilium_drop_count_total{k8s_app=\"cilium\", pod=~\"$pod\", reason=\"Policy denied\"}[1m])) by (direction)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{reason}}",
+          "legendFormat": "{{direction}}",
+          "range": true,
           "refId": "A"
         }
       ],
-      "title": "Dropped Ingress Traffic",
+      "title": "Policy Denies: L3/L4",
       "type": "timeseries"
     },
     {
@@ -7006,10 +7003,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
@@ -7043,14 +7036,15 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(cilium_drop_count_total{direction=\"INGRESS\", k8s_app=\"cilium\", pod=~\"$pod\"}[5m])) by (reason)",
+          "expr": "sum(rate(cilium_policy_l7_total{rule=\"denied\", k8s_app=\"cilium\", pod=~\"$pod\"}[1m])) by (proxy_type)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{reason}}",
+          "range": true,
           "refId": "A"
         }
       ],
-      "title": "Cilium drops Ingress",
+      "title": "Policy Denies: L7",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
Looking at policy drops is a good way to determine that a policy update was broken. However, we didn't show drops for both directions.

Fix that, as well as call out the difference between L3 and L7 drops.

![dashboard-drops](https://github.com/user-attachments/assets/e70b1a28-bb48-42c8-b8c2-f5f3625a2c35)

```release-note
The Grafana dashboard now displays policy drops in both directions.
```
