### PR TITLE
clustermesh: fix mcs-api conflict count

### DIFF
--- a/pkg/clustermesh/mcsapi/serviceimport_controller.go
+++ b/pkg/clustermesh/mcsapi/serviceimport_controller.go
@@ -321,8 +321,10 @@ func checkConflictExport(orderedSvcExports []*mcsapitypes.MCSAPIServiceSpec) str
 			}
 
 			conflictCount := 1
-			if i+1 < len(orderedSvcExports) {
-				for _, otherSvcExport := range orderedSvcExports[i+1:] {
+			// The iterator "i" ranges from the second element in the array which means
+			// we have to look for i+2 to process the next element
+			if i+2 < len(orderedSvcExports) {
+				for _, otherSvcExport := range orderedSvcExports[i+2:] {
 					if !fieldStruct.equalFunc(orderedSvcExports[0], otherSvcExport) {
 						conflictCount += 1
 					}

--- a/pkg/clustermesh/mcsapi/serviceimport_controller_test.go
+++ b/pkg/clustermesh/mcsapi/serviceimport_controller_test.go
@@ -839,6 +839,7 @@ func Test_mcsServiceImport_Reconcile(t *testing.T) {
 		name                 string
 		remoteSvcImportValid func(*mcsapiv1alpha1.ServiceImport) bool
 		localSvcImportValid  func(*mcsapiv1alpha1.ServiceImport) bool
+		assertMsgInclude     string
 	}{
 		{
 			name: "conflict-type",
@@ -848,6 +849,7 @@ func Test_mcsServiceImport_Reconcile(t *testing.T) {
 			localSvcImportValid: func(svcImport *mcsapiv1alpha1.ServiceImport) bool {
 				return svcImport.Spec.Type == mcsapiv1alpha1.ClusterSetIP
 			},
+			assertMsgInclude: "1/2 clusters disagree",
 		},
 		{
 			name: "conflict-port-name",
@@ -949,6 +951,12 @@ func Test_mcsServiceImport_Reconcile(t *testing.T) {
 			require.True(t, meta.IsStatusConditionFalse(svcExport.Status.Conditions, conditionTypeReady))
 			require.True(t, meta.IsStatusConditionTrue(svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportValid))
 			require.True(t, meta.IsStatusConditionTrue(svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportConflict))
+
+			if conflictTest.assertMsgInclude != "" {
+				condition := meta.FindStatusCondition(svcExport.Status.Conditions, mcsapiv1alpha1.ServiceExportConflict)
+				require.NotNil(t, condition)
+				require.Contains(t, condition.Message, conflictTest.assertMsgInclude)
+			}
 		})
 	}
 


### PR DESCRIPTION

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

The first iterator starts at the second element which means that we should add 1 to the `i` variable to get the real index of the array.

The loop we are updating int this commit was supposed to count all the next elements in the array but instead was starting with the current element which means we will always have one more "cluster disagreeing" than what we actually have.


```release-note
clustermesh: fix mcs-api count of clusters disagreeing with a conflict (the count was previously increased by one)
```
