### PR TITLE
Display IPv4/IPv6 Exclusion CIDRs in cilium status

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -535,8 +535,6 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 					status = "BPF"
 				}
 				if sr.KubeProxyReplacement != nil {
-					// When BPF Masquerading is enabled we don't do any masquerading for IPv6
-					// traffic so no SNAT Exclusion IPv6 CIDR is listed in status output.
 					devStr := ""
 					for i, dev := range sr.KubeProxyReplacement.DeviceList {
 						devStr += dev.Name
@@ -548,9 +546,21 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 						devStr,
 						sr.Masquerading.SnatExclusionCidrV4)
 				}
-
 			} else if sr.Masquerading.Mode == models.MasqueradingModeIptables {
 				status = "IPTables"
+				if sr.KubeProxyReplacement != nil {
+					devStr := ""
+					for i, dev := range sr.KubeProxyReplacement.DeviceList {
+						devStr += dev.Name
+						if i+1 != len(sr.KubeProxyReplacement.DeviceList) {
+							devStr += ", "
+						}
+					}
+					status += fmt.Sprintf("\t[%s]\t%s,%s",
+						devStr,
+						sr.Masquerading.SnatExclusionCidrV4,
+						sr.Masquerading.SnatExclusionCidrV6)
+				}
 			}
 
 			status = fmt.Sprintf("%s [IPv4: %s, IPv6: %s]", status,


### PR DESCRIPTION
This change updates the status output to display both IPv4 and IPv6 SNAT Exclusion CIDRs when in iptables mode. Previously, when BPF masquerading was enabled, only the IPv4 SNAT Exclusion CIDR was displayed.

Fixes: #38055

## Testing
1. Tested with BPF masquerading mode:
   - Verified existing behavior is preserved
   - Confirmed only IPv4 CIDR is displayed
2. Tested with iptables masquerading mode:
   - Verified both IPv4 and IPv6 CIDRs are displayed
   - Confirmed correct formatting with comma separation
   - Validated order (IPv4 first, IPv6 second)

```release-note
Display both IPv4 and IPv6 SNAT Exclusion CIDRs in cilium status output when in iptables mode.
```