### PR TITLE
k8s,docs: Deprecate v2alpha1 version of BGPv2 CRDs in favor of the v2 version

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -293,6 +293,10 @@ communicating via the proxy must reconnect to re-establish connections.
 1.18 Upgrade Notes
 ------------------
 * ``cilium-dbg bpf policy`` now prints ``ANY`` and not ``reserved:unknown`` for a bpf policy entry that allows any peer identity.
+* The ``v2alpha1`` version of ``CiliumBGPClusterConfig``, ``CiliumBGPPeerConfig``, ``CiliumBGPAdvertisement``, ``CiliumBGPNodeConfig`` and
+  ``CiliumBGPNodeConfigOverride`` CRDs was deprecated in favor of the ``v2`` version. Change ``apiVersion: cilium.io/v2alpha1``
+  to ``apiVersion: cilium.io/v2`` for these CRDs in all your BGP configs. The previously deprecated field
+  ``spec.transport.localPort`` in ``CiliumBGPPeerConfig`` has been removed and will be ignored if it was configured in the ``v2alpha1`` version.
 
 
 Removed Options

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -65,7 +65,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 		endpointMapDeleteFailed, etcdReconnection, epRestoreMissingState, mutationDetectorKlog,
 		hubbleFailedCreatePeer, fqdnDpUpdatesTimeout, longNetpolUpdate, failedToGetEpLabels,
 		failedCreategRPCClient, unableReallocateIngressIP, fqdnMaxIPPerHostname, failedGetMetricsAPI, envoyTLSWarning,
-		ciliumNodeConfigDeprecation, hubbleUIEnvVarFallback, k8sClientNetworkStatusError}
+		ciliumNodeConfigDeprecation, hubbleUIEnvVarFallback, k8sClientNetworkStatusError, bgpAlphaResourceDeprecation}
 	// The list is adopted from cilium/cilium/test/helper/utils.go
 	var errorMsgsWithExceptions = map[string][]logMatcher{
 		panicMessage:         nil,
@@ -383,4 +383,6 @@ var (
 	// envoyTLSWarningTemplate is the legitimate warning log for negative TLS SNI test case
 	// This is a template string as we need to replace %s for external target flag
 	envoyTLSWarningTemplate = "cilium.tls_wrapper: Could not get server TLS context for pod.*on destination IP.*port 443 sni.*%s.*and raw socket is not allowed"
+	// bgpV2alpha1ResourceDeprecation is expected when using deprecated BGP resource versions in a test, specifically when running the tests after a Cilium downgrade.
+	bgpAlphaResourceDeprecation = regexMatcher{regexp.MustCompile(`cilium.io/v2alpha1 CiliumBGP\w+ is deprecated`)}
 )

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpadvertisements.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpadvertisements.yaml
@@ -254,6 +254,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v2alpha1
     schema:
       openAPIV3Schema:

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpclusterconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpclusterconfigs.yaml
@@ -275,6 +275,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v2alpha1
     schema:
       openAPIV3Schema:

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpnodeconfigoverrides.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpnodeconfigoverrides.yaml
@@ -131,6 +131,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v2alpha1
     schema:
       openAPIV3Schema:

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpnodeconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpnodeconfigs.yaml
@@ -345,6 +345,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v2alpha1
     schema:
       openAPIV3Schema:

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgppeerconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgppeerconfigs.yaml
@@ -330,6 +330,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
     name: v2alpha1
     schema:
       openAPIV3Schema:

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_advert_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_advert_types.go
@@ -62,6 +62,7 @@ const (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories={cilium,ciliumbgp},singular="ciliumbgpadvertisement",path="ciliumbgpadvertisements",scope="Cluster",shortName={cbgpadvert}
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type=date
+// +kubebuilder:deprecatedversion
 
 // CiliumBGPAdvertisement is the Schema for the ciliumbgpadvertisements API
 type CiliumBGPAdvertisement struct {

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_cluster_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_cluster_types.go
@@ -15,6 +15,7 @@ import (
 // +kubebuilder:resource:categories={cilium,ciliumbgp},singular="ciliumbgpclusterconfig",path="ciliumbgpclusterconfigs",scope="Cluster",shortName={cbgpcluster}
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type=date
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
 
 // CiliumBGPClusterConfig is the Schema for the CiliumBGPClusterConfig API
 type CiliumBGPClusterConfig struct {

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_node_override_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_node_override_types.go
@@ -12,6 +12,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories={cilium,ciliumbgp},singular="ciliumbgpnodeconfigoverride",path="ciliumbgpnodeconfigoverrides",scope="Cluster",shortName={cbgpnodeoverride}
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type=date
+// +kubebuilder:deprecatedversion
 
 // CiliumBGPNodeConfigOverride specifies configuration overrides for a CiliumBGPNodeConfig.
 // It allows fine-tuning of BGP behavior on a per-node basis. For the override to be effective,

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_node_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_node_types.go
@@ -13,6 +13,7 @@ import (
 // +kubebuilder:resource:categories={cilium,ciliumbgp},singular="ciliumbgpnodeconfig",path="ciliumbgpnodeconfigs",scope="Cluster",shortName={cbgpnode}
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type=date
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
 
 // CiliumBGPNodeConfig is node local configuration for BGP agent. Name of the object should be node name.
 // This resource will be created by Cilium operator and is read-only for the users.

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_peer_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_peer_types.go
@@ -29,6 +29,7 @@ type CiliumBGPPeerConfigList struct {
 // +kubebuilder:resource:categories={cilium,ciliumbgp},singular="ciliumbgppeerconfig",path="ciliumbgppeerconfigs",scope="Cluster",shortName={cbgppeer}
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type=date
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion
 
 type CiliumBGPPeerConfig struct {
 	// +deepequal-gen=false


### PR DESCRIPTION
In https://github.com/cilium/cilium/pull/37765, the v2 version of `CiliumBGPClusterConfig`, `CiliumBGPPeerConfig`, `CiliumBGPAdvertisement`,  `CiliumBGPNodeConfig` and `CiliumBGPNodeConfigOverride` CRDs was introduced. 

This makes the `v2alpha1` version of the same CRDs deprecated.

```release-note
Deprecate `v2alpha1` version of `CiliumBGPClusterConfig`, `CiliumBGPPeerConfig`, `CiliumBGPAdvertisement`, `CiliumBGPNodeConfig` and `CiliumBGPNodeConfigOverride` CRDs in favor of the `v2` version
```
