### PR TITLE
conformance-gke.yaml: Enable dual-stack for GKE conformance tests

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -265,6 +265,7 @@ jobs:
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ matrix.k8s.zone }} \
             --cluster-version ${{ matrix.k8s.version }} \
+            --enable-dataplane-v2 \
             --enable-ip-alias \
             --create-subnetwork="range=/26" \
             --cluster-ipv4-cidr="/21" \


### PR DESCRIPTION
Modify the GKE workflow to enable dual-stack for the conformance tests.

Fixes: #37143

```release-note
Enable DualStack for GKE conformance tests
```
