### PR TITLE
build: set runtime image directory as variable

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -14,6 +14,7 @@ endif
 
 PLATFORMS=linux/amd64,linux/arm64
 RUNTIME_IMAGE=quay.io/cilium/cilium-runtime
+RUNTIME_DIRECTORY?=images/runtime
 
 all-images: lint runtime-image builder-image cilium-image operator-image hubble-relay-image
 
@@ -26,13 +27,13 @@ lint:
 	docker buildx create --platform $(PLATFORMS) --buildkitd-flags '--debug' > $@
 
 runtime-image: .buildx_builder
-	TEST=true scripts/build-image.sh cilium-runtime-dev images/runtime $(PLATFORMS) $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
+	TEST=true scripts/build-image.sh cilium-runtime-dev $(RUNTIME_DIRECTORY) $(PLATFORMS) $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
 
 update-runtime-image:
-	scripts/update-cilium-runtime-image.sh $(RUNTIME_IMAGE)
+	scripts/update-cilium-runtime-image.sh $(RUNTIME_IMAGE) $(RUNTIME_DIRECTORY)
 
 check-runtime-image:
-	CHECK=true scripts/update-cilium-runtime-image.sh $(RUNTIME_IMAGE)
+	CHECK=true scripts/update-cilium-runtime-image.sh $(RUNTIME_IMAGE) $(RUNTIME_DIRECTORY)
 
 builder-image: .buildx_builder
 	TEST=true scripts/build-image.sh cilium-builder-dev images/builder $(PLATFORMS) $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)

--- a/images/scripts/update-cilium-runtime-image.sh
+++ b/images/scripts/update-cilium-runtime-image.sh
@@ -16,6 +16,7 @@ cd "${root_dir}"
 
 # Retrieve image from parameter and remove tag if one was provided, let make-image-tag in charge of creating the tag
 image=${1}
+image_dir=${2}
 image="${image%%:*}"
 
 image_tag="$(WITHOUT_SUFFIX=1 "${script_dir}/make-image-tag.sh" images/runtime)"
@@ -26,4 +27,4 @@ if [ -n "${sha256}" ]; then
   image_full="${image_full}@${sha256}"
 fi
 
-"${script_dir}/../runtime/update-cilium-runtime-image.sh" "${image_full}"
+"${script_dir}/../../${image_dir}/update-cilium-runtime-image.sh" "${image_full}"


### PR DESCRIPTION
This commit variabilize the image directory in :
- images/scripts/update-cilium-runtime-image.sh
- images/Makefile

This will ease the possibility to move cilium-runtime image directory and allow forks to override this variable if they want to use another runtime image.

```release-note
Set runtime image directory as variable in images/scripts/update-cilium-runtime-image.sh & images/Makefile
```
