### PR TITLE
gha: Update GatewayAPI conformance report

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -302,8 +302,8 @@ jobs:
               --organization cilium \
               --project cilium \
               --url github.com/cilium/cilium \
-              --version main \
-              --contact https://github.com/cilium/community/blob/v1.17/roles/Maintainers.md \
+              --version v1.17 \
+              --contact https://github.com/cilium/community/blob/main/roles/Maintainers.md \
               --report-output report.yaml \
               -test.run "TestConformance" \
               -test.timeout=29m \


### PR DESCRIPTION
This is missed when the 1.17 branch is cut. The main reason is to reflect the right Cilium version in upstream report https://gateway-api.sigs.k8s.io/implementations/v1.2/.

Thanks to @youngnick for highlighting this mismatch.
