### PR TITLE
[v1.17] wireguard:fix: always detach unneeded programs

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -288,12 +288,7 @@ func reinitializeOverlay(ctx context.Context, tunnelConfig tunnel.Config) error 
 }
 
 func reinitializeWireguard(ctx context.Context) (err error) {
-	// to-wireguard bpf is only used for rev-DNAT, which is only needed when NodePort, KPR, native routing and L7 proxy are enabled together
-	if !option.Config.EnableWireguard ||
-		!option.Config.EnableNodePort ||
-		!option.Config.EnableL7Proxy ||
-		option.Config.RoutingMode != option.RoutingModeNative ||
-		option.Config.KubeProxyReplacement != option.KubeProxyReplacementTrue {
+	if !option.Config.EnableWireguard || !option.Config.NeedEgressOnWireGuardDevice() {
 		return
 	}
 

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -288,7 +288,7 @@ func reinitializeOverlay(ctx context.Context, tunnelConfig tunnel.Config) error 
 }
 
 func reinitializeWireguard(ctx context.Context) (err error) {
-	if !option.Config.EnableWireguard || !option.Config.NeedEgressOnWireGuardDevice() {
+	if !option.Config.EnableWireguard {
 		return
 	}
 

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -637,9 +637,24 @@ func replaceWireguardDatapath(ctx context.Context, cArgs []string, device netlin
 	defer obj.Close()
 
 	linkDir := bpffsDeviceLinksDir(bpf.CiliumPath(), device)
-	if err := attachSKBProgram(device, obj.ToWireguard, symbolToWireguard,
-		linkDir, netlink.HANDLE_MIN_EGRESS, option.Config.EnableTCX); err != nil {
-		return fmt.Errorf("interface %s egress: %w", device, err)
+	// Attach/detach cil_to_wireguard to/from egress.
+	if option.Config.NeedEgressOnWireGuardDevice() {
+		if err := attachSKBProgram(device, obj.ToWireguard, symbolToWireguard,
+			linkDir, netlink.HANDLE_MIN_EGRESS, option.Config.EnableTCX); err != nil {
+			return fmt.Errorf("interface %s egress: %w", device, err)
+		}
+	} else {
+		if err := detachSKBProgram(device, symbolToWireguard,
+			linkDir, netlink.HANDLE_MIN_EGRESS); err != nil {
+			log.WithField("device", device).Error(err)
+		}
+	}
+	// Selectively detach cil_from_netdev from ingress.
+	if !option.Config.NeedBPFHostOnWireGuardDevice() {
+		if err := detachSKBProgram(device, symbolFromHostNetdevEp,
+			linkDir, netlink.HANDLE_MIN_INGRESS); err != nil {
+			log.WithField("device", wgTypes.IfaceName).Error(err)
+		}
 	}
 	if err := commit(); err != nil {
 		return fmt.Errorf("committing bpf pins: %w", err)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2386,7 +2386,7 @@ func (c *DaemonConfig) AreDevicesRequired() bool {
 }
 
 // NeedBPFHostOnWireGuardDevice returns true if the agent needs to attach
-// a BPF program on the Ingress of Cilium's WireGuard device
+// cil_from_netdev on the Ingress of Cilium's WireGuard device
 func (c *DaemonConfig) NeedBPFHostOnWireGuardDevice() bool {
 	if !c.EnableWireguard {
 		return false
@@ -2408,6 +2408,27 @@ func (c *DaemonConfig) NeedBPFHostOnWireGuardDevice() bool {
 	// netdev (otherwise, the WG netdev after decrypting the reply will pass
 	// it to the stack which drops the packet).
 	if c.EnableNodePort && c.EncryptNode {
+		return true
+	}
+
+	return false
+}
+
+// NeedEgressOnWireGuardDevice returns true if the agent needs to attach
+// cil_to_wireguard on the Egress of Cilium's WireGuard device
+func (c *DaemonConfig) NeedEgressOnWireGuardDevice() bool {
+	if !c.EnableWireguard {
+		return false
+	}
+
+	// No need to handle rev-NAT xlations in wireguard with tunneling enabled.
+	if c.TunnelingEnabled() {
+		return false
+	}
+
+	// Attaching cil_to_wireguard to cilium_wg0 egress is required for handling
+	// the rev-NAT xlations when encrypting KPR traffic.
+	if c.EnableNodePort && c.EnableL7Proxy && c.KubeProxyReplacement == KubeProxyReplacementTrue {
 		return true
 	}
 


### PR DESCRIPTION
Manual backport for #38179.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 38179
```