### PR TITLE
labels: fix TestNewFrom test

### DIFF
--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -56,7 +56,7 @@ func TestNewFrom(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			newLbls := NewFrom(tt.lbls)
 			// Verify that underlying maps are different
-			assert.NotSame(t, &tt.lbls, &newLbls)
+			assert.NotEqual(t, reflect.ValueOf(tt.lbls).UnsafePointer(), reflect.ValueOf(newLbls).UnsafePointer())
 			// Verify that the map contents are equal
 			assert.EqualValues(t, tt.want, newLbls)
 		})


### PR DESCRIPTION
The TestNewFrom test aimed to test that NewFrom returned a copy of the input labels, while ensuring that the underlying map object was different.

However, the test never worked as intended, because assert.NotSame only works on pointers, and maps are not pointers strictly speaking. Before, assert.NotSame simply silently returned, while starting from testify v1.10.0 it fails loudly with the following error:

    labels_test.go:69:
                Error Trace:    .../pkg/labels/labels_test.go:69
                Error:          Both arguments must be pointers
                Test:           TestNewFrom/non-empty_labels

Simply passing the map pointers would not be correct either, as the pointers would always be different, even when pointing to the same underlying map.

Hence, let's update the test so that it actually asserts the desired behavior, as it can be validated changing NewFrom to directly return the given parameter, without creating a copy.

v1.15 version: https://github.com/cilium/cilium/pull/37845