### PR TITLE
.github: Run BPF Linters on changes to infra

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -43,6 +43,9 @@ jobs:
             bpf-tree:
               - 'bpf/**'
               - 'images/**'
+              - 'Makefile*'
+              - 'contrib/scripts/builder.sh'
+
             coccinelle:
               - 'contrib/coccinelle/**'
             bpf-tests-runner:


### PR DESCRIPTION
We recently introduced a regression into the main branch because we
modified build infrastructure that this workflow depends on, but those
dependencies were not encoded in the path filter for triggering this
action. Fix this by adding those files to this workflow. This should
mean that CI will pick up on build failures introduced by changes to
the build infrastructure.