### PR TITLE
bpf: reduce CTX_ACT_DROP usage in datapath

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -425,7 +425,7 @@ tail_handle_ipv6_cont(struct __ctx_buff *ctx, bool from_host)
 	ret = handle_ipv6_cont(ctx, src_sec_identity, from_host, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_INGRESS);
+						  METRIC_INGRESS);
 	return ret;
 }
 
@@ -475,7 +475,7 @@ tail_handle_ipv6(struct __ctx_buff *ctx, __u32 ipcache_srcid, const bool from_ho
 	/* Catch errors from both handle_ipv6 and invoke_tailcall_if here. */
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_INGRESS);
+						  METRIC_INGRESS);
 
 	return ret;
 }
@@ -903,7 +903,7 @@ tail_handle_ipv4_cont(struct __ctx_buff *ctx, bool from_host)
 	ret = handle_ipv4_cont(ctx, src_sec_identity, from_host, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_INGRESS);
+						  METRIC_INGRESS);
 	return ret;
 }
 
@@ -953,7 +953,7 @@ tail_handle_ipv4(struct __ctx_buff *ctx, __u32 ipcache_srcid, const bool from_ho
 	/* Catch errors from both handle_ipv4 and invoke_tailcall_if here. */
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_INGRESS);
+						  METRIC_INGRESS);
 
 	return ret;
 }
@@ -1127,7 +1127,7 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, __u32 __maybe_unused identity,
 	case bpf_htons(ETH_P_IPV6):
 		if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
 			return send_drop_notify_error(ctx, identity, DROP_INVALID,
-						      CTX_ACT_DROP, METRIC_INGRESS);
+						      METRIC_INGRESS);
 
 		identity = resolve_srcid_ipv6(ctx, ip6, identity, &ipcache_srcid, from_host);
 		ctx_store_meta(ctx, CB_SRC_LABEL, identity);
@@ -1170,7 +1170,7 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, __u32 __maybe_unused identity,
 		 */
 		if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
 			return send_drop_notify_error(ctx, identity, DROP_INVALID,
-						      CTX_ACT_DROP, METRIC_INGRESS);
+						      METRIC_INGRESS);
 
 		identity = resolve_srcid_ipv4(ctx, ip4, identity, &ipcache_srcid,
 					      from_host);
@@ -1215,7 +1215,7 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, __u32 __maybe_unused identity,
 				  ctx->ingress_ifindex, trace.reason, trace.monitor);
 #ifdef ENABLE_HOST_FIREWALL
 		ret = send_drop_notify_error(ctx, identity, DROP_UNKNOWN_L3,
-					     CTX_ACT_DROP, METRIC_INGRESS);
+					     METRIC_INGRESS);
 #else
 		/* Pass unknown traffic to the stack */
 		ret = CTX_ACT_OK;
@@ -1300,7 +1300,7 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 	return do_netdev(ctx, proto, UNKNOWN_ID, TRACE_FROM_NETWORK, false);
 
 drop_err:
-	return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP, METRIC_INGRESS);
+	return send_drop_notify_error(ctx, src_id, ret, METRIC_INGRESS);
 }
 
 /*
@@ -1328,7 +1328,7 @@ int cil_from_host(struct __ctx_buff *ctx)
 #ifdef ENABLE_HOST_FIREWALL
 		return send_drop_notify(ctx, src_sec_identity, dst_sec_identity,
 					TRACE_EP_ID_UNKNOWN, DROP_UNSUPPORTED_L2,
-					CTX_ACT_DROP, METRIC_EGRESS);
+					METRIC_EGRESS);
 #else
 		send_trace_notify(ctx, TRACE_TO_STACK, src_sec_identity, dst_sec_identity,
 				  TRACE_EP_ID_UNKNOWN,
@@ -1346,8 +1346,7 @@ int cil_from_host(struct __ctx_buff *ctx)
 	if (magic == MARK_MAGIC_PROXY_EGRESS_EPID) {
 		/* extracted identity is actually the endpoint ID */
 		ret = tail_call_egress_policy(ctx, (__u16)identity);
-		return send_drop_notify_error(ctx, UNKNOWN_ID, ret, CTX_ACT_DROP,
-					      METRIC_EGRESS);
+		return send_drop_notify_error(ctx, UNKNOWN_ID, ret, METRIC_EGRESS);
 	}
 #endif
 
@@ -1362,8 +1361,7 @@ int cil_from_host(struct __ctx_buff *ctx)
 # ifdef TUNNEL_MODE
 		ret = do_netdev_encrypt_encap(ctx, proto, identity);
 		if (IS_ERR(ret))
