### PR TITLE
bpf: tolerate dropped ICMPv6 messages with ICMPv6 payload

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1630,6 +1630,8 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off)
 
 		port_off = TCP_DPORT_OFF;
 		break;
+	case IPPROTO_ICMPV6:
+		return DROP_UNKNOWN_ICMP6_CODE;
 	default:
 		return DROP_UNKNOWN_L4;
 	}

--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -148,6 +148,7 @@ var (
 		"Unknown L3 target address",
 		"Host datapath not ready",
 		"Unknown ICMPv4 code",
+		"Unknown ICMPv6 code",
 		"Forbidden ICMPv6 message",
 		"No egress gateway found",
 	}


### PR DESCRIPTION
Add a bit of polish for https://github.com/cilium/cilium/pull/37766, until we have proper SNAT support for ICMPv6 messages with ICMPv6 payload.

This allows us to filter out such "known" gaps in the CLI connectivity tests.