### PR TITLE
ci: switch to monitor aggregation medium

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -81,7 +81,6 @@ runs:
             --helm-set=debug.verbose=envoy \
             --helm-set=debug.metricsSamplingInterval=30s \
             --helm-set=hubble.eventBufferCapacity=65535 \
-            --helm-set=bpf.monitorAggregation=none \
             --helm-set=cluster.name=default \
             --helm-set=authentication.mutual.spire.enabled=${{ inputs.mutual-auth }} \
             --nodes-without-cilium \

--- a/.github/actions/helm-default/action.yaml
+++ b/.github/actions/helm-default/action.yaml
@@ -28,7 +28,6 @@ runs:
           --helm-set=debug.enabled=true \
           --helm-set=debug.verbose=envoy \
           --helm-set=debug.metricsSamplingInterval=30s \
-          --helm-set=bpf.monitorAggregation=none \
           --helm-set=hubble.relay.retryTimeout=5s \
           --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
           --helm-set=image.useDigest=false \

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -222,7 +222,6 @@ jobs:
             --helm-set=cluster.name=${{ env.clusterName }} \
             --helm-set=hubble.relay.enabled=true \
             --helm-set loadBalancer.l7.backend=envoy \
-            --helm-set=bpf.monitorAggregation=none \
             --wait=false"
           if [[ "${{ matrix.ipsec }}" == "true" ]]; then
             CILIUM_INSTALL_DEFAULTS+=" --helm-set encryption.enabled=true --helm-set encryption.type=ipsec"

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -188,7 +188,6 @@ jobs:
           #   occurring in the meanwhile.
           CILIUM_INSTALL_DEFAULTS=" \
             --set=debug.enabled=true \
-            --set=bpf.monitorAggregation=medium \
             --set=hubble.enabled=true \
             --set=routingMode=tunnel \
             --set=tunnelProtocol=vxlan \


### PR DESCRIPTION
Switch all workflows from monitorAggregation=none to **default** monitorAggregation=medium value.
Current workflows are often CPU contrained during test execution.
Switching back to default aggregation lowers total time of workflows by ~10-20% and hopefully also reduced flakiness.
Additionally, monitorAggregation=none often causes test flows to be missing when sysdump is taken.

Example CPU after change: https://camo.githubusercontent.com/81117e8831857e830e5cdf9de050e45f39495552ee078dda27f423e0459754b7/68747470733a2f2f6170692e676c6f62616467652e636f6d2f76312f636861727467656e2f737461636b65642d617265612f74696d652f63686172745f737461636b65645f617265615f74696d655f35613963356330312d363036662d346264342d623461372d383331393638623765353366
Example CPU before change:
https://camo.githubusercontent.com/35f8f323c6de7488a27a25564e612d09a44ed62a76727603552d067ca2451b86/68747470733a2f2f6170692e676c6f62616467652e636f6d2f76312f636861727467656e2f737461636b65642d617265612f74696d652f63686172745f737461636b65645f617265615f74696d655f36333837313165312d613134342d343136642d623862392d643536383066353130316262
