### PR TITLE
helm: allow to disable hubble

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -923,9 +923,8 @@ data:
   operator-api-serve-addr: {{ $defaultOperatorApiServeAddr | quote }}
 {{- end }}
 
-{{- if .Values.hubble.enabled }}
-  # Enable Hubble gRPC service.
   enable-hubble: {{ .Values.hubble.enabled | quote }}
+{{- if .Values.hubble.enabled }}
   # UNIX domain socket for Hubble server to listen to.
   hubble-socket-path: {{ .Values.hubble.socketPath | quote }}
 {{- if hasKey .Values.hubble "eventQueueSize" }}


### PR DESCRIPTION
Before this patch, the Helm charts would never render

    enable-hubble: false

in the Cilium configmap. This was not an issue before v1.17 since `--enable-hubble=false` was the default at the cilium agent flag level. The Hubble Hive refactor made Hubble enabled by default in the Cilium agent to reflect the Helm default value, but missed the Helm template logic.

This patch render the enabled-hubble agent flag unconditionally in the configmap regardless of its value.

```release-note
always render enable-hubble in the Cilium configmap
```
