### PR TITLE
Standardize hubble and cilium CLIs makefile

### DIFF
--- a/cilium-cli/Makefile
+++ b/cilium-cli/Makefile
@@ -2,25 +2,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
 include ../Makefile.defs
-GO_BUILD = CGO_ENABLED=0 $(GO) build
-GO_TAGS ?=
+
 TARGET=cilium
+
+all: $(TARGET)
+
+.PHONY: all $(TARGET) local-release install clean test bench clean-tags tags
+
+
 BINDIR = /usr/local/bin
 CLI_VERSION=$(shell git describe --tags --always)
 CLI_MAIN_DIR?=./cmd/cilium
-STRIP_DEBUG=-w -s
-ifdef DEBUG
-	STRIP_DEBUG=
-endif
-GO_BUILD_LDFLAGS = $(STRIP_DEBUG) \
-	-X 'github.com/cilium/cilium/cilium-cli/defaults.CLIVersion=$(CLI_VERSION)'
+GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/cilium-cli/defaults.CLIVersion=$(CLI_VERSION)"
+
+# Kept for bakwards compatibility with previous usage of GO_TAGS
+GO_TAGS_FLAGS += $(GO_TAGS)
 
 TEST_TIMEOUT ?= 5s
 
 $(TARGET):
-	$(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) \
-		-ldflags "$(GO_BUILD_LDFLAGS)" \
-		-o $(TARGET) \
+	$(GO_BUILD) \
+		-o $(@) \
 		$(CLI_MAIN_DIR)
 
 local-release: clean
@@ -43,8 +45,7 @@ local-release: clean
 		for ARCH in $$ARCHS; do \
 			echo Building release binary for $$OS/$$ARCH...; \
 			test -d release/$$OS/$$ARCH|| mkdir -p release/$$OS/$$ARCH; \
-			env GOOS=$$OS GOARCH=$$ARCH $(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) \
-				-ldflags "$(GO_BUILD_LDFLAGS)" \
+			env GOOS=$$OS GOARCH=$$ARCH $(GO_BUILD) \
 				-o release/$$OS/$$ARCH/$(TARGET)$$EXT $(CLI_MAIN_DIR); \
 			if [ $$OS = "windows" ]; \
 			then \
@@ -67,10 +68,10 @@ clean:
 	rm -rf ./release
 
 test:
-	$(GO) test -timeout=$(TEST_TIMEOUT) -race -cover $$($(GO) list ./...)
+	$(GO_TEST) -timeout=$(TEST_TIMEOUT) -race -cover $$($(GO) list ./...)
 
 bench:
-	$(GO) test -timeout=30s -bench=. $$($(GO) list ./...)
+	$(GO_TEST) -timeout=30s -bench=. $$($(GO) list ./...)
 
 clean-tags:
 	@-rm -f cscope.out cscope.in.out cscope.po.out cscope.files tags
@@ -79,6 +80,5 @@ tags: $$($(GO) list ./...)
 	@ctags $<
 	cscope -R -b -q
 
-.PHONY: $(TARGET) local-release install clean test bench check clean-tags tags
 
 -include Makefile.override

--- a/hubble/Makefile
+++ b/hubble/Makefile
@@ -1,31 +1,37 @@
-GO := go
-GO_BUILD_FLAGS =
-GO_TEST_FLAGS =
-GO_BUILD = CGO_ENABLED=0 $(GO) build $(GO_BUILD_FLAGS)
-SUBDIRS_HUBBLE_CLI := .
-TARGET=hubble
-TARGET_DIR=.
-VERSION=$(shell cat ../VERSION)
-# homebrew uses the github release's tarball of the source that does not contain the '.git' directory.
-GIT_BRANCH = $(shell command -v git >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD 2> /dev/null)
-GIT_HASH = $(shell command -v git >/dev/null 2>&1 && git rev-parse --short HEAD 2> /dev/null)
-GO_TAGS ?=
-GOOS ?=
-GOARCH ?=
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Authors of Hubble
 
 include ../Makefile.defs
 # Add the ability to override variables
 -include Makefile.override
 
-all: hubble
+TARGET := hubble
 
