### PR TITLE
kpr: Support kube-apiserver HA

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -286,6 +286,7 @@ cilium-agent [flags]
       --ipv6-range string                                         Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
       --ipv6-service-range string                                 Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
       --k8s-api-server string                                     Kubernetes API server URL
+      --k8s-api-server-urls strings                               Kubernetes API server URLs
       --k8s-client-burst int                                      Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration                 Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                    Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -285,7 +285,6 @@ cilium-agent [flags]
       --ipv6-pod-subnets strings                                  List of IPv6 pod subnets to preconfigure for encryption
       --ipv6-range string                                         Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
       --ipv6-service-range string                                 Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
-      --k8s-api-server string                                     Kubernetes API server URL
       --k8s-api-server-urls strings                               Kubernetes API server URLs
       --k8s-client-burst int                                      Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration                 Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -127,7 +127,6 @@ cilium-agent hive [flags]
       --ingress-secrets-namespace string                          IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --iptables-random-fully                                     Set iptables flag random-fully on masquerading rules
-      --k8s-api-server string                                     Kubernetes API server URL
       --k8s-api-server-urls strings                               Kubernetes API server URLs
       --k8s-client-burst int                                      Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration                 Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -128,6 +128,7 @@ cilium-agent hive [flags]
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --iptables-random-fully                                     Set iptables flag random-fully on masquerading rules
       --k8s-api-server string                                     Kubernetes API server URL
+      --k8s-api-server-urls strings                               Kubernetes API server URLs
       --k8s-client-burst int                                      Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration                 Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                    Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -132,7 +132,6 @@ cilium-agent hive dot-graph [flags]
       --ingress-secrets-namespace string                          IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --iptables-random-fully                                     Set iptables flag random-fully on masquerading rules
-      --k8s-api-server string                                     Kubernetes API server URL
       --k8s-api-server-urls strings                               Kubernetes API server URLs
       --k8s-client-burst int                                      Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration                 Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -133,6 +133,7 @@ cilium-agent hive dot-graph [flags]
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --iptables-random-fully                                     Set iptables flag random-fully on masquerading rules
       --k8s-api-server string                                     Kubernetes API server URL
+      --k8s-api-server-urls strings                               Kubernetes API server URLs
       --k8s-client-burst int                                      Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration                 Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                    Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-dbg_build-config.md
+++ b/Documentation/cmdref/cilium-dbg_build-config.md
@@ -17,7 +17,6 @@ cilium-dbg build-config --node-name $K8S_NODE_NAME [flags]
       --enable-k8s                                  Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                    Enable discovery of Kubernetes API groups and resources with the discovery API
   -h, --help                                        help for build-config
-      --k8s-api-server string                       Kubernetes API server URL
       --k8s-api-server-urls strings                 Kubernetes API server URLs
       --k8s-client-burst int                        Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration   Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-dbg_build-config.md
+++ b/Documentation/cmdref/cilium-dbg_build-config.md
@@ -18,6 +18,7 @@ cilium-dbg build-config --node-name $K8S_NODE_NAME [flags]
       --enable-k8s-api-discovery                    Enable discovery of Kubernetes API groups and resources with the discovery API
   -h, --help                                        help for build-config
       --k8s-api-server string                       Kubernetes API server URL
+      --k8s-api-server-urls strings                 Kubernetes API server URLs
       --k8s-client-burst int                        Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration   Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration      Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-dbg_preflight_migrate-identity.md
+++ b/Documentation/cmdref/cilium-dbg_preflight_migrate-identity.md
@@ -25,7 +25,6 @@ cilium-dbg preflight migrate-identity [flags]
       --enable-k8s                                  Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                    Enable discovery of Kubernetes API groups and resources with the discovery API
   -h, --help                                        help for migrate-identity
-      --k8s-api-server string                       Kubernetes API server URL
       --k8s-api-server-urls strings                 Kubernetes API server URLs
       --k8s-client-burst int                        Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration   Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-dbg_preflight_migrate-identity.md
+++ b/Documentation/cmdref/cilium-dbg_preflight_migrate-identity.md
@@ -26,6 +26,7 @@ cilium-dbg preflight migrate-identity [flags]
       --enable-k8s-api-discovery                    Enable discovery of Kubernetes API groups and resources with the discovery API
   -h, --help                                        help for migrate-identity
       --k8s-api-server string                       Kubernetes API server URL
+      --k8s-api-server-urls strings                 Kubernetes API server URLs
       --k8s-client-burst int                        Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration   Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration      Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-dbg_preflight_validate-cnp.md
+++ b/Documentation/cmdref/cilium-dbg_preflight_validate-cnp.md
@@ -21,7 +21,6 @@ cilium-dbg preflight validate-cnp [flags]
       --enable-k8s                                  Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                    Enable discovery of Kubernetes API groups and resources with the discovery API
   -h, --help                                        help for validate-cnp
-      --k8s-api-server string                       Kubernetes API server URL
       --k8s-api-server-urls strings                 Kubernetes API server URLs
       --k8s-client-burst int                        Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration   Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-dbg_preflight_validate-cnp.md
