### PR TITLE
clustermesh: Consolidate hive

### DIFF
--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -27,6 +27,7 @@ cilium-agent hive [flags]
       --cni-external-routing                                      Whether the chained CNI plugin handles routing on the node
       --cni-log-file string                                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
       --controller-group-metrics strings                          List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --crd-wait-timeout duration                                 Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
       --devices strings                                           List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'
       --direct-routing-device string                              Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
       --disable-envoy-version-check                               Do not perform Envoy version check

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -33,6 +33,7 @@ cilium-agent hive dot-graph [flags]
       --cni-external-routing                                      Whether the chained CNI plugin handles routing on the node
       --cni-log-file string                                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
       --controller-group-metrics strings                          List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --crd-wait-timeout duration                                 Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
       --devices strings                                           List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'
       --direct-routing-device string                              Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
       --disable-envoy-version-check                               Do not perform Envoy version check

--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -34,8 +34,7 @@ var Cell = cell.Module(
 	cell.Config(cmtypes.DefaultClusterInfo),
 	cell.Invoke(cmtypes.RegisterClusterInfoValidator),
 
-	pprof.Cell,
-	cell.Config(pprofConfig),
+	pprof.Cell(pprofConfig),
 	controller.Cell,
 
 	gops.Cell(defaults.EnableGops, defaults.GopsPortApiserver),

--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -7,20 +7,13 @@ import (
 	"github.com/cilium/hive/cell"
 
 	cmk8s "github.com/cilium/cilium/clustermesh-apiserver/clustermesh/k8s"
-	"github.com/cilium/cilium/clustermesh-apiserver/health"
-	cmmetrics "github.com/cilium/cilium/clustermesh-apiserver/metrics"
 	"github.com/cilium/cilium/clustermesh-apiserver/option"
-	"github.com/cilium/cilium/clustermesh-apiserver/syncstate"
 	"github.com/cilium/cilium/pkg/clustermesh/operator"
-	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/synced"
-	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/heartbeat"
-	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/pprof"
 )
 
@@ -28,27 +21,13 @@ var Cell = cell.Module(
 	"clustermesh",
 	"Cilium ClusterMesh",
 
-	cell.Config(option.DefaultLegacyClusterMeshConfig),
 	cell.Config(operator.MCSAPIConfig{}),
 
-	cell.Config(cmtypes.DefaultClusterInfo),
-	cell.Invoke(cmtypes.RegisterClusterInfoValidator),
-
 	pprof.Cell(pprofConfig),
-	controller.Cell,
-
 	gops.Cell(defaults.EnableGops, defaults.GopsPortApiserver),
 
 	k8sClient.Cell,
 	cmk8s.ResourcesCell,
-
-	kvstore.Cell,
-	cell.Provide(func(ss syncstate.SyncState) *kvstore.ExtraOptions {
-		return &kvstore.ExtraOptions{
-			BootstrapComplete: ss.WaitChannel(),
-		}
-	}),
-	store.Cell,
 
 	// Shared synchronization structures for waiting on K8s resources to
 	// be synced
@@ -64,9 +43,6 @@ var Cell = cell.Module(
 
 	heartbeat.Cell,
 	HealthAPIEndpointsCell,
-	health.HealthAPIServerCell,
-
-	cmmetrics.Cell,
 
 	usersManagementCell,
 	cell.Invoke(registerHooks),

--- a/clustermesh-apiserver/common/cells.go
+++ b/clustermesh-apiserver/common/cells.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package common
+
+import (
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/clustermesh-apiserver/health"
+	cmmetrics "github.com/cilium/cilium/clustermesh-apiserver/metrics"
+	"github.com/cilium/cilium/clustermesh-apiserver/option"
+	"github.com/cilium/cilium/clustermesh-apiserver/syncstate"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+)
+
+var Cell = cell.Module(
+	"clustermesh-common",
+	"Common Cilium ClusterMesh modules",
+
+	cell.Config(option.DefaultLegacyClusterMeshConfig),
+	cell.Config(cmtypes.DefaultClusterInfo),
+	cell.Invoke(cmtypes.RegisterClusterInfoValidator),
+
+	cmmetrics.Cell,
+	health.HealthAPIServerCell,
+
+	controller.Cell,
+	kvstore.Cell,
+	cell.Provide(func(ss syncstate.SyncState) *kvstore.ExtraOptions {
+		return &kvstore.ExtraOptions{
+			BootstrapComplete: ss.WaitChannel(),
+		}
+	}),
+	store.Cell,
+)

--- a/clustermesh-apiserver/kvstoremesh/cells.go
+++ b/clustermesh-apiserver/kvstoremesh/cells.go
@@ -29,8 +29,7 @@ var Cell = cell.Module(
 	cell.Config(cmtypes.DefaultClusterInfo),
 	cell.Invoke(cmtypes.RegisterClusterInfoValidator),
 
-	pprof.Cell,
-	cell.Config(pprofConfig),
+	pprof.Cell(pprofConfig),
 	controller.Cell,
 
 	gops.Cell(defaults.EnableGops, defaults.GopsPortKVStoreMesh),

--- a/clustermesh-apiserver/kvstoremesh/cells.go
+++ b/clustermesh-apiserver/kvstoremesh/cells.go
@@ -6,17 +6,10 @@ package kvstoremesh
 import (
 	"github.com/cilium/hive/cell"
 
-	"github.com/cilium/cilium/clustermesh-apiserver/health"
-	cmmetrics "github.com/cilium/cilium/clustermesh-apiserver/metrics"
 	"github.com/cilium/cilium/clustermesh-apiserver/option"
-	"github.com/cilium/cilium/clustermesh-apiserver/syncstate"
 	"github.com/cilium/cilium/pkg/clustermesh/kvstoremesh"
-	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
-	"github.com/cilium/cilium/pkg/kvstore"
-	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/pprof"
 )
 
@@ -24,30 +17,15 @@ var Cell = cell.Module(
 	"kvstoremesh",
 	"Cilium KVStoreMesh",
 
-	cell.Config(option.DefaultLegacyClusterMeshConfig),
 	cell.Config(kvstoremesh.DefaultConfig),
 
-	cell.Config(cmtypes.DefaultClusterInfo),
-	cell.Invoke(cmtypes.RegisterClusterInfoValidator),
-
 	pprof.Cell(pprofConfig),
-	controller.Cell,
-
 	gops.Cell(defaults.EnableGops, defaults.GopsPortKVStoreMesh),
-	cmmetrics.Cell,
 
 	HealthAPIEndpointsCell,
-	health.HealthAPIServerCell,
 
 	APIServerCell,
 
-	kvstore.Cell,
-	cell.Provide(func(ss syncstate.SyncState) *kvstore.ExtraOptions {
-		return &kvstore.ExtraOptions{
-			BootstrapComplete: ss.WaitChannel(),
-		}
-	}),
-	store.Cell,
 	kvstoremesh.Cell,
 
 	cell.Invoke(kvstoremesh.RegisterSyncWaiter),

--- a/clustermesh-apiserver/kvstoremesh/cells.go
+++ b/clustermesh-apiserver/kvstoremesh/cells.go
@@ -23,7 +23,7 @@ var Cell = cell.Module(
 	"kvstoremesh",
 	"Cilium KVStoreMesh",
 
-	cell.Config(option.DefaultLegacyKVStoreMeshConfig),
+	cell.Config(option.DefaultLegacyClusterMeshConfig),
 	cell.Config(kvstoremesh.DefaultConfig),
 
 	cell.Config(cmtypes.DefaultClusterInfo),

--- a/clustermesh-apiserver/kvstoremesh/cells.go
+++ b/clustermesh-apiserver/kvstoremesh/cells.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/pprof"
 )
 
@@ -46,6 +47,7 @@ var Cell = cell.Module(
 			BootstrapComplete: ss.WaitChannel(),
 		}
 	}),
+	store.Cell,
 	kvstoremesh.Cell,
 
 	cell.Invoke(kvstoremesh.RegisterSyncWaiter),

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/clustermesh-apiserver/clustermesh"
 	clustermeshdbg "github.com/cilium/cilium/clustermesh-apiserver/clustermesh-dbg"
+	"github.com/cilium/cilium/clustermesh-apiserver/common"
 	"github.com/cilium/cilium/clustermesh-apiserver/etcdinit"
 	"github.com/cilium/cilium/clustermesh-apiserver/kvstoremesh"
 	kvstoremeshdbg "github.com/cilium/cilium/clustermesh-apiserver/kvstoremesh-dbg"
@@ -31,8 +32,8 @@ func main() {
 		// etcd init does not use the Hive framework, because it's a "one and done" process that doesn't spawn a service
 		// or server, or perform any waiting for connections.
 		etcdinit.NewCmd(),
-		clustermesh.NewCmd(hive.New(clustermesh.Cell)),
-		kvstoremesh.NewCmd(hive.New(kvstoremesh.Cell)),
+		clustermesh.NewCmd(hive.New(common.Cell, clustermesh.Cell)),
+		kvstoremesh.NewCmd(hive.New(common.Cell, kvstoremesh.Cell)),
 		clustermeshdbg.RootCmd,
 		kvstoremeshdbg.RootCmd,
 	)

--- a/clustermesh-apiserver/option/config.go
+++ b/clustermesh-apiserver/option/config.go
@@ -4,8 +4,6 @@
 package option
 
 import (
-	"time"
-
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/option"
@@ -25,22 +23,19 @@ const (
 // LegacyClusterMeshConfig is used to register the flags for the options which
 // are still accessed through the global DaemonConfig variable.
 type LegacyClusterMeshConfig struct {
-	Debug          bool
-	LogDriver      []string
-	LogOpt         map[string]string
-	CRDWaitTimeout time.Duration
+	Debug     bool
+	LogDriver []string
+	LogOpt    map[string]string
 }
 
 var DefaultLegacyClusterMeshConfig = LegacyClusterMeshConfig{
-	Debug:          false,
-	CRDWaitTimeout: 5 * time.Minute,
+	Debug: false,
 }
 
 func (def LegacyClusterMeshConfig) Flags(flags *pflag.FlagSet) {
 	flags.BoolP(option.DebugArg, "D", def.Debug, "Enable debugging mode")
 	flags.StringSlice(option.LogDriver, def.LogDriver, "Logging endpoints to use (example: syslog)")
 	flags.Var(option.NewNamedMapOptions(option.LogOpt, &option.Config.LogOpt, nil), option.LogOpt, "Log driver options (example: format=json)")
-	flags.Duration(option.CRDWaitTimeout, def.CRDWaitTimeout, "Cilium will exit if CRDs are not available within this duration upon startup")
 }
 
 // LegacyKVStoreMeshConfig is used to register the flags for the options which

--- a/clustermesh-apiserver/option/config.go
+++ b/clustermesh-apiserver/option/config.go
@@ -29,28 +29,12 @@ type LegacyClusterMeshConfig struct {
 }
 
 var DefaultLegacyClusterMeshConfig = LegacyClusterMeshConfig{
-	Debug: false,
+	Debug:     false,
+	LogDriver: []string{},
+	LogOpt:    make(map[string]string),
 }
 
 func (def LegacyClusterMeshConfig) Flags(flags *pflag.FlagSet) {
-	flags.BoolP(option.DebugArg, "D", def.Debug, "Enable debugging mode")
-	flags.StringSlice(option.LogDriver, def.LogDriver, "Logging endpoints to use (example: syslog)")
-	flags.Var(option.NewNamedMapOptions(option.LogOpt, &option.Config.LogOpt, nil), option.LogOpt, "Log driver options (example: format=json)")
-}
-
-// LegacyKVStoreMeshConfig is used to register the flags for the options which
-// are still accessed through the global DaemonConfig variable.
-type LegacyKVStoreMeshConfig struct {
-	Debug     bool
-	LogDriver []string
-	LogOpt    map[string]string
-}
-
-var DefaultLegacyKVStoreMeshConfig = LegacyKVStoreMeshConfig{
-	Debug: false,
-}
-
-func (def LegacyKVStoreMeshConfig) Flags(flags *pflag.FlagSet) {
 	flags.BoolP(option.DebugArg, "D", def.Debug, "Enable debugging mode")
 	flags.StringSlice(option.LogDriver, def.LogDriver, "Logging endpoints to use (example: syslog)")
 	flags.Var(option.NewNamedMapOptions(option.LogOpt, &option.Config.LogOpt, nil), option.LogOpt, "Log driver options (example: format=json)")

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -89,8 +89,7 @@ var (
 		"Infrastructure",
 
 		// Register the pprof HTTP handlers, to get runtime profiling data.
-		pprof.Cell,
-		cell.Config(pprofConfig),
+		pprof.Cell(pprofConfig),
 
 		// Runs the gops agent, a tool to diagnose Go processes.
 		gops.Cell(defaults.EnableGops, defaults.GopsPortAgent),

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -923,9 +923,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Var(option.NewNamedMapOptions(option.BPFMapEventBuffers, &option.Config.BPFMapEventBuffers, option.Config.BPFMapEventBuffersValidator), option.BPFMapEventBuffers, "Configuration for BPF map event buffers: (example: --bpf-map-event-buffers cilium_ipcache=true,1024,1h)")
 	flags.MarkHidden(option.BPFMapEventBuffers)
 
-	flags.Duration(option.CRDWaitTimeout, 5*time.Minute, "Cilium will exit if CRDs are not available within this duration upon startup")
-	option.BindEnv(vp, option.CRDWaitTimeout)
-
 	flags.Bool(option.EgressMultiHomeIPRuleCompat, false,
 		"Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.")
 	option.BindEnv(vp, option.EgressMultiHomeIPRuleCompat)

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/pprof"
 )
 
 func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
@@ -327,6 +328,12 @@ const (
 	k8sClientBurst = "operator-k8s-client-burst"
 )
 
+var defaultOperatorPprofConfig = operatorPprofConfig{
+	OperatorPprof:        false,
+	OperatorPprofAddress: operatorOption.PprofAddressOperator,
+	OperatorPprofPort:    operatorOption.PprofPortOperator,
+}
+
 // operatorPprofConfig holds the configuration for the operator pprof cell.
 // Differently from the agent and the clustermesh-apiserver, the operator prefixes
 // the pprof related flags with the string "operator-".
@@ -342,6 +349,14 @@ func (def operatorPprofConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool(pprofOperator, def.OperatorPprof, "Enable serving pprof debugging API")
 	flags.String(pprofAddress, def.OperatorPprofAddress, "Address that pprof listens on")
 	flags.Uint16(pprofPort, def.OperatorPprofPort, "Port that pprof listens on")
+}
+
+func (def operatorPprofConfig) Config() pprof.Config {
+	return pprof.Config{
+		Pprof:        def.OperatorPprof,
+		PprofAddress: def.OperatorPprofAddress,
+		PprofPort:    def.OperatorPprofPort,
+	}
 }
 
 type operatorClientParams struct {

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -88,18 +88,10 @@ var (
 		"Operator Infrastructure",
 
 		// Register the pprof HTTP handlers, to get runtime profiling data.
-		pprof.Cell,
 		cell.ProvidePrivate(func(cfg operatorPprofConfig) pprof.Config {
-			return pprof.Config{
-				Pprof:        cfg.OperatorPprof,
-				PprofAddress: cfg.OperatorPprofAddress,
-				PprofPort:    cfg.OperatorPprofPort,
-			}
+			return cfg.Config()
 		}),
-		cell.Config(operatorPprofConfig{
-			OperatorPprofAddress: operatorOption.PprofAddressOperator,
-			OperatorPprofPort:    operatorOption.PprofPortOperator,
-		}),
+		pprof.Cell(defaultOperatorPprofConfig),
 
 		// Runs the gops agent, a tool to diagnose Go processes.
 		gops.Cell(defaults.EnableGops, defaults.GopsPortOperator),

--- a/pkg/clustermesh/kvstoremesh/cell.go
+++ b/pkg/clustermesh/kvstoremesh/cell.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/pkg/clustermesh/common"
-	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/metrics"
 )
 
@@ -21,7 +20,6 @@ var Cell = cell.Module(
 	),
 
 	cell.Config(common.DefaultConfig),
-	store.Cell,
 
 	metrics.Metric(common.MetricsProvider("")),
 )

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
@@ -547,6 +547,7 @@ func TestRemoteClusterRemoveShutdown(t *testing.T) {
 	h := hive.New(
 		Cell,
 
+		store.Cell,
 		cell.Provide(
 			func() types.ClusterInfo { return types.ClusterInfo{ID: 10, Name: "local"} },
 			func() Config { return DefaultConfig },

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -121,7 +121,7 @@ func AllCiliumCRDResourceNames() []string {
 // installed inside the K8s cluster. These CRDs are added by the
 // Cilium Operator. This function will block until it finds all the
 // CRDs or if a timeout occurs.
-func SyncCRDs(ctx context.Context, clientset client.Clientset, crdNames []string, rs *Resources, ag *APIGroups) error {
+func SyncCRDs(ctx context.Context, clientset client.Clientset, crdNames []string, rs *Resources, ag *APIGroups, cfg CRDSyncConfig) error {
 	crds := newCRDState(crdNames)
 
 	listerWatcher := newListWatchFromClient(
@@ -141,7 +141,7 @@ func SyncCRDs(ctx context.Context, clientset client.Clientset, crdNames []string
 
 	// Create a context so that we can timeout after the configured CRD wait
 	// peroid.
-	ctx, cancel := context.WithTimeout(ctx, option.Config.CRDWaitTimeout)
+	ctx, cancel := context.WithTimeout(ctx, cfg.CRDWaitTimeout)
 	defer cancel()
 
 	crds.Lock()
@@ -198,7 +198,7 @@ func SyncCRDs(ctx context.Context, clientset client.Clientset, crdNames []string
 						"%v timeout. Please ensure that Cilium Operator is "+
 						"running, as it's responsible for registering all "+
 						"the Cilium CRDs. The following CRDs were not found: %v",
-						option.Config.CRDWaitTimeout, crds.unSynced())
+						cfg.CRDWaitTimeout, crds.unSynced())
 			}
 			// If the context was canceled it means the daemon is being stopped
 			// so we can return the context's error.

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -188,14 +188,6 @@ func (k *K8sWatcher) GetAPIGroups() []string {
 	return k.k8sAPIGroups.GetGroups()
 }
 
-// WaitForCRDsToRegister will wait for the Cilium Operator to register the CRDs
-// with the apiserver. This step is required before launching the full K8s
-// watcher, as those resource controllers need the resources to be registered
-// with K8s first.
-func (k *K8sWatcher) WaitForCRDsToRegister(ctx context.Context) error {
-	return synced.SyncCRDs(ctx, k.clientset, synced.AgentCRDResourceNames(), k.k8sResourceSynced, k.k8sAPIGroups)
-}
-
 type watcherKind int
 
 const (

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1015,10 +1015,6 @@ const (
 	// LBMaglevMapMaxEntries configures max entries of bpf map for Maglev.
 	LBMaglevMapMaxEntries = "bpf-lb-maglev-map-max"
 
-	// CRDWaitTimeout is the timeout in which Cilium will exit if CRDs are not
-	// available.
-	CRDWaitTimeout = "crd-wait-timeout"
-
 	// EgressMultiHomeIPRuleCompat instructs Cilium to use a new scheme to
 	// store rules and routes under ENI and Azure IPAM modes, if false.
 	// Otherwise, it will use the old scheme.
@@ -2082,10 +2078,6 @@ type DaemonConfig struct {
 	// LBMaglevMapEntries is the maximum number of entries allowed in BPF lbmap for maglev.
 	LBMaglevMapEntries int
 
-	// CRDWaitTimeout is the timeout in which Cilium will exit if CRDs are not
-	// available.
-	CRDWaitTimeout time.Duration
-
 	// EgressMultiHomeIPRuleCompat instructs Cilium to use a new scheme to
 	// store rules and routes under ENI and Azure IPAM modes, if false.
 	// Otherwise, it will use the old scheme.
@@ -2955,7 +2947,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.PolicyAccounting = vp.GetBool(PolicyAccountingArg)
 	c.EnableIPv4FragmentsTracking = vp.GetBool(EnableIPv4FragmentsTrackingName)
 	c.FragmentsMapEntries = vp.GetInt(FragmentsMapEntriesName)
-	c.CRDWaitTimeout = vp.GetDuration(CRDWaitTimeout)
 	c.LoadBalancerDSRDispatch = vp.GetString(LoadBalancerDSRDispatch)
 	c.LoadBalancerRSSv4CIDR = vp.GetString(LoadBalancerRSSv4CIDR)
 	c.LoadBalancerRSSv6CIDR = vp.GetString(LoadBalancerRSSv6CIDR)

--- a/pkg/pprof/cell.go
+++ b/pkg/pprof/cell.go
@@ -33,20 +33,17 @@ type Server interface {
 
 // Cell creates the cell for pprof, that registers its HTTP handlers to serve
 // profiling data in the format expected by the pprof visualization tool.
-var Cell = cell.Module(
-	"pprof",
-	"pprof HTTP server to expose runtime profiling data",
+func Cell[Cfg cell.Flagger](cfg Cfg) cell.Cell {
+	return cell.Module(
+		"pprof",
+		"pprof HTTP server to expose runtime profiling data",
 
-	// We don't call cell.Config directly here, because the operator
-	// uses different flags names for the same pprof config flags.
-	// Therefore, to register each flag with the correct name, we leave
-	// the call to cell.Config to the user of the cell.
-
-	// Provide coupled with Invoke is used to improve cell testability,
-	// namely to allow taking a reference to the Server and call Port() on it.
-	cell.Provide(newServer),
-	cell.Invoke(func(srv Server) {}),
-)
+		// Provide coupled with Invoke is used to improve cell testability,
+		// namely to allow taking a reference to the Server and call Port() on it.
+		cell.Config(cfg),
+		cell.Provide(newServer),
+		cell.Invoke(func(srv Server) {}))
+}
 
 // Config contains the configuration for the pprof cell.
 type Config struct {


### PR DESCRIPTION
Since merging clustermesh and kvstoremesh together, the code was still
quite separate, registering multiple Hives and duplicate Cells (+
duplicate configuration). This could cause some options to be not
responsive to user configuration, as well as just unnecessarily running
extra instances of core logic that is not necessary to run - for
instance, two pprof or two gops servers. This may also fix issues where
some clustermesh controllers do not appear in debug status output.

Consolidate these into a single Hive with all the common cells, and
expose a new 'clustermesh-apiserver hive' command to inspect the
hierarchy.
