### PR TITLE
doc: fix a typo in bpf.rst

### DIFF
--- a/Documentation/contributing/testing/bpf.rst
+++ b/Documentation/contributing/testing/bpf.rst
@@ -275,7 +275,7 @@ Mocking is easy with this framework:
 1. Create a function with a unique name and the same signature as the function it is replacing.
 
 2. Create a macro with the exact same name as the function we want to replace and point it to the
-   function created in step 1. For example ``#define original_function our_mocked_function```
+   function created in step 1. For example ``#define original_function our_mocked_function``
 
 3. Include the file which contains the definition we are replacing.
 


### PR DESCRIPTION
Found this while reading the doc.

This pull request includes a minor change to the `Documentation/contributing/testing/bpf.rst` file. The change corrects a formatting issue by removing an extra backtick in the example macro definition.

* [`Documentation/contributing/testing/bpf.rst`](diffhunk://#diff-5a45198464cd9d963aa7daa7456baf51fc1ed9c97303254385550fab7f7658d2L278-R278): Removed an extra backtick from the example macro definition to correct the formatting.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

