### PR TITLE
[v1.17] docs: use latest for rtd theme commit with fixed version selector

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -64,7 +64,7 @@ jobs:
           # Needed to detect missing redirects
           fetch-depth: 0
       - name: Build HTML
-        uses: docker://quay.io/cilium/docs-builder:550ca417f5dc0b13fa7f117cc117443b23120f5e@sha256:febb1339085d9bcabcfd547ab2125e67e1c6468f0bc33f62f9326e790efb938a
+        uses: docker://quay.io/cilium/docs-builder:7bc07726f95e26e468f5a14eec6c9422e5eca541@sha256:67220bffa09800d8931f46a5c8c1ee26623b9d84ea99ab21cdeac6e6077b2005
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -3,7 +3,7 @@ Sphinx==7.1.2
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@84a34e7f301e9bfed5330da9acdb65d62020af4d
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@0d7703280a1287e97f37124c1d9689e2efe03923
 # We use semver to parse Cilium's version in the config file
 semver==3.0.1
 # Sphinx extensions


### PR DESCRIPTION
[ upstream commit 59f9336699e9672df6ab20e1028915e7864da20c ]

Backport #37421 to v1.17.

Bump the RTD theme to fix a few issues like the version selector.

```upstream-prs
37421
```