### PR TITLE
bgp: Add BGPRouterManager to hive lifecycle to ensure proper cleanup

### DIFF
--- a/pkg/bgpv1/agent/routermgr.go
+++ b/pkg/bgpv1/agent/routermgr.go
@@ -6,6 +6,8 @@ package agent
 import (
 	"context"
 
+	"github.com/cilium/hive/cell"
+
 	"github.com/cilium/cilium/api/v1/models"
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/bgp"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -53,5 +55,5 @@ type BGPRouterManager interface {
 	GetRoutePolicies(ctx context.Context, params restapi.GetBgpRoutePoliciesParams) ([]*models.BgpRoutePolicy, error)
 
 	// Stop will stop all BGP instances and clean up local state.
-	Stop()
+	Stop(ctx cell.HookContext) error
 }

--- a/pkg/bgpv1/mock/mocks.go
+++ b/pkg/bgpv1/mock/mocks.go
@@ -6,6 +6,7 @@ package mock
 import (
 	"context"
 
+	"github.com/cilium/hive/cell"
 	v1 "k8s.io/api/core/v1"
 	k8sLabels "k8s.io/apimachinery/pkg/labels"
 	v1listers "k8s.io/client-go/listers/core/v1"
@@ -41,7 +42,7 @@ type MockBGPRouterManager struct {
 	GetPeers_           func(ctx context.Context) ([]*models.BgpPeer, error)
 	GetRoutes_          func(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error)
 	GetRoutePolicies_   func(ctx context.Context, params restapi.GetBgpRoutePoliciesParams) ([]*models.BgpRoutePolicy, error)
-	Stop_               func()
+	Stop_               func(cell.HookContext) error
 }
 
 func (m *MockBGPRouterManager) ConfigurePeers(ctx context.Context, policy *v2alpha1.CiliumBGPPeeringPolicy, ciliumNode *v2.CiliumNode) error {
@@ -64,6 +65,6 @@ func (m *MockBGPRouterManager) GetRoutePolicies(ctx context.Context, params rest
 	return m.GetRoutePolicies_(ctx, params)
 }
 
-func (m *MockBGPRouterManager) Stop() {
-	m.Stop_()
+func (m *MockBGPRouterManager) Stop(ctx cell.HookContext) error {
+	return m.Stop_(ctx)
 }

--- a/pkg/bgpv1/test/fixtures.go
+++ b/pkg/bgpv1/test/fixtures.go
@@ -293,8 +293,6 @@ func start(ctx context.Context, t testing.TB, peerConfigs []gobgpConfig, f *fixt
 			peer.stopGoBGP()
 		}
 
-		f.bgp.BGPMgr.Stop()
-
 		f.hive.Stop(tlog, ctx)
 		teardownLinks()
 	}


### PR DESCRIPTION
Ensure `BGPRouterManager.Stop()` is called when BGP CP cell is being destroyed to properly clean up all servers when the agent is stopped.
