### PR TITLE
[v1.15] job: handle ctx cancellation in complete function

### DIFF
--- a/pkg/hive/job/job.go
+++ b/pkg/hive/job/job.go
@@ -615,7 +615,7 @@ func (jo *jobObserver[T]) start(ctx context.Context, wg *sync.WaitGroup, scope c
 	<-done
 
 	jo.health.Stopped("observer job done")
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		l.WithError(err).Error("Observer job stopped with an error")
 	} else {
 		l.WithError(err).Debug("Observer job stopped")


### PR DESCRIPTION
Currently, the termination of an observer job due to context cancellation is logged as error. This might be confusing and lead to unnecessary noise (e.g. in case of graceful shutdown).

The next function already handles the context cancellation differently too.

Therefore, this commit only logs the error, if it's not of type `context.Canceled`.

---

Author Backport of: https://github.com/cilium/hive/pull/23 (and including cilium/hive update)

In the v1.15 branch - the Hive Job framework is still in-tree and not extracted into its own Go Module `github.com/cilium/hive`.

Fixes: https://github.com/cilium/cilium/issues/35581