### PR TITLE
cli: connectivity: Fallback to pod-to-pod-encryption v1 on aws-cni chaining

### DIFF
--- a/cilium-cli/connectivity/builder/pod_to_pod_encryption.go
+++ b/cilium-cli/connectivity/builder/pod_to_pod_encryption.go
@@ -25,12 +25,16 @@ func (t podToPodEncryption) build(ct *check.ConnectivityTest, _ map[string]strin
 		WithCondition(func() bool {
 
 			// for wireguard, we can run the podToPodEncryptionV2 tests if we
-			// are on a post v1.18 cluster
+			// are on a post v1.18 cluster and not using aws-cni chaining
 			encryptionPod, ok := ct.Feature(features.EncryptionPod)
 			if !ok {
 				return false
 			}
-			if encryptionPod.Mode == "wireguard" && versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion) {
+			cniChaining, ok := ct.Feature(features.CNIChaining)
+			if !ok {
+				return false
+			}
+			if encryptionPod.Mode == "wireguard" && versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion) && cniChaining.Mode != "aws-cni" {
 				return false
 			}
 
@@ -44,12 +48,16 @@ func (t podToPodEncryption) build(ct *check.ConnectivityTest, _ map[string]strin
 		WithCondition(func() bool { return !ct.Params().SingleNode }).
 		WithCondition(func() bool {
 			// for wireguard, we can run the podToPodEncryptionV2 tests if we
-			// are on a post v1.18 cluster
+			// are on a post v1.18 cluster and not using aws-cni chaining
 			encryptionPod, ok := ct.Feature(features.EncryptionPod)
 			if !ok {
 				return false
 			}
-			if encryptionPod.Mode == "wireguard" && versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion) {
+			cniChaining, ok := ct.Feature(features.CNIChaining)
+			if !ok {
+				return false
+			}
+			if encryptionPod.Mode == "wireguard" && versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion) && cniChaining.Mode != "aws-cni" {
 				return false
 			}
 

--- a/cilium-cli/connectivity/builder/pod_to_pod_encryption_v2.go
+++ b/cilium-cli/connectivity/builder/pod_to_pod_encryption_v2.go
@@ -25,6 +25,11 @@ func (t podToPodEncryptionV2) build(ct *check.ConnectivityTest, _ map[string]str
 				return false
 			}
 
+			// https://github.com/cilium/cilium/issues/37682
+			if cniChaining, ok := ct.Feature(features.CNIChaining); !ok || cniChaining.Mode == "aws-cni" {
+				return false
+			}
+
 			// we run if no encryption is enabled at all to sanity check our
 			// tcpdump filters
 			encryptionPod, ok := ct.Feature(features.EncryptionPod)
@@ -51,6 +56,11 @@ func (t podToPodEncryptionV2) build(ct *check.ConnectivityTest, _ map[string]str
 		WithCondition(func() bool {
 			// this test only runs post v1.18.0 clusters
 			if !versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion) {
+				return false
+			}
+
+			// https://github.com/cilium/cilium/issues/37682
+			if cniChaining, ok := ct.Feature(features.CNIChaining); !ok || cniChaining.Mode == "aws-cni" {
 				return false
 			}
 


### PR DESCRIPTION
Pod-to-pod-encryption-v2 was introduced by https://github.com/cilium/cilium/pull/37533.
One of the major v2 changes is enabling sanity checks even for
non-encryption cluster. This caused troubles because v2 tests didn't take
cni-chaining mode, which is not compatible with encryption, into consideration.

This patch disabled v2 test on aws-cni chaining to avoid ci breakage.

Fixed: https://github.com/cilium/cilium/issues/37682
