### PR TITLE
hubble: accurately report startup failure reason from cilium status

### DIFF
--- a/pkg/hubble/cell/cell.go
+++ b/pkg/hubble/cell/cell.go
@@ -5,7 +5,6 @@ package hubblecell
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/cilium/hive/cell"
@@ -77,6 +76,7 @@ type hubbleParams struct {
 }
 
 type HubbleIntegration interface {
+	Launch(ctx context.Context) error
 	Status(ctx context.Context) *models.HubbleStatus
 }
 
@@ -104,16 +104,7 @@ func newHubbleIntegration(params hubbleParams) (HubbleIntegration, error) {
 	}
 
 	params.JobGroup.Add(job.OneShot("hubble", func(ctx context.Context, _ cell.Health) error {
-		h.launch(ctx)
-
-		// NOTE: launch() sets the observer pointer at the very end of starting
-		// up all components successfully. While not ideal, this is the only
-		// signal we have to report whether Hubble was initialized successfully
-		// for now.
-		if h.observer.Load() == nil {
-			return errors.New("Hubble launch failed")
-		}
-		return nil
+		return h.Launch(ctx)
 	}))
 
 	return h, nil


### PR DESCRIPTION
### Description

The Hubble cell is a very large system part of the Cilium daemon that can fail to start for many reasons. At the moment, it is not considered a critical Cilium component and will merely output logs whenever a startup issue occurs, making troubleshooting Hubble-related issues a bit less intuitive.

This PR updates the launch and probe mechanisms to record and report the failure reason so it can be accurately displayed in the cilium-cli and cilium-dbg status output.

A follow-up to this PR will be to update the Cilium documentation to add a troubleshooting guide for Hubble.

Do note that more work is coming towards migrating Hubble sub-systems to cells, and hopefully this will allow us to delegate most of the health reporting to Hive.

Related: #37023

## Example

Tested by misconfiguring metrics:

```yaml
hubble:
  metrics:
    enabled:
      - unknown-metric
```

### Before

cilium-cli status

![image](https://github.com/user-attachments/assets/466d985f-76e0-4485-8371-81c22c4ba183)

```text
Warnings:    cilium    cilium-gdbmw    Hubble: Server not initialized
```

cilium-dbg status

```bash
$ kubectl exec -n kube-system -c cilium-agent ds/cilium -- cilium status
...
Hubble:                  Warning Server not initialized
...
Modules Health:          Stopped(0) Degraded(2) OK(81)
```

### After:

cilium-cli status

![image](https://github.com/user-attachments/assets/686ff8bb-724e-4e60-82af-462bc4237130)

```text
Warnings:    cilium    cilium-t6fwb    Hubble: failed to setup metrics: metric 'unknown-metric' does not exist
```

cilium-dbg status

```bash
$ kubectl exec -n kube-system -c cilium-agent ds/cilium -- cilium status
...
Hubble:                  Warning failed to setup metrics: metric 'unknown-metric' does not exist
...
Modules Health:          Stopped(0) Degraded(2) OK(79)
```
