### PR TITLE
cilium-cli: extend no-interrupted-connections to test Egress Gateway

### DIFF
--- a/.github/actions/conn-disrupt-test-check/action.yaml
+++ b/.github/actions/conn-disrupt-test-check/action.yaml
@@ -31,11 +31,11 @@ runs:
           TEST_ARG="${{ inputs.tests }}"
         else
           TEST_ARG="no-interrupted-connections"
-          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic"
+          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic --include-conn-disrupt-test-egw"
         fi
         if [[ "${{ inputs.full-test }}" == "true" ]]; then
           TEST_ARG=""
-          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic"
+          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic --include-conn-disrupt-test-egw"
         fi
         ${{ inputs.cilium-cli }} connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
           --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \

--- a/.github/actions/conn-disrupt-test-setup/action.yaml
+++ b/.github/actions/conn-disrupt-test-setup/action.yaml
@@ -18,6 +18,8 @@ runs:
         # interruption in such flows.
         ${{ inputs.cilium-cli }} connectivity test --include-conn-disrupt-test \
           --include-conn-disrupt-test-ns-traffic \
+          --include-conn-disrupt-test-egw \
+          --include-unsafe-tests \
           --conn-disrupt-test-setup \
           --conn-disrupt-dispatch-interval 0ms \
           --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -736,7 +736,9 @@ jobs:
           # Create pods which establish long lived connections. It will be used by
           # subsequent connectivity tests with --include-conn-disrupt-test to catch any
           # interruption in such flows.
-          cilium connectivity test --include-conn-disrupt-test --include-conn-disrupt-test-ns-traffic \
+          cilium connectivity test --include-unsafe-tests --include-conn-disrupt-test \
+            --include-conn-disrupt-test-ns-traffic \
+            --include-conn-disrupt-test-egw \
             --conn-disrupt-test-setup \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts" \
             --conn-disrupt-dispatch-interval 0ms
@@ -762,8 +764,10 @@ jobs:
         shell: bash
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+            --include-unsafe-tests \
             --include-conn-disrupt-test \
             --include-conn-disrupt-test-ns-traffic \
+            --include-conn-disrupt-test-egw \
             --test "no-interrupted-connections" \
             --conn-disrupt-test-restarts-path "./cilium-conn-disrupt-restarts"
 

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -202,6 +202,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 
 	cmd.Flags().BoolVar(&params.IncludeConnDisruptTest, "include-conn-disrupt-test", false, "Include conn disrupt test")
 	cmd.Flags().BoolVar(&params.IncludeConnDisruptTestNSTraffic, "include-conn-disrupt-test-ns-traffic", false, "Include conn disrupt test for NS traffic")
