### PR TITLE
fqdn/dnsproxy: use `netip.Addr` for `DNSProxy.usedServers`

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -128,7 +128,7 @@ type DNSProxy struct {
 
 	// usedServers is the set of DNS servers that have been allowed and used successfully.
 	// This is used to limit the number of IPs we store for restored DNS rules.
-	usedServers map[string]struct{}
+	usedServers map[netip.Addr]struct{}
 
 	// allowed tracks all allowed L7 DNS rules by endpointID, destination port,
 	// and L3 Selector. All must match for a query to be allowed.
@@ -261,7 +261,7 @@ func (p *DNSProxy) checkRestored(endpointID uint64, destPortProto restore.PortPr
 // skipIPInRestorationRLocked skips IPs that are allowed but have never been used,
 // but only if at least one server has been used so far.
 // Requires the RLock to be held.
-func (p *DNSProxy) skipIPInRestorationRLocked(ip string) bool {
+func (p *DNSProxy) skipIPInRestorationRLocked(ip netip.Addr) bool {
 	if len(p.usedServers) > 0 {
 		if _, used := p.usedServers[ip]; !used {
 			return true
@@ -327,7 +327,7 @@ func (p *DNSProxy) GetRules(version *versioned.VersionHandle, endpointID uint16)
 						}).Warning("Could not parse IP for a DNS rule (?!), skipping")
 						continue
 					}
-					if rip.IsAddr() && p.skipIPInRestorationRLocked(ip) {
+					if rip.IsAddr() && p.skipIPInRestorationRLocked(rip.Addr()) {
 						continue
 					}
 					ips[rip] = struct{}{}
@@ -708,7 +708,7 @@ func StartDNSProxy(
 		NotifyOnDNSMsg:           notifyFunc,
 		logLimiter:               logging.NewLimiter(10*time.Second, 1),
 		lookupTargetDNSServer:    lookupTargetDNSServer,
-		usedServers:              make(map[string]struct{}),
+		usedServers:              make(map[netip.Addr]struct{}),
 		allowed:                  make(perEPAllow),
 		currentRules:             make(perEPPolicy),
 		restored:                 make(perEPRestored),
@@ -1188,7 +1188,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		p.Lock()
 		// Add the server to the set of used DNS servers. This set is never GCd, but is limited by set
 		// of DNS server IPs that are allowed by a policy and for which successful response was received.
-		p.usedServers[targetServer.Addr().String()] = struct{}{}
+		p.usedServers[targetServer.Addr()] = struct{}{}
 		p.Unlock()
 	}
 }

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -806,7 +806,7 @@ func TestFullPathDependence(t *testing.T) {
 
 	// Test with limited set of allowed IPs
 	oldUsed := s.proxy.usedServers
-	s.proxy.usedServers = map[string]struct{}{"127.0.0.2": {}}
+	s.proxy.usedServers = map[netip.Addr]struct{}{netip.MustParseAddr("127.0.0.2"): {}}
 
 	expected1b := restore.DNSRules{
 		udpProtoPort53: restore.IPRules{

--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -99,6 +99,14 @@ func (ip RuleIPOrCIDR) IsAddr() bool {
 	return netip.Prefix(ip).Bits() == -1
 }
 
+func (ip RuleIPOrCIDR) Addr() netip.Addr {
+	if ip.IsAddr() {
+		return netip.Prefix(ip).Addr()
+	} else {
+		return netip.Addr{}
+	}
+}
+
 func (ip RuleIPOrCIDR) String() string {
 	if ip.IsAddr() {
 		return netip.Prefix(ip).Addr().String()


### PR DESCRIPTION
This avoids a `netip.Addr.String` call in the hot path of `(*DNSProxy).ServeDNS`.

For #24246