### PR TITLE
helm chart: Fix YAML parsing error in bootstrap-config causing envoy daemonset crash

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-envoy/configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/configmap.yaml
@@ -18,5 +18,9 @@ metadata:
 data:
   # Keep the key name as bootstrap-config.json to avoid breaking changes
   bootstrap-config.json: |
-    {{- (tpl (.Files.Get "files/cilium-envoy/configmap/bootstrap-config.yaml") .) | fromYaml | toJson | nindent 4 }}
+    {{- $json := tpl (.Files.Get "files/cilium-envoy/configmap/bootstrap-config.yaml") . | fromYaml | toJson -}}
+    {{- if contains "error converting YAML to JSON" $json -}}
+      {{- fail (printf "bootstrap-config.yaml parse error: %s" $json) -}}
+    {{- end -}}
+    {{- $json | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #37653

```release-note
Abort Helm release when bootstrap-config.yaml contains YAML errors, preventing invalid bootstrap-config.json from being deployed and stopping envoy daemonset crashes.
```
