### PR TITLE
envoy: Make xDS server endpoint policy restore wait more robust

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -199,6 +199,7 @@ cilium-agent [flags]
       --envoy-default-log-level string                            Default log level of Envoy application log that is configured if Cilium debug / verbose logging isn't enabled. If not defined, the default log level of the Cilium Agent is used.
       --envoy-keep-cap-netbindservice                             Keep capability NET_BIND_SERVICE for Envoy process
       --envoy-log string                                          Path to a separate Envoy log file, if any
+      --envoy-policy-restore-timeout duration                     Maxiumum time to wait for enpoint policy restoration before starting serving resources to Envoy (default 3m0s)
       --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC
       --exclude-local-address strings                             Exclude CIDR from being recognized as local address
       --exclude-node-label-patterns strings                       List of k8s node label regex patterns to be excluded from CiliumNode

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -69,6 +69,7 @@ cilium-agent hive [flags]
       --envoy-default-log-level string                            Default log level of Envoy application log that is configured if Cilium debug / verbose logging isn't enabled. If not defined, the default log level of the Cilium Agent is used.
       --envoy-keep-cap-netbindservice                             Keep capability NET_BIND_SERVICE for Envoy process
       --envoy-log string                                          Path to a separate Envoy log file, if any
+      --envoy-policy-restore-timeout duration                     Maxiumum time to wait for enpoint policy restoration before starting serving resources to Envoy (default 3m0s)
       --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC
       --force-device-detection                                    Forces the auto-detection of devices, even if specific devices are explicitly listed
       --gateway-api-secrets-namespace string                      GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -75,6 +75,7 @@ cilium-agent hive dot-graph [flags]
       --envoy-default-log-level string                            Default log level of Envoy application log that is configured if Cilium debug / verbose logging isn't enabled. If not defined, the default log level of the Cilium Agent is used.
       --envoy-keep-cap-netbindservice                             Keep capability NET_BIND_SERVICE for Envoy process
       --envoy-log string                                          Path to a separate Envoy log file, if any
+      --envoy-policy-restore-timeout duration                     Maxiumum time to wait for enpoint policy restoration before starting serving resources to Envoy (default 3m0s)
       --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC
       --force-device-detection                                    Forces the auto-detection of devices, even if specific devices are explicitly listed
       --gateway-api-secrets-namespace string                      GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1384,6 +1384,10 @@
      - AppArmorProfile options for the ``cilium-agent`` and init containers
      - object
      - ``{"type":"Unconfined"}``
+   * - :spelling:ignore:`envoy.policyRestoreTimeoutDuration`
+     - Max duration to wait for endpoint policies to be restored on restart. Default "3m".
+     - string
+     - ``nil``
    * - :spelling:ignore:`envoy.priorityClassName`
      - The priority class to use for cilium-envoy.
      - string

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -46,7 +46,7 @@ func (d *Daemon) WaitForEndpointRestore(ctx context.Context) error {
 	return nil
 }
 