+	cmd.Flags().BoolVar(&params.IncludeConnDisruptTestEgressGateway, "include-conn-disrupt-test-egw", false, "Include conn disrupt test for Egress Gateway")
 	cmd.Flags().BoolVar(&params.ConnDisruptTestSetup, "conn-disrupt-test-setup", false, "Set up conn disrupt test dependencies")
 	cmd.Flags().StringVar(&params.ConnDisruptTestRestartsPath, "conn-disrupt-test-restarts-path", "/tmp/cilium-conn-disrupt-restarts", "Conn disrupt test temporary result file (used internally)")
 	cmd.Flags().StringVar(&params.ConnDisruptTestXfrmErrorsPath, "conn-disrupt-test-xfrm-errors-path", "/tmp/cilium-conn-disrupt-xfrm-errors", "Conn disrupt test temporary result file (used internally)")

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -114,12 +114,13 @@ type Parameters struct {
 	ImpersonateGroups      []string
 	IPFamilies             []string
 
-	IncludeConnDisruptTest          bool
-	IncludeConnDisruptTestNSTraffic bool
-	ConnDisruptTestSetup            bool
-	ConnDisruptTestRestartsPath     string
-	ConnDisruptTestXfrmErrorsPath   string
-	ConnDisruptDispatchInterval     time.Duration
+	IncludeConnDisruptTest              bool
+	IncludeConnDisruptTestNSTraffic     bool
+	IncludeConnDisruptTestEgressGateway bool
+	ConnDisruptTestSetup                bool
+	ConnDisruptTestRestartsPath         string
+	ConnDisruptTestXfrmErrorsPath       string
+	ConnDisruptDispatchInterval         time.Duration
 
 	ExpectedDropReasons []string
 	ExpectedXFRMErrors  []string

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1291,5 +1291,6 @@ func (ct *ConnectivityTest) ShouldRunConnDisruptEgressGateway() bool {
 		ct.params.IncludeConnDisruptTestEgressGateway &&
 		ct.Features[features.EgressGateway].Enabled &&
 		ct.Features[features.NodeWithoutCilium].Enabled &&
-		!ct.Features[features.KPRNodePortAcceleration].Enabled
+		!ct.Features[features.KPRNodePortAcceleration].Enabled &&
+		ct.params.MultiCluster == ""
 }

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1285,3 +1285,10 @@ func (ct *ConnectivityTest) ShouldRunConnDisruptNSTraffic() bool {
 		!ct.Features[features.KPRNodePortAcceleration].Enabled &&
 		(!ct.Features[features.IPsecEnabled].Enabled || !ct.Features[features.KPRNodePort].Enabled)
 }
+
+func (ct *ConnectivityTest) ShouldRunConnDisruptEgressGateway() bool {
+	return ct.params.IncludeUnsafeTests &&
+		ct.params.IncludeConnDisruptTestEgressGateway &&
+		ct.Features[features.EgressGateway].Enabled &&
+		ct.Features[features.NodeWithoutCilium].Enabled
+}

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1290,5 +1290,6 @@ func (ct *ConnectivityTest) ShouldRunConnDisruptEgressGateway() bool {
 	return ct.params.IncludeUnsafeTests &&
 		ct.params.IncludeConnDisruptTestEgressGateway &&
 		ct.Features[features.EgressGateway].Enabled &&
-		ct.Features[features.NodeWithoutCilium].Enabled
+		ct.Features[features.NodeWithoutCilium].Enabled &&
+		!ct.Features[features.KPRNodePortAcceleration].Enabled
 }

--- a/cilium-cli/connectivity/tests/egressgateway.go
+++ b/cilium-cli/connectivity/tests/egressgateway.go
@@ -8,119 +8,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strings"
-	"time"
 
-	v1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
-	"github.com/cilium/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
-	"github.com/cilium/cilium/cilium-cli/utils/wait"
 )
-
-// bpfEgressGatewayPolicyEntry represents an entry in the BPF egress gateway policy map
-type bpfEgressGatewayPolicyEntry struct {
-	SourceIP  string `json:"sourceIP"`
-	DestCIDR  string `json:"destCIDR"`
-	EgressIP  string `json:"egressIP"`
-	GatewayIP string `json:"gatewayIP"`
-}
-
-// matches is an helper used to compare the receiver bpfEgressGatewayPolicyEntry with another entry
-func (e *bpfEgressGatewayPolicyEntry) matches(t bpfEgressGatewayPolicyEntry) bool {
-	return t.SourceIP == e.SourceIP &&
-		t.DestCIDR == e.DestCIDR &&
-		t.EgressIP == e.EgressIP &&
-		t.GatewayIP == e.GatewayIP
-}
-
-// WaitForEgressGatewayBpfPolicyEntries waits for the egress gateway policy maps on each node to WaitForEgressGatewayBpfPolicyEntries
-// with the entries returned by the targetEntriesCallback
-func WaitForEgressGatewayBpfPolicyEntries(ctx context.Context, t *check.Test,
-	targetEntriesCallback func(ciliumPod check.Pod) []bpfEgressGatewayPolicyEntry,
-) {
-	ct := t.Context()
-
-	w := wait.NewObserver(ctx, wait.Parameters{Timeout: 10 * time.Second})
-	defer w.Cancel()
-
-	ensureBpfPolicyEntries := func() error {
-		for _, ciliumPod := range ct.CiliumPods() {
-			targetEntries := targetEntriesCallback(ciliumPod)
-
-			cmd := strings.Split("cilium bpf egress list -o json", " ")
-			stdout, err := ciliumPod.K8sClient.ExecInPod(ctx, ciliumPod.Pod.Namespace, ciliumPod.Pod.Name, defaults.AgentContainerName, cmd)
-			if err != nil {
-				t.Fatal("failed to run cilium bpf egress list command: %w", err)
-			}
-
-			entries := []bpfEgressGatewayPolicyEntry{}
-			json.Unmarshal(stdout.Bytes(), &entries)
-
-		nextTargetEntry:
-			for _, targetEntry := range targetEntries {
-				for _, entry := range entries {
-					if targetEntry.matches(entry) {
-						continue nextTargetEntry
-					}
-				}
-
-				return fmt.Errorf("Could not find egress gateway policy entry matching %+v", targetEntry)
-			}
-
-		nextEntry:
-			for _, entry := range entries {
-				for _, targetEntry := range targetEntries {
-					if targetEntry.matches(entry) {
-						continue nextEntry
-					}
-				}
-
-				return fmt.Errorf("Untracked entry %+v in the egress gateway policy map", entry)
-			}
-		}
-
-		return nil
-	}
-
-	for {
-		if err := ensureBpfPolicyEntries(); err != nil {
-			if err := w.Retry(err); err != nil {
-				t.Fatal("Failed to ensure egress gateway policy map is properly populated:", err)
-			}
-
-			continue
-		}
-
-		return
-	}
-}
-
-// getGatewayNodeInternalIP returns the k8s internal IP of the node acting as gateway for this test
-func getGatewayNodeInternalIP(ct *check.ConnectivityTest, egressGatewayNode string) net.IP {
-	gatewayNode, ok := ct.Nodes()[egressGatewayNode]
-	if !ok {
-		return nil
-	}
-
-	for _, addr := range gatewayNode.Status.Addresses {
-		if addr.Type != v1.NodeInternalIP {
-			continue
-		}
-
-		ip := net.ParseIP(addr.Address)
-		if ip == nil || ip.To4() == nil {
-			continue
-		}
-
-		return ip
-	}
-
-	return nil
-}
 
 // extractClientIPFromResponse extracts the client IP from the response of the echo-external service
 func extractClientIPFromResponse(res string) net.IP {
@@ -171,13 +65,13 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 		t.Fatal("Cannot get egress gateway node")
 	}
 
