### PR TITLE
policy: Move L7 parser type to PerSelectorPolicy

### DIFF
--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -572,7 +572,7 @@ func TestProxyID(t *testing.T) {
 	require.Equal(t, "", listener)
 	require.NoError(t, err)
 
-	id, port, proto = e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true, L7Parser: policy.ParserTypeCRD}, "test-listener")
+	id, port, proto = e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true}, "test-listener")
 	require.NotEqual(t, "", id)
 	require.Equal(t, uint16(8080), port)
 	require.Equal(t, u8proto.TCP, proto)

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -397,7 +397,7 @@ func TestRedirectWithDeny(t *testing.T) {
 
 	expected := policy.MapStateMap{
 		mapKeyAllowAllE: policyTypes.AllowEntry(),
-		mapKeyAllL7:     policyTypes.AllowEntry().WithProxyPort(httpPort),
+		mapKeyAllL7:     policyTypes.AllowEntry().WithProxyPort(httpPort).WithListenerPriority(policy.ListenerPriorityHTTP),
 		mapKeyFoo:       policyTypes.DenyEntry(),
 	}
 
@@ -528,7 +528,7 @@ func TestRedirectWithPriority(t *testing.T) {
 
 	expected := policy.MapStateMap{
 		mapKeyAllowAllE: policyTypes.AllowEntry(),
-		mapKeyFooL7:     policyTypes.AllowEntry().WithProxyPort(crd2Port).WithProxyPriority(1),
+		mapKeyFooL7:     policyTypes.AllowEntry().WithProxyPort(crd2Port).WithListenerPriority(1),
 		mapKeyAllL7:     policyTypes.AllowEntry(),
 	}
 	ep.ValidateRuleLabels(t, LabelArrayListMap{
@@ -583,7 +583,7 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 
 	expected := policy.MapStateMap{
 		mapKeyAllowAllE: policyTypes.AllowEntry(),
-		mapKeyFooL7:     policyTypes.AllowEntry().WithProxyPort(crd1Port).WithProxyPriority(1),
+		mapKeyFooL7:     policyTypes.AllowEntry().WithProxyPort(crd1Port).WithListenerPriority(1),
 		mapKeyAllL7:     policyTypes.AllowEntry(),
 	}
 	ep.ValidateRuleLabels(t, LabelArrayListMap{

--- a/pkg/maps/policymap/policymap_test.go
+++ b/pkg/maps/policymap/policymap_test.go
@@ -460,28 +460,28 @@ func TestNewEntryFromPolicyEntry(t *testing.T) {
 		// Proxy tcp 80 to proxy port 1337
 		{
 			key: policyTypes.EgressKey().WithTCPPort(80).WithIdentity(1234),
-			in:  policyTypes.AllowEntry().WithProxyPort(1337).WithProxyPriority(42),
+			in:  policyTypes.AllowEntry().WithProxyPort(1337).WithListenerPriority(42),
 			want: PolicyEntry{
 				Flags: getPolicyEntryFlags(policyEntryFlagParams{
 					IsDeny:    false,
 					PrefixLen: 24,
 				}),
 				ProxyPortNetwork:  byteorder.HostToNetwork16(1337),
-				ProxyPortPriority: 255 - 42, //prio is inverted
+				ProxyPortPriority: 128 - 42, //prio is inverted
 			},
 		},
 
 		// proxy ports 4-7
 		{
 			key: policyTypes.EgressKey().WithTCPPortPrefix(4, 14).WithIdentity(1234),
-			in:  policyTypes.AllowEntry().WithProxyPort(1337).WithProxyPriority(42),
+			in:  policyTypes.AllowEntry().WithProxyPort(1337).WithListenerPriority(42),
 			want: PolicyEntry{
 				Flags: getPolicyEntryFlags(policyEntryFlagParams{
 					IsDeny:    false,
 					PrefixLen: 22,
 				}),
 				ProxyPortNetwork:  byteorder.HostToNetwork16(1337),
-				ProxyPortPriority: 255 - 42, //prio is inverted
+				ProxyPortPriority: 128 - 42, //prio is inverted
 			},
 		},
 	}

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -356,7 +356,7 @@ var (
 		return denyEntry().withLabels(lbls)
 	}
 	mapEntryL7Proxy = func(lbls ...labels.LabelArray) mapStateEntry {
-		return allowEntry().withLabels(lbls).withProxyPort(1)
+		return allowEntry().withLabels(lbls).withHTTPProxyPort(1)
 	}
 )
 

--- a/pkg/policy/l4_filter_deny_test.go
+++ b/pkg/policy/l4_filter_deny_test.go
@@ -69,7 +69,6 @@ func TestMergeDenyAllL3(t *testing.T) {
 		Protocol: api.ProtoTCP,
 		U8Proto:  6,
 		wildcard: td.wildcardCachedSelector,
-		L7Parser: "",
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: &PerSelectorPolicy{IsDeny: true},
 		},
@@ -147,7 +146,6 @@ func TestL3DenyRuleShadowedByL3DenyAll(t *testing.T) {
 		Protocol: api.ProtoTCP,
 		U8Proto:  6,
 		wildcard: td.wildcardCachedSelector,
-		L7Parser: ParserTypeNone,
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorA:        &PerSelectorPolicy{IsDeny: true},
 			td.wildcardCachedSelector: &PerSelectorPolicy{IsDeny: true},
@@ -193,7 +191,6 @@ func TestL3DenyRuleShadowedByL3DenyAll(t *testing.T) {
 		Protocol: api.ProtoTCP,
 		U8Proto:  6,
 		wildcard: td.wildcardCachedSelector,
-		L7Parser: ParserTypeNone,
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: &PerSelectorPolicy{IsDeny: true},
 			td.cachedSelectorA:        &PerSelectorPolicy{IsDeny: true},
@@ -243,7 +240,6 @@ func TestMergingWithDifferentEndpointSelectedDenyAllL7(t *testing.T) {
 		Protocol: api.ProtoTCP,
 		U8Proto:  6,
 		wildcard: nil,
-		L7Parser: ParserTypeNone,
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorA: &PerSelectorPolicy{IsDeny: true},
 			td.cachedSelectorC: &PerSelectorPolicy{IsDeny: true},
@@ -297,7 +293,6 @@ func TestL3AllowRuleShadowedByL3DenyAll(t *testing.T) {
 		Protocol: api.ProtoTCP,
 		U8Proto:  6,
 		wildcard: td.wildcardCachedSelector,
-		L7Parser: ParserTypeNone,
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorA:        &PerSelectorPolicy{IsDeny: true},
 			td.wildcardCachedSelector: nil,
@@ -345,7 +340,6 @@ func TestL3AllowRuleShadowedByL3DenyAll(t *testing.T) {
 		Protocol: api.ProtoTCP,
 		U8Proto:  6,
 		wildcard: td.wildcardCachedSelector,
-		L7Parser: ParserTypeNone,
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorA:        &PerSelectorPolicy{IsDeny: true},
 			td.wildcardCachedSelector: nil,
@@ -404,14 +398,14 @@ func TestL3L4AllowRuleWithByL3DenyAll(t *testing.T) {
 		Protocol: api.ProtoTCP,
 		U8Proto:  6,
 		wildcard: td.wildcardCachedSelector,
-		L7Parser: ParserTypeHTTP,
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorA: &PerSelectorPolicy{IsDeny: true},
 			td.wildcardCachedSelector: &PerSelectorPolicy{
+				L7Parser: ParserTypeHTTP,
+				Priority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 				},
-				isRedirect: true,
 			},
 		},
 		Ingress: true,
@@ -462,14 +456,14 @@ func TestL3L4AllowRuleWithByL3DenyAll(t *testing.T) {
 		Protocol: api.ProtoTCP,
 		U8Proto:  6,
 		wildcard: td.wildcardCachedSelector,
-		L7Parser: ParserTypeHTTP,
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorA: &PerSelectorPolicy{IsDeny: true},
 			td.wildcardCachedSelector: &PerSelectorPolicy{
+				L7Parser: ParserTypeHTTP,
+				Priority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 				},
-				isRedirect: true,
 			},
 		},
 		Ingress: true,

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -153,22 +153,22 @@ func TestCreateL4Filter(t *testing.T) {
 		filter, err := createL4IngressFilter(td.testPolicyContext, eps, nil, nil, portrule, tuple, tuple.Protocol, EmptyStringLabels)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
-		for _, r := range filter.PerSelectorPolicies {
-			explicit, authType := r.getAuthType()
+		for _, sp := range filter.PerSelectorPolicies {
+			explicit, authType := sp.getAuthType()
 			require.False(t, explicit)
 			require.Equal(t, AuthTypeDisabled, authType)
+			require.Equal(t, redirectTypeEnvoy, sp.redirectType())
 		}
-		require.Equal(t, redirectTypeEnvoy, filter.redirectType())
 
 		filter, err = createL4EgressFilter(td.testPolicyContext, eps, nil, portrule, tuple, tuple.Protocol, EmptyStringLabels, nil)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
-		for _, r := range filter.PerSelectorPolicies {
-			explicit, authType := r.getAuthType()
+		for _, sp := range filter.PerSelectorPolicies {
+			explicit, authType := sp.getAuthType()
 			require.False(t, explicit)
 			require.Equal(t, AuthTypeDisabled, authType)
+			require.Equal(t, redirectTypeEnvoy, sp.redirectType())
 		}
-		require.Equal(t, redirectTypeEnvoy, filter.redirectType())
 	}
 }
 
@@ -197,22 +197,22 @@ func TestCreateL4FilterAuthRequired(t *testing.T) {
 		filter, err := createL4IngressFilter(td.testPolicyContext, eps, auth, nil, portrule, tuple, tuple.Protocol, EmptyStringLabels)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
-		for _, r := range filter.PerSelectorPolicies {
-			explicit, authType := r.getAuthType()
+		for _, sp := range filter.PerSelectorPolicies {
+			explicit, authType := sp.getAuthType()
 			require.True(t, explicit)
 			require.Equal(t, AuthTypeDisabled, authType)
+			require.Equal(t, redirectTypeEnvoy, sp.redirectType())
 		}
-		require.Equal(t, redirectTypeEnvoy, filter.redirectType())
 
 		filter, err = createL4EgressFilter(td.testPolicyContext, eps, auth, portrule, tuple, tuple.Protocol, EmptyStringLabels, nil)
 		require.NoError(t, err)
 		require.Len(t, filter.PerSelectorPolicies, 1)
-		for _, r := range filter.PerSelectorPolicies {
-			explicit, authType := r.getAuthType()
+		for _, sp := range filter.PerSelectorPolicies {
+			explicit, authType := sp.getAuthType()
 			require.True(t, explicit)
 			require.Equal(t, AuthTypeDisabled, authType)
+			require.Equal(t, redirectTypeEnvoy, sp.redirectType())
 		}
-		require.Equal(t, redirectTypeEnvoy, filter.redirectType())
 	}
 }
 
@@ -278,9 +278,9 @@ func TestJSONMarshal(t *testing.T) {
 		Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 			"80/TCP": {
 				Port: 80, Protocol: api.ProtoTCP,
-				L7Parser: "http",
 				PerSelectorPolicies: L7DataMap{
 					td.cachedFooSelector: &PerSelectorPolicy{
+						L7Parser: ParserTypeHTTP,
 						L7Rules: api.L7Rules{
 							HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 						},
@@ -290,9 +290,9 @@ func TestJSONMarshal(t *testing.T) {
 			},
 			"9090/TCP": {
 				Port: 9090, Protocol: api.ProtoTCP,
-				L7Parser: "tester",
 				PerSelectorPolicies: L7DataMap{
 					td.cachedFooSelector: &PerSelectorPolicy{
+						L7Parser: "tester",
 						L7Rules: api.L7Rules{
 							L7Proto: "tester",
 							L7: []api.PortRuleL7{
@@ -310,9 +310,9 @@ func TestJSONMarshal(t *testing.T) {
 			},
 			"8080/TCP": {
 				Port: 8080, Protocol: api.ProtoTCP,
-				L7Parser: "http",
 				PerSelectorPolicies: L7DataMap{
 					td.cachedFooSelector: &PerSelectorPolicy{
+						L7Parser: ParserTypeHTTP,
 						L7Rules: api.L7Rules{
 							HTTP: []api.PortRuleHTTP{
 								{Path: "/", Method: "GET"},

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -398,7 +398,7 @@ type mapStateEntry struct {
 }
 
 // newMapStateEntry creates a map state entry.
-func newMapStateEntry(derivedFrom ruleOrigin, proxyPort uint16, priority uint8, deny bool, authReq AuthRequirement) mapStateEntry {
+func newMapStateEntry(derivedFrom ruleOrigin, proxyPort uint16, priority ListenerPriority, deny bool, authReq AuthRequirement) mapStateEntry {
 	return mapStateEntry{
 		MapStateEntry:    types.NewMapStateEntry(deny, proxyPort, priority, authReq),
 		derivedFromRules: derivedFrom,

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -732,7 +732,7 @@ func (ms *mapState) insertWithChanges(newKey Key, newEntry mapStateEntry, featur
 // old entry in 'changes'.
 // Returns 'true' if changes were made.
 func (ms *mapState) overrideProxyPortForAuth(newEntry mapStateEntry, k Key, v mapStateEntry, changes ChangeState) bool {
-	if v.AuthRequirement != newEntry.AuthRequirement && v.AuthRequirement.IsExplicit() {
+	if v.AuthRequirement.IsExplicit() {
 		// Save the old value first
 		changes.insertOldIfNotExists(k, v)
 
@@ -776,9 +776,9 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry mapStateEntry, feat
 			return // bail if covered by deny
 		}
 		if v.ProxyPortPriority > newEntry.ProxyPortPriority {
-			if !newEntryHasExplicitAuth || v.AuthRequirement == newEntry.AuthRequirement {
+			if !newEntryHasExplicitAuth {
 				// Covering entry has higher proxy port priority and newEntry has a
-				// default auth type or the same auth requirement => can bail out
+				// default auth type => can bail out
 				return
 			}
 

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1397,10 +1397,14 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		state: testMapState(mapStateMap{
 			egressKey(43, 6, 0, 0):   proxyPriorityEntry(1, 1),
 			egressKey(43, 6, 80, 12): proxyPriorityEntry(1, 1).withExplicitAuth(AuthTypeSpire),
+			egressKey(43, 6, 80, 16): proxyPriorityEntry(1, 1).withExplicitAuth(AuthTypeSpire),
+			egressKey(43, 6, 81, 16): proxyPriorityEntry(1, 1).withExplicitAuth(AuthTypeSpire),
 		}),
 		adds: Keys{
 			egressKey(43, 6, 0, 0):   {},
 			egressKey(43, 6, 80, 12): {},
+			egressKey(43, 6, 80, 16): {},
+			egressKey(43, 6, 81, 16): {},
 		},
 		deletes: Keys{},
 	}, {
@@ -1415,10 +1419,14 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 		state: testMapState(mapStateMap{
 			egressKey(43, 6, 0, 0):   proxyPriorityEntry(1, 1),
 			egressKey(43, 6, 80, 12): proxyPriorityEntry(1, 1).withExplicitAuth(AuthTypeSpire),
+			egressKey(43, 6, 80, 16): proxyPriorityEntry(1, 1).withExplicitAuth(AuthTypeSpire),
+			egressKey(43, 6, 81, 16): proxyPriorityEntry(1, 1).withExplicitAuth(AuthTypeSpire),
 		}),
 		adds: Keys{
 			egressKey(43, 6, 0, 0):   {},
 			egressKey(43, 6, 80, 12): {},
+			egressKey(43, 6, 80, 16): {},
+			egressKey(43, 6, 81, 16): {},
 		},
 		deletes: Keys{},
 	}, {

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -396,7 +396,6 @@ func TestWildcardL4RulesIngressDeny(t *testing.T) {
 			Port:     80,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			L7Parser: ParserTypeNone,
 			Ingress:  true,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorB: &PerSelectorPolicy{IsDeny: true},
@@ -407,7 +406,6 @@ func TestWildcardL4RulesIngressDeny(t *testing.T) {
 			Port:     9092,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			L7Parser: ParserTypeNone,
 			Ingress:  true,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorB: &PerSelectorPolicy{IsDeny: true},
@@ -598,7 +596,6 @@ func TestWildcardL3RulesEgressDeny(t *testing.T) {
 			Port:     0,
 			Protocol: "ANY",
 			U8Proto:  0x0,
-			L7Parser: "",
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorB: &PerSelectorPolicy{IsDeny: true},
 			},
@@ -609,7 +606,6 @@ func TestWildcardL3RulesEgressDeny(t *testing.T) {
 			Port:     8,
 			Protocol: api.ProtoICMP,
 			U8Proto:  0x1,
-			L7Parser: "",
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorB: &PerSelectorPolicy{IsDeny: true},
 			},
@@ -620,7 +616,6 @@ func TestWildcardL3RulesEgressDeny(t *testing.T) {
 			Port:     128,
 			Protocol: api.ProtoICMPv6,
 			U8Proto:  0x3A,
-			L7Parser: "",
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorB: &PerSelectorPolicy{IsDeny: true},
 			},
@@ -676,7 +671,6 @@ func TestWildcardL4RulesEgressDeny(t *testing.T) {
 			Port:     80,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			L7Parser: ParserTypeNone,
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorB: &PerSelectorPolicy{IsDeny: true},
@@ -687,7 +681,6 @@ func TestWildcardL4RulesEgressDeny(t *testing.T) {
 			Port:     53,
 			Protocol: api.ProtoUDP,
 			U8Proto:  0x11,
-			L7Parser: ParserTypeNone,
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorB: &PerSelectorPolicy{IsDeny: true},
@@ -750,7 +743,6 @@ func TestWildcardCIDRRulesEgressDeny(t *testing.T) {
 			Port:     80,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			L7Parser: ParserTypeNone,
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				cachedSelectors[0]: &PerSelectorPolicy{IsDeny: true},
@@ -761,7 +753,6 @@ func TestWildcardCIDRRulesEgressDeny(t *testing.T) {
 			Port:     0,
 			Protocol: api.ProtoAny,
 			U8Proto:  0x0,
-			L7Parser: ParserTypeNone,
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				cachedSelectors[0]: &PerSelectorPolicy{IsDeny: true},
@@ -793,7 +784,6 @@ func TestWildcardL3RulesIngressDenyFromEntities(t *testing.T) {
 			Port:     0,
 			Protocol: "ANY",
 			U8Proto:  0x0,
-			L7Parser: "",
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorWorld:   &PerSelectorPolicy{IsDeny: true},
 				td.cachedSelectorWorldV4: &PerSelectorPolicy{IsDeny: true},
@@ -834,7 +824,6 @@ func TestWildcardL3RulesEgressDenyToEntities(t *testing.T) {
 			Port:     0,
 			Protocol: "ANY",
 			U8Proto:  0x0,
-			L7Parser: "",
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorWorld:   &PerSelectorPolicy{IsDeny: true},
 				td.cachedSelectorWorldV4: &PerSelectorPolicy{IsDeny: true},
@@ -870,7 +859,6 @@ func TestMinikubeGettingStartedDeny(t *testing.T) {
 
 	expectedDeny := NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-		L7Parser: ParserTypeNone,
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorB: &PerSelectorPolicy{IsDeny: true},
 		},

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -455,14 +455,14 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 			Port:     9092,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			L7Parser: ParserTypeKafka,
 			Ingress:  true,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
+					L7Parser: ParserTypeKafka,
+					Priority: ListenerPriorityKafka,
 					L7Rules: api.L7Rules{
 						Kafka: []kafka.PortRule{kafkaRule.Ingress[0].ToPorts[0].Rules.Kafka[0]},
 					},
-					isRedirect: true,
 				},
 			},
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsKafka}}),
@@ -471,14 +471,14 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 			Port:     80,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			L7Parser: ParserTypeHTTP,
 			Ingress:  true,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
+					L7Parser: ParserTypeHTTP,
+					Priority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{httpRule.Ingress[0].ToPorts[0].Rules.HTTP[0]},
 					},
-					isRedirect: true,
 				},
 			},
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsHTTP}}),
@@ -487,15 +487,15 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 			Port:     9090,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			L7Parser: L7ParserType("tester"),
 			Ingress:  true,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
+					L7Parser: L7ParserType("tester"),
+					Priority: ListenerPriorityProxylib,
 					L7Rules: api.L7Rules{
 						L7Proto: "tester",
 						L7:      []api.PortRuleL7{l7Rule.Ingress[0].ToPorts[0].Rules.L7[0]},
 					},
-					isRedirect: true,
 				},
 			},
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsL7}}),
@@ -593,15 +593,15 @@ func TestWildcardL4RulesIngress(t *testing.T) {
 			Port:     80,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			L7Parser: ParserTypeHTTP,
 			Ingress:  true,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar1: nil,
 				td.cachedSelectorBar2: &PerSelectorPolicy{
+					L7Parser: ParserTypeHTTP,
+					Priority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{httpRule.Ingress[0].ToPorts[0].Rules.HTTP[0]},
 					},
-					isRedirect: true,
 				},
 			},
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
@@ -613,15 +613,15 @@ func TestWildcardL4RulesIngress(t *testing.T) {
 			Port:     9092,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			L7Parser: ParserTypeKafka,
 			Ingress:  true,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar1: nil,
 				td.cachedSelectorBar2: &PerSelectorPolicy{
+					L7Parser: ParserTypeKafka,
+					Priority: ListenerPriorityKafka,
 					L7Rules: api.L7Rules{
 						Kafka: []kafka.PortRule{kafkaRule.Ingress[0].ToPorts[0].Rules.Kafka[0]},
 					},
-					isRedirect: true,
 				},
 			},
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
@@ -864,14 +864,14 @@ func TestWildcardL3RulesEgress(t *testing.T) {
 			Port:     53,
 			Protocol: api.ProtoUDP,
 			U8Proto:  0x11,
-			L7Parser: ParserTypeDNS,
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
+					L7Parser: ParserTypeDNS,
+					Priority: ListenerPriorityDNS,
 					L7Rules: api.L7Rules{
 						DNS: []api.PortRuleDNS{dnsRule.Egress[0].ToPorts[0].Rules.DNS[0]},
 					},
-					isRedirect: true,
 				},
 			},
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsDNS}}),
@@ -880,14 +880,14 @@ func TestWildcardL3RulesEgress(t *testing.T) {
 			Port:     80,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			L7Parser: ParserTypeHTTP,
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
+					L7Parser: ParserTypeHTTP,
+					Priority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{httpRule.Egress[0].ToPorts[0].Rules.HTTP[0]},
 					},
-					isRedirect: true,
 				},
 			},
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsHTTP}}),
@@ -916,7 +916,6 @@ func TestWildcardL3RulesEgress(t *testing.T) {
 			Port:     0,
 			Protocol: "ANY",
 			U8Proto:  0x0,
-			L7Parser: "",
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar1: nil,
 			},
@@ -1016,15 +1015,15 @@ func TestWildcardL4RulesEgress(t *testing.T) {
 			Port:     80,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			L7Parser: ParserTypeHTTP,
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar1: nil,
 				td.cachedSelectorBar2: &PerSelectorPolicy{
+					L7Parser: ParserTypeHTTP,
+					Priority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{httpRule.Egress[0].ToPorts[0].Rules.HTTP[0]},
 					},
-					isRedirect: true,
 				},
 			},
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
@@ -1036,15 +1035,15 @@ func TestWildcardL4RulesEgress(t *testing.T) {
 			Port:     53,
 			Protocol: api.ProtoUDP,
 			U8Proto:  0x11,
-			L7Parser: ParserTypeDNS,
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar1: nil,
 				td.cachedSelectorBar2: &PerSelectorPolicy{
+					L7Parser: ParserTypeDNS,
+					Priority: ListenerPriorityDNS,
 					L7Rules: api.L7Rules{
 						DNS: []api.PortRuleDNS{dnsRule.Egress[0].ToPorts[0].Rules.DNS[0]},
 					},
-					isRedirect: true,
 				},
 			},
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
@@ -1118,10 +1117,11 @@ func TestWildcardCIDRRulesEgress(t *testing.T) {
 			Port:     80,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			L7Parser: ParserTypeHTTP,
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				cachedSelectors[0]: &PerSelectorPolicy{
+					L7Parser: ParserTypeHTTP,
+					Priority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{{
 							Headers: []string{"X-My-Header: true"},
@@ -1129,7 +1129,6 @@ func TestWildcardCIDRRulesEgress(t *testing.T) {
 							Path:    "/",
 						}},
 					},
-					isRedirect: true,
 				},
 			},
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{cachedSelectors[0]: {labelsHTTP}}),
@@ -1138,7 +1137,6 @@ func TestWildcardCIDRRulesEgress(t *testing.T) {
 			Port:     0,
 			Protocol: api.ProtoAny,
 			U8Proto:  0x0,
-			L7Parser: ParserTypeNone,
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				cachedSelectors[0]: nil,
@@ -1215,7 +1213,6 @@ func TestWildcardL3RulesIngressFromEntities(t *testing.T) {
 			Port:     0,
 			Protocol: "ANY",
 			U8Proto:  0x0,
-			L7Parser: "",
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorWorld:   nil,
 				td.cachedSelectorWorldV4: nil,
@@ -1232,14 +1229,14 @@ func TestWildcardL3RulesIngressFromEntities(t *testing.T) {
 			Port:     9092,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			L7Parser: ParserTypeKafka,
 			Ingress:  true,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
+					L7Parser: ParserTypeKafka,
+					Priority: ListenerPriorityKafka,
 					L7Rules: api.L7Rules{
 						Kafka: []kafka.PortRule{kafkaRule.Ingress[0].ToPorts[0].Rules.Kafka[0]},
 					},
-					isRedirect: true,
 				},
 			},
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsKafka}}),
@@ -1248,14 +1245,14 @@ func TestWildcardL3RulesIngressFromEntities(t *testing.T) {
 			Port:     80,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			L7Parser: ParserTypeHTTP,
 			Ingress:  true,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
+					L7Parser: ParserTypeHTTP,
+					Priority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{httpRule.Ingress[0].ToPorts[0].Rules.HTTP[0]},
 					},
-					isRedirect: true,
 				},
 			},
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsHTTP}}),
@@ -1329,7 +1326,6 @@ func TestWildcardL3RulesEgressToEntities(t *testing.T) {
 			Port:     0,
 			Protocol: "ANY",
 			U8Proto:  0x0,
-			L7Parser: "",
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorWorld:   nil,
 				td.cachedSelectorWorldV4: nil,
@@ -1346,14 +1342,14 @@ func TestWildcardL3RulesEgressToEntities(t *testing.T) {
 			Port:     53,
 			Protocol: api.ProtoUDP,
 			U8Proto:  0x11,
-			L7Parser: ParserTypeDNS,
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
+					L7Parser: ParserTypeDNS,
+					Priority: ListenerPriorityDNS,
 					L7Rules: api.L7Rules{
 						DNS: []api.PortRuleDNS{dnsRule.Egress[0].ToPorts[0].Rules.DNS[0]},
 					},
-					isRedirect: true,
 				},
 			},
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsDNS}}),
@@ -1362,14 +1358,14 @@ func TestWildcardL3RulesEgressToEntities(t *testing.T) {
 			Port:     80,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			L7Parser: ParserTypeHTTP,
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
+					L7Parser: ParserTypeHTTP,
+					Priority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{httpRule.Egress[0].ToPorts[0].Rules.HTTP[0]},
 					},
-					isRedirect: true,
 				},
 			},
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsHTTP}}),
@@ -1442,13 +1438,13 @@ func TestMinikubeGettingStarted(t *testing.T) {
 
 	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{"TCP/80": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-		L7Parser: ParserTypeHTTP,
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorB: &PerSelectorPolicy{
+				L7Parser: ParserTypeHTTP,
+				Priority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Method: "GET", Path: "/"}, {}},
 				},
