### PR TITLE
SocketLB: Terminate connections for services with mixed protocols

### DIFF
--- a/pkg/service/connections.go
+++ b/pkg/service/connections.go
@@ -40,7 +40,7 @@ func (s *Service) TerminateUDPConnectionsToBackend(l3n4Addr *lb.L3n4Addr) error 
 	l4Addr := l3n4Addr.L4Addr
 
 	switch l3n4Addr.Protocol {
-	case lb.UDP:
+	case lb.UDP, lb.ANY:
 		protocol = unix.IPPROTO_UDP
 	default:
 		return nil


### PR DESCRIPTION
Hello,

Fixes: https://github.com/cilium/cilium/issues/37577

Following my issue, I continued my investigations to understand why the UDP sockets weren't closed.

I first added a log line at the beginning of `TerminateUDPConnectionsToBackend` to check if I enter the function as I ddin't see the "handling udp connections to deleted backend" log.

What I discovered is that the `l3n4Addr.Protocol` field wasn't set to "UDP" but to "ANY", which I understood being due to having both a TCP and an UDP port on my service.

I therefore added a check for "ANY" in `l3n4Addr.Protocol` and then set the `protocol` variable to UDP.

It resolved my issue in my environment, and, as I understand the code, cannot cause any new issue.

Best Regards.

```release-note
Fix connections to deleted service backends not getting terminated in certain cases involving services with multiple protocol ports.
```