### PR TITLE
bpf: support ipv6 egressgateway policies

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -475,6 +475,18 @@ struct egress_gw_policy_entry {
 	__u32 gateway_ip;
 };
 
+struct egress_gw_policy_key6 {
+	struct bpf_lpm_trie_key lpm_key;
+	union v6addr saddr;
+	union v6addr daddr;
+};
+
+struct egress_gw_policy_entry6 {
+	union v6addr egress_ip;
+	__u32 gateway_ip;
+	__u32 reserved[3]; /* reserved for future extension, e.g. v6 gateway_ip */
+};
+
 struct srv6_vrf_key4 {
 	struct bpf_lpm_trie_key lpm;
 	__u32 src_ip;

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -501,6 +501,18 @@ ipv6_ct_tuple_reverse(struct ipv6_ct_tuple *tuple)
 	ct_flip_tuple_dir6(tuple);
 }
 
+static __always_inline union v6addr
+ipv6_ct_reverse_tuple_saddr(const struct ipv6_ct_tuple *rtuple)
+{
+	return rtuple->daddr;
+}
+
+static __always_inline union v6addr
+ipv6_ct_reverse_tuple_daddr(const struct ipv6_ct_tuple *rtuple)
+{
+	return rtuple->saddr;
+}
+
 static __always_inline int
 ct_extract_ports6(struct __ctx_buff *ctx, int off, struct ipv6_ct_tuple *tuple)
 {

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -14,9 +14,12 @@
 /* EGRESS_STATIC_PREFIX represents the size in bits of the static prefix part of
  * an egress policy key (i.e. the source IP).
  */
-#define EGRESS_STATIC_PREFIX (sizeof(__be32) * 8)
-#define EGRESS_PREFIX_LEN(PREFIX) (EGRESS_STATIC_PREFIX + (PREFIX))
-#define EGRESS_IPV4_PREFIX EGRESS_PREFIX_LEN(32)
+#define EGRESS_STATIC_PREFIX_V4 (sizeof(__be32) * 8)
+#define EGRESS_STATIC_PREFIX_V6 (sizeof(union v6addr) * 8)
+#define EGRESS_PREFIX_LEN_V4(PREFIX) (EGRESS_STATIC_PREFIX_V4 + (PREFIX))
+#define EGRESS_PREFIX_LEN_V6(PREFIX) (EGRESS_STATIC_PREFIX_V6 + (PREFIX))
+#define EGRESS_IPV4_PREFIX EGRESS_PREFIX_LEN_V4(32)
+#define EGRESS_IPV6_PREFIX EGRESS_PREFIX_LEN_V6(128)
 
 /* These are special IP values in the CIDR 0.0.0.0/8 range that map to specific
  * case for in the egress gateway policies handling.
@@ -28,6 +31,7 @@
 
 /* Special values in the policy_entry->egress_ip: */
 #define EGRESS_GATEWAY_NO_EGRESS_IP (0)
+#define EGRESS_GATEWAY_NO_EGRESS_IP_V6 ((union v6addr){{0, 0, 0, 0}})
 
 static __always_inline
 int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, __be32 daddr,
@@ -69,7 +73,7 @@ int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, 
 	return fib_do_redirect(ctx, true, &fib_params, false, ret, &oif, ext_err);
 }
 
-#ifdef ENABLE_EGRESS_GATEWAY
+# ifdef ENABLE_EGRESS_GATEWAY
 struct {
 	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
 	__type(key, struct egress_gw_policy_key);
@@ -89,7 +93,7 @@ struct egress_gw_policy_entry *lookup_ip4_egress_gw_policy(__be32 saddr, __be32 
 	};
 	return map_lookup_elem(&cilium_egress_gw_policy_v4, &key);
 }
-#endif /* ENABLE_EGRESS_GATEWAY */
+# endif /* ENABLE_EGRESS_GATEWAY */
 
 static __always_inline int
 egress_gw_request_needs_redirect(struct ipv4_ct_tuple *rtuple __maybe_unused,
@@ -260,4 +264,227 @@ int egress_gw_handle_packet(struct __ctx_buff *ctx,
 						NOT_VTEP_DST, trace);
 }
 
