### PR TITLE
ci: run build steps as concurrent jobs in lint-build-commits

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Compute variables
     runs-on: ubuntu-22.04
     outputs:
-      commits: ${{ steps.commits.outputs.commits }}
+      matrix: ${{ steps.commits.outputs.matrix }}
       head-commit: ${{ steps.commits.outputs.head-commit }}
       build-bpf: ${{ steps.bpf-changes.outputs.src }}
       build-test: ${{ steps.test-changes.outputs.src }}
@@ -47,7 +47,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Compute commit list
+      - name: Compute matrix
         id: commits
         run: |
           if [[ "${{ github.event_name == 'push' || github.event_name == 'workflow_run' }}" == "true" ]]; then
@@ -57,7 +57,7 @@ jobs:
             commits=$(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | tr '\n' ' ')
             head_commit=${{ github.event.pull_request.head.sha }}
           fi
-          echo "commits=$commits" >> $GITHUB_OUTPUT
+          echo "matrix=$(echo "$commits" | xargs | jq -c -R 'split(" ") | {commit: .}')" >> $GITHUB_OUTPUT
           echo "head-commit=$head_commit" >> $GITHUB_OUTPUT
 
       - name: Check bpf code changes
@@ -65,7 +65,7 @@ jobs:
         id: bpf-changes
         with:
           # If these filters are modified, also modify the step:
-          # build-commits-bpf: Check if datapath build works for every commit
+          # build-bpf: Check if bpf builds
           filters: |
             src:
               - 'bpf/**'
@@ -75,17 +75,20 @@ jobs:
         id: test-changes
         with:
           # If these filters are modified, also modify the step:
-          # build-commits-test: Check if ginkgo test suite build works for every commit
+          # build-test: Check if ginkgo test suite builds
           filters: |
             src:
               - 'pkg/**'
               - 'test/**'
 
-  build-commits-cilium:
-    name: Check if cilium builds for every commit
+  build-cilium:
+    name: cilium build check ${{ matrix.commit }}
     runs-on: ubuntu-22.04
     needs: [compute-vars]
     timeout-minutes: 180
+    strategy:
+      max-parallel: 5
+      matrix: ${{ fromJSON(needs.compute-vars.outputs.matrix) }}
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
@@ -101,8 +104,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
+          ref: ${{ matrix.commit }}
 
       - name: Cleanup Disk space in runner
         uses: ./.github/actions/disk-cleanup
@@ -141,7 +143,7 @@ jobs:
           mkdir -p /tmp/.cache/go/pkg
           mkdir -p /tmp/.cache/ccache/.ccache
 
-      - name: Check if build works for every commit
+      - name: Check if cilium builds for commit
         if: ${{ github.event_name != 'push' || ( (github.event_name == 'push' || github.event_name == 'workflow_run' ) && (steps.go-cache.outputs.cache-hit != 'true' || steps.ccache-cache.outputs.cache-hit != 'true')) }}
         env:
           CLANG: "ccache clang"
@@ -150,11 +152,7 @@ jobs:
           BUILDER_CCACHE_DIR: "/tmp/.cache/ccache/.ccache"
         run: |
           set -eu -o pipefail
-          commits="${{ needs.compute-vars.outputs.commits }}"
-          for commit in $commits; do
-            git checkout $commit || exit 1
-            contrib/scripts/builder.sh make CLANG="${CLANG}" build -j $(nproc) || exit 1
-          done
+          contrib/scripts/builder.sh make CLANG="${CLANG}" build -j $(nproc) || exit 1
 
       - name: Reset cache ownership to GitHub runners user
         if: ${{ steps.go-cache.outputs.cache-hit != 'true' || steps.ccache-cache.outputs.cache-hit != 'true' }}
@@ -163,15 +161,14 @@ jobs:
           sudo du -sh /tmp/.cache/
           sudo chown $USER:$USER -R /tmp/.cache
 
-      - name: Failed commit during the build
-        if: ${{ failure() }}
-        run: git --no-pager log --format=%B -n 1
-
-  build-commits-hubble-cli:
-    name: Check if hubble-cli builds for every commit
+  build-hubble-cli:
+    name: hubble-cli build check ${{ matrix.commit }}
     runs-on: ubuntu-22.04
     needs: [compute-vars]
     timeout-minutes: 180
