### PR TITLE
feat: Standalone dns proxy 

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -67,6 +67,9 @@ inputs:
   bgp-control-plane:
     description: 'Enable BGP Control Plane'
     default: 'false'
+  standalone-dns-proxy:
+    description: 'Enable standalone DNS proxy'
+    default: 'false'
 outputs:
   config:
     description: 'Cilium installation config'
@@ -105,7 +108,10 @@ runs:
             --helm-set=operator.image.useDigest=false \
             --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
             --helm-set=hubble.relay.image.tag=${{ inputs.image-tag }} \
-            --helm-set=hubble.relay.image.useDigest=false"
+            --helm-set=hubble.relay.image.useDigest=false \
+            --helm-set=standaloneDnsProxy.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/standalone-dns-proxy-ci \
+            --helm-set=standaloneDnsProxy.image.tag=${{ inputs.image-tag }} \
+            --helm-set=standaloneDnsProxy.image.useDigest=false"
           fi
 
           TUNNEL="--helm-set-string=tunnelProtocol=${{ inputs.tunnel }}"
@@ -196,5 +202,10 @@ runs:
             BGP_CONTROL_PLANE="${{ env.BGP_CONTROL_PLANE_HELM_VALUES }}"
           fi
 
-          CONFIG="${DEFAULTS} ${IMAGE} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV4} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION} ${INGRESS_CONTROLLER} ${CILIUMENDPOINTSLICE} ${LOCAL_REDIRECT_POLICY} ${BGP_CONTROL_PLANE}"
+          STANDALONE_DNS_PROXY=""
+          if [ "${{ inputs.standalone-dns-proxy }}" == "true" ]; then
+            STANDALONE_DNS_PROXY="--helm-set=standaloneDnsProxy.enabled=true --helm-set=standaloneDnsProxy.l7Proxy=true --set-string=extraConfig.enable-embedded-dns-proxy=false"
+          fi
+
+          CONFIG="${DEFAULTS} ${IMAGE} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV4} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION} ${INGRESS_CONTROLLER} ${CILIUMENDPOINTSLICE} ${LOCAL_REDIRECT_POLICY} ${BGP_CONTROL_PLANE} ${STANDALONE_DNS_PROXY}"
           echo "config=${CONFIG}" >> $GITHUB_OUTPUT

--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -109,8 +109,8 @@ runs:
             --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
             --helm-set=hubble.relay.image.tag=${{ inputs.image-tag }} \
             --helm-set=hubble.relay.image.useDigest=false \
-            --helm-set=standaloneDnsProxy.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/standalone-dns-proxy-ci \
-            --helm-set=standaloneDnsProxy.image.tag=${{ inputs.image-tag }} \
+            --helm-set=standaloneDnsProxy.image.repository=quay.io/singhvipul/standalone-dns-proxy \
+            --helm-set=standaloneDnsProxy.image.tag=latest \
             --helm-set=standaloneDnsProxy.image.useDigest=false"
           fi
 

--- a/.github/actions/helm-default/action.yaml
+++ b/.github/actions/helm-default/action.yaml
@@ -41,7 +41,10 @@ runs:
           --helm-set=clustermesh.apiserver.image.useDigest=false \
           --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
           --helm-set=hubble.relay.image.tag=${{ inputs.image-tag }} \
-          --helm-set=hubble.relay.image.useDigest=false"
+          --helm-set=hubble.relay.image.useDigest=false \
+          --helm-set=standaloneDnsProxy.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/standalone-dns-proxy-ci \
+          --helm-set=standaloneDnsProxy.image.tag=${{ inputs.image-tag }} \
+          --helm-set=standaloneDnsProxy.image.useDigest=false"
 
         if [ -f "${{ inputs.chart-dir }}/../../../.github/actions/helm-default/ci-required-values.yaml" ]; then
           CILIUM_INSTALL_DEFAULTS+=" --values=${{ inputs.chart-dir }}/../../../.github/actions/helm-default/ci-required-values.yaml"

--- a/.github/actions/wait-for-images/action.yaml
+++ b/.github/actions/wait-for-images/action.yaml
@@ -8,7 +8,7 @@ inputs:
   images:
     description: 'list of images to wait for'
     required: false
-    default: 'cilium-ci operator-generic-ci hubble-relay-ci cilium-cli-ci'
+    default: 'cilium-ci operator-generic-ci hubble-relay-ci cilium-cli-ci standalone-dns-proxy-ci'
 runs:
   using: composite
   steps:

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -19,6 +19,7 @@ triggers:
     - tests-datapath-verifier.yaml
     - tests-e2e-upgrade.yaml
     - tests-ipsec-upgrade.yaml
+    - tests-standalone-dns-proxy.yaml
     - hubble-cli-integration-test.yaml
   /ci-aks:
     workflows:
@@ -66,6 +67,9 @@ triggers:
   /ci-runtime:
     workflows:
     - conformance-runtime.yaml
+  /ci-standalone-dns-proxy:
+    workflows:
+    - tests-standalone-dns-proxy.yaml
   /ci-verifier:
     workflows:
     - tests-datapath-verifier.yaml
@@ -125,6 +129,8 @@ workflows:
   tests-e2e-upgrade.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
   tests-ipsec-upgrade.yaml:
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
+  tests-standalone-dns-proxy.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md|.*_test\.go)$)
   hubble-cli-integration-test.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|.github/actions/cl2-modules)/|(.github/renovate\.json5|CODEOWNERS|USERS.md)$)

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -71,6 +71,9 @@ jobs:
             dockerfile: ./images/cilium-docker-plugin/Dockerfile
             platforms: linux/amd64,linux/arm64
 
+          - name: standalone-dns-proxy
+            dockerfile: ./images/standalone-dns-proxy/Dockerfile
+            platforms: linux/amd64,linux/arm64
     steps:
       - name: Checkout base or default branch (trusted)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/tests-standalone-dns-proxy.yaml
