### PR TITLE
pkg/hive: always use default logger when decorating cells

### DIFF
--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -73,8 +73,8 @@ func New(cells ...cell.Cell) *Hive {
 
 	// Scope logging and health by module ID.
 	moduleDecorators := []cell.ModuleDecorator{
-		func(log logrus.FieldLogger, mid cell.ModuleID) logrus.FieldLogger {
-			return log.WithField(logfields.LogSubsys, string(mid))
+		func(mid cell.ModuleID) logrus.FieldLogger {
+			return logging.DefaultLogger.WithField(logfields.LogSubsys, string(mid))
 		},
 		func(hp types.Provider, fmid cell.FullModuleID) cell.Health {
 			return hp.ForModule(fmid)


### PR DESCRIPTION
Using the logrus.FieldLogger argument from the decorator would cause a logrus.FieldLogger returned from a previous execution to be re-used on following executions. Instead, we should always use the Default logger as the "root" for the cell's loggers.