### PR TITLE
docs: Correct the release table format

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Listed below are the actively maintained release branches along with their lates
 patch release, corresponding image pull tags and their release notes:
 
 +---------------------------------------------------------+------------+------------------------------------+----------------------------------------------------------------------------+
-| `v1.17 <https://github.com/cilium/cilium/tree/v1.17>`__ | 2025-02-04 | ``quay.io/cilium/cilium:v1.17.0``   | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.17.0>`__ |
+| `v1.17 <https://github.com/cilium/cilium/tree/v1.17>`__ | 2025-02-04 | ``quay.io/cilium/cilium:v1.17.0``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.17.0>`__  |
 +---------------------------------------------------------+------------+------------------------------------+----------------------------------------------------------------------------+
 | `v1.16 <https://github.com/cilium/cilium/tree/v1.16>`__ | 2025-01-21 | ``quay.io/cilium/cilium:v1.16.6``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.16.6>`__  |
 +---------------------------------------------------------+------------+------------------------------------+----------------------------------------------------------------------------+


### PR DESCRIPTION
The table is a little bit off as per below screen shot

<img width="645" alt="image" src="https://github.com/user-attachments/assets/30443c4f-8128-4d63-986f-5753fc10d864" />
