### PR TITLE
.github: Use dedicated go cache on CI

### DIFF
--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -114,6 +114,9 @@ jobs:
           # hard-code the path instead of using ${{ github.repository }} to make sure it works for forked repo as well
           path: src/github.com/cilium/cilium
       - name: Check api generated files
+        env:
+          BUILDER_GOCACHE_DIR: "/tmp/.cache/go/.cache/go-build"
+          BUILDER_GOMODCACHE_DIR: "/tmp/.cache/go/pkg"
         run: |
           cd src/github.com/cilium/cilium
           contrib/scripts/check-api-code-gen.sh
@@ -134,6 +137,9 @@ jobs:
           # hard-code the path instead of using ${{ github.repository }} to make sure it works for forked repo as well
           path: src/github.com/cilium/cilium
       - name: Check k8s generated files
+        env:
+          BUILDER_GOCACHE_DIR: "/tmp/.cache/go/.cache/go-build"
+          BUILDER_GOMODCACHE_DIR: "/tmp/.cache/go/pkg"
         run: |
           # Set GOBIN to ensure 'go install' binaries end up in the same directory
           # as the one actions/setup-go adds to PATH, regardless of GOPATH.


### PR DESCRIPTION
Commit 8f02631f230c changed the builder.sh script to reuse host go build
caches by default in order to optimize the build time for local
environments. However, in some situations on GitHub infrastructure the
default path is not writable for the actions workflow, which results in
error messages reported like this when making changes to k8s resources:

    ... mkdir /home/runner/go/pkg/mod/cache: permission denied

Fix this by defining a go build cache directory under /tmp, like with
the other GitHub workflows that use go build caches.

Fixes: 8f02631f230c ("contrib: Reuse local go cache in builder")
Reported-by: @sayboras