-hubble:
-	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO_BUILD) $(if $(GO_TAGS),-tags $(GO_TAGS)) -ldflags "-w -s -X 'github.com/cilium/cilium/hubble/pkg.GitBranch=${GIT_BRANCH}' -X 'github.com/cilium/cilium/hubble/pkg.GitHash=$(GIT_HASH)' -X 'github.com/cilium/cilium/hubble/pkg.Version=v${VERSION}'" -o $(TARGET_DIR)/$(TARGET)$(EXT) $(SUBDIRS_HUBBLE_CLI)
+all: $(TARGET)
+
+.PHONY: all $(TARGET) release local-release clean
+
+
+SUBDIRS_HUBBLE_CLI := .
+TARGET_DIR=.
+# homebrew uses the github release's tarball of the source that does not contain the '.git' directory.
+GIT_BRANCH = $(shell command -v git >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD 2> /dev/null)
+GIT_HASH = $(shell command -v git >/dev/null 2>&1 && git rev-parse --short HEAD 2> /dev/null)
+
+GOOS ?=
+GOARCH ?=
+
+GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/hubble/pkg.GitBranch=$(GIT_BRANCH)" \
+					-X "github.com/cilium/cilium/hubble/pkg.GitHash=$(GIT_HASH)" \
+					-X "github.com/cilium/cilium/hubble/pkg.Version=v$(VERSION)"
+
+$(TARGET):
+	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO_BUILD) -o $(TARGET_DIR)/$(@)$(EXT) $(SUBDIRS_HUBBLE_CLI)
 
 release:
 	cd ../ && \
 	$(CONTAINER_ENGINE) run --rm --workdir /cilium --volume `pwd`:/cilium --user "$(shell id -u):$(shell id -g)" \
-		$(CILIUM_BUILDER_IMAGE) sh -c "make -C hubble local-release"
+		$(CILIUM_BUILDER_IMAGE) sh -c "$(MAKE) -C $(TARGET) local-release"
 
 local-release: clean
 	set -o errexit; \
@@ -47,16 +53,12 @@ local-release: clean
 		for ARCH in $$ARCHS; do \
 			echo Building release binary for $$OS/$$ARCH...; \
 			test -d release/$$OS/$$ARCH|| mkdir -p release/$$OS/$$ARCH; \
-			$(MAKE) hubble GOOS=$$OS GOARCH=$$ARCH EXT=$$EXT TARGET_DIR=release/$$OS/$$ARCH; \
+			$(MAKE) $(TARGET) GOOS=$$OS GOARCH=$$ARCH EXT=$$EXT TARGET_DIR=release/$$OS/$$ARCH; \
 			tar -czf release/$(TARGET)-$$OS-$$ARCH.tar.gz -C release/$$OS/$$ARCH $(TARGET)$$EXT; \
 			(cd release && sha256sum $(TARGET)-$$OS-$$ARCH.tar.gz > $(TARGET)-$$OS-$$ARCH.tar.gz.sha256sum); \
 		done; \
 		rm -r release/$$OS; \
 	done;
 
-
-
 clean:
 	rm -f $(TARGET)
-
-.PHONY: all hubble release

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -13,7 +13,7 @@ include ${ROOT_DIR}/../Makefile.defs
 
 TARGETS := cilium-operator cilium-operator-generic cilium-operator-aws cilium-operator-azure cilium-operator-alibabacloud
 
-.PHONY: all $(TARGETS) clean install
+.PHONY: all $(TARGETS) clean install install-generic install-aws install-azure install-alibabacloud
 
 all: $(TARGETS)
 
@@ -34,7 +34,7 @@ $(TARGET):
 clean:
 	@$(ECHO_CLEAN)
 	$(QUIET)rm -f $(TARGETS)
-	$(GO) clean $(GOCLEAN)
+	$(QUIET)$(GO_CLEAN)
 
 install:
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
Standardize hubble and cilium CLIs makefile
```

---

Most `Makefile`s in this repository follow a standard pattern, inheriting a lot of their config from the root's `Makefile.defs`. The `cilium-cli` and `hubble` directories Makefiles are notable exceptions. This PR standardizes them to remove duplicated code and logic and to make them behave more like other Makefiles.

Note: this PR is similar with/related to/a followup of #37911

Summary of changes:

### `cilium-cli/Makefile`:
* Remove duplicated variables already sourced from `Makefile.defs`: `GO`, `GO_BUILD`, `GO_TAGS` 
* Remove variable `STRIP_DEBUG` and `DEBUG`, the behavior they controlled is now controlled via [`NOSTRIP`](https://github.com/DataDog/cilium/blob/0aa249407c9be2b21060eb0b7ddf4a91d23b63a6/Makefile.defs#L120)
* Use `$(GO_TEST)` instead of `$(GO) test`
* Update/Add `.DEFAULT_GOAL` and `.PHONY` targets

Impact on `make -C cilium-cli`:
Before:
```sh
make: Entering directory '/home/hadrien/go/src/github.com/DataDog/cilium/cilium-cli'
CGO_ENABLED=0 go build  \
        -ldflags "-w -s -X 'github.com/cilium/cilium/cilium-cli/defaults.CLIVersion=v1.17.0-pre.3-1281-ge8ee0f0770'" \
        -o cilium \
        ./cmd/cilium
