### PR TITLE
Replace `logging.SlogNopHandler` by `slog.DiscardHandler`

### DIFF
--- a/operator/pkg/ciliumidentity/cache_test.go
+++ b/operator/pkg/ciliumidentity/cache_test.go
@@ -18,7 +18,6 @@ import (
 	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
-	"github.com/cilium/cilium/pkg/logging"
 )
 
 var (
@@ -35,7 +34,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestCIDState(t *testing.T) {
-	logger := slog.New(logging.SlogNopHandler)
+	logger := slog.New(slog.DiscardHandler)
 	// The subtests below share the same state to serially test insert, lookup and
 	// remove operations of CIDState.
 	state := NewCIDState(logger)
@@ -144,7 +143,7 @@ func TestCIDState(t *testing.T) {
 }
 
 func TestCIDStateThreadSafety(t *testing.T) {
-	logger := slog.New(logging.SlogNopHandler)
+	logger := slog.New(slog.DiscardHandler)
 
 	// This test ensures that no changes to the CID state break its thread safety.
 	// Multiple go routines in parallel continuously keep using CIDState.

--- a/pkg/datapath/agentliveness/agent_liveness.go
+++ b/pkg/datapath/agentliveness/agent_liveness.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/bpf"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maps/configmap"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -48,7 +47,7 @@ func newAgentLivenessUpdater(
 	agentLivenessConfig agentLivenessConfig,
 ) {
 	// Discard even debug logs since this particular job is very noisy
-	log := slog.New(logging.SlogNopHandler)
+	log := slog.New(slog.DiscardHandler)
 	group := jobRegistry.NewGroup(health, job.WithLogger(log))
 	group.Add(job.Timer("agent-liveness-updater", func(_ context.Context) error {
 		mtime, err := bpf.GetMtime()

--- a/pkg/dynamicconfig/reflectors_test.go
+++ b/pkg/dynamicconfig/reflectors_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/option/resolver"
 )
 
@@ -159,7 +158,7 @@ func TestParseNodeConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger := slog.New(logging.SlogNopHandler)
+			logger := slog.New(slog.DiscardHandler)
 			got := parseNodeConfig(tt.node, logger)
 
 			if len(got) != len(tt.want) {

--- a/pkg/logging/slog.go
+++ b/pkg/logging/slog.go
@@ -18,16 +18,6 @@ import (
 // logrErrorKey is the key used by the logr library for the error parameter.
 const logrErrorKey = "err"
 
-// SlogNopHandler discards all logs.
-var SlogNopHandler slog.Handler = nopHandler{}
-
-type nopHandler struct{}
-
-func (nopHandler) Enabled(context.Context, slog.Level) bool  { return false }
-func (nopHandler) Handle(context.Context, slog.Record) error { return nil }
-func (n nopHandler) WithAttrs([]slog.Attr) slog.Handler      { return n }
-func (n nopHandler) WithGroup(string) slog.Handler           { return n }
-
 var slogHandlerOpts = &slog.HandlerOptions{
 	AddSource:   false,
 	Level:       slog.LevelInfo,

--- a/tools/api-flaggen/main.go
+++ b/tools/api-flaggen/main.go
@@ -20,7 +20,6 @@ import (
 	operatorServer "github.com/cilium/cilium/api/v1/operator/server"
 	"github.com/cilium/cilium/api/v1/server"
 	"github.com/cilium/cilium/pkg/api"
-	"github.com/cilium/cilium/pkg/logging"
 )
 
 var (
@@ -121,5 +120,5 @@ func printAPIFlagTables(
 }
 
 func main() {
-	Hive.Run(slog.New(logging.SlogNopHandler))
+	Hive.Run(slog.New(slog.DiscardHandler))
 }


### PR DESCRIPTION
The `log/slog` Go standard library package provides `DiscardHandler` since Go 1.24[^1]. Make use of it instead of duplicating it as `logging.SlogNopHandler`.

[^1]: https://go.dev/doc/go1.24#logslogpkglogslog