### PR TITLE
CI/eks: test awsEnablePrefixDelegation in CI

### DIFF
--- a/.github/actions/eks/k8s-versions-schema.yaml
+++ b/.github/actions/eks/k8s-versions-schema.yaml
@@ -6,3 +6,4 @@ includeItem:
   default: bool(required=False)
   ipsec: bool(required=False)
   kpr: bool(required=False)
+  aws-eni-pd: bool(required=False)

--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -11,6 +11,7 @@ include:
     default: true
     ipsec: true
     kpr: true
+    aws-eni-pd: true
   - version: "1.32"
     region: us-east-1
     ipsec: true

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -231,6 +231,9 @@ jobs:
           if [[ "${{ matrix.kpr }}" == "true" ]]; then
             CILIUM_INSTALL_DEFAULTS+=" --helm-set kubeProxyReplacement=true"
           fi
+          if [[ "${{ matrix.aws-eni-pd }}" == "true" ]]; then
+            CILIUM_INSTALL_DEFAULTS+=" --helm-set eni.awsEnablePrefixDelegation=true"
+          fi
 
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --test-concurrency=3 \
             --log-code-owners --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \


### PR DESCRIPTION
- Enable the `awsEnablePrefixDelegation` in CI for eks so we can test it as the first step to enable `awsEnablePrefixDelegation` as the default values

Fixes: #37975

```release-note
Test the awsEnablePrefixDelegation in CI for eks
```
