### PR TITLE
feat(agent/datapath): Expose IP Packet Tracing flag

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -265,6 +265,7 @@ cilium-agent [flags]
       --install-no-conntrack-iptables-rules                       Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.
       --install-uplink-routes-for-delegated-ipam                  Install ingress/egress routes through uplink on host for Pods when working with delegated IPAM plugin.
       --ip-masq-agent-config-path string                          ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
+      --ip-tracing-option-type uint8                              Specifies what IPv4 option type should be used to extract trace information from a packet; a value of 0 (default) disables IP tracing.
       --ipam string                                               Backend to use for IPAM (default "cluster-pool")
       --ipam-cilium-node-update-rate duration                     Maximum rate at which the CiliumNode custom resource is updated (default 15s)
       --ipam-default-ip-pool string                               Name of the default IP Pool when using multi-pool (default "default")

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1247,6 +1247,11 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 		obs_point = TRACE_FROM_CRYPTO;
 #endif
 
+#ifdef IP_TRACING_OPTION_TYPE
+	if (IP_TRACING_OPTION_TYPE > 0)
+		check_and_store_ip_trace_id(ctx, IP_TRACING_OPTION_TYPE);
+#endif
+
 	/* Filter allowed vlan id's and pass them back to kernel.
 	 * We will see the packet again in from-netdev@eth0.vlanXXX.
 	 */
@@ -1743,6 +1748,11 @@ skip_ipsec_nodeport_revdnat:
 #else
 	ret = CTX_ACT_OK;
 #endif /* ENABLE_HOST_FIREWALL */
+
+#ifdef ENABLE_PACKET_IP_TRACING
+	if (ENABLE_PACKET_IP_TRACING > 0)
+		check_and_store_ip_trace_id(ctx, ENABLE_PACKET_IP_TRACING);
+#endif
 
 out:
 	if (IS_ERR(ret))

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1487,6 +1487,11 @@ int cil_from_container(struct __ctx_buff *ctx)
 	 */
 	ctx->queue_mapping = 0;
 
+#ifdef IP_TRACING_OPTION_TYPE
+	if (IP_TRACING_OPTION_TYPE > 0)
+		check_and_store_ip_trace_id(ctx, IP_TRACING_OPTION_TYPE);
+#endif
+
 	send_trace_notify(ctx, TRACE_FROM_LXC, sec_label, UNKNOWN_ID,
 			  TRACE_EP_ID_UNKNOWN, TRACE_IFINDEX_UNKNOWN,
 			  TRACE_REASON_UNKNOWN, TRACE_PAYLOAD_LEN);

--- a/bpf/bpf_network.c
+++ b/bpf/bpf_network.c
@@ -81,6 +81,11 @@ int cil_from_network(struct __ctx_buff *ctx)
 		obs_point_to = TRACE_TO_HOST;
 #endif
 
