### PR TITLE
experimental: Implement support for topology-aware routing

### DIFF
--- a/pkg/loadbalancer/experimental/adapters.go
+++ b/pkg/loadbalancer/experimental/adapters.go
@@ -260,7 +260,6 @@ func clusterServiceToBackendParams(service *store.ClusterService) (beps []Backen
 				PortNames: portNames,
 				Weight:    0,
 				NodeName:  "",
-				ZoneID:    0,
 				State:     loadbalancer.BackendStateActive,
 			}
 			beps = append(beps, bep)
@@ -542,7 +541,7 @@ func (s *serviceManagerAdapter) GetDeepCopyServices() (svcs []*loadbalancer.SVC)
 				ID:         0,
 				Weight:     be.Weight,
 				NodeName:   be.NodeName,
-				ZoneID:     be.ZoneID,
+				ZoneID:     option.Config.GetZoneID(be.Zone),
 				L3n4Addr:   be.Address,
 				State:      be.State,
 				Preferred:  true,

--- a/pkg/loadbalancer/experimental/backend.go
+++ b/pkg/loadbalancer/experimental/backend.go
@@ -38,7 +38,10 @@ type BackendParams struct {
 	NodeName string
 
 	// Zone where backend is located.
-	ZoneID uint8
+	Zone string
+
+	// ForZones where this backend should be consumed in
+	ForZones []string
 
 	// Source of the backend.
 	Source source.Source

--- a/pkg/loadbalancer/experimental/benchmark/benchmark.go
+++ b/pkg/loadbalancer/experimental/benchmark/benchmark.go
@@ -73,6 +73,7 @@ func RunBenchmark(testSize int, iterations int, loglevel slog.Level, validate bo
 			Log:    log,
 			Pinned: false,
 			Cfg: experimental.ExternalConfig{
+				ZoneMapper: &option.DaemonConfig{},
 				LBMapsConfig: experimental.LBMapsConfig{
 					MaxSockRevNatMapEntries:  3 * testSize,
 					ServiceMapMaxEntries:     3 * testSize,
@@ -522,6 +523,7 @@ func testHive(maps experimental.LBMaps,
 	bo **experimental.BPFOps,
 ) *hive.Hive {
 	extConfig := experimental.ExternalConfig{
+		ZoneMapper:        &option.DaemonConfig{},
 		EnableIPv4:        true,
 		EnableIPv6:        true,
 		ExternalClusterIP: false,

--- a/pkg/loadbalancer/experimental/bpf_reconciler.go
+++ b/pkg/loadbalancer/experimental/bpf_reconciler.go
@@ -1044,13 +1044,13 @@ func (ops *BPFOps) upsertBackend(id loadbalancer.BackendID, be *BackendParams) (
 
 	if be.Address.AddrCluster.Is6() {
 		lbbe, err = lbmap.NewBackend6V3(id, be.Address.AddrCluster, be.Address.Port, proto,
-			be.State, be.ZoneID)
+			be.State, ops.cfg.GetZoneID(be.Zone))
 		if err != nil {
 			return err
 		}
 	} else {
 		lbbe, err = lbmap.NewBackend4V3(id, be.Address.AddrCluster, be.Address.Port, proto,
-			be.State, be.ZoneID)
+			be.State, ops.cfg.GetZoneID(be.Zone))
 		if err != nil {
 			return err
 		}

--- a/pkg/loadbalancer/experimental/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/experimental/bpf_reconciler_test.go
@@ -101,7 +101,6 @@ func newTestBackend(addr loadbalancer.L3n4Addr, state loadbalancer.BackendState)
 			BackendParams{
 				Address:   addr,
 				NodeName:  "",
-				ZoneID:    0,
 				PortNames: nil,
 				Weight:    0,
 				State:     state,
@@ -951,6 +950,7 @@ func TestBPFOps(t *testing.T) {
 
 	// Enable features.
 	extCfg := ExternalConfig{
+		ZoneMapper: &option.DaemonConfig{},
 		LBMapsConfig: LBMapsConfig{
 			MaxSockRevNatMapEntries:  1000,
 			ServiceMapMaxEntries:     1000,

--- a/pkg/loadbalancer/experimental/cell.go
+++ b/pkg/loadbalancer/experimental/cell.go
@@ -48,6 +48,9 @@ var Cell = cell.Module(
 	// the node addresses change.
 	cell.Invoke(registerNodePortAddressReconciler),
 
+	// Register a background job to watch for node zone label changes.
+	cell.Invoke(registerNodeZoneWatcher),
+
 	// Replace the [k8s.ServiceCacheReader] and [service.ServiceReader] if this
 	// implementation is enabled.
 	cell.Provide(newAdapters),

--- a/pkg/loadbalancer/experimental/cell_test.go
+++ b/pkg/loadbalancer/experimental/cell_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/maglev"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 )
@@ -29,6 +30,7 @@ func TestCell(t *testing.T) {
 		daemonk8s.ResourcesCell,
 		daemonk8s.TablesCell,
 		maglev.Cell,
+		node.LocalNodeStoreCell,
 		Cell,
 		cell.Provide(source.NewSources),
 		cell.Provide(

--- a/pkg/loadbalancer/experimental/config.go
+++ b/pkg/loadbalancer/experimental/config.go
@@ -64,6 +64,7 @@ func (def TestConfig) Flags(flags *pflag.FlagSet) {
 // DaemonConfig. This avoids direct access of larger configuration structs.
 type ExternalConfig struct {
 	LBMapsConfig
+	ZoneMapper
 
 	EnableIPv4, EnableIPv6          bool
 	ExternalClusterIP               bool
@@ -78,6 +79,7 @@ type ExternalConfig struct {
 func newExternalConfig(cfg *option.DaemonConfig) ExternalConfig {
 	return ExternalConfig{
 		LBMapsConfig:                    newLBMapsConfig(cfg),
+		ZoneMapper:                      cfg,
 		EnableIPv4:                      cfg.EnableIPv4,
 		EnableIPv6:                      cfg.EnableIPv6,
 		ExternalClusterIP:               cfg.ExternalClusterIP,
@@ -88,4 +90,8 @@ func newExternalConfig(cfg *option.DaemonConfig) ExternalConfig {
 		NodePortAlg:                     cfg.NodePortAlg,
 		LoadBalancerAlgorithmAnnotation: cfg.LoadBalancerAlgorithmAnnotation,
 	}
+}
+
+type ZoneMapper interface {
+	GetZoneID(string) uint8
 }

--- a/pkg/loadbalancer/experimental/redirectpolicy/script_test.go
+++ b/pkg/loadbalancer/experimental/redirectpolicy/script_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -65,6 +66,7 @@ func TestScript(t *testing.T) {
 				daemonk8s.TablesCell,
 				experimental.Cell,
 				Cell,
+				node.LocalNodeStoreCell,
 				maglev.Cell,
 				cell.Provide(
 					source.NewSources,

--- a/pkg/loadbalancer/experimental/service.go
+++ b/pkg/loadbalancer/experimental/service.go
@@ -80,10 +80,25 @@ type Service struct {
 	// PortNames maps a port name to a port number.
 	PortNames map[string]uint16
 
+	// TrafficDistribution if not default will influence how backends are chosen for
+	// frontends associated with this service.
+	TrafficDistribution TrafficDistribution
+
 	// Properties are additional untyped properties that can carry feature
 	// specific metadata about the service.
 	Properties part.Map[string, any]
 }
+
+type TrafficDistribution string
+
+const (
+	// TrafficDistributionDefault will ignore any topology aware hints for choosing the backends.
+	TrafficDistributionDefault = TrafficDistribution("")
+
+	// TrafficDistributionPreferClose Indicates preference for routing traffic to topologically close backends,
+	// that is to backends that are in the same zone.
+	TrafficDistributionPreferClose = TrafficDistribution("PreferClose")
+)
 
 type ProxyRedirect struct {
 	ProxyPort uint16
@@ -186,6 +201,10 @@ func (svc *Service) TableRow() []string {
 			propKeys = append(propKeys, k)
 		}
 		flags = append(flags, "Properties="+strings.Join(propKeys, ", "))
+	}
+
+	if svc.TrafficDistribution != TrafficDistributionDefault {
+		flags = append(flags, "TrafficDistribution="+string(svc.TrafficDistribution))
 	}
 
 	sort.Strings(flags)

--- a/pkg/loadbalancer/experimental/testdata/healthserver.txtar
+++ b/pkg/loadbalancer/experimental/testdata/healthserver.txtar
@@ -108,6 +108,7 @@ devicename: test
 Module                      Component                         Level   Message                    Error
 loadbalancer.healthserver   job-control-loop                  OK      0 health servers running
 loadbalancer                job-node-addr-reconciler          OK      Running
+loadbalancer                job-zone-watcher                  OK      Running
 loadbalancer.reconciler     job-reconcile                     OK      OK, 0 object(s)
 loadbalancer.reconciler     job-refresh                       OK      Next refresh in 30m0s
 loadbalancer.reconciler     job-start-reconciler              Stopped Started
@@ -119,6 +120,7 @@ Module                      Component                         Level   Message   
 loadbalancer.healthserver   job-control-loop                  OK      1 health servers running
 loadbalancer.healthserver   job-listener-$HEALTHPORT1                OK      Running
 loadbalancer                job-node-addr-reconciler          OK      Running
+loadbalancer                job-zone-watcher                  OK      Running
 loadbalancer.reconciler     job-reconcile                     OK      OK, 4 object(s)
 loadbalancer.reconciler     job-refresh                       OK      Next refresh in 30m0s
 loadbalancer.reconciler     job-start-reconciler              Stopped Started

--- a/pkg/loadbalancer/experimental/testdata/marshalling.txtar
+++ b/pkg/loadbalancer/experimental/testdata/marshalling.txtar
@@ -75,6 +75,7 @@ Address              Instances
   "PortNames": {
     "http": 80
   },
+  "TrafficDistribution": "",
   "Properties": []
 }
 -- frontends-expected.json --
@@ -111,7 +112,8 @@ Address              Instances
       ],
       "Weight": 100,
       "NodeName": "nodeport-worker",
-      "ZoneID": 0,
+      "Zone": "",
+      "ForZones": null,
       "Source": "k8s",
       "State": 0,
       "Unhealthy": false,
@@ -154,7 +156,8 @@ Address              Instances
       ],
       "Weight": 100,
       "NodeName": "nodeport-worker",
-      "ZoneID": 0,
+      "Zone": "",
+      "ForZones": null,
       "Source": "k8s",
       "State": 0,
       "Unhealthy": false,
@@ -194,7 +197,8 @@ Address              Instances
         ],
         "Weight": 100,
         "NodeName": "nodeport-worker",
-        "ZoneID": 0,
+        "Zone": "",
+        "ForZones": null,
         "Source": "k8s",
         "State": 0,
         "Unhealthy": false,
@@ -232,7 +236,8 @@ Address              Instances
         ],
         "Weight": 100,
         "NodeName": "nodeport-worker",
-        "ZoneID": 0,
+        "Zone": "",
+        "ForZones": null,
         "Source": "k8s",
         "State": 0,
         "Unhealthy": false,
@@ -262,6 +267,7 @@ loopbackhostport: false
 sourceranges: []
 portnames:
     http: 80
+trafficdistribution: ""
 properties: []
 -- frontends-expected.yaml --
 frontendparams:
@@ -283,7 +289,8 @@ backends:
         - http
       weight: 100
       nodename: nodeport-worker
-      zoneid: 0
+      zone: ""
+      forzones: []
       source: k8s
       state: 0
       unhealthy: false
@@ -310,7 +317,8 @@ backends:
         - http
       weight: 100
       nodename: nodeport-worker
-      zoneid: 0
+      zone: ""
+      forzones: []
       source: k8s
       state: 0
       unhealthy: false
@@ -332,7 +340,8 @@ instances:
             - http
         weight: 100
         nodename: nodeport-worker
-        zoneid: 0
+        zone: ""
+        forzones: []
         source: k8s
         state: 0
         unhealthy: false
@@ -352,7 +361,8 @@ instances:
             - http
         weight: 100
         nodename: nodeport-worker
-        zoneid: 0
+        zone: ""
+        forzones: []
         source: k8s
         state: 0
         unhealthy: false

--- a/pkg/loadbalancer/experimental/testdata/topology-aware.txtar
+++ b/pkg/loadbalancer/experimental/testdata/topology-aware.txtar
@@ -1,0 +1,141 @@
+#! --enable-experimental-lb --lb-test-fault-probability=0.0
+#
+# Test topology-aware hints, e.g. backends meant for other zones are ignored.
+#
+
+# Set the node zone label before starting so it's read by the zone watcher.
+test/set-node-labels topology.kubernetes.io/zone=foo
+
+# Start and wait for watchers
+hive start
+db/initialized
+
+# Add the service (with topology-mode=auto) and endpoints
+# 10.244.1.1 (for zones foo & bar), 10.244.2.1 (for zone quux).
+k8s/add service.yaml
+db/cmp services services.table
+k8s/add endpointslice.yaml endpointslice2.yaml
+
+# With zone set to 'foo' and topology-awareness enabled, we should
+# only select backen 10.244.1.1.
+db/cmp backends backends.table 
+db/cmp frontends frontends.table
+
+# Move the node to a different zone which won't match ForZones.
+test/set-node-labels topology.kubernetes.io/zone=baz
+db/cmp frontends frontends-no-backends.table
+
+# Move to another zone which isn't backend's own zone but mentioned in
+# ForZones.
+test/set-node-labels topology.kubernetes.io/zone=bar
+db/cmp frontends frontends.table
+
+# Remove the topology-mode annotation. Both backends should now be selected.
+sed 'topology-mode' 'topology-nope' service.yaml
+k8s/update service.yaml
+db/cmp frontends frontends-no-topo.table
+
+# Set 'trafficDistribution' and check that this results in identical behavior
+# to topology-mode.
+sed '#trafficD' 'trafficD' service.yaml
+k8s/update service.yaml
+db/cmp frontends frontends.table
+
+#####
+
+-- services.table --
+Name        Source   PortNames  TrafficPolicy  Flags
+test/echo   k8s      http=80    Cluster        TrafficDistribution=PreferClose
+
+-- frontends.table --
+Address               Type        ServiceName   PortName   Status  Backends
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP
+
+-- frontends-no-backends.table --
+Address               Type        ServiceName   PortName   Status   Backends
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done
+
+-- frontends-no-topo.table --
+Address               Type        ServiceName   PortName   Status  Backends
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.2.1:80/TCP
+
+-- backends.table --
+Address             Instances
+10.244.1.1:80/TCP   test/echo (http)
+10.244.2.1:80/TCP   test/echo (http)
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  annotations:
+    service.kubernetes.io/topology-mode: auto
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  type: ClusterIP
+  #trafficDistribution: PreferClose
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps1
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+  zone: "foo"
+  hints:
+    forZones:
+    - name: foo
+    - name: bar
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- endpointslice2.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps2
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.2.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+  zone: "quux"
+  hints:
+    forZones:
+    - name: quux
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+

--- a/pkg/loadbalancer/experimental/zones.go
+++ b/pkg/loadbalancer/experimental/zones.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package experimental
+
+import (
+	"context"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/stream"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/cilium/cilium/pkg/node"
+)
+
+// registerNodeZoneWatcher registers a background job that watches the [node.LocalNodeStore]
+// for changes to the node's topology zone. When it changes it updates the zone in [Writer]
+// and refreshes all frontends to re-select backends.
+func registerNodeZoneWatcher(jg job.Group, p zoneWatcherParams) {
+	if p.Config.EnableExperimentalLB {
+		jg.Add(job.OneShot("zone-watcher", zoneWatcher{p}.run))
+	}
+}
+
+type zoneWatcherParams struct {
+	cell.In
+
+	Config         Config
+	Writer         *Writer
+	LocalNodeStore *node.LocalNodeStore
+}
+
+type zoneWatcher struct {
+	zoneWatcherParams
+}
+
+func (zw zoneWatcher) run(ctx context.Context, health cell.Health) error {
+	var zone string
+	for n := range stream.ToChannel(ctx, zw.LocalNodeStore) {
+		newZone := n.Labels[corev1.LabelTopologyZone]
+		if newZone == zone {
+			continue
+		}
+		zone = newZone
+		zw.Writer.updateZone(zone)
+	}
+	return nil
+}


### PR DESCRIPTION
Add support for topology-aware routing:

* Add [Service.TrafficDistribution] for enabling topology-aware routing. This is set either when Spec.TrafficDistribution is set or the service.kubernetes.io/topology-mode annotation is set.

* Add [BackendParams.ForZones] to carry the zones for which the backend is intended for.

* Change [BackendParams.ZoneID] to [BackendParams.Zone]. Convert to ZoneID only when reconciling.

* Skip backend when traffic distribution is set to PreferClose and the local zone is not part of ForZones.

* Watch changes to node's zone label and refresh backend selection of affected frontends on changes.

Topology-aware routing is always supported and we can remove the [k8s.ServiceCacheConfig] once we've switched over.