### PR TITLE
bpf:nat: Restore ORG NAT entry if it's not found

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -403,6 +403,36 @@ snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 
 	*state = __snat_lookup(map, tuple);
 
+	if (*state) {
+		struct ipv4_nat_entry *lookup_result;
+		struct ipv4_nat_entry ostate;
+		struct ipv4_ct_tuple otuple = {};
+		int ret;
+
+		/* Check for the original SNAT entry. If it is missing (e.g. due to LRU
+		 * eviction), it must be restored before returning.
+		 */
+		otuple.saddr = (*state)->to_daddr;
+		otuple.sport = (*state)->to_dport;
+		otuple.daddr = tuple->saddr;
+		otuple.dport = tuple->sport;
+		otuple.nexthdr = tuple->nexthdr;
+		otuple.flags = TUPLE_F_OUT;
+
+		lookup_result = __snat_lookup(map, &otuple);
+		if (!lookup_result) {
+			memset(&ostate, 0, sizeof(ostate));
+			ostate.to_saddr = tuple->daddr;
+			ostate.to_sport = tuple->dport;
+			ostate.common.needs_ct = (*state)->common.needs_ct;
+			ostate.common.created = bpf_mono_now();
+
+			ret = __snat_create(map, &otuple, &ostate);
+			if (ret < 0)
+				return DROP_NAT_NO_MAPPING;
+		}
+	}
+
 	if (*state && (*state)->common.needs_ct) {
 		struct ipv4_ct_tuple tuple_revsnat;
 		int ret;
@@ -1362,6 +1392,36 @@ snat_v6_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 			       struct trace_ctx *trace)
 {
 	*state = snat_v6_lookup(tuple);
+
+	if (*state) {
+		struct ipv6_nat_entry *lookup_result;
+		struct ipv6_nat_entry ostate;
+		struct ipv6_ct_tuple otuple = {};
+		int ret;
+
+		/* Check for the original SNAT entry. If it is missing (e.g. due to LRU
+		 * eviction), it must be restored before returning.
+		 */
+		otuple.saddr = (*state)->to_daddr;
+		otuple.sport = (*state)->to_dport;
+		otuple.daddr = tuple->saddr;
+		otuple.dport = tuple->sport;
+		otuple.nexthdr = tuple->nexthdr;
+		otuple.flags = TUPLE_F_OUT;
+
+		lookup_result = snat_v6_lookup(&otuple);
+		if (!lookup_result) {
+			memset(&ostate, 0, sizeof(ostate));
+			ostate.to_saddr = tuple->daddr;
+			ostate.to_sport = tuple->dport;
+			ostate.common.needs_ct = (*state)->common.needs_ct;
+			ostate.common.created = bpf_mono_now();
+
+			ret = __snat_create(&cilium_snat_v6_external, &otuple, &ostate);
+			if (ret < 0)
+				return DROP_NAT_NO_MAPPING;
+		}
+	}
 
 	if (*state && (*state)->common.needs_ct) {
 		struct ipv6_ct_tuple tuple_revsnat;

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -1177,3 +1177,288 @@ int nodeport_nat_fwd_restore_reply_check(const struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);
 }
+
+ /* The following three tests are checking the scenario where a Original NAT entry gets deleted:
+  * 1. The original packet gets ReSNATed when the entry is deleted.
+  * 2. The reply packet restores the Original NAT entry if it is deleted.
+  * 3. The original pakcket does not get ReSNATed. Because the Original NAT entry is restored.
+  *
+  *
+  * Test that source port is changed when the Original NAT entry is deleted.(ReSNATed)
+  */
+PKTGEN("tc", "tc_nodeport_nat_fwd_original_renated")
+int nodeport_nat_fwd_original_renated_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)lb_mac,
+					  CLIENT_IP, FRONTEND_IP_REMOTE,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_nat_fwd_original_renated")
+int nodeport_nat_fwd_original_renated_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 4;
+	struct ipv4_ct_tuple otuple = {};
+
+	lb_v4_add_service(FRONTEND_IP_REMOTE, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
+	lb_v4_add_backend(FRONTEND_IP_REMOTE, FRONTEND_PORT, 1, 124,
+			  BACKEND_IP_REMOTE, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	ipcache_v4_add_entry(BACKEND_IP_REMOTE, 0, 112233, 0, 0);
+
+	otuple.flags = TUPLE_F_OUT;
+	otuple.saddr = CLIENT_IP;
+	otuple.daddr = BACKEND_IP_REMOTE;
+	otuple.nexthdr = IPPROTO_TCP;
+	otuple.sport = CLIENT_PORT;
+	otuple.dport = BACKEND_PORT;
+
+	/* Delete the Original NAT entry*/
+	if IS_ERR(map_delete_elem(&cilium_snat_v4_external, &otuple))
+		return TEST_ERROR;
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_nat_fwd_original_renated")
+int nodeport_nat_fwd_original_renated_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	__u32 key = 0;
+	__u16 nat_source_port = 0;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)lb_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the LB MAC")
+	if (memcmp(l2->h_dest, (__u8 *)remote_backend_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the remote backend MAC")
+
+	if (l3->saddr != LB_IP)
+		test_fatal("src IP hasn't been NATed to LB IP");
+
+	if (l3->daddr != BACKEND_IP_REMOTE)
+		test_fatal("dst IP hasn't been NATed to remote backend IP");
+
+	if (l3->check != bpf_htons(0xa711))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
+	if (l4->source == CLIENT_PORT)
+		test_fatal("src port hasn't been NATed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been NATed to backend port");
+
+	struct mock_settings *settings = map_lookup_elem(&settings_map, &key);
+
+	if (settings)
+		nat_source_port = settings->nat_source_port;
+
+	if (l4->source == nat_source_port)
+		test_fatal("src port hasn't been changed though original entry was deleted");
+
+	if (settings)
+		settings->nat_source_port = l4->source;
+
+	test_finish();
+}
+
+/* Test that the restored LB RevDNATs and RevSNATs a reply from the
+ * NAT remote backend, and sends it back to the client. And expects
+ * the Original NAT entry to be restored.
+ */
+PKTGEN("tc", "tc_nodeport_nat_fwd_restore_original_entry")
+int nodeport_nat_fwd_restore_original_entry_pktgen(struct __ctx_buff *ctx)
+{
+	return build_reply(ctx);
+}
+
+SETUP("tc", "tc_nodeport_nat_fwd_restore_original_entry")
+int nodeport_nat_fwd_restore_original_entry_setup(struct __ctx_buff *ctx)
+{
+	struct ipv4_ct_tuple otuple = {};
+
+	otuple.flags = TUPLE_F_OUT;
+	otuple.saddr = CLIENT_IP;
+	otuple.daddr = BACKEND_IP_REMOTE;
+	otuple.nexthdr = IPPROTO_TCP;
+	otuple.sport = CLIENT_PORT;
+	otuple.dport = BACKEND_PORT;
+
+	/* Delete the Original NAT entry*/
+	if IS_ERR(map_delete_elem(&cilium_snat_v4_external, &otuple))
+		return TEST_ERROR;
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_nat_fwd_restore_original_entry")
+int nodeport_nat_fwd_restore_original_entry_check(struct __ctx_buff *ctx)
+{
+	return check_reply(ctx);
+}
+
+/* Test that a SVC request that is LBed to a NAT remote backend
+ * - gets DNATed and SNATed,
+ * - gets redirected back out by TC
+ * - verifies that the Original NAT entry is restored.
+ */
+PKTGEN("tc", "tc_nodeport_nat_fwd_verify_restored_original_entry")
+int nodeport_nat_fwd_verify_restored_original_entry_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)lb_mac,
+					  CLIENT_IP, FRONTEND_IP_REMOTE,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_nat_fwd_verify_restored_original_entry")
+int nodeport_nat_fwd_verify_restored_original_entry_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 5;
+
+	lb_v4_add_service(FRONTEND_IP_REMOTE, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
+	lb_v4_add_backend(FRONTEND_IP_REMOTE, FRONTEND_PORT, 1, 124,
+			  BACKEND_IP_REMOTE, BACKEND_PORT, IPPROTO_TCP, 0);
+	ipcache_v4_add_entry(BACKEND_IP_REMOTE, 0, 112233, 0, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_nat_fwd_verify_restored_original_entry")
+int nodeport_nat_fwd_verify_restored_original_entry_check(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	__u32 key = 0;
+	__u16 nat_source_port = 0;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)lb_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the LB MAC")
+	if (memcmp(l2->h_dest, (__u8 *)remote_backend_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the remote backend MAC")
+
+	if (l3->saddr != LB_IP)
+		test_fatal("src IP hasn't been NATed to LB IP");
+
+	if (l3->daddr != BACKEND_IP_REMOTE)
+		test_fatal("dst IP hasn't been NATed to remote backend IP");
+
+	if (l3->check != bpf_htons(0xa711))
+		test_fatal("L3 checksum is invalid: %d", bpf_htons(l3->check));
+
+	if (l4->source == CLIENT_PORT)
+		test_fatal("src port hasn't been NATed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been NATed to backend port");
+
+	struct mock_settings *settings = map_lookup_elem(&settings_map, &key);
+
+	if (settings)
+		nat_source_port = settings->nat_source_port;
+
+	if (l4->source != nat_source_port)
+		test_fatal("Original NAT entry hasn't been restored");
+
+	test_finish();
+}


### PR DESCRIPTION
<!-- Description of change -->
# Problem Statement

- In client-to-service communication, when traffic is load-balanced to a remote endpoint, the remote endpoint sends an RST due to incorrect SNAT(new source port). As a result, the socket and session are terminated.
- The same issue also occurs in pod-to-external communication.
- For more details, refer to #36572 

# Root Cause

- This issue occurs when the original NAT entry is evicted from the SNAT_MAPPING map due to the LRU policy. As a result, even for a flow that has already undergone SNAT, a new source port is assigned. The remote endpoint then terminates the session due to the unexpected source port.

# Solution Summary

- Recreating the deleted original entry in snat_v4_rev_nat_handle_mapping().
![image](https://github.com/user-attachments/assets/70e2bdf1-6c61-4b23-bba5-6f586db1ccef)

# Impact Assessment

This patch has a substantial impact on connection reliability. In testing, it reduced the connection failure rate from 1–10% to virtually 0%, effectively eliminating the issue.

![image](https://github.com/user-attachments/assets/9c5dc5df-015e-492c-9b97-6d89219d5f3f)

# Issue Details

- snat_v4_rev_nat_handle_mapping() correctly finds the reverse entry.
- When the egress packet reaches snat_v4_nat_handle_mapping(), the original entry has already been evicted by LRU.
- Since the original entry is missing, snat_v4_new_mapping() assigns a new source port for NAT.
- If this happens, the endpoint socket detects a port change and sends an RST packet.

# eBPF Unit Test Flow

- The original packet gets ReSNATed when the entry is deleted.
- The reply packet restores the Original NAT entry if it is deleted.
- The original pakcket does not get ReSNATed. Because the Original NAT entry is restored.

----

Network failures can occur due to LRU eviction in the BPF map. This happens because NAT entries are evicted during packet transmission. Inspired by #35304, I developed this PR to help mitigate this issue. This PR restores deleted original NAT entries in `snat_v4_rev_nat_handle_mapping()`. The idea was initially proposed at https://github.com/cilium/cilium/pull/36631#issuecomment-2650776896, and this PR serves as its actual implementation.
Thanks to @julianwiedmann @sugangli 