### PR TITLE
egressgw: optimize removal of unused egress rules

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
@@ -116,10 +117,6 @@ type Manager struct {
 	// policyConfigs stores policy configs indexed by policyID
 	policyConfigs map[policyID]*PolicyConfig
 
-	// policyConfigsBySourceIP stores slices of policy configs indexed by
-	// the policies' source/endpoint IPs
-	policyConfigsBySourceIP map[string][]*PolicyConfig
-
 	// epDataStore stores endpointId to endpoint metadata mapping
 	epDataStore map[endpointID]*endpointMetadata
 
@@ -207,7 +204,6 @@ func NewEgressGatewayManager(p Params) (out struct {
 func newEgressGatewayManager(p Params) (*Manager, error) {
 	manager := &Manager{
 		policyConfigs:                 make(map[policyID]*PolicyConfig),
-		policyConfigsBySourceIP:       make(map[string][]*PolicyConfig),
 		epDataStore:                   make(map[endpointID]*endpointMetadata),
 		identityAllocator:             p.IdentityAllocator,
 		reconciliationTriggerInterval: p.Config.EgressGatewayReconciliationTriggerInterval,
@@ -547,64 +543,6 @@ func (manager *Manager) updatePoliciesMatchedEndpointIDs() {
 	}
 }
 
-func (manager *Manager) updatePoliciesBySourceIP() {
-	manager.policyConfigsBySourceIP = make(map[string][]*PolicyConfig)
-
-	for _, policy := range manager.policyConfigs {
-		for _, ep := range policy.matchedEndpoints {
-			for _, epIP := range ep.ips {
-				ip := epIP.String()
-				manager.policyConfigsBySourceIP[ip] = append(manager.policyConfigsBySourceIP[ip], policy)
-			}
-		}
-	}
-}
-
-// policyMatches returns true if there exists at least one policy matching the
-// given parameters.
-//
-// This method takes:
-//   - a source IP: this is an optimization that allows to iterate only through
-//     policies that reference an endpoint with the given source IP
-//   - a callback function f: this function is invoked for each policy and for
-//     each combination of the policy's endpoints and destination/excludedCIDRs.
-//
-// The callback f takes as arguments:
-// - the given endpoint
-// - the destination CIDR
-// - a boolean value indicating if the CIDR belongs to the excluded ones
-// - the gatewayConfig of the  policy
-//
-// This method returns true whenever the f callback matches one of the endpoint
-// and CIDR tuples (i.e. whenever one callback invocation returns true)
-func (manager *Manager) policyMatches(sourceIP netip.Addr, f func(netip.Addr, netip.Prefix, bool, *gatewayConfig) bool) bool {
-	for _, policy := range manager.policyConfigsBySourceIP[sourceIP.String()] {
-		for _, ep := range policy.matchedEndpoints {
-			for _, endpointIP := range ep.ips {
-				if endpointIP != sourceIP {
-					continue
-				}
-
-				isExcludedCIDR := false
-				for _, dstCIDR := range policy.dstCIDRs {
-					if f(endpointIP, dstCIDR, isExcludedCIDR, &policy.gatewayConfig) {
-						return true
-					}
-				}
-
-				isExcludedCIDR = true
-				for _, excludedCIDR := range policy.excludedCIDRs {
-					if f(endpointIP, excludedCIDR, isExcludedCIDR, &policy.gatewayConfig) {
-						return true
-					}
-				}
-			}
-		}
-	}
-
-	return false
-}
-
 func (manager *Manager) regenerateGatewayConfigs() {
 	for _, policyConfig := range manager.policyConfigs {
 		policyConfig.regenerateGatewayConfig(manager)
@@ -638,15 +576,25 @@ func (manager *Manager) relaxRPFilter() error {
 	return manager.sysctl.ApplySettings(sysSettings)
 }
 
-func (manager *Manager) addMissingEgressRules() {
+func (manager *Manager) updateEgressRules() {
 	egressPolicies := map[egressmap.EgressPolicyKey4]egressmap.EgressPolicyVal4{}
 	manager.policyMap.IterateWithCallback(
 		func(key *egressmap.EgressPolicyKey4, val *egressmap.EgressPolicyVal4) {
 			egressPolicies[*key] = *val
 		})
 
+	// Start with the assumption that all the entries currently present in the
+	// BPF map are stale. Then as we walk the entries below and discover which
+	// entries are actually still needed, shrink this set down.
+	stale := sets.KeySet(egressPolicies)
+
 	addEgressRule := func(endpointIP netip.Addr, dstCIDR netip.Prefix, excludedCIDR bool, gwc *gatewayConfig) {
 		policyKey := egressmap.NewEgressPolicyKey4(endpointIP, dstCIDR)
+
+		// This key needs to be present in the BPF map, hence remove it from
+		// the list of stale ones.
+		stale.Delete(policyKey)
+
 		policyVal, policyPresent := egressPolicies[policyKey]
 
 		gatewayIP := gwc.gatewayIP
@@ -675,36 +623,12 @@ func (manager *Manager) addMissingEgressRules() {
 	for _, policyConfig := range manager.policyConfigs {
 		policyConfig.forEachEndpointAndCIDR(addEgressRule)
 	}
-}
 
-// removeUnusedEgressRules is responsible for removing any entry in the egress policy BPF map which
-// is not baked by an actual k8s CiliumEgressGatewayPolicy.
-func (manager *Manager) removeUnusedEgressRules() {
-	egressPolicies := map[egressmap.EgressPolicyKey4]egressmap.EgressPolicyVal4{}
-	manager.policyMap.IterateWithCallback(
-		func(key *egressmap.EgressPolicyKey4, val *egressmap.EgressPolicyVal4) {
-			egressPolicies[*key] = *val
-		})
-
-	for policyKey, policyVal := range egressPolicies {
-		matchPolicy := func(endpointIP netip.Addr, dstCIDR netip.Prefix, excludedCIDR bool, gwc *gatewayConfig) bool {
-			gatewayIP := gwc.gatewayIP
-			if excludedCIDR {
-				gatewayIP = ExcludedCIDRIPv4
-			}
-
-			return policyKey.Match(endpointIP, dstCIDR) && policyVal.Match(gwc.egressIP, gatewayIP)
-		}
-
-		if manager.policyMatches(policyKey.GetSourceIP(), matchPolicy) {
-			continue
-		}
-
+	// Remove all the entries marked as stale.
+	for policyKey := range stale {
 		logger := log.WithFields(logrus.Fields{
 			logfields.SourceIP:        policyKey.GetSourceIP(),
 			logfields.DestinationCIDR: policyKey.GetDestCIDR().String(),
-			logfields.EgressIP:        policyVal.GetEgressAddr(),
-			logfields.GatewayIP:       policyVal.GetGatewayAddr(),
 		})
 
 		if err := manager.policyMap.Delete(policyKey.GetSourceIP(), policyKey.GetDestCIDR()); err != nil {
@@ -731,9 +655,6 @@ func (manager *Manager) reconcileLocked() {
 	// initial k8s sync
 	case manager.eventBitmapIsSet(eventUpdateEndpoint, eventDeleteEndpoint, eventUpdateNode, eventDeleteNode, eventK8sSyncDone):
 		manager.updatePoliciesMatchedEndpointIDs()
-		fallthrough
-	case manager.eventBitmapIsSet(eventAddPolicy, eventDeletePolicy):
-		manager.updatePoliciesBySourceIP()
 	}
 
 	if manager.eventBitmapIsSet(eventK8sSyncDone, eventAddPolicy, eventDeletePolicy, eventUpdateNode, eventDeleteNode) {
@@ -754,10 +675,8 @@ func (manager *Manager) reconcileLocked() {
 		}
 	}
 
-	// The order of the next 2 function calls matters, as by first adding missing policies and
-	// only then removing obsolete ones we make sure there will be no connectivity disruption
-	manager.addMissingEgressRules()
-	manager.removeUnusedEgressRules()
+	// Update the content of the BPF map.
+	manager.updateEgressRules()
 
 	// clear the events bitmap
 	manager.eventsBitmap = 0


### PR DESCRIPTION
The logic currently in charge of removing stale egress rules does not scale well when the number of endpoints matched by any policy grows. Indeed, given E endpoints, P policies matching the endpoints, each targeting C destination CIDRs (including excluded CIDRs), every `removeUnsuedEgressRules` run would iterate over all policy entries (E*P*C), then for each iterate again over all policies, endpoints and CIDRs; hence, leading to a number of operations quadratic to E*P*C.

Yet, at that point, we already know the list of stale map keys, given that it can be easily computed during the addition phase keeping track of the keys that would not have been inserted. Hence, let's rework the removal logic to benefit from that previous knowledge, so that we don't need to perform any additional computation, but directly remove the keys known to be stale. Overall, this also allows to simplify the overall logic a bit, entirely dropping `policyConfigsBySourceIP` tracking, given that it is no longer needed.

Discovered during egress gateway scale testing, which aims to measure the time before a new pod gets its traffic correctly redirected to the egress gateway and masqueraded. In a scenario with 100 pods + 2K synthetic endpoints, each matched by 6 egress gateway policies, the results for other 100 newly created pods are the following (note that up to 1 second delay is expected considering that it corresponds to the trigger interval).

#### Without this patch

```
        "EGW Masquerade Delay - 50th Percentile": 11.926918787,
        "EGW Masquerade Delay - 90th Percentile": 24.471527239700066,
        "EGW Masquerade Delay - 95th Percentile": 31.30789182765,
        "EGW Masquerade Delay - 99th Percentile": 31.55164688042

        "Avg CPU usage - Perc50": 0.23352574915458935,
        "Avg CPU usage - Perc90": 0.23897826086956522,
        "Avg CPU usage - Perc99": 0.24015869565217393
```

![image](https://github.com/user-attachments/assets/bb51fd0f-9322-45f8-a8be-666110ea1e93)


#### With this patch

```
        "EGW Masquerade Delay - 50th Percentile": 0.003005267,
        "EGW Masquerade Delay - 90th Percentile": 0.40100311060000005,
        "EGW Masquerade Delay - 95th Percentile": 0.5544691593499999,
        "EGW Masquerade Delay - 99th Percentile": 0.7549358789900017

        "Avg CPU usage - Perc50": 0.0635144927536232,
        "Avg CPU usage - Perc90": 0.08240374009661836,
        "Avg CPU usage - Perc99": 0.09625406270531402
```

![image](https://github.com/user-attachments/assets/85c123fe-5347-4509-81e4-963034c14c6d)

<!-- Description of change -->

```release-note
Significantly improve processing of egress gateway policies matching a large number of pods
```
