### PR TITLE
gha: bump timeout of K8s Network E2E tests test

### DIFF
--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -27,7 +27,7 @@ jobs:
   kubernetes-e2e:
     name: K8s Network E2E tests
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This workflow is often failing due to hitting the timeout, probably because it is now executing more tasks. Let's bump the timeout to prevent this problem.

