### PR TITLE
envoy: introduce slog logger for envoy package - part 1

### DIFF
--- a/pkg/envoy/artifact_copier_test.go
+++ b/pkg/envoy/artifact_copier_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,6 +17,7 @@ func TestArtifactCopier_Copy_SourceDirDoesntExist(t *testing.T) {
 	targetTempDir := t.TempDir()
 
 	r := &ArtifactCopier{
+		logger:     hivetest.Logger(t),
 		sourcePath: sourceTempDir,
 		targetPath: targetTempDir,
 	}
@@ -33,6 +35,7 @@ func TestArtifactCopier_Copy_EmptySourceDir(t *testing.T) {
 	targetTempDir := t.TempDir()
 
 	r := &ArtifactCopier{
+		logger:     hivetest.Logger(t),
 		sourcePath: sourceTempDir,
 		targetPath: targetTempDir,
 	}
@@ -53,6 +56,7 @@ func TestArtifactCopier_Copy_CopyFiles(t *testing.T) {
 	assert.NoError(t, err)
 
 	r := &ArtifactCopier{
+		logger:     hivetest.Logger(t),
 		sourcePath: sourceTempDir,
 		targetPath: targetTempDir,
 	}
@@ -81,6 +85,7 @@ func TestArtifactCopier_Copy_DontCopySymlinks(t *testing.T) {
 	assert.NoError(t, err)
 
 	r := &ArtifactCopier{
+		logger:     hivetest.Logger(t),
 		sourcePath: sourceTempDir,
 		targetPath: targetTempDir,
 	}
@@ -102,6 +107,7 @@ func TestArtifactCopier_Copy_DontCopyDirectories(t *testing.T) {
 	assert.NoError(t, err)
 
 	r := &ArtifactCopier{
+		logger:     hivetest.Logger(t),
 		sourcePath: sourceTempDir,
 		targetPath: targetTempDir,
 	}
@@ -128,6 +134,7 @@ func TestArtifactCopier_Copy_CleanupExistingContent(t *testing.T) {
 	assert.NoError(t, err)
 
 	r := &ArtifactCopier{
+		logger:     hivetest.Logger(t),
 		sourcePath: sourceTempDir,
 		targetPath: targetTempDir,
 	}

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -304,8 +304,9 @@ func newLocalEndpointStore() *LocalEndpointStore {
 	}
 }
 
-func newArtifactCopier(lifecycle cell.Lifecycle) *ArtifactCopier {
+func newArtifactCopier(lifecycle cell.Lifecycle, logger *slog.Logger) *ArtifactCopier {
 	artifactCopier := &ArtifactCopier{
+		logger:     logger,
 		sourcePath: "/envoy-artifacts",
 		targetPath: filepath.Join(option.Config.RunDir, "envoy", "artifacts"),
 	}

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -217,8 +217,8 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 	return xdsServer, nil
 }
 
-func newEnvoyAdminClient(envoyProxyConfig ProxyConfig) *EnvoyAdminClient {
-	return NewEnvoyAdminClientForSocket(GetSocketDir(option.Config.RunDir), envoyProxyConfig.EnvoyDefaultLogLevel)
+func newEnvoyAdminClient(logger *slog.Logger, envoyProxyConfig ProxyConfig) *EnvoyAdminClient {
+	return NewEnvoyAdminClientForSocket(logger, GetSocketDir(option.Config.RunDir), envoyProxyConfig.EnvoyDefaultLogLevel)
 }
 
 type accessLogServerParams struct {

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -178,7 +178,7 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 		params.SecretManager)
 
 	if !option.Config.EnableL7Proxy {
-		log.Debug("L7 proxies are disabled - not starting Envoy xDS server")
+		params.Logger.Debug("L7 proxies are disabled - not starting Envoy xDS server")
 		return xdsServer, nil
 	}
 
@@ -231,7 +231,7 @@ type accessLogServerParams struct {
 
 func newEnvoyAccessLogServer(params accessLogServerParams) *AccessLogServer {
 	if !option.Config.EnableL7Proxy {
-		log.Debug("L7 proxies are disabled - not starting Envoy AccessLog server")
+		params.Logger.Debug("L7 proxies are disabled - not starting Envoy AccessLog server")
 		return nil
 	}
 

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -129,6 +129,7 @@ type xdsServerParams struct {
 	cell.In
 
 	Lifecycle          cell.Lifecycle
+	Logger             *slog.Logger
 	IPCache            *ipcache.IPCache
 	RestorerPromise    promise.Promise[endpointstate.Restorer]
 	LocalEndpointStore *LocalEndpointStore
@@ -154,6 +155,7 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 	CiliumXDSConfigSource.InitialFetchTimeout.Seconds = int64(params.EnvoyProxyConfig.ProxyInitialFetchTimeout)
 
 	xdsServer := newXDSServer(
+		params.Logger,
 		params.RestorerPromise,
 		params.IPCache,
 		params.LocalEndpointStore,

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -198,6 +198,7 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 	if !option.Config.ExternalEnvoyProxy {
 		return &onDemandXdsStarter{
 			XDSServer:                xdsServer,
+			logger:                   params.Logger,
 			runDir:                   option.Config.RunDir,
 			envoyLogPath:             params.EnvoyProxyConfig.EnvoyLog,
 			envoyDefaultLogLevel:     params.EnvoyProxyConfig.EnvoyDefaultLogLevel,

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
@@ -329,8 +328,7 @@ func newArtifactCopier(lifecycle cell.Lifecycle, logger *slog.Logger) *ArtifactC
 type syncerParams struct {
 	cell.In
 
-	Slog        *slog.Logger
-	Logger      logrus.FieldLogger
+	Logger      *slog.Logger
 	Lifecycle   cell.Lifecycle
 	JobRegistry job.Registry
 	Health      cell.Health
@@ -370,17 +368,19 @@ func registerSecretSyncer(params syncerParams) error {
 
 	jobGroup := params.JobRegistry.NewGroup(
 		params.Health,
-		job.WithLogger(params.Slog),
+		job.WithLogger(params.Logger),
 		job.WithPprofLabels(pprof.Labels("cell", "envoy-secretsyncer")),
 	)
 
 	params.Lifecycle.Append(jobGroup)
 
-	secretSyncerLogger := params.Logger.WithField("controller", "secretSyncer")
+	secretSyncerLogger := params.Logger.With(logfields.Controller, "secretSyncer")
 
 	secretSyncer := newSecretSyncer(secretSyncerLogger, params.XdsServer)
 
-	secretSyncerLogger.Debug("Watching namespaces for secrets", "namespaces", namespaces)
+	secretSyncerLogger.Debug("Watching namespaces for secrets",
+		logfields.K8sNamespace, namespaces,
+	)
 
 	for ns := range namespaces {
 		jobGroup.Add(job.Observer(

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -224,6 +224,7 @@ type accessLogServerParams struct {
 	cell.In
 
 	Lifecycle          cell.Lifecycle
+	Logger             *slog.Logger
 	LocalEndpointStore *LocalEndpointStore
 	EnvoyProxyConfig   ProxyConfig
 }
@@ -234,7 +235,7 @@ func newEnvoyAccessLogServer(params accessLogServerParams) *AccessLogServer {
 		return nil
 	}
 
-	accessLogServer := newAccessLogServer(GetSocketDir(option.Config.RunDir), params.EnvoyProxyConfig.ProxyGID, params.LocalEndpointStore, params.EnvoyProxyConfig.EnvoyAccessLogBufferSize)
+	accessLogServer := newAccessLogServer(params.Logger, GetSocketDir(option.Config.RunDir), params.EnvoyProxyConfig.ProxyGID, params.LocalEndpointStore, params.EnvoyProxyConfig.EnvoyAccessLogBufferSize)
 
 	params.Lifecycle.Append(cell.Hook{
 		OnStart: func(_ cell.HookContext) error {

--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -117,8 +117,8 @@ type embeddedEnvoyConfig struct {
 	maxConcurrentRetries     uint32
 }
 
-// startEmbeddedEnvoy starts an Envoy proxy instance.
-func startEmbeddedEnvoy(config embeddedEnvoyConfig) (*EmbeddedEnvoy, error) {
+// startEmbeddedEnvoyInternal starts an Envoy proxy instance.
+func (o *onDemandXdsStarter) startEmbeddedEnvoyInternal(config embeddedEnvoyConfig) (*EmbeddedEnvoy, error) {
 	envoy := &EmbeddedEnvoy{
 		stopCh: make(chan struct{}),
 		errCh:  make(chan error, 1),
@@ -135,7 +135,7 @@ func startEmbeddedEnvoy(config embeddedEnvoyConfig) (*EmbeddedEnvoy, error) {
 
 	bootstrapFilePath := filepath.Join(bootstrapDir, "bootstrap.pb")
 
-	writeBootstrapConfigFile(bootstrapConfig{
+	o.writeBootstrapConfigFile(bootstrapConfig{
 		filePath:                 bootstrapFilePath,
 		nodeId:                   "host~127.0.0.1~no-id~localdomain", // node id format inherited from Istio
 		cluster:                  ingressClusterName,
@@ -150,7 +150,7 @@ func startEmbeddedEnvoy(config embeddedEnvoyConfig) (*EmbeddedEnvoy, error) {
 		maxConcurrentRetries:     config.maxConcurrentRetries,
 	})
 
-	log.Debugf("Envoy: Starting: %v", *envoy)
+	o.logger.Debug("Envoy: Starting embedded Envoy")
 
 	// make it a buffered channel, so we can not only
 	// read the written value but also skip it in
@@ -179,7 +179,7 @@ func startEmbeddedEnvoy(config embeddedEnvoyConfig) (*EmbeddedEnvoy, error) {
 
 			// Create a piper that parses and writes into logrus the log
 			// messages from Envoy.
-			logWriter = newEnvoyLogPiper()
+			logWriter = o.newEnvoyLogPiper()
 		}
 		defer logWriter.Close()
 
@@ -196,7 +196,9 @@ func startEmbeddedEnvoy(config embeddedEnvoyConfig) (*EmbeddedEnvoy, error) {
 			cmd.Stdout = logWriter
 
 			if err := cmd.Start(); err != nil {
-				log.WithError(err).Warn("Envoy: Failed to start proxy")
+				o.logger.Warn("Envoy: Failed to start proxy",
+					logfields.Error, err,
+				)
 				select {
 				case started <- false:
 				default:
@@ -204,7 +206,9 @@ func startEmbeddedEnvoy(config embeddedEnvoyConfig) (*EmbeddedEnvoy, error) {
 				return
 			}
 
-			log.WithField(logfields.PID, cmd.Process.Pid).Info("Envoy: Proxy started")
+			o.logger.Info("Envoy: Proxy started",
+				logfields.PID, cmd.Process.Pid,
+			)
 			metrics.SubprocessStart.WithLabelValues(ciliumEnvoyStarter).Inc()
 			select {
 			case started <- true:
@@ -221,11 +225,16 @@ func startEmbeddedEnvoy(config embeddedEnvoyConfig) (*EmbeddedEnvoy, error) {
 			crashCh := make(chan struct{})
 			go func() {
 				if err := cmd.Wait(); err != nil {
-					log.WithError(err).WithField(logfields.PID, cmd.Process.Pid).Warn("Envoy: Proxy crashed")
+					o.logger.Warn("Envoy: Proxy crashed",
+						logfields.PID, cmd.Process.Pid,
+						logfields.Error, err,
+					)
 					// Avoid busy loop & hogging CPU resources by waiting before restarting envoy.
 					time.Sleep(100 * time.Millisecond)
 				} else {
-					log.WithField(logfields.PID, cmd.Process.Pid).Info("Envoy: Proxy terminated")
+					o.logger.Info("Envoy: Proxy terminated",
+						logfields.PID, cmd.Process.Pid,
+					)
 				}
 				close(crashCh)
 			}()
@@ -235,12 +244,18 @@ func startEmbeddedEnvoy(config embeddedEnvoyConfig) (*EmbeddedEnvoy, error) {
 				// Start Envoy again
 				continue
 			case <-envoy.stopCh:
-				log.WithField(logfields.PID, cmd.Process.Pid).Infof("Envoy: Stopping proxy")
+				o.logger.Info("Envoy: Stopping embedded Envoy proxy",
+					logfields.PID, cmd.Process.Pid,
+				)
 				if err := envoy.admin.quit(); err != nil {
-					log.WithError(err).WithField(logfields.PID, cmd.Process.Pid).Fatal("Envoy: Envoy admin quit failed, killing process")
-
+					o.logger.Error("Envoy: Envoy admin quit failed, killing process",
+						logfields.PID, cmd.Process.Pid,
+						logfields.Error, err,
+					)
 					if err := cmd.Process.Kill(); err != nil {
-						log.WithError(err).Fatal("Envoy: Stopping Envoy failed")
+						o.logger.Error("Envoy: Stopping Envoy failed",
+							logfields.Error, err,
+						)
 						envoy.errCh <- err
 					}
 				}
@@ -258,67 +273,67 @@ func startEmbeddedEnvoy(config embeddedEnvoyConfig) (*EmbeddedEnvoy, error) {
 }
 
 // newEnvoyLogPiper creates a writer that parses and logs log messages written by Envoy.
-func newEnvoyLogPiper() io.WriteCloser {
+func (o *onDemandXdsStarter) newEnvoyLogPiper() io.WriteCloser {
 	reader, writer := io.Pipe()
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(nil, 1024*1024)
 	go func() {
-		scopedLog := log.WithFields(logrus.Fields{
-			logfields.LogSubsys: "unknown",
-			logfields.ThreadID:  "unknown",
-		})
-		level := "debug"
-
 		for scanner.Scan() {
 			line := scanner.Text()
-			var msg string
+
+			logThreadID := "unknown"
+			logLevel := "debug"
+			logSubsys := "unknown"
+			logMsg := ""
 
 			parts := strings.SplitN(line, "|", 4)
 			// Parse the line as a log message written by Envoy, assuming it
 			// uses the configured format: "%t|%l|%n|%v".
 			if len(parts) == 4 {
-				threadID := parts[0]
-				level = parts[1]
-				loggerName := parts[2]
+				logThreadID = parts[0]
+				logLevel = parts[1]
+				logSubsys = fmt.Sprintf("envoy-%s", parts[2])
 				// TODO: Parse msg to extract the source filename, line number, etc.
-				msg = fmt.Sprintf("[%s", parts[3])
-
-				scopedLog = log.WithFields(logrus.Fields{
-					logfields.LogSubsys: fmt.Sprintf("envoy-%s", loggerName),
-					logfields.ThreadID:  threadID,
-				})
+				logMsg = fmt.Sprintf("[%s", parts[3])
 			} else {
 				// If this line can't be parsed, it continues a multi-line log
 				// message. In this case, log it at the same level and with the
 				// same fields as the previous line.
-				msg = line
+				logMsg = line
 			}
 
-			if len(msg) == 0 {
+			scopedLog := o.logger.With(
+				logfields.LogSubsys, logSubsys,
+				logfields.ThreadID, logThreadID,
+			)
+
+			if len(logMsg) == 0 {
 				continue
 			}
 
 			// Map the Envoy log level to a logrus level.
-			switch level {
+			switch logLevel {
 			case envoyLogLevelOff, envoyLogLevelCritical, envoyLogLevelError:
-				scopedLog.Error(msg)
+				scopedLog.Error(logMsg)
 			case envoyLogLevelWarning:
 				// Demote expected warnings to info level
-				if strings.Contains(msg, "gRPC config: initial fetch timed out for") {
-					scopedLog.Info(msg)
+				if strings.Contains(logMsg, "gRPC config: initial fetch timed out for") {
+					scopedLog.Info(logMsg)
 					continue
 				}
-				scopedLog.Warn(msg)
+				scopedLog.Warn(logMsg)
 			case envoyLogLevelInfo:
-				scopedLog.Info(msg)
+				scopedLog.Info(logMsg)
 			case envoyLogLevelDebug, envoyLogLevelTrace:
-				scopedLog.Debug(msg)
+				scopedLog.Debug(logMsg)
 			default:
-				scopedLog.Debug(msg)
+				scopedLog.Debug(logMsg)
 			}
 		}
 		if err := scanner.Err(); err != nil {
-			log.WithError(err).Error("Error while parsing Envoy logs")
+			o.logger.Error("Error while parsing Envoy logs",
+				logfields.Error, err,
+			)
 		}
 		reader.Close()
 	}()
@@ -355,7 +370,7 @@ type bootstrapConfig struct {
 	maxConcurrentRetries     uint32
 }
 
-func writeBootstrapConfigFile(config bootstrapConfig) {
+func (o *onDemandXdsStarter) writeBootstrapConfigFile(config bootstrapConfig) {
 	useDownstreamProtocol := map[string]*anypb.Any{
 		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": toAny(&envoy_config_upstream.HttpProtocolOptions{
 			CommonHttpProtocolOptions: &envoy_config_core.HttpProtocolOptions{
@@ -528,14 +543,20 @@ func writeBootstrapConfigFile(config bootstrapConfig) {
 		},
 	}
 
-	log.Debugf("Envoy: Bootstrap: %s", bs)
+	o.logger.Debug("Envoy: Writing Bootstrap config",
+		logfields.Resource, bs,
+	)
 	data, err := proto.Marshal(bs)
 	if err != nil {
-		log.WithError(err).Fatal("Envoy: Error marshaling Envoy bootstrap")
+		o.logger.Error("Envoy: Error marshaling Envoy bootstrap",
+			logfields.Error, err,
+		)
+		return
 	}
-	err = os.WriteFile(config.filePath, data, 0644)
-	if err != nil {
-		log.WithError(err).Fatal("Envoy: Error writing Envoy bootstrap file")
+	if err := os.WriteFile(config.filePath, data, 0644); err != nil {
+		o.logger.Error("Envoy: Error writing Envoy bootstrap file",
+			logfields.Error, err,
+		)
 	}
 }
 

--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -122,7 +122,7 @@ func (o *onDemandXdsStarter) startEmbeddedEnvoyInternal(config embeddedEnvoyConf
 	envoy := &EmbeddedEnvoy{
 		stopCh: make(chan struct{}),
 		errCh:  make(chan error, 1),
-		admin:  NewEnvoyAdminClientForSocket(GetSocketDir(config.runDir), config.defaultLogLevel),
+		admin:  NewEnvoyAdminClientForSocket(o.logger, GetSocketDir(config.runDir), config.defaultLogLevel),
 	}
 
 	bootstrapDir := filepath.Join(config.runDir, "envoy")

--- a/pkg/envoy/embedded_envoy_test.go
+++ b/pkg/envoy/embedded_envoy_test.go
@@ -92,7 +92,8 @@ func TestEnvoy(t *testing.T) {
 	defer accessLogServer.stop()
 
 	// launch debug variant of the Envoy proxy
-	envoyProxy, err := startEmbeddedEnvoy(embeddedEnvoyConfig{
+	starter := &onDemandXdsStarter{logger: logger}
+	envoyProxy, err := starter.startEmbeddedEnvoyInternal(embeddedEnvoyConfig{
 		runDir:         testRunDir,
 		logPath:        filepath.Join(testRunDir, "cilium-envoy.log"),
 		baseID:         15,
@@ -208,7 +209,8 @@ func TestEnvoyNACK(t *testing.T) {
 	defer accessLogServer.stop()
 
 	// launch debug variant of the Envoy proxy
-	envoyProxy, err := startEmbeddedEnvoy(embeddedEnvoyConfig{
+	starter := &onDemandXdsStarter{logger: logger}
+	envoyProxy, err := starter.startEmbeddedEnvoyInternal(embeddedEnvoyConfig{
 		runDir:         testRunDir,
 		logPath:        filepath.Join(testRunDir, "cilium-envoy.log"),
 		baseID:         42,

--- a/pkg/envoy/embedded_envoy_test.go
+++ b/pkg/envoy/embedded_envoy_test.go
@@ -85,7 +85,7 @@ func TestEnvoy(t *testing.T) {
 	require.NoError(t, err)
 	defer xdsServer.stop()
 
-	accessLogServer := newAccessLogServer(testRunDir, 1337, localEndpointStore, 4096)
+	accessLogServer := newAccessLogServer(logger, testRunDir, 1337, localEndpointStore, 4096)
 	require.NotNil(t, accessLogServer)
 	err = accessLogServer.start()
 	require.NoError(t, err)
@@ -201,7 +201,7 @@ func TestEnvoyNACK(t *testing.T) {
 	require.NoError(t, err)
 	defer xdsServer.stop()
 
-	accessLogServer := newAccessLogServer(testRunDir, 1337, localEndpointStore, 4096)
+	accessLogServer := newAccessLogServer(logger, testRunDir, 1337, localEndpointStore, 4096)
 	require.NotNil(t, accessLogServer)
 	err = accessLogServer.start()
 	require.NoError(t, err)

--- a/pkg/envoy/embedded_envoy_test.go
+++ b/pkg/envoy/embedded_envoy_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/completion"
@@ -69,7 +70,9 @@ func TestEnvoy(t *testing.T) {
 
 	localEndpointStore := newLocalEndpointStore()
 
-	xdsServer := newXDSServer(nil, testipcache.NewMockIPCache(), localEndpointStore,
+	logger := hivetest.Logger(t)
+
+	xdsServer := newXDSServer(logger, nil, testipcache.NewMockIPCache(), localEndpointStore,
 		xdsServerConfig{
 			envoySocketDir:    GetSocketDir(testRunDir),
 			proxyGID:          1337,
@@ -184,7 +187,9 @@ func TestEnvoyNACK(t *testing.T) {
 
 	localEndpointStore := newLocalEndpointStore()
 
-	xdsServer := newXDSServer(nil, testipcache.NewMockIPCache(), localEndpointStore,
+	logger := hivetest.Logger(t)
+
+	xdsServer := newXDSServer(logger, nil, testipcache.NewMockIPCache(), localEndpointStore,
 		xdsServerConfig{
 			envoySocketDir:    GetSocketDir(testRunDir),
 			proxyGID:          1337,

--- a/pkg/envoy/envoyadminclient.go
+++ b/pkg/envoy/envoyadminclient.go
@@ -8,24 +8,29 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/safeio"
 )
 
 type EnvoyAdminClient struct {
+	logger          *slog.Logger
 	adminURL        string
 	unixPath        string
 	currentLogLevel string
 	defaultLogLevel string
 }
 
-func NewEnvoyAdminClientForSocket(envoySocketDir string, defaultLogLevel string) *EnvoyAdminClient {
+func NewEnvoyAdminClientForSocket(logger *slog.Logger, envoySocketDir string, defaultLogLevel string) *EnvoyAdminClient {
 	return &EnvoyAdminClient{
+		logger: logger,
+
 		// Needs to be provided to envoy (received as ':authority') - even though we Dial to a Unix domain socket.
 		adminURL:        fmt.Sprintf("http://%s/", "envoy-admin"),
 		unixPath:        getAdminSocketPath(envoySocketDir),
@@ -57,7 +62,10 @@ func (a *EnvoyAdminClient) transact(query string) error {
 		return err
 	}
 	ret := strings.ReplaceAll(string(body), "\r", "")
-	log.Debugf("Envoy: Admin response to %s: %s", query, ret)
+	a.logger.Debug("Envoy: Admin response",
+		logfields.Request, query,
+		logfields.Response, ret,
+	)
 	return nil
 }
 
@@ -66,17 +74,22 @@ func (a *EnvoyAdminClient) ChangeLogLevel(agentLogLevel logrus.Level) error {
 	envoyLevel := mapLogLevel(agentLogLevel, a.defaultLogLevel)
 
 	if envoyLevel == a.currentLogLevel {
-		log.Debugf("Envoy: Log level is already set as: %v", envoyLevel)
+		a.logger.Debug("Envoy: Log level is already set",
+			logfields.Value, envoyLevel,
+		)
 		return nil
 	}
 
-	err := a.transact("logging?level=" + envoyLevel)
-	if err != nil {
-		log.WithError(err).Warnf("Envoy: Failed to set log level to: %v", envoyLevel)
-	} else {
-		a.currentLogLevel = envoyLevel
+	if err := a.transact("logging?level=" + envoyLevel); err != nil {
+		a.logger.Warn("Envoy: Failed to set log level",
+			logfields.Value, envoyLevel,
+			logfields.Error, err,
+		)
+		return err
 	}
-	return err
+
+	a.currentLogLevel = envoyLevel
+	return nil
 }
 
 func (a *EnvoyAdminClient) quit() error {

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -19,13 +19,12 @@ import (
 	"google.golang.org/grpc/reflection"
 
 	"github.com/cilium/cilium/pkg/envoy/xds"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
-var (
-	// ErrNotImplemented is the error returned by gRPC methods that are not
-	// implemented by Cilium.
-	ErrNotImplemented = errors.New("not implemented")
-)
+// ErrNotImplemented is the error returned by gRPC methods that are not
+// implemented by Cilium.
+var ErrNotImplemented = errors.New("not implemented")
 
 // startXDSGRPCServer starts a gRPC server to serve xDS APIs using the given
 // resource watcher and network listener.
@@ -39,7 +38,7 @@ func (s *xdsServer) startXDSGRPCServer(listener net.Listener, config map[string]
 
 	// TODO: https://github.com/cilium/cilium/issues/5051
 	// Implement IncrementalAggregatedResources to support Incremental xDS.
-	//envoy_service_discovery_v3.RegisterAggregatedDiscoveryServiceServer(grpcServer, dsServer)
+	// envoy_service_discovery_v3.RegisterAggregatedDiscoveryServiceServer(grpcServer, dsServer)
 	envoy_service_secret.RegisterSecretDiscoveryServiceServer(grpcServer, dsServer)
 	envoy_service_endpoint.RegisterEndpointDiscoveryServiceServer(grpcServer, dsServer)
 	envoy_service_cluster.RegisterClusterDiscoveryServiceServer(grpcServer, dsServer)
@@ -53,26 +52,32 @@ func (s *xdsServer) startXDSGRPCServer(listener net.Listener, config map[string]
 	ctx, cancel := context.WithTimeout(context.Background(), s.config.policyRestoreTimeout)
 	go func() {
 		if s.restorerPromise != nil {
-			log.Infof("Envoy: Waiting for endpoint restorer before serving xDS resources...")
+			s.logger.Info("Envoy: Waiting for endpoint restorer before serving xDS resources...")
 			restorer, err := s.restorerPromise.Await(ctx)
 			if err == nil && restorer != nil {
-				log.Infof("Envoy: Waiting for endpoint restoration before serving xDS resources...")
+				s.logger.Info("Envoy: Waiting for endpoint restoration before serving xDS resources...")
 				err = restorer.WaitForInitialPolicy(ctx)
 			}
 			if errors.Is(err, context.Canceled) {
-				log.Debug("Envoy: xDS server stopped before started serving")
+				s.logger.Debug("Envoy: xDS server stopped before started serving")
 				return
 			}
 			if errors.Is(err, context.DeadlineExceeded) {
-				log.Warningf("Envoy: Endpoint policy restoration took longer than %s, starting serving resources to Envoy", s.config.policyRestoreTimeout)
+				s.logger.Warn("Envoy: Endpoint policy restoration took longer than configured restore timeout, starting serving resources to Envoy",
+					logfields.Duration, s.config.policyRestoreTimeout,
+				)
 			}
 			// Tell xdsServer it's time to start waiting for acknowledgements
 			xdsServer.RestoreCompleted()
 		}
 
-		log.Infof("Envoy: Starting xDS gRPC server listening on %s", listener.Addr())
+		s.logger.Info("Envoy: Starting xDS gRPC server listening",
+			logfields.Address, listener.Addr(),
+		)
 		if err := grpcServer.Serve(listener); err != nil && !errors.Is(err, net.ErrClosed) {
-			log.WithError(err).Fatal("Envoy: Failed to serve xDS gRPC API")
+			s.logger.Error("Envoy: Failed to serve xDS gRPC API",
+				logfields.Error, err,
+			)
 		}
 	}()
 

--- a/pkg/envoy/resources_test.go
+++ b/pkg/envoy/resources_test.go
@@ -6,12 +6,13 @@ package envoy
 import (
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	envoyAPI "github.com/cilium/proxy/go/cilium/api"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHandleIPUpsert(t *testing.T) {
-	cache := newNPHDSCache(nil)
+	cache := newNPHDSCache(hivetest.Logger(t), nil)
 
 	msg, err := cache.Lookup(NetworkPolicyHostsTypeURL, "123")
 	require.NoError(t, err)

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -294,7 +294,7 @@ func (s *xdsServer) initializeXdsConfigs() {
 		AckObserver: npdsMutator,
 	}
 
-	nphdsCache := newNPHDSCache(s.ipCache)
+	nphdsCache := newNPHDSCache(s.logger, s.ipCache)
 	nphdsConfig := &xds.ResourceTypeConfiguration{
 		Source:      nphdsCache,
 		AckObserver: &nphdsCache,

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -30,7 +30,6 @@ import (
 	envoy_config_tls "github.com/cilium/proxy/go/envoy/extensions/transport_sockets/tls/v3"
 	envoy_type_matcher "github.com/cilium/proxy/go/envoy/type/matcher/v3"
 	"github.com/cilium/proxy/pkg/policy/api/kafka"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -1609,7 +1608,7 @@ func getPortNetworkPolicyRule(version *versioned.VersionHandle, sel policy.Cache
 
 // getWildcardNetworkPolicyRule returns the rule for port 0, which
 // will be considered after port-specific rules.
-func getWildcardNetworkPolicyRule(version *versioned.VersionHandle, selectors policy.L7DataMap) *cilium.PortNetworkPolicyRule {
+func (s *xdsServer) getWildcardNetworkPolicyRule(version *versioned.VersionHandle, selectors policy.L7DataMap) *cilium.PortNetworkPolicyRule {
 	// selections are pre-sorted, so sorting is only needed if merging selections from multiple selectors
 	if len(selectors) == 1 {
 		for sel := range selectors {
@@ -1641,7 +1640,7 @@ func getWildcardNetworkPolicyRule(version *versioned.VersionHandle, selectors po
 			// Issue a warning if this port-0 rule is a redirect.
 			// Deny rules don't support L7 therefore for the deny case
 			// l7.IsRedirect() will always return false.
-			log.Warningf("L3-only rule for selector %v surprisingly requires proxy redirection (%v)!", sel, *l7)
+			s.logger.Warn("L3-only rule for selector surprisingly requires proxy redirection!", logfields.Selector, sel)
 		}
 
 		selections := sel.GetSelections(version)
@@ -1674,7 +1673,7 @@ func getWildcardNetworkPolicyRule(version *versioned.VersionHandle, selectors po
 	}
 }
 
-func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4PolicyMap, policyEnforced bool, useFullTLSContext, useSDS bool, dir string, policySecretsNamespace string) []*cilium.PortNetworkPolicy {
+func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4PolicyMap, policyEnforced bool, useFullTLSContext, useSDS bool, dir string, policySecretsNamespace string) []*cilium.PortNetworkPolicy {
 	// TODO: integrate visibility with enforced policy
 	if !policyEnforced {
 		// Always allow all ports
@@ -1718,15 +1717,15 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 		if port == 0 {
 			// L3-only rule, must generate L7 allow-all in case there are other
 			// port-specific rules. Otherwise traffic from allowed remotes could be dropped.
-			rule := getWildcardNetworkPolicyRule(version, l4.PerSelectorPolicies)
+			rule := s.getWildcardNetworkPolicyRule(version, l4.PerSelectorPolicies)
 			if rule != nil {
-				log.WithFields(logrus.Fields{
-					logfields.EndpointID:       ep.GetID(),
-					logfields.Version:          version,
-					logfields.TrafficDirection: dir,
-					logfields.Port:             port,
-					logfields.PolicyID:         rule.RemotePolicies,
-				}).Debug("Wildcard PortNetworkPolicyRule matching remote IDs")
+				s.logger.Debug("Wildcard PortNetworkPolicyRule matching remote IDs",
+					logfields.EndpointID, ep.GetID(),
+					logfields.Version, version,
+					logfields.TrafficDirection, dir,
+					logfields.Port, port,
+					logfields.PolicyID, rule.RemotePolicies,
+				)
 
 				if len(rule.RemotePolicies) == 0 {
 					// Got an allow-all rule, which can short-circuit all of
@@ -1749,14 +1748,14 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 						canShortCircuit = false
 					}
 
-					log.WithFields(logrus.Fields{
-						logfields.EndpointID:       ep.GetID(),
-						logfields.Version:          version,
-						logfields.TrafficDirection: dir,
-						logfields.Port:             port,
-						logfields.PolicyID:         rule.RemotePolicies,
-						logfields.ServerNames:      rule.ServerNames,
-					}).Debug("PortNetworkPolicyRule matching remote IDs")
+					s.logger.Debug("PortNetworkPolicyRule matching remote IDs",
+						logfields.EndpointID, ep.GetID(),
+						logfields.Version, version,
+						logfields.TrafficDirection, dir,
+						logfields.Port, port,
+						logfields.PolicyID, rule.RemotePolicies,
+						logfields.ServerNames, rule.ServerNames,
+					)
 
 					if len(rule.RemotePolicies) == 0 && rule.L7 == nil && rule.DownstreamTlsContext == nil && rule.UpstreamTlsContext == nil && len(rule.ServerNames) == 0 {
 						// Got an allow-all rule, which can short-circuit all of
@@ -1769,11 +1768,11 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 		}
 		// Short-circuit rules if a rule allows all and all other rules can be short-circuited
 		if allowAll && canShortCircuit {
-			log.WithFields(logrus.Fields{
-				logfields.EndpointID:       ep.GetID(),
-				logfields.TrafficDirection: dir,
-				logfields.Port:             port,
-			}).Debug("Short circuiting HTTP rules due to rule allowing all and no other rules needing attention")
+			s.logger.Debug("Short circuiting HTTP rules due to rule allowing all and no other rules needing attention",
+				logfields.EndpointID, ep.GetID(),
+				logfields.TrafficDirection, dir,
+				logfields.Port, port,
+			)
 			rules = nil
 		}
 
@@ -1782,11 +1781,11 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 		// In this case, just don't generate any PortNetworkPolicy for this
 		// port.
 		if !allowAll && len(rules) == 0 {
-			log.WithFields(logrus.Fields{
-				logfields.EndpointID:       ep.GetID(),
-				logfields.TrafficDirection: dir,
-				logfields.Port:             port,
-			}).Debug("Skipping PortNetworkPolicy due to no matching remote identities")
+			s.logger.Debug("Skipping PortNetworkPolicy due to no matching remote identities",
+				logfields.EndpointID, ep.GetID(),
+				logfields.TrafficDirection, dir,
+				logfields.Port, port,
+			)
 			return true
 		}
 
@@ -1808,7 +1807,7 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 }
 
 // getNetworkPolicy converts a network policy into a cilium.NetworkPolicy.
-func getNetworkPolicy(ep endpoint.EndpointUpdater, ips []string, l4Policy *policy.L4Policy,
+func (s *xdsServer) getNetworkPolicy(ep endpoint.EndpointUpdater, ips []string, l4Policy *policy.L4Policy,
 	ingressPolicyEnforced, egressPolicyEnforced, useFullTLSContext, useSDS bool, policySecretsNamespace string,
 ) *cilium.NetworkPolicy {
 	p := &cilium.NetworkPolicy{
@@ -1823,8 +1822,8 @@ func getNetworkPolicy(ep endpoint.EndpointUpdater, ips []string, l4Policy *polic
 		ingressMap = l4Policy.Ingress.PortRules
 		egressMap = l4Policy.Egress.PortRules
 	}
-	p.IngressPerPortPolicies = getDirectionNetworkPolicy(ep, ingressMap, ingressPolicyEnforced, useFullTLSContext, useSDS, "ingress", policySecretsNamespace)
-	p.EgressPerPortPolicies = getDirectionNetworkPolicy(ep, egressMap, egressPolicyEnforced, useFullTLSContext, useSDS, "egress", policySecretsNamespace)
+	p.IngressPerPortPolicies = s.getDirectionNetworkPolicy(ep, ingressMap, ingressPolicyEnforced, useFullTLSContext, useSDS, "ingress", policySecretsNamespace)
+	p.EgressPerPortPolicies = s.getDirectionNetworkPolicy(ep, egressMap, egressPolicyEnforced, useFullTLSContext, useSDS, "egress", policySecretsNamespace)
 
 	return p
 }
@@ -1888,7 +1887,7 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *pol
 		return nil, func() error { return nil }
 	}
 
-	networkPolicy := getNetworkPolicy(ep, ips, policy, ingressPolicyEnforced, egressPolicyEnforced, s.config.useFullTLSContext, s.config.useSDS, s.secretManager.GetSecretSyncNamespace())
+	networkPolicy := s.getNetworkPolicy(ep, ips, policy, ingressPolicyEnforced, egressPolicyEnforced, s.config.useFullTLSContext, s.config.useSDS, s.secretManager.GetSecretSyncNamespace())
 
 	// First, validate the policy
 	err := networkPolicy.Validate()

--- a/pkg/envoy/xds_server_ondemand.go
+++ b/pkg/envoy/xds_server_ondemand.go
@@ -71,7 +71,7 @@ func (o *onDemandXdsStarter) startEmbeddedEnvoy(wg *completion.WaitGroup) error 
 
 	o.envoyOnce.Do(func() {
 		// Start embedded Envoy on first invocation
-		_, startErr = startEmbeddedEnvoy(embeddedEnvoyConfig{
+		_, startErr = o.startEmbeddedEnvoyInternal(embeddedEnvoyConfig{
 			runDir:                   o.runDir,
 			logPath:                  o.envoyLogPath,
 			defaultLogLevel:          o.envoyDefaultLogLevel,

--- a/pkg/envoy/xds_server_ondemand.go
+++ b/pkg/envoy/xds_server_ondemand.go
@@ -5,6 +5,7 @@ package envoy
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/completion"
@@ -16,6 +17,7 @@ import (
 type onDemandXdsStarter struct {
 	XDSServer
 
+	logger                   *slog.Logger
 	runDir                   string
 	envoyLogPath             string
 	envoyDefaultLogLevel     string
@@ -36,7 +38,9 @@ var _ XDSServer = &onDemandXdsStarter{}
 
 func (o *onDemandXdsStarter) AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup, cb func(err error)) error {
 	if err := o.startEmbeddedEnvoy(nil); err != nil {
-		log.WithError(err).Error("Envoy: Failed to start embedded Envoy proxy on demand")
+		o.logger.Error("Envoy: Failed to start embedded Envoy proxy on demand",
+			logfields.Error, err,
+		)
 	}
 
 	return o.XDSServer.AddListener(name, kind, port, isIngress, mayUseOriginalSourceAddr, wg, cb)
@@ -44,7 +48,9 @@ func (o *onDemandXdsStarter) AddListener(name string, kind policy.L7ParserType, 
 
 func (o *onDemandXdsStarter) UpsertEnvoyResources(ctx context.Context, resources Resources) error {
 	if err := o.startEmbeddedEnvoy(nil); err != nil {
-		log.WithError(err).Error("Envoy: Failed to start embedded Envoy proxy on demand")
+		o.logger.Error("Envoy: Failed to start embedded Envoy proxy on demand",
+			logfields.Error, err,
+		)
 	}
 
 	return o.XDSServer.UpsertEnvoyResources(ctx, resources)
@@ -52,7 +58,9 @@ func (o *onDemandXdsStarter) UpsertEnvoyResources(ctx context.Context, resources
 
 func (o *onDemandXdsStarter) UpdateEnvoyResources(ctx context.Context, old, new Resources) error {
 	if err := o.startEmbeddedEnvoy(nil); err != nil {
-		log.WithError(err).Error("Envoy: Failed to start embedded Envoy proxy on demand")
+		o.logger.Error("Envoy: Failed to start embedded Envoy proxy on demand",
+			logfields.Error, err,
+		)
 	}
 
 	return o.XDSServer.UpdateEnvoyResources(ctx, old, new)
@@ -78,18 +86,22 @@ func (o *onDemandXdsStarter) startEmbeddedEnvoy(wg *completion.WaitGroup) error 
 
 		// Add Prometheus listener if the port is (properly) configured
 		if o.metricsListenerPort < 0 || o.metricsListenerPort > 65535 {
-			log.WithField(logfields.Port, o.metricsListenerPort).Error("Envoy: Invalid configured proxy-prometheus-port")
+			o.logger.Error("Envoy: Invalid configured proxy-prometheus-port",
+				logfields.Port, o.metricsListenerPort,
+			)
 		} else if o.metricsListenerPort != 0 {
 			// We could do this in the bootstrap config as with the Envoy DaemonSet,
 			// but then a failure to bind to the configured port would fail starting Envoy.
-			o.XDSServer.AddMetricsListener(uint16(o.metricsListenerPort), wg)
+			o.AddMetricsListener(uint16(o.metricsListenerPort), wg)
 		}
 
 		// Add Admin listener if the port is (properly) configured
 		if o.adminListenerPort < 0 || o.adminListenerPort > 65535 {
-			log.WithField(logfields.Port, o.adminListenerPort).Error("Envoy: Invalid configured proxy-admin-port")
+			o.logger.Error("Envoy: Invalid configured proxy-admin-port",
+				logfields.Port, o.adminListenerPort,
+			)
 		} else if o.adminListenerPort != 0 {
-			o.XDSServer.AddAdminListener(uint16(o.adminListenerPort), wg)
+			o.AddAdminListener(uint16(o.adminListenerPort), wg)
 		}
 	})
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -449,6 +449,9 @@ const (
 	// Envoy secrets
 	ResourceSecrets = "secrets"
 
+	// Size of the buffer
+	BufferSize = "buffer-size"
+
 	// ListenerPriority is the priority of an Envoy Listener defined in CEC or CCEC
 	ListenerPriority = "listenerPriority"
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -413,6 +413,42 @@ const (
 	// Listener is the name of an Envoy Listener defined in CEC or CCEC
 	Listener = "listener"
 
+	// L7 parser type
+	L7ParserType = "l7-parser-type"
+
+	// Whether original source address can be used or not
+	MayUseOriginalSourceAddr = "mayUseOriginalSourceAddr"
+
+	// Name of a resource
+	ResourceName = "name"
+
+	// Old value before an operation
+	ValueBefore = "before"
+
+	// New value after an operation
+	ValueAfter = "after"
+
+	// Number of upserted resources
+	ResourcesUpserted = "upserted"
+
+	// Number of deleted resources
+	ResourcesDeleted = "deleted"
+
+	// Envoy listeners
+	ResourceListeners = "listeners"
+
+	// Envoy routes
+	ResourceRoutes = "routes"
+
+	// Envoy clusters
+	ResourceClusters = "clusters"
+
+	// Envoy endpoints
+	ResourceEndpoints = "endpoints"
+
+	// Envoy secrets
+	ResourceSecrets = "secrets"
+
 	// ListenerPriority is the priority of an Envoy Listener defined in CEC or CCEC
 	ListenerPriority = "listenerPriority"
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -883,6 +883,9 @@ const (
 	// NetnsCookie is the Linux kernel netns cookie.
 	NetnsCookie = "netnsCookie"
 
+	// Source identifies a source value
+	Source = "source"
+
 	// Target identifies a target value
 	Target = "target"
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -895,6 +895,9 @@ const (
 	// Maximum specifies a maximum allowed value
 	Maximum = "maximum"
 
+	// Size identifies the size of a list
+	Size = "size"
+
 	// Directory identifies a directory
 	Directory = "directory"
 	// PacketsDropped are the number of packets dropped


### PR DESCRIPTION
This commit is refactoring the Envoy package (`pkg/envoy`) functionality to use an injected slog logger instead of the package scoped logrus instance.

Please review the individual commits.

Planned follow ups to clean up the package scoped logrus instance completely

- refactor flow debug log
- refactor L7 policy HTTP rule generation (currently global functions) 