### PR TITLE
.github/renovate: do not update LVH images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -177,6 +177,16 @@
       ]
     },
     {
+      // Disabling updating quay.io/lvh-images/kind until issue https://github.com/cilium/cilium/issues/38058 is fixed.
+      "matchDepNames": [
+        "quay.io/lvh-images/kind",
+      ],
+      "paths": [
+        ".github/actions/ginkgo/main-k8s-versions.yaml",
+      ],
+      "enabled": false
+    },
+    {
       // Avoid updating patch releases of golang in go.mod
       "enabled": "false",
       "matchFiles": [


### PR DESCRIPTION
Skip updating LVH images until the regression [1] is fixed.

[1] https://github.com/cilium/cilium/issues/38058