### PR TITLE
loadbalancer: Add LBMap pressure metrics

### DIFF
--- a/cilium-dbg/cmd/bpf_ct.go
+++ b/cilium-dbg/cmd/bpf_ct.go
@@ -16,6 +16,6 @@ var BPFCtCmd = &cobra.Command{
 }
 
 func init() {
-	ctmap.InitMapInfo(true, true, true)
+	ctmap.InitMapInfo(nil, true, true, true)
 	BPFCmd.AddCommand(BPFCtCmd)
 }

--- a/cilium-dbg/cmd/bpf_endpoint_list.go
+++ b/cilium-dbg/cmd/bpf_endpoint_list.go
@@ -26,7 +26,7 @@ var bpfEndpointListCmd = &cobra.Command{
 		common.RequireRootPrivilege("cilium bpf endpoint list")
 
 		bpfEndpointList := make(map[string][]string)
-		if err := lxcmap.LXCMap().Dump(bpfEndpointList); err != nil {
+		if err := lxcmap.LXCMap(nil).Dump(bpfEndpointList); err != nil {
 			os.Exit(1)
 		}
 

--- a/cilium-dbg/cmd/bpf_ipcache_delete.go
+++ b/cilium-dbg/cmd/bpf_ipcache_delete.go
@@ -47,7 +47,7 @@ var bpfIPCacheDeleteCmd = &cobra.Command{
 		ip := net.IP(prefix.Addr().AsSlice())
 		mask := net.CIDRMask(prefix.Bits(), 32)
 		key := ipcache.NewKey(ip, mask, clusterID)
-		if err := ipcache.IPCacheMap().Delete(&key); err != nil {
+		if err := ipcache.IPCacheMap(nil).Delete(&key); err != nil {
 			fmt.Fprintf(os.Stderr, "Error deleting entry %s: %v\n", key, err)
 			os.Exit(1)
 		}

--- a/cilium-dbg/cmd/bpf_ipcache_get.go
+++ b/cilium-dbg/cmd/bpf_ipcache_get.go
@@ -67,7 +67,7 @@ func init() {
 func dumpIPCache() map[string][]string {
 	bpfIPCache := make(map[string][]string)
 
-	if err := ipcache.IPCacheMap().Dump(bpfIPCache); err != nil {
+	if err := ipcache.IPCacheMap(nil).Dump(bpfIPCache); err != nil {
 		Fatalf("unable to dump IPCache: %s\n", err)
 	}
 

--- a/cilium-dbg/cmd/bpf_ipcache_list.go
+++ b/cilium-dbg/cmd/bpf_ipcache_list.go
@@ -32,7 +32,7 @@ var bpfIPCacheListCmd = &cobra.Command{
 		common.RequireRootPrivilege("cilium bpf ipcache list")
 
 		bpfIPCacheList := make(map[string][]string)
-		if err := ipcache.IPCacheMap().Dump(bpfIPCacheList); err != nil {
+		if err := ipcache.IPCacheMap(nil).Dump(bpfIPCacheList); err != nil {
 			fmt.Fprintf(os.Stderr, "error dumping contents of map: %s\n", err)
 			os.Exit(1)
 		}

--- a/cilium-dbg/cmd/bpf_ipcache_update.go
+++ b/cilium-dbg/cmd/bpf_ipcache_update.go
@@ -77,7 +77,7 @@ var bpfIPCacheUpdateCmd = &cobra.Command{
 		mask := net.CIDRMask(prefix.Bits(), 32)
 		key := ipcache.NewKey(ip, mask, clusterID)
 		value := ipcache.NewValue(identity, tunnelEndpoint, encryptKey, flags)
-		if err := ipcache.IPCacheMap().Update(&key, &value); err != nil {
+		if err := ipcache.IPCacheMap(nil).Update(&key, &value); err != nil {
 			fmt.Fprintf(os.Stderr, "Error updating entry %s: %v\n", key, err)
 			os.Exit(1)
 		}

--- a/cilium-dbg/cmd/bpf_ipmasq_list.go
+++ b/cilium-dbg/cmd/bpf_ipmasq_list.go
@@ -32,8 +32,8 @@ var bpfIPMasqListCmd = &cobra.Command{
 		// Here we try to open the maps as a hack to avoid going
 		// through a full API request to check the config options from
 		// the agent.
-		ipv4Needed := ipmasq.IPMasq4Map().Open() == nil
-		ipv6Needed := ipmasq.IPMasq6Map().Open() == nil
+		ipv4Needed := ipmasq.IPMasq4Map(nil).Open() == nil
+		ipv6Needed := ipmasq.IPMasq6Map(nil).Open() == nil
 		cidrs, err := (&ipmasq.IPMasqBPFMap{}).DumpForProtocols(ipv4Needed, ipv6Needed)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error dumping contents of map: %s\n", err)

--- a/cilium-dbg/cmd/bpf_lb_list.go
+++ b/cilium-dbg/cmd/bpf_lb_list.go
@@ -138,7 +138,7 @@ var bpfLBListCmd = &cobra.Command{
 		// initializing the Go object representing the map. We don't need to
 		// pass the correct sizes here because once the maps are opened, their
 		// size will be read.
-		lbmap.Init(lbmap.InitParams{IPv4: true, IPv6: true})
+		lbmap.Init(nil, lbmap.InitParams{IPv4: true, IPv6: true})
 
 		var firstTitle string
 		secondTitle := backendAddressTitle

--- a/cilium-dbg/cmd/bpf_nat_flush.go
+++ b/cilium-dbg/cmd/bpf_nat_flush.go
@@ -29,7 +29,7 @@ func init() {
 
 func flushNat() {
 	ipv4, ipv6 := getIpEnableStatuses()
-	ipv4Map, ipv6Map := nat.GlobalMaps(ipv4, ipv6, true)
+	ipv4Map, ipv6Map := nat.GlobalMaps(nil, ipv4, ipv6, true)
 
 	for _, m := range []*nat.Map{ipv4Map, ipv6Map} {
 		if m == nil {

--- a/cilium-dbg/cmd/bpf_nat_list.go
+++ b/cilium-dbg/cmd/bpf_nat_list.go
@@ -27,7 +27,7 @@ var bpfNatListCmd = &cobra.Command{
 		common.RequireRootPrivilege("cilium bpf nat list")
 		if len(args) == 0 {
 			ipv4, ipv6 := getIpEnableStatuses()
-			ipv4Map, ipv6Map := nat.GlobalMaps(ipv4, ipv6, true)
+			ipv4Map, ipv6Map := nat.GlobalMaps(nil, ipv4, ipv6, true)
 			globalMaps := make([]nat.NatMap, 2)
 			globalMaps[0] = ipv4Map
 			globalMaps[1] = ipv6Map

--- a/cilium-dbg/cmd/bpf_vtep_delete.go
+++ b/cilium-dbg/cmd/bpf_vtep_delete.go
@@ -30,7 +30,7 @@ var bpfVtepDeleteCmd = &cobra.Command{
 
 		key := vtep.NewKey(vcidr.IP)
 
-		if err := vtep.VtepMap().Delete(&key); err != nil {
+		if err := vtep.VtepMap(nil).Delete(&key); err != nil {
 			Fatalf("error deleting contents of map: %s\n", err)
 		}
 	},

--- a/cilium-dbg/cmd/bpf_vtep_list.go
+++ b/cilium-dbg/cmd/bpf_vtep_list.go
@@ -32,7 +32,7 @@ var bpfVtepListCmd = &cobra.Command{
 		common.RequireRootPrivilege("cilium bpf vtep list")
 
 		bpfVtepList := make(map[string][]string)
-		if err := vtep.VtepMap().Dump(bpfVtepList); err != nil {
+		if err := vtep.VtepMap(nil).Dump(bpfVtepList); err != nil {
 			fmt.Fprintf(os.Stderr, "error dumping contents of map: %s\n", err)
 			os.Exit(1)
 		}

--- a/cilium-dbg/cmd/bpf_vtep_update.go
+++ b/cilium-dbg/cmd/bpf_vtep_update.go
@@ -45,7 +45,7 @@ var bpfVtepUpdateCmd = &cobra.Command{
 			Fatalf("Unable to parse vtep mac '%s'", args[2])
 		}
 
-		if err := vtep.UpdateVTEPMapping(logging.DefaultSlogLogger, vcidr, vip, vmac); err != nil {
+		if err := vtep.UpdateVTEPMapping(logging.DefaultSlogLogger, nil, vcidr, vip, vmac); err != nil {
 			fmt.Fprintf(os.Stderr, "error updating contents of map: %s\n", err)
 			os.Exit(1)
 		}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1464,6 +1464,7 @@ type daemonParams struct {
 	Logger              *slog.Logger
 	Lifecycle           cell.Lifecycle
 	Health              cell.Health
+	MetricsRegistry     *metrics.Registry
 	Clientset           k8sClient.Clientset
 	WGAgent             *wireguard.Agent
 	LocalNodeStore      *node.LocalNodeStore
@@ -1692,7 +1693,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 	}
 
 	if option.Config.EnableIPMasqAgent {
-		ipmasqAgent, err := ipmasq.NewIPMasqAgent(option.Config.IPMasqAgentConfigPath)
+		ipmasqAgent, err := ipmasq.NewIPMasqAgent(d.metricsRegistry, option.Config.IPMasqAgentConfigPath)
 		if err != nil {
 			return fmt.Errorf("failed to create ipmasq agent: %w", err)
 		}

--- a/pkg/auth/authmap_cache.go
+++ b/pkg/auth/authmap_cache.go
@@ -26,11 +26,11 @@ type authMapCache struct {
 	pressureGauge     *metrics.GaugeWithThreshold
 }
 
-func newAuthMapCache(logger *slog.Logger, authMap authMap) *authMapCache {
+func newAuthMapCache(logger *slog.Logger, registry *metrics.Registry, authMap authMap) *authMapCache {
 	var pressureGauge *metrics.GaugeWithThreshold
 
 	if metrics.BPFMapPressure {
-		pressureGauge = metrics.NewBPFMapPressureGauge(authmap.MapName, 0)
+		pressureGauge = registry.NewBPFMapPressureGauge(authmap.MapName, 0)
 	}
 	return &authMapCache{
 		logger:        logger,

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/maps/authmap"
+	"github.com/cilium/cilium/pkg/metrics"
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/signal"
@@ -81,10 +82,11 @@ type MeshAuthConfig interface {
 type authManagerParams struct {
 	cell.In
 
-	Logger    *slog.Logger
-	Lifecycle cell.Lifecycle
-	JobGroup  job.Group
-	Health    cell.Health
+	Logger          *slog.Logger
+	Lifecycle       cell.Lifecycle
+	JobGroup        job.Group
+	Health          cell.Health
+	MetricsRegistry *metrics.Registry
 
 	Config       config
 	AuthMap      authmap.Map
@@ -107,7 +109,7 @@ func registerAuthManager(params authManagerParams) (*AuthManager, error) {
 	// Instantiate & wire auth components
 
 	mapWriter := newAuthMapWriter(params.Logger, params.AuthMap)
-	mapCache := newAuthMapCache(params.Logger, mapWriter)
+	mapCache := newAuthMapCache(params.Logger, params.MetricsRegistry, mapWriter)
 
 	mgr, err := newAuthManager(params.Logger, params.AuthHandlers, mapCache, params.NodeIDHandler, params.Config.MeshAuthSignalBackoffDuration)
 	if err != nil {

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -328,21 +328,25 @@ func (m *Map) WithGroupName(group string) *Map {
 // WithPressureMetricThreshold enables the tracking of a metric that measures
 // the pressure of this map. This metric is only reported if over the
 // threshold.
-func (m *Map) WithPressureMetricThreshold(threshold float64) *Map {
+func (m *Map) WithPressureMetricThreshold(registry *metrics.Registry, threshold float64) *Map {
+	if registry == nil {
+		return m
+	}
+
 	// When pressure metric is enabled, we keep track of map keys in cache
 	if m.cache == nil {
 		m.cache = map[string]*cacheEntry{}
 	}
 
-	m.pressureGauge = metrics.NewBPFMapPressureGauge(m.NonPrefixedName(), threshold)
+	m.pressureGauge = registry.NewBPFMapPressureGauge(m.NonPrefixedName(), threshold)
 
 	return m
 }
 
 // WithPressureMetric enables tracking and reporting of this map pressure with
 // threshold 0.
-func (m *Map) WithPressureMetric() *Map {
-	return m.WithPressureMetricThreshold(0.0)
+func (m *Map) WithPressureMetric(registry *metrics.Registry) *Map {
+	return m.WithPressureMetricThreshold(registry, 0.0)
 }
 
 // UpdatePressureMetricWithSize updates map pressure metric using the given map size.

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -1076,6 +1076,10 @@ func TestBatchIterator(t *testing.T) {
 		assert.Len(t, ks, int(size))
 		assert.Len(t, vs, int(size))
 		assert.Equal(t, size, count)
+
+		count, err := m.BatchCount()
+		require.NoError(t, err, "BatchCount")
+		assert.Equal(t, size, count)
 	}
 
 	for _, test := range []struct {

--- a/pkg/bpf/metrics.go
+++ b/pkg/bpf/metrics.go
@@ -40,7 +40,7 @@ type mapPressureMetricsOps interface {
 //	cell.Invoke(
 //	  bpf.RegisterTablePressureMetricsJob[MyObj, myBPFMap],
 //	)
-func RegisterTablePressureMetricsJob[Obj any, Map mapPressureMetricsOps](g job.Group, db *statedb.DB, table statedb.Table[Obj], m Map) {
+func RegisterTablePressureMetricsJob[Obj any, Map mapPressureMetricsOps](g job.Group, registry *metrics.Registry, db *statedb.DB, table statedb.Table[Obj], m Map) {
 	name := m.NonPrefixedName()
 	var pressureGauge *metrics.GaugeWithThreshold
 	g.Add(job.Timer(
@@ -52,7 +52,7 @@ func RegisterTablePressureMetricsJob[Obj any, Map mapPressureMetricsOps](g job.G
 			}
 
 			if pressureGauge == nil {
-				pressureGauge = metrics.NewBPFMapPressureGauge(name, 0.0)
+				pressureGauge = registry.NewBPFMapPressureGauge(name, 0.0)
 			}
 
 			txn := db.ReadTxn()

--- a/pkg/ciliumenvoyconfig/script_test.go
+++ b/pkg/ciliumenvoyconfig/script_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maglev"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
@@ -72,6 +73,7 @@ func TestScript(t *testing.T) {
 			client.FakeClientCell,
 			daemonk8s.ResourcesCell,
 			daemonk8s.TablesCell,
+			metrics.Cell,
 			maglev.Cell,
 			cell.Config(CECConfig{}),
 			cell.Config(envoy.ProxyConfig{}),

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maglev"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	nodemanager "github.com/cilium/cilium/pkg/node/manager"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -95,6 +96,7 @@ func TestScript(t *testing.T) {
 			cni.Cell,
 			ipset.Cell,
 			dial.ServiceResolverCell,
+			metrics.Cell,
 
 			cell.Config(cmtypes.DefaultClusterInfo),
 			cell.Invoke(cmtypes.ClusterInfo.InitClusterIDMax, cmtypes.ClusterInfo.Validate),

--- a/pkg/datapath/ipcache/cell.go
+++ b/pkg/datapath/ipcache/cell.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheMap "github.com/cilium/cilium/pkg/maps/ipcache"
+	"github.com/cilium/cilium/pkg/metrics"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 )
 
@@ -19,7 +20,7 @@ var Cell = cell.Module(
 
 	cell.Provide(NewListener),
 	cell.ProvidePrivate(
-		func() Map { return ipcacheMap.IPCacheMap() },
+		func(reg *metrics.Registry) Map { return ipcacheMap.IPCacheMap(reg) },
 		func(agent monitorAgent.Agent) monitorNotify { return agent },
 	),
 

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -158,8 +158,8 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 	k.sysctl = sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
 
 	lc := hivetest.Lifecycle(t)
-	policyMap4 := egressmap.CreatePrivatePolicyMap4(lc, egressmap.DefaultPolicyConfig)
-	policyMap6 := egressmap.CreatePrivatePolicyMap6(lc, egressmap.DefaultPolicyConfig)
+	policyMap4 := egressmap.CreatePrivatePolicyMap4(lc, nil, egressmap.DefaultPolicyConfig)
+	policyMap6 := egressmap.CreatePrivatePolicyMap6(lc, nil, egressmap.DefaultPolicyConfig)
 
 	k.manager, err = newEgressGatewayManager(Params{
 		Logger:            logger,

--- a/pkg/endpointmanager/callback_test.go
+++ b/pkg/endpointmanager/callback_test.go
@@ -20,7 +20,7 @@ const numberOfEndpointPolicies = 10
 
 func Test_PolicyUpdateCallback(t *testing.T) {
 	logger := hivetest.Logger(t)
-	mgr := New(logger, &dummyEpSyncher{}, nil, nil, nil)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	called := int32(0)
 	updateFunc := func(idsRegen *set.Set[identity.NumericIdentity], incremental bool) error {
 		atomic.AddInt32(&called, 1)

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -208,7 +208,7 @@ type endpointManagerOut struct {
 func newDefaultEndpointManager(p endpointManagerParams) endpointManagerOut {
 	checker := endpoint.CheckHealth
 
-	mgr := New(p.Logger, p.EPSynchronizer, p.LocalNodeStore, p.Health, p.MonitorAgent)
+	mgr := New(p.Logger, p.MetricsRegistry, p.EPSynchronizer, p.LocalNodeStore, p.Health, p.MonitorAgent)
 	if p.Config.EndpointGCInterval > 0 {
 		ctx, cancel := context.WithCancel(context.Background())
 		p.Lifecycle.Append(cell.Hook{

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -33,7 +33,7 @@ func TestMarkAndSweep(t *testing.T) {
 	logger := hivetest.Logger(t)
 	s := setupEndpointManagerSuite(t)
 	// Open-code WithPeriodicGC() to avoid running the controller
-	mgr := New(logger, &dummyEpSyncher{}, nil, nil, nil)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	mgr.checkHealth = fakeCheck
 	mgr.deleteEndpoint = endpointDeleteFunc(mgr.waitEndpointRemoved)
 

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -110,7 +110,7 @@ type endpointManager struct {
 type endpointDeleteFunc func(*endpoint.Endpoint, endpoint.DeleteConfig) []error
 
 // New creates a new endpointManager.
-func New(logger *slog.Logger, epSynchronizer EndpointResourceSynchronizer, lns *node.LocalNodeStore, health cell.Health, monitorAgent monitoragent.Agent) *endpointManager {
+func New(logger *slog.Logger, registry *metrics.Registry, epSynchronizer EndpointResourceSynchronizer, lns *node.LocalNodeStore, health cell.Health, monitorAgent monitoragent.Agent) *endpointManager {
 	mgr := endpointManager{
 		logger:                       logger,
 		health:                       health,
@@ -126,7 +126,7 @@ func New(logger *slog.Logger, epSynchronizer EndpointResourceSynchronizer, lns *
 		policyUpdateCallbackDetails:  newPolicyUpdateCallbackDetails(),
 	}
 	mgr.deleteEndpoint = mgr.removeEndpoint
-	mgr.policyMapPressure = newPolicyMapPressure(logger)
+	mgr.policyMapPressure = newPolicyMapPressure(logger, registry)
 	return &mgr
 }
 

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -386,7 +386,7 @@ func TestLookup(t *testing.T) {
 			var ep *endpoint.Endpoint
 			var err error
 			logger := hivetest.Logger(t)
-			mgr := New(logger, &dummyEpSyncher{}, nil, nil, nil)
+			mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 			if tt.cm != nil {
 				ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, tt.cm)
 				require.NoErrorf(t, err, "Test Name: %s", tt.name)
@@ -412,7 +412,7 @@ func TestLookupCiliumID(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	model := newTestEndpointModel(2, endpoint.StateReady)
-	mgr := New(logger, &dummyEpSyncher{}, nil, nil, nil)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(t, err)
 
@@ -487,7 +487,7 @@ func TestLookupCNIAttachmentID(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 
 	logger := hivetest.Logger(t)
-	mgr := New(logger, &dummyEpSyncher{}, nil, nil, nil)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, &apiv1.EndpointChangeRequest{
 		ContainerID:            "foo",
 		ContainerInterfaceName: "bar",
@@ -509,7 +509,7 @@ func TestLookupIPv4(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 	logger := hivetest.Logger(t)
 
-	mgr := New(logger, &dummyEpSyncher{}, nil, nil, nil)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	model := newTestEndpointModel(4, endpoint.StateReady)
 	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(t, err)
@@ -582,7 +582,7 @@ func TestLookupIPv4(t *testing.T) {
 func TestLookupCEPName(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 	logger := hivetest.Logger(t)
-	mgr := New(logger, &dummyEpSyncher{}, nil, nil, nil)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	type args struct {
 		podName string
 	}
@@ -710,7 +710,7 @@ func TestUpdateReferences(t *testing.T) {
 		ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, &tt.cm)
 		require.NoErrorf(t, err, "Test Name: %s", tt.name)
 		logger := hivetest.Logger(t)
-		mgr := New(logger, &dummyEpSyncher{}, nil, nil, nil)
+		mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 
 		err = mgr.expose(ep)
 		require.NoErrorf(t, err, "Test Name: %s", tt.name)
@@ -741,7 +741,7 @@ func TestUpdateReferences(t *testing.T) {
 func TestRemove(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 	logger := hivetest.Logger(t)
-	mgr := New(logger, &dummyEpSyncher{}, nil, nil, nil)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	model := newTestEndpointModel(7, endpoint.StateReady)
 	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(t, err)
@@ -787,7 +787,7 @@ func TestRemove(t *testing.T) {
 func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
 	logger := hivetest.Logger(t)
-	mgr := New(logger, &dummyEpSyncher{}, nil, nil, nil)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	model := newTestEndpointModel(1, endpoint.StateReady)
 	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model)
 	require.NoError(t, err)
@@ -920,7 +920,7 @@ func TestMissingNodeLabelsUpdate(t *testing.T) {
 	// Initialize label filter config.
 	labelsfilter.ParseLabelPrefixCfg(logger, nil, nil, "")
 	s := setupEndpointManagerSuite(t)
-	mgr := New(logger, &dummyEpSyncher{}, nil, nil, nil)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	hostEPID := uint16(17)
 
 	// Initialize the local node watcher before the host endpoint is created.
@@ -957,7 +957,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 	// Initialize label filter config.
 	labelsfilter.ParseLabelPrefixCfg(logger, []string{"k8s:!ignore1", "k8s:!ignore2"}, nil, "")
 	s := setupEndpointManagerSuite(t)
-	mgr := New(logger, &dummyEpSyncher{}, nil, nil, nil)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	hostEPID := uint16(17)
 	type args struct {
 		oldLabels, newLabels map[string]string

--- a/pkg/endpointmanager/policymap_pressure.go
+++ b/pkg/endpointmanager/policymap_pressure.go
@@ -41,13 +41,13 @@ func (p *policyMapPressure) Remove(id uint16) {
 
 var policyMapPressureMinInterval = 10 * time.Second
 
-func newPolicyMapPressure(logger *slog.Logger) *policyMapPressure {
+func newPolicyMapPressure(logger *slog.Logger, registry *metrics.Registry) *policyMapPressure {
 	if !metrics.BPFMapPressure {
 		return nil
 	}
 
 	p := &policyMapPressure{logger: logger}
-	p.gauge = metrics.NewBPFMapPressureGauge(policymap.MapName+"*", policymap.PressureMetricThreshold)
+	p.gauge = registry.NewBPFMapPressureGauge(policymap.MapName+"*", policymap.PressureMetricThreshold)
 	p.current = make(map[uint16]float64)
 
 	var err error

--- a/pkg/endpointmanager/policymap_pressure_test.go
+++ b/pkg/endpointmanager/policymap_pressure_test.go
@@ -17,7 +17,7 @@ import (
 func TestPolicyMapPressure(t *testing.T) {
 	assert := assert.New(t)
 	policyMapPressureMinInterval = 0
-	p := newPolicyMapPressure(hivetest.Logger(t))
+	p := newPolicyMapPressure(hivetest.Logger(t), nil)
 	p.gauge = &fakeGauge{}
 	assert.Equal(float64(0), p.gauge.(*fakeGauge).Load())
 	p.Update(endpoint.PolicyMapPressureEvent{

--- a/pkg/fqdn/bootstrap/fqdn_bootstrapper_test.go
+++ b/pkg/fqdn/bootstrap/fqdn_bootstrapper_test.go
@@ -66,7 +66,7 @@ func setupDaemonFQDNSuite(tb testing.TB) *DaemonFQDNSuite {
 	ds := &DaemonFQDNSuite{}
 	d := &fqdnProxyBootstrapper{}
 	d.policyRepo = policy.NewPolicyRepository(logger, nil, nil, nil, nil, api.NewPolicyMetricsNoop())
-	d.endpointManager = endpointmanager.New(logger, &dummyEpSyncher{}, nil, nil, nil)
+	d.endpointManager = endpointmanager.New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 	d.ipcache = ipcache.NewIPCache(&ipcache.Configuration{
 		Context:           context.TODO(),
 		Logger:            logger,

--- a/pkg/fqdn/service/service_test.go
+++ b/pkg/fqdn/service/service_test.go
@@ -81,7 +81,7 @@ func TestFQDNDataServer(t *testing.T) {
 					cell.Config(defaultConfig),
 					cell.Provide(
 						func(logger *slog.Logger) endpointmanager.EndpointManager {
-							return endpointmanager.New(logger, &dummyEpSyncher{}, nil, nil, nil)
+							return endpointmanager.New(logger, nil, &dummyEpSyncher{}, nil, nil, nil)
 						},
 
 						func(em endpointmanager.EndpointManager, logger *slog.Logger) *ipcache.IPCache {
@@ -196,7 +196,7 @@ func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) 
 }
 
 func TestHandleIPUpsert(t *testing.T) {
-	endptMgr := endpointmanager.New(hivetest.Logger(t), &dummyEpSyncher{}, nil, nil, nil)
+	endptMgr := endpointmanager.New(hivetest.Logger(t), nil, &dummyEpSyncher{}, nil, nil, nil)
 
 	// create a new server instance
 	server := NewServer(endptMgr, nil, 1234, hivetest.Logger(t), nil)

--- a/pkg/ipmasq/ipmasq.go
+++ b/pkg/ipmasq/ipmasq.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ipmasq"
+	"github.com/cilium/cilium/pkg/metrics"
 )
 
 var (
@@ -99,8 +100,8 @@ type IPMasqAgent struct {
 	handlerFinished        chan struct{}
 }
 
-func NewIPMasqAgent(configPath string) (*IPMasqAgent, error) {
-	return newIPMasqAgent(configPath, &ipmasq.IPMasqBPFMap{})
+func NewIPMasqAgent(reg *metrics.Registry, configPath string) (*IPMasqAgent, error) {
+	return newIPMasqAgent(configPath, &ipmasq.IPMasqBPFMap{MetricsRegistry: reg})
 }
 
 func newIPMasqAgent(configPath string, ipMasqMap IPMasqMap) (*IPMasqAgent, error) {

--- a/pkg/loadbalancer/cell/cell_test.go
+++ b/pkg/loadbalancer/cell/cell_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/maglev"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
@@ -31,6 +32,7 @@ func TestCell(t *testing.T) {
 		daemonk8s.TablesCell,
 		maglev.Cell,
 		node.LocalNodeStoreCell,
+		metrics.Cell,
 		Cell,
 		cell.Provide(source.NewSources),
 		cell.Provide(

--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -187,6 +187,11 @@ type UserConfig struct {
 	// EnableHealthCheckNodePort enables health checking of NodePort by
 	// cilium
 	EnableHealthCheckNodePort bool `mapstructure:"enable-health-check-nodeport"`
+
+	// LBPressureMetricsInterval sets the interval for updating the load-balancer BPF map
+	// pressure metrics. A batch lookup is performed for all maps periodically to count
+	// the number of elements that are then reported in the `bpf-map-pressure` metric.
+	LBPressureMetricsInterval time.Duration `mapstructure:"lb-pressure-metrics-interval"`
 }
 
 // ConfigCell provides the [Config] and [ExternalConfig] configurations.
@@ -292,6 +297,9 @@ func (def UserConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool(AlgorithmAnnotationName, def.AlgorithmAnnotation, "Enable service-level annotation for configuring BPF load balancing algorithm")
 
 	flags.Bool(EnableHealthCheckNodePortName, def.EnableHealthCheckNodePort, "Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set")
+
+	flags.Duration("lb-pressure-metrics-interval", def.LBPressureMetricsInterval, "Interval for reporting pressure metrics for load-balancing BPF maps. 0 disables reporting.")
+	flags.MarkHidden("lb-pressure-metrics-interval")
 }
 
 // NewConfig takes the user-provided configuration, validates and processes it to produce the final
@@ -429,10 +437,11 @@ func NewConfig(log *slog.Logger, userConfig UserConfig, deprecatedConfig Depreca
 }
 
 var DefaultUserConfig = UserConfig{
-	EnableExperimentalLB: true,
-	RetryBackoffMin:      50 * time.Millisecond,
-	RetryBackoffMax:      time.Minute,
-	LBMapEntries:         DefaultLBMapMaxEntries,
+	EnableExperimentalLB:      true,
+	RetryBackoffMin:           50 * time.Millisecond,
+	RetryBackoffMax:           time.Minute,
+	LBMapEntries:              DefaultLBMapMaxEntries,
+	LBPressureMetricsInterval: 5 * time.Minute,
 
 	LBServiceMapEntries:     0, // Uses [LBMapEntries] if zero
 	LBBackendMapEntries:     0, // ...

--- a/pkg/loadbalancer/healthserver/script_test.go
+++ b/pkg/loadbalancer/healthserver/script_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer/healthserver"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maglev"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
@@ -74,6 +75,7 @@ func TestScript(t *testing.T) {
 				client.FakeClientCell,
 				daemonk8s.ResourcesCell,
 				daemonk8s.TablesCell,
+				metrics.Cell,
 
 				lbcell.Cell,
 

--- a/pkg/loadbalancer/healthserver/testdata/healthserver.txtar
+++ b/pkg/loadbalancer/healthserver/testdata/healthserver.txtar
@@ -20,7 +20,7 @@ replace '$HEALTHPORT' $HEALTHPORT1 frontends.table
 replace '$HEALTHPORT' $HEALTHPORT1 backends.table
 
 # HealthServer's jobs should be reported in module health
-db/cmp --grep=^loadbalancer health health_no_service.table
+db/cmp --grep=^loadbalancer-healthserver health health_no_service.table
 
 # Add endpoints. This is done first to avoid non-determinismic backend
 # id allocation due to health server adding its own service and endpoints
@@ -31,7 +31,7 @@ db/cmp backends backends1.table
 
 # Add the service
 k8s/add service.yaml
-db/cmp --grep=^loadbalancer health health_with_service.table
+db/cmp --grep=^loadbalancer-healthserver health health_with_service.table
 db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table
@@ -105,27 +105,13 @@ primary: true
 devicename: test
 
 -- health_no_service.table --
-Module                                    Component                         Level   Message                    Error
-loadbalancer-healthserver                 job-control-loop                  OK      0 health servers running
-loadbalancer-reconciler                   job-reconcile                     OK      OK, 0 object(s)
-loadbalancer-reconciler                   job-refresh                       OK      Next refresh in 30m0s
-loadbalancer-reconciler                   job-start-reconciler              Stopped Started
-loadbalancer-reflectors.k8s-reflector     job-reflect-pods                  OK      Running
-loadbalancer-reflectors.k8s-reflector     job-reflect-services-endpoints    OK      Running
-loadbalancer-writer                       job-node-addr-reconciler          OK      Running
-loadbalancer-writer                       job-zone-watcher                  OK      Running
+Module                      Component                         Level   Message                    Error
+loadbalancer-healthserver   job-control-loop                  OK      0 health servers running
 
 -- health_with_service.table --
-Module                                    Component                         Level   Message                    Error
-loadbalancer-healthserver                 job-control-loop                  OK      1 health servers running
-loadbalancer-healthserver                 job-listener-40000                OK      Running
-loadbalancer-reconciler                   job-reconcile                     OK      OK, 4 object(s)
-loadbalancer-reconciler                   job-refresh                       OK      Next refresh in 30m0s
-loadbalancer-reconciler                   job-start-reconciler              Stopped Started
-loadbalancer-reflectors.k8s-reflector     job-reflect-pods                  OK      Running
-loadbalancer-reflectors.k8s-reflector     job-reflect-services-endpoints    OK      Running
-loadbalancer-writer                       job-node-addr-reconciler          OK      Running
-loadbalancer-writer                       job-zone-watcher                  OK      Running
+Module                      Component                         Level   Message                    Error
+loadbalancer-healthserver   job-control-loop                  OK      1 health servers running
+loadbalancer-healthserver   job-listener-40000                OK      Running
 
 -- services.table --
 Name                   Source   PortNames  TrafficPolicy   Flags

--- a/pkg/loadbalancer/legacy/service/service.go
+++ b/pkg/loadbalancer/legacy/service/service.go
@@ -272,7 +272,8 @@ func (svc *svcInfo) checkLBSourceRange() bool {
 // The changes can be triggered either by k8s_watcher or directly by
 // API calls to the /services endpoint.
 type Service struct {
-	logger *slog.Logger
+	logger          *slog.Logger
+	metricsRegistry *metrics.Registry
 	lock.RWMutex
 
 	svcByHash map[string]*svcInfo
@@ -306,8 +307,16 @@ type Service struct {
 }
 
 // newService creates a new instance of the service handler.
-func newService(logger *slog.Logger, lbConfig lb.Config, lbmap datapathTypes.LBMap, backendDiscoveryHandler datapathTypes.NodeNeighbors, healthCheckers []HealthChecker, k8sControlplaneEnabled bool,
-	config *option.DaemonConfig) *Service {
+func newService(
+	logger *slog.Logger,
+	registry *metrics.Registry,
+	lbConfig lb.Config,
+	lbmap datapathTypes.LBMap,
+	backendDiscoveryHandler datapathTypes.NodeNeighbors,
+	healthCheckers []HealthChecker,
+	k8sControlplaneEnabled bool,
+	config *option.DaemonConfig,
+) *Service {
 	var localHealthServer healthServer
 	if lbConfig.EnableHealthCheckNodePort {
 		localHealthServer = healthserver.New(logger)
@@ -315,6 +324,7 @@ func newService(logger *slog.Logger, lbConfig lb.Config, lbmap datapathTypes.LBM
 
 	svc := &Service{
 		logger:                   logger,
+		metricsRegistry:          registry,
 		svcByHash:                map[string]*svcInfo{},
 		svcByID:                  map[lb.ID]*svcInfo{},
 		backendRefCount:          counter.Counter[string]{},
@@ -680,7 +690,7 @@ func (s *Service) InitMaps(ipv6, ipv4, sockMaps, restore bool) error {
 			toDelete = append(toDelete, lbmap.Service6MapV2, lbmap.Backend6MapV3, lbmap.RevNat6Map)
 		}
 		if sockMaps {
-			if err := lbmap.CreateSockRevNat6Map(); err != nil {
+			if err := lbmap.CreateSockRevNat6Map(s.metricsRegistry); err != nil {
 				return err
 			}
 		}
@@ -692,7 +702,7 @@ func (s *Service) InitMaps(ipv6, ipv4, sockMaps, restore bool) error {
 			toDelete = append(toDelete, lbmap.Service4MapV2, lbmap.Backend4MapV3, lbmap.RevNat4Map)
 		}
 		if sockMaps {
-			if err := lbmap.CreateSockRevNat4Map(); err != nil {
+			if err := lbmap.CreateSockRevNat4Map(s.metricsRegistry); err != nil {
 				return err
 			}
 		}

--- a/pkg/loadbalancer/legacy/service/service_test.go
+++ b/pkg/loadbalancer/legacy/service/service_test.go
@@ -225,7 +225,7 @@ func setupManagerTestSuite(tb testing.TB) *ManagerTestSuite {
 }
 
 func (m *ManagerTestSuite) newServiceMock(ctx context.Context, lbcfg lb.Config, lbmap datapathTypes.LBMap) {
-	m.svc = newService(m.logger, lbcfg, lbmap, nil, nil, true, option.Config)
+	m.svc = newService(m.logger, nil, lbcfg, lbmap, nil, nil, true, option.Config)
 	m.svc.backendConnectionHandler = testsockets.NewMockSockets(make([]*testsockets.MockSocket, 0))
 	health, _ := cell.NewSimpleHealth()
 	go m.svc.handleHealthCheckEvent(ctx, health)
@@ -764,7 +764,7 @@ func TestRestoreServiceWithStaleBackends(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			lbmap := mockmaps.NewLBMockMap()
 			logger := hivetest.Logger(t)
-			svc := newService(logger, lb.DefaultConfig, lbmap, nil, nil, true, option.Config)
+			svc := newService(logger, nil, lb.DefaultConfig, lbmap, nil, nil, true, option.Config)
 
 			_, id1, err := svc.upsertService(service("foo", "bar", "172.16.0.1", backendAddrs...))
 			require.NoError(t, err, "Failed to upsert service")
@@ -774,7 +774,7 @@ func TestRestoreServiceWithStaleBackends(t *testing.T) {
 			require.ElementsMatch(t, backendAddrs, toBackendAddrs(slices.Collect(maps.Values(lbmap.BackendByID))), "lbmap not populated correctly")
 
 			// Recreate the Service structure, but keep the lbmap to restore services from
-			svc = newService(logger, lb.DefaultConfig, lbmap, nil, nil, true, option.Config)
+			svc = newService(logger, nil, lb.DefaultConfig, lbmap, nil, nil, true, option.Config)
 			require.NoError(t, svc.RestoreServices(), "Failed to restore services")
 
 			// Simulate a set of service updates. Until synchronization completes, a given service
@@ -2358,7 +2358,7 @@ func TestRestoreServicesWithLeakedBackends(t *testing.T) {
 	require.Len(t, m.lbmap.BackendByID, len(backends)+4)
 	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
 	logger := hivetest.Logger(t)
-	m.svc = newService(logger, lb.DefaultConfig, lbmap, nil, nil, true, option.Config)
+	m.svc = newService(logger, nil, lb.DefaultConfig, lbmap, nil, nil, true, option.Config)
 
 	// Restore services from lbmap
 	err := m.svc.RestoreServices()

--- a/pkg/loadbalancer/maps/cell.go
+++ b/pkg/loadbalancer/maps/cell.go
@@ -26,6 +26,9 @@ var Cell = cell.Module(
 
 	// Provide [HaveNetNSCookieSupport] to probe for netns cookie support.
 	cell.Provide(NetnsCookieSupportFunc),
+
+	// Register a periodic job to update the BPF map pressure metrics.
+	cell.Invoke(registerPressureMetricsReporter),
 )
 
 type HaveNetNSCookieSupport func() bool

--- a/pkg/loadbalancer/maps/pressure_metrics.go
+++ b/pkg/loadbalancer/maps/pressure_metrics.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package maps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/metrics"
+)
+
+type pressureMetricsParams struct {
+	cell.In
+
+	JobGroup        job.Group
+	MetricsRegistry *metrics.Registry
+	DB              *statedb.DB
+	Frontends       statedb.Table[*loadbalancer.Frontend]
+	Backends        statedb.Table[*loadbalancer.Backend]
+	Config          loadbalancer.Config
+	LBMaps          LBMaps
+}
+
+type pressureMetrics struct {
+	pressureMetricsParams
+
+	bpfMaps *BPFLBMaps
+	gauges  map[string]*metrics.GaugeWithThreshold
+}
+
+func registerPressureMetricsReporter(p pressureMetricsParams) {
+	if !p.Config.EnableExperimentalLB || p.Config.LBPressureMetricsInterval == 0 {
+		return
+	}
+
+	bpfMaps, ok := p.LBMaps.(*BPFLBMaps)
+	if !ok {
+		return
+	}
+
+	pm := &pressureMetrics{
+		pressureMetricsParams: p,
+		gauges:                map[string]*metrics.GaugeWithThreshold{},
+		bpfMaps:               bpfMaps,
+	}
+
+	// Update the metrics only once every 5 minutes as we need to iterate over all
+	// keys in each map to extract the count. If we're testing update the metrics
+	// frequently.
+	updateInterval := p.Config.LBPressureMetricsInterval
+	p.JobGroup.Add(job.Timer(
+		"pressure-metrics-reporter",
+		pm.report,
+		updateInterval,
+	))
+}
+
+func (pm *pressureMetrics) getGauge(mapName string) *metrics.GaugeWithThreshold {
+	mapName = strings.TrimPrefix(mapName, metrics.Namespace+"_")
+	if g, found := pm.gauges[mapName]; found {
+		return g
+	}
+	// Create a new metric. This will be registered/unregistered on-demand based on
+	// the threshold. E.g. if map pressure is 0.0 it won't appear in metrics.
+	g := pm.MetricsRegistry.NewBPFMapPressureGauge(mapName, 0.0)
+	pm.gauges[mapName] = g
+	return g
+}
+
+func (pm *pressureMetrics) report(ctx context.Context) error {
+	var errs error
+
+	pm.bpfMaps.forEachOpenMap(func(m *bpf.Map) {
+		name := m.Name()
+		if m.Type() != ebpf.Hash {
+			// Skip e.g. maglev HashOfMaps and source-ranges (cannot batch lookup on LPMTrie)
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		if count, err := m.BatchCount(); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("count on %s failed: %w", name, err))
+		} else {
+			ratio := float64(0)
+			if count > 0 && m.MaxEntries() > 0 {
+				ratio = float64(count) / float64(m.MaxEntries())
+			}
+			pm.getGauge(name).Set(ratio)
+		}
+	})
+
+	return errs
+}

--- a/pkg/loadbalancer/reconciler/termination_test.go
+++ b/pkg/loadbalancer/reconciler/termination_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	lbmaps "github.com/cilium/cilium/pkg/loadbalancer/maps"
 	"github.com/cilium/cilium/pkg/maglev"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/netns"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
@@ -63,6 +64,7 @@ func testSocketTermination(t *testing.T, hostOnly bool) {
 	fooNS := &netns.NetNS{}
 
 	h := hive.New(
+		metrics.Cell,
 		maglev.Cell,
 		lbmaps.Cell,
 		loadbalancer.ConfigCell,
@@ -70,6 +72,8 @@ func testSocketTermination(t *testing.T, hostOnly bool) {
 		cell.Provide(
 			loadbalancer.NewBackendsTable,
 			statedb.RWTable[*loadbalancer.Backend].ToTable,
+			loadbalancer.NewFrontendsTable,
+			statedb.RWTable[*loadbalancer.Frontend].ToTable,
 			func() sockets.SocketDestroyer { return mock },
 			func() *loadbalancer.TestConfig { return &loadbalancer.TestConfig{} },
 			func() testSyncChan { return syncChan },
@@ -120,7 +124,16 @@ func testSocketTermination(t *testing.T, hostOnly bool) {
 
 	// Add a backends and wait for the job to pick it up
 	wtxn := db.WriteTxn(backends)
-	backends.Insert(wtxn, &loadbalancer.Backend{Address: beAddr})
+	be := &loadbalancer.Backend{Address: beAddr}
+	be.Instances = be.Instances.Set(loadbalancer.BackendInstanceKey{
+		ServiceName:    loadbalancer.ServiceName{Name: "foo", Namespace: "bar"},
+		SourcePriority: 0,
+	}, loadbalancer.BackendParams{
+		Address:   beAddr,
+		State:     loadbalancer.BackendStateActive,
+		Unhealthy: false,
+	})
+	backends.Insert(wtxn, be)
 	wtxn.Commit()
 
 	// Wait until the first change has been seen
@@ -144,7 +157,6 @@ func testSocketTermination(t *testing.T, hostOnly bool) {
 	} else {
 		require.ElementsMatch(t, visitedNamespaces, []*netns.NetNS{hostNS})
 	}
-
 }
 
 type mockDestroyer struct {
@@ -248,11 +260,16 @@ func TestSocketTermination_Datapath(t *testing.T) {
 	// use an unpinned real BPF map.
 	var lbmap lbmaps.LBMaps
 	h := hive.New(
+		metrics.Cell,
 		maglev.Cell,
 		lbmaps.Cell,
 		cell.Config(loadbalancer.DefaultUserConfig),
 		cell.Config(loadbalancer.DeprecatedConfig{}),
 		cell.Provide(
+			loadbalancer.NewBackendsTable,
+			statedb.RWTable[*loadbalancer.Backend].ToTable,
+			loadbalancer.NewFrontendsTable,
+			statedb.RWTable[*loadbalancer.Frontend].ToTable,
 			loadbalancer.NewConfig,
 			func() loadbalancer.ExternalConfig { return extConfig },
 			func() *option.DaemonConfig { return &option.DaemonConfig{} },

--- a/pkg/loadbalancer/redirectpolicy/script_test.go
+++ b/pkg/loadbalancer/redirectpolicy/script_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
@@ -66,6 +67,7 @@ func TestScript(t *testing.T) {
 				client.FakeClientCell,
 				daemonk8s.ResourcesCell,
 				daemonk8s.TablesCell,
+				metrics.Cell,
 
 				lbcell.Cell,
 

--- a/pkg/loadbalancer/tests/main_test.go
+++ b/pkg/loadbalancer/tests/main_test.go
@@ -10,5 +10,11 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m,
+		// The metrics "status" collector tries to connect to the agent and leaves these
+		// around. We should refactor pkg/metrics to split it into "plain registry"
+		// and the agent specifics.
+		goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
+	)
 }

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s/client"
-	"github.com/cilium/cilium/pkg/k8s/testutils"
+	k8sTestutils "github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	lbcell "github.com/cilium/cilium/pkg/loadbalancer/cell"
@@ -37,11 +37,13 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer/writer"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maglev"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -53,7 +55,7 @@ func TestScript(t *testing.T) {
 	// not EndpointSlice) in the tests here, which is why we're currently only testing against
 	// the default.
 	// Issue for fixing this: https://github.com/cilium/cilium/issues/35537
-	version.Force(testutils.DefaultVersion)
+	version.Force(k8sTestutils.DefaultVersion)
 
 	// Set the node name
 	nodeTypes.SetName("testnode")
@@ -82,6 +84,7 @@ func TestScript(t *testing.T) {
 					// By default 10% of the time the LBMap operations fail
 					TestFaultProbability: 0.1,
 				}),
+				metrics.Cell,
 				maglev.Cell,
 				node.LocalNodeStoreCell,
 				cell.Provide(
@@ -132,8 +135,12 @@ func TestScript(t *testing.T) {
 			require.NoError(t, err, "ScriptCommands")
 			maps.Insert(cmds, maps.All(script.DefaultCmds()))
 
+			conds := map[string]script.Cond{
+				"privileged": script.BoolCondition("testutils.IsPrivileged", testutils.IsPrivileged()),
+			}
 			return &script.Engine{
 				Cmds:             cmds,
+				Conds:            conds,
 				RetryInterval:    20 * time.Millisecond,
 				MaxRetryInterval: 500 * time.Millisecond,
 			}

--- a/pkg/loadbalancer/tests/testdata/dualstack-maglev.txtar
+++ b/pkg/loadbalancer/tests/testdata/dualstack-maglev.txtar
@@ -1,4 +1,4 @@
-#! --enable-experimental-lb --lb-test-fault-probability=0.0 --node-port-algorithm=maglev
+#! --enable-experimental-lb --lb-test-fault-probability=0.0 --node-port-algorithm=maglev --lb-pressure-metrics-interval=100ms --bpf-lb-map-max=1000
 
 # NOTE: Fault injection disabled as it leads to non-deterministic id allocation with multiple
 # frontends from single service.
@@ -24,6 +24,13 @@ db/cmp frontends frontends.table
 # Check the BPF maps
 lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
+
+# Check pressure metrics. We have 8 frontends and 8 backends, 4 per family.
+# For NodePort we have 2 additional backends, so we get: (4+2)*(1+2) == 18,
+# which for MaxEntries=1000 is 0.0018 entries in services maps and
+# revnat maps (one per frontend address).
+[privileged] metrics --out=metrics.actual cilium_bpf_map_pressure
+[privileged] * cmp metrics.expected metrics.actual
 
 # Cleanup
 k8s/delete service.yaml endpointslice-ipv4.yaml endpointslice-ipv6.yaml
@@ -87,6 +94,14 @@ Address                        Instances
 [fd00:10:244:2::a314]:69/UDP   default/echo-dualstack (tftp)
 [fd00:10:244:2::a314]:80/TCP   default/echo-dualstack (http)
 
+-- metrics.expected --
+Metric                    Labels                     Value
+cilium_bpf_map_pressure   map_name=lb4_backends_v3   0.004000
+cilium_bpf_map_pressure   map_name=lb4_reverse_nat   0.006000
+cilium_bpf_map_pressure   map_name=lb4_services_v2   0.018000
+cilium_bpf_map_pressure   map_name=lb6_backends_v3   0.004000
+cilium_bpf_map_pressure   map_name=lb6_reverse_nat   0.006000
+cilium_bpf_map_pressure   map_name=lb6_services_v2   0.018000
 -- service.yaml --
 apiVersion: v1
 kind: Service

--- a/pkg/loadbalancer/tests/testdata/external-clusterip.txtar
+++ b/pkg/loadbalancer/tests/testdata/external-clusterip.txtar
@@ -17,6 +17,11 @@ lb/maps-dump lbmaps.actual
 #####
 
 -- lbmaps.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+MAGLEV: ID=1 INNER=[1(1021)]
+REV: ID=1 ADDR=10.96.50.104:80
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
 -- service.yaml --
 apiVersion: v1
 kind: Service

--- a/pkg/loadbalancer/tests/testdata/ingress.txtar
+++ b/pkg/loadbalancer/tests/testdata/ingress.txtar
@@ -13,7 +13,6 @@ db/initialized
 k8s/add svc-ingress.yaml eps-ingress.yaml
 
 # Validate
-sleep 1s
 db/cmp services services.table
 db/cmp frontends frontends.table
 db/cmp backends backends.table

--- a/pkg/loadbalancer/tests/testdata/svc-forwarding-mode-annotation.txtar
+++ b/pkg/loadbalancer/tests/testdata/svc-forwarding-mode-annotation.txtar
@@ -16,7 +16,7 @@ lb/maps-dump maps.actual
 # Set the forwarding mode to DSR
 sed 'placeholder: placeholder' 'service.cilium.io/forwarding-mode: dsr' service.yaml
 k8s/update service.yaml
-db/cmp services services.table
+db/cmp services services_dsr.table
 
 # Check maps
 lb/maps-dump maps.actual

--- a/pkg/loadbalancer/zz_generated.deepequal.go
+++ b/pkg/loadbalancer/zz_generated.deepequal.go
@@ -167,6 +167,9 @@ func (in *UserConfig) DeepEqual(other *UserConfig) bool {
 	if in.EnableHealthCheckNodePort != other.EnableHealthCheckNodePort {
 		return false
 	}
+	if in.LBPressureMetricsInterval != other.LBPressureMetricsInterval {
+		return false
+	}
 
 	return true
 }

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func init() {
-	InitMapInfo(true, true, true)
+	InitMapInfo(nil, true, true, true)
 }
 
 func setupCTMap(tb testing.TB) {
@@ -126,7 +126,7 @@ func TestCtGcIcmp(t *testing.T) {
 	setupCTMap(t)
 
 	// Init maps
-	natMap := nat.NewMap("cilium_nat_any4_test", nat.IPv4, 1000)
+	natMap := nat.NewMap(nil, "cilium_nat_any4_test", nat.IPv4, 1000)
 	err := natMap.OpenOrCreate()
 	require.NoError(t, err)
 	defer natMap.Map.Unpin()
@@ -240,7 +240,7 @@ func TestCtGcIcmp(t *testing.T) {
 func TestCtGcTcp(t *testing.T) {
 	setupCTMap(t)
 	// Init maps
-	natMap := nat.NewMap("cilium_nat_any4_test", nat.IPv4, 1000)
+	natMap := nat.NewMap(nil, "cilium_nat_any4_test", nat.IPv4, 1000)
 	err := natMap.OpenOrCreate()
 	require.NoError(t, err)
 	defer natMap.Map.Unpin()
@@ -355,7 +355,7 @@ func TestCtGcDsr(t *testing.T) {
 	setupCTMap(t)
 
 	// Init maps
-	natMap := nat.NewMap("cilium_nat_any4_test", nat.IPv4, 1000)
+	natMap := nat.NewMap(nil, "cilium_nat_any4_test", nat.IPv4, 1000)
 	err := natMap.OpenOrCreate()
 	require.NoError(t, err)
 	defer natMap.Map.Unpin()
@@ -448,7 +448,7 @@ func TestOrphanNatGC(t *testing.T) {
 	setupCTMap(t)
 
 	// Init maps
-	natMap := nat.NewMap("cilium_nat_any4_test", nat.IPv4, 1000)
+	natMap := nat.NewMap(nil, "cilium_nat_any4_test", nat.IPv4, 1000)
 	err := natMap.OpenOrCreate()
 	require.NoError(t, err)
 	defer natMap.Map.Unpin()
@@ -689,7 +689,7 @@ func TestOrphanNatGC(t *testing.T) {
 
 	// Let's check IPv6
 
-	natMapV6 := nat.NewMap("cilium_nat_any6_test", nat.IPv6, 1000)
+	natMapV6 := nat.NewMap(nil, "cilium_nat_any6_test", nat.IPv6, 1000)
 	err = natMapV6.OpenOrCreate()
 	require.NoError(t, err)
 	defer natMapV6.Map.Unpin()
@@ -858,7 +858,7 @@ func benchmarkCtGc(t *testing.B, size int) {
 		t.StopTimer()
 		setupCTMap(t)
 		// Init maps
-		natMap := nat.NewMap("cilium_nat_any4_test", nat.IPv4, size)
+		natMap := nat.NewMap(nil, "cilium_nat_any4_test", nat.IPv4, size)
 		err := natMap.OpenOrCreate()
 		assert.NoError(t, err)
 		defer natMap.Map.Unpin()

--- a/pkg/maps/ctmap/ctmap_test.go
+++ b/pkg/maps/ctmap/ctmap_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	InitMapInfo(true, true, true)
+	InitMapInfo(nil, true, true, true)
 }
 
 func TestCalculateInterval(t *testing.T) {

--- a/pkg/maps/egressmap/policy_test.go
+++ b/pkg/maps/egressmap/policy_test.go
@@ -25,7 +25,7 @@ func TestPolicyMap(t *testing.T) {
 	assert.NoError(t, rlimit.RemoveMemlock())
 
 	t.Run("IPv4 policies", func(t *testing.T) {
-		egressPolicyMap := createPolicyMap4(hivetest.Lifecycle(t), DefaultPolicyConfig, ebpf.PinNone)
+		egressPolicyMap := createPolicyMap4(hivetest.Lifecycle(t), nil, DefaultPolicyConfig, ebpf.PinNone)
 
 		sourceIP1 := netip.MustParseAddr("1.1.1.1")
 		sourceIP2 := netip.MustParseAddr("1.1.1.2")
@@ -69,7 +69,7 @@ func TestPolicyMap(t *testing.T) {
 
 	t.Run("IPv6 policies", func(t *testing.T) {
 		fmt.Print("HELLO")
-		egressPolicyMap := createPolicyMap6(hivetest.Lifecycle(t), DefaultPolicyConfig, ebpf.PinNone)
+		egressPolicyMap := createPolicyMap6(hivetest.Lifecycle(t), nil, DefaultPolicyConfig, ebpf.PinNone)
 
 		sourceIP1 := netip.MustParseAddr("2001:db8:1::1")
 		sourceIP2 := netip.MustParseAddr("2001:db8:1::2")

--- a/pkg/maps/fragmap/fragmap.go
+++ b/pkg/maps/fragmap/fragmap.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/types"
 )
@@ -57,14 +58,14 @@ func (v *FragmentValue4) String() string {
 func (v *FragmentValue4) New() bpf.MapValue { return &FragmentValue4{} }
 
 // InitMap4 creates the IPv4 fragments map in the kernel.
-func InitMap4(mapEntries int) error {
+func InitMap4(registry *metrics.Registry, mapEntries int) error {
 	fragMap := bpf.NewMap(MapNameIPv4,
 		ebpf.LRUHash,
 		&FragmentKey4{},
 		&FragmentValue4{},
 		mapEntries,
 		0,
-	).WithEvents(option.Config.GetEventBufferConfig(MapNameIPv4)).WithPressureMetric()
+	).WithEvents(option.Config.GetEventBufferConfig(MapNameIPv4)).WithPressureMetric(registry)
 	return fragMap.Create()
 }
 
@@ -105,14 +106,14 @@ func (v *FragmentValue6) String() string {
 func (v *FragmentValue6) New() bpf.MapValue { return &FragmentValue6{} }
 
 // InitMap6 creates the IPv6 fragments map in the kernel.
-func InitMap6(mapEntries int) error {
+func InitMap6(registry *metrics.Registry, mapEntries int) error {
 	fragMap := bpf.NewMap(MapNameIPv6,
 		ebpf.LRUHash,
 		&FragmentKey6{},
 		&FragmentValue6{},
 		mapEntries,
 		0,
-	).WithEvents(option.Config.GetEventBufferConfig(MapNameIPv6)).WithPressureMetric()
+	).WithEvents(option.Config.GetEventBufferConfig(MapNameIPv6)).WithPressureMetric(registry)
 	return fragMap.Create()
 }
 

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/ebpf"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/types"
 )
@@ -254,9 +255,9 @@ func newIPCacheMapV1(name string) *bpf.Map {
 }
 
 // NewMap instantiates a Map.
-func NewMap(name string) *Map {
+func NewMap(registry *metrics.Registry, name string) *Map {
 	return &Map{
-		Map: *newIPCacheMap(name).WithCache().WithPressureMetric().
+		Map: *newIPCacheMap(name).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(name)),
 	}
 }
@@ -274,9 +275,9 @@ var (
 
 // IPCacheMap gets the ipcache Map singleton. If it has not already been done,
 // this also initializes the Map.
-func IPCacheMap() *Map {
+func IPCacheMap(registry *metrics.Registry) *Map {
 	once.Do(func() {
-		ipcache = NewMap(Name)
+		ipcache = NewMap(registry, Name)
 	})
 	return ipcache
 }

--- a/pkg/maps/lbmap/affinity.go
+++ b/pkg/maps/lbmap/affinity.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/types"
 )
@@ -29,7 +30,7 @@ var (
 )
 
 // initAffinity creates the BPF maps for implementing session affinity.
-func initAffinity(params InitParams) {
+func initAffinity(registry *metrics.Registry, params InitParams) {
 	AffinityMapMaxEntries = params.AffinityMapMaxEntries
 
 	AffinityMatchMap = bpf.NewMap(
@@ -39,7 +40,7 @@ func initAffinity(params InitParams) {
 		&AffinityMatchValue{},
 		AffinityMapMaxEntries,
 		0,
-	).WithCache().WithPressureMetric().
+	).WithCache().WithPressureMetric(registry).
 		WithEvents(option.Config.GetEventBufferConfig(AffinityMatchMapName))
 
 	if params.IPv4 {

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/byteorder"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -64,7 +65,7 @@ var (
 // initSVC constructs the IPv4 & IPv6 LB BPF maps used for Services. The maps
 // have their maximum entries configured. Note this does not create or open the
 // maps; it simply constructs the objects.
-func initSVC(params InitParams) {
+func initSVC(registry *metrics.Registry, params InitParams) {
 	ServiceMapMaxEntries = params.ServiceMapMaxEntries
 	ServiceBackEndMapMaxEntries = params.BackEndMapMaxEntries
 	RevNatMapMaxEntries = params.RevNatMapMaxEntries
@@ -76,7 +77,7 @@ func initSVC(params InitParams) {
 			&Service4Value{},
 			ServiceMapMaxEntries,
 			0,
-		).WithCache().WithPressureMetric().
+		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(Service4MapV2Name))
 		Backend4Map = bpf.NewMap(Backend4MapName,
 			ebpf.Hash,
@@ -84,7 +85,7 @@ func initSVC(params InitParams) {
 			&Backend4Value{},
 			ServiceBackEndMapMaxEntries,
 			0,
-		).WithCache().WithPressureMetric().
+		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(Backend4MapName))
 		Backend4MapV2 = bpf.NewMap(Backend4MapV2Name,
 			ebpf.Hash,
@@ -92,7 +93,7 @@ func initSVC(params InitParams) {
 			&Backend4Value{},
 			ServiceBackEndMapMaxEntries,
 			0,
-		).WithCache().WithPressureMetric().
+		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(Backend4MapV2Name))
 		Backend4MapV3 = bpf.NewMap(Backend4MapV3Name,
 			ebpf.Hash,
@@ -100,7 +101,7 @@ func initSVC(params InitParams) {
 			&Backend4ValueV3{},
 			ServiceBackEndMapMaxEntries,
 			0,
-		).WithCache().WithPressureMetric().
+		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(Backend4MapV3Name))
 		RevNat4Map = bpf.NewMap(RevNat4MapName,
 			ebpf.Hash,
@@ -108,7 +109,7 @@ func initSVC(params InitParams) {
 			&RevNat4Value{},
 			RevNatMapMaxEntries,
 			0,
-		).WithCache().WithPressureMetric().
+		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(RevNat4MapName))
 	}
 
@@ -119,7 +120,7 @@ func initSVC(params InitParams) {
 			&Service6Value{},
 			ServiceMapMaxEntries,
 			0,
-		).WithCache().WithPressureMetric().
+		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(Service6MapV2Name))
 		Backend6Map = bpf.NewMap(Backend6MapName,
 			ebpf.Hash,
@@ -127,7 +128,7 @@ func initSVC(params InitParams) {
 			&Backend6Value{},
 			ServiceBackEndMapMaxEntries,
 			0,
-		).WithCache().WithPressureMetric().
+		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(Backend6MapName))
 		Backend6MapV2 = bpf.NewMap(Backend6MapV2Name,
 			ebpf.Hash,
@@ -135,7 +136,7 @@ func initSVC(params InitParams) {
 			&Backend6Value{},
 			ServiceBackEndMapMaxEntries,
 			0,
-		).WithCache().WithPressureMetric().
+		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(Backend6MapV2Name))
 		Backend6MapV3 = bpf.NewMap(Backend6MapV3Name,
 			ebpf.Hash,
@@ -143,7 +144,7 @@ func initSVC(params InitParams) {
 			&Backend6ValueV3{},
 			ServiceBackEndMapMaxEntries,
 			0,
-		).WithCache().WithPressureMetric().
+		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(Backend6MapV3Name))
 		RevNat6Map = bpf.NewMap(RevNat6MapName,
 			ebpf.Hash,
@@ -151,7 +152,7 @@ func initSVC(params InitParams) {
 			&RevNat6Value{},
 			RevNatMapMaxEntries,
 			0,
-		).WithCache().WithPressureMetric().
+		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(RevNat6MapName))
 	}
 }
@@ -628,13 +629,13 @@ func (v *SockRevNat4Value) String() string {
 func (v *SockRevNat4Value) New() bpf.MapValue { return &SockRevNat4Value{} }
 
 // CreateSockRevNat4Map creates the reverse NAT sock map.
-func CreateSockRevNat4Map() error {
+func CreateSockRevNat4Map(registry *metrics.Registry) error {
 	SockRevNat4Map = bpf.NewMap(SockRevNat4MapName,
 		ebpf.LRUHash,
 		&SockRevNat4Key{},
 		&SockRevNat4Value{},
 		MaxSockRevNat4MapEntries,
 		0,
-	).WithPressureMetric()
+	).WithPressureMetric(registry)
 	return SockRevNat4Map.OpenOrCreate()
 }

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/byteorder"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -525,13 +526,13 @@ func (v *SockRevNat6Value) String() string {
 func (v *SockRevNat6Value) New() bpf.MapValue { return &SockRevNat6Value{} }
 
 // CreateSockRevNat6Map creates the reverse NAT sock map.
-func CreateSockRevNat6Map() error {
+func CreateSockRevNat6Map(registry *metrics.Registry) error {
 	SockRevNat6Map = bpf.NewMap(SockRevNat6MapName,
 		ebpf.LRUHash,
 		&SockRevNat6Key{},
 		&SockRevNat6Value{},
 		MaxSockRevNat6MapEntries,
 		0,
-	).WithPressureMetric()
+	).WithPressureMetric(registry)
 	return SockRevNat6Map.OpenOrCreate()
 }

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maglev"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -790,7 +791,7 @@ func (svcs svcMap) addFEnBE(fe *loadbalancer.L3n4AddrID, be *loadbalancer.Legacy
 
 // Init updates the map info defaults for sock rev nat {4,6} and LB maps and
 // then initializes all LB-related maps.
-func Init(params InitParams) {
+func Init(registry *metrics.Registry, params InitParams) {
 	if params.MaxSockRevNatMapEntries != 0 {
 		MaxSockRevNat4MapEntries = params.MaxSockRevNatMapEntries
 		MaxSockRevNat6MapEntries = params.MaxSockRevNatMapEntries
@@ -798,9 +799,9 @@ func Init(params InitParams) {
 
 	MaglevMapMaxEntries = params.MaglevMapMaxEntries
 
-	initSVC(params)
-	initAffinity(params)
-	initSourceRange(params)
+	initSVC(registry, params)
+	initAffinity(registry, params)
+	initSourceRange(registry, params)
 }
 
 // ExistsSockRevNat checks if the passed entry exists in the sock rev nat map.

--- a/pkg/maps/lbmap/maglev_test.go
+++ b/pkg/maps/lbmap/maglev_test.go
@@ -30,7 +30,7 @@ func setupMaglevSuite(tb testing.TB) *MaglevSuite {
 	err := rlimit.RemoveMemlock()
 	require.NoError(tb, err)
 
-	Init(InitParams{
+	Init(nil, InitParams{
 		IPv4: option.Config.EnableIPv4,
 		IPv6: option.Config.EnableIPv6,
 

--- a/pkg/maps/lbmap/source_range.go
+++ b/pkg/maps/lbmap/source_range.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/ebpf"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/types"
 )
@@ -143,7 +144,7 @@ var (
 
 // initSourceRange creates the BPF maps for storing both IPv4 and IPv6
 // service source ranges.
-func initSourceRange(params InitParams) {
+func initSourceRange(registry *metrics.Registry, params InitParams) {
 	SourceRangeMapMaxEntries = params.SourceRangeMapMaxEntries
 
 	if params.IPv4 {
@@ -154,7 +155,7 @@ func initSourceRange(params InitParams) {
 			&SourceRangeValue{},
 			SourceRangeMapMaxEntries,
 			bpf.BPF_F_NO_PREALLOC,
-		).WithCache().WithPressureMetric().
+		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(SourceRange4MapName))
 	}
 
@@ -166,7 +167,7 @@ func initSourceRange(params InitParams) {
 			&SourceRangeValue{},
 			SourceRangeMapMaxEntries,
 			bpf.BPF_F_NO_PREALLOC,
-		).WithCache().WithPressureMetric().
+		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(SourceRange6MapName))
 	}
 }

--- a/pkg/maps/nat/cell.go
+++ b/pkg/maps/nat/cell.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/time"
@@ -27,7 +28,7 @@ var MapDisabled = fmt.Errorf("nat map is disabled")
 var Cell = cell.Module(
 	"nat-maps",
 	"NAT Maps",
-	cell.Provide(func(lc cell.Lifecycle, cfgPromise promise.Promise[*option.DaemonConfig]) (promise.Promise[NatMap4], promise.Promise[NatMap6]) {
+	cell.Provide(func(lc cell.Lifecycle, registry *metrics.Registry, cfgPromise promise.Promise[*option.DaemonConfig]) (promise.Promise[NatMap4], promise.Promise[NatMap6]) {
 		var ipv4Nat, ipv6Nat *Map
 		res4, promise4 := promise.New[NatMap4]()
 		res6, promise6 := promise.New[NatMap6]()
@@ -46,7 +47,7 @@ var Cell = cell.Module(
 					return nil
 				}
 
-				ipv4Nat, ipv6Nat = GlobalMaps(cfg.EnableIPv4,
+				ipv4Nat, ipv6Nat = GlobalMaps(registry, cfg.EnableIPv4,
 					cfg.EnableIPv6, true)
 
 				// Maps are still created before DaemonConfig promise is resolved in

--- a/pkg/maps/nat/nap_flush_test.go
+++ b/pkg/maps/nat/nap_flush_test.go
@@ -17,10 +17,10 @@ func TestFlushNat(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	numEntries := 5
-	v4NatMap := NewMap("test_nap_v4", IPv4, 1000)
+	v4NatMap := NewMap(nil, "test_nap_v4", IPv4, 1000)
 	err := v4NatMap.OpenOrCreate()
 	assert.NoError(t, err)
-	v6NatMap := NewMap("test_nat_v6", IPv6, 1000)
+	v6NatMap := NewMap(nil, "test_nat_v6", IPv6, 1000)
 	err = v6NatMap.OpenOrCreate()
 	assert.NoError(t, err)
 	t.Cleanup(func() {

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/timestamp"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/tuple"
 )
@@ -85,7 +86,7 @@ type RetriesMap interface {
 }
 
 // NewMap instantiates a Map.
-func NewMap(name string, family IPFamily, entries int) *Map {
+func NewMap(registry *metrics.Registry, name string, family IPFamily, entries int) *Map {
 	var mapKey bpf.MapKey
 	var mapValue bpf.MapValue
 
@@ -107,7 +108,7 @@ func NewMap(name string, family IPFamily, entries int) *Map {
 			0,
 		).WithCache().
 			WithEvents(option.Config.GetEventBufferConfig(name)).
-			WithPressureMetric(),
+			WithPressureMetric(registry),
 		family: family,
 	}
 }
@@ -387,15 +388,15 @@ func DeleteSwappedMapping6(m *Map, tk tuple.TupleKey) error {
 }
 
 // GlobalMaps returns all global NAT maps.
-func GlobalMaps(ipv4, ipv6, nodeport bool) (ipv4Map, ipv6Map *Map) {
+func GlobalMaps(registry *metrics.Registry, ipv4, ipv6, nodeport bool) (ipv4Map, ipv6Map *Map) {
 	if !nodeport {
 		return
 	}
 	if ipv4 {
-		ipv4Map = NewMap(MapNameSnat4Global, IPv4, maxEntries())
+		ipv4Map = NewMap(registry, MapNameSnat4Global, IPv4, maxEntries())
 	}
 	if ipv6 {
-		ipv6Map = NewMap(MapNameSnat6Global, IPv6, maxEntries())
+		ipv6Map = NewMap(registry, MapNameSnat6Global, IPv6, maxEntries())
 	}
 	return
 }

--- a/pkg/maps/nat/nat_batch_test.go
+++ b/pkg/maps/nat/nat_batch_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestDumpBatch4(t *testing.T) {
 	testutils.PrivilegedTest(t)
-	m := NewMap("test_snat_map", IPv4, 1<<18) // approximate default map size.
+	m := NewMap(nil, "test_snat_map", IPv4, 1<<18) // approximate default map size.
 	m.family = IPv4
 	err := m.OpenOrCreate()
 	assert.NoError(t, err)

--- a/pkg/maps/nat/per_cluster_nat.go
+++ b/pkg/maps/nat/per_cluster_nat.go
@@ -149,7 +149,7 @@ func newPerClusterNATMap(family IPFamily, innerMapEntries int) *perClusterNATMap
 }
 
 func (om *perClusterNATMap) newInnerMap(clusterID uint32) *Map {
-	return NewMap(ClusterInnerMapName(om.family, clusterID), om.family, om.innerMapEntries)
+	return NewMap(nil, ClusterInnerMapName(om.family, clusterID), om.family, om.innerMapEntries)
 }
 
 func (om *perClusterNATMap) createClusterNATMap(clusterID uint32) error {

--- a/pkg/maps/nat/stats/stats_test.go
+++ b/pkg/maps/nat/stats/stats_test.go
@@ -41,10 +41,10 @@ func Test_topk(t *testing.T) {
 func Test_countNat(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
-	ip4Map := nat.NewMap("test_nat_map_ip4", nat.IPv4, 262144)
+	ip4Map := nat.NewMap(nil, "test_nat_map_ip4", nat.IPv4, 262144)
 	err := ip4Map.OpenOrCreate()
 	assert.NoError(t, err)
-	ip6Map := nat.NewMap("test_nat_map_ip6", nat.IPv6, 262144)
+	ip6Map := nat.NewMap(nil, "test_nat_map_ip6", nat.IPv6, 262144)
 	err = ip6Map.OpenOrCreate()
 	assert.NoError(t, err)
 	t.Cleanup(func() {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1484,33 +1484,78 @@ func newErrorsWarningsMetric() metric.Vec[metric.Counter] {
 // GaugeWithThreshold is a prometheus gauge that registers itself with
 // prometheus if over a threshold value and unregisters when under.
 type GaugeWithThreshold struct {
+	// reg is the registry to register the gauge to. If nil the global registry
+	// is used.
+	reg *Registry
+
 	gauge     prometheus.Gauge
 	threshold float64
 	active    bool
+}
+
+func (gwt *GaugeWithThreshold) withRegistry(fn func(*Registry)) {
+	if gwt.reg == nil {
+		// Registry was not provided and for backwards compatibility we need
+		// to go via the [registry] global variable which may not yet
+		// have been set up. Since this may be called many times in
+		// rapid succession, use a very low timeout. Eventually Gauge.Set() will
+		// be called after the registry is up and this succeeds.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+		reg, err := registry.Await(ctx)
+		if err == nil {
+			fn(reg)
+		}
+	} else {
+		fn(gwt.reg)
+	}
 }
 
 // Set the value of the GaugeWithThreshold.
 func (gwt *GaugeWithThreshold) Set(value float64) {
 	overThreshold := value > gwt.threshold
 	if gwt.active && !overThreshold {
-		gwt.active = !Unregister(gwt.gauge)
-		if gwt.active {
-			logrus.WithField("metric", gwt.gauge.Desc().String()).Warning("Failed to unregister metric")
-		}
+		gwt.withRegistry(func(reg *Registry) {
+			gwt.active = !reg.Unregister(gwt.gauge)
+			if gwt.active {
+				logrus.WithField("metric", gwt.gauge.Desc().String()).Warning("Failed to unregister metric")
+			}
+		})
 	} else if !gwt.active && overThreshold {
-		err := Register(gwt.gauge)
-		gwt.active = err == nil
-		if err != nil {
-			logrus.WithField("metric", gwt.gauge.Desc().String()).WithError(err).Warning("Failed to register metric")
-		}
+		gwt.withRegistry(func(reg *Registry) {
+			err := reg.Register(gwt.gauge)
+			gwt.active = err == nil
+			if err != nil {
+				logrus.WithField("metric", gwt.gauge.Desc().String()).WithError(err).Warning("Failed to register metric")
+			}
+		})
 	}
 
 	gwt.gauge.Set(value)
 }
 
+// NewGaugeWithThresholdForRegistry creates a new GaugeWithThreshold.
+func (reg *Registry) NewGaugeWithThreshold(name string, subsystem string, desc string, labels map[string]string, threshold float64) *GaugeWithThreshold {
+	return &GaugeWithThreshold{
+		reg: reg,
+		gauge: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace:   Namespace,
+			Subsystem:   subsystem,
+			Name:        name,
+			Help:        desc,
+			ConstLabels: labels,
+		}),
+		threshold: threshold,
+		active:    false,
+	}
+}
+
 // NewGaugeWithThreshold creates a new GaugeWithThreshold.
+//
+// Deprecated: Use [Registry.NewGaugeWithThreshold]
 func NewGaugeWithThreshold(name string, subsystem string, desc string, labels map[string]string, threshold float64) *GaugeWithThreshold {
 	return &GaugeWithThreshold{
+		reg: nil,
 		gauge: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace:   Namespace,
 			Subsystem:   subsystem,
@@ -1525,8 +1570,24 @@ func NewGaugeWithThreshold(name string, subsystem string, desc string, labels ma
 
 // NewBPFMapPressureGauge creates a new GaugeWithThreshold for the
 // cilium_bpf_map_pressure metric with the map name as constant label.
+//
+// Deprecated: Use [Registry.NewGaugeWithThreshold]
 func NewBPFMapPressureGauge(mapname string, threshold float64) *GaugeWithThreshold {
 	return NewGaugeWithThreshold(
+		"map_pressure",
+		SubsystemBPF,
+		"Fill percentage of map, tagged by map name",
+		map[string]string{
+			LabelMapName: mapname,
+		},
+		threshold,
+	)
+}
+
+// NewBPFMapPressureGauge creates a new GaugeWithThreshold for the
+// cilium_bpf_map_pressure metric with the map name as constant label.
+func (reg *Registry) NewBPFMapPressureGauge(mapname string, threshold float64) *GaugeWithThreshold {
+	return reg.NewGaugeWithThreshold(
 		"map_pressure",
 		SubsystemBPF,
 		"Fill percentage of map, tagged by map name",

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -15,7 +15,11 @@ func TestGaugeWithThreshold(t *testing.T) {
 	threshold := 1.0
 	underThreshold := threshold - 0.5
 	overThreshold := threshold + 0.5
-	gauge := NewGaugeWithThreshold(
+	reg := NewRegistry(RegistryParams{
+		DaemonConfig: &option.DaemonConfig{},
+	})
+
+	gauge := reg.NewGaugeWithThreshold(
 		"test_metric",
 		"test_subsystem",
 		"test_metric",
@@ -24,10 +28,6 @@ func TestGaugeWithThreshold(t *testing.T) {
 		},
 		threshold,
 	)
-
-	reg := NewRegistry(RegistryParams{
-		DaemonConfig: &option.DaemonConfig{},
-	})
 
 	metrics, err := reg.inner.Gather()
 	require.NoError(t, err)


### PR DESCRIPTION
This adds the BPF pressure gauges for all the BPF maps used in pkg/loadbalance/maps. The pressure metric is updated every 5 minutes through `NextKeyBytes` count. This is meant to be a temporary measure until we have a BPF iterator way of grabbing BPF map counts (https://github.com/cilium/cilium/pull/37927 explored this, follow up later). Since we already switched to the new load-balancing control-plane I want to make sure we have this implemented for v1.18 even if in a sub-optimal way.

The new load-balancing maps do not use `pkg/bpf` nor do they use the `WithCache` mechanism (no point since the map operation retries are handled by the reconciler (`pkg/loadbalancer/reconciler`). This means we can't use the `(*bpf.Map).WithPressureMetric` and instead need to do it this way.

The first two commits improve the BPFMapPressureGauge infra by removing the functions and moving this to be a method under `metrics.Registry`. This way we avoid the annoying `metrics.registry` promise that a lot of tests hit a timeout with, but of course since lot of the maps are still globals I had to snake through the `*metrics.Registry` to these. The `WithPressureGauge` will be a no-op with a `nil` registry so we can use that in tests or cilium-dbg.