### PR TITLE
[v1.16] docs: Update requirements.txt dependencies

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -64,7 +64,7 @@ jobs:
           # Needed to detect missing redirects
           fetch-depth: 0
       - name: Build HTML
-        uses: docker://quay.io/cilium/docs-builder:d09a4f57a38cb603c45944f1b2a9e68333654b71@sha256:1c02ee80fd52ea02f6e5aa52ca063de86b1c69fb78dce285b320c2fa077f505e
+        uses: docker://quay.io/cilium/docs-builder:5138e308df23149f1aad8a63ef73fa3f1f1478c6@sha256:c44ab6479cb2eac53d8d8712791317ffb897c870d84c925bf04796bce768ce59
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -3,7 +3,7 @@ Sphinx==7.1.2
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@84a34e7f301e9bfed5330da9acdb65d62020af4d
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@0d7703280a1287e97f37124c1d9689e2efe03923
 # We use semver to parse Cilium's version in the config file
 semver==3.0.1
 # Sphinx extensions
@@ -23,7 +23,7 @@ alabaster==0.7.13
 annotated-types==0.5.0
 attrs==23.1.0
 Babel==2.12.1
-certifi==2023.7.22
+certifi==2024.7.4
 charset-normalizer==3.2.0
 click==8.1.7
 colorama==0.4.6
@@ -65,7 +65,7 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-tornado==6.4.1
+tornado==6.4.2
 typer==0.9.0
 typing_extensions==4.7.1
 urllib3==2.2.2


### PR DESCRIPTION
This updates the underlying dependencies and the theme, meaning it
should also fix the version selector for this older branch.

Related: https://github.com/cilium/cilium/pull/37421