### PR TITLE
daemon: fix hubble can't be disabled

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -133,7 +133,7 @@ cilium-agent [flags]
       --enable-host-firewall                                      Enable host network policies
       --enable-host-legacy-routing                                Enable the legacy host forwarding model which does not bypass upper stack in host namespace
       --enable-host-port                                          Enable k8s hostPort mapping feature (requires enabling enable-node-port)
-      --enable-hubble                                             Enable hubble server (default true)
+      --enable-hubble                                             Enable hubble server
       --enable-hubble-open-metrics                                Enable exporting hubble metrics in OpenMetrics format
       --enable-hubble-recorder-api                                Enable the Hubble recorder API (default true)
       --enable-identity-mark                                      Enable setting identity mark for local traffic (default true)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -44,7 +44,7 @@ cilium-agent hive [flags]
       --enable-dynamic-lifecycle-manager                          Enables support for dynamic lifecycle management
       --enable-gateway-api                                        Enables Envoy secret sync for Gateway API related TLS secrets
       --enable-gops                                               Enable gops server (default true)
-      --enable-hubble                                             Enable hubble server (default true)
+      --enable-hubble                                             Enable hubble server
       --enable-hubble-open-metrics                                Enable exporting hubble metrics in OpenMetrics format
       --enable-hubble-recorder-api                                Enable the Hubble recorder API (default true)
       --enable-ingress-controller                                 Enables Envoy secret sync for Ingress controller related TLS secrets

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -50,7 +50,7 @@ cilium-agent hive dot-graph [flags]
       --enable-dynamic-lifecycle-manager                          Enables support for dynamic lifecycle management
       --enable-gateway-api                                        Enables Envoy secret sync for Gateway API related TLS secrets
       --enable-gops                                               Enable gops server (default true)
-      --enable-hubble                                             Enable hubble server (default true)
+      --enable-hubble                                             Enable hubble server
       --enable-hubble-open-metrics                                Enable exporting hubble metrics in OpenMetrics format
       --enable-hubble-recorder-api                                Enable the Hubble recorder API (default true)
       --enable-ingress-controller                                 Enables Envoy secret sync for Ingress controller related TLS secrets

--- a/pkg/hubble/cell/config.go
+++ b/pkg/hubble/cell/config.go
@@ -116,7 +116,7 @@ type config struct {
 }
 
 var defaultConfig = config{
-	EnableHubble: true,
+	EnableHubble: false,
 	// Hubble internals (parser, ringbuffer) configuration
 	EventBufferCapacity:  observeroption.Default.MaxFlows.AsInt(),
 	EventQueueSize:       0, // see getDefaultMonitorQueueSize()


### PR DESCRIPTION
As part of https://github.com/cilium/cilium/pull/35206, we refactored Hubble as a Hive cell, and we inadvertently changed the default EnableHubble to true.

Since the helm chart defaults to not setting EnableHubble at all if the option is false in the values file, it is currently not possible to disable Hubble.

This takes care of setting back the default value of the flag to false.

This PR needs to be backported to 1.17.

Before:

```go
func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
...
	flags.Bool(option.EnableHubble, false, "Enable hubble server")
 	option.BindEnv(vp, option.EnableHubble)
```

Now:

```go
var defaultConfig = config{
 	EnableHubble: true,
```

Helm cilium configmap template

```yaml
{{- if .Values.hubble.enabled }}
  # Enable Hubble gRPC service.
  enable-hubble: {{ .Values.hubble.enabled | quote }}
```

```release-note
Fix a regression that made it impossible to disable Hubble via Helm charts 
```
