### PR TITLE
docs: Document jitter applied to BGP ConnectRetryTimeSeconds

### DIFF
--- a/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
@@ -206,6 +206,11 @@ recommended to set the ``HoldTimer`` and ``KeepaliveTimer`` to a lower value
 for faster possible failure detection. For example, you can set the minimum
 possible values ``holdTimeSeconds=9`` and ``keepAliveTimeSeconds=3``.
 
+To ensure a fast reconnection after losing connectivity with the peer,
+reduce the ``connectRetryTimeSeconds`` (for example to ``5`` or less).
+As random jitter is applied to the configured value internally, the actual value used for the
+``ConnectRetryTimer`` is within the interval ``[ConnectRetryTimeSeconds, 2 * ConnectRetryTimeSeconds)``.
+
 .. code-block:: yaml
 
     apiVersion: cilium.io/v2
@@ -214,7 +219,7 @@ possible values ``holdTimeSeconds=9`` and ``keepAliveTimeSeconds=3``.
       name: cilium-peer
     spec:
       timers:
-        connectRetryTimeSeconds: 12
+        connectRetryTimeSeconds: 5
         holdTimeSeconds: 9
         keepAliveTimeSeconds: 3
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -675,6 +675,7 @@ reconcilation
 reconciler
 reconcilers
 reconfigurations
+reconnection
 reconnections
 recv
 regenerations


### PR DESCRIPTION
Document random jitter applied to the configured `ConnectRetryTimeSeconds` by GoBGP.
Also recommend lowering it from the default value if fast reconnection is required.

