### PR TITLE
docs: Correct the envoy circuit-breaking example manifest

### DIFF
--- a/examples/kubernetes/servicemesh/envoy/envoy-circuit-breaker.yaml
+++ b/examples/kubernetes/servicemesh/envoy/envoy-circuit-breaker.yaml
@@ -42,7 +42,7 @@ spec:
       lb_policy: ROUND_ROBIN
       type: EDS
       edsClusterConfig:
-        serviceName: default/echo-service:8080
+        serviceName: default/echo-service
       circuit_breakers:
         thresholds:
         - priority: "DEFAULT"


### PR DESCRIPTION
Port number is not part of the service name and makes backend selection fail.

Signed-off-by: Raphaël Pinson <raphael@isovalent.com>
