### PR TITLE
docs: clarify wording of remote-nodes

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -347,7 +347,8 @@ cluster
     Cluster is the logical group of all network endpoints inside of the local
     cluster. This includes all Cilium-managed endpoints of the local cluster,
     unmanaged endpoints in the local cluster, as well as the host,
-    remote-node, and init identities.
+    remote-node, and init identities. This also includes all remote nodes
+    in a clustermesh scenario.
 init
     The init entity contains all endpoints in bootstrap phase for which the
     security identity has not been resolved yet. This is typically only


### PR DESCRIPTION
Make a note about remote-nodes in a context of clustermesh.

Fixes: #https://github.com/cilium/cilium/issues/14595


```release-note
docs: clarify wording of remote-nodes in context of a clustermesh
```