-			return send_drop_notify_error(ctx, identity, ret,
-						      CTX_ACT_DROP, METRIC_EGRESS);
+			return send_drop_notify_error(ctx, identity, ret, METRIC_EGRESS);
 # endif /* TUNNEL_MODE */
 		return ret;
 	}
@@ -1639,7 +1637,7 @@ exit:
 
 drop_err:
 	return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
-					  CTX_ACT_DROP, METRIC_EGRESS);
+					  METRIC_EGRESS);
 }
 
 /*
@@ -1747,7 +1745,7 @@ skip_ipsec_nodeport_revdnat:
 out:
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_id, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_INGRESS);
+						  METRIC_INGRESS);
 
 	if (!traced)
 		send_trace_notify(ctx, TRACE_TO_STACK, src_id, UNKNOWN_ID,
@@ -1775,7 +1773,7 @@ int tail_ipv6_host_policy_ingress(struct __ctx_buff *ctx)
 	ret = ipv6_host_policy_ingress(ctx, &src_id, &trace, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_id, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_INGRESS);
+						  METRIC_INGRESS);
 
 	if (!traced)
 		send_trace_notify(ctx, TRACE_TO_STACK, src_id, UNKNOWN_ID,
@@ -1803,7 +1801,7 @@ int tail_ipv4_host_policy_ingress(struct __ctx_buff *ctx)
 	ret = ipv4_host_policy_ingress(ctx, &src_id, &trace, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_id, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_INGRESS);
+						  METRIC_INGRESS);
 
 	if (!traced)
 		send_trace_notify(ctx, TRACE_TO_STACK, src_id, UNKNOWN_ID,
@@ -1867,7 +1865,7 @@ to_host_from_lxc(struct __ctx_buff *ctx)
 out:
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_INGRESS);
+						  METRIC_INGRESS);
 	return ret;
 }
 
@@ -1947,13 +1945,12 @@ int handle_lxc_traffic(struct __ctx_buff *ctx __maybe_unused)
 		ret = from_host_to_lxc(ctx, &ext_err);
 		if (IS_ERR(ret))
 			return send_drop_notify_error_ext(ctx, HOST_ID, ret, ext_err,
-							  CTX_ACT_DROP, METRIC_EGRESS);
+							  METRIC_EGRESS);
 
 		lxc_id = ctx_load_meta(ctx, CB_DST_ENDPOINT_ID);
 		ctx_store_meta(ctx, CB_SRC_LABEL, HOST_ID);
 		ret = tail_call_policy(ctx, (__u16)lxc_id);
-		return send_drop_notify_error(ctx, HOST_ID, ret,
-					      CTX_ACT_DROP, METRIC_EGRESS);
+		return send_drop_notify_error(ctx, HOST_ID, ret, METRIC_EGRESS);
 	}
 
 	return to_host_from_lxc(ctx);

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1159,8 +1159,8 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, __u32 __maybe_unused identity,
 							  CILIUM_CALL_IPV6_FROM_NETDEV,
 					 &ext_err);
 		/* See comment below for IPv4. */
-		return send_drop_notify_error_ext(ctx, identity, ret, ext_err,
-						  CTX_ACT_OK, METRIC_INGRESS);
+		return send_drop_notify_error_with_exitcode_ext(ctx, identity, ret, ext_err,
+								CTX_ACT_OK, METRIC_INGRESS);
 #endif
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
@@ -1207,8 +1207,8 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, __u32 __maybe_unused identity,
 		 * Note: Since drop notification requires a tail call as well,
 		 * this notification is unlikely to succeed.
 		 */
-		return send_drop_notify_error_ext(ctx, identity, ret, ext_err,
-						  CTX_ACT_OK, METRIC_INGRESS);
+		return send_drop_notify_error_with_exitcode_ext(ctx, identity, ret, ext_err,
+								CTX_ACT_OK, METRIC_INGRESS);
 #endif /* ENABLE_IPV4 */
 	default:
 		send_trace_notify(ctx, obs_point, UNKNOWN_ID, UNKNOWN_ID, TRACE_EP_ID_UNKNOWN,

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1474,10 +1474,9 @@ skip_host_firewall:
 #if defined(ENABLE_BANDWIDTH_MANAGER)
 	ret = edt_sched_departure(ctx, proto);
 	/* No send_drop_notify_error() here given we're rate-limiting. */
-	if (ret == CTX_ACT_DROP) {
-		update_metrics(ctx_full_len(ctx), METRIC_EGRESS,
-			       -DROP_EDT_HORIZON);
-		return ret;
+	if (ret < 0) {
+		update_metrics(ctx_full_len(ctx), METRIC_EGRESS, (__u8)-ret);
+		return CTX_ACT_DROP;
 	}
 #endif
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -257,7 +257,7 @@ static __always_inline int drop_for_direction(struct __ctx_buff *ctx,
 	}
 
 	return send_drop_notify_ext(ctx, src_label, dst, dst_id, reason,
-				    ext_err, CTX_ACT_DROP, m_dir);
+				    ext_err, m_dir);
 }
 #endif /* ENABLE_IPV4 || ENABLE_IPV6 */
 
