### PR TITLE
v1.16 Backports 2025-02-21

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -144,7 +144,6 @@ jobs:
 
             # The LVH image ships with LLVM taken from a release Cilium version.
             # Replace it with the one extracted from the cilium-builder image.
-            /bootstrap/deb-docker.sh # Install docker first.
             /host/contrib/scripts/extract-llvm.sh /tmp/llvm
             mv /tmp/llvm/usr/local/bin/{clang,llc} /bin/
             rm -r /tmp/llvm


### PR DESCRIPTION
 * [x] #32067 (@gentoo-root)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 32067
```
