### PR TITLE
ci: use custom kubeconfig for cilium-cli cloud provider tests

### DIFF
--- a/.github/actions/get-cloud-kubeconfig/action.yaml
+++ b/.github/actions/get-cloud-kubeconfig/action.yaml
@@ -1,0 +1,63 @@
+name: Get Kubeconfig for cloud clusters
+description: Creates service account, token and kubeconfig to be used by cilium-cli
+
+inputs:
+  kubeconfig:
+    description: "Kubeconfig used to communicate with control plane"
+    default: "~/.kube/config"
+
+outputs:
+  kubeconfig_path:
+    description: "Path to the generated kubeconfig"
+    value: ${{ steps.service-account-create.outputs.kubeconfig_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Create service account and kubeconfig for cilium-cli
+      id: service-account-create
+      shell: bash
+      run: |
+        kubectl --kubeconfig ${{ inputs.kubeconfig }} create serviceaccount -n kube-system cilium-cli
+        kubectl --kubeconfig ${{ inputs.kubeconfig }} create clusterrolebinding -n kube-system cilium-cli-binding --clusterrole cluster-admin --serviceaccount "kube-system:cilium-cli"
+        cat <<EOF | kubectl apply -f -
+        apiVersion: v1
+        kind: Secret
+        type: kubernetes.io/service-account-token
+        metadata:
+          name: cilium-cli-secret
+          namespace: kube-system
+          annotations:
+            kubernetes.io/service-account.name: cilium-cli
+        EOF
+        kubectl --kubeconfig ${{ inputs.kubeconfig }} wait --for=jsonpath='{.data.token}' secrets/cilium-cli-secret -n kube-system
+        kubectl --kubeconfig ${{ inputs.kubeconfig }} wait --for=jsonpath='{.data.ca\.crt}' secrets/cilium-cli-secret -n kube-system
+        api_endpoint=$(kubectl --kubeconfig ${{ inputs.kubeconfig }} config view --minify --output jsonpath="{.clusters[*].cluster.server}")
+        cluster_name=$(kubectl --kubeconfig ${{ inputs.kubeconfig }} config view --minify -o jsonpath='{.clusters[].name}')
+        # Cilium CLI relies on context name to detect cluster flavor for GKE
+        context_name=$(kubectl --kubeconfig ${{ inputs.kubeconfig }} config view --minify -o jsonpath='{.contexts[].name}')
+        ca=$(kubectl --kubeconfig ${{ inputs.kubeconfig }} get secret -n kube-system cilium-cli-secret --output jsonpath='{.data.ca\.crt}')
+        token=$(kubectl --kubeconfig ${{ inputs.kubeconfig }} get secret -n kube-system cilium-cli-secret --output jsonpath='{.data.token}' | base64 --decode)
+        DIR=$(mktemp -d)
+        KUBECONFIG_PATH=$DIR/control-plane-kubeconfig.yaml
+        cat <<EOF > $KUBECONFIG_PATH
+        apiVersion: v1
+        kind: Config
+        clusters:
+          - name: ${cluster_name}
+            cluster:
+              certificate-authority-data: ${ca}
+              server: ${api_endpoint}
+        contexts:
+          - name: ${context_name}
+            context:
+              cluster: ${cluster_name}
+              namespace: default
+              user: cilium-cli
+        users:
+          - name: cilium-cli
+            user:
+              token: ${token}
+        current-context: ${context_name}
+        EOF
+        echo "kubeconfig_path=$KUBECONFIG_PATH" >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -199,6 +199,7 @@ jobs:
           # We explicity set the cluster-pool Pod CIDR here to not clash with the AKS default Service CIDRs
           # which are 10.0.0.0/16 and fd12:3456:789a:1::/108
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
+            --datapath-mode=aks-byocni \
             --helm-set cluster.name=${{ env.name }} \
             --helm-set loadBalancer.l7.backend=envoy \
             --helm-set=azure.resourceGroup=${{ env.name }} \
@@ -245,12 +246,19 @@ jobs:
             --resource-group ${{ env.name }} \
             --name ${{ env.name }}
 
+      - name: Generate cilium-cli kubeconfig
+        id: gen-kubeconfig
+        uses: ./.github/actions/get-cloud-kubeconfig
+        with:
+          kubeconfig: "~/.kube/config"
+
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@45a3879a8cb769c9e41b912635e03a38849c9242 # v0.18.1
         with:
           skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
           image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
           image-tag: ${{ steps.vars.outputs.sha }}
+          kubeconfig: ${{ steps.gen-kubeconfig.outputs.kubeconfig_path }}
 
       - name: Wait for images to be available
         timeout-minutes: 30

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -273,12 +273,19 @@ jobs:
           version: ${{ matrix.version }}
           spot: false
 
+      - name: Generate cilium-cli kubeconfig
+        id: gen-kubeconfig
+        uses: ./.github/actions/get-cloud-kubeconfig
+        with:
+          kubeconfig: "~/.kube/config"
+
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@45a3879a8cb769c9e41b912635e03a38849c9242 # v0.18.1
         with:
           skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
           image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
           image-tag: ${{ steps.vars.outputs.sha }}
+          kubeconfig: ${{ steps.gen-kubeconfig.outputs.kubeconfig_path }}
 
       - name: Wait for images to be available
         timeout-minutes: 30

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -274,12 +274,19 @@ jobs:
           version: ${{ matrix.version }}
           addons: "coredns kube-proxy"
 
+      - name: Generate cilium-cli kubeconfig
+        id: gen-kubeconfig
+        uses: ./.github/actions/get-cloud-kubeconfig
+        with:
+          kubeconfig: "~/.kube/config"
+
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@45a3879a8cb769c9e41b912635e03a38849c9242 # v0.18.1
         with:
           skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
           image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
           image-tag: ${{ steps.vars.outputs.sha }}
+          kubeconfig: ${{ steps.gen-kubeconfig.outputs.kubeconfig_path }}
 
       - name: Create IPsec key
         if: ${{ matrix.ipsec == true }}

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -259,6 +259,7 @@ jobs:
           gcloud info
 
       - name: Create GKE cluster
+        id: create-cluster
         run: |
           gcloud container clusters create ${{ env.clusterName }}-${{ matrix.config.index }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
@@ -276,9 +277,18 @@ jobs:
             --node-taints ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready=true:NoExecute \
             --no-enable-insecure-kubelet-readonly-port
 
+          native_cidr="$(gcloud container clusters describe ${{ env.clusterName }}-${{ matrix.config.index }} --zone ${{ matrix.k8s.zone }} --format 'value(clusterIpv4Cidr)')"
+          echo native_cidr=${native_cidr} >> $GITHUB_OUTPUT
+
       - name: Get cluster credentials
         run: |
           gcloud container clusters get-credentials ${{ env.clusterName }}-${{ matrix.config.index }} --zone ${{ matrix.k8s.zone }}
+
+      - name: Generate cilium-cli kubeconfig
+        id: gen-kubeconfig
+        uses: ./.github/actions/get-cloud-kubeconfig
+        with:
+          kubeconfig: "~/.kube/config"
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@45a3879a8cb769c9e41b912635e03a38849c9242 # v0.18.1
@@ -286,6 +296,7 @@ jobs:
           skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
           image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
           image-tag: ${{ steps.vars.outputs.sha }}
+          kubeconfig: ${{ steps.gen-kubeconfig.outputs.kubeconfig_path }}
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
@@ -314,7 +325,8 @@ jobs:
       - name: Install Cilium
         id: install-cilium
         run: |
-          cilium install ${{ steps.vars.outputs.cilium_install_defaults }} ${{ matrix.config.cilium-install-opts }}
+          cilium install ${{ steps.vars.outputs.cilium_install_defaults }} ${{ matrix.config.cilium-install-opts }} \
+          --helm-set=ipv4NativeRoutingCIDR=${{ steps.create-cluster.outputs.native_cidr }}
 
       - name: Wait for Cilium to be ready
         run: |

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -214,6 +214,7 @@ jobs:
           gcloud info
 
       - name: Create GKE cluster
+        id: create-cluster
         run: |
           gcloud container clusters create ${{ env.clusterName }}-${{ matrix.index }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
@@ -230,9 +231,18 @@ jobs:
             --disk-size 20GB \
             --node-taints ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready=true:NoExecute
 
+          native_cidr="$(gcloud container clusters describe ${{ env.clusterName }}-${{ matrix.index }} --zone ${{ env.gcp_zone }} --format 'value(clusterIpv4Cidr)')"
+          echo native_cidr=${native_cidr} >> $GITHUB_OUTPUT
+
       - name: Get cluster credentials
         run: |
           gcloud container clusters get-credentials ${{ env.clusterName }}-${{ matrix.index }} --zone ${{ env.gcp_zone }}
+
+      - name: Generate cilium-cli kubeconfig
+        id: gen-kubeconfig
+        uses: ./.github/actions/get-cloud-kubeconfig
+        with:
+          kubeconfig: "~/.kube/config"
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@45a3879a8cb769c9e41b912635e03a38849c9242 # v0.18.1
@@ -240,6 +250,7 @@ jobs:
           skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
           image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
           image-tag: ${{ steps.vars.outputs.sha }}
+          kubeconfig: ${{ steps.gen-kubeconfig.outputs.kubeconfig_path }}
 
       - name: Wait for images to be available
         timeout-minutes: 30
@@ -258,8 +269,8 @@ jobs:
       - name: Install Cilium
         id: install-cilium
         run: |
-          cilium install --dry-run-helm-values ${{ steps.vars.outputs.cilium_install_defaults }}
-          cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
+          cilium install --dry-run-helm-values ${{ steps.vars.outputs.cilium_install_defaults }} --helm-set=ipv4NativeRoutingCIDR=${{ steps.create-cluster.outputs.native_cidr }}
+          cilium install ${{ steps.vars.outputs.cilium_install_defaults }} --helm-set=ipv4NativeRoutingCIDR=${{ steps.create-cluster.outputs.native_cidr }}
 
       - name: Wait for Cilium to be ready
         run: |

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -368,12 +368,19 @@ jobs:
           version: "${{ steps.vars.outputs.eks_version }}"
           addons: "coredns"
 
+      - name: Generate cilium-cli kubeconfig
+        id: gen-kubeconfig
+        uses: ./.github/actions/get-cloud-kubeconfig
+        with:
+          kubeconfig: "~/.kube/config"
+
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@45a3879a8cb769c9e41b912635e03a38849c9242 # v0.18.1
         with:
           skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
           image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
           image-tag: ${{ inputs.SHA || github.sha }}
+          kubeconfig: ${{ steps.gen-kubeconfig.outputs.kubeconfig_path }}
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.

--- a/cilium-cli/Dockerfile
+++ b/cilium-cli/Dockerfile
@@ -31,21 +31,4 @@ LABEL maintainer="maintainer@cilium.io"
 WORKDIR /root/app
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/local/bin/cilium /usr/local/bin/cilium
 
-# Install cloud CLIs. Based on these instructions:
-# - https://cloud.google.com/sdk/docs/install#deb
-# - https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
-# - https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#install-azure-cli
-RUN apt-get update -y \
- && apt-get install -y curl gnupg unzip \
- && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
- && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
- && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
- && apt-get update -y \
- && apt-get install -y google-cloud-cli google-cloud-sdk-gke-gcloud-auth-plugin kubectl \
- && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
- && unzip awscliv2.zip \
- && ./aws/install \
- && rm -r ./aws awscliv2.zip \
- && curl -sL https://aka.ms/InstallAzureCLIDeb | bash
-
 ENTRYPOINT []


### PR DESCRIPTION
Previously, we were bundling all cloud provider SDKs/CLIs within cilium-cli image to be able to access cluster's control plane.
Now, let's switch to service account with all permissions and use that kubeconfig as it doesn't require cloud SDKs/CLIs.
This allows us to remove cloud dependencies from cilium-cli image, reducing image size from ~2.4GB to ~200MB and reducing installation step time from ~40s to ~5s.
For AKS, set datapath mode explicitly as auto detection relies on az CLI.
For GKE, set ipv4NativeRoutingCIDR so we don't rely on gcloud.