### PR TITLE
docs: add troubleshooting hubble deployment section

### DIFF
--- a/Documentation/observability/hubble/configuration/tls.rst
+++ b/Documentation/observability/hubble/configuration/tls.rst
@@ -170,6 +170,7 @@ restart Hubble server or Hubble Relay.
         - ``hubble.metrics.tls.server.existingSecret`` only needs to be provided when ``hubble.metrics.tls.enabled`` (default ``false``).
           For more details on configuring the Hubble metrics API with TLS, see :ref:`hubble_configure_metrics_tls`.
 
+.. _hubble_enable_tls_troubleshooting:
 
 Troubleshooting
 ---------------

--- a/Documentation/observability/hubble/port-forward.rst
+++ b/Documentation/observability/hubble/port-forward.rst
@@ -1,0 +1,21 @@
+.. note::
+
+    The following commands use the ``-P`` (``--port-forward``) flag to automatically
+    port-forward the Hubble Relay service from your local machine on port ``4245``.
+
+    You can also omit the flag and create a port-forward manually with the Cilium CLI:
+
+    .. code-block:: shell-session
+
+        $ cilium hubble port-forward
+        ℹ️ Hubble Relay is available at 127.0.0.1:4245
+
+    Or with kubectl:
+
+    .. code-block:: shell-session
+
+        $ kubectl -n kube-system port-forward service/hubble-relay 4245:80
+        Forwarding from 127.0.0.1:4245 -> 4245
+        Forwarding from [::1]:4245 -> 4245
+
+    For more information on this method, see `Use Port Forwarding to Access Application in a Cluster <https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/>`_.

--- a/Documentation/observability/hubble/setup.rst
+++ b/Documentation/observability/hubble/setup.rst
@@ -24,12 +24,17 @@ cluster.
 Enable Hubble in Cilium
 =======================
 
+.. tip::
+
+    Enabling Hubble requires the TCP port 4244 to be open on all nodes running
+    Cilium. This is required for Relay to operate correctly.
+
 .. tabs::
 
     .. group-tab:: Cilium CLI
 
-        In order to enable Hubble, run the command ``cilium hubble enable`` as shown
-        below:
+        In order to enable Hubble and install Hubble relay, run the
+        command ``cilium hubble enable`` as shown below:
 
         .. code-block:: shell-session
 
@@ -50,46 +55,45 @@ Enable Hubble in Cilium
             2021/04/13 17:11:24 [INFO] signed certificate with serial number 644167683731852948186644541769558498727586273511
             ✨ Deploying Relay...
 
-
-        .. tip::
-
-           Enabling Hubble requires the TCP port 4244 to be open on all nodes running
-           Cilium. This is required for Relay to operate correctly.
-
-        Run ``cilium status`` to validate that Hubble is enabled and running:
-
-        .. code-block:: shell-session
-
-            $ cilium status
-                /¯¯\
-             /¯¯\__/¯¯\    Cilium:         OK
-             \__/¯¯\__/    Operator:       OK
-             /¯¯\__/¯¯\    Hubble:         OK
-             \__/¯¯\__/    ClusterMesh:    disabled
-                \__/
-
-            DaemonSet         cilium                   Desired: 3, Ready: 3/3, Available: 3/3
-            Deployment        cilium-operator          Desired: 1, Ready: 1/1, Available: 1/1
-            Deployment        hubble-relay             Desired: 1, Ready: 1/1, Available: 1/1
-            Containers:       cilium                   Running: 3
-                              cilium-operator          Running: 1
-                              hubble-relay             Running: 1
-            Image versions    cilium-operator          quay.io/cilium/operator-generic:v1.9.5: 1
-                              hubble-relay             quay.io/cilium/hubble-relay:v1.9.5: 1
-                              cilium                   quay.io/cilium/cilium:v1.9.5: 3
-
     .. group-tab:: Helm
 
-        If you installed Cilium via ``helm install``, you may enable Hubble
-        Relay and UI with the following command:
+        If you installed Cilium via ``helm install``, Hubble is enabled by default.
+        You may enable Hubble Relay with the following command:
 
         .. parsed-literal::
 
            helm upgrade cilium |CHART_RELEASE| \\
               --namespace kube-system \\
               --reuse-values \\
