### PR TITLE
.github: Don't mark 'help-wanted' issues as stale

### DIFF
--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -20,7 +20,7 @@ jobs:
         operations-per-run: 1000
         stale-issue-label: stale
         exempt-all-issue-assignees: true
-        exempt-issue-labels: pinned,security,good-first-issue
+        exempt-issue-labels: pinned,security,good-first-issue,help-wanted
 
         days-before-issue-stale: 60
         stale-issue-message: |
@@ -32,7 +32,7 @@ jobs:
           Closing.
 
         stale-pr-label: stale
-        exempt-pr-labels: pinned,security,good-first-issue
+        exempt-pr-labels: pinned,security,good-first-issue,help-wanted
 
         days-before-pr-stale: 30
         stale-pr-message: |


### PR DESCRIPTION
We sometimes use the 'help-wanted' label to indicate issues that are not a
'good-first-issue' but are a candidate for someone in the community to
contribute or develop their experience in an area of the codebase. To
help contributors to find these issues, don't close them automatically.
