### PR TITLE
cilium-cli: Use distroless

### DIFF
--- a/cilium-cli/Dockerfile
+++ b/cilium-cli/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
     make GOARCH=${TARGETARCH} DESTDIR=/out/${TARGETOS}/${TARGETARCH} $(echo $MODIFIERS | tr -d '"') \
     -C cilium-cli install
 
-FROM docker.io/library/ubuntu:24.04@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782 AS release
+FROM gcr.io/distroless/static:latest@sha256:3f2b64ef97bd285e36132c684e6b2ae8f2723293d09aae046196cca64251acac AS release
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
Following up on @marseel's monumental masterpiece [^1], use distroless instead of ubuntu as the base image to slightly reduce the image size (from 84.1 MiB to 56.5 MiB).

[^1]: https://github.com/cilium/cilium/pull/37970