### PR TITLE
Egress gateway parallel connections testing

### DIFF
--- a/.github/actions/cl2-modules/egw/README.md
+++ b/.github/actions/cl2-modules/egw/README.md
@@ -1,63 +1,14 @@
-# egw
+# Egress Gateway Scale and Performance Testing
 
-This directory contains utilities for performing scale tests on Cilium's Egress
-Gateway feature.
+This directory contains utilities for performing scale and performance tests on
+Cilium's Egress Gateway feature.
 
 An additional docker image is utilized to perform the test, which can be found
 within the [cilium/scaffolding](https://github.com/cilium/scaffolding/tree/main/egw-scale-utils)
-repository.
+repository. Refer to the README file therein available for additional information
+on the `egw-scale-utils` tool.
 
-## Pod Masquerade Delay
-
-This test measures the amount of time it takes for a Pod's network traffic to
-be masqueraded through an EGW node to an external target.
-
-### Test Overview
-
-At a high-level, the test works by creating an EGW policy to target a workload
-Pod that attempts to open a TCP connection to a pre-deployed external target.
-If the pre-deployed external target sees that the source address of the TCP
-connection is the pre-set EGW Node IP, then the external target will reply
-with "pong" and close the connection. If the source address is not the pre-set
-EGW Node IP, then the external target will close the connection without sending
-any reply traffic.
-
-When the client connects to the external target and does not receive any reply
-traffic, the connection attempt is deemed a "miss". The client will continue
-to connect to the external target until it receives "pong" in reply, allowing
-for the implementation delay of an EGW policy for a new Pod to be measured.
-
-```mermaid
-sequenceDiagram
-    participant Client
-    participant Client's Datapath
-    participant EGW Node
-    participant External Target
-    note right of Client: Before EGW Policy is in effect
-    Client-->>+Client's Datapath: Connect to target via TCP
-    Client's Datapath-->>+External Target: Forward connection
-    External Target->>+Client: Accept and close connection
-    note right of Client: After EGW Policy is in effect
-    Client->>+Client's Datapath: Connect to target via TCP
-    Client's Datapath-->>+EGW Node: Forward connection
-    EGW Node-->>+External Target: Masquerade connection
-    External Target->>+EGW Node: Send "pong" and close connection
-    EGW Node-->>+Client: Send "pong" and close connection
-```
-
-A baseline test can be executed by running the test without deploying the
-EGW Policy and by configuring the external target to always respond with
-"pong" to any incoming requests.
-
-### Client Pod Metrics
-
-| Name                                            | Description                                                                                              |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `egw_scale_test_leaked_requests_total`          | The total number of leaked requests a client made when trying to access the external target.             |
-| `egw_scale_test_masquerade_delay_seconds_total` | The number of seconds between a client pod starting and hitting the external target.                     |
-| `egw_scale_test_failed_tests_total`             | Incremented when a client Pod is unable to connect to the external target after a preconfigured timeout. |
-
-### Environment Details
+## Environment Details
 
 The cluster needs to be created with four types of nodes:
 
@@ -73,65 +24,78 @@ The cluster needs to be created with four types of nodes:
    monitoring-related traffic and resource usage from the test, labeled
    with `role.scaffolding/monitoring: true`.
 
-### Test Set Up
+## Tests Overview
 
-After the cluster is created, use the `preflight.sh` script to perform setup tasks.
+The remainder of this README provides an overview of the test suite. The test
+suite can be run in *baseline* mode (i.e., without deploying the egress gateway
+policies), to measure baseline performance, or in *egw* mode, to measure
+egress gateway performance. This is controlled via the `CL2_EGW_CREATE_POLICY`
+environment variable.
 
-The components of the test rely on two pieces of information to be hardcoded
-into their manifests:
+The full list of configurations is provided at the top of the
+[config.yaml](config.yaml) file.
 
-1. The address of the dedicated EGW Node, which the external target uses
-   to differentiate masqueraded versus non-masqueraded traffic.
-2. The address of the external target, which is needed by the client to send
-   requests and needed by the EGW Policy to understand the destination CIDR
-   of outgoing connections that needs to be masqueraded.
+### Pod Masquerade Delay
 
-Grabbing and hardcoding these two addresses ahead of time simplifies the
-test execution and limits the overall scope of components under test.
-For instance, using a hardcoded address for the external target allows
-for the client to make a direct connection without the need for a Service
-or DNS.
+This test measures the amount of time it takes for a newly started pod to be able
+to contact an external destination via the egress gateway. Additionally, it assesses
+the scalability of the egress gateway control plane.
 
-The `preflight.sh` script will grab the two addresses, fill out manifest
-templates and apply the EGW policy.
+At a high level, the test leverages the `egw-scale-utils` utility, and is organized
+as follows:
 
-**If running a baseline test, execute `preflight.sh baseline`,
-which will cause the preflight script to configure the manifests for a baseline
-test and skip applying the EGW policy.**
+* The appropriate egress gateway policy is applied to the cluster (in *egw* mode).
+* A server representing the external destination is deployed on the dedicated node;
+  in *egw* mode, it is configured to reply to clients only if the request comes
+  from the expected egress gateway IP.
+* *N* clients are deployed into the cluster (at a rate of *Q* per second); each
+  client tries to contact the server, and measures how much it takes before it
+  receives a response from the server (that is, the packets correctly flow through
+  the egress gateway); this is referred to as the *low-scale* test.
+* The scale is artificially increased via the creation of synthetic CiliumEndpoints,
+  synthetic nodes, and extra EGW policies (each matching all synthetic endpoints
+  and a subset of the synthetic nodes).
+* *N* new clients are deployed into the cluster (at a rate of *Q* per second),
+  measuring again the masquerade delay; this is referred to as the *high-scale* test.
+* CPU and memory used by Cilium agents during the whole test is measured.
 
-### Test Execution
+### Network Performance Testing
 
-The test is executed via [ClusterLoader2](https://github.com/kubernetes/perf-tests/tree/master/clusterloader2).
-The config for the test is named `config.yml`. It executes the following steps
-to run the test:
+This test characterizes the main egress gateway performance metrics, in terms of
+throughput, transaction rate and latency. This validates the potential overhead
+introduced by traffic redirection to the egress gateway node. Additionally, it
+measures the amount of CPU consumed by the egress gateway node.
 
-0. Deploy a PodMonitor to target the Prometheus endpoint of test client Pods.
-1. Deploy the external target Pod and wait for it to be running and ready.
-2. Deploy a single test client Pod and wait for it to be ready. Timeouts are
-   configured in a way where, if the client Pod is unable to successfully
-   connect to the external target through EGW, the test will fail. This
-   step ensures that the EGW policy has been plumbed into the datapath.
-3. Deploy `N` test client Pods and wait for them to be ready. The number
-   of deployed client pods and the rate at which they are deployed can be
-   configured. See the next section for details.
-4. Sleep, to allow for the metrics exposed by each client Pod to be scraped.
-5. Collect and export metrics. See the next section for details regarding
-   the metrics which are exported.
+At a high level, the test leverages the `cilium connectivity perf` suite (based
+on `netperf`  under the hood), and is organized as follows:
 
-### Test Metrics
+* A `netperf` server pod representing the external destination is deployed on
+  the dedicated node.
+* A `netperf` client pod is deployed on one of the client nodes; the client is
+  matched by an egress gateway policy as appropriate.
+* The full suite of netperf tests (including TCP/UDP STREAM, TCP/UDP RR, TCP CRR) is
+  run to evaluate the different performance metrics; each test is run for 30 seconds.
+* CPU and memory consumed by the different nodes during the whole test is measured.
 
-| Name                                     | Description                                                                                                                   |
-| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `EGW Total Number of Client Pods`        | The total number of client pods that were deployed during the test.                                                           |
-| `EGW Total Number of Failed Client Pods` | The total number of client pods that were unable to connect to the external target through EGW within the configured timeout. |
-| `EGW Leaked Pings - Nth Percentile`      | The Nth percentile of pings that were leaked across all client pods.                                                          |
-| `EGW Leaked Pings - Total`               | The total number of pings that were leaked across all client pods.                                                            |
-| `EGW Masquerade Delay - Nth Percentile`  | The Nth percentile of the masquerade delay across all client pods.                                                            |
+### Max Parallel Connections
 
-### Test Configuration
+This test assesses the maximum number of connections that can be opened towards an
+external target via the egress gateway, and the associated latency. Additionally,
+it measures the amount of CPU consumed by Cilium agents during the process.
 
-The following environment variables are available to modify the CL2 config:
+At a high level, the test leverages the `egw-scale-utils` utility, with the external
+target configured to keep client connections open, and the clients continuously
+opening new connections until repeated failures are encountered. The test is
+repeated four times sequentially, to assess the following combinations:
 
-1. `CL2_NUM_EGW_CLIENTS`: The total number of client Pods which the test will
-   deploy.
-2. `CL2_EGW_CLIENTS_QPS`: The number of client Pods to deploy per second.
+* *base*: client hosted on a given node *N1*, towards the target listening on
+  port *P1*;
+* *same-port-node*: client hosted on the same node *N1*, towards the same target
+  listening on port *P1*; it evaluates whether a client hosted on the same node,
+  and targeting the same destination is affected by the other connections.
+* *diff-node*: client hosted on a different node *N2*, towards the same target
+  listening on port *P1*; it evaluates whether a client hosted on a different
+  node, and targeting the same destination is affected by the other connections.
+* *diff-port*: client hosted on the same node *N1*, towards a different target
+  listening on port *P2*; it evaluates whether a client hosted on the same node,
+  but targeting a different destination is affected by the other connections.

--- a/.github/actions/cl2-modules/egw/config.yaml
+++ b/.github/actions/cl2-modules/egw/config.yaml
@@ -87,6 +87,22 @@ steps:
       desiredPodCount: 1
       timeout: 55s
 
+- name: Wait for EGW Client Prometheus target to appear
+  measurements:
+    - Identifier: ExecCommand
+      Method: Exec
+      Params:
+        retries: 60
+        backoffDelay: 5s
+        timeout: 5s
+        command:
+        - /bin/sh
+        - -c
+        - >
+          ! kubectl get podmonitor -n monitoring egw-client > /dev/null || \
+            kubectl get --raw '/api/v1/namespaces/monitoring/services/prometheus-k8s:9090/proxy/api/v1/targets' | \
+              grep -q egw-client
+
 - module:
     path: ../cilium-agent-pprofs.yaml
     params:

--- a/.github/actions/cl2-modules/egw/config.yaml
+++ b/.github/actions/cl2-modules/egw/config.yaml
@@ -92,11 +92,6 @@ steps:
     params:
       action: start
 
-- module:
-    path: ../cilium-metrics.yaml
-    params:
-      action: start
-
 # Run a first iteration of the masquerade delay test.
 - module:
     path: modules/masq-test.yaml
@@ -172,12 +167,6 @@ steps:
       externalTarget: {{$ExternalTarget}}
       replicas: {{$NumEGWClients}}
       metricsSuffix: HighScale
-
-# Gather the Cilium metrics here, so that they are not impacted by the performance test.
-- module:
-    path: ../cilium-metrics.yaml
-    params:
-      action: gather
 
 # Run the performance test.
 - module:

--- a/.github/actions/cl2-modules/egw/config.yaml
+++ b/.github/actions/cl2-modules/egw/config.yaml
@@ -46,7 +46,7 @@ steps:
   - namespaceRange:
       min: 1
       max: 1
-    replicasPerNamespace: 1
+    replicasPerNamespace: 3
     tuningSet: Uniform1qps
     objectBundle:
     - basename: egw-external-target
@@ -61,8 +61,9 @@ steps:
     Method: WaitForRunningPods
     Params:
       labelSelector: app.kubernetes.io/name=egw-external-target
-      desiredPodCount: 1
+      desiredPodCount: 3
       timeout: 60s
+
 - name: Create bootstrap EGW client Pod
   phases:
   - namespaceRange:
@@ -77,7 +78,10 @@ steps:
         Image: {{$TestImage}}
         Instance: "bootstrap"
         ExternalTarget: {{$ExternalTarget}}
+        ExternalTargetPort: 1337
         ClientConnectTimeout: "60s"
+        Stress: false
+
 - name: Wait for EGW bootstrap pod to be running
   measurements:
   - Identifier: WaitForRunningPods
@@ -190,6 +194,14 @@ steps:
     params:
       gatewayAddress: {{$GatewayAddress}}
       udpMessageSize: {{$UDPMessageSize}}
+
+# Run the connections stress test.
+- module:
+    path: modules/stress-test.yaml
+    params:
+      image: {{$TestImage}}
+      externalTarget: {{$ExternalTarget}}
+      instance: stress
 
 - module:
     path: ../cilium-agent-pprofs.yaml

--- a/.github/actions/cl2-modules/egw/manifests/client-pod.yaml
+++ b/.github/actions/cl2-modules/egw/manifests/client-pod.yaml
@@ -15,8 +15,10 @@ spec:
     imagePullPolicy: IfNotPresent
     args:
       - "client"
-      - "--external-target-addr={{.ExternalTarget}}:1337"
+      - "--external-target-addr={{.ExternalTarget}}:{{.ExternalTargetPort}}"
       - "--test-timeout={{.ClientConnectTimeout}}"
+      - "--stress={{.Stress}}"
+      - "--stress-delay=15s"
     ports:
     - name: prometheus
       containerPort: 2112
@@ -35,3 +37,25 @@ spec:
         port: 2112
       initialDelaySeconds: 5
       periodSeconds: 1
+  securityContext:
+    sysctls:
+    # Extend the range of local ports, to avoid hitting this limit first.
+    - name: net.ipv4.ip_local_port_range
+      value: "15000 64999"
+  {{ if eq .AffinityType "affinity" }}
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: {{ .AffinityInstance }}
+        topologyKey: kubernetes.io/hostname
+  {{ else if eq .AffinityType "antiAffinity" }}
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: {{ .AffinityInstance }}
+        topologyKey: kubernetes.io/hostname
+  {{ end }}

--- a/.github/actions/cl2-modules/egw/manifests/external-target-pod.yaml
+++ b/.github/actions/cl2-modules/egw/manifests/external-target-pod.yaml
@@ -1,3 +1,6 @@
+{{$Port := AddInt 1337 .Index}}
+{{$KeepOpen := ge .Index 1}}
+
 apiVersion: v1
 kind: Pod
 metadata:
@@ -20,8 +23,9 @@ spec:
     image: {{.Image}}
     imagePullPolicy: IfNotPresent
     ports:
-    - containerPort: 1337
+    - containerPort: {{$Port}}
     args:
       - "external-target"
       - "--allowed-cidr={{.AllowedCIDR}}"
-      - "--listen-port=1337"
+      - "--listen-port={{$Port}}"
+      - "--keep-open={{$KeepOpen}}"

--- a/.github/actions/cl2-modules/egw/modules/masq-metrics.yaml
+++ b/.github/actions/cl2-modules/egw/modules/masq-metrics.yaml
@@ -1,53 +1,83 @@
 steps:
 - name: "{{ .action }} masquerade delay metrics"
   measurements:
-  - Identifier: EGWMasqueradeDelayMetrics{{ .metricsSuffix }}
+  - Identifier: MasqueradeDelay{{ .metricsSuffix }}
     Method: GenericPrometheusQuery
     Params:
       action: {{ .action }}
-      metricName: "EGW Masquerade Delay Metrics ({{ .metricsSuffix }})"
+      metricName: Masquerade Delay {{ .metricsSuffix }}
       metricVersion: v1
       unit: s
       enableViolations: true
       queries:
-      - name: EGW Masquerade Delay - 50th Percentile
+      - name: P50
         query: quantile(0.5, egw_scale_test_masquerade_delay_seconds_total{k8s_instance="{{ .instance }}"})
         threshold: 1
-      - name: EGW Masquerade Delay - 90th Percentile
+      - name: P90
         query: quantile(0.9, egw_scale_test_masquerade_delay_seconds_total{k8s_instance="{{ .instance }}"})
         threshold: 1
-      - name: EGW Masquerade Delay - 95th Percentile
+      - name: P95
         query: quantile(0.95, egw_scale_test_masquerade_delay_seconds_total{k8s_instance="{{ .instance }}"})
         threshold: 2
-      - name: EGW Masquerade Delay - 99th Percentile
+      - name: P99
         query: quantile(0.99, egw_scale_test_masquerade_delay_seconds_total{k8s_instance="{{ .instance }}"})
         threshold: 2
 
-  - Identifier: EGWLeakedPingsTotal{{ .metricsSuffix }}
+  - Identifier: MasqueradeDelayLeakedPingsTotal{{ .metricsSuffix }}
     Method: GenericPrometheusQuery
     Params:
       action: {{ .action }}
-      metricName: "EGW Leaked Pings Total ({{ .metricsSuffix }})"
+      metricName: Masquerade Delay {{ .metricsSuffix }} - Leaked Pings Total
       metricVersion: v1
       unit: count
       enableViolations: true
       queries:
-      - name: EGW Leaked Pings - Total
+      - name: Total
         query: sum(egw_scale_test_leaked_requests_total{k8s_instance="{{ .instance }}"})
 
-  - Identifier: EGWPodCountMetrics{{ .metricsSuffix }}
+  - Identifier: MasqueradeDelayPodCount{{ .metricsSuffix }}
     Method: GenericPrometheusQuery
     Params:
       action: {{ .action }}
-      metricName: "EGW Pod Count Metrics ({{ .metricsSuffix }})"
+      metricName: Masquerade Delay {{ .metricsSuffix }} - Pod Count
       metricVersion: v1
       unit: pod
       enableViolations: true
       queries:
-      - name: EGW Total Number of Client Pods
+      - name: Total
         query: count(egw_scale_test_failed_tests_total{k8s_instance="{{ .instance }}"})
         threshold: {{ .replicas }}
         lowerBound: true
-      - name: EGW Total Number of Failed Client Pods
+      - name: Failed
         query: sum(egw_scale_test_failed_tests_total{k8s_instance="{{ .instance }}"})
         threshold: 0
+
+  - Identifier: MasqueradeDelayCiliumCPUUsage{{ .metricsSuffix }}
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{ .action }}
+      metricName: Masquerade Delay {{ .metricsSuffix }} - Cilium CPU Usage
+      metricVersion: v1
+      unit: cpu
+      enableViolations: true
+      queries:
+      - name: P50
+        query: quantile(0.50, avg_over_time(rate(cilium_process_cpu_seconds_total[1m])[%v:10s]))
+      - name: Max
+        query: max(avg_over_time(rate(cilium_process_cpu_seconds_total[1m])[%v:10s]))
+        threshold: 0.15
+
+  - Identifier: MasqueradeDelayCiliumMemUsage{{ .metricsSuffix }}
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{ .action }}
+      metricName: Masquerade Delay {{ .metricsSuffix }} - Cilium Memory Usage
+      metricVersion: v1
+      unit: MB
+      enableViolations: true
+      queries:
+      - name: P50
+        query: quantile(0.5, max_over_time(cilium_process_resident_memory_bytes[%v]) / 1024 / 1024)
+      - name: Max
+        query: max(max_over_time(cilium_process_resident_memory_bytes[%v]) / 1024 / 1024)
+        threshold: 260

