### PR TITLE
pkg: Mark node_linux_test.go as unparallel

### DIFF
--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1,3 +1,5 @@
+//go:build unparallel
+
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 


### PR DESCRIPTION
Fixes: https://github.com/cilium/cilium/issues/37764

ci-runtime has run 40+ times successfully in a row: https://github.com/cilium/cilium/actions/runs/13830608406 