+++ b/Documentation/cmdref/cilium-dbg_preflight_validate-cnp.md
@@ -22,6 +22,7 @@ cilium-dbg preflight validate-cnp [flags]
       --enable-k8s-api-discovery                    Enable discovery of Kubernetes API groups and resources with the discovery API
   -h, --help                                        help for validate-cnp
       --k8s-api-server string                       Kubernetes API server URL
+      --k8s-api-server-urls strings                 Kubernetes API server URLs
       --k8s-client-burst int                        Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration   Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration      Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -87,6 +87,7 @@ cilium-operator-alibabacloud [flags]
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "alibabacloud")
       --k8s-api-server string                                Kubernetes API server URL
+      --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -86,7 +86,6 @@ cilium-operator-alibabacloud [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "alibabacloud")
-      --k8s-api-server string                                Kubernetes API server URL
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -65,6 +65,7 @@ cilium-operator-alibabacloud hive [flags]
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
+      --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -64,7 +64,6 @@ cilium-operator-alibabacloud hive [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -69,7 +69,6 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -70,6 +70,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
+      --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -94,7 +94,6 @@ cilium-operator-aws [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "eni")
-      --k8s-api-server string                                Kubernetes API server URL
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -95,6 +95,7 @@ cilium-operator-aws [flags]
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "eni")
       --k8s-api-server string                                Kubernetes API server URL
