### PR TITLE
hubble: provide exporter builders to the cell

### DIFF
--- a/pkg/hubble/exporter/cell/builder.go
+++ b/pkg/hubble/exporter/cell/builder.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package exportercell
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/cilium/cilium/pkg/hubble/exporter"
+)
+
+// FlowLogExporterBuilder knows how to build a FlowLog The Replaces field
+// indicate that an existing builder with a matching Name field should be
+// replaced by this one.
+type FlowLogExporterBuilder struct {
+	Name     string
+	Replaces string
+	Build    func() (exporter.FlowLogExporter, error)
+}
+
+// resolveExporters verifies the slice of builders for duplicates and performs
+// replace operations as needed before building and returning the resulting
+// FlowLogExporters.
+//
+// This function panics if two or more builders have the same name or a
+// Replaces target builder was not found.
+func ResolveExporters(builders []*FlowLogExporterBuilder) ([]exporter.FlowLogExporter, error) {
+	builders, err := replaceBuilders(builders)
+	if err != nil {
+		// if we reach here, we got an implementation bug since we manage builders in code
+		panic(fmt.Sprintf("cannot resolve flow exporter: %s", err))
+	}
+	return buildExporters(builders)
+}
+
+func replaceBuilders(builders []*FlowLogExporterBuilder) ([]*FlowLogExporterBuilder, error) {
+	buildersByName := make(map[string]*FlowLogExporterBuilder, len(builders))
+	for _, builder := range builders {
+		if builder.Name == "" {
+			return nil, fmt.Errorf("exporter builder name not set")
+		}
+		if _, ok := buildersByName[builder.Name]; ok {
+			return nil, fmt.Errorf("exporter builder %q already exists", builder.Name)
+		}
+		buildersByName[builder.Name] = builder
+	}
+	for _, builder := range builders {
+		if builder.Replaces == "" {
+			continue
+		}
+		if builder.Replaces == builder.Name {
+			continue
+		}
+		delete(buildersByName, builder.Replaces)
+		buildersByName[builder.Name] = builder
+	}
+	return slices.Collect(maps.Values(buildersByName)), nil
+}
+
+func buildExporters(builders []*FlowLogExporterBuilder) ([]exporter.FlowLogExporter, error) {
+	exporters := make([]exporter.FlowLogExporter, 0, len(builders))
+	for _, builder := range builders {
+		exp, err := builder.Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build hubble exporter %q: %w", builder.Name, err)
+		}
+		if exp != nil {
+			exporters = append(exporters, exp)
+		}
+	}
+	return exporters, nil
+}

--- a/pkg/hubble/exporter/cell/builder_test.go
+++ b/pkg/hubble/exporter/cell/builder_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package exportercell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplaceBuilders(t *testing.T) {
+	cases := []struct {
+		name     string
+		builders []*FlowLogExporterBuilder
+		want     []*FlowLogExporterBuilder
+		wantErr  bool
+	}{
+		{name: "nil"},
+		{name: "empty", builders: []*FlowLogExporterBuilder{}},
+		{
+			name:     "one",
+			builders: []*FlowLogExporterBuilder{{Name: "my-name"}},
+			want:     []*FlowLogExporterBuilder{{Name: "my-name"}},
+		},
+		{
+			name:     "one-empty-name",
+			builders: []*FlowLogExporterBuilder{{Name: ""}},
+			wantErr:  true,
+		},
+		{
+			name:     "one-replaces",
+			builders: []*FlowLogExporterBuilder{{Name: "my-name", Replaces: "not-found"}},
+			want:     []*FlowLogExporterBuilder{{Name: "my-name", Replaces: "not-found"}},
+		},
+		{
+			name:     "two",
+			builders: []*FlowLogExporterBuilder{{Name: "one"}, {Name: "two"}},
+			want:     []*FlowLogExporterBuilder{{Name: "one"}, {Name: "two"}},
+		},
+		{
+			name:     "two-replaces",
+			builders: []*FlowLogExporterBuilder{{Name: "one", Replaces: "two"}, {Name: "two"}},
+			want:     []*FlowLogExporterBuilder{{Name: "one", Replaces: "two"}},
+		},
+		{
+			name:     "two-replaces-not-found",
+			builders: []*FlowLogExporterBuilder{{Name: "one", Replaces: "three"}, {Name: "two"}},
+			want:     []*FlowLogExporterBuilder{{Name: "one", Replaces: "three"}, {Name: "two"}},
+		},
+		{
+			name:     "two-replaces-self",
+			builders: []*FlowLogExporterBuilder{{Name: "one", Replaces: "one"}, {Name: "two"}},
+			want:     []*FlowLogExporterBuilder{{Name: "one", Replaces: "one"}, {Name: "two"}},
+		},
+		{
+			name:     "two-one-empty-name",
+			builders: []*FlowLogExporterBuilder{{Name: "one"}, {Name: ""}},
+			wantErr:  true,
+		},
+		{
+			name:     "two-duplicates",
+			builders: []*FlowLogExporterBuilder{{Name: "one"}, {Name: "one"}},
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := replaceBuilders(tc.builders)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Exporter cells now provide `FlowLogExporterBuilder` implementations instead of initialized `FlowLogExporter`s. This delays exporter construction in-order for the Hubble cell to accumulate all possible exporters provided by the Hive. This in-turn allows any cell to provide a replacement implementation for an existing exporter using the Replaces field on the builder.

Downstream maintainers can leverage this mechanism to add new exporters and/or replace existing ones.