### PR TITLE
fix(helm): multiPoolPreAllocation fix conditional avoid null

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1040,7 +1040,7 @@ data:
 {{- else }}
   ipam: {{ $ipam | quote }}
 {{- end }}
-{{- if hasKey .Values.ipam "multiPoolPreAllocation" }}
+{{- if .Values.ipam.multiPoolPreAllocation }}
   ipam-multi-pool-pre-allocation: {{ .Values.ipam.multiPoolPreAllocation | quote }}
 {{- end }}
 


### PR DESCRIPTION
Remaking https://github.com/cilium/cilium/pull/37436

*Summary*
This change fixes the conditional for setting the  `ipam-multi-pool-pre-allocation` key/value pair in the cilium-config configmap.

*Notes*
1.17.0 introduced a new field in the cilium-config configmap in https://github.com/cilium/cilium/pull/35812.  That field is only intended to be present when the setting `.ipam.multiPoolPreAllocation` is configured.  The current conditional is always true as it checks to see if the key for `ipam.multiPoolPreAllocation` exists instead of looking at a value.

This lead to `ipam-multi-pool-pre-allocation` being set to null value.  This can be tested by using helm/yq-go.  
```sh
helm template --repo https://helm.cilium.io/ cilium --version 1.17.0

apiVersion: v1
kind: ConfigMap
metadata:
  name: cilium-config
  namespace: demo
data:
  ipam: "cluster-pool"
  ipam-multi-pool-pre-allocation:
  ipam-cilium-node-update-rate: "15s"
  cluster-pool-ipv4-cidr: "10.0.0.0/8"
```
or alternative 1 liner
```sh
helm template --repo https://helm.cilium.io/ cilium --version 1.17.0 | yq eval-all '. | select(.metadata.name == "cilium-config")' - | grep -i ipam-multi
  ipam-multi-pool-pre-allocation:
```

At some point during the upgrade to 1.17.0, the `ipam-multi-pool-pre-allocation` caused a reconciliation loop with ArgoCD related to trying to set a null value.  Workaround of just recreating the configmap fixed the reconciliation loop.
![image](https://github.com/user-attachments/assets/e2d8fb0b-c911-48d1-8d8b-9a435372d133)
