### PR TITLE
Use more efficient `SplitSeq` instead of `Split`

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -330,7 +330,7 @@ func routeCommands() []string {
 	commands := []string{}
 	routes, _ := execCommand("ip route show table all | grep -E --only-matching 'table [0-9]+'")
 
-	for _, r := range bytes.Split(bytes.TrimSuffix(routes, []byte("\n")), []byte("\n")) {
+	for r := range bytes.SplitSeq(bytes.TrimSuffix(routes, []byte("\n")), []byte("\n")) {
 		routeTablev4 := fmt.Sprintf("ip -4 route show %s", r)
 		routeTablev6 := fmt.Sprintf("ip -6 route show %s", r)
 		commands = append(commands, routeTablev4, routeTablev6)

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -274,7 +274,7 @@ func (n *noErrorsInLogs) podContainers(pod *corev1.Pod) podContainers {
 
 func (n *noErrorsInLogs) findUniqueFailures(logs []byte) map[string]int {
 	uniqueFailures := make(map[string]int)
-	for _, chunk := range bytes.Split(logs, []byte("\n")) {
+	for chunk := range bytes.SplitSeq(logs, []byte("\n")) {
 		msg := string(chunk)
 		for fail, ignoreMsgs := range n.errorMsgsWithExceptions {
 			if strings.Contains(msg, fail) {

--- a/cilium-cli/connectivity/tests/health.go
+++ b/cilium-cli/connectivity/tests/health.go
@@ -137,8 +137,7 @@ func filterJSON(data any, filter string) (string, error) {
 
 func parseKVPairs(s string) map[string]string {
 	result := make(map[string]string)
-	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
-	for _, line := range lines {
+	for line := range strings.SplitSeq(strings.TrimRight(s, "\n"), "\n") {
 		vals := strings.Split(line, "=")
 		if len(vals) == 2 {
 			result[vals[0]] = vals[1]

--- a/cilium-cli/encrypt/status.go
+++ b/cilium-cli/encrypt/status.go
@@ -154,8 +154,7 @@ func nodeStatusFromText(str string) (models.EncryptionStatus, error) {
 			Interfaces: make([]*models.WireguardInterface, 0),
 		},
 	}
-	lines := strings.Split(str, "\n")
-	for _, line := range lines {
+	for line := range strings.SplitSeq(str, "\n") {
 		parts := strings.Split(line, ":")
 		if len(parts) < 2 {
 			continue

--- a/cilium-cli/status/k8s.go
+++ b/cilium-cli/status/k8s.go
@@ -412,7 +412,7 @@ func countWrappedLines(text string) int {
 		width = 80 // default width if we can't get the terminal size
 	}
 	lines := 1
-	for _, line := range strings.Split(text, "\n") {
+	for line := range strings.SplitSeq(text, "\n") {
 		lines += (utf8.RuneCountInString(line) + width - 1) / width
 	}
 	return lines

--- a/cilium-cli/status/status.go
+++ b/cilium-cli/status/status.go
@@ -437,7 +437,7 @@ func (s *Status) Format() string {
 
 	header = "Configuration:"
 	for _, msg := range s.ConfigErrors {
-		for _, line := range strings.Split(msg, "\n") {
+		for line := range strings.SplitSeq(msg, "\n") {
 			fmt.Fprintf(w, "%s\t \t%s\n", header, line)
 			header = ""
 		}

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -2510,8 +2510,7 @@ func (c *Collector) submitSpireEntriesTasks(pods []*corev1.Pod) error {
 }
 
 func extractGopsPID(output string) (string, error) {
-	entries := strings.Split(output, "\n")
-	for _, entry := range entries {
+	for entry := range strings.SplitSeq(output, "\n") {
 		match := gopsRegexp.FindStringSubmatch(entry)
 		if len(match) > 0 {
 			result := make(map[string]string)
@@ -2551,8 +2550,7 @@ func (c *Collector) SubmitCniConflistSubtask(pods []*corev1.Pod, containerName s
 			if err != nil {
 				return err
 			}
-			cniConfigFileNames := strings.Split(strings.TrimSpace(outputStr.String()), "\n")
-			for _, cniFileName := range cniConfigFileNames {
+			for cniFileName := range strings.SplitSeq(strings.TrimSpace(outputStr.String()), "\n") {
 				cniConfigPath := path.Join(c.Options.CNIConfigDirectory, cniFileName)
 				if err := c.WithFileSink(fmt.Sprintf(cniConfigFileName, cniFileName, p.GetName()), func(out io.Writer) error {
 					return c.Client.ExecInPodWithWriters(ctx, nil, p.GetNamespace(), p.GetName(), containerName, []string{

--- a/cilium-dbg/cmd/encrypt_status.go
+++ b/cilium-dbg/cmd/encrypt_status.go
@@ -154,8 +154,7 @@ func getXfrmStats(mountPoint string) (int64, map[string]int64, error) {
 
 func extractMaxSequenceNumber(ipOutput string) (int64, error) {
 	maxSeqNum := int64(0)
-	lines := strings.Split(ipOutput, "\n")
-	for _, line := range lines {
+	for line := range strings.SplitSeq(ipOutput, "\n") {
 		matched := regex.FindStringSubmatchIndex(line)
 		if matched != nil {
 			oseq, err := strconv.ParseInt(line[matched[2]:matched[3]], 16, 64)

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -518,7 +518,7 @@ func checkNodePortAndEphemeralPortRanges(sysctl sysctl.Sysctl) error {
 	if err != nil {
 		return fmt.Errorf("Unable to read net.ipv4.ip_local_reserved_ports: %w", err)
 	}
-	for _, portRange := range strings.Split(reservedPortsStr, ",") {
+	for portRange := range strings.SplitSeq(reservedPortsStr, ",") {
 		if portRange == "" {
 			break
 		}

--- a/hubble/cmd/common/config/compat.go
+++ b/hubble/cmd/common/config/compat.go
@@ -31,7 +31,7 @@ var Compat = compatFromEnv()
 func compatFromEnv() CompatOptions {
 	c := CompatOptions{}
 
-	for _, opt := range strings.Split(os.Getenv(compatEnvKey), ",") {
+	for opt := range strings.SplitSeq(os.Getenv(compatEnvKey), ",") {
 		switch strings.ToLower(opt) {
 		case compatLegacyJSONOutput:
 			c.LegacyJSONOutput = true

--- a/hubble/cmd/observe/flows_filter.go
+++ b/hubble/cmd/observe/flows_filter.go
@@ -273,8 +273,7 @@ func (t *filterTracker) checkNamespaceConflicts(ff *flowpb.FlowFilter) error {
 
 func parseTCPFlags(val string) (*flowpb.TCPFlags, error) {
 	flags := &flowpb.TCPFlags{}
-	s := strings.Split(val, ",")
-	for _, f := range s {
+	for f := range strings.SplitSeq(val, ",") {
 		switch strings.ToUpper(f) {
 		case "SYN":
 			flags.SYN = true

--- a/operator/pkg/bgpv2/cluster_test.go
+++ b/operator/pkg/bgpv2/cluster_test.go
@@ -1148,7 +1148,7 @@ func TestConflictingClusterConfigCondition(t *testing.T) {
 						return
 					}
 
-					for _, conflictingConfig := range strings.Split(string(match[1]), " ") {
+					for conflictingConfig := range strings.SplitSeq(string(match[1]), " ") {
 						relation := [2]string{config.Name, conflictingConfig}
 						conflictingRelations = append(conflictingRelations, relation)
 					}

--- a/operator/pkg/gateway-api/conformance_test.go
+++ b/operator/pkg/gateway-api/conformance_test.go
@@ -51,7 +51,7 @@ func TestConformance(t *testing.T) {
 		skipTests = append(skipTests, string(features.SupportGatewayStaticAddresses))
 	} else {
 		var addressType = v1.IPAddressType
-		for _, value := range strings.Split(usableAddresses, ",") {
+		for value := range strings.SplitSeq(usableAddresses, ",") {
 			usableNetworkAddresses = append(usableNetworkAddresses, v1.GatewaySpecAddress{
 				Type:  &addressType,
 				Value: value,
@@ -64,7 +64,7 @@ func TestConformance(t *testing.T) {
 		skipTests = append(skipTests, string(features.SupportGatewayStaticAddresses))
 	} else {
 		var addressType = v1.IPAddressType
-		for _, value := range strings.Split(unusableAddresses, ",") {
+		for value := range strings.SplitSeq(unusableAddresses, ",") {
 			unusableNetworkAddresses = append(unusableNetworkAddresses, v1.GatewaySpecAddress{
 				Type:  &addressType,
 				Value: value,

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -685,7 +685,7 @@ func getSVCRequestedIPs(log *slog.Logger, svc *slim_core_v1.Service) []netip.Add
 	}
 
 	if value, _ := annotation.Get(svc, annotation.LBIPAMIPsKey, annotation.LBIPAMIPKeyAlias); value != "" {
-		for _, ipStr := range strings.Split(value, ",") {
+		for ipStr := range strings.SplitSeq(value, ",") {
 			ip, err := netip.ParseAddr(strings.TrimSpace(ipStr))
 			if err == nil {
 				ips = append(ips, ip)

--- a/operator/pkg/model/translation/helper.go
+++ b/operator/pkg/model/translation/helper.go
@@ -22,7 +22,7 @@ func ParseNodeLabelSelector(nodeLabelSelectorString string) *slim_metav1.LabelSe
 	}
 
 	labels := map[string]string{}
-	for _, v := range strings.Split(nodeLabelSelectorString, ",") {
+	for v := range strings.SplitSeq(nodeLabelSelectorString, ",") {
 		s := strings.Split(v, "=")
 		if len(s) != 2 || len(s[0]) == 0 {
 			continue

--- a/operator/watchers/cilium_podippool.go
+++ b/operator/watchers/cilium_podippool.go
@@ -54,7 +54,7 @@ func parsePoolSpec(poolString string) (cilium_v2alpha1.IPPoolSpec, error) {
 		}
 		switch key {
 		case poolKeyIPv4CIDRs:
-			for _, cidr := range strings.Split(value, ",") {
+			for cidr := range strings.SplitSeq(value, ",") {
 				_, err := netip.ParsePrefix(cidr)
 				if err != nil {
 					return cilium_v2alpha1.IPPoolSpec{}, fmt.Errorf("invalid value for key %q: %w", poolKeyIPv4CIDRs, err)
@@ -68,7 +68,7 @@ func parsePoolSpec(poolString string) (cilium_v2alpha1.IPPoolSpec, error) {
 			}
 			ipv4MaskSize = uint8(mask)
 		case poolKeyIPv6CIDRs:
-			for _, cidr := range strings.Split(value, ",") {
+			for cidr := range strings.SplitSeq(value, ",") {
 				_, err := netip.ParsePrefix(cidr)
 				if err != nil {
 					return cilium_v2alpha1.IPPoolSpec{}, fmt.Errorf("invalid value for key %q: %w", poolKeyIPv6CIDRs, err)

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -38,9 +38,9 @@ func pascalize(in string) string {
 func pathToFlagSuffix(path string) string {
 	result := ""
 	path = strings.TrimPrefix(path, "/")
-	for _, hunk := range strings.Split(path, "/") {
+	for hunk := range strings.SplitSeq(path, "/") {
 		// TODO: Maybe we can just rename the /cgroup-dump-metadata API to /cgroups to avoid this loop?
-		for _, word := range strings.Split(hunk, "-") {
+		for word := range strings.SplitSeq(hunk, "-") {
 			trimmed := strings.Trim(word, "{}")
 			result = result + pascalize(trimmed)
 		}

--- a/pkg/cgroups/manager/provider.go
+++ b/pkg/cgroups/manager/provider.go
@@ -241,7 +241,7 @@ func expandSlice(slice string) (string, error) {
 	if sliceName == "-" {
 		return "/", nil
 	}
-	for _, component := range strings.Split(sliceName, "-") {
+	for component := range strings.SplitSeq(sliceName, "-") {
 		// test--a.slice isn't permitted, nor is -test.slice.
 		if component == "" {
 			return "", fmt.Errorf("invalid slice name: %s", slice)

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -22,8 +22,7 @@ func C2GoArray(str string) []byte {
 		return ret
 	}
 
-	hexStr := strings.Split(str, ", ")
-	for _, hexDigit := range hexStr {
+	for hexDigit := range strings.SplitSeq(str, ", ") {
 		strDigit := strings.TrimPrefix(hexDigit, "0x")
 		digitUint64, err := strconv.ParseUint(strDigit, 16, 8)
 		if err != nil {

--- a/pkg/datapath/iptables/ipset/ipset_test.go
+++ b/pkg/datapath/iptables/ipset/ipset_test.go
@@ -83,8 +83,7 @@ func TestManager(t *testing.T) {
 
 							var commands [][]string
 							if arg[0] == "restore" {
-								lines := strings.Split(stdin, "\n")
-								for _, line := range lines {
+								for line := range strings.SplitSeq(stdin, "\n") {
 									if len(line) > 0 {
 										commands = append(commands, strings.Split(line, " "))
 									}

--- a/pkg/hubble/metrics/api/api.go
+++ b/pkg/hubble/metrics/api/api.go
@@ -170,7 +170,7 @@ func ParseStaticMetricsConfig(enabledMetrics []string) (metricConfigs *Config) {
 func parseOptionConfigs(s string) (options []*ContextOptionConfig) {
 	options = []*ContextOptionConfig{}
 
-	for _, option := range strings.Split(s, ";") {
+	for option := range strings.SplitSeq(s, ";") {
 		if option == "" {
 			continue
 		}
@@ -194,7 +194,7 @@ func parseOptionValues(s string) (values ContextValues) {
 	values = ContextValues{}
 
 	if strings.Contains(s, "|") {
-		for _, option := range strings.Split(s, "|") {
+		for option := range strings.SplitSeq(s, "|") {
 			if option == "" {
 				continue
 			}
@@ -202,7 +202,7 @@ func parseOptionValues(s string) (values ContextValues) {
 		}
 	} else {
 		// temporarily handling comma separated values for labels context
-		for _, option := range strings.Split(s, ",") {
+		for option := range strings.SplitSeq(s, ",") {
 			if option == "" {
 				continue
 			}

--- a/pkg/k8s/slim/k8s/apis/labels/labels.go
+++ b/pkg/k8s/slim/k8s/apis/labels/labels.go
@@ -138,8 +138,7 @@ func ConvertSelectorToLabelsMap(selector string, opts ...field.PathOption) (Set,
 		return labelsMap, nil
 	}
 
-	labels := strings.Split(selector, ",")
-	for _, label := range labels {
+	for label := range strings.SplitSeq(selector, ",") {
 		l := strings.Split(label, "=")
 		if len(l) != 2 {
 			return labelsMap, fmt.Errorf("invalid selector: %s", l)

--- a/pkg/metrics/plot.go
+++ b/pkg/metrics/plot.go
@@ -71,7 +71,7 @@ func PlotSamples(w io.Writer, rate bool, name, labels string, timeSpan, sampling
 
 	// Write out the labels, also centered, but leave some margins.
 	if labels != "" {
-		for _, line := range strings.Split(wordwrap.WrapString(labels, uint(plotWidth-4)), "\n") {
+		for line := range strings.SplitSeq(wordwrap.WrapString(labels, uint(plotWidth-4)), "\n") {
 			fmt.Fprintf(w, "%s%s[ %s ]\n",
 				indentPlotOriginX,
 				strings.Repeat(" ", plotWidth/2-(len(line)+4)/2),

--- a/pkg/proxy/proxyports/netstat.go
+++ b/pkg/proxy/proxyports/netstat.go
@@ -46,11 +46,9 @@ func (p *ProxyPorts) GetOpenLocalPorts() map[uint16]struct{} {
 			continue
 		}
 
-		lines := bytes.Split(b, []byte("\n"))
-
 		// Extract the local port number from the "local_address" column.
 		// The header line won't match and will be ignored.
-		for _, line := range lines {
+		for line := range bytes.SplitSeq(b, []byte("\n")) {
 			groups := procNetFileRegexp.FindSubmatch(line)
 			if len(groups) != 2 { // no match
 				continue

--- a/pkg/rate/api_limiter.go
+++ b/pkg/rate/api_limiter.go
@@ -376,8 +376,7 @@ func (p *APILimiterParameters) mergeUserConfigKeyValue(key, value string) error 
 }
 
 func (p *APILimiterParameters) mergeUserConfig(config string) error {
-	tokens := strings.Split(config, ",")
-	for _, token := range tokens {
+	for token := range strings.SplitSeq(config, ",") {
 		if token == "" {
 			continue
 		}

--- a/pkg/testutils/cgroup.go
+++ b/pkg/testutils/cgroup.go
@@ -27,7 +27,7 @@ func cgroup2Path() (string, error) {
 			return
 		}
 
-		for _, line := range strings.Split(string(mounts), "\n") {
+		for line := range strings.SplitSeq(string(mounts), "\n") {
 			mount := strings.SplitN(line, " ", 3)
 			if mount[0] == "cgroup2" {
 				c.path, c.err = mount[1], nil

--- a/test/controlplane/k8s_versions.go
+++ b/test/controlplane/k8s_versions.go
@@ -15,9 +15,7 @@ var (
 )
 
 func K8sVersions() (k8sVersions []string) {
-	words := bytes.Split(k8sVersionsData, []byte{'\n'})
-
-	for _, w := range words {
+	for w := range bytes.SplitSeq(k8sVersionsData, []byte{'\n'}) {
 		if len(w) != 0 {
 			version := regexp.MustCompile(`\d\.\d{2}`).Find(w)
 			k8sVersions = append(k8sVersions, string(version))

--- a/test/ginkgo-ext/junit_reporter.go
+++ b/test/ginkgo-ext/junit_reporter.go
@@ -180,7 +180,7 @@ func reportChecks(output string) (string, string) {
 	var stdout string
 	var dest = "stdout"
 
-	for _, line := range strings.Split(output, "\n") {
+	for line := range strings.SplitSeq(output, "\n") {
 		if line == "<Checks>" {
 			dest = "checks"
 			continue

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -402,7 +402,7 @@ func (res *CmdRes) KVOutput() map[string]string {
 func (res *CmdRes) OutputPrettyPrint() string {
 	format := func(message string) string {
 		result := []string{}
-		for _, line := range strings.Split(message, "\n") {
+		for line := range strings.SplitSeq(message, "\n") {
 			result = append(result, fmt.Sprintf("\t %s", line))
 		}
 		return strings.Join(result, "\n")

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2815,7 +2815,7 @@ func (kub *Kubectl) CiliumEndpointWaitReady() error {
 			}
 			total := 0
 			invalid := 0
-			for _, line := range strings.Split(status.String(), "\n") {
+			for line := range strings.SplitSeq(status.String(), "\n") {
 				if line == "" {
 					continue
 				}

--- a/test/helpers/logutils/utils.go
+++ b/test/helpers/logutils/utils.go
@@ -51,7 +51,7 @@ func getErrorWarningMsgs(logs string, n int) []string {
 
 	errors := map[string]int{}
 	warnings := map[string]int{}
-	for _, line := range strings.Split(logs, "\n") {
+	for line := range strings.SplitSeq(logs, "\n") {
 		if strings.Contains(line, ErrorLogs) {
 			msg := getMsg(line)
 			errors[msg]++

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -461,7 +461,7 @@ func CanRunK8sVersion(ciliumVersion, k8sVersionStr string) (bool, error) {
 // does not contain ignore messages (map value).
 func failIfContainsBadLogMsg(logs, label string, blacklist map[string][]string) {
 	uniqueFailures := make(map[string]int)
-	for _, msg := range strings.Split(logs, "\n") {
+	for msg := range strings.SplitSeq(logs, "\n") {
 		for fail, ignoreMessages := range blacklist {
 			if strings.Contains(msg, fail) {
 				ok := false

--- a/test/helpers/vagrant.go
+++ b/test/helpers/vagrant.go
@@ -139,7 +139,7 @@ func Status(key string) map[string]string {
 	if err != nil {
 		return result
 	}
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		val := strings.Split(line, ",")
 		if len(val) > 2 && val[2] == "state" {
 			result[val[1]] = val[3]

--- a/tools/dpgen/generate.go
+++ b/tools/dpgen/generate.go
@@ -187,8 +187,7 @@ func getValue[T comparable](v *ebpf.VariableSpec) (out T, err error) {
 // acronyms defined in 'stylized'.
 func camelCase(s string) string {
 	var b strings.Builder
-	words := strings.Split(s, "_")
-	for _, w := range words {
+	for w := range strings.SplitSeq(s, "_") {
 		w = stylize(strings.ToLower(w))
 		b.WriteString(cases.Title(language.English, cases.NoLower).String(w))
 	}
@@ -230,8 +229,7 @@ func tagsToComment(tags []string) (string, error) {
 func wrapString(in, prefix string) string {
 	var b strings.Builder
 	width := uint(80 - len(prefix))
-	lines := strings.Split(wordwrap.WrapString(in, width), "\n")
-	for _, line := range lines {
+	for line := range strings.SplitSeq(wordwrap.WrapString(in, width), "\n") {
 		b.WriteString(prefix)
 		b.WriteString(line)
 		b.WriteString("\n")

--- a/tools/feature-helm-generator/main.go
+++ b/tools/feature-helm-generator/main.go
@@ -279,8 +279,7 @@ func parseMetricsFromProm(promFile io.Reader) []Metric {
 // Parse label string into a map
 func parseLabels(labelsPart string) map[string]map[string]struct{} {
 	labels := make(map[string]map[string]struct{})
-	labelPairs := strings.Split(labelsPart, ",")
-	for _, pair := range labelPairs {
+	for pair := range strings.SplitSeq(labelsPart, ",") {
 		parts := strings.Split(pair, "=")
 		if len(parts) == 2 {
 			if labels[parts[0]] == nil {


### PR DESCRIPTION
Replace `Split` in `for range strings.Split(...)` by Go 1.24's more efficient, iterators-based `strings.SplitSeq`.

Generated using modernize by running:

    go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...

and committing the relevant changes with some minor manual edits.