### PR TITLE
Support tunnel routing in Multi-Pool IPAM mode

### DIFF
--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -81,6 +81,15 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   multi-pool-ipam-conformance-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: 'Direct Routing'
+            tunnel: 'disabled'
+          - name: 'Tunnel Mode'
+            tunnel: 'vxlan'
+
     name: Install and Connectivity Test
     env:
       job_name: "Install and Connectivity Test"
@@ -125,20 +134,15 @@ jobs:
           echo owner=${OWNER} >> $GITHUB_OUTPUT
 
           # Notes:
-          #  - Multi-pool IPAM only supports direct routing, thus we disable
-          #    tunnel mode and enable auto-direct-routes.
-          #  - Multi-pool IPAM only supports endpoint routes, thus we disable
-          #    the local-node-route.
-          #  - helm/kind-action does not support BPF host routing, so we fall
-          #    back on legacy host routing
-          #    (https://github.com/cilium/cilium/issues/23283#issuecomment-1597282247)
+          #  - Multi-pool IPAM only supports endpoint routes
           #  - iptables-based masquerading does not support multiple non-masquerade
           #    CIDRs. Thus, we enable BPF masquerading where we can add multiple
           #    non-masquerade CIDRs.
+          #  - helm/kind-action does not support BPF host routing, so we fall
+          #    back on legacy host routing
+          #    (https://github.com/cilium/cilium/issues/23283#issuecomment-1597282247)
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=hubble.relay.enabled=true \
-            --helm-set=autoDirectNodeRoutes=true \
-            --helm-set=routingMode=native \
             --helm-set=endpointRoutes.enabled=true \
             --helm-set=kubeProxyReplacement=true \
             --helm-set=bpf.masquerade=true \
@@ -155,7 +159,15 @@ jobs:
             --helm-set=ipam.operator.autoCreateCiliumPodIPPools.echo-other-node-pool.ipv4.cidrs='{192.168.16.0/20}' \
             --helm-set=ipam.operator.autoCreateCiliumPodIPPools.echo-other-node-pool.ipv4.maskSize=27"
 
+          if [ "${{ matrix.tunnel }}" == "disabled" ]; then
+            CILIUM_INSTALL_TUNNEL="--helm-set-string=routingMode=native \
+            --helm-set=autoDirectNodeRoutes=true"
+          fi
+
           CONNECTIVITY_TEST_DEFAULTS="--test-concurrency=5 \
+            --sysdump-output-filename \"cilium-sysdump-${{ matrix.name }}-<ts>\" \
+            --junit-file \"cilium-junits/${{ env.job_name }} ${{ matrix.name }}.xml\" \
+            --junit-property github_job_step=\"Run tests ${{ matrix.name }}\" \
             --log-code-owners --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
             --flow-validation=disabled --hubble=false --collect-sysdump-on-failure \
             --external-target bing.com. --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8 \
@@ -165,7 +177,7 @@ jobs:
                 \"echo-other-node\":{\"ipam.cilium.io/ip-pool\":\"echo-other-node-pool\"} \
             }'"
 
-          echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
+          echo cilium_install_defaults="${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_TUNNEL}" >> $GITHUB_OUTPUT
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
 
       # Warning: since this is a privileged workflow, subsequent workflow job
@@ -219,14 +231,13 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
-            --junit-file "cilium-junits/${{ env.job_name }} - 1.xml" --junit-property github_job_step="Run connectivity test"
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
 
       - name: Features tested
         uses: ./.github/actions/feature-status
         with:
           title: "Summary of all features tested"
-          json-filename: "${{ env.job_name }} - 1"
+          json-filename: "${{ env.job_name }} ${{ matrix.name }}"
 
       - name: Collect Pod and Pool IPs
         id: ips
@@ -268,7 +279,7 @@ jobs:
         if: ${{ !success() }}
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: cilium-sysdump-out.zip
+          name: "cilium-sysdumps-${{ matrix.name }}"
           path: cilium-sysdump-*.zip
           retention-days: 5
 