--- a/.github/actions/cl2-modules/egw/modules/masq-metrics.yaml
+++ b/.github/actions/cl2-modules/egw/modules/masq-metrics.yaml
@@ -8,6 +8,7 @@ steps:
       metricName: "EGW Masquerade Delay Metrics ({{ .metricsSuffix }})"
       metricVersion: v1
       unit: s
+      enableViolations: true
       queries:
       - name: EGW Masquerade Delay - 50th Percentile
         query: quantile(0.5, egw_scale_test_masquerade_delay_seconds_total{k8s_instance="{{ .instance }}"})
@@ -29,6 +30,7 @@ steps:
       metricName: "EGW Leaked Pings Total ({{ .metricsSuffix }})"
       metricVersion: v1
       unit: count
+      enableViolations: true
       queries:
       - name: EGW Leaked Pings - Total
         query: sum(egw_scale_test_leaked_requests_total{k8s_instance="{{ .instance }}"})
@@ -40,6 +42,7 @@ steps:
       metricName: "EGW Pod Count Metrics ({{ .metricsSuffix }})"
       metricVersion: v1
       unit: pod
+      enableViolations: true
       queries:
       - name: EGW Total Number of Client Pods
         query: count(egw_scale_test_failed_tests_total{k8s_instance="{{ .instance }}"})

