### PR TITLE
Egress Gateway performance testing

### DIFF
--- a/.github/actions/cl2-modules/egw/config.yaml
+++ b/.github/actions/cl2-modules/egw/config.yaml
@@ -10,8 +10,9 @@
 {{$CreateEGWPolicy := DefaultParam .CL2_EGW_CREATE_POLICY false}}
 {{$EGWPolicyTemplate := DefaultParam .CL2_EGW_POLICY_TEMPLATE "manifests/egw-policy.yaml"}}
 {{$ManifestsDir := DefaultParam .CL2_EGW_MANIFESTS_DIR "manifests"}}
+{{$UDPMessageSize := DefaultParam .CL2_EGW_PERF_UDP_MSG_SIZE 1024}}
 
-name: egw-scale-test-masq-delay
+name: egw-scale-perf-test
 namespace:
   number: 1
   deleteAutomanagedNamespaces: false
@@ -172,10 +173,18 @@ steps:
       replicas: {{$NumEGWClients}}
       metricsSuffix: HighScale
 
+# Gather the Cilium metrics here, so that they are not impacted by the performance test.
 - module:
     path: ../cilium-metrics.yaml
     params:
       action: gather
+
+# Run the performance test.
+- module:
+    path: modules/perf-test.yaml
+    params:
+      gatewayAddress: {{$GatewayAddress}}
+      udpMessageSize: {{$UDPMessageSize}}
 
 - module:
     path: ../cilium-agent-pprofs.yaml

--- a/.github/actions/cl2-modules/egw/manifests/egw-policy.yaml
+++ b/.github/actions/cl2-modules/egw/manifests/egw-policy.yaml
@@ -7,6 +7,9 @@ spec:
   - podSelector:
       matchLabels:
         app.kubernetes.io/name: egw-client
+  - podSelector:
+      matchLabels:
+        name: perf-client-other-node
   destinationCIDRs:
   - "{{.ExternalTarget}}/32"
   egressGateway:

--- a/.github/actions/cl2-modules/egw/modules/masq-metrics.yaml
+++ b/.github/actions/cl2-modules/egw/modules/masq-metrics.yaml
@@ -42,7 +42,7 @@ steps:
       unit: pod
       queries:
       - name: EGW Total Number of Client Pods
-        query: count(count(egw_scale_test_masquerade_delay_seconds_total{k8s_instance="{{ .instance }}"}) by (pod))
+        query: count(egw_scale_test_failed_tests_total{k8s_instance="{{ .instance }}"})
       - name: EGW Total Number of Failed Client Pods
-        query: count(count(egw_scale_test_masquerade_delay_seconds_total{k8s_instance="{{ .instance }}"}==0) by (pod))
+        query: sum(egw_scale_test_failed_tests_total{k8s_instance="{{ .instance }}"})
         threshold: 0

--- a/.github/actions/cl2-modules/egw/modules/perf-metrics.yaml
+++ b/.github/actions/cl2-modules/egw/modules/perf-metrics.yaml
@@ -1,0 +1,23 @@
+steps:
+- name: "{{ .action }} node metrics"
+  measurements:
+  - Identifier: NodeCPUUsage
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{ .action }}
+      metricName: "Node CPU Usage"
+      metricVersion: v1
+      unit: cpu
+      queries:
+      - name: Total (Max)
+        query: max(avg_over_time(rate(container_cpu_usage_seconds_total{id="/"}[1m])[%v:10s]))
+      - name: User (Max)
+        query: max(avg_over_time(rate(container_cpu_user_seconds_total{id="/"}[1m])[%v:10s]))
+      - name: System (Max)
+        query: max(avg_over_time(rate(container_cpu_system_seconds_total{id="/"}[1m])[%v:10s]))
+      - name: Total (Gateway)
+        query: max(avg_over_time(rate(container_cpu_usage_seconds_total{instance=~"{{ .gatewayAddress }}:.*", id="/"}[1m])[%v:10s]))
+      - name: User (Gateway)
+        query: max(avg_over_time(rate(container_cpu_user_seconds_total{instance=~"{{ .gatewayAddress }}:.*", id="/"}[1m])[%v:10s]))
+      - name: System (Gateway)
+        query: max(avg_over_time(rate(container_cpu_system_seconds_total{instance=~"{{ .gatewayAddress }}:.*", id="/"}[1m])[%v:10s]))

--- a/.github/actions/cl2-modules/egw/modules/perf-test.yaml
+++ b/.github/actions/cl2-modules/egw/modules/perf-test.yaml
@@ -1,0 +1,46 @@
+steps:
+- module:
+    path: modules/perf-metrics.yaml
+    params:
+      action: start
+      gatewayAddress: {{ .gatewayAddress }}
+
+# Run the performance tests via CL2 as well, so that metrics are automatically scraped.
+- name: Run performance tests
+  measurements:
+  - Identifier: ExecCommand
+    Method: Exec
+    Params:
+      command:
+      - cilium
+      - connectivity
+      - perf
+      - --report-dir=./report
+      - --duration=30s
+      - --setup-delay=10s
+      - --throughput=true
+      - --rr=true
+      - --crr=true
+      - --udp=true
+      - --msg-size={{ .udpMessageSize }}
+      - --pod-net=false
+      - --host-net=false
+      - --pod-to-host=true
+      - --same-node=false
+      - --other-node=true
+      - --tolerations=node.kubernetes.io/not-ready,cilium.io/no-schedule
+      - --node-selector-server=cilium.io/no-schedule=true
+      - --node-selector-client=role.scaffolding/egw-client=true
+
+- name: Sleep to allow scraping
+  measurements:
+  - Identifier: SleepMetricsScraping
+    Method: Sleep
+    Params:
+      duration: 60s
+
+- module:
+    path: modules/perf-metrics.yaml
+    params:
+      action: gather
+      gatewayAddress: {{ .gatewayAddress }}

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -521,6 +521,7 @@ jobs:
           CL2_MEDIAN_BOOTSTRAP_THRESHOLD: "80" # Takes a bit for ENI interfaces to be added
           CL2_EGW_CREATE_POLICY: ${{ matrix.test_type == 'egw' }}
           CL2_EGW_MANIFESTS_DIR: ../../.github/actions/cl2-modules/egw/manifests
+          CL2_EGW_PERF_UDP_MSG_SIZE: 8900
         run: |
           echo "CL2-related environment variables"
           printenv | grep CL2_
@@ -540,6 +541,9 @@ jobs:
             --kubeconfig=$HOME/.kube/config \
             --testoverrides=./testing/prometheus/not-scrape-kube-proxy.yaml \
             2>&1 | tee cl2-output.txt
+
+          # The cilium-cli creates files owned by the root user when run as a container.
+          sudo chmod --recursive +r ./report
 
       - name: Features tested
         uses: ./.github/actions/feature-status

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -531,6 +531,7 @@ jobs:
             --testconfig=../../.github/actions/cl2-modules/egw/config.yaml \
             --prometheus-additional-monitors-path=../../.github/actions/cl2-modules/egw/prom-extra-podmons \
             --provider=aws \
+            --enable-exec-service=false \
             --enable-prometheus-server \
             --prometheus-scrape-kubelets \
             --tear-down-prometheus-server=false \


### PR DESCRIPTION
Add a step at the end of the egress gateway scale test to measure the network performance for pod to external endpoint traffic, potentially flowing through the egress gateway. More specifically, we leverage the cilium connectivity perf tool and configure it to deploy the client on one of the cluster nodes (in pod network), and the server on the external node (in host network). The egress gateway policy is updated to additionally match the client pod.