@@ -276,15 +287,14 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: cilium-junits
+          name: "cilium-junits-${{ matrix.name }}"
           path: cilium-junits/*.xml
-          retention-days: 5
 
       - name: Upload features tested
         if: ${{ always() }}
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: features-tested
+          name: "features-tested-${{ matrix.name }}"
           path: ${{ env.job_name }}*.json
 
       - name: Publish Test Results As GitHub Summary

--- a/Documentation/network/concepts/ipam/multi-pool.rst
+++ b/Documentation/network/concepts/ipam/multi-pool.rst
@@ -155,7 +155,6 @@ Multi-Pool IPAM is a preview feature. The following limitations apply to Cilium 
 Multi-Pool IPAM mode:
 
 .. warning::
-   - Tunnel mode is not supported. Multi-Pool IPAM may only be used in direct routing mode.
    - Transparent encryption is only supported with WireGuard and cannot be used with IPsec.
    - IPAM pools with overlapping CIDRs are not supported. Each pod IP must be
      unique in the cluster due the way Cilium determines the security identity

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -367,17 +367,6 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		return encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
 						      encrypt_key, secctx, info->sec_identity,
 						      &trace);
-	} else {
-		struct tunnel_key key = {};
-
-		/* IPv6 lookup key: daddr/96 */
-		ipv6_addr_copy(&key.ip6, dst);
-		key.ip6.p4 = 0;
-		key.family = ENDPOINT_KEY_IPV6;
-
-		ret = encap_and_redirect_netdev(ctx, &key, encrypt_key, secctx, &trace);
-		if (ret != DROP_NO_TUNNEL_ENDPOINT)
-			return ret;
 	}
 skip_tunnel:
 #endif
@@ -833,17 +822,6 @@ skip_vtep:
 		return encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
 						      encrypt_key, secctx, info->sec_identity,
 						      &trace);
-	} else {
-		/* IPv4 lookup key: daddr & IPV4_MASK */
-		struct tunnel_key key = {};
-
-		key.ip4 = ip4->daddr & IPV4_MASK;
-		key.family = ENDPOINT_KEY_IPV4;
-
-		cilium_dbg(ctx, DBG_NETDEV_ENCAP4, key.ip4, secctx);
-		ret = encap_and_redirect_netdev(ctx, &key, encrypt_key, secctx, &trace);
-		if (ret != DROP_NO_TUNNEL_ENDPOINT)
-			return ret;
 	}
 skip_tunnel:
 #endif

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -713,8 +713,8 @@ ct_recreate6:
 		 * the packet needs IPSec encap so push ctx to stack for encap, or
 		 * (c) packet was redirected to tunnel device so return.
 		 */
-		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, 0, 0, encrypt_key,
-					     &key, SECLABEL_IPV6, *dst_sec_identity,
+		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key,
+					     SECLABEL_IPV6, *dst_sec_identity,
 					     &trace);
 		switch (ret) {
 		case CTX_ACT_OK:
@@ -1256,8 +1256,7 @@ skip_vtep:
 		}
 #endif
 
