### PR TITLE
ipsec:doc: reject key rotation with different auth key length

### DIFF
--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -184,6 +184,14 @@ Key Rotation
    is, all nodes in the cluster (or clustermesh) should be on the same Cilium
    version before rotating keys.
 
+.. attention::
+
+   Key rotations do not support switching algorithm with different authentication
+   key lengths. If this change is attempted, the new key will be ignored to
+   prevent potential connectivity issues, and an error is logged.
+   After restarting the agent, Cilium will independently configure itself using
+   the latest provided key.
+
 To replace cilium-ipsec-keys secret with a new key:
 
 .. code-block:: shell-session

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -83,11 +83,12 @@ const (
 )
 
 type ipSecKey struct {
-	Spi   uint8
-	ReqID int
-	Auth  *netlink.XfrmStateAlgo
-	Crypt *netlink.XfrmStateAlgo
-	Aead  *netlink.XfrmStateAlgo
+	Spi    uint8
+	KeyLen int
+	ReqID  int
+	Auth   *netlink.XfrmStateAlgo
+	Crypt  *netlink.XfrmStateAlgo
+	Aead   *netlink.XfrmStateAlgo
 }
 
 type oldXfrmStateKey struct {
@@ -1097,10 +1098,14 @@ func LoadIPSecKeys(log *slog.Logger, r io.Reader) (int, uint8, error) {
 		}
 
 		ipSecKey.Spi = spi
+		ipSecKey.KeyLen = keyLen
 
 		if oldKey, ok := ipSecKeysGlobal[""]; ok {
 			if oldKey.Spi == spi {
 				return 0, 0, fmt.Errorf("invalid SPI: changing IPSec keys requires incrementing the key id")
+			}
+			if oldKey.KeyLen != keyLen {
+				return 0, 0, fmt.Errorf("invalid key rotation: key length must not change")
 			}
 			ipSecKeysRemovalTime[oldKey.Spi] = time.Now()
 		}

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -7,6 +7,7 @@ package ipsec
 
 import (
 	"bytes"
+	"fmt"
 	"log/slog"
 	"net"
 	"os"
@@ -48,7 +49,8 @@ const (
 )
 
 var (
-	keysDat        = []byte("1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n2 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n3 digest_null \"\" cipher_null \"\"\n")
+	keysDat        = []byte("1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n2 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n")
+	keysNullDat    = []byte("3 digest_null \"\" cipher_null \"\"\n")
 	keysAeadDat    = []byte("4 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
 	keysAeadDat256 = []byte("5 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f144434241343332312423222114131211 128\n")
 	invalidKeysDat = []byte("6 test abcdefghijklmnopqrstuvwzyzABCDEF test abcdefghijklmnopqrstuvwzyzABCDEF\n")
@@ -95,14 +97,24 @@ func TestInvalidLoadKeys(t *testing.T) {
 func TestLoadKeys(t *testing.T) {
 	log := setupIPSecSuitePrivileged(t)
 
-	testCases := [][]byte{keysDat, keysAeadDat, keysAeadDat256}
+	testCases := [][]byte{keysDat, keysNullDat, keysAeadDat, keysAeadDat256}
 	for _, testCase := range testCases {
 		keys := bytes.NewReader(testCase)
 		_, spi, err := LoadIPSecKeys(log, keys)
+		fmt.Println(string(testCase))
 		require.NoError(t, err)
 		err = SetIPSecSPI(log, spi)
 		require.NoError(t, err)
+		UnsetTestIPSecKey()
 	}
+}
+
+func TestLoadKeysLenChange(t *testing.T) {
+	log := setupIPSecSuitePrivileged(t)
+
+	keys := bytes.NewReader(append(keysDat, keysNullDat...))
+	_, _, err := LoadIPSecKeys(log, keys)
+	require.ErrorContains(t, err, "invalid key rotation: key length must not change")
 }
 
 func TestLoadKeysSameSPI(t *testing.T) {


### PR DESCRIPTION
Edit: Old PR for #37051, opening from cilium/cilium to test CI.