### PR TITLE
cli: Ensure EGW tests trigger failures via actions

### DIFF
--- a/cilium-cli/connectivity/tests/egressgateway.go
+++ b/cilium-cli/connectivity/tests/egressgateway.go
@@ -240,7 +240,7 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 				clientIP := extractClientIPFromResponse(a.CmdOutput())
 
 				if !clientIP.Equal(egressGatewayNodeInternalIP) {
-					t.Fatal("Request reached external echo service with wrong source IP")
+					a.Fatal("Request reached external echo service with wrong source IP")
 				}
 			})
 			i++
@@ -258,7 +258,7 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 				clientIP := extractClientIPFromResponse(a.CmdOutput())
 
 				if !clientIP.Equal(egressGatewayNodeInternalIP) {
-					t.Fatal("Request reached external echo service with wrong source IP")
+					a.Fatal("Request reached external echo service with wrong source IP")
 				}
 			})
 			i++
@@ -385,7 +385,7 @@ func (s *egressGatewayExcludedCIDRs) Run(ctx context.Context, t *check.Test) {
 				clientIP := extractClientIPFromResponse(a.CmdOutput())
 
 				if !clientIP.Equal(net.ParseIP(client.Pod.Status.HostIP)) {
-					t.Fatal("Request reached external echo service with wrong source IP")
+					a.Fatal("Request reached external echo service with wrong source IP")
 				}
 			})
 			i++


### PR DESCRIPTION
When a test fails within an action, the action itself should be used to
report the failure to ensure that the failure is properly attributed in
the test framework.
