### PR TITLE
helm: fix envoy JSON logformat

### DIFF
--- a/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.yaml
+++ b/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.yaml
@@ -289,7 +289,7 @@ overloadManager:
 applicationLogConfig:
   logFormat:
     {{- if .Values.envoy.log.format_json }}
-    jsonFormat: "{{ .Values.envoy.log.format_json | toJson }}"
+    jsonFormat: {{ .Values.envoy.log.format_json | toJson }}
     {{- else }}
     textFormat: "{{ .Values.envoy.log.format }}"
     {{- end }}


### PR DESCRIPTION
Setting the envoy JSON log format via Helm proerty `envoy.log.format_json` results in a YAML to JSON conversion error that results in an invalid `boostrap-config.json` containing the error itself).

```
❯ helm template --set-json   'envoy.log.format_json={"test": "test"}'  ./install/kubernetes/cilium   | grep -C 2 error
  # Keep the key name as bootstrap-config.json to avoid breaking changes
  bootstrap-config.json: |
    {"Error":"error converting YAML to JSON: yaml: line 216: did not find expected key"}
---
```

This has been introduced while changing the boostrap config from JSON to YAML with https://github.com/cilium/cilium/pull/36820.

Therefore, this commit is fixing this by removing the quotes around the JSON format.

With fix applied:

```
❯ helm template --set-json   'envoy.log.format_json={"test": "bla"}'  ./install/kubernetes/cilium   | grep -C 2 bla
  # Keep the key name as bootstrap-config.json to avoid breaking changes
  bootstrap-config.json: |
    {"admin":{"address":{"pipe":{"path":"/var/run/cilium/envoy/sockets/admin.sock"}}},"applicationLogConfig":{"logFormat":{"jsonFormat":{"test":"bla"}}}, ...
```

Fixes: https://github.com/cilium/cilium/issues/37470