+++ b/.github/workflows/tests-standalone-dns-proxy.yaml
@@ -1,0 +1,330 @@
+name: Standalone Dns Proxy test (ci-standalone-dns-proxy)
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  pull_request:
+    paths-ignore:
+      - 'Documentation/**'
+      - 'test/**'
+  workflow_dispatch:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: true
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: true
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: true
+  push:
+    branches:
+      - 'renovate/main-**'
+  # Run every 8 hours
+  schedule:
+    - cron:  '0 5/8 * * *'
+
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # To read actions state with catchpoint/workflow-telemetry-action
+  actions: read
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # To be able to set commit status
+  statuses: write
+
+concurrency:
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - workflow_dispatch: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing, such that re-runs will cancel the previous run.
+  group: |
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'push' && github.sha) ||
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+    }}
+  cancel-in-progress: true
+
+env:
+  test_concurrency: 5
+
+jobs:
+  echo-inputs:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    name: Echo Workflow Dispatch Inputs
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Echo Workflow Dispatch Inputs
+        run: |
+          echo '${{ tojson(inputs) }}'
+
+  commit-status-start:
+    name: Commit Status Start
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set initial commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+
+  wait-for-images:
+    name: Wait for images
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+      - name: Wait for images
+        uses: ./.github/actions/wait-for-images
+        with:
+          SHA: ${{ github.event.pull_request.head.sha }} #Not sure why this is needed
+          # SHA: ${{ inputs.SHA || github.sha }}
+          images: cilium-ci operator-generic-ci cilium-cli-ci
+
+  setup-and-test:
+    needs: [wait-for-images]
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
+    name: 'Setup & Test'
+    env:
+      job_name: 'Setup & Test'
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        include:
+          - name: '1'
+            kernel: '6.12-20250126.112744'
+            kpr: 'true'
+            standalone-dns-proxy: 'true'
+            misc: 'l7Proxy=true,dnsProxy.proxyPort=40046'
+            kube-proxy: 'none'
+
+    timeout-minutes: 30
+    steps:
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
+        with:
+          comment_on_pr: false
+
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Cleanup Disk space in runner
+        if: runner.name == 'ubuntu-24.04'
+        uses: ./.github/actions/disk-cleanup
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up job variables
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            SHA="${{ inputs.SHA }}"
+          else
+            SHA="${{ github.event.pull_request.head.sha  }}"
+          fi
+          echo sha=${SHA} >> $GITHUB_OUTPUT
+
+      - name: Derive Cilium installation config
+        id: cilium-newest-config
+        uses: ./.github/actions/cilium-config
+        with:
+          image-tag: ${{ steps.vars.outputs.sha }}
+          chart-dir: './untrusted/cilium-newest/install/kubernetes/cilium'
+          ipv4: true
+          ipv6: false
+          kpr: ${{ matrix.kpr }}
+          mutual-auth: false
+          misc: ${{ matrix.misc }}
+          standalone-dns-proxy: ${{ matrix.standalone-dns-proxy }}
+
+      - name: Set Kind params
+        id: kind-params
+        shell: bash
+        run: |
+          IP_FAM="ipv4"
+          echo params="--xdp --secondary-network \"\" 3 \"\" \"\" ${{ matrix.kube-proxy }} $IP_FAM" >> $GITHUB_OUTPUT
+
+      - name: Provision K8s on LVH VM
+        uses: ./.github/actions/lvh-kind
+        with:
+          test-name: e2e-conformance
+          kernel: ${{ matrix.kernel }}
+          kind-params: "${{ steps.kind-params.outputs.params }}"
+          kind-image: ${{ env.KIND_K8S_IMAGE }}
+
+      - name: Install Cilium CLI
+        uses: cilium/cilium-cli@45a3879a8cb769c9e41b912635e03a38849c9242 # v0.18.1
+        with:
+          skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
+          image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
+          image-tag: ${{ steps.vars.outputs.sha }}
+          repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
+          release-version: ${{ env.CILIUM_CLI_VERSION }}
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ steps.vars.outputs.sha }}
+          persist-credentials: false
+          path: untrusted/cilium-newest
+          sparse-checkout: |
+            install/kubernetes/cilium
+            examples
+
+      - name: Install Cilium
+        shell: bash
+        run: |
+          cilium install ${{ steps.cilium-newest-config.outputs.config }}
+          cilium status --wait --interactive=false
+          kubectl get pods --all-namespaces -o wide
+          kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
+
+          mkdir -p cilium-junits
+
+      - name: Test Cilium
+        shell: bash
+        run: |
+          cilium connectivity test --log-check-levels="error"
+
+      - name: Create pods for standalone-dns-proxy test
+        shell: bash
+        run: |
+          kubectl apply -f untrusted/cilium-newest/examples/minikube/http-sw-app.yaml
+          kubectl apply -f untrusted/cilium-newest/examples/policies/l7/dns/dns.yaml
+          #wait for pods to be ready
+          kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=xwing --timeout=120s
+
+      - name: Test DNS connectivity
+        shell: bash
+        run: |
+          #this should pass
+          kubectl exec xwing -- curl cilium.io
+          #this should fail
+          kubectl exec xwing -- curl one.one.one.one || true
+
+      - name: Features tested before making cilium down
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested before making cilium down"
+          json-filename: "${{ env.job_name }} (${{ matrix.name }}) - before making cilium down"
+
+      - name: Make Cilium down
+        shell: bash
+        run: |
+          cilium upgrade \
+            --chart-directory=./untrusted/cilium-newest/install/kubernetes/cilium \
+            --helm-set=debug.enabled=true \
+            --set-string='image.override=quay.io/cilium/cilium:invalid-image' \
+            --set-string='extraConfig.enable-embedded-dns-proxy=false' \
+            --set='l7Proxy=true,dnsProxy.proxyPort=40046' \
+            --helm-set=standaloneDnsProxy.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/standalone-dns-proxy-ci \
+            --helm-set=standaloneDnsProxy.image.tag=${{ steps.vars.outputs.sha }} \
+            --helm-set=standaloneDnsProxy.image.useDigest=false
+
+          kubectl rollout restart -n kube-system daemonset/cilium
+          kubectl get pods --all-namespaces -o wide
+          sleep 10s
+
+      - name: Test DNS connectivity after Down
+        shell: bash
+        run: |
+          kubectl exec xwing -- curl cilium.io
+
+      - name: Fetch artifacts
+        if: ${{ !success() }}
+        shell: bash
+        run: |
+          kubectl get pods --all-namespaces -o wide
+          cilium status
+          mkdir -p cilium-sysdumps
+          cilium sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
+
+      - name: Upload artifacts
+        if: ${{ !success() }}
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: cilium-sysdumps-${{ matrix.name }}
+          path: cilium-sysdump-*.zip
+
+      - name: Upload JUnits [junit]
+        if: ${{ always() }}
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: cilium-junits-${{ matrix.name }}
+          path: cilium-junits/*.xml
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: features-tested-${{ matrix.name }}
+          path: ${{ env.job_name }}*.json
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
+
+  merge-upload:
+    if: ${{ always() }}
+    name: Merge and Upload Artifacts
+    runs-on: ubuntu-24.04
+    needs: setup-and-test
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+      - name: Merge Sysdumps
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: cilium-sysdumps
+          pattern: cilium-sysdumps-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge JUnits
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: cilium-junits
+          pattern: cilium-junits-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge Features tested
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: features-tested
+          pattern: features-tested-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  commit-status-final:
+    if: ${{ always() }}
+    name: Commit Status Final
+    needs: setup-and-test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set final commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+          status: ${{ needs.setup-and-test.result }}

--- a/.github/workflows/tests-standalone-dns-proxy.yaml
+++ b/.github/workflows/tests-standalone-dns-proxy.yaml
@@ -238,8 +238,8 @@ jobs:
             --set-string='image.override=quay.io/cilium/cilium:invalid-image' \
             --set-string='extraConfig.enable-embedded-dns-proxy=false' \
             --set='l7Proxy=true,dnsProxy.proxyPort=40046' \
-            --helm-set=standaloneDnsProxy.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/standalone-dns-proxy-ci \
-            --helm-set=standaloneDnsProxy.image.tag=${{ steps.vars.outputs.sha }} \
+            --helm-set=standaloneDnsProxy.image.repository=quay.io/singhvipul/standalone-dns-proxy \
+            --helm-set=standaloneDnsProxy.image.tag=latest \
             --helm-set=standaloneDnsProxy.image.useDigest=false
 
           kubectl rollout restart -n kube-system daemonset/cilium

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -638,6 +638,7 @@ Makefile* @cilium/build
 /SECURITY.md @cilium/contributing
 /SECURITY-INSIGHTS.yml @cilium/security
 /stable.txt @cilium/release-managers
+/standalone-dns-proxy/ @cilium/proxy @cilium/fqdn
 /test/ @cilium/ci-structure
 /test/Makefile* @cilium/ci-structure @cilium/build
 # Service handling tests

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -176,6 +176,7 @@ cilium-agent [flags]
       --enable-route-mtu-for-cni-chaining                         Enable route MTU for pod netns when CNI chaining is used
       --enable-sctp                                               Enable SCTP support (beta)
       --enable-service-topology                                   Enable support for service topology aware hints
+      --enable-standalone-dns-proxy                               Enables standalone DNS proxy.
       --enable-svc-source-range-check                             Enable check of service source ranges (currently, only for LoadBalancer) (default true)
       --enable-tcx                                                Attach endpoint programs using tcx if supported by the kernel (default true)
       --enable-tracing                                            Enable tracing while determining policy (debugging)
@@ -385,6 +386,7 @@ cilium-agent [flags]
       --tofqdns-pre-cache string                                  DNS cache data at this path is preloaded on agent startup
       --tofqdns-proxy-port int                                    Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
       --tofqdns-proxy-response-max-delay duration                 The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
+      --tofqdns-server-port int                                   Global port on which the gRPC server for standalone DNS proxy should listen. (default 40045)
       --trace-payloadlen int                                      Length of payload to capture when tracing (default 128)
       --trace-sock                                                Enable tracing for socket-based LB (default true)
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3352,6 +3352,62 @@
      - Enable socket LB
      - bool
      - ``false``
+   * - :spelling:ignore:`standaloneDnsProxy`
+     - Standalone DNS Proxy Configuration
+     - object
+     - ``{"annotations":{},"automountServiceAccountToken":false,"debug":false,"dnsCompression":true,"enabled":false,"image":{"digest":"","override":null,"pullPolicy":"Always","repository":"","tag":"","useDigest":false},"l7Proxy":true,"nodeSelector":{"kubernetes.io/os":"linux"},"proxyPort":40046,"rollOutPods":false,"serverPort":40045,"tolerations":[],"updateStrategy":{"rollingUpdate":{"maxSurge":2,"maxUnavailable":0},"type":"RollingUpdate"}}``
+   * - :spelling:ignore:`standaloneDnsProxy.annotations`
+     - Standalone DNS proxy annotations
+     - object
+     - ``{}``
+   * - :spelling:ignore:`standaloneDnsProxy.automountServiceAccountToken`
+     - Standalone DNS proxy auto mount service account token
+     - bool
+     - ``false``
+   * - :spelling:ignore:`standaloneDnsProxy.debug`
+     - Standalone DNS proxy debug mode
+     - bool
+     - ``false``
+   * - :spelling:ignore:`standaloneDnsProxy.dnsCompression`
+     - Standalone DNS proxy DNS compression
+     - bool
+     - ``true``
+   * - :spelling:ignore:`standaloneDnsProxy.enabled`
+     - Enable standalone DNS proxy
+     - bool
+     - ``false``
+   * - :spelling:ignore:`standaloneDnsProxy.image`
+     - Standalone DNS proxy image
+     - object
+     - ``{"digest":"","override":null,"pullPolicy":"Always","repository":"","tag":"","useDigest":false}``
+   * - :spelling:ignore:`standaloneDnsProxy.l7Proxy`
+     - L7 proxy mode enables proxy for DNS traffic
+     - bool
+     - ``true``
+   * - :spelling:ignore:`standaloneDnsProxy.nodeSelector`
+     - Standalone DNS proxy Node Selector
+     - object
+     - ``{"kubernetes.io/os":"linux"}``
+   * - :spelling:ignore:`standaloneDnsProxy.proxyPort`
+     - Standalone DNS proxy port
+     - int
+     - ``40046``
+   * - :spelling:ignore:`standaloneDnsProxy.rollOutPods`
+     - Roll out Standalone Dns proxy automatically when configmap is updated.
+     - bool
+     - ``false``
+   * - :spelling:ignore:`standaloneDnsProxy.serverPort`
+     - Standalone DNS proxy server port
+     - int
+     - ``40045``
+   * - :spelling:ignore:`standaloneDnsProxy.tolerations`
+     - Standalone DNS proxy tolerations
+     - list
+     - ``[]``
+   * - :spelling:ignore:`standaloneDnsProxy.updateStrategy`
+     - Standalone DNS proxy update strategy
+     - object
+     - ``{"rollingUpdate":{"maxSurge":2,"maxUnavailable":0},"type":"RollingUpdate"}``
    * - :spelling:ignore:`startupProbe.failureThreshold`
      - failure threshold of startup probe. Allow Cilium to take up to 600s to start up (300 attempts with 2s between attempts).
      - int

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ include Makefile.defs
 SUBDIRS_CILIUM_CONTAINER := cilium-dbg daemon cilium-health bugtool tools/mount tools/sysctlfix plugins/cilium-cni
 SUBDIR_OPERATOR_CONTAINER := operator
 SUBDIR_RELAY_CONTAINER := hubble-relay
+SUBDIR_STANDALONE_DNS_PROXY_CONTAINER := standalone-dns-proxy
 
 ifdef LIBNETWORK_PLUGIN
 SUBDIRS_CILIUM_CONTAINER += plugins/cilium-docker
@@ -76,6 +77,9 @@ build-container-operator-alibabacloud: ## Builds components required for a ciliu
 
 build-container-hubble-relay:
 	$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR_RELAY_CONTAINER) all
+
+build-container-standalone-dns-proxy: ## Builds components required for standalone dns proxy container.
+	$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR_STANDALONE_DNS_PROXY_CONTAINER) standalone-dns-proxy
 
 $(SUBDIRS): force ## Execute default make target(make all) for the provided subdirectory.
 	@ $(MAKE) $(SUBMAKEOPTS) -C $@ all
@@ -214,6 +218,10 @@ install-container-binary-operator-alibabacloud: ## Install binaries for all comp
 install-container-binary-hubble-relay:
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR_RELAY_CONTAINER) install-binary
+
+install-container-binary-standalone-dns-proxy: ## Install binaries for all components required for standalone-dns-proxy container.
+	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
+	$(MAKE) $(SUBMAKEOPTS) -C standalone-dns-proxy install
 
 # Workaround for not having git in the build environment
 # Touch the file only if needed
@@ -513,6 +521,7 @@ help: ## Display help for the Makefile, from https://www.thapaliya.com/en/writin
 	$(call print_help_line,"docker-operator-*-image","Build platform specific cilium-operator images(alibabacloud, aws, azure, generic)")
 	$(call print_help_line,"docker-operator-*-image-debug","Build platform specific cilium-operator debug images(alibabacloud, aws, azure, generic)")
 	$(call print_help_line,"docker-*-image-unstripped","Build unstripped version of above docker images(cilium, hubble-relay, operator etc.)")
+	$(call print_help_line,"docker-standalone-dns-proxy-image","Build standalone DNS proxy docker image")
 
 .PHONY: help clean clean-container dev-doctor force generate-api generate-health-api generate-operator-api generate-kvstoremesh-api generate-hubble-api generate-sdp-api install licenses-all veryclean run_bpf_tests run-builder
 force :;

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -134,6 +134,9 @@ $(eval $(call DOCKER_IMAGE_TEMPLATE,docker-hubble-relay-image,images/hubble-rela
 # docker-clustermesh-apiserver-image
 $(eval $(call DOCKER_IMAGE_TEMPLATE,docker-clustermesh-apiserver-image,images/clustermesh-apiserver/Dockerfile,clustermesh-apiserver,$(DOCKER_IMAGE_TAG),release))
 
+# docker-standalone-dns-proxy-image
+$(eval $(call DOCKER_IMAGE_TEMPLATE, docker-standalone-dns-proxy-image,images/standalone-dns-proxy/Dockerfile,standalone-dns-proxy,$(DOCKER_IMAGE_TAG),release))
+
 # docker-operator-images.
 # We eat the ending of "operator" in to the stem ('%') to allow this pattern
 # to build also 'docker-operator-image', where the stem would be empty otherwise.
@@ -144,9 +147,9 @@ $(eval $(call DOCKER_IMAGE_TEMPLATE,dev-docker-opera%-image-debug,images/operato
 #
 # docker-*-all targets are mainly used from the CI
 #
-docker-images-all: docker-cilium-image docker-plugin-image docker-hubble-relay-image docker-clustermesh-apiserver-image docker-operator-images-all ## Build all Cilium related docker images.
+docker-images-all: docker-cilium-image docker-plugin-image docker-hubble-relay-image docker-clustermesh-apiserver-image docker-operator-images-all docker-standalone-dns-proxy-image ## Build all Cilium related docker images.
 
-docker-images-all-unstripped: docker-cilium-image-unstripped docker-plugin-image-unstripped docker-hubble-relay-image-unstripped docker-clustermesh-apiserver-image-unstripped docker-operator-images-all-unstripped ## Build all Cilium related unstripped docker images.
+docker-images-all-unstripped: docker-cilium-image-unstripped docker-plugin-image-unstripped docker-hubble-relay-image-unstripped docker-clustermesh-apiserver-image-unstripped docker-operator-images-all-unstripped docker-standalone-dns-proxy-image-unstripped ## Build all Cilium related unstripped docker images.
 
 docker-operator-images-all: docker-operator-image docker-operator-aws-image docker-operator-azure-image docker-operator-alibabacloud-image docker-operator-generic-image ## Build all variants of cilium-operator images.
 

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -33,6 +33,9 @@ var (
 	//go:embed manifests/client-egress-to-fqdns.yaml
 	clientEgressToFQDNsPolicyYAML string
 
+	//go:embed manifests/client-egress-standalone-dns-proxy.yaml
+	clientEgressStandaloneDNSProxyYAML string
+
 	//go:embed manifests/echo-ingress-from-other-client.yaml
 	echoIngressFromOtherClientPolicyYAML string
 
@@ -217,6 +220,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		allEntitiesDeny{},
 		clusterEntity{},
 		clusterEntityMultiCluster{},
+		checkStandaloneDnsProxy{},
 		hostEntityEgress{},
 		hostEntityIngress{},
 		echoIngress{},
@@ -321,6 +325,7 @@ func renderTemplates(clusterName string, param check.Parameters) (map[string]str
 		"clientEgressL7HTTPExternalYAML":                     clientEgressL7HTTPExternalYAML,
 		"clientEgressNodeLocalDNSYAML":                       clientEgressNodeLocalDNSYAML,
 		"clientEgressOnlyDNSPolicyYAML":                      clientEgressOnlyDNSPolicyYAML,
+		"clientEgressStandaloneDNSProxyYAML":                 clientEgressStandaloneDNSProxyYAML,
 		"echoIngressFromCIDRYAML":                            echoIngressFromCIDRYAML,
 		"denyCIDRPolicyYAML":                                 denyCIDRPolicyYAML,
 	}

--- a/cilium-cli/connectivity/builder/check_standalone_dns_proxy.go
+++ b/cilium-cli/connectivity/builder/check_standalone_dns_proxy.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type checkStandaloneDnsProxy struct{}
+
+func (t checkStandaloneDnsProxy) build(ct *check.ConnectivityTest, templates map[string]string) {
+	newTest("check-standalone-dns-proxy", ct).
+		WithCiliumPolicy(templates["clientEgressStandaloneDNSProxyYAML"]).
+		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy), features.RequireDisabled(features.EmbeddedDNSProxy), features.RequireEnabled(features.StandaloneDNSProxy)). // Flags for standalone DNS proxy
+		WithScenarios(
+			tests.StandaloneDNSProxy(),
+		)
+}

--- a/cilium-cli/connectivity/builder/manifests/client-egress-standalone-dns-proxy.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-standalone-dns-proxy.yaml
@@ -1,0 +1,48 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-standalone-dns-proxy
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+      rules:
+        dns:
+        - matchPattern: "{{.ExternalTarget}}"
+    toEndpoints:
+      - matchExpressions:
+          - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
+          - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
+          - { key: 'io.cilium.k8s.policy.cluster', operator: In, values: [ "{{.ClusterName}}" ] }
+  - toPorts:
+    - ports:
+      - port: "5353"
+        protocol: UDP
+      - port: "5353"
+        protocol: TCP
+      rules:
+        dns:
+        - matchPattern: "{{.ExternalTarget}}"
+    toEndpoints:
+    - matchExpressions:
+      - { key: 'dns.operator.openshift.io/daemonset-dns', operator: Exists }
+      - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "openshift-dns" ] }
+      - { key: 'io.cilium.k8s.policy.cluster', operator: In, values: [ "{{.ClusterName}}" ] }
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+      rules:
+        dns:
+        - matchPattern: "{{.ExternalTarget}}"
+    toEntities:
+    - world

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -80,6 +80,11 @@ func (ct *ConnectivityTest) extractFeaturesFromRuntimeConfig(ctx context.Context
 		Enabled: isFeatureKNPEnabled,
 	}
 
+	// Embedded DNS proxy is enabled by default, so we only need to set it if it's disabled
+	result[features.EmbeddedDNSProxy] = features.Status{
+		Enabled: cfg.EnableEmbeddedDNSProxy,
+	}
+
 	return nil
 }
 

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -50,7 +50,8 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 	errorLogExceptions := []logMatcher{
 		stringMatcher("Error in delegate stream, restarting"),
 		failedToUpdateLock, failedToReleaseLock,
-		failedToListCRDs, removeInexistentID, knownIssueWireguardCollision, nilDetailsForService}
+		failedToListCRDs, removeInexistentID, knownIssueWireguardCollision, nilDetailsForService,
+		standaloneDNSProxyConnError}
 	if ciliumVersion.LT(semver.MustParse("1.14.0")) {
 		errorLogExceptions = append(errorLogExceptions, previouslyUsedCIDR, klogLeaderElectionFail)
 	}
@@ -330,43 +331,43 @@ const (
 	klogLeaderElectionFail stringMatcher = "error retrieving resource lock kube-system/cilium-operator-resource-lock:" // from: https://github.com/cilium/cilium/issues/31050
 	nilDetailsForService   stringMatcher = "retrieved nil details for Service"                                         // from: https://github.com/cilium/cilium/issues/35595
 
-	cantEnableJIT               stringMatcher = "bpf_jit_enable: no such file or directory"                              // Because we run tests in Kind.
-	delMissingService           stringMatcher = "Deleting no longer present service"                                     // cf. https://github.com/cilium/cilium/issues/29679
-	podCIDRUnavailable          stringMatcher = " PodCIDR not available"                                                 // cf. https://github.com/cilium/cilium/issues/29680
-	unableGetNode               stringMatcher = "Unable to get node resource"                                            // cf. https://github.com/cilium/cilium/issues/29710
-	sessionAffinitySocketLB     stringMatcher = "Session affinity for host reachable services needs kernel"              // cf. https://github.com/cilium/cilium/issues/29736
-	objectHasBeenModified       stringMatcher = "the object has been modified; please apply your changes"                // cf. https://github.com/cilium/cilium/issues/29712
-	noBackendResponse           stringMatcher = "The kernel does not support --service-no-backend-response=reject"       // cf. https://github.com/cilium/cilium/issues/29733
-	legacyBGPFeature            stringMatcher = "You are using the legacy BGP feature"                                   // Expected when testing the legacy BGP feature.
-	etcdTimeout                 stringMatcher = "etcd client timeout exceeded"                                           // cf. https://github.com/cilium/cilium/issues/29714
-	endpointRestoreFailed       stringMatcher = "Unable to restore endpoint, ignoring"                                   // cf. https://github.com/cilium/cilium/issues/29716
-	unableRestoreRouterIP       stringMatcher = "Unable to restore router IP from filesystem"                            // cf. https://github.com/cilium/cilium/issues/29715
-	routerIPReallocated         stringMatcher = "Router IP could not be re-allocated"                                    // cf. https://github.com/cilium/cilium/issues/29715
-	cantFindIdentityInCache     stringMatcher = "unable to release identity: unable to find key in local cache"          // cf. https://github.com/cilium/cilium/issues/29732
-	keyAllocFailedFoundMaster   stringMatcher = "Found master key after proceeding with new allocation"                  // cf. https://github.com/cilium/cilium/issues/29738
-	cantRecreateMasterKey       stringMatcher = "unable to re-create missing master key"                                 // cf. https://github.com/cilium/cilium/issues/29738
-	cantUpdateCRDIdentity       stringMatcher = "Unable update CRD identity information with a reference for this node"  // cf. https://github.com/cilium/cilium/issues/29739
-	cantDeleteFromPolicyMap     stringMatcher = "cilium_call_policy: delete: key does not exist"                         // cf. https://github.com/cilium/cilium/issues/29754
-	hubbleQueueFull             stringMatcher = "hubble events queue is full"                                            // Because we run without monitor aggregation
-	reflectPanic                stringMatcher = "reflect.Value.SetUint using value obtained using unexported field"      // cf. https://github.com/cilium/cilium/issues/33766
-	svcNotFound                 stringMatcher = "service not found"                                                      // cf. https://github.com/cilium/cilium/issues/35768
-	unableTranslateCIDRgroups   stringMatcher = "Unable to translate all CIDR groups to CIDRs"                           // Can be removed once v1.17 is released.
-	gobgpWarnings               stringMatcher = "component=gobgp.BgpServerInstance"                                      // cf. https://github.com/cilium/cilium/issues/35799
-	etcdReconnection            stringMatcher = "Error observed on etcd connection, reconnecting etcd"                   // cf. https://github.com/cilium/cilium/issues/35865
-	epRestoreMissingState       stringMatcher = "Couldn't find state, ignoring endpoint"                                 // cf. https://github.com/cilium/cilium/issues/35869
-	mutationDetectorKlog        stringMatcher = "Mutation detector is enabled, this will result in memory leakage."      // cf. https://github.com/cilium/cilium/issues/35929
-	hubbleFailedCreatePeer      stringMatcher = "Failed to create peer client for peers synchronization"                 // cf. https://github.com/cilium/cilium/issues/35930
-	fqdnDpUpdatesTimeout        stringMatcher = "Timed out waiting for datapath updates of FQDN IP information"          // cf. https://github.com/cilium/cilium/issues/35931
-	longNetpolUpdate            stringMatcher = "onConfigUpdate(): Worker threads took longer than"                      // cf. https://github.com/cilium/cilium/issues/36067
-	failedToGetEpLabels         stringMatcher = "Failed to get identity labels for endpoint"                             // cf. https://github.com/cilium/cilium/issues/36068
-	failedCreategRPCClient      stringMatcher = "Failed to create gRPC client"                                           // cf. https://github.com/cilium/cilium/issues/36070
-	unableReallocateIngressIP   stringMatcher = "unable to re-allocate ingress IPv6"                                     // cf. https://github.com/cilium/cilium/issues/36072
-	fqdnMaxIPPerHostname        stringMatcher = "Raise tofqdns-endpoint-max-ip-per-hostname to mitigate this"            // cf. https://github.com/cilium/cilium/issues/36073
-	failedGetMetricsAPI         stringMatcher = "retrieve the complete list of server APIs: metrics.k8s.io/v1beta1"      // cf. https://github.com/cilium/cilium/issues/36085
-	ciliumNodeConfigDeprecation stringMatcher = "cilium.io/v2alpha1 CiliumNodeConfig will be deprecated in cilium v1.16" // cf. https://github.com/cilium/cilium/issues/37249
-	hubbleUIEnvVarFallback      stringMatcher = "using fallback value for env var"                                       // cf. https://github.com/cilium/hubble-ui/pull/940
-	k8sClientNetworkStatusError stringMatcher = "Network status error received, restarting client connections"           // cf. https://github.com/cilium/cilium/issues/37712
-
+	cantEnableJIT               stringMatcher = "bpf_jit_enable: no such file or directory"                                  // Because we run tests in Kind.
+	delMissingService           stringMatcher = "Deleting no longer present service"                                         // cf. https://github.com/cilium/cilium/issues/29679
+	podCIDRUnavailable          stringMatcher = " PodCIDR not available"                                                     // cf. https://github.com/cilium/cilium/issues/29680
+	unableGetNode               stringMatcher = "Unable to get node resource"                                                // cf. https://github.com/cilium/cilium/issues/29710
+	sessionAffinitySocketLB     stringMatcher = "Session affinity for host reachable services needs kernel"                  // cf. https://github.com/cilium/cilium/issues/29736
+	objectHasBeenModified       stringMatcher = "the object has been modified; please apply your changes"                    // cf. https://github.com/cilium/cilium/issues/29712
+	noBackendResponse           stringMatcher = "The kernel does not support --service-no-backend-response=reject"           // cf. https://github.com/cilium/cilium/issues/29733
+	legacyBGPFeature            stringMatcher = "You are using the legacy BGP feature"                                       // Expected when testing the legacy BGP feature.
+	etcdTimeout                 stringMatcher = "etcd client timeout exceeded"                                               // cf. https://github.com/cilium/cilium/issues/29714
+	endpointRestoreFailed       stringMatcher = "Unable to restore endpoint, ignoring"                                       // cf. https://github.com/cilium/cilium/issues/29716
+	unableRestoreRouterIP       stringMatcher = "Unable to restore router IP from filesystem"                                // cf. https://github.com/cilium/cilium/issues/29715
+	routerIPReallocated         stringMatcher = "Router IP could not be re-allocated"                                        // cf. https://github.com/cilium/cilium/issues/29715
+	cantFindIdentityInCache     stringMatcher = "unable to release identity: unable to find key in local cache"              // cf. https://github.com/cilium/cilium/issues/29732
+	keyAllocFailedFoundMaster   stringMatcher = "Found master key after proceeding with new allocation"                      // cf. https://github.com/cilium/cilium/issues/29738
+	cantRecreateMasterKey       stringMatcher = "unable to re-create missing master key"                                     // cf. https://github.com/cilium/cilium/issues/29738
+	cantUpdateCRDIdentity       stringMatcher = "Unable update CRD identity information with a reference for this node"      // cf. https://github.com/cilium/cilium/issues/29739
+	cantDeleteFromPolicyMap     stringMatcher = "cilium_call_policy: delete: key does not exist"                             // cf. https://github.com/cilium/cilium/issues/29754
+	hubbleQueueFull             stringMatcher = "hubble events queue is full"                                                // Because we run without monitor aggregation
+	reflectPanic                stringMatcher = "reflect.Value.SetUint using value obtained using unexported field"          // cf. https://github.com/cilium/cilium/issues/33766
+	svcNotFound                 stringMatcher = "service not found"                                                          // cf. https://github.com/cilium/cilium/issues/35768
+	unableTranslateCIDRgroups   stringMatcher = "Unable to translate all CIDR groups to CIDRs"                               // Can be removed once v1.17 is released.
+	gobgpWarnings               stringMatcher = "component=gobgp.BgpServerInstance"                                          // cf. https://github.com/cilium/cilium/issues/35799
+	etcdReconnection            stringMatcher = "Error observed on etcd connection, reconnecting etcd"                       // cf. https://github.com/cilium/cilium/issues/35865
+	epRestoreMissingState       stringMatcher = "Couldn't find state, ignoring endpoint"                                     // cf. https://github.com/cilium/cilium/issues/35869
+	mutationDetectorKlog        stringMatcher = "Mutation detector is enabled, this will result in memory leakage."          // cf. https://github.com/cilium/cilium/issues/35929
+	hubbleFailedCreatePeer      stringMatcher = "Failed to create peer client for peers synchronization"                     // cf. https://github.com/cilium/cilium/issues/35930
+	fqdnDpUpdatesTimeout        stringMatcher = "Timed out waiting for datapath updates of FQDN IP information"              // cf. https://github.com/cilium/cilium/issues/35931
+	longNetpolUpdate            stringMatcher = "onConfigUpdate(): Worker threads took longer than"                          // cf. https://github.com/cilium/cilium/issues/36067
+	failedToGetEpLabels         stringMatcher = "Failed to get identity labels for endpoint"                                 // cf. https://github.com/cilium/cilium/issues/36068
+	failedCreategRPCClient      stringMatcher = "Failed to create gRPC client"                                               // cf. https://github.com/cilium/cilium/issues/36070
+	unableReallocateIngressIP   stringMatcher = "unable to re-allocate ingress IPv6"                                         // cf. https://github.com/cilium/cilium/issues/36072
+	fqdnMaxIPPerHostname        stringMatcher = "Raise tofqdns-endpoint-max-ip-per-hostname to mitigate this"                // cf. https://github.com/cilium/cilium/issues/36073
+	failedGetMetricsAPI         stringMatcher = "retrieve the complete list of server APIs: metrics.k8s.io/v1beta1"          // cf. https://github.com/cilium/cilium/issues/36085
+	ciliumNodeConfigDeprecation stringMatcher = "cilium.io/v2alpha1 CiliumNodeConfig will be deprecated in cilium v1.16"     // cf. https://github.com/cilium/cilium/issues/37249
+	hubbleUIEnvVarFallback      stringMatcher = "using fallback value for env var"                                           // cf. https://github.com/cilium/hubble-ui/pull/940
+	k8sClientNetworkStatusError stringMatcher = "Network status error received, restarting client connections"               // cf. https://github.com/cilium/cilium/issues/37712
+	standaloneDNSProxyConnError stringMatcher = "Error while dialing: dial tcp 127.0.0.1:40045: connect: connection refused" // Expected when as standalone DNS proxy can come up before cilium agent
 	// Logs messages that should not be in the cilium-envoy DS logs
 	envoyErrorMessage    = "[error]"
 	envoyCriticalMessage = "[critical]"

--- a/cilium-cli/connectivity/tests/standalone-dns-proxy.go
+++ b/cilium-cli/connectivity/tests/standalone-dns-proxy.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tests
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+func StandaloneDNSProxy() check.Scenario {
+
+	return &standaloneDNSProxy{}
+}
+
+type standaloneDNSProxy struct {
+	check.ScenarioBase
+}
+
+func (s *standaloneDNSProxy) Name() string {
+	return "standalone-dns-proxy"
+}
+
+func (s *standaloneDNSProxy) Run(ctx context.Context, t *check.Test) {
+	extTarget := t.Context().Params().ExternalTarget
+	http := check.HTTPEndpoint(extTarget+"-http", "http://"+extTarget)
+
+	ct := t.Context()
+
+	for _, client := range ct.ClientPods() {
+		t.NewAction(s, fmt.Sprintf("nsLookUp-%s", extTarget), &client, http, features.IPFamilyV4).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, ct.NSLookupCommandService(http, features.IPFamilyV4))
+		})
+	}
+}

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -119,6 +119,9 @@ const (
 	NodeLocalDNS Feature = "node-local-dns"
 
 	Multicast Feature = "multicast-enabled"
+
+	StandaloneDNSProxy Feature = "enable-standalone-dns-proxy"
+	EmbeddedDNSProxy   Feature = "enable-embedded-dns-proxy"
 )
 
 // Feature is the name of a Cilium Feature (e.g. l7-proxy, cni chaining mode etc)
@@ -404,6 +407,10 @@ func (fs Set) ExtractFromConfigMap(cm *v1.ConfigMap) {
 
 	fs[PolicySecretSync] = Status{
 		Enabled: cm.Data[string(PolicySecretSync)] == "true",
+	}
+
+	fs[StandaloneDNSProxy] = Status{
+		Enabled: cm.Data[string(StandaloneDNSProxy)] == "true",
 	}
 }
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -801,8 +801,18 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Int(option.ToFQDNsMinTTL, defaults.ToFQDNsMinTTL, "The minimum time, in seconds, to use DNS data for toFQDNs policies")
 	option.BindEnv(vp, option.ToFQDNsMinTTL)
 
+	flags.Bool(option.EnableStandaloneDNSProxy, false, "Enables standalone DNS proxy.")
+	option.BindEnv(vp, option.EnableStandaloneDNSProxy)
+
+	flags.Bool(option.EnableEmbeddedDNSProxy, true, "Enables embedded DNS proxy.")
+	flags.MarkHidden(option.EnableEmbeddedDNSProxy)
+	option.BindEnv(vp, option.EnableEmbeddedDNSProxy)
+
 	flags.Int(option.ToFQDNsProxyPort, 0, "Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.")
 	option.BindEnv(vp, option.ToFQDNsProxyPort)
+
+	flags.Int(option.ToFQDNsServerPort, 40045, "Global port on which the gRPC server for standalone DNS proxy should listen.")
+	option.BindEnv(vp, option.ToFQDNsServerPort)
 
 	flags.String(option.FQDNRejectResponseCode, option.FQDNProxyDenyWithRefused, fmt.Sprintf("DNS response code for rejecting DNS requests, available options are '%v'", option.FQDNRejectOptions))
 	option.BindEnv(vp, option.FQDNRejectResponseCode)

--- a/images/standalone-dns-proxy/.dockerignore
+++ b/images/standalone-dns-proxy/.dockerignore
@@ -1,0 +1,17 @@
+@@ -0,0 +1,16 @@
+*
+
+# must-have toplevel files
+!/Makefile*
+!/go.sum
+!/go.mod
+!/VERSION
+
+# directories
+!/.git
+!/api
+!/daemon
+!/standalone-dns-proxy
+!/pkg
+!/tools
+!/vendor

--- a/images/standalone-dns-proxy/Dockerfile
+++ b/images/standalone-dns-proxy/Dockerfile
@@ -1,0 +1,32 @@
+ARG BASE_IMAGE=scratch
+ARG GOLANG_IMAGE=docker.io/library/golang:1.24.0@sha256:3f7444391c51a11a039bf0359ee81cc64e663c17d787ad0e637a4de1a3f62a71
+
+# BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
+# Represents the plataform where the build is happening, do not mix with
+# TARGETARCH
+FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} AS builder
+
+# TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETOS
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETARCH
+ARG NOSTRIP
+ARG NOOPT
+ARG LOCKDEBUG
+ARG RACE
+
+WORKDIR /go/src/github.com/cilium/cilium
+
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
+    --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/go/pkg \
+    make GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} \
+    DESTDIR=/out/${TARGETOS}/${TARGETARCH} build-container-standalone-dns-proxy install-container-binary-standalone-dns-proxy
+
+FROM ${BASE_IMAGE} AS release
+# TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETOS
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETARCH
+COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/standalone-dns-proxy /usr/bin/standalone-dns-proxy
+ENTRYPOINT [ "/usr/bin/standalone-dns-proxy" ]

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -888,6 +888,20 @@ contributors across the globe, there is almost always someone available to help.
 | sleepAfterInit | bool | `false` | Do not run Cilium agent when running with clean mode. Useful to completely uninstall Cilium as it will stop Cilium from starting and create artifacts in the node. |
 | socketLB | object | `{"enabled":false}` | Configure socket LB |
 | socketLB.enabled | bool | `false` | Enable socket LB |
+| standaloneDnsProxy | object | `{"annotations":{},"automountServiceAccountToken":false,"debug":false,"dnsCompression":true,"enabled":false,"image":{"digest":"","override":null,"pullPolicy":"Always","repository":"","tag":"","useDigest":false},"l7Proxy":true,"nodeSelector":{"kubernetes.io/os":"linux"},"proxyPort":40046,"rollOutPods":false,"serverPort":40045,"tolerations":[],"updateStrategy":{"rollingUpdate":{"maxSurge":2,"maxUnavailable":0},"type":"RollingUpdate"}}` | Standalone DNS Proxy Configuration |
+| standaloneDnsProxy.annotations | object | `{}` | Standalone DNS proxy annotations |
+| standaloneDnsProxy.automountServiceAccountToken | bool | `false` | Standalone DNS proxy auto mount service account token |
+| standaloneDnsProxy.debug | bool | `false` | Standalone DNS proxy debug mode |
+| standaloneDnsProxy.dnsCompression | bool | `true` | Standalone DNS proxy DNS compression |
+| standaloneDnsProxy.enabled | bool | `false` | Enable standalone DNS proxy |
+| standaloneDnsProxy.image | object | `{"digest":"","override":null,"pullPolicy":"Always","repository":"","tag":"","useDigest":false}` | Standalone DNS proxy image |
+| standaloneDnsProxy.l7Proxy | bool | `true` | L7 proxy mode enables proxy for DNS traffic  |
+| standaloneDnsProxy.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Standalone DNS proxy Node Selector |
+| standaloneDnsProxy.proxyPort | int | `40046` | Standalone DNS proxy port |
+| standaloneDnsProxy.rollOutPods | bool | `false` | Roll out Standalone Dns proxy automatically when configmap is updated. |
+| standaloneDnsProxy.serverPort | int | `40045` | Standalone DNS proxy server port |
+| standaloneDnsProxy.tolerations | list | `[]` | Standalone DNS proxy tolerations |
+| standaloneDnsProxy.updateStrategy | object | `{"rollingUpdate":{"maxSurge":2,"maxUnavailable":0},"type":"RollingUpdate"}` | Standalone DNS proxy update strategy |
 | startupProbe.failureThreshold | int | `300` | failure threshold of startup probe. Allow Cilium to take up to 600s to start up (300 attempts with 2s between attempts). |
 | startupProbe.periodSeconds | int | `2` | interval between checks of the startup probe |
 | svcSourceRangeCheck | bool | `true` | Enable check of service source ranges (currently, only for LoadBalancer). |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1324,6 +1324,12 @@ data:
   {{- end }}
 {{- end }}
 
+{{- if hasKey .Values "standaloneDnsProxy" }}
+  {{- if .Values.standaloneDnsProxy.enabled }}
+  enable-standalone-dns-proxy: {{ .Values.standaloneDnsProxy.enabled | quote }}
+  {{- end }}
+{{- end }}
+
 {{- if hasKey .Values "agentNotReadyTaintKey" }}
   agent-not-ready-taint-key: {{ .Values.agentNotReadyTaintKey | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/standalone-dns-proxy/configmap.yaml
+++ b/install/kubernetes/cilium/templates/standalone-dns-proxy/configmap.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.standaloneDnsProxy.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: standalone-dns-proxy-config
+  namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.standaloneDnsProxy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  enable-l7-proxy: {{ .Values.standaloneDnsProxy.l7Proxy | quote }}
+  debug: {{ .Values.standaloneDnsProxy.debug | quote }}
+  enable-standalone-dns-proxy: {{ .Values.standaloneDnsProxy.enabled | quote }}
+  enable-ipv4: {{ .Values.ipv4.enabled | quote }}
+  enable-ipv6: {{ .Values.ipv6.enabled | quote }}
+  tofqdns-proxy-port: {{ .Values.standaloneDnsProxy.proxyPort | quote }}
+  tofqdns-server-port: {{ .Values.standaloneDnsProxy.serverPort | quote }}
+  tofqdns-enable-dns-compression: {{ .Values.standaloneDnsProxy.dnsCompression | quote }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/standalone-dns-proxy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/standalone-dns-proxy/daemonset.yaml
@@ -1,0 +1,91 @@
+{{- if .Values.standaloneDnsProxy.enabled }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: standalone-dns-proxy
+  namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.standaloneDnsProxy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    k8s-app: standalone-dns-proxy
+    app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/name: standalone-dns-proxy
+    name: standalone-dns-proxy
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  minReadySeconds: 5
+  {{- with .Values.standaloneDnsProxy.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      k8s-app: standalone-dns-proxy
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.standaloneDnsProxy.rollOutPods }}
+        # ensure pods roll when configmap updates
+        cilium.io/standalone-dns-proxy-configmap-checksum: {{ include (print $.Template.BasePath "/standalone-dns-proxy/configmap.yaml") . | sha256sum | quote }}
+        {{- end }}
+        container.apparmor.security.beta.kubernetes.io/standalone-dns-proxy: "unconfined"
+      labels:
+        k8s-app: standalone-dns-proxy
+        name: standalone-dns-proxy
+        app.kubernetes.io/name: standalone-dns-proxy
+        app.kubernetes.io/part-of: cilium
+        {{- with .Values.commonLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      hostNetwork: true
+      automountServiceAccountToken: {{ .Values.standaloneDnsProxy.automountServiceAccountToken }}
+      {{- with .Values.standaloneDnsProxy.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      tolerations:
+      - operator: Exists
+      {{- with .Values.standaloneDnsProxy.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: standalone-dns-proxy
+          image: {{ include "cilium.image" .Values.standaloneDnsProxy.image | quote }}
+          args:
+          - --config-dir=/tmp/standalone-dns-proxy/config-map
+          imagePullPolicy: {{ .Values.standaloneDnsProxy.image.pullPolicy }}
+          livenessProbe:
+            tcpSocket:
+              host: {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }}
+              port: {{ .Values.standaloneDnsProxy.proxyPort }}
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              host: {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }}
+              port: {{ .Values.standaloneDnsProxy.proxyPort }}
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 3
+            timeoutSeconds: 5
+          volumeMounts:
+          - mountPath: /tmp/standalone-dns-proxy/config-map
+            name: standalone-dns-proxy-config-path
+            readOnly: true
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN", "NET_RAW"]
+              drop: ["ALL"]
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: standalone-dns-proxy-config
+        name: standalone-dns-proxy-config-path
+{{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -5497,6 +5497,95 @@
       },
       "type": "object"
     },
+    "standaloneDnsProxy": {
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean"
+        },
+        "debug": {
+          "type": "boolean"
+        },
+        "dnsCompression": {
+          "type": "boolean"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "properties": {
+            "digest": {
+              "type": "string"
+            },
+            "override": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "pullPolicy": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "useDigest": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "l7Proxy": {
+          "type": "boolean"
+        },
+        "nodeSelector": {
+          "properties": {
+            "kubernetes.io/os": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "proxyPort": {
+          "type": "integer"
+        },
+        "rollOutPods": {
+          "type": "boolean"
+        },
+        "serverPort": {
+          "type": "integer"
+        },
+        "tolerations": {
+          "items": {},
+          "type": "array"
+        },
+        "updateStrategy": {
+          "properties": {
+            "rollingUpdate": {
+              "properties": {
+                "maxSurge": {
+                  "type": "integer"
+                },
+                "maxUnavailable": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
     "startupProbe": {
       "properties": {
         "failureThreshold": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3922,3 +3922,45 @@ authentication:
 enableInternalTrafficPolicy: true
 # -- Enable LoadBalancer IP Address Management
 enableLBIPAM: true
+# -- Standalone DNS Proxy Configuration
+standaloneDnsProxy:
+  # -- Enable standalone DNS proxy
+  enabled: false
+  # -- Roll out Standalone Dns proxy automatically when configmap is updated.
+  rollOutPods: false
+  # -- L7 proxy mode enables proxy for DNS traffic 
+  l7Proxy: true
+  # -- Standalone DNS proxy annotations
+  annotations: {}
+  # -- Standalone DNS proxy debug mode
+  debug: false
+  # -- Standalone DNS proxy port
+  proxyPort: 40046
+  # -- Standalone DNS proxy server port
+  serverPort: 40045
+  # -- Standalone DNS proxy DNS compression
+  dnsCompression: true
+  # -- Standalone DNS proxy Node Selector
+  nodeSelector:
+    kubernetes.io/os: linux
+  # -- Standalone DNS proxy tolerations
+  tolerations: []
+  # -- Standalone DNS proxy auto mount service account token
+  automountServiceAccountToken: false
+  # -- Standalone DNS proxy update strategy
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 0
+  # -- Standalone DNS proxy image
+  image:
+    # @schema
+    # type: [null, string]
+    # @schema
+    override: ~
+    repository: ""
+    tag: ""
+    digest: ""
+    useDigest: false
+    pullPolicy: "Always"

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3951,4 +3951,46 @@ authentication:
 enableInternalTrafficPolicy: true
 # -- Enable LoadBalancer IP Address Management
 enableLBIPAM: true
+# -- Standalone DNS Proxy Configuration
+standaloneDnsProxy:
+  # -- Enable standalone DNS proxy
+  enabled: false
+  # -- Roll out Standalone Dns proxy automatically when configmap is updated.
+  rollOutPods: false
+  # -- L7 proxy mode enables proxy for DNS traffic 
+  l7Proxy: true
+  # -- Standalone DNS proxy annotations
+  annotations: {}
+  # -- Standalone DNS proxy debug mode
+  debug: false
+  # -- Standalone DNS proxy port
+  proxyPort: 40046
+  # -- Standalone DNS proxy server port
+  serverPort: 40045
+  # -- Standalone DNS proxy DNS compression
+  dnsCompression: true
+  # -- Standalone DNS proxy Node Selector
+  nodeSelector:
+    kubernetes.io/os: linux
+  # -- Standalone DNS proxy tolerations
+  tolerations: []
+  # -- Standalone DNS proxy auto mount service account token
+  automountServiceAccountToken: false
+  # -- Standalone DNS proxy update strategy
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 0
+  # -- Standalone DNS proxy image
+  image:
+    # @schema
+    # type: [null, string]
+    # @schema
+    override: ~
+    repository: "${STANDALONE_DNS_PROXY_REPO}"
+    tag: "${STANDALONE_DNS_PROXY_VERSION}"
+    digest: "${STANDALONE_DNS_PROXY_DIGEST}"
+    useDigest: ${USE_DIGESTS}
+    pullPolicy: "${PULL_POLICY}"
 

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/revert"
@@ -17,6 +18,7 @@ import (
 type EndpointProxy interface {
 	CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, epID uint16, wg *completion.WaitGroup) (proxyPort uint16, err error, revertFunc revert.RevertFunc)
 	RemoveRedirect(id string)
+	UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy)
 	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
 	UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
 	RemoveNetworkPolicy(ep endpoint.EndpointInfoSource)
@@ -63,3 +65,6 @@ func (f *FakeEndpointProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, pol
 
 // RemoveNetworkPolicy does nothing.
 func (f *FakeEndpointProxy) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {}
+
+func (f *FakeEndpointProxy) UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy) {
+}

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -122,6 +122,10 @@ func (r *RedirectSuiteProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, po
 // RemoveNetworkPolicy does nothing.
 func (r *RedirectSuiteProxy) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {}
 
+// UpdateSDP does nothing.
+func (r *RedirectSuiteProxy) UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy) {
+}
+
 // DummyIdentityAllocatorOwner implements
 // pkg/identity/cache/IdentityAllocatorOwner. It is used for unit testing.
 type DummyIdentityAllocatorOwner struct{}

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -644,6 +644,10 @@ func (mgr *endpointManager) GetPolicyEndpoints() map[policy.Endpoint]struct{} {
 	return eps
 }
 
+func (mgr *endpointManager) ExposeTestEndpoint(ep *endpoint.Endpoint) error {
+	return mgr.expose(ep)
+}
+
 func (mgr *endpointManager) expose(ep *endpoint.Endpoint) error {
 	newID, err := mgr.allocateID(ep.ID)
 	if err != nil {

--- a/pkg/fqdn/service/service.go
+++ b/pkg/fqdn/service/service.go
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/netip"
+
+	"github.com/cilium/dns"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/container/versioned"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/time"
+
+	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
+)
+
+type updateOnDNSMsgFunc func(lookupTime time.Time, ep *endpoint.Endpoint, qname string, responseIPs []netip.Addr, TTL int, stat *dnsproxy.ProxyRequestContext) error
+
+type FQDNDataServer struct {
+	pb.UnimplementedFQDNDataServer
+
+	ctx             context.Context
+	closeServer     func()
+	endpointManager endpointmanager.EndpointManager
+
+	// streams is a map of the active streams and their cancel functions
+	// Streams are added when a client(standalone dns proxy) subscribes to DNS policies and removed when the client closes the connection
+	streams lock.Map[pb.FQDNData_StreamPolicyStateServer, context.CancelFunc]
+
+	// updateOnDNSMsg is a function to update the DNS message in the cilium agent on receiving the FQDN mapping
+	updateOnDNSMsg updateOnDNSMsgFunc
+
+	// dnsMappingResult is a map of the dns request id and bool value for success/failure
+	dnsMappingResult lock.Map[string, bool]
+
+	// snapshotMutex is a mutex to protect the current state of the DNS rules
+	snapshotMutex lock.Mutex
+
+	// currentSnapshot is the current state of the DNS rules
+	currentSnapshot map[identity.NumericIdentity]policy.SelectorPolicy
+
+	// identityToIpMutex is a mutex to protect the current state of the identity to Ip mapping
+	identityToIpMutex lock.Mutex
+
+	// currentIdentityToIp is a map of the identity to list of Ips
+	currentIdentityToIp map[identity.NumericIdentity][]net.IP
+
+	// log is the logger for the FQDNDataServer
+	log *slog.Logger
+}
+
+var (
+	kaep = keepalive.EnforcementPolicy{
+		PermitWithoutStream: true, // Allow pings even when there are no active streams
+	}
+	kasp = keepalive.ServerParameters{
+		Time:    5 * time.Second, // Ping the client if it is idle for 5 seconds to ensure the connection is still active
+		Timeout: 1 * time.Second, // Wait 1 second for the ping ack before assuming the connection is dead
+	}
+)
+
+// StreamPolicyState is a bidirectional streaming RPC to subscribe to DNS policies
+// SDP calls this method to subscribe to DNS policies
+// For each stream, we start a goroutine to receive the DNS policies ACKs
+// The flow of the method is as follows:
+// 1. Add the stream to the map( called by the client i.e SDP)
+// 2. Start a goroutine to receive the DNS policies ACKs for that particular client.
+// 3. Send the current state of the DNS rules to the client (We store the current state fo DNS rules during the endpoint regeneration see UpdatePolicyRulesLocked)
+// 4. Wait for the context to be done
+func (s *FQDNDataServer) StreamPolicyState(stream pb.FQDNData_StreamPolicyStateServer) error {
+	streamCtx, cancel := context.WithCancel(stream.Context())
+	s.streams.Store(stream, cancel)
+
+	// Start a goroutine to receive the DNS policies ACKs
+	go func() {
+		if err := s.receiveDNSPolicyACKs(stream); err != nil {
+			s.log.Error("Error receiving DNS policies ACK: ", logfields.Error, err)
+			cancel() // Cancel the context to close the stream
+		}
+	}()
+
+	//Send the current state of the DNS rules
+	go func() {
+		s.log.Debug("Sending current state of DNS rules")
+
+		// Send the current state of the DNS rules
+		if err := s.UpdatePolicyRulesLocked(nil, false); err != nil {
+			s.log.Error("Error sending current state of DNS rules: ", logfields.Error, err)
+			cancel() // Cancel the context to close the stream
+		}
+	}()
+
+	s.log.Debug("StreamPolicyState waiting for context to be done")
+	<-streamCtx.Done()
+	err := streamCtx.Err()
+	s.log.Error("StreamPolicyState context done: ", logfields.Error, err)
+	s.DeleteStream(stream)
+	return err
+}
+
+// receiveDNSPolicyACKs receives the DNS policies ACKs from the client
+// If the success is false, we can send cancel signal to the channel
+// in that case SDP will recreate the stream.
+func (s *FQDNDataServer) receiveDNSPolicyACKs(stream pb.FQDNData_StreamPolicyStateServer) error {
+	for {
+		select {
+		case <-stream.Context().Done():
+			s.log.Info("Stream context is finished, closing the stream")
+			return stream.Context().Err()
+		default:
+			// Continue receiving the DNS policies ACKs
+		}
+		update, err := stream.Recv()
+		if err != nil {
+			s.log.Error("Error receiving DNS policies ACK: ", logfields.Error, err)
+			return err
+		}
+		s.log.Debug("Received DNS policies ACK: ", logfields.Response, update)
+		requestId := update.GetRequestId()
+		_, ok := s.dnsMappingResult.Load(requestId)
+		if !ok {
+			s.log.Error("Received Message id not found: ", logfields.ID, requestId)
+		} else {
+			s.log.Debug("Received response for dns message id: ", logfields.ID, requestId)
+
+			// We can send cancel signal to the channel if the response code is not NO_ERROR,
+			// in that case SDP will recreate the stream.
+			responseCode := update.GetResponse()
+			if responseCode != pb.ResponseCode_RESPONSE_CODE_NO_ERROR {
+				s.log.Error("Received error response for dns message id: ", logfields.ID, requestId)
+				cancel, ok := s.streams.Load(stream)
+				if ok {
+					cancel()
+				}
+			}
+		}
+		// Delete the request from the map
+		s.dnsMappingResult.Delete(requestId)
+		s.log.Debug("Deleted request id from the map: ", logfields.ID, requestId)
+
+	}
+}
+
+// NewServer creates a new FQDNDataServer which is used to handle the Standalone DNS Proxy grpc service
+func NewServer(endpointManager endpointmanager.EndpointManager, updateOnDNSMsg updateOnDNSMsgFunc, logger *slog.Logger) *FQDNDataServer {
+	ctx := context.Background()
+
+	s := &FQDNDataServer{
+		endpointManager:     endpointManager,
+		updateOnDNSMsg:      updateOnDNSMsg,
+		ctx:                 ctx,
+		streams:             lock.Map[pb.FQDNData_StreamPolicyStateServer, context.CancelFunc]{},
+		currentSnapshot:     make(map[identity.NumericIdentity]policy.SelectorPolicy),
+		currentIdentityToIp: make(map[identity.NumericIdentity][]net.IP),
+		log:                 logger.With(logfields.LogSubsys, "fqdn/server"),
+	}
+
+	go func() {
+		<-s.ctx.Done()
+		s.log.Info("FQDN service context done, cleaning up resources")
+		if s.ctx.Err() != nil {
+			s.log.Error("FQDN service context error: ", logfields.Error, s.ctx.Err())
+		}
+		// Cleanup the streams
+		s.cleanupStreams()
+		s.closeServer()
+	}()
+
+	return s
+}
+
+func convertToBytes(ips []net.IP) [][]byte {
+	var byteIps [][]byte
+	for _, ip := range ips {
+		byteIps = append(byteIps, ip)
+	}
+	return byteIps
+}
+
+// convertEndpointInfo converts the endpoint info to the format required by the standalone dns proxy
+func (s *FQDNDataServer) convertEndpointInfo(ips []net.IP) []*pb.EndpointInfo {
+	var endpointInfo = make(map[uint64][]net.IP)
+	for _, ip := range ips {
+		var epId uint64
+		ep := s.endpointManager.LookupIP(netip.MustParseAddr(ip.String()))
+		if ep == nil {
+			// If the endpoint is not found, log a warning
+			// This can happen for the endpoints that are not managed by this cilium agent
+			s.log.Warn("Endpoint not found for IP: ", logfields.IPAddr, ip)
+		} else {
+			epId = ep.GetID()
+		}
+		endpointInfo[epId] = append(endpointInfo[epId], ip)
+	}
+
+	var convertedEndpointInfo []*pb.EndpointInfo
+	for epId, ips := range endpointInfo {
+		convertedEndpointInfo = append(convertedEndpointInfo, &pb.EndpointInfo{
+			Id: epId,
+			Ip: convertToBytes(ips),
+		})
+	}
+
+	return convertedEndpointInfo
+}
+
+// OnIPIdentityCacheChange is a method to receive the IP identity cache change events
+func (s *FQDNDataServer) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidr types.PrefixCluster, oldHostIP, newHostIP net.IP, oldID *ipcache.Identity, newID ipcache.Identity, encryptKey uint8, k8sMeta *ipcache.K8sMetadata, endpointFlags uint8) {
+	s.identityToIpMutex.Lock()
+	switch modType {
+	case ipcache.Upsert:
+		ip := cidr.AsIPNet().IP
+		s.currentIdentityToIp[newID.ID] = append(s.currentIdentityToIp[newID.ID], ip)
+	case ipcache.Delete:
+		if oldID != nil {
+			delete(s.currentIdentityToIp, oldID.ID)
+		}
+	}
+	s.identityToIpMutex.Unlock()
+	err := s.UpdatePolicyRulesLocked(nil, false)
+	if err != nil {
+		s.log.Error("Error updating policy rules: ", logfields.Error, err)
+	}
+}
+
+// UpdatePolicyRulesLocked updates the current state of the DNS rules with the given policies and sends the current state of the DNS rules to the client
+// This method is called:
+// 1. when the DNS rules are updated during the endpoint regeneration, we store the state of the DNS rules with flag rulesUpdate as true
+// 2. when the client subscribes to DNS policies, we send the current state of the DNS rules to the client(flag rulesUpdate as false)
+// 3. when the IP identity cache changes, we update the current state of the identity to IP mapping and send the current state of the DNS rules to
+// the client(flag rulesUpdate as false)
+func (s *FQDNDataServer) UpdatePolicyRulesLocked(policies map[identity.NumericIdentity]policy.SelectorPolicy, rulesUpdate bool) error {
+	s.snapshotMutex.Lock()
+	defer s.snapshotMutex.Unlock()
+
+	// We only update the rules if the rules are updated during the endpoint regeneration
+	if rulesUpdate {
+		s.currentSnapshot = policies
+	}
+
+	egressL7DnsPolicy := make([]*pb.DNSPolicy, 0, len(s.currentSnapshot))
+	identityToEndpointMapping := make([]*pb.IdentityToEndpointMapping, 0, len(s.currentSnapshot))
+	for identity, pol := range s.currentSnapshot {
+		for l4, polSelTuple := range pol.RedirectFilters() {
+			switch polSelTuple.Policy.L7Parser {
+			case policy.ParserTypeDNS:
+				selectorPolicy := polSelTuple.Policy
+				cacheSelector := polSelTuple.Selector
+
+				// Acquire the lock to read the current state of the identity to IP mapping
+				s.identityToIpMutex.Lock()
+				var dnsServersIdentity []uint32
+				var dnsServers []*pb.DNSServer
+				if cacheSelector != nil {
+					for _, sel := range cacheSelector.GetSelections(versioned.Latest()) {
+						dnsServersIdentity = append(dnsServersIdentity, sel.Uint32())
+						identityToEndpointMapping = append(identityToEndpointMapping, &pb.IdentityToEndpointMapping{
+							Identity:     sel.Uint32(),
+							EndpointInfo: s.convertEndpointInfo(s.currentIdentityToIp[sel]),
+						})
+					}
+					dnsServers = make([]*pb.DNSServer, 0, len(cacheSelector.GetSelections(versioned.Latest())))
+					for _, dnsServerIdentity := range dnsServersIdentity {
+						dnsServers = append(dnsServers, &pb.DNSServer{
+							DnsServerIdentity: dnsServerIdentity,
+							DnsServerPort:     uint32(l4.GetPort()),
+							DnsServerProto:    uint32(l4.U8Proto),
+						})
+					}
+				} else {
+					dnsServers = make([]*pb.DNSServer, 0, 1)
+					dnsServers = append(dnsServers, &pb.DNSServer{
+						DnsServerPort:  uint32(l4.GetPort()),
+						DnsServerProto: uint32(l4.U8Proto),
+					})
+				}
+				var dnsPattern []string
+				if selectorPolicy != nil && selectorPolicy.DNS != nil {
+					dnsPattern = make([]string, 0, len(selectorPolicy.DNS))
+					for _, dns := range selectorPolicy.DNS {
+						if dns.MatchPattern != "" {
+							dnsPattern = append(dnsPattern, dns.MatchPattern)
+						}
+						if dns.MatchName != "" {
+							dnsPattern = append(dnsPattern, dns.MatchName)
+						}
+					}
+				}
+				epIPs := s.currentIdentityToIp[identity]
+				for _, epIP := range epIPs {
+					ep := s.endpointManager.LookupIP(netip.MustParseAddr(epIP.String()))
+					if ep == nil {
+						// If the endpoint is not found, log a warning
+						// This can happen for the endpoints that are not managed by this cilium agent
+						s.log.Debug("Endpoint not found for IP: ", logfields.IPAddr, epIP)
+						continue
+					}
+					egressL7DnsPolicy = append(egressL7DnsPolicy, &pb.DNSPolicy{
+						SourceEndpointId: uint32(ep.GetID()),
+						DnsServers:       dnsServers,
+						DnsPattern:       dnsPattern,
+					})
+				}
+
+				identityToEndpointMapping = append(identityToEndpointMapping, &pb.IdentityToEndpointMapping{
+					Identity:     identity.Uint32(),
+					EndpointInfo: s.convertEndpointInfo(s.currentIdentityToIp[identity]),
+				})
+				s.identityToIpMutex.Unlock()
+			}
+		}
+	}
+
+	requestId := uuid.New().String()
+	s.log.Debug("Current EgressL7DnsPolicy: ",
+		logfields.Rule, egressL7DnsPolicy,
+		logfields.ID, requestId)
+	dnsPolices := &pb.PolicyState{
+		IdentityToEndpointMapping: identityToEndpointMapping,
+		RequestId:                 requestId,
+		EgressL7DnsPolicy:         egressL7DnsPolicy,
+	}
+
+	s.streams.Range(func(stream pb.FQDNData_StreamPolicyStateServer, cancel context.CancelFunc) bool {
+		s.log.Debug("Sending DNS policies to client: ", logfields.ID, requestId)
+		s.dnsMappingResult.Store(requestId, false)
+		if err := stream.Send(dnsPolices); err != nil {
+			s.log.Error("Error sending DNS policies to client: ", logfields.Error, err)
+			// Cancel the goroutine and remove the stream from the map
+			cancel()
+		}
+		return true
+	})
+	return nil
+}
+
+// DeleteStream deletes the stream from the map
+func (s *FQDNDataServer) DeleteStream(stream pb.FQDNData_StreamPolicyStateServer) {
+	_, ok := s.streams.Load(stream)
+	if ok {
+		s.log.Info("Deleting stream: ", logfields.ID, stream)
+		s.streams.Delete(stream)
+	} else {
+		s.log.Warn("Stream not found: ", logfields.ID, stream)
+	}
+
+}
+
+// cleanupStreams handles the cleanup of streams when the server's context is cancelled.
+func (s *FQDNDataServer) cleanupStreams() {
+	s.streams.Range(func(key pb.FQDNData_StreamPolicyStateServer, cancelFunc context.CancelFunc) bool {
+		cancelFunc() // Ensure we cancel the context of each stream
+		s.streams.Delete(key)
+		return true
+	})
+	s.log.Info("All streams have been cleaned up")
+}
+
+// UpdateMappingRequest updates the FQDN mapping with the given data
+// SDP sends the fqdn mapping to cilium agent
+// Steps to update the mapping:
+// 1. Get the endpoint from the IP
+// 2. If the endpoint is not found, return an error
+// 3. If the IPs are not empty, update the cilium agent with the mapping
+func (s *FQDNDataServer) UpdateMappingRequest(ctx context.Context, mappings *pb.FQDNMapping) (*pb.UpdateMappingResponse, error) {
+	now := time.Now()
+	var ips []netip.Addr
+
+	endpointAddr := netip.MustParseAddr(string(mappings.SourceIp))
+
+	ep := s.endpointManager.LookupIP(endpointAddr)
+	if ep == nil {
+		s.log.Error("Endpoint not found for IP: ", logfields.IPAddr, endpointAddr)
+		return &pb.UpdateMappingResponse{}, fmt.Errorf("endpoint not found for IP: %s", mappings.SourceIp)
+	}
+
+	recordIps := mappings.GetRecordIp()
+	if len(recordIps) == 0 {
+		// We don't have any IPs to update the mappings with
+		return &pb.UpdateMappingResponse{
+			Response: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
+		}, nil
+	}
+
+	for _, ip := range recordIps {
+		ips = append(ips, netip.MustParseAddr(string(ip)))
+	}
+
+	if mappings.GetResponseCode() == dns.RcodeSuccess {
+		err := s.updateOnDNSMsg(now, ep, mappings.GetFqdn(), ips, int(mappings.GetTtl()), nil)
+		if err != nil {
+			return &pb.UpdateMappingResponse{}, fmt.Errorf("cannot update DNS cache: %w", err)
+		}
+	}
+
+	return &pb.UpdateMappingResponse{
+		Response: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
+	}, nil
+}
+
+// RunServer starts the Standalone DNS Proxy grpc server on the given port
+func RunServer(port int, server *FQDNDataServer) error {
+	address := fmt.Sprintf("localhost:%d", port)
+	server.log.Info("Starting Standalone DNS Proxy server on: ", logfields.Address, address)
+	lis, err := net.Listen("tcp", address)
+	if err != nil {
+		server.log.Error("Failed to listen: ", logfields.Error, err)
+		return err
+	}
+	grpcServer := grpc.NewServer(grpc.KeepaliveEnforcementPolicy(kaep), grpc.KeepaliveParams(kasp))
+	pb.RegisterFQDNDataServer(grpcServer, server)
+
+	closer := func() {
+		grpcServer.GracefulStop()
+	}
+	server.closeServer = closer
+
+	if err := grpcServer.Serve(lis); err != nil {
+		server.log.Error("Failed to serve: ", logfields.Error, err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/fqdn/service/service_test.go
+++ b/pkg/fqdn/service/service_test.go
@@ -1,0 +1,559 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"log/slog"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/testutils"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
+	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
+	"github.com/cilium/cilium/pkg/time"
+
+	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
+)
+
+const (
+	dnsServerIdentity = identity.NumericIdentity(2)
+	endpointIdentity  = identity.NumericIdentity(1)
+)
+
+type dummyEpSyncher struct{}
+
+func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, h cell.Health) {
+}
+
+func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
+}
+
+type Dummy struct {
+	repo policy.PolicyRepository
+}
+
+func (s *Dummy) GetPolicyRepository() policy.PolicyRepository {
+	return s.repo
+}
+
+func (s *Dummy) GetProxyPort(string) (uint16, error) {
+	return 0, nil
+}
+
+func (s *Dummy) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), error) {
+	return nil, nil
+}
+
+func (s *Dummy) GetCompilationLock() types.CompilationLock {
+	return nil
+}
+
+func (s *Dummy) GetCIDRPrefixLengths() (s6, s4 []int) {
+	return nil, nil
+}
+
+func (s *Dummy) SendNotification(msg monitorAPI.AgentNotifyMessage) error {
+	return nil
+}
+
+func (s *Dummy) Loader() types.Loader {
+	return nil
+}
+
+func (s *Dummy) Orchestrator() types.Orchestrator {
+	return nil
+}
+
+func (s *Dummy) BandwidthManager() types.BandwidthManager {
+	return nil
+}
+
+func (s *Dummy) IPTablesManager() types.IptablesManager {
+	return nil
+}
+
+func (s *Dummy) GetDNSRules(epID uint16) restore.DNSRules {
+	return nil
+}
+
+func (s *Dummy) RemoveRestoredDNSRules(epID uint16) {}
+
+func (s *Dummy) AddIdentity(id *identity.Identity) {}
+
+func (s *Dummy) RemoveIdentity(id *identity.Identity) {}
+
+func (s *Dummy) RemoveOldAddNewIdentity(old, new *identity.Identity) {}
+
+func server(ctx context.Context, t *testing.T) (*FQDNDataServer, pb.FQDNDataClient, func()) {
+	buffer := 1024
+	lis := bufconn.Listen(buffer)
+
+	baseServer := grpc.NewServer()
+	endptMgr := endpointmanager.New(&dummyEpSyncher{}, nil, nil)
+	repo := policy.NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, api.NewPolicyMetricsNoop())
+	do := &Dummy{
+		repo: repo,
+	}
+	// Add a test endpoint
+	ep := endpoint.NewTestEndpointWithState(do, nil, do, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), 1, endpoint.StateReady)
+	ep.IPv4 = netip.MustParseAddr("1.1.1.1")
+	err := endptMgr.ExposeTestEndpoint(ep)
+	if err != nil {
+		panic(err)
+	}
+
+	server := NewServer(endptMgr,
+		func(lookupTime time.Time, ep *endpoint.Endpoint, qname string, responseIPs []netip.Addr, TTL int, stat *dnsproxy.ProxyRequestContext) error {
+			// Mocking the response for the test
+			if qname == "example.com" {
+				return nil
+			}
+			return errors.New("Failed to update fqdn mapping")
+		},
+		logging.DefaultSlogLogger,
+	)
+	// Add the identity to ip mapping
+	server.currentIdentityToIp = map[identity.NumericIdentity][]net.IP{
+		endpointIdentity:  {net.ParseIP("1.1.1.1")},
+		dnsServerIdentity: {net.ParseIP("1.1.1.0")},
+	}
+
+	pb.RegisterFQDNDataServer(baseServer, server)
+	go func() {
+		if err := baseServer.Serve(lis); err != nil {
+			server.log.Error("Failed to serve bufnet listener", logfields.Error, err)
+		}
+	}()
+
+	conn, err := grpc.NewClient("passthrough://bufnet", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	if err != nil {
+		server.log.Error("Failed to dial bufnet", logfields.Error, err)
+	}
+	closer := func() {
+		server.ctx.Done()
+
+		err := lis.Close()
+		if err != nil {
+			server.log.Error("Failed to close bufnet listener", logfields.Error, err)
+		}
+		baseServer.Stop()
+	}
+
+	client := pb.NewFQDNDataClient(conn)
+
+	return server, client, closer
+}
+
+func TestUpdateMappingRequest(t *testing.T) {
+	ctx := context.Background()
+
+	_, client, closer := server(ctx, t)
+	defer closer()
+
+	type expected struct {
+		out *pb.UpdateMappingResponse
+		err error
+	}
+
+	responseIps := []string{
+		"2.2.2.2",
+	}
+	var ips [][]byte
+	for _, i := range responseIps {
+		ips = append(ips, []byte(i))
+	}
+
+	tests := map[string]struct {
+		in       *pb.FQDNMapping
+		expected expected
+	}{
+		"Success on updating the fqdn ips": {
+			in: &pb.FQDNMapping{
+				Fqdn:           "example.com",
+				RecordIp:       ips,
+				Ttl:            60,
+				SourceIdentity: 1,
+				SourceIp:       []byte("1.1.1.1"),
+				ResponseCode:   0,
+			},
+			expected: expected{
+				out: &pb.UpdateMappingResponse{
+					Response: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
+				},
+				err: nil,
+			},
+		},
+		"Failure due to update of fqdn ips": {
+			in: &pb.FQDNMapping{
+				Fqdn:           "failure.com",
+				RecordIp:       ips,
+				Ttl:            60,
+				SourceIdentity: 1,
+				SourceIp:       []byte("1.1.1.1"),
+				ResponseCode:   0,
+			},
+			expected: expected{
+				out: &pb.UpdateMappingResponse{},
+				err: errors.New("rpc error: code = Unknown desc = cannot update DNS cache: Failed to update fqdn mapping"),
+			},
+		},
+		"Success on response code non zero": {
+			in: &pb.FQDNMapping{
+				Fqdn:           "example.com",
+				RecordIp:       ips,
+				Ttl:            60,
+				SourceIdentity: 1,
+				SourceIp:       []byte("1.1.1.1"),
+				ResponseCode:   1,
+			},
+			expected: expected{
+				out: &pb.UpdateMappingResponse{
+					Response: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
+				},
+				err: nil,
+			},
+		},
+		"Failure due to endpoint not found": {
+			in: &pb.FQDNMapping{
+				Fqdn:           "example.com",
+				RecordIp:       ips,
+				Ttl:            60,
+				SourceIdentity: 1,
+				SourceIp:       []byte("1.1.1.0"),
+				ResponseCode:   0,
+			},
+			expected: expected{
+				out: &pb.UpdateMappingResponse{},
+				err: errors.New("rpc error: code = Unknown desc = endpoint not found for IP: 1.1.1.0"),
+			},
+		},
+		"Success if length of response ips is 0": {
+			in: &pb.FQDNMapping{
+				Fqdn:           "example.com",
+				RecordIp:       [][]byte{},
+				Ttl:            60,
+				SourceIdentity: 1,
+				SourceIp:       []byte("1.1.1.1"),
+				ResponseCode:   0,
+			},
+			expected: expected{
+				out: &pb.UpdateMappingResponse{
+					Response: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
+				},
+				err: nil,
+			},
+		},
+	}
+
+	for scenario, tt := range tests {
+		t.Run(scenario, func(t *testing.T) {
+			out, err := client.UpdateMappingRequest(ctx, tt.in)
+			require.Equal(t, tt.expected.out.GetResponse(), out.GetResponse())
+			if err != nil {
+				require.Equal(t, tt.expected.err.Error(), err.Error())
+			} else {
+				require.Equal(t, tt.expected.err, err)
+			}
+		})
+	}
+}
+
+type dummySelectorPolicy struct{}
+
+func (sp *dummySelectorPolicy) DistillPolicy(logger *slog.Logger, owner policy.PolicyOwner, redirects map[string]uint16) *policy.EndpointPolicy {
+	return nil
+}
+
+func (sp *dummySelectorPolicy) RedirectFilters() iter.Seq2[*policy.L4Filter, policy.PerSelectorPolicyTuple] {
+	sc := policy.NewSelectorCache(
+		logging.DefaultSlogLogger,
+		identity.IdentityMap{
+			dnsServerIdentity: labels.LabelArray{
+				labels.Label{
+					Key:   "app",
+					Value: "test",
+				},
+			},
+		},
+	)
+	sc.SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
+	dummySelectorCacheUser := &testpolicy.DummySelectorCacheUser{}
+	endpointSelector := api.NewESFromLabels(labels.ParseSelectLabel("app=test"))
+	cachedSelector, _ := sc.AddIdentitySelector(dummySelectorCacheUser, policy.EmptyStringLabels, endpointSelector)
+	expectedPolicy := policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
+		"53/UDP": {
+			Port:     53,
+			Protocol: api.ProtoUDP,
+			U8Proto:  0x11,
+			Ingress:  false,
+			PerSelectorPolicies: policy.L7DataMap{
+				cachedSelector: &policy.PerSelectorPolicy{
+					L7Parser: policy.ParserTypeDNS,
+					L7Rules: api.L7Rules{
+						DNS: []api.PortRuleDNS{
+							{
+								MatchName:    "example.com",
+								MatchPattern: "*.cilium.io",
+							},
+						},
+					},
+				},
+			},
+		},
+		"ANY/ANY": {
+			Port:     0,
+			Protocol: api.ProtoAny,
+			U8Proto:  0x00,
+			Ingress:  false,
+		},
+	})
+
+	// return the expected policy
+	return func(yield func(*policy.L4Filter, policy.PerSelectorPolicyTuple) bool) {
+		expectedPolicy.ForEach(func(l4 *policy.L4Filter) bool {
+			for cs, perSelectorPolicy := range l4.PerSelectorPolicies {
+				return yield(l4, policy.PerSelectorPolicyTuple{
+					Policy:   perSelectorPolicy,
+					Selector: cs,
+				})
+			}
+			return true
+		})
+	}
+}
+
+func TestSuccessfullyStreamPolicyState(t *testing.T) {
+	ctx := context.Background()
+	server, client, closer := server(ctx, t)
+	defer closer()
+
+	type in struct {
+		snaptshot   map[identity.NumericIdentity]policy.SelectorPolicy
+		policyRules *pb.PolicyState
+	}
+
+	tests := map[string]struct {
+		in in
+	}{
+		"Success on sending the rules to the client": {
+			in: in{
+				snaptshot: map[identity.NumericIdentity]policy.SelectorPolicy{
+					endpointIdentity: &dummySelectorPolicy{},
+				},
+				policyRules: &pb.PolicyState{
+					EgressL7DnsPolicy: []*pb.DNSPolicy{
+						{
+							SourceEndpointId: 1,
+							DnsPattern:       []string{"*.cilium.io", "example.com"},
+							DnsServers: []*pb.DNSServer{
+								{
+									DnsServerIdentity: 2,
+									DnsServerPort:     53,
+									DnsServerProto:    17,
+								},
+							},
+						},
+					},
+					RequestId: "1",
+					IdentityToEndpointMapping: []*pb.IdentityToEndpointMapping{
+						{
+							Identity: 2,
+							EndpointInfo: []*pb.EndpointInfo{
+								{
+									Ip: [][]byte{[]byte("1.1.1.0")},
+								},
+							},
+						},
+						{
+							Identity: 1,
+							EndpointInfo: []*pb.EndpointInfo{
+								{
+									Ip: [][]byte{[]byte("1.1.1.1")},
+									Id: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"Success on sending empty rules to the client": {
+			in: in{
+				snaptshot:   map[identity.NumericIdentity]policy.SelectorPolicy{},
+				policyRules: &pb.PolicyState{},
+			},
+		},
+	}
+
+	for scenario, test := range tests {
+		t.Run(scenario, func(t *testing.T) {
+			// set the server snapshot
+			server.currentSnapshot = test.in.snaptshot
+
+			// Client subscribes to the DNS rules
+			outClient, err := client.StreamPolicyState(ctx)
+			require.NoError(t, err)
+
+			// Server sends the DNS rules
+			actualOut, err := outClient.Recv()
+			require.NoError(t, err)
+			require.Equal(t, len(test.in.policyRules.GetEgressL7DnsPolicy()), len(actualOut.GetEgressL7DnsPolicy()))
+
+			for i, expectedPolicy := range test.in.policyRules.GetEgressL7DnsPolicy() {
+				actualPolicy := actualOut.GetEgressL7DnsPolicy()[i]
+				require.Equal(t, expectedPolicy.GetSourceEndpointId(), actualPolicy.GetSourceEndpointId())
+				require.Equal(t, expectedPolicy.GetDnsPattern(), actualPolicy.GetDnsPattern())
+				require.Equal(t, len(expectedPolicy.GetDnsServers()), len(actualPolicy.GetDnsServers()))
+				for j, expectedServer := range expectedPolicy.GetDnsServers() {
+					actualServer := actualPolicy.GetDnsServers()[j]
+					require.Equal(t, expectedServer.GetDnsServerPort(), actualServer.GetDnsServerPort())
+					require.Equal(t, expectedServer.GetDnsServerProto(), actualServer.GetDnsServerProto())
+				}
+			}
+
+			for i, expectedMapping := range test.in.policyRules.GetIdentityToEndpointMapping() {
+				actualMapping := actualOut.GetIdentityToEndpointMapping()[i]
+				require.Equal(t, expectedMapping.GetIdentity(), actualMapping.GetIdentity())
+				require.Equal(t, len(expectedMapping.GetEndpointInfo()), len(actualMapping.GetEndpointInfo()))
+				for j, expectedInfo := range expectedMapping.GetEndpointInfo() {
+					actualInfo := actualMapping.GetEndpointInfo()[j]
+					for _, ip := range expectedInfo.GetIp() {
+						require.Equal(t, string(ip), net.IP(actualInfo.GetIp()[j]).String())
+					}
+					require.Equal(t, expectedInfo.GetId(), actualInfo.GetId())
+				}
+			}
+
+			err = outClient.Send(&pb.PolicyStateResponse{
+				Response:  pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
+				RequestId: actualOut.RequestId,
+			})
+			require.NoError(t, err)
+
+			_, val := server.dnsMappingResult.Load(actualOut.RequestId)
+			require.True(t, val)
+
+			// Client closes the connection
+			err = outClient.CloseSend()
+			require.NoError(t, err)
+
+			// Wait for a second before checking if the server has received the close signal
+			sleepTime := time.NewTimer(1 * time.Second)
+			<-sleepTime.C
+			// Server receives the close signal and deletes the mapping
+			_, val = server.dnsMappingResult.Load(actualOut.RequestId)
+			require.False(t, val)
+		})
+	}
+}
+
+func TestFailureToStreamPolicyState(t *testing.T) {
+	ctx := context.Background()
+	server, client, closer := server(ctx, t)
+	defer closer()
+
+	// Client subscribes to the DNS rules
+	outClient, err := client.StreamPolicyState(ctx)
+	require.NoError(t, err)
+
+	for {
+		actualOut, err := outClient.Recv()
+		if err != nil {
+			// This is expected as the server has received the success as false
+			// So the client should receive an error and reestablish the stream
+			require.Equal(t, "rpc error: code = Canceled desc = context canceled", err.Error())
+			break
+		}
+		require.NoError(t, err)
+
+		// Client sends a failure response
+		err = outClient.Send(&pb.PolicyStateResponse{
+			Response:  pb.ResponseCode_RESPONSE_CODE_SERVER_FAILURE,
+			RequestId: actualOut.RequestId,
+		})
+		require.NoError(t, err)
+
+		mapValue, _ := server.dnsMappingResult.Load(actualOut.RequestId)
+		require.False(t, mapValue)
+	}
+}
+
+func TestRunServer(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	test := map[string]struct {
+		port   int
+		server *FQDNDataServer
+		err    error
+	}{
+		"Success on running the server": {
+			port: 1234,
+			server: &FQDNDataServer{
+				log: logging.DefaultSlogLogger,
+			},
+			err: nil,
+		},
+		"Failure on running the server": {
+			port: -1,
+			server: &FQDNDataServer{
+				log: logging.DefaultSlogLogger,
+			},
+			err: errors.New("listen tcp: address -1: invalid port"),
+		},
+	}
+
+	for scenario, tt := range test {
+		t.Run(scenario, func(t *testing.T) {
+
+			go func() {
+				err := RunServer(tt.port, tt.server)
+				if err != nil {
+					require.Equal(t, tt.err.Error(), err.Error())
+					// If the error is not nil, then terminate the test
+					return
+				} else {
+					require.Equal(t, tt.err, err)
+				}
+			}()
+
+			// Give the server some time to start
+			time.Sleep(1 * time.Second)
+
+			// Try to connect to the server
+			conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", tt.port), grpc.WithTransportCredentials(insecure.NewCredentials()))
+			require.NoError(t, err)
+			defer conn.Close()
+
+		})
+	}
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3127,6 +3127,12 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 		log.Info("L7 proxy is not enabled. Disabling embedded DNS proxy has no effect")
 	}
 
+	if c.EnableStandaloneDNSProxy {
+		if !c.EnableL7Proxy {
+			log.Fatalf("Standalone DNS proxy requires L7 proxy to be enabled")
+		}
+	}
+
 	// toFQDNs options
 	c.DNSMaxIPsPerRestoredRule = vp.GetInt(DNSMaxIPsPerRestoredRule)
 	c.DNSPolicyUnloadOnShutdown = vp.GetBool(DNSPolicyUnloadOnShutdown)

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -49,6 +49,17 @@ func (cache *policyCache) lookupOrCreate(identity *identityPkg.Identity) *cached
 	return cip
 }
 
+// GetPolicySnapshot returns a snapshot of the current policy cache.
+func (cache *policyCache) GetPolicySnapshot() map[identityPkg.NumericIdentity]SelectorPolicy {
+	cache.Lock()
+	defer cache.Unlock()
+	snapshot := make(map[identityPkg.NumericIdentity]SelectorPolicy, len(cache.policies))
+	for k, v := range cache.policies {
+		snapshot[k] = v.getPolicy()
+	}
+	return snapshot
+}
+
 // delete forgets about any cached SelectorPolicy that this endpoint uses.
 //
 // Returns true if the SelectorPolicy was removed from the cache.

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -122,6 +122,8 @@ type PolicyRepository interface {
 	// calculation.
 	GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics, endpointID uint64) (SelectorPolicy, uint64, error)
 
+	// GetPolicySnapshot returns a map of all the SelectorPolicies in the repository.
+	GetPolicySnapshot() map[identity.NumericIdentity]SelectorPolicy
 	GetRevision() uint64
 	GetRulesList() *models.Policy
 	GetSelectorCache() *SelectorCache
@@ -719,4 +721,12 @@ func (p *Repository) ReplaceByLabels(rules api.Rules, searchLabelsList []labels.
 	}
 
 	return affectedIDs, p.BumpRevision(), len(oldRules)
+}
+
+// GetPolicySnapshot returns a map of all the SelectorPolicies in the repository.
+func (p *Repository) GetPolicySnapshot() map[identity.NumericIdentity]SelectorPolicy {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+
+	return p.policyCache.GetPolicySnapshot()
 }

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -25,7 +25,7 @@ import (
 type SelectorPolicy interface {
 	// CreateRedirects is used to ensure the endpoint has created all the needed redirects
 	// before a new EndpointPolicy is created.
-	RedirectFilters() iter.Seq2[*L4Filter, *PerSelectorPolicy]
+	RedirectFilters() iter.Seq2[*L4Filter, PerSelectorPolicyTuple]
 
 	// DistillPolicy returns the policy in terms of connectivity to peer
 	// Identities.
@@ -380,21 +380,26 @@ func (l4policy L4DirectionPolicy) toMapState(logger *slog.Logger, p *EndpointPol
 	})
 }
 
+type PerSelectorPolicyTuple struct {
+	Policy   *PerSelectorPolicy
+	Selector CachedSelector
+}
+
 // RedirectFilters returns an iterator for each L4Filter with a redirect in the policy.
-func (p *selectorPolicy) RedirectFilters() iter.Seq2[*L4Filter, *PerSelectorPolicy] {
-	return func(yield func(*L4Filter, *PerSelectorPolicy) bool) {
+func (p *selectorPolicy) RedirectFilters() iter.Seq2[*L4Filter, PerSelectorPolicyTuple] {
+	return func(yield func(*L4Filter, PerSelectorPolicyTuple) bool) {
 		if p.L4Policy.Ingress.forEachRedirectFilter(yield) {
 			p.L4Policy.Egress.forEachRedirectFilter(yield)
 		}
 	}
 }
 
-func (l4policy L4DirectionPolicy) forEachRedirectFilter(yield func(*L4Filter, *PerSelectorPolicy) bool) bool {
+func (l4policy L4DirectionPolicy) forEachRedirectFilter(yield func(*L4Filter, PerSelectorPolicyTuple) bool) bool {
 	ok := true
 	l4policy.PortRules.ForEach(func(l4 *L4Filter) bool {
-		for _, ps := range l4.PerSelectorPolicies {
+		for cs, ps := range l4.PerSelectorPolicies {
 			if ps != nil && ps.IsRedirect() {
-				ok = yield(l4, ps)
+				ok = yield(l4, PerSelectorPolicyTuple{ps, cs})
 			}
 		}
 		return ok

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -9,9 +9,15 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/fqdn/defaultdns"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/revert"
+)
+
+var (
+	// GlobalStandaloneDNSProxy is the global, shared, standalone DNS Proxy singleton.
+	GlobalStandaloneDNSProxy sdpPolicyUpdater
 )
 
 // dnsRedirect implements the Redirect interface for an l7 proxy
@@ -22,6 +28,10 @@ type dnsRedirect struct {
 
 func (dr *dnsRedirect) GetRedirect() *Redirect {
 	return &dr.Redirect
+}
+
+type sdpPolicyUpdater interface {
+	UpdatePolicyRulesLocked(map[identity.NumericIdentity]policy.SelectorPolicy, bool) error
 }
 
 // setRules replaces old l7 rules of a redirect with new ones.

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -163,6 +164,16 @@ func proxyTypeNotFoundError(proxyType types.ProxyType, listener string, ingress 
 		dir = "ingress"
 	}
 	return fmt.Errorf("unrecognized %s proxy type for %s: %s", dir, listener, proxyType)
+}
+
+func (p *Proxy) UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy) {
+	if GlobalStandaloneDNSProxy == nil {
+		return
+	}
+
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	GlobalStandaloneDNSProxy.UpdatePolicyRulesLocked(rules, true)
 }
 
 func (p *Proxy) createNewRedirect(

--- a/standalone-dns-proxy/.gitignore
+++ b/standalone-dns-proxy/.gitignore
@@ -1,0 +1,1 @@
+standalone-dns-proxy

--- a/standalone-dns-proxy/Makefile
+++ b/standalone-dns-proxy/Makefile
@@ -1,0 +1,20 @@
+ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+include ${ROOT_DIR}/../Makefile.defs
+
+TARGET := standalone-dns-proxy
+
+.PHONY: $(TARGET)
+
+clean:
+	@$(ECHO_CLEAN)
+	$(QUIET)rm -f $(TARGET)
+	$(GO) clean $(GOCLEAN)
+
+install:
+	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
+	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
+
+$(TARGET):
+	@$(ECHO_GO)
+	$(QUIET)$(GO_BUILD) -o $(@)

--- a/standalone-dns-proxy/cmd/flags.go
+++ b/standalone-dns-proxy/cmd/flags.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"github.com/cilium/cilium/pkg/option"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
+	flags := cmd.Flags()
+
+	flags.String(option.ConfigDir, "", `Configuration directory that contains a file for each option`)
+	option.BindEnv(vp, option.ConfigDir)
+	vp.BindPFlags(flags)
+}

--- a/standalone-dns-proxy/cmd/root.go
+++ b/standalone-dns-proxy/cmd/root.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+var (
+	DNSProxy = cell.Module(
+		"standalone-dns-proxy",
+		"Standalone DNS Proxy",
+
+		cell.Provide(func() *option.DaemonConfig { return option.Config }),
+		cell.Invoke(registerDNSProxyHooks),
+	)
+
+	binaryName = "standalone-dns-proxy"
+)
+
+type DNSProxyParamsParams struct {
+	cell.In
+
+	DaemonConfig *option.DaemonConfig
+	Lifecycle    cell.Lifecycle
+	Logger       *slog.Logger
+}
+
+func NewDNSProxyCmd(h *hive.Hive) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   binaryName,
+		Short: "Run " + binaryName,
+		Run: func(cobraCmd *cobra.Command, args []string) {
+			initEnv(h.Viper())
+
+			if err := h.Run(logging.DefaultSlogLogger); err != nil {
+				logging.Fatal(logging.DefaultSlogLogger, err.Error())
+			}
+		},
+	}
+	h.RegisterFlags(cmd.Flags())
+
+	InitGlobalFlags(cmd, h.Viper())
+	cmd.AddCommand(
+		h.Command(),
+	)
+	cobra.OnInitialize(option.InitConfig(cmd, "Standalone-DNS-Proxy", "standalone-dns-proxy", h.Viper()))
+
+	return cmd
+}
+
+func initEnv(vp *viper.Viper) {
+	option.Config.SetupLogging(vp, binaryName)
+	option.Config.Populate(vp)
+	log := logging.DefaultSlogLogger.With(logfields.LogSubsys, "standalone-dns-proxy")
+	option.LogRegisteredSlogOptions(vp, log)
+}
+
+func Execute(cmd *cobra.Command) {
+	if err := cmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func registerDNSProxyHooks(p DNSProxyParamsParams) {
+	args := &StandaloneDNSProxyArgs{
+		DNSProxyConfig: dnsproxy.DNSProxyConfig{
+			Address:                "",
+			Port:                   uint16(option.Config.ToFQDNsProxyPort),
+			IPv4:                   option.Config.EnableIPv4,
+			IPv6:                   option.Config.EnableIPv6,
+			EnableDNSCompression:   option.Config.ToFQDNsEnableDNSCompression,
+			MaxRestoreDNSIPs:       option.Config.DNSMaxIPsPerRestoredRule,
+			ConcurrencyLimit:       option.Config.DNSProxyConcurrencyLimit,
+			ConcurrencyGracePeriod: option.Config.DNSProxyConcurrencyProcessingGracePeriod,
+			DNSProxyType:           dnsproxy.StandaloneDNSProxy,
+		},
+		toFQDNsServerPort:        uint16(option.Config.ToFQDNsServerPort),
+		enableL7Proxy:            option.Config.EnableL7Proxy,
+		enableStandaloneDNsProxy: option.Config.EnableStandaloneDNSProxy,
+	}
+
+	sdp, err := NewStandaloneDNSProxy(args, p.Logger)
+	if err != nil {
+		p.Logger.Error("Failed to create Standalone DNS Proxy")
+		return
+	}
+
+	p.Lifecycle.Append(cell.Hook{
+		OnStart: func(cell.HookContext) error {
+			return sdp.StartStandaloneDNSProxy()
+		},
+		OnStop: func(cell.HookContext) error {
+			return sdp.StopStandaloneDNSProxy()
+		},
+	})
+}

--- a/standalone-dns-proxy/cmd/standalonednsproxy.go
+++ b/standalone-dns-proxy/cmd/standalonednsproxy.go
@@ -1,0 +1,614 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/netip"
+
+	ciliumdns "github.com/cilium/dns"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/status"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/revert"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/trigger"
+	"github.com/cilium/cilium/pkg/u8proto"
+
+	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
+)
+
+var kacp = keepalive.ClientParameters{
+	Time:                10 * time.Second, // send pings every 10 seconds if there is no activity
+	Timeout:             5 * time.Second,  // wait 1 second for ping ack before considering the connection dead
+	PermitWithoutStream: true,             // send pings even without active streams
+}
+
+type StandaloneDNSProxyArgs struct {
+	dnsproxy.DNSProxyConfig
+
+	toFQDNsServerPort        uint16
+	enableL7Proxy            bool
+	enableStandaloneDNsProxy bool
+}
+
+type StandaloneDNSProxy struct {
+	// DNSProxy is the standalone DNS proxy
+	DNSProxy *dnsproxy.DNSProxy
+
+	// Client is the client for the standalone DNS proxy to connect to the cilium agent
+	Client pb.FQDNDataClient
+
+	// connection stores the grpc connection to the cilium agent
+	connection *grpc.ClientConn
+
+	// ciliumAgentConnectionTrigger is the trigger to connect to the cilium agent
+	ciliumAgentConnectionTrigger *trigger.Trigger
+
+	// mu is the mutex to protect creation of multiple policy state stream in case of multiple triggers
+	mu lock.Mutex
+
+	// policyStateStream is the stream to subscribe to the policy state
+	policyStateStream pb.FQDNData_StreamPolicyStateClient
+
+	// cancelStreamPolicyStateStream is the cancel function for the PolicyState stream
+	cancelStreamPolicyStateStream context.CancelFunc
+
+	// args are the arguments for the standalone DNS proxy
+	args *StandaloneDNSProxyArgs
+
+	ipToIdentityCacheMu lock.Mutex
+	ipToIdentityCache   map[string]uint32
+
+	ipToEndpointIdCacheMu lock.Mutex
+	ipToEndpointIdCache   map[string]uint64
+
+	log *slog.Logger
+}
+
+// NewStandaloneDNSProxy creates a new standalone DNS proxy
+func NewStandaloneDNSProxy(args *StandaloneDNSProxyArgs, logger *slog.Logger) (*StandaloneDNSProxy, error) {
+	if args.toFQDNsServerPort == 0 {
+		logger.Error("toFQDNsServerPort is 0")
+		return nil, errors.New("toFQDNsServerPort is 0")
+	}
+
+	return &StandaloneDNSProxy{
+		args:                args,
+		ipToIdentityCache:   make(map[string]uint32),
+		ipToEndpointIdCache: make(map[string]uint64),
+		log:                 logger,
+	}, nil
+}
+
+func (sdp *StandaloneDNSProxy) StopStandaloneDNSProxy() error {
+	if sdp.DNSProxy != nil {
+		sdp.DNSProxy.Cleanup()
+	}
+
+	err := sdp.closeConnection()
+	if err != nil {
+		sdp.log.Error("Failed to close connection", logfields.Error, err)
+		return err
+	}
+	return nil
+}
+
+// CreateClient creates a client for the cilium agent connection
+// 1. It checks if connection is created, if not it returns an error and triggers the cilium agent connection trigger
+// 2. Else it creates the client
+// 3. If the policy state stream is not created, it creates the stream
+// Note: This function is called with a mutex lock in the caller function because there can be multiple triggers trying to
+// create the stream at the same time
+func (sdp *StandaloneDNSProxy) CreateClient(ctx context.Context) error {
+	var err error
+	defer func() {
+		if err != nil {
+			sdp.log.Error("Failed to create cilium agent connection", logfields.Error, err)
+			sdp.closeConnection()
+			sdp.ciliumAgentConnectionTrigger.TriggerWithReason("Failed to create cilium agent connection")
+		}
+	}()
+
+	if sdp.connection == nil {
+		sdp.log.Error("Connection is nil")
+		return fmt.Errorf("connection is nil")
+	}
+
+	// Create the client
+	sdp.Client = pb.NewFQDNDataClient(sdp.connection)
+
+	if sdp.policyStateStream == nil {
+		err = sdp.createStreamPolicyStateStream(ctx)
+		if err != nil {
+			sdp.log.Error("Failed to create subscription stream", logfields.Error, err)
+			return err
+		}
+	}
+	sdp.log.Debug("Successfully created client for Cilium agent")
+
+	return nil
+}
+
+// ConnectToCiliumAgent creates a connection to the cilium agent
+// It returns an error if the connection is not successful and triggers the cilium agent connection trigger
+func (sdp *StandaloneDNSProxy) ConnectToCiliumAgent() error {
+	var err error
+	defer func() {
+		if err != nil {
+			sdp.log.Error("Failed to connect to cilium agent", logfields.Error, err)
+			sdp.ciliumAgentConnectionTrigger.TriggerWithReason("Failed to connect to cilium agent")
+		}
+	}()
+
+	if sdp.connection != nil {
+		return nil
+	}
+
+	address := fmt.Sprintf("localhost:%d", sdp.args.toFQDNsServerPort)
+
+	scopedLog := sdp.log.With(
+		logfields.Address, address,
+		logfields.Port, sdp.args.toFQDNsServerPort,
+	)
+	scopedLog.Info("Connecting to server")
+	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithKeepaliveParams(kacp))
+	if err != nil {
+		scopedLog.Error("Failed to connect to server", logfields.Error, err)
+		return err
+	}
+
+	scopedLog.Info("Connected to server")
+	sdp.connection = conn
+
+	return nil // Successfully connected
+}
+
+// StartStandaloneDNSProxy starts the standalone DNS proxy and creates the cilium agent connection trigger
+// The flow is as follows:
+// 1. It starts the DNS Proxy
+// 2. It creates the cilium agent connection trigger
+// 3. It triggers the cilium agent connection trigger
+func (sdp *StandaloneDNSProxy) StartStandaloneDNSProxy() error {
+	var err error
+
+	if !sdp.args.enableL7Proxy {
+		sdp.log.Info("L7 Proxy is disabled")
+		return nil
+	}
+
+	if !sdp.args.enableStandaloneDNsProxy {
+		sdp.log.Info("Standalone DNS Proxy is disabled")
+		return nil
+	}
+
+	// Initialize the DNS Proxy
+	sdp.DNSProxy, err = dnsproxy.StartDNSProxy(sdp.args.DNSProxyConfig, sdp.LookupEPByIP, sdp.LookupSecIDByIP, sdp.LookupIPsBySecID, sdp.NotifyOnDNSMsg)
+	if err != nil {
+		sdp.log.Error("Failed to start DNS Proxy", logfields.Error, err)
+		return err
+	}
+	sdp.log.Info("DNS Proxy started on",
+		logfields.Address, sdp.args.Address,
+		logfields.Port, sdp.args.Port)
+
+	// Create the cilium agent connection trigger
+	err = sdp.createciliumAgentConnectionTrigger()
+	if err != nil {
+		sdp.log.Error("Failed to create the trigger for connecting to Cilium agent", logfields.Error, err)
+		return err
+	}
+
+	// trigger the cilium agent connection
+	sdp.ciliumAgentConnectionTrigger.TriggerWithReason("Start standalone DNS proxy")
+	return nil
+}
+
+// createciliumAgentConnectionTrigger creates a trigger to connect to the cilium agent
+// 1. It tries to connect to the cilium agent
+// 2. If the connection is successful, it tries to start the grpc streams
+// 3. If the streams are started, it tries to subscribe to the policy state as go routine
+func (sdp *StandaloneDNSProxy) createciliumAgentConnectionTrigger() error {
+	var err error
+	sdp.ciliumAgentConnectionTrigger, err = trigger.NewTrigger(trigger.Parameters{
+		Name:        "start-cilium-agent-connection",
+		MinInterval: 5 * time.Second,
+		TriggerFunc: func(reasons []string) {
+			defer func() {
+				if r := recover(); r != nil {
+					sdp.log.Error("Recovered from panic in trigger function", logfields.Error, r)
+				}
+			}()
+			sdp.log.Info("Triggering cilium agent connection", logfields.Reasons, reasons)
+			// 1. Try creating the connection to the cilium agent
+			err := sdp.ConnectToCiliumAgent()
+			if err != nil {
+				sdp.log.Error("Failed to connect to cilium agent", logfields.Error, err)
+				return
+			}
+
+			sdp.mu.Lock()
+			defer sdp.mu.Unlock()
+			// 2. Try starting the cilium agent connection
+			// only create the client if no stream is already open
+			// Imagine a scenarios where two triggers are fired at the same time
+			// and both try to create the client at the same time
+			// Due to the mutex, only one of them will create the client and start the stream
+			// The other one will just return
+			if sdp.policyStateStream == nil {
+				ctx, cancel := context.WithCancel(context.Background())
+
+				err = sdp.CreateClient(ctx)
+				if err != nil {
+					sdp.log.Error("Failed to create client", logfields.Error, err)
+					cancel()
+					return
+				}
+
+				// 3. Try to subscribe to the policy state
+				sdp.cancelStreamPolicyStateStream = cancel // Store the cancel function for later use
+				go sdp.streamPolicyState(ctx)
+			}
+		},
+	})
+	if err != nil {
+		sdp.log.Error("Failed to create trigger", logfields.Error, err)
+		return err // Return the error after logging
+	}
+	return nil
+}
+
+// Note: isHost is always false as it is not used in the current implementation
+// TODO: Remove isHost from the function signature
+func (sdp *StandaloneDNSProxy) LookupEPByIP(ip netip.Addr) (ep *endpoint.Endpoint, isHost bool, err error) {
+	sdp.ipToIdentityCacheMu.Lock()
+	defer sdp.ipToIdentityCacheMu.Unlock()
+	sdp.ipToEndpointIdCacheMu.Lock()
+	defer sdp.ipToEndpointIdCacheMu.Unlock()
+
+	sdp.log.Debug("Lookup ep by IP", logfields.IPAddr, ip.String())
+	// find the identity from the cache
+	secId, ok := sdp.ipToIdentityCache[ip.String()]
+	if !ok {
+		sdp.log.Error("Failed to get identity for IP", logfields.IPAddr, ip.String())
+		return nil, false, fmt.Errorf("failed to get identity for IP %s", ip.String())
+	}
+
+	id, ok := sdp.ipToEndpointIdCache[ip.String()]
+	if !ok {
+		sdp.log.Error("Endpoint ID not found for IP", logfields.IPAddr, ip.String())
+		return nil, false, fmt.Errorf("endpoint ID not found for IP %s", ip.String())
+	}
+
+	endpt := &endpoint.Endpoint{
+		ID: uint16(id),
+		SecurityIdentity: &identity.Identity{
+			ID: identity.NumericIdentity(secId),
+		},
+	}
+	sdp.log.Debug("Endpoint Identity found",
+		logfields.EndpointID, endpt.ID,
+		logfields.Identity, endpt.SecurityIdentity.ID,
+		logfields.IPAddr, ip.String())
+
+	return endpt, false, nil
+}
+
+// LookupIPsBySecID is used by cilium agent during the restoration of the DNS rules.
+// In case of standalone DNS proxy, it is not used as the DNS rules are restored
+// from the embedded DNS proxy.
+func (sdp *StandaloneDNSProxy) LookupIPsBySecID(nid identity.NumericIdentity) []string {
+	return nil
+}
+
+func (sdp *StandaloneDNSProxy) LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool) {
+	sdp.ipToIdentityCacheMu.Lock()
+	defer sdp.ipToIdentityCacheMu.Unlock()
+
+	sdp.log.Debug("Look up SecID by IP", logfields.IPAddr, ip.String())
+
+	id, ok := sdp.ipToIdentityCache[ip.String()]
+	if !ok {
+		sdp.log.Error("Failed to get identity for IP", logfields.IPAddr, ip.String())
+		return ipcache.Identity{}, false
+	}
+
+	sdp.log.Debug("Identity found",
+		logfields.Identity, id,
+		logfields.IPAddr, ip.String())
+	return ipcache.Identity{
+		ID:     identity.NumericIdentity(id),
+		Source: source.Local, // Local source means the identity is from the local agent
+	}, true
+}
+
+func (sdp *StandaloneDNSProxy) NotifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, serverAddr netip.AddrPort, msg *ciliumdns.Msg, protocol string, allowed bool, stat *dnsproxy.ProxyRequestContext) error {
+	qname, responseIPs, TTL, _, rcode, _, _, err := dnsproxy.ExtractMsgDetails(msg)
+	if err != nil {
+		sdp.log.Error("Cannot extract DNS message details", logfields.Error, err)
+		return err
+	}
+	scopedLog := sdp.log.With(
+		logfields.Name, qname,
+		logfields.IPAddr, epIPPort,
+		logfields.Response, rcode,
+		logfields.Protocol, protocol,
+		logfields.EndpointID, ep.ID,
+		logfields.IPAddrs, responseIPs,
+	)
+	var ips [][]byte
+	for _, i := range responseIPs {
+		ips = append(ips, []byte(i.String()))
+	}
+
+	sourceIp, _, err := net.SplitHostPort(epIPPort)
+	if err != nil {
+		scopedLog.Error("Failed to split IP:Port", logfields.Error, err)
+		return err
+	}
+
+	sourceIdentity, err := ep.GetSecurityIdentity()
+	if err != nil {
+		scopedLog.Error("Failed to get security identity", logfields.Error, err)
+		return err
+	}
+	message := &pb.FQDNMapping{
+		Fqdn:           qname,
+		RecordIp:       ips,
+		Ttl:            TTL,
+		SourceIp:       []byte(sourceIp),
+		SourceIdentity: uint32(sourceIdentity.ID),
+		ResponseCode:   uint32(rcode),
+	}
+
+	if sdp.Client == nil {
+		sdp.log.Error("Client is nil")
+		return fmt.Errorf("client is nil")
+	}
+	result, err := sdp.Client.UpdateMappingRequest(context.Background(), message)
+	scopedLog.Debug("Update mapping request response",
+		logfields.Response, result,
+		logfields.Error, err)
+	if err != nil {
+		scopedLog.Error("Failed to send FQDN Mapping message", logfields.Error, err)
+		return err
+	}
+
+	return nil
+}
+
+// streamPolicyState subscribes to the policy state
+// 1. Tries to get the stream connected
+// 2. If the stream is connected, it waits for the policy state to be received
+func (sdp *StandaloneDNSProxy) streamPolicyState(ctx context.Context) error {
+	var err error
+	defer func() {
+		if err != nil {
+			sdp.closePolicyStateStream()
+			reason := "Failed to subscribe to policy state"
+			switch status.Code(err) {
+			case codes.Unavailable:
+				sdp.closeConnection()
+				reason = "DNS server unavailable"
+			default:
+				if errors.Is(err, io.EOF) {
+					sdp.closeConnection()
+					reason = "Received EOF from policy state stream"
+					sdp.log.Error("Received EOF from policy state stream")
+				} else {
+					sdp.log.Error("Failed to subscribe to policy state", logfields.Error, err)
+				}
+			}
+			sdp.ciliumAgentConnectionTrigger.TriggerWithReason(reason)
+		}
+		sdp.cancelStreamPolicyStateStream()
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Context was cancelled, exit goroutine
+			sdp.log.Info("Stopping subscription to policy state")
+			return nil
+		default:
+			sdp.log.Debug("Waiting for policy state")
+			policyState, recvErr := sdp.policyStateStream.Recv()
+			if recvErr != nil {
+				if errors.Is(recvErr, io.EOF) || status.Code(recvErr) == codes.Unavailable {
+					sdp.log.Error("Policy state stream closed", logfields.Error, recvErr)
+					err = recvErr
+					return err
+				}
+				sdp.log.Error("Failed to receive policy state", logfields.Error, recvErr)
+				err = recvErr // Set the outer err for the deferred function to handle.
+				return err
+			}
+
+			response := &pb.PolicyStateResponse{
+				RequestId: policyState.GetRequestId(),
+			}
+			revertStack, err := sdp.UpdatePolicyState(policyState)
+			if err != nil {
+				sdp.log.Error("Failed to update policy state", logfields.Error, err)
+				revertStack.Revert()
+				err = sdp.policyStateStream.Send(response)
+				if err != nil {
+					sdp.log.Error("Failed to send policy state response", logfields.Error, err)
+					return err
+				}
+				return err
+			}
+			response.Response = pb.ResponseCode_RESPONSE_CODE_NO_ERROR
+			err = sdp.policyStateStream.Send(response)
+			if err != nil {
+				sdp.log.Error("Failed to send policy state response", logfields.Error, err)
+				return err
+			}
+		}
+	}
+}
+
+func (sdp *StandaloneDNSProxy) closePolicyStateStream() {
+	if sdp.policyStateStream != nil {
+		err := sdp.policyStateStream.CloseSend()
+		if err != nil {
+			sdp.log.Error("Failed to close policy state stream", logfields.Error, err)
+		}
+		sdp.policyStateStream = nil
+	}
+}
+
+func (sdp *StandaloneDNSProxy) closeConnection() error {
+	if sdp.connection != nil {
+		err := sdp.connection.Close()
+		if err != nil {
+			sdp.log.Error("Failed to close connection", logfields.Error, err)
+			return err
+		}
+		sdp.connection = nil
+	}
+	return nil
+}
+
+// createStreamPolicyStateStream creates a subscription stream to the policy state
+func (sdp *StandaloneDNSProxy) createStreamPolicyStateStream(ctx context.Context) error {
+	if sdp.Client == nil {
+		sdp.log.Error("Client is nil")
+		return fmt.Errorf("client is nil")
+	}
+
+	if sdp.policyStateStream != nil {
+		sdp.log.Warn("Policy state stream is not nil")
+		sdp.closePolicyStateStream()
+	}
+
+	stream, err := sdp.Client.StreamPolicyState(ctx)
+	if err != nil {
+		sdp.log.Error("Failed to subscribe to policy state", logfields.Error, err)
+		return err
+	}
+	sdp.policyStateStream = stream
+	return nil
+}
+
+// UpdatePolicyState updates the DNS rules in the standalone DNS proxy
+// 1. It updates the ip to identity cache and ip to endpoint id cache
+// 2. It updates the DNS rules in the standalone DNS proxy
+// The input is the policy state received from the cilium agent as :
+//
+//	PolicyState : {
+//	  EgressL7DnsPolicy : [
+//	    {
+//	    SourceEndpointId : 1
+//	    DnsServers : [{
+//	      DnsServerIdentity : 2
+//	      DnsServerPort : 53
+//	      DnsServerProto : 17
+//	    	},
+//	    	{
+//	      DnsServerIdentity : 3
+//	      DnsServerPort : 53
+//	      DnsServerProto : 17
+//	    	}]
+//	    DnsPattern : ["www.example.com"]
+//	    },
+//	    {
+//	    SourceEndpointId : 1
+//	    DnsServers : [{
+//	      DnsServerIdentity : 2
+//	      DnsServerPort : 54
+//	      DnsServerProto : 17
+//	    	}]
+//	    DnsPattern : ["www.test.com"]
+//	    }
+//	  ]
+//	  IdentityToEndpointMapping : []
+//	}
+func (sdp *StandaloneDNSProxy) UpdatePolicyState(rules *pb.PolicyState) (revert.RevertStack, error) {
+	sdp.ipToIdentityCacheMu.Lock()
+	defer sdp.ipToIdentityCacheMu.Unlock()
+	sdp.ipToEndpointIdCacheMu.Lock()
+	defer sdp.ipToEndpointIdCacheMu.Unlock()
+
+	var revertStack revert.RevertStack
+	identityToEndpointMapping := rules.GetIdentityToEndpointMapping()
+
+	// Update the ip to identity cache and ip to endpoint id cache
+	for _, mapping := range identityToEndpointMapping {
+		for _, epInfo := range mapping.GetEndpointInfo() {
+			for _, ip := range epInfo.GetIp() {
+				sdp.ipToIdentityCache[net.IP(ip).String()] = mapping.GetIdentity()
+				if epInfo.GetId() != 0 {
+					sdp.ipToEndpointIdCache[net.IP(ip).String()] = epInfo.GetId()
+				}
+			}
+		}
+	}
+
+	endpointIdToRule := make(map[uint32]map[restore.PortProto]map[policy.CachedSelector][]string)
+	for _, rule := range rules.GetEgressL7DnsPolicy() {
+
+		portProtoToServerIdentity := make(map[restore.PortProto][]uint32)
+		for _, dnsServer := range rule.GetDnsServers() {
+			portProto := restore.MakeV2PortProto(uint16(dnsServer.GetDnsServerPort()), u8proto.U8proto(dnsServer.GetDnsServerProto()))
+			portProtoToServerIdentity[portProto] = append(portProtoToServerIdentity[portProto], dnsServer.GetDnsServerIdentity())
+		}
+
+		portProtoToDNSrules := make(map[restore.PortProto]map[policy.CachedSelector][]string)
+		for portProto, identities := range portProtoToServerIdentity {
+			cs := make(map[policy.CachedSelector][]string)
+			cs[&dnsproxy.DnsServerIdentity{Identities: identities}] = rule.GetDnsPattern()
+			portProtoToDNSrules[portProto] = cs
+		}
+
+		epId := rule.GetSourceEndpointId()
+		if _, ok := endpointIdToRule[epId]; !ok {
+			endpointIdToRule[epId] = make(map[restore.PortProto]map[policy.CachedSelector][]string)
+		}
+
+		for portProto, cs := range portProtoToDNSrules {
+			if _, ok := endpointIdToRule[epId][portProto]; !ok {
+				endpointIdToRule[epId][portProto] = make(map[policy.CachedSelector][]string)
+			}
+
+			for k, v := range cs {
+				endpointIdToRule[epId][portProto][k] = v
+			}
+		}
+	}
+
+	for epId, rules := range endpointIdToRule {
+		for portProto, cs := range rules {
+			revertFunc, err := sdp.DNSProxy.UpdateAllowedStandaloneDnsProxy(uint64(epId), portProto, cs)
+			if err != nil {
+				sdp.log.Error("Failed to update DNS rules",
+					logfields.EndpointID, epId,
+					logfields.Port, portProto.Protocol(),
+					logfields.Protocol, portProto.Protocol(),
+					logfields.Error, err)
+				return revertStack, err
+			}
+			revertStack.Push(revertFunc)
+		}
+	}
+
+	return revertStack, nil
+}

--- a/standalone-dns-proxy/cmd/standalonednsproxy_test.go
+++ b/standalone-dns-proxy/cmd/standalonednsproxy_test.go
@@ -1,0 +1,675 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/cilium/dns"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/trigger"
+	"github.com/cilium/cilium/pkg/u8proto"
+
+	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
+)
+
+var testLog = slog.Default()
+
+func TestNewStandaloneDNSProxy(t *testing.T) {
+	tests := []struct {
+		name string
+		args *StandaloneDNSProxyArgs
+		err  error
+	}{
+		{
+			name: "Valid grpc server port",
+			args: &StandaloneDNSProxyArgs{
+				toFQDNsServerPort: 1234,
+				enableL7Proxy:     true,
+			},
+			err: nil,
+		},
+		{
+			name: "Invalid grpc server port",
+			args: &StandaloneDNSProxyArgs{
+				toFQDNsServerPort: 0,
+				enableL7Proxy:     true,
+			},
+			err: errors.New("toFQDNsServerPort is 0"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sdp, err := NewStandaloneDNSProxy(tt.args, testLog)
+			if err != nil {
+				require.Equal(t, tt.err, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, sdp)
+		})
+	}
+}
+
+func TestStandaloneDNSProxyWhenDisabled(t *testing.T) {
+	test := map[string]struct {
+		args *StandaloneDNSProxyArgs
+		err  error
+	}{
+		"L7ProxyDisbaled": {
+			args: &StandaloneDNSProxyArgs{
+				toFQDNsServerPort:        4321,
+				enableStandaloneDNsProxy: false,
+				enableL7Proxy:            false,
+			},
+			err: nil,
+		},
+		"StandaloneDNSProxyDisabled": {
+			args: &StandaloneDNSProxyArgs{
+				toFQDNsServerPort:        4321,
+				enableStandaloneDNsProxy: false,
+				enableL7Proxy:            true,
+			},
+			err: nil,
+		},
+	}
+
+	for name, tt := range test {
+		t.Run(name, func(t *testing.T) {
+			sdp, err := NewStandaloneDNSProxy(tt.args, testLog)
+			require.NoError(t, err)
+			require.Nil(t, sdp.DNSProxy)
+		})
+	}
+}
+
+func TestStandaloneDNSProxyWhenEnabled(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	sdp, err := NewStandaloneDNSProxy(&StandaloneDNSProxyArgs{
+		DNSProxyConfig: dnsproxy.DNSProxyConfig{
+			Address:                "",
+			Port:                   1234,
+			IPv4:                   true,
+			IPv6:                   true,
+			EnableDNSCompression:   true,
+			MaxRestoreDNSIPs:       10,
+			ConcurrencyLimit:       10,
+			ConcurrencyGracePeriod: 10,
+			DNSProxyType:           dnsproxy.StandaloneDNSProxy,
+		},
+		toFQDNsServerPort:        4321,
+		enableStandaloneDNsProxy: true,
+		enableL7Proxy:            true,
+	}, testLog)
+	require.NoError(t, err)
+
+	sdp.StartStandaloneDNSProxy()
+	defer sdp.StopStandaloneDNSProxy()
+
+	// check if the server is running
+	require.Equal(t, dnsproxy.StandaloneDNSProxy, sdp.DNSProxy.DNSProxyType)
+	require.NotNil(t, sdp.ciliumAgentConnectionTrigger)
+}
+
+type MockFQDNDataServer struct {
+	pb.UnimplementedFQDNDataServer
+}
+
+func (m *MockFQDNDataServer) UpdateMappingRequest(ctx context.Context, in *pb.FQDNMapping) (*pb.UpdateMappingResponse, error) {
+	return &pb.UpdateMappingResponse{
+		Response: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
+	}, nil
+}
+
+// create a channel to receive the policy state
+var dnsPoliciesResult = make(chan *pb.PolicyStateResponse)
+
+func (m *MockFQDNDataServer) StreamPolicyState(stream pb.FQDNData_StreamPolicyStateServer) error {
+	//Receive the success message from the SDP
+	go func() {
+		res, err := stream.Recv()
+		if err != nil {
+			testLog.Error("Error receiving policy state response", logfields.Error, err)
+		}
+		dnsPoliciesResult <- res
+		// Send the close message
+		stream.Context().Done()
+	}()
+	go func() {
+		// Send the current state of the policy state
+		err := stream.Send(&pb.PolicyState{
+			EgressL7DnsPolicy: []*pb.DNSPolicy{
+				{
+					SourceEndpointId: 1,
+					DnsPattern:       []string{"*.cilium.io", "example.com"},
+					DnsServers: []*pb.DNSServer{
+						{
+							DnsServerIdentity: 2,
+							DnsServerPort:     53,
+							DnsServerProto:    17,
+						},
+					},
+				},
+			},
+			RequestId: "1",
+			IdentityToEndpointMapping: []*pb.IdentityToEndpointMapping{
+				{
+					Identity: 1,
+					EndpointInfo: []*pb.EndpointInfo{
+						{
+							Ip: [][]byte{net.ParseIP("1.1.1.0")},
+							Id: 100,
+						},
+					},
+				},
+				{
+					Identity: 2,
+					EndpointInfo: []*pb.EndpointInfo{
+						{
+							Ip: [][]byte{net.ParseIP("1.1.1.1")},
+							Id: 101,
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			testLog.Error("Error sending policy state", logfields.Error, err)
+		}
+	}()
+
+	testLog.Info("Waiting for the stream to finish")
+	<-stream.Context().Done()
+	testLog.Info("Stream finished")
+	return stream.Context().Err()
+}
+
+func setupStandaloneDNSProxy(t *testing.T, ctx context.Context) (*StandaloneDNSProxy, func()) {
+	buffer := 1024
+	lis := bufconn.Listen(buffer)
+
+	baseServer := grpc.NewServer()
+
+	server := &MockFQDNDataServer{}
+	pb.RegisterFQDNDataServer(baseServer, server)
+	go func() {
+		if err := baseServer.Serve(lis); err != nil {
+			// The server is closed, so we can ignore the error
+			// as it is expected when the test ends
+			// and the server is closed.
+			testLog.Error("Error serving bufnet listener", logfields.Error, err)
+		}
+	}()
+
+	conn, err := grpc.NewClient("passthrough://bufnet", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithKeepaliveParams(kacp))
+
+	if err != nil {
+		t.Fatalf("Failed to dial bufnet: %v", err)
+	}
+
+	sdp, err := NewStandaloneDNSProxy(&StandaloneDNSProxyArgs{
+		DNSProxyConfig: dnsproxy.DNSProxyConfig{
+			Address: "",
+			Port:    1234,
+			IPv4:    true,
+			IPv6:    false,
+		},
+		toFQDNsServerPort:        4321,
+		enableStandaloneDNsProxy: true,
+		enableL7Proxy:            true,
+	}, testLog)
+	require.NoError(t, err)
+
+	sdp.connection = conn
+
+	closer := func() {
+		if sdp.Client != nil {
+			sdp.connection.Close()
+		}
+		err := lis.Close()
+		if err != nil {
+			t.Error("Error closing bufnet listener", err)
+		}
+		baseServer.Stop()
+	}
+
+	return sdp, closer
+}
+
+func TestSubscribeToPolicyState(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	sdp, closer := setupStandaloneDNSProxy(t, context.Background())
+	defer closer()
+
+	// Create the client
+	err := sdp.CreateClient(context.Background())
+	require.NoError(t, err)
+	tr, err := trigger.NewTrigger(trigger.Parameters{
+		TriggerFunc: func(reasons []string) {
+			time.Sleep(time.Second)
+		},
+	})
+	require.NoError(t, err)
+	sdp.ciliumAgentConnectionTrigger = tr
+	// Add a dummy dns proxy server
+	sdp.DNSProxy, err = dnsproxy.StartDNSProxy(sdp.args.DNSProxyConfig, // any address, any port, enable ipv4, enable ipv6, enable compression, max 1000 restore IPs
+		// LookupEPByIP
+		func(ip netip.Addr) (*endpoint.Endpoint, bool, error) {
+			return &endpoint.Endpoint{}, false, nil
+		},
+		// LookupSecIDByIP
+		func(ip netip.Addr) (ipcache.Identity, bool) {
+			return ipcache.Identity{}, false
+		},
+		// LookupIPsBySecID
+		func(nid identity.NumericIdentity) []string {
+			return []string{}
+		},
+		// NotifyOnDNSMsg
+		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, dstAddr netip.AddrPort, msg *dns.Msg, protocol string, allowed bool, stat *dnsproxy.ProxyRequestContext) error {
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	// StreamPolicyState is called successfully
+	go func() {
+		context, cancel := context.WithCancel(context.Background())
+		sdp.cancelStreamPolicyStateStream = cancel
+		err = sdp.streamPolicyState(context)
+		require.Contains(t, err.Error(), "rpc error: code = Canceled desc = grpc: the client connection is closing")
+	}()
+
+	// check if the server received the success or not
+	result := <-dnsPoliciesResult
+	require.Equal(t, pb.ResponseCode_RESPONSE_CODE_NO_ERROR, result.GetResponse())
+	// Check the data sent from the server is added
+	require.Equal(t, map[string]uint64{"1.1.1.1": 101, "1.1.1.0": 100}, sdp.ipToEndpointIdCache)
+	require.Equal(t, map[string]uint32{"1.1.1.1": 2, "1.1.1.0": 1}, sdp.ipToIdentityCache)
+
+	// // check the dnsResult channel is empty
+	select {
+	case <-dnsPoliciesResult:
+		for _, s := range sdp.DNSProxy.DNSServers {
+			s.Shutdown()
+		}
+		t.Fatalf("dnsPoliciesResult channel is not empty")
+	default:
+		t.Logf("dnsPoliciesResult channel is empty")
+	}
+}
+
+func TestCreateClientIsCreatedSuccessfully(t *testing.T) {
+	ctx := context.Background()
+	sdp, closer := setupStandaloneDNSProxy(t, ctx)
+	defer closer()
+
+	err := sdp.CreateClient(ctx)
+	require.NoError(t, err)
+
+	// check if the client is created
+	require.NotNil(t, sdp.Client)
+	// Check if dns rules stream is created
+	require.NotNil(t, sdp.policyStateStream)
+}
+
+func TestCreateClientFails(t *testing.T) {
+	ctx := context.Background()
+	sdp, closer := setupStandaloneDNSProxy(t, ctx)
+	defer closer()
+
+	sdp.connection = nil
+	err := sdp.CreateClient(ctx)
+	require.Error(t, err)
+}
+
+func TestNotifyOnDNSMsg(t *testing.T) {
+	ctx := context.Background()
+	sdp, closer := setupStandaloneDNSProxy(t, ctx)
+	defer closer()
+
+	err := sdp.CreateClient(ctx)
+	require.NoError(t, err)
+
+	ep := &endpoint.Endpoint{
+		SecurityIdentity: &identity.Identity{
+			ID: 1,
+		},
+	}
+	serverId := identity.NumericIdentity(2)
+	msg := new(dns.Msg)
+	msg.SetQuestion("test.com.", dns.TypeA)
+	retARR, err := dns.NewRR(msg.Question[0].Name + " 60 IN A 1.1.1.1")
+	if err != nil {
+		panic(err)
+	}
+	msg.Answer = append(msg.Answer, retARR)
+
+	// Case 1: NotifyOnDNSMsg is called successfully
+	err = sdp.NotifyOnDNSMsg(time.Now(), ep, "1.1.1.1:80", serverId, netip.AddrPortFrom(netip.MustParseAddr("10.0.0.1"), 53), msg, "udp", true, nil)
+	require.NoError(t, err)
+
+	// Case 2: NotifyOnDNSMsg is called with invalid epIpPort
+	err = sdp.NotifyOnDNSMsg(time.Now(), ep, "1.1.1.1", serverId, netip.AddrPortFrom(netip.MustParseAddr("10.0.0.1"), 53), msg, "udp", true, nil)
+	require.Error(t, err)
+
+	// Case 3: NotifyOnDNSMsg is called with nil client
+	sdp.Client = nil
+	err = sdp.NotifyOnDNSMsg(time.Now(), ep, "1.1.1.1:80", serverId, netip.AddrPortFrom(netip.MustParseAddr("10.0.0.1"), 53), msg, "udp", true, nil)
+	require.Error(t, err)
+
+	// Case 4: NotifyOnDNSMsg is called with invalid msg
+	err = sdp.CreateClient(ctx)
+	require.NoError(t, err)
+	msg = new(dns.Msg)
+	err = sdp.NotifyOnDNSMsg(time.Now(), ep, "1.1.1.1:80", serverId, netip.AddrPortFrom(netip.MustParseAddr("10.0.0.1"), 53), msg, "udp", true, nil)
+	require.Equal(t, errors.New("Invalid DNS message"), err)
+
+}
+
+func TestCreateSubscriptionStream(t *testing.T) {
+	ctx := context.Background()
+	sdp, closer := setupStandaloneDNSProxy(t, ctx)
+	defer closer()
+
+	// First check if the subscription stream is created successfully
+	err := sdp.CreateClient(ctx)
+	require.NoError(t, err)
+
+	err = sdp.createStreamPolicyStateStream(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, sdp.policyStateStream)
+
+	// Now check if the subscription stream is created again if the dnsRulesStream is not nil
+	current := sdp.policyStateStream
+	err = sdp.createStreamPolicyStateStream(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, sdp.policyStateStream)
+	require.NotEqual(t, current, sdp.policyStateStream)
+
+	// Now check if the subscription stream is not created if the client is nil
+	sdp.Client = nil
+	err = sdp.createStreamPolicyStateStream(ctx)
+	require.Error(t, err)
+}
+
+var (
+	ipToEndpointIdCache = map[string]uint64{"1.1.1.10": 1}
+	ipToIdentityCache   = map[string]uint32{"1.1.1.10": 100}
+)
+
+func TestLookupSecIDByIP(t *testing.T) {
+	ctx := context.Background()
+	sdp, closer := setupStandaloneDNSProxy(t, ctx)
+	defer closer()
+
+	sdp.ipToIdentityCache = ipToIdentityCache
+	// Case 1: LookupSecIDByIP is called successfully
+	secID, found := sdp.LookupSecIDByIP(netip.MustParseAddr("1.1.1.10"))
+	require.True(t, found)
+	require.Equal(t, ipcache.Identity{
+		ID:     identity.NumericIdentity(100),
+		Source: source.Local,
+	}, secID)
+
+	// Case 2: LookupSecIDByIP is called with invalid ip
+	secID, found = sdp.LookupSecIDByIP(netip.MustParseAddr("2.2.2.2"))
+	require.False(t, found)
+	require.Equal(t, ipcache.Identity{}, secID)
+}
+
+func TestLookEPByIP(t *testing.T) {
+	ctx := context.Background()
+	sdp, closer := setupStandaloneDNSProxy(t, ctx)
+	defer closer()
+
+	sdp.ipToEndpointIdCache = ipToEndpointIdCache
+	sdp.ipToIdentityCache = ipToIdentityCache
+	// Case 1: LookupEPByIP is called successfully
+	ep, _, err := sdp.LookupEPByIP(netip.MustParseAddr("1.1.1.10"))
+	require.NoError(t, err)
+	require.NotNil(t, ep)
+	require.Equal(t, uint64(1), ep.GetID())
+	require.Equal(t, identity.NumericIdentity(100), ep.SecurityIdentity.ID)
+
+	// Case 2: LookupEPByIP is called with invalid ip
+	ep, _, err = sdp.LookupEPByIP(netip.MustParseAddr("2.2.2.2"))
+	require.Error(t, err)
+	require.Nil(t, ep)
+}
+
+func TestUpdatePolicyState(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ctx := context.Background()
+	sdp, closer := setupStandaloneDNSProxy(t, ctx)
+	defer closer()
+
+	dnsProxyConfig := dnsproxy.DNSProxyConfig{
+		Address:                "",
+		Port:                   1234,
+		IPv4:                   true,
+		IPv6:                   true,
+		EnableDNSCompression:   true,
+		MaxRestoreDNSIPs:       10,
+		ConcurrencyLimit:       10,
+		ConcurrencyGracePeriod: 10,
+		DNSProxyType:           dnsproxy.StandaloneDNSProxy,
+	}
+	epId := uint32(1)
+	dnsServerIps := []net.IP{
+		net.ParseIP("2.2.2.2"),
+	}
+	var dnsIps [][]byte
+	for _, i := range dnsServerIps {
+		dnsIps = append(dnsIps, []byte(i.String()))
+	}
+
+	epIps := []net.IP{
+		net.ParseIP("1.1.1.1"),
+	}
+	var ips [][]byte
+	for _, i := range epIps {
+		ips = append(ips, []byte(i.String()))
+	}
+
+	dstPortProto := restore.MakeV2PortProto(53, u8proto.UDP) // Set below when we setup the server!
+	IdentityToEndpointMapping := []*pb.IdentityToEndpointMapping{
+		{
+			Identity: 2,
+			EndpointInfo: []*pb.EndpointInfo{
+				{
+					Ip: dnsIps,
+					Id: 101,
+				},
+			},
+		},
+		{
+			Identity: 3,
+			EndpointInfo: []*pb.EndpointInfo{
+				{
+					Ip: dnsIps,
+					Id: 102,
+				},
+			},
+		},
+		{
+			Identity: 1,
+			EndpointInfo: []*pb.EndpointInfo{
+				{
+					Ip: ips,
+					Id: 100,
+				},
+			},
+		},
+	}
+	var test = []struct {
+		name string
+		args *pb.PolicyState
+		err  error
+		out  map[restore.PortProto][]identity.NumericIdentitySlice
+	}{
+		{
+			name: "Single DNS Policy with single DNS server",
+			args: &pb.PolicyState{
+				EgressL7DnsPolicy: []*pb.DNSPolicy{
+					{
+						SourceEndpointId: epId,
+						DnsPattern:       []string{"*.cilium.io", "example.com"},
+						DnsServers: []*pb.DNSServer{
+							{
+								DnsServerIdentity: 2,
+								DnsServerPort:     53,
+								DnsServerProto:    17,
+							},
+						},
+					},
+				},
+				IdentityToEndpointMapping: IdentityToEndpointMapping,
+			},
+			err: nil,
+			out: map[restore.PortProto][]identity.NumericIdentitySlice{
+				dstPortProto: {
+					{identity.NumericIdentity(2)},
+				},
+			},
+		},
+		{
+			name: "Single DNS Policy with multiple port and protocol DNS servers",
+			args: &pb.PolicyState{
+				EgressL7DnsPolicy: []*pb.DNSPolicy{
+					{
+						SourceEndpointId: epId,
+						DnsPattern:       []string{"*.cilium.io", "example.com"},
+						DnsServers: []*pb.DNSServer{
+							{
+								DnsServerIdentity: 2,
+								DnsServerPort:     53,
+								DnsServerProto:    17,
+							},
+							{
+								DnsServerIdentity: 3,
+								DnsServerPort:     53,
+								DnsServerProto:    17,
+							},
+						},
+					},
+				},
+				IdentityToEndpointMapping: IdentityToEndpointMapping,
+			},
+			err: nil,
+			out: map[restore.PortProto][]identity.NumericIdentitySlice{
+				dstPortProto: {
+					{identity.NumericIdentity(2), identity.NumericIdentity(3)},
+				},
+			},
+		},
+		{
+			name: "Multiple DNS Policies with same identity",
+			args: &pb.PolicyState{
+				EgressL7DnsPolicy: []*pb.DNSPolicy{
+					{
+						SourceEndpointId: epId,
+						DnsPattern:       []string{"*.aws.io"},
+						DnsServers: []*pb.DNSServer{
+							{
+								DnsServerIdentity: 2,
+								DnsServerPort:     53,
+								DnsServerProto:    17,
+							},
+						},
+					},
+					{
+						SourceEndpointId: epId,
+						DnsPattern:       []string{"*.cilium.io", "example.com"},
+						DnsServers: []*pb.DNSServer{
+							{
+								DnsServerIdentity: 3,
+								DnsServerPort:     53,
+								DnsServerProto:    17,
+							},
+						},
+					},
+				},
+				IdentityToEndpointMapping: IdentityToEndpointMapping,
+			},
+			err: nil,
+			out: map[restore.PortProto][]identity.NumericIdentitySlice{
+				dstPortProto: {
+					{identity.NumericIdentity(2)},
+					{identity.NumericIdentity(3)},
+				},
+			},
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy, err := dnsproxy.StartDNSProxy(dnsProxyConfig, // any address, any port, enable ipv4, enable ipv6, enable compression, max 1000 restore IPs
+				// LookupEPByIP
+				func(ip netip.Addr) (*endpoint.Endpoint, bool, error) {
+					return &endpoint.Endpoint{}, false, nil
+				},
+				// LookupSecIDByIP
+				func(ip netip.Addr) (ipcache.Identity, bool) {
+					return ipcache.Identity{}, false
+				},
+				// LookupIPsBySecID
+				func(nid identity.NumericIdentity) []string {
+					return []string{}
+				},
+				// NotifyOnDNSMsg
+				func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, dstAddr netip.AddrPort, msg *dns.Msg, protocol string, allowed bool, stat *dnsproxy.ProxyRequestContext) error {
+					return nil
+				},
+			)
+			require.NoError(t, err, "error starting DNS Proxy")
+			sdp.DNSProxy = proxy
+
+			_, err = sdp.UpdatePolicyState(tt.args)
+			if err != nil {
+				require.Equal(t, tt.err, err)
+				return
+			}
+			require.NoError(t, err)
+
+			allowedRules, err := sdp.DNSProxy.GetAllowedRulesForEndpoint(uint64(epId))
+			require.NoError(t, err)
+			// Compare the allowed rules with the expected output
+			for portProto, expectedSelectors := range tt.out {
+				actualSelectors, ok := allowedRules[portProto]
+				require.True(t, ok)
+				require.Equal(t, len(expectedSelectors), len(actualSelectors))
+			}
+
+			// Shutdown the DNS Proxy
+			for _, s := range sdp.DNSProxy.DNSServers {
+				s.Shutdown()
+			}
+		})
+	}
+}

--- a/standalone-dns-proxy/main.go
+++ b/standalone-dns-proxy/main.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/standalone-dns-proxy/cmd"
+)
+
+func main() {
+	dnsProxyHive := hive.New(cmd.DNSProxy)
+
+	cmd.Execute(cmd.NewDNSProxyCmd(dnsProxyHive))
+}

--- a/vendor/google.golang.org/grpc/test/bufconn/bufconn.go
+++ b/vendor/google.golang.org/grpc/test/bufconn/bufconn.go
@@ -1,0 +1,318 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package bufconn provides a net.Conn implemented by a buffer and related
+// dialing and listening functionality.
+package bufconn
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+// Listener implements a net.Listener that creates local, buffered net.Conns
+// via its Accept and Dial method.
+type Listener struct {
+	mu   sync.Mutex
+	sz   int
+	ch   chan net.Conn
+	done chan struct{}
+}
+
+// Implementation of net.Error providing timeout
+type netErrorTimeout struct {
+	error
+}
+
+func (e netErrorTimeout) Timeout() bool   { return true }
+func (e netErrorTimeout) Temporary() bool { return false }
+
+var errClosed = fmt.Errorf("closed")
+var errTimeout net.Error = netErrorTimeout{error: fmt.Errorf("i/o timeout")}
+
+// Listen returns a Listener that can only be contacted by its own Dialers and
+// creates buffered connections between the two.
+func Listen(sz int) *Listener {
+	return &Listener{sz: sz, ch: make(chan net.Conn), done: make(chan struct{})}
+}
+
+// Accept blocks until Dial is called, then returns a net.Conn for the server
+// half of the connection.
+func (l *Listener) Accept() (net.Conn, error) {
+	select {
+	case <-l.done:
+		return nil, errClosed
+	case c := <-l.ch:
+		return c, nil
+	}
+}
+
+// Close stops the listener.
+func (l *Listener) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	select {
+	case <-l.done:
+		// Already closed.
+		break
+	default:
+		close(l.done)
+	}
+	return nil
+}
+
+// Addr reports the address of the listener.
+func (l *Listener) Addr() net.Addr { return addr{} }
+
+// Dial creates an in-memory full-duplex network connection, unblocks Accept by
+// providing it the server half of the connection, and returns the client half
+// of the connection.
+func (l *Listener) Dial() (net.Conn, error) {
+	return l.DialContext(context.Background())
+}
+
+// DialContext creates an in-memory full-duplex network connection, unblocks Accept by
+// providing it the server half of the connection, and returns the client half
+// of the connection.  If ctx is Done, returns ctx.Err()
+func (l *Listener) DialContext(ctx context.Context) (net.Conn, error) {
+	p1, p2 := newPipe(l.sz), newPipe(l.sz)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-l.done:
+		return nil, errClosed
+	case l.ch <- &conn{p1, p2}:
+		return &conn{p2, p1}, nil
+	}
+}
+
+type pipe struct {
+	mu sync.Mutex
+
+	// buf contains the data in the pipe.  It is a ring buffer of fixed capacity,
+	// with r and w pointing to the offset to read and write, respectively.
+	//
+	// Data is read between [r, w) and written to [w, r), wrapping around the end
+	// of the slice if necessary.
+	//
+	// The buffer is empty if r == len(buf), otherwise if r == w, it is full.
+	//
+	// w and r are always in the range [0, cap(buf)) and [0, len(buf)].
+	buf  []byte
+	w, r int
+
+	wwait sync.Cond
+	rwait sync.Cond
+
+	// Indicate that a write/read timeout has occurred
+	wtimedout bool
+	rtimedout bool
+
+	wtimer *time.Timer
+	rtimer *time.Timer
+
+	closed      bool
+	writeClosed bool
+}
+
+func newPipe(sz int) *pipe {
+	p := &pipe{buf: make([]byte, 0, sz)}
+	p.wwait.L = &p.mu
+	p.rwait.L = &p.mu
+
+	p.wtimer = time.AfterFunc(0, func() {})
+	p.rtimer = time.AfterFunc(0, func() {})
+	return p
+}
+
+func (p *pipe) empty() bool {
+	return p.r == len(p.buf)
+}
+
+func (p *pipe) full() bool {
+	return p.r < len(p.buf) && p.r == p.w
+}
+
+func (p *pipe) Read(b []byte) (n int, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Block until p has data.
+	for {
+		if p.closed {
+			return 0, io.ErrClosedPipe
+		}
+		if !p.empty() {
+			break
+		}
+		if p.writeClosed {
+			return 0, io.EOF
+		}
+		if p.rtimedout {
+			return 0, errTimeout
+		}
+
+		p.rwait.Wait()
+	}
+	wasFull := p.full()
+
+	n = copy(b, p.buf[p.r:len(p.buf)])
+	p.r += n
+	if p.r == cap(p.buf) {
+		p.r = 0
+		p.buf = p.buf[:p.w]
+	}
+
+	// Signal a blocked writer, if any
+	if wasFull {
+		p.wwait.Signal()
+	}
+
+	return n, nil
+}
+
+func (p *pipe) Write(b []byte) (n int, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return 0, io.ErrClosedPipe
+	}
+	for len(b) > 0 {
+		// Block until p is not full.
+		for {
+			if p.closed || p.writeClosed {
+				return 0, io.ErrClosedPipe
+			}
+			if !p.full() {
+				break
+			}
+			if p.wtimedout {
+				return 0, errTimeout
+			}
+
+			p.wwait.Wait()
+		}
+		wasEmpty := p.empty()
+
+		end := cap(p.buf)
+		if p.w < p.r {
+			end = p.r
+		}
+		x := copy(p.buf[p.w:end], b)
+		b = b[x:]
+		n += x
+		p.w += x
+		if p.w > len(p.buf) {
+			p.buf = p.buf[:p.w]
+		}
+		if p.w == cap(p.buf) {
+			p.w = 0
+		}
+
+		// Signal a blocked reader, if any.
+		if wasEmpty {
+			p.rwait.Signal()
+		}
+	}
+	return n, nil
+}
+
+func (p *pipe) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closed = true
+	// Signal all blocked readers and writers to return an error.
+	p.rwait.Broadcast()
+	p.wwait.Broadcast()
+	return nil
+}
+
+func (p *pipe) closeWrite() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.writeClosed = true
+	// Signal all blocked readers and writers to return an error.
+	p.rwait.Broadcast()
+	p.wwait.Broadcast()
+	return nil
+}
+
+type conn struct {
+	io.Reader
+	io.Writer
+}
+
+func (c *conn) Close() error {
+	err1 := c.Reader.(*pipe).Close()
+	err2 := c.Writer.(*pipe).closeWrite()
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+func (c *conn) SetDeadline(t time.Time) error {
+	c.SetReadDeadline(t)
+	c.SetWriteDeadline(t)
+	return nil
+}
+
+func (c *conn) SetReadDeadline(t time.Time) error {
+	p := c.Reader.(*pipe)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.rtimer.Stop()
+	p.rtimedout = false
+	if !t.IsZero() {
+		p.rtimer = time.AfterFunc(time.Until(t), func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.rtimedout = true
+			p.rwait.Broadcast()
+		})
+	}
+	return nil
+}
+
+func (c *conn) SetWriteDeadline(t time.Time) error {
+	p := c.Writer.(*pipe)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.wtimer.Stop()
+	p.wtimedout = false
+	if !t.IsZero() {
+		p.wtimer = time.AfterFunc(time.Until(t), func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.wtimedout = true
+			p.wwait.Broadcast()
+		})
+	}
+	return nil
+}
+
+func (*conn) LocalAddr() net.Addr  { return addr{} }
+func (*conn) RemoteAddr() net.Addr { return addr{} }
+
+type addr struct{}
+
+func (addr) Network() string { return "bufconn" }
+func (addr) String() string  { return "bufconn" }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1866,6 +1866,7 @@ google.golang.org/grpc/serviceconfig
 google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
+google.golang.org/grpc/test/bufconn
 # google.golang.org/protobuf v1.36.5
 ## explicit; go 1.21
 google.golang.org/protobuf/encoding/protodelim


### PR DESCRIPTION
#### Overview
This PR is the full implementation of the standalone dns proxy feature based on the CFP: https://github.com/cilium/design-cfps/pull/54 and the grpc protocol merged in this PR: https://github.com/cilium/cilium/pull/36121
For overall flow of the data, please refer to this comment on the issue: https://github.com/cilium/cilium/issues/30984#issuecomment-2505035738

#### The PR consists of 6 commits:
- Commit 1: (PR #36213 ) Cilium agent grpc server - This commit add the grpc handler on the cilium agent and sending the policy state to the standalone dns proxy.
- Commit 2: (PR #36214 ) Standalone dns proxy running the dns proxy and connecting to the cilium agent grpc server created in commit 1. The data from cilium agent -> SDP is stored in the dns proxy in the similar manner as that of inbuilt dns proxy.
- Commit 3: (PR #36215 ) Dockerfile for the standalone dns proxy. Used for creating the standalone dns proxy image.
- Commit 4: Templates of the daemonset for the standalone dns proxy and default values for the standalone dns proxy daemon set.
- Commit 5: CLI testing for the standalone dns proxy. Added a cli test that is responsible for testing the sdp while inbuilt dns proxy is down.
- Commit 6: CI for the standalone dns proxy. Added a CI scenario where you install the standalone dns proxy and checks the dns request even when cilium agent is down. Note: Since the standalone dns proxy path does not exists on the `quay.io/cilium`, we will need to add that to make sure ci works as expected.

#### Steps to test the standalone dns proxy.
- First thing you will need is a standalone dns proxy image.
```
make docker-standalone-dns-proxy-image # This will create an image with tag quay.io/cilium/standalone-dns-proxy:latest
```
- Push that image to your preferred container repo. (for example:  `quay.io/cilium/standalone-dns-proxy:test`)
- Create a kind cluster using the make cmd
```
make kind && make kind-image && make kind-install-cilium

# Update the cilium to disable the dns proxy and enable standalone dns proxy
cilium upgrade --set-string='extraConfig.enable-embedded-dns-proxy=false' --helm-set=standaloneDnsProxy.enabled=true --helm-set=standaloneDnsProxy.l7Proxy=true --set='l7Proxy=true,dnsProxy.proxyPort=40046' --chart-directory='./install/kubernetes/cilium' --helm-set=standaloneDnsProxy.image.repository=quay.io/cilium/standalone-dns-proxy --helm-
set=standaloneDnsProxy.image.tag=test --helm-set=standaloneDnsProxy.image.useDigest=false

# Restart the cilium agent
kubectl rollout restart ds -n kube-system cilium

# Run the cilium connectivity test
cd cilium-cli
make install #this will be updating the cli with the standalone dns proxy feature test
cilium connectivity test
```
The output of the connectivity test would include:
```
[=] [cilium-test-1] Test [check-standalone-dns-proxy] [17/113]
...
```

##### Steps to test standalone dns proxy even when cilium agent is down.
```
# Assuming you were able to run the previous test mentioned above.
kubectl apply -f examples/minikube/http-sw-app.yaml
kubectl apply -f examples/policies/l7/dns/dns.yaml
kubectl exec xwing -- curl cilium.io

kubectl edit ds -n kube-system cilium
# edit the cilium agent image to have an invalid image tag for example: quay.io/cilium/cilium:invalid-image
# Once the cilium is in errImgPull Error, try curl again
kubectl exec xwing -- curl cilium.io
```

Fixes: #30984
