### PR TITLE
contrib: Reverse default for running builder as root

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -87,7 +87,7 @@
     "^make -C Documentation update-helm-values$",
     "^make generate-k8s-api$",
     "^make manifests$",
-    "^make GO='RUN_AS_NONROOT=1 contrib/scripts/builder.sh go' generate-apis$"
+    "^make GO='contrib/scripts/builder.sh go' generate-apis$"
   ],
   "assignAutomerge": true,
   "packageRules": [
@@ -546,7 +546,7 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "make GO='RUN_AS_NONROOT=1 contrib/scripts/builder.sh go' generate-apis"
+          "make GO='contrib/scripts/builder.sh go' generate-apis"
         ],
         "executionMode": "update"
       }
@@ -559,7 +559,7 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "make GO='RUN_AS_NONROOT=1 contrib/scripts/builder.sh go' generate-apis"
+          "make GO='contrib/scripts/builder.sh go' generate-apis"
         ],
         "executionMode": "update"
       }

--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,7 @@ generate-k8s-api-local:
 
 .PHONY: generate-k8s-api
 generate-k8s-api: ## Generate Cilium k8s API client, deepcopy and deepequal Go sources.
-	RUN_AS_NONROOT=1 contrib/scripts/builder.sh \
+	contrib/scripts/builder.sh \
 		$(MAKE) -C /go/src/github.com/cilium/cilium/ generate-k8s-api-local
 
 check-k8s-clusterrole: ## Ensures there is no diff between preflight's clusterrole and runtime's clusterrole.
@@ -522,7 +522,7 @@ BPF_TEST_DUMP_CTX ?= ""
 BPF_TEST_VERBOSE ?= 0
 
 run_bpf_tests: ## Build and run the BPF unit tests using the cilium-builder container image.
-	DOCKER_ARGS=--privileged contrib/scripts/builder.sh \
+	DOCKER_ARGS=--privileged RUN_AS_ROOT=1 contrib/scripts/builder.sh \
 		"make" "-j$(shell nproc)" "-C" "bpf/tests/" "run" "BPF_TEST_FILE=$(BPF_TEST_FILE)" "BPF_TEST_DUMP_CTX=$(BPF_TEST_DUMP_CTX)" "V=$(BPF_TEST_VERBOSE)"
 
 run-builder: ## Drop into a shell inside a container running the cilium-builder image.

--- a/contrib/scripts/builder.sh
+++ b/contrib/scripts/builder.sh
@@ -13,7 +13,7 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     USER_PATH="/tmp"
 fi
 
-if [ -n "${RUN_AS_NONROOT:-}" ]; then
+if [ -z "${RUN_AS_ROOT:-}" ]; then
     USER_OPTION="--user $(id -u):$(id -g)"
     USER_PATH="$HOME"
 fi


### PR DESCRIPTION
Depends on https://github.com/cilium/cilium/pull/37755 for testing the change.

The default was to run this script as root, then opt in to running as a
regular user. However, there's one specific case where this needs to run
as root, where privileged BPF tests are triggered. Reverse the logic so
that this is the only case that passes the 'RUN_AS_ROOT' environment
variable, so then the default is to trigger this build as non-root by
default.

Suggested-by: @jrajahalme 