### PR TITLE
metrics: change bootstrap_seconds metric to gauge type

### DIFF
--- a/.github/actions/cl2-modules/cilium-metrics.yaml
+++ b/.github/actions/cl2-modules/cilium-metrics.yaml
@@ -88,11 +88,11 @@ steps:
         enableViolations: true
         queries:
         - name: Perc99
-          query: quantile(0.99, cilium_agent_bootstrap_seconds_sum{scope="overall"})
+          query: quantile(0.99, cilium_agent_bootstrap_seconds{scope="overall"})
         - name: Perc90
-          query: quantile(0.90, cilium_agent_bootstrap_seconds_sum{scope="overall"})
+          query: quantile(0.90, cilium_agent_bootstrap_seconds{scope="overall"})
         - name: Perc50
-          query: quantile(0.5, cilium_agent_bootstrap_seconds_sum{scope="overall"})
+          query: quantile(0.5, cilium_agent_bootstrap_seconds{scope="overall"})
           threshold: {{$MEDIAN_BOOTSTRAP_THRESHOLD}}
 
     - Identifier: WatchRequestThresholds

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -342,6 +342,7 @@ Changed Metrics
 * ``doublewrite_identity_kvstore_total_count`` has been renamed to ``doublewrite_kvstore_identities``
 * ``doublewrite_identity_crd_only_count`` has been renamed to ``doublewrite_crd_only_identities``
 * ``doublewrite_identity_kvstore_only_count`` has been renamed to ``doublewrite_kvstore_only_identities``
+* The type of the ``cilium_agent_bootstrap_seconds`` metric has been changed from histogram to gauge.
 
 Deprecated Metrics
 ~~~~~~~~~~~~~~~~~~

--- a/daemon/cmd/bootstrap_statistics.go
+++ b/daemon/cmd/bootstrap_statistics.go
@@ -16,15 +16,11 @@ type bootstrapStatistics struct {
 	restore         spanstat.SpanStat
 	healthCheck     spanstat.SpanStat
 	ingressIPAM     spanstat.SpanStat
-	initAPI         spanstat.SpanStat
-	initDaemon      spanstat.SpanStat
 	cleanup         spanstat.SpanStat
 	bpfBase         spanstat.SpanStat
-	clusterMeshInit spanstat.SpanStat
 	ipam            spanstat.SpanStat
 	daemonInit      spanstat.SpanStat
 	mapsInit        spanstat.SpanStat
-	workloadsInit   spanstat.SpanStat
 	fqdn            spanstat.SpanStat
 	enableConntrack spanstat.SpanStat
 	kvstore         spanstat.SpanStat
@@ -38,10 +34,10 @@ func (b *bootstrapStatistics) updateMetrics() {
 
 	for scope, stat := range b.getMap() {
 		if stat.SuccessTotal() != time.Duration(0) {
-			metrics.BootstrapTimes.WithLabelValues(scope, metrics.LabelValueOutcomeSuccess).Observe(stat.SuccessTotal().Seconds())
+			metrics.BootstrapTimes.WithLabelValues(scope, metrics.LabelValueOutcomeSuccess).Set(stat.SuccessTotal().Seconds())
 		}
 		if stat.FailureTotal() != time.Duration(0) {
-			metrics.BootstrapTimes.WithLabelValues(scope, metrics.LabelValueOutcomeFail).Observe(stat.FailureTotal().Seconds())
+			metrics.BootstrapTimes.WithLabelValues(scope, metrics.LabelValueOutcomeFail).Set(stat.FailureTotal().Seconds())
 		}
 	}
 }
@@ -54,15 +50,11 @@ func (b *bootstrapStatistics) getMap() map[string]*spanstat.SpanStat {
 		"restore":         &b.restore,
 		"healthCheck":     &b.healthCheck,
 		"ingressIPAM":     &b.ingressIPAM,
-		"initAPI":         &b.initAPI,
-		"initDaemon":      &b.initDaemon,
 		"cleanup":         &b.cleanup,
 		"bpfBase":         &b.bpfBase,
-		"clusterMeshInit": &b.clusterMeshInit,
 		"ipam":            &b.ipam,
 		"daemonInit":      &b.daemonInit,
 		"mapsInit":        &b.mapsInit,
-		"workloadsInit":   &b.workloadsInit,
 		"fqdn":            &b.fqdn,
 		"enableConntrack": &b.enableConntrack,
 		"kvstore":         &b.kvstore,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -274,7 +274,7 @@ var (
 	BPFMapPressure = true
 
 	// BootstrapTimes is the durations of cilium-agent bootstrap sequence.
-	BootstrapTimes = NoOpObserverVec
+	BootstrapTimes = NoOpGaugeVec
 
 	// APIInteractions is the total time taken to process an API call made
 	// to the cilium-agent
@@ -655,7 +655,7 @@ var (
 )
 
 type LegacyMetrics struct {
-	BootstrapTimes                   metric.Vec[metric.Observer]
+	BootstrapTimes                   metric.Vec[metric.Gauge]
 	APIInteractions                  metric.Vec[metric.Observer]
 	NodeConnectivityStatus           metric.DeletableVec[metric.Gauge]
 	NodeConnectivityLatency          metric.DeletableVec[metric.Gauge]
@@ -739,7 +739,7 @@ type LegacyMetrics struct {
 
 func NewLegacyMetrics() *LegacyMetrics {
 	lm := &LegacyMetrics{
-		BootstrapTimes: metric.NewHistogramVec(metric.HistogramOpts{
+		BootstrapTimes: metric.NewGaugeVec(metric.GaugeOpts{
 			ConfigName: Namespace + "_" + SubsystemAgent + "_bootstrap_seconds",
 			Namespace:  Namespace,
 			Subsystem:  SubsystemAgent,


### PR DESCRIPTION
Currently, the `cilium_agent_bootstrap_seconds` metric is declared as histogram type, even though it always collects at most a single observation for each label pair. In turn, making it difficult to retrieve the actual value (which can be indirectly obtained via the `_sum` metric), and causing unnecessary bloat, given that each agent emits up to 15 scopes * (12 buckets + _count + _sum) = 210 time series (granted that each scope is associated with a single outcome only, and all combinations are not initialized in advance).

Let's fix this by changing the metric to gauge type, so that it directly conveys the actual value (that can be then easily aggregated afterwards), reducing at the same time the number of time series per agent to up to 15 only (or 30 if both outcomes were initialized).

While being there, let's also cleanup the metric scopes that are no longer used.

/cc @marseel FYI

<!-- Description of change -->

```release-note
``cilium_agent_bootstrap_seconds`` metric type changed from histogram to gauge
```
