### PR TITLE
bpf: host: identify Cilium's Wireguard traffic as from HOST

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1394,7 +1394,7 @@ int cil_to_netdev(struct __ctx_buff *ctx)
 
 	bpf_clear_meta(ctx);
 
-	if (magic == MARK_MAGIC_HOST || magic == MARK_MAGIC_OVERLAY)
+	if (magic == MARK_MAGIC_HOST || magic == MARK_MAGIC_OVERLAY || ctx_mark_is_wireguard(ctx))
 		src_sec_identity = HOST_ID;
 	else if (magic == MARK_MAGIC_IDENTITY)
 		src_sec_identity = get_identity(ctx);


### PR DESCRIPTION
This improves the information in the trace notifications, and allows us to skip the EgressGW policy handling. It also matches the expected security identity when performing an ipcache lookup for the source IP.