### PR TITLE
cilium-cli/sysdump: relax extra-label-selectors to target all namespaces

### DIFF
--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -1632,7 +1632,7 @@ func (c *Collector) Run() error {
 			Description:     fmt.Sprintf("Collecting logs from extra pods %q", selector),
 			Quick:           false,
 			Task: func(ctx context.Context) error {
-				p, err := c.Client.ListPods(ctx, c.Options.CiliumNamespace, metav1.ListOptions{
+				p, err := c.Client.ListPods(ctx, metav1.NamespaceAll, metav1.ListOptions{
 					LabelSelector: selector,
 				})
 				if err != nil {


### PR DESCRIPTION
The --extra-label-selectors flag allows to select extra pods to scrape the corresponding logs. However, the pods currently need to be inside the same namespace where Cilium is installed (typically kube-system). Relax this by letting the selectors match pods in any namespace, so that it is possible to includes logs of arbitrary components where necessary.