### PR TITLE
gh: ipsec-e2e: add concurrency for connectivity tests

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -56,6 +56,9 @@ concurrency:
     }}
   cancel-in-progress: true
 
+env:
+  test_concurrency: 5
+
 jobs:
   echo-inputs:
     if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -158,7 +161,16 @@ jobs:
           else
             SHA="${{ github.sha }}"
           fi
+
+          CONNECTIVITY_TEST_DEFAULTS="--include-unsafe-tests \
+                                      --collect-sysdump-on-failure \
+                                      --sysdump-hubble-flows-count=1000000 \
+                                      --sysdump-hubble-flows-timeout=5m \
+                                      --log-code-owners \
+                                      --flush-ct"
+
           echo sha=${SHA} >> $GITHUB_OUTPUT
+          echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
 
       - name: Derive Cilium installation config and junit type
         id: cilium-config
@@ -279,18 +291,28 @@ jobs:
           script: ./.github/actions/bpftrace/scripts/check-encryption-leaks.bt
           args: ${{ steps.bpftrace-params.outputs.params }} "true" "ipsec"
 
-      - name: Run tests (${{ join(matrix.*, ', ') }})
+      - name: Run sequential tests (${{ join(matrix.*, ', ') }})
         shell: bash
         run: |
           mkdir -p cilium-junits
 
-          cilium connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-            --log-code-owners \
-            --flush-ct
+            --test 'seq-.*'
+
+      - name: Run concurrent tests (${{ join(matrix.*, ', ') }})
+        shell: bash
+        run: |
+          mkdir -p cilium-junits
+
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+            --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
+            --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
+            --test '!seq-.*' \
+            --test-concurrency=${{ env.test_concurrency }}
 
       - name: Features tested
         uses: ./.github/actions/feature-status
@@ -332,24 +354,34 @@ jobs:
           script: ./.github/actions/bpftrace/scripts/check-encryption-leaks.bt
           args: ${{ steps.bpftrace-params.outputs.params }} "true" "ipsec"
 
-      - name: Run tests (${{ join(matrix.*, ', ') }})
+      - name: Run sequential tests (${{ join(matrix.*, ', ') }})
         shell: bash
         run: |
           mkdir -p cilium-junits
 
-          TEST=""
-          if [ "${{ matrix.key-one }}" = "gcm(aes)" ] && [ "${{ matrix.key-two }}" = "cbc(aes)" ]; then
-            # Until https://github.com/cilium/cilium/issues/29480 is resolved
-            TEST='--test "!pod-to-pod-no-frag"'
-          fi
-
-          cilium connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
             --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-            --log-code-owners \
-            --flush-ct $TEST
+            --test 'seq-.*'
+
+      - name: Run concurrent tests (${{ join(matrix.*, ', ') }})
+        shell: bash
+        run: |
+          mkdir -p cilium-junits
+
+          TEST='--test "!seq-.*"'
+          if [ "${{ matrix.key-one }}" = "gcm(aes)" ] && [ "${{ matrix.key-two }}" = "cbc(aes)" ]; then
+            # Until https://github.com/cilium/cilium/issues/29480 is resolved
+            TEST='--test "!(seq-.*|pod-to-pod-no-frag)"'
+          fi
+
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+            --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
+            --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
+            $TEST \
+            --test-concurrency=${{ env.test_concurrency }}
 
       - name: Features tested
         uses: ./.github/actions/feature-status


### PR DESCRIPTION
Inspired by https://github.com/cilium/cilium/pull/34806 and https://github.com/cilium/cilium/pull/37704, enable concurrent execution when running the connectivity tests. This substantially reduces the workflow's runtime.