### PR TITLE
feat(agent/datapath): Add Trace ID to notify structs

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -265,6 +265,7 @@ cilium-agent [flags]
       --install-no-conntrack-iptables-rules                       Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.
       --install-uplink-routes-for-delegated-ipam                  Install ingress/egress routes through uplink on host for Pods when working with delegated IPAM plugin.
       --ip-masq-agent-config-path string                          ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
+      --ip-tracing-option-type uint8                              Specifies what IPv4 option type should be used to extract trace information from a packet; a value of 0 (default) disables IP tracing.
       --ipam string                                               Backend to use for IPAM (default "cluster-pool")
       --ipam-cilium-node-update-rate duration                     Maximum rate at which the CiliumNode custom resource is updated (default 15s)
       --ipam-default-ip-pool string                               Name of the default IP Pool when using multi-pool (default "default")

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1247,6 +1247,11 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 		obs_point = TRACE_FROM_CRYPTO;
 #endif
 
+#ifdef IP_TRACING_OPTION_TYPE
+	if (IP_TRACING_OPTION_TYPE > 0)
+		check_and_store_ip_trace_id(ctx, IP_TRACING_OPTION_TYPE);
+#endif
+
 	/* Filter allowed vlan id's and pass them back to kernel.
 	 * We will see the packet again in from-netdev@eth0.vlanXXX.
 	 */
@@ -1743,6 +1748,11 @@ skip_ipsec_nodeport_revdnat:
 #else
 	ret = CTX_ACT_OK;
 #endif /* ENABLE_HOST_FIREWALL */
+
+#ifdef ENABLE_PACKET_IP_TRACING
+	if (ENABLE_PACKET_IP_TRACING > 0)
+		check_and_store_ip_trace_id(ctx, ENABLE_PACKET_IP_TRACING);
+#endif
 
 out:
 	if (IS_ERR(ret))

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1487,6 +1487,11 @@ int cil_from_container(struct __ctx_buff *ctx)
 	 */
 	ctx->queue_mapping = 0;
 
+#ifdef IP_TRACING_OPTION_TYPE
+	if (IP_TRACING_OPTION_TYPE > 0)
+		check_and_store_ip_trace_id(ctx, IP_TRACING_OPTION_TYPE);
+#endif
+
 	send_trace_notify(ctx, TRACE_FROM_LXC, sec_label, UNKNOWN_ID,
 			  TRACE_EP_ID_UNKNOWN, TRACE_IFINDEX_UNKNOWN,
 			  TRACE_REASON_UNKNOWN, TRACE_PAYLOAD_LEN);

--- a/bpf/bpf_network.c
+++ b/bpf/bpf_network.c
@@ -81,6 +81,11 @@ int cil_from_network(struct __ctx_buff *ctx)
 		obs_point_to = TRACE_TO_HOST;
 #endif
 
+#ifdef IP_TRACING_OPTION_TYPE
+	if (IP_TRACING_OPTION_TYPE > 0)
+		check_and_store_ip_trace_id(ctx, IP_TRACING_OPTION_TYPE);
+#endif
+
 out:
 	send_trace_notify(ctx, obs_point_from, UNKNOWN_ID, UNKNOWN_ID,
 			  TRACE_EP_ID_UNKNOWN, ingress_ifindex,

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -594,6 +594,11 @@ int cil_from_overlay(struct __ctx_buff *ctx)
 	__u16 proto;
 	int ret;
 
+#ifdef IP_TRACING_OPTION_TYPE
+	if (IP_TRACING_OPTION_TYPE > 0)
+		check_and_store_ip_trace_id(ctx, IP_TRACING_OPTION_TYPE);
+#endif
+
 	bpf_clear_meta(ctx);
 	ctx_skip_nodeport_clear(ctx);
 

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -19,6 +19,7 @@
 #include "utils.h"
 #include "metrics.h"
 #include "ratelimit.h"
+#include "trace_helpers.h"
 
 struct drop_notify {
 	NOTIFY_CAPTURE_HDR

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -30,9 +30,15 @@ struct drop_notify {
 	__u8		file;
 	__s8		ext_error;
 	__u32		ifindex;
+	__u32		unused;
+	__u64		ip_trace_id;
 };
 
 #ifdef DROP_NOTIFY
+
+/* Drop notify version 2 includes IP Trace support. */
+#define NOTIFY_DROP_VER 2
+
 /*
  * We pass information in the meta area as follows:
  *
@@ -54,6 +60,7 @@ __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_DROP_NOTIFY)
 int __send_drop_notify(struct __ctx_buff *ctx)
 {
 	/* Mask needed to calm verifier. */
+	__u64 ip_trace_id = load_ip_trace_id();
 	__u32 error = ctx_load_meta(ctx, 2) & 0xFFFFFFFF;
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, TRACE_PAYLOAD_LEN, ctx_len);
@@ -78,7 +85,7 @@ int __send_drop_notify(struct __ctx_buff *ctx)
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_DROP, (__u8)error),
-		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_CAPTURE_VER),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_DROP_VER),
 		.src_label	= ctx_load_meta(ctx, 0),
 		.dst_label	= ctx_load_meta(ctx, 1),
 		.dst_id		= ctx_load_meta(ctx, 3),
@@ -86,6 +93,7 @@ int __send_drop_notify(struct __ctx_buff *ctx)
 		.file           = file,
 		.ext_error      = (__s8)(__u8)(error >> 8),
 		.ifindex        = ctx_get_ifindex(ctx),
