### PR TITLE
chore(deps): update all lvh-images main (main) (patch)

### DIFF
--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -6,25 +6,25 @@ include:
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.32.0@sha256:22cf2864f90cfab0d442fda2decf2eae107edd03483053a902614dec637eff76"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "bpf-next-20250110.013326"
+    kernel: "bpf-next-20250303.013113"
 
   - k8s-version: "1.31"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.31.0@sha256:d2b2a8cd6fa282b9a4126938341a4d2924dfa96f60b1f983d519498c9cde1a99"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "rhel8.6-20241218.004849"
+    kernel: "rhel8.6-20250226.175419"
 
   - k8s-version: "1.30"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.30.0@sha256:edcb457c0b2ecc69a0fa9b0878bdcfd4a0f1205340cf08bf36a03d3a94a16dd9"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "rhel8.6-20241218.004849"
+    kernel: "rhel8.6-20250226.175419"
 
   - k8s-version: "1.29"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "5.4-20241218.004849"
+    kernel: "5.4-20250226.175419"

--- a/.github/actions/ipsec/configs.yaml
+++ b/.github/actions/ipsec/configs.yaml
@@ -1,6 +1,6 @@
 - name: '1'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  kernel: 'rhel8.6-20241031.113911'
+  kernel: 'rhel8.6-20250226.175419'
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'vxlan'
@@ -8,7 +8,7 @@
   key-two: 'cbc(aes)'
 - name: '2'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  kernel: '5.4-20240710.064909'
+  kernel: '5.4-20250226.175419'
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'disabled'
@@ -16,7 +16,7 @@
   key-two: 'cbc(aes)'
 - name: '3'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  kernel: '5.10-20240710.064909'
+  kernel: '5.10-20250226.175419'
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'disabled'
@@ -26,7 +26,7 @@
   kvstore: 'true'
 - name: '4'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  kernel: 'bpf-next-20240711.013133'
+  kernel: 'bpf-next-20250303.013113'
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'geneve'
@@ -36,7 +36,7 @@
   kvstore: 'true'
 - name: '5'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  kernel: '5.4-20240710.064909'
+  kernel: '5.4-20250226.175419'
   kube-proxy: 'none'
   kpr: 'true'
   tunnel: 'disabled'
@@ -44,7 +44,7 @@
   key-two: 'cbc(aes)'
 - name: '6'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  kernel: '5.10-20240710.064909'
+  kernel: '5.10-20250226.175419'
   kube-proxy: 'none'
   kpr: 'true'
   tunnel: 'disabled'
@@ -55,7 +55,7 @@
   key-two: 'gcm(aes)'
 - name: '7'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  kernel: '5.15-20240710.064909'
+  kernel: '5.15-20250226.175419'
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'vxlan'
@@ -63,7 +63,7 @@
   key-two: 'gcm(aes)'
 - name: '8'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  kernel: 'bpf-next-20240711.013133'
+  kernel: 'bpf-next-20250303.013113'
   kube-proxy: 'none'
   kpr: 'true'
   tunnel: 'vxlan'

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -265,7 +265,7 @@ jobs:
         with:
           test-name: runtime-tests
           install-dependencies: true
-          # renovate: datasource=docker depName=quay.io/lvh-images/kind
+          # renovate: disabled until LVH upgrade is fixed
           image-version: "bpf-next-20250110.013326"
           host-mount: ./
           images-folder-parent: "/tmp"

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -87,28 +87,28 @@ jobs:
       matrix:
         include:
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '5.4-20250126.112744'
+          - kernel: '5.4-20250226.175419'
             ci-kernel: '54'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: 'rhel8.6-20250126.112744'
+          - kernel: 'rhel8.6-20250226.175419'
             ci-kernel: '54'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '5.10-20250126.112744'
+          - kernel: '5.10-20250226.175419'
             ci-kernel: '510'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '5.15-20250126.112744'
