### PR TITLE
bpf: nat: support ICMPV6_DEST_UNREACH in egress path

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -2039,7 +2039,7 @@ int tail_no_service_ipv4(struct __ctx_buff *ctx)
 		/* Redirect ICMP to the interface we received it on. */
 		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY,
 				   ctx_get_ifindex(ctx));
-		ret = ctx_redirect(ctx, ctx_get_ifindex(ctx), 0);
+		ret = redirect_self(ctx);
 	}
 
 	if (IS_ERR(ret))
@@ -2219,7 +2219,7 @@ int tail_no_service_ipv6(struct __ctx_buff *ctx)
 		/* Redirect ICMP to the interface we received it on. */
 		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY,
 				   ctx_get_ifindex(ctx));
-		ret = ctx_redirect(ctx, ctx_get_ifindex(ctx), 0);
+		ret = redirect_self(ctx);
 	}
 
 drop_err:

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -2025,10 +2025,7 @@ int __tail_no_service_ipv4(struct __ctx_buff *ctx)
 	csum += csum_diff(icmphdr, 0, icmphdr, sizeof(struct icmphdr), 0);
 	icmphdr->checksum = csum_fold(csum);
 
-	/* Redirect ICMP to the interface we received it on. */
-	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY,
-			   ctx_get_ifindex(ctx));
-	return ctx_redirect(ctx, ctx_get_ifindex(ctx), 0);
+	return 0;
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NO_SERVICE)
@@ -2038,6 +2035,13 @@ int tail_no_service_ipv4(struct __ctx_buff *ctx)
 	int ret;
 
 	ret = __tail_no_service_ipv4(ctx);
+	if (!ret) {
+		/* Redirect ICMP to the interface we received it on. */
+		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY,
+				   ctx_get_ifindex(ctx));
+		ret = ctx_redirect(ctx, ctx_get_ifindex(ctx), 0);
+	}
+
 	if (IS_ERR(ret))
 		return send_drop_notify_error(ctx, src_sec_identity, ret,
 					      METRIC_INGRESS);
@@ -2086,25 +2090,12 @@ int __tail_no_service_ipv6(struct __ctx_buff *ctx)
 	union macaddr dmac = {};
 	struct in6_addr saddr;
 	struct in6_addr daddr;
-	struct ratelimit_key rkey = {
-		.usage = RATELIMIT_USAGE_ICMPV6,
-	};
-	/* Rate limit to 100 ICMPv6 replies per second, burstable to 1000 responses/s */
-	struct ratelimit_settings settings = {
-		.bucket_size = 1000,
-		.tokens_per_topup = 100,
-		.topup_interval_ns = NSEC_PER_SEC,
-	};
 	__wsum csum;
 	__u64 sample_len;
 	int i;
 	int ret;
 	const int inner_offset = sizeof(struct ethhdr) + sizeof(struct ipv6hdr) +
 		sizeof(struct icmp6hdr);
-
-	rkey.key.icmpv6.netdev_idx = ctx_get_ifindex(ctx);
-	if (!ratelimit_check_and_take(&rkey, &settings))
-		return DROP_RATE_LIMITED;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
@@ -2199,19 +2190,39 @@ int __tail_no_service_ipv6(struct __ctx_buff *ctx)
 
 	icmphdr->icmp6_cksum = csum_fold(csum);
 
-	/* Redirect ICMP to the interface we received it on. */
-	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY,
-			   ctx_get_ifindex(ctx));
-	return ctx_redirect(ctx, ctx_get_ifindex(ctx), 0);
+	return 0;
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NO_SERVICE)
 int tail_no_service_ipv6(struct __ctx_buff *ctx)
 {
 	__u32 src_sec_identity = ctx_load_meta(ctx, CB_SRC_LABEL);
+	struct ratelimit_key rkey = {
+		.usage = RATELIMIT_USAGE_ICMPV6,
+	};
+	/* Rate limit to 100 ICMPv6 replies per second, burstable to 1000 responses/s */
+	struct ratelimit_settings settings = {
+		.bucket_size = 1000,
+		.tokens_per_topup = 100,
+		.topup_interval_ns = NSEC_PER_SEC,
+	};
 	int ret;
 
+	rkey.key.icmpv6.netdev_idx = ctx_get_ifindex(ctx);
+	if (!ratelimit_check_and_take(&rkey, &settings)) {
+		ret = DROP_RATE_LIMITED;
+		goto drop_err;
+	}
+
 	ret = __tail_no_service_ipv6(ctx);
+	if (!ret) {
+		/* Redirect ICMP to the interface we received it on. */
+		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY,
+				   ctx_get_ifindex(ctx));
+		ret = ctx_redirect(ctx, ctx_get_ifindex(ctx), 0);
+	}
+
+drop_err:
 	if (IS_ERR(ret))
 		return send_drop_notify_error(ctx, src_sec_identity, ret,
 					      METRIC_INGRESS);

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1582,6 +1582,76 @@ snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 	return NAT_PUNT_TO_STACK;
 }
 
