### PR TITLE
Fix error handling in Azure IPAM causing to an infinite loop and a deadlock

### DIFF
--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -223,6 +223,11 @@ func (c *Client) listVirtualMachineScaleSetsNetworkInterfaces(ctx context.Contex
 	for _, virtualMachineScaleSet := range virtualMachineScaleSets {
 		virtualMachineScaleSetNetworkInterfaces, err := c.listVirtualMachineScaleSetNetworkInterfaces(ctx, *virtualMachineScaleSet.Name)
 		if err != nil {
+			// For scale set created by AKS node group (otherwise it will return an empty list) without any instances API will return not found. Then it can be skipped.
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+				continue
+			}
 			return nil, err
 		}
 
@@ -280,11 +285,6 @@ func (c *Client) listVirtualMachineScaleSetNetworkInterfaces(ctx context.Context
 		nextResult, err := pager.NextPage(ctx)
 
 		if err != nil {
-			// For scale set created by AKS node group (otherwise it will return an empty list) without any instances API will return not found. Then it can be skipped.
-			var respErr *azcore.ResponseError
-			if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
-				continue
-			}
 			return nil, err
 		}
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
Fix error handling in Azure IPAM causing to an infinite loop and a deadlock
```
---
Following #36751, we started to observe that in some cases, the cilium-operator-azure would get stuck, not assigning IPs anymore. After using [deadlock detection debugging](https://docs.cilium.io/en/stable/contributing/development/debugging/#deadlock-detection), we discovered that the operator was stuck running `github.com/cilium/cilium/pkg/azure/api.(*Client).listVirtualMachineScaleSetNetworkInterfaces`.
<details>
<summary>See deadlock detection goroutine trace:</summary>

<img width="1544" alt="image" src="https://github.com/user-attachments/assets/d93ac09f-c91c-4c1a-95a8-6c3c51117aa1" />
</details>

This turned out to be an instance of this issue: https://github.com/Azure/azure-sdk-for-go/issues/23249#issuecomment-2275495567

And the reason this is happening is because a small piece of code got misplaced during the SDK upgrade PR: 
Before  #36751, we had the [`vmssNetworkInterfaces`](https://github.com/DataDog/cilium/blob/e2e6ec5f5b3c6676e939976b2f0dd835e1e2990d/pkg/azure/api/api.go#L180-L227) function that first listed all VMSSs with `c.vmscalesets.ListComplete` and then for each of those, listed their interfaces with `c.interfaces.ListVirtualMachineScaleSetNetworkInterfacesComplete`. There was [a piece of error handling code](https://github.com/DataDog/cilium/blob/e2e6ec5f5b3c6676e939976b2f0dd835e1e2990d/pkg/azure/api/api.go#L208-L212) that would `continue` to the next VMSS when the interfaces list method returned a not found error.

With #36751 we now have [`listVirtualMachineScaleSetsNetworkInterfaces`](https://github.com/DataDog/cilium/blob/main/pkg/azure/api/api.go#L213-L233) that replaces `vmssNetworkInterfaces` and first calls `listVirtualMachineScaleSets` to get a list of VMSSs and then runs `listVirtualMachineScaleSetNetworkInterfaces` on each of those to get their interfaces.
But the piece of error handling code that covered the case where a VMSS was not found ended up inside [`listVirtualMachineScaleSetNetworkInterfaces`](https://github.com/DataDog/cilium/blob/b55b14817180a41b5f62a0f545a66ea99c380316/pkg/azure/api/api.go#L266) instead of in [`listVirtualMachineScaleSetsNetworkInterfaces`](https://github.com/DataDog/cilium/blob/b55b14817180a41b5f62a0f545a66ea99c380316/pkg/azure/api/api.go#L214).

Note: while debugging this, we noticed that none of the contexts passed down to the azure SDK methods carry any deadlines or cancellation policy. Adding a timeout to those with [context.WithTimeout](https://pkg.go.dev/context#WithTimeout) allowed the operator to gracefully recover from the deadlock after the context's deadline expired and to resume its IP management operations.