### PR TITLE
docs: masquerading: mention that BPF masq also pulls in BPF Host-Routing

### DIFF
--- a/Documentation/network/concepts/masquerading.rst
+++ b/Documentation/network/concepts/masquerading.rst
@@ -51,6 +51,9 @@ eBPF-based
 The eBPF-based implementation is the most efficient implementation. It can be enabled with
 the ``bpf.masquerade=true`` helm option.
 
+By default, BPF masquerading also enables the BPF Host-Routing mode.
+See :ref:`eBPF_Host_Routing` for benefits and limitations of this mode.
+
 The current implementation depends on :ref:`the BPF NodePort feature <kubeproxy-free>`.
 The dependency will be removed in the future (:gh-issue:`13732`).
 


### PR DESCRIPTION
The implicit opt-in for BPF Host-Routing is a regular gotcha when enabling BPF masquerading. Highlight this in the docs, so users can blame the correct feature when they encounter issues (and fall back to legacy routing).