### PR TITLE
CODEOWNERS: Assign EKS to ipsec as well

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -252,6 +252,7 @@
 /.github/actions/cl2-modules/ @cilium/sig-scalability
 /.github/workflows/*scale*.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*perf*.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure
+/.github/workflows/conformance-eks.yaml @cilium/ipsec @cilium/github-sec @cilium/ci-structure
 /.github/workflows/tests-ces-migrate.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure
 /.gitignore @cilium/contributing
 /.golangci.yaml @cilium/ci-structure


### PR DESCRIPTION
This workflow has some ipsec-specific logic in it, so the ipsec team
should be a co-owner of this workflow.

cc @cilium/ipsec 