-              --set hubble.relay.enabled=true \\
-              --set hubble.ui.enabled=true
+              --set hubble.relay.enabled=true
+
+Run ``cilium status`` to validate that Hubble is enabled and running:
+
+.. code-block:: shell-session
+
+    $ cilium status
+        /¯¯\
+     /¯¯\__/¯¯\    Cilium:             OK
+     \__/¯¯\__/    Operator:           OK
+     /¯¯\__/¯¯\    Envoy DaemonSet:    OK
+     \__/¯¯\__/    Hubble Relay:       OK
+        \__/       ClusterMesh:        disabled
+
+    DaemonSet             cilium                   Desired: 1, Ready: 1/1, Available: 1/1
+    DaemonSet             cilium-envoy             Desired: 1, Ready: 1/1, Available: 1/1
+    Deployment            cilium-operator          Desired: 1, Ready: 1/1, Available: 1/1
+    Deployment            hubble-relay             Desired: 1, Ready: 1/1, Available: 1/1
+    Containers:           cilium                   Running: 1
+                          cilium-envoy             Running: 1
+                          cilium-operator          Running: 1
+                          clustermesh-apiserver
+                          hubble-relay             Running: 1
+    Cluster Pods:         8/8 managed by Cilium
+    Helm chart version:   1.17.0
+    Image versions        cilium             quay.io/cilium/cilium:latest: 1
+                          cilium-envoy       quay.io/cilium/cilium-envoy:v1.32.3-1739240299-e85e926b0fa4cec519cefff54b60bd7942d7871b@sha256:ced8a89d642d10d648471afc2d8737238f1479c368955e6f2553ded58029ac88: 1
+                          cilium-operator    quay.io/cilium/operator-generic-ci:latest: 1
+                          hubble-relay       quay.io/cilium/hubble-relay-ci:latest: 1
 
 .. _hubble_cli_install:
 

--- a/Documentation/observability/hubble/setup.rst
+++ b/Documentation/observability/hubble/setup.rst
@@ -151,25 +151,16 @@ Select the tab for your platform below and install the latest release of Hubble 
 .. _hubble_validate_api_access:
 
 Validate Hubble API Access
-====================================
+==========================
 
-In order to access the Hubble API, create a port forward to the Hubble service
-from your local machine. This will allow you to connect the Hubble client to
-the local port ``4245`` and access the Hubble Relay service in your Kubernetes
-cluster. For more information on this method, see `Use Port Forwarding to Access Application in a Cluster <https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/>`_.
-
-.. code-block:: shell-session
-
-    $ cilium hubble port-forward&
-    Forwarding from 0.0.0.0:4245 -> 4245
-    Forwarding from [::]:4245 -> 4245
+.. include:: port-forward.rst
 
 Now you can validate that you can access the Hubble API via the installed CLI:
 
 .. code-block:: shell-session
 
-    $ hubble status
-    Healthcheck (via localhost:4245): Ok
+    $ hubble status -P
+    Healthcheck (via 127.0.0.1:4245): Ok
     Current/Max Flows: 11917/12288 (96.98%)
     Flows/s: 11.74
     Connected Nodes: 3/3
@@ -178,16 +169,19 @@ You can also query the flow API and look for flows:
 
 .. code-block:: shell-session
 
-   $ hubble observe
+   $ hubble observe -P
+   Feb 12 19:13:58.111: kube-system/hubble-relay-6467f4f4d-xrxfs:47550 (ID:95552) -> 172.18.0.2:4244 (host) to-stack FORWARDED (TCP Flags: ACK, PSH)
+   ...
 
 .. note::
 
-   If you port forward to a port other than ``4245``, make sure to use the
-   ``--server`` flag or ``HUBBLE_SERVER`` environment variable to set the
-   Hubble server address (default: ``localhost:4245``). For more information,
-   check out Hubble CLI's help message by running ``hubble help status`` or
-   ``hubble help observe`` as well as ``hubble config`` for  configuring Hubble
-   CLI.
+   If you port forward to a port other than ``4245`` (``--port-forward-port PORT``
+   when using automatic port-forwarding), make sure to use the ``--server`` flag
+   or ``HUBBLE_SERVER`` environment variable to set the Hubble server address
+   (default: ``localhost:4245``).
+
+   For more information, check out Hubble CLI's help message by running ``hubble help status``
+   or ``hubble help observe`` as well as ``hubble config`` for  configuring Hubble CLI.
 
 .. note::
 

--- a/Documentation/observability/hubble/setup.rst
+++ b/Documentation/observability/hubble/setup.rst
@@ -191,6 +191,179 @@ You can also query the flow API and look for flows:
 
    If you have :ref:`enabled TLS<hubble_enable_tls>` then you will need to specify additional flags to :ref:`access the Hubble API<hubble_api_tls>`.
 