+#ifdef ENABLE_IPV6
+#ifdef ENABLE_EGRESS_GATEWAY
+struct {
+	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
+	__type(key, struct egress_gw_policy_key6);
+	__type(value, struct egress_gw_policy_entry6);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, EGRESS_POLICY_MAP_SIZE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} cilium_egress_gw_policy_v6 __section_maps_btf;
+
+static __always_inline
+struct egress_gw_policy_entry6 *lookup_ip6_egress_gw_policy(const union v6addr *saddr,
+							    const union v6addr *daddr)
+{
+	struct egress_gw_policy_key6 key = {
+		.lpm_key = { EGRESS_IPV6_PREFIX, {} },
+		.saddr = *saddr,
+		.daddr = *daddr,
+	};
+	return map_lookup_elem(&cilium_egress_gw_policy_v6, &key);
+}
+#endif /* ENABLE_EGRESS_GATEWAY */
+
+static __always_inline int
+egress_gw_request_needs_redirect_v6(struct ipv6_ct_tuple *rtuple __maybe_unused,
+				    __be32 *gateway_ip __maybe_unused)
+{
+#if defined(ENABLE_EGRESS_GATEWAY)
+	struct egress_gw_policy_entry6 *egress_gw_policy;
+	union v6addr saddr, daddr;
+
+	saddr = ipv6_ct_reverse_tuple_saddr(rtuple);
+	daddr = ipv6_ct_reverse_tuple_daddr(rtuple);
+
+	egress_gw_policy = lookup_ip6_egress_gw_policy(&saddr, &daddr);
+	if (!egress_gw_policy)
+		return CTX_ACT_OK;
+
+	switch (egress_gw_policy->gateway_ip) {
+	case EGRESS_GATEWAY_NO_GATEWAY:
+		/* If no gateway is found, drop the packet. */
+		return DROP_NO_EGRESS_GATEWAY;
+	case EGRESS_GATEWAY_EXCLUDED_CIDR:
+		return CTX_ACT_OK;
+	}
+
+	*gateway_ip = egress_gw_policy->gateway_ip;
+	return CTX_ACT_REDIRECT;
+#else
+	return CTX_ACT_OK;
+#endif /* ENABLE_EGRESS_GATEWAY */
+}
+
+static __always_inline
+bool egress_gw_snat_needed_v6(union v6addr *saddr __maybe_unused,
+			      union v6addr *daddr __maybe_unused,
+			      union v6addr *snat_addr __maybe_unused,
+			      __u32 *egress_ifindex __maybe_unused)
+{
+#if defined(ENABLE_EGRESS_GATEWAY)
+	struct egress_gw_policy_entry6 *egress_gw_policy;
+
+	egress_gw_policy = lookup_ip6_egress_gw_policy(saddr, daddr);
+	if (!egress_gw_policy)
+		return false;
+
+	if (egress_gw_policy->gateway_ip == EGRESS_GATEWAY_NO_GATEWAY ||
+	    egress_gw_policy->gateway_ip == EGRESS_GATEWAY_EXCLUDED_CIDR)
+		return false;
+
+	*snat_addr = egress_gw_policy->egress_ip;
+# ifdef EGRESS_IFINDEX
+	*egress_ifindex = EGRESS_IFINDEX;
+# endif
+
+	return true;
+#else
+	return false;
+#endif /* ENABLE_EGRESS_GATEWAY */
+}
+
+static __always_inline
+bool egress_gw_reply_matches_policy_v6(struct ipv6hdr *ip6 __maybe_unused)
+{
+#if defined(ENABLE_EGRESS_GATEWAY)
+	struct egress_gw_policy_entry6 *egress_policy;
+
+	egress_policy = lookup_ip6_egress_gw_policy((union v6addr *)&ip6->daddr,
+						    (union v6addr *)&ip6->saddr);
+	if (!egress_policy)
+		return false;
+
+	if (egress_policy->gateway_ip == EGRESS_GATEWAY_NO_GATEWAY ||
+	    egress_policy->gateway_ip == EGRESS_GATEWAY_EXCLUDED_CIDR)
+		return false;
+
+	return true;
+#else
+	return false;
+#endif /* ENABLE_EGRESS_GATEWAY */
+}
+
+static __always_inline int
+egress_gw_request_needs_redirect_hook_v6(struct ipv6_ct_tuple *rtuple,
+					 __be32 *gateway_ip)
+{
+	return egress_gw_request_needs_redirect_v6(rtuple, gateway_ip);
+}
+
+static __always_inline
+bool egress_gw_snat_needed_hook_v6(union v6addr *saddr, union v6addr *daddr,
+				   union v6addr *snat_addr, __u32 *egress_ifindex)
+{
+	struct remote_endpoint_info *remote_ep;
+
+	remote_ep = lookup_ip6_remote_endpoint(daddr, 0);
+	/* If the packet is destined to an entity inside the cluster, either EP
+	 * or node, skip SNAT since only traffic leaving the cluster is supposed
+	 * to be masqueraded with an egress IP.
+	 */
+	if (remote_ep && identity_is_cluster(remote_ep->sec_identity))
+		return false;
+
+	return egress_gw_snat_needed_v6(saddr, daddr, snat_addr, egress_ifindex);
+}
+
+static __always_inline
+int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
+					 const union v6addr *egress_ip,
+					 const union v6addr *daddr,
+					 __u32 egress_ifindex, __s8 *ext_err)
+{
+	struct bpf_fib_lookup_padded fib_params = {};
+	int oif = 0;
+	int ret;
+
+	if (egress_ifindex && neigh_resolver_available())
+		return redirect_neigh(egress_ifindex, NULL, 0, 0);
+
+	ret = (__s8)fib_lookup_v6(ctx, &fib_params,
+				  (struct in6_addr *)egress_ip,
+				  (struct in6_addr *)daddr, 0);
+
+	switch (ret) {
+	case BPF_FIB_LKUP_RET_SUCCESS:
+		break;
+	case BPF_FIB_LKUP_RET_NO_NEIGH:
+		if (!neigh_resolver_available())
+			return CTX_ACT_OK;
+		if (!is_defined(HAVE_FIB_IFINDEX))
+			return CTX_ACT_OK;
+		break;
+	default:
+		*ext_err = (__s8)ret;
+		return DROP_NO_FIB;
+	}
+
+	if (is_defined(IS_BPF_HOST) &&
+	    fib_params.l.ifindex == ctx_get_ifindex(ctx))
+		return CTX_ACT_OK;
+
+	return fib_do_redirect(ctx, true, &fib_params, false, ret, &oif, ext_err);
+}
+
+static __always_inline
+bool egress_gw_reply_needs_redirect_hook_v6(struct ipv6hdr *ip6, __u32 *tunnel_endpoint,
+					    __u32 *dst_sec_identity)
+{
+	if (egress_gw_reply_matches_policy_v6(ip6)) {
+		struct remote_endpoint_info *info;
+
+		info = lookup_ip6_remote_endpoint((union v6addr *)&ip6->daddr, 0);
+		if (!info || info->tunnel_endpoint == 0)
+			return false;
+
+		*tunnel_endpoint = info->tunnel_endpoint;
+		*dst_sec_identity = info->sec_identity;
+
+		return true;
+	}
+
+	return false;
+}
+
+static __always_inline
+int egress_gw_handle_packet_v6(struct __ctx_buff *ctx,
+			       struct ipv6_ct_tuple *tuple,
+			       __u32 src_sec_identity, __u32 dst_sec_identity,
+			       const struct trace_ctx *trace)
+{
+	struct endpoint_info *gateway_node_ep;
+	__be32 gateway_ip = 0;
+	int ret;
+
+	/* If the packet is destined to an entity inside the cluster,
+	 * either EP or node, it should not be forwarded to an egress
+	 * gateway since only traffic leaving the cluster is supposed to
+	 * be masqueraded with an egress IP.
+	 */
+	if (identity_is_cluster(dst_sec_identity))
+		return CTX_ACT_OK;
+
+	ret = egress_gw_request_needs_redirect_hook_v6(tuple, &gateway_ip);
+	if (IS_ERR(ret))
+		return ret;
+
+	if (ret == CTX_ACT_OK)
+		return ret;
+
+	/* If the gateway node is the local node, then just let the
+	 * packet go through, as it will be SNATed later on by
+	 * handle_nat_fwd().
+	 */
+	gateway_node_ep = __lookup_ip4_endpoint(gateway_ip);
+	if (gateway_node_ep && (gateway_node_ep->flags & ENDPOINT_F_HOST))
+		return CTX_ACT_OK;
+
+	/* Send the packet to egress gateway node through a tunnel. */
+	return __encap_and_redirect_with_nodeid(ctx, gateway_ip, src_sec_identity,
+						dst_sec_identity, NOT_VTEP_DST, trace);
+}
+#endif /* ENABLE_IPV6 */
 #endif /* ENABLE_EGRESS_GATEWAY_COMMON */

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -14,6 +14,16 @@
 #define EGRESS_IP2		IPV4(2, 3, 4, 5)
 #define EGRESS_IP3		IPV4(3, 3, 4, 5)
 