+		.ip_trace_id    = ip_trace_id,
 	};
 
 	ctx_event_output(ctx, &EVENTS_MAP,

--- a/bpf/lib/ip_options.h
+++ b/bpf/lib/ip_options.h
@@ -1,0 +1,206 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#ifdef IP_TRACING_OPTION_TYPE
+
+/* Length of the initial supported IPv4 trace_id option (4 bytes).
+ * IPv4 IP options consist of 2 fixed bytes for the type and length,
+ * followed by a variable-length data field. An option length of 4 bytes
+ * indicates 2 fixed bytes for the type and length fields, and 2 bytes of
+ * ip_trace_id data.
+ */
+#define OPT16_LEN 4
+
+/* Length of the second supported IPv4 trace_id option (6 bytes).
+ * Indicates 4 bytes of ip_trace_id data.
+ */
+#define OPT32_LEN 6
+
+/* Length of the third supported IPv4 trace_id option (10 bytes).
+ * Indicates 8 bytes of ip_trace_id data.
+ */
+#define OPT64_LEN 10
+
+/* Maximum number of IPv4 options to process. */
+#define MAX_IPV4_OPTS 3
+
+/* The minimum value for IHL which corresponds to a packet with no options.
+ *
+ * A standard IP packet header has 20 bytes and the IHL is the number of 32 byte
+ * words.
+ */
+#define IHL_WITH_NO_OPTS 5
+
+/* Signifies that options were parsed correctly but no trace ID was found. */
+#define TRACE_ID_NOT_FOUND 0
+
+/* Signifies a failure to determine the trace ID based on an unspecified error. */
+#define TRACE_ID_ERROR -1
+
+/* Signifies that the trace ID was found but it was invalid. */
+#define TRACE_ID_INVALID -2
+
+/* Signifies a failure to determine trace ID because the IP family was not found. */
+#define TRACE_ID_NO_FAMILY -3
+
+/* Signifies a failure to determine trace ID because the IP option length was
+ * not supported.
+ */
+#define TRACE_ID_UNSUPPORTED_LENGTH_ERROR -4
+
+/* Signifies trace points which are being ignored because they're in IPv6
+ * code and not supported yet.
+ */
+#define TRACE_ID_SKIP_IPV6 -100
+
+/* Converts a 64-bit integer from network byte order to host byte order. */
+static __always_inline __u64 ntohll(__u64 value)
+{
+	return ((value & 0x00000000000000FFULL) << 56) |
+		   ((value & 0x000000000000FF00ULL) << 40) |
+		   ((value & 0x0000000000FF0000ULL) << 24) |
+		   ((value & 0x00000000FF000000ULL) << 8)  |
+		   ((value & 0x000000FF00000000ULL) >> 8)  |
+		   ((value & 0x0000FF0000000000ULL) >> 24) |
+		   ((value & 0x00FF000000000000ULL) >> 40) |
+		   ((value & 0xFF00000000000000ULL) >> 56);
+}
+
+/* trace_id_from_ip4 parses the IP options and returns the trace ID.
+ *
+ * See trace_id_from_ctx for more info.
+ */
+static __always_inline int
+trace_id_from_ip4(struct __ctx_buff *ctx, __s64 *value,
+		  const struct iphdr *ip4,
+		  __u8 trace_ip_opt_type)
+{
+	__u32 offset;
+	__u32 end;
+	int i;
+	__u8 opt_type;
+	__u8 optlen;
+
+	if (ip4->ihl <= IHL_WITH_NO_OPTS)
+		return TRACE_ID_NOT_FOUND;
+
+	offset = ETH_HLEN + sizeof(struct iphdr);
+	end = offset + (ip4->ihl << 2);
+
+#pragma unroll(MAX_IPV4_OPTS)
+	for (i = 0; i < MAX_IPV4_OPTS && offset < end; i++) {
+		/* We load the option header 1 field at a time since different types
+		 * have different formats.
+		 *
+		 * "Options 0 and 1 are exactly one octet which is their type field. All
+		 * other options have their one octet type field, followed by a one
+		 * octet length field, followed by length-2 octets of option data."
+		 *
+		 * Ref: https://www.iana.org/assignments/ip-parameters/ip-parameters.xhtml
+		 */
+
+		if (ctx_load_bytes(ctx, offset, &opt_type, 1) < 0)
+			return TRACE_ID_ERROR;
+
+		if (opt_type == IPOPT_END)
+			break;
+
+		if (opt_type == IPOPT_NOOP) {
+			offset++;
+			continue;
+		}
+
+		if (ctx_load_bytes(ctx, offset + 1, &optlen, 1) < 0)
+			return TRACE_ID_ERROR;
+
+		if (opt_type != trace_ip_opt_type) {
+			offset += optlen;
+			continue;
+		}
+
+		if (optlen != OPT16_LEN && optlen != OPT32_LEN && optlen != OPT64_LEN)
+			return TRACE_ID_INVALID;
+
+		switch (optlen) {
+			case OPT16_LEN: {
+				__s16 temp;
+
+				if (ctx_load_bytes(ctx, offset + 2, &temp, sizeof(temp)) < 0)
+					return TRACE_ID_ERROR;
+				*value = bpf_ntohs(temp);
+				return 0;
+			}
+			case OPT32_LEN: {
+				__s32 temp;
+
+				if (ctx_load_bytes(ctx, offset + 2, &temp, sizeof(temp)) < 0)
+					return TRACE_ID_ERROR;
+				*value = bpf_ntohl(temp);
+				return 0;
+			}
+			case OPT64_LEN: {
+				__s64 temp;
+
+				if (ctx_load_bytes(ctx, offset + 2, &temp, sizeof(temp)) < 0)
+					return TRACE_ID_ERROR;
+				*value = ntohll(temp);
+				return 0;
+			}
+		default:
+			return TRACE_ID_UNSUPPORTED_LENGTH_ERROR;
+		}
+	}
+	return TRACE_ID_NOT_FOUND;
+}
+
+/*
+ * Parses the context to extract the trace ID from the IP options.
+ *
+ * Arguments:
+ * - ctx: The context buffer from which the IP options will be read.
+ * - ip_opt_type_value: The type value of the IP option that contains the trace ID.
+ *
+ * Prerequisites:
+ * - Supports reading a trace ID embedded in IP options with lengths of 2, 4, or 8 bytes.
+ * - No support for trace_ids that are not 2, 4, or 8 bytes.
+ *
+ * Outputs:
+ * - Returns 0 if the trace ID is found.
+ * - Returns TRACE_ID_NOT_FOUND if no trace ID is found in the options.
+ * - Returns TRACE_ID_INVALID if the found trace ID is invalid (e.g., non-positive).
+ * - Returns TRACE_ID_ERROR if there is an error during parsing.
+ * - Returns TRACE_ID_NO_FAMILY if the packet is not IPv4.
+ * - Returns TRACE_ID_SKIP_IPV6 if the packet is IPv6.
+ */
+static __always_inline int
+trace_id_from_ctx(struct __ctx_buff *ctx, __s64 *value, __u8 ip_opt_type_value)
+{
+	__u16 proto;
+	void *data, *data_end;
+	struct iphdr *ip4;
+	int ret;
+	__s64 trace_id = 0;
+
+	if (!validate_ethertype(ctx, &proto))
+		return TRACE_ID_ERROR;
+
+	if (proto == bpf_htons(ETH_P_IPV6))
+		return TRACE_ID_SKIP_IPV6;
+
+	if (proto != bpf_htons(ETH_P_IP))
+		return TRACE_ID_NO_FAMILY;
+
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+		return TRACE_ID_ERROR;
+
+	ret = trace_id_from_ip4(ctx, &trace_id, ip4, ip_opt_type_value);
+	if (IS_ERR(ret))
+		return ret;
+
+	*value = trace_id;
+	return 0;
+}
+
+#endif /* IP_TRACING_OPTION_TYPE */

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -27,6 +27,7 @@
 #include "utils.h"
 #include "metrics.h"
 #include "ratelimit.h"
+#include "trace_helpers.h"
 
 /* Available observation points. */
 enum trace_point {

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -182,9 +182,14 @@ struct trace_notify {
 		};
 		union v6addr	orig_ip6;
 	};
+	__u64		ip_trace_id;
 };
 
 #ifdef TRACE_NOTIFY
+
+/* Trace notify version 2 includes IP Trace support. */
+#define NOTIFY_TRACE_VER 2
+
 static __always_inline bool
 emit_trace_notify(enum trace_point obs_point, __u32 monitor)
 {
@@ -224,6 +229,7 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 		   __u32 src, __u32 dst, __u16 dst_id, __u32 ifindex,
 		   enum trace_reason reason, __u32 monitor, __u16 line, __u8 file)
 {
+	__u64 ip_trace_id = load_ip_trace_id();
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, monitor ? : TRACE_PAYLOAD_LEN,
 			      ctx_len);
@@ -249,12 +255,13 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_CAPTURE_VER),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_TRACE_VER),
 		.src_label	= src,
 		.dst_label	= dst,
 		.dst_id		= dst_id,
 		.reason		= reason,
 		.ifindex	= ifindex,
+		.ip_trace_id = ip_trace_id,
 	};
 	memset(&msg.orig_ip6, 0, sizeof(union v6addr));
 
@@ -268,6 +275,7 @@ send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 		   __u32 src, __u32 dst, __be32 orig_addr, __u16 dst_id,
 		   __u32 ifindex, enum trace_reason reason, __u32 monitor)
 {
+	__u64 ip_trace_id = load_ip_trace_id();
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, monitor ? : TRACE_PAYLOAD_LEN,
 			      ctx_len);
@@ -293,7 +301,7 @@ send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_CAPTURE_VER),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_TRACE_VER),
 		.src_label	= src,
 		.dst_label	= dst,
 		.dst_id		= dst_id,
@@ -301,6 +309,7 @@ send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 		.ifindex	= ifindex,
 		.ipv6		= 0,
 		.orig_ip4	= orig_addr,
+		.ip_trace_id = ip_trace_id,
 	};
 
 	ctx_event_output(ctx, &EVENTS_MAP,
@@ -314,6 +323,7 @@ send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 		   __u16 dst_id, __u32 ifindex, enum trace_reason reason,
 		   __u32 monitor)
 {
+	__u64 ip_trace_id = load_ip_trace_id();
 	__u64 ctx_len = ctx_full_len(ctx);
 	__u64 cap_len = min_t(__u64, monitor ? : TRACE_PAYLOAD_LEN,
 			      ctx_len);
@@ -339,13 +349,14 @@ send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 
 	msg = (typeof(msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
-		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_CAPTURE_VER),
+		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_TRACE_VER),
 		.src_label	= src,
 		.dst_label	= dst,
 		.dst_id		= dst_id,
 		.reason		= reason,
 		.ifindex	= ifindex,
 		.ipv6		= 1,
+		.ip_trace_id = ip_trace_id,
 	};
 
 	ipv6_addr_copy(&msg.orig_ip6, orig_addr);

--- a/bpf/lib/trace_helpers.h
+++ b/bpf/lib/trace_helpers.h
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#ifndef TRACE_ID_UTIL_H
+#define TRACE_ID_UTIL_H
+
+#include <bpf/ctx/ctx.h>
+#include <bpf/api.h>
+#include "common.h"
+#include "ip_options.h"
+
+#ifdef IP_TRACING_OPTION_TYPE
+/* Define the ip trace ID map with __u64 trace_id */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32); /* only one key */
+	__type(value, __u64); /* trace_id type */
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+} trace_id_map __section_maps_btf;
+
+/* bpf_trace_id_set sets the trace_id in the map. */
+static __always_inline __u64 bpf_trace_id_set(__u64 trace_id)
+{
+	__u32 __z = 0;
+	__u64 *__cache = map_lookup_elem(&trace_id_map, &__z);
+
+	if (__cache)
+		*__cache = trace_id;
+
+	return trace_id;
+}
+
+/* bpf_trace_id_get retrieves the trace_id from the map. */
+static __always_inline __u64 bpf_trace_id_get(void)
+{
+	__u32 __z = 0;
+	__u64 *__cache = map_lookup_elem(&trace_id_map, &__z);
+	__u64 trace_id = 0;
+
+	if (__cache)
+		trace_id = *__cache;
+
+	return trace_id;
+}
+
+/* Function to parse and store the trace_id and if valid. */
+static __always_inline void
+check_and_store_ip_trace_id(struct __ctx_buff *ctx, __u8 ip_opt_type_value)
+{
+	int ret;
+	__s64 trace_id = 0;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, ip_opt_type_value);
+	if (IS_ERR(ret))
+		bpf_trace_id_set(0);
+	else
+		bpf_trace_id_set(trace_id);
+}
+
+#else
+
+/* Provide alternative definitions for when tracing is disabled. */
+
+#define bpf_trace_id_get() (0)
+
+#endif /* IP_TRACING_OPTION_TYPE */
+
+static __always_inline __u64 load_ip_trace_id(void)
+{
+	return bpf_trace_id_get();
+}
+
+#endif /* TRACE_ID_UTIL_H */