-	egressGatewayNodeInternalIP := getGatewayNodeInternalIP(ct, egressGatewayNode)
+	egressGatewayNodeInternalIP := ct.GetGatewayNodeInternalIP(egressGatewayNode)
 	if egressGatewayNodeInternalIP == nil {
 		t.Fatal("Cannot get egress gateway node internal IP")
 	}
 
-	WaitForEgressGatewayBpfPolicyEntries(ctx, t, func(ciliumPod check.Pod) []bpfEgressGatewayPolicyEntry {
-		targetEntries := []bpfEgressGatewayPolicyEntry{}
+	err := check.WaitForEgressGatewayBpfPolicyEntries(ctx, ct.CiliumPods(), func(ciliumPod check.Pod) ([]check.BPFEgressGatewayPolicyEntry, error) {
+		var targetEntries []check.BPFEgressGatewayPolicyEntry
 
 		egressIP := "0.0.0.0"
 		if ciliumPod.Pod.Spec.NodeName == egressGatewayNode {
@@ -186,7 +80,7 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 
 		for _, client := range ct.ClientPods() {
 			targetEntries = append(targetEntries,
-				bpfEgressGatewayPolicyEntry{
+				check.BPFEgressGatewayPolicyEntry{
 					SourceIP:  client.Pod.Status.PodIP,
 					DestCIDR:  "0.0.0.0/0",
 					EgressIP:  egressIP,
@@ -196,7 +90,7 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 
 		for _, echo := range ct.EchoPods() {
 			targetEntries = append(targetEntries,
-				bpfEgressGatewayPolicyEntry{
+				check.BPFEgressGatewayPolicyEntry{
 					SourceIP:  echo.Pod.Status.PodIP,
 					DestCIDR:  "0.0.0.0/0",
 					EgressIP:  egressIP,
@@ -204,8 +98,13 @@ func (s *egressGateway) Run(ctx context.Context, t *check.Test) {
 				})
 		}
 
-		return targetEntries
+		return targetEntries, nil
+	}, func(ciliumPod check.Pod) ([]check.BPFEgressGatewayPolicyEntry, error) {
+		return ct.GetConnDisruptEgressPolicyEntries(ctx, ciliumPod)
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Ping hosts (pod to host connectivity). Should not get masqueraded with egress IP
 	i := 0
@@ -336,13 +235,13 @@ func (s *egressGatewayExcludedCIDRs) Run(ctx context.Context, t *check.Test) {
 		t.Fatal("Cannot get egress gateway node")
 	}
 
-	egressGatewayNodeInternalIP := getGatewayNodeInternalIP(ct, egressGatewayNode)
+	egressGatewayNodeInternalIP := ct.GetGatewayNodeInternalIP(egressGatewayNode)
 	if egressGatewayNodeInternalIP == nil {
 		t.Fatal("Cannot get egress gateway node internal IP")
 	}
 
-	WaitForEgressGatewayBpfPolicyEntries(ctx, t, func(ciliumPod check.Pod) []bpfEgressGatewayPolicyEntry {
-		targetEntries := []bpfEgressGatewayPolicyEntry{}
+	err := check.WaitForEgressGatewayBpfPolicyEntries(ctx, ct.CiliumPods(), func(ciliumPod check.Pod) ([]check.BPFEgressGatewayPolicyEntry, error) {
+		var targetEntries []check.BPFEgressGatewayPolicyEntry
 
 		egressIP := "0.0.0.0"
 		if ciliumPod.Pod.Spec.NodeName == egressGatewayNode {
@@ -361,7 +260,7 @@ func (s *egressGatewayExcludedCIDRs) Run(ctx context.Context, t *check.Test) {
 				}
 
 				targetEntries = append(targetEntries,
-					bpfEgressGatewayPolicyEntry{
+					check.BPFEgressGatewayPolicyEntry{
 						SourceIP:  client.Pod.Status.PodIP,
 						DestCIDR:  "0.0.0.0/0",
 						EgressIP:  egressIP,
@@ -369,7 +268,7 @@ func (s *egressGatewayExcludedCIDRs) Run(ctx context.Context, t *check.Test) {
 					})
 
 				targetEntries = append(targetEntries,
-					bpfEgressGatewayPolicyEntry{
+					check.BPFEgressGatewayPolicyEntry{
 						SourceIP:  client.Pod.Status.PodIP,
 						DestCIDR:  fmt.Sprintf("%s/32", nodeWithoutCilium.Status.Addresses[0].Address),
 						EgressIP:  egressIP,
@@ -378,8 +277,13 @@ func (s *egressGatewayExcludedCIDRs) Run(ctx context.Context, t *check.Test) {
 			}
 		}
 
-		return targetEntries
+		return targetEntries, nil
+	}, func(ciliumPod check.Pod) ([]check.BPFEgressGatewayPolicyEntry, error) {
+		return ct.GetConnDisruptEgressPolicyEntries(ctx, ciliumPod)
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Traffic matching an egress gateway policy and an excluded CIDR should leave the cluster masqueraded with the
 	// node IP where the pod is running rather than with the egress IP(pod to external service)

--- a/cilium-cli/connectivity/tests/upgrade.go
+++ b/cilium-cli/connectivity/tests/upgrade.go
@@ -77,6 +77,22 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 		} else {
 			ct.Info("Skipping conn-disrupt-test for NS traffic")
 		}
+
+		if ct.ShouldRunConnDisruptEgressGateway() {
+			pods, err = client.ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + check.KindTestConnDisruptEgressGateway})
+			if err != nil {
+				t.Fatalf("Unable to list test-conn-disrupt-egw pods: %s", err)
+			}
+			if len(pods.Items) == 0 {
+				t.Fatal("No test-conn-disrupt-{client,server} for Egress Gateway pods found")
+			}
+
+			for _, pod := range pods.Items {
+				restartCount[pod.GetObjectMeta().GetName()] = strconv.Itoa(int(pod.Status.ContainerStatuses[0].RestartCount))
+			}
+		} else {
+			ct.Info("Skipping conn-disrupt-test for Egress Gateway")
+		}
 	}
 
 	// Only store restart counters which will be used later when running the same


### PR DESCRIPTION
This PR extends the conn-disrupt-test to ensure that connections through a Egress Gateway are not disrupted.

The test deploys a conn-disrupt-test server with a single replica on an external node, a client on a gateway node and another client on a non gateway node. Clients establish long-lived TCP connections with the server through the gateway node.

After upgrade, the test checks the restart counters, and compares them with the counters stored before the upgrade. A mismatch indicates that a connection was interrupted.

Example output from `kubectl -n cilium-test-1 get po -o wide`:
```
NAME                                                        READY   STATUS    RESTARTS      AGE   IP             NODE                 NOMINATED NODE   READINESS GATES
test-conn-disrupt-client-egw-gw-node-859d6b6875-vkvh2       1/1     Running   0             15s   10.244.3.206   kind-worker          <none>           <none>
test-conn-disrupt-client-egw-non-gw-node-6c69d885df-7z6c5   1/1     Running   0             15s   10.244.1.14    kind-worker2         <none>           <none>
test-conn-disrupt-server-egw-644f65cb-vz8v7                 1/1     Running   0             17s   172.18.0.4     kind-worker3         <none>           <none>
```
Fixes: #37092
