### PR TITLE
Revert: ci: run each commit concurrently in lint-build-commits

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Compute variables
     runs-on: ubuntu-22.04
     outputs:
-      matrix: ${{ steps.commits.outputs.matrix }}
+      commits: ${{ steps.commits.outputs.commits }}
       head-commit: ${{ steps.commits.outputs.head-commit }}
       build-bpf: ${{ steps.bpf-changes.outputs.src }}
       build-test: ${{ steps.test-changes.outputs.src }}
@@ -47,7 +47,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Compute matrix
+      - name: Compute commit list
         id: commits
         run: |
           if [[ "${{ github.event_name == 'push' || github.event_name == 'workflow_run' }}" == "true" ]]; then
@@ -57,7 +57,7 @@ jobs:
             commits=$(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | tr '\n' ' ')
             head_commit=${{ github.event.pull_request.head.sha }}
           fi
-          echo "matrix=$(echo "$commits" | xargs | jq -c -R 'split(" ") | {commit: .}')" >> $GITHUB_OUTPUT
+          echo "commits=$commits" >> $GITHUB_OUTPUT
           echo "head-commit=$head_commit" >> $GITHUB_OUTPUT
 
       - name: Check bpf code changes
@@ -65,7 +65,7 @@ jobs:
         id: bpf-changes
         with:
           # If these filters are modified, also modify the step:
-          # build-bpf: Check if bpf builds
+          # build-commits-bpf: Check if datapath build works for every commit
           filters: |
             src:
               - 'bpf/**'
@@ -75,20 +75,17 @@ jobs:
         id: test-changes
         with:
           # If these filters are modified, also modify the step:
-          # build-test: Check if ginkgo test suite builds
+          # build-commits-test: Check if ginkgo test suite build works for every commit
           filters: |
             src:
               - 'pkg/**'
               - 'test/**'
 
-  build-cilium:
-    name: cilium build check ${{ matrix.commit }}
+  build-commits-cilium:
+    name: Check if cilium builds for every commit
     runs-on: ubuntu-22.04
     needs: [compute-vars]
     timeout-minutes: 180