+    strategy:
+      max-parallel: 5
+      matrix: ${{ fromJSON(needs.compute-vars.outputs.matrix) }}
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
@@ -187,8 +184,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
+          ref: ${{ matrix.commit }}
 
       - name: Cleanup Disk space in runner
         uses: ./.github/actions/disk-cleanup
@@ -227,7 +223,7 @@ jobs:
           mkdir -p /tmp/.cache/hubble-cli/.cache/go-build
           mkdir -p /tmp/.cache/hubble-cli/pkg
 
-      - name: Check if hubble CLI builds for every commit
+      - name: Check if hubble CLI builds for commit
         if: ${{ github.event_name != 'push' || ( github.event_name == 'push' && steps.hubble-cache.outputs.cache-hit != 'true' ) }}
         env:
           CLANG: "ccache clang"
@@ -235,18 +231,15 @@ jobs:
           BUILDER_GOMODCACHE_DIR: "/tmp/.cache/hubble-cli/pkg"
         run: |
           set -eu -o pipefail
-          commits="${{ needs.compute-vars.outputs.commits }}"
+          commit="${{ matrix.commit }}"
           head_commit="${{ needs.compute-vars.outputs.head-commit }}"
-          for commit in $commits; do
-            git checkout $commit || exit 1
-            echo "Only run full build (with `local-release`) for head commit (i.e. last commit in sequence)"
-            target=hubble
-            if [[ "$commit" == "$head_commit" ]]; then
-              target=local-release
-            fi
-            echo "Running build: $target (commit: $commit)"
-            contrib/scripts/builder.sh make CLANG="${CLANG}" -C hubble $target -j $(nproc) || exit 1
-          done
+          echo "Only run full build (with `local-release`) for head commit (i.e. last commit in sequence)"
+          target=hubble
+          if [[ "$commit" == "$head_commit" ]]; then
+            target=local-release
+          fi
+          echo "Running build: $target (commit: $commit)"
+          contrib/scripts/builder.sh make CLANG="${CLANG}" -C hubble local-release -j $(nproc) || exit 1
 
       - name: Reset cache ownership to GitHub runners user
         if: ${{ steps.ccache-cache.outputs.cache-hit != 'true' }}
@@ -255,17 +248,16 @@ jobs:
           sudo du -sh /tmp/.cache/
           sudo chown $USER:$USER -R /tmp/.cache
 
-      - name: Failed commit during the build
-        if: ${{ failure() }}
-        run: git --no-pager log --format=%B -n 1
-
-  build-commits-bpf:
-    name: Check if bpf builds for every commit
+  build-bpf:
+    name: bpf build check ${{ matrix.commit }}
     runs-on: ubuntu-22.04
     needs: [compute-vars]
     # Runs only if code under bpf/ is changed.
     if: needs.compute-vars.outputs.build-bpf == 'true'
     timeout-minutes: 180
+    strategy:
+      max-parallel: 5
+      matrix: ${{ fromJSON(needs.compute-vars.outputs.matrix) }}
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
@@ -281,8 +273,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
+          ref: ${{ matrix.commit }}
 
       - name: Cleanup Disk space in runner
         uses: ./.github/actions/disk-cleanup
@@ -321,7 +312,7 @@ jobs:
           mkdir -p /tmp/.cache/go/pkg
           mkdir -p /tmp/.cache/ccache/.ccache
 
-      - name: Check if datapath build works for every commit
+      - name: Check if bpf builds
         env:
           CLANG: "ccache clang"
           BUILDER_GOCACHE_DIR: "/tmp/.cache/go/.cache/go-build"
@@ -329,17 +320,13 @@ jobs:
           BUILDER_CCACHE_DIR: "/tmp/.cache/ccache/.ccache"
         run: |
           set -eu -o pipefail
-          commits="${{ needs.compute-vars.outputs.commits }}"
-          for commit in $commits; do
-            git checkout $commit || exit 1
-            # Do not run make if there aren't any files modified in these
-            # directories from the previous commit to the current commit.
-            # If these filters are modified, also modify the step:
-            # compute-vars: Check bpf code changes
-            if ! git diff --quiet HEAD^ bpf/ ; then
-              contrib/scripts/builder.sh make CLANG="${CLANG}" -C bpf build_all -j $(nproc) || exit 1
-            fi
-          done
+          # Do not run make if there aren't any files modified in these
+          # directories from the previous commit to the current commit.
+          # If these filters are modified, also modify the step:
+          # compute-vars: Check bpf code changes
+          if ! git diff --quiet HEAD^ bpf/ ; then
+            contrib/scripts/builder.sh make CLANG="${CLANG}" -C bpf build_all -j $(nproc) || exit 1
+          fi
 
       - name: Reset cache ownership to GitHub runners user
         if: ${{ steps.go-cache.outputs.cache-hit != 'true' || steps.ccache-cache.outputs.cache-hit != 'true' }}
