### PR TITLE
cilium-cli: add test owners as part of junit files

### DIFF
--- a/cilium-cli/connectivity/check/junit.go
+++ b/cilium-cli/connectivity/check/junit.go
@@ -5,11 +5,14 @@ package check
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/internal/junit"
 )
+
+const MetadataDelimiter = ";metadata;"
 
 // NewJUnitCollector factory function that returns JUnitCollector.
 func NewJUnitCollector(junitProperties map[string]string, junitFile string) *JUnitCollector {
@@ -68,7 +71,8 @@ func (j *JUnitCollector) Collect(ct *ConnectivityTest) {
 			j.testSuite.Failures++
 			msgs := []string{}
 			for _, a := range t.failedActions() {
-				msgs = append(msgs, a.String())
+				owners := ct.GetOwners(a.Scenario())
+				msgs = append(msgs, fmt.Sprintf("%s%sOwners: %s", a, MetadataDelimiter, strings.Join(owners, ", ")))
 			}
 			test.Failure.Value = strings.Join(msgs, "\n")
 		}


### PR DESCRIPTION
As we are retrieving the junit files into OpenSearch so that we can have analytics for our CI, we should also add the test owners every time a test fails. This will allow to filter test failures by ownership.