### PR TITLE
Add an option to disable L3/L4 network policy correlation of flows

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -242,6 +242,7 @@ cilium-agent [flags]
       --hubble-metrics-server-tls-client-ca-files strings         Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
       --hubble-metrics-server-tls-key-file string                 Path to the private key file for the Hubble metrics server. The file must contain PEM encoded data.
       --hubble-monitor-events strings                             Cilium monitor events for Hubble to observe: [drop debug capture trace policy-verdict recorder trace-sock l7 agent]. By default, Hubble observes all monitor events.
+      --hubble-network-policy-correlation-enabled                 Enable network policy correlation of Hubble flows (default true)
       --hubble-prefer-ipv6                                        Prefer IPv6 addresses for announcing nodes when both address types are available.
       --hubble-recorder-sink-queue-size int                       Queue size of each Hubble recorder sink (default 1024)
       --hubble-recorder-storage-path string                       Directory in which pcap files created via the Hubble Recorder API are stored (default "/var/run/cilium/pcaps")

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -109,6 +109,7 @@ cilium-agent hive [flags]
       --hubble-metrics-server-tls-client-ca-files strings         Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
       --hubble-metrics-server-tls-key-file string                 Path to the private key file for the Hubble metrics server. The file must contain PEM encoded data.
       --hubble-monitor-events strings                             Cilium monitor events for Hubble to observe: [drop debug capture trace policy-verdict recorder trace-sock l7 agent]. By default, Hubble observes all monitor events.
+      --hubble-network-policy-correlation-enabled                 Enable network policy correlation of Hubble flows (default true)
       --hubble-prefer-ipv6                                        Prefer IPv6 addresses for announcing nodes when both address types are available.
       --hubble-recorder-sink-queue-size int                       Queue size of each Hubble recorder sink (default 1024)
       --hubble-recorder-storage-path string                       Directory in which pcap files created via the Hubble Recorder API are stored (default "/var/run/cilium/pcaps")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -114,6 +114,7 @@ cilium-agent hive dot-graph [flags]
       --hubble-metrics-server-tls-client-ca-files strings         Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
       --hubble-metrics-server-tls-key-file string                 Path to the private key file for the Hubble metrics server. The file must contain PEM encoded data.
       --hubble-monitor-events strings                             Cilium monitor events for Hubble to observe: [drop debug capture trace policy-verdict recorder trace-sock l7 agent]. By default, Hubble observes all monitor events.
+      --hubble-network-policy-correlation-enabled                 Enable network policy correlation of Hubble flows (default true)
       --hubble-prefer-ipv6                                        Prefer IPv6 addresses for announcing nodes when both address types are available.
       --hubble-recorder-sink-queue-size int                       Queue size of each Hubble recorder sink (default 1024)
       --hubble-recorder-storage-path string                       Directory in which pcap files created via the Hubble Recorder API are stored (default "/var/run/cilium/pcaps")

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1832,6 +1832,10 @@
      - Name of the ConfigMap containing the CA to validate client certificates against. If mTLS is enabled and this is unspecified, it will default to the same CA used for Hubble metrics server certificates.
      - string
      - ``nil``
+   * - :spelling:ignore:`hubble.networkPolicyCorrelation`
+     - Enables network policy correlation of Hubble flows, i.e. populating ``egress_allowed_by``\ , ``ingress_denied_by`` fields with policy information.
+     - object
+     - ``{"enabled":true}``
    * - :spelling:ignore:`hubble.peerService.clusterDomain`
      - The cluster domain to use to query the Hubble Peer service. It should be the local cluster.
      - string

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -508,6 +508,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.metrics.tls.server.mtls | object | `{"enabled":false,"key":"ca.crt","name":null,"useSecret":false}` | Configure mTLS for the Hubble metrics server. |
 | hubble.metrics.tls.server.mtls.key | string | `"ca.crt"` | Entry of the ConfigMap containing the CA. |
 | hubble.metrics.tls.server.mtls.name | string | `nil` | Name of the ConfigMap containing the CA to validate client certificates against. If mTLS is enabled and this is unspecified, it will default to the same CA used for Hubble metrics server certificates. |
