### PR TITLE
operator/bgpv2: Improve BGP reconciliation metrics

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -659,7 +659,7 @@ Name                               Labels                                       
 ``session_state``                  ``vrouter``, ``neighbor``, ``neighbor_asn``                     Enabled  Current state of the BGP session with the peer, Up = 1 or Down = 0
 ``advertised_routes``              ``vrouter``, ``neighbor``, ``neighbor_asn``, ``afi``, ``safi``  Enabled  Number of routes advertised to the peer
 ``received_routes``                ``vrouter``, ``neighbor``, ``neighbor_asn``, ``afi``, ``safi``  Enabled  Number of routes received from the peer
-``reconcile_error_count``          ``vrouter``                                                     Enabled  Number of reconciliation runs that returned an error
+``reconcile_errors_total``         ``vrouter``                                                     Enabled  Number of reconciliation runs that returned an error
 ``reconcile_run_duration_seconds`` ``vrouter``                                                     Enabled  Histogram of reconciliation run duration
 ================================== =============================================================== ======== ===================================================================
 
@@ -715,11 +715,12 @@ All metrics are exported under the ``cilium_operator_`` Prometheus namespace.
 BGP Control Plane Operator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-================================== ======================= ======== ======================================================================
-Name                               Labels                  Default  Description
-================================== ======================= ======== ======================================================================
-``cluster_config_error_count``     ``bgp_cluster_config``  Enabled  Number of errors returned per BGP cluster configuration reconciliation
-================================== ======================= ======== ======================================================================
+================================== ===================================== ======== ======================================================================
+Name                               Labels                                Default  Description
+================================== ===================================== ======== ======================================================================
+``reconcile_errors_total``         ``resource_kind``, ``resource_name``  Enabled  Number of errors returned per BGP resource reconciliation
+``reconcile_run_duration_seconds``                                       Enabled  Histogram of reconciliation run duration
+================================== ===================================== ======== ======================================================================
 
 All metrics are enabled only when the BGP Control Plane is enabled.
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -348,6 +348,9 @@ Changed Metrics
 * ``doublewrite_identity_crd_only_count`` has been renamed to ``doublewrite_crd_only_identities``
 * ``doublewrite_identity_kvstore_only_count`` has been renamed to ``doublewrite_kvstore_only_identities``
 * The type of the ``cilium_agent_bootstrap_seconds`` metric has been changed from histogram to gauge.
+* ``cilium_agent_bgp_control_plane_reconcile_error_count`` has been renamed to ``cilium_agent_bgp_control_plane_reconcile_errors_total``.
+* ``cilium_operator_bgp_control_plane_cluster_config_error_count`` has been renamed to ``cilium_operator_bgp_control_plane_reconcile_errors_total``
+  and its label ``bgp_cluster_config`` has been replaced with labels ``resource_kind`` and ``resource_name``.
 
 Deprecated Metrics
 ~~~~~~~~~~~~~~~~~~

--- a/operator/pkg/bgpv2/cluster.go
+++ b/operator/pkg/bgpv2/cluster.go
@@ -29,7 +29,7 @@ func (b *BGPResourceManager) reconcileBGPClusterConfigs(ctx context.Context) err
 	for _, config := range b.clusterConfigStore.List() {
 		rcErr := b.reconcileBGPClusterConfig(ctx, config)
 		if rcErr != nil {
-			b.metrics.BGPClusterConfigErrorCount.WithLabelValues(config.Name).Inc()
+			b.metrics.ReconcileErrorsTotal.WithLabelValues(v2.BGPCCKindDefinition, config.Name).Inc()
 			err = errors.Join(err, rcErr)
 		}
 	}

