### PR TITLE
ci: add runtime prefix to env var

### DIFF
--- a/.github/actions/set-env-variables/action.yml
+++ b/.github/actions/set-env-variables/action.yml
@@ -19,6 +19,7 @@ runs:
         echo "CILIUM_CLI_SKIP_BUILD=true" >> $GITHUB_ENV
         echo "PUSH_TO_DOCKER_HUB=true" >> $GITHUB_ENV
         echo "GCP_PERF_RESULTS_BUCKET=gs://cilium-scale-results" >> $GITHUB_ENV
+        echo "CILIUM_RUNTIME_IMAGE_PREFIX=quay.io/cilium/" >> $GITHUB_ENV
 
         # renovate: datasource=github-releases depName=kubernetes-sigs/kind
         KIND_VERSION="v0.26.0"


### PR DESCRIPTION
This commit will add the cilium-runtime image prefix to the env var, and will be used in https://github.com/cilium/cilium/pull/37595 (specific commit : 3ad66ae3f816e8653593744df55716e9d623d30d) to verify the provenance of the runtime image used in the CI.

```release-note
add cilium-runtime image prefix to env var
```
