### PR TITLE
gitattributes: auto resolve merge conflicts for generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,7 @@ pkg/k8s/client/clientset/** linguist-generated
 pkg/k8s/client/informers/** linguist-generated
 pkg/k8s/client/listers/** linguist-generated
 *.bt linguist-language=D
+
+./install/kubernetes/cilium/Chart.yaml merge=ours
+./install/kubernetes/cilium/values.yaml merge=ours
+./install/kubernetes/cilium/README.md merge=ours

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,5 @@ pkg/k8s/client/informers/** linguist-generated
 pkg/k8s/client/listers/** linguist-generated
 *.bt linguist-language=D
 
-./install/kubernetes/cilium/Chart.yaml merge=ours
 ./install/kubernetes/cilium/values.yaml merge=ours
 ./install/kubernetes/cilium/README.md merge=ours


### PR DESCRIPTION
Let git automatically choose a dummy merge strategy for our generated files to streamline the process of release prep.
