### PR TITLE
Fix darwin(macOS) contrib/scripts/builder.sh error

### DIFF
--- a/contrib/scripts/builder.sh
+++ b/contrib/scripts/builder.sh
@@ -9,6 +9,10 @@ CILIUM_BUILDER_IMAGE=$(cat images/cilium/Dockerfile | grep '^ARG CILIUM_BUILDER_
 USER_OPTION=""
 USER_PATH="/root"
 
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    USER_PATH="/tmp"
+fi
+
 if [ -n "${RUN_AS_NONROOT:-}" ]; then
     USER_OPTION="--user $(id -u):$(id -g)"
     USER_PATH="$HOME"


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

macOS SIP(System Integrity Protection) prevents using /root directory. So the builder script fails on macOS. This commit makes the builder script use /tmp directory instead of /root on macOS. I discovered this issue while working on #37747.

The error occuring is as follows:
```
❯ sudo make run_bpf_tests -j8
DOCKER_ARGS=--privileged contrib/scripts/builder.sh \
		"make" "-j12" "-C" "bpf/tests/" "run" "BPF_TEST_FILE=""" "BPF_TEST_DUMP_CTX=""" "V=0"
docker: Error response from daemon: Mounts denied:
The path /root/.ccache is not shared from the host and is not known to Docker.
You can configure shared paths from Docker -> Preferences... -> Resources -> File Sharing.
See https://docs.docker.com/desktop/settings/mac/#file-sharing for more info.
make: *** [run_bpf_tests] Error 125
```