+/* IPv6 definitions */
+#define CLIENT_IP_V6		{ .addr = { 0x1, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+#define EXTERNAL_SVC_IP_V6	{ .addr = { 0x2, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+
+#define EGRESS_IP_V6		{ .addr = { 0x3, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+#define EGRESS_IP2_V6		{ .addr = { 0x4, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+#define EGRESS_IP3_V6		{ .addr = { 0x5, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+
+#define IPV6_SUBNET_PREFIX 64
+
 #include "egressgw_policy.h"
 
 static volatile const __u8 *client_mac  = mac_one;
@@ -271,3 +281,222 @@ static __always_inline int create_ct_entry(struct __ctx_buff *ctx, __be16 client
 	return ct_create4(get_ct_map4(&tuple), &cilium_ct_any4_global, &tuple, ctx,
 			 CT_EGRESS, &ct_state, NULL);
 }
+
+#ifdef ENABLE_IPV6
+static __always_inline int egressgw_pktgen_v6(struct __ctx_buff *ctx,
+					      struct egressgw_test_ctx test_ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+	union v6addr egress_ip3 = EGRESS_IP3_V6;
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	if (test_ctx.dir == CT_INGRESS)
+		ethhdr__set_macs(l2, (__u8 *)ext_svc_mac, (__u8 *)client_mac);
+	else /* CT_EGRESS */
+		ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)ext_svc_mac);
+
+	/* Push IPv6 header */
+	l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	if (test_ctx.dir == CT_INGRESS) {
+		ipv6_addr_copy((union v6addr *)&l3->saddr, &ext_svc_ip);
+		if (test_ctx.tuple_collision)
+			ipv6_addr_copy((union v6addr *)&l3->daddr, &egress_ip3);
+		else
+			ipv6_addr_copy((union v6addr *)&l3->daddr, &egress_ip);
+
+	} else { /* CT_EGRESS */
+		ipv6_addr_copy((union v6addr *)&l3->saddr, &client_ip);
+		ipv6_addr_copy((union v6addr *)&l3->daddr, &ext_svc_ip);
+	}
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	if (test_ctx.dir == CT_INGRESS) {
+		/* Get the destination port from the NAT entry. */
+		struct ipv6_ct_tuple tuple = {
+			.saddr   = client_ip,
+			.daddr   = ext_svc_ip,
+			.dport   = EXTERNAL_SVC_PORT,
+			.sport   = client_port(test_ctx.test),
+			.nexthdr = IPPROTO_TCP,
+		};
+		struct ipv6_nat_entry *nat_entry = __snat_lookup(&cilium_snat_v6_external, &tuple);
+
+		if (!nat_entry)
+			return TEST_ERROR;
+		l4->source = EXTERNAL_SVC_PORT;
+		l4->dest = nat_entry->to_sport;
+	} else { /* CT_EGRESS */
+		l4->source = client_port(test_ctx.test);
+		l4->dest = EXTERNAL_SVC_PORT;
+	}
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+static __always_inline int egressgw_snat_check_v6(const struct __ctx_buff *ctx,
+						  struct egressgw_test_ctx test_ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+	union v6addr egress_ip3 = EGRESS_IP3_V6;
+	void *data, *data_end;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	union v6addr expected_saddr;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	assert(*(__u32 *)data == test_ctx.status_code);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (test_ctx.dir == CT_INGRESS) {
+		if (memcmp(l2->h_source, (__u8 *)ext_svc_mac, ETH_ALEN) != 0)
+			test_fatal("src MAC is not the external svc MAC");
+
+		if (memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) != 0)
+			test_fatal("dst MAC is not the client MAC");
+
+		if (memcmp(&l3->saddr, &ext_svc_ip, sizeof(struct in6_addr)) != 0)
+			test_fatal("src IP has changed");
+
+		if (memcmp(&l3->daddr, &client_ip, sizeof(struct in6_addr)) != 0)
+			test_fatal("dst IP hasn't been revSNATed to client IP");
+	} else { /* CT_EGRESS */
+		if (test_ctx.redirect) {
+			if (memcmp(l2->h_source, (__u8 *)mac_zero, ETH_ALEN) != 0)
+				test_fatal("src MAC is not the secondary iface MAC");
+
+			if (memcmp(l2->h_dest, (__u8 *)mac_zero, ETH_ALEN) != 0)
+				test_fatal("dst MAC is not the external svc MAC");
+
+			if (memcmp(&l3->saddr, &client_ip, sizeof(struct in6_addr)) != 0)
+				test_fatal("src IP has changed before redirecting to egress iface");
+		} else {
+			if (memcmp(l2->h_source, (__u8 *)client_mac, ETH_ALEN) != 0)
+				test_fatal("src MAC is not the client MAC");
+
+			if (memcmp(l2->h_dest, (__u8 *)ext_svc_mac, ETH_ALEN) != 0)
+				test_fatal("dst MAC is not the external svc MAC");
+
+			ipv6_addr_copy((union v6addr *)&expected_saddr, &egress_ip);
+			if (test_ctx.tuple_collision)
+				ipv6_addr_copy((union v6addr *)&expected_saddr, &egress_ip3);
+
+			if (memcmp(&l3->saddr, &expected_saddr, sizeof(struct in6_addr)) != 0)
+				test_fatal("src IP hasn't been NATed to egress gateway IP");
+		}
+
+		if (memcmp(&l3->daddr, &ext_svc_ip, sizeof(struct in6_addr)) != 0)
+			test_fatal("dst IP has changed");
+	}
+
+	/* SNAT happens *after* redirect: */
+	if (!test_ctx.redirect) {
+		/* Lookup the SNAT mapping for the original packet to determine the new source port */
+		struct ipv6_ct_tuple tuple = {
+			.daddr   = client_ip,
+			.saddr   = ext_svc_ip,
+			.dport   = EXTERNAL_SVC_PORT,
+			.sport   = client_port(test_ctx.test),
+			.nexthdr = IPPROTO_TCP,
+			.flags = TUPLE_F_OUT,
+		};
+		struct ct_entry *ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+
+		if (!ct_entry)
+			test_fatal("no CT entry found");
+		if (ct_entry->packets != test_ctx.packets)
+			test_fatal("bad packet count (expected %u, actual %u)",
+				   test_ctx.packets, ct_entry->packets);
+
+		tuple.saddr = client_ip;
+		tuple.daddr = ext_svc_ip;
+
+		struct ipv6_nat_entry *nat_entry = __snat_lookup(&cilium_snat_v6_external, &tuple);
+
+		if (!nat_entry)
+			test_fatal("could not find a NAT entry for the packet");
+
+		if (test_ctx.dir == CT_INGRESS) {
+			if (l4->source != EXTERNAL_SVC_PORT)
+				test_fatal("src port has changed");
+
+			if (l4->dest != client_port(test_ctx.test))
+				test_fatal("dst TCP port hasn't been revSNATed to client port");
+		} else { /* CT_EGRESS */
+			if (l4->source != nat_entry->to_sport)
+				test_fatal("src TCP port hasn't been NATed to egress gateway port");
+
+			if (l4->dest != EXTERNAL_SVC_PORT)
+				test_fatal("dst port has changed");
+		}
+	}
+
+	test_finish();
+}
+
+static __always_inline int create_ct_entry_v6(struct __ctx_buff *ctx, __be16 client_port)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	struct ipv6_ct_tuple __align_stack_8 tuple = {};
+	struct ct_state ct_state = {};
+
+	tuple.nexthdr = IPPROTO_TCP;
+	ipv6_addr_copy((union v6addr *)&tuple.daddr, &ext_svc_ip);
+	tuple.sport = EXTERNAL_SVC_PORT;
+	ipv6_addr_copy((union v6addr *)&tuple.saddr, &client_ip);
+	tuple.dport = client_port;
+	__ipv6_ct_tuple_reverse(&tuple);
+
+	return ct_create6(get_ct_map6(&tuple), &cilium_ct_any6_global, &tuple, ctx,
+			  CT_EGRESS, &ct_state, NULL);
+}
+#endif

