### PR TITLE
fix(install): create service monitor when using dynamic metrics

### DIFF
--- a/install/kubernetes/cilium/templates/hubble/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/hubble/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.hubble.enabled .Values.hubble.metrics.enabled .Values.hubble.metrics.serviceMonitor.enabled }}
+{{- if and .Values.hubble.enabled (or .Values.hubble.metrics.enabled .Values.hubble.metrics.dynamic.enabled) .Values.hubble.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
While trying to use dynamic metrics through the Helm chart with a `values.yaml` file containing the following:

```yaml
hubble:
  enabled: true
  metrics:
    enabled:
      - dns:query;ignoreAAAA
      - drop:labelsContext=source_namespace,source_pod,destination_namespace,destination_pod
      - tcp
      - flow
      - icmp
      - http
    serviceMonitor:
      enabled: true
      labels:
        release: monitoring
    dynamic:
      enabled: true
      config:
        content:
          - name: flow
            excludeFilters:
              - protocol:
                  - udp
                source_port:
                  - "8000"
                destination_port:
                  - "8000"
```

we learned that having both `hubble.metrics.enabled` and `hubble.metrics.dynamic.enabled` set caused rendering errors for the cilium-config ConfigMap due to having duplicate keys such as "hubble-metrics-server".

We then changed our `values.yaml` to only have dynamic metrics enabled like:

```yaml
hubble:
  metrics:
    dynamic:
      enabled: true
      config:
        content:
          - name: dns
            contextOptions:
              - name: query
              - name: ignoreAAAA
          - name: drop
            contextOptions:
              - name: labelsContext
                values:
                  - source_namespace
                  - source_pod
                  - destination_namespace
                  - destination_pod
          - name: tcp
          - name: flow
            excludeFilters:
              - protocol:
                  - udp
                source_port:
                  - "8000"
                destination_port:
                  - "8000"
          - name: icmp
          - name: http
```

This got us past rendering issues with the ConfigMap, but resulted in metrics no longer being scraped by Prometheus since the ServiceMonitor was not being created.

This pull request assumes the expectation is:
1. only `hubble.metrics.enabled` or `hubble.metrics.dynamic.enabled` is set
2. create the Hubble Service Monitor if either `hubble.metrics.enabled` or `hubble.metrics.dynamic.enabled` is true

This now enables users with `hubble.metrics.dynamic.enabled` set to true to have a ServiceMonitor created as expected.

Another solution if enabling both of these is supported then the ConfigMap's template could be fixed to handle this scenario.


```release-note
Fix creating ServiceMonitor for Hubble when dynamic metrics are enabled in the Helm chart
```
