### PR TITLE
cilium-cli: Allow running outside the Cilium tree

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -95,9 +95,14 @@ func RunE(hooks api.Hooks) func(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		owners, err := owners_util.Load(params.CodeOwners)
-		if err != nil {
-			return fmt.Errorf("❗ Failed to load code owners: %w", err)
+		var owners codeowners.Ruleset
+		if params.LogCodeOwners {
+			var err error
+
+			owners, err = owners_util.Load(params.CodeOwners)
+			if err != nil {
+				return fmt.Errorf("❗ Failed to load code owners: %w", err)
+			}
 		}
 
 		logger := check.NewConcurrentLogger(params.Writer, params.TestConcurrency)


### PR DESCRIPTION
The last change in this area baked in a hard expectation that the CLI is
run inside the Cilium tree, but this doesn't make sense. Relax it so the
code owners are only loaded when --log-code-owners is passed on the
command line.

Fixes: a7f4ba11026c ("cli: Load code owners dynamically via --code-owners")
Reported-by: @giorio94
