### PR TITLE
gateway-api: Support LoadBalancerSourceRangesPolicy in CGCC

### DIFF
--- a/operator/pkg/model/ingestion/gateway_config.go
+++ b/operator/pkg/model/ingestion/gateway_config.go
@@ -43,6 +43,12 @@ func toServiceModel(params *v2alpha1.CiliumGatewayClassConfig) *model.Service {
 	res.ExternalTrafficPolicy = string(params.Spec.Service.ExternalTrafficPolicy)
 	res.LoadBalancerClass = params.Spec.Service.LoadBalancerClass
 	res.LoadBalancerSourceRanges = params.Spec.Service.LoadBalancerSourceRanges
+	if len(params.Spec.Service.LoadBalancerSourceRangesPolicy) != 0 {
+		res.LoadBalancerSourceRangesPolicy = string(params.Spec.Service.LoadBalancerSourceRangesPolicy)
+	} else {
+		// Defaults to allowed, same as default value in CRD
+		res.LoadBalancerSourceRangesPolicy = string(v2alpha1.LoadBalancerSourceRangesPolicyAllow)
+	}
 	res.IPFamilies = toIPFamilies(params.Spec.Service.IPFamilies)
 	res.IPFamilyPolicy = (*string)(params.Spec.Service.IPFamilyPolicy)
 	res.AllocateLoadBalancerNodePorts = params.Spec.Service.AllocateLoadBalancerNodePorts

--- a/operator/pkg/model/ingestion/testdata/gateway/basic_http/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/basic_http/output-listeners.yaml
@@ -21,6 +21,7 @@
     timeout: {}
   service:
     type: LoadBalancer
+    load_balancer_source_ranges_policy: Allow
   sources:
   - group: gateway.networking.k8s.io
     kind: Gateway

--- a/operator/pkg/model/ingestion/testdata/gateway/basic_http_external_traffic_policy/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/basic_http_external_traffic_policy/output-listeners.yaml
@@ -21,6 +21,7 @@
     timeout: {}
   service:
     type: NodePort
+    load_balancer_source_ranges_policy: Allow
     external_traffic_policy: Local
   sources:
   - group: gateway.networking.k8s.io

--- a/operator/pkg/model/ingestion/testdata/gateway/basic_http_load_balancer/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/basic_http_load_balancer/output-listeners.yaml
@@ -27,6 +27,7 @@
     - IPv6
     ip_family_policy: PreferDualStack
     load_balancer_class: cilium
+    load_balancer_source_ranges_policy: Allow
     load_balancer_source_ranges:
     - 10.0.0.0/8
     traffic_distribution: PreferClose

--- a/operator/pkg/model/ingestion/testdata/gateway/basic_http_nodeport_service/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/basic_http_nodeport_service/output-listeners.yaml
@@ -21,6 +21,7 @@
     timeout: {}
   service:
     type: NodePort
+    load_balancer_source_ranges_policy: Allow
   sources:
   - group: gateway.networking.k8s.io
     kind: Gateway

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -177,13 +177,14 @@ type Service struct {
 	// Applicable only if Type is Node NodePort
 	SecureNodePort *uint32 `json:"secure_node_port,omitempty"`
 
-	ExternalTrafficPolicy         string   `json:"external_traffic_policy,omitempty"`
-	LoadBalancerClass             *string  `json:"load_balancer_class,omitempty"`
-	LoadBalancerSourceRanges      []string `json:"load_balancer_source_ranges,omitempty"`
-	IPFamilies                    []string `json:"ip_families,omitempty"`
-	IPFamilyPolicy                *string  `json:"ip_family_policy,omitempty"`
-	AllocateLoadBalancerNodePorts *bool    `json:"allocate_load_balancer_node_ports,omitempty"`
-	TrafficDistribution           *string  `json:"traffic_distribution,omitempty"`
+	ExternalTrafficPolicy          string   `json:"external_traffic_policy,omitempty"`
+	LoadBalancerClass              *string  `json:"load_balancer_class,omitempty"`
+	LoadBalancerSourceRanges       []string `json:"load_balancer_source_ranges,omitempty"`
+	LoadBalancerSourceRangesPolicy string   `json:"load_balancer_source_ranges_policy,omitempty"`
+	IPFamilies                     []string `json:"ip_families,omitempty"`
+	IPFamilyPolicy                 *string  `json:"ip_family_policy,omitempty"`
+	AllocateLoadBalancerNodePorts  *bool    `json:"allocate_load_balancer_node_ports,omitempty"`
+	TrafficDistribution            *string  `json:"traffic_distribution,omitempty"`
 }
 
 // FullyQualifiedResource stores the full details of a Kubernetes resource, including

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_external_traffic_policy/input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_external_traffic_policy/input.yaml
@@ -13,6 +13,7 @@ http:
     timeout: {}
   service:
     type: NodePort
+    load_balancer_source_ranges_policy: Allow
   sources:
   - group: gateway.networking.k8s.io
     kind: Gateway

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_external_traffic_policy/service-output.yaml
@@ -5,6 +5,8 @@ metadata:
     io.cilium.gateway/owning-gateway: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default
+  annotations:
+    service.cilium.io/src-ranges-policy: Allow
   ownerReferences:
   - apiVersion: gateway.networking.k8s.io/v1
     controller: true

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_load_balancer/input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_load_balancer/input.yaml
@@ -19,6 +19,7 @@ http:
     - IPv6
     ip_family_policy: PreferDualStack
     load_balancer_class: cilium
+    load_balancer_source_ranges_policy: Deny
     load_balancer_source_ranges:
     - 10.0.0.0/8
     traffic_distribution: PreferClose

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_load_balancer/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_load_balancer/service-output.yaml
@@ -5,6 +5,8 @@ metadata:
     io.cilium.gateway/owning-gateway: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default
+  annotations:
+    service.cilium.io/src-ranges-policy: Deny
   ownerReferences:
   - apiVersion: gateway.networking.k8s.io/v1
     controller: true

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_nodeport/input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_nodeport/input.yaml
@@ -14,6 +14,7 @@ http:
   service:
     type: NodePort
     external_traffic_policy: Local
+    load_balancer_source_ranges_policy: Allow
   sources:
   - group: gateway.networking.k8s.io
     kind: Gateway

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_nodeport/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_nodeport/service-output.yaml
@@ -5,6 +5,8 @@ metadata:
     io.cilium.gateway/owning-gateway: my-gateway
   name: cilium-gateway-my-gateway
   namespace: default
+  annotations:
+    service.cilium.io/src-ranges-policy: Allow
   ownerReferences:
   - apiVersion: gateway.networking.k8s.io/v1
     controller: true

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/operator/pkg/model/translation"
+	"github.com/cilium/cilium/pkg/annotation"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/shortener"
 )