+Troubleshooting Hubble Deployment
+=================================
+
+Validate the state of Hubble and/or Hubble Relay by running ``cilium status``:
+
+.. code-block:: shell-session
+
+    $ cilium status
+        /¯¯\
+     /¯¯\__/¯¯\    Cilium:             OK
+     \__/¯¯\__/    Operator:           OK
+     /¯¯\__/¯¯\    Envoy DaemonSet:    OK
+     \__/¯¯\__/    Hubble Relay:       OK
+        \__/       ClusterMesh:        disabled
+
+    DaemonSet             cilium                   Desired: 1, Ready: 1/1, Available: 1/1
+    DaemonSet             cilium-envoy             Desired: 1, Ready: 1/1, Available: 1/1
+    Deployment            cilium-operator          Desired: 1, Ready: 1/1, Available: 1/1
+    Deployment            hubble-relay             Desired: 1, Ready: 1/1, Available: 1/1
+    Containers:           cilium                   Running: 1
+                          cilium-envoy             Running: 1
+                          cilium-operator          Running: 1
+                          clustermesh-apiserver
+                          hubble-relay             Running: 1
+    Cluster Pods:         8/8 managed by Cilium
+    Helm chart version:   1.17.0
+    Image versions        cilium             quay.io/cilium/cilium:latest: 1
+                          cilium-envoy       quay.io/cilium/cilium-envoy:v1.32.3-1739240299-e85e926b0fa4cec519cefff54b60bd7942d7871b@sha256:ced8a89d642d10d648471afc2d8737238f1479c368955e6f2553ded58029ac88: 1
+                          cilium-operator    quay.io/cilium/operator-generic-ci:latest: 1
+                          hubble-relay       quay.io/cilium/hubble-relay-ci:latest: 1
+
+Hubble Relay
+------------
+
+If Hubble Relay is enabled, ``cilium status`` should display: ``OK``.
+Otherwise, we should expect to see errors/warnings reported:
+
+.. code-block:: shell-session
+
+    $ cilium status
+        /¯¯\
+     /¯¯\__/¯¯\    Cilium:             OK
+     \__/¯¯\__/    Operator:           OK
+     /¯¯\__/¯¯\    Envoy DaemonSet:    OK
+     \__/¯¯\__/    Hubble Relay:       1 errors, 2 warnings
+        \__/       ClusterMesh:        disabled
+
+    DaemonSet              cilium                   Desired: 1, Ready: 1/1, Available: 1/1
+    DaemonSet              cilium-envoy             Desired: 1, Ready: 1/1, Available: 1/1
+    Deployment             cilium-operator          Desired: 1, Ready: 1/1, Available: 1/1
+    Deployment             hubble-relay             Desired: 1, Unavailable: 1/1
+    Containers:            cilium                   Running: 1
+                           cilium-envoy             Running: 1
+                           cilium-operator          Running: 1
+                           clustermesh-apiserver
+                           hubble-relay             Pending: 1
+    Cluster Pods:          8/8 managed by Cilium
+    Helm chart version:    1.17.0
+    Image versions         cilium             quay.io/cilium/cilium:latest: 1
+                           cilium-envoy       quay.io/cilium/cilium-envoy:v1.32.3-1739240299-e85e926b0fa4cec519cefff54b60bd7942d7871b@sha256:ced8a89d642d10d648471afc2d8737238f1479c368955e6f2553ded58029ac88: 1
+                           cilium-operator    quay.io/cilium/operator-generic-ci:latest: 1
+                           hubble-relay       quay.io/cilium/hubble-relay-ci:latest-: 1
+    Errors:                hubble-relay       hubble-relay                     1 pods of Deployment hubble-relay are not ready
+    Warnings:              hubble-relay       hubble-relay-85f98cc7df-s2lkq    pod is pending
+                           hubble-relay       hubble-relay-85f98cc7df-s2lkq    pod is pending
+
+.. tip::
+
+    If warnings or errors are reported for both ``Cilium`` and ``Hubble Relay``, it
+    often hints at a misconfiguration in Hubble or the Hubble system failing to start.
+    Since Hubble is a non-critical system running in the Cilium Agent, it is expected
+    for the Cilium pods to remain running and healthy even when Hubble fails to start.
+    See the :ref:`hubble_setup_troubleshooting` section below for Hubble-specific troubleshooting
+    steps.
+
+Verify the state of the pods with:
+
+.. code-block:: shell-session
+
+    $ kubectl -n kube-system get pods -l k8s-app=hubble-relay
+    NAME                           READY   STATUS             RESTARTS      AGE
+    hubble-relay-6467f4f4d-x825b   0/1     CrashLoopBackOff   5 (19s ago)   7m28s
+
+If one or more pods are in ``Pending`` state, describe the pod(s) with:
+
+.. code-block:: shell-session
+
+    $ kubectl describe -n kube-system pod/cilium-5bjkq
+    Name:             hubble-relay-6467f4f4d-x825b
+    Namespace:        kube-system
+    ...
+
+If one or more pods are not in ``Running`` state, look at the pod(s) logs with:
+
+.. code-block:: shell-session
+
+    $ kubectl -n kube-system logs hubble-relay-6467f4f4d-x825b
+    time="2025-02-12T21:21:40.246596435Z" level=info msg="Starting gRPC health server..." addr=":4222" subsys=hubble-relay
+    time="2025-02-12T21:21:40.246611018Z" level=info msg="Starting gRPC server..." options="{peerTarget:hubble-peer.kube-system.svc.cluster.local.:443 retryTimeout:30000000000 listenAddress::4245 healthListenAddress::4222 metricsListenAddress: log:0x400038fc00 serverTLSConfig:<nil> insecureServer:true clientTLSConfig:0x4000b12528 clusterName:cluster insecureClient:false observerOptions:[0x28cb1e0 0x28cb2e0] grpcMetrics:<nil> grpcUnaryInterceptors:[] grpcStreamInterceptors:[]}" subsys=hubble-relay
+    time="2025-02-12T21:21:40.251658493Z" level=info msg="Failed to create peer notify client for peers change notification; will try again after the timeout has expired" connection timeout=30s error="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 10.96.49.4:443: connect: connection refused\"" subsys=hubble-relay
+    time="2025-02-12T21:22:10.25956541Z" level=info msg="Failed to create peer notify client for peers change notification; will try again after the timeout has expired" connection timeout=30s error="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 10.96.49.4:443: connect: connection refused\"" subsys=hubble-relay
+    time="2025-02-12T21:22:40.265123839Z" level=info msg="Failed to create peer notify client for peers change notification; will try again after the timeout has expired" connection timeout=30s error="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 10.96.49.4:443: connect: connection refused\"" subsys=hubble-relay
+    time="2025-02-12T21:22:49.055746359Z" level=info msg="Stopping server..." subsys=hubble-relay
+    time="2025-02-12T21:22:49.056293486Z" level=info msg="Server stopped" subsys=hubble-relay
+
+If you face a ``connection refused`` error, it means that Hubble-Relay can't connect
+to the Hubble API exposed by Cilium agents through the ``hubble-peer`` service.
+See the :ref:`hubble_setup_troubleshooting` section below for Hubble-specific troubleshooting
+steps.
+
+For TLS related errors, see :ref:`Hubble TLS Troubleshooting<hubble_enable_tls_troubleshooting>`.
+
+.. _hubble_setup_troubleshooting:
+
+Hubble
+------
+
+If Hubble is enabled, ``cilium status`` should display: ``OK`` for ``Cilium``.
+Otherwise, we should expect to see errors/warnings reported:
+
+.. code-block:: shell-session
+
+    $ cilium status
+        /¯¯\
+     /¯¯\__/¯¯\    Cilium:             1 warnings
+     \__/¯¯\__/    Operator:           OK
+     /¯¯\__/¯¯\    Envoy DaemonSet:    OK
+     \__/¯¯\__/    Hubble Relay:       1 errors
+        \__/       ClusterMesh:        disabled
+
+    DaemonSet              cilium                   Desired: 1, Ready: 1/1, Available: 1/1
+    DaemonSet              cilium-envoy             Desired: 1, Ready: 1/1, Available: 1/1
+    Deployment             cilium-operator          Desired: 1, Ready: 1/1, Available: 1/1
+    Deployment             hubble-relay             Desired: 1, Unavailable: 1/1
+    Containers:            cilium                   Running: 1
+                           cilium-envoy             Running: 1
+                           cilium-operator          Running: 1
+                           clustermesh-apiserver
+                           hubble-relay             Running: 1
+    Cluster Pods:          8/8 managed by Cilium
+    Helm chart version:    1.17.0
+    Image versions         cilium             quay.io/cilium/cilium:latest: 1
+                           cilium-envoy       quay.io/cilium/cilium-envoy:v1.32.3-1739240299-e85e926b0fa4cec519cefff54b60bd7942d7871b@sha256:ced8a89d642d10d648471afc2d8737238f1479c368955e6f2553ded58029ac88: 1
+                           cilium-operator    quay.io/cilium/operator-generic-ci:latest: 1
+                           hubble-relay       quay.io/cilium/hubble-relay-ci:latest: 1
+    Errors:                hubble-relay       hubble-relay    1 pods of Deployment hubble-relay are not ready
+    Warnings:              cilium             cilium-5bjkq    Hubble: failed to setup metrics: metric 'unknown-metric' does not exist
+
+Verify the state of the pods with:
+
+.. code-block:: shell-session
+
+    $ kubectl -n kube-system get pods -l k8s-app=cilium
+    NAME           READY   STATUS    RESTARTS      AGE
+    cilium-5bjkq   1/1     Running   1 (18m ago)   33m
+
+If one or more pods are in ``Pending`` state, describe the pod(s) with:
+
+.. code-block:: shell-session
+
+    $ kubectl describe -n kube-system pod/cilium-5bjkq
+    Name:                 cilium-5bjkq
+    Namespace:            kube-system
+    ...
+
+If one or more pods are not in ``Running`` state, look at the pod(s) logs with:
+
+.. code-block:: shell-session
+
+    $ kubectl logs -n kube-system -c cilium-agent -l k8s-app=cilium --tail=-1 | grep subsys=hubble
+    time="2025-02-12T22:12:01.227357082Z" level=info msg="Starting Hubble Metrics server" address=":9965" metrics=unknown-metric subsys=hubble tls=false
+    time="2025-02-12T22:12:01.22740229Z" level=error msg="Failed to launch hubble" error="failed to setup metrics: metric 'unknown-metric' does not exist" subsys=hubble
+
 Next Steps
 ==========
 

