### PR TITLE
cli/connectivity: Don't run conn-disrupt in case of kpf=false+np=true

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1319,5 +1319,8 @@ func (ct *ConnectivityTest) ShouldRunConnDisruptNSTraffic() bool {
 		ct.Features[features.NodeWithoutCilium].Enabled &&
 		(ct.Params().MultiCluster == "" || ct.Features[features.KPRNodePort].Enabled) &&
 		!ct.Features[features.KPRNodePortAcceleration].Enabled &&
-		(!ct.Features[features.IPsecEnabled].Enabled || !ct.Features[features.KPRNodePort].Enabled)
+		(!ct.Features[features.IPsecEnabled].Enabled || !ct.Features[features.KPRNodePort].Enabled) &&
+		// v1.18 is going to remove KPR sub-flags, and thus in the case kpr=false+nodeport=true
+		// N/S will be handled by kube-proxy. The upgrade to v1.18 will cause N/S flow interruptions.
+		!(!ct.Features[features.KPRMode].Enabled && ct.Features[features.KPRNodePort].Enabled)
 }


### PR DESCRIPTION
We are planning to remove the KPR sub-flags in v1.18. In the case of --kube-proxy-replacement=false & --enable-node-port=true, the upgrade will cause N/S NodePort flows to be interrupted, as their handling will switch from Cilium's nodeport.h to kube-proxy's iptables.

Skip the test for such configurations.

cc @ysksuzuki @julianwiedmann 