### PR TITLE
IPv4 fragments refactoring (preparation for IPv6 fragments support)

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -320,6 +320,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 	struct endpoint_info *ep;
 	bool decrypted;
 	bool __maybe_unused is_dsr = false;
+	fraginfo_t fraginfo __maybe_unused;
 	int ret;
 
 	/* verifier workaround (dereference of modified ctx ptr) */
@@ -331,7 +332,8 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
  * then drop the packet.
  */
 #ifndef ENABLE_IPV4_FRAGMENTS
-	if (ipv4_is_fragment(ip4))
+	fraginfo = ipfrag_encode_ipv4(ip4);
+	if (ipfrag_is_fragment(fraginfo))
 		return DROP_FRAG_NOSUPPORT;
 #endif
 

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -451,7 +451,7 @@ ipv6_extract_tuple(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple)
 	if (ret < 0)
 		return DROP_CT_INVALID_HDR;
 
-	return CTX_ACT_OK;
+	return 0;
 }
 
 static __always_inline void ct_flip_tuple_dir6(struct ipv6_ct_tuple *tuple)
@@ -672,7 +672,6 @@ ipv4_extract_tuple(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple)
 {
 	void *data, *data_end;
 	struct iphdr *ip4;
-	int ret;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
@@ -689,12 +688,8 @@ ipv4_extract_tuple(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple)
 	tuple->daddr = ip4->daddr;
 	tuple->saddr = ip4->saddr;
 
-	ret = ipv4_load_l4_ports(ctx, ip4, ETH_HLEN + ipv4_hdrlen(ip4),
-				 CT_EGRESS, &tuple->dport, NULL);
-	if (ret < 0)
-		return ret;
-
-	return CTX_ACT_OK;
+	return ipv4_load_l4_ports(ctx, ip4, ETH_HLEN + ipv4_hdrlen(ip4),
+				  CT_EGRESS, &tuple->dport, NULL);
 }
 
 static __always_inline void ct_flip_tuple_dir4(struct ipv4_ct_tuple *tuple)