@@ -801,7 +801,7 @@ int tail_handle_ipv6_cont(struct __ctx_buff *ctx)
 	if (IS_ERR(ret))
 		return send_drop_notify_ext(ctx, SECLABEL_IPV6, dst_sec_identity,
 					    TRACE_EP_ID_UNKNOWN, ret, ext_err,
-					    CTX_ACT_DROP, METRIC_EGRESS);
+					    METRIC_EGRESS);
 
 #ifdef ENABLE_CUSTOM_CALLS
 	if (!encode_custom_prog_meta(ctx, ret, dst_sec_identity)) {
@@ -854,7 +854,7 @@ int tail_handle_ipv6(struct __ctx_buff *ctx)
 
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, SECLABEL_IPV6, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_EGRESS);
+						  METRIC_EGRESS);
 	return ret;
 }
 #endif /* ENABLE_IPV6 */
@@ -1351,7 +1351,7 @@ int tail_handle_ipv4_cont(struct __ctx_buff *ctx)
 	if (IS_ERR(ret))
 		return send_drop_notify_ext(ctx, SECLABEL_IPV4, dst_sec_identity,
 					    TRACE_EP_ID_UNKNOWN, ret, ext_err,
-					    CTX_ACT_DROP, METRIC_EGRESS);
+					    METRIC_EGRESS);
 
 #ifdef ENABLE_CUSTOM_CALLS
 	if (!encode_custom_prog_meta(ctx, ret, dst_sec_identity)) {
@@ -1424,7 +1424,7 @@ int tail_handle_ipv4(struct __ctx_buff *ctx)
 
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, SECLABEL_IPV4, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_EGRESS);
+						  METRIC_EGRESS);
 	return ret;
 }
 
@@ -1527,7 +1527,7 @@ out:
 	if (IS_ERR(ret))
 		return send_drop_notify_ext(ctx, sec_label, UNKNOWN_ID,
 					    TRACE_EP_ID_UNKNOWN, ret, ext_err,
-					    CTX_ACT_DROP, METRIC_EGRESS);
+					    METRIC_EGRESS);
 	return ret;
 }
 
