### PR TITLE
bpf: wireguard: improve the handling for proxy traffic

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -395,7 +395,7 @@ skip_tunnel:
 					 info->sec_identity, true, false);
 
 	if (from_proxy && !identity_is_cluster(info->sec_identity))
-		ctx->mark = MARK_MAGIC_PROXY_TO_WORLD;
+		ctx->mark = MARK_MAGIC_PROXY_REDIRECTED;
 #endif /* ENABLE_IPSEC && !TUNNEL_MODE */
 
 	return CTX_ACT_OK;
@@ -873,7 +873,7 @@ skip_tunnel:
 					 info->sec_identity, true, false);
 
 	if (from_proxy && !identity_is_cluster(info->sec_identity))
-		ctx->mark = MARK_MAGIC_PROXY_TO_WORLD;
+		ctx->mark = MARK_MAGIC_PROXY_REDIRECTED;
 #endif /* ENABLE_IPSEC && !TUNNEL_MODE */
 
 	return CTX_ACT_OK;

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -393,10 +393,10 @@ skip_tunnel:
 	if (from_proxy && info->tunnel_endpoint && encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
 					 info->sec_identity, true, false);
-
-	if (from_proxy && !identity_is_cluster(info->sec_identity))
-		ctx->mark = MARK_MAGIC_PROXY_REDIRECTED;
 #endif /* ENABLE_IPSEC && !TUNNEL_MODE */
+
+	if (from_proxy)
+		ctx->mark = MARK_MAGIC_PROXY_REDIRECTED;
 
 	return CTX_ACT_OK;
 }
@@ -871,10 +871,10 @@ skip_tunnel:
 	if (from_proxy && info->tunnel_endpoint && encrypt_key)
 		return set_ipsec_encrypt(ctx, encrypt_key, info->tunnel_endpoint,
 					 info->sec_identity, true, false);
-
-	if (from_proxy && !identity_is_cluster(info->sec_identity))
-		ctx->mark = MARK_MAGIC_PROXY_REDIRECTED;
 #endif /* ENABLE_IPSEC && !TUNNEL_MODE */
+
+	if (from_proxy)
+		ctx->mark = MARK_MAGIC_PROXY_REDIRECTED;
 
 	return CTX_ACT_OK;
 }

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -713,7 +713,7 @@ enum metric_dir {
  *    In the IPsec case this becomes the SPI on the wire.
  */
 #define MARK_MAGIC_HOST_MASK		0x0F00
-#define MARK_MAGIC_PROXY_TO_WORLD	0x0800
+#define MARK_MAGIC_PROXY_REDIRECTED	0x0800
 #define MARK_MAGIC_PROXY_EGRESS_EPID	0x0900 /* mark carries source endpoint ID */
 #define MARK_MAGIC_PROXY_INGRESS	0x0A00
 #define MARK_MAGIC_PROXY_EGRESS		0x0B00

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -130,10 +130,16 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 	 *  encrypted.
 	 */
 	magic = ctx->mark & MARK_MAGIC_HOST_MASK;
-	if (magic == MARK_MAGIC_PROXY_INGRESS || magic == MARK_MAGIC_PROXY_EGRESS)
+	if (magic == MARK_MAGIC_PROXY_INGRESS ||
+	    magic == MARK_MAGIC_PROXY_EGRESS ||
+	    magic == MARK_MAGIC_PROXY_REDIRECTED)
 		goto maybe_encrypt;
+
 #if defined(TUNNEL_MODE)
 	/* In tunneling mode the mark might have been reset. Check TC index instead.
+	 *
+	 * TODO: superseded by MARK_MAGIC_PROXY_REDIRECTED, remove
+	 *	 this part once n-1 has support.
 	 */
 	if (tc_index_from_ingress_proxy(ctx) || tc_index_from_egress_proxy(ctx))
 		goto maybe_encrypt;

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -518,14 +518,14 @@ func (m *Manager) inboundProxyRedirectRule(cmd string) []string {
 	// excluding traffic for the loopback device.
 	toProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
 	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
-	matchProxyToWorld := fmt.Sprintf("%#08x/%#08x", linux_defaults.MarkProxyToWorld, linux_defaults.RouteMarkMask)
+	matchFromProxyRedirected := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkProxyRedirected, linux_defaults.MagicMarkHostMask)
 	return []string{
 		"-t", "mangle",
 		cmd, ciliumPreMangleChain,
 		"-m", "socket", "--transparent",
 		"!", "-o", "lo",
 		"-m", "mark", "!", "--mark", matchFromIPSecEncrypt,
-		"-m", "mark", "!", "--mark", matchProxyToWorld,
+		"-m", "mark", "!", "--mark", matchFromProxyRedirected,
 		"-m", "comment", "--comment", "cilium: any->pod redirect proxied traffic to host proxy",
 		"-j", "MARK",
 		"--set-mark", toProxyMark}

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -27,10 +27,6 @@ const (
 	// table which is between 253-255. See ip-route(8).
 	RouteTableInterfacesOffset = 10
 
-	// MarkProxyToWorld is the default mark to use to indicate that a packet
-	// from proxy needs to be sent to the world.
-	MarkProxyToWorld = 0x800
-
 	// RouteMarkDecrypt is the default route mark to use to indicate datapath
 	// needs to decrypt a packet.
 	RouteMarkDecrypt = MagicMarkDecrypt

--- a/pkg/datapath/linux/linux_defaults/mark.go
+++ b/pkg/datapath/linux/linux_defaults/mark.go
@@ -58,6 +58,14 @@ const (
 	// to identify cilium-managed overlay traffic.
 	MagicMarkOverlay int = 0x0400
 
+	// MagicMarkProxyRedirected is the mark used for proxy traffic
+	// that was redirected (by eg policy routing) to another interface and
+	// processed by a BPF program.
+	// We need to set a mark so that transparent proxy connections can be
+	// excluded from tproxy matching in netfilter. But to avoid a routing loop,
+	// we can't restore the initial MagicMark{Egress,Ingress}.
+	MagicMarkProxyRedirected = 0x800
+
 	// MagicMarkProxyEgressEPID determines that the traffic is sourced from
 	// the proxy which is capturing traffic before it is subject to egress
 	// policy enforcement that must be done after the proxy. The identity


### PR DESCRIPTION
Make the detection of proxy traffic a bit robuster. We can phase out the `tc_index` variant in the future, once we know that `cilium_host` has been regenerated and is setting the new mark value.