+#ifdef IP_TRACING_OPTION_TYPE
+	if (IP_TRACING_OPTION_TYPE > 0)
+		check_and_store_ip_trace_id(ctx, IP_TRACING_OPTION_TYPE);
+#endif
+
 out:
 	send_trace_notify(ctx, obs_point_from, UNKNOWN_ID, UNKNOWN_ID,
 			  TRACE_EP_ID_UNKNOWN, ingress_ifindex,

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -594,6 +594,11 @@ int cil_from_overlay(struct __ctx_buff *ctx)
 	__u16 proto;
 	int ret;
 
+#ifdef IP_TRACING_OPTION_TYPE
+	if (IP_TRACING_OPTION_TYPE > 0)
+		check_and_store_ip_trace_id(ctx, IP_TRACING_OPTION_TYPE);
+#endif
+
 	bpf_clear_meta(ctx);
 	ctx_skip_nodeport_clear(ctx);
 

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -19,6 +19,7 @@
 #include "utils.h"
 #include "metrics.h"
 #include "ratelimit.h"
+#include "trace_helpers.h"
 
 struct drop_notify {
 	NOTIFY_CAPTURE_HDR

--- a/bpf/lib/ip_options.h
+++ b/bpf/lib/ip_options.h
@@ -1,0 +1,206 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#ifdef IP_TRACING_OPTION_TYPE
+
+/* Length of the initial supported IPv4 trace_id option (4 bytes).
+ * IPv4 IP options consist of 2 fixed bytes for the type and length,
+ * followed by a variable-length data field. An option length of 4 bytes
+ * indicates 2 fixed bytes for the type and length fields, and 2 bytes of
+ * ip_trace_id data.
+ */
+#define OPT16_LEN 4
+
+/* Length of the second supported IPv4 trace_id option (6 bytes).
+ * Indicates 4 bytes of ip_trace_id data.
+ */
+#define OPT32_LEN 6
+
+/* Length of the third supported IPv4 trace_id option (10 bytes).
+ * Indicates 8 bytes of ip_trace_id data.
+ */
+#define OPT64_LEN 10
+
+/* Maximum number of IPv4 options to process. */
+#define MAX_IPV4_OPTS 3
+
+/* The minimum value for IHL which corresponds to a packet with no options.
+ *
+ * A standard IP packet header has 20 bytes and the IHL is the number of 32 byte
+ * words.
+ */
+#define IHL_WITH_NO_OPTS 5
+
+/* Signifies that options were parsed correctly but no trace ID was found. */
+#define TRACE_ID_NOT_FOUND 0
+
+/* Signifies a failure to determine the trace ID based on an unspecified error. */
+#define TRACE_ID_ERROR -1
+
+/* Signifies that the trace ID was found but it was invalid. */
+#define TRACE_ID_INVALID -2
+
+/* Signifies a failure to determine trace ID because the IP family was not found. */
+#define TRACE_ID_NO_FAMILY -3
+
+/* Signifies a failure to determine trace ID because the IP option length was
+ * not supported.
+ */
+#define TRACE_ID_UNSUPPORTED_LENGTH_ERROR -4
+
+/* Signifies trace points which are being ignored because they're in IPv6
+ * code and not supported yet.
+ */
+#define TRACE_ID_SKIP_IPV6 -100
+
+/* Converts a 64-bit integer from network byte order to host byte order. */
+static __always_inline __u64 ntohll(__u64 value)
+{
+	return ((value & 0x00000000000000FFULL) << 56) |
+		   ((value & 0x000000000000FF00ULL) << 40) |
+		   ((value & 0x0000000000FF0000ULL) << 24) |
+		   ((value & 0x00000000FF000000ULL) << 8)  |
+		   ((value & 0x000000FF00000000ULL) >> 8)  |
+		   ((value & 0x0000FF0000000000ULL) >> 24) |
+		   ((value & 0x00FF000000000000ULL) >> 40) |
+		   ((value & 0xFF00000000000000ULL) >> 56);
+}
+
+/* trace_id_from_ip4 parses the IP options and returns the trace ID.
+ *
+ * See trace_id_from_ctx for more info.
+ */
+static __always_inline int
+trace_id_from_ip4(struct __ctx_buff *ctx, __s64 *value,
+		  const struct iphdr *ip4,
+		  __u8 trace_ip_opt_type)
+{
+	__u32 offset;
+	__u32 end;
+	int i;
+	__u8 opt_type;
+	__u8 optlen;
+
+	if (ip4->ihl <= IHL_WITH_NO_OPTS)
+		return TRACE_ID_NOT_FOUND;
+
+	offset = ETH_HLEN + sizeof(struct iphdr);
+	end = offset + (ip4->ihl << 2);
+
+#pragma unroll(MAX_IPV4_OPTS)
+	for (i = 0; i < MAX_IPV4_OPTS && offset < end; i++) {
+		/* We load the option header 1 field at a time since different types
+		 * have different formats.
+		 *
+		 * "Options 0 and 1 are exactly one octet which is their type field. All
+		 * other options have their one octet type field, followed by a one
+		 * octet length field, followed by length-2 octets of option data."
+		 *
+		 * Ref: https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml
+		 */
+
+		if (ctx_load_bytes(ctx, offset, &opt_type, 1) < 0)
+			return TRACE_ID_ERROR;
+
+		if (opt_type == IPOPT_END)
+			break;
+
+		if (opt_type == IPOPT_NOOP) {
+			offset++;
+			continue;
+		}
+
+		if (ctx_load_bytes(ctx, offset + 1, &optlen, 1) < 0)
+			return TRACE_ID_ERROR;
+
+		if (opt_type != trace_ip_opt_type) {
+			offset += optlen;
+			continue;
+		}
+
+		if (optlen != OPT16_LEN && optlen != OPT32_LEN && optlen != OPT64_LEN)
+			return TRACE_ID_INVALID;
+
+		switch (optlen) {
+			case OPT16_LEN: {
+				__s16 temp;
+
+				if (ctx_load_bytes(ctx, offset + 2, &temp, sizeof(temp)) < 0)
+					return TRACE_ID_ERROR;
+				*value = bpf_ntohs(temp);
+				return 0;
+			}
+			case OPT32_LEN: {
+				__s32 temp;
+
+				if (ctx_load_bytes(ctx, offset + 2, &temp, sizeof(temp)) < 0)
+					return TRACE_ID_ERROR;
+				*value = bpf_ntohl(temp);
+				return 0;
+			}
+			case OPT64_LEN: {
+				__s64 temp;
+
+				if (ctx_load_bytes(ctx, offset + 2, &temp, sizeof(temp)) < 0)
+					return TRACE_ID_ERROR;
+				*value = ntohll(temp);
+				return 0;
+			}
+		default:
+			return TRACE_ID_UNSUPPORTED_LENGTH_ERROR;
+		}
+	}
+	return TRACE_ID_NOT_FOUND;
+}
+
+/*
+ * Parses the context to extract the trace ID from the IP options.
+ *
+ * Arguments:
+ * - ctx: The context buffer from which the IP options will be read.
+ * - ip_opt_type_value: The type value of the IP option that contains the trace ID.
+ *
+ * Prerequisites:
+ * - Supports reading a trace ID embedded in IP options with lengths of 2, 4, or 8 bytes.
+ * - No support for trace_ids that are not 2, 4, or 8 bytes.
+ *
+ * Outputs:
+ * - Returns 0 if the trace ID is found.
+ * - Returns TRACE_ID_NOT_FOUND if no trace ID is found in the options.
+ * - Returns TRACE_ID_INVALID if the found trace ID is invalid (e.g., non-positive).
+ * - Returns TRACE_ID_ERROR if there is an error during parsing.
+ * - Returns TRACE_ID_NO_FAMILY if the packet is not IPv4.
+ * - Returns TRACE_ID_SKIP_IPV6 if the packet is IPv6.
+ */
+static __always_inline int
+trace_id_from_ctx(struct __ctx_buff *ctx, __s64 *value, __u8 ip_opt_type_value)
+{
+	__u16 proto;
+	void *data, *data_end;
+	struct iphdr *ip4;
+	int ret;
+	__s64 trace_id = 0;
+
+	if (!validate_ethertype(ctx, &proto))
+		return TRACE_ID_ERROR;
+
+	if (proto == bpf_htons(ETH_P_IPV6))
+		return TRACE_ID_SKIP_IPV6;
+
+	if (proto != bpf_htons(ETH_P_IP))
+		return TRACE_ID_NO_FAMILY;
+
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+		return TRACE_ID_ERROR;
+
+	ret = trace_id_from_ip4(ctx, &trace_id, ip4, ip_opt_type_value);
+	if (IS_ERR(ret))
+		return ret;
+
+	*value = trace_id;
+	return 0;
+}
+
+#endif /* IP_TRACING_OPTION_TYPE */

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -27,6 +27,7 @@
 #include "utils.h"
 #include "metrics.h"
 #include "ratelimit.h"
+#include "trace_helpers.h"
 
 /* Available observation points. */
 enum trace_point {

--- a/bpf/lib/trace_helpers.h
+++ b/bpf/lib/trace_helpers.h
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#ifndef TRACE_ID_UTIL_H
+#define TRACE_ID_UTIL_H
+
+#include <bpf/ctx/ctx.h>
+#include <bpf/api.h>
+#include "common.h"
+#include "ip_options.h"
+
+#ifdef IP_TRACING_OPTION_TYPE
+/* Define the ip trace ID map with __u64 trace_id */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32); /* only one key */
+	__type(value, __u64); /* trace_id type */
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+} trace_id_map __section_maps_btf;
+
+/* bpf_trace_id_set sets the trace_id in the map. */
+static __always_inline __u64 bpf_trace_id_set(__u64 trace_id)
+{
+	__u32 __z = 0;
+	__u64 *__cache = map_lookup_elem(&trace_id_map, &__z);
+
+	if (__cache)
+		*__cache = trace_id;
+
+	return trace_id;
+}
+
+/* bpf_trace_id_get retrieves the trace_id from the map. */
+static __always_inline __u64 bpf_trace_id_get(void)
+{
+	__u32 __z = 0;
+	__u64 *__cache = map_lookup_elem(&trace_id_map, &__z);
+	__u64 trace_id = 0;
+
+	if (__cache)
+		trace_id = *__cache;
+
+	return trace_id;
+}
+
+/* Function to parse and store the trace_id and if valid. */
+static __always_inline void
+check_and_store_ip_trace_id(struct __ctx_buff *ctx, __u8 ip_opt_type_value)
+{
+	int ret;
+	__s64 trace_id = 0;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, ip_opt_type_value);
+	if (IS_ERR(ret))
+		bpf_trace_id_set(0);
+	else
+		bpf_trace_id_set(trace_id);
+}
+
+#else
+
+/* Provide alternative definitions for when tracing is disabled. */
+
+#define bpf_trace_id_get() (0)
+
+#endif /* IP_TRACING_OPTION_TYPE */
+
+static __always_inline __u64 load_ip_trace_id(void)
+{
+	return bpf_trace_id_get();
+}
+
+#endif /* TRACE_ID_UTIL_H */

