### PR TITLE
ci: increase global timeout for Envoy Embedded github action workflow

### DIFF
--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -27,7 +27,7 @@ jobs:
   installation-and-connectivity:
     name: "Installation and Connectivity Test"
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 60
     env:
       job_name: "Installation and Connectivity Test"
     steps:


### PR DESCRIPTION
This commit increases the timeout for the GitHub action workflow `Conformance Kind Envoy Embedded` from 45 to 60 minutes.

It seems as there are a lot of timeout related aborts because the step `Install Cilium CLI` can take quite a bit.

It seems as other jobs aren't affected - even though installing the Cilium CLI also takes some time (maybe they have their timeouts set (adjusted?) correctly)

Examples:

* https://github.com/cilium/cilium/actions/runs/13397443067/job/37419908007
* https://github.com/cilium/cilium/actions/runs/13409356832/job/37455715392
* https://github.com/cilium/cilium/actions/runs/13410964474/job/37460902423