### PR TITLE
[backport] gateway-api: Fix handling multiple independent parentRefs

### DIFF
--- a/operator/pkg/gateway-api/grpcroute_reconcile.go
+++ b/operator/pkg/gateway-api/grpcroute_reconcile.go
@@ -84,7 +84,7 @@ func (r *grpcRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		})
 
 		// run the actual validators
-		for _, fn := range []routechecks.CheckParentFunc{
+		for _, fn := range []routechecks.CheckWithParentFunc{
 			routechecks.CheckGatewayRouteKindAllowed,
 			routechecks.CheckGatewayMatchingPorts,
 			routechecks.CheckGatewayMatchingHostnames,
@@ -100,16 +100,16 @@ func (r *grpcRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				break
 			}
 		}
-	}
 
-	for _, fn := range []routechecks.CheckRuleFunc{
-		routechecks.CheckAgainstCrossNamespaceBackendReferences,
-		routechecks.CheckBackend,
-		routechecks.CheckHasServiceImportSupport,
-		routechecks.CheckBackendIsExistingService,
-	} {
-		if continueCheck, err := fn(i); err != nil || !continueCheck {
-			return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to apply Backend check: %w", err), original, gr)
+		for _, fn := range []routechecks.CheckWithParentFunc{
+			routechecks.CheckAgainstCrossNamespaceBackendReferences,
+			routechecks.CheckBackend,
+			routechecks.CheckHasServiceImportSupport,
+			routechecks.CheckBackendIsExistingService,
+		} {
+			if continueCheck, err := fn(i, parent); err != nil || !continueCheck {
+				return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to apply Backend check: %w", err), gr, original)
+			}
 		}
 	}
 

--- a/operator/pkg/gateway-api/httproute_gamma_reconcile.go
+++ b/operator/pkg/gateway-api/httproute_gamma_reconcile.go
@@ -13,11 +13,13 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	controllerruntime "github.com/cilium/cilium/operator/pkg/controller-runtime"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/routechecks"
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/operator/pkg/model/ingestion"
@@ -78,6 +80,14 @@ func (r *gammaHttpRouteReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// gateway validators
 	for _, parent := range hr.Spec.ParentRefs {
 
+		if !helpers.IsGammaService(parent) {
+			scopedLog.Debug("Non GAMMA parentRef in GAMMA HTTPRoute reconciliation",
+				logfields.Controller, "gammaHttpRoute",
+				logfields.Resource, client.ObjectKeyFromObject(hr),
+			)
+			continue
+		}
+
 		// set acceptance to okay, this wil be overwritten in checks if needed
 		i.SetParentCondition(parent, metav1.Condition{
 			Type:    string(gatewayv1.RouteConditionAccepted),
@@ -87,40 +97,41 @@ func (r *gammaHttpRouteReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		})
 
 		// set status to okay, this wil be overwritten in checks if needed
-		i.SetAllParentCondition(metav1.Condition{
+		i.SetParentCondition(parent, metav1.Condition{
 			Type:    string(gatewayv1.RouteConditionResolvedRefs),
 			Status:  metav1.ConditionTrue,
 			Reason:  string(gatewayv1.RouteReasonResolvedRefs),
 			Message: "Service reference is valid",
 		})
 
-		for _, fn := range []routechecks.CheckParentFunc{
+		for _, fn := range []routechecks.CheckWithParentFunc{
 			routechecks.CheckGammaServiceAllowedForNamespace,
 		} {
 			continueCheck, err := fn(i, parent)
 			if err != nil {
-				return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to apply Gateway check: %w", err), original, hr)
+				return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to apply parentRef check: %w", err), original, hr)
 			}
 
 			if !continueCheck {
 				break
 			}
 		}
-	}
 
-	for _, fn := range []routechecks.CheckRuleFunc{
-		routechecks.CheckAgainstCrossNamespaceBackendReferences,
-		routechecks.CheckBackend,
-		routechecks.CheckBackendIsExistingService,
-	} {
-		continueCheck, err := fn(i)
-		if err != nil {
-			return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to apply Backend check: %w", err), original, hr)
+		for _, fn := range []routechecks.CheckWithParentFunc{
+			routechecks.CheckAgainstCrossNamespaceBackendReferences,
+			routechecks.CheckBackend,
+			routechecks.CheckBackendIsExistingService,
+		} {
+			continueCheck, err := fn(i, parent)
+			if err != nil {
+				return r.handleReconcileErrorWithStatus(ctx, fmt.Errorf("failed to apply route rule check: %w", err), original, hr)
+			}
+
+			if !continueCheck {
+				break
+			}
 		}
 
-		if !continueCheck {
-			break
-		}
 	}
 
 	if err := r.updateStatus(ctx, original, hr); err != nil {

--- a/operator/pkg/gateway-api/httproute_reconcile_test.go
+++ b/operator/pkg/gateway-api/httproute_reconcile_test.go
@@ -27,6 +27,10 @@ import (
 var (
 	httpRFFinalizer = "batch.gateway.io/finalizer"
 
+	// Used for GAMMA parentRef checks
+	serviceKind = (gatewayv1.Kind)("Service")
+	coreGroup   = (gatewayv1.Group)("")
+
 	crdsFixture = []client.Object{
 		// Minimal ServiceImport CRD for existence checking
 		&apiextensionsv1.CustomResourceDefinition{
@@ -103,6 +107,15 @@ var (
 				ControllerName: "io.cilium/gateway-controller",
 			},
 		},
+		// Non-Matching GatewayClass
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "someotherimplementation",
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "someothergateway.io/implementation",
+			},
+		},
 
 		// Gateway for valid HTTPRoute
 		&gatewayv1.Gateway{
@@ -112,6 +125,25 @@ var (
 			},
 			Spec: gatewayv1.GatewaySpec{
 				GatewayClassName: "cilium",
+				Listeners: []gatewayv1.Listener{
+					{
+						Name:     "http",
+						Port:     80,
+						Hostname: ptr.To[gatewayv1.Hostname]("*.cilium.io"),
+					},
+				},
+			},
+			Status: gatewayv1.GatewayStatus{},
+		},
+
+		// Gateway that rolls up to a different GatewayClass
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "other-implementation-gateway",
+				Namespace: "default",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "someotherimplementation",
 				Listeners: []gatewayv1.Listener{
 					{
 						Name:     "http",
@@ -196,6 +228,7 @@ var (
 			},
 			Status: gatewayv1.GatewayStatus{},
 		},
+
 		// Service for valid HTTPRoute
 		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -911,6 +944,137 @@ var (
 				},
 			},
 		},
+
+		// InvalidHTTPRoute, no Gateway ParentRef, should not be processed at all
+		&gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gamma-parentref-only",
+				Namespace: "default",
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Name:  "dummy-backend",
+							Kind:  &serviceKind,
+							Group: &coreGroup,
+						},
+					},
+				},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "dummy-backend",
+										Port: ptr.To[gatewayv1.PortNumber](8080),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		// ValidHTTPRoute, one Gateway ParentRef, one GAMMA, only Gateway should be processed
+		&gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "both-parentrefs",
+				Namespace: "default",
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Name:  "dummy-backend",
+							Kind:  &serviceKind,
+							Group: &coreGroup,
+						},
+						{
+							Name: "dummy-gateway",
+						},
+					},
+				},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "dummy-backend",
+										Port: ptr.To[gatewayv1.PortNumber](8080),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		// ValidHTTPRoute, belongs to another implementation
+		&gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "otherimpl-parentref",
+				Namespace: "default",
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Name: "other-implementation-gateway",
+						},
+					},
+				},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "dummy-backend",
+										Port: ptr.To[gatewayv1.PortNumber](8080),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		// ValidHTTPRoute, one Cilium Gateway ParentRef, one other impl, only Cilium Gateway should be processed
+		&gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "oneofeach-gateway-parentrefs",
+				Namespace: "default",
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Name: "dummy-gateway",
+						},
+						{
+							Name: "other-implementation-gateway",
+						},
+					},
+				},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "dummy-backend",
+										Port: ptr.To[gatewayv1.PortNumber](8080),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 )
 
