### PR TITLE
Update connectivity tests to correctly detect TLS Interception

### DIFF
--- a/cilium-cli/connectivity/builder/client_egress_l7_set_header.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_set_header.go
@@ -31,7 +31,7 @@ func clientEgressL7SetHeaderTest(ct *check.ConnectivityTest, templates map[strin
 	// Test L7 HTTP with a header replace set in the policy
 	newTest(testName, ct).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
-		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretBackendK8s)).
+		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretsOnlyFromSecretsNamespace)).
 		WithSecret(&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "header-match",

--- a/cilium-cli/connectivity/builder/client_egress_l7_tls_deny_without_headers.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_tls_deny_without_headers.go
@@ -16,7 +16,7 @@ func (t clientEgressL7TlsDenyWithoutHeaders) build(ct *check.ConnectivityTest, t
 	// Fail to load site due to missing headers.
 	newTest("seq-client-egress-l7-tls-deny-without-headers", ct).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
-		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretBackendK8s)).
+		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretsOnlyFromSecretsNamespace)).
 		WithCABundleSecret().
 		WithCertificate("externaltarget-tls", ct.Params().ExternalTarget).
 		WithCiliumPolicy(templates["clientEgressL7TLSPolicyYAML"]).   // L7 allow policy with TLS interception

--- a/cilium-cli/connectivity/builder/client_egress_l7_tls_headers.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_tls_headers.go
@@ -29,7 +29,8 @@ func clientEgressL7TlsHeadersTest(ct *check.ConnectivityTest, templates map[stri
 	// Test L7 HTTPS interception using an egress policy on the clients.
 	newTest(testName, ct).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
-		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretBackendK8s)).
+		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretsOnlyFromSecretsNamespace)).
+		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretSync)).
 		WithCABundleSecret().
 		WithCertificate("externaltarget-tls", ct.Params().ExternalTarget).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy with TLS interception
@@ -50,7 +51,7 @@ func clientEgressL7ExtraTlsHeadersTest(ct *check.ConnectivityTest, templates map
 	// Test L7 HTTPS interception using an egress policy on the clients.
 	newTest(testName, ct).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
-		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretBackendK8s)).
+		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretsOnlyFromSecretsNamespace)).
 		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretSync)).
 		WithCABundleSecret().
 		WithCertificate("externaltarget-tls", ct.Params().ExternalTarget). // Only one certificate for ExternalTarget

--- a/cilium-cli/connectivity/builder/client_egress_tls_sni.go
+++ b/cilium-cli/connectivity/builder/client_egress_tls_sni.go
@@ -58,7 +58,7 @@ func clientEgressL7TlsSniTest(ct *check.ConnectivityTest, templates map[string]s
 	newTest(testName, ct).
 		WithCiliumVersion("!1.14.15 !1.14.16 !1.15.9 !1.15.10 !1.16.2 !1.16.3").
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
-		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretBackendK8s)).
+		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretsOnlyFromSecretsNamespace)).
 		WithCABundleSecret().
 		WithCertificate("externaltarget-tls", ct.Params().ExternalTarget).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -90,8 +90,8 @@ func (ct *ConnectivityTest) extractFeaturesFromClusterRole(ctx context.Context, 
 	}
 
 	// This could be enabled via configmap check, so only check if it's not enabled already.
-	if !result[features.PolicySecretBackendK8s].Enabled {
-		result[features.PolicySecretBackendK8s] = features.Status{
+	if !result[features.PolicySecretsOnlyFromSecretsNamespace].Enabled {
+		result[features.PolicySecretsOnlyFromSecretsNamespace] = features.Status{
 			Enabled: canAccessK8sResourceSecret(cr),
 		}
 	}

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -53,23 +53,41 @@ const (
 
 	Flavor Feature = "flavor"
 
-	// PolicySecretBackendK8s sets if Policy supports saving secrets in
-	// Kubernetes (instead of reading from local disk).
-	// It's enabled by setting tls.secretsBackend to "k8s" in
-	// Helm.
-	// This can have two possible effects, depending on if
-	// policy secret synchronization is enabled using tls.SecretSync.enabled
-	// in Helm:
-	// * If SecretSync is not enabled, then the agent will be granted read access
-	//   to _all_ Secrets in the cluster. Not desirable, included for backwards
-	//   compatibility.
-	// * If SecretSync is enabled, then the `enable-policy-secrets-sync` agent
-	//   param will be set in the configmap.
+	// The following settings control Policy Secrets tests.
 	//
-	// So, there are _two_ places where this feature will be set, either in the
-	// ClusterRole detection or the Configmap detection.
-	PolicySecretBackendK8s Feature = "secret-backend-k8s"
-	PolicySecretSync       Feature = "enable-policy-secrets-sync"
+	// Cilium can be in three states for Policy Secrets:
+	//
+	// * Policy Secrets can be read by the agent from anywhere in the cluster (via either
+	//   direct read or from the configured secret namespace via secret
+	//   synchonrization by the Cilium Operator).
+	// * Policy Secrets can be read by the agent, but only from the configured Secrets
+	//   namespace. This is an advanced use case, and is included for migration purposes.
+	// * Policy Secrets cannot be read.
+
+	// PolicySecretsOnlyFromSecretsNamespace sets if Cilium  will look only
+	// in the configured secrets namespace for Policy Secrets, or if it will look
+	// in the entire cluster.
+	//
+	// If it's `true`, then Cilium will only read Secrets from the configured namespace.
+	//
+	// If it's `false`, then the Cilium agent will be granted Read access to _all_ Secrets
+	// in the cluster.
+	//
+	// This feature replaces the existing `tls.secretsBackend: k8s` one. SecretsBackend
+	// will be removed in a future release.
+	//
+	// This feature has Helm automation to mirror the setting of secretsBackend in the meantime.
+	PolicySecretsOnlyFromSecretsNamespace Feature = "policy-secrets-only-from-secrets-namespace"
+
+	// PolicySecretSync controls whether the Cilium Operator will synchronize Secrets referenced
+	// in Network Policy into the configured Secrets namespace.
+	//
+	// This has important interactions with
+	PolicySecretSync Feature = "enable-policy-secrets-sync"
+	// For connectivity tests, we only care if Secrets can be read from the cluster
+	// _somehow_, whether that is via direct read or secret sync is not important.
+	// So, this feature tracks if we can read Policy secrets _somehow_.
+	PolicySecretsReadable Feature = "policy-secrets-readable"
 
 	CNP  Feature = "cilium-network-policy"
 	CCNP Feature = "cilium-clusterwide-network-policy"
@@ -378,8 +396,8 @@ func (fs Set) ExtractFromConfigMap(cm *v1.ConfigMap) {
 
 	// This could be enabled via ClusterRole check as well, so only
 	// check if it's false.
-	if !fs[PolicySecretBackendK8s].Enabled {
-		fs[PolicySecretBackendK8s] = Status{
+	if !fs[PolicySecretsOnlyFromSecretsNamespace].Enabled {
+		fs[PolicySecretsOnlyFromSecretsNamespace] = Status{
 			Enabled: cm.Data[string(PolicySecretSync)] == "true",
 		}
 	}


### PR DESCRIPTION
The existing connectivity tests were using the old PolicySecretsBackendK8s feature to detect if TLS Interception was in use, this fixes those tests to use the new
PolicySecretsOnlyFromSecretsNamespace feature instead.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
