### PR TITLE
Fix cilium-agent unable to start on IPv6-only cluster

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -978,9 +978,18 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 				}
 
 				ID := e.SecurityIdentity.ID
-				hostIP, ok := netipx.FromStdIP(node.GetIPv4())
-				if !ok {
-					return controller.NewExitReason("Failed to convert node IPv4 address")
+				var hostIP netip.Addr
+				var ok bool
+				if endpointIP.Is4() {
+					hostIP, ok = netipx.FromStdIP(node.GetIPv4())
+					if !ok {
+						return controller.NewExitReason("Failed to convert node IPv4 address")
+					}
+				} else {
+					hostIP, ok = netipx.FromStdIP(node.GetIPv6())
+					if !ok {
+						return controller.NewExitReason("Failed to convert node IPv6 address")
+					}
 				}
 				key := node.GetEndpointEncryptKeyIndex()
 				metadata := e.FormatGlobalEndpointID()

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -295,14 +295,26 @@ func AutoComplete(directRoutingDevice string) error {
 // ValidatePostInit validates the entire addressing setup and completes it as
 // required
 func ValidatePostInit() error {
-	if option.Config.EnableIPv4 || option.Config.TunnelingEnabled() {
-		if GetIPv4() == nil {
-			return fmt.Errorf("external IPv4 node address could not be derived, please configure via --ipv4-node")
+	if option.Config.EnableIPv4 && GetIPv4() == nil {
+		return fmt.Errorf("external IPv4 node address could not be derived, please configure via --ipv4-node")
+	}
+
+	if option.Config.EnableIPv6 && GetIPv6() == nil {
+		return fmt.Errorf("external IPv6 node address could not be derived, please configure via --ipv6-node")
+	}
+
+	if option.Config.TunnelingEnabled() {
+		if GetIPv4() == nil && GetIPv6() == nil {
+			return fmt.Errorf("external IPv4 and IPv6 node addresses could not be derived, please configure via --ipv4-node or --ipv6-node")
 		}
 	}
 
 	if option.Config.EnableIPv4 && GetInternalIPv4Router() == nil {
 		return fmt.Errorf("BUG: Internal IPv4 node address was not configured")
+	}
+
+	if option.Config.EnableIPv6 && GetIPv6Router() == nil {
+		return fmt.Errorf("BUG: Internal IPv6 node address was not configured")
 	}
 
 	return nil


### PR DESCRIPTION
The cilium-agent failed to start due to lack of IPv4 node address on IPv6-only cluster. the error log is as follows.
```
level=fatal msg="failed to start: postinit failed: external IPv4 node
address could not be derived, please configure via --ipv4-node" subsys=daemon
```
In addition, the `sync-IPv6-identity-mapping` controller failed to convert node IPv4 address due to missing endpoint IPv6 address family check.

This commit adds IPV6 address check logic for node and endpoint in `ValidatePostInit` and `runIPIdentitySync` functions.

Fixes: #37791

```release-note
Fix cilium-agent unable to start on IPv6-only cluster due to missing node IPv6 address check
```
