### PR TITLE
docs: complete load balancer service manifest in kubeproxy-free

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -384,6 +384,7 @@ service type:
       - port: 80
         targetPort: 80
     type: LoadBalancer
+    allocateLoadBalancerNodePorts: false
 
 In the above example only the ``LoadBalancer`` service is created without
 corresponding ``NodePort`` and ``ClusterIP`` services. If the annotation


### PR DESCRIPTION
Specify the allocateLoadBalancerNodePorts service spec of the load balancer service example in the chapter 'Selective Service Type Exposure'.

If this spec is not set (true by default), then Kubernetes will allocate node ports on the service anyway. Then, clarify the use of this example.

