### PR TITLE
Add: `cilium-dbg shell -- health` command

### DIFF
--- a/cilium-dbg/cmd/status.go
+++ b/cilium-dbg/cmd/status.go
@@ -126,7 +126,9 @@ func statusDaemon() {
 			}
 
 			healthPkg.GetAndFormatHealthStatus(w, allNodes, verbose, healthLines)
-			healthPkg.GetAndFormatModulesHealth(w, ss, allHealth)
+			fmt.Fprintf(w, "Modules Health:")
+			healthPkg.GetAndFormatModulesHealth(w, ss, allHealth, "\t\t")
+			fmt.Fprintln(w)
 		} else {
 			fmt.Fprint(w, "Cluster health:\t\tProbe disabled\n")
 		}

--- a/pkg/health/client/modules_test.go
+++ b/pkg/health/client/modules_test.go
@@ -21,11 +21,10 @@ func TestGetAndFormatModulesHealth(t *testing.T) {
 		v  bool
 	}{
 		"happy": {
-			e: "Modules Health:\tStopped(0) Degraded(2) OK(2)",
+			e: "Stopped(0) Degraded(2) OK(2)",
 		},
 		"happy-verbose": {
-			e: `Modules Health:
-		agent
+			e: `agent
 		├── a
 		│   └── b
 		│       └── c
@@ -43,7 +42,7 @@ func TestGetAndFormatModulesHealth(t *testing.T) {
 		u := uu[k]
 		t.Run(k, func(t *testing.T) {
 			w := bytes.NewBufferString("")
-			client.GetAndFormatModulesHealth(w, getHealth(), u.v)
+			client.GetAndFormatModulesHealth(w, getHealth(), u.v, "\t\t")
 			assert.Equal(t, u.e, strings.TrimSpace(w.String()))
 		})
 	}

--- a/pkg/hive/health/cell.go
+++ b/pkg/hive/health/cell.go
@@ -4,13 +4,12 @@
 package health
 
 import (
-	"github.com/cilium/hive/cell"
-
-	"github.com/cilium/statedb"
-	"github.com/cilium/statedb/index"
-
 	"github.com/cilium/cilium/pkg/hive/health/types"
 	"github.com/cilium/cilium/pkg/metrics"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
 )
 
 var Cell = cell.Module(
@@ -21,10 +20,11 @@ var Cell = cell.Module(
 		newHealthV2Provider,
 		statedb.RWTable[types.Status].ToTable,
 	),
-
 	// Module health metrics.
 	cell.Invoke(metricPublisher),
 	metrics.Metric(newMetrics),
+
+	cell.Provide(healthCommands),
 )
 
 var (

--- a/pkg/hive/health/cmds_test.go
+++ b/pkg/hive/health/cmds_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package health
+
+import (
+	"context"
+	"maps"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/hive/health/types"
+
+	"github.com/cilium/hive"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/cilium/statedb"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthCommands(t *testing.T) {
+	log := hivetest.Logger(t)
+	scripttest.Test(t,
+		context.Background(),
+		func(t testing.TB, args []string) *script.Engine {
+			h := hive.New(
+				statedb.Cell,
+				Cell,
+				job.Cell,
+				cell.Provide(func(lc cell.Lifecycle, p types.Provider, jr job.Registry) job.Group {
+					h := p.ForModule(cell.FullModuleID{"test"})
+					jg := jr.NewGroup(h)
+					lc.Append(jg)
+					return jg
+				}),
+				cell.Invoke(func(p types.Provider) {
+					hr := p.ForModule(cell.FullModuleID{"agent", "m0"})
+					hr.NewScope("c0").OK("ok")
+				}),
+			)
+			t.Cleanup(func() {
+				assert.NoError(t, h.Stop(log, context.TODO()))
+			})
+			cmds, err := h.ScriptCommands(log)
+			require.NoError(t, err, "ScriptCommands")
+			maps.Insert(cmds, maps.All(script.DefaultCmds()))
+			return &script.Engine{
+				Cmds: cmds,
+			}
+		}, []string{}, "testdata/*.txtar")
+}

--- a/pkg/hive/health/command.go
+++ b/pkg/hive/health/command.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package health
+
+import (
+	"os"
+	"slices"
+	"strings"
+
+	healthPkg "github.com/cilium/cilium/pkg/health/client"
+	"github.com/cilium/cilium/pkg/hive/health/types"
+
+	"github.com/cilium/hive"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/statedb"
+
+	"github.com/spf13/pflag"
+)
+
+func healthCommands(db *statedb.DB, table statedb.Table[types.Status]) hive.ScriptCmdsOut {
+	return hive.NewScriptCmds(map[string]script.Cmd{
+		"health": healthTreeCommand(db, table),
+	})
+}
+
+func healthTreeCommand(db *statedb.DB, table statedb.Table[types.Status]) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Log health reporter tree",
+			Args:    "[reporter-id-prefix]",
+			Flags: func(fs *pflag.FlagSet) {
+				fs.StringP("match", "m", "", "Output only health reports where the reporter ID path contains the substring")
+				fs.StringArrayP("levels", "s", []string{types.LevelOK, types.LevelDegraded, types.LevelDegraded},
+					"Output only health reports with the specified state (i.e. ok,degraded,stopped)")
+				fs.StringP("output", "o", "", "File to write output to")
+			},
+			Detail: []string{
+				"Prints out a health reporter tree",
+				"If passed prefix is not-empty then only nodes of this subtree",
+				"will be displayed",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			var prefix string
+			if len(args) > 0 {
+				prefix = args[0]
+			}
+
+			match, err := s.Flags.GetString("match")
+			if err != nil {
+				return nil, err
+			}
+
+			levels, err := s.Flags.GetStringArray("levels")
+			if err != nil {
+				return nil, err
+			}
+
+			file, err := s.Flags.GetString("output")
+			if err != nil {
+				return nil, err
+			}
+
+			for i := range levels {
+				levels[i] = strings.ToLower(levels[i])
+			}
+
+			w := s.LogWriter()
+			if file != "" {
+				p := s.Path(file)
+				fd, err := os.Create(p)
+				if err != nil {
+					return nil, err
+				}
+				w = fd
+			}
+
+			ss := getHealth(db, table, prefix, match, levels)
+			healthPkg.GetAndFormatModulesHealth(w, ss, true, "")
+			return nil, nil
+		},
+	)
+}
+
+func getHealth(db *statedb.DB, table statedb.Table[types.Status], prefix, match string, levels []string) []types.Status {
+	ss := []types.Status{}
+	if prefix != "" {
+		tx := db.ReadTxn()
+		for status := range table.Prefix(tx, PrimaryIndex.Query(types.HealthID(prefix))) {
+			ss = append(ss, status)
+		}
+	} else {
+		tx := db.ReadTxn()
+		for status := range table.All(tx) {
+			if match != "" && !strings.Contains(status.ID.String(), match) {
+				continue
+			}
+
+			if !slices.Contains(levels, strings.ToLower(status.Level.String())) {
+				continue
+			}
+
+			ss = append(ss, status)
+		}
+	}
+	return ss
+}

--- a/pkg/hive/health/testdata/health.txtar
+++ b/pkg/hive/health/testdata/health.txtar
@@ -1,0 +1,99 @@
+db/insert health allok.yaml
+
+# Should be all ok
+* health/ok
+
+db/insert health degraded.yaml
+
+# Adding degraded module should fail
+!* health/ok
+
+db/insert health module1.yaml
+
+# Check output
+health --output=out
+sed ' \(.*\)' '' out
+cmp all.expected.txt out
+
+health --output=out agent.m0
+sed ' \(.*\)' '' out
+cmp m0.expected.txt out
+
+health --output=out --levels=degraded 
+sed ' \(.*\)' '' out
+cmp degraded.expected.txt out
+
+-- allok.yaml --
+id:
+    module:
+        - agent
+        - m0
+    component:
+        - c0
+level: OK
+message: ok
+error: ""
+lastok: 2025-04-01T21:28:00.000000000-07:00
+updated: 2025-04-01T21:28:00.000000000-07:00
+stopped: 0001-01-01T00:00:00Z
+final: ""
+count: 1
+-- degraded.yaml --
+id:
+    module:
+        - agent
+        - m0
+    component:
+        - c1
+level: Degraded 
+message: no! 
+error: "err"
+lastok: 2025-04-01T21:28:00.000000000-07:00
+updated: 2025-04-01T21:28:00.000000000-07:00
+stopped: 0001-01-01T00:00:00Z
+final: ""
+count: 1
+-- degraded.txt --
+agent
+└── m0
+    ├── c0                                          [OK] ok (2m27s, x1)
+    └── c1                                          [DEGRADED] no! (2m27s, x1)
+
+-- ok.yaml --
+agent
+└── m0
+    └── c0                                          [OK] ok (3m14s, x1)
+-- module1.yaml --
+id:
+    module:
+        - agent
+        - m1
+    component:
+        - c1
+level: OK 
+message: yay 
+error: ""
+lastok: 2025-04-01T21:28:00.000000000-07:00
+updated: 2025-04-01T21:28:00.000000000-07:00
+stopped: 0001-01-01T00:00:00Z
+final: ""
+count: 1
+-- all.expected.txt --
+agent
+├── m0
+│   ├── c0                                          [OK] ok
+│   └── c1                                          [DEGRADED] no!
+└── m1
+    └── c1                                          [OK] yay
+
+-- m0.expected.txt --
+agent
+└── m0
+    ├── c0                                          [OK] ok
+    └── c1                                          [DEGRADED] no!
+
+-- degraded.expected.txt --
+agent
+└── m0
+    └── c1                                          [DEGRADED] no!
+

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/cilium/hive/cell"
@@ -1392,7 +1393,7 @@ func (m *manager) StartNodeNeighborLinkUpdater(nh datapath.NodeNeighbors) {
 					}
 
 					log.Debugf("Refreshing node neighbor link for %s", e.node.Name)
-					hr := sc.NewScope(e.node.Name)
+					hr := sc.NewScope(strings.ReplaceAll(e.node.Name, ".", "-"))
 					if err := nh.NodeNeighborRefresh(ctx, *e.node); err != nil {
 						hr.Degraded("Failed node neighbor link update", err)
 						errs = errors.Join(errs, err)


### PR DESCRIPTION
Please see commits. Does the following:

* Add `cilium shell -- health` command that takes a optional prefix and prints the reporter tree similar to current `cilium status --verbose` output.
* Add `cilium shell -- health/ok` which asserts that all specified reporters are not degraded.
* Do some minor fixes on health reporter naming periods breaking node manager reporters.  

```release-note
Add `cilium-dbg shell -- health` command that takes a optional prefix and prints the reporter tree similar to current `cilium-dbg status --verbose` output.
```
