### PR TITLE
Make Cilium CLI performance tests not depend on Cilium 

### DIFF
--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -160,7 +160,7 @@ jobs:
             --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
             --flow-validation=disabled --hubble=false --collect-sysdump-on-failure \
             --external-target bing.com. --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8 \
-            --namespace-annotations='{\"ipam.cilium.io/ip-pool\":\"cilium-test-pool\"}' \
+            --namespace-annotations=ipam.cilium.io/ip-pool=cilium-test-pool \
             --deployment-pod-annotations='{ \
                 \"client\":{\"ipam.cilium.io/ip-pool\":\"client-pool\"}, \
                 \"echo-other-node\":{\"ipam.cilium.io/ip-pool\":\"echo-other-node-pool\"} \

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -44,6 +44,7 @@ var params = check.Parameters{
 	ExternalDeploymentPort: 8080,
 	EchoServerHostPort:     4000,
 	JunitProperties:        make(map[string]string),
+	NamespaceAnnotations:   make(map[string]string),
 	NodeSelector:           make(map[string]string),
 	Writer:                 os.Stdout,
 	SysdumpOptions: sysdump.Options{
@@ -148,9 +149,6 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.AgentPodSelector, "agent-pod-selector", defaults.AgentPodSelector, "Label on cilium-agent pods to select with")
 	cmd.Flags().StringVar(&params.CiliumPodSelector, "cilium-pod-selector", defaults.CiliumPodSelector, "Label selector matching all cilium-related pods")
 	cmd.Flags().Var(option.NewNamedMapOptions("node-selector", &params.NodeSelector, nil), "node-selector", "Restrict connectivity pods to nodes matching this label")
-	cmd.Flags().Var(&params.NamespaceAnnotations, "namespace-annotations", "Add annotations to the connectivity test namespace, e.g. '{\"foo\":\"bar\"}'")
-	cmd.Flags().MarkHidden("namespace-annotations")
-	cmd.Flags().MarkHidden("deployment-pod-annotations")
 	cmd.Flags().StringVar(&params.MultiCluster, "multi-cluster", "", "Test across clusters to given context")
 	cmd.Flags().StringSliceVar(&tests, "test", []string{}, "Run tests that match one of the given regular expressions, skip tests by starting the expression with '!', target Scenarios with e.g. '/pod-to-cidr'")
 	cmd.Flags().StringVar(&params.FlowValidation, "flow-validation", check.FlowValidationModeWarning, "Enable Hubble flow validation { disabled | warning | strict }")
@@ -288,7 +286,10 @@ func newCmdConnectivityPerf(hooks api.Hooks) *cobra.Command {
 func registerCommonFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&params.Debug, "debug", "d", false, "Show debug messages")
 	flags.StringVar(&params.TestNamespace, "test-namespace", defaults.ConnectivityCheckNamespace, "Namespace to perform the connectivity in (always suffixed with a sequence number to be compliant with test-concurrency param, e.g.: cilium-test-1)")
+	flags.Var(option.NewNamedMapOptions("namespace-annotations", &params.NamespaceAnnotations, nil), "namespace-annotations", "Add annotations to the connectivity test namespace")
+	flags.MarkHidden("namespace-annotations")
 	flags.Var(&params.DeploymentAnnotations, "deployment-pod-annotations", "Add annotations to the connectivity pods, e.g. '{\"client\":{\"foo\":\"bar\"}}'")
+	flags.MarkHidden("deployment-pod-annotations")
 	flags.BoolVar(&params.PrintImageArtifacts, "print-image-artifacts", false, "Prints the used image artifacts")
 }
 

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -44,6 +44,7 @@ var params = check.Parameters{
 	ExternalDeploymentPort: 8080,
 	EchoServerHostPort:     4000,
 	JunitProperties:        make(map[string]string),
+	NamespaceLabels:        make(map[string]string),
 	NamespaceAnnotations:   make(map[string]string),
 	NodeSelector:           make(map[string]string),
 	Writer:                 os.Stdout,
@@ -286,6 +287,7 @@ func newCmdConnectivityPerf(hooks api.Hooks) *cobra.Command {
 func registerCommonFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&params.Debug, "debug", "d", false, "Show debug messages")
 	flags.StringVar(&params.TestNamespace, "test-namespace", defaults.ConnectivityCheckNamespace, "Namespace to perform the connectivity in (always suffixed with a sequence number to be compliant with test-concurrency param, e.g.: cilium-test-1)")
+	flags.Var(option.NewNamedMapOptions("namespace-labels", &params.NamespaceLabels, nil), "namespace-labels", "Add labels to the connectivity test namespace")
 	flags.Var(option.NewNamedMapOptions("namespace-annotations", &params.NamespaceAnnotations, nil), "namespace-annotations", "Add annotations to the connectivity test namespace")
 	flags.MarkHidden("namespace-annotations")
 	flags.Var(&params.DeploymentAnnotations, "deployment-pod-annotations", "Add annotations to the connectivity pods, e.g. '{\"client\":{\"foo\":\"bar\"}}'")

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -94,7 +94,7 @@ type Parameters struct {
 	CiliumPodSelector      string
 	NodeSelector           map[string]string
 	DeploymentAnnotations  annotationsMap
-	NamespaceAnnotations   annotations
+	NamespaceAnnotations   map[string]string
 	ExternalTarget         string
 	ExternalOtherTarget    string
 	ExternalCIDR           string

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -94,6 +94,7 @@ type Parameters struct {
 	CiliumPodSelector      string
 	NodeSelector           map[string]string
 	DeploymentAnnotations  annotationsMap
+	NamespaceLabels        map[string]string
 	NamespaceAnnotations   map[string]string
 	ExternalTarget         string
 	ExternalOtherTarget    string

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -303,6 +303,21 @@ func (ct *ConnectivityTest) SetupAndValidate(ctx context.Context, extra SetupHoo
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+
+	setupAndValidate := ct.setupAndValidate
+	if ct.Params().Perf {
+		setupAndValidate = ct.setupAndValidatePerf
+	}
+
+	if err := setupAndValidate(ctx, extra); err != nil {
+		return err
+	}
+
+	// Setup and validate all the extras coming from extended functionalities.
+	return extra.SetupAndValidate(ctx, ct)
+}
+
+func (ct *ConnectivityTest) setupAndValidate(ctx context.Context, extra SetupHooks) error {
 	if err := ct.detectSingleNode(ctx); err != nil {
 		return err
 	}
@@ -375,8 +390,23 @@ func (ct *ConnectivityTest) SetupAndValidate(ctx context.Context, extra SetupHoo
 		}
 	}
 
-	// Setup and validate all the extras coming from extended functionalities.
-	return extra.SetupAndValidate(ctx, ct)
+	return nil
+}
+
+func (ct *ConnectivityTest) setupAndValidatePerf(ctx context.Context, _ SetupHooks) error {
+	if err := ct.initClients(ctx); err != nil {
+		return err
+	}
+
+	if err := ct.deployPerf(ctx); err != nil {
+		return err
+	}
+
+	if err := ct.validateDeploymentPerf(ctx); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // PrintTestInfo prints connectivity test names and count.

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -561,12 +561,12 @@ func (ct *ConnectivityTest) report() error {
 			}
 		}
 		ct.Logf("%s", strings.Repeat("-", 200))
-		ct.Logf("%s", strings.Repeat("-", 85))
-		ct.Logf("📋 %-15s | %-10s | %-15s | %-15s | %-15s ", "Scenario", "Node", "Test", "Duration", "Throughput Mb/s")
-		ct.Logf("%s", strings.Repeat("-", 85))
+		ct.Logf("%s", strings.Repeat("-", 88))
+		ct.Logf("📋 %-15s | %-10s | %-18s | %-15s | %-15s ", "Scenario", "Node", "Test", "Duration", "Throughput Mb/s")
+		ct.Logf("%s", strings.Repeat("-", 88))
 		for _, result := range ct.PerfResults {
 			if result.Result.ThroughputMetric != nil {
-				ct.Logf("📋 %-15s | %-10s | %-15s | %-15s | %-12.2f ",
+				ct.Logf("📋 %-15s | %-10s | %-18s | %-15s | %-12.2f ",
 					result.PerfTest.Scenario,
 					nodeString(result.PerfTest.SameNode),
 					result.PerfTest.Test,
@@ -575,7 +575,7 @@ func (ct *ConnectivityTest) report() error {
 				)
 			}
 		}
-		ct.Logf("%s", strings.Repeat("-", 85))
+		ct.Logf("%s", strings.Repeat("-", 88))
 		if ct.Params().PerfParameters.ReportDir != "" {
 			common.ExportPerfSummaries(ct.PerfResults, ct.Params().PerfParameters.ReportDir)
 		}

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -539,7 +539,7 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        ct.params.TestNamespace,
 					Annotations: ct.params.NamespaceAnnotations,
-					Labels:      appLabels,
+					Labels:      labels.Merge(ct.params.NamespaceLabels, appLabels),
 				},
 			}
 			_, err = client.CreateNamespace(ctx, namespace, metav1.CreateOptions{})

--- a/cilium-cli/connectivity/check/features.go
+++ b/cilium-cli/connectivity/check/features.go
@@ -330,7 +330,7 @@ func (ct *ConnectivityTest) detectFeatures(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		features.ExtractFromNodes(ct.params.Perf, ct.nodesWithoutCilium)
+		features.ExtractFromNodes(ct.nodesWithoutCilium)
 		err = ct.extractFeaturesFromCiliumStatus(ctx, ciliumPod, features)
 		if err != nil {
 			return err

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -407,9 +407,9 @@ func (fs Set) ExtractFromConfigMap(cm *v1.ConfigMap) {
 	}
 }
 
-func (fs Set) ExtractFromNodes(perf bool, nodesWithoutCilium map[string]struct{}) {
+func (fs Set) ExtractFromNodes(nodesWithoutCilium map[string]struct{}) {
 	fs[NodeWithoutCilium] = Status{
-		Enabled: !perf && len(nodesWithoutCilium) != 0,
+		Enabled: len(nodesWithoutCilium) != 0,
 		Mode:    strings.Join(slices.Collect(maps.Keys(nodesWithoutCilium)), ","),
 	}
 }


### PR DESCRIPTION
Generalize the performance tests initialization phase to not require Cilium to be running on the target cluster to simplify reuse, given that the measurements are not Cilium specific. Additionally, let's improve configurability of test namespace labels and annotations.