### PR TITLE
feat: Support IPv6 for delegated IPAM

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1325,10 +1325,12 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 		if (option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure) &&
 			len(option.Config.IPv4PodSubnets) == 0 {
 			if info := node.GetRouterInfo(); info != nil {
-				ipv4CIDRs := info.GetIPv4CIDRs()
-				ipv4PodSubnets := make([]*cidr.CIDR, 0, len(ipv4CIDRs))
-				for _, c := range ipv4CIDRs {
-					ipv4PodSubnets = append(ipv4PodSubnets, cidr.NewCIDR(&c))
+				cidrs := info.GetCIDRs()
+				var ipv4PodSubnets []*cidr.CIDR
+				for _, c := range cidrs {
+					if c.IP.To4() != nil {
+						ipv4PodSubnets = append(ipv4PodSubnets, cidr.NewCIDR(&c))
+					}
 				}
 				n.nodeConfig.IPv4PodSubnets = ipv4PodSubnets
 			}

--- a/pkg/datapath/linux/routing/info_test.go
+++ b/pkg/datapath/linux/routing/info_test.go
@@ -104,8 +104,8 @@ func TestParse(t *testing.T) {
 			macAddr:  "11:22:33:44:55:66",
 			ifaceNum: "1",
 			wantRInfo: &RoutingInfo{
-				IPv4Gateway:     net.ParseIP("192.168.1.1"),
-				IPv4CIDRs:       validCIDRs,
+				Gateway:         net.ParseIP("192.168.1.1"),
+				CIDRs:           validCIDRs,
 				MasterIfMAC:     fakeMAC,
 				InterfaceNumber: 1,
 				IpamMode:        ipamOption.IPAMENI,
@@ -120,8 +120,8 @@ func TestParse(t *testing.T) {
 			masq:     false,
 			ifaceNum: "0",
 			wantRInfo: &RoutingInfo{
-				IPv4Gateway: net.ParseIP("192.168.1.1"),
-				IPv4CIDRs:   []net.IPNet{},
+				Gateway:     net.ParseIP("192.168.1.1"),
+				CIDRs:       []net.IPNet{},
 				MasterIfMAC: fakeMAC,
 				IpamMode:    ipamOption.IPAMENI,
 			},

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -70,8 +70,7 @@ func TestConfigureRouteWithIncompatibleIP(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
 	_, ri := getFakes(t, true, false)
-	ipv6 := netip.MustParseAddr("fd00::2").AsSlice()
-	err := ri.Configure(ipv6, 1500, false, false)
+	err := ri.Configure(nil, 1500, false, false)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "IP not compatible")
 }
@@ -79,8 +78,8 @@ func TestConfigureRouteWithIncompatibleIP(t *testing.T) {
 func TestDeleteRouteWithIncompatibleIP(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
-	ipv6 := netip.MustParseAddr("fd00::2")
-	err := Delete(ipv6, false)
+	ip := netip.Addr{}
+	err := Delete(ip, false)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "IP not compatible")
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2549,8 +2549,16 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 		// ingress rule and multiple egress rules. If we find more rules than
 		// expected, then the rules will be left as-is because there was
 		// likely manual intervention.
-		if err := linuxrouting.Delete(e.IPv4, option.Config.EgressMultiHomeIPRuleCompat); err != nil {
-			errs = append(errs, fmt.Errorf("unable to delete endpoint routing rules: %w", err))
+		if e.IPv4.IsValid() {
+			if err := linuxrouting.Delete(e.IPv4, option.Config.EgressMultiHomeIPRuleCompat); err != nil {
+				errs = append(errs, fmt.Errorf("unable to delete endpoint routing rules: %w", err))
+			}
+		}
+
+		if e.IPv6.IsValid() {
+			if err := linuxrouting.Delete(e.IPv6, option.Config.EgressMultiHomeIPRuleCompat); err != nil {
+				errs = append(errs, fmt.Errorf("unable to delete endpoint routing rules: %w", err))
+			}
 		}
 	}
 

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -58,7 +58,7 @@ type addresses struct {
 }
 
 type RouterInfo interface {
-	GetIPv4CIDRs() []net.IPNet
+	GetCIDRs() []net.IPNet
 }
 
 func makeIPv6HostIP() net.IP {

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -216,36 +216,49 @@ func allocateIPsWithDelegatedPlugin(
 	// https://github.com/containernetworking/cni/pull/1137
 	masterMac := ""
 	for _, iface := range ipamResult.Interfaces {
-		if iface.Sandbox == "" && iface.Name != "" {
+		if iface.Sandbox != "" {
+			continue
+		}
+
+		if iface.Mac != "" {
+			if ifMac, err := net.ParseMAC(iface.Mac); err != nil {
+				return nil, releaseFunc, fmt.Errorf("failed to parse interface MAC %q: %w", iface.Mac, err)
+			} else {
+				masterMac = ifMac.String()
+			}
+		} else if iface.Name != "" {
 			if uplink, err := safenetlink.LinkByName(iface.Name); err != nil {
 				return nil, releaseFunc, fmt.Errorf("failed to get uplink %q: %w", iface.Name, err)
 			} else {
 				masterMac = uplink.Attrs().HardwareAddr.String()
 			}
-			break
 		}
+		break
 	}
 	// Interface number could not be determined from IPAM result for now.
 	// Set a static value zero before we have a proper solution.
 	// option.Config.EgressMultiHomeIPRuleCompat also needs to be set to true.
 	for _, ipConfig := range ipamResult.IPs {
 		ipNet := ipConfig.Address
-		if ipv4 := ipNet.IP.To4(); ipv4 != nil {
-			ipam.Address.IPV4 = ipNet.String()
-			ipam.IPV4 = &models.IPAMAddressResponse{
-				IP:              ipv4.String(),
-				Gateway:         ipConfig.Gateway.String(),
-				MasterMac:       masterMac,
-				InterfaceNumber: "0",
+		if ipNet.IP.To4() != nil {
+			if conf.Addressing.IPV4 != nil {
+				ipam.Address.IPV4 = ipNet.String()
+				ipam.IPV4 = &models.IPAMAddressResponse{
+					IP:              ipNet.IP.String(),
+					Gateway:         ipConfig.Gateway.String(),
+					MasterMac:       masterMac,
+					InterfaceNumber: "0",
+				}
 			}
-		} else if conf.Addressing.IPV6 != nil {
-			// assign ipam ipv6 address only if agent ipv6 config is enabled
-			ipam.Address.IPV6 = ipNet.String()
-			ipam.IPV6 = &models.IPAMAddressResponse{
-				IP:              ipNet.IP.String(),
-				Gateway:         ipConfig.Gateway.String(),
-				MasterMac:       masterMac,
-				InterfaceNumber: "0",
+		} else {
+			if conf.Addressing.IPV6 != nil {
+				ipam.Address.IPV6 = ipNet.String()
+				ipam.IPV6 = &models.IPAMAddressResponse{
+					IP:              ipNet.IP.String(),
+					Gateway:         ipConfig.Gateway.String(),
+					MasterMac:       masterMac,
+					InterfaceNumber: "0",
+				}
 			}
 		}
 	}
@@ -654,21 +667,22 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 		}
 
 		var (
-			ipConfig *cniTypesV1.IPConfig
-			routes   []*cniTypes.Route
+			ipConfig   *cniTypesV1.IPConfig
+			ipv6Config *cniTypesV1.IPConfig
+			routes     []*cniTypes.Route
 		)
 		if ipv6IsEnabled(ipam) && conf.Addressing.IPV6 != nil {
 			ep.Addressing.IPV6 = ipam.Address.IPV6
 			ep.Addressing.IPV6PoolName = ipam.Address.IPV6PoolName
 			ep.Addressing.IPV6ExpirationUUID = ipam.IPV6.ExpirationUUID
 
-			ipConfig, routes, err = prepareIP(ep.Addressing.IPV6, state, int(conf.RouteMTU))
+			ipv6Config, routes, err = prepareIP(ep.Addressing.IPV6, state, int(conf.RouteMTU))
 			if err != nil {
 				return fmt.Errorf("unable to prepare IP addressing for %s: %w", ep.Addressing.IPV6, err)
 			}
 			// set the addresses interface index to that of the container-side interface
-			ipConfig.Interface = cniTypesV1.Int(len(res.Interfaces))
-			res.IPs = append(res.IPs, ipConfig)
+			ipv6Config.Interface = cniTypesV1.Int(len(res.Interfaces))
+			res.IPs = append(res.IPs, ipv6Config)
 			res.Routes = append(res.Routes, routes...)
 		}
 
@@ -688,9 +702,18 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 		}
 
 		if needsEndpointRoutingOnHost(conf) {
-			err = interfaceAdd(ipConfig, ipam.IPV4, conf)
-			if err != nil {
-				return fmt.Errorf("unable to setup interface datapath: %w", err)
+			if ipam.IPV4 != nil && ipConfig != nil {
+				err = interfaceAdd(ipConfig, ipam.IPV4, conf)
+				if err != nil {
+					return fmt.Errorf("unable to setup interface datapath: %w", err)
+				}
+			}
+
+			if ipam.IPV6 != nil && ipv6Config != nil {
+				err = interfaceAdd(ipv6Config, ipam.IPV6, conf)
+				if err != nil {
+					return fmt.Errorf("unable to setup interface datapath: %w", err)
+				}
 			}
 		}
 


### PR DESCRIPTION
For the scenario where there are multiple interfaces on a Node and delegated IPAM is used to determine the IP and the uplink interface of a Pod. The "interfaces" field can be used by IPAM plugin to pass uplink interface info to Cilium. And then Cilium can setup host routes for the Pod according to the uplink interface info.

The "interfaces" field is allowed to specify the related host interface according to the CNI spec and is already widely used by existing plugins, such as bridge and ptp plugin. It's actually not used by any IPAM plugin for now, but it's reasonable and conforms to the original definition of the field.

Motivations/Benefits of the PR for the native routing mode:

More cloud(public or private) envs with multiple uplink can be easily ingregrated with Cilium without involving any cloud specific logic. A common way is provided for the case: "uplink interface" support.
Cilium keeps full control of the Pod traffic. Cilium choose the implement of the "routing" for egress traffic, through Linux routes or eBPF forwarding rules or any other methods.

The IPv4 support for this was done as part of this PR https://github.com/cilium/cilium/pull/34779

This PR is for IPv6 support

These changes were initially authored by @caorui-io as part of this PR https://github.com/cilium/cilium/pull/36656 but had been inactive for a couple of months.

```release-note
Support IPv6 for delegated IPAM
```