-		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, ip4->saddr,
-					     ip4->daddr, encrypt_key, &key,
+		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key,
 					     SECLABEL_IPV4, *dst_sec_identity, &trace);
 		switch (ret) {
 		case CTX_ACT_OK:

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -114,51 +114,17 @@ __encap_and_redirect_lxc(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
  * CTX_ACT_REDIRECT.
  */
 static __always_inline int
-encap_and_redirect_lxc(struct __ctx_buff *ctx,
-		       __be32 tunnel_endpoint __maybe_unused,
-		       __u32 src_ip __maybe_unused,
-		       __u32 dst_ip __maybe_unused,
-		       __u8 encrypt_key __maybe_unused,
-		       struct tunnel_key *key __maybe_unused,
-		       __u32 seclabel, __u32 dstid,
-		       const struct trace_ctx *trace)
+encap_and_redirect_lxc(struct __ctx_buff *ctx __maybe_unused,
+		       __be32 tunnel_endpoint, __u8 encrypt_key __maybe_unused,
+		       __u32 seclabel __maybe_unused, __u32 dstid __maybe_unused,
+		       const struct trace_ctx *trace __maybe_unused)
 {
-	struct tunnel_value *tunnel __maybe_unused;
-
-	if (tunnel_endpoint)
-		return __encap_and_redirect_lxc(ctx, tunnel_endpoint,
-						encrypt_key, seclabel, dstid,
-						trace);
-
-	tunnel = map_lookup_elem(&TUNNEL_MAP, key);
-	if (!tunnel)
+	if (!tunnel_endpoint)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
-# ifdef ENABLE_IPSEC
-	if (tunnel->key) {
-		__u8 min_encrypt_key = get_min_encrypt_key(tunnel->key);
-
-		return set_ipsec_encrypt(ctx, min_encrypt_key, tunnel->ip4,
-					 seclabel, false, false);
-	}
-# endif
-	return __encap_and_redirect_with_nodeid(ctx, tunnel->ip4, seclabel,
-						dstid, NOT_VTEP_DST, trace);
-}
-
-static __always_inline int
-encap_and_redirect_netdev(struct __ctx_buff *ctx, struct tunnel_key *k,
-			  __u8 encrypt_key, __u32 seclabel,
-			  const struct trace_ctx *trace)
-{
-	struct tunnel_value *tunnel;
-
-	tunnel = map_lookup_elem(&TUNNEL_MAP, k);
-	if (!tunnel)
-		return DROP_NO_TUNNEL_ENDPOINT;
-
-	return encap_and_redirect_with_nodeid(ctx, tunnel->ip4, encrypt_key,
-					      seclabel, 0, trace);
+	return __encap_and_redirect_lxc(ctx, tunnel_endpoint,
+					encrypt_key, seclabel, dstid,
+					trace);
 }
 #endif /* TUNNEL_MODE */
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1333,10 +1333,6 @@ func initEnv(vp *viper.Viper) {
 		option.Config.EncryptInterface = append(option.Config.EncryptInterface, link)
 	}
 
-	if option.Config.TunnelingEnabled() && option.Config.EnableAutoDirectRouting {
-		log.Fatalf("%s cannot be used with tunneling. Packets must be routed through the tunnel device.", option.EnableAutoDirectRoutingName)
-	}
-
 	initClockSourceOption()
 
 	if option.Config.EnableSRv6 {
@@ -1402,9 +1398,6 @@ func initEnv(vp *viper.Viper) {
 	}
 
 	if option.Config.IPAM == ipamOption.IPAMMultiPool {
-		if option.Config.TunnelingEnabled() {
-			log.Fatalf("Cannot specify IPAM mode %s in tunnel mode.", option.Config.IPAM)
-		}
 		if option.Config.EnableIPSec {
 			log.Fatalf("Cannot specify IPAM mode %s with %s.", option.Config.IPAM, option.EnableIPSecName)
 		}

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -1328,6 +1328,79 @@ func Test_metadata_mergeParentLabels(t *testing.T) {
 	}
 }
 
+func TestIPCachePodCIDREntries(t *testing.T) {
+	cancel := setupTest(t)
+	defer cancel()
+
+	ctx := context.Background()
+
+	// This emulates the upsert of fallback pod CIDR entry emitted by node manager
+	podCIDR1 := netip.MustParsePrefix("10.10.0.0/24")
+	podCIDR2 := netip.MustParsePrefix("10.20.30.40/32")
+	IPIdentityCache.metadata.upsertLocked(podCIDR1, source.CustomResource, "node-1",
+		labels.NewLabelsFromSortedList("reserved:world-ipv4"),
+		types.TunnelPeer{Addr: netip.MustParseAddr("192.168.1.101")},
+		types.EncryptKey(6),
+	)
+	IPIdentityCache.metadata.upsertLocked(podCIDR2, source.CustomResource, "node-1",
+		labels.NewLabelsFromSortedList("reserved:world-ipv4"),
+		types.TunnelPeer{Addr: netip.MustParseAddr("192.168.1.101")},
+		types.EncryptKey(6),
+	)
+	_, _, err := IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{podCIDR1, podCIDR2})
+	require.NoError(t, err)
+
+	ip, key := IPIdentityCache.getHostIPCache(podCIDR1.String())
+	assert.Equal(t, "192.168.1.101", ip.String())
+	assert.Equal(t, uint8(6), key)
+	nid, ok := IPIdentityCache.LookupByPrefix(podCIDR1.String())
+	assert.True(t, ok)
+	assert.Equal(t, identity.ReservedIdentityWorldIPv4, nid.ID)
+
+	ip, key = IPIdentityCache.getHostIPCache(podCIDR2.String())
+	assert.Equal(t, "192.168.1.101", ip.String())
+	assert.Equal(t, uint8(6), key)
+	nid, ok = IPIdentityCache.LookupByPrefix(podCIDR2.String())
+	assert.True(t, ok)
+	assert.Equal(t, identity.ReservedIdentityWorldIPv4, nid.ID)
+
+	// Emulate selecting pod CIDR in CIDRGroup
+	IPIdentityCache.metadata.upsertLocked(podCIDR1, source.CustomResource, "r1",
+		labels.NewLabelsFromSortedList("cidr:10.10.0.0/24=;cidrgroup:a="),
+	)
+	_, _, err = IPIdentityCache.doInjectLabels(ctx, []netip.Prefix{podCIDR1})
+	require.NoError(t, err)
+
+	// Assert identity labels have been merged
+	nid, ok = IPIdentityCache.LookupByPrefix(podCIDR1.String())
+	require.True(t, ok)
+	id := IPIdentityCache.LookupIdentityByID(ctx, nid.ID)
+	require.NotNil(t, id)
+	wantlbls := labels.NewLabelsFromSortedList("cidr:10.10.0.0/24=;cidrgroup:a=;reserved:world-ipv4=")
+	require.Equal(t, wantlbls, id.Labels)
+	// Assert tunnel and encryption metadata has been preserved
+	ip, key = IPIdentityCache.getHostIPCache(podCIDR1.String())
+	assert.Equal(t, "192.168.1.101", ip.String())
+	assert.Equal(t, uint8(6), key)
+
+	// Emulate /32 pod CIDR being shadowed by CEP IP
+	podIP2 := "10.20.30.40"
+	podIdentity := identity.NumericIdentity(68)
+	IPIdentityCache.Upsert(podIP2, nil, 0, nil, Identity{
+		ID:     podIdentity,
+		Source: source.KVStore,
+	})
+	nid, ok = IPIdentityCache.LookupByPrefix(podCIDR2.String())
+	assert.True(t, ok)
+	assert.Equal(t, podIdentity, nid.ID)
+
+	// Unshadow PodCIDR2
+	IPIdentityCache.Delete(podIP2, source.KVStore)
+	nid, ok = IPIdentityCache.LookupByPrefix(podCIDR2.String())
+	assert.True(t, ok)
+	assert.Equal(t, identity.ReservedIdentityWorldIPv4, nid.ID)
+}
+
 func BenchmarkManyResources(b *testing.B) {
 	m := newMetadata()
 

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -24,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 
+	"github.com/cilium/cilium/pkg/cidr"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -107,6 +109,20 @@ func (i *ipcacheMock) RemoveMetadata(prefix netip.Prefix, resource ipcacheTypes.
 
 func (i *ipcacheMock) RemoveIdentityOverride(prefix netip.Prefix, identityLabels labels.Labels, resource ipcacheTypes.ResourceID) {
 	i.Delete(prefix.String(), source.CustomResource)
+}
+
+func (i *ipcacheMock) UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64) {
+	for _, update := range updates {
+		i.UpsertMetadata(update.Prefix, update.Source, update.Resource, update.Metadata)
+	}
+	return 0
+}
+
+func (i *ipcacheMock) RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64) {
+	for _, update := range updates {
+		i.RemoveMetadata(update.Prefix, update.Resource, update.Metadata)
+	}
+	return 0
 }
 
 type ipsetMock struct {
@@ -511,6 +527,15 @@ func TestIpcache(t *testing.T) {
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
 
+	expectIPCacheUpdate := func(eventType string, prefix netip.Prefix) {
+		select {
+		case event := <-ipcacheMock.events:
+			require.Equal(t, nodeEvent{event: eventType, prefix: prefix}, event)
+		case <-time.After(5 * time.Second):
+			t.Errorf("timeout while waiting for ipcache upsert for %s", prefix)
+		}
+	}
+
 	n1 := nodeTypes.Node{
 		Name:    "node1",
 		Cluster: "c1",
@@ -519,29 +544,21 @@ func TestIpcache(t *testing.T) {
 			{Type: addressing.NodeInternalIP, IP: net.ParseIP("10.0.0.2")},
 			{Type: addressing.NodeExternalIP, IP: net.ParseIP("f00d::1")},
 		},
+
+		IPv4AllocCIDR:           cidr.MustParseCIDR("10.0.0.0/24"),
+		IPv4SecondaryAllocCIDRs: []*cidr.CIDR{cidr.MustParseCIDR("192.168.10.0/28")},
+		IPv6AllocCIDR:           cidr.MustParseCIDR("f00d::/96"),
+		IPv6SecondaryAllocCIDRs: []*cidr.CIDR{cidr.MustParseCIDR("cafe::/96")},
 	}
 	mngr.NodeUpdated(n1)
 
-	select {
-	case event := <-ipcacheMock.events:
-		require.Equal(t, nodeEvent{event: "upsert", prefix: netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)}, event)
-	case <-time.After(5 * time.Second):
-		t.Errorf("timeout while waiting for ipcache upsert for IP 1.1.1.1")
-	}
-
-	select {
-	case event := <-ipcacheMock.events:
-		require.Equal(t, nodeEvent{event: "upsert", prefix: netip.PrefixFrom(netip.MustParseAddr("10.0.0.2"), 32)}, event)
-	case <-time.After(5 * time.Second):
-		t.Errorf("timeout while waiting for ipcache upsert for IP 10.0.0.2")
-	}
-
-	select {
-	case event := <-ipcacheMock.events:
-		require.Equal(t, nodeEvent{event: "upsert", prefix: netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128)}, event)
-	case <-time.After(5 * time.Second):
-		t.Errorf("timeout while waiting for ipcache upsert for IP f00d::1")
-	}
+	expectIPCacheUpdate("upsert", netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32))
+	expectIPCacheUpdate("upsert", netip.PrefixFrom(netip.MustParseAddr("10.0.0.2"), 32))
+	expectIPCacheUpdate("upsert", netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128))
+	expectIPCacheUpdate("upsert", netip.MustParsePrefix("10.0.0.0/24"))
+	expectIPCacheUpdate("upsert", netip.MustParsePrefix("192.168.10.0/28"))
+	expectIPCacheUpdate("upsert", netip.MustParsePrefix("f00d::/96"))
+	expectIPCacheUpdate("upsert", netip.MustParsePrefix("cafe::/96"))
 
 	select {
 	case event := <-ipcacheMock.events:
@@ -549,28 +566,29 @@ func TestIpcache(t *testing.T) {
 	default:
 	}
 
+	// Update node by removing ExternalIPs and secondary PodCIDRs
+	n1 = *n1.DeepCopy()
+	n1.IPAddresses = slices.DeleteFunc(n1.IPAddresses, func(address nodeTypes.Address) bool {
+		return address.IP.Equal(net.ParseIP("f00d::1"))
+	})
+	n1.IPv4SecondaryAllocCIDRs = nil
+	n1.IPv6SecondaryAllocCIDRs = nil
+	mngr.NodeUpdated(n1)
+
+	expectIPCacheUpdate("upsert", netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32))
+	expectIPCacheUpdate("upsert", netip.PrefixFrom(netip.MustParseAddr("10.0.0.2"), 32))
+	expectIPCacheUpdate("upsert", netip.MustParsePrefix("10.0.0.0/24"))
+	expectIPCacheUpdate("upsert", netip.MustParsePrefix("f00d::/96"))
+	expectIPCacheUpdate("delete", netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128))
+	expectIPCacheUpdate("delete", netip.MustParsePrefix("192.168.10.0/28"))
+	expectIPCacheUpdate("delete", netip.MustParsePrefix("cafe::/96"))
+
 	mngr.NodeDeleted(n1)
 