+| hubble.networkPolicyCorrelation | object | `{"enabled":true}` | Enables network policy correlation of Hubble flows, i.e. populating `egress_allowed_by`, `ingress_denied_by` fields with policy information. |
 | hubble.peerService.clusterDomain | string | `"cluster.local"` | The cluster domain to use to query the Hubble Peer service. It should be the local cluster. |
 | hubble.peerService.targetPort | int | `4244` | Target Port for the Peer service, must match the hubble.listenAddress' port. |
 | hubble.preferIpv6 | bool | `false` | Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -981,6 +981,9 @@ data:
   enable-hubble-open-metrics: {{ .Values.hubble.metrics.enableOpenMetrics | quote }}
 {{- end }}
 
+{{- if hasKey .Values.hubble.networkPolicyCorrelation "enabled" }}
+  hubble-network-policy-correlation-enabled: {{ .Values.hubble.networkPolicyCorrelation.enabled | quote }}
+{{- end }}
 {{- if .Values.hubble.redact }}
 {{- if eq .Values.hubble.redact.enabled true }}
   # Enables hubble redact capabilities

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2871,6 +2871,14 @@
           },
           "type": "object"
         },
+        "networkPolicyCorrelation": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
         "peerService": {
           "properties": {
             "clusterDomain": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1331,6 +1331,10 @@ hubble:
             excludeFilters: []
   # -- Unix domain socket path to listen to when Hubble is enabled.
   socketPath: /var/run/cilium/hubble.sock
+  # -- Enables network policy correlation of Hubble flows, i.e. populating `egress_allowed_by`, `ingress_denied_by` fields with policy information.
+  networkPolicyCorrelation:
+    # @default -- `true`
+    enabled: true
   # -- Enables redacting sensitive information present in Layer 7 flows.
   redact:
     enabled: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1343,6 +1343,10 @@ hubble:
             excludeFilters: []
   # -- Unix domain socket path to listen to when Hubble is enabled.
   socketPath: /var/run/cilium/hubble.sock
+  # -- Enables network policy correlation of Hubble flows, i.e. populating `egress_allowed_by`, `ingress_denied_by` fields with policy information.
+  networkPolicyCorrelation:
+    # @default -- `true`
+    enabled: true  
   # -- Enables redacting sensitive information present in Layer 7 flows.
   redact:
     enabled: false

--- a/pkg/hubble/cell/config.go
+++ b/pkg/hubble/cell/config.go
@@ -113,6 +113,8 @@ type config struct {
 	K8sDropEventsInterval time.Duration `mapstructure:"hubble-drop-events-interval"`
 	// K8sDropEventsReasons controls which drop reasons to emit events for.
 	K8sDropEventsReasons []string `mapstructure:"hubble-drop-events-reasons"`
+	// EnableNetworkPolicyCorrelation controls whether to enable network policy correlation of Hubble flows
+	EnableNetworkPolicyCorrelation bool `mapstructure:"hubble-network-policy-correlation-enabled"`
 }
 
 var defaultConfig = config{
@@ -154,9 +156,10 @@ var defaultConfig = config{
 	RedactHttpHeadersDeny:  []string{},
 	RedactKafkaAPIKey:      false,
 	// Hubble k8s v1.Events integration configuration.
-	EnableK8sDropEvents:   false,
-	K8sDropEventsInterval: 2 * time.Minute,
-	K8sDropEventsReasons:  []string{"auth_required", "policy_denied"},
+	EnableK8sDropEvents:            false,
+	K8sDropEventsInterval:          2 * time.Minute,
+	K8sDropEventsReasons:           []string{"auth_required", "policy_denied"},
+	EnableNetworkPolicyCorrelation: true,
 }
 
 func (def config) Flags(flags *pflag.FlagSet) {
@@ -205,6 +208,7 @@ func (def config) Flags(flags *pflag.FlagSet) {
 	flags.Bool("hubble-drop-events", def.EnableK8sDropEvents, "Emit packet drop Events related to pods (alpha)")
 	flags.Duration("hubble-drop-events-interval", def.K8sDropEventsInterval, "Minimum time between emitting same events")
 	flags.StringSlice("hubble-drop-events-reasons", def.K8sDropEventsReasons, "Drop reasons to emit events for")
+	flags.Bool("hubble-network-policy-correlation-enabled", def.EnableNetworkPolicyCorrelation, "Enable network policy correlation of Hubble flows")
 }
 
 func (cfg *config) normalize() {

--- a/pkg/hubble/cell/hubbleintegration.go
+++ b/pkg/hubble/cell/hubbleintegration.go
@@ -461,6 +461,8 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 		)
 	}
 
+	parserOpts = append(parserOpts, parserOptions.WithNetworkPolicyCorrelation(h.log, h.config.EnableNetworkPolicyCorrelation))
+
 	payloadParser, err := parser.New(h.log, h, h, h, h.ipcache, h, link.NewLinkCache(), h.cgroupManager, h.config.SkipUnknownCGroupIDs, parserOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create parser: %w", err)

--- a/pkg/hubble/cell/hubbleintegration.go
+++ b/pkg/hubble/cell/hubbleintegration.go
@@ -450,7 +450,7 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 	if h.config.EnableRedact {
 		parserOpts = append(
 			parserOpts,
-			parserOptions.Redact(
+			parserOptions.WithRedact(
 				h.log,
 				h.config.RedactHttpURLQuery,
 				h.config.RedactHttpUserInfo,

--- a/pkg/hubble/parser/options/options.go
+++ b/pkg/hubble/parser/options/options.go
@@ -15,8 +15,9 @@ type Option func(*Options)
 
 // Options contains all parser options
 type Options struct {
-	CacheSize            int
-	HubbleRedactSettings HubbleRedactSettings
+	CacheSize                      int
+	HubbleRedactSettings           HubbleRedactSettings
+	EnableNetworkPolicyCorrelation bool
 }
 
 // HubbleRedactSettings contains all hubble redact related options
@@ -58,6 +59,16 @@ func Redact(logger *slog.Logger, httpQuery, httpUserInfo, kafkaApiKey bool, allo
 				logfields.Options, opt,
 			)
 		}
+	}
+}
+
+// EnableL3L4PolicyCorrelation configures the Network Policy correlation of Hubble Flows.
+func WithNetworkPolicyCorrelation(logger *slog.Logger, enabled bool) Option {
+	return func(opt *Options) {
+		opt.EnableNetworkPolicyCorrelation = enabled
+		logger.Info("configured Hubble with network policy correlation options",
+			logfields.Options, opt,
+		)
 	}
 }
 

--- a/pkg/hubble/parser/options/options.go
+++ b/pkg/hubble/parser/options/options.go
@@ -43,7 +43,7 @@ func CacheSize(size int) Option {
 }
 
 // Redact configures which data Hubble will redact.
-func Redact(logger *slog.Logger, httpQuery, httpUserInfo, kafkaApiKey bool, allowHeaders, denyHeaders []string) Option {
+func WithRedact(logger *slog.Logger, httpQuery, httpUserInfo, kafkaApiKey bool, allowHeaders, denyHeaders []string) Option {
 	return func(opt *Options) {
 		opt.HubbleRedactSettings.Enabled = true
 		opt.HubbleRedactSettings.RedactHTTPQuery = httpQuery
@@ -55,8 +55,8 @@ func Redact(logger *slog.Logger, httpQuery, httpUserInfo, kafkaApiKey bool, allo
 		}
 		if logger != nil {
 			logger.Info(
-				"configured Hubble with redact options",
-				logfields.Options, opt,
+				"configured Hubble with redact",
+				logfields.Options, opt.HubbleRedactSettings,
 			)
 		}
 	}
@@ -66,8 +66,8 @@ func Redact(logger *slog.Logger, httpQuery, httpUserInfo, kafkaApiKey bool, allo
 func WithNetworkPolicyCorrelation(logger *slog.Logger, enabled bool) Option {
 	return func(opt *Options) {
 		opt.EnableNetworkPolicyCorrelation = enabled
-		logger.Info("configured Hubble with network policy correlation options",
-			logfields.Options, opt,
+		logger.Info("configured Hubble with network policy correlation",
+			logfields.Options, opt.EnableNetworkPolicyCorrelation,
 		)
 	}
 }

--- a/pkg/hubble/parser/options/options_test.go
+++ b/pkg/hubble/parser/options/options_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestRedact(t *testing.T) {
-	want := "level=info msg=\"configured Hubble with redact options\" options=\"&{CacheSize:3 HubbleRedactSettings:{Enabled:true RedactHTTPQuery:false RedactHTTPUserInfo:false RedactKafkaAPIKey:false RedactHttpHeaders:{Allow:map[] Deny:map[]}} EnableNetworkPolicyCorrelation:false}\"\n"
+	want := "level=info msg=\"configured Hubble with redact\" options=\"{Enabled:true RedactHTTPQuery:false RedactHTTPUserInfo:false RedactKafkaAPIKey:false RedactHttpHeaders:{Allow:map[] Deny:map[]}}\"\n"
 	var buf bytes.Buffer
 	logger := slog.New(
 		slog.NewTextHandler(&buf,
@@ -23,9 +23,8 @@ func TestRedact(t *testing.T) {
 			},
 		),
 	)
-	opt := Redact(logger, false, false, false, nil, nil)
+	opt := WithRedact(logger, false, false, false, nil, nil)
 	opt(&Options{
-		CacheSize: 3,
 		HubbleRedactSettings: HubbleRedactSettings{
 			Enabled:            false,
 			RedactHTTPQuery:    false,
@@ -41,7 +40,7 @@ func TestRedact(t *testing.T) {
 }
 
 func TestEnableNetworkPolicyCorrelation(t *testing.T) {
-	want := "level=info msg=\"configured Hubble with network policy correlation options\" options=\"&{CacheSize:0 HubbleRedactSettings:{Enabled:false RedactHTTPQuery:false RedactHTTPUserInfo:false RedactKafkaAPIKey:false RedactHttpHeaders:{Allow:map[] Deny:map[]}} EnableNetworkPolicyCorrelation:true}\"\n"
+	want := "level=info msg=\"configured Hubble with network policy correlation\" options=true\n"
 	var buf bytes.Buffer
 	logger := slog.New(
 		slog.NewTextHandler(&buf,

--- a/pkg/hubble/parser/options/options_test.go
+++ b/pkg/hubble/parser/options/options_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestRedact(t *testing.T) {
-	want := "level=info msg=\"configured Hubble with redact options\" options=\"&{CacheSize:3 HubbleRedactSettings:{Enabled:true RedactHTTPQuery:false RedactHTTPUserInfo:false RedactKafkaAPIKey:false RedactHttpHeaders:{Allow:map[] Deny:map[]}}}\"\n"
+	want := "level=info msg=\"configured Hubble with redact options\" options=\"&{CacheSize:3 HubbleRedactSettings:{Enabled:true RedactHTTPQuery:false RedactHTTPUserInfo:false RedactKafkaAPIKey:false RedactHttpHeaders:{Allow:map[] Deny:map[]}} EnableNetworkPolicyCorrelation:false}\"\n"
 	var buf bytes.Buffer
 	logger := slog.New(
 		slog.NewTextHandler(&buf,
@@ -36,6 +36,23 @@ func TestRedact(t *testing.T) {
 				Deny:  map[string]struct{}{"tracecontent": {}},
 			},
 		},
+	})
+	assert.Equal(t, want, buf.String())
+}
+
+func TestEnableNetworkPolicyCorrelation(t *testing.T) {
+	want := "level=info msg=\"configured Hubble with network policy correlation options\" options=\"&{CacheSize:0 HubbleRedactSettings:{Enabled:false RedactHTTPQuery:false RedactHTTPUserInfo:false RedactKafkaAPIKey:false RedactHttpHeaders:{Allow:map[] Deny:map[]}} EnableNetworkPolicyCorrelation:true}\"\n"
+	var buf bytes.Buffer
+	logger := slog.New(
+		slog.NewTextHandler(&buf,
+			&slog.HandlerOptions{
+				ReplaceAttr: logging.ReplaceAttrFnWithoutTimestamp,
+			},
+		),
+	)
+	opt := WithNetworkPolicyCorrelation(logger, true)
+	opt(&Options{
+		EnableNetworkPolicyCorrelation: true,
 	})
 	assert.Equal(t, want, buf.String())
 }

--- a/pkg/hubble/parser/parser.go
+++ b/pkg/hubble/parser/parser.go
@@ -55,7 +55,7 @@ func New(
 	opts ...options.Option,
 ) (*Parser, error) {
 
-	l34, err := threefour.New(log, endpointGetter, identityGetter, dnsGetter, ipGetter, serviceGetter, linkGetter)
+	l34, err := threefour.New(log, endpointGetter, identityGetter, dnsGetter, ipGetter, serviceGetter, linkGetter, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hubble/parser/seven/http_test.go
+++ b/pkg/hubble/parser/seven/http_test.go
@@ -508,7 +508,7 @@ func TestDecodeL7HTTPRequestRemoveUrlQuery(t *testing.T) {
 	lr.SourceEndpoint.Port = 56789
 	lr.DestinationEndpoint.Port = 80
 
-	opts := []options.Option{options.Redact(nil, true, true, false, []string{}, []string{"authorization"})}
+	opts := []options.Option{options.WithRedact(nil, true, true, false, []string{}, []string{"authorization"})}
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 
@@ -556,7 +556,7 @@ func TestDecodeL7HTTPRequestHeadersRedact(t *testing.T) {
 	lr.SourceEndpoint.Port = 56789
 	lr.DestinationEndpoint.Port = 80
 
-	opts := []options.Option{options.Redact(nil, true, true, false, []string{"host"}, []string{})}
+	opts := []options.Option{options.WithRedact(nil, true, true, false, []string{"host"}, []string{})}
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 
@@ -574,7 +574,7 @@ func TestDecodeL7HTTPRequestHeadersRedact(t *testing.T) {
 		},
 	}, f.GetL7().GetHttp())
 
-	opts = []options.Option{options.Redact(nil, true, true, false, []string{}, []string{"host"})}
+	opts = []options.Option{options.WithRedact(nil, true, true, false, []string{}, []string{"host"})}
 	parser, err = New(hivetest.Logger(t), nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 
@@ -694,7 +694,7 @@ func TestDecodeL7HTTPRequestPasswordRedact(t *testing.T) {
 	lr.SourceEndpoint.Port = 56789
 	lr.DestinationEndpoint.Port = 80
 
-	opts := []options.Option{options.Redact(nil, true, true, false, []string{}, []string{})}
+	opts := []options.Option{options.WithRedact(nil, true, true, false, []string{}, []string{})}
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!-- Description of change -->
Adding a config option to disable L3/L4 network policy correlation of Hubble flows.
This is enabled by default, only setting the flag to 'false' will cause a change in behavior.
the new flag can be set as such:
```  --set hubble.networkpolicycorrelation.enabled=false ```
or set in values.yaml :
``` .Values.hubble.networkpolicycorrelation.enabled ```

Fixes: #37528 

```release-note
Add an option to disable L3/L4 network policy correlation of Hubble flows
```

Manual verification in a cluster:
- build feature images & update the cluster
- edit config map cilium-config to add:
   - ```hubble-network-policy-correlation-enabled: "false"```
- or helm upgrade  with ``` --set hubble.networkpolicycorrelation.enabled=false```
- restart cilium & hubble-relay pods
- use node-shell to the cilium pod
   - navigate to var/run/cilium/hubble
   - check flows in events.log
   - When flag is enabled the flow object will contain : "egress_allowed_by"/ "ingress_allowed_by" property with an array of evaluated policies.
   - When the flag is disabled the flow object will not contain the above properties