### PR TITLE
cilium-cli: quarantine Wireguard v2 tests

### DIFF
--- a/cilium-cli/connectivity/builder/pod_to_pod_encryption.go
+++ b/cilium-cli/connectivity/builder/pod_to_pod_encryption.go
@@ -22,20 +22,6 @@ func (t podToPodEncryption) build(ct *check.ConnectivityTest, _ map[string]strin
 	// unencrypted packets shall, or shall not, be observed based on the feature set.
 	newTest("pod-to-pod-encryption", ct).
 		WithCondition(func() bool { return !ct.Params().SingleNode }).
-		WithCondition(func() bool {
-
-			// for wireguard, we can run the podToPodEncryptionV2 tests if we
-			// are on a post v1.18 cluster
-			encryptionPod, ok := ct.Feature(features.EncryptionPod)
-			if !ok {
-				return false
-			}
-			if encryptionPod.Mode == "wireguard" && versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion) {
-				return false
-			}
-
-			return true
-		}).
 		WithScenarios(
 			tests.PodToPodEncryption(features.RequireEnabled(features.EncryptionPod)),
 		)
@@ -43,16 +29,6 @@ func (t podToPodEncryption) build(ct *check.ConnectivityTest, _ map[string]strin
 	newTest("pod-to-pod-with-l7-policy-encryption", ct).
 		WithCondition(func() bool { return !ct.Params().SingleNode }).
 		WithCondition(func() bool {
-			// for wireguard, we can run the podToPodEncryptionV2 tests if we
-			// are on a post v1.18 cluster
-			encryptionPod, ok := ct.Feature(features.EncryptionPod)
-			if !ok {
-				return false
-			}
-			if encryptionPod.Mode == "wireguard" && versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion) {
-				return false
-			}
-
 			if ok, _ := ct.Features.MatchRequirements(features.RequireMode(features.EncryptionPod, "ipsec")); ok {
 				// Introduced in v1.17.0, backported to v1.15.11 and v1.16.4.
 				if !versioncheck.MustCompile(">=1.15.11 <1.16.0 || >=1.16.4")(ct.CiliumVersion) {

--- a/cilium-cli/connectivity/builder/pod_to_pod_encryption_v2.go
+++ b/cilium-cli/connectivity/builder/pod_to_pod_encryption_v2.go
@@ -20,6 +20,9 @@ func (t podToPodEncryptionV2) build(ct *check.ConnectivityTest, _ map[string]str
 	newTest("pod-to-pod-encryption-v2", ct).
 		WithCondition(func() bool { return !ct.Params().SingleNode }).
 		WithCondition(func() bool {
+			// Quarantine temporarily
+			return false
+
 			// this test only runs post v1.18.0 clusters
 			if !versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion) {
 				return false
@@ -49,6 +52,9 @@ func (t podToPodEncryptionV2) build(ct *check.ConnectivityTest, _ map[string]str
 	newTest("pod-to-pod-with-l7-policy-encryption-v2", ct).
 		WithCondition(func() bool { return !ct.Params().SingleNode }).
 		WithCondition(func() bool {
+			// Quarantine temporarily
+			return false
+
 			// this test only runs post v1.18.0 clusters
 			if !versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion) {
 				return false


### PR DESCRIPTION
There's some unresolved breakage in CI for at least ci-awscni [^0]. To unblock the development branch, switch back to the old tests.

[^0]: https://github.com/cilium/cilium/actions/runs/13320057239