--- a/bpf/tests/ip_options_trace_id.c
+++ b/bpf/tests/ip_options_trace_id.c
@@ -1,0 +1,1041 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+#include "node_config.h"
+
+#define DEBUG
+#define IP_TRACING_OPTION_TYPE
+
+#include <lib/ip_options.h>
+
+/* Used to define IP options for packet generation. */
+struct ipopthdr {
+	/* type field of the IP option. */
+	__u8 type;
+	/* len field of the IP option. Usually equal to total length of the IP
+	 * option, including type and len. Can be specified different from data
+	 * length for testing purposes. If zero, it will not be written to the
+	 * packet, so that tests can specify single-byte options.
+	 */
+	__u8 len;
+	/* Arbitrary data for the payload of the IP option. */
+	__u8 *data;
+	/* Length of the data field in bytes. Must match exactly. */
+	__u8 data_len;
+};
+
+/* Injects a packet into the ctx with the IPv4 options specified. See comments
+ * on the struct for more details on how to specify options. The total byte
+ * content of the options must align on 4-byte boundaries so that the IHL can be
+ * accurate.
+ * opts_len:   the number of options in opts.
+ * opts_bytes: the total number of bytes in options.
+ */
+static __always_inline __maybe_unused int
+gen_packet_with_options(struct __sk_buff *ctx,
+			const struct ipopthdr *opts,
+			__u8 opts_len, __u8 opt_bytes)
+{
+	struct pktgen builder;
+	struct iphdr *l3;
+	__u8 *new_opt;
+	int i, j, new_opt_len;
+
+	if (opt_bytes % 4 != 0)
+		return TEST_ERROR;
+	pktgen__init(&builder, ctx);
+	if (!pktgen__push_ethhdr(&builder))
+		return TEST_ERROR;
+	l3 = pktgen__push_default_iphdr_with_options(&builder, opt_bytes / 4);
+	if (!l3)
+		return TEST_ERROR;
+
+	new_opt = (__u8 *)&l3[1];
+	for (i = 0; i < opts_len; i++) {
+		new_opt_len = 0;
+		new_opt[0] = opts[i].type;
+		new_opt_len++;
+		if (opts[i].len != 0) {
+			new_opt[new_opt_len] = opts[i].len;
+			new_opt_len++;
+		}
+		for (j = 0; j < opts[i].data_len; j++) {
+			new_opt[new_opt_len] = opts[i].data[j];
+			new_opt_len++;
+		}
+		new_opt += new_opt_len;
+	}
+	if (!pktgen__push_data(&builder, default_data, sizeof(default_data)))
+		return TEST_ERROR;
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+/* SECTION 1: Following section has tests for the ntohll function,
+ * which converts a 64 byte int from network order to host byte order.
+ */
+
+/* General test for non-mixed. */
+CHECK("tc", "test_ntohll_function")
+int check_test_ntohll_function(void)
+{
+	test_init();
+
+	__u64 input = 0x0102030405060708;
+	__u64 expected_output = 0x0807060504030201;
+	__u64 output = ntohll(input);
+
+	if (output != expected_output)
+		test_fatal("0x%016llx but want 0x%016llx\n", input, output, expected_output);
+	test_finish();
+}
+
+/* Test positive values which would be negative on conversion. */
+CHECK("tc", "test_ntohll_max_positive")
+int check_test_ntohll_max_positive(void)
+{
+	test_init();
+
+	__u64 input = 0xFFFFFFFFFFFFFF80;
+	__u64 expected_output = 0x80FFFFFFFFFFFFFF;
+	__u64 output = ntohll(input);
+
+	if (output != expected_output)
+		test_fatal("0x%016llx but want 0x%016llx\n", input, output, expected_output);
+	test_finish();
+}
+
+/* Test max negative values. */
+CHECK("tc", "test_ntohll_min_negative")
+int check_test_ntohll_min_negative(void)
+{
+	test_init();
+
+	__u64 input = 0x8000000000000000;
+	__u64 expected_output = 0x0000000000000080;
+	__u64 output = ntohll(input);
+
+	if (output != expected_output)
+		test_fatal("0x%016llx but want 0x%016llx\n", input, output, expected_output);
+	test_finish();
+}
+
+/* Test for mixed_endian. */
+CHECK("tc", "test_ntohll_mixed_endian")
+int check_test_ntohll_mixed_endian(void)
+{
+	test_init();
+
+	__u64 input = 0x12345678ABCDEF01;
+	__u64 expected_output = 0x01EFCDAB78563412;
+	__u64 output = ntohll(input);
+
+	if (output != expected_output)
+		test_fatal("0x%016llx but want 0x%016llx\n", input, output, expected_output);
+	test_finish();
+}
+
+/* SECTION 2: Following section has tests for trace ID feature for packet
+ * validation and preprocessing.
+ */
+
+/* Test packet with no l3 header should return TRACE_ID_ERROR. */
+PKTGEN("tc", "extract_trace_id_with_no_l3_header_error")
+int test_extract_trace_id_with_no_l3_header_error_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	if (!pktgen__push_ethhdr(&builder))
+		return TEST_ERROR;
+	if (!pktgen__push_data(&builder, default_data, sizeof(default_data)))
+		return TEST_ERROR;
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+CHECK("tc", "extract_trace_id_with_no_l3_header_error")
+int test_extract_trace_id_with_no_l3_header_error_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_ERROR;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test packet with no eth header should return TRACE_ID_NO_FAMILY. */
+PKTGEN("tc", "extract_trace_id_with_no_eth_header_no_family")
+int test_extract_trace_id_with_no_eth_header_no_family_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	if (!pktgen__push_data(&builder, default_data, sizeof(default_data)))
+		return TEST_ERROR;
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+CHECK("tc", "extract_trace_id_with_no_eth_header_no_family")
+int test_extract_trace_id_with_no_eth_header_no_family_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_NO_FAMILY;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test packet with IPv6 header should return TRACE_ID_SKIP_IPV6. */
+PKTGEN("tc", "extract_trace_id_no_ipv6_options")
+int test_extract_trace_id_no_ipv6_options_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	if (!pktgen__push_ethhdr(&builder))
+		return TEST_ERROR;
+	if (!pktgen__push_default_ipv6hdr(&builder))
+		return TEST_ERROR;
+	if (!pktgen__push_data(&builder, default_data, sizeof(default_data)))
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+CHECK("tc", "extract_trace_id_no_ipv6_options")
+int test_extract_trace_id_no_ipv6_options_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_SKIP_IPV6;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+	test_finish();
+}
+
+/* Test a single option specifying the trace ID with no special cases. */
+PKTGEN("tc", "extract_trace_id_solo")
+int test_extract_trace_id_solo_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 4,
+			.data = (__u8 *)"\x00\x01",
+			.data_len = 2,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 1, 4);
+}
+
+CHECK("tc", "extract_trace_id_solo")
+int test_extract_trace_id_solo_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 1;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test packet with IPv4 header should return TRACE_ID_NOT_FOUND. */
+PKTGEN("tc", "extract_trace_id_no_ipv4_options")
+int test_extract_trace_id_no_options_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	if (!pktgen__push_ethhdr(&builder))
+		return TEST_ERROR;
+	if (!pktgen__push_iphdr(&builder, 0))
+		return TEST_ERROR;
+	if (!pktgen__push_data(&builder, default_data, sizeof(default_data)))
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+CHECK("tc", "extract_trace_id_no_ipv4_options")
+int test_extract_trace_id_no_options_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_NOT_FOUND;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test trace ID after END should return TRACE_ID_NOT_FOUND. */
+PKTGEN("tc", "extract_trace_id_after_ipopt_end_not_found")
+int test_extract_trace_id_after_ipopt_end_not_found_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = IPOPT_END,
+			.len = 0,
+			.data_len = 0,
+		},
+		{
+			.type = 136,
+			.len = 4,
+			.data = (__u8 *)"\x00\x01",
+			.data_len = 2,
+		},
+		/* Add padding to align on 4-byte boundary. */
+		{
+			.type = IPOPT_NOOP,
+			.len = 0,
+			.data_len = 0,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0,
+			.data_len = 0,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0,
+			.data_len = 0,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 5, 8);
+}
+
+CHECK("tc", "extract_trace_id_after_ipopt_end_not_found")
+int test_extract_trace_id_after_ipopt_end_not_found_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_NOT_FOUND;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test trace ID comes after loop limit should return TRACE_ID_NOT_FOUND. */
+PKTGEN("tc", "extract_trace_id_after_loop_limit_not_found")
+int test_extract_trace_id_after_loop_limit_not_found_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = IPOPT_NOOP,
+			.len = 0,
+			.data_len = 0,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0,
+			.data_len = 0,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0,
+			.data_len = 0,
+		},
+		/* The loop limit is 3 so the following options are ignored. */
+		{
+			.type = 136,
+			.len = 4,
+			.data = (__u8 *)"\x00\x01",
+			.data_len = 2,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0,
+			.data_len = 0,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 5, 8);
+}
+
+CHECK("tc", "extract_trace_id_after_loop_limit_not_found")
+int test_extract_trace_id_after_loop_limit_not_found_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_NOT_FOUND;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test three options with the trace ID option being first. */
+PKTGEN("tc", "extract_trace_id_first_of_three")
+int test_extract_trace_id_first_of_three_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 4,
+			.data = (__u8 *)"\x00\x01",
+			.data_len = 2,
+		},
+		{
+			.type = 10,
+			.len = 4,
+			.data = (__u8 *)"\x10\x10",
+			.data_len = 2,
+		},
+		{
+			.type = 11,
+			.len = 4,
+			.data = (__u8 *)"\x11\x11",
+			.data_len = 2,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 3, 12);
+}
+
+CHECK("tc", "extract_trace_id_first_of_three")
+int test_extract_trace_id_first_of_three_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 1;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test three options with the trace ID option being between the other two. */
+PKTGEN("tc", "extract_trace_id_middle_of_three")
+int test_extract_trace_id_middle_of_three_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 10,
+			.len = 4,
+			.data = (__u8 *)"\x10\x10",
+			.data_len = 2,
+		},
+		{
+			.type = 136,
+			.len = 4,
+			.data = (__u8 *)"\x00\x01",
+			.data_len = 2,
+		},
+		{
+			.type = 11,
+			.len = 4,
+			.data = (__u8 *)"\x11\x11",
+			.data_len = 2,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 3, 12);
+}
+
+CHECK("tc", "extract_trace_id_middle_of_three")
+int test_extract_trace_id_middle_of_three_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 1;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test three options with the trace ID option being last of the three. */
+PKTGEN("tc", "extract_trace_id_last_of_three")
+int test_extract_trace_id_last_of_three_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 10,
+			.len = 4,
+			.data = (__u8 *)"\x10\x10",
+			.data_len = 2,
+		},
+		{
+			.type = 11,
+			.len = 4,
+			.data = (__u8 *)"\x11\x11",
+			.data_len = 2,
+		},
+		{
+			.type = 136,
+			.len = 4,
+			.data = (__u8 *)"\x00\x01",
+			.data_len = 2,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 3, 12);
+}
+
+CHECK("tc", "extract_trace_id_last_of_three")
+int test_extract_trace_id_last_of_three_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 1;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test multiple options with the trace ID coming after a NOOP option. */
+PKTGEN("tc", "extract_trace_id_after_ipopt_noop")
+int test_extract_trace_id_after_ipopt_noop_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = IPOPT_NOOP,
+			.len = 0, /* Single byte option. */
+			.data_len = 0,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0, /* Single byte option. */
+			.data_len = 0,
+		},
+		{
+			.type = 136,
+			.len = 4,
+			.data = (__u8 *)"\x00\x01",
+			.data_len = 2,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0, /* Single byte option. */
+			.data_len = 0,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0, /* Single byte option. */
+			.data_len = 0,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 5, 8);
+}
+
+CHECK("tc", "extract_trace_id_after_ipopt_noop")
+int test_extract_trace_id_after_ipopt_noop_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 1;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test multiple options with the trace ID not present should return TRACE_ID_NOT_FOUND. */
+PKTGEN("tc", "extract_trace_id_not_found_with_other_options")
+int test_extract_trace_id__not_found_with_other_options_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 10,
+			.len = 4,
+			.data = (__u8 *)"\x10\x10",
+			.data_len = 2,
+		},
+		{
+			.type = 11,
+			.len = 4,
+			.data = (__u8 *)"\x11\x11",
+			.data_len = 2,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 2, 8);
+}
+
+CHECK("tc", "extract_trace_id_not_found_with_other_options")
+int test_extract_trace_id_not_found_with_other_options_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_NOT_FOUND;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test trace ID with incorrect length field should return INVALID. */
+PKTGEN("tc", "extract_trace_id_wrong_len_invalid")
+int test_extract_trace_id_wrong_len_invalid_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 3, /* Invalid length with this option. */
+			.data = (__u8 *)"\x00\x01",
+			.data_len = 2,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 1, 4);
+}
+
+CHECK("tc", "extract_trace_id_wrong_len_invalid")
+int test_extract_trace_id_wrong_len_invalid_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_INVALID;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test trace ID with negative value should return TRACE_ID_INVALID. */
+PKTGEN("tc", "extract_trace_id_negative")
+int test_extract_trace_id_negative_invalid_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+				.type = 136,
+				.len = 4,
+				.data = (__u8 *)"\x80\x01",
+				.data_len = 2,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 1, 4);
+}
+
+CHECK("tc", "extract_trace_id_negative")
+int test_extract_trace_id_negative_invalid_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 0x8001;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+
+	test_finish();
+}
+
+/* Store and read trace ID to different option than stream ID with 2 bytes of data. */
+PKTGEN("tc", "extract_trace_id_different_option_type")
+int test_extract_trace_id_different_option_type_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 137,
+			.len = 4,
+			.data = (__u8 *)"\x00\x02",
+			.data_len = 2,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 1, 4);
+}
+
+CHECK("tc", "extract_trace_id_different_option_type")
+int test_extract_trace_id_different_option_type_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 0x0002;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 137);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Read trace ID from wrong IP option. */
+PKTGEN("tc", "extract_read_trace_id_wrong_option_type")
+int test_extract_read_trace_id_wrong_option_type_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 137,
+			.len = 4,
+			.data = (__u8 *)"\x00\x02",
+			.data_len = 2,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 1, 4);
+}
+
+CHECK("tc", "extract_read_trace_id_wrong_option_type")
+int test_extract_read_trace_id_wrong_option_type_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_NOT_FOUND;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %d; want %d\n", trace_id, want);
+	test_finish();
+}
+
+/* Test a valid 4-byte trace ID. */
+PKTGEN("tc", "extract_trace_id_4_bytes_valid")
+int test_extract_trace_id_4_bytes_valid_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 6,
+			.data = (__u8 *)"\x00\x01\x23\x45",
+			.data_len = 4,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 1, 8);
+}
+
+CHECK("tc", "extract_trace_id_4_bytes_valid")
+int test_extract_trace_id_4_bytes_valid_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 0x00012345;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+	test_finish();
+}
+
+/* Test negative trace id should return valid. */
+PKTGEN("tc", "extract_trace_id_negative_4_bytes")
+int test_extract_trace_id_negative_4_bytes_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 6,
+			.data = (__u8 *)"\x80\x01\x23\x45",
+			.data_len = 4,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 1, 8);
+}
+
+CHECK("tc", "extract_trace_id_negative_4_bytes")
+int test_extract_trace_id_negative_4_bytes_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 0x80012345;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+	test_finish();
+}
+
+/* Test a 4-byte trace ID with incorrect length. */
+PKTGEN("tc", "extract_trace_id_4_bytes_wrong_length")
+int test_extract_trace_id_4_bytes_wrong_length_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 5, /* Incorrect length */
+			.data = (__u8 *)"\x01\x23\x45\x67",
+			.data_len = 4,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 1, 8);
+}
+
+CHECK("tc", "extract_trace_id_4_bytes_wrong_length")
+int test_extract_trace_id_4_bytes_wrong_length_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_INVALID;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+	test_finish();
+}
+
+/* Test a 4-byte trace ID before the end of option list. */
+PKTGEN("tc", "extract_trace_id_4_bytes_before_end")
+int test_extract_trace_id_4_bytes_before_end_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 6,
+			.data = (__u8 *)"\x00\x01\x23\x45",
+			.data_len = 4,
+		},
+		{
+			.type = IPOPT_END,
+			.len = 0,
+			.data_len = 0,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 2, 8);
+}
+
+CHECK("tc", "extract_trace_id_4_bytes_before_end")
+int test_extract_trace_id_4_bytes_before_end_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 0x12345;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+	test_finish();
+}
+
+/* Test a valid 8-byte trace ID should return TRACE_ID_ERROR. */
+PKTGEN("tc", "extract_trace_id_8_bytes_valid")
+int test_extract_trace_id_8_bytes_valid_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 10,
+			.data = (__u8 *)"\x12\x34\x56\x78\x9A\xBC\xDE\xF0",
+			.data_len = 8,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 1, 12);
+}
+
+CHECK("tc", "extract_trace_id_8_bytes_valid")
+int test_extract_trace_id_8_bytes_valid_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 0x123456789abcdef0;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+	test_finish();
+}
+
+/* Test an 8-byte trace ID followed by padding. */
+PKTGEN("tc", "extract_trace_id_8_bytes_with_padding")
+int test_extract_trace_id_8_bytes_with_padding_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 10, /* Total length including type and len fields */
+			.data = (__u8 *)"\x01\x02\x03\x04\x00\x00\x00\x00",
+			.data_len = 8,
+		},
+		{
+			.type = IPOPT_NOOP,
+			.len = 0,
+			.data_len = 0,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 2, 12);
+}
+
+CHECK("tc", "extract_trace_id_8_bytes_with_padding")
+int test_extract_trace_id_8_bytes_with_padding_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 0x0102030400000000; /* Expected valid trace ID */
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+	test_finish();
+}
+
+/* Test an 8-byte trace ID that represents a negative value. */
+PKTGEN("tc", "extract_trace_id_8_bytes_negative")
+int test_extract_trace_id_8_bytes_negative_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 10,
+			.data = (__u8 *)"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFA",
+			.data_len = 8,
+		},
+	};
+
+	return gen_packet_with_options(ctx, opts, 1, 12);
+}
+
+CHECK("tc", "extract_trace_id_8_bytes_negative")
+int test_extract_trace_id_8_bytes_negative_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = 0xFFFFFFFFFFFFFFFA;
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+
+	test_finish();
+}
+
+/* Test an 8-byte trace ID with an invalid option length. */
+PKTGEN("tc", "extract_trace_id_8_bytes_invalid_length")
+int test_extract_trace_id_8_bytes_invalid_length_pktgen(struct __ctx_buff *ctx)
+{
+	struct ipopthdr opts[] = {
+		{
+			.type = 136,
+			.len = 9, /* Invalid length, should be 10 */
+			.data = (__u8 *)"\x01\x02\x03\x04\x05\x06\x07\x08",
+			.data_len = 8,
+		},
+	};
+	return gen_packet_with_options(ctx, opts, 1, 12);
+}
+
+CHECK("tc", "extract_trace_id_8_bytes_invalid_length")
+int test_extract_trace_id_8_bytes_invalid_length_check(struct __ctx_buff *ctx)
+{
+	test_init();
+	__s64 want = TRACE_ID_INVALID; /* Expected invalid trace ID */
+	__s64 trace_id = 0;
+	int ret;
+
+	ret = trace_id_from_ctx(ctx, &trace_id, 136);
+	if (IS_ERR(ret))
+		trace_id = ret;
+
+	if (trace_id != want)
+		test_fatal("trace_id_from_ctx(ctx) = %lld; want %lld\n", trace_id, want);
+	test_finish();
+}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1055,6 +1055,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Float64(option.ConnectivityProbeFrequencyRatio, defaults.ConnectivityProbeFrequencyRatio, "Ratio of the connectivity probe frequency vs resource usage, a float in [0, 1]. 0 will give more frequent probing, 1 will give less frequent probing. Probing frequency is dynamically adjusted based on the cluster size.")
 	option.BindEnv(vp, option.ConnectivityProbeFrequencyRatio)
 