--- a/bpf/tests/lib/egressgw_policy.h
+++ b/bpf/tests/lib/egressgw_policy.h
@@ -29,4 +29,39 @@ static __always_inline void del_egressgw_policy_entry(__be32 saddr, __be32 daddr
 
 	map_delete_elem(&cilium_egress_gw_policy_v4, &in_key);
 }
+
+#ifdef ENABLE_IPV6
+static __always_inline void add_egressgw_policy_entry_v6(const union v6addr *saddr,
+							 const union v6addr *daddr,
+							 __u8 cidr,
+							 __be32 gateway_ip,
+							 const union v6addr *egress_ip)
+{
+	struct egress_gw_policy_key6 in_key = {
+		.lpm_key = { EGRESS_PREFIX_LEN_V6(cidr), {} },
+		.saddr   = *saddr,
+		.daddr   = *daddr,
+	};
+
+	struct egress_gw_policy_entry6 in_val = {
+		.egress_ip  = *egress_ip,
+		.gateway_ip = gateway_ip,
+	};
+
+	map_update_elem(&cilium_egress_gw_policy_v6, &in_key, &in_val, 0);
+}
+
+static __always_inline void del_egressgw_policy_entry_v6(const union v6addr *saddr,
+							 const union v6addr *daddr,
+							 __u8 cidr)
+{
+	struct egress_gw_policy_key6 in_key = {
+		.lpm_key = { EGRESS_PREFIX_LEN_V6(cidr), {} },
+		.saddr   = *saddr,
+		.daddr   = *daddr,
+	};
+
+	map_delete_elem(&cilium_egress_gw_policy_v6, &in_key);
+}
+#endif /* ENABLE_IPV6 */
 #endif /* ENABLE_EGRESS_GATEWAY */

