### PR TITLE
 bpf: lxc: prioritize ct_state->from_tunnel over destination's .skip_tunnel

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -704,7 +704,7 @@ ct_recreate6:
 
 	/* The packet goes to a peer not managed by this agent instance */
 #ifdef TUNNEL_MODE
-	if (!skip_tunnel) {
+	if (ct_state->from_tunnel || !skip_tunnel) {
 		struct tunnel_key key = {};
 		union v6addr *daddr = (union v6addr *)&ip6->daddr;
 
@@ -1237,7 +1237,10 @@ skip_vtep:
 #endif
 
 #if defined(TUNNEL_MODE)
-	if (!skip_tunnel) {
+	/* If the connection was established over the tunnel, ignore the
+	 * destination's `skip_tunnel` flag.
+	 */
+	if (ct_state->from_tunnel || !skip_tunnel) {
 		struct tunnel_key key = {};
 
 		if (cluster_id > UINT16_MAX)

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
@@ -255,7 +255,8 @@ int lxc_to_overlay_synack_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "02_lxc_to_overlay_synack")
 int lxc_to_overlay_synack_setup(struct __ctx_buff *ctx)
 {
-	ipcache_v4_add_entry(CLIENT_NODE_IP, 0, REMOTE_NODE_ID, 0, 0);
+	ipcache_v4_add_entry_with_flags(CLIENT_NODE_IP, 0, REMOTE_NODE_ID,
+					CLIENT_NODE_IP, 0, true);
 
 	tail_call_static(ctx, entry_call_map, FROM_CONTAINER);
 


### PR DESCRIPTION
```
With https://github.com/cilium/cilium/pull/36978 the IPcache entry for
a remote node now contains a tunnel_endpoint, typically in combination
with the `skip_tunnel` flag set. But when dealing with replies for a
connection that was established via the overlay network, we want to
continue routing those replies via the overlay.

Also fix up the corresponding BPF test for inter-cluster-SNAT.
```

```release-note
Fix a bug that prevented inter-cluster-SNAT reply traffic from being routed via the overlay network.
```