@@ -1742,7 +1742,7 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 
 drop_err:
 	return send_drop_notify_ext(ctx, src_label, SECLABEL_IPV6, LXC_ID,
-				    ret, ext_err, CTX_ACT_DROP, METRIC_INGRESS);
+				    ret, ext_err, METRIC_INGRESS);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_TO_ENDPOINT)
@@ -1814,7 +1814,7 @@ int tail_ipv6_to_endpoint(struct __ctx_buff *ctx)
 out:
 	if (IS_ERR(ret))
 		return send_drop_notify_ext(ctx, src_sec_identity, SECLABEL_IPV6, LXC_ID,
-					ret, ext_err, CTX_ACT_DROP, METRIC_INGRESS);
+					ret, ext_err, METRIC_INGRESS);
 
 #ifdef ENABLE_CUSTOM_CALLS
 	/* Make sure we skip the tail call when the packet is being redirected
@@ -2101,7 +2101,7 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 
 drop_err:
 	return send_drop_notify_ext(ctx, src_label, SECLABEL_IPV4, LXC_ID,
-				    ret, ext_err, CTX_ACT_DROP, METRIC_INGRESS);
+				    ret, ext_err, METRIC_INGRESS);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_TO_ENDPOINT)
@@ -2172,7 +2172,7 @@ int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 out:
 	if (IS_ERR(ret))
 		return send_drop_notify_ext(ctx, src_sec_identity, SECLABEL_IPV4, LXC_ID,
-					ret, ext_err, CTX_ACT_DROP, METRIC_INGRESS);
+					ret, ext_err, METRIC_INGRESS);
 
 #ifdef ENABLE_CUSTOM_CALLS
 	/* Make sure we skip the tail call when the packet is being redirected
@@ -2251,7 +2251,7 @@ int handle_policy(struct __ctx_buff *ctx)
 out:
 	if (IS_ERR(ret))
 		return send_drop_notify_ext(ctx, src_label, sec_label, LXC_ID, ret, ext_err,
-					    CTX_ACT_DROP, METRIC_INGRESS);
+					    METRIC_INGRESS);
 
 	return ret;
 }
@@ -2306,7 +2306,7 @@ out:
 	if (IS_ERR(ret))
 		return send_drop_notify_ext(ctx, sec_label, UNKNOWN_ID,
 					    TRACE_EP_ID_UNKNOWN, ret, ext_err,
-					    CTX_ACT_DROP, METRIC_EGRESS);
+					    METRIC_EGRESS);
 
 	return ret;
 #else
@@ -2341,7 +2341,7 @@ int cil_to_container(struct __ctx_buff *ctx)
 	else if (magic == MARK_MAGIC_PROXY_EGRESS_EPID) {
 		ret = tail_call_egress_policy(ctx, (__u16)identity);
 		return send_drop_notify(ctx, identity, sec_label, LXC_ID,
-					ret, CTX_ACT_DROP, METRIC_INGRESS);
+					ret, METRIC_INGRESS);
 	}
 #endif
 
@@ -2363,8 +2363,7 @@ int cil_to_container(struct __ctx_buff *ctx)
 
 		ret = tail_call_policy(ctx, HOST_EP_ID);
 		return send_drop_notify(ctx, identity, sec_label, LXC_ID,
-					DROP_HOST_NOT_READY, CTX_ACT_DROP,
-					METRIC_INGRESS);
+					DROP_HOST_NOT_READY, METRIC_INGRESS);
 	}
 #endif /* ENABLE_HOST_FIREWALL && !ENABLE_ROUTING */
 
@@ -2397,7 +2396,7 @@ int cil_to_container(struct __ctx_buff *ctx)
 out:
 	if (IS_ERR(ret))
 		return send_drop_notify_ext(ctx, identity, sec_label, LXC_ID, ret,
-					    ext_err, CTX_ACT_DROP, METRIC_INGRESS);
+					    ext_err, METRIC_INGRESS);
 
 	return ret;
 }

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -183,7 +183,7 @@ int tail_handle_ipv6(struct __ctx_buff *ctx)
 
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_INGRESS);
+						  METRIC_INGRESS);
 	return ret;
 }
 #endif /* ENABLE_IPV6 */
@@ -272,7 +272,7 @@ int tail_handle_inter_cluster_revsnat(struct __ctx_buff *ctx)
 	ret = handle_inter_cluster_revsnat(ctx, src_sec_identity, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_INGRESS);
+						  METRIC_INGRESS);
 	return ret;
 }
 #endif
@@ -486,7 +486,7 @@ int tail_handle_ipv4(struct __ctx_buff *ctx)
 	ret = handle_ipv4(ctx, &src_sec_identity, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_INGRESS);
+						  METRIC_INGRESS);
 	return ret;
 }
 
@@ -514,8 +514,7 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 
 	key_size = TUNNEL_KEY_WITHOUT_SRC_IP;
 	if (unlikely(ctx_get_tunnel_key(ctx, &key, key_size, 0) < 0))
-		return send_drop_notify_error(ctx, UNKNOWN_ID, DROP_NO_TUNNEL_KEY, CTX_ACT_DROP,
-										METRIC_INGRESS);
+		return send_drop_notify_error(ctx, UNKNOWN_ID, DROP_NO_TUNNEL_KEY, METRIC_INGRESS);
 
 	if (!arp_validate(ctx, &mac, &smac, &sip, &tip) || !__lookup_ip4_endpoint(tip))
 		goto pass_to_stack;
@@ -526,7 +525,7 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 
 	ret = arp_prepare_response(ctx, &mac, tip, &smac, sip);
 	if (unlikely(ret != 0))
-		return send_drop_notify_error(ctx, UNKNOWN_ID, ret, CTX_ACT_DROP, METRIC_EGRESS);
+		return send_drop_notify_error(ctx, UNKNOWN_ID, ret, METRIC_EGRESS);
 	if (info->tunnel_endpoint) {
 		ret = __encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
 						       LOCAL_NODE_ID, WORLD_IPV4_ID,
@@ -539,7 +538,7 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 
 	ret = DROP_UNKNOWN_L3;
 drop_err:
-	return send_drop_notify_error(ctx, UNKNOWN_ID, ret, CTX_ACT_DROP, METRIC_EGRESS);
+	return send_drop_notify_error(ctx, UNKNOWN_ID, ret, METRIC_EGRESS);
 
 pass_to_stack:
 	send_trace_notify(ctx, TRACE_TO_STACK, UNKNOWN_ID, UNKNOWN_ID,
@@ -713,8 +712,7 @@ int cil_from_overlay(struct __ctx_buff *ctx)
 out:
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_sec_identity, ret,
-						  ext_err, CTX_ACT_DROP,
-						  METRIC_INGRESS);
+						  ext_err, METRIC_INGRESS);
 	return ret;
 }
 
