### PR TITLE
CODEOWNERS: polish sig-datapath related entries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -491,7 +491,6 @@ Makefile* @cilium/build
 /pkg/azure/ @cilium/azure
 /pkg/backoff/ @cilium/sig-agent
 /pkg/bufuuid/ @cilium/sig-scalability
-/pkg/datapath/linux/bandwidth/ @cilium/sig-datapath
 /pkg/bgpv1/ @cilium/sig-bgp
 /pkg/bpf/ @cilium/loader
 /pkg/byteorder/ @cilium/sig-datapath @cilium/api
@@ -517,6 +516,8 @@ Makefile* @cilium/build
 /pkg/crypto/certloader @cilium/sig-hubble
 /pkg/datapath/ @cilium/sig-datapath
 /pkg/datapath/fake/ipsec.go @cilium/ipsec
+/pkg/datapath/ipcache/ @cilium/ipcache
+/pkg/datapath/linux/bandwidth/ @cilium/sig-datapath
 /pkg/datapath/linux/config/ @cilium/loader
 /pkg/datapath/linux/ipsec/ @cilium/ipsec
 /pkg/datapath/linux/ipsec/xfrm_collector* @cilium/ipsec @cilium/metrics
@@ -525,10 +526,9 @@ Makefile* @cilium/build
 /pkg/datapath/linux/probes/ @cilium/loader
 /pkg/datapath/linux/requirements.go @cilium/loader
 /pkg/datapath/linux/sysctl/ @cilium/sig-datapath
+/pkg/datapath/loader/ @cilium/loader
 /pkg/datapath/types/ipsec.go @cilium/ipsec
 /pkg/datapath/types/loader.go @cilium/loader
-/pkg/datapath/loader/ @cilium/loader
-/pkg/datapath/ipcache/ @cilium/ipcache
 /pkg/defaults @cilium/sig-agent
 /pkg/debug @cilium/sig-agent
 /pkg/dial @cilium/sig-agent

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -272,20 +272,20 @@
 /api/v1/peer/ @cilium/sig-hubble-api
 /api/v1/recorder/ @cilium/sig-hubble-api
 /api/v1/relay/ @cilium/sig-hubble-api
-/bpf/ @cilium/sig-datapath
-/bpf/lib/egress_gateway.h @cilium/egress-gateway
 Makefile* @cilium/build
-/bpf/Makefile* @cilium/loader
-/bpf/custom/Makefile* @cilium/build @cilium/loader
-/bpf/lib/auth.h @cilium/sig-datapath @cilium/sig-servicemesh
-/bpf/lib/encrypt.h @cilium/ipsec
-/bpf/lib/policy.h @cilium/sig-datapath @cilium/sig-policy
-/bpf/lib/wireguard.h @cilium/wireguard @cilium/sig-datapath
+/bpf/ @cilium/sig-datapath
 /bpf/bpf_wireguard.c @cilium/wireguard @cilium/sig-datapath
-/bpf/lib/ids.h @cilium/loader
-/bpf/lib/proxy.h @cilium/proxy @cilium/sig-datapath
+/bpf/custom/Makefile* @cilium/build @cilium/loader
 /bpf/include/bpf/tailcall.h @cilium/loader
 /bpf/include/bpf/config @cilium/loader
+/bpf/lib/auth.h @cilium/sig-datapath @cilium/sig-servicemesh
+/bpf/lib/egress_gateway.h @cilium/egress-gateway
+/bpf/lib/encrypt.h @cilium/ipsec
+/bpf/lib/ids.h @cilium/loader
+/bpf/lib/policy.h @cilium/sig-datapath @cilium/sig-policy
+/bpf/lib/proxy.h @cilium/proxy @cilium/sig-datapath
+/bpf/lib/wireguard.h @cilium/wireguard @cilium/sig-datapath
+/bpf/Makefile* @cilium/loader
 /bugtool/ @cilium/cli
 /cilium-dbg/ @cilium/cli
 /cilium-dbg/cmd/encrypt* @cilium/ipsec @cilium/cli

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -517,15 +517,12 @@ Makefile* @cilium/build
 /pkg/datapath/ @cilium/sig-datapath
 /pkg/datapath/fake/ipsec.go @cilium/ipsec
 /pkg/datapath/ipcache/ @cilium/ipcache
-/pkg/datapath/linux/bandwidth/ @cilium/sig-datapath
 /pkg/datapath/linux/config/ @cilium/loader
 /pkg/datapath/linux/ipsec/ @cilium/ipsec
 /pkg/datapath/linux/ipsec/xfrm_collector* @cilium/ipsec @cilium/metrics
 /pkg/datapath/linux/ipsec.go @cilium/ipsec
-/pkg/datapath/linux/node.go @cilium/sig-datapath
 /pkg/datapath/linux/probes/ @cilium/loader
 /pkg/datapath/linux/requirements.go @cilium/loader
-/pkg/datapath/linux/sysctl/ @cilium/sig-datapath
 /pkg/datapath/loader/ @cilium/loader
 /pkg/datapath/types/ipsec.go @cilium/ipsec
 /pkg/datapath/types/loader.go @cilium/loader

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -642,7 +642,6 @@ Makefile* @cilium/build
 # Service handling tests
 /test/k8s/services.go @cilium/sig-lb @cilium/ci-structure
 # Datapath tests
-/bpf/tests/bpftest/ @cilium/sig-datapath
 /test/k8s/bandwidth.go @cilium/sig-datapath @cilium/ci-structure
 /test/k8s/chaos.go @cilium/sig-datapath @cilium/ci-structure
 /test/k8s/datapath_configuration.go @cilium/sig-datapath @cilium/ci-structure


### PR DESCRIPTION
Bring more order into the sig-datapath related entries, and remove a few redundant entries.