### PR TITLE
ci: update docs-builder

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -64,7 +64,7 @@ jobs:
           # Needed to detect missing redirects
           fetch-depth: 0
       - name: Build HTML
-        uses: docker://quay.io/cilium/docs-builder:5f497e3f4c73f217a780c8038f9174ceabfabe57@sha256:37105a84068e427116bad64f8812ef5f4239812fd4f085252901b4c7cddb48af
+        uses: docker://quay.io/cilium/docs-builder:7bc07726f95e26e468f5a14eec6c9422e5eca541@sha256:67220bffa09800d8931f46a5c8c1ee26623b9d84ea99ab21cdeac6e6077b2005
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html


### PR DESCRIPTION
This step was skipped as part of the most recent commit 59f9336699e9
("docs: use latest for rtd theme commit with fixed version selector")
because the PR was opened from an external branch. Bump the version in
the workflow to properly match the tree.

Related: https://github.com/cilium/cilium/pull/37421