@@ -1074,6 +1238,44 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 			NamespacedName: key,
 		})
 
+		require.Error(t, err, "Expecting Reconciliation error")
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		route := &gatewayv1.HTTPRoute{}
+		err = c.Get(context.Background(), key, route)
+
+		require.NoError(t, err)
+		require.Empty(t, route.Status.RouteStatus.Parents, "Should have 0 parents")
+	})
+
+	t.Run("http route with only GAMMA parentRef", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "gamma-parentref-only",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.Error(t, err, "Expecting Reconciliation error")
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		route := &gatewayv1.HTTPRoute{}
+		err = c.Get(context.Background(), key, route)
+
+		require.NoError(t, err)
+		require.Empty(t, route.Status.RouteStatus.Parents, "Should have 0 parents")
+	})
+
+	t.Run("valid http route with another GAMMA parentRef", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "both-parentrefs",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
 		require.NoError(t, err, "Error reconciling httpRoute")
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
@@ -1085,8 +1287,52 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 		require.Len(t, route.Status.RouteStatus.Parents[0].Conditions, 2)
 
 		require.Equal(t, "Accepted", route.Status.RouteStatus.Parents[0].Conditions[0].Type)
-		require.Equal(t, metav1.ConditionStatus("False"), route.Status.RouteStatus.Parents[0].Conditions[0].Status)
-		require.Equal(t, "InvalidHTTPRoute", route.Status.RouteStatus.Parents[0].Conditions[0].Reason)
+		require.Equal(t, metav1.ConditionStatus("True"), route.Status.RouteStatus.Parents[0].Conditions[0].Status)
+
+		require.Equal(t, "ResolvedRefs", route.Status.RouteStatus.Parents[0].Conditions[1].Type)
+		require.Equal(t, metav1.ConditionStatus("True"), route.Status.RouteStatus.Parents[0].Conditions[1].Status)
+	})
+
+	t.Run("valid http route that belongs to another implementation", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "otherimpl-parentref",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.Error(t, err, "Expecting Reconciliation error")
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		route := &gatewayv1.HTTPRoute{}
+		err = c.Get(context.Background(), key, route)
+
+		require.NoError(t, err)
+		require.Empty(t, route.Status.RouteStatus.Parents, "Should have 0 parents")
+	})
+
+	t.Run("valid http route with another implementation parentRef as well", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "oneofeach-gateway-parentrefs",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err, "Error reconciling httpRoute")
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		route := &gatewayv1.HTTPRoute{}
+		err = c.Get(context.Background(), key, route)
+
+		require.NoError(t, err)
+		require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
+		require.Len(t, route.Status.RouteStatus.Parents[0].Conditions, 2)
+
+		require.Equal(t, "Accepted", route.Status.RouteStatus.Parents[0].Conditions[0].Type)
+		require.Equal(t, metav1.ConditionStatus("True"), route.Status.RouteStatus.Parents[0].Conditions[0].Status)
 
 		require.Equal(t, "ResolvedRefs", route.Status.RouteStatus.Parents[0].Conditions[1].Type)
 		require.Equal(t, metav1.ConditionStatus("True"), route.Status.RouteStatus.Parents[0].Conditions[1].Status)