+          - kernel: '5.15-20250226.175419'
             ci-kernel: '510'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '6.1-20250126.112744'
+          - kernel: '6.1-20250226.175419'
             ci-kernel: '61'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '6.6-20250126.112744'
+          - kernel: '6.6-20250226.175419'
             ci-kernel: '61'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: '6.12-20250126.112744'
+          - kernel: '6.12-20250226.175419'
             ci-kernel: '61'
           # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-          - kernel: 'bpf-next-20250131.013253'
+          - kernel: 'bpf-next-20250303.013113'
             ci-kernel: 'netnext'
     timeout-minutes: 60
     steps:

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -106,7 +106,7 @@ jobs:
         include:
           - name: '1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: 'rhel8.6-20250126.112744'
+            kernel: 'rhel8.6-20250226.175419'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'
@@ -115,7 +115,7 @@ jobs:
 
           - name: '2'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.4-20250126.112744'
+            kernel: '5.4-20250226.175419'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'disabled'
@@ -124,7 +124,7 @@ jobs:
 
           - name: '3'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20250126.112744'
+            kernel: '5.10-20250226.175419'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'disabled'
@@ -133,7 +133,7 @@ jobs:
 
           - name: '4'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20250126.112744'
+            kernel: '5.10-20250226.175419'
             kube-proxy: 'iptables'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -146,7 +146,7 @@ jobs:
 
           - name: '5'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.15-20250126.112744'
+            kernel: '5.15-20250226.175419'
             kube-proxy: 'iptables'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -160,7 +160,7 @@ jobs:
 
           - name: '6'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.1-20250126.112744'
+            kernel: '6.1-20250226.175419'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -201,7 +201,7 @@ jobs:
 
           - name: '9'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20250126.112744'
+            kernel: '5.10-20250226.175419'
             kube-proxy: 'iptables'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -216,7 +216,7 @@ jobs:
 
           - name: '10'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.15-20250126.112744'
+            kernel: '5.15-20250226.175419'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'disabled'
@@ -230,7 +230,7 @@ jobs:
 
           - name: '11'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.1-20250126.112744'
+            kernel: '6.1-20250226.175419'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -262,7 +262,7 @@ jobs:
 
           - name: '13'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: 'rhel8.6-20250126.112744'
+            kernel: 'rhel8.6-20250226.175419'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'
@@ -274,7 +274,7 @@ jobs:
             # explains why 5.4 might cause north-south-loadbalancing tests to
             # fail.
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.15-20250126.112744'
+            kernel: '5.15-20250226.175419'
             kube-proxy: 'iptables'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -300,7 +300,7 @@ jobs:
 
           - name: '16'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.15-20250126.112744'
+            kernel: '5.15-20250226.175419'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -421,7 +421,7 @@ jobs:
 
           - name: '26'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.6-20250126.112744'
+            kernel: '6.6-20250226.175419'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -433,7 +433,7 @@ jobs:
 
           - name: '27'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.6-20250126.112744'
+            kernel: '6.6-20250226.175419'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -445,7 +445,7 @@ jobs:
 
           - name: '28'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.6-20250126.112744'
+            kernel: '6.6-20250226.175419'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -458,7 +458,7 @@ jobs:
 
           - name: '29'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.12-20250126.112744'
+            kernel: '6.12-20250226.175419'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -470,7 +470,7 @@ jobs:
 
           - name: '30'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.12-20250126.112744'
+            kernel: '6.12-20250226.175419'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'
@@ -482,7 +482,7 @@ jobs:
 
           - name: '31'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.12-20250126.112744'
+            kernel: '6.12-20250226.175419'
             kube-proxy: 'none'
             kpr: 'true'
             devices: '{eth0,eth1}'


### PR DESCRIPTION
Manually apply https://github.com/cilium/cilium/pull/37494, and disable the dependency in `conformance-runtime` until the failing CI is addressed.