### PR TITLE
docs: Add missing kernel options to system requirements

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -191,6 +191,7 @@ The following kernel configuration options are required for proper operation:
 ::
 
         CONFIG_VXLAN=y
+        CONFIG_GENEVE=y
         CONFIG_FIB_RULES=y
 
 Requirements for L7 and FQDN Policies

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -179,6 +179,19 @@ default value), then you will need the following kernel configuration options.
         CONFIG_NETFILTER_XT_SET=m
         CONFIG_IP_SET=m
         CONFIG_IP_SET_HASH_IP=m
+        CONFIG_NETFILTER_XT_MATCH_COMMENT=m
+
+Requirements for Tunneling and Routing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Cilium uses tunneling protocols like VXLAN by default for pod-to-pod communication
+across nodes, as well as policy routing for various traffic management functionality. 
+The following kernel configuration options are required for proper operation:
+
+::
+
+        CONFIG_VXLAN=y
+        CONFIG_FIB_RULES=y
 
 Requirements for L7 and FQDN Policies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Add missing kernel options to system requirements

This PR adds the following kernel options to the system requirements documentation:

- `CONFIG_NETFILTER_XT_MATCH_COMMENT` for iptables-based masquerading and k3s compatibility
- `CONFIG_VXLAN` for tunneling between nodes (default mode)
- `CONFIG_FIB_RULES` for policy routing used by Cilium

These options were found to be necessary when running Cilium on a custom kernel, but were not documented in the system requirements.

## Changes
- Added `CONFIG_NETFILTER_XT_MATCH_COMMENT` to the "Requirements for Iptables-based Masquerading" section
- Added a new "Requirements for Tunneling and Routing" section
- Added `CONFIG_VXLAN` and `CONFIG_FIB_RULES` to the new section with explanations

```release-note
docs: Add missing kernel options to system requirements documentation to help users with custom kernels.
```

Fixes: #36189
