### PR TITLE
cilium_unreachable_node metric: Add the node name

### DIFF
--- a/pkg/metrics/status_test.go
+++ b/pkg/metrics/status_test.go
@@ -90,7 +90,63 @@ var sampleSingleClusterConnectivityResponse = &connectivity.GetStatusOK{
 	},
 }
 
-const expectedStatusMetric = `
+var sampleSingleClusterUnreachableConnectivityResponse = &connectivity.GetStatusOK{
+	Payload: &healthModels.HealthStatusResponse{
+		Local: &healthModels.SelfStatus{
+			Name: "kind-worker",
+		},
+		Nodes: []*healthModels.NodeStatus{
+			{
+				HealthEndpoint: &healthModels.EndpointStatus{
+					PrimaryAddress: &healthModels.PathStatus{
+						HTTP: &healthModels.ConnectivityStatus{
+							Latency: 212100,
+						},
+						Icmp: &healthModels.ConnectivityStatus{
+							Latency: 672600,
+						},
+						IP: "10.244.3.219",
+					},
+					SecondaryAddresses: []*healthModels.PathStatus{
+						{
+							HTTP: &healthModels.ConnectivityStatus{
+								Latency: 212101,
+							},
+							Icmp: &healthModels.ConnectivityStatus{
+								Latency: 672601,
+							},
+							IP: "10.244.3.220",
+						},
+						{
+							HTTP: &healthModels.ConnectivityStatus{
+								Latency: 212102,
+							},
+							Icmp: &healthModels.ConnectivityStatus{
+								Latency: 672602,
+							},
+							IP: "10.244.3.221",
+						},
+					},
+				},
+				Host: &healthModels.HostStatus{
+					PrimaryAddress: &healthModels.PathStatus{
+						HTTP: &healthModels.ConnectivityStatus{
+							Status: "non-empty-means-not-reachable",
+						},
+						Icmp: &healthModels.ConnectivityStatus{
+							Latency: 704179,
+						},
+						IP: "172.18.0.3",
+					},
+					SecondaryAddresses: nil,
+				},
+				Name: "kind-worker",
+			},
+		},
+	},
+}
+
+const expectedStatusMetricSuccess = `
 # HELP cilium_controllers_failing Number of failing controllers
 # TYPE cilium_controllers_failing gauge
 cilium_controllers_failing 1
@@ -103,7 +159,23 @@ cilium_ip_addresses{family="ipv6"} 3
 cilium_unreachable_health_endpoints 0
 # HELP cilium_unreachable_nodes Number of nodes that cannot be reached
 # TYPE cilium_unreachable_nodes gauge
-cilium_unreachable_nodes 0
+cilium_unreachable_nodes{node_name=""} 0
+`
+
+const expectedStatusMetricFailure = `
+# HELP cilium_controllers_failing Number of failing controllers
+# TYPE cilium_controllers_failing gauge
+cilium_controllers_failing 1
+# HELP cilium_ip_addresses Number of allocated IP addresses
+# TYPE cilium_ip_addresses gauge
+cilium_ip_addresses{family="ipv4"} 3
+cilium_ip_addresses{family="ipv6"} 3
+# HELP cilium_unreachable_health_endpoints Number of health endpoints that cannot be reached
+# TYPE cilium_unreachable_health_endpoints gauge
+cilium_unreachable_health_endpoints 0
+# HELP cilium_unreachable_nodes Number of nodes that cannot be reached
+# TYPE cilium_unreachable_nodes gauge
+cilium_unreachable_nodes{node_name="kind-worker"} 1
 `
 
 type fakeDaemonClient struct {
@@ -131,34 +203,41 @@ func Test_statusCollector_Collect(t *testing.T) {
 		expectedCount        int
 	}{
 		{
-			name:                 "check status metrics",
+			name:                 "Success",
 			healthResponse:       sampleHealthResponse,
 			connectivityResponse: sampleSingleClusterConnectivityResponse,
 			expectedCount:        5,
-			expectedMetric:       expectedStatusMetric,
+			expectedMetric:       expectedStatusMetricSuccess,
+		},
+		{
+			name:                 "Failure",
+			healthResponse:       sampleHealthResponse,
+			connectivityResponse: sampleSingleClusterUnreachableConnectivityResponse,
+			expectedCount:        5,
+			expectedMetric:       expectedStatusMetricFailure,
 		},
 	}
 
 	for _, tt := range tests {
-		t.Log("Test :", tt.name)
-		collector := newStatusCollectorWithClients(&fakeDaemonClient{
-			response: tt.healthResponse,
-		}, &fakeConnectivityClient{
-			response: tt.connectivityResponse,
+		t.Run(tt.name, func(t *testing.T) {
+			collector := newStatusCollectorWithClients(&fakeDaemonClient{
+				response: tt.healthResponse,
+			}, &fakeConnectivityClient{
+				response: tt.connectivityResponse,
+			})
+
+			// perform static checks such as prometheus naming convention, number of labels matching, etc
+			lintProblems, err := testutil.CollectAndLint(collector)
+			require.NoError(t, err)
+			require.Empty(t, lintProblems)
+
+			// check the number of metrics
+			count := testutil.CollectAndCount(collector)
+			require.Equal(t, tt.expectedCount, count)
+
+			// compare the metric output
+			err = testutil.CollectAndCompare(collector, strings.NewReader(tt.expectedMetric))
+			require.NoError(t, err)
 		})
-
-		// perform static checks such as prometheus naming convention, number of labels matching, etc
-		lintProblems, err := testutil.CollectAndLint(collector)
-		require.NoError(t, err)
-		require.Empty(t, lintProblems)
-
-		// check the number of metrics
-		count := testutil.CollectAndCount(collector)
-		require.Equal(t, tt.expectedCount, count)
-
-		// compare the metric output
-		err = testutil.CollectAndCompare(collector, strings.NewReader(tt.expectedMetric))
-		require.NoError(t, err)
 	}
-
 }


### PR DESCRIPTION
Currently, if a single node becomes unreachable, all other nodes will emit this metric but not what node it is for. As a result, it is not possible to distinguish if 10 nodes became unreachable as observed by one node or 10 nodes each observe one node to be unreachable.

Additionally, it is impossible to exclude some nodes if they have a known issue.

This change adds a `name` dimension in the metric to fix the two above issues. To avoid a cardinality explosion given the fact that all nodes emit this metric, the logic is changed to only emit this metric on failure.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
The `cilium_unreachable_nodes` metric was changed to include the name of the unreachable node(s) and will only be emitted on failure
```