-				isRedirect: true,
 			},
 		},
 		Ingress:    true,

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -381,11 +381,9 @@ func (p *selectorPolicy) RedirectFilters() iter.Seq2[*L4Filter, *PerSelectorPoli
 func (l4policy L4DirectionPolicy) forEachRedirectFilter(yield func(*L4Filter, *PerSelectorPolicy) bool) bool {
 	ok := true
 	l4policy.PortRules.ForEach(func(l4 *L4Filter) bool {
-		if l4.IsRedirect() {
-			for _, ps := range l4.PerSelectorPolicies {
-				if ps != nil && ps.IsRedirect() {
-					ok = yield(l4, ps)
-				}
+		for _, ps := range l4.PerSelectorPolicies {
+			if ps != nil && ps.IsRedirect() {
+				ok = yield(l4, ps)
 			}
 		}
 		return ok

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -257,7 +257,6 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
 						wildcard: td.wildcardCachedSelector,
-						L7Parser: ParserTypeNone,
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
 							td.wildcardCachedSelector: &PerSelectorPolicy{IsDeny: true},
@@ -352,7 +351,6 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
 						wildcard: td.wildcardCachedSelector,
-						L7Parser: ParserTypeNone,
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
 							td.wildcardCachedSelector: &PerSelectorPolicy{IsDeny: true},
@@ -447,7 +445,6 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
 						wildcard: td.wildcardCachedSelector,
-						L7Parser: ParserTypeNone,
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
 							td.wildcardCachedSelector: &PerSelectorPolicy{IsDeny: true},
@@ -603,7 +600,6 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
-						L7Parser: ParserTypeNone,
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
 							cachedSelectorWorld:   &PerSelectorPolicy{IsDeny: true},

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -285,15 +285,15 @@ func TestL7WithIngressWildcard(t *testing.T) {
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
 						wildcard: td.wildcardCachedSelector,
-						L7Parser: ParserTypeHTTP,
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
 							td.wildcardCachedSelector: &PerSelectorPolicy{
+								L7Parser: ParserTypeHTTP,
+								Priority: ListenerPriorityHTTP,
 								L7Rules: api.L7Rules{
 									HTTP: []api.PortRuleHTTP{{Method: "GET", Path: "/good"}},
 								},
 								CanShortCircuit: true,
-								isRedirect:      true,
 							},
 						},
 						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
@@ -397,15 +397,15 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
 						wildcard: td.wildcardCachedSelector,
-						L7Parser: ParserTypeHTTP,
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
 							td.wildcardCachedSelector: &PerSelectorPolicy{
+								L7Parser: ParserTypeHTTP,
+								Priority: ListenerPriorityHTTP,
 								L7Rules: api.L7Rules{
 									HTTP: []api.PortRuleHTTP{{Method: "GET", Path: "/good"}},
 								},
 								CanShortCircuit: true,
-								isRedirect:      true,
 							},
 							cachedSelectorHost: nil,
 						},
@@ -504,7 +504,6 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
 						wildcard: td.wildcardCachedSelector,
-						L7Parser: ParserTypeNone,
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
 							td.wildcardCachedSelector: nil,
@@ -662,7 +661,6 @@ func TestMapStateWithIngress(t *testing.T) {
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
-						L7Parser: ParserTypeNone,
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
 							cachedSelectorWorld:   nil,

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -55,22 +55,23 @@ func TestL4Policy(t *testing.T) {
 	}
 	l7map := L7DataMap{
 		td.wildcardCachedSelector: &PerSelectorPolicy{
-			L7Rules:    l7rules,
-			isRedirect: true,
+			L7Parser: ParserTypeHTTP,
+			Priority: ListenerPriorityHTTP,
+			L7Rules:  l7rules,
 		},
 	}
 
 	expected := NewL4Policy(0)
 	expected.Ingress.PortRules.Upsert("80", 0, "TCP", &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-		wildcard: td.wildcardCachedSelector,
-		L7Parser: "http", PerSelectorPolicies: l7map, Ingress: true,
+		wildcard:            td.wildcardCachedSelector,
+		PerSelectorPolicies: l7map, Ingress: true,
 		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
 	expected.Ingress.PortRules.Upsert("8080", 0, "TCP", &L4Filter{
 		Port: 8080, Protocol: api.ProtoTCP, U8Proto: 6,
-		wildcard: td.wildcardCachedSelector,
-		L7Parser: "http", PerSelectorPolicies: l7map, Ingress: true,
+		wildcard:            td.wildcardCachedSelector,
+		PerSelectorPolicies: l7map, Ingress: true,
 		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
 
@@ -143,13 +144,13 @@ func TestL4Policy(t *testing.T) {
 		Protocol: api.ProtoTCP,
 		U8Proto:  6,
 		wildcard: td.wildcardCachedSelector,
-		L7Parser: ParserTypeHTTP,
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: &PerSelectorPolicy{
+				L7Parser: ParserTypeHTTP,
+				Priority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}, {}},
 				},
-				isRedirect: true,
 			},
 		},
 		Ingress:    true,
@@ -217,7 +218,7 @@ func TestMergeL4PolicyIngress(t *testing.T) {
 	}
 	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-		L7Parser: ParserTypeNone, PerSelectorPolicies: mergedES, Ingress: true,
+		PerSelectorPolicies: mergedES, Ingress: true,
 		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedFooSelector: {nil},
 			td.cachedBazSelector: {nil},
@@ -262,7 +263,7 @@ func TestMergeL4PolicyEgress(t *testing.T) {
 	}
 	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-		L7Parser: ParserTypeNone, PerSelectorPolicies: mergedES, Ingress: false,
+		PerSelectorPolicies: mergedES, Ingress: false,
 		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorB: {nil},
 			td.cachedSelectorC: {nil},
@@ -319,19 +320,20 @@ func TestMergeL7PolicyIngress(t *testing.T) {
 		Protocol: api.ProtoTCP,
 		U8Proto:  6,
 		wildcard: td.wildcardCachedSelector,
-		L7Parser: ParserTypeHTTP,
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: &PerSelectorPolicy{
+				L7Parser: ParserTypeHTTP,
+				Priority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}, {}},
 				},
-				isRedirect: true,
 			},
 			td.cachedSelectorB: &PerSelectorPolicy{
+				L7Parser: ParserTypeHTTP,
+				Priority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 				},
-				isRedirect: true,
 			},
 		},
 		Ingress: true,
@@ -380,19 +382,21 @@ func TestMergeL7PolicyIngress(t *testing.T) {
 	}
 	l7map := L7DataMap{
 		td.wildcardCachedSelector: &PerSelectorPolicy{
-			L7Rules:    l7rules,
-			isRedirect: true,
+			L7Parser: ParserTypeKafka,
+			Priority: ListenerPriorityKafka,
+			L7Rules:  l7rules,
 		},
 		td.cachedSelectorB: &PerSelectorPolicy{
-			L7Rules:    l7rules,
-			isRedirect: true,
+			L7Parser: ParserTypeKafka,
+			Priority: ListenerPriorityKafka,
+			L7Rules:  l7rules,
 		},
 	}
 
 	expected = NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-		wildcard: td.wildcardCachedSelector,
-		L7Parser: "kafka", PerSelectorPolicies: l7map, Ingress: true,
+		wildcard:            td.wildcardCachedSelector,
+		PerSelectorPolicies: l7map, Ingress: true,
 		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorB:        {nil},
 			td.wildcardCachedSelector: {nil},
@@ -451,18 +455,20 @@ func TestMergeL7PolicyIngress(t *testing.T) {
 	// The L3-dependent L7 rules are not merged together.
 	l7map = L7DataMap{
 		td.cachedSelectorB: &PerSelectorPolicy{
-			L7Rules:    fooRules,
-			isRedirect: true,
+			L7Parser: ParserTypeKafka,
+			Priority: ListenerPriorityKafka,
+			L7Rules:  fooRules,
 		},
 		td.wildcardCachedSelector: &PerSelectorPolicy{
-			L7Rules:    barRules,
-			isRedirect: true,
+			L7Parser: ParserTypeKafka,
+			Priority: ListenerPriorityKafka,
+			L7Rules:  barRules,
 		},
 	}
 	expected = NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-		wildcard: td.wildcardCachedSelector,
-		L7Parser: "kafka", PerSelectorPolicies: l7map, Ingress: true,
+		wildcard:            td.wildcardCachedSelector,
+		PerSelectorPolicies: l7map, Ingress: true,
 		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorB:        {nil},
 			td.wildcardCachedSelector: {nil},
@@ -518,19 +524,20 @@ func TestMergeL7PolicyEgress(t *testing.T) {
 	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		wildcard: td.wildcardCachedSelector,
-		L7Parser: ParserTypeHTTP,
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: &PerSelectorPolicy{
+				L7Parser: ParserTypeHTTP,
+				Priority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/public", Method: "GET"}, {}},
 				},
-				isRedirect: true,
 			},
 			td.cachedSelectorB: &PerSelectorPolicy{
+				L7Parser: ParserTypeHTTP,
+				Priority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/private", Method: "GET"}},
 				},
-				isRedirect: true,
 			},
 		},
 		Ingress: false,
@@ -586,19 +593,20 @@ func TestMergeL7PolicyEgress(t *testing.T) {
 		"80/TCP": {
 			Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 			wildcard: td.wildcardCachedSelector,
-			L7Parser: ParserTypeHTTP,
 			PerSelectorPolicies: L7DataMap{
 				td.wildcardCachedSelector: &PerSelectorPolicy{
+					L7Parser: ParserTypeHTTP,
+					Priority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{{Path: "/public", Method: "GET"}, {}},
 					},
-					isRedirect: true,
 				},
 				td.cachedSelectorB: &PerSelectorPolicy{
+					L7Parser: ParserTypeHTTP,
+					Priority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{{Path: "/private", Method: "GET"}},
 					},
-					isRedirect: true,
 				},
 			},
 			Ingress: false,
@@ -610,19 +618,20 @@ func TestMergeL7PolicyEgress(t *testing.T) {
 		"9092/TCP": {
 			Port: 9092, Protocol: api.ProtoTCP, U8Proto: 6,
 			wildcard: td.wildcardCachedSelector,
-			L7Parser: ParserTypeKafka,
 			PerSelectorPolicies: L7DataMap{
 				td.wildcardCachedSelector: &PerSelectorPolicy{
+					L7Parser: ParserTypeKafka,
+					Priority: ListenerPriorityKafka,
 					L7Rules: api.L7Rules{
 						Kafka: []kafka.PortRule{{Topic: "foo"}, {}},
 					},
-					isRedirect: true,
 				},
 				td.cachedSelectorB: &PerSelectorPolicy{
+					L7Parser: ParserTypeKafka,
+					Priority: ListenerPriorityKafka,
 					L7Rules: api.L7Rules{
 						Kafka: []kafka.PortRule{{Topic: "foo"}},
 					},
-					isRedirect: true,
 				},
 			},
 			Ingress: false,
@@ -679,18 +688,20 @@ func TestMergeL7PolicyEgress(t *testing.T) {
 	// The l3-dependent l7 rules are not merged together.
 	l7map := L7DataMap{
 		td.cachedSelectorB: &PerSelectorPolicy{
-			L7Rules:    fooRules,
-			isRedirect: true,
+			L7Parser: ParserTypeKafka,
+			Priority: ListenerPriorityKafka,
+			L7Rules:  fooRules,
 		},
 		td.wildcardCachedSelector: &PerSelectorPolicy{
-			L7Rules:    barRules,
-			isRedirect: true,
+			L7Parser: ParserTypeKafka,
+			Priority: ListenerPriorityKafka,
+			L7Rules:  barRules,
 		},
 	}
 	expected = NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-		wildcard: td.wildcardCachedSelector,
-		L7Parser: "kafka", PerSelectorPolicies: l7map, Ingress: false,
+		wildcard:            td.wildcardCachedSelector,
+		PerSelectorPolicies: l7map, Ingress: false,
 		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
 			td.cachedSelectorB:        {nil},
 			td.wildcardCachedSelector: {nil},
@@ -1838,14 +1849,14 @@ func TestL4WildcardMerge(t *testing.T) {
 	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		wildcard: td.wildcardCachedSelector,
-		L7Parser: "http",
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: nil,
 			td.cachedSelectorC: &PerSelectorPolicy{
+				L7Parser: ParserTypeHTTP,
+				Priority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 				},
-				isRedirect: true,
 			},
 		},
 		Ingress: true,
@@ -1856,14 +1867,14 @@ func TestL4WildcardMerge(t *testing.T) {
 	},
 		"7000/TCP": {
 			Port: 7000, Protocol: api.ProtoTCP, U8Proto: 6,
-			L7Parser: "testparser",
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorC: &PerSelectorPolicy{
+					L7Parser: "testparser",
+					Priority: ListenerPriorityProxylib,
 					L7Rules: api.L7Rules{
 						L7Proto: "testparser",
 						L7:      []api.PortRuleL7{{"Key": "Value"}, {}},
 					},
-					isRedirect: true,
 				},
 			},
 			Ingress:    true,
@@ -1968,14 +1979,14 @@ func TestL4WildcardMerge(t *testing.T) {
 	expected = NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		wildcard: td.wildcardCachedSelector,
-		L7Parser: "http",
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: nil,
 			td.cachedSelectorC: &PerSelectorPolicy{
+				L7Parser: ParserTypeHTTP,
+				Priority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 				},
-				isRedirect: true,
 			},
 		},
 		Ingress: true,
@@ -2025,14 +2036,14 @@ func TestL4WildcardMerge(t *testing.T) {
 	expected = NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		wildcard: td.wildcardCachedSelector,
-		L7Parser: "http",
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: nil,
 			td.cachedSelectorC: &PerSelectorPolicy{
+				L7Parser: ParserTypeHTTP,
+				Priority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 				},
-				isRedirect: true,
 			},
 		},
 		Ingress: true,
@@ -2088,14 +2099,14 @@ func TestL3L4L7Merge(t *testing.T) {
 	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		wildcard: td.wildcardCachedSelector,
-		L7Parser: "http",
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorC: nil,
 			td.wildcardCachedSelector: &PerSelectorPolicy{
+				L7Parser: ParserTypeHTTP,
+				Priority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 				},
-				isRedirect: true,
 			},
 		},
 		Ingress: true,
