### PR TITLE
ci: build CI images within merge group

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -11,6 +11,8 @@ on:
     branches:
       - main
       - ft/main/**
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   # To be able to access the repository with `actions/checkout`


### PR DESCRIPTION
Previously, images build by push event sometimes failed. As a result, this caused scheduled workflows and upgrade/downgrade tests to fail as images were missing. Let's add building CI images as part of merge_group so we always have images to test against.

I've added label `dont-merge/discussion` to wait for early-morning hours to merge this PR.