-	select {
-	case event := <-ipcacheMock.events:
-		require.Equal(t, nodeEvent{event: "delete", prefix: netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32)}, event)
-	case <-time.After(5 * time.Second):
-		t.Errorf("timeout while waiting for ipcache delete for IP 1.1.1.1")
-	}
-
-	select {
-	case event := <-ipcacheMock.events:
-		require.Equal(t, nodeEvent{event: "delete", prefix: netip.PrefixFrom(netip.MustParseAddr("10.0.0.2"), 32)}, event)
-	case <-time.After(5 * time.Second):
-		t.Errorf("timeout while waiting for ipcache delete for IP 10.0.0.2")
-	}
-
-	select {
-	case event := <-ipcacheMock.events:
-		require.Equal(t, nodeEvent{event: "delete", prefix: netip.PrefixFrom(netip.MustParseAddr("f00d::1"), 128)}, event)
-	case <-time.After(5 * time.Second):
-		t.Errorf("timeout while waiting for ipcache delete for IP f00d::1")
-	}
+	expectIPCacheUpdate("delete", netip.PrefixFrom(netip.MustParseAddr("1.1.1.1"), 32))
+	expectIPCacheUpdate("delete", netip.PrefixFrom(netip.MustParseAddr("10.0.0.2"), 32))
+	expectIPCacheUpdate("delete", netip.MustParsePrefix("10.0.0.0/24"))
+	expectIPCacheUpdate("delete", netip.MustParsePrefix("f00d::/96"))
 
 	select {
 	case event := <-ipcacheMock.events:


### PR DESCRIPTION
This PR introduces support for tunnel routing with the Multi-Pool IPAM mode. This is achieved by removing the reliance on the tunnel map as a fallback mechanism and instead use Pod CIDR entries in IPCache that act as this fallback. The pod CIDR entries contain the node's tunnel endpoint and encryption key and have the `reserved:world` identity (i.e. the same identity as the existing catch-all fallback, which would have been hit before this PR). 

The bulk of the work in this PR was done by @pippolo84. This PR is a replacement for his PR https://github.com/cilium/cilium/pull/37146 with a few notable changes:

1. The first commit has been reworked to add unit tests and fix up some issues in the previous version (c.f. https://github.com/cilium/cilium/pull/37146#discussion_r1973593637).
2. A commit has been added adding some unit tests to the IPCache package emulating some of the expected corner cases.
3. Commit `node: Remove insertions and deletions to tunnel map` has been dropped. In other words, even though the tunnel map is no longer used in the `main` branch, we still populate it. This addresses concerns with regards to downgrades.
4. The Conformance Multi-Pool workflow has been extended to also test in tunnel mode.

This change will eventually allow us to remove the tunnel map completely (ref https://github.com/cilium/cilium/issues/20170).