+	flags.Uint8(option.IPTracingOptionType, 0, "Specifies what IPv4 option type should be used to extract trace information from a packet; a value of 0 (default) disables IP tracing.")
+	option.BindEnv(vp, option.IPTracingOptionType)
+
 	if err := vp.BindPFlags(flags); err != nil {
 		log.Fatalf("BindPFlags failed: %s", err)
 	}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -787,6 +787,11 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION"] = "1"
 	}
 
+	// Write IP_OPTION_TRACING_TYPE macro from EnablePacketIPTracing value
+	if option.Config.IPTracingOptionType > 0 {
+		cDefinesMap["IP_TRACING_OPTION_TYPE"] = strconv.Itoa(int(option.Config.IPTracingOptionType))
+	}
+
 	fmt.Fprint(fw, declareConfig("identity_length", identity.GetClusterIDShift(), "Identity length in bits"))
 	fmt.Fprint(fw, assignConfig("identity_length", identity.GetClusterIDShift()))
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -587,6 +587,9 @@ const (
 
 	// ConnectivityProbeFrequencyRatio is the default connectivity probe frequency
 	ConnectivityProbeFrequencyRatio = 0.5
+
+	// IPTracingOptionType is the default value for option.IPTracingOptionType
+	IPTracingOptionType = 0
 )
 
 var (

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
 	"github.com/stretchr/testify/assert"
@@ -370,53 +371,114 @@ func TestDecodeTraceNotify(t *testing.T) {
 }
 
 func TestDecodeDropNotify(t *testing.T) {
-	buf := &bytes.Buffer{}
-	dn := monitor.DropNotify{
-		Type:     byte(monitorAPI.MessageTypeDrop),
-		File:     1, // bpf_host.c
-		Line:     42,
-		SrcLabel: 123,
-		DstLabel: 456,
-	}
-	err := binary.Write(buf, byteorder.Native, &dn)
-	require.NoError(t, err)
-	buffer := gopacket.NewSerializeBuffer()
-	err = gopacket.SerializeLayers(buffer,
+	packetBuffer := gopacket.NewSerializeBuffer()
+	if err := gopacket.SerializeLayers(packetBuffer,
 		gopacket.SerializeOptions{},
 		&layers.Ethernet{
-			SrcMAC: net.HardwareAddr{1, 2, 3, 4, 5, 6},
-			DstMAC: net.HardwareAddr{1, 2, 3, 4, 5, 6},
+			SrcMAC:       net.HardwareAddr{1, 2, 3, 4, 5, 6},
+			DstMAC:       net.HardwareAddr{4, 5, 6, 7, 8, 9},
+			EthernetType: layers.EthernetTypeIPv4,
 		},
 		&layers.IPv4{
+			IHL:   5,
 			SrcIP: net.IPv4(1, 2, 3, 4),
 			DstIP: net.IPv4(1, 2, 3, 4),
 		},
-	)
-	require.NoError(t, err)
-	buf.Write(buffer.Bytes())
-	require.NoError(t, err)
+	); err != nil {
+		t.Fatalf("SerializeLayers(...) buffer: %v", err)
+	}
+
+	SrcLabel := identity.NumericIdentity(123)
+	DstLabel := identity.NumericIdentity(456)
+
+	dropNotify := func(version uint16) monitor.DropNotify {
+		return monitor.DropNotify{
+			Type:     byte(monitorAPI.MessageTypeDrop),
+			File:     1, // bpf_host.c
+			Version:  version,
+			SrcLabel: SrcLabel,
+			DstLabel: DstLabel,
+		}
+	}
 	identityGetter := &testutils.FakeIdentityGetter{
 		OnGetIdentity: func(securityIdentity uint32) (*identity.Identity, error) {
-			if securityIdentity == uint32(dn.SrcLabel) {
-				return &identity.Identity{Labels: labels.NewLabelsFromModel([]string{"k8s:src=label"})}, nil
-			} else if securityIdentity == uint32(dn.DstLabel) {
-				return &identity.Identity{Labels: labels.NewLabelsFromModel([]string{"k8s:dst=label"})}, nil
+			m := map[identity.NumericIdentity][]string{
+				SrcLabel: {"k8s:src=label"},
+				DstLabel: {"k8s:dst=label"},
 			}
-			return nil, fmt.Errorf("identity not found for %d", securityIdentity)
+
+			v, ok := m[identity.NumericIdentity(securityIdentity)]
+			if !ok {
+				return nil, fmt.Errorf("identity not found for %d", securityIdentity)
+			}
+			return &identity.Identity{Labels: labels.NewLabelsFromModel(v)}, nil
 		},
 	}
 
 	parser, err := New(hivetest.Logger(t), &testutils.NoopEndpointGetter, identityGetter, &testutils.NoopDNSGetter, &testutils.NoopIPGetter, &testutils.NoopServiceGetter, &testutils.NoopLinkGetter)
 	require.NoError(t, err)
+	testCases := []struct {
+		name      string
+		dn        any
+		srcLabels []string
+		dstLabels []string
+		want      *flowpb.Flow
+	}{
+		{
+			name:      "v1",
+			dn:        dropNotify(1),
+			srcLabels: []string{"k8s:src=label"},
+			dstLabels: []string{"k8s:dst=label"},
+			want: &flowpb.Flow{
+				Verdict: flowpb.Verdict_DROPPED,
+				Ethernet: &flowpb.Ethernet{
+					Source:      "01:02:03:04:05:06",
+					Destination: "04:05:06:07:08:09",
+				},
+				IP: &flowpb.IP{
+					Source:      "1.2.3.4",
+					Destination: "1.2.3.4",
+					IpVersion:   flowpb.IPVersion_IPv4,
+				},
+				Source: &flowpb.Endpoint{
+					Identity: 123,
+					Labels:   []string{"k8s:src=label"},
+				},
+				Destination: &flowpb.Endpoint{
+					Identity: 456,
+					Labels:   []string{"k8s:dst=label"},
+				},
+				Type: flowpb.FlowType_L3_L4,
+				EventType: &flowpb.CiliumEventType{
+					Type: 1,
+				},
+				Summary: "IPv4",
+				File:    &flowpb.FileInfo{Name: "bpf_host.c"},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := tc.dn
+			buf := &bytes.Buffer{}
+			if err := binary.Write(buf, byteorder.Native, n); err != nil {
+				t.Fatalf("Write(...) %T to buffer: %v", n, err)
+			}
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(buf.Bytes(), f)
-	require.NoError(t, err)
-	assert.Equal(t, []string{"k8s:src=label"}, f.GetSource().GetLabels())
-	assert.Equal(t, []string{"k8s:dst=label"}, f.GetDestination().GetLabels())
-	assert.NotNil(t, f.GetFile())
-	assert.Equal(t, "bpf_host.c", f.GetFile().GetName())
-	assert.Equal(t, uint32(42), f.GetFile().GetLine())
+			buf.Write(packetBuffer.Bytes())
+
+			f := &flowpb.Flow{}
+			if err := parser.Decode(buf.Bytes(), f); err != nil {
+				t.Fatalf("parser.Decode(bytes, f): %v", err)
+
+			}
+			require.NoError(t, err)
+
+			if diff := cmp.Diff(tc.want, f, cmpopts.IgnoreFields(flowpb.Flow{}, "File"), protocmp.Transform()); diff != "" {
+				t.Errorf("Unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
 }
 
 func TestDecodePolicyVerdictNotify(t *testing.T) {

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -241,7 +241,8 @@ func TestL34Decode(t *testing.T) {
 	// ff02::1:ff00:b3e5   f00d::a10:0:0:9195   L3/4
 	d2 := []byte{
 		4, 5, 168, 11, 95, 22, 242, 184, 86, 0, 0, 0, 86, 0, 0, 0, 104, 0, 0, 0,
-		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 51, 51, 255, 0, 179, 229, 18, 145,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		51, 51, 255, 0, 179, 229, 18, 145,
 		6, 226, 34, 26, 134, 221, 96, 0, 0, 0, 0, 32, 58, 255, 255, 2, 0, 0, 0,
 		0, 0, 0, 0, 0, 0, 1, 255, 0, 179, 229, 240, 13, 0, 0, 0, 0, 0, 0, 10,
 		16, 0, 0, 0, 0, 145, 149, 135, 0, 80, 117, 0, 0, 0, 0, 240, 13, 0, 0, 0,
@@ -391,8 +392,8 @@ func TestDecodeDropNotify(t *testing.T) {
 	SrcLabel := identity.NumericIdentity(123)
 	DstLabel := identity.NumericIdentity(456)
 
-	dropNotify := func(version uint16) monitor.DropNotify {
-		return monitor.DropNotify{
+	dropNotify := func(version uint16) monitor.DropNotifyV1 {
+		return monitor.DropNotifyV1{
 			Type:     byte(monitorAPI.MessageTypeDrop),
 			File:     1, // bpf_host.c
 			Version:  version,
@@ -427,6 +428,40 @@ func TestDecodeDropNotify(t *testing.T) {
 		{
 			name:      "v1",
 			dn:        dropNotify(1),
+			srcLabels: []string{"k8s:src=label"},
+			dstLabels: []string{"k8s:dst=label"},
+			want: &flowpb.Flow{
+				Verdict: flowpb.Verdict_DROPPED,
+				Ethernet: &flowpb.Ethernet{
+					Source:      "01:02:03:04:05:06",
+					Destination: "04:05:06:07:08:09",
+				},
+				IP: &flowpb.IP{
+					Source:      "1.2.3.4",
+					Destination: "1.2.3.4",
+					IpVersion:   flowpb.IPVersion_IPv4,
+				},
+				Source: &flowpb.Endpoint{
+					Identity: 123,
+					Labels:   []string{"k8s:src=label"},
+				},
+				Destination: &flowpb.Endpoint{
+					Identity: 456,
+					Labels:   []string{"k8s:dst=label"},
+				},
+				Type: flowpb.FlowType_L3_L4,
+				EventType: &flowpb.CiliumEventType{
+					Type: 1,
+				},
+				Summary: "IPv4",
+				File:    &flowpb.FileInfo{Name: "bpf_host.c"},
+			},
+		},
+		{
+			name: "v2",
+			dn: monitor.DropNotify{
+				DropNotifyV1: dropNotify(2),
+			},
 			srcLabels: []string{"k8s:src=label"},
 			dstLabels: []string{"k8s:dst=label"},
 			want: &flowpb.Flow{
@@ -612,7 +647,7 @@ func TestDecodePolicyVerdictNotify(t *testing.T) {
 
 func TestDecodeDropReason(t *testing.T) {
 	reason := uint8(130)
-	dn := monitor.DropNotify{
+	dn := monitor.DropNotifyV1{
 		Type:    byte(monitorAPI.MessageTypeDrop),
 		SubType: reason,
 	}
@@ -790,7 +825,7 @@ func TestDecodeTrafficDirection(t *testing.T) {
 	}
 
 	// DROP at unknown endpoint
-	dn := monitor.DropNotify{
+	dn := monitor.DropNotifyV1{
 		Type: byte(monitorAPI.MessageTypeDrop),
 	}
 	f := parseFlow(dn, localIP, remoteIP)
@@ -798,7 +833,7 @@ func TestDecodeTrafficDirection(t *testing.T) {
 	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
 
 	// DROP Egress
-	dn = monitor.DropNotify{
+	dn = monitor.DropNotifyV1{
 		Type:   byte(monitorAPI.MessageTypeDrop),
 		Source: localEP,
 	}
@@ -807,7 +842,7 @@ func TestDecodeTrafficDirection(t *testing.T) {
 	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
 
 	// DROP Ingress
-	dn = monitor.DropNotify{
+	dn = monitor.DropNotifyV1{
 		Type:   byte(monitorAPI.MessageTypeDrop),
 		Source: localEP,
 	}
@@ -1096,7 +1131,7 @@ func TestDecodeIsReply(t *testing.T) {
 	assert.False(t, f.GetReply())
 
 	// DropNotify statically assumes is_reply=unknown
-	dn := monitor.DropNotify{
+	dn := monitor.DropNotifyV1{
 		Type: byte(monitorAPI.MessageTypeDrop),
 	}
 	f = parseFlow(dn, localIP, remoteIP)
@@ -1485,13 +1520,13 @@ func TestDecode_DropNotify(t *testing.T) {
 
 	testCases := []struct {
 		name    string
-		event   monitor.DropNotify
+		event   monitor.DropNotifyV1
 		ipTuple ipTuple
 		want    *flowpb.Flow
 	}{
 		{
 			name: "drop_unknown",
-			event: monitor.DropNotify{
+			event: monitor.DropNotifyV1{
 				Type: byte(monitorAPI.MessageTypeDrop),
 				File: 2,
 				Line: 42,
@@ -1507,7 +1542,7 @@ func TestDecode_DropNotify(t *testing.T) {
 		},
 		{
 			name: "drop_egress",
-			event: monitor.DropNotify{
+			event: monitor.DropNotifyV1{
 				Type:   byte(monitorAPI.MessageTypeDrop),
 				Source: localEP,
 				File:   6,
@@ -1525,7 +1560,7 @@ func TestDecode_DropNotify(t *testing.T) {
 		},
 		{
 			name: "drop_ingress",
-			event: monitor.DropNotify{
+			event: monitor.DropNotifyV1{
 				Type:   byte(monitorAPI.MessageTypeDrop),
 				Source: localEP,
 				File:   4,

--- a/pkg/hubble/testutils/payload.go
+++ b/pkg/hubble/testutils/payload.go
@@ -22,6 +22,7 @@ func CreateL3L4Payload(message interface{}, layers ...gopacket.SerializableLayer
 	switch messageType := message.(type) {
 	case monitor.DebugCapture,
 		monitor.DropNotify,
+		monitor.DropNotifyV1,
 		monitor.PolicyVerdictNotify,
 		monitor.TraceNotify,
 		monitor.TraceNotifyV0,

--- a/pkg/hubble/testutils/payload_test.go
+++ b/pkg/hubble/testutils/payload_test.go
@@ -26,16 +26,16 @@ func decodeHex(s string) []byte {
 
 func TestCreateL3L4Payload(t *testing.T) {
 	// These contain TraceNotify headers plus the ethernet header of the packet
-	packetv4Prefix := decodeHex("0403a80b8d4598d462000000620000006800000001000000000002000000000006e9183bb275129106e2221a080045000054bfe900003f019ae2")
-	packetv4802Prefix := decodeHex("0403a80b8d4598d462000000620000006800000001000000000002000000000006e9183bb275129106e2221a81000202080045000054bfe900003f019ae2")
-	packetv6Prefix := decodeHex("0405a80b5f16f2b85600000056000000680000000000000000000000000000003333ff00b3e5129106e2221a86dd6000000000203aff")
-	packetv6802Prefix := decodeHex("0405a80b5f16f2b85600000056000000680000000000000000000000000000003333ff00b3e5129106e2221a8100020286dd6000000000203aff")
+	packetv4Prefix := "0403a80b8d4598d462000000620000006800000001000000000002000000000006e9183bb275129106e2221a080045000054bfe900003f019ae2"
+	packetv4802Prefix := "0403a80b8d4598d462000000620000006800000001000000000002000000000006e9183bb275129106e2221a81000202080045000054bfe900003f019ae2"
+	packetv6Prefix := "0405a80b5f16f2b85600000056000000680000000000000000000000000000003333ff00b3e5129106e2221a86dd6000000000203aff"
+	packetv6802Prefix := "0405a80b5f16f2b85600000056000000680000000000000000000000000000003333ff00b3e5129106e2221a8100020286dd6000000000203aff"
 
 	// ICMPv4/v6 packets (with reversed src/dst IPs)
-	packetICMPv4 := decodeHex("010101010a107e4000003639225700051b7b415d0000000086bf050000000000101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031323334353637")
-	packetICMPv6Req := decodeHex("f00d0000000000000a10000000009195ff0200000000000000000001ff00b3e58700507500000000f00d0000000000000a1000000000b3e50101129106e2221a")
-	packetICMPv4Rev := decodeHex("0a107e400101010100003639225700051b7b415d0000000086bf050000000000101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031323334353637")
-	packetICMPv6Rev := decodeHex("ff0200000000000000000001ff00b3e5f00d0000000000000a100000000091958700507500000000f00d0000000000000a1000000000b3e50101129106e2221a")
+	packetICMPv4 := "010101010a107e4000003639225700051b7b415d0000000086bf050000000000101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031323334353637"
+	packetICMPv6Req := "f00d0000000000000a10000000009195ff0200000000000000000001ff00b3e58700507500000000f00d0000000000000a1000000000b3e50101129106e2221a"
+	packetICMPv4Rev := "0a107e400101010100003639225700051b7b415d0000000086bf050000000000101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031323334353637"
+	packetICMPv6Rev := "ff0200000000000000000001ff00b3e5f00d0000000000000a100000000091958700507500000000f00d0000000000000a1000000000b3e50101129106e2221a"
 
 	// The following structs are decoded pieces of the above packets
 	traceNotifyIPv4 := monitor.TraceNotifyV0{
@@ -163,7 +163,7 @@ func TestCreateL3L4Payload(t *testing.T) {
 				msg: traceNotifyIPv4,
 				l:   []gopacket.SerializableLayer{etherIPv4, ipv4, icmpv4, icmpv4Payload},
 			},
-			want: append(packetv4Prefix[:], packetICMPv4...),
+			want: decodeHex(packetv4Prefix + packetICMPv4),
 		},
 		{
 			name: "ICMPv6 Neighbor Solicitation",
@@ -171,7 +171,7 @@ func TestCreateL3L4Payload(t *testing.T) {
 				msg: traceNotifyIPv6,
 				l:   []gopacket.SerializableLayer{etherIPv6, ipv6, icmpv6, icmpv6Payload},
 			},
-			want: append(packetv6Prefix[:], packetICMPv6Req...),
+			want: decodeHex(packetv6Prefix + packetICMPv6Req),
 		},
 		{
 			name: "ICMPv4 Echo Reply Reversed",
@@ -179,7 +179,7 @@ func TestCreateL3L4Payload(t *testing.T) {
 				msg: traceNotifyIPv4,
 				l:   []gopacket.SerializableLayer{etherIPv4, ipv4Rev, icmpv4, icmpv4Payload},
 			},
-			want: append(packetv4Prefix[:], packetICMPv4Rev...),
+			want: decodeHex(packetv4Prefix + packetICMPv4Rev),
 		},
 		{
 			name: "ICMPv6 Neighbor Solicitation Reversed",
@@ -187,7 +187,7 @@ func TestCreateL3L4Payload(t *testing.T) {
 				msg: traceNotifyIPv6,
 				l:   []gopacket.SerializableLayer{etherIPv6, ipv6Rev, icmpv6, icmpv6Payload},
 			},
-			want: append(packetv6Prefix[:], packetICMPv6Rev...),
+			want: decodeHex(packetv6Prefix + packetICMPv6Rev),
 		},
 		{
 			name: "802.11q ICMPv4 Echo Reply",
@@ -195,7 +195,7 @@ func TestCreateL3L4Payload(t *testing.T) {
 				msg: traceNotifyIPv4,
 				l:   []gopacket.SerializableLayer{etherIPv4Dot1Q, dot1QIPv4, ipv4, icmpv4, icmpv4Payload},
 			},
-			want: append(packetv4802Prefix[:], packetICMPv4...),
+			want: decodeHex(packetv4802Prefix + packetICMPv4),
 		},
 		{
 			name: "802.11q ICMPv6 Neighbor Solicitation",
@@ -203,7 +203,7 @@ func TestCreateL3L4Payload(t *testing.T) {
 				msg: traceNotifyIPv6,
 				l:   []gopacket.SerializableLayer{etherIPv6Dot1Q, dot1QIPv6, ipv6, icmpv6, icmpv6Payload},
 			},
-			want: append(packetv6802Prefix[:], packetICMPv6Req...),
+			want: decodeHex(packetv6802Prefix + packetICMPv6Req),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/monitor/datapath_drop_test.go
+++ b/pkg/monitor/datapath_drop_test.go
@@ -8,57 +8,210 @@ import (
 	"encoding/binary"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/byteorder"
 )
 
-func TestDecodeDropNotify(t *testing.T) {
+func TestDropNotifyV1_Decode(t *testing.T) {
 	// This check on the struct length constant is there to ensure that this
 	// test is updated when the struct changes.
 	require.Equal(t, 36, DropNotifyV1Len)
 
-	input := DropNotify{
-		Type:     0x00,
-		SubType:  0x01,
-		Source:   0x02_03,
-		Hash:     0x04_05_06_07,
-		OrigLen:  0x08_09_0a_0b,
-		CapLen:   0x0c_0d,
-		Version:  0x01,
-		SrcLabel: 0x11_12_13_14,
-		DstLabel: 0x15_16_17_18,
-		DstID:    0x19_1a_1b_1c,
-		Line:     0x1d_1e,
-		File:     0x20,
-		ExtError: 0x21,
-		Ifindex:  0x22_23_24_25,
+	testCases := []struct {
+		name  string
+		input DropNotifyV1
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "arbitrary",
+			input: DropNotifyV1{
+				Type:     0x00,
+				SubType:  0x01,
+				Source:   0x02_03,
+				Hash:     0x04_05_06_07,
+				OrigLen:  0x08_09_0a_0b,
+				CapLen:   0x0e_10,
+				Version:  0x00_01,
+				SrcLabel: 0x11_12_13_14,
+				DstLabel: 0x15_16_17_18,
+				DstID:    0x19_1a_1b_1c,
+				Line:     0x1d_1e,
+				File:     0x20,
+				ExtError: 0x21,
+				Ifindex:  0x22_23_24_25,
+			},
+		},
 	}
-	buf := bytes.NewBuffer(nil)
-	err := binary.Write(buf, byteorder.Native, input)
-	require.NoError(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			if err := binary.Write(buf, byteorder.Native, tc.input); err != nil {
+				t.Fatalf("Unexpected error from Write(...); got: %v", err)
+			}
 
-	output := &DropNotify{}
-	err = DecodeDropNotify(buf.Bytes(), output)
-	require.NoError(t, err)
+			output := DropNotifyV1{}
+			if err := output.Decode(buf.Bytes()); err != nil {
+				t.Fatalf("Unexpected error from Decode(<bytes>); got: %v", err)
+			}
 
-	require.Equal(t, input.Type, output.Type)
-	require.Equal(t, input.SubType, output.SubType)
-	require.Equal(t, input.Source, output.Source)
-	require.Equal(t, input.Hash, output.Hash)
-	require.Equal(t, input.OrigLen, output.OrigLen)
-	require.Equal(t, input.CapLen, output.CapLen)
-	require.Equal(t, input.SrcLabel, output.SrcLabel)
-	require.Equal(t, input.DstLabel, output.DstLabel)
-	require.Equal(t, input.DstID, output.DstID)
-	require.Equal(t, input.Line, output.Line)
-	require.Equal(t, input.File, output.File)
-	require.Equal(t, input.ExtError, output.ExtError)
-	require.Equal(t, input.Ifindex, output.Ifindex)
+			if diff := cmp.Diff(tc.input, output); diff != "" {
+				t.Errorf("Unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
 }
 
-func BenchmarkNewDecodeDropNotify(b *testing.B) {
-	input := DropNotify{}
+func TestDropNotify_Decode(t *testing.T) {
+	// This check on the struct length constant is there to ensure that this
+	// test is updated when the struct changes.
+	require.Equal(t, 48, DropNotifyV2Len)
+
+	testCases := []struct {
+		name  string
+		input DropNotify
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "arbitrary",
+			input: DropNotify{
+				IPTraceID: 0x99,
+				DropNotifyV1: DropNotifyV1{
+					Type:     0x00,
+					SubType:  0x01,
+					Source:   0x02_03,
+					Hash:     0x04_05_06_07,
+					OrigLen:  0x08_09_0a_0b,
+					CapLen:   0x0e_10,
+					Version:  0x00_02,
+					SrcLabel: 0x11_12_13_14,
+					DstLabel: 0x15_16_17_18,
+					DstID:    0x19_1a_1b_1c,
+					Line:     0x1d_1e,
+					File:     0x20,
+					ExtError: 0x21,
+					Ifindex:  0x22_23_24_25,
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			if err := binary.Write(buf, byteorder.Native, tc.input); err != nil {
+				t.Fatalf("Unexpected error from Write(...); got: %v", err)
+			}
+
+			output := DropNotify{}
+			if err := output.Decode(buf.Bytes()); err != nil {
+				t.Fatalf("Unexpected error from Decode(<bytes>); got: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.input, output); diff != "" {
+				t.Errorf("Unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDecodeDropNotify(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input any
+		want  uint
+	}{
+		{
+			name: "v1",
+			input: DropNotifyV1{
+				Type:     0x00,
+				SubType:  0x01,
+				Source:   0x02_03,
+				Hash:     0x04_05_06_07,
+				OrigLen:  0x08_09_0a_0b,
+				CapLen:   0x0e_10,
+				Version:  0x00_01,
+				SrcLabel: 0x11_12_13_14,
+				DstLabel: 0x15_16_17_18,
+				DstID:    0x19_1a_1b_1c,
+				Line:     0x1d_1e,
+				File:     0x20,
+				ExtError: 0x21,
+				Ifindex:  0x22_23_24_25,
+			},
+			want: DropNotifyV1Len,
+		},
+		{
+			name: "v2",
+			input: DropNotifyV2{
+				DropNotifyV1: DropNotifyV1{
+					Type:     0x00,
+					SubType:  0x01,
+					Source:   0x02_03,
+					Hash:     0x04_05_06_07,
+					OrigLen:  0x08_09_0a_0b,
+					CapLen:   0x0e_10,
+					Version:  0x00_02,
+					SrcLabel: 0x11_12_13_14,
+					DstLabel: 0x15_16_17_18,
+					DstID:    0x19_1a_1b_1c,
+					Line:     0x1d_1e,
+					File:     0x20,
+					ExtError: 0x21,
+					Ifindex:  0x22_23_24_25,
+				},
+			},
+			want: DropNotifyV2Len,
+		},
+		{
+			name: "with_iptrace",
+			input: DropNotifyV2{
+				DropNotifyV1: DropNotifyV1{
+					Type:     0x00,
+					SubType:  0x01,
+					Source:   0x02_03,
+					Hash:     0x04_05_06_07,
+					OrigLen:  0x08_09_0a_0b,
+					CapLen:   0x0e_10,
+					Version:  0x00_02,
+					SrcLabel: 0x11_12_13_14,
+					DstLabel: 0x15_16_17_18,
+					DstID:    0x19_1a_1b_1c,
+					Line:     0x1d_1e,
+					File:     0x20,
+					ExtError: 0x21,
+					Ifindex:  0x22_23_24_25,
+				},
+				IPTraceID: 0x999,
+			},
+			want: DropNotifyV2Len,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			if err := binary.Write(buf, byteorder.Native, tc.input); err != nil {
+				t.Fatalf("Unexpected error from Write(...); got: %v", err)
+			}
+
+			output := DropNotify{}
+			if err := DecodeDropNotify(buf.Bytes(), &output); err != nil {
+				t.Fatalf("Unexpected error from Decode(<bytes>); got: %v", err)
+			}
+
+			if got := output.DataOffset(); got != tc.want {
+				t.Fatalf("Unexpected DataOffset(); want %d, got %d", tc.want, got)
+			}
+		})
+	}
+}
+
+func BenchmarkNewDropNotifyV1_Decode(b *testing.B) {
+	input := DropNotifyV1{}
 	buf := bytes.NewBuffer(nil)
 
 	if err := binary.Write(buf, byteorder.Native, input); err != nil {
@@ -69,15 +222,15 @@ func BenchmarkNewDecodeDropNotify(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		dn := &DropNotify{}
-		if err := DecodeDropNotify(buf.Bytes(), dn); err != nil {
+		dn := &DropNotifyV1{}
+		if err := dn.Decode(buf.Bytes()); err != nil {
 			b.Fatal(err)
 		}
 	}
 }
 
-func BenchmarkOldDecodeDropNotify(b *testing.B) {
-	input := DropNotify{}
+func BenchmarkOldDropNotifyV1_Decode(b *testing.B) {
+	input := DropNotifyV1{}
 	buf := bytes.NewBuffer(nil)
 
 	if err := binary.Write(buf, byteorder.Native, input); err != nil {
@@ -88,7 +241,7 @@ func BenchmarkOldDecodeDropNotify(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		dn := &DropNotify{}
+		dn := &DropNotifyV1{}
 		if err := binary.Read(bytes.NewReader(buf.Bytes()), byteorder.Native, dn); err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1144,6 +1144,9 @@ const (
 
 	// ConnectivityProbeFrequencyRatio is the name of the option to specify the connectivity probe frequency
 	ConnectivityProbeFrequencyRatio = "connectivity-probe-frequency-ratio"
+
+	// IPTracingOptionType specifies what IPv4 option type should be used to extract trace information from a packet
+	IPTracingOptionType = "ip-tracing-option-type"
 )
 
 // Default string arguments
@@ -2241,6 +2244,9 @@ type DaemonConfig struct {
 
 	// ConnectivityProbeFrequencyRatio is the ratio of the connectivity probe frequency vs resource consumption
 	ConnectivityProbeFrequencyRatio float64
+
+	// IPTracingOptionType determines whether to enable IP tracing, and if enabled what option type to use.
+	IPTracingOptionType uint
 }
 
 var (
@@ -2307,6 +2313,8 @@ var (
 		EnableSourceIPVerification: defaults.EnableSourceIPVerification,
 
 		ConnectivityProbeFrequencyRatio: defaults.ConnectivityProbeFrequencyRatio,
+
+		IPTracingOptionType: defaults.IPTracingOptionType,
 	}
 )
 
@@ -2968,6 +2976,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableIPSecEncryptedOverlay = vp.GetBool(EnableIPSecEncryptedOverlay)
 	c.LBSourceRangeAllTypes = vp.GetBool(LBSourceRangeAllTypes)
 	c.BootIDFile = vp.GetString(BootIDFilename)
+	c.IPTracingOptionType = vp.GetUint(IPTracingOptionType)
 
 	c.ServiceNoBackendResponse = vp.GetString(ServiceNoBackendResponse)
 	switch c.ServiceNoBackendResponse {


### PR DESCRIPTION
Related: https://github.com/cilium/cilium/issues/35057

This PR includes the initial IP packet tracing implementation (https://github.com/cilium/cilium/issues/35057), including:

- Add trace ID to drop notify structs
- Add trace ID to trace notify structs

This PR is a subset of https://github.com/cilium/cilium/pull/36825 to reduce the number of reviewers.

```release-note
Update notify structs to include trace ID
```