### PR TITLE
labelsfilter: Add serviceaccount label in the default labels

### DIFF
--- a/Documentation/operations/performance/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/performance/scalability/identity-relevant-labels.rst
@@ -51,15 +51,16 @@ for identities. Additionally, when at least one inclusive label pattern is
 configured, the following inclusive label patterns are automatically added to
 the configuration:
 
-========================================== =====================================================
-Label                                      Description
------------------------------------------- -----------------------------------------------------
-``reserved:.*``                            Include all ``reserved:`` labels
-``io\.kubernetes\.pod\.namespace``         Include all ``io.kubernetes.pod.namespace`` labels
-``io\.cilium\.k8s\.namespace\.labels``     Include all ``io.cilium.k8s.namespace.labels`` labels
-``io\.cilium\.k8s\.policy\.cluster``       Include all ``io.cilium.k8s.policy.cluster`` labels
-``app\.kubernetes\.io``                    Include all ``app.kubernetes.io`` labels
-========================================== =====================================================
+=================================================== =========================================================
+Label                                               Description
+--------------------------------------------------- ---------------------------------------------------------
+``reserved:.*``                                     Include all ``reserved:`` labels
+``io\.kubernetes\.pod\.namespace``                  Include all ``io.kubernetes.pod.namespace`` labels
+``io\.cilium\.k8s\.namespace\.labels``              Include all ``io.cilium.k8s.namespace.labels`` labels
+``io\.cilium\.k8s\.policy\.cluster``                Include all ``io.cilium.k8s.policy.cluster`` labels
+``io\.cilium\.k8s\.policy\.serviceaccount``         Include all ``io.cilium.k8s.policy.serviceaccount`` labels
+``app\.kubernetes\.io``                             Include all ``app.kubernetes.io`` labels
+=================================================== =========================================================
 
 
 
@@ -147,6 +148,7 @@ evaluating Cilium identities:
 - io\.kubernetes\.pod\.namespace
 - io\.cilium\.k8s.namespace\.labels
 - io\.cilium\.k8s\.policy\.cluster
+- io\.cilium\.k8s\.policy\.serviceaccount
 - app\.kubernetes\.io
 
 Note that ``io.kubernetes.pod.namespace`` is already included in default

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -301,6 +301,11 @@ communicating via the proxy must reconnect to re-establish connections.
   BGP CRDs (``CiliumBGPClusterConfig``, ``CiliumBGPPeerConfig``, ``CiliumBGPAdvertisement``, ``CiliumBGPNodeConfigOverride``) to configure BGP.
 * The check for connectivity to the Kubernetes apiserver has been removed from the cilium-agent liveness probe. This can be turned back on
   by setting the helm option ``livenessProbe.requireK8sConnectivity`` to ``true``.
+* The label ``io.cilium.k8s.policy.serviceaccount`` will be included in the default label list. If you configure your own identity-relevant labels 
+  on your cluster, the number of identities will temporarily increase during the upgrade, which will result in increased drops. If you would like 
+  to disable this new behavior, you can add ``!io\.cilium\.k8s\.policy\.serviceaccount`` to your identity-relevant labels to 
+  exclude the ``io.cilium.k8s.policy.serviceaccount`` label.
+
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -716,6 +716,7 @@ selftests
 serverinfo
 serviceAccount
 serviceMonitor
+serviceaccount
 setrlimit
 sfc
 sg

