### PR TITLE
operator: explicit controller-runtime controller names to avoid naming conflicts

### DIFF
--- a/operator/pkg/ciliumenvoyconfig/ciliumenvoyconfig.go
+++ b/operator/pkg/ciliumenvoyconfig/ciliumenvoyconfig.go
@@ -27,7 +27,8 @@ type ciliumEnvoyConfigReconciler struct {
 }
 
 func newCiliumEnvoyConfigReconciler(c client.Client, logger *slog.Logger, defaultAlgorithm string, ports []string,
-	maxRetries int, idleTimeoutSeconds int, enableIpv4 bool, enableIpv6 bool) *ciliumEnvoyConfigReconciler {
+	maxRetries int, idleTimeoutSeconds int, enableIpv4 bool, enableIpv6 bool,
+) *ciliumEnvoyConfigReconciler {
 	return &ciliumEnvoyConfigReconciler{
 		client: c,
 		logger: logger,
@@ -46,5 +47,6 @@ func (r *ciliumEnvoyConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Service{}).
 		Owns(&ciliumv2.CiliumEnvoyConfig{}).
+		Named("service-l7lb").
 		Complete(r)
 }

--- a/operator/pkg/lbipam/cell.go
+++ b/operator/pkg/lbipam/cell.go
@@ -119,7 +119,7 @@ func newLBIPAMCell(params lbipamCellParams) *LBIPAM {
 
 const (
 	DefaultLBClassLBIPAM   = "lbipam"
-	DefaulLBClasstNodeIPAM = "nodeipam"
+	DefaultLBClassNodeIPAM = "nodeipam"
 )
 
 // SharedConfig contains the configuration that is shared between

--- a/operator/pkg/nodeipam/cell.go
+++ b/operator/pkg/nodeipam/cell.go
@@ -58,7 +58,7 @@ func registerNodeSvcLBReconciler(params nodeipamCellParams) error {
 	if err := newNodeSvcLBReconciler(
 		params.CtrlRuntimeManager,
 		params.Logger,
-		params.SharedConfig.DefaultLBServiceIPAM == lbipam.DefaulLBClasstNodeIPAM,
+		params.SharedConfig.DefaultLBServiceIPAM == lbipam.DefaultLBClassNodeIPAM,
 	).SetupWithManager(params.CtrlRuntimeManager); err != nil {
 		return fmt.Errorf("Failed to register NodeSvcLBReconciler: %w", err)
 	}

--- a/operator/pkg/nodeipam/nodesvclb.go
+++ b/operator/pkg/nodeipam/nodesvclb.go
@@ -63,6 +63,7 @@ func (r *nodeSvcLBReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&discoveryv1.EndpointSlice{}, r.enqueueRequestForEndpointSlice()).
 		// Watch for changes to Nodes
 		Watches(&corev1.Node{}, r.enqueueRequestForNode()).
+		Named("service-nodeipam").
 		Complete(r)
 }
 

--- a/operator/pkg/nodeipam/nodesvclb.go
+++ b/operator/pkg/nodeipam/nodesvclb.go
@@ -198,7 +198,7 @@ func (r *nodeSvcLBReconciler) getEndpointSliceNodeNames(ctx context.Context, svc
 	return selectedNodes, nil
 }
 
-// getRelevantNodes gets all the nodes candidates for seletion by nodeipam
+// getRelevantNodes gets all the nodes candidates for selection by nodeipam
 func (r *nodeSvcLBReconciler) getRelevantNodes(ctx context.Context, svc *corev1.Service) ([]corev1.Node, error) {
 	scopedLog := r.Logger.With(logfields.Controller, "node-service-lb",
 		logfields.Resource, client.ObjectKeyFromObject(svc))


### PR DESCRIPTION
The library `controller-runtime` introduced a validation for unique controller names with [v0.19.0](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.19.0).

> Breaking Changes
> ...
> controller: Validate controller names are unique & add SkipNameValidation option

If no name is explicitly configured, controllers are named using the lowercase version of their kind. (defined in `For(...)` builder function). This might lead to validation issues that prevent the operator from starting.

Therefore this PR sets explicit names when registering the controllers for the same kind (K8s Service) to the controller-runtime manager.

Note: There's also the option to completely disable this validation in controller-runtime. But this also leads to overlapping metrics names which was the reason why this check was introduced in the first place. (We need to have an extra eye on this when new controller-runtime based controllers are added to the Cilium Operator - but this shouldn't be that big of a deal as most k8s kinds are only owned by one controller)

Fixes: https://github.com/cilium/cilium/issues/37582