--- a/.github/actions/cl2-modules/egw/modules/masq-metrics.yaml
+++ b/.github/actions/cl2-modules/egw/modules/masq-metrics.yaml
@@ -46,6 +46,8 @@ steps:
       queries:
       - name: EGW Total Number of Client Pods
         query: count(egw_scale_test_failed_tests_total{k8s_instance="{{ .instance }}"})
+        threshold: {{ .replicas }}
+        lowerBound: true
       - name: EGW Total Number of Failed Client Pods
         query: sum(egw_scale_test_failed_tests_total{k8s_instance="{{ .instance }}"})
         threshold: 0

--- a/.github/actions/cl2-modules/egw/modules/masq-test.yaml
+++ b/.github/actions/cl2-modules/egw/modules/masq-test.yaml
@@ -34,7 +34,7 @@ steps:
 
 - name: Sleep to allow scraping
   measurements:
-  - Identifier: SleepTwiceScrapeInterval
+  - Identifier: Sleep
     Method: Sleep
     Params:
       duration: 30s

--- a/.github/actions/cl2-modules/egw/modules/masq-test.yaml
+++ b/.github/actions/cl2-modules/egw/modules/masq-test.yaml
@@ -4,6 +4,7 @@ steps:
     params:
       action: start
       instance: {{ .instance }}
