### PR TITLE
ci-aks: Enable dual-stack in Conformance AKS

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -195,12 +195,17 @@ jobs:
             OWNER="${OWNER//[.\/]/-}"
           fi
 
+          # We explicity set the cluster-pool Pod CIDR here to not clash with the AKS default Service CIDRs
+          # which are 10.0.0.0/16 and fd12:3456:789a:1::/108
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set cluster.name=${{ env.name }} \
             --helm-set loadBalancer.l7.backend=envoy \
             --helm-set tls.secretsBackend=k8s \
             --helm-set=azure.resourceGroup=${{ env.name }} \
-            --helm-set ipam.operator.clusterPoolIPv4PodCIDRList=192.168.0.0/16" # To avoid clashing with the default Service CIDR of AKS (10.0.0.0/16)
+            --helm-set=ipv4.enabled=true \
+            --helm-set=ipv6.enabled=true \
+            --helm-set ipam.operator.clusterPoolIPv4PodCIDRList=192.168.0.0/16 \
+            --helm-set ipam.operator.clusterPoolIPv6PodCIDRList=fd00::/104"
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled \
             --hubble=false --collect-sysdump-on-failure --external-target bing.com. --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8"
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
@@ -229,6 +234,7 @@ jobs:
             --kubernetes-version ${{ matrix.version }} \
             --network-plugin none \
             --node-count 2 \
+            --ip-families ipv4,ipv6 \
             ${{ env.cost_reduction }} \
             --generate-ssh-keys
 

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -61,6 +61,7 @@ concurrency:
 env:
   name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   cost_reduction: --node-vm-size Standard_B2s --node-osdisk-size 30
+  test_concurrency: 5
 
 jobs:
   echo-inputs:
@@ -287,10 +288,20 @@ jobs:
         run: |
           mkdir -p cilium-junits
 
-      - name: Run connectivity test (${{ join(matrix.*, ', ') }})
+      - name: Run sequential connectivity test (${{ join(matrix.*, ', ') }})
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
           --log-code-owners \
+          --test "seq-.*" \
+          --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1.xml" \
+          --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
+
+      - name: Run concurrent connectivity test (${{ join(matrix.*, ', ') }})
+        run: |
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --log-code-owners \
+          --test-concurrency=${{ env.test_concurrency }} \
+          --test "!seq-.*" \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1.xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
@@ -322,10 +333,20 @@ jobs:
         run: |
           cilium status --wait --interactive=false --wait-duration=10m
 
-      - name: Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})
+      - name: Run sequential connectivity test with IPSec (${{ join(matrix.*, ', ') }})
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
           --log-code-owners \
+          --test "seq-.*" \
+          --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 2.xml" \
+          --junit-property github_job_step="Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})"
+
+      - name: Run concurrent connectivity test with IPSec (${{ join(matrix.*, ', ') }})
+        run: |
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
+          --log-code-owners \
+          --test-concurrency=${{ env.test_concurrency }} \
+          --test "!seq-.*" \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 2.xml" \
           --junit-property github_job_step="Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})"
 


### PR DESCRIPTION
This commit enables dual-stack in both the created AKS cluster as well as in Cilium CNI. This ensures that we are testing BYOCNI with dual-stack, which is a supported configuration after all.

- [x] Verified that IPv6 Tests are running by inspecting cilium CLI debug logs ([logs_34548161447.zip](https://github.com/user-attachments/files/18865414/logs_34548161447.zip)) and sysdump ([cilium-sysdumps.zip](https://github.com/user-attachments/files/18865590/cilium-sysdumps.zip))
- [x] Enabled concurrent `cilium connectivity test` which reduces the overall dual-stack connectivity test from 25mins to 7-10mins. Before this PR, sequential IPv4 tests took about 15-20mins:

   - [IPv4-only sequential (before this PR)](https://github.com/cilium/cilium/actions/runs/13394833262/job/37411712273):
   ![image](https://github.com/user-attachments/assets/7c8cc92e-bfbd-4dd4-a5fd-54434744fad7)
   - [Dual-Stack sequential (only first commit of  this PR)](https://github.com/cilium/cilium/actions/runs/13390597115/job/37397280550):
   ![image](https://github.com/user-attachments/assets/895523a4-dad7-4508-8afd-a1e8d41b0627)
   - [Dual-Stack concurrent (both commits of this PR)](https://github.com/cilium/cilium/actions/runs/13395710793/job/37415052673):
   ![image](https://github.com/user-attachments/assets/969d8f62-49a5-4330-9cda-0740089ac962)


Fixes: cilium/cilium#37142
