### PR TITLE
Modernize Go map and slice operations

### DIFF
--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -1319,10 +1319,8 @@ func (k *K8sClusterMesh) checkConnectionMode() error {
 		defaults.ClusterMeshConnectionModeUnicast,
 	}
 
-	for _, mode := range validModes {
-		if k.params.ConnectionMode == mode {
-			return nil
-		}
+	if slices.Contains(validModes, k.params.ConnectionMode) {
+		return nil
 	}
 
 	k.Log("❌ %s is not a correct connection mode.", k.params.ConnectionMode)
@@ -1497,7 +1495,7 @@ func (k *K8sClusterMesh) retrieveRemoteHelmValues(ctx context.Context, remoteCli
 }
 
 func removeStringFromSlice(name string, names []string) []string {
-	namesCopy := append([]string{}, names...)
+	namesCopy := slices.Clone(names)
 	namesCopy = slices.DeleteFunc(namesCopy, func(n string) bool {
 		return n == name
 	})

--- a/cilium-cli/clustermesh/clustermesh_test.go
+++ b/cilium-cli/clustermesh/clustermesh_test.go
@@ -29,7 +29,7 @@ func equalClusterSlices(a, b []map[string]interface{}) bool {
 	return slices.EqualFunc(a, bCopy, func(m1, m2 map[string]interface{}) bool {
 		for i, bm := range bCopy {
 			if reflect.DeepEqual(m1, bm) {
-				bCopy = append(bCopy[:i], bCopy[i+1:]...)
+				bCopy = slices.Delete(bCopy, i, i+1)
 				return true
 			}
 		}

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"regexp"
 	"strings"
 	"time"
@@ -311,9 +312,7 @@ func (r *FlowRequirementResults) Merge(from *FlowRequirementResults) {
 	if r.Matched == nil {
 		r.Matched = from.Matched
 	} else {
-		for k, v := range from.Matched {
-			r.Matched[k] = v
-		}
+		maps.Copy(r.Matched, from.Matched)
 	}
 	r.Failures += from.Failures
 	r.NeedMoreFlows = r.NeedMoreFlows || from.NeedMoreFlows

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -198,9 +198,7 @@ func newDeployment(p deploymentParameters) *appsv1.Deployment {
 		},
 	}
 
-	for k, v := range p.Labels {
-		dep.Spec.Template.ObjectMeta.Labels[k] = v
-	}
+	maps.Copy(dep.Spec.Template.ObjectMeta.Labels, p.Labels)
 
 	return dep
 }
@@ -313,9 +311,7 @@ func newDaemonSet(p daemonSetParameters) *appsv1.DaemonSet {
 		},
 	}
 
-	for k, v := range p.Labels {
-		ds.Spec.Template.ObjectMeta.Labels[k] = v
-	}
+	maps.Copy(ds.Spec.Template.ObjectMeta.Labels, p.Labels)
 
 	if p.NodeSelector != nil {
 		ds.Spec.Template.Spec.NodeSelector = p.NodeSelector

--- a/cilium-cli/connectivity/check/peer.go
+++ b/cilium-cli/connectivity/check/peer.go
@@ -5,6 +5,7 @@ package check
 
 import (
 	"fmt"
+	"maps"
 	"net"
 	"net/url"
 	"strconv"
@@ -129,9 +130,7 @@ func (p Pod) Port() uint32 {
 
 func (p Pod) Labels() map[string]string {
 	newMap := make(map[string]string, len(p.Pod.Labels))
-	for k, v := range p.Pod.Labels {
-		newMap[k] = v
-	}
+	maps.Copy(newMap, p.Pod.Labels)
 	return newMap
 }
 
@@ -239,9 +238,7 @@ func (s Service) HasLabel(name, value string) bool {
 // Labels returns the copy of service labels
 func (s Service) Labels() map[string]string {
 	newMap := make(map[string]string, len(s.Service.Labels))
-	for k, v := range s.Service.Labels {
-		newMap[k] = v
-	}
+	maps.Copy(newMap, s.Service.Labels)
 	return newMap
 }
 
@@ -436,9 +433,7 @@ func (he httpEndpoint) HasLabel(name, value string) bool {
 
 func (he httpEndpoint) Labels() map[string]string {
 	newMap := make(map[string]string, len(*he.labels))
-	for k, v := range *he.labels {
-		newMap[k] = v
-	}
+	maps.Copy(newMap, *he.labels)
 	return newMap
 }
 

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"slices"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -855,10 +856,5 @@ func (t *Test) CiliumLocalRedirectPolicies() map[string]*ciliumv2.CiliumLocalRed
 }
 
 func (t *Test) HasNetworkPolicies() bool {
-	for _, obj := range t.resources {
-		if isPolicy(obj) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(t.resources, isPolicy)
 }

--- a/cilium-cli/connectivity/tests/multicast.go
+++ b/cilium-cli/connectivity/tests/multicast.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"slices"
 	"strings"
 	"sync"
 
@@ -146,12 +147,7 @@ func (s *socatMulticast) addNodeWithoutGroup(nodeName string) {
 func (s *socatMulticast) isNodeWithoutGroup(nodeName string) bool {
 	NodeWithoutGroupMu.RLock()
 	defer NodeWithoutGroupMu.RUnlock()
-	for _, node := range NodeWithoutGroup {
-		if node == nodeName {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(NodeWithoutGroup, nodeName)
 }
 
 func (s *socatMulticast) addNotSubscribePodAddress(nodeName string, podAddress v2.NodeAddress) {

--- a/cilium-cli/connectivity/tests/upgrade.go
+++ b/cilium-cli/connectivity/tests/upgrade.go
@@ -6,6 +6,7 @@ package tests
 import (
 	"context"
 	gojson "encoding/json"
+	"maps"
 	"os"
 	"strconv"
 
@@ -88,10 +89,7 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 		}
 		defer file.Close()
 
-		counts := make(map[string]string)
-		for pod, count := range restartCount {
-			counts[pod] = count
-		}
+		counts := maps.Clone(restartCount)
 		j, err := gojson.Marshal(counts)
 		if err != nil {
 			t.Fatalf("Failed to marshal JSON: %s", err)

--- a/cilium-cli/encrypt/status.go
+++ b/cilium-cli/encrypt/status.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -312,9 +312,7 @@ func printClusterStatus(cs clusterStatus, format string) error {
 			for k := range cs.IPsecKeysInUseNodeCount {
 				keys = append(keys, k)
 			}
-			sort.Slice(keys, func(i, j int) bool {
-				return keys[i] < keys[j]
-			})
+			slices.Sort(keys)
 			keyStrs := make([]string, 0, len(keys))
 			for _, k := range keys {
 				keyStrs = append(keyStrs, fmt.Sprintf("%d on %d/%d", k, cs.IPsecKeysInUseNodeCount[k], cs.TotalNodeCount))

--- a/cilium-cli/internal/helm/helm.go
+++ b/cilium-cli/internal/helm/helm.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path"
 	"regexp"
@@ -38,10 +39,7 @@ var settings = cli.New()
 
 // Merge maps recursively merges the values of b into a copy of a, preferring the values from b
 func mergeMaps(a, b map[string]interface{}) map[string]interface{} {
-	out := make(map[string]interface{}, len(a))
-	for k, v := range a {
-		out[k] = v
-	}
+	out := maps.Clone(a)
 	for k, v := range b {
 		if v, ok := v.(map[string]interface{}); ok {
 			if bv, ok := out[k]; ok {

--- a/cilium-dbg/cmd/bpf_lb_maglev_list.go
+++ b/cilium-dbg/cmd/bpf_lb_maglev_list.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"errors"
+	"maps"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -52,9 +53,7 @@ func dumpMaglevTables() (map[string][]string, error) {
 	}
 
 	// Merge v6 lookup tables into result.
-	for k, v := range v6 {
-		out[k] = v
-	}
+	maps.Copy(out, v6)
 
 	return out, nil
 }

--- a/cilium-dbg/cmd/helpers.go
+++ b/cilium-dbg/cmd/helpers.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -423,13 +424,8 @@ func getIpEnableStatuses() (bool, bool) {
 }
 
 func mergeMaps(m1, m2 map[string]interface{}) map[string]interface{} {
-	m3 := make(map[string]interface{})
-	for k, v := range m1 {
-		m3[k] = v
-	}
-	for k, v := range m2 {
-		m3[k] = v
-	}
+	m3 := maps.Clone(m1)
+	maps.Copy(m3, m2)
 	return m3
 }
 

--- a/cilium-dbg/cmd/helpers_test.go
+++ b/cilium-dbg/cmd/helpers_test.go
@@ -6,7 +6,7 @@ package cmd
 import (
 	"bytes"
 	"path"
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -555,9 +555,7 @@ func TestParseTrafficString(t *testing.T) {
 
 func TestParsePolicyUpdateArgsHelper(t *testing.T) {
 	sortProtos := func(ints []u8proto.U8proto) {
-		sort.Slice(ints, func(i, j int) bool {
-			return ints[i] < ints[j]
-		})
+		slices.Sort(ints)
 	}
 
 	allProtos := []u8proto.U8proto{}

--- a/cilium-dbg/cmd/kvstore.go
+++ b/cilium-dbg/cmd/kvstore.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"log/slog"
+	"maps"
 
 	"github.com/spf13/cobra"
 
@@ -42,9 +43,7 @@ func setupKvstore(ctx context.Context, logger *slog.Logger) {
 		}
 
 		if len(kvStoreOpts) == 0 {
-			for k, v := range cfgStatus.KvstoreConfiguration.Options {
-				kvStoreOpts[k] = v
-			}
+			maps.Copy(kvStoreOpts, cfgStatus.KvstoreConfiguration.Options)
 		}
 	}
 

--- a/cilium-dbg/cmd/policy.go
+++ b/cilium-dbg/cmd/policy.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -104,11 +105,9 @@ func handleUnmarshalError(f string, content []byte, err error) error {
 }
 
 func ignoredFile(name string) bool {
-	for _, n := range ignoredFileNames {
-		if name == n {
-			logrus.WithField(logfields.Path, name).Debug("Ignoring file")
-			return true
-		}
+	if slices.Contains(ignoredFileNames, name) {
+		logrus.WithField(logfields.Path, name).Debug("Ignoring file")
+		return true
 	}
 
 	return false

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -9,7 +9,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -350,9 +350,7 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 		// uint32(prodFooSecLblsCtx.ID),
 		// uint32(prodFooJoeSecLblsCtx.ID),
 	}
-	sort.Slice(expectedRemotePolicies, func(i, j int) bool {
-		return expectedRemotePolicies[i] < expectedRemotePolicies[j]
-	})
+	slices.Sort(expectedRemotePolicies)
 	expectedNetworkPolicy := &cilium.NetworkPolicy{
 		EndpointIps:      []string{QAIPv6Addr.String(), QAIPv4Addr.String()},
 		EndpointId:       uint64(eQABar.ID),
@@ -393,9 +391,7 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 		uint32(prodFooSecLblsCtx.ID),
 		uint32(prodFooJoeSecLblsCtx.ID),
 	}
-	sort.Slice(expectedRemotePolicies, func(i, j int) bool {
-		return expectedRemotePolicies[i] < expectedRemotePolicies[j]
-	})
+	slices.Sort(expectedRemotePolicies)
 
 	expectedNetworkPolicy = &cilium.NetworkPolicy{
 		EndpointIps:      []string{ProdIPv6Addr.String(), ProdIPv4Addr.String()},

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"slices"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -318,7 +319,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState, endpoi
 		if err := d.endpointManager.RestoreEndpoint(ep); err != nil {
 			log.WithError(err).Warning("Unable to restore endpoint")
 			// remove endpoint from slice of endpoints to restore
-			state.restored = append(state.restored[:i], state.restored[i+1:]...)
+			state.restored = slices.Delete(state.restored, i, i+1)
 		}
 	}
 

--- a/hubble/cmd/observe/flows_filter.go
+++ b/hubble/cmd/observe/flows_filter.go
@@ -47,10 +47,8 @@ func (f filterTracker) String() string {
 }
 
 func (f *filterTracker) add(name string) bool {
-	for _, exists := range f.changed {
-		if name == exists {
-			return false
-		}
+	if slices.Contains(f.changed, name) {
+		return false
 	}
 
 	// wipe the existing values if this is the first time usage of this

--- a/operator/pkg/ciliumidentity/reconciler_test.go
+++ b/operator/pkg/ciliumidentity/reconciler_test.go
@@ -6,6 +6,7 @@ package ciliumidentity
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 	"testing"
 	"time"
@@ -97,9 +98,7 @@ func testNewReconciler(t *testing.T, ctx context.Context, enableCES bool) (*reco
 
 func testCreateCIDObj(id string, lbs map[string]string) *capi_v2.CiliumIdentity {
 	secLbs := make(map[string]string)
-	for k, v := range lbs {
-		secLbs[k] = v
-	}
+	maps.Copy(secLbs, lbs)
 
 	k := key.GetCIDKeyFromLabels(secLbs, labels.LabelSourceK8s)
 	secLbs = k.GetAsMap()

--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -6,6 +6,7 @@ package gateway_api
 import (
 	"context"
 	"log/slog"
+	"maps"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -167,9 +168,7 @@ func mergeMap(left, right map[string]string) map[string]string {
 	if left == nil {
 		return right
 	} else {
-		for key, value := range right {
-			left[key] = value
-		}
+		maps.Copy(left, right)
 	}
 	return left
 }

--- a/operator/pkg/gateway-api/httproute_gamma.go
+++ b/operator/pkg/gateway-api/httproute_gamma.go
@@ -6,6 +6,7 @@ package gateway_api
 import (
 	"context"
 	"log/slog"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -134,13 +135,7 @@ func (r *gammaHttpRouteReconciler) hasGammaParent() func(object client.Object) b
 			return false
 		}
 
-		for _, parent := range hr.Spec.ParentRefs {
-			if helpers.IsGammaService(parent) {
-				return true
-			}
-		}
-
-		return false
+		return slices.ContainsFunc(hr.Spec.ParentRefs, helpers.IsGammaService)
 	}
 }
 

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"math/big"
 	"net/netip"
 	"slices"
@@ -458,9 +459,7 @@ func (ipam *LBIPAM) serviceViewFromService(key resource.Key, svc *slim_core_v1.S
 	copy(sv.Ports, svc.Spec.Ports)
 	sv.Namespace = svc.Namespace
 	sv.Selector = make(map[string]string)
-	for k, v := range svc.Spec.Selector {
-		sv.Selector[k] = v
-	}
+	maps.Copy(sv.Selector, svc.Spec.Selector)
 	sv.Status = svc.Status.DeepCopy()
 
 	return sv

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -5,6 +5,7 @@ package gateway_api
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
@@ -376,8 +377,6 @@ func mergeMap(left, right map[string]string) map[string]string {
 	if left == nil {
 		return right
 	}
-	for key, value := range right {
-		left[key] = value
-	}
+	maps.Copy(left, right)
 	return left
 }

--- a/operator/pkg/networkpolicy/cell.go
+++ b/operator/pkg/networkpolicy/cell.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -234,7 +235,7 @@ func updateCondition(conditions []cilium_api_v2.NetworkPolicyCondition, errs err
 		Message:            message,
 	}
 
-	out := append([]cilium_api_v2.NetworkPolicyCondition{}, conditions...)
+	out := slices.Clone(conditions)
 
 	if foundIdx >= 0 {
 		// If the status did not change (just the message), don't bump the

--- a/operator/watchers/node_taint.go
+++ b/operator/watchers/node_taint.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync"
 	"time"
 
@@ -385,7 +386,7 @@ func setNodeTaint(ctx context.Context, c kubernetes.Interface, nodeGetter slimNo
 
 	taintFound := false
 
-	taints := append([]slim_corev1.Taint{}, k8sNode.Spec.Taints...)
+	taints := slices.Clone(k8sNode.Spec.Taints)
 	for _, taint := range k8sNode.Spec.Taints {
 		if taint.Key == pkgOption.Config.AgentNotReadyNodeTaintValue() {
 			taintFound = true

--- a/pkg/alibabacloud/eni/instances.go
+++ b/pkg/alibabacloud/eni/instances.go
@@ -6,6 +6,7 @@ package eni
 import (
 	"context"
 	"log/slog"
+	"maps"
 
 	eniTypes "github.com/cilium/cilium/pkg/alibabacloud/eni/types"
 	"github.com/cilium/cilium/pkg/alibabacloud/types"
@@ -181,9 +182,7 @@ func (m *InstancesManager) GetVSwitches() ipamTypes.SubnetMap {
 	defer m.mutex.RUnlock()
 
 	subnetsCopy := make(ipamTypes.SubnetMap)
-	for k, v := range m.vSwitches {
-		subnetsCopy[k] = v
-	}
+	maps.Copy(subnetsCopy, m.vSwitches)
 
 	return subnetsCopy
 }

--- a/pkg/alibabacloud/eni/limits/limits.go
+++ b/pkg/alibabacloud/eni/limits/limits.go
@@ -5,6 +5,7 @@ package limits
 
 import (
 	"context"
+	"maps"
 
 	openapi "github.com/cilium/cilium/pkg/alibabacloud/api"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
@@ -28,9 +29,7 @@ func Update(limitMap map[string]ipamTypes.Limits) {
 	limits.Lock()
 	defer limits.Unlock()
 
-	for k, v := range limitMap {
-		limits.m[k] = v
-	}
+	maps.Copy(limits.m, limitMap)
 }
 
 // Get returns the instance limits of a particular instance type.

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
@@ -154,9 +155,7 @@ func NewTagsFilter(tags map[string]string) []ec2_types.Filter {
 func MergeTags(tagMaps ...map[string]string) map[string]string {
 	merged := make(map[string]string)
 	for _, tagMap := range tagMaps {
-		for k, v := range tagMap {
-			merged[k] = v
-		}
+		maps.Copy(merged, tagMap)
 	}
 	return merged
 }

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -8,6 +8,7 @@ package eni
 import (
 	"context"
 	"log/slog"
+	"maps"
 	"slices"
 
 	ec2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -122,9 +123,7 @@ func (m *InstancesManager) GetSubnets(ctx context.Context) ipamTypes.SubnetMap {
 	defer m.mutex.RUnlock()
 
 	subnetsCopy := make(ipamTypes.SubnetMap)
-	for k, v := range m.subnets {
-		subnetsCopy[k] = v
-	}
+	maps.Copy(subnetsCopy, m.subnets)
 
 	return subnetsCopy
 }

--- a/pkg/bgpv1/manager/reconciler/advertisements.go
+++ b/pkg/bgpv1/manager/reconciler/advertisements.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 
 	"github.com/cilium/cilium/pkg/bgpv1/manager/instance"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
@@ -132,7 +133,7 @@ func exportAdvertisementsReconciler(params *advertisementsReconcilerParams) ([]*
 
 	if len(toAdvertise) == 0 && len(toWithdraw) == 0 {
 		l.Debug("No reconciliation necessary")
-		return append([]*types.Path{}, params.currentAdvertisements...), nil
+		return slices.Clone(params.currentAdvertisements), nil
 	}
 
 	// create new adverts

--- a/pkg/bgpv1/manager/reconcilerv2/crd_status.go
+++ b/pkg/bgpv1/manager/reconcilerv2/crd_status.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sort"
 	"strings"
 
@@ -293,7 +294,7 @@ func (r *StatusReconciler) Reconcile(ctx context.Context, params StateReconcileP
 		// remove instance from status
 		for idx, instance := range current.BGPInstances {
 			if instance.Name == params.DeletedInstance {
-				current.BGPInstances = append(current.BGPInstances[:idx], current.BGPInstances[idx+1:]...)
+				current.BGPInstances = slices.Delete(current.BGPInstances, idx, idx+1)
 				break
 			}
 		}

--- a/pkg/bgpv1/manager/reconcilerv2/policies.go
+++ b/pkg/bgpv1/manager/reconcilerv2/policies.go
@@ -267,9 +267,7 @@ func mergePolicy(
 	// This function aims to be purely functional.  Here, we are creating a copy of the input to hold the result
 	// of the merge operation.
 	outputPolicyStatements = map[string]*types.RoutePolicyStatement{}
-	for key, value := range inputPolicyStatements {
-		outputPolicyStatements[key] = value
-	}
+	maps.Copy(outputPolicyStatements, inputPolicyStatements)
 
 	for _, statement := range policy.Statements {
 		key := statement.Conditions.String()

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"maps"
 	"net/netip"
+	"slices"
 
 	"github.com/cilium/hive/cell"
 	corev1 "k8s.io/api/core/v1"
@@ -862,13 +863,7 @@ func checkServiceAdvertisement(advert v2.BGPAdvertisement, advertServiceType v2.
 	}
 
 	// check service type is enabled in advertisement
-	svcTypeEnabled := false
-	for _, serviceType := range advert.Service.Addresses {
-		if serviceType == advertServiceType {
-			svcTypeEnabled = true
-			break
-		}
-	}
+	svcTypeEnabled := slices.Contains(advert.Service.Addresses, advertServiceType)
 	if !svcTypeEnabled {
 		return false, nil
 	}

--- a/pkg/bgpv1/manager/reconcilerv2/service_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service_test.go
@@ -2210,9 +2210,7 @@ func advertisedPoliciesAttributesMatch(
 	// Index policies by name
 	expectedPolicies := make(map[string]*types.RoutePolicy)
 	for _, routePolicyMap := range expectedResourceRoutePolicyMap {
-		for policyName, policy := range routePolicyMap {
-			expectedPolicies[policyName] = policy
-		}
+		maps.Copy(expectedPolicies, routePolicyMap)
 	}
 
 	req.Len(response.Policies, len(expectedPolicies))

--- a/pkg/bgpv1/test/gobgp.go
+++ b/pkg/bgpv1/test/gobgp.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 
 	gobgpapi "github.com/osrg/gobgp/v3/api"
 	"github.com/osrg/gobgp/v3/pkg/apiutil"
@@ -329,10 +330,8 @@ func (g *goBGP) waitForSessionState(ctx context.Context, expectedStates []string
 		case e := <-g.peerNotif:
 			g.logger.Info("GoBGP test instance", types.PeerEventLogField, e)
 
-			for _, state := range expectedStates {
-				if e.state == state {
-					return nil
-				}
+			if slices.Contains(expectedStates, e.state) {
+				return nil
 			}
 		case <-ctx.Done():
 			return fmt.Errorf("did not receive expected peering state %q: %w", expectedStates, ctx.Err())

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -4,6 +4,8 @@
 package client
 
 import (
+	"maps"
+
 	"github.com/cilium/cilium/api/v1/client/daemon"
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/api"
@@ -25,9 +27,7 @@ func (c *Client) ConfigPatch(cfg models.DaemonConfigurationSpec) error {
 		return err
 	}
 
-	for opt, value := range cfg.Options {
-		fullCfg.Spec.Options[opt] = value
-	}
+	maps.Copy(fullCfg.Spec.Options, cfg.Options)
 	if cfg.PolicyEnforcement != "" {
 		fullCfg.Spec.PolicyEnforcement = cfg.PolicyEnforcement
 	}

--- a/pkg/clustermesh/endpointslicesync/service_informer.go
+++ b/pkg/clustermesh/endpointslicesync/service_informer.go
@@ -119,9 +119,7 @@ func toKubeServicePort(clusterSvc *store.ClusterService) []v1.ServicePort {
 	// Merge all the port config into one to get all the possible ports
 	globalPortConfig := store.PortConfiguration{}
 	for _, portConfig := range clusterSvc.Backends {
-		for name, l4Addr := range portConfig {
-			globalPortConfig[name] = l4Addr
-		}
+		maps.Copy(globalPortConfig, portConfig)
 	}
 
 	// Get the ServicePort from the PortConfig

--- a/pkg/comparator/comparator.go
+++ b/pkg/comparator/comparator.go
@@ -3,6 +3,8 @@
 
 package comparator
 
+import "slices"
+
 // MapStringEqualsIgnoreKeys returns true if both maps have the same values for
 // the keys that are not present in the 'ignoreKeys'.
 func MapStringEqualsIgnoreKeys(m1, m2 map[string]string, ignoreKeys []string) bool {
@@ -16,11 +18,8 @@ func MapStringEqualsIgnoreKeys(m1, m2 map[string]string, ignoreKeys []string) bo
 	ignoredM1 := 0
 	for k1, v1 := range m1 {
 		var ignore bool
-		for _, ig := range ignoreKeys {
-			if k1 == ig {
-				ignore = true
-				break
-			}
+		if slices.Contains(ignoreKeys, k1) {
+			ignore = true
 		}
 		if ignore {
 			ignoredM1++

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -6,6 +6,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -229,9 +230,7 @@ func (m *Manager) GetStatusModel() models.ControllerStatuses {
 	// manager mutex quickly again
 	controllers := controllerMap{}
 	m.mutex.RLock()
-	for key, c := range m.controllers {
-		controllers[key] = c
-	}
+	maps.Copy(controllers, m.controllers)
 	m.mutex.RUnlock()
 
 	statuses := models.ControllerStatuses{}

--- a/pkg/counter/counter.go
+++ b/pkg/counter/counter.go
@@ -3,6 +3,8 @@
 
 package counter
 
+import "maps"
+
 // Counter tracks references for comparable .
 //
 // No thread safety is provided within this structure, the user is expected to
@@ -31,9 +33,7 @@ func (c Counter[T]) Delete(key T) bool {
 // DeepCopy makes a new copy of the received Counter.
 func (c Counter[T]) DeepCopy() Counter[T] {
 	result := make(Counter[T], len(c))
-	for k, v := range c {
-		result[k] = v
-	}
+	maps.Copy(result, c)
 	return result
 }
 

--- a/pkg/counter/prefixes_test.go
+++ b/pkg/counter/prefixes_test.go
@@ -4,6 +4,7 @@
 package counter
 
 import (
+	"maps"
 	"net"
 	"net/netip"
 	"testing"
@@ -101,9 +102,7 @@ func TestReferenceTracker(t *testing.T) {
 	expectedPrefixLengths = make(IntCounter, len(v6PrefixesLengths))
 
 	// Add the v6 prefixes (changed: true)
-	for k, v := range v6PrefixesLengths {
-		expectedPrefixLengths[k] = v
-	}
+	maps.Copy(expectedPrefixLengths, v6PrefixesLengths)
 	changed, err = result.Add(v6Prefixes)
 	require.NoError(t, err)
 	require.True(t, changed)

--- a/pkg/crypto/certloader/server.go
+++ b/pkg/crypto/certloader/server.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -146,10 +147,8 @@ func (c *WatchedServerConfig) ServerConfig(base *tls.Config) *tls.Config {
 
 // constructWithH2ProtoIfNeed constructs a new slice of protocols with h2
 func constructWithH2ProtoIfNeed(existingProtocols []string) []string {
-	for _, p := range existingProtocols {
-		if p == alpnProtocolH2 {
-			return existingProtocols
-		}
+	if slices.Contains(existingProtocols, alpnProtocolH2) {
+		return existingProtocols
 	}
 	ret := make([]string, 0, len(existingProtocols)+1)
 	ret = append(ret, existingProtocols...)

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net"
 	"net/netip"
 	"slices"
@@ -730,9 +731,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 
 	// Populate cDefinesMap with extraMacrosMap to get all the configuration
 	// in the cDefinesMap itself.
-	for key, value := range extraMacrosMap {
-		cDefinesMap[key] = value
-	}
+	maps.Copy(cDefinesMap, extraMacrosMap)
 
 	// Write the JSON encoded config as base64 encoded commented string to
 	// the header file.

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1478,10 +1478,8 @@ func TestArpPingHandlingIPv6(t *testing.T) {
 			neighs, err := netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V6)
 			require.NoError(t, err)
 			for _, n := range neighs {
-				for _, ip := range ips {
-					if n.IP.Equal(ip) {
-						return false
-					}
+				if slices.ContainsFunc(ips, n.IP.Equal) {
+					return false
 				}
 			}
 			return true
@@ -2235,10 +2233,8 @@ func TestArpPingHandlingForMultiDeviceIPv6(t *testing.T) {
 			neighs, err := netlink.NeighList(link.Attrs().Index, netlink.FAMILY_V6)
 			require.NoError(t, err)
 			for _, n := range neighs {
-				for _, ip := range ips {
-					if n.IP.Equal(ip) {
-						return false
-					}
+				if slices.ContainsFunc(ips, n.IP.Equal) {
+					return false
 				}
 			}
 			return true
@@ -2507,10 +2503,8 @@ func TestArpPingHandlingIPv4(t *testing.T) {
 			neighs, err := netlink.NeighList(veth0.Attrs().Index, netlink.FAMILY_V4)
 			require.NoError(t, err)
 			for _, n := range neighs {
-				for _, ip := range ips {
-					if n.IP.Equal(ip) {
-						return false
-					}
+				if slices.ContainsFunc(ips, n.IP.Equal) {
+					return false
 				}
 			}
 			return true
@@ -3257,10 +3251,8 @@ func TestArpPingHandlingForMultiDeviceIPv4(t *testing.T) {
 			neighs, err := netlink.NeighList(link.Attrs().Index, netlink.FAMILY_V4)
 			require.NoError(t, err)
 			for _, n := range neighs {
-				for _, ip := range ips {
-					if n.IP.Equal(ip) {
-						return false
-					}
+				if slices.ContainsFunc(ips, n.IP.Equal) {
+					return false
 				}
 			}
 			return true

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/netip"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 
@@ -230,13 +231,7 @@ func isObsoleteDev(dev string, devices []string) bool {
 	}
 
 	// exclude devices that will still be managed going forward.
-	for _, d := range devices {
-		if dev == d {
-			return false
-		}
-	}
-
-	return true
+	return !slices.Contains(devices, dev)
 }
 
 // removeObsoleteNetdevPrograms removes cil_to_netdev and cil_from_netdev from devices

--- a/pkg/debug/subsystem.go
+++ b/pkg/debug/subsystem.go
@@ -5,6 +5,7 @@ package debug
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/cilium/cilium/pkg/lock"
 )
@@ -56,13 +57,9 @@ func (s *statusFunctions) registerStatusObject(name string, obj StatusObject) er
 }
 
 func (s *statusFunctions) collectStatus() StatusMap {
-	fnCopy := functionMap{}
-
 	// Make a copy to not hold the mutex while collecting the status
 	s.mutex.RLock()
-	for name, fn := range s.functions {
-		fnCopy[name] = fn
-	}
+	fnCopy := maps.Clone(s.functions)
 	s.mutex.RUnlock()
 
 	status := StatusMap{}

--- a/pkg/endpoint/metrics.go
+++ b/pkg/endpoint/metrics.go
@@ -4,6 +4,8 @@
 package endpoint
 
 import (
+	"maps"
+
 	"github.com/cilium/cilium/api/v1/models"
 	loaderMetrics "github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/lock"
@@ -88,9 +90,7 @@ func (s *regenerationStatistics) GetMap() map[string]*spanstat.SpanStat {
 		"prepareBuild":               &s.prepareBuild,
 		"total":                      &s.totalTime,
 	}
-	for k, v := range s.datapathRealization.GetMap() {
-		result[k] = v
-	}
+	maps.Copy(result, s.datapathRealization.GetMap())
 	return result
 }
 

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -161,11 +161,9 @@ func (cache *NPHDSCache) handleIPUpsert(npHost *envoyAPI.NetworkPolicyHosts, ide
 	} else {
 		// Resource already exists, create a copy of it and insert
 		// the new IP address into its HostAddresses list, if not already there.
-		for _, addr := range npHost.HostAddresses {
-			if addr == cidrStr {
-				// IP already exists, nothing to add
-				return nil
-			}
+		if slices.Contains(npHost.HostAddresses, cidrStr) {
+			// IP already exists, nothing to add
+			return nil
 		}
 		hostAddresses = make([]string, 0, len(npHost.HostAddresses)+1)
 		hostAddresses = append(hostAddresses, npHost.HostAddresses...)

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"os"
 	"path/filepath"
@@ -1137,9 +1138,7 @@ func getL7Rules(l7Rules []api.PortRuleL7, l7Proto string) *cilium.L7NetworkPolic
 		} else {
 			// proxylib go extension key/value policy
 			rule := &cilium.L7NetworkPolicyRule{Rule: make(map[string]string, len(l7))}
-			for k, v := range l7 {
-				rule.Rule[k] = v
-			}
+			maps.Copy(rule.Rule, l7)
 			allowRules = append(allowRules, rule)
 		}
 	}

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -793,7 +793,7 @@ type DNSZombieMapping struct {
 // or fields
 func (zombie *DNSZombieMapping) DeepCopy() *DNSZombieMapping {
 	return &DNSZombieMapping{
-		Names:           append([]string{}, zombie.Names...),
+		Names:           slices.Clone(zombie.Names),
 		IP:              zombie.IP,
 		DeletePendingAt: zombie.DeletePendingAt,
 		AliveAt:         zombie.AliveAt,

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -1255,7 +1255,7 @@ func Benchmark_perEPAllow_setPortRulesForID(b *testing.B) {
 	}
 
 	for i := 0; i < nEPs; i++ {
-		commonRules := append([]api.PortRuleDNS{}, defaultRules...)
+		commonRules := slices.Clone(defaultRules)
 		if i%everyNIsEqual != 0 {
 			commonRules = append(
 				commonRules,

--- a/pkg/health/client/tree.go
+++ b/pkg/health/client/tree.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -177,13 +178,7 @@ func dumpVals(w io.Writer, level, maxLevel int, levelsEnded []int, edge decorati
 }
 
 func isEnded(levelsEnded []int, level int) bool {
-	for _, l := range levelsEnded {
-		if l == level {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(levelsEnded, level)
 }
 
 func dumpVal(level int, node *node) string {

--- a/pkg/hubble/filters/cluster_name.go
+++ b/pkg/hubble/filters/cluster_name.go
@@ -6,6 +6,7 @@ package filters
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
@@ -20,21 +21,13 @@ func destinationClusterName(ev *v1.Event) string {
 }
 
 func filterByClusterName(names []string, getClusterName func(*v1.Event) string) (FilterFunc, error) {
-	for _, name := range names {
-		if name == "" {
-			return nil, fmt.Errorf("invalid filter, name must not be empty")
-		}
+	if slices.Contains(names, "") {
+		return nil, fmt.Errorf("invalid filter, name must not be empty")
 	}
 
 	return func(ev *v1.Event) bool {
 		target := getClusterName(ev)
-		for _, n := range names {
-			if n == target {
-				return true
-			}
-		}
-
-		return false
+		return slices.Contains(names, target)
 	}, nil
 }
 

--- a/pkg/hubble/relay/pool/manager_test.go
+++ b/pkg/hubble/relay/pool/manager_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -1219,7 +1220,7 @@ func metricTextFormatFromPeerStatusMap(peerStatus map[string]uint32) string {
 	for key := range peerStatus {
 		keys = append(keys, key)
 	}
-	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	slices.Sort(keys)
 	for _, key := range keys {
 		buf.WriteString(fmt.Sprintf("hubble_relay_pool_peer_connection_status{status=\"%s\"} %d\n", key, peerStatus[key]))
 	}

--- a/pkg/identity/cache/local.go
+++ b/pkg/identity/cache/local.go
@@ -6,6 +6,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/cilium/stream"
 
@@ -237,16 +238,9 @@ func (l *localIdentityCache) lookupByID(id identity.NumericIdentity) *identity.I
 
 // GetIdentities returns all local identities
 func (l *localIdentityCache) GetIdentities() map[identity.NumericIdentity]*identity.Identity {
-	cache := map[identity.NumericIdentity]*identity.Identity{}
-
 	l.mutex.RLock()
 	defer l.mutex.RUnlock()
-
-	for key, id := range l.identitiesByID {
-		cache[key] = id
-	}
-
-	return cache
+	return maps.Clone(l.identitiesByID)
 }
 
 func (l *localIdentityCache) checkpoint(dst []*identity.Identity) []*identity.Identity {

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -132,7 +132,7 @@ func removeRedundantCIDRs(CIDRs []*net.IPNet) []*net.IPNet {
 
 	if len(redundant) == 1 {
 		for i := range redundant {
-			return append(CIDRs[:i], CIDRs[i+1:]...)
+			return slices.Delete(CIDRs, i, i+1)
 		}
 	}
 
@@ -175,12 +175,12 @@ func RemoveCIDRs(allowCIDRs, removeCIDRs []*net.IPNet) []*net.IPNet {
 
 				// Remove CIDR that we have just processed and append new CIDRs
 				// that we computed from removing the CIDR to remove.
-				allowCIDRs = append(allowCIDRs[:i], allowCIDRs[i+1:]...)
+				allowCIDRs = slices.Delete(allowCIDRs, i, i+1)
 				allowCIDRs = append(allowCIDRs, nets...)
 			} else if remove.Contains(allowCIDR.IP.Mask(allowCIDR.Mask)) {
 				// If a CIDR that we want to remove contains a CIDR in the list
 				// that is allowed, then we can just remove the CIDR to allow.
-				allowCIDRs = append(allowCIDRs[:i], allowCIDRs[i+1:]...)
+				allowCIDRs = slices.Delete(allowCIDRs, i, i+1)
 			} else {
 				// Advance only if CIDR at index 'i' was not removed
 				i++
@@ -500,7 +500,7 @@ func mergeAdjacentCIDRs(ranges []*netWithRange) []*netWithRange {
 
 			// Since we have combined ranges[i] with the preceding item in the
 			// ranges list, we can delete ranges[i] from the slice.
-			ranges = append(ranges[:i], ranges[i+1:]...)
+			ranges = slices.Delete(ranges, i, i+1)
 		}
 	}
 	return ranges

--- a/pkg/ipam/allocator/multipool/pool_allocator.go
+++ b/pkg/ipam/allocator/multipool/pool_allocator.go
@@ -156,13 +156,7 @@ func (p *PoolAllocator) updateCIDRSets(isV6 bool, cidrSets []cidralloc.CIDRAlloc
 
 	// delete CIDR set for CIDRs not present in the new CIDRs
 	for i, oldCIDR := range cidrSets {
-		exists := false
-		for _, cidr := range newCIDRs {
-			if oldCIDR.IsClusterCIDR(cidr) {
-				exists = true
-				break
-			}
-		}
+		exists := slices.ContainsFunc(newCIDRs, oldCIDR.IsClusterCIDR)
 		if !exists {
 			cidrSets[i] = nil
 			cidrSets = slices.Delete(cidrSets, i, i+1)

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"reflect"
 	"slices"
@@ -565,9 +566,7 @@ func (n *nodeStore) refreshNode() error {
 
 	for _, a := range staleCopyOfAllocators {
 		a.mutex.RLock()
-		for ip, ipInfo := range a.allocated {
-			node.Status.IPAM.Used[ip] = ipInfo
-		}
+		maps.Copy(node.Status.IPAM.Used, a.allocated)
 		a.mutex.RUnlock()
 	}
 

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -5,6 +5,7 @@ package ipam
 
 import (
 	"fmt"
+	"maps"
 	"net"
 	"net/netip"
 	"strings"
@@ -107,9 +108,7 @@ func (f fakePoolAllocator) Dump() (map[Pool]map[string]string, string) {
 		if _, ok := result[name]; !ok {
 			result[name] = map[string]string{}
 		}
-		for k, v := range dump[name] {
-			result[name][k] = v
-		}
+		maps.Copy(result[name], dump[name])
 	}
 	return result, fmt.Sprintf("%d pools", len(f.pools))
 }

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"slices"
 	"sort"
@@ -632,9 +633,7 @@ func (m *multiPoolManager) dump(family Family) (allocated map[Pool]map[string]st
 			allocated[poolName] = map[string]string{}
 		}
 
-		for ip, owner := range ipToOwner {
-			allocated[poolName][ip] = owner
-		}
+		maps.Copy(allocated[poolName], ipToOwner)
 	}
 
 	return allocated, fmt.Sprintf("%d IPAM pool(s) available", len(m.pools))

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"sync/atomic"
 
 	"k8s.io/client-go/tools/cache"
@@ -532,9 +533,7 @@ func (n *Node) releaseNeeded() (needed bool) {
 func (n *Node) Pool() (pool ipamTypes.AllocationMap) {
 	pool = ipamTypes.AllocationMap{}
 	n.mutex.RLock()
-	for k, allocationIP := range n.ipv4Alloc.available {
-		pool[k] = allocationIP
-	}
+	maps.Copy(pool, n.ipv4Alloc.available)
 	n.mutex.RUnlock()
 	return
 }

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"slices"
 	"sync/atomic"
 
 	"k8s.io/client-go/tools/cache"
@@ -829,13 +830,7 @@ func (n *Node) handleIPRelease(ctx context.Context, a *maintenanceAction) (insta
 
 	for markedIP, ts := range n.ipv4Alloc.ipsMarkedForRelease {
 		// Determine which IPs are still marked for release.
-		stillMarkedForRelease := false
-		for _, ip := range a.release.IPsToRelease {
-			if markedIP == ip {
-				stillMarkedForRelease = true
-				break
-			}
-		}
+		stillMarkedForRelease := slices.Contains(a.release.IPsToRelease, markedIP)
 		if !stillMarkedForRelease {
 			// n.determineMaintenanceAction() only returns the IPs on the interface with maximum number of IPs that
 			// can be freed up. If the selected interface changes or if this IP is not excess anymore, remove entry

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -153,7 +154,7 @@ func (n *nodeOperationsMock) releaseIP(ip string) error {
 	defer n.allocator.mutex.Unlock()
 	for i, allocatedIP := range n.allocatedIPs {
 		if allocatedIP == ip {
-			n.allocatedIPs = append(n.allocatedIPs[:i], n.allocatedIPs[i+1:]...)
+			n.allocatedIPs = slices.Delete(n.allocatedIPs, i, i+1)
 			n.allocator.allocatedIPs--
 			return nil
 		}

--- a/pkg/ipmasq/ipmasq.go
+++ b/pkg/ipmasq/ipmasq.go
@@ -6,6 +6,7 @@ package ipmasq
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -185,9 +186,7 @@ func (a *IPMasqAgent) Update() error {
 
 	// Set default nonMasq CIDRS if user hasn't specified any
 	if isEmpty {
-		for cidrStr, cidr := range defaultNonMasqCIDRs {
-			a.nonMasqCIDRsFromConfig[cidrStr] = cidr
-		}
+		maps.Copy(a.nonMasqCIDRsFromConfig, defaultNonMasqCIDRs)
 	}
 
 	if !a.masqLinkLocalIPv4 {

--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -5,6 +5,7 @@ package k8s
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/cilium/cilium/pkg/annotation"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -255,9 +256,7 @@ func parsePodSelector(podSelectorIn *slim_metav1.LabelSelector, namespace string
 	podSelector := &slim_metav1.LabelSelector{
 		MatchLabels: make(map[string]slim_metav1.MatchLabelsValue, len(podSelectorIn.MatchLabels)),
 	}
-	for k, v := range podSelectorIn.MatchLabels {
-		podSelector.MatchLabels[k] = v
-	}
+	maps.Copy(podSelector.MatchLabels, podSelectorIn.MatchLabels)
 	// The PodSelector should only reflect to the same namespace
 	// the policy is being stored, thus we add the namespace to
 	// the MatchLabels map.

--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -6,6 +6,7 @@ package k8s
 import (
 	"fmt"
 	"maps"
+	"slices"
 
 	"github.com/cilium/cilium/pkg/annotation"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -104,12 +105,7 @@ func parseNetworkPolicyPeer(namespace string, peer *slim_networkingv1.NetworkPol
 }
 
 func hasV1PolicyType(pTypes []slim_networkingv1.PolicyType, typ slim_networkingv1.PolicyType) bool {
-	for _, pType := range pTypes {
-		if pType == typ {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(pTypes, typ)
 }
 
 // ParseNetworkPolicy parses a k8s NetworkPolicy. Returns a list of

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -691,13 +691,9 @@ func (s *Service) UniquePorts() map[string]bool {
 func NewClusterService(id ServiceID, k8sService *Service, k8sEndpoints *Endpoints) serviceStore.ClusterService {
 	svc := serviceStore.NewClusterService(id.Name, id.Namespace)
 
-	for key, value := range k8sService.Labels {
-		svc.Labels[key] = value
-	}
+	maps.Copy(svc.Labels, k8sService.Labels)
 
-	for key, value := range k8sService.Selector {
-		svc.Selector[key] = value
-	}
+	maps.Copy(svc.Selector, k8sService.Selector)
 
 	portConfig := serviceStore.PortConfiguration{}
 	for portName, port := range k8sService.Ports {

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -642,11 +642,8 @@ func (s *ServiceCacheImpl) filterEndpoints(localEndpoints *Endpoints, svc *Servi
 			return localEndpoints
 		}
 
-		for _, hint := range backend.HintsForZones {
-			if hint == s.selfNodeZoneLabel {
-				filteredEndpoints.Backends[key] = backend
-				break
-			}
+		if slices.Contains(backend.HintsForZones, s.selfNodeZoneLabel) {
+			filteredEndpoints.Backends[key] = backend
 		}
 	}
 

--- a/pkg/k8s/slim/k8s/apis/labels/labels.go
+++ b/pkg/k8s/slim/k8s/apis/labels/labels.go
@@ -7,6 +7,7 @@ package labels
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 
@@ -105,14 +106,8 @@ func Conflicts(labels1, labels2 Set) bool {
 // Merge combines given maps, and does not check for any conflicts
 // between the maps. In case of conflicts, second map (labels2) wins
 func Merge(labels1, labels2 Set) Set {
-	mergedMap := Set{}
-
-	for k, v := range labels1 {
-		mergedMap[k] = v
-	}
-	for k, v := range labels2 {
-		mergedMap[k] = v
-	}
+	mergedMap := maps.Clone(labels1)
+	maps.Copy(mergedMap, labels2)
 	return mergedMap
 }
 

--- a/pkg/k8s/slim/k8s/apis/labels/selector.go
+++ b/pkg/k8s/slim/k8s/apis/labels/selector.go
@@ -192,12 +192,7 @@ func NewRequirement(key string, op selection.Operator, vals []string, opts ...fi
 }
 
 func (r *Requirement) hasValue(value string) bool {
-	for i := range r.strValues {
-		if r.strValues[i] == value {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(r.strValues, value)
 }
 
 // Matches returns true if the Requirement matches the input Labels.

--- a/pkg/k8s/slim/k8s/apis/labels/selector.go
+++ b/pkg/k8s/slim/k8s/apis/labels/selector.go
@@ -7,6 +7,7 @@ package labels
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"strconv"
@@ -1006,11 +1007,7 @@ func (s ValidatedSetSelector) Requirements() (requirements Requirements, selecta
 }
 
 func (s ValidatedSetSelector) DeepCopySelector() Selector {
-	res := make(ValidatedSetSelector, len(s))
-	for k, v := range s {
-		res[k] = v
-	}
-	return res
+	return maps.Clone(s)
 }
 
 func (s ValidatedSetSelector) RequiresExactMatch(label string) (value string, found bool) {

--- a/pkg/k8s/slim/k8s/apis/meta/v1/helpers.go
+++ b/pkg/k8s/slim/k8s/apis/meta/v1/helpers.go
@@ -8,6 +8,7 @@ package v1
 import (
 	"fmt"
 	"maps"
+	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -48,7 +49,7 @@ func LabelSelectorAsSelector(ps *LabelSelector) (labels.Selector, error) {
 		default:
 			return nil, fmt.Errorf("%q is not a valid label selector operator", expr.Operator)
 		}
-		r, err := labels.NewRequirement(expr.Key, op, append([]string(nil), expr.Values...))
+		r, err := labels.NewRequirement(expr.Key, op, slices.Clone(expr.Values))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/k8s/slim/k8s/apis/meta/v1/helpers.go
+++ b/pkg/k8s/slim/k8s/apis/meta/v1/helpers.go
@@ -7,6 +7,7 @@ package v1
 
 import (
 	"fmt"
+	"maps"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -66,10 +67,7 @@ func LabelSelectorAsMap(ps *LabelSelector) (map[string]string, error) {
 	if ps == nil {
 		return nil, nil
 	}
-	selector := map[string]string{}
-	for k, v := range ps.MatchLabels {
-		selector[k] = v
-	}
+	selector := maps.Clone(ps.MatchLabels)
 	for _, expr := range ps.MatchExpressions {
 		switch expr.Operator {
 		case LabelSelectorOpIn:
@@ -145,9 +143,7 @@ func SetAsLabelSelector(ls labels.Set) *LabelSelector {
 	selector := &LabelSelector{
 		MatchLabels: make(map[string]string, len(ls)),
 	}
-	for label, value := range ls {
-		selector.MatchLabels[label] = value
-	}
+	maps.Copy(selector.MatchLabels, ls)
 
 	return selector
 }

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"net"
 	"net/netip"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -913,11 +914,8 @@ func (k *K8sPodWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPo
 			// receive any other event with these old IP addresses.
 			for _, oldPodIP := range oldPodIPs {
 				var found bool
-				for _, newPodIP := range newPodIPs {
-					if newPodIP == oldPodIP {
-						found = true
-						break
-					}
+				if slices.Contains(newPodIPs, oldPodIP) {
+					found = true
 				}
 				if !found {
 					npc := k.ipcache.Delete(oldPodIP, source.Kubernetes)

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"path"
 	"strings"
 	"sync"
@@ -355,12 +356,7 @@ func (s *SharedStore) NumEntries() int {
 func (s *SharedStore) SharedKeysMap() map[string]Key {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
-	sharedKeysCopy := make(map[string]Key, len(s.sharedKeys))
-
-	for k, v := range s.sharedKeys {
-		sharedKeysCopy[k] = v
-	}
-	return sharedKeysCopy
+	return maps.Clone(s.sharedKeys)
 }
 
 // UpdateLocalKeySync synchronously synchronizes a local key with the kvstore

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/netip"
 	"slices"
 	"strings"
@@ -625,9 +626,7 @@ func (l Labels) GetModel() []string {
 //
 //	Labels{Label{key1, value3, source4}, Label{key2, value3, source4}}
 func (l Labels) MergeLabels(from Labels) {
-	for k, v := range from {
-		l[k] = v
-	}
+	maps.Copy(l, from)
 }
 
 // Remove is similar to MergeLabels, but returns a new Labels object with the

--- a/pkg/labels/oplabels.go
+++ b/pkg/labels/oplabels.go
@@ -5,6 +5,7 @@ package labels
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/sirupsen/logrus"
 
@@ -74,13 +75,9 @@ func (o *OpLabels) SplitUserLabelChanges(lbls Labels) (add, del Labels) {
 func (o *OpLabels) IdentityLabels() Labels {
 	enabled := make(Labels, len(o.Custom)+len(o.OrchestrationIdentity))
 
-	for k, v := range o.Custom {
-		enabled[k] = v
-	}
+	maps.Copy(enabled, o.Custom)
 
-	for k, v := range o.OrchestrationIdentity {
-		enabled[k] = v
-	}
+	maps.Copy(enabled, o.OrchestrationIdentity)
 
 	return enabled
 }
@@ -98,21 +95,13 @@ func (o *OpLabels) GetIdentityLabel(key string) (l Label, found bool) {
 func (o *OpLabels) AllLabels() Labels {
 	all := make(Labels, len(o.Custom)+len(o.OrchestrationInfo)+len(o.OrchestrationIdentity)+len(o.Disabled))
 
-	for k, v := range o.Custom {
-		all[k] = v
-	}
+	maps.Copy(all, o.Custom)
 
-	for k, v := range o.Disabled {
-		all[k] = v
-	}
+	maps.Copy(all, o.Disabled)
 
-	for k, v := range o.OrchestrationIdentity {
-		all[k] = v
-	}
+	maps.Copy(all, o.OrchestrationIdentity)
 
-	for k, v := range o.OrchestrationInfo {
-		all[k] = v
-	}
+	maps.Copy(all, o.OrchestrationInfo)
 	return all
 }
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -368,13 +369,7 @@ func (o LogOptions) validateOpts(logDriver string, supportedOpts map[string]bool
 			return fmt.Errorf("provided configuration key %q is not supported as a logging option for log driver %s", k, logDriver)
 		}
 		if validValues, ok := validKVs[k]; ok {
-			valid := false
-			for _, vv := range validValues {
-				if v == vv {
-					valid = true
-					break
-				}
-			}
+			valid := slices.Contains(validValues, v)
 			if !valid {
 				return fmt.Errorf("provided configuration value %q is not a valid value for %q in log driver %s, valid values: %v", v, k, logDriver, validValues)
 			}

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -138,13 +139,7 @@ func (m *MessageTypeFilter) Type() string {
 }
 
 func (m *MessageTypeFilter) Contains(typ int) bool {
-	for _, v := range *m {
-		if v == typ {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(*m, typ)
 }
 
 // Must be synchronized with <bpf/lib/trace.h>

--- a/pkg/monitor/format/flags.go
+++ b/pkg/monitor/format/flags.go
@@ -4,6 +4,7 @@
 package format
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 
@@ -42,11 +43,5 @@ func (i *Uint16Flags) Type() string {
 
 // Has returns true of value exist
 func (i *Uint16Flags) Has(value uint16) bool {
-	for _, v := range *i {
-		if v == value {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(*i, value)
 }

--- a/pkg/node/manager/rest_api.go
+++ b/pkg/node/manager/rest_api.go
@@ -5,6 +5,7 @@ package manager
 
 import (
 	"math/rand/v2"
+	"slices"
 
 	"github.com/go-openapi/runtime/middleware"
 
@@ -159,14 +160,11 @@ func (c *clusterNodesClient) NodeDelete(node nodeTypes.Node) error {
 	// If the node was added/updated and removed before the clusterNodesClient
 	// was aware of it then we can safely remove it from the list of added
 	// nodes and not set it in the list of removed nodes.
-	found := -1
-	for i, added := range c.NodesAdded {
-		if added.Name == node.Fullname() {
-			found = i
-		}
-	}
+	found := slices.IndexFunc(c.NodesAdded, func(added *models.NodeElement) bool {
+		return added.Name == node.Fullname()
+	})
 	if found != -1 {
-		c.NodesAdded = append(c.NodesAdded[:found], c.NodesAdded[found+1:]...)
+		c.NodesAdded = slices.Delete(c.NodesAdded, found, found+1)
 	} else {
 		c.NodesRemoved = append(c.NodesRemoved, node.GetModel())
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2528,12 +2528,7 @@ func (c *DaemonConfig) K8sNetworkPolicyEnabled() bool {
 }
 
 func (c *DaemonConfig) PolicyCIDRMatchesNodes() bool {
-	for _, mode := range c.PolicyCIDRMatchMode {
-		if mode == "nodes" {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.PolicyCIDRMatchMode, "nodes")
 }
 
 // PerNodeLabelsEnabled returns true if per-node labels feature

--- a/pkg/option/daemon.go
+++ b/pkg/option/daemon.go
@@ -3,6 +3,8 @@
 
 package option
 
+import "maps"
+
 var (
 	specPolicyTracing = Option{
 		Description: "Enable tracing when resolving policy (Debug)",
@@ -31,9 +33,7 @@ var (
 )
 
 func init() {
-	for k, v := range DaemonMutableOptionLibrary {
-		DaemonOptionLibrary[k] = v
-	}
+	maps.Copy(DaemonOptionLibrary, DaemonMutableOptionLibrary)
 }
 
 // ParseDaemonOption parses a string as daemon option

--- a/pkg/option/endpoint.go
+++ b/pkg/option/endpoint.go
@@ -3,6 +3,8 @@
 
 package option
 
+import "maps"
+
 var (
 	endpointMutableOptionLibrary = OptionLibrary{
 		ConntrackAccounting:  &specConntrackAccounting,
@@ -21,9 +23,5 @@ var (
 )
 
 func GetEndpointMutableOptionLibrary() OptionLibrary {
-	opt := OptionLibrary{}
-	for k, v := range endpointMutableOptionLibrary {
-		opt[k] = v
-	}
-	return opt
+	return maps.Clone(endpointMutableOptionLibrary)
 }

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -61,13 +61,7 @@ const (
 
 // RequiresOption returns true if the option requires the specified option `name`.
 func (o Option) RequiresOption(name string) bool {
-	for _, o := range o.Requires {
-		if o == name {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(o.Requires, name)
 }
 
 type OptionLibrary map[string]*Option

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -6,6 +6,7 @@ package option
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -141,11 +142,7 @@ func (l OptionLibrary) Validate(name string, value string) error {
 type OptionMap map[string]OptionSetting
 
 func (om OptionMap) DeepCopy() OptionMap {
-	cpy := make(OptionMap, len(om))
-	for k, v := range om {
-		cpy[k] = v
-	}
-	return cpy
+	return maps.Clone(om)
 }
 
 // IntOptions member functions with external access do not require

--- a/pkg/option/resolver/resolver.go
+++ b/pkg/option/resolver/resolver.go
@@ -114,11 +114,7 @@ func ResolveConfigurations(ctx context.Context, client client.Clientset, nodeNam
 }
 
 func mergeConfig(source ConfigSource, lower, upper map[string]string) map[string]string {
-	out := make(map[string]string, len(lower))
-
-	for k, v := range lower {
-		out[k] = v
-	}
+	out := maps.Clone(lower)
 
 	for k, v := range upper {
 		if _, set := out[k]; set {

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -566,10 +567,8 @@ func (pr *PortRule) sanitize(ingress bool) error {
 	if len(pr.ServerNames) > 0 && !pr.Rules.IsEmpty() && pr.TerminatingTLS == nil {
 		return fmt.Errorf("ServerNames are not allowed with L7 rules without TLS termination")
 	}
-	for _, sn := range pr.ServerNames {
-		if sn == "" {
-			return errEmptyServerName
-		}
+	if slices.Contains(pr.ServerNames, "") {
+		return errEmptyServerName
 	}
 
 	if len(pr.Ports) > maxPorts {

--- a/pkg/policy/api/utils.go
+++ b/pkg/policy/api/utils.go
@@ -6,18 +6,13 @@ package api
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 )
 
 // Exists returns true if the HTTP rule already exists in the list of rules
 func (h *PortRuleHTTP) Exists(rules L7Rules) bool {
-	for _, existingRule := range rules.HTTP {
-		if h.Equal(existingRule) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(rules.HTTP, h.Equal)
 }
 
 // Equal returns true if both HTTP rules are equal
@@ -62,24 +57,12 @@ func (h *HeaderMatch) Equal(o *HeaderMatch) bool {
 
 // Exists returns true if the DNS rule already exists in the list of rules
 func (d *PortRuleDNS) Exists(rules L7Rules) bool {
-	for _, existingRule := range rules.DNS {
-		if d.Equal(existingRule) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(rules.DNS, d.Equal)
 }
 
 // Exists returns true if the L7 rule already exists in the list of rules
 func (h *PortRuleL7) Exists(rules L7Rules) bool {
-	for _, existingRule := range rules.L7 {
-		if h.Equal(existingRule) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(rules.L7, h.Equal)
 }
 
 // Equal returns true if both rules are equal

--- a/pkg/policy/k8s/service.go
+++ b/pkg/policy/k8s/service.go
@@ -6,6 +6,7 @@ package k8s
 import (
 	"context"
 	"errors"
+	"maps"
 	"sync"
 
 	"github.com/cilium/stream"
@@ -283,10 +284,7 @@ func appendEndpoints(toCIDRSet *api.CIDRRuleSlice, endpoints []api.CIDR) {
 
 // appendSelector appends the service selector as a generated EndpointSelector
 func appendSelector(toEndpoints *[]api.EndpointSelector, svcSelector map[string]string, namespace string) {
-	selector := make(map[string]string)
-	for k, v := range svcSelector {
-		selector[k] = v
-	}
+	selector := maps.Clone(svcSelector)
 	selector[labels.LabelSourceK8sKeyPrefix+k8sConst.PodNamespaceLabel] = namespace
 	endpointSelector := api.NewESFromMatchRequirements(selector, nil)
 	endpointSelector.Generated = true

--- a/pkg/policy/k8s/service.go
+++ b/pkg/policy/k8s/service.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"maps"
+	"slices"
 	"sync"
 
 	"github.com/cilium/stream"
@@ -194,12 +195,7 @@ func hasToServices(cnp *types.SlimCNP) bool {
 	if specHasToServices(cnp.Spec) {
 		return true
 	}
-	for _, spec := range cnp.Specs {
-		if specHasToServices(spec) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(cnp.Specs, specHasToServices)
 }
 
 // specHasToServices returns true if the rule contains a ToServices rule

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"sync"
 	"testing"
 
@@ -97,9 +98,7 @@ func newTestData(logger *slog.Logger) *testData {
 func (td *testData) withIDs(initIDs ...identity.IdentityMap) *testData {
 	initial := identity.IdentityMap{}
 	for _, im := range initIDs {
-		for id, lbls := range im {
-			initial[id] = lbls
-		}
+		maps.Copy(initial, im)
 	}
 	wg := &sync.WaitGroup{}
 	td.sc.UpdateIdentities(initial, nil, wg)

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand/v2"
+	"slices"
 	"sort"
 	"strconv"
 	"testing"
@@ -449,7 +450,7 @@ func TestL4PolicyMapPortRangeOverlaps(t *testing.T) {
 			pRs := make([]struct{ startPort, endPort uint16 }, len(portRanges))
 			copy(pRs, portRanges)
 			// Iterate over every port range except the one being tested.
-			for _, altPR := range append(pRs[:i], pRs[i+1:]...) {
+			for _, altPR := range slices.Delete(pRs, i, i+1) {
 				t.Logf("Checking for port range %d-%d on main port range %d-%d", altPR.startPort, altPR.endPort, portRange.startPort, portRange.endPort)
 				altStartPort := fmt.Sprintf("%d", altPR.startPort)
 				// This range should not exist yet.

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"slices"
 	"sync/atomic"
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
@@ -692,12 +693,9 @@ func (p *Repository) ReplaceByLabels(rules api.Rules, searchLabelsList []labels.
 
 	// determine outgoing rules
 	for ruleKey, rule := range p.rules {
-		for _, searchLabels := range searchLabelsList {
-			if rule.Labels.Contains(searchLabels) {
-				p.del(ruleKey)
-				oldRules = append(oldRules, rule)
-				break
-			}
+		if slices.ContainsFunc(searchLabelsList, rule.Labels.Contains) {
+			p.del(ruleKey)
+			oldRules = append(oldRules, rule)
 		}
 	}
 

--- a/pkg/policy/selectorcache_selector.go
+++ b/pkg/policy/selectorcache_selector.go
@@ -5,6 +5,7 @@ package policy
 
 import (
 	"log/slog"
+	"slices"
 	"sort"
 	"sync"
 
@@ -125,10 +126,8 @@ func (l *labelIdentitySelector) xxxMatches(labels labels.LabelArray) bool {
 func (l *labelIdentitySelector) matchesNamespace(ns string) bool {
 	if len(l.namespaces) > 0 {
 		if ns != "" {
-			for i := range l.namespaces {
-				if ns == l.namespaces[i] {
-					return true
-				}
+			if slices.Contains(l.namespaces, ns) {
+				return true
 			}
 		}
 		// namespace required, but no match
@@ -268,9 +267,7 @@ func (i *identitySelector) updateSelections(nextVersion *versioned.Tx) {
 	// Sort the numeric identities so that the map iteration order
 	// does not matter. This makes testing easier, but may help
 	// identifying changes easier also otherwise.
-	sort.Slice(selections, func(i, j int) bool {
-		return selections[i] < selections[j]
-	})
+	slices.Sort(selections)
 	i.setSelections(selections, nextVersion)
 }
 

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -6,6 +6,7 @@ package policy
 import (
 	"log/slog"
 	"net/netip"
+	"slices"
 	"sync"
 	"testing"
 
@@ -53,12 +54,7 @@ func newUser(t *testing.T, name string, sc *SelectorCache) *cachedSelectionUser 
 }
 
 func haveNid(nid identity.NumericIdentity, selections []identity.NumericIdentity) bool {
-	for i := range selections {
-		if selections[i] == nid {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(selections, nid)
 }
 
 func (csu *cachedSelectionUser) AddIdentitySelector(sel api.EndpointSelector) CachedSelector {
@@ -197,7 +193,7 @@ func (cs *testCachedSelector) deleteSelections(selections ...int) (deletes []ide
 		}
 		for i := 0; i < len(cs.selections); i++ {
 			if nid == cs.selections[i] {
-				cs.selections = append(cs.selections[:i], cs.selections[i+1:]...)
+				cs.selections = slices.Delete(cs.selections, i, i+1)
 				i--
 			}
 		}
@@ -215,12 +211,7 @@ func (cs *testCachedSelector) GetMetadataLabels() labels.LabelArray {
 	return nil
 }
 func (cs *testCachedSelector) Selects(_ *versioned.VersionHandle, nid identity.NumericIdentity) bool {
-	for _, id := range cs.selections {
-		if id == nid {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(cs.selections, nid)
 }
 
 func (cs *testCachedSelector) IsWildcard() bool {

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"slices"
 	"strings"
 	"sync"
 
@@ -1085,12 +1086,8 @@ func (rpm *Manager) updateFrontendMapping(config *LRPConfig, frontendMapping *fe
 
 	if podPolicies, ok := rpm.policyPods[podID]; ok {
 		newPodPolicy := true
-		for _, poID := range podPolicies {
-			// Existing pod policy update
-			if poID == config.id {
-				newPodPolicy = false
-				break
-			}
+		if slices.Contains(podPolicies, config.id) {
+			newPodPolicy = false
 		}
 		if newPodPolicy {
 			// Pod selected by a new policy

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"slices"
 	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
@@ -250,12 +251,7 @@ func (i *L7LBInfo) isProtoAndPortMatch(fe *lb.L4Addr) bool {
 		return true
 	}
 
-	for _, p := range i.ports {
-		if p == fe.Port {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(i.ports, fe.Port)
 }
 
 type L7LBResourceName struct {

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"reflect"
@@ -181,9 +182,7 @@ func (driver *driver) updateCiliumEP(event events.Message) {
 	if img.Config != nil && img.Config.Labels != nil {
 		lbls = img.Config.Labels
 		// container labels overwrite image labels
-		for k, v := range cont.Config.Labels {
-			lbls[k] = v
-		}
+		maps.Copy(lbls, cont.Config.Labels)
 	}
 	addLbls := labels.Map2Labels(lbls, labels.LabelSourceContainer).GetModel()
 	ecr := &models.EndpointChangeRequest{

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -17,6 +17,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -4395,11 +4396,8 @@ func validateCiliumSvc(cSvc models.Service, k8sSvcs []v1.Service, k8sEps []v1.En
 			k8sService = &k8sSvc
 			break
 		}
-		for _, clusterIP := range k8sSvc.Spec.ClusterIPs {
-			if clusterIP == cSvc.Status.Realized.FrontendAddress.IP {
-				k8sService = &k8sSvc
-				break
-			}
+		if slices.Contains(k8sSvc.Spec.ClusterIPs, cSvc.Status.Realized.FrontendAddress.IP) {
+			k8sService = &k8sSvc
 		}
 		if k8sService != nil {
 			break

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"os"
 	"path"
@@ -2594,9 +2595,7 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		options["ipv6.enabled"] = "false"
 	}
 
-	for k, v := range cliOverrideOptions {
-		options[k] = v
-	}
+	maps.Copy(options, cliOverrideOptions)
 
 	return nil
 }

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -12,6 +12,7 @@ import (
 	"math/rand/v2"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -672,12 +673,7 @@ func (kub *Kubectl) GetNodeCILabel(nodeName string) string {
 
 // IsNodeWithoutCilium returns true if node node doesn't run Cilium.
 func IsNodeWithoutCilium(node string) bool {
-	for _, n := range GetNodesWithoutCilium() {
-		if n == node {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(GetNodesWithoutCilium(), node)
 }
 
 // SkipQuarantined returns whether test under quarantine should be skipped

--- a/test/k8s/assertion_helpers.go
+++ b/test/k8s/assertion_helpers.go
@@ -5,6 +5,7 @@ package k8sTest
 
 import (
 	"fmt"
+	"maps"
 	"time"
 
 	. "github.com/onsi/gomega"
@@ -112,12 +113,8 @@ func RedeployCiliumWithMerge(vm *helpers.Kubectl,
 
 	// Merge configuration
 	newOpts := make(map[string]string, len(options))
-	for k, v := range from {
-		newOpts[k] = v
-	}
-	for k, v := range options {
-		newOpts[k] = v
-	}
+	maps.Copy(newOpts, from)
+	maps.Copy(newOpts, options)
 
 	RedeployCilium(vm, ciliumFilename, newOpts)
 }

--- a/tools/crdcheck/main.go
+++ b/tools/crdcheck/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 
 	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -72,10 +73,5 @@ func checkForCategory(crd *crdv1.CustomResourceDefinition) error {
 }
 
 func sliceContains(slice []string, item string) bool {
-	for _, a := range slice {
-		if a == item {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, item)
 }

--- a/tools/dev-doctor/dockergroupcheck.go
+++ b/tools/dev-doctor/dockergroupcheck.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os/user"
 	"runtime"
+	"slices"
 )
 
 // A dockerGroupCheck checks that the current user is in the docker group.
@@ -36,10 +37,8 @@ func (dockerGroupCheck) Run() (checkResult, string) {
 		return checkFailed, err.Error()
 	}
 
-	for _, groupID := range groupIDs {
-		if groupID == dockerGroup.Gid {
-			return checkOK, fmt.Sprintf("user %s in docker group", currentUser.Username)
-		}
+	if slices.Contains(groupIDs, dockerGroup.Gid) {
+		return checkOK, fmt.Sprintf("user %s in docker group", currentUser.Username)
 	}
 
 	return checkError, fmt.Sprintf("user %s not in docker group", currentUser.Username)


### PR DESCRIPTION
Use the convenience functions from the `maps` and `slices` standard library packages, added in Go 1.21 and extended in the successive releases.

Generated using modernize by running:

    go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...

and committing the relevant changes with some minor manual edits (e.g. reordering added imports).

---

Sorry for the large PR touching many pieces of the code base. Best reviewed by filtering for "Only files owned by you" so you only see changes for your own review groups:

![image](https://github.com/user-attachments/assets/f8ef37ce-01c6-4af9-8b31-70ec6fb71c12)