### PR TITLE
metrics: add pressure metric for fragmentation map

### DIFF
--- a/pkg/maps/fragmap/fragmap.go
+++ b/pkg/maps/fragmap/fragmap.go
@@ -56,7 +56,7 @@ func InitMap(mapEntries int) error {
 		&FragmentValue{},
 		mapEntries,
 		0,
-	).WithEvents(option.Config.GetEventBufferConfig(MapName))
+	).WithEvents(option.Config.GetEventBufferConfig(MapName)).WithPressureMetric()
 	return fragMap.Create()
 }
 


### PR DESCRIPTION
Add pressure metric for fragmentation map
to help users detect fragmentation quickly

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Add pressure metric for fragmentation map
to help users detect fragmentation quickly

Fixes: #34368 