@@ -780,7 +778,7 @@ out:
 #endif
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_EGRESS);
+						  METRIC_EGRESS);
 	return ret;
 }
 

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -743,9 +743,8 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 	 */
 	ret = edt_sched_departure(ctx, proto);
 	/* No send_drop_notify_error() here given we're rate-limiting. */
-	if (ret == CTX_ACT_DROP) {
-		update_metrics(ctx_full_len(ctx), METRIC_EGRESS,
-			       -DROP_EDT_HORIZON);
+	if (ret < 0) {
+		update_metrics(ctx_full_len(ctx), METRIC_EGRESS, (__u8)-ret);
 		return CTX_ACT_DROP;
 	}
 #endif

--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -49,7 +49,7 @@ int cil_to_wireguard(struct __ctx_buff *ctx)
 	ret = handle_nat_fwd(ctx, 0, proto, true, &trace, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_EGRESS);
+						  METRIC_EGRESS);
 
 out:
 #endif /* ENABLE_NODEPORT */

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -202,7 +202,7 @@ no_encap:
 out:
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_INGRESS);
+						  METRIC_INGRESS);
 
 	return bpf_xdp_exit(ctx, ret);
 }
@@ -213,8 +213,7 @@ static __always_inline int check_v4_lb(struct __ctx_buff *ctx)
 	int ret;
 
 	ret = tail_call_internal(ctx, CILIUM_CALL_IPV4_FROM_NETDEV, &ext_err);
-	return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err, CTX_ACT_DROP,
-					  METRIC_INGRESS);
+	return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err, METRIC_INGRESS);
 }
 #else
 static __always_inline int check_v4_lb(struct __ctx_buff *ctx __maybe_unused)
@@ -282,8 +281,7 @@ int tail_lb_ipv6(struct __ctx_buff *ctx)
 	return bpf_xdp_exit(ctx, ret);
 
 drop_err:
-	return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
-					  CTX_ACT_DROP, METRIC_INGRESS);
+	return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err, METRIC_INGRESS);
 }
 
 static __always_inline int check_v6_lb(struct __ctx_buff *ctx)
@@ -292,8 +290,7 @@ static __always_inline int check_v6_lb(struct __ctx_buff *ctx)
 	int ret;
 
 	ret = tail_call_internal(ctx, CILIUM_CALL_IPV6_FROM_NETDEV, &ext_err);
-	return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err, CTX_ACT_DROP,
-					  METRIC_INGRESS);
+	return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err, METRIC_INGRESS);
 }
 #else
 static __always_inline int check_v6_lb(struct __ctx_buff *ctx __maybe_unused)

--- a/bpf/lib/arp.h
+++ b/bpf/lib/arp.h
@@ -85,5 +85,5 @@ arp_respond(struct __ctx_buff *ctx, union macaddr *smac, __be32 sip,
 	return ctx_redirect(ctx, ctx_get_ifindex(ctx), direction);
 
 error:
-	return send_drop_notify_error(ctx, UNKNOWN_ID, ret, CTX_ACT_DROP, METRIC_EGRESS);
+	return send_drop_notify_error(ctx, UNKNOWN_ID, ret, METRIC_EGRESS);
 }

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -191,3 +191,7 @@ int _send_drop_notify(__u8 file __maybe_unused, __u16 line __maybe_unused,
 #define send_drop_notify_error_ext(ctx, src, reason, ext_err, exitcode, direction) \
 	_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, ctx, src, 0, 0, \
 			  __DROP_REASON_EXT(reason, ext_err), exitcode, direction)
+
+#define send_drop_notify_error_with_exitcode_ext(ctx, src, reason, ext_err, exitcode, direction) \
+	_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, ctx, src, 0, 0, \
+			  __DROP_REASON_EXT(reason, ext_err), exitcode, direction)

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -176,21 +176,21 @@ int _send_drop_notify(__u8 file __maybe_unused, __u16 line __maybe_unused,
 	__DROP_REASON(err) | ((__u8)(__ext_err < -128 ? 0 : __ext_err) << 8); \
 })
 
