### PR TITLE
bgp: report reconcile errors in CiliumBGPNodeConfig conditions.

### DIFF
--- a/pkg/bgpv1/agent/controller.go
+++ b/pkg/bgpv1/agent/controller.go
@@ -338,13 +338,8 @@ func (c *Controller) cleanupBGPP(ctx context.Context) {
 }
 
 func (c *Controller) reconcileBGPNC(ctx context.Context, bgpnc *v2alpha1api.CiliumBGPNodeConfig) error {
-	err := c.BGPMgr.ReconcileInstances(ctx, bgpnc, c.LocalCiliumNode)
-	if err != nil {
-		return fmt.Errorf("failed to reconcile BGPNodeConfig: %w", err)
-	}
-
 	c.ConfigMode.Set(mode.BGPv2)
-	return nil
+	return c.BGPMgr.ReconcileInstances(ctx, bgpnc, c.LocalCiliumNode)
 }
 
 func (c *Controller) cleanupBGPNC(ctx context.Context) {

--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -5,6 +5,7 @@ package bgpv1
 
 import (
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
 
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	"github.com/cilium/cilium/pkg/bgpv1/agent/mode"
@@ -14,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/manager/reconciler"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/reconcilerv2"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/store"
+	"github.com/cilium/cilium/pkg/bgpv1/manager/tables"
 	bgp_metrics "github.com/cilium/cilium/pkg/bgpv1/metrics"
 	ipam_option "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -79,6 +81,11 @@ var Cell = cell.Module(
 		api.NewGetRoutePoliciesHandler,
 	),
 
+	// statedb tables
+	cell.ProvidePrivate(
+		tables.NewBGPReconcileErrorTable,
+	),
+
 	// provide privates for reconciler v2
 	cell.ProvidePrivate(
 		reconcilerv2.NewCiliumPeerAdvertisement,
@@ -98,6 +105,8 @@ var Cell = cell.Module(
 		func(*agent.Controller) {},
 		// Register the bgp_metrics collector
 		bgp_metrics.RegisterCollector,
+		// Register statedb tables
+		statedb.RegisterTable[*tables.BGPReconcileError],
 	),
 
 	metrics.Metric(manager.NewBGPManagerMetrics),

--- a/pkg/bgpv1/manager/instance/fake_instance.go
+++ b/pkg/bgpv1/manager/instance/fake_instance.go
@@ -7,6 +7,14 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 )
 
+func NewFakeBGPInstanceWithName(name string) *BGPInstance {
+	return &BGPInstance{
+		Name:   name,
+		Config: nil,
+		Router: types.NewFakeRouter(),
+	}
+}
+
 // NewFakeBGPInstance is fake BGP instance, to be used in unit tests.
 func NewFakeBGPInstance() *BGPInstance {
 	return &BGPInstance{

--- a/pkg/bgpv1/manager/manager_test.go
+++ b/pkg/bgpv1/manager/manager_test.go
@@ -9,13 +9,18 @@ import (
 	"net/netip"
 	"testing"
 
+	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/bgp"
 	"github.com/cilium/cilium/pkg/bgpv1/agent/mode"
 	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
+	"github.com/cilium/cilium/pkg/bgpv1/manager/reconcilerv2"
+	"github.com/cilium/cilium/pkg/bgpv1/manager/tables"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
+	v2api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
 
@@ -216,6 +221,301 @@ func TestGetRoutes(t *testing.T) {
 				retrievedPrefixes = append(retrievedPrefixes, netip.MustParsePrefix(r.Prefix))
 			}
 			require.EqualValues(t, tt.expectedPrefixes, retrievedPrefixes)
+		})
+	}
+}
+
+func TestStatedbReconcileErrors(t *testing.T) {
+	var tests = []struct {
+		name            string
+		instances       []*instance.BGPInstance
+		reconcilers     []reconcilerv2.ConfigReconciler
+		initStatedb     []*tables.BGPReconcileError
+		expectedError   bool
+		expectedStatedb []*tables.BGPReconcileError
+	}{
+		{
+			name: "No reconciler error",
+			instances: []*instance.BGPInstance{
+				instance.NewFakeBGPInstanceWithName("instance-1"),
+				instance.NewFakeBGPInstanceWithName("instance-2"),
+			},
+			reconcilers: []reconcilerv2.ConfigReconciler{
+				reconcilerv2.NewFakeReconciler(reconcilerv2.FakeReconcilerParams{
+					Name: "reconciler-1",
+					ReconcilerFunc: func(ctx context.Context, p reconcilerv2.ReconcileParams) error {
+						return nil
+					},
+				}),
+				reconcilerv2.NewFakeReconciler(reconcilerv2.FakeReconcilerParams{
+					Name: "reconciler-2",
+					ReconcilerFunc: func(ctx context.Context, p reconcilerv2.ReconcileParams) error {
+						return nil
+					},
+				}),
+			},
+			initStatedb:     []*tables.BGPReconcileError{},
+			expectedStatedb: []*tables.BGPReconcileError{},
+		},
+		{
+			name: "Both reconcilers return error, for two instances",
+			instances: []*instance.BGPInstance{
+				instance.NewFakeBGPInstanceWithName("instance-1"),
+				instance.NewFakeBGPInstanceWithName("instance-2"),
+			},
+			reconcilers: []reconcilerv2.ConfigReconciler{
+				reconcilerv2.NewFakeReconciler(reconcilerv2.FakeReconcilerParams{
+					Name: "reconciler-1",
+					ReconcilerFunc: func(ctx context.Context, p reconcilerv2.ReconcileParams) error {
+						return fmt.Errorf("reconciler-1 error")
+					},
+				}),
+				reconcilerv2.NewFakeReconciler(reconcilerv2.FakeReconcilerParams{
+					Name: "reconciler-2",
+					ReconcilerFunc: func(ctx context.Context, p reconcilerv2.ReconcileParams) error {
+						return fmt.Errorf("reconciler-2 error")
+					},
+				}),
+			},
+			initStatedb:   []*tables.BGPReconcileError{},
+			expectedError: true,
+			expectedStatedb: []*tables.BGPReconcileError{
+				{
+					Instance: "instance-1",
+					ErrorID:  0,
+					Error:    "reconciler-1 error",
+				},
+				{
+					Instance: "instance-1",
+					ErrorID:  1,
+					Error:    "reconciler-2 error",
+				},
+				{
+					Instance: "instance-2",
+					ErrorID:  0,
+					Error:    "reconciler-1 error",
+				},
+				{
+					Instance: "instance-2",
+					ErrorID:  1,
+					Error:    "reconciler-2 error",
+				},
+			},
+		},
+		{
+			name: "Reconcilers recover from previous error condition",
+			instances: []*instance.BGPInstance{
+				instance.NewFakeBGPInstanceWithName("instance-1"),
+				instance.NewFakeBGPInstanceWithName("instance-2"),
+			},
+			reconcilers: []reconcilerv2.ConfigReconciler{
+				reconcilerv2.NewFakeReconciler(reconcilerv2.FakeReconcilerParams{
+					Name: "reconciler-1",
+					ReconcilerFunc: func(ctx context.Context, p reconcilerv2.ReconcileParams) error {
+						return nil
+					},
+				}),
+				reconcilerv2.NewFakeReconciler(reconcilerv2.FakeReconcilerParams{
+					Name: "reconciler-2",
+					ReconcilerFunc: func(ctx context.Context, p reconcilerv2.ReconcileParams) error {
+						return nil
+					},
+				}),
+			},
+			initStatedb: []*tables.BGPReconcileError{
+				{
+					Instance: "instance-1",
+					ErrorID:  0,
+					Error:    "reconciler-1 error",
+				},
+				{
+					Instance: "instance-1",
+					ErrorID:  1,
+					Error:    "reconciler-2 error",
+				},
+				{
+					Instance: "instance-2",
+					ErrorID:  0,
+					Error:    "reconciler-1 error",
+				},
+				{
+					Instance: "instance-2",
+					ErrorID:  1,
+					Error:    "reconciler-2 error",
+				},
+			},
+			expectedStatedb: []*tables.BGPReconcileError{},
+			expectedError:   false,
+		},
+		{
+			name: "Maximum 5 errors allowed per instance",
+			instances: []*instance.BGPInstance{
+				instance.NewFakeBGPInstanceWithName("instance-1"),
+			},
+			reconcilers: []reconcilerv2.ConfigReconciler{
+				reconcilerv2.NewFakeReconciler(reconcilerv2.FakeReconcilerParams{
+					Name: "reconciler-1",
+					ReconcilerFunc: func(ctx context.Context, p reconcilerv2.ReconcileParams) error {
+						return fmt.Errorf("reconciler-1 error")
+					},
+				}),
+				reconcilerv2.NewFakeReconciler(reconcilerv2.FakeReconcilerParams{
+					Name: "reconciler-2",
+					ReconcilerFunc: func(ctx context.Context, p reconcilerv2.ReconcileParams) error {
+						return fmt.Errorf("reconciler-2 error")
+					},
+				}),
+				reconcilerv2.NewFakeReconciler(reconcilerv2.FakeReconcilerParams{
+					Name: "reconciler-3",
+					ReconcilerFunc: func(ctx context.Context, p reconcilerv2.ReconcileParams) error {
+						return fmt.Errorf("reconciler-3 error")
+					},
+				}),
+				reconcilerv2.NewFakeReconciler(reconcilerv2.FakeReconcilerParams{
+					Name: "reconciler-4",
+					ReconcilerFunc: func(ctx context.Context, p reconcilerv2.ReconcileParams) error {
+						return fmt.Errorf("reconciler-4 error")
+					},
+				}),
+				reconcilerv2.NewFakeReconciler(reconcilerv2.FakeReconcilerParams{
+					Name: "reconciler-5",
+					ReconcilerFunc: func(ctx context.Context, p reconcilerv2.ReconcileParams) error {
+						return fmt.Errorf("reconciler-5 error")
+					},
+				}),
+				reconcilerv2.NewFakeReconciler(reconcilerv2.FakeReconcilerParams{ // this error is not saved
+					Name: "reconciler-6",
+					ReconcilerFunc: func(ctx context.Context, p reconcilerv2.ReconcileParams) error {
+						return fmt.Errorf("reconciler-6 error")
+					},
+				}),
+			},
+			initStatedb: []*tables.BGPReconcileError{},
+			expectedStatedb: []*tables.BGPReconcileError{
+				{
+					Instance: "instance-1",
+					ErrorID:  0,
+					Error:    "reconciler-1 error",
+				},
+				{
+					Instance: "instance-1",
+					ErrorID:  1,
+					Error:    "reconciler-2 error",
+				},
+				{
+					Instance: "instance-1",
+					ErrorID:  2,
+					Error:    "reconciler-3 error",
+				},
+				{
+					Instance: "instance-1",
+					ErrorID:  3,
+					Error:    "reconciler-4 error",
+				},
+				{
+					Instance: "instance-1",
+					ErrorID:  4,
+					Error:    "reconciler-5 error",
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "abort reconcile error only logged once",
+			instances: []*instance.BGPInstance{
+				instance.NewFakeBGPInstanceWithName("instance-1"),
+			},
+			reconcilers: []reconcilerv2.ConfigReconciler{
+				reconcilerv2.NewFakeReconciler(reconcilerv2.FakeReconcilerParams{
+					Name: "reconciler-1",
+					ReconcilerFunc: func(ctx context.Context, p reconcilerv2.ReconcileParams) error {
+						return reconcilerv2.ErrAbortReconcile // abort reconcile error
+					},
+				}),
+				reconcilerv2.NewFakeReconciler(reconcilerv2.FakeReconcilerParams{
+					Name: "reconciler-2",
+					ReconcilerFunc: func(ctx context.Context, p reconcilerv2.ReconcileParams) error {
+						return fmt.Errorf("reconciler-2 error")
+					},
+				}),
+				reconcilerv2.NewFakeReconciler(reconcilerv2.FakeReconcilerParams{
+					Name: "reconciler-3",
+					ReconcilerFunc: func(ctx context.Context, p reconcilerv2.ReconcileParams) error {
+						return fmt.Errorf("reconciler-3 error")
+					},
+				}),
+			},
+			initStatedb: []*tables.BGPReconcileError{},
+			expectedStatedb: []*tables.BGPReconcileError{
+				{
+					Instance: "instance-1",
+					ErrorID:  0,
+					Error:    reconcilerv2.ErrAbortReconcile.Error(),
+				},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := statedb.New()
+			reconcileErrTbl, err := tables.NewBGPReconcileErrorTable()
+			require.NoError(t, err)
+
+			err = db.RegisterTable(reconcileErrTbl)
+			require.NoError(t, err)
+
+			testInstances := make(map[string]*instance.BGPInstance)
+			for _, inst := range tt.instances {
+				testInstances[inst.Name] = inst
+			}
+
+			m := BGPRouterManager{
+				BGPInstances:        testInstances,
+				ConfigReconcilers:   tt.reconcilers,
+				DB:                  db,
+				ReconcileErrorTable: reconcileErrTbl,
+				metrics:             NewBGPManagerMetrics(),
+			}
+
+			// init statedb with test data
+			txn := db.WriteTxn(m.ReconcileErrorTable)
+			for _, errObj := range tt.initStatedb {
+				_, _, err = m.ReconcileErrorTable.Insert(txn, errObj)
+				require.NoError(t, err)
+			}
+			txn.Commit()
+
+			// call reconcile for each instance
+			for _, inst := range tt.instances {
+				err = m.reconcileBGPConfigV2(
+					context.Background(),
+					inst,
+					&v2alpha1api.CiliumBGPNodeInstance{
+						Name: inst.Name,
+					},
+					&v2api.CiliumNode{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-1",
+						},
+					},
+				)
+				if tt.expectedError {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+			}
+
+			// check if the statedb is updated correctly
+			var runningStatedb []*tables.BGPReconcileError
+			iter := m.ReconcileErrorTable.All(db.ReadTxn())
+			for errObj := range iter {
+				runningStatedb = append(runningStatedb, errObj)
+			}
+
+			require.ElementsMatch(t, tt.expectedStatedb, runningStatedb)
 		})
 	}
 }

--- a/pkg/bgpv1/manager/reconcilerv2/fake.go
+++ b/pkg/bgpv1/manager/reconcilerv2/fake.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconcilerv2
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
+)
+
+type FakeReconcilerParams struct {
+	Name           string
+	ReconcilerFunc func(_ context.Context, _ ReconcileParams) error
+}
+
+type fakeReconciler struct {
+	name           string
+	reconcilerFunc func(_ context.Context, _ ReconcileParams) error
+}
+
+func NewFakeReconciler(p FakeReconcilerParams) ConfigReconciler {
+	return &fakeReconciler{
+		name:           p.Name,
+		reconcilerFunc: p.ReconcilerFunc,
+	}
+}
+
+func (f *fakeReconciler) Name() string {
+	return f.name
+}
+
+func (f *fakeReconciler) Priority() int {
+	return 10 // hardcoded priority
+}
+
+func (f *fakeReconciler) Init(_ *instance.BGPInstance) error {
+	return nil
+}
+
+func (f *fakeReconciler) Cleanup(_ *instance.BGPInstance) {}
+
+func (f *fakeReconciler) Reconcile(ctx context.Context, params ReconcileParams) error {
+	return f.reconcilerFunc(ctx, params)
+}

--- a/pkg/bgpv1/manager/store/resource_store_mock.go
+++ b/pkg/bgpv1/manager/store/resource_store_mock.go
@@ -13,26 +13,26 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 )
 
