### PR TITLE
ci: enable SDS in cloud provider tests

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -201,7 +201,6 @@ jobs:
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set cluster.name=${{ env.name }} \
             --helm-set loadBalancer.l7.backend=envoy \
-            --helm-set tls.secretsBackend=k8s \
             --helm-set=azure.resourceGroup=${{ env.name }} \
             --helm-set=ipv4.enabled=true \
             --helm-set=ipv6.enabled=true \

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -205,7 +205,6 @@ jobs:
             --helm-set=cluster.name=${{ env.clusterName }} \
             --helm-set=hubble.relay.enabled=true \
             --helm-set loadBalancer.l7.backend=envoy \
-            --helm-set tls.secretsBackend=k8s \
             --helm-set=bpf.monitorAggregation=none \
             --wait=false"
           if [[ "${{ matrix.ipsec }}" == "true" ]]; then

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -224,7 +224,6 @@ jobs:
             --helm-set=hubble.relay.enabled=true \
             --helm-set=agentNotReadyTaintKey=ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready \
             --helm-set loadBalancer.l7.backend=envoy \
-            --helm-set tls.secretsBackend=k8s \
             --wait=false"
 
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --collect-sysdump-on-failure \


### PR DESCRIPTION
Since #37076 was merged we have a new mode of synchronizing TLS secrets to Envoy. Previously we used NPDS, while new way uses SDS. However, by setting secretsBackend=k8s we were forcing old behaviour. Let's start testing SDS as it's a new default.

Most likely fixes https://github.com/cilium/cilium/issues/37874