+      replicas: {{ .replicas }}
       metricsSuffix: {{ .metricsSuffix }}
 
 - name: Create EGW client Pods
@@ -43,4 +44,5 @@ steps:
     params:
       action: gather
       instance: {{ .instance }}
+      replicas: {{ .replicas }}
       metricsSuffix: {{ .metricsSuffix }}

--- a/.github/actions/cl2-modules/egw/modules/masq-test.yaml
+++ b/.github/actions/cl2-modules/egw/modules/masq-test.yaml
@@ -21,7 +21,9 @@ steps:
         Image: {{ .image }}
         Instance: {{ .instance }}
         ExternalTarget: {{ .externalTarget }}
+        ExternalTargetPort: 1337
         ClientConnectTimeout: "295s"
+        Stress: false
 
 - name: Wait for EGW Client pods to be running
   measurements:

--- a/.github/actions/cl2-modules/egw/modules/perf-metrics.yaml
+++ b/.github/actions/cl2-modules/egw/modules/perf-metrics.yaml
@@ -8,6 +8,7 @@ steps:
       metricName: "Node CPU Usage"
       metricVersion: v1
       unit: cpu
+      enableViolations: true
       queries:
       - name: Total (Max)
         query: max(avg_over_time(rate(container_cpu_usage_seconds_total{id="/"}[1m])[%v:10s]))

