### PR TITLE
Stop TLS Interception config being included in preflight

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
@@ -126,7 +126,7 @@ subjects:
   namespace: {{ include "cilium.namespace" . }}
 {{- end}}
 
-{{- if and $readSecretsOnlyFromSecretsNamespace .Values.tls.secretsNamespace.name }}
+{{- if and (not .Values.preflight.enabled) $readSecretsOnlyFromSecretsNamespace .Values.tls.secretsNamespace.name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/install/kubernetes/cilium/templates/cilium-secrets-namespace.yaml
+++ b/install/kubernetes/cilium/templates/cilium-secrets-namespace.yaml
@@ -5,7 +5,7 @@
 {{- end -}}
 {{- end -}}
 
-{{- if and .Values.tls.secretsNamespace.create .Values.tls.secretsNamespace.name -}}
+{{- if and .Values.tls.secretsNamespace.create .Values.tls.secretsNamespace.name (not .Values.preflight.enabled) -}}
 {{- $_ := set $secretNamespaces .Values.tls.secretsNamespace.name 1 -}}
 {{- end -}}
 


### PR DESCRIPTION
This commit stops the Cilium Secrets Namespace and TLS interception rolebinding from being included in the Cilium preflight check.

This allows upgrading from v1.16 to v1.17 to work as the directions indicate.

Fixes: #37465

```release-note
Stop TLS Interception config being included in preflight
```
