### PR TITLE
bpf: enable usage of BPF ring buffer

### DIFF
--- a/bpf/include/bpf/helpers.h
+++ b/bpf/include/bpf/helpers.h
@@ -113,3 +113,7 @@ static inline int try_set_retval(int retval __maybe_unused)
 }
 
 static long BPF_FUNC(loop, __u32 nr_loops, void *callback_fn, void *callback_ctx, __u64 flags);
+
+static void *BPF_FUNC(ringbuf_reserve, void *ringbuf, __u64 size, __u64 flags);
+static void BPF_FUNC(ringbuf_submit, void *data, __u64 flags);
+static void BPF_FUNC(ringbuf_discard, void *data, __u64 flags);

--- a/pkg/ebpf/map.go
+++ b/pkg/ebpf/map.go
@@ -29,6 +29,7 @@ const (
 	LPMTrie    = ciliumebpf.LPMTrie
 	LRUHash    = ciliumebpf.LRUHash
 	LRUCPUHash = ciliumebpf.LRUCPUHash
+	RingBuf    = ciliumebpf.RingBuf
 
 	PinNone   = ciliumebpf.PinNone
 	PinByName = ciliumebpf.PinByName


### PR DESCRIPTION
Add the RingBuf constant definition to cilium/ebpf and add necessary BPF helpers declarations to bpf/include/bpf/helpers.h. This will let developers to use the BPF ring buffer map from the BPF side and from the Go packages.

```release-note
Allow cilium to use eBPF ring buffers from Go and eBPF sides
```