### PR TITLE
daemon: Write CNI configuration with 0600 permissions

### DIFF
--- a/daemon/cmd/cni/config.go
+++ b/daemon/cmd/cni/config.go
@@ -318,7 +318,7 @@ func (c *cniConfigManager) setupCNIConfFile() (err error) {
 			c.log.Debugf("Failed to read existing CNI configuration file %s: %v", dest, err)
 		}
 		// commit CNI config
-		if err := renameio.WriteFile(dest, contents, 0644); err != nil {
+		if err := renameio.WriteFile(dest, contents, 0600); err != nil {
 			return fmt.Errorf("failed to write CNI configuration file at %s: %w", dest, err)
 		}
 		c.log.Infof("Wrote CNI configuration file to %s", dest)


### PR DESCRIPTION
This change writes out the `/etc/cni/net.d/05-cilium.conflist` file with 0600 permissions, which conforms to 1.1.9 of the CIS Benchmark for Kubernetes:

1.1.9 | Ensure that the Container Network Interface file permissions are set to 600 or more restrictive

```release-note
daemon: write CNI configuration with 0600 permissions
```
