### PR TITLE
bugtool: document removal of k8s-mode in upgrade guide

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -331,6 +331,9 @@ Agent Options
 Bugtool Options
 ~~~~~~~~~~~~~~~
 
+* The deprecated flag ``k8s-mode`` (and related flags ``cilium-agent-container-name``, ``k8s-namespace`` & ``k8s-label``)
+  have been removed. Cilium CLI should be used to gather a sysdump from a K8s cluster.
+
 
 Added Metrics
 ~~~~~~~~~~~~~


### PR DESCRIPTION
The deprecated k8s-mode (and its related flags) have been removed with https://github.com/cilium/cilium/pull/36632.

This commit documents the removal in the upgrade guide for Cilium release v1.18.

v1.17 deprecation PR: https://github.com/cilium/cilium/pull/35689
v1.18 removal PR (main): https://github.com/cilium/cilium/pull/36632