### PR TITLE
bpf: overlay: clear skb->cb at start of to-overlay program

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1036,7 +1036,7 @@ do_netdev_encrypt_encap(struct __ctx_buff *ctx, __be16 proto, __u32 src_id)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
 	ctx->mark = 0;
-	bpf_clear_meta(ctx);
+
 	return encap_and_redirect_with_nodeid(ctx, ep->tunnel_endpoint, 0,
 					      src_id, 0, &trace);
 }

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -732,6 +732,8 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 	__be16 __maybe_unused proto = 0;
 	__s8 ext_err = 0;
 
+	bpf_clear_meta(ctx);
+
 	/* Load the ethertype just once: */
 	validate_ethertype(ctx, &proto);
 

--- a/bpf/tests/ipsec_from_host_generic.h
+++ b/bpf/tests/ipsec_from_host_generic.h
@@ -136,10 +136,6 @@ int ipv4_ipsec_from_host_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	assert(ctx->mark == 0);
 
-#ifdef CHECK_CB_ENCRYPT_IDENTITY
-	assert(ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY) == 0);
-#endif
-
 	l2 = data + sizeof(*status_code);
 
 	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
@@ -257,10 +253,6 @@ int ipv6_ipsec_from_host_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	status_code = data;
 	assert(*status_code == EXPECTED_STATUS_CODE);
-
-#ifdef CHECK_CB_ENCRYPT_IDENTITY
-	assert(ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY) == 0);
-#endif
 
 	assert(ctx->mark == 0);
 

--- a/bpf/tests/ipsec_from_host_tunnel.c
+++ b/bpf/tests/ipsec_from_host_tunnel.c
@@ -5,6 +5,5 @@
 #define ENABLE_ROUTING
 
 #define EXPECTED_STATUS_CODE CTX_ACT_REDIRECT
-#define CHECK_CB_ENCRYPT_IDENTITY
 
 #include "ipsec_from_host_generic.h"

--- a/bpf/tests/ipsec_from_host_tunnel_endpoint.c
+++ b/bpf/tests/ipsec_from_host_tunnel_endpoint.c
@@ -5,6 +5,5 @@
 #define ENABLE_ENDPOINT_ROUTES 1
 
 #define EXPECTED_STATUS_CODE CTX_ACT_REDIRECT
-#define CHECK_CB_ENCRYPT_IDENTITY
 
 #include "ipsec_from_host_generic.h"


### PR DESCRIPTION
It's good practice to 0-initialize the meta-data block, even just to ensure that we're not relying on the (fragile) transfer of data via `skb->cb`.

Noticed while chasing down why `do_netdev_encrypt_encap()` would be handling it. Clean it up there.