### PR TITLE
hubble: Decode Cilium encapsulated traffic in Hubble

### DIFF
--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -41,6 +41,7 @@
     - [TimeNotification](#flow-TimeNotification)
     - [TraceContext](#flow-TraceContext)
     - [TraceParent](#flow-TraceParent)
+    - [Tunnel](#flow-Tunnel)
     - [UDP](#flow-UDP)
     - [Workload](#flow-Workload)
   
@@ -58,6 +59,7 @@
     - [TraceObservationPoint](#flow-TraceObservationPoint)
     - [TraceReason](#flow-TraceReason)
     - [TrafficDirection](#flow-TrafficDirection)
+    - [Tunnel.Protocol](#flow-Tunnel-Protocol)
     - [Verdict](#flow-Verdict)
   
 - [Scalar Value Types](#scalar-value-types)
@@ -292,6 +294,7 @@ EventTypeFilter is a filter describing a particular event type.
 | ethernet | [Ethernet](#flow-Ethernet) |  | l2 |
 | IP | [IP](#flow-IP) |  | l3 |
 | l4 | [Layer4](#flow-Layer4) |  | l4 |
+| tunnel | [Tunnel](#flow-Tunnel) |  |  |
 | source | [Endpoint](#flow-Endpoint) |  |  |
 | destination | [Endpoint](#flow-Endpoint) |  |  |
 | Type | [FlowType](#flow-FlowType) |  |  |
@@ -809,6 +812,23 @@ TraceParent identifies the incoming request in a tracing system.
 
 
 
+<a name="flow-Tunnel"></a>
+
+### Tunnel
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| protocol | [Tunnel.Protocol](#flow-Tunnel-Protocol) |  |  |
+| IP | [IP](#flow-IP) |  |  |
+| l4 | [Layer4](#flow-Layer4) |  |  |
+
+
+
+
+
+
 <a name="flow-UDP"></a>
 
 ### UDP
@@ -1200,6 +1220,19 @@ This mirrors enum xlate_point in bpf/lib/trace_sock.h
 | TRAFFIC_DIRECTION_UNKNOWN | 0 |  |
 | INGRESS | 1 |  |
 | EGRESS | 2 |  |
+
+
+
+<a name="flow-Tunnel-Protocol"></a>
+
+### Tunnel.Protocol
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| UNKNOWN | 0 |  |
+| VXLAN | 1 |  |
+| GENEVE | 2 |  |
 
 
 

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -1386,6 +1386,55 @@ func (DebugEventType) EnumDescriptor() ([]byte, []int) {
 	return file_flow_flow_proto_rawDescGZIP(), []int{14}
 }
 
+type Tunnel_Protocol int32
+
+const (
+	Tunnel_UNKNOWN Tunnel_Protocol = 0
+	Tunnel_VXLAN   Tunnel_Protocol = 1
+	Tunnel_GENEVE  Tunnel_Protocol = 2
+)
+
+// Enum value maps for Tunnel_Protocol.
+var (
+	Tunnel_Protocol_name = map[int32]string{
+		0: "UNKNOWN",
+		1: "VXLAN",
+		2: "GENEVE",
+	}
+	Tunnel_Protocol_value = map[string]int32{
+		"UNKNOWN": 0,
+		"VXLAN":   1,
+		"GENEVE":  2,
+	}
+)
+
+func (x Tunnel_Protocol) Enum() *Tunnel_Protocol {
+	p := new(Tunnel_Protocol)
+	*p = x
+	return p
+}
+
+func (x Tunnel_Protocol) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (Tunnel_Protocol) Descriptor() protoreflect.EnumDescriptor {
+	return file_flow_flow_proto_enumTypes[15].Descriptor()
+}
+
+func (Tunnel_Protocol) Type() protoreflect.EnumType {
+	return &file_flow_flow_proto_enumTypes[15]
+}
+
+func (x Tunnel_Protocol) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use Tunnel_Protocol.Descriptor instead.
+func (Tunnel_Protocol) EnumDescriptor() ([]byte, []int) {
+	return file_flow_flow_proto_rawDescGZIP(), []int{16, 0}
+}
+
 type Flow struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Time  *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=time,proto3" json:"time,omitempty"`
@@ -1406,6 +1455,7 @@ type Flow struct {
 	IP *IP `protobuf:"bytes,5,opt,name=IP,proto3" json:"IP,omitempty"`
 	// l4
 	L4          *Layer4   `protobuf:"bytes,6,opt,name=l4,proto3" json:"l4,omitempty"`
+	Tunnel      *Tunnel   `protobuf:"bytes,39,opt,name=tunnel,proto3" json:"tunnel,omitempty"`
 	Source      *Endpoint `protobuf:"bytes,8,opt,name=source,proto3" json:"source,omitempty"`
 	Destination *Endpoint `protobuf:"bytes,9,opt,name=destination,proto3" json:"destination,omitempty"`
 	Type        FlowType  `protobuf:"varint,10,opt,name=Type,proto3,enum=flow.FlowType" json:"Type,omitempty"`
@@ -1577,6 +1627,13 @@ func (x *Flow) GetIP() *IP {
 func (x *Flow) GetL4() *Layer4 {
 	if x != nil {
 		return x.L4
+	}
+	return nil
+}
+
+func (x *Flow) GetTunnel() *Tunnel {
+	if x != nil {
+		return x.Tunnel
 	}
 	return nil
 }
@@ -2864,6 +2921,66 @@ func (x *ICMPv6) GetCode() uint32 {
 	return 0
 }
 
+type Tunnel struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Protocol      Tunnel_Protocol        `protobuf:"varint,1,opt,name=protocol,proto3,enum=flow.Tunnel_Protocol" json:"protocol,omitempty"`
+	IP            *IP                    `protobuf:"bytes,2,opt,name=IP,proto3" json:"IP,omitempty"`
+	L4            *Layer4                `protobuf:"bytes,3,opt,name=l4,proto3" json:"l4,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Tunnel) Reset() {
+	*x = Tunnel{}
+	mi := &file_flow_flow_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Tunnel) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Tunnel) ProtoMessage() {}
+
+func (x *Tunnel) ProtoReflect() protoreflect.Message {
+	mi := &file_flow_flow_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Tunnel.ProtoReflect.Descriptor instead.
+func (*Tunnel) Descriptor() ([]byte, []int) {
+	return file_flow_flow_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *Tunnel) GetProtocol() Tunnel_Protocol {
+	if x != nil {
+		return x.Protocol
+	}
+	return Tunnel_UNKNOWN
+}
+
+func (x *Tunnel) GetIP() *IP {
+	if x != nil {
+		return x.IP
+	}
+	return nil
+}
+
+func (x *Tunnel) GetL4() *Layer4 {
+	if x != nil {
+		return x.L4
+	}
+	return nil
+}
+
 type Policy struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -2877,7 +2994,7 @@ type Policy struct {
 
 func (x *Policy) Reset() {
 	*x = Policy{}
-	mi := &file_flow_flow_proto_msgTypes[16]
+	mi := &file_flow_flow_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2889,7 +3006,7 @@ func (x *Policy) String() string {
 func (*Policy) ProtoMessage() {}
 
 func (x *Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[16]
+	mi := &file_flow_flow_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2902,7 +3019,7 @@ func (x *Policy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Policy.ProtoReflect.Descriptor instead.
 func (*Policy) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{16}
+	return file_flow_flow_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *Policy) GetName() string {
@@ -2958,7 +3075,7 @@ type EventTypeFilter struct {
 
 func (x *EventTypeFilter) Reset() {
 	*x = EventTypeFilter{}
-	mi := &file_flow_flow_proto_msgTypes[17]
+	mi := &file_flow_flow_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2970,7 +3087,7 @@ func (x *EventTypeFilter) String() string {
 func (*EventTypeFilter) ProtoMessage() {}
 
 func (x *EventTypeFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[17]
+	mi := &file_flow_flow_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2983,7 +3100,7 @@ func (x *EventTypeFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EventTypeFilter.ProtoReflect.Descriptor instead.
 func (*EventTypeFilter) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{17}
+	return file_flow_flow_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *EventTypeFilter) GetType() int32 {
@@ -3024,7 +3141,7 @@ type CiliumEventType struct {
 
 func (x *CiliumEventType) Reset() {
 	*x = CiliumEventType{}
-	mi := &file_flow_flow_proto_msgTypes[18]
+	mi := &file_flow_flow_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3036,7 +3153,7 @@ func (x *CiliumEventType) String() string {
 func (*CiliumEventType) ProtoMessage() {}
 
 func (x *CiliumEventType) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[18]
+	mi := &file_flow_flow_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3049,7 +3166,7 @@ func (x *CiliumEventType) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CiliumEventType.ProtoReflect.Descriptor instead.
 func (*CiliumEventType) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{18}
+	return file_flow_flow_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *CiliumEventType) GetType() int32 {
@@ -3172,7 +3289,7 @@ type FlowFilter struct {
 
 func (x *FlowFilter) Reset() {
 	*x = FlowFilter{}
-	mi := &file_flow_flow_proto_msgTypes[19]
+	mi := &file_flow_flow_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3184,7 +3301,7 @@ func (x *FlowFilter) String() string {
 func (*FlowFilter) ProtoMessage() {}
 
 func (x *FlowFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[19]
+	mi := &file_flow_flow_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3197,7 +3314,7 @@ func (x *FlowFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FlowFilter.ProtoReflect.Descriptor instead.
 func (*FlowFilter) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{19}
+	return file_flow_flow_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *FlowFilter) GetUuid() []string {
@@ -3505,7 +3622,7 @@ type DNS struct {
 
 func (x *DNS) Reset() {
 	*x = DNS{}
-	mi := &file_flow_flow_proto_msgTypes[20]
+	mi := &file_flow_flow_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3517,7 +3634,7 @@ func (x *DNS) String() string {
 func (*DNS) ProtoMessage() {}
 
 func (x *DNS) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[20]
+	mi := &file_flow_flow_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3530,7 +3647,7 @@ func (x *DNS) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DNS.ProtoReflect.Descriptor instead.
 func (*DNS) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{20}
+	return file_flow_flow_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *DNS) GetQuery() string {
@@ -3599,7 +3716,7 @@ type HTTPHeader struct {
 
 func (x *HTTPHeader) Reset() {
 	*x = HTTPHeader{}
-	mi := &file_flow_flow_proto_msgTypes[21]
+	mi := &file_flow_flow_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3611,7 +3728,7 @@ func (x *HTTPHeader) String() string {
 func (*HTTPHeader) ProtoMessage() {}
 
 func (x *HTTPHeader) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[21]
+	mi := &file_flow_flow_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3624,7 +3741,7 @@ func (x *HTTPHeader) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HTTPHeader.ProtoReflect.Descriptor instead.
 func (*HTTPHeader) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{21}
+	return file_flow_flow_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *HTTPHeader) GetKey() string {
@@ -3655,7 +3772,7 @@ type HTTP struct {
 
 func (x *HTTP) Reset() {
 	*x = HTTP{}
-	mi := &file_flow_flow_proto_msgTypes[22]
+	mi := &file_flow_flow_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3667,7 +3784,7 @@ func (x *HTTP) String() string {
 func (*HTTP) ProtoMessage() {}
 
 func (x *HTTP) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[22]
+	mi := &file_flow_flow_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3680,7 +3797,7 @@ func (x *HTTP) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HTTP.ProtoReflect.Descriptor instead.
 func (*HTTP) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{22}
+	return file_flow_flow_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *HTTP) GetCode() uint32 {
@@ -3732,7 +3849,7 @@ type Kafka struct {
 
 func (x *Kafka) Reset() {
 	*x = Kafka{}
-	mi := &file_flow_flow_proto_msgTypes[23]
+	mi := &file_flow_flow_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3744,7 +3861,7 @@ func (x *Kafka) String() string {
 func (*Kafka) ProtoMessage() {}
 
 func (x *Kafka) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[23]
+	mi := &file_flow_flow_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3757,7 +3874,7 @@ func (x *Kafka) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Kafka.ProtoReflect.Descriptor instead.
 func (*Kafka) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{23}
+	return file_flow_flow_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *Kafka) GetErrorCode() int32 {
@@ -3805,7 +3922,7 @@ type Service struct {
 
 func (x *Service) Reset() {
 	*x = Service{}
-	mi := &file_flow_flow_proto_msgTypes[24]
+	mi := &file_flow_flow_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3817,7 +3934,7 @@ func (x *Service) String() string {
 func (*Service) ProtoMessage() {}
 
 func (x *Service) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[24]
+	mi := &file_flow_flow_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3830,7 +3947,7 @@ func (x *Service) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Service.ProtoReflect.Descriptor instead.
 func (*Service) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{24}
+	return file_flow_flow_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *Service) GetName() string {
@@ -3864,7 +3981,7 @@ type LostEvent struct {
 
 func (x *LostEvent) Reset() {
 	*x = LostEvent{}
-	mi := &file_flow_flow_proto_msgTypes[25]
+	mi := &file_flow_flow_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3876,7 +3993,7 @@ func (x *LostEvent) String() string {
 func (*LostEvent) ProtoMessage() {}
 
 func (x *LostEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[25]
+	mi := &file_flow_flow_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3889,7 +4006,7 @@ func (x *LostEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LostEvent.ProtoReflect.Descriptor instead.
 func (*LostEvent) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{25}
+	return file_flow_flow_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *LostEvent) GetSource() LostEventSource {
@@ -3933,7 +4050,7 @@ type AgentEvent struct {
 
 func (x *AgentEvent) Reset() {
 	*x = AgentEvent{}
-	mi := &file_flow_flow_proto_msgTypes[26]
+	mi := &file_flow_flow_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3945,7 +4062,7 @@ func (x *AgentEvent) String() string {
 func (*AgentEvent) ProtoMessage() {}
 
 func (x *AgentEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[26]
+	mi := &file_flow_flow_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3958,7 +4075,7 @@ func (x *AgentEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentEvent.ProtoReflect.Descriptor instead.
 func (*AgentEvent) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{26}
+	return file_flow_flow_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *AgentEvent) GetType() AgentEventType {
@@ -4117,7 +4234,7 @@ type AgentEventUnknown struct {
 
 func (x *AgentEventUnknown) Reset() {
 	*x = AgentEventUnknown{}
-	mi := &file_flow_flow_proto_msgTypes[27]
+	mi := &file_flow_flow_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4129,7 +4246,7 @@ func (x *AgentEventUnknown) String() string {
 func (*AgentEventUnknown) ProtoMessage() {}
 
 func (x *AgentEventUnknown) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[27]
+	mi := &file_flow_flow_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4142,7 +4259,7 @@ func (x *AgentEventUnknown) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AgentEventUnknown.ProtoReflect.Descriptor instead.
 func (*AgentEventUnknown) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{27}
+	return file_flow_flow_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *AgentEventUnknown) GetType() string {
@@ -4168,7 +4285,7 @@ type TimeNotification struct {
 
 func (x *TimeNotification) Reset() {
 	*x = TimeNotification{}
-	mi := &file_flow_flow_proto_msgTypes[28]
+	mi := &file_flow_flow_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4180,7 +4297,7 @@ func (x *TimeNotification) String() string {
 func (*TimeNotification) ProtoMessage() {}
 
 func (x *TimeNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[28]
+	mi := &file_flow_flow_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4193,7 +4310,7 @@ func (x *TimeNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimeNotification.ProtoReflect.Descriptor instead.
 func (*TimeNotification) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{28}
+	return file_flow_flow_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *TimeNotification) GetTime() *timestamppb.Timestamp {
@@ -4214,7 +4331,7 @@ type PolicyUpdateNotification struct {
 
 func (x *PolicyUpdateNotification) Reset() {
 	*x = PolicyUpdateNotification{}
-	mi := &file_flow_flow_proto_msgTypes[29]
+	mi := &file_flow_flow_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4226,7 +4343,7 @@ func (x *PolicyUpdateNotification) String() string {
 func (*PolicyUpdateNotification) ProtoMessage() {}
 
 func (x *PolicyUpdateNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[29]
+	mi := &file_flow_flow_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4239,7 +4356,7 @@ func (x *PolicyUpdateNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyUpdateNotification.ProtoReflect.Descriptor instead.
 func (*PolicyUpdateNotification) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{29}
+	return file_flow_flow_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *PolicyUpdateNotification) GetLabels() []string {
@@ -4274,7 +4391,7 @@ type EndpointRegenNotification struct {
 
 func (x *EndpointRegenNotification) Reset() {
 	*x = EndpointRegenNotification{}
-	mi := &file_flow_flow_proto_msgTypes[30]
+	mi := &file_flow_flow_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4286,7 +4403,7 @@ func (x *EndpointRegenNotification) String() string {
 func (*EndpointRegenNotification) ProtoMessage() {}
 
 func (x *EndpointRegenNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[30]
+	mi := &file_flow_flow_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4299,7 +4416,7 @@ func (x *EndpointRegenNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EndpointRegenNotification.ProtoReflect.Descriptor instead.
 func (*EndpointRegenNotification) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{30}
+	return file_flow_flow_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *EndpointRegenNotification) GetId() uint64 {
@@ -4336,7 +4453,7 @@ type EndpointUpdateNotification struct {
 
 func (x *EndpointUpdateNotification) Reset() {
 	*x = EndpointUpdateNotification{}
-	mi := &file_flow_flow_proto_msgTypes[31]
+	mi := &file_flow_flow_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4348,7 +4465,7 @@ func (x *EndpointUpdateNotification) String() string {
 func (*EndpointUpdateNotification) ProtoMessage() {}
 
 func (x *EndpointUpdateNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[31]
+	mi := &file_flow_flow_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4361,7 +4478,7 @@ func (x *EndpointUpdateNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EndpointUpdateNotification.ProtoReflect.Descriptor instead.
 func (*EndpointUpdateNotification) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{31}
+	return file_flow_flow_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *EndpointUpdateNotification) GetId() uint64 {
@@ -4415,7 +4532,7 @@ type IPCacheNotification struct {
 
 func (x *IPCacheNotification) Reset() {
 	*x = IPCacheNotification{}
-	mi := &file_flow_flow_proto_msgTypes[32]
+	mi := &file_flow_flow_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4427,7 +4544,7 @@ func (x *IPCacheNotification) String() string {
 func (*IPCacheNotification) ProtoMessage() {}
 
 func (x *IPCacheNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[32]
+	mi := &file_flow_flow_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4440,7 +4557,7 @@ func (x *IPCacheNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IPCacheNotification.ProtoReflect.Descriptor instead.
 func (*IPCacheNotification) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{32}
+	return file_flow_flow_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *IPCacheNotification) GetCidr() string {
@@ -4510,7 +4627,7 @@ type ServiceUpsertNotificationAddr struct {
 
 func (x *ServiceUpsertNotificationAddr) Reset() {
 	*x = ServiceUpsertNotificationAddr{}
-	mi := &file_flow_flow_proto_msgTypes[33]
+	mi := &file_flow_flow_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4522,7 +4639,7 @@ func (x *ServiceUpsertNotificationAddr) String() string {
 func (*ServiceUpsertNotificationAddr) ProtoMessage() {}
 
 func (x *ServiceUpsertNotificationAddr) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[33]
+	mi := &file_flow_flow_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4535,7 +4652,7 @@ func (x *ServiceUpsertNotificationAddr) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceUpsertNotificationAddr.ProtoReflect.Descriptor instead.
 func (*ServiceUpsertNotificationAddr) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{33}
+	return file_flow_flow_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ServiceUpsertNotificationAddr) GetIp() string {
@@ -4571,7 +4688,7 @@ type ServiceUpsertNotification struct {
 
 func (x *ServiceUpsertNotification) Reset() {
 	*x = ServiceUpsertNotification{}
-	mi := &file_flow_flow_proto_msgTypes[34]
+	mi := &file_flow_flow_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4583,7 +4700,7 @@ func (x *ServiceUpsertNotification) String() string {
 func (*ServiceUpsertNotification) ProtoMessage() {}
 
 func (x *ServiceUpsertNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[34]
+	mi := &file_flow_flow_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4596,7 +4713,7 @@ func (x *ServiceUpsertNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceUpsertNotification.ProtoReflect.Descriptor instead.
 func (*ServiceUpsertNotification) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{34}
+	return file_flow_flow_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ServiceUpsertNotification) GetId() uint32 {
@@ -4673,7 +4790,7 @@ type ServiceDeleteNotification struct {
 
 func (x *ServiceDeleteNotification) Reset() {
 	*x = ServiceDeleteNotification{}
-	mi := &file_flow_flow_proto_msgTypes[35]
+	mi := &file_flow_flow_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4685,7 +4802,7 @@ func (x *ServiceDeleteNotification) String() string {
 func (*ServiceDeleteNotification) ProtoMessage() {}
 
 func (x *ServiceDeleteNotification) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[35]
+	mi := &file_flow_flow_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4698,7 +4815,7 @@ func (x *ServiceDeleteNotification) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceDeleteNotification.ProtoReflect.Descriptor instead.
 func (*ServiceDeleteNotification) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{35}
+	return file_flow_flow_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ServiceDeleteNotification) GetId() uint32 {
@@ -4718,7 +4835,7 @@ type NetworkInterface struct {
 
 func (x *NetworkInterface) Reset() {
 	*x = NetworkInterface{}
-	mi := &file_flow_flow_proto_msgTypes[36]
+	mi := &file_flow_flow_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4730,7 +4847,7 @@ func (x *NetworkInterface) String() string {
 func (*NetworkInterface) ProtoMessage() {}
 
 func (x *NetworkInterface) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[36]
+	mi := &file_flow_flow_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4743,7 +4860,7 @@ func (x *NetworkInterface) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkInterface.ProtoReflect.Descriptor instead.
 func (*NetworkInterface) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{36}
+	return file_flow_flow_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *NetworkInterface) GetIndex() uint32 {
@@ -4776,7 +4893,7 @@ type DebugEvent struct {
 
 func (x *DebugEvent) Reset() {
 	*x = DebugEvent{}
-	mi := &file_flow_flow_proto_msgTypes[37]
+	mi := &file_flow_flow_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4788,7 +4905,7 @@ func (x *DebugEvent) String() string {
 func (*DebugEvent) ProtoMessage() {}
 
 func (x *DebugEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[37]
+	mi := &file_flow_flow_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4801,7 +4918,7 @@ func (x *DebugEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DebugEvent.ProtoReflect.Descriptor instead.
 func (*DebugEvent) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{37}
+	return file_flow_flow_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *DebugEvent) GetType() DebugEventType {
@@ -4880,7 +4997,7 @@ type FlowFilter_Experimental struct {
 
 func (x *FlowFilter_Experimental) Reset() {
 	*x = FlowFilter_Experimental{}
-	mi := &file_flow_flow_proto_msgTypes[38]
+	mi := &file_flow_flow_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4892,7 +5009,7 @@ func (x *FlowFilter_Experimental) String() string {
 func (*FlowFilter_Experimental) ProtoMessage() {}
 
 func (x *FlowFilter_Experimental) ProtoReflect() protoreflect.Message {
-	mi := &file_flow_flow_proto_msgTypes[38]
+	mi := &file_flow_flow_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4905,7 +5022,7 @@ func (x *FlowFilter_Experimental) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FlowFilter_Experimental.ProtoReflect.Descriptor instead.
 func (*FlowFilter_Experimental) Descriptor() ([]byte, []int) {
-	return file_flow_flow_proto_rawDescGZIP(), []int{19, 0}
+	return file_flow_flow_proto_rawDescGZIP(), []int{20, 0}
 }
 
 func (x *FlowFilter_Experimental) GetCelExpression() []string {
@@ -4919,7 +5036,7 @@ var File_flow_flow_proto protoreflect.FileDescriptor
 
 const file_flow_flow_proto_rawDesc = "" +
 	"\n" +
-	"\x0fflow/flow.proto\x12\x04flow\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x8e\x0f\n" +
+	"\x0fflow/flow.proto\x12\x04flow\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb4\x0f\n" +
 	"\x04Flow\x12.\n" +
 	"\x04time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x04time\x12\x12\n" +
 	"\x04uuid\x18\" \x01(\tR\x04uuid\x12'\n" +
@@ -4929,7 +5046,8 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\tauth_type\x18# \x01(\x0e2\x0e.flow.AuthTypeR\bauthType\x12*\n" +
 	"\bethernet\x18\x04 \x01(\v2\x0e.flow.EthernetR\bethernet\x12\x18\n" +
 	"\x02IP\x18\x05 \x01(\v2\b.flow.IPR\x02IP\x12\x1c\n" +
-	"\x02l4\x18\x06 \x01(\v2\f.flow.Layer4R\x02l4\x12&\n" +
+	"\x02l4\x18\x06 \x01(\v2\f.flow.Layer4R\x02l4\x12$\n" +
+	"\x06tunnel\x18' \x01(\v2\f.flow.TunnelR\x06tunnel\x12&\n" +
 	"\x06source\x18\b \x01(\v2\x0e.flow.EndpointR\x06source\x120\n" +
 	"\vdestination\x18\t \x01(\v2\x0e.flow.EndpointR\vdestination\x12\"\n" +
 	"\x04Type\x18\n" +
@@ -5043,7 +5161,16 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\x04code\x18\x02 \x01(\rR\x04code\"0\n" +
 	"\x06ICMPv6\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\rR\x04type\x12\x12\n" +
-	"\x04code\x18\x02 \x01(\rR\x04code\"\x82\x01\n" +
+	"\x04code\x18\x02 \x01(\rR\x04code\"\xa3\x01\n" +
+	"\x06Tunnel\x121\n" +
+	"\bprotocol\x18\x01 \x01(\x0e2\x15.flow.Tunnel.ProtocolR\bprotocol\x12\x18\n" +
+	"\x02IP\x18\x02 \x01(\v2\b.flow.IPR\x02IP\x12\x1c\n" +
+	"\x02l4\x18\x03 \x01(\v2\f.flow.Layer4R\x02l4\".\n" +
+	"\bProtocol\x12\v\n" +
+	"\aUNKNOWN\x10\x00\x12\t\n" +
+	"\x05VXLAN\x10\x01\x12\n" +
+	"\n" +
+	"\x06GENEVE\x10\x02\"\x82\x01\n" +
 	"\x06Policy\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x16\n" +
@@ -5488,8 +5615,8 @@ func file_flow_flow_proto_rawDescGZIP() []byte {
 	return file_flow_flow_proto_rawDescData
 }
 
-var file_flow_flow_proto_enumTypes = make([]protoimpl.EnumInfo, 15)
-var file_flow_flow_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
+var file_flow_flow_proto_enumTypes = make([]protoimpl.EnumInfo, 16)
+var file_flow_flow_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
 var file_flow_flow_proto_goTypes = []any{
 	(FlowType)(0),                         // 0: flow.FlowType
 	(AuthType)(0),                         // 1: flow.AuthType
@@ -5506,132 +5633,138 @@ var file_flow_flow_proto_goTypes = []any{
 	(AgentEventType)(0),                   // 12: flow.AgentEventType
 	(SocketTranslationPoint)(0),           // 13: flow.SocketTranslationPoint
 	(DebugEventType)(0),                   // 14: flow.DebugEventType
-	(*Flow)(nil),                          // 15: flow.Flow
-	(*FileInfo)(nil),                      // 16: flow.FileInfo
-	(*Layer4)(nil),                        // 17: flow.Layer4
-	(*Layer7)(nil),                        // 18: flow.Layer7
-	(*TraceContext)(nil),                  // 19: flow.TraceContext
-	(*TraceParent)(nil),                   // 20: flow.TraceParent
-	(*Endpoint)(nil),                      // 21: flow.Endpoint
-	(*Workload)(nil),                      // 22: flow.Workload
-	(*TCP)(nil),                           // 23: flow.TCP
-	(*IP)(nil),                            // 24: flow.IP
-	(*Ethernet)(nil),                      // 25: flow.Ethernet
-	(*TCPFlags)(nil),                      // 26: flow.TCPFlags
-	(*UDP)(nil),                           // 27: flow.UDP
-	(*SCTP)(nil),                          // 28: flow.SCTP
-	(*ICMPv4)(nil),                        // 29: flow.ICMPv4
-	(*ICMPv6)(nil),                        // 30: flow.ICMPv6
-	(*Policy)(nil),                        // 31: flow.Policy
-	(*EventTypeFilter)(nil),               // 32: flow.EventTypeFilter
-	(*CiliumEventType)(nil),               // 33: flow.CiliumEventType
-	(*FlowFilter)(nil),                    // 34: flow.FlowFilter
-	(*DNS)(nil),                           // 35: flow.DNS
-	(*HTTPHeader)(nil),                    // 36: flow.HTTPHeader
-	(*HTTP)(nil),                          // 37: flow.HTTP
-	(*Kafka)(nil),                         // 38: flow.Kafka
-	(*Service)(nil),                       // 39: flow.Service
-	(*LostEvent)(nil),                     // 40: flow.LostEvent
-	(*AgentEvent)(nil),                    // 41: flow.AgentEvent
-	(*AgentEventUnknown)(nil),             // 42: flow.AgentEventUnknown
-	(*TimeNotification)(nil),              // 43: flow.TimeNotification
-	(*PolicyUpdateNotification)(nil),      // 44: flow.PolicyUpdateNotification
-	(*EndpointRegenNotification)(nil),     // 45: flow.EndpointRegenNotification
-	(*EndpointUpdateNotification)(nil),    // 46: flow.EndpointUpdateNotification
-	(*IPCacheNotification)(nil),           // 47: flow.IPCacheNotification
-	(*ServiceUpsertNotificationAddr)(nil), // 48: flow.ServiceUpsertNotificationAddr
-	(*ServiceUpsertNotification)(nil),     // 49: flow.ServiceUpsertNotification
-	(*ServiceDeleteNotification)(nil),     // 50: flow.ServiceDeleteNotification
-	(*NetworkInterface)(nil),              // 51: flow.NetworkInterface
-	(*DebugEvent)(nil),                    // 52: flow.DebugEvent
-	(*FlowFilter_Experimental)(nil),       // 53: flow.FlowFilter.Experimental
-	(*timestamppb.Timestamp)(nil),         // 54: google.protobuf.Timestamp
-	(*wrapperspb.BoolValue)(nil),          // 55: google.protobuf.BoolValue
-	(*anypb.Any)(nil),                     // 56: google.protobuf.Any
-	(*wrapperspb.Int32Value)(nil),         // 57: google.protobuf.Int32Value
-	(*wrapperspb.UInt32Value)(nil),        // 58: google.protobuf.UInt32Value
+	(Tunnel_Protocol)(0),                  // 15: flow.Tunnel.Protocol
+	(*Flow)(nil),                          // 16: flow.Flow
+	(*FileInfo)(nil),                      // 17: flow.FileInfo
+	(*Layer4)(nil),                        // 18: flow.Layer4
+	(*Layer7)(nil),                        // 19: flow.Layer7
+	(*TraceContext)(nil),                  // 20: flow.TraceContext
+	(*TraceParent)(nil),                   // 21: flow.TraceParent
+	(*Endpoint)(nil),                      // 22: flow.Endpoint
+	(*Workload)(nil),                      // 23: flow.Workload
+	(*TCP)(nil),                           // 24: flow.TCP
+	(*IP)(nil),                            // 25: flow.IP
+	(*Ethernet)(nil),                      // 26: flow.Ethernet
+	(*TCPFlags)(nil),                      // 27: flow.TCPFlags
+	(*UDP)(nil),                           // 28: flow.UDP
+	(*SCTP)(nil),                          // 29: flow.SCTP
+	(*ICMPv4)(nil),                        // 30: flow.ICMPv4
+	(*ICMPv6)(nil),                        // 31: flow.ICMPv6
+	(*Tunnel)(nil),                        // 32: flow.Tunnel
+	(*Policy)(nil),                        // 33: flow.Policy
+	(*EventTypeFilter)(nil),               // 34: flow.EventTypeFilter
+	(*CiliumEventType)(nil),               // 35: flow.CiliumEventType
+	(*FlowFilter)(nil),                    // 36: flow.FlowFilter
+	(*DNS)(nil),                           // 37: flow.DNS
+	(*HTTPHeader)(nil),                    // 38: flow.HTTPHeader
+	(*HTTP)(nil),                          // 39: flow.HTTP
+	(*Kafka)(nil),                         // 40: flow.Kafka
+	(*Service)(nil),                       // 41: flow.Service
+	(*LostEvent)(nil),                     // 42: flow.LostEvent
+	(*AgentEvent)(nil),                    // 43: flow.AgentEvent
+	(*AgentEventUnknown)(nil),             // 44: flow.AgentEventUnknown
+	(*TimeNotification)(nil),              // 45: flow.TimeNotification
+	(*PolicyUpdateNotification)(nil),      // 46: flow.PolicyUpdateNotification
+	(*EndpointRegenNotification)(nil),     // 47: flow.EndpointRegenNotification
+	(*EndpointUpdateNotification)(nil),    // 48: flow.EndpointUpdateNotification
+	(*IPCacheNotification)(nil),           // 49: flow.IPCacheNotification
+	(*ServiceUpsertNotificationAddr)(nil), // 50: flow.ServiceUpsertNotificationAddr
+	(*ServiceUpsertNotification)(nil),     // 51: flow.ServiceUpsertNotification
+	(*ServiceDeleteNotification)(nil),     // 52: flow.ServiceDeleteNotification
+	(*NetworkInterface)(nil),              // 53: flow.NetworkInterface
+	(*DebugEvent)(nil),                    // 54: flow.DebugEvent
+	(*FlowFilter_Experimental)(nil),       // 55: flow.FlowFilter.Experimental
+	(*timestamppb.Timestamp)(nil),         // 56: google.protobuf.Timestamp
+	(*wrapperspb.BoolValue)(nil),          // 57: google.protobuf.BoolValue
+	(*anypb.Any)(nil),                     // 58: google.protobuf.Any
+	(*wrapperspb.Int32Value)(nil),         // 59: google.protobuf.Int32Value
+	(*wrapperspb.UInt32Value)(nil),        // 60: google.protobuf.UInt32Value
 }
 var file_flow_flow_proto_depIdxs = []int32{
-	54, // 0: flow.Flow.time:type_name -> google.protobuf.Timestamp
+	56, // 0: flow.Flow.time:type_name -> google.protobuf.Timestamp
 	6,  // 1: flow.Flow.verdict:type_name -> flow.Verdict
 	1,  // 2: flow.Flow.auth_type:type_name -> flow.AuthType
-	25, // 3: flow.Flow.ethernet:type_name -> flow.Ethernet
-	24, // 4: flow.Flow.IP:type_name -> flow.IP
-	17, // 5: flow.Flow.l4:type_name -> flow.Layer4
-	21, // 6: flow.Flow.source:type_name -> flow.Endpoint
-	21, // 7: flow.Flow.destination:type_name -> flow.Endpoint
-	0,  // 8: flow.Flow.Type:type_name -> flow.FlowType
-	18, // 9: flow.Flow.l7:type_name -> flow.Layer7
-	33, // 10: flow.Flow.event_type:type_name -> flow.CiliumEventType
-	39, // 11: flow.Flow.source_service:type_name -> flow.Service
-	39, // 12: flow.Flow.destination_service:type_name -> flow.Service
-	8,  // 13: flow.Flow.traffic_direction:type_name -> flow.TrafficDirection
-	2,  // 14: flow.Flow.trace_observation_point:type_name -> flow.TraceObservationPoint
-	3,  // 15: flow.Flow.trace_reason:type_name -> flow.TraceReason
-	16, // 16: flow.Flow.file:type_name -> flow.FileInfo
-	7,  // 17: flow.Flow.drop_reason_desc:type_name -> flow.DropReason
-	55, // 18: flow.Flow.is_reply:type_name -> google.protobuf.BoolValue
-	9,  // 19: flow.Flow.debug_capture_point:type_name -> flow.DebugCapturePoint
-	51, // 20: flow.Flow.interface:type_name -> flow.NetworkInterface
-	19, // 21: flow.Flow.trace_context:type_name -> flow.TraceContext
-	13, // 22: flow.Flow.sock_xlate_point:type_name -> flow.SocketTranslationPoint
-	56, // 23: flow.Flow.extensions:type_name -> google.protobuf.Any
-	31, // 24: flow.Flow.egress_allowed_by:type_name -> flow.Policy
-	31, // 25: flow.Flow.ingress_allowed_by:type_name -> flow.Policy
-	31, // 26: flow.Flow.egress_denied_by:type_name -> flow.Policy
-	31, // 27: flow.Flow.ingress_denied_by:type_name -> flow.Policy
-	23, // 28: flow.Layer4.TCP:type_name -> flow.TCP
-	27, // 29: flow.Layer4.UDP:type_name -> flow.UDP
-	29, // 30: flow.Layer4.ICMPv4:type_name -> flow.ICMPv4
-	30, // 31: flow.Layer4.ICMPv6:type_name -> flow.ICMPv6
-	28, // 32: flow.Layer4.SCTP:type_name -> flow.SCTP
-	4,  // 33: flow.Layer7.type:type_name -> flow.L7FlowType
-	35, // 34: flow.Layer7.dns:type_name -> flow.DNS
-	37, // 35: flow.Layer7.http:type_name -> flow.HTTP
-	38, // 36: flow.Layer7.kafka:type_name -> flow.Kafka
-	20, // 37: flow.TraceContext.parent:type_name -> flow.TraceParent
-	22, // 38: flow.Endpoint.workloads:type_name -> flow.Workload
-	26, // 39: flow.TCP.flags:type_name -> flow.TCPFlags
-	5,  // 40: flow.IP.ipVersion:type_name -> flow.IPVersion
-	22, // 41: flow.FlowFilter.source_workload:type_name -> flow.Workload
-	22, // 42: flow.FlowFilter.destination_workload:type_name -> flow.Workload
-	8,  // 43: flow.FlowFilter.traffic_direction:type_name -> flow.TrafficDirection
-	6,  // 44: flow.FlowFilter.verdict:type_name -> flow.Verdict
-	7,  // 45: flow.FlowFilter.drop_reason_desc:type_name -> flow.DropReason
-	51, // 46: flow.FlowFilter.interface:type_name -> flow.NetworkInterface
-	32, // 47: flow.FlowFilter.event_type:type_name -> flow.EventTypeFilter
-	36, // 48: flow.FlowFilter.http_header:type_name -> flow.HTTPHeader
-	26, // 49: flow.FlowFilter.tcp_flags:type_name -> flow.TCPFlags
-	5,  // 50: flow.FlowFilter.ip_version:type_name -> flow.IPVersion
-	53, // 51: flow.FlowFilter.experimental:type_name -> flow.FlowFilter.Experimental
-	36, // 52: flow.HTTP.headers:type_name -> flow.HTTPHeader
-	11, // 53: flow.LostEvent.source:type_name -> flow.LostEventSource
-	57, // 54: flow.LostEvent.cpu:type_name -> google.protobuf.Int32Value
-	12, // 55: flow.AgentEvent.type:type_name -> flow.AgentEventType
-	42, // 56: flow.AgentEvent.unknown:type_name -> flow.AgentEventUnknown
-	43, // 57: flow.AgentEvent.agent_start:type_name -> flow.TimeNotification
-	44, // 58: flow.AgentEvent.policy_update:type_name -> flow.PolicyUpdateNotification
-	45, // 59: flow.AgentEvent.endpoint_regenerate:type_name -> flow.EndpointRegenNotification
-	46, // 60: flow.AgentEvent.endpoint_update:type_name -> flow.EndpointUpdateNotification
-	47, // 61: flow.AgentEvent.ipcache_update:type_name -> flow.IPCacheNotification
-	49, // 62: flow.AgentEvent.service_upsert:type_name -> flow.ServiceUpsertNotification
-	50, // 63: flow.AgentEvent.service_delete:type_name -> flow.ServiceDeleteNotification
-	54, // 64: flow.TimeNotification.time:type_name -> google.protobuf.Timestamp
-	58, // 65: flow.IPCacheNotification.old_identity:type_name -> google.protobuf.UInt32Value
-	48, // 66: flow.ServiceUpsertNotification.frontend_address:type_name -> flow.ServiceUpsertNotificationAddr
-	48, // 67: flow.ServiceUpsertNotification.backend_addresses:type_name -> flow.ServiceUpsertNotificationAddr
-	14, // 68: flow.DebugEvent.type:type_name -> flow.DebugEventType
-	21, // 69: flow.DebugEvent.source:type_name -> flow.Endpoint
-	58, // 70: flow.DebugEvent.hash:type_name -> google.protobuf.UInt32Value
-	58, // 71: flow.DebugEvent.arg1:type_name -> google.protobuf.UInt32Value
-	58, // 72: flow.DebugEvent.arg2:type_name -> google.protobuf.UInt32Value
-	58, // 73: flow.DebugEvent.arg3:type_name -> google.protobuf.UInt32Value
-	57, // 74: flow.DebugEvent.cpu:type_name -> google.protobuf.Int32Value
-	75, // [75:75] is the sub-list for method output_type
-	75, // [75:75] is the sub-list for method input_type
-	75, // [75:75] is the sub-list for extension type_name
-	75, // [75:75] is the sub-list for extension extendee
-	0,  // [0:75] is the sub-list for field type_name
+	26, // 3: flow.Flow.ethernet:type_name -> flow.Ethernet
+	25, // 4: flow.Flow.IP:type_name -> flow.IP
+	18, // 5: flow.Flow.l4:type_name -> flow.Layer4
+	32, // 6: flow.Flow.tunnel:type_name -> flow.Tunnel
+	22, // 7: flow.Flow.source:type_name -> flow.Endpoint
+	22, // 8: flow.Flow.destination:type_name -> flow.Endpoint
+	0,  // 9: flow.Flow.Type:type_name -> flow.FlowType
+	19, // 10: flow.Flow.l7:type_name -> flow.Layer7
+	35, // 11: flow.Flow.event_type:type_name -> flow.CiliumEventType
+	41, // 12: flow.Flow.source_service:type_name -> flow.Service
+	41, // 13: flow.Flow.destination_service:type_name -> flow.Service
+	8,  // 14: flow.Flow.traffic_direction:type_name -> flow.TrafficDirection
+	2,  // 15: flow.Flow.trace_observation_point:type_name -> flow.TraceObservationPoint
+	3,  // 16: flow.Flow.trace_reason:type_name -> flow.TraceReason
+	17, // 17: flow.Flow.file:type_name -> flow.FileInfo
+	7,  // 18: flow.Flow.drop_reason_desc:type_name -> flow.DropReason
+	57, // 19: flow.Flow.is_reply:type_name -> google.protobuf.BoolValue
+	9,  // 20: flow.Flow.debug_capture_point:type_name -> flow.DebugCapturePoint
+	53, // 21: flow.Flow.interface:type_name -> flow.NetworkInterface
+	20, // 22: flow.Flow.trace_context:type_name -> flow.TraceContext
+	13, // 23: flow.Flow.sock_xlate_point:type_name -> flow.SocketTranslationPoint
+	58, // 24: flow.Flow.extensions:type_name -> google.protobuf.Any
+	33, // 25: flow.Flow.egress_allowed_by:type_name -> flow.Policy
+	33, // 26: flow.Flow.ingress_allowed_by:type_name -> flow.Policy
+	33, // 27: flow.Flow.egress_denied_by:type_name -> flow.Policy
+	33, // 28: flow.Flow.ingress_denied_by:type_name -> flow.Policy
+	24, // 29: flow.Layer4.TCP:type_name -> flow.TCP
+	28, // 30: flow.Layer4.UDP:type_name -> flow.UDP
+	30, // 31: flow.Layer4.ICMPv4:type_name -> flow.ICMPv4
+	31, // 32: flow.Layer4.ICMPv6:type_name -> flow.ICMPv6
+	29, // 33: flow.Layer4.SCTP:type_name -> flow.SCTP
+	4,  // 34: flow.Layer7.type:type_name -> flow.L7FlowType
+	37, // 35: flow.Layer7.dns:type_name -> flow.DNS
+	39, // 36: flow.Layer7.http:type_name -> flow.HTTP
+	40, // 37: flow.Layer7.kafka:type_name -> flow.Kafka
+	21, // 38: flow.TraceContext.parent:type_name -> flow.TraceParent
+	23, // 39: flow.Endpoint.workloads:type_name -> flow.Workload
+	27, // 40: flow.TCP.flags:type_name -> flow.TCPFlags
+	5,  // 41: flow.IP.ipVersion:type_name -> flow.IPVersion
+	15, // 42: flow.Tunnel.protocol:type_name -> flow.Tunnel.Protocol
+	25, // 43: flow.Tunnel.IP:type_name -> flow.IP
+	18, // 44: flow.Tunnel.l4:type_name -> flow.Layer4
+	23, // 45: flow.FlowFilter.source_workload:type_name -> flow.Workload
+	23, // 46: flow.FlowFilter.destination_workload:type_name -> flow.Workload
+	8,  // 47: flow.FlowFilter.traffic_direction:type_name -> flow.TrafficDirection
+	6,  // 48: flow.FlowFilter.verdict:type_name -> flow.Verdict
+	7,  // 49: flow.FlowFilter.drop_reason_desc:type_name -> flow.DropReason
+	53, // 50: flow.FlowFilter.interface:type_name -> flow.NetworkInterface
+	34, // 51: flow.FlowFilter.event_type:type_name -> flow.EventTypeFilter
+	38, // 52: flow.FlowFilter.http_header:type_name -> flow.HTTPHeader
+	27, // 53: flow.FlowFilter.tcp_flags:type_name -> flow.TCPFlags
+	5,  // 54: flow.FlowFilter.ip_version:type_name -> flow.IPVersion
+	55, // 55: flow.FlowFilter.experimental:type_name -> flow.FlowFilter.Experimental
+	38, // 56: flow.HTTP.headers:type_name -> flow.HTTPHeader
+	11, // 57: flow.LostEvent.source:type_name -> flow.LostEventSource
+	59, // 58: flow.LostEvent.cpu:type_name -> google.protobuf.Int32Value
+	12, // 59: flow.AgentEvent.type:type_name -> flow.AgentEventType
+	44, // 60: flow.AgentEvent.unknown:type_name -> flow.AgentEventUnknown
+	45, // 61: flow.AgentEvent.agent_start:type_name -> flow.TimeNotification
+	46, // 62: flow.AgentEvent.policy_update:type_name -> flow.PolicyUpdateNotification
+	47, // 63: flow.AgentEvent.endpoint_regenerate:type_name -> flow.EndpointRegenNotification
+	48, // 64: flow.AgentEvent.endpoint_update:type_name -> flow.EndpointUpdateNotification
+	49, // 65: flow.AgentEvent.ipcache_update:type_name -> flow.IPCacheNotification
+	51, // 66: flow.AgentEvent.service_upsert:type_name -> flow.ServiceUpsertNotification
+	52, // 67: flow.AgentEvent.service_delete:type_name -> flow.ServiceDeleteNotification
+	56, // 68: flow.TimeNotification.time:type_name -> google.protobuf.Timestamp
+	60, // 69: flow.IPCacheNotification.old_identity:type_name -> google.protobuf.UInt32Value
+	50, // 70: flow.ServiceUpsertNotification.frontend_address:type_name -> flow.ServiceUpsertNotificationAddr
+	50, // 71: flow.ServiceUpsertNotification.backend_addresses:type_name -> flow.ServiceUpsertNotificationAddr
+	14, // 72: flow.DebugEvent.type:type_name -> flow.DebugEventType
+	22, // 73: flow.DebugEvent.source:type_name -> flow.Endpoint
+	60, // 74: flow.DebugEvent.hash:type_name -> google.protobuf.UInt32Value
+	60, // 75: flow.DebugEvent.arg1:type_name -> google.protobuf.UInt32Value
+	60, // 76: flow.DebugEvent.arg2:type_name -> google.protobuf.UInt32Value
+	60, // 77: flow.DebugEvent.arg3:type_name -> google.protobuf.UInt32Value
+	59, // 78: flow.DebugEvent.cpu:type_name -> google.protobuf.Int32Value
+	79, // [79:79] is the sub-list for method output_type
+	79, // [79:79] is the sub-list for method input_type
+	79, // [79:79] is the sub-list for extension type_name
+	79, // [79:79] is the sub-list for extension extendee
+	0,  // [0:79] is the sub-list for field type_name
 }
 
 func init() { file_flow_flow_proto_init() }
@@ -5651,7 +5784,7 @@ func file_flow_flow_proto_init() {
 		(*Layer7_Http)(nil),
 		(*Layer7_Kafka)(nil),
 	}
-	file_flow_flow_proto_msgTypes[26].OneofWrappers = []any{
+	file_flow_flow_proto_msgTypes[27].OneofWrappers = []any{
 		(*AgentEvent_Unknown)(nil),
 		(*AgentEvent_AgentStart)(nil),
 		(*AgentEvent_PolicyUpdate)(nil),
@@ -5666,8 +5799,8 @@ func file_flow_flow_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_flow_flow_proto_rawDesc), len(file_flow_flow_proto_rawDesc)),
-			NumEnums:      15,
-			NumMessages:   39,
+			NumEnums:      16,
+			NumMessages:   40,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/v1/flow/flow.pb.json.go
+++ b/api/v1/flow/flow.pb.json.go
@@ -203,6 +203,18 @@ func (msg *ICMPv6) UnmarshalJSON(b []byte) error {
 }
 
 // MarshalJSON implements json.Marshaler
+func (msg *Tunnel) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		UseProtoNames: true,
+	}.Marshal(msg)
+}
+
+// UnmarshalJSON implements json.Unmarshaler
+func (msg *Tunnel) UnmarshalJSON(b []byte) error {
+	return protojson.UnmarshalOptions{}.Unmarshal(b, msg)
+}
+
+// MarshalJSON implements json.Marshaler
 func (msg *Policy) MarshalJSON() ([]byte, error) {
 	return protojson.MarshalOptions{
 		UseProtoNames: true,

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -33,6 +33,8 @@ message Flow {
     // l4
     Layer4 l4 = 6;
 
+    Tunnel tunnel = 39;
+
     reserved 7; // removed, do not use
 
     Endpoint source = 8;
@@ -348,6 +350,18 @@ enum IPVersion {
     IP_NOT_USED = 0;
     IPv4 = 1;
     IPv6 = 2;
+}
+
+message Tunnel {
+    enum Protocol {
+        UNKNOWN = 0;
+        VXLAN = 1;
+        GENEVE = 2;
+    }
+
+    Protocol protocol = 1;
+    IP IP = 2;
+    Layer4 l4 = 3;
 }
 
 enum Verdict {

--- a/api/v1/observer/observer.pb.go
+++ b/api/v1/observer/observer.pb.go
@@ -347,6 +347,15 @@ const DebugEventType_DBG_SKIP_POLICY = flow.DebugEventType_DBG_SKIP_POLICY
 var DebugEventType_name = flow.DebugEventType_name
 var DebugEventType_value = flow.DebugEventType_value
 
+type Tunnel_Protocol = flow.Tunnel_Protocol
+
+const Tunnel_UNKNOWN = flow.Tunnel_UNKNOWN
+const Tunnel_VXLAN = flow.Tunnel_VXLAN
+const Tunnel_GENEVE = flow.Tunnel_GENEVE
+
+var Tunnel_Protocol_name = flow.Tunnel_Protocol_name
+var Tunnel_Protocol_value = flow.Tunnel_Protocol_value
+
 type Flow = flow.Flow
 type FileInfo = flow.FileInfo
 type Layer4 = flow.Layer4
@@ -371,6 +380,7 @@ type UDP = flow.UDP
 type SCTP = flow.SCTP
 type ICMPv4 = flow.ICMPv4
 type ICMPv6 = flow.ICMPv6
+type Tunnel = flow.Tunnel
 type Policy = flow.Policy
 type EventTypeFilter = flow.EventTypeFilter
 type CiliumEventType = flow.CiliumEventType

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/google/gops v0.3.28
 	github.com/google/renameio/v2 v2.0.0
 	github.com/google/uuid v1.6.0
-	github.com/gopacket/gopacket v1.3.1
+	github.com/gopacket/gopacket v1.3.2-0.20250413013317-2b39da4e3de0
 	github.com/gorilla/mux v1.8.1
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gopacket/gopacket v1.3.1 h1:ZppWyLrOJNZPe5XkdjLbtuTkfQoxQ0xyMJzQCqtqaPU=
-github.com/gopacket/gopacket v1.3.1/go.mod h1:3I13qcqSpB2R9fFQg866OOgzylYkZxLTmkvcXhvf6qg=
+github.com/gopacket/gopacket v1.3.2-0.20250413013317-2b39da4e3de0 h1:ity2P6MFHO98xiKueK1UgNw0RxLDfhlfdp4Q0GcDOUI=
+github.com/gopacket/gopacket v1.3.2-0.20250413013317-2b39da4e3de0/go.mod h1:ycMMMdDWl8vXqVQdQ/LpIbZqbdG9d32EGh5mtzzVhyY=
 github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -32,6 +32,10 @@ const (
 	DropNotifyFlagIsIPv6 uint8 = 1 << iota
 	// DropNotifyFlagIsL3Device is set in DropNotify.Flags when it refers to a L3 device.
 	DropNotifyFlagIsL3Device
+	// DropNotifyFlagIsVXLAN is set in DropNotify.Flags when it refers to an overlay VXLAN packet.
+	DropNotifyFlagIsVXLAN
+	// DropNotifyFlagIsGeneve is set in DropNotify.Flags when it refers to an overlay Geneve packet.
+	DropNotifyFlagIsGeneve
 )
 
 var (
@@ -127,6 +131,16 @@ func (n *DropNotify) IsIPv6() bool {
 	return n.Flags&DropNotifyFlagIsIPv6 != 0
 }
 
+// IsGeneve returns true if the trace refers to an overlay Geneve packet.
+func (n *DropNotify) IsGeneve() bool {
+	return n.Flags&DropNotifyFlagIsGeneve != 0
+}
+
+// IsVXLAN returns true if the trace refers to an overlay VXLAN packet.
+func (n *DropNotify) IsVXLAN() bool {
+	return n.Flags&DropNotifyFlagIsVXLAN != 0
+}
+
 // DataOffset returns the offset from the beginning of DropNotify where the
 // notification data begins.
 //
@@ -141,7 +155,7 @@ func (n *DropNotify) DumpInfo(data []byte, numeric DisplayFormat) {
 	fmt.Fprintf(buf, "xx drop (%s) flow %#x to endpoint %d, ifindex %d, file %s:%d, ",
 		api.DropReasonExt(n.SubType, n.ExtError), n.Hash, n.DstID, n.Ifindex, api.BPFFileName(n.File), int(n.Line))
 	n.dumpIdentity(buf, numeric)
-	fmt.Fprintf(buf, ": %s\n", GetConnectionSummary(data[n.DataOffset():], &decodeOpts{n.IsL3Device(), n.IsIPv6()}))
+	fmt.Fprintf(buf, ": %s\n", GetConnectionSummary(data[n.DataOffset():], &decodeOpts{n.IsL3Device(), n.IsIPv6(), n.IsVXLAN(), n.IsGeneve()}))
 	buf.Flush()
 }
 

--- a/pkg/monitor/datapath_drop_test.go
+++ b/pkg/monitor/datapath_drop_test.go
@@ -33,7 +33,7 @@ func TestDecodeDropNotify(t *testing.T) {
 		File:     0x20,
 		ExtError: 0x21,
 		Ifindex:  0x22_23_24_25,
-		Flags:    DropNotifyFlagIsIPv6 | DropNotifyFlagIsL3Device,
+		Flags:    0x0f,
 	}
 	buf := bytes.NewBuffer(nil)
 	err := binary.Write(buf, byteorder.Native, input)
@@ -59,6 +59,8 @@ func TestDecodeDropNotify(t *testing.T) {
 	require.Equal(t, input.Flags, output.Flags)
 	require.True(t, output.IsL3Device())
 	require.True(t, output.IsIPv6())
+	require.True(t, output.IsVXLAN())
+	require.True(t, output.IsGeneve())
 }
 
 func TestDecodeDropNotifyErrors(t *testing.T) {

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -31,6 +31,12 @@ const (
 	// TraceNotifyFlagIsL3Device is set in TraceNotify.Flags when the
 	// notification refers to a L3 device.
 	TraceNotifyFlagIsL3Device
+	// TraceNotifyFlagIsVXLAN is set in TraceNotify.Flags when the
+	// notification refers to an overlay VXLAN packet.
+	TraceNotifyFlagIsVXLAN
+	// TraceNotifyFlagIsGeneve is set in TraceNotify.Flags when the
+	// notification refers to an overlay Geneve packet.
+	TraceNotifyFlagIsGeneve
 )
 
 const (
@@ -255,6 +261,16 @@ func (n *TraceNotify) IsIPv6() bool {
 	return n.Flags&TraceNotifyFlagIsIPv6 != 0
 }
 
+// IsVXLAN returns true if the trace refers to an overlay VXLAN packet.
+func (n *TraceNotify) IsVXLAN() bool {
+	return n.Flags&TraceNotifyFlagIsVXLAN != 0
+}
+
+// IsGeneve returns true if the trace refers to an overlay Geneve packet.
+func (n *TraceNotify) IsGeneve() bool {
+	return n.Flags&TraceNotifyFlagIsGeneve != 0
+}
+
 // OriginalIP returns the original source IP if reverse NAT was performed on
 // the flow
 func (n *TraceNotify) OriginalIP() net.IP {
@@ -285,7 +301,7 @@ func (n *TraceNotify) DumpInfo(data []byte, numeric DisplayFormat, linkMonitor g
 	n.dumpIdentity(buf, numeric)
 	ifname := linkMonitor.Name(n.Ifindex)
 	fmt.Fprintf(buf, " state %s ifindex %s orig-ip %s: %s\n", n.traceReasonString(),
-		ifname, n.OriginalIP().String(), GetConnectionSummary(data[hdrLen:], &decodeOpts{n.IsL3Device(), n.IsIPv6()}))
+		ifname, n.OriginalIP().String(), GetConnectionSummary(data[hdrLen:], &decodeOpts{n.IsL3Device(), n.IsIPv6(), n.IsVXLAN(), n.IsGeneve()}))
 	buf.Flush()
 }
 

--- a/pkg/monitor/datapath_trace_test.go
+++ b/pkg/monitor/datapath_trace_test.go
@@ -106,6 +106,16 @@ func TestIsEncrypted(t *testing.T) {
 	}
 }
 
+func TestTraceFlags(t *testing.T) {
+	tn := &TraceNotify{
+		Flags: 0x0f,
+	}
+	require.True(t, tn.IsIPv6())
+	require.True(t, tn.IsL3Device())
+	require.True(t, tn.IsVXLAN())
+	require.True(t, tn.IsGeneve())
+}
+
 func TestTraceReason(t *testing.T) {
 	tt := []struct {
 		name   string

--- a/pkg/monitor/dissect.go
+++ b/pkg/monitor/dissect.go
@@ -138,10 +138,6 @@ func getConnectionInfoFromCache() (c *ConnectionInfo, hasIP, hasEth bool) {
 		case layers.LayerTypeSCTP:
 			c.Proto = "sctp"
 			c.SrcPort, c.DstPort = uint16(cache.sctp.SrcPort), uint16(cache.sctp.DstPort)
-		case layers.LayerTypeIPSecAH:
-			c.Proto = "IPsecAH"
-		case layers.LayerTypeIPSecESP:
-			c.Proto = "IPsecESP"
 		case layers.LayerTypeICMPv4:
 			c.Proto = "icmp"
 			c.IcmpCode = cache.icmp4.TypeCode.String()
@@ -195,16 +191,10 @@ func GetConnectionSummary(data []byte, opts *decodeOpts) string {
 	case icmpCode != "":
 		return fmt.Sprintf("%s -> %s %s %s", srcIP, dstIP, proto, icmpCode)
 	case proto != "":
-		var s string
-
-		if proto == "esp" {
-			s = proto
-		} else {
-			s = fmt.Sprintf("%s -> %s %s",
-				net.JoinHostPort(srcIP.String(), srcPort),
-				net.JoinHostPort(dstIP.String(), dstPort),
-				proto)
-		}
+		s := fmt.Sprintf("%s -> %s %s",
+			net.JoinHostPort(srcIP.String(), srcPort),
+			net.JoinHostPort(dstIP.String(), dstPort),
+			proto)
 		if proto == "tcp" {
 			s += " " + getTCPInfo()
 		}

--- a/pkg/monitor/dissect_test.go
+++ b/pkg/monitor/dissect_test.go
@@ -6,7 +6,7 @@ package monitor
 import (
 	"fmt"
 	"net"
-	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -50,28 +50,53 @@ func TestConnectionSummaryTcp(t *testing.T) {
 	sport := "80"
 	dport := "443"
 
-	// Generated in scapy:
-	// Ether(src="01:23:45:67:89:ab", dst="02:33:45:67:89:ab")/IP(src="1.2.3.4",dst="5.6.7.8")/TCP(sport=80,dport=443)
-	l2Data := []byte{2, 51, 69, 103, 137, 171, 1, 35, 69, 103, 137, 171, 8, 0}
-	l3Data := []byte{69, 0, 0, 40, 0, 1, 0, 0, 64, 6, 106, 188, 1, 2, 3, 4, 5, 6, 7, 8, 0, 80, 1, 187, 0, 0, 0, 0, 0, 0, 0, 0, 80, 2, 32, 0, 125, 196, 0, 0}
-
 	for _, c := range []struct {
 		Name       string
 		IsL3Device bool
 	}{{"L3Device", true}, {"L2Device", false}} {
 		t.Run(c.Name, func(t *testing.T) {
-			var data []byte
+			// Ether(src="01:23:45:67:89:ab", dst="02:33:45:67:89:ab")/IP(src="1.2.3.4",dst="5.6.7.8")/TCP(sport=80,dport=443)
+			data := []byte{2, 51, 69, 103, 137, 171, 1, 35, 69, 103, 137, 171, 8, 0, 69, 0, 0, 40, 0, 1, 0, 0, 64, 6, 106, 188, 1, 2, 3, 4, 5, 6, 7, 8, 0, 80, 1, 187, 0, 0, 0, 0, 0, 0, 0, 0, 80, 2, 32, 0, 125, 196, 0, 0}
 			if c.IsL3Device {
-				data = l3Data
-			} else {
-				data = slices.Concat(l2Data, l3Data)
+				// Remove ethernet layer.
+				data = data[14:]
 			}
-			summary := GetConnectionSummary(data, &decodeOpts{c.IsL3Device, false})
+			summary := GetConnectionSummary(data, &decodeOpts{IsL3Device: c.IsL3Device})
 
 			expect := fmt.Sprintf("%s -> %s %s",
 				net.JoinHostPort(srcIP, sport),
 				net.JoinHostPort(dstIP, dport),
 				"tcp SYN")
+			require.Equal(t, expect, summary)
+		})
+	}
+
+	srcIPOuter := "1.1.1.1"
+	dstIPOuter := "2.2.2.2"
+
+	sportOuter := "8472"
+	dportOuter := "9999"
+
+	for _, c := range []struct {
+		Name string
+		Data []byte
+	}{
+		// Ether(src="01:02:03:04:05:06", dst="11:12:13:14:15:16")/IP(src="1.1.1.1",dst="2.2.2.2")/UDP(sport=8472,dport=9999)/VXLAN(vni=2)/Ether(src="01:23:45:67:89:ab", dst="02:33:45:67:89:ab")/IP(src="1.2.3.4",dst="5.6.7.8")/TCP(sport=80,dport=443)
+		{"VXLAN", []byte{17, 18, 19, 20, 21, 22, 1, 2, 3, 4, 5, 6, 8, 0, 69, 0, 0, 90, 0, 1, 0, 0, 64, 17, 116, 141, 1, 1, 1, 1, 2, 2, 2, 2, 33, 24, 39, 15, 0, 70, 9, 229, 12, 0, 0, 3, 0, 0, 2, 0, 2, 51, 69, 103, 137, 171, 1, 35, 69, 103, 137, 171, 8, 0, 69, 0, 0, 40, 0, 1, 0, 0, 64, 6, 106, 188, 1, 2, 3, 4, 5, 6, 7, 8, 0, 80, 1, 187, 0, 0, 0, 0, 0, 0, 0, 0, 80, 2, 32, 0, 125, 196, 0, 0}},
+		// Ether(src="01:02:03:04:05:06", dst="11:12:13:14:15:16")/IP(src="1.1.1.1",dst="2.2.2.2")/UDP(sport=8472,dport=9999)/GENEVE(vni=2,proto=0x6558)/Ether(src="01:23:45:67:89:ab", dst="02:33:45:67:89:ab")/IP(src="1.2.3.4",dst="5.6.7.8")/TCP(sport=80,dport=443)
+		{"Geneve", []byte{17, 18, 19, 20, 21, 22, 1, 2, 3, 4, 5, 6, 8, 0, 69, 0, 0, 90, 0, 1, 0, 0, 64, 17, 116, 141, 1, 1, 1, 1, 2, 2, 2, 2, 33, 24, 39, 15, 0, 70, 176, 143, 0, 0, 101, 88, 0, 0, 2, 0, 2, 51, 69, 103, 137, 171, 1, 35, 69, 103, 137, 171, 8, 0, 69, 0, 0, 40, 0, 1, 0, 0, 64, 6, 106, 188, 1, 2, 3, 4, 5, 6, 7, 8, 0, 80, 1, 187, 0, 0, 0, 0, 0, 0, 0, 0, 80, 2, 32, 0, 125, 196, 0, 0}},
+	} {
+		t.Run(c.Name, func(t *testing.T) {
+			summary := GetConnectionSummary(c.Data, &decodeOpts{IsVXLAN: c.Name == "VXLAN", IsGeneve: c.Name == "Geneve"})
+
+			expect := fmt.Sprintf("%s -> %s %s [tunnel %s -> %s %s]",
+				net.JoinHostPort(srcIP, sport),
+				net.JoinHostPort(dstIP, dport),
+				"tcp SYN",
+				net.JoinHostPort(srcIPOuter, sportOuter),
+				net.JoinHostPort(dstIPOuter, dportOuter),
+				strings.ToLower(c.Name))
+
 			require.Equal(t, expect, summary)
 		})
 	}

--- a/vendor/github.com/gopacket/gopacket/layers/dns.go
+++ b/vendor/github.com/gopacket/gopacket/layers/dns.go
@@ -1264,7 +1264,9 @@ func (rrsig *DNSRRSIG) decode(data []byte, offset int) error {
 	rrsig.Inception = binary.BigEndian.Uint32(data[offset+12:])
 	rrsig.KeyTag = binary.BigEndian.Uint16(data[offset+16:])
 	_, offset, err = decodeName(data, offset+18, &rrsig.SignerName, 1)
-	rrsig.SignerName = rrsig.SignerName[1:] // remove the first '.'
+	if len(rrsig.SignerName) > 1 {
+		rrsig.SignerName = rrsig.SignerName[1:] // Remove leading '.'
+	}
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/gopacket/gopacket/layers/geneve.go
+++ b/vendor/github.com/gopacket/gopacket/layers/geneve.go
@@ -50,6 +50,9 @@ type GeneveOption struct {
 	Data   []byte
 }
 
+// ensure Geneve implements DecodingLayer.
+var _ gopacket.DecodingLayer = (*Geneve)(nil)
+
 // LayerType returns LayerTypeGeneve
 func (gn *Geneve) LayerType() gopacket.LayerType { return LayerTypeGeneve }
 
@@ -191,4 +194,9 @@ func (gn *Geneve) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serializ
 	}
 
 	return nil
+}
+
+// CanDecode implements DecodingLayer.
+func (gn *Geneve) CanDecode() gopacket.LayerClass {
+	return LayerTypeGeneve
 }

--- a/vendor/github.com/gopacket/gopacket/layers/sip.go
+++ b/vendor/github.com/gopacket/gopacket/layers/sip.go
@@ -250,6 +250,7 @@ func (s *SIP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	var line []byte
 	var err error
 	var offset int
+	var eoh = false // track End Of Headers
 
 	// Iterate on all lines of the SIP Headers
 	// and stop when we reach the SDP (aka when the new line
@@ -277,6 +278,10 @@ func (s *SIP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 
 		// Empty line, we hit Body
 		if len(line) == 0 {
+			if countLines == 0 {
+				return fmt.Errorf("invalid first SIP line, empty")
+			}
+			eoh = true
 			break
 		}
 
@@ -296,6 +301,9 @@ func (s *SIP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 		}
 
 		countLines++
+	}
+	if !eoh {
+		df.SetTruncated()
 	}
 	s.setBaseLayer(data, offset, df)
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -990,8 +990,8 @@ github.com/google/shlex
 # github.com/google/uuid v1.6.0
 ## explicit
 github.com/google/uuid
-# github.com/gopacket/gopacket v1.3.1
-## explicit; go 1.22.0
+# github.com/gopacket/gopacket v1.3.2-0.20250413013317-2b39da4e3de0
+## explicit; go 1.23.0
 github.com/gopacket/gopacket
 github.com/gopacket/gopacket/layers
 # github.com/gorilla/mux v1.8.1


### PR DESCRIPTION
_<del>Currently blocked by https://github.com/cilium/cilium/pull/37097 and need proper datapath support to signal whether the packet was encapsulated by Cilium.</del>_

Can be merged once #39650 lands.
The logic to push more bytes during trace notifications from datapath will be landed separately in #38984.

This PR implement Cilium VXLAN/Geneve decoding in Hubble/Monitor, allowing to surface the overlay information in Hubble flows.

Closes: #28001
Closes: #39029

```release-note
Decode Cilium encapsulated traffic in Hubble/Monitor
```
