### PR TITLE
gh: remove some v1.14 parts

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -29,8 +29,6 @@ body:
         - 'equal or higher than v1.16.6 and lower than v1.17.0'
         # renovate: datasource=github-tags depName=cilium/cilium
         - 'equal or higher than v1.15.13 and lower than v1.16.0'
-        # renovate: datasource=github-tags depName=cilium/cilium
-        - 'equal or higher than v1.14.19 and lower than v1.15.0'
     validations:
       required: true
   - type: textarea

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -72,7 +72,6 @@
     "v1.17",
     "v1.16",
     "v1.15",
-    "v1.14",
   ],
   "vulnerabilityAlerts": {
     "enabled": true
@@ -197,7 +196,6 @@
         "v1.17",
         "v1.16",
         "v1.15",
-        "v1.14",
       ]
     },
     {
@@ -213,7 +211,6 @@
         "v1.17",
         "v1.16",
         "v1.15",
-        "v1.14",
       ]
     },
     {
@@ -275,17 +272,6 @@
         "v1.17",
         "v1.16",
         "v1.15",
-        "v1.14",
-      ]
-    },
-    {
-      // Do not upgrade etcd as they have removed bash starting from v3.5.5
-      "matchDepNames": [
-        "quay.io/coreos/etcd"
-      ],
-      "allowedVersions": "<3.5.5",
-      "matchBaseBranches": [
-        "v1.14",
       ]
     },
     {
@@ -315,19 +301,6 @@
       "allowedVersions": "<1.10",
     },
     {
-      "matchFiles": [
-        "install/kubernetes/Makefile.values"
-      ],
-      "matchPackageNames": [
-        "ghcr.io/spiffe/spire-agent",
-        "ghcr.io/spiffe/spire-server"
-      ],
-      "matchBaseBranches": [
-        "v1.14"
-      ],
-      "allowedVersions": "<1.7",
-    },
-    {
       "matchPackageNames": [
         "docker.io/library/ubuntu"
       ],
@@ -345,7 +318,6 @@
       "matchBaseBranches": [
         "v1.16",
         "v1.15",
-        "v1.14",
       ],
     },
     {
@@ -358,7 +330,6 @@
         "v1.17",
         "v1.16",
         "v1.15",
-        "v1.14"
       ]
     },
     {
@@ -374,15 +345,6 @@
     },
     {
       "matchPackageNames": [
-        "docker.io/library/alpine"
-      ],
-      "allowedVersions": "<3.19",
-      "matchBaseBranches": [
-        "v1.14"
-      ]
-    },
-    {
-      "matchPackageNames": [
         "quay.io/cilium/certgen",
       ],
       "allowedVersions": "<0.2.0",
@@ -390,7 +352,6 @@
         "v1.17",
         "v1.16",
         "v1.15",
-        "v1.14",
       ]
     },
     {
@@ -431,7 +392,6 @@
         "v1.17",
         "v1.16",
         "v1.15",
-        "v1.14"
       ]
     },
     {
@@ -467,7 +427,6 @@
         "v1.17",
         "v1.16",
         "v1.15",
-        "v1.14",
       ]
     },
     {
@@ -490,7 +449,6 @@
         "v1.17",
         "v1.16",
         "v1.15",
-        "v1.14",
       ],
     },
     {
@@ -616,7 +574,6 @@
         "v1.17",
         "v1.16",
         "v1.15",
-        "v1.14"
       ]
     },
     {


### PR DESCRIPTION
We released v1.17, and therefore v1.14 is EOL. Stop accepting bug reports, and stop updating dependencies for the v1.14 branch.