### PR TITLE
workflows/e2e: Cover IPv6-only

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -13,6 +13,9 @@ inputs:
   endpoint-routes:
     description: 'Enable endpoint routes'
     default: 'false'
+  ipv4:
+    description: 'Enable IPv4'
+    default: 'true'
   ipv6:
     description: 'Enable IPv6'
     default: 'true'
@@ -126,6 +129,11 @@ runs:
             ENDPOINT_ROUTES="--helm-set-string=endpointRoutes.enabled=true"
           fi
 
+          IPV4=""
+          if [ "${{ inputs.ipv4 }}" == "false" ]; then
+            IPV4="--helm-set=ipv4.enabled=false"
+          fi
+
           IPV6=""
           if [ "${{ inputs.ipv6 }}" != "false" ]; then
             IPV6="--helm-set=ipv6.enabled=true"
@@ -188,5 +196,5 @@ runs:
             BGP_CONTROL_PLANE="${{ env.BGP_CONTROL_PLANE_HELM_VALUES }}"
           fi
 
-          CONFIG="${DEFAULTS} ${IMAGE} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION} ${INGRESS_CONTROLLER} ${CILIUMENDPOINTSLICE} ${LOCAL_REDIRECT_POLICY} ${BGP_CONTROL_PLANE}"
+          CONFIG="${DEFAULTS} ${IMAGE} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV4} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION} ${INGRESS_CONTROLLER} ${CILIUMENDPOINTSLICE} ${LOCAL_REDIRECT_POLICY} ${BGP_CONTROL_PLANE}"
           echo "config=${CONFIG}" >> $GITHUB_OUTPUT

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -101,7 +101,7 @@ jobs:
       job_name: 'Setup & Test'
     strategy:
       fail-fast: false
-      max-parallel: 31
+      max-parallel: 32
       matrix:
         include:
           - name: '1'
@@ -493,6 +493,16 @@ jobs:
             egress-gateway: 'true'
             ingress-controller: 'true'
 
+          - name: '32'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: '5.15-20241107.001101'
+            kube-proxy: 'iptables'
+            kpr: 'false'
+            ipv6: 'true'
+            ipv4: 'false'
+            tunnel: 'disabled'
+            skip-upgrade: 'true'
+
           # Example of a feature that is being introduced, and we want to test
           # it without performing an upgrade, we use skip-upgrade: 'true'
           # - name: '23'
@@ -567,6 +577,7 @@ jobs:
           tunnel: ${{ matrix.tunnel }}
           devices: ${{ matrix.devices }}
           endpoint-routes: ${{ matrix.endpoint-routes }}
+          ipv4: ${{ matrix.ipv4 }}
           ipv6: ${{ matrix.ipv6 }}
           kpr: ${{ matrix.kpr }}
           lb-mode: ${{ matrix.lb-mode }}
@@ -592,6 +603,7 @@ jobs:
           tunnel: ${{ matrix.tunnel }}
           devices: ${{ matrix.devices }}
           endpoint-routes: ${{ matrix.endpoint-routes }}
+          ipv4: ${{ matrix.ipv4 }}
           ipv6: ${{ matrix.ipv6 }}
           kpr: ${{ matrix.kpr }}
           lb-mode: ${{ matrix.lb-mode }}
@@ -615,6 +627,9 @@ jobs:
           IP_FAM="dual"
           if [ "${{ matrix.ipv6 }}" == "false" ]; then
             IP_FAM="ipv4"
+          fi
+          if [ "${{ matrix.ipv4 }}" == "false" ]; then
+            IP_FAM="ipv6"
           fi
           echo params="--xdp --secondary-network \"\" 3 \"\" \"\" ${{ matrix.kube-proxy }} $IP_FAM" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -786,7 +786,7 @@ jobs:
         run: |
           TEST='--test "!seq-.*"'
           if [ "${{ matrix.ipv4 }}" == "false" ]; then
-            TEST='--test "!(seq-.*|pod-to-world.*|pod-to-cidr)"'
+            TEST='--test "!(seq-.*|pod-to-world.*|pod-to-cidr|pod-to-pod-encryption-v2)"'
           fi
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --test-concurrency=${{ env.test_concurrency }} \
@@ -867,7 +867,7 @@ jobs:
         run: |
           TEST='--test "!seq-.*"'
           if [ "${{ matrix.ipv4 }}" == "false" ]; then
-            TEST='--test "!(seq-.*|pod-to-world.*|pod-to-cidr)"'
+            TEST='--test "!(seq-.*|pod-to-world.*|pod-to-cidr|pod-to-pod-encryption-v2)"'
           fi
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --test-concurrency=${{ env.test_concurrency }} \

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -779,14 +779,18 @@ jobs:
         shell: bash
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
-            --test "seq-.*"
+            --test "seq-.*,!pod-to-world.*"
 
       - name: Run concurrent Cilium tests
         shell: bash
         run: |
+          TEST='--test "!seq-.*"'
+          if [ "${{ matrix.ipv4 }}" == "false" ]; then
+            TEST='--test "!(seq-.*|pod-to-world.*|pod-to-cidr)"'
+          fi
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --test-concurrency=${{ env.test_concurrency }} \
-            --test "!seq-.*"
+            $TEST
 
       - name: Assert that no unencrypted packets are leaked during connectivity tests after upgrade
         if: ${{ matrix.encryption != '' }}
@@ -855,15 +859,19 @@ jobs:
         shell: bash
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
-            --test "seq-.*"
+            --test "seq-.*,!pod-to-world.*"
 
       - name: Run concurrent Cilium tests
         if: ${{ matrix.skip-upgrade != 'true' }}
         shell: bash
         run: |
+          TEST='--test "!seq-.*"'
+          if [ "${{ matrix.ipv4 }}" == "false" ]; then
+            TEST='--test "!(seq-.*|pod-to-world.*|pod-to-cidr)"'
+          fi
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
             --test-concurrency=${{ env.test_concurrency }} \
-            --test "!seq-.*"
+            $TEST
 
       - name: Assert that no unencrypted packets are leaked during connectivity tests after downgrade
         if: ${{ matrix.encryption != '' }}

--- a/cilium-cli/connectivity/tests/pod.go
+++ b/cilium-cli/connectivity/tests/pod.go
@@ -326,6 +326,10 @@ func (s *podToPodMissingIPCache) Run(ctx context.Context, t *check.Test) {
 				continue
 			}
 			matches := ipcacheGetPat.FindStringSubmatch(output.String())
+			if matches == nil {
+				ct.Warnf(`failed to find IP cache entry: "%s"`, output.String())
+				continue
+			}
 			identity := matches[1]
 			encryptkey := matches[2]
 			tunnelendpoint := matches[3]


### PR DESCRIPTION
This pull request adds coverage for an IPv6-only configuration in our end-to-end upgrade workflow. IPv6-only is already covered in the IPv6 Smoke Test, but with a different configuration (ex., KPR is enabled) and a lot fewer tests executed.

The first commit adds the new test case. The second and third skip some connectivity tests for which we don't have IPv-only support yet. The last three commits fix issues in the connectivity tests.