### PR TITLE
test: Move tgraf/netperf image to Quay

### DIFF
--- a/test/k8s/manifests/netperf-deployment.yaml
+++ b/test/k8s/manifests/netperf-deployment.yaml
@@ -10,7 +10,7 @@ spec:
   terminationGracePeriodSeconds: 0
   containers:
   - name: netperf
-    image: docker.io/tgraf/netperf:v1.0
+    image: quay.io/cilium/netperf:v1.0
     readinessProbe:
       exec:
         command: ["netperf", "-H", "127.0.0.1", "-l", "1"]
@@ -29,7 +29,7 @@ spec:
   terminationGracePeriodSeconds: 0
   containers:
   - name: netperf
-    image: docker.io/tgraf/netperf:v1.0
+    image: quay.io/cilium/netperf:v1.0
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The `K8sAgentChaosTest Restart with long lived connections` test sometimes fails because we get rate-limited by docker.io on the netperf image. This commit changes the test to use the copy of the image hosted on quay.