### PR TITLE
ipsec: cleanup stale encrypted overlay comments

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -716,9 +716,6 @@ enum metric_dir {
 #define MARK_MAGIC_PROXY_EGRESS		0x0B00
 #define MARK_MAGIC_HOST			0x0C00
 #define MARK_MAGIC_DECRYPT		0x0D00
-/* used to identify encrypted overlay traffic post decryption.
- * therefore, SPI bit can be reused to not steal an additional magic mark value.
- */
 #define MARK_MAGIC_ENCRYPT		0x0E00
 #define MARK_MAGIC_IDENTITY		0x0F00 /* mark carries identity */
 #define MARK_MAGIC_TO_PROXY		0x0200


### PR DESCRIPTION
In e202a4e1 ("ipsec: despecify decrypted overlay") we removed the special purpose mark used for Encrypted Overlay.

Remove the stale comments left in the wake.

```release-note
ipsec: remove stale encrypted overlay comments
```
