### PR TITLE
daemon: Fix opening of SkipLBMap early in initialization

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -296,7 +296,10 @@ func (d *Daemon) initMaps() error {
 		}
 	}
 
-	_, err := lbmap.NewSkipLBMap()
+	skiplbmap, err := lbmap.NewSkipLBMap()
+	if err == nil {
+		err = skiplbmap.OpenOrCreate()
+	}
 	if err != nil {
 		return fmt.Errorf("initializing local redirect policy maps: %w", err)
 	}


### PR DESCRIPTION
Commit 64968210015b5 ("daemon: Create IPsec and LRP maps early on startup") added an early unconditional creation of the LRP map. I however broke that in 02c6c1075164 when I moved the creation of the map to OpenOrCreate() from NewSkipLBMap(). Fix by adding invocation of OpenOrCreate() to initMaps()


This fixes the following error:
```
  error="loading eBPF collection into the kernel: map cilium_skip_lb6:
    pin map to /sys/fs/bpf/tc/globals/cilium_skip_lb6: file exists" ...
```

Fixes: 02c6c1075164 ("redirectpolicy,skiplbmap: Add OpenOrCreate, AllLB*, DeleteLB*")

No need for backports or a release note as the above commit did not make into a release.