### PR TITLE
Policy: Fix auth policies with proxy redirects

### DIFF
--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -646,15 +646,13 @@ func (ms *mapState) addKeyWithChanges(key Key, entry mapStateEntry, changes Chan
 // deleteKeyWithChanges deletes a 'key' from 'ms' keeping track of incremental changes in 'changes'
 func (ms *mapState) deleteKeyWithChanges(key Key, changes ChangeState) {
 	if entry, exists := ms.get(key); exists {
-		// Save old value before any changes, if desired
-		changes.insertOldIfNotExists(key, entry)
-
-		if changes.Deletes != nil {
+		// Only record as a delete if the entry was not added on the same round of changes
+		if changes.insertOldIfNotExists(key, entry) && changes.Deletes != nil {
 			changes.Deletes[key] = struct{}{}
-			// Remove a potential previously added key
-			if changes.Adds != nil {
-				delete(changes.Adds, key)
-			}
+		}
+		// Remove a potential previously added key
+		if changes.Adds != nil {
+			delete(changes.Adds, key)
 		}
 
 		ms.delete(key)

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -812,6 +812,10 @@ func proxyEntry(proxyPort uint16) mapStateEntry {
 	return NewMapStateEntry(AllowEntry.WithProxyPort(proxyPort)).withLabels(labels.LabelArrayList{nil})
 }
 
+func proxyPriorityEntry(proxyPort uint16, priority uint8) mapStateEntry {
+	return NewMapStateEntry(AllowEntry.WithProxyPort(proxyPort).WithProxyPriority(priority)).withLabels(labels.LabelArrayList{nil})
+}
+
 func denyEntry() mapStateEntry {
 	return NewMapStateEntry(DenyEntry).withLabels(labels.LabelArrayList{nil})
 }
@@ -1167,9 +1171,10 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		adds     []int
 		deletes  []int
 		port     uint16
+		prefix   uint8
 		proto    u8proto.U8proto
 		ingress  bool
-		redirect bool
+		redirect uint8 // listener priority
 		deny     bool
 		authReq  AuthRequirement
 	}
@@ -1183,7 +1188,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 	}{{
 		name: "test-2a - Adding 2 identities, and deleting a nonexisting key on an empty state",
 		args: []args{
-			{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
+			{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true},
 		},
 		state: testMapState(mapStateMap{
 			HttpIngressKey(42): allowEntry(),
@@ -1198,7 +1203,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		continued: true,
 		name:      "test-2b - Adding Bar also selecting 42",
 		args: []args{
-			{cs: csBar, adds: []int{42, 44}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
+			{cs: csBar, adds: []int{42, 44}, deletes: []int{}, port: 80, proto: 6, ingress: true},
 		},
 		state: testMapState(mapStateMap{
 			HttpIngressKey(42): allowEntry(),
@@ -1213,8 +1218,8 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		continued: true,
 		name:      "test-2c - Deleting 42",
 		args: []args{
-			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
-			{cs: csBar, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
+			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true},
+			{cs: csBar, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true},
 		},
 		state: testMapState(mapStateMap{
 			HttpIngressKey(43): allowEntry(),
@@ -1228,7 +1233,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		continued: true,
 		name:      "test-2f - Adding an entry that already exists, no adds",
 		args: []args{
-			{cs: csBar, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
+			{cs: csBar, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: true},
 		},
 		state: testMapState(mapStateMap{
 			HttpIngressKey(43): allowEntry(),
@@ -1240,10 +1245,10 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		continued: false,
 		name:      "test-3a - egress HTTP proxy (setup)",
 		args: []args{
-			{cs: nil, adds: []int{0}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: false},
-			{cs: nil, adds: []int{1}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: false},
-			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
-			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
+			{cs: nil, adds: []int{0}, deletes: []int{}, port: 0, proto: 0, ingress: true},
+			{cs: nil, adds: []int{1}, deletes: []int{}, port: 0, proto: 0, ingress: true},
+			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false},
+			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false},
 		},
 		state: testMapState(mapStateMap{
 			AnyIngressKey():     allowEntry(),
@@ -1262,14 +1267,14 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		continued: true,
 		name:      "test-3b - egress HTTP proxy (incremental update)",
 		args: []args{
-			{cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
+			{cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: 1},
 		},
 		state: testMapState(mapStateMap{
 			AnyIngressKey():     allowEntry(),
 			HostIngressKey():    allowEntry(),
 			DNSUDPEgressKey(42): allowEntry(),
 			DNSTCPEgressKey(42): allowEntry(),
-			HttpEgressKey(43):   proxyEntry(1),
+			HttpEgressKey(43):   proxyPriorityEntry(1, 1),
 		}),
 		adds: Keys{
 			HttpEgressKey(43): {},
@@ -1279,8 +1284,8 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		continued: false,
 		name:      "test-4a - Add & delete; delete cancels the add in reply",
 		args: []args{
-			{cs: csFoo, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
-			{cs: csFoo, adds: []int{}, deletes: []int{44}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
+			{cs: csFoo, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: 1},
+			{cs: csFoo, adds: []int{}, deletes: []int{44}, port: 80, proto: 6, ingress: false, redirect: 1},
 		},
 		state:   emptyMapState(),
 		adds:    Keys{},
@@ -1289,12 +1294,12 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		continued: true,
 		name:      "test-4b - Add, delete, & add; delete suppressed",
 		args: []args{
-			{cs: csFoo, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
-			{cs: csFoo, adds: []int{}, deletes: []int{44}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
-			{cs: csFoo, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
+			{cs: csFoo, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: 1},
+			{cs: csFoo, adds: []int{}, deletes: []int{44}, port: 80, proto: 6, ingress: false, redirect: 1},
+			{cs: csFoo, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: 1},
 		},
 		state: testMapState(mapStateMap{
-			HttpEgressKey(44): proxyEntry(1),
+			HttpEgressKey(44): proxyPriorityEntry(1, 1),
 		}),
 		adds: Keys{
 			HttpEgressKey(44): {},
@@ -1306,12 +1311,12 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		args: []args{
 			{cs: csFoo, adds: []int{43}, authReq: AuthTypeAlwaysFail.AsExplicitRequirement()},
 			{cs: csFoo, adds: []int{0}, proto: 6, authReq: AuthTypeSpire.AsExplicitRequirement()},
-			{cs: csBar, adds: []int{43}, port: 80, proto: 6, redirect: true},
+			{cs: csBar, adds: []int{43}, port: 80, proto: 6, redirect: 1},
 		},
 		state: testMapState(mapStateMap{
 			egressKey(43, 0, 0, 0):  allowEntry().withExplicitAuth(AuthTypeAlwaysFail),
 			egressKey(0, 6, 0, 0):   allowEntry().withExplicitAuth(AuthTypeSpire),
-			egressKey(43, 6, 80, 0): proxyEntry(1).withDerivedAuth(AuthTypeAlwaysFail),
+			egressKey(43, 6, 80, 0): proxyPriorityEntry(1, 1).withDerivedAuth(AuthTypeAlwaysFail),
 		}),
 		adds: Keys{
 			egressKey(43, 0, 0, 0):  {},
@@ -1323,14 +1328,14 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		continued: false,
 		name:      "test-5b - auth type propagation from the most specific covering key - reverse",
 		args: []args{
-			{cs: csBar, adds: []int{43}, port: 80, proto: 6, redirect: true},
+			{cs: csBar, adds: []int{43}, port: 80, proto: 6, redirect: 1},
 			{cs: csFoo, adds: []int{0}, proto: 6, authReq: AuthTypeSpire.AsExplicitRequirement()},
 			{cs: csFoo, adds: []int{43}, authReq: AuthTypeAlwaysFail.AsExplicitRequirement()},
 		},
 		state: testMapState(mapStateMap{
 			egressKey(43, 0, 0, 0):  allowEntry().withExplicitAuth(AuthTypeAlwaysFail),
 			egressKey(0, 6, 0, 0):   allowEntry().withExplicitAuth(AuthTypeSpire),
-			egressKey(43, 6, 80, 0): proxyEntry(1).withDerivedAuth(AuthTypeAlwaysFail),
+			egressKey(43, 6, 80, 0): proxyPriorityEntry(1, 1).withDerivedAuth(AuthTypeAlwaysFail),
 		}),
 		adds: Keys{
 			egressKey(43, 0, 0, 0):  {},
@@ -1340,14 +1345,130 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		deletes: Keys{},
 	}, {
 		continued: false,
+		name:      "test-5c - higher priority proxy port override with auth entries",
+		args: []args{
+			{cs: csFoo, adds: []int{43}, proto: 6, redirect: 1},
+			// lower priority redirect (priority 2) is overridden by priority 1 redirect
+			{cs: csFoo, adds: []int{43}, port: 80, proto: 6, prefix: 12, redirect: 2},
+			// but more specific entries with different auth are not
+			{cs: csBar, adds: []int{43}, port: 80, proto: 6, prefix: 16, authReq: AuthTypeSpire.AsExplicitRequirement()},
+			{cs: csBar, adds: []int{43}, port: 81, proto: 6, prefix: 16, authReq: AuthTypeSpire.AsExplicitRequirement()},
+		},
+		state: testMapState(mapStateMap{
+			egressKey(43, 6, 0, 0): proxyPriorityEntry(1, 1),
+			//egressKey(43, 6, 80, 12): proxyPriorityEntry(1, 2),
+			egressKey(43, 6, 80, 0): proxyPriorityEntry(1, 1).withExplicitAuth(AuthTypeSpire),
+			egressKey(43, 6, 81, 0): proxyPriorityEntry(1, 1).withExplicitAuth(AuthTypeSpire),
+		}),
+		adds: Keys{
+			egressKey(43, 6, 0, 0): {},
+			//egressKey(43, 6, 80, 12): {},
+			egressKey(43, 6, 80, 16): {},
+			egressKey(43, 6, 81, 16): {},
+		},
+		deletes: Keys{},
+	}, {
+		continued: false,
+		name:      "test-5d - higher priority proxy port override with auth entries - reverse",
+		args: []args{
+			{cs: csBar, adds: []int{43}, port: 80, proto: 6, prefix: 16, authReq: AuthTypeSpire.AsExplicitRequirement()},
+			{cs: csFoo, adds: []int{43}, port: 80, proto: 6, prefix: 12, redirect: 1},
+		},
+		state: testMapState(mapStateMap{
+			egressKey(43, 6, 80, 12): proxyPriorityEntry(1, 1),
+			egressKey(43, 6, 80, 0):  proxyPriorityEntry(1, 1).withExplicitAuth(AuthTypeSpire),
+		}),
+		adds: Keys{
+			egressKey(43, 6, 80, 12): {},
+			egressKey(43, 6, 80, 0):  {},
+		},
+		deletes: Keys{},
+	}, {
+		continued: false,
+		name:      "test-5e - higher priority proxy port propagation to auth entries",
+		args: []args{
+			{cs: csFoo, adds: []int{43}, proto: 6, redirect: 1},
+			// lower priority redirect (priority 2) is overridden by priority 1 redirect, but kept due to different auth requirement
+			{cs: csFoo, adds: []int{43}, port: 80, proto: 6, prefix: 12, redirect: 2, authReq: AuthTypeSpire.AsExplicitRequirement()},
+			// but more specific entries with same auth are not added
+			{cs: csBar, adds: []int{43}, port: 80, proto: 6, prefix: 16, authReq: AuthTypeSpire.AsExplicitRequirement()},
+			{cs: csBar, adds: []int{43}, port: 81, proto: 6, prefix: 16, authReq: AuthTypeSpire.AsExplicitRequirement()},
+		},
+		state: testMapState(mapStateMap{
+			egressKey(43, 6, 0, 0):   proxyPriorityEntry(1, 1),
+			egressKey(43, 6, 80, 12): proxyPriorityEntry(1, 1).withExplicitAuth(AuthTypeSpire),
+		}),
+		adds: Keys{
+			egressKey(43, 6, 0, 0):   {},
+			egressKey(43, 6, 80, 12): {},
+		},
+		deletes: Keys{},
+	}, {
+		continued: false,
+		name:      "test-5f - higher priority proxy port propagation to auth entries - reverse",
+		args: []args{
+			{cs: csBar, adds: []int{43}, port: 81, proto: 6, prefix: 16, authReq: AuthTypeSpire.AsExplicitRequirement()},
+			{cs: csBar, adds: []int{43}, port: 80, proto: 6, prefix: 16, authReq: AuthTypeSpire.AsExplicitRequirement()},
+			{cs: csFoo, adds: []int{43}, port: 80, proto: 6, prefix: 12, redirect: 2, authReq: AuthTypeSpire.AsExplicitRequirement()},
+			{cs: csFoo, adds: []int{43}, proto: 6, redirect: 1},
+		},
+		state: testMapState(mapStateMap{
+			egressKey(43, 6, 0, 0):   proxyPriorityEntry(1, 1),
+			egressKey(43, 6, 80, 12): proxyPriorityEntry(1, 1).withExplicitAuth(AuthTypeSpire),
+		}),
+		adds: Keys{
+			egressKey(43, 6, 0, 0):   {},
+			egressKey(43, 6, 80, 12): {},
+		},
+		deletes: Keys{},
+	}, {
+		continued: false,
+		name:      "test-5g - higher priority proxy port propagation to auth proxy entry",
+		args: []args{
+			{cs: csFoo, adds: []int{43}, proto: 6, redirect: 1},
+			// lower priority redirect (priority 2) is overridden by priority 1 redirect, but kept due to different auth requirement
+			{cs: csFoo, adds: []int{43}, port: 80, proto: 6, prefix: 12, redirect: 2, authReq: AuthTypeSpire.AsExplicitRequirement()},
+			// but more specific entries with same auth are not added
+			{cs: csBar, adds: []int{43}, port: 80, proto: 6, prefix: 16},
+			{cs: csBar, adds: []int{43}, port: 81, proto: 6, prefix: 16},
+		},
+		state: testMapState(mapStateMap{
+			egressKey(43, 6, 0, 0):   proxyPriorityEntry(1, 1),
+			egressKey(43, 6, 80, 12): proxyPriorityEntry(1, 1).withExplicitAuth(AuthTypeSpire),
+		}),
+		adds: Keys{
+			egressKey(43, 6, 0, 0):   {},
+			egressKey(43, 6, 80, 12): {},
+		},
+		deletes: Keys{},
+	}, {
+		continued: false,
+		name:      "test-5h - higher priority proxy port propagation to auth proxy entry - reverse",
+		args: []args{
+			{cs: csBar, adds: []int{43}, port: 81, proto: 6, prefix: 16},
+			{cs: csBar, adds: []int{43}, port: 80, proto: 6, prefix: 16},
+			{cs: csFoo, adds: []int{43}, port: 80, proto: 6, prefix: 12, redirect: 2, authReq: AuthTypeSpire.AsExplicitRequirement()},
+			{cs: csFoo, adds: []int{43}, proto: 6, redirect: 1},
+		},
+		state: testMapState(mapStateMap{
+			egressKey(43, 6, 0, 0):   proxyPriorityEntry(1, 1),
+			egressKey(43, 6, 80, 12): proxyPriorityEntry(1, 1).withExplicitAuth(AuthTypeSpire),
+		}),
+		adds: Keys{
+			egressKey(43, 6, 0, 0):   {},
+			egressKey(43, 6, 80, 12): {},
+		},
+		deletes: Keys{},
+	}, {
+		continued: false,
 		name:      "test-6a - L3-only explicit auth type and L4-only without",
 		args: []args{
 			{cs: csFoo, adds: []int{43}, authReq: AuthTypeSpire.AsExplicitRequirement()},
-			{cs: csWildcard, adds: []int{0}, port: 80, proto: 6, redirect: true},
+			{cs: csWildcard, adds: []int{0}, port: 80, proto: 6, redirect: 1},
 		},
 		state: testMapState(mapStateMap{
 			egressKey(43, 0, 0, 0): allowEntry().withExplicitAuth(AuthTypeSpire),
-			egressKey(0, 6, 80, 0): proxyEntry(1),
+			egressKey(0, 6, 80, 0): proxyPriorityEntry(1, 1),
 		}),
 		adds: Keys{
 			egressKey(43, 0, 0, 0): {},
@@ -1358,12 +1479,12 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		continued: false,
 		name:      "test-6b - L3-only explicit auth type and L4-only without - reverse",
 		args: []args{
-			{cs: csWildcard, adds: []int{0}, port: 80, proto: 6, redirect: true},
+			{cs: csWildcard, adds: []int{0}, port: 80, proto: 6, redirect: 1},
 			{cs: csFoo, adds: []int{43}, authReq: AuthTypeSpire.AsExplicitRequirement()},
 		},
 		state: testMapState(mapStateMap{
 			egressKey(43, 0, 0, 0): allowEntry().withExplicitAuth(AuthTypeSpire),
-			egressKey(0, 6, 80, 0): proxyEntry(1),
+			egressKey(0, 6, 80, 0): proxyPriorityEntry(1, 1),
 		}),
 		adds: Keys{
 			egressKey(43, 0, 0, 0): {},
@@ -1375,11 +1496,11 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		name:      "test-7a - L3/proto explicit auth type and L4-only without",
 		args: []args{
 			{cs: csFoo, adds: []int{43}, proto: 6, authReq: AuthTypeSpire.AsExplicitRequirement()},
-			{cs: csWildcard, adds: []int{0}, port: 80, proto: 6, redirect: true},
+			{cs: csWildcard, adds: []int{0}, port: 80, proto: 6, redirect: 1},
 		},
 		state: testMapState(mapStateMap{
 			egressKey(43, 6, 0, 0): allowEntry().withExplicitAuth(AuthTypeSpire),
-			egressKey(0, 6, 80, 0): proxyEntry(1),
+			egressKey(0, 6, 80, 0): proxyPriorityEntry(1, 1),
 		}),
 		adds: Keys{
 			egressKey(43, 6, 0, 0): {},
@@ -1390,12 +1511,12 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		continued: false,
 		name:      "test-7b - L3/proto explicit auth type and L4-only without - reverse",
 		args: []args{
-			{cs: csWildcard, adds: []int{0}, port: 80, proto: 6, redirect: true},
+			{cs: csWildcard, adds: []int{0}, port: 80, proto: 6, redirect: 1},
 			{cs: csFoo, adds: []int{43}, proto: 6, authReq: AuthTypeSpire.AsExplicitRequirement()},
 		},
 		state: testMapState(mapStateMap{
 			egressKey(43, 6, 0, 0): allowEntry().withExplicitAuth(AuthTypeSpire),
-			egressKey(0, 6, 80, 0): proxyEntry(1),
+			egressKey(0, 6, 80, 0): proxyPriorityEntry(1, 1),
 		}),
 		adds: Keys{
 			egressKey(43, 6, 0, 0): {},
@@ -1441,12 +1562,12 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			}
 			adds := x.cs.addSelections(x.adds...)
 			deletes := x.cs.deleteSelections(x.deletes...)
-			key := KeyForDirection(dir).WithPortProto(x.proto, x.port)
+			key := KeyForDirection(dir).WithPortProtoPrefix(x.proto, x.port, x.prefix)
 			var proxyPort uint16
-			if x.redirect {
+			if x.redirect != 0 {
 				proxyPort = 1
 			}
-			value := newMapStateEntry(NilRuleOrigin, proxyPort, 0, x.deny, x.authReq)
+			value := newMapStateEntry(NilRuleOrigin, proxyPort, x.redirect, x.deny, x.authReq)
 			policyMaps.AccumulateMapChanges(adds, deletes, []Key{key}, value)
 		}
 		policyMaps.SyncMapChanges(versioned.LatestTx)

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1282,12 +1282,9 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{cs: csFoo, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 			{cs: csFoo, adds: []int{}, deletes: []int{44}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: emptyMapState(),
-		adds:  Keys{},
-		deletes: Keys{
-			// Delete of the key is recoded as the key may have existed already in the (bpf) map
-			HttpEgressKey(44): {},
-		},
+		state:   emptyMapState(),
+		adds:    Keys{},
+		deletes: Keys{},
 	}, {
 		continued: true,
 		name:      "test-4b - Add, delete, & add; delete suppressed",

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -646,9 +646,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 		ingressKey(192, 6, 80, 0): {},
 		ingressKey(194, 6, 80, 0): {},
 	}, changes.Adds)
-	require.Equal(t, Keys{
-		ingressKey(193, 6, 80, 0): {},
-	}, changes.Deletes)
+	require.Equal(t, Keys{}, changes.Deletes)
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop
 	policy.selectorPolicy.Detach()

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -718,9 +718,7 @@ func TestMapStateWithIngress(t *testing.T) {
 		ingressKey(192, 6, 80, 0): {},
 		ingressKey(194, 6, 80, 0): {},
 	}, changes.Adds)
-	require.Equal(t, Keys{
-		ingressKey(193, 6, 80, 0): {},
-	}, changes.Deletes)
+	require.Equal(t, Keys{}, changes.Deletes)
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.


### PR DESCRIPTION
When covered entries with lower proxy port priority have different explicit auth types, the proxy port (and priority) must be propagated to those entries instead of deleting them. Same applies in reverse, when adding an explicit auth entry the proxy port and priority must be propagated from a covering entry with higher priority proxy port, if any.

Keep the non-auth policy handling simple by branching to authPreferredInsert early, and take care of deny & higher priority proxy port logic in the same loops with the auth propagation. This required changing 'CoveringKeysWithSameID' and 'SubsetKeysWithSameID' to also iterate keys equal to the 'newKey', so that a deny key would not be overridden by an allow key, for example.

Add a new unit test to prevent future regressions.

Fixes: #36056

```release-note
Auth policy is properly maintained also when covered by proxy redirects.
```
