### PR TITLE
container: Clone before sorting in NewImmSet

### DIFF
--- a/pkg/container/immset.go
+++ b/pkg/container/immset.go
@@ -22,7 +22,7 @@ func NewImmSet[T cmp.Ordered](items ...T) ImmSet[T] {
 }
 
 func NewImmSetFunc[T any](compare func(T, T) int, items ...T) ImmSet[T] {
-	s := ImmSet[T]{items, compare, cmpToEqual(compare)}
+	s := ImmSet[T]{slices.Clone(items), compare, cmpToEqual(compare)}
 	slices.SortFunc(s.xs, s.cmp)
 	s.xs = slices.CompactFunc(s.xs, s.eq)
 	return s


### PR DESCRIPTION
If we pass a slice, e.g. "NewImmSet(xs...)", then the in-place sorting will mangle the "xs" slice which is not what one would expect.

Clone the items passed to NewImmSet, Insert and Delete as it's better to be safe than sorry.

NOTE:  Currently there were no users of ImmSet except pkg/loadbalancer/experimental and I'm dropping it from there as well. So no bugs possible due to this (except the one I just catched in pkg/loadbalancer/experimental...).