### PR TITLE
bpf: tests: populate L4 protocol in service entries

### DIFF
--- a/bpf/tests/common.h
+++ b/bpf/tests/common.h
@@ -9,6 +9,8 @@
 #include <bpf/loader.h>
 #include <bpf/section.h>
 
+#define ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION		1
+
 /* We can use this macro inside the actual datapath code
  * to compile-in the code for testing. The primary usecase
  * is initializing map-in-map or prog-map.

--- a/bpf/tests/hairpin_sctp_flow.c
+++ b/bpf/tests/hairpin_sctp_flow.c
@@ -88,7 +88,7 @@ int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 	/* Calc lengths, set protocol fields and calc checksums */
 	pktgen__finish(&builder);
 
-	lb_v4_add_service(v4_svc_one, tcp_svc_one, 1, revnat_id);
+	lb_v4_add_service(v4_svc_one, tcp_svc_one, IPPROTO_SCTP, 1, revnat_id);
 	lb_v4_add_backend(v4_svc_one, tcp_svc_one, 1, 124,
 			  v4_pod_one, tcp_svc_one, IPPROTO_SCTP, 0);
 

--- a/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
@@ -151,7 +151,7 @@ SETUP("tc", "01_lxc_to_overlay_syn")
 int lxc_to_overlay_syn_setup(struct __ctx_buff *ctx)
 {
 
-	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, 1, 1);
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, 1);
 	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, 1, 1,
 			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP,
 			  BACKEND_CLUSTER_ID);

--- a/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
+++ b/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
@@ -137,7 +137,7 @@ int nodeport_geneve_dsr_lb_xdp1_local_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
 
