### PR TITLE
Per-CPU policy stats

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -60,6 +60,7 @@ cilium-agent [flags]
       --bpf-neigh-global-max int                                  Maximum number of entries for the global BPF neighbor table (default 524288)
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --bpf-policy-map-max int                                    Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
+      --bpf-policy-stats-map-max int                              Maximum number of entries in bpf policy stats map (default 65536)
       --bpf-root string                                           Path to BPF filesystem
       --bpf-sock-rev-map-max int                                  Maximum number of entries for the SockRevNAT BPF map (default 262144)
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -16,6 +16,8 @@ cilium-agent hive [flags]
       --bpf-lb-maglev-hash-seed string                            Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
       --bpf-lb-maglev-table-size uint                             Maglev per service backend table size (parameter M, one of: [251 509 1021 2039 4093 8191 16381 32749 65521 131071]) (default 16381)
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
+      --bpf-policy-map-max int                                    Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
+      --bpf-policy-stats-map-max int                              Maximum number of entries in bpf policy stats map (default 65536)
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --cluster-id uint32                                         Unique identifier of the cluster
       --cluster-name string                                       Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -22,6 +22,8 @@ cilium-agent hive dot-graph [flags]
       --bpf-lb-maglev-hash-seed string                            Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
       --bpf-lb-maglev-table-size uint                             Maglev per service backend table size (parameter M, one of: [251 509 1021 2039 4093 8191 16381 32749 65521 131071]) (default 16381)
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
+      --bpf-policy-map-max int                                    Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
+      --bpf-policy-stats-map-max int                              Maximum number of entries in bpf policy stats map (default 65536)
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --cluster-id uint32                                         Unique identifier of the cluster
       --cluster-name string                                       Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -424,6 +424,10 @@
      - Configure the maximum number of entries in endpoint policy map (per endpoint). @schema type: [null, integer] @schema
      - int
      - ``16384``
+   * - :spelling:ignore:`bpf.policyStatsMapMax`
+     - Configure the maximum number of entries in global policy stats map. @schema type: [null, integer] @schema
+     - int
+     - ``65536``
    * - :spelling:ignore:`bpf.preallocateMaps`
      - Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency.
      - bool

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -391,7 +391,7 @@ struct policy_key {
 	__u8		egress:1,
 			pad:7;
 	__u8		protocol; /* can be wildcarded if 'dport' is fully wildcarded */
-	__u16		dport; /* can be wildcarded with CIDR-like prefix */
+	__be16		dport; /* can be wildcarded with CIDR-like prefix */
 };
 
 /* POLICY_FULL_PREFIX gets full prefix length of policy_key */
@@ -408,8 +408,6 @@ struct policy_entry {
 	__u8		proxy_port_priority;
 	__u8		pad1;
 	__u16	        pad2;
-	__u64		packets;
-	__u64		bytes;
 };
 
 /*
@@ -418,6 +416,25 @@ struct policy_entry {
  */
 #define LPM_PROTO_PREFIX_BITS 8                             /* protocol specified */
 #define LPM_FULL_PREFIX_BITS (LPM_PROTO_PREFIX_BITS + 16)   /* protocol and dport specified */
+
+/*
+ * policy_stats_key has the same layout as policy_key, apart from the first four bytes.
+ */
+struct policy_stats_key {
+	__u16		endpoint_id;
+	__u8		pad1;
+	__u8		prefix_len;
+	__u32		sec_label;
+	__u8		egress:1,
+			pad:7;
+	__u8		protocol; /* can be wildcarded if 'dport' is fully wildcarded */
+	__be16		dport; /* can be wildcarded with CIDR-like prefix */
+};
+
+struct policy_stats_value {
+	__u64		packets;
+	__u64		bytes;
+};
 
 struct auth_key {
 	__u32       local_sec_label;

--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -84,6 +84,18 @@ struct {
 } POLICY_MAP __section_maps_btf;
 #endif
 
+#ifdef POLICY_STATS_MAP
+/* Global policy stats map */
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_PERCPU_HASH);
+	__type(key, struct policy_stats_key);
+	__type(value, struct policy_stats_value);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, POLICY_STATS_MAP_SIZE);
+	__uint(map_flags, BPF_F_NO_COMMON_LRU);
+} POLICY_STATS_MAP __section_maps_btf;
+#endif
+
 #ifdef AUTH_MAP
 /* Global auth map for enforcing authentication policy */
 struct {

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -10,21 +10,77 @@
 #include "eps.h"
 #include "maps.h"
 
+#ifdef POLICY_STATS_MAP
+
+/*
+ * Both non-host and host EP programs have HOST_EP_ID defined, but only non-host EPs have LXC_ID
+ * defined. Hence, if LXC_ID is defined, we are doing policy for a non-host EP, otherwise for the
+ * host EP.
+ */
+#ifdef LXC_ID
+#define EFFECTIVE_EP_ID LXC_ID
+#else
+#define EFFECTIVE_EP_ID HOST_EP_ID
+#endif
+
+static __always_inline void
+__policy_account(__u32 remote_id, __u8 egress, __u8 proto, __be16 dport, __u8 lpm_prefix_length,
+		 __u64 bytes)
+{
+	struct policy_stats_value *value;
+	struct policy_stats_key stats_key = {
+		.endpoint_id = EFFECTIVE_EP_ID,
+		.pad1 = 0,
+		.prefix_len = lpm_prefix_length,
+		.sec_label = remote_id,
+		.egress = egress,
+		.pad = 0,
+	};
+
+	/*
+	 * Must compute the wildcarded protocol and port for the policy stats map key.
+	 * If bpf lookup ever returned the key of the matching entry we would not need
+	 * to do this.
+	 */
+	if (lpm_prefix_length <= LPM_PROTO_PREFIX_BITS) {
+		if (lpm_prefix_length < LPM_PROTO_PREFIX_BITS) {
+			/* Protocol is not partially maskable */
+			proto = 0;
+		}
+		dport = 0;
+	} else if (lpm_prefix_length < LPM_FULL_PREFIX_BITS) {
+		dport &= bpf_htons((__u16)(0xffff << (LPM_FULL_PREFIX_BITS - lpm_prefix_length)));
+	}
+	stats_key.protocol = proto;
+	stats_key.dport = dport;
+
+	value = map_lookup_elem(&POLICY_STATS_MAP, &stats_key);
+
+	if (value) {
+		__sync_fetch_and_add(&value->packets, 1);
+		__sync_fetch_and_add(&value->bytes, bytes);
+	} else {
+		struct policy_stats_value newval = { 1, bytes };
+
+		map_update_elem(&POLICY_STATS_MAP, &stats_key, &newval, BPF_NOEXIST);
+	}
+}
+#else
+static __always_inline void
+__policy_account(__u32 remote_id, __u8 egress, __u8 proto, __be16 dport, __u8 lpm_prefix_length,
+		 __u64 bytes)
+{}
+#endif
+
 static __always_inline int
-__account_and_check(struct __ctx_buff *ctx __maybe_unused, struct policy_entry *policy,
-		    const struct policy_entry *policy2, __s8 *ext_err, __u16 *proxy_port)
+__policy_check(struct policy_entry *policy, const struct policy_entry *policy2, __s8 *ext_err,
+	       __u16 *proxy_port)
 {
 	/* auth_type is derived from the matched policy entry, except if both L3/L4 and L4-only
 	 * match, and the chosen policy has no explicit auth type: in this case the auth type is
 	 * derived from the less specific policy entry.
 	 */
 	__u8 auth_type;
-
-#ifdef POLICY_ACCOUNTING
-	/* FIXME: Use per cpu counters */
-	__sync_fetch_and_add(&policy->packets, 1);
-	__sync_fetch_and_add(&policy->bytes, ctx_full_len(ctx));
-#endif
 
 	if (unlikely(policy->deny))
 		return DROP_POLICY_DENY;
@@ -61,7 +117,7 @@ __account_and_check(struct __ctx_buff *ctx __maybe_unused, struct policy_entry *
 
 static __always_inline int
 __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
-		    __u32 remote_id, __u16 ethertype __maybe_unused, __u16 dport,
+		    __u32 remote_id, __u16 ethertype __maybe_unused, __be16 dport,
 		    __u8 proto, int off __maybe_unused, int dir,
 		    bool is_untracked_fragment, __u8 *match_type, __s8 *ext_err,
 		    __u16 *proxy_port)
@@ -168,19 +224,25 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 check_policy:
 	cilium_dbg3(ctx, DBG_L4_CREATE, remote_id, local_id, dport << 16 | proto);
 	p_len = policy->lpm_prefix_length;
+#ifdef POLICY_ACCOUNTING
+	__policy_account(remote_id, key.egress, proto, dport, p_len, ctx_full_len(ctx));
+#endif
 	*match_type =
 		p_len > LPM_PROTO_PREFIX_BITS ? POLICY_MATCH_L3_L4 :	/* 1. id/proto/port */
 		p_len > 0 ? POLICY_MATCH_L3_PROTO :			/* 3. id/proto/ANY */
 		POLICY_MATCH_L3_ONLY;					/* 5. id/ANY/ANY */
-	return __account_and_check(ctx, policy, l4policy, ext_err, proxy_port);
+	return __policy_check(policy, l4policy, ext_err, proxy_port);
 
 check_l4_policy:
 	p_len = l4policy->lpm_prefix_length;
+#ifdef POLICY_ACCOUNTING
+	__policy_account(0, key.egress, proto, dport, p_len, ctx_full_len(ctx));
+#endif
 	*match_type =
 		p_len == 0 ? POLICY_MATCH_ALL :					/* 6. ANY/ANY/ANY */
 		p_len <= LPM_PROTO_PREFIX_BITS ? POLICY_MATCH_PROTO_ONLY :	/* 4. ANY/proto/ANY */
 		POLICY_MATCH_L4_ONLY;						/* 2. ANY/proto/port */
-	return __account_and_check(ctx, l4policy, policy, ext_err, proxy_port);
+	return __policy_check(l4policy, policy, ext_err, proxy_port);
 }
 
 /**
@@ -205,7 +267,7 @@ check_l4_policy:
  */
 static __always_inline int
 policy_can_ingress(struct __ctx_buff *ctx, const void *map, __u32 src_id, __u32 dst_id,
-		   __u16 ethertype, __u16 dport, __u8 proto, int l4_off,
+		   __u16 ethertype, __be16 dport, __u8 proto, int l4_off,
 		   bool is_untracked_fragment, __u8 *match_type, __u8 *audited,
 		   __s8 *ext_err, __u16 *proxy_port)
 {
@@ -255,7 +317,7 @@ static __always_inline int policy_can_ingress4(struct __ctx_buff *ctx,
 }
 
 #ifdef HAVE_ENCAP
-static __always_inline bool is_encap(__u16 dport, __u8 proto)
+static __always_inline bool is_encap(__be16 dport, __u8 proto)
 {
 	return proto == IPPROTO_UDP && dport == bpf_htons(TUNNEL_PORT);
 }
@@ -263,7 +325,7 @@ static __always_inline bool is_encap(__u16 dport, __u8 proto)
 
 static __always_inline int
 policy_can_egress(struct __ctx_buff *ctx, const void *map, __u32 src_id, __u32 dst_id,
-		  __u16 ethertype, __u16 dport, __u8 proto, int l4_off, __u8 *match_type,
+		  __u16 ethertype, __be16 dport, __u8 proto, int l4_off, __u8 *match_type,
 		  __u8 *audited, __s8 *ext_err, __u16 *proxy_port)
 {
 	int ret;

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -142,6 +142,8 @@ volatile const __u64 __config_ROUTER_IP_2;
 #define METRICS_MAP test_cilium_metrics
 #define AUTH_MAP test_cilium_auth
 #define CONFIG_MAP test_cilium_runtime_config
+#define POLICY_STATS_MAP test_cilium_policy_stats
+#define POLICY_STATS_MAP_SIZE 200
 #define IPCACHE_MAP test_cilium_ipcache
 #define NODE_MAP_V2 test_cilium_node_map
 #define ENCRYPT_MAP test_cilium_encrypt_state

--- a/cilium-dbg/cmd/bpf_policy_get.go
+++ b/cilium-dbg/cmd/bpf_policy_get.go
@@ -193,9 +193,17 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 		} else {
 			policyStr = "Allow"
 		}
+		packets := "-"
+		if stat.Packets != policymap.StatNotAvailable {
+			packets = strconv.FormatUint(stat.Packets, 10)
+		}
+		bytes := "-"
+		if stat.Bytes != policymap.StatNotAvailable {
+			bytes = strconv.FormatUint(stat.Bytes, 10)
+		}
 		if printIDs {
-			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\t%d\t%d\t%d\t\n",
-				policyStr, trafficDirectionString, id, port, proxyPort, stat.AuthRequirement.AuthType(), stat.Bytes, stat.Packets, prefixLen)
+			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%d\t\n",
+				policyStr, trafficDirectionString, id, port, proxyPort, stat.AuthRequirement.AuthType(), bytes, packets, prefixLen)
 		} else if lbls := labelsID[id]; lbls != nil && len(lbls.Labels) > 0 {
 			first := true
 			for _, lbl := range lbls.Labels.GetPrintableModel() {
@@ -203,16 +211,16 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 					lbl = "ANY"
 				}
 				if first {
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t\n",
-						policyStr, trafficDirectionString, lbl, port, proxyPort, stat.AuthRequirement.AuthType(), stat.Bytes, stat.Packets, prefixLen)
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t\n",
+						policyStr, trafficDirectionString, lbl, port, proxyPort, stat.AuthRequirement.AuthType(), bytes, packets, prefixLen)
 					first = false
 				} else {
 					fmt.Fprintf(w, "\t\t%s\t\t\t\t\t\t\t\n", lbl)
 				}
 			}
 		} else {
-			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\t%d\t%d\t%d\t\n",
-				policyStr, trafficDirectionString, id, port, proxyPort, stat.AuthRequirement.AuthType(), stat.Bytes, stat.Packets, prefixLen)
+			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%d\t\n",
+				policyStr, trafficDirectionString, id, port, proxyPort, stat.AuthRequirement.AuthType(), bytes, packets, prefixLen)
 		}
 	}
 }