-#define send_drop_notify(ctx, src, dst, dst_id, reason, exitcode, direction) \
+#define send_drop_notify(ctx, src, dst, dst_id, reason, direction) \
 	_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, ctx, src, dst, dst_id, \
-			  __DROP_REASON(reason), exitcode, direction)
+			  __DROP_REASON(reason), CTX_ACT_DROP, direction)
 
-#define send_drop_notify_error(ctx, src, reason, exitcode, direction) \
+#define send_drop_notify_error(ctx, src, reason, direction) \
 	_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, ctx, src, 0, 0, \
-			  __DROP_REASON(reason), exitcode, direction)
+			  __DROP_REASON(reason), CTX_ACT_DROP, direction)
 
-#define send_drop_notify_ext(ctx, src, dst, dst_id, reason, ext_err, exitcode, direction) \
+#define send_drop_notify_ext(ctx, src, dst, dst_id, reason, ext_err, direction) \
 	_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, ctx, src, dst, dst_id, \
-			  __DROP_REASON_EXT(reason, ext_err), exitcode, direction)
+			  __DROP_REASON_EXT(reason, ext_err), CTX_ACT_DROP, direction)
 
-#define send_drop_notify_error_ext(ctx, src, reason, ext_err, exitcode, direction) \
+#define send_drop_notify_error_ext(ctx, src, reason, ext_err, direction) \
 	_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, ctx, src, 0, 0, \
-			  __DROP_REASON_EXT(reason, ext_err), exitcode, direction)
+			  __DROP_REASON_EXT(reason, ext_err), CTX_ACT_DROP, direction)
 
 #define send_drop_notify_error_with_exitcode_ext(ctx, src, reason, ext_err, exitcode, direction) \
 	_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, ctx, src, 0, 0, \

--- a/bpf/lib/edt.h
+++ b/bpf/lib/edt.h
@@ -79,7 +79,7 @@ edt_sched_departure(struct __ctx_buff *ctx, __be16 proto)
 	 * potentially allow for per aggregate control.
 	 */
 	if (t_next - now >= info->t_horizon_drop)
-		return CTX_ACT_DROP;
+		return DROP_EDT_HORIZON;
 	WRITE_ONCE(info->t_last, t_next);
 	ctx->tstamp = t_next;
 out:

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -185,7 +185,6 @@ do_decrypt(struct __ctx_buff *ctx, __u16 proto)
 
 		if (!node_id)
 			return send_drop_notify_error(ctx, UNKNOWN_ID, DROP_NO_NODE_ID,
-						      CTX_ACT_DROP,
 						      METRIC_INGRESS);
 		set_ipsec_decrypt_mark(ctx, node_id);
 

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -266,8 +266,7 @@ int tail_icmp6_send_time_exceeded(struct __ctx_buff *ctx __maybe_unused)
 
 	ret = __icmp6_send_time_exceeded(ctx, nh_off);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, UNKNOWN_ID, ret, CTX_ACT_DROP,
-					      direction);
+		return send_drop_notify_error(ctx, UNKNOWN_ID, ret, direction);
 	return ret;
 }
 
@@ -342,7 +341,7 @@ int tail_icmp6_handle_ns(struct __ctx_buff *ctx)
 
 	ret = __icmp6_handle_ns(ctx, nh_off);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, UNKNOWN_ID, ret, CTX_ACT_DROP, direction);
+		return send_drop_notify_error(ctx, UNKNOWN_ID, ret, direction);
 	return ret;
 }
 #endif

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -2040,7 +2040,7 @@ int tail_no_service_ipv4(struct __ctx_buff *ctx)
 	ret = __tail_no_service_ipv4(ctx);
 	if (IS_ERR(ret))
 		return send_drop_notify_error(ctx, src_sec_identity, ret,
-			CTX_ACT_DROP, METRIC_INGRESS);
+					      METRIC_INGRESS);
 
 	return ret;
 }
@@ -2214,7 +2214,7 @@ int tail_no_service_ipv6(struct __ctx_buff *ctx)
 	ret = __tail_no_service_ipv6(ctx);
 	if (IS_ERR(ret))
 		return send_drop_notify_error(ctx, src_sec_identity, ret,
-			CTX_ACT_DROP, METRIC_INGRESS);
+					      METRIC_INGRESS);
 
 	return ret;
 }

