### PR TITLE
policy: Fix Endpoint Selector Policy Deadlock

### DIFF
--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1830,7 +1830,7 @@ func (l4 *L4Policy) detach(selectorCache *SelectorCache, isDelete bool, endpoint
 	if !isDelete {
 		for ePolicy := range l4.users {
 			if endpointID != ePolicy.PolicyOwner.GetID() {
-				ePolicy.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
+				go ePolicy.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
 					Reason:            "selector policy has changed because of another endpoint with the same identity",
 					RegenerationLevel: regeneration.RegenerateWithoutDatapath,
 				})


### PR DESCRIPTION
The selectorPolicy, when replaced, triggers
endpoint regeneration for any other endpoints that use it. 
If an endpoint undergoes deletion simultaneously, the 
endpoint lock, in concert with the selectorPolicy lock, 
can create a deadlock. To prevent this, the selectorPolicy 
can regenerate the endpoints via a go routine, so
 that the selectorPolicy is guaranteed to unlock after 
triggering regeneration.

Fixes: 12565044f0b7 ("endpoint: Trigger Regeneration on SelectorPolicy Update")
Fixes: #37910
Fixes: #38056

