### PR TITLE
cli: Clean up Makefile

### DIFF
--- a/cilium-cli/Makefile
+++ b/cilium-cli/Makefile
@@ -1,20 +1,18 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-GO := go
+include ../Makefile.defs
 GO_BUILD = CGO_ENABLED=0 $(GO) build
 GO_TAGS ?=
 TARGET=cilium
-INSTALL = $(QUIET)install
-BINDIR ?= /usr/local/bin
+BINDIR = /usr/local/bin
 CLI_VERSION=$(shell git describe --tags --always)
-THIS_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 CLI_MAIN_DIR?=./cmd/cilium
 STRIP_DEBUG=-w -s
 ifdef DEBUG
 	STRIP_DEBUG=
 endif
-GO_BUILD_LDFLAGS ?= $(STRIP_DEBUG) \
+GO_BUILD_LDFLAGS = $(STRIP_DEBUG) \
 	-X 'github.com/cilium/cilium/cilium-cli/defaults.CLIVersion=$(CLI_VERSION)'
 
 TEST_TIMEOUT ?= 5s


### PR DESCRIPTION
- Include the top-level Makefile.defs, and re-use GO and INSTALL variables.
- Remove unused THIS_DIR variable [^1].
- Explicitly set BINDIR and GO_BUILD_LDFLAGS variable. Cilium and Cilium CLI use different values for these settings.

[^1]: https://github.com/cilium/cilium/pull/36344