### PR TITLE
cilium-dbg: Use node name in shell prompt

### DIFF
--- a/cilium-dbg/cmd/shell.go
+++ b/cilium-dbg/cmd/shell.go
@@ -128,7 +128,13 @@ func interactiveShell() {
 	defer signal.Stop(sigs)
 	signal.Notify(sigs, os.Interrupt)
 
-	console := term.NewTerminal(stdReadWriter, "cilium> ")
+	// Use the node's name as the prompt.
+	hostName, err := os.Hostname()
+	if err != nil {
+		hostName = "cilium"
+	}
+
+	console := term.NewTerminal(stdReadWriter, hostName+"> ")
 	printShellGreeting(console)
 
 	for {


### PR DESCRIPTION
Use the name of the node as the prompt in cilium-dbg shell to make it easy to figure out to which node you connected:
```
  $ kubectl exec -it -n kube-system ds/cilium -- cilium-dbg shell
  ...
  kind-control-plane>
```
