### PR TITLE
k8s: move portforward functionality to separate sub-package

### DIFF
--- a/cilium-cli/connectivity/check/metrics.go
+++ b/cilium-cli/connectivity/check/metrics.go
@@ -12,7 +12,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 
-	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/portforward"
 )
 
 // metricsURLFormat is the path format to retrieve the metrics on the
@@ -68,12 +68,12 @@ func (a *Action) collectMetricsForPod(pod Pod, port string) (promMetricsFamily, 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	p := k8s.PortForwardParameters{
+	p := portforward.PortForwardParameters{
 		Namespace:  pod.Namespace(),
 		Pod:        pod.NameWithoutNamespace(),
 		Ports:      []string{fmt.Sprintf(":%s", port)},
 		Addresses:  nil, // default is localhost
-		OutWriters: k8s.OutWriters{Out: &debugWriter{ct: a.test.ctx}, ErrOut: &warnWriter{ct: a.test.ctx}},
+		OutWriters: portforward.OutWriters{Out: &debugWriter{ct: a.test.ctx}, ErrOut: &warnWriter{ct: a.test.ctx}},
 	}
 
 	// Call the k8s dialer to port forward,

--- a/cilium-cli/k8s/dialer.go
+++ b/cilium-cli/k8s/dialer.go
@@ -6,13 +6,13 @@ package k8s
 import (
 	"context"
 
-	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/portforward"
 )
 
 // PortForward executes in a goroutine a port forward command.
 // To stop the port-forwarding, use the context by cancelling it
-func (c *Client) PortForward(ctx context.Context, p k8s.PortForwardParameters) (*k8s.PortForwardResult, error) {
-	return k8s.NewPortForwarder(c.Clientset, c.Config).PortForward(ctx, p)
+func (c *Client) PortForward(ctx context.Context, p portforward.PortForwardParameters) (*portforward.PortForwardResult, error) {
+	return portforward.NewPortForwarder(c.Clientset, c.Config).PortForward(ctx, p)
 }
 
 // PortForwardService executes in a goroutine a port forward command towards one of the pod behind a
@@ -20,6 +20,6 @@ func (c *Client) PortForward(ctx context.Context, p k8s.PortForwardParameters) (
 // configured on the service.
 //
 // To stop the port-forwarding, use the context by cancelling it.
-func (c *Client) PortForwardService(ctx context.Context, namespace, name string, localPort, svcPort int32) (*k8s.PortForwardServiceResult, error) {
-	return k8s.NewPortForwarder(c.Clientset, c.Config).PortForwardService(ctx, namespace, name, localPort, svcPort)
+func (c *Client) PortForwardService(ctx context.Context, namespace, name string, localPort, svcPort int32) (*portforward.PortForwardServiceResult, error) {
+	return portforward.NewPortForwarder(c.Clientset, c.Config).PortForwardService(ctx, namespace, name, localPort, svcPort)
 }

--- a/hubble/cmd/common/conn/conn.go
+++ b/hubble/cmd/common/conn/conn.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cilium/cilium/hubble/cmd/common/config"
 	"github.com/cilium/cilium/hubble/pkg/defaults"
 	"github.com/cilium/cilium/hubble/pkg/logger"
-	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/portforward"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -98,7 +98,7 @@ func NewWithFlags(ctx context.Context, vp *viper.Viper) (*grpc.ClientConn, error
 	return conn, nil
 }
 
-func newPortForwarder(context, kubeconfig string) (*k8s.PortForwarder, error) {
+func newPortForwarder(context, kubeconfig string) (*portforward.PortForwarder, error) {
 	restClientGetter := genericclioptions.ConfigFlags{
 		Context:    &context,
 		KubeConfig: &kubeconfig,
@@ -115,6 +115,6 @@ func newPortForwarder(context, kubeconfig string) (*k8s.PortForwarder, error) {
 		return nil, err
 	}
 
-	pf := k8s.NewPortForwarder(clientset, config)
+	pf := portforward.NewPortForwarder(clientset, config)
 	return pf, nil
 }

--- a/pkg/k8s/portforward/portforward.go
+++ b/pkg/k8s/portforward/portforward.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package k8s
+package portforward
 
 import (
 	"context"


### PR DESCRIPTION
The k8s package currently is a catch-all package for all kind of k8s-related functionality. By itself it already has a prettly large list of (transitive) dependencies, among them packages specific to the datapath or the underlying operating system. This becomes problematic once cross-built tools such as Cilium CLI or Hubble CLI start depending on pkg/k8s as is the case since the portforward functionality was added in commit ae0d2f3fb6fd ("cilium-cli: extract portforward logic into new PortForwarder type") and they transitively start depending on the platform-specific pacakges such as pkg/datapath.

This commit fixes that by moving the portforward functionality to pkg/k8s/portforward which is easy because it doesn't depend on any other code in pkg/k8s. This should help to break these transitive dependencies.

Towards #37598