--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -220,6 +220,7 @@ func defaultLabelPrefixCfg() *labelPrefixCfg {
 		regexp.QuoteMeta(k8sConst.PodNamespaceMetaLabels),               // include all namespace labels
 		regexp.QuoteMeta(k8sConst.AppKubernetes),                        // include app.kubernetes.io
 		regexp.QuoteMeta(k8sConst.PolicyLabelCluster),                   // include io.cilium.k8s.policy.cluster
+		regexp.QuoteMeta(k8sConst.PolicyLabelServiceAccount),            // include io.cilium.k8s.policy.serviceaccount
 		`!io\.kubernetes`,                                               // ignore all other io.kubernetes labels
 		`!kubernetes\.io`,                                               // ignore all other kubernetes.io labels
 		"!" + regexp.QuoteMeta(k8sConst.StatefulSetPodNameLabel),        // ignore statefulset.kubernetes.io/pod-name label

--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -16,12 +16,13 @@ import (
 
 func TestFilterLabels(t *testing.T) {
 	wanted := labels.Labels{
-		"id.lizards":                   labels.NewLabel("id.lizards", "web", labels.LabelSourceContainer),
-		"id.lizards.k8s":               labels.NewLabel("id.lizards.k8s", "web", labels.LabelSourceK8s),
-		"io.kubernetes.pod.namespace":  labels.NewLabel("io.kubernetes.pod.namespace", "default", labels.LabelSourceContainer),
-		"app.kubernetes.io":            labels.NewLabel("app.kubernetes.io", "my-nginx", labels.LabelSourceContainer),
-		"foo2.lizards.k8s":             labels.NewLabel("foo2.lizards.k8s", "web", labels.LabelSourceK8s),
-		"io.cilium.k8s.policy.cluster": labels.NewLabel("io.cilium.k8s.policy.cluster", "default", labels.LabelSourceContainer),
+		"id.lizards":                          labels.NewLabel("id.lizards", "web", labels.LabelSourceContainer),
+		"id.lizards.k8s":                      labels.NewLabel("id.lizards.k8s", "web", labels.LabelSourceK8s),
+		"io.kubernetes.pod.namespace":         labels.NewLabel("io.kubernetes.pod.namespace", "default", labels.LabelSourceContainer),
+		"app.kubernetes.io":                   labels.NewLabel("app.kubernetes.io", "my-nginx", labels.LabelSourceContainer),
+		"foo2.lizards.k8s":                    labels.NewLabel("foo2.lizards.k8s", "web", labels.LabelSourceK8s),
+		"io.cilium.k8s.policy.cluster":        labels.NewLabel("io.cilium.k8s.policy.cluster", "default", labels.LabelSourceContainer),
+		"io.cilium.k8s.policy.serviceaccount": labels.NewLabel("io.cilium.k8s.policy.serviceaccount", "luke", labels.LabelSourceContainer),
 	}
 
 	err := ParseLabelPrefixCfg([]string{":!ignor[eE]", "id.*", "foo"}, []string{}, "")
@@ -47,22 +48,24 @@ func TestFilterLabels(t *testing.T) {
 		"annotation.kubernetes.io/config.seen":                      "2017-05-30T14:22:17.691491034Z",
 		"controller-revision-hash":                                  "123456",
 		"io.cilium.k8s.policy.cluster":                              "default",
+		"io.cilium.k8s.policy.serviceaccount":                       "luke",
 	}
 	allLabels := labels.Map2Labels(allNormalLabels, labels.LabelSourceContainer)
 	filtered, _ := dlpcfg.filterLabels(allLabels)
-	require.Len(t, filtered, 3)
+
+	require.Len(t, filtered, 4)
 	allLabels["id.lizards"] = labels.NewLabel("id.lizards", "web", labels.LabelSourceContainer)
 	allLabels["id.lizards.k8s"] = labels.NewLabel("id.lizards.k8s", "web", labels.LabelSourceK8s)
 	filtered, _ = dlpcfg.filterLabels(allLabels)
-	require.Len(t, filtered, 5)
+	require.Len(t, filtered, 6)
 	// Checking that it does not need to an exact match of "foo", but "foo2" also works since it's not a regex
 	allLabels["foo2.lizards.k8s"] = labels.NewLabel("foo2.lizards.k8s", "web", labels.LabelSourceK8s)
 	filtered, _ = dlpcfg.filterLabels(allLabels)
-	require.Len(t, filtered, 6)
+	require.Len(t, filtered, 7)
 	// Checking that "foo" only works if it's the prefix of a label
 	allLabels["lizards.foo.lizards.k8s"] = labels.NewLabel("lizards.foo.lizards.k8s", "web", labels.LabelSourceK8s)
 	filtered, _ = dlpcfg.filterLabels(allLabels)
-	require.Len(t, filtered, 6)
+	require.Len(t, filtered, 7)
 	require.Equal(t, wanted, filtered)
 	// Making sure we are deep copying the labels
 	allLabels["id.lizards"] = labels.NewLabel("id.lizards", "web", "I can change this and doesn't affect any one")
@@ -71,15 +74,16 @@ func TestFilterLabels(t *testing.T) {
 
 func TestDefaultFilterLabels(t *testing.T) {
 	wanted := labels.Labels{
-		"app.kubernetes.io":            labels.NewLabel("app.kubernetes.io", "my-nginx", labels.LabelSourceContainer),
-		"id.lizards.k8s":               labels.NewLabel("id.lizards.k8s", "web", labels.LabelSourceK8s),
-		"id.lizards":                   labels.NewLabel("id.lizards", "web", labels.LabelSourceContainer),
-		"ignorE":                       labels.NewLabel("ignorE", "foo", labels.LabelSourceContainer),
-		"ignore":                       labels.NewLabel("ignore", "foo", labels.LabelSourceContainer),
-		"host":                         labels.NewLabel("host", "", labels.LabelSourceReserved),
-		"io.kubernetes.pod.namespace":  labels.NewLabel("io.kubernetes.pod.namespace", "default", labels.LabelSourceContainer),
-		"ioXkubernetes":                labels.NewLabel("ioXkubernetes", "foo", labels.LabelSourceContainer),
-		"io.cilium.k8s.policy.cluster": labels.NewLabel("io.cilium.k8s.policy.cluster", "default", labels.LabelSourceContainer),
+		"app.kubernetes.io":                   labels.NewLabel("app.kubernetes.io", "my-nginx", labels.LabelSourceContainer),
+		"id.lizards.k8s":                      labels.NewLabel("id.lizards.k8s", "web", labels.LabelSourceK8s),
+		"id.lizards":                          labels.NewLabel("id.lizards", "web", labels.LabelSourceContainer),
+		"ignorE":                              labels.NewLabel("ignorE", "foo", labels.LabelSourceContainer),
+		"ignore":                              labels.NewLabel("ignore", "foo", labels.LabelSourceContainer),
+		"host":                                labels.NewLabel("host", "", labels.LabelSourceReserved),
+		"io.kubernetes.pod.namespace":         labels.NewLabel("io.kubernetes.pod.namespace", "default", labels.LabelSourceContainer),
+		"ioXkubernetes":                       labels.NewLabel("ioXkubernetes", "foo", labels.LabelSourceContainer),
+		"io.cilium.k8s.policy.cluster":        labels.NewLabel("io.cilium.k8s.policy.cluster", "default", labels.LabelSourceContainer),
+		"io.cilium.k8s.policy.serviceaccount": labels.NewLabel("io.cilium.k8s.policy.serviceaccount", "luke", labels.LabelSourceContainer),
 	}
 
 	err := ParseLabelPrefixCfg([]string{}, []string{}, "")
@@ -109,6 +113,7 @@ func TestDefaultFilterLabels(t *testing.T) {
 		"batch.kubernetes.io/job-completion-index":                  "42",
 		"apps.kubernetes.io/pod-index":                              "0",
 		"io.cilium.k8s.policy.cluster":                              "default",
+		"io.cilium.k8s.policy.serviceaccount":                       "luke",
 	}
 	allLabels := labels.Map2Labels(allNormalLabels, labels.LabelSourceContainer)
 	allLabels["host"] = labels.NewLabel("host", "", labels.LabelSourceReserved)
@@ -122,43 +127,60 @@ func TestDefaultFilterLabels(t *testing.T) {
 
 func TestFilterLabelsDocExample(t *testing.T) {
 	wanted := labels.Labels{
-		"k8s-app-team":                labels.NewLabel("k8s-app-team", "foo", labels.LabelSourceK8s),
-		"app-production":              labels.NewLabel("app-production", "foo", labels.LabelSourceK8s),
-		"name-defined":                labels.NewLabel("name-defined", "foo", labels.LabelSourceK8s),
-		"kind":                        labels.NewLabel("kind", "foo", labels.LabelSourceK8s),
-		"other":                       labels.NewLabel("other", "foo", labels.LabelSourceK8s),
-		"host":                        labels.NewLabel("host", "", labels.LabelSourceReserved),
-		"io.kubernetes.pod.namespace": labels.NewLabel("io.kubernetes.pod.namespace", "docker", labels.LabelSourceK8s),
+
+		"io.cilium.k8s.namespace.labels":      labels.NewLabel("io.cilium.k8s.namespace.labels", "foo", labels.LabelSourceK8s),
+		"k8s-app-team":                        labels.NewLabel("k8s-app-team", "foo", labels.LabelSourceK8s),
+		"app-production":                      labels.NewLabel("app-production", "foo", labels.LabelSourceK8s),
+		"name-defined":                        labels.NewLabel("name-defined", "foo", labels.LabelSourceK8s),
+		"kind":                                labels.NewLabel("kind", "foo", labels.LabelSourceK8s),
+		"other":                               labels.NewLabel("other", "foo", labels.LabelSourceK8s),
+		"host":                                labels.NewLabel("host", "", labels.LabelSourceReserved),
+		"io.kubernetes.pod.namespace":         labels.NewLabel("io.kubernetes.pod.namespace", "docker", labels.LabelSourceK8s),
+		"io.cilium.k8s.policy.cluster":        labels.NewLabel("io.cilium.k8s.policy.cluster", "default", labels.LabelSourceK8s),
+		"io.cilium.k8s.policy.serviceaccount": labels.NewLabel("io.cilium.k8s.policy.serviceaccount", "luke", labels.LabelSourceK8s),
 	}
 
-	err := ParseLabelPrefixCfg([]string{"k8s:io.kubernetes.pod.namespace", "k8s:k8s-app", "k8s:app", "k8s:name", "k8s:kind", "k8s:other"}, []string{}, "")
+	err := ParseLabelPrefixCfg([]string{"k8s:io.kubernetes.pod.namespace", "k8s:k8s-app", "k8s:app", "k8s:name", "k8s:kind$", "k8s:other$"}, []string{}, "")
 	require.NoError(t, err)
 	dlpcfg := validLabelPrefixes
 	allNormalLabels := map[string]string{
-		"k8s-app-team":   "foo",
-		"app-production": "foo",
-		"name-defined":   "foo",
-		"kind":           "foo",
-		"other":          "foo",
+		"io.cilium.k8s.namespace.labels": "foo",
+		"k8s-app-team":                   "foo",
+		"app-production":                 "foo",
+		"name-defined":                   "foo",
+		"kind":                           "foo",
+		"other":                          "foo",
 	}
 	allLabels := labels.Map2Labels(allNormalLabels, labels.LabelSourceK8s)
 	filtered, _ := dlpcfg.filterLabels(allLabels)
-	require.Len(t, filtered, 5)
+	require.Len(t, filtered, 6)
 
 	// Reserved labels are included.
 	allLabels["host"] = labels.NewLabel("host", "", labels.LabelSourceReserved)
 	filtered, _ = dlpcfg.filterLabels(allLabels)
-	require.Len(t, filtered, 6)
+
+	require.Len(t, filtered, 7)
 
 	// io.kubernetes.pod.namespace=docker matches because the default list has k8s:io.kubernetes.pod.namespace.
 	allLabels["io.kubernetes.pod.namespace"] = labels.NewLabel("io.kubernetes.pod.namespace", "docker", labels.LabelSourceK8s)
 	filtered, _ = dlpcfg.filterLabels(allLabels)
-	require.Len(t, filtered, 7)
 
+	require.Len(t, filtered, 8)
+
+	// io.cilium.k8s.policy.cluster=default matches because the default list has k8s:io.cilium.k8s.policy.cluster.
+	allLabels["io.cilium.k8s.policy.cluster"] = labels.NewLabel("io.cilium.k8s.policy.cluster", "default", labels.LabelSourceK8s)
+	filtered, _ = dlpcfg.filterLabels(allLabels)
+	require.Len(t, filtered, 9)
+
+	// io.cilium.k8s.policy.serviceaccount=default matches because the default list has k8s:io.cilium.k8s.policy.serviceaccount.
+	allLabels["io.cilium.k8s.policy.serviceaccount"] = labels.NewLabel("io.cilium.k8s.policy.serviceaccount", "luke", labels.LabelSourceK8s)
+	filtered, _ = dlpcfg.filterLabels(allLabels)
+	require.Len(t, filtered, 10)
 	// container:k8s-app-role=foo doesn't match because it doesn't have source k8s.
 	allLabels["k8s-app-role"] = labels.NewLabel("k8s-app-role", "foo", labels.LabelSourceContainer)
 	filtered, _ = dlpcfg.filterLabels(allLabels)
-	require.Len(t, filtered, 7)
+
+	require.Len(t, filtered, 10)
 	require.Equal(t, wanted, filtered)
 }
 


### PR DESCRIPTION
- Add serviceaccount label in the default labels list
- Update the unit test
- Update the doc

Fixes: #36923

```release-note
Add serviceaccount label in the default labels list
```
