### PR TITLE
gha/scale-egw: fix waiting for images availability

### DIFF
--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -119,6 +119,7 @@ jobs:
   install-and-scaletest:
     runs-on: ubuntu-24.04
     name: Install and Scale Test
+    needs: wait-for-images
     timeout-minutes: 150
     strategy:
       fail-fast: false


### PR DESCRIPTION
The blamed commit changed the egress gateway scale test to use the dedicated action to wait for images. However, it missed adding the new step as dependency of the main one, effectively making it non functional. Let's get that fixed.

Fixes: 1bf5853227d7 ("gha/scale-egw: refactor image waiting logic")