--- a/operator/pkg/gateway-api/routechecks/input.go
+++ b/operator/pkg/gateway-api/routechecks/input.go
@@ -36,11 +36,9 @@ type Input interface {
 	GetHostnames() []gatewayv1.Hostname
 
 	SetParentCondition(ref gatewayv1.ParentReference, condition metav1.Condition)
-	SetAllParentCondition(condition metav1.Condition)
 	Log() *slog.Logger
 }
 
 type (
-	CheckRuleFunc   func(input Input) (bool, error)
-	CheckParentFunc func(input Input, ref gatewayv1.ParentReference) (bool, error)
+	CheckWithParentFunc func(input Input, ref gatewayv1.ParentReference) (bool, error)
 )

--- a/operator/pkg/model/ingestion/gamma_test.go
+++ b/operator/pkg/model/ingestion/gamma_test.go
@@ -17,11 +17,11 @@ const (
 )
 
 func TestGammaConformance(t *testing.T) {
-	tests := map[string]struct {
-	}{
-		"Mesh Split":    {},
-		"Mesh Ports":    {},
-		"Mesh Frontend": {},
+	tests := map[string]struct{}{
+		"Mesh Split":          {},
+		"Mesh Ports":          {},
+		"Mesh Frontend":       {},
+		"multiple_parentRefs": {},
 	}
 
 	for name := range tests {

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -30,7 +30,11 @@ func KindPtr(name string) *gatewayv1.Kind {
 
 func TestHTTPGatewayAPI(t *testing.T) {
 	tests := map[string]struct{}{
-		"basic http": {},
+		"basic http":                                             {},
+		"basic http nodeport service":                            {},
+		"basic http external traffic policy":                     {},
+		"basic http load balancer":                               {},
+		"multiple parentRefs":                                    {},
 		"Conformance/HTTPRouteSimpleSameNamespace":               {},
 		"Conformance/HTTPRouteCrossNamespace":                    {},
 		"Conformance/HTTPExactPathMatching":                      {},
@@ -65,8 +69,7 @@ func TestHTTPGatewayAPI(t *testing.T) {
 }
 
 func TestTLSGatewayAPI(t *testing.T) {
-	tests := map[string]struct {
-	}{
+	tests := map[string]struct{}{
 		"basic tls http": {},
 		"Conformance/TLSRouteSimpleSameNamespace": {},
 	}
@@ -84,8 +87,7 @@ func TestTLSGatewayAPI(t *testing.T) {
 }
 
 func TestGRPCGatewayAPI(t *testing.T) {
-	tests := map[string]struct {
-	}{
+	tests := map[string]struct{}{
 		"basic grpc": {},
 	}
 

--- a/operator/pkg/model/ingestion/testdata/gamma/multiple_parentRefs/input-httproute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gamma/multiple_parentRefs/input-httproute.yaml
@@ -1,0 +1,27 @@
+- metadata:
+    creationTimestamp: null
+    name: mesh-multipleParentRefs
+    namespace: gateway-conformance-mesh
+  spec:
+    parentRefs:
+    - group: ""
+      kind: Service
+      name: echo
+    - name: someGateway
+    rules:
+    - backendRefs:
+      - name: echo-v1
+        port: 80
+      matches:
+      - path:
+          type: Exact
+          value: /v1
+    - backendRefs:
+      - name: echo-v2
+        port: 80
+      matches:
+      - path:
+          type: Exact
+          value: /v2
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gamma/multiple_parentRefs/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gamma/multiple_parentRefs/input-service.yaml
@@ -1,0 +1,86 @@
+- metadata:
+    creationTimestamp: null
+    name: echo
+    namespace: gateway-conformance-mesh
+  spec:
+    ports:
+    - appProtocol: http
+      name: http
+      port: 80
+      targetPort: 8080
+    - appProtocol: http
+      name: http-alt
+      port: 8080
+      targetPort: 0
+    - name: https
+      port: 443
+      targetPort: 8443
+    - name: tcp
+      port: 9090
+      targetPort: 0
+    - appProtocol: grpc
+      name: grpc
+      port: 7070
+      targetPort: 0
+    selector:
+      app: echo
+  status:
+    loadBalancer: {}
+- metadata:
+    creationTimestamp: null
+    name: echo-v1
+    namespace: gateway-conformance-mesh
+  spec:
+    ports:
+    - appProtocol: http
+      name: http
+      port: 80
+      targetPort: 8080
+    - appProtocol: http
+      name: http-alt
+      port: 8080
+      targetPort: 0
+    - name: https
+      port: 443
+      targetPort: 8443
+    - name: tcp
+      port: 9090
+      targetPort: 0
+    - appProtocol: grpc
+      name: grpc
+      port: 7070
+      targetPort: 0
+    selector:
+      app: echo
+      version: v1
+  status:
+    loadBalancer: {}
+- metadata:
+    creationTimestamp: null
+    name: echo-v2
+    namespace: gateway-conformance-mesh
+  spec:
+    ports:
+    - appProtocol: http
+      name: http
+      port: 80
+      targetPort: 8080
+    - appProtocol: http
+      name: http-alt
+      port: 8080
+      targetPort: 0
+    - name: https
+      port: 443
+      targetPort: 8443
+    - name: tcp
+      port: 9090
+      targetPort: 0
+    - appProtocol: grpc
+      name: grpc
+      port: 7070
+      targetPort: 0
+    selector:
+      app: echo
+      version: v2
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gamma/multiple_parentRefs/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gamma/multiple_parentRefs/output-listeners.yaml
@@ -1,0 +1,76 @@
+- hostname: '*'
+  name: gateway-conformance-mesh-echo-80
+  port: 80
+  routes:
+  - backends:
+    - app_protocol: http
+      name: echo-v1
+      namespace: gateway-conformance-mesh
+      port:
+        port: 80
+    hostnames:
+    - '*'
+    path_match:
+      exact: /v1
+    timeout: {}
+  - backends:
+    - app_protocol: http
+      name: echo-v2
+      namespace: gateway-conformance-mesh
+      port:
+        port: 80
+    hostnames:
+    - '*'
+    path_match:
+      exact: /v2
+    timeout: {}
+  service:
+    type: ClusterIP
+  sources:
+  - kind: Service
+    name: echo
+    namespace: gateway-conformance-mesh
+    version: v1
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: mesh-multipleParentRefs
+    namespace: gateway-conformance-mesh
+    version: v1
+- hostname: '*'
+  name: gateway-conformance-mesh-echo-8080
+  port: 8080
+  routes:
+  - backends:
+    - app_protocol: http
+      name: echo-v1
+      namespace: gateway-conformance-mesh
+      port:
+        port: 80
+    hostnames:
+    - '*'
+    path_match:
+      exact: /v1
+    timeout: {}
+  - backends:
+    - app_protocol: http
+      name: echo-v2
+      namespace: gateway-conformance-mesh
+      port:
+        port: 80
+    hostnames:
+    - '*'
+    path_match:
+      exact: /v2
+    timeout: {}
+  service:
+    type: ClusterIP
+  sources:
+  - kind: Service
+    name: echo
+    namespace: gateway-conformance-mesh
+    version: v1
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: mesh-multipleParentRefs
+    namespace: gateway-conformance-mesh
+    version: v1

--- a/operator/pkg/model/ingestion/testdata/gateway/multiple_parentRefs/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/multiple_parentRefs/input-gateway.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: ""
+  infrastructure:
+    annotations:
+      internal-loadbalancer-annotation: "true"
+    labels:
+      internal-loadbalancer-label: "true"
+  listeners:
+  - name: prod-web-gw
+    port: 80
+    protocol: HTTP
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/multiple_parentRefs/input-gatewayclass.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/multiple_parentRefs/input-gatewayclass.yaml
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec:
+  controllerName: ""
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/multiple_parentRefs/input-gatewayclassconfig.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/multiple_parentRefs/input-gatewayclassconfig.yaml
@@ -1,0 +1,7 @@
+kind: CiliumGatewayClassConfig
+metadata:
+  name: cilium-gateway-config
+  namespace: default
+spec:
+  service:
+    type: LoadBalancer

--- a/operator/pkg/model/ingestion/testdata/gateway/multiple_parentRefs/input-httproute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/multiple_parentRefs/input-httproute.yaml
@@ -1,0 +1,24 @@
+- metadata:
+    creationTimestamp: null
+    name: http-app-1
+    namespace: default
+  spec:
+    parentRefs:
+    - name: my-gateway
+    - group: ""
+      kind: Service
+      name: echo    
+    rules:
+    - backendRefs:
+      - name: my-service
+        port: 8080
+      - group: multicluster.x-k8s.io
+        kind: ServiceImport
+        name: my-service
+        port: 8080
+      matches:
+      - path:
+          type: PathPrefix
+          value: /bar
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/multiple_parentRefs/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/multiple_parentRefs/input-service.yaml
@@ -1,0 +1,7 @@
+- metadata:
+    creationTimestamp: null
+    name: my-service
+    namespace: default
+  spec: {}
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/multiple_parentRefs/input-serviceimport.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/multiple_parentRefs/input-serviceimport.yaml
@@ -1,0 +1,10 @@
+- metadata:
+    annotations:
+      multicluster.kubernetes.io/derived-service: my-service
+    creationTimestamp: null
+    name: my-service
+    namespace: default
+  spec:
+    ports: null
+    type: ""
+  status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/multiple_parentRefs/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/multiple_parentRefs/output-listeners.yaml
@@ -1,0 +1,30 @@
+- hostname: '*'
+  infrastructure:
+    Annotations:
+      internal-loadbalancer-annotation: "true"
+    Labels:
+      internal-loadbalancer-label: "true"
+  name: prod-web-gw
+  port: 80
+  routes:
+  - backends:
+    - name: my-service
+      namespace: default
+      port:
+        port: 8080
+    - name: my-service
+      namespace: default
+      port:
+        port: 8080
+    path_match:
+      prefix: /bar
+    timeout: {}
+  service:
+    type: LoadBalancer
+    load_balancer_source_ranges_policy: Allow
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: my-gateway
+    namespace: default
+    version: v1


### PR DESCRIPTION
This commit fixes a subtle bug with Gateway API processing, where a HTTPRoute, GRPCRoute, or TLSRoute with multiple parentRefs set would have status updated for _all_ parentRefs, and would not handle a HTTPRoute with _both_ Gateway and Service (GAMMA) parentRefs correctly.

Important changes:
- removed the SetAllParentsCondition() function from the Input interface in `operator/pkg/gateway-api/routechecks`, and moved all calls to it to call SetParentCondition per-parentRef instead
- added checks to the GAMMA reconciler to ensure that only GAMMA parents are handled (in `operator/pkg/gateway-api`)
- added checks to the HTTPRoute, GRPCRoute, and TLSRoute reconcilers to ensure that both GAMMA parentRefs and parentRefs that roll up to other implementations will be skipped processing and have no status updates applied
- added tests to cover most of the above (GRPCRoute and TLSRoute reconcilers currently do not have tests, will leave adding them to a follow-up PR)

```release-note
Updated Gateway API and GAMMA processing to remove incorrect behavior when both parentRefs were present.
```
