### PR TITLE
proxy: introduce slog logger for proxy package

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -98,7 +98,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 			if isStatic {
 				port = oldPort
 			} else {
-				openLocalPorts := proxy.OpenLocalPorts()
+				openLocalPorts := d.l7Proxy.OpenLocalPorts()
 				if _, alreadyOpen := openLocalPorts[oldPort]; !alreadyOpen {
 					port = oldPort
 				} else {
@@ -221,7 +221,7 @@ func (d *Daemon) notifyOnDNSMsg(
 	allowed bool,
 	stat *dnsproxy.ProxyRequestContext,
 ) error {
-	var protoID = u8proto.ProtoIDs[strings.ToLower(protocol)]
+	protoID := u8proto.ProtoIDs[strings.ToLower(protocol)]
 	var verdict accesslog.FlowVerdict
 	var reason string
 	metricError := metricErrorAllow
@@ -282,7 +282,7 @@ func (d *Daemon) notifyOnDNSMsg(
 	// point is always Egress, however.
 	var flowType accesslog.FlowType
 	var addrInfo logger.AddressingInfo
-	var serverAddrPortStr = serverAddrPort.String()
+	serverAddrPortStr := serverAddrPort.String()
 	if msg.Response {
 		flowType = accesslog.TypeResponse
 		addrInfo.DstIPPort = epIPPort
@@ -386,7 +386,8 @@ func (d *Daemon) notifyOnDNSMsg(
 			qname: {
 				IPs: responseIPs,
 				TTL: int(TTL),
-			}})
+			},
+		})
 
 		stat.PolicyGenerationTime.End(true)
 		stat.DataplaneTime.Start()

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -98,7 +98,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 			if isStatic {
 				port = oldPort
 			} else {
-				openLocalPorts := d.l7Proxy.OpenLocalPorts()
+				openLocalPorts := d.l7Proxy.GetOpenLocalPorts()
 				if _, alreadyOpen := openLocalPorts[oldPort]; !alreadyOpen {
 					port = oldPort
 				} else {

--- a/pkg/proxy/cell.go
+++ b/pkg/proxy/cell.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
-	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/controller"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -16,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/proxy/logger"
 	"github.com/cilium/cilium/pkg/proxy/logger/endpoint"
+	"github.com/cilium/cilium/pkg/proxy/proxyports"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
@@ -31,28 +31,16 @@ var Cell = cell.Module(
 	cell.Provide(newEnvoyProxyIntegration),
 	cell.Provide(newDNSProxyIntegration),
 	cell.ProvidePrivate(endpoint.NewEndpointInfoRegistry),
-	cell.Config(ProxyConfig{}),
+	cell.ProvidePrivate(proxyports.NewProxyPorts),
+	cell.Config(proxyports.ProxyPortsConfig{}),
 )
-
-type ProxyConfig struct {
-	ProxyPortrangeMin          uint16
-	ProxyPortrangeMax          uint16
-	RestoredProxyPortsAgeLimit uint
-}
-
-func (r ProxyConfig) Flags(flags *pflag.FlagSet) {
-	flags.Uint16("proxy-portrange-min", 10000, "Start of port range that is used to allocate ports for L7 proxies.")
-	flags.Uint16("proxy-portrange-max", 20000, "End of port range that is used to allocate ports for L7 proxies.")
-	flags.Uint("restored-proxy-ports-age-limit", 15, "Time after which a restored proxy ports file is considered stale (in minutes)")
-}
 
 type proxyParams struct {
 	cell.In
 
 	Lifecycle             cell.Lifecycle
 	Logger                *slog.Logger
-	Config                ProxyConfig
-	IPTablesManager       datapath.IptablesManager
+	ProxyPorts            *proxyports.ProxyPorts
 	EndpointInfoRegistry  logger.EndpointInfoRegistry
 	MonitorAgent          monitoragent.Agent
 	EnvoyProxyIntegration *envoyProxyIntegration
@@ -70,7 +58,7 @@ func newProxy(params proxyParams) *Proxy {
 
 	configureProxyLogger(params.EndpointInfoRegistry, params.MonitorAgent, option.Config.AgentLabels)
 
-	p := createProxy(params.Logger, params.Config.ProxyPortrangeMin, params.Config.ProxyPortrangeMax, params.IPTablesManager, params.EnvoyProxyIntegration, params.DNSProxyIntegration)
+	p := createProxy(params.Logger, params.ProxyPorts, params.EnvoyProxyIntegration, params.DNSProxyIntegration)
 
 	triggerDone := make(chan struct{})
 
@@ -82,7 +70,7 @@ func newProxy(params proxyParams) *Proxy {
 		OnStart: func(cell.HookContext) (err error) {
 			// Restore all proxy ports before we create the trigger to overwrite the
 			// file below
-			p.proxyPorts.RestoreProxyPorts(params.Config.RestoredProxyPortsAgeLimit)
+			p.proxyPorts.RestoreProxyPorts()
 
 			p.proxyPorts.Trigger, err = trigger.NewTrigger(trigger.Parameters{
 				MinInterval: 10 * time.Second,

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -103,9 +103,9 @@ func (p *Proxy) SetProxyPort(name string, proxyType types.ProxyType, port uint16
 	return p.proxyPorts.SetProxyPort(name, proxyType, port, ingress)
 }
 
-// OpenLocalPorts returns the set of L4 ports currently open locally.
-func (p *Proxy) OpenLocalPorts() map[uint16]struct{} {
-	return p.proxyPorts.OpenLocalPorts()
+// GetOpenLocalPorts returns the set of L4 ports currently open locally.
+func (p *Proxy) GetOpenLocalPorts() map[uint16]struct{} {
+	return p.proxyPorts.GetOpenLocalPorts()
 }
 
 // CreateOrUpdateRedirect creates or updates a L4 redirect with corresponding

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -53,9 +53,7 @@ type Proxy struct {
 
 func createProxy(
 	logger *slog.Logger,
-	minPort uint16,
-	maxPort uint16,
-	datapathUpdater proxyports.DatapathUpdater,
+	proxyPorts *proxyports.ProxyPorts,
 	envoyIntegration *envoyProxyIntegration,
 	dnsIntegration *dnsProxyIntegration,
 ) *Proxy {
@@ -64,7 +62,7 @@ func createProxy(
 		redirects:        make(map[string]RedirectImplementation),
 		envoyIntegration: envoyIntegration,
 		dnsIntegration:   dnsIntegration,
-		proxyPorts:       proxyports.NewProxyPorts(logger, minPort, maxPort, datapathUpdater),
+		proxyPorts:       proxyPorts,
 	}
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -104,8 +104,8 @@ func (p *Proxy) SetProxyPort(name string, proxyType types.ProxyType, port uint16
 }
 
 // OpenLocalPorts returns the set of L4 ports currently open locally.
-func OpenLocalPorts() map[uint16]struct{} {
-	return proxyports.OpenLocalPorts()
+func (p *Proxy) OpenLocalPorts() map[uint16]struct{} {
+	return p.proxyPorts.OpenLocalPorts()
 }
 
 // CreateOrUpdateRedirect creates or updates a L4 redirect with corresponding

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -64,7 +64,7 @@ func createProxy(
 		redirects:        make(map[string]RedirectImplementation),
 		envoyIntegration: envoyIntegration,
 		dnsIntegration:   dnsIntegration,
-		proxyPorts:       proxyports.NewProxyPorts(minPort, maxPort, datapathUpdater),
+		proxyPorts:       proxyports.NewProxyPorts(logger, minPort, maxPort, datapathUpdater),
 	}
 }
 

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -21,8 +21,14 @@ import (
 )
 
 func proxyForTest(t *testing.T) (*Proxy, func()) {
-	mockDatapathUpdater := &proxyports.MockDatapathUpdater{}
-	p := createProxy(hivetest.Logger(t), 10000, 20000, mockDatapathUpdater, nil, nil)
+	mockDatapathUpdater := &proxyports.MockIPTablesManager{}
+	ppConfig := proxyports.ProxyPortsConfig{
+		ProxyPortrangeMin:          10000,
+		ProxyPortrangeMax:          20000,
+		RestoredProxyPortsAgeLimit: 0,
+	}
+	pp := proxyports.NewProxyPorts(hivetest.Logger(t), ppConfig, mockDatapathUpdater)
+	p := createProxy(hivetest.Logger(t), pp, nil, nil)
 	triggerDone := make(chan struct{})
 	p.proxyPorts.Trigger, _ = trigger.NewTrigger(trigger.Parameters{
 		MinInterval:  10 * time.Second,

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/completion"
@@ -19,9 +20,9 @@ import (
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
-func proxyForTest() (*Proxy, func()) {
+func proxyForTest(t *testing.T) (*Proxy, func()) {
 	mockDatapathUpdater := &proxyports.MockDatapathUpdater{}
-	p := createProxy(10000, 20000, mockDatapathUpdater, nil, nil)
+	p := createProxy(hivetest.Logger(t), 10000, 20000, mockDatapathUpdater, nil, nil)
 	triggerDone := make(chan struct{})
 	p.proxyPorts.Trigger, _ = trigger.NewTrigger(trigger.Parameters{
 		MinInterval:  10 * time.Second,
@@ -66,7 +67,7 @@ func TestCreateOrUpdateRedirectMissingListener(t *testing.T) {
 	err := os.MkdirAll(socketDir, 0700)
 	require.NoError(t, err)
 
-	p, cleaner := proxyForTest()
+	p, cleaner := proxyForTest(t)
 	defer cleaner()
 
 	l4 := &fakeProxyPolicy{}

--- a/pkg/proxy/proxyports/netstat.go
+++ b/pkg/proxy/proxyports/netstat.go
@@ -35,8 +35,8 @@ var (
 	procNetFileRegexp = regexp.MustCompile("^ *[[:digit:]]*: *[[:xdigit:]]*:([[:xdigit:]]*) ")
 )
 
-// OpenLocalPorts returns the set of L4 ports currently open locally.
-func (p *ProxyPorts) OpenLocalPorts() map[uint16]struct{} {
+// GetOpenLocalPorts returns the set of L4 ports currently open locally.
+func (p *ProxyPorts) GetOpenLocalPorts() map[uint16]struct{} {
 	openLocalPorts := make(map[uint16]struct{}, 128)
 
 	for _, file := range append(procNetTCPFiles, procNetUDPFiles...) {

--- a/pkg/proxy/proxyports/netstat.go
+++ b/pkg/proxy/proxyports/netstat.go
@@ -36,7 +36,7 @@ var (
 )
 
 // OpenLocalPorts returns the set of L4 ports currently open locally.
-func OpenLocalPorts() map[uint16]struct{} {
+func (p *ProxyPorts) OpenLocalPorts() map[uint16]struct{} {
 	openLocalPorts := make(map[uint16]struct{}, 128)
 
 	for _, file := range append(procNetTCPFiles, procNetUDPFiles...) {

--- a/pkg/proxy/proxyports/netstat.go
+++ b/pkg/proxy/proxyports/netstat.go
@@ -35,12 +35,11 @@ var (
 	procNetFileRegexp = regexp.MustCompile("^ *[[:digit:]]*: *[[:xdigit:]]*:([[:xdigit:]]*) ")
 )
 
-// readOpenLocalPorts returns the set of L4 ports currently open locally.
-// procNetFiles should be procNetTCPFiles or procNetUDPFiles (or both).
-func readOpenLocalPorts(procNetFiles []string) map[uint16]struct{} {
+// OpenLocalPorts returns the set of L4 ports currently open locally.
+func OpenLocalPorts() map[uint16]struct{} {
 	openLocalPorts := make(map[uint16]struct{}, 128)
 
-	for _, file := range procNetFiles {
+	for _, file := range append(procNetTCPFiles, procNetUDPFiles...) {
 		b, err := os.ReadFile(file)
 		if err != nil {
 			log.WithError(err).WithField(logfields.Path, file).Errorf("cannot read proc file")
@@ -67,9 +66,4 @@ func readOpenLocalPorts(procNetFiles []string) map[uint16]struct{} {
 	}
 
 	return openLocalPorts
-}
-
-// OpenLocalPorts returns the set of L4 ports currently open locally.
-func OpenLocalPorts() map[uint16]struct{} {
-	return readOpenLocalPorts(append(procNetTCPFiles, procNetUDPFiles...))
 }

--- a/pkg/proxy/proxyports/netstat.go
+++ b/pkg/proxy/proxyports/netstat.go
@@ -9,11 +9,8 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
-
-var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "proxy")
 
 var (
 	// procNetTCPFiles is the constant list of /proc/net files to read to get
@@ -42,7 +39,7 @@ func (p *ProxyPorts) GetOpenLocalPorts() map[uint16]struct{} {
 	for _, file := range append(procNetTCPFiles, procNetUDPFiles...) {
 		b, err := os.ReadFile(file)
 		if err != nil {
-			log.WithError(err).WithField(logfields.Path, file).Errorf("cannot read proc file")
+			p.logger.Error("cannot read proc file", logfields.Path, file, logfields.Error, err)
 			continue
 		}
 
@@ -58,7 +55,7 @@ func (p *ProxyPorts) GetOpenLocalPorts() map[uint16]struct{} {
 			// The port number is in hexadecimal.
 			localPort, err := strconv.ParseUint(string(groups[1]), 16, 16)
 			if err != nil {
-				log.WithError(err).WithField(logfields.Path, file).Errorf("cannot read proc file")
+				p.logger.Error("failed to parse port from proc file", logfields.Path, file, logfields.Error, err)
 				continue
 			}
 			openLocalPorts[uint16(localPort)] = struct{}{}

--- a/pkg/proxy/proxyports/netstat.go
+++ b/pkg/proxy/proxyports/netstat.go
@@ -9,8 +9,11 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "proxy")
 
 var (
 	// procNetTCPFiles is the constant list of /proc/net files to read to get

--- a/pkg/proxy/proxyports/proxyports.go
+++ b/pkg/proxy/proxyports/proxyports.go
@@ -198,7 +198,7 @@ func (p *ProxyPorts) isPortAvailable(openLocalPorts map[uint16]struct{}, port ui
 // Returns a non-zero allocated port if successful, or 0 and error if not.
 func (p *ProxyPorts) allocatePort(port, min, max uint16) (uint16, error) {
 	// Get a snapshot of the TCP and UDP ports already open locally.
-	openLocalPorts := p.OpenLocalPorts()
+	openLocalPorts := p.GetOpenLocalPorts()
 
 	if port != 0 && p.isPortAvailable(openLocalPorts, port, false) {
 		return port, nil

--- a/pkg/proxy/proxyports/proxyports.go
+++ b/pkg/proxy/proxyports/proxyports.go
@@ -198,7 +198,7 @@ func (p *ProxyPorts) isPortAvailable(openLocalPorts map[uint16]struct{}, port ui
 // Returns a non-zero allocated port if successful, or 0 and error if not.
 func (p *ProxyPorts) allocatePort(port, min, max uint16) (uint16, error) {
 	// Get a snapshot of the TCP and UDP ports already open locally.
-	openLocalPorts := OpenLocalPorts()
+	openLocalPorts := p.OpenLocalPorts()
 
 	if port != 0 && p.isPortAvailable(openLocalPorts, port, false) {
 		return port, nil

--- a/pkg/proxy/proxyports/proxyports_test.go
+++ b/pkg/proxy/proxyports/proxyports_test.go
@@ -33,7 +33,7 @@ func TestPortAllocator(t *testing.T) {
 			os.RemoveAll(socketDir)
 		}()
 	}
-	p, cleaner := proxyPortsForTest()
+	p, cleaner := proxyPortsForTest(t)
 	defer cleaner()
 
 	port, err := p.AllocateCRDProxyPort("listener1")
@@ -225,7 +225,7 @@ func TestRestoredPort(t *testing.T) {
 			os.RemoveAll(socketDir)
 		}()
 	}
-	p, cleaner := proxyPortsForTest()
+	p, cleaner := proxyPortsForTest(t)
 	defer cleaner()
 
 	// simulate proxy port restored from file

--- a/pkg/proxy/proxyports/testutils.go
+++ b/pkg/proxy/proxyports/testutils.go
@@ -4,6 +4,10 @@
 package proxyports
 
 import (
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
@@ -17,9 +21,9 @@ func (m *MockDatapathUpdater) GetProxyPorts() map[string]uint16 {
 	return nil
 }
 
-func proxyPortsForTest() (*ProxyPorts, func()) {
+func proxyPortsForTest(t *testing.T) (*ProxyPorts, func()) {
 	mockDatapathUpdater := &MockDatapathUpdater{}
-	p := NewProxyPorts(10000, 20000, mockDatapathUpdater)
+	p := NewProxyPorts(hivetest.Logger(t), 10000, 20000, mockDatapathUpdater)
 	triggerDone := make(chan struct{})
 	p.Trigger, _ = trigger.NewTrigger(trigger.Parameters{
 		MinInterval:  10 * time.Millisecond,

--- a/pkg/proxy/proxyports/testutils.go
+++ b/pkg/proxy/proxyports/testutils.go
@@ -4,26 +4,43 @@
 package proxyports
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
 
+	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 
-type MockDatapathUpdater struct{}
+type MockIPTablesManager struct{}
 
-func (m *MockDatapathUpdater) InstallProxyRules(proxyPort uint16, name string) {
+var _ datapath.IptablesManager = &MockIPTablesManager{}
+
+func (m *MockIPTablesManager) InstallNoTrackRules(ip netip.Addr, port uint16) {}
+
+func (m *MockIPTablesManager) RemoveNoTrackRules(ip netip.Addr, port uint16) {}
+
+func (m *MockIPTablesManager) SupportsOriginalSourceAddr() bool {
+	return false
 }
 
-func (m *MockDatapathUpdater) GetProxyPorts() map[string]uint16 {
+func (m *MockIPTablesManager) InstallProxyRules(proxyPort uint16, name string) {}
+
+func (m *MockIPTablesManager) GetProxyPorts() map[string]uint16 {
 	return nil
 }
 
 func proxyPortsForTest(t *testing.T) (*ProxyPorts, func()) {
-	mockDatapathUpdater := &MockDatapathUpdater{}
-	p := NewProxyPorts(hivetest.Logger(t), 10000, 20000, mockDatapathUpdater)
+	mockIPTablesManager := &MockIPTablesManager{}
+	config := ProxyPortsConfig{
+		ProxyPortrangeMin:          10000,
+		ProxyPortrangeMax:          20000,
+		RestoredProxyPortsAgeLimit: 0,
+	}
+
+	p := NewProxyPorts(hivetest.Logger(t), config, mockIPTablesManager)
 	triggerDone := make(chan struct{})
 	p.Trigger, _ = trigger.NewTrigger(trigger.Parameters{
 		MinInterval:  10 * time.Millisecond,

--- a/pkg/proxy/redirect.go
+++ b/pkg/proxy/redirect.go
@@ -4,6 +4,8 @@
 package proxy
 
 import (
+	"log/slog"
+
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/proxyports"
@@ -30,14 +32,16 @@ type RedirectImplementation interface {
 
 // Redirect is the common static config for each RedirectImplementation
 type Redirect struct {
+	logger       *slog.Logger
 	name         string
 	proxyPort    *proxyports.ProxyPort
 	dstPortProto restore.PortProto
 	endpointID   uint16
 }
 
-func initRedirect(epID uint16, name string, listener *proxyports.ProxyPort, port uint16, proto u8proto.U8proto) Redirect {
+func initRedirect(logger *slog.Logger, epID uint16, name string, listener *proxyports.ProxyPort, port uint16, proto u8proto.U8proto) Redirect {
 	return Redirect{
+		logger:       logger,
 		name:         name,
 		proxyPort:    listener,
 		dstPortProto: restore.MakeV2PortProto(port, proto),


### PR DESCRIPTION
This commit is refactoring the Proxy functionality to use an injected slog logger instead of the package scoped logrus instances.

In addition to this, it was necessary to modularize the internals of the proxy package - the ProxyPorts became a proper Hive component.

Please review the individual commits.