### PR TITLE
bgpv1: wait for watchers to be ready in tests

### DIFF
--- a/pkg/bgpv1/test/adverts_test.go
+++ b/pkg/bgpv1/test/adverts_test.go
@@ -139,10 +139,13 @@ func Test_PodCIDRAdvert(t *testing.T) {
 	defer testDone()
 
 	// setup topology
-	gobgpPeers, fixture, cleanup, err := setup(testCtx, t, []gobgpConfig{gobgpConf}, newFixtureConf())
+	gobgpPeers, fixture, ready, cleanup, err := setup(testCtx, t, []gobgpConfig{gobgpConf}, newFixtureConf())
 	require.NoError(t, err)
 	require.Len(t, gobgpPeers, 1)
 	defer cleanup()
+
+	// block till ready
+	ready()
 
 	// setup neighbor
 	err = setupSingleNeighbor(testCtx, fixture, gobgpASN)
@@ -416,10 +419,13 @@ func Test_PodIPPoolAdvert(t *testing.T) {
 	// setup topology
 	cfg := newFixtureConf()
 	cfg.ipam = ipam_option.IPAMMultiPool
-	gobgpPeers, fixture, cleanup, err := setup(testCtx, t, []gobgpConfig{gobgpConf}, cfg)
+	gobgpPeers, fixture, ready, cleanup, err := setup(testCtx, t, []gobgpConfig{gobgpConf}, cfg)
 	require.NoError(t, err)
 	require.Len(t, gobgpPeers, 1)
 	defer cleanup()
+
+	// block till ready
+	ready()
 
 	// setup neighbor
 	err = setupSingleNeighbor(testCtx, fixture, gobgpASN)
@@ -668,10 +674,13 @@ func Test_LBEgressAdvertisementWithLoadBalancerIP(t *testing.T) {
 	defer testDone()
 
 	// setup topology
-	gobgpPeers, fixture, cleanup, err := setup(testCtx, t, []gobgpConfig{gobgpConf}, newFixtureConf())
+	gobgpPeers, fixture, ready, cleanup, err := setup(testCtx, t, []gobgpConfig{gobgpConf}, newFixtureConf())
 	require.NoError(t, err)
 	require.Len(t, gobgpPeers, 1)
 	defer cleanup()
+
+	// block till ready
+	ready()
 
 	// setup neighbor
 	err = setupSingleNeighbor(testCtx, fixture, gobgpASN)
@@ -865,10 +874,13 @@ func Test_LBEgressAdvertisementWithClusterIP(t *testing.T) {
 	defer testDone()
 
 	// setup topology
-	gobgpPeers, fixture, cleanup, err := setup(testCtx, t, []gobgpConfig{gobgpConf}, newFixtureConf())
+	gobgpPeers, fixture, ready, cleanup, err := setup(testCtx, t, []gobgpConfig{gobgpConf}, newFixtureConf())
 	require.NoError(t, err)
 	require.Len(t, gobgpPeers, 1)
 	defer cleanup()
+
+	// block till ready
+	ready()
 
 	// setup neighbor
 	err = setupSingleNeighbor(testCtx, fixture, gobgpASN)
@@ -1062,10 +1074,13 @@ func Test_LBEgressAdvertisementWithExternalIP(t *testing.T) {
 	defer testDone()
 
 	// setup topology
-	gobgpPeers, fixture, cleanup, err := setup(testCtx, t, []gobgpConfig{gobgpConf}, newFixtureConf())
+	gobgpPeers, fixture, ready, cleanup, err := setup(testCtx, t, []gobgpConfig{gobgpConf}, newFixtureConf())
 	require.NoError(t, err)
 	require.Len(t, gobgpPeers, 1)
 	defer cleanup()
+
+	// block till ready
+	ready()
 
 	// setup neighbor
 	err = setupSingleNeighbor(testCtx, fixture, gobgpASN)
@@ -1250,10 +1265,13 @@ func Test_AdvertisedPathAttributes(t *testing.T) {
 	defer testDone()
 
 	// setup topology - iBGP (ASN == ciliumASN)
-	gobgpPeers, fixture, cleanup, err := setup(testCtx, t, []gobgpConfig{gobgpConfIBGP}, newFixtureConf())
+	gobgpPeers, fixture, ready, cleanup, err := setup(testCtx, t, []gobgpConfig{gobgpConfIBGP}, newFixtureConf())
 	require.NoError(t, err)
 	require.Len(t, gobgpPeers, 1)
 	defer cleanup()
+
+	// block till ready
+	ready()
 
 	// setup neighbor - iBGP (ASN == ciliumASN)
 	err = setupSingleNeighbor(testCtx, fixture, ciliumASN)

--- a/pkg/bgpv1/test/neighbor_test.go
+++ b/pkg/bgpv1/test/neighbor_test.go
@@ -126,10 +126,12 @@ func Test_NeighborAddDel(t *testing.T) {
 	defer testDone()
 
 	// test setup, we configure two gobgp instances here.
-	gobgpInstances, fixture, cleanup, err := setup(testCtx, t, []gobgpConfig{gobgpConfPassword, gobgpConf2}, newFixtureConf())
+	gobgpInstances, fixture, ready, cleanup, err := setup(testCtx, t, []gobgpConfig{gobgpConfPassword, gobgpConf2}, newFixtureConf())
 	require.NoError(t, err)
 	require.Len(t, gobgpInstances, 2)
 	defer cleanup()
+
+	ready()
 
 	for _, step := range steps {
 		t.Run(step.description, func(t *testing.T) {
@@ -268,11 +270,12 @@ func Test_NeighborGracefulRestart(t *testing.T) {
 	defer testDone()
 
 	// test setup, we configure single gobgp instance here.
-	gobgpInstances, fixture, cleanup, err := setup(testCtx, t, []gobgpConfig{gobgpConf}, newFixtureConf())
+	gobgpInstances, fixture, ready, cleanup, err := setup(testCtx, t, []gobgpConfig{gobgpConf}, newFixtureConf())
 	require.NoError(t, err)
 	require.Len(t, gobgpInstances, 1)
 	defer cleanup()
 
+	ready()
 	for _, step := range steps {
 		t.Run(step.description, func(t *testing.T) {
 			// update bgp policy with neighbors defined in test step


### PR DESCRIPTION
Introduce ready callback method in tests which checks that all expected watchers are initialized properly.

With this change
```
3m55s: 1724 runs so far, 0 failures
4m0s: 1762 runs so far, 0 failures
```

WIthout this change 
```
4m10s: 1784 runs so far, 2 failures (0.11%)
4m15s: 1824 runs so far, 2 failures (0.11%)
```

Main symptom of the issue is missing peer in Cilium, 

working case 
```
time="2025-02-26T21:12:55.270568103Z" level=info msg="Cilium BGP Control Plane Controller now running..." component=Controller.Run subsys=bgp-control-plane
time="2025-02-26T21:12:55.270986361Z" level=info msg="Registering BGP servers for policy with local ASN 65001" component=manager.registerBGPServer subsys=bgp-control-plane
time="2025-02-26T21:12:55.271844878Z" level=info msg="Adding peer 172.16.100.2/32 65011 to local ASN 65001" component=NeighborReconciler subsys=bgp-control-plane
time="2025-02-26T21:12:55.272004464Z" level=info msg="Add a peer configuration" Key=172.16.100.2 Topic=Peer asn=65001 component=gobgp.BgpServerInstance subsys=bgp-control-plane
time="2025-02-26T21:12:55.272177843Z" level=info msg="Successfully registered GoBGP servers for policy with local ASN 65001" component=manager.registerBGPServer subsys=bgp-control-plane
```

non-working case, we skip adding peer.
```
time="2025-02-26T20:41:50.81480455Z" level=info msg="Cilium BGP Control Plane Controller now running..." component=Controller.Run subsys=bgp-control-plane
time="2025-02-26T20:41:50.814996428Z" level=info msg="Registering BGP servers for policy with local ASN 65001" component=manager.registerBGPServer subsys=bgp-control-plane
time="2025-02-26T20:41:50.81528835Z" level=info msg="Successfully registered GoBGP servers for policy with local ASN 65001" component=manager.registerBGPServer subsys=bgp-control-plane

```

Fixes: #35607