### PR TITLE
[v1.15] docs: Update requirements.txt dependencies

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -62,7 +62,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build HTML
-        uses: docker://quay.io/cilium/docs-builder:9ccbdd04a50d599e9e699face6231e59c0036a51@sha256:6d1a0eaeb32ba98b60df52c69e7c8031a38e8aa6a0d4738bef35bd48a3bfbc0e
+        uses: docker://quay.io/cilium/docs-builder:5d167cf440c5986704100eb35caf8bf0d5692302@sha256:c7d8a2a5e160f7a19f4f71f2b4a6587a05ec4cdacccde7828bd5c0822554e2bb
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -3,7 +3,7 @@ Sphinx==7.1.2
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@84a34e7f301e9bfed5330da9acdb65d62020af4d
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@0d7703280a1287e97f37124c1d9689e2efe03923
 # We use semver to parse Cilium's version in the config file
 semver==3.0.1
 # Sphinx extensions
@@ -14,6 +14,7 @@ sphinxcontrib-googleanalytics==0.4
 sphinxcontrib-openapi==0.8.1
 sphinxcontrib-spelling==8.0.0
 sphinxcontrib-websupport==1.2.4
+sphinxext-rediraffe==0.2.7
 # Linters
 rstcheck==6.2.0
 yamllint==1.32.0
@@ -22,15 +23,15 @@ alabaster==0.7.13
 annotated-types==0.5.0
 attrs==23.1.0
 Babel==2.12.1
-certifi==2023.7.22
+certifi==2024.7.4
 charset-normalizer==3.2.0
 click==8.1.7
 colorama==0.4.6
 deepmerge==1.1.0
 docutils==0.18.1
-idna==3.4
+idna==3.7
 imagesize==1.4.1
-Jinja2==3.1.3
+Jinja2==3.1.4
 jsonschema==4.19.0
 jsonschema-specifications==2023.7.1
 livereload==2.6.3
@@ -48,7 +49,7 @@ pyenchant==3.2.2
 Pygments==2.16.1
 PyYAML==6.0.1
 referencing==0.30.2
-requests==2.31.0
+requests==2.32.0
 rich==13.5.2
 rpds-py==0.10.3
 rstcheck-core==1.1.1
@@ -64,7 +65,7 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-tornado==6.3.3
+tornado==6.4.2
 typer==0.9.0
 typing_extensions==4.7.1
 urllib3==2.2.2


### PR DESCRIPTION
This updates the underlying dependencies and the theme, meaning it
should also fix the version selector for this older branch.

Related: https://github.com/cilium/cilium/pull/37421