### PR TITLE
vendor: Bump hive to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/cilium/ebpf v0.17.1
 	github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b
 	github.com/cilium/fake v0.7.0
-	github.com/cilium/hive v0.0.0-20250217113459-914947d44393
+	github.com/cilium/hive v0.0.0-20250310151328-80661b1da398
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20250214115704-3e4b99dc5d1f
 	github.com/cilium/statedb v0.3.6

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b h1
 github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b/go.mod h1:izWO5C3waDVkh/nt++nNyozXyJAPL6tfFpJSMtzVnwQ=
 github.com/cilium/fake v0.7.0 h1:4EKBtTweQrJoD4q45qDGu8udulmYMo48Y0BhEbrB1jc=
 github.com/cilium/fake v0.7.0/go.mod h1:hA1YsEjgIs5Gdeq/DVrDWGuhLCoVok7THTvQaGDO5bc=
-github.com/cilium/hive v0.0.0-20250217113459-914947d44393 h1:x2VYGSK1hnX6N7j2V6rtIDN0E+dO6ozTyYz8iYOugD8=
-github.com/cilium/hive v0.0.0-20250217113459-914947d44393/go.mod h1:pI2GJ1n3SLKIQVFrKF7W6A6gb6BQkZ+3Hp4PAEo5SuI=
+github.com/cilium/hive v0.0.0-20250310151328-80661b1da398 h1:xYS5PmOEqfqXAPNFe9EH5I7ekIWHd+bDYGCICZ920/w=
+github.com/cilium/hive v0.0.0-20250310151328-80661b1da398/go.mod h1:pI2GJ1n3SLKIQVFrKF7W6A6gb6BQkZ+3Hp4PAEo5SuI=
 github.com/cilium/linters v0.1.0 h1:ABdLyPBtF+X6oTlTE0AAJbkuo2s1OYaEsP2jb9+7BGY=
 github.com/cilium/linters v0.1.0/go.mod h1:mpr0RBmILRLQu2F7ek+gjBxxuacUB/IBmjDRC3RaFkI=
 github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y2qDBs=

--- a/pkg/loadbalancer/experimental/testdata/healthserver.txtar
+++ b/pkg/loadbalancer/experimental/testdata/healthserver.txtar
@@ -64,8 +64,10 @@ db/cmp frontends frontends_tpcluster.table
 
 # Restore health checking for next test.
 k8s/update service2.yaml
+
+# Response should be 200
 * http/get http://$HEALTHADDR:$HEALTHPORT2 healthserver.actual
-cmp healthserver.expected healthserver.actual
+* cmp healthserver.expected healthserver.actual
 
 # Test without local backends
 k8s/update endpointslice2.yaml

--- a/vendor/github.com/cilium/hive/script/cmds.go
+++ b/vendor/github.com/cilium/hive/script/cmds.go
@@ -256,9 +256,10 @@ func doCompare(s *State, env bool, args ...string) error {
 	}
 
 	if text1 != text2 {
-		if s.DoUpdate {
-			// Updates requested, store the file contents and
-			// ignore mismatches.
+		if s.DoUpdate && s.RetryCount > 0 {
+			// Updates requested and we've already retried at least once
+			// (and given time for things to settle down).
+			// Store the file contents and ignore the mismatch.
 			s.FileUpdates[name1] = text2
 			s.FileUpdates[name2] = text1
 			return nil

--- a/vendor/github.com/cilium/hive/script/state.go
+++ b/vendor/github.com/cilium/hive/script/state.go
@@ -40,6 +40,7 @@ type State struct {
 	Flags       *pflag.FlagSet
 	DoUpdate    bool
 	FileUpdates map[string]string
+	RetryCount  int
 
 	BreakOnError bool
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -296,7 +296,7 @@ github.com/cilium/endpointslice-controller/util/endpointslice
 # github.com/cilium/fake v0.7.0
 ## explicit; go 1.22
 github.com/cilium/fake
-# github.com/cilium/hive v0.0.0-20250217113459-914947d44393
+# github.com/cilium/hive v0.0.0-20250310151328-80661b1da398
 ## explicit; go 1.21.3
 github.com/cilium/hive
 github.com/cilium/hive/cell


### PR DESCRIPTION
Bump cilium/hive to latest version to fix retrying script commands with 0s interval.

Also fix a flake in healthserver.txtar found when validating after bump (`cmp` not retried leading to sometimes seeing 0 healthy backends).