--- a/.github/actions/cl2-modules/egw/modules/perf-metrics.yaml
+++ b/.github/actions/cl2-modules/egw/modules/perf-metrics.yaml
@@ -1,11 +1,11 @@
 steps:
 - name: "{{ .action }} node metrics"
   measurements:
-  - Identifier: NodeCPUUsage
+  - Identifier: PerfNodeCPUUsage
     Method: GenericPrometheusQuery
     Params:
       action: {{ .action }}
-      metricName: "Node CPU Usage"
+      metricName: Perf Node CPU Usage
       metricVersion: v1
       unit: cpu
       enableViolations: true

--- a/.github/actions/cl2-modules/egw/modules/stress-metrics.yaml
+++ b/.github/actions/cl2-modules/egw/modules/stress-metrics.yaml
@@ -1,0 +1,73 @@
+{{$action := .action}}
+{{$tests := .tests}}
+
+steps:
+- name: "{{ $action }} stress metrics"
+  measurements:
+  - Identifier: StressConnections
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{ $action }}
+      metricName: Stress Connections
+      metricVersion: v1
+      unit: count
+      enableViolations: true
+      queries:
+      {{range $test := StringSplit $tests}}
+      - name: Opened (client={{ $test }})
+        query: egw_scale_test_stress_connections_total{k8s_instance="{{ $.instance }}-{{ $test }}", operation="open"}
+      - name: Closed (client={{ $test }})
+        query: egw_scale_test_stress_connections_total{k8s_instance="{{ $.instance }}-{{ $test }}", operation="close"}
+        # Ideally, no connection should have been dropped. However, that does not
+        # seem to be the case at the moment, so let's not configure a threshold
+        # until we better understand what is going on here.
+        # threshold: 0
+      {{end}}
+
+  - Identifier: StressConnectionsLatency
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{ $action }}
+      metricName: Stress Connections Latency
+      metricVersion: v1
+      unit: s
+      enableViolations: true
+      queries:
+      {{range $test := StringSplit $tests}}
+      - name: Latency (client={{ $test }}) - P50
+        query: histogram_quantile(0.5, sum(egw_scale_test_stress_connection_latency_seconds_bucket{k8s_instance="{{ $.instance }}-{{ $test }}"}) by (le))
+      - name: Latency (client={{ $test }}) - P90
+        query: histogram_quantile(0.9, sum(egw_scale_test_stress_connection_latency_seconds_bucket{k8s_instance="{{ $.instance }}-{{ $test }}"}) by (le))
+      - name: Latency (client={{ $test }}) - P99
+        query: histogram_quantile(0.99, sum(egw_scale_test_stress_connection_latency_seconds_bucket{k8s_instance="{{ $.instance }}-{{ $test }}"}) by (le))
+      {{end}}
+
+  - Identifier: StressConnectionsCPUUsage
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{ $action }}
+      metricName: Stress Connections CPU Usage
+      metricVersion: v1
+      unit: cpu
+      enableViolations: true
+      queries:
+      - name: Cilium (Max)
+        query: max(avg_over_time(rate(cilium_process_cpu_seconds_total[1m])[%v:10s]))
+      - name: Node Total (Max)
+        query: max(avg_over_time(rate(container_cpu_usage_seconds_total{id="/"}[1m])[%v:10s]))
+      - name: Node User (Max)
+        query: max(avg_over_time(rate(container_cpu_user_seconds_total{id="/"}[1m])[%v:10s]))
+      - name: Node System (Max)
+        query: max(avg_over_time(rate(container_cpu_system_seconds_total{id="/"}[1m])[%v:10s]))
+
+  - Identifier: StressConnectionsNATMaxConnections
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{ $action }}
+      metricName: Stress Connections Source Port Saturation
+      metricVersion: v1
+      unit: "%"
+      enableViolations: true
+      queries:
+      - name: Max
+        query: max(cilium_nat_endpoint_max_connection) * 100

