### PR TITLE
Explicitly display protocol for ICMP packet drop notifications

### DIFF
--- a/pkg/monitor/dissect.go
+++ b/pkg/monitor/dissect.go
@@ -168,7 +168,7 @@ func GetConnectionSummary(data []byte) string {
 
 	switch {
 	case icmpCode != "":
-		return fmt.Sprintf("%s -> %s %s", srcIP, dstIP, icmpCode)
+		return fmt.Sprintf("%s -> %s %s %s", srcIP, dstIP, proto, icmpCode)
 	case proto != "":
 		var s string
 

--- a/pkg/monitor/dissect_test.go
+++ b/pkg/monitor/dissect_test.go
@@ -42,7 +42,7 @@ func TestDissectSummary(t *testing.T) {
 	require.Equal(t, dport, summary.L4.Dst)
 }
 
-func TestConnectionSummary(t *testing.T) {
+func TestConnectionSummaryTcp(t *testing.T) {
 	srcIP := "1.2.3.4"
 	dstIP := "5.6.7.8"
 
@@ -59,5 +59,22 @@ func TestConnectionSummary(t *testing.T) {
 		net.JoinHostPort(srcIP, sport),
 		net.JoinHostPort(dstIP, dport),
 		"tcp SYN")
+	require.Equal(t, expect, summary)
+}
+
+func TestConnectionSummaryIcmp(t *testing.T) {
+	srcIP := "1.2.3.4"
+	dstIP := "5.6.7.8"
+
+	// Generated in scapy:
+	// Ether(src="01:23:45:67:89:ab", dst="02:33:45:67:89:ab")/IP(src="1.2.3.4",dst="5.6.7.8")/ICMP(type=3, code=1)
+	packetData := []byte{2, 51, 69, 103, 137, 171, 1, 35, 69, 103, 137, 171, 8, 0, 69, 0, 0, 28, 0, 1, 0, 0, 64, 1, 106, 205, 1, 2, 3, 4, 5, 6, 7, 8, 3, 1, 252, 254, 0, 0, 0, 0}
+
+	summary := GetConnectionSummary(packetData)
+
+	expect := fmt.Sprintf("%s -> %s %s",
+		srcIP,
+		dstIP,
+		"icmp DestinationUnreachable(Host)")
 	require.Equal(t, expect, summary)
 }


### PR DESCRIPTION
This is a tiny UX improvement to make ICMP packet drop notification messages consistent with TCP and UDP ones. We had several reports from users in our company confused by ICMP packet drop notifications since the protocol is not explicitly specified and they did not immediately connect the dots with ICMP because they are not intimately familiar with ICMP types and codes.

Example TCP drop notification:
```
xx drop (Policy denied) [...] 100.161.131.48:51096 -> 100.161.93.125:9093 tcp SYN
```
 
Example UDP drop notification:
```
xx drop (Policy denied) [...] 100.161.131.48:39060 -> 169.254.20.10:53 udp
```

Example ICMP drop notification before my PR (note that the protocol is not specified anywhere):
```
xx drop (Policy denied) [...] 100.161.131.48 -> 100.161.93.125 DestinationUnreachable(Port)
```

Example ICMP drop notification after my PR:
```
xx drop (Policy denied) [...] 100.161.131.48 -> 100.161.93.125 icmp DestinationUnreachable(Port)
```
The protocol is now explicitly specified, as it is the case for TCP and UDP drops.

<br/><br/>

```release-note
Explicitly display protocol for ICMP packet drop notifications
```
