### PR TITLE
Documentation: Add test scripts sections to Hive and StateDB docs

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -391,6 +391,7 @@ hostns
 hostonlyifs
 hostscope
 hq
+html
 http
 httpbin
 httpd
@@ -700,6 +701,7 @@ runnable
 runtimes
 sandboxing
 scalable
+scripttest
 sctl
 seccomp
 secretName
@@ -766,6 +768,7 @@ templating
 terminatingTLS
 terminationGracePeriodSeconds
 testability
+testdata
 testsuite
 testutils
 tetragon
@@ -789,6 +792,7 @@ transpiling
 tsne
 tunings
 tunnelProtocol
+txtar
 ubuntu
 udp
 ui

--- a/contrib/examples/script/example.go
+++ b/contrib/examples/script/example.go
@@ -1,0 +1,99 @@
+package script
+
+import (
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/cilium/hive"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/script"
+	"github.com/spf13/pflag"
+)
+
+// Cell defines our example module that provides the [Example] object
+// and script commands to interact with it.
+var Cell = cell.Module(
+	"example",
+	"Example module",
+
+	cell.Provide(
+		New,
+		ExampleCommands,
+	),
+)
+
+type Example struct {
+	log   *slog.Logger
+	count atomic.Int32
+}
+
+func New(log *slog.Logger) *Example {
+	return &Example{log: log}
+}
+
+func (e *Example) SayHello(name, greeting string) string {
+	e.log.Info("SayHello() called", "name", name, "greeting", greeting)
+	e.count.Add(1)
+	return fmt.Sprintf("%s %s\n", greeting, name)
+}
+
+func ExampleCommands(e *Example) hive.ScriptCmdsOut {
+	return hive.NewScriptCmds(map[string]script.Cmd{
+		// example/hello command says a greeting to the stdout buffer.
+		"example/hello": script.Command(
+			script.CmdUsage{
+				Summary: "Say hello",
+				Args:    "name",
+				Flags: func(fs *pflag.FlagSet) {
+					fs.String("greeting", "Hello,", "Greeting to use")
+				},
+			},
+
+			// Define the function for executing the command.  The function takes
+			// [script.State] that provides logging, flags and utilities, and the
+			// command arguments that are left over from parsing [CmdUsage.Flags].
+			//
+			// The function can either directly execute the command and return a
+			// nil [script.WaitFunc] or if the command should run in the background
+			// ([script.CmdUsage.Async] is true) or the if the command needs to write
+			// to stdout/stderr buffers, then a [script.WaitFunc] should be returned.
+			//
+			// It is preferable to return output in stdout and not Logf'd so it
+			// can be matched against.  In "cilium-dbg shell" the output looks the
+			// same regardless of whether Logf() or stdout is used (the "[stdout]"
+			// banner is stripped).
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) != 1 {
+					return nil, fmt.Errorf("%w: expected name", script.ErrUsage)
+				}
+				name := args[0]
+				return func(s *script.State) (stdout, stderr string, err error) {
+					greeting, err := s.Flags.GetString("greeting")
+					if err != nil {
+						return "", "", err
+					}
+					// In addition to [stdout] and [stderr] the command can also write to
+					// a separate log buffer. The logs however are not matchable in tests.
+					s.Logf("calling SayHello(%s, %s)\n", name, greeting)
+					stdout = e.SayHello(name, greeting)
+					return
+				}, nil
+			},
+		),
+
+		// example/counts command writes the number of times SayHello() has been called to
+		// stdout.
+		"example/counts": script.Command(
+			script.CmdUsage{
+				Summary: "Show the call counts of the example module",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				return func(s *script.State) (stdout, stderr string, err error) {
+					stdout = fmt.Sprintf("%d SayHello()\n", e.count.Load())
+					return
+				}, nil
+			},
+		),
+	})
+}

--- a/contrib/examples/script/example_test.go
+++ b/contrib/examples/script/example_test.go
@@ -1,0 +1,60 @@
+package script
+
+import (
+	"context"
+	"maps"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScript(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	// Run the test scripts in parallel using the [ctx] defined above. This
+	// gives each test script 5 seconds to complete. Without a context that
+	// times out we would default to the 10 minute test timeout. Choose a
+	// timeout that is suitable large for your tests that has enough buffer,
+	// but still makes a good feedback cycle when working on new or failing
+	// tests.
+	scripttest.Test(
+		t,
+		ctx,
+		func(t testing.TB, args []string) *script.Engine {
+			log := hivetest.Logger(t)
+
+			// Define a "test" hive consisting of the cell being tested and
+			// its dependencies.
+			h := hive.New(
+				Cell,
+
+				// dependencies of [Cell] would go here.
+			)
+			flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+			h.RegisterFlags(flags)
+
+			// Gather the commands provided by cells in the hive [h] and add
+			// the default script commands.
+			cmds, err := h.ScriptCommands(log)
+			require.NoError(t, err, "ScriptCommands")
+			maps.Insert(cmds, maps.All(script.DefaultCmds()))
+
+			// Stop the hive automatically after the test is complete.
+			t.Cleanup(func() { h.Stop(log, context.Background()) })
+
+			// Return the engine for executing the test scripts.
+			return &script.Engine{
+				Cmds: cmds,
+			}
+		},
+		[]string{},         // Environment
+		"testdata/*.txtar", // Scripts to execute
+	)
+}

--- a/contrib/examples/script/testdata/example.txtar
+++ b/contrib/examples/script/testdata/example.txtar
@@ -1,0 +1,29 @@
+#! --enable-example=true
+# ^ an (optional) shebang can be used to configure cells
+
+# This is a comment that starts a section of commands
+echo 'hello'
+
+# The test hive has not been started yet, let's start it!
+hive/start
+
+# Cells can provide custom commands
+example/hello foo
+stdout 'Hello, foo'
+
+# Check that call count equals 1
+example/counts
+stdout '1 SayHello()'
+
+# The file 'foo' should not be the same as 'bar'
+! cmp foo bar
+
+# The 'break' command breaks into an interactive prompt.
+# (commented out to not break the test)
+# break
+
+-- foo --
+foo
+
+-- bar --
+bar


### PR DESCRIPTION
This adds test script sections to the Hive and StateDB docs.