### PR TITLE
make: load docker images sequentially into kind nodes

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -165,8 +165,9 @@ kind-build-image-agent: ## Build cilium-dev docker image
 $(eval $(call KIND_ENV,kind-image-agent))
 kind-image-agent: .SHELLFLAGS=-c
 kind-image-agent: kind-ready kind-build-image-agent ## Build cilium-dev docker image and import it into kind.
-	$(QUIET)kind load docker-image $(LOCAL_AGENT_IMAGE) -n $(KIND_CLUSTER_NAME); \
-	[ $$? -eq 0 ] || $(QUIET)kind load docker-image $(LOCAL_AGENT_IMAGE) -n $(KIND_CLUSTER_NAME)
+	for node in $(shell kind -n $(KIND_CLUSTER_NAME) get nodes); do \
+		$(QUIET)kind load docker-image $(LOCAL_AGENT_IMAGE) -n $(KIND_CLUSTER_NAME) --nodes $$node; \
+	done
 
 $(eval $(call KIND_ENV,kind-build-image-operator))
 kind-build-image-operator: ## Build cilium-operator-dev docker image
@@ -175,8 +176,9 @@ kind-build-image-operator: ## Build cilium-operator-dev docker image
 $(eval $(call KIND_ENV,kind-image-operator))
 kind-image-operator: .SHELLFLAGS=-c
 kind-image-operator: kind-ready kind-build-image-operator ## Build cilium-operator-dev docker image and import it into kind.
-	$(QUIET)kind load docker-image $(LOCAL_OPERATOR_IMAGE) -n $(KIND_CLUSTER_NAME); \
-	[ $$? -eq 0 ] || $(QUIET)kind load docker-image $(LOCAL_OPERATOR_IMAGE) -n $(KIND_CLUSTER_NAME)
+	for node in $(shell kind -n $(KIND_CLUSTER_NAME) get nodes); do \
+		$(QUIET)kind load docker-image $(LOCAL_OPERATOR_IMAGE) -n $(KIND_CLUSTER_NAME) --nodes $$node; \
+	done
 
 $(eval $(call KIND_ENV,kind-build-clustermesh-apiserver))
 kind-build-clustermesh-apiserver: ## Build cilium-clustermesh-apiserver docker image
@@ -206,8 +208,9 @@ kind-install-cilium-fast: check_deps kind-ready ## "Fast" Install a local Cilium
 	@echo "  INSTALL cilium"
 	docker pull quay.io/cilium/cilium-ci:latest
 	for cluster_name in $${KIND_CLUSTERS:-$(shell kind get clusters)}; do \
-		kind load docker-image --name $$cluster_name quay.io/cilium/cilium-ci:latest; \
-		[ $$? -eq 0 ] || kind load docker-image --name $$cluster_name quay.io/cilium/cilium-ci:latest; \
+		for node in $(shell kind -n "$$cluster_name" get nodes); do \
+			$(QUIET)kind load docker-image quay.io/cilium/cilium-ci:latest -n $$cluster_name --nodes $$node; \
+		done; \
 		$(CILIUM_CLI) --context=kind-$$cluster_name uninstall >/dev/null 2>&1 || true; \
 		$(CILIUM_CLI) install --context=kind-$$cluster_name \
 			--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \


### PR DESCRIPTION
Currently, the make target `kind-image-agent` retries loading the agent image into kind once. Loading the image might fail with the following error.

```
... failed to unmount target /var/lib/containerd/tmpmounts/containerd-mount1974330188: device or resource busy
```

There are scenarios (e.g. kind clusters with an increased number of nodes) where retrying once is unfortunately not enough - and increasing the number of retries isn't the best option either.

Therefore, this commit changes the logic from loading the docker images in parallel into all the nodes (with one retry) into sequentially loading the images into the nodes - one node after another.

Note: This PR only changes the occurrences that previously already had the retry (make targets `kind-install-cilium & `kind-install-cilium-fast`) - but can easily be adopted by other targets if needed.