-var _ BGPCPResourceStore[*runtime.Unknown] = (*mockBGPCPResourceStore[*runtime.Unknown])(nil)
+var _ BGPCPResourceStore[*runtime.Unknown] = (*MockBGPCPResourceStore[*runtime.Unknown])(nil)
 
-type mockBGPCPResourceStore[T runtime.Object] struct {
+type MockBGPCPResourceStore[T runtime.Object] struct {
 	objMu   lock.Mutex
 	objects map[resource.Key]T
 }
 
-func NewMockBGPCPResourceStore[T runtime.Object]() *mockBGPCPResourceStore[T] {
-	return &mockBGPCPResourceStore[T]{
+func NewMockBGPCPResourceStore[T runtime.Object]() *MockBGPCPResourceStore[T] {
+	return &MockBGPCPResourceStore[T]{
 		objects: make(map[resource.Key]T),
 	}
 }
 
-func (mds *mockBGPCPResourceStore[T]) List() ([]T, error) {
+func (mds *MockBGPCPResourceStore[T]) List() ([]T, error) {
 	mds.objMu.Lock()
 	defer mds.objMu.Unlock()
 	return slices.Collect(maps.Values(mds.objects)), nil
 }
 
-func (mds *mockBGPCPResourceStore[T]) GetByKey(key resource.Key) (item T, exists bool, err error) {
+func (mds *MockBGPCPResourceStore[T]) GetByKey(key resource.Key) (item T, exists bool, err error) {
 	mds.objMu.Lock()
 	defer mds.objMu.Unlock()
 
@@ -41,7 +41,7 @@ func (mds *mockBGPCPResourceStore[T]) GetByKey(key resource.Key) (item T, exists
 	return item, exists, nil
 }
 
-func (mds *mockBGPCPResourceStore[T]) Upsert(obj T) {
+func (mds *MockBGPCPResourceStore[T]) Upsert(obj T) {
 	mds.objMu.Lock()
 	defer mds.objMu.Unlock()
 
@@ -49,7 +49,7 @@ func (mds *mockBGPCPResourceStore[T]) Upsert(obj T) {
 	mds.objects[key] = obj
 }
 
-func (mds *mockBGPCPResourceStore[T]) Delete(key resource.Key) {
+func (mds *MockBGPCPResourceStore[T]) Delete(key resource.Key) {
 	mds.objMu.Lock()
 	defer mds.objMu.Unlock()
 

--- a/pkg/bgpv1/manager/tables/errors.go
+++ b/pkg/bgpv1/manager/tables/errors.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tables
+
+import (
+	"fmt"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+)
+
+const (
+	// BGPReconcileErrCountPerInstance is number of errors stored per instance in statedb.
+	BGPReconcileErrCountPerInstance = 5
+)
+
+type BGPReconcileError struct {
+	Instance string
+	ErrorID  int
+	Error    string
+}
+
+func (re *BGPReconcileError) DeepCopy() *BGPReconcileError {
+	return &BGPReconcileError{
+		Instance: re.Instance,
+		ErrorID:  re.ErrorID,
+		Error:    re.Error,
+	}
+}
+
+func (re *BGPReconcileError) String() string {
+	return fmt.Sprintf("BGPReconcileError{Instance: %s, ErrorID: %d, Error: %s}", re.Instance, re.ErrorID, re.Error)
+}
+
+func (re *BGPReconcileError) TableHeader() []string {
+	return []string{
+		"Instance",
+		"ErrorID",
+		"Error",
+	}
+}
+
+func (re *BGPReconcileError) TableRow() []string {
+	return []string{
+		re.Instance,
+		fmt.Sprintf("%d", re.ErrorID),
+		re.Error,
+	}
+}
+
+type BGPReconcileErrorKey struct {
+	Instance string
+	ErrorID  int
+}
+
+func (k BGPReconcileErrorKey) Key() index.Key {
+	return index.String(fmt.Sprintf("%s-%d", k.Instance, k.ErrorID))
+}
+
+var (
+	BGPReconcileErrorIndex = statedb.Index[*BGPReconcileError, BGPReconcileErrorKey]{
+		Name: "key",
+		FromObject: func(obj *BGPReconcileError) index.KeySet {
+			return index.NewKeySet(
+				BGPReconcileErrorKey{
+					Instance: obj.Instance,
+					ErrorID:  obj.ErrorID,
+				}.Key(),
+			)
+		},
+		FromKey: BGPReconcileErrorKey.Key,
+		Unique:  true,
+	}
+	BGPReconcileErrorInstance = statedb.Index[*BGPReconcileError, string]{
+		Name: "Instance",
+		FromObject: func(obj *BGPReconcileError) index.KeySet {
+			return index.NewKeySet(index.String(obj.Instance))
+		},
+		FromKey:    index.String,
+		FromString: index.FromString,
+		Unique:     false,
+	}
+)
+
+func NewBGPReconcileErrorTable() (statedb.RWTable[*BGPReconcileError], error) {
+	return statedb.NewTable(
+		"bgp-reconcile-errors",
+		BGPReconcileErrorIndex,
+		BGPReconcileErrorInstance,
+	)
+}

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpnodeconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgpnodeconfigs.yaml
@@ -284,6 +284,66 @@ spec:
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
+              conditions:
+                description: The current conditions of the CiliumBGPNodeConfig
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         required:
         - metadata

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.31.1"
+	CustomResourceDefinitionSchemaVersion = "1.31.2"
 )

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_node_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_node_types.go
@@ -141,6 +141,14 @@ type CiliumBGPNodeStatus struct {
 	// +listType=map
 	// +listMapKey=name
 	BGPInstances []CiliumBGPNodeInstanceStatus `json:"bgpInstances,omitempty"`
+
+	// The current conditions of the CiliumBGPNodeConfig
+	//
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	// +deepequal-gen=false
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 type CiliumBGPNodeInstanceStatus struct {
@@ -237,3 +245,7 @@ type BGPFamilyRouteCount struct {
 	// +kubebuilder:validation:Optional
 	Advertised *int32 `json:"advertised,omitempty"`
 }
+
+const (
+	BGPInstanceConditionReconcileError = "cilium.io/BGPReconcileError"
+)

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
@@ -888,6 +888,13 @@ func (in *CiliumBGPNodeStatus) DeepCopyInto(out *CiliumBGPNodeStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]metav1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
First commit will be dropped as https://github.com/cilium/cilium/pull/37420 is merged.

This change introduces error conditions in CRD CiliumBGPNodeConfig. Whenever BGP subsystem reports reconciliation error, we store some of the errors ( 5 errors per instance ) to statedb table bgp-reconcile-errors. 

Statedb table is tracked by CRD status reconcilier and it updates the error condition in the CRD. Message of the condition contains actual returned error from reconciler.

```release-note
bgp: report reconcile errors in CiliumBGPNodeConfig conditions.
```
