### PR TITLE
datapath: tracing pre/post NAT Port

### DIFF
--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -817,6 +817,7 @@ that happened before the events were captured by Hubble.
 | source_port | [uint32](#uint32) |  |  |
 | destination_port | [uint32](#uint32) |  |  |
 | flags | [TCPFlags](#flow-TCPFlags) |  |  |
+| source_port_xlated | [uint32](#uint32) |  | source_port_xlated is the post-translation source port when the flow was SNATed. When &#34;source_port_xlated&#34; is set, the &#34;source_port&#34; field is populated with the pre-translation source port. |
 
 
 
@@ -921,6 +922,7 @@ TraceParent identifies the incoming request in a tracing system.
 | ----- | ---- | ----- | ----------- |
 | source_port | [uint32](#uint32) |  |  |
 | destination_port | [uint32](#uint32) |  |  |
+| source_port_xlated | [uint32](#uint32) |  | source_port_xlated is the post-translation source port when the flow was SNATed. When &#34;source_port_xlated&#34; is set, the &#34;source_port&#34; field is populated with the pre-translation source port. |
 
 
 

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -2609,8 +2609,12 @@ type TCP struct {
 	SourcePort      uint32                 `protobuf:"varint,1,opt,name=source_port,json=sourcePort,proto3" json:"source_port,omitempty"`
 	DestinationPort uint32                 `protobuf:"varint,2,opt,name=destination_port,json=destinationPort,proto3" json:"destination_port,omitempty"`
 	Flags           *TCPFlags              `protobuf:"bytes,3,opt,name=flags,proto3" json:"flags,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// source_port_xlated is the post-translation source port when the flow was
+	// SNATed. When "source_port_xlated" is set, the "source_port" field is
+	// populated with the pre-translation source port.
+	SourcePortXlated uint32 `protobuf:"varint,4,opt,name=source_port_xlated,json=sourcePortXlated,proto3" json:"source_port_xlated,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *TCP) Reset() {
@@ -2662,6 +2666,13 @@ func (x *TCP) GetFlags() *TCPFlags {
 		return x.Flags
 	}
 	return nil
+}
+
+func (x *TCP) GetSourcePortXlated() uint32 {
+	if x != nil {
+		return x.SourcePortXlated
+	}
+	return 0
 }
 
 type IP struct {
@@ -2909,8 +2920,12 @@ type UDP struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	SourcePort      uint32                 `protobuf:"varint,1,opt,name=source_port,json=sourcePort,proto3" json:"source_port,omitempty"`
 	DestinationPort uint32                 `protobuf:"varint,2,opt,name=destination_port,json=destinationPort,proto3" json:"destination_port,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// source_port_xlated is the post-translation source port when the flow was
+	// SNATed. When "source_port_xlated" is set, the "source_port" field is
+	// populated with the pre-translation source port.
+	SourcePortXlated uint32 `protobuf:"varint,3,opt,name=source_port_xlated,json=sourcePortXlated,proto3" json:"source_port_xlated,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *UDP) Reset() {
@@ -2953,6 +2968,13 @@ func (x *UDP) GetSourcePort() uint32 {
 func (x *UDP) GetDestinationPort() uint32 {
 	if x != nil {
 		return x.DestinationPort
+	}
+	return 0
+}
+
+func (x *UDP) GetSourcePortXlated() uint32 {
+	if x != nil {
+		return x.SourcePortXlated
 	}
 	return 0
 }
@@ -5609,12 +5631,13 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\tworkloads\x18\x06 \x03(\v2\x0e.flow.WorkloadR\tworkloads\"2\n" +
 	"\bWorkload\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
-	"\x04kind\x18\x02 \x01(\tR\x04kind\"w\n" +
+	"\x04kind\x18\x02 \x01(\tR\x04kind\"\xa5\x01\n" +
 	"\x03TCP\x12\x1f\n" +
 	"\vsource_port\x18\x01 \x01(\rR\n" +
 	"sourcePort\x12)\n" +
 	"\x10destination_port\x18\x02 \x01(\rR\x0fdestinationPort\x12$\n" +
-	"\x05flags\x18\x03 \x01(\v2\x0e.flow.TCPFlagsR\x05flags\"\xb0\x01\n" +
+	"\x05flags\x18\x03 \x01(\v2\x0e.flow.TCPFlagsR\x05flags\x12,\n" +
+	"\x12source_port_xlated\x18\x04 \x01(\rR\x10sourcePortXlated\"\xb0\x01\n" +
 	"\x02IP\x12\x16\n" +
 	"\x06source\x18\x01 \x01(\tR\x06source\x12#\n" +
 	"\rsource_xlated\x18\x05 \x01(\tR\fsourceXlated\x12 \n" +
@@ -5633,11 +5656,12 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\x03URG\x18\x06 \x01(\bR\x03URG\x12\x10\n" +
 	"\x03ECE\x18\a \x01(\bR\x03ECE\x12\x10\n" +
 	"\x03CWR\x18\b \x01(\bR\x03CWR\x12\x0e\n" +
-	"\x02NS\x18\t \x01(\bR\x02NS\"Q\n" +
+	"\x02NS\x18\t \x01(\bR\x02NS\"\x7f\n" +
 	"\x03UDP\x12\x1f\n" +
 	"\vsource_port\x18\x01 \x01(\rR\n" +
 	"sourcePort\x12)\n" +
-	"\x10destination_port\x18\x02 \x01(\rR\x0fdestinationPort\"\x86\x01\n" +
+	"\x10destination_port\x18\x02 \x01(\rR\x0fdestinationPort\x12,\n" +
+	"\x12source_port_xlated\x18\x03 \x01(\rR\x10sourcePortXlated\"\x86\x01\n" +
 	"\x04SCTP\x12\x1f\n" +
 	"\vsource_port\x18\x01 \x01(\rR\n" +
 	"sourcePort\x12)\n" +

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -317,6 +317,10 @@ message TCP {
     uint32 source_port = 1;
     uint32 destination_port = 2;
     TCPFlags flags = 3;
+    // source_port_xlated is the post-translation source port when the flow was
+    // SNATed. When "source_port_xlated" is set, the "source_port" field is
+    // populated with the pre-translation source port.
+    uint32 source_port_xlated = 4;
 }
 
 message IP {
@@ -352,6 +356,10 @@ message TCPFlags {
 message UDP {
     uint32 source_port = 1;
     uint32 destination_port = 2;
+    // source_port_xlated is the post-translation source port when the flow was
+    // SNATed. When "source_port_xlated" is set, the "source_port" field is
+    // populated with the pre-translation source port.
+    uint32 source_port_xlated = 3;
 }
 
 message SCTP {

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1984,13 +1984,13 @@ ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, __u32 src_label,
 		goto redirect_to_proxy;
 
 	/* Not redirected to host / proxy. */
-	send_trace_notify6(ctx, TRACE_TO_LXC, src_label, SECLABEL_IPV6, &orig_sip,
+	send_trace_notify6(ctx, TRACE_TO_LXC, src_label, SECLABEL_IPV6, &orig_sip, 0,
 			   LXC_ID, ifindex, trace.reason, trace.monitor);
 
 	return CTX_ACT_OK;
 
 redirect_to_proxy:
-	send_trace_notify6(ctx, TRACE_TO_PROXY, src_label, SECLABEL_IPV6, &orig_sip,
+	send_trace_notify6(ctx, TRACE_TO_PROXY, src_label, SECLABEL_IPV6, &orig_sip, 0,
 			   bpf_ntohs(*proxy_port), ifindex, trace.reason,
 			   trace.monitor);
 	if (tuple_out)
@@ -2297,13 +2297,13 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, __u32 src_label,
 		goto redirect_to_proxy;
 
 	/* Not redirected to host / proxy. */
-	send_trace_notify4(ctx, TRACE_TO_LXC, src_label, SECLABEL_IPV4, orig_sip,
+	send_trace_notify4(ctx, TRACE_TO_LXC, src_label, SECLABEL_IPV4, orig_sip, 0,
 			   LXC_ID, ifindex, trace.reason, trace.monitor);
 
 	return CTX_ACT_OK;
 
 redirect_to_proxy:
-	send_trace_notify4(ctx, TRACE_TO_PROXY, src_label, SECLABEL_IPV4, orig_sip,
+	send_trace_notify4(ctx, TRACE_TO_PROXY, src_label, SECLABEL_IPV4, orig_sip, 0,
 			   bpf_ntohs(*proxy_port), ifindex, trace.reason,
 			   trace.monitor);
 	if (tuple_out)

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -56,6 +56,7 @@ nodeport_has_nat_conflict_ipv6(const struct __ctx_buff *ctx __maybe_unused,
 
 static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 						  union v6addr *saddr,
+						  __be16 *sport,
 						  struct trace_ctx *trace,
 						  __s8 *ext_err)
 {
@@ -123,6 +124,7 @@ apply_snat:
 			  target, trace, ext_err);
 	if (IS_ERR(ret))
 		goto out;
+	*sport = tuple->sport;
 
 	/* See the equivalent v4 path for comment */
 	if (is_defined(IS_BPF_HOST))
@@ -144,10 +146,11 @@ int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 		.monitor = 0,
 	};
 	union v6addr saddr = {};
+	__be16 sport = 0;
 	int ret;
 	__s8 ext_err = 0;
 
-	ret = nodeport_snat_fwd_ipv6(ctx, &saddr, &trace, &ext_err);
+	ret = nodeport_snat_fwd_ipv6(ctx, &saddr, &sport, &trace, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_id, ret, ext_err, METRIC_EGRESS);
 
@@ -158,7 +161,7 @@ int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 	 */
 	if (ret == CTX_ACT_OK)
 		send_trace_notify6(ctx, NODEPORT_OBS_POINT_EGRESS, src_id, UNKNOWN_ID,
-				   &saddr, TRACE_EP_ID_UNKNOWN, CONFIG(interface_ifindex),
+				   &saddr, sport, TRACE_EP_ID_UNKNOWN, CONFIG(interface_ifindex),
 				   trace.reason, trace.monitor);
 
 	return ret;
@@ -335,6 +338,7 @@ nodeport_has_nat_conflict_ipv4(const struct __ctx_buff *ctx __maybe_unused,
 static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 						  __u32 cluster_id __maybe_unused,
 						  __be32 *saddr,
+						  __be16 *sport,
 						  struct trace_ctx *trace,
 						  __s8 *ext_err)
 {
@@ -412,6 +416,7 @@ apply_snat:
 			  &target, trace, ext_err);
 	if (IS_ERR(ret))
 		goto out;
+	*sport = tuple.sport;
 
 	/* If multiple netdevs process an outgoing packet, then this packets will
 	 * be handled multiple times by the "to-netdev" section. This can lead
@@ -441,10 +446,11 @@ int tail_handle_snat_fwd_ipv4(struct __ctx_buff *ctx)
 		.monitor = 0,
 	};
 	__be32 saddr = 0;
+	__be16 sport = 0;
 	int ret;
 	__s8 ext_err = 0;
 
-	ret = nodeport_snat_fwd_ipv4(ctx, cluster_id, &saddr, &trace, &ext_err);
+	ret = nodeport_snat_fwd_ipv4(ctx, cluster_id, &saddr, &sport, &trace, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_id, ret, ext_err, METRIC_EGRESS);
 
@@ -455,7 +461,7 @@ int tail_handle_snat_fwd_ipv4(struct __ctx_buff *ctx)
 	 */
 	if (ret == CTX_ACT_OK)
 		send_trace_notify4(ctx, NODEPORT_OBS_POINT_EGRESS, src_id, UNKNOWN_ID,
-				   saddr, TRACE_EP_ID_UNKNOWN, CONFIG(interface_ifindex),
+				   saddr, sport, TRACE_EP_ID_UNKNOWN, CONFIG(interface_ifindex),
 				   trace.reason, trace.monitor);
 
 	return ret;

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -167,13 +167,15 @@ struct trace_notify {
 		union v6addr	orig_ip6;
 	};
 	__u64		ip_trace_id;
+	__u16		orig_port;
+	__u8		pad[6];
 	TRACE_EXTENSION
 } __align_stack_8;
 
 #ifdef TRACE_NOTIFY
 
-/* Trace notify version 2 includes IP Trace support. */
-#define NOTIFY_TRACE_VER 2
+/* Trace notify version 3 includes OrigPort. */
+#define NOTIFY_TRACE_VER 3
 
 static __always_inline bool
 emit_trace_notify(enum trace_point obs_point, __u32 monitor)
@@ -249,6 +251,7 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 		.flags		= flags,
 		.ifindex	= ifindex,
 		.ip_trace_id	= ip_trace_id,
+		.orig_port = 0,
 	};
 	memset(&msg.orig_ip6, 0, sizeof(union v6addr));
 
@@ -260,7 +263,7 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 
 static __always_inline void
 _send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
-		    __u32 src, __u32 dst, __be32 orig_addr, __u16 dst_id,
+		    __u32 src, __u32 dst, __be32 orig_addr, __be16 orig_port, __u16 dst_id,
 		    __u32 ifindex, enum trace_reason reason, __u32 monitor,
 		    __u16 line, __u8 file)
 {
@@ -302,6 +305,7 @@ _send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 		.flags		= flags,
 		.orig_ip4.be32	= orig_addr,
 		.ip_trace_id	= ip_trace_id,
+		.orig_port = bpf_ntohs(orig_port),
 	};
 
 	trace_extension_hook(ctx, msg);
@@ -312,7 +316,7 @@ _send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 
 static __always_inline void
 _send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
-		    __u32 src, __u32 dst, const union v6addr *orig_addr,
+		    __u32 src, __u32 dst, const union v6addr *orig_addr, __be16 orig_port,
 		    __u16 dst_id, __u32 ifindex, enum trace_reason reason,
 		    __u32 monitor, __u16 line, __u8 file)
 {
@@ -353,6 +357,7 @@ _send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 		.ifindex	= ifindex,
 		.flags		= flags,
 		.ip_trace_id	= ip_trace_id,
+		.orig_port = bpf_ntohs(orig_port),
 	};
 
 	ipv6_addr_copy(&msg.orig_ip6, orig_addr);
@@ -376,9 +381,9 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 static __always_inline void
 _send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 		    __u32 src __maybe_unused, __u32 dst __maybe_unused,
-		    __be32 orig_addr __maybe_unused, __u16 dst_id __maybe_unused,
-		    __u32 ifindex __maybe_unused, enum trace_reason reason,
-		    __u32 monitor __maybe_unused,
+		    __be32 orig_addr __maybe_unused, __be16 orig_port __maybe_unused,
+			__u16 dst_id __maybe_unused, __u32 ifindex __maybe_unused,
+			enum trace_reason reason, __u32 monitor __maybe_unused,
 		    __u16 line, __u8 file)
 {
 	_update_trace_metrics(ctx, obs_point, reason, line, file);
@@ -387,7 +392,7 @@ _send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 static __always_inline void
 _send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 		    __u32 src __maybe_unused, __u32 dst __maybe_unused,
-		    union v6addr *orig_addr __maybe_unused,
+		    union v6addr *orig_addr __maybe_unused, __be16 orig_port __maybe_unused,
 		    __u16 dst_id __maybe_unused, __u32 ifindex __maybe_unused,
 		    enum trace_reason reason, __u32 monitor __maybe_unused,
 		    __u16 line, __u8 file)
@@ -402,11 +407,15 @@ _send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 	__MAGIC_LINE__, __MAGIC_FILE__)
 
 /* send_trace_notify4 emits a trace notify with the original IPv4 address before translation. */
-#define send_trace_notify4(ctx, obs_point, src, dst, orig_addr, dst_id, ifindex, reason, monitor) \
-	_send_trace_notify4(ctx, obs_point, src, dst, orig_addr, dst_id, ifindex, reason, monitor, \
+#define send_trace_notify4(ctx, obs_point, src, dst, orig_addr, orig_port, \
+	dst_id, ifindex, reason, monitor) \
+	_send_trace_notify4(ctx, obs_point, src, dst, orig_addr, orig_port, dst_id, \
+		ifindex, reason, monitor, \
 	__MAGIC_LINE__, __MAGIC_FILE__)
 
 /* send_trace_notify6 emits a trace notify with the original IPv6 address before translation. */
-#define send_trace_notify6(ctx, obs_point, src, dst, orig_addr, dst_id, ifindex, reason, monitor) \
-	_send_trace_notify6(ctx, obs_point, src, dst, orig_addr, dst_id, ifindex, reason, monitor, \
+#define send_trace_notify6(ctx, obs_point, src, dst, orig_addr, orig_port, \
+	dst_id, ifindex, reason, monitor) \
+	_send_trace_notify6(ctx, obs_point, src, dst, orig_addr, orig_port, dst_id, \
+		ifindex, reason, monitor, \
 	__MAGIC_LINE__, __MAGIC_FILE__)

--- a/hubble/pkg/printer/printer.go
+++ b/hubble/pkg/printer/printer.go
@@ -89,6 +89,13 @@ func (p *Printer) Close() error {
 	return nil
 }
 
+func formatPortWithTranslation(port, xlated uint32) string {
+	if xlated != 0 && xlated != port {
+		return fmt.Sprintf("%d->%d", port, xlated)
+	}
+	return strconv.Itoa(int(port))
+}
+
 // GetPorts returns source and destination port of a flow.
 func (p *Printer) GetPorts(f *flowpb.Flow) (string, string) {
 	l4 := f.GetL4()
@@ -97,9 +104,11 @@ func (p *Printer) GetPorts(f *flowpb.Flow) (string, string) {
 	}
 	switch l4.GetProtocol().(type) {
 	case *flowpb.Layer4_TCP:
-		return strconv.Itoa(int(l4.GetTCP().GetSourcePort())), strconv.Itoa(int(l4.GetTCP().GetDestinationPort()))
+		tcp := l4.GetTCP()
+		return formatPortWithTranslation(tcp.GetSourcePort(), tcp.GetSourcePortXlated()), strconv.Itoa(int(tcp.GetDestinationPort()))
 	case *flowpb.Layer4_UDP:
-		return strconv.Itoa(int(l4.GetUDP().GetSourcePort())), strconv.Itoa(int(l4.GetUDP().GetDestinationPort()))
+		udp := l4.GetUDP()
+		return formatPortWithTranslation(udp.GetSourcePort(), udp.GetSourcePortXlated()), strconv.Itoa(int(udp.GetDestinationPort()))
 	case *flowpb.Layer4_SCTP:
 		return strconv.Itoa(int(l4.GetSCTP().GetSourcePort())), strconv.Itoa(int(l4.GetSCTP().GetDestinationPort()))
 	default:

--- a/pkg/datapath/types/types_generated.go
+++ b/pkg/datapath/types/types_generated.go
@@ -960,6 +960,8 @@ type TraceNotify struct {
 	}
 	_         [12]byte
 	IPTraceID uint64
+	OrigPort  uint16
+	Pad       [6]uint8
 }
 
 // TraceSockNotify is generated from the BPF C type trace_sock_notify.

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -522,7 +522,7 @@ func TestDecodeTraceNotify(t *testing.T) {
 				Type:     byte(monitorAPI.MessageTypeTrace),
 				SrcLabel: 123,
 				DstLabel: 456,
-				Version:  monitor.TraceNotifyVersion2,
+				Version:  monitor.TraceNotifyVersion3,
 			}
 			lay := []gopacket.SerializableLayer{
 				&layers.Ethernet{

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -23,6 +23,8 @@ const (
 	traceNotifyV1Len = 48
 	// traceNotifyV2Len is the amount of packet data provided in a trace notification v2.
 	traceNotifyV2Len = 56
+	// traceNotifyV3Len is the amount of packet data provided in a trace notification v3.
+	traceNotifyV3Len = 64
 )
 
 const (
@@ -44,6 +46,7 @@ const (
 	TraceNotifyVersion0 = iota
 	TraceNotifyVersion1
 	TraceNotifyVersion2
+	TraceNotifyVersion3
 )
 
 // TraceNotify is the message format of a trace notification in the BPF ring buffer
@@ -64,6 +67,8 @@ type TraceNotify struct {
 	Ifindex    uint32                   `align:"ifindex"`
 	OrigIP     types.IPv6               `align:"$union0"`
 	IPTraceID  uint64                   `align:"ip_trace_id"`
+	OrigPort   uint16                   `align:"orig_port"`
+	_          [6]uint8                 `align:"pad"`
 	// data
 }
 
@@ -99,12 +104,18 @@ func (tn *TraceNotify) Decode(data []byte) error {
 	version := data[14]
 
 	// Check against max version.
-	if version > TraceNotifyVersion2 {
+	if version > TraceNotifyVersion3 {
 		return fmt.Errorf("Unrecognized trace event (version %d)", version)
 	}
 
 	// Decode logic for version >= v1.
 	switch version {
+	case TraceNotifyVersion3:
+		if l := len(data); l < traceNotifyV3Len {
+			return fmt.Errorf("unexpected TraceNotify data length (version %d), expected at least %d but got %d", version, traceNotifyV3Len, l)
+		}
+		tn.OrigPort = binary.NativeEndian.Uint16(data[56:58])
+		fallthrough
 	case TraceNotifyVersion2:
 		if l := len(data); l < traceNotifyV2Len {
 			return fmt.Errorf("unexpected TraceNotify data length (version %d), expected at least %d but got %d", version, traceNotifyV2Len, l)
@@ -186,6 +197,7 @@ var (
 		TraceNotifyVersion0: traceNotifyV0Len,
 		TraceNotifyVersion1: traceNotifyV1Len,
 		TraceNotifyVersion2: traceNotifyV2Len,
+		TraceNotifyVersion3: traceNotifyV3Len,
 	}
 )
 
@@ -324,6 +336,12 @@ func (n *TraceNotify) OriginalIP() net.IP {
 	return n.OrigIP[:4]
 }
 
+// OriginalPort returns the original source port if reverse NAT was performed on
+// the flow.
+func (n *TraceNotify) OriginalPort() uint16 {
+	return n.OrigPort
+}
+
 // DataOffset returns the offset from the beginning of TraceNotify where the
 // trace notify data begins.
 //
@@ -347,8 +365,8 @@ func (n *TraceNotify) DumpInfo(buf *bufio.Writer, data []byte, numeric api.Displ
 	if id := n.IPTraceID; id > 0 {
 		fmt.Fprintf(buf, " [ ip-trace-id = %d ]", id)
 	}
-	fmt.Fprintf(buf, " state %s ifindex %s orig-ip %s: %s\n",
-		n.traceReasonString(), ifname, n.OriginalIP().String(), GetConnectionSummary(data[hdrLen:], &decodeOpts{n.IsL3Device(), n.IsIPv6(), n.IsVXLAN(), n.IsGeneve()}))
+	fmt.Fprintf(buf, " state %s ifindex %s orig-ip %s orig-port %d: %s\n",
+		n.traceReasonString(), ifname, n.OriginalIP().String(), n.OriginalPort(), GetConnectionSummary(data[hdrLen:], &decodeOpts{n.IsL3Device(), n.IsIPv6(), n.IsVXLAN(), n.IsGeneve()}))
 	buf.Flush()
 }
 
@@ -371,7 +389,7 @@ func (n *TraceNotify) DumpVerbose(buf *bufio.Writer, dissect bool, data []byte, 
 		n.dumpIdentity(buf, numeric)
 	}
 
-	fmt.Fprintf(buf, ", orig-ip %s", n.OriginalIP().String())
+	fmt.Fprintf(buf, ", orig-ip %s, orig-port %d", n.OriginalIP().String(), n.OriginalPort())
 
 	if n.DstID != 0 {
 		dst := "endpoint"

--- a/pkg/monitor/datapath_trace_test.go
+++ b/pkg/monitor/datapath_trace_test.go
@@ -17,7 +17,7 @@ import (
 func TestDecodeTraceNotify(t *testing.T) {
 	// This check on the struct length constant is there to ensure that this
 	// test is updated when the struct changes.
-	require.Equal(t, 56, traceNotifyV2Len)
+	require.Equal(t, 64, traceNotifyV3Len)
 
 	in := TraceNotify{
 		Type:     0x00,
@@ -26,7 +26,7 @@ func TestDecodeTraceNotify(t *testing.T) {
 		Hash:     0x05_06_07_08,
 		OrigLen:  0x09_0a_0b_0c,
 		CapLen:   0x0d_0e,
-		Version:  TraceNotifyVersion2,
+		Version:  TraceNotifyVersion3,
 		SrcLabel: identity.NumericIdentity(0x11_12_13_14),
 		DstLabel: identity.NumericIdentity(0x15_16_17_18),
 		DstID:    0x19_1a,
@@ -40,6 +40,7 @@ func TestDecodeTraceNotify(t *testing.T) {
 			0x2d, 0x2e, 0x2f, 0x30,
 		},
 		IPTraceID: 0x2b_2c_2d_2e_2f_30_31_32,
+		OrigPort:  0x00_50,
 	}
 	buf := bytes.NewBuffer(nil)
 	err := binary.Write(buf, binary.NativeEndian, in)
@@ -63,6 +64,7 @@ func TestDecodeTraceNotify(t *testing.T) {
 	require.Equal(t, in.Ifindex, out.Ifindex)
 	require.Equal(t, in.OrigIP, out.OrigIP)
 	require.Equal(t, in.IPTraceID, out.IPTraceID)
+	require.Equal(t, in.OrigPort, out.OrigPort)
 }
 
 func TestDecodeTraceNotifyExtension(t *testing.T) {
@@ -88,14 +90,14 @@ func TestDecodeTraceNotifyExtension(t *testing.T) {
 		{
 			name: "no extension",
 			tn: TraceNotify{
-				Version:    TraceNotifyVersion2,
+				Version:    TraceNotifyVersion3,
 				ExtVersion: 0,
 			},
 		},
 		{
 			name: "extension 1",
 			tn: TraceNotify{
-				Version:    TraceNotifyVersion2,
+				Version:    TraceNotifyVersion3,
 				ExtVersion: 1,
 			},
 			extension: []uint32{
@@ -105,7 +107,7 @@ func TestDecodeTraceNotifyExtension(t *testing.T) {
 		{
 			name: "extension 2",
 			tn: TraceNotify{
-				Version:    TraceNotifyVersion2,
+				Version:    TraceNotifyVersion3,
 				ExtVersion: 2,
 			},
 			extension: []uint32{
@@ -116,7 +118,7 @@ func TestDecodeTraceNotifyExtension(t *testing.T) {
 		{
 			name: "extension 2",
 			tn: TraceNotify{
-				Version:    TraceNotifyVersion2,
+				Version:    TraceNotifyVersion3,
 				ExtVersion: 3,
 			},
 			extension: []uint32{


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #31307 

The feature records orig port information for SNATed packets.

## Test Senario:
### cluster setting
```
make kind-egressgw
make kind-image-agent
make kind-egressgw-install-cilium

kubectl label node kind-worker3 cilium.io/no-schedule-
```
### egressgw policy apply
```
kubectl apply -f - <<EOF
apiVersion: cilium.io/v2
kind: CiliumEgressGatewayPolicy
metadata:
  name: test
spec:
  selectors:
    - podSelector:
        matchLabels:
          app: testclient
  destinationCIDRs:
    - "0.0.0.0/0"
  egressGateway:
    nodeSelector:
      matchLabels:
        kubernetes.io/hostname: "kind-worker3"
EOF
```

### deploy test pod
```
kubectl run testclient \
  --image=busybox:1.36 \
  --restart=Never \
  -l app=testclient \
  -- sleep 1d
```

### test
Two terminals are required for testing.
One for monitoring and one for generating a request for testing.

#### worker3 node monitoring terminal
```
kubectl exec -it -n kube-system <pod_name/cilium-agent kind-worker3> -- cilium-dbg monitor -v | grep "state new"
```
##### example result
```
-> network flow 0xfeaf603a , identity 30027->unknown state new ifindex eth0 orig-ip 10.244.2.121 orig-port 36990: 56:57:83:8c:47:10 -> 00:00:00:00:00:00 UnknownEthernetType
```

#### request termial
```
kubectl exec -it testclient -- wget -S -O /dev/null https://example.com
```

### worker3 node bpf nat table select
```
kubectl exec -it -n kube-system <pod_name/cilum-agent in kind-worker3>  -- cilium-dbg bpf nat list | grep <test pod ip>
```
#### example result
```
kubectl exec -it -n kube-system cilium-6pzwk  -- cilium-dbg bpf nat list | grep "10.244.2.121"
TCP IN 23.192.228.80:80 -> 172.19.0.3:36990 XLATE_DST 10.244.2.121:36990 Created=63sec ago NeedsCT=1
TCP OUT 10.244.2.121:36990 -> 23.192.228.80:80 XLATE_SRC 172.19.0.3:36990 Created=63sec ago NeedsCT=1
```