### PR TITLE
CODEOWNERS: Assign ownership for cloud teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -252,7 +252,9 @@
 /.github/actions/cl2-modules/ @cilium/sig-scalability
 /.github/workflows/*scale*.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*perf*.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure
-/.github/workflows/conformance-eks.yaml @cilium/ipsec @cilium/github-sec @cilium/ci-structure
+/.github/workflows/conformance-aks.yaml @cilium/azure @cilium/ipsec @cilium/github-sec @cilium/ci-structure
+/.github/workflows/conformance-aws-cni.yaml @cilium/aws @cilium/github-sec @cilium/ci-structure
+/.github/workflows/conformance-eks.yaml @cilium/aws @cilium/ipsec @cilium/github-sec @cilium/ci-structure
 /.github/workflows/tests-ces-migrate.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure
 /.gitignore @cilium/contributing
 /.golangci.yaml @cilium/ci-structure


### PR DESCRIPTION
There is specific code in Cilium for integrating on Azure and AWS cloud
platforms, so we have existing teams for these. We also have GitHub
workflows to test this functionality, so it makes sense that these
codeowner groups become primary owners for these workflows.

Related discussion: https://github.com/cilium/cilium/pull/37719#issuecomment-2666829581