### PR TITLE
fqdn: avoid re-parsing DNS server address/port

### DIFF
--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -141,7 +141,7 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 				// parameter is only used in logging. Not using the endpoint's IP
 				// so we don't spend any time in the benchmark on converting from
 				// net.IP to string.
-				require.NoError(b, ds.d.notifyOnDNSMsg(time.Now(), ep, "10.96.64.8:12345", 0, "10.96.64.1:53", &ciliumdns.Msg{
+				require.NoError(b, ds.d.notifyOnDNSMsg(time.Now(), ep, "10.96.64.8:12345", 0, netip.MustParseAddrPort("10.96.64.1:53"), &ciliumdns.Msg{
 					MsgHdr: ciliumdns.MsgHdr{
 						Response: true,
 					},
@@ -153,7 +153,7 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 						A:   net.ParseIP("192.0.2.3"),
 					}}}, "udp", true, &dnsproxy.ProxyRequestContext{}))
 
-				require.NoError(b, ds.d.notifyOnDNSMsg(time.Now(), ep, "10.96.64.4:54321", 0, "10.96.64.1:53", &ciliumdns.Msg{
+				require.NoError(b, ds.d.notifyOnDNSMsg(time.Now(), ep, "10.96.64.4:54321", 0, netip.MustParseAddrPort("10.96.64.1:53"), &ciliumdns.Msg{
 					MsgHdr: ciliumdns.MsgHdr{
 						Response: true,
 					},

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -122,7 +122,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 			}
 		},
 		// NotifyOnDNSMsg
-		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext) error {
+		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, dstAddr netip.AddrPort, msg *dns.Msg, protocol string, allowed bool, stat *ProxyRequestContext) error {
 			return nil
 		},
 	)


### PR DESCRIPTION
All callers of `(*Daemon).notifyOnDNSMsg` (via the `(*DNSProxy).NotifyOnDNSMsg` callback) already have the DNS server address/port as a `netip.AddrPort`. Avoid converting it to string and parsing it again in `notifyOnDNSMsg` by passing the `netip.AddrPort` directly.

Ref. https://github.com/cilium/cilium/pull/37467#pullrequestreview-2608166844