### PR TITLE
CI: Update tested K8S versions with 1.32

### DIFF
--- a/.github/actions/aws-cni/k8s-versions.yaml
+++ b/.github/actions/aws-cni/k8s-versions.yaml
@@ -1,15 +1,15 @@
 # List of k8s version for EKS tests
 ---
 include:
-  - version: "1.28"
-    region: us-west-1
   - version: "1.29"
-    region: us-east-2
+    region: us-west-1
   - version: "1.30"
+    region: us-east-2
+  - version: "1.31"
     region: ca-central-1
     default: true
     kpr: true
-  - version: "1.31"
+  - version: "1.32"
     region: us-east-1
     default: true
     wireguard: true

--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -1,17 +1,17 @@
 # List of k8s version for EKS tests
 ---
 include:
-  - version: "1.28"
-    region: us-west-1
   - version: "1.29"
+    region: us-west-1
+  - version: "1.30"
     region: us-east-2
     ipsec: true
-  - version: "1.30"
+  - version: "1.31"
     region: ca-central-1
     default: true
     ipsec: true
     kpr: true
-  - version: "1.31"
+  - version: "1.32"
     region: us-east-1
     ipsec: true
     default: true

--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,16 +1,16 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.28"
+  - version: "1.29"
     zone: us-west2-c
     vmIndex: 1
-  - version: "1.29"
+  - version: "1.30"
     zone: us-west3-a
     vmIndex: 2
-  - version: "1.30"
+  - version: "1.31"
     zone: us-east4-b
     vmIndex: 3
-  - version: "1.31"
+  - version: "1.32"
     zone: us-east1-c
     vmIndex: 4
     default: true


### PR DESCRIPTION
In this commit we add the tests on our cloud provider conformance workflows to k8s 1.32 and remove the 1.28  
Exception is made for AKS as the GA version for 1.32 will be available later in march 2025  

```release-note
add the tests on our cloud provider (without aks) conformance workflows to k8s 1.32 and remove the 1.28
```