+      --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -64,7 +64,6 @@ cilium-operator-aws hive [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -65,6 +65,7 @@ cilium-operator-aws hive [flags]
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
+      --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -70,6 +70,7 @@ cilium-operator-aws hive dot-graph [flags]
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
+      --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -69,7 +69,6 @@ cilium-operator-aws hive dot-graph [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -89,7 +89,6 @@ cilium-operator-azure [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "azure")
-      --k8s-api-server string                                Kubernetes API server URL
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -90,6 +90,7 @@ cilium-operator-azure [flags]
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "azure")
       --k8s-api-server string                                Kubernetes API server URL
+      --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -65,6 +65,7 @@ cilium-operator-azure hive [flags]
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
+      --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -64,7 +64,6 @@ cilium-operator-azure hive [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -69,7 +69,6 @@ cilium-operator-azure hive dot-graph [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -70,6 +70,7 @@ cilium-operator-azure hive dot-graph [flags]
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
+      --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -85,7 +85,6 @@ cilium-operator-generic [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "cluster-pool")
-      --k8s-api-server string                                Kubernetes API server URL
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -86,6 +86,7 @@ cilium-operator-generic [flags]
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server string                                Kubernetes API server URL
+      --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -65,6 +65,7 @@ cilium-operator-generic hive [flags]
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
+      --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -64,7 +64,6 @@ cilium-operator-generic hive [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -69,7 +69,6 @@ cilium-operator-generic hive dot-graph [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -70,6 +70,7 @@ cilium-operator-generic hive dot-graph [flags]
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
+      --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -99,7 +99,6 @@ cilium-operator [flags]
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "cluster-pool")
-      --k8s-api-server string                                Kubernetes API server URL
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -100,6 +100,7 @@ cilium-operator [flags]
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server string                                Kubernetes API server URL
+      --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -64,7 +64,6 @@ cilium-operator hive [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -65,6 +65,7 @@ cilium-operator hive [flags]
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
+      --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -69,7 +69,6 @@ cilium-operator hive dot-graph [flags]
       --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server string                                Kubernetes API server URL
       --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -70,6 +70,7 @@ cilium-operator hive dot-graph [flags]
       --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
+      --k8s-api-server-urls strings                          Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)

--- a/Documentation/cmdref/clustermesh-apiserver_clustermesh.md
+++ b/Documentation/cmdref/clustermesh-apiserver_clustermesh.md
@@ -26,7 +26,6 @@ clustermesh-apiserver clustermesh [flags]
       --gops-port uint16                             Port for gops server to listen on (default 9892)
       --health-port int                              TCP port for ClusterMesh health API (default 9880)
   -h, --help                                         help for clustermesh
-      --k8s-api-server string                        Kubernetes API server URL
       --k8s-api-server-urls strings                  Kubernetes API server URLs
       --k8s-client-burst int                         Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration    Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/clustermesh-apiserver_clustermesh.md
+++ b/Documentation/cmdref/clustermesh-apiserver_clustermesh.md
@@ -27,6 +27,7 @@ clustermesh-apiserver clustermesh [flags]
       --health-port int                              TCP port for ClusterMesh health API (default 9880)
   -h, --help                                         help for clustermesh
       --k8s-api-server string                        Kubernetes API server URL
+      --k8s-api-server-urls strings                  Kubernetes API server URLs
       --k8s-client-burst int                         Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration    Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration       Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/clustermesh-apiserver_clustermesh_hive.md
+++ b/Documentation/cmdref/clustermesh-apiserver_clustermesh_hive.md
@@ -26,7 +26,6 @@ clustermesh-apiserver clustermesh hive [flags]
       --gops-port uint16                             Port for gops server to listen on (default 9892)
       --health-port int                              TCP port for ClusterMesh health API (default 9880)
   -h, --help                                         help for hive
-      --k8s-api-server string                        Kubernetes API server URL
       --k8s-api-server-urls strings                  Kubernetes API server URLs
       --k8s-client-burst int                         Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration    Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/clustermesh-apiserver_clustermesh_hive.md
+++ b/Documentation/cmdref/clustermesh-apiserver_clustermesh_hive.md
@@ -27,6 +27,7 @@ clustermesh-apiserver clustermesh hive [flags]
       --health-port int                              TCP port for ClusterMesh health API (default 9880)
   -h, --help                                         help for hive
       --k8s-api-server string                        Kubernetes API server URL
+      --k8s-api-server-urls strings                  Kubernetes API server URLs
       --k8s-client-burst int                         Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration    Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration       Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/clustermesh-apiserver_clustermesh_hive_dot-graph.md
+++ b/Documentation/cmdref/clustermesh-apiserver_clustermesh_hive_dot-graph.md
@@ -32,6 +32,7 @@ clustermesh-apiserver clustermesh hive dot-graph [flags]
       --gops-port uint16                             Port for gops server to listen on (default 9892)
       --health-port int                              TCP port for ClusterMesh health API (default 9880)
       --k8s-api-server string                        Kubernetes API server URL
+      --k8s-api-server-urls strings                  Kubernetes API server URLs
       --k8s-client-burst int                         Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration    Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration       Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/clustermesh-apiserver_clustermesh_hive_dot-graph.md
+++ b/Documentation/cmdref/clustermesh-apiserver_clustermesh_hive_dot-graph.md
@@ -31,7 +31,6 @@ clustermesh-apiserver clustermesh hive dot-graph [flags]
       --enable-k8s-endpoint-slice                    Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
       --gops-port uint16                             Port for gops server to listen on (default 9892)
       --health-port int                              TCP port for ClusterMesh health API (default 9880)
-      --k8s-api-server string                        Kubernetes API server URL
       --k8s-api-server-urls strings                  Kubernetes API server URLs
       --k8s-client-burst int                         Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration    Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1735,6 +1735,21 @@ As per `k8s Service <https://kubernetes.io/docs/concepts/services-networking/ser
 Cilium's eBPF kube-proxy replacement by default disallows access to a ClusterIP service from outside the cluster.
 This can be allowed by setting ``bpf.lbExternalClusterIP=true``.
 
+Kubernetes API server high availability
+***************************************
+
+If you are running multiple instances of Kubernetes API servers in your cluster, you can set the ``k8s-api-server-urls`` flag
+so that Cilium can fail over to an active instance. Cilium switches to the ``kubernetes`` service address so that
+API requests are load-balanced to API server endpoints during runtime. However, if the initially configured API servers
+are rotated while the agent is down, you can update the ``k8s-api-server-urls`` flag with the updated API servers.
+
+.. parsed-literal::
+
+    helm install cilium |CHART_RELEASE| \\
+        --namespace kube-system \\
+        --set kubeProxyReplacement=true \\
+        --set k8s.apiServerURLs="https://172.21.0.4:6443 https://172.21.0.5:6443 https://172.21.0.6:6443"
+
 Observability
 *************
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -307,6 +307,10 @@ Deprecated Options
 
 * Operator flag ``ces-slice-mode`` has been deprecated and will be removed in Cilium 1.19.
   CiliumEndpointSlice batching mode defaults to first-come-first-serve mode.
+* The flag value ``--datapath-mode=lb-only`` for plain Docker mode has been migrated into
+  ``--bpf-lb-only`` and will be removed in Cilium 1.19.
+* ``k8s-api-server``: This option has been deprecated in favor of ``k8s-api-server-urls``
+  and will be removed in Cilium 1.19.
 
 Helm Options
 ~~~~~~~~~~~~
@@ -323,9 +327,14 @@ Helm Options
   ``k8sClientExponentialBackoff.backoffMaxDurationSeconds``. Users who were already setting these
   using ``extraEnv`` should either remove them from ``extraEnv`` or set ``k8sClientExponentialBackoff.enabled=false``.
 * The deprecated Helm option ``hubble.relay.dialTimeout`` has been removed.
+* ``k8s.apiServerURLs`` has been introduced to specify multiple Kubernetes API servers so that the agent can fail over
+  to an active instance.
 
 Agent Options
 ~~~~~~~~~~~~~
+
+``k8s-api-server-urls``: This option specifies a list of URLs for Kubernetes API server instances to support high availability
+for the servers. The agent will fail over to an active instance in case of connectivity failures at runtime.
 
 Bugtool Options
 ~~~~~~~~~~~~~~~

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -864,6 +864,9 @@ data:
 {{- if hasKey .Values.k8s "requireIPv6PodCIDR" }}
   k8s-require-ipv6-pod-cidr: {{ .Values.k8s.requireIPv6PodCIDR | quote }}
 {{- end }}
+{{- if hasKey .Values.k8s "apiServerURLs" }}
+  k8s-api-server-urls: {{ .Values.k8s.apiServerURLs | quote }}
+{{- end }}
 {{- if and .Values.endpointRoutes .Values.endpointRoutes.enabled }}
   enable-endpoint-routes: {{ .Values.endpointRoutes.enabled | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2049,6 +2049,9 @@ k8s:
   # -- requireIPv6PodCIDR enables waiting for Kubernetes to provide the PodCIDR
   # range via the Kubernetes node resource
   requireIPv6PodCIDR: false
+  # -- A space separated list of Kubernetes API server URLs to use with the client.
+  # For example "https://192.168.0.1:6443 https://192.168.0.2:6443"
+  # apiServerURLs: ""
 # -- Keep the deprecated selector labels when deploying Cilium DaemonSet.
 keepDeprecatedLabels: false
 # -- Keep the deprecated probes when deploying Cilium DaemonSet

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2063,6 +2063,10 @@ k8s:
   # -- requireIPv6PodCIDR enables waiting for Kubernetes to provide the PodCIDR
   # range via the Kubernetes node resource
   requireIPv6PodCIDR: false
+  # -- A space separated list of Kubernetes API server URLs to use with the client.
+  # For example "https://192.168.0.1:6443 https://192.168.0.2:6443"
+  # apiServerURLs: ""
+
 # -- Keep the deprecated selector labels when deploying Cilium DaemonSet.
 keepDeprecatedLabels: false
 # -- Keep the deprecated probes when deploying Cilium DaemonSet

--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -26,7 +25,6 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/connrotation"
 	mcsapi_clientset "sigs.k8s.io/mcs-api/pkg/client/clientset/versioned"
 
@@ -40,7 +38,6 @@ import (
 	slim_clientset "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/version"
 )
 
 // client.Cell provides Clientset, a composition of clientsets to Kubernetes resources
@@ -116,12 +113,12 @@ type compositeClientset struct {
 	*CiliumClientset
 	clientsetGetters
 
-	controller    *controller.Manager
-	slim          *SlimClientset
-	config        Config
-	log           logrus.FieldLogger
-	closeAllConns func()
-	restConfig    *rest.Config
+	controller        *controller.Manager
+	slim              *SlimClientset
+	config            Config
+	log               logrus.FieldLogger
+	closeAllConns     func()
+	restConfigManager restConfig
 }
 
 func newClientset(lc cell.Lifecycle, log logrus.FieldLogger, cfg Config) (Clientset, error) {
@@ -133,35 +130,22 @@ func newClientsetForUserAgent(lc cell.Lifecycle, log logrus.FieldLogger, cfg Con
 		return &compositeClientset{disabled: true}, nil
 	}
 
-	if cfg.K8sAPIServer != "" &&
-		!strings.HasPrefix(cfg.K8sAPIServer, "http") {
-		cfg.K8sAPIServer = "http://" + cfg.K8sAPIServer // default to HTTP
-	}
-
 	client := compositeClientset{
 		log:        log,
 		controller: controller.NewManager(),
 		config:     cfg,
 	}
 
-	cmdName := "cilium"
-	if len(os.Args[0]) != 0 {
-		cmdName = filepath.Base(os.Args[0])
-	}
-	userAgent := fmt.Sprintf("%s/%s", cmdName, version.Version)
-
-	if name != "" {
-		userAgent = fmt.Sprintf("%s %s", userAgent, name)
-	}
-
-	restConfig, err := createConfig(cfg.K8sAPIServer, cfg.K8sKubeConfigPath, cfg.K8sClientQPS, cfg.K8sClientBurst, userAgent)
+	var err error
+	client.restConfigManager, err = restConfigManagerInit(cfg, name, log)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create k8s client rest configuration: %w", err)
 	}
-	client.restConfig = restConfig
-	defaultCloseAllConns := setDialer(cfg, restConfig)
+	rc := client.restConfigManager.getConfig()
 
-	httpClient, err := rest.HTTPClientFor(restConfig)
+	defaultCloseAllConns := setDialer(cfg, rc)
+
+	httpClient, err := rest.HTTPClientFor(rc)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create k8s REST client: %w", err)
 	}
@@ -172,29 +156,29 @@ func newClientsetForUserAgent(lc cell.Lifecycle, log logrus.FieldLogger, cfg Con
 		client.closeAllConns = defaultCloseAllConns
 	} else {
 		client.closeAllConns = func() {
-			utilnet.CloseIdleConnectionsFor(restConfig.Transport)
+			utilnet.CloseIdleConnectionsFor(rc.Transport)
 		}
 	}
 
 	// Slim and K8s clients use protobuf marshalling.
-	restConfig.ContentConfig.ContentType = `application/vnd.kubernetes.protobuf`
+	rc.ContentConfig.ContentType = `application/vnd.kubernetes.protobuf`
 
-	client.slim, err = slim_clientset.NewForConfigAndClient(restConfig, httpClient)
+	client.slim, err = slim_clientset.NewForConfigAndClient(rc, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create slim k8s client: %w", err)
 	}
 
-	client.APIExtClientset, err = slim_apiext_clientset.NewForConfigAndClient(restConfig, httpClient)
+	client.APIExtClientset, err = slim_apiext_clientset.NewForConfigAndClient(rc, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create apiext k8s client: %w", err)
 	}
 
-	client.MCSAPIClientset, err = mcsapi_clientset.NewForConfigAndClient(restConfig, httpClient)
+	client.MCSAPIClientset, err = mcsapi_clientset.NewForConfigAndClient(rc, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create mcsapi k8s client: %w", err)
 	}
 
-	client.KubernetesClientset, err = kubernetes.NewForConfigAndClient(restConfig, httpClient)
+	client.KubernetesClientset, err = kubernetes.NewForConfigAndClient(rc, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create k8s client: %w", err)
 	}
@@ -202,8 +186,8 @@ func newClientsetForUserAgent(lc cell.Lifecycle, log logrus.FieldLogger, cfg Con
 	client.clientsetGetters = clientsetGetters{&client}
 
 	// The cilium client uses JSON marshalling.
-	restConfig.ContentConfig.ContentType = `application/json`
-	client.CiliumClientset, err = cilium_clientset.NewForConfigAndClient(restConfig, httpClient)
+	rc.ContentConfig.ContentType = `application/json`
+	client.CiliumClientset, err = cilium_clientset.NewForConfigAndClient(rc, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create cilium k8s client: %w", err)
 	}
@@ -240,7 +224,7 @@ func (c *compositeClientset) Config() Config {
 }
 
 func (c *compositeClientset) RestConfig() *rest.Config {
-	return rest.CopyConfig(c.restConfig)
+	return c.restConfigManager.getConfig()
 }
 
 func (c *compositeClientset) onStart(startCtx cell.HookContext) error {
@@ -311,62 +295,13 @@ func (c *compositeClientset) startHeartbeat() {
 		})
 }
 
-// createConfig creates a rest.Config for connecting to k8s api-server.
-//
-// The precedence of the configuration selection is the following:
-// 1. kubeCfgPath
-// 2. apiServerURL (https if specified)
-// 3. rest.InClusterConfig().
-func createConfig(apiServerURL, kubeCfgPath string, qps float32, burst int, userAgent string) (*rest.Config, error) {
-	var (
-		config *rest.Config
-		err    error
-	)
-
-	switch {
-	// If the apiServerURL and the kubeCfgPath are empty then we can try getting
-	// the rest.Config from the InClusterConfig
-	case apiServerURL == "" && kubeCfgPath == "":
-		if config, err = rest.InClusterConfig(); err != nil {
-			return nil, err
-		}
-	case kubeCfgPath != "":
-		if config, err = clientcmd.BuildConfigFromFlags("", kubeCfgPath); err != nil {
-			return nil, err
-		}
-	case strings.HasPrefix(apiServerURL, "https://"):
-		if config, err = rest.InClusterConfig(); err != nil {
-			return nil, err
-		}
-		config.Host = apiServerURL
-	default:
-		//exhaustruct:ignore
-		config = &rest.Config{Host: apiServerURL, UserAgent: userAgent}
-	}
-
-	setConfig(config, userAgent, qps, burst)
-	return config, nil
-}
-
-func setConfig(config *rest.Config, userAgent string, qps float32, burst int) {
-	if userAgent != "" {
-		config.UserAgent = userAgent
-	}
-	if qps != 0.0 {
-		config.QPS = qps
-	}
-	if burst != 0 {
-		config.Burst = burst
-	}
-}
-
 func (c *compositeClientset) waitForConn(ctx context.Context) error {
 	stop := make(chan struct{})
 	timeout := time.NewTimer(time.Minute)
 	defer timeout.Stop()
 	var err error
 	wait.Until(func() {
-		c.log.WithField("host", c.restConfig.Host).Info("Establishing connection to apiserver")
+		c.log.WithField("host", c.restConfigManager.getConfig().Host).Info("Establishing connection to apiserver")
 		err = isConnReady(c)
 		if err == nil {
 			close(stop)
@@ -380,7 +315,7 @@ func (c *compositeClientset) waitForConn(ctx context.Context) error {
 			return
 		}
 
-		c.log.WithError(err).WithField(logfields.IPAddr, c.restConfig.Host).Error("Unable to contact k8s api-server")
+		c.log.WithError(err).WithField(logfields.IPAddr, c.restConfigManager.getConfig().Host).Error("Unable to contact k8s api-server")
 		close(stop)
 	}, 5*time.Second, stop)
 	if err == nil {

--- a/pkg/k8s/client/client_test.go
+++ b/pkg/k8s/client/client_test.go
@@ -226,7 +226,7 @@ func Test_client(t *testing.T) {
 	// Set the server URL and use a low heartbeat timeout for quick test completion.
 	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
 	hive.RegisterFlags(flags)
-	flags.Set(option.K8sAPIServer, srv.URL)
+	flags.Set(option.K8sAPIServerURLs, srv.URL)
 	flags.Set(option.K8sHeartbeatTimeout, "5ms")
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)

--- a/pkg/k8s/client/config.go
+++ b/pkg/k8s/client/config.go
@@ -25,6 +25,9 @@ type SharedConfig struct {
 	// operates with CNI-compatible orchestrators other than Kubernetes. Default to true.
 	EnableK8s bool
 
+	// K8sAPIServerURLs is the list of API server instances
+	K8sAPIServerURLs []string
+
 	// K8sAPIServer is the kubernetes api address server (for https use --k8s-kubeconfig-path instead)
 	K8sAPIServer string
 
@@ -65,6 +68,7 @@ func (def ClientParams) Flags(flags *pflag.FlagSet) {
 var defaultSharedConfig = SharedConfig{
 	EnableK8s:                    true,
 	K8sAPIServer:                 "",
+	K8sAPIServerURLs:             []string{},
 	K8sKubeConfigPath:            "",
 	K8sClientConnectionTimeout:   30 * time.Second,
 	K8sClientConnectionKeepAlive: 30 * time.Second,
@@ -75,6 +79,7 @@ var defaultSharedConfig = SharedConfig{
 func (def SharedConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool(option.EnableK8s, def.EnableK8s, "Enable the k8s clientset")
 	flags.String(option.K8sAPIServer, def.K8sAPIServer, "Kubernetes API server URL")
+	flags.StringSlice(option.K8sAPIServerURLs, def.K8sAPIServerURLs, "Kubernetes API server URLs")
 	flags.String(option.K8sKubeConfigPath, def.K8sKubeConfigPath, "Absolute path of the kubernetes kubeconfig file")
 	flags.Duration(option.K8sClientConnectionTimeout, def.K8sClientConnectionTimeout, "Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0")
 	flags.Duration(option.K8sClientConnectionKeepAlive, def.K8sClientConnectionKeepAlive, "Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0")
@@ -94,6 +99,7 @@ func (cfg Config) isEnabled() bool {
 		return false
 	}
 	return cfg.K8sAPIServer != "" ||
+		len(cfg.K8sAPIServerURLs) >= 1 ||
 		cfg.K8sKubeConfigPath != "" ||
 		(os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&
 			os.Getenv("KUBERNETES_SERVICE_PORT") != "") ||

--- a/pkg/k8s/client/config.go
+++ b/pkg/k8s/client/config.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -79,6 +80,7 @@ var defaultSharedConfig = SharedConfig{
 func (def SharedConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool(option.EnableK8s, def.EnableK8s, "Enable the k8s clientset")
 	flags.String(option.K8sAPIServer, def.K8sAPIServer, "Kubernetes API server URL")
+	flags.MarkDeprecated(option.K8sAPIServer, fmt.Sprintf("use --%s", option.K8sAPIServerURLs))
 	flags.StringSlice(option.K8sAPIServerURLs, def.K8sAPIServerURLs, "Kubernetes API server URLs")
 	flags.String(option.K8sKubeConfigPath, def.K8sKubeConfigPath, "Absolute path of the kubernetes kubeconfig file")
 	flags.Duration(option.K8sClientConnectionTimeout, def.K8sClientConnectionTimeout, "Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0")

--- a/pkg/k8s/client/restConfig_provider.go
+++ b/pkg/k8s/client/restConfig_provider.go
@@ -5,6 +5,9 @@ package client
 
 import (
 	"fmt"
+	"math/rand/v2"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,25 +16,43 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/version"
 )
 
 type restConfigManager struct {
-	restConfig *rest.Config
-	log        logrus.FieldLogger
+	restConfig    *rest.Config
+	apiServerURLs []*url.URL
+	lock.RWMutex
+	log logrus.FieldLogger
+	rt  *rotatingHttpRoundTripper
 }
 
 type restConfig interface {
 	getConfig() *rest.Config
+	canRotateAPIServerURL() bool
+	rotateAPIServerURL()
 }
 
 func (r *restConfigManager) getConfig() *rest.Config {
+	r.RLock()
+	defer r.RUnlock()
 	return rest.CopyConfig(r.restConfig)
+}
+
+func (r *restConfigManager) canRotateAPIServerURL() bool {
+	return len(r.apiServerURLs) > 1
 }
 
 func restConfigManagerInit(cfg Config, name string, log logrus.FieldLogger) (restConfig, error) {
 	var err error
-	manager := restConfigManager{log: log}
+	manager := restConfigManager{
+		log: log,
+		rt: &rotatingHttpRoundTripper{
+			log: log,
+		}}
+
+	manager.parseConfig(cfg)
 
 	cmdName := "cilium"
 	if len(os.Args[0]) != 0 {
@@ -43,7 +64,13 @@ func restConfigManagerInit(cfg Config, name string, log logrus.FieldLogger) (res
 		userAgent = fmt.Sprintf("%s %s", userAgent, name)
 	}
 
-	manager.restConfig, err = createConfig(cfg.K8sAPIServer, cfg.K8sKubeConfigPath, cfg.K8sClientQPS, cfg.K8sClientBurst, userAgent)
+	if manager.restConfig, err = manager.createConfig(cfg, userAgent); err != nil {
+		return nil, err
+	}
+	if manager.canRotateAPIServerURL() {
+		// Pick an API server at random.
+		manager.rotateAPIServerURL()
+	}
 
 	return &manager, err
 }
@@ -52,13 +79,22 @@ func restConfigManagerInit(cfg Config, name string, log logrus.FieldLogger) (res
 //
 // The precedence of the configuration selection is the following:
 // 1. kubeCfgPath
-// 2. apiServerURL (https if specified)
+// 2. apiServerURL(s) (https if specified)
 // 3. rest.InClusterConfig().
-func createConfig(apiServerURL, kubeCfgPath string, qps float32, burst int, userAgent string) (*rest.Config, error) {
+func (r *restConfigManager) createConfig(cfg Config, userAgent string) (*rest.Config, error) {
 	var (
-		config *rest.Config
-		err    error
+		config       *rest.Config
+		err          error
+		apiServerURL string
 	)
+	if cfg.K8sAPIServer != "" {
+		apiServerURL = cfg.K8sAPIServer
+	} else if len(r.apiServerURLs) > 0 {
+		apiServerURL = r.apiServerURLs[0].String()
+	}
+	kubeCfgPath := cfg.K8sKubeConfigPath
+	qps := cfg.K8sClientQPS
+	burst := cfg.K8sClientBurst
 
 	switch {
 	// If the apiServerURL and the kubeCfgPath are empty then we can try getting
@@ -81,8 +117,50 @@ func createConfig(apiServerURL, kubeCfgPath string, qps float32, burst int, user
 		config = &rest.Config{Host: apiServerURL, UserAgent: userAgent}
 	}
 
+	// The HTTP round tripper rotates API server URLs in case of connectivity failures.
+	if len(r.apiServerURLs) > 1 {
+		config.Wrap(r.WrapRoundTripper)
+	}
+
 	setConfig(config, userAgent, qps, burst)
 	return config, nil
+}
+
+func (r *restConfigManager) parseConfig(cfg Config) {
+	if cfg.K8sAPIServer != "" {
+		var (
+			serverURL *url.URL
+			err       error
+		)
+		s := cfg.K8sAPIServer
+		if !strings.HasPrefix(s, "http") {
+			s = fmt.Sprintf("http://%s", s) // default to HTTP
+		}
+		serverURL, err = url.Parse(s)
+		if err != nil {
+			r.log.WithError(err).Errorf("Failed to parse APIServerURL %s, skipping", serverURL)
+			return
+		}
+		r.apiServerURLs = append(r.apiServerURLs, serverURL)
+		return
+	}
+	for _, apiServerURL := range cfg.K8sAPIServerURLs {
+		if apiServerURL == "" {
+			continue
+		}
+
+		if !strings.HasPrefix(apiServerURL, "http") && !strings.HasPrefix(apiServerURL, "https") {
+			apiServerURL = fmt.Sprintf("https://%s", apiServerURL)
+		}
+
+		serverURL, err := url.Parse(apiServerURL)
+		if err != nil {
+			r.log.WithError(err).Errorf("Failed to parse APIServerURL %s, skipping", apiServerURL)
+			continue
+		}
+
+		r.apiServerURLs = append(r.apiServerURLs, serverURL)
+	}
 }
 
 func setConfig(config *rest.Config, userAgent string, qps float32, burst int) {
@@ -95,4 +173,46 @@ func setConfig(config *rest.Config, userAgent string, qps float32, burst int) {
 	if burst != 0 {
 		config.Burst = burst
 	}
+}
+
+func (r *restConfigManager) rotateAPIServerURL() {
+	if len(r.apiServerURLs) <= 1 {
+		return
+	}
+
+	r.rt.Lock()
+	defer r.rt.Unlock()
+	for {
+		idx := rand.IntN(len(r.apiServerURLs))
+		if r.rt.apiServerURL != r.apiServerURLs[idx] {
+			r.rt.apiServerURL = r.apiServerURLs[idx]
+			break
+		}
+	}
+	r.Lock()
+	r.restConfig.Host = r.rt.apiServerURL.String()
+	r.Unlock()
+	r.log.WithField("url", r.rt.apiServerURL).Info("Rotated api server")
+}
+
+// rotatingHttpRoundTripper sets the remote host in the rest configuration used to make API requests to the API server.
+type rotatingHttpRoundTripper struct {
+	delegate     http.RoundTripper
+	log          logrus.FieldLogger
+	apiServerURL *url.URL
+	lock.RWMutex // Synchronizes access to apiServerURL
+}
+
+func (rt *rotatingHttpRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.RLock()
+	defer rt.RUnlock()
+
+	rt.log.WithField("host", rt.apiServerURL).Debug("Kubernetes api server host")
+	req.URL.Host = rt.apiServerURL.Host
+	return rt.delegate.RoundTrip(req)
+}
+
+func (r *restConfigManager) WrapRoundTripper(rt http.RoundTripper) http.RoundTripper {
+	r.rt.delegate = rt
+	return r.rt
 }

--- a/pkg/k8s/client/restConfig_provider.go
+++ b/pkg/k8s/client/restConfig_provider.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package client
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/cilium/cilium/pkg/version"
+)
+
+type restConfigManager struct {
+	restConfig *rest.Config
+	log        logrus.FieldLogger
+}
+
+type restConfig interface {
+	getConfig() *rest.Config
+}
+
+func (r *restConfigManager) getConfig() *rest.Config {
+	return rest.CopyConfig(r.restConfig)
+}
+
+func restConfigManagerInit(cfg Config, name string, log logrus.FieldLogger) (restConfig, error) {
+	var err error
+	manager := restConfigManager{log: log}
+
+	cmdName := "cilium"
+	if len(os.Args[0]) != 0 {
+		cmdName = filepath.Base(os.Args[0])
+	}
+	userAgent := fmt.Sprintf("%s/%s", cmdName, version.Version)
+
+	if name != "" {
+		userAgent = fmt.Sprintf("%s %s", userAgent, name)
+	}
+
+	manager.restConfig, err = createConfig(cfg.K8sAPIServer, cfg.K8sKubeConfigPath, cfg.K8sClientQPS, cfg.K8sClientBurst, userAgent)
+
+	return &manager, err
+}
+
+// createConfig creates a rest.Config for connecting to k8s api-server.
+//
+// The precedence of the configuration selection is the following:
+// 1. kubeCfgPath
+// 2. apiServerURL (https if specified)
+// 3. rest.InClusterConfig().
+func createConfig(apiServerURL, kubeCfgPath string, qps float32, burst int, userAgent string) (*rest.Config, error) {
+	var (
+		config *rest.Config
+		err    error
+	)
+
+	switch {
+	// If the apiServerURL and the kubeCfgPath are empty then we can try getting
+	// the rest.Config from the InClusterConfig
+	case apiServerURL == "" && kubeCfgPath == "":
+		if config, err = rest.InClusterConfig(); err != nil {
+			return nil, err
+		}
+	case kubeCfgPath != "":
+		if config, err = clientcmd.BuildConfigFromFlags("", kubeCfgPath); err != nil {
+			return nil, err
+		}
+	case strings.HasPrefix(apiServerURL, "https://"):
+		if config, err = rest.InClusterConfig(); err != nil {
+			return nil, err
+		}
+		config.Host = apiServerURL
+	default:
+		//exhaustruct:ignore
+		config = &rest.Config{Host: apiServerURL, UserAgent: userAgent}
+	}
+
+	setConfig(config, userAgent, qps, burst)
+	return config, nil
+}
+
+func setConfig(config *rest.Config, userAgent string, qps float32, burst int) {
+	if userAgent != "" {
+		config.UserAgent = userAgent
+	}
+	if qps != 0.0 {
+		config.QPS = qps
+	}
+	if burst != 0 {
+		config.Burst = burst
+	}
+}

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -1124,6 +1124,12 @@ func (l *L3n4Addr) ProtocolsEqual(o *L3n4Addr) bool {
 			l.AddrCluster.Is6() && o.AddrCluster.Is6())
 }
 
+func (l *L3n4Addr) AddrString() string {
+	str := l.AddrCluster.Addr().String() + ":" + strconv.FormatUint(uint64(l.Port), 10)
+
+	return str
+}
+
 // Bytes returns the address as a byte slice for indexing purposes.
 // Similar to Hash() but includes the L4 protocol.
 func (l L3n4Addr) Bytes() []byte {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -199,6 +199,9 @@ const (
 	// K8sAPIServer is the kubernetes api address server (for https use --k8s-kubeconfig-path instead)
 	K8sAPIServer = "k8s-api-server"
 
+	// K8sAPIServerURLs is the kubernetes api address server url
+	K8sAPIServerURLs = "k8s-api-server-urls"
+
 	// K8sKubeConfigPath is the absolute path of the kubernetes kubeconfig file
 	K8sKubeConfigPath = "k8s-kubeconfig-path"
 


### PR DESCRIPTION
Support kube-apiserver high availability with kube-proxy replacement where the agent can fail over to an active kube-apiserver at runtime. 

### Background 
Cilium agent requires a connection to the kube-apiserver control plane to program the BPF datapath without depending on kube-proxy load-balancing when kube-proxy replacement is enabled. To achieve this, Cilium uses `API_SERVER_IP` and `API_SERVER_PORT` configurations for direct connection to the kube-apiserver. However, this approach doesn't support production environments that require multiple kube-apiservers for high availability. Additionally, it cannot rely on a fixed set of addresses provided at bootstrap time due to potential Kubernetes node failures or recycling in production environments.

### Commits summary
This PR introduces a flag for user to configure multiple kube-apiserver URLs. Additionally, it adds logic to connect to one of the active kube-apiservers in a cluster during initial connection time, and switches over to the `kubernetes` service at runtime (and post agent restarts).
The PR extends - https://github.com/cilium/cilium/pull/20090. 
See individual commits for implementation details.

![kubeapiserverHA](https://github.com/user-attachments/assets/847cc378-b588-44cd-9fb8-c46f4965c41a)

### Testing
- Manually tested on a kind cluster with >1 control plane nodes.
- Unit test cases cover various fail over scenarios. 

Follow-up:
Automated E2E test in a kind cluster environment.

Fixes: https://github.com/cilium/cilium/issues/19038

```release-note
Add support for kube-apiserver high availability with kube-proxy replacement where the Cilium agent can fail over to an active kube-apiserver at runtime.
```