### PR TITLE
policy/api: use `omitzero` option for `enableDefaultDeny` field

### DIFF
--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -140,28 +140,24 @@ type Rule struct {
 // enforce omitempty on the EndpointSelector nested structures.
 func (r *Rule) MarshalJSON() ([]byte, error) {
 	type common struct {
-		Ingress           []IngressRule      `json:"ingress,omitempty"`
-		IngressDeny       []IngressDenyRule  `json:"ingressDeny,omitempty"`
-		Egress            []EgressRule       `json:"egress,omitempty"`
-		EgressDeny        []EgressDenyRule   `json:"egressDeny,omitempty"`
-		Labels            labels.LabelArray  `json:"labels,omitempty"`
-		EnableDefaultDeny *DefaultDenyConfig `json:"enableDefaultDeny,omitempty"`
-		Description       string             `json:"description,omitempty"`
+		Ingress           []IngressRule     `json:"ingress,omitempty"`
+		IngressDeny       []IngressDenyRule `json:"ingressDeny,omitempty"`
+		Egress            []EgressRule      `json:"egress,omitempty"`
+		EgressDeny        []EgressDenyRule  `json:"egressDeny,omitempty"`
+		Labels            labels.LabelArray `json:"labels,omitempty"`
+		EnableDefaultDeny DefaultDenyConfig `json:"enableDefaultDeny,omitzero"`
+		Description       string            `json:"description,omitempty"`
 	}
 
 	var a interface{}
 	ruleCommon := common{
-		Ingress:     r.Ingress,
-		IngressDeny: r.IngressDeny,
-		Egress:      r.Egress,
-		EgressDeny:  r.EgressDeny,
-		Labels:      r.Labels,
-		Description: r.Description,
-	}
-
-	// TODO: convert this to `omitzero` when Go v1.24 is released
-	if r.EnableDefaultDeny.Egress != nil || r.EnableDefaultDeny.Ingress != nil {
-		ruleCommon.EnableDefaultDeny = &r.EnableDefaultDeny
+		Ingress:           r.Ingress,
+		IngressDeny:       r.IngressDeny,
+		Egress:            r.Egress,
+		EgressDeny:        r.EgressDeny,
+		Labels:            r.Labels,
+		EnableDefaultDeny: r.EnableDefaultDeny,
+		Description:       r.Description,
 	}
 
 	// Only one of endpointSelector or nodeSelector is permitted.


### PR DESCRIPTION
Now that the tree is updated to Go 1.24 the `omitzero` option can be used to omit zero enableDefaultDeny fields when marshalling network policies.

Follow-up for ede9dfe4f3a4 ("policy/api: don't write zero enableDefaultDeny field") addressing a TODO introduced by that commit.