@@ -348,17 +335,16 @@ jobs:
           sudo du -sh /tmp/.cache/
           sudo chown $USER:$USER -R /tmp/.cache
 
-      - name: Failed commit during the build
-        if: ${{ failure() }}
-        run: git --no-pager log --format=%B -n 1
-
-  build-commits-test:
-    name: Check if test builds for every commit
+  build-test:
+    name: test build check ${{ matrix.commit }}
     runs-on: ubuntu-22.04
     needs: [compute-vars]
     # Runs only if code under test/ is changed.
     if: needs.compute-vars.outputs.build-test == 'true'
     timeout-minutes: 180
+    strategy:
+      max-parallel: 5
+      matrix: ${{ fromJSON(needs.compute-vars.outputs.matrix) }}
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
@@ -374,8 +360,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
+          ref: ${{ matrix.commit }}
 
       - name: Cleanup Disk space in runner
         uses: ./.github/actions/disk-cleanup
@@ -406,21 +391,13 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/ginkgo@cc0216944b25a88d3259699a029d4e601fb8a222 # v1.12.1
 
-      - name: Check if ginkgo test suite build works for every commit
+      - name: Check if ginkgo test suite builds
         run: |
           set -eu -o pipefail
-          commits="${{ needs.compute-vars.outputs.commits }}"
-          for commit in $commits; do
-            git checkout $commit || exit 1
-            # Do not run make if there aren't any files modified in these
-            # directories from the previous commit to the current commit.
-            # If these filters are modified, also modify the step:
-            # compute-vars: Check test code changes
-            if ! git diff --quiet HEAD^ pkg/ test/ ; then
-              (make -C test build -j $(nproc) && make -C test build-darwin -j $(nproc)) || exit 1
-            fi
-          done
-
-      - name: Failed commit during the build
-        if: ${{ failure() }}
-        run: git --no-pager log --format=%B -n 1
+          # Do not run make if there aren't any files modified in these
+          # directories from the previous commit to the current commit.
+          # If these filters are modified, also modify the step:
+          # compute-vars: Check test code changes
+          if ! git diff --quiet HEAD^ pkg/ test/ ; then
+            (make -C test build -j $(nproc) && make -C test build-darwin -j $(nproc)) || exit 1
+          fi

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -25,9 +25,66 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_commits:
-    name: Check if build works for every commit
+  compute-vars:
+    name: Compute variables
     runs-on: ubuntu-22.04
+    outputs:
+      commits: ${{ steps.commits.outputs.commits }}
+      head-commit: ${{ steps.commits.outputs.head-commit }}
+      build-bpf: ${{ steps.bpf-changes.outputs.src }}
+      build-test: ${{ steps.test-changes.outputs.src }}
+    timeout-minutes: 180
+    steps:
+      - name: Configure git
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Compute commit list
+        id: commits
+        run: |
+          if [[ "${{ github.event_name == 'push' || github.event_name == 'workflow_run' }}" == "true" ]]; then
+            commits=${{ github.sha }}
+            head_commit=${{ github.sha }}
+          else
+            commits=$(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | tr '\n' ' ')
+            head_commit=${{ github.event.pull_request.head.sha }}
+          fi
+          echo "commits=$commits" >> $GITHUB_OUTPUT
+          echo "head-commit=$head_commit" >> $GITHUB_OUTPUT
+
+      - name: Check bpf code changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: bpf-changes
+        with:
+          # If these filters are modified, also modify the step:
+          # build-commits-bpf: Check if datapath build works for every commit
+          filters: |
+            src:
+              - 'bpf/**'
+
+      - name: Check test code changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: test-changes
+        with:
+          # If these filters are modified, also modify the step:
+          # build-commits-test: Check if ginkgo test suite build works for every commit
+          filters: |
+            src:
+              - 'pkg/**'
+              - 'test/**'
+
+  build-commits-cilium:
+    name: Check if cilium builds for every commit
+    runs-on: ubuntu-22.04
+    needs: [compute-vars]
     timeout-minutes: 180
     steps:
       - name: Collect Workflow Telemetry
