### PR TITLE
datapath: Avoid using link-local IPv6 address for direct routing

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -591,7 +591,9 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 			for _, addr := range drd.Addrs {
 				if addr.Addr.Is6() {
 					ip = addr.AsIP()
-					break
+					if !ip.IsLinkLocalUnicast() {
+						break
+					}
 				}
 			}
 			if ip.IsUnspecified() {


### PR DESCRIPTION
This PR fixes the issue where link-local IPv6 address ends up being used for direct routing. Using link-local address results in packets being dropped during  FIB lookup with Nodeport services.  

Fixes: #36752

```release-note
datapath: Avoid using link-local IPv6 address for direct routing.
```