--- a/cilium-dbg/cmd/bpf_policy_get.go
+++ b/cilium-dbg/cmd/bpf_policy_get.go
@@ -117,7 +117,7 @@ func listMap(args []string) {
 }
 
 func mapContent(file string) policymap.PolicyEntriesDump {
-	m, err := policymap.Open(file)
+	m, err := policymap.OpenPolicyMap(file)
 	if err != nil {
 		Fatalf("Failed to open map: %s\n", err)
 	}

--- a/cilium-dbg/cmd/bpf_policy_get.go
+++ b/cilium-dbg/cmd/bpf_policy_get.go
@@ -177,7 +177,7 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 			policyTitle, trafficDirectionTitle, labelsDesTitle, portTitle, proxyPortTitle, authTypeTitle, bytesTitle, packetsTitle, prefixTitle)
 	}
 	for _, stat := range statsMap {
-		prefixLen := stat.Key.Prefixlen - policymap.StaticPrefixBits
+		prefixLen := stat.Key.GetPrefixLen()
 		id := identity.NumericIdentity(stat.Key.Identity)
 		trafficDirection := trafficdirection.TrafficDirection(stat.Key.TrafficDirection)
 		trafficDirectionString := trafficDirection.String()

--- a/cilium-dbg/cmd/helpers.go
+++ b/cilium-dbg/cmd/helpers.go
@@ -332,7 +332,7 @@ func updatePolicyKey(pa *PolicyUpdateArgs, add bool) {
 	// The map needs not to be transparently initialized here even if
 	// it's not present for some reason. Triggering map recreation with
 	// OpenOrCreate when some map attribute had changed would be much worse.
-	policyMap, err := policymap.Open(pa.path)
+	policyMap, err := policymap.OpenPolicyMap(pa.path)
 	if err != nil {
 		Fatalf("Cannot open policymap %q : %s", pa.path, err)
 	}

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/launcher"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/netns"
@@ -221,6 +222,7 @@ type EndpointAdder interface {
 // cleanup of prior cilium-health endpoint instances.
 func LaunchAsEndpoint(baseCtx context.Context,
 	owner regeneration.Owner,
+	policyMapFactory policymap.Factory,
 	policyGetter policyRepoGetter,
 	ipcache *ipcache.IPCache,
 	mtuConfig mtu.MTU,
@@ -319,7 +321,7 @@ func LaunchAsEndpoint(baseCtx context.Context,
 	}
 
 	// Create the endpoint
-	ep, err := endpoint.NewEndpointFromChangeModel(baseCtx, owner, policyGetter, ipcache, nil, allocator, ctMapGC, info)
+	ep, err := endpoint.NewEndpointFromChangeModel(baseCtx, owner, policyMapFactory, policyGetter, ipcache, nil, allocator, ctMapGC, info)
 	if err != nil {
 		return nil, fmt.Errorf("Error while creating endpoint model: %w", err)
 	}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -57,7 +57,6 @@ import (
 	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
-	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitoragent "github.com/cilium/cilium/pkg/monitor/agent"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -315,7 +314,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	}
 
 	ctmap.InitMapInfo(option.Config.EnableIPv4, option.Config.EnableIPv6, option.Config.EnableNodePort)
-	policymap.InitMapInfo(option.Config.PolicyMapEntries)
 
 	lbmapInitParams := lbmap.InitParams{
 		IPv4: option.Config.EnableIPv4,

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -57,6 +57,7 @@ import (
 	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitoragent "github.com/cilium/cilium/pkg/monitor/agent"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -129,6 +130,8 @@ type Daemon struct {
 
 	// ipam is the IP address manager of the agent
 	ipam *ipam.IPAM
+
+	policyMapFactory policymap.Factory
 
 	endpointManager endpointmanager.EndpointManager
 
@@ -388,6 +391,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		bigTCPConfig:      params.BigTCPConfig,
 		tunnelConfig:      params.TunnelConfig,
 		bwManager:         params.BandwidthManager,
+		policyMapFactory:  params.PolicyMapFactory,
 		endpointManager:   params.EndpointManager,
 		k8sWatcher:        params.K8sWatcher,
 		k8sSvcCache:       params.K8sSvcCache,

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -83,6 +83,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/nat"
 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -1526,6 +1527,7 @@ type daemonParams struct {
 	NodeHandler         datapath.NodeHandler
 	NodeNeighbors       datapath.NodeNeighbors
 	NodeAddressing      datapath.NodeAddressing
+	PolicyMapFactory    policymap.Factory
 	EndpointManager     endpointmanager.EndpointManager
 	CertManager         certificatemanager.CertificateManager
 	SecretManager       certificatemanager.SecretManager
@@ -1725,7 +1727,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 	} else {
 		log.Info("Creating host endpoint")
 		err := d.endpointManager.AddHostEndpoint(
-			d.ctx, d, d, d.ipcache, d.l7Proxy, d.identityAllocator, d.ctMapGC)
+			d.ctx, d, d.policyMapFactory, d, d.ipcache, d.l7Proxy, d.identityAllocator, d.ctMapGC)
 		if err != nil {
 			return fmt.Errorf("unable to create host endpoint: %w", err)
 		}
@@ -1741,7 +1743,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 			} else {
 				log.Info("Creating ingress endpoint")
 				err := d.endpointManager.AddIngressEndpoint(
-					d.ctx, d, d, d.ipcache, d.l7Proxy, d.identityAllocator, d.ctMapGC)
+					d.ctx, d, d.policyMapFactory, d, d.ipcache, d.l7Proxy, d.identityAllocator, d.ctMapGC)
 				if err != nil {
 					return fmt.Errorf("unable to create ingress endpoint: %w", err)
 				}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -83,7 +83,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/nat"
 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
-	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -781,9 +780,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 
 	flags.Int(option.NeighMapEntriesGlobalName, option.NATMapEntriesGlobalDefault, "Maximum number of entries for the global BPF neighbor table")
 	option.BindEnv(vp, option.NeighMapEntriesGlobalName)
-
-	flags.Int(option.PolicyMapEntriesName, policymap.MaxEntries, "Maximum number of entries in endpoint policy map (per endpoint)")
-	option.BindEnv(vp, option.PolicyMapEntriesName)
 
 	flags.Duration(option.PolicyMapFullReconciliationIntervalName, 15*time.Minute, "Interval for full reconciliation of endpoint policy map")
 	option.BindEnv(vp, option.PolicyMapFullReconciliationIntervalName)

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -134,6 +135,7 @@ func setupDaemonSuite(tb testing.TB) *DaemonSuite {
 			func() *option.DaemonConfig { return option.Config },
 			func() cnicell.CNIConfigManager { return &fakecni.FakeCNIConfigManager{} },
 			func() ctmap.GCRunner { return ctmap.NewFakeGCRunner() },
+			func() policymap.Factory { return nil },
 			k8sSynced.RejectedCRDSyncPromise,
 		),
 		fakeDatapath.Cell,

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -182,10 +182,6 @@ func (d *Daemon) initMaps() error {
 		log.WithError(err).Fatal("Unable to initialize service maps")
 	}
 
-	if err := policymap.InitCallMaps(); err != nil {
-		return fmt.Errorf("initializing policy map: %w", err)
-	}
-
 	for _, ep := range d.endpointManager.GetEndpoints() {
 		ep.InitMap()
 	}

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -395,7 +395,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 	apiLabels := labels.NewLabelsFromModel(epTemplate.Labels)
 	epTemplate.Labels = nil
 
-	ep, err := endpoint.NewEndpointFromChangeModel(d.ctx, owner, d, d.ipcache, d.l7Proxy, d.identityAllocator, d.ctMapGC, epTemplate)
+	ep, err := endpoint.NewEndpointFromChangeModel(d.ctx, owner, d.policyMapFactory, d, d.ipcache, d.l7Proxy, d.identityAllocator, d.ctMapGC, epTemplate)
 	if err != nil {
 		return invalidDataError(ep, fmt.Errorf("unable to parse endpoint parameters: %w", err))
 	}
@@ -706,7 +706,7 @@ func patchEndpointIDHandler(d *Daemon, params PatchEndpointIDParams) middleware.
 
 	// Validate the template. Assignment afterwards is atomic.
 	// Note: newEp's labels are ignored.
-	newEp, err2 := endpoint.NewEndpointFromChangeModel(d.ctx, d, d, d.ipcache, d.l7Proxy, d.identityAllocator, d.ctMapGC, epTemplate)
+	newEp, err2 := endpoint.NewEndpointFromChangeModel(d.ctx, d, d.policyMapFactory, d, d.ipcache, d.l7Proxy, d.identityAllocator, d.ctMapGC, epTemplate)
 	if err2 != nil {
 		r.Error(err2, PutEndpointIDInvalidCode)
 		return api.Error(PutEndpointIDInvalidCode, err2)

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -82,6 +82,7 @@ func (d *Daemon) initHealth(spec *healthApi.Spec, cleaner *daemonCleanup, sysctl
 					client, err = health.LaunchAsEndpoint(
 						ctx,
 						d,
+						d.policyMapFactory,
 						d,
 						d.ipcache,
 						d.mtuConfig,

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -202,7 +202,7 @@ func (ds *DaemonSuite) prepareEndpoint(t *testing.T, identity *identity.Identity
 	if qa {
 		testEndpointID = testQAEndpointID
 	}
-	e := endpoint.NewTestEndpointWithState(ds.d, ds.d, testipcache.NewMockIPCache(), ds.d.l7Proxy, ds.d.identityAllocator, ds.d.ctMapGC, testEndpointID, endpoint.StateWaitingForIdentity)
+	e := endpoint.NewTestEndpointWithState(ds.d, ds.d.policyMapFactory, ds.d, testipcache.NewMockIPCache(), ds.d.l7Proxy, ds.d.identityAllocator, ds.d.ctMapGC, testEndpointID, endpoint.StateWaitingForIdentity)
 	e.SetPropertyValue(endpoint.PropertyFakeEndpoint, false)
 	e.SetPropertyValue(endpoint.PropertyWithouteBPFDatapath, true)
 	e.SetPropertyValue(endpoint.PropertySkipBPFPolicy, true)

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -180,7 +180,7 @@ func (d *Daemon) fetchOldEndpoints(dir string) (*endpointRestoreState, error) {
 	}
 	eptsID := endpoint.FilterEPDir(dirFiles)
 
-	state.possible = endpoint.ReadEPsFromDirNames(d.ctx, d, d, d.ipcache, dir, eptsID)
+	state.possible = endpoint.ReadEPsFromDirNames(d.ctx, d, d.policyMapFactory, d, d.ipcache, dir, eptsID)
 
 	if len(state.possible) == 0 {
 		log.Info("No old endpoints found.")

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -396,7 +396,7 @@ func (d *Daemon) getBPFMapStatus() *models.BPFMapStatus {
 				Size: int64(option.Config.CTMapEntriesGlobalTCP),
 			},
 			{
-				Name: "Endpoint policy",
+				Name: "Endpoints",
 				Size: int64(lxcmap.MaxEntries),
 			},
 			{
@@ -456,7 +456,7 @@ func (d *Daemon) getBPFMapStatus() *models.BPFMapStatus {
 				Size: int64(option.Config.NeighMapEntriesGlobal),
 			},
 			{
-				Name: "Global policy",
+				Name: "Endpoint policy",
 				Size: int64(option.Config.PolicyMapEntries),
 			},
 			{

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
-	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
 	"github.com/cilium/cilium/pkg/maps/timestamp"
 	tunnelmap "github.com/cilium/cilium/pkg/maps/tunnel"
@@ -458,7 +457,11 @@ func (d *Daemon) getBPFMapStatus() *models.BPFMapStatus {
 			},
 			{
 				Name: "Endpoint policy",
-				Size: int64(policymap.MaxEntries),
+				Size: int64(d.policyMapFactory.PolicyMaxEntries()),
+			},
+			{
+				Name: "Policy stats",
+				Size: int64(d.policyMapFactory.StatsMaxEntries()),
 			},
 			{
 				Name: "Session affinity",

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
 	"github.com/cilium/cilium/pkg/maps/timestamp"
 	tunnelmap "github.com/cilium/cilium/pkg/maps/tunnel"
@@ -457,7 +458,7 @@ func (d *Daemon) getBPFMapStatus() *models.BPFMapStatus {
 			},
 			{
 				Name: "Endpoint policy",
-				Size: int64(option.Config.PolicyMapEntries),
+				Size: int64(policymap.MaxEntries),
 			},
 			{
 				Name: "Session affinity",

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -156,6 +156,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.neighMax | int | `524288` | Configure the maximum number of entries for the neighbor table. |
 | bpf.nodeMapMax | int | `nil` | Configures the maximum number of entries for the node table. |
 | bpf.policyMapMax | int | `16384` | Configure the maximum number of entries in endpoint policy map (per endpoint). @schema type: [null, integer] @schema |
+| bpf.policyStatsMapMax | int | `65536` | Configure the maximum number of entries in global policy stats map. @schema type: [null, integer] @schema |
 | bpf.preallocateMaps | bool | `false` | Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency. |
 | bpf.root | string | `"/sys/fs/bpf"` | Configure the mount point for the BPF filesystem |
 | bpf.tproxy | bool | `false` | Configure the eBPF-based TPROXY (beta) to reduce reliance on iptables rules for implementing Layer 7 policy. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -443,6 +443,11 @@ data:
   # policy map (per endpoint)
   bpf-policy-map-max: "{{ .Values.bpf.policyMapMax | int }}"
 {{- end }}
+{{- if hasKey .Values.bpf "policyStatsMapMax" }}
+  # bpf-policy-stats-map-max specifies the maximum number of entries in global
+  # policy stats map
+  bpf-policy-stats-map-max: "{{ .Values.bpf.policyStatsMapMax | int }}"
+{{- end }}
 {{- if hasKey .Values.bpf "lbMapMax" }}
   # bpf-lb-map-max specifies the maximum number of entries in bpf lb service,
   # backend and affinity maps.

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -639,6 +639,12 @@
             "integer"
           ]
         },
+        "policyStatsMapMax": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
         "preallocateMaps": {
           "type": "boolean"
         },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -575,6 +575,11 @@ bpf:
   # type: [null, integer]
   # @schema
   policyMapMax: 16384
+  # -- Configure the maximum number of entries in global policy stats map.
+  # @schema
+  # type: [null, integer]
+  # @schema
+  policyStatsMapMax: 65536
   # @schema
   # type: [null, number]
   # @schema

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -577,6 +577,11 @@ bpf:
   # type: [null, integer]
   # @schema
   policyMapMax: 16384
+  # -- Configure the maximum number of entries in global policy stats map.
+  # @schema
+  # type: [null, integer]
+  # @schema
+  policyStatsMapMax: 65536
   # @schema
   # type: [null, number]
   # @schema

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -195,7 +195,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	cDefinesMap["ENDPOINTS_MAP_SIZE"] = fmt.Sprintf("%d", lxcmap.MaxEntries)
 	cDefinesMap["METRICS_MAP"] = metricsmap.MapName
 	cDefinesMap["METRICS_MAP_SIZE"] = fmt.Sprintf("%d", metricsmap.MaxEntries)
-	cDefinesMap["POLICY_MAP_SIZE"] = fmt.Sprintf("%d", policymap.MaxEntries)
 	cDefinesMap["AUTH_MAP"] = authmap.MapName
 	cDefinesMap["AUTH_MAP_SIZE"] = fmt.Sprintf("%d", option.Config.AuthMapEntries)
 	cDefinesMap["CONFIG_MAP"] = configmap.MapName

--- a/pkg/ebpf/map.go
+++ b/pkg/ebpf/map.go
@@ -28,6 +28,7 @@ const (
 	HashOfMaps = ciliumebpf.HashOfMaps
 	LPMTrie    = ciliumebpf.LPMTrie
 	LRUHash    = ciliumebpf.LRUHash
+	LRUCPUHash = ciliumebpf.LRUCPUHash
 
 	PinNone   = ciliumebpf.PinNone
 	PinByName = ciliumebpf.PinByName

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
@@ -56,12 +57,12 @@ func (e *Endpoint) GetLabelsModel() (*models.LabelConfiguration, error) {
 }
 
 // NewEndpointFromChangeModel creates a new endpoint from a request
-func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, policyGetter policyRepoGetter, namedPortsGetter namedPortsGetter, proxy EndpointProxy, allocator cache.IdentityAllocator, ctMapGC ctmap.GCRunner, base *models.EndpointChangeRequest) (*Endpoint, error) {
+func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, policyMapFactory policymap.Factory, policyGetter policyRepoGetter, namedPortsGetter namedPortsGetter, proxy EndpointProxy, allocator cache.IdentityAllocator, ctMapGC ctmap.GCRunner, base *models.EndpointChangeRequest) (*Endpoint, error) {
 	if base == nil {
 		return nil, nil
 	}
 
-	ep := createEndpoint(owner, policyGetter, namedPortsGetter, proxy, allocator, ctMapGC, uint16(base.ID), base.InterfaceName)
+	ep := createEndpoint(owner, policyMapFactory, policyGetter, namedPortsGetter, proxy, allocator, ctMapGC, uint16(base.ID), base.InterfaceName)
 	ep.ifIndex = int(base.InterfaceIndex)
 	ep.containerIfName = base.ContainerInterfaceName
 	ep.parentIfIndex = int(base.ParentInterfaceIndex)

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -22,7 +22,7 @@ import (
 func TestWriteInformationalComments(t *testing.T) {
 	s := setupEndpointSuite(t)
 
-	e := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 100, StateWaitingForIdentity)
+	e := NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 100, StateWaitingForIdentity)
 
 	var f bytes.Buffer
 	err := e.writeInformationalComments(&f)
@@ -36,7 +36,7 @@ func BenchmarkWriteHeaderfile(b *testing.B) {
 
 	s := setupEndpointSuite(b)
 
-	e := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 100, StateWaitingForIdentity)
+	e := NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 100, StateWaitingForIdentity)
 	configWriter := &config.HeaderfileWriter{}
 	cfg := datapath.LocalNodeConfiguration{}
 

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -18,7 +18,7 @@ import (
 func TestGetCiliumEndpointStatus(t *testing.T) {
 	s := setupEndpointSuite(t)
 
-	e, err := NewEndpointFromChangeModel(context.TODO(), s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, s.mgr, ctmap.NewFakeGCRunner(), &models.EndpointChangeRequest{
+	e, err := NewEndpointFromChangeModel(context.TODO(), s, nil, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, s.mgr, ctmap.NewFakeGCRunner(), &models.EndpointChangeRequest{
 		Addressing: &models.AddressPair{
 			IPV4: "192.168.1.100",
 			IPV6: "f00d::a10:0:0:abcd",

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -252,7 +252,7 @@ func TestEndpointStatus(t *testing.T) {
 func TestEndpointDatapathOptions(t *testing.T) {
 	s := setupEndpointSuite(t)
 
-	e, err := NewEndpointFromChangeModel(context.TODO(), s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, s.mgr, ctmap.NewFakeGCRunner(), &models.EndpointChangeRequest{
+	e, err := NewEndpointFromChangeModel(context.TODO(), s, nil, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, s.mgr, ctmap.NewFakeGCRunner(), &models.EndpointChangeRequest{
 		DatapathConfiguration: &models.EndpointDatapathConfiguration{
 			DisableSipVerification: true,
 		},
@@ -264,7 +264,7 @@ func TestEndpointDatapathOptions(t *testing.T) {
 func TestEndpointUpdateLabels(t *testing.T) {
 	s := setupEndpointSuite(t)
 
-	e := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 100, StateWaitingForIdentity)
+	e := NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 100, StateWaitingForIdentity)
 
 	// Test that inserting identity labels works
 	rev := e.replaceIdentityLabels(labels.LabelSourceAny, labels.Map2Labels(map[string]string{"foo": "bar", "zip": "zop"}, "cilium"))
@@ -305,7 +305,7 @@ func TestEndpointUpdateLabels(t *testing.T) {
 func TestEndpointState(t *testing.T) {
 	s := setupEndpointSuite(t)
 
-	e := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 100, StateWaitingForIdentity)
+	e := NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 100, StateWaitingForIdentity)
 	e.unconditionalLock()
 	defer e.unlock()
 
@@ -696,7 +696,7 @@ func TestEndpointEventQueueDeadlockUponStop(t *testing.T) {
 		option.Config.EndpointQueueSize = oldQueueSize
 	}()
 
-	ep := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 12345, StateReady)
+	ep := NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 12345, StateReady)
 
 	ep.properties[PropertyFakeEndpoint] = true
 	ep.properties[PropertySkipBPFPolicy] = true
@@ -772,7 +772,7 @@ func TestEndpointEventQueueDeadlockUponStop(t *testing.T) {
 func BenchmarkEndpointGetModel(b *testing.B) {
 	s := setupEndpointSuite(b)
 
-	e := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 123, StateWaitingForIdentity)
+	e := NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 123, StateWaitingForIdentity)
 
 	for i := 0; i < 256; i++ {
 		e.LogStatusOK(BPF, "Hello World!")
@@ -847,7 +847,7 @@ func TestMetadataResolver(t *testing.T) {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 
-				ep := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{},
+				ep := NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{},
 					testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 123, StateWaitingForIdentity)
 				ep.K8sNamespace, ep.K8sPodName, ep.K8sUID = "bar", "foo", "uid"
 

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -26,7 +26,7 @@ func TestEndpointLogFormat(t *testing.T) {
 
 	// Default log format is text
 	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())}
-	ep := NewTestEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 12345, StateReady)
+	ep := NewTestEndpointWithState(do, nil, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 12345, StateReady)
 
 	_, ok := ep.getLogger().Logger.Formatter.(*logrus.TextFormatter)
 	require.True(t, ok)
@@ -37,7 +37,7 @@ func TestEndpointLogFormat(t *testing.T) {
 		logging.SetLogFormat(logging.LogFormatText)
 	}()
 	do = &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())}
-	ep = NewTestEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 12345, StateReady)
+	ep = NewTestEndpointWithState(do, nil, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 12345, StateReady)
 
 	_, ok = ep.getLogger().Logger.Formatter.(*logrus.JSONFormatter)
 	require.True(t, ok)
@@ -47,7 +47,7 @@ func TestPolicyLog(t *testing.T) {
 	setupEndpointSuite(t)
 
 	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil, api.NewPolicyMetricsNoop())}
-	ep := NewTestEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 12345, StateReady)
+	ep := NewTestEndpointWithState(do, nil, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 12345, StateReady)
 
 	// Initially nil
 	policyLogger := ep.getPolicyLogger()

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -214,7 +214,7 @@ const (
 )
 
 func (s *RedirectSuite) NewTestEndpoint(t *testing.T) *Endpoint {
-	ep := NewTestEndpointWithState(s.do, s.do, testipcache.NewMockIPCache(), s.rsp, s.mgr, ctmap.NewFakeGCRunner(), 12345, StateRegenerating)
+	ep := NewTestEndpointWithState(s.do, nil, s.do, testipcache.NewMockIPCache(), s.rsp, s.mgr, ctmap.NewFakeGCRunner(), 12345, StateRegenerating)
 	ep.SetPropertyValue(PropertyFakeEndpoint, false)
 
 	epIdentity, _, err := s.mgr.AllocateIdentity(context.Background(), labelsBar.Labels(), true, identityBar)

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
@@ -46,7 +47,7 @@ var (
 
 // ReadEPsFromDirNames returns a mapping of endpoint ID to endpoint of endpoints
 // from a list of directory names that can possible contain an endpoint.
-func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, policyGetter policyRepoGetter,
+func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, policyMapFactory policymap.Factory, policyGetter policyRepoGetter,
 	namedPortsGetter namedPortsGetter, basePath string, eptsDirNames []string) map[uint16]*Endpoint {
 
 	completeEPDirNames, incompleteEPDirNames := partitionEPDirNamesByRestoreStatus(eptsDirNames)
@@ -79,7 +80,7 @@ func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, policyGe
 			continue
 		}
 
-		ep, err := parseEndpoint(owner, policyGetter, namedPortsGetter, state)
+		ep, err := parseEndpoint(owner, policyMapFactory, policyGetter, namedPortsGetter, state)
 		if err != nil {
 			scopedLog.WithError(err).Warn("Unable to parse the C header file")
 			continue

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -58,7 +58,7 @@ func (s *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdentit
 	}
 	identity.Sanitize()
 
-	ep := NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), id, StateReady)
+	ep := NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), id, StateReady)
 	// Random network ID and docker endpoint ID with 59 hex chars + 5 strID = 64 hex chars
 	ep.dockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID
 	ep.dockerEndpointID = "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID
@@ -124,7 +124,7 @@ func TestReadEPsFromDirNames(t *testing.T) {
 			epsNames = append(epsNames, ep.DirectoryPath())
 		}
 	}
-	eps := ReadEPsFromDirNames(context.TODO(), s, s, s, tmpDir, epsNames)
+	eps := ReadEPsFromDirNames(context.TODO(), s, nil, s, s, tmpDir, epsNames)
 	require.Equal(t, len(epsWanted), len(eps))
 
 	sort.Slice(epsWanted, func(i, j int) bool { return epsWanted[i].ID < epsWanted[j].ID })
@@ -186,7 +186,7 @@ func TestReadEPsFromDirNamesWithRestoreFailure(t *testing.T) {
 		ep.DirectoryPath(), ep.NextDirectoryPath(),
 	}
 
-	epResult := ReadEPsFromDirNames(context.TODO(), s, s, s, tmpDir, epNames)
+	epResult := ReadEPsFromDirNames(context.TODO(), s, nil, s, s, tmpDir, epNames)
 	require.Len(t, epResult, 1)
 
 	restoredEP := epResult[ep.ID]
@@ -241,7 +241,7 @@ func BenchmarkReadEPsFromDirNames(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		eps := ReadEPsFromDirNames(context.TODO(), s, s, s, tmpDir, epsNames)
+		eps := ReadEPsFromDirNames(context.TODO(), s, nil, s, s, tmpDir, epsNames)
 		require.Equal(b, len(epsWanted), len(eps))
 	}
 }

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
@@ -98,6 +99,7 @@ type EndpointsModify interface {
 	AddIngressEndpoint(
 		ctx context.Context,
 		owner regeneration.Owner,
+		policyMapFactory policymap.Factory,
 		policyGetter policyRepoGetter,
 		ipcache *ipcache.IPCache,
 		proxy endpoint.EndpointProxy,
@@ -108,6 +110,7 @@ type EndpointsModify interface {
 	AddHostEndpoint(
 		ctx context.Context,
 		owner regeneration.Owner,
+		policyMapFactory policymap.Factory,
 		policyGetter policyRepoGetter,
 		ipcache *ipcache.IPCache,
 		proxy endpoint.EndpointProxy,

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -40,7 +40,7 @@ func TestMarkAndSweep(t *testing.T) {
 	healthyEndpointIDs := []uint16{1, 3, 5, 7}
 	allEndpointIDs := append(healthyEndpointIDs, endpointIDToDelete)
 	for _, id := range allEndpointIDs {
-		ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), id, endpoint.StateReady)
+		ep := endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), id, endpoint.StateReady)
 		err := mgr.expose(ep)
 		require.NoError(t, err)
 	}

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/mcastmanager"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
@@ -722,13 +723,14 @@ func (mgr *endpointManager) AddEndpoint(owner regeneration.Owner, ep *endpoint.E
 func (mgr *endpointManager) AddIngressEndpoint(
 	ctx context.Context,
 	owner regeneration.Owner,
+	policyMapFactory policymap.Factory,
 	policyGetter policyRepoGetter,
 	ipcache *ipcache.IPCache,
 	proxy endpoint.EndpointProxy,
 	allocator cache.IdentityAllocator,
 	ctMapGC ctmap.GCRunner,
 ) error {
-	ep, err := endpoint.CreateIngressEndpoint(owner, policyGetter, ipcache, proxy, allocator, ctMapGC)
+	ep, err := endpoint.CreateIngressEndpoint(owner, policyMapFactory, policyGetter, ipcache, proxy, allocator, ctMapGC)
 	if err != nil {
 		return err
 	}
@@ -745,13 +747,14 @@ func (mgr *endpointManager) AddIngressEndpoint(
 func (mgr *endpointManager) AddHostEndpoint(
 	ctx context.Context,
 	owner regeneration.Owner,
+	policyMapFactory policymap.Factory,
 	policyGetter policyRepoGetter,
 	ipcache *ipcache.IPCache,
 	proxy endpoint.EndpointProxy,
 	allocator cache.IdentityAllocator,
 	ctMapGC ctmap.GCRunner,
 ) error {
-	ep, err := endpoint.CreateHostEndpoint(owner, policyGetter, ipcache, proxy, allocator, ctMapGC)
+	ep, err := endpoint.CreateHostEndpoint(owner, policyMapFactory, policyGetter, ipcache, proxy, allocator, ctMapGC)
 	if err != nil {
 		return err
 	}

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -439,7 +439,7 @@ func TestLookup(t *testing.T) {
 			var err error
 			mgr := New(&dummyEpSyncher{}, nil, nil)
 			if tt.cm != nil {
-				ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), tt.cm)
+				ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), tt.cm)
 				require.NoErrorf(t, err, "Test Name: %s", tt.name)
 				err = mgr.expose(ep)
 				require.NoErrorf(t, err, "Test Name: %s", tt.name)
@@ -462,7 +462,7 @@ func TestLookupCiliumID(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 
 	mgr := New(&dummyEpSyncher{}, nil, nil)
-	ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 2, endpoint.StateReady)
+	ep := endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 2, endpoint.StateReady)
 	type args struct {
 		id uint16
 	}
@@ -531,7 +531,7 @@ func TestLookupCNIAttachmentID(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 
 	mgr := New(&dummyEpSyncher{}, nil, nil)
-	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), &apiv1.EndpointChangeRequest{
+	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), &apiv1.EndpointChangeRequest{
 		ContainerID:            "foo",
 		ContainerInterfaceName: "bar",
 	})
@@ -552,7 +552,7 @@ func TestLookupIPv4(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 
 	mgr := New(&dummyEpSyncher{}, nil, nil)
-	ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 4, endpoint.StateReady)
+	ep := endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 4, endpoint.StateReady)
 	type args struct {
 		ip string
 	}
@@ -699,7 +699,7 @@ func TestLookupCEPName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), &tt.cm)
+		ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), &tt.cm)
 		require.NoErrorf(t, err, "Test Name: %s", tt.name)
 		tt.preTestRun(ep)
 		args := tt.setupArgs()
@@ -742,7 +742,7 @@ func TestUpdateReferences(t *testing.T) {
 	}
 	for _, tt := range tests {
 		var err error
-		ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), &tt.cm)
+		ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), &tt.cm)
 		require.NoErrorf(t, err, "Test Name: %s", tt.name)
 		mgr := New(&dummyEpSyncher{}, nil, nil)
 
@@ -775,7 +775,7 @@ func TestUpdateReferences(t *testing.T) {
 func TestRemove(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 	mgr := New(&dummyEpSyncher{}, nil, nil)
-	ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 7, endpoint.StateReady)
+	ep := endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 7, endpoint.StateReady)
 	type args struct{}
 	type want struct{}
 	tests := []struct {
@@ -815,7 +815,7 @@ func TestHasGlobalCT(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 
 	mgr := New(&dummyEpSyncher{}, nil, nil)
-	ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
+	ep := endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
 	type want struct {
 		result bool
 	}
@@ -839,7 +839,7 @@ func TestHasGlobalCT(t *testing.T) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
+				ep = endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
 				ep.ID = 0
 				ep.Options = nil
 			},
@@ -859,7 +859,7 @@ func TestHasGlobalCT(t *testing.T) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
+				ep = endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
 				ep.ID = 0
 				ep.Options = nil
 			},
@@ -877,7 +877,7 @@ func TestHasGlobalCT(t *testing.T) {
 func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 	mgr := New(&dummyEpSyncher{}, nil, nil)
-	ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
+	ep := endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
 	type args struct {
 		ctx    context.Context
 		rev    uint64
@@ -915,7 +915,7 @@ func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
+				ep = endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
 			},
 		},
 		{
@@ -941,7 +941,7 @@ func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
+				ep = endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
 			},
 		},
 		{
@@ -967,7 +967,7 @@ func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
+				ep = endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
 			},
 		},
 	}
@@ -1000,7 +1000,7 @@ func TestMissingNodeLabelsUpdate(t *testing.T) {
 	require.False(t, ok)
 
 	// Create host endpoint and expose it in the endpoint manager.
-	ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
+	ep := endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
 	ep.SetIsHost(true)
 	ep.ID = hostEPID
 	require.NoError(t, mgr.expose(ep))
@@ -1037,7 +1037,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 		{
 			name: "Add labels",
 			preTestRun: func() {
-				ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
+				ep := endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
 				ep.SetIsHost(true)
 				ep.ID = hostEPID
 				require.NoError(t, mgr.expose(ep))
@@ -1062,7 +1062,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 		{
 			name: "Update labels",
 			preTestRun: func() {
-				ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
+				ep := endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
 				ep.SetIsHost(true)
 				ep.ID = hostEPID
 				ep.OpLabels.Custom = labels.Labels{"k1": labels.NewLabel("k1", "v1", labels.LabelSourceK8s)}
@@ -1089,7 +1089,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 		{
 			name: "Ignore labels",
 			preTestRun: func() {
-				ep := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
+				ep := endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
 				ep.SetIsHost(true)
 				ep.ID = hostEPID
 				ep.OpLabels.Custom = labels.Labels{"k1": labels.NewLabel("k1", "v1", labels.LabelSourceK8s)}

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -89,7 +89,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 			if s.restoring {
 				return nil, false, fmt.Errorf("No EPs available when restoring")
 			}
-			return endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), uint16(epID1), endpoint.StateReady), false, nil
+			return endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), uint16(epID1), endpoint.StateReady), false, nil
 		},
 		// LookupSecIDByIP
 		func(ip netip.Addr) (ipcache.Identity, bool) {
@@ -873,7 +873,7 @@ func TestFullPathDependence(t *testing.T) {
 	require.False(t, allowed, "request was allowed when it should be rejected")
 
 	// Restore rules
-	ep1 := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), uint16(epID1), endpoint.StateReady)
+	ep1 := endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), uint16(epID1), endpoint.StateReady)
 	ep1.DNSRulesV2 = restored1
 	s.proxy.RestoreRules(ep1)
 	_, exists = s.proxy.restored[epID1]
@@ -919,7 +919,7 @@ func TestFullPathDependence(t *testing.T) {
 	require.True(t, allowed, "request was rejected when it should be allowed")
 
 	// Restore rules for epID3
-	ep3 := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), uint16(epID3), endpoint.StateReady)
+	ep3 := endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), uint16(epID3), endpoint.StateReady)
 	ep3.DNSRulesV2 = restored3
 	s.proxy.RestoreRules(ep3)
 	_, exists = s.proxy.restored[epID3]
@@ -1125,7 +1125,7 @@ func TestRestoredEndpoint(t *testing.T) {
 
 	// restore rules, set the mock to restoring state
 	s.restoring = true
-	ep1 := endpoint.NewTestEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), uint16(epID1), endpoint.StateReady)
+	ep1 := endpoint.NewTestEndpointWithState(s, nil, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), uint16(epID1), endpoint.StateReady)
 	ep1.IPv4 = netip.MustParseAddr("127.0.0.1")
 	ep1.IPv6 = netip.MustParseAddr("::1")
 	ep1.DNSRulesV2 = restored

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -836,4 +836,10 @@ const (
 
 	// Target identifies a target value
 	Target = "target"
+
+	// Minimum specifies a minimum allowed value
+	Minimum = "minimum"
+
+	// Maximum specifies a maximum allowed value
+	Maximum = "maximum"
 )

