### PR TITLE
clustermesh: kvstoremesh fully synces remote cluster configuration

### DIFF
--- a/pkg/clustermesh/kvstoremesh/kvstoremesh.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh.go
@@ -163,6 +163,7 @@ func (km *KVStoreMesh) newRemoteCluster(name string, status common.StatusFunc) c
 		serviceExports: newReflector(km.backend, name, mcsapitypes.ServiceExportStorePrefix, "", km.storeFactory, synced.resources),
 		identities:     newReflector(km.backend, name, identityCache.IdentitiesPath, identityCacheSuffix, km.storeFactory, synced.resources),
 		ipcache:        newReflector(km.backend, name, ipcache.IPIdentitiesPath, "", km.storeFactory, synced.resources),
+		config:         newClusterConfigSyncer(km.backend, name, km.storeFactory, synced.resources),
 		status:         status,
 		storeFactory:   km.storeFactory,
 		synced:         synced,
@@ -186,6 +187,7 @@ func (km *KVStoreMesh) newRemoteCluster(name string, status common.StatusFunc) c
 	run(rc.serviceExports.syncer.Run)
 	run(rc.identities.syncer.Run)
 	run(rc.ipcache.syncer.Run)
+	run(rc.config.syncer.Run)
 
 	run(rc.waitForConnection)
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

kvstoremesh now synces remote clustere's config instead of just copying it once on etcd (re)connection.

Fixes: #37701

```release-note
kvstoremesh synces remote cluster configuration instead of just copying it once on etcd (re)connection
```
