### PR TITLE
bgpv2: Allow setting LocalPort from ClusterConfig

### DIFF
--- a/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
@@ -38,12 +38,24 @@ respectively. The configuration of the peers is defined by the ``peerConfigRef``
 to a peer configuration resource. ``Group`` and ``kind`` in ``peerConfigRef`` are optional and default to
 ``cilium.io`` and ``CiliumBGPPeerConfig``, respectively.
 
+By default, the BGP Control Plane instantiates each router instance without a listening port. This means
+the BGP router can only initiate connections to the configured peers, but cannot accept incoming connections.
+This is the default behavior because the BGP Control Plane is designed to function in environments where
+another BGP router (such as Bird) is running on the same node. When it is required to accept incoming
+connections, the ``localPort`` field can be used to specify the listening port.
 
 .. warning::
 
     The ``CiliumBGPPeeringPolicy`` and ``CiliumBGPClusterConfig`` should not be used together. If both
     resources are present and Cilium agent matches with both based on the node selector,
     ``CiliumBGPPeeringPolicy`` will take precedence.
+
+.. warning::
+
+    Listening on the default BGP port (179) requires ``CAP_NET_BIND_SERVICE``.
+    If you wish to use the default port, you must grant the
+    ``CAP_NET_BIND_SERVICE`` capability with
+    ``securityContext.capabilities.ciliumAgent`` Helm value.
 
 Here is an example configuration of the ``CiliumBGPClusterConfig`` with a BGP instance named ``instance-65000``
 and two peers configured under this BGP instance.
@@ -63,6 +75,7 @@ and two peers configured under this BGP instance.
         localASN: 65000
         peers:
         - name: "peer-65000-tor1"
+          localPort: 179
           peerASN: 65000
           peerAddress: fd00:10:0:0::1
           peerConfigRef:
@@ -863,11 +876,11 @@ In order to configure custom Router ID, you can set ``routerID`` field in an IPv
 Listening Port
 --------------
 
-By default, the BGP Control Plane instantiates each virtual router without a listening port. This means
-the BGP router can only initiate connections to the configured peers, but cannot accept incoming connections.
-This is the default behavior because the BGP Control Plane is designed to function in environments where
-another BGP router (such as Bird) is running on the same node. When it is required to accept incoming
-connections, the ``localPort`` field can be used to specify the listening port.
+The ``localPort`` field in the ``CiliumBGPClusterConfig`` can be used to
+specify the listening port. If you wish to override it on a per-node basis, you
+can set the ``localPort`` field in the ``CiliumBGPNodeConfigOverride``
+resource. This also works even if the ``localPort`` field is not set in the
+``CiliumBGPClusterConfig``.
 
 Local Peering Address
 ---------------------

--- a/operator/pkg/bgpv2/cluster.go
+++ b/operator/pkg/bgpv2/cluster.go
@@ -291,8 +291,9 @@ func toNodeBGPInstance(clusterBGPInstances []v2alpha1.CiliumBGPInstance, overrid
 
 	for _, clusterBGPInstance := range clusterBGPInstances {
 		nodeBGPInstance := v2alpha1.CiliumBGPNodeInstance{
-			Name:     clusterBGPInstance.Name,
-			LocalASN: clusterBGPInstance.LocalASN,
+			Name:      clusterBGPInstance.Name,
+			LocalASN:  clusterBGPInstance.LocalASN,
+			LocalPort: clusterBGPInstance.LocalPort,
 		}
 
 		// find BGPResourceManager global override for this instance
@@ -300,7 +301,9 @@ func toNodeBGPInstance(clusterBGPInstances []v2alpha1.CiliumBGPInstance, overrid
 		for _, overrideBGPInstance := range overrideBGPInstances {
 			if overrideBGPInstance.Name == clusterBGPInstance.Name {
 				nodeBGPInstance.RouterID = overrideBGPInstance.RouterID
-				nodeBGPInstance.LocalPort = overrideBGPInstance.LocalPort
+				if overrideBGPInstance.LocalPort != nil {
+					nodeBGPInstance.LocalPort = overrideBGPInstance.LocalPort
+				}
 				if overrideBGPInstance.LocalASN != nil {
 					nodeBGPInstance.LocalASN = overrideBGPInstance.LocalASN
 				}

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpclusterconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpclusterconfigs.yaml
@@ -64,6 +64,15 @@ spec:
                       maximum: 4294967295
                       minimum: 1
                       type: integer
+                    localPort:
+                      description: |-
+                        LocalPort is the port on which the BGP daemon listens for incoming connections.
+
+                        If not specified, BGP instance will not listen for incoming connections.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
                     name:
                       description: |-
                         Name is the name of the BGP instance. It is a unique identifier for the BGP instance

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.31.0"
+	CustomResourceDefinitionSchemaVersion = "1.31.1"
 )

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_cluster_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_cluster_types.go
@@ -82,6 +82,15 @@ type CiliumBGPInstance struct {
 	// +kubebuilder:validation:Maximum=4294967295
 	LocalASN *int64 `json:"localASN,omitempty"`
 
+	// LocalPort is the port on which the BGP daemon listens for incoming connections.
+	//
+	// If not specified, BGP instance will not listen for incoming connections.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	LocalPort *int32 `json:"localPort,omitempty"`
+
 	// Peers is a list of neighboring BGP peers for this virtual router
 	//
 	// +kubebuilder:validation:Optional

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
@@ -393,6 +393,11 @@ func (in *CiliumBGPInstance) DeepCopyInto(out *CiliumBGPInstance) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.LocalPort != nil {
+		in, out := &in.LocalPort, &out.LocalPort
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Peers != nil {
 		in, out := &in.Peers, &out.Peers
 		*out = make([]CiliumBGPPeer, len(*in))

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
@@ -352,6 +352,14 @@ func (in *CiliumBGPInstance) DeepEqual(other *CiliumBGPInstance) bool {
 		}
 	}
 
+	if (in.LocalPort == nil) != (other.LocalPort == nil) {
+		return false
+	} else if in.LocalPort != nil {
+		if *in.LocalPort != *other.LocalPort {
+			return false
+		}
+	}
+
 	if ((in.Peers != nil) && (other.Peers != nil)) || ((in.Peers == nil) != (other.Peers == nil)) {
 		in, other := &in.Peers, &other.Peers
 		if other == nil {


### PR DESCRIPTION
Currently, `LocalPort` of the `CiliumBGPNodeConfig` is only configurable via `CiliumNodeConfigOverride`. This PR allows configuring it via `CiliumBGPClusterConfig`.

By default, Cilium doesn't listen on the BGP port, because we want to support the setup that Cilium makes a peer with local BGP daemon (listening on 179 may conflict with the local BGP daemon).

However, there's a case, where the peer router doesn't listen on the port and Cilium needs to accept the connection. Instead of creating Override for each node one by one, it's useful to configure the port globally in such a case.

We have discussed out-of-band about naming of the `LocalPort` is potentially confusing (Is it the "source" port number of the locally-initiated connection, or the "listening" port?) and should be `ListenPort`. However, since we are already using this `LocalPort` naming in the NodeConfig and Override. Changing it here makes inconsistency and further confusion. That's why I kept it as is.

```release-note
bgpv2: Allow setting LocalPort from ClusterConfig
```
