### PR TITLE
bpf batch improvements

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -968,7 +968,7 @@ func (bi *BatchIterator[KT, VT, KP, VP]) IterateAll(ctx context.Context, opts ..
 		break
 	default:
 		bi.err = fmt.Errorf("unsupported map type %s, must be one either hash or lru-hash types", bi.m.Type())
-		return nil
+		return func(yield func(KP, VP) bool) {}
 	}
 
 	bi.chunkSize = startingChunkSize(int(bi.m.MaxEntries()))

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -964,7 +964,7 @@ func startingChunkSize(maxEntries int) int {
 // If the iteration fails, then the Err() function will return the error that caused the failure.
 func (bi *BatchIterator[KT, VT, KP, VP]) IterateAll(ctx context.Context, opts ...BatchIteratorOpt[KT, VT, KP, VP]) iter.Seq2[KP, VP] {
 	switch bi.m.Type() {
-	case ebpf.Hash, ebpf.LRUHash:
+	case ebpf.Hash, ebpf.LRUHash, ebpf.LPMTrie:
 		break
 	default:
 		bi.err = fmt.Errorf("unsupported map type %s, must be one either hash or lru-hash types", bi.m.Type())


### PR DESCRIPTION
* Fix issue related to returning nil when a bad map type is passed, instead a empty iterator is returned.
* Add support for LPM trie type for batch iterator.