### PR TITLE
implement agent daemonset (pod) name as documented

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2665,7 +2665,7 @@
      - bool
      - ``false``
    * - :spelling:ignore:`name`
-     - Agent container name.
+     - Agent daemonset name.
      - string
      - ``"cilium"``
    * - :spelling:ignore:`namespaceOverride`

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -716,7 +716,7 @@ contributors across the globe, there is almost always someone available to help.
 | maglev | object | `{}` | Configure maglev consistent hashing |
 | monitor | object | `{"enabled":false}` | cilium-monitor sidecar. |
 | monitor.enabled | bool | `false` | Enable the cilium-monitor sidecar. |
-| name | string | `"cilium"` | Agent container name. |
+| name | string | `"cilium"` | Agent daemonset name. |
 | namespaceOverride | string | `""` | namespaceOverride allows to override the destination namespace for Cilium resources. This property allows to use Cilium as part of an Umbrella Chart with different targets. |
 | nat.mapStatsEntries | int | `32` | Number of the top-k SNAT map connections to track in Cilium statedb. |
 | nat.mapStatsInterval | string | `"30s"` | Interval between how often SNAT map is counted for stats. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: cilium
+  name: {{ .Values.name }}
   namespace: {{ include "cilium.namespace" . }}
   {{- with .Values.annotations }}
   annotations:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -188,7 +188,7 @@ serviceAccounts:
 terminationGracePeriodSeconds: 1
 # -- Install the cilium agent resources.
 agent: true
-# -- Agent container name.
+# -- Agent daemonset name.
 name: cilium
 # -- Roll out cilium agent pods automatically when configmap is updated.
 rollOutCiliumPods: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -190,7 +190,7 @@ serviceAccounts:
 terminationGracePeriodSeconds: 1
 # -- Install the cilium agent resources.
 agent: true
-# -- Agent container name.
+# -- Agent daemonset name.
 name: cilium
 # -- Roll out cilium agent pods automatically when configmap is updated.
 rollOutCiliumPods: false


### PR DESCRIPTION


<!-- Description of change -->

The .Values.name variable [already exists](https://github.com/cilium/cilium/blob/3c9ec986621c7f228bd94505c9d5fb8fa56efc69/install/kubernetes/cilium/values.yaml#L192) and is documented but evidently not implemented.
This MR causes this value to function as it says it does. The default value is `cilium` so it does not result in any change of behaviour.

There are two benefits to having the daemonset name be customizable:
1. To enforce security policies with fine granularity, e.g. with Kyverno based on regexes on pod names. If you can change the daemonset name from 'cilium' to 'cilium-agent' then you can apply a rule on pods named `cilium-agent-*` (i.e. only the agent pods). Otherwise, as is currently the case, you have to apply a rule on pods named `cilium-*` (including hubble, operator etc) so it is not possible to apply specific controls on the agent pods.
2. General clarity and avoiding confusion.

```release-note
The .Values.name variable to optionally configure agent pod names now functions as intended.
```