--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -222,27 +222,20 @@ simultaneously and aggregate the results. See :ref:`hubble_setup` to enable
 Hubble Relay if it is not yet enabled and install the Hubble CLI on your local
 machine.
 
-You may access the Hubble Relay service by port-forwarding it locally:
-
-.. code-block:: shell-session
-
-   kubectl -n kube-system port-forward service/hubble-relay --address 0.0.0.0 --address :: 4245:80
-
-This will forward the Hubble Relay service port (``80``) to your local machine
-on port ``4245`` on all of it's IP addresses.
+.. include:: /observability/hubble/port-forward.rst
 
 You can verify that Hubble Relay can be reached by using the Hubble CLI and
 running the following command from your local machine:
 
 .. code-block:: shell-session
 
-   hubble status
+   hubble status -P
 
 This command should return an output similar to the following:
 
 ::
 
-   Healthcheck (via localhost:4245): Ok
+   Healthcheck (via 127.0.0.1:4245): Ok
    Current/Max Flows: 16380/16380 (100.00%)
    Flows/s: 46.19
    Connected Nodes: 4/4
@@ -252,7 +245,10 @@ the following command:
 
 .. code-block:: shell-session
 
-   hubble list nodes
+   $ hubble list nodes -P
+   NAME              STATUS      AGE     FLOWS/S   CURRENT/MAX-FLOWS
+   cluster/node-cp   Connected   2m30s   13.94     2227/4095 ( 54.38%)
+   cluster/node-w1   Connected   2m31s   51.37     5108/9840 ( 51.91%)
 
 As Hubble Relay shares the same API as individual Hubble instances, you may
 follow the `Observing flows with Hubble`_ section keeping in mind that


### PR DESCRIPTION
Add a new section in the Hubble setup documentation to help troubleshoot the Hubble deployment, including Hubble Relay
and the Hubble system running in the Cilium agent.

The new section is relatively light but offers a good start, especially combined with the linked PR to bubble-up the hubble startup errors into `cilium status`. More so, this section now makes it clearer that hubble-relay issues might be related to Hubble errors, which is currently the majority of cases we see in bug reports.

While here, I also updated the `Validate Hubble API Access` and `Observing flows with Hubble Relay` sections to use the new automatic port-forwarding feature of the Hubble CLI released in 1.17. Plus some consistency changes in the setup hubble page. See commits for more details. 

Related: #37567
Fixes: #37023