### PR TITLE
pkg/hive/health: Set level to LevelStopped when stopping

### DIFF
--- a/operator/pkg/bgpv2/peer_test.go
+++ b/operator/pkg/bgpv2/peer_test.go
@@ -299,7 +299,7 @@ func TestDisablePeerConfigStatusReport(t *testing.T) {
 			return
 		}
 
-		assert.Equal(ct, healthTypes.Level(healthTypes.LevelOK), o.Level)
+		assert.Equal(ct, healthTypes.Level(healthTypes.LevelStopped), o.Level)
 		assert.Equal(ct, "Cleanup job is done successfully", o.Message)
 	}, time.Second*3, time.Millisecond*100)
 }

--- a/pkg/hive/health/provider.go
+++ b/pkg/hive/health/provider.go
@@ -139,6 +139,7 @@ func (p *provider) ForModule(mid cell.FullModuleID) cell.Health {
 			if !old.Stopped.IsZero() {
 				return fmt.Errorf("reporting for %q has been stopped", i)
 			}
+			old.Level = types.LevelStopped
 			old.Stopped = time.Now()
 			if _, _, err := p.statusTable.Insert(tx, old); err != nil {
 				return fmt.Errorf("stopping reporter - upsert status %s: %w", old, err)

--- a/pkg/hive/health/provider_test.go
+++ b/pkg/hive/health/provider_test.go
@@ -66,6 +66,7 @@ func TestProvider(t *testing.T) {
 			for _, s := range all {
 				if s.ID.String() == "foo.bar.zzz.xxx" {
 					assert.NotZero(s.Stopped)
+					assert.EqualValues(types.LevelStopped, s.Level)
 					continue
 				}
 				assert.Zero(s.Stopped)


### PR DESCRIPTION
Only the 'Stopped' timestamp was set when stopping and not the level. This made the 'db/show health' output quite confusing as it doesn't show the 'Stopped' timestamp and it was impossible to see whether a health status was marked stopped or not.