make: Leaving directory '/home/hadrien/go/src/github.com/DataDog/cilium/cilium-cli'
```

After:
```sh
make: Entering directory '/home/hadrien/go/src/github.com/DataDog/cilium/cilium-cli'
CGO_ENABLED=0 go build  -mod=vendor -ldflags ' -X "github.com/cilium/cilium/pkg/version.ciliumVersion=1.18.0-dev bbd15b1532 2025-02-18T15:24:14+01:00" -s -w -X "github.com/cilium/cilium/pkg/envoy.requiredEnvoyVersionSHA=c3c35d52ca3b699de1f9448ab7174a9bdcb13f69" -X "github.com/cilium/cilium/cilium-cli/defaults.CLIVersion=v1.17.0-pre.3-1282-gbbd15b1532" ' -tags=osusergo  \
        -o cilium \
        ./cmd/cilium
make: Leaving directory '/home/hadrien/go/src/github.com/DataDog/cilium/cilium-cli'
```
Difference are the addition of `-mod=vendor` and `-tags=osusergo` as well as cilium version variables (currently unused by cilium-cli)

Note: to build the cilium-cli binary with debug symbols unstripped, we now should use `NOSTRIP=1 make -C cilium-cli` instead of the previous `DEBUG=1 make -C cilium-cli`

### `hubble/Makefile`:
* Add missing copyright header
* Remove duplicated variables already sourced from `Makefile.defs`: `GO`, `GO_BUILD_FLAGS`, `GO_TEST_FLAGS`, `GO_BUILD`, `VERSION`, `GO_TAGS`
* Replace hardcoded references to the `hubble` target with `$(TARGET)`
* Replace `make` with [`$(MAKE)`](https://www.cse.unr.edu/~sushil/class/cs202/help/man/make/make_50.html)
* Update/Add `.DEFAULT_GOAL` and `.PHONY` targets

Impact on `make -C hubble`:
Before:
```sh
make: Entering directory '/home/hadrien/go/src/github.com/DataDog/cilium/hubble'
GOOS= GOARCH= CGO_ENABLED=0 go build  -mod=vendor -ldflags ' -X "github.com/cilium/cilium/pkg/version.ciliumVersion=1.18.0-dev e8ee0f0770 2025-02-28T14:15:28+01:00" -s -w -X "github.com/cilium/cilium/pkg/envoy.requiredEnvoyVersionSHA=c3c35d52ca3b699de1f9448ab7174a9bdcb13f69" ' -tags=osusergo   -ldflags "-w -s -X 'github.com/cilium/cilium/hubble/pkg.GitBranch=main' -X 'github.com/cilium/cilium/hubble/pkg.GitHash=e8ee0f0770' -X 'github.com/cilium/cilium/hubble/pkg.Version=v1.18.0-dev'" -o ./hubble .
make: Leaving directory '/home/hadrien/go/src/github.com/DataDog/cilium/hubble'
```
After:
```sh
make: Entering directory '/home/hadrien/go/src/github.com/DataDog/cilium/hubble'
GOOS= GOARCH=amd64 CGO_ENABLED=0 go build  -mod=vendor -ldflags ' -X "github.com/cilium/cilium/pkg/version.ciliumVersion=1.18.0-dev bbd15b1532 2025-02-18T15:24:14+01:00" -s -w -X "github.com/cilium/cilium/pkg/envoy.requiredEnvoyVersionSHA=c3c35d52ca3b699de1f9448ab7174a9bdcb13f69" -X "github.com/cilium/cilium/hubble/pkg.GitBranch=makefile" -X "github.com/cilium/cilium/hubble/pkg.GitHash=bbd15b1532" -X "github.com/cilium/cilium/hubble/pkg.Version=v1.18.0-dev" ' -tags=osusergo  -o ./hubble .
make: Leaving directory '/home/hadrien/go/src/github.com/DataDog/cilium/hubble'
```
Difference is that the two separate `-ldflags` args are now combined as a single one.

`operator/Makefile`:
* Remove reference to non defined `GOCLEAN` variable and replace `$(GO) clean` with `$(GO_CLEAN)`
* Update/Add `.DEFAULT_GOAL` and `.PHONY` targets

Note: the `GO_BUILD` variable from `Makefile.defs` already automatically wires up the go build flags and ldflags, simplifying usage.