### PR TITLE
cli: Attribute test failures outside of action failures

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -515,9 +515,18 @@ func (ct *ConnectivityTest) report() error {
 			}
 		}
 		if len(failed) > 0 && failedActions == 0 {
-			// Test failure was triggered not by a specific action
-			// failing, but some other infrastructure code.
-			ct.LogOwners(defaultTestOwners)
+			allScenarios := make([]ownedScenario, 0, len(failed))
+			for _, t := range failed {
+				for scenario := range t.scenarios {
+					allScenarios = append(allScenarios, scenario)
+				}
+			}
+			if len(allScenarios) == 0 {
+				// Test failure was triggered not by a specific action
+				// failing, but some other infrastructure code.
+				allScenarios = []ownedScenario{defaultTestOwners}
+			}
+			ct.LogOwners(allScenarios...)
 		}
 
 		return fmt.Errorf("[%s] %d tests failed", ct.params.TestNamespace, nf)


### PR DESCRIPTION
Julian reports that when a test fails directly (via `t.Fail()`,
`t.Fatal()` and friends), the CLI falls back to attributing the failure
to the ci-structure group that owns the overall testing infrastructure
in the CLI, rather than attributing to the failed test itself.

This commit amends the fallback when a failure is not triggered directly
through an action / scenario by instead assembling all of the failed
scenarios and then reporting the ownership for those failed scenarios.
This should improve the accuracy of the test ownership attribution.
