### PR TITLE
namemanager efficiency improvements

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -336,11 +336,9 @@ func (d *Daemon) notifyOnDNSMsg(
 		defer updateCancel()
 		updateStart := time.Now()
 
-		dpUpdates := d.dnsNameManager.UpdateGenerateDNS(updateCtx, lookupTime, map[string]*fqdn.DNSIPRecords{
-			qname: {
-				IPs: responseIPs,
-				TTL: int(TTL),
-			},
+		dpUpdates := d.dnsNameManager.UpdateGenerateDNS(updateCtx, lookupTime, qname, &fqdn.DNSIPRecords{
+			IPs: responseIPs,
+			TTL: int(TTL),
 		})
 
 		stat.PolicyGenerationTime.End(true)

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -346,7 +346,7 @@ func (d *Daemon) notifyOnDNSMsg(
 		stat.PolicyGenerationTime.End(true)
 		stat.DataplaneTime.Start()
 
-		if err := dpUpdates.Wait(); err != nil {
+		if err := <-dpUpdates; err != nil {
 			log.Warning("Timed out waiting for datapath updates of FQDN IP information; returning response. Consider increasing --tofqdns-proxy-response-max-delay if this keeps happening.")
 			metrics.ProxyDatapathUpdateTimeout.Inc()
 		}

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -309,6 +309,10 @@ func (d *Daemon) notifyOnDNSMsg(
 				option.DNSProxyLockCount, option.DNSProxyLockTimeout)
 		}
 
+		logDebug := log.Logger.IsLevelEnabled(logrus.DebugLevel)
+		if logDebug {
+			log.WithField(logfields.EndpointID, ep.ID).Debug("Recording DNS lookup in endpoint specific cache")
+		}
 		// This must happen before the NameManager update below, to ensure that
 		// this data is included in the serialized Endpoint object.
 		// We also need to add to the cache before we purge any matching zombies
@@ -316,16 +320,17 @@ func (d *Daemon) notifyOnDNSMsg(
 		// consistent if a regeneration happens between the two steps. If an update
 		// doesn't happen in the case, we play it safe and don't purge the zombie
 		// in case of races.
-		log.WithField(logfields.EndpointID, ep.ID).Debug("Recording DNS lookup in endpoint specific cache")
 		if updated := ep.DNSHistory.Update(lookupTime, qname, responseIPs, int(TTL)); updated {
 			ep.DNSZombies.ForceExpireByNameIP(lookupTime, qname, responseIPs...)
 			ep.SyncEndpointHeaderFile()
 		}
 
-		log.WithFields(logrus.Fields{
-			"qname": qname,
-			"ips":   responseIPs,
-		}).Debug("Updating DNS name in cache from response to query")
+		if logDebug {
+			log.WithFields(logrus.Fields{
+				"qname": qname,
+				"ips":   responseIPs,
+			}).Debug("Updating DNS name in cache from response to query")
+		}
 
 		updateCtx, updateCancel := context.WithTimeout(d.ctx, option.Config.FQDNProxyResponseMaxDelay)
 		defer updateCancel()
@@ -349,11 +354,13 @@ func (d *Daemon) notifyOnDNSMsg(
 		// Policy updates for this name have been pushed out; we can release the lock.
 		d.dnsNameManager.UnlockName(qname)
 
-		log.WithFields(logrus.Fields{
-			logfields.Duration:   time.Since(updateStart),
-			logfields.EndpointID: ep.GetID(),
-			"qname":              qname,
-		}).Debug("Waited for endpoints to regenerate due to a DNS response")
+		if logDebug {
+			log.WithFields(logrus.Fields{
+				logfields.Duration:   time.Since(updateStart),
+				logfields.EndpointID: ep.GetID(),
+				"qname":              qname,
+			}).Debug("Waited for endpoints to regenerate due to a DNS response")
+		}
 
 		endMetric()
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1652,7 +1652,10 @@ func (e *Endpoint) UpdateProxyStatistics(proxyType, l4Protocol string, port, pro
 
 	proxyStats, ok := e.proxyStatistics[key]
 	if !ok {
-		e.getLogger().WithField(logfields.L4PolicyID, key).Debug("Proxy stats not found when updating")
+		if l := e.getLogger(); l.Logger.IsLevelEnabled(logrus.DebugLevel) {
+			l.WithField(logfields.L4PolicyID, key).Debug("Proxy stats not found when updating")
+		}
+
 		return
 	}
 

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -801,7 +801,7 @@ type DNSZombieMappings struct {
 	lock.Mutex
 	deletes        map[netip.Addr]*DNSZombieMapping
 	lastCTGCUpdate time.Time
-	NextCTGCUpdate time.Time // estimated
+	nextCTGCUpdate time.Time // estimated
 	// ctGCRevision is a serial number tracking the number of conntrack
 	// garbage collection runs. It is used to ensure that entries
 	// are not reaped until CT GC has run at least twice.
@@ -1079,9 +1079,17 @@ func (zombies *DNSZombieMappings) MarkAlive(now time.Time, ip netip.Addr) {
 func (zombies *DNSZombieMappings) SetCTGCTime(ctGCStart, estNext time.Time) {
 	zombies.Lock()
 	zombies.lastCTGCUpdate = ctGCStart
-	zombies.NextCTGCUpdate = estNext
+	zombies.nextCTGCUpdate = estNext
 	zombies.ctGCRevision++
 	zombies.Unlock()
+}
+
+// NextCTGCUpdate returns the estimated next CT GC time.
+func (zombies *DNSZombieMappings) NextCTGCUpdate() time.Time {
+	zombies.Lock()
+	defer zombies.Unlock()
+
+	return zombies.nextCTGCUpdate
 }
 
 // ForceExpire is used to clear zombies irrespective of their alive status.

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -96,7 +96,7 @@ func (s ipEntries) getIPs(now time.Time) []netip.Addr {
 // called.
 // Redundant entries are removed on insert.
 type DNSCache struct {
-	lock.RWMutex
+	mu lock.RWMutex
 
 	// forward DNS lookups name -> IPEntries
 	// IPEntries maps IP -> entry that provides it. An entry may provide multiple IPs.
@@ -164,8 +164,8 @@ func NewDNSCacheWithLimit(minTTL int, limit int) *DNSCache {
 }
 
 func (c *DNSCache) DisableCleanupTrack() {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.cleanup = nil
 }
 
@@ -191,8 +191,8 @@ func (c *DNSCache) Update(lookupTime time.Time, name string, ips []netip.Addr, t
 		IPs:            ips,
 	}
 
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.updateWithEntry(entry)
 }
 
@@ -324,10 +324,10 @@ func (c *DNSCache) cleanupOverLimitEntries() (affectedNames sets.Set[string], re
 // Note: zombies use the original lookup's ExpirationTime for DeletePendingAt,
 // not the now parameter. This allows better ordering in zombie GC.
 func (c *DNSCache) GC(now time.Time, zombies *DNSZombieMappings) (affectedNames sets.Set[string]) {
-	c.Lock()
+	c.mu.Lock()
 	expiredNames, expiredEntries := c.cleanupExpiredEntries(now)
 	overLimitNames, overLimitEntries := c.cleanupOverLimitEntries()
-	c.Unlock()
+	c.mu.Unlock()
 
 	if zombies != nil {
 		// Iterate over 2 maps
@@ -367,14 +367,14 @@ func (c *DNSCache) UpdateFromCache(update *DNSCache, namesToUpdate []string) {
 		return
 	}
 
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.updateFromCache(update, namesToUpdate)
 }
 
 func (c *DNSCache) updateFromCache(update *DNSCache, namesToUpdate []string) {
-	update.RLock()
-	defer update.RUnlock()
+	update.mu.RLock()
+	defer update.mu.RUnlock()
 
 	if len(namesToUpdate) == 0 {
 		for name := range update.forward {
@@ -397,8 +397,8 @@ func (c *DNSCache) updateFromCache(update *DNSCache, namesToUpdate []string) {
 // for DNS names in namesToUpdate from each DNSCache in updates, replacing the
 // current entries for each of those names.
 func (c *DNSCache) ReplaceFromCacheByNames(namesToUpdate []string, updates ...*DNSCache) {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	// Remove any DNS name in namesToUpdate with a lookup before "now". This
 	// effectively deletes all lookups because we're holding the lock.
@@ -413,8 +413,8 @@ func (c *DNSCache) ReplaceFromCacheByNames(namesToUpdate []string, updates ...*D
 // any exist. An empty list indicates no valid records exist. The IPs are
 // returned unsorted.
 func (c *DNSCache) Lookup(name string) (ips []netip.Addr) {
-	c.RLock()
-	defer c.RUnlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	return c.lookupByTime(c.lastCleanup, name)
 }
@@ -441,8 +441,8 @@ func (c *DNSCache) LookupByRegexp(re *regexp.Regexp) (matches map[string][]netip
 func (c *DNSCache) lookupByRegexpByTime(now time.Time, re *regexp.Regexp) (matches map[string][]netip.Addr) {
 	matches = make(map[string][]netip.Addr)
 
-	c.RLock()
-	defer c.RUnlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	for name, entry := range c.forward {
 		if re.MatchString(name) {
@@ -460,8 +460,8 @@ func (c *DNSCache) lookupByRegexpByTime(now time.Time, re *regexp.Regexp) (match
 // names referring to the same IP will expire from the cache at different times,
 // and only 1 entry for each name-IP pair is internally retained.
 func (c *DNSCache) LookupIP(ip netip.Addr) (names []string) {
-	c.RLock()
-	defer c.RUnlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	return c.lookupIPByTime(c.lastCleanup, ip)
 }
@@ -487,8 +487,8 @@ func (c *DNSCache) lookupIPByTime(now time.Time, ip netip.Addr) (names []string)
 // RemoveKnown removes all ip-name associations from mappings which are known to
 // the cache.
 func (c *DNSCache) RemoveKnown(mappings map[netip.Addr][]string) {
-	c.RLock()
-	defer c.RUnlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	for ip, names := range mappings {
 		rnames, exists := c.reverse[ip]
@@ -596,8 +596,8 @@ func (c *DNSCache) removeReverse(ip netip.Addr, entry *cacheEntry) {
 
 // GetIPs takes a snapshot of all IPs in the reverse cache.
 func (c *DNSCache) GetIPs() map[netip.Addr][]string {
-	c.RWMutex.RLock()
-	defer c.RWMutex.RUnlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	out := make(map[netip.Addr][]string, len(c.reverse))
 
@@ -623,8 +623,8 @@ func (c *DNSCache) GetIPs() map[netip.Addr][]string {
 // order to remove it.
 // nameMatch will remove any DNS names that match.
 func (c *DNSCache) ForceExpire(expireLookupsBefore time.Time, nameMatch *regexp.Regexp) (namesAffected sets.Set[string]) {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	namesAffected = sets.New[string]()
 
@@ -663,8 +663,8 @@ func (c *DNSCache) forceExpireByNames(expireLookupsBefore time.Time, names []str
 // Dump returns unexpired cache entries in the cache. They are deduplicated,
 // but not usefully sorted. These objects should not be modified.
 func (c *DNSCache) Dump() (lookups []*cacheEntry) {
-	c.RLock()
-	defer c.RUnlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	// Collect all the still-valid entries
 	lookups = make([]*cacheEntry, 0, len(c.forward))
@@ -702,8 +702,8 @@ func (c *DNSCache) Dump() (lookups []*cacheEntry) {
 // represents an accurate tally of IPs associated with an FQDN in the DNS
 // cache.
 func (c *DNSCache) Count() (uint64, uint64) {
-	c.RLock()
-	defer c.RUnlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	var ips uint64
 	for _, entries := range c.forward {
@@ -732,8 +732,8 @@ func (c *DNSCache) UnmarshalJSON(raw []byte) error {
 		return err
 	}
 
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	c.forward = make(map[string]ipEntries)
 	c.reverse = make(map[netip.Addr]nameEntries)

--- a/pkg/fqdn/namemanager/api.go
+++ b/pkg/fqdn/namemanager/api.go
@@ -115,7 +115,7 @@ func (n *manager) dnsHistoryModel(endpointID string, prefixMatcher fqdn.PrefixMa
 					Ips:            []string{delete.IP.String()},
 					LookupTime:     strfmt.DateTime(delete.AliveAt),
 					TTL:            0,
-					ExpirationTime: strfmt.DateTime(ep.DNSZombies.NextCTGCUpdate),
+					ExpirationTime: strfmt.DateTime(ep.DNSZombies.NextCTGCUpdate()),
 					EndpointID:     int64(ep.ID),
 					Source:         DNSSourceConnection,
 				})

--- a/pkg/fqdn/namemanager/bench_test.go
+++ b/pkg/fqdn/namemanager/bench_test.go
@@ -69,17 +69,15 @@ func BenchmarkUpdateGenerateDNS(b *testing.B) {
 		ip = ip.Next()
 
 		k := i % numSelectors
-		nameManager.UpdateGenerateDNS(context.Background(), t, map[string]*fqdn.DNSIPRecords{
-			dns.FQDN(fmt.Sprintf("%d.example.com", k)): {
-				TTL: 60,
-				IPs: []netip.Addr{ip},
-			}})
+		nameManager.UpdateGenerateDNS(context.Background(), t, dns.FQDN(fmt.Sprintf("%d.example.com", k)), &fqdn.DNSIPRecords{
+			TTL: 60,
+			IPs: []netip.Addr{ip},
+		})
 
-		nameManager.UpdateGenerateDNS(context.Background(), t, map[string]*fqdn.DNSIPRecords{
-			dns.FQDN(fmt.Sprintf("example.%d.example.com", k)): {
-				TTL: 60,
-				IPs: []netip.Addr{ip},
-			}})
+		nameManager.UpdateGenerateDNS(context.Background(), t, dns.FQDN(fmt.Sprintf("example.%d.example.com", k)), &fqdn.DNSIPRecords{
+			TTL: 60,
+			IPs: []netip.Addr{ip},
+		})
 	}
 }
 

--- a/pkg/fqdn/namemanager/cell.go
+++ b/pkg/fqdn/namemanager/cell.go
@@ -100,7 +100,7 @@ type NameManager interface {
 	UnregisterFQDNSelector(selector api.FQDNSelector)
 	// UpdateGenerateDNS inserts the new DNS information into the cache. If the IPs
 	// have changed for a name they will be reflected in updatedDNSIPs.
-	UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, updatedDNSIPs map[string]*fqdn.DNSIPRecords) <-chan error
+	UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, name string, record *fqdn.DNSIPRecords) <-chan error
 
 	// LockName is used to serialize  parallel end-to-end updates to the same name.
 	LockName(name string)

--- a/pkg/fqdn/namemanager/cell.go
+++ b/pkg/fqdn/namemanager/cell.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/cilium/hive/cell"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/cilium/cilium/api/v1/server/restapi/policy"
 	"github.com/cilium/cilium/pkg/endpoint"
@@ -101,7 +100,7 @@ type NameManager interface {
 	UnregisterFQDNSelector(selector api.FQDNSelector)
 	// UpdateGenerateDNS inserts the new DNS information into the cache. If the IPs
 	// have changed for a name they will be reflected in updatedDNSIPs.
-	UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, updatedDNSIPs map[string]*fqdn.DNSIPRecords) *errgroup.Group
+	UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, updatedDNSIPs map[string]*fqdn.DNSIPRecords) <-chan error
 
 	// LockName is used to serialize  parallel end-to-end updates to the same name.
 	LockName(name string)

--- a/pkg/fqdn/namemanager/gc.go
+++ b/pkg/fqdn/namemanager/gc.go
@@ -60,7 +60,7 @@ type serializedSelector struct {
 // the global DNSCache instance. The data there drives toFQDNs policy via
 // NameManager and ToFQDNs selectors. DNSCache entries expire data when the TTL
 // elapses and when the entries for a DNS name are above a limit. The data is
-// then placed into DNSZombieMappings instances. These rely on the CT doGC loop
+// then placed into DNSZombieMappings instances. These rely on the CT GC loop
 // to update liveness for each to-delete IP. When an IP is not in-use it is
 // finally deleted from the global DNSCache. Until then, each of these IPs is
 // inserted into the global cache as a synthetic DNS lookup.

--- a/pkg/fqdn/namemanager/manager.go
+++ b/pkg/fqdn/namemanager/manager.go
@@ -327,23 +327,20 @@ func (n *manager) maybeRemoveMetadata(maybeRemoved map[netip.Addr][]string) {
 	n.RWMutex.RLock()
 	defer n.RWMutex.RUnlock()
 
-	n.cache.RLock()
+	n.cache.RemoveKnown(maybeRemoved)
 	ipCacheUpdates := make([]ipcache.MU, 0, len(maybeRemoved))
 	for ip, names := range maybeRemoved {
 		for _, name := range names {
-			if !n.cache.EntryExistsLocked(name, ip) {
-				ipCacheUpdates = append(ipCacheUpdates, ipcache.MU{
-					Prefix:   netip.PrefixFrom(ip, ip.BitLen()),
-					Source:   source.Generated,
-					Resource: ipcacheResource(name),
-					Metadata: []ipcache.IPMetadata{
-						labels.Labels{}, // remove all labels for this (ip, name) pair
-					},
-				})
-			}
+			ipCacheUpdates = append(ipCacheUpdates, ipcache.MU{
+				Prefix:   netip.PrefixFrom(ip, ip.BitLen()),
+				Source:   source.Generated,
+				Resource: ipcacheResource(name),
+				Metadata: []ipcache.IPMetadata{
+					labels.Labels{}, // remove all labels for this (ip, name) pair
+				},
+			})
 		}
 	}
-	n.cache.RUnlock()
 	n.params.IPCache.RemoveMetadataBatch(ipCacheUpdates...)
 }
 

--- a/pkg/fqdn/namemanager/manager.go
+++ b/pkg/fqdn/namemanager/manager.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
@@ -146,11 +145,13 @@ func (n *manager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, u
 
 	// Update IPs in n
 	updatedDNSNames, ipcacheRevision := n.updateDNSIPs(lookupTime, updatedDNSIPs)
-	for dnsName, IPs := range updatedDNSNames {
-		log.WithFields(logrus.Fields{
-			"matchName": dnsName,
-			"IPs":       IPs,
-		}).Debug("Updated FQDN with new IPs")
+	if log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		for dnsName, IPs := range updatedDNSNames {
+			log.WithFields(logrus.Fields{
+				"matchName": dnsName,
+				"IPs":       IPs,
+			}).Debug("Updated FQDN with new IPs")
+		}
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
@@ -204,10 +205,12 @@ func (n *manager) updateDNSIPs(lookupTime time.Time, updatedDNSIPs map[string]*f
 
 		// The IPs didn't change. No more to be done for this dnsName
 		if !updated && n.bootstrapCompleted {
-			log.WithFields(logrus.Fields{
-				"dnsName":   dnsName,
-				"lookupIPs": lookupIPs,
-			}).Debug("FQDN: IPs didn't change for DNS name")
+			if log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+				log.WithFields(logrus.Fields{
+					"dnsName":   dnsName,
+					"lookupIPs": lookupIPs,
+				}).Debug("FQDN: IPs didn't change for DNS name")
+			}
 			continue
 		}
 
@@ -216,10 +219,12 @@ func (n *manager) updateDNSIPs(lookupTime time.Time, updatedDNSIPs map[string]*f
 
 		// accumulate the new labels affected by new IPs
 		if len(n.allSelectors) == 0 {
-			log.WithFields(logrus.Fields{
-				"dnsName":   dnsName,
-				"lookupIPs": lookupIPs,
-			}).Debug("FQDN: No selectors registered for updates")
+			if log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+				log.WithFields(logrus.Fields{
+					"dnsName":   dnsName,
+					"lookupIPs": lookupIPs,
+				}).Debug("FQDN: No selectors registered for updates")
+			}
 			continue
 		}
 
@@ -287,7 +292,7 @@ func (n *manager) updateMetadata(nameToMetadata map[string]nameMetadata) (ipcach
 		var updates []ipcache.MU
 		resource := ipcacheResource(dnsName)
 
-		if option.Config.Debug {
+		if log.Logger.IsLevelEnabled(logrus.DebugLevel) {
 			log.WithFields(logrus.Fields{
 				"name":     dnsName,
 				"prefixes": metadata.addrs,
@@ -428,11 +433,13 @@ func (n *manager) mapSelectorsToNamesLocked(fqdnSelector api.FQDNSelector) (name
 		dnsName := prepareMatchName(fqdnSelector.MatchName)
 		lookupIPs := n.cache.Lookup(dnsName)
 		if len(lookupIPs) > 0 {
-			log.WithFields(logrus.Fields{
-				"DNSName":   dnsName,
-				"IPs":       lookupIPs,
-				"matchName": fqdnSelector.MatchName,
-			}).Debug("Emitting matching DNS Name -> IPs for FQDNSelector")
+			if log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+				log.WithFields(logrus.Fields{
+					"DNSName":   dnsName,
+					"IPs":       lookupIPs,
+					"matchName": fqdnSelector.MatchName,
+				}).Debug("Emitting matching DNS Name -> IPs for FQDNSelector")
+			}
 			namesIPMapping[dnsName] = lookupIPs
 		}
 	}

--- a/pkg/fqdn/namemanager/manager_test.go
+++ b/pkg/fqdn/namemanager/manager_test.go
@@ -114,7 +114,7 @@ func TestNameManagerIPCacheUpdates(t *testing.T) {
 
 	// Simulate lookup for single selector
 	prefix := netip.MustParsePrefix("1.1.1.1/32")
-	nameManager.UpdateGenerateDNS(context.TODO(), time.Now(), map[string]*fqdn.DNSIPRecords{dns.FQDN("cilium.io"): {TTL: 60, IPs: []netip.Addr{prefix.Addr()}}})
+	nameManager.UpdateGenerateDNS(context.TODO(), time.Now(), dns.FQDN("cilium.io"), &fqdn.DNSIPRecords{TTL: 60, IPs: []netip.Addr{prefix.Addr()}})
 	require.Equal(t, ipc.labelsForPrefix(prefix), labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}))
 
 	// Add match pattern
@@ -127,16 +127,15 @@ func TestNameManagerIPCacheUpdates(t *testing.T) {
 	require.Equal(t, ipc.labelsForPrefix(prefix), labels.FromSlice([]labels.Label{ciliumIOSelMatchPattern.IdentityLabel()}))
 
 	// Same IP matched by two selectors
-	nameManager.UpdateGenerateDNS(context.TODO(), time.Now(), map[string]*fqdn.DNSIPRecords{dns.FQDN("github.com"): {TTL: 60, IPs: []netip.Addr{prefix.Addr()}}})
+	nameManager.UpdateGenerateDNS(context.TODO(), time.Now(), dns.FQDN("github.com"), &fqdn.DNSIPRecords{TTL: 60, IPs: []netip.Addr{prefix.Addr()}})
 	require.Equal(t, ipc.labelsForPrefix(prefix), labels.FromSlice([]labels.Label{ciliumIOSelMatchPattern.IdentityLabel(), githubSel.IdentityLabel()}))
 
 	// Additional unique IPs for each selector
 	githubPrefix := netip.MustParsePrefix("10.0.0.2/32")
 	awesomePrefix := netip.MustParsePrefix("10.0.0.3/32")
-	nameManager.UpdateGenerateDNS(context.TODO(), time.Now(), map[string]*fqdn.DNSIPRecords{
-		dns.FQDN("github.com"):       {TTL: 60, IPs: []netip.Addr{githubPrefix.Addr()}},
-		dns.FQDN("awesomecilium.io"): {TTL: 60, IPs: []netip.Addr{awesomePrefix.Addr()}},
-	})
+	n := time.Now()
+	nameManager.UpdateGenerateDNS(context.TODO(), n, dns.FQDN("github.com"), &fqdn.DNSIPRecords{TTL: 60, IPs: []netip.Addr{githubPrefix.Addr()}})
+	nameManager.UpdateGenerateDNS(context.TODO(), n, dns.FQDN("awesomecilium.io"), &fqdn.DNSIPRecords{TTL: 60, IPs: []netip.Addr{awesomePrefix.Addr()}})
 	require.Equal(t, ipc.labelsForPrefix(prefix), labels.FromSlice([]labels.Label{ciliumIOSelMatchPattern.IdentityLabel(), githubSel.IdentityLabel()}))
 	require.Equal(t, ipc.labelsForPrefix(githubPrefix), labels.FromSlice([]labels.Label{githubSel.IdentityLabel()}))
 	require.Equal(t, ipc.labelsForPrefix(awesomePrefix), labels.FromSlice([]labels.Label{ciliumIOSelMatchPattern.IdentityLabel()}))


### PR DESCRIPTION
Probably easiest to review commit by commit. In addition to avoiding some allocations (primarily logfields), this fixes a data race, unexports the mutex of fqdn.DNSCache to reduce API surface and improves the below benchmark.

Reducing allocations does help with the benchmark a bit, but there's more gains to be had if we can optimize the proxy log records and fqdn selector labels. Will continue down this route in a future PR.

```
env INTEGRATION_TESTS=1 go test ./daemon/cmd -bench="Notify" -run="xxx"
```
goes from 

    BenchmarkNotifyOnDNSMsg-10    	     39	 43553014 ns/op	12148998 B/op	 151530 allocs/op`
to

    BenchmarkNotifyOnDNSMsg-10    	     52	 28072063 ns/op	5244570 B/op	  86374 allocs/op

i.e. a reduction of about 40% of stuff.