--- a/bpf/tests/ip_options_trace_id.c
+++ b/bpf/tests/ip_options_trace_id.c
@@ -1,0 +1,1041 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+#include "node_config.h"
+
+#define DEBUG
+#define IP_TRACING_OPTION_TYPE
+
+#include <lib/ip_options.h>
+
+/* Used to define IP options for packet generation. */
+struct ipopthdr {
+	/* type field of the IP option. */
+	__u8 type;
+	/* len field of the IP option. Usually equal to total length of the IP
+	 * option, including type and len. Can be specified different from data
+	 * length for testing purposes. If zero, it will not be written to the
+	 * packet, so that tests can specify single-byte options.
+	 */
+	__u8 len;
+	/* Arbitrary data for the payload of the IP option. */
+	__u8 *data;
+	/* Length of the data field in bytes. Must match exactly. */
+	__u8 data_len;
+};
+
+/* Injects a packet into the ctx with the IPv4 options specified. See comments
+ * on the struct for more details on how to specify options. The total byte
+ * content of the options must align on 4-byte boundaries so that the IHL can be
+ * accurate.
+ * opts_len:   the number of options in opts.
+ * opts_bytes: the total number of bytes in options.
+ */
+static __always_inline __maybe_unused int
+gen_packet_with_options(struct __sk_buff *ctx,
+			const struct ipopthdr *opts,
+			__u8 opts_len, __u8 opt_bytes)
+{
+	struct pktgen builder;
+	struct iphdr *l3;
+	__u8 *new_opt;
+	int i, j, new_opt_len;
+
+	if (opt_bytes % 4 != 0)
+		return TEST_ERROR;
+	pktgen__init(&builder, ctx);
+	if (!pktgen__push_ethhdr(&builder))
+		return TEST_ERROR;
+	l3 = pktgen__push_default_iphdr_with_options(&builder, opt_bytes / 4);
+	if (!l3)
+		return TEST_ERROR;
+
+	new_opt = (__u8 *)&l3[1];
+	for (i = 0; i < opts_len; i++) {
+		new_opt_len = 0;
+		new_opt[0] = opts[i].type;
+		new_opt_len++;
+		if (opts[i].len != 0) {
+			new_opt[new_opt_len] = opts[i].len;
+			new_opt_len++;
+		}
+		for (j = 0; j < opts[i].data_len; j++) {
+			new_opt[new_opt_len] = opts[i].data[j];
+			new_opt_len++;
+		}
+		new_opt += new_opt_len;
+	}
+	if (!pktgen__push_data(&builder, default_data, sizeof(default_data)))
+		return TEST_ERROR;
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+/* SECTION 1: Following section has tests for the ntohll function,
+ * which converts a 64 byte int from network order to host byte order.
+ */
+
+/* General test for non-mixed. */
+CHECK("tc", "test_ntohll_function")
+int check_test_ntohll_function(void)
+{
+	test_init();
+
+	__u64 input = 0x0102030405060708;
+	__u64 expected_output = 0x0807060504030201;
+	__u64 output = ntohll(input);
+
+	if (output != expected_output)
+		test_fatal("0x%016llx but want 0x%016llx\n", input, output, expected_output);
+	test_finish();
+}
+
+/* Test positive values which would be negative on conversion. */
+CHECK("tc", "test_ntohll_max_positive")
+int check_test_ntohll_max_positive(void)
+{
+	test_init();
+
+	__u64 input = 0xFFFFFFFFFFFFFF80;
+	__u64 expected_output = 0x80FFFFFFFFFFFFFF;
+	__u64 output = ntohll(input);
+
+	if (output != expected_output)
+		test_fatal("0x%016llx but want 0x%016llx\n", input, output, expected_output);
+	test_finish();
+}
+
+/* Test max negative values. */
+CHECK("tc", "test_ntohll_min_negative")
+int check_test_ntohll_min_negative(void)
+{
+	test_init();
+
+	__u64 input = 0x8000000000000000;
+	__u64 expected_output = 0x0000000000000080;
+	__u64 output = ntohll(input);
+
+	if (output != expected_output)
+		test_fatal("0x%016llx but want 0x%016llx\n", input, output, expected_output);
+	test_finish();
+}
+
+/* Test for mixed_endian. */
+CHECK("tc", "test_ntohll_mixed_endian")
+int check_test_ntohll_mixed_endian(void)
+{
+	test_init();
+
+	__u64 input = 0x12345678ABCDEF01;
+	__u64 expected_output = 0x01EFCDAB78563412;
+	__u64 output = ntohll(input);
+
+	if (output != expected_output)
+		test_fatal("0x%016llx but want 0x%016llx\n", input, output, expected_output);
+	test_finish();
+}
+
+/* SECTION 2: Following section has tests for trace ID feature for packet
+ * validation and preprocessing.
+ */
+
+/* Test packet with no l3 header should return TRACE_ID_ERROR. */
+PKTGEN("tc", "extract_trace_id_with_no_l3_header_error")
+int test_extract_trace_id_with_no_l3_header_error_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	if (!pktgen__push_ethhdr(&builder))
+		return TEST_ERROR;
+	if (!pktgen__push_data(&builder, default_data, sizeof(default_data)))
+		return TEST_ERROR;
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+CHECK("tc", "extract_trace_id_with_no_l3_header_error")
+int test_extract_trace_id_with_no_l3_header_error_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_ERROR;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test packet with no eth header should return TRACE_ID_NO_FAMILY. */
+PKTGEN("tc", "extract_trace_id_with_no_eth_header_no_family")
+int test_extract_trace_id_with_no_eth_header_no_family_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	if (!pktgen__push_data(&builder, default_data, sizeof(default_data)))
+		return TEST_ERROR;
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+CHECK("tc", "extract_trace_id_with_no_eth_header_no_family")
+int test_extract_trace_id_with_no_eth_header_no_family_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_NO_FAMILY;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test packet with IPv6 header should return TRACE_ID_SKIP_IPV6. */
+PKTGEN("tc", "extract_trace_id_no_ipv6_options")
+int test_extract_trace_id_no_ipv6_options_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	if (!pktgen__push_ethhdr(&builder))
+		return TEST_ERROR;
+	if (!pktgen__push_default_ipv6hdr(&builder))
+		return TEST_ERROR;
+	if (!pktgen__push_data(&builder, default_data, sizeof(default_data)))
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+CHECK("tc", "extract_trace_id_no_ipv6_options")
+int test_extract_trace_id_no_ipv6_options_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_SKIP_IPV6;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+	test_finish();
+}
+
+/* Test a single option specifying the trace ID with no special cases. */
+PKTGEN("tc", "extract_trace_id_solo")
+int test_extract_trace_id_solo_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 4,
+			.data = (__u8 *)"\x00\x01",
+			.data_len = 2,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 1, 4);
+}
+
+CHECK("tc", "extract_trace_id_solo")
+int test_extract_trace_id_solo_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 1;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test packet with IPv4 header should return TRACE_ID_NOT_FOUND. */
+PKTGEN("tc", "extract_trace_id_no_ipv4_options")
+int test_extract_trace_id_no_options_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	if (!pktgen__push_ethhdr(&builder))
+		return TEST_ERROR;
+	if (!pktgen__push_iphdr(&builder, 0))
+		return TEST_ERROR;
+	if (!pktgen__push_data(&builder, default_data, sizeof(default_data)))
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+CHECK("tc", "extract_trace_id_no_ipv4_options")
+int test_extract_trace_id_no_options_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_NOT_FOUND;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test trace ID after END should return TRACE_ID_NOT_FOUND. */
+PKTGEN("tc", "extract_trace_id_after_ipopt_end_not_found")
+int test_extract_trace_id_after_ipopt_end_not_found_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = IPOPT_END,
+			.len = 0,
+			.data_len = 0,
+		},
+		{
+			.type = 136,
+			.len = 4,
+			.data = (__u8 *)"\x00\x01",
+			.data_len = 2,
+		},
+		/* Add padding to align on 4-byte boundary. */
+		{
+			.type = IPOPT_NOOP,
+			.len = 0,
+			.data_len = 0,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0,
+			.data_len = 0,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0,
+			.data_len = 0,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 5, 8);
+}
+
+CHECK("tc", "extract_trace_id_after_ipopt_end_not_found")
+int test_extract_trace_id_after_ipopt_end_not_found_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_NOT_FOUND;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test trace ID comes after loop limit should return TRACE_ID_NOT_FOUND. */
+PKTGEN("tc", "extract_trace_id_after_loop_limit_not_found")
+int test_extract_trace_id_after_loop_limit_not_found_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = IPOPT_NOOP,
+			.len = 0,
+			.data_len = 0,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0,
+			.data_len = 0,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0,
+			.data_len = 0,
+		},
+		/* The loop limit is 3 so the following options are ignored. */
+		{
+			.type = 136,
+			.len = 4,
+			.data = (__u8 *)"\x00\x01",
+			.data_len = 2,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0,
+			.data_len = 0,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 5, 8);
+}
+
+CHECK("tc", "extract_trace_id_after_loop_limit_not_found")
+int test_extract_trace_id_after_loop_limit_not_found_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_NOT_FOUND;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test three options with the trace ID option being first. */
+PKTGEN("tc", "extract_trace_id_first_of_three")
+int test_extract_trace_id_first_of_three_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 4,
+			.data = (__u8 *)"\x00\x01",
+			.data_len = 2,
+		},
+		{
+			.type = 10,
+			.len = 4,
+			.data = (__u8 *)"\x10\x10",
+			.data_len = 2,
+		},
+		{
+			.type = 11,
+			.len = 4,
+			.data = (__u8 *)"\x11\x11",
+			.data_len = 2,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 3, 12);
+}
+
+CHECK("tc", "extract_trace_id_first_of_three")
+int test_extract_trace_id_first_of_three_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 1;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test three options with the trace ID option being between the other two. */
+PKTGEN("tc", "extract_trace_id_middle_of_three")
+int test_extract_trace_id_middle_of_three_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 10,
+			.len = 4,
+			.data = (__u8 *)"\x10\x10",
+			.data_len = 2,
+		},
+		{
+			.type = 136,
+			.len = 4,
+			.data = (__u8 *)"\x00\x01",
+			.data_len = 2,
+		},
+		{
+			.type = 11,
+			.len = 4,
+			.data = (__u8 *)"\x11\x11",
+			.data_len = 2,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 3, 12);
+}
+
+CHECK("tc", "extract_trace_id_middle_of_three")
+int test_extract_trace_id_middle_of_three_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 1;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test three options with the trace ID option being last of the three. */
+PKTGEN("tc", "extract_trace_id_last_of_three")
+int test_extract_trace_id_last_of_three_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 10,
+			.len = 4,
+			.data = (__u8 *)"\x10\x10",
+			.data_len = 2,
+		},
+		{
+			.type = 11,
+			.len = 4,
+			.data = (__u8 *)"\x11\x11",
+			.data_len = 2,
+		},
+		{
+			.type = 136,
+			.len = 4,
+			.data = (__u8 *)"\x00\x01",
+			.data_len = 2,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 3, 12);
+}
+
+CHECK("tc", "extract_trace_id_last_of_three")
+int test_extract_trace_id_last_of_three_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 1;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test multiple options with the trace ID coming after a NOOP option. */
+PKTGEN("tc", "extract_trace_id_after_ipopt_noop")
+int test_extract_trace_id_after_ipopt_noop_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = IPOPT_NOOP,
+			.len = 0, /* Single byte option. */
+			.data_len = 0,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0, /* Single byte option. */
+			.data_len = 0,
+		},
+		{
+			.type = 136,
+			.len = 4,
+			.data = (__u8 *)"\x00\x01",
+			.data_len = 2,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0, /* Single byte option. */
+			.data_len = 0,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0, /* Single byte option. */
+			.data_len = 0,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 5, 8);
+}
+
+CHECK("tc", "extract_trace_id_after_ipopt_noop")
+int test_extract_trace_id_after_ipopt_noop_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 1;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test multiple options with the trace ID not present should return TRACE_ID_NOT_FOUND. */
+PKTGEN("tc", "extract_trace_id_not_found_with_other_options")
+int test_extract_trace_id__not_found_with_other_options_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 10,
+			.len = 4,
+			.data = (__u8 *)"\x10\x10",
+			.data_len = 2,
+		},
+		{
+			.type = 11,
+			.len = 4,
+			.data = (__u8 *)"\x11\x11",
+			.data_len = 2,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 2, 8);
+}
+
+CHECK("tc", "extract_trace_id_not_found_with_other_options")
+int test_extract_trace_id_not_found_with_other_options_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_NOT_FOUND;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test trace ID with incorrect length field should return INVALID. */
+PKTGEN("tc", "extract_trace_id_wrong_len_invalid")
+int test_extract_trace_id_wrong_len_invalid_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 3, /* Invalid length with this option. */
+			.data = (__u8 *)"\x00\x01",
+			.data_len = 2,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 1, 4);
+}
+
+CHECK("tc", "extract_trace_id_wrong_len_invalid")
+int test_extract_trace_id_wrong_len_invalid_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_INVALID;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test trace ID with negative value should return TRACE_ID_INVALID. */
+PKTGEN("tc", "extract_trace_id_negative")
+int test_extract_trace_id_negative_invalid_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+				.type = 136,
+				.len = 4,
+				.data = (__u8 *)"\x80\x01",
+				.data_len = 2,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 1, 4);
+}
+
+CHECK("tc", "extract_trace_id_negative")
+int test_extract_trace_id_negative_invalid_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 0x8001;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+
+	test_finish();
+}
+
+/* Store and read trace ID to different option than stream ID with 2 bytes of data. */
+PKTGEN("tc", "extract_trace_id_different_option_type")
+int test_extract_trace_id_different_option_type_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 137,
+			.len = 4,
+			.data = (__u8 *)"\x00\x02",
+			.data_len = 2,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 1, 4);
+}
+
+CHECK("tc", "extract_trace_id_different_option_type")
+int test_extract_trace_id_different_option_type_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 0x0002;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 137);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Read trace ID from wrong IP option. */
+PKTGEN("tc", "extract_read_trace_id_wrong_option_type")
+int test_extract_read_trace_id_wrong_option_type_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 137,
+			.len = 4,
+			.data = (__u8 *)"\x00\x02",
+			.data_len = 2,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 1, 4);
+}
+
+CHECK("tc", "extract_read_trace_id_wrong_option_type")
+int test_extract_read_trace_id_wrong_option_type_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_NOT_FOUND;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test a valid 4-byte trace ID. */
+PKTGEN("tc", "extract_trace_id_4_bytes_valid")
+int test_extract_trace_id_4_bytes_valid_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 6,
+			.data = (__u8 *)"\x00\x01\x23\x45",
+			.data_len = 4,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 1, 8);
+}
+
+CHECK("tc", "extract_trace_id_4_bytes_valid")
+int test_extract_trace_id_4_bytes_valid_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 0x00012345;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+	test_finish();
+}
+
+/* Test negative trace id should return valid. */
+PKTGEN("tc", "extract_trace_id_negative_4_bytes")
+int test_extract_trace_id_negative_4_bytes_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 6,
+			.data = (__u8 *)"\x80\x01\x23\x45",
+			.data_len = 4,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 1, 8);
+}
+
+CHECK("tc", "extract_trace_id_negative_4_bytes")
+int test_extract_trace_id_negative_4_bytes_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 0x80012345;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+	test_finish();
+}
+
+/* Test a 4-byte trace ID with incorrect length. */
+PKTGEN("tc", "extract_trace_id_4_bytes_wrong_length")
+int test_extract_trace_id_4_bytes_wrong_length_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 5, /* Incorrect length */
+			.data = (__u8 *)"\x01\x23\x45\x67",
+			.data_len = 4,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 1, 8);
+}
+
+CHECK("tc", "extract_trace_id_4_bytes_wrong_length")
+int test_extract_trace_id_4_bytes_wrong_length_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_INVALID;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+	test_finish();
+}
+
+/* Test a 4-byte trace ID before the end of option list. */
+PKTGEN("tc", "extract_trace_id_4_bytes_before_end")
+int test_extract_trace_id_4_bytes_before_end_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 6,
+			.data = (__u8 *)"\x00\x01\x23\x45",
+			.data_len = 4,
+		},
+		{
+			.type = IPOPT_END,
+			.len = 0,
+			.data_len = 0,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 2, 8);
+}
+
+CHECK("tc", "extract_trace_id_4_bytes_before_end")
+int test_extract_trace_id_4_bytes_before_end_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 0x12345;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+	test_finish();
+}
+
+/* Test a valid 8-byte trace ID should return TRACE_ID_ERROR. */
+PKTGEN("tc", "extract_trace_id_8_bytes_valid")
+int test_extract_trace_id_8_bytes_valid_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 10,
+			.data = (__u8 *)"\x12\x34\x56\x78\x9A\xBC\xDE\xF0",
+			.data_len = 8,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 1, 12);
+}
+
+CHECK("tc", "extract_trace_id_8_bytes_valid")
+int test_extract_trace_id_8_bytes_valid_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 0x123456789abcdef0;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+	test_finish();
+}
+
+/* Test an 8-byte trace ID followed by padding. */
+PKTGEN("tc", "extract_trace_id_8_bytes_with_padding")
+int test_extract_trace_id_8_bytes_with_padding_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 10, /* Total length including type and len fields */
+			.data = (__u8 *)"\x01\x02\x03\x04\x00\x00\x00\x00",
+			.data_len = 8,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0,
+			.data_len = 0,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 2, 12);
+}
+
+CHECK("tc", "extract_trace_id_8_bytes_with_padding")
+int test_extract_trace_id_8_bytes_with_padding_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 0x0102030400000000; /* Expected valid trace ID */
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+	test_finish();
+}
+
+/* Test an 8-byte trace ID that represents a negative value. */
+PKTGEN("tc", "extract_trace_id_8_bytes_negative")
+int test_extract_trace_id_8_bytes_negative_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 10,
+			.data = (__u8 *)"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFA",
+			.data_len = 8,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 1, 12);
+}
+
+CHECK("tc", "extract_trace_id_8_bytes_negative")
+int test_extract_trace_id_8_bytes_negative_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 0xFFFFFFFFFFFFFFFA;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+
+	test_finish();
+}
+
+/* Test an 8-byte trace ID with an invalid option length. */
+PKTGEN("tc", "extract_trace_id_8_bytes_invalid_length")
+int test_extract_trace_id_8_bytes_invalid_length_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 9, /* Invalid length, should be 10 */
+			.data = (__u8 *)"\x01\x02\x03\x04\x05\x06\x07\x08",
+			.data_len = 8,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 1, 12);
+}
+
+CHECK("tc", "extract_trace_id_8_bytes_invalid_length")
+int test_extract_trace_id_8_bytes_invalid_length_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_INVALID; /* Expected invalid trace ID */
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+	test_finish();
+}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1055,6 +1055,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Float64(option.ConnectivityProbeFrequencyRatio, defaults.ConnectivityProbeFrequencyRatio, "Ratio of the connectivity probe frequency vs resource usage, a float in [0, 1]. 0 will give more frequent probing, 1 will give less frequent probing. Probing frequency is dynamically adjusted based on the cluster size.")
 	option.BindEnv(vp, option.ConnectivityProbeFrequencyRatio)
 
