### PR TITLE
k8s/client: Rework fake client commands

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -126,8 +126,8 @@ func setupDaemonSuite(tb testing.TB) *DaemonSuite {
 	var daemonPromise promise.Promise[*Daemon]
 	ds.hive = hive.New(
 		cell.Provide(
-			func() k8sClient.Clientset {
-				cs, _ := k8sClient.NewFakeClientset()
+			func(log *slog.Logger) k8sClient.Clientset {
+				cs, _ := k8sClient.NewFakeClientset(log)
 				cs.Disable()
 				return cs
 			},

--- a/daemon/k8s/script_test.go
+++ b/daemon/k8s/script_test.go
@@ -34,8 +34,10 @@ func TestScript(t *testing.T) {
 	t.Setenv("TZ", "")
 
 	log := hivetest.Logger(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
 	scripttest.Test(t,
-		context.Background(),
+		ctx,
 		func(t testing.TB, args []string) *script.Engine {
 			h := hive.New(
 				client.FakeClientCell,

--- a/daemon/k8s/testdata/pod.txtar
+++ b/daemon/k8s/testdata/pod.txtar
@@ -11,16 +11,23 @@
 hive start
 db/initialized
 
+# We can also use the k8s/wait-watchers to wait for a watcher to appear.
+# This is useful when we don't have a StateDB table and thus cannot use
+# 'db/initialized'.
+# This is only here as an example for other tests. You don't need both
+# this and db/initialized!
+k8s/wait-watchers v1.pods
+
 # At the start the table is empty
 db/cmp k8s-pods empty.table 
 
 # Add a pod
-k8s add pod.yaml
+k8s/add pod.yaml
 
 # TIP: Since this is the first test of its kind, it's worth mentioning
 # here that you can add a 'break' command to drop into an interactive
 # debug shell to explore. E.g. if you would have 'break' here, you could
-# run 'help', 'db show k8s-pods', 'db show health', etc. to explore what
+# run 'help', 'db/show k8s-pods', 'db/show health', etc. to explore what
 # state the 'k8s add' above left us in.
 
 # Validate that it gets reflected and health is reported
@@ -46,7 +53,7 @@ db/prefix --index=name --columns=Name -o actual.table k8s-pods default/
 cmp pods_name.table actual.table
 
 # Remove the pod
-k8s delete pod.yaml
+k8s/delete pod.yaml
 
 # Table should be empty
 db/cmp k8s-pods empty.table
@@ -97,7 +104,7 @@ default/nginx
       }
     ],
     "serviceAccountName": "default",
-    "nodeName": "kind-worker"
+    "nodeName": "testnode"
   },
   "status": {
     "phase": "Running",
@@ -183,7 +190,7 @@ spec:
       readOnly: true
   dnsPolicy: ClusterFirst
   enableServiceLinks: true
-  nodeName: kind-worker
+  nodeName: testnode
   preemptionPolicy: PreemptLowerPriority
   priority: 0
   restartPolicy: Always

--- a/operator/auth/spire/client_test.go
+++ b/operator/auth/spire/client_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	entryv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/entry/v1"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/stretchr/testify/require"
@@ -412,7 +413,7 @@ func TestClient_Delete(t *testing.T) {
 }
 
 func Test_resolvedK8sService(t *testing.T) {
-	_, c := client.NewFakeClientset()
+	_, c := client.NewFakeClientset(hivetest.Logger(t))
 	_, _ = c.CoreV1().Services("dummy-namespace").Create(context.Background(), &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "valid-service",

--- a/operator/endpointgc/gc_test.go
+++ b/operator/endpointgc/gc_test.go
@@ -42,7 +42,7 @@ func TestRegisterController(t *testing.T) {
 		}),
 		metrics.Metric(NewMetrics),
 		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint]) {
-			prepareCiliumEndpoints(*c)
+			prepareCiliumEndpoints(c)
 			ciliumEndpoint = cep
 		}),
 		cell.Invoke(func(p params) error {
@@ -81,7 +81,7 @@ func TestRegisterControllerOnce(t *testing.T) {
 		metrics.Metric(NewMetrics),
 		cell.Invoke(prepareCiliumEndpointCRD),
 		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint]) {
-			prepareCiliumEndpoints(*c)
+			prepareCiliumEndpoints(c)
 			ciliumEndpoint = cep
 		}),
 		cell.Invoke(func(p params) error {
@@ -118,7 +118,7 @@ func TestRegisterControllerWithCRDDisabled(t *testing.T) {
 			}
 		}),
 		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint]) {
-			prepareCiliumEndpoints(*c)
+			prepareCiliumEndpoints(c)
 			ciliumEndpoint = cep
 		}),
 		cell.Invoke(func(p params) error {
@@ -147,7 +147,7 @@ func prepareCiliumEndpointCRD(c *k8sClient.FakeClientset) error {
 	return nil
 }
 
-func prepareCiliumEndpoints(fakeClient k8sClient.FakeClientset) {
+func prepareCiliumEndpoints(fakeClient *k8sClient.FakeClientset) {
 	// Create set of Cilium Endpoints:
 	// - CEP with no owner reference and no pods
 	cep := createCiliumEndpoint("cep1", "ns")

--- a/operator/identitygc/crd_gc_test.go
+++ b/operator/identitygc/crd_gc_test.go
@@ -23,13 +23,13 @@ import (
 )
 
 func TestUsedIdentitiesInCESs(t *testing.T) {
-	var fakeClient k8sClient.FakeClientset
+	var fakeClient *k8sClient.FakeClientset
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
 	hive := hive.New(
 		k8sClient.FakeClientCell,
 		k8s.ResourcesCell,
 		cell.Invoke(func(c *k8sClient.FakeClientset, ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) error {
-			fakeClient = *c
+			fakeClient = c
 			ciliumEndpointSlice = ces
 			return nil
 		}),

--- a/operator/pkg/bgpv2/cluster_test.go
+++ b/operator/pkg/bgpv2/cluster_test.go
@@ -297,7 +297,7 @@ func Test_NodeLabels(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			req := require.New(t)
 
-			f, watcherReady := newFixture(ctx, req, true)
+			f, watcherReady := newFixture(t, ctx, req, true)
 
 			tlog := hivetest.Logger(t)
 			f.hive.Start(tlog, ctx)
@@ -612,7 +612,7 @@ func Test_ClusterConfigSteps(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
 
-	f, watchersReady := newFixture(ctx, require.New(t), true)
+	f, watchersReady := newFixture(t, ctx, require.New(t), true)
 
 	tlog := hivetest.Logger(t)
 	f.hive.Start(tlog, ctx)
@@ -835,7 +835,7 @@ func TestClusterConfigConditions(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 			defer cancel()
 
-			f, watchersReady := newFixture(ctx, require.New(t), true)
+			f, watchersReady := newFixture(t, ctx, require.New(t), true)
 
 			tlog := hivetest.Logger(t)
 			f.hive.Start(tlog, ctx)
@@ -1073,7 +1073,7 @@ func TestConflictingClusterConfigCondition(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 			defer cancel()
 
-			f, watchersReady := newFixture(ctx, require.New(t), true)
+			f, watchersReady := newFixture(t, ctx, require.New(t), true)
 
 			tlog := hivetest.Logger(t)
 			f.hive.Start(tlog, ctx)
@@ -1181,7 +1181,7 @@ func TestDisableClusterConfigStatusReport(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
 
-	f, watchersReady := newFixture(ctx, require.New(t), false)
+	f, watchersReady := newFixture(t, ctx, require.New(t), false)
 
 	tlog := hivetest.Logger(t)
 	f.hive.Start(tlog, ctx)

--- a/operator/pkg/bgpv2/fixture_test.go
+++ b/operator/pkg/bgpv2/fixture_test.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"testing"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/watch"
 	k8sTesting "k8s.io/client-go/testing"
@@ -41,7 +43,7 @@ type fixture struct {
 	bgpnClient cilium_client_v2alpha1.CiliumBGPNodeConfigInterface
 }
 
-func newFixture(ctx context.Context, req *require.Assertions, enableStatusReport bool) (*fixture, func()) {
+func newFixture(t testing.TB, ctx context.Context, req *require.Assertions, enableStatusReport bool) (*fixture, func()) {
 	rws := map[string]*struct {
 		once    sync.Once
 		watchCh chan any
@@ -54,7 +56,7 @@ func newFixture(ctx context.Context, req *require.Assertions, enableStatusReport
 	}
 
 	f := &fixture{}
-	f.fakeClientSet, _ = k8s_client.NewFakeClientset()
+	f.fakeClientSet, _ = k8s_client.NewFakeClientset(hivetest.Logger(t))
 
 	watchReactorFn := func(action k8sTesting.Action) (handled bool, ret watch.Interface, err error) {
 		w := action.(k8sTesting.WatchAction)

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -29,7 +29,7 @@ import (
 func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 	log := hivetest.Logger(t)
 	var r *reconciler
-	var fakeClient k8sClient.FakeClientset
+	var fakeClient *k8sClient.FakeClientset
 	m := newCESManager(2, log).(*cesManager)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
@@ -44,7 +44,7 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
 			metrics *Metrics,
 		) error {
-			fakeClient = *c
+			fakeClient = c
 			ciliumEndpoint = cep
 			ciliumEndpointSlice = ces
 			cesMetrics = metrics
@@ -101,7 +101,7 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 func TestDifferentSpeedQueues(t *testing.T) {
 	log := hivetest.Logger(t)
 	var r *reconciler
-	var fakeClient k8sClient.FakeClientset
+	var fakeClient *k8sClient.FakeClientset
 	m := newCESManager(2, log)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
@@ -116,7 +116,7 @@ func TestDifferentSpeedQueues(t *testing.T) {
 			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
 			metrics *Metrics,
 		) error {
-			fakeClient = *c
+			fakeClient = c
 			ciliumEndpoint = cep
 			ciliumEndpointSlice = ces
 			cesMetrics = metrics
@@ -203,7 +203,7 @@ func TestDifferentSpeedQueues(t *testing.T) {
 func TestCESManagement(t *testing.T) {
 	log := hivetest.Logger(t)
 	var r *reconciler
-	var fakeClient k8sClient.FakeClientset
+	var fakeClient *k8sClient.FakeClientset
 	m := newCESManager(2, log)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
@@ -218,7 +218,7 @@ func TestCESManagement(t *testing.T) {
 			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
 			metrics *Metrics,
 		) error {
-			fakeClient = *c
+			fakeClient = c
 			ciliumEndpoint = cep
 			ciliumEndpointSlice = ces
 			cesMetrics = metrics

--- a/operator/pkg/ciliumendpointslice/reconciler_test.go
+++ b/operator/pkg/ciliumendpointslice/reconciler_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestReconcileCreate(t *testing.T) {
 	var r *reconciler
-	var fakeClient k8sClient.FakeClientset
+	var fakeClient *k8sClient.FakeClientset
 	m := newCESManager(2, hivetest.Logger(t)).(*cesManager)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
@@ -40,7 +40,7 @@ func TestReconcileCreate(t *testing.T) {
 			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
 			metrics *Metrics,
 		) error {
-			fakeClient = *c
+			fakeClient = c
 			ciliumEndpoint = cep
 			ciliumEndpointSlice = ces
 			cesMetrics = metrics
@@ -84,7 +84,7 @@ func TestReconcileCreate(t *testing.T) {
 
 func TestReconcileUpdate(t *testing.T) {
 	var r *reconciler
-	var fakeClient k8sClient.FakeClientset
+	var fakeClient *k8sClient.FakeClientset
 	m := newCESManager(2, hivetest.Logger(t)).(*cesManager)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
@@ -99,7 +99,7 @@ func TestReconcileUpdate(t *testing.T) {
 			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
 			metrics *Metrics,
 		) error {
-			fakeClient = *c
+			fakeClient = c
 			ciliumEndpoint = cep
 			ciliumEndpointSlice = ces
 			cesMetrics = metrics
@@ -149,7 +149,7 @@ func TestReconcileUpdate(t *testing.T) {
 
 func TestReconcileDelete(t *testing.T) {
 	var r *reconciler
-	var fakeClient k8sClient.FakeClientset
+	var fakeClient *k8sClient.FakeClientset
 	m := newCESManager(2, hivetest.Logger(t)).(*cesManager)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
@@ -164,7 +164,7 @@ func TestReconcileDelete(t *testing.T) {
 			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
 			metrics *Metrics,
 		) error {
-			fakeClient = *c
+			fakeClient = c
 			ciliumEndpoint = cep
 			ciliumEndpointSlice = ces
 			cesMetrics = metrics
@@ -208,7 +208,7 @@ func TestReconcileDelete(t *testing.T) {
 
 func TestReconcileNoop(t *testing.T) {
 	var r *reconciler
-	var fakeClient k8sClient.FakeClientset
+	var fakeClient *k8sClient.FakeClientset
 	m := newCESManager(2, hivetest.Logger(t)).(*cesManager)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
@@ -223,7 +223,7 @@ func TestReconcileNoop(t *testing.T) {
 			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
 			metrics *Metrics,
 		) error {
-			fakeClient = *c
+			fakeClient = c
 			ciliumEndpoint = cep
 			ciliumEndpointSlice = ces
 			cesMetrics = metrics

--- a/operator/pkg/ciliumidentity/controller_test.go
+++ b/operator/pkg/ciliumidentity/controller_test.go
@@ -38,7 +38,7 @@ const (
 )
 
 func TestRegisterControllerWithOperatorManagingCIDs(t *testing.T) {
-	cidResource, cesResource, fakeClient, m, h := initHiveTest(true)
+	cidResource, cesResource, fakeClient, m, h := initHiveTest(t, true)
 
 	ctx := context.Background()
 	tlog := hivetest.Logger(t)
@@ -74,7 +74,7 @@ func TestRegisterControllerWithOperatorManagingCIDs(t *testing.T) {
 }
 
 func TestRegisterController(t *testing.T) {
-	cidResource, _, fakeClient, m, h := initHiveTest(false)
+	cidResource, _, fakeClient, m, h := initHiveTest(t, false)
 
 	ctx := context.Background()
 	tlog := hivetest.Logger(t)
@@ -104,10 +104,10 @@ func TestRegisterController(t *testing.T) {
 	}
 }
 
-func initHiveTest(operatorManagingCID bool) (*resource.Resource[*capi_v2.CiliumIdentity], *resource.Resource[*capi_v2a1.CiliumEndpointSlice], *k8sClient.FakeClientset, *Metrics, *hive.Hive) {
+func initHiveTest(t *testing.T, operatorManagingCID bool) (*resource.Resource[*capi_v2.CiliumIdentity], *resource.Resource[*capi_v2a1.CiliumEndpointSlice], *k8sClient.FakeClientset, *Metrics, *hive.Hive) {
 	var cidResource resource.Resource[*capi_v2.CiliumIdentity]
 	var cesResource resource.Resource[*capi_v2a1.CiliumEndpointSlice]
-	var fakeClient k8sClient.FakeClientset
+	var fakeClient *k8sClient.FakeClientset
 	var cidMetrics Metrics
 
 	h := hive.New(
@@ -147,14 +147,18 @@ func initHiveTest(operatorManagingCID bool) (*resource.Resource[*capi_v2.CiliumI
 			ces resource.Resource[*capi_v2a1.CiliumEndpointSlice],
 			m *Metrics,
 		) error {
-			fakeClient = *c
+			fakeClient = c
 			cidResource = cid
 			cesResource = ces
 			cidMetrics = *m
 			return nil
 		}),
 	)
-	return &cidResource, &cesResource, &fakeClient, &cidMetrics, h
+	// Populate to call the invoke functions that pull out the values.
+	if err := h.Populate(hivetest.Logger(t)); err != nil {
+		t.Fatalf("Populate: %s", err)
+	}
+	return &cidResource, &cesResource, fakeClient, &cidMetrics, h
 }
 
 func createNsAndPod(ctx context.Context, fakeClient *k8sClient.FakeClientset) error {
@@ -221,7 +225,7 @@ func TestCreateTwoPodsWithSameLabels(t *testing.T) {
 	cid2 := testCreateCIDObjNs("2000", pod3, ns1)
 
 	// Start test hive.
-	cidResource, _, fakeClient, _, h := initHiveTest(true)
+	cidResource, _, fakeClient, _, h := initHiveTest(t, true)
 	ctx, cancelCtxFunc := context.WithCancel(context.Background())
 	tlog := hivetest.Logger(t)
 	if err := h.Start(tlog, ctx); err != nil {
@@ -294,7 +298,7 @@ func TestUpdatePodLabels(t *testing.T) {
 	cid2 := testCreateCIDObjNs("2000", pod1b, ns1)
 
 	// Start test hive.
-	cidResource, _, fakeClient, _, h := initHiveTest(true)
+	cidResource, _, fakeClient, _, h := initHiveTest(t, true)
 	ctx, cancelCtxFunc := context.WithCancel(context.Background())
 	tlog := hivetest.Logger(t)
 	if err := h.Start(tlog, ctx); err != nil {
@@ -361,7 +365,7 @@ func TestUpdateUsedCIDIsReverted(t *testing.T) {
 	cid2 := testCreateCIDObjNs("2000", pod2, ns1)
 
 	// Start test hive.
-	cidResource, _, fakeClient, _, h := initHiveTest(true)
+	cidResource, _, fakeClient, _, h := initHiveTest(t, true)
 	ctx, cancelCtxFunc := context.WithCancel(context.Background())
 	tlog := hivetest.Logger(t)
 	if err := h.Start(tlog, ctx); err != nil {
@@ -441,7 +445,7 @@ func TestDeleteUsedCIDIsRecreated(t *testing.T) {
 	cid1 := testCreateCIDObjNs("1000", pod1, ns1)
 
 	// Start test hive.
-	cidResource, _, fakeClient, _, h := initHiveTest(true)
+	cidResource, _, fakeClient, _, h := initHiveTest(t, true)
 	ctx, cancelCtxFunc := context.WithCancel(context.Background())
 	tlog := hivetest.Logger(t)
 	if err := h.Start(tlog, ctx); err != nil {

--- a/operator/pkg/ciliumidentity/reconciler_test.go
+++ b/operator/pkg/ciliumidentity/reconciler_test.go
@@ -45,13 +45,13 @@ func (t testQueueOps) enqueueReconciliation(item QueuedItem, delay time.Duration
 	t.fakeWorkQueue[item.Key().String()] = true
 }
 
-func testNewReconciler(t *testing.T, ctx context.Context, enableCES bool) (*reconciler, *testQueueOps, k8sClient.FakeClientset, func()) {
+func testNewReconciler(t *testing.T, ctx context.Context, enableCES bool) (*reconciler, *testQueueOps, *k8sClient.FakeClientset, func()) {
 	var namespace resource.Resource[*slim_corev1.Namespace]
 	var pod resource.Resource[*slim_corev1.Pod]
 	var ciliumIdentity resource.Resource[*capi_v2.CiliumIdentity]
 	var ciliumEndpoint resource.Resource[*capi_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*capi_v2a1.CiliumEndpointSlice]
-	var fakeClient k8sClient.FakeClientset
+	var fakeClient *k8sClient.FakeClientset
 
 	h := hive.New(
 		k8sClient.FakeClientCell,
@@ -64,7 +64,7 @@ func testNewReconciler(t *testing.T, ctx context.Context, enableCES bool) (*reco
 			cepResource resource.Resource[*capi_v2.CiliumEndpoint],
 			cesResource resource.Resource[*capi_v2a1.CiliumEndpointSlice],
 		) error {
-			fakeClient = *c
+			fakeClient = c
 			namespace = nsResource
 			pod = podResource
 			ciliumIdentity = cidResource

--- a/pkg/bgpv1/test/fixtures.go
+++ b/pkg/bgpv1/test/fixtures.go
@@ -126,12 +126,12 @@ func newFixtureConf() fixtureConfig {
 	}
 }
 
-func newFixture(conf fixtureConfig) *fixture {
+func newFixture(t testing.TB, conf fixtureConfig) *fixture {
 	f := &fixture{
 		config: conf,
 	}
 
-	f.fakeClientSet, _ = k8sClient.NewFakeClientset()
+	f.fakeClientSet, _ = k8sClient.NewFakeClientset(hivetest.Logger(t))
 	f.policyClient = f.fakeClientSet.CiliumFakeClientset.CiliumV2alpha1().CiliumBGPPeeringPolicies()
 	f.secretClient = f.fakeClientSet.SlimFakeClientset.CoreV1().Secrets("bgp-secrets")
 
@@ -211,7 +211,7 @@ func setupSingleNeighbor(ctx context.Context, f *fixture, peerASN uint32) error 
 
 // setup configures the test environment based on provided gobgp and fixture config.
 func setup(ctx context.Context, t testing.TB, peerConfigs []gobgpConfig, fixConfig fixtureConfig) (peers []*goBGP, f *fixture, cleanup func(), err error) {
-	f = newFixture(fixConfig)
+	f = newFixture(t, fixConfig)
 	peers, cleanup, err = start(ctx, t, peerConfigs, f)
 	return
 }

--- a/pkg/ciliumenvoyconfig/testdata/anyport.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/anyport.txtar
@@ -9,11 +9,11 @@ db/cmp services services_empty.table
 db/cmp ciliumenvoyconfigs cec_empty.table
 
 # Set up the services and endpoints
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
 
 # Add the CiliumEnvoyConfig and wait for it to be ingested.
-k8s add cec.yaml
+k8s/add cec.yaml
 db/cmp ciliumenvoyconfigs cec.table
 
 # Check that both services are now redirected to proxy.
@@ -29,18 +29,18 @@ envoy envoy.out
 
 # Test the processing other way around, e.g. CEC exists before
 # the service. Start by dropping the backends.
-k8s delete endpointslice.yaml
+k8s/delete endpointslice.yaml
 
 # Backends towards Envoy should be dropped.
 envoy envoy.out
 * cmp envoy.out envoy2.expected
 
 # Drop the service
-k8s delete service.yaml
+k8s/delete service.yaml
 db/cmp services services_empty.table
 
 # Add back the service and endpoints
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 db/cmp services services_redirected.table
 
 # Check again that updates happened.
@@ -48,7 +48,7 @@ envoy envoy.out
 * cmp envoy.out envoy3.expected
 
 # Cleanup. Remove CEC and check that proxy redirect is gone.
-k8s delete cec.yaml
+k8s/delete cec.yaml
 db/cmp services services.table
 db/cmp ciliumenvoyconfigs cec_empty.table
 

--- a/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
@@ -9,11 +9,11 @@ db/cmp services services_empty.table
 db/cmp ciliumenvoyconfigs cec_empty.table
 
 # Set up the services and endpoints
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
 
 # Add the CiliumClusterwideEnvoyConfig and wait for it to be ingested.
-k8s add ccec.yaml
+k8s/add ccec.yaml
 db/cmp ciliumenvoyconfigs cec.table
 
 # Check that both services are now redirected to proxy.
@@ -25,7 +25,7 @@ envoy envoy.out
 
 # Test the processing other way around, e.g. CEC exists before
 # the service.
-k8s delete service.yaml endpointslice.yaml
+k8s/delete service.yaml endpointslice.yaml
 db/cmp services services_empty.table
 
 # Backends towards Envoy should be updated.
@@ -33,7 +33,7 @@ envoy envoy.out
 * cmp envoy.out envoy2.expected
 
 # Add back the service and endpoints
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 db/cmp services services_redirected.table
 
 # Check again that updates happened.
@@ -41,7 +41,7 @@ envoy envoy.out
 * cmp envoy.out envoy3.expected
 
 # Cleanup. Remove CEC and check that proxy redirect is gone.
-k8s delete ccec.yaml
+k8s/delete ccec.yaml
 db/cmp services services.table
 db/cmp ciliumenvoyconfigs cec_empty.table
 

--- a/pkg/ciliumenvoyconfig/testdata/labels.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/labels.txtar
@@ -7,7 +7,7 @@ db/initialized
 set-node-labels foo=a
 
 # Add CECs with foo=a and foo=b node selectors
-k8s add cec_a.yaml cec_b.yaml
+k8s/add cec_a.yaml cec_b.yaml
 
 # CEC with foo=a should be selected.
 db/cmp ciliumenvoyconfigs cec_a.table

--- a/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
@@ -9,11 +9,11 @@ db/cmp services services_empty.table
 db/cmp ciliumenvoyconfigs cec_empty.table
 
 # Set up the services and endpoints
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
 
 # Add the CiliumEnvoyConfig and wait for it to be ingested.
-k8s add cec.yaml
+k8s/add cec.yaml
 db/cmp ciliumenvoyconfigs cec.table
 
 # Check that both services are now redirected to proxy.
@@ -29,18 +29,18 @@ envoy envoy.out
 
 # Test the processing other way around, e.g. CEC exists before
 # the service. Start by dropping the backends.
-k8s delete endpointslice.yaml
+k8s/delete endpointslice.yaml
 
 # Backends towards Envoy should be dropped.
 envoy envoy.out
 * cmp envoy.out envoy2.expected
 
 # Drop the service
-k8s delete service.yaml
+k8s/delete service.yaml
 db/cmp services services_empty.table
 
 # Add back the service and endpoints
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 db/cmp services services_redirected.table
 
 # Check again that updates happened.
@@ -48,7 +48,7 @@ envoy envoy.out
 * cmp envoy.out envoy3.expected
 
 # Cleanup. Remove CEC and check that proxy redirect is gone.
-k8s delete cec.yaml
+k8s/delete cec.yaml
 db/cmp services services.table
 db/cmp ciliumenvoyconfigs cec_empty.table
 

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -408,7 +409,7 @@ func testAllocatorOperatorIDManagement(t *testing.T) {
 			lbls1 := labels.NewLabelsFromSortedList("blah=%%//!!;id=foo;user=anna")
 
 			ctx := context.Background()
-			_, kubeClient := k8sClient.NewFakeClientset()
+			_, kubeClient := k8sClient.NewFakeClientset(hivetest.Logger(t))
 
 			owner := newDummyOwner()
 			identity.InitWellKnownIdentities(fakeConfig, cmtypes.ClusterInfo{Name: "default", ID: 5})

--- a/pkg/k8s/client/fake.go
+++ b/pkg/k8s/client/fake.go
@@ -1,0 +1,522 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package client
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/cilium/hive"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/script"
+	"github.com/spf13/pflag"
+	apiext_fake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/discovery"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	k8sTesting "k8s.io/client-go/testing"
+	mcsapi_fake "sigs.k8s.io/mcs-api/pkg/client/clientset/versioned/fake"
+	k8sYaml "sigs.k8s.io/yaml"
+
+	cilium_fake "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/fake"
+	slim_clientset "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned"
+	slim_fake "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned/fake"
+	"github.com/cilium/cilium/pkg/k8s/testutils"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+var FakeClientCell = cell.Module(
+	"k8s-fake-client",
+	"Fake Kubernetes client",
+
+	cell.Provide(
+		NewFakeClientset,
+		func(fc *FakeClientset) hive.ScriptCmdsOut {
+			return hive.NewScriptCmds(FakeClientCommands(fc))
+		},
+	),
+)
+
+type (
+	MCSAPIFakeClientset     = mcsapi_fake.Clientset
+	KubernetesFakeClientset = fake.Clientset
+	SlimFakeClientset       = slim_fake.Clientset
+	CiliumFakeClientset     = cilium_fake.Clientset
+	APIExtFakeClientset     = apiext_fake.Clientset
+)
+
+type FakeClientset struct {
+	disabled bool
+
+	*MCSAPIFakeClientset
+	*KubernetesFakeClientset
+	*CiliumFakeClientset
+	*APIExtFakeClientset
+	clientsetGetters
+
+	SlimFakeClientset *SlimFakeClientset
+
+	trackers map[string]k8sTesting.ObjectTracker
+
+	watchers lock.Map[string, struct{}]
+}
+
+var _ Clientset = &FakeClientset{}
+
+func (c *FakeClientset) Slim() slim_clientset.Interface {
+	return c.SlimFakeClientset
+}
+
+func (c *FakeClientset) Discovery() discovery.DiscoveryInterface {
+	return c.KubernetesFakeClientset.Discovery()
+}
+
+func (c *FakeClientset) IsEnabled() bool {
+	return !c.disabled
+}
+
+func (c *FakeClientset) Disable() {
+	c.disabled = true
+}
+
+func (c *FakeClientset) Config() Config {
+	//exhaustruct:ignore
+	return Config{}
+}
+
+func (c *FakeClientset) RestConfig() *rest.Config {
+	//exhaustruct:ignore
+	return &rest.Config{}
+}
+
+func NewFakeClientset(log *slog.Logger) (*FakeClientset, Clientset) {
+	version := testutils.DefaultVersion
+	return NewFakeClientsetWithVersion(log, version)
+}
+
+// trackerPreference has the trackers in preference order,
+// e.g. which tracker to look into first for k8s/get or k8s/list.
+// We prefer the slim one over the kubernetes one as that's the one
+// likely used in Cilium.
+var trackerPreference = []string{
+	"slim",
+	"cilium",
+	"mcs",
+	"apiext",
+	"kubernetes",
+}
+
+func NewFakeClientsetWithVersion(log *slog.Logger, version string) (*FakeClientset, Clientset) {
+	if version == "" {
+		version = testutils.DefaultVersion
+	}
+	resources, found := testutils.APIResources[version]
+	if !found {
+		panic("version " + version + " not found from testutils.APIResources")
+	}
+
+	client := FakeClientset{
+		SlimFakeClientset:       slim_fake.NewSimpleClientset(),
+		CiliumFakeClientset:     cilium_fake.NewSimpleClientset(),
+		APIExtFakeClientset:     apiext_fake.NewSimpleClientset(),
+		MCSAPIFakeClientset:     mcsapi_fake.NewSimpleClientset(),
+		KubernetesFakeClientset: fake.NewSimpleClientset(),
+	}
+	client.KubernetesFakeClientset.Resources = resources
+	client.SlimFakeClientset.Resources = resources
+	client.CiliumFakeClientset.Resources = resources
+	client.APIExtFakeClientset.Resources = resources
+	client.trackers = map[string]k8sTesting.ObjectTracker{
+		"slim":       augmentTracker(log, client.SlimFakeClientset, &client.watchers),
+		"cilium":     augmentTracker(log, client.CiliumFakeClientset, &client.watchers),
+		"mcs":        augmentTracker(log, client.MCSAPIFakeClientset, &client.watchers),
+		"kubernetes": augmentTracker(log, client.KubernetesFakeClientset, &client.watchers),
+		"apiext":     augmentTracker(log, client.APIExtFakeClientset, &client.watchers),
+	}
+
+	fd := client.KubernetesFakeClientset.Discovery().(*fakediscovery.FakeDiscovery)
+	fd.FakedServerVersion = toVersionInfo(version)
+
+	client.clientsetGetters = clientsetGetters{&client}
+	return &client, &client
+}
+
+var FakeClientBuilderCell = cell.Provide(FakeClientBuilder)
+
+func FakeClientBuilder(log *slog.Logger) ClientBuilderFunc {
+	fc, _ := NewFakeClientset(log)
+	return func(_ string) (Clientset, error) {
+		return fc, nil
+	}
+}
+
+func showGVR(gvr schema.GroupVersionResource) string {
+	if gvr.Group == "" {
+		return fmt.Sprintf("%s.%s", gvr.Version, gvr.Resource)
+	}
+	return fmt.Sprintf("%s.%s.%s", gvr.Group, gvr.Version, gvr.Resource)
+}
+
+func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
+	seenResources := map[schema.GroupVersionKind]schema.GroupVersionResource{}
+
+	addUpdateOrDelete := func(s *script.State, action string, files []string) error {
+		for _, file := range files {
+			b, err := os.ReadFile(s.Path(file))
+			if err != nil {
+				// Try relative to current directory, e.g. to allow reading "testdata/foo.yaml"
+				b, err = os.ReadFile(file)
+			}
+			if err != nil {
+				return fmt.Errorf("failed to read %s: %w", file, err)
+			}
+			obj, gvk, err := testutils.DecodeObjectGVK(b)
+			if err != nil {
+				return fmt.Errorf("decode: %w", err)
+			}
+
+			// Also try decoding using the kubernetes schema instead
+			// of the slim schema so that we get an object that the "kubernetes"
+			// tracker accepts.
+			kobj, _ := testutils.DecodeKubernetesObject(b)
+
+			gvr, _ := meta.UnsafeGuessKindToResource(*gvk)
+			objMeta, err := meta.Accessor(obj)
+			if err != nil {
+				return fmt.Errorf("accessor: %w", err)
+			}
+			seenResources[*gvk] = gvr
+
+			name := objMeta.GetName()
+			ns := objMeta.GetNamespace()
+
+			// Try to add the object to all the trackers. If one of them
+			// accepts we're good. We'll add to all since multiple trackers
+			// may accept (e.g. slim and kubernetes).
+
+			// err will get set to nil if any of the tracker methods succeed.
+			// start with a non-nil default error.
+			err = fmt.Errorf("none of the trackers of FakeClientset accepted %T", obj)
+			for trackerName, tracker := range fc.trackers {
+				var trackerErr error
+				switch action {
+				case "add":
+					trackerErr = tracker.Add(obj)
+					if trackerErr != nil && kobj != nil {
+						trackerErr = tracker.Add(kobj)
+					}
+				case "update":
+					trackerErr = tracker.Update(gvr, obj, ns)
+					if trackerErr != nil && kobj != nil {
+						trackerErr = tracker.Update(gvr, kobj, ns)
+					}
+				case "delete":
+					trackerErr = tracker.Delete(gvr, ns, name)
+				}
+				if err != nil {
+					if trackerErr == nil {
+						// One of the trackers accepted the object, it's a success!
+						err = nil
+					} else {
+						err = errors.Join(err, fmt.Errorf("%s: %w", trackerName, trackerErr))
+					}
+				}
+			}
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	return map[string]script.Cmd{
+		"k8s/add": script.Command(
+			script.CmdUsage{
+				Summary: "Add new K8s object(s) to the object trackers",
+				Detail: []string{
+					"The files should be YAML, e.g. in the format produced by",
+					"'kubectl get -o yaml'",
+				},
+				Args: "files...",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) == 0 {
+					return nil, script.ErrUsage
+				}
+				return nil, addUpdateOrDelete(s, "add", args)
+			},
+		),
+
+		"k8s/update": script.Command(
+			script.CmdUsage{
+				Summary: "Update K8s object(s) in the object trackers",
+				Args:    "files...",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) == 0 {
+					return nil, script.ErrUsage
+				}
+				return nil, addUpdateOrDelete(s, "update", args)
+			},
+		),
+
+		"k8s/delete": script.Command(
+			script.CmdUsage{
+				Summary: "Delete K8s object(s) from the object trackers",
+				Args:    "files...",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) == 0 {
+					return nil, script.ErrUsage
+				}
+				return nil, addUpdateOrDelete(s, "delete", args)
+			},
+		),
+
+		"k8s/get": script.Command(
+			script.CmdUsage{
+				Summary: "Get a K8s object from the object trackers",
+				Detail: []string{
+					"Tries object trackers in order. Prefers the slim over kubernetes.",
+					"For list of resources run 'k8s/resources'",
+				},
+				Args: "resource name",
+				Flags: func(fs *pflag.FlagSet) {
+					fs.StringP("out", "o", "", "File to write to instead of stdout")
+				},
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				file, err := s.Flags.GetString("out")
+				if err != nil {
+					return nil, err
+				}
+				if len(args) != 2 {
+					return nil, script.ErrUsage
+				}
+
+				var gvr schema.GroupVersionResource
+				for _, r := range seenResources {
+					res := showGVR(r)
+					if res == args[0] {
+						gvr = r
+						break
+					} else if strings.Contains(res, args[0]) {
+						s.Logf("Using closest match %q\n", res)
+						gvr = r
+						break
+					}
+				}
+				if gvr.Resource == "" {
+					return nil, fmt.Errorf("%q not a known resource, see 'k8s/resources' for full list", args[0])
+				}
+
+				ns, name, found := strings.Cut(args[1], "/")
+				if !found {
+					name = ns
+					ns = ""
+				}
+
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					var trackerErr error
+					for _, trackerName := range trackerPreference {
+						tracker := fc.trackers[trackerName]
+						obj, err := tracker.Get(gvr, ns, name)
+						if err == nil {
+							bs, err := k8sYaml.Marshal(obj)
+							if file != "" {
+								return "", "", os.WriteFile(s.Path(file), bs, 0644)
+							}
+							return string(bs), "", err
+						}
+						trackerErr = errors.Join(trackerErr, err)
+					}
+					return "", "", fmt.Errorf("%w: no tracker recognized %s", trackerErr, gvr)
+				}, nil
+			},
+		),
+
+		"k8s/list": script.Command(
+			script.CmdUsage{
+				Summary: "List K8s objects in the object trackers",
+				Detail: []string{
+					"For example to list pods in any namespace: k8s/list v1.pods ''",
+					"Run 'k8s/resources' for a list of seen resources.",
+				},
+				Args: "resource namespace",
+				Flags: func(fs *pflag.FlagSet) {
+					fs.StringP("out", "o", "", "File to write to instead of stdout")
+				},
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				file, err := s.Flags.GetString("out")
+				if err != nil {
+					return nil, err
+				}
+				if len(args) != 2 {
+					return nil, fmt.Errorf("%w: expected resource and namespace", script.ErrUsage)
+				}
+
+				var gvr schema.GroupVersionResource
+				var gvk schema.GroupVersionKind
+				for k, r := range seenResources {
+					res := showGVR(r)
+					if res == args[0] {
+						gvr = r
+						gvk = k
+						break
+					} else if strings.Contains(res, args[0]) {
+						s.Logf("Using closest match %q\n", res)
+						gvr = r
+						gvk = k
+						break
+					}
+				}
+				if gvr.Resource == "" {
+					return nil, fmt.Errorf("%q not a known resource, see 'k8s/resources' for full list", args[0])
+				}
+
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					var trackerErr error
+					for _, trackerName := range trackerPreference {
+						tracker := fc.trackers[trackerName]
+						obj, err := tracker.List(gvr, gvk, args[1])
+						if err == nil {
+							bs, err := k8sYaml.Marshal(obj)
+							if file != "" {
+								return "", "", os.WriteFile(s.Path(file), bs, 0644)
+							}
+							return string(bs), "", err
+						}
+						trackerErr = errors.Join(trackerErr, err)
+					}
+					return "", "", fmt.Errorf("%w: no tracker recognized %s", trackerErr, gvr)
+				}, nil
+			},
+		),
+
+		"k8s/summary": script.Command(
+			script.CmdUsage{
+				Summary: "Show a summary of object trackers",
+				Detail: []string{
+					"Lists each object tracker and the objects stored within.",
+				},
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				for _, trackerName := range trackerPreference {
+					tracker := fc.trackers[trackerName]
+					s.Logf("%s:\n", trackerName)
+					for gvk, gvr := range seenResources {
+						objs, err := tracker.List(gvr, gvk, "")
+						if err == nil {
+							lst, _ := meta.ExtractList(objs)
+							s.Logf("- %s: %d\n", showGVR(gvr), len(lst))
+						}
+					}
+				}
+				return nil, nil
+			},
+		),
+
+		"k8s/resources": script.Command(
+			script.CmdUsage{
+				Summary: "List which resources have been seen by the fake client",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					var buf strings.Builder
+					for _, gvr := range seenResources {
+						fmt.Fprintf(&buf, "%s\n", showGVR(gvr))
+					}
+					stdout = buf.String()
+					return
+				}, nil
+			},
+		),
+
+		"k8s/wait-watchers": script.Command(
+			script.CmdUsage{
+				Summary: "Wait for watchers for given resources to appear",
+				Detail: []string{
+					"Takes a list of resources and waits for a Watch() to appear for it.",
+					"",
+					"Useful when working with an informer/reflector that is not backed by",
+					"a StateDB table and thus cannot use 'db/initialized'.",
+				},
+				Args: "resources...",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				resources := map[string]struct{}{}
+				for _, r := range args {
+					resources[r] = struct{}{}
+				}
+				for s.Context().Err() == nil && len(resources) > 0 {
+					for r := range resources {
+						_, ok := fc.watchers.Load(r)
+						if ok {
+							delete(resources, r)
+						}
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+				if len(resources) > 0 {
+					seen := []string{}
+					fc.watchers.Range(func(key string, value struct{}) bool {
+						seen = append(seen, key)
+						return true
+					})
+					return nil, fmt.Errorf("watchers did not appear. saw: %v", seen)
+				}
+				return nil, nil
+			},
+		),
+	}
+
+}
+
+type fakeWithTracker interface {
+	PrependReactor(verb string, resource string, reaction k8sTesting.ReactionFunc)
+	PrependWatchReactor(resource string, reaction k8sTesting.WatchReactionFunc)
+	Tracker() k8sTesting.ObjectTracker
+}
+
+// augmentTracker augments the fake clientset to record watchers.
+// The reason we need to do this is the following: The k8s object tracker's implementation
+// of Watch is not equivalent to Watch on a real api-server, as it does not respect the
+// ResourceVersion from whence to start the watch. As a consequence, when informers (or
+// reflectors) call ListAndWatch, they miss events which occur between the end of List and
+// the establishment of Watch.
+func augmentTracker[T fakeWithTracker](log *slog.Logger, f T, watchers *lock.Map[string, struct{}]) k8sTesting.ObjectTracker {
+	o := f.Tracker()
+
+	f.PrependWatchReactor(
+		"*",
+		func(action k8sTesting.Action) (handled bool, ret watch.Interface, err error) {
+			w := action.(k8sTesting.WatchAction)
+			gvr := w.GetResource()
+			ns := w.GetNamespace()
+			watch, err := o.Watch(gvr, ns)
+			if err != nil {
+				return false, nil, err
+			}
+			watchName := showGVR(gvr)
+			if _, ok := watchers.Load(watchName); ok {
+				log.Warn("Multiple watches for resource intercepted. This highlights a potential cause for flakes", "resource", watchName)
+			}
+
+			log.Debug("Watch started", "resource", watchName)
+			watchers.Store(watchName, struct{}{})
+
+			return true, watch, nil
+		})
+
+	return o
+}

--- a/pkg/k8s/identitybackend/identity_test.go
+++ b/pkg/k8s/identitybackend/identity_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -184,7 +185,7 @@ func TestGetIdentity(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			_, client := k8sClient.NewFakeClientset()
+			_, client := k8sClient.NewFakeClientset(hivetest.Logger(t))
 			backend, err := NewCRDBackend(CRDBackendConfiguration{
 				Store:    nil,
 				StoreSet: &atomic.Bool{},

--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -104,7 +104,7 @@ func TestResource_WithFakeClient(t *testing.T) {
 		}
 
 		nodes          resource.Resource[*corev1.Node]
-		fakeClient, cs = k8sClient.NewFakeClientset()
+		fakeClient, cs = k8sClient.NewFakeClientset(hivetest.Logger(t))
 
 		events <-chan resource.Event[*corev1.Node]
 	)
@@ -453,7 +453,7 @@ func TestResource_CompletionOnStop(t *testing.T) {
 func TestResource_WithTransform(t *testing.T) {
 	type StrippedNode = metav1.PartialObjectMetadata
 	var strippedNodes resource.Resource[*StrippedNode]
-	var fakeClient, cs = k8sClient.NewFakeClientset()
+	var fakeClient, cs = k8sClient.NewFakeClientset(hivetest.Logger(t))
 
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -525,7 +525,7 @@ func TestResource_WithoutIndexers(t *testing.T) {
 			},
 		}
 		nodeResource   resource.Resource[*corev1.Node]
-		fakeClient, cs = k8sClient.NewFakeClientset()
+		fakeClient, cs = k8sClient.NewFakeClientset(hivetest.Logger(t))
 	)
 
 	fakeClient.KubernetesFakeClientset.Tracker().Create(
@@ -632,7 +632,7 @@ func TestResource_WithIndexers(t *testing.T) {
 			},
 		}
 		nodeResource   resource.Resource[*corev1.Node]
-		fakeClient, cs = k8sClient.NewFakeClientset()
+		fakeClient, cs = k8sClient.NewFakeClientset(hivetest.Logger(t))
 
 		indexName = "node-index-key"
 		indexFunc = func(obj interface{}) ([]string, error) {
@@ -739,7 +739,7 @@ var RetryFiveTimes resource.ErrorHandler = func(key resource.Key, numRetries int
 func TestResource_Retries(t *testing.T) {
 	var (
 		nodes          resource.Resource[*corev1.Node]
-		fakeClient, cs = k8sClient.NewFakeClientset()
+		fakeClient, cs = k8sClient.NewFakeClientset(hivetest.Logger(t))
 	)
 
 	var rateLimiterUsed atomic.Int64
@@ -878,7 +878,7 @@ func TestResource_Observe(t *testing.T) {
 				Phase: "init",
 			},
 		}
-		fakeClient, cs = k8sClient.NewFakeClientset()
+		fakeClient, cs = k8sClient.NewFakeClientset(hivetest.Logger(t))
 		nodes          resource.Resource[*corev1.Node]
 	)
 
@@ -938,7 +938,7 @@ func TestResource_Releasable(t *testing.T) {
 			},
 		}
 		nodeResource   resource.Resource[*corev1.Node]
-		fakeClient, cs = k8sClient.NewFakeClientset()
+		fakeClient, cs = k8sClient.NewFakeClientset(hivetest.Logger(t))
 	)
 
 	fakeClient.KubernetesFakeClientset.Tracker().Create(
@@ -1077,7 +1077,7 @@ func TestResource_ReleasableCtxCanceled(t *testing.T) {
 			},
 		}
 		nodeResource   resource.Resource[*corev1.Node]
-		fakeClient, cs = k8sClient.NewFakeClientset()
+		fakeClient, cs = k8sClient.NewFakeClientset(hivetest.Logger(t))
 	)
 
 	fakeClient.KubernetesFakeClientset.Tracker().Create(
@@ -1264,7 +1264,7 @@ func TestResource_SkippedDonePanics(t *testing.T) {
 			},
 		}
 		nodes          resource.Resource[*corev1.Node]
-		fakeClient, cs = k8sClient.NewFakeClientset()
+		fakeClient, cs = k8sClient.NewFakeClientset(hivetest.Logger(t))
 		events         <-chan resource.Event[*corev1.Node]
 	)
 

--- a/pkg/k8s/testutils/decoder.go
+++ b/pkg/k8s/testutils/decoder.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -21,13 +22,18 @@ import (
 )
 
 var (
-	// Scheme for object types used in Cilium.
+	// Scheme for object types used in Cilium. Excludes the core Kubernetes schema
+	// in favour of the slim one.
+	//
 	// The scheme can be extended by init() functions since [Decoder] is
 	// lazily constructed.
 	Scheme = runtime.NewScheme()
 
 	decoderOnce sync.Once
 	decoder     runtime.Decoder
+
+	kubernetesDecoderOnce sync.Once
+	kubernetesDecoder     runtime.Decoder
 )
 
 // Decoder returns an object decoder for Cilium and Slim objects.
@@ -67,6 +73,16 @@ func DecodeObject(bytes []byte) (runtime.Object, error) {
 func DecodeObjectGVK(bytes []byte) (runtime.Object, *schema.GroupVersionKind, error) {
 	obj, gvk, err := Decoder().Decode(bytes, nil, nil)
 	return obj, gvk, err
+}
+
+func DecodeKubernetesObject(bytes []byte) (runtime.Object, error) {
+	kubernetesDecoderOnce.Do(func() {
+		scheme := runtime.NewScheme()
+		fake.AddToScheme(scheme)
+		kubernetesDecoder = serializer.NewCodecFactory(scheme).UniversalDeserializer()
+	})
+	obj, _, err := kubernetesDecoder.Decode(bytes, nil, nil)
+	return obj, err
 }
 
 func DecodeFile(path string) (runtime.Object, error) {

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -24,7 +25,7 @@ func (f *fakeK8sWatcherConfiguration) KVstoreEnabledWithoutPodNetworkSupport() b
 }
 
 func Test_No_Resources_InitK8sSubsystem(t *testing.T) {
-	fakeClientSet, _ := client.NewFakeClientset()
+	fakeClientSet, _ := client.NewFakeClientset(hivetest.Logger(t))
 
 	w := newWatcher(
 		fakeClientSet,

--- a/pkg/kvstore/allocator/doublewrite/backend_test.go
+++ b/pkg/kvstore/allocator/doublewrite/backend_test.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -34,7 +35,7 @@ func setup(tb testing.TB) (string, *k8sClient.FakeClientset, allocator.Backend) 
 
 	kvstore.SetupDummy(tb, "etcd")
 	kvstorePrefix := fmt.Sprintf("test-prefix-%s", rand.String(12))
-	kubeClient, _ := k8sClient.NewFakeClientset()
+	kubeClient, _ := k8sClient.NewFakeClientset(hivetest.Logger(tb))
 	backend, err := NewDoubleWriteBackend(
 		DoubleWriteBackendConfiguration{
 			CRDBackendConfiguration: identitybackend.CRDBackendConfiguration{

--- a/pkg/loadbalancer/experimental/testdata/clusterip.txtar
+++ b/pkg/loadbalancer/experimental/testdata/clusterip.txtar
@@ -6,7 +6,7 @@ hive start
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
 db/initialized
 
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table 
@@ -16,7 +16,7 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
 
 # Cleanup
-k8s delete service.yaml endpointslice.yaml 
+k8s/delete service.yaml endpointslice.yaml 
 db/cmp services services_empty.table
 db/cmp frontends frontends_empty.table
 db/cmp backends backends_empty.table

--- a/pkg/loadbalancer/experimental/testdata/dualstack-maglev.txtar
+++ b/pkg/loadbalancer/experimental/testdata/dualstack-maglev.txtar
@@ -15,9 +15,9 @@ db/initialized
 
 # For determinism, add the IPv4 endpoints first and wait for reconciliation (for ID alloc)
 # and then do IPv6.
-k8s add service.yaml endpointslice-ipv4.yaml
+k8s/add service.yaml endpointslice-ipv4.yaml
 db/cmp frontends frontends-ipv4.table
-k8s add endpointslice-ipv6.yaml
+k8s/add endpointslice-ipv6.yaml
 db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table
@@ -27,7 +27,7 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
 
 # Cleanup
-k8s delete service.yaml endpointslice-ipv4.yaml endpointslice-ipv6.yaml
+k8s/delete service.yaml endpointslice-ipv4.yaml endpointslice-ipv6.yaml
 db/cmp services services_empty.table
 db/cmp frontends frontends_empty.table
 db/cmp backends backends_empty.table

--- a/pkg/loadbalancer/experimental/testdata/dualstack.txtar
+++ b/pkg/loadbalancer/experimental/testdata/dualstack.txtar
@@ -14,9 +14,9 @@ db/initialized
 
 # For determinism, add the IPv4 endpoints first and wait for reconciliation (for ID alloc)
 # and then do IPv6.
-k8s add service.yaml endpointslice-ipv4.yaml
+k8s/add service.yaml endpointslice-ipv4.yaml
 db/cmp frontends frontends-ipv4.table
-k8s add endpointslice-ipv6.yaml
+k8s/add endpointslice-ipv6.yaml
 db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table 
@@ -26,7 +26,7 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
 
 # Cleanup
-k8s delete service.yaml endpointslice-ipv4.yaml endpointslice-ipv6.yaml
+k8s/delete service.yaml endpointslice-ipv4.yaml endpointslice-ipv6.yaml
 db/cmp services services_empty.table
 db/cmp frontends frontends_empty.table
 db/cmp backends backends_empty.table

--- a/pkg/loadbalancer/experimental/testdata/graceful-termination.txtar
+++ b/pkg/loadbalancer/experimental/testdata/graceful-termination.txtar
@@ -6,7 +6,7 @@ hive start
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
 db/initialized
 
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table
@@ -16,7 +16,7 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps-active.expected lbmaps.actual
 
 # Set the backend as terminating
-k8s update endpointslice-terminating.yaml
+k8s/update endpointslice-terminating.yaml
 db/cmp frontends frontends-terminating.table
 db/cmp backends backends-terminating.table
 
@@ -25,7 +25,7 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps-terminating.expected lbmaps.actual
 
 # Cleanup
-k8s delete service.yaml endpointslice.yaml 
+k8s/delete service.yaml endpointslice.yaml 
 db/cmp services services_empty.table
 db/cmp frontends frontends_empty.table
 db/cmp backends backends_empty.table

--- a/pkg/loadbalancer/experimental/testdata/healthserver.txtar
+++ b/pkg/loadbalancer/experimental/testdata/healthserver.txtar
@@ -29,7 +29,7 @@ db/cmp --grep=^loadbalancer health health_no_service.table
 # Add a node address, service and endpoints.
 db/insert node-addresses addrv4.yaml
 db/cmp node-addresses nodeaddrs.table
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 db/cmp --grep=^loadbalancer health health_with_service.table
 db/cmp services services.table
 db/cmp frontends frontends.table
@@ -44,7 +44,7 @@ lb/maps-dump lbmaps.actual
 cmp healthserver.expected healthserver.actual
 
 # Test changing the health check port
-k8s update service2.yaml
+k8s/update service2.yaml
 
 # Check that the frontend for the health server is updated
 replace $HEALTHPORT1 $HEALTHPORT2 frontends.table
@@ -62,19 +62,19 @@ cmp healthserver.expected healthserver.actual
 cp service2.yaml service2_tpcluster.yaml
 replace 'externalTrafficPolicy: Local' 'externalTrafficPolicy: Cluster' service2_tpcluster.yaml
 replace 'internalTrafficPolicy: Local' 'internalTrafficPolicy: Cluster' service2_tpcluster.yaml
-k8s update service2_tpcluster.yaml
+k8s/update service2_tpcluster.yaml
 db/cmp frontends frontends_tpcluster.table
 
 # The health checker server should be down now.
 !* http/get http://$HEALTHADDR:$HEALTHPORT2 healthserver.actual
 
 # Restore health checking for next test.
-k8s update service2.yaml
+k8s/update service2.yaml
 * http/get http://$HEALTHADDR:$HEALTHPORT2 healthserver.actual
 cmp healthserver.expected healthserver.actual
 
 # Test removing the health check port
-k8s update service_no_health.yaml
+k8s/update service_no_health.yaml
 
 # Both ports should now stop responding
 # "!*" means expect failure and retry if needed

--- a/pkg/loadbalancer/experimental/testdata/hostport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/hostport.txtar
@@ -9,7 +9,8 @@ hive start
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
 db/initialized
 
-k8s add pod.yaml 
+k8s/add pod.yaml
+
 db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table 
@@ -19,7 +20,7 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
 
 # Cleanup
-k8s delete pod.yaml
+k8s/delete pod.yaml
 db/cmp services services_empty.table
 db/cmp frontends frontends_empty.table
 db/cmp backends backends_empty.table
@@ -84,7 +85,7 @@ spec:
     terminationMessagePolicy: File
   dnsPolicy: ClusterFirst
   enableServiceLinks: true
-  nodeName: kind-worker
+  nodeName: testnode
   preemptionPolicy: PreemptLowerPriority
   priority: 0
   restartPolicy: Always

--- a/pkg/loadbalancer/experimental/testdata/multiport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/multiport.txtar
@@ -6,7 +6,7 @@ hive start
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
 db/initialized
 
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table 
@@ -16,7 +16,7 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
 
 # Cleanup
-k8s delete service.yaml endpointslice.yaml 
+k8s/delete service.yaml endpointslice.yaml 
 db/cmp services services_empty.table
 db/cmp frontends frontends_empty.table
 db/cmp backends backends_empty.table

--- a/pkg/loadbalancer/experimental/testdata/nodeport-addr.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport-addr.txtar
@@ -7,7 +7,7 @@ db/insert node-addresses addrv4-1.yaml
 db/cmp node-addresses nodeaddrs.table
 
 # Add the first service before starting (List() path)
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 
 # Start the test application
 hive start
@@ -21,7 +21,7 @@ db/initialized
 # have the ID assigned.
 db/cmp frontends frontends1.table
 
-k8s add service2.yaml endpointslice2.yaml
+k8s/add service2.yaml endpointslice2.yaml
 
 db/cmp services services.table
 db/cmp frontends frontends.table
@@ -45,11 +45,11 @@ lb/maps-dump lbmaps-updated.actual
 * cmp lbmaps-updated.expected lbmaps-updated.actual
 
 # Cleanup. Backends first in this test.
-k8s delete endpointslice.yaml endpointslice2.yaml
+k8s/delete endpointslice.yaml endpointslice2.yaml
 db/cmp backends backends_empty.table
 db/cmp frontends frontends_nobackends.table
 
-k8s delete service.yaml service2.yaml
+k8s/delete service.yaml service2.yaml
 db/cmp frontends frontends_empty.table
 db/cmp services services_empty.table
 

--- a/pkg/loadbalancer/experimental/testdata/nodeport-explicit-maglev.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport-explicit-maglev.txtar
@@ -5,7 +5,7 @@ db/insert node-addresses addrv4.yaml
 db/cmp node-addresses nodeaddrs.table
 
 # Add the first service before starting (List() path)
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 
 # Start the test application
 hive start
@@ -19,7 +19,7 @@ db/initialized
 # have the ID assigned.
 db/cmp frontends frontends1.table
 
-k8s add service2.yaml endpointslice2.yaml
+k8s/add service2.yaml endpointslice2.yaml
 
 db/cmp services services.table
 db/cmp frontends frontends.table
@@ -31,11 +31,11 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
 
 # Cleanup. Backends first in this test.
-k8s delete endpointslice.yaml endpointslice2.yaml
+k8s/delete endpointslice.yaml endpointslice2.yaml
 db/cmp backends backends_empty.table
 db/cmp frontends frontends_nobackends.table
 
-k8s delete service.yaml service2.yaml
+k8s/delete service.yaml service2.yaml
 db/cmp frontends frontends_empty.table
 db/cmp services services_empty.table
 

--- a/pkg/loadbalancer/experimental/testdata/nodeport-explicit-random.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport-explicit-random.txtar
@@ -5,7 +5,7 @@ db/insert node-addresses addrv4.yaml
 db/cmp node-addresses nodeaddrs.table
 
 # Add the first service before starting (List() path)
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 
 # Start the test application
 hive start
@@ -19,7 +19,7 @@ db/initialized
 # have the ID assigned.
 db/cmp frontends frontends1.table
 
-k8s add service2.yaml endpointslice2.yaml
+k8s/add service2.yaml endpointslice2.yaml
 
 db/cmp services services.table
 db/cmp frontends frontends.table
@@ -31,11 +31,11 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
 
 # Cleanup. Backends first in this test.
-k8s delete endpointslice.yaml endpointslice2.yaml
+k8s/delete endpointslice.yaml endpointslice2.yaml
 db/cmp backends backends_empty.table
 db/cmp frontends frontends_nobackends.table
 
-k8s delete service.yaml service2.yaml
+k8s/delete service.yaml service2.yaml
 db/cmp frontends frontends_empty.table
 db/cmp services services_empty.table
 

--- a/pkg/loadbalancer/experimental/testdata/nodeport-maglev.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport-maglev.txtar
@@ -5,7 +5,7 @@ db/insert node-addresses addrv4.yaml
 db/cmp node-addresses nodeaddrs.table
 
 # Add the first service before starting (List() path)
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 
 # Start the test application
 hive start
@@ -19,7 +19,7 @@ db/initialized
 # have the ID assigned.
 db/cmp frontends frontends1.table
 
-k8s add service2.yaml endpointslice2.yaml
+k8s/add service2.yaml endpointslice2.yaml
 
 db/cmp services services.table
 db/cmp frontends frontends.table
@@ -30,11 +30,11 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
 
 # Cleanup. Backends first in this test.
-k8s delete endpointslice.yaml endpointslice2.yaml
+k8s/delete endpointslice.yaml endpointslice2.yaml
 db/cmp backends backends_empty.table
 db/cmp frontends frontends_nobackends.table
 
-k8s delete service.yaml service2.yaml
+k8s/delete service.yaml service2.yaml
 db/cmp frontends frontends_empty.table
 db/cmp services services_empty.table
 

--- a/pkg/loadbalancer/experimental/testdata/nodeport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport.txtar
@@ -5,7 +5,7 @@ db/insert node-addresses addrv4.yaml
 db/cmp node-addresses nodeaddrs.table
 
 # Add the first service before starting (List() path)
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 
 # Start the test application
 hive start
@@ -19,7 +19,7 @@ db/initialized
 # have the ID assigned.
 db/cmp frontends frontends1.table
 
-k8s add service2.yaml endpointslice2.yaml
+k8s/add service2.yaml endpointslice2.yaml
 
 db/cmp services services.table
 db/cmp frontends frontends.table
@@ -30,11 +30,11 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
 
 # Cleanup. Backends first in this test.
-k8s delete endpointslice.yaml endpointslice2.yaml
+k8s/delete endpointslice.yaml endpointslice2.yaml
 db/cmp backends backends_empty.table
 db/cmp frontends frontends_nobackends.table
 
-k8s delete service.yaml service2.yaml
+k8s/delete service.yaml service2.yaml
 db/cmp frontends frontends_empty.table
 db/cmp services services_empty.table
 

--- a/pkg/loadbalancer/experimental/testdata/pruning.txtar
+++ b/pkg/loadbalancer/experimental/testdata/pruning.txtar
@@ -6,7 +6,7 @@ hive start
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
 db/initialized
 
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table 
@@ -25,7 +25,7 @@ cmp lbmaps.expected lbmaps.actual
 lb/maps-snapshot
 
 # Cleanup
-k8s delete service.yaml endpointslice.yaml 
+k8s/delete service.yaml endpointslice.yaml 
 db/cmp services services_empty.table
 db/cmp frontends frontends_empty.table
 db/cmp backends backends_empty.table

--- a/pkg/loadbalancer/experimental/testdata/source-ranges.txtar
+++ b/pkg/loadbalancer/experimental/testdata/source-ranges.txtar
@@ -6,7 +6,7 @@ hive start
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
 db/initialized
 
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table 
@@ -15,7 +15,7 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
 
 # Cleanup
-k8s delete service.yaml endpointslice.yaml 
+k8s/delete service.yaml endpointslice.yaml 
 db/cmp services services_empty.table
 db/cmp frontends frontends_empty.table
 db/cmp backends backends_empty.table

--- a/pkg/loadbalancer/experimental/testdata/trafficpolicy.txtar
+++ b/pkg/loadbalancer/experimental/testdata/trafficpolicy.txtar
@@ -8,7 +8,7 @@ db/initialized
 
 # Create a LoadBalancer service with Local traffic policies and associate two backends 
 # to it, one of them on this node ("testnode") and one on another node.
-k8s add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table 

--- a/pkg/option/resolver/resolver_test.go
+++ b/pkg/option/resolver/resolver_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +52,7 @@ func TestWriteConfigurations(t *testing.T) {
 func TestResolveConfigurations(t *testing.T) {
 	testNS := "test-ns"
 	g := gomega.NewWithT(t)
-	clients, _ := k8sClient.NewFakeClientset()
+	clients, _ := k8sClient.NewFakeClientset(hivetest.Logger(t))
 
 	fakeNode := corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -183,7 +184,7 @@ func TestResolveConfigurations(t *testing.T) {
 func TestWithBlockedFields(t *testing.T) {
 	testNS := "test-ns"
 	g := gomega.NewWithT(t)
-	clients, _ := k8sClient.NewFakeClientset()
+	clients, _ := k8sClient.NewFakeClientset(hivetest.Logger(t))
 
 	fakeNode := corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -347,7 +348,7 @@ func TestReadNodeConfigs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 
-			clients, _ := k8sClient.NewFakeClientset()
+			clients, _ := k8sClient.NewFakeClientset(hivetest.Logger(t))
 
 			fakeNode := corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
@@ -462,7 +463,7 @@ func TestReadNodeConfigsAlpha(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 
-			clients, _ := k8sClient.NewFakeClientset()
+			clients, _ := k8sClient.NewFakeClientset(hivetest.Logger(t))
 
 			fakeNode := corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -68,7 +68,7 @@ func (cpt *ControlPlaneTest) AgentDB() (*statedb.DB, statedb.Table[datapathTable
 }
 
 func NewControlPlaneTest(t *testing.T, nodeName string, k8sVersion string) *ControlPlaneTest {
-	clients, _ := k8sClient.NewFakeClientset()
+	clients, _ := k8sClient.NewFakeClientset(hivetest.Logger(t))
 	var w lock.Map[string, struct{}]
 	clients.KubernetesFakeClientset = augmentTracker(clients.KubernetesFakeClientset, t, &w)
 	clients.SlimFakeClientset = augmentTracker(clients.SlimFakeClientset, t, &w)


### PR DESCRIPTION
Flatten the 'k8s' command into 'k8s/add', 'k8s/delete' etc. Add new commands for inspecting the object trackers and for waiting for watchers to come up (to avoid the race between List and Watch).

NewFakeClientset now takes a logger so it can log a warning if we see multiple Watch() calls for the same resource.

 ```
debug> help k8s
k8s/add files...
        Add new K8s object(s) to the object trackers

        The files should be YAML, e.g. in the format produced by
        'kubectl get -o yaml'
k8s/delete files...
        Delete K8s object(s) from the object trackers
k8s/get [-o] [--out=string] resource name
        Get a K8s object from the object trackers

        Tries object trackers in order. Prefers the slim over
        kubernetes.
        For list of resources run 'k8s/resources'

        Flags:
          -o, --out string   File to write to instead of stdout

k8s/list [-o] [--out=string] resource namespace
        List K8s objects in the object trackers

        For example to list pods in any namespace: k8s/list v1.pods
        ''
        Run 'k8s/resources' for a list of seen resources.

        Flags:
          -o, --out string   File to write to instead of stdout

k8s/resources
        List which resources have been seen by the fake client
k8s/summary
        Show a summary of object trackers

        Lists each object tracker and the objects stored within.
k8s/update files...
        Update K8s object(s) in the object trackers
k8s/wait-watchers resources...
        Wait for watchers for given resources to appear

        Takes a list of resources and waits for a Watch() to appear
        for it.

        Useful when working with an informer/reflector that is not
        backed by
        a StateDB table and thus cannot use 'db/initialized'.

debug> k8s/summary
slim:
- v1.pods: 1
cilium:
mcs:
apiext:
kubernetes:
- v1.pods: 1
debug> k8s/list v1.pods ''
[stdout]
items:
- apiVersion: v1
  kind: Pod
  metadata:
    labels:
      run: nginx
    name: nginx
...
debug> k8s/get v1.pods default/nginx -o nginx.yaml
```

