### PR TITLE
pkg: loader: remove cleanup of legacy cilium_calls_xdp map

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -325,10 +325,6 @@ func reinitializeXDPLocked(ctx context.Context, extraCArgs []string, devices []s
 		}
 	}
 
-	// Clean up the legacy cilium_calls_xdp path.
-	// TODO:  Remove in Cilium 1.17.
-	os.Remove(filepath.Join(bpf.TCGlobalsPath(), "cilium_calls_xdp"))
-
 	return nil
 }
 


### PR DESCRIPTION
We shipped this cleanup logic in v1.16, and so the map shouldn't exist anymore on any newer release. We can stop cleaning it up.