### PR TITLE
ipam/aws: update the assigned IPs from aws to instance map

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -710,7 +710,7 @@ func (c *Client) ModifyNetworkInterface(ctx context.Context, eniID, attachmentID
 
 // AssignPrivateIpAddresses assigns the specified number of secondary IP
 // addresses
-func (c *Client) AssignPrivateIpAddresses(ctx context.Context, eniID string, addresses int32) error {
+func (c *Client) AssignPrivateIpAddresses(ctx context.Context, eniID string, addresses int32) ([]string, error) {
 	input := &ec2.AssignPrivateIpAddressesInput{
 		NetworkInterfaceId:             aws.String(eniID),
 		SecondaryPrivateIpAddressCount: aws.Int32(addresses),
@@ -718,9 +718,16 @@ func (c *Client) AssignPrivateIpAddresses(ctx context.Context, eniID string, add
 
 	c.limiter.Limit(ctx, AssignPrivateIpAddresses)
 	sinceStart := spanstat.Start()
-	_, err := c.ec2Client.AssignPrivateIpAddresses(ctx, input)
+	output, err := c.ec2Client.AssignPrivateIpAddresses(ctx, input)
 	c.metricsAPI.ObserveAPICall(AssignPrivateIpAddresses, deriveStatus(err), sinceStart.Seconds())
-	return err
+	if err != nil {
+		return nil, err
+	}
+	assignedIPs := make([]string, addresses)
+	for i, ip := range output.AssignedPrivateIpAddresses {
+		assignedIPs[i] = aws.ToString(ip.PrivateIpAddress)
+	}
+	return assignedIPs, nil
 }
 
 // UnassignPrivateIpAddresses unassigns specified IP addresses from ENI

--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -344,7 +344,7 @@ func (e *API) GetDetachedNetworkInterfaces(ctx context.Context, tags ipamTypes.T
 	return result, nil
 }
 
-func (e *API) AssignPrivateIpAddresses(ctx context.Context, eniID string, addresses int32) error {
+func (e *API) AssignPrivateIpAddresses(ctx context.Context, eniID string, addresses int32) ([]string, error) {
 	e.rateLimit()
 	e.delaySim.Delay(AssignPrivateIpAddresses)
 
@@ -352,18 +352,18 @@ func (e *API) AssignPrivateIpAddresses(ctx context.Context, eniID string, addres
 	defer e.mutex.Unlock()
 
 	if err, ok := e.errors[AssignPrivateIpAddresses]; ok {
-		return err
+		return nil, err
 	}
 
 	for _, enis := range e.enis {
 		if eni, ok := enis[eniID]; ok {
 			subnet, ok := e.subnets[eni.Subnet.ID]
 			if !ok {
-				return fmt.Errorf("subnet %s not found", eni.Subnet.ID)
+				return nil, fmt.Errorf("subnet %s not found", eni.Subnet.ID)
 			}
 
 			if int(addresses) > subnet.AvailableAddresses {
-				return fmt.Errorf("subnet %s has not enough addresses available", eni.Subnet.ID)
+				return nil, fmt.Errorf("subnet %s has not enough addresses available", eni.Subnet.ID)
 			}
 
 			for i := int32(0); i < addresses; i++ {
@@ -374,10 +374,10 @@ func (e *API) AssignPrivateIpAddresses(ctx context.Context, eniID string, addres
 				eni.Addresses = append(eni.Addresses, ip.String())
 			}
 			subnet.AvailableAddresses -= int(addresses)
-			return nil
+			return eni.Addresses, nil
 		}
 	}
-	return fmt.Errorf("Unable to find ENI with ID %s", eniID)
+	return nil, fmt.Errorf("Unable to find ENI with ID %s", eniID)
 }
 
 func (e *API) UnassignPrivateIpAddresses(ctx context.Context, eniID string, addresses []string) error {

--- a/pkg/aws/ec2/mock/mock_test.go
+++ b/pkg/aws/ec2/mock/mock_test.go
@@ -102,7 +102,7 @@ func TestSetMockError(t *testing.T) {
 	require.Equal(t, mockError, err)
 
 	api.SetMockError(AssignPrivateIpAddresses, mockError)
-	err = api.AssignPrivateIpAddresses(context.TODO(), "e-1", 10)
+	_, err = api.AssignPrivateIpAddresses(context.TODO(), "e-1", 10)
 	require.Equal(t, mockError, err)
 
 	api.SetMockError(UnassignPrivateIpAddresses, mockError)

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -7,6 +7,7 @@ package eni
 
 import (
 	"context"
+	"slices"
 
 	ec2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/sirupsen/logrus"
@@ -34,7 +35,7 @@ type EC2API interface {
 	AttachNetworkInterface(ctx context.Context, index int32, instanceID, eniID string) (string, error)
 	DeleteNetworkInterface(ctx context.Context, eniID string) error
 	ModifyNetworkInterface(ctx context.Context, eniID, attachmentID string, deleteOnTermination bool) error
-	AssignPrivateIpAddresses(ctx context.Context, eniID string, addresses int32) error
+	AssignPrivateIpAddresses(ctx context.Context, eniID string, addresses int32) ([]string, error)
 	UnassignPrivateIpAddresses(ctx context.Context, eniID string, addresses []string) error
 	AssignENIPrefixes(ctx context.Context, eniID string, prefixes int32) error
 	UnassignENIPrefixes(ctx context.Context, eniID string, prefixes []string) error
@@ -276,6 +277,51 @@ func (m *InstancesManager) UpdateENI(instanceID string, eni *eniTypes.ENI) {
 	eniRevision := ipamTypes.InterfaceRevision{Resource: eni}
 	m.instances.Update(instanceID, eniRevision)
 	m.mutex.Unlock()
+}
+
+func (m *InstancesManager) AddIPsToENI(instanceID string, eniID string, ips []string) {
+	m.modifyIPsToENI(instanceID, eniID, ips, true)
+}
+
+func (m *InstancesManager) RemoveIPsFromENI(instanceID string, eniID string, ips []string) {
+	m.modifyIPsToENI(instanceID, eniID, ips, false)
+}
+
+func (m *InstancesManager) modifyIPsToENI(instanceID string, eniID string, ips []string, isAdd bool) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	ifaces, ok := m.instances.GetInterface(instanceID, eniID)
+	if !ok {
+		log.WithFields(logrus.Fields{
+			"instance": instanceID,
+			"eni":      eniID,
+		}).Warning("ENI not found")
+		return
+	}
+
+	eniIntf := ifaces.Resource.DeepCopyInterface()
+	eni, ok := eniIntf.(*eniTypes.ENI)
+	if !ok {
+		log.WithFields(logrus.Fields{
+			"instance": instanceID,
+			"eni":      eniID,
+		}).Warning("Unexpected resource type, expected *eniTypes.ENI")
+		return
+	}
+	if isAdd {
+		for _, ip := range ips {
+			if !slices.Contains(eni.Addresses, ip) {
+				eni.Addresses = append(eni.Addresses, ip)
+			}
+		}
+	} else {
+		for _, ip := range ips {
+			eni.Addresses = slices.DeleteFunc(eni.Addresses, func(addr string) bool {
+				return addr == ip
+			})
+		}
+	}
+	m.instances.Update(instanceID, ipamTypes.InterfaceRevision{Resource: eni})
 }
 
 // ForeachInstance will iterate over each interface for a particular instance inside `instances`

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -198,7 +198,13 @@ func (n *Node) PrepareIPRelease(excessIPs int, scopedLog *logrus.Entry) *ipam.Re
 
 // ReleaseIPs performs the ENI IP release operation
 func (n *Node) ReleaseIPs(ctx context.Context, r *ipam.ReleaseAction) error {
-	return n.manager.api.UnassignPrivateIpAddresses(ctx, r.InterfaceID, r.IPsToRelease)
+	if err := n.manager.api.UnassignPrivateIpAddresses(ctx, r.InterfaceID, r.IPsToRelease); err != nil {
+		return err
+	}
+
+	n.manager.RemoveIPsFromENI(n.node.InstanceID(), r.InterfaceID, r.IPsToRelease)
+	return nil
+
 }
 
 // PrepareIPAllocation returns the number of ENI IPs and interfaces that can be
@@ -289,7 +295,12 @@ func (n *Node) AllocateIPs(ctx context.Context, a *ipam.AllocationAction) error 
 			logfields.Node: n.k8sObj.Name,
 		}).Warning("Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore")
 	}
-	return n.manager.api.AssignPrivateIpAddresses(ctx, a.InterfaceID, int32(a.IPv4.AvailableForAllocation))
+	assignedIPs, err := n.manager.api.AssignPrivateIpAddresses(ctx, a.InterfaceID, int32(a.IPv4.AvailableForAllocation))
+	if err != nil {
+		return err
+	}
+	n.manager.AddIPsToENI(n.node.InstanceID(), a.InterfaceID, assignedIPs)
+	return nil
 }
 
 func (n *Node) AllocateStaticIP(ctx context.Context, staticIPTags ipamTypes.Tags) (string, error) {


### PR DESCRIPTION
- Extracting and returning the assigned IP addresses from aws
- Adding a new method to update ENI IP addresses in the instances manager

Fixes: #36428

```release-note
Fix the possible race condition caused by async update from aws to instance map in issue #36428 
```
