### PR TITLE
cilium-cli/sysdump: drop obsolete CiliumEgressNATPolicy entry

### DIFF
--- a/cilium-cli/sysdump/constants.go
+++ b/cilium-cli/sysdump/constants.go
@@ -62,7 +62,6 @@ const (
 	ciliumSPIREServerConfigMapFileName       = "cilium-spire-server-configmap-<ts>.yaml"
 	ciliumSPIREServerEntriesFileName         = "cilium-spire-server-entries-%s-<ts>.json"
 	ciliumIngressesFileName                  = "ciliumingresses-<ts>.yaml"
-	ciliumEgressNATPoliciesFileName          = "ciliumegressnatpolicies-<ts>.yaml"
 	ciliumEgressGatewayPoliciesFileName      = "ciliumegressgatewaypolicies-<ts>.yaml"
 	ciliumEndpointsFileName                  = "ciliumendpoints-<ts>.yaml"
 	ciliumEndpointSlicesFileName             = "ciliumendpointslices-<ts>.yaml"

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -686,26 +686,6 @@ func (c *Collector) Run() error {
 			},
 		},
 		{
-			Description: "Collecting Cilium egress NAT policies",
-			Quick:       true,
-			Task: func(ctx context.Context) error {
-				gvr := schema.GroupVersionResource{
-					Group:    "cilium.io",
-					Version:  "v2alpha1",
-					Resource: "ciliumegressnatpolicies",
-				}
-				allNamespace := corev1.NamespaceAll
-				v, err := c.Client.ListUnstructured(ctx, gvr, &allNamespace, metav1.ListOptions{})
-				if err != nil {
-					return fmt.Errorf("failed to collect Cilium egress NAT policies: %w", err)
-				}
-				if err := c.WriteYAML(ciliumEgressNATPoliciesFileName, v); err != nil {
-					return fmt.Errorf("failed to collect Cilium egress NAT policies: %w", err)
-				}
-				return nil
-			},
-		},
-		{
 			Description: "Collecting Cilium Egress Gateway policies",
 			Quick:       true,
 			Task: func(ctx context.Context) error {


### PR DESCRIPTION
The CiliumEgressNATPolicy CRD was deprecated in v1.12 and subsequently removed in v1.13 \[1]. It is now time to remove the last references still present as part of the Cilium CLI.

\[1]: 710297f22948 ("egressgw: remove deprecated CENP CRD")