### PR TITLE
Generalize sockets library and add test coverage for serviceLB. 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -530,6 +530,7 @@ Makefile* @cilium/build
 /pkg/datapath/loader/ @cilium/loader
 /pkg/datapath/types/ipsec.go @cilium/ipsec
 /pkg/datapath/types/loader.go @cilium/loader
+/pkg/datapath/sockets/ @cilium/sig-lb
 /pkg/defaults @cilium/sig-agent
 /pkg/debug @cilium/sig-agent
 /pkg/dial @cilium/sig-agent

--- a/pkg/loadbalancer/experimental/adapters.go
+++ b/pkg/loadbalancer/experimental/adapters.go
@@ -512,7 +512,7 @@ func (s *serviceManagerAdapter) SyncWithK8sFinished(localOnly bool, localService
 }
 
 // TerminateUDPConnectionsToBackend implements service.ServiceManager.
-func (s *serviceManagerAdapter) TerminateUDPConnectionsToBackend(l3n4Addr *loadbalancer.L3n4Addr) {
+func (s *serviceManagerAdapter) TerminateUDPConnectionsToBackend(l3n4Addr *loadbalancer.L3n4Addr) error {
 	// Used by LRP, but not when new implementation is enabled.
 	panic("unimplemented")
 }

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -44,7 +44,7 @@ var (
 type svcManager interface {
 	DeleteService(frontend lb.L3n4Addr) (bool, error)
 	UpsertService(*lb.SVC) (bool, lb.ID, error)
-	TerminateUDPConnectionsToBackend(l3n4Addr *lb.L3n4Addr)
+	TerminateUDPConnectionsToBackend(l3n4Addr *lb.L3n4Addr) error
 }
 
 type svcCache interface {

--- a/pkg/redirectpolicy/manager_test.go
+++ b/pkg/redirectpolicy/manager_test.go
@@ -106,10 +106,11 @@ func (f *fakeSvcManager) UpsertService(s *lb.SVC) (bool, lb.ID, error) {
 	return true, 1, nil
 }
 
-func (f *fakeSvcManager) TerminateUDPConnectionsToBackend(l3n4Addr *lb.L3n4Addr) {
+func (f *fakeSvcManager) TerminateUDPConnectionsToBackend(l3n4Addr *lb.L3n4Addr) error {
 	if f.destroyConnectionEvents != nil {
 		f.destroyConnectionEvents <- *l3n4Addr
 	}
+	return nil
 }
 
 type fakeEpManager struct {

--- a/pkg/service/cell.go
+++ b/pkg/service/cell.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/types"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 // Cell provides access to the Service Manager.
@@ -40,6 +41,8 @@ type serviceManagerParams struct {
 	HealthCheckers []HealthChecker `group:"healthCheckers"`
 	Clientset      k8sClient.Clientset
 	NodeNeighbors  types.NodeNeighbors
+
+	Config *option.DaemonConfig
 }
 
 func newServiceInternal(params serviceManagerParams) *Service {
@@ -50,7 +53,8 @@ func newServiceInternal(params serviceManagerParams) *Service {
 		}
 	}
 
-	svc := newService(params.Logger, params.MonitorAgent, params.LBMap, params.NodeNeighbors, enabledHealthCheckers, params.Clientset.IsEnabled())
+	svc := newService(params.Logger, params.MonitorAgent, params.LBMap, params.NodeNeighbors, enabledHealthCheckers, params.Clientset.IsEnabled(),
+		params.Config)
 
 	params.JG.Add(job.OneShot("health-check-event-watcher", svc.handleHealthCheckEvent))
 

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -232,7 +232,7 @@ func setupManagerTestSuite(tb testing.TB) *ManagerTestSuite {
 }
 
 func (m *ManagerTestSuite) newServiceMock(ctx context.Context, lbmap datapathTypes.LBMap) {
-	m.svc = newService(m.logger, &FakeMonitorAgent{}, lbmap, nil, nil, true)
+	m.svc = newService(m.logger, &FakeMonitorAgent{}, lbmap, nil, nil, true, option.Config)
 	m.svc.backendConnectionHandler = testsockets.NewMockSockets(make([]*testsockets.MockSocket, 0))
 	health, _ := cell.NewSimpleHealth()
 	go m.svc.handleHealthCheckEvent(ctx, health)
@@ -773,7 +773,7 @@ func TestRestoreServiceWithStaleBackends(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			lbmap := mockmaps.NewLBMockMap()
 			logger := hivetest.Logger(t)
-			svc := newService(logger, &FakeMonitorAgent{}, lbmap, nil, nil, true)
+			svc := newService(logger, &FakeMonitorAgent{}, lbmap, nil, nil, true, option.Config)
 
 			_, id1, err := svc.upsertService(service("foo", "bar", "172.16.0.1", backendAddrs...))
 			require.NoError(t, err, "Failed to upsert service")
@@ -783,7 +783,7 @@ func TestRestoreServiceWithStaleBackends(t *testing.T) {
 			require.ElementsMatch(t, backendAddrs, toBackendAddrs(slices.Collect(maps.Values(lbmap.BackendByID))), "lbmap not populated correctly")
 
 			// Recreate the Service structure, but keep the lbmap to restore services from
-			svc = newService(logger, &FakeMonitorAgent{}, lbmap, nil, nil, true)
+			svc = newService(logger, &FakeMonitorAgent{}, lbmap, nil, nil, true, option.Config)
 			require.NoError(t, svc.RestoreServices(), "Failed to restore services")
 
 			// Simulate a set of service updates. Until synchronization completes, a given service
@@ -2371,7 +2371,7 @@ func TestRestoreServicesWithLeakedBackends(t *testing.T) {
 	require.Len(t, m.lbmap.BackendByID, len(backends)+4)
 	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
 	logger := hivetest.Logger(t)
-	m.svc = newService(logger, &FakeMonitorAgent{}, lbmap, nil, nil, true)
+	m.svc = newService(logger, &FakeMonitorAgent{}, lbmap, nil, nil, true, option.Config)
 
 	// Restore services from lbmap
 	err := m.svc.RestoreServices()

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -83,5 +83,5 @@ type ServiceManager interface {
 
 	// TerminateUDPConnectionsToBackend terminates UDP connections to the passed
 	// backend with address when socket-LB is enabled.
-	TerminateUDPConnectionsToBackend(l3n4Addr *lb.L3n4Addr)
+	TerminateUDPConnectionsToBackend(l3n4Addr *lb.L3n4Addr) error
 }

--- a/pkg/testutils/mockmaps/lbmap.go
+++ b/pkg/testutils/mockmaps/lbmap.go
@@ -273,3 +273,23 @@ func (m *LBMockMap) ExistsSockRevNat(cookie uint64, addr net.IP, port uint16) bo
 
 	return false
 }
+
+// AddSockRevNat inserts a socket reverse nat entry. This simulates a socket
+// being tracked via the svc lb rev socket map.
+func (m *LBMockMap) AddSockRevNat(cookie uint64, addr net.IP, port uint16) {
+	if addr.To4() != nil {
+		key := lbmap.NewSockRevNat4Key(cookie, addr, port)
+		m.SockRevNat4[*key] = lbmap.SockRevNat4Value{
+			Address:     key.Address,
+			Port:        int16(port),
+			RevNatIndex: 0,
+		}
+	} else {
+		key := lbmap.NewSockRevNat6Key(cookie, addr, port)
+		m.SockRevNat6[*key] = lbmap.SockRevNat6Value{
+			Address:     key.Address,
+			Port:        int16(port),
+			RevNatIndex: 0,
+		}
+	}
+}


### PR DESCRIPTION
The `datapath/sockets` code evolved from the use-case of serviceLB socket termination.  This makes the code very specific to that code. Instead this generalizes the underlying code to expose more general functions for iterating and closing sockets via netlink.


```release-note
Make datapath sockets code more general to promote code reuse.
```
