### PR TITLE
experimental: ServiceCache/ServiceManager adapters, LocalRedirectPolicy support

### DIFF
--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -162,6 +162,20 @@ jobs:
         run: |
           cilium install --wait ${{ steps.vars.outputs.cilium_install_defaults }}
 
+      - name: Create LB IPAM pool
+        run: |
+          # Needed so that Cilium can allocate LoadBalancer service IPs
+          # needed for the tests
+          kubectl apply -f - <<EOF
+          apiVersion: "cilium.io/v2alpha1"
+          kind: CiliumLoadBalancerIPPool
+          metadata:
+            name: "test-lb-pool"
+          spec:
+            blocks:
+            - cidr: "10.0.10.0/24"
+          EOF
+
       - name: Run Kubernetes sig-network test
         run: |
           # output_dir

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/l2announcer"
 	loadbalancer_experimental "github.com/cilium/cilium/pkg/loadbalancer/experimental"
+	redirectpolicy_experimental "github.com/cilium/cilium/pkg/loadbalancer/experimental/redirectpolicy"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
@@ -205,6 +206,9 @@ var (
 
 		// Experimental control-plane for configuring service load-balancing.
 		loadbalancer_experimental.Cell,
+
+		// Experimental control-plane implementation for local redirect policies.
+		redirectpolicy_experimental.Cell,
 
 		// Service is a datapath service handler. Its main responsibility is to reflect
 		// service-related changes into BPF maps used by datapath BPF programs.

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -52,6 +52,7 @@ import (
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maglev"
@@ -186,6 +187,8 @@ type Daemon struct {
 	lrpManager   *redirectpolicy.Manager
 	ctMapGC      ctmap.GCRunner
 	maglevConfig maglev.Config
+
+	explbConfig experimental.Config
 }
 
 // GetPolicyRepository returns the policy repository of the daemon
@@ -402,6 +405,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		ctMapGC:           params.CTNATMapGC,
 		maglevConfig:      params.MaglevConfig,
 		dnsNameManager:    params.NameManager,
+		explbConfig:       params.ExpLBConfig,
 	}
 
 	// initialize endpointRestoreComplete channel as soon as possible so that subsystems

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -75,6 +75,7 @@ import (
 	"github.com/cilium/cilium/pkg/l2announcer"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
+	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
 	"github.com/cilium/cilium/pkg/loadinfo"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -1580,6 +1581,7 @@ type daemonParams struct {
 	LRPManager          *redirectpolicy.Manager
 	MaglevConfig        maglev.Config
 	NameManager         namemanager.NameManager
+	ExpLBConfig         experimental.Config
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/labelsfilter"
+	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
@@ -135,6 +136,9 @@ func setupDaemonSuite(tb testing.TB) *DaemonSuite {
 			func() cnicell.CNIConfigManager { return &fakecni.FakeCNIConfigManager{} },
 			func() ctmap.GCRunner { return ctmap.NewFakeGCRunner() },
 			k8sSynced.RejectedCRDSyncPromise,
+			func() *experimental.TestConfig {
+				return &experimental.TestConfig{}
+			},
 		),
 		fakeDatapath.Cell,
 		prefilter.Cell,

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -292,8 +292,9 @@ func (d *Daemon) initMaps() error {
 		}
 	}
 
-	if option.Config.NodePortAlg == option.NodePortAlgMaglev ||
-		option.Config.LoadBalancerAlgorithmAnnotation {
+	if !d.explbConfig.EnableExperimentalLB &&
+		(option.Config.NodePortAlg == option.NodePortAlgMaglev ||
+			option.Config.LoadBalancerAlgorithmAnnotation) {
 		if err := lbmap.InitMaglevMaps(option.Config.EnableIPv4, option.Config.EnableIPv6, uint32(d.maglevConfig.MaglevTableSize)); err != nil {
 			return fmt.Errorf("initializing maglev maps: %w", err)
 		}

--- a/daemon/k8s/pods.go
+++ b/daemon/k8s/pods.go
@@ -35,6 +35,7 @@ type LocalPod struct {
 func (p LocalPod) TableHeader() []string {
 	return []string{
 		"Name",
+		"UID",
 		"HostNetwork",
 		"PodIPs",
 		"Containers",
@@ -66,6 +67,7 @@ func (p LocalPod) TableRow() []string {
 	}
 	return []string{
 		p.Namespace + "/" + p.Name,
+		string(p.UID),
 		strconv.FormatBool(p.Spec.HostNetwork),
 		strings.Join(podIPs, ", "),
 		strings.Join(containers, ", "),

--- a/pkg/ciliumenvoyconfig/exp_controller.go
+++ b/pkg/ciliumenvoyconfig/exp_controller.go
@@ -17,21 +17,16 @@ import (
 	envoy_config_core "github.com/cilium/proxy/go/envoy/config/core/v3"
 	envoy_config_endpoint "github.com/cilium/proxy/go/envoy/config/endpoint/v3"
 	"github.com/cilium/statedb"
-	"github.com/cilium/statedb/part"
 	"github.com/cilium/statedb/reconciler"
 	"github.com/cilium/stream"
-	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/cilium/cilium/pkg/envoy"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
 	"github.com/cilium/cilium/pkg/node"
-	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -43,32 +38,18 @@ type cecControllerParams struct {
 	Log            *slog.Logger
 	ExpConfig      experimental.Config
 	LocalNodeStore *node.LocalNodeStore
+	Metrics        experimentalMetrics
 
-	NodeLabels    *nodeLabels
-	CECs          statedb.RWTable[*CEC]
-	EnvoySyncer   resourceMutator
-	PolicyTrigger policyTrigger
-}
-
-type resourceMutator interface {
-	DeleteEnvoyResources(context.Context, envoy.Resources) error
-	UpdateEnvoyResources(context.Context, envoy.Resources, envoy.Resources) error
-}
-
-type policyTrigger interface {
-	TriggerPolicyUpdates()
+	NodeLabels     *nodeLabels
+	CECs           statedb.RWTable[*CEC]
+	EnvoyResources statedb.RWTable[*EnvoyResource]
+	Writer         *experimental.Writer
+	Services       statedb.Table[*experimental.Service]
+	Backends       statedb.Table[*experimental.Backend]
 }
 
 type cecController struct {
-	params cecControllerParams
-	writer *experimental.Writer
-}
-
-type cecControllerOut struct {
-	cell.Out
-
-	C    *cecController
-	Hook experimental.ServiceHook `group:"service-hooks"`
+	cecControllerParams
 }
 
 func newNodeLabels() *nodeLabels {
@@ -78,156 +59,32 @@ func newNodeLabels() *nodeLabels {
 	return nl
 }
 
-func newCECController(params cecControllerParams) cecControllerOut {
+func registerCECController(params cecControllerParams) {
 	if !params.ExpConfig.EnableExperimentalLB {
-		return cecControllerOut{}
+		return
 	}
 
-	c := &cecController{params, nil}
-	params.JobGroup.Add(job.OneShot("proxy-redirect-controller", c.proxyRedirectController))
-	params.JobGroup.Add(job.OneShot("backends-controller", c.backendController))
+	c := &cecController{
+		cecControllerParams: params,
+	}
 	params.JobGroup.Add(job.OneShot("node-label-controller", c.nodeLabelController))
-	return cecControllerOut{
-		C:    c,
-		Hook: c.onServiceUpsert,
-	}
-}
-
-func (c *cecController) setWriter(w *experimental.Writer) {
-	if c != nil {
-		c.writer = w
-	}
-}
-
-// proxyRedirectController watches for changed CECs and updates the proxy redirect in services.
-func (c *cecController) proxyRedirectController(ctx context.Context, health cell.Health) error {
-	wtxn := c.params.DB.WriteTxn(c.params.CECs)
-	changeIter, err := c.params.CECs.Changes(wtxn)
-	wtxn.Commit()
-	if err != nil {
-		return err
-	}
-
-	svcs := c.writer.Services()
-	limiter := rate.NewLimiter(50*time.Millisecond, 3)
-	listeners := part.Set[uint16]{}
-
-	for {
-		wtxn := c.writer.WriteTxn()
-		changes, watch := changeIter.Next(wtxn)
-		oldListeners := listeners
-		for change := range changes {
-			cec := change.Object
-			if !change.Deleted && cec.Status.Kind != reconciler.StatusKindDone {
-				// Only process the CEC once it has been reconciled towards Envoy to avoid
-				// setting redirects before Envoy is ready.
-				continue
-			}
-
-			for _, port := range cec.Listeners.All() {
-				if change.Deleted {
-					listeners = listeners.Delete(port)
-				} else {
-					listeners = listeners.Set(port)
-				}
-			}
-
-			for _, svcl := range cec.Spec.Services {
-				svc, _, found := svcs.Get(wtxn, experimental.ServiceByName(svcl.ServiceName()))
-				if found && (change.Deleted || !getProxyRedirect(cec, svcl).Equal(svc.ProxyRedirect)) {
-					// Do an upsert to call into onServiceUpsert() to update the L7ProxyPort.
-					c.writer.UpsertService(wtxn, svc.Clone())
-				}
-			}
-		}
-		wtxn.Commit()
-
-		// When listeners change trigger the policy updates.
-		if !oldListeners.Equal(listeners) {
-			// TODO: Policy does not need to be recomputed for this, but if we do not 'force'
-			// the bpf maps are not updated with the new proxy ports either. Move from the
-			// simple boolean to an enum that can more selectively skip regeneration steps (like
-			// we do for the datapath recompilations already?)
-			c.params.PolicyTrigger.TriggerPolicyUpdates()
-		}
-
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-watch:
-		}
-
-		if err := limiter.Wait(ctx); err != nil {
-			return err
-		}
-	}
-}
-
-// backendController watches the frontends (that are associated with backends) for changes
-// and recomputes the endpoints resource. Frontends are watched as the services in CiliumEnvoyConfig
-// can specify frontend ports to filter by.
-func (c *cecController) backendController(ctx context.Context, health cell.Health) error {
-	frontends := c.writer.Frontends()
-	wtxn := c.params.DB.WriteTxn(frontends)
-	changeIter, err := c.writer.Frontends().Changes(wtxn)
-	wtxn.Commit()
-	if err != nil {
-		return err
-	}
-
-	limiter := rate.NewLimiter(50*time.Millisecond, 3)
-
-	for {
-		// Iterate over the changes to collect the services that reference changed backends.
-		wtxn := c.params.DB.WriteTxn(c.params.CECs)
-		services := sets.New[loadbalancer.ServiceName]()
-		changes, watch := changeIter.Next(wtxn)
-		for change := range changes {
-			services.Insert(change.Object.ServiceName)
-		}
-
-		// Find all CECs that reference those services and recompute their backends.
-		visited := sets.New[CECName]()
-		for serviceName := range services {
-			for cec := range c.params.CECs.List(wtxn, CECByServiceName(serviceName)) {
-				if visited.Has(cec.Name) {
-					continue
-				}
-				visited.Insert(cec.Name)
-				cec = cec.Clone()
-				if updateBackends(cec, wtxn, frontends) {
-					c.params.CECs.Insert(wtxn, cec)
-				}
-			}
-		}
-		wtxn.Commit()
-
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-watch:
-		}
-
-		if err := limiter.Wait(ctx); err != nil {
-			return err
-		}
-	}
+	params.JobGroup.Add(job.OneShot("resources-controller", c.processLoop))
 }
 
 // nodeLabelController updates the [SelectsLocalNode] when node labels change.
 func (c *cecController) nodeLabelController(ctx context.Context, health cell.Health) error {
-	localNodeChanges := stream.ToChannel(ctx, c.params.LocalNodeStore)
+	localNodeChanges := stream.ToChannel(ctx, c.LocalNodeStore)
 
 	for localNode := range localNodeChanges {
 		newLabels := localNode.Labels
-		oldLabels := *c.params.NodeLabels.Load()
+		oldLabels := *c.NodeLabels.Load()
 
 		if !maps.Equal(newLabels, oldLabels) {
-			c.params.Log.Debug("Labels changed", "old", oldLabels, "new", newLabels)
+			c.Log.Debug("Labels changed", "old", oldLabels, "new", newLabels)
 
 			// Since the labels changed, recompute 'SelectsLocalNode'
 			// for all CECs.
-			wtxn := c.params.DB.WriteTxn(c.params.CECs)
+			wtxn := c.DB.WriteTxn(c.CECs)
 
 			// Store the new labels so the reflector can compute 'SelectsLocalNode'
 			// on the fly. The reflector may already update 'SelectsLocalNode' to the
@@ -238,16 +95,15 @@ func (c *cecController) nodeLabelController(ctx context.Context, health cell.Hea
 			// this can be removed and we can instead read the labels directly from the node
 			// table.
 			labelSet := labels.Set(newLabels)
-			c.params.NodeLabels.Store(&newLabels)
+			c.NodeLabels.Store(&newLabels)
 
-			for cec := range c.params.CECs.All(wtxn) {
+			for cec := range c.CECs.All(wtxn) {
 				if cec.Selector != nil {
 					selects := cec.Selector.Matches(labelSet)
 					if selects != cec.SelectsLocalNode {
 						cec = cec.Clone()
 						cec.SelectsLocalNode = selects
-						cec.Status = reconciler.StatusPending()
-						c.params.CECs.Insert(wtxn, cec)
+						c.CECs.Insert(wtxn, cec)
 					}
 				}
 			}
@@ -257,87 +113,253 @@ func (c *cecController) nodeLabelController(ctx context.Context, health cell.Hea
 	return nil
 }
 
-// updateBackends recomputes the endpoint resources. Returns true if updated.
-func updateBackends(cec *CEC, txn statedb.ReadTxn, fes statedb.Table[*experimental.Frontend]) bool {
-	revision := fes.Revision(txn)
-	if cec.FrontendsRevision > revision {
-		// Already computed with a newer revision. This is used to coordinate between
-		// the reflector and the backend controller.
-		return false
+func getProxyRedirect(cec *CEC, svcl *ciliumv2.ServiceListener) *experimental.ProxyRedirect {
+	var port uint16
+	if svcl.Listener != "" {
+		// Listener names are qualified after parsing, so qualify the listener reference as well for it to match
+		svcListener, _ := api.ResourceQualifiedName(
+			cec.Name.Namespace, cec.Name.Name, svcl.Listener, api.ForceNamespace)
+		port, _ = cec.Listeners.Get(svcListener)
+	} else {
+		for _, p := range cec.Listeners.All() {
+			port = p
+			break
+		}
 	}
-	cec.FrontendsRevision = revision
+	if port == 0 {
+		return nil
+	}
+	return &experimental.ProxyRedirect{
+		ProxyPort: port,
+		Ports:     svcl.Ports,
+	}
+}
 
-	services := map[loadbalancer.ServiceName]sets.Set[string]{}
+func (c *cecController) processLoop(ctx context.Context, health cell.Health) error {
+	watchSets := map[CECName]*statedb.WatchSet{}
+	var closedWatches []<-chan struct{}
+	orphans := sets.New[CECName]()
+
+	for {
+		t0 := time.Now()
+		wtxn := c.DB.WriteTxn(c.EnvoyResources)
+
+		// Process all Cilium(ClusterWide)EnvoyConfigs to compute the new EnvoyResources.
+		// We use the [statedb.WatchSet] to figure out which things to recompute. If any
+		// of the queries made for a particular CEC changes we recompute the Envoy resources
+		// for it.
+		allWatches := statedb.NewWatchSet()
+
+		cecs, watch := c.CECs.AllWatch(wtxn)
+		allWatches.Add(watch)
+		existing := sets.New[CECName]()
+		for cec := range cecs {
+			if !cec.SelectsLocalNode {
+				continue
+			}
+
+			existing.Insert(cec.Name)
+			orphans.Delete(cec.Name)
+
+			if ws, found := watchSets[cec.Name]; found {
+				if !ws.HasAny(closedWatches) {
+					// Queries related to this CEC did not change, skip.
+					allWatches.Merge(ws)
+					continue
+				}
+			}
+			watchSet := c.processCEC(wtxn, cec.Name)
+			if watchSet != nil {
+				allWatches.Merge(watchSet)
+				watchSets[cec.Name] = watchSet
+			}
+		}
+
+		// Remove orphaned envoy resources.
+		for orphan := range orphans {
+			c.EnvoyResources.Delete(wtxn, &EnvoyResource{Name: orphan})
+			delete(watchSets, orphan)
+		}
+		wtxn.Commit()
+
+		orphans = existing
+
+		c.Metrics.ControllerDuration.Observe(float64(time.Since(t0)) / float64(time.Second))
+
+		// Wait for any of the queries we made to invalidate before
+		// recomputing again. [allWatches] is cleared by Wait().
+		var err error
+		closedWatches, err = allWatches.Wait(ctx, 100*time.Millisecond)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (c *cecController) processCEC(wtxn statedb.WriteTxn, cecName CECName) *statedb.WatchSet {
+	cec, _, watch, found := c.CECs.GetWatch(wtxn, CECByName(cecName))
+	if !found {
+		return nil
+	}
+	ws := statedb.NewWatchSet()
+	ws.Add(watch)
+
+	assignments := map[string]*envoy_config_endpoint.ClusterLoadAssignment{}
+	redirects := c.specToAssignmentsAndRedirects(
+		wtxn,
+		ws,
+		cec,
+		assignments,
+	)
+
+	// Shallow copy of Resources is enough as we just set the Endpoints field.
+	resources := cec.Resources
+
+	resources.Endpoints = make([]*envoy_config_endpoint.ClusterLoadAssignment, 0, len(assignments))
+	for _, key := range slices.Sorted(maps.Keys(assignments)) {
+		resources.Endpoints = append(resources.Endpoints, assignments[key])
+	}
+
+	c.EnvoyResources.Modify(
+		wtxn,
+		&EnvoyResource{
+			Name:      cec.Name,
+			Resources: resources,
+			Redirects: redirects,
+			Status:    reconciler.StatusPending(),
+		},
+		func(old, new *EnvoyResource) *EnvoyResource {
+			if old != nil {
+				new.ReconciledResources = old.ReconciledResources
+				new.ReconciledRedirects = old.ReconciledRedirects
+			}
+			return new
+		},
+	)
+
+	// Return the watch set. When any of the channels in the set closes we will
+	// reprocess this CEC.
+	return ws
+}
+
+func (c *cecController) specToAssignmentsAndRedirects(
+	txn statedb.ReadTxn,
+	ws *statedb.WatchSet,
+	cec *CEC,
+	assignments map[string]*envoy_config_endpoint.ClusterLoadAssignment,
+) map[loadbalancer.ServiceName]*experimental.ProxyRedirect {
+	redirects := map[loadbalancer.ServiceName]*experimental.ProxyRedirect{}
+	servicePorts := map[loadbalancer.ServiceName]sets.Set[string]{}
+
 	for _, l := range cec.Spec.Services {
-		name := l.ServiceName()
-		ports := services[name]
+		ports := servicePorts[l.ServiceName()]
 		if ports == nil {
 			ports = sets.New[string]()
-			services[name] = ports
+			servicePorts[l.ServiceName()] = ports
 		}
 		for _, p := range l.Ports {
 			ports.Insert(strconv.Itoa(int(p)))
 		}
+		redirects[l.ServiceName()] = getProxyRedirect(cec, l)
 	}
+
 	for _, l := range cec.Spec.BackendServices {
-		name := l.ServiceName()
-		ports := services[name]
+		ports := servicePorts[l.ServiceName()]
 		if ports == nil {
 			ports = sets.New[string]()
-			services[name] = ports
+			servicePorts[l.ServiceName()] = ports
 		}
 		for _, p := range l.Ports {
 			ports.Insert(p)
 		}
 	}
-	assignments := []*envoy_config_endpoint.ClusterLoadAssignment{}
-	for svc, ports := range services {
-		assignments = append(
+
+	for name, ports := range servicePorts {
+		svc, _, watchSvc, found := c.Services.GetWatch(txn, experimental.ServiceByName(name))
+		ws.Add(watchSvc)
+		if !found {
+			continue
+		}
+		bes, watchBes := c.Backends.ListWatch(txn, experimental.BackendByServiceName(svc.Name))
+		ws.Add(watchBes)
+
+		computeLoadAssignments(
 			assignments,
-			backendsToLoadAssignments(
-				svc,
-				ports,
-				fes.List(txn, experimental.FrontendByServiceName(svc)))...)
+			svc.Name,
+			ports,
+			svc.PortNames,
+			bes)
 	}
-	if assignmentsEqual(cec.Resources.Endpoints, assignments) {
-		return false
-	}
-	cec.Resources.Endpoints = assignments
-	cec.Status = reconciler.StatusPending()
-	return true
+
+	return redirects
 }
 
-func backendsToLoadAssignments(
+func computeLoadAssignments(
+	assignments map[string]*envoy_config_endpoint.ClusterLoadAssignment,
 	serviceName loadbalancer.ServiceName,
 	ports sets.Set[string],
-	frontends iter.Seq2[*experimental.Frontend, statedb.Revision]) []*envoy_config_endpoint.ClusterLoadAssignment {
-	var endpoints []*envoy_config_endpoint.ClusterLoadAssignment
-
+	portNames map[string]uint16,
+	backends iter.Seq2[*experimental.Backend, statedb.Revision],
+) {
 	// Partition backends by port name.
-	backendMap := map[string]map[string]experimental.BackendParams{}
-	backendMap[anyPort] = nil
-	for fe := range frontends {
-		portName := anyPort
-		// If ports are specified, only pick frontends with matching port or port name.
+	backendMap := map[string]map[string]*experimental.Backend{}
+
+	for be := range backends {
+		inst := be.GetInstance(serviceName)
+		if inst.State != loadbalancer.BackendStateActive {
+			// FIXME: should use the control-plane logic for picking the backends,
+			// e.g. if all terminating then all active and so on. Since we must support
+			// headless services we can't go via [Frontend.Backends] and must produce
+			// that list of backends separately.
+			continue
+		}
+
+		bePortNames := []string{anyPort}
+
+		// If ports are specified only pick the backends that match the service port name or number.
 		if ports.Len() > 0 {
-			switch {
-			case ports.Has(string(fe.PortName)):
-				portName = string(fe.PortName)
-			case ports.Has(strconv.Itoa(int(fe.Address.Port))):
-				portName = strconv.Itoa(int(fe.Address.Port))
-			case ports.Has(strconv.Itoa(int(fe.ServicePort))):
-				portName = strconv.Itoa(int(fe.ServicePort))
-			default:
-				continue
+			bePortNames = bePortNames[:0]
+			if len(inst.PortNames) == 0 {
+				// Backend without a port name will match with the
+				// nameless port in the service.
+				for name, number := range portNames {
+					if name != "" {
+						continue
+					}
+					portS := strconv.FormatUint(uint64(number), 10)
+					if ports.Has(portS) {
+						bePortNames = append(bePortNames, portS)
+					}
+				}
+			} else {
+				// Backend has port name(s), try to match them up
+				// against the filter ports. We try to match both
+				// by name and by port number.
+				for _, portName := range inst.PortNames {
+					if ports.Has(portName) {
+						bePortNames = append(bePortNames, portName)
+						continue
+					}
+
+					// The "name" not found from ports, see if the
+					// "number" can be found.
+					port, found := portNames[portName]
+					if !found {
+						continue
+					}
+					portS := strconv.FormatUint(uint64(port), 10)
+					// Try looking up by port number
+					if !ports.Has(portS) {
+						continue
+					}
+					bePortNames = append(bePortNames, portS)
+				}
 			}
 		}
-		for be := range fe.Backends {
-			if be.State != loadbalancer.BackendStateActive {
-				continue
-			}
+		for _, portName := range bePortNames {
 			backends := backendMap[portName]
 			if backends == nil {
-				backends = map[string]experimental.BackendParams{}
+				backends = map[string]*experimental.Backend{}
 				backendMap[portName] = backends
 			}
 			backends[be.L3n4Addr.String()] = be
@@ -383,163 +405,20 @@ func backendsToLoadAssignments(
 				},
 			},
 		}
-		endpoints = append(endpoints, endpoint)
+		assignments[endpoint.ClusterName] = endpoint
 
 		// for backward compatibility, if any port is allowed, publish one more
 		// endpoint having cluster name as service name.
 		if port == anyPort {
-			endpoints = append(endpoints, &envoy_config_endpoint.ClusterLoadAssignment{
-				ClusterName: serviceName.String(),
-				Endpoints: []*envoy_config_endpoint.LocalityLbEndpoints{
-					{
-						LbEndpoints: lbEndpoints,
+			assignments[serviceName.String()] =
+				&envoy_config_endpoint.ClusterLoadAssignment{
+					ClusterName: serviceName.String(),
+					Endpoints: []*envoy_config_endpoint.LocalityLbEndpoints{
+						{
+							LbEndpoints: lbEndpoints,
+						},
 					},
-				},
-			})
+				}
 		}
 	}
-	return endpoints
-}
-
-// assignmentsEqual returns false if the cluster load assignments are not equal. Equal assignments but in different
-// order are assumed non-equal.
-func assignmentsEqual(a []*envoy_config_endpoint.ClusterLoadAssignment, b []*envoy_config_endpoint.ClusterLoadAssignment) bool {
-
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if !proto.Equal(a[i], b[i]) {
-			return false
-		}
-	}
-	return true
-}
-
-func getProxyRedirect(cec *CEC, svcl *ciliumv2.ServiceListener) *experimental.ProxyRedirect {
-	var port uint16
-	if svcl.Listener != "" {
-		// Listener names are qualified after parsing, so qualify the listener reference as well for it to match
-		svcListener, _ := api.ResourceQualifiedName(
-			cec.Name.Namespace, cec.Name.Name, svcl.Listener, api.ForceNamespace)
-		port, _ = cec.Listeners.Get(svcListener)
-	} else {
-		for _, p := range cec.Listeners.All() {
-			port = p
-			break
-		}
-	}
-	if port == 0 {
-		return nil
-	}
-	return &experimental.ProxyRedirect{
-		ProxyPort: port,
-		Ports:     svcl.Ports,
-	}
-}
-
-// onServiceUpsert is called when the service is upserted, but before it is committed.
-// We set the proxy port on the service if there's a matching CEC.
-func (c *cecController) onServiceUpsert(txn statedb.ReadTxn, svc *experimental.Service) {
-	// Look up if there is a CiliumEnvoyConfig that references this service.
-	cec, _, found := c.params.CECs.Get(txn, CECByServiceName(svc.Name))
-	if !found {
-		c.params.Log.Debug("onServiceUpsert: CEC not found", "name", svc.Name)
-		svc.ProxyRedirect = nil
-		return
-	}
-
-	// Find the service listener that referenced this service.
-	var svcl *ciliumv2.ServiceListener
-	for _, l := range cec.Spec.Services {
-		if l.Namespace == svc.Name.Namespace && l.Name == svc.Name.Name {
-			svcl = l
-			break
-		}
-	}
-	if svcl == nil {
-		return
-	}
-
-	pr := getProxyRedirect(cec, svcl)
-	c.params.Log.Debug("Setting proxy redirection (on service upsert)",
-		"namespace", svcl.Namespace,
-		"name", svcl.Name,
-		"ProxyRedirect", pr,
-		"Listener", svcl.Listener)
-	svc.ProxyRedirect = pr
-}
-
-type policyTriggerWrapper struct{ updater *policy.Updater }
-
-func (p policyTriggerWrapper) TriggerPolicyUpdates() {
-	p.updater.TriggerPolicyUpdates("Envoy Listeners changed")
-}
-
-func newPolicyTrigger(log *slog.Logger, updater *policy.Updater) policyTrigger {
-	return policyTriggerWrapper{updater}
-}
-
-type envoyOps struct {
-	log *slog.Logger
-	xds resourceMutator
-}
-
-// Delete implements reconciler.Operations.
-func (ops *envoyOps) Delete(ctx context.Context, _ statedb.ReadTxn, cec *CEC) error {
-	if prev := cec.ReconciledResources; prev != nil {
-		// Perform the deletion with the resources that were last successfully reconciled
-		// instead of whatever the latest one is (which would have not been pushed to Envoy).
-		return ops.xds.DeleteEnvoyResources(ctx, *prev)
-	}
-	return nil
-}
-
-// Prune implements reconciler.Operations.
-func (ops *envoyOps) Prune(ctx context.Context, txn statedb.ReadTxn, objects iter.Seq2[*CEC, statedb.Revision]) error {
-	return nil
-}
-
-// Update implements reconciler.Operations.
-func (ops *envoyOps) Update(ctx context.Context, txn statedb.ReadTxn, cec *CEC) error {
-	var prevResources envoy.Resources
-	if cec.ReconciledResources != nil {
-		prevResources = *cec.ReconciledResources
-	}
-
-	var err error
-	if cec.SelectsLocalNode {
-		resources := cec.Resources
-		err := ops.xds.UpdateEnvoyResources(ctx, prevResources, resources)
-		if err == nil {
-			cec.ReconciledResources = &resources
-		}
-	} else if cec.ReconciledResources != nil {
-		// The local node no longer selected and it had been reconciled to envoy previously.
-		// Delete the resources and forget.
-		err = ops.xds.DeleteEnvoyResources(ctx, prevResources)
-		if err == nil {
-			cec.ReconciledResources = nil
-		}
-	}
-	return err
-}
-
-var _ reconciler.Operations[*CEC] = &envoyOps{}
-
-func registerEnvoyReconciler(log *slog.Logger, xds resourceMutator, params reconciler.Params, cecs statedb.RWTable[*CEC]) error {
-	ops := &envoyOps{
-		log: log, xds: xds,
-	}
-	_, err := reconciler.Register(
-		params,
-		cecs,
-		(*CEC).Clone,
-		(*CEC).SetStatus,
-		(*CEC).GetStatus,
-		ops,
-		nil,
-		reconciler.WithoutPruning(),
-	)
-	return err
 }

--- a/pkg/ciliumenvoyconfig/exp_controller.go
+++ b/pkg/ciliumenvoyconfig/exp_controller.go
@@ -314,7 +314,7 @@ func backendsToLoadAssignments(
 	var endpoints []*envoy_config_endpoint.ClusterLoadAssignment
 
 	// Partition backends by port name.
-	backendMap := map[string]map[string]*experimental.Backend{}
+	backendMap := map[string]map[string]experimental.BackendParams{}
 	backendMap[anyPort] = nil
 	for fe := range frontends {
 		portName := anyPort
@@ -337,7 +337,7 @@ func backendsToLoadAssignments(
 			}
 			backends := backendMap[portName]
 			if backends == nil {
-				backends = map[string]*experimental.Backend{}
+				backends = map[string]experimental.BackendParams{}
 				backendMap[portName] = backends
 			}
 			backends[be.L3n4Addr.String()] = be

--- a/pkg/ciliumenvoyconfig/exp_reconciler.go
+++ b/pkg/ciliumenvoyconfig/exp_reconciler.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumenvoyconfig
+
+import (
+	"context"
+	"iter"
+	"log/slog"
+	"maps"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+
+	"github.com/cilium/cilium/pkg/envoy"
+	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+type envoyOps struct {
+	log           *slog.Logger
+	xds           resourceMutator
+	policyTrigger policyTrigger
+	writer        *experimental.Writer
+}
+
+// Delete implements reconciler.Operations.
+func (ops *envoyOps) Delete(ctx context.Context, _ statedb.ReadTxn, res *EnvoyResource) error {
+	if len(res.Redirects) > 0 {
+		// Remove redirects from services no longer selected by the CEC
+		wtxn := ops.writer.WriteTxn()
+		defer wtxn.Abort()
+		for name := range res.ReconciledRedirects {
+			svc, _, found := ops.writer.Services().Get(wtxn, experimental.ServiceByName(name))
+			if found {
+				svc = svc.Clone()
+				svc.ProxyRedirect = nil
+				ops.writer.UpsertService(wtxn, svc)
+			}
+		}
+		wtxn.Commit()
+	}
+
+	var err error
+	if prev := res.ReconciledResources; prev != nil {
+		// Perform the deletion with the resources that were last successfully reconciled
+		// instead of whatever the latest one is (which would have not been pushed to Envoy).
+		err = ops.xds.DeleteEnvoyResources(ctx, *prev)
+	}
+	ops.policyTrigger.TriggerPolicyUpdates()
+	return err
+}
+
+// Prune implements reconciler.Operations.
+func (ops *envoyOps) Prune(ctx context.Context, txn statedb.ReadTxn, objects iter.Seq2[*EnvoyResource, statedb.Revision]) error {
+	return nil
+}
+
+// Update implements reconciler.Operations.
+func (ops *envoyOps) Update(ctx context.Context, txn statedb.ReadTxn, res *EnvoyResource) error {
+	resources := res.Resources
+
+	var prevResources envoy.Resources
+	if res.ReconciledResources != nil {
+		prevResources = *res.ReconciledResources
+	}
+	err := ops.xds.UpdateEnvoyResources(ctx, prevResources, resources)
+	if err == nil {
+		if prevResources.ListenersAddedOrDeleted(&resources) {
+			ops.policyTrigger.TriggerPolicyUpdates()
+		}
+
+		// With the envoy resources successfully pushed to Envoy, set the proxy redirections
+		// for the associated services.
+		if len(res.Redirects) > 0 || len(res.ReconciledRedirects) > 0 {
+			wtxn := ops.writer.WriteTxn()
+			for name, redirect := range res.Redirects {
+				svc, _, found := ops.writer.Services().Get(wtxn, experimental.ServiceByName(name))
+				if found && !svc.ProxyRedirect.Equal(redirect) {
+					svc = svc.Clone()
+					svc.ProxyRedirect = redirect
+					ops.writer.UpsertService(wtxn, svc)
+				}
+			}
+			for name := range res.ReconciledRedirects {
+				if _, found := res.Redirects[name]; !found {
+					svc, _, found := ops.writer.Services().Get(wtxn, experimental.ServiceByName(name))
+					if found {
+						svc = svc.Clone()
+						svc.ProxyRedirect = nil
+						ops.writer.UpsertService(wtxn, svc)
+					}
+				}
+			}
+			wtxn.Commit()
+			res.ReconciledRedirects = maps.Clone(res.Redirects)
+		}
+
+		res.ReconciledResources = &resources
+	}
+	return err
+}
+
+var _ reconciler.Operations[*EnvoyResource] = &envoyOps{}
+
+func registerEnvoyReconciler(
+	log *slog.Logger,
+	xds resourceMutator,
+	pt policyTrigger,
+	params reconciler.Params,
+	writer *experimental.Writer,
+	envoyResources statedb.RWTable[*EnvoyResource],
+) error {
+	ops := &envoyOps{
+		log:           log,
+		xds:           xds,
+		writer:        writer,
+		policyTrigger: pt,
+	}
+	_, err := reconciler.Register(
+		params,
+		envoyResources,
+		(*EnvoyResource).Clone,
+		(*EnvoyResource).SetStatus,
+		(*EnvoyResource).GetStatus,
+		ops,
+		nil,
+		reconciler.WithoutPruning(),
+	)
+	return err
+}
+
+type policyTriggerWrapper struct{ updater *policy.Updater }
+
+func (p policyTriggerWrapper) TriggerPolicyUpdates() {
+	p.updater.TriggerPolicyUpdates("Envoy Listeners changed")
+}
+
+func newPolicyTrigger(log *slog.Logger, updater *policy.Updater) policyTrigger {
+	return policyTriggerWrapper{updater}
+}
+
+type resourceMutator interface {
+	DeleteEnvoyResources(context.Context, envoy.Resources) error
+	UpdateEnvoyResources(context.Context, envoy.Resources, envoy.Resources) error
+}
+
+type policyTrigger interface {
+	TriggerPolicyUpdates()
+}

--- a/pkg/ciliumenvoyconfig/exp_test.go
+++ b/pkg/ciliumenvoyconfig/exp_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -40,6 +41,9 @@ import (
 )
 
 func TestScript(t *testing.T) {
+	// Catch any leaked goroutines.
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
 	version.Force(testutils.DefaultVersion)
 	setup := func(t testing.TB, args []string) *script.Engine {
 		fakeEnvoy := &fakeEnvoySyncerAndPolicyTrigger{}
@@ -59,10 +63,14 @@ func TestScript(t *testing.T) {
 				source.NewSources,
 				func() *option.DaemonConfig {
 					return &option.DaemonConfig{
-						EnableIPv4:        true,
-						EnableIPv6:        true,
-						SockRevNatEntries: 1000,
-						LBMapEntries:      1000,
+						EnableIPv4:           true,
+						EnableIPv6:           true,
+						EnableNodePort:       true,
+						SockRevNatEntries:    1000,
+						LBMapEntries:         1000,
+						EnableL7Proxy:        true,
+						EnableEnvoyConfig:    true,
+						KubeProxyReplacement: option.KubeProxyReplacementTrue,
 					}
 				},
 				func() *experimental.TestConfig {
@@ -125,7 +133,7 @@ func TestScript(t *testing.T) {
 				}
 				for _, info := range fakeEnvoy.all() {
 					if info.res == nil {
-						_, err = fmt.Fprintf(f, "%s: count=%d listeners=<nil> endpoints=<nil>\n", info.name, info.count)
+						_, err = fmt.Fprintf(f, "%s: listeners=<nil> endpoints=<nil>\n", info.name)
 						if err != nil {
 							return nil, err
 						}
@@ -149,7 +157,7 @@ func TestScript(t *testing.T) {
 						}
 					}
 					sort.Strings(endpoints)
-					_, err = fmt.Fprintf(f, "%s: count=%d listeners=%s endpoints=%s\n", info.name, info.count, strings.Join(listeners, ","), strings.Join(endpoints, ","))
+					_, err = fmt.Fprintf(f, "%s: listeners=%s endpoints=%s\n", info.name, strings.Join(listeners, ","), strings.Join(endpoints, ","))
 					if err != nil {
 						return nil, err
 					}
@@ -180,8 +188,9 @@ func TestScript(t *testing.T) {
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
+
 	scripttest.Test(t,
 		ctx,
 		setup,

--- a/pkg/ciliumenvoyconfig/testdata/backendservices.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/backendservices.txtar
@@ -1,0 +1,304 @@
+# Test handling of CiliumEnvoyConfig with backend services.
+
+# Start the hive and wait for tables to be synchronized before adding k8s objects.
+hive start
+db/initialized
+
+# Start with clean state.
+db/cmp services services_empty.table
+db/cmp ciliumenvoyconfigs cec_empty.table
+
+# Set up the services and endpoints. Add the test/frontend first and wait for it
+# to reconcile.
+k8s/add service.yaml endpointslice.yaml
+db/cmp frontends frontends1.table
+
+# Add the first backend service with named ports. The 'http' one
+# will be matched and the backend with port 9080 chosen. The
+# existence of the alternative port name (http-alt) should not
+# affect the matching. Wait for frontends to be reconciled for
+# deterministic ID allocation.
+k8s/add be_service.yaml be_endpointslice.yaml
+db/cmp frontends frontends2.table
+
+# Then add a second one with unnamed ports.
+k8s/add be_service_unnamed_port.yaml be_endpointslice_unnamed_port.yaml
+db/cmp services services.table
+
+# Add the CiliumEnvoyConfig and wait for it to be ingested.
+k8s/add cec.yaml
+db/cmp ciliumenvoyconfigs cec.table
+
+# Check that service is now redirected to proxy.
+db/cmp services services_redirected.table
+db/cmp frontends frontends3.table
+db/cmp envoy-resources envoy-resources.table
+
+# Check BPF maps. The service should have L7 redirect set.
+lb/maps-dump lbmaps.out
+* cmp lbmaps.out lbmaps.expected
+
+# Check that right updates towards Envoy happened.
+envoy envoy.out
+replace 'count=2' 'count=1' envoy.out
+* cmp envoy.out envoy1.expected
+
+# Cleanup
+k8s/delete cec.yaml
+db/cmp services services.table
+db/cmp ciliumenvoyconfigs cec_empty.table
+
+# The listener should now be deleted. The update count may be either
+# 1 or 2 depending on when the controller is woken up.
+envoy envoy.out
+replace 'count=2' 'count=1' envoy.out
+* cmp envoy.out envoy2.expected
+
+# ---------------------------------------------
+
+-- services_empty.table --
+Name  ProxyRedirect
+
+-- services.table --
+Name                       ProxyRedirect
+test/backend
+test/backend_unnamed_port
+test/frontend   
+
+-- services_redirected.table --
+Name                      ProxyRedirect
+test/backend
+test/backend_unnamed_port
+test/frontend             1000 (ports: [80])
+
+-- frontends1.table --
+Address            Type        ServiceName     PortName   Backends           Status   Error
+1.0.0.1:80/TCP     ClusterIP   test/frontend   http       1.1.0.1:8080/TCP   Done
+1.0.0.1:82/TCP     ClusterIP   test/frontend   http2      1.1.0.1:9090/TCP   Done
+
+-- frontends2.table --
+Address            Type        ServiceName                PortName   Backends                             Status   Error
+1.0.0.1:80/TCP     ClusterIP   test/frontend              http       1.1.0.1:8080/TCP                     Done
+1.0.0.1:82/TCP     ClusterIP   test/frontend              http2      1.1.0.1:9090/TCP                     Done
+2.0.0.1:9080/TCP   ClusterIP   test/backend               http       2.1.0.1:9080/TCP, 2.1.0.2:9080/TCP   Done
+2.0.0.1:9081/TCP   ClusterIP   test/backend               http-alt   2.1.0.1:9080/TCP, 2.1.0.2:9080/TCP   Done
+
+-- frontends3.table --
+Address            Type        ServiceName                PortName   Backends                            Status   Error
+1.0.0.1:80/TCP     ClusterIP   test/frontend              http       1.1.0.1:8080/TCP                    Done
+1.0.0.1:82/TCP     ClusterIP   test/frontend              http2      1.1.0.1:9090/TCP                    Done
+2.0.0.1:9080/TCP   ClusterIP   test/backend               http       2.1.0.1:9080/TCP, 2.1.0.2:9080/TCP  Done
+2.0.0.1:9081/TCP   ClusterIP   test/backend               http-alt   2.1.0.1:9080/TCP, 2.1.0.2:9080/TCP  Done
+3.0.0.1:9080/TCP   ClusterIP   test/backend_unnamed_port             3.1.0.1:9080/TCP                    Done
+
+-- envoy-resources.table --
+Name           Listeners             Endpoints                                                                                               Status   Error
+test/ingress   test/ingress/listener test/backend:9080: 2.1.0.1, 2.1.0.2, test/backend_unnamed_port:9080: 3.1.0.1, test/frontend:80: 1.1.0.1 Done
+
+-- cec_empty.table --
+Name    Services
+
+-- cec.table --
+Name           Services        BackendServices
+test/ingress   test/frontend   test/backend, test/backend_unnamed_port
+
+-- cec.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: ingress
+  namespace: test
+spec:
+  services:
+    - name: frontend
+      namespace: test
+      listener: ""
+      ports:
+      - 80
+  backendServices:
+    - name: backend
+      namespace: test
+      number:
+      - "9080"
+    - name: backend_unnamed_port
+      namespace: test
+      number:
+      - "9080"
+
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: listener
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: test
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 1.0.0.1
+  clusterIPs:
+  - 1.0.0.1
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: http2
+    port: 82
+    protocol: TCP
+    targetPort: 82
+  selector:
+    name: frontend
+  type: ClusterIP
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: frontend
+  name: frontend-eps1
+  namespace: test
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 1.1.0.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+- name: http2
+  port: 9090
+  protocol: TCP
+  
+-- be_service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: test
+  uid: b49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 2.0.0.1
+  clusterIPs:
+  - 2.0.0.1
+  ports:
+  - name: http
+    port: 9080
+    protocol: TCP
+    targetPort: 9080
+  - name: http-alt
+    port: 9081
+    protocol: TCP
+    targetPort: 9081
+  selector:
+    name: backend
+  type: ClusterIP
+
+-- be_endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: backend
+  name: backend-eps1
+  namespace: test
+  uid: e1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 2.1.0.1
+  - 2.1.0.2
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 9080
+  protocol: TCP
+- name: http-alt
+  port: 9080
+  protocol: TCP
+
+-- be_service_unnamed_port.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend_unnamed_port
+  namespace: test
+  uid: f49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 3.0.0.1
+  clusterIPs:
+  - 3.0.0.1
+  ports:
+  - port: 9080
+    protocol: TCP
+    targetPort: 9080
+  selector:
+    name: unnamed_port
+  type: ClusterIP
+
+-- be_endpointslice_unnamed_port.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: backend_unnamed_port
+  name: backend-eps-unnamed-port
+  namespace: test
+  uid: e1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 3.1.0.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- port: 9080
+  protocol: TCP
+
+-- lbmaps.expected --
+BE: ID=1 ADDR=1.1.0.1:8080/TCP STATE=active
+BE: ID=2 ADDR=1.1.0.1:9090/TCP STATE=active
+BE: ID=3 ADDR=2.1.0.1:9080/TCP STATE=active
+BE: ID=4 ADDR=2.1.0.2:9080/TCP STATE=active
+BE: ID=5 ADDR=3.1.0.1:9080/TCP STATE=active
+REV: ID=1 ADDR=1.0.0.1:80
+REV: ID=2 ADDR=1.0.0.1:82
+REV: ID=3 ADDR=2.0.0.1:9080
+REV: ID=4 ADDR=2.0.0.1:9081
+REV: ID=5 ADDR=3.0.0.1:9080
+SVC: ID=1 ADDR=1.0.0.1:80/TCP SLOT=0 L7Proxy=1000 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
+SVC: ID=1 ADDR=1.0.0.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
+SVC: ID=2 ADDR=1.0.0.1:82/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=1.0.0.1:82/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=2.0.0.1:9080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=2.0.0.1:9080/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=2.0.0.1:9080/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=2.0.0.1:9081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=2.0.0.1:9081/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=2.0.0.1:9081/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=3.0.0.1:9080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=3.0.0.1:9080/TCP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- envoy1.expected --
+policy-trigger-count: 1
+update: listeners=test/ingress/listener/1000 endpoints=test/backend:9080=2.1.0.1:9080,2.1.0.2:9080,test/backend_unnamed_port:9080=3.1.0.1:9080,test/frontend:80=1.1.0.1:8080
+delete: listeners=<nil> endpoints=<nil>
+-- envoy2.expected --
+policy-trigger-count: 2
+update: listeners=test/ingress/listener/1000 endpoints=test/backend:9080=2.1.0.1:9080,2.1.0.2:9080,test/backend_unnamed_port:9080=3.1.0.1:9080,test/frontend:80=1.1.0.1:8080
+delete: listeners=test/ingress/listener/1000 endpoints=test/backend:9080=2.1.0.1:9080,2.1.0.2:9080,test/backend_unnamed_port:9080=3.1.0.1:9080,test/frontend:80=1.1.0.1:8080

--- a/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
@@ -130,17 +130,17 @@ ports:
 
 -- envoy1.expected --
 policy-trigger-count: 1
-update: count=1 listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=,test/echo2=
-delete: count=0 listeners=<nil> endpoints=<nil>
+update: listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=10.244.1.2:8081,test/echo2=10.244.1.2:8081
+delete: listeners=<nil> endpoints=<nil>
 -- envoy2.expected --
 policy-trigger-count: 1
-update: count=1 listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=,test/echo2=
-delete: count=0 listeners=<nil> endpoints=<nil>
+update: listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=
+delete: listeners=<nil> endpoints=<nil>
 -- envoy3.expected --
 policy-trigger-count: 1
-update: count=1 listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=,test/echo2=
-delete: count=0 listeners=<nil> endpoints=<nil>
+update: listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=10.244.1.2:8081,test/echo2=10.244.1.2:8081
+delete: listeners=<nil> endpoints=<nil>
 -- envoy4.expected --
 policy-trigger-count: 2
-update: count=1 listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=,test/echo2=
-delete: count=1 listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=,test/echo2=
+update: listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=10.244.1.2:8081,test/echo2=10.244.1.2:8081
+delete: listeners=/envoy-lb-listener-2/envoy-lb-listener-2/1000 endpoints=test/echo2:*=10.244.1.2:8081,test/echo2=10.244.1.2:8081

--- a/pkg/ciliumenvoyconfig/testdata/headless.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/headless.txtar
@@ -1,4 +1,4 @@
-# Test handling of CiliumEnvoyConfig, without specifying service ports
+# Test handling of headless services
 
 # Start the hive and wait for tables to be synchronized before adding k8s objects.
 hive start
@@ -15,13 +15,7 @@ db/cmp services services.table
 # Add the CiliumEnvoyConfig and wait for it to be ingested.
 k8s/add cec.yaml
 db/cmp ciliumenvoyconfigs cec.table
-
-# Check that both services are now redirected to proxy.
-db/cmp services services_redirected.table
-
-# Check BPF maps. The service should have L7 redirect set.
-lb/maps-dump lbmaps.out
-* cmp lbmaps.out lbmaps.expected
+db/cmp envoy-resources envoy-resources.table
 
 # Check that right updates towards Envoy happened.
 envoy envoy.out
@@ -35,23 +29,32 @@ k8s/delete endpointslice.yaml
 envoy envoy.out
 * cmp envoy.out envoy2.expected
 
-# Drop the service
+# Drop the service. No changes towards envoy as the load assignments
+# do not change.
 k8s/delete service.yaml
 db/cmp services services_empty.table
 
 # Add back the service and endpoints
 k8s/add service.yaml endpointslice.yaml
-db/cmp services services_redirected.table
+db/cmp services services.table
 
 # Check again that updates happened.
 envoy envoy.out
 * cmp envoy.out envoy3.expected
 
+# Adding an unrelated service does not trigger updates.
+k8s/add unrelated_service.yaml unrelated_endpointslice.yaml
+
+# No updates should happen.
+envoy envoy.out
+* cmp envoy.out envoy3.expected
+
+k8s/delete unrelated_service.yaml unrelated_endpointslice.yaml
+
 # Cleanup. Remove CEC and check that proxy redirect is gone.
 k8s/delete cec.yaml
-db/cmp ciliumenvoyconfigs cec_empty.table
-db/cmp envoy-resources envoy_resources_empty.table
 db/cmp services services.table
+db/cmp ciliumenvoyconfigs cec_empty.table
 
 # The listener should now be deleted.
 envoy envoy.out
@@ -64,21 +67,18 @@ Name        ProxyRedirect
 
 -- services.table --
 Name        ProxyRedirect
-test/echo   
-
--- services_redirected.table --
-Name        ProxyRedirect
-test/echo   1000
+test/echo
 
 -- cec_empty.table --
 Name    Services
 
--- envoy_resources_empty.table --
-Name
-
 -- cec.table --
-Name                    Services
+Name                    BackendServices  Services
 test/envoy-lb-listener  test/echo
+
+-- envoy-resources.table --
+Name                     Status
+test/envoy-lb-listener   Done 
 
 -- cec.yaml --
 apiVersion: cilium.io/v2
@@ -87,10 +87,11 @@ metadata:
   name: envoy-lb-listener
   namespace: test
 spec:
-  services:
+  backendServices:
     - name: echo
       namespace: test
-      listener: envoy-lb-listener
+      number:
+      - "80"
   resources:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       name: envoy-lb-listener
@@ -102,26 +103,42 @@ metadata:
   name: echo
   namespace: test
   uid: a49fe99c-3564-4754-acc4-780f2331a49b
+  annotations:
+    service.kubernetes.io/headless: "true"
 spec:
-  clusterIP: 10.96.50.104
-  clusterIPs:
-  - 10.96.50.104
+  clusterIP: "none"
   ports:
   - name: http
     nodePort: 30781
     port: 80
     protocol: TCP
     targetPort: 80
-  - name: smtp
-    nodePort: 30725
-    port: 25
-    protocol: TCP
-    targetPort: 25
   selector:
     name: echo
   type: NodePort
 status:
   loadBalancer: {}
+
+-- unrelated_service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: unrelated
+  namespace: test
+  uid: b49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 1.2.3.4
+  clusterIPs:
+  - 1.2.3.4
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: unrelated
+  type: ClusterIP
 
 -- endpointslice.yaml --
 apiVersion: discovery.k8s.io/v1
@@ -145,38 +162,43 @@ ports:
 - name: http
   port: 8080
   protocol: TCP
-- name: smtp
-  port: 25
+
+-- unrelated_endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: unrelated
+  name: unrelated-eps1
+  namespace: test
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.2.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 8080
   protocol: TCP
 
--- lbmaps.expected --
-BE: ID=1 ADDR=10.244.1.1:8080/TCP STATE=active
-BE: ID=2 ADDR=10.244.1.1:25/TCP STATE=active
-REV: ID=1 ADDR=10.96.50.104:80
-REV: ID=2 ADDR=10.96.50.104:25
-REV: ID=3 ADDR=0.0.0.0:30781
-REV: ID=4 ADDR=0.0.0.0:30725
-SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 L7Proxy=1000 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
-SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
-SVC: ID=2 ADDR=10.96.50.104:25/TCP SLOT=0 L7Proxy=1000 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
-SVC: ID=2 ADDR=10.96.50.104:25/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
-SVC: ID=3 ADDR=0.0.0.0:30781/TCP SLOT=0 L7Proxy=1000 COUNT=1 QCOUNT=0 FLAGS=NodePort+non-routable+l7-load-balancer
-SVC: ID=3 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable+l7-load-balancer
-SVC: ID=4 ADDR=0.0.0.0:30725/TCP SLOT=0 L7Proxy=1000 COUNT=1 QCOUNT=0 FLAGS=NodePort+non-routable+l7-load-balancer
-SVC: ID=4 ADDR=0.0.0.0:30725/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable+l7-load-balancer
 -- envoy1.expected --
 policy-trigger-count: 1
-update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=10.244.1.1:25,10.244.1.1:8080,test/echo=10.244.1.1:25,10.244.1.1:8080
+update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080
 delete: listeners=<nil> endpoints=<nil>
 -- envoy2.expected --
 policy-trigger-count: 1
-update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=10.244.1.1:25,10.244.1.1:8080,test/echo=10.244.1.1:25,10.244.1.1:8080
+update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=
 delete: listeners=<nil> endpoints=<nil>
 -- envoy3.expected --
 policy-trigger-count: 1
-update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=10.244.1.1:25,10.244.1.1:8080,test/echo=10.244.1.1:25,10.244.1.1:8080
+update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080
 delete: listeners=<nil> endpoints=<nil>
 -- envoy4.expected --
 policy-trigger-count: 2
-update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=10.244.1.1:25,10.244.1.1:8080,test/echo=10.244.1.1:25,10.244.1.1:8080
-delete: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=10.244.1.1:25,10.244.1.1:8080,test/echo=10.244.1.1:25,10.244.1.1:8080
+update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080
+delete: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080

--- a/pkg/ciliumenvoyconfig/testdata/labels.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/labels.txtar
@@ -28,14 +28,14 @@ envoy envoy.out
 Name    Services
 
 -- cec_a.table --
-Name                    Selected  NodeSelector  StatusKind
-test/envoy-a            true      foo=a         Done
-test/envoy-b            false     foo=b         Done
+Name                    Selected  NodeSelector
+test/envoy-a            true      foo=a       
+test/envoy-b            false     foo=b       
 
 -- cec_b.table --
-Name                    Selected  NodeSelector  StatusKind
-test/envoy-a            false     foo=a         Done
-test/envoy-b            true      foo=b         Done
+Name                    Selected  NodeSelector
+test/envoy-a            false     foo=a       
+test/envoy-b            true      foo=b       
 
 -- cec_a.yaml --
 apiVersion: cilium.io/v2
@@ -75,9 +75,9 @@ spec:
 
 -- envoy_a.expected --
 policy-trigger-count: 1
-update: count=1 listeners=test/envoy-a/envoy-lb-listener/1000 endpoints=test/a:*=,test/a=
-delete: count=0 listeners=<nil> endpoints=<nil>
+update: listeners=test/envoy-a/envoy-lb-listener/1000 endpoints=
+delete: listeners=<nil> endpoints=<nil>
 -- envoy_b.expected --
-policy-trigger-count: 1
-update: count=2 listeners=test/envoy-b/envoy-lb-listener/1000 endpoints=test/b:*=,test/b=
-delete: count=1 listeners=test/envoy-a/envoy-lb-listener/1000 endpoints=test/a:*=,test/a=
+policy-trigger-count: 3
+update: listeners=test/envoy-b/envoy-lb-listener/1000 endpoints=
+delete: listeners=test/envoy-a/envoy-lb-listener/1000 endpoints=

--- a/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
@@ -1,5 +1,8 @@
 # Test handling of CiliumEnvoyConfig
 
+# Add a node address for NodePort services
+db/insert node-addresses addrv4.yaml
+
 # Start the hive and wait for tables to be synchronized before adding k8s objects.
 hive start
 db/initialized
@@ -18,6 +21,7 @@ db/cmp ciliumenvoyconfigs cec.table
 
 # Check that both services are now redirected to proxy.
 db/cmp services services_redirected.table
+db/cmp frontends frontends.table
 
 # Check BPF maps. The service should have L7 redirect set.
 lb/maps-dump lbmaps.out
@@ -47,7 +51,17 @@ db/cmp services services_redirected.table
 envoy envoy.out
 * cmp envoy.out envoy3.expected
 
-# Cleanup. Remove CEC and check that proxy redirect is gone.
+# Change the service name in the CEC and check that
+# proxy redirect gets removed.
+cp cec.yaml cec2.yaml
+replace 'name: echo' 'name: echo2' cec2.yaml
+k8s/update cec2.yaml
+db/cmp services services.table
+
+# Revert and then check that deleting the CEC results in
+# proxy redirect and listeners being removed.
+k8s/update cec.yaml
+db/cmp services services_redirected.table
 k8s/delete cec.yaml
 db/cmp services services.table
 db/cmp ciliumenvoyconfigs cec_empty.table
@@ -57,6 +71,12 @@ envoy envoy.out
 * cmp envoy.out envoy4.expected
 
 # ---------------------------------------------
+
+-- addrv4.yaml --
+addr: 1.1.1.1
+nodeport: true
+primary: true
+devicename: test
 
 -- services_empty.table --
 Name        ProxyRedirect
@@ -68,6 +88,13 @@ test/echo
 -- services_redirected.table --
 Name        ProxyRedirect
 test/echo   1000 (ports: [80])
+
+-- frontends.table --
+Address               Type        ServiceName   PortName   Status  Backends
+0.0.0.0:30725/TCP     NodePort    test/echo     smtp       Done    10.244.1.1:25/TCP
+0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:8080/TCP
+10.96.50.104:25/TCP   ClusterIP   test/echo     smtp       Done    10.244.1.1:25/TCP
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:8080/TCP
 
 -- cec_empty.table --
 Name    Services
@@ -152,23 +179,35 @@ BE: ID=1 ADDR=10.244.1.1:8080/TCP STATE=active
 BE: ID=2 ADDR=10.244.1.1:25/TCP STATE=active
 REV: ID=1 ADDR=10.96.50.104:80
 REV: ID=2 ADDR=10.96.50.104:25
+REV: ID=3 ADDR=0.0.0.0:30781
+REV: ID=4 ADDR=1.1.1.1:30781
+REV: ID=5 ADDR=0.0.0.0:30725
+REV: ID=6 ADDR=1.1.1.1:30725
 SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 L7Proxy=1000 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
 SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable+l7-load-balancer
 SVC: ID=2 ADDR=10.96.50.104:25/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=2 ADDR=10.96.50.104:25/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=0.0.0.0:30781/TCP SLOT=0 L7Proxy=1000 COUNT=1 QCOUNT=0 FLAGS=NodePort+non-routable+l7-load-balancer
+SVC: ID=3 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable+l7-load-balancer
+SVC: ID=4 ADDR=1.1.1.1:30781/TCP SLOT=0 L7Proxy=1000 COUNT=1 QCOUNT=0 FLAGS=NodePort+l7-load-balancer
+SVC: ID=4 ADDR=1.1.1.1:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+l7-load-balancer
+SVC: ID=5 ADDR=0.0.0.0:30725/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=0.0.0.0:30725/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=6 ADDR=1.1.1.1:30725/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30725/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort
 -- envoy1.expected --
 policy-trigger-count: 1
-update: count=1 listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=,test/echo:80=10.244.1.1:8080,test/echo=
-delete: count=0 listeners=<nil> endpoints=<nil>
+update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080
+delete: listeners=<nil> endpoints=<nil>
 -- envoy2.expected --
 policy-trigger-count: 1
-update: count=2 listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=,test/echo=
-delete: count=0 listeners=<nil> endpoints=<nil>
+update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080
+delete: listeners=<nil> endpoints=<nil>
 -- envoy3.expected --
 policy-trigger-count: 1
-update: count=3 listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=,test/echo:80=10.244.1.1:8080,test/echo=
-delete: count=0 listeners=<nil> endpoints=<nil>
+update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080
+delete: listeners=<nil> endpoints=<nil>
 -- envoy4.expected --
 policy-trigger-count: 2
-update: count=3 listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=,test/echo:80=10.244.1.1:8080,test/echo=
-delete: count=1 listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:*=,test/echo:80=10.244.1.1:8080,test/echo=
+update: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080
+delete: listeners=test/envoy-lb-listener/envoy-lb-listener/1000 endpoints=test/echo:80=10.244.1.1:8080

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -43,7 +43,6 @@ import (
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/testutils/mockmaps"
 	wg "github.com/cilium/cilium/pkg/wireguard/agent"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
@@ -81,11 +80,9 @@ var Cell = cell.Module(
 
 	cell.Provide(func(expConfig experimental.Config, maglev *maglev.Maglev) types.LBMap {
 		if expConfig.EnableExperimentalLB {
-			// The experimental control-plane is enabled. Use a fake LBMap
-			// to effectively disable the other code paths writing to LBMaps.
-			return mockmaps.NewLBMockMap()
+			// The experimental control-plane comes with its own LBMap implementation.
+			return nil
 		}
-
 		return lbmap.New(maglev)
 	}),
 

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1962,7 +1962,7 @@ type Resources struct {
 	Endpoints []*envoy_config_endpoint.ClusterLoadAssignment
 
 	// Callback functions that are called if the corresponding Listener change was successfully acked by Envoy
-	PortAllocationCallbacks map[string]func(context.Context) error `json:"-"`
+	PortAllocationCallbacks map[string]func(context.Context) error `json:"-" yaml:"-"`
 }
 
 // ListenersAddedOrDeleted returns 'true' if a listener is added or removed when updating from 'old'

--- a/pkg/loadbalancer/experimental/README.md
+++ b/pkg/loadbalancer/experimental/README.md
@@ -26,9 +26,6 @@ The basic architecture looks as follows:
 ```
 The different data sources insert data using `Writer.UpsertService`, `Writer.UpsertFrontend`, etc. methods.
 
-A health checker observes the backends table to find targets to health check and uses
-`Writer.SetBackendHealth` to update the state.
-
 The BPF reconciler watches the frontend table (service and backend objects are referenced by
 the frontend object) and reconcile updates towards the BPF maps. The reconciliation status is
 written back to frontends.
@@ -62,99 +59,24 @@ Once running the state can be inspected with:
   > db/show backends
   > db/show services
   > db/prefix health agent.controlplane.loadbalancer-experimental
-  > lbmaps/dump
+  > lb/maps-dump
 ```
-## Integration testing
+
+## Testing
 
 The new architecture makes it easier to write integration tests due to the decoupling. An
 integration test for a data source can depend just on the tables & writer and verify that the
 tables are correctly populated without having to mock other features or the BPF operations. An
 example of this sort of test is in `writer_test.go`.
 
-A more "end-to-end" style test can be found in `k8s_test.go` that tests going from Kubernetes
-objects specified in YAML to the BPF map contents.
+A more "end-to-end" style test can be found in `script_test.go` that tests going from Kubernetes
+objects specified in YAML to the BPF map contents using script tests in `testdata`.
+
+For quick feedback loop you can use the `watch.sh` script to run a script test when the
+txtar file changes.
 
 To run the privileged tests:
 ```
   $ go test -c
   $ PRIVILEGED_TESTS=1 sudo -E ./experimental.test -test.run . -test.v -test.count 1
 ```
-## Unimplemented features
-
-This section lists the major unimplemented features and some thoughts on how we'd go about
-implementing them.
-
-### Local Redirect Policies
-
-These are currently implemented by `pkg/redirectpolicy`. The manager there subscribes to pods
-and redirect policies and create a `-local` service with the backends derived from the matched
-local pods.
-
-With the new architecture this should be implemented as a controller that watches `Table[Pod]`
-and `Table[CiliumLocalRedirectPolicy]` and updates the load-balancing state accordingly when
-they change.  The controller should be as stateless as possible.
-
-Still TBD is the design for how services would be overridden to redirect traffic to a local pod.
-The essential problem is that there's two sets of backends for the service: the normal backends
-and the LRP backends, and it should be possible to return to normal when the LRP is removed.
-One option is to use a generated service name for the set of LRP backends and then set this in
-the Service object.  The matching of frontends with backends would then see if this field is
-set and use the alternative service name. The challenge here is how to make it easy for observers
-of the tables, e.g. how the L7 proxy would be able to correctly look up backends for a specific
-service.
-
-### L7 proxy
-
-A CiliumEnvoyConfig CRD specifies that traffic for a specific service should be redirected to
-an Envoy instance. This is accomplished by setting the L7 proxy port in the services BPF map
-value. The current implementation lives in `pkg/ciliumenvoyconfig` and on `Resource[CiliumEnvoyConfig]`
-event calls to ServiceManager to add the L7 proxy port to matching services.
-
-As with LRPs it should be possible to reimplement this in mostly stateless way by switching
-`Resource[CiliumEnvoyConfig]` to `Table[CiliumEnvoyConfig]` and having the controller watch
-`Table[Service]` for matches and updating when the service matches with a CiliumEnvoyConfig. To avoid
-the intermediate state where a service is missing the L7 proxy port we can implement a "service
-hook" that is invoked when a service is upserted to do a query against `Table[CiliumEnvoyConfig]`
-and fill it in on the fly.
-
-### REST API (/service)
-
-The REST API handlers are currently implemented against ServiceManager. Implementing the inspection
-of the state is relatively easy thanks to the generic StateDB HTTP API. Handlers for modifying the
-state (e.g. for lb-only use) are trickier due to the semantic differences. In the new design the
-"primary key" is the `L3n4Addr` rather than the `ID`, so changes would be needed to the REST API to
-accomodate this. There's relatively few users of this and the message has been that the change from
-IDs to addresses would simplify their lives.
-
-Additional question here is the change to the restoration of data from BPF maps. The new implementation
-only restores the IDs (in order to reuse them and avoid connection disruption), but not all the rest of
-the data. This means that in lb-only use the services and backends need to be restored when the agent has
-restarted. Likely it would make sense to rethink the API to allow implementation of "data sources" via
-the REST API that can be resynced, e.g. move into a more of a pull-style API.
-
-### ClusterMesh
-
-ClusterMesh is implemented by merging the external services and endpoints in ServiceCache
-(`Merge*` methods). This can be now implemented more directly with the `Writer` API. The 
-ClusterMesh services and backends are essentially the same as those coming from Kubernetes
-and do not require any special handling.
-
-One notable requirement for ClusterMesh is the need to prune non-global services before
-ClusterMesh-sourced services are initialized. See `cf4279c68202bae83917b65b8e7da21e20869def`
-for context. Yet unclear how to cleanly implement this. The reconciler currently won't
-perform the `Prune()` operation if there are any pending initializers.
-
-### ServiceCache replacement
-
-ServiceCache in addition to merging Services with Endpoints and forwarding as events to a
-handler, it has a set of getters and a `Notifications()` stream (used by policy engine).
-
-These are all easy to replace by queries against the service/frontend/backend tables.
-
-### kvstore data source
-
-### Misc features
-
-- ServiceAffinity/"Preferred"
-- TopologyAware/Zones
-- LoopbackHostPort

--- a/pkg/loadbalancer/experimental/adapters.go
+++ b/pkg/loadbalancer/experimental/adapters.go
@@ -1,0 +1,692 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package experimental
+
+import (
+	"context"
+	"iter"
+	"log/slog"
+	"net"
+	"net/netip"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+	"github.com/cilium/stream"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/k8s"
+	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/service"
+	"github.com/cilium/cilium/pkg/service/store"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// The adapters in this file replace the [k8s.ServiceCacheReader] and [service.ServiceReader]
+// implementations when the experimental load-balancing is enabled. These are meant to be
+// temporary until the uses of these interfaces have been migrated over to using the tables
+// directly.
+
+type adapterParams struct {
+	cell.In
+
+	JobGroup   job.Group
+	Log        *slog.Logger
+	Config     Config
+	DB         *statedb.DB
+	Services   statedb.Table[*Service]
+	Backends   statedb.Table[*Backend]
+	Frontends  statedb.Table[*Frontend]
+	Ops        *BPFOps
+	Writer     *Writer
+	TestConfig *TestConfig `optional:"true"`
+}
+
+type decorateParams struct {
+	cell.In
+
+	Config Config
+	SCA    *serviceCacheAdapter
+	SC     k8s.ServiceCache `optional:"true"`
+	SMA    *serviceManagerAdapter
+	SM     service.ServiceManager `optional:"true"`
+}
+
+func decorateAdapters(p decorateParams) (k8s.ServiceCache, service.ServiceManager) {
+	if !p.Config.EnableExperimentalLB {
+		return p.SC, p.SM
+	}
+	return p.SCA, p.SMA
+}
+
+// newAdapters constructs the ServiceCache and ServiceManager adapters. This is separate
+// from [decorateAdapters] in order to have access to the module's job.Group which is not
+// accessible in the [cell.DecorateAll] scope.
+func newAdapters(p adapterParams) (sca *serviceCacheAdapter, sma *serviceManagerAdapter) {
+	if !p.Config.EnableExperimentalLB {
+		return nil, nil
+	}
+	sca = &serviceCacheAdapter{
+		log:      p.Log,
+		db:       p.DB,
+		services: p.Services,
+		backends: p.Backends,
+		writer:   p.Writer,
+	}
+	sca.notifications, sca.emit, sca.complete = stream.Multicast[k8s.ServiceNotification]()
+	p.JobGroup.Add(job.OneShot("adapter-notifications", sca.feedNotifications))
+
+	// If we are not running in tests we should register a table initializer to
+	// delay pruning until ClusterMesh has catched up. This happens via
+	// (*Daemon).initRestore in daemon/cmd/state.go. Once ClusterMesh has switched
+	// to using the Writer directly this can be removed.
+	var initDone func(WriteTxn)
+	if p.TestConfig == nil {
+		initDone = p.Writer.RegisterInitializer("adapters")
+	} else {
+		initDone = func(WriteTxn) {}
+	}
+	sma = &serviceManagerAdapter{
+		log:       p.Log,
+		db:        p.DB,
+		services:  p.Services,
+		frontends: p.Frontends,
+		writer:    p.Writer,
+		initDone:  initDone,
+	}
+	return
+}
+
+type serviceCacheAdapter struct {
+	log           *slog.Logger
+	db            *statedb.DB
+	services      statedb.Table[*Service]
+	backends      statedb.Table[*Backend]
+	writer        *Writer
+	notifications stream.Observable[k8s.ServiceNotification]
+	emit          func(k8s.ServiceNotification)
+	complete      func(error)
+}
+
+// DebugStatus implements k8s.ServiceCache.
+func (s *serviceCacheAdapter) DebugStatus() string {
+	return "<experimental.serviceCacheAdapter>"
+}
+
+// DeleteEndpoints implements k8s.ServiceCache.
+func (s *serviceCacheAdapter) DeleteEndpoints(svcID k8s.EndpointSliceID, swg *lock.StoppableWaitGroup) k8s.ServiceID {
+	s.log.Debug("serviceCacheAdapter: Ignoring DeleteEndpoints", "svcID", svcID)
+	return k8s.ServiceID{}
+}
+
+// DeleteService implements k8s.ServiceCache.
+func (s *serviceCacheAdapter) DeleteService(k8sSvc *v1.Service, swg *lock.StoppableWaitGroup) {
+	s.log.Debug("serviceCacheAdapter: Ignoring DeleteService", "name", k8sSvc.Namespace+"/"+k8sSvc.Name)
+}
+
+// EnsureService implements k8s.ServiceCache.
+func (s *serviceCacheAdapter) EnsureService(svcID k8s.ServiceID, swg *lock.StoppableWaitGroup) bool {
+	s.log.Debug("serviceCacheAdapter: Ignoring EnsureService", "svcID", svcID)
+	return true
+}
+
+// Events implements k8s.ServiceCache.
+func (s *serviceCacheAdapter) Events() <-chan k8s.ServiceEvent {
+	return make(chan k8s.ServiceEvent)
+}
+
+// GetServiceAddrsWithType implements k8s.ServiceCache.
+func (s *serviceCacheAdapter) GetServiceAddrsWithType(svcID k8s.ServiceID, svcType loadbalancer.SVCType) (map[loadbalancer.FEPortName][]*loadbalancer.L3n4Addr, int) {
+	// Used by LRP, which is not used when new implementation is enabled.
+	panic("unimplemented")
+}
+
+// GetServiceFrontendIP implements k8s.ServiceCache.
+func (s *serviceCacheAdapter) GetServiceFrontendIP(svcID k8s.ServiceID, svcType loadbalancer.SVCType) net.IP {
+	// Used by LRP, which is not used when new implementation is enabled.
+	panic("unimplemented")
+}
+
+// LocalServices implements k8s.ServiceCache.
+func (s *serviceCacheAdapter) LocalServices() sets.Set[k8s.ServiceID] {
+	// Used for the "two-phase GC" of services with ClusterMesh, e.g. the cluster-local services are GCd first
+	// to clean up any stale info about clustermesh etcd endpoints and then the second phase cleans up everything.
+	// This method is used to return the services that are cluster-local.
+	// With the new implementation this "two-phase GC" is not needed as the new implementation does not restore
+	// services from BPF maps but updates them directly and later prunes once both k8s and ClusterMesh has synced.
+	return nil
+}
+
+// MergeClusterServiceDelete implements k8s.ServiceCache.
+func (s *serviceCacheAdapter) MergeClusterServiceDelete(service *store.ClusterService, swg *lock.StoppableWaitGroup) {
+	name := loadbalancer.ServiceName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+		// TODO ClusterAware
+		// Cluster: csvc.Cluster,
+	}
+	txn := s.writer.WriteTxn()
+	defer txn.Commit()
+	s.writer.DeleteServiceAndFrontends(
+		txn,
+		name,
+	)
+}
+
+// MergeClusterServiceUpdate implements k8s.ServiceCache.
+func (s *serviceCacheAdapter) MergeClusterServiceUpdate(service *store.ClusterService, swg *lock.StoppableWaitGroup) {
+	svc, fes := clusterServiceToServiceAndFrontends(service)
+
+	txn := s.writer.WriteTxn()
+	defer txn.Commit()
+	s.writer.UpsertServiceAndFrontends(
+		txn,
+		svc,
+		fes...,
+	)
+}
+
+// MergeExternalServiceDelete implements k8s.ServiceCache.
+func (s *serviceCacheAdapter) MergeExternalServiceDelete(service *store.ClusterService, swg *lock.StoppableWaitGroup) {
+	if service.Cluster == option.Config.ClusterName {
+		// Ignore updates of own cluster
+		return
+	}
+	name := loadbalancer.ServiceName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+		// TODO ClusterAware
+		// Cluster: csvc.Cluster,
+	}
+	txn := s.writer.WriteTxn()
+	defer txn.Commit()
+	s.writer.DeleteBackendsOfService(
+		txn,
+		name,
+		source.ClusterMesh,
+	)
+}
+
+// MergeExternalServiceUpdate implements k8s.ServiceCache.
+func (s *serviceCacheAdapter) MergeExternalServiceUpdate(service *store.ClusterService, swg *lock.StoppableWaitGroup) {
+	if service.Cluster == option.Config.ClusterName {
+		// Ignore updates of own cluster
+		return
+	}
+
+	name := loadbalancer.ServiceName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+		// TODO ClusterAware
+		// Cluster: service.Cluster,
+	}
+
+	backends := clusterServiceToBackendParams(service)
+	txn := s.writer.WriteTxn()
+	defer txn.Commit()
+	s.writer.UpsertBackends(
+		txn,
+		name,
+		source.ClusterMesh,
+		backends...,
+	)
+}
+
+func clusterServiceToBackendParams(service *store.ClusterService) (beps []BackendParams) {
+	for ipString, portConfig := range service.Backends {
+		addrCluster, err := cmtypes.ParseAddrCluster(ipString)
+		if err != nil {
+			continue
+		}
+		for name, l4 := range portConfig {
+			portNames := []string(nil)
+			if name != "" {
+				portNames = []string{name}
+			}
+			bep := BackendParams{
+				L3n4Addr: loadbalancer.L3n4Addr{
+					AddrCluster: addrCluster,
+					L4Addr:      *l4,
+				},
+				PortNames: portNames,
+				Weight:    0,
+				NodeName:  "",
+				ZoneID:    0,
+				State:     loadbalancer.BackendStateActive,
+			}
+			beps = append(beps, bep)
+		}
+	}
+	return
+}
+
+func clusterServiceToServiceAndFrontends(csvc *store.ClusterService) (*Service, []FrontendParams) {
+	name := loadbalancer.ServiceName{
+		// TODO ClusterAware
+		// Cluster: csvc.Cluster,
+		Name:      csvc.Name,
+		Namespace: csvc.Namespace,
+	}
+	svc := &Service{
+		Name:             name,
+		Source:           source.ClusterMesh,
+		Labels:           labels.Map2Labels(csvc.Labels, string(source.ClusterMesh)),
+		Selector:         csvc.Selector,
+		NatPolicy:        loadbalancer.SVCNatPolicyNone,
+		ExtTrafficPolicy: loadbalancer.SVCTrafficPolicyCluster,
+		IntTrafficPolicy: loadbalancer.SVCTrafficPolicyCluster,
+	}
+
+	fes := make([]FrontendParams, 0, len(csvc.Frontends))
+	for ipStr, ports := range csvc.Frontends {
+		addrCluster, err := cmtypes.ParseAddrCluster(ipStr)
+		if err != nil {
+			continue
+		}
+		for portName, port := range ports {
+			l4 := loadbalancer.NewL4Addr(loadbalancer.L4Type(port.Protocol), uint16(port.Port))
+			portName := loadbalancer.FEPortName(portName)
+			fes = append(fes,
+				FrontendParams{
+					Address: loadbalancer.L3n4Addr{
+						AddrCluster: addrCluster,
+						L4Addr:      *l4,
+					},
+					Type:        loadbalancer.SVCTypeClusterIP,
+					ServiceName: name,
+					PortName:    portName,
+					ServicePort: l4.Port,
+				},
+			)
+		}
+	}
+	return svc, fes
+}
+
+// UpdateEndpoints implements k8s.ServiceCache.
+func (s *serviceCacheAdapter) UpdateEndpoints(newEndpoints *k8s.Endpoints, swg *lock.StoppableWaitGroup) (k8s.ServiceID, *k8s.Endpoints) {
+	s.log.Debug("serviceCacheAdapter: Ignoring UpdateEndpoints", "name", newEndpoints.Namespace+"/"+newEndpoints.Name)
+	return k8s.ServiceID{}, newEndpoints
+}
+
+// UpdateService implements k8s.ServiceCache.
+func (s *serviceCacheAdapter) UpdateService(k8sSvc *v1.Service, swg *lock.StoppableWaitGroup) k8s.ServiceID {
+	s.log.Debug("serviceCacheAdapter: Ignoring UpdateService", "name", k8sSvc.Namespace+"/"+k8sSvc.Name)
+	return k8s.ServiceID{}
+}
+
+func newMinimalService(svc *Service) *k8s.MinimalService {
+	return &k8s.MinimalService{
+		Labels:      svc.Labels.K8sStringMap(),
+		Annotations: svc.Annotations,
+		Selector:    svc.Selector,
+	}
+}
+
+func newMinimalEndpoints(svcName loadbalancer.ServiceName, backends iter.Seq[*Backend]) *k8s.MinimalEndpoints {
+	eps := &k8s.MinimalEndpoints{
+		Backends: map[cmtypes.AddrCluster]store.PortConfiguration{},
+	}
+	for be := range backends {
+		inst := be.GetInstance(svcName)
+		if inst == nil {
+			continue
+		}
+		ports, ok := eps.Backends[be.AddrCluster]
+		if !ok {
+			ports = store.PortConfiguration{}
+			eps.Backends[be.AddrCluster] = ports
+		}
+		if len(inst.PortNames) == 0 {
+			ports[""] = &be.L4Addr
+		} else {
+			for _, portName := range inst.PortNames {
+				ports[portName] = &be.L4Addr
+			}
+		}
+	}
+	return eps
+}
+
+// ForEachService implements k8s.ServiceCacheReader.
+func (s *serviceCacheAdapter) ForEachService(yield func(svcID k8s.ServiceID, svc *k8s.MinimalService, eps *k8s.MinimalEndpoints) bool) {
+	txn := s.db.ReadTxn()
+
+	for svc := range s.services.All(txn) {
+		backends := statedb.ToSeq(s.backends.List(txn, BackendByServiceName(svc.Name)))
+		if !yield(
+			k8s.ServiceID{
+				Cluster:   svc.Name.Cluster,
+				Name:      svc.Name.Name,
+				Namespace: svc.Name.Namespace,
+			},
+			newMinimalService(svc),
+			newMinimalEndpoints(svc.Name, backends),
+		) {
+			return
+		}
+	}
+}
+
+// Notifications implements k8s.ServiceCacheReader.
+func (s *serviceCacheAdapter) Notifications() stream.Observable[k8s.ServiceNotification] {
+	return s.notifications
+}
+
+// Notifications implements k8s.ServiceCacheReader.
+func (s *serviceCacheAdapter) feedNotifications(ctx context.Context, _ cell.Health) error {
+	state := map[loadbalancer.ServiceName]*k8s.ServiceNotification{}
+
+	wtxn := s.db.WriteTxn(s.services, s.backends)
+	defer wtxn.Abort()
+	serviceChanges, err := s.services.Changes(wtxn)
+	if err != nil {
+		s.complete(err)
+		return nil
+	}
+	backendChanges, err := s.backends.Changes(wtxn)
+	if err != nil {
+		s.complete(err)
+		return nil
+	}
+	wtxn.Commit()
+	defer s.complete(nil)
+
+	for {
+		txn := s.db.ReadTxn()
+
+		// Collect the names of all changed services. Both a change to a service or to the
+		// set of backends associated with a service is worthy of a notification.
+		changed := sets.Set[loadbalancer.ServiceName]{}
+
+		services, watchServices := serviceChanges.Next(txn)
+		for ev := range services {
+			changed.Insert(ev.Object.Name)
+		}
+
+		backends, watchBackends := backendChanges.Next(txn)
+		for ev := range backends {
+			be := ev.Object
+			for inst := range be.Instances.All() {
+				changed.Insert(inst.ServiceName)
+			}
+		}
+
+		// For each changed service look it up along with the associated backends and
+		// emit a notification for it.
+		for name := range changed {
+			// Look up the service and the previous notification we sent for it.
+			n, stateFound := state[name]
+			svc, _, found := s.services.Get(txn, ServiceByName(name))
+
+			// If no previously sent notification is found then no need to emit anything
+			// for the deletion.
+			if !found && !stateFound {
+				continue
+			}
+
+			if found {
+				if !stateFound {
+					n = &k8s.ServiceNotification{
+						ID: k8s.ServiceID{
+							Cluster:   name.Cluster,
+							Name:      name.Name,
+							Namespace: name.Namespace,
+						},
+					}
+					state[name] = n
+				}
+				n.Action = k8s.UpdateService
+				n.OldService = n.Service
+				n.OldEndpoints = n.Endpoints
+				n.Service = newMinimalService(svc)
+				backends := statedb.ToSeq(s.backends.List(txn, BackendByServiceName(name)))
+				n.Endpoints = newMinimalEndpoints(name, backends)
+			} else {
+				n.Action = k8s.DeleteService
+				n.Service = n.OldService
+				n.Endpoints = n.OldEndpoints
+				n.OldService = nil
+				n.OldEndpoints = nil
+				delete(state, name)
+			}
+
+			s.emit(*n)
+		}
+
+		select {
+		case <-watchServices:
+		case <-watchBackends:
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+var _ k8s.ServiceCache = &serviceCacheAdapter{}
+
+type serviceManagerAdapter struct {
+	log       *slog.Logger
+	db        *statedb.DB
+	services  statedb.Table[*Service]
+	frontends statedb.Table[*Frontend]
+	writer    *Writer
+
+	initDone func(WriteTxn)
+}
+
+// DeleteService implements service.ServiceManager.
+func (s *serviceManagerAdapter) DeleteService(frontend loadbalancer.L3n4Addr) (bool, error) {
+	s.log.Debug("serviceManagerAdapter: Ignoring DeleteService", "frontend", frontend.StringWithProtocol())
+	return true, nil
+}
+
+// DeleteServiceByID implements service.ServiceManager.
+func (s *serviceManagerAdapter) DeleteServiceByID(id loadbalancer.ServiceID) (bool, error) {
+	// Used by REST API.
+	s.log.Debug("serviceManagerAdapter: Ignoring DeleteServiceByID", "id", id)
+	return true, nil
+}
+
+// DeregisterL7LBServiceBackendSync implements service.ServiceManager.
+func (s *serviceManagerAdapter) DeregisterL7LBServiceBackendSync(serviceName loadbalancer.ServiceName, backendSyncRegistration service.BackendSyncer) error {
+	// Used by ciliumenvoyconfig, but not when new implementation is enabled.
+	panic("unimplemented")
+}
+
+// DeregisterL7LBServiceRedirect implements service.ServiceManager.
+func (s *serviceManagerAdapter) DeregisterL7LBServiceRedirect(serviceName loadbalancer.ServiceName, resourceName service.L7LBResourceName) error {
+	// Used by ciliumenvoyconfig, but not when new implementation is enabled.
+	panic("unimplemented")
+}
+
+// GetCurrentTs implements service.ServiceManager.
+func (s *serviceManagerAdapter) GetCurrentTs() time.Time {
+	// Used by kubeproxyhealthz.
+	return time.Now()
+}
+
+// GetDeepCopyServiceByFrontend implements service.ServiceManager.
+func (s *serviceManagerAdapter) GetDeepCopyServiceByFrontend(frontend loadbalancer.L3n4Addr) (*loadbalancer.SVC, bool) {
+	// Used by pod watcher, which will be replaced when new implementation is enabled.
+	return nil, false
+}
+
+// GetDeepCopyServiceByID implements service.ServiceManager.
+func (s *serviceManagerAdapter) GetDeepCopyServiceByID(id loadbalancer.ServiceID) (*loadbalancer.SVC, bool) {
+	// Used by REST API
+	return nil, false
+}
+
+// GetDeepCopyServices implements service.ServiceManager.
+func (s *serviceManagerAdapter) GetDeepCopyServices() (svcs []*loadbalancer.SVC) {
+	// Used by REST API.
+	txn := s.db.ReadTxn()
+	for fe := range s.frontends.All(txn) {
+		bes := []*loadbalancer.Backend{}
+		svc := fe.service
+		for be := range fe.Backends {
+			// Get the instance of the referenced service. This may be different from fe.ServiceName
+			// if it is being redirected.
+			beModel := &loadbalancer.Backend{
+				FEPortName: "",
+				ID:         0,
+				Weight:     be.Weight,
+				NodeName:   be.NodeName,
+				ZoneID:     be.ZoneID,
+				L3n4Addr:   be.L3n4Addr,
+				State:      be.State,
+				Preferred:  true,
+			}
+			if len(be.PortNames) == 0 {
+				bes = append(bes, beModel)
+			} else {
+				for _, portName := range be.PortNames {
+					beModel = beModel.DeepCopy()
+					beModel.FEPortName = portName
+					bes = append(bes, beModel)
+				}
+			}
+		}
+		proxyPort := uint16(0)
+		if svc.ProxyRedirect != nil {
+			proxyPort = svc.ProxyRedirect.ProxyPort
+		}
+
+		svcType := fe.Type
+		if fe.RedirectTo != nil {
+			svcType = loadbalancer.SVCTypeLocalRedirect
+		}
+
+		svcModel := &loadbalancer.SVC{
+			Frontend: loadbalancer.L3n4AddrID{
+				L3n4Addr: fe.Address,
+				ID:       loadbalancer.ID(fe.ID),
+			},
+			Type:        svcType,
+			Name:        fe.ServiceName,
+			Annotations: fe.service.Annotations,
+			Backends:    bes,
+
+			ForwardingMode:            "", // FIXME (not implemented)
+			ExtTrafficPolicy:          svc.ExtTrafficPolicy,
+			IntTrafficPolicy:          svc.IntTrafficPolicy,
+			NatPolicy:                 svc.NatPolicy,
+			SourceRangesPolicy:        "", // FIXME (not implemented)
+			SessionAffinity:           svc.SessionAffinity,
+			SessionAffinityTimeoutSec: uint32(svc.SessionAffinityTimeout),
+			HealthCheckNodePort:       svc.HealthCheckNodePort,
+			LoadBalancerAlgorithm:     svc.GetLBAlgorithmAnnotation(),
+			LoadBalancerSourceRanges:  nil, // FIXME CIDR vs *CIDR
+			L7LBProxyPort:             proxyPort,
+			LoopbackHostport:          svc.LoopbackHostPort,
+		}
+		svcs = append(svcs, svcModel)
+	}
+	return
+}
+
+// GetLastUpdatedTs implements service.ServiceManager.
+func (s *serviceManagerAdapter) GetLastUpdatedTs() time.Time {
+	// Used by kubeproxyhealthz. Unclear how important it is to have real last updated time here.
+	// We could e.g. keep a timestamp behind an atomic in BPFOps to implement that.
+	return time.Now()
+}
+
+// InitMaps implements service.ServiceManager.
+func (s *serviceManagerAdapter) InitMaps(ipv6 bool, ipv4 bool, sockMaps bool, restore bool) error {
+	// No need for this since new implementation manages its own maps. Called from daemon/cmd/datapath.go.
+	s.log.Debug("serviceManagerAdapter: Ignoring InitMaps")
+	return nil
+}
+
+// RegisterL7LBServiceBackendSync implements service.ServiceManager.
+func (s *serviceManagerAdapter) RegisterL7LBServiceBackendSync(serviceName loadbalancer.ServiceName, backendSyncRegistration service.BackendSyncer) error {
+	// Used by ciliumenvoyconfig, but not when new implementation is enabled.
+	panic("unimplemented")
+}
+
+// RegisterL7LBServiceRedirect implements service.ServiceManager.
+func (s *serviceManagerAdapter) RegisterL7LBServiceRedirect(serviceName loadbalancer.ServiceName, resourceName service.L7LBResourceName, proxyPort uint16, frontendPorts []uint16) error {
+	// Used by ciliumenvoyconfig, but not when new implementation is enabled.
+	panic("unimplemented")
+}
+
+// RestoreServices implements service.ServiceManager.
+func (s *serviceManagerAdapter) RestoreServices() error {
+	s.log.Debug("serviceManagerAdapter: Ignoring RestoreServices")
+	return nil
+}
+
+// SyncNodePortFrontends implements service.ServiceManager.
+func (s *serviceManagerAdapter) SyncNodePortFrontends(sets.Set[netip.Addr]) error {
+	s.log.Debug("serviceManagerAdapter: Ignoring SyncNodePortFrontends")
+	return nil
+}
+
+// SyncWithK8sFinished implements service.ServiceManager.
+func (s *serviceManagerAdapter) SyncWithK8sFinished(localOnly bool, localServices sets.Set[k8s.ServiceID]) (stale []k8s.ServiceID, err error) {
+	if !localOnly {
+		txn := s.writer.WriteTxn()
+		s.initDone(txn)
+		txn.Commit()
+	}
+	return
+}
+
+// TerminateUDPConnectionsToBackend implements service.ServiceManager.
+func (s *serviceManagerAdapter) TerminateUDPConnectionsToBackend(l3n4Addr *loadbalancer.L3n4Addr) {
+	// Used by LRP, but not when new implementation is enabled.
+	panic("unimplemented")
+}
+
+// UpdateBackendsState implements service.ServiceManager.
+func (s *serviceManagerAdapter) UpdateBackendsState(backends []*loadbalancer.Backend) ([]loadbalancer.L3n4Addr, error) {
+	// Used by REST API.
+	s.log.Debug("serviceManagerAdapter: Ignoring UpdateBackendsState")
+	return nil, nil
+}
+
+// UpsertService implements service.ServiceManager.
+func (s *serviceManagerAdapter) UpsertService(svc *loadbalancer.SVC) (bool, loadbalancer.ID, error) {
+	// Used by pod watcher, LRP and REST API
+	s.log.Debug("serviceManagerAdapter: Ignoring UpsertService", "name", svc.Name)
+	return true, 0, nil
+}
+
+// GetServiceIDs implements service.ServiceReader.
+func (s *serviceManagerAdapter) GetServiceIDs() []loadbalancer.ServiceID {
+	// Used by pkg/act.
+
+	txn := s.db.ReadTxn()
+	ids := make([]loadbalancer.ServiceID, 0, s.frontends.NumObjects(txn))
+	for fe := range s.frontends.All(txn) {
+		if fe.Status.Kind == reconciler.StatusKindDone {
+			ids = append(ids, fe.ID)
+		}
+	}
+	return ids
+}
+
+// GetServiceNameByAddr implements service.ServiceReader.
+func (s *serviceManagerAdapter) GetServiceNameByAddr(addr loadbalancer.L3n4Addr) (string, string, bool) {
+	// Used by hubble.
+
+	txn := s.db.ReadTxn()
+
+	fe, _, found := s.frontends.Get(txn, FrontendByAddress(addr))
+	if !found {
+		return "", "", false
+	}
+	return fe.service.Name.Namespace, fe.service.Name.Name, true
+}
+
+var _ service.ServiceManager = &serviceManagerAdapter{}

--- a/pkg/loadbalancer/experimental/cell.go
+++ b/pkg/loadbalancer/experimental/cell.go
@@ -35,17 +35,23 @@ var Cell = cell.Module(
 	ReconcilerCell,
 
 	// Provide [lbmaps], abstraction for the load-balancing BPF map access.
-	cell.ProvidePrivate(newLBMaps, newLBMapsConfig),
+	cell.ProvidePrivate(newLBMaps),
 
 	// Provide the 'lb/' script commands for debugging and testing.
 	cell.Provide(scriptCommands),
 
-	//
 	// Health server runs an HTTP server for each service on port [HealthCheckNodePort]
 	// (when non-zero) and responds with the number of healthy backends.
 	healthServerCell,
 
+	// Register a background job to re-reconcile NodePort and HostPort frontends when
+	// the node addresses change.
 	cell.Invoke(registerNodePortAddressReconciler),
+
+	// Replace the [k8s.ServiceCacheReader] and [service.ServiceReader] if this
+	// implementation is enabled.
+	cell.Provide(newAdapters),
+	cell.DecorateAll(decorateAdapters),
 )
 
 // TablesCell provides the [Writer] API for configuring load-balancing and the

--- a/pkg/loadbalancer/experimental/errors.go
+++ b/pkg/loadbalancer/experimental/errors.go
@@ -9,4 +9,8 @@ var (
 	// ErrServiceNotFound occurs when a frontend is being upserted that refers to
 	// a non-existing service.
 	ErrServiceNotFound = errors.New("service not found")
+
+	// ErrFrontendConflict occurs when a frontend is being upserted but it already
+	// exists and is owned by a different service.
+	ErrFrontendConflict = errors.New("frontend already owned by another service")
 )

--- a/pkg/loadbalancer/experimental/frontend.go
+++ b/pkg/loadbalancer/experimental/frontend.go
@@ -4,7 +4,10 @@
 package experimental
 
 import (
+	"encoding/json"
+	"fmt"
 	"iter"
+	"slices"
 	"strings"
 
 	"github.com/cilium/statedb"
@@ -50,7 +53,19 @@ type Frontend struct {
 	Status reconciler.Status
 
 	// Backends associated with the frontend.
-	Backends iter.Seq2[*Backend, statedb.Revision]
+	Backends backendsSeq2
+
+	// ID is the identifier allocated to this frontend. Used as the key
+	// in the services BPF map. This field is populated by the reconciler
+	// and is initially set to zero. It can be considered valid only when
+	// [Status] is set to done.
+	ID loadbalancer.ServiceID
+
+	// RedirectTo if set selects the backends from this service name instead
+	// of that of [FrontendParams.ServiceName]. This is used to implement the
+	// local redirect policies where traffic going to a specific service/frontend
+	// is redirected to a local pod instead.
+	RedirectTo *loadbalancer.ServiceName
 
 	// service associated with the frontend. If service is updated
 	// this pointer to the service will update as well and the
@@ -61,9 +76,16 @@ type Frontend struct {
 	service *Service
 }
 
-type BackendWithRevision struct {
-	*Backend
-	Revision statedb.Revision
+// backendsSeq2 is an iterator for sequence of backends that is also JSON and YAML
+// marshalable.
+type backendsSeq2 iter.Seq2[BackendParams, statedb.Revision]
+
+func (s backendsSeq2) MarshalJSON() ([]byte, error) {
+	return json.Marshal(slices.Collect(statedb.ToSeq(iter.Seq2[BackendParams, statedb.Revision](s))))
+}
+
+func (s backendsSeq2) MarshalYAML() (any, error) {
+	return slices.Collect(statedb.ToSeq(iter.Seq2[BackendParams, statedb.Revision](s))), nil
 }
 
 func (fe *Frontend) Service() *Service {
@@ -91,6 +113,7 @@ func (fe *Frontend) TableHeader() []string {
 		"ServiceName",
 		"PortName",
 		"Backends",
+		"RedirectTo",
 		"Status",
 		"Since",
 		"Error",
@@ -98,12 +121,17 @@ func (fe *Frontend) TableHeader() []string {
 }
 
 func (fe *Frontend) TableRow() []string {
+	redirectTo := ""
+	if fe.RedirectTo != nil {
+		redirectTo = fe.RedirectTo.String()
+	}
 	return []string{
 		fe.Address.StringWithProtocol(),
 		string(fe.Type),
 		fe.ServiceName.String(),
 		string(fe.PortName),
 		showBackends(fe.Backends),
+		redirectTo,
 		string(fe.Status.Kind),
 		duration.HumanDuration(time.Since(fe.Status.UpdatedAt)),
 		fe.Status.Error,
@@ -111,29 +139,30 @@ func (fe *Frontend) TableRow() []string {
 }
 
 // showBackends returns the backends associated with a frontend in form
-// "1.2.3.4:80 (active), [2001::1]:443 (terminating)"
-// TODO: Skip showing the state?
-func showBackends(bes iter.Seq2[*Backend, statedb.Revision]) string {
+// "1.2.3.4:80, [2001::1]:443"
+func showBackends(bes backendsSeq2) string {
+	const maxToShow = 5
+	count := 0
 	var b strings.Builder
 	for be := range bes {
-		b.WriteString(be.L3n4Addr.String())
-		b.WriteString(" (")
-		state, err := be.State.String()
-		if err != nil {
-			state = err.Error()
+		if count < maxToShow {
+			b.WriteString(be.L3n4Addr.String())
+			b.WriteString(", ")
 		}
-		b.WriteString(state)
-		b.WriteString(")")
-		b.WriteString(", ")
+		count++
 	}
 	s := b.String()
 	s, _ = strings.CutSuffix(s, ", ")
+
+	if count > maxToShow {
+		s += fmt.Sprintf(" + %d more ...", count-maxToShow)
+	}
 	return s
 }
 
 var (
 	frontendAddressIndex = statedb.Index[*Frontend, loadbalancer.L3n4Addr]{
-		Name: "frontends",
+		Name: "address",
 		FromObject: func(fe *Frontend) index.KeySet {
 			return index.NewKeySet(fe.Address.Bytes())
 		},

--- a/pkg/loadbalancer/experimental/healthserver.go
+++ b/pkg/loadbalancer/experimental/healthserver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/statedb"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/rate"
@@ -40,14 +41,16 @@ var healthServerCell = cell.Module(
 type healthServerParams struct {
 	cell.In
 
-	Jobs      job.Group
-	Log       *slog.Logger
-	DB        *statedb.DB
-	Config    Config
-	ExtConfig ExternalConfig
-	Frontends statedb.Table[*Frontend]
-	Backends  statedb.Table[*Backend]
-	Writer    *Writer
+	Jobs          job.Group
+	Log           *slog.Logger
+	DB            *statedb.DB
+	Config        Config
+	TestConfig    *TestConfig `optional:"true"`
+	ExtConfig     ExternalConfig
+	Frontends     statedb.Table[*Frontend]
+	Backends      statedb.Table[*Backend]
+	Writer        *Writer
+	NodeAddresses statedb.Table[tables.NodeAddress]
 }
 
 // healthServer manages HTTP health check ports. For each added service,
@@ -55,14 +58,15 @@ type healthServerParams struct {
 // responds with 200 OK if there are local endpoints for the service, or with
 // 503 Service Unavailable if the service does not have any local endpoints.
 type healthServer struct {
-	params        healthServerParams
-	serverByPort  map[uint16]*httpHealthServer
-	portByService map[lb.ServiceName]uint16
-	nodeName      string
+	params           healthServerParams
+	serverByPort     map[uint16]*httpHealthServer
+	portByService    map[lb.ServiceName]uint16
+	nodeName         string
+	healthServerAddr *cmtypes.AddrCluster
 }
 
 func registerHealthServer(params healthServerParams) {
-	if !params.Config.EnableExperimentalLB || !params.ExtConfig.EnableHealthCheckNodePort {
+	if !params.Config.EnableExperimentalLB {
 		return
 	}
 
@@ -71,14 +75,20 @@ func registerHealthServer(params healthServerParams) {
 		serverByPort:  map[uint16]*httpHealthServer{},
 		portByService: map[lb.ServiceName]uint16{},
 	}
+
+	if params.TestConfig != nil {
+		addr := chooseHealthServerLoopbackAddressForTesting()
+		addrCluster := cmtypes.AddrClusterFrom(addr, 0)
+		s.healthServerAddr = &addrCluster
+	}
+
 	params.Jobs.Add(job.OneShot("control-loop", s.controlLoop))
 }
 
-func chooseHealthServerLoopbackAddress() netip.Addr {
+func chooseHealthServerLoopbackAddressForTesting() netip.Addr {
 	// Choose a loopback IP address that's tied to the process ID.
 	// This makes it possible to stress test the health server in parallel
-	// as each process gets its own address. In production the agent runs
-	// in its own PID namespace and this always returns 127.1.0.1.
+	// as each process gets its own address.
 	pid := os.Getpid()
 	return netip.AddrFrom4(
 		[4]byte{
@@ -90,15 +100,12 @@ func chooseHealthServerLoopbackAddress() netip.Addr {
 	)
 }
 
-var (
-	// healthServerAddr is the IP address on which the health HTTP servers
-	// listen on. We use the process ID as the seed for choosing the address
-	// to allow parallel testing. In production use it's deterministically
-	// 127.1.0.1.
-	healthServerAddr = cmtypes.AddrClusterFrom(chooseHealthServerLoopbackAddress(), 0)
-)
-
 func (s *healthServer) controlLoop(ctx context.Context, health cell.Health) error {
+	extCfg := s.params.ExtConfig
+	if !extCfg.KubeProxyReplacement || !extCfg.EnableHealthCheckNodePort {
+		return nil
+	}
+
 	s.nodeName = nodeTypes.GetName()
 
 	// Watch services for changes to add and remove the listeners.
@@ -111,6 +118,7 @@ func (s *healthServer) controlLoop(ctx context.Context, health cell.Health) erro
 
 	// Limit the rate at which the change batches are processed.
 	limiter := rate.NewLimiter(100*time.Millisecond, 1)
+	defer limiter.Stop()
 
 	defer s.cleanupListeners(ctx)
 
@@ -122,13 +130,13 @@ func (s *healthServer) controlLoop(ctx context.Context, health cell.Health) erro
 		changes, watch := frontendChanges.Next(s.params.DB.ReadTxn())
 		for change := range changes {
 			fe := change.Object
-			if fe.Type != lb.SVCTypeLoadBalancer {
+			if (fe.Type != lb.SVCTypeLoadBalancer && fe.Type != lb.SVCTypeNodePort) ||
+				fe.Address.Scope == lb.ScopeInternal {
 				continue
 			}
 
 			svc := fe.service
 			name := svc.Name
-			healthServiceName := name.AppendSuffix("-healthserver")
 			port := svc.HealthCheckNodePort
 
 			// Health server is only for LoadBalancer services with a local
@@ -139,68 +147,93 @@ func (s *healthServer) controlLoop(ctx context.Context, health cell.Health) erro
 
 			// Check if a health checker server exists already for this service and remove it if port has changed
 			// or if the service is no longer applicable.
+			// NOTE: A complication here is that we may have both a NodePort and a LoadBalancer frontend and
+			// we will process both here. We may see the NodePort first and create the listener and then we'll
+			// see the LoadBalancer and create the Frontend for providing access to the health server using the
+			// LoadBalancer VIP.
 			oldPort, exists := s.portByService[name]
 			if exists && (oldPort != port || !needsServer) {
 				s.removeListener(ctx, oldPort)
 				delete(s.portByService, name)
 				exists = false
-				wtxn := s.params.Writer.WriteTxn()
-				s.params.Writer.DeleteServiceAndFrontends(
-					wtxn,
-					healthServiceName,
-				)
-				wtxn.Commit()
 			}
 
-			if !needsServer || exists {
-				continue
+			if !exists && needsServer {
+				s.addListener(svc, port)
+				s.portByService[name] = port
 			}
 
-			s.serverByPort[port] = s.addListener(svc, port)
-			s.portByService[name] = port
+			if fe.Type == lb.SVCTypeLoadBalancer {
+				healthServiceName := name.AppendSuffix(":healthserver")
+				if !needsServer {
+					wtxn := s.params.Writer.WriteTxn()
+					s.params.Writer.DeleteBackendsOfService(wtxn, healthServiceName, source.Local)
+					s.params.Writer.DeleteServiceAndFrontends(wtxn, healthServiceName)
+					wtxn.Commit()
+				} else {
+					// Create a LoadBalancer service to expose the health server on the $LB_VIP.
+					// For NodePort we don't need anything as the HealthServer is already listening on
+					// all node addresses.
+					wtxn := s.params.Writer.WriteTxn()
+					s.params.Writer.UpsertServiceAndFrontends(
+						wtxn,
+						&Service{
+							Name:             healthServiceName,
+							Source:           source.Local,
+							ExtTrafficPolicy: lb.SVCTrafficPolicyLocal,
+							IntTrafficPolicy: lb.SVCTrafficPolicyLocal,
+						},
+						FrontendParams{
+							Address: lb.L3n4Addr{
+								AddrCluster: fe.Address.AddrCluster,
+								L4Addr: lb.L4Addr{
+									Protocol: lb.TCP,
+									Port:     port,
+								},
+								Scope: lb.ScopeExternal,
+							},
+							Type:        lb.SVCTypeLoadBalancer,
+							ServiceName: healthServiceName,
+							ServicePort: port,
+						},
+					)
 
-			// Create a NodePort service to expose the health server.
-			wtxn := s.params.Writer.WriteTxn()
-			s.params.Writer.UpsertServiceAndFrontends(
-				wtxn,
-				&Service{
-					Name:             healthServiceName,
-					Source:           source.Local,
-					ExtTrafficPolicy: lb.SVCTrafficPolicyLocal,
-					IntTrafficPolicy: lb.SVCTrafficPolicyLocal,
-				},
-				FrontendParams{
-					Address: lb.L3n4Addr{
-						AddrCluster: fe.Address.AddrCluster,
-						L4Addr: lb.L4Addr{
-							Protocol: lb.TCP,
-							Port:     port,
+					// Find NodePort addr to use as a backend for $LB_VIP:$HC_NODEPORT frontend.
+					beAddr := netip.IPv4Unspecified()
+					is4 := fe.Address.AddrCluster.Is4()
+					if !is4 {
+						beAddr = netip.IPv6Unspecified()
+					}
+					for addr := range s.params.NodeAddresses.List(wtxn, tables.NodeAddressNodePortIndex.Query(true)) {
+						if is4 && addr.Addr.Is4() {
+							beAddr = addr.Addr
+							break
+						} else if !is4 && addr.Addr.Is6() {
+							beAddr = addr.Addr
+							break
+						}
+					}
+
+					s.params.Writer.SetBackends(
+						wtxn,
+						healthServiceName,
+						source.Local,
+						BackendParams{
+							L3n4Addr: lb.L3n4Addr{
+								AddrCluster: cmtypes.AddrClusterFrom(beAddr, 0),
+								L4Addr: lb.L4Addr{
+									Protocol: lb.TCP,
+									Port:     port,
+								},
+								Scope: lb.ScopeInternal,
+							},
+							NodeName: s.nodeName,
+							State:    lb.BackendStateActive,
 						},
-						Scope: lb.ScopeExternal,
-					},
-					Type:        fe.Type,
-					ServiceName: healthServiceName,
-					ServicePort: port,
-				},
-			)
-			s.params.Writer.UpsertBackends(
-				wtxn,
-				healthServiceName,
-				source.Local,
-				BackendParams{
-					L3n4Addr: lb.L3n4Addr{
-						AddrCluster: healthServerAddr,
-						L4Addr: lb.L4Addr{
-							Protocol: lb.TCP,
-							Port:     port,
-						},
-						Scope: lb.ScopeInternal,
-					},
-					NodeName: s.nodeName,
-					State:    lb.BackendStateActive,
-				},
-			)
-			wtxn.Commit()
+					)
+					wtxn.Commit()
+				}
+			}
 		}
 		health.OK(fmt.Sprintf("%d health servers running", len(s.serverByPort)))
 
@@ -218,7 +251,12 @@ func (s *healthServer) cleanupListeners(ctx context.Context) {
 	}
 }
 
-func (s *healthServer) addListener(svc *Service, port uint16) *httpHealthServer {
+func (s *healthServer) addListener(svc *Service, port uint16) {
+	if srv, exists := s.serverByPort[port]; exists {
+		s.params.Log.Warn("HealthServer: Listener already exists", "port", port, "new", svc.Name, "old", srv.name)
+		return
+	}
+
 	srv := &httpHealthServer{
 		nodeName: s.nodeName,
 		name:     svc.Name,
@@ -226,8 +264,12 @@ func (s *healthServer) addListener(svc *Service, port uint16) *httpHealthServer 
 		db:       s.params.DB,
 		backends: s.params.Backends,
 	}
+	bindAddr := fmt.Sprintf(":%d", port)
+	if s.healthServerAddr != nil {
+		bindAddr = s.healthServerAddr.Addr().String() + bindAddr
+	}
 	srv.Server = http.Server{
-		Addr:    fmt.Sprintf("%s:%d", healthServerAddr.Addr().String(), port),
+		Addr:    bindAddr,
 		Handler: srv,
 	}
 	s.params.Jobs.Add(
@@ -235,7 +277,6 @@ func (s *healthServer) addListener(svc *Service, port uint16) *httpHealthServer 
 			fmt.Sprintf("listener-%d", port),
 			func(ctx context.Context, health cell.Health) error {
 				if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-					fmt.Printf(">>> ListenAndServe: %s\n", err)
 					return err
 				}
 				return nil
@@ -246,8 +287,7 @@ func (s *healthServer) addListener(svc *Service, port uint16) *httpHealthServer 
 			}),
 		),
 	)
-
-	return srv
+	s.serverByPort[port] = srv
 }
 
 func (s *healthServer) removeListener(ctx context.Context, port uint16) {
@@ -287,11 +327,15 @@ func (h *httpHealthServer) getLocalEndpointCount() int {
 
 	txn := h.db.ReadTxn()
 
-	// Gather the backends. Since the service has traffic policy set to local the
-	// backends we find here are node local.
+	// Gather the backends for the service.
 	activeCount := 0
 	for be := range h.backends.List(txn, BackendByServiceName(h.name)) {
-		if be.State == lb.BackendStateActive {
+		inst := be.GetInstance(h.name)
+		if inst.NodeName != "" && inst.NodeName != h.nodeName {
+			// Skip non-local backends.
+			continue
+		}
+		if inst.State == lb.BackendStateActive {
 			activeCount++
 		}
 	}

--- a/pkg/loadbalancer/experimental/lbmaps.go
+++ b/pkg/loadbalancer/experimental/lbmaps.go
@@ -6,10 +6,10 @@ package experimental
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/rand/v2"
 	"os"
 	"reflect"
-	"strings"
 	"unsafe"
 
 	"github.com/cilium/hive/cell"
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/ebpf"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/option"
@@ -27,16 +28,17 @@ import (
 type lbmapsParams struct {
 	cell.In
 
+	Log          *slog.Logger
 	Lifecycle    cell.Lifecycle
 	TestConfig   *TestConfig `optional:"true"`
-	MapsConfig   LBMapsConfig
 	MaglevConfig maglev.Config
+	ExtConfig    ExternalConfig
 	Writer       *Writer
 }
 
-func newLBMaps(p lbmapsParams) LBMaps {
+func newLBMaps(p lbmapsParams) bpf.MapOut[LBMaps] {
 	if !p.Writer.IsEnabled() {
-		return nil
+		return bpf.MapOut[LBMaps]{}
 	}
 
 	pinned := true
@@ -55,13 +57,13 @@ func newLBMaps(p lbmapsParams) LBMaps {
 					failureProbability: p.TestConfig.TestFaultProbability,
 				}
 			}
-			return m
+			return bpf.NewMapOut(m)
 		}
 	}
 
-	r := &BPFLBMaps{Pinned: pinned, Cfg: p.MapsConfig, MaglevCfg: p.MaglevConfig}
+	r := &BPFLBMaps{Log: p.Log, Pinned: pinned, Cfg: p.ExtConfig, MaglevCfg: p.MaglevConfig}
 	p.Lifecycle.Append(r)
-	return r
+	return bpf.NewMapOut(LBMaps(r))
 }
 
 // LBMapsConfig specifies the configuration for the load-balancing BPF
@@ -152,8 +154,6 @@ type LBMaps interface {
 	sourceRangeMaps
 	maglevMaps
 
-	// TODO rest of the maps:
-	// SockRevNat, SkipLB
 	IsEmpty() bool
 }
 
@@ -161,7 +161,8 @@ type BPFLBMaps struct {
 	// Pinned if true will pin the maps to a file. Tests may turn this off.
 	Pinned bool
 
-	Cfg       LBMapsConfig
+	Log       *slog.Logger
+	Cfg       ExternalConfig
 	MaglevCfg maglev.Config
 
 	service4Map, service6Map         *ebpf.Map
@@ -170,6 +171,7 @@ type BPFLBMaps struct {
 	affinityMatchMap                 *ebpf.Map
 	sourceRange4Map, sourceRange6Map *ebpf.Map
 	maglev4Map, maglev6Map           *ebpf.Map // Inner maps are referenced inside maglev4Map and maglev6Map and can be retrieved by lbmap.MaglevInnerMapFromID.
+	maglevInnerMapSpec               *ebpf.MapSpec
 }
 
 func sizeOf[T any]() uint32 {
@@ -241,32 +243,22 @@ var (
 		KeySize:   sizeOf[lbmap.SourceRangeKey6](),
 		ValueSize: sizeOf[lbmap.SourceRangeValue](),
 	}
-
-	maglevInnerMapSpec = &ebpf.MapSpec{
-		Name:       lbmap.MaglevInnerMapName,
-		Type:       ebpf.Array,
-		KeySize:    uint32(unsafe.Sizeof(lbmap.MaglevInnerKey{})),
-		MaxEntries: 1,
-	}
-
-	maglev4MapSpec = &ebpf.MapSpec{
-		Name:      lbmap.MaglevOuter4MapName,
-		Type:      ebpf.HashOfMaps,
-		KeySize:   uint32(unsafe.Sizeof(lbmap.MaglevOuterKey{})),
-		ValueSize: uint32(unsafe.Sizeof(lbmap.MaglevOuterVal{})),
-		InnerMap:  maglevInnerMapSpec,
-		Pinning:   ebpf.PinByName,
-	}
-
-	maglev6MapSpec = &ebpf.MapSpec{
-		Name:      lbmap.MaglevOuter6MapName,
-		Type:      ebpf.HashOfMaps,
-		KeySize:   uint32(unsafe.Sizeof(lbmap.MaglevOuterKey{})),
-		ValueSize: uint32(unsafe.Sizeof(lbmap.MaglevOuterVal{})),
-		InnerMap:  maglevInnerMapSpec,
-		Pinning:   ebpf.PinByName,
-	}
 )
+
+func maglevMapSpec(ipv6 bool, innerSpec *ebpf.MapSpec) *ebpf.MapSpec {
+	name := lbmap.MaglevOuter4MapName
+	if ipv6 {
+		name = lbmap.MaglevOuter6MapName
+	}
+	return &ebpf.MapSpec{
+		Name:      name,
+		Type:      ebpf.HashOfMaps,
+		KeySize:   uint32(unsafe.Sizeof(lbmap.MaglevOuterKey{})),
+		ValueSize: uint32(unsafe.Sizeof(lbmap.MaglevOuterVal{})),
+		InnerMap:  innerSpec.Copy(),
+		Pinning:   ebpf.PinByName,
+	}
+}
 
 type mapDesc struct {
 	target     **ebpf.Map // pointer to the field in realLBMaps
@@ -274,40 +266,83 @@ type mapDesc struct {
 	maxEntries int
 }
 
-func (r *BPFLBMaps) allMaps() []mapDesc {
-	return []mapDesc{
+func (r *BPFLBMaps) allMaps() ([]mapDesc, []mapDesc) {
+	maglev4, maglev6 := maglevMapSpec(false, r.maglevInnerMapSpec), maglevMapSpec(true, r.maglevInnerMapSpec)
+	v4Maps := []mapDesc{
 		{&r.service4Map, service4MapSpec, r.Cfg.ServiceMapMaxEntries},
-		{&r.service6Map, service6MapSpec, r.Cfg.ServiceMapMaxEntries},
 		{&r.backend4Map, backend4MapSpec, r.Cfg.BackendMapMaxEntries},
-		{&r.backend6Map, backend6MapSpec, r.Cfg.BackendMapMaxEntries},
 		{&r.revNat4Map, revNat4MapSpec, r.Cfg.RevNatMapMaxEntries},
-		{&r.revNat6Map, revNat6MapSpec, r.Cfg.RevNatMapMaxEntries},
-		{&r.affinityMatchMap, affinityMatchMapSpec, r.Cfg.AffinityMapMaxEntries},
 		{&r.sourceRange4Map, sourceRange4MapSpec, r.Cfg.SourceRangeMapMaxEntries},
-		{&r.sourceRange6Map, sourceRange6MapSpec, r.Cfg.SourceRangeMapMaxEntries},
-		{&r.maglev4Map, maglev4MapSpec, r.Cfg.MaglevMapMaxEntries},
-		{&r.maglev6Map, maglev6MapSpec, r.Cfg.MaglevMapMaxEntries},
+		{&r.maglev4Map, maglev4, r.Cfg.MaglevMapMaxEntries},
 	}
+	v6Maps := []mapDesc{
+		{&r.service6Map, service6MapSpec, r.Cfg.ServiceMapMaxEntries},
+		{&r.backend6Map, backend6MapSpec, r.Cfg.BackendMapMaxEntries},
+		{&r.revNat6Map, revNat6MapSpec, r.Cfg.RevNatMapMaxEntries},
+		{&r.sourceRange6Map, sourceRange6MapSpec, r.Cfg.SourceRangeMapMaxEntries},
+		{&r.maglev6Map, maglev6, r.Cfg.MaglevMapMaxEntries},
+	}
+	mapsToCreate := []mapDesc{
+		{&r.affinityMatchMap, affinityMatchMapSpec, r.Cfg.AffinityMapMaxEntries},
+	}
+	mapsToDelete := []mapDesc{}
+	if r.Cfg.EnableIPv4 {
+		mapsToCreate = append(mapsToCreate, v4Maps...)
+	} else {
+		mapsToDelete = append(mapsToDelete, v4Maps...)
+	}
+	if r.Cfg.EnableIPv6 {
+		mapsToCreate = append(mapsToCreate, v6Maps...)
+	} else {
+		mapsToDelete = append(mapsToDelete, v6Maps...)
+	}
+	return mapsToCreate, mapsToDelete
 }
 
 // Start implements cell.HookInterface.
-func (r *BPFLBMaps) Start(cell.HookContext) error {
-	for _, desc := range r.allMaps() {
+func (r *BPFLBMaps) Start(ctx cell.HookContext) (err error) {
+	r.maglevInnerMapSpec = &ebpf.MapSpec{
+		Name:       lbmap.MaglevInnerMapName,
+		Type:       ebpf.Array,
+		KeySize:    uint32(unsafe.Sizeof(lbmap.MaglevInnerKey{})),
+		MaxEntries: 1,
+		ValueSize:  lbmap.MaglevBackendLen * uint32(r.MaglevCfg.MaglevTableSize),
+	}
+
+	mapsToCreate, mapsToDelete := r.allMaps()
+	for _, desc := range mapsToCreate {
+		// Make a shallow copy of the spec. We might be running tests in parallel
+		// and thus shouldn't mutate the original.
+		desc.spec = desc.spec.Copy()
+
 		if r.Pinned {
 			desc.spec.Pinning = ebpf.PinByName
 		} else {
 			desc.spec.Pinning = ebpf.PinNone
 		}
 		desc.spec.MaxEntries = uint32(desc.maxEntries)
-		if strings.HasSuffix(desc.spec.Name, "maglev") {
-			desc.spec.InnerMap.ValueSize = lbmap.MaglevBackendLen * uint32(r.MaglevCfg.MaglevTableSize)
-		}
 		m := ebpf.NewMap(desc.spec)
 		*desc.target = m
 
 		if err := m.OpenOrCreate(); err != nil {
-			fmt.Printf("open failed: spec: %+v, innermap: %+v\n", desc.spec, desc.spec.InnerMap)
 			return fmt.Errorf("opening map %s: %w", desc.spec.Name, err)
+		}
+	}
+
+	if !r.Pinned {
+		// nothing to unpin, return early
+		return nil
+	}
+
+	for _, desc := range mapsToDelete {
+		mapPath := bpf.MapPath(desc.spec.Name)
+		m, err := ebpf.LoadPinnedMap(mapPath)
+		if err != nil {
+			// Map not found, nothing to do.
+			continue
+		}
+		if err := m.Unpin(); err != nil {
+			r.Log.Warn("Unpin failed", logfields.Error, err)
 		}
 	}
 	return nil
@@ -316,7 +351,9 @@ func (r *BPFLBMaps) Start(cell.HookContext) error {
 // Stop implements cell.HookInterface.
 func (r *BPFLBMaps) Stop(cell.HookContext) error {
 	var errs []error
-	for _, desc := range r.allMaps() {
+
+	mapsToCreate, _ := r.allMaps()
+	for _, desc := range mapsToCreate {
 		m := *desc.target
 		if m != nil {
 			if err := m.Close(); err != nil {
@@ -330,6 +367,9 @@ func (r *BPFLBMaps) Stop(cell.HookContext) error {
 // iterateMap iterates over a BPF map, yielding new keys and values. Similar to
 // ebpf.IterateWithCallback but allocates new key & value instead of reusing.
 func iterateMap(m *ebpf.Map, newPair func() (any, any), cb func(any, any)) error {
+	if m == nil {
+		return nil
+	}
 	entries := m.Iterate()
 	for {
 		key, value := newPair()
@@ -546,7 +586,7 @@ func (r *BPFLBMaps) UpdateSourceRange(key lbmap.SourceRangeKey, value *lbmap.Sou
 
 // UpdateMaglev implements lbmaps.
 func (r *BPFLBMaps) UpdateMaglev(key lbmap.MaglevOuterKey, backendIDs []loadbalancer.BackendID, ipv6 bool) error {
-	inner := ebpf.NewMap(maglevInnerMapSpec)
+	inner := ebpf.NewMap(r.maglevInnerMapSpec)
 	if err := inner.OpenOrCreate(); err != nil {
 		return err
 	}
@@ -603,11 +643,15 @@ func (r *BPFLBMaps) DumpMaglev(cb func(lbmap.MaglevOuterKey, lbmap.MaglevOuterVa
 		}
 		cb(maglevKey, *maglevValue, singletonKey, innerValue, ipv6)
 	}
-	majorErrs := []error{
-		r.maglev4Map.IterateWithCallback(&lbmap.MaglevOuterKey{}, &lbmap.MaglevOuterVal{}, func(k, v any) { cbWrap(k, v, false) }),
-		r.maglev6Map.IterateWithCallback(&lbmap.MaglevOuterKey{}, &lbmap.MaglevOuterVal{}, func(k, v any) { cbWrap(k, v, true) }),
+	if r.maglev4Map != nil {
+		errs = append(errs,
+			r.maglev4Map.IterateWithCallback(&lbmap.MaglevOuterKey{}, &lbmap.MaglevOuterVal{}, func(k, v any) { cbWrap(k, v, false) }))
 	}
-	return errors.Join(append(majorErrs, errs...)...)
+	if r.maglev6Map != nil {
+		errs = append(errs,
+			r.maglev6Map.IterateWithCallback(&lbmap.MaglevOuterKey{}, &lbmap.MaglevOuterVal{}, func(k, v any) { cbWrap(k, v, true) }))
+	}
+	return errors.Join(errs...)
 }
 
 // IsEmpty implements lbmaps.

--- a/pkg/loadbalancer/experimental/main_test.go
+++ b/pkg/loadbalancer/experimental/main_test.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package experimental
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/loadbalancer/experimental/node_addr_reconciler.go
+++ b/pkg/loadbalancer/experimental/node_addr_reconciler.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type nodePortAddressReconcilerParams struct {
@@ -51,11 +53,16 @@ type nodePortAddrReconciler struct {
 }
 
 func (r *nodePortAddrReconciler) nodePortAddressReconcilerLoop(ctx context.Context, health cell.Health) error {
+	// Limit the rate of processing to avoid unnecessary churn, but keep it fast enough for humans.
+	limiter := rate.NewLimiter(time.Second, 1)
+	defer limiter.Stop()
+
 	for {
 		wtxn := r.db.WriteTxn(r.frontends)
-
 		_, watch := r.nodeAddrs.ListWatch(wtxn, tables.NodeAddressNodePortIndex.Query(true))
 
+		// The node port addresses have changed, set all NodePort/HostPort frontends as pending to reconcile
+		// the new addresses.
 		for fe := range r.frontends.All(wtxn) {
 			if fe.Type != loadbalancer.SVCTypeNodePort &&
 				!(fe.Type == loadbalancer.SVCTypeHostPort && fe.Address.AddrCluster.IsUnspecified()) {
@@ -78,6 +85,10 @@ func (r *nodePortAddrReconciler) nodePortAddressReconcilerLoop(ctx context.Conte
 		case <-ctx.Done():
 			return nil
 		case <-watch:
+		}
+
+		if err := limiter.Wait(ctx); err != nil {
+			return err
 		}
 	}
 }

--- a/pkg/loadbalancer/experimental/redirectpolicy/api.go
+++ b/pkg/loadbalancer/experimental/redirectpolicy/api.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package redirectpolicy
+
+import (
+	"github.com/cilium/statedb"
+	"github.com/go-openapi/runtime/middleware"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/api/v1/server/restapi/service"
+)
+
+type getLrpHandler struct {
+	db   *statedb.DB
+	lrps statedb.Table[*LocalRedirectPolicy]
+}
+
+func (h *getLrpHandler) Handle(params service.GetLrpParams) middleware.Responder {
+	return service.NewGetLrpOK().WithPayload(getLRPs(h.db.ReadTxn(), h.lrps))
+}
+
+func getLRPs(txn statedb.ReadTxn, lrps statedb.Table[*LocalRedirectPolicy]) []*models.LRPSpec {
+	list := make([]*models.LRPSpec, 0, lrps.NumObjects(txn))
+	for lrp := range lrps.All(txn) {
+		list = append(list, lrp.getModel())
+	}
+	return list
+}
+
+func (lrp *LocalRedirectPolicy) getModel() *models.LRPSpec {
+	if lrp == nil {
+		return nil
+	}
+
+	var feType, lrpType string
+	switch lrp.FrontendType {
+	case frontendTypeUnknown:
+		feType = "unknown"
+	case svcFrontendAll:
+		feType = "clusterIP + all svc ports"
+	case svcFrontendNamedPorts:
+		feType = "clusterIP + named ports"
+	case svcFrontendSinglePort:
+		feType = "clusterIP + port"
+	case addrFrontendSinglePort:
+		feType = "IP + port"
+	case addrFrontendNamedPorts:
+		feType = "IP + named ports"
+	}
+
+	switch lrp.LRPType {
+	case lrpConfigTypeNone:
+		lrpType = "none"
+	case lrpConfigTypeAddr:
+		lrpType = "addr"
+	case lrpConfigTypeSvc:
+		lrpType = "svc"
+	}
+
+	feMappingModelArray := make([]*models.FrontendMapping, 0, len(lrp.FrontendMappings))
+	for _, feM := range lrp.FrontendMappings {
+		feMappingModelArray = append(feMappingModelArray, feM.getModel())
+	}
+
+	return &models.LRPSpec{
+		UID:              string(lrp.UID),
+		Name:             lrp.ID.Name,
+		Namespace:        lrp.ID.Namespace,
+		FrontendType:     feType,
+		LrpType:          lrpType,
+		ServiceID:        lrp.ServiceID.String(),
+		FrontendMappings: feMappingModelArray,
+	}
+}
+
+func (feM *feMapping) getModel() *models.FrontendMapping {
+	return &models.FrontendMapping{
+		FrontendAddress: &models.FrontendAddress{
+			IP:       feM.feAddr.AddrCluster.String(),
+			Protocol: feM.feAddr.Protocol,
+			Port:     feM.feAddr.Port,
+		},
+	}
+}

--- a/pkg/loadbalancer/experimental/redirectpolicy/cell.go
+++ b/pkg/loadbalancer/experimental/redirectpolicy/cell.go
@@ -4,13 +4,8 @@
 package redirectpolicy
 
 import (
-	"errors"
-	"sync"
-
-	"github.com/cilium/cilium/pkg/netns"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
-	"golang.org/x/sys/unix"
 )
 
 // Cell implements the processing of the CiliumLocalRedirectPolicy CRD.
@@ -24,7 +19,6 @@ var Cell = cell.Module(
 
 	cell.Provide(
 		newLRPIsEnabled,
-		netnsCookieSupport,
 
 		NewLRPTable,
 		statedb.RWTable[*LocalRedirectPolicy].ToTable,
@@ -53,12 +47,3 @@ var Cell = cell.Module(
 		registerSkipLB,
 	),
 )
-
-type haveNetNSCookieSupport func() bool
-
-func netnsCookieSupport() haveNetNSCookieSupport {
-	return sync.OnceValue(func() bool {
-		_, err := netns.GetNetNSCookie()
-		return !errors.Is(err, unix.ENOPROTOOPT)
-	})
-}

--- a/pkg/loadbalancer/experimental/redirectpolicy/cell.go
+++ b/pkg/loadbalancer/experimental/redirectpolicy/cell.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package redirectpolicy
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/cilium/cilium/pkg/netns"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
+	"golang.org/x/sys/unix"
+)
+
+// Cell implements the processing of the CiliumLocalRedirectPolicy CRD.
+// For each policy it creates a pseudo-service with suffix -local-redirect
+// and associates to it all matching local pods as backends. The service
+// frontends that are being redirected will then take the backends of the
+// pseudo-service.
+var Cell = cell.Module(
+	"local-redirect-policies",
+	"Controller for CiliumLocalRedirectPolicy",
+
+	cell.Provide(
+		newLRPIsEnabled,
+		netnsCookieSupport,
+
+		NewLRPTable,
+		statedb.RWTable[*LocalRedirectPolicy].ToTable,
+
+		newLRPListerWatcher,
+
+		newDesiredSkipLBTable,
+		newSkipLBMap,
+	),
+
+	cell.Provide(
+		// Provide the 'skiplbmap' command for inspecting SkipLBMap.
+		newSkipLBMapCommand,
+	),
+
+	cell.Invoke(
+		// Reflect the CiliumLocalRedirectPolicy CRDs into Table[*LocalRedirectPolicy]
+		registerLRPReflector,
+
+		// Register a controller to process the changes in the LRP, pod and frontend
+		// tables.
+		registerLRPController,
+
+		// Register the SkipLBMap recnociler and the endpoint subscriber for pulling
+		// pod netns cookies
+		registerSkipLB,
+	),
+)
+
+type haveNetNSCookieSupport func() bool
+
+func netnsCookieSupport() haveNetNSCookieSupport {
+	return sync.OnceValue(func() bool {
+		_, err := netns.GetNetNSCookie()
+		return !errors.Is(err, unix.ENOPROTOOPT)
+	})
+}

--- a/pkg/loadbalancer/experimental/redirectpolicy/controller.go
+++ b/pkg/loadbalancer/experimental/redirectpolicy/controller.go
@@ -1,0 +1,458 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package redirectpolicy
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+
+	daemonk8s "github.com/cilium/cilium/daemon/k8s"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/k8s"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
+	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
+	lb "github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+const localRedirectSvcStr = "-local-redirect"
+
+type lrpIsEnabled bool
+
+func newLRPIsEnabled(expConfig experimental.Config, daemonConfig *option.DaemonConfig) lrpIsEnabled {
+	return lrpIsEnabled(
+		expConfig.EnableExperimentalLB && daemonConfig.EnableLocalRedirectPolicy,
+	)
+}
+
+type lrpControllerParams struct {
+	cell.In
+
+	Enabled            lrpIsEnabled
+	Log                *slog.Logger
+	DB                 *statedb.DB
+	LRPs               statedb.Table[*LocalRedirectPolicy]
+	Pods               statedb.Table[daemonk8s.LocalPod]
+	DesiredSkipLB      statedb.RWTable[*desiredSkipLB]
+	Writer             *experimental.Writer
+	NetNSCookieSupport haveNetNSCookieSupport
+}
+
+type lrpController struct {
+	p lrpControllerParams
+
+	skipLBWarningLogged bool
+}
+
+// podInfo is the condensed data from the pod relevant for the LRP processing.
+type podInfo struct {
+	namespace      string
+	namespacedName string
+	addrs          []podAddr
+	labels         map[string]string
+}
+
+func getPodInfo(pod daemonk8s.LocalPod) podInfo {
+	return podInfo{
+		namespace:      pod.Namespace,
+		namespacedName: pod.Namespace + "/" + pod.Name,
+		addrs:          podAddrs(pod.Pod),
+		labels:         pod.Labels,
+	}
+}
+
+// run processes changes to Table[LocalRedirectPolicy], Table[LocalPod] and Table[Frontend]
+// and 1) creates pseudo-service (with suffix -local-redirect) with pods as backends and sets
+// redirects from matched services to the pseudo-service, 2) updates the Table[DesiredSkipLB]
+// to reconcile changes to the SkipLBMap in order to instruct BPF datapath to not perform
+// load-balancing from the backend pod to the redirected frontends (if SkipRedirectFromBackend is set).
+func (c *lrpController) run(ctx context.Context, health cell.Health) error {
+	wtxn := c.p.DB.WriteTxn(c.p.LRPs, c.p.Pods, c.p.Writer.Frontends(), c.p.DesiredSkipLB)
+	defer wtxn.Abort()
+
+	lrps, err := c.p.LRPs.Changes(wtxn)
+	if err != nil {
+		return err
+	}
+
+	pods, err := c.p.Pods.Changes(wtxn)
+	if err != nil {
+		return err
+	}
+
+	frontends, err := c.p.Writer.Frontends().Changes(wtxn)
+	if err != nil {
+		return err
+	}
+
+	desiredSkipLBInit := c.p.DesiredSkipLB.RegisterInitializer(wtxn, "controller")
+	_, podsInitWatch := c.p.Pods.Initialized(wtxn)
+	_, lrpsInitWatch := c.p.LRPs.Initialized(wtxn)
+	_, fesInitWatch := c.p.Writer.Frontends().Initialized(wtxn)
+
+	wtxn.Commit()
+
+	// Limit the rate at which the changes are processed. This allows processing in
+	// larger batches and skipping intermediate states of the objects.
+	limiter := rate.NewLimiter(100*time.Millisecond, 1)
+	defer limiter.Stop()
+
+	for {
+		health.OK("Processing changes")
+
+		// Write transaction against the load-balancing tables and the desired-skiplb table.
+		wtxn := c.p.Writer.WriteTxn(c.p.DesiredSkipLB)
+
+		lrpChanges, lrpWatch := lrps.Next(wtxn)
+		// Process the changed local redirect policies. Find frontends that should be redirected
+		// and find mathed pods from which to create backends.
+		for change := range lrpChanges {
+			lrp := change.Object
+			toName := lrp.ServiceName()
+
+			if change.Deleted {
+				c.p.Writer.DeleteServiceAndFrontends(wtxn, toName)
+			} else {
+				// Create a frontendless pseudo-service for the redirect policy. The backends
+				// will be associated with this service.
+				c.p.Writer.UpsertService(wtxn,
+					&experimental.Service{
+						Name:             toName,
+						Source:           source.Kubernetes,
+						ExtTrafficPolicy: lb.SVCTrafficPolicyCluster,
+						IntTrafficPolicy: lb.SVCTrafficPolicyCluster,
+					},
+				)
+			}
+
+			// NOTE: Redirect policies are immutable, so we don't need to unset redirects here.
+			// If they were made mutable, we'd need to find each frontend that has a redirect to
+			// the pseudo-service and remove the redirects from frontends that no longer match
+			// the spec.
+
+			switch lrp.LRPType {
+			case lrpConfigTypeSvc:
+				targetName := lb.ServiceName{Name: lrp.ServiceID.Name, Namespace: lrp.ServiceID.Namespace}
+				if !change.Deleted {
+					c.p.Writer.SetRedirectToByName(wtxn, targetName, &toName)
+				} else {
+					c.p.Writer.SetRedirectToByName(wtxn, targetName, nil)
+				}
+			case lrpConfigTypeAddr:
+				// In address-based mode there is no existing service/frontend to match against, but rather we'll
+				// create the frontend here.
+				if !change.Deleted {
+					for _, feM := range lrp.FrontendMappings {
+						_, err := c.p.Writer.UpsertFrontend(
+							wtxn,
+							experimental.FrontendParams{
+								Address:     feM.feAddr,
+								Type:        lb.SVCTypeLocalRedirect,
+								ServiceName: toName,
+								ServicePort: feM.feAddr.Port,
+							},
+						)
+						if err != nil {
+							// Error may occur when a frontend already exists as part of some other
+							// service.
+							c.p.Log.Warn("failed to upsert frontend", logfields.Error, err)
+						}
+					}
+				}
+			}
+
+			// Find pods that match with the LRP
+			if !change.Deleted {
+				matchingPods := c.p.Pods.Prefix(wtxn, daemonk8s.PodByName(lrp.ID.Namespace, ""))
+				for pod := range matchingPods {
+					if len(pod.Namespace) != len(lrp.ID.Namespace) {
+						break
+					}
+					if lrp.BackendSelector.Matches(labels.Set(pod.Labels)) {
+						c.processLRPAndPod(wtxn, lrp, getPodInfo(pod))
+					}
+				}
+			}
+		}
+
+		// Process changed pods and find matching LRPs and add the pods as backends.
+		podChanges, podWatch := pods.Next(wtxn)
+		for change := range podChanges {
+			if !change.Deleted &&
+				k8sUtils.GetLatestPodReadiness(change.Object.Status) != slim_corev1.ConditionTrue {
+				// Ignore pods that are not yet ready.
+				continue
+			}
+
+			podInfo := getPodInfo(change.Object)
+
+			// Find LRPs in the same namespace that match with this pod.
+			matchingLRPs := c.p.LRPs.Prefix(wtxn, lrpIDIndex.Query(k8s.ServiceID{Namespace: podInfo.namespace}))
+			for lrp := range matchingLRPs {
+				if len(lrp.ID.Namespace) != len(podInfo.namespace) {
+					// Different (longer) namespace, stop here.
+					break
+				}
+				if lrp.BackendSelector.Matches(labels.Set(podInfo.labels)) {
+					if change.Deleted {
+						toName := lrp.ServiceName()
+						for _, addr := range podInfo.addrs {
+							c.p.Writer.ReleaseBackend(wtxn, toName, addr.L3n4Addr)
+						}
+					} else {
+						c.processLRPAndPod(wtxn, lrp, podInfo)
+					}
+				}
+			}
+		}
+
+		// Process changes to service frontends to find if any redirect policy matches on them
+		// and set the redirects accordingly.
+		frontendChanges, frontendWatch := frontends.Next(wtxn)
+		for change := range frontendChanges {
+			fe := change.Object
+			if change.Deleted {
+				continue
+			}
+
+			serviceID := k8s.ServiceID{
+				Namespace: fe.ServiceName.Namespace,
+				Name:      fe.ServiceName.Name,
+			}
+
+			lrp, _, found := c.p.LRPs.Get(wtxn, lrpServiceIndex.Query(serviceID))
+			if !found {
+				continue
+			}
+
+			// A local redirect policy matches this frontend, set the redirect.
+			toName := lrp.ServiceName()
+			targetName := lb.ServiceName{Name: lrp.ServiceID.Name, Namespace: lrp.ServiceID.Namespace}
+			if fe.RedirectTo != nil && fe.RedirectTo.Equal(targetName) {
+				// Redirect already set, nothing to do.
+				continue
+			}
+			c.p.Writer.SetRedirectToByName(wtxn, targetName, &toName)
+		}
+
+		if desiredSkipLBInit != nil {
+			if podsInitWatch == nil && lrpsInitWatch == nil && fesInitWatch == nil {
+				// All the relevant input tables have initialized and we've processed the changes,
+				// mark the Table[*desiredSkipLB] also as initialized to initiate pruning of stale
+				// data.
+				desiredSkipLBInit(wtxn)
+				desiredSkipLBInit = nil
+			}
+		}
+
+		wtxn.Commit()
+
+		health.OK("Waiting for changes")
+
+		// Rate limit the processing of the changes to increase efficiency.
+		if err := limiter.Wait(ctx); err != nil {
+			// Context cancelled, shutting down.
+			return nil
+		}
+
+		select {
+		case <-lrpWatch:
+		case <-podWatch:
+		case <-frontendWatch:
+		case <-podsInitWatch:
+			podsInitWatch = nil
+		case <-fesInitWatch:
+			fesInitWatch = nil
+		case <-lrpsInitWatch:
+			lrpsInitWatch = nil
+		case <-ctx.Done():
+			return nil
+		}
+
+	}
+}
+
+func (c *lrpController) processLRPAndPod(wtxn experimental.WriteTxn, lrp *LocalRedirectPolicy, podInfo podInfo) {
+	c.p.Log.Info("processLRPAndPod",
+		"lrp", lrp.ID,
+		"pod", podInfo.namespacedName)
+
+	portNameMatches := func(portName string) bool {
+		for bePortName := range lrp.BackendPortsByPortName {
+			if bePortName == portName {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Port name checks can be skipped in certain cases.
+	switch {
+	case lrp.FrontendType == svcFrontendAll:
+		fallthrough
+	case lrp.FrontendType == svcFrontendSinglePort:
+		fallthrough
+	case lrp.FrontendType == addrFrontendSinglePort:
+		portNameMatches = nil
+
+	}
+
+	toName := lrp.ServiceName()
+
+	beps := make([]experimental.BackendParams, 0, len(podInfo.addrs))
+	for _, addr := range podInfo.addrs {
+		if portNameMatches != nil && !portNameMatches(addr.portName) {
+			c.p.Log.Info("Mismatching port name", "portName", addr.portName, "frontendType", lrp.FrontendType)
+			continue
+		}
+		beps = append(beps, experimental.BackendParams{
+			L3n4Addr:  addr.L3n4Addr,
+			State:     lb.BackendStateActive,
+			PortNames: []string{addr.portName},
+		})
+		c.p.Log.Info("Adding backend instance", "name", toName)
+	}
+	c.p.Writer.SetBackends(
+		wtxn,
+		toName,
+		source.Kubernetes,
+		beps...,
+	)
+
+	// Update the desired skiplb state. The Table[desiredSkipLB] holds all local endpoints filled in
+	// from EndpointManager. We may see the endpoint first and thus have the netns cookie and can
+	// reconcile immediately, or we may see LRP & pod first and thus have to wait for the EndpointManager
+	// callback before reconciling.
+	if c.p.NetNSCookieSupport() {
+		skiplb, _, found := c.p.DesiredSkipLB.Get(wtxn, desiredSkipLBPodIndex.Query(podInfo.namespacedName))
+		if found {
+			skiplb = skiplb.clone()
+		} else {
+			skiplb = newDesiredSkipLB(podInfo.namespacedName)
+		}
+
+		if skiplb.SkipRedirectForFrontends == nil {
+			skiplb.SkipRedirectForFrontends = map[lb.ServiceName][]lb.L3n4Addr{}
+		} else {
+			skiplb.SkipRedirectForFrontends = maps.Clone(skiplb.SkipRedirectForFrontends)
+		}
+		skiplb.SkipRedirectForFrontends[toName] = c.frontendsToSkip(wtxn, lrp)
+		if skiplb.NetnsCookie != nil {
+			skiplb.Status = reconciler.StatusPending()
+		}
+		c.p.DesiredSkipLB.Insert(wtxn, skiplb)
+	} else if lrp.SkipRedirectFromBackend && !c.skipLBWarningLogged {
+		c.p.Log.Warn("LocalRedirectPolicy with SkipRedirectFromBackend cannot be applied, needs kernel version >= 5.12")
+		c.skipLBWarningLogged = true
+	}
+
+	// Finally refresh the frontends of the redirected service to recalculate its backends.
+	switch lrp.LRPType {
+	case lrpConfigTypeSvc:
+		targetName := lb.ServiceName{Name: lrp.ServiceID.Name, Namespace: lrp.ServiceID.Namespace}
+		c.p.Writer.RefreshFrontends(wtxn, targetName)
+	case lrpConfigTypeAddr:
+		c.p.Writer.RefreshFrontends(wtxn, toName)
+	}
+}
+
+func (c *lrpController) frontendsToSkip(txn statedb.ReadTxn, lrp *LocalRedirectPolicy) []lb.L3n4Addr {
+	var targetName lb.ServiceName
+	if lrp.LRPType == lrpConfigTypeAddr {
+		// For address-based matching we created the frontends, so we look up from the pseudo-service
+		targetName = lrp.ServiceName()
+	} else {
+		targetName = lb.ServiceName{Name: lrp.ServiceID.Name, Namespace: lrp.ServiceID.Namespace}
+	}
+
+	if !lrp.SkipRedirectFromBackend {
+		return nil
+	}
+	feAddrs := []lb.L3n4Addr{}
+	for fe := range c.p.Writer.Frontends().List(txn, experimental.FrontendByServiceName(targetName)) {
+		if len(lrp.FrontendMappings) > 0 {
+			skip := false
+			for _, addr := range lrp.FrontendMappings {
+				if lrp.LRPType == lrpConfigTypeAddr {
+					if !addr.feAddr.DeepEqual(&fe.Address) {
+						skip = true
+						break
+					}
+				} else {
+					if addr.feAddr.Port != fe.Address.Port {
+						skip = true
+						break
+					}
+					if addr.fePort != "" && string(fe.PortName) != addr.fePort {
+						skip = true
+						break
+					}
+				}
+			}
+			if skip {
+				continue
+			}
+		}
+		feAddrs = append(feAddrs, fe.Address)
+	}
+	return feAddrs
+}
+
+func (lrp *LocalRedirectPolicy) ServiceName() lb.ServiceName {
+	return lb.ServiceName{Name: lrp.ID.Name + localRedirectSvcStr, Namespace: lrp.ID.Namespace}
+}
+
+type podAddr struct {
+	lb.L3n4Addr
+	portName string
+}
+
+func podAddrs(pod *slim_corev1.Pod) (addrs []podAddr) {
+	podIPs := k8sUtils.ValidIPs(pod.Status)
+	if len(podIPs) == 0 {
+		// IPs not available yet.
+		return nil
+	}
+	for _, podIP := range podIPs {
+		addrCluster, err := cmtypes.ParseAddrCluster(podIP)
+		if err != nil {
+			continue
+		}
+		for _, container := range pod.Spec.Containers {
+			for _, port := range container.Ports {
+				l4addr := lb.NewL4Addr(lb.L4Type(port.Protocol), uint16(port.ContainerPort))
+				addr := podAddr{
+					L3n4Addr: lb.L3n4Addr{
+						AddrCluster: addrCluster,
+						L4Addr:      *l4addr,
+						Scope:       0,
+					},
+					portName: port.Name,
+				}
+				addrs = append(addrs, addr)
+			}
+		}
+	}
+	return
+}
+
+func registerLRPController(g job.Group, p lrpControllerParams) {
+	if !p.Enabled {
+		return
+	}
+	h := &lrpController{p: p}
+	g.Add(job.OneShot("controller", h.run))
+}

--- a/pkg/loadbalancer/experimental/redirectpolicy/controller.go
+++ b/pkg/loadbalancer/experimental/redirectpolicy/controller.go
@@ -48,7 +48,7 @@ type lrpControllerParams struct {
 	Pods               statedb.Table[daemonk8s.LocalPod]
 	DesiredSkipLB      statedb.RWTable[*desiredSkipLB]
 	Writer             *experimental.Writer
-	NetNSCookieSupport haveNetNSCookieSupport
+	NetNSCookieSupport experimental.HaveNetNSCookieSupport
 }
 
 type lrpController struct {

--- a/pkg/loadbalancer/experimental/redirectpolicy/main_test.go
+++ b/pkg/loadbalancer/experimental/redirectpolicy/main_test.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package redirectpolicy
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/loadbalancer/experimental/redirectpolicy/redirectpolicy.go
+++ b/pkg/loadbalancer/experimental/redirectpolicy/redirectpolicy.go
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package redirectpolicy
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/k8s"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
+	lb "github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+type lrpConfigType = int
+
+const (
+	lrpConfigTypeNone = iota
+	// LRP config is specified using IP/port tuple.
+	lrpConfigTypeAddr
+	// LRP config is specified using Kubernetes service name and namespace.
+	lrpConfigTypeSvc
+)
+
+func lrpConfigTypeString(t lrpConfigType) string {
+	switch t {
+	case lrpConfigTypeNone:
+		return "none"
+	case lrpConfigTypeAddr:
+		return "address"
+	case lrpConfigTypeSvc:
+		return "service"
+	default:
+		return "unknown"
+	}
+}
+
+type frontendConfigType = int
+
+const (
+	frontendTypeUnknown = iota
+	// Get frontends for service with clusterIP and all service ports.
+	svcFrontendAll
+	// Get frontends for service with clusterIP and parsed config named ports.
+	svcFrontendNamedPorts
+	// Get a frontend for service with clusterIP and parsed config port.
+	svcFrontendSinglePort
+	// Get a frontend with parsed config frontend IP and port.
+	addrFrontendSinglePort
+	// Get frontends with parsed config frontend IPs and named ports.
+	addrFrontendNamedPorts
+)
+
+func frontendConfigTypeString(t frontendConfigType) string {
+	switch t {
+	case svcFrontendAll:
+		return "all"
+	case svcFrontendNamedPorts:
+		return "named-ports"
+	case svcFrontendSinglePort:
+		return "svc-single-port"
+	case addrFrontendSinglePort:
+		return "addr-single-port"
+	case addrFrontendNamedPorts:
+		return "addr-named-ports"
+	default:
+		return "unknown"
+	}
+}
+
+// LocalRedirectPolicy is the internal representation of Cilium Local Redirect Policy.
+type LocalRedirectPolicy struct {
+	// ID is the parsed config name and namespace
+	ID k8s.ServiceID
+	// UID is the unique identifier assigned by Kubernetes
+	UID types.UID
+	// LRPType is the type of either address matcher or service matcher policy
+	LRPType lrpConfigType
+	// FrontendType is the type for the parsed config frontend.
+	FrontendType frontendConfigType
+	// FrontendMappings is a slice of policy config frontend mappings that include
+	// frontend address, frontend port name, and a slice of its associated backends
+	FrontendMappings []feMapping
+	// ServiceID is the parsed service name and namespace
+	ServiceID k8s.ServiceID
+	// BackendSelector is an endpoint selector generated from the parsed policy selector
+	BackendSelector api.EndpointSelector
+	// BackendPorts is a slice of backend port and protocol along with the port name
+	BackendPorts []bePortInfo
+	// BackendPortsByPortName is a map indexed by port name with the value as
+	// a pointer to bePortInfo for easy lookup into backendPorts
+	BackendPortsByPortName map[portName]bePortInfo
+	// SkipRedirectFromBackend is the flag that enables/disables redirection
+	// for traffic matching the policy frontend(s) from the backends selected by the policy
+	SkipRedirectFromBackend bool
+}
+
+func (lrp *LocalRedirectPolicy) TableHeader() []string {
+	return []string{
+		"Name",
+		"Type",
+		"Service",
+		"FrontendType",
+		"Frontends",
+		"BackendSelector",
+	}
+}
+
+func (lrp *LocalRedirectPolicy) TableRow() []string {
+	mappings := make([]string, 0, len(lrp.FrontendMappings))
+	for _, feM := range lrp.FrontendMappings {
+		addr := feM.feAddr
+		mappings = append(mappings, fmt.Sprintf("%s:%d %s", addr.AddrCluster, addr.Port, addr.Protocol))
+	}
+	return []string{
+		lrp.ID.Namespace + "/" + lrp.ID.Name,
+		lrpConfigTypeString(lrp.LRPType),
+		lrp.ServiceID.Namespace + "/" + lrp.ServiceID.Name,
+		frontendConfigTypeString(lrp.FrontendType),
+		strings.Join(mappings, ", "),
+		lrp.BackendSelector.String(),
+	}
+}
+
+type portName = string
+
+// feMapping stores frontend address and a list of associated backend addresses.
+type feMapping struct {
+	feAddr lb.L3n4Addr
+	fePort portName
+}
+
+type bePortInfo struct {
+	// l4Addr is the port and protocol
+	l4Addr lb.L4Addr
+	// name is the port name
+	name string
+}
+
+// parse parses the specified cilium local redirect policy spec, and returns
+// a sanitized LocalRedirectPolicy.
+func parseLRP(clrp *v2.CiliumLocalRedirectPolicy, sanitize bool) (*LocalRedirectPolicy, error) {
+	name := clrp.ObjectMeta.Name
+	if name == "" {
+		return nil, fmt.Errorf("CiliumLocalRedirectPolicy must have a name")
+	}
+
+	namespace := k8sUtils.ExtractNamespace(&clrp.ObjectMeta)
+	if namespace == "" {
+		return nil, fmt.Errorf("CiliumLocalRedirectPolicy must have a non-empty namespace")
+	}
+
+	if sanitize {
+		return getSanitizedLocalRedirectPolicy(name, namespace, clrp.UID, clrp.Spec)
+	} else {
+		return &LocalRedirectPolicy{
+			ID: k8s.ServiceID{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}, nil
+	}
+}
+
+func getSanitizedLocalRedirectPolicy(name, namespace string, uid types.UID, spec v2.CiliumLocalRedirectPolicySpec) (*LocalRedirectPolicy, error) {
+
+	var (
+		addrMatcher    = spec.RedirectFrontend.AddressMatcher
+		svcMatcher     = spec.RedirectFrontend.ServiceMatcher
+		redirectTo     = spec.RedirectBackend
+		frontendType   = frontendTypeUnknown
+		checkNamedPort = false
+		lrpType        lrpConfigType
+		k8sSvc         k8s.ServiceID
+		fe             lb.L3n4Addr
+		feMappings     []feMapping
+		bePorts        []bePortInfo
+		bePortsMap     = make(map[portName]bePortInfo)
+	)
+
+	// Parse frontend config
+	switch {
+	case addrMatcher == nil && svcMatcher == nil:
+		return nil, fmt.Errorf("both address and service" +
+			" matchers can not be empty")
+	case addrMatcher != nil && svcMatcher != nil:
+		return nil, fmt.Errorf("both address and service" +
+			" matchers can not be specified")
+	case addrMatcher != nil:
+		// LRP specifies IP/port tuple config for traffic that needs to be redirected.
+		addrCluster, err := cmtypes.ParseAddrCluster(addrMatcher.IP)
+		if err != nil {
+			return nil, fmt.Errorf("invalid address matcher IP %v: %w", addrMatcher.IP, err)
+		}
+		if len(addrMatcher.ToPorts) > 1 {
+			// If there are multiple ports, then the ports must be named.
+			checkNamedPort = true
+			frontendType = addrFrontendNamedPorts
+		} else if len(addrMatcher.ToPorts) == 1 {
+			frontendType = addrFrontendSinglePort
+		}
+		feMappings = make([]feMapping, len(addrMatcher.ToPorts))
+		for i, portInfo := range addrMatcher.ToPorts {
+			p, pName, proto, err := portInfo.SanitizePortInfo(checkNamedPort)
+			if err != nil {
+				return nil, fmt.Errorf("invalid address matcher port: %w", err)
+			}
+			// Set the scope to ScopeExternal as the externalTrafficPolicy is set to Cluster.
+			fe = *lb.NewL3n4Addr(proto, addrCluster, p, lb.ScopeExternal)
+			feMappings[i] = feMapping{
+				feAddr: fe,
+				fePort: pName,
+			}
+		}
+		lrpType = lrpConfigTypeAddr
+	case svcMatcher != nil:
+		// LRP specifies service config for traffic that needs to be redirected.
+		k8sSvc = k8s.ServiceID{
+			Name:      svcMatcher.Name,
+			Namespace: svcMatcher.Namespace,
+		}
+		if k8sSvc.Name == "" {
+			return nil, fmt.Errorf("kubernetes service name can" +
+				"not be empty")
+		}
+		if namespace != "" && k8sSvc.Namespace != namespace {
+			return nil, fmt.Errorf("kubernetes service namespace" +
+				"does not match with the CiliumLocalRedirectPolicy namespace")
+		}
+		switch len(svcMatcher.ToPorts) {
+		case 0:
+			frontendType = svcFrontendAll
+		case 1:
+			frontendType = svcFrontendSinglePort
+		default:
+			frontendType = svcFrontendNamedPorts
+			checkNamedPort = true
+		}
+		feMappings = make([]feMapping, len(svcMatcher.ToPorts))
+		for i, portInfo := range svcMatcher.ToPorts {
+			p, pName, proto, err := portInfo.SanitizePortInfo(checkNamedPort)
+			if err != nil {
+				return nil, fmt.Errorf("invalid service matcher port: %w", err)
+			}
+			// Set the scope to ScopeExternal as the externalTrafficPolicy is set to Cluster.
+			// frontend ip will later be populated with the clusterIP of the service.
+			fe = *lb.NewL3n4Addr(proto, cmtypes.AddrCluster{}, p, lb.ScopeExternal)
+			feMappings[i] = feMapping{
+				feAddr: fe,
+				fePort: pName,
+			}
+		}
+		lrpType = lrpConfigTypeSvc
+	default:
+		return nil, fmt.Errorf("invalid local redirect policy %v", spec)
+	}
+
+	if lrpType == lrpConfigTypeNone || frontendType == frontendTypeUnknown {
+		return nil, fmt.Errorf("invalid local redirect policy %v", spec)
+	}
+
+	// Parse backend config
+	bePorts = make([]bePortInfo, len(redirectTo.ToPorts))
+	if len(redirectTo.ToPorts) > 1 {
+		// We check for backend named ports if either frontend/backend have
+		// multiple ports.
+		checkNamedPort = true
+	}
+	for i, portInfo := range redirectTo.ToPorts {
+		p, pName, proto, err := portInfo.SanitizePortInfo(checkNamedPort)
+		if err != nil {
+			return nil, fmt.Errorf("invalid backend port: %w", err)
+		}
+		beP := bePortInfo{
+			l4Addr: lb.L4Addr{
+				Protocol: proto,
+				Port:     p,
+			},
+			name: pName,
+		}
+		bePorts[i] = beP
+		if len(pName) > 0 {
+			// Port name is present.
+			bePortsMap[pName] = bePorts[i]
+
+		}
+	}
+	// When a single port is specified in the LRP frontend, the protocol for frontend and
+	// backend must match.
+	if len(feMappings) == 1 {
+		if bePorts[0].l4Addr.Protocol != feMappings[0].feAddr.Protocol {
+			return nil, fmt.Errorf("backend protocol must match with " +
+				"frontend protocol")
+		}
+	}
+
+	// Get an EndpointSelector from the passed policy labelSelector for optimized matching.
+	selector := api.NewESFromK8sLabelSelector("", &redirectTo.LocalEndpointSelector)
+
+	return &LocalRedirectPolicy{
+		UID:                     uid,
+		ServiceID:               k8sSvc,
+		FrontendMappings:        feMappings,
+		BackendSelector:         selector,
+		BackendPorts:            bePorts,
+		BackendPortsByPortName:  bePortsMap,
+		LRPType:                 lrpType,
+		FrontendType:            frontendType,
+		SkipRedirectFromBackend: spec.SkipRedirectFromBackend,
+		ID: k8s.ServiceID{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}, nil
+}

--- a/pkg/loadbalancer/experimental/redirectpolicy/script_test.go
+++ b/pkg/loadbalancer/experimental/redirectpolicy/script_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package redirectpolicy
+
+import (
+	"context"
+	"flag"
+	"iter"
+	"log/slog"
+	"maps"
+	"net"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/cilium/statedb"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	daemonk8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	k8sTestutils "github.com/cilium/cilium/pkg/k8s/testutils"
+	"github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/maglev"
+	"github.com/cilium/cilium/pkg/maps/lbmap"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+var debug = flag.Bool("debug", false, "Enable debug logging")
+
+func TestScript(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	version.Force(k8sTestutils.DefaultVersion)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	var opts []hivetest.LogOption
+	if *debug {
+		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
+		logging.SetLogLevelToDebug()
+	}
+
+	scripttest.Test(t,
+		ctx,
+		func(t testing.TB, args []string) *script.Engine {
+			log := hivetest.Logger(t, opts...)
+			h := hive.New(
+				client.FakeClientCell,
+				daemonk8s.ResourcesCell,
+				daemonk8s.TablesCell,
+				experimental.Cell,
+				Cell,
+				maglev.Cell,
+				cell.Provide(
+					source.NewSources,
+					func() *experimental.TestConfig { return &experimental.TestConfig{} },
+					tables.NewNodeAddressTable,
+					statedb.RWTable[tables.NodeAddress].ToTable,
+					func() *option.DaemonConfig {
+						return &option.DaemonConfig{
+							EnableIPv4:                true,
+							EnableIPv6:                true,
+							EnableNodePort:            true,
+							SockRevNatEntries:         1000,
+							LBMapEntries:              1000,
+							EnableLocalRedirectPolicy: true,
+							KubeProxyReplacement:      option.KubeProxyReplacementTrue,
+						}
+					},
+					func() testSkipLBMap {
+						// Only use fake SkipLBMap if we're running unprivileged tests.
+						if testutils.IsPrivileged() {
+							return nil
+						}
+						return &fakeSkipLBMap{}
+					},
+				),
+				cell.Invoke(statedb.RegisterTable[tables.NodeAddress]),
+			)
+
+			flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+			h.RegisterFlags(flags)
+
+			// Set some defaults
+			flags.Set("enable-experimental-lb", "true")
+			require.NoError(t, flags.Parse(args), "flags.Parse")
+
+			t.Cleanup(func() {
+				assert.NoError(t, h.Stop(log, context.TODO()))
+			})
+			cmds, err := h.ScriptCommands(log)
+			require.NoError(t, err, "ScriptCommands")
+			maps.Insert(cmds, maps.All(script.DefaultCmds()))
+			return &script.Engine{
+				Cmds: cmds,
+			}
+		}, []string{}, "testdata/*.txtar")
+}
+
+type fakeSkipLBMap struct {
+	entries lock.Map[any, any]
+}
+
+// OpenOrCreate implements lbmap.SkipLBMap.
+func (f *fakeSkipLBMap) OpenOrCreate() error {
+	return nil
+}
+
+// Close implements lbmap.SkipLBMap.
+func (f *fakeSkipLBMap) Close() error {
+	return nil
+}
+
+// AddLB4 implements lbmap.SkipLBMap.
+func (f *fakeSkipLBMap) AddLB4(netnsCookie uint64, ip net.IP, port uint16) error {
+	key := lbmap.SkipLB4Key{
+		NetnsCookie: netnsCookie,
+		Address:     ([4]byte)(ip),
+		Port:        port,
+	}
+	f.entries.Store(
+		key,
+		&lbmap.SkipLB4Value{},
+	)
+	return nil
+}
+
+// AddLB6 implements lbmap.SkipLBMap.
+func (f *fakeSkipLBMap) AddLB6(netnsCookie uint64, ip net.IP, port uint16) error {
+	key := lbmap.SkipLB6Key{
+		NetnsCookie: netnsCookie,
+		Address:     ([16]byte)(ip),
+		Port:        port,
+	}
+	f.entries.Store(
+		key,
+		&lbmap.SkipLB6Value{},
+	)
+	return nil
+}
+
+// AllLB4 implements lbmap.SkipLBMap.
+func (f *fakeSkipLBMap) AllLB4() iter.Seq2[*lbmap.SkipLB4Key, *lbmap.SkipLB4Value] {
+	return func(yield func(*lbmap.SkipLB4Key, *lbmap.SkipLB4Value) bool) {
+		f.entries.Range(func(key any, value any) bool {
+			switch key := key.(type) {
+			case lbmap.SkipLB4Key:
+				if !yield(&key, value.(*lbmap.SkipLB4Value)) {
+					return false
+				}
+			}
+			return true
+		})
+	}
+}
+
+// AllLB6 implements lbmap.SkipLBMap.
+func (f *fakeSkipLBMap) AllLB6() iter.Seq2[*lbmap.SkipLB6Key, *lbmap.SkipLB6Value] {
+	return func(yield func(*lbmap.SkipLB6Key, *lbmap.SkipLB6Value) bool) {
+		f.entries.Range(func(key any, value any) bool {
+			switch key := key.(type) {
+			case lbmap.SkipLB6Key:
+				if !yield(&key, value.(*lbmap.SkipLB6Value)) {
+					return false
+				}
+			}
+			return true
+		})
+	}
+}
+
+// DeleteLB4 implements lbmap.SkipLBMap.
+func (f *fakeSkipLBMap) DeleteLB4(key *lbmap.SkipLB4Key) error {
+	f.entries.Delete(*key)
+	return nil
+}
+
+// DeleteLB4ByAddrPort implements lbmap.SkipLBMap.
+func (f *fakeSkipLBMap) DeleteLB4ByAddrPort(ip net.IP, port uint16) {
+	panic("unimplemented")
+}
+
+// DeleteLB4ByNetnsCookie implements lbmap.SkipLBMap.
+func (f *fakeSkipLBMap) DeleteLB4ByNetnsCookie(cookie uint64) {
+	panic("unimplemented")
+}
+
+// DeleteLB6 implements lbmap.SkipLBMap.
+func (f *fakeSkipLBMap) DeleteLB6(key *lbmap.SkipLB6Key) error {
+	f.entries.Delete(*key)
+	return nil
+}
+
+// DeleteLB6ByAddrPort implements lbmap.SkipLBMap.
+func (f *fakeSkipLBMap) DeleteLB6ByAddrPort(ip net.IP, port uint16) {
+	panic("unimplemented")
+}
+
+// DeleteLB6ByNetnsCookie implements lbmap.SkipLBMap.
+func (f *fakeSkipLBMap) DeleteLB6ByNetnsCookie(cookie uint64) {
+	panic("unimplemented")
+}
+
+var _ lbmap.SkipLBMap = &fakeSkipLBMap{}

--- a/pkg/loadbalancer/experimental/redirectpolicy/skiplb.go
+++ b/pkg/loadbalancer/experimental/redirectpolicy/skiplb.go
@@ -1,0 +1,416 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package redirectpolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"log/slog"
+	"net"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/hive"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+	"github.com/cilium/statedb/reconciler"
+	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/ebpf"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/maps/lbmap"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type skiplbParams struct {
+	cell.In
+
+	Log                *slog.Logger
+	IsEnabled          lrpIsEnabled
+	DB                 *statedb.DB
+	Lifecycle          cell.Lifecycle
+	DesiredSkipLB      statedb.RWTable[*desiredSkipLB]
+	Map                lbmap.SkipLBMap
+	EM                 endpointmanager.EndpointManager `optional:"true"`
+	NetNSCookieSupport haveNetNSCookieSupport
+}
+
+func registerSkipLB(p skiplbParams, rp reconciler.Params) {
+	if !p.IsEnabled {
+		return
+	}
+
+	// Register endpoint subscriber. In tests the cookies are inserted directly
+	// to the table.
+	if p.EM != nil {
+		sub := &skiplbEndpointSubscriber{
+			db:            p.DB,
+			desiredSkipLB: p.DesiredSkipLB,
+		}
+		p.Lifecycle.Append(cell.Hook{
+			OnStart: func(cell.HookContext) error {
+				if p.NetNSCookieSupport() {
+					p.EM.Subscribe(sub)
+				}
+				return nil
+			},
+			OnStop: func(cell.HookContext) error {
+				if p.NetNSCookieSupport() {
+					p.EM.Unsubscribe(sub)
+				}
+				return nil
+			},
+		})
+	}
+
+	// Register reconciler for the SkipLBMap
+	reconciler.Register(
+		rp,
+		p.DesiredSkipLB,
+		(*desiredSkipLB).clone,
+		func(dsl *desiredSkipLB, s reconciler.Status) *desiredSkipLB {
+			dsl.Status = s
+			return dsl
+		},
+		func(dsl *desiredSkipLB) reconciler.Status {
+			return dsl.Status
+		},
+		&skiplbOps{p.Map},
+		nil,
+	)
+}
+
+type desiredSkipLB struct {
+	PodNamespacedName        string
+	SkipRedirectForFrontends map[loadbalancer.ServiceName][]loadbalancer.L3n4Addr
+	ReconciledAddrs          sets.Set[loadbalancer.L3n4Addr]
+	NetnsCookie              *uint64
+	Status                   reconciler.Status
+}
+
+func newDesiredSkipLB(pod string) *desiredSkipLB {
+	return &desiredSkipLB{
+		PodNamespacedName:        pod,
+		SkipRedirectForFrontends: map[loadbalancer.ServiceName][]loadbalancer.L3n4Addr{},
+	}
+}
+
+func (dsl *desiredSkipLB) TableHeader() []string {
+	return []string{
+		"Pod",
+		"SkipRedirects",
+		"NetnsCookie",
+		"Status",
+		"Since",
+	}
+}
+
+func (dsl *desiredSkipLB) TableRow() []string {
+	cookie := "<unset>"
+	if dsl.NetnsCookie != nil {
+		cookie = strconv.FormatUint(*dsl.NetnsCookie, 10)
+	}
+	var skipRedirects []string
+	for _, addrs := range dsl.SkipRedirectForFrontends {
+		for _, addr := range addrs {
+			skipRedirects = append(skipRedirects, addr.StringWithProtocol())
+		}
+	}
+
+	return []string{
+		dsl.PodNamespacedName,
+		strings.Join(skipRedirects, ", "),
+		cookie,
+		string(dsl.Status.Kind),
+		duration.HumanDuration(time.Since(dsl.Status.UpdatedAt)),
+	}
+}
+
+func (dsl *desiredSkipLB) clone() *desiredSkipLB {
+	copy := *dsl
+	return &copy
+}
+
+var (
+	desiredSkipLBPodIndex = statedb.Index[*desiredSkipLB, string]{
+		Name: "pod-name",
+		FromObject: func(obj *desiredSkipLB) index.KeySet {
+			return index.NewKeySet(index.String(obj.PodNamespacedName))
+		},
+		FromKey:    index.String,
+		FromString: index.FromString,
+		Unique:     true,
+	}
+)
+
+func newDesiredSkipLBTable(db *statedb.DB) (statedb.RWTable[*desiredSkipLB], error) {
+	tbl, err := statedb.NewTable("desired-skiplbmap", desiredSkipLBPodIndex)
+	if err != nil {
+		return nil, err
+	}
+	return tbl, db.RegisterTable(tbl)
+}
+
+type skiplbOps struct {
+	m lbmap.SkipLBMap
+}
+
+// Delete implements reconciler.Operations.
+func (ops *skiplbOps) Delete(ctx context.Context, txn statedb.ReadTxn, d *desiredSkipLB) (err error) {
+	if d.NetnsCookie == nil {
+		return nil
+	}
+
+	for addr := range d.ReconciledAddrs {
+		var deleteErr error
+		if addr.IsIPv6() {
+			deleteErr = ops.m.DeleteLB6(&lbmap.SkipLB6Key{
+				NetnsCookie: *d.NetnsCookie,
+				Address:     addr.AddrCluster.Addr().As16(),
+				Port:        addr.Port,
+			})
+		} else {
+			deleteErr = ops.m.DeleteLB4(&lbmap.SkipLB4Key{
+				NetnsCookie: *d.NetnsCookie,
+				Address:     addr.AddrCluster.Addr().As4(),
+				Port:        addr.Port,
+			})
+		}
+		if deleteErr != nil && !errors.Is(deleteErr, ebpf.ErrKeyNotExist) {
+			err = errors.Join(err, deleteErr)
+		}
+	}
+
+	return
+}
+
+// Prune implements reconciler.Operations.
+func (ops *skiplbOps) Prune(ctx context.Context, txn statedb.ReadTxn, objs iter.Seq2[*desiredSkipLB, statedb.Revision]) (err error) {
+	// Collect the known netns cookies of all existing endpoints.
+	known := sets.New[uint64]()
+	for d := range objs {
+		if d.NetnsCookie != nil {
+			known.Insert(*d.NetnsCookie)
+		}
+	}
+	// Remove SkipLB entries that have unknown cookies.
+	for key := range ops.m.AllLB4() {
+		if !known.Has(key.NetnsCookie) {
+			if deleteErr := ops.m.DeleteLB4(key); deleteErr != nil {
+				err = errors.Join(err, deleteErr)
+			}
+		}
+	}
+	for key := range ops.m.AllLB6() {
+		if !known.Has(key.NetnsCookie) {
+			if deleteErr := ops.m.DeleteLB6(key); deleteErr != nil {
+				err = errors.Join(err, deleteErr)
+			}
+		}
+	}
+	return
+}
+
+// Update implements reconciler.Operations.
+func (ops *skiplbOps) Update(ctx context.Context, txn statedb.ReadTxn, d *desiredSkipLB) (err error) {
+	if d.NetnsCookie == nil {
+		return nil
+	}
+
+	newAddrs := sets.New[loadbalancer.L3n4Addr]()
+	for _, addrs := range d.SkipRedirectForFrontends {
+		for _, addr := range addrs {
+			var addErr error
+			if addr.IsIPv6() {
+				addErr = ops.m.AddLB6(*d.NetnsCookie, addr.AddrCluster.AsNetIP(), addr.Port)
+			} else {
+				addErr = ops.m.AddLB4(*d.NetnsCookie, addr.AddrCluster.AsNetIP(), addr.Port)
+			}
+			if addErr != nil {
+				err = errors.Join(err, addErr)
+			}
+			newAddrs.Insert(addr)
+		}
+	}
+
+	// Remove orphans
+	for addr := range d.ReconciledAddrs.Difference(newAddrs) {
+		var deleteErr error
+		if addr.IsIPv6() {
+			deleteErr = ops.m.DeleteLB6(&lbmap.SkipLB6Key{
+				NetnsCookie: *d.NetnsCookie,
+				Address:     addr.AddrCluster.Addr().As16(),
+				Port:        addr.Port,
+			})
+		} else {
+			deleteErr = ops.m.DeleteLB4(&lbmap.SkipLB4Key{
+				NetnsCookie: *d.NetnsCookie,
+				Address:     addr.AddrCluster.Addr().As4(),
+				Port:        addr.Port,
+			})
+		}
+		if deleteErr != nil && !errors.Is(deleteErr, ebpf.ErrKeyNotExist) {
+			err = errors.Join(err, deleteErr)
+		}
+	}
+
+	d.ReconciledAddrs = newAddrs
+
+	return
+}
+
+var _ reconciler.Operations[*desiredSkipLB] = &skiplbOps{}
+
+// skiplbEndpointSubscriber adds the netnsCookie information into the Table[desiredSkipLB]
+// table.
+type skiplbEndpointSubscriber struct {
+	db            *statedb.DB
+	desiredSkipLB statedb.RWTable[*desiredSkipLB]
+}
+
+var _ endpointmanager.Subscriber = &skiplbEndpointSubscriber{}
+
+// EndpointCreated implements endpointmanager.Subscriber.
+func (sub *skiplbEndpointSubscriber) EndpointCreated(ep *endpoint.Endpoint) {
+	if !ep.K8sNamespaceAndPodNameIsSet() {
+		return
+	}
+
+	cookie := ep.NetNsCookie
+
+	wtxn := sub.db.WriteTxn(sub.desiredSkipLB)
+	defer wtxn.Commit()
+
+	var dsl *desiredSkipLB
+	if old, _, found := sub.desiredSkipLB.Get(wtxn, desiredSkipLBPodIndex.Query(ep.GetK8sNamespaceAndPodName())); found {
+		dsl = old.clone()
+	} else {
+		dsl = newDesiredSkipLB(ep.GetK8sNamespaceAndPodName())
+	}
+	dsl.NetnsCookie = &cookie
+	sub.desiredSkipLB.Insert(wtxn, dsl)
+}
+
+// EndpointDeleted implements endpointmanager.Subscriber.
+func (sub *skiplbEndpointSubscriber) EndpointDeleted(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) {
+	if !ep.K8sNamespaceAndPodNameIsSet() {
+		return
+	}
+
+	wtxn := sub.db.WriteTxn(sub.desiredSkipLB)
+	defer wtxn.Commit()
+	sub.desiredSkipLB.Delete(
+		wtxn,
+		newDesiredSkipLB(ep.GetK8sNamespaceAndPodName()),
+	)
+}
+
+// EndpointRestored implements endpointmanager.Subscriber.
+func (sub *skiplbEndpointSubscriber) EndpointRestored(ep *endpoint.Endpoint) {
+	sub.EndpointCreated(ep)
+}
+
+// testSkipLBMap is a SkipLBMap that the test suite can provide to override the
+// map implementation.
+type testSkipLBMap lbmap.SkipLBMap
+
+type skiplbmapParams struct {
+	cell.In
+
+	IsEnabled          lrpIsEnabled
+	TestSkipLBMap      testSkipLBMap `optional:"true"`
+	Lifecycle          cell.Lifecycle
+	NetNSCookieSupport haveNetNSCookieSupport
+}
+
+func newSkipLBMap(p skiplbmapParams) (out bpf.MapOut[lbmap.SkipLBMap], err error) {
+	if !p.IsEnabled {
+		return
+	}
+
+	if p.TestSkipLBMap != nil {
+		m := lbmap.SkipLBMap(p.TestSkipLBMap)
+		out = bpf.NewMapOut(m)
+		return
+	}
+
+	var m lbmap.SkipLBMap
+	m, err = lbmap.NewSkipLBMap()
+	if err != nil {
+		return
+	}
+	p.Lifecycle.Append(cell.Hook{
+		OnStart: func(cell.HookContext) error {
+			if !p.NetNSCookieSupport() {
+				return nil
+			}
+			return m.OpenOrCreate()
+		},
+		OnStop: func(cell.HookContext) error {
+			return m.Close()
+		},
+	})
+	out = bpf.NewMapOut(m)
+	return
+}
+
+func newSkipLBMapCommand(m lbmap.SkipLBMap) hive.ScriptCmdsOut {
+	if m == nil {
+		return hive.NewScriptCmds(nil)
+	}
+	return hive.NewScriptCmds(map[string]script.Cmd{
+		"skiplbmap": script.Command(
+			script.CmdUsage{
+				Summary: "Dump the SkipLBMap to file",
+				Args:    "file",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) != 1 {
+					return nil, fmt.Errorf("%w: output file needed", script.ErrUsage)
+				}
+				file, err := os.OpenFile(s.Path(args[0]), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+				if err != nil {
+					return nil, err
+				}
+				defer file.Close()
+				var out []string
+
+				for key := range m.AllLB4() {
+					addr := net.IP(key.Address[:])
+					out = append(out, fmt.Sprintf("COOKIE=%d IP=%s PORT=%d\n",
+						key.NetnsCookie,
+						addr,
+						key.Port,
+					))
+				}
+				for key := range m.AllLB6() {
+					addr := net.IP(key.Address[:])
+					out = append(out, fmt.Sprintf("COOKIE=%d IP=%s PORT=%d\n",
+						key.NetnsCookie,
+						addr,
+						key.Port,
+					))
+				}
+
+				// Sort since the iteration order of lock.Map is undeterministic.
+				sort.Strings(out)
+				for _, line := range out {
+					fmt.Fprint(file, line)
+				}
+
+				return nil, nil
+			},
+		),
+	})
+}

--- a/pkg/loadbalancer/experimental/redirectpolicy/skiplb.go
+++ b/pkg/loadbalancer/experimental/redirectpolicy/skiplb.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -43,7 +44,7 @@ type skiplbParams struct {
 	DesiredSkipLB      statedb.RWTable[*desiredSkipLB]
 	Map                lbmap.SkipLBMap
 	EM                 endpointmanager.EndpointManager `optional:"true"`
-	NetNSCookieSupport haveNetNSCookieSupport
+	NetNSCookieSupport experimental.HaveNetNSCookieSupport
 }
 
 func registerSkipLB(p skiplbParams, rp reconciler.Params) {
@@ -331,7 +332,7 @@ type skiplbmapParams struct {
 	IsEnabled          lrpIsEnabled
 	TestSkipLBMap      testSkipLBMap `optional:"true"`
 	Lifecycle          cell.Lifecycle
-	NetNSCookieSupport haveNetNSCookieSupport
+	NetNSCookieSupport experimental.HaveNetNSCookieSupport
 }
 
 func newSkipLBMap(p skiplbmapParams) (out bpf.MapOut[lbmap.SkipLBMap], err error) {

--- a/pkg/loadbalancer/experimental/redirectpolicy/table.go
+++ b/pkg/loadbalancer/experimental/redirectpolicy/table.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package redirectpolicy
+
+import (
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/pkg/k8s"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
+	lb "github.com/cilium/cilium/pkg/loadbalancer"
+)
+
+const (
+	LRPTableName = "localredirectpolicies"
+)
+
+var (
+	lrpIDIndex = statedb.Index[*LocalRedirectPolicy, k8s.ServiceID]{
+		Name: "id",
+		FromObject: func(obj *LocalRedirectPolicy) index.KeySet {
+			return index.NewKeySet(index.String(obj.ID.String()))
+		},
+		FromKey: index.Stringer[k8s.ServiceID],
+		Unique:  true,
+	}
+
+	lrpServiceIndex = statedb.Index[*LocalRedirectPolicy, k8s.ServiceID]{
+		Name: "service",
+		FromObject: func(lrp *LocalRedirectPolicy) index.KeySet {
+			return index.NewKeySet(index.String(lrp.ServiceID.String()))
+		},
+		FromKey: index.Stringer[k8s.ServiceID],
+		Unique:  false,
+	}
+
+	lrpAddressIndex = statedb.Index[*LocalRedirectPolicy, lb.L3n4Addr]{
+		Name: "address",
+		FromObject: func(lrp *LocalRedirectPolicy) index.KeySet {
+			if lrp.LRPType != lrpConfigTypeAddr {
+				return index.KeySet{}
+			}
+			keys := make([]index.Key, 0, len(lrp.FrontendMappings))
+			for _, feM := range lrp.FrontendMappings {
+				keys = append(keys, feM.feAddr.Bytes())
+
+			}
+			return index.NewKeySet(keys...)
+		},
+		FromKey: func(addr lb.L3n4Addr) index.Key { return addr.Bytes() },
+		Unique:  false,
+	}
+)
+
+func NewLRPTable(db *statedb.DB) (statedb.RWTable[*LocalRedirectPolicy], error) {
+	tbl, err := statedb.NewTable(
+		LRPTableName,
+		lrpIDIndex,
+		lrpServiceIndex,
+		lrpAddressIndex,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return tbl, db.RegisterTable(tbl)
+}
+
+type lrpListerWatcher cache.ListerWatcher
+
+func newLRPListerWatcher(cs client.Clientset) lrpListerWatcher {
+	if !cs.IsEnabled() {
+		return nil
+	}
+	return k8sUtils.ListerWatcherFromTyped(cs.CiliumV2().CiliumLocalRedirectPolicies("" /* all namespaces */))
+}
+
+func registerLRPReflector(enabled lrpIsEnabled, db *statedb.DB, jg job.Group, lw lrpListerWatcher, lrps statedb.RWTable[*LocalRedirectPolicy]) {
+	if !enabled || lw == nil {
+		return
+	}
+
+	k8s.RegisterReflector(jg, db,
+		k8s.ReflectorConfig[*LocalRedirectPolicy]{
+			Name:          "lrps",
+			Table:         lrps,
+			ListerWatcher: lw,
+			Transform: func(_ statedb.ReadTxn, obj any) (*LocalRedirectPolicy, bool) {
+				clrp, ok := obj.(*ciliumv2.CiliumLocalRedirectPolicy)
+				if !ok {
+					return nil, false
+				}
+				rp, err := parseLRP(clrp, true)
+				return rp, err == nil
+			},
+		})
+}

--- a/pkg/loadbalancer/experimental/redirectpolicy/testdata/address.txtar
+++ b/pkg/loadbalancer/experimental/redirectpolicy/testdata/address.txtar
@@ -1,0 +1,107 @@
+hive start
+db/initialized
+
+# Add a pod and an address-based redirection
+k8s/add pod.yaml lrp-addr.yaml
+
+# Check tables
+db/cmp localredirectpolicies lrp.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table
+
+# Maps should have the created frontend: 169.254.169.254 => 10.244.2.1
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps.expected
+
+# Deleting the LRP cleans up the tables.
+k8s/delete lrp-addr.yaml
+db/cmp services services-empty.table
+db/cmp frontends frontends-empty.table
+
+# Maps should now be empty.
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps-empty.expected
+
+-- lrp.table --
+Name           Type     FrontendType      Frontends
+test/lrp-addr  address  addr-single-port  169.254.169.254:8080 TCP
+
+-- services-empty.table --
+Name                          Source
+
+-- services.table --
+Name                          Source
+test/lrp-addr-local-redirect  k8s   
+
+-- frontends-empty.table --
+Address                    Type        ServiceName
+
+-- frontends.table --
+Address                    Type          ServiceName                    Backends            RedirectTo  Status
+169.254.169.254:8080/TCP   LocalRedirect test/lrp-addr-local-redirect   10.244.2.1:80/TCP               Done
+
+-- backends.table --
+Address             Instances
+10.244.2.1:80/TCP   test/lrp-addr-local-redirect (tcp)
+
+-- maps.expected --
+BE: ID=1 ADDR=10.244.2.1:80/TCP STATE=active
+REV: ID=1 ADDR=169.254.169.254:8080
+SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+-- maps-empty.expected --
+
+-- lrp-addr.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-addr"
+  namespace: "test"
+spec:
+  redirectFrontend:
+    addressMatcher:
+      ip: "169.254.169.254"
+      toPorts:
+        - port: "8080"
+          protocol: TCP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: proxy
+    toPorts:
+      - port: "80"
+        protocol: TCP
+
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lrp-pod
+  namespace: test
+  labels:
+    app: proxy
+spec:
+  containers:
+    - name: lrp-pod
+      image: nginx
+      ports:
+        - containerPort: 80
+          name: tcp
+          protocol: TCP
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  qosClass: BestEffort
+  startTime: "2024-07-10T16:20:42Z"
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: '2019-07-08T09:41:59Z'
+    status: 'True'
+    type: Ready
+

--- a/pkg/loadbalancer/experimental/redirectpolicy/testdata/service.txtar
+++ b/pkg/loadbalancer/experimental/redirectpolicy/testdata/service.txtar
@@ -1,0 +1,188 @@
+hive start
+db/initialized
+
+# Add pods, services and endpoints.
+k8s/add pod.yaml service.yaml endpointslice.yaml
+db/cmp services services-before.table
+db/cmp frontends frontends-before.table
+
+# Compare maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps-before.expected
+
+# Add service-name based redirect
+k8s/add lrp-svc.yaml
+db/cmp localredirectpolicies lrp.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+
+# Compare maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps.expected
+
+# Updating the k8s objects doesn't change anything
+k8s/update pod.yaml service.yaml endpointslice.yaml
+db/cmp localredirectpolicies lrp.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+
+# Compare maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps.expected
+
+# Removing policy reverts (but we'll get new backend id)
+k8s/delete lrp-svc.yaml
+db/cmp services services-before.table
+db/cmp frontends frontends-before.table
+
+# Compare maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps-after.expected
+
+-- lrp.table --
+Name           Type     FrontendType                Frontends
+test/lrp-svc   service  all
+
+-- services-before.table --
+Name                          Source
+test/echo                     k8s   
+
+-- services.table --
+Name                          Source
+test/echo                     k8s   
+test/lrp-svc-local-redirect   k8s   
+
+-- frontends-before.table --
+Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status   
+169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                                 Done 
+
+-- frontends.table --
+Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
+169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.2.1:80/TCP     test/lrp-svc-local-redirect   Done
+
+-- maps-before.expected --
+BE: ID=1 ADDR=10.244.1.1:8080/TCP STATE=active
+REV: ID=1 ADDR=169.254.169.254:8080
+SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- maps.expected --
+BE: ID=2 ADDR=10.244.2.1:80/TCP STATE=active
+REV: ID=1 ADDR=169.254.169.254:8080
+SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+-- maps-after.expected --
+BE: ID=3 ADDR=10.244.1.1:8080/TCP STATE=active
+REV: ID=1 ADDR=169.254.169.254:8080
+SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lrp-svc.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-svc"
+  namespace: "test"
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: echo
+      namespace: test
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: proxy
+    toPorts:
+      - port: "80"
+        protocol: TCP
+
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lrp-pod
+  namespace: test
+  labels:
+    app: proxy
+spec:
+  containers:
+    - name: lrp-pod
+      image: nginx
+      ports:
+        - containerPort: 80
+          name: tcp
+          protocol: TCP
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  qosClass: BestEffort
+  startTime: "2024-07-10T16:20:42Z"
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: '2019-07-08T09:41:59Z'
+    status: 'True'
+    type: Ready
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 169.254.169.254
+  clusterIPs:
+  - 169.254.169.254
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: ClusterIP
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  annotations:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  generateName: echo-
+  generation: 3
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+  resourceVersion: "797"
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+  targetRef:
+    kind: Pod
+    name: echo-757d4cb97f-9gmf7
+    namespace: test
+    uid: 88542b9d-6369-4ec3-a5eb-fd53720013e8
+ports:
+- name: tcp
+  port: 8080
+  protocol: TCP
+
+

--- a/pkg/loadbalancer/experimental/redirectpolicy/testdata/skiplb-addr.txtar
+++ b/pkg/loadbalancer/experimental/redirectpolicy/testdata/skiplb-addr.txtar
@@ -1,0 +1,192 @@
+# Test the handling of 'SkipRedirectFromBackend'. If this field is set in the
+# LocalRedirectPolicy then the SkipLBMap should be populated accordingly to skip
+# the load-balancing in datapath for packets originating from the backend.
+
+hive start
+db/initialized
+
+### Case 1: 1) cookie, 2) pod 3) LRP
+
+# Add the netns cookie info to the skiplb table
+# This simulates the EndpointCreated() callback
+# coming from the EndpointManager.
+db/insert desired-skiplbmap pod-cookie.yaml
+
+# Add pods, services and endpoints.
+k8s/add pod.yaml lrp.yaml
+db/cmp localredirectpolicies lrp.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp desired-skiplbmap skiplbmap.table
+
+# Compare LB maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps-case1.expected
+
+# Compare SkipLB map
+skiplbmap skiplbmap.actual
+* cmp skiplbmap.actual skiplbmap.expected
+
+# Turn off the redirect. The SkipLB map entry should be removed.
+cp lrp.yaml lrp-noredirect.yaml
+replace 'skipRedirectFromBackend: true' 'skipRedirectFromBackend: false' lrp-noredirect.yaml
+k8s/update lrp-noredirect.yaml
+
+# Compare SkipLB map (should be empty now)
+skiplbmap skiplbmap.actual
+* cmp skiplbmap.actual skiplbmap.empty
+
+# Cleanup
+k8s/delete pod.yaml lrp.yaml
+db/delete desired-skiplbmap pod-cookie.yaml
+
+# Wait until empty
+* db/empty frontends localredirectpolicies services desired-skiplbmap
+skiplbmap skiplbmap.actual
+* cmp skiplbmap.actual skiplbmap.empty
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps.empty
+
+### Case 2: 1) pod & LRP 2) cookie
+
+# Add pod and LRP, but no cookie.
+k8s/add pod.yaml lrp.yaml
+db/cmp localredirectpolicies lrp.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+
+# The desired-skiplbmap now has the pod&lrp info, but there is no cookie
+# and it has not been reconciled or marked pending.
+db/cmp desired-skiplbmap skiplbmap-nocookie.table
+
+# Compare LB maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps-case2.expected
+
+# Compare SkipLB map (should be empty since no cookie yet)
+skiplbmap skiplbmap.actual
+* cmp skiplbmap.actual skiplbmap.empty
+
+# Add the cookie. Here we rely on the [desiredSkipLBMap] struct being
+# trivially serializable, allowing us to manipulate it.
+db/get desired-skiplbmap test/lrp-pod -f yaml -o skiplbmap.yaml
+cat skiplbmap.yaml
+replace 'netnscookie: null' 'netnscookie: 12345' skiplbmap.yaml
+replace 'kind: \"\"' 'kind: Pending' skiplbmap.yaml
+db/insert desired-skiplbmap skiplbmap.yaml
+
+# Should have the SkipLBMap entry again
+db/cmp desired-skiplbmap skiplbmap.table
+skiplbmap skiplbmap.actual
+* cmp skiplbmap.actual skiplbmap.expected
+
+# Cleanup
+k8s/delete pod.yaml lrp.yaml
+db/delete desired-skiplbmap pod-cookie.yaml
+
+# Wait until empty
+* db/empty frontends localredirectpolicies services desired-skiplbmap
+db/show desired-skiplbmap
+skiplbmap skiplbmap.actual
+* cmp skiplbmap.actual skiplbmap.empty
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps.empty
+
+-- pod-cookie.yaml --
+podnamespacedname: test/lrp-pod
+netnscookie: 12345
+
+-- lrp.table --
+Name           Type     FrontendType                Frontends
+test/lrp-addr  address  addr-single-port            169.254.169.255:8080 TCP
+
+-- skiplbmap.table --
+Pod            SkipRedirects                                 NetnsCookie  Status
+test/lrp-pod   169.254.169.255:8080/TCP                      12345        Done
+
+-- skiplbmap-nocookie.table --
+Pod            SkipRedirects                                 NetnsCookie  Status
+test/lrp-pod   169.254.169.255:8080/TCP                      <unset>
+
+-- skiplbmap.expected --
+COOKIE=12345 IP=169.254.169.255 PORT=8080
+-- skiplbmap.empty --
+-- services-before.table --
+Name                          Source
+test/echo                     k8s   
+
+-- services.table --
+Name                          Source
+test/lrp-addr-local-redirect  k8s
+
+-- frontends.table --
+Address                    Type          ServiceName                    PortName   Backends              RedirectTo                    Status
+169.254.169.255:8080/TCP   LocalRedirect test/lrp-addr-local-redirect              10.244.2.1:80/TCP                                   Done
+
+-- maps.empty --
+
+-- maps-case1.expected --
+BE: ID=1 ADDR=10.244.2.1:80/TCP STATE=active
+REV: ID=1 ADDR=169.254.169.255:8080
+SVC: ID=1 ADDR=169.254.169.255:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=1 ADDR=169.254.169.255:8080/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+-- maps-case2.expected --
+BE: ID=2 ADDR=10.244.2.1:80/TCP STATE=active
+REV: ID=2 ADDR=169.254.169.255:8080
+SVC: ID=2 ADDR=169.254.169.255:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=169.254.169.255:8080/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+-- lrp.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-addr"
+  namespace: "test"
+spec:
+  skipRedirectFromBackend: true
+  redirectFrontend:
+    addressMatcher:
+      ip: "169.254.169.255"
+      toPorts:
+        - port: "8080"
+          protocol: TCP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: proxy
+    toPorts:
+      - port: "80"
+        protocol: TCP
+
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lrp-pod
+  namespace: test
+  labels:
+    app: proxy
+spec:
+  containers:
+    - name: lrp-pod
+      image: nginx
+      ports:
+        - containerPort: 80
+          name: tcp
+          protocol: TCP
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  - ip: 2002::2
+  qosClass: BestEffort
+  startTime: "2024-07-10T16:20:42Z"
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: '2019-07-08T09:41:59Z'
+    status: 'True'
+    type: Ready
+

--- a/pkg/loadbalancer/experimental/redirectpolicy/testdata/skiplb.txtar
+++ b/pkg/loadbalancer/experimental/redirectpolicy/testdata/skiplb.txtar
@@ -1,0 +1,264 @@
+# Test the handling of 'SkipRedirectFromBackend'. If this field is set in the
+# LocalRedirectPolicy then the SkipLBMap should be populated accordingly to skip
+# the load-balancing in datapath for packets originating from the backend.
+
+hive start
+db/initialized
+
+### Case 1: 1) cookie, 2) pod,service,eps, 3) LRP
+
+# Add the netns cookie info to the skiplb table
+# This simulates the EndpointCreated() callback
+# coming from the EndpointManager.
+db/insert desired-skiplbmap pod-cookie.yaml
+
+# Add pods, services and endpoints.
+k8s/add pod.yaml service.yaml endpointslice.yaml lrp-svc.yaml
+db/cmp localredirectpolicies lrp.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp desired-skiplbmap skiplbmap.table
+
+# Compare LB maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps-case1.expected
+
+# Compare SkipLB map
+skiplbmap skiplbmap.actual
+* cmp skiplbmap.actual skiplbmap.expected
+
+# Turn off the redirect. The SkipLB map entry should be removed.
+cp lrp-svc.yaml lrp-svc-noredirect.yaml
+replace 'skipRedirectFromBackend: true' 'skipRedirectFromBackend: false' lrp-svc-noredirect.yaml
+k8s/update lrp-svc-noredirect.yaml
+
+# Compare SkipLB map (should be empty now)
+skiplbmap skiplbmap.actual
+* cmp skiplbmap.actual skiplbmap.empty
+
+# Cleanup
+k8s/delete pod.yaml service.yaml endpointslice.yaml lrp-svc.yaml
+db/delete desired-skiplbmap pod-cookie.yaml
+
+# Wait until empty
+* db/empty frontends localredirectpolicies services desired-skiplbmap
+db/show desired-skiplbmap
+skiplbmap skiplbmap.actual
+* cmp skiplbmap.actual skiplbmap.empty
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps.empty
+
+### Case 2: 1) pod,service,eps, 2) LRP, 3) cookie
+
+# Add pod, service, endpoints and LRP, but no cookie.
+k8s/add pod.yaml service.yaml endpointslice.yaml lrp-svc.yaml
+db/cmp localredirectpolicies lrp.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+
+# The desired-skiplbmap now has the pod&lrp info, but there is no cookie
+# and it has not been reconciled or marked pending.
+db/cmp desired-skiplbmap skiplbmap-nocookie.table
+
+# Compare LB maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps-case2.expected
+
+# Compare SkipLB map (should be empty since no cookie yet)
+skiplbmap skiplbmap.actual
+* cmp skiplbmap.actual skiplbmap.empty
+
+# Add the cookie. Here we rely on the [desiredSkipLBMap] struct being
+# trivially serializable, allowing us to manipulate it.
+db/get desired-skiplbmap test/lrp-pod -f yaml -o skiplbmap.yaml
+cat skiplbmap.yaml
+replace 'netnscookie: null' 'netnscookie: 12345' skiplbmap.yaml
+replace 'kind: \"\"' 'kind: Pending' skiplbmap.yaml
+db/insert desired-skiplbmap skiplbmap.yaml
+
+# Should have the SkipLBMap entry again
+db/cmp desired-skiplbmap skiplbmap.table
+skiplbmap skiplbmap.actual
+* cmp skiplbmap.actual skiplbmap.expected
+
+# Cleanup
+k8s/delete pod.yaml service.yaml endpointslice.yaml lrp-svc.yaml
+db/delete desired-skiplbmap pod-cookie.yaml
+
+# Wait until empty
+* db/empty frontends localredirectpolicies services desired-skiplbmap
+db/show desired-skiplbmap
+skiplbmap skiplbmap.actual
+* cmp skiplbmap.actual skiplbmap.empty
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual maps.empty
+
+-- pod-cookie.yaml --
+podnamespacedname: test/lrp-pod
+netnscookie: 12345
+
+-- lrp.table --
+Name           Type     FrontendType                Frontends
+test/lrp-svc   service  all
+
+-- skiplbmap.table --
+Pod            SkipRedirects                                 NetnsCookie  Status
+test/lrp-pod   [1001::1]:8080/TCP, 169.254.169.254:8080/TCP  12345        Done
+
+-- skiplbmap-nocookie.table --
+Pod            SkipRedirects                                 NetnsCookie  Status
+test/lrp-pod   [1001::1]:8080/TCP, 169.254.169.254:8080/TCP  <unset>
+
+-- skiplbmap.expected --
+COOKIE=12345 IP=1001::1 PORT=8080
+COOKIE=12345 IP=169.254.169.254 PORT=8080
+-- skiplbmap.empty --
+-- services-before.table --
+Name                          Source
+test/echo                     k8s   
+
+-- services.table --
+Name                          Source
+test/echo                     k8s   
+test/lrp-svc-local-redirect   k8s   
+
+-- frontends.table --
+Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
+169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.2.1:80/TCP     test/lrp-svc-local-redirect   Done
+[1001::1]:8080/TCP         ClusterIP   test/echo     tcp        [2002::2]:80/TCP      test/lrp-svc-local-redirect   Done
+
+-- maps.empty --
+
+-- maps-case1.expected --
+BE: ID=3 ADDR=[2002::2]:80/TCP STATE=active
+BE: ID=4 ADDR=10.244.2.1:80/TCP STATE=active
+REV: ID=1 ADDR=[1001::1]:8080
+REV: ID=2 ADDR=169.254.169.254:8080
+SVC: ID=1 ADDR=[1001::1]:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=1 ADDR=[1001::1]:8080/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=4 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+-- maps-case2.expected --
+BE: ID=7 ADDR=[2002::2]:80/TCP STATE=active
+BE: ID=8 ADDR=10.244.2.1:80/TCP STATE=active
+REV: ID=3 ADDR=[1001::1]:8080
+REV: ID=4 ADDR=169.254.169.254:8080
+SVC: ID=3 ADDR=[1001::1]:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=3 ADDR=[1001::1]:8080/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=4 ADDR=169.254.169.254:8080/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=4 ADDR=169.254.169.254:8080/TCP SLOT=1 BEID=8 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+-- lrp-svc.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-svc"
+  namespace: "test"
+spec:
+  skipRedirectFromBackend: true
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: echo
+      namespace: test
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: proxy
+    toPorts:
+      - port: "80"
+        protocol: TCP
+
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lrp-pod
+  namespace: test
+  labels:
+    app: proxy
+spec:
+  containers:
+    - name: lrp-pod
+      image: nginx
+      ports:
+        - containerPort: 80
+          name: tcp
+          protocol: TCP
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  - ip: 2002::2
+  qosClass: BestEffort
+  startTime: "2024-07-10T16:20:42Z"
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: '2019-07-08T09:41:59Z'
+    status: 'True'
+    type: Ready
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 169.254.169.254
+  clusterIPs:
+  - 169.254.169.254
+  - 1001::1
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: ClusterIP
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  annotations:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  generateName: echo-
+  generation: 3
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+  resourceVersion: "797"
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  - 2001::1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+  targetRef:
+    kind: Pod
+    name: echo-757d4cb97f-9gmf7
+    namespace: test
+    uid: 88542b9d-6369-4ec3-a5eb-fd53720013e8
+ports:
+- name: tcp
+  port: 8080
+  protocol: TCP
+
+

--- a/pkg/loadbalancer/experimental/redirectpolicy/watch.sh
+++ b/pkg/loadbalancer/experimental/redirectpolicy/watch.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# watch.sh watches the current and testdata directories and will
+# either recompile or execute the test for the changes test script.
+# This is useful when working on a test case as "go test" can be slow
+# due to slow linking as we pull in the client-go.
+# 
+# https://github.com/kubernetes/kubernetes/issues/127888 is an issue
+# for making client-go lighter that should improve the binary size and
+# compilation times.
+
+set -ux
+go test -c || exit 1
+
+inotifywait -e close_write -m . testdata |
+while read -r directory events filename; do
+  case "$directory" in
+    ./) 
+      go test -c && ./redirectpolicy.test -test.v -test.failfast
+      ;;
+    testdata/) 
+      ./redirectpolicy.test -test.run TestScript/$filename -test.v 
+      ;;
+  esac
+done
+

--- a/pkg/loadbalancer/experimental/reflector_test.go
+++ b/pkg/loadbalancer/experimental/reflector_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package experimental
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/k8s"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_discovery_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
+	"github.com/cilium/cilium/pkg/k8s/testutils"
+)
+
+var (
+	benchmarkExternalConfig = ExternalConfig{
+		EnableIPv4:                      true,
+		EnableIPv6:                      true,
+		ExternalClusterIP:               true,
+		EnableHealthCheckNodePort:       true,
+		KubeProxyReplacement:            true,
+		NodePortMin:                     10000,
+		NodePortMax:                     30000,
+		NodePortAlg:                     "random",
+		LoadBalancerAlgorithmAnnotation: false,
+	}
+)
+
+func BenchmarkConvertService(b *testing.B) {
+	obj, err := testutils.DecodeFile("benchmark/testdata/service.yaml")
+	if err != nil {
+		panic(err)
+	}
+	svc := obj.(*slim_corev1.Service)
+
+	b.ResetTimer()
+	for range b.N {
+		convertService(benchmarkExternalConfig, svc)
+	}
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "services/sec")
+}
+
+func BenchmarkParseEndpointSlice(b *testing.B) {
+	obj, err := testutils.DecodeFile("benchmark/testdata/endpointslice.yaml")
+	if err != nil {
+		panic(err)
+	}
+	epSlice := obj.(*slim_discovery_v1.EndpointSlice)
+
+	b.ResetTimer()
+	for range b.N {
+		k8s.ParseEndpointSliceV1(epSlice)
+	}
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "endpointslices/sec")
+}
+
+func BenchmarkConvertEndpoints(b *testing.B) {
+	obj, err := testutils.DecodeFile("benchmark/testdata/endpointslice.yaml")
+	if err != nil {
+		panic(err)
+	}
+	epSlice := obj.(*slim_discovery_v1.EndpointSlice)
+	eps := k8s.ParseEndpointSliceV1(epSlice)
+
+	b.ResetTimer()
+	for range b.N {
+		convertEndpoints(benchmarkExternalConfig, eps)
+	}
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "endpoints/sec")
+}

--- a/pkg/loadbalancer/experimental/service.go
+++ b/pkg/loadbalancer/experimental/service.go
@@ -38,6 +38,11 @@ type Service struct {
 	// Annotations associated with this service.
 	Annotations map[string]string
 
+	// Selector specifies which pods should be associated with this service. If
+	// this is empty the backends associated to this service are managed externally
+	// and not by Kubernetes.
+	Selector map[string]string
+
 	// NatPolicy defines whether we need NAT46/64 translation for backends.
 	NatPolicy loadbalancer.SVCNatPolicy
 
@@ -69,6 +74,9 @@ type Service struct {
 	// SourceRanges if non-empty will restrict access to the service to the specified
 	// client addresses.
 	SourceRanges []cidr.CIDR
+
+	// PortNames maps a port name to a port number.
+	PortNames map[string]uint16
 
 	// Properties are additional untyped properties that can carry feature
 	// specific metadata about the service.
@@ -168,12 +176,12 @@ func (svc *Service) TableRow() []string {
 		strconv.FormatUint(uint64(svc.HealthCheckNodePort), 10),
 		showBool(svc.LoopbackHostPort),
 		showSourceRanges(svc.SourceRanges),
-		svc.GetLBAlgorithmAnnotation(),
+		svc.GetLBAlgorithmAnnotation().String(),
 	}
 }
 
-func (svc *Service) GetLBAlgorithmAnnotation() string {
-	return svc.Annotations[annotation.ServiceLoadBalancingAlgorithm]
+func (svc *Service) GetLBAlgorithmAnnotation() loadbalancer.SVCLoadBalancingAlgorithm {
+	return loadbalancer.ToSVCLoadBalancingAlgorithm(svc.Annotations[annotation.ServiceLoadBalancingAlgorithm])
 }
 
 var (

--- a/pkg/loadbalancer/experimental/stress.sh
+++ b/pkg/loadbalancer/experimental/stress.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eux
+[ ! -f $HOME/go/bin/stress ] && go install golang.org/x/tools/cmd/stress@latest
+
+DIRS=". redirectpolicy"
+
+for dir in $DIRS; do
+  pushd $dir
+  go test -c -o stress.test
+  $HOME/go/bin/stress -count 500 ./stress.test
+  rm stress.test
+  popd
+done

--- a/pkg/loadbalancer/experimental/test_utils.go
+++ b/pkg/loadbalancer/experimental/test_utils.go
@@ -314,7 +314,7 @@ func FastCheckEmptyTablesAndState(db *statedb.DB, writer *Writer, bo *BPFOps) bo
 	if writer.Frontends().NumObjects(txn) > 0 || writer.Backends().NumObjects(txn) > 0 || writer.Services().NumObjects(txn) > 0 {
 		return false
 	}
-	if len(bo.backendReferences) > 0 || len(bo.backendStates) > 0 || len(bo.nodePortAddrByService) > 0 || len(bo.serviceIDAlloc.entities) > 0 || len(bo.backendIDAlloc.entities) > 0 {
+	if len(bo.backendReferences) > 0 || len(bo.backendStates) > 0 || len(bo.nodePortAddrByPort) > 0 || len(bo.serviceIDAlloc.entities) > 0 || len(bo.backendIDAlloc.entities) > 0 {
 		return false
 	}
 	return true

--- a/pkg/loadbalancer/experimental/testdata/clusterip.txtar
+++ b/pkg/loadbalancer/experimental/testdata/clusterip.txtar
@@ -25,15 +25,15 @@ db/cmp backends backends_empty.table
 
 -- services.table --
 Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-test/echo   k8s                  Cluster            Cluster                              0                     false              
+test/echo   k8s                  Cluster            Cluster            42s               0                     false
 
 -- frontends.table --
-Address               Type        ServiceName   PortName   Backends                     Status
-10.96.50.104:80/TCP   ClusterIP   test/echo     http       10.244.1.1:80/TCP (active)   Done
+Address               Type        ServiceName   PortName   Backends           Status
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       10.244.1.1:80/TCP  Done
 
 -- backends.table --
-Address             State    Instances          Shadows        NodeName          ZoneID
-10.244.1.1:80/TCP   active   test/echo (http)   test/echo []   nodeport-worker   0
+Address             Instances          Shadows
+10.244.1.1:80/TCP   test/echo (http)
 
 -- services_empty.table --
 Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
@@ -42,7 +42,7 @@ Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionA
 Address               Type        ServiceName   PortName   Status  Backends
 
 -- backends_empty.table --
-Address             State    Instances   Shadows          NodeName           ZoneID
+Address
 
 -- service.yaml --
 apiVersion: v1
@@ -65,6 +65,10 @@ spec:
   selector:
     name: echo
   type: ClusterIP
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 42
 
 -- endpointslice.yaml --
 apiVersion: discovery.k8s.io/v1
@@ -101,7 +105,8 @@ ports:
   protocol: TCP
 
 -- lbmaps.expected --
+AFF: ID=1 BEID=1
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
 REV: ID=1 ADDR=10.96.50.104:80
-SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
-SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=random AFFTimeout=42 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+sessionAffinity+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+sessionAffinity+non-routable

--- a/pkg/loadbalancer/experimental/testdata/dualstack-maglev.txtar
+++ b/pkg/loadbalancer/experimental/testdata/dualstack-maglev.txtar
@@ -56,46 +56,46 @@ Name                     Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolic
 default/echo-dualstack   k8s                  Cluster            Cluster                              0                     false
 
 -- frontends-ipv4.table --
-Address                     Type        ServiceName              PortName   Backends                                                                       Status
-[::]:30181/TCP              NodePort    default/echo-dualstack   http                                                                                      Done
-[::]:32757/UDP              NodePort    default/echo-dualstack   tftp                                                                                      Done
-0.0.0.0:30181/TCP           NodePort    default/echo-dualstack   http       10.244.1.54:80/TCP (active), 10.244.2.9:80/TCP (active)                        Done
-0.0.0.0:32757/UDP           NodePort    default/echo-dualstack   tftp       10.244.1.54:69/UDP (active), 10.244.2.9:69/UDP (active)                        Done
-10.96.207.99:69/UDP         ClusterIP   default/echo-dualstack   tftp       10.244.1.54:69/UDP (active), 10.244.2.9:69/UDP (active)                        Done
-10.96.207.99:80/TCP         ClusterIP   default/echo-dualstack   http       10.244.1.54:80/TCP (active), 10.244.2.9:80/TCP (active)                        Done
-[fd00:10:96::b050]:69/UDP   ClusterIP   default/echo-dualstack   tftp                                                                                      Done
-[fd00:10:96::b050]:80/TCP   ClusterIP   default/echo-dualstack   http                                                                                      Done
+Address                     Type        ServiceName              PortName   Backends                                                     Status
+[::]:30181/TCP              NodePort    default/echo-dualstack   http                                                                    Done
+[::]:32757/UDP              NodePort    default/echo-dualstack   tftp                                                                    Done
+0.0.0.0:30181/TCP           NodePort    default/echo-dualstack   http       10.244.1.54:80/TCP, 10.244.2.9:80/TCP                        Done
+0.0.0.0:32757/UDP           NodePort    default/echo-dualstack   tftp       10.244.1.54:69/UDP, 10.244.2.9:69/UDP                        Done
+10.96.207.99:69/UDP         ClusterIP   default/echo-dualstack   tftp       10.244.1.54:69/UDP, 10.244.2.9:69/UDP                        Done
+10.96.207.99:80/TCP         ClusterIP   default/echo-dualstack   http       10.244.1.54:80/TCP, 10.244.2.9:80/TCP                        Done
+[fd00:10:96::b050]:69/UDP   ClusterIP   default/echo-dualstack   tftp                                                                    Done
+[fd00:10:96::b050]:80/TCP   ClusterIP   default/echo-dualstack   http                                                                    Done
 
 -- frontends.table --
-Address                     Type        ServiceName              PortName   Backends                                                                       Status
-[::]:30181/TCP              NodePort    default/echo-dualstack   http       [fd00:10:244:1::247e]:80/TCP (active), [fd00:10:244:2::a314]:80/TCP (active)   Done
-[::]:32757/UDP              NodePort    default/echo-dualstack   tftp       [fd00:10:244:1::247e]:69/UDP (active), [fd00:10:244:2::a314]:69/UDP (active)   Done
-0.0.0.0:30181/TCP           NodePort    default/echo-dualstack   http       10.244.1.54:80/TCP (active), 10.244.2.9:80/TCP (active)                        Done
-0.0.0.0:32757/UDP           NodePort    default/echo-dualstack   tftp       10.244.1.54:69/UDP (active), 10.244.2.9:69/UDP (active)                        Done
-10.96.207.99:69/UDP         ClusterIP   default/echo-dualstack   tftp       10.244.1.54:69/UDP (active), 10.244.2.9:69/UDP (active)                        Done
-10.96.207.99:80/TCP         ClusterIP   default/echo-dualstack   http       10.244.1.54:80/TCP (active), 10.244.2.9:80/TCP (active)                        Done
-[fd00:10:96::b050]:69/UDP   ClusterIP   default/echo-dualstack   tftp       [fd00:10:244:1::247e]:69/UDP (active), [fd00:10:244:2::a314]:69/UDP (active)   Done
-[fd00:10:96::b050]:80/TCP   ClusterIP   default/echo-dualstack   http       [fd00:10:244:1::247e]:80/TCP (active), [fd00:10:244:2::a314]:80/TCP (active)   Done
+Address                     Type        ServiceName              PortName   Backends                                                     Status
+[::]:30181/TCP              NodePort    default/echo-dualstack   http       [fd00:10:244:1::247e]:80/TCP, [fd00:10:244:2::a314]:80/TCP   Done
+[::]:32757/UDP              NodePort    default/echo-dualstack   tftp       [fd00:10:244:1::247e]:69/UDP, [fd00:10:244:2::a314]:69/UDP   Done
+0.0.0.0:30181/TCP           NodePort    default/echo-dualstack   http       10.244.1.54:80/TCP, 10.244.2.9:80/TCP                        Done
+0.0.0.0:32757/UDP           NodePort    default/echo-dualstack   tftp       10.244.1.54:69/UDP, 10.244.2.9:69/UDP                        Done
+10.96.207.99:69/UDP         ClusterIP   default/echo-dualstack   tftp       10.244.1.54:69/UDP, 10.244.2.9:69/UDP                        Done
+10.96.207.99:80/TCP         ClusterIP   default/echo-dualstack   http       10.244.1.54:80/TCP, 10.244.2.9:80/TCP                        Done
+[fd00:10:96::b050]:69/UDP   ClusterIP   default/echo-dualstack   tftp       [fd00:10:244:1::247e]:69/UDP, [fd00:10:244:2::a314]:69/UDP   Done
+[fd00:10:96::b050]:80/TCP   ClusterIP   default/echo-dualstack   http       [fd00:10:244:1::247e]:80/TCP, [fd00:10:244:2::a314]:80/TCP   Done
 
 -- backends.table --
-Address                        State    Instances                       NodeName             ZoneID
-10.244.1.54:69/UDP             active   default/echo-dualstack (tftp)   dual-stack-worker    0
-10.244.1.54:80/TCP             active   default/echo-dualstack (http)   dual-stack-worker    0
-10.244.2.9:69/UDP              active   default/echo-dualstack (tftp)   dual-stack-worker2   0
-10.244.2.9:80/TCP              active   default/echo-dualstack (http)   dual-stack-worker2   0
-[fd00:10:244:1::247e]:69/UDP   active   default/echo-dualstack (tftp)   dual-stack-worker    0
-[fd00:10:244:1::247e]:80/TCP   active   default/echo-dualstack (http)   dual-stack-worker    0
-[fd00:10:244:2::a314]:69/UDP   active   default/echo-dualstack (tftp)   dual-stack-worker2   0
-[fd00:10:244:2::a314]:80/TCP   active   default/echo-dualstack (http)   dual-stack-worker2   0
+Address                        Instances
+10.244.1.54:69/UDP             default/echo-dualstack (tftp)
+10.244.1.54:80/TCP             default/echo-dualstack (http)
+10.244.2.9:69/UDP              default/echo-dualstack (tftp)
+10.244.2.9:80/TCP              default/echo-dualstack (http)
+[fd00:10:244:1::247e]:69/UDP   default/echo-dualstack (tftp)
+[fd00:10:244:1::247e]:80/TCP   default/echo-dualstack (http)
+[fd00:10:244:2::a314]:69/UDP   default/echo-dualstack (tftp)
+[fd00:10:244:2::a314]:80/TCP   default/echo-dualstack (http)
 
 -- services_empty.table --
 Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
 
 -- frontends_empty.table --
-Address               Type        ServiceName   PortName   Status  Backends
+Address  Type        ServiceName   PortName   Status  Backends
 
 -- backends_empty.table --
-Address             State    Instances            NodeName           ZoneID
+Address
 
 
 -- service.yaml --

--- a/pkg/loadbalancer/experimental/testdata/dualstack.txtar
+++ b/pkg/loadbalancer/experimental/testdata/dualstack.txtar
@@ -55,37 +55,37 @@ Name                     Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolic
 default/echo-dualstack   k8s                  Cluster            Cluster                              0                     false              
 
 -- frontends-ipv4.table --
-Address                     Type        ServiceName              PortName   Backends                                                                       Status
-[::]:30181/TCP              NodePort    default/echo-dualstack   http                                                                                      Done
-[::]:32757/UDP              NodePort    default/echo-dualstack   tftp                                                                                      Done
-0.0.0.0:30181/TCP           NodePort    default/echo-dualstack   http       10.244.1.54:80/TCP (active), 10.244.2.9:80/TCP (active)                        Done
-0.0.0.0:32757/UDP           NodePort    default/echo-dualstack   tftp       10.244.1.54:69/UDP (active), 10.244.2.9:69/UDP (active)                        Done
-10.96.207.99:69/UDP         ClusterIP   default/echo-dualstack   tftp       10.244.1.54:69/UDP (active), 10.244.2.9:69/UDP (active)                        Done
-10.96.207.99:80/TCP         ClusterIP   default/echo-dualstack   http       10.244.1.54:80/TCP (active), 10.244.2.9:80/TCP (active)                        Done
-[fd00:10:96::b050]:69/UDP   ClusterIP   default/echo-dualstack   tftp                                                                                      Done
-[fd00:10:96::b050]:80/TCP   ClusterIP   default/echo-dualstack   http                                                                                      Done
+Address                     Type        ServiceName              PortName   Backends                                                     Status
+[::]:30181/TCP              NodePort    default/echo-dualstack   http                                                                    Done
+[::]:32757/UDP              NodePort    default/echo-dualstack   tftp                                                                    Done
+0.0.0.0:30181/TCP           NodePort    default/echo-dualstack   http       10.244.1.54:80/TCP, 10.244.2.9:80/TCP                        Done
+0.0.0.0:32757/UDP           NodePort    default/echo-dualstack   tftp       10.244.1.54:69/UDP, 10.244.2.9:69/UDP                        Done
+10.96.207.99:69/UDP         ClusterIP   default/echo-dualstack   tftp       10.244.1.54:69/UDP, 10.244.2.9:69/UDP                        Done
+10.96.207.99:80/TCP         ClusterIP   default/echo-dualstack   http       10.244.1.54:80/TCP, 10.244.2.9:80/TCP                        Done
+[fd00:10:96::b050]:69/UDP   ClusterIP   default/echo-dualstack   tftp                                                                    Done
+[fd00:10:96::b050]:80/TCP   ClusterIP   default/echo-dualstack   http                                                                    Done
 
 -- frontends.table --
-Address                     Type        ServiceName              PortName   Backends                                                                       Status
-[::]:30181/TCP              NodePort    default/echo-dualstack   http       [fd00:10:244:1::247e]:80/TCP (active), [fd00:10:244:2::a314]:80/TCP (active)   Done
-[::]:32757/UDP              NodePort    default/echo-dualstack   tftp       [fd00:10:244:1::247e]:69/UDP (active), [fd00:10:244:2::a314]:69/UDP (active)   Done
-0.0.0.0:30181/TCP           NodePort    default/echo-dualstack   http       10.244.1.54:80/TCP (active), 10.244.2.9:80/TCP (active)                        Done
-0.0.0.0:32757/UDP           NodePort    default/echo-dualstack   tftp       10.244.1.54:69/UDP (active), 10.244.2.9:69/UDP (active)                        Done
-10.96.207.99:69/UDP         ClusterIP   default/echo-dualstack   tftp       10.244.1.54:69/UDP (active), 10.244.2.9:69/UDP (active)                        Done
-10.96.207.99:80/TCP         ClusterIP   default/echo-dualstack   http       10.244.1.54:80/TCP (active), 10.244.2.9:80/TCP (active)                        Done
-[fd00:10:96::b050]:69/UDP   ClusterIP   default/echo-dualstack   tftp       [fd00:10:244:1::247e]:69/UDP (active), [fd00:10:244:2::a314]:69/UDP (active)   Done
-[fd00:10:96::b050]:80/TCP   ClusterIP   default/echo-dualstack   http       [fd00:10:244:1::247e]:80/TCP (active), [fd00:10:244:2::a314]:80/TCP (active)   Done
+Address                     Type        ServiceName              PortName   Backends                                                     Status
+[::]:30181/TCP              NodePort    default/echo-dualstack   http       [fd00:10:244:1::247e]:80/TCP, [fd00:10:244:2::a314]:80/TCP   Done
+[::]:32757/UDP              NodePort    default/echo-dualstack   tftp       [fd00:10:244:1::247e]:69/UDP, [fd00:10:244:2::a314]:69/UDP   Done
+0.0.0.0:30181/TCP           NodePort    default/echo-dualstack   http       10.244.1.54:80/TCP, 10.244.2.9:80/TCP                        Done
+0.0.0.0:32757/UDP           NodePort    default/echo-dualstack   tftp       10.244.1.54:69/UDP, 10.244.2.9:69/UDP                        Done
+10.96.207.99:69/UDP         ClusterIP   default/echo-dualstack   tftp       10.244.1.54:69/UDP, 10.244.2.9:69/UDP                        Done
+10.96.207.99:80/TCP         ClusterIP   default/echo-dualstack   http       10.244.1.54:80/TCP, 10.244.2.9:80/TCP                        Done
+[fd00:10:96::b050]:69/UDP   ClusterIP   default/echo-dualstack   tftp       [fd00:10:244:1::247e]:69/UDP, [fd00:10:244:2::a314]:69/UDP   Done
+[fd00:10:96::b050]:80/TCP   ClusterIP   default/echo-dualstack   http       [fd00:10:244:1::247e]:80/TCP, [fd00:10:244:2::a314]:80/TCP   Done
 
 -- backends.table --
-Address                        State    Instances                       NodeName             ZoneID
-10.244.1.54:69/UDP             active   default/echo-dualstack (tftp)   dual-stack-worker    0
-10.244.1.54:80/TCP             active   default/echo-dualstack (http)   dual-stack-worker    0
-10.244.2.9:69/UDP              active   default/echo-dualstack (tftp)   dual-stack-worker2   0
-10.244.2.9:80/TCP              active   default/echo-dualstack (http)   dual-stack-worker2   0
-[fd00:10:244:1::247e]:69/UDP   active   default/echo-dualstack (tftp)   dual-stack-worker    0
-[fd00:10:244:1::247e]:80/TCP   active   default/echo-dualstack (http)   dual-stack-worker    0
-[fd00:10:244:2::a314]:69/UDP   active   default/echo-dualstack (tftp)   dual-stack-worker2   0
-[fd00:10:244:2::a314]:80/TCP   active   default/echo-dualstack (http)   dual-stack-worker2   0
+Address                        Instances
+10.244.1.54:69/UDP             default/echo-dualstack (tftp)
+10.244.1.54:80/TCP             default/echo-dualstack (http)
+10.244.2.9:69/UDP              default/echo-dualstack (tftp)
+10.244.2.9:80/TCP              default/echo-dualstack (http)
+[fd00:10:244:1::247e]:69/UDP   default/echo-dualstack (tftp)
+[fd00:10:244:1::247e]:80/TCP   default/echo-dualstack (http)
+[fd00:10:244:2::a314]:69/UDP   default/echo-dualstack (tftp)
+[fd00:10:244:2::a314]:80/TCP   default/echo-dualstack (http)
 
 -- services_empty.table --
 Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
@@ -94,8 +94,7 @@ Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionA
 Address               Type        ServiceName   PortName   Status  Backends
 
 -- backends_empty.table --
-Address             State    Instances            NodeName           ZoneID
-
+Address
 
 -- service.yaml --
 apiVersion: v1

--- a/pkg/loadbalancer/experimental/testdata/external-clusterip.txtar
+++ b/pkg/loadbalancer/experimental/testdata/external-clusterip.txtar
@@ -1,0 +1,67 @@
+#! --enable-experimental-lb --bpf-lb-external-clusterip --node-port-algorithm=maglev
+# Test the handling of the external ClusterIP support.
+
+# Start the test application
+hive start
+
+# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
+db/initialized
+
+k8s/add service.yaml endpointslice.yaml
+
+# Check the BPF maps. The service should not be marked as "non-routable"
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
+! grep "non-routable" lbmaps.actual
+
+#####
+
+-- lbmaps.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+MAGLEV: ID=1 INNER=[1(1021)]
+REV: ID=1 ADDR=10.96.50.104:80
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=maglev AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  type: ClusterIP
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+

--- a/pkg/loadbalancer/experimental/testdata/graceful-termination.txtar
+++ b/pkg/loadbalancer/experimental/testdata/graceful-termination.txtar
@@ -6,6 +6,13 @@ hive start
 # Wait for tables to initialize (e.g. reflector to start) before adding more objects.
 db/initialized
 
+# Start with two backends that are both active.
+cp endpointslice.yaml.tmpl endpointslice.yaml
+replace '$TERM1' 'false' endpointslice.yaml
+replace '$READY1' 'true' endpointslice.yaml
+replace '$TERM2' 'false' endpointslice.yaml
+replace '$READY2' 'true' endpointslice.yaml
+
 k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
 db/cmp frontends frontends.table
@@ -15,14 +22,31 @@ db/cmp backends backends.table
 lb/maps-dump lbmaps.actual
 * cmp lbmaps-active.expected lbmaps.actual
 
-# Set the backend as terminating
-k8s/update endpointslice-terminating.yaml
-db/cmp frontends frontends-terminating.table
-db/cmp backends backends-terminating.table
+# Set the first backend as terminating. The second backend
+# will now serve the traffic.
+cp endpointslice.yaml.tmpl endpointslice.yaml
+replace '$TERM1' 'true' endpointslice.yaml
+replace '$READY1' 'false' endpointslice.yaml
+replace '$TERM2' 'false' endpointslice.yaml
+replace '$READY2' 'true' endpointslice.yaml
+k8s/update endpointslice.yaml
+db/cmp backends backends-terminating1.table
 
 # Check BPF maps
 lb/maps-dump lbmaps.actual
-* cmp lbmaps-terminating.expected lbmaps.actual
+* cmp lbmaps-terminating1.expected lbmaps.actual
+
+# Set also the second backend as terminating. Now since there
+# are now active backends the terminating backends are used
+# instead.
+cp endpointslice.yaml.tmpl endpointslice.yaml
+replace '$TERM1' 'true' endpointslice.yaml
+replace '$READY1' 'false' endpointslice.yaml
+replace '$TERM2' 'true' endpointslice.yaml
+replace '$READY2' 'false' endpointslice.yaml
+k8s/update endpointslice.yaml
+db/cmp frontends frontends-terminating2.table
+db/cmp backends backends-terminating2.table
 
 # Cleanup
 k8s/delete service.yaml endpointslice.yaml 
@@ -37,20 +61,27 @@ Name                     Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolic
 test/graceful-term-svc   k8s                  Cluster            Cluster                              0                     false              
 
 -- frontends.table --
-Address                 Type        ServiceName              Backends                              Status
-10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   10.244.0.112:8081/TCP (active)        Done
+Address                 Type        ServiceName              Status  Backends                              
+10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
 
--- frontends-terminating.table --
-Address                 Type        ServiceName              Backends                              Status
-10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   10.244.0.112:8081/TCP (terminating)   Done
+-- frontends-terminating2.table --
+Address                 Type        ServiceName              Status  Backends
+10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
 
 -- backends.table --
-Address                 State   Instances                NodeName                      ZoneID
-10.244.0.112:8081/TCP   active  test/graceful-term-svc   graceful-term-control-plane   0
+Address                 Instances                NodeName
+10.244.0.112:8081/TCP   test/graceful-term-svc   graceful-term-control-plane
+10.244.0.113:8081/TCP   test/graceful-term-svc   graceful-term-control-plane
 
--- backends-terminating.table --
-Address                 State         Instances                NodeName                      ZoneID
-10.244.0.112:8081/TCP   terminating   test/graceful-term-svc   graceful-term-control-plane   0
+-- backends-terminating1.table --
+Address                 Instances                              NodeName
+10.244.0.112:8081/TCP   test/graceful-term-svc [terminating]   graceful-term-control-plane
+10.244.0.113:8081/TCP   test/graceful-term-svc                 graceful-term-control-plane
+
+-- backends-terminating2.table --
+Address                 Instances                             NodeName
+10.244.0.112:8081/TCP   test/graceful-term-svc [terminating]  graceful-term-control-plane
+10.244.0.113:8081/TCP   test/graceful-term-svc [terminating]  graceful-term-control-plane
 
 -- services_empty.table --
 Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
@@ -59,7 +90,7 @@ Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionA
 Address               Type        ServiceName   PortName   Status  Backends
 
 -- backends_empty.table --
-Address             State    Instances            NodeName           ZoneID
+Address
 
 -- service.yaml --
 apiVersion: v1
@@ -92,23 +123,9 @@ spec:
 status:
   loadBalancer: {}
 
--- endpointslice.yaml --
-addressType: IPv4
-apiVersion: discovery.k8s.io/v1
-endpoints:
-- addresses:
-  - 10.244.0.112
-  conditions:
-    ready: true
-    serving: true
-    terminating: false
-  nodeName: graceful-term-control-plane
-  targetRef:
-    kind: Pod
-    name: graceful-term-server
-    namespace: test
-    uid: 82f690d0-e3ed-4981-af97-30133d1b457e
+-- endpointslice.yaml.tmpl --
 kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
 metadata:
   creationTimestamp: "2023-02-02T01:21:10Z"
   generateName: graceful-term-svc-
@@ -127,57 +144,54 @@ metadata:
     uid: be7e85d4-6d27-400b-aff2-bd7284837fc9
   resourceVersion: "729"
   uid: ed13283f-c92e-4531-ae1b-f6d6aa4463b7
-ports:
-- name: ""
-  port: 8081
-  protocol: TCP
-
--- endpointslice-terminating.yaml --
 addressType: IPv4
-apiVersion: discovery.k8s.io/v1
 endpoints:
 - addresses:
   - 10.244.0.112
   conditions:
-    ready: false
+    ready: $READY1
     serving: true
-    terminating: true
+    terminating: $TERM1
   nodeName: graceful-term-control-plane
   targetRef:
     kind: Pod
     name: graceful-term-server
     namespace: test
     uid: 82f690d0-e3ed-4981-af97-30133d1b457e
-kind: EndpointSlice
-metadata:
-  creationTimestamp: "2023-02-02T01:21:10Z"
-  generateName: graceful-term-svc-
-  generation: 4
-  labels:
-    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
-    kubernetes.io/service-name: graceful-term-svc
-  name: graceful-term-svc-pg7nd
-  namespace: test
-  ownerReferences:
-  - apiVersion: v1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Service
-    name: graceful-term-svc
-    uid: be7e85d4-6d27-400b-aff2-bd7284837fc9
-  resourceVersion: "730"
-  uid: ed13283f-c92e-4531-ae1b-f6d6aa4463b7
+
+- addresses:
+  - 10.244.0.113
+  conditions:
+    ready: $READY2
+    serving: true
+    terminating: $TERM2
+  nodeName: graceful-term-control-plane
+  targetRef:
+    kind: Pod
+    name: graceful-term-server-2
+    namespace: test
+    uid: 92f690d0-e3ed-4981-af97-30133d1b457e
 ports:
 - name: ""
   port: 8081
   protocol: TCP
 
+
 -- lbmaps-active.expected --
 BE: ID=1 ADDR=10.244.0.112:8081/TCP STATE=active
+BE: ID=2 ADDR=10.244.0.113:8081/TCP STATE=active
 REV: ID=1 ADDR=10.96.116.33:8081
-SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
--- lbmaps-terminating.expected --
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps-terminating1.expected --
+BE: ID=1 ADDR=10.244.0.112:8081/TCP STATE=terminating
+BE: ID=2 ADDR=10.244.0.113:8081/TCP STATE=active
+REV: ID=1 ADDR=10.96.116.33:8081
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=1 QCOUNT=1 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps-terminating2.expected --
 BE: ID=1 ADDR=10.244.0.112:8081/TCP STATE=terminating
 REV: ID=1 ADDR=10.96.116.33:8081
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=0 QCOUNT=1 FLAGS=ClusterIP+non-routable

--- a/pkg/loadbalancer/experimental/testdata/headless.txtar
+++ b/pkg/loadbalancer/experimental/testdata/headless.txtar
@@ -1,0 +1,163 @@
+#! --enable-experimental-lb
+
+# Start the test application
+hive start
+
+# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
+db/initialized
+
+# Add a headless service with backends. It should appear in the services table, but should have
+# no frontends.
+k8s/add service_clusterip_none.yaml endpointslice.yaml
+db/cmp services services.table
+db/cmp backends backends.table 
+db/cmp frontends frontends_empty.table
+
+# The BPF maps should be empty since there are no frontends.
+lb/maps-dump lbmaps.actual
+cmp lbmaps.empty lbmaps.actual
+
+# Cleanup the headless service. The endpoint slice is not deleted
+# so we still have backends referencing the removed service.
+k8s/delete service_clusterip_none.yaml
+db/cmp services services_empty.table
+db/cmp frontends frontends_empty.table
+db/cmp backends backends.table
+
+# Add a non-headless service
+k8s/add service.yaml
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table 
+
+# The BPF maps should now have the ClusterIP frontend
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
+
+# Toggle the headless label
+replace 'placeholder' 'service.kubernetes.io/headless' service.yaml
+k8s/update service.yaml
+
+# Frontends are now removed.
+db/cmp services services.table
+db/cmp backends backends.table 
+db/cmp frontends frontends_empty.table
+
+# The BPF maps should be empty since there are no frontends.
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.empty lbmaps.actual
+
+# Clean up everything.
+k8s/delete service.yaml endpointslice.yaml
+db/cmp services services_empty.table
+db/cmp frontends frontends_empty.table
+db/cmp backends backends_empty.table
+
+#####
+
+-- services.table --
+Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+test/echo   k8s                  Cluster            Cluster                              0                     false
+
+-- services_empty.table --
+Name  Source
+
+-- backends.table --
+Address             Instances          Shadows        NodeName
+10.244.1.1:80/TCP   test/echo (http)                  nodeport-worker
+
+-- backends_empty.table --
+Address
+
+-- frontends_empty.table --
+Address  Type
+
+-- frontends.table --
+Address        Type       Status  Backends 
+1.1.1.1:80/TCP ClusterIP  Done    10.244.1.1:80/TCP
+
+-- service_clusterip_none.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: echo
+  namespace: test
+  resourceVersion: "741"
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: "none"
+  selector:
+    name: echo
+  ports:
+  - name: http
+    protocol: TCP
+    port: 80
+    targetPort: 80
+  type: ClusterIP
+  
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: echo
+  namespace: test
+  resourceVersion: "741"
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+  labels:
+    placeholder: ""
+spec:
+  clusterIP: 1.1.1.1
+  clusterIPs:
+  - 1.1.1.1
+  selector:
+    name: echo
+  ports:
+  - name: http
+    protocol: TCP
+    port: 80
+    targetPort: 80
+  type: ClusterIP
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  annotations:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  generateName: echo-
+  generation: 3
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+  resourceVersion: "797"
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+  targetRef:
+    kind: Pod
+    name: echo-757d4cb97f-9gmf7
+    namespace: test
+    uid: 88542b9d-6369-4ec3-a5eb-fd53720013e8
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- lbmaps.empty --
+
+-- lbmaps.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+REV: ID=1 ADDR=1.1.1.1:80
+SVC: ID=1 ADDR=1.1.1.1:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=1.1.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable

--- a/pkg/loadbalancer/experimental/testdata/healthserver.txtar
+++ b/pkg/loadbalancer/experimental/testdata/healthserver.txtar
@@ -4,9 +4,6 @@
 hive start
 db/initialized
 
-# Expand the addresses and ports. To make this test deterministic it uses a loopback
-# address (127.x.x.x) that is based on the process ID in order to not have the ports
-# clash with other processes in the system.
 env HEALTHPORT1=40000
 env HEALTHPORT2=40001
 cp service.yaml service2.yaml
@@ -16,12 +13,9 @@ replace '$HEALTHPORT' $HEALTHPORT2 service2.yaml
 replace '$HEALTHPORT' 0 service_no_health.yaml
 replace '$HEALTHPORT1' $HEALTHPORT1 services.table
 replace '$HEALTHPORT1' $HEALTHPORT1 health_with_service.table
-replace '$HEALTHADDR' $HEALTHADDR frontends.table
 replace '$HEALTHPORT' $HEALTHPORT1 frontends.table
 replace '$HEALTHPORT' $HEALTHPORT1 backends.table
-replace '$HEALTHADDR' $HEALTHADDR backends.table
 replace '$HEALTHPORT' $HEALTHPORT1 lbmaps.expected
-replace '$HEALTHADDR' $HEALTHADDR lbmaps.expected
 
 # HealthServer's jobs should be reported in module health
 db/cmp --grep=^loadbalancer health health_no_service.table
@@ -29,7 +23,7 @@ db/cmp --grep=^loadbalancer health health_no_service.table
 # Add a node address, service and endpoints.
 db/insert node-addresses addrv4.yaml
 db/cmp node-addresses nodeaddrs.table
-k8s/add service.yaml endpointslice.yaml
+k8s/add service.yaml endpointslice1.yaml
 db/cmp --grep=^loadbalancer health health_with_service.table
 db/cmp services services.table
 db/cmp frontends frontends.table
@@ -54,7 +48,7 @@ db/cmp backends backends.table
 
 # Check that $HEALTHPORT2 now responds and old port does not.
 * http/get http://$HEALTHADDR:$HEALTHPORT2 healthserver.actual
-cmp healthserver.expected healthserver.actual
+* cmp healthserver.expected healthserver.actual
 !* http/get http://$HEALTHADDR:$HEALTHPORT1 healthserver.actual
 
 # Setting the traffic policy to Cluster makes the service
@@ -73,6 +67,15 @@ k8s/update service2.yaml
 * http/get http://$HEALTHADDR:$HEALTHPORT2 healthserver.actual
 cmp healthserver.expected healthserver.actual
 
+# Test without local backends
+k8s/update endpointslice2.yaml
+replace '$HEALTHPORT' $HEALTHPORT2 frontends_nobackends.table
+db/cmp frontends frontends_nobackends.table
+
+# Response should now be 503
+http/get http://$HEALTHADDR:$HEALTHPORT2 healthserver.actual
+* cmp healthserver-unhealthy.expected healthserver.actual
+
 # Test removing the health check port
 k8s/update service_no_health.yaml
 
@@ -82,7 +85,7 @@ k8s/update service_no_health.yaml
 !* http/get http://$HEALTHADDR:$HEALTHPORT1 healthserver.actual
 
 db/cmp frontends frontends_nohealthcheck.table
-db/cmp backends backends_nohealthcheck.table
+db/cmp backends backends_othernode.table
 
 #####
 
@@ -105,7 +108,7 @@ Module                                   Component                   Level   Mes
 loadbalancer-experimental.healthserver   job-control-loop            OK      1 health servers running
 loadbalancer-experimental.healthserver   job-listener-$HEALTHPORT1          OK      Running
 loadbalancer-experimental                job-node-addr-reconciler    OK      Running
-loadbalancer-experimental.reconciler     job-reconcile               OK      OK, 3 object(s)
+loadbalancer-experimental.reconciler     job-reconcile               OK      OK, 4 object(s)
 loadbalancer-experimental.reconciler     job-refresh                 OK      Next refresh in 30m0s
 loadbalancer-experimental.reflector      job-reflector               OK      Running
 
@@ -116,41 +119,49 @@ Address NodePort Primary DeviceName
 -- services.table --
 Name                   Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   HealthCheckNodePort
 test/echo              k8s                  Local              Local              $HEALTHPORT1
-test/echo-healthserver local                Local              Local              0
+test/echo:healthserver local                Local              Local              0
 
 -- frontends.table --
 Address               Type         ServiceName            PortName   Status  Backends
-10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active)
-172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active)
-172.16.1.1:$HEALTHPORT/TCP  LoadBalancer test/echo-healthserver            Done    $HEALTHADDR:$HEALTHPORT/TCP/i (active)
-
--- frontends_nohealthcheck.table --
-Address               Type         ServiceName            PortName   Status  Backends
-10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active)
-172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active)
+0.0.0.0:30781/TCP     NodePort     test/echo              http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+172.16.1.1:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    1.1.1.1:$HEALTHPORT/TCP/i
 
 -- frontends_tpcluster.table --
 Address               Type         ServiceName            PortName   Status  Backends
-10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
-172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
+0.0.0.0:30781/TCP     NodePort     test/echo              http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+
+-- frontends_nobackends.table --
+Address               Type         ServiceName            PortName   Status  Backends
+0.0.0.0:30781/TCP     NodePort     test/echo              http       Done    
+10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    
+172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    
+172.16.1.1:$HEALTHPORT/TCP  LoadBalancer test/echo:healthserver            Done    1.1.1.1:$HEALTHPORT/TCP/i
+
+-- frontends_nohealthcheck.table --
+Address               Type         ServiceName            PortName   Status  Backends
+0.0.0.0:30781/TCP     NodePort     test/echo              http       Done    
+10.96.50.104:80/TCP   ClusterIP    test/echo              http       Done    
+172.16.1.1:80/TCP     LoadBalancer test/echo              http       Done    
 
 -- frontends_empty.table --
 Address               Type        ServiceName   PortName   Status  Backends
 
 -- backends.table --
-State    Instances              Address
-active   test/echo (http)       10.244.1.1:80/TCP
-active   test/echo (http)       10.244.1.2:80/TCP
-active   test/echo (http)       10.244.1.3:80/TCP
-active   test/echo (http)       10.244.1.4:80/TCP
-active   test/echo-healthserver $HEALTHADDR:$HEALTHPORT/TCP/i
+Instances              Address
+test/echo:healthserver 1.1.1.1:$HEALTHPORT/TCP/i
+test/echo (http)       10.244.1.1:80/TCP
+test/echo (http)       10.244.1.2:80/TCP
+test/echo (http)       10.244.1.3:80/TCP
+test/echo (http)       10.244.1.4:80/TCP
 
--- backends_nohealthcheck.table --
-Address               State    Instances              NodeName     ZoneID
-10.244.1.1:80/TCP     active   test/echo (http)       testnode     0
-10.244.1.2:80/TCP     active   test/echo (http)       testnode     0
-10.244.1.3:80/TCP     active   test/echo (http)       othernode    0
-10.244.1.4:80/TCP     active   test/echo (http)       othernode    0
+-- backends_othernode.table --
+Address               Instances              NodeName
+10.244.1.3:80/TCP     test/echo (http)       othernode
+10.244.1.4:80/TCP     test/echo (http)       othernode
 
 -- backends_empty.table --
 Address             State    Instances            NodeName           ZoneID
@@ -189,7 +200,7 @@ status:
     ingress:
     - ip: 172.16.1.1
 
--- endpointslice.yaml --
+-- endpointslice1.yaml --
 apiVersion: discovery.k8s.io/v1
 kind: EndpointSlice
 metadata:
@@ -200,10 +211,10 @@ metadata:
   labels:
     endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
     kubernetes.io/service-name: echo
-  name: echo-kvlm2
+  name: echo-eps
   namespace: test
   resourceVersion: "797"
-  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+  uid: e1f517f6-ab88-4c76-9bd0-4906a17cdd75
 addressType: IPv4
 endpoints:
 - addresses:
@@ -223,27 +234,72 @@ ports:
   port: 80
   protocol: TCP
 
+-- endpointslice2.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  annotations:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  generateName: echo-
+  generation: 3
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: echo
+  name: echo-eps
+  namespace: test
+  resourceVersion: "797"
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.3
+  nodeName: othernode
+- addresses:
+  - 10.244.1.4
+  nodeName: othernode
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
 -- healthserver.expected --
 200 OK
 Content-Length=66
 Content-Type=application/json
 Date=<omitted>
 X-Content-Type-Options=nosniff
-X-Load-Balancing-Endpoint-Weight=4
+X-Load-Balancing-Endpoint-Weight=2
 ---
-{"service":{"namespace":"test","name":"echo"},"localEndpoints":4}
+{"service":{"namespace":"test","name":"echo"},"localEndpoints":2}
+-- healthserver-unhealthy.expected --
+503 Service Unavailable
+Content-Length=66
+Content-Type=application/json
+Date=<omitted>
+X-Content-Type-Options=nosniff
+X-Load-Balancing-Endpoint-Weight=0
+---
+{"service":{"namespace":"test","name":"echo"},"localEndpoints":0}
 -- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
 BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
-BE: ID=3 ADDR=$HEALTHADDR:$HEALTHPORT/TCP STATE=active
+BE: ID=3 ADDR=1.1.1.1:$HEALTHPORT/TCP STATE=active
 REV: ID=1 ADDR=10.96.50.104:80
-REV: ID=2 ADDR=172.16.1.1:80
-REV: ID=3 ADDR=172.16.1.1:$HEALTHPORT
+REV: ID=2 ADDR=0.0.0.0:30781
+REV: ID=3 ADDR=1.1.1.1:30781
+REV: ID=4 ADDR=172.16.1.1:80
+REV: ID=5 ADDR=172.16.1.1:$HEALTHPORT
 SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable
 SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable
 SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable
-SVC: ID=2 ADDR=172.16.1.1:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
-SVC: ID=2 ADDR=172.16.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
-SVC: ID=2 ADDR=172.16.1.1:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
-SVC: ID=3 ADDR=172.16.1.1:$HEALTHPORT/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
-SVC: ID=3 ADDR=172.16.1.1:$HEALTHPORT/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
+SVC: ID=2 ADDR=0.0.0.0:30781/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+Local+InternalLocal+non-routable
+SVC: ID=2 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+Local+InternalLocal+non-routable
+SVC: ID=2 ADDR=0.0.0.0:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+Local+InternalLocal+non-routable
+SVC: ID=3 ADDR=1.1.1.1:30781/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+Local+InternalLocal
+SVC: ID=3 ADDR=1.1.1.1:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+Local+InternalLocal
+SVC: ID=3 ADDR=1.1.1.1:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+Local+InternalLocal
+SVC: ID=4 ADDR=172.16.1.1:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
+SVC: ID=4 ADDR=172.16.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
+SVC: ID=4 ADDR=172.16.1.1:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
+SVC: ID=5 ADDR=172.16.1.1:$HEALTHPORT/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
+SVC: ID=5 ADDR=172.16.1.1:$HEALTHPORT/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal

--- a/pkg/loadbalancer/experimental/testdata/hostport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/hostport.txtar
@@ -1,26 +1,67 @@
-#! --enable-experimental-lb
+#! --enable-experimental-lb --lb-test-fault-probability=0.0
+# Fault injection is currently disabled as it in some cases leads to
+# the backend being recreated when switching to host port 5555 due
+# to injected faults causing the deletion of the host port 4444 to be
+# processed after a failed upsert of port 5555 frontend, which in turn
+# leads to the backend being considered orphan as the BPFOps backend state
+# will not have processed to the new use for the backend. Not entirely clear
+# how we could avoid this situation (or if we even should try).
 
+# Add a node address that we'll use as the host port frontend.
 db/insert node-addresses addrv4.yaml
 db/cmp node-addresses nodeaddrs.table
 
 # Start the test application
 hive start
-
-# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
 db/initialized
 
-k8s/add pod.yaml
-
+# Add a pod with 'hostPort'. A synthetic service, frontend and backend will
+# be created for it.
+k8s/add pod.yaml 
 db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table 
 
-# Check BPF maps
+# Validate that BPF maps contain the new frontend and backend.
 lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
 
-# Cleanup
+# "terminate" the pod
+replace 'phase: Running' 'phase: Succeeded' pod.yaml
+k8s/update pod.yaml
+db/cmp services services2.table
+
+# Add a new pod to take over the HostPort
+k8s/add other-pod.yaml
+db/cmp frontends frontends3.table
+db/cmp services services3.table
+
+# Check that BPF maps now contain the new pod for the same host port.
+lb/maps-dump lbmaps.actual
+* cmp lbmaps2.expected lbmaps.actual
+
+# Removing the terminated pod will now have no effect on services.
 k8s/delete pod.yaml
+
+# Check that tables and the BPF maps are the same.
+db/cmp frontends frontends3.table
+db/cmp services services3.table
+lb/maps-dump lbmaps.actual
+* cmp lbmaps2.expected lbmaps.actual
+
+# Test changing the host port
+db/show backends
+replace 4444 5555 other-pod.yaml
+k8s/update other-pod.yaml
+db/cmp frontends frontends4.table
+db/cmp backends backends4.table
+
+# Check that BPF maps now have the port 5555
+lb/maps-dump lbmaps.actual
+* cmp lbmaps3.expected lbmaps.actual
+
+# Cleanup
+k8s/delete other-pod.yaml
 db/cmp services services_empty.table
 db/cmp frontends frontends_empty.table
 db/cmp backends backends_empty.table
@@ -38,16 +79,35 @@ Address NodePort Primary DeviceName
 1.1.1.1 true     true    test
 
 -- services.table --
-Name                                           Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
-default/my-app-85f46c4bd9-nnk25/host-port/4444 k8s                  Cluster            Cluster                              0                     false
+Name                                                                  Source
+default/my-app:host-port:4444:11111111-2e9b-4c61-8454-ae81344876d8    k8s
+
+-- services2.table --
+Name                                                                  Source
+
+-- services3.table --
+Name                                                                  Source
+default/other-app:host-port:4444:22222222-2e9b-4c61-8454-ae81344876d8 k8s
 
 -- frontends.table --
-Address           Type        ServiceName                                     PortName   Backends                      Status
-0.0.0.0:4444/TCP  HostPort    default/my-app-85f46c4bd9-nnk25/host-port/4444             10.244.1.113:80/TCP (active)  Done
+Address           Type      Status  ServiceName                                                         Backends
+0.0.0.0:4444/TCP  HostPort  Done    default/my-app:host-port:4444:11111111-2e9b-4c61-8454-ae81344876d8  10.244.1.113:80/TCP
+
+-- frontends3.table --
+Address           Type      Status  ServiceName                                                           Backends
+0.0.0.0:4444/TCP  HostPort  Done    default/other-app:host-port:4444:22222222-2e9b-4c61-8454-ae81344876d8 10.244.1.114:80/TCP
+
+-- frontends4.table --
+Address           Type      Status  ServiceName                                                           Backends
+0.0.0.0:5555/TCP  HostPort  Done    default/other-app:host-port:5555:22222222-2e9b-4c61-8454-ae81344876d8 10.244.1.114:80/TCP
 
 -- backends.table --
-Address                        State    Instances                                       NodeName             ZoneID
-10.244.1.113:80/TCP            active   default/my-app-85f46c4bd9-nnk25/host-port/4444                       0
+Address             Instances 
+10.244.1.113:80/TCP default/my-app:host-port:4444:11111111-2e9b-4c61-8454-ae81344876d8
+
+-- backends4.table --
+Address             Instances 
+10.244.1.114:80/TCP default/other-app:host-port:5555:22222222-2e9b-4c61-8454-ae81344876d8
 
 -- services_empty.table --
 Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
@@ -56,21 +116,19 @@ Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionA
 Address               Type        ServiceName   PortName   Status  Backends
 
 -- backends_empty.table --
-Address             State    Instances            NodeName           ZoneID
+Address
 
 -- pod.yaml --
 apiVersion: v1
 kind: Pod
 metadata:
   creationTimestamp: "2024-07-10T16:20:42Z"
-  generateName: my-app-85f46c4bd9-
   labels:
-    pod-template-hash: 85f46c4bd9
     run: my-app
-  name: my-app-85f46c4bd9-nnk25
+  name: my-app
   namespace: default
   resourceVersion: "100491"
-  uid: 1e75ff92-2e9b-4c61-8454-ae81344876d8
+  uid: 11111111-2e9b-4c61-8454-ae81344876d8
 spec:
   containers:
   - image: nginx
@@ -105,6 +163,44 @@ status:
   qosClass: BestEffort
   startTime: "2024-07-10T16:20:42Z"
 
+-- other-pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2024-07-10T16:20:42Z"
+  name: other-app
+  namespace: default
+  resourceVersion: "100491"
+  uid: 22222222-2e9b-4c61-8454-ae81344876d8
+spec:
+  containers:
+  - image: nginx
+    imagePullPolicy: Always
+    name: other-app
+    ports:
+    - containerPort: 80
+      hostPort: 4444
+      protocol: TCP
+    resources: {}
+  nodeName: kind-worker
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+status:
+  hostIP: 172.19.0.4
+  hostIPs:
+  - ip: 172.19.0.4
+  phase: Running
+  podIP: 10.244.1.114
+  podIPs:
+  - ip: 10.244.1.114
+  qosClass: BestEffort
+  startTime: "2024-07-10T16:20:42Z"
+
+
 -- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.113:80/TCP STATE=active
 REV: ID=1 ADDR=0.0.0.0:4444
@@ -113,3 +209,19 @@ SVC: ID=1 ADDR=0.0.0.0:4444/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=1 QCOUNT=
 SVC: ID=1 ADDR=0.0.0.0:4444/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=HostPort+non-routable
 SVC: ID=2 ADDR=1.1.1.1:4444/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort
 SVC: ID=2 ADDR=1.1.1.1:4444/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=HostPort
+-- lbmaps2.expected --
+BE: ID=2 ADDR=10.244.1.114:80/TCP STATE=active
+REV: ID=3 ADDR=0.0.0.0:4444
+REV: ID=4 ADDR=1.1.1.1:4444
+SVC: ID=3 ADDR=0.0.0.0:4444/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:4444/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=4 ADDR=1.1.1.1:4444/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort
+SVC: ID=4 ADDR=1.1.1.1:4444/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=HostPort
+-- lbmaps3.expected --
+BE: ID=2 ADDR=10.244.1.114:80/TCP STATE=active
+REV: ID=5 ADDR=0.0.0.0:5555
+REV: ID=6 ADDR=1.1.1.1:5555
+SVC: ID=5 ADDR=0.0.0.0:5555/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=5 ADDR=0.0.0.0:5555/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=6 ADDR=1.1.1.1:5555/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort
+SVC: ID=6 ADDR=1.1.1.1:5555/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=HostPort

--- a/pkg/loadbalancer/experimental/testdata/loadbalancer.txtar
+++ b/pkg/loadbalancer/experimental/testdata/loadbalancer.txtar
@@ -1,0 +1,165 @@
+#! --enable-experimental-lb --lb-test-fault-probability=0.0
+
+# Add some node addresses
+db/insert node-addresses addrv4.yaml
+db/cmp node-addresses nodeaddrs.table
+
+# Add the first service before starting (List() path)
+k8s/add service.yaml endpointslice.yaml
+
+# Start the test application
+hive start
+
+# Wait for tables to initialize (e.g. reflector to start) before adding more objects.
+# (otherwise might miss events due to List() vs Watch() race in fake client).
+# NOTE: The 100ms delay you might see is from WaitForCacheSync polling at 100ms.
+db/initialized
+
+# First frontends should exist and be reconciled. Need to wait for reconciliation to
+# have the ID assigned.
+db/cmp frontends frontends1.table
+
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table 
+
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
+
+# Cleanup. Backends first in this test.
+k8s/delete endpointslice.yaml
+db/cmp backends backends_empty.table
+db/cmp frontends frontends_nobackends.table
+
+k8s/delete service.yaml
+db/cmp frontends frontends_empty.table
+db/cmp services services_empty.table
+
+#####
+
+-- addrv4.yaml --
+addr: 1.1.1.1
+nodeport: true
+primary: true
+devicename: test
+
+-- nodeaddrs.table --
+Address NodePort Primary DeviceName
+1.1.1.1 true     true    test
+
+-- services.table --
+Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
+test/echo    k8s                  Cluster            Cluster                              0                     false              
+
+-- services_empty.table --
+Name         Source
+
+-- frontends1.table --
+Address               Type         ServiceName   PortName   Status  Backends
+0.0.0.0:30781/TCP     NodePort     test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+10.96.50.104:80/TCP   ClusterIP    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+172.16.1.1:80/TCP     LoadBalancer test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+
+-- frontends.table --
+Address               Type         ServiceName   PortName   Status  Backends
+0.0.0.0:30781/TCP     NodePort     test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+10.96.50.104:80/TCP   ClusterIP    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+172.16.1.1:80/TCP     LoadBalancer test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+
+-- frontends_nobackends.table --
+Address               Type         ServiceName   PortName   Status  Backends
+0.0.0.0:30781/TCP     NodePort     test/echo     http       Done        
+10.96.50.104:80/TCP   ClusterIP    test/echo     http       Done        
+172.16.1.1:80/TCP     LoadBalancer test/echo     http       Done
+
+-- frontends_empty.table --
+Address               Type        ServiceName   PortName   Status  Backends
+
+-- backends.table --
+Address             Instances            NodeName
+10.244.1.1:80/TCP   test/echo (http)     nodeport-worker
+10.244.1.2:80/TCP   test/echo (http)     nodeport-worker2
+
+-- backends_empty.table --
+Address
+
+-- lbmaps.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
+REV: ID=1 ADDR=10.96.50.104:80
+REV: ID=2 ADDR=0.0.0.0:30781
+REV: ID=3 ADDR=1.1.1.1:30781
+REV: ID=4 ADDR=172.16.1.1:80
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=0.0.0.0:30781/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=2 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=2 ADDR=0.0.0.0:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=1.1.1.1:30781/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=1.1.1.1:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=1.1.1.1:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=172.16.1.1:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=4 ADDR=172.16.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=4 ADDR=172.16.1.1:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: echo
+  namespace: test
+  resourceVersion: "741"
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 172.16.1.1
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  annotations:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  generateName: echo-
+  generation: 3
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+  resourceVersion: "797"
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  nodeName: nodeport-worker
+- addresses:
+  - 10.244.1.2
+  nodeName: nodeport-worker2
+ports:
+- name: http
+  port: 80
+  protocol: TCP

--- a/pkg/loadbalancer/experimental/testdata/multiport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/multiport.txtar
@@ -29,14 +29,14 @@ test/echo   k8s                  Cluster            Cluster                     
 
 -- frontends.table --
 
-Address                Type        ServiceName   PortName   Backends                      Status
-10.96.50.104:80/TCP    ClusterIP   test/echo     http       10.244.1.1:80/TCP (active)    Done
-10.96.50.104:443/TCP   ClusterIP   test/echo     https      10.244.1.1:443/TCP (active)   Done
+Address                Type        ServiceName   PortName   Backends             Status
+10.96.50.104:80/TCP    ClusterIP   test/echo     http       10.244.1.1:80/TCP    Done
+10.96.50.104:443/TCP   ClusterIP   test/echo     https      10.244.1.1:443/TCP   Done
 
 -- backends.table --
-Address              State    Instances           NodeName          ZoneID
-10.244.1.1:80/TCP    active   test/echo (http)    nodeport-worker   0
-10.244.1.1:443/TCP   active   test/echo (https)   nodeport-worker   0
+Address              Instances           NodeName
+10.244.1.1:80/TCP    test/echo (http)    nodeport-worker
+10.244.1.1:443/TCP   test/echo (https)   nodeport-worker
 
 -- services_empty.table --
 Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
@@ -45,7 +45,7 @@ Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionA
 Address               Type        ServiceName   PortName   Status  Backends
 
 -- backends_empty.table --
-Address             State    Instances            NodeName           ZoneID
+Address
 
 -- service.yaml --
 apiVersion: v1

--- a/pkg/loadbalancer/experimental/testdata/nodeport-addr.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport-addr.txtar
@@ -93,15 +93,15 @@ Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionA
 
 -- frontends1.table --
 Address               Type        ServiceName   PortName   Status  Backends
-0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
-10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
+0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
 
 -- frontends.table --
 Address               Type        ServiceName   PortName   Status  Backends
-0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
-0.0.0.0:30782/TCP     NodePort    test/echo2    http2      Done    10.244.2.1:80/TCP (active), 10.244.2.2:80/TCP (active), 10.244.2.3:80/TCP (active), 10.244.2.4:80/TCP (active)
-10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
-10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done    10.244.2.1:80/TCP (active), 10.244.2.2:80/TCP (active), 10.244.2.3:80/TCP (active), 10.244.2.4:80/TCP (active)
+0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+0.0.0.0:30782/TCP     NodePort    test/echo2    http2      Done    10.244.2.1:80/TCP, 10.244.2.2:80/TCP, 10.244.2.3:80/TCP, 10.244.2.4:80/TCP
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done    10.244.2.1:80/TCP, 10.244.2.2:80/TCP, 10.244.2.3:80/TCP, 10.244.2.4:80/TCP
 
 -- frontends_nobackends.table --
 Address               Type        ServiceName   PortName   Status  Backends
@@ -114,18 +114,18 @@ Address               Type        ServiceName   PortName   Status  Backends
 Address               Type        ServiceName   PortName   Status  Backends
 
 -- backends.table --
-Address             State    Instances            NodeName           ZoneID
-10.244.1.1:80/TCP   active   test/echo (http)     nodeport-worker    0
-10.244.1.2:80/TCP   active   test/echo (http)     nodeport-worker    0
-10.244.1.3:80/TCP   active   test/echo (http)     nodeport-worker2   0
-10.244.1.4:80/TCP   active   test/echo (http)     nodeport-worker2   0
-10.244.2.1:80/TCP   active   test/echo2 (http2)   nodeport-worker    0
-10.244.2.2:80/TCP   active   test/echo2 (http2)   nodeport-worker    0
-10.244.2.3:80/TCP   active   test/echo2 (http2)   nodeport-worker2   0
-10.244.2.4:80/TCP   active   test/echo2 (http2)   nodeport-worker2   0
+Address             Instances            NodeName        
+10.244.1.1:80/TCP   test/echo (http)     nodeport-worker 
+10.244.1.2:80/TCP   test/echo (http)     nodeport-worker 
+10.244.1.3:80/TCP   test/echo (http)     nodeport-worker2
+10.244.1.4:80/TCP   test/echo (http)     nodeport-worker2
+10.244.2.1:80/TCP   test/echo2 (http2)   nodeport-worker 
+10.244.2.2:80/TCP   test/echo2 (http2)   nodeport-worker 
+10.244.2.3:80/TCP   test/echo2 (http2)   nodeport-worker2
+10.244.2.4:80/TCP   test/echo2 (http2)   nodeport-worker2
 
 -- backends_empty.table --
-Address             State    Instances            NodeName           ZoneID
+Address
 
 -- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active

--- a/pkg/loadbalancer/experimental/testdata/nodeport-explicit-maglev.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport-explicit-maglev.txtar
@@ -57,7 +57,7 @@ Address NodePort Primary DeviceName
 
 -- services.table --
 Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges   ExplicitLBAlgorithm
-test/echo    k8s                  Cluster            Cluster                              0                     false
+test/echo    k8s                  Cluster            Cluster                              0                     false                             undef
 test/echo2   k8s                  Cluster            Cluster                              0                     false                             maglev
 
 -- services_empty.table --
@@ -66,15 +66,15 @@ Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionA
 
 -- frontends1.table --
 Address               Type        ServiceName   PortName   Status  Backends
-0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
-10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
+0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
 
 -- frontends.table --
 Address               Type        ServiceName   PortName   Status  Backends
-0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
-0.0.0.0:30782/TCP     NodePort    test/echo2    http2      Done    10.244.2.1:80/TCP (active), 10.244.2.2:80/TCP (active), 10.244.2.3:80/TCP (active), 10.244.2.4:80/TCP (active)
-10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
-10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done    10.244.2.1:80/TCP (active), 10.244.2.2:80/TCP (active), 10.244.2.3:80/TCP (active), 10.244.2.4:80/TCP (active)
+0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+0.0.0.0:30782/TCP     NodePort    test/echo2    http2      Done    10.244.2.1:80/TCP, 10.244.2.2:80/TCP, 10.244.2.3:80/TCP, 10.244.2.4:80/TCP
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done    10.244.2.1:80/TCP, 10.244.2.2:80/TCP, 10.244.2.3:80/TCP, 10.244.2.4:80/TCP
 
 -- frontends_nobackends.table --
 Address               Type        ServiceName   PortName   Status  Backends
@@ -87,18 +87,18 @@ Address               Type        ServiceName   PortName   Status  Backends
 Address               Type        ServiceName   PortName   Status  Backends
 
 -- backends.table --
-Address             State    Instances            NodeName           ZoneID
-10.244.1.1:80/TCP   active   test/echo (http)     nodeport-worker    0
-10.244.1.2:80/TCP   active   test/echo (http)     nodeport-worker    0
-10.244.1.3:80/TCP   active   test/echo (http)     nodeport-worker2   0
-10.244.1.4:80/TCP   active   test/echo (http)     nodeport-worker2   0
-10.244.2.1:80/TCP   active   test/echo2 (http2)   nodeport-worker    0
-10.244.2.2:80/TCP   active   test/echo2 (http2)   nodeport-worker    0
-10.244.2.3:80/TCP   active   test/echo2 (http2)   nodeport-worker2   0
-10.244.2.4:80/TCP   active   test/echo2 (http2)   nodeport-worker2   0
+Address             Instances            NodeName
+10.244.1.1:80/TCP   test/echo (http)     nodeport-worker 
+10.244.1.2:80/TCP   test/echo (http)     nodeport-worker 
+10.244.1.3:80/TCP   test/echo (http)     nodeport-worker2
+10.244.1.4:80/TCP   test/echo (http)     nodeport-worker2
+10.244.2.1:80/TCP   test/echo2 (http2)   nodeport-worker 
+10.244.2.2:80/TCP   test/echo2 (http2)   nodeport-worker 
+10.244.2.3:80/TCP   test/echo2 (http2)   nodeport-worker2
+10.244.2.4:80/TCP   test/echo2 (http2)   nodeport-worker2
 
 -- backends_empty.table --
-Address             State    Instances            NodeName           ZoneID
+Address
 
 -- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active

--- a/pkg/loadbalancer/experimental/testdata/nodeport-explicit-random.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport-explicit-random.txtar
@@ -57,7 +57,7 @@ Address NodePort Primary DeviceName
 
 -- services.table --
 Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges   ExplicitLBAlgorithm
-test/echo    k8s                  Cluster            Cluster                              0                     false
+test/echo    k8s                  Cluster            Cluster                              0                     false                             undef
 test/echo2   k8s                  Cluster            Cluster                              0                     false                             random
 
 -- services_empty.table --
@@ -66,15 +66,15 @@ Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionA
 
 -- frontends1.table --
 Address               Type        ServiceName   PortName   Status  Backends
-0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
-10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
+0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
 
 -- frontends.table --
 Address               Type        ServiceName   PortName   Status  Backends
-0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
-0.0.0.0:30782/TCP     NodePort    test/echo2    http2      Done    10.244.2.1:80/TCP (active), 10.244.2.2:80/TCP (active), 10.244.2.3:80/TCP (active), 10.244.2.4:80/TCP (active)
-10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
-10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done    10.244.2.1:80/TCP (active), 10.244.2.2:80/TCP (active), 10.244.2.3:80/TCP (active), 10.244.2.4:80/TCP (active)
+0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+0.0.0.0:30782/TCP     NodePort    test/echo2    http2      Done    10.244.2.1:80/TCP, 10.244.2.2:80/TCP, 10.244.2.3:80/TCP, 10.244.2.4:80/TCP
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done    10.244.2.1:80/TCP, 10.244.2.2:80/TCP, 10.244.2.3:80/TCP, 10.244.2.4:80/TCP
 
 -- frontends_nobackends.table --
 Address               Type        ServiceName   PortName   Status  Backends
@@ -87,18 +87,18 @@ Address               Type        ServiceName   PortName   Status  Backends
 Address               Type        ServiceName   PortName   Status  Backends
 
 -- backends.table --
-Address             State    Instances            NodeName           ZoneID
-10.244.1.1:80/TCP   active   test/echo (http)     nodeport-worker    0
-10.244.1.2:80/TCP   active   test/echo (http)     nodeport-worker    0
-10.244.1.3:80/TCP   active   test/echo (http)     nodeport-worker2   0
-10.244.1.4:80/TCP   active   test/echo (http)     nodeport-worker2   0
-10.244.2.1:80/TCP   active   test/echo2 (http2)   nodeport-worker    0
-10.244.2.2:80/TCP   active   test/echo2 (http2)   nodeport-worker    0
-10.244.2.3:80/TCP   active   test/echo2 (http2)   nodeport-worker2   0
-10.244.2.4:80/TCP   active   test/echo2 (http2)   nodeport-worker2   0
+Address             Instances            NodeName
+10.244.1.1:80/TCP   test/echo (http)     nodeport-worker
+10.244.1.2:80/TCP   test/echo (http)     nodeport-worker
+10.244.1.3:80/TCP   test/echo (http)     nodeport-worker2
+10.244.1.4:80/TCP   test/echo (http)     nodeport-worker2
+10.244.2.1:80/TCP   test/echo2 (http2)   nodeport-worker
+10.244.2.2:80/TCP   test/echo2 (http2)   nodeport-worker
+10.244.2.3:80/TCP   test/echo2 (http2)   nodeport-worker2
+10.244.2.4:80/TCP   test/echo2 (http2)   nodeport-worker2
 
 -- backends_empty.table --
-Address             State    Instances            NodeName           ZoneID
+Address
 
 -- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active

--- a/pkg/loadbalancer/experimental/testdata/nodeport-maglev.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport-maglev.txtar
@@ -65,15 +65,15 @@ Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionA
 
 -- frontends1.table --
 Address               Type        ServiceName   PortName   Status  Backends
-0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
-10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
+0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
 
 -- frontends.table --
 Address               Type        ServiceName   PortName   Status  Backends
-0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
-0.0.0.0:30782/TCP     NodePort    test/echo2    http2      Done    10.244.2.1:80/TCP (active), 10.244.2.2:80/TCP (active), 10.244.2.3:80/TCP (active), 10.244.2.4:80/TCP (active)
-10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
-10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done    10.244.2.1:80/TCP (active), 10.244.2.2:80/TCP (active), 10.244.2.3:80/TCP (active), 10.244.2.4:80/TCP (active)
+0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+0.0.0.0:30782/TCP     NodePort    test/echo2    http2      Done    10.244.2.1:80/TCP, 10.244.2.2:80/TCP, 10.244.2.3:80/TCP, 10.244.2.4:80/TCP
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done    10.244.2.1:80/TCP, 10.244.2.2:80/TCP, 10.244.2.3:80/TCP, 10.244.2.4:80/TCP
 
 -- frontends_nobackends.table --
 Address               Type        ServiceName   PortName   Status  Backends
@@ -86,18 +86,18 @@ Address               Type        ServiceName   PortName   Status  Backends
 Address               Type        ServiceName   PortName   Status  Backends
 
 -- backends.table --
-Address             State    Instances            NodeName           ZoneID
-10.244.1.1:80/TCP   active   test/echo (http)     nodeport-worker    0
-10.244.1.2:80/TCP   active   test/echo (http)     nodeport-worker    0
-10.244.1.3:80/TCP   active   test/echo (http)     nodeport-worker2   0
-10.244.1.4:80/TCP   active   test/echo (http)     nodeport-worker2   0
-10.244.2.1:80/TCP   active   test/echo2 (http2)   nodeport-worker    0
-10.244.2.2:80/TCP   active   test/echo2 (http2)   nodeport-worker    0
-10.244.2.3:80/TCP   active   test/echo2 (http2)   nodeport-worker2   0
-10.244.2.4:80/TCP   active   test/echo2 (http2)   nodeport-worker2   0
+Address             Instances            NodeName         
+10.244.1.1:80/TCP   test/echo (http)     nodeport-worker  
+10.244.1.2:80/TCP   test/echo (http)     nodeport-worker  
+10.244.1.3:80/TCP   test/echo (http)     nodeport-worker2 
+10.244.1.4:80/TCP   test/echo (http)     nodeport-worker2 
+10.244.2.1:80/TCP   test/echo2 (http2)   nodeport-worker  
+10.244.2.2:80/TCP   test/echo2 (http2)   nodeport-worker  
+10.244.2.3:80/TCP   test/echo2 (http2)   nodeport-worker2 
+10.244.2.4:80/TCP   test/echo2 (http2)   nodeport-worker2 
 
 -- backends_empty.table --
-Address             State    Instances            NodeName           ZoneID
+Address
 
 -- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active

--- a/pkg/loadbalancer/experimental/testdata/nodeport.txtar
+++ b/pkg/loadbalancer/experimental/testdata/nodeport.txtar
@@ -30,13 +30,31 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
 
 # Cleanup. Backends first in this test.
-k8s/delete endpointslice.yaml endpointslice2.yaml
-db/cmp backends backends_empty.table
-db/cmp frontends frontends_nobackends.table
+k8s/delete endpointslice2.yaml
+db/cmp backends backends_only1.table
+db/cmp frontends frontends_only1.table
 
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps-only1.expected lbmaps.actual
+
+# Delete the remaining endpointslice
+k8s/delete endpointslice.yaml
+db/cmp frontends frontends_nobackends.table
+db/cmp backends backends_empty.table
+
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps-nobackends.expected lbmaps.actual
+
+# Finally delete the services
 k8s/delete service.yaml service2.yaml
 db/cmp frontends frontends_empty.table
 db/cmp services services_empty.table
+
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps-empty.expected lbmaps.actual
 
 #####
 
@@ -61,15 +79,22 @@ Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionA
 
 -- frontends1.table --
 Address               Type        ServiceName   PortName   Status  Backends
-0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
-10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
+0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
 
 -- frontends.table --
 Address               Type        ServiceName   PortName   Status  Backends
-0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
-0.0.0.0:30782/TCP     NodePort    test/echo2    http2      Done    10.244.2.1:80/TCP (active), 10.244.2.2:80/TCP (active), 10.244.2.3:80/TCP (active), 10.244.2.4:80/TCP (active)
-10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP (active), 10.244.1.2:80/TCP (active), 10.244.1.3:80/TCP (active), 10.244.1.4:80/TCP (active)
-10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done    10.244.2.1:80/TCP (active), 10.244.2.2:80/TCP (active), 10.244.2.3:80/TCP (active), 10.244.2.4:80/TCP (active)
+0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+0.0.0.0:30782/TCP     NodePort    test/echo2    http2      Done    10.244.2.1:80/TCP, 10.244.2.2:80/TCP, 10.244.2.3:80/TCP, 10.244.2.4:80/TCP
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done    10.244.2.1:80/TCP, 10.244.2.2:80/TCP, 10.244.2.3:80/TCP, 10.244.2.4:80/TCP
+
+-- frontends_only1.table --
+Address               Type        ServiceName   PortName   Status  Backends
+0.0.0.0:30781/TCP     NodePort    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+0.0.0.0:30782/TCP     NodePort    test/echo2    http2      Done
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP, 10.244.1.3:80/TCP, 10.244.1.4:80/TCP
+10.96.50.105:80/TCP   ClusterIP   test/echo2    http2      Done
 
 -- frontends_nobackends.table --
 Address               Type        ServiceName   PortName   Status  Backends
@@ -82,18 +107,29 @@ Address               Type        ServiceName   PortName   Status  Backends
 Address               Type        ServiceName   PortName   Status  Backends
 
 -- backends.table --
-Address             State    Instances            NodeName           ZoneID
-10.244.1.1:80/TCP   active   test/echo (http)     nodeport-worker    0
-10.244.1.2:80/TCP   active   test/echo (http)     nodeport-worker    0
-10.244.1.3:80/TCP   active   test/echo (http)     nodeport-worker2   0
-10.244.1.4:80/TCP   active   test/echo (http)     nodeport-worker2   0
-10.244.2.1:80/TCP   active   test/echo2 (http2)   nodeport-worker    0
-10.244.2.2:80/TCP   active   test/echo2 (http2)   nodeport-worker    0
-10.244.2.3:80/TCP   active   test/echo2 (http2)   nodeport-worker2   0
-10.244.2.4:80/TCP   active   test/echo2 (http2)   nodeport-worker2   0
+Address             Instances            NodeName
+10.244.1.1:80/TCP   test/echo (http)     nodeport-worker
+10.244.1.2:80/TCP   test/echo (http)     nodeport-worker
+10.244.1.3:80/TCP   test/echo (http)     nodeport-worker2
+10.244.1.4:80/TCP   test/echo (http)     nodeport-worker2
+10.244.2.1:80/TCP   test/echo2 (http2)   nodeport-worker
+10.244.2.2:80/TCP   test/echo2 (http2)   nodeport-worker
+10.244.2.3:80/TCP   test/echo2 (http2)   nodeport-worker2
+10.244.2.4:80/TCP   test/echo2 (http2)   nodeport-worker2
+
+-- backends_only1.table --
+Address             Instances            NodeName           
+10.244.1.1:80/TCP   test/echo (http)     nodeport-worker    
+10.244.1.2:80/TCP   test/echo (http)     nodeport-worker    
+10.244.1.3:80/TCP   test/echo (http)     nodeport-worker2   
+10.244.1.4:80/TCP   test/echo (http)     nodeport-worker2   
+10.244.2.1:80/TCP   test/echo2 (http2)   nodeport-worker    
+10.244.2.2:80/TCP   test/echo2 (http2)   nodeport-worker    
+10.244.2.3:80/TCP   test/echo2 (http2)   nodeport-worker2   
+10.244.2.4:80/TCP   test/echo2 (http2)   nodeport-worker2   
 
 -- backends_empty.table --
-Address             State    Instances            NodeName           ZoneID
+Address
 
 -- lbmaps.expected --
 BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
@@ -140,6 +176,50 @@ SVC: ID=6 ADDR=1.1.1.1:30782/TCP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=NodePort
 SVC: ID=6 ADDR=1.1.1.1:30782/TCP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=NodePort
 SVC: ID=6 ADDR=1.1.1.1:30782/TCP SLOT=3 BEID=7 COUNT=0 QCOUNT=0 FLAGS=NodePort
 SVC: ID=6 ADDR=1.1.1.1:30782/TCP SLOT=4 BEID=8 COUNT=0 QCOUNT=0 FLAGS=NodePort
+-- lbmaps-only1.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
+BE: ID=3 ADDR=10.244.1.3:80/TCP STATE=active
+BE: ID=4 ADDR=10.244.1.4:80/TCP STATE=active
+REV: ID=1 ADDR=10.96.50.104:80
+REV: ID=2 ADDR=0.0.0.0:30781
+REV: ID=3 ADDR=1.1.1.1:30781
+REV: ID=4 ADDR=10.96.50.105:80
+REV: ID=5 ADDR=0.0.0.0:30782
+REV: ID=6 ADDR=1.1.1.1:30782
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=4 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=3 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=4 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=0.0.0.0:30781/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=4 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=2 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=2 ADDR=0.0.0.0:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=2 ADDR=0.0.0.0:30781/TCP SLOT=3 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=2 ADDR=0.0.0.0:30781/TCP SLOT=4 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=1.1.1.1:30781/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=4 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=1.1.1.1:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=1.1.1.1:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=1.1.1.1:30781/TCP SLOT=3 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=1.1.1.1:30781/TCP SLOT=4 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=10.96.50.105:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=0.0.0.0:30782/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=6 ADDR=1.1.1.1:30782/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=NodePort
+-- lbmaps-nobackends.expected --
+REV: ID=1 ADDR=10.96.50.104:80
+REV: ID=2 ADDR=0.0.0.0:30781
+REV: ID=3 ADDR=1.1.1.1:30781
+REV: ID=4 ADDR=10.96.50.105:80
+REV: ID=5 ADDR=0.0.0.0:30782
+REV: ID=6 ADDR=1.1.1.1:30782
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=0.0.0.0:30781/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=1.1.1.1:30781/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=10.96.50.105:80/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=0.0.0.0:30782/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=6 ADDR=1.1.1.1:30782/TCP SLOT=0 LBALG=random AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=NodePort
+-- lbmaps-empty.expected --
+
 -- service.yaml --
 apiVersion: v1
 kind: Service

--- a/pkg/loadbalancer/experimental/testdata/pruning.txtar
+++ b/pkg/loadbalancer/experimental/testdata/pruning.txtar
@@ -53,12 +53,12 @@ Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAf
 test/echo   k8s                  Cluster            Cluster                              0                     false              
 
 -- frontends.table --
-Address               Type        ServiceName   PortName   Backends                     Status
-10.96.50.104:80/TCP   ClusterIP   test/echo     http       10.244.1.1:80/TCP (active)   Done
+Address               Type        ServiceName   PortName   Backends            Status
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       10.244.1.1:80/TCP   Done
 
 -- backends.table --
-Address             State    Instances          NodeName          ZoneID
-10.244.1.1:80/TCP   active   test/echo (http)   nodeport-worker   0
+Address             Instances
+10.244.1.1:80/TCP   test/echo (http)
 
 -- services_empty.table --
 Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
@@ -67,7 +67,7 @@ Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionA
 Address               Type        ServiceName   PortName   Status  Backends
 
 -- backends_empty.table --
-Address             State    Instances            NodeName           ZoneID
+Address
 
 -- service.yaml --
 apiVersion: v1

--- a/pkg/loadbalancer/experimental/testdata/queries.txtar
+++ b/pkg/loadbalancer/experimental/testdata/queries.txtar
@@ -1,0 +1,190 @@
+#! --enable-experimental-lb 
+#
+# This tests different queries that can be made against the load-balancing tables.
+#
+
+# Start and wait for sync against the k8s fake client.
+hive start
+db/initialized
+
+# Show the registered tables and indexes
+db
+
+# Insert some data:
+#   foo/echo: 1.1.1.1:80/TCP => 10.244.1.[1-4]
+#   bar/echo: 2.2.2.2:80/TCP => 10.244.2.[1-4]
+cp service.yaml service2.yaml
+replace 'foo' 'bar' service2.yaml
+replace '1.1.1.1' '2.2.2.2' service2.yaml
+cp endpointslice.yaml endpointslice2.yaml
+replace 'foo' 'bar' endpointslice2.yaml
+replace '10.244.1' '10.244.2' endpointslice2.yaml
+k8s/add service.yaml service2.yaml endpointslice.yaml endpointslice2.yaml
+
+# Validate
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table
+
+# Service name index
+db/list --columns Name,Source -i name -o list.actual services foo/echo
+cmp services-foo.table list.actual 
+db/prefix --columns Name,Source -i name -o list.actual services ''
+cmp services.table list.actual 
+db/prefix --columns Name,Source -i name -o list.actual services foo/
+cmp services-foo.table list.actual 
+db/prefix --columns Name,Source -i name -o list.actual services bar/
+cmp services-bar.table list.actual 
+
+# Frontend service index
+db/list --columns Address,ServiceName -i service -o list.actual frontends foo/echo
+cmp frontends-echo.table list.actual 
+db/list --columns Address,ServiceName -i service -o list.actual frontends bar/echo
+cmp frontends-echo2.table list.actual 
+db/prefix --columns Address,ServiceName -i service -o list.actual frontends ''
+cmp frontends-by-servicename.table list.actual
+db/prefix --columns Address,ServiceName -i service -o list.actual frontends bar/echo
+cmp frontends-echo2.table list.actual
+
+# Frontend address index
+db/list --columns Address,ServiceName -i address -o list.actual frontends 1.1.1.1:80/TCP
+cmp frontends-echo.table list.actual 
+db/list --columns Address,ServiceName -i address -o list.actual frontends 2.2.2.2:80/TCP
+cmp frontends-echo2.table list.actual 
+
+# Backend service index
+db/list --columns Address,Instances -i service -o list.actual backends foo/echo
+cmp backends-foo.table list.actual
+db/prefix --columns Address,Instances -i service -o list.actual backends 'foo/'
+cmp backends-foo.table list.actual
+db/prefix --columns Address,Instances -i service -o list.actual backends 'bar/'
+cmp backends-bar.table list.actual
+db/prefix --columns Address,Instances -i service -o list.actual backends ''
+cmp backends-by-servicename.table list.actual
+
+# Backend address index
+db/list --columns Address,Instances -i address -o list.actual backends 10.244.1.1:80/TCP
+cmp backends-foo1.table list.actual
+
+# Backend address search by address prefix (only classful supported since we index by byte!)
+db/prefix --columns Address,Instances -i address -o list.actual backends 10.0.0.0/8
+cmp backends.table list.actual
+db/prefix --columns Address,Instances -i address -o list.actual backends 192.0.0.0/8
+cmp backends-empty.table list.actual
+db/prefix --columns Address,Instances -i address -o list.actual backends 10.244.2.0/24
+cmp backends-bar.table list.actual
+
+# ----
+
+-- services.table --
+Name       Source
+bar/echo   k8s
+foo/echo   k8s
+-- services-foo.table --
+Name       Source
+foo/echo   k8s
+-- services-bar.table --
+Name       Source
+bar/echo   k8s
+-- frontends.table --
+Address          ServiceName
+1.1.1.1:80/TCP   foo/echo
+2.2.2.2:80/TCP   bar/echo
+-- frontends-by-servicename.table --
+Address          ServiceName
+2.2.2.2:80/TCP   bar/echo
+1.1.1.1:80/TCP   foo/echo
+-- frontends-echo.table --
+Address          ServiceName
+1.1.1.1:80/TCP   foo/echo
+-- frontends-echo2.table --
+Address          ServiceName
+2.2.2.2:80/TCP   bar/echo
+-- backends.table --
+Address             Instances
+10.244.1.1:80/TCP   foo/echo (http)
+10.244.1.2:80/TCP   foo/echo (http)
+10.244.1.3:80/TCP   foo/echo (http)
+10.244.1.4:80/TCP   foo/echo (http)
+10.244.2.1:80/TCP   bar/echo (http)
+10.244.2.2:80/TCP   bar/echo (http)
+10.244.2.3:80/TCP   bar/echo (http)
+10.244.2.4:80/TCP   bar/echo (http)
+-- backends-by-servicename.table --
+Address             Instances
+10.244.2.1:80/TCP   bar/echo (http)
+10.244.2.2:80/TCP   bar/echo (http)
+10.244.2.3:80/TCP   bar/echo (http)
+10.244.2.4:80/TCP   bar/echo (http)
+10.244.1.1:80/TCP   foo/echo (http)
+10.244.1.2:80/TCP   foo/echo (http)
+10.244.1.3:80/TCP   foo/echo (http)
+10.244.1.4:80/TCP   foo/echo (http)
+-- backends-foo1.table --
+Address             Instances
+10.244.1.1:80/TCP   foo/echo (http)
+-- backends-foo.table --
+Address             Instances
+10.244.1.1:80/TCP   foo/echo (http)
+10.244.1.2:80/TCP   foo/echo (http)
+10.244.1.3:80/TCP   foo/echo (http)
+10.244.1.4:80/TCP   foo/echo (http)
+-- backends-bar.table --
+Address             Instances
+10.244.2.1:80/TCP   bar/echo (http)
+10.244.2.2:80/TCP   bar/echo (http)
+10.244.2.3:80/TCP   bar/echo (http)
+10.244.2.4:80/TCP   bar/echo (http)
+-- backends-empty.table --
+Address   Instances
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: foo
+spec:
+  clusterIP: 1.1.1.1
+  clusterIPs:
+  - 1.1.1.1
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  type: ClusterIP
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: foo
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  nodeName: nodeport-worker
+- addresses:
+  - 10.244.1.2
+  nodeName: nodeport-worker
+- addresses:
+  - 10.244.1.3
+  nodeName: nodeport-worker2
+- addresses:
+  - 10.244.1.4
+  nodeName: nodeport-worker2
+ports:
+- name: http
+  port: 80
+  protocol: TCP

--- a/pkg/loadbalancer/experimental/testdata/source-ranges.txtar
+++ b/pkg/loadbalancer/experimental/testdata/source-ranges.txtar
@@ -27,13 +27,13 @@ Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAf
 test/echo   k8s                  Cluster            Cluster                              0                     false              10.0.0.0/8
 
 -- frontends.table --
-Address               Type          ServiceName   PortName   Backends                     Status
-10.0.0.1:80/TCP       ClusterIP     test/echo     http       10.244.1.1:80/TCP (active)   Done
-10.0.0.2:80/TCP       LoadBalancer  test/echo     http       10.244.1.1:80/TCP (active)   Done
+Address               Type          ServiceName   PortName   Backends            Status
+10.0.0.1:80/TCP       ClusterIP     test/echo     http       10.244.1.1:80/TCP   Done
+10.0.0.2:80/TCP       LoadBalancer  test/echo     http       10.244.1.1:80/TCP   Done
 
 -- backends.table --
-Address             State    Instances          NodeName          ZoneID
-10.244.1.1:80/TCP   active   test/echo (http)   nodeport-worker   0
+Address             Instances          NodeName
+10.244.1.1:80/TCP   test/echo (http)   nodeport-worker
 
 -- services_empty.table --
 Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionAffinity   HealthCheckNodePort   LoopbackHostPort   SourceRanges
@@ -42,7 +42,7 @@ Name         Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy   SessionA
 Address               Type        ServiceName   PortName   Status  Backends
 
 -- backends_empty.table --
-Address             State    Instances            NodeName           ZoneID
+Address
 
 -- service.yaml --
 apiVersion: v1

--- a/pkg/loadbalancer/experimental/testdata/trafficpolicy.txtar
+++ b/pkg/loadbalancer/experimental/testdata/trafficpolicy.txtar
@@ -24,14 +24,14 @@ Name        Source   NatPolicy   ExtTrafficPolicy   IntTrafficPolicy
 test/echo   k8s                  Local              Local           
 
 -- frontends.table --
-Address               Type         ServiceName   PortName   Backends                     Status
-1.1.1.1:80/TCP        LoadBalancer test/echo     http       10.244.1.1:80/TCP (active)   Done
-10.96.50.104:80/TCP   ClusterIP    test/echo     http       10.244.1.1:80/TCP (active)   Done
+Address               Type         ServiceName   PortName   Backends            Status
+1.1.1.1:80/TCP        LoadBalancer test/echo     http       10.244.1.1:80/TCP   Done
+10.96.50.104:80/TCP   ClusterIP    test/echo     http       10.244.1.1:80/TCP   Done
 
 -- backends.table --
-Address             State    Instances          NodeName
-10.244.1.1:80/TCP   active   test/echo (http)   testnode
-10.244.2.1:80/TCP   active   test/echo (http)   othernode
+Address             Instances          NodeName
+10.244.1.1:80/TCP   test/echo (http)   testnode
+10.244.2.1:80/TCP   test/echo (http)   othernode
 
 -- service.yaml --
 apiVersion: v1

--- a/pkg/loadbalancer/experimental/watch.sh
+++ b/pkg/loadbalancer/experimental/watch.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# watch.sh watches the current and testdata directories and will
+# either recompile or execute the test for the changes test script.
+# This is useful when working on a test case as "go test" can be slow
+# due to slow linking as we pull in the client-go.
+# 
+# https://github.com/kubernetes/kubernetes/issues/127888 is an issue
+# for making client-go lighter that should improve the binary size and
+# compilation times.
+
+set -ux
+go test -c || exit 1
+
+inotifywait -e close_write -m . testdata |
+while read -r directory events filename; do
+  case "$directory" in
+    ./) 
+      go test -c && ./experimental.test -test.v -test.failfast
+      ;;
+    testdata/) 
+      ./experimental.test -test.run TestScript/$filename -test.v 
+      ;;
+  esac
+done
+

--- a/pkg/loadbalancer/experimental/writer_test.go
+++ b/pkg/loadbalancer/experimental/writer_test.go
@@ -6,6 +6,7 @@ package experimental
 import (
 	"context"
 	"encoding/binary"
+	"iter"
 	"log/slog"
 	"os"
 	"slices"
@@ -211,7 +212,6 @@ func TestWriter_Backend_UpsertDelete(t *testing.T) {
 
 	name1 := loadbalancer.ServiceName{Namespace: "test", Name: "test1"}
 	name2 := loadbalancer.ServiceName{Namespace: "test", Name: "test2"}
-	name3 := loadbalancer.ServiceName{Namespace: "test", Name: "test3"}
 
 	nextAddr := 0
 	mkAddr := func(port uint16) loadbalancer.L3n4Addr {
@@ -303,64 +303,6 @@ func TestWriter_Backend_UpsertDelete(t *testing.T) {
 		require.True(t, bes[0].L3n4Addr.DeepEqual(&beAddr3))
 	}
 
-	// SetBackendHealth
-	{
-
-		wtxn := p.Writer.WriteTxn()
-
-		be, _, _ := p.BackendTable.Get(wtxn, BackendByAddress(beAddr1))
-		require.Equal(t, loadbalancer.BackendStateActive, be.State)
-
-		err := p.Writer.SetBackendHealth(wtxn, beAddr1, false)
-		require.NoError(t, err, "SetBackendHealth")
-
-		be, _, _ = p.BackendTable.Get(wtxn, BackendByAddress(beAddr1))
-		require.Equal(t, loadbalancer.BackendStateQuarantined, be.State)
-
-		err = p.Writer.SetBackendHealth(wtxn, beAddr1, true)
-		require.NoError(t, err, "SetBackendHealth")
-
-		be, _, _ = p.BackendTable.Get(wtxn, BackendByAddress(beAddr1))
-		require.Equal(t, loadbalancer.BackendStateActive, be.State)
-
-		// Marking the backend terminating will cause health updates to be ignored.
-		p.Writer.UpsertBackends(wtxn, name2, source.Kubernetes,
-			BackendParams{
-				L3n4Addr: beAddr1,
-				State:    loadbalancer.BackendStateTerminating,
-			},
-		)
-
-		err = p.Writer.SetBackendHealth(wtxn, beAddr1, false)
-		require.NoError(t, err, "SetBackendHealth")
-
-		be, _, _ = p.BackendTable.Get(wtxn, BackendByAddress(beAddr1))
-		require.Equal(t, loadbalancer.BackendStateTerminating, be.State)
-
-		// Adding another active instance to the backend won't change the
-		// computed state.
-		p.Writer.UpsertBackends(wtxn, name3, source.Kubernetes,
-			BackendParams{
-				L3n4Addr: beAddr1,
-				State:    loadbalancer.BackendStateActive,
-			},
-		)
-
-		be, _, _ = p.BackendTable.Get(wtxn, BackendByAddress(beAddr1))
-		require.Equal(t, loadbalancer.BackendStateTerminating, be.State)
-		require.Equal(t, 3, be.Instances.Len()) // name1, name2, name3
-
-		// Removing the "terminating" instance will not change the state, e.g.
-		// when a backend has been marked terminating by any instances it'll stay
-		// terminating until removed.
-		p.Writer.ReleaseBackend(wtxn, name2, beAddr1)
-		be, _, _ = p.BackendTable.Get(wtxn, BackendByAddress(beAddr1))
-		require.Equal(t, 2, be.Instances.Len()) // name1, name3
-		require.Equal(t, loadbalancer.BackendStateTerminating, be.State)
-
-		wtxn.Abort()
-	}
-
 	// ReleaseBackend
 	{
 		wtxn := p.Writer.WriteTxn()
@@ -380,11 +322,11 @@ func TestWriter_Backend_UpsertDelete(t *testing.T) {
 		require.Equal(t, 3, p.BackendTable.NumObjects(wtxn))
 		err := p.Writer.DeleteBackendsBySource(wtxn, source.Kubernetes)
 		require.NoError(t, err, "DeleteBackendsBySource failed")
-		iter := p.BackendTable.All(wtxn)
-		require.Empty(t, statedb.Collect(iter))
+		bes := p.BackendTable.All(wtxn)
+		require.Empty(t, statedb.Collect(bes))
 
 		// No backends remain for the service.
-		require.Empty(t, statedb.Collect(fe.Backends))
+		require.Empty(t, statedb.Collect(iter.Seq2[BackendParams, statedb.Revision](fe.Backends)))
 
 		wtxn.Abort()
 	}
@@ -713,7 +655,7 @@ func TestWithConflictingSources(t *testing.T) {
 				if weight == nil {
 					_, _, found := p.Writer.Backends().Get(txn, BackendByServiceName(name))
 					require.False(t, found)
-					require.Empty(t, statedb.Collect(fe.Backends))
+					require.Empty(t, statedb.Collect(iter.Seq2[BackendParams, statedb.Revision](fe.Backends)))
 				} else {
 					backends := p.Writer.Backends().List(txn, BackendByServiceName(name))
 					count := 0
@@ -723,12 +665,11 @@ func TestWithConflictingSources(t *testing.T) {
 						backendFromTable = b
 					}
 					require.Equal(t, 1, count)
-					actual := slices.Collect(statedb.ToSeq(fe.Backends))
+					actual := slices.Collect(statedb.ToSeq(iter.Seq2[BackendParams, statedb.Revision](fe.Backends)))
 					require.Len(t, actual, 1)
-					for desc, b := range map[string]*Backend{"from table": backendFromTable, "from Frontend": actual[0]} {
-						bi := b.GetInstance(name)
-						require.NotNil(t, bi, desc)
-						require.Equal(t, int(*weight), int(bi.Weight), "backend %s", desc)
+					for desc, b := range map[string]BackendParams{"from table": *backendFromTable.GetInstance(name), "from Frontend": actual[0]} {
+						require.NotNil(t, b, desc)
+						require.Equal(t, int(*weight), int(b.Weight), "backend %s", desc)
 					}
 				}
 			}

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -8,18 +8,28 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/cilium/statedb/index"
 	"github.com/cilium/statedb/part"
+	"gopkg.in/yaml.v3"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/cidr"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+type IPFamily = bool
+
+const (
+	IPFamilyIPv4 = IPFamily(false)
+	IPFamilyIPv6 = IPFamily(true)
 )
 
 // SVCType is a type of a service.
@@ -814,7 +824,7 @@ func NewL3n4AddrFromModel(base *models.FrontendAddress) (*L3n4Addr, error) {
 // keys for prefix searches, e.g. "1.2.3.4".
 // This must be kept in sync with Bytes().
 func L3n4AddrFromString(key string) (index.Key, error) {
-	keyErr := errors.New("bad key, expected \"<addr>:<port>/<proto>(/i)\", e.g. \"1.2.3.4:80/TCP\"")
+	keyErr := errors.New("bad key, expected \"<addr>:<port>/<proto>(/i)\", e.g. \"1.2.3.4:80/TCP\" or classful prefix \"10.0.0.0/8\"")
 	var out []byte
 
 	if len(key) == 0 {
@@ -837,6 +847,22 @@ func L3n4AddrFromString(key string) (index.Key, error) {
 
 	addrCluster, err := cmtypes.ParseAddrCluster(addr)
 	if err != nil {
+		// See if the address is a prefix and try to parse it as such.
+		// We only support classful searches, e.g. /8, /16, /24, /32 since
+		// indexing is byte-wise.
+		if prefix, err := netip.ParsePrefix(addr); err == nil {
+			bits := prefix.Bits()
+			if bits%8 != 0 {
+				return index.Key{}, fmt.Errorf("%w: only classful prefixes supported (/8,/16,/24,/32)", keyErr)
+			}
+			bytes := prefix.Addr().As16()
+			if prefix.Addr().Is6() {
+				return index.Key(bytes[:bits/8]), nil
+			} else {
+				// The address is in the 16-byte format, cut from the last 4 bytes.
+				return index.Key(bytes[:12+bits/8]), nil
+			}
+		}
 		return index.Key{}, fmt.Errorf("%w: %w", keyErr, err)
 	}
 	addr20 := addrCluster.As20()
@@ -947,6 +973,64 @@ func NewL3n4AddrFromBackendModel(base *models.BackendAddress) (*L3n4Addr, error)
 	return &L3n4Addr{AddrCluster: addrCluster, L4Addr: *l4addr}, nil
 }
 
+func (l *L3n4Addr) ParseFromString(s string) error {
+	formatError := fmt.Errorf(
+		"bad address %q, expected \"<addr>:<port>/<proto>(/i)\", e.g. \"1.2.3.4:80/TCP\"",
+		s,
+	)
+
+	// Parse address
+	var addr string
+	if strings.HasPrefix(s, "[") {
+		addr, s, _ = strings.Cut(s[1:], "]")
+		switch {
+		case strings.HasPrefix(s, ":"):
+			s = s[1:]
+		case len(s) > 0:
+			return formatError
+		}
+	} else {
+		addr, s, _ = strings.Cut(s, ":")
+	}
+
+	var err error
+	l.AddrCluster, err = cmtypes.ParseAddrCluster(addr)
+	if err != nil {
+		return formatError
+	}
+
+	// Parse port
+	if len(s) < 1 {
+		return formatError
+	}
+
+	var portS string
+	portS, s, _ = strings.Cut(s, "/")
+	port, err := strconv.ParseUint(portS, 10, 16)
+	if err != nil {
+		return formatError
+	}
+	l.L4Addr.Port = uint16(port)
+
+	// Parse protocol
+	l.L4Addr.Protocol = TCP
+	if len(s) > 0 {
+		var proto string
+		proto, s, _ = strings.Cut(s, "/")
+		l.L4Addr.Protocol = L4Type(strings.ToUpper(proto))
+		if !slices.Contains(AllProtocols, l.L4Addr.Protocol) {
+			return formatError
+		}
+	}
+
+	// Parse scope.
+	l.Scope = ScopeExternal
+	if s == "i" {
+		l.Scope = ScopeInternal
+	}
+	return nil
+}
+
 func (a *L3n4Addr) GetModel() *models.FrontendAddress {
 	if a == nil {
 		return nil
@@ -1055,6 +1139,14 @@ func (l L3n4Addr) Bytes() []byte {
 	key = append(key, L4TypeAsByte(l.Protocol))
 	key = append(key, l.Scope)
 	return key
+}
+
+func (l L3n4Addr) MarshalYAML() (any, error) {
+	return l.StringWithProtocol(), nil
+
+}
+func (l *L3n4Addr) UnmarshalYAML(value *yaml.Node) error {
+	return l.ParseFromString(value.Value)
 }
 
 // L3n4AddrID is used to store, as an unique L3+L4 plus the assigned ID, in the

--- a/pkg/maps/lbmap/skip_lb_map.go
+++ b/pkg/maps/lbmap/skip_lb_map.go
@@ -4,7 +4,9 @@
 package lbmap
 
 import (
+	"errors"
 	"fmt"
+	"iter"
 	"net"
 	"unsafe"
 
@@ -15,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/ebpf"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/types"
 )
 
@@ -37,10 +40,22 @@ type SkipLBMap interface {
 	DeleteLB6ByAddrPort(ip net.IP, port uint16)
 	DeleteLB4ByNetnsCookie(cookie uint64)
 	DeleteLB6ByNetnsCookie(cookie uint64)
+	AllLB4() iter.Seq2[*SkipLB4Key, *SkipLB4Value]
+	AllLB6() iter.Seq2[*SkipLB6Key, *SkipLB6Value]
+	DeleteLB4(key *SkipLB4Key) error
+	DeleteLB6(key *SkipLB6Key) error
+	OpenOrCreate() error
+	Close() error
 }
 
 func NewSkipLBMap() (SkipLBMap, error) {
 	skipLBMap := &skipLBMap{}
+
+	pinning := ebpf.PinByName
+	if testutils.IsPrivileged() {
+		// Running in privileged tests, don't pin the map.
+		pinning = ebpf.PinNone
+	}
 
 	if option.Config.EnableIPv4 {
 		skipLBMap.bpfMap4 = ebpf.NewMap(&ebpf.MapSpec{
@@ -50,11 +65,8 @@ func NewSkipLBMap() (SkipLBMap, error) {
 			ValueSize:  uint32(unsafe.Sizeof(SkipLB4Value{})),
 			MaxEntries: SkipLBMapMaxEntries,
 			Flags:      bpf.BPF_F_NO_PREALLOC,
-			Pinning:    ebpf.PinByName},
-		)
-		if err := skipLBMap.bpfMap4.OpenOrCreate(); err != nil {
-			return nil, fmt.Errorf("failed to open or create %s: %w", SkipLB4MapName, err)
-		}
+			Pinning:    pinning,
+		})
 	}
 	if option.Config.EnableIPv6 {
 		skipLBMap.bpfMap6 = ebpf.NewMap(&ebpf.MapSpec{
@@ -64,14 +76,65 @@ func NewSkipLBMap() (SkipLBMap, error) {
 			ValueSize:  uint32(unsafe.Sizeof(SkipLB6Value{})),
 			MaxEntries: SkipLBMapMaxEntries,
 			Flags:      bpf.BPF_F_NO_PREALLOC,
-			Pinning:    ebpf.PinByName},
-		)
-		if err := skipLBMap.bpfMap6.OpenOrCreate(); err != nil {
-			return nil, fmt.Errorf("failed to open or create %s: %w", SkipLB6MapName, err)
-		}
+			Pinning:    pinning,
+		})
 	}
 
 	return skipLBMap, nil
+}
+
+func (m *skipLBMap) OpenOrCreate() error {
+	if m.bpfMap4 != nil {
+		if err := m.bpfMap4.OpenOrCreate(); err != nil {
+			return fmt.Errorf("failed to open or create %s: %w", SkipLB4MapName, err)
+		}
+	}
+	if m.bpfMap6 != nil {
+		if err := m.bpfMap6.OpenOrCreate(); err != nil {
+			return fmt.Errorf("failed to open or create %s: %w", SkipLB6MapName, err)
+		}
+	}
+	return nil
+}
+
+func (m *skipLBMap) Close() (err error) {
+	if m.bpfMap4 != nil {
+		err = errors.Join(err, m.bpfMap4.Close())
+	}
+	if m.bpfMap6 != nil {
+		err = errors.Join(err, m.bpfMap6.Close())
+	}
+	return
+}
+
+func (m *skipLBMap) AllLB4() iter.Seq2[*SkipLB4Key, *SkipLB4Value] {
+	return func(yield func(*SkipLB4Key, *SkipLB4Value) bool) {
+		stop := false
+		m.bpfMap4.IterateWithCallback(&SkipLB4Key{}, &SkipLB4Value{},
+			func(k, v interface{}) {
+				key := k.(*SkipLB4Key)
+				value := v.(*SkipLB4Value)
+				key.Port = byteorder.NetworkToHost16(key.Port)
+				if !stop && !yield(key, value) {
+					stop = true
+				}
+			})
+	}
+}
+
+func (m *skipLBMap) AllLB6() iter.Seq2[*SkipLB6Key, *SkipLB6Value] {
+	return func(yield func(*SkipLB6Key, *SkipLB6Value) bool) {
+		stop := false
+		m.bpfMap6.IterateWithCallback(&SkipLB6Key{}, &SkipLB6Value{},
+			func(k, v interface{}) {
+				key := k.(*SkipLB6Key)
+				value := v.(*SkipLB6Value)
+				key.Port = byteorder.NetworkToHost16(key.Port)
+				if !stop && !yield(key, value) {
+					stop = true
+				}
+			})
+	}
 }
 
 // AddLB4 adds the given tuple to skip LB for to the BPF v4 map.
@@ -86,6 +149,16 @@ func (m *skipLBMap) AddLB6(netnsCookie uint64, ip net.IP, port uint16) error {
 	return m.bpfMap6.Update(
 		NewSkipLB6Key(netnsCookie, ip.To16(), port),
 		&SkipLB6Value{}, 0)
+}
+
+func (m *skipLBMap) DeleteLB4(key *SkipLB4Key) error {
+	key.Port = byteorder.HostToNetwork16(key.Port)
+	return m.bpfMap4.Delete(key)
+}
+
+func (m *skipLBMap) DeleteLB6(key *SkipLB6Key) error {
+	key.Port = byteorder.HostToNetwork16(key.Port)
+	return m.bpfMap6.Delete(key)
 }
 
 // DeleteLB4ByAddrPort deletes entries associated with the passed address and port from the v4 map.
@@ -297,7 +370,7 @@ type SkipLB6Value struct {
 func NewSkipLB6Key(netnsCookie uint64, address net.IP, port uint16) *SkipLB6Key {
 	key := SkipLB6Key{
 		NetnsCookie: netnsCookie,
-		Port:        port,
+		Port:        byteorder.HostToNetwork16(port),
 	}
 	copy(key.Address[:], address.To16())
 

--- a/pkg/policy/k8s/service.go
+++ b/pkg/policy/k8s/service.go
@@ -44,7 +44,7 @@ func (p *policyWatcher) updateToServicesPolicies(svcID k8s.ServiceID, newSVC, ol
 	endpointsChanged := !newEps.DeepEqual(oldEps)
 	// newService is true if this is the first time we observe this service
 	newService := oldSVC == nil
-	// changedService is true if the service label or selector has changed
+	// changedService is true if the service label, selector or endpoints has changed
 	changedService := !newSVC.DeepEqual(oldSVC) || endpointsChanged
 
 	// candidatePolicyKeys contains the set of policy names we need to process

--- a/pkg/redirectpolicy/cell.go
+++ b/pkg/redirectpolicy/cell.go
@@ -11,6 +11,7 @@ import (
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/loadbalancer/experimental"
 	"github.com/cilium/cilium/pkg/service"
 )
 
@@ -32,9 +33,14 @@ type lrpManagerParams struct {
 	Pods           statedb.Table[agentK8s.LocalPod]
 	Ep             endpointmanager.EndpointManager
 	MetricsManager LRPMetrics
+	ExpConfig      experimental.Config
 }
 
 func newLRPManager(params lrpManagerParams) *Manager {
+	if params.ExpConfig.EnableExperimentalLB {
+		// The experimental implementation is enabled, do nothing here.
+		return nil
+	}
 	return NewRedirectPolicyManager(params.DB, params.Svc, params.SvcCache, params.Pods, params.Ep, params.MetricsManager)
 }
 

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -123,6 +123,10 @@ func NewRedirectPolicyManager(db *statedb.DB, svc svcManager, svcCache k8s.Servi
 // AddRedirectPolicy parses the given local redirect policy config, and updates
 // internal state with the config fields.
 func (rpm *Manager) AddRedirectPolicy(config LRPConfig) (bool, error) {
+	if rpm == nil {
+		return true, nil
+	}
+
 	rpm.mutex.Lock()
 	defer rpm.mutex.Unlock()
 
@@ -135,10 +139,14 @@ func (rpm *Manager) AddRedirectPolicy(config LRPConfig) (bool, error) {
 			if rpm.skipLBMap == nil {
 				var err error
 				rpm.skipLBMap, err = lbmap.NewSkipLBMap()
+				if err == nil {
+					err = rpm.skipLBMap.OpenOrCreate()
+				}
 				if err != nil {
 					log.WithError(err).Warn("failed to init cilium_skip_lb maps: " +
 						"policies with skipRedirectFromBackend flag set not supported")
 				}
+
 			}
 
 			return false
@@ -223,6 +231,10 @@ func (rpm *Manager) AddRedirectPolicy(config LRPConfig) (bool, error) {
 
 // DeleteRedirectPolicy deletes the internal state associated with the given policy.
 func (rpm *Manager) DeleteRedirectPolicy(config LRPConfig) error {
+	if rpm == nil {
+		return nil
+	}
+
 	rpm.mutex.Lock()
 	defer rpm.mutex.Unlock()
 
@@ -262,6 +274,10 @@ func (rpm *Manager) DeleteRedirectPolicy(config LRPConfig) error {
 // OnAddService handles Kubernetes service (clusterIP type) add events, and
 // updates the internal state for the policy config associated with the service.
 func (rpm *Manager) OnAddService(svcID k8s.ServiceID) {
+	if rpm == nil {
+		return
+	}
+
 	rpm.mutex.Lock()
 	defer rpm.mutex.Unlock()
 	if len(rpm.policyConfigs) == 0 {
@@ -282,6 +298,10 @@ func (rpm *Manager) OnAddService(svcID k8s.ServiceID) {
 // EnsureService ensures that the LRP service is updated to the latest state.
 // It is called after synchronization is complete during agent startup.
 func (rpm *Manager) EnsureService(svcID k8s.ServiceID) (bool, error) {
+	if rpm == nil {
+		return false, nil
+	}
+
 	rpm.mutex.Lock()
 	defer rpm.mutex.Unlock()
 
@@ -309,6 +329,10 @@ func (rpm *Manager) EnsureService(svcID k8s.ServiceID) (bool, error) {
 // OnDeleteService handles Kubernetes service deletes, and deletes the internal state
 // for the policy config that might be associated with the service.
 func (rpm *Manager) OnDeleteService(svcID k8s.ServiceID) {
+	if rpm == nil {
+		return
+	}
+
 	rpm.mutex.Lock()
 	defer rpm.mutex.Unlock()
 	if len(rpm.policyConfigs) == 0 {
@@ -319,6 +343,10 @@ func (rpm *Manager) OnDeleteService(svcID k8s.ServiceID) {
 }
 
 func (rpm *Manager) OnAddPod(pod *slimcorev1.Pod) {
+	if rpm == nil {
+		return
+	}
+
 	rpm.mutex.Lock()
 	defer rpm.mutex.Unlock()
 
@@ -340,7 +368,7 @@ func (rpm *Manager) OnAddPod(pod *slimcorev1.Pod) {
 }
 
 func (rpm *Manager) OnUpdatePodLocked(pod *slimcorev1.Pod, removeOld bool, upsertNew bool) {
-	if len(rpm.policyConfigs) == 0 {
+	if rpm == nil || len(rpm.policyConfigs) == 0 {
 		return
 	}
 
@@ -411,6 +439,9 @@ func (rpm *Manager) OnUpdatePodLocked(pod *slimcorev1.Pod, removeOld bool, upser
 }
 
 func (rpm *Manager) OnUpdatePod(pod *slimcorev1.Pod, needsReassign bool, ready bool) {
+	if rpm == nil {
+		return
+	}
 	rpm.mutex.Lock()
 	defer rpm.mutex.Unlock()
 	// TODO add unit test to validate that we get callbacks only for relevant events
@@ -418,6 +449,9 @@ func (rpm *Manager) OnUpdatePod(pod *slimcorev1.Pod, needsReassign bool, ready b
 }
 
 func (rpm *Manager) OnDeletePod(pod *slimcorev1.Pod) {
+	if rpm == nil {
+		return
+	}
 	rpm.mutex.Lock()
 	defer rpm.mutex.Unlock()
 	if len(rpm.policyConfigs) == 0 {
@@ -439,6 +473,9 @@ func (rpm *Manager) OnDeletePod(pod *slimcorev1.Pod) {
 }
 
 func (rpm *Manager) EndpointCreated(ep *endpoint.Endpoint) {
+	if rpm == nil {
+		return
+	}
 	podID := k8s.ServiceID{
 		Name:      ep.GetK8sPodName(),
 		Namespace: ep.GetK8sNamespace(),
@@ -1095,6 +1132,9 @@ func (rpm *Manager) getPodMetadata(pod *slimcorev1.Pod) *podMetadata {
 }
 
 func (rpm *Manager) GetLRPs() []*LRPConfig {
+	if rpm == nil {
+		return nil
+	}
 	rpm.mutex.Lock()
 	defer rpm.mutex.Unlock()
 

--- a/pkg/redirectpolicy/manager_test.go
+++ b/pkg/redirectpolicy/manager_test.go
@@ -5,6 +5,7 @@ package redirectpolicy
 
 import (
 	"fmt"
+	"iter"
 	"net"
 	"net/netip"
 	"sync"
@@ -24,6 +25,7 @@ import (
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -130,6 +132,36 @@ type fakeSkipLBMap struct {
 	lb6Events chan skipLBParams
 }
 
+// Close implements lbmap.SkipLBMap.
+func (f fakeSkipLBMap) Close() error {
+	return nil
+}
+
+// OpenOrCreate implements lbmap.SkipLBMap.
+func (f fakeSkipLBMap) OpenOrCreate() error {
+	return nil
+}
+
+// AllLB4 implements lbmap.SkipLBMap.
+func (f fakeSkipLBMap) AllLB4() iter.Seq2[*lbmap.SkipLB4Key, *lbmap.SkipLB4Value] {
+	panic("not implemented")
+}
+
+// AllLB6 implements lbmap.SkipLBMap.
+func (f fakeSkipLBMap) AllLB6() iter.Seq2[*lbmap.SkipLB6Key, *lbmap.SkipLB6Value] {
+	panic("not implemented")
+}
+
+// DeleteLB4 implements lbmap.SkipLBMap.
+func (f fakeSkipLBMap) DeleteLB4(key *lbmap.SkipLB4Key) error {
+	return nil
+}
+
+// DeleteLB6 implements lbmap.SkipLBMap.
+func (f fakeSkipLBMap) DeleteLB6(key *lbmap.SkipLB6Key) error {
+	return nil
+}
+
 type skipLBParams struct {
 	cookie uint64
 	ip     net.IP
@@ -157,20 +189,18 @@ func (f fakeSkipLBMap) AddLB6(netnsCookie uint64, ip net.IP, port uint16) error 
 }
 
 func (f fakeSkipLBMap) DeleteLB4ByAddrPort(ip net.IP, port uint16) {
-	panic("implement me")
 }
 
 func (f fakeSkipLBMap) DeleteLB6ByAddrPort(ip net.IP, port uint16) {
-	panic("implement me")
 }
 
 func (f fakeSkipLBMap) DeleteLB4ByNetnsCookie(cookie uint64) {
-	panic("implement me")
 }
 
 func (f fakeSkipLBMap) DeleteLB6ByNetnsCookie(cookie uint64) {
-	panic("implement me")
 }
+
+var _ lbmap.SkipLBMap = fakeSkipLBMap{}
 
 var (
 	tcpStr    = "TCP"

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4265,9 +4265,6 @@ func (kub *Kubectl) ciliumServicePreFlightCheck() error {
 				return fmt.Errorf("Error validating Cilium service on pod %v: %s", pod, err.Error())
 			}
 		}
-		if len(pod.services) != len(pod.loadBalancers) {
-			return fmt.Errorf("Length of Cilium services doesn't match length of bpf LB map on pod %v", pod)
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
This implements adapters that bridge pkg/loadbalancer/experimental to the `ServiceCache` and `ServiceManager` APIs and brings in LocalRedirectPolicy support for the experimental control-plane. The CiliumEnvoyConfig handling for the new control-plane was rewritten to support headless services (the original approach of watching Table[Frontend] of course didn't work as headless services have no frontends...).

The PR is large as it contains many fixes uncovered when running the full CI with the new control-plane (https://github.com/cilium/cilium/pull/37083) and iterating on fixing issues. Since the changes are within the experimental packages I've decided to just do a large PR to push them in.