### PR TITLE
cilium-cli/connectivity: Fix output for LRP tests

### DIFF
--- a/cilium-cli/connectivity/tests/lrp.go
+++ b/cilium-cli/connectivity/tests/lrp.go
@@ -216,7 +216,8 @@ func (s lrpWithNodeDNS) Run(ctx context.Context, t *check.Test) {
 		for _, externalEchoSvc := range ct.EchoExternalServices() {
 			externalEcho := externalEchoSvc.ToEchoIPService()
 
-			t.NewAction(s, fmt.Sprintf("lrp-node-dns-http-to-%s-%d", externalEcho, i), &client, externalEcho, features.IPFamilyV4).Run(func(a *check.Action) {
+			actionName := fmt.Sprintf("lrp-node-dns-http-to-%s-%d", externalEcho.NameWithoutNamespace(), i)
+			t.NewAction(s, actionName, &client, externalEcho, features.IPFamilyV4).Run(func(a *check.Action) {
 				a.ExecInPod(ctx, a.CurlCommandWithOutput(externalEcho))
 			})
 			i++


### PR DESCRIPTION
When LRP tests are printed, we get this sort of unreadible blob:

    ❌ local-redirect-policy-with-node-dns/local-redirect-policy-with-node-
    dns/lrp-node-dns-http-to-{{&Service{ObjectMeta:{echo-external-node  ci
    lium-test-5  e4ee46a5-4243-4216-b4b4-90d7c633ec1f 3603 0 2025-02-25 15
    :38:30 +0000 UTC <nil> <nil> map[kind:echo-external-node] map[] [] []
    [{cilium Update v1 2025-02-25 15:38:30 +0000 UTC FieldsV1 {"f:metadata
    ":{"f:labels":{".":{},"f:kind":{}}},"f:spec":{"f:clusterIP":{},"f:inte
    rnalTrafficPolicy":{},"f:ipFamilyPolicy":{},"f:ports":{".":{},"k:{\"po
    rt\":8084,\"protocol\":\"TCP\"}":{".":{},"f:name":{},"f:port":{},"f:pr
    otocol":{},"f:targetPort":{}}},"f:selector":{},"f:sessionAffinity":{},
    "f:type":{}}} }]},Spec:ServiceSpec{Ports:[]ServicePort{ServicePort{Nam
    e:http,Protocol:TCP,Port:8084,TargetPort:{0 8084 },NodePort:0,AppProto
    col:nil,},},Selector:map[string]string{kind: echo-external-node,name:
    echo-external-node,},ClusterIP:None,Type:ClusterIP,ExternalIPs:[],Sess
    ionAffinity:None,LoadBalancerIP:,LoadBalancerSourceRanges:[],ExternalN
    ame:,ExternalTrafficPolicy:,HealthCheckNodePort:0,PublishNotReadyAddre
    sses:false,SessionAffinityConfig:nil,IPFamilyPolicy:*PreferDualStack,C
    lusterIPs:[None],IPFamilies:[IPv4 IPv6],AllocateLoadBalancerNodePorts:
    nil,LoadBalancerClass:nil,InternalTrafficPolicy:*Cluster,TrafficDistri
    bution:nil,},Status:ServiceStatus{LoadBalancer:LoadBalancerStatus{Ingr
    ess:[]LoadBalancerIngress{},},Conditions:[]Condition{},},} }}-2: ciliu
    m-test-5/client3-87db7485b-xngvs (10.244.3.155) -> cilium-test-5/echo-
    external-node (echo-external-node.cilium-test-5:8084)

This is because we try to print the `externalEcho` object instead of just its name. This commit fixes it.

Fixes: https://github.com/cilium/cilium/pull/34178.