### PR TITLE
Revert "cli: Use error def of github.com/cilium/ebpf"

### DIFF
--- a/cilium-cli/connectivity/tests/multicast.go
+++ b/cilium-cli/connectivity/tests/multicast.go
@@ -14,8 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/cilium/ebpf"
-
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node/addressing"
@@ -26,6 +24,8 @@ import (
 )
 
 const (
+	notExistMsg          = "does not exist"
+	alreadyExistMsg      = "already exists"
 	testMulticastGroupIP = "239.255.9.9"
 	testSocatPort        = 6666
 )
@@ -266,7 +266,7 @@ func (s *socatMulticast) addAllNodes(ctx context.Context, t *check.Test) error {
 			cmd := []string{"cilium-dbg", "bpf", "multicast", "subscriber", "list", testMulticastGroupIP}
 			_, stdErr, err := client.ExecInPodWithStderr(ctx, pod.Namespace, pod.Name, defaults.AgentContainerName, cmd)
 			if err != nil {
-				if !strings.Contains(stdErr.String(), ebpf.ErrKeyNotExist.Error()) {
+				if !strings.Contains(stdErr.String(), notExistMsg) {
 					errMsg := fmt.Sprintf("Error: %v, Stderr: %s", err, stdErr.String())
 					errCh <- errors.New(errMsg)
 					t.Fatalf("Fatal error occurred while checking multicast group %s in %s", testMulticastGroupIP, pod.Spec.NodeName)
@@ -289,7 +289,7 @@ func (s *socatMulticast) addAllNodes(ctx context.Context, t *check.Test) error {
 					_, stdErr, err := client.ExecInPodWithStderr(ctx, pod.Namespace, pod.Name, defaults.AgentContainerName, cmd)
 					if err == nil {
 						s.addNotSubscribePodAddress(pod.Spec.NodeName, ip)
-					} else if !strings.Contains(stdErr.String(), ebpf.ErrKeyExist.Error()) {
+					} else if !strings.Contains(stdErr.String(), alreadyExistMsg) {
 						errMsg := fmt.Sprintf("Error: %v, Stderr: %s", err, stdErr.String())
 						errCh <- errors.New(errMsg)
 						t.Fatalf("Fatal error occurred while adding node %s to multicast group %s in %s", ip.IP, testMulticastGroupIP, pod.Spec.NodeName)
@@ -327,7 +327,7 @@ func (s *socatMulticast) delGroup(ctx context.Context, t *check.Test, nodeName s
 			cmd := []string{"cilium-dbg", "bpf", "multicast", "group", "delete", testMulticastGroupIP}
 			_, stdErr, err := client.ExecInPodWithStderr(ctx, ciliumPod.Namespace, ciliumPod.Name, defaults.AgentContainerName, cmd)
 			if err != nil {
-				if !strings.Contains(stdErr.String(), ebpf.ErrKeyNotExist.Error()) {
+				if !strings.Contains(stdErr.String(), notExistMsg) {
 					errMsg := fmt.Sprintf("Error: %v while deleting Multicast Group for test %s, Stderr: %s", err, testMulticastGroupIP, stdErr.String())
 					return errors.New(errMsg)
 				}
@@ -354,7 +354,7 @@ func (s *socatMulticast) delSubscriber(ctx context.Context, t *check.Test, nodeN
 			cmd := []string{"cilium-dbg", "bpf", "multicast", "subscriber", "delete", testMulticastGroupIP, subscriberIP}
 			_, stdErr, err := client.ExecInPodWithStderr(ctx, ciliumPod.Namespace, ciliumPod.Name, defaults.AgentContainerName, cmd)
 			if err != nil {
-				if !strings.Contains(stdErr.String(), ebpf.ErrKeyNotExist.Error()) {
+				if !strings.Contains(stdErr.String(), notExistMsg) {
 					errMsg := fmt.Sprintf("Error: %v while removing %s from Multicast Group %s Stderr: %s", err, subscriberIP, testMulticastGroupIP, stdErr.String())
 					return errors.New(errMsg)
 				}


### PR DESCRIPTION
This reverts commit 1037713bbc10e88d8258e542e59c829e5579a6e9.

The commit was fine and well-intentioned, but it introduced a hard
dependency from the CLI onto cilium/ebpf library. The CLI is intended as
a tool to run on user systems, not the target system. Introducing a
dependency on libraries that directly interface with ebpf causes trouble
because it means that cilium/ebpf must stub out all declarations on all
platforms, even ones that don't make sense because the platform doesn't
have ebpf support.

So, rather than depending on this library just to do some substring
matches, just retain the copies of the strings in the CLI and make the
comparisons without the library.

Related: https://github.com/cilium/cilium/issues/37598