### PR TITLE
Egress route reconciliation

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -105,6 +106,7 @@ type Daemon struct {
 	ciliumHealth *health.CiliumHealth
 
 	directRoutingDev datapathTables.DirectRoutingDevice
+	routes           statedb.Table[*datapathTables.Route]
 	devices          statedb.Table[*datapathTables.Device]
 	nodeAddrs        statedb.Table[datapathTables.NodeAddress]
 
@@ -164,6 +166,7 @@ type Daemon struct {
 
 	// Controllers owned by the daemon
 	controllers *controller.Manager
+	jobGroup    job.Group
 
 	// BIG-TCP config values
 	bigTCPConfig *bigtcp.Configuration
@@ -368,6 +371,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		directRoutingDev:  params.DirectRoutingDevice,
 		loader:            params.Loader,
 		nodeAddressing:    params.NodeAddressing,
+		routes:            params.Routes,
 		devices:           params.Devices,
 		nodeAddrs:         params.NodeAddrs,
 		nodeDiscovery:     params.NodeDiscovery,
@@ -375,6 +379,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		endpointCreations: newEndpointCreationManager(params.Clientset),
 		apiLimiterSet:     params.APILimiterSet,
 		controllers:       controller.NewManager(),
+		jobGroup:          params.JobGroup,
 		// **NOTE** The global identity allocator is not yet initialized here; that
 		// happens below via InitIdentityAllocator(). Only the local identity
 		// allocator is initialized here.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -1533,6 +1534,7 @@ type daemonParams struct {
 	CertManager         certificatemanager.CertificateManager
 	SecretManager       certificatemanager.SecretManager
 	IdentityAllocator   identitycell.CachingIdentityAllocator
+	JobGroup            job.Group
 	Policy              policy.PolicyRepository
 	IPCache             *ipcache.IPCache
 	DirReadStatus       policyDirectory.DirectoryWatcherReadStatus
@@ -1550,6 +1552,7 @@ type daemonParams struct {
 	APILimiterSet       *rate.APILimiterSet
 	AuthManager         *auth.AuthManager
 	Settings            cellSettings
+	Routes              statedb.Table[*datapathTables.Route]
 	Devices             statedb.Table[*datapathTables.Device]
 	NodeAddrs           statedb.Table[datapathTables.NodeAddress]
 	DirectRoutingDevice datapathTables.DirectRoutingDevice

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"time"
 
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/cidr"
-	"github.com/cilium/cilium/pkg/controller"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/types"
@@ -24,6 +24,8 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (
@@ -223,20 +225,35 @@ func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily, fromK8s,
 
 		node.SetRouterInfo(routingInfo)
 
-		d.controllers.CreateController("egress-route-reconciler", controller.ControllerParams{
-			DoFunc: func(_ context.Context) error {
-				return routingInfo.InstallRoutes(
+		d.jobGroup.Add(job.OneShot("egress-route-reconciler", func(ctx context.Context, health cell.Health) error {
+			// Limit the rate of reconciliation if for whatever reason the routes
+			// table is very busy. Once every 30 seconds seems reasonable as a
+			// worst case scenario.
+			limiter := rate.NewLimiter(30*time.Second, 1)
+
+			for {
+				watchSet, err := routingInfo.ReconcileGatewayRoutes(
 					d.mtuConfig.GetDeviceMTU(),
 					option.Config.EgressMultiHomeIPRuleCompat,
+					d.db.ReadTxn(),
+					d.routes,
 				)
-			},
-			// This time is a tradeoff between recovering fast from a failure and not
-			// overwhelming the system with too many reconciliations.
-			// Being without connectivity for at most 30 seconds and on average 15
-			// seconds after a hopefully uncommon event seems like a reasonable value.
-			RunInterval: 30 * time.Second,
-			Context:     d.ctx,
-		})
+				if err != nil {
+					health.Degraded("Failed to install egress routes", err)
+					limiter.Wait(ctx)
+					continue
+				}
+
+				health.OK("Egress routes installed")
+
+				limiter.Wait(ctx)
+
+				_, err = watchSet.Wait(ctx, 0)
+				if err != nil {
+					return err
+				}
+			}
+		}))
 	}
 
 	return result.IP, nil

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -14,9 +14,12 @@ import (
 	"go4.org/netipx"
 	"golang.org/x/sys/unix"
 
+	"github.com/cilium/statedb"
+
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging"
@@ -117,10 +120,12 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, compat bool, host bool) e
 	return info.installRoutes(ifindex, tableID)
 }
 
-func (info *RoutingInfo) InstallRoutes(mtu int, compat bool) error {
+func (info *RoutingInfo) ReconcileGatewayRoutes(mtu int, compat bool, rx statedb.ReadTxn, routes statedb.Table[*tables.Route]) (*statedb.WatchSet, error) {
+	set := statedb.NewWatchSet()
+
 	ifindex, err := retrieveIfIndexFromMAC(info.MasterIfMAC, mtu)
 	if err != nil {
-		return fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
+		return set, fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
 	}
 
 	var tableID int
@@ -130,33 +135,67 @@ func (info *RoutingInfo) InstallRoutes(mtu int, compat bool) error {
 		tableID = computeTableIDFromIfaceNumber(info.InterfaceNumber)
 	}
 
-	return info.installRoutes(ifindex, tableID)
+	// Get the desired routes.
+	gwRoutes := info.gatewayRoutes(ifindex, tableID)
+	for _, r := range gwRoutes {
+		// See if they already exist.
+		cidr, _ := r.Dst.Mask.Size()
+		_, _, watch, found := routes.GetWatch(rx, tables.RouteIDIndex.Query(tables.RouteID{
+			Table:     tables.RouteTable(r.Table),
+			LinkIndex: r.LinkIndex,
+			Dst:       netip.PrefixFrom(netipx.MustFromStdIP(r.Dst.IP), cidr),
+		}))
+
+		if found {
+			// If a route already exist, just add it to the watch
+			set.Add(watch)
+		} else {
+			// Since we cannot watch a non-existent route, we need to watch the
+			// table instead.
+			_, watch = routes.AllWatch(rx)
+			set.Add(watch)
+
+			// If the route doesn't exist, add it.
+			if err := netlink.RouteReplace(r); err != nil {
+				return set, fmt.Errorf("unable to add L2 nexthop route: %w", err)
+			}
+		}
+	}
+
+	return set, nil
+}
+
+func (info *RoutingInfo) gatewayRoutes(ifindex, tableID int) []*netlink.Route {
+	return []*netlink.Route{
+		// Nexthop route to the VPC or subnet gateway
+		//
+		// Note: This is a /32 route to avoid any L2. The endpoint does no L2
+		// either.
+		{
+			LinkIndex: ifindex,
+			Dst:       &net.IPNet{IP: info.IPv4Gateway, Mask: net.CIDRMask(32, 32)},
+			Scope:     netlink.SCOPE_LINK,
+			Table:     tableID,
+			Protocol:  linux_defaults.RTProto,
+		},
+
+		// Default route to the VPC or subnet gateway
+		{
+			Dst:      &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)},
+			Table:    tableID,
+			Gw:       info.IPv4Gateway,
+			Protocol: linux_defaults.RTProto,
+		},
+	}
 }
 
 func (info *RoutingInfo) installRoutes(ifindex, tableID int) error {
+	routes := info.gatewayRoutes(ifindex, tableID)
 
-	// Nexthop route to the VPC or subnet gateway
-	//
-	// Note: This is a /32 route to avoid any L2. The endpoint does no L2
-	// either.
-	if err := netlink.RouteReplace(&netlink.Route{
-		LinkIndex: ifindex,
-		Dst:       &net.IPNet{IP: info.IPv4Gateway, Mask: net.CIDRMask(32, 32)},
-		Scope:     netlink.SCOPE_LINK,
-		Table:     tableID,
-		Protocol:  linux_defaults.RTProto,
-	}); err != nil {
-		return fmt.Errorf("unable to add L2 nexthop route: %w", err)
-	}
-
-	// Default route to the VPC or subnet gateway
-	if err := netlink.RouteReplace(&netlink.Route{
-		Dst:      &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)},
-		Table:    tableID,
-		Gw:       info.IPv4Gateway,
-		Protocol: linux_defaults.RTProto,
-	}); err != nil {
-		return fmt.Errorf("unable to add L2 nexthop route: %w", err)
+	for _, r := range routes {
+		if err := netlink.RouteReplace(r); err != nil {
+			return fmt.Errorf("unable to add L2 nexthop route: %w", err)
+		}
 	}
 
 	return nil

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -114,6 +114,27 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, compat bool, host bool) e
 		}
 	}
 
