### PR TITLE
service: selective node exposure via labelselector

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -420,6 +420,27 @@ To add a new service that should only be exposed to nodes with label ``service.c
         targetPort: 9376
     type: LoadBalancer
 
+It's also possible to control the service node exposure via the annotation ``service.cilium.io/node-selector`` - where
+the annotation value contains the label selector. This way, the service is only exposed on nodes that match the
+node label selector. The annotation ``service.cilium.io/node-selector`` always has priority over 
+``service.cilium.io/node`` if both exist on the same service.
+
+.. code-block:: yaml
+
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: example-service
+    annotations:
+      service.cilium.io/node-selector: "service.cilium.io/node in ( beefy , slow )"
+  spec:
+    selector:
+      app: example
+    ports:
+      - port: 8765
+        targetPort: 9376
+    type: LoadBalancer
+
 Note that changing a node label after a service has been exposed matching that label does not
 automatically update the list of nodes where the service is exposed. To update exposure of the
 service after changing node labels, restart the Cilium agent. Generally it is advised to fixate the

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -358,6 +358,7 @@ func (d *Daemon) getKubeProxyReplacementStatus() *models.KubeProxyReplacement {
 		features.Annotations = append(features.Annotations, annotation.ServiceForwardingMode)
 	}
 	features.Annotations = append(features.Annotations, annotation.ServiceNodeExposure)
+	features.Annotations = append(features.Annotations, annotation.ServiceNodeSelectorExposure)
 	features.Annotations = append(features.Annotations, annotation.ServiceTypeExposure)
 	if option.Config.EnableSVCSourceRangeCheck {
 		features.Annotations = append(features.Annotations, annotation.ServiceSourceRangesPolicy)

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -130,6 +130,11 @@ const (
 	// service is ignored and not installed into their datapath.
 	ServiceNodeExposure = ServicePrefix + "/node"
 
+	// ServiceNodeSelectorExposure is the label name used to mark a service to only a
+	// subset of the nodes which match the label selector. For all other nodes, this
+	// service is ignored and not installed into their datapath.
+	ServiceNodeSelectorExposure = ServicePrefix + "/node-selector"
+
 	// ServiceTypeExposure is the annotation name used to mark what service type
 	// to provision (only single type is allowed; allowed types: "ClusterIP",
 	// "NodePort" and "LoadBalancer").

--- a/pkg/k8s/watchers/service_test.go
+++ b/pkg/k8s/watchers/service_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 
 	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
@@ -20,6 +22,8 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/util/intstr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -2591,4 +2595,79 @@ func TestHeadless(t *testing.T) {
 	require.Equal(t, len(delstWanted), svcDeleteManagerCalls)
 	require.EqualValues(t, upsertsWanted, upserts)
 	require.EqualValues(t, delstWanted, delst)
+}
+
+func TestK8sServiceWatcher_checkServiceNodeExposure(t *testing.T) {
+	tests := []struct {
+		name           string // description of this test case
+		nodeLabels     map[string]string
+		svcAnnotations map[string]string
+		wantExposed    bool
+	}{
+		{
+			name:           "no annotation matches all nodes",
+			nodeLabels:     map[string]string{},
+			svcAnnotations: map[string]string{},
+			wantExposed:    true,
+		},
+		{
+			name:           "match via service.cilium.io/node annotation",
+			nodeLabels:     map[string]string{"service.cilium.io/node": "beefy"},
+			svcAnnotations: map[string]string{annotation.ServiceNodeExposure: "beefy"},
+			wantExposed:    true,
+		},
+		{
+			name:           "no match via service.cilium.io/node annotation",
+			nodeLabels:     map[string]string{"service.cilium.io/node": "beefy"},
+			svcAnnotations: map[string]string{annotation.ServiceNodeExposure: "slow"},
+			wantExposed:    false,
+		},
+		{
+			name:           "exact match via service.cilium.io/node-selector annotation",
+			nodeLabels:     map[string]string{"service.cilium.io/node": "beefy"},
+			svcAnnotations: map[string]string{annotation.ServiceNodeSelectorExposure: "service.cilium.io/node == beefy"},
+			wantExposed:    true,
+		},
+		{
+			name:           "no match via exact service.cilium.io/node-selector annotation",
+			nodeLabels:     map[string]string{"service.cilium.io/node": "beefy"},
+			svcAnnotations: map[string]string{annotation.ServiceNodeSelectorExposure: "service.cilium.io/node == slow"},
+			wantExposed:    false,
+		},
+		{
+			name:           "in match via service.cilium.io/node-selector annotation",
+			nodeLabels:     map[string]string{"service.cilium.io/node": "beefy"},
+			svcAnnotations: map[string]string{annotation.ServiceNodeSelectorExposure: "service.cilium.io/node in ( beefy , slow )"},
+			wantExposed:    true,
+		},
+		{
+			name:           "in match via service.cilium.io/node-selector annotation 2",
+			nodeLabels:     map[string]string{"service.cilium.io/node": "slow"},
+			svcAnnotations: map[string]string{annotation.ServiceNodeSelectorExposure: "service.cilium.io/node in ( beefy , slow )"},
+			wantExposed:    true,
+		},
+		{
+			name:           "no match via in service.cilium.io/node-selector annotation",
+			nodeLabels:     map[string]string{"service.cilium.io/node": "another"},
+			svcAnnotations: map[string]string{annotation.ServiceNodeSelectorExposure: "service.cilium.io/node in ( beefy , slow )"},
+			wantExposed:    false,
+		},
+		{
+			name:       "no match via via node annotation if node-selector exists and doesn't match",
+			nodeLabels: map[string]string{"service.cilium.io/node": "another"},
+			svcAnnotations: map[string]string{
+				annotation.ServiceNodeSelectorExposure: "service.cilium.io/node in ( beefy , slow )",
+				annotation.ServiceNodeExposure:         "another",
+			},
+			wantExposed: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &K8sServiceWatcher{localNodeStore: node.NewTestLocalNodeStore(node.LocalNode{Node: types.Node{Labels: tt.nodeLabels}})}
+			exposedOnLocalNode, err := k.checkServiceNodeExposure(&k8s.Service{Annotations: tt.svcAnnotations})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantExposed, exposedOnLocalNode)
+		})
+	}
 }


### PR DESCRIPTION
Currently, selective node exposure of a K8s Service is only possible via the annotation `service.cilium.io/node` where the service is exposed on K8s Nodes with the same value for the label `service.cilium.io/node`.

To improve the flexibility of this feature, this commit is adding the possibility to select K8s nodes by a label selector that is defined in a new annotation `service.cilium.io/node-selector`. As an example, this allows for selecting nodes by multiple labels and/or different values (with IN conditions).

See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more information about K8s labels & selectors.
