### PR TITLE
ipcache: unexport and rename internal methods

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -846,14 +846,13 @@ func (ipc *IPCache) Delete(IP string, source source.Source) (namedPortsChanged b
 func (ipc *IPCache) LookupByIP(IP string) (Identity, bool) {
 	ipc.mutex.RLock()
 	defer ipc.mutex.RUnlock()
-	return ipc.LookupByIPRLocked(IP)
+	return ipc.lookupByIPRLocked(IP)
 }
 
-// LookupByIPRLocked returns the corresponding security identity that endpoint IP maps
+// lookupByIPRLocked returns the corresponding security identity that endpoint IP maps
 // to within the provided IPCache, as well as if the corresponding entry exists
 // in the IPCache.
-func (ipc *IPCache) LookupByIPRLocked(IP string) (Identity, bool) {
-
+func (ipc *IPCache) lookupByIPRLocked(IP string) (Identity, bool) {
 	identity, exists := ipc.ipToIdentityCache[IP]
 	return identity, exists
 }
@@ -898,7 +897,7 @@ func (ipc *IPCache) LookupSecIDByIP(ip netip.Addr) (id Identity, ok bool) {
 	ipc.mutex.RLock()
 	defer ipc.mutex.RUnlock()
 
-	if id, ok = ipc.LookupByIPRLocked(ip.String()); ok {
+	if id, ok = ipc.lookupByIPRLocked(ip.String()); ok {
 		return id, ok
 	}
 

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/counter"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/labels"
@@ -223,18 +224,6 @@ func (ipc *IPCache) UpdateController(
 	params controller.ControllerParams,
 ) {
 	ipc.controllers.UpdateController(name, params)
-}
-
-// endpointIPToCIDR converts the endpoint IP into an equivalent full CIDR.
-func endpointIPToCIDR(ip net.IP) *net.IPNet {
-	bits := net.IPv6len * 8
-	if ip.To4() != nil {
-		bits = net.IPv4len * 8
-	}
-	return &net.IPNet{
-		IP:   ip,
-		Mask: net.CIDRMask(bits, bits),
-	}
 }
 
 func (ipc *IPCache) GetHostIPCache(ip string) (net.IP, uint8) {
@@ -956,7 +945,7 @@ func (ipc *IPCache) LookupByHostRLocked(hostIPv4, hostIPv6 net.IP) (cidrs []net.
 			_, cidr, err := net.ParseCIDR(ip)
 			if err != nil {
 				endpointIP := net.ParseIP(ip)
-				cidr = endpointIPToCIDR(endpointIP)
+				cidr = iputil.IPToPrefix(endpointIP)
 			}
 			cidrs = append(cidrs, *cidr)
 		}

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -226,7 +226,7 @@ func (ipc *IPCache) UpdateController(
 	ipc.controllers.UpdateController(name, params)
 }
 
-func (ipc *IPCache) GetHostIPCache(ip string) (net.IP, uint8) {
+func (ipc *IPCache) getHostIPCache(ip string) (net.IP, uint8) {
 	ipc.mutex.RLock()
 	defer ipc.mutex.RUnlock()
 	return ipc.getHostIPCacheRLocked(ip)
@@ -256,8 +256,8 @@ func (ipc *IPCache) getK8sMetadata(ip string) *K8sMetadata {
 	return nil
 }
 
-// GetEndpointFlags returns endpoint flags for the given IP address.
-func (ipc *IPCache) GetEndpointFlags(ip string) uint8 {
+// getEndpointFlags returns endpoint flags for the given IP address.
+func (ipc *IPCache) getEndpointFlags(ip string) uint8 {
 	ipc.mutex.RLock()
 	defer ipc.mutex.RUnlock()
 	return ipc.getEndpointFlagsRLocked(ip)

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -121,7 +121,7 @@ func TestIPCache(t *testing.T) {
 		Source: source.KVStore,
 	})
 
-	cachedHostIP, _ := IPIdentityCache.getHostIPCache(endpointIP)
+	cachedHostIP, _ := IPIdentityCache.getHostIPCacheRLocked(endpointIP)
 	require.EqualValues(t, hostIP, cachedHostIP)
 	require.EqualValues(t, k8sMeta, IPIdentityCache.GetK8sMetadata(netip.MustParseAddr(endpointIP)))
 
@@ -385,7 +385,7 @@ func TestIPCacheNamedPorts(t *testing.T) {
 	require.Len(t, IPIdentityCache.ipToHostIPCache, 1)
 	require.Len(t, IPIdentityCache.ipToK8sMetadata, 2)
 
-	cachedHostIP, _ := IPIdentityCache.getHostIPCache(endpointIP)
+	cachedHostIP, _ := IPIdentityCache.getHostIPCacheRLocked(endpointIP)
 	require.EqualValues(t, hostIP, cachedHostIP)
 	require.EqualValues(t, k8sMeta, IPIdentityCache.GetK8sMetadata(netip.MustParseAddr(endpointIP)))
 

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -355,8 +355,8 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
 	for i, prefix := range modifiedPrefixes {
 		pstr := prefix.String()
 		oldID, entryExists := ipc.LookupByIP(pstr)
-		oldTunnelIP, oldEncryptionKey := ipc.GetHostIPCache(pstr)
-		oldEndpointFlags := ipc.GetEndpointFlags(pstr)
+		oldTunnelIP, oldEncryptionKey := ipc.getHostIPCache(pstr)
+		oldEndpointFlags := ipc.getEndpointFlags(pstr)
 		prefixInfo := ipc.metadata.getLocked(prefix)
 		var newID *identity.Identity
 		var isNew bool

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -626,7 +626,7 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, remaining)
 
-	ip, key := IPIdentityCache.getHostIPCache(inClusterPrefix.String())
+	ip, key := IPIdentityCache.getHostIPCacheRLocked(inClusterPrefix.String())
 	assert.Equal(t, "192.168.1.100", ip.String())
 	assert.Equal(t, uint8(7), key)
 
@@ -638,7 +638,7 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 		types.EncryptKey(6))
 	_, _, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix})
 	assert.NoError(t, err)
-	ip, key = IPIdentityCache.getHostIPCache(inClusterPrefix.String())
+	ip, key = IPIdentityCache.getHostIPCacheRLocked(inClusterPrefix.String())
 	assert.Equal(t, "192.168.1.100", ip.String())
 	assert.Equal(t, uint8(7), key)
 
@@ -650,7 +650,7 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 	assert.Empty(t, remaining)
 
 	// Assert that there should only be the entry with the tunnelPeer set.
-	ip, key = IPIdentityCache.getHostIPCache(inClusterPrefix.String())
+	ip, key = IPIdentityCache.getHostIPCacheRLocked(inClusterPrefix.String())
 	assert.Equal(t, "192.168.1.100", ip.String())
 	assert.Equal(t, uint8(0), key)
 
@@ -674,7 +674,7 @@ func TestUpsertMetadataTunnelPeerAndEncryptKey(t *testing.T) {
 	)
 	_, _, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{inClusterPrefix})
 	assert.NoError(t, err)
-	ip, key = IPIdentityCache.getHostIPCache(inClusterPrefix.String())
+	ip, key = IPIdentityCache.getHostIPCacheRLocked(inClusterPrefix.String())
 	assert.Equal(t, "192.168.1.101", ip.String())
 	assert.Equal(t, uint8(6), key)
 }


### PR DESCRIPTION
Unexport some methods that are not used outside of package ipcache to reduce the API surface. Also rename some methods such that is clear from their names that they need to be called with `ipc.mutex` read-locked. This is a common pattern with other methods in `pkg/ipcache` and across the Cilium code base.

See commits for details.
