### PR TITLE
cilium: force hash recalc before sending packet off to tunnel dev

### DIFF
--- a/bpf/include/bpf/helpers_skb.h
+++ b/bpf/include/bpf/helpers_skb.h
@@ -13,6 +13,7 @@
 
 /* Hash computation */
 static int BPF_FUNC(get_hash_recalc, struct __sk_buff *skb);
+static int BPF_FUNC(set_hash_invalid, struct __sk_buff *skb);
 
 /* Packet redirection */
 static int BPF_FUNC(redirect, int ifindex, __u32 flags);

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -294,6 +294,15 @@ ctx_set_encap_info(struct __sk_buff *ctx, __u32 src_ip,
 	__u32 key_size = TUNNEL_KEY_WITHOUT_SRC_IP;
 	int ret;
 
+	/* Trigger SW-based hash calculation via kernel flow dissector
+	 * right before we push the packet into vxlan/geneve tunnel,
+	 * so that udp_flow_src_port() actually takes the proper L4
+	 * hash for source port selection instead of having to fall
+	 * back.
+	 */
+	set_hash_invalid(ctx);
+	get_hash_recalc(ctx);
+
 #ifdef ENABLE_VTEP
 	if (vni != NOT_VTEP_DST)
 		key.tunnel_id = get_tunnel_id(vni);


### PR DESCRIPTION
(See commit desc, this has been observed in Azure envs for off-node traffic hitting k8s service with remote backend where the traffic is then pushed to remote backend via vxlan tunnel.)