### PR TITLE
cilium-cli: Force curl to use IPv4/IPv6 when asked

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -938,6 +938,13 @@ func (ct *ConnectivityTest) CurlCommand(peer TestPeer, ipFam features.IPFamily, 
 		cmd = append(cmd, "--insecure")
 	}
 
+	switch ipFam {
+	case features.IPFamilyV4:
+		cmd = append(cmd, "-4")
+	case features.IPFamilyV6:
+		cmd = append(cmd, "-6")
+	}
+
 	if host := peer.Address(ipFam); strings.HasSuffix(host, ".") {
 		// Let's explicitly configure the Host header in case the DNS name has a
 		// trailing dot. This allows us to use trailing dots to prevent system

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -923,7 +923,7 @@ func (ct *ConnectivityTest) DetectMinimumCiliumVersion(ctx context.Context) (*se
 func (ct *ConnectivityTest) CurlCommand(peer TestPeer, ipFam features.IPFamily, opts ...string) []string {
 	cmd := []string{
 		"curl",
-		"-w", "%{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code}",
+		"-w", "%{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code}\n",
 		"--silent", "--fail", "--show-error",
 		"--output", "/dev/null",
 	}


### PR DESCRIPTION
Currently, CurlCommand() relies on peer.Address(ipFam) to be of the requested address family. However, it's not always the case, for example, httpEndpoint.Address() ignores its parameter and just returns the domain name.

Make curl use the right address family in these cases by passing -4 or -6 accordingly.

Dependency of https://github.com/cilium/cilium/pull/37435 and https://github.com/cilium/cilium/pull/37461

```release-note
Preparation to test IPv4 and IPv6 explicitly in connectivity tests
```
