### PR TITLE
doc: Clarified CNP inter-NS handling

### DIFF
--- a/Documentation/security/policy/kubernetes.rst
+++ b/Documentation/security/policy/kubernetes.rst
@@ -261,10 +261,23 @@ policies to a particular cluster.
 Note the ``io.kubernetes.pod.namespace: default`` in the policy
 rule. It makes sure the policy applies to ``rebel-base`` in the
 ``default`` namespace of ``cluster2`` regardless of the namespace in
-``cluster1`` where ``x-wing`` is deployed in. If the namespace label
-of policy rules is omitted it defaults to the same namespace where the
-policy itself is applied in, which may be not what is wanted when
-deploying cross-cluster policies.
+``cluster1`` where ``x-wing`` is deployed in.
+
+If the namespace label of policy rules is omitted it defaults to the same namespace
+where the policy itself is applied in, which may be not what is wanted when deploying
+cross-cluster policies. To allow access from/to any namespace, use ``matchExpressions``
+combined with an ``Exists`` operator.
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../../examples/policies/kubernetes/clustermesh/cross-cluster-any-namespace-policy.yaml
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../../../examples/policies/kubernetes/clustermesh/cross-cluster-any-namespace-policy.yaml
 
 Clusterwide Policies
 ~~~~~~~~~~~~~~~~~~~~

--- a/examples/policies/kubernetes/clustermesh/cross-cluster-any-namespace-policy.yaml
+++ b/examples/policies/kubernetes/clustermesh/cross-cluster-any-namespace-policy.yaml
@@ -1,0 +1,23 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "allow-cross-cluster-any-ns"
+spec:
+  description: "Allow x-wing in cluster1 to contact rebel-base in cluster2 (in any NS)"
+  endpointSelector:
+    matchLabels:
+      name: x-wing
+      io.cilium.k8s.policy.cluster: cluster1
+  egress:
+  - toEndpoints:
+    - matchExpressions:
+      - key: "k8s:io.kubernetes.pod.namespace"
+        operator: "Exists"
+      - key: "k8s:io.cilium.k8s.policy.cluster"
+        operator: "In"
+        values:
+        - "cluster2"
+      - key: "k8s:name"
+        operator: "In"
+        values:
+        - "rebel-base"

--- a/examples/policies/kubernetes/clustermesh/cross-cluster-policy.yaml
+++ b/examples/policies/kubernetes/clustermesh/cross-cluster-policy.yaml
@@ -2,8 +2,8 @@ apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
   name: "allow-cross-cluster"
-  description: "Allow x-wing in cluster1 to contact rebel-base in cluster2"
 spec:
+  description: "Allow x-wing in cluster1 to contact rebel-base in cluster2"
   endpointSelector:
     matchLabels:
       name: x-wing


### PR DESCRIPTION
Added minimal CNP documentation that explains how to allow traffic from/to any namespace by leveraging `matchExpressions` with the key `k8s:io.kubernetes.pod.namespace` set to `Exists`.

```release-note
doc: Clarified CNP inter-NS handling
```
