### PR TITLE
contrib: Reuse local build caches for builder.sh

### DIFF
--- a/contrib/scripts/builder.sh
+++ b/contrib/scripts/builder.sh
@@ -8,18 +8,20 @@ CILIUM_BUILDER_IMAGE=$(cat images/cilium/Dockerfile | grep '^ARG CILIUM_BUILDER_
 RUN_AS_NONROOT="${RUN_AS_NONROOT:-1}"
 
 USER_OPTION=""
+USER_PATH="/root"
 
 if [ -n "${RUN_AS_NONROOT:-}" ]; then
     USER_OPTION="--user $(id -u):$(id -g)"
+    USER_PATH="$HOME"
 fi
 
-MOUNT_GOCACHE_DIR=""
+MOUNT_GOCACHE_DIR="-v $(go env GOCACHE):$(go env GOCACHE)"
 
 if [ -n "${BUILDER_GOCACHE_DIR:-}" ]; then
-    MOUNT_GOCACHE_DIR="-v ${BUILDER_GOCACHE_DIR}:/root/.cache/go-build"
+    MOUNT_GOCACHE_DIR="-v ${BUILDER_GOCACHE_DIR}:${USER_PATH}/.cache/go-build"
 fi
 
-MOUNT_GOMODCACHE_DIR=""
+MOUNT_GOMODCACHE_DIR="-v $(go env GOMODCACHE):$(go env GOMODCACHE)"
 
 if [ -n "${BUILDER_GOMODCACHE_DIR:-}" ]; then
     MOUNT_GOMODCACHE_DIR="-v ${BUILDER_GOMODCACHE_DIR}:/go/pkg/mod"
@@ -27,8 +29,10 @@ fi
 
 MOUNT_CCACHE_DIR=""
 
-if [ -n "${BUILDER_CCACHE_DIR:-}" ]; then
-    MOUNT_CCACHE_DIR="-v ${BUILDER_CCACHE_DIR}:/root/.ccache"
+if [ -z "${BUILDER_CCACHE_DIR:-}" ]; then
+    MOUNT_CCACHE_DIR="-v ${USER_PATH}/.ccache:${USER_PATH}/.ccache"
+else
+    MOUNT_CCACHE_DIR="-v ${BUILDER_CCACHE_DIR}:${USER_PATH}/.ccache"
 fi
 
 docker run --rm \

--- a/contrib/scripts/builder.sh
+++ b/contrib/scripts/builder.sh
@@ -5,6 +5,7 @@ set -eu
 cd "$(dirname "$0")/../.."
 
 CILIUM_BUILDER_IMAGE=$(cat images/cilium/Dockerfile | grep '^ARG CILIUM_BUILDER_IMAGE=' | cut -d '=' -f 2)
+RUN_AS_NONROOT="${RUN_AS_NONROOT:-1}"
 
 USER_OPTION=""
 


### PR DESCRIPTION
The builder script here was ignoring local go build caches even when
available. The result is that attempting to update the command reference
in the docs via `make -C Documentation update-cmdref` could take dozens
of minutes because it would recreate all Go caches each time you run the
command.

CI should already be specifying the cache directories, but for all other
cases (such as running the script locally), attempt to reuse locally
available caches.

There's also no hard requirement to run this as root, avoid root by default.

