### PR TITLE
node/manager: explicitly define daemon statedir in test

### DIFF
--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -879,7 +879,9 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 	}
 
 	ipcacheMock := newIPcacheMock()
-	config := &option.DaemonConfig{}
+	config := &option.DaemonConfig{
+		StateDir: t.TempDir(),
+	}
 	hive := hive.New(
 		cell.Provide(func() testParams {
 			return testParams{


### PR DESCRIPTION
Currently, executing the Go tests locally leaves the file `pkg/node/manager/nodes.json` behind.

The reason is that the nodemanager in package `pkg/node/manager` generates this file into the daemon statedir.

To prevent having unnecessary changes in the workdir after executing the tests, this commit is setting the statedir explicitly to a tempdir while setting up the test.

cc @dylandreimerink 

Fixes: https://github.com/cilium/cilium/pull/37310