+	flags.Uint8(option.IPTracingOptionType, 0, "Specifies what IPv4 option type should be used to extract trace information from a packet; a value of 0 (default) disables IP tracing.")
+	option.BindEnv(vp, option.IPTracingOptionType)
+
 	if err := vp.BindPFlags(flags); err != nil {
 		log.Fatalf("BindPFlags failed: %s", err)
 	}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -787,6 +787,11 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION"] = "1"
 	}
 
+	// Write IP_OPTION_TRACING_TYPE macro from EnablePacketIPTracing value
+	if option.Config.IPTracingOptionType > 0 {
+		cDefinesMap["IP_TRACING_OPTION_TYPE"] = strconv.Itoa(int(option.Config.IPTracingOptionType))
+	}
+
 	fmt.Fprint(fw, declareConfig("identity_length", identity.GetClusterIDShift(), "Identity length in bits"))
 	fmt.Fprint(fw, assignConfig("identity_length", identity.GetClusterIDShift()))
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -587,6 +587,9 @@ const (
 
 	// ConnectivityProbeFrequencyRatio is the default connectivity probe frequency
 	ConnectivityProbeFrequencyRatio = 0.5
+
+	// IPTracingOptionType is the default value for option.IPTracingOptionType
+	IPTracingOptionType = 0
 )
 
 var (

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1144,6 +1144,9 @@ const (
 
 	// ConnectivityProbeFrequencyRatio is the name of the option to specify the connectivity probe frequency
 	ConnectivityProbeFrequencyRatio = "connectivity-probe-frequency-ratio"
+
+	// IPTracingOptionType specifies what IPv4 option type should be used to extract trace information from a packet
+	IPTracingOptionType = "ip-tracing-option-type"
 )
 
 // Default string arguments
@@ -2241,6 +2244,9 @@ type DaemonConfig struct {
 
 	// ConnectivityProbeFrequencyRatio is the ratio of the connectivity probe frequency vs resource consumption
 	ConnectivityProbeFrequencyRatio float64
+
+	// IPTracingOptionType determines whether to enable IP tracing, and if enabled what option type to use.
+	IPTracingOptionType uint
 }
 
 var (
@@ -2307,6 +2313,8 @@ var (
 		EnableSourceIPVerification: defaults.EnableSourceIPVerification,
 
 		ConnectivityProbeFrequencyRatio: defaults.ConnectivityProbeFrequencyRatio,
+
+		IPTracingOptionType: defaults.IPTracingOptionType,
 	}
 )
 
@@ -2968,6 +2976,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableIPSecEncryptedOverlay = vp.GetBool(EnableIPSecEncryptedOverlay)
 	c.LBSourceRangeAllTypes = vp.GetBool(LBSourceRangeAllTypes)
 	c.BootIDFile = vp.GetString(BootIDFilename)
+	c.IPTracingOptionType = vp.GetUint(IPTracingOptionType)
 
 	c.ServiceNoBackendResponse = vp.GetString(ServiceNoBackendResponse)
 	switch c.ServiceNoBackendResponse {


### PR DESCRIPTION
Related: https://github.com/cilium/cilium/issues/35057


This PR includes the initial IP packet tracing implementation (https://github.com/cilium/cilium/issues/35057), including:

- expose IP trace ID flag in agent
- define flag in datapath

This PR is a subset of https://github.com/cilium/cilium/pull/36825 to reduce the number of reviewers.


```release-note
Expose Trace ID flag
```