### PR TITLE
cilium-dbg: Fix map not found bugs on IPv6-only clusters

### DIFF
--- a/cilium-dbg/cmd/bpf_ct_flush.go
+++ b/cilium-dbg/cmd/bpf_ct_flush.go
@@ -42,7 +42,8 @@ func (d dummyEndpoint) GetID() uint64 {
 func flushCt(eID string) {
 	var maps []*ctmap.Map
 	if eID == "global" {
-		maps = ctmap.GlobalMaps(true, getIpv6EnableStatus())
+		ipv4, ipv6 := getIpEnableStatuses()
+		maps = ctmap.GlobalMaps(ipv4, ipv6)
 	} else {
 		id, _ := strconv.Atoi(eID)
 		maps = ctmap.LocalMaps(&dummyEndpoint{ID: id}, true, true)

--- a/cilium-dbg/cmd/bpf_ct_list.go
+++ b/cilium-dbg/cmd/bpf_ct_list.go
@@ -89,15 +89,16 @@ func parseArgs(args []string) (string, uint32, error) {
 func getMaps(t string, id uint32) []ctmap.CtMap {
 	var m []*ctmap.Map
 	var r []ctmap.CtMap
+	ipv4, ipv6 := getIpEnableStatuses()
 	if t == "global" {
-		m = ctmap.GlobalMaps(true, getIpv6EnableStatus())
+		m = ctmap.GlobalMaps(ipv4, ipv6)
 	}
 	if t == "endpoint" {
 		m = ctmap.LocalMaps(&dummyEndpoint{ID: int(id)}, true, true)
 	}
 	if t == "cluster" {
 		// Ignoring the error, as we already validated the cluster ID.
-		m, _ = ctmap.GetClusterCTMaps(id, true, getIpv6EnableStatus())
+		m, _ = ctmap.GetClusterCTMaps(id, ipv4, ipv6)
 	}
 	for _, v := range m {
 		r = append(r, v)

--- a/cilium-dbg/cmd/bpf_nat_flush.go
+++ b/cilium-dbg/cmd/bpf_nat_flush.go
@@ -28,9 +28,10 @@ func init() {
 }
 
 func flushNat() {
-	ipv4, ipv6 := nat.GlobalMaps(true, getIpv6EnableStatus(), true)
+	ipv4, ipv6 := getIpEnableStatuses()
+	ipv4Map, ipv6Map := nat.GlobalMaps(ipv4, ipv6, true)
 
-	for _, m := range []*nat.Map{ipv4, ipv6} {
+	for _, m := range []*nat.Map{ipv4Map, ipv6Map} {
 		if m == nil {
 			continue
 		}

--- a/cilium-dbg/cmd/bpf_nat_list.go
+++ b/cilium-dbg/cmd/bpf_nat_list.go
@@ -26,10 +26,11 @@ var bpfNatListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf nat list")
 		if len(args) == 0 {
-			ipv4, ipv6 := nat.GlobalMaps(true, getIpv6EnableStatus(), true)
+			ipv4, ipv6 := getIpEnableStatuses()
+			ipv4Map, ipv6Map := nat.GlobalMaps(ipv4, ipv6, true)
 			globalMaps := make([]nat.NatMap, 2)
-			globalMaps[0] = ipv4
-			globalMaps[1] = ipv6
+			globalMaps[0] = ipv4Map
+			globalMaps[1] = ipv6Map
 			dumpNat(globalMaps)
 		} else if len(args) == 2 && args[0] == "cluster" {
 			clusterID, err := strconv.ParseUint(args[1], 10, 32)
@@ -37,14 +38,15 @@ var bpfNatListCmd = &cobra.Command{
 				cmd.PrintErrf("Invalid ClusterID: %s", err.Error())
 				return
 			}
-			ipv4, ipv6, err := nat.ClusterMaps(uint32(clusterID), true, getIpv6EnableStatus())
+			ipv4, ipv6 := getIpEnableStatuses()
+			ipv4Map, ipv6Map, err := nat.ClusterMaps(uint32(clusterID), ipv4, ipv6)
 			if err != nil {
 				cmd.PrintErrf("Failed to retrieve cluster maps: %s", err.Error())
 				return
 			}
 			clusterMaps := make([]nat.NatMap, 2)
-			clusterMaps[0] = ipv4
-			clusterMaps[1] = ipv6
+			clusterMaps[0] = ipv4Map
+			clusterMaps[1] = ipv6Map
 			dumpNat(clusterMaps)
 		} else {
 			cmd.PrintErr("Invalid argument")

--- a/cilium-dbg/cmd/bpf_nat_retries_flush.go
+++ b/cilium-dbg/cmd/bpf_nat_retries_flush.go
@@ -28,9 +28,10 @@ func init() {
 }
 
 func flushRetries() {
-	ipv4, ipv6 := nat.RetriesMaps(true, getIpv6EnableStatus(), true)
+	ipv4, ipv6 := getIpEnableStatuses()
+	ipv4Map, ipv6Map := nat.RetriesMaps(ipv4, ipv6, true)
 
-	for _, m := range []nat.RetriesMap{ipv4, ipv6} {
+	for _, m := range []nat.RetriesMap{ipv4Map, ipv6Map} {
 		if m == nil {
 			continue
 		}

--- a/cilium-dbg/cmd/bpf_nat_retries_list.go
+++ b/cilium-dbg/cmd/bpf_nat_retries_list.go
@@ -27,12 +27,13 @@ var bpfNatRetriesListCmd = &cobra.Command{
 			return
 		}
 
-		ipv4, ipv6 := nat.RetriesMaps(true, getIpv6EnableStatus(), true)
-		if ipv4 != nil {
-			dumpRetries(ipv4)
+		ipv4, ipv6 := getIpEnableStatuses()
+		ipv4Map, ipv6Map := nat.RetriesMaps(ipv4, ipv6, true)
+		if ipv4Map != nil {
+			dumpRetries(ipv4Map)
 		}
-		if ipv6 != nil {
-			dumpRetries(ipv6)
+		if ipv6Map != nil {
+			dumpRetries(ipv6Map)
 		}
 	},
 }

--- a/cilium-dbg/cmd/bpf_recorder_list.go
+++ b/cilium-dbg/cmd/bpf_recorder_list.go
@@ -23,7 +23,7 @@ var bpfRecorderListCmd = &cobra.Command{
 	Run: func(_ *cobra.Command, _ []string) {
 		common.RequireRootPrivilege("cilium bpf recorder list")
 		maps := []recorder.CaptureMap{recorder.CaptureMap4()}
-		if getIpv6EnableStatus() {
+		if _, ipv6 := getIpEnableStatuses(); ipv6 {
 			maps = append(maps, recorder.CaptureMap6())
 		}
 		dumpRecorderEntries(maps)

--- a/cilium-dbg/cmd/helpers.go
+++ b/cilium-dbg/cmd/helpers.go
@@ -402,32 +402,33 @@ func mapKeysToLowerCase(s map[string]interface{}) map[string]interface{} {
 	return m
 }
 
-// getIpv6EnableStatus api returns the EnableIPv6 status
-// by consulting the cilium-agent otherwise reads from the
-// runtime system config
-func getIpv6EnableStatus() bool {
+// getIpEnableStatuses api returns the EnableIPv6 and EnableIPv4 statuses by
+// consulting the cilium-agent otherwise reads from the runtime system config.
+func getIpEnableStatuses() (bool, bool) {
 	params := daemon.NewGetHealthzParamsWithTimeout(5 * time.Second)
 	brief := true
 	params.SetBrief(&brief)
-	// If cilium-agent is running get the ipv6 enable status
+	// If cilium-agent is running get the enable statuses
 	if _, err := client.Daemon.GetHealthz(params); err == nil {
 		if resp, err := client.ConfigGet(); err == nil {
 			if resp.Status != nil {
-				return resp.Status.Addressing.IPV6 != nil && resp.Status.Addressing.IPV6.Enabled
+				ipv4 := resp.Status.Addressing.IPV4 != nil && resp.Status.Addressing.IPV4.Enabled
+				ipv6 := resp.Status.Addressing.IPV6 != nil && resp.Status.Addressing.IPV6.Enabled
+				return ipv4, ipv6
 			}
 		}
-	} else { // else read the EnableIPv6 status from the file-system
+	} else { // else read the statuses from the file-system
 		agentConfigFile := filepath.Join(defaults.RuntimePath, defaults.StateDir,
 			"agent-runtime-config.json")
 
 		if byteValue, err := os.ReadFile(agentConfigFile); err == nil {
 			if err = json.Unmarshal(byteValue, &option.Config); err == nil {
-				return option.Config.EnableIPv6
+				return option.Config.EnableIPv4, option.Config.EnableIPv6
 			}
 		}
 	}
-	// returning the EnableIPv6 default status
-	return defaults.EnableIPv6
+	// returning the default statuses
+	return defaults.EnableIPv4, defaults.EnableIPv6
 }
 
 func mergeMaps(m1, m2 map[string]interface{}) map[string]interface{} {


### PR DESCRIPTION
On IPv6-only clusters, several of our `cilium-dbg bpf` commands fail because we try to open IPv4 maps and they don't exist. This commit fixes it by extending (and renaming) the `getIpv6EnableStatus` helper to detect both the IPv4 and IPv6 statuses in the agent. This information is then passed to the map creation functions.

```release-note
Fix bug causing `cilium-dbg bpf` commands to fail with a map not found error in IPv6-only clusters.
```