--- a/.github/actions/cl2-modules/egw/modules/stress-test.yaml
+++ b/.github/actions/cl2-modules/egw/modules/stress-test.yaml
@@ -1,0 +1,64 @@
+{{$instance := .instance}}
+{{$image := .image}}
+{{$externalTarget := .externalTarget}}
+
+# One repetition towards the given IP/port combination
+# Another repetition towards the same IP/port combination (same node)
+# Another repetition towards the same IP/port combination (different node)
+# Another repetition towards the same IP, but different port (same node)
+{{$tests := "base,same-port-node,diff-node,diff-port" }}
+
+steps:
+- module:
+    path: modules/stress-metrics.yaml
+    params:
+      action: start
+      instance: {{ $instance }}
+      tests: {{ $tests }}
+
+# Repeat the test multiple times sequentially, to identify which factors influence
+# the limit in the maximum number of parallel connections.
+{{range $test := StringSplit $tests}}
+- name: Create EGW client pod (stress-test-{{ $test }})
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: 1
+    tuningSet: UniformParamqps
+    objectBundle:
+    - basename: egw-client-pod-{{ $instance }}-{{ $test }}
+      objectTemplatePath: manifests/client-pod.yaml
+      templateFillMap:
+        Image: {{ $image }}
+        Instance: {{ $instance }}-{{ $test }}
+        ExternalTarget: {{ $externalTarget }}
+        ExternalTargetPort: {{ IfThenElse (ne $test "diff-port") 1338 1339 }}
+        ClientConnectTimeout: "30s"
+        Stress: true
+        AffinityType: {{ IfThenElse (eq $test "base") "none" ( IfThenElse (eq $test "diff-node") "antiAffinity" "affinity" ) }}
+        AffinityInstance: {{ $instance }}-base
+
+- name: Wait for EGW Client pods to be running (stress-test-{{ $test }})
+  measurements:
+  - Identifier: WaitForRunningPods
+    Method: WaitForRunningPods
+    Params:
+      labelSelector: app.kubernetes.io/name=egw-client,app.kubernetes.io/instance={{ $instance }}-{{ $test }}
+      desiredPodCount: 1
+      timeout: 900s
+{{end}}
+
+- name: Sleep to allow scraping
+  measurements:
+  - Identifier: Sleep
+    Method: Sleep
+    Params:
+      duration: 30s
+
+- module:
+    path: modules/stress-metrics.yaml
+    params:
+      action: gather
+      instance: {{ $instance }}
+      tests: {{ $tests }}

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -251,6 +251,17 @@ jobs:
           EKS_VERSION=$(echo $eks_version_and_region | cut -d',' -f1)
           EKS_REGION=$(echo $eks_version_and_region | cut -d',' -f2)
 