--- a/bpf/tests/lib/egressgw_policy.h
+++ b/bpf/tests/lib/egressgw_policy.h
@@ -6,7 +6,7 @@ static __always_inline void add_egressgw_policy_entry(__be32 saddr, __be32 daddr
 						      __be32 gateway_ip, __be32 egress_ip)
 {
 	struct egress_gw_policy_key in_key = {
-		.lpm_key = { EGRESS_PREFIX_LEN(cidr), {} },
+		.lpm_key = { EGRESS_PREFIX_LEN_V4(cidr), {} },
 		.saddr   = saddr,
 		.daddr   = daddr,
 	};
@@ -22,7 +22,7 @@ static __always_inline void add_egressgw_policy_entry(__be32 saddr, __be32 daddr
 static __always_inline void del_egressgw_policy_entry(__be32 saddr, __be32 daddr, __u8 cidr)
 {
 	struct egress_gw_policy_key in_key = {
-		.lpm_key = { EGRESS_PREFIX_LEN(cidr), {} },
+		.lpm_key = { EGRESS_PREFIX_LEN_V4(cidr), {} },
 		.saddr   = saddr,
 		.daddr   = daddr,
 	};

--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -8,9 +8,11 @@
 
 /* Enable code paths under test */
 #define ENABLE_IPV4
+#define ENABLE_IPV6
 #define ENABLE_NODEPORT
 #define ENABLE_EGRESS_GATEWAY
 #define ENABLE_MASQUERADE_IPV4
+#define ENABLE_MASQUERADE_IPV6
 #define ENCAP_IFINDEX 0
 
 #include "bpf_host.c"
@@ -159,6 +161,7 @@ int egressgw_skip_no_gateway_redirect_check(const struct __ctx_buff *ctx)
 	assert(entry->count == 1);
 
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
+	map_delete_elem(&cilium_metrics, &key);
 
 	test_finish();
 }
@@ -213,6 +216,216 @@ int egressgw_drop_no_egress_ip_check(const struct __ctx_buff *ctx)
 
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
 	endpoint_v4_del_entry(GATEWAY_NODE_IP);
+	map_delete_elem(&cilium_metrics, &key);
+
+	test_finish();
+}
+
+/* Test that a packet matching an egress gateway policy on the to-netdev
+ * program gets redirected to the gateway node (IPv6).
+ */
+PKTGEN("tc", "tc_egressgw_redirect_v6")
+int egressgw_redirect_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_REDIRECT,
+	});
+}
+
+SETUP("tc", "tc_egressgw_redirect_v6")
+int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+
+	ipcache_v6_add_entry(&ext_svc_ip, 0, WORLD_IPV6_ID, 0, 0);
+	create_ct_entry_v6(ctx, client_port(TEST_REDIRECT));
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
+				     &egress_ip);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_redirect_v6")
+int egressgw_redirect_check_v6(const struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = TC_ACT_REDIRECT,
+	});
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX);
+
+	return ret;
+}
+
+/* Test that a packet matching an excluded CIDR egress gateway policy on the
+ * to-netdev program does not get redirected to the gateway node (IPv6).
+ */
+PKTGEN("tc", "tc_egressgw_skip_excluded_cidr_redirect_v6")
+int egressgw_skip_excluded_cidr_redirect_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_REDIRECT_EXCL_CIDR,
+	});
+}
+
+SETUP("tc", "tc_egressgw_skip_excluded_cidr_redirect_v6")
+int egressgw_skip_excluded_cidr_redirect_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+
+	ipcache_v6_add_entry(&ext_svc_ip, 0, WORLD_IPV6_ID, 0, 0);
+	create_ct_entry_v6(ctx, client_port(TEST_REDIRECT_EXCL_CIDR));
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
+				     &egress_ip);
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, EGRESS_GATEWAY_EXCLUDED_CIDR,
+				     &egress_ip);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_skip_excluded_cidr_redirect_v6")
+int egressgw_skip_excluded_cidr_redirect_check_v6(const struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = TC_ACT_OK,
+	});
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX);
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128);
+
+	return ret;
+}
+
+/* Test that a packet matching an egress gateway policy without a gateway on the
+ * to-netdev program does not get redirected to the gateway node (IPv6).
+ */
+PKTGEN("tc", "tc_egressgw_skip_no_gateway_redirect_v6")
+int egressgw_skip_no_gateway_redirect_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_REDIRECT_SKIP_NO_GATEWAY,
+	});
+}
+
+SETUP("tc", "tc_egressgw_skip_no_gateway_redirect_v6")
+int egressgw_skip_no_gateway_redirect_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+
+	ipcache_v6_add_entry(&ext_svc_ip, 0, WORLD_IPV6_ID, 0, 0);
+	create_ct_entry_v6(ctx, client_port(TEST_REDIRECT_SKIP_NO_GATEWAY));
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, EGRESS_GATEWAY_NO_GATEWAY,
+				     &egress_ip);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_skip_no_gateway_redirect_v6")
+int egressgw_skip_no_gateway_redirect_check_v6(const struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	struct metrics_value *entry = NULL;
+	struct metrics_key key = {};
+
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = CTX_ACT_DROP,
+	});
+	if (ret != TEST_PASS)
+		return ret;
+
+	test_init();
+
+	key.reason = (__u8)-DROP_NO_EGRESS_GATEWAY;
+	key.dir = METRIC_EGRESS;
+	entry = map_lookup_elem(&cilium_metrics, &key);
+	if (!entry)
+		test_fatal("metrics entry not found");
+	assert(entry->count == 1);
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128);
+	map_delete_elem(&cilium_metrics, &key);
+
+	test_finish();
+}
+
+/* Test that a packet matching an egress gateway policy without an egressIP on the
+ * to-netdev program gets dropped (IPv6).
+ */
+PKTGEN("tc", "tc_egressgw_drop_no_egress_ip_v6")
+int egressgw_drop_no_egress_ip_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_DROP_NO_EGRESS_IP,
+	});
+}
+
+SETUP("tc", "tc_egressgw_drop_no_egress_ip_v6")
+int egressgw_drop_no_egress_ip_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	ipcache_v6_add_entry(&ext_svc_ip, 0, WORLD_IPV6_ID, 0, 0);
+	endpoint_v4_add_entry(GATEWAY_NODE_IP, 0, 0, ENDPOINT_F_HOST, 0, 0, NULL, NULL);
+
+	create_ct_entry_v6(ctx, client_port(TEST_DROP_NO_EGRESS_IP));
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, GATEWAY_NODE_IP,
+				     &EGRESS_GATEWAY_NO_EGRESS_IP_V6);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_drop_no_egress_ip_v6")
+int egressgw_drop_no_egress_ip_check_v6(const struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	struct metrics_value *entry = NULL;
+	struct metrics_key key = {};
+
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = CTX_ACT_DROP,
+	});
+	if (ret != TEST_PASS)
+		return ret;
+
+	test_init();
+
+	key.reason = (__u8)-DROP_NO_EGRESS_IP;
+	key.dir = METRIC_EGRESS;
+	entry = map_lookup_elem(&cilium_metrics, &key);
+	if (!entry)
+		test_fatal("metrics entry not found");
+	assert(entry->count == 1);
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128);
+	endpoint_v4_del_entry(GATEWAY_NODE_IP);
+	map_delete_elem(&cilium_metrics, &key);
 
 	test_finish();
 }

--- a/bpf/tests/tc_egressgw_redirect_from_overlay.c
+++ b/bpf/tests/tc_egressgw_redirect_from_overlay.c
@@ -8,9 +8,11 @@
 
 /* Enable code paths under test */
 #define ENABLE_IPV4
+#define ENABLE_IPV6
 #define ENABLE_NODEPORT
 #define ENABLE_EGRESS_GATEWAY
 #define ENABLE_MASQUERADE_IPV4
+#define ENABLE_MASQUERADE_IPV6
 #define ENCAP_IFINDEX	42
 #define IFACE_IFINDEX	44
 
