### PR TITLE
Revert "contrib: Run builder script as non-root by default"

### DIFF
--- a/contrib/scripts/builder.sh
+++ b/contrib/scripts/builder.sh
@@ -5,7 +5,6 @@ set -eu
 cd "$(dirname "$0")/../.."
 
 CILIUM_BUILDER_IMAGE=$(cat images/cilium/Dockerfile | grep '^ARG CILIUM_BUILDER_IMAGE=' | cut -d '=' -f 2)
-RUN_AS_NONROOT="${RUN_AS_NONROOT:-1}"
 
 USER_OPTION=""
 USER_PATH="/root"


### PR DESCRIPTION
Running build script as non-root breaks running bpf tests (`make run_bpf_tests`). There seems to be no way of reversing the default `RUN_AS_NONROOT`, as setting it to empty or `0` does not work. Maybe the logic needs to be reverted and have a `RUN_AS_ROOT` instead?

This reverts commit cc59b474490abadf15e3515be8aceb6094fc5778.
