### PR TITLE
health: Periodically log degraded health

### DIFF
--- a/pkg/hive/health/logger.go
+++ b/pkg/hive/health/logger.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package health
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/cilium/cilium/pkg/hive/health/types"
+	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+)
+
+const (
+	healthLoggerInterval = 10 * time.Minute
+)
+
+func registerHealthLogger(jg job.Group, p healthLoggerParams) {
+	hl := &healthLogger{
+		healthLoggerParams: p,
+		prevDegraded:       map[types.HealthID]types.Status{},
+	}
+	jg.Add(
+		job.Timer(
+			"health-logger",
+			hl.report,
+			10*time.Minute,
+		),
+	)
+}
+
+type healthLoggerParams struct {
+	cell.In
+
+	Log         *slog.Logger
+	DB          *statedb.DB
+	StatusTable statedb.Table[types.Status]
+}
+
+// logger periodically reports degraded modules in logs and reports the
+// recovery back to normal.
+type healthLogger struct {
+	healthLoggerParams
+
+	prevDegraded map[types.HealthID]types.Status
+	since        map[types.HealthID]time.Time
+}
+
+func (l *healthLogger) report(ctx context.Context) error {
+	txn := l.DB.ReadTxn()
+
+	// Grab all degraded statuses
+	degraded := map[types.HealthID]types.Status{}
+	for s := range l.StatusTable.List(txn, LevelIndex.Query(types.LevelDegraded)) {
+		degraded[s.ID.HealthID()] = s
+	}
+
+	// Remove existing statuses from [degraded] and add the no longer degraded statuses
+	// to [recovered]. This leaves only newly degraded statuses to [degraded].
+	recovered := map[types.HealthID]types.Status{}
+	for id, s := range l.prevDegraded {
+		newStatus, found := degraded[id]
+		if !found {
+			delete(l.prevDegraded, id)
+			recovered[id] = s
+		} else if s.Updated == newStatus.Updated {
+			l.prevDegraded[id] = s
+			delete(degraded, id)
+		}
+	}
+	for id, s := range degraded {
+		l.since[id] = s.Updated
+		l.prevDegraded[id] = s
+	}
+
+	// If there are no newly degraded statuses nor any recovered statuses then nothing has
+	// changed since last time.
+	if len(degraded) == 0 && len(recovered) == 0 {
+		return nil
+	}
+
+	// TODO: Or should this be a single call to report health and have everything in attributes?
+	l.Log.Info("--- Module health update ---")
+	for id, s := range l.prevDegraded {
+		l.Log.Warn("Degraded", "id", s.ID, "message", s.Message, "error", s.Error, "since", time.Since(l.since[id]))
+	}
+	for id, oldStatus := range recovered {
+		newStatus, _, _ := l.StatusTable.Get(txn, PrimaryIndex.Query(id))
+		l.Log.Info("Recovered",
+			"id", id,
+			"message", newStatus.Message,
+			"old-message", oldStatus.Message,
+			"old-error", oldStatus.Error,
+			"duration", time.Since(l.since[id]))
+		delete(l.since, id)
+	}
+
+	return nil
+}

--- a/pkg/hive/health/logger_test.go
+++ b/pkg/hive/health/logger_test.go
@@ -1,0 +1,100 @@
+package health
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/hive/health/types"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func TestHealthLogger(t *testing.T) {
+	now := time.Now
+	t0 := time.Date(2000, 1, 1, 10, 30, 0, 0, time.UTC)
+	time.Now = func() time.Time {
+		return t0
+	}
+	since := time.Since
+	time.Since = func(t time.Time) time.Duration {
+		return t0.Sub(t)
+	}
+	t.Cleanup(func() { time.Now = now; time.Since = since })
+	opts := &slog.HandlerOptions{
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	}
+	var buf strings.Builder
+	log := slog.New(slog.NewTextHandler(&buf, opts))
+
+	db := statedb.New()
+	tbl, err := newTablesPrivate(db)
+	require.NoError(t, err)
+
+	hl := &healthLogger{
+		healthLoggerParams: healthLoggerParams{Log: log, DB: db, StatusTable: tbl},
+		prevDegraded:       map[types.HealthID]types.Status{},
+		since:              map[types.HealthID]time.Time{},
+	}
+
+	// With empty table report writes nothing.
+	hl.report(context.TODO())
+	require.Equal(t, "", buf.String())
+
+	txn := db.WriteTxn(tbl)
+	status := types.Status{
+		ID:      types.Identifier{Module: []string{"foo", "bar"}, Component: []string{"baz"}},
+		Level:   types.LevelDegraded,
+		Message: "oh no",
+		Error:   "some error",
+		LastOK:  t0.Add(-2 * time.Minute),
+		Updated: t0.Add(-time.Minute),
+		Count:   1,
+	}
+	tbl.Insert(txn, status)
+	txn.Commit()
+
+	// With degraded status we'll get an health update
+	hl.report(context.TODO())
+	require.Equal(t,
+		"level=INFO msg=\"--- Module health update ---\"\n"+
+			"level=WARN msg=Degraded id=foo.bar.baz message=\"oh no\" error=\"some error\" since=1m0s\n",
+		buf.String())
+	buf.Reset()
+
+	// With no changes to statuses nothing is logged.
+	hl.report(context.TODO())
+	require.Equal(t, "", buf.String())
+
+	// Going back to OK will report recovery.
+	status.Level = types.LevelOK
+	status.Message = "all OK"
+	status.Error = ""
+	status.LastOK = t0
+	status.Updated = t0
+	txn = db.WriteTxn(tbl)
+	tbl.Insert(txn, status)
+	txn.Commit()
+	hl.report(context.TODO())
+	require.Equal(t,
+		"level=INFO msg=\"--- Module health update ---\"\n"+
+			"level=INFO msg=Recovered id=foo.bar.baz message=\"all OK\" old-message=\"oh no\" old-error=\"some error\" duration=1m0s\n",
+		buf.String())
+	buf.Reset()
+
+	// With no changes to statuses nothing is logged.
+	hl.report(context.TODO())
+	require.Equal(t, "", buf.String())
+
+	// As everything has recovered there should be no internal state anymore.
+	require.Empty(t, hl.prevDegraded)
+	require.Empty(t, hl.since)
+}


### PR DESCRIPTION
Log degraded modules and the recovery of degraded health periodically:
```
  level=INFO msg="--- Module health update ---"
  level=WARN msg=Degraded id=foo.bar.baz message="oh no" error="some error" since=1m0s
  level=WARN msg=Degraded id=quux message="fail" error="quux error" since=3m0s
```

After the degraded module goes back to either OK or Stopped we would log:
```
  level=INFO msg="--- Module health update ---"
  level=INFO msg=Recovered id=foo.bar.baz message="all OK" old-message="oh no" old-error="some error" duration=11m1s
  level=WARN msg=Degraded id=quux message="fail" error="quux error" since=13m1s
```

Questions:
- Should this be a single log record with all the details as attributes?
- How often should this update happen?
- What information to include?