### PR TITLE
.github: Remove misleading step from ipsec workflow

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -198,24 +198,6 @@ jobs:
           ref: ${{ inputs.context-ref || github.sha }}
           persist-credentials: false
 
-      - name: Check we effectively removed Git credentials
-        shell: bash
-        run: |
-          # For private repositories requiring authentication, check that we
-          # can no longer fetch from the repository.
-          if ! curl -L \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${{ github.repository }}" | \
-            tee /dev/stderr | \
-            jq --exit-status '.private == false'; then
-            echo 'Checking whether "git fetch" succeeds'
-            if git fetch origin HEAD; then
-              echo "::error::Git credentials not removed, aborting now."
-              false
-            fi
-          fi
-
       - name: Derive stable Cilium installation config
         id: cilium-stable-config
         if: ${{ steps.vars.outputs.downgrade_version != '' }}


### PR DESCRIPTION
This step makes a query for the cilium/cilium repo on GitHub and then
checks that the field 'private' is set to false. Note that cilium/cilium
is public repository, so 'private' is always set to false. This means
that the check is not validating whether git credentials were removed,
it's just checking whether a public repository is public. [API reference](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#get-a-repository).

When this step fails, for instance due to occasional ratelimits imposed
by GitHub, *then* it would do a check whether a read-only git fetch
would succeed, which would always succeed because this workflow is not
removing Git/GitHub credentials. Because this step succeeds, the check
would fail. This would happen on *any* curl failure.

This commit therefore removes the misleading and incorrect step as it's
better to have no check than to have a check that creates the impression
of some property holding in the workflow run.