--- a/bpf/lib/mcast.h
+++ b/bpf/lib/mcast.h
@@ -437,7 +437,6 @@ int tail_mcast_ep_delivery(struct __ctx_buff *ctx)
 				UNKNOWN_ID,
 				TRACE_EP_ID_UNKNOWN,
 				DROP_MULTICAST_HANDLED,
-				CTX_ACT_DROP,
 				METRIC_INGRESS);
 }
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -619,8 +619,7 @@ static __always_inline int dsr_reply_icmp6(struct __ctx_buff *ctx,
 	return ctx_redirect(ctx, ctx_get_ifindex(ctx), 0);
 drop_err:
 #endif
-	return send_drop_notify_error(ctx, UNKNOWN_ID, code, CTX_ACT_DROP,
-				      METRIC_EGRESS);
+	return send_drop_notify_error(ctx, UNKNOWN_ID, code, METRIC_EGRESS);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_DSR)
@@ -701,7 +700,7 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 	}
 drop_err:
 	return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
-					  CTX_ACT_DROP, METRIC_EGRESS);
+					  METRIC_EGRESS);
 }
 
 static __always_inline int
@@ -810,7 +809,7 @@ int tail_nat_ipv46(struct __ctx_buff *ctx)
 	}
 drop_err:
 	return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
-					  CTX_ACT_DROP, METRIC_EGRESS);
+					  METRIC_EGRESS);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV64_RFC6052)
@@ -841,7 +840,7 @@ int tail_nat_ipv64(struct __ctx_buff *ctx)
 	}
 drop_err:
 	return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
-					  CTX_ACT_DROP, METRIC_EGRESS);
+					  METRIC_EGRESS);
 }
 #endif /* ENABLE_NAT_46X64_GATEWAY */
 
@@ -1002,7 +1001,7 @@ int tail_nodeport_rev_dnat_ingress_ipv6(struct __ctx_buff *ctx)
 	return ret;
 drop:
 	return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
-					  CTX_ACT_DROP, METRIC_EGRESS);
+					  METRIC_EGRESS);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_NAT_INGRESS)
@@ -1075,8 +1074,7 @@ recircle:
 	ret = tail_call_internal(ctx, CILIUM_CALL_IPV6_FROM_NETDEV, &ext_err);
 
 drop_err:
-	return send_drop_notify_error_ext(ctx, src_id, ret, ext_err, CTX_ACT_DROP,
-					  METRIC_INGRESS);
+	return send_drop_notify_error_ext(ctx, src_id, ret, ext_err, METRIC_INGRESS);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_NAT_EGRESS)
@@ -1208,7 +1206,7 @@ fib_ipv4:
 	}
 drop_err:
 	return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
-					  CTX_ACT_DROP, METRIC_EGRESS);
+					  METRIC_EGRESS);
 }
 
 static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
@@ -1929,8 +1927,7 @@ static __always_inline int dsr_reply_icmp4(struct __ctx_buff *ctx,
 	return ctx_redirect(ctx, ctx_get_ifindex(ctx), 0);
 drop_err:
 #endif
-	return send_drop_notify_error(ctx, UNKNOWN_ID, code, CTX_ACT_DROP,
-				      METRIC_EGRESS);
+	return send_drop_notify_error(ctx, UNKNOWN_ID, code, METRIC_EGRESS);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_DSR)
@@ -1987,7 +1984,7 @@ int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 	}
 drop_err:
 	return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
-					  CTX_ACT_DROP, METRIC_EGRESS);
+					  METRIC_EGRESS);
 }
 
 static __always_inline int
@@ -2270,7 +2267,7 @@ int tail_nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx)
 
 drop_err:
 	return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
-					  CTX_ACT_DROP, METRIC_EGRESS);
+					  METRIC_EGRESS);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_NAT_INGRESS)
@@ -2359,7 +2356,7 @@ recircle:
 	ret = tail_call_internal(ctx, CILIUM_CALL_IPV4_FROM_NETDEV, &ext_err);
 
 drop_err:
-	return send_drop_notify_error_ext(ctx, src_id, ret, ext_err, CTX_ACT_DROP,
+	return send_drop_notify_error_ext(ctx, src_id, ret, ext_err,
 					  METRIC_INGRESS);
 }
 
@@ -2496,7 +2493,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 	}
 drop_err:
 	return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
-					  CTX_ACT_DROP, METRIC_EGRESS);
+					  METRIC_EGRESS);
 }
 
 static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -112,7 +112,7 @@ int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 	ret = nodeport_snat_fwd_ipv6(ctx, &saddr, &trace, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_EGRESS);