-func (d *Daemon) WaitForInitialEnvoyPolicy(ctx context.Context) error {
+func (d *Daemon) WaitForInitialPolicy(ctx context.Context) error {
 	if !option.Config.RestoreState {
 		return nil
 	}
@@ -54,6 +54,7 @@ func (d *Daemon) WaitForInitialEnvoyPolicy(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
+	case <-d.endpointRestoreComplete:
 	case <-d.endpointInitialPolicyComplete:
 	}
 	return nil

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -396,6 +396,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.podLabels | object | `{}` | Labels to be added to envoy pods |
 | envoy.podSecurityContext | object | `{"appArmorProfile":{"type":"Unconfined"}}` | Security Context for cilium-envoy pods. |
 | envoy.podSecurityContext.appArmorProfile | object | `{"type":"Unconfined"}` | AppArmorProfile options for the `cilium-agent` and init containers |
+| envoy.policyRestoreTimeoutDuration | string | `nil` | Max duration to wait for endpoint policies to be restored on restart. Default "3m". |
 | envoy.priorityClassName | string | `nil` | The priority class to use for cilium-envoy. |
 | envoy.prometheus | object | `{"enabled":true,"port":"9964","serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]}}` | Configure Cilium Envoy Prometheus options. Note that some of these apply to either cilium-agent or cilium-envoy. |
 | envoy.prometheus.enabled | bool | `true` | Enable prometheus metrics for cilium-envoy |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1345,6 +1345,10 @@ data:
   external-envoy-proxy: {{ include "envoyDaemonSetEnabled" . | quote }}
   envoy-base-id: {{ .Values.envoy.baseID | quote }}
 
+{{- if .Values.envoy.policyRestoreTimeoutDuration }}
+  envoy-policy-restore-timeout: {{ .Values.envoy.policyRestoreTimeoutDuration | quote }}
+{{- end }}
+
 {{- if .Values.envoy.log.path }}
   envoy-log: {{ .Values.envoy.log.path | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2127,6 +2127,12 @@
           },
           "type": "object"
         },
+        "policyRestoreTimeoutDuration": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "priorityClassName": {
           "type": [
             "null",

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2361,6 +2361,11 @@ envoy:
   xffNumTrustedHopsL7PolicyIngress: 0
   # -- Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
   xffNumTrustedHopsL7PolicyEgress: 0
+  # @schema
+  # type: [null, string]
+  # @schema
+  # -- Max duration to wait for endpoint policies to be restored on restart. Default "3m".
+  policyRestoreTimeoutDuration: null
   # -- Envoy container image.
   image:
     # @schema

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2378,6 +2378,11 @@ envoy:
   xffNumTrustedHopsL7PolicyIngress: 0
   # -- Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
   xffNumTrustedHopsL7PolicyEgress: 0
+  # @schema
+  # type: [null, string]
+  # @schema
+  # -- Max duration to wait for endpoint policies to be restored on restart. Default "3m".
+  policyRestoreTimeoutDuration: null
   # -- Envoy container image.
   image:
     # @schema

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -614,6 +614,15 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 	stats := &regenContext.Stats
 	datapathRegenCtxt := regenContext.datapathRegenerationContext
 
+	// Signal computation of the initial Envoy policy even if we fail out so
+	// that Envoy xDS server can start serving even if some endpoint
+	// computations fail.
+	defer func() {
+		e.unconditionalLock()
+		e.InitialPolicyComputedLocked()
+		e.unlock()
+	}()
+
 	// lock the endpoint, read our values, then unlock
 	err := e.lockAlive()
 	if err != nil {

--- a/pkg/endpointcleanup/cleanup_test.go
+++ b/pkg/endpointcleanup/cleanup_test.go
@@ -281,6 +281,6 @@ func (r *fakeRestorer) WaitForEndpointRestore(_ context.Context) error {
 	return nil
 }
 
-func (r *fakeRestorer) WaitForInitialEnvoyPolicy(_ context.Context) error {
+func (r *fakeRestorer) WaitForInitialPolicy(_ context.Context) error {
 	return nil
 }

--- a/pkg/endpointstate/restorer.go
+++ b/pkg/endpointstate/restorer.go
@@ -11,7 +11,7 @@ type Restorer interface {
 	// cancelled or all the endpoints have been restored from a previous run.
 	WaitForEndpointRestore(ctx context.Context) error
 
-	// WaitForInitialEnvoyPolicy blocks the caller until either the context is
-	// cancelled or policies of all the endpoints have been computed.
-	WaitForInitialEnvoyPolicy(ctx context.Context) error
+	// WaitForInitialPolicy blocks the caller until either the context is
+	// cancelled or initial policies of all restored endpoints have been computed.
+	WaitForInitialPolicy(ctx context.Context) error
 }

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -75,6 +75,7 @@ type ProxyConfig struct {
 	UseFullTLSContext                 bool
 	ProxyXffNumTrustedHopsIngress     uint32
 	ProxyXffNumTrustedHopsEgress      uint32
+	EnvoyPolicyRestoreTimeout         time.Duration
 }
 
 func (r ProxyConfig) Flags(flags *pflag.FlagSet) {
@@ -103,6 +104,7 @@ func (r ProxyConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool("use-full-tls-context", false, "If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.")
 	flags.Uint32("proxy-xff-num-trusted-hops-ingress", 0, "Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.")
 	flags.Uint32("proxy-xff-num-trusted-hops-egress", 0, "Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.")
+	flags.Duration("envoy-policy-restore-timeout", 3*time.Minute, "Maxiumum time to wait for enpoint policy restoration before starting serving resources to Envoy")
 }
 
 type secretSyncConfig struct {
@@ -168,6 +170,7 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 			useSDS:                        params.SecretManager.PolicySecretSyncEnabled(),
 			proxyXffNumTrustedHopsIngress: params.EnvoyProxyConfig.ProxyXffNumTrustedHopsIngress,
 			proxyXffNumTrustedHopsEgress:  params.EnvoyProxyConfig.ProxyXffNumTrustedHopsEgress,
+			policyRestoreTimeout:          params.EnvoyProxyConfig.EnvoyPolicyRestoreTimeout,
 			metrics:                       params.Metrics,
 		},
 		params.SecretManager)

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -214,6 +214,7 @@ type xdsServerConfig struct {
 	useSDS                        bool
 	proxyXffNumTrustedHopsIngress uint32
 	proxyXffNumTrustedHopsEgress  uint32
+	policyRestoreTimeout          time.Duration
 	metrics                       xds.Metrics
 }
 


### PR DESCRIPTION
Make the xDS server wait more robust in three ways:
1. stop the wait when all the endpoints have been regenerated
2. signal initial policy computation completed even if it fails during initial regeneration
3. add a timeout to bound the time Cilium Agent waits until it starts serving resources to Envoy after restart

(1) bounds the wait until endpoints have been restored. Normally initial policy computation would have been done by this time.

(2) lets xDS server start even if some restored endpoints fail their (initial) regeneration.

(3) adds the upper bound via new agent option `--policy-restore-timeout` (default 3 minutes).

These measures are needed to bound the time Cilium Agent waits before it starts serving resources to Envoy on restart. Details herein may still need to be discussed.

Fixes: #36433

```release-note
New agent option `--policy-restore-timeout` (default 3m) has been added to bound the maximum time Cilium agent waits for endpoint policies to regenerate before starting serving resources to `cilium-envoy` proxy.
```