+          # Currently, ClusterLoader2 does not play well with EKS 1.32, because
+          # anonymous authentication to the API Server metrics endpoint is no
+          # longer possible [1]. Let's ensure we use a supported version until
+          # the issue gets addressed upstream [2].
+          #
+          # [1]: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions-standard.html#kubernetes-1-32
+          # [2]: https://github.com/kubernetes/perf-tests/pull/3214
+          if [[ "$EKS_VERSION" == "1.32" ]]; then
+            EKS_VERSION=1.31
+          fi
+
           echo sha=${SHA} >> $GITHUB_OUTPUT
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo owner=${OWNER} >> $GITHUB_OUTPUT

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -172,6 +172,7 @@ jobs:
             --set=k8sClientRateLimit.qps=100 \
             --set=extraConfig.cilium-endpoint-gc-interval=24h \
             --set-string=extraConfig.enable-stale-cilium-endpoint-cleanup=false \
+            --set=prometheus.metrics="{+cilium_datapath_nat_gc_entries}" \
             --set=image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci:${SHA} \
             --set=operator.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator-aws-ci:${SHA} \
             --values=values-dummy-health-server.yaml \

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -391,10 +391,24 @@ jobs:
           K8S_API_SRV_ADDR=$(kubectl config view -o jsonpath='{.clusters[0].cluster.server}' | sed 's|https://||')
           echo "Retrieved Kubernetes API Server address: '${K8S_API_SRV_ADDR}'"
 
