### PR TITLE
cilium-cli: Add connectivity test for service loopback

### DIFF
--- a/cilium-cli/connectivity/builder/client_to_itself.go
+++ b/cilium-cli/connectivity/builder/client_to_itself.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type clientToItself struct{}
+
+func (t clientToItself) build(ct *check.ConnectivityTest, templates map[string]string) {
+	newTest("client-to-itself", ct).
+		WithCondition(func() bool {
+			return !isSocketLBDisabled(ct)
+		}).
+		WithScenarios(
+			tests.ClientToItself(),
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			return check.ResultOK, check.ResultOK
+		})
+}
+
+func isSocketLBDisabled(ct *check.ConnectivityTest) bool {
+	socketLBDisabled, _ := ct.Features.MatchRequirements(features.RequireDisabled(features.KPRSocketLB))
+	return socketLBDisabled
+}

--- a/cilium-cli/connectivity/tests/client.go
+++ b/cilium-cli/connectivity/tests/client.go
@@ -61,3 +61,43 @@ func (s *clientToClient) Run(ctx context.Context, t *check.Test) {
 		}
 	}
 }
+
+// ClientToItself is a test to check whether a client can connect itself via Service loopback.
+func ClientToItself() check.Scenario {
+	return &clientToItself{
+		ScenarioBase: check.NewScenarioBase(),
+	}
+}
+
+type clientToItself struct {
+	check.ScenarioBase
+}
+
+func (s *clientToItself) Name() string {
+	return "pod-to-itself"
+}
+
+func (s *clientToItself) Run(ctx context.Context, t *check.Test) {
+	ct := t.Context()
+	var i int
+	for _, echo := range ct.EchoPods() {
+		for _, svc := range ct.EchoServices() {
+			t.ForEachIPFamily(func(ipFam features.IPFamily) {
+				if ipFam == features.IPFamilyV6 {
+					// Skip IPv6 for now since it's not supported.
+					return
+				}
+				t.NewAction(s, fmt.Sprintf("curl-%s-%d", ipFam, i), &echo, svc, ipFam).Run(func(a *check.Action) {
+					a.ExecInPod(ctx, a.CurlCommand(svc))
+
+					a.ValidateFlows(ctx, echo, a.GetEgressRequirements(check.FlowParameters{
+						DNSRequired: true,
+						AltDstPort:  svc.Port(),
+					}))
+					a.ValidateMetrics(ctx, echo, a.GetEgressMetricsRequirements())
+				})
+			})
+			i++
+		}
+	}
+}


### PR DESCRIPTION
Add connectivity test for service loopback. 

Fixes: #33194


