### PR TITLE
cli: Reduce the flood of the terminal with logs on failure during tests

### DIFF
--- a/cilium-cli/connectivity/check/policy.go
+++ b/cilium-cli/connectivity/check/policy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium/cilium-cli/k8s"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
+	logfilter "github.com/cilium/cilium/cilium-cli/utils/log"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/scheme"
@@ -378,7 +379,13 @@ func (t *Test) ContainerLogs(ctx context.Context) {
 		if err != nil {
 			t.Fatalf("Error reading Cilium logs: %s", err)
 		}
-		t.Infof("Cilium agent %s/%s logs since %s:\n%s", pod.Pod.Namespace, pod.Pod.Name, t.startTime.String(), log)
+		t.Infof(
+			"Cilium agent %s/%s logs since %s:\n%s",
+			pod.Pod.Namespace,
+			pod.Pod.Name,
+			t.startTime.String(),
+			logfilter.Reduce(log, t.verbose),
+		)
 	}
 }
 

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -69,6 +69,7 @@ func NewTest(name string, verbose bool, debug bool) *Test {
 		clrps:       make(map[string]*ciliumv2.CiliumLocalRedirectPolicy),
 		logBuf:      &bytes.Buffer{}, // maintain internal buffer by default
 		conditionFn: nil,
+		verbose:     verbose,
 	}
 	// Setting the internal buffer to nil causes the logger to
 	// write directly to stdout in verbose or debug mode.
@@ -141,8 +142,9 @@ type Test struct {
 
 	// Buffer to store output until it's flushed by a failure.
 	// Unused when run in verbose or debug mode.
-	logMu  lock.RWMutex
-	logBuf io.ReadWriter
+	logMu   lock.RWMutex
+	logBuf  io.ReadWriter
+	verbose bool
 
 	// conditionFn is a function that returns true if the test needs to run,
 	// and false otherwise. By default, it's set to a function that returns

--- a/cilium-cli/status/k8s.go
+++ b/cilium-cli/status/k8s.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium/cilium-cli/k8s"
+	logfilter "github.com/cilium/cilium/cilium-cli/utils/log"
 	"github.com/cilium/cilium/pkg/annotation"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
@@ -451,7 +452,7 @@ func (k *K8sStatusCollector) logComponentTask(status *Status, namespace, deploym
 						if errLogCollection != nil {
 							status.CollectionError(fmt.Errorf("failed to gather logs from %s:%s:%s: %w", namespace, podName, containerName, err))
 						} else if logs != "" {
-							lastLog := k.processLogs(logs)
+							lastLog := logfilter.Reduce(logs, k.params.Verbose)
 							err = fmt.Errorf("container %s %s:\n%s", containerName, desc, lastLog)
 						}
 					}
@@ -468,54 +469,6 @@ func (k *K8sStatusCollector) logComponentTask(status *Status, namespace, deploym
 			return nil
 		},
 	}
-}
-
-func (k *K8sStatusCollector) processLogs(logs string) string {
-	logs = strings.TrimSpace(logs)
-	if k.params.Verbose {
-		return logs
-	}
-
-	// If the log is small, just print the whole thing.
-	context := 5 // lines
-	lines := strings.Split(logs, "\n")
-	if len(lines) <= context*2 {
-		return logs
-	}
-
-	// There's a few critical things in most logs:
-	// - A few of the oldest lines from initial startup
-	// - A few of the newest lines with the final error
-	// - Anything marked with warning level or higher severity
-	truncated := false
-	result := lines[:context]
-	for i := context; i < len(lines); i++ {
-		// Always keep the end of the log
-		if i >= len(lines)-context {
-			result = append(result, lines[i])
-			continue
-		}
-
-		// Keep serious-looking logs
-		switch {
-		case strings.Contains(lines[i], "level=warn"):
-			result = append(result, lines[i])
-			truncated = false
-		case strings.Contains(lines[i], "level=err"):
-			result = append(result, lines[i])
-			truncated = false
-		case strings.Contains(lines[i], "level=fatal"):
-			result = append(result, lines[i])
-			truncated = false
-		default:
-			if !truncated {
-				result = append(result, "<...>")
-				truncated = true
-			}
-		}
-	}
-
-	return strings.Join(result, "\n")
 }
 
 func (k *K8sStatusCollector) status(ctx context.Context, cancel context.CancelFunc) *Status {

--- a/cilium-cli/utils/log/log.go
+++ b/cilium-cli/utils/log/log.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package log
+
+import "strings"
+
+// Reduce function filters log messages
+// and returns only valuable data (warn, err, fatal)
+// in case of verbose all the messages will be returned
+func Reduce(logs string, verbose bool) string {
+	logs = strings.TrimSpace(logs)
+	if verbose {
+		return logs
+	}
+
+	// If the log is small, just print the whole thing.
+	context := 5 // lines
+	lines := strings.Split(logs, "\n")
+	if len(lines) <= context*2 {
+		return logs
+	}
+
+	// There's a few critical things in most logs:
+	// - A few of the oldest lines from initial startup
+	// - A few of the newest lines with the final error
+	// - Anything marked with warning level or higher severity
+	truncated := false
+	result := lines[:context]
+	for i := context; i < len(lines); i++ {
+		// Always keep the end of the log
+		if i >= len(lines)-context {
+			result = append(result, lines[i])
+			continue
+		}
+
+		// Keep serious-looking logs
+		switch {
+		case strings.Contains(lines[i], "level=warn"):
+			result = append(result, lines[i])
+			truncated = false
+		case strings.Contains(lines[i], "level=err"):
+			result = append(result, lines[i])
+			truncated = false
+		case strings.Contains(lines[i], "level=fatal"):
+			result = append(result, lines[i])
+			truncated = false
+		default:
+			if !truncated {
+				result = append(result, "<...>")
+				truncated = true
+			}
+		}
+	}
+
+	return strings.Join(result, "\n")
+}


### PR DESCRIPTION
…t setup/teardown

Return only valuable (err, warn, fatal) messages in case of verbose enabled all the messages will returned.

Fixes #38182
Based on https://github.com/cilium/cilium/pull/37160
