### PR TITLE
helm: Add IPv6 address configuration for envoy metrics

### DIFF
--- a/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.yaml
+++ b/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.yaml
@@ -7,8 +7,15 @@ staticResources:
   - name: "envoy-prometheus-metrics-listener"
     address:
       socketAddress:
-        address: "0.0.0.0"
+        address: {{ .Values.ipv4.enabled | ternary "0.0.0.0" "::" | quote }}
         portValue: {{ .Values.envoy.prometheus.port }}
+    {{- if and .Values.ipv4.enabled .Values.ipv6.enabled }}
+    additionalAddresses:
+    - address:
+        socketAddress:
+          address: "::"
+          portValue: {{ .Values.envoy.prometheus.port }}
+    {{- end }}
     filterChains:
     - filters:
       - name: "envoy.filters.network.http_connection_manager"


### PR DESCRIPTION
This PR fixes that the envoy metrics can not be obtained on IPv6-only clusters

Fixes: #37816
```release-note
Fix envoy metrics could not be obtained on IPv6-only clusters
```