--- a/operator/pkg/bgpv2/manager.go
+++ b/operator/pkg/bgpv2/manager.go
@@ -277,7 +277,12 @@ func (b *BGPResourceManager) reconcileWithRetry(ctx context.Context) error {
 
 // reconcile is called when any interesting resource change event is triggered.
 func (b *BGPResourceManager) reconcile(ctx context.Context) error {
-	return b.reconcileBGPClusterConfigs(ctx)
+	reconcileStart := time.Now()
+
+	err := b.reconcileBGPClusterConfigs(ctx)
+
+	b.metrics.ReconcileRunDuration.WithLabelValues().Observe(time.Since(reconcileStart).Seconds())
+	return err
 }
 
 // TrimError trims error message to maxLen.

--- a/operator/pkg/bgpv2/metrics.go
+++ b/operator/pkg/bgpv2/metrics.go
@@ -11,19 +11,28 @@ import (
 
 // BGPOperatorMetrics contains all metrics for the BGP control plane operator.
 type BGPOperatorMetrics struct {
-	// BGPClusterConfigErrorCount is the number of errors during reconciliation of the cluster
-	// configuration.
-	BGPClusterConfigErrorCount metric.Vec[metric.Counter]
+	// ReconcileErrorsTotal is the number of errors during reconciliation of BGP configuration.
+	ReconcileErrorsTotal metric.Vec[metric.Counter]
+
+	// ReconcileRunDuration measures the duration of the reconciliation run. Histogram can
+	// be used to observe the total number of reconciliation runs and distribution of the run duration.
+	ReconcileRunDuration metric.Vec[metric.Observer]
 }
 
 // NewBGPOperatorMetrics returns a new BGPOperatorMetrics with all metrics initialized.
 func NewBGPOperatorMetrics() *BGPOperatorMetrics {
 	return &BGPOperatorMetrics{
-		BGPClusterConfigErrorCount: metric.NewCounterVec(metric.CounterOpts{
+		ReconcileErrorsTotal: metric.NewCounterVec(metric.CounterOpts{
 			Namespace: metrics.CiliumOperatorNamespace,
 			Subsystem: types.MetricsSubsystem,
-			Name:      "cluster_config_error_count",
+			Name:      types.MetricReconcileErrorsTotal,
 			Help:      "The number of errors during reconciliation of the cluster configuration.",
-		}, []string{types.LabelClusterConfig}),
+		}, []string{types.LabelResourceKind, types.LabelResourceName}),
+		ReconcileRunDuration: metric.NewHistogramVec(metric.HistogramOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: types.MetricsSubsystem,
+			Name:      types.MetricReconcileRunDurationSeconds,
+			Help:      "The duration of the BGP reconciliation run",
+		}, nil),
 	}
 }

--- a/pkg/bgpv1/manager/manager.go
+++ b/pkg/bgpv1/manager/manager.go
@@ -959,7 +959,7 @@ func (m *BGPRouterManager) reconcileBGPConfigV2(ctx context.Context,
 			DesiredConfig: newc,
 			CiliumNode:    ciliumNode,
 		}); rErr != nil {
-			m.metrics.ReconcileErrorCount.WithLabelValues(newc.Name).Inc()
+			m.metrics.ReconcileErrorsTotal.WithLabelValues(newc.Name).Inc()
 			reconcileErrs = append(reconcileErrs, rErr)
 			// If r.Reconcile returns ErrAbortReconcile, we should stop the reconciliation
 			// for this instance and return the error.

--- a/pkg/bgpv1/manager/metrics.go
+++ b/pkg/bgpv1/manager/metrics.go
@@ -10,8 +10,8 @@ import (
 )
 
 type BGPManagerMetrics struct {
-	// ReconcileErrorCount is the number of errors during reconciliation of the BGP manager.
-	ReconcileErrorCount metric.Vec[metric.Counter]
+	// ReconcileErrorsTotal is the number of errors during reconciliation of the BGP manager.
+	ReconcileErrorsTotal metric.Vec[metric.Counter]
 
 	// ReconcileRunDuration measures the duration of the reconciliation run. Histogram can
 	// be used to observe the total number of reconciliation runs and distribution of the run
@@ -21,16 +21,16 @@ type BGPManagerMetrics struct {
 
 func NewBGPManagerMetrics() *BGPManagerMetrics {
 	return &BGPManagerMetrics{
-		ReconcileErrorCount: metric.NewCounterVec(metric.CounterOpts{
+		ReconcileErrorsTotal: metric.NewCounterVec(metric.CounterOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: types.MetricsSubsystem,
-			Name:      "reconcile_error_count",
+			Name:      types.MetricReconcileErrorsTotal,
 			Help:      "The number of errors during reconciliation of the BGP manager",
 		}, []string{types.LabelVRouter}),
 		ReconcileRunDuration: metric.NewHistogramVec(metric.HistogramOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: types.MetricsSubsystem,
-			Name:      "reconcile_run_duration_seconds",
+			Name:      types.MetricReconcileRunDurationSeconds,
 			Help:      "The duration of the BGP manager reconciliation run",
 		}, []string{types.LabelVRouter}),
 	}

--- a/pkg/bgpv1/types/bgp.go
+++ b/pkg/bgpv1/types/bgp.go
@@ -21,8 +21,12 @@ const (
 	LabelNeighborAsn   = "neighbor_asn"
 	LabelAfi           = "afi"
 	LabelSafi          = "safi"
+	LabelResourceKind  = "resource_kind"
+	LabelResourceName  = "resource_name"
 
-	MetricsSubsystem = "bgp_control_plane"
+	MetricsSubsystem                  = "bgp_control_plane"
+	MetricReconcileErrorsTotal        = "reconcile_errors_total"
+	MetricReconcileRunDurationSeconds = "reconcile_run_duration_seconds"
 )
 
 // BGPGlobal contains high level BGP configuration for given instance.


### PR DESCRIPTION
Adds a new metric to track BGP reconciliation time (`*reconcile_run_duration_seconds`) and change the existing metric `*cluster_config_error_count` to a more generic name `*reconcile_errors_total` with resource name recoded as its label, so that it can be reused later when more k8s resources will be reconciled by the BGP operator. 

To align with the operator change and comply with the [OpenMetrics standard](https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md#suffixes), also change the existing agent BGP metric
`*reconcile_error_count` to `*reconcile_errors_total`.

![Screenshot 2025-02-28 at 11 42 10](https://github.com/user-attachments/assets/c62c44e1-979b-44b8-ac2f-09ff8ec72f39)


```release-note
BGPv2: Rename the operator metric `cilium_operator_bgp_control_plane_cluster_config_error_count` to `cilium_operator_bgp_control_plane_reconcile_errors_total` and introduce new operator metric: `cilium_operator_bgp_control_plane_reconcile_run_duration_seconds`.
Rename the agent metric `cilium_agent_bgp_control_plane_reconcile_error_count` to `cilium_agent_bgp_control_plane_reconcile_errors_total`.
```