@@ -137,7 +138,7 @@ func (t *gatewayAPITranslator) desiredService(params *model.Service, owner *mode
 				owningGatewayLabel: shortenName,
 				gatewayNameLabel:   shortenName,
 			}, labels),
-			Annotations: annotations,
+			Annotations: t.toServiceAnnotations(annotations, params),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: gatewayv1beta1.GroupVersion.String(),
@@ -332,6 +333,17 @@ func (t *gatewayAPITranslator) desiredEndpoints(owner *model.FullyQualifiedResou
 			},
 		},
 	}
+}
+
+func (t *gatewayAPITranslator) toServiceAnnotations(annotations map[string]string, params *model.Service) map[string]string {
+	if params == nil {
+		return annotations
+	}
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[annotation.ServiceSourceRangesPolicy] = params.LoadBalancerSourceRangesPolicy
+	return annotations
 }
 
 func decorateCEC(cec *ciliumv2.CiliumEnvoyConfig, resource *model.FullyQualifiedResource, labels, annotations map[string]string) error {

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumgatewayclassconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumgatewayclassconfigs.yaml
@@ -100,6 +100,15 @@ spec:
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
+                  loadBalancerSourceRangesPolicy:
+                    default: Allow
+                    description: |-
+                      LoadBalancerSourceRangesPolicy defines the policy for the LoadBalancerSourceRanges if the incoming traffic
+                      is allowed or denied.
+                    enum:
+                    - Allow
+                    - Deny
+                    type: string
                   trafficDistribution:
                     description: Sets the Service.Spec.TrafficDistribution in generated
                       Service objects to the given value.

--- a/pkg/k8s/apis/cilium.io/v2alpha1/gatewayclassconfig_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/gatewayclassconfig_types.go
@@ -55,6 +55,16 @@ type CiliumGatewayClassConfigList struct {
 
 // +deepequal-gen=true
 
+type LoadBalancerSourceRangesPolicyType string
+
+const (
+	// LoadBalancerSourceRangesPolicyAllow allows traffic for the given source ranges.
+	LoadBalancerSourceRangesPolicyAllow LoadBalancerSourceRangesPolicyType = "Allow"
+
+	// LoadBalancerSourceRangesPolicyDeny denies traffic for the given source ranges.
+	LoadBalancerSourceRangesPolicyDeny LoadBalancerSourceRangesPolicyType = "Deny"
+)
+
 type ServiceConfig struct {
 	// Sets the Service.Spec.Type in generated Service objects to the given value.
 	//
@@ -93,6 +103,14 @@ type ServiceConfig struct {
 	// +optional
 	// +listType=atomic
 	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty"`
+
+	// LoadBalancerSourceRangesPolicy defines the policy for the LoadBalancerSourceRanges if the incoming traffic
+	// is allowed or denied.
+	//
+	// +optional
+	// +kubebuilder:validation:Enum=Allow;Deny
+	// +kubebuilder:default="Allow"
+	LoadBalancerSourceRangesPolicy LoadBalancerSourceRangesPolicyType `json:"loadBalancerSourceRangesPolicy,omitempty"`
 
 	// Sets the Service.Spec.TrafficDistribution in generated Service objects to the given value.
 	//

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
@@ -1770,6 +1770,9 @@ func (in *ServiceConfig) DeepEqual(other *ServiceConfig) bool {
 		}
 	}
 
+	if in.LoadBalancerSourceRangesPolicy != other.LoadBalancerSourceRangesPolicy {
+		return false
+	}
 	if (in.TrafficDistribution == nil) != (other.TrafficDistribution == nil) {
 		return false
 	} else if in.TrafficDistribution != nil {


### PR DESCRIPTION
## Description

This is to extend the support of LoadBalancerSourceRanges. User can enforce either Allow (default) or Deny for incoming traffics.

--- 

## Testing

Testing was done as per below

<details>
<summary>Base scenario</summary>

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: GatewayClass
metadata:
  name: cilium-with-config
spec:
  controllerName: io.cilium/gateway-controller
  description: The default Cilium GatewayClass
  parametersRef:
    group: cilium.io
    kind: CiliumGatewayClassConfig
    name: cilium-gateway-config
    namespace: default
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: my-gateway
spec:
  gatewayClassName: cilium-with-configmap
  listeners:
  - protocol: HTTP
    port: 80
    name: web-gw
    allowedRoutes:
      namespaces:
        from: Same
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: http-app-1
spec:
  parentRefs:
  - name: my-gateway
    namespace: default
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /details
    backendRefs:
    - name: details
      port: 9080
```

</details>

---
### Allowed Policy for LoadBalancerSourceRanges
GatewayConfig to allow only specific CIDR (e.g. 172.18.0.4/32) and deny all other CIDRs

```yaml
---
apiVersion: cilium.io/v2alpha1
kind: CiliumGatewayClassConfig
metadata:
  name: cilium-gateway-config
  namespace: default
spec:
  service:
    type: LoadBalancer
    loadBalancerSourceRanges:
    - 172.18.0.4/32
    loadBalancerSourceRangesPolicy: Allow
```

```shell
$ kg services cilium-gateway-my-gateway        
NAME                        TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)        AGE
cilium-gateway-my-gateway   LoadBalancer   10.96.130.62   172.18.255.193   80:30730/TCP   9s

# Send a request to the gateway service from allowed CIDR
$ ip addr show | grep 172
    inet 172.18.0.4/16 brd 172.18.255.255 scope global eth0
$ curl --connect-timeout 1 http://172.18.255.193/details/1
{"id":1,"author":"William Shakespeare","year":1595,"type":"paperback","pages":200,"publisher":"PublisherA","language":"English","ISBN-10":"1234567890","ISBN-13":"123-1234567890"}

# Send a request to the gateway service from disallowed CIDR
$ curl -v --connect-timeout 5 http://172.18.255.193/details/1
*   Trying 172.18.255.193:80...
* After 5000ms connect time, move on!
* connect to 172.18.255.193 port 80 failed: Connection timed out
* Connection timeout after 5000 ms
* Closing connection 0
curl: (28) Connection timeout after 5000 ms

# Hubble flow for DROPPED verdict
root@kind-worker:/home/cilium# hubble observe -f --verdict DROPPED
Feb 21 12:40:14.362: 172.18.0.1:32834 (world-ipv4) <> 172.18.255.193:80 (world-ipv4) Denied by LB src range check DROPPED (TCP Flags: SYN)
```

---
### Denied Policy for LoadBalancerSourceRanges

GatewayConfig to deny only specific CIDR (e.g. 172.18.0.4/32) and allow all other CIDRs

```yaml
---
apiVersion: cilium.io/v2alpha1
kind: CiliumGatewayClassConfig
metadata:
  name: cilium-gateway-config
  namespace: default
spec:
  service:
    type: LoadBalancer
    loadBalancerSourceRanges:
    - 172.18.0.4/32
    loadBalancerSourceRangesPolicy: Deny
```

```shell
# Send a request to the gateway service from denied CIDR
$ ip addr show | grep 172
    inet 172.18.0.4/16 brd 172.18.255.255 scope global eth0
$ curl --connect-timeout 1 http://172.18.255.193/details/1
curl: (28) Failed to connect to 172.18.255.193 port 80 after 1001 ms: Timeout was reached

# Send a request to the gateway service from allowed CIDR
$ curl --connect-timeout 5 http://172.18.255.193/details/1 
{"id":1,"author":"William Shakespeare","year":1595,"type":"paperback","pages":200,"publisher":"PublisherA","language":"English","ISBN-10":"1234567890","ISBN-13":"123-1234567890"}%   
```

