### PR TITLE
fqdn: split proxy creation and listen methods

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -84,7 +84,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 		ConcurrencyLimit:       0,
 		ConcurrencyGracePeriod: 0,
 	}
-	proxy, err := StartDNSProxy(dnsProxyConfig, // any address, any port, enable ipv4, enable ipv6, enable compression, max 1000 restore IPs
+	proxy := NewDNSProxy(dnsProxyConfig, // any address, any port, enable ipv4, enable ipv6, enable compression, max 1000 restore IPs
 		// LookupEPByIP
 		func(ip netip.Addr) (*endpoint.Endpoint, bool, error) {
 			if s.restoring {
@@ -127,7 +127,8 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 			return nil
 		},
 	)
-	require.NoError(tb, err, "error starting DNS Proxy")
+	err := proxy.Listen()
+	require.NoError(tb, err, "error listening for DNS requests")
 	s.proxy = proxy
 
 	// This is here because Listener or Listener.Addr() was nil. The


### PR DESCRIPTION
This is a minor cleanup to make it clearer when, exactly, the FQDN proxy should be listening.
