### PR TITLE
ci: switch default to base branch on images wf

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -65,20 +65,15 @@ jobs:
     environment: ${{ inputs.environment || 'release-base-images' }}
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout default branch (trusted)
+      - name: Checkout base or default branch (trusted)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          # This workflow is supposed to run only on pull_request_target context, but in case workflow call is made from a push context we still keep the default to default_branch
+          ref: ${{ github.base_ref || github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Cleanup Disk space in runner
         uses: ./.github/actions/disk-cleanup
-
-      - name: Checkout base branch (trusted)
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.base_ref }}
-          persist-credentials: false
 
       - name: Copy scripts to trusted directory
         run: |

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -69,10 +69,11 @@ jobs:
             platforms: linux/amd64,linux/arm64
 
     steps:
-      - name: Checkout default branch (trusted)
+      - name: Checkout base or default branch (trusted)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          # We first check if base_ref exist, meaning we're in pull_request_target context, and if not we just use default_branch
+          ref: ${{ github.base_ref || github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Cleanup Disk space in runner

--- a/.github/workflows/build-images-docs-builder.yaml
+++ b/.github/workflows/build-images-docs-builder.yaml
@@ -29,10 +29,10 @@ jobs:
       tag: ${{ steps.docs-builder-tag.outputs.tag }}
       digest: ${{ steps.docker-build-docs-builder.outputs.digest }}
     steps:
-      - name: Checkout default branch (trusted)
+      - name: Checkout base branch (trusted)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.base_ref }}
           persist-credentials: false
 
       - name: Cleanup Disk space in runner
@@ -98,10 +98,10 @@ jobs:
     timeout-minutes: 10
     environment: docs-builder
     steps:
-      - name: Checkout default branch (trusted)
+      - name: Checkout base branch (trusted)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.base_ref }}
           persist-credentials: false
 
       - name: Set environment variables
@@ -150,10 +150,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - name: Checkout default branch (trusted)
+      - name: Checkout base branch (trusted)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.base_ref }}
           persist-credentials: false
 
       - name: Set environment variables

--- a/.github/workflows/lint-images-base.yaml
+++ b/.github/workflows/lint-images-base.yaml
@@ -23,10 +23,11 @@ jobs:
     name: Lint image build logic
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout default branch (trusted)
+      - name: Checkout base or default branch (trusted)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          # We first check if base_ref exist, meaning we're in pull_request context, and if not we just use default_branch
+          ref: ${{ github.base_ref || github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Set Environment Variables


### PR DESCRIPTION
For image building workflows we are using two contexts, pull_request_target and push, with a specific filter targeting main branch for the push context.

This commit changes the trusted branch from default to base branch, targeting first base_ref in case of pull_request_target context, and defaulting to ref_name if base_ref isn't available (push context). 
This will ensure that for PRs targeting stable branches, trusted actions like set-env-variable will be pulled from the stable branches instead of main, avoiding running upstream workflows on stable branch. 

Every informations about base_ref and ref_name can be found in https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs

```release-note
switch default branch to base branch for trusted context in image build/lint workflows
```
