### PR TITLE
Documentation: fix mentions of per-node `cilium-dbg` tool

### DIFF
--- a/Documentation/gettingstarted/demo.rst
+++ b/Documentation/gettingstarted/demo.rst
@@ -308,7 +308,7 @@ You can observe the L7 policy via ``kubectl``:
               Path:    /v1/request-landing
     Events:            <none>
 
-and ``cilium`` CLI:
+and ``cilium-dbg`` CLI:
 
 .. code-block:: shell-session
 

--- a/Documentation/overview/component-overview.rst
+++ b/Documentation/overview/component-overview.rst
@@ -31,19 +31,19 @@ Agent
   manages the eBPF programs which the Linux kernel uses to control all network
   access in / out of those containers.
 
-Client (CLI)
-  The Cilium CLI client (``cilium``) is a command-line tool that is installed
-  along with the Cilium agent. It interacts with the REST API of the Cilium
-  agent running on the same node. The CLI allows inspecting the state and
-  status of the local agent. It also provides tooling to directly access the
-  eBPF maps to validate their state.
+Debug Client (CLI)
+  The Cilium debug CLI client (``cilium-dbg``) is a command-line tool that is
+  installed along with the Cilium agent. It interacts with the REST API of the
+  Cilium agent running on the same node. The debug CLI allows inspecting the
+  state and status of the local agent. It also provides tooling to directly
+  access the eBPF maps to validate their state.
 
   .. note::
 
-     The in-agent Cilium CLI client described here should not be confused with
-     the `command line tool for quick-installing, managing and troubleshooting
-     Cilium on Kubernetes clusters <https://github.com/cilium/cilium-cli>`_,
-     which also has the name ``cilium``. That tool is typically installed
+     The in-agent Cilium debug CLI client described here should not be confused
+     with the ```cilium`` command line tool for quick-installing, managing and
+     troubleshooting Cilium on Kubernetes clusters
+     <https://github.com/cilium/cilium-cli>`_. That tool is typically installed
      remote from the cluster, and uses ``kubeconfig`` information to access
      Cilium running on the cluster via the Kubernetes API.
 

--- a/Documentation/security/gsg_sw_demo.rst
+++ b/Documentation/security/gsg_sw_demo.rst
@@ -42,9 +42,9 @@ point the pod is ready.
     service/deathstar    ClusterIP   10.96.110.8   <none>        80/TCP    107s
     service/kubernetes   ClusterIP   10.96.0.1     <none>        443/TCP   3m53s
 
-Each pod will be represented in Cilium as an :ref:`endpoint` in the local cilium agent. 
-We can invoke the ``cilium`` tool inside the Cilium pod to list them (in a single-node installation
-``kubectl -n kube-system exec ds/cilium -- cilium-dbg endpoint list`` lists them all, but in a 
+Each pod will be represented in Cilium as an :ref:`endpoint` in the local cilium agent.
+We can invoke the ``cilium-dbg`` tool inside the Cilium pod to list them (in a single-node installation
+``kubectl -n kube-system exec ds/cilium -- cilium-dbg endpoint list`` lists them all, but in a
 multi-node installation, only the ones running on the same node will be listed):
 
 .. code-block:: shell-session

--- a/Documentation/security/policy-creation.rst
+++ b/Documentation/security/policy-creation.rst
@@ -77,7 +77,7 @@ This approach is meant to be temporary.  **Restarting Cilium pod will reset the 
 Mode to match the daemon's configuration.**
 
 Policy Audit Mode is enabled for a given endpoint by modifying the endpoint configuration via
-the ``cilium`` tool on the endpoint's Kubernetes node. The steps include:
+the ``cilium-dbg`` tool on the endpoint's Kubernetes node. The steps include:
 
 #. Determine the endpoint id on which Policy Audit Mode will be enabled.
 #. Identify the Cilium pod running on the same Kubernetes node corresponding to the endpoint.


### PR DESCRIPTION
The per-node `cilium` tool was renamed to `cilium-dbg` in commit 4deff3cd65c5 ("cilium: Rename local CLI to cilium-dbg") and the code base was changed to use the new name in successive commits for Cilium release v1.15.

Some places in documentation still reference the `cilium-dbg` CLI tool by its old name in free text (the respective example commands were change to the new name already). Adjust these as well and also slightly rephrase the description of the per-node `cilium-dbg` and the out-of-cluster `cilium` tools in the component overview page.