--- a/pkg/maps/cells.go
+++ b/pkg/maps/cells.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/multicast"
 	"github.com/cilium/cilium/pkg/maps/nat"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/maps/signalmap"
 	"github.com/cilium/cilium/pkg/maps/srv6map"
 )
@@ -66,6 +67,9 @@ var Cell = cell.Module(
 
 	// Provides access to NAT maps.
 	nat.Cell,
+
+	// Provides access to policy maps.
+	policymap.Cell,
 )
 
 type mapApiHandlerOut struct {

--- a/pkg/maps/policymap/cell.go
+++ b/pkg/maps/policymap/cell.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policymap
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+var Cell = cell.Module(
+	"policymap",
+	"Policymap provides access to the datapath policy maps",
+	cell.Config(DefaultPolicyConfig),
+	cell.Provide(createStatsMap),
+)
+
+type PolicyConfig struct {
+	// BpfPolicyMapMax is the maximum number of peer identities that an
+	// endpoint may allow traffic to exchange traffic with.
+	BpfPolicyMapMax int
+
+	// PolicyStatsMapMax is the maximum number of entries allowed in a BPF policy map.
+	BpfPolicyStatsMapMax int
+}
+
+var DefaultPolicyConfig = PolicyConfig{
+	BpfPolicyMapMax:      16384,
+	BpfPolicyStatsMapMax: 1 << 16,
+}
+
+const (
+	PolicyMapMaxName      = "bpf-policy-map-max"
+	PolicyStatsMapMaxName = "bpf-policy-stats-map-max"
+)
+
+func (def PolicyConfig) Flags(flags *pflag.FlagSet) {
+	flags.Int(PolicyMapMaxName, def.BpfPolicyMapMax, "Maximum number of entries in endpoint policy map (per endpoint)")
+	flags.Int(PolicyStatsMapMaxName, def.BpfPolicyStatsMapMax, "Maximum number of entries in bpf policy stats map")
+}
+
+func createStatsMap(in struct {
+	cell.In
+
+	Lifecycle cell.Lifecycle
+	Log       *slog.Logger
+	PolicyConfig
+}) (out struct {
+	cell.Out
+
+	bpf.MapOut[*StatsMap]
+	defines.NodeOut
+}) {
+	if in.BpfPolicyMapMax < option.PolicyMapMin {
+		in.Log.Warn("specified PolicyMap max entries too low, using minimum value instead",
+			logfields.Entries, in.BpfPolicyMapMax,
+			logfields.Minimum, option.PolicyMapMin)
+		in.BpfPolicyMapMax = option.PolicyMapMin
+	}
+	if in.BpfPolicyMapMax > option.PolicyMapMax {
+		in.Log.Warn("specified PolicyMap max entries too high, using maximum value instead",
+			logfields.Entries, in.BpfPolicyMapMax,
+			logfields.Maximum, option.PolicyMapMax)
+		in.BpfPolicyMapMax = option.PolicyMapMax
+	}
+	MaxEntries = in.BpfPolicyMapMax
+
+	if in.BpfPolicyStatsMapMax < option.LimitTableMin {
+		in.Log.Warn("specified policy stats map max entries too low, using minimum value instead",
+			logfields.Entries, in.BpfPolicyStatsMapMax,
+			logfields.Minimum, option.LimitTableMin)
+		in.BpfPolicyStatsMapMax = option.LimitTableMin
+	}
+	if in.BpfPolicyStatsMapMax > option.LimitTableMax {
+		in.Log.Warn("specified policy stats map max entries too high, using maximum value instead",
+			logfields.Entries, in.BpfPolicyStatsMapMax,
+			logfields.Maximum, option.LimitTableMax)
+		in.BpfPolicyStatsMapMax = option.LimitTableMax
+	}
+
+	m, maxStatsEntries := newStatsMap(in.BpfPolicyStatsMapMax, in.Log)
+	if int(maxStatsEntries) != in.BpfPolicyStatsMapMax {
+		in.Log.Debug("Rounded policy stats map size down to the closest multiple of the number of possible CPUs",
+			"entries", maxStatsEntries)
+	}
+
+	out.NodeDefines = map[string]string{
+		"POLICY_STATS_MAP":      StatsMapName,
+		"POLICY_STATS_MAP_SIZE": fmt.Sprint(maxStatsEntries),
+	}
+
+	in.Lifecycle.Append(cell.Hook{
+		OnStart: func(cell.HookContext) error {
+			err := initCallMaps()
+			if err != nil {
+				return fmt.Errorf("Policy call map creation failed: %w", err)
+			}
+			return m.OpenOrCreate()
+		},
+		OnStop: func(cell.HookContext) error {
+			return m.Close()
+		},
+	})
+
+	out.MapOut = bpf.NewMapOut(m)
+	return
+}

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -4,6 +4,7 @@
 package policymap
 
 import (
+	"log/slog"
 	"os"
 	"testing"
 
@@ -19,6 +20,16 @@ import (
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
+const (
+	testMapSize = 1024
+)
+
+// createStatsMapForTest creates the global policy stats map.
+func createStatsMapForTest(maxStatsEntries int) (*StatsMap, error) {
+	m, _ := newStatsMap(maxStatsEntries, slog.Default())
+	return m, m.OpenOrCreate()
+}
+
 func setupPolicyMapPrivilegedTestSuite(tb testing.TB) *PolicyMap {
 	testutils.PrivilegedTest(tb)
 
@@ -28,10 +39,15 @@ func setupPolicyMapPrivilegedTestSuite(tb testing.TB) *PolicyMap {
 		tb.Fatal(err)
 	}
 
-	testMap := newMap("cilium_policy_v2_test")
+	_, err := createStatsMapForTest(testMapSize)
+	require.NoError(tb, err)
 
-	_ = os.RemoveAll(bpf.MapPath("cilium_policy_v2_test"))
-	err := testMap.CreateUnpinned()
+	testMap, err := newMap("cilium_policy_v2_00000")
+	require.NoError(tb, err)
+	require.NotNil(tb, testMap)
+
+	_ = os.RemoveAll(bpf.MapPath("cilium_policy_v2_00000"))
+	err = testMap.CreateUnpinned()
 	require.NoError(tb, err)
 
 	tb.Cleanup(func() {

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -24,7 +24,6 @@ const (
 	testMapSize = 1024
 )
 
-// createStatsMapForTest creates the global policy stats map.
 func createStatsMapForTest(maxStatsEntries int) (*StatsMap, error) {
 	m, _ := newStatsMap(maxStatsEntries, slog.Default())
 	return m, m.OpenOrCreate()
@@ -39,14 +38,15 @@ func setupPolicyMapPrivilegedTestSuite(tb testing.TB) *PolicyMap {
 		tb.Fatal(err)
 	}
 
-	_, err := createStatsMapForTest(testMapSize)
+	stats, err := createStatsMapForTest(testMapSize)
 	require.NoError(tb, err)
+	require.NotNil(tb, stats)
 
-	testMap, err := newMap("cilium_policy_v2_00000")
+	testMap, err := newPolicyMap(0, testMapSize, stats)
 	require.NoError(tb, err)
 	require.NotNil(tb, testMap)
 
-	_ = os.RemoveAll(bpf.MapPath("cilium_policy_v2_00000"))
+	_ = os.RemoveAll(bpf.LocalMapPath(MapName, 0))
 	err = testMap.CreateUnpinned()
 	require.NoError(tb, err)
 

--- a/pkg/maps/policymap/policymap_test.go
+++ b/pkg/maps/policymap/policymap_test.go
@@ -338,11 +338,11 @@ func TestPolicyMapWildcarding(t *testing.T) {
 			require.Equal(t, uint8(0), entry.GetPrefixLen())
 		} else {
 			if key.DestPortNetwork == 0 {
-				require.Equal(t, StaticPrefixBits+NexthdrBits, key.Prefixlen)
+				require.Equal(t, StaticPrefixBits+uint32(NexthdrBits), key.Prefixlen)
 				require.Equal(t, uint8(NexthdrBits), entry.GetPrefixLen())
 			} else {
 				require.Equal(t, uint16(tt.args.dport), byteorder.NetworkToHost16(key.DestPortNetwork))
-				require.Equal(t, StaticPrefixBits+NexthdrBits+uint32(tt.args.dportPrefixLen), key.Prefixlen)
+				require.Equal(t, StaticPrefixBits+uint32(NexthdrBits+tt.args.dportPrefixLen), key.Prefixlen)
 				require.Equal(t, uint8(NexthdrBits)+tt.args.dportPrefixLen, entry.GetPrefixLen())
 			}
 		}
@@ -375,7 +375,7 @@ func TestPortProtoString(t *testing.T) {
 			name: "Fully specified port",
 			args: args{
 				&PolicyKey{
-					Prefixlen:        StaticPrefixBits + NexthdrBits + DestPortBits,
+					Prefixlen:        StaticPrefixBits + uint32(NexthdrBits+DestPortBits),
 					Identity:         0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 					Nexthdr:          0,
@@ -388,7 +388,7 @@ func TestPortProtoString(t *testing.T) {
 			name: "Fully specified port and proto",
 			args: args{
 				&PolicyKey{
-					Prefixlen:        StaticPrefixBits + NexthdrBits + DestPortBits,
+					Prefixlen:        StaticPrefixBits + uint32(NexthdrBits+DestPortBits),
 					Identity:         0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 					Nexthdr:          6,
@@ -401,7 +401,7 @@ func TestPortProtoString(t *testing.T) {
 			name: "Match TCP / wildcarded port",
 			args: args{
 				&PolicyKey{
-					Prefixlen:        StaticPrefixBits + NexthdrBits,
+					Prefixlen:        StaticPrefixBits + uint32(NexthdrBits),
 					Identity:         0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 					Nexthdr:          6,
@@ -414,7 +414,7 @@ func TestPortProtoString(t *testing.T) {
 			name: "Wildard proto / match upper 8 bits of port",
 			args: args{
 				&PolicyKey{
-					Prefixlen:        StaticPrefixBits + NexthdrBits + DestPortBits/2,
+					Prefixlen:        StaticPrefixBits + uint32(NexthdrBits+DestPortBits/2),
 					Identity:         0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 					Nexthdr:          0,

--- a/pkg/maps/policymap/statsmap.go
+++ b/pkg/maps/policymap/statsmap.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policymap
+
+import (
+	"errors"
+	"log/slog"
+	"math"
+	"strconv"
+	"unsafe"
+
+	ciliumebpf "github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/ebpf"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+const (
+	// Name is the canonical name for the policy stats map on the filesystem.
+	// Note: There is no underscore between 'policy' and 'stats' as that would confuse tools
+	// trying to parse an endpoint ID from 'stats'.
+	StatsMapName = "cilium_policystats"
+
+	StatNotAvailable = uint64(math.MaxUint64)
+)
+
+var (
+	// nCPU must be on package level to be available for StatsValues.New() below
+	nCPU = ciliumebpf.MustPossibleCPU()
+)
+
+// PolicyStatsMap maps endpoint IDs to the fd for the program which
+// implements its policy.
+type StatsMap struct {
+	*ebpf.Map
+	log *slog.Logger
+}
+
+func newStatsMap(maxStatsEntries int, log *slog.Logger) (*StatsMap, int) {
+	roundDown := maxStatsEntries % nCPU
+	maxStatsEntries -= roundDown
+
+	// Must return a valid map even if returning an error
+	return &StatsMap{
+		Map: ebpf.NewMap(&ebpf.MapSpec{
+			Name:       StatsMapName,
+			Type:       ebpf.LRUCPUHash,
+			KeySize:    uint32(unsafe.Sizeof(StatsKey{})),
+			ValueSize:  uint32(unsafe.Sizeof(StatsValue{})),
+			MaxEntries: uint32(maxStatsEntries),
+			Flags:      unix.BPF_F_NO_COMMON_LRU,
+			Pinning:    ebpf.PinByName,
+		}),
+		log: log,
+	}, maxStatsEntries
+}
+
+// OpenStatsMap opens the existing global policy stats map.
+// Should only be called from cilium-dbg
+func OpenStatsMap() (*StatsMap, error) {
+	m, err := ebpf.LoadRegisterMap(StatsMapName)
+	if err != nil {
+		return nil, err
+	}
+	return &StatsMap{
+		Map: m,
+		log: slog.Default(),
+	}, nil
+}
+
+type StatsKey struct {
+	EpID             uint16 `align:"endpoint_id"`
+	Pad1             uint8  `align:"pad1"`
+	PrefixLen        uint8  `align:"prefix_len"`
+	Identity         uint32 `align:"sec_label"`
+	TrafficDirection uint8  `align:"egress"`
+	Nexthdr          uint8  `align:"protocol"`
+	DestPortNetwork  uint16 `align:"dport"` // In network byte-order
+}
+
+type StatsValue struct {
+	Packets uint64 `align:"packets"`
+	Bytes   uint64 `align:"bytes"`
+}
+
+func (v *StatsValue) String() string {
+	bb := make([]byte, 0, 20)
+
+	if v.Packets == StatNotAvailable {
+		bb = append(bb, '-')
+	} else {
+		bb = strconv.AppendUint(bb, v.Packets, 10)
+	}
+	bb = append(bb, ' ')
+	if v.Bytes == StatNotAvailable {
+		bb = append(bb, '-')
+	} else {
+		bb = strconv.AppendUint(bb, v.Bytes, 10)
+	}
+	return string(bb)
+}
+
+// StatsMap is a per-CPU map, so the value is a slice
+type StatsValues []StatsValue
+
+// GetStat looks up stats for the given endpoint and policy key
+func (m *StatsMap) GetStat(epID uint16, k PolicyKey) (packets, bytes uint64) {
+	statsKey := StatsKey{
+		EpID:             epID,
+		PrefixLen:        k.GetPrefixLen(),
+		Identity:         k.Identity,
+		TrafficDirection: k.TrafficDirection,
+		Nexthdr:          k.Nexthdr,
+		DestPortNetwork:  k.DestPortNetwork,
+	}
+	var values StatsValues
+	err := m.Lookup(&statsKey, &values)
+	if err == nil {
+		for _, v := range values {
+			packets += v.Packets
+			bytes += v.Bytes
+		}
+		return packets, bytes
+	}
+
+	if !errors.Is(err, unix.ENOENT) {
+		m.log.Warn("Error getting policy stats",
+			logfields.Error, err,
+			logfields.BPFMapKey, statsKey)
+	}
+	return StatNotAvailable, StatNotAvailable
+}
+
+// ClearStat removes stats for the given endpoint and policy key
+func (m *StatsMap) ClearStat(epID uint16, k PolicyKey) error {
+	statsKey := StatsKey{
+		EpID:             epID,
+		PrefixLen:        k.GetPrefixLen(),
+		Identity:         k.Identity,
+		TrafficDirection: k.TrafficDirection,
+		Nexthdr:          k.Nexthdr,
+		DestPortNetwork:  k.DestPortNetwork,
+	}
+
+	err := m.Delete(&statsKey)
+
+	if err == nil || errors.Is(err, unix.ENOENT) {
+		return nil
+	}
+
+	m.log.Warn("Error deleting policy stats",
+		logfields.Error, err,
+		logfields.BPFMapKey, statsKey)
+	return err
+}
+
+// ZeroStat updates stats to "0,0" for the given endpoint and policy key
+func (m *StatsMap) ZeroStat(epID uint16, k PolicyKey) error {
+	statsKey := StatsKey{
+		EpID:             epID,
+		PrefixLen:        k.GetPrefixLen(),
+		Identity:         k.Identity,
+		TrafficDirection: k.TrafficDirection,
+		Nexthdr:          k.Nexthdr,
+		DestPortNetwork:  k.DestPortNetwork,
+	}
+	zeroValue := make(StatsValues, nCPU)
+
+	err := m.Update(&statsKey, zeroValue, 0)
+
+	if err != nil {
+		m.log.Warn("Error zeroing policy stats",
+			logfields.Error, err,
+			logfields.BPFMapKey, statsKey)
+	}
+	return err
+}

--- a/pkg/maps/policymap/statsmap_privileged_test.go
+++ b/pkg/maps/policymap/statsmap_privileged_test.go
@@ -13,12 +13,12 @@ func TestStatMap(t *testing.T) {
 	policyMap := setupPolicyMapPrivilegedTestSuite(t)
 	require.NotNil(t, policyMap)
 
-	testMap, err := createStatsMapForTest(1024)
-	require.NoError(t, err)
+	testMap := policyMap.stats
+	require.NotNil(t, testMap)
 
 	fooKey := NewKey(1, 1, 1, 1, SinglePortPrefixLen)
 
-	err = testMap.ClearStat(0, fooKey)
+	err := testMap.ClearStat(0, fooKey)
 	require.NoError(t, err)
 
 	packets, bytes := testMap.GetStat(0, fooKey)

--- a/pkg/maps/policymap/statsmap_privileged_test.go
+++ b/pkg/maps/policymap/statsmap_privileged_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policymap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatMap(t *testing.T) {
+	policyMap := setupPolicyMapPrivilegedTestSuite(t)
+	require.NotNil(t, policyMap)
+
+	testMap, err := createStatsMapForTest(1024)
+	require.NoError(t, err)
+
+	fooKey := NewKey(1, 1, 1, 1, SinglePortPrefixLen)
+
+	err = testMap.ClearStat(0, fooKey)
+	require.NoError(t, err)
+
+	packets, bytes := testMap.GetStat(0, fooKey)
+	require.Equal(t, StatNotAvailable, packets)
+	require.Equal(t, StatNotAvailable, bytes)
+
+	err = testMap.ZeroStat(0, fooKey)
+	require.NoError(t, err)
+
+	packets, bytes = testMap.GetStat(0, fooKey)
+	require.Equal(t, uint64(0), packets)
+	require.Equal(t, uint64(0), bytes)
+
+	err = testMap.ClearStat(0, fooKey)
+	require.NoError(t, err)
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3399,14 +3399,14 @@ func (c *DaemonConfig) populateNodePortRange(vp *viper.Viper) error {
 
 func (c *DaemonConfig) checkMapSizeLimits() error {
 	if c.AuthMapEntries < AuthMapEntriesMin {
-		return fmt.Errorf("specified AuthMap max entries %d must exceed minimum %d", c.AuthMapEntries, AuthMapEntriesMin)
+		return fmt.Errorf("specified AuthMap max entries %d must be greater or equal to %d", c.AuthMapEntries, AuthMapEntriesMin)
 	}
 	if c.AuthMapEntries > AuthMapEntriesMax {
 		return fmt.Errorf("specified AuthMap max entries %d must not exceed maximum %d", c.AuthMapEntries, AuthMapEntriesMax)
 	}
 
 	if c.CTMapEntriesGlobalTCP < LimitTableMin || c.CTMapEntriesGlobalAny < LimitTableMin {
-		return fmt.Errorf("specified CT tables values %d/%d must exceed minimum %d",
+		return fmt.Errorf("specified CT tables values %d/%d must be greater or equal to %d",
 			c.CTMapEntriesGlobalTCP, c.CTMapEntriesGlobalAny, LimitTableMin)
 	}
 	if c.CTMapEntriesGlobalTCP > LimitTableMax || c.CTMapEntriesGlobalAny > LimitTableMax {
@@ -3415,7 +3415,7 @@ func (c *DaemonConfig) checkMapSizeLimits() error {
 	}
 
 	if c.NATMapEntriesGlobal < LimitTableMin {
-		return fmt.Errorf("specified NAT table size %d must exceed minimum %d",
+		return fmt.Errorf("specified NAT table size %d must be greater or equal to %d",
 			c.NATMapEntriesGlobal, LimitTableMin)
 	}
 	if c.NATMapEntriesGlobal > LimitTableMax {
@@ -3433,7 +3433,7 @@ func (c *DaemonConfig) checkMapSizeLimits() error {
 	}
 
 	if c.SockRevNatEntries < LimitTableMin {
-		return fmt.Errorf("specified Socket Reverse NAT table size %d must exceed minimum %d",
+		return fmt.Errorf("specified Socket Reverse NAT table size %d must be greater or equal to %d",
 			c.SockRevNatEntries, LimitTableMin)
 	}
 	if c.SockRevNatEntries > LimitTableMax {
@@ -3442,7 +3442,7 @@ func (c *DaemonConfig) checkMapSizeLimits() error {
 	}
 
 	if c.PolicyMapEntries < PolicyMapMin {
-		return fmt.Errorf("specified PolicyMap max entries %d must exceed minimum %d",
+		return fmt.Errorf("specified PolicyMap max entries %d must be greater or equal to %d",
 			c.PolicyMapEntries, PolicyMapMin)
 	}
 	if c.PolicyMapEntries > PolicyMapMax {
@@ -3452,7 +3452,7 @@ func (c *DaemonConfig) checkMapSizeLimits() error {
 	}
 
 	if c.FragmentsMapEntries < FragmentsMapMin {
-		return fmt.Errorf("specified max entries %d for fragment-tracking map must exceed minimum %d",
+		return fmt.Errorf("specified max entries %d for fragment-tracking map must be greater or equal to %d",
 			c.FragmentsMapEntries, FragmentsMapMin)
 	}
 	if c.FragmentsMapEntries > FragmentsMapMax {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -633,9 +633,6 @@ const (
 	// NeighMapEntriesGlobalName configures max entries for BPF neighbor table
 	NeighMapEntriesGlobalName = "bpf-neigh-global-max"
 
-	// PolicyMapEntriesName configures max entries for BPF policymap.
-	PolicyMapEntriesName = "bpf-policy-map-max"
-
 	// PolicyMapFullReconciliationInterval sets the interval for performing the full
 	// reconciliation of the endpoint policy map.
 	PolicyMapFullReconciliationIntervalName = "bpf-policy-map-full-reconciliation-interval"
@@ -1484,10 +1481,6 @@ type DaemonConfig struct {
 
 	// AuthMapEntries is the maximum number of entries in the auth map.
 	AuthMapEntries int
-
-	// PolicyMapEntries is the maximum number of peer identities that an
-	// endpoint may allow traffic to exchange traffic with.
-	PolicyMapEntries int
 
 	// PolicyMapFullReconciliationInterval is the interval at which to perform
 	// the full reconciliation of the endpoint policy map.
@@ -3441,16 +3434,6 @@ func (c *DaemonConfig) checkMapSizeLimits() error {
 			c.SockRevNatEntries, LimitTableMax)
 	}
 
-	if c.PolicyMapEntries < PolicyMapMin {
-		return fmt.Errorf("specified PolicyMap max entries %d must be greater or equal to %d",
-			c.PolicyMapEntries, PolicyMapMin)
-	}
-	if c.PolicyMapEntries > PolicyMapMax {
-		log.Warnf("specified PolicyMap max entries %d must not exceed maximum %d, lowering it to the maximum value",
-			c.PolicyMapEntries, PolicyMapMax)
-		c.PolicyMapEntries = PolicyMapMax
-	}
-
 	if c.FragmentsMapEntries < FragmentsMapMin {
 		return fmt.Errorf("specified max entries %d for fragment-tracking map must be greater or equal to %d",
 			c.FragmentsMapEntries, FragmentsMapMin)
@@ -3564,7 +3547,6 @@ func (c *DaemonConfig) calculateBPFMapSizes(vp *viper.Viper) error {
 	c.CTMapEntriesGlobalAny = vp.GetInt(CTMapEntriesGlobalAnyName)
 	c.NATMapEntriesGlobal = vp.GetInt(NATMapEntriesGlobalName)
 	c.NeighMapEntriesGlobal = vp.GetInt(NeighMapEntriesGlobalName)
-	c.PolicyMapEntries = vp.GetInt(PolicyMapEntriesName)
 	c.PolicyMapFullReconciliationInterval = vp.GetDuration(PolicyMapFullReconciliationIntervalName)
 	c.SockRevNatEntries = vp.GetInt(SockRevNatEntriesName)
 	c.LBMapEntries = vp.GetInt(LBMapEntriesName)

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -264,7 +264,6 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		CTMapEntriesGlobalTCP int
 		CTMapEntriesGlobalAny int
 		NATMapEntriesGlobal   int
-		PolicyMapEntries      int
 		LBMapEntries          int
 		FragmentsMapEntries   int
 		NeighMapEntriesGlobal int
@@ -283,7 +282,6 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalTCP: CTMapEntriesGlobalTCPDefault,
 				CTMapEntriesGlobalAny: CTMapEntriesGlobalAnyDefault,
 				NATMapEntriesGlobal:   NATMapEntriesGlobalDefault,
-				PolicyMapEntries:      16384,
 				LBMapEntries:          65536,
 				FragmentsMapEntries:   defaults.FragmentsMapEntries,
 				NeighMapEntriesGlobal: NATMapEntriesGlobalDefault,
@@ -294,7 +292,6 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalTCP: CTMapEntriesGlobalTCPDefault,
 				CTMapEntriesGlobalAny: CTMapEntriesGlobalAnyDefault,
 				NATMapEntriesGlobal:   NATMapEntriesGlobalDefault,
-				PolicyMapEntries:      16384,
 				LBMapEntries:          65536,
 				FragmentsMapEntries:   defaults.FragmentsMapEntries,
 				NeighMapEntriesGlobal: NATMapEntriesGlobalDefault,
@@ -309,7 +306,6 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalTCP: 20000,
 				CTMapEntriesGlobalAny: 18000,
 				NATMapEntriesGlobal:   2048,
-				PolicyMapEntries:      512,
 				LBMapEntries:          1 << 14,
 				SockRevNatEntries:     18000,
 				FragmentsMapEntries:   2 << 14,
@@ -319,7 +315,6 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalTCP: 20000,
 				CTMapEntriesGlobalAny: 18000,
 				NATMapEntriesGlobal:   2048,
-				PolicyMapEntries:      512,
 				LBMapEntries:          1 << 14,
 				SockRevNatEntries:     18000,
 				FragmentsMapEntries:   2 << 14,
@@ -414,7 +409,6 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalAny: 4096,
 				NATMapEntriesGlobal:   NATMapEntriesGlobalDefault,
 				SockRevNatEntries:     4096,
-				PolicyMapEntries:      16384,
 				LBMapEntries:          65536,
 				FragmentsMapEntries:   defaults.FragmentsMapEntries,
 			},
@@ -424,7 +418,6 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalAny: 4096,
 				NATMapEntriesGlobal:   (2048 + 4096) * 2 / 3,
 				SockRevNatEntries:     4096,
-				PolicyMapEntries:      16384,
 				LBMapEntries:          65536,
 				FragmentsMapEntries:   defaults.FragmentsMapEntries,
 				WantErr:               false,
@@ -442,58 +435,6 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalAny: 4096,
 				NATMapEntriesGlobal:   8192,
 				WantErr:               true,
-			},
-		},
-		{
-			name: "Policy map size below range",
-			d: &DaemonConfig{
-				AuthMapEntries:        AuthMapEntriesDefault,
-				CTMapEntriesGlobalTCP: 2048,
-				CTMapEntriesGlobalAny: 4096,
-				NATMapEntriesGlobal:   (2048 + 4096) * 2 / 3,
-				SockRevNatEntries:     4096,
-				LBMapEntries:          65536,
-				FragmentsMapEntries:   defaults.FragmentsMapEntries,
-				//
-				PolicyMapEntries: PolicyMapMin - 1,
-			},
-			want: sizes{
-				AuthMapEntries:        AuthMapEntriesDefault,
-				CTMapEntriesGlobalTCP: 2048,
-				CTMapEntriesGlobalAny: 4096,
-				NATMapEntriesGlobal:   (2048 + 4096) * 2 / 3,
-				SockRevNatEntries:     4096,
-				LBMapEntries:          65536,
-				FragmentsMapEntries:   defaults.FragmentsMapEntries,
-				//
-				PolicyMapEntries: PolicyMapMin - 1,
-				WantErr:          true,
-			},
-		},
-		{
-			name: "Policy map size above range",
-			d: &DaemonConfig{
-				AuthMapEntries:        AuthMapEntriesDefault,
-				CTMapEntriesGlobalTCP: 2048,
-				CTMapEntriesGlobalAny: 4096,
-				NATMapEntriesGlobal:   (2048 + 4096) * 2 / 3,
-				SockRevNatEntries:     4096,
-				LBMapEntries:          65536,
-				FragmentsMapEntries:   defaults.FragmentsMapEntries,
-				//
-				PolicyMapEntries: PolicyMapMax + 1,
-			},
-			want: sizes{
-				AuthMapEntries:        AuthMapEntriesDefault,
-				CTMapEntriesGlobalTCP: 2048,
-				CTMapEntriesGlobalAny: 4096,
-				NATMapEntriesGlobal:   (2048 + 4096) * 2 / 3,
-				SockRevNatEntries:     4096,
-				LBMapEntries:          65536,
-				FragmentsMapEntries:   defaults.FragmentsMapEntries,
-				//
-				PolicyMapEntries: PolicyMapMax,
-				WantErr:          false,
 			},
 		},
 		{
@@ -526,7 +467,6 @@ func TestCheckMapSizeLimits(t *testing.T) {
 				CTMapEntriesGlobalTCP: tt.d.CTMapEntriesGlobalTCP,
 				CTMapEntriesGlobalAny: tt.d.CTMapEntriesGlobalAny,
 				NATMapEntriesGlobal:   tt.d.NATMapEntriesGlobal,
-				PolicyMapEntries:      tt.d.PolicyMapEntries,
 				LBMapEntries:          tt.d.LBMapEntries,
 				FragmentsMapEntries:   tt.d.FragmentsMapEntries,
 				NeighMapEntriesGlobal: tt.d.NeighMapEntriesGlobal,

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -447,9 +447,25 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "Policy map size below range",
 			d: &DaemonConfig{
+				AuthMapEntries:        AuthMapEntriesDefault,
+				CTMapEntriesGlobalTCP: 2048,
+				CTMapEntriesGlobalAny: 4096,
+				NATMapEntriesGlobal:   (2048 + 4096) * 2 / 3,
+				SockRevNatEntries:     4096,
+				LBMapEntries:          65536,
+				FragmentsMapEntries:   defaults.FragmentsMapEntries,
+				//
 				PolicyMapEntries: PolicyMapMin - 1,
 			},
 			want: sizes{
+				AuthMapEntries:        AuthMapEntriesDefault,
+				CTMapEntriesGlobalTCP: 2048,
+				CTMapEntriesGlobalAny: 4096,
+				NATMapEntriesGlobal:   (2048 + 4096) * 2 / 3,
+				SockRevNatEntries:     4096,
+				LBMapEntries:          65536,
+				FragmentsMapEntries:   defaults.FragmentsMapEntries,
+				//
 				PolicyMapEntries: PolicyMapMin - 1,
 				WantErr:          true,
 			},
@@ -457,11 +473,27 @@ func TestCheckMapSizeLimits(t *testing.T) {
 		{
 			name: "Policy map size above range",
 			d: &DaemonConfig{
+				AuthMapEntries:        AuthMapEntriesDefault,
+				CTMapEntriesGlobalTCP: 2048,
+				CTMapEntriesGlobalAny: 4096,
+				NATMapEntriesGlobal:   (2048 + 4096) * 2 / 3,
+				SockRevNatEntries:     4096,
+				LBMapEntries:          65536,
+				FragmentsMapEntries:   defaults.FragmentsMapEntries,
+				//
 				PolicyMapEntries: PolicyMapMax + 1,
 			},
 			want: sizes{
-				PolicyMapEntries: PolicyMapMax + 1,
-				WantErr:          true,
+				AuthMapEntries:        AuthMapEntriesDefault,
+				CTMapEntriesGlobalTCP: 2048,
+				CTMapEntriesGlobalAny: 4096,
+				NATMapEntriesGlobal:   (2048 + 4096) * 2 / 3,
+				SockRevNatEntries:     4096,
+				LBMapEntries:          65536,
+				FragmentsMapEntries:   defaults.FragmentsMapEntries,
+				//
+				PolicyMapEntries: PolicyMapMax,
+				WantErr:          false,
 			},
 		},
 		{

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -27,6 +27,7 @@ import (
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/option"
@@ -77,6 +78,7 @@ func (h *agentHandle) setupCiliumAgentHive(clientset k8sClient.Clientset, extraC
 			func() *option.DaemonConfig { return option.Config },
 			func() cnicell.CNIConfigManager { return &fakecni.FakeCNIConfigManager{} },
 			func() ctmap.GCRunner { return ctmap.NewFakeGCRunner() },
+			func() policymap.Factory { return nil },
 			k8sSynced.RejectedCRDSyncPromise,
 		),
 		fakeDatapath.Cell,


### PR DESCRIPTION
Move policy stats to a global per-CPU LRU map. This eliminates memory trashing and associated contention on the bpf datapath packet forwarding path.

Map size defaults to `65536`, older entries will be cleared out when more space is needed for new ones. This size is configurable via the new command line option `--bpf-policy-stats-map-max` between the minimum of `1024` and maximum of `16777216`. Equivalent Helm option is `bpf.policyStatsMapMax`. The actual map size is rounded down to the closest even multiple of "possible CPUs" in the system, and is observable with the `cilium-dbg status --verbose` command.

In order to retain existing behavior useful in policy bug triaging we clear the stats for any policy entry when the entry is updated. This way the policy stats after a policy update are still reported as starting from zeroes.

Policy stats are still reported via the same `cilium-dbg bpf policy get` API as before, so the only visible change is that if there is traffic hitting thousands of different policy rules, the older ones will be cleared as space is needed for new ones, whereas previously policy stats were cleared only when the endpoint's policy map entry was updated.

Unavailable stats are printed as `-` by `cilium-dbg bpf policy get`. Stats can be unavailable if evicted by LRU or not initialized to zero (when debug is disabled).

Address an existing TODO in `bpf/lib/policy.h`:
```
#ifdef POLICY_ACCOUNTING
	/* FIXME: Use per cpu counters */
```
