### PR TITLE
aws/ec2: properly paginate `DescribeNetworkInterfaces` results

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -20,6 +20,7 @@ import (
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/aws/types"
 	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/defaults"
 	ipPkg "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipam/option"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
@@ -242,6 +243,7 @@ func (c *Client) describeNetworkInterfaces(ctx context.Context, subnets ipamType
 				Values: []string{"*"},
 			},
 		},
+		MaxResults: aws.Int32(defaults.ENIMaxResultsPerApiCall),
 	}
 	if len(c.subnetsFilters) > 0 {
 		subnetsIDs := make([]string, 0, len(subnets))
@@ -278,6 +280,7 @@ func (c *Client) describeNetworkInterfacesByInstance(ctx context.Context, instan
 				Values: []string{instanceID},
 			},
 		},
+		MaxResults: aws.Int32(defaults.ENIMaxResultsPerApiCall),
 	}
 	paginator := ec2.NewDescribeNetworkInterfacesPaginator(c.ec2Client, input)
 	for paginator.HasMorePages() {
@@ -336,6 +339,7 @@ func (c *Client) describeNetworkInterfacesFromInstances(ctx context.Context) ([]
 				Values: []string{"*"},
 			},
 		},
+		MaxResults: aws.Int32(defaults.ENIMaxResultsPerApiCall),
 	}
 	if len(enisListFromInstances) > 0 {
 		ENIAttrs.NetworkInterfaceIds = enisListFromInstances

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -414,6 +414,9 @@ const (
 	// per GC interval
 	ENIGarbageCollectionMaxPerInterval = 25
 
+	// ENIMaxResultsPerApiCall is the maximum number of ENI objects to fetch per DescribeNetworkInterfaces API call
+	ENIMaxResultsPerApiCall = 1000
+
 	// ParallelAllocWorkers is the default max number of parallel workers doing allocation in the operator
 	ParallelAllocWorkers = 50
 


### PR DESCRIPTION
# Description
Follow-up to https://github.com/cilium/cilium/pull/14491

We noticed that `DescribeNetworkInterfaces` API calls are not properly paginated. The code uses `ec2.NewDescribeNetworkInterfacesPaginator` but:
- it doesn't specify `MaxResults` in `DescribeNetworkInterfacesInput`,
- nor does it specify any `Limit` in the Paginator options:
  ```go
  paginator := ec2.NewDescribeNetworkInterfacesPaginator(c.ec2Client, input, func(o *ec2.DescribeNetworkInterfacesPaginatorOptions) {
		  o.Limit = 1000
  })
  ```

This causes pages to have unlimited size because `MaxResults` ends up not being set: https://github.com/aws/aws-sdk-go-v2/blob/2d43b815f645eae163e7521c9789554dfe60e40c/service/ec2/api_op_DescribeNetworkInterfaces.go#L548-L552

This PR fixes the issue by adding `MaxResults` to the API calls in order to actually force pagination.

# Testing
## Before the PR
### Test 1
I did some testing in an AWS account which has ~19000 ENIs. I deployed the Operator without `--subnet-tags-filter` and added logging to the [`describeNetworkInterfaces()`](https://github.com/cilium/cilium/blob/d1e7f3a7641116b6813ff2b838d802901265edcf/pkg/aws/ec2/ec2.go#L217) function. The log showed that there was only 1 page with ~19000 results. 

API call duration went through the roof (>10 seconds):
<img width="1451" alt="image" src="https://github.com/user-attachments/assets/ff995079-9cb9-41ef-9294-447973eb285b" />
(comparison before vs after I removed `--subnet-tags-filter`)

The memory also more than doubled:
<img width="1463" alt="image" src="https://github.com/user-attachments/assets/e31cacec-39aa-412d-9ce6-6157cf563d4d" />

### Test 2
We also tried deploying the Operator without `--subnet-tags-filter` in a larger account and got the following error from the AWS API:
```json
{
  "error": "operation error EC2: DescribeNetworkInterfaces, https response error StatusCode: 400, RequestID: da1b1af3-4c8d-4f1d-86eb-e1acbe2c2925, api error OperationNotPermitted: This operation is not permitted.",
  "level": "warning",
  "msg": "Unable to synchronize EC2 interface list",
  "subsys": "eni",
  "time": "2025-02-19T17:48:07.983328963Z"
}
```
According to [AWS docs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNetworkInterfaces.html):
> If you have a large number of network interfaces, the operation fails unless you use pagination or one of the following filters: group-id, mac-address, private-dns-name, private-ip-address, subnet-id, or vpc-id.

Which is exactly what's happening here: the filters are not specified and pagination is disabled, so we get a 400 error from the API.


## After the PR
I confirmed with logging, that the calls are now properly paginated:
<img width="555" alt="image" src="https://github.com/user-attachments/assets/44584cf6-ae63-4af3-9e0d-317b2f5e1abe" />

Moreover, the duration of API calls dropped:
<img width="2508" alt="image" src="https://github.com/user-attachments/assets/40903ba7-34fe-47ca-93fd-72abcbc5c608" />


However, the memory usage stayed the same unfortunately:
<img width="1454" alt="image" src="https://github.com/user-attachments/assets/29f4665a-454e-449e-bb29-09bce056dbc9" />
 
This is due to the fact that all results are still all added to the same big slice: https://github.com/cilium/cilium/blob/d1e7f3a7641116b6813ff2b838d802901265edcf/pkg/aws/ec2/ec2.go#L248

However, the pagination is still beneficial, because we do not risk running into 400 errors from the API or be "[susceptible to throttling and timeouts](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNetworkInterfaces.html)" 

# Notes
- This issue also affects other API calls such as `DescribeInstanceTypes`, `DescribeVpcs`, `DescribeSubnets`, and `DescribeSecurityGroups`, which aren’t paginated properly either. However, the impact is most noticeable for ENIs, since they’re far more numerous and the fix will have the biggest effect there. We can address the other API calls in a separate PR.
- I hard-coded the page size to 1000 elements. We can also make it configurable but I am not sure it's worth it?
- This change is not very interesting for [`describeNetworkInterfacesByInstance()`](https://github.com/cilium/cilium/blob/d1e7f3a7641116b6813ff2b838d802901265edcf/pkg/aws/ec2/ec2.go#L254) because the number of returned of results should be very small anyway. I added the change there for the sake of consistency.
- I also noticed that the logic in [`GetDetachedNetworkInterfaces()`](https://github.com/cilium/cilium/blob/d1e7f3a7641116b6813ff2b838d802901265edcf/pkg/aws/ec2/ec2.go#L185C18-L185C46) is a bit strange: it actually uses pagination but the number of returned ENIs can exceed `maxResults` passed in the parameters. Mainly, this can happen [here](https://github.com/cilium/cilium/blob/d1e7f3a7641116b6813ff2b838d802901265edcf/pkg/aws/ec2/ec2.go#L206-L211) if the first page returns `x` results where `x < maxResults` and then the second page returns for example exactly `maxResults`, so the length of `result` will be `maxResults + x > maxResults`. The `break` should happen inside the loop on `output.NetworkInterfaces`. I think the fix for this problem is out of scope for this PR though.


```release-note
ipam/aws: properly paginate Operator `DescribeNetworkInterfaces` AWS API calls in ENI IPAM mode in order to avoid throttling, timeouts and errors from the API
```