-    strategy:
-      max-parallel: 5
-      matrix: ${{ fromJSON(needs.compute-vars.outputs.matrix) }}
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
@@ -104,7 +101,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-          ref: ${{ matrix.commit }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Cleanup Disk space in runner
         uses: ./.github/actions/disk-cleanup
@@ -143,7 +141,7 @@ jobs:
           mkdir -p /tmp/.cache/go/pkg
           mkdir -p /tmp/.cache/ccache/.ccache
 
-      - name: Check if cilium builds for commit
+      - name: Check if build works for every commit
         if: ${{ github.event_name != 'push' || ( (github.event_name == 'push' || github.event_name == 'workflow_run' ) && (steps.go-cache.outputs.cache-hit != 'true' || steps.ccache-cache.outputs.cache-hit != 'true')) }}
         env:
           CLANG: "ccache clang"
@@ -152,7 +150,11 @@ jobs:
           BUILDER_CCACHE_DIR: "/tmp/.cache/ccache/.ccache"
         run: |
           set -eu -o pipefail
-          contrib/scripts/builder.sh make CLANG="${CLANG}" build -j $(nproc) || exit 1
+          commits="${{ needs.compute-vars.outputs.commits }}"
+          for commit in $commits; do
+            git checkout $commit || exit 1
+            contrib/scripts/builder.sh make CLANG="${CLANG}" build -j $(nproc) || exit 1
+          done
 
       - name: Reset cache ownership to GitHub runners user
         if: ${{ steps.go-cache.outputs.cache-hit != 'true' || steps.ccache-cache.outputs.cache-hit != 'true' }}
@@ -161,14 +163,15 @@ jobs:
           sudo du -sh /tmp/.cache/
           sudo chown $USER:$USER -R /tmp/.cache
 
-  build-hubble-cli:
-    name: hubble-cli build check ${{ matrix.commit }}
+      - name: Failed commit during the build
+        if: ${{ failure() }}
+        run: git --no-pager log --format=%B -n 1
+
+  build-commits-hubble-cli:
+    name: Check if hubble-cli builds for every commit
     runs-on: ubuntu-22.04
     needs: [compute-vars]
     timeout-minutes: 180
-    strategy:
-      max-parallel: 5
-      matrix: ${{ fromJSON(needs.compute-vars.outputs.matrix) }}
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
@@ -184,7 +187,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-          ref: ${{ matrix.commit }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Cleanup Disk space in runner
         uses: ./.github/actions/disk-cleanup
@@ -223,7 +227,7 @@ jobs:
           mkdir -p /tmp/.cache/hubble-cli/.cache/go-build
           mkdir -p /tmp/.cache/hubble-cli/pkg
 
-      - name: Check if hubble CLI builds for commit
+      - name: Check if hubble CLI builds for every commit
         if: ${{ github.event_name != 'push' || ( github.event_name == 'push' && steps.hubble-cache.outputs.cache-hit != 'true' ) }}
         env:
           CLANG: "ccache clang"
@@ -231,15 +235,18 @@ jobs:
           BUILDER_GOMODCACHE_DIR: "/tmp/.cache/hubble-cli/pkg"
         run: |
           set -eu -o pipefail
-          commit="${{ matrix.commit }}"
+          commits="${{ needs.compute-vars.outputs.commits }}"
           head_commit="${{ needs.compute-vars.outputs.head-commit }}"
-          echo "Only run full build (with `local-release`) for head commit (i.e. last commit in sequence)"
-          target=hubble
-          if [[ "$commit" == "$head_commit" ]]; then
-            target=local-release
-          fi
-          echo "Running build: $target (commit: $commit)"
-          contrib/scripts/builder.sh make CLANG="${CLANG}" -C hubble local-release -j $(nproc) || exit 1
+          for commit in $commits; do
+            git checkout $commit || exit 1
+            echo "Only run full build (with `local-release`) for head commit (i.e. last commit in sequence)"
+            target=hubble
+            if [[ "$commit" == "$head_commit" ]]; then
+              target=local-release
+            fi
+            echo "Running build: $target (commit: $commit)"
+            contrib/scripts/builder.sh make CLANG="${CLANG}" -C hubble $target -j $(nproc) || exit 1
+          done
 
       - name: Reset cache ownership to GitHub runners user
         if: ${{ steps.ccache-cache.outputs.cache-hit != 'true' }}
@@ -248,16 +255,17 @@ jobs:
           sudo du -sh /tmp/.cache/
           sudo chown $USER:$USER -R /tmp/.cache
 
-  build-bpf:
-    name: bpf build check ${{ matrix.commit }}
+      - name: Failed commit during the build
+        if: ${{ failure() }}
+        run: git --no-pager log --format=%B -n 1
+
+  build-commits-bpf:
+    name: Check if bpf builds for every commit
     runs-on: ubuntu-22.04
     needs: [compute-vars]
     # Runs only if code under bpf/ is changed.
     if: needs.compute-vars.outputs.build-bpf == 'true'
     timeout-minutes: 180
-    strategy:
-      max-parallel: 5
-      matrix: ${{ fromJSON(needs.compute-vars.outputs.matrix) }}
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
@@ -273,7 +281,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-          ref: ${{ matrix.commit }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Cleanup Disk space in runner
         uses: ./.github/actions/disk-cleanup
@@ -312,7 +321,7 @@ jobs:
           mkdir -p /tmp/.cache/go/pkg
           mkdir -p /tmp/.cache/ccache/.ccache
 
-      - name: Check if bpf builds
+      - name: Check if datapath build works for every commit
         env:
           CLANG: "ccache clang"
           BUILDER_GOCACHE_DIR: "/tmp/.cache/go/.cache/go-build"
@@ -320,13 +329,17 @@ jobs:
           BUILDER_CCACHE_DIR: "/tmp/.cache/ccache/.ccache"
         run: |
           set -eu -o pipefail
-          # Do not run make if there aren't any files modified in these
-          # directories from the previous commit to the current commit.
-          # If these filters are modified, also modify the step:
-          # compute-vars: Check bpf code changes
-          if ! git diff --quiet HEAD^ bpf/ ; then
-            contrib/scripts/builder.sh make CLANG="${CLANG}" -C bpf build_all -j $(nproc) || exit 1
-          fi
+          commits="${{ needs.compute-vars.outputs.commits }}"
+          for commit in $commits; do
+            git checkout $commit || exit 1
+            # Do not run make if there aren't any files modified in these
+            # directories from the previous commit to the current commit.
+            # If these filters are modified, also modify the step:
+            # compute-vars: Check bpf code changes
+            if ! git diff --quiet HEAD^ bpf/ ; then
+              contrib/scripts/builder.sh make CLANG="${CLANG}" -C bpf build_all -j $(nproc) || exit 1
+            fi
+          done
 
       - name: Reset cache ownership to GitHub runners user
         if: ${{ steps.go-cache.outputs.cache-hit != 'true' || steps.ccache-cache.outputs.cache-hit != 'true' }}
@@ -335,16 +348,17 @@ jobs:
           sudo du -sh /tmp/.cache/
           sudo chown $USER:$USER -R /tmp/.cache
 
-  build-test:
-    name: test build check ${{ matrix.commit }}
+      - name: Failed commit during the build
+        if: ${{ failure() }}
+        run: git --no-pager log --format=%B -n 1
+
+  build-commits-test:
+    name: Check if test builds for every commit
     runs-on: ubuntu-22.04
     needs: [compute-vars]
     # Runs only if code under test/ is changed.
     if: needs.compute-vars.outputs.build-test == 'true'
     timeout-minutes: 180
-    strategy:
-      max-parallel: 5
-      matrix: ${{ fromJSON(needs.compute-vars.outputs.matrix) }}
     steps:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
@@ -360,7 +374,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-          ref: ${{ matrix.commit }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Cleanup Disk space in runner
         uses: ./.github/actions/disk-cleanup
@@ -391,13 +406,21 @@ jobs:
         run: |
           go install github.com/onsi/ginkgo/ginkgo@cc0216944b25a88d3259699a029d4e601fb8a222 # v1.12.1
 
-      - name: Check if ginkgo test suite builds
+      - name: Check if ginkgo test suite build works for every commit
         run: |
           set -eu -o pipefail
-          # Do not run make if there aren't any files modified in these
-          # directories from the previous commit to the current commit.
-          # If these filters are modified, also modify the step:
-          # compute-vars: Check test code changes
-          if ! git diff --quiet HEAD^ pkg/ test/ ; then
-            (make -C test build -j $(nproc) && make -C test build-darwin -j $(nproc)) || exit 1
-          fi
+          commits="${{ needs.compute-vars.outputs.commits }}"
+          for commit in $commits; do
+            git checkout $commit || exit 1
+            # Do not run make if there aren't any files modified in these
+            # directories from the previous commit to the current commit.
+            # If these filters are modified, also modify the step:
+            # compute-vars: Check test code changes
+            if ! git diff --quiet HEAD^ pkg/ test/ ; then
+              (make -C test build -j $(nproc) && make -C test build-darwin -j $(nproc)) || exit 1
+            fi
+          done
+
+      - name: Failed commit during the build
+        if: ${{ failure() }}
+        run: git --no-pager log --format=%B -n 1


### PR DESCRIPTION
This reverts commit a4dc66c4fd6c1fd4308ba432ce5921081c943b5d.

PR https://github.com/cilium/cilium/pull/37754 introduced two commits, one to make each lint type its own job (cilium, hubble-cli, ebpf, test) and one to make each commit within lint type its own job.

With 10+ commits, the PR checks UX becomes unwieldy, and with the current 5 parallel jobs limit + the amount of ongoing workflows running, it's probably too extreme to have each commit be a job. Additionally, jobs can't take advantage of the cache from the previous commit.

Lets revert the second commit and keep the conccurent jobs for lint types, which is still a substantial improvement over sequential run.