+	return info.installRoutes(ifindex, tableID)
+}
+
+func (info *RoutingInfo) InstallRoutes(mtu int, compat bool) error {
+	ifindex, err := retrieveIfIndexFromMAC(info.MasterIfMAC, mtu)
+	if err != nil {
+		return fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
+	}
+
+	var tableID int
+	if compat {
+		tableID = ifindex
+	} else {
+		tableID = computeTableIDFromIfaceNumber(info.InterfaceNumber)
+	}
+
+	return info.installRoutes(ifindex, tableID)
+}
+
+func (info *RoutingInfo) installRoutes(ifindex, tableID int) error {
+
 	// Nexthop route to the VPC or subnet gateway
 	//
 	// Note: This is a /32 route to avoid any L2. The endpoint does no L2


### PR DESCRIPTION
This PR adds a somewhat crude egress route reconciliation for ENI, Azure, and Alibaba Cloud IPAM environment. This is a stopgap until we can implement proper route reconciliation.

Motivation for this PR is that nodes running Cilium can lose connectivity and not not automatically recover when external systems remove egress routes created by Cilium in these environments. I specifically encountered this on AKS where the systemd/networkd + DHCP setup will remove these routes on a carrier down event. A small 2 second carrier down event causes all routes related to the primary interface (`eth0`) be removed. When the link comes back up, our egress routes are not restored. This causes all pods on that node to lose connectivity until the Cilium agent is restarted or a new pod scheduled on the node.

The proper way to deal with this would be to implement comprehensive reconciliation, using tools we have developed for this very thing. However, that is a fairly significant change that will time to do right. So this commit adds a crude way of reconciling just these specific routes.

The PR contains 2 commits. The first is written in such a way that it does not use any of the new infrastructure such as hive, jobs, and tables to allow us to back-port this to older Cilium versions. The second commit brings the changes added in the first up to modern standards.