### PR TITLE
helm: fix spire-server statefulset defined labels twice

### DIFF
--- a/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
@@ -4,10 +4,6 @@ kind: StatefulSet
 metadata:
   name: spire-server
   namespace: {{ .Values.authentication.mutual.spire.install.namespace }}
-  {{- with .Values.commonLabels }}
-  labels:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
   {{- if or .Values.authentication.mutual.spire.install.server.annotations .Values.authentication.mutual.spire.annotations }}
   annotations:
     {{- with .Values.authentication.mutual.spire.annotations }}
@@ -19,6 +15,9 @@ metadata:
   {{- end }}
   labels:
     app: spire-server
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.authentication.mutual.spire.install.server.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -76,7 +75,7 @@ spec:
         {{- with .Values.authentication.mutual.spire.install.server.resources }}
         resources:
           {{- toYaml . | trim | nindent 10 }}
-        {{- end }}        
+        {{- end }}
         ports:
         - name: grpc
           containerPort: 8081


### PR DESCRIPTION
The spire-server statefulset currently defines the `metadata.labels` value twice. This pull request combined the commonLabels with `spire.install.server.labels`

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

```release-note
Fix duplicate labels on spire-server statefulset
```