@@ -212,6 +214,178 @@ int egressgw_drop_no_egress_ip_check(const struct __ctx_buff *ctx)
 	});
 
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
+
+	return ret;
+}
+
+/* Test that a packet matching an egress gateway policy on the from-overlay program
+ * gets correctly redirected to the target netdev for IPv6.
+ */
+PKTGEN("tc", "tc_egressgw_redirect_from_overlay_v6")
+int egressgw_redirect_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_REDIRECT,
+			.redirect = true,
+		});
+}
+
+SETUP("tc", "tc_egressgw_redirect_from_overlay_v6")
+int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
+				     &egress_ip);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_redirect_from_overlay_v6")
+int egressgw_redirect_check_v6(const struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = TC_ACT_REDIRECT,
+	});
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX);
+
+	return ret;
+}
+
+/* Test that a packet matching an excluded CIDR egress gateway policy on the
+ * from-overlay program does not get redirected to the target netdev.
+ */
+PKTGEN("tc", "tc_egressgw_skip_excluded_cidr_redirect_from_overlay_v6")
+int egressgw_skip_excluded_cidr_redirect_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_REDIRECT_EXCL_CIDR,
+		});
+}
+
+SETUP("tc", "tc_egressgw_skip_excluded_cidr_redirect_from_overlay_v6")
+int egressgw_skip_excluded_cidr_redirect_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
+				     &egress_ip);
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, EGRESS_GATEWAY_EXCLUDED_CIDR,
+				     &egress_ip);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_skip_excluded_cidr_redirect_from_overlay_v6")
+int egressgw_skip_excluded_cidr_redirect_check_v6(const struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = TC_ACT_OK,
+	});
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX);
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128);
+
+	return ret;
+}
+
+/* Test that a packet matching an egress gateway policy without a gateway on the
+ * from-overlay program does not get redirected to the target netdev.
+ */
+PKTGEN("tc", "tc_egressgw_skip_no_gateway_redirect_from_overlay_v6")
+int egressgw_skip_no_gateway_redirect_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_REDIRECT_SKIP_NO_GATEWAY,
+		});
+}
+
+SETUP("tc", "tc_egressgw_skip_no_gateway_redirect_from_overlay_v6")
+int egressgw_skip_no_gateway_redirect_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, EGRESS_GATEWAY_NO_GATEWAY,
+				     &egress_ip);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_skip_no_gateway_redirect_from_overlay_v6")
+int egressgw_skip_no_gateway_redirect_check_v6(const struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = TC_ACT_OK,
+	});
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128);
+
+	return ret;
+}
+
+/* Test that a packet matching an egress gateway policy without an egressIP on the
+ * from-overlay program gets dropped.
+ */
+PKTGEN("tc", "tc_egressgw_drop_no_egress_ip_from_overlay_v6")
+int egressgw_drop_no_egress_ip_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_DROP_NO_EGRESS_IP,
+		});
+}
+
+SETUP("tc", "tc_egressgw_drop_no_egress_ip_from_overlay_v6")
+int egressgw_drop_no_egress_ip_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr no_egress_ip = EGRESS_GATEWAY_NO_EGRESS_IP_V6;
+
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, GATEWAY_NODE_IP,
+				     &no_egress_ip);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_drop_no_egress_ip_from_overlay_v6")
+int egressgw_drop_no_egress_ip_check_v6(const struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = CTX_ACT_DROP,
+	});
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128);
 
 	return ret;
 }

--- a/bpf/tests/tc_egressgw_redirect_from_overlay_with_egress_interface.c
+++ b/bpf/tests/tc_egressgw_redirect_from_overlay_with_egress_interface.c
@@ -10,9 +10,11 @@
 #define HAVE_FIB_NEIGH	1
 
 #define ENABLE_IPV4
+#define ENABLE_IPV6
 #define ENABLE_NODEPORT
 #define ENABLE_EGRESS_GATEWAY
 #define ENABLE_MASQUERADE_IPV4
+#define ENABLE_MASQUERADE_IPV6
 #define ENCAP_IFINDEX	42
 #define IFACE_IFINDEX	44
 
@@ -104,6 +106,49 @@ int egressgw_redirect_check(const struct __ctx_buff *ctx)
 	});
 
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24);
+
+	return ret;
+}
+
+/* Test that a packet matching an egress gateway policy on the from-overlay program
+ * gets correctly redirected to the target netdev for IPv6.
+ */
+PKTGEN("tc", "tc_egressgw_redirect_from_overlay_with_egress_interface_v6")
+int egressgw_redirect_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_REDIRECT,
+			.redirect = true,
+		});
+}
+
+SETUP("tc", "tc_egressgw_redirect_from_overlay_with_egress_interface_v6")
+int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
+				     &egress_ip);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_OVERLAY);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_redirect_from_overlay_with_egress_interface_v6")
+int egressgw_redirect_check_v6(const struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = TC_ACT_REDIRECT,
+	});
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX);
 
 	return ret;
 }

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -8,9 +8,11 @@
 
 /* Enable code paths under test */
 #define ENABLE_IPV4
+#define ENABLE_IPV6
 #define ENABLE_NODEPORT
 #define ENABLE_EGRESS_GATEWAY
 #define ENABLE_MASQUERADE_IPV4
+#define ENABLE_MASQUERADE_IPV6
 #define ENCAP_IFINDEX		42
 #define SECONDARY_IFACE_IFINDEX	44
 
@@ -47,8 +49,15 @@ static __always_inline __maybe_unused long
 mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_unused,
 		int plen __maybe_unused, __u32 flags __maybe_unused)
 {
-	if (params && params->ipv4_src == EGRESS_IP2)
-		params->ifindex = SECONDARY_IFACE_IFINDEX;
+	union v6addr egress_ip = EGRESS_IP2_V6;
+
+	if (params) {
+		if (params->ipv4_src == EGRESS_IP2)
+			params->ifindex = SECONDARY_IFACE_IFINDEX;
+
+		if (memcmp(&params->ipv6_src, &egress_ip, sizeof(union v6addr)) == 0)
+			params->ifindex = SECONDARY_IFACE_IFINDEX;
+	}
 
 	return 0;
 }
@@ -401,3 +410,371 @@ int egressgw_fib_redirect_check(const struct __ctx_buff *ctx __maybe_unused)
 	return ret;
 }
 