@@ -2138,14 +2149,14 @@ func TestL3L4L7Merge(t *testing.T) {
 	expected = NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		wildcard: td.wildcardCachedSelector,
-		L7Parser: "http",
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorC: nil,
 			td.wildcardCachedSelector: &PerSelectorPolicy{
+				L7Parser: ParserTypeHTTP,
+				Priority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 				},
-				isRedirect: true,
 			},
 		},
 		Ingress: true,
@@ -2328,14 +2339,14 @@ func TestMergeL7PolicyEgressWithMultipleSelectors(t *testing.T) {
 
 	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-		L7Parser: ParserTypeHTTP,
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorB: nil,
 			td.cachedSelectorC: &PerSelectorPolicy{
+				L7Parser: ParserTypeHTTP,
+				Priority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Method: "GET"}, {Host: "foo"}},
 				},
-				isRedirect: true,
 			},
 		},
 		Ingress: false,
@@ -2351,80 +2362,80 @@ func TestMergeL7PolicyEgressWithMultipleSelectors(t *testing.T) {
 func TestMergeListenerReference(t *testing.T) {
 	// No listener remains a no listener
 	ps := &PerSelectorPolicy{}
-	err := ps.mergeListenerReference(ps)
+	err := ps.mergeRedirect(ps)
 	require.NoError(t, err)
 	require.Equal(t, "", ps.Listener)
-	require.Equal(t, uint8(0), ps.Priority)
+	require.Equal(t, ListenerPriority(0), ps.Priority)
 
 	// Listener reference remains when the other has none
 	ps0 := &PerSelectorPolicy{Listener: "listener0"}
-	err = ps0.mergeListenerReference(ps)
+	err = ps0.mergeRedirect(ps)
 	require.NoError(t, err)
 	require.Equal(t, "listener0", ps0.Listener)
-	require.Equal(t, uint8(0), ps0.Priority)
+	require.Equal(t, ListenerPriority(0), ps0.Priority)
 
 	// Listener reference is propagated when there is none to begin with
-	err = ps.mergeListenerReference(ps0)
+	err = ps.mergeRedirect(ps0)
 	require.NoError(t, err)
 	require.Equal(t, "listener0", ps.Listener)
-	require.Equal(t, uint8(0), ps.Priority)
+	require.Equal(t, ListenerPriority(0), ps.Priority)
 
 	// A listener is not changed when there is no change
-	err = ps0.mergeListenerReference(ps0)
+	err = ps0.mergeRedirect(ps0)
 	require.NoError(t, err)
 	require.Equal(t, "listener0", ps0.Listener)
-	require.Equal(t, uint8(0), ps0.Priority)
+	require.Equal(t, ListenerPriority(0), ps0.Priority)
 
 	// Cannot merge two different listeners with the default (zero) priority
 	ps0a := &PerSelectorPolicy{Listener: "listener0a"}
-	err = ps0.mergeListenerReference(ps0a)
+	err = ps0.mergeRedirect(ps0a)
 	require.Error(t, err)
 
-	err = ps0a.mergeListenerReference(ps0)
+	err = ps0a.mergeRedirect(ps0)
 	require.Error(t, err)
 
 	// Listener with a defined (non-zero) priority takes precedence over
 	// a listener with an undefined (zero) priority
 	ps1 := &PerSelectorPolicy{Listener: "listener1", Priority: 1}
-	err = ps1.mergeListenerReference(ps0)
+	err = ps1.mergeRedirect(ps0)
 	require.NoError(t, err)
 	require.Equal(t, "listener1", ps1.Listener)
-	require.Equal(t, uint8(1), ps1.Priority)
+	require.Equal(t, ListenerPriority(1), ps1.Priority)
 
-	err = ps0.mergeListenerReference(ps1)
+	err = ps0.mergeRedirect(ps1)
 	require.NoError(t, err)
 	require.Equal(t, "listener1", ps0.Listener)
-	require.Equal(t, uint8(1), ps0.Priority)
+	require.Equal(t, ListenerPriority(1), ps0.Priority)
 
 	// Listener with the lower priority value takes precedence
 	ps2 := &PerSelectorPolicy{Listener: "listener2", Priority: 2}
-	err = ps1.mergeListenerReference(ps2)
+	err = ps1.mergeRedirect(ps2)
 	require.NoError(t, err)
 	require.Equal(t, "listener1", ps1.Listener)
-	require.Equal(t, uint8(1), ps1.Priority)
+	require.Equal(t, ListenerPriority(1), ps1.Priority)
 
-	err = ps2.mergeListenerReference(ps1)
+	err = ps2.mergeRedirect(ps1)
 	require.NoError(t, err)
 	require.Equal(t, "listener1", ps2.Listener)
-	require.Equal(t, uint8(1), ps2.Priority)
+	require.Equal(t, ListenerPriority(1), ps2.Priority)
 
 	// Cannot merge two different listeners with the same priority
 	ps12 := &PerSelectorPolicy{Listener: "listener1", Priority: 2}
 	ps2 = &PerSelectorPolicy{Listener: "listener2", Priority: 2}
-	err = ps12.mergeListenerReference(ps2)
+	err = ps12.mergeRedirect(ps2)
 	require.Error(t, err)
-	err = ps2.mergeListenerReference(ps12)
+	err = ps2.mergeRedirect(ps12)
 	require.Error(t, err)
 
 	// Lower priority is propagated also when the listeners are the same
 	ps23 := &PerSelectorPolicy{Listener: "listener2", Priority: 3}
-	err = ps2.mergeListenerReference(ps23)
+	err = ps2.mergeRedirect(ps23)
 	require.NoError(t, err)
 	require.Equal(t, "listener2", ps2.Listener)
-	require.Equal(t, uint8(2), ps2.Priority)
+	require.Equal(t, ListenerPriority(2), ps2.Priority)
 
-	err = ps23.mergeListenerReference(ps2)
+	err = ps23.mergeRedirect(ps2)
 	require.NoError(t, err)
 	require.Equal(t, "listener2", ps23.Listener)
-	require.Equal(t, uint8(2), ps23.Priority)
+	require.Equal(t, ListenerPriority(2), ps23.Priority)
 }

--- a/pkg/policy/types/entry.go
+++ b/pkg/policy/types/entry.go
@@ -5,11 +5,12 @@ package types
 
 import "strconv"
 
+type ListenerPriority uint8
 type ProxyPortPriority uint8
 
 const (
-	MaxProxyPortPriority = 255
-	MaxListenerPriority  = 100
+	MaxProxyPortPriority = 127
+	MaxListenerPriority  = 126
 )
 
 // MapStateEntry is the configuration associated with a Key in a
@@ -53,9 +54,9 @@ func (e MapStateEntry) String() string {
 		authText
 }
 
-// NewMapStateEntry creeates a new MapStateEntry
+// NewMapStateEntry creates a new MapStateEntry
 // Listener 'priority' is encoded in ProxyPortPriority, inverted
-func NewMapStateEntry(deny bool, proxyPort uint16, priority uint8, authReq AuthRequirement) MapStateEntry {
+func NewMapStateEntry(deny bool, proxyPort uint16, priority ListenerPriority, authReq AuthRequirement) MapStateEntry {
 	// Normalize inputs
 	if deny {
 		proxyPort = 0
@@ -66,7 +67,7 @@ func NewMapStateEntry(deny bool, proxyPort uint16, priority uint8, authReq AuthR
 		isDeny:          deny,
 		ProxyPort:       proxyPort,
 		AuthRequirement: authReq,
-	}.WithProxyPriority(priority)
+	}.WithListenerPriority(priority)
 }
 
 func (e MapStateEntry) IsDeny() bool {
@@ -94,19 +95,28 @@ func (e MapStateEntry) WithDeny(isDeny bool) MapStateEntry {
 	return e
 }
 
-// WithProxyPriority returns a MapStateEntry with the given listener priority:
+// WithListenerPriority returns a MapStateEntry with the given listener priority:
 // 0 - default (low) priority for all proxy redirects
 // 1 - highest listener priority
 // ..
 // 100 - lowest (non-default) listener priority
-func (e MapStateEntry) WithProxyPriority(priority uint8) MapStateEntry {
+// 101 - priority for HTTP parser type
+// 106 - priority for the Kafka parser type
+// 111 - priority for the proxylib parsers
+// 116 - priority for TLS interception parsers (can be promoted to HTTP/Kafka/proxylib)
+// 121 - priority for DNS parser type
+// 126 - default priority for CRD parser type
+// 127 - reserved (listener priority passed as 0)
+func (e MapStateEntry) WithListenerPriority(priority ListenerPriority) MapStateEntry {
 	if e.ProxyPort != 0 {
 		if priority > 0 {
 			priority = min(priority, MaxListenerPriority)
 
 			// invert the priority so that higher number has the
-			// precedence, priority 1 becomes 254, 100 -> 155
-			e.ProxyPortPriority = MaxProxyPortPriority - ProxyPortPriority(priority)
+			// precedence, priority 1 becomes '127', 100 -> '28', 126 -> '2'
+			// '1' is reserved for a listener priority passed as 0
+			// '0' is reserved for entries without proxy redirect
+			e.ProxyPortPriority = MaxProxyPortPriority + 1 - ProxyPortPriority(priority)
 		} else {
 			e.ProxyPortPriority = 1 // proxy port without explicit priority
 		}
@@ -116,8 +126,10 @@ func (e MapStateEntry) WithProxyPriority(priority uint8) MapStateEntry {
 
 // WithProxyPort return the MapStateEntry with proxy port set at the default precedence
 func (e MapStateEntry) WithProxyPort(proxyPort uint16) MapStateEntry {
-	e.ProxyPort = proxyPort
-	e.ProxyPortPriority = 1 // proxy port without explicit priority
+	if proxyPort > 0 {
+		e.ProxyPort = proxyPort
+		e.ProxyPortPriority = 1 // proxy port without explicit priority
+	}
 	return e
 }
 


### PR DESCRIPTION
Move L7 parser type to PerSelectorPolicy, so that different selectors on the same port can have different parser types, e.g., CRD for explicit listener reference and HTTP.

When selectors are overlapping and the proxy port priorities are the same the tie-breaking is currently random based on the allocated proxy port numbers. This is solved by mapping proxy port priorities as follows when an explicit priority (1-100) is not specified:

```
none:  0 (as before)
       1-100 (explicit listener priorities)
HTTP:  101
Kafka: 106
other (proxylib): 111
TLS:   116 (TLS can be promoted to the types above when merging)
DNS:   121
CRD:   126 (can be explicitly overridden to range 1-100 in the policy)
```

Similar conflict between different parsers was previously possible with named ports, so this resolved l7 parser conflicts also in that case.

1st commit fixes an issue that currently can't trigger due to "spire" being the only supported auth type: (policy: Keep all explicit auth entries):

Do not delete covered explicit auth entries even if the covering entry has the same auth requirement, as it is possible for a more specific covering key with a different auth requirement to be added later, after which the covered key (now with different auth requirement than the most specific covering key) is needed after all.
