### PR TITLE
endpoint: fix typos in InitWithIngressLabels()

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1957,7 +1957,7 @@ func (e *Endpoint) IsInit() bool {
 }
 
 // InitWithIngressLabels initializes the endpoint with reserved:ingress.
-// It should only be used for the host endpoint.
+// It should only be used for the ingress endpoint.
 func (e *Endpoint) InitWithIngressLabels(ctx context.Context, launchTime time.Duration) {
 	if !e.isIngress {
 		return
@@ -1971,7 +1971,7 @@ func (e *Endpoint) InitWithIngressLabels(ctx context.Context, launchTime time.Du
 	defer cancel()
 	e.UpdateLabels(newCtx, labels.LabelSourceAny, epLabels, epLabels, true)
 	if errors.Is(newCtx.Err(), context.DeadlineExceeded) {
-		log.WithError(newCtx.Err()).Warning("Timed out while updating security identify for host endpoint")
+		log.WithError(newCtx.Err()).Warning("Timed out while updating security identify for ingress endpoint")
 	}
 }
 


### PR DESCRIPTION
Make the comment and log message match the function.

This was probably a bad copy&paste in
04f19e98705c ("daemon: Add ingress endpoint").