+          # Retrieve the CIDR associated with the availability zone where the cluster
+          # is deployed, and configure it as native routing CIDR. Otherwise, Cilium
+          # would default to the VPC CIDR, but we want to masquerade traffic towards
+          # the external destination (which is located in the same VPC, but different
+          # availability zone), to reflect the most common type of real deployments.
+          NATIVE_CIDR_BLOCK=$(aws ec2 describe-subnets --region ${{ steps.vars.outputs.eks_region }} \
+            --filters Name=availability-zone,Values=${{ steps.vars.outputs.eks_zone_1 }} \
+                Name=tag:alpha.eksctl.io/cluster-name,Values=${{ steps.vars.outputs.cluster_name }} \
+                Name=map-public-ip-on-launch,Values=false \
+            --query 'Subnets[*].CidrBlock' --output text)
+          echo "Retrieved native routing CIDR: '${NATIVE_CIDR_BLOCK}'"
+
           cilium install --dry-run-helm-values ${{ steps.vars.outputs.cilium_install_defaults }} \
-            --set=k8sServiceHost="${K8S_API_SRV_ADDR}" --set=k8sServicePort=443
+            --set=k8sServiceHost="${K8S_API_SRV_ADDR}" --set=k8sServicePort=443 \
+            --set=ipv4NativeRoutingCIDR="${NATIVE_CIDR_BLOCK}"
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \
-            --set=k8sServiceHost="${K8S_API_SRV_ADDR}" --set=k8sServicePort=443
+            --set=k8sServiceHost="${K8S_API_SRV_ADDR}" --set=k8sServicePort=443 \
+            --set=ipv4NativeRoutingCIDR="${NATIVE_CIDR_BLOCK}"
 
       - name: Delete context ref
         run: |

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -77,7 +77,7 @@ env:
   # Hosted under quay.io/cilium/egw-scale-utils and built by
   # a workflow in cilium/scaffolding.
   # renovate: datasource=git-refs depName=https://github.com/cilium/scaffolding branch=main
-  egw_utils_ref: 2857ed459734365bfd3ee94815fd74e986a79e12
+  egw_utils_ref: affdf829a14afbfd4f4a524726bb2fca2ecbf08a
   test_name: egw
   cluster_name: ${{ github.run_id }}-${{ github.run_attempt }}
 

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -586,6 +586,14 @@ jobs:
           artifacts: ./perf-tests/clusterloader2/report/*
           other_files: cilium-sysdump-final.zip ./perf-tests/clusterloader2/cl2-output.txt
 
+      # Refresh credentials
+      - name: Set up AWS CLI credentials
+        if:  ${{ always() && steps.deploy-cluster.outcome != 'skipped' }}
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: ${{ secrets.AWS_PR_ASSUME_ROLE }}
+          aws-region: ${{ steps.vars.outputs.eks_region }}
+
       - name: Cleanup cluster
         if: ${{ always() && steps.deploy-cluster.outcome != 'skipped' }}
         run: |


### PR DESCRIPTION
Add a step at the end of the egress gateway scale test to assess the maximum number of parallel connections that can be opened via the egress gateway. The test leverages an extended version of the egw-scale-utils tools, with the server configured to keep connections open, and the client opening new connections until repeated failures are encountered.

The test is repeated four times, assessing the following combinations:

1. base: client hosted on node N1, towards target at port P1.
2. same-port-node: client hosted on node N1, towards target at port P1; it evaluates whether a client hosted on the same node, and targeting the same destination is affected by the other open connections.
3. diff-node: client hosted on node N2, towards target at port P1; it evaluates whether a client hosted on a different node, and targeting the same destination is affected by the other open connections.
4. diff-port: client hosted on node N1, towards target at port P2; it evaluates whether a client hosted on the same node, but targeting a different destination is affected by the other open connections.

Please review commit by commit, and refer to the individual commit descriptions for additional details.