+/* Test that a packet matching an egress gateway policy on the to-netdev program
+ * gets correctly SNATed with the egress IP of the policy (IPv6).
+ */
+PKTGEN("tc", "tc_v6_egressgw_snat1")
+int egressgw_snat1_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT1,
+		});
+}
+
+SETUP("tc", "tc_v6_egressgw_snat1")
+int egressgw_snat1_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
+				     &egress_ip);
+
+	/* Jump into the entrypoint */
+	ctx_egw_done_set(ctx);
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_v6_egressgw_snat1")
+int egressgw_snat1_check_v6(const struct __ctx_buff *ctx)
+{
+	return egressgw_snat_check_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT1,
+			.packets = 1,
+			.status_code = CTX_ACT_OK
+		});
+}
+
+/* Test that a packet matching an egress gateway policy on the from-netdev program
+ * gets correctly revSNATed and connection tracked (IPv6).
+ */
+PKTGEN("tc", "tc_v6_egressgw_snat1_2_reply")
+int egressgw_snat1_2_reply_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT1,
+			.dir = CT_INGRESS,
+		});
+}
+
+SETUP("tc", "tc_v6_egressgw_snat1_2_reply")
+int egressgw_snat1_2_reply_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	/* install ipcache entry for the CLIENT_IP: */
+	ipcache_v6_add_entry(&client_ip, 0, 0, CLIENT_NODE_IP, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_v6_egressgw_snat1_2_reply")
+int egressgw_snat1_2_reply_check_v6(const struct __ctx_buff *ctx)
+{
+	return egressgw_snat_check_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT1,
+			.dir = CT_INGRESS,
+			.packets = 2,
+			.status_code = CTX_ACT_REDIRECT,
+		});
+}
+
+PKTGEN("tc", "tc_v6_egressgw_snat2")
+int egressgw_snat2_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT2,
+		});
+}
+
+SETUP("tc", "tc_v6_egressgw_snat2")
+int egressgw_snat2_setup_v6(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	ctx_egw_done_set(ctx);
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_v6_egressgw_snat2")
+int egressgw_snat2_check_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	int ret = egressgw_snat_check_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT2,
+			.packets = 1,
+			.status_code = CTX_ACT_OK
+		});
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX);
+
+	return ret;
+}
+
+/* Test that a packet matching an egress gateway policy on the to-netdev program
+ * gets correctly SNATed with the desired egress IP of the policy, even if the
+ * packet hits a stale NAT entry (IPv6).
+ */
+PKTGEN("tc", "tc_v6_egressgw_tuple_collision1")
+int egressgw_tuple_collision1_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+		});
+}
+
+SETUP("tc", "tc_v6_egressgw_tuple_collision1")
+int egressgw_tuple_collision1_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
+				     &egress_ip);
+
+	/* Jump into the entrypoint */
+	ctx_egw_done_set(ctx);
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_v6_egressgw_tuple_collision1")
+int egressgw_tuple_collision1_check_v6(const struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	int ret = egressgw_snat_check_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+			.packets = 1,
+			.status_code = CTX_ACT_OK
+		});
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX);
+
+	return ret;
+}
+
+PKTGEN("tc", "tc_v6_egressgw_tuple_collision2")
+int egressgw_tuple_collision2_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+		});
+}
+
+SETUP("tc", "tc_v6_egressgw_tuple_collision2")
+int egressgw_tuple_collision2_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP3_V6;
+
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
+				     &egress_ip);
+
+	/* Jump into the entrypoint */
+	ctx_egw_done_set(ctx);
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_v6_egressgw_tuple_collision2")
+int egressgw_tuple_collision2_check_v6(const struct __ctx_buff *ctx)
+{
+	return egressgw_snat_check_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+			.tuple_collision = true,
+			.packets = 2,
+			.status_code = CTX_ACT_OK
+		});
+}
+
+/* Test that a packet matching an egress gateway policy on the from-netdev program
+ * gets correctly revSNATed and connection tracked, even if the packet hits a
+ * stale NAT entry (IPv6).
+ */
+PKTGEN("tc", "tc_v6_egressgw_tuple_collision2_reply")
+int egressgw_tuple_collision2_reply_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+			.tuple_collision = true,
+			.dir = CT_INGRESS,
+		});
+}
+
+SETUP("tc", "tc_v6_egressgw_tuple_collision2_reply")
+int egressgw_tuple_collision2_reply_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	/* install ipcache entry for the CLIENT_IP: */
+	ipcache_v6_add_entry(&client_ip, 0, 0, CLIENT_NODE_IP, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_v6_egressgw_tuple_collision2_reply")
+int egressgw_tuple_collision2_reply_check_v6(const struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	int ret = egressgw_snat_check_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_TUPLE_COLLISION,
+			.dir = CT_INGRESS,
+			.packets = 3,
+			.status_code = CTX_ACT_REDIRECT,
+		});
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX);
+
+	return ret;
+}
+
+/* Test that a packet matching an excluded CIDR egress gateway policy on the
+ * to-netdev program does not get SNATed with the egress IP of the policy (IPv6).
+ */
+PKTGEN("tc", "tc_v6_egressgw_skip_excluded_cidr_snat")
+int egressgw_skip_excluded_cidr_snat_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT_EXCL_CIDR,
+		});
+}
+
+SETUP("tc", "tc_v6_egressgw_skip_excluded_cidr_snat")
+int egressgw_skip_excluded_cidr_snat_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
+				     &EGRESS_GATEWAY_NO_EGRESS_IP_V6);
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, EGRESS_GATEWAY_EXCLUDED_CIDR,
+				     &EGRESS_GATEWAY_NO_EGRESS_IP_V6);
+
+	/* Jump into the entrypoint */
+	ctx_egw_done_set(ctx);
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_v6_egressgw_skip_excluded_cidr_snat")
+int egressgw_skip_excluded_cidr_snat_check_v6(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	test_init();
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128);
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)client_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the client MAC");
+
+	if (memcmp(l2->h_dest, (__u8 *)ext_svc_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the external svc MAC");
+
+	if (memcmp(&l3->saddr, &client_ip, sizeof(union v6addr)) != 0)
+		test_fatal("src IP has changed");
+
+	if (memcmp(&l3->daddr, &ext_svc_ip, sizeof(union v6addr)) != 0)
+		test_fatal("dst IP has changed");
+
+	if (l4->source != client_port(TEST_SNAT_EXCL_CIDR))
+		test_fatal("src TCP port has changed");
+
+	if (l4->dest != EXTERNAL_SVC_PORT)
+		test_fatal("dst port has changed");
+
+	test_finish();
+}
+
+/* Test FIB lookup based redirect functionality (IPv6) */
+PKTGEN("tc", "tc_v6_egressgw_fib_redirect")
+int egressgw_fib_redirect_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_FIB,
+			.redirect = true,
+		});
+}
+
+SETUP("tc", "tc_v6_egressgw_fib_redirect")
+int egressgw_fib_redirect_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP2_V6;
+
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
+				     &egress_ip);
+
+	/* Jump into the entrypoint */
+	ctx_egw_done_set(ctx);
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_v6_egressgw_fib_redirect")
+int egressgw_fib_redirect_check_v6(const struct __ctx_buff *ctx __maybe_unused)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	int ret = egressgw_snat_check_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_FIB,
+			.redirect = true,
+			.packets = 1,
+			.status_code = CTX_ACT_REDIRECT,
+		});
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX);
+
+	return ret;
+}

--- a/bpf/tests/xdp_egressgw_reply.c
+++ b/bpf/tests/xdp_egressgw_reply.c
@@ -8,6 +8,7 @@
 
 /* Enable code paths under test */
 #define ENABLE_IPV4
