### PR TITLE
cilium-cli: Fix GITHUB_WORKFLOW_REF parsing

### DIFF
--- a/cilium-cli/connectivity/check/logging.go
+++ b/cilium-cli/connectivity/check/logging.go
@@ -128,8 +128,9 @@ func (ct *ConnectivityTest) LogOwners(scenario ownedScenario) {
 	var workflowOwners []codeowners.Owner
 	// Example: cilium/cilium/.github/workflows/conformance-kind-proxy-embedded.yaml@refs/pull/37593/merge
 	ghWorkflow := os.Getenv("GITHUB_WORKFLOW_REF")
-	ghWorkflow = strings.TrimPrefix(ghWorkflow, "cilium/cilium/")
 	ghWorkflow, _, _ = strings.Cut(ghWorkflow, "@")
+	segments := strings.Split(ghWorkflow, "/")
+	ghWorkflow = strings.Join(segments[2:], "/")
 	if ghWorkflow != "" {
 		workflowRule, err := ct.CodeOwners.Match(ghWorkflow)
 		if err != nil || workflowRule == nil || workflowRule.Owners == nil {


### PR DESCRIPTION
Always trim the name/repo from GITHUB_WORKFLOW_REF, regardless of which
target GitHub repo location it is. This should fix attribution when
using this tooling outside of cilium/cilium.

Fixes: d877fe367515 ("cilium-cli: Autodetect owners for GitHub workflows")
