### PR TITLE
datapath/iptable: fuzzy match for devices than exact match

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1215,7 +1215,8 @@ func (m *Manager) installMasqueradeRules(
 						return fmt.Errorf("cannot correlate source route device for generating masquerading rules")
 					}
 					for _, device := range devices {
-						if device == link.Attrs().Name {
+						filter := tables.DeviceFilter{device}
+						if filter.Match(link.Attrs().Name) {
 							match = true
 							break
 						}


### PR DESCRIPTION
Use device filter to fuzzy match the devices than the exact match to match the users input for `devices` and `MasqueradeInterfaces`. We described this in the doc but not really doing it in the code.

we need to backport it  all the way to 1.15 since that's when we introduce the MasqueradeRouteSource
Fixes: #37448

```release-note
Fix traffic not getting masqueraded with wildcard devices or egress-masquerade-interfaces when enable-masquerade-to-route-source flag is set.
```