+#define ENABLE_IPV6
 #define ENABLE_NODEPORT
 #define ENABLE_NODEPORT_ACCELERATION
 
@@ -236,6 +237,175 @@ int egressgw_reply_check(__maybe_unused const struct __ctx_buff *ctx)
 		test_fatal("innerDstPort hasn't been revNATed to client port");
 
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24);
+
+	test_finish();
+}
+
+/* Test that a EgressGW reply gets RevSNATed, and forwarded to the
+ * worker node via tunnel (IPv6).
+ */
+PKTGEN("xdp", "xdp_egressgw_reply_v6")
+int egressgw_reply_pktgen_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+
+	/* Add a new NAT entry so that pktgen can figure out the correct destination port */
+	struct ipv6_ct_tuple __align_stack_8 tuple = {
+		.nexthdr = IPPROTO_TCP,
+		.dport   = EXTERNAL_SVC_PORT,
+		.sport   = client_port(TEST_XDP_REPLY),
+	};
+	ipv6_addr_copy(&tuple.saddr, &client_ip);
+	ipv6_addr_copy(&tuple.daddr, &ext_svc_ip);
+
+	struct ipv6_nat_entry nat_entry = {
+		.to_sport = MASQ_PORT,
+	};
+	ipv6_addr_copy(&nat_entry.to_saddr, &egress_ip);
+
+	map_update_elem(&cilium_snat_v6_external, &tuple, &nat_entry, BPF_ANY);
+
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_XDP_REPLY,
+			.dir = CT_INGRESS,
+		});
+}
+
+SETUP("xdp", "xdp_egressgw_reply_v6")
+int egressgw_reply_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+
+	/* install EgressGW policy for the connection: */
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
+				     &EGRESS_GATEWAY_NO_EGRESS_IP_V6);
+
+	/* install RevSNAT entry */
+	struct ipv6_ct_tuple snat_tuple = {
+		.nexthdr = IPPROTO_TCP,
+		.dport   = MASQ_PORT,
+		.sport   = EXTERNAL_SVC_PORT,
+		.flags   = NAT_DIR_INGRESS,
+	};
+	ipv6_addr_copy(&snat_tuple.daddr, &egress_ip);
+	ipv6_addr_copy(&snat_tuple.saddr, &ext_svc_ip);
+
+	struct ipv6_nat_entry snat_entry = {
+		.to_dport = client_port(TEST_XDP_REPLY),
+	};
+	ipv6_addr_copy(&snat_entry.to_daddr, &client_ip);
+
+	map_update_elem(&cilium_snat_v6_external, &snat_tuple, &snat_entry, BPF_ANY);
+
+	/* install ipcache entry for the CLIENT_IP: */
+	ipcache_v6_add_entry(&client_ip, 0, 0, CLIENT_NODE_IP, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("xdp", "xdp_egressgw_reply_v6")
+int egressgw_reply_check_v6(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *inner_l4;
+	struct udphdr *l4;
+	struct ethhdr *l2, *inner_l2;
+	struct ipv6hdr *inner_l3;
+	struct iphdr *l3;
+	struct vxlanhdr *vxlan;
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(*l2) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(*l2);
+	if ((void *)l3 + sizeof(*l3) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(*l3);
+	if ((void *)l4 + sizeof(*l4) > data_end)
+		test_fatal("l4 out of bounds");
+
+	vxlan = (void *)l4 + sizeof(*l4);
+	if ((void *)vxlan + sizeof(*vxlan) > data_end)
+		test_fatal("vxlan out of bounds");
+
+	inner_l2 = (void *)vxlan + sizeof(*vxlan);
+	if ((void *)inner_l2 + sizeof(*inner_l2) > data_end)
+		test_fatal("inner l2 out of bounds");
+
+	inner_l3 = (void *)inner_l2 + sizeof(*inner_l2);
+	if ((void *)inner_l3 + sizeof(*inner_l3) > data_end)
+		test_fatal("inner l3 out of bounds");
+
+	inner_l4 = (void *)inner_l3 + sizeof(*inner_l3);
+	if ((void *)inner_l4 + sizeof(*inner_l4) > data_end)
+		test_fatal("inner l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)gateway_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the gateway MAC")
+	if (memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the client node MAC")
+
+	if (l2->h_proto != bpf_htons(ETH_P_IP))
+		test_fatal("l2 doesn't have correct proto type")
+
+	if (l3->protocol != IPPROTO_UDP)
+		test_fatal("outer IP doesn't have correct L4 protocol")
+
+	if (l3->check != bpf_htons(0x526a))
+		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+
+	if (l3->saddr != IPV4_DIRECT_ROUTING)
+		test_fatal("outerSrcIP is not correct")
+
+	if (l3->daddr != CLIENT_NODE_IP)
+		test_fatal("outerDstIP is not correct")
+
+	if (l4->dest != bpf_htons(TUNNEL_PORT))
+		test_fatal("outerDstPort is not tunnel port")
+
+	if (inner_l2->h_proto != bpf_htons(ETH_P_IPV6))
+		test_fatal("inner L2 doesn't have correct ethertype")
+
+	if (inner_l3->nexthdr != IPPROTO_TCP)
+		test_fatal("inner IP doesn't have correct L4 protocol")
+
+	if (memcmp(&inner_l3->saddr, &ext_svc_ip, sizeof(union v6addr)) != 0)
+		test_fatal("innerSrcIP is not the external SVC IP");
+
+	if (memcmp(&inner_l3->daddr, &client_ip, sizeof(union v6addr)) != 0)
+		test_fatal("innerDstIP hasn't been revNATed to the client IP");
+
+	if (inner_l4->source != EXTERNAL_SVC_PORT)
+		test_fatal("innerSrcPort is not the external SVC port");
+
+	if (inner_l4->dest != client_port(TEST_XDP_REPLY))
+		test_fatal("innerDstPort hasn't been revNATed to client port");
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX);
 
 	test_finish();
 }


### PR DESCRIPTION
This PR enables ipv6 egressgateway policies at the datapath level, ensuring that IPv6 traffic can be matched when respective policies are in place. It should be noted that intra cluster traffic that needs to be redirected to the correct gateway node, is still going through an IPv4 tunnel.

Apart from that, all the newly IPv6 related changes in this commit should be akin to the already existing code paths that provide the egressgateway functionality for IPv4 traffic.

It also adds the same tests as we currently have for ipv4 policies.
