### PR TITLE
linux/devices_controller: do not auto-detect ipoib devices

### DIFF
--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -675,6 +675,12 @@ func (dc *devicesController) isSelectedDevice(d *tables.Device, txn statedb.Writ
 		// purposes. In the rare cases where a user wants to load datapath
 		// programs onto them they can override device detection with --devices.
 		return false, "bridge-like device, use --devices to override"
+
+	case "ipoib":
+		// Skip IPoIB devices since they are untested and assumed to not work.
+		// In the rare cases where a user wants to load datapath programs onto
+		// them they can override device detection with --devices.
+		return false, "IPoIB device, use --devices to override"
 	}
 
 	if !hasGlobalRoute(d.Index, dc.params.RouteTable, txn) {


### PR DESCRIPTION
Cilium currently does not support IPoIB devices. They have different assumptions in the kernel and are currently not covered by any tests. Yet, we were still selecting them in the device controller.

This commit specifically excludes IPoIB devices, users can still override this behavior by setting the `--device` flag.

Fixes: #37425

```release-note
Do not auto detect / auto select IPoIB devices
```