@@ -57,7 +114,6 @@ jobs:
           # renovate: datasource=golang-version depName=go
           go-version: 1.24.0
 
-      # Load Golang cache build from GitHub
       - name: Load Golang cache build from GitHub
         uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
         id: go-cache
@@ -68,18 +124,6 @@ jobs:
             ${{ runner.os }}-go-all-cache-
             ${{ runner.os }}-go-
 
-      # Load Hubble cache build from GitHub
-      - name: Load hubble-cli Golang cache build from GitHub
-        uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
-        id: hubble-cache
-        with:
-          path: /tmp/.cache/hubble-cli
-          key: ${{ runner.os }}-go-hubble-cli-cache-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-hubble-cli-cache-
-            ${{ runner.os }}-go-
-
-      # Load CCache build from GitHub
       - name: Load ccache cache build from GitHub
         uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
         id: ccache-cache
@@ -90,16 +134,12 @@ jobs:
             ${{ runner.os }}-ccache-
 
       - name: Create cache directories if they don't exist
-        if: ${{ steps.go-cache.outputs.cache-hit != 'true' ||
-          steps.ccache-cache.outputs.cache-hit != 'true' ||
-          steps.hubble-cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.go-cache.outputs.cache-hit != 'true' || steps.ccache-cache.outputs.cache-hit != 'true' }}
         shell: bash
         run: |
           mkdir -p /tmp/.cache/go/.cache/go-build
           mkdir -p /tmp/.cache/go/pkg
           mkdir -p /tmp/.cache/ccache/.ccache
-          mkdir -p /tmp/.cache/hubble-cli/.cache/go-build
-          mkdir -p /tmp/.cache/hubble-cli/pkg
 
       - name: Check if build works for every commit
         if: ${{ github.event_name != 'push' || ( (github.event_name == 'push' || github.event_name == 'workflow_run' ) && (steps.go-cache.outputs.cache-hit != 'true' || steps.ccache-cache.outputs.cache-hit != 'true')) }}
@@ -110,15 +150,82 @@ jobs:
           BUILDER_CCACHE_DIR: "/tmp/.cache/ccache/.ccache"
         run: |
           set -eu -o pipefail
