### PR TITLE
proxy: Provide DefaultDNSProxy as a Hive Cell

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -67,6 +67,7 @@ import (
 	policyK8s "github.com/cilium/cilium/pkg/policy/k8s"
 	"github.com/cilium/cilium/pkg/pprof"
 	"github.com/cilium/cilium/pkg/proxy"
+	"github.com/cilium/cilium/pkg/proxy/defaultdns"
 	"github.com/cilium/cilium/pkg/recorder"
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 	"github.com/cilium/cilium/pkg/service"
@@ -140,6 +141,10 @@ var (
 
 		// Shell for inspecting the agent. Listens on the 'shell.sock' UNIX socket.
 		shellCell,
+
+		// DNSProxy provides the DefaultDNSProxy singleton which is used by different
+		// pacakges.
+		defaultdns.Cell,
 	)
 
 	// ControlPlane implement the per-node control functions. These are pure

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -99,6 +99,7 @@ import (
 	policyDirectory "github.com/cilium/cilium/pkg/policy/directory"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy"
+	"github.com/cilium/cilium/pkg/proxy/defaultdns"
 	"github.com/cilium/cilium/pkg/proxy/logger"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/redirectpolicy"
@@ -1585,6 +1586,7 @@ type daemonParams struct {
 	MaglevConfig        maglev.Config
 	NameManager         namemanager.NameManager
 	ExpLBConfig         experimental.Config
+	DNSProxy            defaultdns.Proxy
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cilium/cilium/pkg/mac"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/resiliency"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -1179,14 +1178,15 @@ func (d *Daemon) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), e
 }
 
 func (d *Daemon) GetDNSRules(epID uint16) restore.DNSRules {
-	if proxy.DefaultDNSProxy == nil {
+	dnsProxy := d.dnsProxy.Get()
+	if dnsProxy == nil {
 		return nil
 	}
 
 	// We get the latest consistent view on the DNS rules by getting handle to the latest
 	// coherent state of the selector cache
 	version := d.policy.GetSelectorCache().GetVersionHandle()
-	rules, err := proxy.DefaultDNSProxy.GetRules(version, epID)
+	rules, err := dnsProxy.GetRules(version, epID)
 	version.Close()
 
 	if err != nil {
@@ -1197,9 +1197,10 @@ func (d *Daemon) GetDNSRules(epID uint16) restore.DNSRules {
 }
 
 func (d *Daemon) RemoveRestoredDNSRules(epID uint16) {
-	if proxy.DefaultDNSProxy == nil {
+	dnsProxy := d.dnsProxy.Get()
+	if dnsProxy == nil {
 		return
 	}
 
-	proxy.DefaultDNSProxy.RemoveRestoredRules(epID)
+	dnsProxy.RemoveRestoredRules(epID)
 }

--- a/pkg/proxy/cell.go
+++ b/pkg/proxy/cell.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/proxy/defaultdns"
 	"github.com/cilium/cilium/pkg/proxy/logger"
 	"github.com/cilium/cilium/pkg/proxy/logger/endpoint"
 	"github.com/cilium/cilium/pkg/proxy/proxyports"
@@ -115,10 +116,12 @@ func newEnvoyProxyIntegration(params envoyProxyIntegrationParams) *envoyProxyInt
 	}
 }
 
-func newDNSProxyIntegration() *dnsProxyIntegration {
+func newDNSProxyIntegration(dnsProxy defaultdns.Proxy) *dnsProxyIntegration {
 	if !option.Config.EnableL7Proxy {
 		return nil
 	}
 
-	return &dnsProxyIntegration{}
+	return &dnsProxyIntegration{
+		dnsProxy: dnsProxy,
+	}
 }

--- a/pkg/proxy/defaultdns/cell.go
+++ b/pkg/proxy/defaultdns/cell.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package defaultdns
+
+import "github.com/cilium/hive/cell"
+
+// Cell provides the DefaultDNSProxy for the entire process.
+var Cell = cell.Module(
+	"default-dns-proxy",
+	"Provides the DefaultDNSProxy for the entire process",
+
+	cell.Provide(NewProxy),
+)

--- a/pkg/proxy/defaultdns/default_dns_proxy.go
+++ b/pkg/proxy/defaultdns/default_dns_proxy.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package defaultdns
+
+import (
+	"github.com/cilium/cilium/pkg/fqdn/proxy"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// NewProxy instantiates the Proxy singleton.
+func NewProxy() Proxy {
+	return &defaultProxy{
+		mu: &lock.RWMutex{},
+	}
+}
+
+// Proxy represents the interface setting
+// and getting the default dns proxy. It
+// is an interface so that it can be mocked.
+type Proxy interface {
+	Get() proxy.DNSProxier
+	Set(proxy.DNSProxier)
+}
+
+// defaultProxy is the default dns proxy getter
+// and setter for the process.
+type defaultProxy struct {
+	mu    *lock.RWMutex
+	proxy proxy.DNSProxier
+}
+
+// Set sets the DefaultDNSProxy
+func (p *defaultProxy) Set(dnsProxy proxy.DNSProxier) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.proxy = dnsProxy
+}
+
+// Get gets the DefaultDNSProxy
+func (p *defaultProxy) Get() proxy.DNSProxier {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.proxy
+}


### PR DESCRIPTION
DefaultDNSProxy is a singleton that has been in the codebase for a while. It is get and set by various daemon methods without synchronization. Providing the singleton via a Cell allows for synchronization control and removes the ugliness of using a package singleton.
