### PR TITLE
hubble: fix debug GetFlows log line

### DIFF
--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -297,7 +297,7 @@ func (s *LocalObserverServer) GetFlows(
 				logfields.NumberOfFlows, i,
 				logfields.BufferSize, ring.Cap(),
 				logfields.Whitelist, logFilters(req.Whitelist),
-				logfields.Blacklist, logFilters(req.Whitelist),
+				logfields.Blacklist, logFilters(req.Blacklist),
 				logfields.Took, time.Since(start),
 			)
 		}()


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
```

I am  verifying some lint idea in my project see https://github.com/alingse/sundrylint/pull/10
it report the function call with repeat args from a sub-function call.

we think the sub-function call is heavy, so the repeat args probably a copy-and-paste mistake.

I check the top 200 github repos, and found cilium has this case.

it's really tiny so i remove the release-note

