### PR TITLE
cilium-cli: Only use --curl-parallel when expecting success

### DIFF
--- a/cilium-cli/connectivity/check/action.go
+++ b/cilium-cli/connectivity/check/action.go
@@ -1083,3 +1083,15 @@ func (a *Action) validateMetric(ctx context.Context, node string, result Metrics
 		}
 	}
 }
+
+func (a *Action) expectingSuccess() bool {
+	return a.expectedExitCode() == ExitCode(0)
+}
+
+func (a *Action) CurlCommandWithOutput(peer TestPeer, opts ...string) []string {
+	return a.test.ctx.CurlCommandWithOutput(peer, a.IPFamily(), a.expectingSuccess(), opts)
+}
+
+func (a *Action) CurlCommand(peer TestPeer, opts ...string) []string {
+	return a.test.ctx.CurlCommand(peer, a.IPFamily(), a.expectingSuccess(), opts)
+}

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1010,32 +1010,6 @@ func (ct *ConnectivityTest) CurlCommandWithOutput(peer TestPeer, ipFam features.
 	return cmd
 }
 
-func (ct *ConnectivityTest) CurlCommandParallelWithOutput(peer TestPeer, ipFam features.IPFamily, parallel int, opts ...string) []string {
-	cmd := []string{
-		"curl", "--silent", "--fail", "--show-error",
-		"--parallel", "--parallel-immediate", "--parallel-max", fmt.Sprint(parallel),
-	}
-
-	if connectTimeout := ct.params.ConnectTimeout.Seconds(); connectTimeout > 0.0 {
-		cmd = append(cmd, "--connect-timeout", strconv.FormatFloat(connectTimeout, 'f', -1, 64))
-	}
-	if requestTimeout := ct.params.RequestTimeout.Seconds(); requestTimeout > 0.0 {
-		cmd = append(cmd, "--max-time", strconv.FormatFloat(requestTimeout, 'f', -1, 64))
-	}
-
-	cmd = append(cmd, opts...)
-	url := fmt.Sprintf("%s://%s%s",
-		peer.Scheme(),
-		net.JoinHostPort(peer.Address(ipFam), fmt.Sprint(peer.Port())),
-		peer.Path())
-
-	for i := 0; i < parallel; i++ {
-		cmd = append(cmd, url)
-	}
-
-	return cmd
-}
-
 func (ct *ConnectivityTest) PingCommand(peer TestPeer, ipFam features.IPFamily, extraArgs ...string) []string {
 	cmd := []string{"ping", "-c", "1"}
 

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -940,7 +940,7 @@ func (ct *ConnectivityTest) DetectMinimumCiliumVersion(ctx context.Context) (*se
 	return minVersion, nil
 }
 
-func (ct *ConnectivityTest) CurlCommandWithOutput(peer TestPeer, ipFam features.IPFamily, opts ...string) []string {
+func (ct *ConnectivityTest) CurlCommandWithOutput(peer TestPeer, ipFam features.IPFamily, expectingSuccess bool, opts []string) []string {
 	cmd := []string{
 		"curl", "--silent", "--fail", "--show-error",
 	}
@@ -972,7 +972,7 @@ func (ct *ConnectivityTest) CurlCommandWithOutput(peer TestPeer, ipFam features.
 	}
 
 	numTargets := 1
-	if ct.params.CurlParallel > 0 {
+	if expectingSuccess && ct.params.CurlParallel > 0 {
 		numTargets = int(ct.params.CurlParallel)
 		cmd = append(cmd, "--parallel", "--parallel-immediate")
 	}
@@ -990,11 +990,11 @@ func (ct *ConnectivityTest) CurlCommandWithOutput(peer TestPeer, ipFam features.
 	return cmd
 }
 
-func (ct *ConnectivityTest) CurlCommand(peer TestPeer, ipFam features.IPFamily, opts ...string) []string {
-	return ct.CurlCommandWithOutput(peer, ipFam, append([]string{
+func (ct *ConnectivityTest) CurlCommand(peer TestPeer, ipFam features.IPFamily, expectingSuccess bool, opts []string) []string {
+	return ct.CurlCommandWithOutput(peer, ipFam, expectingSuccess, append([]string{
 		"-w", "%{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code}\n",
 		"--output", "/dev/null",
-	}, opts...)...)
+	}, opts...))
 }
 
 func (ct *ConnectivityTest) PingCommand(peer TestPeer, ipFam features.IPFamily, extraArgs ...string) []string {

--- a/cilium-cli/connectivity/tests/bgp.go
+++ b/cilium-cli/connectivity/tests/bgp.go
@@ -96,7 +96,7 @@ func (s *bgpAdvertisements) Run(ctx context.Context, t *check.Test) {
 			i := 0
 			for _, echo := range ct.EchoPods() {
 				t.NewAction(s, fmt.Sprintf("curl-echo-pod-%s-%d", ipFamily, i), &client, echo, ipFamily).Run(func(a *check.Action) {
-					a.ExecInPod(ctx, ct.CurlCommand(echo, ipFamily))
+					a.ExecInPod(ctx, a.CurlCommand(echo))
 				})
 				i++
 			}
@@ -105,7 +105,7 @@ func (s *bgpAdvertisements) Run(ctx context.Context, t *check.Test) {
 			if status, ok := ct.Feature(features.BPFLBExternalClusterIP); ok && status.Enabled {
 				for _, echo := range ct.EchoServices() {
 					t.NewAction(s, fmt.Sprintf("curl-echo-service-%s-%d", ipFamily, i), &client, echo, ipFamily).Run(func(a *check.Action) {
-						a.ExecInPod(ctx, ct.CurlCommand(echo, ipFamily))
+						a.ExecInPod(ctx, a.CurlCommand(echo))
 					})
 					i++
 				}

--- a/cilium-cli/connectivity/tests/egressgateway.go
+++ b/cilium-cli/connectivity/tests/egressgateway.go
@@ -240,7 +240,7 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 			externalEcho := externalEchoSvc.ToEchoIPService()
 
 			t.NewAction(s, fmt.Sprintf("curl-external-echo-service-%d", i), &client, externalEcho, features.IPFamilyV4).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlCommandWithOutput(externalEcho, features.IPFamilyV4))
+				a.ExecInPod(ctx, a.CurlCommandWithOutput(externalEcho))
 				clientIP := extractClientIPFromResponse(a.CmdOutput())
 
 				if !clientIP.Equal(egressGatewayNodeInternalIP) {
@@ -258,7 +258,7 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 			externalEcho := externalEcho.ToEchoIPPod()
 
 			t.NewAction(s, fmt.Sprintf("curl-external-echo-pod-%d", i), &client, externalEcho, features.IPFamilyV4).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlCommandWithOutput(externalEcho, features.IPFamilyV4))
+				a.ExecInPod(ctx, a.CurlCommandWithOutput(externalEcho))
 				clientIP := extractClientIPFromResponse(a.CmdOutput())
 
 				if !clientIP.Equal(egressGatewayNodeInternalIP) {
@@ -279,7 +279,7 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 				echo := echo.ToNodeportService(node)
 
 				t.NewAction(s, fmt.Sprintf("curl-echo-service-%d", i), &client, echo, features.IPFamilyV4).Run(func(a *check.Action) {
-					a.ExecInPod(ctx, ct.CurlCommand(echo, features.IPFamilyV4))
+					a.ExecInPod(ctx, a.CurlCommand(echo))
 				})
 				i++
 			}
@@ -298,7 +298,7 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 		for _, client := range ct.ExternalEchoPods() {
 			for _, echo := range ct.EchoPods() {
 				t.NewAction(s, fmt.Sprintf("curl-echo-pod-%d", i), &client, echo, features.IPFamilyV4).Run(func(a *check.Action) {
-					a.ExecInPod(ctx, ct.CurlCommand(echo, features.IPFamilyV4))
+					a.ExecInPod(ctx, a.CurlCommand(echo))
 				})
 				i++
 			}
@@ -389,7 +389,7 @@ func (s *egressGatewayExcludedCIDRs) Run(ctx context.Context, t *check.Test) {
 			externalEcho := externalEcho.ToEchoIPPod()
 
 			t.NewAction(s, fmt.Sprintf("curl-%d", i), &client, externalEcho, features.IPFamilyV4).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlCommandWithOutput(externalEcho, features.IPFamilyV4))
+				a.ExecInPod(ctx, a.CurlCommandWithOutput(externalEcho))
 				clientIP := extractClientIPFromResponse(a.CmdOutput())
 
 				if !clientIP.Equal(net.ParseIP(client.Pod.Status.HostIP)) {

--- a/cilium-cli/connectivity/tests/egressgateway.go
+++ b/cilium-cli/connectivity/tests/egressgateway.go
@@ -240,7 +240,7 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 			externalEcho := externalEchoSvc.ToEchoIPService()
 
 			t.NewAction(s, fmt.Sprintf("curl-external-echo-service-%d", i), &client, externalEcho, features.IPFamilyV4).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlCommandWithOutput(externalEcho, features.IPFamilyV4, "-4"))
+				a.ExecInPod(ctx, ct.CurlCommandWithOutput(externalEcho, features.IPFamilyV4))
 				clientIP := extractClientIPFromResponse(a.CmdOutput())
 
 				if !clientIP.Equal(egressGatewayNodeInternalIP) {

--- a/cilium-cli/connectivity/tests/encryption.go
+++ b/cilium-cli/connectivity/tests/encryption.go
@@ -302,7 +302,7 @@ func testNoTrafficLeak(ctx context.Context, t *check.Test, s check.Scenario,
 	case requestHTTP:
 		// Curl the server from the client to generate some traffic
 		t.NewAction(s, fmt.Sprintf("curl-%s", ipFam), client, server, ipFam).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, t.Context().CurlCommand(server, ipFam))
+			a.ExecInPod(ctx, a.CurlCommand(server))
 			srcSniffer.Validate(ctx, a)
 			if dstSniffer != nil {
 				dstSniffer.Validate(ctx, a)

--- a/cilium-cli/connectivity/tests/encryption_v2.go
+++ b/cilium-cli/connectivity/tests/encryption_v2.go
@@ -485,7 +485,7 @@ func (s *podToPodEncryptionV2) clientToServerTest(ctx context.Context, t *check.
 		t.Debugf("performing client->server curl: [client: %s] [server: %s] [family: ipv4]", s.client.Pod.Name, s.server.Pod.Name)
 		action := t.NewAction(s, fmt.Sprintf("curl-%s", features.IPFamilyV4), s.client, s.server, features.IPFamilyV4)
 		action.Run(func(a *check.Action) {
-			a.ExecInPod(ctx, t.Context().CurlCommand(s.server, features.IPFamilyV4))
+			a.ExecInPod(ctx, a.CurlCommand(s.server))
 			s.clientSniffer4.Validate(ctx, a)
 			s.serverSniffer4.Validate(ctx, a)
 		})
@@ -495,7 +495,7 @@ func (s *podToPodEncryptionV2) clientToServerTest(ctx context.Context, t *check.
 		t.Debugf("performing client->server curl: [client: %s] [server: %s] [family: ipv6]", s.client.Pod.Name, s.server.Pod.Name)
 		action := t.NewAction(s, fmt.Sprintf("curl-%s", features.IPFamilyV6), s.client, s.server, features.IPFamilyV6)
 		action.Run(func(a *check.Action) {
-			a.ExecInPod(ctx, t.Context().CurlCommand(s.server, features.IPFamilyV6))
+			a.ExecInPod(ctx, a.CurlCommand(s.server))
 			s.clientSniffer6.Validate(ctx, a)
 			s.serverSniffer6.Validate(ctx, a)
 		})

--- a/cilium-cli/connectivity/tests/from-cidr.go
+++ b/cilium-cli/connectivity/tests/from-cidr.go
@@ -42,7 +42,7 @@ func (f *fromCIDRToPod) Run(ctx context.Context, t *check.Test) {
 			)
 
 			t.NewAction(f, "host-netns-to-pod", &clientPod, pod, ipFam).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, t.Context().CurlCommand(ep, ipFam))
+				a.ExecInPod(ctx, a.CurlCommand(ep))
 			})
 			i++
 		})

--- a/cilium-cli/connectivity/tests/host.go
+++ b/cilium-cli/connectivity/tests/host.go
@@ -147,7 +147,7 @@ func (s *podToHostPort) Run(ctx context.Context, t *check.Test) {
 			baseURL := fmt.Sprintf("%s://%s:%d%s", echo.Scheme(), echo.Pod.Status.HostIP, ct.Params().EchoServerHostPort, echo.Path())
 			ep := check.HTTPEndpoint(echo.Name(), baseURL)
 			t.NewAction(s, fmt.Sprintf("curl-%d", i), &client, ep, features.IPFamilyAny).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlCommand(ep, features.IPFamilyAny))
+				a.ExecInPod(ctx, a.CurlCommand(ep))
 
 				a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{
 					// Because the HostPort request is NATed, we might only
@@ -191,7 +191,7 @@ func (s *hostToPod) Run(ctx context.Context, t *check.Test) {
 		for _, dst := range ct.EchoPods() {
 			t.ForEachIPFamily(func(ipFam features.IPFamily) {
 				t.NewAction(s, fmt.Sprintf("curl-%s-%d", ipFam, i), &src, dst, ipFam).Run(func(a *check.Action) {
-					a.ExecInPod(ctx, ct.CurlCommand(dst, ipFam))
+					a.ExecInPod(ctx, a.CurlCommand(dst))
 				})
 			})
 

--- a/cilium-cli/connectivity/tests/k8s.go
+++ b/cilium-cli/connectivity/tests/k8s.go
@@ -36,7 +36,7 @@ func (s *podToK8sLocal) Run(ctx context.Context, t *check.Test) {
 		for _, ipFamily := range ipFamilies {
 			actionName := fmt.Sprintf("curl-k8s-from-pod-%s-%s", pod.Name(), ipFamily)
 			t.NewAction(s, actionName, &pod, k8sSvc, ipFamily).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlCommand(k8sSvc, ipFamily))
+				a.ExecInPod(ctx, a.CurlCommand(k8sSvc))
 				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 					DNSRequired: true,
 					AltDstPort:  k8sSvc.Port(),

--- a/cilium-cli/connectivity/tests/lrp.go
+++ b/cilium-cli/connectivity/tests/lrp.go
@@ -86,7 +86,7 @@ func (s lrp) Run(ctx context.Context, t *check.Test) {
 			i := 0
 			lf := check.NewLRPFrontend(policy.Spec.RedirectFrontend)
 			t.NewAction(s, fmt.Sprintf("curl-%d", i), &pod, lf, features.IPFamilyV4).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlCommand(lf, features.IPFamilyV4))
+				a.ExecInPod(ctx, a.CurlCommand(lf))
 				i++
 			})
 		}
@@ -103,7 +103,7 @@ func (s lrp) Run(ctx context.Context, t *check.Test) {
 			i := 0
 			lf := check.NewLRPFrontend(policy.Spec.RedirectFrontend)
 			t.NewAction(s, fmt.Sprintf("curl-%d", i), &pod, lf, features.IPFamilyV4).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlCommand(lf, features.IPFamilyV4))
+				a.ExecInPod(ctx, a.CurlCommand(lf))
 
 				if policy.Spec.SkipRedirectFromBackend {
 					a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
@@ -217,7 +217,7 @@ func (s lrpWithNodeDNS) Run(ctx context.Context, t *check.Test) {
 			externalEcho := externalEchoSvc.ToEchoIPService()
 
 			t.NewAction(s, fmt.Sprintf("lrp-node-dns-http-to-%s-%d", externalEcho, i), &client, externalEcho, features.IPFamilyV4).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlCommandWithOutput(externalEcho, features.IPFamilyV4))
+				a.ExecInPod(ctx, a.CurlCommandWithOutput(externalEcho))
 			})
 			i++
 		}

--- a/cilium-cli/connectivity/tests/pod.go
+++ b/cilium-cli/connectivity/tests/pod.go
@@ -65,9 +65,9 @@ func (s *podToPod) Run(ctx context.Context, t *check.Test) {
 			t.ForEachIPFamily(func(ipFam features.IPFamily) {
 				t.NewAction(s, fmt.Sprintf("curl-%s-%d", ipFam, i), &client, echo, ipFam).Run(func(a *check.Action) {
 					if s.method == "" {
-						a.ExecInPod(ctx, ct.CurlCommand(echo, ipFam))
+						a.ExecInPod(ctx, a.CurlCommand(echo))
 					} else {
-						a.ExecInPod(ctx, ct.CurlCommand(echo, ipFam, "-X", s.method))
+						a.ExecInPod(ctx, a.CurlCommand(echo, "-X", s.method))
 					}
 
 					a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{}))
@@ -162,7 +162,7 @@ func (s *podToPodWithEndpoints) curlEndpoints(ctx context.Context, t *check.Test
 
 		t.NewAction(s, epName, client, ep, ipFam).Run(func(a *check.Action) {
 			curlOpts = append(curlOpts, s.retryCondition.CurlOptions(ep, ipFam, *client, ct.Params())...)
-			a.ExecInPod(ctx, ct.CurlCommand(ep, ipFam, curlOpts...))
+			a.ExecInPod(ctx, a.CurlCommand(ep, curlOpts...))
 
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{}))
 			a.ValidateFlows(ctx, ep, a.GetIngressRequirements(check.FlowParameters{}))
@@ -179,7 +179,7 @@ func (s *podToPodWithEndpoints) curlEndpoints(ctx context.Context, t *check.Test
 				opts = append(opts, curlOpts...)
 				opts = append(opts, "-H", "X-Very-Secret-Token: 42")
 
-				a.ExecInPod(ctx, ct.CurlCommand(ep, ipFam, opts...))
+				a.ExecInPod(ctx, a.CurlCommand(ep, opts...))
 
 				a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{}))
 				a.ValidateFlows(ctx, ep, a.GetIngressRequirements(check.FlowParameters{}))
@@ -356,7 +356,7 @@ func (s *podToPodMissingIPCache) Run(ctx context.Context, t *check.Test) {
 					return
 				}
 				t.NewAction(s, fmt.Sprintf("curl-%s-%d", ipFam, i), &client, echo, ipFam).Run(func(a *check.Action) {
-					a.ExecInPod(ctx, ct.CurlCommand(echo, ipFam))
+					a.ExecInPod(ctx, a.CurlCommand(echo))
 
 					a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{}))
 					a.ValidateFlows(ctx, echo, a.GetIngressRequirements(check.FlowParameters{}))

--- a/cilium-cli/connectivity/tests/service.go
+++ b/cilium-cli/connectivity/tests/service.go
@@ -55,7 +55,7 @@ func (s *podToService) Run(ctx context.Context, t *check.Test) {
 			}
 
 			t.NewAction(s, fmt.Sprintf("curl-%d", i), &pod, svc, features.IPFamilyAny).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlCommand(svc, features.IPFamilyAny))
+				a.ExecInPod(ctx, a.CurlCommand(svc))
 
 				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 					DNSRequired: true,
@@ -110,7 +110,7 @@ func (s *podToIngress) Run(ctx context.Context, t *check.Test) {
 			}
 
 			t.NewAction(s, fmt.Sprintf("curl-%d", i), &pod, svc, features.IPFamilyAny).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, ct.CurlCommand(svc, features.IPFamilyAny))
+				a.ExecInPod(ctx, a.CurlCommand(svc))
 
 				a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
 					DNSRequired: true,
@@ -256,7 +256,7 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 			// Create the Action with the original svc as this will influence what the
 			// flow matcher looks for in the flow logs.
 			t.NewAction(s, name, pod, svc, features.IPFamilyAny).Run(func(a *check.Action) {
-				a.ExecInPod(ctx, t.Context().CurlCommand(ep, features.IPFamilyAny))
+				a.ExecInPod(ctx, a.CurlCommand(ep))
 
 				if validateFlows {
 					a.ValidateFlows(ctx, pod, a.GetEgressRequirements(check.FlowParameters{
@@ -328,7 +328,7 @@ func (s *outsideToIngressService) Run(ctx context.Context, t *check.Test) {
 	for _, svc := range t.Context().IngressService() {
 		t.NewAction(s, fmt.Sprintf("curl-ingress-service-%d", i), &clientPod, svc, features.IPFamilyAny).Run(func(a *check.Action) {
 			for _, node := range t.Context().Nodes() {
-				a.ExecInPod(ctx, t.Context().CurlCommand(svc.ToNodeportService(node), features.IPFamilyAny))
+				a.ExecInPod(ctx, a.CurlCommand(svc.ToNodeportService(node)))
 
 				a.ValidateFlows(ctx, clientPod, a.GetEgressRequirements(check.FlowParameters{
 					DNSRequired: true,

--- a/cilium-cli/connectivity/tests/to-cidr.go
+++ b/cilium-cli/connectivity/tests/to-cidr.go
@@ -47,7 +47,7 @@ func (s *podToCIDR) Run(ctx context.Context, t *check.Test) {
 		for _, src := range ct.ClientPods() {
 			t.NewAction(s, fmt.Sprintf("%s-%d", ep.Name(), i), &src, ep, features.IPFamilyAny).Run(func(a *check.Action) {
 				opts := s.rc.CurlOptions(ep, features.IPFamilyAny, src, ct.Params())
-				a.ExecInPod(ctx, ct.CurlCommand(ep, features.IPFamilyAny, opts...))
+				a.ExecInPod(ctx, a.CurlCommand(ep, opts...))
 
 				a.ValidateFlows(ctx, src, a.GetEgressRequirements(check.FlowParameters{
 					RSTAllowed: true,

--- a/cilium-cli/connectivity/tests/world.go
+++ b/cilium-cli/connectivity/tests/world.go
@@ -65,21 +65,21 @@ func (s *podToWorld) Run(ctx context.Context, t *check.Test) {
 		// With http, over port 80.
 		httpOpts := s.rc.CurlOptions(http, features.IPFamilyAny, client, ct.Params())
 		t.NewAction(s, fmt.Sprintf("http-to-%s-%d", extTarget, i), &client, http, features.IPFamilyAny).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, ct.CurlCommand(http, features.IPFamilyAny, httpOpts...))
+			a.ExecInPod(ctx, a.CurlCommand(http, httpOpts...))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 
 		// With https, over port 443.
 		httpsOpts := s.rc.CurlOptions(https, features.IPFamilyAny, client, ct.Params())
 		t.NewAction(s, fmt.Sprintf("https-to-%s-%d", extTarget, i), &client, https, features.IPFamilyAny).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, ct.CurlCommand(https, features.IPFamilyAny, httpsOpts...))
+			a.ExecInPod(ctx, a.CurlCommand(https, httpsOpts...))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 
 		// With https, over port 443, index.html.
 		httpsindexOpts := s.rc.CurlOptions(httpsindex, features.IPFamilyAny, client, ct.Params())
 		t.NewAction(s, fmt.Sprintf("https-to-%s-index-%d", extTarget, i), &client, httpsindex, features.IPFamilyAny).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, ct.CurlCommand(httpsindex, features.IPFamilyAny, httpsindexOpts...))
+			a.ExecInPod(ctx, a.CurlCommand(httpsindex, httpsindexOpts...))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 
@@ -119,7 +119,7 @@ func (s *podToWorld2) Run(ctx context.Context, t *check.Test) {
 	for _, client := range ct.ClientPods() {
 		// With https, over port 443.
 		t.NewAction(s, fmt.Sprintf("https-%s-%d", extTarget, i), &client, https, features.IPFamilyAny).Run(func(a *check.Action) {
-			a.ExecInPod(ctx, ct.CurlCommand(https, features.IPFamilyAny))
+			a.ExecInPod(ctx, a.CurlCommand(https))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 			a.ValidateMetrics(ctx, client, a.GetEgressMetricsRequirements())
 		})
@@ -175,7 +175,7 @@ func (s *podToWorldWithTLSIntercept) Run(ctx context.Context, t *check.Test) {
 		// With https, over port 443.
 		t.NewAction(s, fmt.Sprintf("https-to-%s-%d", extTarget, i), &client, https, features.IPFamilyAny).Run(func(a *check.Action) {
 			a.WriteDataToPod(ctx, "/tmp/test-ca.crt", caBundle)
-			a.ExecInPod(ctx, ct.CurlCommand(https, features.IPFamilyAny, s.curlOpts...))
+			a.ExecInPod(ctx, a.CurlCommand(https, s.curlOpts...))
 			a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 		})
 
@@ -234,7 +234,7 @@ func (s *podToWorldWithExtraTLSIntercept) Run(ctx context.Context, t *check.Test
 			https := check.HTTPEndpoint(target+"-https", "https://"+target)
 			t.NewAction(s, fmt.Sprintf("https-to-%s-%d", target, i), &client, https, features.IPFamilyAny).Run(func(a *check.Action) {
 				a.WriteDataToPod(ctx, "/tmp/test-ca.crt", caBundle)
-				a.ExecInPod(ctx, ct.CurlCommand(https, features.IPFamilyAny, s.curlOpts...))
+				a.ExecInPod(ctx, a.CurlCommand(https, s.curlOpts...))
 				a.ValidateFlows(ctx, client, a.GetEgressRequirements(fp))
 			})
 		}


### PR DESCRIPTION
Only use `--curl-parallel` on curl commands that are expected to succeed. When expecting failure and issuing parallel requests, curl will report failure if any of the parallel requests fail, thus possibly hiding unexpectedly succeeding requests.