+						  METRIC_EGRESS);
 
 	/* contrary to tail_handle_snat_fwd_ipv4, we don't check for
 	 *
@@ -245,7 +245,7 @@ int tail_handle_nat_fwd_ipv6(struct __ctx_buff *ctx)
 	ret = handle_nat_fwd_ipv6(ctx, &trace, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_EGRESS);
+						  METRIC_EGRESS);
 
 	if (ret == CTX_ACT_OK)
 		send_trace_notify(ctx, obs_point, UNKNOWN_ID, UNKNOWN_ID,
@@ -420,7 +420,7 @@ int tail_handle_snat_fwd_ipv4(struct __ctx_buff *ctx)
 	ret = nodeport_snat_fwd_ipv4(ctx, cluster_id, &saddr, &trace, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_EGRESS);
+						  METRIC_EGRESS);
 
 	/* Don't emit a trace event if the packet has been redirected to another
 	 * interface.
@@ -569,7 +569,7 @@ int tail_handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
 	ret = handle_nat_fwd_ipv4(ctx, &trace, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, UNKNOWN_ID, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_EGRESS);
+						  METRIC_EGRESS);
 
 	if (ret == CTX_ACT_OK)
 		send_trace_notify(ctx, obs_point, UNKNOWN_ID, UNKNOWN_ID,

--- a/bpf/lib/srv6.h
+++ b/bpf/lib/srv6.h
@@ -377,8 +377,7 @@ int tail_srv6_encap(struct __ctx_buff *ctx)
 	srv6_load_meta_sid(ctx, &dst_sid);
 	ret = srv6_handling(ctx, &dst_sid);
 	if (ret < 0)
-		return send_drop_notify_error(ctx, SECLABEL_IPV6, ret, CTX_ACT_DROP,
-					      METRIC_EGRESS);
+		return send_drop_notify_error(ctx, SECLABEL_IPV6, ret, METRIC_EGRESS);
 
 	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL_IPV6, UNKNOWN_ID,
 			  TRACE_EP_ID_UNKNOWN,
@@ -413,7 +412,7 @@ int tail_srv6_decap(struct __ctx_buff *ctx)
 				  TRACE_REASON_SRV6_DECAP, 0);
 		ret = tail_call_internal(ctx, CILIUM_CALL_IPV4_FROM_NETDEV, &ext_err);
 		return send_drop_notify_error_ext(ctx, SECLABEL_IPV6, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_INGRESS);
+						  METRIC_INGRESS);
 #endif /* ENABLE_IPV4 */
 #ifdef ENABLE_IPV6
 	case IPPROTO_IPV6:
@@ -422,14 +421,13 @@ int tail_srv6_decap(struct __ctx_buff *ctx)
 				  TRACE_REASON_SRV6_DECAP, 0);
 		ret = tail_call_internal(ctx, CILIUM_CALL_IPV6_FROM_NETDEV, &ext_err);
 		return send_drop_notify_error_ext(ctx, SECLABEL_IPV6, ret, ext_err,
-						  CTX_ACT_DROP, METRIC_INGRESS);
+						  METRIC_INGRESS);
 #endif /* ENABLE_IPV6 */
 	default:
 		ret = DROP_UNKNOWN_L3;
 	}
 error_drop:
-	return send_drop_notify_error(ctx, SECLABEL_IPV6, ret, CTX_ACT_DROP,
-				      METRIC_EGRESS);
+	return send_drop_notify_error(ctx, SECLABEL_IPV6, ret, METRIC_EGRESS);
 }
 # endif /* SKIP_SRV6_HANDLING */
 #endif /* ENABLE_SRV6 */

--- a/bpf/tests/drop_notify_test.c
+++ b/bpf/tests/drop_notify_test.c
@@ -60,8 +60,8 @@ int test_send_drop_notify(struct __ctx_buff ctx)
 {
 	test_init();
 
-	assert(!send_drop_notify(&ctx, 0, 0, 0, 0, 0, 0));
-	assert(!__send_drop_notify_res);
+	assert(send_drop_notify(&ctx, 0, 0, 0, 0, 0) == CTX_ACT_DROP);
+	assert(__send_drop_notify_res == CTX_ACT_DROP);
 
 	test_finish();
 }


### PR DESCRIPTION
While auditing the codebase a while ago for missing `CTX_ACT_DROP` return values, all the noise from embedding this macro into *every* drop notification call was really annoying. Just make it the default exitcode, so that the guidance for dropping a packet becomes:
> Call a `send_drop_notify_*()` helper, and bubble up the return value to the kernel.
