### PR TITLE
bgp: keep bgp table creation public

### DIFF
--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -83,7 +83,7 @@ var Cell = cell.Module(
 	),
 
 	// statedb tables
-	cell.ProvidePrivate(
+	cell.Provide(
 		tables.NewBGPReconcileErrorTable,
 	),
 


### PR DESCRIPTION
Tables created in BGP subsystems should be kept public so other sub-systems may use them for interacting with BGP control plane.