+static __always_inline __maybe_unused int
+snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off)
+{
+	__u32 inner_l3_off = (__u32)(off + sizeof(struct icmp6hdr));
+	struct ipv6_ct_tuple tuple = {};
+	struct ipv6_nat_entry *state;
+	struct ipv6hdr ip6;
+	__u16 port_off;
+	__u32 icmpoff;
+	int hdrlen;
+	int ret;
+
+	/* According to the RFC 5508, any networking equipment that is
+	 * responding with an ICMP Error packet should embed the original
+	 * packet in its response.
+	 */
+	if (ctx_load_bytes(ctx, inner_l3_off, &ip6, sizeof(ip6)) < 0)
+		return DROP_INVALID;
+
+	/* From the embedded IP headers we should be able to determine
+	 * corresponding protocol, IP src/dst of the packet sent to resolve
+	 * the NAT session.
+	 */
+	tuple.nexthdr = ip6.nexthdr;
+	ipv6_addr_copy(&tuple.saddr, (union v6addr *)&ip6.daddr);
+	ipv6_addr_copy(&tuple.daddr, (union v6addr *)&ip6.saddr);
+	tuple.flags = NAT_DIR_EGRESS;
+
+	hdrlen = ipv6_hdrlen_offset(ctx, &tuple.nexthdr, inner_l3_off);
+	if (hdrlen < 0)
+		return hdrlen;
+
+	icmpoff = inner_l3_off + hdrlen;
+
+	switch (tuple.nexthdr) {
+	case IPPROTO_TCP:
+	case IPPROTO_UDP:
+#ifdef ENABLE_SCTP
+	case IPPROTO_SCTP:
+#endif /* ENABLE_SCTP */
+		/* No reasons to handle IP fragmentation for this case as it is
+		 * expected that DF isn't set for this particular context.
+		 */
+		if (l4_load_ports(ctx, icmpoff, &tuple.dport) < 0)
+			return DROP_INVALID;
+
+		port_off = TCP_DPORT_OFF;
+		break;
+	default:
+		return DROP_UNKNOWN_L4;
+	}
+	state = snat_v6_lookup(&tuple);
+	if (!state)
+		return NAT_PUNT_TO_STACK;
+
+	/* We found SNAT entry to NAT embedded packet. The destination addr
+	 * should be NATed according to the entry.
+	 */
+	ret = snat_v6_rewrite_headers(ctx, tuple.nexthdr, inner_l3_off, icmpoff,
+				      &tuple.saddr, &state->to_saddr, IPV6_DADDR_OFF,
+				      tuple.sport, state->to_sport, port_off);
+	if (IS_ERR(ret))
+		return ret;
+
+	/* Rewrite outer headers. No port rewrite needed. */
+	return snat_v6_rewrite_headers(ctx, IPPROTO_ICMPV6, ETH_HLEN, (int)off,
+				       &tuple.saddr, &state->to_saddr, IPV6_SADDR_OFF,
+				       0, 0, 0);
+}
+
 static __always_inline int
 __snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 	      int l4_off, bool update_tuple,
@@ -1650,6 +1720,11 @@ snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple, int off,
 			port_off = offsetof(struct icmp6hdr,
 					    icmp6_dataun.u_echo.identifier);
 			break;
+		case ICMPV6_DEST_UNREACH:
+			if (icmp6hdr.icmp6_code > ICMPV6_REJECT_ROUTE)
+				return DROP_UNKNOWN_ICMP6_CODE;
+
+			return snat_v6_nat_handle_icmp_error(ctx, off);
 		default:
 			return DROP_NAT_UNSUPP_PROTO;
 		}


### PR DESCRIPTION
Add the missing bits in the IPv6 SNAT engine, so that `ICMPV6_DEST_UNREACH` packets (which we generate for a NodePort service without backends) can exit the node.