### PR TITLE
operator: Fix Allocator leaking IDs in CID controller [archive]

### DIFF
--- a/operator/pkg/ciliumidentity/reconciler_test.go
+++ b/operator/pkg/ciliumidentity/reconciler_test.go
@@ -89,6 +89,7 @@ func testNewReconciler(t *testing.T, ctx context.Context, enableCES bool) (*reco
 		ciliumIdentity,
 		ciliumEndpoint,
 		ciliumEndpointSlice,
+		defaultIDRange(),
 		enableCES,
 		queueOps,
 	)


### PR DESCRIPTION
**Closed in favor of https://github.com/cilium/cilium/pull/38196**
**Issue opened to track flaky tests due to fake client and store interactions: https://github.com/cilium/cilium/issues/38197**

The Cilium Identity (CID) controller in cilium-operator fails to return IDs to the available pool when the CIDs are cleaned up by CID GC.

A test is added that confirms that without the fix it will fail and there will be the following errors generated by the CID controller:
```
cilium/operator/pkg/ciliumidentity/controller.go:256
msg="Failed to process resource item" key=ns-6/pod1 retries=2 maxRetries=15
error="failed to allocate CID: failed to allocate random ID"
```

A new struct `idRange` is added to enable modifying allocator's ID range in tests.

---

Release note

```release-note
Fix Allocator leaking IDs in CID controller
```

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>