-	lb_v4_add_service(FRONTEND_IP_LOCAL, FRONTEND_PORT, 1, revnat_id);
+	lb_v4_add_service(FRONTEND_IP_LOCAL, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 	lb_v4_add_backend(FRONTEND_IP_LOCAL, FRONTEND_PORT, 1, 124,
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
 
@@ -256,7 +256,7 @@ int nodeport_geneve_dsr_lb_xdp2_fwd_setup(struct __ctx_buff *ctx)
 	__u32 backend_id = 125;
 	__u16 revnat_id = 2;
 
-	lb_v4_add_service(FRONTEND_IP_REMOTE, FRONTEND_PORT, 1, revnat_id);
+	lb_v4_add_service(FRONTEND_IP_REMOTE, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 	lb_v4_add_backend(FRONTEND_IP_REMOTE, FRONTEND_PORT, 1, backend_id,
 			  BACKEND_IP_REMOTE, BACKEND_PORT, IPPROTO_TCP, 0);
 

--- a/bpf/tests/skip_lb_xlate_lrp_per_packet_lb.c
+++ b/bpf/tests/skip_lb_xlate_lrp_per_packet_lb.c
@@ -67,7 +67,7 @@ int  v4_local_backend_to_service_packetgen(struct __ctx_buff *ctx)
 SETUP("tc", "v4_local_redirect")
 int v4_local_backend_to_service_setup(struct __ctx_buff *ctx)
 {
-	lb_v4_add_service_with_flags(V4_SERVICE_IP, SERVICE_PORT, 1, 1,
+	lb_v4_add_service_with_flags(V4_SERVICE_IP, SERVICE_PORT, IPPROTO_TCP, 1, 1,
 				     SVC_FLAG_ROUTABLE, SVC_FLAG_LOCALREDIRECT);
 	lb_v4_add_backend(V4_SERVICE_IP, SERVICE_PORT, 1, 124,
 			  V4_BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
@@ -165,7 +165,7 @@ int v6_local_backend_to_service_setup(struct __ctx_buff *ctx)
 	memcpy(service_ip.addr, (void *)V6_SERVICE_IP, 16);
 	memcpy(backend_ip.addr, (void *)V6_BACKEND_IP, 16);
 
-	lb_v6_add_service_with_flags(&service_ip, SERVICE_PORT, 1, 1,
+	lb_v6_add_service_with_flags(&service_ip, SERVICE_PORT, IPPROTO_TCP, 1, 1,
 				     SVC_FLAG_ROUTABLE, SVC_FLAG_LOCALREDIRECT);
 	lb_v6_add_backend(&service_ip, SERVICE_PORT, 1, 124, &backend_ip,
 			  BACKEND_PORT, IPPROTO_TCP, 0);

--- a/bpf/tests/skip_lb_xlate_socket_lb.c
+++ b/bpf/tests/skip_lb_xlate_socket_lb.c
@@ -72,9 +72,9 @@ int test_sock4_xlate_fwd_skip_lb(__maybe_unused struct xdp_md *ctx)
 	};
 	__u8 val = 0;
 
-	lb_v4_add_service_with_flags(v4_svc_one, tcp_svc_one, 1, revnat_id,
+	lb_v4_add_service_with_flags(v4_svc_one, tcp_svc_one, IPPROTO_TCP, 1, revnat_id,
 				     0, SVC_FLAG_LOCALREDIRECT);
-	lb_v4_add_service_with_flags(v4_svc_two, tcp_svc_two, 1, revnat_id2,
+	lb_v4_add_service_with_flags(v4_svc_two, tcp_svc_two, IPPROTO_TCP, 1, revnat_id2,
 				     0, SVC_FLAG_LOCALREDIRECT);
 	lb_v4_add_backend(v4_svc_one, tcp_svc_one, 1, 124,
 			  v4_pod_one, tcp_dst_one, IPPROTO_TCP, 0);
@@ -143,9 +143,9 @@ int test_sock6_xlate_fwd_skip_lb(__maybe_unused struct xdp_md *ctx)
 
 	memcpy(frontend_ip1.addr, (void *)V6_SVC_ONE, 16);
 	memcpy(frontend_ip2.addr, (void *)V6_SVC_TWO, 16);
-	lb_v6_add_service_with_flags(&frontend_ip1, tcp_svc_one, 1, revnat_id,
+	lb_v6_add_service_with_flags(&frontend_ip1, tcp_svc_one, IPPROTO_TCP, 1, revnat_id,
 				     0, SVC_FLAG_LOCALREDIRECT);
-	lb_v6_add_service_with_flags(&frontend_ip2, tcp_svc_two, 1, revnat_id2,
+	lb_v6_add_service_with_flags(&frontend_ip2, tcp_svc_two, IPPROTO_TCP, 1, revnat_id2,
 				     0, SVC_FLAG_LOCALREDIRECT);
 	lb_v6_add_backend(&frontend_ip1, tcp_svc_one, 1, 124,
 			  (union v6addr *)V6_BACKEND1, tcp_dst_one, IPPROTO_TCP, 0);

--- a/bpf/tests/skip_tunnel_nodeport_nat.c
+++ b/bpf/tests/skip_tunnel_nodeport_nat.c
@@ -173,13 +173,13 @@ setup(struct __ctx_buff *ctx, bool v4, bool flag_skip_tunnel)
 	 */
 
 	if (v4) {
-		lb_v4_add_service(NODEPORT_IPV4, NODEPORT_PORT, 1, 1);
+		lb_v4_add_service(NODEPORT_IPV4, NODEPORT_PORT, IPPROTO_TCP, 1, 1);
 		lb_v4_add_backend(NODEPORT_IPV4, NODEPORT_PORT, 1, 124,
 				  DST_IPV4, DST_PORT, IPPROTO_TCP, 0);
 		ipcache_v4_add_entry_with_flags(DST_IPV4,
 						0, 1230, DST_TUNNEL_IP, 0, flag_skip_tunnel);
 	} else {
-		lb_v6_add_service((union v6addr *)NODEPORT_IPV6, NODEPORT_PORT, 1, 1);
+		lb_v6_add_service((union v6addr *)NODEPORT_IPV6, NODEPORT_PORT, IPPROTO_TCP, 1, 1);
 		lb_v6_add_backend((union v6addr *)NODEPORT_IPV6, NODEPORT_PORT, 1, 123,
 				  (union v6addr *)DST_IPV6, DST_PORT, IPPROTO_TCP, 0);
 		ipcache_v6_add_entry_with_flags((union v6addr *)DST_IPV6,

--- a/bpf/tests/tc_lxc_lb4_no_backend.c
+++ b/bpf/tests/tc_lxc_lb4_no_backend.c
@@ -75,7 +75,7 @@ int lxc_no_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
 
-	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, 1, revnat_id);
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 
 	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, 0, 0);
 

--- a/bpf/tests/tc_lxc_lb6_no_backend.c
+++ b/bpf/tests/tc_lxc_lb6_no_backend.c
@@ -80,7 +80,7 @@ int lxc_no_backend_setup(struct __ctx_buff *ctx)
 
 	memcpy(frontend_ip.addr, (void *)FRONTEND_IP, 16);
 
-	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, 1, revnat_id);
+	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 
 	union v6addr backend_ip = {};
 

--- a/bpf/tests/tc_nodeport_l3_dev_lb_dsr_geneve_lb.c
+++ b/bpf/tests/tc_nodeport_l3_dev_lb_dsr_geneve_lb.c
@@ -111,7 +111,7 @@ int ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd_setup(struct __ctx_buff *ctx)
 	__u64 flags = BPF_F_ADJ_ROOM_FIXED_GSO;
 	__u16 revnat_id = 1;
 
-	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, 1, revnat_id);
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, 1, 124,
 			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
 
@@ -221,7 +221,7 @@ int ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd_setup(struct __ctx_buff *ctx)
 	union v6addr backend_ip = BACKEND_IPV6;
 	__u16 revnat_id = 1;
 
-	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, 1, revnat_id);
+	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 	lb_v6_add_backend(&frontend_ip, FRONTEND_PORT, 1, 124,
 			  &backend_ip, BACKEND_PORT, IPPROTO_TCP, 0);
 

--- a/bpf/tests/tc_nodeport_l3_dev_to_tunnel.c
+++ b/bpf/tests/tc_nodeport_l3_dev_to_tunnel.c
@@ -91,7 +91,7 @@ int ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel_setup(struct __ctx_buff *ct
 	void *data_end = (void *)(long)ctx->data_end;
 	__u64 flags = BPF_F_ADJ_ROOM_FIXED_GSO;
 
-	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, 1, 1);
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, 1);
 	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, 1, 124,
 			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
 
@@ -191,7 +191,7 @@ int ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel_setup(struct __ctx_buff *ct
 	void *data_end = (void *)(long)ctx->data_end;
 	__u64 flags = BPF_F_ADJ_ROOM_FIXED_GSO;
 
-	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, 1, 1);
+	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, IPPROTO_TCP, 1, 1);
 	lb_v6_add_backend(&frontend_ip, FRONTEND_PORT, 1, 124,
 			  &backend_ip, BACKEND_PORT, IPPROTO_TCP, 0);
 

--- a/bpf/tests/tc_nodeport_lb4_dsr_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_lb.c
@@ -111,7 +111,7 @@ int nodeport_dsr_fwd_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
 
-	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, 1, revnat_id);
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, 1, 124,
 			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
 

--- a/bpf/tests/tc_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_backend.c
@@ -114,7 +114,7 @@ int nodeport_nat_backend_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_nodeport_nat_backend")
 int nodeport_nat_backend_setup(struct __ctx_buff *ctx)
 {
-	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, 1, 1);
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, 1);
 	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, 1, 124,
 			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
 

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -214,7 +214,7 @@ int nodeport_local_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
 
-	lb_v4_add_service(FRONTEND_IP_LOCAL, FRONTEND_PORT, 1, revnat_id);
+	lb_v4_add_service(FRONTEND_IP_LOCAL, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 	lb_v4_add_backend(FRONTEND_IP_LOCAL, FRONTEND_PORT, 1, 124,
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
 
@@ -617,7 +617,7 @@ int nodeport_udp_local_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 2;
 
-	lb_v4_add_service(FRONTEND_IP_LOCAL, FRONTEND_PORT, 1, revnat_id);
+	lb_v4_add_service(FRONTEND_IP_LOCAL, FRONTEND_PORT, IPPROTO_UDP, 1, revnat_id);
 	lb_v4_add_backend(FRONTEND_IP_LOCAL, FRONTEND_PORT, 1, 125,
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_UDP, 0);
 
@@ -722,7 +722,7 @@ int nodeport_nat_fwd_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
 
-	lb_v4_add_service(FRONTEND_IP_REMOTE, FRONTEND_PORT, 1, revnat_id);
+	lb_v4_add_service(FRONTEND_IP_REMOTE, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 	lb_v4_add_backend(FRONTEND_IP_REMOTE, FRONTEND_PORT, 1, 124,
 			  BACKEND_IP_REMOTE, BACKEND_PORT, IPPROTO_TCP, 0);
 
@@ -1080,7 +1080,7 @@ int nodeport_nat_fwd_restore_setup(struct __ctx_buff *ctx)
 	if (settings)
 		settings->fail_fib = false;
 
-	lb_v4_add_service(FRONTEND_IP_REMOTE, FRONTEND_PORT, 1, revnat_id);
+	lb_v4_add_service(FRONTEND_IP_REMOTE, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 	lb_v4_add_backend(FRONTEND_IP_REMOTE, FRONTEND_PORT, 1, 124,
 			  BACKEND_IP_REMOTE, BACKEND_PORT, IPPROTO_TCP, 0);
 

--- a/bpf/tests/tc_nodeport_lb4_no_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_no_backend.c
@@ -82,7 +82,7 @@ int nodeport_no_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
 
-	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, 1, revnat_id);
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 
 	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, 0, 0);
 

--- a/bpf/tests/tc_nodeport_lb6_dsr_lb.c
+++ b/bpf/tests/tc_nodeport_lb6_dsr_lb.c
@@ -115,7 +115,7 @@ int nodeport_dsr_fwd_setup(struct __ctx_buff *ctx)
 	union v6addr backend_ip = BACKEND_IP;
 	__u16 revnat_id = 1;
 
-	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, 1, revnat_id);
+	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 	lb_v6_add_backend(&frontend_ip, FRONTEND_PORT, 1, 124,
 			  &backend_ip, BACKEND_PORT, IPPROTO_TCP, 0);
 

--- a/bpf/tests/tc_nodeport_lb6_no_backend.c
+++ b/bpf/tests/tc_nodeport_lb6_no_backend.c
@@ -90,7 +90,7 @@ int nodeport_no_backend_setup(struct __ctx_buff *ctx)
 
 	memcpy(frontend_ip.addr, (void *)FRONTEND_IP, 16);
 
-	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, 1, revnat_id);
+	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 
 	union v6addr backend_ip = {};
 

--- a/bpf/tests/tc_nodeport_lb_terminating_backend.c
+++ b/bpf/tests/tc_nodeport_lb_terminating_backend.c
@@ -143,7 +143,7 @@ int tc_nodeport_lb_terminating_backend_0_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = SVC_REV_NAT_ID;
 
-	lb_v4_add_service(FRONTEND_IP_LOCAL, FRONTEND_PORT, 1, revnat_id);
+	lb_v4_add_service(FRONTEND_IP_LOCAL, FRONTEND_PORT, IPPROTO_UDP, 1, revnat_id);
 	lb_v4_add_backend(FRONTEND_IP_LOCAL, FRONTEND_PORT, 1, 125,
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_UDP, 0);
 
@@ -256,7 +256,7 @@ int tc_nodeport_lb_terminating_backend_1_setup(struct __ctx_buff *ctx)
 	/* Remove the service's last backend, and flip the backend to
 	 * 'terminating' state.
 	 */
-	lb_v4_upsert_service(FRONTEND_IP_LOCAL, FRONTEND_PORT, 0, revnat_id);
+	lb_v4_upsert_service(FRONTEND_IP_LOCAL, FRONTEND_PORT, IPPROTO_UDP, 0, revnat_id);
 	lb_v4_upsert_backend(125, BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_UDP,
 			     BE_STATE_TERMINATING, 0);
 

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -97,7 +97,7 @@ int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
 
-	lb_v4_add_service(v4_svc_one, tcp_svc_one, 1, revnat_id);
+	lb_v4_add_service(v4_svc_one, tcp_svc_one, IPPROTO_TCP, 1, revnat_id);
 	lb_v4_add_backend(v4_svc_one, tcp_svc_one, 1, 124,
 			  v4_pod_one, tcp_dst_one, IPPROTO_TCP, 0);
 
@@ -506,7 +506,7 @@ int tc_drop_no_backend_setup(struct __ctx_buff *ctx)
 	if (ret)
 		return ret;
 
-	lb_v4_add_service(v4_svc_one, tcp_svc_one, 0, 1);
+	lb_v4_add_service(v4_svc_one, tcp_svc_one, IPPROTO_TCP, 0, 1);
 
 	/* avoid policy drop */
 	policy_add_egress_allow_all_entry();

--- a/bpf/tests/tc_srv6_decap.c
+++ b/bpf/tests/tc_srv6_decap.c
@@ -401,7 +401,7 @@ int srv6_decap_to_service_ipv4_setup(struct __ctx_buff *ctx __maybe_unused)
 
 	map_update_elem(&SRV6_SID_MAP, &sid, &vrf_id, 0);
 
-	lb_v4_add_service(SERVICE_IPV4, SERVICE_PORT, 1, 1);
+	lb_v4_add_service(SERVICE_IPV4, SERVICE_PORT, IPPROTO_TCP, 1, 1);
 	lb_v4_add_backend(SERVICE_IPV4, SERVICE_PORT, 1, 124,
 			  POD_IPV4, SERVICE_PORT, IPPROTO_TCP, 0);
 
@@ -544,7 +544,7 @@ int srv6_decap_to_service_ipv6_setup(struct __ctx_buff *ctx __maybe_unused)
 
 	map_update_elem(&SRV6_SID_MAP, &sid, &vrf_id, 0);
 
-	lb_v6_add_service((const union v6addr *)SERVICE_IPV6, SERVICE_PORT, 1, 1);
+	lb_v6_add_service((const union v6addr *)SERVICE_IPV6, SERVICE_PORT, IPPROTO_TCP, 1, 1);
 	lb_v6_add_backend((const union v6addr *)SERVICE_IPV6, SERVICE_PORT, 1, 124,
 			  (const union v6addr *)POD_IPV6, SERVICE_PORT, IPPROTO_TCP, 0);
 

--- a/bpf/tests/xdp_nodeport_lb4_dsr_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_dsr_lb.c
@@ -107,7 +107,7 @@ int nodeport_dsr_fwd_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
 
-	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, 1, revnat_id);
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, 1, 124,
 			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
 

--- a/bpf/tests/xdp_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_backend.c
@@ -84,7 +84,7 @@ int nodeport_nat_backend_pktgen(struct __ctx_buff *ctx)
 SETUP("xdp", "xdp_nodeport_nat_backend")
 int nodeport_nat_backend_setup(struct __ctx_buff *ctx)
 {
-	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, 1, 1);
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, 1);
 	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, 1, 124,
 			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
 

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -135,7 +135,7 @@ int nodeport_local_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
 
-	lb_v4_add_service(FRONTEND_IP_LOCAL, FRONTEND_PORT, 1, revnat_id);
+	lb_v4_add_service(FRONTEND_IP_LOCAL, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 	lb_v4_add_backend(FRONTEND_IP_LOCAL, FRONTEND_PORT, 1, 124,
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
 
@@ -251,7 +251,7 @@ int nodeport_nat_fwd_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
 
-	lb_v4_add_service(FRONTEND_IP_REMOTE, FRONTEND_PORT, 1, revnat_id);
+	lb_v4_add_service(FRONTEND_IP_REMOTE, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 	lb_v4_add_backend(FRONTEND_IP_REMOTE, FRONTEND_PORT, 1, 124,
 			  BACKEND_IP_REMOTE, BACKEND_PORT, IPPROTO_TCP, 0);
 

--- a/bpf/tests/xdp_nodeport_lb4_test.c
+++ b/bpf/tests/xdp_nodeport_lb4_test.c
@@ -123,7 +123,7 @@ int test1_setup(struct __ctx_buff *ctx)
 	if (ret)
 		return ret;
 
-	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, 1, 1);
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, 1);
 	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, 1, 124,
 			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
 
@@ -209,7 +209,7 @@ int test2_setup(struct __ctx_buff *ctx)
 	if (ret)
 		return ret;
 
-	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, 0, 1);
+	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 0, 1);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, 0);

--- a/bpf/tests/xdp_nodeport_lb6_dsr_lb.c
+++ b/bpf/tests/xdp_nodeport_lb6_dsr_lb.c
@@ -111,7 +111,7 @@ int nodeport_dsr_fwd_setup(struct __ctx_buff *ctx)
 	union v6addr backend_ip = BACKEND_IP;
 	__u16 revnat_id = 1;
 
-	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, 1, revnat_id);
+	lb_v6_add_service(&frontend_ip, FRONTEND_PORT, IPPROTO_TCP, 1, revnat_id);
 	lb_v6_add_backend(&frontend_ip, FRONTEND_PORT, 1, 124,
 			  &backend_ip, BACKEND_PORT, IPPROTO_TCP, 0);
 


### PR DESCRIPTION
Reflect https://github.com/cilium/cilium/pull/33434 in the BPF tests.