### PR TITLE
helm: Allow hostPort and externalIPs without kubeProxyReplacement

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -760,12 +760,12 @@ data:
 {{- end }}
 
 {{- if hasKey .Values "hostPort" }}
-{{- if eq $kubeProxyReplacement "partial" }}
+{{- if or (eq $kubeProxyReplacement "partial") (eq $kubeProxyReplacement "false") }}
   enable-host-port: {{ .Values.hostPort.enabled | quote }}
 {{- end }}
 {{- end }}
 {{- if hasKey .Values "externalIPs" }}
-{{- if eq $kubeProxyReplacement "partial" }}
+{{- if or (eq $kubeProxyReplacement "partial") (eq $kubeProxyReplacement "false") }}
   enable-external-ips: {{ .Values.externalIPs.enabled | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- Description of change -->

Fixes: #38083

Fix hostPort and externalIPs toggles when kubeProxyReplacement is false
