### PR TITLE
bpf/lib/policy: Always define EFFECTIVE_EP_ID

### DIFF
--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -15,12 +15,14 @@
 /*
  * Both non-host and host EP programs have HOST_EP_ID defined, but only non-host EPs have LXC_ID
  * defined. Hence, if LXC_ID is defined, we are doing policy for a non-host EP, otherwise for the
- * host EP.
+ * host EP, or zero if neither is defined.
  */
 #ifdef LXC_ID
 #define EFFECTIVE_EP_ID LXC_ID
-#else
+#elif defined(HOST_EP_ID)
 #define EFFECTIVE_EP_ID HOST_EP_ID
+#else
+#define EFFECTIVE_EP_ID 0
 #endif
 
 static __always_inline void


### PR DESCRIPTION
Define EFFECTIVE_EP_ID as zero if neither LXC_ID nor HOST_EP_ID is defined.

Fixes: #37591