-          if [[ "${{ github.event_name == 'push' || github.event_name == 'workflow_run' }}" == "true" ]]; then
-            COMMITS=${{ github.sha }}
-          else
-            COMMITS=$(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
-          fi
-          for commit in $COMMITS ; do
+          commits="${{ needs.compute-vars.outputs.commits }}"
+          for commit in $commits; do
             git checkout $commit || exit 1
             contrib/scripts/builder.sh make CLANG="${CLANG}" build -j $(nproc) || exit 1
           done
+
+      - name: Reset cache ownership to GitHub runners user
+        if: ${{ steps.go-cache.outputs.cache-hit != 'true' || steps.ccache-cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          sudo du -sh /tmp/.cache/
+          sudo chown $USER:$USER -R /tmp/.cache
+
+      - name: Failed commit during the build
+        if: ${{ failure() }}
+        run: git --no-pager log --format=%B -n 1
+
+  build-commits-hubble-cli:
+    name: Check if hubble-cli builds for every commit
+    runs-on: ubuntu-22.04
+    needs: [compute-vars]
+    timeout-minutes: 180
+    steps:
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
+        with:
+          comment_on_pr: false
+
+      - name: Configure git
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
+
+      - name: Install Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          cache: false
+          # renovate: datasource=golang-version depName=go
+          go-version: 1.24.0
+
+      - name: Load hubble-cli Golang cache build from GitHub
+        uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
+        id: hubble-cache
+        with:
+          path: /tmp/.cache/hubble-cli
+          key: ${{ runner.os }}-go-hubble-cli-cache-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-hubble-cli-cache-
+            ${{ runner.os }}-go-
+
+      - name: Load ccache cache build from GitHub
+        uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
+        id: ccache-cache
+        with:
+          path: /tmp/.cache/ccache
+          key: ${{ runner.os }}-ccache-${{ hashFiles('bpf/**') }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-
+
+      - name: Create cache directories if they don't exist
+        if: ${{ steps.ccache-cache.outputs.cache-hit != 'true' || steps.hubble-cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.cache/ccache/.ccache
+          mkdir -p /tmp/.cache/hubble-cli/.cache/go-build
+          mkdir -p /tmp/.cache/hubble-cli/pkg
 
       - name: Check if hubble CLI builds for every commit
         if: ${{ github.event_name != 'push' || ( github.event_name == 'push' && steps.hubble-cache.outputs.cache-hit != 'true' ) }}
@@ -128,37 +235,93 @@ jobs:
           BUILDER_GOMODCACHE_DIR: "/tmp/.cache/hubble-cli/pkg"
         run: |
           set -eu -o pipefail
-          if [[ "${{ github.event_name == 'push' || github.event_name == 'workflow_run' }}" == "true" ]]; then
-            COMMITS=${{ github.sha }}
-            HEAD_COMMIT=${{ github.sha }}
-          else
-            COMMITS=$(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
-            HEAD_COMMIT=${{ github.event.pull_request.head.sha }}
-          fi
-          for commit in $COMMITS ; do
+          commits="${{ needs.compute-vars.outputs.commits }}"
+          head_commit="${{ needs.compute-vars.outputs.head-commit }}"
+          for commit in $commits; do
             git checkout $commit || exit 1
-            # full build (with `local-release`) only for head commit (i.e. last commit in sequence)
+            echo "Only run full build (with `local-release`) for head commit (i.e. last commit in sequence)"
             target=hubble
-            if [[ "$commit" == "$HEAD_COMMIT" ]] ; then
+            if [[ "$commit" == "$head_commit" ]]; then
               target=local-release
             fi
+            echo "Running build: $target (commit: $commit)"
             contrib/scripts/builder.sh make CLANG="${CLANG}" -C hubble $target -j $(nproc) || exit 1
           done
 
+      - name: Reset cache ownership to GitHub runners user
+        if: ${{ steps.ccache-cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          sudo du -sh /tmp/.cache/
+          sudo chown $USER:$USER -R /tmp/.cache
 
-      - name: Check bpf code changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: bpf-tree
+      - name: Failed commit during the build
+        if: ${{ failure() }}
+        run: git --no-pager log --format=%B -n 1
+
+  build-commits-bpf:
+    name: Check if bpf builds for every commit
+    runs-on: ubuntu-22.04
+    needs: [compute-vars]
+    # Runs only if code under bpf/ is changed.
+    if: needs.compute-vars.outputs.build-bpf == 'true'
+    timeout-minutes: 180
+    steps:
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
         with:
-          # If these filters are modified, also modify the step below where we
-          # do a git diff
-          filters: |
-            src:
-              - 'bpf/**'
+          comment_on_pr: false
 
-      # Runs only if code under bpf/ is changed.
+      - name: Configure git
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
+
+      - name: Install Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          cache: false
+          # renovate: datasource=golang-version depName=go
+          go-version: 1.24.0
+
+      - name: Load Golang cache build from GitHub
+        uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
+        id: go-cache
+        with:
+          path: /tmp/.cache/go
+          key: ${{ runner.os }}-go-all-cache-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-all-cache-
+            ${{ runner.os }}-go-
+
+      - name: Load ccache cache build from GitHub
+        uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
+        id: ccache-cache
+        with:
+          path: /tmp/.cache/ccache
+          key: ${{ runner.os }}-ccache-${{ hashFiles('bpf/**') }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-
+
+      - name: Create cache directories if they don't exist
+        if: ${{ steps.go-cache.outputs.cache-hit != 'true' || steps.ccache-cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.cache/go/.cache/go-build
+          mkdir -p /tmp/.cache/go/pkg
+          mkdir -p /tmp/.cache/ccache/.ccache
+
       - name: Check if datapath build works for every commit
-        if: steps.bpf-tree.outputs.src == 'true'
         env:
           CLANG: "ccache clang"
           BUILDER_GOCACHE_DIR: "/tmp/.cache/go/.cache/go-build"
@@ -166,17 +329,13 @@ jobs:
           BUILDER_CCACHE_DIR: "/tmp/.cache/ccache/.ccache"
         run: |
           set -eu -o pipefail
-          if [[ "${{ github.event_name == 'push' || github.event_name == 'workflow_run' }}" == "true" ]]; then
-            COMMITS=${{ github.sha }}
-          else
-            COMMITS=$(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
-          fi
-          for commit in $COMMITS ; do
+          commits="${{ needs.compute-vars.outputs.commits }}"
+          for commit in $commits; do
             git checkout $commit || exit 1
             # Do not run make if there aren't any files modified in these
             # directories from the previous commit to the current commit.
-            # If these filters are modified, also modify the step above where we
-            # run dorny/paths-filter.
+            # If these filters are modified, also modify the step:
+            # compute-vars: Check bpf code changes
             if ! git diff --quiet HEAD^ bpf/ ; then
               contrib/scripts/builder.sh make CLANG="${CLANG}" -C bpf build_all -j $(nproc) || exit 1
             fi
@@ -189,56 +348,74 @@ jobs:
           sudo du -sh /tmp/.cache/
           sudo chown $USER:$USER -R /tmp/.cache
 
-      - name: Check test code changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: test-tree
+      - name: Failed commit during the build
+        if: ${{ failure() }}
+        run: git --no-pager log --format=%B -n 1
+
+  build-commits-test:
+    name: Check if test builds for every commit
+    runs-on: ubuntu-22.04
+    needs: [compute-vars]
+    # Runs only if code under test/ is changed.
+    if: needs.compute-vars.outputs.build-test == 'true'
+    timeout-minutes: 180
+    steps:
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
         with:
-          # If these filters are modified, also modify the step below where we
-          # do a git diff
-          filters: |
-            src:
-              - 'pkg/**'
-              - 'test/**'
+          comment_on_pr: false
+
+      - name: Configure git
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
+
+      - name: Install Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          cache: false
+          # renovate: datasource=golang-version depName=go
+          go-version: 1.24.0
 
       - name: Set clang directory
-        if: steps.test-tree.outputs.src == 'true'
         id: set_clang_dir
         run: echo "clang_dir=$HOME/.clang" >> $GITHUB_OUTPUT
 
       - name: Install LLVM and Clang prerequisites
-        if: steps.test-tree.outputs.src == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libtinfo5
 
       - name: Install LLVM and Clang
-        if: steps.test-tree.outputs.src == 'true'
         uses: KyleMayes/install-llvm-action@e0a8dc9cb8a22e8a7696e8a91a4e9581bec13181 # v2.0.5
         with:
           version: "18.1.8"
           directory: ${{ steps.set_clang_dir.outputs.clang_dir }}
 
       - name: Install ginkgo
-        if: steps.test-tree.outputs.src == 'true'
         run: |
           go install github.com/onsi/ginkgo/ginkgo@cc0216944b25a88d3259699a029d4e601fb8a222 # v1.12.1
 
-      # Runs only if code under test/ is changed.
       - name: Check if ginkgo test suite build works for every commit
-        if: steps.test-tree.outputs.src == 'true'
         run: |
           set -eu -o pipefail
-          if [[ "${{ github.event_name == 'push' || github.event_name == 'workflow_run' }}" == "true" ]]; then
-            COMMITS=${{ github.sha }}
-          else
-            COMMITS=$(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
-          fi
-          for commit in $COMMITS ; do
+          commits="${{ needs.compute-vars.outputs.commits }}"
+          for commit in $commits; do
             git checkout $commit || exit 1
             # Do not run make if there aren't any files modified in these
             # directories from the previous commit to the current commit.
-            # If these filters are modified, also modify the step above where we
-            # run dorny/paths-filter.
+            # If these filters are modified, also modify the step:
+            # compute-vars: Check test code changes
             if ! git diff --quiet HEAD^ pkg/ test/ ; then
               (make -C test build -j $(nproc) && make -C test build-darwin -j $(nproc)) || exit 1
             fi


### PR DESCRIPTION
### Description

Update the `lint-build-commits` workflow to run all builds concurrently to reduce total run time.
In practice, we can often see this workflow run for 1-2hours.

As mentioned [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#handling-failures), the default fail-fast behaviour on matrix jobs will cancel any in-flight and queued jobs on failure, which is probably what we want here, but we could also consider letting them all run to obtain an overview of all commits that fails to build instead of the first one.

Note that the `cleanup disk space in runner` task takes from 30s to ~1min on each each job.

Related: https://github.com/cilium/cilium/pull/37750

### Build type concurrency

First commit runs each build type (cilium, hubble-cli, ebp, test) concurrently.
![image](https://github.com/user-attachments/assets/6b55613d-05cb-4b59-b1b4-7fa20a9d5d83)
https://github.com/cilium/cilium/actions/runs/13419158139

### Commit concurrency

Second commit runs each commit for each build type concurrently.
![image](https://github.com/user-attachments/assets/aae8a4eb-df20-46fa-bcde-7df976b5eefe)
https://github.com/cilium/cilium/actions/runs/13419693338

This is rather aggressive but should significantly reduce the total run time for PRs with multiple commits and/or with changes that touch multiple build types.