@@ -759,8 +754,6 @@ static __always_inline int
 ct_extract_ports4(struct __ctx_buff *ctx, struct iphdr *ip4, int off,
 		  enum ct_dir dir, struct ipv4_ct_tuple *tuple, bool *has_l4_header)
 {
-	int err;
-
 	switch (tuple->nexthdr) {
 	case IPPROTO_ICMP:
 		if (1) {
@@ -802,12 +795,8 @@ ct_extract_ports4(struct __ctx_buff *ctx, struct iphdr *ip4, int off,
 #ifdef ENABLE_SCTP
 	case IPPROTO_SCTP:
 #endif  /* ENABLE_SCTP */
-		err = ipv4_load_l4_ports(ctx, ip4, off, dir, &tuple->dport,
-					 has_l4_header);
-		if (err < 0)
-			return err;
-
-		break;
+		return ipv4_load_l4_ports(ctx, ip4, off, dir, &tuple->dport,
+					  has_l4_header);
 	default:
 		/* Can't handle extension headers yet */
 		return DROP_CT_UNKNOWN_PROTO;

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -506,6 +506,7 @@ __ipv4_host_policy_ingress(struct __ctx_buff *ctx, struct iphdr *ip4,
 	__u8 audited = 0;
 	__u8 auth_type = 0;
 	struct remote_endpoint_info *info;
+	fraginfo_t fraginfo __maybe_unused;
 	bool is_untracked_fragment = false;
 	__u16 proxy_port = 0;
 
@@ -529,7 +530,8 @@ __ipv4_host_policy_ingress(struct __ctx_buff *ctx, struct iphdr *ip4,
 	/* Indicate that this is a datagram fragment for which we cannot
 	 * retrieve L4 ports. Do not set flag if we support fragmentation.
 	 */
-	is_untracked_fragment = ipv4_is_fragment(ip4);
+	fraginfo = ipfrag_encode_ipv4(ip4);
+	is_untracked_fragment = ipfrag_is_fragment(fraginfo);
 #  endif
 
 	/* Perform policy lookup */

--- a/bpf/lib/ipfrag.h
+++ b/bpf/lib/ipfrag.h
@@ -1,0 +1,110 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+#include <linux/ip.h>
+#include "common.h"
+
+/* IP fragment information is packed in a single __s64:
+ *
+ *  63    62...42 41     40     39...32 31...    ...0
+ * +-----+-------+------+------+-------+-------------+
+ * | err |  ...  | nol4 | frag | proto | fragment id |
+ * +-----+-------+------+------+-------+-------------+
+ *
+ * err: Sign bit, negative values encode error codes.
+ * nol4: The packet doesn't have an L4 header (i.e. not the first fragment).
+ * frag: The packet is fragmented.
+ * proto: L4 protocol (the last nexthdr for IPv6).
+ * fragment id: 32-bit for IPv6, 16-bit for IPv4 (lower 16 bits).
+ *
+ * This information is extracted from the IPv4 header or from the IPv6
+ * NEXTHDR_FRAGMENT extension header. The latter is an expensive operation (in
+ * terms of verifier complexity and CPU cycles), so we aim to extract it once
+ * and pass the __s64 bitmask around (aliased as fraginfo_t).
+ *
+ * proto should only be used by the fragment tracker, making 0 a valid default
+ * value for a non-fragmented packet.
+ *
+ * This file contains an abstraction level over IPv4 and IPv6 fragments.
+ */
+
+typedef __s64 fraginfo_t;
+
+#define IPFRAG_BIT_FRAGMENTED (1LL << 40)
+#define IPFRAG_BIT_NO_L4_HEADER (1LL << 41)
+
+struct ipv6_frag_hdr {
+	__u8 nexthdr;
+	__u8 reserved;
+	__be16 frag_off;
+	__be32 id;
+} __packed;
+
+/* This function doesn't return errors. */
+static __always_inline fraginfo_t ipfrag_encode_ipv4(const struct iphdr *ip4)
+{
+	fraginfo_t fraginfo = (__u16)ip4->id; /* Store in network byte order. */
+
+	fraginfo |= (__u64)ip4->protocol << 32;
+
+	/* The frag_off portion of the IPv4 header consists of:
+	 *
+	 * +---+----+----+----------------------------------+
+	 * | 0 | DF | MF | ...13 bits of fragment offset... |
+	 * +---+----+----+----------------------------------+
+	 *
+	 * If "More fragments" or the offset is nonzero, then this is an IP
+	 * fragment (RFC791). If the offset is nonzero, it's not the first
+	 * fragment, therefore it doesn't have an L4 header.
+	 */
+	if (ip4->frag_off & bpf_htons(0x3fff))
+		fraginfo |= IPFRAG_BIT_FRAGMENTED;
+	if (ip4->frag_off & bpf_htons(0x1fff))
+		fraginfo |= IPFRAG_BIT_NO_L4_HEADER;
+
+	return fraginfo;
+}
+
+/* This function doesn't return errors. */
+static __always_inline fraginfo_t ipfrag_encode_ipv6(const struct ipv6_frag_hdr *exthdr)
+{
+	fraginfo_t fraginfo = (__u32)exthdr->id; /* Store in network byte order. */
+
+	fraginfo |= (__u64)exthdr->nexthdr << 32;
+
+	/* frag_off of the IPv6 fragment extension header:
+	 *
+	 * +----------------------------------+---+---+----+
+	 * | ...13 bits of fragment offset... | 0 | 0 | MF |
+	 * +----------------------------------+---+---+----+
+	 */
+	if (exthdr->frag_off & bpf_htons(0xfff9))
+		fraginfo |= IPFRAG_BIT_FRAGMENTED;
+	if (exthdr->frag_off & bpf_htons(0xfff8))
+		fraginfo |= IPFRAG_BIT_NO_L4_HEADER;
+
+	return fraginfo;
+}
+
+static __always_inline bool ipfrag_is_fragment(fraginfo_t fraginfo)
+{
+	return fraginfo & IPFRAG_BIT_FRAGMENTED;
+}
+
+static __always_inline bool ipfrag_has_l4_header(fraginfo_t fraginfo)
+{
+	return !(fraginfo & IPFRAG_BIT_NO_L4_HEADER);
+}
+
+static __always_inline __u8 ipfrag_get_protocol(fraginfo_t fraginfo)
+{
+	return (fraginfo >> 32) & 0xff;
+}
+
+/* Downcast to __be16 for IPv4. */
+static __always_inline __be32 ipfrag_get_id(fraginfo_t fraginfo)
+{
+	return (__be32)(fraginfo & 0xffffffff);
+}

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -8,6 +8,7 @@
 #include "dbg.h"
 #include "l4.h"
 #include "metrics.h"
+#include "ipfrag.h"
 
 #define IPV4_SADDR_OFF		offsetof(struct iphdr, saddr)
 #define IPV4_DADDR_OFF		offsetof(struct iphdr, daddr)
@@ -79,32 +80,6 @@ static __always_inline int ipv4_hdrlen(const struct iphdr *ip4)
 	return ip4->ihl * 4;
 }
 
-static __always_inline bool ipv4_is_fragment(const struct iphdr *ip4)
-{
-	/* The frag_off portion of the header consists of:
-	 *
-	 * +----+----+----+----------------------------------+
-	 * | RS | DF | MF | ...13 bits of fragment offset... |
-	 * +----+----+----+----------------------------------+
-	 *
-	 * If "More fragments" or the offset is nonzero, then this is an IP
-	 * fragment (RFC791).
-	 */
-	return ip4->frag_off & bpf_htons(0x3FFF);
-}
-
-static __always_inline bool ipv4_is_not_first_fragment(const struct iphdr *ip4)
-{
-	/* Ignore "More fragments" bit to catch all fragments but the first */
-	return ip4->frag_off & bpf_htons(0x1FFF);
-}
-
-/* Simply a reverse of ipv4_is_not_first_fragment to avoid double negative. */
-static __always_inline bool ipv4_has_l4_header(const struct iphdr *ip4)
-{
-	return !ipv4_is_not_first_fragment(ip4);
-}
-
 static __always_inline bool ipv4_is_in_subnet(__be32 addr,
 					      __be32 subnet, int prefixlen)
 {
@@ -129,39 +104,27 @@ ipv4_frag_get_l4ports(const struct ipv4_frag_id *frag_id,
 
 static __always_inline int
 ipv4_handle_fragmentation(struct __ctx_buff *ctx,
-			  const struct iphdr *ip4, int l4_off,
+			  const struct iphdr *ip4,
+			  fraginfo_t fraginfo,
+			  int l4_off,
 			  enum ct_dir ct_dir,
-			  struct ipv4_frag_l4ports *ports,
-			  bool *has_l4_header)
+			  struct ipv4_frag_l4ports *ports)
 {
-	bool is_fragment, not_first_fragment;
-	int ret;
-
 	struct ipv4_frag_id frag_id = {
 		.daddr = ip4->daddr,
 		.saddr = ip4->saddr,
-		.id = ip4->id,
-		.proto = ip4->protocol,
-		.pad = 0,
+		.id = (__be16)ipfrag_get_id(fraginfo),
+		.proto = ipfrag_get_protocol(fraginfo),
 	};
 
-	is_fragment = ipv4_is_fragment(ip4);
-
-	if (unlikely(is_fragment)) {
-		not_first_fragment = ipv4_is_not_first_fragment(ip4);
-		if (has_l4_header)
-			*has_l4_header = !not_first_fragment;
-
-		if (likely(not_first_fragment))
-			return ipv4_frag_get_l4ports(&frag_id, ports);
-	}
+	if (unlikely(!ipfrag_has_l4_header(fraginfo)))
+		return ipv4_frag_get_l4ports(&frag_id, ports);
 
 	/* load sport + dport into tuple */
-	ret = l4_load_ports(ctx, l4_off, (__be16 *)ports);
-	if (ret < 0)
+	if (l4_load_ports(ctx, l4_off, (__be16 *)ports) < 0)
 		return DROP_CT_INVALID_HDR;
 
-	if (unlikely(is_fragment)) {
+	if (unlikely(ipfrag_is_fragment(fraginfo))) {
 		/* First logical fragment for this datagram (not necessarily the first
 		 * we receive). Fragment has L4 header, create an entry in datagrams map.
 		 */
@@ -180,14 +143,15 @@ ipv4_handle_fragmentation(struct __ctx_buff *ctx,
 
 static __always_inline int
 ipv4_load_l4_ports(struct __ctx_buff *ctx, struct iphdr *ip4 __maybe_unused,
-		   int l4_off, enum ct_dir dir __maybe_unused,
-		   __be16 *ports, bool *has_l4_header __maybe_unused)
+		   fraginfo_t fraginfo, int l4_off, enum ct_dir dir __maybe_unused,
+		   __be16 *ports)
 {
 #ifdef ENABLE_IPV4_FRAGMENTS
-	return ipv4_handle_fragmentation(ctx, ip4, l4_off, dir,
-					 (struct ipv4_frag_l4ports *)ports,
-					 has_l4_header);
+	return ipv4_handle_fragmentation(ctx, ip4, fraginfo, l4_off, dir,
+					 (struct ipv4_frag_l4ports *)ports);
 #else
+	if (unlikely(!ipfrag_has_l4_header(fraginfo)))
+		return DROP_FRAG_NOSUPPORT;
 	if (l4_load_ports(ctx, l4_off, ports) < 0)
 		return DROP_CT_INVALID_HDR;
 #endif

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -192,5 +192,5 @@ ipv4_load_l4_ports(struct __ctx_buff *ctx, struct iphdr *ip4 __maybe_unused,
 		return DROP_CT_INVALID_HDR;
 #endif
 
-	return CTX_ACT_OK;
+	return 0;
 }

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1321,8 +1321,6 @@ static __always_inline int
 lb4_extract_tuple(struct __ctx_buff *ctx, struct iphdr *ip4, int l3_off, int *l4_off,
 		  struct ipv4_ct_tuple *tuple)
 {
-	int ret;
-
 	tuple->nexthdr = ip4->protocol;
 	tuple->daddr = ip4->daddr;
 	tuple->saddr = ip4->saddr;
@@ -1335,12 +1333,8 @@ lb4_extract_tuple(struct __ctx_buff *ctx, struct iphdr *ip4, int l3_off, int *l4
 #ifdef ENABLE_SCTP
 	case IPPROTO_SCTP:
 #endif  /* ENABLE_SCTP */
-		ret = ipv4_load_l4_ports(ctx, ip4, *l4_off, CT_EGRESS,
-					 &tuple->dport, NULL);
-
-		if (IS_ERR(ret))
-			return ret;
-		return 0;
+		return ipv4_load_l4_ports(ctx, ip4, *l4_off, CT_EGRESS,
+					  &tuple->dport, NULL);
 	case IPPROTO_ICMP:
 		return DROP_UNSUPP_SERVICE_PROTO;
 	default:

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -394,8 +394,7 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 
 apply_snat:
 	*saddr = tuple.saddr;
-	ret = snat_v4_nat(ctx, &tuple, ip4, l4_off, ipv4_has_l4_header(ip4),
-			  &target, trace, ext_err);
+	ret = snat_v4_nat(ctx, &tuple, ip4, l4_off, &target, trace, ext_err);
 	if (IS_ERR(ret))
 		goto out;
 

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -272,12 +272,12 @@ NAME(struct __ctx_buff *ctx, struct PREFIX ## _ct_tuple *tuple)		\
 	int err;							\
 									\
 	err = PREFIX ## _extract_tuple(ctx, tuple);			\
-	if (err != CTX_ACT_OK)						\
+	if (err < 0)							\
 		return err;						\
 									\
 	__ ## PREFIX ## _ct_tuple_reverse(tuple);			\
 									\
-	return CTX_ACT_OK;						\
+	return 0;							\
 }
 
 #ifdef ENABLE_IPV4

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -605,7 +605,8 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, l4_off, &target, &trace, NULL);
+	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, ipfrag_encode_ipv4(ip4),
+			  l4_off, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -723,7 +724,8 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, l4_off, &target, &trace, NULL);
+	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, ipfrag_encode_ipv4(ip4),
+			  l4_off, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -840,7 +842,8 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, l4_off, &target, &trace, NULL);
+	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, ipfrag_encode_ipv4(ip4),
+			  l4_off, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -946,7 +949,8 @@ int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, l4_off, &target, &trace, NULL);
+	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, ipfrag_encode_ipv4(ip4),
+			  l4_off, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -605,8 +605,7 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, l4_off, ipv4_has_l4_header(ip4),
-			  &target, &trace, NULL);
+	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, l4_off, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -724,8 +723,7 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, l4_off, ipv4_has_l4_header(ip4),
-			  &target, &trace, NULL);
+	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, l4_off, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -842,8 +840,7 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, l4_off, ipv4_has_l4_header(ip4),
-			  &target, &trace, NULL);
+	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, l4_off, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -949,8 +946,7 @@ int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, l4_off, ipv4_has_l4_header(ip4),
-			  &target, &trace, NULL);
+	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, l4_off, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;

--- a/bpf/tests/ipfrag.c
+++ b/bpf/tests/ipfrag.c
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+#include <node_config.h>
+
+#include <lib/ipfrag.h>
+
+PKTGEN("tc", "ipfrag_helpers_ipv4")
+int test_ipfrag_helpers_ipv4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_udp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_two,
+					  v4_node_one, v4_node_two,
+					  tcp_src_one, tcp_svc_one);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+CHECK("tc", "ipfrag_helpers_ipv4")
+int test_ipfrag_helpers_ipv4_check(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	fraginfo_t fraginfo;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	l2 = data;
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	assert(l3->frag_off == 0);
+
+	/* Non-fragmented packet */
+	fraginfo = ipfrag_encode_ipv4(l3);
+	assert(!ipfrag_is_fragment(fraginfo));
+	assert(ipfrag_has_l4_header(fraginfo));
+
+	/* First fragment */
+	l3->id = bpf_htons(0x1234);
+	l3->frag_off = bpf_htons(1 << 13); /* MF flag */
+	fraginfo = ipfrag_encode_ipv4(l3);
+	assert(ipfrag_is_fragment(fraginfo));
+	assert(ipfrag_has_l4_header(fraginfo));
+	assert(ipfrag_get_protocol(fraginfo) == IPPROTO_UDP);
+	assert((__be16)ipfrag_get_id(fraginfo) == bpf_htons(0x1234));
+
+	/* Non-first fragment */
+	l3->frag_off = bpf_htons((1 << 13) | 0x100);
+	fraginfo = ipfrag_encode_ipv4(l3);
+	assert(ipfrag_is_fragment(fraginfo));
+	assert(!ipfrag_has_l4_header(fraginfo));
+	assert(ipfrag_get_protocol(fraginfo) == IPPROTO_UDP);
+	assert((__be16)ipfrag_get_id(fraginfo) == bpf_htons(0x1234));
+
+	/* Last fragment */
+	l3->frag_off = bpf_htons(0x200);
+	fraginfo = ipfrag_encode_ipv4(l3);
+	assert(ipfrag_is_fragment(fraginfo));
+	assert(!ipfrag_has_l4_header(fraginfo));
+	assert(ipfrag_get_protocol(fraginfo) == IPPROTO_UDP);
+	assert((__be16)ipfrag_get_id(fraginfo) == bpf_htons(0x1234));
+
+	test_finish();
+}
+
+CHECK("tc", "ipfrag_helpers_ipv6")
+int test_ipfrag_helpers_ipv6_check(struct __ctx_buff *ctx __maybe_unused)
+{
+	fraginfo_t fraginfo;
+
+	test_init();
+
+	/* Stub fraginfo until parsing IPv6 extension headers is implemented. */
+
+	/* Non-fragmented packet */
+	fraginfo = 0x0000001100000000;
+	assert(!ipfrag_is_fragment(fraginfo));
+	assert(ipfrag_has_l4_header(fraginfo));
+
+	/* First fragment */
+	fraginfo = 0x0000011112345678;
+	assert(ipfrag_is_fragment(fraginfo));
+	assert(ipfrag_has_l4_header(fraginfo));
+	assert(ipfrag_get_protocol(fraginfo) == IPPROTO_UDP);
+	assert(ipfrag_get_id(fraginfo) == (__be32)(0x12345678));
+
+	/* Non-first fragment */
+	fraginfo = 0x0000031112345678;
+	assert(ipfrag_is_fragment(fraginfo));
+	assert(!ipfrag_has_l4_header(fraginfo));
+	assert(ipfrag_get_protocol(fraginfo) == IPPROTO_UDP);
+	assert(ipfrag_get_id(fraginfo) == (__be32)(0x12345678));
+
+	test_finish();
+}


### PR DESCRIPTION
This is the preparation part for https://github.com/cilium/cilium/pull/38110 (IPv6 fragments). This pull request contains only IPv4 modifications. It closes some gaps in handling fragmented packets (prevents parsing the L4 header when it's not present — in non-first fragments), and then refactors the code to move ipv4_is_fragment() and ipv4_has_l4_header() calls sprayed over the code to a single place in the beginning (well, almost: once per tailcall, and it can be improved further to persist over tailcalls). The goal of the latter is having parallel code structure with IPv6, where such queries are expensive (they require going over extension headers). A unified format is introduced to store fragment info, that works for both IPv4 and IPv6.

See individual commits for more details.

```release-note
Harden against misuse of IPv4 fragments.
```
