### PR TITLE
Use Hive to provide resource list to k8swatcher.

### DIFF
--- a/pkg/k8s/watchers/cell.go
+++ b/pkg/k8s/watchers/cell.go
@@ -27,6 +27,8 @@ var Cell = cell.Module(
 	cell.Provide(newK8sEventReporter),
 )
 
+type ResourceGroupFunc = func(cfg WatcherConfiguration) (resourceGroups, waitForCachesOnly []string)
+
 type k8sWatcherParams struct {
 	cell.In
 
@@ -44,10 +46,12 @@ type k8sWatcherParams struct {
 	Clientset         k8sClient.Clientset
 	K8sResourceSynced *k8sSynced.Resources
 	K8sAPIGroups      *k8sSynced.APIGroups
+	ResourceGroupsFn  ResourceGroupFunc
 }
 
 func newK8sWatcher(params k8sWatcherParams) *K8sWatcher {
 	return newWatcher(
+		params.ResourceGroupsFn,
 		params.Clientset,
 		params.K8sPodWatcher,
 		params.K8sCiliumNodeWatcher,

--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -19,6 +19,7 @@ import (
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
+	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -61,7 +62,7 @@ type K8sNamespaceWatcher struct {
 }
 
 func (k *K8sNamespaceWatcher) namespacesInit() {
-	apiGroup := k8sAPIGroupNamespaceV1Core
+	apiGroup := resources.K8sAPIGroupNamespaceV1Core
 
 	var synced atomic.Bool
 

--- a/pkg/k8s/watchers/resources/resources.go
+++ b/pkg/k8s/watchers/resources/resources.go
@@ -12,6 +12,10 @@ import (
 )
 
 const (
+	// K8sAPIGroupNetworkingV1Core is the identifier for K8S resources of type networking.k8s.io/v1/NetworkPolicy
+	K8sAPIGroupNetworkingV1Core = "networking.k8s.io/v1::NetworkPolicy"
+	// K8sAPIGroupNamespaceV1Core is the identifier for K8s resources of type core/v1/Namespace.
+	K8sAPIGroupNamespaceV1Core = "core/v1::Namespace"
 	// K8sAPIGroupServiceV1Core is the identifier for K8s resources of type core/v1/Service.
 	K8sAPIGroupServiceV1Core = "core/v1::Service"
 	// K8sAPIGroupPodV1Core is the identifier for K8s resources of type core/v1/Pod.

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -28,6 +28,9 @@ func Test_No_Resources_InitK8sSubsystem(t *testing.T) {
 	fakeClientSet, _ := client.NewFakeClientset(hivetest.Logger(t))
 
 	w := newWatcher(
+		func(cfg WatcherConfiguration) (resourceGroups []string, waitForCachesOnly []string) {
+			return []string{}, []string{}
+		},
 		fakeClientSet,
 		&K8sPodWatcher{
 			controllersStarted: make(chan struct{}),
@@ -44,10 +47,6 @@ func Test_No_Resources_InitK8sSubsystem(t *testing.T) {
 		nil,
 		&fakeK8sWatcherConfiguration{},
 	)
-
-	w.resourceGroupsFn = func(cfg WatcherConfiguration) (resourceGroups []string, waitForCachesOnly []string) {
-		return []string{}, []string{}
-	}
 
 	// ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	deadline, _ := t.Deadline()


### PR DESCRIPTION
### Description
`K8sWatcher` receives the list of resources to watch via its member field `resourceGroupFn`, currently hardcoded as a static function in its constructor `newWatcher`.

To align with other parameters, provide it in the `ControlPlane` Hive cell.
This moves the responsibility for config specification fully out of the configured component to its user.

### Details:
- Add `ResourceGroupsFn` to `k8sWatcherParams`
- New function `GetGroupsForCiliumResources` deals with transforming resource names between domains defined in the `watchers` package, while its caller `allResourceGroupsFn` supplies the config in its format.

